### PR TITLE
bs_productconvert: match arch precisely

### DIFF
--- a/src/backend/bs_productconvert
+++ b/src/backend/bs_productconvert
@@ -615,7 +615,7 @@ sub groupToPackages( $$$$$ )
 		if( $p->{arch} ) {
 		    $takeIt = 0;
 		    foreach my $validArch( @validArchs ) {
-			if( grep( /$validArch/, @condArchs ) ) {
+			if( grep( /\b$validArch\b/, @condArchs ) ) {
 			    $takeIt = 1;
 			    last;
 			}


### PR DESCRIPTION
In case we have ppc64le in @condArchs, we don't want match ppc64 here,
as those two architectures are completely different.

Don't use regular expression, but match architecture precisely

Signed-off-by: Dinar Valeev <dvaleev@suse.com>