### PR TITLE
[webui] Fix display of accept_at in the past

### DIFF
--- a/src/api/app/views/webui/request/show.html.erb
+++ b/src/api/app/views/webui/request/show.html.erb
@@ -49,8 +49,13 @@
               by <%= link_to @superseded_by, number: @superseded_by %></li>
         <% end %>
         <% if @accept_at -%>
-            <li><%= sprite_tag('exclamation', title: '') %> This request will get accepted in
+            <li><%= sprite_tag('exclamation', title: '') %>
+               <% if Time.now > Time.parse(@accept_at.to_s) %>
+                 This request will get accepted automatically when it enters the 'new' state!
+              <% else %>
+               This request will get accepted in
               <%= distance_of_time_in_words(Time.now, Time.parse(@accept_at.to_s)) %> automatically!
+              <% end %>
             </li>
         <% end -%>
         <% @other_open_reviews.each do |review| %>


### PR DESCRIPTION
Requests with accept_at set are not accepted with pending reviews.
If the accept_at date was in the past, the web UI would show a wrong
time difference in natural language.