### PR TITLE
Make _log viewable within Firefox

### DIFF
--- a/src/api/app/controllers/application_controller.rb
+++ b/src/api/app/controllers/application_controller.rb
@@ -374,6 +374,7 @@ class ApplicationController < ActionController::Base
       end
     end
     opts[:length] = @volleyfile.length
+    opts[:disposition] = 'inline' if opts[:type] == 'text/plain'
     # streaming makes it very hard for test cases to verify output
     opts[:stream] = false if Rails.env.test?
     send_file(@volleyfile.path, opts)


### PR DESCRIPTION
Without this fix, text files such as _log are served with `Content-Disposition: attachment`, which makes Firefox prompt the user to download the file rather than simply showing the text within the browser.