### PR TITLE
[ci] Fixes Timecop affects OBS's test coverage, issue#1268

### DIFF
--- a/src/api/test/functional/source_controller_test.rb
+++ b/src/api/test/functional/source_controller_test.rb
@@ -3131,9 +3131,10 @@ Ignore: package:cups'
     assert_xml_tag :tag => "value", :parent =>
                  { :tag => "attribute", :attributes =>{ :name=>"AutoCleanup", :namespace=>"OBS"} }
 
-    Timecop.freeze(10.days) # in future
-    ProjectCreateAutoCleanupRequests.new.perform
-    Timecop.return
+    # in future
+    Timecop.freeze(10.days) do
+      ProjectCreateAutoCleanupRequests.new.perform
+    end
     #validate request
     br = BsRequest.all.last
     assert_equal br.state, :new
@@ -3141,9 +3142,10 @@ Ignore: package:cups'
     assert_equal br.bs_request_actions.first.target_project, "home:fredlibs:branches:home:Iggy"
     assert_not_nil br.accept_at
     # second run shall not open another request
-    Timecop.freeze(12.days) # in future
-    ProjectCreateAutoCleanupRequests.new.perform
-    Timecop.return
+    # in future
+    Timecop.freeze(12.days) do
+      ProjectCreateAutoCleanupRequests.new.perform
+    end
     assert_equal br, BsRequest.all.last
 
     # cleanup and try again with defaults

--- a/src/api/test/functional/status_controller_test.rb
+++ b/src/api/test/functional/status_controller_test.rb
@@ -4,6 +4,10 @@ class StatusControllerTest < ActionDispatch::IntegrationTest
 
   fixtures :all
 
+  teardown do
+    Timecop.return
+  end
+
   def setup
     prepare_request_valid_user
   end

--- a/src/api/test/functional/webui/watchlists_test.rb
+++ b/src/api/test/functional/webui/watchlists_test.rb
@@ -2,6 +2,10 @@ require_relative '../../test_helper'
 
 class Webui::WatchlistTest < Webui::IntegrationTest
 
+  teardown do
+    Timecop.return
+  end
+
   def test_watchlists
     use_js
     login_tom to: project_show_path(project: 'BaseDistro')

--- a/src/api/test/unit/event_mailer_test.rb
+++ b/src/api/test/unit/event_mailer_test.rb
@@ -3,6 +3,10 @@ require_relative '../test_helper'
 class EventMailerTest < ActionMailer::TestCase
   fixtures :all
 
+  teardown do
+    Timecop.return
+  end
+
   def verify_email(fixture_name, email)
     should = load_fixture("event_mailer/#{fixture_name}").chomp
     assert_equal should, email.encoded.lines.map(&:chomp).select { |l| l !~ %r{^Date:} }.join("\n")


### PR DESCRIPTION
Timecop seems to affect how coveralls determines testcoverage, see PR 1262.
This commit should make sure that our tests return to a normal state after
using Timecop and hopefully help getting a realistic coverage.