### PR TITLE
Live log

### DIFF
--- a/src/api/app/controllers/webui/package_controller.rb
+++ b/src/api/app/controllers/webui/package_controller.rb
@@ -20,7 +20,7 @@ class Webui::PackageController < Webui::WebuiController
                                         :branch_dialog, :branch, :save_new_link, :save, :delete_dialog,
                                         :remove, :add_file, :save_file, :remove_file, :save_person,
                                         :save_group, :remove_role, :view_file,
-                                        :live_build_log, :update_build_log, :abort_build, :trigger_rebuild,
+                                        :abort_build, :trigger_rebuild,
                                         :wipe_binaries, :buildresult, :rpmlint_result, :rpmlint_log, :meta,
                                         :save_meta, :attributes, :edit, :change_flag,
                                         :import_spec, :files, :comments]
@@ -31,7 +31,7 @@ class Webui::PackageController < Webui::WebuiController
                                             :branch_dialog, :branch, :save, :delete_dialog,
                                             :remove, :add_file, :save_file, :remove_file, :save_person,
                                             :save_group, :remove_role, :view_file,
-                                            :live_build_log, :update_build_log, :abort_build, :trigger_rebuild,
+                                            :abort_build, :trigger_rebuild,
                                             :wipe_binaries, :buildresult, :rpmlint_result, :rpmlint_log, :meta,
                                             :save_meta, :attributes, :edit, :change_flag,
                                             :import_spec, :files, :comments, :repositories, :users,
@@ -803,11 +803,17 @@ class Webui::PackageController < Webui::WebuiController
 
   def live_build_log
     required_parameters :arch, :repository
-    if @package and not @package.check_source_access?
+
+    @project = Project.get_by_name(params[:project])
+    @package = Package.get_by_project_and_name(params[:project], params[:package], use_source: false, follow_project_links: true)
+
+    if @package && !@package.check_source_access?
       flash[:error] = 'Could not access build log'
       redirect_to action: :show, project: @project.name, package: @package.name
       return
     end
+
+    @package = params[:package] unless @package
     @arch = params[:arch]
     @repo = params[:repository]
     @offset = 0

--- a/src/api/app/helpers/webui/webui_helper.rb
+++ b/src/api/app/helpers/webui/webui_helper.rb
@@ -97,17 +97,8 @@ module Webui::WebuiHelper
 
     if %w(unresolvable blocked).include?(code)
       result += link_to(code, '#', title: link_title, id: status_id, class: code)
-    elsif %w(- excluded).include?(code)
+    elsif %w(- excluded scheduled).include?(code)
       result += code
-    elsif @localpackages && !@localpackages.has_key?(package_name)
-      # Scheduled packages have no raw log file...
-      if 'scheduled' == code
-        result += code
-      else
-        result += link_to(code.gsub(/\s/, '&nbsp;'),
-                          raw_logfile_path(package: package_name, project: @project.to_s, arch: arch, repository: repo),
-                          title: link_title, rel: 'nofollow')
-      end
     else
       result += link_to(code.gsub(/\s/, '&nbsp;'),
                         {

--- a/src/api/app/views/webui/package/_live_log_controls.html.erb
+++ b/src/api/app/views/webui/package/_live_log_controls.html.erb
@@ -4,7 +4,7 @@
   <%= link_to sprited_text('script', 'Download logfile'), raw_logfile_path(package: @package, project: @project, arch: @arch, repository: @repo) %>
 </p>
 
-<% if User.current.can_modify_package? @package %>
+<% if @package.kind_of?(Package) && User.current.can_modify_package?(@package) %>
     <p>
       <span class="link_trigger_rebuild hidden">
       <%= link_to sprited_text('rebuild', 'Trigger Rebuild'), {action: 'trigger_rebuild', project: @project, package: @package, arch: @arch, repo: @repo}, method: :delete %>

--- a/src/api/app/views/webui/package/live_build_log.html.erb
+++ b/src/api/app/views/webui/package/live_build_log.html.erb
@@ -3,7 +3,9 @@
    package_bread_crumb 'Build Log' 
 -%>
 
-<%= render :partial => "tabs" %>
+<% if !@project.is_remote? && @package.kind_of?(Package)%>
+  <%= render :partial => "tabs" %>
+<% end %>
 
 <%= content_for :ready_function do %>
   live_build_log_ready();
@@ -25,7 +27,7 @@
   <pre id="log_space"></pre>
 </div>
 
-<% if not @workerid %>
+<% unless @workerid %>
   <%= render :partial => "live_log_controls" %>
 <% end %>
 

--- a/src/api/script/start_test_backend
+++ b/src/api/script/start_test_backend
@@ -270,6 +270,7 @@ Suse::Backend.put('/source/kde4/kdebase/myfile2?user=king', 'DummyContent')
 Suse::Backend.put('/source/kde4/kdelibs/my_patch.diff?user=king', 'argl')
 Suse::Backend.put('/source/home:dmayr/x11vnc/README?user=king', 'just to delete')
 Suse::Backend.put('/source/home:king/_config?user=king', 'Type: spec')
+Suse::Backend.put('/source/UseRemoteInstance/_config?user=king', 'Type: spec')
 
 # manual placing of files
 FileUtils.cp("#{Rails.root}/test/fixtures/backend/source/_pubkey", "#{backend_data}/projects/BaseDistro.pkg/_pubkey")
@@ -347,6 +348,7 @@ scheduler_thread = Thread.new do
   inject_build_job('home:Iggy', 'TestPack', '10.2', 'i586')
   inject_build_job('home:Iggy', 'TestPack', '10.2', 'x86_64')
   inject_build_job('HiddenProject', 'pack', 'nada', 'i586')
+  inject_build_job('UseRemoteInstance', 'pack2.linked', 'pop', 'i586')
   inject_build_job('BinaryprotectedProject', 'bdpack', 'nada', 'i586')
   inject_build_job('SourceprotectedProject', 'pack', 'repo', 'i586')
   inject_build_job('BaseDistro3', 'pack2', 'BaseDistro3_repo', 'i586', "package_newweaktags-1.0-1.x86_64.rpm")

--- a/src/api/test/fixtures/linked_projects.yml
+++ b/src/api/test/fixtures/linked_projects.yml
@@ -1,7 +1,7 @@
 UseRemoteInstance:
   id: 43
   position: 1
-  linked_remote_project_name: RemoteInstance:BaseDistro
+  linked_remote_project_name: RemoteInstance:BaseDistro2.0
   project: UseRemoteInstance
 UseRemoteInstanceIndirect_to_UseRemoteInstance:
   id: 45

--- a/src/api/test/fixtures/path_elements.yml
+++ b/src/api/test/fixtures/path_elements.yml
@@ -26,3 +26,7 @@ record_6:
   parent_id: 83
   repository_id: 82
   position: 1
+UseRemoteInstance_pop_path:
+  parent_id: BaseDistro_repo
+  repository_id: UseRemoteInstance_pop
+  position: 1

--- a/src/api/test/fixtures/repositories.yml
+++ b/src/api/test/fixtures/repositories.yml
@@ -31,10 +31,11 @@ repositories_83:
   id: 83
   name: home_coolo
   project: home_coolo_test
-repositories_87:
+UseRemoteInstance_pop:
   id: 87
   name: pop
   project: UseRemoteInstance
+  linkedbuild: all
 repositories_88:
   id: 88
   name: pop
@@ -47,7 +48,7 @@ repositories_90:
   id: 90
   name: nada
   project: BinaryprotectedProject
-repositories_91:
+BaseDistro_repo:
   id: 91
   name: BaseDistro_repo
   project: BaseDistro

--- a/src/api/test/functional/interconnect_test.rb
+++ b/src/api/test/functional/interconnect_test.rb
@@ -116,21 +116,21 @@ class InterConnectTests < ActionDispatch::IntegrationTest
     assert_response :success
     get '/public/source/UseRemoteInstance/_meta'
     assert_response :success
-    get '/public/source/UseRemoteInstance/pack1'
+    get '/public/source/UseRemoteInstance/pack2.linked'
     assert_response :success
-    get '/public/source/UseRemoteInstance/pack1?expand'
+    get '/public/source/UseRemoteInstance/pack2.linked?expand'
     assert_response :success
-    get '/public/source/UseRemoteInstance/pack1?expand=1'
+    get '/public/source/UseRemoteInstance/pack2.linked?expand=1'
     assert_response :success
-    get '/public/source/UseRemoteInstance/pack1/_meta'
+    get '/public/source/UseRemoteInstance/pack2.linked/_meta'
     assert_response :success
-    get '/public/source/UseRemoteInstance/pack1/my_file'
+    get '/public/source/UseRemoteInstance/pack2.linked/package.spec'
     assert_response :success
     get '/public/source/UseRemoteInstance/NotExisting'
     assert_response 404
     get '/public/source/UseRemoteInstance/NotExisting/_meta'
     assert_response 404
-    get '/public/source/UseRemoteInstance/NotExisting/my_file'
+    get '/public/source/UseRemoteInstance/NotExisting/package.spec'
     assert_response 404
   end
 
@@ -288,15 +288,15 @@ class InterConnectTests < ActionDispatch::IntegrationTest
       assert_response :success
       get "/source/#{project}/_meta"
       assert_response :success
-      get "/source/#{project}/pack1"
+      get "/source/#{project}/pack2.linked"
       assert_response :success
-      get "/source/#{project}/pack1/_meta"
+      get "/source/#{project}/pack2.linked/_meta"
       assert_response :success
-      get "/source/#{project}/pack1/my_file"
+      get "/source/#{project}/pack2.linked/package.spec"
       assert_response :success
-      post "/source/#{project}/pack1", :cmd => 'showlinked'
+      post "/source/#{project}/pack2", :cmd => 'showlinked'
       assert_response :success
-      post "/source/#{project}/pack1", :cmd => 'branch'
+      post "/source/#{project}/pack2", :cmd => 'branch'
       assert_response :success
       get "/source/#{project}"
       assert_response :success
@@ -311,13 +311,12 @@ end
     end
 
     # check access to binaries of remote instance
-    get '/build/UseRemoteInstance/pop/i586/pack1/_log'
-    assert_response 400
-    assert_match(/remote error: pack1  no logfile/, @response.body) # we had no build, but request reached backend
+    get '/build/UseRemoteInstance/pop/i586/pack2.linked/_log'
+    assert_response :success
     # test source modifications
-    post '/build/UseRemoteInstance/pack1', :cmd => 'set_flag'
+    post '/build/UseRemoteInstance/pack2', :cmd => 'set_flag'
     assert_response 403
-    post '/build/UseRemoteInstance/pack1', :cmd => 'unlock'
+    post '/build/UseRemoteInstance/pack2', :cmd => 'unlock'
     assert_response 403
     get '/source/UseRemoteInstance/NotExisting'
     assert_response 404
@@ -327,9 +326,9 @@ end
     assert_response 404
     # test binary operations
     login_king
-    post '/build/UseRemoteInstance', :cmd => 'wipe', :package => 'pack1'
+    post '/build/UseRemoteInstance', :cmd => 'wipe', :package => 'pack2.linked'
     assert_response :success
-    post '/build/UseRemoteInstance', :cmd => 'rebuild', :package => 'pack1'
+    post '/build/UseRemoteInstance', :cmd => 'rebuild', :package => 'pack2.linked'
     assert_response :success
     post '/build/UseRemoteInstance', :cmd => 'wipe'
     assert_response :success
@@ -413,15 +412,15 @@ end
   def test_submit_requests_from_remote
 
     login_king
-    post '/source/LocalProject/pack1', :cmd => :copy, :oproject => 'LocalProject', :opackage => 'remotepackage'
+    post '/source/LocalProject/pack2.linked', :cmd => :copy, :oproject => 'LocalProject', :opackage => 'remotepackage'
     assert_response :success
 
     login_tom
-    # FIXME: submission from a remote project is not yet supported "RemoteInstance:BaseDistro"
+    # FIXME: submission from a remote project is not yet supported "RemoteInstance:BaseDistro2.0"
     %w(LocalProject UseRemoteInstance).each do |prj|
       post '/request?cmd=create', '<request>
                                    <action type="submit">
-                                     <source project="' + prj + '" package="pack1" rev="1"/>
+                                     <source project="' + prj + '" package="pack2.linked" rev="1"/>
                                      <target project="home:tom" package="pack1"/>
                                    </action>
                                    <state name="new" />
@@ -440,7 +439,7 @@ end
     end
 
     login_king
-    delete '/source/LocalProject/pack1'
+    delete '/source/LocalProject/pack2.linked'
     assert_response :success
   end
 
@@ -453,14 +452,14 @@ end
     assert_response :success
     delete '/source/LocalProject/temporary'
     assert_response :success
-    post '/source/LocalProject/temporary', :cmd => :copy, :oproject => 'UseRemoteInstance', :opackage => 'pack1'
+    post '/source/LocalProject/temporary', :cmd => :copy, :oproject => 'UseRemoteInstance', :opackage => 'pack2.linked'
     assert_response :success
     post '/source/LocalProject/temporary', :cmd => :copy, :oproject => 'RemoteInstance:BaseDistro', :opackage => 'pack1'
     assert_response :success
 
     post '/source/LocalProject/temporary', :cmd => :diff, :oproject => 'LocalProject', :opackage => 'remotepackage'
     assert_response :success
-    post '/source/LocalProject/temporary', :cmd => :diff, :oproject => 'UseRemoteInstance', :opackage => 'pack1'
+    post '/source/LocalProject/temporary', :cmd => :diff, :oproject => 'UseRemoteInstance', :opackage => 'pack2.linked'
     assert_response :success
 
     login_king

--- a/src/api/test/functional/source_controller_test.rb
+++ b/src/api/test/functional/source_controller_test.rb
@@ -2851,7 +2851,7 @@ Ignore: package:cups'
     put url, '<link project="RemoteInstance:BaseDistro2.0:LinkedUpdateProject" package="pack2" />'
     assert_response :success
     # working link to remote project link
-    put url, '<link project="UseRemoteInstance" package="pack1" />'
+    put url, '<link project="UseRemoteInstance" package="pack2" />'
     assert_response :success
 
     # check backend functionality
@@ -2860,17 +2860,17 @@ Ignore: package:cups'
     assert_no_xml_tag(:tag => 'entry', :attributes => { :name => 'my_file' })
     assert_xml_tag(:tag => 'entry', :attributes => { :name => 'file_in_linked_package' })
     assert_xml_tag(:tag => 'entry', :attributes => { :name => '_link' })
-    assert_xml_tag(:tag => 'linkinfo', :attributes => { :project => 'UseRemoteInstance', :package => 'pack1',
-                                                        :srcmd5 => '96c3955b419fec1a637698e52b6a7d37', :xsrcmd5 => '6660e7c304ba16c50a415617bacb8b2f', :lsrcmd5 => 'eabf686413b92c976ea073b11d797a2e' })
+    assert_xml_tag(:tag => 'linkinfo', :attributes => { :project => 'UseRemoteInstance', :package => 'pack2',
+                                                        :srcmd5 => 'd3e3fafcc29140ff418220a649df8070', :xsrcmd5 => '3481fc5f1445a65a2d463b8adf26d3a9', :lsrcmd5 => 'e6a8595663acb2095c62824bf457142c' })
     get '/source/kde4/temporary2?expand=1'
     assert_response :success
-    assert_xml_tag(:tag => 'entry', :attributes => { :name => 'my_file' })
+    assert_xml_tag(:tag => 'entry', :attributes => { :name => 'package.spec' })
     assert_xml_tag(:tag => 'entry', :attributes => { :name => 'file_in_linked_package' })
     assert_xml_tag(:tag => 'linkinfo', :attributes => { :project => 'kde4', :package => 'temporary' })
     assert_no_xml_tag(:tag => 'entry', :attributes => { :name => '_link' })
     get '/source/TEMPORARY/temporary2?expand=1'
     assert_response :success
-    assert_xml_tag(:tag => 'entry', :attributes => { :name => 'my_file' })
+    assert_xml_tag(:tag => 'entry', :attributes => { :name => 'package.spec' })
     assert_xml_tag(:tag => 'entry', :attributes => { :name => 'file_in_linked_package' })
     assert_xml_tag(:tag => 'linkinfo', :attributes => { :project => 'kde4', :package => 'temporary2' })
     assert_no_xml_tag(:tag => 'entry', :attributes => { :name => '_link' })

--- a/src/api/test/functional/webui/package_controller_test.rb
+++ b/src/api/test/functional/webui/package_controller_test.rb
@@ -375,10 +375,17 @@ class Webui::PackageControllerTest < Webui::IntegrationTest
   end
 
   def test_access_live_build_log
+    use_js
     visit '/package/live_build_log/home:Iggy/TestPack/10.2/i586'
     page.status_code.must_equal 200
+    page.must_have_text "Build finished"
+    page.must_have_text "[1] this is my dummy logfile -&gt; ümlaut"
     login_Iggy to: '/package/live_build_log/SourceprotectedProject/pack/repo/i586'
     page.status_code.must_equal 200
     flash_message.must_equal 'Could not access build log'
+    visit '/package/live_build_log/UseRemoteInstance/pack2.linked/pop/i586/'
+    page.status_code.must_equal 200
+    page.must_have_text "Build finished"
+    page.must_have_text "[1] this is my dummy logfile -&gt; ümlaut"
   end
 end


### PR DESCRIPTION
If the package is not local we showed the raw log instead. This commit will show the livelog instead.
Fix #1211.