### PR TITLE
[api][webui] Fix NoMethodError in project model

### DIFF
--- a/src/api/app/models/project.rb
+++ b/src/api/app/models/project.rb
@@ -199,7 +199,7 @@ class Project < ActiveRecord::Base
           begin
             request.change_state({:newstate => 'revoked', :comment => "The source project '#{self.name}' has been removed"})
           rescue PostRequestNoPermission
-            logger.debug "#{User.current.login} tried to revoke request #{self.number} but had no permissions"
+            logger.debug "#{User.current.login} tried to revoke request #{request.number} but had no permissions"
           end
           break
         end
@@ -207,7 +207,7 @@ class Project < ActiveRecord::Base
           begin
             request.change_state({:newstate => 'declined', :comment => "The target project '#{self.name}' has been removed"})
           rescue PostRequestNoPermission
-            logger.debug "#{User.current.login} tried to decline request #{self.number} but had no permissions"
+            logger.debug "#{User.current.login} tried to decline request #{request.number} but had no permissions"
           end
           break
         end


### PR DESCRIPTION
With a recent change (8167d4a5) we started to user number as external
identifier for requests. The debug logging code was wrongly using
self.id instead of request.id as identifier of the failing request. With
the number change this started to fail.
This commit fixes it.

https://errbit-opensuse.herokuapp.com/apps/5620ca2bdc71fa00b1000000/problems/5710e2667eacee000c000004
https://errbit-opensuse.herokuapp.com/apps/5620ca2bdc71fa00b1000000/problems/57125e5a92ad29000c000000