### PR TITLE
[backend] call build script with --statistics also when using vm-type emulator

### DIFF
--- a/src/backend/bs_worker
+++ b/src/backend/bs_worker
@@ -2250,8 +2250,8 @@ sub dobuild {
     } else {
       push @args, $vm, "$vm_root";
       push @args, '--swap', "$vm_swap";
-      push @args, '--statistics';
     }
+    push @args, '--statistics';
     my $vmmemory = readstr("$buildroot/memory", 1);
     $vmmemory = $vm_memory if $vm_memory;
     push @args, '--memory', $vmmemory if $vmmemory;


### PR DESCRIPTION
Reading /proc/meminfo every five seconds should not be too much work even
for an emulator, and the statistics are still useful there.
