### PR TITLE
[backend] fixed corner case in keeplink

### DIFF
--- a/src/backend/bs_srcserver
+++ b/src/backend/bs_srcserver
@@ -5374,9 +5374,10 @@ sub keeplink {
   for my $file (sort keys %{{%$files, %$ofiles}}) {
     if ($ofiles->{$file}) {
       if (!$files->{$file}) {
-	if (!$ltgtfiles->{$file} && $ofilesl->{$file} && $ofilesl->{$file} eq ($ofiles->{$file} || '')) {
+	if (!$ltgtfiles->{$file}) {
 	  # local file no longer needed
 	  delete $nfiles->{$file};
+	  next;
 	}
 	push @dfiles, $file;
 	delete $nfiles->{$file};


### PR DESCRIPTION
Assume we have two packages "lnk" and "foo", where "lnk" is a a plain
link to "foo". Moreover, let "foobar" denote a file that neither exists
in "lnk" nor "foo".
Consider the following commits:
- add "foobar" to the expanded sources of "lnk" and commit (keeplink=1)
- remove "foobar" from the expanded sources of "lnk" and commit (keeplink=1)
- add "foobar" to the sources of the package "foo" and commit

At this point, "foobar" should be part of the expanded sources of "lnk".