### PR TITLE
[backend] always clean worker dir on startup

### DIFF
--- a/dist/obsworker
+++ b/dist/obsworker
@@ -284,19 +284,23 @@ case "$1" in
 	    else
                 WORKERID="${HOSTNAME}:$I"
 	    fi
-            R=$OBS_WORKER_DIRECTORY/root_$I
+            R="$OBS_WORKER_DIRECTORY/root_$I"
             # prepare obsworker startup in screen...
             TMPFS=
             if [ "$OBS_VM_TYPE" = "xen" -o "$OBS_VM_TYPE" = "kvm" -o "${OBS_VM_TYPE#emulator:}" != "$OBS_VM_TYPE" ] ; then
-                mkdir -p $R
-                DEVICE="$OBS_WORKER_DIRECTORY/root_$I/root"
+                # clean worker root from previous run
+                if [ -d "$R" ]; then
+                    rm -rf "$R"
+                fi
+                mkdir -p "$R"
+                DEVICE="$R/root"
                 if [ -n "$OBS_VM_DISK_AUTOSETUP_ROOT_FILESIZE" ]; then
                     OBS_WORKER_OPT="$OBS_WORKER_OPT1 $VMDISK_AUTOSETUP $VMDISK_ROOT_FILESIZE $VMDISK_SWAP_FILESIZE $VMDISK_FILESYSTEM $VMDISK_MOUNT_OPTIONS $VMDISK_CLEAN"
                 elif [ ! -e "$DEVICE" ]; then
                     echo "ERROR: worker is configured to use a VM, but the root device do not exist: $DEVICE"
                     exit 1
                 else
-                  SWAP="--swap $OBS_WORKER_DIRECTORY/root_$I/swap"
+                  SWAP="--swap $R/swap"
                 fi
                 if [ -n "$OBS_VM_USE_TMPFS" ]; then
                     TMPFS="--tmpfs"


### PR DESCRIPTION
This prevents files from previuos obsworker
run to actually leak into this session (and
get packaged e.g. into preinstall images)
