### PR TITLE
[webui] add titles/popovers for build states

### DIFF
--- a/src/api/app/helpers/webui/buildresult_helper.rb
+++ b/src/api/app/helpers/webui/buildresult_helper.rb
@@ -1,0 +1,35 @@
+module Webui::BuildresultHelper
+  def arch_repo_table_cell(repo, arch, package_name)
+    status = @statushash[repo][arch][package_name] || { 'package' => package_name }
+    status_id = valid_xml_id("id-#{package_name}_#{repo}_#{arch}")
+    link_title = status['details']
+    if status['code']
+      code = status['code']
+      theclass = 'status_' + code.gsub(/[- ]/, '_')
+    else
+      code = ''
+      theclass = ' '
+    end
+
+    result = content_tag(:td, class: [theclass, "buildstatus", "nowrap"]) do
+      if %w(- unresolvable blocked excluded scheduled).include?(code)
+        concat link_to(code, '#', title: link_title, id: status_id, class: code)
+      else
+        concat link_to(code.gsub(/\s/, '&nbsp;'),
+                       {
+                         action: :live_build_log, package: package_name, project: @project.to_s,
+                         arch: arch, controller: 'package', repository: repo
+                       },
+                       { title: link_title, rel: 'nofollow' }
+                      )
+      end
+
+      if status['code']
+        concat " "
+        concat sprite_tag('help', title: Buildresult.status_description(status['code']))
+      end
+    end
+
+    result
+  end
+end

--- a/src/api/app/helpers/webui/webui_helper.rb
+++ b/src/api/app/helpers/webui/webui_helper.rb
@@ -4,6 +4,7 @@ require 'digest/md5'
 module Webui::WebuiHelper
   include ActionView::Helpers::JavaScriptHelper
   include ActionView::Helpers::AssetTagHelper
+  include Webui::BuildresultHelper
 
   def get_frontend_url_for(opt = {})
     opt[:host] ||= CONFIG['external_frontend_host'] || CONFIG['frontend_host']
@@ -61,37 +62,6 @@ module Webui::WebuiHelper
       end
     end
     prjname
-  end
-
-  def arch_repo_table_cell(repo, arch, package_name)
-    status = @statushash[repo][arch][package_name] || { 'package' => package_name }
-    status_id = valid_xml_id("id-#{package_name}_#{repo}_#{arch}")
-    link_title = status['details']
-    if status['code']
-      code = status['code']
-      theclass = 'status_' + code.gsub(/[- ]/, '_')
-    else
-      code = ''
-      theclass = ' '
-    end
-
-    result = "<td class='".html_safe
-    result += "#{theclass}"
-    result +=" buildstatus'>".html_safe
-
-    if %w(- unresolvable blocked excluded scheduled).include?(code)
-      result += link_to(code, '#', title: link_title, id: status_id, class: code)
-    else
-      result += link_to(code.gsub(/\s/, '&nbsp;'),
-                        {
-                          action: :live_build_log, package: package_name, project: @project.to_s,
-                          arch: arch, controller: 'package', repository: repo
-                        },
-                        { title: link_title, rel: 'nofollow' }
-                       )
-    end
-    result += '</td>'.html_safe
-    result
   end
 
   REPO_STATUS_ICONS = {
@@ -422,5 +392,10 @@ module Webui::WebuiHelper
   def replace_jquery_meta_characters(input)
     # The stated characters are c&p from https://api.jquery.com/category/selectors/
     input.gsub(/[!"#$%&'()*+,.\/:\\;<=>?@\[\]^`{|}~]/, '_')
+  end
+
+  def word_break(string, length)
+    # adds a <wbr> tag after an amount of given characters
+    safe_join(string.scan(/.{1,#{length}}/), "<wbr>".html_safe)
   end
 end

--- a/src/api/app/models/buildresult.rb
+++ b/src/api/app/models/buildresult.rb
@@ -19,6 +19,30 @@ class Buildresult < ActiveXML::Node
   }
   # rubocop:enable Style/AlignHash
 
+  STATUS_DESCRIPTION = {
+      succeeded:    "Package has built successfully and can be used to build further packages.",
+      failed:       "The package does not build successfully. No packages have been created. Packages " +
+                    "that depend on this package will be built using any previously created packages, if they exist.",
+      unresolvable: "The build can not begin, because required packages are either missing or not explicitly defined.",
+      broken:       "The sources either contain no build description (e.g. specfile), automatic source processing failed or a " +
+                    "merge conflict does exist.",
+      blocked:      "This package waits for other packages to be built. These can be in the same or other projects.",
+      scheduled:    "A package has been marked for building, but the build has not started yet.",
+      dispatching:  "A package is being copied to a build host. This is an intermediate state before building.",
+      building:     "The package is currently being built.",
+      signing:      "The package has been built successfully and is assigned to get signed.",
+      finished:     "The package has been built and signed, but has not yet been picked up by the scheduler. This is an " +
+                    "intermediate state prior to 'succeeded' or 'failed'.",
+      disabled:     "The package has been disabled from building in project or package metadata.",
+      excluded:     "The package build has been disabled in package build description (for example in the .spec file) or " +
+                    "does not provide a matching build description for the target.",
+      unknown:      "The scheduler has not yet evaluated this package. Should be a short intermediate state for new packages."
+  }.with_indifferent_access
+
+  def self.status_description(status)
+    STATUS_DESCRIPTION[status] || "status explanation not found"
+  end
+
   def self.avail_status_values
     AVAIL_STATUS_VALUES.keys.map(&:to_s)
   end

--- a/src/api/app/views/webui/package/_buildstatus.html.erb
+++ b/src/api/app/views/webui/package/_buildstatus.html.erb
@@ -12,8 +12,8 @@
           -%>
           <tr>
             <% if index == 0 %>
-              <td class="nowrap" title="<%= r %>" rowspan="<%= archs.length %>">
-                <%= link_to(elide(r, 20), {:action => :binaries, :controller => :package, :project => @project, :package => @package, :repository => r}, {:title => "Binaries for #{r}"}) %>
+              <td title="<%= r %>" rowspan="<%= archs.length %>">
+                <%= link_to(word_break(r, 22), {:action => :binaries, :controller => :package, :project => @project, :package => @package, :repository => r}, {:title => "Binaries for #{r}"}) %>
               </td>
               <% index += 1 -%>
             <% end # if -%>

--- a/src/api/app/views/webui/project/_buildstatus.html.erb
+++ b/src/api/app/views/webui/project/_buildstatus.html.erb
@@ -10,25 +10,25 @@
           <p><i>No build result available</i></p>
       <% end %>
   <% else %>
-      <table title="Repositories" class="repostatus">
-        <% @buildresult.each do |repo, archarray| %>
+      <table class="repostatus">
+        <% @buildresult.each do |repository, archarray| %>
             <% index = 0
-               srepo = truncate(repo, :length => 17)
                archarray.each do |arch, counts| %>
                 <tr>
                   <% if index == 0 %>
-                      <td class="repo nowrap" rowspan="<%= archarray.length %>">
-                        <%= link_to(elide(srepo, 26), { action: :state, project: @project.name, repository: repo, controller: :repositories }, { title: "Repository #{srepo}"}) %>
+                      <td class="repo" rowspan="<%= archarray.length %>">
+                        <%= link_to(word_break(repository, 12), { action: :state, project: @project.name, repository: repository, controller: :repositories }, { title: "Repository #{repository}"}) %>
                       </td>
                       <% index += 1 %>
                   <% end %>
                   <td class="nowrap">
-                    <%= repo_status_icon(@repostatushash[repo][arch], @repostatusdetailshash[repo][arch])%> <%= arch %>
+                    <%= repo_status_icon(@repostatushash[repository][arch], @repostatusdetailshash[repository][arch])%> <%= arch %>
                   </td>
-                  <td style="width: 1%">
+                  <td style="width: 1%" class="nowrap">
                     <% counts.each do |code, count| %>
-                        <%= link_to("#{code}: #{count}", {:action => :monitor, valid_xml_id('repo_' + repo) => 1,
+                        <%= link_to("#{code}: #{count}", {:action => :monitor, valid_xml_id('repo_' + repository) => 1,
                                                           'arch_' + arch => 1, :project => params[:project], code => 1, :defaults => 0}, :rel => 'nofollow', :class => 'nowrap') %>
+                        <%= sprite_tag('help', title: Buildresult.status_description(code)) %><br />
                     <% end %>
                   </td>
                 </tr>

--- a/src/api/app/views/webui/project/monitor.html.erb
+++ b/src/api/app/views/webui/project/monitor.html.erb
@@ -102,8 +102,8 @@
       <tbody>      <!-- package rows -->
         <% @packagenames.each do |packname| -%>
           <tr>
-            <td class="nowrap">
-              <%= link_to elide(packname, 40), :controller => "package", :action => "show",
+            <td>
+              <%= link_to word_break(packname, 40), :controller => "package", :action => "show",
                 :package => packname, :project => @project.to_s %>
             </td>
             <% @repohash.sort.each do |repo, archlist| -%>
@@ -120,21 +120,9 @@
   <div id="legend">
     <h3>Legend</h3>
     <ul>
-      <li><strong>succeeded: </strong><span class="descr">Package has built successfully and can be used to build further packages.</span></li>
-      <li><strong>failed: </strong><span class="descr">The package does not build successfully. No packages have been created. Packages that depend on this package will be built using any previously created packages, if they exist.</span></li>
-      <li><strong>unresolvable: </strong><span class="descr">The build can not begin, because required packages are either missing or not explicitly defined.</span></li>
-      <li><strong>broken: </strong><span class="descr">The sources either contain no build description (e.g. specfile), automatic source processing failed or a merge conflict does exist.</span></li>
-
-      <li><strong>blocked: </strong><span class="descr">This package waits for other packages to be built. These can be in the same or other projects.</span></li>
-      <li><strong>scheduled: </strong><span class="descr">A package has been marked for building, but the build has not started yet.</span></li>
-      <li><strong>dispatching: </strong><span class="descr">A package is being copied to a build host. This is an intermediate state before building.</span></li>
-      <li><strong>building: </strong><span class="descr">The package is currently being built.</span></li>
-      <li><strong>signing: </strong><span class="descr">The package has been built successfully and is assigned to get signed.</span></li>
-      <li><strong>finished: </strong><span class="descr">The package has been built and signed, but has not yet been picked up by the scheduler. This is an intermediate state prior to 'succeeded' or 'failed'.</span></li>
-      
-      <li><strong>disabled: </strong><span class="descr">The package has been disabled from building in project or package metadata.</span></li>
-      <li><strong>excluded: </strong><span class="descr">The package build has been disabled in package build description (for example in the .spec file) or does not provide a matching build description for the target. </span></li>
-      <li><strong>unknown: </strong><span class="descr">The scheduler has not yet evaluated this package. Should be a short intermediate state for new packages.</span></li>
+      <% Buildresult::STATUS_DESCRIPTION.each do |status, description| %>
+        <li><strong><%= status %>: </strong><span class="descr"><%= description %></span></li>
+      <% end %>
     </ul>
   </div>
 

--- a/src/api/spec/helpers/webui/webui_helper_spec.rb
+++ b/src/api/spec/helpers/webui/webui_helper_spec.rb
@@ -40,6 +40,25 @@ RSpec.describe Webui::WebuiHelper do
     end
   end
 
+  describe '#word_break' do
+    it "continuously adds tag after N characters" do
+      expect(word_break("0123456789012345678901234567890123456789", 10)).to \
+        eq("0123456789<wbr>0123456789<wbr>0123456789<wbr>0123456789")
+    end
+
+    it "adds no tag if string is shorter than N characters" do
+      expect(word_break("0123456789", 10)).to eq("0123456789")
+    end
+
+    it "adds one tag if string is longer than N characters" do
+      expect(word_break("01234567890", 10)).to eq("0123456789<wbr>0")
+    end
+
+    it "does not evaluate HTML tags" do
+      expect(word_break("01234<b>567</b>890", 3)).to eq("012<wbr>34&lt;<wbr>b&gt;5<wbr>67&lt;<wbr>/b&gt;<wbr>890")
+    end
+  end
+
   describe '#repo_status_icon' do
     it 'renders icon' do
       blocked = repo_status_icon('blocked')

--- a/src/api/spec/models/buildresult_spec.rb
+++ b/src/api/spec/models/buildresult_spec.rb
@@ -1,0 +1,13 @@
+require 'rails_helper'
+
+RSpec.describe Buildresult do
+  describe '#status_description' do
+    it "returns a message when a status code is unknown" do
+      expect(Buildresult.status_description("unknown_status")).to eq("status explanation not found")
+    end
+
+    it "returns an explanation for a status" do
+      expect(Buildresult.status_description("succeeded")).not_to eq("status explanation not found")
+    end
+  end
+end


### PR DESCRIPTION
This fixes #672

Here are a few screenshots:
![preview-1](https://cloud.githubusercontent.com/assets/8287131/18050116/d82da814-6dec-11e6-95a1-c0c6460873b2.png)

(Hovering over the info icon will display a tooltip with the explanation of the current status code)

![screenshot-6](https://cloud.githubusercontent.com/assets/8287131/18056719/649a981e-6e0d-11e6-942b-f3c7e84c0fa9.png)

![screenshot-7](https://cloud.githubusercontent.com/assets/8287131/18057388/1a387fcc-6e10-11e6-874b-87827a03d47c.png)