### PR TITLE
[webui] Fix redirect after login for IChain mode, issue#1182

### DIFF
--- a/src/api/app/views/layouts/webui/_personal_navigation.html.erb
+++ b/src/api/app/views/layouts/webui/_personal_navigation.html.erb
@@ -31,6 +31,7 @@
             <%= hidden_field_tag(:context, 'default') %>
             <%= hidden_field_tag(:proxypath, 'reserve') %>
             <%= hidden_field_tag(:message, 'Please log in') %>
+            <%= hidden_field_tag(:url, request.fullpath) %>
             <%= label_tag(:username, 'Username') %>
             <%= text_field_tag(:username, '') %>
           </p>


### PR DESCRIPTION
This provides a redirect url which IChain can use to properly redirect to OBS.
Otherwise this would always redirect to the main page.