### PR TITLE
[backend] Fix error on adding first project in a multi host setup

### DIFF
--- a/src/backend/bs_srcserver
+++ b/src/backend/bs_srcserver
@@ -8428,6 +8428,8 @@ if ($BSConfig::workersrcserver) {
   $conf->{'port2'} = $wport if $wport != $port;
 }
 
+# always create the event directory if it not exist
+BSUtil::mkdir_p_chown("$eventdir", $BSConfig::bsuser, $BSConfig::bsgroup) unless -d "$eventdir";
 # set a repoid for identification of this data repository
 BSUtil::mkdir_p_chown("$projectsdir", $BSConfig::bsuser, $BSConfig::bsgroup) unless -d "$projectsdir";
 if (! -e "$projectsdir/_repoid") {


### PR DESCRIPTION
Obsolete pull request #1756
If the srcserver run on it's own machine, adding the first project results
in an error page. Reason is that the /srv/obs/events directory was not created.

So this directory should be created on first start of the source server as well.