### PR TITLE
[webui] don't double encode build log

### DIFF
--- a/src/api/app/mixins/build_log_support.rb
+++ b/src/api/app/mixins/build_log_support.rb
@@ -10,7 +10,7 @@ module BuildLogSupport
   def get_log_chunk( project, package, repo, arch, start, theend )
     log = raw_log_chunk( project, package, repo, arch, start, theend )
     begin
-      log.encode!(invalid: :replace, xml: :text, undef: :replace, cr_newline: true)
+      log.encode!(invalid: :replace, undef: :replace, cr_newline: true)
     rescue Encoding::UndefinedConversionError
       # encode is documented not to throw it if undef: is :replace, but at least we tried - and ruby 1.9.3 is buggy
     end

--- a/src/api/test/functional/webui/package_controller_test.rb
+++ b/src/api/test/functional/webui/package_controller_test.rb
@@ -265,7 +265,7 @@ class Webui::PackageControllerTest < Webui::IntegrationTest
     end
     first('.buildstatus').must_have_text 'succeeded'
     click_link 'succeeded'
-    find(:id, 'log_space').must_have_text '[1] this is my dummy logfile -&gt; ümlaut'
+    find(:id, 'log_space').must_have_text '[1] this is my dummy logfile -> ümlaut'
     first(:link, 'Download logfile').click
     # don't bother with the ümlaut
     assert_match %r{this is my dummy}, page.source
@@ -478,14 +478,14 @@ class Webui::PackageControllerTest < Webui::IntegrationTest
     visit '/package/live_build_log/home:Iggy/TestPack/10.2/i586'
     page.status_code.must_equal 200
     page.must_have_text "Build finished"
-    page.must_have_text "[1] this is my dummy logfile -&gt; ümlaut"
+    page.must_have_text "[1] this is my dummy logfile -> ümlaut"
     login_Iggy to: '/package/live_build_log/SourceprotectedProject/pack/repo/i586'
     page.status_code.must_equal 200
     flash_message.must_equal 'Could not access build log'
     visit '/package/live_build_log/UseRemoteInstance/pack2.linked/pop/i586/'
     page.status_code.must_equal 200
     page.must_have_text "Build finished"
-    page.must_have_text "[1] this is my dummy logfile -&gt; ümlaut"
+    page.must_have_text "[1] this is my dummy logfile -> ümlaut"
   end
 
   def test_save_meta


### PR DESCRIPTION
Don't xml encode in get_log_chunk, this is already done by the caller