### PR TITLE
[api][webui] avoid wrong usage of User.can_modify_project?

### DIFF
--- a/src/api/app/models/user.rb
+++ b/src/api/app/models/user.rb
@@ -526,6 +526,11 @@ class User < ActiveRecord::Base
       raise ArgumentError, "illegal parameter type to User#can_modify_project?: #{project.class.name}"
     end
 
+    if project.new_record?
+      # Project.check_write_access(!) should have been used?
+      raise NotFoundError, "Project is not stored yet"
+    end
+
     # we don't touch the cache for ignoreLock
     return can_modify_project_internal(project, ignoreLock) if ignoreLock
 


### PR DESCRIPTION
can_modify_project? must not be used on non-stored projects. We
check only at store time creation permissions, so we would just skip them here.

There is a convenience method in Project.check_write_access(!) to
call the right check depending on if a project got created already or not.

Raise an error, when this is not done right. Fixes obs#1291