### PR TITLE
Fix LDAP first login

### DIFF
--- a/src/api/app/controllers/webui/user_controller.rb
+++ b/src/api/app/controllers/webui/user_controller.rb
@@ -38,10 +38,10 @@ class Webui::UserController < Webui::WebuiController
       session[:password] = params[:password]
       authenticate_form_auth
 
-      # TODO: remove again and use
-      User.current = User.where(login: session[:login]).first
       begin
         ActiveXML.api.direct_http "/person/#{session[:login]}/login", method: 'POST'
+        # TODO: remove again and use
+        User.current = User.where(login: session[:login]).first
       rescue ActiveXML::Transport::UnauthorizedError
         User.current = nil
       end


### PR DESCRIPTION
When using the LDAP mode, first login gives authentication error, because the user is created during the person=>login API call and thus the "User.current" here remains nil. Moving the assignment after the API call seems to fix the problem.

I'm not sure about the meaning of the "TODO"-comment, so maybe this is not inline with some other plans.