### PR TITLE
[api] Take sub-packages into account (dependecy check)

### DIFF
--- a/src/api/app/controllers/status_controller.rb
+++ b/src/api/app/controllers/status_controller.rb
@@ -348,6 +348,11 @@ class StatusController < ApplicationController
               buildcode='failed' 
             end
 
+            # get subpackages
+            buildinfo.each_subpack do |s|
+              packages[s.text] = 1
+            end
+
             buildinfo.each_bdep do |b|
               unless b.value(:preinstall)
                 unless packages.has_key? b.value(:name)


### PR DESCRIPTION
Dependencies are checked in status method, but sub-packages of submitted
package are not taken into account and are reported incorrectly as
missing dependencies. This patch fixes it.

See https://api.opensuse.org/status/bsrequest?id=148204 as an example
