### PR TITLE
[webui] Fix tests and update redirect after failed login attempts

### DIFF
--- a/src/api/Gemfile
+++ b/src/api/Gemfile
@@ -8,7 +8,7 @@ gem 'actionmailer'
 # as our database
 gem 'mysql2'
 # as requirement for activexml
-gem 'nokogiri', '~>1.6.3'
+gem 'nokogiri', '~>1.6.7.2'
 # for delayed tasks
 gem 'delayed_job_active_record', '>= 4.0.0'
 # to have the delayed job daemon
@@ -103,7 +103,7 @@ group :assets do
   # for minifying CSS
   gem 'cssmin', '>= 1.0.2'
   # for minifying JavaScript
-  gem 'uglifier', '>= 1.2.2'
+  gem 'uglifier', '>= 2.7.2'
   # to use sass in the asset pipeline
   gem 'sass-rails', '4.0.5'
   # assets for jQuery DataTables

--- a/src/api/Gemfile.lock
+++ b/src/api/Gemfile.lock
@@ -67,7 +67,7 @@ GEM
     docile (1.1.5)
     erubis (2.7.0)
     escape_utils (1.0.1)
-    execjs (2.2.2)
+    execjs (2.6.0)
     faker (1.4.3)
       i18n (~> 0.5)
     flog (4.3.0)
@@ -103,14 +103,14 @@ GEM
     method_source (0.8.2)
     middleware (0.1.0)
     mime-types (2.4.1)
-    mini_portile (0.6.0)
+    mini_portile2 (2.0.0)
     minitest (5.3.3)
     mocha (1.1.0)
       metaclass (~> 0.0.1)
     multi_json (1.10.1)
     mysql2 (0.3.16)
-    nokogiri (1.6.3.1)
-      mini_portile (= 0.6.0)
+    nokogiri (1.6.7.2)
+      mini_portile2 (~> 2.0.0.rc2)
     nokogumbo (1.4.1)
       nokogiri
     pkg-config (1.1.5)
@@ -198,9 +198,8 @@ GEM
     timecop (0.7.1)
     tzinfo (1.2.2)
       thread_safe (~> 0.1)
-    uglifier (2.5.3)
-      execjs (>= 0.3.0)
-      json (>= 1.8.0)
+    uglifier (3.0.0)
+      execjs (>= 0.3.0, < 3)
     unicorn (4.8.3)
       kgio (~> 2.6)
       rack
@@ -248,7 +247,7 @@ DEPENDENCIES
   minitest (= 5.3.3)
   mocha (> 0.13.0)
   mysql2
-  nokogiri (~> 1.6.3)
+  nokogiri (~> 1.6.7.2)
   poltergeist (>= 1.4)
   pry (>= 0.9.12)
   pundit
@@ -263,11 +262,10 @@ DEPENDENCIES
   simplecov
   single_test
   sprite-factory (>= 1.5.2)
-  sprockets (= 2.11.3)
   thinking-sphinx (> 3.1)
   tilt (>= 1.4.1)
   timecop
-  uglifier (>= 1.2.2)
+  uglifier (>= 2.7.2)
   unicorn-rails
   webmock (>= 1.18.0)
   xmlhash (>= 1.3.6)

--- a/src/api/app/controllers/webui/package_controller.rb
+++ b/src/api/app/controllers/webui/package_controller.rb
@@ -12,6 +12,7 @@ class Webui::PackageController < Webui::WebuiController
   include Webui::RequiresProject
   include Webui::ManageRelationships
   include BuildLogSupport
+  include ERB::Util
 
   helper 'webui/comment'
 
@@ -1044,7 +1045,7 @@ class Webui::PackageController < Webui::WebuiController
       flash[:error] = "Package \"#{params[:package]}\" not found in project \"#{params[:project]}\""
       redirect_to :controller => 'project', :action => 'show', :project => @project, :nextstatus => 404
     else
-      render :text => "Package \"#{params[:package]}\" not found in project \"#{params[:project]}\"", :status => 404 and return
+      render :text => "Package \"#{h(params[:package])}\" not found in project \"#{h(params[:project])}\"", :status => 404 and return
     end
   end
 

--- a/src/api/app/controllers/webui/user_controller.rb
+++ b/src/api/app/controllers/webui/user_controller.rb
@@ -45,9 +45,10 @@ class Webui::UserController < Webui::WebuiController
       end
 
       unless User.current
-        flash.now[:error] = 'Authentication failed'
+        reset_session
+        flash[:error] = 'Authentication failed'
         User.current = User.find_by_login('_nobody_')
-        render :template => 'webui/user/login'
+        redirect_to action: 'login'
         return
       end
 

--- a/src/api/test/functional/webui/user_controller_test.rb
+++ b/src/api/test/functional/webui/user_controller_test.rb
@@ -71,6 +71,7 @@ class Webui::UserControllerTest < Webui::IntegrationTest
     page.must_have_checked_field('CommentForProject_commenter')
   end
 
+  # Using the widget
   def test_that_redirect_after_login_works
     use_js
 
@@ -84,15 +85,32 @@ class Webui::UserControllerTest < Webui::IntegrationTest
     assert_equal search_path, current_path
   end
 
-  def test_that_redirect_from_user_do_login_works
+  # Using the login form
+  def test_that_login_via_user_login_form_works
     use_js
 
     visit user_login_path
     fill_in 'Username', with: "tom"
-    fill_in 'Password', with: "buildservice"
+    fill_in 'Password', with: "thunder"
     click_button 'Log In'
 
-    assert_equal "tom", find('#home-username').text
+    assert_equal "tom", find('#link-to-user-home').text
+    # Logins that are not done via widget should redirect to the user page
     assert_equal "/user/show/tom", page.current_path
+  end
+
+  def test_failed_logins
+    use_js
+
+    visit search_path
+    click_link("Log In")
+    fill_in 'Username', with: "tom"
+    fill_in 'Password', with: "foo"
+    click_button 'Log In'
+
+    page.wont_have_css('#link-to-user-home')
+    assert_equal user_login_path, current_path
+    flash_message.must_equal "Authentication failed"
+    flash_message_type.must_equal :alert
   end
 end


### PR DESCRIPTION
* Add test for failed logins.
* Update and rename test for login form.
* Redirect after failed logins instead of using render.
  Since do_login action was called via POST rendering a view here lead to the wrong
  impression that /user/do_login is a valid path for a GET request. Doing a redirect
  prevents this from happening.