### PR TITLE
[webui] Remove extract_user before_filter from ApidocsCtrl

### DIFF
--- a/src/api/app/controllers/webui/apidocs_controller.rb
+++ b/src/api/app/controllers/webui/apidocs_controller.rb
@@ -1,7 +1,4 @@
 class Webui::ApidocsController < Webui::WebuiController
-  # Apidocs is insensitive static information, no login needed therefore
-  skip_before_filter :extract_user
-
   def index
     filename = File.expand_path(CONFIG['apidocs_location']) + "/index.html"
     if File.exist?(filename)


### PR DESCRIPTION
because ApidocsCtrl inherits from WebuiController which does not implement extract_user.
This will raise an exception with Rails 5.