### PR TITLE
[webui] rename Project.is_remote? to defines_remote?

### DIFF
--- a/src/api/app/controllers/webui/package_controller.rb
+++ b/src/api/app/controllers/webui/package_controller.rb
@@ -798,11 +798,11 @@ class Webui::PackageController < Webui::WebuiController
     end
 
     begin
-      @package = Package.get_by_project_and_name(params[:project], params[:package],
+      @package = Package.get_by_project_and_name(@project, params[:package],
                                                  use_source: false, follow_project_links: true)
     rescue Package::UnknownObjectError
-      flash[:error] = "Couldn't find package '#{params[:package]}' in project '#{params[:project]}'. Are you sure it exists?"
-      redirect_to project_show_path(@project.name)
+      flash[:error] = "Couldn't find package '#{params[:package]}' in project '#{@project.to_param}'. Are you sure it exists?"
+      redirect_to project_show_path(@project.to_param)
       return
     end
 
@@ -812,7 +812,7 @@ class Webui::PackageController < Webui::WebuiController
       return
     end
 
-    @package = params[:package] unless @package
+    @package ||= params[:package] # for remote package
     @arch = params[:arch]
     @repo = params[:repository]
     @offset = 0

--- a/src/api/app/controllers/webui/patchinfo_controller.rb
+++ b/src/api/app/controllers/webui/patchinfo_controller.rb
@@ -312,13 +312,14 @@ class Webui::PatchinfoController < Webui::WebuiController
 
   def require_exists
     unless params[:package].blank?
-      @package = Package.get_by_project_and_name(@project.to_param, params[:package], use_source: false)
+      @package = Package.get_by_project_and_name(params[:project], params[:package], use_source: false)
     end
-    @patchinfo = @file = @package.patchinfo
 
-    unless @file
+    unless @package && @package.patchinfo
+      # FIXME: should work for remote packages
       flash[:error] = "Patchinfo not found for #{params[:project]}"
       redirect_to controller: 'package', action: 'show', project: @project, package: @package and return
     end
+    @patchinfo = @file = @package.patchinfo
   end
 end

--- a/src/api/app/controllers/webui/project_controller.rb
+++ b/src/api/app/controllers/webui/project_controller.rb
@@ -288,7 +288,7 @@ class Webui::ProjectController < Webui::WebuiController
   end
 
   def repositories
-    if @project.is_remote?
+    unless @project
       # TODO support flagdetails for remote instances in the API
       flash[:error] = "You can't show repositories for remote instances"
       redirect_to :action => :show, :project => params[:project]

--- a/src/api/app/helpers/webui/project_helper.rb
+++ b/src/api/app/helpers/webui/project_helper.rb
@@ -42,11 +42,8 @@ module Webui::ProjectHelper
   def project_bread_crumb(*args)
     @crumb_list = [link_to('Projects', project_list_public_path)]
     return if @spider_bot
-    # Sometimes @project is a WebuiProject and sometimes a Project
-    # We need to check this before calling new_record?
-    unless @project.nil? ||
-        (@project.kind_of?(Project) && @project.new_record?) ||
-        @project.is_remote?
+    # FIXME: should also work for remote
+    if @project && @project.kind_of?(Project) && !@project.new_record?
       prj_parents = nil
       if @namespace # corner case where no project object is available
         prj_parents = Project.parent_projects(@namespace)

--- a/src/api/app/models/project.rb
+++ b/src/api/app/models/project.rb
@@ -284,7 +284,7 @@ class Project < ActiveRecord::Base
   def self.is_remote_project?(name, skip_access = false)
     lpro = find_remote_project(name, skip_access)
 
-    lpro && lpro[0].is_remote?
+    lpro && lpro[0].defines_remote_instance?
   end
 
   def self.check_access?(dbp = self)
@@ -391,8 +391,8 @@ class Project < ActiveRecord::Base
       logger.debug "Trying to find local project #{local_project}, remote_project #{remote_project}"
 
       project = Project.find_by(name: local_project)
-      if project && check_access?(project) && project.is_remote?
-        logger.debug "Found local project #{project.name} with remoteurl #{project.remoteurl}"
+      if project && check_access?(project) && project.defines_remote_instance?
+        logger.debug "Found local project #{project.name} for #{remote_project} with remoteurl #{project.remoteurl}"
         return project, remote_project
       end
     end
@@ -456,7 +456,7 @@ class Project < ActiveRecord::Base
     self.kind == 'standard'
   end
 
-  def is_remote?
+  def defines_remote_instance?
     self.remoteurl.present?
   end
 
@@ -677,7 +677,7 @@ class Project < ActiveRecord::Base
 
     # recreate release targets from xml
     repo.elements('releasetarget') do |rt|
-      if Project.find_by(name: rt['project']).is_remote?
+      if Project.find_by(name: rt['project']).defines_remote_instance?
         raise SaveError, "Can not use remote repository as release target '#{rt['project']}/#{rt['repository']}'"
       else
         target_repo = Repository.find_by_project_and_name(rt['project'], rt['repository'])

--- a/src/api/app/policies/project_policy.rb
+++ b/src/api/app/policies/project_policy.rb
@@ -9,7 +9,7 @@ class ProjectPolicy < ApplicationPolicy
     return true if @user.is_admin?
 
     # Regular users are not allowed to modify projects with remote references
-    !@record.is_remote? && !@record.has_remote_repositories?
+    !@record.defines_remote_instance? && !@record.has_remote_repositories?
   end
 
   def destroy?

--- a/src/api/app/views/webui/package/_live_log_controls.html.erb
+++ b/src/api/app/views/webui/package/_live_log_controls.html.erb
@@ -8,6 +8,10 @@
   <% end %>
 </p>
 
+<% if @package.kind_of?(Package)%>
+  <%= render :partial => "tabs" %>
+<% end %>
+
 <% if @package.kind_of?(Package) && User.current.can_modify_package?(@package) %>
     <p>
       <span class="link_trigger_rebuild hidden">

--- a/src/api/app/views/webui/package/live_build_log.html.erb
+++ b/src/api/app/views/webui/package/live_build_log.html.erb
@@ -3,10 +3,6 @@
    package_bread_crumb 'Build Log' 
 -%>
 
-<% if !@project.is_remote? && @package.kind_of?(Package)%>
-  <%= render :partial => "tabs" %>
-<% end %>
-
 <%= content_for :ready_function do %>
   live_build_log_ready();
 <% end -%>

--- a/src/api/app/views/webui/project/_packages_table.html.erb
+++ b/src/api/app/views/webui/project/_packages_table.html.erb
@@ -33,8 +33,8 @@
           <p><i>This project does not contain any packages</i></p>
       <% end %>
 
-      <% if User.current.can_modify_project?(@project) %>
-          <% if !@project.is_remote? && !(@is_incident_project && !@packages.blank? && @has_patchinfo && @open_release_requests.length == 0) && !@is_maintenance_project %>
+      <% if @project.kind_of?(Project) && User.current.can_modify_project?(@project) %>
+          <% if !@project.defines_remote_instance? && !(@is_incident_project && !@packages.blank? && @has_patchinfo && @open_release_requests.length == 0) && !@is_maintenance_project %>
               <ul class="horizontal-list">
                 <li>
                   <%= link_to(sprited_text('package_add', 'Create package'), controller: 'project', action: 'new_package', project: @project) %>

--- a/src/api/app/views/webui/project/_tabs.html.erb
+++ b/src/api/app/views/webui/project/_tabs.html.erb
@@ -12,15 +12,15 @@
       <%= tab 'incidents', 'Incidents', :controller => :project, :action => :maintenance_incidents %>
       <%= tab 'maintained', 'Maintained Projects', :controller => :project, :action => :maintained_projects %>
     <% else %> <!-- also for incident project -->
-      <%= tab 'repositories', "Repositories", :controller => :project, :action => :repositories unless @project.is_remote? or @spider_bot %>
+      <%= tab 'repositories', "Repositories", :controller => :project, :action => :repositories unless @project.defines_remote_instance? or @spider_bot %>
     <% end %>
     <% if @project.repositories.any? && !@spider_bot -%>
       <%= tab 'monitor', "Monitor", :controller => :project, :action => :monitor %>
     <% end -%>
     <% unless @spider_bot -%>
       <%= tab 'requests', "Requests", :controller => :project, :action => 'requests' %>
-      <%= tab 'users', 'Users', :controller => :project, :action => :users unless @project.is_remote? %>
-      <%= tab 'subprojects', 'Subprojects', :controller => :project, :action => :subprojects unless @project.is_remote? or @is_maintenance_project %>
+      <%= tab 'users', 'Users', :controller => :project, :action => :users unless @project.defines_remote_instance? %>
+      <%= tab 'subprojects', 'Subprojects', :controller => :project, :action => :subprojects unless @project.defines_remote_instance? or @is_maintenance_project %>
     <% end -%>
   
     <% if is_advanced_tab? %>
@@ -33,11 +33,11 @@
   </ul>
   <div id="advanced_tabs" class="hidden">
     <ul>
-      <%= tab 'projectconfig', 'Project Config', :controller => :project, :action => :prjconf unless @project.is_remote? or @is_maintenance_project %>
+      <%= tab 'projectconfig', 'Project Config', :controller => :project, :action => :prjconf unless @project.defines_remote_instance? or @is_maintenance_project %>
       <% unless @spider_bot -%>
         <%= tab 'attribute', 'Attributes', :controller => :attribute, :project => @project, :action => 'index' %>
         <%= tab 'meta', "Meta", :controller => :project, :action => :meta %>
-        <%= tab 'status', 'Status', :controller => :project, :action => :status unless @project.is_remote? or @is_maintenance_project %>
+        <%= tab 'status', 'Status', :controller => :project, :action => :status unless @project.defines_remote_instance? or @is_maintenance_project %>
       <% end -%>
     </ul>
   </div>

--- a/src/api/app/views/webui/project/show.html.erb
+++ b/src/api/app/views/webui/project/show.html.erb
@@ -73,7 +73,7 @@
 
         <%= render partial: 'shared/open_requests' %>
 
-        <% if @project.is_remote? %>
+        <% if @project.defines_remote_instance? %>
             <li>
               <%= sprite_tag 'information' %>
               Links against the remote OBS instance at: <i><%= link_to_if(@project.remoteurl,
@@ -110,7 +110,7 @@
               </li>
           <% end -%>
           <% if User.current.can_modify_project?(@project, true) %>
-              <% unless @project.is_remote? %>
+              <% unless @project.defines_remote_instance? %>
                   <% if @is_incident_project && @packages.present? && @has_patchinfo && @open_release_requests.blank? %>
                       <li>
                         <%= link_to(sprited_text('brick_go', 'Request to release'), { controller: 'project', action: 'release_request_dialog', project: @project }, remote: true) %>


### PR DESCRIPTION
The Project database object for remote usages is always the project
defining the remote instance. find_remote delivers an additional string
identifing the remote project name.

We could have a is_remote? for repositories, because they can be indeed
local active record objects for remote projects, but it seems we don't
have the use case yet for adding this.

Cleaning up some misleaded code which just crashes so far when operating
on a remote project.