### PR TITLE
[api] migrate the watched projects to ids

### DIFF
--- a/src/api/app/controllers/person_controller.rb
+++ b/src/api/app/controllers/person_controller.rb
@@ -245,19 +245,19 @@ class PersonController < ApplicationController
     end
 
     user.watched_projects.each do |wp|
-      old_watchlist << wp.name
+      old_watchlist << wp.project.name
     end
     add_to_watchlist = new_watchlist.collect {|i| old_watchlist.include?(i) ? nil : i}.compact
     remove_from_watchlist = old_watchlist.collect {|i| new_watchlist.include?(i) ? nil : i}.compact
 
     remove_from_watchlist.each do |name|
-      user.watched_projects.find_by_name(name).destroy
+      user.watched_projects.where(project_id: Project.find_by_name(name).id).delete_all
     end
 
     add_to_watchlist.each do |name|
-      user.watched_projects.new(:name => name)
+      user.watched_projects.new(project_id: Project.find_by_name(name).id)
     end
-    true
+    return true
   end
   private :update_watchlist
 

--- a/src/api/app/models/project.rb
+++ b/src/api/app/models/project.rb
@@ -26,6 +26,7 @@ class Project < ActiveRecord::Base
   has_many :attribs, :dependent => :destroy, foreign_key: :db_project_id
   has_many :repositories, :dependent => :destroy, foreign_key: :db_project_id
   has_many :messages, :as => :db_object, :dependent => :delete_all
+  has_many :watched_projects, :dependent => :destroy
 
   has_many :linkedprojects, :order => :position, :class_name => "LinkedProject", foreign_key: :db_project_id
 

--- a/src/api/app/models/user.rb
+++ b/src/api/app/models/user.rb
@@ -4,7 +4,7 @@ class User < ActiveRecord::Base
   has_many :taggings, :dependent => :destroy
   has_many :tags, :through => :taggings
 
-  has_many :watched_projects, :foreign_key => 'bs_user_id'
+  has_many :watched_projects, :foreign_key => 'bs_user_id', :dependent => :destroy
   has_many :groups_users, :foreign_key => 'user_id'
   has_many :roles_users, :foreign_key => 'user_id'
   has_many :project_user_role_relationships, :foreign_key => 'bs_user_id'
@@ -839,8 +839,8 @@ class User < ActiveRecord::Base
       # Show the watchlist only to the user for privacy reasons
       if watchlist
         person.watchlist() do |wl|
-          self.watched_projects.each do |project|
-            wl.project( :name => project.name )
+          self.watched_projects.each do |wp|
+            wl.project( :name => wp.project.name )
           end
         end
       end

--- a/src/api/app/models/watched_project.rb
+++ b/src/api/app/models/watched_project.rb
@@ -1,8 +1,10 @@
 class WatchedProject < ActiveRecord::Base
   belongs_to :user, foreign_key: 'bs_user_id'
+  belongs_to :project
 
-  attr_accessible :name
-
-  validates :name, presence: true
+  validates :project_id, presence: true
   validates :bs_user_id, presence: true
+ 
+  attr_accessible :bs_user_id, :project_id
+
 end

--- a/src/api/db/migrate/20121121142111_watchlist_use_ids.rb
+++ b/src/api/db/migrate/20121121142111_watchlist_use_ids.rb
@@ -1,0 +1,26 @@
+class WatchlistUseIds < ActiveRecord::Migration
+  def up
+    add_column :watched_projects, :project_id, :integer, :after => :bs_user_id, :null => false
+    # Convert names to project ids
+    WatchedProject.all.each do |wp|
+      prj = Project.where(name: wp.name).first
+      if prj
+        wp.project_id = prj.id
+        wp.save
+      else
+        wp.delete 
+      end
+    end
+    remove_column :watched_projects, :name
+  end
+
+  def down
+    add_column :watched_projects, :name, :string, :after => :bs_user_id, :null => false
+    # Convert db_project ids to names
+    WatchedProject.all.each do |wp|
+      wp.name = wp.project.name
+      wp.save
+    end
+    remove_column :watched_projects, :project_id
+  end
+end

--- a/src/api/db/structure.sql
+++ b/src/api/db/structure.sql
@@ -682,7 +682,7 @@ CREATE TABLE `users` (
 CREATE TABLE `watched_projects` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `bs_user_id` int(11) NOT NULL DEFAULT '0',
-  `name` varchar(100) CHARACTER SET utf8 NOT NULL DEFAULT '',
+  `project_id` int(11) NOT NULL,
   PRIMARY KEY (`id`),
   KEY `watched_projects_users_fk_1` (`bs_user_id`),
   CONSTRAINT `watched_projects_ibfk_1` FOREIGN KEY (`bs_user_id`) REFERENCES `users` (`id`)
@@ -997,6 +997,8 @@ INSERT INTO schema_migrations (version) VALUES ('20121114093616');
 INSERT INTO schema_migrations (version) VALUES ('20121120110642');
 
 INSERT INTO schema_migrations (version) VALUES ('20121120124300');
+
+INSERT INTO schema_migrations (version) VALUES ('20121121142111');
 
 INSERT INTO schema_migrations (version) VALUES ('21');
 

--- a/src/api/test/fixtures/watched_projects.yml
+++ b/src/api/test/fixtures/watched_projects.yml
@@ -1,16 +1,12 @@
 watched_projects_1:
   id: 1
   bs_user_id: 1
-  name: kde4
-watched_projects_2:
-  id: 2
-  bs_user_id: 1
-  name: kde5
+  project_id: 2
 watched_projects_3:
   id: 3
   bs_user_id: 42
-  name: CopyTest
+  project_id: 3004
 watched_projects_4:
   id: 4
   bs_user_id: 267
-  name: home:coolo
+  project_id: 600


### PR DESCRIPTION
This should have been done like 2002, but now we can let rails delete
the watches for deleted users and deleted projects

Based on saschpe's work from 2009 ;-)
