### PR TITLE
obsapisetup wants to do an initial setup everytime

### DIFF
--- a/dist/obsapisetup
+++ b/dist/obsapisetup
@@ -67,7 +67,7 @@ if [ "$?" != "0" ]; then
 fi
 
 #Is there a non default configured datadir?
-MYSQL_DATA_DIR=`sed -n 's,^datadir[ \t]*=[\t ]*\(.*\),\1,p' /etc/my.cnf`
+MYSQL_DATA_DIR=`sed -n 's,^datadir[ \t]*=[\t ]*\(.*\),\1,p' /etc/my.cnf | head -n 1`
 [ -z "$MYSQL_DATA_DIR" ] && MYSQL_DATA_DIR="${backenddir}/MySQL"
 
 rc_reset


### PR DESCRIPTION
In the appliance, `/etc/my.cnf` contains the entry `datadir` twice. This leads to a wrong `$MYSQL_DATA_DIR`, which let [this conditional](https://github.com/chkpnt/open-build-service/blob/b3b6b1de71b17e0db77760363a74dd8462557673/dist/obsapisetup#L134) fail.
