### PR TITLE
[backend] Replace RabbitMQ provider in notify_rabbitmq.pm

### DIFF
--- a/src/backend/plugins/notify_rabbitmq.pm
+++ b/src/backend/plugins/notify_rabbitmq.pm
@@ -22,7 +22,7 @@
 
 package notify_rabbitmq;
 
-use Net::RabbitMQ;
+use Net::AMQP::RabbitMQ;
 use BSConfig;
 use JSON::XS;
 #use Data::UUID;
@@ -53,7 +53,7 @@ sub notify() {
   #my $uu = Data::UUID->new;
   $paramRef ||= {};
   $paramRef->{'eventtype'} = $type;
-  my $mq = Net::RabbitMQ->new();
+  my $mq = Net::AMQP::RabbitMQ->new();
   my %rabbitparam = %{$BSConfig::rabbitmqconfig || $BSConfig::rabbitmqconfig || $defaultconfig};
   my $rabbitserver = delete $rabbitparam{'server'};
   $mq->connect($rabbitserver, \%rabbitparam);


### PR DESCRIPTION
Switch from `Net::RabbitMQ` to `Net::AMQP::RabbitMQ` because `Net::RabbitMQ` doesn't work with modern versions of RabbitMQ. 

The replacement provider is API compatible to the extent that the module uses it, as the only function no longer supported is `basic_return($subroutine)`, which the module does not use.