### PR TITLE
[webui] fix review handling and validation

### DIFF
--- a/src/api/app/controllers/webui/request_controller.rb
+++ b/src/api/app/controllers/webui/request_controller.rb
@@ -41,7 +41,7 @@ class Webui::RequestController < Webui::WebuiController
       req.addreview(opts)
     rescue BsRequestPermissionCheck::AddReviewNotPermitted
       flash[:error] = "Not permitted to add a review to '#{params[:id]}'"
-    rescue APIException => e
+    rescue ActiveRecord::RecordInvalid, APIException => e
       flash[:error] = "Unable add review to '#{params[:id]}': #{e.message}"
     end
     redirect_to :controller => :request, :action => 'show', :id => params[:id]

--- a/src/api/app/models/history_element.rb
+++ b/src/api/app/models/history_element.rb
@@ -184,6 +184,12 @@ class HistoryElement::ReviewReopened < HistoryElement::Review
   end
 end
 
+class HistoryElement::ReviewObsoleted < HistoryElement::Review
+  def description
+    'Review got obsoleted'
+  end
+end
+
 class HistoryElement::ReviewAssigned < HistoryElement::Review
   def description
     'Review got assigned'

--- a/src/api/app/models/package.rb
+++ b/src/api/app/models/package.rb
@@ -1126,7 +1126,7 @@ class Package < ActiveRecord::Base
       # Don't alter the request that is the trigger of this close_requests run
       next if request.id == @commit_opts[:request]
 
-      request.remove_reviews(:by_package => self.name)
+      request.obsolete_reviews(:by_project => self.project.name, :by_package => self.name)
     end
   end
 

--- a/src/api/app/models/project.rb
+++ b/src/api/app/models/project.rb
@@ -220,7 +220,7 @@ class Project < ActiveRecord::Base
       # Don't alter the request that is the trigger of this revoke_requests run
       next if request.id == @commit_opts[:request]
 
-      request.remove_reviews(:by_project => self.name)
+      request.obsolete_reviews(:by_project => self.name)
     end
   end
 

--- a/src/api/config/initializers/valid_states.rb
+++ b/src/api/config/initializers/valid_states.rb
@@ -1,1 +1,2 @@
 VALID_REQUEST_STATES = [:new, :deleted, :declined, :accepted, :review, :revoked, :superseded]
+VALID_REVIEW_STATES = [:new, :declined, :accepted, :superseded, :obsoleted]

--- a/src/api/test/functional/webui/request_controller_test.rb
+++ b/src/api/test/functional/webui/request_controller_test.rb
@@ -156,6 +156,28 @@ class Webui::RequestControllerTest < Webui::IntegrationTest
     page.must_have_text "There's nothing to be done right now"
   end
 
+  uses_transaction :test_tom_adds_invalid_project_reviewer
+  def test_tom_adds_invalid_project_reviewer
+    login_tom to: user_show_path(user: 'tom')
+
+    within('tr#tr_request_4') do
+      page.must_have_text '~:branches:kde4 / BranchPack'
+      first(:css, 'a.request_link').click
+    end
+
+    page.must_have_text 'Review for tom'
+
+    click_link 'Add a review'
+    page.must_have_text 'Add Reviewer'
+    # test switching reviewer type
+    find(:id, 'review_type').select('Project')
+    page.must_have_text 'Project:'
+    fill_in 'review_project', with: 'INVALID/PROJECT'
+    click_button 'Ok'
+    find('#flash-messages').must_have_text 'Unable add review to'
+    page.must_have_text 'Open review for test_group'
+  end
+
   uses_transaction :test_tom_adds_reviewer_Iggy
   def test_tom_adds_reviewer_Iggy
     login_tom to: user_show_path(user: 'tom')
@@ -174,7 +196,8 @@ class Webui::RequestControllerTest < Webui::IntegrationTest
     page.must_have_text 'Group:'
     fill_in 'review_group', with: 'test_group_b'
     click_button 'Ok'
-    page.must_have_text 'Open review for test_group'
+    page.must_have_text 'Open review for test_group' # existed already
+    page.must_have_text 'Open review for test_group_b' # added by us
 
     click_link 'Add a review'
     find(:id, 'review_type').select('Project')

--- a/src/api/test/unit/code_quality_test.rb
+++ b/src/api/test/unit/code_quality_test.rb
@@ -88,7 +88,7 @@ class CodeQualityTest < ActiveSupport::TestCase
       'Owner::search'                                                           => 80.51,
       'PersonController#internal_register'                                      => 112.01,
       'Package#find_changed_issues'                                             => 93.74,
-      'Package#close_requests'                                                  => 81.68,
+      'Package#close_requests'                                                  => 84.82,
       'Project#update_one_repository_without_path'                              => 115.39,
       'PublicController#binary_packages'                                        => 126.16,
       'Repository#cleanup_before_destroy'                                       => 82.98,


### PR DESCRIPTION
- it was possible since the webui merge to create invalid reviews in DB, eg
  projects containing a "/" in name. This leads to crashes when just trying
  to view the request in webui due to routing errors

- reviews got removed (even in the history) when the reviewer object got
  removed (not at all for packages due to another bug though).
    Reviews get turned into "obsolete" state now instead