### PR TITLE
[api] use the date of the event in the mail

### DIFF
--- a/src/api/app/mailers/event_mailer.rb
+++ b/src/api/app/mailers/event_mailer.rb
@@ -49,6 +49,7 @@ class EventMailer < ActionMailer::Base
     mail(to: tos,
          subject: e.subject,
          from: orig,
+         date: e.created_at,
          template_name: template_name)
   end
 


### PR DESCRIPTION
In case of big backlogs as we have now, this helps to identify the
cause of the failure. For backend created events this is still not
proper as the backlog might be in the backlog->API part, but one
death you have to die