### PR TITLE
Some LDAP refactoring and fallback to User Principal Name if no email address is found

### DIFF
--- a/src/api/test/unit/user_ldap_strategy_test.rb
+++ b/src/api/test/unit/user_ldap_strategy_test.rb
@@ -38,7 +38,26 @@ class UserLdapStrategyTest < ActiveSupport::TestCase
     assert a == false
     a = UserLdapStrategy.authenticate_with_local("test", test_entry)
     assert a == true
+  end
 
+  def test_dn2user_principal_name
+    a = UserLdapStrategy.dn2user_principal_name(["uid=jdoe", "ou=People", "dc=opensuse", "dc=org"])
+    assert a == "jdoe@opensuse.org"
+
+    a = UserLdapStrategy.dn2user_principal_name(["uid=jdoe,ou=People, dc=opensuse,dc=org"])
+    assert a == "jdoe@opensuse.org"
+
+    a = UserLdapStrategy.dn2user_principal_name("uid=jdoe,ou=People, dc=opensuse,dc=org")
+    assert a == "jdoe@opensuse.org"
+
+    a = UserLdapStrategy.dn2user_principal_name("uid=jdoe, dc=opensuse,dc=org")
+    assert a == "jdoe@opensuse.org"
+
+    a = UserLdapStrategy.dn2user_principal_name(" dc=opensuse,dc=org")
+    assert a.empty?
+
+    a = UserLdapStrategy.dn2user_principal_name([" dc=opensuse,dc=org"])
+    assert a.empty?
   end
 
 end


### PR DESCRIPTION
Some refactorings related to how the LDAP authentication works (first authenticate then gather information).

Some LDAP servers do not explicitly expose a mail attribute. Therefore we use the User Principal Name as an email address if we are not able to use the attribute define by ldap_mail_attr.
