### PR TITLE
[webui] redirect logins from /user/do_login to :home

### DIFF
--- a/src/api/app/controllers/webui/user_controller.rb
+++ b/src/api/app/controllers/webui/user_controller.rb
@@ -36,7 +36,7 @@ class Webui::UserController < Webui::WebuiController
 
     session[:login] = User.current.login
 
-    redirect_back_or_to root_path
+    redirect_to :action => 'home'
   end
 
   def show

--- a/src/api/config/routes.rb
+++ b/src/api/config/routes.rb
@@ -299,6 +299,7 @@ OBSApi::Application.routes.draw do
       get 'user/tokens' => :tokens
 
       post 'user/do_login' => :do_login
+      get 'user/do_login' => :home
       get 'user/edit/:user' => :edit, constraints: cons, as: 'user_edit'
 
       post 'user/notifications' => :update_notifications

--- a/src/api/config/routes.rb
+++ b/src/api/config/routes.rb
@@ -299,7 +299,6 @@ OBSApi::Application.routes.draw do
       get 'user/tokens' => :tokens
 
       post 'user/do_login' => :do_login
-      get 'user/do_login' => :home
       get 'user/edit/:user' => :edit, constraints: cons, as: 'user_edit'
 
       post 'user/notifications' => :update_notifications


### PR DESCRIPTION
Logins from /user/do_login page redirects to th 404 page because a get route for /user/do_login is missing, redirecting into :home to fix that.

this commit fixes #1557