### PR TITLE
[backend] Fix addding an interconnect if using partioning

### DIFF
--- a/src/backend/bs_srcserver
+++ b/src/backend/bs_srcserver
@@ -3648,10 +3648,15 @@ sub putproject {
 
   my %except = map {$_ => 1} qw{title description person group url attributes};
   if (!identical($oldproj, $proj, \%except)) {
-    if ($cgi->{'lowprio'}) {
-      notify_repservers('lowprioproject', $projid);
+    my $type = ($cgi->{'lowprio'}) ? 'lowprioproject' : 'project';
+    if ($proj->{'remoteurl'}) {
+      # inform all repserves about a remote project
+      # need to add the event here since notify_all_repservers() doesn't do it
+      my $ev = {'type' => $type, 'project' => $projid};
+      addevent($ev);
+      notify_all_repservers($type, $projid);
     } else {
-      notify_repservers('project', $projid);
+      notify_repservers($type, $projid);
     }
   }
 


### PR DESCRIPTION
Obsolete pull request #1756
With using multiple repservers as partitions adding a interconnect may not
work properly, if the first use of the interconnect happens on a different
partion.
In this case the scheduler states an error 'bad config' and need a
cold start to resolve this situation.
The reason is that the %remoteprojs map on the local scheduler has no entry
for this project in addrepo().
So if a remote project was added all repservers need to be notified about the
remote project.