### PR TITLE
[backend] support .sha256 format for static links in published area

### DIFF
--- a/src/backend/bs_publish
+++ b/src/backend/bs_publish
@@ -813,7 +813,7 @@ sub createrepo_staticlinks {
       } elsif (/^(.*)_([^_]*)-[^_]*\.deb$/s) {
         $link = "$1.deb";
         $link = "${1}_$2.deb" if $versioned;
-      } elsif (/^(.*)-(\d+\.\d+\.\d+)-Build\d+\.\d+([-\.].*\.(gz|bz2|tbz|xz))$/s) {
+      } elsif (/^(.*)-(\d+\.\d+\.\d+)-Build\d+\.\d+([-\.].*\.(gz|bz2|tbz|xz|sha256))$/s) {
         $link = "$1$3";
         $link = "$1-$2$3" if $versioned;
       } elsif (/^(.*)-(\d+\.\d+\.\d+)-Build\d+\.\d+(\.(raw.install.raw.xz|raw.xz|box|json|install.iso|iso|qcow2|ova))$/s) {


### PR DESCRIPTION
Completly untested. I want to have links for the sha256 sum files. i.e. here: http://download.opensuse.org/repositories/Cloud:/Images/images/ for openSUSE-13.1-OS-guest.x86_64-raw.tar.bz2  should be a openSUSE-13.1-OS-guest.x86_64-raw.tar.bz2.sha256 file.
Is this the right approach?
