### PR TITLE
Add gcc-c++ package to bootstrap.sh

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -3,7 +3,7 @@ echo -e "\ninstalling required software packages...\n"
 echo 'solver.allowVendorChange = true' >> /etc/zypp/zypp.conf
 zypper -q ar -f http://download.opensuse.org/repositories/OBS:/Server:/Unstable/openSUSE_13.2/OBS:Server:Unstable.repo
 zypper -q --gpg-auto-import-keys refresh
-zypper -q -n install update-alternatives ruby-devel make gcc patch cyrus-sasl-devel openldap2-devel libmysqld-devel libxml2-devel zlib-devel libxslt-devel nodejs mariadb memcached sphinx screen sphinx obs-server phantomjs
+zypper -q -n install update-alternatives ruby-devel make gcc gcc-c++ patch cyrus-sasl-devel openldap2-devel libmysqld-devel libxml2-devel zlib-devel libxslt-devel nodejs mariadb memcached sphinx screen sphinx obs-server phantomjs
 
 echo -e "\nsetup ruby binaries...\n"
 for bin in rake rdoc ri; do


### PR DESCRIPTION
The gcc-c++ package is necessary to install the unf_ext gem.