### PR TITLE
cleanup_empty_projects: add new configuration option

### DIFF
--- a/docs/api/api/configuration.rng
+++ b/docs/api/api/configuration.rng
@@ -124,6 +124,15 @@
             </choice>
           </element>
         </optional>
+        <optional>
+          <element name="cleanup_empty_projects">
+            <!-- If the last package in a project is cleaned up by sourceupdate=cleanup, delete the whole project? -->
+            <choice>
+              <value>on</value>
+              <value>off</value>
+            </choice>
+          </element>
+        </optional>
 
         <!-- webui only stuff -->
         <optional>

--- a/src/api/app/models/bs_request_action.rb
+++ b/src/api/app/models/bs_request_action.rb
@@ -415,7 +415,7 @@ class BsRequestAction < ActiveRecord::Base
 
   def source_cleanup_delete_path
     source_project = Project.find_by_name!(self.source_project)
-    if source_project.packages.count == 1 or !self.source_package
+    if (source_project.packages.count == 1 and ::Configuration.first.cleanup_empty_projects) or !self.source_package
 
       # remove source project, if this is the only package and not a user's home project
       splits = self.source_project.split(':')

--- a/src/api/app/models/configuration.rb
+++ b/src/api/app/models/configuration.rb
@@ -26,8 +26,9 @@ class Configuration < ActiveRecord::Base
                    :no_proxy => nil,
                    :cleanup_after_days => nil,
                    :theme => CONFIG['theme'],
+                   :cleanup_empty_projects => nil,
                  }
-  ON_OFF_OPTIONS = [ :anonymous, :default_access_disabled, :allow_user_to_create_home_project, :disallow_group_creation, :change_password, :hide_private_options, :gravatar, :download_on_demand, :enforce_project_keys ]
+  ON_OFF_OPTIONS = [ :anonymous, :default_access_disabled, :allow_user_to_create_home_project, :disallow_group_creation, :change_password, :hide_private_options, :gravatar, :download_on_demand, :enforce_project_keys, :cleanup_empty_projects ]
    
   class << self
     def map_value(key, value)

--- a/src/api/db/migrate/20140218174400_cleanup_empty_projects.rb
+++ b/src/api/db/migrate/20140218174400_cleanup_empty_projects.rb
@@ -1,0 +1,9 @@
+class AddCleanupEmptyProjects < ActiveRecord::Migration
+  def self.up
+    add_column :configurations, :cleanup_empty_projects, :boolean, :default => true
+  end
+
+  def self.down
+    remove_column :configurations, :cleanup_empty_projects
+  end
+end

--- a/src/api/db/structure.sql
+++ b/src/api/db/structure.sql
@@ -344,6 +344,7 @@ CREATE TABLE `configurations` (
   `theme` varchar(255) COLLATE utf8_bin DEFAULT NULL,
   `obs_url` varchar(255) COLLATE utf8_bin DEFAULT NULL,
   `cleanup_after_days` int(11) DEFAULT NULL,
+  `cleanup_empty_projects` tinyint(1) DEFAULT '1',
   PRIMARY KEY (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin;
 
@@ -1441,6 +1442,8 @@ INSERT INTO schema_migrations (version) VALUES ('20140123071042');
 INSERT INTO schema_migrations (version) VALUES ('20140124071042');
 
 INSERT INTO schema_migrations (version) VALUES ('20140210114542');
+
+INSERT INTO schema_migrations (version) VALUES ('20140218174400');
 
 INSERT INTO schema_migrations (version) VALUES ('21');
 


### PR DESCRIPTION
Normally, if a submit request is accepted and results in cleaning up
the last package in a branched project, the branched project is
deleted too. This is annoying if the branched project is a long-running
branch (e.g. for a developer in a small team) and has been reconfigured,
for instance to turn on publishing in installations where branches do
not normally have publishing.

Bug: https://github.com/openSUSE/open-build-service/issues/596

---

Only manually tested, so far.
