### PR TITLE
[testing] unified functions to start scheduler in testing

### DIFF
--- a/src/api/app/mixins/test_backend_tasks.rb
+++ b/src/api/app/mixins/test_backend_tasks.rb
@@ -1,0 +1,30 @@
+module TestBackendTasks
+
+  def run_scheduler(arch)
+    Rails.logger.debug "RUN_SCHEDULER #{arch}"
+    perlopts="-I#{Rails.root}/../backend -I#{Rails.root}/../backend/build"
+    IO.popen("cd #{backend_config}; exec perl #{perlopts} ./bs_sched --testmode #{arch}") do |io|
+      # just for waiting until scheduler finishes
+      io.each { |line| Rails.logger.debug("scheduler(#{arch}): #{line.strip.chomp}") unless line.blank? }
+    end
+  end
+
+  def run_dispatcher
+    Rails.logger.debug 'run dispatcher'
+    perlopts="-I#{Rails.root}/../backend -I#{Rails.root}/../backend/build"
+    IO.popen("cd #{backend_config}; exec perl #{perlopts} ./bs_dispatch --test-mode") do |io|
+      # just for waiting until dispatcher finishes
+      io.each { |line| Rails.logger.debug("dispatcher: #{line.strip.chomp}") unless line.blank? }
+    end
+  end
+
+  def run_publisher
+    Rails.logger.debug 'run publisher'
+    perlopts="-I#{Rails.root}/../backend -I#{Rails.root}/../backend/build"
+    IO.popen("cd #{backend_config}; exec perl #{perlopts} ./bs_publish --testmode") do |io|
+      # just for waiting until publisher finishes
+      io.each { |line| Rails.logger.debug("publisher: #{line.strip.chomp}") unless line.blank? }
+    end
+  end
+
+end

--- a/src/api/script/start_test_backend
+++ b/src/api/script/start_test_backend
@@ -4,6 +4,8 @@ ENV['origin_RAILS_ENV'] ||= ENV['RAILS_ENV']
 ENV['LC_ALL'] = 'C'
 require File.expand_path(File.join(File.dirname(__FILE__), '..', 'config', 'environment'))
 
+include TestBackendTasks
+
 port_src_server = 3200
 port_rep_server = 3201
 port_service_server = 3202
@@ -334,15 +336,20 @@ scheduler_thread = Thread.new do
   #
 
   # run scheduler once
-  IO.popen("cd #{backend_config}; exec ./bs_sched --testmode i586") do |io|
-    # just for waiting until scheduler finishes
-    io.each { |line| logger.debug line.strip unless line.blank? }
-  end
+  TestBackendTasks.run_scheduler('i586')
+
+  #IO.popen("cd #{backend_config}; exec ./bs_sched --testmode i586") do |io|
+  #  # just for waiting until scheduler finishes
+  #  io.each { |line| logger.debug line.strip unless line.blank? }
+  #end
+
   # run scheduler once
-  IO.popen("cd #{backend_config}; exec ./bs_sched --testmode x86_64") do |io|
-    # just for waiting until scheduler finishes
-    io.each { |line| logger.debug line.strip unless line.blank? }
-  end
+  TestBackendTasks.run_scheduler('x86_64')
+
+  #IO.popen("cd #{backend_config}; exec ./bs_sched --testmode x86_64") do |io|
+  #  # just for waiting until scheduler finishes
+  #  io.each { |line| logger.debug line.strip unless line.blank? }
+  #end
 
   # Inject build job results
   inject_build_job('home:Iggy', 'TestPack', '10.2', 'i586')
@@ -357,21 +364,19 @@ scheduler_thread = Thread.new do
   Suse::Backend.put('/build/home:Iggy/10.2/i586/_repository/delete_me.rpm?wipe=1',
                     File.open("#{Rails.root}/test/fixtures/backend/binary/delete_me-1.0-1.i586.rpm").read())
 
+  TestBackendTasks.run_scheduler('i586')
   # run scheduler again to handle the build result
-  IO.popen("cd #{backend_config}; exec ./bs_sched --testmode i586") do |io|
-    # just for waiting until scheduler finishes
-    io.each { |line| logger.debug line.strip unless line.blank? }
-  end
+  #IO.popen("cd #{backend_config}; exec ./bs_sched --testmode i586") do |io|
+  #  # just for waiting until scheduler finishes
+  #  io.each { |line| logger.debug line.strip unless line.blank? }
+  #end
 
   # copy build result
   Suse::Backend.post('/build/HiddenProject/nada/i586/packCopy?cmd=copy&opackage=pack', nil)
   Suse::Backend.post('/build/BaseDistro/BaseDistro_repo/i586/pack2?cmd=copy&oproject=home:Iggy&orepository=10.2&opackage=TestPack', nil)
 
   # run scheduler again to handle the copy build event
-  IO.popen("cd #{backend_config}; exec ./bs_sched --testmode i586") do |io|
-    # just for waiting until scheduler finishes
-    io.each { |line| logger.debug line.strip unless line.blank? }
-  end
+  TestBackendTasks.run_scheduler('i586')
 
   # update event database, esp. binary_release table
   BinaryRelease.transaction(requires_new: true) do

--- a/src/api/test/test_helper.rb
+++ b/src/api/test/test_helper.rb
@@ -3,6 +3,7 @@ ENV['RAILS_ENV'] = 'test'
 require 'simplecov'
 require 'coveralls'
 require "minitest/reporters"
+
 Minitest::Reporters.use! Minitest::Reporters::SpecReporter.new
 
 if ENV['DO_COVERAGE']
@@ -371,6 +372,8 @@ end
 module ActionDispatch
   class IntegrationTest
 
+    include TestBackendTasks
+
     def teardown
       Rails.cache.clear
       reset_auth
@@ -434,35 +437,8 @@ module ActionDispatch
       super(hash)
     end
 
-    def run_dispatcher
-      Rails.logger.debug 'run dispatcher'
-      perlopts="-I#{Rails.root}/../backend -I#{Rails.root}/../backend/build"
-      IO.popen("cd #{backend_config}; exec perl #{perlopts} ./bs_dispatch --test-mode") do |io|
-        # just for waiting until dispatcher finishes
-        io.each { |line| Rails.logger.debug("dispatcher: #{line.strip.chomp}") unless line.blank? }
-      end
-    end
-
-    def run_publisher
-      Rails.logger.debug 'run publisher'
-      perlopts="-I#{Rails.root}/../backend -I#{Rails.root}/../backend/build"
-      IO.popen("cd #{backend_config}; exec perl #{perlopts} ./bs_publish --testmode") do |io|
-        # just for waiting until publisher finishes
-        io.each { |line| Rails.logger.debug("publisher: #{line.strip.chomp}") unless line.blank? }
-      end
-    end
-
     def wait_for_scheduler_start
       Suse::Backend.wait_for_scheduler_start
-    end
-
-    def run_scheduler(arch)
-      Rails.logger.debug "RUN_SCHEDULER #{arch}"
-      perlopts="-I#{Rails.root}/../backend -I#{Rails.root}/../backend/build"
-      IO.popen("cd #{backend_config}; exec perl #{perlopts} ./bs_sched --testmode #{arch}") do |io|
-        # just for waiting until scheduler finishes
-        io.each { |line| Rails.logger.debug("scheduler(#{arch}): #{line.strip.chomp}") unless line.blank? }
-      end
     end
 
     def login_king


### PR DESCRIPTION
Implemented function "run_scheduler" as mixin which can be used in
the class ActionDispatch::IntegrationTest and script/start_test_backend