### PR TITLE
[api] include people mentioned with @<login> as commenters

### DIFF
--- a/src/api/app/models/comment.rb
+++ b/src/api/app/models/comment.rb
@@ -22,10 +22,18 @@ class Comment < ActiveRecord::Base
   def involved_users(object_field, object_value)
     record = Comment.where(object_field => object_value)
     users = []
+    users_mentioned = []
     record.each do |comment|
-      Rails.logger.debug "IU2 #{comment.inspect}"
+      # take the one making the comment
       users << comment.user_id
+      # check if users are mentioned
+      comment.body.split.each do |word|
+        if word =~ /^@/
+          users_mentioned << word.gsub(%r{^@}, '')
+        end
+      end
     end
+    users += User.where(login: users_mentioned).pluck(:id)
     users.uniq
   end
 

--- a/src/api/test/functional/comments_controller_test.rb
+++ b/src/api/test/functional/comments_controller_test.rb
@@ -87,5 +87,14 @@ class CommentsControllerTest < ActionDispatch::IntegrationTest
 
     email = ActionMailer::Base.deliveries.last
     assert_equal %w(adrian@example.com tschmidt@example.com), email.to
+
+    # now to something fancy
+    assert_difference 'ActionMailer::Base.deliveries.size', +1 do
+      raw_post create_request_comment_path(id: 2), 'Hallo @fred'
+      assert_response :success
+    end
+
+    email = ActionMailer::Base.deliveries.last
+    assert_equal %w(adrian@example.com fred@feuerstein.de tschmidt@example.com), email.to
   end
 end


### PR DESCRIPTION
This is kind of faking, but I don't want to have yet another receiver role
