### PR TITLE
bs_publish: fix regex support in publishedhooks

### DIFF
--- a/src/backend/bs_publish
+++ b/src/backend/bs_publish
@@ -1663,7 +1663,7 @@ publishprog_done:
   # support for regex usage in $BSConfig::publishedhook
   my $publish_prp = $prp;
   if ($BSConfig::publishedhook_use_regex) {
-    for my $key (sort {$b cmp $a}} keys %{$BSConfig::publishedhook}) {
+    for my $key (sort {$b cmp $a} keys %{$BSConfig::publishedhook}) {
       if ($prp =~ /^$key/) {
         $publish_prp = $key;
         last;


### PR DESCRIPTION
Fixed support for regular expressions in publishedhooks.
