### PR TITLE
[backend] Avoid failing job when Build.pm cannot be imported

### DIFF
--- a/src/backend/bs_worker
+++ b/src/backend/bs_worker
@@ -2715,6 +2715,8 @@ if ($@) {
   }
   print "$@";
   $ex = 1;
+  # mark as bad build host if Build.pm could not be imported
+  $ex = 3 unless defined &Build::queryhdrmd5;
 }
 if ($buildinfo->{'followupfile'}) {
   my $buildsrcdir = "$buildroot/.build.packages/SOURCES";


### PR DESCRIPTION
Thats most likely a host problem (cpio not working,
network conflicts), don't fail the job
