### PR TITLE
[ci] Fix flaky request test

### DIFF
--- a/src/api/spec/features/webui/requests_spec.rb
+++ b/src/api/spec/features/webui/requests_spec.rb
@@ -137,7 +137,7 @@ RSpec.feature "Requests", :type => :feature, :js => true do
       click_link 'Submit package'
       fill_in 'targetproject', with: target_project.name
       fill_in 'description', with: 'Testing superseeding'
-      check("supersede_request_numbers#{bs_request.id}")
+      check("supersede_request_numbers#{bs_request.number}")
       click_button 'Ok'
       within '#flash-messages' do
         click_link 'submit request'


### PR DESCRIPTION
We used the wrong attribute , id instead of number, for identifying the
supersede checkbox. Since id and number are usually equal in our tests
this just failed seldomly.