### PR TITLE
[api] fix bug with creating repositories in remote project

### DIFF
--- a/src/api/app/models/repository.rb
+++ b/src/api/app/models/repository.rb
@@ -19,7 +19,7 @@ class Repository < ActiveRecord::Base
 
   validate :validate_duplicates, :on => :create
   def validate_duplicates
-    if Repository.where("db_project_id = ? AND name = ?", self.db_project_id, self.name).first
+    if Repository.where("db_project_id = ? AND name = ? AND ( remote_project_name = ? OR remote_project_name is NULL)", self.db_project_id, self.name, self.remote_project_name).first
       errors.add(:name, "Project already has repository with name #{self.name}")
     end
   end

--- a/src/api/db/migrate/20121130143300_uniq_repositories.rb
+++ b/src/api/db/migrate/20121130143300_uniq_repositories.rb
@@ -23,8 +23,7 @@ class UniqRepositories < ActiveRecord::Migration
         prj.save
       end
 
-# This fails unfortunatly with repositories in remote projects
-#      execute("alter table repositories ADD UNIQUE(db_project_id,name);");
+      execute("alter table repositories ADD UNIQUE(db_project_id,name,remote_project_name);");
     end
 
     CONFIG['global_write_through'] = old

--- a/src/api/db/structure.sql
+++ b/src/api/db/structure.sql
@@ -535,7 +535,7 @@ CREATE TABLE `repositories` (
   `linkedbuild` enum('off','localdep','all') CHARACTER SET utf8 DEFAULT NULL,
   `hostsystem_id` int(11) DEFAULT NULL,
   PRIMARY KEY (`id`),
-  UNIQUE KEY `db_project_id` (`db_project_id`,`name`),
+  UNIQUE KEY `db_project_id` (`db_project_id`,`name`,`remote_project_name`),
   UNIQUE KEY `projects_name_index` (`db_project_id`,`name`,`remote_project_name`),
   KEY `remote_project_name_index` (`remote_project_name`),
   KEY `hostsystem_id` (`hostsystem_id`),

--- a/src/api/test/unit/project_test.rb
+++ b/src/api/test/unit/project_test.rb
@@ -198,6 +198,57 @@ class ProjectTest < ActiveSupport::TestCase
      assert_equal orig, @project.render_axml
   end
 
+  test "duplicated repos with remote" do
+     orig = @project.render_axml
+
+     xml = <<END
+<project name="home:Iggy">
+  <title>Iggy"s Home Project</title>
+  <description></description>
+  <repository name="remote_1">
+    <path project="RemoteInstance:remote_project_1" repository="standard"/>
+    <arch>i586</arch>
+  </repository>
+  <repository name="remote_1">
+    <path project="RemoteInstance:remote_project_1" repository="standard"/>
+    <arch>x86_64</arch>
+  </repository>
+</project>
+END
+     axml = Xmlhash.parse(xml)
+     assert_raise(ActiveRecord::RecordInvalid) do
+       Project.transaction do
+         @project.update_from_xml(axml)
+       end
+     end
+     @project.reload
+     assert_equal orig, @project.render_axml
+  end
+  test "not duplicated repos with remote" do
+     xml = <<END
+<project name="home:Iggy">
+  <title>Iggy"s Home Project</title>
+  <description></description>
+  <repository name="remote_2">
+    <path project="RemoteInstance:remote_project_2" repository="standard"/>
+    <arch>x86_64</arch>
+    <arch>i586</arch>
+  </repository>
+  <repository name="remote_1">
+    <path project="RemoteInstance:remote_project_1" repository="standard"/>
+    <arch>x86_64</arch>
+    <arch>i586</arch>
+  </repository>
+</project>
+END
+     axml = Xmlhash.parse(xml)
+     Project.transaction do
+       @project.update_from_xml(axml)
+     end
+     @project.reload
+     assert_equal xml, @project.render_axml
+  end
+
   def test_create_maintenance_project_and_maintained_project
     maintenance_project = Project.new(:name => 'Maintenance:Project')
     assert_equal true, maintenance_project.set_project_type('maintenance')


### PR DESCRIPTION
Now you can create repositories in remote project like
`openSUSE.org:RedHat:RHEL-4` and `openSUSE.org:RedHat:RHEL-4` with no
error
