### PR TITLE
[webui] Move request permission check in lock statement

### DIFF
--- a/src/api/app/models/bs_request.rb
+++ b/src/api/app/models/bs_request.rb
@@ -436,9 +436,8 @@ class BsRequest < ActiveRecord::Base
   end
 
   def change_state(opts)
-    self.permission_check_change_state!(opts)
-
     self.with_lock do
+      self.permission_check_change_state!(opts)
       changestate_revoked if opts[:newstate] == 'revoked'
       changestate_accepted(opts) if opts[:newstate] == 'accepted'
 
@@ -470,27 +469,27 @@ class BsRequest < ActiveRecord::Base
         end
       end
       self.save!
-    end
 
-    params={request: self, comment: opts[:comment], user_id: User.current.id}
-    case opts[:newstate]
-      when "accepted" then
-        history = HistoryElement::RequestAccepted
-      when "declined" then
-        history = HistoryElement::RequestDeclined
-      when "revoked" then
-        history = HistoryElement::RequestRevoked
-      when "superseded" then
-        history = HistoryElement::RequestSuperseded
-        params[:description_extension] = self.superseded_by.to_s
-      when "review" then
-        history = HistoryElement::RequestReopened
-      when "new" then
-        history = HistoryElement::RequestReopened
-      else
-        raise RuntimeError, "Unhandled state #{opts[:newstate]} for history"
+      params={request: self, comment: opts[:comment], user_id: User.current.id}
+      case opts[:newstate]
+        when "accepted" then
+          history = HistoryElement::RequestAccepted
+        when "declined" then
+          history = HistoryElement::RequestDeclined
+        when "revoked" then
+          history = HistoryElement::RequestRevoked
+        when "superseded" then
+          history = HistoryElement::RequestSuperseded
+          params[:description_extension] = self.superseded_by.to_s
+        when "review" then
+          history = HistoryElement::RequestReopened
+        when "new" then
+          history = HistoryElement::RequestReopened
+        else
+          raise RuntimeError, "Unhandled state #{opts[:newstate]} for history"
+      end
+      history.create(params)
     end
-    history.create(params)
   end
 
   def _assignreview_update_reviews(reviewer, opts)


### PR DESCRIPTION
User reported that it was possible to accept a request several times.
Changing the request state is already wrapped in a transaction but
checking the permissions and creating the history is not. So finally
moved permission check and creating history also in the with_lock
block to avoid race conditions. This will fix #1157.