### PR TITLE
[backend] Dependence between worker instances and OBS_SETUP_WORKER_PARTITIONS

### DIFF
--- a/dist/obsstoragesetup
+++ b/dist/obsstoragesetup
@@ -198,7 +198,7 @@ EOF
                         [ -d "$backenddir"/MySQL/ ] && touch "$backenddir"/MySQL/.run-mysql_upgrade
 		fi
 
-		if [ "$OBS_SETUP_WORKER_PARTITIONS" = "take_all" -o "$OBS_SETUP_WORKER_PARTITIONS" = "use_obs_vg" ]; then
+			# FIXME: re-indent start
 			if [ 0"$OBS_WORKER_INSTANCES" -gt 0 ]; then
 				# got config setting from sysconfig or PXE server
 				NUM="$OBS_WORKER_INSTANCES"
@@ -223,7 +223,9 @@ EOF
 				echo "WARNING: OBS worker instances are 0, either misconfiguration or not enough resources"
 				exit 0
 			fi
+			# FIXME: re-indent stop
 
+		if [ "$OBS_SETUP_WORKER_PARTITIONS" = "take_all" -o "$OBS_SETUP_WORKER_PARTITIONS" = "use_obs_vg" ]; then
 			# Look for PV devices in OBS VG
 			pvs=""
 			for i in `vgdisplay -v OBS 2>/dev/null | grep "PV Name" | awk '{ print $3 }' | sort`; do
@@ -323,6 +325,26 @@ EOF
 			mkfs -text4 /dev/OBS/cache || exit
 		fi
 
+		if [ "$OBS_SETUP_WORKER_PARTITIONS" = "none" ]; then
+			# FIXME: this only checks if the same number of root and swap LVs are present. Additionally, they have to have the same name.
+			num_of_worker_root=`lvdisplay -c OBS 2>/dev/null | cut -d':' -f1 | grep worker_root_ | wc -l`
+			num_of_worker_swap=`lvdisplay -c OBS 2>/dev/null | cut -d':' -f1 | grep worker_swap_ | wc -l`
+			if [ $num_of_worker_root -ne $num_of_worker_swap ]; then
+				echo "WARNING: Inconsistent number of root and swap LVs for the workers. LVs won't be mounted."
+				NUM=0
+			else
+				if [ `lvdisplay -c OBS/cache 2>/dev/null` -ne 1 ]; then
+					echo "WARNING: No cache partition available for the workers. LVs won't be mounted."
+					NUM=0
+				else
+					if [ $num_of_worker_root -gt $NUM ]; then
+						echo "WARNING: Your resources allow to have ${NUM} workers, but the VG \"OBS\" is configured for ${num_of_worker_root} workers."
+					fi;
+					NUM=$num_of_worker_root
+				fi
+			fi
+		fi
+		
 		if [ ! "0$NUM" -gt 0 ]; then
 			exit 0
 		fi

--- a/dist/sysconfig.obs-server
+++ b/dist/sysconfig.obs-server
@@ -301,7 +301,10 @@ OBS_STORAGE_AUTOSETUP=""
 ## Config:      OBS
 #
 # take_all: WARNING: all LVM partitions will be used and all data erased !
-# use_obs_vg:  A lvm volume group named "OBS" will be re-setup for the workers.
+# use_obs_vg: A lvm volume group named "OBS" will be re-setup for the workers.
+# none: No partitions are created. Nevertheless, if you have a LV "cache"
+# as well as LVs "worker_root_<name>" and "worker_swap_<name>" within the
+# volume group "OBS", they will be mounted and used for the workers.
 #
 OBS_SETUP_WORKER_PARTITIONS="use_obs_vg"
 


### PR DESCRIPTION
Currently, you have to set OBS_SETUP_WORKER_PARTITIONS to something else than "none", so workers are used at all. But if you set it to "none", so that the server LV isn't removed, no workers are prepared because of

```
        if [ ! "0$NUM" -gt 0 ]; then
            exit 0
        fi
```

where `$NUM` isn't set.

In my opinion, the worker instances themselves (`OBS_WORKER_INSTANCES`) shouldn't require OBS_SETUP_WORKER_PARTITIONS!="none".

Do not pull the changes as it is only a first draft / idea, which isn't tested. (on my system, I've just commented out the three lines above)
