### PR TITLE
[api] fix path to apidocs

### DIFF
--- a/src/api/config/environment.rb
+++ b/src/api/config/environment.rb
@@ -13,7 +13,7 @@ rescue Exception
 end
 
 CONFIG['schema_location'] ||= File.expand_path("public/schema")+"/"
-CONFIG['apidocs_location'] ||= File.expand_path("../../docs/api/html/")
+CONFIG['apidocs_location'] ||= File.expand_path("../docs/api/html/")
 CONFIG['global_write_through'] ||= true
 CONFIG['proxy_auth_mode'] ||= :off
 CONFIG['frontend_ldap_mode'] ||= :off


### PR DESCRIPTION
The 'apidocs_location' lead to /srv/www/docs instead /srv/www/obs/docs, so <obsurl>/apidocs/ was not working.