### PR TITLE
[backend] Sync vm-disk/swap defaults with build

### DIFF
--- a/src/backend/bs_worker
+++ b/src/backend/bs_worker
@@ -533,8 +533,10 @@ if ($exitrestart) {
 usage(1) unless $buildroot && $statedir;
 usage(1) if ($cachedir && !$cachesize) || ($cachesize && !$cachedir);
 
-$vm_root = "$buildroot/root" unless $vm_root;
-$vm_swap = "$buildroot/swap" unless $vm_swap;
+# default needs to be in sync with build(1)
+# otherwise job killing does not work in a default setup
+$vm_root = "${buildroot}.img" unless $vm_root;
+$vm_swap = "${buildroot}.swap" unless $vm_swap;
 
 # here's the build code we want to use
 $::ENV{'BUILD_DIR'} = "$statedir/build";


### PR DESCRIPTION
Build and bs_worker had different defaults on
vm-disk/swap, which caused e.g. job killing to
not work correctly if only defaults were used
(only happens in default installations, not
in our production setup).
