### PR TITLE
[api] export request creator via xml

### DIFF
--- a/docs/api/api/request.rng
+++ b/docs/api/api/request.rng
@@ -202,6 +202,11 @@
           <data type="string" />
         </attribute>
       </optional>
+      <optional>
+        <attribute name="creator">
+          <data type="string" />
+        </attribute>
+      </optional>
       <interleave>
         <oneOrMore>
           <ref name="request-action-element" />

--- a/docs/api/api/request.xml
+++ b/docs/api/api/request.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<request id="12">
+<request id="12" creator="Iggy">
  <priority>moderate</priority>
  <action type="submit">
    <source project="home:kfreitag" package="kraft" rev="23" />

--- a/src/api/app/models/bs_request.rb
+++ b/src/api/app/models/bs_request.rb
@@ -157,6 +157,8 @@ class BsRequest < ActiveRecord::Base
     else
       theid = nil
     end
+    # we will set it our own according to the user
+    hashed.delete('creator')
 
     if hashed['submit'] && hashed['type'] == 'submit'
       # old style, convert to new style on the fly
@@ -258,7 +260,7 @@ class BsRequest < ActiveRecord::Base
 
   def render_xml(opts = {})
     builder = Nokogiri::XML::Builder.new
-    builder.request(id: self.number) do |r|
+    builder.request(id: self.number, creator: self.creator) do |r|
       self.bs_request_actions.each do |action|
         action.render_xml(r)
       end

--- a/src/api/lib/xpath_engine.rb
+++ b/src/api/lib/xpath_engine.rb
@@ -220,6 +220,7 @@ class XpathEngine
       },
       'requests' => {
         '@id' => { :cpart => 'bs_requests.number' },
+        '@creator' => { :cpart => 'bs_requests.creator' },
         'state/@name' => { :cpart => 'bs_requests.state' },
         'state/@who' => { :cpart => 'bs_requests.commenter' },
         'state/@when' => { :cpart => 'bs_requests.updated_at' },

--- a/src/api/test/functional/group_request_test.rb
+++ b/src/api/test/functional/group_request_test.rb
@@ -38,6 +38,7 @@ class GroupRequestTest < ActionDispatch::IntegrationTest
 
     # 2 is new, so the group is new too
     assert_equal({"id"          => id,
+                  "creator"     => "king",
                   "action"      => {"type" => "group", "grouped" => {"id" => "2"}},
                   "state"       =>
                                    {"name" => "new", "who" => "king", "when" => "2010-07-12T00:00:00", "comment" => {}},
@@ -64,6 +65,7 @@ class GroupRequestTest < ActionDispatch::IntegrationTest
 
     # state didn't change, only history
     assert_equal({"id"          => id,
+                  "creator"     => "king",
                   "action"      => {"type" => "group", "grouped" => [{"id" => "2"}, {"id" => adi}]},
                   "state"       =>
                                    {"name" => "new", "who" => "king", "when" => "2010-07-12T00:00:00", "comment" => {}},
@@ -80,6 +82,7 @@ class GroupRequestTest < ActionDispatch::IntegrationTest
 
     # state changed to review
     assert_equal({"id"          => id,
+                  "creator"     => "king",
                   "action"      => {"type" => "group", "grouped" => [{"id" => "2"}, {"id" => adi}, {"id" => withr}]},
                   "state"       =>
                                    {"name" => "review", "who" => "king", "when" => "2010-07-12T00:00:02", "comment" => {}},
@@ -90,6 +93,7 @@ class GroupRequestTest < ActionDispatch::IntegrationTest
     get "/request/#{adi}"
     assert_response :success
     assert_equal({"id"          => adi,
+                  "creator"     => "king",
                   "action"      => {
                     "type"   => "add_role",
                     "target" => {"project" => "Apache", "package" => "apache2"},
@@ -112,6 +116,7 @@ class GroupRequestTest < ActionDispatch::IntegrationTest
     get "/request/#{adi}?withhistory=1"
     assert_response :success
     assert_equal({"id"          => adi,
+                  "creator"     => "king",
                   "action"      => {
                     "type"   => "add_role",
                     "target" => {"project" => "Apache", "package" => "apache2"},
@@ -218,6 +223,7 @@ class GroupRequestTest < ActionDispatch::IntegrationTest
     get "/request/#{id}"
     assert_response :success
     assert_equal({"id"          => id,
+                  "creator"     => "king",
                   "action"      => {"type"=>"group", "grouped"=>[{"id"=>"2"}, {"id"=>withr}]},
                   "state"       => {
                     "name"    => "review",
@@ -237,6 +243,7 @@ class GroupRequestTest < ActionDispatch::IntegrationTest
     get "/request/#{id}"
     assert_response :success
     assert_equal({"id"          => id,
+                  "creator"     => "king",
                   "action"      => {"type"=>"group", "grouped"=>[{"id"=>"2"}, {"id"=>withr2}]},
                   "state"       => {
                     "name"    => "review",

--- a/src/api/test/functional/request_controller_test.rb
+++ b/src/api/test/functional/request_controller_test.rb
@@ -1,5 +1,6 @@
 # encoding: UTF-8
 # rubocop:disable Metrics/LineLength
+# rubocop:disable Metrics/ClassLength
 require File.expand_path(File.dirname(__FILE__) + '/..') + '/test_helper'
 require 'request_controller'
 
@@ -278,6 +279,7 @@ XML
     assert_xml_tag(:tag => 'history', :attributes => { who: 'Iggy' })
     assert_equal({
                    'id'          => id,
+                   'creator'     => "Iggy",
                    'action'      => {
                      'type'       => 'submit',
                      'source'     => { 'project' => 'home:Iggy:branches:home:Iggy', 'package' => 'NEW_PACKAGE' },
@@ -933,6 +935,7 @@ XML
     assert_xml_tag(:parent => { tag: 'review', attributes: { state: 'new', by_user: 'tom' } }, :tag => 'comment', :content => 'reopen2')
     node = Xmlhash.parse(@response.body)
     assert_equal({ 'id'      => "#{id}",
+                   'creator' => 'Iggy',
                    'action'  => {
                      'type'   => 'add_role',
                      'target' => { 'project' => 'home:Iggy', 'package' => 'TestPack' },
@@ -1140,6 +1143,13 @@ XML
     assert_xml_tag(:tag => 'review', :attributes => { by_user: 'adrian' })
     assert_xml_tag(:tag => 'review', :attributes => { by_user: 'tom' })
     assert_xml_tag(:tag => 'review', :attributes => { by_group: 'test_group' })
+  end
+
+  def test_search_by_creator
+    login_Iggy
+    get '/search/request', :match => "@creator='Iggy'"
+    assert_response :success
+    assert_xml_tag(tag: "request", :attributes => {id: "6", creator: "Iggy"})
   end
 
   def test_search_and_involved_requests
@@ -3249,6 +3259,7 @@ XML
     get "/request/#{id}?withhistory=1"
     node = Xmlhash.parse(@response.body)
     assert_equal({ 'id'      => id,
+                   'creator' => "Iggy",
                    'action'  =>
                                 { 'type'   => 'add_role',
                                   'target' => { 'project' => 'home:Iggy:fordecline' },
@@ -3272,6 +3283,7 @@ XML
     get "/request/#{id}?withhistory=1"
     node = Xmlhash.parse(@response.body)
     assert_equal({ 'id'      => id,
+                   'creator' => "Iggy",
                    'action'  =>
                                 { 'type'   => 'add_role',
                                   'target' => { 'project' => 'home:Iggy:fordecline' },

--- a/src/api/test/unit/bs_request_test.rb
+++ b/src/api/test/unit/bs_request_test.rb
@@ -95,7 +95,7 @@ class BsRequestTest < ActiveSupport::TestCase
 
   def test_parse_bigger
     xml = <<eos
-<request id="1027">
+<request id="1027" creator="Iggy">
   <action type="submit">
     <source project="home:Iggy" package="TestPack" rev="1"/>
     <target project="kde4" package="mypackage"/>

--- a/src/backend/BSXML.pm
+++ b/src/backend/BSXML.pm
@@ -1141,6 +1141,7 @@ our $pattern_id = [
 our $request = [
     'request' =>
 	'id',
+	'creator',
 	'type',		# obsolete, still here to handle OBS pre-1.5 requests
 	'key',		# cache key, not really in request
 	'retryafter',	# timed out waiting for a key change


### PR DESCRIPTION
We have the request creator in the database, but our clients need to figure
it our manualy, so let's export it.

Exporting as own element would be nicer, but would break old osc versions

added search interface to xpath search