### PR TITLE
[api] track the number of delayed jobs associated with an event

### DIFF
--- a/src/api/app/jobs/cleanup_cache_lines.rb
+++ b/src/api/app/jobs/cleanup_cache_lines.rb
@@ -1,9 +1,9 @@
-class CleanupCacheLines
+class CleanupCacheLines < CreateJob
 
   attr_accessor :event
 
   def initialize(event)
-    self.event = event
+    super(event)
   end
 
   def perform

--- a/src/api/app/jobs/cleanup_events.rb
+++ b/src/api/app/jobs/cleanup_events.rb
@@ -1,5 +1,5 @@
 class CleanupEvents
   def perform
-    Event::Base.where(project_logged: true, queued: true).delete_all
+    Event::Base.where(project_logged: true, queued: true, undone_jobs: 0).delete_all
   end
 end

--- a/src/api/app/jobs/create_job.rb
+++ b/src/api/app/jobs/create_job.rb
@@ -1,0 +1,22 @@
+class CreateJob
+  
+  def initialize(event) 
+    self.event = event
+  end
+
+  def after(job)
+    event = job.payload_object.event
+    # in test suite the undone_jobs are 0 as the delayed jobs are not delayed
+    Rails.logger.debug "WITH #{event.inspect}"
+    event.with_lock do
+      event.undone_jobs -= 1
+      Rails.logger.debug "WITHOUT #{event.inspect}"
+      event.save!
+    end
+  end
+
+  def error(job, exception)
+    HoptoadNotifier.notify(exception, job.inspect)
+    notify_hoptoad(ex)
+  end
+end

--- a/src/api/app/jobs/send_event_emails.rb
+++ b/src/api/app/jobs/send_event_emails.rb
@@ -1,10 +1,6 @@
-class SendEventEmails 
+class SendEventEmails < CreateJob
 
   attr_accessor :event
-
-  def initialize(event)
-    self.event = event
-  end
 
   def perform
     users = event.subscribers

--- a/src/api/app/jobs/update_backend_infos.rb
+++ b/src/api/app/jobs/update_backend_infos.rb
@@ -1,10 +1,10 @@
-class UpdateBackendInfos
+class UpdateBackendInfos < CreateJob
 
   attr_accessor :event
   attr_accessor :checked_pkgs
 
   def initialize(event)
-    self.event = event
+    super(event)
     self.checked_pkgs = {}
   end
 

--- a/src/api/app/jobs/update_released_binaries.rb
+++ b/src/api/app/jobs/update_released_binaries.rb
@@ -1,13 +1,9 @@
-class UpdateReleasedBinaries
+class UpdateReleasedBinaries < CreateJob
 
   attr_accessor :event
 
   def self.job_queue
     'releasetracking'
-  end
-
-  def initialize(event)
-    self.event = event
   end
 
   def perform

--- a/src/api/db/migrate/20140714112346_create_undone_jobs_counter.rb
+++ b/src/api/db/migrate/20140714112346_create_undone_jobs_counter.rb
@@ -1,0 +1,5 @@
+class CreateUndoneJobsCounter < ActiveRecord::Migration
+  def change
+    add_column :events, :undone_jobs, :integer, default: 0
+  end
+end

--- a/src/api/db/structure.sql
+++ b/src/api/db/structure.sql
@@ -464,6 +464,7 @@ CREATE TABLE `events` (
   `created_at` datetime DEFAULT NULL,
   `updated_at` datetime DEFAULT NULL,
   `project_logged` tinyint(1) DEFAULT '0',
+  `undone_jobs` int(11) DEFAULT '0',
   PRIMARY KEY (`id`),
   KEY `index_events_on_queued` (`queued`),
   KEY `index_events_on_project_logged` (`project_logged`),
@@ -1499,6 +1500,8 @@ INSERT INTO schema_migrations (version) VALUES ('20140627071042');
 INSERT INTO schema_migrations (version) VALUES ('20140704101043');
 
 INSERT INTO schema_migrations (version) VALUES ('20140709071042');
+
+INSERT INTO schema_migrations (version) VALUES ('20140714112346');
 
 INSERT INTO schema_migrations (version) VALUES ('21');
 

--- a/src/api/test/models/project_log_rotate_test.rb
+++ b/src/api/test/models/project_log_rotate_test.rb
@@ -1,4 +1,4 @@
-require 'test_helper'
+require_relative '../test_helper'
 
 class ProjectLogRotateTest < ActiveSupport::TestCase
   fixtures :all


### PR DESCRIPTION
so we can't delete events that have already send_mails jobs pending - or
we can't send mails about the events
