### PR TITLE
[backend] publish: fix arguments passed to createpatterns_comps()

### DIFF
--- a/src/backend/bs_publish
+++ b/src/backend/bs_publish
@@ -1998,7 +1998,7 @@ sub publish {
     deletepatterns_rpmmd($extrep, $projid, $xrepoid, $data);
   }
   if ($patterntype{'comps'}) {
-    createpatterns_comps($extrep, $projid, $xrepoid, $patterntype{'comps'});
+    createpatterns_comps($extrep, $projid, $xrepoid, $data, $patterntype{'comps'});
   } else {
     deletepatterns_comps($extrep, $projid, $xrepoid, $data);
   }


### PR DESCRIPTION
The `$data` argument was missing for `createpatterns_comps()` call
since argument passing was refactored in 3c5cf394 commit,
causing "`Not a HASH reference`" error in this function.

This change fixes that omission.