### PR TITLE
[api] Fix adding commit messages for project meta

### DIFF
--- a/src/api/app/controllers/source_controller.rb
+++ b/src/api/app/controllers/source_controller.rb
@@ -520,7 +520,7 @@ class SourceController < ApplicationController
       else
         prj.update_from_xml(rdata)
       end
-      prj.store
+      prj.store({ :comment => params[:comment] })
     end
     render_ok
   end

--- a/src/api/test/unit/code_quality_test.rb
+++ b/src/api/test/unit/code_quality_test.rb
@@ -100,7 +100,7 @@ class CodeQualityTest < ActiveSupport::TestCase
       'SearchController#search' => 81.64, 
       'SourceController#project_command_copy' => 140.04,
       'SourceController#update_file' => 97.26,
-      'SourceController#update_project_meta' => 106.89,
+      'SourceController#update_project_meta' => 110.01,
       'UserLdapStrategy::find_with_ldap' => 119.04,
       'UserLdapStrategy::render_grouplist_ldap' => 100.3,
       'Webui::DriverUpdateController#save' => 97.16,


### PR DESCRIPTION
The api and the backend support commit messages for the project meta
but the controller function did ignore the comment parameter.

Fix for 2.6 with adjustment of code quality test