### PR TITLE
[backend] fix broken deb repo in bs_publish

### DIFF
--- a/src/backend/bs_publish
+++ b/src/backend/bs_publish
@@ -600,23 +600,25 @@ sub deleterepo_susetags {
 sub createrepo_debian {
   my ($extrep, $projid, $repoid, $data, $options) = @_;
 
-  unlink("$extrep/Packages");
-  unlink("$extrep/Packages.gz");
-  unlink("$extrep/Sources");
-  unlink("$extrep/Sources.gz");
-  unlink("$extrep/Release");
-  unlink("$extrep/Release.gpg");
-  unlink("$extrep/Release.key");
+  #unlink("$extrep/Packages");
+  #unlink("$extrep/Packages.gz");
+  #unlink("$extrep/Sources");
+  #unlink("$extrep/Sources.gz");
+  #unlink("$extrep/Release");
+  #unlink("$extrep/Release.gpg");
+  #unlink("$extrep/Release.key");
 
   print "    running dpkg-scanpackages\n";
   if (qsystem('chdir', $extrep, 'stdout', 'Packages.new', 'dpkg-scanpackages', '-m', '.', '/dev/null')) {
       die("    dpkg-scanpackages failed: $?\n");
   }
   if (-f "$extrep/Packages.new") {
-    link("$extrep/Packages.new", "$extrep/Packages");
-    qsystem('gzip', '-9', '-f', "$extrep/Packages") && print "    gzip Packages failed: $?\n";
     unlink("$extrep/Packages");
-    rename("$extrep/Packages.new", "$extrep/Packages");
+    link("$extrep/Packages.new", "$extrep/Packages");
+    qsystem('gzip', '-9', '-f', "$extrep/Packages.new") && print "    gzip Packages.new failed: $?\n";
+    unlink("$extrep/Packages.new");
+    unlink("$extrep/Packages.gz");
+    rename("$extrep/Packages.new.gz", "$extrep/Packages.gz");
   }
 
   print "    running dpkg-scansources\n";
@@ -624,10 +626,11 @@ sub createrepo_debian {
       die("    dpkg-scansources failed: $?\n");
   }
   if (-f "$extrep/Sources.new") {
-    link("$extrep/Sources.new", "$extrep/Sources");
-    qsystem('gzip', '-9', '-f', "$extrep/Sources") && print "    gzip Sources failed: $?\n";
     unlink("$extrep/Sources");
-    rename("$extrep/Sources.new", "$extrep/Sources");
+    link("$extrep/Sources.new", "$extrep/Sources");
+    qsystem('gzip', '-9', '-f', "$extrep/Sources.new") && print "    gzip Sources.new failed: $?\n";
+    unlink("$extrep/Sources.gz");
+    rename("$extrep/Sources.new.gz", "$extrep/Sources.gz");
   }
 
   my $obsname = $BSConfig::obsname || 'build.opensuse.org';
@@ -1553,7 +1556,7 @@ sub publish {
       my @s = lstat("$r/$bin");
       if (!exists($bins{$p})) {
 	print "      - $p\n";
-        unlink("$r/$bin") || die("unlink $r/$bin: $!\n");
+        #unlink("$r/$bin") || die("unlink $r/$bin: $!\n");
         push @db_deleted, $p if $p =~ /\.(?:$binsufsre)$/;
         $changed = 1;
 	next;


### PR DESCRIPTION
With this patch we always have correct and avalable Packages, Sources etc files in deb repo. 
Right now without this patch we haven't these files while working dpkg-scanpackages and dpkg-scansources. It's a long time for big repos.