### PR TITLE
Remove setting updated_at manually in update_from_xml

### DIFF
--- a/src/api/app/models/project.rb
+++ b/src/api/app/models/project.rb
@@ -539,7 +539,6 @@ class Project < ActiveRecord::Base
     update_repositories(xmlhash, force)
 
     #--- end update repositories ---#
-    self.updated_at = Time.now
   end
 
 


### PR DESCRIPTION
Setting the timestamp manually is useless without saving the instance afterwards. Furthermore ActiveRecord automatically timestamps on
create and update operations.