### PR TITLE
[ci] [backend] Backend tests in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ env:
   - TEST_SUITE=webui
   - TEST_SUITE=spider
   - TEST_SUITE=rspec
+  - TEST_SUITE=backend
 matrix:
   fast_finish: true
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: ruby
 cache: bundler
 rvm: 2.3.0
 gemfile: src/api/Gemfile
-before_install: dist/ci/obs_testsuite_travis_install.sh
+before_install: "dist/ci/obs_testsuite_travis_install.sh $TEST_SUITE"
 before_script: dist/ci/obs_testsuite_travis_before.sh
 after_failure: dist/ci/obs_testsuite_travis_failure.sh
 script: "dist/ci/obs_testsuite_travis.sh $TEST_SUITE"

--- a/dist/ci/obs_testsuite_travis.sh
+++ b/dist/ci/obs_testsuite_travis.sh
@@ -35,11 +35,19 @@ if test -z "$SUBTEST"; then
     rspec)
       bundle exec rspec
       ;;
+    backend)
+      pushd ../backend
+      bundle exec make test_unit
+      popd
+      ;;
     *)
       bundle exec rake rubocop
       bundle exec rake test:api
       bundle exec rake test:webui
       bundle exec rspec
+      pushd ../backend
+      bundle exec make test_unit
+      popd
       unset DO_COVERAGE
       bundle exec rake test:spider
       ;;

--- a/dist/ci/obs_testsuite_travis_install.sh
+++ b/dist/ci/obs_testsuite_travis_install.sh
@@ -16,4 +16,4 @@ echo 'deb http://download.opensuse.org/repositories/OBS:/Server:/Unstable/xUbunt
 sudo apt-get update
 
 # Install the dependencies of the backend
-sudo apt-get install --force-yes travis-deps libxml-parser-perl libfile-sync-perl python-rpm python-urlgrabber python-sqlitecachec python-libxml2 createrepo libbssolv-perl sphinxsearch libjson-xs-perl libxml-simple-perl libgd-gd2-perl
+sudo apt-get install --force-yes travis-deps libxml-parser-perl libfile-sync-perl python-rpm python-urlgrabber python-sqlitecachec python-libxml2 createrepo libbssolv-perl sphinxsearch libjson-xs-perl libxml-simple-perl libgd-gd2-perl libdevel-cover-perl

--- a/dist/ci/obs_testsuite_travis_install.sh
+++ b/dist/ci/obs_testsuite_travis_install.sh
@@ -4,6 +4,8 @@
 # Be verbose and fail script on the first error
 set -xe
 
+TEST_SUITE="$1"
+
 sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys C5C219E7
 
 # Install updates from our own repository
@@ -16,4 +18,8 @@ echo 'deb http://download.opensuse.org/repositories/OBS:/Server:/Unstable/xUbunt
 sudo apt-get update
 
 # Install the dependencies of the backend
-sudo apt-get install --force-yes travis-deps libxml-parser-perl libfile-sync-perl python-rpm python-urlgrabber python-sqlitecachec python-libxml2 createrepo libbssolv-perl sphinxsearch libjson-xs-perl libxml-simple-perl libgd-gd2-perl libdevel-cover-perl
+sudo apt-get install --force-yes travis-deps libxml-parser-perl libfile-sync-perl python-rpm python-urlgrabber python-sqlitecachec python-libxml2 createrepo libbssolv-perl sphinxsearch libjson-xs-perl libxml-simple-perl libgd-gd2-perl
+
+if [ "$TEST_SUITE" == "backend" ]; then
+  sudo apt-get install --force-yes libdevel-cover-perl
+fi


### PR DESCRIPTION
Option "TEST_SUITE=backend" added in .travis.yml file, so perl backend tests can be run with travis.

TEST_SUITE variable is passed as argument to dist/ci/obs_testsuite_travis_install.sh, so ubuntu package libdevel-cover-perl is installed only when testing backend.