### PR TITLE
[webui] redirect to home after login from /user/do_login

### DIFF
--- a/src/api/app/controllers/webui/user_controller.rb
+++ b/src/api/app/controllers/webui/user_controller.rb
@@ -36,7 +36,11 @@ class Webui::UserController < Webui::WebuiController
 
     session[:login] = User.current.login
 
-    redirect_back_or_to root_path
+    if request.referer.end_with?("/user/login")
+      redirect_to home_path
+    else
+      redirect_back_or_to root_path
+    end
   end
 
   def show

--- a/src/api/test/functional/webui/user_controller_test.rb
+++ b/src/api/test/functional/webui/user_controller_test.rb
@@ -181,6 +181,22 @@ class Webui::UserControllerTest < Webui::IntegrationTest
     assert_equal search_path, current_path
   end
 
+  def test_that_redirect_from_user_do_login_works # spec/controllers/webui/users_spec.rb
+    use_js
+
+    visit search_path
+    click_link("Log In")
+    fill_in 'Username', with: "tom"
+    fill_in 'Password', with: "brokenpassword"
+    click_button 'Log In'
+
+    fill_in 'Username', with: "tom"
+    fill_in 'Password', with: "buildservice"
+    click_button 'Log In'
+
+    assert_equal "tom", find('#home-username').text
+  end
+
   def test_redirect_after_register_user_action_works # spec/controllers/webui/users_spec.rb
     visit user_register_user_path
     within ".sign-up" do

--- a/src/api/test/functional/webui/user_controller_test.rb
+++ b/src/api/test/functional/webui/user_controller_test.rb
@@ -181,20 +181,16 @@ class Webui::UserControllerTest < Webui::IntegrationTest
     assert_equal search_path, current_path
   end
 
-  def test_that_redirect_from_user_do_login_works # spec/controllers/webui/users_spec.rb
+  def test_that_redirect_from_user_do_login_works
     use_js
 
-    visit search_path
-    click_link("Log In")
-    fill_in 'Username', with: "tom"
-    fill_in 'Password', with: "brokenpassword"
-    click_button 'Log In'
-
+    visit user_login_path
     fill_in 'Username', with: "tom"
     fill_in 'Password', with: "buildservice"
     click_button 'Log In'
 
     assert_equal "tom", find('#home-username').text
+    assert_equal "/user/show/tom", page.current_path
   end
 
   def test_redirect_after_register_user_action_works # spec/controllers/webui/users_spec.rb


### PR DESCRIPTION
If a user enters wrong credentials in login widget and he gets redirected to /user/do_login.
If login happens with correct credentials now the user is logged in but stays on the page and sees the login form again in master, or gets an 404 in 2.6.

Now he gets redirected into home if the user comes from the login page.

fixes #1557
closes #1615 