### PR TITLE
[ci] Update rspec-rails to 3.4.2

### DIFF
--- a/src/api/Gemfile
+++ b/src/api/Gemfile
@@ -106,7 +106,7 @@ end
 
 group :development, :test do
   # as testing framework
-  gem 'rspec-rails', '~> 3.4.0'
+  gem 'rspec-rails', '~> 3.4.2'
   # for fixtures
   gem 'factory_girl_rails'
   # for mocking the backend

--- a/src/api/Gemfile.lock
+++ b/src/api/Gemfile.lock
@@ -229,7 +229,7 @@ GEM
     rspec-mocks (3.4.1)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.4.0)
-    rspec-rails (3.4.0)
+    rspec-rails (3.4.2)
       actionpack (>= 3.0, < 4.3)
       activesupport (>= 3.0, < 4.3)
       railties (>= 3.0, < 4.3)
@@ -372,7 +372,7 @@ DEPENDENCIES
   rdoc
   redcarpet
   responders (~> 2.0)
-  rspec-rails (~> 3.4.0)
+  rspec-rails (~> 3.4.2)
   rubocop
   ruby-ldap
   sanitize


### PR DESCRIPTION
to fix Undefined Method  in Tests.
See https://github.com/rspec/rspec-rails/issues/1532.