### PR TITLE
[dist] Fix CustomLog in apache config

### DIFF
--- a/dist/obs-apache2.conf
+++ b/dist/obs-apache2.conf
@@ -82,7 +82,7 @@ LimitRequestFieldsize 20000
 		 nokeepalive ssl-unclean-shutdown \
 		 downgrade-1.0 force-response-1.0
 
-	CustomLog /var/log/apache2/ssl_request.log   ssl_combined
+	CustomLog /var/log/apache2/ssl_request_log   ssl_combined
 
 
         # from http://guides.rubyonrails.org/asset_pipeline.html
@@ -100,8 +100,6 @@ LimitRequestFieldsize 20000
 
         ## Older firefox versions needs this, otherwise it wont cache anything over SSL.
         Header append Cache-Control "public"
-
-	CustomLog /var/log/apache2/ssl_request.log   ssl_combined
 
 </VirtualHost>                                  
 

--- a/dist/obs-apache24.conf
+++ b/dist/obs-apache24.conf
@@ -80,7 +80,7 @@ LimitRequestFieldsize 20000
 		 nokeepalive ssl-unclean-shutdown \
 		 downgrade-1.0 force-response-1.0
 
-	CustomLog /var/log/apache2/ssl_request.log   ssl_combined
+	CustomLog /var/log/apache2/ssl_request_log   ssl_combined
 
 
         # from http://guides.rubyonrails.org/asset_pipeline.html
@@ -98,8 +98,6 @@ LimitRequestFieldsize 20000
 
         ## Older firefox versions needs this, otherwise it wont cache anything over SSL.
         Header append Cache-Control "public"
-
-	CustomLog /var/log/apache2/ssl_request.log   ssl_combined
 
 </VirtualHost>
 


### PR DESCRIPTION
Remove duplicated CustomLog entry and fix logfile name so that it is
covered by /etc/logrotate.d/apache2