### PR TITLE
Fixed incorrect usage of @login

### DIFF
--- a/src/api/app/controllers/application_controller.rb
+++ b/src/api/app/controllers/application_controller.rb
@@ -128,7 +128,7 @@ class ApplicationController < ActionController::Base
         chars = ["A".."Z","a".."z","0".."9"].collect { |r| r.to_a }.join
         fakepw = (1..24).collect { chars[rand(chars.size)] }.pack('a'*24)
         newuser = User.create(
-            :login => login,
+            :login => @login,
             :password => fakepw,
             :password_confirmation => fakepw,
             :email => ldap_info[0] )


### PR DESCRIPTION
'login' parameter was passed as a text to User.create in LDAP mode.
This caused the following crash:

[db7618b9-c802-46c9-99c3-2d03fd9195a4] [30517:0.81] No user found in
database, creating [db7618b9-c802-46c9-99c3-2d03fd9195a4] [30517:0.81]
Email: name@xyz [db7618b9-c802-46c9-99c3-2d03fd9195a4] [30517:0.81] Name
: name
[db7618b9-c802-46c9-99c3-2d03fd9195a4] [30517:0.82]   Rendered
status.xml.builder (1.9ms)
[db7618b9-c802-46c9-99c3-2d03fd9195a4] [30517:0.83]   ^[[1m^[[35m
(0.2ms)^[[0m  BEGIN
[db7618b9-c802-46c9-99c3-2d03fd9195a4] [30517:0.83]   ^[[1m^[[36m
(0.4ms)^[[0m  ^[[1mROLLBACK^[[0m
[db7618b9-c802-46c9-99c3-2d03fd9195a4] [30517:0.83] Completed 500
Internal Server Error in 152ms [db7618b9-c802-46c9-99c3-2d03fd9195a4]
[30517:0.84] TypeError (can't cast Array to text):
  activerecord (4.0.3)
lib/active_record/connection_adapters/abstract/quoting.rb:76:in
`type_cast'
  activerecord (4.0.3) lib/active_record/validations/uniqueness.rb:60:in
`build_relation'
  activerecord (4.0.3) lib/active_record/validations/uniqueness.rb:22:in
`validate_each'
  activemodel (4.0.3) lib/active_model/validator.rb:153:in`block in
validate'
  activemodel (4.0.3) lib/active_model/validator.rb:150:in `each'
  activemodel (4.0.3) lib/active_model/validator.rb:150:in`validate'
  activesupport (4.0.3) lib/active_support/callbacks.rb:283:in
`_callback_before_60'
  activesupport (4.0.3) lib/active_support/callbacks.rb:497:in
`_run__4016273609476760183__validate__callbacks'
  activesupport (4.0.3) lib/active_support/callbacks.rb:80:in
`run_callbacks'
  activemodel (4.0.3) lib/active_model/validations.rb:373:in
`run_validations!'
  activemodel (4.0.3) lib/active_model/validations/callbacks.rb:106:in
`block in run_validations!'
  activesupport (4.0.3) lib/active_support/callbacks.rb:383:in
`_run__4016273609476760183__validation__callbacks'
  activesupport (4.0.3) lib/active_support/callbacks.rb:80:in
`run_callbacks'
  activemodel (4.0.3) lib/active_model/validations/callbacks.rb:106:in
`run_validations!'
  activemodel (4.0.3) lib/active_model/validations.rb:314:in `valid?'
  activerecord (4.0.3) lib/active_record/validations.rb:70:in`valid?'
  activerecord (4.0.3) lib/active_record/validations.rb:77:in
`perform_validations'
  activerecord (4.0.3) lib/active_record/validations.rb:51:in`save'
  activerecord (4.0.3)
lib/active_record/attribute_methods/dirty.rb:32:in `save'
  activerecord (4.0.3) lib/active_record/transactions.rb:270:in`block
(2 levels) in save'
  activerecord (4.0.3) lib/active_record/transactions.rb:326:in `block
in with_transaction_returning_status'
  activerecord (4.0.3)
lib/active_record/connection_adapters/abstract/database_statements.rb:202:in
`block in transaction'
  activerecord (4.0.3)
lib/active_record/connection_adapters/abstract/database_statements.rb:210:in
`within_new_transaction'
  activerecord (4.0.3)
lib/active_record/connection_adapters/abstract/database_statements.rb:202:in
`transaction'
  activerecord (4.0.3) lib/active_record/transactions.rb:209:in
`transaction'
  activerecord (4.0.3) lib/active_record/transactions.rb:323:in
`with_transaction_returning_status'
  activerecord (4.0.3) lib/active_record/transactions.rb:270:in `block
in save'
  activerecord (4.0.3) lib/active_record/transactions.rb:281:in
`rollback_active_record_state!'
  activerecord (4.0.3) lib/active_record/transactions.rb:269:in `save'
  activerecord (4.0.3) lib/active_record/persistence.rb:37:in`create'
  app/controllers/application_controller.rb:123:in `extract_ldap_user'
  app/controllers/application_controller.rb:242:in`extract_user'
  activesupport (4.0.3) lib/active_support/callbacks.rb:407:in
`_run__4089627648474487359__process_action__callbacks'
  activesupport (4.0.3) lib/active_support/callbacks.rb:80:in
`run_callbacks'
  actionpack (4.0.3) lib/abstract_controller/callbacks.rb:17:in
`process_action'
  actionpack (4.0.3) lib/action_controller/metal/rescue.rb:29:in
`process_action'

Signed-off-by: Ed Bartosh eduard.bartosh@intel.com
