### PR TITLE
[backend] die in cpio_sender if sysread returns undef

### DIFF
--- a/src/backend/BSHTTP.pm
+++ b/src/backend/BSHTTP.pm
@@ -376,6 +376,7 @@ sub cpio_sender {
       my $r = 0;
       while(1) {
 	$r = sysread(F, $data, $l > 8192 ? 8192 : $l, length($data)) if $l;
+	die "Error while reading file $file->{filename}: $!\n" if ! defined($r);
 	$data .= $pad if $r == $l;
 	swrite($sock, $data, $param->{'chunked'});
 	$data = '';


### PR DESCRIPTION
reading should not continue if we got badblocks

@mlschroe  - Please review