### PR TITLE
Allow .repo file priority to be indicated in project _meta.

### DIFF
--- a/src/api/test/unit/project_test.rb
+++ b/src/api/test/unit/project_test.rb
@@ -202,6 +202,23 @@ Ignore: package:cups'
 
   end
 
+  def test_priority
+    User.current = users(:Iggy)
+
+    #project is given as axml
+    axml = Xmlhash.parse(
+      "<project name='home:Iggy'>
+        <title>Iggy's Home Project</title>
+        <description>dummy</description>
+        <priority>17</priority>
+      </project>"
+      )
+    @project.update_from_xml!(axml)
+    @project.reload
+    xml = @project.render_xml
+    assert_xml_tag xml, :tag => :priority, :content => '17'
+  end
+
   def test_maintains
     User.current = users(:Iggy)
 

--- a/src/backend/bs_publish
+++ b/src/backend/bs_publish
@@ -459,6 +459,7 @@ sub createrepo_rpmmd {
   }
 
   my $title = $data->{'repoinfo'}->{'title'};
+  my $priority = $data->{'repoinfo'}->{'priority'};
   my $downloadurl = get_downloadurl("$projid/$repoid", $prp_ext);
   if (-x "/usr/bin/repoview") {
     my @downloadurlarg;
@@ -504,6 +505,10 @@ sub createrepo_rpmmd {
       }
     }
     print FILE "enabled=1\n";
+    # 0 represents default so no need to print, plus older version of zypper will reject
+    if ($priority ne 0) {
+      print FILE "priority=$priority\n";
+    }
     close(FILE) || die("close: $!\n");
     rename("$extrep/$projid.repo$$", "$extrep/$projid.repo") || die("rename $extrep/$projid.repo$$ $extrep/$projid.repo: $!\n");
   }
@@ -1732,10 +1737,16 @@ sub publish {
   $title .= " ($repoid)";
   $title =~ s/\n/ /sg;
 
+  my $priority = $proj->{'priority'} || 0;
+  if ($priority !~ /^\d+$/ || $priority < 0) {
+    print "WARNING: priority must be a non-negative integer\n";
+  }
+
   my $state;
   $state = $proj->{'patternmd5'} || '';
   $state .= "\0".join(',', @{$config->{'repotype'} || []}) if %bins;
   $state .= "\0".($proj->{'title'} || '') if %bins;
+  $state .= "\0".$priority if $priority;
   $state .= "\0".join(',', @{$config->{'patterntype'} || []}) if $proj->{'patternmd5'};
   $state .= "\0".join('/', map {"$_->{'project'}/$_->{'repository'}"} @{$prpsearchpath || []}) if $proj->{'patternmd5'};
   $state .= "\0".$updateinfos_state if $updateinfos_state;
@@ -1882,6 +1893,7 @@ sub publish {
     'prpsearchpath' => $prpsearchpath,
     'binaryorigins' => $binaryorigins,
     'title' => $title,
+    'priority' => $priority,
     'state' => $state,
   };
   $repoinfo->{'projectkind'} = $proj->{'kind'} if $proj->{'kind'};


### PR DESCRIPTION
Zypper already supports reading the priority option when adding a repository
from a .repo file. It can be useful for projects to specify a default priority
to ensure the desired behavior on client systems.

A possible extension of this change could be to default branched projects to a lower number (higher priority) to ensure they replace default packages they branched. Perhaps there are some other sensible defaults based on context. Additionally, I would like to see defaults specified for many of the core repositories (like kde stable/unstable etc) to help ensure users setup a local system without having all priorities set to `99` which can result in flip flop (back and forth vendor change) depending on when they refresh and the repository state.

I did not attempt to test this. If necessary I can attempt to build a local obs instance to test, but I am hoping change is simple enough a maintainer with local development environment can double check.

Please let me know if there is somewhere pre-backend that should validate the priority option. It seems like _meta is the right place based on reading docs for various project level configuration.

I look forward to your thoughts.