### PR TITLE
[webui] Multiple Changes and fixes for the patchinfo-editor

### DIFF
--- a/src/webui/app/controllers/patchinfo_controller.rb
+++ b/src/webui/app/controllers/patchinfo_controller.rb
@@ -73,6 +73,7 @@ class PatchinfoController < ApplicationController
     if @file.has_element?("issue")
       @file.each_issue do |a|
         if a.text == ""
+          # old uploaded patchinfos could have broken tracker-names like "bnc " instead of "bnc". Catch these.
           begin
             get_issue_sum(a.tracker, a.value(:id))
             a.text = @issuesum

--- a/src/webui/app/helpers/patchinfo_helper.rb
+++ b/src/webui/app/helpers/patchinfo_helper.rb
@@ -5,23 +5,18 @@ module PatchinfoHelper
     project_bread_crumb( *args )
   end
 
-  def create_issue_list( *args )
-    unless @issues.blank?
-      issue_list = ""
-      issue_list += "<ul>"
-      @issues.each do |issue| 
-        #issue[0] = tracker-name
-        #issue[1] = issue-id
-        #issue[2] = issue-url
-        #issue[3] = issue-summary
-        if issue[0] == "CVE"
-          issue_list += "<li>" + link_to("#{issue[1]}", issue[2]) + ": #{issue[3]}" + "</li>"
-        else
-          issue_list += "<li>" + link_to("#{issue[0]}##{issue[1]}", issue[2]) + ": #{issue[3]}" + "</li>"
-        end
-      end
-      issue_list += "</ul>"
-      issue_list.html_safe
+  def issue_link( issue )
+
+    # list issue-names with urls and summary from the patchinfo-file
+    # issue[0] = tracker-name
+    # issue[1] = issueid
+    # issue[2] = issue-url
+    # issue[3] = issue-summary
+
+    if issue[0] == "CVE"
+      content_tag(:li, link_to("#{issue[1]}", issue[2]) + ": #{issue[3]}")
+    else
+      content_tag(:li, link_to("#{issue[0]}##{issue[1]}", issue[2]) +  ": #{issue[3]}")
     end
   end
 end

--- a/src/webui/app/views/patchinfo/show.html.erb
+++ b/src/webui/app/views/patchinfo/show.html.erb
@@ -39,8 +39,14 @@
     <%= description_wrapper(@description) %>
   </div>
     <div class="box show_left show_right">
-      <b>Fixed bugs:</b><br/>
-      <%= create_issue_list(@issues) %> 
+      <b>Fixed bugs:</b>
+      <% unless @issues.blank? %>
+        <ul>
+          <% @issues.each do |issue| %>
+            <%= issue_link(issue) %>
+          <% end %>
+        </ul>
+      <% end %>
     </div>
     <div class="box show_left show_right">
       <b>Required actions:</b><br/>


### PR DESCRIPTION
- Fixed tracker issue not found error in patchinfo-editor
- show CVE-foo-bar instead of CVE#CVE-foo-bar in patchinfo-show-view
- moved creation of issue-list to patchinfo-helper
- removed useless begin/end
- catch ActiveXML::Transport::NotFoundError instead of all errors
