### PR TITLE
[webui] don't double encode build log

### DIFF
--- a/src/api/app/mixins/build_log_support.rb
+++ b/src/api/app/mixins/build_log_support.rb
@@ -10,7 +10,7 @@ module BuildLogSupport
   def get_log_chunk( project, package, repo, arch, start, theend )
     log = raw_log_chunk( project, package, repo, arch, start, theend )
     begin
-      log.encode!(invalid: :replace, xml: :text, undef: :replace, cr_newline: true)
+      log.encode!(invalid: :replace, undef: :replace, cr_newline: true)
     rescue Encoding::UndefinedConversionError
       # encode is documented not to throw it if undef: is :replace, but at least we tried - and ruby 1.9.3 is buggy
     end


### PR DESCRIPTION
Don't xml encode in get_log_chunk, this is already done by the caller