### PR TITLE
[webui] make active menu titles more readable

### DIFF
--- a/src/api/app/assets/stylesheets/webui/application/bento/base.scss
+++ b/src/api/app/assets/stylesheets/webui/application/bento/base.scss
@@ -93,7 +93,7 @@ blockquote{border-left:5px solid #690;color:#666;font-style:italic;}
 #global-navigation li:first-child{border-left-width:1px;}
 #global-navigation li{float:left;border-right-width:1px;}
 #global-navigation li a{color:#fefefe;display:block;height:100%;margin:0 15px;padding-top:7px;text-decoration:none;width:100%;}
-#global-navigation li a:hover, #global-navigation li a:focus{color:#690;}
+#global-navigation li:not(.selected) a:hover{color:#690;}
 #global-favorites{float:right !important;border-left-width:1px;}
 #header-logo{float:left;margin-top:1px;margin-right:25px;}
 #header #global-search-form{float:right;margin-top:4px;position:relative;}


### PR DESCRIPTION
This fixes the color issue (green on green :mask:) when the main dropdown menus are active.


----

Screenshots:

# Before

![before](https://cloud.githubusercontent.com/assets/126848/16708860/aebcba42-45ce-11e6-8c01-f885789bbae6.png)


## After

![after](https://cloud.githubusercontent.com/assets/126848/16708861/b42db076-45ce-11e6-9abb-da45f19aa0a9.png)
