### PR TITLE
Refactor logging

### DIFF
--- a/dist/obs-server.spec
+++ b/dist/obs-server.spec
@@ -246,6 +246,7 @@ Summary:        The Open Build Service -- source service daemon
 Group:          Productivity/Networking/Web/Utilities
 %endif
 # Our default services, used in osc and webui
+Requires:	obs-common
 Recommends:     obs-service-download_url
 Recommends:     obs-service-verify_file
 

--- a/dist/t/0000-check_users_and_group.ts
+++ b/dist/t/0000-check_users_and_group.ts
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+export BASH_TAP_ROOT=$(dirname $0)
+
+
+. $(dirname $0)/bash-tap-bootstrap
+
+
+plan tests 3
+
+
+for group in obsrun;do
+  result_group=$(getent group $group | cut -f1 -d:)
+  is "$result_group" "$group" "Checking group $group"
+done
+
+for user in obsrun obsservicerun;do
+  result_user=$(getent passwd $user | cut -f1 -d:)
+  is "$result_user" "$user" "Checking user $user"
+done

--- a/dist/t/spec/features/0040_prepare_package_building_spec.rb
+++ b/dist/t/spec/features/0040_prepare_package_building_spec.rb
@@ -58,11 +58,9 @@ RSpec.describe "Preparation for building package obs-build" do
     click_link('build targets')
     expect(page).to have_content("openSUSE distributions")
     check('repo_openSUSE_Tumbleweed')
-    check('repo_openSUSE_Leap_42.1')
-    find('input[id="submitrepos"]').click #Add selected repositories
-    expect(page).to have_content("Successfully added repositories")
-    expect(page).to have_content("openSUSE_Leap_42.1 (x86_64)")
-    expect(page).to have_content("openSUSE_Tumbleweed (i586, x86_64)")
+    expect(page).to have_content("Successfully added repository 'openSUSE_Tumbleweed'")
+    check('repo_openSUSE_Leap_42_1')
+    expect(page).to have_content("Successfully added repository 'openSUSE_Leap_42.1'")
   end
 
   it "should be able to disable x86_64 in Tumbleweed" do

--- a/src/backend/BSSched/Lookat.pm
+++ b/src/backend/BSSched/Lookat.pm
@@ -221,8 +221,8 @@ sub lookatprp {
     @$lookat_med = grep {$_ ne $prp} @$lookat_med;
   }
   delete $gctx->{'nextmed'}->{$prp};
-  print BSUtil::isotime().": looking at $lookattype prio $prp";
-  print " (".@$lookat_high."/".@$lookat_med."/".@$lookat_low."/".(keys %$lookat_next)."/".@{$gctx->{'prps'}}.")\n";
+  BSUtil::printlog("looking at $lookattype prio $prp".
+    " (".@$lookat_high."/".@$lookat_med."/".@$lookat_low."/".(keys %$lookat_next)."/".@{$gctx->{'prps'}}.")");
 }
 
 1;

--- a/src/backend/BSServer.pm
+++ b/src/backend/BSServer.pm
@@ -216,7 +216,7 @@ sub server {
   my $idle_next = 0;
 
   if ($conf->{'serverstatus'}) {
-    open(STA, '>', $conf->{'serverstatus'});
+    open(STA, '>', $conf->{'serverstatus'}) || die "Could not open $conf->{'serverstatus'}: $!";
   }
 
   while (1) {

--- a/src/backend/BSServer.pm
+++ b/src/backend/BSServer.pm
@@ -359,9 +359,9 @@ sub server {
 sub msg {
   my $peer = ($BSServer::request || {})->{'peer'};
   if (defined($peer)) {
-    print BSUtil::isotime().": $peer: $_[0]\n";
+    BSUtil::printlog("$peer: $_[0]");
   } else {
-    print BSUtil::isotime().": $_[0]\n";
+    BSUtil::printlog($_[0]);
   }
 }
 

--- a/src/backend/BSStdRunner.pm
+++ b/src/backend/BSStdRunner.pm
@@ -221,7 +221,7 @@ sub run {
     }
   }
 
-  BSUtil::printlog("$name started\n");
+  BSUtil::printlog("$name started");
   $conf->{'run'}->($conf);
 }
 

--- a/src/backend/BSStdRunner.pm
+++ b/src/backend/BSStdRunner.pm
@@ -59,7 +59,7 @@ sub fc_exit {
   my ($conf, $fc) = @_;
   unlink($fc);
   close($conf->{'runlock'});
-  print BSUtil::isotime().": $conf->{'name'} exiting...\n";
+  BSUtil::printlog("$conf->{'name'} exiting...");
   exit(0);
 }
 
@@ -67,7 +67,7 @@ sub fc_restart {
   my ($conf, $fc) = @_;
   unlink($fc);
   close($conf->{'runlock'});
-  print BSUtil::isotime().": $conf->{'name'} restarting...\n";
+  BSUtil::printlog("$conf->{'name'} restarting...");
   exec($0);
   die("$0: $!\n");
 }
@@ -221,7 +221,7 @@ sub run {
     }
   }
 
-  print BSUtil::isotime().": $name started\n";
+  BSUtil::printlog("$name started\n");
   $conf->{'run'}->($conf);
 }
 

--- a/src/backend/BSStdServer.pm
+++ b/src/backend/BSStdServer.pm
@@ -86,8 +86,14 @@ sub authorize {
 
 sub dispatch {
   my ($conf, $req) = @_;
-  my @lt = localtime(time);
-  my $msg = "$req->{'action'} $req->{'path'}?$req->{'query'}";
+
+  my $msg = sprintf("%s %-17s %s %s %s",
+    $req->{'action'},
+    "($req->{'peer'})",
+    $req->{'path'},
+    ($req->{'query'}) ? "?$req->{'query'}" : '',
+    ($isajax) ? " (AJAX)" : '',
+  );
   BSServer::setstatus(2, $msg) if $conf->{'serverstatus'};
   $msg .= " (AJAX)" if $isajax;
   BSUtil::printlog($msg);

--- a/src/backend/BSStdServer.pm
+++ b/src/backend/BSStdServer.pm
@@ -89,9 +89,8 @@ sub dispatch {
   my @lt = localtime(time);
   my $msg = "$req->{'action'} $req->{'path'}?$req->{'query'}";
   BSServer::setstatus(2, $msg) if $conf->{'serverstatus'};
-  $msg = BSUtil::isotime()." [$$]: $msg";
   $msg .= " (AJAX)" if $isajax;
-  print "$msg\n";
+  BSUtil::printlog($msg);
   if ($isajax) {
     BSServerEvents::cloneconnect("OK\n", "Content-Type: text/plain");
   }

--- a/src/backend/BSUtil.pm
+++ b/src/backend/BSUtil.pm
@@ -724,7 +724,6 @@ sub identical {
 
 sub printlog {
   my ($msg) = @_;
-  $msg =~ s/\n$//s;
   my @ltim = localtime(time);
   printf "%04d-%02d-%02d %02d:%02d:%02d: %-7s - %s\n",
     $ltim[5] + 1900,  # year

--- a/src/backend/BSUtil.pm
+++ b/src/backend/BSUtil.pm
@@ -1,5 +1,6 @@
 #
 # Copyright (c) 2006, 2007 Michael Schroeder, Novell Inc.
+# Copyright (c) 2016  Frank Schreiner, SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 2 as
@@ -16,11 +17,14 @@
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA
 #
 ################################################################
-#
-# collection of useful functions
-#
 
 package BSUtil;
+
+=head1 NAME
+
+BSUtil - collection of useful functions
+
+=cut
 
 require Exporter;
 @ISA = qw(Exporter);
@@ -36,6 +40,10 @@ use IO::Handle;
 use strict;
 
 our $fdatasync_before_rename;
+
+=head1 FUNCTIONS / METHODS
+
+=cut
 
 sub set_fdatasync_before_rename {
   $fdatasync_before_rename = 1;
@@ -171,8 +179,13 @@ sub mkdir_p {
   return 1;
 }
 
-# calls mkdir_p and changes ownership of the created directory to the
-# supplied user and group if provided.
+=head2 mkdir_p_chown - create directory recursivly and change ownership
+
+ calls mkdir_p and changes ownership of the created directory to the
+ supplied user and group if provided.
+
+=cut
+
 sub mkdir_p_chown {
   my ($dir, $user, $group) = @_;
 
@@ -466,12 +479,17 @@ sub lockcreatexml {
 
 # XXX: does that really belong here?
 #
-# Algorithm:
-# each enable/disable has a score:
-# +1 if it's a disable
-# +2 if the arch matches
-# +4 if the repo matches
-#
+
+=head2 enabled
+
+ Algorithm:
+ each enable/disable has a score:
+ +1 if it's a disable
+ +2 if the arch matches
+ +4 if the repo matches
+
+=cut
+
 sub enabled {
   my ($repoid, $disen, $default, $arch) = @_;
 
@@ -721,6 +739,14 @@ sub identical {
   }
   return 1;
 }
+
+=head2 printlog - print unified log messages
+
+ BSUtil::printlog($message);
+
+FORMAT: "YYYY-MM-DD hh:mm:ss [$pid] - $message"
+
+=cut
 
 sub printlog {
   my ($msg) = @_;

--- a/src/backend/BSUtil.pm
+++ b/src/backend/BSUtil.pm
@@ -464,12 +464,6 @@ sub lockcreatexml {
   return 1;
 }
 
-sub isotime {
-  my ($t) = @_;
-  my @lt = localtime($t || time());
-  return sprintf "%04d-%02d-%02d %02d:%02d:%02d", $lt[5] + 1900, $lt[4] + 1, @lt[3,2,1,0];
-}
-
 # XXX: does that really belong here?
 #
 # Algorithm:
@@ -732,8 +726,13 @@ sub printlog {
   my ($msg) = @_;
   $msg =~ s/\n$//s;
   my @ltim = localtime(time);
-  my $msgtm = sprintf "%04d-%02d-%02d %02d:%02d:%02d:", $ltim[5] + 1900, $ltim[4] + 1, @ltim[3,2,1,0];
-  print "$msgtm $msg\n";
+  printf "%04d-%02d-%02d %02d:%02d:%02d: %-7s - %s\n",
+    $ltim[5] + 1900,  # year
+    $ltim[4] + 1,     # month
+    @ltim[3,2,1,0],   # day, hour, minute, second
+    "[$$]",	      # [pid] (gets space padded right)
+    $msg
+    ;
 }
 
 

--- a/src/backend/BSUtil.pm
+++ b/src/backend/BSUtil.pm
@@ -728,4 +728,13 @@ sub identical {
   return 1;
 }
 
+sub printlog {
+  my ($msg) = @_;
+  $msg =~ s/\n$//s;
+  my @ltim = localtime(time);
+  my $msgtm = sprintf "%04d-%02d-%02d %02d:%02d:%02d:", $ltim[5] + 1900, $ltim[4] + 1, @ltim[3,2,1,0];
+  print "$msgtm $msg\n";
+}
+
+
 1;

--- a/src/backend/bs_dispatch
+++ b/src/backend/bs_dispatch
@@ -186,14 +186,6 @@ my %lastbuild;	# last time a job was build in that prpa
 
 my %masterdispatched;	# we masterdispatched those, prpa => [ starttime, ... ]
 
-sub printlog {
-  my ($msg) = @_;
-  $msg =~ s/\n$//s;
-  my @ltim = localtime(time);
-  my $msgtm = sprintf "%04d-%02d-%02d %02d:%02d:%02d:", $ltim[5] + 1900, $ltim[4] + 1, @ltim[3,2,1,0];
-  print "$msgtm $msg\n";
-}
-
 sub checkbadhost {
   my (@attempts) = @_;
   my %hosts;
@@ -211,12 +203,12 @@ sub assignjob {
   my ($job, $idlename, $arch) = @_;
   local *F;
 
-  printlog("assignjob $arch/$job -> $idlename");
+  BSUtil::printlog("assignjob $arch/$job -> $idlename");
   my $jobstatus = {
     'code' => 'dispatching',
   };
   if (!BSUtil::lockcreatexml(\*F, "$jobsdir/$arch/.dispatch.$$", "$jobsdir/$arch/$job:status", $jobstatus, $BSXML::jobstatus)) {
-    printlog("job lock failed!");
+    BSUtil::printlog("job lock failed!");
     return 'badjob';
   }
 
@@ -224,7 +216,7 @@ sub assignjob {
   if (! -e "$jobsdir/$arch/$job") {
     unlink("$jobsdir/$arch/$job:status");
     close F;
-    printlog("job disappered!");
+    BSUtil::printlog("job disappered!");
     return 'badjob';
   }
 
@@ -251,7 +243,7 @@ sub assignjob {
   if (!$worker) {
     unlink("$jobsdir/$arch/$job:status");
     close F;
-    printlog("worker is gone!");
+    BSUtil::printlog("worker is gone!");
     return undef;
   }
   $worker->{'hardware'}->{'nativeonly'} = undef if $worker->{'hardware'} && exists($worker->{'hardware'}->{'nativeonly'});
@@ -277,7 +269,7 @@ sub assignjob {
   };
   if ($@) {
     my $err = $@;
-    printlog("rpc error: $@");
+    BSUtil::printlog("rpc error: $@");
     unlink("$jobsdir/$arch/$job:status");
     close F;
     if ($err =~ /cannot build anything/) {
@@ -363,7 +355,7 @@ sub staleness {
   }
   my $ret = ($lb - $newestsrcchange) / (($now - $lb) * 40 + 5000000);
   $ret = 0 if $ret < 0;
-  #printlog("staleness $prpa: $ret");
+  #BSUtil::printlog("staleness $prpa: $ret");
   return $ret;
 }
 
@@ -717,7 +709,7 @@ sub dispatchslave {
       $synced++;
       delete $syncedjobs{$arch}->{$job};
     }
-    printlog("$arch: added $added, deleted $deleted") if $added || $deleted;
+    BSUtil::printlog("$arch: added $added, deleted $deleted") if $added || $deleted;
     # adapt the load
     my $load = {};
     for my $job (keys %locked) {
@@ -741,7 +733,7 @@ sub dispatchslave {
   # upload the mdload from time to time
   my $now = time();
   if (!$lastmdloadsync || $lastmdloadsync + 120 < $now) {
-    printlog("uploading load to master dispatcher");
+    BSUtil::printlog("uploading load to master dispatcher");
     $lastmdloadsync = $now;
     my $load = BSUtil::retrieve("$jobsdir/load", 1) || {};
     for my $prpa (keys %$load) {
@@ -787,7 +779,7 @@ sub forwardevents {
       if ($ev->{'type'} eq 'built') {
         # resend to rep server
       } elsif ($ev->{'type'} eq 'badhost') {
-        printlog("badhost event: $ev->{'project'}/$ev->{'package'}/$ev->{'arch'}/$ev->{'worker'}");
+        BSUtil::printlog("badhost event: $ev->{'project'}/$ev->{'package'}/$ev->{'arch'}/$ev->{'worker'}");
 	if ($BSConfig::masterdispatcher && $BSConfig::masterdispatcher ne $BSConfig::reposerver) {
           sendeventtoserver($BSConfig::masterdispatcher, $ev) unless $ev->{'package'} eq '_deltas';	# XXX
 	} else {
@@ -818,7 +810,7 @@ sub filechecks {
     BSUtil::store("$rundir/bs_dispatch.state.new", "$rundir/bs_dispatch.state", $state);
     close(RUNLOCK);
     unlink("$rundir/bs_dispatch.exit");
-    printlog("exiting...");
+    BSUtil::printlog("exiting...");
     exit(0);
   }
   if (-e "$rundir/bs_dispatch.restart") {
@@ -830,7 +822,7 @@ sub filechecks {
     BSUtil::store("$rundir/bs_dispatch.state.new", "$rundir/bs_dispatch.state", $state);
     close(RUNLOCK);
     unlink("$rundir/bs_dispatch.restart");
-    printlog("restarting...");
+    BSUtil::printlog("restarting...");
     exec($0);
     die("$0: $!\n");
   }
@@ -842,11 +834,11 @@ sub filechecks {
     };
     BSUtil::store("$rundir/bs_dispatch.state.new", "$rundir/bs_dispatch.state", $state);
     unlink("$rundir/bs_dispatch.dumpstate");
-    printlog("dumped state to $rundir/bs_dispatch.state ...");
+    BSUtil::printlog("dumped state to $rundir/bs_dispatch.state ...");
   }
   if (-e "$rundir/bs_dispatch.dropbadhosts") {
     unlink("$rundir/bs_dispatch.dropbadhosts");
-    printlog("removing all badhost entries...");
+    BSUtil::printlog("removing all badhost entries...");
     %badhost = ();
   }
 }
@@ -854,7 +846,7 @@ sub filechecks {
 $| = 1;
 $SIG{'PIPE'} = 'IGNORE';
 BSUtil::restartexit($ARGV[0], 'dispatcher', "$rundir/bs_dispatch");
-printlog("starting build service dispatcher");
+BSUtil::printlog("starting build service dispatcher");
 
 # get lock
 mkdir_p($rundir);
@@ -867,7 +859,7 @@ my $dispatchprios_project;
 my $dispatchprios_id = '';
 
 if (-s "$rundir/bs_dispatch.state") {
-  printlog("reading old state...");
+  BSUtil::printlog("reading old state...");
   my $state = BSUtil::retrieve("$rundir/bs_dispatch.state", 2);
   unlink("$rundir/bs_dispatch.state");
   %infocache = %{$state->{'infocache'}} if $state && $state->{'infocache'};
@@ -876,7 +868,7 @@ if (-s "$rundir/bs_dispatch.state") {
 }
 
 if ($BSConfig::masterdispatcher && $BSConfig::masterdispatcher ne $BSConfig::reposerver) {
-  printlog("running is dispatch slave mode");
+  BSUtil::printlog("running is dispatch slave mode");
 }
 
 if ($testmode) {
@@ -1017,7 +1009,7 @@ while (1) {
       push @{$idlearch{$_}}, $idle;
     }
   }
-  #printlog("finding jobs");
+  #BSUtil::printlog("finding jobs");
   my %jobs;
   my %maybesrcchange;
   my @archs = sort keys %idlearch;
@@ -1042,7 +1034,7 @@ while (1) {
 	# deltete orphaned marker
 	for (@{$crossarchs{$crossarch}}) {
 	  next if $cj{$_};
-	  printlog("  - deleting orphaned cross marker $arch/$_:${crossarch}:cross");
+	  BSUtil::printlog("  - deleting orphaned cross marker $arch/$_:${crossarch}:cross");
 	  unlink("$jobsdir/$arch/$_:${crossarch}:cross");
 	}
 	push @archs, $crossarch;
@@ -1122,7 +1114,7 @@ while (1) {
     }
   }
 
-  #printlog("calculating scales");
+  #BSUtil::printlog("calculating scales");
   my %scales;
   my @jobprpas = keys %jobs;
   for my $prpa (@jobprpas) {
@@ -1152,7 +1144,7 @@ while (1) {
   }
 
   if (1) {
-    #printlog("writing debug data");
+    #BSUtil::printlog("writing debug data");
     # write debug data
     if (@jobprpas) {
       BSUtil::store("$rundir/.dispatch.data", "$rundir/dispatch.data", {
@@ -1169,7 +1161,7 @@ while (1) {
   my %extraload;
 
   # the following helps a lot...
-  #printlog("fast src change load adapt");
+  #BSUtil::printlog("fast src change load adapt");
   for my $prpa (@jobprpas) {
     next if $maybesrcchange{$prpa};
     my $arch = (split('/', $prpa))[2];
@@ -1181,7 +1173,7 @@ while (1) {
 
   @jobprpas = sort {$scales{$a} * $load->{$a} <=> $scales{$b} * $load->{$b}} @jobprpas;
 
-  #printlog("assigning jobs");
+  #BSUtil::printlog("assigning jobs");
   while (@jobprpas) {
     my $prpa = shift @jobprpas;
     my $arch = (split('/', $prpa))[2];
@@ -1297,7 +1289,7 @@ while (1) {
 	  push @idle, $idle if grep {$idlehost =~ /^$_/} @$BSConfig::powerhosts;
 	}
         if (!@idle) {
-          printlog("job can not be assigned on $arch due to lack of powerhosts: $job");
+          BSUtil::printlog("job can not be assigned on $arch due to lack of powerhosts: $job");
           next;
         }
       }
@@ -1314,7 +1306,7 @@ while (1) {
 	}
 	$constraints = $constraintscache{$constraintsmd5};
 	if (!ref($constraints)) {
-	  printlog("job has bad constraints file: $job");
+	  BSUtil::printlog("job has bad constraints file: $job");
 	  next;
 	}
 	if (ref($constraints) eq 'ARRAY') {
@@ -1431,12 +1423,12 @@ while (1) {
   forwardevents();
 
   sleep(1) unless $assigned;
-  printlog("assigned $assigned jobs") if $assigned;
+  BSUtil::printlog("assigned $assigned jobs") if $assigned;
   if (%badhost) {
     my $now = time();
     for (keys %badhost) {
       if ($badhost{$_} + 24*3600 < $now) {
-        printlog("deleting badhost $_");
+        BSUtil::printlog("deleting badhost $_");
         delete $badhost{$_};
       }
     }

--- a/src/backend/bs_dodup
+++ b/src/backend/bs_dodup
@@ -421,7 +421,7 @@ sub scan_dodsdir {
 sub check_dod {
   my ($doddata) = @_;
   my $prpa = "$doddata->{'project'}/$doddata->{'repository'}/$doddata->{'arch'}";
-  printlog("checking $prpa...\n");
+  BSUtil::printlog("checking $prpa...");
   eval { update_dod($doddata) };
   my $now = time();
   $doddata->{'lastcheck'} = $now;
@@ -437,25 +437,17 @@ sub check_dod {
   }
 }
 
-sub printlog {
-  my ($msg) = @_;
-  $msg =~ s/\n$//s;
-  my @ltim = localtime(time);
-  my $msgtm = sprintf "%04d-%02d-%02d %02d:%02d:%02d:", $ltim[5] + 1900, $ltim[4] + 1, @ltim[3,2,1,0];
-  print "$msgtm $msg\n";
-}
-
 sub check_exitrestart {
   if (-e "$rundir/bs_dodup.exit") {
     close(RUNLOCK);
     unlink("$rundir/bs_dodup.exit");
-    printlog("exiting...");
+    BSUtil::printlog("exiting...");
     exit(0);
   }
   if (-e "$rundir/bs_dodup.restart") {
     close(RUNLOCK);
     unlink("$rundir/bs_dodup.restart");
-    printlog("restarting...");
+    BSUtil::printlog("restarting...");
     exec($0);
     die("$0: $!\n");
   }
@@ -496,7 +488,7 @@ if (!@ARGV || (@ARGV == 1 && ($ARGV[0] eq '--restart' || $ARGV[0] eq '--exit' ||
   $| = 1;
   $SIG{'PIPE'} = 'IGNORE';
   BSUtil::restartexit($ARGV[0], 'dodup', "$rundir/bs_dodup");
-  printlog("starting build service DoD updater");
+  BSUtil::printlog("starting build service DoD updater");
   mkdir_p($rundir);
   open(RUNLOCK, '>>', "$rundir/bs_dodup.lock") || die("$rundir/bs_dodup.lock: $!\n");
   flock(RUNLOCK, LOCK_EX | LOCK_NB) || die("dodup is already running!\n");

--- a/src/backend/bs_publish
+++ b/src/backend/bs_publish
@@ -1279,7 +1279,7 @@ sub deleterepo {
 sub publish {
   my ($projid, $repoid, $dbgsplit, $dbgpacktrack) = @_;
   my $prp = "$projid/$repoid";
-  print BSUtil::isotime().": publishing $prp\n";
+  BSUtil::printlog("publishing $prp");
 
   # get info from source server about this project/repository
   # we specify "withsrcmd5" so that we get the patternmd5. It still
@@ -2307,7 +2307,7 @@ sub publishevent {
     clear_repoinfo_state($prp);
     set_publish_retry($req, time() + 60);
     db_sync();
-    print BSUtil::isotime().": pushlish failed for $prp\n" if $req->{'forked'};
+    BSUtil::printlog("pushlish failed for $prp") if $req->{'forked'};
     return 0;
   }
 
@@ -2317,7 +2317,7 @@ sub publishevent {
   writepublishtimeevent($projid, $repoid, $now, $now - $starttime) if $req->{'forked'};
   notify_state($projid, $repoid, 'published');
   db_sync();
-  print BSUtil::isotime().": pushlish done for $prp\n" if $req->{'forked'};
+  BSUtil::printlog("pushlish done for $prp") if $req->{'forked'};
   return 1;
 }
 

--- a/src/backend/bs_sched
+++ b/src/backend/bs_sched
@@ -839,7 +839,7 @@ eval {
         my $ectx = BSSched::EventQueue->new($gctx);
         BSSched::EventHandler::event_exit($ectx, { 'type' => 'exitcomplete' });
       }
-      print BSUtil::isotime().": waiting for an event...\n";
+      BSUtil::printlog("waiting for an event...");
       exit 0 if $testprojid;
       my $sleepstart = time();
       my @watchers = (values(%remotewatchers), $gctx->{'retryevents'}->events(), $gctx->{'rctx'}->xrpc_handles());

--- a/src/backend/bs_service
+++ b/src/backend/bs_service
@@ -138,7 +138,7 @@ sub run_source_update {
         print "Skip $name\n";
         next;
       }
-      print "Run for $name\n";
+      BSUtil::printlog("Run for $name\n");
       my $servicedef = readxml("$rootservicedir/$name.service", $BSXML::servicetype);
       my @run;
       if (defined $BSConfig::service_wrapper->{$name} ) {
@@ -159,6 +159,7 @@ sub run_source_update {
 
       mkdir("$myworkdir/out") || die("mkdir $myworkdir/out: $!\n");
     
+      BSUtil::printlog("Running command '@run'\n");
       # call the service
       if (! open(SERVICE, '-|')) {
         open(STDERR, ">&STDOUT");

--- a/src/backend/bs_service
+++ b/src/backend/bs_service
@@ -138,7 +138,7 @@ sub run_source_update {
         print "Skip $name\n";
         next;
       }
-      BSUtil::printlog("Run for $name\n");
+      BSUtil::printlog("Run for $name");
       my $servicedef = readxml("$rootservicedir/$name.service", $BSXML::servicetype);
       my @run;
       if (defined $BSConfig::service_wrapper->{$name} ) {
@@ -159,7 +159,7 @@ sub run_source_update {
 
       mkdir("$myworkdir/out") || die("mkdir $myworkdir/out: $!\n");
     
-      BSUtil::printlog("Running command '@run'\n");
+      BSUtil::printlog("Running command '@run'");
       # call the service
       if (! open(SERVICE, '-|')) {
         open(STDERR, ">&STDOUT");

--- a/src/backend/bs_warden
+++ b/src/backend/bs_warden
@@ -53,7 +53,7 @@ my $jobsdir = "$BSConfig::bsdir/jobs";
 $| = 1;
 $SIG{'PIPE'} = 'IGNORE';
 BSUtil::restartexit($ARGV[0], 'warden', "$rundir/bs_warden");
-print BSUtil::isotime().": starting build service worker warden\n";
+BSUtil::printlog("starting build service worker warden");
 
 # get lock
 mkdir_p($rundir);
@@ -113,7 +113,7 @@ while (1) {
     if ($@) {
       warn($@);
       if ($worker->{'reposerver'}) {
-	print BSUtil::isotime().": restarting build of $arch/$job building on $js->{'workerid'}\n";
+	BSUtil::printlog("restarting build of $arch/$job building on $js->{'workerid'}");
 	my $param = {
 	  'uri' => "$worker->{'reposerver'}/jobs/$arch/$job",
 	  'request' => 'POST',
@@ -133,7 +133,7 @@ while (1) {
 	  close F;
 	  next;
 	}
-	print BSUtil::isotime().": restarting build of $arch/$job building on $js->{'workerid'}\n";
+	BSUtil::printlog("restarting build of $arch/$job building on $js->{'workerid'}");
 	unlink("$jobsdir/$arch/$job:status");
         unlink("$workersdir/building/$wname");
         delete $building{$wname};
@@ -169,7 +169,7 @@ while (1) {
 	if ($js && $js->{'code'} ne 'building') {
 	  my @s = stat("$jobsdir/$arch/$job:status");
 	  if (@s && $s[9] + 86400 < $now) {
-	    print BSUtil::isotime().": restarting build of $arch/$job stuck in code $js->{'code'}\n";
+	    BSUtil::printlog("restarting build of $arch/$job stuck in code $js->{'code'}");
 	    unlink("$jobsdir/$arch/$job:status");
 	  }
 	  next;
@@ -192,7 +192,7 @@ while (1) {
 	    close F;
 	    next;
 	  }
-	  print BSUtil::isotime().": restarting orphaned build of $arch/$job building on $js->{'workerid'}\n";
+	  BSUtil::printlog("restarting orphaned build of $arch/$job building on $js->{'workerid'}");
 	  unlink("$jobsdir/$arch/$job:status");
           close F;
 	}
@@ -205,7 +205,7 @@ while (1) {
 	  next if $jobs{$job};
 	  my @s = stat("$jobsdir/$arch/$job:dir");
 	  if (@s && $s[9] + 86400 < $now) {
-	    print BSUtil::isotime().": removing orphaned $arch/$job result directory\n";
+	    BSUtil::printlog("removing orphaned $arch/$job result directory");
 	    BSUtil::cleandir("$jobsdir/$arch/$job:dir");
 	    rmdir("$jobsdir/$arch/$job:dir");
 	  }
@@ -214,7 +214,7 @@ while (1) {
 	  next if $jobs{$job};
 	  my @s = stat("$jobsdir/$arch/$job:status");
 	  if (@s && $s[9] + 86400 < $now) {
-	    print BSUtil::isotime().": removing orphaned $arch/$job status file\n";
+	    BSUtil::printlog("removing orphaned $arch/$job status file");
 	    rmdir("$jobsdir/$arch/$job:status");
 	  }
 	}
@@ -227,13 +227,13 @@ while (1) {
     if (-e "$rundir/bs_warden.exit") {
       close(RUNLOCK);
       unlink("$rundir/bs_warden.exit");
-      print BSUtil::isotime().": exiting...\n";
+      BSUtil::printlog("exiting...");
       exit(0);
     }
     if (-e "$rundir/bs_warden.restart") {
       close(RUNLOCK);
       unlink("$rundir/bs_warden.restart");
-      print BSUtil::isotime().": restarting...\n";
+      BSUtil::printlog("restarting...");
       exec($0);
       die("$0: $!\n");
     }


### PR DESCRIPTION
* unification of logging output
* get rid of bs_dodup::printlog and bs_dispatch::printlog
* get rid of isotime and use BSUtil::printlog instead
* logging peer ip address now in case of dispatching remote request
* removed '\n' in printlog calls and removed regex to remove '\n'
* BSServer: die if open of .status files fails