### PR TITLE
Modify the publisher to create virt-builder images source site.

### DIFF
--- a/src/backend/bs_publish
+++ b/src/backend/bs_publish
@@ -513,6 +513,25 @@ sub deleterepo_rpmmd {
   unlink("$extrep/$projid.repo");
 }
 
+sub createrepo_virtbuilder {
+  my ($extrep, $projid, $repoid, $data) = @_;
+
+  # cleanup
+  unlink("$extrep/index.key");
+  unlink("$extrep/index.asc");
+
+  # Sign the index
+  if ($BSConfig::sign && -e "$extrep/index") {
+    my @signargs;
+    print "Signing the index for $projid/$repoid\n";
+    push @signargs, '--project', $projid if $BSConfig::sign_project;
+    push @signargs, @{$data->{'signargs'} || []};
+    print "Running command: $BSConfig::sign @signargs -c $extrep/index\n";
+    qsystem($BSConfig::sign, @signargs, '-c', "$extrep/index") && die("    sign failed: $?\n");
+    writestr("$extrep/index.key", undef, $data->{'pubkey'}) if $data->{'pubkey'};
+  }
+}
+
 sub createrepo_hdlist2 {
   my ($extrep, $projid, $repoid, $data, $options) = @_;
 
@@ -775,7 +794,7 @@ sub createrepo_staticlinks {
       } elsif (/^(.*)-(\d+\.\d+\.\d+)-Build\d+\.\d+([-\.].*\.(gz|bz2|tbz|tgz|xz)?(?:\.sha256)?)$/s) {
         $link = "$1$3";
         $link = "$1-$2$3" if $versioned;
-      } elsif (/^(.*)-(\d+\.\d+\.\d+)-Build\d+\.\d+(\.(raw.install.raw.xz|raw.xz|box|json|install.iso|tbz|tgz|vmx|vmdk|iso|qcow2|ova)?(?:\.sha256)?)$/s) {
+      } elsif (/^(.*)-(\d+\.\d+\.\d+)-Build\d+\.\d+(\.(raw.install.raw.xz|raw.xz|box|json|install.iso|tbz|tgz|vmx|vmdk|iso|qcow2|qcow2.xz|ova)?(?:\.sha256)?)$/s) {
         $link = "$1$3";
         $link = "$1-$2$3" if $versioned;
       }
@@ -1303,6 +1322,7 @@ sub publish {
 
   my %kiwireport;	# store collected report (under the original name)
   my %kiwimedium;	# maps published name to original name
+  my $kiwiindex;	# store collected index parts
 
   if ($archorder) {
     my %archorder = map {$_ => 1} @$archorder;
@@ -1422,12 +1442,16 @@ sub publish {
 	  $p = "$bin";
 	} elsif ($bin =~ /\.dsc(?:\.sha256)?$/) {
 	  $p = "$bin";
-	} elsif ($bin =~ /\.(?:box|json|ovf|qcow2|vmx|vmdk)(?:\.sha256)?$/) {
+	} elsif ($bin =~ /\.(?:box|json|ovf|qcow2|qcow2\.xz|vmx|vmdk)(?:\.sha256)?$/) {
 	  $p = "$bin";
         } elsif ($bin =~ /^(.*)\.report$/) {
 	  # collect kiwi reports
 	  $kiwireport{$1} = readxml("$r/$rbin", $BSXML::report, 1);
 	  next;
+    } elsif ($bin =~ /^(.*)\.index$/) {
+      # collect virt-builder index parts
+      $kiwiindex .= readstr("$r/$bin", 1) . "\n";
+      next;
 	} elsif (-d "$r/$rbin") {
 	  $p = "repo/$bin";
 	  if ($repotype{'slepool'}) {
@@ -1663,6 +1687,13 @@ sub publish {
     }
     push @db_changed, $p if $p =~ /\.(?:$binsufsre)$/;
     push @changed, $p;
+    $changed = 1;
+  }
+
+  # Write the kiwi index file if we got it
+  if (length $kiwiindex) {
+    writestr("$extrep/index", undef, $kiwiindex);
+    push @changed, "$extrep/index";
     $changed = 1;
   }
 
@@ -1992,6 +2023,10 @@ sub publish {
     deletepatterns_comps($extrep, $projid, $xrepoid, $data);
   }
 
+  # virt-builder repository
+  if (-e "$extrep/index") {
+    createrepo_virtbuilder($extrep, $projid, $xrepoid, $data);
+  }
 
 publishprog_done:
   unlink("$uploaddir/publisher.$$") if $signkey;


### PR DESCRIPTION
The virt-builder images source site structure is described in
http://libguestfs.org/virt-builder.1.html#create-the-templates and
following.

This commit allows publishing of qcow2.xz files as virt-builder site
requires the images to be xz-compressed. It also creates the signed
index from .index files found in the repository. Those files can
typically be created using a kiwi_post_run hook.