### PR TITLE
[webui] Return false in click function for build result

### DIFF
--- a/src/api/app/views/webui/project/monitor.html.erb
+++ b/src/api/app/views/webui/project/monitor.html.erb
@@ -147,5 +147,6 @@
     $('.unresolvable, .blocked').click(function() {
     var title = $(this).attr('title');
     alert(title);
+    return false;
     });
 <% end %>


### PR DESCRIPTION
This avoids following the dummy href which causes the browser to scroll to
the top of the page.