### PR TITLE
[obs_mirror_project] add api-url to osc meta calls

### DIFF
--- a/dist/obs_mirror_project
+++ b/dist/obs_mirror_project
@@ -48,9 +48,9 @@ system("mkdir -p #{destinationdir} #{projectdir}")
 
 # create meta data
 puts "Creating project meta data: osc meta prj #{project} > #{projectdir}/#{project}.xml\n" if verbose
-system("osc meta prj #{project} > #{projectdir}/#{project}.xml")
+system("osc -A https://api.opensuse.org meta prj #{project} > #{projectdir}/#{project}.xml")
 puts "Creating project configuration data: osc meta prjconf #{project} > #{projectdir}/#{project}.conf\n" if verbose
-system("osc meta prjconf #{project} > #{projectdir}/#{project}.conf")
+system("osc -A https://api.opensuse.org meta prjconf #{project} > #{projectdir}/#{project}.conf")
 
 # download all binary packages
 puts "Downloading: osc api -m GET https://api.opensuse.org/build/#{project}/#{repository}/#{architecture}/_repository\n" if verbose


### PR DESCRIPTION
Add api-url to the osc meta calls for prj and prjconf to make sure the openSUSE api is used.
If the openSUSE API is not the default one prj and prjconf are just empty created or overwritten with nothing.
