### PR TITLE
[api] LDAP_OBSDB_FILTER feature patch

### DIFF
--- a/src/api/config/environments/production.rb
+++ b/src/api/config/environments/production.rb
@@ -64,6 +64,16 @@ LDAP_SEARCH_AUTH=""
 #
 # Also note that openLDAP must be configured to use the memberOf overlay
 
+# By default any LDAP user can be used to authenticate to the OBS
+# In some deployments this may be too broad and certain criteria should
+# be met; eg OBS database user table
+# This checks the existence of user in OBS database first before query LDAP.
+# If the user doesn't exist in OBS database,
+# it simply skipped LDAP query.
+# If the user exists in OBS database,
+# it continues to query LDAP and checks for LDAP username/password.
+#LDAP_OBSDB_FILTER = :on
+
 # How to verify:
 #   :ldap = attempt to bind to ldap as user using supplied credentials
 #   :local = compare the credentials supplied with those in 

--- a/src/api/lib/active_rbac_mixins/user_mixins.rb
+++ b/src/api/lib/active_rbac_mixins/user_mixins.rb
@@ -653,6 +653,18 @@ module UserMixins
           # password in the active directory server.  Returns nil unless 
           # credentials are correctly found using LDAP.
           def self.find_with_ldap(login, password)
+            if defined?( LDAP_OBSDB_FILTER ) && LDAP_OBSDB_FILTER == :on
+              logger.debug( "LDAP_OBSDB_FILTER = :on" )
+              logger.debug( "Looking for user (#{login}) in obs database before using ldap" )
+              db_con = User.find_by_login( login )
+              if db_con.nil?
+                logger.debug( "User (#{login}) not found in obs database" )
+                return nil
+              else
+                logger.debug( "User (#{login}) found in obs database" )
+              end
+            end
+
             logger.debug( "Looking for #{login} using ldap" )
             ldap_info = Array.new
             # use cache to check the password firstly


### PR DESCRIPTION
In a large enterprise,
LDAP server is normally maintained by IT people,
but OBS server is normally maintained by CM group.
It's always inconvenient to ask IT to add/remove people from LDAP membership
to control access write.

To gain the advantage of using LDAP for one single password
and still use OBS's MySQL database for user access control,
LDAP_OBSDB_FILTER feature is required.

The work flow is as follows:
1. 
When both LDAP_MODE and LDAP_OBSDB_FILTER are ":on",
it will first search the user in OBS database.
2.
If the user is not found in OBS database, 
meaning the user has no access right,
it would fail the login without trying to query LDAP server.
If the user is found in OBS database,
meaning the user has access right,
it would continue to query LDAP server to check the password.

In this way,
CM group can control OBS access rights
by creating/removing user from OBS database
without involving IT personals,
and
end users can gain the advantage of using LDAP password.
