### PR TITLE
Remove codemirror line-height

### DIFF
--- a/src/webui/public/stylesheets/cm2/suse.css
+++ b/src/webui/public/stylesheets/cm2/suse.css
@@ -1,6 +1,5 @@
 /* BEGIN: CodeMirror */
 .CodeMirror {
-  line-height: 1em;
   font-family: monospace;
 }
 .CodeMirror-scroll {


### PR DESCRIPTION
Removed codemirror line-height, as requested by fisiu82@jabster.pl on admin@opensuse.org 

> Hi,
> 
> web file editor on build.opensuse.org uses line-height: 1em and because of 
> that, all fonts are stripped down from top and bottom in each line (in Firefox 
> and Opera). Removing line-height: 1em from .CodeMirror in file 
> /hosts/build2.o.o/stylesheets/cm2/suse.css should fix it.
> 
> I marked few important places on attached screenshot
