### PR TITLE
[ci] Remove test for accidentally added debugger statement

### DIFF
--- a/src/api/test/unit/code_quality_test.rb
+++ b/src/api/test/unit/code_quality_test.rb
@@ -54,16 +54,6 @@ class CodeQualityTest < ActiveSupport::TestCase
     end
   end
 
-  # Checks that no 'debugger' statement is present in ruby code
-  test 'no ruby debugger statement' do
-    @ruby_files.each do |ruby_file|
-      File.open(ruby_file).each_with_index do |line, number|
-        assert(false, "#{ruby_file}:#{number + 1} 'debugger' statement found!") if line.match(/^\s*debugger/)
-	assert(false, "#{ruby_file}:#{number + 1} 'save_and_open_page' statement found!") if line.match(/^\s*save_and_open_page/)
-      end
-    end
-  end
-
   # our current exceptions
   BlackList = {
       'ApplicationController#extract_ldap_user'                                 => 119.9,


### PR DESCRIPTION
Nowadays 'debugger' in the code would throw a NameError error because it's
not available anymore. We could replace this by checking for pry, but such
things should be found by running the tests and / or by our code reviews.