### PR TITLE
[dist] Require rubygem-passenger-apache2 in spec file

### DIFF
--- a/dist/obs-server.spec
+++ b/dist/obs-server.spec
@@ -151,7 +151,7 @@ PreReq:         %fillup_prereq %insserv_prereq
 %endif
 
 #For apache
-Recommends:     apache2 apache2-mod_xforward rubygem(passenger-apache2)
+Requires:     apache2 apache2-mod_xforward rubygem(passenger-apache2)
 
 # memcache is required for session data
 Requires:       memcached


### PR DESCRIPTION
Per discussion with Adrian. We only support one webserver nowadays.