### PR TITLE
[backend] put timestamp in generated servicemark

### DIFF
--- a/src/backend/bs_srcserver
+++ b/src/backend/bs_srcserver
@@ -322,7 +322,8 @@ sub genservicemark {
   # argh, somewhat racy. luckily we just need something unique...
   # (files is not unique enough because we want a different id
   # for each commit, even if it has the same srcmd5)
-  my $smd5 = "sourceservice/$projid/$packid";
+  # (maybe we should use the same time as in the upcoming rev)
+  my $smd5 = "sourceservice/$projid/$packid/".time()."\n";
   eval {
     my $rev_old = getrev($projid, $packid);
     $smd5 .= "$rev_old->{'rev'}" if $rev_old->{'rev'};
@@ -4723,6 +4724,7 @@ sub getfilelist {
 	  $serviceinfo->{'code'} = 'running';
 	} else {
 	  $serviceinfo->{'code'} = 'failed';
+	  $serviceinfo->{'xsrcmd5'} = $li->{'xservicemd5'};
 	  $serviceinfo->{'error'} = $error;
 	}
       }


### PR DESCRIPTION
Cherry-pick of: ee33559638c16678b78467eb89160bc790df349c

Fixes issue #852.

Also sets the xsrcmd5 for failed service runs, this breaks very old
osc versions, but hey...