### PR TITLE
[vagrant] start bs_service with backend

### DIFF
--- a/contrib/common.sh
+++ b/contrib/common.sh
@@ -7,6 +7,7 @@ function allow_vendor_change() {
 function add_common_repos() {
   zypper -q ar -f http://download.opensuse.org/repositories/devel:/languages:/perl/openSUSE_Leap_42.1/devel:languages:perl.repo
   zypper -q ar -f http://download.opensuse.org/repositories/OBS:/Server:/Unstable/openSUSE_42.1/OBS:Server:Unstable.repo
+  zypper -q ar -f http://download.opensuse.org/repositories/openSUSE:/Tools/openSUSE_42.1/openSUSE:Tools.repo
   zypper -q --gpg-auto-import-keys refresh
 }
 
@@ -34,7 +35,10 @@ function install_common_packages() {
     perl-JSON-XS \
     curl \
     vim-data \
-    psmisc
+    psmisc \
+    obs-service-download_src_package obs-service-download_files obs-service-download_url \
+    obs-service-format_spec_file obs-service-kiwi_import \
+    osc
 
   # This is a workaround for a very strange behavior
   # After installing one of the follwing packages - obs-server, curl or vim-data

--- a/contrib/start_development_backend
+++ b/contrib/start_development_backend
@@ -57,10 +57,11 @@ if [ -n "$REDIR_LOG" ]; then
   APPEND_ARR[3]=">$REDIR_LOG/bs_sched_x86_64.log 2>&1"
   APPEND_ARR[4]=">$REDIR_LOG/bs_dispatch.log 2>&1"
   APPEND_ARR[5]=">$REDIR_LOG/bs_publish.log 2>&1"
+  APPEND_ARR[6]=">$REDIR_LOG/bs_service.log 2>&1"
   w_count=1
   while [ $w_count -le $WORKER_N ]
   do 
-    index=5+$w_count
+    index=6+$w_count
     APPEND_ARR[$index]=">$REDIR_LOG/bs_worker_$w_count.log 2>&1"
     let w_count=$w_count+1
   done
@@ -82,6 +83,7 @@ if [ ! -f $GIT_HOME/src/backend/BSConfig.pm ]; then
   cp $GIT_HOME/src/backend/BSConfig.pm.template $GIT_HOME/src/backend/BSConfig.pm
 fi
 perl -pi -e 's/my \$hostname.*/my \$hostname="localhost";/' $GIT_HOME/src/backend/BSConfig.pm
+perl -pi -e 's/our \$bsserviceuser.*/our \$bsserviceuser="obsrun";/' $GIT_HOME/src/backend/BSConfig.pm
 
 
 #start backend services (the minimum needed) with two arch(i586/x86_64) schedulers and one worker
@@ -105,6 +107,9 @@ eval $COMMAND_STRING
 echo "Starting bs_publish"
 COMMAND_STRING="sudo $GIT_HOME/src/backend/bs_publish ${APPEND_ARR[5]} &"
 eval $COMMAND_STRING
+echo "Starting bs_service"
+COMMAND_STRING="sudo $GIT_HOME/src/backend/bs_service ${APPEND_ARR[6]} &"
+eval $COMMAND_STRING
 w_count=1
 while [ $w_count -le $WORKER_N ]
 do
@@ -116,7 +121,7 @@ do
   fi
   sudo chown -R obsrun:obsrun /srv/obs/run/
 
-  index=$w_count+5;
+  index=$w_count+6;
   echo "Starting bs_worker"
   COMMAND_STRING="sudo $GIT_HOME/src/backend/bs_worker --hardstatus --root /var/cache/obs/worker/root_$w_count --statedir /srv/obs/run/worker/$w_count --id $HOSTNAME:$w_count --reposerver http://localhost:5252 --hostlabel OBS_WORKER_SECURITY_LEVEL_ --jobs 1 --cachedir /var/cache/obs/worker/cache --cachesize 3967 ${APPEND_ARR[$index]} &"
   eval $COMMAND_STRING
@@ -138,6 +143,8 @@ function clean_up {
   sudo killall bs_worker
   echo -e "Terminated Worker"
   sudo killall bs_publish
+  echo -e "Terminated Publisher"
+  sudo killall bs_service
   echo -e "Terminated Publisher"
   exit;
 }


### PR DESCRIPTION
bs_service is now started with the backend. So the development box is now capable of handling _service files and source services. 

To archive this another repo and the obs-service-* packages were needed. 