### PR TITLE
[backend] fixed test_unit to use backend dir in perl search path

### DIFF
--- a/src/backend/Makefile
+++ b/src/backend/Makefile
@@ -30,7 +30,7 @@ install_data_dirs: prepare_dirs
 
 test_unit: bs_config clean_cover
 	rm -rf t/tmp/*
-	PERL5OPT=-MDevel::Cover LANG=C prove -Ibuild -v t/*.t
+	PERL5OPT=-MDevel::Cover LANG=C prove -Ibuild -I. -v t/*.t
 
 cover: test_unit
 	cover -ignore_re '^((build|XML|t)/|/usr/bin/prove$$)' -outputdir /srv/www/htdocs


### PR DESCRIPTION
This is needed for the tests to use the same XML::Structured module like our backend code