### PR TITLE
Fix Makefile to support 'make all' command.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,3 +10,5 @@ test:
 	make -C src/api test
 	make -C dist test
 	make -C src/backend test
+clean:
+	make -C src/api clean

--- a/src/api/Makefile
+++ b/src/api/Makefile
@@ -67,5 +67,7 @@ test_unit:
 	[ -d log ] || mkdir log
 	echo > log/test.log
 	./script/api_test_in_spec.sh
+clean:
+	rm -rf ../../docs/api/html
 
 .PHONY: test


### PR DESCRIPTION
We cannot execute "make all" command with the existing Makefile.
because the "make install" command is dependent on the "make apidocs".
So, Let's modify the Makefile to support "make all" command.
This PR is tested on Ubuntu 16.04 LTS X64 distribution.

Signed-off-by: Geunsik Lim <geunsik.lim@samsung.com>