### PR TITLE
[api] handle bcntsync on branching

### DIFF
--- a/src/api/app/helpers/branch_package.rb
+++ b/src/api/app/helpers/branch_package.rb
@@ -122,8 +122,12 @@ class BranchPackage
       else
         if pac.is_a? Package
           tpkg = tprj.packages.new(:name => pack_name, :title => pac.title, :description => pac.description)
+          tpkg.bcntsynctag = pac.bcntsynctag
         else
           tpkg = tprj.packages.new(:name => pack_name)
+        end
+        if tpkg.bcntsynctag && @extend_names
+          tpkg.bcntsynctag << '.' + p[:link_target_project].name.gsub(':', '_')
         end
         tprj.packages << tpkg
       end

--- a/src/api/test/fixtures/packages.yml
+++ b/src/api/test/fixtures/packages.yml
@@ -56,6 +56,7 @@ BaseDistro2.0_pack2.linked:
   name: pack2.linked
   title: For maintenance tests
   description: ''
+  bcntsynctag: pack2
   created_at: 2007-05-16 16:19:18.000000000 Z
   updated_at: 2007-05-16 16:19:18.000000000 Z
   update_counter: 1

--- a/src/api/test/functional/maintenance_test.rb
+++ b/src/api/test/functional/maintenance_test.rb
@@ -147,6 +147,37 @@ class MaintenanceTests < ActionDispatch::IntegrationTest
     assert_response :success
   end
 
+  def test_branch_package_with_local_link
+    login_tom
+
+    post '/source/BaseDistro2.0/pack2', cmd: :branch, ignoredevel: 1
+    assert_response :success
+
+    get '/source/home:tom:branches:BaseDistro2.0/pack2/_meta'
+    assert_response :success
+    # local linked package got branched as well
+    get '/source/home:tom:branches:BaseDistro2.0/pack2.linked/_meta'
+    assert_response :success
+    assert_xml_tag tag: "bcntsynctag", content: "pack2"
+
+    # and trying with extended package names
+    delete '/source/home:tom:branches:BaseDistro2.0'
+    assert_response :success
+    post '/source/BaseDistro2.0/pack2', cmd: :branch, ignoredevel: 1, maintenance: 1
+    assert_response :success
+
+    get '/source/home:tom:branches:BaseDistro2.0/pack2.BaseDistro2.0/_meta'
+    assert_response :success
+    # local linked package got branched as well
+    get '/source/home:tom:branches:BaseDistro2.0/pack2.linked.BaseDistro2.0/_meta'
+    assert_response :success
+    assert_xml_tag tag: "bcntsynctag", content: "pack2.BaseDistro2.0"
+
+    # cleanup
+    delete '/source/home:tom:branches:BaseDistro2.0'
+    assert_response :success
+  end
+
   def test_maintenance_request_from_foreign_and_remote_project
     login_king
     # special kdelibs

--- a/src/api/test/unit/code_quality_test.rb
+++ b/src/api/test/unit/code_quality_test.rb
@@ -60,7 +60,7 @@ class CodeQualityTest < ActiveSupport::TestCase
       'AttributeController#attribute_definition'                                => 87.7,
       'BinaryRelease::update_binary_releases_via_json'                          => 128.58,
       'BranchPackage#find_packages_to_branch'                                   => 238.17,
-      'BranchPackage#create_branch_packages'                                    => 219.25,
+      'BranchPackage#create_branch_packages'                                    => 234.78,
       'BranchPackage#check_for_update_project'                                  => 105.96,
       'BranchPackage#determine_details_about_package_to_branch'                 => 91.39,
       'BranchPackage#lookup_incident_pkg'                                       => 83.09,


### PR DESCRIPTION
Still missing:
- when branching from remote
- backend test cases to handle it right for release numbers