### PR TITLE
[dist] correctly print OBS Worker type for LXC Containers

### DIFF
--- a/dist/obsworker
+++ b/dist/obsworker
@@ -263,6 +263,7 @@ case "$1" in
 	elif [ "--zvm" == "$vmopt" ]; then echo "z/VM virtual machine"
 	elif [ "--pvm" == "$vmopt" ]; then echo "PowerVM LPAR"
 	elif [ "--emulator" == "$vmopt" ]; then echo "System emulated virtual machine"
+	elif [ "--lxc" == "$vmopt" ]; then echo "LXC container"
 	else  echo "chroot"
 	fi
 


### PR DESCRIPTION
To get the correct worker type message in `systemctl status obsworker`, add this elseif in the start script.