### PR TITLE
[api] fix parsing of XPATH searches using not() in the correct way

### DIFF
--- a/src/api/lib/xpath_engine.rb
+++ b/src/api/lib/xpath_engine.rb
@@ -652,13 +652,18 @@ class XpathEngine
     # Note that this can result in bloated SQL statements, so some trust in the query optimization
     # capabilities of your DBMS is neeed :-)
 
-    @condition_values_needed = 2
-    cond = evaluate_expr(expr, root)
-
-    condition = "(NOT #{cond} OR ISNULL(#{cond}))"
+    if [:child, :attribute].include? expr.first
+       # for incorrect writings of not(@name) as existens check
+       # we used to support it :/
+       @condition_values_needed = 2 if expr.first == :attribute
+       cond = evaluate_expr(expr, root)
+       condition = "(NOT #{cond} OR ISNULL(#{cond}))"
+       @condition_values_needed = 1
+    else
+       parse_predicate(root, expr)
+       condition = "(#{@conditions.pop})"
+    end
     # logger.debug "-- condition : [#{condition}]"
-
-    @condition_values_needed = 1
     @conditions << condition
   end
 

--- a/src/api/test/functional/search_controller_test.rb
+++ b/src/api/test/functional/search_controller_test.rb
@@ -132,6 +132,17 @@ class SearchControllerTest < ActionDispatch::IntegrationTest
     assert_xml_tag content: "#&lt;NoMethodError: undefined method `[]' for nil:NilClass&gt;"
   end
 
+  def test_xpath_not_method
+    login_Iggy
+    # not correct, but we used to support it :/
+    get "/search/package", match: '[not(@name)]'
+    assert_response :success
+    # this needs to work as well osc#205)
+    get "/search/package", match: '[not(@name="home:Iggy")]'
+    assert_response :success
+    assert_xml_tag tag: 'collection'
+  end
+
   def test_xpath_search_for_person_or_group
     # used by maintenance people
     login_Iggy


### PR DESCRIPTION
We have to support the old incorrect way nevertheless since too many
tools are using it. osc#205