### PR TITLE
[backend] Add constraint type jobs

### DIFF
--- a/docs/api/api/constraints.rng
+++ b/docs/api/api/constraints.rng
@@ -102,6 +102,11 @@
               </element>
             </optional>
             <optional>
+              <element name="jobs">
+                <data type="integer"/>
+              </element>
+            </optional>
+            <optional>
               <element name="disk">
                 <ref name="size-unit"/>
               </element>

--- a/src/backend/BSXML.pm
+++ b/src/backend/BSXML.pm
@@ -722,6 +722,7 @@ our $worker = [
           [ 'flag' ],
         ],
         'processors',
+        'jobs',
 	'memory',	# in MBytes
 	'swap',		# in MBytes
 	'disk',		# in MBytes
@@ -1632,6 +1633,7 @@ our @constraint = (
 	      [ 'flag' ],
 	  ],
 	    'processors',
+	    'jobs',
 	  [ 'disk' => $size ],
 	  [ 'memory' => $size ],
 	  [ 'physicalmemory' => $size ],

--- a/src/backend/bs_dispatch
+++ b/src/backend/bs_dispatch
@@ -553,6 +553,7 @@ sub oracle {
   if ($constraints->{'hardware'}) {
     return 0 unless $worker->{'hardware'};
     return 0 if $constraints->{'hardware'}->{'processors'} && $constraints->{'hardware'}->{'processors'} > ($worker->{'hardware'}->{'processors'} || 0);
+    return 0 if $constraints->{'hardware'}->{'jobs'} && $constraints->{'hardware'}->{'jobs'} > ($worker->{'hardware'}->{'jobs'} || 0);
     return 0 if $constraints->{'hardware'}->{'disk'} && getmbsize($constraints->{'hardware'}->{'disk'}) > ($worker->{'hardware'}->{'disk'} || 0);
     my $memory = ($worker->{'hardware'}->{'memory'} || 0);
     my $swap = ($worker->{'hardware'}->{'swap'} || 0);

--- a/src/backend/bs_worker
+++ b/src/backend/bs_worker
@@ -662,6 +662,7 @@ my $workerenvstate = {};
     }
     close FILE;
   }
+  $hw->{'jobs'} = $jobs if $jobs;
   $hw->{'memory'} = $vm_memory if $vm_memory;
   $hw->{'swap'} = $vmdisk_swapsize if $vmdisk_swapsize;
   $hw->{'disk'} = $vmdisk_rootsize if $vmdisk_rootsize;


### PR DESCRIPTION
'jobs' is the minimum required number of CPUs allocated
for the worker. It maps directly to 'make -jN'.