### PR TITLE
[webui] Fix namespace issues when catching exceptions

### DIFF
--- a/src/api/app/controllers/webui/project_controller.rb
+++ b/src/api/app/controllers/webui/project_controller.rb
@@ -173,9 +173,9 @@ class Webui::ProjectController < Webui::WebuiController
       rescue Patchinfo::IncompletePatchinfo,
              BsRequestAction::UnknownProject,
              BsRequestAction::BuildNotFinished,
-             BsRequestAction::RepositoryWithoutReleaseTarget,
-             BsRequestAction::RepositoryWithoutArchitecture,
-             BsRequestAction::ArchitectureOrderMissmatch,
+             BsRequestActionMaintenanceRelease::RepositoryWithoutReleaseTarget,
+             BsRequestActionMaintenanceRelease::RepositoryWithoutArchitecture,
+             BsRequestActionMaintenanceRelease::ArchitectureOrderMissmatch,
              BsRequestAction::VersionReleaseDiffers,
              BsRequestAction::UnknownTargetProject,
              BsRequestAction::UnknownTargetPackage => e


### PR DESCRIPTION
This was causing following error when an exception occured in /projects/new_release_request:
  "uninitialized constant BsRequestAction::RepositoryWithoutReleaseTarget"

Commit that introduced this: a1632de5