### PR TITLE
It seems typo in api/app/controllers/webui/user_controller.rb

### DIFF
--- a/src/api/app/controllers/webui/user_controller.rb
+++ b/src/api/app/controllers/webui/user_controller.rb
@@ -210,8 +210,8 @@ class Webui::UserController < Webui::WebuiController
     if User.current.is_admin?
       redirect_to :controller => :configuration, :action => :users
     else
-      session[:login] = unreg_person_opts[:login]
-      session[:password] = unreg_person_opts[:password]
+      session[:login] = opts[:login]
+      session[:password] = opts[:password]
       authenticate_form_auth
       redirect_back_or_to :controller => :main, :action => :index
     end


### PR DESCRIPTION
"unreg_person_opts" doesn't work. It seems that "opts" could be enough.

[1a7282c7-1107-451d-b5d4-6c58920cb301] [25857:31.46]   Parameters: {"utf8"=>"✓", "authenticity_token"=>"L4MArpfq83mf452WuqF8ZPRMxDpXMuCyBH0yFpg6i4g=", "login"=>"user1000", "email"=>"user1000@mail.com", "password"=>"[FILTERED]", "register"=>"true", "commit"=>"Sign Up", "method"=>"post"}
[1a7282c7-1107-451d-b5d4-6c58920cb301] [25857:31.46] Anonymous request to /user/register?method=post
[1a7282c7-1107-451d-b5d4-6c58920cb301] [25857:31.70] Completed 500 Internal Server Error in 242ms
[1a7282c7-1107-451d-b5d4-6c58920cb301] [25857:32.38] 
NameError (undefined local variable or method `unreg_person_opts' for #<Webui::UserController:0x00000007659878>):
  app/controllers/webui/user_controller.rb:210:in`register'
  vendor/bundle/ruby/2.0.0/gems/actionpack-4.0.2/lib/action_controller/metal/implicit_render.rb:4:in `send_action'
  vendor/bundle/ruby/2.0.0/gems/actionpack-4.0.2/lib/abstract_controller/base.rb:189:in`process_action'
  vendor/bundle/ruby/2.0.0/gems/actionpack-4.0.2/lib/action_controller/metal/rendering.rb:10:in `process_action'
  vendor/bundle/ruby/2.0.0/gems/actionpack-4.0.2/lib/abstract_controller/callbacks.rb:18:in`block in process_action'
  vendor/bundle/ruby/2.0.0/gems/activesupport-4.0.2/lib/active_support/callbacks.rb:473:in `_run__2927746566845881590__process_action__callbacks'
  vendor/bundle/ruby/2.0.0/gems/activesupport-4.0.2/lib/active_support/callbacks.rb:80:in`run_callbacks'
  vendor/bundle/ruby/2.0.0/gems/actionpack-4.0.2/lib/abstract_controller/callbacks.rb:17:in `process_action'
  vendor/bundle/ruby/2.0.0/gems/actionpack-4.0.2/lib/action_controller/metal/rescue.rb:29:in`process_action'
  vendor/bundle/ruby/2.0.0/gems/actionpack-4.0.2/lib/action_controller/metal/instrumentation.rb:31:in `block in process_action'
  vendor/bundle/ruby/2.0.0/gems/activesupport-4.0.2/lib/active_support/notifications.rb:159:in`block in instrument'
  vendor/bundle/ruby/2.0.0/gems/activesupport-4.0.2/lib/active_support/notifications/instrumenter.rb:20:in `instrument'
  vendor/bundle/ruby/2.0.0/gems/activesupport-4.0.2/lib/active_support/notifications.rb:159:in`instrument'
  vendor/bundle/ruby/2.0.0/gems/actionpack-4.0.2/lib/action_controller/metal/instrumentation.rb:30:in `process_action'
  vendor/bundle/ruby/2.0.0/gems/actionpack-4.0.2/lib/action_controller/metal/params_wrapper.rb:245:in`process_action'
  vendor/bundle/ruby/2.0.0/gems/activerecord-4.0.2/lib/active_record/railties/controller_runtime.rb:18:in `process_action'
  vendor/bundle/ruby/2.0.0/gems/actionpack-4.0.2/lib/abstract_controller/base.rb:136:in`process'
  vendor/bundle/ruby/2.0.0/gems/actionpack-4.0.2/lib/abstract_controller/rendering.rb:44:in `process'
  vendor/bundle/ruby/2.0.0/gems/actionpack-4.0.2/lib/action_controller/metal.rb:195:in`dispatch'
  vendor/bundle/ruby/2.0.0/gems/actionpack-4.0.2/lib/action_controller/metal/rack_delegation.rb:13:in `dispatch'
  vendor/bundle/ruby/2.0.0/gems/actionpack-4.0.2/lib/action_controller/metal.rb:231:in`block in action'
  vendor/bundle/ruby/2.0.0/gems/actionpack-4.0.2/lib/action_dispatch/routing/route_set.rb:80:in `call'
  vendor/bundle/ruby/2.0.0/gems/actionpack-4.0.2/lib/action_dispatch/routing/route_set.rb:80:in`dispatch'
  vendor/bundle/ruby/2.0.0/gems/actionpack-4.0.2/lib/action_dispatch/routing/route_set.rb:48:in `call'
  vendor/bundle/ruby/2.0.0/gems/actionpack-4.0.2/lib/action_dispatch/routing/mapper.rb:44:in`call'
  vendor/bundle/ruby/2.0.0/gems/actionpack-4.0.2/lib/action_dispatch/journey/router.rb:71:in `block in call'
  vendor/bundle/ruby/2.0.0/gems/actionpack-4.0.2/lib/action_dispatch/journey/router.rb:59:in`each'
  vendor/bundle/ruby/2.0.0/gems/actionpack-4.0.2/lib/action_dispatch/journey/router.rb:59:in `call'
  vendor/bundle/ruby/2.0.0/gems/actionpack-4.0.2/lib/action_dispatch/routing/route_set.rb:680:in`call'
  config/initializers/wrap_parameters.rb:41:in `call'
  vendor/bundle/ruby/2.0.0/gems/newrelic_rpm-3.7.0.177/lib/new_relic/rack/error_collector.rb:50:in`call'
  vendor/bundle/ruby/2.0.0/gems/newrelic_rpm-3.7.0.177/lib/new_relic/rack/agent_hooks.rb:28:in `call'
  vendor/bundle/ruby/2.0.0/gems/newrelic_rpm-3.7.0.177/lib/new_relic/rack/browser_monitoring.rb:23:in`call'
  vendor/bundle/ruby/2.0.0/gems/hoptoad_notifier-2.4.11/lib/hoptoad_notifier/rack.rb:27:in `call'
  vendor/bundle/ruby/2.0.0/gems/rack-1.5.2/lib/rack/deflater.rb:25:in`call'
  vendor/bundle/ruby/2.0.0/gems/rack-1.5.2/lib/rack/etag.rb:23:in `call'
  vendor/bundle/ruby/2.0.0/gems/rack-1.5.2/lib/rack/conditionalget.rb:35:in`call'
  vendor/bundle/ruby/2.0.0/gems/rack-1.5.2/lib/rack/head.rb:11:in `call'
  vendor/bundle/ruby/2.0.0/gems/actionpack-4.0.2/lib/action_dispatch/middleware/flash.rb:241:in`call'
  vendor/bundle/ruby/2.0.0/gems/rack-1.5.2/lib/rack/session/abstract/id.rb:225:in `context'
  vendor/bundle/ruby/2.0.0/gems/rack-1.5.2/lib/rack/session/abstract/id.rb:220:in`call'
  vendor/bundle/ruby/2.0.0/gems/actionpack-4.0.2/lib/action_dispatch/middleware/cookies.rb:486:in `call'
  vendor/bundle/ruby/2.0.0/gems/activerecord-4.0.2/lib/active_record/query_cache.rb:36:in`call'
  vendor/bundle/ruby/2.0.0/gems/activerecord-4.0.2/lib/active_record/connection_adapters/abstract/connection_pool.rb:626:in `call'
  vendor/bundle/ruby/2.0.0/gems/actionpack-4.0.2/lib/action_dispatch/middleware/callbacks.rb:29:in`block in call'
  vendor/bundle/ruby/2.0.0/gems/activesupport-4.0.2/lib/active_support/callbacks.rb:373:in `_run__3973423607774511787__call__callbacks'
  vendor/bundle/ruby/2.0.0/gems/activesupport-4.0.2/lib/active_support/callbacks.rb:80:in`run_callbacks'
  vendor/bundle/ruby/2.0.0/gems/actionpack-4.0.2/lib/action_dispatch/middleware/callbacks.rb:27:in `call'
  vendor/bundle/ruby/2.0.0/gems/actionpack-4.0.2/lib/action_dispatch/middleware/remote_ip.rb:76:in`call'
  vendor/bundle/ruby/2.0.0/gems/actionpack-4.0.2/lib/action_dispatch/middleware/debug_exceptions.rb:17:in `call'
  vendor/bundle/ruby/2.0.0/gems/actionpack-4.0.2/lib/action_dispatch/middleware/show_exceptions.rb:30:in`call'
  vendor/bundle/ruby/2.0.0/gems/railties-4.0.2/lib/rails/rack/logger.rb:38:in `call_app'
  vendor/bundle/ruby/2.0.0/gems/railties-4.0.2/lib/rails/rack/logger.rb:20:in`block in call'
  vendor/bundle/ruby/2.0.0/gems/activesupport-4.0.2/lib/active_support/tagged_logging.rb:67:in `block in tagged'
  vendor/bundle/ruby/2.0.0/gems/activesupport-4.0.2/lib/active_support/tagged_logging.rb:25:in`tagged'
  vendor/bundle/ruby/2.0.0/gems/activesupport-4.0.2/lib/active_support/tagged_logging.rb:67:in `tagged'
  vendor/bundle/ruby/2.0.0/gems/railties-4.0.2/lib/rails/rack/logger.rb:20:in`call'
  vendor/bundle/ruby/2.0.0/gems/actionpack-4.0.2/lib/action_dispatch/middleware/request_id.rb:21:in `call'
  vendor/bundle/ruby/2.0.0/gems/rack-1.5.2/lib/rack/methodoverride.rb:21:in`call'
  vendor/bundle/ruby/2.0.0/gems/rack-1.5.2/lib/rack/runtime.rb:17:in `call'
  vendor/bundle/ruby/2.0.0/gems/activesupport-4.0.2/lib/active_support/cache/strategy/local_cache.rb:83:in`call'
  vendor/bundle/ruby/2.0.0/gems/rack-1.5.2/lib/rack/lock.rb:17:in `call'
  vendor/bundle/ruby/2.0.0/gems/rack-1.5.2/lib/rack/sendfile.rb:112:in`call'
  vendor/bundle/ruby/2.0.0/gems/hoptoad_notifier-2.4.11/lib/hoptoad_notifier/user_informer.rb:12:in `call'
  vendor/bundle/ruby/2.0.0/gems/railties-4.0.2/lib/rails/engine.rb:511:in`call'
  vendor/bundle/ruby/2.0.0/gems/railties-4.0.2/lib/rails/application.rb:97:in `call'
  vendor/bundle/ruby/2.0.0/gems/railties-4.0.2/lib/rails/railtie/configurable.rb:30:in`method_missing'
  vendor/bundle/ruby/2.0.0/gems/unicorn-4.7.0/lib/unicorn/http_server.rb:580:in `process_client'
  vendor/bundle/ruby/2.0.0/gems/unicorn-4.7.0/lib/unicorn/http_server.rb:660:in`worker_loop'
  vendor/bundle/ruby/2.0.0/gems/newrelic_rpm-3.7.0.177/lib/new_relic/agent/instrumentation/unicorn_instrumentation.rb:22:in `call'
  vendor/bundle/ruby/2.0.0/gems/newrelic_rpm-3.7.0.177/lib/new_relic/agent/instrumentation/unicorn_instrumentation.rb:22:in`block (4 levels) in <top (required)>'
  vendor/bundle/ruby/2.0.0/gems/unicorn-4.7.0/lib/unicorn/http_server.rb:527:in `spawn_missing_workers'
  vendor/bundle/ruby/2.0.0/gems/unicorn-4.7.0/lib/unicorn/http_server.rb:153:in`start'
  vendor/bundle/ruby/2.0.0/gems/unicorn-4.7.0/bin/unicorn_rails:209:in `<top (required)>'
  vendor/bundle/ruby/2.0.0/bin/unicorn_rails:23:in`load'
  vendor/bundle/ruby/2.0.0/bin/unicorn_rails:23:in `<main>'
