### PR TITLE
[backend] "obsname" is now available from BSConfiguration

### DIFF
--- a/src/backend/bs_worker
+++ b/src/backend/bs_worker
@@ -40,7 +40,7 @@ use Storable;
 
 use BSRPC;
 use BSServer;
-use BSConfig;
+use BSConfiguration;
 use BSUtil;
 use BSXML;
 use BSKiwiXML;

--- a/src/backend/worker/BSConfiguration.pm
+++ b/src/backend/worker/BSConfiguration.pm
@@ -1,0 +1,1 @@
+../BSConfiguration.pm


### PR DESCRIPTION
Without this change, bs_worker logs this message to syslog:
Shutting down obsworkerName "BSConfig::obsname" used only once: possible
typo at ./bs_worker line 2187.
