### PR TITLE
[backend] Fix finding the host specific bsconfig.* if CWD is not /usr/li...

### DIFF
--- a/src/backend/BSConfig.pm.template
+++ b/src/backend/BSConfig.pm.template
@@ -24,6 +24,7 @@ package BSConfig;
 
 use Net::Domain;
 use Socket;
+use File::Basename qw(dirname);
 
 my $hostname = Net::Domain::hostfqdn() || 'localhost';
 # IP corresponding to hostname (only used for $ipaccess); fallback to localhost since inet_aton may fail to resolve at shutdown.
@@ -198,7 +199,7 @@ our $relsync_pool = {
 
 # host specific configs
 my $hostconfig = "bsconfig." . $hostname;
-if(-r $hostconfig) {
+if(-r join('/', dirname(__FILE__), $hostconfig)) {
   print "reading $hostconfig...\n";
   require $hostconfig;
 }


### PR DESCRIPTION
...b/obs/server

Cherry-pick from master-branch.

Some processes do not start up with the correct configuration in cases
bsconfig.$hostname is used. The problem is that the test for the host
specific configuration file uses the current working directory instead of
the path that BSConfig.pm is in.

Signed-off-by: Jan Blunck <jblunck@infradead.org>