### PR TITLE
[backend] use freectx()

### DIFF
--- a/src/backend/BSSSL.pm
+++ b/src/backend/BSSSL.pm
@@ -134,6 +134,7 @@ sub UNTIE {
 sub DESTROY {
   my ($sslr) = @_;
   UNTIE($sslr) if $sslr && $sslr->[0];
+  freectx();
 }
 
 1;


### PR DESCRIPTION
freectx() is currently dead code. Not referenced from anywhere in code.
So the function should be either removed or probably used somewhere. And DESTROY
of TIE seems like good place to call it there.
