### PR TITLE
[dist] force setup-appliance.sh to break if no FQHN could be determined

### DIFF
--- a/dist/setup-appliance.sh
+++ b/dist/setup-appliance.sh
@@ -166,6 +166,21 @@ function get_hostname {
   else
     SHORTHOSTNAME=$FQHOSTNAME
   fi 
+
+  if [[ -z $FQHOSTNAME ]]; then
+    cat <<EOF
+Could not determine FQHN. Please check your DNS resolution for this host.
+Exiting here, because otherwise apache would break later on. You can run $0 
+securely after fixing your DNS resolution.
+
+HINT: use "hostname -f" to test your DNS resolution.
+
+... Exiting now.
+EOF
+    exit 1
+  fi
+
+
 }
 ###############################################################################
 function generate_proposed_dnsnames {


### PR DESCRIPTION
related to #1552 

@adrianschroeter :  Please review and comment if this is a reasonable solution for you.

Please only comment and do not merge. Patch not tested yet.