### PR TITLE
[backend] fix for issue#2166

### DIFF
--- a/dist/obs-server.logrotate
+++ b/dist/obs-server.logrotate
@@ -2,10 +2,17 @@
 /srv/obs/log/*.log {
     compress
     dateext
-    rotate 2 
+    rotate 2
     daily
     missingok
     copytruncate
-} 
+}
 
-
+/srv/obs/service/log/*.log {
+    compress
+    dateext
+    rotate 2
+    daily
+    missingok
+    copytruncate
+}


### PR DESCRIPTION
* added "docker rm" in call-service-in-docker.sh
  ("docker run ... --rm" seems not to be sufficient)
* added printlog function and some logging statements
* added logrotate entries for the new logfiles
* using basename of tempdir as part of container name instead of PID