### PR TITLE
[api] Better fix to work when hosted in non-root server directory.

### DIFF
--- a/src/api/app/controllers/application_controller.rb
+++ b/src/api/app/controllers/application_controller.rb
@@ -393,9 +393,8 @@ class ApplicationController < ActionController::Base
   end
 
   def get_request_path
-    path = request.path
+    path = request.path_info
     query_string = request.query_string
-    path.slice!( 0, root_path.length-1 ) if path.start_with?( root_path )
     if request.form_data?
       # it's uncommon, but possible that we have both
       query_string += "&" unless query_string.blank?
@@ -407,11 +406,7 @@ class ApplicationController < ActionController::Base
 
   def pass_to_backend( path = nil )
 
-    if path
-      path.slice!( 0, root_path.length-1 ) if path.start_with?( root_path )
-    else
-      path = get_request_path
-    end
+    path ||= get_request_path
 
     if request.get? || request.head?
       forward_from_backend( path )

--- a/src/api/app/controllers/build_controller.rb
+++ b/src/api/app/controllers/build_controller.rb
@@ -152,7 +152,7 @@ class BuildController < ApplicationController
       return
     end
 
-    path = request.path+"?"+request.query_string
+    path = request.path_info+"?"+request.query_string
 
     if request.delete?
       unless permissions.project_change? params[:project]

--- a/src/api/app/controllers/public_controller.rb
+++ b/src/api/app/controllers/public_controller.rb
@@ -54,8 +54,8 @@ class PublicController < ApplicationController
     # project visible/known ? 
     Project.get_by_name(params[:project])
 
-    path = unshift_public(request.path)
-    path << "?#{request.query_string}" unless request.query_string.empty?
+    path = unshift_public(request.path_info)
+    path += "?#{request.query_string}" unless request.query_string.empty?
 
     pass_to_backend path
   end
@@ -65,14 +65,14 @@ class PublicController < ApplicationController
     # project visible/known ? 
     Project.get_by_name(params[:project])
 
-    pass_to_backend unshift_public(request.path)
+    pass_to_backend unshift_public(request.path_info)
   end
 
   # GET /public/source/:project
   def project_index
     # project visible/known ? 
     Project.get_by_name(params[:project])
-    path = unshift_public(request.path)
+    path = unshift_public(request.path_info)
     if params[:view] == 'info'
       # nofilename since a package may have no source access
       if params[:nofilename] and params[:nofilename] != '1'
@@ -94,7 +94,7 @@ class PublicController < ApplicationController
     # project visible/known ? 
     Project.get_by_name(params[:project])
 
-    path = unshift_public(request.path)
+    path = unshift_public(request.path_info)
     path += "?#{request.query_string}" unless request.query_string.empty?
     pass_to_backend path
   end
@@ -103,7 +103,7 @@ class PublicController < ApplicationController
   def package_index
     check_package_access(params[:project], params[:package])
 
-    path = unshift_public(request.path)
+    path = unshift_public(request.path_info)
     path += "?#{request.query_string}" unless request.query_string.empty?
     pass_to_backend path
   end
@@ -112,7 +112,7 @@ class PublicController < ApplicationController
   def package_meta
     check_package_access(params[:project], params[:package], false)
 
-    pass_to_backend unshift_public(request.path)
+    pass_to_backend unshift_public(request.path_info)
   end
 
   # GET /public/source/:project/:package/:filename


### PR DESCRIPTION
This partially reverts commit 5eb11ac98543449f59e09b55e6b801878670c00a
and implements more correct handling of hosting
under non-root server pathname prefix.

Instead of removing prefix from full path obtained from request.path,
this change uses request.path_info which does not contain prefix at all.

Also, << operator used to append to obtained path was replaced with +=
because unlike request.path which returns newly constructed string,
request.path_info returns reference to environvent variable,
so << operator appends to this environment variable, whereas += operator
works on newly constructed string.

Besides using more efficient way to obtain path without prefix,
this change also fixes some cases which were not handled
by the previous approach.

Signed-off-by: Oleg Girko <ol@infoserver.lv>