### PR TITLE
[dist] Use free space in VG when calculating OBS_WORKER_ROOT_SIZE

### DIFF
--- a/dist/obsstoragesetup
+++ b/dist/obsstoragesetup
@@ -252,7 +252,8 @@ EOF
 				OBS_WORKER_SWAP_SIZE=`round_down_to_pe $OBS_WORKER_SWAP_SIZE $PE_SIZE`
 
 				if [ -z "$OBS_WORKER_ROOT_SIZE" ]; then
-					VG_SIZE=`vgdisplay -c OBS | awk -F':' '{print( int(int($12) / 1024) )}'`
+					VG_SIZE=`vgdisplay -c OBS | cut -d: -f16`
+					VG_SIZE=$(( $VG_SIZE * ( $PE_SIZE / 1024 ) ))
 					VG_SIZE=$(( $VG_SIZE - $OBS_WORKER_CACHE_SIZE - ( $NUM * $OBS_WORKER_SWAP_SIZE ) ))
 					OBS_WORKER_ROOT_SIZE=$(( $VG_SIZE / $NUM ))
 					if test $OBS_WORKER_ROOT_SIZE -lt $(( 4 * 1024 )); then


### PR DESCRIPTION
If there is a preexisting logical volume in the OBS volume group the
calculated size for the worker root volumes is too large and the storage
setup fails. It is better to use the number of free physical extents in
this case.

Signed-off-by: Jan Blunck jblunck@infradead.org
