### PR TITLE
[api] Use correct query method to iterate over

### DIFF
--- a/src/api/app/models/issue_tracker.rb
+++ b/src/api/app/models/issue_tracker.rb
@@ -31,7 +31,7 @@ class IssueTracker < ActiveRecord::Base
   end
 
   def update_package_metadata
-    Project.each do |prj|
+    Project.all.each do |prj|
       next unless Project.exists?(prj)
       prj.packages.each do |pkg|
         next unless Package.exists?(pkg)


### PR DESCRIPTION
Without this, delayed jobs would fail with:
IssueTracker#update_package_metadata failed with NoMethodError: undefined method `each' for #Class:0x00000003d0a7c0...
