### PR TITLE
[webui] Remove flag actions from before filters

### DIFF
--- a/src/api/app/controllers/webui/package_controller.rb
+++ b/src/api/app/controllers/webui/package_controller.rb
@@ -21,8 +21,7 @@ class Webui::PackageController < Webui::WebuiController
                                         :save_group, :remove_role, :view_file,
                                         :abort_build, :trigger_rebuild,
                                         :wipe_binaries, :buildresult, :rpmlint_result, :rpmlint_log, :meta,
-                                        :save_meta, :attributes, :edit, :create_flag, :toggle_flag, :remove_flag,
-                                        :import_spec, :files, :comments]
+                                        :save_meta, :attributes, :edit, :import_spec, :files, :comments]
 
   before_filter :require_package, :only => [:show, :linking_packages, :dependency, :binary, :binaries,
                                             :requests, :statistics, :commit, :revisions, :submit_request_dialog,
@@ -32,8 +31,7 @@ class Webui::PackageController < Webui::WebuiController
                                             :save_group, :remove_role, :view_file,
                                             :abort_build, :trigger_rebuild,
                                             :wipe_binaries, :buildresult, :rpmlint_result, :rpmlint_log, :meta,
-                                            :attributes, :edit, :create_flag, :toggle_flag, :remove_flag,
-                                            :import_spec, :files, :comments, :users,
+                                            :attributes, :edit, :import_spec, :files, :comments, :users,
                                             :save_comment]
 
   # make sure it's after the require_, it requires both

--- a/src/api/app/controllers/webui/project_controller.rb
+++ b/src/api/app/controllers/webui/project_controller.rb
@@ -18,7 +18,7 @@ class Webui::ProjectController < Webui::WebuiController
                                      :show, :linking_projects, :add_person, :add_group, :buildresult, :delete_dialog,
                                      :destroy, :remove_path_from_target, :rebuild_time, :packages_simple,
                                      :requests, :save, :monitor, :toggle_watch, :meta,
-                                     :prjconf, :create_flag, :toggle_flag, :remove_flag, :edit, :save_comment, :edit_comment,
+                                     :prjconf, :edit, :save_comment, :edit_comment,
                                      :status, :maintained_projects,
                                      :add_maintained_project_dialog, :add_maintained_project, :remove_maintained_project,
                                      :maintenance_incidents, :unlock_dialog, :unlock, :save_person, :save_group, :remove_role,


### PR DESCRIPTION
create_flag, :toggle_flag, :remove_flag actions moved to repositories_controller.