### PR TITLE
[webui] patchinfo-editor

### DIFF
--- a/src/webui/app/views/patchinfo/_form.html.erb
+++ b/src/webui/app/views/patchinfo/_form.html.erb
@@ -109,7 +109,7 @@
             <p><strong>Block release?</strong>
               <%= check_box_tag("block", true, @block, :onchange => "enable_block_reason()") %></p>
             <p><strong>Reason: </strong>
-              <%=text_field_tag "block_reason", @block_reason, :size => 50 %></p>
+              <%=text_field_tag "block_reason", @block_reason, :size => 45 %></p>
           </div>
           <div style="margin-left:5px;">
             <%= submit_tag "Save Patchinfo" %>

--- a/src/webui/app/views/patchinfo/show.html.erb
+++ b/src/webui/app/views/patchinfo/show.html.erb
@@ -15,7 +15,7 @@
 
         <span>
           <%= link_to image_tag('icons/package_delete.png', :title => 'Remove Patchinfo'), {:action => :remove, :project => @project, :package => @package},
-            {:confirm => "Really remove '#{@package}'?", :method => :post } %>
+            :data => { :confirm => "Really remove '#{@package}'?", :method => :post } %>
         </span>
       <% end %>
     </span>


### PR DESCRIPTION
- Fixed deprecation-warning for confirm-message in delete function
- Fixed routing-error for error if submit is not post
- Fixed nil-error if no issue is entered and the patchinfo is not filled
  correct
- Fixed caching-problem after updating patchinfo
- Fixed size of stopped-reason text field
