### PR TITLE
[api] When branching a package, copy repository linkedbuild, block, and ...

### DIFF
--- a/src/api/app/helpers/maintenance_helper.rb
+++ b/src/api/app/helpers/maintenance_helper.rb
@@ -816,7 +816,7 @@ module MaintenanceHelper
           end
           if add_repositories
             unless tprj.repositories.find_by_name(repoName)
-              trepo = tprj.repositories.create :name => repoName
+              trepo = tprj.repositories.create( :name => repoName, :rebuild => repo.rebuild, :linkedbuild => repo.linkedbuild, :block => repo.block)
               trepo.architectures = repo.architectures
               trepo.path_elements.create(:link => repo, :position => 1)
               trigger = "manual"


### PR DESCRIPTION
...rebuild attributes.

Fixes issue #269

Tested here with obs 2.3.8 branching both a project with repositories with those attributes and one without. Both worked as expected.
