### PR TITLE
[backend] Add support for cleaning up worker chroot

### DIFF
--- a/dist/obsworker
+++ b/dist/obsworker
@@ -80,6 +80,9 @@ if [ -n "$OBS_WORKER_NICE_LEVEL" ]; then
 else
     OBS_NICE=18
 fi
+if [ -n "$OBS_WORKER_CLEANUP_CHROOT" ]; then
+    OBS_CLEANUP_CHROOT="--cleanup-chroot"
+fi
 
 REPO_PARAM=
 for i in $OBS_REPO_SERVERS; do
@@ -347,7 +350,7 @@ case "$1" in
 	    echo "screen -t $WORKERID nice -n $OBS_NICE ./bs_worker --hardstatus $vmopt $port --root $R" \
                 "--statedir $workerdir/$I --id $WORKERID $REPO_PARAM $HUGETLBFS $HOSTLABELS" \
                 "$HOSTOWNER $OBS_JOBS $OBS_THREADS $OBS_TEST $OBS_WORKER_OPT $TMPFS $DEVICE $SWAP $MEMORY" \
-                "$ARCH $EMULATOR" \
+                "$OBS_CLEANUP_CHROOT $ARCH $EMULATOR" \
                 >> $screenrc
 	    mkdir -p $workerdir/$I
         done

--- a/dist/sysconfig.obs-server
+++ b/dist/sysconfig.obs-server
@@ -361,3 +361,11 @@ OBS_ROOT_SSHD_KEY_URL=""
 #
 OBS_WORKER_SCRIPT_URL=""
 
+## Path:        Applications/OBS
+## Description: If chroot/lxc is used for build, empty it after build is finished
+## Type:        ("yes" | "")
+## Default:     ""
+## Config:      OBS
+#
+#
+OBS_WORKER_CLEANUP_CHROOT=""

--- a/src/backend/bs_worker
+++ b/src/backend/bs_worker
@@ -94,6 +94,7 @@ my $jobs;
 my $threads;
 my $cachedir;
 my $cachesize;
+my $cleanup_chroot;
 
 # current XEN has no xenstore anymore
 my $xenstore_maxsize = 20 * 1000000;
@@ -177,6 +178,14 @@ sub cleanup_job {
       qsystem("umount", "-l", $buildroot) && die("umount tmpfs failed: $!\n");
     }
   }
+
+  # if this is the chroot case, get rid of it after the build
+  if ((!$vm || $vm =~ /lxc/) && $cleanup_chroot) {
+      printf "Removing buildroot $buildroot";
+      rm_rf($buildroot);
+      mkdir_p($buildroot);
+  }
+
 }
 
 sub kill_job {
@@ -541,6 +550,11 @@ while (@ARGV) {
   if ($ARGV[0] eq '--hardstatus') {
     shift @ARGV;
     $hardstatus = 1;
+    next;
+  }
+  if ($ARGV[0] eq '--cleanup-chroot') {
+    shift @ARGV;
+    $cleanup_chroot = 1;
     next;
   }
   last;


### PR DESCRIPTION
Add a configuration option to cleanup chroot/lxc buildroots from workers after build has finished.