### PR TITLE
[ci] Fix syntax error in request controller test and search controlle…

### DIFF
--- a/src/api/test/functional/request_controller_test.rb
+++ b/src/api/test/functional/request_controller_test.rb
@@ -84,10 +84,10 @@ XML
     # Should respond with a collection of 2 requests
     assert_select 'collection request', 2
 
-    # Request 1000 should have exactly 4 review elements
-    assert_select 'request[id=1000] review', 4
+    # Request 1000 should have exactly 2 review elements
+    assert_select "request[id='1000'] review", 2
     # Request 4 should have exactly 1 review elements
-    assert_select 'request[id=4] review', 1
+    assert_select "request[id='4'] review", 1
 
     # Should show all data belonging to each request
     assert_select 'collection', matches: 2 do

--- a/src/api/test/functional/search_controller_test.rb
+++ b/src/api/test/functional/search_controller_test.rb
@@ -383,7 +383,7 @@ class SearchControllerTest < ActionDispatch::IntegrationTest
     # Should respond with a collection of 1 requests
     assert_select 'collection request', 1
     # Request 1000 should have exactly 4 review elements
-    assert_select 'request[id=1000] review', 4
+    assert_select "request[id='1000'] review", 4
 
     # Should show all data belonging to each request
     assert_select 'collection', matches: 2 do
@@ -402,7 +402,7 @@ class SearchControllerTest < ActionDispatch::IntegrationTest
         assert_select 'description', 'want to see his reaction'
       end
       # XPath search is not expected to find requests of groups adrian belongs to
-      assert_select 'request[id=4]', false
+      assert_select "request[id='4']", false
     end
   end
 


### PR DESCRIPTION
…r test

This caused a SyntaxError when running tests in rails 5 environment.
Besides the syntax also the test was wrong and should expect 2 instead of
4 review elements.

----------------

test_get_requests_collection                                   ERROR (34.99s)
Nokogiri::CSS::SyntaxError:         Nokogiri::CSS::SyntaxError: unexpected '1000' after 'equal'
            test/functional/request_controller_test.rb:88:in `test_get_requests_collection'
            test/test_helper.rb:123:in `block in __run'
            test/test_helper.rb:123:in `map'
            test/test_helper.rb:123:in `__run'