### PR TITLE
[webui] Show all open requests of a project

### DIFF
--- a/src/api/app/controllers/webui/project_controller.rb
+++ b/src/api/app/controllers/webui/project_controller.rb
@@ -364,7 +364,7 @@ class Webui::ProjectController < Webui::WebuiController
   end
 
   def requests
-    @requests = @project.request_ids_by_class(false)
+    @requests = @project.open_requests
     @default_request_type = params[:type] if params[:type]
     @default_request_state = params[:state] if params[:state]
   end
@@ -901,8 +901,8 @@ class Webui::ProjectController < Webui::WebuiController
     @ipackages = @project.expand_all_packages.find_all{ |p| not @packages.include?(p[0]) }
     @linking_projects = @project.find_linking_projects.map { |p| p.name }
 
-    reqs = @project.request_ids_by_class
-    @requests = (reqs['reviews'] + reqs['targets'] + reqs['incidents'] + reqs['maintenance_release']).sort.uniq
+    reqs = @project.open_requests
+    @requests = (reqs[:reviews] + reqs[:targets] + reqs[:incidents] + reqs[:maintenance_release]).sort.uniq
 
     @nr_of_problem_packages = @project.number_of_build_problems
   end

--- a/src/api/app/models/project.rb
+++ b/src/api/app/models/project.rb
@@ -1416,24 +1416,18 @@ class Project < ActiveRecord::Base
     end
   end
 
-  def request_ids_by_class(useroles = true)
-    roles = %w(reviewer) if useroles
-    reviews = BsRequest.collection(project: name, states: %w(review), roles: roles ).ids
-
-    roles = %w(target) if useroles
-    targets = BsRequest.collection(project: name, states: %w(new), roles: roles ).ids
-
-    roles = %w(source) if useroles
-    incidents = BsRequest.collection(project: name, states: %w(new), roles: roles, types: %w(maintenance_incident)).ids
+  def open_requests
+    reviews = BsRequest.collection(project: name, states: %w(review)).ids
+    targets = BsRequest.collection(project: name, states: %w(new)).ids
+    incidents = BsRequest.collection(project: name, states: %w(new), types: %w(maintenance_incident)).ids
 
     if is_maintenance?
-      roles = %w(source) if useroles
-      maintenance_release = BsRequest.collection(project: name, states: %w(new), roles: roles, types: %w(maintenance_release), subprojects: true).ids
+      maintenance_release = BsRequest.collection(project: name, states: %w(new), types: %w(maintenance_release), subprojects: true).ids
     else
       maintenance_release = []
     end
 
-    { 'reviews' => reviews, 'targets' => targets, 'incidents' => incidents, 'maintenance_release' => maintenance_release }
+    { reviews: reviews, targets: targets, incidents: incidents, maintenance_release: maintenance_release }
   end
 
   # for the clockworkd - called delayed

--- a/src/api/test/fixtures/bs_request_actions.yml
+++ b/src/api/test/fixtures/bs_request_actions.yml
@@ -85,3 +85,33 @@ record_8:
   source_rev: '1'
   updatelink: 0
   created_at: 2012-09-03 13:08:02.000000000 Z
+record_9:
+  bs_request_id: 5
+  type: submit
+  target_project: Apache
+  target_package: BranchPack
+  source_project: home:Iggy:branches:kde4
+  source_package: BranchPack
+  source_rev: '1'
+  updatelink: 0
+  created_at: 2012-09-03 13:08:02.000000000 Z
+record_10:
+  bs_request_id: 6
+  type: maintenance_incident
+  target_project: My:Maintenance
+  target_package: pack2
+  source_project: BaseDistro2.0
+  source_package: pack2
+  source_rev: '1'
+  updatelink: 0
+  created_at: 2012-09-03 13:08:02.000000000 Z
+record_11:
+  bs_request_id: 7
+  type: maintenance_release
+  target_project: My:Maintenance:Temporary
+  target_package: pack2
+  source_project: BaseDistro2.0
+  source_package: pack2
+  source_rev: '1'
+  updatelink: 0
+  created_at: 2012-09-03 13:08:02.000000000 Z

--- a/src/api/test/fixtures/bs_requests.yml
+++ b/src/api/test/fixtures/bs_requests.yml
@@ -47,3 +47,30 @@ submit_from_home_project:
   commenter: king
   created_at: 2012-09-04 13:08:02.000000000 Z
   updated_at: 2012-09-28 11:56:53.000000000 Z
+submit_from_home_project_new:
+  id: 5
+  description: test open requests for My:Maintenance
+  creator: Iggy
+  state: new
+  comment: A new request
+  commenter: king
+  created_at: 2012-09-04 13:08:02.000000000 Z
+  updated_at: 2012-09-28 11:56:53.000000000 Z
+submit_from_home_project_maintenance_incident:
+  id: 6
+  description: test open requests
+  creator: Iggy
+  state: new
+  comment: A new maintenance incident
+  commenter: king
+  created_at: 2012-08-04 13:08:02.000000000 Z
+  updated_at: 2012-08-28 11:56:53.000000000 Z
+submit_from_home_project_maintenance_release:
+  id: 7
+  description: test open requests
+  creator: Iggy
+  state: new
+  comment: A new maintenance release
+  commenter: king
+  created_at: 2012-08-04 13:08:02.000000000 Z
+  updated_at: 2012-08-28 11:56:53.000000000 Z

--- a/src/api/test/functional/maintenance_test.rb
+++ b/src/api/test/functional/maintenance_test.rb
@@ -1290,7 +1290,7 @@ class MaintenanceTests < ActionDispatch::IntegrationTest
     get '/request?view=collection&types=maintenance_release&project=My:Maintenance&subprojects=true'
     assert_response :success
     assert_xml_tag( :tag => 'collection', :child => { tag: 'request' } )
-    assert_xml_tag( :tag => 'collection', :attributes => { matches: '1' } )
+    assert_xml_tag( :tag => 'collection', :attributes => { matches: '2' } )
 
     # validate that request is diffable (not broken)
     post "/request/#{reqid}?cmd=diff"

--- a/src/api/test/functional/webui/maintenance_workflow_test.rb
+++ b/src/api/test/functional/webui/maintenance_workflow_test.rb
@@ -56,6 +56,7 @@ class Webui::MaintenanceWorkflowTest < Webui::IntegrationTest
     login_user('maintenance_coord', 'buildservice', to: project_show_path(project: 'My:Maintenance'))
 
     find(:link, 'open request').click
+    first('.request_link').click
     find(:id, 'description_text').text.must_equal 'I want the update'
     find(:id, 'action_display_0').must_have_text ('Release in BaseDistro2.0:LinkedUpdateProject')
     fill_in 'reason', with: 'really? ok'
@@ -110,6 +111,7 @@ class Webui::MaintenanceWorkflowTest < Webui::IntegrationTest
     login_user('maintenance_coord', 'buildservice', to: project_show_path(project: 'My:Maintenance'))
 
     find(:link, 'open request').click
+    first('.request_link').click
     find(:id, 'description_text').text.must_equal 'I have a additional fix'
     find(:link, 'Merge with existing incident').click
     # set to not existing incident

--- a/src/api/test/unit/project_test.rb
+++ b/src/api/test/unit/project_test.rb
@@ -957,4 +957,12 @@ END
     # Leave the backend file as it was
     assert @project.config.save(query_params, CONFIG_FILE_STRING_FOR_HOME_IGGY_PROJECT)
   end
+
+  def test_open_requests
+    apache = projects(:Apache)
+    assert_equal apache.open_requests, { reviews: [1000, 10, 4], targets: [5], incidents: [], maintenance_release: [] }
+
+    maintenance = projects(:My_Maintenance)
+    assert_equal maintenance.open_requests, { reviews: [], targets: [6], incidents: [6], maintenance_release: [7] }
+  end
 end

--- a/src/api/test/unit/user_test.rb
+++ b/src/api/test/unit/user_test.rb
@@ -115,15 +115,10 @@ class UserTest < ActiveSupport::TestCase
   end
 
   def test_user_requests
-    # no projects, no requests
-    # assert_equal({:declined=>[], :new=>[], :reviews=>[]}, users(:user4).request_ids_by_class)
     assert_equal 0, users(:user4).nr_of_requests_that_need_work
-    # assert_equal({declined: [], new: [], reviews: [4]}, users(:tom).request_ids_by_class)
     assert_equal 1, users(:tom).nr_of_requests_that_need_work
-    # assert_equal({declined: [], new: [1], reviews: [4, 1000]}, users(:adrian).request_ids_by_class)
     assert_equal 3, users(:adrian).nr_of_requests_that_need_work
-    # assert_equal({declined: [], new: [1], reviews: [10, 1000]}, users(:fred).request_ids_by_class)
-    assert_equal 3, users(:fred).nr_of_requests_that_need_work
+    assert_equal 4, users(:fred).nr_of_requests_that_need_work
   end
 
   def test_update_globalroles


### PR DESCRIPTION
instead of only user related requests. This caused some misunderstandings recently because the project page only showed open requests when thei're related to the user and not all open requests. Now we show all open requests of a project. Furthermore this commit does some refactoring of the according function.
This will fix #1232.