### PR TITLE
[webui] Remove unused proxy code from user controller's do_login action

### DIFF
--- a/src/api/app/controllers/webui/user_controller.rb
+++ b/src/api/app/controllers/webui/user_controller.rb
@@ -31,22 +31,10 @@ class Webui::UserController < Webui::WebuiController
   end
 
   def do_login
-    mode = CONFIG['proxy_auth_mode'] || CONFIG['ichain_mode'] || :basic
-    logger.debug "do_login: with #{mode}"
-
-    case mode
-    when :on
-      user = User.authenticate(request.env['HTTP_X_USERNAME'])
-    when :basic, :off
-      user = User.authenticate(params[:username], params[:password])
-    end
-
-    unless user
+    unless User.authenticate(params[:username], params[:password])
       redirect_to(user_login_path, error: 'Authentication failed')
       return
     end
-
-    logger.debug "USER found: #{user.login}"
 
     session[:login] = User.current.login
     session[:password] = params[:password]

--- a/src/api/app/models/user.rb
+++ b/src/api/app/models/user.rb
@@ -369,17 +369,13 @@ class User < ActiveRecord::Base
       '_nobody_'
     end
 
-    def authenticate(user_login, password = nil)
-      if password.nil?
-        user = User.find_by(login: user_login)
-      else
-        user = User.find_with_credentials(user_login, password)
-      end
+    def authenticate(user_login, password)
+      user = User.find_with_credentials(user_login, password)
 
       # User account is not confirmed yet
-      if [STATES['ichainrequest'], STATES['unconfirmed']].include?(user.try(:state))
-        return
-      end
+      return if user.try(:state) == STATES['unconfirmed']
+
+      Rails.logger.debug "Authentificated user '#{user.try(:login)}'"
 
       User.current = user
     end

--- a/src/api/test/fixtures/users.yml
+++ b/src/api/test/fixtures/users.yml
@@ -289,7 +289,7 @@ unconfirmed_user:
   login: unconfirmed_user
   email: test@example.com
   realname: ''
-  password: df9a257e5a7c1af44987f695369adc44
+  password: 5c7686c0284e0875b26de99c1008e998
   password_hash_type: md5
   password_salt: Vibb8QsN4I
   password_crypted: osEJSjdDGtlBY

--- a/src/api/test/unit/user_test.rb
+++ b/src/api/test/unit/user_test.rb
@@ -10,10 +10,6 @@ class UserTest < ActiveSupport::TestCase
   end
 
   def test_login
-    user = User.authenticate("tom")
-    assert_equal User.find_by(login: "tom"), user
-    assert_equal User.find_by(login: "tom"), User.current
-
     user = User.authenticate("tom", "thunder")
     assert_equal User.find_by(login: "tom"), user
     assert_equal User.find_by(login: "tom"), User.current
@@ -22,12 +18,12 @@ class UserTest < ActiveSupport::TestCase
     assert_equal nil, user
     assert_equal nil, User.current
 
-    user = User.authenticate("nonexistant")
+    user = User.authenticate("nonexistant", "foobar")
     assert_equal nil, user
     assert_equal nil, User.current
 
-    user = User.authenticate("unconfirmed_user")
-    assert_equal nil, user
+    user = User.authenticate("unconfirmed_user", "thunder")
+    assert_equal nil, user, "Should not authenticate users with state 'unconfirmed'"
     assert_equal nil, User.current
   end
 


### PR DESCRIPTION
Apparently the proxy login goes over an external IChain server. Thus the
do_login action won't get called in proxy mode.

I verified this on our test instance, which is using IChain.