### PR TITLE
[api] Fix adding commit messages for project meta

### DIFF
--- a/src/api/app/controllers/source_controller.rb
+++ b/src/api/app/controllers/source_controller.rb
@@ -517,7 +517,7 @@ class SourceController < ApplicationController
         # FIXME3.0: don't modify send data
         project.relationships.build(user: User.current, role: Role.find_by_title!('maintainer'))
       end
-      project.store
+      project.store({ :comment => params[:comment] })
     end
     render_ok
   end

--- a/src/api/test/unit/code_quality_test.rb
+++ b/src/api/test/unit/code_quality_test.rb
@@ -93,7 +93,7 @@ class CodeQualityTest < ActiveSupport::TestCase
       'SearchController#find_attribute'                                         => 97.33,
       'SearchController#search'                                                 => 81.15,
       'SourceController#project_command_copy'                                   => 140.04,
-      'SourceController#update_project_meta'                                    => 100.07,
+      'SourceController#update_project_meta'                                    => 103.21,
       'UserLdapStrategy::find_with_ldap'                                        => 122.14,
       'User::find_with_credentials'                                             => 121.31,
       'UserLdapStrategy::render_grouplist_ldap'                                 => 100.3,


### PR DESCRIPTION
The api and the backend support commit messages for the project meta
but the controller function did ignore the comment parameter.

Now with adjustment of the code quality check.