### PR TITLE
[dist] Fix incorrect folder name of $obsdir variable

### DIFF
--- a/dist/obsdeltastore
+++ b/dist/obsdeltastore
@@ -37,7 +37,7 @@ fi
 if [ -n "$OBS_BACKENDCODE_DIR" ]; then
 	obsdir="$OBS_BACKENDCODE_DIR"
 else
-	obsdir=/usr/lib/obs/server/
+	obsdir=/usr/lib/obs/server
 fi
 rundir="$OBS_RUN_DIR"
 logdir="$OBS_LOG_DIR"

--- a/dist/obsdispatcher
+++ b/dist/obsdispatcher
@@ -39,7 +39,7 @@ fi
 if [ -n "$OBS_BACKENDCODE_DIR" ]; then
 	obsdir="$OBS_BACKENDCODE_DIR"
 else
-	obsdir=/usr/lib/obs/server/
+	obsdir=/usr/lib/obs/server
 fi
 rundir="$OBS_RUN_DIR"
 logdir="$OBS_LOG_DIR"

--- a/dist/obsdodup
+++ b/dist/obsdodup
@@ -37,7 +37,7 @@ fi
 if [ -n "$OBS_BACKENDCODE_DIR" ]; then
 	obsdir="$OBS_BACKENDCODE_DIR"
 else
-	obsdir=/usr/lib/obs/server/
+	obsdir=/usr/lib/obs/server
 fi
 rundir="$OBS_RUN_DIR"
 logdir="$OBS_LOG_DIR"

--- a/dist/obspublisher
+++ b/dist/obspublisher
@@ -39,7 +39,7 @@ fi
 if [ -n "$OBS_BACKENDCODE_DIR" ]; then
         obsdir="$OBS_BACKENDCODE_DIR"
 else
-        obsdir=/usr/lib/obs/server/
+        obsdir=/usr/lib/obs/server
 fi
 rundir="$OBS_RUN_DIR"
 logdir="$OBS_LOG_DIR"

--- a/dist/obsrepserver
+++ b/dist/obsrepserver
@@ -37,7 +37,7 @@ fi
 if [ -n "$OBS_BACKENDCODE_DIR" ]; then
 	obsdir="$OBS_BACKENDCODE_DIR"
 else
-	obsdir=/usr/lib/obs/server/
+	obsdir=/usr/lib/obs/server
 fi
 rundir="$OBS_RUN_DIR"
 logdir="$OBS_LOG_DIR"

--- a/dist/obsscheduler
+++ b/dist/obsscheduler
@@ -37,7 +37,7 @@ fi
 if [ -n "$OBS_BACKENDCODE_DIR" ]; then
 	obsdir="$OBS_BACKENDCODE_DIR"
 else
-	obsdir=/usr/lib/obs/server/
+	obsdir=/usr/lib/obs/server
 fi
 rundir="$OBS_RUN_DIR"
 logdir="$OBS_LOG_DIR"

--- a/dist/obsservice
+++ b/dist/obsservice
@@ -37,7 +37,7 @@ fi
 if [ -n "$OBS_BACKENDCODE_DIR" ]; then
 	obsdir="$OBS_BACKENDCODE_DIR"
 else
-	obsdir=/usr/lib/obs/server/
+	obsdir=/usr/lib/obs/server
 fi
 rundir="$OBS_RUN_DIR"
 logdir="$OBS_LOG_DIR"

--- a/dist/obsservicedispatch
+++ b/dist/obsservicedispatch
@@ -37,7 +37,7 @@ fi
 if [ -n "$OBS_BACKENDCODE_DIR" ]; then
 	obsdir="$OBS_BACKENDCODE_DIR"
 else
-	obsdir=/usr/lib/obs/server/
+	obsdir=/usr/lib/obs/server
 fi
 rundir="$OBS_RUN_DIR"
 logdir="$OBS_LOG_DIR"

--- a/dist/obssigner
+++ b/dist/obssigner
@@ -39,7 +39,7 @@ fi
 if [ -n "$OBS_BACKENDCODE_DIR" ]; then
 	obsdir="$OBS_BACKENDCODE_DIR"
 else
-	obsdir=/usr/lib/obs/server/
+	obsdir=/usr/lib/obs/server
 fi
 rundir="$OBS_RUN_DIR"
 logdir="$OBS_LOG_DIR"

--- a/dist/obssrcserver
+++ b/dist/obssrcserver
@@ -37,7 +37,7 @@ fi
 if [ -n "$OBS_BACKENDCODE_DIR" ]; then
 	obsdir="$OBS_BACKENDCODE_DIR"
 else
-	obsdir=/usr/lib/obs/server/
+	obsdir=/usr/lib/obs/server
 fi
 rundir="$OBS_RUN_DIR"
 logdir="$OBS_LOG_DIR"

--- a/dist/obswarden
+++ b/dist/obswarden
@@ -39,7 +39,7 @@ fi
 if [ -n "$OBS_BACKENDCODE_DIR" ]; then
 	obsdir="$OBS_BACKENDCODE_DIR"
 else
-	obsdir=/usr/lib/obs/server/
+	obsdir=/usr/lib/obs/server
 fi
 rundir="$OBS_RUN_DIR"
 logdir="$OBS_LOG_DIR"


### PR DESCRIPTION
The $obsdir variable has unnecessary '/' symbol. As an example,
the $obsdir in the './dist/obssrcserver' service script is combined by
'"$obsdir"/bs_srcserver' statement.

For example:
obsdir=/usr/lib/obs/server/
startproc -f -l "$logdir"/src_server.log "$obsdir"/bs_srcserver

As a result, "/" is duplicated with "//".
Let's modify the folder name of $obsdir variable from
"obsdir=/usr/lib/obs/server/" to "obsdir=/usr/lib/obs/server".

Signed-off-by: Geunsik Lim <geunsik.lim@samsung.com>