### PR TITLE
[webui] fix formatting abbreviated project name

### DIFF
--- a/src/api/app/helpers/webui/webui_helper.rb
+++ b/src/api/app/helpers/webui/webui_helper.rb
@@ -79,7 +79,7 @@ module Webui::WebuiHelper
   end
 
   def format_projectname(prjname, login)
-    splitted = prjname.split(':', 4)
+    splitted = prjname.split(':', 3)
     if splitted[0] == 'home'
       if login and splitted[1] == login
         if splitted.length == 2

--- a/src/api/test/functional/webui/request_controller_test.rb
+++ b/src/api/test/functional/webui/request_controller_test.rb
@@ -160,7 +160,7 @@ class Webui::RequestControllerTest < Webui::IntegrationTest
     login_tom to: user_show_path(user: 'tom')
 
     within('tr#tr_request_4') do
-      page.must_have_text '~:kde4 / BranchPack'
+      page.must_have_text '~:branches:kde4 / BranchPack'
       first(:css, 'a.request_link').click
     end
 


### PR DESCRIPTION
Don't drop the third component from home projects.
