### PR TITLE
[api] Better logging in level warn for Project/Package destroy

### DIFF
--- a/src/api/app/models/project.rb
+++ b/src/api/app/models/project.rb
@@ -852,7 +852,7 @@ class Project < ActiveRecord::Base
         # ignore this error, backend was out of sync
         logger.warn("Project #{self.name} was already missing on backend on removal")
       end
-      logger.tagged('backend_sync') { logger.debug "Deleted Project #{self.name}" }
+      logger.tagged('backend_sync') { logger.warn "Deleted Project #{self.name}" }
     else
       if @commit_opts[:no_backend_write]
         logger.tagged('backend_sync') { logger.warn "Not deleting Project #{self.name}, backend_write is off " }


### PR DESCRIPTION
This should it make more obvious when Project/Package destroy has been run successfully without changing the log level. @adrianschroeter that might help for the sync problems...