### PR TITLE
[webui][ci] Update admin handling in user model

### DIFF
--- a/src/api/app/controllers/application_controller.rb
+++ b/src/api/app/controllers/application_controller.rb
@@ -57,7 +57,6 @@ class ApplicationController < ActionController::Base
   def load_nobody
     @http_user = User.find_nobody!
     User.current = @http_user
-    User.current.is_admin = false
     @user_permissions = Suse::Permission.new( User.current )
   end
 

--- a/src/api/app/models/user.rb
+++ b/src/api/app/models/user.rb
@@ -508,10 +508,7 @@ class User < ActiveRecord::Base
   #####################
 
   def is_admin?
-    if @is_admin.nil? # false is fine
-      @is_admin = roles.where(title: 'Admin').exists?
-    end
-    @is_admin
+    self.roles.where(title: 'Admin').exists?
   end
 
   def is_nobody?
@@ -520,11 +517,6 @@ class User < ActiveRecord::Base
 
   def is_active?
     self.state == 'confirmed'
-  end
-
-  # used to avoid
-  def is_admin=(is_she)
-    @is_admin = is_she
   end
 
   def is_in_group?(group)

--- a/src/api/spec/models/package_spec.rb
+++ b/src/api/spec/models/package_spec.rb
@@ -1,6 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe Package, vcr: true do
+  let(:admin) { create(:admin_user) }
   let(:user) { create(:confirmed_user, login: 'tom') }
   let(:home_project) { user.home_project }
   let(:package) { create(:package, name: 'test_package', project: home_project) }
@@ -19,6 +20,16 @@ RSpec.describe Package, vcr: true do
     it 'does not call #addKiwiImport if filename ends not with kiwi.txz' do
       Service.any_instance.expects(:addKiwiImport).never
       package.save_file({ filename: 'foo.spec' })
+    end
+  end
+
+  context "is_admin?" do
+    it "returns true for admins" do
+      expect(admin.is_admin?).to be true
+    end
+
+    it "returns false for non-admins" do
+      expect(user.is_admin?).to be false
     end
   end
 end


### PR DESCRIPTION
* Removes usage of an instance variable (@is_admin). This was quite flaky, eg.
  changing the admin role of a user required to update @is_admin as well. Which
  we didn't.
* Removes is_admin= method which wasn't really used and relied on @is_admin.
* Adds a test for is_admin?