### PR TITLE
[webui] Fix recursion in expand_all_projects

### DIFF
--- a/src/api/app/models/project.rb
+++ b/src/api/app/models/project.rb
@@ -1021,7 +1021,7 @@ class Project < ActiveRecord::Base
           projects << lp.linked_remote_project_name
         end
       else
-        lp.linked_db_project.expand_all_projects(project_map).each do |p|
+        lp.linked_db_project.expand_all_projects(project_map, allow_remote_projects).each do |p|
           projects << p
         end
       end


### PR DESCRIPTION
Fixes "NoMethodError (undefined method `packages' for
"openSUSE.org:openSUSE:Factory:ARM":String)" when called from
linked_packages.