### PR TITLE
bs_repserver: Fix different xml results return the same md5sum.

### DIFF
--- a/src/backend/bs_repserver
+++ b/src/backend/bs_repserver
@@ -2272,6 +2272,7 @@ sub getresult {
       }
       next if %code && !$code{$code};
       $state .= "$packid\0$code\0";
+      $state .= "$sl->{'state'}\0$sl->{'code'}\0";
       if ($cgi->{'summary'}) {
         $sum{$code} = ($sum{$code} || 0) + 1;
       } else {


### PR DESCRIPTION
The resultlist node contains an entry 'state' which holds the calculated
md5sum for the corresponding message.

The 'code' and 'state' of the result nodes have not been taken into account
when calculating the md5sum for resultlist 'state'. Thus a client watching
those entries may wait forever, e.g. using ``osc.core.get_package_results``
which uses the oldstate HTTP-GET parameter. Using this parameter the server
will not send any new responses until the md5sum has changed.
With this patch the corresponding 'code' and 'state' entries will be
appended to the $state variable which will be used for the md5_hex calculation.