### PR TITLE
[ci] Re-add Sign_up/User_with_confirmation cassette

### DIFF
--- a/src/api/spec/cassettes/Sign_up/User_with_confirmation.yml
+++ b/src/api/spec/cassettes/Sign_up/User_with_confirmation.yml
@@ -1,0 +1,53 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://localhost:3200/build/_workerstatus
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - text/plain
+      Accept-Encoding:
+      - identity
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '589'
+    body:
+      encoding: UTF-8
+      string: |
+        <workerstatus clients="0">
+          <waiting arch="i586" jobs="1" />
+          <waiting arch="x86_64" jobs="0" />
+          <blocked arch="i586" jobs="0" />
+          <blocked arch="x86_64" jobs="0" />
+          <buildavg arch="i586" buildavg="1200" />
+          <buildavg arch="x86_64" buildavg="1200" />
+          <partition>
+            <daemon type="scheduler" arch="i586" state="dead">
+              <queue high="0" med="0" low="3" next="0" />
+            </daemon>
+            <daemon type="scheduler" arch="x86_64" state="dead">
+              <queue high="0" med="0" low="6" next="0" />
+            </daemon>
+            <daemon type="publisher" state="dead" />
+          </partition>
+        </workerstatus>
+    http_version: 
+  recorded_at: Thu, 11 Feb 2016 13:51:48 GMT
+recorded_with: VCR 3.0.1


### PR DESCRIPTION
Depending on the order of the execution of the test
the first sign up test caches _workerstatus so we need
both cassettes