### PR TITLE
[ci] Add NyanUnicornFormatter for RSpec

### DIFF
--- a/src/api/Gemfile
+++ b/src/api/Gemfile
@@ -96,6 +96,8 @@ group :test do
   gem 'mocha', '> 0.13.0', require: false
   # for testing common Rails functionality with simple one-liners
   gem 'shoulda-matchers', '~> 3.1'
+  # for having fun while waiting for Rspec to finish
+  gem 'nyan-cat-formatter'
 end
 
 # Gems used only during development not required in production environments by default.

--- a/src/api/Gemfile.lock
+++ b/src/api/Gemfile.lock
@@ -166,6 +166,8 @@ GEM
       mini_portile2 (~> 2.0.0)
     nokogumbo (1.4.1)
       nokogiri
+    nyan-cat-formatter (0.11)
+      rspec (>= 2.99, >= 2.14.2, < 4)
     parser (2.2.3.0)
       ast (>= 1.1, < 3.0)
     pkg-config (1.1.6)
@@ -226,6 +228,10 @@ GEM
       mime-types (>= 1.16, < 3.0)
       netrc (~> 0.7)
     riddle (1.5.12)
+    rspec (3.4.0)
+      rspec-core (~> 3.4.0)
+      rspec-expectations (~> 3.4.0)
+      rspec-mocks (~> 3.4.0)
     rspec-core (3.4.2)
       rspec-support (~> 3.4.0)
     rspec-expectations (3.4.0)
@@ -374,6 +380,7 @@ DEPENDENCIES
   mocha (> 0.13.0)
   mysql2
   nokogiri (~> 1.6.7)
+  nyan-cat-formatter
   poltergeist (>= 1.4)
   pry (>= 0.9.12)
   pundit

--- a/src/api/spec/nyan_unicorn_formatter.rb
+++ b/src/api/spec/nyan_unicorn_formatter.rb
@@ -1,0 +1,59 @@
+# -*- coding: utf-8 -*-
+require 'nyan_cat_formatter'
+
+class NyanUnicornFormatter < NyanCatFormatter
+  RSpec::Core::Formatters.register self, :example_started, :example_passed, :example_pending, :example_failed, :start_dump, :start
+
+  # Determine which Ascii Nyan Cat to display. If tests are complete,
+  # Nyan Cat goes to sleep. If there are failing or pending examples,
+  # Nyan Cat is concerned.
+  #
+  # @return [String] Nyan Cat
+  def nyan_cat
+    if self.failed_or_pending? && self.finished?
+      ascii_cat('x')[@color_index%2].join("\n")
+    elsif self.failed_or_pending?
+      ascii_cat('o')[@color_index%2].join("\n")
+    elsif self.finished?
+      ascii_cat('-')[@color_index%2].join("\n")
+    else
+      ascii_cat('·')[@color_index%2].join("\n")
+    end
+  end
+
+  def progress_lines
+    last_length = 1
+    [
+      nyan_trail.split("\n").each_with_index.inject([]) do |result, (trail, index)|
+        last_length = format("%s", "#{scoreboard[index]}/#{@example_count}:").length unless scoreboard[index].nil?
+        value =  scoreboard[index].nil? ? ' ' * (last_length / 2) : "#{scoreboard[index]}/#{@example_count}:"
+        result << format("%s %s", value, trail)
+      end
+    ].flatten
+  end
+
+  # Ascii version of Nyan cat. Two cats in the array allow Nyan to animate running.
+  #
+  # @param o [String] Nyan's eye
+  # @return [Array] Nyan cats
+  def ascii_cat(o = '.')
+    [
+      [
+        'OBS·         / ',
+        "*·*       sS#{o}\\ ",
+        '   .--,__sS/\,)',
+        ' S(  /_ \  )   ',
+        'Ss ||    ||    ',
+        "   ''    ''    "
+      ],
+      [
+        'OBS*         / ',
+        "·*·       sS#{o}\\ ",
+        '   .--,__sS/\,)',
+        ' S(  /_ \  )   ',
+        'Ss \\\\    \\\\    ',
+        "    ''    ''   "
+      ]
+    ]
+  end
+end

--- a/src/api/spec/spec_helper.rb
+++ b/src/api/spec/spec_helper.rb
@@ -71,6 +71,11 @@ RSpec.configure do |config|
   # test failures related to randomization by passing the same `--seed` value
   # as the one that triggered the failure.
   Kernel.srand config.seed
+
+  # Custom formatter, but not in Travis-CI
+  unless ENV['TRAVIS']
+    config.formatter = 'NyanUnicornFormatter'
+  end
 end
 
 # We never want the backend to autostart itself...


### PR DESCRIPTION
Adding nyan-cat-formatter and override it to have our custom formatter. Just for fun :smile_cat: 
Avoiding to use it at TRAVIS to not break the log there.

This is how it looks 
![nyan_unicorn](https://cloud.githubusercontent.com/assets/11314634/17021011/487c6298-4f45-11e6-98fa-b17e08d1c278.gif)
