### PR TITLE
[webui] Break project names in watchlist

### DIFF
--- a/src/api/app/views/layouts/webui/_watch_and_search.html.erb
+++ b/src/api/app/views/layouts/webui/_watch_and_search.html.erb
@@ -19,7 +19,7 @@
       <% User.current.watched_project_names.each do |project| -%>
           <li>
             <%= link_to(content_tag(:span, content_tag(:span, "", class:
-                    "icons-project") + elide(project, 32), class: "project-link"),
+                    "icons-project") + raw(project.gsub(":", ":<wbr>")), class: "project-link"),
                     project_show_path(project)) %>
           </li>
       <% end -%>


### PR DESCRIPTION
Currently long project names are shortened in the watchlist. This makes
it quite hard to identify projects in that list.
This commit will instead add html zery width spaces after every colon
which allows HTML to break them if necessary.