### PR TITLE
[backend] retry 5 times on locking process state file

### DIFF
--- a/src/backend/BSUtil.pm
+++ b/src/backend/BSUtil.pm
@@ -726,4 +726,26 @@ sub identical {
   return 1;
 }
 
+sub lock_daemon_file {
+  # workaround when systemd starts the new process while the old is still running.
+  my ($dir, $name) = @_;
+  mkdir_p($dir);
+  my $count = 0;
+  while ($count < 5) {
+    $count++;
+    open(RUNLOCK, '>>', "$dir/bs_$name.lock") || die("$dir/bs_$name.lock: $!\n");
+    if (flock(RUNLOCK, LOCK_EX | LOCK_NB)) {
+      # success
+      utime undef, undef, "$dir/bs_$name.lock";
+      return;
+    } else {
+      # failed, sleep and retry
+      print "lock of $name failed, retrying...\n";
+      close(RUNLOCK);
+      sleep(1);
+    }
+  }
+  die("$name is already running!\n");
+}
+
 1;

--- a/src/backend/bs_dispatch
+++ b/src/backend/bs_dispatch
@@ -825,10 +825,7 @@ BSUtil::restartexit($ARGV[0], 'dispatcher', "$rundir/bs_dispatch");
 printlog("starting build service dispatcher");
 
 # get lock
-mkdir_p($rundir);
-open(RUNLOCK, '>>', "$rundir/bs_dispatch.lock") || die("$rundir/bs_dispatch.lock: $!\n");
-flock(RUNLOCK, LOCK_EX | LOCK_NB) || die("dispatcher is already running!\n");
-utime undef, undef, "$rundir/bs_dispatch.lock";
+BSUtil::lock_daemon_file($rundir, "dispatch");
 
 my $dispatchprios;
 my $dispatchprios_project;

--- a/src/backend/bs_dodup
+++ b/src/backend/bs_dodup
@@ -478,10 +478,7 @@ if (!@ARGV || (@ARGV == 1 && ($ARGV[0] eq '--restart' || $ARGV[0] eq '--exit' ||
   $SIG{'PIPE'} = 'IGNORE';
   BSUtil::restartexit($ARGV[0], 'dodup', "$rundir/bs_dodup");
   printlog("starting build service DoD updater");
-  mkdir_p($rundir);
-  open(RUNLOCK, '>>', "$rundir/bs_dodup.lock") || die("$rundir/bs_dodup.lock: $!\n");
-  flock(RUNLOCK, LOCK_EX | LOCK_NB) || die("dodup is already running!\n");
-  utime undef, undef, "$rundir/bs_dodup.lock";
+  BSUtil::lock_daemon_file($rundir, "dodup");
   daemon();
 }
 

--- a/src/backend/bs_publish
+++ b/src/backend/bs_publish
@@ -2175,11 +2175,7 @@ $| = 1;
 $SIG{'PIPE'} = 'IGNORE';
 BSUtil::restartexit($ARGV[0], 'publisher', "$rundir/bs_publish", "$myeventdir/.ping");
 print "starting build service publisher\n";
-
-mkdir_p($rundir);
-open(RUNLOCK, '>>', "$rundir/bs_publish.lock") || die("$rundir/bs_publish.lock: $!\n");
-flock(RUNLOCK, LOCK_EX | LOCK_NB) || die("publisher is already running!\n");
-utime undef, undef, "$rundir/bs_publish.lock";
+BSUtil::lock_daemon_file($rundir, "publish");
 
 mkdir_p($myeventdir);
 if (!-p "$myeventdir/.ping") {

--- a/src/backend/bs_sched
+++ b/src/backend/bs_sched
@@ -358,9 +358,7 @@ print "starting build service scheduler\n";
 # get lock
 mkdir_p($_rundir);
 if (!$testprojid) {
-  open(RUNLOCK, '>>', "$_rundir/bs_sched.$_myarch.lock") || die("$_rundir/bs_sched.$_myarch.lock: $!\n");
-  flock(RUNLOCK, LOCK_EX | LOCK_NB) || die("scheduler is already running for $_myarch!\n");
-  utime undef, undef, "$_rundir/bs_sched.$_myarch.lock";
+  BSUtil::lock_daemon_file($_rundir, "sched.$_myarch");
 }
 
 for my $d ("$_eventdir/$_myarch", "$_jobsdir/$_myarch", $_infodir) {

--- a/src/backend/bs_signer
+++ b/src/backend/bs_signer
@@ -643,10 +643,7 @@ BSUtil::restartexit($ARGV[0], 'signer', "$rundir/bs_signer", "$myeventdir/.ping"
 print "starting build service signer\n";
 
 # get lock
-mkdir_p($rundir);
-open(RUNLOCK, '>>', "$rundir/bs_signer.lock") || die("$rundir/bs_signer.lock: $!\n");
-flock(RUNLOCK, LOCK_EX | LOCK_NB) || die("signer is already running!\n");
-utime undef, undef, "$rundir/bs_signer.lock";
+BSUtil::lock_daemon_file($rundir, "signer");
 
 die("sign program is not configured!\n") unless $BSConfig::sign;
 

--- a/src/backend/bs_warden
+++ b/src/backend/bs_warden
@@ -56,10 +56,7 @@ BSUtil::restartexit($ARGV[0], 'warden', "$rundir/bs_warden");
 print BSUtil::isotime().": starting build service worker warden\n";
 
 # get lock
-mkdir_p($rundir);
-open(RUNLOCK, '>>', "$rundir/bs_warden.lock") || die("$rundir/bs_warden.lock: $!\n");
-flock(RUNLOCK, LOCK_EX | LOCK_NB) || die("worker warden is already running!\n");
-utime undef, undef, "$rundir/bs_warden.lock";
+BSUtil::lock_daemon_file($rundir, "warden");
 
 my %building;
 my $nextorphan = 0;

--- a/src/backend/bs_worker
+++ b/src/backend/bs_worker
@@ -2906,9 +2906,7 @@ my $buildcode = codemd5('build');
 $| = 1;
 print "starting worker $workercode build $buildcode\n";
 
-open(RUNLOCK, '>>', "$statedir/lock") || die("$statedir/lock: $!");
-flock(RUNLOCK, LOCK_EX | LOCK_NB) || die("worker is already running on $statedir!\n");
-utime undef, undef, "$statedir/lock";
+BSUtil::lock_daemon_file($statedir, "worker");
 
 # we always start idle
 lockstate();


### PR DESCRIPTION
systemd seems to start the new process before the old one got stopped.
This caused occasionaly missing daemons on package update