### PR TITLE
[webui] Fix inherited packages tab bug and pagination

### DIFF
--- a/src/api/app/controllers/webui/project_controller.rb
+++ b/src/api/app/controllers/webui/project_controller.rb
@@ -872,7 +872,7 @@ class Webui::ProjectController < Webui::WebuiController
 
   def load_project_info
     find_maintenance_infos
-    @ipackages = @project.linked_packages.map { |package| [ package.name, package.project_id ] }
+    @ipackages = @project.linked_packages.map { |package| [ package.name, package.project.name ] }
     @packages = @project.packages.pluck(:name)
     @linking_projects = @project.find_linking_projects.map { |p| p.name }
     reqs = @project.request_ids_by_class

--- a/src/api/app/views/webui/home/index.html.erb
+++ b/src/api/app/views/webui/home/index.html.erb
@@ -79,7 +79,7 @@
       <% content_for :ready_function do %>
         var ipackages = [ <%= @ipackages.map {|p|
                            "['#{p[0]}','#{escape_javascript(p[1])}']" }.join(",\n").html_safe %> ];
-        renderPackagesProjectsTable({packages: ipackages, length: '15', name: 'ipackages_wrapper'});
+        renderPackagesProjectsTable({packages: ipackages, length: 15, name: 'ipackages_wrapper'});
       <% end %>
     </div>
     <% else %>
@@ -116,7 +116,7 @@
           <% content_for :ready_function do %>
             var iowned = [ <%= @owned.map {|p|
                                 "['#{p[1]}','#{escape_javascript(p[0])}']" }.join(",\n").html_safe %> ];
-            renderPackagesProjectsTable({packages: iowned, length: '15', name: 'iowned_wrapper'});
+            renderPackagesProjectsTable({packages: iowned, length: 15, name: 'iowned_wrapper'});
           <% end %>
         </div>
       <% end %>
@@ -240,4 +240,3 @@
         $( "#patchinfos" ).tabs();
       <% end -%>
 <% end %>
-

--- a/src/api/app/views/webui/project/_packages_table.html.erb
+++ b/src/api/app/views/webui/project/_packages_table.html.erb
@@ -54,7 +54,7 @@
               <div id="ipackages_wrapper" data-url="<%= packageurl %>">
                 <%= javascript_tag do %>
                     var ipackages = [ <%= @ipackages.map { |p| "#{p}" }.join(',').html_safe %>
-                    ]; renderPackagesProjectsTable({packages: ipackages, length: '25', name: 'ipackages_wrapper'});
+                    ]; renderPackagesProjectsTable({packages: ipackages, name: 'ipackages_wrapper'});
                 <% end %>
               </div>
           <% end %>

--- a/src/api/app/views/webui/user/show.html.erb
+++ b/src/api/app/views/webui/user/show.html.erb
@@ -79,7 +79,7 @@
       <% content_for :ready_function do %>
         var ipackages = [ <%= @ipackages.map {|p|
                            "['#{p[0]}','#{escape_javascript(p[1])}']" }.join(",\n").html_safe %> ];
-        renderPackagesProjectsTable({packages: ipackages, length: '15', name: 'ipackages_wrapper'});
+        renderPackagesProjectsTable({packages: ipackages, length: 15, name: 'ipackages_wrapper'});
       <% end %>
     </div>
     <% else %>
@@ -116,7 +116,7 @@
           <% content_for :ready_function do %>
             var iowned = [ <%= @owned.map {|p|
                                 "['#{p[1]}','#{escape_javascript(p[0])}']" }.join(",\n").html_safe %> ];
-            renderPackagesProjectsTable({packages: iowned, length: '15', name: 'iowned_wrapper'});
+            renderPackagesProjectsTable({packages: iowned, length: 15, name: 'iowned_wrapper'});
           <% end %>
         </div>
       <% end %>


### PR DESCRIPTION
Inherited packages tab was showing project ids instead of names. And the pagination wasn't working at all.