### PR TITLE
[api][webui] "filter" -> "action"

### DIFF
--- a/src/api/app/controllers/configurations_controller.rb
+++ b/src/api/app/controllers/configurations_controller.rb
@@ -3,7 +3,7 @@ require 'configuration'
 class ConfigurationsController < ApplicationController
   # Site-specific configuration is insensitive information, no login needed therefore
   before_action :require_admin, :only => [:update]
-  skip_filter :validate_params, :only => [:update] # we use an array for archs here
+  skip_action_callback :validate_params, :only => [:update] # we use an array for archs here
 
   validate_action :show => {:method => :get, :response => :configuration}
 # webui is using this route with parameters instead of content

--- a/src/api/app/controllers/trigger_controller.rb
+++ b/src/api/app/controllers/trigger_controller.rb
@@ -8,7 +8,7 @@ class TriggerController < ApplicationController
   skip_before_action :require_login
 
   # github.com sends a hash payload
-  skip_filter :validate_params, :only => [:runservice]
+  skip_action_callback :validate_params, :only => [:runservice]
 
   def runservice
     auth = request.env['HTTP_AUTHORIZATION']

--- a/src/api/app/controllers/webui/webui_controller.rb
+++ b/src/api/app/controllers/webui/webui_controller.rb
@@ -14,7 +14,7 @@ class Webui::WebuiController < ActionController::Base
   before_action :check_user
   before_action :check_anonymous
   before_action :require_configuration
-  after_filter :clean_cache
+  after_action :clean_cache
 
   # We execute both strategies here. The default rails strategy (resetting the session)
   # and throwing an exception if the session is handled elswhere (e.g. proxy_auth_mode: :on)


### PR DESCRIPTION
As @mdeniz  pointed out in https://github.com/openSUSE/open-build-service/pull/2157 `after_filter` should also be changed  as it is also deprecated and will be removed in Rails 5.1. The same happens with `skip_filter`.