### PR TITLE
bs_publish: RPM: Make writing the project public key and referencing …

### DIFF
--- a/src/backend/bs_publish
+++ b/src/backend/bs_publish
@@ -494,11 +494,14 @@ sub createrepo_rpmmd {
     print FILE "name=$title\n";
     print FILE "type=rpm-md\n";
     print FILE "baseurl=$BSConfig::repodownload/$prp_ext/\n";
-    print FILE "gpgcheck=1\n";
-    if (!@{$data->{'signargs'} || []}) {
-      print FILE "gpgkey=$BSConfig::gpg_standard_key\n" if defined $BSConfig::gpg_standard_key;
-    } else {
-      print FILE "gpgkey=$BSConfig::repodownload/$prp_ext/repodata/repomd.xml.key\n";
+    if ($BSConfig::sign) {
+      print FILE "gpgcheck=1\n";
+      if (-e "$extrep/repodata/repomd.xml.key") {
+        print FILE "gpgkey=$BSConfig::repodownload/$prp_ext/repodata/repomd.xml.key\n";
+      } else {
+        die("neither a project key is available nor gpg_standard_key is set\n") unless defined($BSConfig::gpg_standard_key);
+        print FILE "gpgkey=$BSConfig::gpg_standard_key\n";
+      }
     }
     print FILE "enabled=1\n";
     close(FILE) || die("close: $!\n");


### PR DESCRIPTION
…it in the .repo file consistent.

This commit fixes the following bug/situation:
- a global keyfile is defined (option "keyfile"), but no project-specific sign key exists
- the RPM repository will be published with the public key from the global keyfile
- the .repo does not reference this public key file with gpgkey= because the code only triggers if there is a project-specific sign key. Instead, for gpgkey= the "gpg_standard_key" config value will be written to the .repo file ("gpg_standard_key" usually points to a local file on the OBS host)

In the end, adding the repository using the .repo file will most likely fail because gpgkey= now contains a path to a local file which doesn't exist on the machine where the repository should be added. The solution is to reference the project's public key file when it was generated.

This commit also introduces two behavior changes:
- "gpgcheck=1" won't be added to the .repo file if signing was not configured
- when signing was configured, but "gpg_standard_key" was not configured, the .repo file did contain "gpgcheck=1", but not "gpgkey=". Now the publisher will fail.