### PR TITLE
Don't hardcode userinfo's min-height

### DIFF
--- a/src/api/app/assets/stylesheets/webui/home.css.scss
+++ b/src/api/app/assets/stylesheets/webui/home.css.scss
@@ -2,10 +2,6 @@
   color: lightgrey;
 }
 
-#userinfo {
-  min-height: 420px;
-}
-
 .ui-tabs {
   margin-top: -10px;
 }


### PR DESCRIPTION
While the value seems to be near what the 'involved' box may take, it's
usually wasting a lot of space (375px vs 520px in saschpe's case).

http://wstaw.org/m/2013/11/12/obshomecss.png
vs
http://wstaw.org/m/2013/11/12/obshomecss1.png
