### PR TITLE
[webui] make use of 'sprite_tag' for build status icon

### DIFF
--- a/src/api/app/helpers/webui/buildstatus_helper.rb
+++ b/src/api/app/helpers/webui/buildstatus_helper.rb
@@ -22,7 +22,7 @@ module Webui::BuildstatusHelper
   # rubocop:enable Style/AlignHash
 
   def get_package_status_description(status)
-    PACKAGE_STATUS_LIST[status] || "status explanation not found"
+    PACKAGE_STATUS_LIST[status.to_s] || "status explanation not found"
   end
 
   def arch_repo_table_cell(repo, arch, package_name)
@@ -54,6 +54,6 @@ module Webui::BuildstatusHelper
     end
 
     status_desc = get_package_status_description(status['code'])
-    result += " <img title='#{status_desc}' class='icons-help' alt='#{status_desc}' src='/assets/s.gif' /></td>".html_safe
+    result += " #{sprite_tag 'help', title: status_desc}</td>".html_safe
   end
 end

--- a/src/api/app/views/webui/project/_buildstatus.html.erb
+++ b/src/api/app/views/webui/project/_buildstatus.html.erb
@@ -33,7 +33,7 @@
                   </td>
                   <td>
                     <% counts.each do |code, count| %>
-                        <img title="<%= get_package_status_description(code) %>" class="icons-help" alt="<%= get_package_status_description(code) %>" src='/assets/s.gif' /><br />
+                      <%= sprite_tag "help", title: get_package_status_description(code) %><br />
                     <% end %>
                   </td>
                 </tr>


### PR DESCRIPTION
This fixes an issue that the icon was not correctly rendered in production mode.