### PR TITLE
[ci][api] Update tests for calls to /status/history

### DIFF
--- a/src/api/test/functional/status_controller_test.rb
+++ b/src/api/test/functional/status_controller_test.rb
@@ -73,14 +73,33 @@ class StatusControllerTest < ActionDispatch::IntegrationTest
   def test_history
     get "/status/history"
     assert_response 400
+    assert_select "status", code: "missing_parameter" do
+      assert_select "summary", "Required Parameter hours missing"
+    end
 
-    get "/status/history?hours=24&key=idle_i586"
+    Timecop.freeze(2010, 7, 12)
+    day_before_yesterday = Time.now.to_i - 2.days
+    yesterday = Time.now.to_i - 1.days
+    1.times do |i|
+      StatusHistory.create(time: day_before_yesterday + i, key: 'squeue_low_aarch64', value: i)
+    end
+    2.times do |i|
+      StatusHistory.create(time: yesterday + i, key: 'squeue_low_aarch64', value: i)
+    end
+
+    get "/status/history?hours=24&key=squeue_low_aarch64"
     assert_response :success
+    assert_select "history" do
+      assert_select "value", time: "1278806399.5", value: "0.0"
+    end
+
     # there is no history in fixtures so the result doesn't matter
     # invalid parameters
     get "/status/history?hours=-1&samples=-10"
     assert_response 400
-
+    assert_select "status", code: "missing_parameter" do
+      assert_select "summary", "Required Parameter key missing"
+    end
 
     get "/status/history?hours=5&samples=10&key=idle_i586"
     assert_not_nil assigns(@samples)


### PR DESCRIPTION
This add tests for the xml response of calls to /status/history. Before
just tested the http status codes got tested.