### PR TITLE
[api] maintenance_release lock by package

### DIFF
--- a/ReleaseNotes-2.8
+++ b/ReleaseNotes-2.8
@@ -32,11 +32,15 @@ Features
  * Allow admins to lock or delete users and their home projects via new command
  * Users can be declared sub accounts of other users. Useful for automated scripts.
 
-Incompatible changes:
-=====================
+Wanted changes:
+===============
 
  * kiwi builds: build configuration changes from the project where the kiwi 
                 file is stored have always an effect now.
+
+ * maintenance_release requests are locking only the source packages on
+   creation now. They don't lock the patchinfos. The project gets locked on release
+   now.
 
 Notes for systems using systemd:
 ================================

--- a/src/api/app/models/bs_request.rb
+++ b/src/api/app/models/bs_request.rb
@@ -478,7 +478,12 @@ class BsRequest < ApplicationRecord
     self.bs_request_actions.where(type: 'maintenance_release').each do |action|
       # unlock incident project in the soft way
       prj = Project.get_by_name(action.source_project)
-      prj.unlock_by_request(self)
+      if prj.is_locked?
+        prj.unlock_by_request(self)
+      else
+        pkg = Package.get_by_project_and_name(action.source_project, action.source_package)
+        pkg.unlock_by_request(self) if pkg.is_locked?
+      end
     end
   end
 

--- a/src/api/app/models/package.rb
+++ b/src/api/app/models/package.rb
@@ -377,6 +377,14 @@ class Package < ApplicationRecord
     end
   end
 
+  def unlock_by_request(request)
+    f = self.flags.find_by_flag_and_status('lock', 'enable')
+    if f
+      self.flags.delete(f)
+      self.store(comment: "Request got revoked", request: request, lowprio: 1)
+    end
+  end
+
   def sources_changed(opts = {})
     dir_xml = opts[:dir_xml]
     update_activity

--- a/src/api/test/functional/kgraft_maintenance_test.rb
+++ b/src/api/test/functional/kgraft_maintenance_test.rb
@@ -1,3 +1,6 @@
+# rubocop:disable Metrics/AbcSize
+# rubocop:disable Metrics/MethodLength
+
 require File.expand_path(File.dirname(__FILE__) + '/..') + '/test_helper'
 require 'source_controller'
 
@@ -321,7 +324,9 @@ class MaintenanceTests < ActionDispatch::IntegrationTest
                                    <state name="new" />
                                  </request>'
     assert_response :success
-    assert_no_xml_tag( :tag => 'source', :attributes => { rev: nil } )
+    assert_no_xml_tag( :tag => 'source', :attributes => { package: 'BaseDistro2.Channel', rev: nil } )
+    assert_no_xml_tag( :tag => 'source', :attributes => { package: 'kgraft-GA.BaseDistro2.0', rev: nil } )
+    assert_xml_tag( :tag => 'source', :attributes => { package: 'patchinfo', rev: nil } )
     # GM project may be locked, must not appear
     assert_no_xml_tag( :tag => 'target', :attributes => { project: 'BaseDistro2.0' } )
     assert_xml_tag( :parent => { :tag => "action", :attributes => { :type => "maintenance_release" } },

--- a/src/api/test/functional/maintenance_test.rb
+++ b/src/api/test/functional/maintenance_test.rb
@@ -1,6 +1,7 @@
 # rubocop:disable Metrics/LineLength
 # rubocop:disable Metrics/AbcSize
 # rubocop:disable Metrics/MethodLength
+# rubocop:disable Metrics/ClassLength
 require File.expand_path(File.dirname(__FILE__) + '/..') + '/test_helper'
 require 'source_controller'
 
@@ -1253,7 +1254,9 @@ class MaintenanceTests < ActionDispatch::IntegrationTest
                                    <state name="new" />
                                  </request>'
     assert_response :success
-    assert_no_xml_tag( :tag => 'source', :attributes => { rev: nil } )
+    assert_no_xml_tag( :tag => 'source', :attributes => { package: 'pack2.0', rev: nil } )
+    assert_no_xml_tag( :tag => 'source', :attributes => { package: 'pack2.linked.0', rev: nil } )
+    assert_xml_tag( :tag => 'source', :attributes => { package: 'patchinfo', rev: nil } )
     assert_no_xml_tag( :tag => 'target', :attributes => { project: 'BaseDistro2.0' } ) # BaseDistro2 has an update project, nothing should go to GA project
     assert_no_xml_tag( :tag => 'target', :attributes => { project: 'BaseDistro2.0:LinkedUpdateProject', package: 'pack2' } )
     assert_no_xml_tag( :tag => 'target', :attributes => { project: 'BaseDistro3', package: 'pack2' } )
@@ -1299,10 +1302,20 @@ class MaintenanceTests < ActionDispatch::IntegrationTest
     # source project got locked?
     get "/source/#{incidentProject}/_meta"
     assert_response :success
-    assert_xml_tag( :parent => { tag: 'lock' }, :tag => 'enable')
+    assert_xml_tag( :parent => { tag: 'lock' }, :tag => 'disable')
     assert_xml_tag( :parent => { tag: 'access' }, :tag => 'disable', :content => nil ) # but still not out there
     assert_no_xml_tag( :parent => { tag: 'publish' } )
-    assert_no_xml_tag( :parent => { tag: 'lock' }, :tag => 'disable') # disable got removed
+    # packages are locked
+    ['pack2.BaseDistro2.0_LinkedUpdateProject',
+     'pack2.BaseDistro3',
+     'pack2.linked.BaseDistro2.0_LinkedUpdateProject',
+     'packNew.BaseDistro2.0_LinkedUpdateProject'].each do |pkg|
+      get "/source/#{incidentProject}/#{pkg}/_meta"
+      assert_xml_tag( :parent => { tag: 'lock' }, :tag => 'enable')
+    end
+    # patchinfo not
+    get "/source/#{incidentProject}/patchinfo/_meta"
+    assert_no_xml_tag( :parent => { tag: 'lock' }, :tag => 'enable')
 
     # incident project not visible for tom
     login_tom
@@ -1318,7 +1331,7 @@ class MaintenanceTests < ActionDispatch::IntegrationTest
     login_adrian
     post '/request?cmd=create&addrevision=1', '<request>
                                    <action type="maintenance_incident">
-                                     <source project="kde4" package="kdelibs" />
+                                     <source project="BaseDistro3" package="pack2" />
                                      <target project="' + incidentProject + '" releaseproject="BaseDistro2.0:LinkedUpdateProject" />
                                    </action>
                                    <state name="new" />
@@ -1431,7 +1444,7 @@ class MaintenanceTests < ActionDispatch::IntegrationTest
     # validate result
     get "/source/#{incidentProject}/_meta"
     assert_response :success
-    assert_xml_tag( :parent => { tag: 'lock' }, :tag => 'enable') # still locked
+    assert_xml_tag( :parent => { tag: 'lock' }, :tag => 'enable') # got locked
     assert_no_xml_tag( :parent => { tag: 'access' }, :tag => 'disable', :content => nil ) # got published, so access got enabled
     get "/source/#{incidentProject}/patchinfo/_meta"
     assert_response :success


### PR DESCRIPTION
FATE#319680

* Don't lock entire project on maintenance release request creation, but
  only packages.
* Don't lock patchinfos to allow modification of meta data
  (binary packages don't change as they are locked)
* Lock incident project on release

Works in test suite as discussed with maintenance teams, but needs real life
testing.