### PR TITLE
[webui] Use data: confirm: instead of :confirm for popups

### DIFF
--- a/src/api/app/views/webui/configuration/users.html.erb
+++ b/src/api/app/views/webui/configuration/users.html.erb
@@ -32,25 +32,25 @@
               <li>
                 <%= sprite_tag('accept') %>
                 <%= link_to('Confirm user', {:controller => "user", :action => "confirm", :user => user.login },
-                          :method => :post, :confirm => "Are you sure?")
+                          :method => :post, data: { confirm: "Are you sure?" })
                           %>
               </li>
               <li>
                 <%= sprite_tag('lock') %>
                 <%= link_to('Lock user', {:controller => "user", :action => "lock", :user => user.login },
-                          :method => :post, :confirm => "Are you sure?")
+                          :method => :post, data: { confirm: "Are you sure?" })
                           %>
               </li>
               <li>
                 <%= sprite_tag('cancel') %>
                 <%= link_to('Delete user', {:controller => "user", :action => "delete", :user => user.login },
-                          :method => :delete, :confirm => "Are you sure?")
+                          :method => :delete, data: { confirm: "Are you sure?" })
                           %>
               </li>
               <li>
                 <%= sprite_tag('cog_add') %>
                 <%= link_to('Make user admin', {:controller => "user", :action => "admin", :user => user.login },
-                        :method => :post, :confirm => "Are you sure?")
+                        :method => :post, data: { confirm: "Are you sure?" })
                         %>
               </li>
               <li>

--- a/src/api/app/views/webui/project/_edit_repository.html.erb
+++ b/src/api/app/views/webui/project/_edit_repository.html.erb
@@ -31,7 +31,7 @@
                 <% end %>
               <% end %>
               <%= link_to(image_tag('drive_delete.png'), {:action => :remove_path_from_target, :project => @project, :repository => repository.name, :path_project => path.project, :path_repository => path.repository},
-                           {:confirm => "Really remove #{path.project} / #{path.repository} path from repository  '#{repository.name}'?", :class => 'x', :method => :post}) -%>
+                           {data: { confirm: "Really remove #{path.project} / #{path.repository} path from repository  '#{repository.name}'?" }, :class => 'x', :method => :post}) -%>
               <br/>
             <% end %>
           <% end -%>

--- a/src/api/app/views/webui/request/show.html.erb
+++ b/src/api/app/views/webui/request/show.html.erb
@@ -230,7 +230,7 @@
                   <%= hidden_field_tag(:id, @id) %>
                   <% if %w(new review).include?(@state) && @is_target_maintainer %>
                       <% if @state == 'review' %>
-                          <%= submit_tag 'Accept request', name: 'accepted', id: 'accept_request_button', :confirm => 'Do you really want to approve this request, despite of open review requests?' %>
+                          <%= submit_tag 'Accept request', name: 'accepted', id: 'accept_request_button', data: { confirm: 'Do you really want to approve this request, despite of open review requests?' } %>
                       <% else %>
                           <%= submit_tag 'Accept request', name: 'accepted', id: 'accept_request_button' %>
                       <% end %>


### PR DESCRIPTION
:confirm-tag doesn't work anymore. Replaced with data: { confirm: "bla" }.
