### PR TITLE
[webui] Fix display of remote link on project page

### DIFF
--- a/src/api/app/views/webui/project/show.html.erb
+++ b/src/api/app/views/webui/project/show.html.erb
@@ -77,8 +77,8 @@
         <% if @project.is_remote? %>
             <li>
               <%= sprite_tag 'information' %>
-              Links against the remote OBS instance at: <i><%= link_to_if(@project.value('remoteurl'),
-                                                                          @project.value('remoteurl'), @project.value('remoteurl')) %></i>
+              Links against the remote OBS instance at: <i><%= link_to_if(@project.remoteurl,
+                                                                          @project.remoteurl, @project.remoteurl) %></i>
             </li>
         <% end %>
         <% if @linking_projects.size > 0 %>


### PR DESCRIPTION
The @project.value('remoteurl') method no longer exists, use the
.remoteurl field instead. (equivalent changes for .name in 8b4d426)

Avoids an Error 500 page and thereby resolves part of issue #1149.

Signed-off-by: Andreas Färber <afaerber@suse.de>