### PR TITLE
Basic support for simpleimage

### DIFF
--- a/src/backend/bs_publish
+++ b/src/backend/bs_publish
@@ -66,7 +66,7 @@ my $extrepodb = "$BSConfig::bsdir/db/published";
 
 my $myeventdir = "$eventdir/publish";
 
-my @binsufs = qw{rpm deb pkg.tar.gz pkg.tar.xz};
+my @binsufs = qw{rpm deb pkg.tar.gz pkg.tar.xz tar.gz squashfs};
 my $binsufsre = join('|', map {"\Q$_\E"} @binsufs);
 my @binsufsrsync = map {"--include=*.$_"} @binsufs;
 

--- a/src/backend/bs_sched
+++ b/src/backend/bs_sched
@@ -62,7 +62,7 @@ $startupmode = $BSConfig::sched_startupmode if $BSConfig::sched_startupmode;
 
 my $bsdir = $BSConfig::bsdir || "/srv/obs";
 
-my @binsufs = qw{rpm deb pkg.tar.gz pkg.tar.xz};
+my @binsufs = qw{rpm deb pkg.tar.gz pkg.tar.xz tar.gz squashfs};
 my $binsufsre = join('|', map {"\Q$_\E"} @binsufs);
 
 BSUtil::mkdir_p_chown($bsdir, $BSConfig::bsuser, $BSConfig::bsgroup);
@@ -7028,6 +7028,11 @@ my %handlers = (
     'expand' => \&Build::get_deps,
     'check' => \&checkpreinstallimage,
     'rebuild' => \&rebuildpreinstallimage,
+  },
+  'simpleimage' => {
+    'expand' => \&Build::get_deps,
+    'check' => \&checkpackage,
+    'rebuild' => \&rebuildpackage,
   },
   'channel' => {
     'expand' => \&no_expander,

--- a/src/backend/bs_srcserver
+++ b/src/backend/bs_srcserver
@@ -2707,6 +2707,7 @@ sub findfile {
   }
 
   return @{$files{'_preinstallimage'}} if $ext ne 'kiwi' && keys(%files) == 1 && $files{'_preinstallimage'};
+  return @{$files{'simpleimage'}} if $files{'simpleimage'};
 
   if ($ext eq 'arch') {
     return @{$files{'PKGBUILD'}} if $files{'PKGBUILD'};
@@ -3376,7 +3377,7 @@ sub getprojpack {
             my ($md5, $file) = findfile($rev, $repoid, $type, $files);
 	    if (!$md5) {
 	      # no spec/dsc/kiwi file found
-	      if ($files->{'_preinstallimage'} || grep {/\.(?:spec|dsc|kiwi)$/} keys %$files) {
+	      if ($files->{'_preinstallimage'} || $files->{'simpleimage'}  || grep {/\.(?:spec|dsc|kiwi)$/} keys %$files) {
 		# only different types available
 		$rinfo->{'error'} = 'excluded';
 	      }

--- a/src/backend/bs_worker
+++ b/src/backend/bs_worker
@@ -50,7 +50,7 @@ use BSCando;
 
 use strict;
 
-my @binsufs = qw{rpm deb pkg.tar.gz pkg.tar.xz};
+my @binsufs = qw{rpm deb pkg.tar.gz pkg.tar.xz tar.gz squashfs};
 my $binsufsre = join('|', map {"\Q$_\E"} @binsufs);
 
 my $buildroot;


### PR DESCRIPTION
Adding support for squashfs and tar.gz binaries and for simpleimage
build type.

Request for build update to support it sent separately:
https://github.com/openSUSE/obs-build/pull/166