### PR TITLE
[dist] Don't redirect to /dev/null

### DIFF
--- a/dist/find-requires.sh
+++ b/dist/find-requires.sh
@@ -6,12 +6,12 @@ shift
 tdir=`mktemp -d`
 
 # extract files
-tar xJf $sourcearchive -C $tdir >&/dev/null
+tar xJf $sourcearchive -C $tdir
 
-pushd $tdir/open-build-service*/src/api >& /dev/null
+pushd $tdir/open-build-service*/src/api
 
 ruby -rbundler -e 'Bundler.definition.resolve.to_a.each { |s| puts "rubygem(2.1.0:#{s.name}) = #{s.version}" }' | grep -v ':webui' | while read i; do echo -n $i", "; done
-popd >& /dev/null
+popd
 
 #cleanup
 rm -rf $tdir


### PR DESCRIPTION
We surely want it to tell us if these commands don't succeed (because
e.g. your tar file has the wrong name).
