### PR TITLE
[api] Don't raise error if password is empty and LDAP mode is on

### DIFF
--- a/src/api/app/controllers/application_controller.rb
+++ b/src/api/app/controllers/application_controller.rb
@@ -95,6 +95,9 @@ class ApplicationController < ActionController::Base
   end
 
   def extract_ldap_user
+    # Reject empty passwords to prevent LDAP lockouts.
+    return if @passwd.blank?
+
     begin
       require 'ldap'
       logger.debug( "Using LDAP to find #{@login}" )
@@ -241,11 +244,6 @@ class ApplicationController < ActionController::Base
       extract_basic_auth_user
 
       if CONFIG['ldap_mode'] == :on
-        # disallow empty passwords to prevent LDAP lockouts
-        if @passwd.blank?
-          raise AuthenticationRequiredError.new "User '#{@login}' did not provide a password"
-        end
-
         extract_ldap_user
       end
 


### PR DESCRIPTION
Without this fix, the user is not allowed to perform actions even if subsequent user checks would have succeeded.