### PR TITLE
[backend] Ensure that bs_worker and build use the same vm-disk

### DIFF
--- a/src/backend/bs_worker
+++ b/src/backend/bs_worker
@@ -2123,6 +2123,7 @@ sub dobuild {
   } elsif ($vm =~ /emulator/) {
     push @args, '--root', "$buildroot/.mount";
     push @args, '--vm-type', 'emulator';
+    push @args, '--vm-disk', $vm_root;
     push @args, '--statistics';
     push @args, '--emulator-script', $emulator_script if $emulator_script;
   } elsif ($vm =~ /lxc/) {


### PR DESCRIPTION
Make sure that build uses the same
vm-disk than bs_worker in the emulator backend case.
