### PR TITLE
Allow an OBS to run off of shared infrastructure

### DIFF
--- a/src/backend/BSFileDB.pm
+++ b/src/backend/BSFileDB.pm
@@ -24,14 +24,14 @@ package BSFileDB;
 
 use strict;
 
-use Fcntl qw(:DEFAULT :flock);
+use Fcntl qw(:DEFAULT);
 
 sub lockopen {
   my ($fg, $fn) = @_;
   local *FL = $fg;
   while (1) {
     open(FL, '+>>', $fn) || die("$fn: $!\n");
-    flock(FL, LOCK_EX) || die("$fn: $!\n");
+    fcntl(FL, F_SETFL, O_EXCL | O_NONBLOCK) || die("$fn: $!\n");
     my @s = stat(FL);
     return if @s && $s[3];
     close FL;

--- a/src/backend/BSServer.pm
+++ b/src/backend/BSServer.pm
@@ -35,7 +35,7 @@ use Data::Dumper;
 
 use Socket;
 use POSIX;
-use Fcntl qw(:DEFAULT :flock);
+use Fcntl qw(:DEFAULT);
 BEGIN { Fcntl->import(':seek') unless defined &SEEK_SET; }
 use Symbol;
 
@@ -118,7 +118,7 @@ sub serveropen_unix {
   # we need a lock for exclusive socket access
   mkdir_p($1) if $filename =~ /^(.*)\//;
   open(LCK, '>', "$filename.lock") || die("$filename.lock: $!\n");
-  flock(LCK, LOCK_EX | LOCK_NB) || die("$filename: already in use\n");
+  fcntl(LCK, F_SETFL, O_EXCL | O_NONBLOCK) || die("$filename: already in use\n");
   socket(MS, PF_UNIX, SOCK_STREAM, 0) || die("socket: $!\n");
   unlink($filename);
   bind(MS, sockaddr_un($filename)) || die("bind: $!\n");

--- a/src/backend/bs_admin
+++ b/src/backend/bs_admin
@@ -30,6 +30,7 @@ BEGIN {
 
 use POSIX;
 use Data::Dumper;
+use File::Copy qw(move);
 use Getopt::Long;
 use Storable ();
 use Digest::MD5 ();
@@ -381,8 +382,8 @@ sub clone_repository {
   }
 
   print "exchanging with $destproject / $destrepo\n";
-  rename($destdir, "$tmpdir.old") || die("rename $destdir $tmpdir.old: $!\n");
-  rename($tmpdir, $destdir) || die("rename $tmpdir $destdir: $!\n");
+  move($destdir, "$tmpdir.old") || die("move $destdir $tmpdir.old: $!\n");
+  move($tmpdir, $destdir) || die("move $tmpdir $destdir: $!\n");
 
   print "tell schedulers about the change ";
   my @archs = grep {-d "$destdir/$_"} ls($destdir);

--- a/src/backend/bs_archivereq
+++ b/src/backend/bs_archivereq
@@ -9,7 +9,7 @@ BEGIN {
 
 use Date::Parse;
 use Data::Dumper;
-
+use File::Copy qw(move);
 use XML::Structured ':bytes';
 
 use BSConfig;
@@ -50,7 +50,7 @@ for my $id (@r) {
   next if $t + $cut > $now;
   print "state $state, ".localtime($t)."\n";
   $db->updateindex($id, $req, {});
-  rename("$requestsdir/$id", "$oldrequestsdir/$id") || die("rename $requestsdir/$id $oldrequestsdir/$id: $!\n");
+  move("$requestsdir/$id", "$oldrequestsdir/$id") || die("move $requestsdir/$id $oldrequestsdir/$id: $!\n");
 }
 
 

--- a/src/backend/bs_dispatch
+++ b/src/backend/bs_dispatch
@@ -39,7 +39,7 @@ use POSIX;
 use Data::Dumper;
 use Digest::MD5 ();
 use List::Util;
-use Fcntl qw(:DEFAULT :flock);
+use Fcntl qw(:DEFAULT);
 use XML::Structured ':bytes';
 use Storable;
 use Build::Rpm;	# for verscmp
@@ -820,7 +820,7 @@ printlog("starting build service dispatcher");
 # get lock
 mkdir_p($rundir);
 open(RUNLOCK, '>>', "$rundir/bs_dispatch.lock") || die("$rundir/bs_dispatch.lock: $!\n");
-flock(RUNLOCK, LOCK_EX | LOCK_NB) || die("dispatcher is already running!\n");
+fcntl(RUNLOCK, F_SETFL, O_EXCL | O_NONBLOCK) || die("dispatcher is already running!\n");
 utime undef, undef, "$rundir/bs_dispatch.lock";
 
 my $dispatchprios;

--- a/src/backend/bs_getbinariesproxy
+++ b/src/backend/bs_getbinariesproxy
@@ -33,6 +33,7 @@ use XML::Structured ':bytes';
 use POSIX;
 use Digest::MD5 ();
 use Data::Dumper;
+use File::Copy qw(copy move);
 use Storable ();
 use Symbol;
 
@@ -100,14 +101,14 @@ sub manage_cache {
       my $cachefile = "$cachedir/".substr($cacheid, 0, 2)."/$cacheid";
       mkdir_p("$cachedir/".substr($cacheid, 0, 2));
       unlink("$cachefile.$$");
-      next unless link($path, "$cachefile.$$");
-      rename("$cachefile.$$", $cachefile) || die("rename $cachefile.$$ $cachefile: $!\n");
+      next unless link($path, "$cachefile.$$") || copy($path, "$cachefile.$$");
+      move("$cachefile.$$", $cachefile) || die("move $cachefile.$$ $cachefile: $!\n");
       my $mpath = "$path.meta";
       $mpath = "$1.meta" if $path =~ /^(.*)\.(?:$binsufsre)$/;
       if (-s $mpath) {
 	unlink("$cachefile.meta.$$");
-	if (link($mpath, "$cachefile.meta.$$")) {
-	  rename("$cachefile.meta.$$", "$cachefile.meta") || die("rename $cachefile.meta.$$ $cachefile.meta: $!\n");
+	if ((link($mpath, "$cachefile.meta.$$") || copy($mpath, "$cachefile.meta.$$"))) {
+	  move("$cachefile.meta.$$", "$cachefile.meta") || die("move $cachefile.meta.$$ $cachefile.meta: $!\n");
 	} else {
 	  unlink("$cachefile.meta");
 	}
@@ -136,7 +137,7 @@ sub manage_cache {
   }
   @$content = grep {defined $_} @$content;
   Storable::nstore($content, "$cachedir/content.new");
-  rename("$cachedir/content.new", "$cachedir/content") || die("rename $cachedir/content.new $cachedir/content");
+  move("$cachedir/content.new", "$cachedir/content") || die("move $cachedir/content.new $cachedir/content");
   close F;
 }
 
@@ -228,7 +229,7 @@ sub getbinaries {
     } else {
       my $fd = gensym;
       my $tmpname = "$cachetmpdir/$tmpprefix$bv->{'name'}";
-      if (link($cachefile, $tmpname)) {
+      if ((link($cachefile, $tmpname) || copy($cachefile, $tmpname))) {
 	# check hdrmd5 to be sure we got the right bin
 	my $id;
 	eval {

--- a/src/backend/bs_publish
+++ b/src/backend/bs_publish
@@ -31,10 +31,11 @@ BEGIN {
 use Digest;
 use Digest::MD5 ();
 use Digest::SHA ();
+use File::Copy qw(copy move);
 use XML::Structured ':bytes';
 use XML::Simple ();
 use POSIX;
-use Fcntl qw(:DEFAULT :flock);
+use Fcntl qw(:DEFAULT);
 use Data::Dumper;
 use Storable ();
 use MIME::Base64;
@@ -233,7 +234,7 @@ sub db_sync {
     warn($@);
     mkdir_p($1) if $extrepodb =~ /^(.*)\//;
     Storable::nstore(\@db_sync, "$extrepodb.sync.new");
-    rename("$extrepodb.sync.new", "$extrepodb.sync") || die("rename $extrepodb.sync.new $extrepodb.sync: $!\n");
+    move("$extrepodb.sync.new", "$extrepodb.sync") || die("move $extrepodb.sync.new $extrepodb.sync: $!\n");
   } else {
     @db_sync = ();
     unlink("$extrepodb.sync");
@@ -536,7 +537,7 @@ sub createrepo_rpmmd {
     }
     print FILE "enabled=1\n";
     close(FILE) || die("close: $!\n");
-    rename("$extrep/$projid.repo$$", "$extrep/$projid.repo") || die("rename $extrep/$projid.repo$$ $extrep/$projid.repo: $!\n");
+    move("$extrep/$projid.repo$$", "$extrep/$projid.repo") || die("move $extrep/$projid.repo$$ $extrep/$projid.repo: $!\n");
   }
 }
 
@@ -647,10 +648,10 @@ sub createrepo_debian {
       die("    dpkg-scanpackages failed: $?\n");
   }
   if (-f "$extrep/Packages.new") {
-    link("$extrep/Packages.new", "$extrep/Packages");
+    link("$extrep/Packages.new", "$extrep/Packages") || copy("$extrep/Packages.new", "$extrep/Packages");
     qsystem('gzip', '-9', '-f', "$extrep/Packages") && print "    gzip Packages failed: $?\n";
     unlink("$extrep/Packages");
-    rename("$extrep/Packages.new", "$extrep/Packages");
+    move("$extrep/Packages.new", "$extrep/Packages");
   }
 
   print "    running dpkg-scansources\n";
@@ -658,10 +659,10 @@ sub createrepo_debian {
       die("    dpkg-scansources failed: $?\n");
   }
   if (-f "$extrep/Sources.new") {
-    link("$extrep/Sources.new", "$extrep/Sources");
+    link("$extrep/Sources.new", "$extrep/Sources") || copy("$extrep/Sources.new", "$extrep/Sources");
     qsystem('gzip', '-9', '-f', "$extrep/Sources") && print "    gzip Sources failed: $?\n";
     unlink("$extrep/Sources");
-    rename("$extrep/Sources.new", "$extrep/Sources");
+    move("$extrep/Sources.new", "$extrep/Sources");
   }
 
   my $obsname = $BSConfig::obsname || 'build.opensuse.org';
@@ -723,7 +724,7 @@ EOL
     push @signargs, '--project', $projid if $BSConfig::sign_project;
     push @signargs, @{$data->{'signargs'} || []};
     qsystem($BSConfig::sign, @signargs, '-d', "$extrep/Release") && die("    sign failed: $?\n");
-    rename("$extrep/Release.asc","$extrep/Release.gpg");
+    move("$extrep/Release.asc","$extrep/Release.gpg");
   }
   if ($BSConfig::sign) {
     writestr("$extrep/Release.key", undef, $data->{'pubkey'}) if $data->{'pubkey'};
@@ -757,10 +758,10 @@ sub createrepo_arch {
     print "    running bs_mkarchrepo $arch\n";
     qsystem("$INC[0]/bs_mkarchrepo", $rname, "$extrep/$arch") && die("    repo creation failed: $?\n");
     if (-e "$extrep/$arch/$rname.db.tar.gz") {
-      link("$extrep/$arch/$rname.db.tar.gz", "$extrep/$arch/$rname.db");
+      link("$extrep/$arch/$rname.db.tar.gz", "$extrep/$arch/$rname.db") || copy("$extrep/$arch/$rname.db.tar.gz", "$extrep/$arch/$rname.db");
     }
     if (-e "$extrep/$arch/$rname.files.tar.gz") {
-      link("$extrep/$arch/$rname.files.tar.gz", "$extrep/$arch/$rname.files");
+      link("$extrep/$arch/$rname.files.tar.gz", "$extrep/$arch/$rname.files") || copy("$extrep/$arch/$rname.files.tar.gz", "$extrep/$arch/$rname.files");
     }
     if ($BSConfig::sign) {
       my @signargs;
@@ -768,11 +769,11 @@ sub createrepo_arch {
       push @signargs, @{$data->{'signargs'} || []};
       if (-e "$extrep/$arch/$rname.db.tar.gz") {
         qsystem($BSConfig::sign, @signargs, '-D', "$extrep/$arch/$rname.db.tar.gz") && die("    sign failed: $?\n");
-        link("$extrep/$arch/$rname.db.tar.gz.sig", "$extrep/$arch/$rname.db.sig");
+        link("$extrep/$arch/$rname.db.tar.gz.sig", "$extrep/$arch/$rname.db.sig") || copy("$extrep/$arch/$rname.db.tar.gz.sig", "$extrep/$arch/$rname.db.sig");
       }
       if (-e "$extrep/$arch/$rname.files.tar.gz") {
         qsystem($BSConfig::sign, @signargs, '-D', "$extrep/$arch/$rname.files.tar.gz") && die("    sign failed: $?\n");
-        link("$extrep/$arch/$rname.files.tar.gz.sig", "$extrep/$arch/$rname.files.sig");
+        link("$extrep/$arch/$rname.files.tar.gz.sig", "$extrep/$arch/$rname.files.sig") || copy("$extrep/$arch/$rname.files.tar.gz.sig", "$extrep/$arch/$rname.files.sig");
       }
     }
   }
@@ -815,7 +816,7 @@ sub createrepo_staticlinks {
       next unless $link;
       unlink("$extrep/$arch/.$link"); # drop left over
       symlink($_, "$extrep/$arch/.$link");
-      rename("$extrep/$arch/.$link", "$extrep/$arch/$link"); # atomar update
+      move("$extrep/$arch/.$link", "$extrep/$arch/$link"); # atomar update
     }
   }
 }
@@ -1262,9 +1263,9 @@ sub publish {
   # get us the lock
   local *F;
   open(F, '>', "$reporoot/$prp/.finishedlock") || die("$reporoot/$prp/.finishedlock: $!\n");
-  if (!flock(F, LOCK_EX | LOCK_NB)) {
+  if (!fcntl(F, F_SETFL, O_EXCL | O_NONBLOCK)) {
     print "    waiting for lock...\n";
-    flock(F, LOCK_EX) || die("flock: $!\n");
+    fcntl(F, F_SETFL, O_EXCL | O_NONBLOCK) || die("fcntl: $!\n");
     print "    got the lock...\n";
   }
 
@@ -1520,7 +1521,7 @@ sub publish {
       }
       if ("$s[9]/$s[7]/$s[1]" ne $bins_id{$p}) {
         unlink("$r/$bin") || die("unlink $r/$bin: $!\n");
-        link($bins{$p}, "$r/$bin") || die("link $bins{$p} $r/$bin: $!\n");
+        link($bins{$p}, "$r/$bin") || copy($bins{$p}, "$r/$bin") || die("link $bins{$p} $r/$bin: $!\n");
 	push @db_changed, $p if $p =~ /\.(?:$binsufsre)$/;
 	push @changed, $p;
         $changed = 1;
@@ -1568,7 +1569,7 @@ sub publish {
 	if (! -l $bins{$p} && -d _) {
 	  BSUtil::linktree($bins{$p}, "$r/$bin");
 	} else {
-          link($bins{$p}, "$r/$bin") || die("link $bins{$p} $r/$bin: $!\n");
+          link($bins{$p}, "$r/$bin") || copy($bins{$p}, "$r/$bin") || die("link $bins{$p} $r/$bin: $!\n");
 	}
 	push @db_changed, $p if $p =~ /\.(?:$binsufsre)$/;
 	push @changed, $p;
@@ -1592,7 +1593,7 @@ sub publish {
     if (! -l $bins{$p} && -d _) {
       BSUtil::linktree($bins{$p}, "$r/$bin");
     } else {
-      link($bins{$p}, "$r/$bin") || die("link $bins{$p} $r/$bin: $!\n");
+      link($bins{$p}, "$r/$bin") || copy($bins{$p}, "$r/$bin") || die("link $bins{$p} $r/$bin: $!\n");
     }
     push @db_changed, $p if $p =~ /\.(?:$binsufsre)$/;
     push @changed, $p;
@@ -1758,7 +1759,7 @@ sub publish {
   if ($BSConfig::publishprogram && $BSConfig::publishprogram->{$prp}) {
     local *PPLOCK;
     open(PPLOCK, '>', "$reporoot/$prp/.pplock") || die("$reporoot/$prp/.pplock: $!\n");
-    flock(PPLOCK, LOCK_EX) || die("flock: $!\n");
+    fcntl(PPLOCK, F_SETFL, O_EXCL | O_NONBLOCK) || die("fcntl: $!\n");
     if (xfork()) {
       close PPLOCK;
       return;
@@ -1887,7 +1888,7 @@ print "starting build service publisher\n";
 
 mkdir_p($rundir);
 open(RUNLOCK, '>>', "$rundir/bs_publish.lock") || die("$rundir/bs_publish.lock: $!\n");
-flock(RUNLOCK, LOCK_EX | LOCK_NB) || die("publisher is already running!\n");
+fcntl(RUNLOCK, F_SETFL, O_EXCL | O_NONBLOCK) || die("publisher is already running!\n");
 utime undef, undef, "$rundir/bs_publish.lock";
 
 mkdir_p($myeventdir);
@@ -1935,7 +1936,7 @@ while(1) {
       # check if background publish is still running
       local *PPLOCK;
       if (open(PPLOCK, '<', "$reporoot/$prp/.pplock")) {
-        if (flock(PPLOCK, LOCK_EX | LOCK_NB)) {
+        if (fcntl(PPLOCK, F_SETFL, O_EXCL | O_NONBLOCK)) {
 	  close PPLOCK;
 	  print "$prp: external publish program still running\n";
 	  $publish_retry{$event} = time() + 60;
@@ -1951,7 +1952,7 @@ while(1) {
 	$publish_retry{$event} = $starttime + 60 * 5;
 	next;
       }
-    rename("$myeventdir/$event", "$myeventdir/${event}::inprogress");
+    move("$myeventdir/$event", "$myeventdir/${event}::inprogress");
     notify('REPO_PUBLISH_STATE', { 'project' => $ev->{'project'}, 'repo' => $ev->{'repository'}, 'state' => 'publishing'} );
     eval {
       publish($ev->{'project'}, $ev->{'repository'});
@@ -1968,7 +1969,7 @@ while(1) {
 	  }
 	};
       }
-      rename("$myeventdir/${event}::inprogress", "$myeventdir/$event");
+      move("$myeventdir/${event}::inprogress", "$myeventdir/$event");
       $publish_retry{$event} = time() + 60;
       db_sync();
     } else {

--- a/src/backend/bs_repserver
+++ b/src/backend/bs_repserver
@@ -36,8 +36,9 @@ BEGIN {
 }
 
 use POSIX;
-use Fcntl qw(:DEFAULT :flock);
+use Fcntl qw(:DEFAULT);
 BEGIN { Fcntl->import(':seek') unless defined &SEEK_SET; }
+use File::Copy qw(copy move);
 use XML::Structured ':bytes';
 use Storable ();
 use Data::Dumper;
@@ -224,7 +225,7 @@ sub fetchdodbinary {
   $param->{'maxredirects'} = $maxredirects if defined $maxredirects;
   my $r = BSWatcher::rpc($param);
   return unless defined $r;
-  rename($tmp, $localname) || die("rename $tmp $localname: $!\n");
+  move($tmp, $localname) || die("move $tmp $localname: $!\n");
   return $localname;
 }
 
@@ -631,7 +632,7 @@ sub getbinarylist_repository {
 	  Storable::nstore_fd(\%data, $fd) || die("nstore_fd $tmpname: $!\n");
 	  $fd->flush();
 	  BSUtil::do_fdatasync(fileno($fd)) if $BSUtil::fdatasync_before_rename;
-	  rename($tmpname, "$reporoot/$prp/$arch/:full.xcache");
+	  move($tmpname, "$reporoot/$prp/$arch/:full.xcache");
 	  sysseek($fd, 64, Fcntl::SEEK_SET);
           push @files, { 'name' => 'repositorycache', 'filename' => $fd };
 	}
@@ -1274,7 +1275,7 @@ sub putbinary {
     for my $file (@$uploaded) {
       my $fn = $file->{'name'};
       next if $cgi->{'ignoreolder'} && isolder("$tdir/$fn", "$fdir/$fn");
-      rename("$fdir/$fn", "$tdir/$fn") || die("rename $fdir/$fn $tdir/$fn: $!\n");
+      move("$fdir/$fn", "$tdir/$fn") || die("move $fdir/$fn $tdir/$fn: $!\n");
       $fn =~ s/\.(?:$binsufsre|meta)$//;
       unlink("$tdir/$fn.meta") unless $upfiles{"$fn.meta"};
     }
@@ -1294,7 +1295,7 @@ sub putbinary {
       return $BSStdServer::return_ok;
     }
     mkdir_p($tdir);
-    rename($fn, $tn) || die("rename $fn $tn: $!\n");
+    move($fn, $tn) || die("move $fn $tn: $!\n");
     if ($tn =~ s/\.(?:$binsufsre)$//) {
       unlink("$tn.meta");
     }
@@ -1632,7 +1633,7 @@ sub workerstatus {
     }
     next if %types && !$types{$daemondata->{'type'}};
     if (open(F, '<', "$rundir/$lock")) {
-      if (!flock(F, LOCK_EX | LOCK_NB)) {
+      if (!fcntl(F, F_SETFL, O_EXCL | O_NONBLOCK)) {
         my @s = stat(F);
         $daemondata->{'state'} = 'running';
         $daemondata->{'starttime'} = $s[9] if @s;
@@ -1739,7 +1740,7 @@ sub receivekiwitree {
       if ($extra) {
 	die("extra is not a md5 sum\n") unless $extra =~ /^[0-9a-f]{32}$/s;
 	$leads ||= receivekiwitree_scan($info);
-	if ($leads->{$extra} && link("$reporoot/$leads->{$extra}", "$dir/$file")) {
+	if ($leads->{$extra} && (link("$reporoot/$leads->{$extra}", "$dir/$file") || copy("$reporoot/$leads->{$extra}", "$dir/$file"))) {
 	  # make sure it's really the correct file
 	  my $leadsigmd5;
 	  eval { Build::queryhdrmd5("$dir/$file", \$leadsigmd5); };
@@ -1860,7 +1861,7 @@ sub putjob {
         BSUtil::cleandir($dir);
         rmdir($dir);
       }
-      rename($tmpdir, $dir) || die("rename $tmpdir $dir: $!\n");
+      move($tmpdir, $dir) || die("move $tmpdir $dir: $!\n");
     }
   };
   if ($@) {
@@ -2047,7 +2048,7 @@ sub copybuild {
       if (-d "$odir/$bin") {
         $delayed_linking->{"$dir/$nbin"} = "$odir/$bin";
       } else {
-        link("$odir/$bin", "$dir/$nbin") || die("link $odir/$bin $dir/$nbin: $!\n");
+        link("$odir/$bin", "$dir/$nbin") || copy("$odir/$bin", "$dir/$nbin") || die("link $odir/$bin $dir/$nbin: $!\n");
       }
     }
   }

--- a/src/backend/bs_sched
+++ b/src/backend/bs_sched
@@ -31,10 +31,11 @@ BEGIN {
 
 use Digest::MD5 ();
 use Data::Dumper;
+use File::Copy qw(copy move);
 use Storable ();
 use XML::Structured ':bytes';
 use POSIX;
-use Fcntl qw(:DEFAULT :flock);
+use Fcntl qw(:DEFAULT);
 
 use BSConfiguration;
 use BSRPC ':https';
@@ -242,7 +243,7 @@ sub writesolv {
   }
   return unless defined $fnf;
   $! = 0;
-  rename($fn, $fnf) || die("rename $fn $fnf: $!\n");
+  move($fn, $fnf) || die("move $fn $fnf: $!\n");
 }
 
 my $projpacks;		# global project/package data
@@ -973,8 +974,8 @@ sub createdeltajob {
   for my $delta (@$needdelta) {
     #print Dumper($delta);
     my $deltaid = $delta->[2];
-    link($delta->[0], "$jobdatadir/$deltaid.old") || return (undef, "link error: $!");
-    link($delta->[1], "$jobdatadir/$deltaid.new") || return (undef, "link error: $!");
+    link($delta->[0], "$jobdatadir/$deltaid.old") || copy($delta->[0], "$jobdatadir/$deltaid.old") || return (undef, "link error: $!");
+    link($delta->[1], "$jobdatadir/$deltaid.new") || copy($delta->[1], "$jobdatadir/$deltaid.new") || return (undef, "link error: $!");
     my $qold = Build::Rpm::query("$jobdatadir/$deltaid.old", 'evra' => 1);
     my $qnew = Build::Rpm::query("$jobdatadir/$deltaid.new", 'evra' => 1);
     return (undef, "bad rpms") unless $qold && $qnew;
@@ -1167,8 +1168,8 @@ sub makedeltas {
 	      # yes, link it over
 	      unlink("$ddir/$deltaid");
 	      unlink("$ddir/$deltaid.dseq");
-	      $ddir{$deltaid} = 1 if link("$ddir/$olddeltaid", "$ddir/$deltaid");
-	      $ddir{"$deltaid.dseq"} = 1 if link("$ddir/$olddeltaid.dseq", "$ddir/$deltaid.dseq");
+	      $ddir{$deltaid} = 1 if (link("$ddir/$olddeltaid", "$ddir/$deltaid") || copy("$ddir/$olddeltaid", "$ddir/$deltaid"));
+	      $ddir{"$deltaid.dseq"} = 1 if (link("$ddir/$olddeltaid.dseq", "$ddir/$deltaid.dseq") || copy("$ddir/$olddeltaid.dseq", "$ddir/$deltaid.dseq"));
 	    }
 	  }
 	  $deltaids{$deltaid} = 1;
@@ -1312,8 +1313,8 @@ sub publishdelta {
     print @sr ? "      ! :repo/${rbin}::$deltaname\n" : "      + :repo/${rbin}::$deltaname\n";
     unlink("$rdir/${rbin}::$deltaname");
     unlink("$rdir/${rbin}::$deltaseqname");
-    link("$reporoot/$prp/$myarch/_deltas/$delta->[0]", "$rdir/${rbin}::$deltaname") || die("link $reporoot/$prp/$myarch/_deltas/$delta->[0] $rdir/${rbin}::$deltaname: $!");
-    link("$reporoot/$prp/$myarch/_deltas/$delta->[0].dseq", "$rdir/${rbin}::$deltaseqname") || die("link $reporoot/$prp/$myarch/_deltas/$delta->[0].dseq $rdir/${rbin}::$deltaseqname: $!");
+    link("$reporoot/$prp/$myarch/_deltas/$delta->[0]", "$rdir/${rbin}::$deltaname") || copy("$reporoot/$prp/$myarch/_deltas/$delta->[0]", "$rdir/${rbin}::$deltaname") || die("link $reporoot/$prp/$myarch/_deltas/$delta->[0] $rdir/${rbin}::$deltaname: $!");
+    link("$reporoot/$prp/$myarch/_deltas/$delta->[0].dseq", "$rdir/${rbin}::$deltaseqname") || copy("$reporoot/$prp/$myarch/_deltas/$delta->[0].dseq", "$rdir/${rbin}::$deltaseqname") || die("link $reporoot/$prp/$myarch/_deltas/$delta->[0].dseq $rdir/${rbin}::$deltaseqname: $!");
     $changed = 1;
   }
   $origin->{"${rbin}::$deltaname"} = $packid;
@@ -1329,9 +1330,9 @@ sub prpfinished {
   my ($projid, $repoid) = split('/', $prp, 2);
   local *F;
   open(F, '>', "$reporoot/$prp/.finishedlock") || die("$reporoot/$prp/.finishedlock: $!\n");
-  if (!flock(F, LOCK_EX | LOCK_NB)) {
+  if (!fcntl(F, F_SETFL, O_EXCL | O_NONBLOCK)) {
     print "    waiting for lock...\n";
-    flock(F, LOCK_EX) || die("flock: $!\n");
+    fcntl(F, F_SETFL, O_EXCL | O_NONBLOCK) || die("fcntl: $!\n");
     print "    got the lock...\n";
   }
   if (!$packs) {
@@ -1462,7 +1463,7 @@ sub prpfinished {
       if (! -l "$pdir/$bin" && -d _) {
 	BSUtil::linktree("$pdir/$bin", "$rdir/$rbin");
       } else {
-        link("$pdir/$bin", "$rdir/$rbin") || die("link $pdir/$bin $rdir/$rbin: $!\n");
+        link("$pdir/$bin", "$rdir/$rbin") || copy("$pdir/$bin", "$rdir/$rbin") || die("link $pdir/$bin $rdir/$rbin: $!\n");
 	if ($deltas->{"$packid/$bin"}) {
 	  for my $delta (@{$deltas->{"$packid/$bin"}}) {
 	    publishdelta($prp, $delta, $bin, $rdir, $rbin, \%origin, $packid);
@@ -1532,15 +1533,15 @@ sub createexportjob {
   my $dir = "$jobsdir/$arch/$job:dir";
   mkdir_p($dir);
   if ($meta) {
-    link($meta, "$meta.dup");
-    rename("$meta.dup", "$dir/meta");
+    link($meta, "$meta.dup") || copy($meta, "$meta.dup");
+    move("$meta.dup", "$dir/meta");
     unlink("$meta.dup");
   }
   my %seen;
   while (@exports) {
     my ($rp, $r) = splice(@exports, 0, 2);
     next unless $r->{'source'};
-    link("$dst/$rp", "$dir/$rp") || warn("link $dst/$rp $dir/$rp: $!\n");
+    link("$dst/$rp", "$dir/$rp") || copy("$dst/$rp", "$dir/$rp") || warn("link $dst/$rp $dir/$rp: $!\n");
     $seen{$r->{'id'}} = 1;
   }
   my @replaced;
@@ -1842,12 +1843,12 @@ sub fctx_add_binary_to_full {
     $dir = "$gdst/$packid";
   }
   # link gives an error if the dest exists, so we dup
-  # and rename instead.
-  # when the dest is the same file, rename doesn't do
-  # anything, so we need the unlink after the rename
+  # and move instead.
+  # when the dest is the same file, move doesn't do
+  # anything, so we need the unlink after the move
   unlink("$dir/$fn.dup");
-  link("$dir/$fn", "$dir/$fn.dup");
-  rename("$dir/$fn.dup", "$gdst/:full/$n.$suf") || die("rename $dir/$fn.dup $gdst/:full/$n.$suf: $!\n");
+  link("$dir/$fn", "$dir/$fn.dup") || copy("$dir/$fn", "$dir/$fn.dup");
+  move("$dir/$fn.dup", "$gdst/:full/$n.$suf") || die("move $dir/$fn.dup $gdst/:full/$n.$suf: $!\n");
   unlink("$dir/$fn.dup");
   $fctx->{'oldids'}->{"$n.$suf"} = $r->{'id'};
   for my $osuf (@binsufs) {
@@ -1863,8 +1864,8 @@ sub fctx_add_binary_to_full {
       $fctx->{'lastmeta'} = $meta;
     }
     fctx_check_linkedmeta($fctx) if $BSConfig::maxmetahardlink;
-    link($meta, "$meta.dup");
-    rename("$meta.dup", "$gdst/:full/$n.meta") || die("rename $meta.dup $gdst/:full/$n.meta: $!\n");
+    link($meta, "$meta.dup") || copy($meta, "$meta.dup");
+    move("$meta.dup", "$gdst/:full/$n.meta") || die("move $meta.dup $gdst/:full/$n.meta: $!\n");
     unlink("$meta.dup");
     fctx_set_metaidmd5($fctx) if $fctx->{'metacache'} && !$fctx->{'metamd5'};
     $fctx->{'metacache'}->{$n} = [$fctx->{'metaid'}, $fctx->{'metamd5'}] if $fctx->{'metacache'};
@@ -2107,7 +2108,7 @@ sub fctx_migrate_full {
 	next unless $m && $m =~ s/^.*?  //;;
 	next if $packidschecked{$m};
 	next unless grep {$_ eq $m} @{$knownids{$id}};
-	link($meta, "$gdst/$m/.meta.success");
+	link($meta, "$gdst/$m/.meta.success") || copy($meta, "$gdst/$m/.meta.success");
 	$packidschecked{$m} = 1;
       }
       next;
@@ -2115,9 +2116,9 @@ sub fctx_migrate_full {
     mkdir_p("$gdst/_volatile");
     unlink("$gdst/_volatile/$bin");
     unlink("$gdst/_volatile/$name.meta");
-    link("$gdst/:full/$bin", "$gdst/_volatile/$bin") || die("link $gdst/:full/$bin $gdst/_volatile/$bin: $!\n");
+    link("$gdst/:full/$bin", "$gdst/_volatile/$bin") || copy("$gdst/:full/$bin", "$gdst/_volatile/$bin") || die("link $gdst/:full/$bin $gdst/_volatile/$bin: $!\n");
     if ($meta) {
-      link($meta, "$gdst/_volatile/$name.meta") || die("link $meta $gdst/_volatile/$name.meta: $!\n");
+      link($meta, "$gdst/_volatile/$name.meta") || copy($meta, "$gdst/_volatile/$name.meta") || die("link $meta $gdst/_volatile/$name.meta: $!\n");
     }
     $dirty = 1;
   }
@@ -2394,7 +2395,7 @@ sub update_dst_full {
     my $oldcache = { map {$_->{'id'} => $_} grep {$_->{'id'}} values %$oldbininfo };
     $oldrepo = findbins_dir([ map {"$dst/$_"} grep {/\.(?:$binsufsre)$/ && !/\.delta\.rpm$/} @oldfiles ], $oldcache);
 
-    # move files over (and rename in import case)
+    # move files over (and move in import case)
     my %new;
     for my $f (@jobfiles) {
       next if $importarch && $f eq 'replaced.xml';	# not needed
@@ -2403,7 +2404,7 @@ sub update_dst_full {
 	rmdir("$dst/$f");
       }
       my $df = $importarch ? "::import::${importarch}::$f" : $f;
-      rename("$jobdir/$f", "$dst/$df") || die("rename $jobdir/$f $dst/$df: $!\n");
+      move("$jobdir/$f", "$dst/$df") || die("move $jobdir/$f $dst/$df: $!\n");
       $new{$df} = 1;
       $bininfo->{$df} = $jobbininfo->{$f} if $jobbininfo->{$f};
       $bininfo->{'.nouseforbuild'} = {} if $f eq '.channelinfo' || $f eq 'updateinfo.xml';
@@ -2440,7 +2441,7 @@ sub update_dst_full {
     my $dmeta = $importarch ? ".meta.success.import.$importarch" : '.meta.success';
     unlink("$dst/$dmeta");
     if ($meta) {
-      link($meta, "$dst/$dmeta") || die("link $meta $dst/$dmeta: $!\n");
+      link($meta, "$dst/$dmeta") || copy($meta, "$dst/$dmeta") || die("link $meta $dst/$dmeta: $!\n");
     }
     # we only check 'sourceaccess', not 'access' here. 'access' has
     # to be handled anyway, so we don't gain anything by limiting
@@ -2711,10 +2712,10 @@ sub update_preinstallimage {
       push @bins, $2;
     }
     unlink("$jobdir/.preinstallimage.$id");
-    link("$jobdir/$tar", "$jobdir/.preinstallimage.$id") || die("link $jobdir/$tar $jobdir/.preinstallimage.$id");
+    link("$jobdir/$tar", "$jobdir/.preinstallimage.$id") || copy("$jobdir/$tar", "$jobdir/.preinstallimage.$id") || die("link $jobdir/$tar $jobdir/.preinstallimage.$id");
     if ($dst && $dst ne $jobdir) {
       unlink("$dst/.preinstallimage.$id");
-      link("$jobdir/.preinstallimage.$id", "$dst/.preinstallimage.$id") || die("link $jobdir/.$id $dst/.preinstallimage.$id");
+      link("$jobdir/.preinstallimage.$id", "$dst/.preinstallimage.$id") || copy("$jobdir/.preinstallimage.$id", "$dst/.preinstallimage.$id") || die("link $jobdir/.$id $dst/.preinstallimage.$id");
     }
     my $sizek = int(($s[7] + 1023) / 1024);
     push @$imagedata, {'package' => $packid, 'hdrmd5' => $id, 'file' => $tar, 'sizek' => $sizek, 'bitstring' => $b, 'hdrmd5s' => \@hdrmd5s, 'bins' => \@bins};
@@ -4277,8 +4278,8 @@ sub jobfinished {
     print "  - $job: build result is unchanged\n";
     if ( -e "$gdst/:logfiles.success/$packid" ){
       # make sure to use the last succeeded logfile matching to these binaries
-      link("$gdst/:logfiles.success/$packid", "$dst/logfile.dup");
-      rename("$dst/logfile.dup", "$dst/logfile");
+      link("$gdst/:logfiles.success/$packid", "$dst/logfile.dup") || copy("$gdst/:logfiles.success/$packid", "$dst/logfile.dup");
+      move("$dst/logfile.dup", "$dst/logfile");
       unlink("$dst/logfile.dup");
     }
     if (open(F, '+>>', "$dst/logfile")) {
@@ -4287,7 +4288,7 @@ sub jobfinished {
       close(F);
     }
     unlink("$gdst/:logfiles.fail/$packid");
-    rename($meta, "$gdst/:meta/$packid") if $meta;
+    move($meta, "$gdst/:meta/$packid") if $meta;
     unlink($_) for @all;
     rmdir($jobdatadir);
     addjobhist($prp, $info, $status, $js, 'unchanged');
@@ -4298,10 +4299,10 @@ sub jobfinished {
   }
   if ($code eq 'failed') {
     print "  - $job: build failed\n";
-    link("$jobdatadir/logfile", "$jobdatadir/logfile.dup");
-    rename("$jobdatadir/logfile", "$dst/logfile");
-    rename("$jobdatadir/logfile.dup", "$gdst/:logfiles.fail/$packid");
-    rename($meta, "$gdst/:meta/$packid") if $meta;
+    link("$jobdatadir/logfile", "$jobdatadir/logfile.dup") || copy("$jobdatadir/logfile", "$jobdatadir/logfile.dup");
+    move("$jobdatadir/logfile", "$dst/logfile");
+    move("$jobdatadir/logfile.dup", "$gdst/:logfiles.fail/$packid");
+    move($meta, "$gdst/:meta/$packid") if $meta;
     unlink($_) for @all;
     rmdir($jobdatadir);
     $status->{'status'} = 'failed';
@@ -4326,7 +4327,7 @@ sub jobfinished {
   $changed->{$prp} ||= 1;
 
   # save meta file
-  rename($meta, "$gdst/:meta/$packid") if $meta;
+  move($meta, "$gdst/:meta/$packid") if $meta;
 
   # write new status
   $status->{'status'} = 'succeeded';
@@ -4349,9 +4350,9 @@ sub jobfinished {
   }
   
   # save logfile
-  link("$jobdatadir/logfile", "$jobdatadir/logfile.dup");
-  rename("$jobdatadir/logfile", "$dst/logfile");
-  rename("$jobdatadir/logfile.dup", "$gdst/:logfiles.success/$packid");
+  link("$jobdatadir/logfile", "$jobdatadir/logfile.dup") || copy("$jobdatadir/logfile", "$jobdatadir/logfile.dup");
+  move("$jobdatadir/logfile", "$dst/logfile");
+  move("$jobdatadir/logfile.dup", "$gdst/:logfiles.success/$packid");
   unlink("$gdst/:logfiles.fail/$packid");
   unlink($_) for @all;
   rmdir($jobdatadir);
@@ -4402,7 +4403,7 @@ sub aggregatefinished {
   unlink("$dst/logfile");
   unlink("$dst/status");
   mkdir_p("$gdst/:meta");
-  rename("$jobdatadir/meta", "$gdst/:meta/$packid") || die("rename $jobdatadir/meta $gdst/:meta/$packid: $!\n");
+  move("$jobdatadir/meta", "$gdst/:meta/$packid") || die("move $jobdatadir/meta $gdst/:meta/$packid: $!\n");
   patchpackstatus($prp, $packid, 'succeeded');
 }
 
@@ -4437,7 +4438,7 @@ sub deltafinished {
   if ($code ne 'succeeded') {
     print "  - $job: build failed\n";
     unlink("$dst/logfile");
-    rename("$jobdatadir/logfile", "$dst/logfile");
+    move("$jobdatadir/logfile", "$dst/logfile");
     unlink("$reporoot/$prp/$myarch/:repodone");
     return;
   }
@@ -4447,15 +4448,15 @@ sub deltafinished {
     next unless $f =~ /^(.*)\.(drpm|out|dseq)$/s;
     my $deltaid = $1;
     if ($2 ne 'dseq') {
-      rename("$jobdatadir/$f", "$dst/$deltaid");
+      move("$jobdatadir/$f", "$dst/$deltaid");
     } else {
-      rename("$jobdatadir/$f", "$dst/$deltaid.dseq");
+      move("$jobdatadir/$f", "$dst/$deltaid.dseq");
     }
   }
   $changed->{$prp} ||= 1;
   unlink("$reporoot/$prp/$myarch/:repodone");
   unlink("$dst/logfile");
-  rename("$jobdatadir/logfile", "$dst/logfile");
+  move("$jobdatadir/logfile", "$dst/logfile");
 }
 
 sub uploadbuildevent {
@@ -4577,20 +4578,20 @@ sub fakejobfinished_nouseforbuild {
   mkdir_p("$gdst/:logfiles.success");
   unlink("$reporoot/$prp/$myarch/:repodone");
   if (-e "$jobdatadir/logfile") {
-    link("$jobdatadir/logfile", "$jobdatadir/logfile.dup");
+    link("$jobdatadir/logfile", "$jobdatadir/logfile.dup") || copy("$jobdatadir/logfile", "$jobdatadir/logfile.dup");
     if ($code eq 'failed') {
-      rename("$jobdatadir/logfile.dup", "$gdst/:logfiles.fail/$packid");
+      move("$jobdatadir/logfile.dup", "$gdst/:logfiles.fail/$packid");
     } else {
-      rename("$jobdatadir/logfile.dup", "$gdst/:logfiles.success/$packid");
+      move("$jobdatadir/logfile.dup", "$gdst/:logfiles.success/$packid");
       unlink("$gdst/:logfiles.fail/$packid");
     }
-    rename("$jobdatadir/logfile", "$dst/logfile");
+    move("$jobdatadir/logfile", "$dst/logfile");
   }
-  rename("$jobdatadir/meta", "$gdst/:meta/$packid");
+  move("$jobdatadir/meta", "$gdst/:meta/$packid");
   if ($code eq 'succeeded') {
     BSUtil::cleandir($dst);
     for my $f (ls($jobdatadir)) {
-      rename("$jobdatadir/$f", "$dst/$f") || die("rename $jobdatadir/$f $dst/$f: $!\n");
+      move("$jobdatadir/$f", "$dst/$f") || die("move $jobdatadir/$f $dst/$f: $!\n");
     }
     if (!checkaccess('sourceaccess', $projid, $packid, $repoid)) {
       BSUtil::touch("$dst/.nosourceaccess");
@@ -5668,7 +5669,7 @@ sub rebuildpatchinfo {
         }
         next;
       }
-      if (!link("$from/$bin", "$jobdatadir/$bin")) {
+      if (!(link("$from/$bin", "$jobdatadir/$bin") || copy("$from/$bin", "$jobdatadir/$bin"))) {
         my $error = "link $from/$bin $jobdatadir/$bin: $!\n";
         return ('broken', $error);
       }
@@ -6027,7 +6028,7 @@ sub rebuildchannel {
       rmdir($jobdatadir);
       return ('broken', "id mismatch in $arepoid/$apackid $s[9]/$s[7]/$s[1] $bi->{'id'}");
     }
-    link($file, "$jobdatadir/$bi->{'filename'}") || die("link $file $jobdatadir/$bi->{'filename'}: $!\n");
+    link($file, "$jobdatadir/$bi->{'filename'}") || copy($file, "$jobdatadir/$bi->{'filename'}") || die("link $file $jobdatadir/$bi->{'filename'}: $!\n");
     $bininfo->{$bi->{'filename'}} = $bi;
     my $ci = { 'repository' => $arepoid, 'package' => $apackid };
     $ci->{'supportstatus'} = $supportstatus if defined $supportstatus;
@@ -7541,7 +7542,7 @@ print "starting build service scheduler\n";
 mkdir_p($rundir);
 if (!$testprojid) {
   open(RUNLOCK, '>>', "$rundir/bs_sched.$myarch.lock") || die("$rundir/bs_sched.$myarch.lock: $!\n");
-  flock(RUNLOCK, LOCK_EX | LOCK_NB) || die("scheduler is already running for $myarch!\n");
+  fcntl(RUNLOCK, F_SETFL, O_EXCL | O_NONBLOCK) || die("scheduler is already running for $myarch!\n");
   utime undef, undef, "$rundir/bs_sched.$myarch.lock";
 }
 
@@ -9036,8 +9037,8 @@ NEXTPRP:
       };
       if (!$@) {
 	unlink("$reporoot/$prp/$myarch/:relsync$$");
-	link("$reporoot/$prp/$myarch/:relsync", "$reporoot/$prp/$myarch/:relsync$$");
-	rename("$reporoot/$prp/$myarch/:relsync$$", "$reporoot/$prp/$myarch/:relsync.sent");
+	link("$reporoot/$prp/$myarch/:relsync", "$reporoot/$prp/$myarch/:relsync$$") || copy("$reporoot/$prp/$myarch/:relsync", "$reporoot/$prp/$myarch/:relsync$$");
+	move("$reporoot/$prp/$myarch/:relsync$$", "$reporoot/$prp/$myarch/:relsync.sent");
       } else {
 	warn($@);
       }

--- a/src/backend/bs_service
+++ b/src/backend/bs_service
@@ -31,10 +31,11 @@ BEGIN {
 }
 
 use Digest::MD5 ();
+use File::Copy qw(move);
 use XML::Structured ':bytes';
 use Data::Dumper;
 use POSIX;
-use Fcntl qw(:DEFAULT :flock);
+use Fcntl qw(:DEFAULT);
 
 use BSRPC;
 use BSServer;
@@ -128,7 +129,7 @@ sub run_source_update {
   mkdir_p($myworkdir."/.old");
   for my $file (grep {/^_service[:_]/} ls(".")) {
     print "moving old file ".$file." to .old\n";
-    rename($file,".old/".$file);
+    move($file,".old/".$file);
   }
 
   # set environment
@@ -184,7 +185,7 @@ sub run_source_update {
           my $mode = (stat("$myworkdir/.tmp/$file"))[2];
           if (!S_ISDIR($mode)) {
             my $tfile = "_service:".$service->{'name'}.":".$file;
-            rename("$myworkdir/.tmp/".$file, $tfile);
+            move("$myworkdir/.tmp/".$file, $tfile);
           }
         }
       } else { 

--- a/src/backend/bs_signer
+++ b/src/backend/bs_signer
@@ -31,7 +31,8 @@ BEGIN {
 use POSIX;
 use Data::Dumper;
 use Digest::MD5 ();
-use Fcntl qw(:DEFAULT :flock);
+use Fcntl qw(:DEFAULT);
+use File::Copy qw(move);
 use XML::Structured ':bytes';
 use Build;
 use Storable;
@@ -520,7 +521,7 @@ sub ping {
 sub signevent {
   my ($event, $ev) = @_;
 
-  rename("$myeventdir/$event", "$myeventdir/${event}::inprogress");
+  move("$myeventdir/$event", "$myeventdir/${event}::inprogress");
   my $job = $ev->{'job'};
   my $arch = $ev->{'arch'};
   my $res;
@@ -529,7 +530,7 @@ sub signevent {
   };
   if ($@) {
     warn("sign failed: $@");
-    rename("$myeventdir/${event}::inprogress", "$myeventdir/$event");
+    move("$myeventdir/${event}::inprogress", "$myeventdir/$event");
     return;
   } elsif ($res) {
     my $name = $ev->{'type'} eq 'built' ? 'finished' : $ev->{'type'};
@@ -560,7 +561,7 @@ print "starting build service signer\n";
 # get lock
 mkdir_p($rundir);
 open(RUNLOCK, '>>', "$rundir/bs_signer.lock") || die("$rundir/bs_signer.lock: $!\n");
-flock(RUNLOCK, LOCK_EX | LOCK_NB) || die("signer is already running!\n");
+fcntl(RUNLOCK, F_SETFL, O_EXCL | O_NONBLOCK) || die("signer is already running!\n");
 utime undef, undef, "$rundir/bs_signer.lock";
 
 die("sign program is not configured!\n") unless $BSConfig::sign;
@@ -573,7 +574,7 @@ if (!-p "$myeventdir/.ping") {
 sysopen(PING, "$myeventdir/.ping", POSIX::O_RDWR) || die("$myeventdir/.ping: $!");
 
 for my $event (grep {s/::inprogress$//s} ls($myeventdir)) {
-  rename("$myeventdir/${event}::inprogress", "$myeventdir/$event");
+  move("$myeventdir/${event}::inprogress", "$myeventdir/$event");
 }
 
 check_sign_S();

--- a/src/backend/bs_srcserver
+++ b/src/backend/bs_srcserver
@@ -30,6 +30,7 @@ BEGIN {
   unshift @INC,  "$wd";
 }
 
+use File::Copy qw(copy move);
 use XML::Structured ':bytes';
 use POSIX;
 use Digest::MD5 ();
@@ -127,7 +128,7 @@ sub prune_lastnotifications {
     unlink("$eventdir/.lastnotifications.$$");
     if (! -e "$eventdir/.lastnotifications.$$") {
       BSFileDB::fdb_add_multiple("$eventdir/.lastnotifications.$$", $notificationlay, @l);
-      rename("$eventdir/.lastnotifications.$$", "$eventdir/lastnotifications") || die("rename $eventdir/.lastnotifications.$$ $eventdir/lastnotifications: $!\n");
+      move("$eventdir/.lastnotifications.$$", "$eventdir/lastnotifications") || die("move $eventdir/.lastnotifications.$$ $eventdir/lastnotifications: $!\n");
     }
   }
   close F;
@@ -591,7 +592,7 @@ sub expandproduct {
   BSUtil::cleandir($dir);
   mkdir_p($dir);
   for my $file (sort keys %$files) {
-    link("$srcrep/$packid/$files->{$file}-$file", "$dir/$file") || die("link $srcrep/$packid/$files->{$file}-$file $dir/$file: $!\n");
+    link("$srcrep/$packid/$files->{$file}-$file", "$dir/$file") || copy("$srcrep/$packid/$files->{$file}-$file", "$dir/$file") || die("link $srcrep/$packid/$files->{$file}-$file $dir/$file: $!\n");
   }
   my @prods = grep {/.product$/}  sort keys %$files;
   my %pids;
@@ -823,13 +824,13 @@ sub addfile {
     $md5 = $ctx->hexdigest();
   }
   if (! -e "$srcrep/$packid/$md5-$filename") {
-    if (!rename($tmpfile, "$srcrep/$packid/$md5-$filename")) {
+    if (!move($tmpfile, "$srcrep/$packid/$md5-$filename")) {
       mkdir_p("$srcrep/$packid");
-      if (!rename($tmpfile, "$srcrep/$packid/$md5-$filename")) {
+      if (!move($tmpfile, "$srcrep/$packid/$md5-$filename")) {
         my $err = $!;
         if (! -e "$srcrep/$packid/$md5-$filename") {
           $! = $err;
-          die("rename $tmpfile $srcrep/$packid/$md5-$filename: $!\n");
+          die("move $tmpfile $srcrep/$packid/$md5-$filename: $!\n");
         }
       }
     }
@@ -851,7 +852,7 @@ sub copyfiles {
   for my $f (sort keys %$files) {
     next if $except && $except->{$f};
     next if -e "$srcrep/$packid/$files->{$f}-$f";
-    link("$srcrep/$opackid/$files->{$f}-$f", "$srcrep/$packid/$files->{$f}-$f");
+    link("$srcrep/$opackid/$files->{$f}-$f", "$srcrep/$packid/$files->{$f}-$f") || copy("$srcrep/$opackid/$files->{$f}-$f", "$srcrep/$packid/$files->{$f}-$f") ;
     die("link error $srcrep/$opackid/$files->{$f}-$f\n") unless -e "$srcrep/$packid/$files->{$f}-$f";
   }
 }
@@ -1562,7 +1563,7 @@ sub patchspec {
     print O "$_\n";
   }
   close(O) || die("close: $!\n");
-  rename("$dir/.patchspec$$", "$dir/$spec") || die("rename $dir/.patchspec$$ $dir/$spec: $!\n");
+  move("$dir/.patchspec$$", "$dir/$spec") || die("move $dir/.patchspec$$ $dir/$spec: $!\n");
   return '';
 }
 # " Make emacs wired syntax highlighting happy
@@ -1581,7 +1582,7 @@ sub topaddspec {
     print O "$_\n";
   }
   close(O) || die("close: $!\n");
-  rename("$dir/.topaddspec$$", "$dir/$spec") || die("rename $dir/.topaddspec$$ $dir/$spec: $!\n");
+  move("$dir/.topaddspec$$", "$dir/$spec") || die("move $dir/.topaddspec$$ $dir/$spec: $!\n");
 }
 
 #
@@ -1668,12 +1669,12 @@ sub applylink {
   if (!$isbranch) {
     for my $f (sort keys %$fsrc) {
       next if $flnk->{$f} && !$apply{$f};
-      link("$srcrep/$lsrc->{'package'}/$fsrc->{$f}-$f", "$tmpdir/$f") || die("$f: $!\n");
+      link("$srcrep/$lsrc->{'package'}/$fsrc->{$f}-$f", "$tmpdir/$f") || copy("$srcrep/$lsrc->{'package'}/$fsrc->{$f}-$f", "$tmpdir/$f") || die("$f: $!\n");
       $fl{$f} = "$lsrc->{'package'}/$fsrc->{$f}-$f";
     }
     for my $f (sort keys %$flnk) {
       next if $apply{$f} || $f eq '_link';
-      link("$srcrep/$llnk->{'package'}/$flnk->{$f}-$f", "$tmpdir/$f") || die("$f: $!\n");
+      link("$srcrep/$llnk->{'package'}/$flnk->{$f}-$f", "$tmpdir/$f") || copy("$srcrep/$llnk->{'package'}/$flnk->{$f}-$f", "$tmpdir/$f") || die("$f: $!\n");
       $fl{$f} = "$llnk->{'package'}/$flnk->{$f}-$f";
     }
   }
@@ -1713,13 +1714,13 @@ sub applylink {
 	my $mlnk = $flnk->{$f} || '';
 	if ($mbas eq $mlnk) {
 	  next if $msrc eq '';
-	  link("$srcrep/$lsrc->{'package'}/$fsrc->{$f}-$f", "$tmpdir/$f") || die("$fsrc->{$f}-$f: $!\n");
+	  link("$srcrep/$lsrc->{'package'}/$fsrc->{$f}-$f", "$tmpdir/$f") || copy("$srcrep/$lsrc->{'package'}/$fsrc->{$f}-$f", "$tmpdir/$f") || die("$fsrc->{$f}-$f: $!\n");
 	  $fl{$f} = "$lsrc->{'package'}/$fsrc->{$f}-$f";
 	  next;
 	}
 	if ($mbas eq $msrc || $mlnk eq $msrc) {
 	  next if $mlnk eq '';
-	  link("$srcrep/$llnk->{'package'}/$flnk->{$f}-$f", "$tmpdir/$f") || die("$flnk->{$f}-$f: $!\n");
+	  link("$srcrep/$llnk->{'package'}/$flnk->{$f}-$f", "$tmpdir/$f") || copy("$srcrep/$llnk->{'package'}/$flnk->{$f}-$f", "$tmpdir/$f") || die("$flnk->{$f}-$f: $!\n");
 	  $fl{$f} = "$llnk->{'package'}/$flnk->{$f}-$f";
 	  next;
 	}
@@ -1728,9 +1729,9 @@ sub applylink {
 	  last;
 	}
         # run diff3
-	link("$srcrep/$lsrc->{'package'}/$fsrc->{$f}-$f", "$tmpdir/$f.new") || die("link $fsrc->{$f}-$f: $!\n");
-	link("$srcrep/$lsrc->{'package'}/$fbas->{$f}-$f", "$tmpdir/$f.old") || die("link $fbas->{$f}-$f: $!\n");
-	link("$srcrep/$llnk->{'package'}/$flnk->{$f}-$f", "$tmpdir/$f.mine") || die("link $flnk->{$f}-$f: $!\n");
+	link("$srcrep/$lsrc->{'package'}/$fsrc->{$f}-$f", "$tmpdir/$f.new") || copy("$srcrep/$lsrc->{'package'}/$fsrc->{$f}-$f", "$tmpdir/$f.new") || die("link $fsrc->{$f}-$f: $!\n");
+	link("$srcrep/$lsrc->{'package'}/$fbas->{$f}-$f", "$tmpdir/$f.old") || copy("$srcrep/$lsrc->{'package'}/$fbas->{$f}-$f", "$tmpdir/$f.old") || die("link $fbas->{$f}-$f: $!\n");
+	link("$srcrep/$llnk->{'package'}/$flnk->{$f}-$f", "$tmpdir/$f.mine") || copy("$srcrep/$llnk->{'package'}/$flnk->{$f}-$f", "$tmpdir/$f.mine") || die("link $flnk->{$f}-$f: $!\n");
 	if (!isascii("$tmpdir/$f.new") || !isascii("$tmpdir/$f.old") || !isascii("$tmpdir/$f.mine")) {
 	  $failed = "conflict in file $f";
 	  last;
@@ -1819,7 +1820,7 @@ sub applylink {
     print F "\n$failed\n";
     close F;
     # link error marker
-    if ($md5 && !link("$tmpdir/.log", "$srcrep/$llnk->{'package'}/$md5-_linkerror")) {
+    if ($md5 && !(link("$tmpdir/.log", "$srcrep/$llnk->{'package'}/$md5-_linkerror") || copy("$tmpdir/.log", "$srcrep/$llnk->{'package'}/$md5-_linkerror"))) {
       my $err = "link $tmpdir/.log $srcrep/$llnk->{'package'}/$md5-_linkerror: $!\n";
       die($err) unless -e "$srcrep/$llnk->{'package'}/$md5-_linkerror";
     }
@@ -1852,9 +1853,9 @@ sub applylink {
 
   # if we just want the patched files we're finished
   if (!$md5) {
-    # rename into md5 form, sort so that there's no collision
+    # move into md5 form, sort so that there's no collision
     for my $f (sort {length($b) <=> length($a) || $a cmp $b} @newf) {
-      rename("$tmpdir/$f", "$tmpdir/$newf->{$f}-$f");
+      move("$tmpdir/$f", "$tmpdir/$newf->{$f}-$f");
     }
     return $newf;
   }
@@ -2370,7 +2371,7 @@ sub extract_old_meta {
     if ($signkey) {
       writestr("$uploaddir/$$.2", undef, $signkey);
       chmod(0600, "$uploaddir/$$.2");
-      rename("$uploaddir/$$.2", "$projectsdir/$projid.pkg/_signkey") || die("rename $uploaddir/$$.2 $projectsdir/$projid.pkg/_signkey: $!\n");
+      move("$uploaddir/$$.2", "$projectsdir/$projid.pkg/_signkey") || die("move $uploaddir/$$.2 $projectsdir/$projid.pkg/_signkey: $!\n");
     }
     my $meta;
     $meta = repreadstr($rev, '_meta', $files->{'_meta'}, 1) if $files->{'_meta'};
@@ -2448,7 +2449,7 @@ sub addrev_meta_multiple {
     my ($tmpfile, $file, $rfile) = @$todo;
     if (defined($file)) {
       if (defined($tmpfile)) {
-        rename($tmpfile, $file) || die("rename $tmpfile $file: $!\n");
+        move($tmpfile, $file) || die("move $tmpfile $file: $!\n");
       } else {
         unlink($file);
       }
@@ -5308,11 +5309,11 @@ sub integratelink {
 	  my $oppatch = $_->{'apply'}->{'name'};
 	  if ($files->{$oppatch}) {
 	    $dontcopy{$oppatch} = 1;
-	    # argh, patch file already exists, rename...
+	    # argh, patch file already exists, move...
 	    my $ppatch = findprojectpatchname($files);
 	    mkdir_p($uploaddir);
 	    unlink("$uploaddir/$$");
-	    link("$srcrep/$opackid/$ofiles->{$oppatch}-$oppatch", "$uploaddir/$$") || die("link $srcrep/$opackid/$ofiles->{$oppatch}-$oppatch $uploaddir/$$: $!\n");
+	    link("$srcrep/$opackid/$ofiles->{$oppatch}-$oppatch", "$uploaddir/$$") || copy("$srcrep/$opackid/$ofiles->{$oppatch}-$oppatch", "$uploaddir/$$") || die("link $srcrep/$opackid/$ofiles->{$oppatch}-$oppatch $uploaddir/$$: $!\n");
             $files->{$ppatch} = addfile($projid, $packid, "$uploaddir/$$", $ppatch);
 	    push @{$nl->{'patches'}->{''}}, {'apply' => {'name' => $ppatch}};
 	    next;
@@ -7289,7 +7290,7 @@ sub worker_getbinaries {
       my $cachemd5 = Digest::MD5::md5_hex("$projid/$repoid/$arch/$bin");
       substr($cachemd5, 2, 0, '/');
       mkdir_p("$remotecache/".substr($cachemd5, 0, 2));
-      rename("$remotecache/$f->{'name'}", "$remotecache/$cachemd5");
+      move("$remotecache/$f->{'name'}", "$remotecache/$cachemd5");
       push @reply, {'name' => $fetch{$bin}->{'filename'}, 'filename' => "$remotecache/$cachemd5"};
       delete $fetch{$bin};
     }

--- a/src/backend/bs_warden
+++ b/src/backend/bs_warden
@@ -31,7 +31,7 @@ BEGIN {
 use POSIX;
 use Data::Dumper;
 use Digest::MD5 ();
-use Fcntl qw(:DEFAULT :flock);
+use Fcntl qw(:DEFAULT);
 use XML::Structured ':bytes';
 
 use BSConfiguration;
@@ -58,7 +58,7 @@ print BSUtil::isotime().": starting build service worker warden\n";
 # get lock
 mkdir_p($rundir);
 open(RUNLOCK, '>>', "$rundir/bs_warden.lock") || die("$rundir/bs_warden.lock: $!\n");
-flock(RUNLOCK, LOCK_EX | LOCK_NB) || die("worker warden is already running!\n");
+fcntl(RUNLOCK, F_SETFL, O_EXCL | O_NONBLOCK) || die("worker warden is already running!\n");
 utime undef, undef, "$rundir/bs_warden.lock";
 
 my %building;

--- a/src/backend/bs_worker
+++ b/src/backend/bs_worker
@@ -30,10 +30,11 @@ BEGIN {
 }
 
 use Digest::MD5 ();
+use File::Copy qw(copy move);
 use XML::Structured ':bytes';
 use Data::Dumper;
 use POSIX;
-use Fcntl qw(:DEFAULT :flock);
+use Fcntl qw(:DEFAULT);
 BEGIN { Fcntl->import(':seek') unless defined &SEEK_SET; }
 
 use Storable;
@@ -111,7 +112,7 @@ $hostcheck = $BSConfig::workerhostcheck if defined($BSConfig::workerhostcheck);
 sub lockstate {
   while (1) {
     open(STATELOCK, '>>', "$statedir/state") || die("$statedir/state: $!\n");
-    flock(STATELOCK, LOCK_EX) || die("flock $statedir/state: $!\n");
+    fcntl(STATELOCK, F_SETFL, O_EXCL | O_NONBLOCK) || die("fcntl $statedir/state: $!\n");
     my @s = stat(STATELOCK);
     last if $s[3];	# check nlink
     close(STATELOCK);	# race, try again
@@ -152,7 +153,7 @@ sub trunc_logfile {
   open(LF, ">$lf.new") || return; 
   syswrite(LF, $buf);
   close LF;
-  rename("$lf.new", $lf);
+  move("$lf.new", $lf);
 }
 
 sub tail_logfile {
@@ -809,9 +810,9 @@ sub getcode {
 
   # ok, commit
   if (-e $dir) {
-    rename($dir, $odir) || die("rename $dir $odir: $!\n");
+    move($dir, $odir) || die("move $dir $odir: $!\n");
   }
-  rename($ndir, $dir) || die("rename $ndir $dir: $!\n");
+  move($ndir, $dir) || die("move $ndir $dir: $!\n");
   rm_rf($odir) if -e $odir;
   my $md5 = '';
   for my $file (sort {$a->{'name'} cmp $b->{'name'}} @$res) {
@@ -952,7 +953,7 @@ sub qsystem {
 sub link_or_copy {
   my ($from, $to) = @_;
   unlink($to);
-  return 1 if link($from, $to);
+  return 1 if (link($from, $to) || copy($from, $to));
   local *F;
   local *G;
   return undef unless open(F, '<', $from);
@@ -997,13 +998,13 @@ sub manage_cache {
       mkdir_p("$cachedir/".substr($cacheid, 0, 2));
       unlink("$cachefile.$$");
       next unless link_or_copy($path, "$cachefile.$$");
-      rename("$cachefile.$$", $cachefile) || die("rename $cachefile.$$ $cachefile: $!\n");
+      move("$cachefile.$$", $cachefile) || die("move $cachefile.$$ $cachefile: $!\n");
       my $mpath = "$path.meta";
       $mpath = "$1.meta" if $path =~ /^(.*)\.(?:$binsufsre)$/;
       if (-s $mpath) {
 	unlink("$cachefile.meta.$$");
 	if (link_or_copy($mpath, "$cachefile.meta.$$")) {
-	  rename("$cachefile.meta.$$", "$cachefile.meta") || die("rename $cachefile.meta.$$ $cachefile.meta: $!\n");
+	  move("$cachefile.meta.$$", "$cachefile.meta") || die("move $cachefile.meta.$$ $cachefile.meta: $!\n");
 	} else {
 	  unlink("$cachefile.meta");
 	}
@@ -1034,7 +1035,7 @@ sub manage_cache {
   }
   @$content = grep {defined $_} @$content;
   Storable::nstore($content, "$cachedir/content.new");
-  rename("$cachedir/content.new", "$cachedir/content") || die("rename $cachedir/content.new $cachedir/content: $!\n");
+  move("$cachedir/content.new", "$cachedir/content") || die("move $cachedir/content.new $cachedir/content: $!\n");
   close F;
 }
 
@@ -1303,7 +1304,7 @@ sub getbinaries_kiwiproduct {
 	next if $nodbgpkgs && $name =~ /-(?:debuginfo|debugsource)-/;
 	next if $nosrcpkgs && ($rarch eq 'src' || $rarch eq 'nosrc');
 	mkdir_p("$ddir/$rarch") unless -d "$ddir/$rarch";
-	if (!link("$localkiwi/build/$projid/$repoid/$arch/$packid/$name", "$ddir/$rarch/$name")) {
+	if (!(link("$localkiwi/build/$projid/$repoid/$arch/$packid/$name", "$ddir/$rarch/$name") || copy("$localkiwi/build/$projid/$repoid/$arch/$packid/$name", "$ddir/$rarch/$name"))) {
 	  # link fails if file already exists, rpc just overwrites
 	  unlink("$ddir/$rarch/$name");
 	  link_or_copy("$localkiwi/build/$projid/$repoid/$arch/$packid/$name", "$ddir/$rarch/$name") || die("link $localkiwi/build/$projid/$repoid/$arch/$packid/$name $ddir/$rarch/$name: $!\n");
@@ -1461,7 +1462,7 @@ sub getbinaries_kiwiproduct {
       }
       if ($bvl && !@bad) {
 	for (@good) {
-	  rename("$ddir/$_.new.rpm", "$ddir/$_") || die("rename $ddir/$_.new.rpm $ddir/$_: $!\n");
+	  move("$ddir/$_.new.rpm", "$ddir/$_") || die("move $ddir/$_.new.rpm $ddir/$_: $!\n");
           $kiwiorigins->{"obs://$prpdir/$_"} = $prpap;
 	}
         $res = [ map {{'name' => $_}} @good ];
@@ -1619,7 +1620,7 @@ sub getpreinstallimage_metas {
 	my $cachefile = "$cachedir/".substr($cacheid, 0, 2)."/$cacheid";
 	unlink("$cachefile.meta.$$");
 	if (link_or_copy("$dir/$bin.meta", "$cachefile.meta.$$")) {
-	  rename("$cachefile.meta.$$", "$cachefile.meta") || die("rename $cachefile.meta.$$ $cachefile.meta: $!\n");
+	  move("$cachefile.meta.$$", "$cachefile.meta") || die("move $cachefile.meta.$$ $cachefile.meta: $!\n");
 	}
       }
     } else {
@@ -2469,8 +2470,8 @@ sub dobuild {
   if ($vm =~ /(xen|kvm|zvm|emulator)/) {
     rm_rf("$buildroot/.build.packages");
     # move directory with extracted build results
-    if(!rename("$buildroot/.mount/.build.packages", "$buildroot/.build.packages")) {
-      print "final rename failed: $!";
+    if(!move("$buildroot/.mount/.build.packages", "$buildroot/.build.packages")) {
+      print "final move failed: $!";
       return 1;
     }
     # XXX: extracted cpio is flat but code below expects those directories...
@@ -2586,7 +2587,7 @@ $| = 1;
 print "starting worker $workercode build $buildcode\n";
 
 open(RUNLOCK, '>>', "$statedir/lock") || die("$statedir/lock: $!");
-flock(RUNLOCK, LOCK_EX | LOCK_NB) || die("worker is already running on $statedir!\n");
+fcntl(RUNLOCK, F_SETFL, O_EXCL | O_NONBLOCK) || die("worker is already running on $statedir!\n");
 utime undef, undef, "$statedir/lock";
 
 # we always start idle
@@ -2870,7 +2871,7 @@ if (!$nobuildcodecheck && $cgi->{'buildcode'} && $cgi->{'port'} && $cgi->{'build
   die("could not update build code\n") unless $buildcode;
 }
 
-rename('job.new', 'job') || die("rename job.new job: $!\n");
+move('job.new', 'job') || die("move job.new job: $!\n");
 
 if ($hostcheck) {
   my $server = $buildinfo->{'srcserver'} || $srcserver;
@@ -2945,7 +2946,7 @@ if ($buildinfo->{'followupfile'}) {
 	my $buf;
 	syswrite(T, $buf) while sysread(F, $buf, 8192);
 	close T;
-	rename("$buildsrcdir/logfile", "$buildroot/.build.log");
+	move("$buildsrcdir/logfile", "$buildroot/.build.log");
       }
       close F;
     }
@@ -3101,12 +3102,12 @@ if (!$testmode) {
     BSUtil::cleandir($jobdir);
     for my $f (ls("$buildroot/.build.packages/KIWI")) {
       system('chown', '-h', '-R', '--reference', "$jobdir", "$buildroot/.build.packages/KIWI/$f");
-      rename("$buildroot/.build.packages/KIWI/$f", "$jobdir/$f") || die("rename $buildroot/.build.packages/KIWI/$f $jobdir/$f: $!\n");
+      move("$buildroot/.build.packages/KIWI/$f", "$jobdir/$f") || die("move $buildroot/.build.packages/KIWI/$f $jobdir/$f: $!\n");
     }
     chown($localkiwi_uid, $localkiwi_gid, "$buildroot/.build.log");
     chown($localkiwi_uid, $localkiwi_gid, "$buildroot/.build.meta");
-    rename("$buildroot/.build.log", "$jobdir/logfile");
-    rename("$buildroot/.build.meta", "$jobdir/meta");
+    move("$buildroot/.build.log", "$jobdir/logfile");
+    move("$buildroot/.build.meta", "$jobdir/meta");
     @send = ();
   }
   my $param = {


### PR DESCRIPTION
Allow an OBS to run off of shared infrastructure, such as a GFS or NFS volume, or even just multiple disks (/srv/obs/build/ can be large volumes of cheap storage, /srv/obs/sources/ can be expensive and redundant, /srv/obs/jobs/ can be fast, /srv/obs/repos/ can be redundant and replicated, etc.).

  1) Replace the use of rename() with move().

```
 rename() usually does not work across filesystem boundaries. move() on
 the other hand does, and is more platform independent.
```

  2) Replace the use of flock() with fcntl().

```
 Some versions of flock() cannot lock over the network. fcntl() is
 more robust in this regard.
```

  3) Catch failures of link() with copy() before issuing die().

```
 Linking is a privilege, not a right, and does not work across
 filesystem boundaries.
```
