### PR TITLE
[dist] Get rid of mini profiler

### DIFF
--- a/src/api/Gemfile
+++ b/src/api/Gemfile
@@ -101,8 +101,6 @@ end
 group :development do
   # as alternative to the standard IRB shell
   gem 'unicorn-rails' # webrick won't work
-  # for client side, DB and server profiling
-  gem 'rack-mini-profiler'
   # for calling single testd
   gem 'single_test'
   # as debugging tool in the default error page

--- a/src/api/Gemfile.lock
+++ b/src/api/Gemfile.lock
@@ -170,8 +170,6 @@ GEM
     pundit (1.0.1)
       activesupport (>= 3.0.0)
     rack (1.6.4)
-    rack-mini-profiler (0.9.3)
-      rack (>= 1.1.3)
     rack-test (0.6.3)
       rack (>= 1.0)
     rails (4.2.2)
@@ -337,7 +335,6 @@ DEPENDENCIES
   poltergeist (>= 1.4)
   pry (>= 0.9.12)
   pundit
-  rack-mini-profiler
   rails (~> 4.2.2)
   rails_tokeninput (>= 1.6.1.rc1)
   rdoc


### PR DESCRIPTION
It runs amok when javascript crashes. And no one is using it anyhow...