### PR TITLE
[api] avoid crash on package removal

### DIFF
--- a/src/api/app/models/package.rb
+++ b/src/api/app/models/package.rb
@@ -735,6 +735,10 @@ class Package < ActiveRecord::Base
   end
 
   def delete_on_backend
+    # lock this package object to avoid that dependend objects get created in parallel
+    # for example a backend_package
+    reload(lock: true)
+
     # not really packages...
     # everything below _product:
     return true if name =~ /\A_product:\w[-+\w\.]*\z/
@@ -1036,6 +1040,9 @@ class Package < ActiveRecord::Base
   end
 
   def update_backendinfo
+    # avoid creation of backend_package while destroying this package object
+    reload(lock: true)
+
     bp = build_backend_package
 
     # determine the infos provided by srcsrv

--- a/src/api/test/unit/project_remove_test.rb
+++ b/src/api/test/unit/project_remove_test.rb
@@ -83,7 +83,7 @@ class ProjectRemoveTest < ActiveSupport::TestCase
     User.current = users(:Iggy)
     branch_package
     project = Project.find_by(name: "home:Iggy:branches:Apache")
-    other_package = project.packages.create(name: 'pack')
+    project.packages.create!(name: 'pack')
     create_request
 
     User.current = users(:fred)
@@ -95,7 +95,6 @@ class ProjectRemoveTest < ActiveSupport::TestCase
     assert_equal 0, HistoryElement::RequestRevoked.where(op_object_id: @request.id).count
 
     @package.project.destroy
-    other_package.destroy
   end
 
   def test_review_gets_obsoleted


### PR DESCRIPTION
The removal starts while no backend package got created, but failed due
to DB constraints on package removal.

A broken test case needed to be fixed as well