### PR TITLE
Keep enforce_project_keys/forceprojectkeys in sync

### DIFF
--- a/src/backend/bs_srcserver
+++ b/src/backend/bs_srcserver
@@ -3567,6 +3567,7 @@ sub extendkey {
 sub deletekey {
   my ($cgi, $projid) = @_;
   $cgi->{'comment'} ||= 'delete sign key';
+  BSConfiguration::update_from_configuration();
   if ($BSConfig::forceprojectkeys) {
     my $pprojid = $projid;
     $pprojid =~ s/:[^:]*$//;
@@ -3621,6 +3622,7 @@ sub putproject {
   notify($oldproj ? "SRCSRV_UPDATE_PROJECT" : "SRCSRV_CREATE_PROJECT", { "project" => $projid, "sender" => ($cgi->{'user'} || "unknown") });
   mkdir_p("$projectsdir") || die("creating $projectsdir: $!\n");
   addrev_meta($cgi, $projid, undef, "$uploaddir/$$.2", "$projectsdir/$projid.xml", '_meta');
+  BSConfiguration::update_from_configuration();
   if ($BSConfig::forceprojectkeys) {
     my ($sk) = getsignkey({}, $projid);
     createkey({ %$cgi, 'comment' => 'autocreate key' }, $projid) if $sk eq '';


### PR DESCRIPTION
In setups where enforce_project_keys is set in configuration.xml
to on. But $BSConfig::forceprojectkeys is undefined sporadic
per-project key creations happens, even if a global OBS instance
got configured.

This is due the fact that $BSConfig::forceprojectkeys get set to 1
once once a src_server API routine got called which calls
update_from_configuration().

(Adapted master fix)