### PR TITLE
[ci] Extend request controller test

### DIFF
--- a/src/api/test/functional/webui/request_controller_test.rb
+++ b/src/api/test/functional/webui/request_controller_test.rb
@@ -317,6 +317,8 @@ class Webui::RequestControllerTest < Webui::IntegrationTest
     fill_in 'description', with: 'I want to see his reaction'
     click_button 'Ok'
 
+    assert_equal package_show_path(project: 'Apache', package: 'apache2'), page.current_path
+    assert page.has_content?(/Created submit request \d+ to kde4/)
     within '#flash-messages' do
       click_link 'submit request'
     end


### PR DESCRIPTION
The test in question currently fails randomly because of missing '#flash-messages'.
Testing the page content before searching for the flash message might give us
a clue what is going wrong, eg. having an error page rendered instead.