### PR TITLE
[webui] Fix bnc#792666 in patchinfo-editor

### DIFF
--- a/src/webui/app/controllers/patchinfo_controller.rb
+++ b/src/webui/app/controllers/patchinfo_controller.rb
@@ -55,8 +55,6 @@ class PatchinfoController < ApplicationController
       @pkg_names << pkg.value(:name)
     end
     @pkg_names.delete("patchinfo")
-    @description = @description.gsub(/\n/, "<br/>").html_safe
-    @summary = @summary.gsub(/\n/, "<br/>").html_safe
     @packager = Person.find(:login => @packager)
   end
 


### PR DESCRIPTION
Removed an old part of the code which prints the summary and description-strings in patchinfo html_safe. This fixes bnc#792666.
