### PR TITLE
[backend] Don't start architectures "reading" and "bsconfig.$hostname…

### DIFF
--- a/dist/obsscheduler
+++ b/dist/obsscheduler
@@ -42,7 +42,7 @@ fi
 rundir="$OBS_RUN_DIR"
 logdir="$OBS_LOG_DIR"
 
-OBS_NEW_SCHEDULER_ARCHITECTURES=`$obsdir/bs_admin --show-scheduler-architectures`
+OBS_NEW_SCHEDULER_ARCHITECTURES=`$obsdir/bs_admin --show-scheduler-architectures 2>/dev/null`
 
 if test -n "$OBS_NEW_SCHEDULER_ARCHITECTURES" ; then
 	if test -n "$OBS_SCHEDULER_ARCHITECTURES" ; then

--- a/src/backend/BSConfig.pm.template
+++ b/src/backend/BSConfig.pm.template
@@ -200,7 +200,7 @@ our $relsync_pool = {
 my $hostconfig = __FILE__;
 $hostconfig =~ s/[^\/]*$/bsconfig.$hostname/;
 if (-r $hostconfig) {
-  print "reading $hostconfig...\n";
+  print STDERR "reading $hostconfig...\n";
   require $hostconfig;
 }
 


### PR DESCRIPTION
…..."

Since obsscheduler script is using bs_admin the informational output of
reading the bsconfig.$hostname is used as a scheduler architecture.