### PR TITLE
bs_sched: Don't block repository updates if a repository is set to never...

### DIFF
--- a/src/backend/bs_sched
+++ b/src/backend/bs_sched
@@ -9013,7 +9013,7 @@ NEXTPRP:
     }
 
     # we always publish kiwi...
-    if ((!%unfinished && !$ctx->{'havedelayed'}) || $prptype eq 'kiwi') {
+    if ((!%unfinished && !$ctx->{'havedelayed'}) || $prptype eq 'kiwi' || ($repo->{'block'} && $repo->{'block'} eq 'never')) {
       my $locked = 0;
       $locked = enabled($repoid, $projpacks->{$projid}->{'lock'}, $locked) if $projpacks->{$projid}->{'lock'};
       my $pubenabled = enabled($repoid, $projpacks->{$projid}->{'publish'}, 1);


### PR DESCRIPTION
... block

In case repository scheduling is set to never block, delaying the
publishing of freshly build packages (to ensure a consistent state) does
not make much sense. So in that case, publish the repository
straight after build.
