### PR TITLE
[api] Better logs for Sphinx related tasks in clockworkd -l

### DIFF
--- a/src/api/config/clock.rb
+++ b/src/api/config/clock.rb
@@ -58,9 +58,11 @@ end
 # every week ensures that initial start and doesn't really hurt. Not the
 # cleanest solution, but avoids creating/modifying init.d scripts
 every(1.week, 're(start) sphinx', thread: true) do
-  `rake ts:restart`
+  interface = ThinkingSphinx::RakeInterface.new
+  interface.stop
+  interface.start
 end
 
 every(1.hour, 'reindex sphinx', thread: true) do
-  `rake ts:index`
+  ThinkingSphinx::RakeInterface.new.index
 end


### PR DESCRIPTION
Now, the logfile for

```
clockworkd -l -c config/clock.rb start
```

(usually located in tmp/clockworkd.clock.output) logs information about the sphinx indexing (and restarting).
