### PR TITLE
Typo in README.SETUP

### DIFF
--- a/dist/README.SETUP
+++ b/dist/README.SETUP
@@ -257,7 +257,7 @@ The alternative manual way is to call the following command:
 
   curl -0 --user "Admin:opensuse" -X PUT \
        -T /usr/share/doc/packages/obs-api/openSUSE.org.xml \
-       https://localhost:444/source/openSUSE.org/_meta
+       https://localhost:443/source/openSUSE.org/_meta
 
 If you created a self-signed certificate as described above, also add the
 option "--insecure".


### PR DESCRIPTION
Hello darix,

as asked for, here is the pull request for the typo.

I also had problems when configuring "use_xforward:true", as the service did not start then.
Removing it helped. Maybe you can review if it makes sense to still set that in the config.
