### PR TITLE
Improve handling of validation errors and add client-side validation with simple_form

### DIFF
--- a/src/api/app/controllers/webui/main_controller.rb
+++ b/src/api/app/controllers/webui/main_controller.rb
@@ -91,8 +91,13 @@ class Webui::MainController < Webui::WebuiController
       redirect_to(:action => 'index') and return
     end
     # TODO - make use of permissions.status_message_create
-    StatusMessage.create!(message: params[:message], severity: params[:severity], user: User.current)
-    redirect_to(:action => 'index')
+    status_message = StatusMessage.new(message: params[:message], severity: params[:severity], user: User.current)
+    if status_message.save
+      flash[:notice] = "Status message was successfully created."
+    else
+      flash[:error] = "Could not create status message: #{status_message.errors.full_messages.to_sentence}"
+    end
+    redirect_to(:action => "index")
   end
 
   def delete_message_dialog

--- a/src/api/app/controllers/webui/project_controller.rb
+++ b/src/api/app/controllers/webui/project_controller.rb
@@ -467,7 +467,11 @@ class Webui::ProjectController < Webui::WebuiController
     authorize @project, :update?
     params[:architectures] ||= []
 
-    repository = @project.repositories.find_or_create_by!(name: params[:repository])
+    repository = @project.repositories.find_or_initialize_by(name: params[:repository])
+    unless repository.save
+      redirect_to :back, error: "Couldn't add repository: 'Name must not start with '_' or contain any of these characters ':/'"
+      return
+    end
 
     if params[:target_repo]
       # add a repository from an existing project

--- a/src/api/app/controllers/webui/user_controller.rb
+++ b/src/api/app/controllers/webui/user_controller.rb
@@ -106,9 +106,14 @@ class Webui::UserController < Webui::WebuiController
       @displayed_user.state = User::STATES[params[:state]] if params[:state]
       @displayed_user.update_globalroles([params[:globalrole]]) if params[:globalrole]
     end
-    @displayed_user.save!
 
-    flash[:success] = "User data for user '#{@displayed_user.login}' successfully updated."
+    begin
+      @displayed_user.save!
+      flash[:success] = "User data for user '#{@displayed_user.login}' successfully updated."
+    rescue ActiveRecord::RecordInvalid => e
+      flash[:error] = "Couldn't update user: #{e.message}."
+    end
+
     redirect_back_or_to :action => 'show', user: @displayed_user
   end
 

--- a/src/api/app/models/download_repository.rb
+++ b/src/api/app/models/download_repository.rb
@@ -6,7 +6,7 @@ class DownloadRepository < ActiveRecord::Base
   validates :repository_id, presence: true
   validates :arch, uniqueness: { scope: :repository_id }, presence: true
   validate :architecture_inclusion
-  validates :url, presence: true
+  validates :url, presence: true, :format => { :with => /\A[a-zA-Z]+:.*\Z/ } # from backend/BSVerify.pm
   validates :repotype, presence: true
   validates :repotype, inclusion: { in: REPOTYPES }
 

--- a/src/api/app/models/repository.rb
+++ b/src/api/app/models/repository.rb
@@ -21,7 +21,7 @@ class Repository < ActiveRecord::Base
   validates :name, length: { in: 1..200 }
   # Keep in sync with src/backend/BSVerify.pm
   validates :name, format: { with:    /\A[^_:\/\000-\037][^:\/\000-\037]*\Z/,
-                             message: "Repository name must not start with '_' or contain any of these characters ':/'" }
+                             message: "must not start with '_' or contain any of these characters ':/'" }
 
   # Name has to be unique among local repositories and remote_repositories of the associated db_project.
   # Note that remote repositories have to be unique among their remote project (remote_project_name)

--- a/src/api/app/views/shared/_add_group.html.erb
+++ b/src/api/app/views/shared/_add_group.html.erb
@@ -3,12 +3,12 @@
 <%= form_tag :action => :save_group do %>
   <p>
     <label for="groupid"><b>Group:</b></label><br/>
-    <%= text_field_tag 'groupid', params[:groupid], :size => '25' %><br/>
+    <%= text_field_tag 'groupid', params[:groupid], :size => '25', required: true %><br/>
     <%= javascript_tag do %>
       $("#groupid").autocomplete({source: '<%= url_for :controller => 'groups', :action => 'autocomplete' %>', minLength: 2});
     <% end %>
     <b>Role:</b><br/>
-    <%= select_tag 'role', options_for_select(@roles, params[:role]) %><br/>
+    <%= select_tag 'role', options_for_select(@roles, params[:role]), required: true %><br/>
     <%= hidden_field_tag 'package', @package %>
     <%= hidden_field_tag 'project', @project %>
   </p>

--- a/src/api/app/views/shared/_add_user.html.erb
+++ b/src/api/app/views/shared/_add_user.html.erb
@@ -3,12 +3,12 @@
 <%= form_tag :action => :save_person do %>
   <p>
     <label for="userid"><b>User:</b></label><br/>
-    <%= text_field_tag 'userid', params[:userid] %><br/>
+    <%= text_field_tag 'userid', params[:userid], required: true %><br/>
     <%= javascript_tag do %>
       $("#userid").autocomplete({source: '<%= url_for :controller => 'user', :action => 'autocomplete' %>', minLength: 2});
     <% end %>
     <b>Role:</b><br/>
-    <%= select_tag 'role', options_for_select(@roles, params[:role]) %><br/>
+    <%= select_tag 'role', options_for_select(@roles, params[:role]), required: true %><br/>
     <%= hidden_field_tag 'package', @package %>
     <%= hidden_field_tag 'project', @project %>
   </p>

--- a/src/api/app/views/webui/comment/_reply.html.erb
+++ b/src/api/app/views/webui/comment/_reply.html.erb
@@ -1,7 +1,7 @@
 <div id="<%="reply_form_of_#{comment.id}"%>" style="display: none;">
   <%= save_comment_form do %>
     <p>
-      <%= text_area_tag 'body', nil, size: '80x1', :onkeyup => 'sz(this);', :onclick => 'sz(this);', id: "reply_body_#{comment.id}", :placeholder => 'Comment Text', :required => 'required' %>
+      <%= text_area_tag 'body', nil, size: '80x1', onkeyup: 'sz(this);', onclick: 'sz(this);', id: "reply_body_#{comment.id}", placeholder: 'Comment Text', required: true %>
       <%= hidden_field_tag 'parent_id', comment.id, id: "reply_parent_id_#{comment.id}" %>
     </p>
     <p><%= submit_tag 'Add reply', id: "add_reply_#{comment.id}"%></p>

--- a/src/api/app/views/webui/main/_add_news_dialog.html.erb
+++ b/src/api/app/views/webui/main/_add_news_dialog.html.erb
@@ -6,7 +6,7 @@
         <%= form_tag({:controller => 'main', :action => 'add_news'}, :method => 'post') do %>
           <p>
             <%= label_tag(:message, 'Message:') %><br/>
-            <%= text_area_tag(:message, '', :size => '40x3') %><br/>
+            <%= text_area_tag(:message, '', :size => '40x3', required: true) %><br/>
             <%= label_tag(:severity, "Severity:") %><br/>
             <%= select_tag(:severity, options_for_select([['Information', 0], ['Green', 1], ['Yellow', 2], ['Red', 3]])) %>
           </p>

--- a/src/api/app/views/webui/package/_submit_request_dialog.html.haml
+++ b/src/api/app/views/webui/package/_submit_request_dialog.html.haml
@@ -17,7 +17,7 @@
         %br/
         = label_tag(:targetproject, 'To target project:')
         %br/
-        = text_field_tag(:targetproject, @tprj, size: 40, disabled: params[:readonly], |
+        = text_field_tag(:targetproject, @tprj, size: 40, disabled: params[:readonly], required: true, |
                          data: { autocomplete_url: url_for(controller: :project, action: :autocomplete_projects), |
                                  requests_url: url_for(controller: :request, action: :list_small), |
                                  develpackage_url: url_for(controller: :package, action: :devel_project) })

--- a/src/api/app/views/webui/patchinfo/_form.html.erb
+++ b/src/api/app/views/webui/patchinfo/_form.html.erb
@@ -20,13 +20,13 @@
               <strong><%= image_tag('info.png', :title => 'Enter a short summary. Mainpackage: shortdescription of the mainfix', :alt => 'Summaryinfo') %>
                 Summary:</strong>
 
-              <%= text_area_tag 'summary', @summary, :size => '60x1', required: true %>
+              <%= text_area_tag 'summary', @summary, :size => '60x1', required: true, min: 10 %>
             </p>
 
             <p>
               <strong><%= image_tag('info.png', :title => 'Enter a full description what the update fixes', :alt => 'Descriptioninfo') %>
                 Description: </strong>
-              <%= text_area_tag 'description', @description, :size => '65x9', required: true %>
+              <%= text_area_tag 'description', @description, :size => '65x9', required: true, min: 10 %>
             </p>
 
             <p>

--- a/src/api/app/views/webui/patchinfo/_form.html.erb
+++ b/src/api/app/views/webui/patchinfo/_form.html.erb
@@ -10,7 +10,7 @@
           <div class="box show_left show_right">
             <p>
               <strong>Packager:</strong><br/>
-              <%= text_field_tag 'packager', @packager %>
+              <%= text_field_tag 'packager', @packager, required: true %>
               <%= javascript_tag do %>
                   $("#packager").autocomplete({source: '<%= url_for :controller => 'user', :action => 'autocomplete' %>', minLength: 2});
               <% end %>
@@ -20,13 +20,13 @@
               <strong><%= image_tag('info.png', :title => 'Enter a short summary. Mainpackage: shortdescription of the mainfix', :alt => 'Summaryinfo') %>
                 Summary:</strong>
 
-              <%= text_area_tag 'summary', @summary, :size => '60x1' %>
+              <%= text_area_tag 'summary', @summary, :size => '60x1', required: true %>
             </p>
 
             <p>
               <strong><%= image_tag('info.png', :title => 'Enter a full description what the update fixes', :alt => 'Descriptioninfo') %>
                 Description: </strong>
-              <%= text_area_tag 'description', @description, :size => '65x9' %>
+              <%= text_area_tag 'description', @description, :size => '65x9', required: true %>
             </p>
 
             <p>

--- a/src/api/app/views/webui/project/_dod_repository_form.haml
+++ b/src/api/app/views/webui/project/_dod_repository_form.haml
@@ -6,7 +6,7 @@
     %div
       %p
         = label_tag(:name, "Repository name")
-        = text_field_tag(:name)
+        = text_field_tag(:name, required: true)
 
     %div
       %h4
@@ -14,7 +14,7 @@
       - # Note: Mostly C&P from app/views/webui/download_on_demand/_form.html.erb
       %div{ style: "margin-bottom: 1.2em; margin-left: 2em" }
         = label_tag :arch, "Architecture", style: "display:inline-block;width:100px;"
-        = select_tag :arch, options_for_select(Architecture.available, "")
+        = select_tag :arch, options_for_select(Architecture.available, ""), required: true
         %br
         %br
         = label_tag :repotype, 'Type', style: "display:inline-block;width:100px;"
@@ -22,7 +22,7 @@
         %br
         %br
         = label_tag :url, 'Url', style: "display:inline-block;width:100px;"
-        = text_field_tag :url
+        = text_field_tag :url, required: true
         %br
         %br
         = label_tag :archfilter, 'Arch. Filter' , style: "display:inline-block;width:100px;"

--- a/src/api/app/views/webui/project/_form.html.erb
+++ b/src/api/app/views/webui/project/_form.html.erb
@@ -6,7 +6,7 @@
             <%= hidden_field_tag :ns, ns %>
             <%= ns + ':'%>
       <% end %>
-      <%= f.text_field :name, size: 50 %>
+      <%= f.text_field :name, size: 50, required: true %>
       <br/>
       <label for="title"><b>Title: </b></label>
       <br/>

--- a/src/api/app/views/webui/project/add_repository.html.erb
+++ b/src/api/app/views/webui/project/add_repository.html.erb
@@ -16,19 +16,19 @@
   <p>
     <strong>Project: </strong>
     <br/>
-    <%= text_field_tag 'target_project', '', :size => 60, :id => 'target_project',
+    <%= text_field_tag 'target_project', '', :size => 60, :id => 'target_project', required: true,
                       data: { 'ajaxurl' => url_for(:controller => 'project', :action => 'autocomplete_projects') } %>
     <br/>
     <strong>Repository: </strong><br/>
     <%= image_tag('ajax-loader.gif', :id => 'loader-repo', class: 'hidden') %>
-    <%= select_tag "target_repo", options_for_select([""]), id: 'target_repo',
+    <%= select_tag "target_repo", options_for_select([""]), id: 'target_repo', required: true,
                       disabled: true, data: { 'ajaxurl' => url_for(:controller => :project, :action => :autocomplete_repositories) } %><br/>
     <!-- Do not offer new name if we add this repo to an existing one as path -->
     <% if params[:torepository] %>
       <%= hidden_field_tag( "repository", params[:torepository] ) %><br/>
     <% else %>
       <strong>Name: </strong><br/>
-      <%= text_field_tag 'repository', '', size: 60, id: 'repo_name', disabled: false %><br/>
+      <%= text_field_tag 'repository', '', size: 60, id: 'repo_name', disabled: false, required: true %><br/>
       <strong>Architectures: </strong><br/>
       <% Architecture.available.each do |architecture| %>
         <%= check_box_tag "architectures[]", architecture.name, true, id: "architecture_#{architecture.name}" %><%= architecture.name %>

--- a/src/api/app/views/webui/project/new_package.html.erb
+++ b/src/api/app/views/webui/project/new_package.html.erb
@@ -16,7 +16,7 @@
 <%= form_tag controller: :package, action: 'save_new', project: @project.to_param do %>
 <p>
   <strong>Name:</strong><br/>
-  <%= text_field_tag 'name', @package_name, :size => 80 %><br/>
+  <%= text_field_tag 'name', @package_name, :size => 80, required: true %><br/>
   <strong>Title:</strong><br/>
   <%= text_field_tag 'title', @package_title, :size => 80 %><br/>
   <strong>Description:</strong><br/>

--- a/src/api/app/views/webui/user/_save_dialog.html.erb
+++ b/src/api/app/views/webui/user/_save_dialog.html.erb
@@ -12,7 +12,7 @@
         </p>
         <p>
           <%= label_tag :email, 'e-Mail:' %><br/>
-          <%= email_field_tag :email, User.current.email, required: true %>
+          <%= email_field_tag :email, User.current.email, required: true, email: true %>
         </p>
         <div class="dialog-buttons">
           <%= submit_tag("Ok") %>

--- a/src/api/app/views/webui/user/_save_dialog.html.erb
+++ b/src/api/app/views/webui/user/_save_dialog.html.erb
@@ -12,7 +12,7 @@
         </p>
         <p>
           <%= label_tag :email, 'e-Mail:' %><br/>
-          <%= email_field_tag :email, User.current.email %>
+          <%= email_field_tag :email, User.current.email, required: true %>
         </p>
         <div class="dialog-buttons">
           <%= submit_tag("Ok") %>

--- a/src/api/app/views/webui/user/edit.html.erb
+++ b/src/api/app/views/webui/user/edit.html.erb
@@ -14,7 +14,7 @@
     </p>
     <p>
      <%= label_tag :email, 'e-Mail:' %><br/>
-     <%= text_field_tag :email, @displayed_user.email, required: true %>
+     <%= text_field_tag :email, @displayed_user.email, required: true, email: true %>
     </p>
     <p>
     <%= label_tag :globalrole, 'Admin:' %>

--- a/src/api/app/views/webui/user/edit.html.erb
+++ b/src/api/app/views/webui/user/edit.html.erb
@@ -14,7 +14,7 @@
     </p>
     <p>
      <%= label_tag :email, 'e-Mail:' %><br/>
-     <%= text_field_tag :email, @displayed_user.email %>
+     <%= text_field_tag :email, @displayed_user.email, required: true %>
     </p>
     <p>
     <%= label_tag :globalrole, 'Admin:' %>

--- a/src/api/spec/controllers/webui/main_controller_spec.rb
+++ b/src/api/spec/controllers/webui/main_controller_spec.rb
@@ -14,6 +14,22 @@ RSpec.describe Webui::MainController do
       expect(message).to exist
     end
 
+    it "requires message and severity parameters" do
+      login(admin_user)
+
+      expect {
+        post :add_news, message: "Some message"
+      }.to_not change(StatusMessage, :count)
+      expect(response).to redirect_to(root_path)
+      expect(flash[:error]).to eq("Please provide a message and severity")
+
+      expect {
+        post :add_news, severity: "Green"
+      }.to_not change(StatusMessage, :count)
+      expect(response).to redirect_to(root_path)
+      expect(flash[:error]).to eq("Please provide a message and severity")
+    end
+
     context "non-admin users" do
       before do
         login(user)

--- a/src/api/spec/controllers/webui/project_controller_spec.rb
+++ b/src/api/spec/controllers/webui/project_controller_spec.rb
@@ -367,4 +367,14 @@ RSpec.describe Webui::ProjectController, vcr: true do
       expect(assigns(:roles)).to match_array(Role.local_roles)
     end
   end
+
+  describe 'POST #save_repository' do
+    it 'does not save invalid repositories' do
+      login user
+      expect {
+        get :save_repository, project: user.home_project, repository: "_invalid"
+      }.to_not change(Repository, :count)
+      expect(flash[:error]).to eq("Couldn't add repository: 'Name must not start with '_' or contain any of these characters ':/'")
+    end
+  end
 end

--- a/src/api/spec/controllers/webui/user_controller_spec.rb
+++ b/src/api/spec/controllers/webui/user_controller_spec.rb
@@ -104,15 +104,31 @@ RSpec.describe Webui::UserController do
 
   describe "POST #save" do
     context "when user is updating its own profile" do
-      before do
-        login user
-        post :save, {user: user, realname: 'another real name', email: 'new_valid@email.es' }
-        user.reload
+      context "with valid data" do
+        before do
+          login user
+          post :save, { user: user, realname: 'another real name', email: 'new_valid@email.es' }
+          user.reload
+        end
+
+        it { expect(flash[:success]).to eq("User data for user '#{user.login}' successfully updated.") }
+        it { expect(user.realname).to eq('another real name') }
+        it { expect(user.email).to eq('new_valid@email.es') }
+        it { is_expected.to redirect_to user_show_path(user) }
       end
 
-      it { expect(user.realname).to eq('another real name') }
-      it { expect(user.email).to eq('new_valid@email.es') }
-      it { is_expected.to redirect_to user_show_path(user) }
+      context "with invalid data" do
+        before do
+          login user
+          post :save, { user: user, realname: "another real name", email: "" }
+          user.reload
+        end
+
+        it { expect(flash[:error]).to eq("Couldn't update user: Validation failed: Email must be given, Email must be a valid email address..") }
+        it { expect(user.realname).to eq(user.realname) }
+        it { expect(user.email).to eq(user.email) }
+        it { is_expected.to redirect_to user_show_path(user) }
+      end
     end
 
     context "when user is trying to update another user's profile" do

--- a/src/api/test/functional/webui/package_controller_test.rb
+++ b/src/api/test/functional/webui/package_controller_test.rb
@@ -414,16 +414,14 @@ class Webui::PackageControllerTest < Webui::IntegrationTest
     visit(package_show_path(project: "home:Iggy", package: "TestPack"))
     click_link("Submit package")
     click_button("Ok")
-    page.must_have_text "Please provide a target for the submit request"
     assert_equal package_show_path(project: "home:Iggy", package: "TestPack"),
-                 page.current_path
+                 page.current_path, "Client-side validation should have prevented package submission."
 
     click_link("Submit package")
     fill_in "To target project", with: "nonexistant:project"
     click_button("Ok")
-    page.must_have_text "Unable to submit (missing target): nonexistant:project"
     assert_equal package_show_path(project: "home:Iggy", package: "TestPack"),
-                 page.current_path
+                 page.current_path, "Client-side validation should have prevented package submission."
 
     click_link("Submit package")
     fill_in "To target project", with: "home:Iggy"

--- a/src/api/test/functional/webui/package_controller_test.rb
+++ b/src/api/test/functional/webui/package_controller_test.rb
@@ -542,7 +542,7 @@ class Webui::PackageControllerTest < Webui::IntegrationTest
     use_js
     login_king to: package_live_build_log_path(package: 'pack2.linked', project: 'BaseDistro2.0', repository: 'BaseDistro2_repo', arch: 'i586')
 
-    page.all(:link, 'Trigger Rebuild')[0].click
+    page.first(:link, 'Trigger Rebuild').click
     find('#flash-messages').must_have_text('Triggered rebuild for BaseDistro2.0/pack2.linked successfully.')
   end
 end

--- a/src/api/test/functional/webui/users_test.rb
+++ b/src/api/test/functional/webui/users_test.rb
@@ -20,7 +20,6 @@ class Webui::EditPackageUsersTest < Webui::IntegrationTest
     add_user 'user6', 'downloader'
 
     add_user 'sadasxsacxsacsa', 'reader', :expect => :unknown_user
-    add_user '', 'maintainer', :expect => :unknown_user
     add_user '~@$@#%#%@$0-=m,.,\/\/12`;.{{}}{}', 'maintainer', :expect => :unknown_user
 
     # add_package_role_to_username_with_question_sign do


### PR DESCRIPTION
Those commits will fix handling of server side validation errors in some places as well adding some client side form validation.
Validation of the form entries happens as soon as a user clicks the submit button.

This is how it looks like:
![email_validation](https://cloud.githubusercontent.com/assets/968949/15609730/0952fe86-2422-11e6-9562-6300b774dc3b.png)

and

![form_validation](https://cloud.githubusercontent.com/assets/968949/15609735/0cda9c4e-2422-11e6-8aac-1d8c0e95837f.png)
