### PR TITLE
[ci] Fix decreased test coverage value caused by 7d818bd

### DIFF
--- a/src/api/test/functional/status_controller_test.rb
+++ b/src/api/test/functional/status_controller_test.rb
@@ -77,31 +77,32 @@ class StatusControllerTest < ActionDispatch::IntegrationTest
       assert_select "summary", "Required Parameter hours missing"
     end
 
-    Timecop.freeze(2010, 7, 12)
-    day_before_yesterday = Time.now.to_i - 2.days
-    yesterday = Time.now.to_i - 1.days
-    1.times do |i|
-      StatusHistory.create(time: day_before_yesterday + i, key: 'squeue_low_aarch64', value: i)
-    end
-    2.times do |i|
-      StatusHistory.create(time: yesterday + i, key: 'squeue_low_aarch64', value: i)
-    end
+    Timecop.freeze(2010, 7, 12) do
+      day_before_yesterday = Time.now.to_i - 2.days
+      yesterday = Time.now.to_i - 1.days
+      1.times do |i|
+        StatusHistory.create(time: day_before_yesterday + i, key: 'squeue_low_aarch64', value: i)
+      end
+      2.times do |i|
+        StatusHistory.create(time: yesterday + i, key: 'squeue_low_aarch64', value: i)
+      end
 
-    get "/status/history?hours=24&key=squeue_low_aarch64"
-    assert_response :success
-    assert_select "history" do
-      assert_select "value", time: "1278806399.5", value: "0.0"
-    end
+      get "/status/history?hours=24&key=squeue_low_aarch64"
+      assert_response :success
+      assert_select "history" do
+        assert_select "value", time: "1278806399.5", value: "0.0"
+      end
 
-    # there is no history in fixtures so the result doesn't matter
-    # invalid parameters
-    get "/status/history?hours=-1&samples=-10"
-    assert_response 400
-    assert_select "status", code: "missing_parameter" do
-      assert_select "summary", "Required Parameter key missing"
-    end
+      # there is no history in fixtures so the result doesn't matter
+      # invalid parameters
+      get "/status/history?hours=-1&samples=-10"
+      assert_response 400
+      assert_select "status", code: "missing_parameter" do
+        assert_select "summary", "Required Parameter key missing"
+      end
 
-    get "/status/history?hours=5&samples=10&key=idle_i586"
-    assert_not_nil assigns(@samples)
+      get "/status/history?hours=5&samples=10&key=idle_i586"
+      assert_not_nil assigns(@samples)
+    end
   end
 end


### PR DESCRIPTION
For some strange reason coverage went down by 20% because of the Timecop.freeze
call. Putting the code into a block should make sure to unfreeze time afterwards
and thus fix the coverage report.