### PR TITLE
[ci] rails 5: Fix faulty syntax when visiting pages

### DIFF
--- a/src/api/test/functional/webui/package_controller_test.rb
+++ b/src/api/test/functional/webui/package_controller_test.rb
@@ -153,7 +153,7 @@ class Webui::PackageControllerTest < Webui::IntegrationTest
   def test_succesful_comment_creation
     use_js
     login_Iggy
-    visit root_path + '/package/show/home:Iggy/TestPack'
+    visit '/package/show/home:Iggy/TestPack'
     # rubocop:disable Metrics/LineLength
     fill_comment "Write some http://link.com\n\nand some other\n\n* Markdown\n* markup\n\nReferencing sr#23, bco#24, fate#25, @_nobody_, @a-dashed-user and @Iggy. https://anotherlink.com"
     # rubocop:enable Metrics/LineLength
@@ -175,7 +175,7 @@ class Webui::PackageControllerTest < Webui::IntegrationTest
   def test_another_succesful_comment_creation
     use_js
     login_Iggy
-    visit root_path + '/package/show?project=home:Iggy&package=TestPack'
+    visit '/package/show?project=home:Iggy&package=TestPack'
     # @Iggy works at the very beginning and requests are case insensitive
     fill_comment "@Iggy likes to mention himself and to write request#23 with capital 'R', like Request#23."
     within('div.thread_level_0') do
@@ -194,7 +194,7 @@ class Webui::PackageControllerTest < Webui::IntegrationTest
   def test_succesful_reply_comment_creation
     use_js
     login_Iggy
-    visit root_path + '/package/show/BaseDistro3/pack2'
+    visit '/package/show/BaseDistro3/pack2'
 
     find(:id, 'reply_link_id_201').click
     fill_in 'reply_body_201', with: 'Comment Body'

--- a/src/api/test/functional/webui/project_controller_test.rb
+++ b/src/api/test/functional/webui/project_controller_test.rb
@@ -372,7 +372,7 @@ XML
     result = Nokogiri::XML(meta_xml)
     assert_select result, "project", name: "home:adrian" do
       assert_select "title", "My Home Project", 1
-      assert_select "description[not(text())]", 1, "Should have an empty description"
+      assert_select "description", { count: 1, text: "" }, "Should have an empty description"
       assert_select "person", userid: "adrian", role: "maintainer"
     end
     assert_equal 3, result.xpath("/project/child::*").count, "Should not have additional nodes."
@@ -395,7 +395,7 @@ XML
     result = Nokogiri::XML(meta_xml)
     assert_select result, "project", name: "home:adrian" do
       assert_select "title", "My Home Project", 1
-      assert_select "description[not(text())]", 1, "Should have an empty description"
+      assert_select "description", { count: 1, text: "" }, "Should have an empty description"
       assert_select "person", userid: "adrian", role: "maintainer"
     end
     assert_equal 3, result.xpath("/project/child::*").count, "Should not have additional nodes."

--- a/src/api/test/functional/webui/search_controller_test.rb
+++ b/src/api/test/functional/webui/search_controller_test.rb
@@ -88,13 +88,13 @@ class Webui::SearchControllerTest < Webui::IntegrationTest
     visit search_path
     validate_search_page
 
-    visit root_path + '/search?search_text=basedistro'
+    visit '/search?search_text=basedistro'
     page.must_have_text(/Base.* contains official released updates/)
 
-    visit root_path + '/search?search_text=basedistro3'
+    visit '/search?search_text=basedistro3'
     page.must_have_text(/Base.* distro without update project/)
 
-    visit root_path + '/search?search_text=kdebase'
+    visit '/search?search_text=kdebase'
     page.must_have_link 'kdebase'
   end
 


### PR DESCRIPTION
This was causing some test failures running with rails 5, aka. newer
capybara version.