### PR TITLE
[backend] introduce $BSConfig::bsserviceuser variable

### DIFF
--- a/dist/obs-server.spec
+++ b/dist/obs-server.spec
@@ -433,6 +433,13 @@ exit 0
 %endif
 %restart_on_update obsscheduler
 
+%pre -n obs-source_service
+getent group obsrun >/dev/null || groupadd -r obsrun
+getent passwd obsservicerun >/dev/null || \
+    /usr/sbin/useradd -r -g obsrun -d /usr/lib/obs -s %{sbin}/nologin \
+    -c "User for the build service source service" obsservicerun
+exit 0
+
 %preun -n obs-source_service
 %stop_on_removal obsservice
 

--- a/dist/obsservice
+++ b/dist/obsservice
@@ -43,11 +43,17 @@ rundir="$OBS_RUN_DIR"
 logdir="$OBS_LOG_DIR"
 workdir="/var/tmp/obs_service"
 
+rundir_perm() {
+	# make sure rundir is group writable
+	test "$(stat -c "%A" "$rundir" | cut -c6)" = "-" && chmod 0775 "$rundir"
+}
+
 rc_reset
 case "$1" in
 	start)
 		echo -n "Initializing obsservice"
 		mkdir -p "$rundir" "$logdir" "$workdir"
+		rundir_perm
 		chown obsrun:obsrun "$logdir" "$rundir" "$workdir"
 		startproc -f -l "$logdir"/src_service.log "$obsdir"/bs_service --tempdir "$workdir"
 		rc_status -v
@@ -60,12 +66,14 @@ case "$1" in
 	restart)
 		## If first returns OK call the second, if first or
 		## second command fails, set echo return value.
+		rundir_perm
 		"$obsdir"/bs_service --restart
 		rc_status
 	;;
 	try-restart|reload)
 		$0 status
 		if test $? = 0; then
+			rundir_perm
 			"$obsdir"/bs_service --restart
 		else
 			rc_reset        # Not running is not a failure.

--- a/src/backend/BSConfig.pm.template
+++ b/src/backend/BSConfig.pm.template
@@ -77,6 +77,12 @@ our @reposervers = ("http://$hostname:5252");
 our $bsdir = '/srv/obs';
 our $bsuser = 'obsrun';
 our $bsgroup = 'obsrun';
+# user and group for bs_service (if the lxc service wrapper is used, set
+# $bsserviceuser to root). If several obs services (e.g., bs_service and
+# bs_srcserver) run on the same host, make sure that $bsservicegroup is set
+# to $bsgroup.
+our $bsserviceuser = 'obsservicerun';
+our $bsservicegroup = $bsgroup;
 #our $bsquotafile = '/srv/obs/quota.xml';
 
 # Use asynchronus scheduler. This avoids hanging schedulers on remote projects,

--- a/src/backend/bs_service
+++ b/src/backend/bs_service
@@ -47,8 +47,8 @@ use BSBuild;
 
 use strict;
 
-undef $BSConfig::bsuser;	# need to stay root
-undef $BSConfig::bsgroup;
+$BSConfig::bsuser = $BSConfig::bsserviceuser;
+$BSConfig::bsgroup = $BSConfig::bsservicegroup;
 
 BSUtil::set_fdatasync_before_rename() unless $BSConfig::disable_data_sync || $BSConfig::disable_data_sync;
 


### PR DESCRIPTION
$BSConfig::bsserviceuser and $BSConfig::bsservicegroup can be used to
configure the user/group under which "bs_service" is running. The defaults
are $BSConfig::bsuser and $BSConfig::bsgroup.

The new defaults shouldn't break existing installations, because
* the /usr/lib/obs/server/BSConfig.pm file is marked as %config(noreplace)
* bs_service's default $tempdir is set to /var/tmp, which is writable by "obsrun".
  Additionally, I'm not aware of any service that explicitly needs write access to the
  home directory of the user who is executing the service (by default obsrun's
  homedir (/usr/lib/obs) is owned by root).