### PR TITLE
[dist] Turn of asset pipeline logging in test/dev

### DIFF
--- a/src/api/Gemfile
+++ b/src/api/Gemfile
@@ -123,6 +123,8 @@ group :development, :test do
   gem 'poltergeist', '>= 1.4'
   # to launch browser in test
   gem 'launchy'
+  # to turn off the asset pipeline log
+  gem 'quiet_assets'
 end
 
 # Gems used only for assets and not required in production environments by default.

--- a/src/api/Gemfile.lock
+++ b/src/api/Gemfile.lock
@@ -181,6 +181,8 @@ GEM
       slop (~> 3.4)
     pundit (1.0.1)
       activesupport (>= 3.0.0)
+    quiet_assets (1.0.2)
+      railties (>= 3.1, < 5.0)
     rack (1.6.4)
     rack-test (0.6.3)
       rack (>= 1.0)
@@ -372,6 +374,7 @@ DEPENDENCIES
   poltergeist (>= 1.4)
   pry (>= 0.9.12)
   pundit
+  quiet_assets
   rails (~> 4.2.2)
   rails_tokeninput (>= 1.6.1.rc1)
   rdoc
@@ -399,4 +402,4 @@ DEPENDENCIES
   yajl-ruby
 
 BUNDLED WITH
-   1.10.6
+   1.11.2


### PR DESCRIPTION
This turns off request logging for stuff in `/assets`. Entries like
```
Started GET "/assets/application.js" for 127.0.0.1 at 2015-01-28 13:35:34 +0300
Served asset /application.js - 304 Not Modified (8ms)
```