### PR TITLE
[backend] fixed array dereference in BSXPath

### DIFF
--- a/src/backend/BSXPath.pm
+++ b/src/backend/BSXPath.pm
@@ -163,7 +163,7 @@ sub predicate {
     while (1) {
       my $r = shift @ncwd;
       my $b = shift @$v2;
-      $b = @$_ ? 'true' : '' if ref($b) eq 'ARRAY';
+      $b = @$b ? 'true' : '' if ref($b) eq 'ARRAY';
       if ($b =~ /^-?\d+$/) { 
         push @nvv, $r->[1] if $r->[2] == $b;
       } else {


### PR DESCRIPTION
Otherwise something like "BSXPath::match($dir, './entry[@size > 3]');" fails with
"Can't use an undefined value as an ARRAY reference at BSXPath.pm line 166."