### PR TITLE
Filtering latest updates

### DIFF
--- a/src/api/app/controllers/statistics_controller.rb
+++ b/src/api/app/controllers/statistics_controller.rb
@@ -154,8 +154,15 @@ class StatisticsController < ApplicationController
 
 
   def latest_updated
-    @limit = 10 unless @limit
-    @list = get_latest_updated(@limit)
+    if params[:timelimit].nil?
+      @timelimit = Time.at(0)
+    else
+      @timelimit = params[:timelimit].to_i.day.ago
+      # Override the default, since we want to limit by the time here.                                                                                                                                                                             
+      @limit = nil if params[:limit].nil?
+    end
+
+    @list = get_latest_updated(@limit,@timelimit)
   end
 
   def updated_timestamp

--- a/src/api/app/controllers/statistics_controller.rb
+++ b/src/api/app/controllers/statistics_controller.rb
@@ -154,6 +154,18 @@ class StatisticsController < ApplicationController
 
 
   def latest_updated
+    if params[:prjfilter].nil?
+      prj_filter = ".*"
+    else
+      prj_filter = params[:prjfilter]
+    end
+
+    if params[:pkgfilter].nil?
+      pkg_filter = ".*"
+    else
+      pkg_filter = params[:pkgfilter]
+    end
+
     if params[:timelimit].nil?
       @timelimit = Time.at(0)
     else
@@ -162,7 +174,7 @@ class StatisticsController < ApplicationController
       @limit = nil if params[:limit].nil?
     end
 
-    @list = get_latest_updated(@limit,@timelimit)
+    @list = get_latest_updated(@limit,@timelimit,prj_filter,pkg_filter)
   end
 
   def updated_timestamp

--- a/src/api/app/mixins/statistics_calculations.rb
+++ b/src/api/app/mixins/statistics_calculations.rb
@@ -1,12 +1,12 @@
 module StatisticsCalculations
-  def get_latest_updated(limit = 10, timelimit = Time.at(0))
-    packages = Package.includes(:project).where(updated_at: timelimit..Time.now).order("updated_at DESC").limit(limit).pluck(:name, "projects.name as project", :updated_at).map { |name, project, at| [at, :package, name, project] }
-    projects = Project.where(updated_at: timelimit..Time.now).order("updated_at DESC").limit(limit).pluck(:name, :updated_at).map { |name, at| [at, name, :project] }
+  def get_latest_updated(limit = 10, timelimit = Time.at(0), prj_filter = ".*", pkg_filter = ".*")
+    packages = Package.includes(:project).where(updated_at: timelimit..Time.now).where('packages.name REGEXP ? AND projects.name REGEXP ?',pkg_filter,prj_filter).references(:project).order("updated_at DESC").limit(limit).pluck(:name, "projects.name as project", :updated_at).map { |name, project, at| [at, :package, name, project] }
+    projects = Project.where(updated_at: timelimit..Time.now).where('name REGEXP ?',prj_filter).order("updated_at DESC").limit(limit).pluck(:name, :updated_at).map { |name, at| [at, name, :project] }
 
     list = packages + projects
     list.sort! { |a, b| b[0] <=> a[0] }
     return list if limit.nil?
-    list.slice(0, limit)
+    list.first(limit)
   end
 end
 

--- a/src/api/app/mixins/statistics_calculations.rb
+++ b/src/api/app/mixins/statistics_calculations.rb
@@ -1,10 +1,11 @@
 module StatisticsCalculations
-  def get_latest_updated(limit = 10)
-    packages = Package.includes(:project).order("updated_at DESC").limit(limit).pluck(:name, "projects.name as project", :updated_at).map { |name, project, at| [at, :package, name, project] }
-    projects = Project.order("updated_at DESC").limit(limit).pluck(:name, :updated_at).map { |name, at| [at, name, :project] }
+  def get_latest_updated(limit = 10, timelimit = Time.at(0))
+    packages = Package.includes(:project).where(updated_at: timelimit..Time.now).order("updated_at DESC").limit(limit).pluck(:name, "projects.name as project", :updated_at).map { |name, project, at| [at, :package, name, project] }
+    projects = Project.where(updated_at: timelimit..Time.now).order("updated_at DESC").limit(limit).pluck(:name, :updated_at).map { |name, at| [at, name, :project] }
 
     list = packages + projects
     list.sort! { |a, b| b[0] <=> a[0] }
+    return list if limit.nil?
     list.slice(0, limit)
   end
 end


### PR DESCRIPTION
I added some filtering into the rendering of the list of latest updates. I've found this very useful when trying to figure out what has been going on in our OBS. The timelimit is number of days. The package and project filters support regexp syntax.

Some examples of the usage:
* Updates from the last 10 days
 * `osc api -X GET "statistics/latest_updated?timelimit=10"`
* Updates to packages with name eding "rpm"
 * `osc api -X GET "statistics/latest_updated?pkgfilter=rpm$"`
* Updates to projects with name starting "home"
 * `osc api -X GET "statistics/latest_updated?prjfilter=^home"`
* All the above combined
 * `osc api -X GET "statistics/latest_updated?timelimit=10&pkgfilter=rpm$&prjfilter=^home"`