### PR TITLE
[api][webui] Use default limit defined by backend for xml size(s)

### DIFF
--- a/src/api/app/mixins/request_source_diff.rb
+++ b/src/api/app/mixins/request_source_diff.rb
@@ -74,7 +74,6 @@ module RequestSourceDiff
         end
 
         path = Package.source_path(action.source_project, spkg)
-        query[:filelimit] = 10000
 
         if !provided_in_other_action && !action.updatelink
           # do show the same diff multiple times, so just diff unexpanded so we see possible link changes instead

--- a/src/api/app/models/bs_request_action_delete.rb
+++ b/src/api/app/models/bs_request_action_delete.rb
@@ -43,7 +43,7 @@ class BsRequestActionDelete < BsRequestAction
   def sourcediff(opts = {})
     if self.target_package
       path = Package.source_path self.target_project, self.target_package
-      query = {'cmd' => 'diff', expand: 1, filelimit: 0, rev: 0}
+      query = {'cmd' => 'diff', expand: 1, rev: 0}
       query[:view] = 'xml' if opts[:view] == 'xml' # Request unified diff in full XML view
       return BsRequestAction.get_package_diff(path, query)
     elsif self.target_repository


### PR DESCRIPTION
* Use the same limits for all kind of request actions
* Use backend defaults

default filelimit: 200 (lines of code)
default tarlimit: 16000 (lines of code of the tardiff)