### PR TITLE
Add Debian ppc64el architecture to debarches

### DIFF
--- a/src/backend/bs_publish
+++ b/src/backend/bs_publish
@@ -671,6 +671,7 @@ sub createrepo_debian {
   for (@debarchs) {
      s/x86_64/amd64/g;
      s/i.86/i386/g;
+     s/ppc64le/ppc64el/g;
   };
   my $archs = join(' ', @debarchs);
 


### PR DESCRIPTION
Debian based distros have different name for PowerPC 64Bit Little Endian
architecture.

Signed-off-by: Dinar Valeev dvaleev@suse.com
