### PR TITLE
[api] defined OBS:PlannedReleaseDate attribute

### DIFF
--- a/src/api/db/attribute_descriptions.rb
+++ b/src/api/db/attribute_descriptions.rb
@@ -23,6 +23,7 @@ def update_all_attrib_type_descriptions
     "QualityCategory"                 => "Use this attrbitue to classify the usability of a project. This gets used by the user package search for instance.",
     "IncidentPriority"                => "A numeric value which defines the importance of this incident project.",
     "EmbargoDate"                     => "A timestamp until outgoing requests can not get accepted.",
+    "PlannedReleaseDate"              => "A timestamp for the planned release date of an incident.",
     "MakeOriginOlder"                 => "Initialize packages by making the build results newer then updated ones"
   }
 

--- a/src/api/db/migrate/20160808135426_planned_release_attribute.rb
+++ b/src/api/db/migrate/20160808135426_planned_release_attribute.rb
@@ -1,0 +1,20 @@
+require_relative '../attribute_descriptions'
+
+class PlannedReleaseAttribute  < ActiveRecord::Migration
+  def self.up
+    ans = AttribNamespace.find_by_name "OBS"
+
+    AttribTypeModifiableBy.reset_column_information
+
+    at=AttribType.create( :attrib_namespace => ans, :name => "PlannedReleaseDate", :value_count=>1 )
+
+    role = Role.find_by_title("maintainer")
+    AttribTypeModifiableBy.create(role_id: role.id, attrib_type_id: at.id)
+
+    update_all_attrib_type_descriptions
+  end
+
+  def self.down
+    AttribType.find_by_namespace_and_name("OBS", "PlannedReleaseDate").delete()
+  end
+end

--- a/src/api/db/structure.sql
+++ b/src/api/db/structure.sql
@@ -1682,6 +1682,8 @@ INSERT INTO schema_migrations (version) VALUES ('20160518105300');
 
 INSERT INTO schema_migrations (version) VALUES ('20160610105300');
 
+INSERT INTO schema_migrations (version) VALUES ('20160808135426');
+
 INSERT INTO schema_migrations (version) VALUES ('21');
 
 INSERT INTO schema_migrations (version) VALUES ('22');


### PR DESCRIPTION
Similar to OBS:EmbargoDate. For now only for use for external tools,
but we should also support it in webui and osc incident lists to highlight
incidents which past their planned release date.

belongs to FATE#319971