### PR TITLE
Fix issue#1699 - plotters on /monitor page exchanged

### DIFF
--- a/src/api/app/assets/javascripts/webui/application.js
+++ b/src/api/app/assets/javascripts/webui/application.js
@@ -19,6 +19,7 @@
 //= require jquery.flot
 //= require jquery.flot.resize
 //= require jquery.flot.time
+//= require jquery.flot.stack.js
 //= require jquery.expander.min.js
 //= require jquery_ujs
 //= require dataTables/jquery.dataTables

--- a/src/api/app/views/webui/monitor/_events.html.erb
+++ b/src/api/app/views/webui/monitor/_events.html.erb
@@ -56,9 +56,9 @@
       xaxis: { mode: 'time' },
       yaxis: { min: 0, max: data['events_max'], position: "left", labelWidth: 25 }
     });
-    
+
     $.plot($("#building"), [ { data: data['building'], label: "Currently building", color: 3},
-                             {  data: data['idle'], label: "Idle workers", color: 4 } ],
+                             { data: data['idle'], label: "Idle workers", color: 4 } ],
       {
             series: {
                 stack: true,


### PR DESCRIPTION
Updating the jquery flot version required to explicitly add jquery.flot.stack.js
to the application.js file.
This caused the active workers monitor graph not being stacked anymore.