### PR TITLE
[webui] prevent duplicate comments

### DIFF
--- a/src/api/app/assets/javascripts/webui/application/comment.js
+++ b/src/api/app/assets/javascripts/webui/application/comment.js
@@ -1,3 +1,5 @@
+// Expand the comment textarea to fit the text
+// as it's being typed.
 function sz(t) {
     var a = t.value.split('\n');
     var b = 1;
@@ -8,10 +10,15 @@ function sz(t) {
     if (b > t.rows) t.rows = b;
 }
 
-function setup_comment_toggles() {
+function setup_comment_page() {
+    // setup toggle events
     $('.togglable_comment').click(function () {
         var toggleid = $(this).data("toggle");
         $("#" + toggleid).toggle();
     });
-}
 
+    // prevent duplicate comment submissions
+    $('.comment_new').submit(function() {
+        $(this).find('input[type="submit"]').prop('disabled', true);
+    });
+}

--- a/src/api/app/assets/stylesheets/webui/application/bento/base.scss
+++ b/src/api/app/assets/stylesheets/webui/application/bento/base.scss
@@ -260,7 +260,7 @@ img.alignright { padding-right: 10px; display:inline; }
 .clear-right{clear:right;}
 .no-shadow{box-shadow:none;-webkit-box-shadow:none;-moz-box-shadow:none;}
 .button, button, input[type="submit"]{border-radius:5px;-moz-border-radius:5px;-webkit-border-radius:5px;-khtml-border-radius:5px;border-color:#999;background:#DDD image-url('images/gradient-medium-short.png') repeat-x scroll 0 0;color:#555;}
-.button:hover, button:hover, input[type="submit"]:hover{background-color:#eee;border-color:#666;color:#069;cursor:pointer;}
+.button:hover, button:hover, input[type="submit"]:not([disabled]):hover{background-color:#eee;border-color:#666;color:#069;cursor:pointer;}
 form *[disabled="disabled"], form *[disabled=""], form *[disabled="true"]{background-color:#f6f6f6;border-color:#ccc;color:#aaa;}
 .main .button, .main button, .main input[type="submit"]{background:#9c0 image-url('images/gradient-light-short-green.png') repeat-x scroll 0 -5px;color:#fcfcfc;}
 .main .button:hover, .main button:hover, .main input[type="submit"]:hover{border-color:#069;cursor:pointer;color:#fff;}

--- a/src/api/app/views/webui/comment/_reply.html.erb
+++ b/src/api/app/views/webui/comment/_reply.html.erb
@@ -1,4 +1,4 @@
-<div id="<%="reply_form_of_#{comment.id}"%>" style="display: none;">
+<div class="comment_new" id="<%="reply_form_of_#{comment.id}"%>" style="display: none;">
   <%= save_comment_form do %>
     <p>
       <%= text_area_tag 'body', nil, size: '80x1', onkeyup: 'sz(this);', onclick: 'sz(this);', id: "reply_body_#{comment.id}", placeholder: 'Comment Text', required: true %>

--- a/src/api/app/views/webui/comment/_show.html.erb
+++ b/src/api/app/views/webui/comment/_show.html.erb
@@ -15,5 +15,5 @@
 </div>
 
 <% content_for :ready_function do %>
-  setup_comment_toggles();
+  setup_comment_page();
 <% end %>


### PR DESCRIPTION
I got tired of accidentally pressing that button twice :sweat_smile: 

This takes care of both `new comments` and `comment replies` (their parent containers now share a classname). 

I also documented what `sz` does as it is kind of cryptic otherwise.

Please review :smile: