### PR TITLE
[backend] fix namespace problem in bs_srcserver

### DIFF
--- a/src/backend/bs_srcserver
+++ b/src/backend/bs_srcserver
@@ -718,7 +718,7 @@ sub expandproduct {
 	if ($pidpack) {
 	  eval {
 	    $pidpack->{'name'} = $pid unless defined $pidpack->{'name'};
-	    verify_pack($pidpack, $pid);
+	    BSVerify::verify_pack($pidpack, $pid);
 	  };
 	  if ($@) {
 	    warn($@);


### PR DESCRIPTION
fixed missing namespace in bs_srcserver
 verify_pack -> BSVerify::verify_pack
to prevent "Undefined subroutine" problems