### PR TITLE
[api][webui] Fix deprecated string callback

### DIFF
--- a/src/api/app/models/project.rb
+++ b/src/api/app/models/project.rb
@@ -32,9 +32,9 @@ class Project < ApplicationRecord
 
   before_destroy :cleanup_before_destroy
 
-  after_save 'Relationship.discard_cache'
+  after_save :discard_cache
   after_rollback :reset_cache
-  after_rollback 'Relationship.discard_cache'
+  after_rollback :discard_cache
   after_initialize :init
 
   attr_reader :commit_opts
@@ -1819,6 +1819,10 @@ class Project < ApplicationRecord
   end
 
   private
+
+  def discard_cache
+    Relationship.discard_cache
+  end
 
   # Go through all enabled build flags and look for a repo name that matches a
   # previously parsed release target name (from "release_targets_ng").

--- a/src/api/app/models/relationship.rb
+++ b/src/api/app/models/relationship.rb
@@ -54,9 +54,9 @@ class Relationship < ApplicationRecord
 
   # we only care for project<->user relationships, but the cache is not *that* expensive
   # to recalculate
-  after_create 'Relationship.discard_cache'
-  after_rollback 'Relationship.discard_cache'
-  after_destroy 'Relationship.discard_cache'
+  after_create :discard_cache
+  after_rollback :discard_cache
+  after_destroy :discard_cache
 
   def self.add_user(obj, user, role, ignoreLock = nil, check = nil)
     obj.check_write_access!(ignoreLock)
@@ -157,6 +157,10 @@ class Relationship < ApplicationRecord
   end
 
   private
+
+  def discard_cache
+    Relationship.discard_cache
+  end
 
   def check_global_role
     return unless self.role && self.role.global

--- a/src/api/app/models/user.rb
+++ b/src/api/app/models/user.rb
@@ -116,9 +116,9 @@ class User < ApplicationRecord
 
   # After saving, we want to set the "@new_hash_type" value set to false
   # again.
-  after_save '@new_hash_type = false'
+  after_save :set_new_hash_type_false
   # After saving the object into the database, the password is not new any more.
-  after_save '@new_password = false'
+  after_save :set_new_password_false
 
   # When a record object is initialized, we set the state, password
   # hash type, indicator whether the password has freshly been set
@@ -985,6 +985,14 @@ class User < ApplicationRecord
   end
 
   private
+
+  def set_new_hash_type_false
+    @new_hash_type = false
+  end
+
+  def set_new_password_false
+    @new_password = false
+  end
 
   def can_modify_project_internal(project, ignoreLock)
     # The ordering is important because of the lock status check


### PR DESCRIPTION
> **DEPRECATION WARNING:** Passing string to define callback is deprecated and will be removed in Rails 5.1 without replacement.