### PR TITLE
[webui] Catch UnknownObject exception in repositories_controller

### DIFF
--- a/src/api/app/controllers/webui/repositories_controller.rb
+++ b/src/api/app/controllers/webui/repositories_controller.rb
@@ -275,7 +275,14 @@ class Webui::RepositoriesController < Webui::WebuiController
 
   def find_repository_parent
     if params[:package]
-      @main_object = @package = Package.get_by_project_and_name(@project.to_param, params[:package], use_source: false, follow_project_links: true)
+      # FIXME: Handle APIException different, this is just c&p from packages_controller
+      begin
+        @main_object = @package = Package.get_by_project_and_name(@project.to_param, params[:package], use_source: false, follow_project_links: true)
+      rescue APIException
+        flash[:error] = "Package \"#{params[:package]}\" not found in project \"#{params[:project]}\""
+        redirect_to project_show_path(project: @project, nextstatus: 404)
+        return
+      end
     else
       @main_object = @project
     end


### PR DESCRIPTION
just c&p from require_package before filter in packages_controller.
Missed while introducing repositories_controller in #1968.