### PR TITLE
[api] Fix issue #2150 - webui project meta editor broken

### DIFF
--- a/src/api/app/models/project.rb
+++ b/src/api/app/models/project.rb
@@ -542,9 +542,6 @@ class Project < ApplicationRecord
     self.remoteurl = xmlhash.value('remoteurl')
     self.remoteproject = xmlhash.value('remoteproject')
     self.kind = xmlhash.value('kind') unless xmlhash.value('kind').blank?
-
-    # give us an id
-    self.commit_opts = { no_backend_write: 1 }
     self.save!
 
     update_linked_projects(xmlhash)


### PR DESCRIPTION
With f8ac9e47fcfd18cec5d146e1c4b2ced5c47136d9 some previously dead code,
that enabled no_backend_write, became active and prevented update_to_xml
to write to the backend.

Group debugging with Ana, Eduardo, Henne and Manuel.