### PR TITLE
[ci] Add backend calls to project and package factories

### DIFF
--- a/src/api/spec/factories/packages.rb
+++ b/src/api/spec/factories/packages.rb
@@ -2,13 +2,22 @@ FactoryGirl.define do
   factory :package do
     project
     sequence(:name) { |n| "package_#{n}" }
+
+    after(:create) do |package|
+      # NOTE: Enable global write through when writing new VCR cassetes.
+      # ensure the backend knows the project
+      if CONFIG['global_write_through']
+        Suse::Backend.put("/source/#{CGI.escape(package.project.name)}/#{CGI.escape(package.name)}/_meta", package.to_axml)
+      end
+    end
+
     factory :package_with_file do
       after(:create) do |package|
         # NOTE: Enable global write through when writing new VCR cassetes.
         # ensure the backend knows the project
-        Suse::Backend.put("/source/#{CGI.escape(package.project.name)}/_meta", package.project.to_axml)
-        Suse::Backend.put("/source/#{CGI.escape(package.project.name)}/#{CGI.escape(package.name)}/_meta", package.to_axml)
-        Suse::Backend.put("/source/#{CGI.escape(package.project.name)}/#{CGI.escape(package.name)}/somefile.txt", Faker::Lorem.paragraph)
+        if CONFIG['global_write_through']
+          Suse::Backend.put("/source/#{CGI.escape(package.project.name)}/#{CGI.escape(package.name)}/somefile.txt", Faker::Lorem.paragraph)
+        end
       end
     end
   end

--- a/src/api/spec/factories/project.rb
+++ b/src/api/spec/factories/project.rb
@@ -3,6 +3,14 @@ FactoryGirl.define do
     sequence(:name) { |n| "project_#{n}" }
     title { Faker::Book.title }
 
+    after(:create) do |project|
+      # NOTE: Enable global write through when writing new VCR cassetes.
+      # ensure the backend knows the project
+      if CONFIG['global_write_through']
+        Suse::Backend.put("/source/#{CGI.escape(project.name)}/_meta", project.to_axml)
+      end
+    end
+
     # remote projects validate additional the description and remoteurl
     factory :remote_project do
       description { Faker::Lorem.sentence }


### PR DESCRIPTION
Certain parts of OBS send http requests to the backend. For that to work we
need project, package and probably other factories to correctly setup the
backend for the created objects.