### PR TITLE
Revert "[webui][api] Refactor destroying Project/Package objects"

### DIFF
--- a/src/api/app/controllers/webui/package_controller.rb
+++ b/src/api/app/controllers/webui/package_controller.rb
@@ -622,14 +622,13 @@ class Webui::PackageController < Webui::WebuiController
   end
 
   def remove
-    authorize @package, :destroy?
-
-    if @package.destroy
-      redirect_to(project_show_path(@project), notice: "Package was successfully removed.")
-    else
-      redirect_to(package_show_path(project: @project, package: @package),
-                  notice: "Package can't be removed: #{@package.errors.full_messages.to_sentence}")
+    begin
+      FrontendCompat.new.delete_package :project => @project, :package => @package
+      flash[:notice] = "Package '#{@package}' was removed successfully from project '#{@project}'"
+    rescue ActiveXML::Transport::Error => e
+      flash[:error] = e.summary
     end
+    redirect_to :controller => 'project', :action => 'show', :project => @project
   end
 
   def add_file

--- a/src/api/app/controllers/webui/patchinfo_controller.rb
+++ b/src/api/app/controllers/webui/patchinfo_controller.rb
@@ -193,14 +193,31 @@ class Webui::PatchinfoController < Webui::WebuiController
   end
 
   def remove
-    authorize @package, :destroy?
+    authorize @package, :delete?
 
-    if @package.destroy
-      redirect_to(project_show_path(@project), notice: "Patchinfo was successfully removed.")
-    else
-      redirect_to(patchinfo_show_path(package: @package, project: @project),
-                  notice: "Patchinfo can't be removed: #{@package.errors.full_messages.to_sentence}")
+    # checks
+    error_message = nil
+    if @package.name == '_project'
+      error_message = "_project package can not be deleted."
     end
+
+    # deny deleting if other packages use this as develpackage
+    unless error_message
+      begin
+        @package.can_be_deleted? # FIXME: This should be handled differently
+        Package.delete_patchinfo_of_project!(@project, @package, User.current) unless error_message
+      rescue APIException, Package::PackageError => e
+        error_message = e.message
+      end
+    end
+
+    if error_message
+      flash[:error] = error_message
+    else
+      flash[:notice] = "'#{@package}' was removed successfully from project '#{@project}'"
+    end
+
+    redirect_to controller: 'project', action: 'show', project: @project
   end
 
   def delete_dialog

--- a/src/api/app/controllers/webui/project_controller.rb
+++ b/src/api/app/controllers/webui/project_controller.rb
@@ -255,7 +255,10 @@ class Webui::ProjectController < Webui::WebuiController
     authorize @project, :destroy?
     if @project.can_be_really_deleted?
       parent = @project.parent
-      @project.destroy
+      Project.transaction do
+        @project.delete_on_backend
+        @project.destroy
+      end
       if parent
         redirect_to project_show_path(parent), notice: "Project was successfully removed."
       else

--- a/src/api/app/models/bs_request_action.rb
+++ b/src/api/app/models/bs_request_action.rb
@@ -459,6 +459,19 @@ class BsRequestAction < ActiveRecord::Base
 
   # general source cleanup, used in submit and maintenance_incident actions
   def source_cleanup
+    # cleanup source project
+    delete_path = source_cleanup_delete_path
+    return unless delete_path
+    del_params = {
+      user:      User.current.login,
+      requestid: self.bs_request.id,
+      comment:   self.bs_request.description
+    }
+    delete_path << Suse::Backend.build_query_from_hash(del_params, [:user, :comment, :requestid])
+    Suse::Backend.delete delete_path
+  end
+
+  def source_cleanup_delete_path
     source_project = Project.find_by_name(self.source_project)
     return unless source_project
     if (source_project.packages.count == 1 and ::Configuration.cleanup_empty_projects) or !self.source_package
@@ -467,15 +480,11 @@ class BsRequestAction < ActiveRecord::Base
       splits = self.source_project.split(':')
       return nil if splits.count == 2 && splits[0] == 'home'
 
-      source_project.commit_opts[:comment] = self.bs_request.description
-      source_project.commit_opts[:request] = self.bs_request.id
       source_project.destroy
       return "/source/#{self.source_project}"
     end
     # just remove one package
     source_package = source_project.packages.find_by_name!(self.source_package)
-    source_package.commit_opts[:comment] = self.bs_request.description
-    source_package.commit_opts[:request] = self.bs_request.id
     source_package.destroy
     return Package.source_path(self.source_project, self.source_package)
   end

--- a/src/api/app/models/bs_request_action_delete.rb
+++ b/src/api/app/models/bs_request_action_delete.rb
@@ -60,18 +60,26 @@ class BsRequestActionDelete < BsRequestAction
       return
     end
 
+    delete_path = destroy_object
+    # use the request description as comments for history
+    source_history_comment = self.bs_request.description
+    h = {:user => User.current.login, :comment => source_history_comment, :requestid => self.bs_request.id}
+    delete_path << Suse::Backend.build_query_from_hash(h, [:user, :comment, :requestid])
+    Suse::Backend.delete delete_path
+
+    if self.target_package == "_product"
+      Project.find_by_name!(self.target_project).update_product_autopackages
+    end
+
+  end
+
+  def destroy_object
     if self.target_package
-      package = Package.get_by_project_and_name(self.target_project, self.target_package,
-                                                use_source: true, follow_project_links: false)
-      package.commit_opts[:comment] = self.bs_request.description
-      package.commit_opts[:request] = self.bs_request.id
-      package.destroy
+      Package.get_by_project_and_name(self.target_project, self.target_package,
+                                      use_source: true, follow_project_links: false).destroy
       return Package.source_path self.target_project, self.target_package
     else
-      project = Project.get_by_name(self.target_project)
-      project.commit_opts[:comment] = self.bs_request.description
-      project.commit_opts[:request] = self.bs_request.id
-      project.destroy
+      Project.get_by_name(self.target_project).destroy
       return "/source/#{self.target_project}"
     end
   end

--- a/src/api/app/models/project.rb
+++ b/src/api/app/models/project.rb
@@ -31,16 +31,13 @@ class Project < ActiveRecord::Base
   end
 
   before_destroy :cleanup_before_destroy
-  before_destroy :cleanup_packages
-  before_destroy :delete_on_backend
-
   after_save 'Relationship.discard_cache'
   after_rollback :reset_cache
   after_rollback 'Relationship.discard_cache'
   after_initialize :init
 
   has_many :relationships, dependent: :destroy, inverse_of: :project
-  has_many :packages, inverse_of: :project do
+  has_many :packages, :dependent => :destroy, inverse_of: :project do
     def autocomplete(search)
       where(['lower(packages.name) like lower(?)', "#{search}%"])
     end
@@ -80,7 +77,6 @@ class Project < ActiveRecord::Base
 
   has_many :project_log_entries, :dependent => :delete_all
 
-  serialize(:commit_opts, Hash)
 
   default_scope { where('projects.id not in (?)', Relationship.forbidden_project_ids ) }
 
@@ -137,8 +133,16 @@ class Project < ActiveRecord::Base
       end
     end
 
-    # revoke all requests that have this project as source/target
-    revoke_requests
+    # revoke all requests
+    # FIXME: this is breaking request accepting with cleanup, if the project
+    #        will be removed during that
+#    revoke_requests
+  end
+
+  def delete_on_backend(comment = nil)
+    path = source_path
+    path << Suse::Backend.build_query_from_hash({user: User.current.login, comment: comment}, [:user, :comment])
+    Suse::Backend.delete path
   end
 
   def subprojects
@@ -172,19 +176,11 @@ class Project < ActiveRecord::Base
     self.open_requests_with_project_as_source_or_target.each do |request|
       request.bs_request_actions.each do |action|
         if action.source_project == self.name
-          begin
-            request.change_state({:newstate => 'revoked', :comment => "The source project '#{self.name}' was removed"})
-          rescue PostRequestNoPermission
-            logger.debug "#{User.current.login} tried to revoke request #{self.id} but had no permissions"
-          end
+          request.change_state({:newstate => 'revoked', :comment => "The source project '#{self.name}' was removed"})
           break
         end
         if action.target_project == self.name
-          begin
-            request.change_state({:newstate => 'declined', :comment => "The target project '#{self.name}' was removed"})
-          rescue PostRequestNoPermission
-            logger.debug "#{User.current.login} tried to decline request #{self.id} but had no permissions"
-          end
+          request.change_state({:newstate => 'declined', :comment => "The target project '#{self.name}' was removed"})
           break
         end
       end
@@ -790,6 +786,7 @@ class Project < ActiveRecord::Base
   end
 
   def write_to_backend
+    logger.debug 'write_to_backend'
     # expire cache
     reset_cache
     @commit_opts ||= {}
@@ -800,25 +797,9 @@ class Project < ActiveRecord::Base
       query[:comment] = @commit_opts[:comment] unless @commit_opts[:comment].blank?
       query[:requestid] = @commit_opts[:requestid] unless @commit_opts[:requestid].blank?
       query[:lowprio] = '1' if @commit_opts[:lowprio]
-      logger.debug "Writing #{self.name} to backend"
       Suse::Backend.put_source(self.source_path('_meta', query), to_axml)
-      logger.tagged('backend_sync') { logger.debug "Saved Project #{self.name}" }
-    else
-      logger.tagged('backend_sync') { logger.warn "Not saving Project #{self.name}, global_write_through is off" }
     end
     @commit_opts = {}
-  end
-
-  def delete_on_backend
-    if CONFIG['global_write_through']
-      path = source_path
-      path << Suse::Backend.build_query_from_hash({user: User.current.login, comment: commit_opts[:comment]}, [:user, :comment])
-      Suse::Backend.delete path
-      logger.tagged('backend_sync') { logger.debug "Deleted Project #{self.name}" }
-    else
-      logger.tagged('backend_sync') { logger.warn "Not deleting Project #{self.name}, global_write_through is off" }
-    end
-    return true
   end
 
   def store(opts = {})
@@ -826,15 +807,6 @@ class Project < ActiveRecord::Base
     self.transaction do
       save!
       write_to_backend
-    end
-  end
-
-  # The backend takes care of deleting the packages,
-  # when we delete ourself. No need to delete packages
-  # individually
-  def cleanup_packages
-    packages.each do |package|
-      package.destroy_without_backend_write
     end
   end
 
@@ -1771,8 +1743,8 @@ class Project < ActiveRecord::Base
       end
 
       # remove this repository, but be careful, because we may have done it already.
-      repository = project.repositories.find(repo.id)
-      if Repository.exists?(repo.id) && repository
+      repository = project.repositories.find(repo)
+      if Repository.exists?(repo) && repository
         logger.info "destroy repo #{repository.name} in '#{project.name}'"
         repository.destroy
         project.store({ lowprio: true }) # low prio storage

--- a/src/api/app/policies/package_policy.rb
+++ b/src/api/app/policies/package_policy.rb
@@ -6,11 +6,7 @@ class PackagePolicy < ApplicationPolicy
     @package = package
   end
 
-  def update?
-    @user.can_modify_package?(@package)
-  end
-
-  def destroy?
+  def delete?
     @user.can_modify_package?(@package)
   end
 end

--- a/src/api/db/migrate/20150907164338_add_backendcomment_to_package.rb
+++ b/src/api/db/migrate/20150907164338_add_backendcomment_to_package.rb
@@ -1,5 +1,0 @@
-class AddBackendcommentToPackage < ActiveRecord::Migration
-  def change
-    add_column :packages, :commit_opts, :string
-  end
-end

--- a/src/api/db/migrate/20150907164610_add_backendcomment_to_project.rb
+++ b/src/api/db/migrate/20150907164610_add_backendcomment_to_project.rb
@@ -1,5 +1,0 @@
-class AddBackendcommentToProject < ActiveRecord::Migration
-  def change
-    add_column :projects, :commit_opts, :string
-  end
-end

--- a/src/api/db/structure.sql
+++ b/src/api/db/structure.sql
@@ -715,7 +715,6 @@ CREATE TABLE `packages` (
   `bcntsynctag` varchar(255) CHARACTER SET utf8 DEFAULT NULL,
   `develpackage_id` int(11) DEFAULT NULL,
   `delta` tinyint(1) NOT NULL DEFAULT '1',
-  `commit_opts` varchar(255) COLLATE utf8_bin DEFAULT NULL,
   PRIMARY KEY (`id`),
   UNIQUE KEY `packages_all_index` (`project_id`,`name`(255)),
   KEY `devel_package_id_index` (`develpackage_id`),
@@ -826,7 +825,6 @@ CREATE TABLE `projects` (
   `develproject_id` int(11) DEFAULT NULL,
   `delta` tinyint(1) NOT NULL DEFAULT '1',
   `kind` enum('standard','maintenance','maintenance_incident','maintenance_release') COLLATE utf8_bin DEFAULT 'standard',
-  `commit_opts` varchar(255) COLLATE utf8_bin DEFAULT NULL,
   PRIMARY KEY (`id`),
   UNIQUE KEY `projects_name_index` (`name`(255)),
   KEY `updated_at_index` (`updated_at`),
@@ -1660,10 +1658,6 @@ INSERT INTO schema_migrations (version) VALUES ('20150807105426');
 INSERT INTO schema_migrations (version) VALUES ('20150902130939');
 
 INSERT INTO schema_migrations (version) VALUES ('20150903084813');
-
-INSERT INTO schema_migrations (version) VALUES ('20150907164338');
-
-INSERT INTO schema_migrations (version) VALUES ('20150907164610');
 
 INSERT INTO schema_migrations (version) VALUES ('20150916084813');
 

--- a/src/api/test/functional/request_controller_test.rb
+++ b/src/api/test/functional/request_controller_test.rb
@@ -235,7 +235,6 @@ XML
                      {"who"=>"Iggy", "when"=>"2010-07-12T00:00:01", "description"=>"Request got a new priority: critical => low", "comment"=>"dontcare"},
                      {"who"=>"Iggy", "when"=>"2010-07-12T00:00:02", "description"=>"Request got declined", "comment"=>"notgood"},
                      {"who"=>"Iggy", "when"=>"2010-07-12T00:00:03", "description"=>"Request got reopened", "comment"=>"oops"},
-                     {"who"=>"Iggy", "when"=>"2010-07-12T00:00:04", "description"=>"Request got revoked", "comment"=>"The source project 'home:Iggy:branches:home:Iggy' was removed"},
                      {"who"=>"Iggy", "when"=>"2010-07-12T00:00:04", "description"=>"Request got accepted", "comment"=>"approved"}
                    ],
                    'description' => 'DESCRIPTION IS HERE'
@@ -2480,8 +2479,8 @@ XML
     # accept the other request, what will fail
     login_king
     post "/request/#{id2}?cmd=changestate&newstate=accepted&force=1"
-    assert_response 403
-    assert_xml_tag(:tag => 'status', :attributes => { code: 'post_request_no_permission' })
+    assert_response 404
+    assert_xml_tag(:tag => 'status', :attributes => { code: 'not_existing_target' })
 
     # decline the request
     post "/request/#{id2}?cmd=changestate&newstate=declined"
@@ -2592,7 +2591,7 @@ XML
     get "/request/#{id2}"
     assert_response :success
     assert_xml_tag(tag: 'state', attributes: { name: 'revoked', when: '2010-07-14T00:00:00', who: 'Iggy' })
-    assert_xml_tag(:tag => 'comment', :content => 'Permission problem')
+    assert_xml_tag(:tag => 'comment', :content => 'Target disappeared')
 
     # good, now revive to fix the state of the union
     post '/source/home:Iggy/TestPack?cmd=undelete'

--- a/src/api/test/functional/webui/user_controller_test.rb
+++ b/src/api/test/functional/webui/user_controller_test.rb
@@ -12,7 +12,6 @@ class Webui::UserControllerTest < Webui::IntegrationTest
   end
 
   def test_creation_of_home_projects
-    User.current = users(:Iggy)
     Project.find_by(name: "home:Iggy").destroy
     login_Iggy
 

--- a/src/api/test/test_helper.rb
+++ b/src/api/test/test_helper.rb
@@ -427,7 +427,7 @@ module Webui
       find(:id, 'delete-package').click
       find(:id, 'del_dialog').must_have_text 'Delete Confirmation'
       find_button('Ok').click
-      find('#flash-messages').must_have_text "Package was successfully removed."
+      find('#flash-messages').must_have_text "Package '#{package}' was removed successfully"
     end
 
   end

--- a/src/api/test/unit/attribute_test.rb
+++ b/src/api/test/unit/attribute_test.rb
@@ -126,7 +126,7 @@ class AttributeTest < ActiveSupport::TestCase
     #check precondition
     assert_equal "OBS", @attrib_ns.name
 
-    @at = AttribType.find_by_namespace_and_name("OBS", "Maintained")
+    @at = AttribType.find_by_namespace_and_name( "OBS", "Maintained" )
     assert_not_nil @at
     assert_equal 58, @at.id
     assert_equal "Maintained", @at.name
@@ -134,30 +134,30 @@ class AttributeTest < ActiveSupport::TestCase
     assert_equal "OBS", @at.attrib_namespace.name
 
     axml = " <attribute namespace='OBS' name='Maintained' /> "
-    xml = ActiveXML::Node.new(axml)
+    xml = ActiveXML::Node.new( axml )
 
     # store in a project
-    @project = Project.create(name: "GNOME18")
+    @project = Project.find_by_name( "kde4" )
     assert_not_nil @project
     @project.store_attribute_axml(xml)
     @project.store
 
-    @p = Project.find_by_name("GNOME18")
+    @p = Project.find_by_name( "kde4" )
     assert_not_nil @p
-    @a = @p.find_attribute("OBS", "Maintained")
+    @a = @p.find_attribute( "OBS", "Maintained" )
     assert_not_nil @a
     assert_equal "Maintained", @a.attrib_type.name
 
 
     # store in a package
-    @package = @project.packages.create(name: "kdebase")
+    @package = Package.find_by_project_and_name( "kde4", "kdebase" )
     assert_not_nil @package
     @package.store_attribute_axml(xml)
     @package.store
 
-    @p = Package.find_by_project_and_name("GNOME18", "kdebase")
+    @p = Package.find_by_project_and_name( "kde4", "kdebase" )
     assert_not_nil @p
-    @a = @p.find_attribute("OBS", "Maintained")
+    @a = @p.find_attribute( "OBS", "Maintained" )
     assert_not_nil @a
     assert_equal "Maintained", @a.attrib_type.name
 
@@ -166,16 +166,16 @@ class AttributeTest < ActiveSupport::TestCase
     axml = "<attribute namespace='OBS' name='Maintained' >
               <value>blah</value>
             </attribute> "
-    xml = ActiveXML::Node.new(axml)
+    xml = ActiveXML::Node.new( axml )
 
     # store in a project
-    @project = Project.find_by_name( "GNOME18" )
+    @project = Project.find_by_name( "kde4" )
     assert_not_nil @project
     assert_raise ActiveRecord::RecordInvalid do
       @project.store_attribute_axml(xml)
     end
     # store in a package
-    @package = Package.find_by_project_and_name( "GNOME18", "kdebase" )
+    @package = Package.find_by_project_and_name( "kde4", "kdebase" )
     assert_not_nil @package
     e = assert_raise(ActiveRecord::RecordInvalid) do
       @package.store_attribute_axml(xml)

--- a/src/api/test/unit/project_test.rb
+++ b/src/api/test/unit/project_test.rb
@@ -327,7 +327,6 @@ END
   end
 
   def test_handle_project_links
-    Suse::Backend.start_test_backend
     User.current = users( :Iggy )
 
     # project A
@@ -340,8 +339,6 @@ END
       )
     projectA = Project.create( :name => "home:Iggy:A" )
     projectA.update_from_xml!(axml)
-    projectA.store
-
     # project B
     axml = Xmlhash.parse(
       "<project name='home:Iggy:B'>
@@ -352,7 +349,6 @@ END
       )
     projectB = Project.create( :name => "home:Iggy:B" )
     projectB.update_from_xml!(axml)
-    projectB.store
 
     # validate xml
     xml_string = projectA.to_axml
@@ -364,7 +360,6 @@ END
     projectB.reload
     xml_string = projectB.to_axml
     assert_no_xml_tag xml_string, :tag => :link
-    projectB.destroy
   end
 
 

--- a/src/api/test/unit/watched_project_test.rb
+++ b/src/api/test/unit/watched_project_test.rb
@@ -6,7 +6,6 @@ class WatchedProjectTest < ActiveSupport::TestCase
   def test_watchlist_cleaned_after_project_removal
     User.current = users(:Iggy)
     tmp_prj = Project.create(name: 'home:Iggy:whatever')
-    tmp_prj.write_to_backend
     user_ids = User.limit(5).map{|u|u.id} # Roundup some users to watch tmp_prj
     user_ids.each do |uid|
       tmp_prj.watched_projects.create(user_id: uid)


### PR DESCRIPTION
Just stumbled over the commit_opts in the code again. I do not think that this save that way on multiple rails instance setup, since the database operation is not in a transaction in all situations (eg. source commit). So the wrong options might be used in the history of source files.

Revert right away to avoid that instance apply the migrations, let's discuss that before.

Reverts openSUSE/open-build-service#1161