### PR TITLE
[backend] Create SRCSRV_SERVICE_FAIL notification if source service fail...

### DIFF
--- a/src/api/app/models/event/package.rb
+++ b/src/api/app/models/event/package.rb
@@ -71,4 +71,22 @@ module Event
     payload_keys :project, :package, :comment, :filename, :requestid, :target, :user
   end
 
+  class ServiceFail < Package
+    self.raw_type = 'SRCSRV_SERVICE_FAIL'
+    self.description = 'Package souce service has failed'
+    payload_keys :comment, :error, :package, :project, :rev, :user
+    receiver_roles :maintainer, :bugowner
+
+    def subject
+      "Source service failure of #{payload['project']}/#{payload['package']}"
+    end
+
+    def custom_headers
+      h = super
+      h['X-OBS-Package'] = "#{payload['project']}/#{payload['package']}"
+      h
+    end
+
+  end
+
 end

--- a/src/api/test/fixtures/events.yml
+++ b/src/api/test/fixtures/events.yml
@@ -17,6 +17,15 @@ build_failure_for_iggy:
   created_at: 2013-08-31 14:56:52.000000000 Z
   updated_at: 2013-08-31 14:56:52.000000000 Z
   project_logged: 0
+service_failure_for_iggy:
+  id: 18
+  eventtype: Event::ServiceFail
+  payload: '{"project":"home:Iggy","package":"TestPack","rev":"2","comment":"trigger service run","error":"service daemon error:\n400 remote error: /usr/lib/obs/service//not_existing  No such file or directory","user":"Admin"}'
+  queued: 0
+  lock_version: 0
+  created_at: 2013-08-31 14:56:52.000000000 Z
+  updated_at: 2013-08-31 14:56:52.000000000 Z
+  project_logged: 0
 build_success_from_deleted_project:
   id: 2
   eventtype: Event::BuildSuccess

--- a/src/api/test/models/event_test.rb
+++ b/src/api/test/models/event_test.rb
@@ -130,4 +130,15 @@ end
 
     assert_equal %w(Iggy), users_for_event(events(:build_failure_for_iggy))
   end
+
+  test 'maintainer mails for source service fail' do
+    # for this test we don't want fixtures to interfere
+    EventSubscription.delete_all
+
+    # just one subsciption
+    EventSubscription.create eventtype: 'Event::ServiceFail', receiver_role: :maintainer, user: users(:Iggy)
+
+    assert_equal %w(Iggy), users_for_event(events(:service_failure_for_iggy))
+  end
+
 end

--- a/src/backend/bs_srcserver
+++ b/src/backend/bs_srcserver
@@ -367,6 +367,19 @@ sub addrev_service {
     mkdir_p($treedir);
     if ($error) {
       writestr("$treedir/.$srcmd5-_serviceerror", "$treedir/$srcmd5-_serviceerror", "$error\n");
+
+      my $user = $cgi->{'user'};
+      my $comment = $cgi->{'comment'};
+      my $requestid = $cgi->{'requestid'};
+      $user = '' unless defined $user;
+      $user = 'unknown' if $user eq '';
+      $user = str2utf8xml($user);
+      $comment = '' unless defined $comment;
+      $comment = str2utf8xml($comment);
+      notify('SRCSRV_SERVICE_FAIL', {project => $projid, package => $packid,
+                                     error => $error, rev => $rev->{'rev'},
+                                     user => $user, comment => $comment,
+                                     'requestid' => $requestid});
     } else {
       return if -e "$treedir/$srcmd5-MD5SUMS";	# huh? why did we run twice?
       my $meta = '';


### PR DESCRIPTION
...s

A source service failure is similar to a build failure so bs_srcserver
should generate a notification event in this case.

Signed-off-by: Jan Blunck jblunck@infradead.org
