### PR TITLE
Fix obs interconnect in an apache2 setup if use_xforward is disabled

### DIFF
--- a/src/backend/BSWatcher.pm
+++ b/src/backend/BSWatcher.pm
@@ -752,21 +752,9 @@ sub rpc_recv_handler {
     return;
   }
   my $ans;
-  $ev->{'rpceof'} = 1 if !$r;
   $ans = $ev->{'recvbuf'};
-
-  if ($ev->{'_need'}) {
-    #shortcut for need more bytes...
-    if (!$ev->{'rpceof'} && length($ans) < $ev->{'_need'}) {
-      #printf "... %d/%d\n", length($ans), $ev->{'_need'};
-      BSEvents::add($ev);
-      return;
-    }
-    delete $ev->{'_need'};
-  }
-
   if ($ans !~ /\n\r?\n/s) {
-    if ($ev->{'rpceof'}) {
+    if (!$r) {
       rpc_error($ev, "EOF from $ev->{'rpcdest'}");
       return;
     }
@@ -821,10 +809,10 @@ sub rpc_recv_handler {
 
   my $cl = $headers{'content-length'};
   my $chunked = $headers{'transfer-encoding'} && lc($headers{'transfer-encoding'}) eq 'chunked' ? 1 : 0;
+  $ev->{'contentlength'} = $cl if !$chunked;
 
   if ($param->{'receiver'}) {
     #rpc_error($ev, "answer is neither chunked nor does it contain a content length\n") unless $chunked || defined($cl);
-    $ev->{'contentlength'} = $cl if !$chunked;
     if ($param->{'receiver'} == \&BSHTTP::file_receiver) {
       rpc_recv_file($ev, $chunked, $ans, $param->{'filename'}, $param->{'withmd5'});
     } elsif ($param->{'receiver'} == \&BSHTTP::cpio_receiver) {
@@ -844,22 +832,7 @@ sub rpc_recv_handler {
     }
     return;
   }
-
-  if ($chunked) {
-    rpc_recv_non_receiver($ev, $chunked, $ans);
-    return;
-  }
-  if ($ev->{'rpceof'} && $cl && length($ans) < $cl) {
-    rpc_error($ev, "EOF from $ev->{'rpcdest'}");
-    return;
-  }
-  if (!$ev->{'rpceof'} && (!defined($cl) || length($ans) < $cl)) {
-    $ev->{'_need'} = length($headers) + $cl if defined $cl;
-    BSEvents::add($ev);
-    return;
-  }
-  $ans = substr($ans, 0, $cl) if defined $cl;
-  rpc_result($ev, $ans);
+  rpc_recv_non_receiver($ev, $chunked, $ans);
 }
 
 sub rpc_send_handler {


### PR DESCRIPTION
- commit 8942b65609d74886996b5a9cfe86d52667c746ee fixes the issue described in PR#937
  (see https://github.com/openSUSE/open-build-service/pull/937)
- commit fc65c01c0dfd0b42cdc7fb8868771db920cc517e simplifies BSWatcher::rpc_recv_handler
  a bit (this commit depends in the first commit)

If needed, I can also split this into two separate pull requests.