### PR TITLE
[webui] $(document).ready(fn) -> $(fn)

### DIFF
--- a/src/api/app/assets/javascripts/webui/application.js
+++ b/src/api/app/assets/javascripts/webui/application.js
@@ -246,7 +246,7 @@ $(document).ajaxSend(function (event, request, settings) {
 var URL_REGEX = /\b((?:[a-z][\w-]+:(?:\/{1,3}|[a-z0-9%])|www\d{0,3}[.]|[a-z0-9.\-]+[.][a-z]{2,4}\/)(?:[^\s()<>]+|\(([^\s()<>]+|(\([^\s()<>]+\)))*\))+(?:\(([^\s()<>]+|(\([^\s()<>]+\)))*\)|[^\s`!()\[\]{};:'".,<>?«»“”‘’]))/gi;
 
 // jquery.dataTables setup:
-$(document).ready(function () {
+$(function () {
     $.extend($.fn.dataTable.defaults, {
         'iDisplayLength': 25,
     });

--- a/src/api/app/assets/javascripts/webui/application/bento/global-navigation.js
+++ b/src/api/app/assets/javascripts/webui/application/bento/global-navigation.js
@@ -5,7 +5,7 @@ var position_menu = function(button_id, menu_id) {
     $('#' + menu_id).offset({left:left,top:top});
 };
 
-$(document).ready(function() {
+$(function() {
 
     if (!global_navigation_data) return;
 

--- a/src/api/app/assets/javascripts/webui/application/bento/script.js
+++ b/src/api/app/assets/javascripts/webui/application/bento/script.js
@@ -1,4 +1,4 @@
-$(document).ready(function() {
+$(function() {
   
   // == Login Form UI Actions ================================================
   

--- a/src/api/app/views/webui/comment/_expand_collapse.js.erb
+++ b/src/api/app/views/webui/comment/_expand_collapse.js.erb
@@ -1,4 +1,4 @@
-$(document).ready(function(){
+$(function(){
 	$("#toggle_replies_of_<%=comment_id%>").click(function(ev){
 		$(<%="reply_of_comment_#{comment_id}"%>).toggle();
 		var imgTag = $(this).children("img");

--- a/src/api/app/views/webui/groups/edit.html.erb
+++ b/src/api/app/views/webui/groups/edit.html.erb
@@ -12,7 +12,7 @@
 <% end %>
 
 <%= javascript_tag do %>
-  $(document).ready(function() {
+  $(function() {
     $("#members").tokenInput("<%= url_for :controller => 'user', :action => 'tokens' %>" ,{
                 theme: "facebook",
                 tokenValue: "name",

--- a/src/api/app/views/webui/groups/index.html.erb
+++ b/src/api/app/views/webui/groups/index.html.erb
@@ -43,7 +43,7 @@
 
 
 <%= javascript_tag do %>
-    $(document).ready(function() {
+    $(function() {
     <% if @groups.length > 0 %>
         $('#group_table').dataTable();
     <% end %>

--- a/src/api/app/views/webui/groups/new.html.erb
+++ b/src/api/app/views/webui/groups/new.html.erb
@@ -15,7 +15,7 @@
   <% end %>
 
 <%= javascript_tag do %>
-  $(document).ready(function() {
+  $(function() {
     $("#members").tokenInput("<%= url_for :controller => 'user', :action => 'tokens' %>" ,{
                 theme: "facebook",
                 tokenValue: "name"

--- a/src/api/app/views/webui/home/index.html.erb
+++ b/src/api/app/views/webui/home/index.html.erb
@@ -221,7 +221,7 @@
    </div>
   </div>
     <%= javascript_tag do %>
-    $(document).ready(function() {
+    $(function() {
       $('#open_patchinfos-table').dataTable();
     });
   <% end %>

--- a/src/api/app/views/webui/package/edit.html.erb
+++ b/src/api/app/views/webui/package/edit.html.erb
@@ -23,7 +23,7 @@
 <% end %>
 
 <%= javascript_tag do %>
-  $(document).ready(function() {
+  $(function() {
     var toggleLoading = function () { $('#spinner').toggle(); };
     $('#import-spec-link')
       .bind('ajax:loading', toggleLoading)

--- a/src/api/app/views/webui/project/maintained_projects.html.erb
+++ b/src/api/app/views/webui/project/maintained_projects.html.erb
@@ -29,7 +29,7 @@
     </tbody>
   </table>
   <%= javascript_tag do %>
-    $(document).ready(function() {
+    $(function() {
       $('#maintained_projects_table').dataTable({
         "bSort": false,
       });

--- a/src/api/app/views/webui/user/index.html.haml
+++ b/src/api/app/views/webui/user/index.html.haml
@@ -34,7 +34,7 @@
         There are no users configured
 
 :javascript
-  $(document).ready(function() {
+  $(function() {
     if ("#{@users.count}" !== "0")
       $('#user_table').dataTable();
   });

--- a/src/api/app/views/webui/user/show.html.erb
+++ b/src/api/app/views/webui/user/show.html.erb
@@ -211,7 +211,7 @@
    </div>
   </div>
     <%= javascript_tag do %>
-    $(document).ready(function() {
+    $(function() {
       $('#open_patchinfos-table').dataTable();
     });
   <% end %>


### PR DESCRIPTION
Per jQuery blog, `$(fn)` has always been supported, and will be the only supported handler from jQuery 3.0 onwards. [Source](https://jquery.com/upgrade-guide/3.0/#deprecated-document-ready-handlers-other-than-jquery-function).

This commit replaces all instances of code with the supported handler.