### PR TITLE
[backend] copy missing tree meta data to linked projects

### DIFF
--- a/src/backend/bs_srcserver
+++ b/src/backend/bs_srcserver
@@ -726,6 +726,13 @@ sub getrev {
 	  my $files = lsrev($lrev);
 	  copyfiles($projid, $packid, $lprojid, $packid, $files);
 	  addmeta($projid, $packid, $files) if $BSConfig::nosharedtrees;
+	  my $treedir = $BSConfig::nosharedtrees ? "$treesdir/$projid/$packid" : "$treesdir/$packid";
+	  my $ltreedir = $BSConfig::nosharedtrees ? "$treesdir/$lprojid/$packid" : "$treesdir/$packid";
+	  if (-e "$ltreedir/$lrev->{'srcmd5'}-MD5SUMS" && ! -e "$treedir/$lrev->{'srcmd5'}-MD5SUMS") {
+	    mkdir_p($ltreedir);
+	    my $meta = readstr("$ltreedir/$lrev->{'srcmd5'}-MD5SUMS");
+	    writestr("$uploaddir/$$", "$treedir/$lrev->{'srcmd5'}-MD5SUMS", $meta);
+	  }
 	  $lrev->{'originproject'} ||= $lprojid;
 	  $lrev->{'project'} = $projid;
 	  return $lrev;


### PR DESCRIPTION
In case of special meta data like after source service runs the current
code does not always transfer the meta data to linked projects
completely.  This change copies missing meta data files to linked
projects to fix this situation.
