### PR TITLE
[backend] support architecture or package container specific constraints

### DIFF
--- a/docs/api/api/constraints.rng
+++ b/docs/api/api/constraints.rng
@@ -9,9 +9,27 @@
 
   <define ns="" name="constraints-element">
     <element name="constraints">
-      <zeroOrMore>
+        <!-- generic part -->
         <ref name="constraint-element"/>
-      </zeroOrMore>
+
+        <zeroOrMore>
+          <!-- multiple arch specific parts -->
+          <element name="overwrite">
+            <element name="conditions">
+              <zeroOrMore>
+                <element name="arch">
+                  <ref name="build-arch" />
+                </element>
+              </zeroOrMore>
+              <zeroOrMore>
+                <element name="package">
+                  <text/> <!-- package container name for multiple spec file packages -->
+                </element>
+              </zeroOrMore>
+            </element>
+            <ref name="constraint-element"/>
+          </element>
+        </zeroOrMore>
     </element>
   </define>
 

--- a/docs/api/api/constraints.xml
+++ b/docs/api/api/constraints.xml
@@ -16,7 +16,7 @@
     </cpu>
     <processors>2</processors>
     <disk>
-      <size unit="T">2</size>
+      <size unit="T">1</size>
     </disk>
     <memory>
       <size unit="G">1.5</size>
@@ -25,4 +25,18 @@
       <size unit="M">512</size>
     </physicalmemory>
   </hardware>
+  <overwrite>
+    <conditions>
+      <arch>i586</arch>      <!-- applies only for either i586 or x86_64 packages -->
+      <arch>x86_64</arch>
+      <package>kernel-default</package> <!-- and they must be build either as kernel-default or kernel-smp package -->
+      <package>kernel-smp</package>
+    </conditions>
+    <hardware>
+      <processors>8</processors>
+      <disk>
+        <size unit="T">2</size>
+      </disk>
+    </hardware>
+  </overwrite>
 </constraints>

--- a/src/backend/BSXML.pm
+++ b/src/backend/BSXML.pm
@@ -1564,9 +1564,7 @@ our $time = [
 ];
 
 # define constraints for build jobs in packages or projects.
-our $constraints = [
-    'constraints' => 
-	[],
+our @constraint = (
      [[ 'hostlabel' =>
         'exclude',   # true or false. default is false.
         [],
@@ -1593,7 +1591,18 @@ our $constraints = [
 	  [ 'disk' => $size ],
 	  [ 'memory' => $size ],
 	  [ 'physicalmemory' => $size ],
-      ],
+      ]
+);
+our $constraints = [
+    'constraints' => 
+        @constraint,
+        [[ 'overwrite' =>
+             [ 'conditions' =>
+               [ 'arch' ],
+               [ 'package' ],
+             ],
+             @constraint,
+        ]]
 ];
 
 our $buildstatistics = [

--- a/src/backend/bs_dispatch
+++ b/src/backend/bs_dispatch
@@ -277,8 +277,20 @@ sub staleness {
   return $ret;
 }
 
+sub overwrite {
+  my ($dst, $src) = @_;
+  for my $k (sort keys %$src) {
+    my $d = $src->{$k};
+    if (!exists($dst->{$k}) || !ref($d) || ref($d) ne 'HASH') {
+      $dst->{$k} = $d;
+    } else {
+      overwrite($dst->{$k}, $d);
+    }
+  }
+}
+
 sub getconstraints {
-  my ($info, $constraintsmd5) = @_;
+  my ($info, $architecture, $constraintsmd5) = @_;
   my $param = {
     'uri' => "$BSConfig::srcserver/source/$info->{'project'}/$info->{'package'}/_constraints",
     'timeout' => 300,
@@ -293,14 +305,28 @@ sub getconstraints {
     return [ time() + 600 ];	# better luck next time
   }
   return undef unless $constraintsxml;
-  return BSUtil::fromxml($constraintsxml, $BSXML::constraints, 1);
+  my $xml = BSUtil::fromxml($constraintsxml, $BSXML::constraints, 1);
+  # use condition specific constraints to merge it properly
+  for my $o (@{$xml->{'overwrite'}||[]}) {
+    next unless $o and $o->{'conditions'};
+    if ($o->{'conditions'}->{'arch'}) {
+      next if grep {$_ eq $architecture} @{$o->{'conditions'}->{'arch'}};
+    }
+    if ($o->{'conditions'}->{'package'}) {
+      next if grep {$_ eq $info->{'package'}} @{$o->{'conditions'}->{'package'}};
+    }
+    # conditions are matching, overwrite...
+    overwrite($xml, $o);
+  }
+  return $xml;
 }
 
 # last one wins
 sub mergeconstraints {
-  my ($con, @other) = @_;
+  my ($con, @xmlcons) = @_;
   $con = Storable::dclone($con);
-  for my $con2 (@other) {
+  # merge constraints
+  for my $con2 (@xmlcons) {
     if ($con2->{'hostlabel'}) {
       $con->{'hostlabel'} = [ @{$con->{'hostlabel'} || []},  @{$con2->{'hostlabel'}} ];
     }
@@ -1143,7 +1169,7 @@ while (1) {
       if ($ic->{$job}->{'constraintsmd5'}) {
 	my $constraintsmd5 = $ic->{$job}->{'constraintsmd5'};
 	if (!exists($constraintscache{$constraintsmd5})) {
-	  $constraintscache{$constraintsmd5} = getconstraints($ic->{$job}, $constraintsmd5);
+	  $constraintscache{$constraintsmd5} = getconstraints($ic->{$job}, $arch, $constraintsmd5);
 	}
 	$constraints = $constraintscache{$constraintsmd5};
 	if (!ref($constraints)) {


### PR DESCRIPTION
To be discussed, support and api extension to define architecture or package specific constraints.

One famous use case is the kernel package. It contains a constraints package which requires 15GB disk storage, but not all architectures and not all spec files from that source do need that.

This can be finer configured now with this patch.
