### PR TITLE
[webui] All tabs for requests are shown on user's page

### DIFF
--- a/src/api/app/views/shared/_requests.html.erb
+++ b/src/api/app/views/shared/_requests.html.erb
@@ -3,7 +3,7 @@
   request_table_id ||= 'request_table'
   hide_state ||= false
   no_target ||= false
-  paginate = serverProcessing ? true : requests.count > 25
+  paginate = serverProcessing || (!requests.nil? && requests.count > 25)
   if serverProcessing
     sort_columns = ['null', "{'bSortable': false}", '{\'bSortable\': false}']
   else

--- a/src/api/app/views/webui/user/show.html.erb
+++ b/src/api/app/views/webui/user/show.html.erb
@@ -151,48 +151,30 @@
   </div>
 <% end %>
 
- <% if @requests_in.present? || @requests_out.present? || @declined_requests.present? || @user_have_requests %>
-  <div class="grid_16 alpha omega box box-shadow">
-    <div id="requests">
-      <div class="box-header header-tabs">
-        <ul>
-          <% if @requests_in.count > 0 %>
-            <li><a href="#requests_in" title="Requests that <%= @displayed_user.login %> has to merge">Incoming Requests</a></li>
-          <% end -%>
-          <% if @requests_out.count > 0 %>
-            <li><a href="#requests_out" title="Requests that <%= @displayed_user.login %> has sent">Outgoing Requests</a></li>
-          <% end -%>
-          <% if @declined_requests.count > 0 %>
-            <li><a href="#requests_declined" title="Requests from <%= @displayed_user.login %> that are declined">Declined Requests</a></li>
-          <% end -%>
-          <% if @user_have_requests %>
-            <li><a href="#all_requests" title="All Requests from <%= @displayed_user.login %>">All Requests</a></li>
-          <% end -%>
-        </ul>
+<div class="grid_16 alpha omega box box-shadow">
+  <div id="requests">
+    <div class="box-header header-tabs">
+      <ul>
+          <li><a href="#requests_in" title="Requests that <%= @displayed_user.login %> has to merge">Incoming Requests</a></li>
+          <li><a href="#requests_out" title="Requests that <%= @displayed_user.login %> has sent">Outgoing Requests</a></li>
+          <li><a href="#requests_declined" title="Requests from <%= @displayed_user.login %> that are declined">Declined Requests</a></li>
+          <li><a href="#all_requests" title="All Requests from <%= @displayed_user.login %>">All Requests</a></li>
+      </ul>
+    </div>
+      <div id="requests_in" class="tab">
+        <%= render(:partial => 'shared/requests', :locals => { :requests => @requests_in, :request_table_id => 'requests_in_table', :hide_state => true }) %>
       </div>
-      <% if @requests_in.count > 0 %>
-        <div id="requests_in" class="tab">
-          <%= render(:partial => 'shared/requests', :locals => { :requests => @requests_in, :request_table_id => 'requests_in_table', :hide_state => true }) %>
-        </div>
-      <% end -%>
-      <% if @requests_out.count > 0 %>
-        <div id="requests_out" class="tab">
-          <%= render(:partial => 'shared/requests', :locals => { :requests => @requests_out, :request_table_id => 'requests_out_table', :hide_state => true }) %>
-        </div>
-      <% end -%>
-      <% if @declined_requests.count > 0 %>
-        <div id="requests_declined" class="tab">
-          <%= render(:partial => 'shared/requests', :locals => { :requests => @declined_requests, :request_table_id => 'requests_declined_table', :hide_state => true }) %>
-        </div>
-      <% end -%>
-      <% if @user_have_requests %>
-        <div id="all_requests" class="tab">
-          <%= render(:partial => 'shared/requests', :locals => { :request_table_id => 'all_requests_table', :hide_state => true, :serverProcessing => true}) %>
-        </div>
-      <% end -%>
-   </div>
+      <div id="requests_out" class="tab">
+        <%= render(:partial => 'shared/requests', :locals => { :requests => @requests_out, :request_table_id => 'requests_out_table', :hide_state => true }) %>
+      </div>
+      <div id="requests_declined" class="tab">
+        <%= render(:partial => 'shared/requests', :locals => { :requests => @declined_requests, :request_table_id => 'requests_declined_table', :hide_state => true }) %>
+      </div>
+      <div id="all_requests" class="tab">
+        <%= render(:partial => 'shared/requests', :locals => { :request_table_id => 'all_requests_table', :hide_state => true, :serverProcessing => true}) %>
+      </div>
   </div>
-<% end %>
+</div>
 
  <% if @patchinfos.present? %>
   <div class="grid_16 alpha omega box box-shadow">

--- a/src/api/test/functional/webui/spider_test.rb
+++ b/src/api/test/functional/webui/spider_test.rb
@@ -150,7 +150,7 @@ class Webui::SpiderTest < Webui::IntegrationTest
 
     crawl
     ActiveRecord::Base.clear_active_connections!
-    
+
     @pages_visited.keys.length.must_be :>, 700
   end
 


### PR DESCRIPTION
Now all tabs for requests at user's page will be displayed, no matter if they don't have any item to show.
![all_tabs_shown](https://cloud.githubusercontent.com/assets/11314634/8906449/27bdb53a-346f-11e5-9c08-746bf1ab65fa.png)
