### PR TITLE
[dist] fix obsstoragesetup trying to grab all available diskspace for OBS worker setup

### DIFF
--- a/dist/obsstoragesetup
+++ b/dist/obsstoragesetup
@@ -369,6 +369,7 @@ EOF
 			else
 				#plain chroot build
 				mkdir -p "$OBS_WORKER_DIRECTORY/$name"
+				mkfs -text4 $i || exit
 				mount $i "$OBS_WORKER_DIRECTORY/$name"
 			fi
 			OBS_WORKER_INSTANCES=$(( $OBS_WORKER_INSTANCES + 1 ))


### PR DESCRIPTION
Two commits included in the pull request:

b721627:
Couple issues associated with results grabbed from vgdisplay:
- it can return a float which leads to failure and script termination trying to perform shell arithmetics
- even with that out of the way --units M (at least with vgdisplay on openSUSE 12.1) returns values in MB. However creating LVs further down the script values passed are understood as MiB. I.e. script runs out of space creating in the VG creating LVs.
- since it needed fixing, it seems to make sense to prefer output meant for machine parsing.

75b1a65:
When chroot workers are used, we're trying to mount freshly created LVs without creating filesystem first. When we exercise this code path, it should be safe to assume, we do not need to be too conservative and can just go ahead running mkfs (like for initializing the cache).
