### PR TITLE
[api] fix request diffing special case

### DIFF
--- a/src/api/app/mixins/request_source_diff.rb
+++ b/src/api/app/mixins/request_source_diff.rb
@@ -56,8 +56,7 @@ module RequestSourceDiff
         # maintenance release targets will have a base link
         tprj = Project.get_by_name(@target_project)
         if tprj && tprj.is_maintenance_release?
-          @target_package.gsub!(/\.[^\.]*$/, '')
-          tpkg = tprj.find_package(@target_package)
+          tpkg = tprj.find_package(@target_package.gsub(/\.[^\.]*$/, ''))
           if tpkg
             if tpkg.project.is_maintenance_release? && tpkg.is_local_link?
               # use package container from former incident update


### PR DESCRIPTION
* maintenance_release request which is not accepted
* contains a patchinfo in a container using a dot in the name
* first time submission

sorry, no testcase for this yet ...