### PR TITLE
Clean worker dirs on startup

### DIFF
--- a/dist/obsworker
+++ b/dist/obsworker
@@ -284,11 +284,14 @@ case "$1" in
 	    else
                 WORKERID="${HOSTNAME}:$I"
 	    fi
+            # clean worker root from previous run
             R=$OBS_WORKER_DIRECTORY/root_$I
+            test -d "$R" && rm -rf "$R"
+            mkdir -p "$R"
+
             # prepare obsworker startup in screen...
             TMPFS=
             if [ "$OBS_VM_TYPE" = "xen" -o "$OBS_VM_TYPE" = "kvm" -o "${OBS_VM_TYPE#emulator:}" != "$OBS_VM_TYPE" ] ; then
-                mkdir -p $R
                 DEVICE="$OBS_WORKER_DIRECTORY/root_$I/root"
                 if [ -n "$OBS_VM_DISK_AUTOSETUP_ROOT_FILESIZE" ]; then
                     OBS_WORKER_OPT="$OBS_WORKER_OPT1 $VMDISK_AUTOSETUP $VMDISK_ROOT_FILESIZE $VMDISK_SWAP_FILESIZE $VMDISK_FILESYSTEM $VMDISK_MOUNT_OPTIONS $VMDISK_CLEAN"
@@ -307,13 +310,11 @@ case "$1" in
                     HUGETLBFS="--hugetlbfs $OBS_VM_USE_HUGETLBFS"
                 fi
 	    elif [ -n "$vmopt" -a "$OBS_VM_TYPE" = 'zvm' ]; then
-		mkdir -p $R
 		# Without a worker being defined, we would not be in this loop.
 		WORKER="--vm-worker ${WORKERS[$I_INDEX]}"
 		WORKER_NR="--vm-worker-nr $I"
 		OBS_WORKER_OPT="$OBS_WORKER_OPT1 $WORKER $WORKER_NR $VMDISK_FILESYSTEM $VMDISK_MOUNT_OPTIONS $VMDISK_CLEAN"
             else
-                mkdir -p $R
                 DEVICE=
                 SWAP=
                 MEMORY=


### PR DESCRIPTION
Ensure that there is nothing left in there. Especially
when changing worker types there can be artefacts propagating
into the build (e.g. preinstallimages picking up previous
build root images)
