### PR TITLE
[webui] Use 'Liberation Mono' font for code blocks

### DIFF
--- a/src/api/app/assets/stylesheets/webui/application/cm2/suse.css.scss
+++ b/src/api/app/assets/stylesheets/webui/application/cm2/suse.css.scss
@@ -1,4 +1,5 @@
 .CodeMirror {
+  font-family: "Liberation Mono", monospace;
   font-size: 9pt;
   height: auto;
 }


### PR DESCRIPTION
Firefox has trouble rendering underlines with the default monospace font (DejaVu Sans Mono) on some systems.