### PR TITLE
[webui] Fix errbit error: Package::UnknownObjectError: home:TEggers/p…

### DIFF
--- a/src/api/app/controllers/webui/package_controller.rb
+++ b/src/api/app/controllers/webui/package_controller.rb
@@ -1079,7 +1079,7 @@ class Webui::PackageController < Webui::WebuiController
 
     unless @package
       flash[:error] = "Package \"#{params[:package]}\" not found in project \"#{params[:project]}\""
-      redirect_to controller: :project, action: :show, project: @project, nextstatus: 404
+      redirect_to project_show_path(project: @project, nextstatus: 404)
     end
   end
 

--- a/src/api/app/controllers/webui/patchinfo_controller.rb
+++ b/src/api/app/controllers/webui/patchinfo_controller.rb
@@ -311,7 +311,13 @@ class Webui::PatchinfoController < Webui::WebuiController
 
   def require_exists
     unless params[:package].blank?
-      @package = Package.get_by_project_and_name(params[:project], params[:package], use_source: false)
+      begin
+        @package = Package.get_by_project_and_name(params[:project], params[:package], use_source: false)
+      rescue Package::UnknownObjectError
+        flash[:error] = "Patchinfo '#{params[:package]}' not found in project '#{params[:project]}'"
+        redirect_to project_show_path(project: params[:project])
+        return
+      end
     end
 
     unless @package && @package.patchinfo


### PR DESCRIPTION
…atchinfo

With this patch we catch UnknownObjectErrors and show an error message in
the ui, instead of failing with a 500.

http://errbit-opensuse.herokuapp.com/apps/5620ca2bdc71fa00b1000000/problems/57220b6d66cb310006000000