### PR TITLE
Logrotate will pickup all Apache logfiles 

### DIFF
--- a/dist/obs-api.logrotate
+++ b/dist/obs-api.logrotate
@@ -1,5 +1,4 @@
-
-/srv/www/obs/api/log/*.log {
+/srv/www/obs/api/log/*log {
   compress
   dateext
   maxage 365


### PR DESCRIPTION
The logfiles in obs-apache2.conf have a trailing "_log" in the name (Example: /srv/www/obs/webui/log/apache_error_log).

As a result there is no log rotation on these files.  My Apache access logfile had grown to 6.8G
