### PR TITLE
Fix gem version for jquery-datatables-rails to avoid incompatibilities

### DIFF
--- a/src/api/Gemfile
+++ b/src/api/Gemfile
@@ -138,7 +138,7 @@ group :assets do
   # to use sass in the asset pipeline
   gem 'sass-rails', '~> 5.0.1'
   # assets for jQuery DataTables
-  gem 'jquery-datatables-rails'
+  gem 'jquery-datatables-rails', '= 1.12.2'
   # assets for the text editor
   gem 'codemirror-rails'
   # assets for jQuery tokeninput

--- a/src/api/Gemfile.lock
+++ b/src/api/Gemfile.lock
@@ -363,7 +363,7 @@ DEPENDENCIES
   font-awesome-rails
   haml
   hoptoad_notifier (~> 2.3)
-  jquery-datatables-rails
+  jquery-datatables-rails (= 1.12.2)
   jquery-rails
   jquery-ui-rails (~> 4.2.1)
   kaminari


### PR DESCRIPTION
This fixes  https://github.com/openSUSE/open-build-service/issues/1978  and closes https://github.com/openSUSE/open-build-service/pull/1979

To avoid future issues because changes in the version of DataTables packed inside the jquery-datatables-rails gem.