### PR TITLE
Logrotate will pickup all Apache logfiles

### DIFF
--- a/dist/obs-build.logrotate
+++ b/dist/obs-build.logrotate
@@ -1,4 +1,4 @@
-/srv/www/obs/webui/log/access.log {
+/srv/www/obs/webui/log/apache*log {
   compress
   dateext
   maxage 365


### PR DESCRIPTION
The logfiles in obs-apache2.conf have a trailing "_log" in the name (Example: /srv/www/obs/webui/log/apache_error_log).

As a result there is no log rotation on these files.
