### PR TITLE
[backend] AArch64 can not actually build armv7l

### DIFF
--- a/src/backend/BSCando.pm
+++ b/src/backend/BSCando.pm
@@ -31,12 +31,12 @@ package BSCando;
 #FIXME 3.0: obsolete the not exiting arm architectures
 
 our %cando = (
-  'aarch64' => [ 'aarch64', 'armv4l', 'armv5l', 'armv6l', 'armv7l', 'armv5el', 'armv6el', 'armv6hl', 'armv7el', 'armv7hl' ],
-
+  'aarch64' => [ 'aarch64', 'armv8l' ], # armv8l is aarch32 (32-bit mode of aarch64), not a full subset of armv7l
   'armv4l'  => [ 'armv4l'                                                                                                 ],
   'armv5l'  => [ 'armv4l', 'armv5l'                    , 'armv5el'                                                        ],
   'armv6l'  => [ 'armv4l', 'armv5l', 'armv6l'          , 'armv5el', 'armv6el'                                             ],
   'armv7l'  => [ 'armv4l', 'armv5l', 'armv6l', 'armv7l', 'armv5el', 'armv6el', 'armv6hl', 'armv7el', 'armv7hl', 'armv8el' ], # this armv8el is just for MeeGo, it does not exist for real
+  'armv8l'  => [ 'armv8l' ],
 
   'sh4'     => [ 'sh4' ],
 


### PR DESCRIPTION
the 32bit mode of AArch64 is armv8l (aarch32). This is a subset of armv7l,
which means there are things that can not run on a aarch64 host.
Even worse, there is hardware that does not even have a 32bit mode.

This reverts effc064f.