### PR TITLE
[ci] Increase capybara timeout value to 6

### DIFF
--- a/src/api/test/test_helper.rb
+++ b/src/api/test/test_helper.rb
@@ -40,7 +40,7 @@ require 'mocha/setup'
 require 'capybara/poltergeist'
 
 require 'capybara/rails'
-Capybara.default_wait_time = 2
+Capybara.default_wait_time = 6
 
 Capybara.register_driver :poltergeist do |app|
   Capybara::Poltergeist::Driver.new(app, debug: false, timeout: 30)


### PR DESCRIPTION
Commit 82380aedccfae20e6003ed6c decreased the capybara timeout to allow
faster development - test cycles. Since recently we got a couple of test
failures, which might have been caused by this change. And the fact that travis got under higher load. So we have to tweak the value a bit.

Let's see if a timeout of 6 works better for OBS.