### PR TITLE
[ci] Refactor rspec tests

### DIFF
--- a/src/api/spec/controllers/webui/architectures_controller_spec.rb
+++ b/src/api/spec/controllers/webui/architectures_controller_spec.rb
@@ -4,13 +4,9 @@ RSpec.describe Webui::ArchitecturesController do
   let(:confirmed_user) { create(:confirmed_user) }
   let(:admin_user) { create(:admin_user) }
 
-  describe 'GET #index' do
-    it { should use_before_action(:require_admin) }
-  end
+  it { is_expected.to use_before_action(:require_admin) }
 
   describe 'POST #bulk_update_availability' do
-    it { should use_before_action(:require_admin) }
-
     context 'as admin' do
       it 'creates the architectures' do
         login(admin_user)

--- a/src/api/spec/controllers/webui/configuration_controller_spec.rb
+++ b/src/api/spec/controllers/webui/configuration_controller_spec.rb
@@ -4,21 +4,9 @@ RSpec.describe Webui::ConfigurationController do
   let(:confirmed_user) { create(:confirmed_user) }
   let(:admin_user) { create(:admin_user) }
 
-  describe 'GET #index' do
-    it { should use_before_action(:require_admin) }
-  end
-
-  describe 'POST #update' do
-    it { should use_before_action(:require_admin) }
-  end
-
-  describe 'GET #interconnect' do
-    it { should use_before_action(:require_admin) }
-  end
+  it { is_expected.to use_before_action(:require_admin) }
 
   describe 'POST #create_interconnect' do
-    it { should use_before_action(:require_admin) }
-
     context 'as admin' do
       it 'creates a new remote project' do
         login(admin_user)

--- a/src/api/spec/models/architecture_spec.rb
+++ b/src/api/spec/models/architecture_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
 RSpec.describe Architecture do
-  it { should validate_presence_of(:name) }
-  it { should validate_uniqueness_of(:name) }
+  it { is_expected.to validate_presence_of(:name) }
+  it { is_expected.to validate_uniqueness_of(:name) }
 end

--- a/src/api/spec/models/configuration_spec.rb
+++ b/src/api/spec/models/configuration_spec.rb
@@ -1,9 +1,9 @@
 require 'rails_helper'
 
 RSpec.describe Configuration do
-  it { should validate_presence_of(:name) }
-  it { should validate_presence_of(:title) }
-  it { should validate_presence_of(:description) }
+  it { is_expected.to validate_presence_of(:name) }
+  it { is_expected.to validate_presence_of(:title) }
+  it { is_expected.to validate_presence_of(:description) }
 
   it 'creates a new Configuration if no Configuration exists' do
     Configuration.first.destroy


### PR DESCRIPTION
- Use new expect syntax instead of deprecated should
- Remove duplicated use_before_action shoulda-matchers