### PR TITLE
[webui] Update OBS redirect after login

### DIFF
--- a/src/api/app/views/layouts/webui/_personal_navigation.html.erb
+++ b/src/api/app/views/layouts/webui/_personal_navigation.html.erb
@@ -18,17 +18,15 @@
   <% else %>
     <% if CONFIG['proxy_auth_mode'] == :on %>
       <% unless CONFIG['proxy_auth_register_page'].blank? %>
-        <%= link_to 'Sign Up', "#{CONFIG['proxy_auth_register_page']}?%22#{@return_to_host}#{@return_to_path}%22" %> |
+        <%= link_to 'Sign Up', "#{CONFIG['proxy_auth_register_page']}?%22" %> |
       <% end %>
       <%= link_to 'Log In', user_login_path, id: 'login-trigger' %>
       <div id="login-form">
         <%= form_tag(CONFIG['proxy_auth_login_page'], method: :post, id: 'login_form', enctype: 'application/x-www-form-urlencoded') do %>
           <p>
-            <%= hidden_field_tag(:url, "#{@return_to_host}#{@return_to_path}") %>
             <%= hidden_field_tag(:context, 'default') %>
             <%= hidden_field_tag(:proxypath, 'reserve') %>
             <%= hidden_field_tag(:message, 'Please log in') %>
-            <%= hidden_field_tag(:return_to_path, @return_to_path) %>
             <%= label_tag(:username, 'Username') %>
             <%= text_field_tag(:username, '') %>
           </p>
@@ -48,7 +46,6 @@
       <div id="login-form">
         <%= form_tag(user_do_login_path) do %>
           <p>
-            <%= hidden_field_tag(:return_to_path, @return_to_path) %>
             <%= label_tag(:username, 'Username') %>
             <%= text_field_tag(:username, '') %>
           </p>

--- a/src/api/app/views/webui/user/login.html.erb
+++ b/src/api/app/views/webui/user/login.html.erb
@@ -4,7 +4,6 @@
   <form action="<%= CONFIG['proxy_auth_login_page'] %>"
         method="post" enctype="application/x-www-form-urlencoded">
     <div>
-      <input name="url" value="<%= "#{@return_to_host}#{@return_to_path}" %>" type="hidden" />
       <input name="context" value="default" type="hidden" />
       <input name="proxypath" value="reverse" type="hidden" />
       <input name="message" value="Please log In" type="hidden" />
@@ -20,7 +19,6 @@
       <input type="text" name="username" id="user_login" size="30" value=""/><br/><br/>
       <label for="user_password">Password:</label>
       <input type="password" name="password" id="user_password" size="30"/>
-      <input name="return_to_path" value="<%= "#{@return_to_path}" %>" type="hidden" />
     </p>
     <p>
       <input type="submit" name="login" value="Log In &#187;" class="primary" />
@@ -30,7 +28,7 @@
   <p>
     <% if CONFIG['proxy_auth_mode'] == :on %>
       Or
-      <%= link_to "register", CONFIG['proxy_auth_register_page'] + "?%22#{@return_to_host}#{@return_to_path}%22" %>
+      <%= link_to "register", CONFIG['proxy_auth_register_page'] + "?%22" %>
       as a new user.
     <% else %>
       <% unless CONFIG['frontend_ldap_mode'] == :on %>

--- a/src/api/test/functional/webui/patchinfo_create_test.rb
+++ b/src/api/test/functional/webui/patchinfo_create_test.rb
@@ -135,7 +135,7 @@ class Webui::PatchinfoCreateTest < Webui::IntegrationTest
       :rating => "low")
 
     # check that the patchinfo is not editable for unauthorized users per buttons
-    login_adrian
+    login_adrian(do_assert: false)
     visit patchinfo_show_path(project: "home:Iggy", package: "patchinfo")
     page.wont_have_content("Edit patchinfo")
     page.wont_have_content("Delete patchinfo")

--- a/src/api/test/functional/webui/signup_test.rb
+++ b/src/api/test/functional/webui/signup_test.rb
@@ -12,7 +12,8 @@ class Webui::SignupTest < Webui::IntegrationTest
 
   def test_signup_allow
     signup_user root_path
-    flash_message.must_equal 'The account "eisendieter" is now active.'
+    flash_message.must_equal "The account 'eisendieter' is now active."
+    assert User.find_by(login: "eisendieter").is_active?
   end
 
   def test_signup_confirmation

--- a/src/api/test/functional/webui/user_controller_test.rb
+++ b/src/api/test/functional/webui/user_controller_test.rb
@@ -89,4 +89,15 @@ class Webui::UserControllerTest < Webui::IntegrationTest
     page.must_have_checked_field('Event::CommentForProject_maintainer')
     page.must_have_checked_field('Event::CommentForProject_commenter')
   end
+
+  def test_that_redirect_after_login_works
+    visit search_path
+    visit user_login_path
+    fill_in 'Username', with: "tom"
+    fill_in 'Password', with: "thunder"
+    click_button 'Log In'
+
+    assert_equal "tom", User.current.try(:login)
+    assert_equal search_path, current_path
+  end
 end

--- a/src/api/test/test_helper.rb
+++ b/src/api/test/test_helper.rb
@@ -208,10 +208,13 @@ module Webui
     def login_user(user, password, opts = {})
       # no idea why calling it twice would help
       WebMock.disable_net_connect!(allow_localhost: true)
-      visit user_login_path(return_to_path: opts[:to])
+      visit user_login_path
       fill_in 'Username', with: user
       fill_in 'Password', with: password
       click_button 'Log In'
+
+      visit opts[:to] if opts[:to]
+
       @current_user = user
       if opts[:do_assert] != false
         assert_match %r{^#{user}( |$)}, find('#link-to-user-home').text


### PR DESCRIPTION
After login OBS users get redirected to the page they initially visited. So far
this was done via hidden fields in the views and parameters that were processed
in the controller.
An attacker could use those parameters to redirect to an untrusted side.
This commit stores the last visited page in the session store to avoid that kind
of attack.