### PR TITLE
[api] allow engines not in our git to be loaded

### DIFF
--- a/src/api/config/application.rb
+++ b/src/api/config/application.rb
@@ -4,6 +4,8 @@ require 'rails/all'
 
 # Assets should be precompiled for production (so we don't need the gems loaded then)
 Bundler.require(*Rails.groups(assets: %w(development test)))
+require_relative '../lib/engines/base.rb'
+OBSEngine::load_engines
 
 module OBSApi
   class Application < Rails::Application

--- a/src/api/config/routes.rb
+++ b/src/api/config/routes.rb
@@ -680,3 +680,7 @@ OBSApi::Application.routes.draw do
   get 'main/sitemap_packages/:listaction' => 'webui/main#sitemap_packages'
 
 end
+
+OBSEngine::Base.subclasses.each do |engine|
+  engine.mount_it
+end

--- a/src/api/lib/engines/README.md
+++ b/src/api/lib/engines/README.md
@@ -1,0 +1,14 @@
+All .rb files in this directory will be required (to require
+the engine itself) and after the application routes are setup,
+the mount\_it functions are called, so the engines can be mounted
+
+  require '/usr/share/obs_factory/lib/obs_factory.rb'
+
+  class LoadFactoryEngine < OBSEngine::Base
+    def self.mount_it
+      OBSApi::Application.routes.draw do
+        mount ObsFactory::Engine => "/factory"
+      end
+    end
+  end
+

--- a/src/api/lib/engines/base.rb
+++ b/src/api/lib/engines/base.rb
@@ -1,0 +1,19 @@
+module OBSEngine
+  # base class for all engine hooks
+  class Base
+    # implement this function to patch the routes
+    def mount_it
+    end
+  end
+
+  def self.load_engines
+    dirname = File.dirname(__FILE__)
+    Dir.foreach(dirname) do |filename|
+      next unless filename =~ %r(.rb)
+      # ignore ourselves
+      next if filename == File.basename(__FILE__)
+      require File.join(dirname, filename)
+    end
+  end
+end
+


### PR DESCRIPTION
They need to drop a file in lib/engines which requires the engine and
implements mount_it call
