### PR TITLE
[api] Fix adding commit messages for project meta

### DIFF
--- a/src/api/app/controllers/source_controller.rb
+++ b/src/api/app/controllers/source_controller.rb
@@ -520,7 +520,8 @@ class SourceController < ApplicationController
       else
         prj.update_from_xml(rdata)
       end
-      prj.store
+      opts = { :comment => params[:comment] }
+      prj.store opts
     end
     render_ok
   end


### PR DESCRIPTION
The api and the backend support commit messages for the project meta
but the controller function did ignore the comment parameter.

Patch for 2.6
