### PR TITLE
[ci] Fix flacky rspec tests

### DIFF
--- a/src/api/spec/cassettes/Login/login_via_widget.yml
+++ b/src/api/spec/cassettes/Login/login_via_widget.yml
@@ -1,0 +1,53 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://localhost:3200/build/_workerstatus
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - text/plain
+      Accept-Encoding:
+      - identity
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '589'
+    body:
+      encoding: UTF-8
+      string: |
+        <workerstatus clients="0">
+          <waiting arch="i586" jobs="1" />
+          <waiting arch="x86_64" jobs="0" />
+          <blocked arch="i586" jobs="0" />
+          <blocked arch="x86_64" jobs="0" />
+          <buildavg arch="i586" buildavg="1200" />
+          <buildavg arch="x86_64" buildavg="1200" />
+          <partition>
+            <daemon type="scheduler" arch="i586" state="dead">
+              <queue high="0" med="0" low="3" next="0" />
+            </daemon>
+            <daemon type="scheduler" arch="x86_64" state="dead">
+              <queue high="0" med="0" low="6" next="0" />
+            </daemon>
+            <daemon type="publisher" state="dead" />
+          </partition>
+        </workerstatus>
+    http_version: 
+  recorded_at: Mon, 04 Apr 2016 14:06:08 GMT
+recorded_with: VCR 3.0.1

--- a/src/api/spec/cassettes/Login/login_with_wrong_data.yml
+++ b/src/api/spec/cassettes/Login/login_with_wrong_data.yml
@@ -1,0 +1,53 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://localhost:3200/build/_workerstatus
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - text/plain
+      Accept-Encoding:
+      - identity
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '589'
+    body:
+      encoding: UTF-8
+      string: |
+        <workerstatus clients="0">
+          <waiting arch="i586" jobs="1" />
+          <waiting arch="x86_64" jobs="0" />
+          <blocked arch="i586" jobs="0" />
+          <blocked arch="x86_64" jobs="0" />
+          <buildavg arch="i586" buildavg="1200" />
+          <buildavg arch="x86_64" buildavg="1200" />
+          <partition>
+            <daemon type="scheduler" arch="i586" state="dead">
+              <queue high="0" med="0" low="3" next="0" />
+            </daemon>
+            <daemon type="scheduler" arch="x86_64" state="dead">
+              <queue high="0" med="0" low="6" next="0" />
+            </daemon>
+            <daemon type="publisher" state="dead" />
+          </partition>
+        </workerstatus>
+    http_version: 
+  recorded_at: Mon, 04 Apr 2016 14:05:11 GMT
+recorded_with: VCR 3.0.1


### PR DESCRIPTION
Visiting the root path accesses update_workerstatus_cache, which triggers a
http call to build/_workerstatus if the cache is empty. This means that each
test that touches this cache (root path) needs to store the http request in
it's VCR cassete.