### PR TITLE
[webui] Limit setting the return_path to non ajax calls

### DIFF
--- a/src/api/app/controllers/webui/webui_controller.rb
+++ b/src/api/app/controllers/webui/webui_controller.rb
@@ -100,7 +100,7 @@ class Webui::WebuiController < ActionController::Base
   end
 
   def set_return_path(path)
-    session[:return_path] = path
+    session[:return_path] = path unless request.xhr?
   end
 
   def set_project


### PR DESCRIPTION
As Henne recommended previously (pr#1078) we should narrow the scope
of storing the return_path.