### PR TITLE
Enable 'no_proxy' in backend services

### DIFF
--- a/src/backend/bs_service
+++ b/src/backend/bs_service
@@ -62,6 +62,8 @@ $servicedir="/usr/lib/obs/service" unless $servicedir;
 my $rootservicedir = $servicedir;
 $rootservicedir = $BSConfig::serviceroot."/".$servicedir if $BSConfig::serviceroot;
 
+my $noproxy = $BSConfig::noproxy;
+
 sub usage {
   my ($ret) = @_;
 
@@ -131,6 +133,7 @@ sub run_source_update {
   # set environment
   $::ENV{'OBS_SERVICE_PROJECT'} = $projid;
   $::ENV{'OBS_SERVICE_PACKAGE'} = $packid;
+  $::ENV{'no_proxy'} = $noproxy;
 
   # run all services
   mkdir_p($myworkdir."/.tmp");


### PR DESCRIPTION
If you have to use a proxy to connect the Internet (i.e. to connect to build.opensuse.org), but you must not use the proxy for internal servers, you can set up the relevant variables in `/etc/sysconfig/proxy` and `/usr/lib/obs/server/BSConfig.pm`.

Nevertheless, for a backend service (I checked download_src_package), this doesn't seem to work:

```
        service download_src_package failed:
asking libproxy about url 'http://rpms.internal/src/rpm-4.4.2.3-37.50.6.src.rpm'
libproxy suggest to use 'http://squid.internal:3128'
[...]
```

With the requested patch, the download from the internal server is working. The environment variable has to be 'no_proxy'; uppercase didn't work for me.
