### PR TITLE
[vagrant] fix startup bugs

### DIFF
--- a/contrib/common.sh
+++ b/contrib/common.sh
@@ -102,7 +102,7 @@ function setup_data_dir() {
 
 function print_final_information() {
   echo -e "\nProvisioning of your OBS API rails app done!"
-  echo -e "To start your development OBS backend run: vagrant exec start_development_backend\n"
+  echo -e "To start your development OBS backend run: vagrant exec contrib/start_development_backend\n"
   echo -e "To start your development OBS frontend run: vagrant exec rails server\n"
   echo -e "\nHappy hacking!\n"
 }

--- a/contrib/start_development_backend
+++ b/contrib/start_development_backend
@@ -17,7 +17,7 @@ sudo /vagrant/src/backend/bs_srcserver &
 sleep 4
 echo "Starting bs_repserver"
 sudo /vagrant/src/backend/bs_repserver &
-sleep 2 
+sleep 2
 echo "Starting bs_sched"
 sudo /vagrant/src/backend/bs_sched i586 &
 sudo /vagrant/src/backend/bs_sched x86_64 &


### PR DESCRIPTION
One problem was that **configuration.xml** was missing. Thus the backend could not schedule the build jobs. Now the existence of the default configuration in /srv/obs/ is checked. And if not a basic 
configuration.xml is provided.

The other problem was the execution of start_development_backend. To start it with 

`vagrant exec start_development_backend`

the following had to be added to the Vagrantfile: 

`fe.exec.commands 'start_development_backend', prepend: 'sh'`

Also one tailing space removed

@hennevogel: please review. 