### PR TITLE
Partionioning fixes

### DIFF
--- a/src/backend/bs_srcserver
+++ b/src/backend/bs_srcserver
@@ -8428,6 +8428,8 @@ if ($BSConfig::workersrcserver) {
   $conf->{'port2'} = $wport if $wport != $port;
 }
 
+# always create the event directory if it not exist
+BSUtil::mkdir_p_chown("$eventdir", $BSConfig::bsuser, $BSConfig::bsgroup) unless -d "$eventdir";
 # set a repoid for identification of this data repository
 BSUtil::mkdir_p_chown("$projectsdir", $BSConfig::bsuser, $BSConfig::bsgroup) unless -d "$projectsdir";
 if (! -e "$projectsdir/_repoid") {

--- a/src/backend/bs_srcserver
+++ b/src/backend/bs_srcserver
@@ -3648,10 +3648,15 @@ sub putproject {
 
   my %except = map {$_ => 1} qw{title description person group url attributes};
   if (!identical($oldproj, $proj, \%except)) {
-    if ($cgi->{'lowprio'}) {
-      notify_repservers('lowprioproject', $projid);
+    my $type = ($cgi->{'lowprio'}) ? 'lowprioproject' : 'project';
+    if ($proj->{'remoteurl'}) {
+      # inform all repserves about a remote project
+      # need to add the event here since notify_all_repservers() doesn't do it
+      my $ev = {'type' => $type, 'project' => $projid};
+      addevent($ev);
+      notify_all_repservers($type, $projid);
     } else {
-      notify_repservers('project', $projid);
+      notify_repservers($type, $projid);
     }
   }
 


### PR DESCRIPTION
While setting up some test environment with partioning and separated hosts for srcserver, api and multiple partitions of repserver and scheduler we found two bugs in current 2.6.
**1. Missing /srv/obs/events**
On the srcserver machine the /srv/obs/events directory was never created, which caused following error while creating the first project:
[13b94558-f3ab-45dc-87d0-5d5bc24821f3] [4164:52.34] Started PUT "/source/project1/_meta" for 192.168.200.100 at 2016-04-26 11:06:37 +0200
[13b94558-f3ab-45dc-87d0-5d5bc24821f3] [4164:52.34] Processing by SourceController#update_project_meta as XML
[13b94558-f3ab-45dc-87d0-5d5bc24821f3] [4164:52.34]   Parameters: {"project"=>"project1"}
[13b94558-f3ab-45dc-87d0-5d5bc24821f3] [4164:52.34] Can't verify CSRF token authenticity
[13b94558-f3ab-45dc-87d0-5d5bc24821f3] [4164:52.53]   Rendered models/_project.xml.builder (5.7ms)
[13b94558-f3ab-45dc-87d0-5d5bc24821f3] [4164:52.69]   Rendered text template (0.0ms)
[13b94558-f3ab-45dc-87d0-5d5bc24821f3] [4164:52.69] Completed 400 Bad Request in 346ms (Views: 0.6ms | ActiveRecord: 290.9ms | Backend: 3.9ms | XML: 0.1ms)
[a0628cee-b71d-44cd-b36e-585b0fc60d53] [4156:382.73] Completed 500 Internal Server Error in 360ms (ActiveRecord: 0.7ms | Backend: 0.0ms | XML: 0.2ms)
[a0628cee-b71d-44cd-b36e-585b0fc60d53] [4156:382.73] 
ActiveXML::Transport::Error (<status code="400" origin="backend">
  <summary>/srv/obs/events/lastnotifications: No such file or directory</summary>
</status>):
  lib/activexml/transport.rb:459:in `handle_response'
  lib/activexml/transport.rb:394:in `http_do'
  lib/activexml/transport.rb:198:in `save'
  lib/activexml/node.rb:510:in `save'
...

Which was caused by the missing /srv/obs/events/ directory on the srcserver. fixed for 2.6  by the first patch in this pull request.

**2. Bad config error on partition scheduler**
If you have setup multiple partitions and interconnect to a remote OBS instance, the first add of a remote repository only works on the main partition (which match the remote project). If you add
the first repository on e.g. a separate home: partition, the scheduler for this partition does not have the info about the remote project and tries to solve it locally, which failed with 'bad config' for the home project. Only a cold restart of this scheduler make the project working again. So it is not enough to only send the remote project info to the main scheduler, also the partition schedulers need this info.
Here is code in the srcserver which inform all repo servers about the remote project, but this only works if the first use of a remote repository happens on the main partition.
And it does not recover the scheduler, on other partions, if they already in the bad config state.
The second patch fix this issue for 2.6.