### PR TITLE
Fix ruby23 in vagrant

### DIFF
--- a/contrib/common.sh
+++ b/contrib/common.sh
@@ -12,19 +12,21 @@ function add_common_repos() {
 function install_common_packages() {
   echo -e "\ninstalling required software packages...\n"
   zypper -q -n install \
-    update-alternatives ruby-devel make gcc gcc-c++ patch cyrus-sasl-devel openldap2-devel \
+    update-alternatives make gcc gcc-c++ patch cyrus-sasl-devel openldap2-devel \
     libmysqld-devel libxml2-devel zlib-devel libxslt-devel nodejs mariadb memcached \
     sphinx sphinx phantomjs \
     screen \
-    perl-XML-Parser \
-    ruby2.2-rubygem-bundler \
-    ruby2.2-rubygem-mysql2 \
-    ruby2.2-rubygem-nokogiri \
-    ruby2.2-rubygem-multi_json \
-    ruby2.2-rubygem-ruby-ldap \
-    ruby2.2-rubygem-xmlhash \
-    ruby2.2-rubygem-thinking-sphinx\
+    ruby2.3-devel \
+    ruby2.3-rubygem-bundler \
+    ruby2.3-rubygem-mysql2 \
+    ruby2.3-rubygem-nokogiri \
+    ruby2.3-rubygem-multi_json \
+    ruby2.3-rubygem-ruby-ldap \
+    ruby2.3-rubygem-xmlhash \
+    ruby2.3-rubygem-thinking-sphinx\
     perl-GD \
+    perl-XML-Parser \
+    perl-Devel-Cover \
     obs-server \
     curl \
     vim-data \
@@ -38,9 +40,9 @@ function install_common_packages() {
 
 function setup_ruby() {
   echo -e "\nsetup ruby binaries...\n"
-  [ -f /usr/bin/ruby ] ||ln -s /usr/bin/ruby.ruby2.2 /usr/bin/ruby
+  [ -f /usr/bin/ruby ] ||ln -s /usr/bin/ruby.ruby2.3 /usr/bin/ruby
   for bin in rake rdoc ri; do
-     /usr/sbin/update-alternatives --set $bin /usr/bin/$bin.ruby.ruby2.2
+     /usr/sbin/update-alternatives --set $bin /usr/bin/$bin.ruby.ruby2.3
   done
 }
 

--- a/dist/obs-server.spec
+++ b/dist/obs-server.spec
@@ -169,7 +169,7 @@ Requires:       obs-common
 %endif
 
 #For apache
-Requires:     apache2 apache2-mod_xforward %{our_ruby_prefix}-rubygem-passenger-apache2
+Requires:     apache2 apache2-mod_xforward rubygem-passenger-apache2
 # enforce passenger update to ruby 2.3 stack without requiring it
 Conflicts:      ruby2.1-rubygem-passenger
 Conflicts:      ruby2.2-rubygem-passenger

--- a/dist/obs-server.spec
+++ b/dist/obs-server.spec
@@ -363,6 +363,8 @@ make -C src/api test
 
 make -C dist test
 
+# TODO - clarify if test suite is needed as extra package (M0ses)
+rm -rf $RPM_BUILD_ROOT/srv/www/obs/api/spec
 
 %pre
 getent group obsrun >/dev/null || groupadd -r obsrun
@@ -629,6 +631,7 @@ chown %{apache_user}:%{apache_group} /srv/www/obs/api/log/production.log
 %ghost /srv/www/obs/api/log/error.log
 %ghost /srv/www/obs/api/log/lastevents.access.log
 %ghost /srv/www/obs/api/log/production.log
+
 
 %files -n obs-common
 %defattr(-,root,root)

--- a/dist/obs-server.spec
+++ b/dist/obs-server.spec
@@ -308,6 +308,7 @@ export DESTDIR=$RPM_BUILD_ROOT
 #  find -type f | xargs sed -i '1,$s/group www/group apache/g'
 #%endif
 
+export OBS_VERSION="%{version}"
 DESTDIR=%{buildroot} make install
 
 #

--- a/src/api/Makefile
+++ b/src/api/Makefile
@@ -60,7 +60,7 @@ build: config
 	# fixed hardlinking problem in SLE 11
 	echo "# This is to prevent fdupes from hardlinking" >> $(DESTDIR)$(OBS_API_PREFIX)/config/database.yml
 	: >  $(DESTDIR)/srv/www/obs/api/log/production.log
-	sed -i -e 's,^api_version.*,api_version = "%version",'  $(DESTDIR)$(OBS_API_PREFIX)/config/initializers/02_apiversion.rb
+	sed -i -e 's,^api_version.*,api_version = "$(OBS_VERSION)",'  $(DESTDIR)$(OBS_API_PREFIX)/config/initializers/02_apiversion.rb
 
 test_unit:
 	[ -d log ] || mkdir log


### PR DESCRIPTION
@hennevogel: Please review as I only remove (spec) files from installation, maybe a package for testsuite is wanted.

* fix installation of ruby2.3 package in vagrant
* remove files in /srv/www/obs/api/spec - I don't think that test go into a package
* fix for %version problem #1468