### PR TITLE
Remove P0 label from CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,8 +29,7 @@ In particular, this community seeks the following types of contributions:
 * Prerequisites: familiarity with [GitHub Issues](https://guides.github.com/features/issues/).
 * Enter your issue and a member of the [open-build-service team](https://github.com/orgs/openSUSE/teams/open-build-service) will label and prioritize it for you.
 
-We are using priority labels from **P0** to **P4** for our issues. So if you are a member of the [open-build-service team](https://github.com/orgs/openSUSE/teams/open-build-service) you are supposed to
-* P0: Critical Situation - Drop what you are doing and fix this issue now!
+We are using priority labels from **P1** to **P4** for our issues. So if you are a member of the [open-build-service team](https://github.com/orgs/openSUSE/teams/open-build-service) you are supposed to
 * P1: Urgent - Fix this next even if you still have other issues assigned to you.
 * P2: High   - Fix this after you have fixed all your other issues.
 * P3: Medium - Fix this when you have time.


### PR DESCRIPTION
As discussed in https://github.com/openSUSE/open-build-service/issues/2146 I have removed the P0 label from the Contribution readme as it does not exist.

I am not sure if we want to change the description of the rest labels (P1-P4). I think it is fine like that.

Closes https://github.com/openSUSE/open-build-service/issues/2146