### PR TITLE
[backend] fix interconnect with disabled use_xforward

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,14 +220,7 @@ The obs-api package comes with an apache configuration file.
 /etc/apache2/vhosts.d/obs.conf
 ```
 
-6. Enable the xforward mode.
-<br>
-In */srv/www/obs/api/config/options.yml*:
-```
-use_xforward: true
-```
-
-7. Create a self-signed SSL certificate
+6. Create a self-signed SSL certificate
 ```
 mkdir /srv/obs/certs
 openssl genrsa -out /srv/obs/certs/server.key 1024
@@ -236,25 +229,25 @@ openssl x509 -req -days 365 -in /srv/obs/certs/server.csr -signkey /srv/obs/cert
 cat /srv/obs/certs/server.key /srv/obs/certs/server.crt > /srv/obs/certs/server.pem
 ```
 
-8. Trust this certificate on your host
+7. Trust this certificate on your host
 ```
 cp /srv/obs/certs/server.pem /etc/ssl/certs/
 c_rehash /etc/ssl/certs/
 ```
 
-9. Start the web server permanently
+8. Start the web server permanently
 ```
 systemctl enable apache2
 systemctl start apache2
 ```
 
-10. Start the OBS delayed job daemon
+9. Start the OBS delayed job daemon
 ```
 systemctl enable obsapidelayed.service
 systemctl start obsapidelayed.service
 ```
 
-11. Check out your OBS frontend
+10. Check out your OBS frontend
 By default, you can see the HTML views on port 443 (e.g: https://localhost) and the repos on port 82 (once some packages are built). The default admin user is "Admin" with the password "opensuse".
 
 #### Development

--- a/dist/README.SETUP
+++ b/dist/README.SETUP
@@ -215,11 +215,12 @@ If you change the hostnames/ips of the api, you need to adjust
 You should set "exception_recipients" to a valid mail address which
 should receive notification mail if the API hits any program exception.
 
-It is recommended to enable
+It is recommended to keep
 
   use_xforward: true
 
-as well here.
+enabled. For instance this is mandatory if your OBS gets interconnected
+with another OBS instance.
 
 
 3.2.3 Restart apache2

--- a/src/api/config/options.yml.example
+++ b/src/api/config/options.yml.example
@@ -5,7 +5,7 @@
 #read_only_hosts: [ "build.opensuse.org", "software.opensuse.org" ]
 
 # Make use of mod_xforward module in apache
-#use_xforward: true
+use_xforward: true
 
 # Make use of X-Accel-Redirect for Nginx.
 # http://kovyrin.net/2010/07/24/nginx-fu-x-accel-redirect-remote


### PR DESCRIPTION
OBS interconnect is not working without use_xforward. Without use_xforward
all RPC replies have Content-Type: chunked, which breaks builds/src-server
when fetching from interconnects build-dependencies.

If use_xforward is disabled the worker or src-server run in this rpc_error:
chunked decoder not implemented yet for non-receiver requests