### PR TITLE
Drop webconsole gem

### DIFF
--- a/src/api/Gemfile
+++ b/src/api/Gemfile
@@ -104,8 +104,6 @@ group :development do
   gem 'unicorn-rails' # webrick won't work
   # for calling single testd
   gem 'single_test'
-  # as debugging tool in the default error page
-  gem 'web-console', '~> 2.0'
 end
 
 group :development, :test do

--- a/src/api/Gemfile.lock
+++ b/src/api/Gemfile.lock
@@ -46,8 +46,6 @@ GEM
     ast (2.1.0)
     astrolabe (1.3.1)
       parser (~> 2.2)
-    binding_of_caller (0.7.2)
-      debug_inspector (>= 0.0.1)
     builder (3.2.2)
     capybara (2.5.0)
       mime-types (>= 1.16)
@@ -85,7 +83,6 @@ GEM
     daemons (1.2.3)
     dalli (2.7.4)
     database_cleaner (1.5.1)
-    debug_inspector (0.0.2)
     delayed_job (4.1.1)
       activesupport (>= 3.0, < 5.0)
     delayed_job_active_record (4.1.0)
@@ -317,11 +314,6 @@ GEM
       rack
       unicorn
     vcr (3.0.1)
-    web-console (2.2.1)
-      activemodel (>= 4.0)
-      binding_of_caller (>= 0.7.2)
-      railties (>= 4.0)
-      sprockets-rails (>= 2.0, < 4.0)
     webmock (1.21.0)
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
@@ -399,7 +391,6 @@ DEPENDENCIES
   uglifier (>= 1.2.2)
   unicorn-rails
   vcr
-  web-console (~> 2.0)
   webmock (>= 1.18.0)
   xmlhash (>= 1.3.6)
   yajl-ruby


### PR DESCRIPTION
because nobody is using it. As discussed on the ML to reduce number of gems.