### PR TITLE
With DocumentRoot /srv/obs/repos, I get an Error 403: "Symbolic link not...

### DIFF
--- a/dist/obs-apache2.conf
+++ b/dist/obs-apache2.conf
@@ -1,4 +1,3 @@
-
 Listen 82
 Listen 444
 # May needed on old distributions or after an update from them.
@@ -28,9 +27,9 @@ LimitRequestFieldsize 20000
 # Build Results
 <VirtualHost *:82>
         # The resulting repositories
-        DocumentRoot  "/srv/obs/repos"
+        DocumentRoot  "/obs/repos"
 
-        <Directory /srv/obs/repos>
+        <Directory /obs/repos>
            Options Indexes FollowSymLinks
            Allow from all
         </Directory>


### PR DESCRIPTION
... allowed or link target not accessible: /srv/obs"
