### PR TITLE
[api][webui] Raise an exception when there is no package set

### DIFF
--- a/src/api/app/models/patchinfo.rb
+++ b/src/api/app/models/patchinfo.rb
@@ -242,7 +242,7 @@ class Patchinfo < ActiveXML::Node
     path = if self.init_options[:package]
       "/source/#{self.init_options[:project]}/#{self.init_options[:package]}/_patchinfo"
     else
-      "/source/_patchinfo"
+      raise IncompletePatchinfo.new "The _patchinfo has no package name set."
     end
 
     begin


### PR DESCRIPTION
As per discussion with Adrian, we should raise an exception here. The case of
not having a package might never happened. And if it does we'll get aware of
it now and can solve those cases.