### PR TITLE
[api] fix and test timestamps of requests

### DIFF
--- a/src/api/Gemfile
+++ b/src/api/Gemfile
@@ -26,6 +26,7 @@ group :test do
   gem 'simplecov-rcov', :require => false
   gem 'minitest'
   gem 'faker'
+  gem 'timecop'
 end
 
 group :development do

--- a/src/api/Gemfile.lock
+++ b/src/api/Gemfile.lock
@@ -100,6 +100,7 @@ GEM
       tilt (~> 1.1, != 1.3.0)
     thor (0.16.0)
     tilt (1.3.3)
+    timecop (0.5.4)
     treetop (1.4.12)
       polyglot
       polyglot (>= 0.3.1)
@@ -131,5 +132,6 @@ DEPENDENCIES
   rake (~> 0.9.2)
   rdoc
   simplecov-rcov
+  timecop
   xmlhash (>= 1.3.4)
   yajl-ruby

--- a/src/api/app/models/bs_request.rb
+++ b/src/api/app/models/bs_request.rb
@@ -285,7 +285,7 @@ class BsRequest < ActiveRecord::Base
           
       raise Review::NotFound.new unless found
       if go_new_state || state == :superseded
-        bs_request_histories.create comment: self.comment, commenter: self.commenter, state: self.state, superseded_by: self.superseded_by        
+        bs_request_histories.create comment: self.comment, commenter: self.commenter, state: self.state, superseded_by: self.superseded_by, created_at: self.updated_at
         
         if state == :superseded
           self.state = :superseded
@@ -320,7 +320,7 @@ class BsRequest < ActiveRecord::Base
       if !opts[:by_user] && !opts[:by_group] && !opts[:by_project]
         raise InvalidReview.new
       end
-      bs_request_histories.create comment: self.comment, commenter: self.commenter, state: self.state, superseded_by: self.superseded_by        
+      bs_request_histories.create comment: self.comment, commenter: self.commenter, state: self.state, superseded_by: self.superseded_by, created_at: self.updated_at
 
       self.state = 'review'
       self.commenter = User.current.login
@@ -557,9 +557,9 @@ class BsRequest < ActiveRecord::Base
     user_reviews, other_open_reviews = [], []
     self.reviews.where(state: 'new').each do |review|
       if review_matches_user?(review, user)
-        user_reviews << review
+        user_reviews << review.webui_infos
       else
-        other_open_reviews << review
+        other_open_reviews << review.webui_infos
       end
     end
     return user_reviews, other_open_reviews

--- a/src/api/app/models/review.rb
+++ b/src/api/app/models/review.rb
@@ -45,7 +45,7 @@ class Review < ActiveRecord::Base
     r
   end
 
-  def render_xml(builder)
+  def _get_attributes
     attributes = { :state => self.state.to_s  }
     # old requests didn't have who and when
     attributes[:when] = self.created_at.strftime("%Y-%m-%dT%H:%M:%S") if self.reviewer
@@ -54,12 +54,23 @@ class Review < ActiveRecord::Base
     attributes[:by_user] = self.by_user if self.by_user
     attributes[:by_package] = self.by_package if self.by_package
     attributes[:by_project] = self.by_project if self.by_project
-    
-    builder.review(attributes) do
+
+    attributes
+  end
+
+  def render_xml(builder)
+    builder.review(_get_attributes) do
       builder.comment! self.reason if self.reason
     end
   end
-  
+
+  def webui_infos
+    ret = _get_attributes
+    # XML has this perl format, don't use that here
+    ret[:when] = self.created_at
+    ret
+  end
+
   def notify_parameters(params = {})
     hermes_type = nil
     if self.by_package

--- a/src/webui/Gemfile
+++ b/src/webui/Gemfile
@@ -11,7 +11,7 @@ group :assets do
   gem 'sass-rails'
   gem 'compass-rails'
   gem 'jquery-datatables-rails'
-  gem 'codemirror-rails'
+  gem 'codemirror-rails', '~> 2.35'
 end
 
 group :development do

--- a/src/webui/Gemfile.lock
+++ b/src/webui/Gemfile.lock
@@ -174,7 +174,7 @@ PLATFORMS
 DEPENDENCIES
   capybara (>= 2.0)
   ci_reporter
-  codemirror-rails
+  codemirror-rails (~> 2.35)
   compass-rails
   cssmin (>= 1.0.2)
   delayed_job (> 3.0)


### PR DESCRIPTION
I used timecop to avoid having to guess the expected timestamps
by means of sleep, but I can move the clock myself in tests and
as such verify the result is 100% what I expect
