### PR TITLE
Only modify new reviews and only reopen last review.

### DIFF
--- a/src/backend/bs_srcserver
+++ b/src/backend/bs_srcserver
@@ -5743,13 +5743,14 @@ sub postrequest {
     my $go_new_state = 'review';
     $go_new_state = $cgi->{'newstate'} if $cgi->{'newstate'} eq 'declined' or $cgi->{'newstate'} eq 'superseded';
     my $found = 0;
+    my $index = 1;
     for my $r (@{$req->{'review'} || []}) {
       my $matching = 1;
       $matching = 0 if defined($r->{'by_user'}) && $r->{'by_user'} ne ($cgi->{'by_user'}||'');
       $matching = 0 if defined($r->{'by_group'}) && $r->{'by_group'} ne ($cgi->{'by_group'}||'');
       $matching = 0 if defined($r->{'by_project'}) && $r->{'by_project'} ne ($cgi->{'by_project'}||'');
       $matching = 0 if defined($r->{'by_package'}) && $r->{'by_package'} ne ($cgi->{'by_package'}||'');
-      if ($matching) {
+      if ($matching && ($r->{'state'} eq 'new' || ($cgi->{'newstate'} eq 'new' && $index eq scalar @{$req->{'review'}}))) {
         $r->{'state'} = $cgi->{'newstate'};
         $r->{'when'} = $mytime;
         $r->{'who'} = $cgi->{'user'} if defined $cgi->{'user'};
@@ -5762,6 +5763,7 @@ sub postrequest {
         # review got declined or superseded or reopened.
         $go_new_state = '' if $r->{'state'} eq 'new' and $go_new_state ne 'declined' and $go_new_state ne 'superseded';
       }
+      $index++;
     }
     die("review item not found.\n") if $found == 0;
     if ($go_new_state or $cgi->{'newstate'} eq 'superseded'){


### PR DESCRIPTION
Old reviews that have been accepted, declined or superseded should not be
modified. When reopening a review, only reopen the last review if there
are multiple ones.
Added test case to ensure code works
