### PR TITLE
[webui] Update ui of project repository page

### DIFF
--- a/src/api/app/views/webui/project/add_repository_from_default_list.html.erb
+++ b/src/api/app/views/webui/project/add_repository_from_default_list.html.erb
@@ -7,10 +7,6 @@
 
 <h2>Add Repositories to <%= @project %></h2>
 
-<p>Please choose the repositories that your packages will be built for by following default list. Or
-  <%= link_to 'pick one via advanced interface', :action => :add_repository, :project => @project %>.
-</p>
-
 <%= form_tag(:action => :save_distributions, :project => @project) do %>
     <% @distributions.each do |vendor, list| %>
         <h3><%= sprite_tag("distributions-#{vendor.downcase}") %> <%= vendor -%> distributions</h3>
@@ -37,7 +33,10 @@
     </p>
 
     <p>
-      <%= submit_tag 'Add selected repositories', :disabled => true, :id => 'submitrepos' -%>
+      <span class="nowrap">
+        <%= submit_tag 'Add selected repositories', :disabled => true, :id => 'submitrepos' -%>
+        <%= link_to 'Expert mode', { action: 'add_repository', project: @project }, { style: 'padding-left: 4px' } %>
+      </span>
     </p>
 
 <% end %>

--- a/src/api/test/functional/webui/project_controller_test.rb
+++ b/src/api/test/functional/webui/project_controller_test.rb
@@ -256,7 +256,7 @@ class Webui::ProjectControllerTest < Webui::IntegrationTest
     assert first(:id, 'images')
 
     find(:link, 'Add repositories').click
-    find(:link, 'advanced interface').click
+    find(:link, 'Expert mode').click
     fill_autocomplete 'target_project', with: 'Base', select: 'BaseDistro'
 
     # wait for the ajax loader to disappear


### PR DESCRIPTION


* Remove self-explanatory description. The point of adding a repository should be clear:)
* Make advanced interface link more visible by moving it next to the 'add repo' button
* Rename advanced interface to expert mode