### PR TITLE
[api] Adapt Illegal Encoding test

### DIFF
--- a/src/api/lib/opensuse/backend.rb
+++ b/src/api/lib/opensuse/backend.rb
@@ -4,10 +4,6 @@ require 'api_exception'
 
 module Suse
   class Backend
-    class IllegalEncodingError < APIException
-      setup 'invalid_text_encoding'
-    end
-
     @source_host = CONFIG['source_host']
     @source_port = CONFIG['source_port']
 
@@ -133,9 +129,6 @@ module Suse
           if hash.has_key?(key)
             str = hash[key].to_s
             str.toutf8
-            unless str.isutf8
-              raise IllegalEncodingError.new("Illegal encoded parameter")
-            end
 
             if hash[key].nil?
               # just a boolean argument ?

--- a/src/api/test/functional/source_controller_test.rb
+++ b/src/api/test/functional/source_controller_test.rb
@@ -117,7 +117,6 @@ class SourceControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
     put '/source/kde4/kdelibs/DUMMY?comment=illegalchar%96%96asd', 'NOTWORKING'
     assert_response 400
-    assert_xml_tag :tag => 'status', :attributes => { :code => 'invalid_text_encoding' }
     delete '/source/kde4/kdelibs/DUMMY'
     assert_response :success
   end


### PR DESCRIPTION
because Rails raises now an ActionController::BadRequest error, so raising an ApiException is not necessary anymore.
See Rails commit 59ab2d1ee5995d9ea27ca60e92576518c1898c59.