### PR TITLE
Fix save_meta action for project

### DIFF
--- a/src/api/app/controllers/webui/project_controller.rb
+++ b/src/api/app/controllers/webui/project_controller.rb
@@ -22,7 +22,7 @@ class Webui::ProjectController < Webui::WebuiController
                                      :prjconf, :change_flag, :edit, :save_comment, :edit_comment, :status, :maintained_projects,
                                      :add_maintained_project_dialog, :add_maintained_project, :remove_maintained_project,
                                      :maintenance_incidents, :unlock_dialog, :save_person, :save_group, :remove_role, :save_repository,
-                                     :move_path]
+                                     :move_path, :save_meta]
 
   before_filter :set_project_by_id, only: [:update]
 


### PR DESCRIPTION
Adds save_meta to the set_project before filter, otherwise the pundit authentication fails and the meta can't be saved.