### PR TITLE
[worker] Introduce vmdisk mount options config

### DIFF
--- a/dist/obsworker
+++ b/dist/obsworker
@@ -116,6 +116,9 @@ if [ -n "$vmopt" -a "$OBS_VM_TYPE" = "xen" -o "$OBS_VM_TYPE" = "kvm" ]; then
         if [ -n "$OBS_VM_DISK_AUTOSETUP_FILESYSTEM" ]; then
             VMDISK_FILESYSTEM="--vmdisk-filesystem ${OBS_VM_DISK_AUTOSETUP_FILESYSTEM}"
         fi
+        if [ -n "$OBS_VM_DISK_AUTOSETUP_MOUNT_OPTIONS" ]; then
+            VMDISK_MOUNT_OPTIONS="--vmdisk-mount-options ${OBS_VM_DISK_AUTOSETUP_MOUNT_OPTIONS}"
+        fi
     fi
 fi
 

--- a/dist/sysconfig.obs-server
+++ b/dist/sysconfig.obs-server
@@ -247,6 +247,15 @@ OBS_VM_DISK_AUTOSETUP_SWAP_FILESIZE="1024"
 OBS_VM_DISK_AUTOSETUP_FILESYSTEM="ext3"
 
 ## Path:        Applications/OBS
+## Description: Filesystem mount options to use for autosetup
+## Type:        string
+## Default:     "-o data=writeback,nobarrier,commit=150,noatime"
+## Config:      OBS
+#
+#
+OBS_VM_DISK_AUTOSETUP_MOUNT_OPTIONS="-o data=writeback,nobarrier,commit=150,noatime"
+
+## Path:        Applications/OBS
 ## Description: Enable build in memory
 ## Type:        ("yes" | "")
 ## Default:     ""

--- a/src/backend/bs_worker
+++ b/src/backend/bs_worker
@@ -64,6 +64,7 @@ my $vm_memory;
 my $vmdisk_rootsize;
 my $vmdisk_swapsize;
 my $vmdisk_filesystem;
+my $vmdisk_mount_options;
 my $workerid;
 my $srcserver;
 my @reposervers;
@@ -339,6 +340,11 @@ while (@ARGV) {
   if ($ARGV[0] eq '--vmdisk-filesystem') {
     shift @ARGV;
     $vmdisk_filesystem = shift @ARGV;
+    next;
+  }
+  if ($ARGV[0] eq '--vmdisk-mount-options') {
+    shift @ARGV;
+    $vmdisk_mount_options = shift @ARGV;
     next;
   }
   if ($ARGV[0] eq '--build') {
@@ -1544,6 +1550,8 @@ sub dobuild {
     push @args, '--vmdisk-rootsize', $vmdisk_rootsize if $vmdisk_rootsize;
     push @args, '--vmdisk-swapsize', $vmdisk_swapsize if $vmdisk_swapsize;
     push @args, '--vmdisk-filesystem', $vmdisk_filesystem if $vmdisk_filesystem;
+    # mount options require quoting due to arguments which might start with "-o ..."
+    push @args, '--vmdisk-mount-options', "\"$vmdisk_mount_options\"" if $vmdisk_mount_options;
   } elsif ($vm =~ /lxc/) {
     push @args, '--root', $buildroot;
     push @args, '--vm-type', $vm;


### PR DESCRIPTION
Allow to configure vmdisk mount options with obs-server sysconfig.
Requires obs-build dc8793b
