### PR TITLE
[ci] Fix monitor controller spec

### DIFF
--- a/src/api/spec/controllers/webui/monitor_controller_spec.rb
+++ b/src/api/spec/controllers/webui/monitor_controller_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe Webui::MonitorController, vcr: true do
       create_list(:status_history, 10, source: 'waiting', range: 10000..42000)
       # i586
       create_list(:status_history, 5, source: 'squeue_high', architecture: 'i586')
-      get :events, params: { arch: 'x86_64', range: 8760 }, xhr: true
+      get :events, params: { arch: 'x86_64', range: 8761 }, xhr: true
       @json_response = JSON.parse(response.body)
     end
 


### PR DESCRIPTION
I was wondering why this test was failing in https://github.com/openSUSE/open-build-service/pull/2133:

![spectacle u19148](https://cloud.githubusercontent.com/assets/16052290/18558306/e26e667c-7b72-11e6-9cb8-3137bc805ab6.png)

In the status_history factory times are generated in the range _0-365_ randomly. In case that 365 is returned, [here](https://github.com/openSUSE/open-build-service/blob/master/src/api/app/models/status_history.rb#L5) the `status_history` will only be returned if it the time that has passed since the it was created and the `history_by_key_and_hours` function is reached in **less than 1 second**. Is it possible that this takes more than 1 second? 1 second is quite a lot, but that would explain why this test occasionally fails. If that is the case, increasing the range in 1 hour will solve the problem, as I think it is not reasonable that 1 hour passes since the status history is created and the `history_by_key_and_hours` function is reached.  :anguished: