### PR TITLE
[doc] Update rspec readme

### DIFF
--- a/src/api/spec/README.md
+++ b/src/api/spec/README.md
@@ -70,14 +70,7 @@ file path of the new one to every test covered.
 
 ### Untested methods
 When you work on the test suite and you notice a method or part of a feature that
-is not tested please either add a test for it or at least add a skipped test case
-like this
-
-```ruby
-describe "some method/feature" do
- skip
-end
-```
+is not tested please add a test for it.
 
 ## Better Specs
 As a set of "rules" to follow in our specs we use [BetterSpecs.org](http://betterspecs.org/).


### PR DESCRIPTION
Remove adding skip to tests as a valid approach to handle untested code. This
was leading developers to the wrong impression that adding skips in our test suite
is a valid approach when migrating tests, or even writing new features.

It's not! Skips should be used in rare exceptions, when we can't fix a broken
test right away.
In any other case we should aim for writing the test!