### PR TITLE
Add cpu type flag

### DIFF
--- a/src/backend/BSXML.pm
+++ b/src/backend/BSXML.pm
@@ -706,6 +706,7 @@ our $worker = [
       [ 'hardware' =>
         [ 'cpu' =>
           [ 'flag' ],
+          [ 'kind' ],
         ],
         'processors',
 	'memory',	# in MBytes

--- a/src/backend/bs_worker
+++ b/src/backend/bs_worker
@@ -651,6 +651,10 @@ my $workerenvstate = {};
       if (/^processor/s) {
         $hw->{'processors'} = $hw->{'processors'} + 1;
       }
+      elsif (/cpu[\s]*:\s(.*)$/) {
+        (my $cpukind) = ($1 =~ /\A(.*?) /);
+        $hw->{'cpu'}->{'kind'} = $cpukind;
+      }
       elsif (/^flags[\s]*:\s(.*)$/) {
         my @cpuflags = split(' ', $1);
         $hw->{'cpu'}->{'flag'} = \@cpuflags;


### PR DESCRIPTION
Somtimes it is required to have an ability to schedule a job into
specific CPU generation. Like build of SLE12 ppc64le is only possible on
Power8 cpus and newer.

Signed-off-by: Dinar Valeev <dvaleev@suse.com>