### PR TITLE
Add support for k1om

### DIFF
--- a/docs/api/api/obs.rng
+++ b/docs/api/api/obs.rng
@@ -59,6 +59,8 @@
 
       <value>x86_64</value>
 
+      <value>k1om</value>
+
       <value>local</value>
     </choice>
   </define>

--- a/src/backend/BSCando.pm
+++ b/src/backend/BSCando.pm
@@ -44,6 +44,8 @@ our %cando = (
   'i686'    => [           'i586',         'i686' ],
   'x86_64'  => [ 'x86_64', 'i586:linux32', 'i686:linux32' ],
 
+  'k1om'    => [           'k1om' ],
+
   'parisc'  => [ 'hppa', 'hppa64:linux64' ],
   'parisc64'=> [ 'hppa64', 'hppa:linux32' ],
 

--- a/src/backend/bs_publish
+++ b/src/backend/bs_publish
@@ -579,6 +579,7 @@ VERSION 1.0-0
 LABEL $data->{'repoinfo'}->{'title'}
 VENDOR Open Build Service
 ARCH.x86_64 x86_64 i686 i586 i486 i386 noarch
+ARCH.k1om k1om noarch
 ARCH.ppc64p7 ppc64p7 noarch
 ARCH.ppc64 ppc64 ppc noarch
 ARCH.ppc64le ppc64le noarch


### PR DESCRIPTION
This is a forward port from 2.5. There was a change against `build-vm` that I can't find in master now.