### PR TITLE
[webui] Order arch headers for package flag tables

### DIFF
--- a/src/api/app/controllers/webui/package_controller.rb
+++ b/src/api/app/controllers/webui/package_controller.rb
@@ -1066,7 +1066,7 @@ class Webui::PackageController < Webui::WebuiController
     @debuginfo = @package.get_flags('debuginfo')
     @publish = @package.get_flags('publish')
     @useforbuild = @package.get_flags('useforbuild')
-    @architectures = @package.project.architectures.uniq
+    @architectures = @package.project.architectures.reorder('name').uniq
   end
 
   private


### PR DESCRIPTION
Since 8dfd6f67e10b5b4ca44869a81cb0f55fe99d996d OBS orders the architectures by
name. This requires the arch headers of each table to be ordered as well,
which wasn't the case for the package flags.