### PR TITLE
bs_publish: enable published hooks with parameters

### DIFF
--- a/src/backend/bs_publish
+++ b/src/backend/bs_publish
@@ -116,6 +116,10 @@ sub qsystem {
       splice(@args, 0, 2);
     }
     eval {
+      if ($args[0] =~ /\s/) {
+        my @arg0 = split('\s', shift(@args));
+        unshift(@args, @arg0);
+      }
       exec(@args);
       die("$args[0]: $!\n");
     };


### PR DESCRIPTION
Enable the usage of parameters in publishedhooks for easier usage.

for example:

our $publishedhook = {
  "general_packages" => "/usr/lib/b1/glue-api-hook.py channel1-x86_64",
  "other_packages" => "/usr/lib/b1/glue-api-hook.py channel-others-x86_64",
};
