### PR TITLE
[dist] obsstoragesetup is now recommended service

### DIFF
--- a/dist/setup-appliance.sh
+++ b/dist/setup-appliance.sh
@@ -405,7 +405,7 @@ function check_required_backend_services {
 function check_recommended_backend_services {
 
   [[ $SETUP_ONLY == 1 ]] && return 
-  RECOMMENDED_SERVICES="obsdodup obsdeltastore obssigner"
+  RECOMMENDED_SERVICES="obsstoragesetup obsdodup obsdeltastore obssigner"
 
   for srv in $RECOMMENDED_SERVICES;do
     STATE=$(chkconfig $srv|awk '{print $2}')

--- a/dist/t/0070-check_recommended_services.ts
+++ b/dist/t/0070-check_recommended_services.ts
@@ -13,6 +13,7 @@ tmpcount=$MAX_WAIT
 # Service enabled and started
 for srv in \
 obsdodup \
+obsstoragesetup \
 obssigner \
 obsdeltastore
 do


### PR DESCRIPTION
This is to avoid problems with obssigner as obsstoragesetup will
configure $sign in BSConfig and generate gpg keys for proper signing