### PR TITLE
Pass threads option to build

### DIFF
--- a/dist/obsworker
+++ b/dist/obsworker
@@ -72,6 +72,9 @@ fi
 if [ -n "$OBS_WORKER_JOBS" ]; then
     OBS_JOBS="--jobs $OBS_WORKER_JOBS"
 fi
+if [ -n "$OBS_WORKER_THREADS" ]; then
+    OBS_THREADS="--threads $OBS_WORKER_THREADS"
+fi
 if [ -n "$OBS_WORKER_NICE_LEVEL" ]; then
     OBS_NICE=$OBS_WORKER_NICE_LEVEL
 else
@@ -323,7 +326,7 @@ case "$1" in
             fi
 	    echo "screen -t $WORKERID nice -n $OBS_NICE ./bs_worker $vmopt $port --root $R" \
                 "--statedir $workerdir/$I --id $WORKERID $REPO_PARAM $HUGETLBFS $HOSTLABELS" \
-                "$HOSTOWNER $OBS_JOBS $OBS_TEST $OBS_WORKER_OPT $TMPFS $DEVICE $SWAP $MEMORY" \
+                "$HOSTOWNER $OBS_JOBS $OBS_THREADS $OBS_TEST $OBS_WORKER_OPT $TMPFS $DEVICE $SWAP $MEMORY" \
                 "$ARCH $EMULATOR" \
                 >> $screenrc
 	    mkdir -p $workerdir/$I

--- a/src/backend/bs_worker
+++ b/src/backend/bs_worker
@@ -88,6 +88,7 @@ my @hostlabel;
 my $getbinariesproxy;
 
 my $jobs;
+my $threads;
 my $cachedir;
 my $cachesize;
 
@@ -263,6 +264,8 @@ Usage: $0 [OPTION] --root <directory> --statedir <directory>
                    : do not update both worker and build code
 
        --jobs <nr> : hand over the number of parallel jobs to build
+
+       --threads <nr> : sets number of threads for KVM
 
        --oneshot <seconds>
                    : just build one package, do not wait more then
@@ -489,6 +492,11 @@ while (@ARGV) {
   if ($ARGV[0] eq '--jobs') {
     shift @ARGV;
     $jobs = shift @ARGV;
+    next;
+  }
+  if ($ARGV[0] eq '--threads') {
+    shift @ARGV;
+    $treads = shift @ARGV;
     next;
   }
   if ($ARGV[0] eq '--cachedir') {
@@ -2253,6 +2261,7 @@ sub dobuild {
   push @args, '--debug' if $buildinfo->{'debuginfo'};
   push @args, '--arch', $arch;
   push @args, '--jobs', $jobs if $jobs;
+  push @args, '--threads', $threads if $treads;
   push @args, '--reason', "Building $packid for project '$projid' repository '$repoid' arch '$arch' srcmd5 '$buildinfo->{'srcmd5'}'";
   push @args, '--disturl', $disturl;
   push @args, '--linksources' if $localkiwi;


### PR DESCRIPTION
KVM on power uses advanced format to specify number of cpus and threads
to be used, like -smp 4,threads=8

Signed-off-by: Dinar Valeev dvaleev@suse.com
