### PR TITLE
Improve copyproject API

### DIFF
--- a/src/api/app/models/project.rb
+++ b/src/api/app/models/project.rb
@@ -1142,7 +1142,7 @@ class Project < ActiveRecord::Base
     # copy entire project in the backend
     begin
       path = "/source/#{URI.escape(self.name)}"
-      path << Suse::Backend.build_query_from_hash(params, [:cmd, :user, :comment, :oproject, :withbinaries, :withhistory, :makeolder, :noservice])
+      path << Suse::Backend.build_query_from_hash(params, [:cmd, :user, :comment, :oproject, :withbinaries, :withhistory, :makeolder, :noservice, :synctimeout])
       Suse::Backend.post path, nil
     rescue ActiveXML::Transport::Error => e
       logger.debug "copy failed: #{e.summary}"

--- a/src/api/test/functional/source_controller_test.rb
+++ b/src/api/test/functional/source_controller_test.rb
@@ -2338,6 +2338,78 @@ class SourceControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
   end
 
+  def test_copy_project_withbinaries
+    login_king
+
+    # prerequisite: there should be 4 binaries in source project i586 arch
+    get '/build/home:Iggy/10.2/i586/TestPack'
+    assert_xml_tag :tag => 'binarylist', :children => { :count => 4 }
+
+    # prerequisite: no binaries in source project for x86_64 arch
+    get '/build/home:Iggy/10.2/x86_64/TestPack'
+    assert_xml_tag :tag => 'binarylist', :children => { :count => 0 }
+
+    run_scheduler('i586')
+    inject_build_job( 'home:Iggy', 'TestPack', '10.2', 'i586')
+    run_scheduler('i586')
+    wait_for_publisher
+
+    # copy project with binaries
+    post '/source/IggyHomeCopy?cmd=copy&oproject=home:Iggy&noservice=1&withbinaries=1&nodelay=1'
+    assert_response :success
+
+    # let scheduler process events...
+    run_scheduler('i586')
+    run_scheduler('x86_64')
+
+    # get copy project meta and verify copied repositories
+    get '/source/IggyHomeCopy/_meta'
+    assert_response :success
+
+    assert_xml_tag :parent => { :tag => 'project', :attributes => { :name => 'IggyHomeCopy' } },
+      :tag => 'repository', :attributes => { :name => '10.2' }
+
+    assert_xml_tag :parent => { :tag => 'repository', :attributes => { :name => '10.2' } },
+      :tag => 'path', :attributes => { :project => 'BaseDistro', :repository => 'BaseDistro_repo' }
+
+    assert_xml_tag :parent => { :tag => 'repository', :attributes => { :name => '10.2' } },
+      :tag => 'arch', :content => 'i586'
+
+    assert_xml_tag :parent => { :tag => 'repository', :attributes => { :name => '10.2' } },
+      :tag => 'arch', :content => 'x86_64'
+
+    # check build results are copied correctly
+    get '/build/IggyHomeCopy/_result'
+    assert_xml_tag :parent => {
+        :tag => 'result', :attributes => {
+            :project => 'IggyHomeCopy',
+            :repository => '10.2',
+            :arch => 'i586',
+            :code => 'published',
+            :state => 'published' } },
+      :tag => 'status', :attributes => {
+          :package => 'TestPack',
+          :code => 'succeeded' }
+
+    assert_xml_tag :parent => {
+        :tag => 'result', :attributes => {
+            :project => 'IggyHomeCopy',
+            :repository => '10.2',
+            :arch => 'x86_64',
+            :code => 'published',
+            :state => 'published' } },
+      :tag => 'status', :attributes => {
+          :package => 'TestPack',
+          :code => 'disabled' }
+
+    # check that binaries are copied
+    get '/build/IggyHomeCopy/10.2/i586/TestPack'
+    assert_xml_tag :tag => 'binarylist', :children => { :count => 4 }
+
+    get '/build/IggyHomeCopy/10.2/x86_64/TestPack'
+    assert_xml_tag :tag => 'binarylist', :children => { :count => 0 }
+  end
+
   def test_source_commits
     login_tom
     post '/source/home:Iggy/TestPack', :cmd => 'commitfilelist'

--- a/src/backend/bs_repserver
+++ b/src/backend/bs_repserver
@@ -2046,11 +2046,12 @@ sub copybuild {
     die("job lock failed\n");
   }
   my $dir = "$jobsdir/$arch/$job:dir";
+  my $repodir = "$reporoot/$oprojid/$orepoid/$arch";
   my $odir = "$reporoot/$oprojid/$orepoid/$arch/$opackid";
   mkdir_p($dir);
   my $delayed_linking;
   my $needsign;
-  for my $bin (grep {$_ ne 'status' && $_ ne 'reason' && $_ ne 'history' && $_ ne 'meta' && !/^\./} sort(ls($odir))) {
+  for my $bin (grep {$_ ne 'status' && $_ ne 'reason' && $_ ne 'history' && $_ ne 'meta' && (/^\.preinstall/ || !/^\./)} sort(ls($odir))) {
     if ($bin eq "updateinfo.xml" && $cgi->{'setupdateinfoid'}) {
       my $updateinfo = readxml("$odir/$bin", $BSXML::updateinfo);
       for (@{$updateinfo->{'update'} || []}) {
@@ -2080,7 +2081,11 @@ sub copybuild {
       }
     }
   }
-  link("$odir/.meta.success", "$dir/meta") if -e "$odir/.meta.success";
+
+  link("$repodir/:lastcheck", "$dir/lastcheck") if -e "$repodir/:lastcheck";
+  link("$repodir/:meta/$opackid", "$dir/meta") if -e "$repodir/:meta/$opackid";
+  link("$repodir/:logfiles.success/$opackid", "$dir/logfiles.success") if -e "$repodir/:logfiles.success/$opackid";
+  link("$repodir/:logfiles.fail/$opackid", "$dir/logfiles.fail") if -e "$repodir/:logfiles.fail/$opackid";
 
   # we run the linking of directory trees in background, since it can take a long time
   # for simple files it happened already
@@ -3962,7 +3967,7 @@ my $dispatches = [
   '/build/$project/$repository/$arch/_jobhistory package* code:* limit:num?' => \&getjobhistory,
   'POST:/build/$project/$repository/$arch/_relsync' => \&postrelsync,
   '/build/$project/$repository/$arch/_relsync' => \&getrelsync,
-  'POST:/build/$project/$repository/$arch/$package cmd=copy oproject:project? opackage:package? orepository:repository? setupdateinfoid:? resign:bool? setrelease:?' => \&copybuild,
+  'POST:/build/$project/$repository/$arch/$package cmd=copy oproject:project? opackage:package? orepository:repository? setupdateinfoid:? resign:bool? setrelease:? withmeta:bool?' => \&copybuild,
   'POST:/build/$project/$repository/$arch/$package' => \&uploadbuild,
   '!worker,rw /build/$project/$repository/$arch/$package:package_repository view:? binary:filename* nometa:bool? noajax:bool? nosource:bool? noimport:bool? withmd5:bool?' => \&getbinarylist,
   'POST:/build/$project/$repository/$arch/$package_repository/_buildinfo add:* internal:bool? debug:bool? deps:bool?' => \&getbuildinfo_post,

--- a/src/backend/bs_sched
+++ b/src/backend/bs_sched
@@ -4538,18 +4538,31 @@ sub uploadbuildevent {
   my $gdst = "$reporoot/$prp/$myarch";
   my $dst = "$gdst/$packid";
   mkdir_p($dst);
-  my $meta;
-  $meta = "$jobdatadir/meta" if -e "$jobdatadir/meta";
   print "  - $prp: $packid uploaded\n";
   my $useforbuildenabled = 1;
   $useforbuildenabled = enabled($repoid, $projpacks->{$projid}->{'useforbuild'}, $useforbuildenabled);
   $useforbuildenabled = enabled($repoid, $pdata->{'useforbuild'}, $useforbuildenabled);
-  update_dst_full($prp, $packid, $jobdatadir, $meta, $useforbuildenabled, $prpsearchpath{$prp});
-  $changed->{$prp} = 2 if $useforbuildenabled;
+  my $meta = "$jobdatadir/meta" if -e "$jobdatadir/meta";
   if ($meta) {
     mkdir_p("$gdst/:meta");
-    rename($meta, "$gdst/:meta/$packid");
+    link($meta, "$gdst/:meta/$packid");
   }
+  if (-e "$jobdatadir/lastcheck") {
+    link("$jobdatadir/lastcheck", "$gdst/:lastcheck") unless -e "$gdst/:lastcheck";
+    unlink "$jobdatadir/lastcheck";
+  }
+  if (-e "$jobdatadir/logfiles.success") {
+    mkdir_p("$gdst/:logfiles.success");
+    link "$jobdatadir/logfiles.success", "$gdst/:logfiles.success/$packid";
+    unlink "$jobdatadir/logfiles.success";
+  }
+  if (-e "$jobdatadir/logfiles.fail") {
+    mkdir_p("$gdst/:logfiles.fail");
+    link "$jobdatadir/logfiles.fail", "$gdst/:logfiles.fail/$packid";
+    unlink "$jobdatadir/logfiles.fail";
+  }
+  update_dst_full($prp, $packid, $jobdatadir, $meta, $useforbuildenabled, $prpsearchpath{$prp});
+  $changed->{$prp} = 2 if $useforbuildenabled;
   delete $repounchanged{$prp} if $useforbuildenabled;
   $repounchanged{$prp} = 2 if $repounchanged{$prp};
   $changed->{$prp} ||= 1;

--- a/src/backend/bs_srcserver
+++ b/src/backend/bs_srcserver
@@ -5594,6 +5594,24 @@ sub sourcecommitfilelist {
   return getfilelist($cgi, $projid, $packid);
 }
 
+sub copyproject_sync {
+  my ($projid, $pkgs, $repos, $tmo) = @_;
+  AGAIN: for (; $tmo > 0; $tmo -= 1, sleep(1)) {
+    my $status = (getresult({}, $projid))[0];
+    for my $repo (@{$repos}) {
+      next AGAIN unless grep { $_->{'repository'} eq $repo->{'name'} } @{$status->{'result'}};
+    }
+    for my $repo (@{$status->{'result'}}) {
+      next AGAIN unless $repo->{'status'};
+      for my $pkg (@{$repo->{'status'}}) {
+        next AGAIN unless grep { $_ eq $pkg->{'package'} } @{$pkgs};
+      }
+    }
+    last;
+  }
+  return $tmo > 0;
+}
+
 # copy sources of entire project, project exists ensured by api.
 sub copyproject {
   my ($cgi, $projid) = @_;
@@ -5746,6 +5764,7 @@ sub copyproject {
 	  push @args, "opackage=$packid"; # same package name
 	  push @args, "orepository=$repo->{'name'}"; # same repo name
 	  push @args, 'resign=1' if $cgi->{'resign'};
+	  push @args, 'withmeta=1';
 	  my $param = {
 	    'uri' => "$reposerver/build/$projid/$repo->{'name'}/$arch/$packid",
 	    'request' => 'POST',
@@ -5761,6 +5780,9 @@ sub copyproject {
   }
   # check all packages in project
   notify_repservers('package', $projid);
+  if ($cgi->{'synctimeout'} && $cgi->{'synctimeout'} > 0) {
+    return undef unless copyproject_sync($projid, \@pkgs, \@{$proj->{'repository'} || []}, $cgi->{'synctimeout'});
+  }
   return $BSStdServer::return_ok;	# also resumes the project
 }
 
@@ -8247,7 +8269,7 @@ my $dispatches = [
   'POST:/source/$project cmd=createkey user:? comment:?' => \&createkey,
   'POST:/source/$project cmd=extendkey user:? comment:?' => \&extendkey,
   'POST:/source/$project cmd=undelete user:? comment:?' => \&undeleteproject,
-  'POST:/source/$project cmd=copy user:? comment:? oproject:project withbinaries:bool? withhistory:bool? makeolder:bool? resign:bool? noservice:bool?' => \&copyproject,
+  'POST:/source/$project cmd=copy user:? comment:? oproject:project withbinaries:bool? withhistory:bool? makeolder:bool? resign:bool? noservice:bool? synctimeout:num?' => \&copyproject,
   'POST:/source/$project cmd: *:*' => \&unknowncmd,
   '/source/$project view=info parse:bool? nofilename:bool? repository? arch? package* withchangesmd5:bool?' => \&getprojectsourceinfo,
   '/source/$project deleted:bool? expand:bool? noorigins:bool?' => \&getpackagelist,


### PR DESCRIPTION
Copy more missing files from source project when using copyproject API. This prevents more cases where rebuilding occurs after copy and also fixes viewing of logs etc.