### PR TITLE
Send notification to hermes for new comment creation

### DIFF
--- a/src/api/app/models/comment.rb
+++ b/src/api/app/models/comment.rb
@@ -1,7 +1,10 @@
+require 'event/comment'
 class Comment < ActiveRecord::Base
   belongs_to :project
   belongs_to :package
   belongs_to :bs_request
+
+  after_save :create_notification
 
   def self.save(params)
     @comment = {}
@@ -13,6 +16,21 @@ class Comment < ActiveRecord::Base
 
   def self.remove(params)
     self.update(params[:comment_id], :title => "This comment has been deleted", :body => "", :user => "_nobody_")
+  end
+
+  def create_notification(params = {})
+    params[:commenter] = self.user
+    params[:comment] = self.body
+  end
+
+  # build an array of users, commenting on a specific object type
+  def involved_users(object_field , object_value)
+    record = Comment.where(object_field => object_value)
+    users = []
+    record.each do |comment|
+      users << comment.user
+    end
+    users.uniq!
   end
 
 end

--- a/src/api/app/models/comment_package.rb
+++ b/src/api/app/models/comment_package.rb
@@ -5,4 +5,13 @@ class CommentPackage < Comment
 		@comment['package_id'] = package.id
 		CommentPackage.create(@comment)
 	end
+	def create_notification(params = {})
+		super
+		params[:project] = self.package.project.name
+		params[:package] = self.package.name
+		params[:involved_users] = involved_users(:package_id, self.package.id)
+
+		# call the action
+		Event::CommentForPackage.create params
+	end
 end

--- a/src/api/app/models/comment_project.rb
+++ b/src/api/app/models/comment_project.rb
@@ -6,4 +6,13 @@ class CommentProject < Comment
 		@comment['project_id'] = project.id
 		CommentProject.create(@comment)
 	end
+
+	def create_notification(params = {})
+		super
+		params[:project] = self.project.name
+		params[:involved_users] = involved_users(:project_id, self.project.id)
+
+		# call the action
+		Event::CommentForProject.create params
+	end
 end

--- a/src/api/app/models/comment_request.rb
+++ b/src/api/app/models/comment_request.rb
@@ -1,7 +1,16 @@
 class CommentRequest < Comment
 	def self.save(params)
 		super
-                @comment['bs_request_id'] = params[:id]
+		@comment['bs_request_id'] = params[:id]
 		CommentRequest.create(@comment)
+	end
+
+	def create_notification(params = {})
+		super
+		params[:request_id] = self.bs_request_id
+		params[:involved_users] = involved_users(:bs_request_id, self.bs_request_id)
+
+		# call the action
+		Event::CommentForRequest.create params
 	end
 end

--- a/src/api/app/models/event.rb
+++ b/src/api/app/models/event.rb
@@ -1,3 +1,4 @@
 require_dependency 'event/base.rb'
 require_dependency 'event/project.rb'
 require_dependency 'event/request.rb'
+require_dependency 'event/comment.rb'

--- a/src/api/app/models/event/comment.rb
+++ b/src/api/app/models/event/comment.rb
@@ -1,0 +1,18 @@
+class Event::CommentForProject < ::Event::Project
+  self.raw_type = 'PROJECT_COMMENT_ADDED'
+  self.description = 'New comment for project created.'
+  payload_keys :involved_users, :commenter, :comment
+end
+
+class Event::CommentForPackage < ::Event::Package
+  self.raw_type = 'PACKAGE_COMMENT_ADDED'
+  self.description = 'New comment for package created.'
+  payload_keys :involved_users, :commenter, :comment
+end
+
+class Event::CommentForRequest < ::Event::Base
+  self.raw_type = 'REQUEST_COMMENT_ADDED'
+  self.description = 'New comment for request created.'
+  payload_keys :involved_users, :commenter, :request_id, :comment
+end
+


### PR DESCRIPTION
Once a new comment is created, a new entry is created under Event table to be able to sent out to hermes.

Payload keys include - `project_name` (if), `package_name` (if), `request_id` (if), `comment` (body of the comment), `commenter` (name of the user making comment) and involved_users (list of users who have made comment under a $object type.).

Any feedback or comments are welcome.

Hermes template files are at - https://github.com/shayonj/hermes/commit/acb74f4671114573f2048610f72358f38b332cc0

Cheers!
