### PR TITLE
[backend] Add feature to support multiple notify plugins

### DIFF
--- a/src/backend/BSConfig.pm.template
+++ b/src/backend/BSConfig.pm.template
@@ -60,8 +60,8 @@ our $repodownload = "http://$hostname/repositories";
 #our $hermesserver = "http://$hostname/hermes";
 #our $hermesnamespace = "OBS";
 #
-# Notification Plugin
-#our $notification_plugin = "notify_hermes";
+# Notification Plugin, multiple plugins supported, separated by space
+#our $notification_plugin = "notify_hermes notify_rabbitmq";
 #
 #FIXME2.4 belongs in API
 # Does the notify plugin supports multiple actions?

--- a/src/backend/BSNotify.pm
+++ b/src/backend/BSNotify.pm
@@ -32,8 +32,12 @@ sub notify($$) {
 
   return unless $BSConfig::notification_plugin;
 
-  my $notifier = &loadPackage($BSConfig::notification_plugin);
-  $notifier->notify($type, $paramRef );
+  my @hostnames = split(/\s+/, $BSConfig::notification_plugin);
+
+  for my $i (0..@hostnames -1){
+      my $notifier = &loadPackage($hostnames[$i]);
+      $notifier->notify($type, $paramRef );
+  }
 
 }
 


### PR DESCRIPTION
Event can be sent to more events handler services

Signed-off-by: Hasan Wan hasan.wan@intel.com
