### PR TITLE
[ci] Switch artifacts to after_failure script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ rvm: 2.3.0
 gemfile: src/api/Gemfile
 before_install: dist/ci/obs_testsuite_travis_install.sh
 before_script: dist/ci/obs_testsuite_travis_before.sh
+after_failure: dist/ci/obs_testsuite_travis_failure.sh
 script: "dist/ci/obs_testsuite_travis.sh $TEST_SUITE"
 env:
   - TEST_SUITE=rubocop
@@ -21,6 +22,3 @@ notifications:
 services:
   - memcached
 sudo: required
-addons:
-  artifacts: true
-  s3_region: "us-east-1"

--- a/dist/ci/obs_testsuite_travis_failure.sh
+++ b/dist/ci/obs_testsuite_travis_failure.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+if [ -z "$ARTIFACTS_KEY" ] || [ -z "$ARTIFACTS_SECRET" ]; then
+  echo 'No AWS secrets set...'
+  exit 0 
+fi
+
+pushd src/api
+
+function upload_to_s3 {
+dateValue=`date -R`
+stringToSign="PUT\n\ntext/plain\n${dateValue}\n/obs-travis-articafts/$TRAVIS_BUILD_NUMBER/$TRAVIS_JOB_NUMBER/$1"
+signature=`echo -en ${stringToSign} | openssl sha1 -hmac ${ARTIFACTS_SECRET} -binary | base64`
+curl -X PUT -T $1 \
+  -H "Host: obs-travis-articafts.s3.amazonaws.com" \
+  -H "Date: ${dateValue}" \
+  -H "Content-Type: text/plain" \
+  -H "Authorization: AWS ${ARTIFACTS_KEY}:${signature}" \
+  https://obs-travis-articafts.s3.amazonaws.com/$TRAVIS_BUILD_NUMBER/$TRAVIS_JOB_NUMBER/$1
+}
+
+if [ -f log/test.log ]; then
+  upload_to_s3 log/test.log
+fi
+
+for file in tmp/capybara/*; do
+  upload_to_s3 $file
+done
+
+echo "You can find the logs etc. here: https://obs-travis-articafts.s3.amazonaws.com/$TRAVIS_BUILD_NUMBER/$TRAVIS_JOB_NUMBER/"


### PR DESCRIPTION
The artifacts feature of travis always uploads _all_ files not
tracked by git (git ls-files -o) which is way to much in our case.