### PR TITLE
Update dod view

### DIFF
--- a/src/api/app/assets/javascripts/webui/application/repository_tab.js
+++ b/src/api/app/assets/javascripts/webui/application/repository_tab.js
@@ -1,7 +1,8 @@
 $(document).on(
   'click',
   'a[data-repository-edit]',
-  function() {
+  function(e) {
+    e.preventDefault();
     $(this).
       parent('.edit-repository-field').
       hide().

--- a/src/api/app/assets/javascripts/webui/application/repository_tab.js
+++ b/src/api/app/assets/javascripts/webui/application/repository_tab.js
@@ -8,4 +8,28 @@ $(document).on(
       hide().
       next('.edit-repository-container').
       show();
-});
+  }
+);
+
+$(document).on(
+  'click',
+  'a[data-dod-repository-edit]',
+  function(e) {
+    e.preventDefault();
+    $(this).
+      parent('.edit-dod-repository-link-container').
+      hide().
+      next('.edit-dod-repository-form').
+      show();
+  }
+);
+
+$(document).on(
+  'click',
+  'a#add-dod-repository-link',
+  function(e) {
+    e.preventDefault();
+    $(this).hide();
+    $('.add-dod-repository-form').slideDown();
+  }
+);

--- a/src/api/app/controllers/webui/download_on_demand_controller.rb
+++ b/src/api/app/controllers/webui/download_on_demand_controller.rb
@@ -5,16 +5,23 @@ class Webui::DownloadOnDemandController < Webui::WebuiController
     @download_on_demand = DownloadRepository.new(permitted_params)
     authorize @download_on_demand
 
+    # Workaround: We need this association to pass the DownloadRepository validation.
+    #             If something in the transaction goes wrong, we have to destroy the object again.
+    repository_arch = nil
+    unless @download_on_demand.repository.architectures.pluck(:name).include?(permitted_params[:arch])
+      repository_arch = RepositoryArchitecture.create(
+        repository:   @download_on_demand.repository,
+        architecture: Architecture.find_by_name(permitted_params[:arch])
+      )
+    end
+
     begin
       ActiveRecord::Base.transaction do
-        RepositoryArchitecture.first_or_create!(
-          repository:   @download_on_demand.repository,
-          architecture: Architecture.find_by_name(permitted_params[:arch])
-        )
         @download_on_demand.save!
         @project.store
       end
     rescue ActiveRecord::RecordInvalid, ActiveXML::Transport::Error => exception
+      repository_arch.destroy if repository_arch
       redirect_to :back, error: "Download on Demand can't be created: #{exception.message}"
       return
     end

--- a/src/api/app/controllers/webui/download_on_demand_controller.rb
+++ b/src/api/app/controllers/webui/download_on_demand_controller.rb
@@ -64,6 +64,7 @@ class Webui::DownloadOnDemandController < Webui::WebuiController
       end
     rescue ActiveRecord::RecordInvalid, ActiveXML::Transport::Error => exception
       redirect_to :back, error: "Download on Demand can't be removed: #{exception.message}"
+      return
     end
 
     redirect_to project_repositories_path(@project), notice: "Successfully removed Download on Demand"

--- a/src/api/app/controllers/webui/download_on_demand_controller.rb
+++ b/src/api/app/controllers/webui/download_on_demand_controller.rb
@@ -51,6 +51,11 @@ class Webui::DownloadOnDemandController < Webui::WebuiController
     @download_on_demand = DownloadRepository.find(params[:id])
     authorize @download_on_demand
 
+    if @download_on_demand.repository.download_repositories.count <= 1
+      redirect_to :back, error: "Download on Demand can't be removed: DoD Repositories must have at least one repository."
+      return
+    end
+
     begin
       ActiveRecord::Base.transaction do
         # FIXME: should remove repo arch?

--- a/src/api/app/models/repository.rb
+++ b/src/api/app/models/repository.rb
@@ -206,4 +206,8 @@ class Repository < ActiveRecord::Base
       xml.elements('url').last.to_s
     end
   end
+
+  def is_dod_repository?
+    self.download_repositories.any?
+  end
 end

--- a/src/api/app/views/layouts/webui/_flash.html.erb
+++ b/src/api/app/views/layouts/webui/_flash.html.erb
@@ -1,7 +1,5 @@
-
-<% unless flash.blank? %>
-
-  <div id="flash-messages" class="container_16" >
+<div id="flash-messages" class="container_16" >
+  <% unless flash.blank? %>
     <div class="ui-widget grid_16 alpha omega">
 
       <% [:success, :error, :alert, :notice].each do |flash_type|
@@ -37,5 +35,5 @@
       <% end %>
 
     </div>
-  </div>
-<% end %>
+  <% end %>
+</div>

--- a/src/api/app/views/layouts/webui/webui.html.erb
+++ b/src/api/app/views/layouts/webui/webui.html.erb
@@ -59,6 +59,7 @@
       <%= render :partial => "layouts/webui/personal_navigation"  %>
     </div>
 
+
     <%= render :partial => "layouts/webui/flash", :object => flash  %>
 
     <!-- this is needed for the delete confirm dialogues -->

--- a/src/api/app/views/webui/download_on_demand/_form.html.erb
+++ b/src/api/app/views/webui/download_on_demand/_form.html.erb
@@ -1,7 +1,7 @@
 <%= form_for(download_on_demand) do |form| %>
   <div style="margin-bottom: 1.2em; margin-left: 2em" >
     <%= form.label :arch, 'Architecture', style: "display:inline-block;width:100px;" %>
-    <%= form.select :arch, options_for_select(repository.architectures, download_on_demand.try(:arch)) %>
+    <%= form.select :arch, options_for_select(Architecture.available, download_on_demand.try(:arch)) %>
     <br/><br/>
     <%= form.label :repotype, 'Type', style: "display:inline-block;width:100px;" %>
     <%= form.select :repotype, options_for_select(DownloadRepository::REPOTYPES, download_on_demand.try(:repotype)) %>

--- a/src/api/app/views/webui/download_on_demand/_index.html.erb
+++ b/src/api/app/views/webui/download_on_demand/_index.html.erb
@@ -9,7 +9,8 @@
       <%= render partial: 'webui/download_on_demand/add', locals: { project: project, repository: repository, download_on_demand: new_download_on_demand } %>
     </div>
     <% content_for :ready_function do %>
-        $("#<%= "add_dod_repository_link_#{repository_id}" %>").click(function() {
+        $("#<%= "add_dod_repository_link_#{repository_id}" %>").click(function(e) {
+          e.preventDefault();
           $("#<%= "add_dod_repository_form_#{repository_id}" %>").show();
           $("#<%= "add_dod_repository_link_container_#{repository_id}" %>").hide();
         });
@@ -32,7 +33,8 @@
           <%= render partial: 'webui/download_on_demand/edit', locals: { project: project, repository: repository, download_on_demand: dod_element } %>
         </div>
         <% content_for :ready_function do %>
-            $("#<%= "edit_dod_repository_link_#{dod_element}" %>").click(function() {
+            $("#<%= "edit_dod_repository_link_#{dod_element}" %>").click(function(e) {
+              e.preventDefault();
               $("#<%= "edit_dod_repository_form_#{dod_element}" %>").show();
               $("#<%= "edit_dod_repository_link_container_#{dod_element}" %>").hide();
             });

--- a/src/api/app/views/webui/download_on_demand/_index.html.erb
+++ b/src/api/app/views/webui/download_on_demand/_index.html.erb
@@ -1,12 +1,14 @@
-<div style="margin-top: 1em"><%= repository.download_repositories.empty? ? "No d" : "D" %>ownload on demand repositories
-  <% if User.current.is_admin? && repository.download_repositories.count != repository.architectures.count%>
+<% repository_id = valid_xml_id(repository.name) %>
+<div style="margin-top: 10px">
+  <b>Download on demand sources</b>
+  <% if User.current.is_admin? %>
     &nbsp;
     <span id="<%= "add_dod_repository_link_container_#{repository_id}" %>">
       <%= sprite_tag('drive_add') %>
       <%= link_to('Add', '#', id: "add_dod_repository_link_#{repository_id}") %>
     </span>
     <div class="hidden" id="<%= "add_dod_repository_form_#{repository_id}" %>">
-      <%= render partial: 'webui/download_on_demand/add', locals: { project: project, repository: repository, download_on_demand: new_download_on_demand } %>
+      <%= render partial: 'webui/download_on_demand/add', locals: { project: project, repository: repository, download_on_demand: DownloadRepository.new(repository_id: repository.id) } %>
     </div>
     <% content_for :ready_function do %>
         $("#<%= "add_dod_repository_link_#{repository_id}" %>").click(function(e) {
@@ -22,23 +24,16 @@
       <b><%= dod_element.arch %></b>:&nbsp;<a href="<%= dod_element.url %>" target="_blank" title="Go to the repository"><%= dod_element.url %></a>&nbsp;(<%= dod_element.repotype %>)
       <% if User.current.is_admin? %>
         &nbsp;
-        <span id="<%= "edit_dod_repository_link_container_#{dod_element}" %>" class="edit_dod_repository_link_container">
+        <span class="edit-dod-repository-link-container">
           <%= sprite_tag('drive_edit') %>
-          <%= link_to('Edit', '#', id: "edit_dod_repository_link_#{dod_element}") %>
+          <%= link_to('Edit', '#', data: { "dod-repository-edit": true }) %>
           <%= sprite_tag('drive_delete', title: 'Delete repository') %>
           <%= link_to "Delete", download_repository_path(dod_element, project: project),
                       {data: {confirm: "Really remove Download on Demand for '#{repository.name} / #{dod_element.arch}'?"}, class: 'x', method: :delete} %>
         </span>
-        <div class="hidden" id="<%= "edit_dod_repository_form_#{dod_element}" %>">
+        <div class="hidden edit-dod-repository-form">
           <%= render partial: 'webui/download_on_demand/edit', locals: { project: project, repository: repository, download_on_demand: dod_element } %>
         </div>
-        <% content_for :ready_function do %>
-            $("#<%= "edit_dod_repository_link_#{dod_element}" %>").click(function(e) {
-              e.preventDefault();
-              $("#<%= "edit_dod_repository_form_#{dod_element}" %>").show();
-              $("#<%= "edit_dod_repository_link_container_#{dod_element}" %>").hide();
-            });
-        <% end -%>
       <% end -%>
     </li>
   <% end -%>

--- a/src/api/app/views/webui/project/_dod_repository_form.haml
+++ b/src/api/app/views/webui/project/_dod_repository_form.haml
@@ -1,0 +1,44 @@
+.box{ style: "margin-left: 20px;" }
+  %h3.box-header{ style: "padding-left: 6px;" }
+    = "Add DoD repository"
+
+  = form_tag({ :action => :create_dod_repository, :project => @project }, method: "post", remote: true) do
+    %div
+      %p
+        = label_tag(:name, "Repository name")
+        = text_field_tag(:name)
+
+    %div
+      %h4
+        = "Download on Demand Source"
+      - # Note: Mostly C&P from app/views/webui/download_on_demand/_form.html.erb
+      %div{ style: "margin-bottom: 1.2em; margin-left: 2em" }
+        = label_tag :arch, "Architecture", style: "display:inline-block;width:100px;"
+        = select_tag :arch, options_for_select(Architecture.available, "")
+        %br
+        %br
+        = label_tag :repotype, 'Type', style: "display:inline-block;width:100px;"
+        = select_tag :repotype, options_for_select(DownloadRepository::REPOTYPES, "")
+        %br
+        %br
+        = label_tag :url, 'Url', style: "display:inline-block;width:100px;"
+        = text_field_tag :url
+        %br
+        %br
+        = label_tag :archfilter, 'Arch. Filter' , style: "display:inline-block;width:100px;"
+        = text_field_tag :archfilter
+        %br
+        %br
+        = label_tag :masterurl, 'Master Url', style: "display:inline-block;width:100px;"
+        = text_field_tag :masterurl
+        %br
+        %br
+        = label_tag :mastersslfingerprint, 'SSL Fingerprint', style: "display:inline-block;width:100px;"
+        = text_field_tag :mastersslfingerprint
+        %br
+        %br
+        = label_tag :pubkey, 'Public Key', style: "display:inline-block;width:100px;"
+        = text_area_tag :pubkey, nil, style: "width: 400px;"
+
+        %p
+          = submit_tag "Save"

--- a/src/api/app/views/webui/project/_repository_entry.haml
+++ b/src/api/app/views/webui/project/_repository_entry.haml
@@ -14,12 +14,14 @@
           = "#{path.link.project}/#{path.link.name}"
 
     %div{ style: "margin-top: 1em" }
-      - if User.current.can_modify_project?(@project)
+      - # No edit for DoD repositories
+      - if User.current.can_modify_project?(@project) && !repository.is_dod_repository?
         %span.edit-repository-field
           = sprite_tag('drive_edit')
           = link_to('Edit repository', '#', data: { "repository-edit": true })
         %div.hidden.edit-repository-container
           = render partial: 'edit_repository', locals: { project: @project, repository: repository }
+      - if User.current.can_modify_project?(@project)
         = sprite_tag('drive_delete', title: 'Delete repository')
         = link_to('Delete repository', { action: "remove_target", project: @project, target: repository.name }, |
                       { data: { confirm: "Really remove repository '#{repository.name}'?" }, class: 'x', method: :post })
@@ -30,5 +32,5 @@
       - if repository.release_targets.where(trigger: "manual").exists?
         = sprite_tag('flag_green')
         = link_to('Release repository', { :action => :release_repository_dialog, :project => @project, :repository => repository.name }, :remote => true)
-    = render :partial => 'webui/download_on_demand/index', :locals => {project: @project, repository: repository, repository_id: valid_xml_id(repository.name), new_download_on_demand: DownloadRepository.new(repository_id: repository.id)}
-
+    - if repository.is_dod_repository?
+      = render :partial => 'webui/download_on_demand/index', :locals => { project: @project, repository: repository }

--- a/src/api/app/views/webui/project/create_dod_repository.js.erb
+++ b/src/api/app/views/webui/project/create_dod_repository.js.erb
@@ -1,0 +1,12 @@
+$('.add-dod-repository-form').hide();
+$('#add-dod-repository-link').show();
+<% if @error %>
+  console.log("<%= @error %>");
+  $('#flash-messages').
+    replaceWith("<%= escape_javascript(render(partial: "layouts/webui/flash", locals: { flash: { error: @error } })) %>");
+  $("html, body").scrollTop(0);
+<% else %>
+  $('#flash-messages').html("");
+  $('#repository-list').
+    append("<%= escape_javascript(render(partial: 'repository_entry', locals: { project: @project, repository: @new_repository })) %>");
+<% end %>

--- a/src/api/app/views/webui/project/repositories.haml
+++ b/src/api/app/views/webui/project/repositories.haml
@@ -9,12 +9,17 @@
 %p
   You can configure individual flags for this project here.
 
-- @project.repositories.each do |repository|
-  = render partial: "repository_entry", locals: { repository: repository }
+#repository-list
+  - @project.repositories.each do |repository|
+    = render partial: "repository_entry", locals: { repository: repository }
 
+- if User.current.is_admin?
+  %div.hidden.add-dod-repository-form
+    = render partial: "dod_repository_form", locals: { project: @project, download_on_demand: DownloadRepository.new }
+  %p
+    = link_to(sprite_tag("drive_add", title: "Add DoD repository") + " Add DoD repository", "#", id: "add-dod-repository-link")
 - if User.current.can_modify_project?(@project)
   %p
-    = link_to(sprite_tag("drive_add", title: "Add repository"), action: "add_repository_from_default_list", project: @project)
-    = link_to("Add repositories", action: "add_repository_from_default_list", project: @project)
+    = link_to(sprite_tag("drive_add", title: "Add repository") + " Add repositories", action: "add_repository_from_default_list", project: @project)
 
 = render partial: "shared/repositories", locals: { obj: @project }

--- a/src/api/config/routes.rb
+++ b/src/api/config/routes.rb
@@ -244,6 +244,9 @@ OBSApi::Application.routes.draw do
       get 'project/unlock_dialog' => :unlock_dialog
       post 'project/unlock' => :unlock
       post 'project/comments/:project' => :save_comment, constraints: cons, as: 'save_project_comment'
+
+      # dod resource ...
+      post 'project/create_dod_repository' => :create_dod_repository
     end
 
     controller 'webui/request' do

--- a/src/api/spec/controllers/webui/download_on_demand_controller_spec.rb
+++ b/src/api/spec/controllers/webui/download_on_demand_controller_spec.rb
@@ -69,7 +69,10 @@ RSpec.describe Webui::DownloadOnDemandController do
       end
 
       it { is_expected.to redirect_to(root_path) }
-      it { expect(flash[:error]).to eq("Download on Demand can't be created: Validation failed: Architecture can't be blank") }
+      it {
+        expect(flash[:error]).to eq("Download on Demand can't be created: Validation failed: " +
+          "Arch can't be blank, Architecture has to be available via repository association.")
+      }
       it { expect(assigns(:download_on_demand)).to be_kind_of(DownloadRepository) }
       it { expect(DownloadRepository.where(dod_parameters[:download_repository])).not_to exist }
     end

--- a/src/api/spec/controllers/webui/download_on_demand_controller_spec.rb
+++ b/src/api/spec/controllers/webui/download_on_demand_controller_spec.rb
@@ -79,11 +79,7 @@ RSpec.describe Webui::DownloadOnDemandController do
   end
 
   describe 'DELETE destroy' do
-    let(:dod_repository) { create(:download_repository) }
-
-    before do
-      repository.download_repositories << dod_repository
-    end
+    let!(:dod_repository) { create(:download_repository, repository: repository) }
 
     context "for non-admin users" do
       before do
@@ -97,6 +93,8 @@ RSpec.describe Webui::DownloadOnDemandController do
     end
 
     context "valid requests" do
+      let!(:dod_repository_2) { create(:download_repository, arch: "i586", repository: repository) }
+
       before do
         login(admin_user)
         delete :destroy, id: dod_repository.id, project: project.name

--- a/src/api/spec/controllers/webui/download_on_demand_controller_spec.rb
+++ b/src/api/spec/controllers/webui/download_on_demand_controller_spec.rb
@@ -69,10 +69,7 @@ RSpec.describe Webui::DownloadOnDemandController do
       end
 
       it { is_expected.to redirect_to(root_path) }
-      it {
-        expect(flash[:error]).to eq("Download on Demand can't be created: Validation failed: " +
-          "Arch can't be blank, Architecture has to be available via repository association.")
-      }
+      it { expect(flash[:error]).to eq("Download on Demand can't be created: Validation failed: Architecture can't be blank") }
       it { expect(assigns(:download_on_demand)).to be_kind_of(DownloadRepository) }
       it { expect(DownloadRepository.where(dod_parameters[:download_repository])).not_to exist }
     end
@@ -106,7 +103,14 @@ RSpec.describe Webui::DownloadOnDemandController do
     end
 
     context "invalid requests" do
-      skip("Please add some tests:-)")
+      before do
+        login(admin_user)
+        delete :destroy, id: dod_repository.id, project: project.name
+      end
+
+      it { is_expected.to redirect_to(root_path) }
+      it { expect(flash[:error]).to eq "Download on Demand can't be removed: DoD Repositories must have at least one repository." }
+      it { expect(DownloadRepository.where(id: dod_repository.id)).to exist }
     end
   end
 

--- a/src/api/spec/factories/download_repository_factory.rb
+++ b/src/api/spec/factories/download_repository_factory.rb
@@ -3,12 +3,12 @@ FactoryGirl.define do
     arch "x86_64"
     url "http://suse.com"
     repotype "rpmmd"
-    repository
+    repository { create(:repository, architectures: [arch])}
 
     before(:create) do |download_repository|
-      RepositoryArchitecture.first_or_create!(
+      RepositoryArchitecture.find_or_create_by!(
         repository:   download_repository.repository,
-        architecture: Architecture.find_by_name("x86_64")
+        architecture: Architecture.find_by_name(download_repository.arch)
       )
     end
   end

--- a/src/api/spec/factories/repository.rb
+++ b/src/api/spec/factories/repository.rb
@@ -2,5 +2,18 @@ FactoryGirl.define do
   factory :repository do
     project
     name { Faker::Internet.domain_word }
+
+    transient do
+      architectures []
+    end
+
+    after(:create) do |repository, evaluator|
+      evaluator.architectures.each do |arch|
+        create(:repository_architecture, {
+          repository:   repository,
+          architecture: Architecture.find_or_create_by!(name: arch)
+        })
+      end
+    end
   end
 end

--- a/src/api/spec/features/webui/projects_spec.rb
+++ b/src/api/spec/features/webui/projects_spec.rb
@@ -1,6 +1,7 @@
 require "browser_helper"
 
 RSpec.feature "Projects", :type => :feature, :js => true do
+  let!(:admin_user) { create(:admin_user) }
   let!(:user) { create(:confirmed_user, login: "Jane") }
   let(:project) { Project.find_by_name(user.home_project_name) }
 
@@ -87,6 +88,111 @@ RSpec.feature "Projects", :type => :feature, :js => true do
 
       visit project_show_path(project: locked_project.name)
       expect(page).to have_text("is locked")
+    end
+  end
+
+  describe "DoD repositories" do
+    let(:project_with_dod_repo) { create(:project) }
+    let(:repository) { create(:repository, project: project_with_dod_repo) }
+    let!(:download_repository) { create(:download_repository, repository: repository) }
+
+    before do
+      login admin_user
+    end
+
+    scenario "adding DoD repositories" do
+      visit(project_repositories_path(project: admin_user.home_project_name))
+      click_link("Add DoD repository")
+      fill_in("Repository name", with: "My DoD repository")
+      select("i586", from: "Architecture")
+      select("rpmmd", from: "Type")
+      fill_in("Url", with: "http://somerandomurl.es")
+      fill_in("Arch. Filter", with: "i586, noarch")
+      fill_in("Master Url", with: "http://somerandomurl2.es")
+      fill_in("SSL Fingerprint", with: "293470239742093")
+      fill_in("Public Key", with: "JLKSDJFSJ83U4902RKLJSDFLJF2J9IJ23OJFKJFSDF")
+      click_button("Save")
+
+      within ".repository-container" do
+        expect(page).to have_text("My DoD repository")
+        expect(page).to have_link("Delete repository")
+        expect(page).to have_text("Download on demand sources")
+        expect(page).to have_css("#add_dod_repository_link_container_My_DoD_repository", text: "Add")
+        expect(page).to have_link("Edit")
+        expect(page).to have_link("Delete")
+        expect(page).to have_link("http://somerandomurl.es")
+        expect(page).to have_text("rpmmd")
+      end
+    end
+
+    scenario "removing DoD repositories" do
+      visit(project_repositories_path(project: project_with_dod_repo))
+      within ".repository-container" do
+        click_link("Delete repository")
+      end
+      expect(project_with_dod_repo.repositories).to be_empty
+    end
+
+    # Note DownloadRepositories belong to Repositories (= DoD repositories)
+    scenario "editing download repositories" do
+      visit(project_repositories_path(project: project_with_dod_repo))
+      within ".repository-container" do
+        click_link("Edit")
+      end
+      select("i586", from: "Architecture")
+      select("deb", from: "Type")
+      fill_in("Url", with: "http://some_random_url_2.es")
+      fill_in("Arch. Filter", with: "i586, noarch")
+      fill_in("Master Url", with: "http://some_other_url.es")
+      fill_in("SSL Fingerprint", with: "test")
+      fill_in("Public Key", with: "some_key")
+      click_button("Update Download on Demand")
+
+      download_repository.reload
+      expect(download_repository.arch).to eq "i586"
+      expect(download_repository.repotype).to eq "deb"
+      expect(download_repository.url).to eq "http://some_random_url_2.es"
+      expect(download_repository.archfilter).to eq "i586, noarch"
+      expect(download_repository.masterurl).to eq "http://some_other_url.es"
+      expect(download_repository.mastersslfingerprint).to eq "test"
+      expect(download_repository.pubkey).to eq "some_key"
+    end
+
+    scenario "removing download repositories" do
+      create(:repository_architecture, repository: repository, architecture: Architecture.find_by_name("i586"))
+      download_repository_2 = create(:download_repository, repository: repository, arch: "i586")
+
+      visit(project_repositories_path(project: project_with_dod_repo))
+      # Delete link
+      find(:xpath, "//a[@href='/download_repositories/#{download_repository.id}?project=#{project_with_dod_repo}'][text()='Delete']").click
+      expect(page).to have_text "Successfully removed Download on Demand"
+      expect(repository.download_repositories.count).to eq 1
+
+      find(:xpath, "//a[@href='/download_repositories/#{download_repository_2.id}?project=#{project_with_dod_repo}'][text()='Delete']").click
+      expect(page).to have_text "Download on Demand can't be removed: DoD Repositories must have at least one repository."
+      expect(repository.download_repositories.count).to eq 1
+    end
+
+    scenario "adding DoD repositories via meta editor" do
+      fixture_file = File.read(Rails.root + "test/fixtures/backend/download_on_demand/project_with_dod.xml").
+        gsub("user5", admin_user.login)
+
+      visit(project_meta_path(project: admin_user.home_project_name))
+      page.evaluate_script("editors[0].setValue(\"#{fixture_file.gsub("\n", '\n')}\");")
+      click_button("Save")
+      expect(page).to have_css("#flash-messages", text: "Config successfully saved!")
+
+      visit(project_repositories_path(project: admin_user.home_project_name))
+      within ".repository-container" do
+        expect(page).to have_link("standard")
+        expect(page).to have_link("Delete repository")
+        expect(page).to have_text("Download on demand sources")
+        expect(page).to have_css("#add_dod_repository_link_container_standard", text: "Add")
+        expect(page).to have_link("Edit")
+        expect(page).to have_link("Delete")
+        expect(page).to have_link("http://mola.org2")
+        expect(page).to have_text("rpmmd")
+      end
     end
   end
 end

--- a/src/api/test/fixtures/backend/download_on_demand/project_with_several_dod.xml
+++ b/src/api/test/fixtures/backend/download_on_demand/project_with_several_dod.xml
@@ -1,0 +1,15 @@
+<project name='home:user5'>
+<title>User5 Home Project</title>
+<description/>
+<person userid='user5' role='maintainer'/>
+<repository name='standard'>
+  <download arch='i586' url='http://mola.org2' repotype='rpmmd'>
+    <archfilter>i586, noarch</archfilter>
+    <master url='http://opensuse.org' sslfingerprint='asdfasd'/>
+    <pubkey>3jnlkdsjfoisdjf0932juro2ikjfdslñkfj</pubkey>
+  </download>
+  <download arch='x86_64' url='http://suse.de' repotype='deb' />
+  <arch>i586</arch>
+  <arch>x86_64</arch>
+</repository>
+</project>

--- a/src/api/test/functional/webui/download_on_demand_controller_test.rb
+++ b/src/api/test/functional/webui/download_on_demand_controller_test.rb
@@ -47,7 +47,7 @@ class Webui::DownloadOnDemandControllerTest < Webui::IntegrationTest
     page.wont_have_text 'rpmmd'
   end
 
-  def test_adding_download_on_demand
+  def test_adding_download_on_demand # spec/features/webui/projects_spec.rb
     use_js
 
     # Login as admin
@@ -86,7 +86,7 @@ class Webui::DownloadOnDemandControllerTest < Webui::IntegrationTest
     find(:id, 'flash-messages').must_have_text("Download on Demand can't be created: Validation failed: Url can't be blank")
   end
 
-  def test_editing_download_on_demand
+  def test_editing_download_on_demand # spec/features/webui/projects_spec.rb
     use_js
 
     # Login as admin
@@ -130,7 +130,7 @@ class Webui::DownloadOnDemandControllerTest < Webui::IntegrationTest
     page.must_have_link 'http://somerandomurl_2.es'
   end
 
-  def test_destroying_download_on_demand
+  def test_destroying_download_on_demand # spec/features/webui/projects_spec.rb
     use_js
 
     # Login as admin


### PR DESCRIPTION
* UI now distinguishes between repositories and DoD repositories.
* Architecture associations get created when new download element get's added
* DB writes and backend syncs are done via transactions
* Disallow removing of the last DownloadRepository of a DoD Repository
* Implement adding multiple 'download' elements (= DownloadRepository) to a repository via the webui