### PR TITLE
[dists] actually use OBS_VM_DISK_AUTOSETUP_MOUNT_OPTIONS on worker start...

### DIFF
--- a/dist/obsworker
+++ b/dist/obsworker
@@ -119,7 +119,7 @@ if [ "$OBS_VM_TYPE" = "xen" -o "$OBS_VM_TYPE" = "kvm" ]; then
             VMDISK_FILESYSTEM="--vmdisk-filesystem ${OBS_VM_DISK_AUTOSETUP_FILESYSTEM}"
         fi
         if [ -n "$OBS_VM_DISK_AUTOSETUP_MOUNT_OPTIONS" ]; then
-            VMDISK_MOUNT_OPTIONS="--vmdisk-mount-options ${OBS_VM_DISK_AUTOSETUP_MOUNT_OPTIONS}"
+            VMDISK_MOUNT_OPTIONS="--vmdisk-mount-options \"${OBS_VM_DISK_AUTOSETUP_MOUNT_OPTIONS}\""
         fi
     fi
 fi


### PR DESCRIPTION
...up

fix related to 5dfa8bd where this option was introduced.

since it was not appended to OBS_WORKER_OPT it was never passed to the worker and thus did not work so far.
