### PR TITLE
[test] Do not click on invisible reload button, wait for it to appear.

### DIFF
--- a/src/api/test/functional/webui/package_controller_test.rb
+++ b/src/api/test/functional/webui/package_controller_test.rb
@@ -194,7 +194,12 @@ class Webui::PackageControllerTest < Webui::IntegrationTest
     # test reload and wait for the build to finish
     starttime=Time.now
     while Time.now - starttime < 10
-      first('.icons-reload').click
+      reload_button = first('.icons-reload')
+      if !reload_button
+        sleep 0.1
+        next
+      end
+      reload_button.click
       if page.has_selector? '.buildstatus'
         break if first('.buildstatus').text == 'succeeded'
       end


### PR DESCRIPTION
This change fixes test error that happens intermittently.

Sometimes reload button doesn't become visible immediately, it appears little bit later.

If `Capybara.ignore_hidden_elements` is `true` (this is default), then `first('.icons-reload')` returns `nil` until the button becomes visible. Hence, it's better to wait until it appears and then click it than to try to use `#click` method on `nil`.