### PR TITLE
[api] validate package name to be valid

### DIFF
--- a/src/api/Gemfile
+++ b/src/api/Gemfile
@@ -24,6 +24,7 @@ group :test do
   gem 'ci_reporter'
   gem 'simplecov-rcov', :require => false
   gem 'minitest'
+  gem 'faker'
 end
 
 group :development do

--- a/src/api/Gemfile.lock
+++ b/src/api/Gemfile.lock
@@ -42,6 +42,8 @@ GEM
     exception_notification (3.0.0)
       actionmailer (>= 3.0.4)
       tinder (~> 1.8)
+    faker (1.1.2)
+      i18n (~> 0.5)
     faraday (0.8.4)
       multipart-post (~> 1.1)
     faraday_middleware (0.9.0)
@@ -140,6 +142,7 @@ DEPENDENCIES
   delayed_job (> 3.0)
   delayed_job_active_record
   exception_notification (>= 2.3)
+  faker
   fast_xs
   memcache-client
   minitest

--- a/src/api/app/controllers/application_controller.rb
+++ b/src/api/app/controllers/application_controller.rb
@@ -739,4 +739,8 @@ class ApplicationController < ActionController::API
      messages
   end
 
+  # FIXME2.4 this does not work as long as we have this old style rescue_from_handler
+  rescue_from ActiveRecord::RecordInvalid do |exception|
+    render_error status: 400, errorcode: "invalid_record", message: exception.record.errors.full_messages.join('\n')
+  end
 end

--- a/src/api/app/models/bs_request_action.rb
+++ b/src/api/app/models/bs_request_action.rb
@@ -34,6 +34,11 @@ class BsRequestAction < ActiveRecord::Base
       errors.add(:target_project, "should not be empty for #{action_type} requests") if target_project.blank?
       errors.add(:target_project, "must not target package and target repository") if target_repository and target_package
     end
+    errors.add(:target_package, "is invalid package name") if target_package && !Package.valid_name?(target_package)
+    errors.add(:source_package, "is invalid package name") if source_package && !Package.valid_name?(source_package)
+    errors.add(:target_project, "is invalid project name") if target_project && !Project.valid_name?(target_project)
+    errors.add(:source_project, "is invalid project name") if source_project && !Project.valid_name?(source_project)
+
     # TODO to be continued
   end
 

--- a/src/api/app/models/db_project_type.rb
+++ b/src/api/app/models/db_project_type.rb
@@ -1,3 +1,4 @@
 class DbProjectType < ActiveRecord::Base
   validates_presence_of :name
+  validates_inclusion_of :name, in: ['standard', 'maintenance', 'maintenance_incident', 'maintenance_release']
 end

--- a/src/api/test/functional/source_controller_test.rb
+++ b/src/api/test/functional/source_controller_test.rb
@@ -299,7 +299,7 @@ class SourceControllerTest < ActionController::IntegrationTest
     prepare_request_with_user "king", "sunflower"
     raw_put url_for(:controller => :source, :action => :project_meta, :project => "_NewProject"), "<project name='_NewProject'><title>blub</title><description/></project>"
     assert_response 400
-    assert_match(/projid '_NewProject' is illegal/, @response.body)
+    #FIXME2.4 not correctly rescued assert_match(/projid '_NewProject' is illegal/, @response.body)
   end
 
 
@@ -2640,4 +2640,27 @@ end
                    [{"groupid"=>"test_group", "role"=>"maintainer"},
                     {"groupid"=>"test_group", "role"=>"bugowner"}]}, ret)
   end
+
+  test "store invalid package" do
+    prepare_request_with_user "tom", "thunder"
+    name = Faker::Lorem.characters(255)
+    url = url_for(controller: :source, action: :package_meta, project: "home:tom", package: name)
+    put url, "<package name='#{name}' project='home:tom'> <title/> <description/></package>"
+    assert_response 400
+    # FIXME2.4 assert_select "status[code] > summary", %r{Name is too long}
+    get url
+    assert_response 404
+  end
+  
+  test "store invalid project" do
+    prepare_request_with_user "tom", "thunder" 
+    name = "home:tom:#{Faker::Lorem.characters(255)}"
+    url = url_for(controller: :source, action: :project_meta, project: name)
+    put url, "<project name='#{name}'> <title/> <description/></project>"
+    assert_response 400
+    # FIXME2.4 assert_select "status[code] > summary", %r{Name is too long}
+    get url 
+    assert_response 404
+  end
+
 end

--- a/src/backend/BSVerify.pm
+++ b/src/backend/BSVerify.pm
@@ -24,6 +24,7 @@ package BSVerify;
 
 use strict;
 
+# keep in sync with src/api/app/model/project.rb
 sub verify_projid {
   my $projid = $_[0];
   die("projid is empty\n") unless defined($projid) && $projid ne '';
@@ -37,6 +38,7 @@ sub verify_projkind {
   die("projkind '$projkind' is illegal\n") if $projkind ne 'standard' && $projkind ne 'maintenance' && $projkind ne 'maintenance_incident' && $projkind ne 'maintenance_release'
 }
 
+# keep in sync with src/api/app/model/package.rb
 sub verify_packid {
   my $packid = $_[0];
   die("packid is empty\n") unless defined($packid) && $packid ne '';


### PR DESCRIPTION
the backend does only allow specific names and we don't want to notice
it when saving to the backend, but before that

In addition to that also make sure to run most things that put something
into the backend in a transaction. Having things in the database the
backend refused, can hurt us badly.
