### PR TITLE
[dist] obs_mirror_project*: skip debug packages

### DIFF
--- a/dist/obs_mirror_project
+++ b/dist/obs_mirror_project
@@ -63,6 +63,12 @@ filelist.elements.each("binarylist/binary") { |binary|
   # skip src and nosrc rpms
   inform_user_about_hacky_reget=false
   unless fname[-7..-1] == "src.rpm"
+    # skip debuginfo and debugsource packages
+    if fname.include? "-debuginfo" or fname.include? "-debugsource"
+      puts "Debug package #{fname} - skip."
+      next
+    end
+
     if File.file?("#{destinationdir}/#{fname}")
 
       puts "package #{destinationdir}/#{fname} already exists."

--- a/dist/obs_mirror_project.py
+++ b/dist/obs_mirror_project.py
@@ -78,6 +78,10 @@ if __name__ == '__main__':
     filenames = core.get_binarylist(conf.config['apiurl'], project, repository, architecture)
 
     for filename in filenames:
+	if filename.contains("debuginfo") or filename.contains("debugsource"):
+		print "Skipping debug package: %s" % filename
+		continue
+
         if not os.path.exists('%s/%s' % (destinationdir, filename)):
             attempt = 0
             done = False


### PR DESCRIPTION
debuginfo and debugsource packages are rarely needed inside a build
target.
