### PR TITLE
bs_publish: add regex support in publishedhook

### DIFF
--- a/src/backend/bs_publish
+++ b/src/backend/bs_publish
@@ -1514,8 +1514,19 @@ publishprog_done:
     }
   }
 
+  # support for regex usage in $BSConfig::publishedhook
+  my $publish_prp = $prp;
+  if ($BSConfig::publishedhook_use_regex) {
+    for my $key (keys %BSConfig::publishedhook) {
+      if ($prp =~ /$key/) {
+        $publish_prp = $key;
+        last;
+      }
+    }
+  }
+
   if ($BSConfig::publishedhook && $BSConfig::publishedhook->{$prp}) {
-    qsystem($BSConfig::publishedhook->{$prp}, $prp, $extrep, @changed) && warn("    $BSConfig::publishedhook->{$prp} failed: $?");
+    qsystem($BSConfig::publishedhook->{$publish_prp}, $prp, $extrep, @changed) && warn("    $BSConfig::publishedhook->{$publish_prp} failed: $?");
   }
 
   


### PR DESCRIPTION
Adds support for regular expressions in $BSConfig::publishedhook.
Usage is configurable with $BSConfig::publishedhook_use_regex.
