### PR TITLE
[webui] Fix parent projects table

### DIFF
--- a/src/api/app/views/webui/project/subprojects.html.haml
+++ b/src/api/app/views/webui/project/subprojects.html.haml
@@ -40,7 +40,7 @@
     #create_subproject.hidden
       = render partial: 'form', locals: { project: Project.new, configuration: @configuration, ns: @project.name }
 
-- if @subprojects.present?
+- if @subprojects.present? || @parentprojects.present?
   - content_for :ready_function do
     setup_subprojects_tables();
 - content_for :ready_function do


### PR DESCRIPTION
That caused that parent projects table got only dataTable-fied, if
there was a subproject. This fixes it.