### PR TITLE
[backend] Avoid endless rebuilds if qemu-linux-user is missing

### DIFF
--- a/src/backend/bs_worker
+++ b/src/backend/bs_worker
@@ -2789,7 +2789,8 @@ if (!$ex) {
     sysseek(LL, -10240, 2);
     sysread(LL, $data, 10240);
     close LL;
-    if ($data =~ /^mount: error while loading shared libraries:/m) {
+    if ($data =~ /^mount: error while loading shared libraries:/m
+        || $data =~ /^execve: Exec format error/m) {
       print "Wait ... spotted failed build. Host is good.\n";
       $code = 'failed';
     }


### PR DESCRIPTION
A common error happening on the build.opensuse.org instance
is that buidl is enabled for armv7l, but no or not the right
qemu-linux-user is installed. In those cases the builds
are looping endlessly on the build cluster, wasting a lot of
CPU. Detect that case and end it.
