### PR TITLE
[ci] Fix flaky flag test

### DIFF
--- a/src/api/spec/support/shared_examples/features/flags_tables.rb
+++ b/src/api/spec/support/shared_examples/features/flags_tables.rb
@@ -36,7 +36,9 @@ RSpec.shared_examples "a flag table" do
     expect(subject.find("tr:first-child th:nth-child(2)").text).to eq("All")
     architectures.each do |arch|
       pos = architectures.index(arch) + 3
-      expect(subject.find("tr:first-child th:nth-child(#{pos})").text).to eq(arch)
+      # There might be delays when rendering the table. Thus including the
+      # text entry to the selector.
+      subject.find("tr:first-child th:nth-child(#{pos})", text: arch)
     end
   end
 


### PR DESCRIPTION
This will add the expected element text to the capybara selector, which makes the
selector more strict and causes capybara to wait till javascript rendering of the
flag table is finished.

--------------

1) Projects repositories tab flags tables #flag_table_publish behaves like a flag table has correct table headers (arch labels)
     Failure/Error: expect(subject.find("tr:first-child th:nth-child(#{pos})").text).to eq(arch)

       expected: "i586"

            got: "x86_64"

       (compared using ==)

     Shared Example Group: "a flag table" called from ./spec/support/shared_examples/features/flags_tables.rb:112
     Shared Example Group: "tests for sections with flag tables" called from ./spec/features/webui/projects_spec.rb:174
     # ./spec/support/shared_examples/features/flags_tables.rb:39:in `block (3 levels) in <top (required)>'
     # ./spec/support/shared_examples/features/flags_tables.rb:37:in `each'
     # ./spec/support/shared_examples/features/flags_tables.rb:37:in `block (2 levels) in <top (required)>'