### PR TITLE
Don't truncate project or packages names on search results. 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,3 +25,4 @@ notifications:
      on_failure: change  
 services:
   - memcached # will start memcached
+sudo: required

--- a/src/api/app/helpers/webui/webui_helper.rb
+++ b/src/api/app/helpers/webui/webui_helper.rb
@@ -427,7 +427,7 @@ module Webui::WebuiHelper
     opts[:package_text] ||= opts[:package]
 
     opts[:project_text], opts[:package_text] =
-        elide_two(opts[:project_text], opts[:package_text], opts[:trim_to])
+        elide_two(opts[:project_text], opts[:package_text], opts[:trim_to]) unless opts[:trim_to].nil?
 
     if opts[:short]
       out = ''.html_safe
@@ -458,7 +458,8 @@ module Webui::WebuiHelper
     else
       out = 'project '.html_safe
     end
-    out + link_to_if(prj, elide(opts[:project_text], opts[:trim_to]),
+    project_text = opts[:trim_to].nil? ? opts[:project_text] : elide(opts[:project_text], opts[:trim_to])
+    out + link_to_if(prj, project_text,
                      { controller: 'project', action: 'show', project: opts[:project] },
                      { class: 'project', title: opts[:project] })
   end

--- a/src/api/app/views/webui/search/_results.html.erb
+++ b/src/api/app/views/webui/search/_results.html.erb
@@ -14,7 +14,7 @@
     <div class="search_result">
       <h6 class="data-title">
       <%= sprite_tag(rtype, class: rtype, title: rtype.humanize) %>
-      <%= project_or_package_link project: project, package: package, short: false %>
+      <%= project_or_package_link project: project, package: package, short: false, trim_to: nil %>
       <%= content_tag :span, result.sphinx_attributes, style: 'display:none' %>
       </h6>
 


### PR DESCRIPTION
 Don't use elide functions if the trim_to option is nil.

Fixes #883.