### PR TITLE
fix sudden worker death

### DIFF
--- a/src/backend/bs_worker
+++ b/src/backend/bs_worker
@@ -171,7 +171,10 @@ sub tail_logfile {
 
 sub cleanup_job {
   if ($vm_tmpfs_mode) {
-    qsystem("umount", "-l", $buildroot) && die("umount tmpfs failed: $!\n");
+    # no need to umount if $buildroot is already umounted
+    if (not qsystem('mountpoint', '-q', $buildroot)) {
+      qsystem("umount", "-l", $buildroot) && die("umount tmpfs failed: $!\n");
+    }
   }
 }
 


### PR DESCRIPTION
sometimes a worker process tries to umount the tmpfs buildroot which was already umounted by another worker process which is not possible and the worker process dies.

this fix checks whether the buildroot tmpfs is still mounted and only trieds to umount the tmpfs buildroot if it is still mounted.