### PR TITLE
Revert "[ci] disable test for russian search for now"

### DIFF
--- a/src/api/test/functional/webui/search_controller_test.rb
+++ b/src/api/test/functional/webui/search_controller_test.rb
@@ -260,7 +260,6 @@ class Webui::SearchControllerTest < Webui::IntegrationTest
   def test_search_russian
     visit search_path
 
-if $ENABLE_BROKEN_TEST
     search(
       :text => 'вокябюч',
       :for  => [:projects, :packages],
@@ -270,7 +269,6 @@ if $ENABLE_BROKEN_TEST
     page.must_have_text '窞綆腤 埱娵徖 渮湸湤 殠 唲堔'
     results.include?(:type => :project, :project_name => 'home:tom')
     results.count.must_equal 1
-end
   end
 
   def test_search_in_nothing


### PR DESCRIPTION
This reverts commit a444ecbf10e15d2bbfdc4180882a41d1e5239cba.

Test are passing now on my local instance. Let's give it a try in travis,
our OBS project and elsewhere.