### PR TITLE
[api][webui] Do not cache authorization

### DIFF
--- a/src/api/app/models/relationship.rb
+++ b/src/api/app/models/relationship.rb
@@ -146,7 +146,6 @@ class Relationship < ActiveRecord::Base
     cache_sequence = Rails.cache.read('cache_sequence_for_forbidden_projects') || 0
     Rails.cache.write('cache_sequence_for_forbidden_projects', cache_sequence + 1)
     Rails.cache.delete('forbidden_projects')
-    User.current.discard_cache if User.current
   end
 
   private

--- a/src/api/app/models/user.rb
+++ b/src/api/app/models/user.rb
@@ -139,16 +139,7 @@ class User < ActiveRecord::Base
     @new_password
   end
 
-  def discard_cache
-    @projects_to_modify = {}
-  end
-
-  after_initialize :init
-  def init
-    @projects_to_modify = {}
-  end
-
-    # Method to update the password and confirmation at the same time. Call
+  # Method to update the password and confirmation at the same time. Call
   # this method when you update the password from code and don't need
   # password_confirmation - which should really only be used when data
   # comes from forms.
@@ -551,15 +542,7 @@ class User < ActiveRecord::Base
       raise NotFoundError, "Project is not stored yet"
     end
 
-    # we don't touch the cache for ignoreLock
-    return can_modify_project_internal(project, ignoreLock) if ignoreLock
-
-    unless @projects_to_modify.has_key? project.id
-      # build cache
-      @projects_to_modify[project.id] = can_modify_project_internal(project, nil)
-    end
-
-    @projects_to_modify[project.id]
+    can_modify_project_internal(project, ignoreLock)
   end
 
   # package is instance of Package


### PR DESCRIPTION
If User1 caches the authorization in @projects_to_modify and
User2 changes the Relation the instance variable in User1 is not
discarded. This can't be...