### PR TITLE
[ci] Set RuboCop::RakeTask fail level to 'convention'

### DIFF
--- a/src/api/Rakefile
+++ b/src/api/Rakefile
@@ -23,7 +23,7 @@ unless Rails.env.production?
   require 'rubocop/rake_task'
 
   RuboCop::RakeTask.new(:rubocop) do |task|
-    task.options = [ '-D', '-F', '--fail-level', 'error' ]
+    task.options = [ '-D', '-F', '--fail-level', 'convention' ]
   end
 end
 


### PR DESCRIPTION
This causes rubocop to fail on any broken convention, which is
what we need for integrating rubocop into our travis testsuite.

https://github.com/bbatsov/rubocop#severity