### PR TITLE
[webui] Refactor and fix filtering of binaries in patchinfo controller

### DIFF
--- a/src/api/app/controllers/webui/patchinfo_controller.rb
+++ b/src/api/app/controllers/webui/patchinfo_controller.rb
@@ -26,11 +26,7 @@ class Webui::PatchinfoController < Webui::WebuiController
     end
 
     read_patchinfo
-    @binaries.each do |bin|
-      if @binarylist.match(bin)
-        @binarylist.delete(bin)
-      end
-    end
+    @binaries.each { |bin| @binarylist.delete(bin) }
   end
 
   def updatepatchinfo
@@ -42,11 +38,7 @@ class Webui::PatchinfoController < Webui::WebuiController
   def edit_patchinfo
     read_patchinfo
     @tracker = ::Configuration.default_tracker
-    @binaries.each do |bin|
-      if @binarylist.find(bin)
-        @binarylist.delete(bin)
-      end
-    end
+    @binaries.each { |bin| @binarylist.delete(bin) }
   end
 
   def show


### PR DESCRIPTION
The 2 bug fixes:
- @binarylist is an Array, which doesn't have a match method.
- @binarylist.find without a block parameter always returns an Enumerator object:
    irb(main):001:0> ["foo"].find("bar")
    => #<Enumerator: ["foo"]:find("bar")>