### PR TITLE
[ci] Better logging for rspec suite

### DIFF
--- a/src/api/spec/spec_helper.rb
+++ b/src/api/spec/spec_helper.rb
@@ -75,3 +75,6 @@ end
 
 # We never want the backend to autostart itself...
 ENV['BACKEND_STARTED']='1'
+
+# support logging
+require 'support/logging'

--- a/src/api/spec/support/database_cleaner.rb
+++ b/src/api/spec/support/database_cleaner.rb
@@ -5,9 +5,12 @@ RSpec.configure do |config|
 
   config.before(:suite) do
     # Before the test suites runs make sure the database is empty
+    log_level = Rails.logger.level
+    Rails.logger.level = :fatal
     DatabaseCleaner.clean_with(:truncation)
     # and is seeded
     load "#{Rails.root}/db/seeds.rb"
+    Rails.logger.level = log_level
   end
 
   config.before(:each) do |example|

--- a/src/api/spec/support/logging.rb
+++ b/src/api/spec/support/logging.rb
@@ -1,0 +1,6 @@
+RSpec.configure do |config|
+  config.around do |example|
+    Rails.logger.debug("\n\n\n===== #{example.full_description} =====\n\n")
+    example.run
+  end
+end


### PR DESCRIPTION
Do not log the database cleaning before the suite is running.
Log the description of the example before it runs.