### PR TITLE
[api] Fix to work when hosted in non-root server directory.

### DIFF
--- a/src/api/app/controllers/application_controller.rb
+++ b/src/api/app/controllers/application_controller.rb
@@ -394,6 +394,7 @@ class ApplicationController < ActionController::Base
   def get_request_path
     path = request.path
     query_string = request.query_string
+    path.slice!( 0, root_path.length-1 ) if path.start_with?( root_path )
     if request.form_data?
       # it's uncommon, but possible that we have both
       query_string += "&" unless query_string.blank?
@@ -405,7 +406,11 @@ class ApplicationController < ActionController::Base
 
   def pass_to_backend( path = nil )
 
-    path ||= get_request_path
+    if path
+      path.slice!( 0, root_path.length-1 ) if path.start_with?( root_path )
+    else
+      path = get_request_path
+    end
 
     if request.get? || request.head?
       forward_from_backend( path )

--- a/src/api/app/views/layouts/webui/webui.html.erb
+++ b/src/api/app/views/layouts/webui/webui.html.erb
@@ -6,7 +6,7 @@
     <meta name="robots" content="<%= @metarobots %>"/>
     <% end %>
 
-    <link href="<%= CONFIG['relative_url_root'] %>/favicon.ico" rel="shortcut icon" />
+    <link href="<%= root_path %>/favicon.ico" rel="shortcut icon" />
 
     <title><%= "#{@pagetitle} - " if @pagetitle -%><%= @configuration ? @configuration['title'] : 'Open Build Service' %></title>
 

--- a/src/api/config/initializers/activexml.rb
+++ b/src/api/config/initializers/activexml.rb
@@ -1,6 +1,7 @@
 require_dependency 'activexml/activexml'
 
 CONFIG['source_protocol'] ||= 'http'
+CONFIG['api_relative_url_root'] ||= ''
 
 map = ActiveXML::setup_transport_backend(CONFIG['source_protocol'], CONFIG['source_host'], CONFIG['source_port'])
 
@@ -32,7 +33,7 @@ if defined?(Rack::MiniProfiler)
   end
 end
 
-map = ActiveXML::setup_transport_api(CONFIG['frontend_protocol'], CONFIG['frontend_host'], CONFIG['frontend_port'])
+map = ActiveXML::setup_transport_api(CONFIG['frontend_protocol'], CONFIG['frontend_host'], CONFIG['frontend_port'], CONFIG['api_relative_url_root'])
 
 map.connect :webuiproject, 'rest:///source/:name/_meta?:view',
     :delete => 'rest:///source/:name?:force',

--- a/src/api/config/options.yml.example
+++ b/src/api/config/options.yml.example
@@ -27,6 +27,7 @@ source_port: 5352
 frontend_host: localhost
 frontend_port: 443
 frontend_protocol: https
+#api_relative_url_root: /obs
 # if your users access the hosts through a proxy (or just a different name, use this to
 # overwrite the settings for users)
 #external_frontend_host: api.opensuse.org

--- a/src/api/lib/activexml/transport.rb
+++ b/src/api/lib/activexml/transport.rb
@@ -3,8 +3,8 @@ module ActiveXML
     @@transport_api
   end
 
-  def self.setup_transport_api(schema, host, port)
-    @@transport_api = Transport.new(schema, host, port)
+  def self.setup_transport_api(schema, host, port, prefix='')
+    @@transport_api = Transport.new(schema, host, port, prefix)
   end
 
   def self.backend
@@ -110,10 +110,11 @@ module ActiveXML
       @mapping[model][:opt]
     end
 
-    def initialize( schema, host, port )
+    def initialize( schema, host, port, prefix='' )
       @schema = schema
       @host = host
       @port = port
+      @prefix = prefix
       @default_servers ||= Hash.new
       @http_header = {"Content-Type" => "text/plain", 'Accept-Encoding' => 'identity'}
       # stores mapping information
@@ -329,7 +330,7 @@ module ActiveXML
         @http.read_timeout = opt[:timeout]
 
         raise "url.path.nil" if url.path.nil?
-        path = url.path
+        path = @prefix + url.path
         path += "?" + url.query if url.query
         logger.debug "http_do: method: #{method} url: " +
         "http#{"s" if @http.use_ssl?}://#{url.host}:#{url.port}#{path}"


### PR DESCRIPTION
This change allows OBS API and WebUI to be installed on a web server
in a place other than document root, so its URL prefix has a non-empty
pathname (like https://example.com/obs instead of https://obs.example.com).

This is useful for those who can't have OBS and main site on
different domains and buy separate X.509 certificates for them,
or just can't afford to have separate IP addresses for them
(please note that currently osc doesn't support TLS SNI).

Signed-off-by: Oleg Girko <ol@infoserver.lv>