### PR TITLE
bs_worker: use lazy unmount if TMPFS is used

### DIFF
--- a/src/backend/bs_worker
+++ b/src/backend/bs_worker
@@ -145,7 +145,7 @@ sub tail_logfile {
 
 sub cleanup_job {
   if ($vm_tmpfs_mode) {
-    qsystem("umount", $buildroot) && die("umount tmpfs failed: $!\n");
+    qsystem("umount", "-l", $buildroot) && die("umount tmpfs failed: $!\n");
   }
 }
 


### PR DESCRIPTION
Use lazy unmount if TMPFS is used as the worker dies if someone
watches the live buildlog during build, because the FS is busy.
