### PR TITLE
Write test for app/controllers/webui/project_controller.rb#unlock.

### DIFF
--- a/src/api/app/models/project.rb
+++ b/src/api/app/models/project.rb
@@ -491,10 +491,10 @@ class Project < ApplicationRecord
       maintenance_release_requests = requests.where(bs_request_actions: { type: 'maintenance_release', source_project: self.name})
       if maintenance_release_requests.exists?
         if with_exception
-          raise OpenReleaseRequest.new "Unlock of maintenance incident #{self.maintenance_incident.project.name} is not possible," +
+          raise OpenReleaseRequest.new "Unlock of maintenance incident #{self.name} is not possible," +
                                        " because there is a running release request: #{maintenance_release_requests.first.id}"
         else
-          errors.add(:base, "Unlock of maintenance incident #{self.maintenance_incident.project.name} is not possible," +
+          errors.add(:base, "Unlock of maintenance incident #{self.name} is not possible," +
                             " because there is a running release request: #{maintenance_release_requests.first.id}")
         end
       end

--- a/src/api/spec/factories/bs_requests.rb
+++ b/src/api/spec/factories/bs_requests.rb
@@ -3,7 +3,12 @@ FactoryGirl.define do
     description { Faker::Lorem.paragraph }
     state "new"
 
-    before(:create) do |request|
+    transient do
+      type nil
+      source_project nil
+    end
+
+    before(:create) do |request, evaluator|
       unless request.creator
         user = create(:confirmed_user)
 
@@ -11,7 +16,7 @@ FactoryGirl.define do
         request.commenter = user.login
       end
       unless request.bs_request_actions.any?
-        request.bs_request_actions << create(:bs_request_action)
+        request.bs_request_actions << create(:bs_request_action, type: evaluator.type, source_project: evaluator.source_project)
       end
       # Monkeypatch to avoid errors caused by permission checks made
       # in user and bs_request model

--- a/src/api/spec/factories/bs_requests.rb
+++ b/src/api/spec/factories/bs_requests.rb
@@ -15,7 +15,7 @@ FactoryGirl.define do
         request.creator   = user.login
         request.commenter = user.login
       end
-      unless request.bs_request_actions.any?
+      if request.bs_request_actions.none?
         request.bs_request_actions << create(:bs_request_action, type: evaluator.type, source_project: evaluator.source_project)
       end
       # Monkeypatch to avoid errors caused by permission checks made


### PR DESCRIPTION
Write test for app/controllers/webui/project_controller.rb#unlock.

Also, there was a has_one-belongs_to relation (`maintenance_incident.project`) between Project and MaintenanceIncident that was used twice so it is useless and I removed it.