### PR TITLE
[webui] Fix code mirror file mode

### DIFF
--- a/src/api/app/assets/javascripts/webui/application/cm2/index.js
+++ b/src/api/app/assets/javascripts/webui/application/cm2/index.js
@@ -79,7 +79,7 @@ function use_codemirror(id, read_only, mode)
     else {
 	codeMirrorOptions['addToolBars'] = 0;
 	if (mode.length)
-	    codeMirrorOptions['fileType'] = mode;
+	    codeMirrorOptions['mode'] = mode;
         codeMirrorOptions['extraKeys'] = {"Tab": "defaultTab", "Shift-Tab": "indentLess"};
     }
 


### PR DESCRIPTION
It's mode and not file type. This caused that it's not possible to edit special files (eg .spec, .js) in the
codemirror editor.