### PR TITLE
[webui] Fix broken link to publish_enable_blue.png (part of #1687)

### DIFF
--- a/src/api/app/assets/images/group.png
+++ b/src/api/app/assets/images/group.png
@@ -1,1 +1,1 @@
-icons/publish_enabled_blue.png
+icons/publish_enable_blue.png


### PR DESCRIPTION
Icon file names got changed in 1a4bf15ade0350c1d579, which broke the
link