### PR TITLE
Don't split GPG signature on multiple lines

### DIFF
--- a/src/backend/bs_mkarchrepo
+++ b/src/backend/bs_mkarchrepo
@@ -90,7 +90,8 @@ for my $pkg (@pkgs) {
   my $sig = readstr("$dir/$pkg.sig", 1);
   if ($sig && length($sig) <= 16384) {
     $sig = encode_base64($sig, '');
-    $vars->{'pgpsig'} = [ $sig =~ /(.{1,64})/g ];
+    # pacman expects the whole signature on a single line
+    $vars->{'pgpsig'} = [ $sig ];
   }
   
   my $d = "$vars->{'pkgname'}->[0]-$vars->{'pkgver'}->[0]";


### PR DESCRIPTION
This breaks pacman check for signature read and verification.