### PR TITLE
[dist] worker doesn't make use of swap if chroot is used

### DIFF
--- a/dist/obsstoragesetup
+++ b/dist/obsstoragesetup
@@ -377,6 +377,8 @@ EOF
 				mkdir -p "$OBS_WORKER_DIRECTORY/$name"
 				mkfs -text4 $i || exit
 				mount $i "$OBS_WORKER_DIRECTORY/$name"
+				mkswap -f "$swap"
+				swapon "$swap"
 			fi
 			OBS_WORKER_INSTANCES=$(( $OBS_WORKER_INSTANCES + 1 ))
 		done


### PR DESCRIPTION
mkswap and swapon is missing
