### PR TITLE
Fix issue #1720 - image build view is broken

### DIFF
--- a/src/api/app/views/webui/package/_live_log_controls.html.erb
+++ b/src/api/app/views/webui/package/_live_log_controls.html.erb
@@ -8,10 +8,6 @@
   <% end %>
 </p>
 
-<% if @package.kind_of?(Package)%>
-  <%= render :partial => "tabs" %>
-<% end %>
-
 <% if @package.kind_of?(Package) && User.current.can_modify_package?(@package) %>
     <p>
       <span class="link_trigger_rebuild hidden">

--- a/src/api/app/views/webui/package/live_build_log.html.erb
+++ b/src/api/app/views/webui/package/live_build_log.html.erb
@@ -3,6 +3,10 @@
    package_bread_crumb 'Build Log' 
 -%>
 
+<% if @package.kind_of?(Package)%>
+  <%= render :partial => "tabs" %>
+<% end %>
+
 <%= content_for :ready_function do %>
   live_build_log_ready();
 <% end -%>


### PR DESCRIPTION
This is a partial revert of 1d98db6e50d1328c6abacf4 which broke the
project tabs on the live log view