### PR TITLE
[webui] Fix RAILS_ENV=production rake db:migrate

### DIFF
--- a/src/webui/lib/tasks/sprites.rake
+++ b/src/webui/lib/tasks/sprites.rake
@@ -1,5 +1,3 @@
-require 'sprite_factory'
-
 namespace :assets do
   desc 'recreate sprite images and css'
   task :resprite => :environment do 


### PR DESCRIPTION
rake aborted!
cannot load such file -- sprite-factory
/srv/www/obs/webui/lib/tasks/sprites.rake:1:in <top (required)>'
(See full trace by running task with --trace)
