### PR TITLE
LDAP: Fix wrong classname for UserLdapStrategy methods

### DIFF
--- a/src/api/app/controllers/application_controller.rb
+++ b/src/api/app/controllers/application_controller.rb
@@ -87,12 +87,12 @@ class ApplicationController < ActionController::Base
     begin
       require 'ldap'
       logger.debug( "Using LDAP to find #{@login}" )
-      ldap_info = User.find_with_ldap( @login, @passwd )
+      ldap_info = UserLdapStrategy.find_with_ldap( @login, @passwd )
     rescue LoadError
       logger.warn "ldap_mode selected but 'ruby-ldap' module not installed."
       ldap_info = nil # now fall through as if we'd not found a user
     rescue Exception
-      logger.debug "#{login} not found in LDAP."
+      logger.debug "#{@login} not found in LDAP."
       ldap_info = nil # now fall through as if we'd not found a user
     end
 

--- a/src/api/app/controllers/person_controller.rb
+++ b/src/api/app/controllers/person_controller.rb
@@ -233,7 +233,7 @@ class PersonController < ApplicationController
         require 'base64'
         begin
           logger.debug( "Using LDAP to change password for #{login}" )
-          result = User.change_password_ldap(login, ldap_password)
+          result = UserLdapStrategy.change_password_ldap(login, ldap_password)
         rescue Exception
           logger.debug "CONFIG['ldap_mode'] selected but 'ruby-ldap' module not installed."
         end

--- a/src/api/app/mixins/has_relationships.rb
+++ b/src/api/app/mixins/has_relationships.rb
@@ -163,7 +163,7 @@ module HasRelationships
 
       # check with LDAP
       if CONFIG['ldap_mode'] == :on && CONFIG['ldap_group_support'] == :on
-        if User.find_group_with_ldap(id)
+        if UserLdapStrategy.find_group_with_ldap(id)
           logger.debug "Find and Create group '#{id}' from LDAP"
           return Group.create!(title: id)
         else

--- a/src/api/app/models/project.rb
+++ b/src/api/app/models/project.rb
@@ -186,7 +186,7 @@ class Project < ActiveRecord::Base
             # LDAP
             # FIXME: please do not do special things here for ldap. please cover this in a generic group model.
             if CONFIG['ldap_mode'] == :on && CONFIG['ldap_group_support'] == :on
-              if User.current.user_in_group_ldap?(group.group_id)
+              if UserLdapStrategy.user_in_group_ldap?(User.current, group.group_id)
                 ret = ret + 1
               end
             end

--- a/src/api/app/models/user_ldap_strategy.rb
+++ b/src/api/app/models/user_ldap_strategy.rb
@@ -250,7 +250,7 @@ class UserLdapStrategy
       end
 
       unless group.kind_of? String
-        raise ArgumentError, "illegal parameter type to user#render_grouplist_ldap?: #{eachgroup.class.name}"
+        raise ArgumentError, "illegal parameter type to UserLdapStrategy#render_grouplist_ldap?: #{eachgroup.class.name}"
       end
 
       # search group
@@ -461,10 +461,10 @@ class UserLdapStrategy
     logger.debug "List the groups #{self.login} is in"
     ldapgroups = Array.new
     # check with LDAP
-    if User.ldapgroup_enabled?
+    if Configuration.ldapgroup_enabled?
       grouplist = Group.all
       begin
-        ldapgroups = User.render_grouplist_ldap(grouplist, self.login)
+        ldapgroups = UserLdapStrategy.render_grouplist_ldap(grouplist, self.login)
       rescue Exception
         logger.debug "Error occurred in searching user_group in ldap."
       end


### PR DESCRIPTION
Commit 8ad64791400f60e03ab336b63ac64b1f79f6fab8
moves ldap related methods out of User class into a new UserLdapStrategy class
but didn't update the caller in other places
