### PR TITLE
fix db conn leak caused by reindex run

### DIFF
--- a/src/api/config/clock.rb
+++ b/src/api/config/clock.rb
@@ -43,7 +43,7 @@ module Clockwork
   end
 
   # Ensure that sphinx's searchd is running and reindex
-  every(1.hour, 'reindex sphinx', thread: true) do
+  every(1.hour, 'reindex sphinx') do
     FullTextSearch.new.delay.index_and_start
   end
 


### PR DESCRIPTION
The delay job with delayed_job_active_record as queue_adapter creates
for each FullTextSearch.new.delay.index_and_start a delayed_job entry
in the MySQL/MariaDB.

This delayed job gets created in a periodic clockwork event. The
sphinx-reindex clockwork event is the only event in clock.rb which
runs delayed _and_ inside a clockword thread.

Since the delayed job gets created in inside the clockworkd thread
the delayed job ActiveRecord code establishes a new MySQL/MariaDB
client connection (regardless if socket or TCP is configured) without
using existing database connections.

This repeast until the number of  connection in the configured database
pool is exceeded.

Which causes fetch-notification and other clock.rb events using
ActiveRecord::Base.connection_pool to fail once the connection
pool is exhausted.

Related to issue#988