### PR TITLE
Add readers to BuildFail notifications

### DIFF
--- a/src/api/app/models/event/base.rb
+++ b/src/api/app/models/event/base.rb
@@ -236,6 +236,13 @@ module Event
       ret
     end
 
+    def readers
+      Rails.logger.debug "Readers #{payload.inspect}"
+      ret = _roles('reader', payload['project'])
+      Rails.logger.debug "Readers ret #{ret.inspect}"
+      ret
+    end
+
     def _roles(role, project, package = nil)
       return [] unless project
       p = nil

--- a/src/api/app/models/event/build.rb
+++ b/src/api/app/models/event/build.rb
@@ -30,7 +30,7 @@ class Event::BuildFail < Event::Build
 
   self.raw_type = 'BUILD_FAIL'
   self.description = 'Package has failed to build'
-  receiver_roles :maintainer, :bugowner
+  receiver_roles :maintainer, :bugowner, :reader
 
   def subject
     "Build failure of #{payload['project']}/#{payload['package']} in #{payload['repository']}/#{payload['arch']}"

--- a/src/api/app/models/event_subscription.rb
+++ b/src/api/app/models/event_subscription.rb
@@ -2,7 +2,7 @@ class EventSubscription < ActiveRecord::Base
   belongs_to :user, inverse_of: :event_subscriptions
   belongs_to :group, inverse_of: :event_subscriptions
 
-  validates :receiver_role, inclusion: { in: [:all, :maintainer, :bugowner, :source_maintainer,
+  validates :receiver_role, inclusion: { in: [:all, :maintainer, :bugowner, :reader, :source_maintainer,
                                               :target_maintainer, :reviewer, :commenter, :creator] }
 
   def receiver_role

--- a/src/api/test/fixtures/event_mailer/build_fail_reader
+++ b/src/api/test/fixtures/event_mailer/build_fail_reader
@@ -1,0 +1,37 @@
+Return-Path: <obs-email@opensuse.org>
+From: OBS Notification <obs-email@opensuse.org>
+Sender: OBS Notification <obs-email@opensuse.org>
+To: Frederic Feuerstone <fred@feuerstein.de>
+Message-ID: <notrandom@localhost>
+In-Reply-To: <build-f22a287c0bb24a0a9c2bac8d59f35aa3@localhost>
+References: <build-f22a287c0bb24a0a9c2bac8d59f35aa3@localhost>
+Subject: Build failure of home:Iggy/TestPack in 10.2/i586
+Mime-Version: 1.0
+Content-Type: text/plain;
+ charset=UTF-8
+Content-Transfer-Encoding: quoted-printable
+Precedence: bulk
+X-Mailer: OBS Notification System
+X-OBS-URL: http://localhost
+Auto-Submitted: auto-generated
+X-OBS-event-type: build_fail
+X-OBS-Package: home:Iggy/TestPack
+X-OBS-Repository: 10.2/i586
+X-OBS-Worker: build12
+X-OBS-Rebuild-Reason: new build
+
+Visit http://localhost/package/live_build_log/home:Iggy/TestPack/10.2/i58=
+6
+
+Package home:Iggy/TestPack failed to build in 10.2/i586
+
+Check out the package for editing:
+  osc checkout home:Iggy TestPack
+
+Last lines of build log:
+[1] this is my dummy logfile -> =C3=BCmlaut
+
+-- =
+
+Configure notifications at http://localhost/user/notifications
+Open Build Service (http://localhost/)

--- a/src/api/test/fixtures/events.yml
+++ b/src/api/test/fixtures/events.yml
@@ -17,6 +17,16 @@ build_failure_for_iggy:
   created_at: 2013-08-31 14:56:52.000000000 Z
   updated_at: 2013-08-31 14:56:52.000000000 Z
   project_logged: 0
+build_failure_for_reader:
+  id: 19 
+  eventtype: Event::BuildFail
+  payload: '{"project":"home:Iggy","package":"TestPack","repository":"10.2","arch":"i586","release":"42.1","versrel":"1.0-42","readytime":"1377958901","srcmd5":"1ac07842727acaf13d0e2b3213b47785","rev":"2","revtime":"1377958897","reason":"new
+    build","bcnt":"1","verifymd5":"1ac07842727acaf13d0e2b3213b47785","workerid":"build12"}'
+  queued: 0
+  lock_version: 0
+  created_at: 2013-08-31 14:56:52.000000000 Z
+  updated_at: 2013-08-31 14:56:52.000000000 Z
+  project_logged: 0
 service_failure_for_iggy:
   id: 18
   eventtype: Event::ServiceFail

--- a/src/api/test/fixtures/relationships.yml
+++ b/src/api/test/fixtures/relationships.yml
@@ -186,3 +186,7 @@ record_46:
   user: fred
   role: maintainer
   package: Apache_apache2
+record_47:
+  user: fred 
+  role: reader
+  project: home_Iggy

--- a/src/api/test/models/event_test.rb
+++ b/src/api/test/models/event_test.rb
@@ -28,7 +28,7 @@ class EventTest < ActionDispatch::IntegrationTest
   end
 
   test 'receive roles for build failure' do
-    assert_equal [:maintainer, :bugowner], events(:build_fails_with_deleted_user_and_request).receiver_roles
+    assert_equal [:maintainer, :bugowner, :reader], events(:build_fails_with_deleted_user_and_request).receiver_roles
   end
 
   def users_for_event(e)
@@ -125,6 +125,16 @@ class EventTest < ActionDispatch::IntegrationTest
     EventSubscription.create eventtype: 'Event::BuildFail', receiver_role: :maintainer, user: users(:Iggy)
 
     assert_equal %w(Iggy), users_for_event(events(:build_failure_for_iggy))
+  end
+
+  test 'reader mails for build failure' do
+    # for this test we don't want fixtures to interfere
+    EventSubscription.delete_all
+
+    # just one subsciption
+    EventSubscription.create eventtype: 'Event::BuildFail', receiver_role: :reader, user: users(:fred)
+
+    assert_equal %w(fred), users_for_event(events(:build_failure_for_reader))
   end
 
   test 'maintainer mails for source service fail' do

--- a/src/api/test/unit/event_mailer_test.rb
+++ b/src/api/test/unit/event_mailer_test.rb
@@ -31,6 +31,18 @@ class EventMailerTest < ActionMailer::TestCase
     verify_email('build_fail', mail)
   end
 
+  test 'reader mails for build failure' do
+    # for this test we don't want fixtures to interfere
+    EventSubscription.delete_all
+
+    # just one subsciption
+    EventSubscription.create eventtype: 'Event::BuildFail', receiver_role: :reader, user: users(:fred)
+    Suse::Backend.wait_for_scheduler_start
+
+    mail = EventMailer.event([users(:fred)], events(:build_failure_for_reader))
+    verify_email('build_fail_reader', mail)
+  end
+
   test 'group emails' do
     User.current = users(:Iggy)
 


### PR DESCRIPTION
This will allow third parties to watch build failures in projects
they are listed as readers (watchers).

Signed-off-by: Dinar Valeev <dvaleev@suse.com>