### PR TITLE
bs_srcserver: configurable vendorname

### DIFF
--- a/src/backend/BSConfig.pm.template
+++ b/src/backend/BSConfig.pm.template
@@ -45,6 +45,7 @@ if ($frontend) {
 }
 
 our $obsname = $hostname; # unique identifier for this Build Service instance
+# our $vendorname = "Open Build Service";
 # Change also the SLP reg files in /etc/slp.reg.d/ when you touch hostname or port
 our $srcserver = "http://$hostname:5352";
 our $reposerver = "http://$hostname:5252";

--- a/src/backend/bs_srcserver
+++ b/src/backend/bs_srcserver
@@ -3597,7 +3597,8 @@ sub concatconfigs {
   }
   $vprojid = $projid if $vprojid eq '';
   my $obsname = $BSConfig::obsname || 'build.opensuse.org';
-  $macros .= "%vendor obs://$obsname/$vprojid\n";
+  my $vendorname = $BSConfig::vendorname || "obs://$obsname/$vprojid";
+  $macros .= "%vendor $vendorname\n";
 
   $macros .= "%_project $projid\n";
   my $lastr = '';


### PR DESCRIPTION
Make the vendortag set by srcserver configurable through new variable
in BSConfig.pm.

If variable is not set (default) the current "obs://$obsname/$vprojid"
