### PR TITLE
obsapisetup removes options from options.yml

### DIFF
--- a/dist/obsapisetup
+++ b/dist/obsapisetup
@@ -126,8 +126,6 @@ case "$1" in
 		    /srv/www/obs/webui/config/options.yml
                 sed -i 's,^read_only_hosts: .*,read_only_hosts: [ "'"$FQHOSTNAME"'" ],' \
 		    /srv/www/obs/api/config/options.yml
-                sed -i -e /webui_url:/d -e /webui_host:/d -e /read_only_hosts:/d -e /allow_anonymous:/d \
-		    /srv/www/obs/api/config/options.yml
 		OBSVERSION=`rpm -q --qf '%{VERSION}' obs-server`
 		OS=`head -n 1 /etc/SuSE-release`
                 RUN_INITIAL_SETUP=""


### PR DESCRIPTION
In former times, obsapisetup was used to set `webui_url`, `webui_host`, `read_only_hosts` and `allow_anonymous`. This was removed with c44418b90d8e2d1395d88530cd4bd84c52a5c2ec, as the settings are now configured using `osc api /configuration`, but one line survived. 
