### PR TITLE
[ci] Test for remote linked projects

### DIFF
--- a/src/api/test/functional/webui/project_controller_test.rb
+++ b/src/api/test/functional/webui/project_controller_test.rb
@@ -35,6 +35,11 @@ class Webui::ProjectControllerTest < Webui::IntegrationTest
     end
   end
 
+  def test_project_show_remote_instances
+    visit project_show_path(project: 'RemoteInstance')
+    page.must_have_text "Links against the remote OBS instance at: http://localhost:3200"
+  end
+
   def test_kde4_has_two_packages
     use_js
 


### PR DESCRIPTION
Remotely linked projects were broken before and got fixed by Andreas in f61610a0f2b1deb7.
Since we already have a remote instance set up in our test environment we can use this
simple test to sure this won't happen again.