### PR TITLE
[webui] Fix issue #2125 - webui can't handle .yaml suffixed files

### DIFF
--- a/src/api/config/routes.rb
+++ b/src/api/config/routes.rb
@@ -125,7 +125,7 @@ OBSApi::Application.routes.draw do
       post 'package/save_person/:project/:package' => :save_person, constraints: cons
       post 'package/save_group/:project/:package' => :save_group, constraints: cons
       post 'package/remove_role/:project/:package' => :remove_role, constraints: cons
-      get 'package/view_file/(:project/(:package/(:filename)))' => :view_file, constraints: cons, as: 'package_view_file'
+      get 'package/view_file/(:project/(:package/(:filename)))' => :view_file, constraints: cons, as: 'package_view_file', defaults: {format: "html"}
       get 'package/live_build_log/(:project/(:package/(:repository/(:arch))))' => :live_build_log, constraints: cons, as: 'package_live_build_log'
       get 'package/update_build_log/:project/:package' => :update_build_log, constraints: cons
       get 'package/abort_build/:project/:package' => :abort_build, constraints: cons


### PR DESCRIPTION
Rails was routing certain .* extensions (.json, .txt, .yml, ...) as different format, which
caused the view file page not to work properly.
This probably is a regression of the recent Rails 5 update.

Setting the specific route to 'html' format by default fixes the issue.