### PR TITLE
renderPackagesTable() function did ignore length parameter

### DIFF
--- a/src/api/app/assets/javascripts/webui/application/project.js
+++ b/src/api/app/assets/javascripts/webui/application/project.js
@@ -13,6 +13,7 @@ function renderPackagesTable(wrapper, packages, length) {
                 }
             }
         ],
+        "iDisplayLength": length,
         "bStateSave": true
     });
 }


### PR DESCRIPTION
This fix the issue, that package lists always first rendered with 25 items setting, ignoring
the given length parameter.

Signed-off-by: Karsten Keil keil@b1-systems.de
