### PR TITLE
[backend] bs_publish: unpublished hook added

### DIFF
--- a/src/backend/bs_publish
+++ b/src/backend/bs_publish
@@ -2135,6 +2135,23 @@ publishprog_done:
     }
   }
 
+  # support for regex usage in $BSConfig::unpublishedhook
+  my $unpublish_prp = $prp;
+  if ($BSConfig::unpublishedhook_use_regex || $BSConfig::unpublishedhook_use_regex) {
+    for my $key (sort {$b cmp $a} keys %{$BSConfig::unpublishedhook}) {
+      if ($prp =~ /^$key/) {
+        $unpublish_prp = $key;
+        last;
+      }
+    }
+  }
+  if ($BSConfig::unpublishedhook && $BSConfig::unpublishedhook->{$unpublish_prp}) {
+    my $hook = $BSConfig::unpublishedhook->{$unpublish_prp};
+    $hook = [ $hook ] unless ref $hook;
+    print "    calling unpublished hook @$hook\n";
+    qsystem(@$hook, $prp, $extrep, @db_deleted) && warn("    @$hook failed: $?\n");
+  }
+
   # support for regex usage in $BSConfig::publishedhook
   my $publish_prp = $prp;
   if ($BSConfig::publishedhook_use_regex || $BSConfig::publishedhook_use_regex) {


### PR DESCRIPTION
This patch add an unpublish hook to the publisher, very similar to the publish hook, but set as arguments
to the script the package versions which are removed from the repository.  It runs before the publish hook.
The patch should apply on master, 2.7 and 2.6, please also add it to 2.6 and 2.7.
A section for the OBS reference guide already exist in the [obs-docu clone](https://github.com/b1-systems/obs-docu/tree/AdminGuide) together with documentation of the publish hook.