### PR TITLE
[webui][ci] Fix error handling for adding invalid maintained projects

### DIFF
--- a/src/api/app/controllers/webui/project_controller.rb
+++ b/src/api/app/controllers/webui/project_controller.rb
@@ -40,7 +40,7 @@ class Webui::ProjectController < Webui::WebuiController
                                                      :add_maintained_project,
                                                      :remove_maintained_project]
 
-  before_action :set_maintained_project, only: [:add_maintained_project, :remove_maintained_project]
+  before_action :set_maintained_project, only: [:remove_maintained_project]
 
   after_action :verify_authorized, only: [:save_new, :new_incident, :save_meta]
 
@@ -698,12 +698,15 @@ class Webui::ProjectController < Webui::WebuiController
 
   def add_maintained_project
     authorize @project, :update?
-    @project.maintained_projects.new(project: @maintained_project)
-    if @project.save
+
+    maintained_project = Project.find_by(name: params[:maintained_project])
+    if maintained_project
+      @project.maintained_projects.create!(project: maintained_project)
       @project.store
-      redirect_to({action: 'maintained_projects', project: @project}, notice: "Added #{@maintained_project} to maintenance" )
+      redirect_to({action: 'maintained_projects', project: @project}, notice: "Added #{params[:maintained_project]} to maintenance")
     else
-      redirect_to :back, error: "Failed to add #{@maintained_project} to maintenance"
+      # TODO: Better redirect to the project (maintained project tab), where the user actually came from
+      redirect_to(:back, error: "Failed to add #{params[:maintained_project]} to maintenance")
     end
   end
 

--- a/src/api/spec/cassettes/Webui_ProjectController/POST_add_maintained_project/with_a_maintenance_project_kind_maintenance_/adding_an_invalid_project/1_30_1_2_1.yml
+++ b/src/api/spec/cassettes/Webui_ProjectController/POST_add_maintained_project/with_a_maintenance_project_kind_maintenance_/adding_an_invalid_project/1_30_1_2_1.yml
@@ -1,0 +1,44 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://localhost:3200/build/home:tom/_result?code=unresolvable&view=status
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - text/plain
+      Accept-Encoding:
+      - identity
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '786'
+    body:
+      encoding: UTF-8
+      string: |
+        <resultlist state="2253242fe08c2762782382d6624a4db3">
+          <result project="home:tom" repository="home_coolo_standard" arch="i586" code="published" state="published" />
+          <result project="home:tom" repository="home_coolo_standard" arch="x86_64" code="published" state="published" />
+          <result project="home:tom" repository="home_adrian_ProtectionTest_repo" arch="i586" code="published" state="published" />
+          <result project="home:tom" repository="home_adrian_ProtectionTest_repo" arch="x86_64" code="published" state="published" />
+          <result project="home:tom" repository="SourceprotectedProject_repo" arch="i586" code="published" state="published" />
+          <result project="home:tom" repository="SourceprotectedProject_repo" arch="x86_64" code="published" state="published" />
+        </resultlist>
+    http_version: 
+  recorded_at: Fri, 16 Sep 2016 15:13:09 GMT
+recorded_with: VCR 3.0.3

--- a/src/api/spec/cassettes/Webui_ProjectController/POST_add_maintained_project/with_a_maintenance_project_kind_maintenance_/adding_an_invalid_project/1_30_1_2_2.yml
+++ b/src/api/spec/cassettes/Webui_ProjectController/POST_add_maintained_project/with_a_maintenance_project_kind_maintenance_/adding_an_invalid_project/1_30_1_2_2.yml
@@ -1,0 +1,44 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://localhost:3200/build/home:tom/_result?code=unresolvable&view=status
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - text/plain
+      Accept-Encoding:
+      - identity
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '786'
+    body:
+      encoding: UTF-8
+      string: |
+        <resultlist state="2253242fe08c2762782382d6624a4db3">
+          <result project="home:tom" repository="home_coolo_standard" arch="i586" code="published" state="published" />
+          <result project="home:tom" repository="home_coolo_standard" arch="x86_64" code="published" state="published" />
+          <result project="home:tom" repository="home_adrian_ProtectionTest_repo" arch="i586" code="published" state="published" />
+          <result project="home:tom" repository="home_adrian_ProtectionTest_repo" arch="x86_64" code="published" state="published" />
+          <result project="home:tom" repository="SourceprotectedProject_repo" arch="i586" code="published" state="published" />
+          <result project="home:tom" repository="SourceprotectedProject_repo" arch="x86_64" code="published" state="published" />
+        </resultlist>
+    http_version: 
+  recorded_at: Fri, 16 Sep 2016 15:13:09 GMT
+recorded_with: VCR 3.0.3

--- a/src/api/spec/cassettes/Webui_ProjectController/POST_add_maintained_project/with_a_maintenance_project_kind_maintenance_/adding_an_invalid_project/1_30_1_2_3.yml
+++ b/src/api/spec/cassettes/Webui_ProjectController/POST_add_maintained_project/with_a_maintenance_project_kind_maintenance_/adding_an_invalid_project/1_30_1_2_3.yml
@@ -1,0 +1,44 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://localhost:3200/build/home:tom/_result?code=unresolvable&view=status
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - text/plain
+      Accept-Encoding:
+      - identity
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '786'
+    body:
+      encoding: UTF-8
+      string: |
+        <resultlist state="2253242fe08c2762782382d6624a4db3">
+          <result project="home:tom" repository="home_coolo_standard" arch="i586" code="published" state="published" />
+          <result project="home:tom" repository="home_coolo_standard" arch="x86_64" code="published" state="published" />
+          <result project="home:tom" repository="home_adrian_ProtectionTest_repo" arch="i586" code="published" state="published" />
+          <result project="home:tom" repository="home_adrian_ProtectionTest_repo" arch="x86_64" code="published" state="published" />
+          <result project="home:tom" repository="SourceprotectedProject_repo" arch="i586" code="published" state="published" />
+          <result project="home:tom" repository="SourceprotectedProject_repo" arch="x86_64" code="published" state="published" />
+        </resultlist>
+    http_version: 
+  recorded_at: Fri, 16 Sep 2016 15:13:09 GMT
+recorded_with: VCR 3.0.3

--- a/src/api/spec/controllers/webui/project_controller_spec.rb
+++ b/src/api/spec/controllers/webui/project_controller_spec.rb
@@ -806,11 +806,14 @@ RSpec.describe Webui::ProjectController, vcr: true do
         it { is_expected.to redirect_to(action: 'maintained_projects', project: user.home_project) }
       end
 
-      # raise the exception in the before_action set_maintained_project
-      it "#add_maintained_project raise excepction with invalid maintained project" do
-        expect {
-          post :add_maintained_project, project: user.home_project, maintained_project: "invalid"
-        }.to raise_exception ActiveRecord::RecordNotFound
+      context "adding an invalid project" do
+        before do
+          post :add_maintained_project, project: user.home_project, maintained_project: "invalid project"
+        end
+
+        it { expect(user.home_project.maintained_projects.where(project_id: user.home_project.id)).not_to exist }
+        it { expect(flash[:error]).to eq("Failed to add invalid project to maintenance") }
+        it { is_expected.to redirect_to(root_path) }
       end
     end
 


### PR DESCRIPTION
Previously we showed a 404 page when a user added an invalid maintained
project. With this commit this will instead show an error message.
TODO: redirect to previous page (maintenance tab).

Pairprogramming with @bgeuken