### PR TITLE
[webui] Fix home project link for users without home project (#1090)

### DIFF
--- a/src/api/app/controllers/webui/project_controller.rb
+++ b/src/api/app/controllers/webui/project_controller.rb
@@ -93,6 +93,7 @@ class Webui::ProjectController < Webui::WebuiController
 
   def new
     @project = Project.new
+    @project.name = params[:name] if params[:name]
   end
 
   def new_incident

--- a/src/api/app/views/layouts/webui/_personal_navigation.html.erb
+++ b/src/api/app/views/layouts/webui/_personal_navigation.html.erb
@@ -13,7 +13,11 @@
         <%= User.current %>
        <% end %>
     <% end %> |
-    <%= link_to 'Home Project', project_show_path(User.current.home_project_name) %> |
+      <% if Project.where(name: User.current.home_project_name).exists? %>
+        <%= link_to "Home Project", project_show_path(User.current.home_project_name) %>
+      <% else %>
+        <%= link_to "Create Home", new_project_path(name: User.current.home_project_name) %>
+      <% end %> |
     <%= link_to 'Logout', user_logout_path, method: :post, id: 'logout-link' %>
   <% else %>
     <% if CONFIG['proxy_auth_mode'] == :on %>

--- a/src/api/app/views/layouts/webui/webui.html.erb
+++ b/src/api/app/views/layouts/webui/webui.html.erb
@@ -84,7 +84,11 @@
         <strong class="grey-medium spacer1"><%= link_to(user_show_path(User.current)) do %><%= User.current %><% end %>:</strong>
         <ul>
           <li><%= link_to "Your Profile", user_show_path(User.current) %> </li>
-          <li><%= link_to "Home Project", project_show_path(User.current.home_project_name) %></li>
+          <% if Project.where(name: User.current.home_project_name).exists? %>
+            <li><%= link_to "Home Project", project_show_path(User.current.home_project_name) %></li>
+          <% else %>
+            <li><%= link_to "Create Home Project", new_project_path(name: User.current.home_project_name) %></li>
+          <% end %>
           <li><%= link_to 'Logout', user_logout_path, method: :post %></li>
         </ul>
       </div>

--- a/src/api/test/functional/webui/user_controller_test.rb
+++ b/src/api/test/functional/webui/user_controller_test.rb
@@ -11,6 +11,19 @@ class Webui::UserControllerTest < Webui::IntegrationTest
     find('#flash-messages').must_have_text("User data for user 'tom' successfully updated.")
   end
 
+  def test_creation_of_home_projects
+    Project.find_by(name: "home:Iggy").destroy
+    login_Iggy
+
+    page.must_have_text "Iggy | Create Home | Logout"
+    click_link("Create Home")
+    assert_equal "home:Iggy", find("#project_name").value
+    click_button("Create Project")
+
+    page.must_have_text "Iggy | Home Project | Logout"
+    assert Project.where(name: User.current.home_project_name).exists?
+  end
+
   def test_show_user_page
     # email hidden to public
     visit user_show_path(user: 'tom')


### PR DESCRIPTION
This will show a 'Create home' link instead of the 'Home Project' when a
user doesn't yet have a home. The project creation page now contains the
home project name when following this link.