### PR TITLE
[ci] Enable Capybara.wait_on_first_by_default

### DIFF
--- a/src/api/test/test_helper.rb
+++ b/src/api/test/test_helper.rb
@@ -43,6 +43,7 @@ require 'capybara/poltergeist'
 
 require 'capybara/rails'
 Capybara.default_max_wait_time = 6
+Capybara.wait_on_first_by_default = true
 
 Capybara.register_driver :poltergeist do |app|
   Capybara::Poltergeist::Driver.new(app, debug: false, timeout: 30)


### PR DESCRIPTION
While Capybara's find is waiting for a matching element to appear, first
doesn't. Turning wait_on_first_by_default on enables that kind of behaviour
which will make maintenance_workflow_test.rb succeed with newer phantomjs
version (v1.9.8 -> v2.1.1).

This was blocking phantomjs update.