### PR TITLE
[webui] Remove duplicated permissin check when merging requests

### DIFF
--- a/src/api/app/controllers/webui/request_controller.rb
+++ b/src/api/app/controllers/webui/request_controller.rb
@@ -415,7 +415,6 @@ class Webui::RequestController < Webui::WebuiController
       flash[:error] = "Unknown incident project to set"
     else
       begin
-        req.permission_check_setincident!(params[:incident_project])
         req.setincident(params[:incident_project])
         flash[:notice] = "Set target of request #{req.id} to incident #{params[:incident_project]}"
       rescue Project::UnknownObjectError => e


### PR DESCRIPTION
The permissioncheck is done by the setincident method. Thus we don't need
to explicitly call it in the controller.