### PR TITLE
Remove unnecessary line in project controller spec

### DIFF
--- a/src/api/spec/controllers/webui/project_controller_spec.rb
+++ b/src/api/spec/controllers/webui/project_controller_spec.rb
@@ -779,7 +779,6 @@ RSpec.describe Webui::ProjectController, vcr: true do
       let(:maintained_project) { create(:maintained_project, project: user.home_project) }
 
       before do
-        user.home_project.update(kind: nil)
         post :remove_maintained_project, project: user.home_project, maintained_project: maintained_project.project.name
       end
 


### PR DESCRIPTION
This line is not necessary as by default the user home project hasn't got `maintenance` kind, so better remove it.   :bowtie: