### PR TITLE
[webui] Remove duplicate search_owners_list

### DIFF
--- a/src/api/app/views/webui/search/_owners.html.erb
+++ b/src/api/app/views/webui/search/_owners.html.erb
@@ -8,8 +8,6 @@
     <%= project_or_package_link project: result.project, package: result.package, short: false %>
     </h6>
     <p>
-    <%= search_owners_list(result.users) %>
-    <%= search_owners_list(result.groups, :group) %>
     <% search_owners_list(result.groups, :group).each do |result| %>
       <%= result %>
       <br/>


### PR DESCRIPTION
Probably caused by a merge conflict.