### PR TITLE
renderPackagesTable() function did ignore length parameter

### DIFF
--- a/src/webui/app/assets/javascripts/project.js
+++ b/src/webui/app/assets/javascripts/project.js
@@ -12,7 +12,8 @@ function renderPackagesTable(packages, length)
 						 var url = packageurl.replace(/REPLACEIT/, encodeURIComponent(obj.aData));
 						 return '<a href="' + url +'">' + obj.aData + '</a>';
 					     }
-					 } ]
+					 } ],
+                                     "iDisplayLength": length
 				    });
 }
 


### PR DESCRIPTION
This fix the issue, that package lists always first rendered with 25 items setting, ignoring
the given length parameter.

Signed-off-by: Karsten Keil keil@b1-systems.de
