### PR TITLE
[webui][api] Fix commit_opts omitted by store

### DIFF
--- a/src/api/app/models/project.rb
+++ b/src/api/app/models/project.rb
@@ -878,7 +878,7 @@ class Project < ActiveRecord::Base
   end
 
   def store(opts = {})
-    self.commit_opts = opts if opts
+    self.commit_opts = opts if opts.present?
     self.transaction do
       save!
       write_to_backend

--- a/src/api/spec/models/project_spec.rb
+++ b/src/api/spec/models/project_spec.rb
@@ -326,4 +326,26 @@ RSpec.describe Project do
       end
     end
   end
+
+  describe "#store" do
+    before do
+      project.stubs(:save!).returns(true)
+      project.stubs(:write_to_backend).returns(true)
+      project.commit_opts = { comment: 'the comment' }
+    end
+
+    context "without commit_opts parameter" do
+      it "does not overwrite the commit_opts" do
+        project.store
+        expect(project.commit_opts).to eq({ comment: 'the comment' })
+      end
+    end
+
+    context "with commit_opts parameter" do
+      it "does overwrite the commit_opts" do
+        project.store({ comment: 'a new comment'})
+        expect(project.commit_opts).to eq({ comment: 'a new comment' })
+      end
+    end
+  end
 end


### PR DESCRIPTION
Project#store always omitted the commit_opts set previously to the function call.
because the check for the empty hash always returned true.

While project.store({ options }) worked, setting the options in two steps did not:
project.commit_opts = { options }
project.store

This fix brings the store function in accordance with the destroy function.