### PR TITLE
A new attribute: LockedBy

### DIFF
--- a/src/api/db/attribute_descriptions.rb
+++ b/src/api/db/attribute_descriptions.rb
@@ -23,6 +23,7 @@ def update_all_attrib_type_descriptions
     "IncidentPriority" => "A numeric value which defines the importance of this incident project.",
     "EmbargoDate" => "A timestamp until outgoing requests can not get accepted.",
     "MakeOriginOlder" => "Initialize packages by making the build results newer then updated ones",
+    "LockedBy" => "Gives a hint to other users that a contributor is performing tasks that take some time while others should not act on the same project",
   }
   
   for k in d.keys do


### PR DESCRIPTION
We're looking for a very simple 'locking' mechanism for osc-plugin-factory.

The idea is that the script as first sets the lock to the maintainer working on it, re-reads it to ensure it could get it and then performs its task.

There are several script actions that have quite some strange effects if multiple things happen in parallel.

I'm absolutely not sure if this is all that's needed to get a new Attribute.