### PR TITLE
[webui] Fix alert message for build result

### DIFF
--- a/src/api/app/helpers/webui/webui_helper.rb
+++ b/src/api/app/helpers/webui/webui_helper.rb
@@ -104,10 +104,7 @@ module Webui::WebuiHelper
 
     out = "<td class='#{theclass} buildstatus'>"
     if %w(unresolvable blocked).include? code
-      out += link_to code, '#', title: link_title, id: status_id
-      content_for :ready_function do
-        "$('a##{status_id}').click(function() { alert('#{link_title.gsub(/'/, '\\\\\'')}'); return false; });\n".html_safe
-      end
+      out += link_to code, '#', title: link_title, id: status_id, class: code
     elsif %w(- excluded).include? code
       out += code
     elsif @localpackages and not @localpackages.has_key? packname

--- a/src/api/app/views/webui/package/_buildstatus.html.erb
+++ b/src/api/app/views/webui/package/_buildstatus.html.erb
@@ -30,3 +30,10 @@
 
   <% end # if -%>
 </div>
+
+<%= javascript_tag do %>
+    $('.unresolvable, .blocked').click(function() {
+        var title = $(this).attr('title');
+        alert(title);
+    });
+<% end %>

--- a/src/api/app/views/webui/project/monitor.html.erb
+++ b/src/api/app/views/webui/project/monitor.html.erb
@@ -143,3 +143,10 @@
   </div>
 
 </div>
+
+<% content_for :ready_function do %>
+    $('.unresolvable, .blocked').click(function() {
+    var title = $(this).attr('title');
+    alert(title);
+    });
+<% end %>


### PR DESCRIPTION
When the build result is unresolvable or blocked an alert message should pop up when clicking on it.
Because the buildstatus will be called via ajax, the content_for :ready_function didn't worked.
This commit will fix #948