### PR TITLE
Allow arch specific repository url

### DIFF
--- a/src/backend/BSProductXML.pm
+++ b/src/backend/BSProductXML.pm
@@ -179,6 +179,7 @@ our $product = [
              [],
              [[ 'url' => 
                 'name',
+                'arch',
                 [],
                 '_content',
              ]],

--- a/src/backend/bs_productconvert
+++ b/src/backend/bs_productconvert
@@ -179,10 +179,18 @@ sub getUrl( $$$ ){
     my $url="";
     foreach my $url ( @{$product->{'urls'}->{'url'}} ){
         if ( "$url->{'name'}" eq "$searchstring" ){
-            my $url = $url->{'_content'};
-            $url =~ s/%{_target_cpu}/$arch/g;
-            return $url;
-	}
+            if ( exists $url->{'arch'} && "$url->{'arch'}" eq "$arch" ) {
+                my $url = $url->{'_content'};
+                $url =~ s/%{_target_cpu}/$arch/g;
+                return $url;
+            } elsif (exists $url->{'arch'}) {
+                next;
+            } else {
+                my $url = $url->{'_content'};
+                $url =~ s/%{_target_cpu}/$arch/g;
+                return $url;
+            }
+        }
     }
     return $url;
 }


### PR DESCRIPTION
In case we build multiple products from a single _product (like we do in :Ports),
we need an ability to specify REPO_LOCATION per architecture. So each
media will get architecture specific URL

e.g.
<url name="repository" arch="ppc64le">ppc64le</url>
<url name="repository" arch="aarch64">aarch64</url>
<url name="repository">default/x86</url>

Signed-off-by: Dinar Valeev <dvaleev@suse.com>