### PR TITLE
Optimize sourcedeletion function

### DIFF
--- a/src/backend/bs_admin
+++ b/src/backend/bs_admin
@@ -1024,13 +1024,16 @@ while (@ARGV) {
           my ($hash, $desc) = split(/\s+/, $_);
           if ( /_link/ ) {
             my ($hash, $desc) = split(/\s+/, $_);
+            next if !defined( $sourcefiles{$hash.'-'.$desc});
             # open link file to look if it links to a file that will be deleted
             my $link = readxml($sourcefiles{$hash.'-'.$desc}, $BSXML::link);
+            next if !defined $link->{"package"} || !defined $link->{"project"} || !defined $link->{"rev"};
             my $revision = getrev($link->{"project"}, $link->{"package"}, $link->{"rev"});
             next if !defined($revision->{"time"});
             if ($revision->{"time"} < $mastertimestamp) {
               # delete the hash with the link to be able to rewrite .rev files
               delete ($deletehashes{$revision->{"srcmd5"}});
+              next unless (-e $treesfiles{$revision->{"srcmd5"}});
               open(F, '<', $treesfiles{$revision->{"srcmd5"}}) or die($!);
                 foreach my $line (<F>) {
                   $keepfiles{$hash} = $hash."-".$desc;
@@ -1099,7 +1102,7 @@ while (@ARGV) {
           foreach my $line (<F>) {
             my ($hash) = ( split(/\|/, $line) )[2];
             # do not rewrite hashes from %deletehashes, to not overwrite files uploaded as the deletion runs
-            push @revfile, $line if (!grep {/$hash/} keys %deletehashes) || (grep{/$hash/} keys %keephashes);
+            push @revfile, $line if (!defined $deletehashes{$hash} || defined $keephashes{$hash});
           }
           close(F);
           open(F, '>', $revfile) or die($!);


### PR DESCRIPTION
Optimization done in runtime at revfile rewrite process and do
not fail if a project was deleted during (long) run
