### PR TITLE
[api][webui] Fix ActiveRecord::HasManyThroughCantAssociateThroughHasO…

### DIFF
--- a/src/api/app/models/project.rb
+++ b/src/api/app/models/project.rb
@@ -52,7 +52,7 @@ class Project < ActiveRecord::Base
   has_many :attribs, :dependent => :destroy
 
   has_many :repositories, :dependent => :destroy, foreign_key: :db_project_id
-  has_many :repository_architectures, -> { order("position") }, :dependent => :destroy, through: :repositories
+  has_many :repository_architectures, -> { order("position") }, through: :repositories
   has_many :architectures, -> { order("position").distinct }, :through => :repository_architectures
 
   has_many :messages, :as => :db_object, :dependent => :delete_all


### PR DESCRIPTION
…neOrManyReflection error

This fixes an ActiveRecord exception that happened when destroying a project with
repository_architecture association. This was caused by an unnessicary dependent-destroy
instruction in a has_many_through associtation.

http://errbit-opensuse.herokuapp.com/apps/5620ca2bdc71fa00b1000000/problems/56fc2c4cab0904000c000000