### PR TITLE
Improve remove_maintained_project test

### DIFF
--- a/src/api/spec/cassettes/Webui_ProjectController/POST_remove_maintained_project/with_maintained_kind/maintained_project_successfully_removed/1_29_1_1_3.yml
+++ b/src/api/spec/cassettes/Webui_ProjectController/POST_remove_maintained_project/with_maintained_kind/maintained_project_successfully_removed/1_29_1_1_3.yml
@@ -1,0 +1,44 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://localhost:3200/build/home:tom/_result?code=unresolvable&view=status
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - text/plain
+      Accept-Encoding:
+      - identity
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '786'
+    body:
+      encoding: UTF-8
+      string: |
+        <resultlist state="2253242fe08c2762782382d6624a4db3">
+          <result project="home:tom" repository="home_coolo_standard" arch="i586" code="published" state="published" />
+          <result project="home:tom" repository="home_coolo_standard" arch="x86_64" code="published" state="published" />
+          <result project="home:tom" repository="home_adrian_ProtectionTest_repo" arch="i586" code="published" state="published" />
+          <result project="home:tom" repository="home_adrian_ProtectionTest_repo" arch="x86_64" code="published" state="published" />
+          <result project="home:tom" repository="SourceprotectedProject_repo" arch="i586" code="published" state="published" />
+          <result project="home:tom" repository="SourceprotectedProject_repo" arch="x86_64" code="published" state="published" />
+        </resultlist>
+    http_version: 
+  recorded_at: Fri, 16 Sep 2016 14:05:16 GMT
+recorded_with: VCR 3.0.3

--- a/src/api/spec/controllers/webui/project_controller_spec.rb
+++ b/src/api/spec/controllers/webui/project_controller_spec.rb
@@ -752,6 +752,7 @@ RSpec.describe Webui::ProjectController, vcr: true do
           post :remove_maintained_project, project: user.home_project, maintained_project: maintained_project.project.name
         end
 
+        it { expect(user.home_project.maintained_projects.where(project: user.home_project)).not_to exist }
         it { expect(flash[:notice]).to eq("Removed #{maintained_project.project.name} from maintenance") }
         it { is_expected.to redirect_to(action: 'maintained_projects', project: user.home_project) }
       end
@@ -774,7 +775,6 @@ RSpec.describe Webui::ProjectController, vcr: true do
       end
     end
 
-    # redirect in the before_filter require_maintenance_project
     context "#remove_maintained_project fails without maintenance kind for a valid maintained project" do
       let(:maintained_project) { create(:maintained_project, project: user.home_project) }
 


### PR DESCRIPTION
Improve `project_controller#remove_maintained_project` test:

- Remove unnecessary comment.
- Check that the maintained project is truly removed in the successful case. 

I can not test that it is not removed when it fails because as the `.destroy` can not fail, it only fails when the `maintained_project` is invalid and in that case it doesn't exist so it can not be removed. 