### PR TITLE
[ci] Fix syntax error in request controller test

### DIFF
--- a/src/api/test/functional/request_controller_test.rb
+++ b/src/api/test/functional/request_controller_test.rb
@@ -84,10 +84,10 @@ XML
     # Should respond with a collection of 2 requests
     assert_select 'collection request', 2
 
-    # Request 1000 should have exactly 4 review elements
-    assert_select 'request[id=1000] review', 4
+    # Request 1000 should have exactly 2 review elements
+    assert_select "request[id='1000'] review", 2
     # Request 4 should have exactly 1 review elements
-    assert_select 'request[id=4] review', 1
+    assert_select "request[id='4'] review", 1
 
     # Should show all data belonging to each request
     assert_select 'collection', matches: 2 do


### PR DESCRIPTION
This caused a SyntaxError when running tests in rails 5 environment.
Besides the syntax also the test was wrong and should expect 2 instead of
4 review elements.

----------------

test_get_requests_collection                                   ERROR (34.99s)
Nokogiri::CSS::SyntaxError:         Nokogiri::CSS::SyntaxError: unexpected '1000' after 'equal'
            test/functional/request_controller_test.rb:88:in `test_get_requests_collection'
            test/test_helper.rb:123:in `block in __run'
            test/test_helper.rb:123:in `map'
            test/test_helper.rb:123:in `__run'