### PR TITLE
[api] Fix adding commit messages for project meta

### DIFF
--- a/src/api/app/controllers/source_controller.rb
+++ b/src/api/app/controllers/source_controller.rb
@@ -517,7 +517,8 @@ class SourceController < ApplicationController
         # FIXME3.0: don't modify send data
         project.relationships.build(user: User.current, role: Role.find_by_title!('maintainer'))
       end
-      project.store
+      opts = { :comment => params[:comment] }
+      project.store opts
     end
     render_ok
   end


### PR DESCRIPTION
The api and the backend support commit messages for the project meta
but the controller function did ignore the comment parameter.

This patch works for master and can be cherry-picked for 2.7