### PR TITLE
[ci] split testing into system and appliance

### DIFF
--- a/dist/Makefile
+++ b/dist/Makefile
@@ -66,4 +66,7 @@ test_unit:
 test_system:
 	prove -v t/*.ts
 
+test_appliance:
+	prove -v t/*.ta
+
 .PHONY: test_unit test_system

--- a/dist/t/0020-test-appliance.ts
+++ b/dist/t/0020-test-appliance.ts
@@ -6,7 +6,7 @@ export BASH_TAP_ROOT=$(dirname $0)
 
 . $(dirname $0)/bash-tap-bootstrap
 
-plan tests 29
+plan tests 27
 
 for i in $(dirname $0)/../setup-appliance.sh /usr/lib/obs/server/setup-appliance.sh;do
 	[[ -f $i && -z $SETUP_APPLIANCE ]] && SETUP_APPLIANCE=$i
@@ -24,7 +24,6 @@ tmpcount=$MAX_WAIT
 
 # Service enabled and started
 for srv in \
-obsapisetup \
 obsapidelayed \
 obsdispatcher \
 obspublisher \

--- a/dist/t/0050-test-appliance.ta
+++ b/dist/t/0050-test-appliance.ta
@@ -1,0 +1,42 @@
+#!/bin/bash
+
+export BOOTSTRAP_TEST_MODE=1
+export NON_INTERACTIVE=1
+export BASH_TAP_ROOT=$(dirname $0)
+
+. $(dirname $0)/bash-tap-bootstrap
+
+plan tests 2
+
+for i in $(dirname $0)/../setup-appliance.sh /usr/lib/obs/server/setup-appliance.sh;do
+	[[ -f $i && -z $SETUP_APPLIANCE ]] && SETUP_APPLIANCE=$i
+done
+
+if [[ -z $SETUP_APPLIANCE ]];then
+	BAIL_OUT "Could not find setup appliance"
+fi
+
+. $SETUP_APPLIANCE
+
+MAX_WAIT=300
+
+tmpcount=$MAX_WAIT
+
+# Service enabled and started
+for srv in \
+obsapisetup
+do
+  STATE=` systemctl is-enabled $srv\.service 2>/dev/null`
+  is "$STATE" "enabled" "Checking $srv enabled"
+  ACTIVE=`systemctl is-active $srv\.service`
+  while [[ $ACTIVE != 'active' ]];do
+    tmpcount=$(( $tmpcount - 1 ))
+    ACTIVE=`systemctl is-active $srv\.service`
+    if [[ $tmpcount -le 0 ]];then
+      ACTIVE='timeout'
+      break
+    fi
+    sleep 1
+  done
+  is "$ACTIVE" "active" "Checking $srv status"
+done


### PR DESCRIPTION
@shyukri Please comment.

The idea is to have test which can be run on manually/wizard installed systems separated from tests which purely will succeed on the appliance