### PR TITLE
[api][webui] delete_all with conditions deprecated

### DIFF
--- a/src/api/app/controllers/tag_controller.rb
+++ b/src/api/app/controllers/tag_controller.rb
@@ -342,7 +342,7 @@ class TagController < ApplicationController
       old_tags = get_tags_by_user_and_package( false )
       old_tags.each do |old_tag|
         unless tag_hash.has_key? old_tag.name
-          Tagging.delete_all("user_id = #{@user.id} AND taggable_id = #{@package.id} AND taggable_type = 'Package' AND tag_id = #{old_tag.id}")
+          Tagging.where("user_id = #{@user.id} AND taggable_id = #{@package.id} AND taggable_type = 'Package' AND tag_id = #{old_tag.id}").delete_all
         end
       end
       save_tags(@package, @user, tags)
@@ -351,7 +351,7 @@ class TagController < ApplicationController
       old_tags = get_tags_by_user_and_project( false )
       old_tags.each do |old_tag|
         unless tag_hash.has_key? old_tag.name
-          Tagging.delete_all("user_id = #{@user.id} AND taggable_id = #{@project.id} AND taggable_type = 'Project' AND tag_id = #{old_tag.id}")
+          Tagging.where("user_id = #{@user.id} AND taggable_id = #{@project.id} AND taggable_type = 'Project' AND tag_id = #{old_tag.id}").delete_all
         end
       end
       save_tags(@project, @user, tags)

--- a/src/api/app/models/group.rb
+++ b/src/api/app/models/group.rb
@@ -55,7 +55,7 @@ class Group < ApplicationRecord
       end
     end
     cache.each do |login_id, _|
-      GroupMaintainer.delete_all(['user_id = ? AND group_id = ?', login_id, self.id])
+      GroupMaintainer.where('user_id = ? AND group_id = ?', login_id, self.id).delete_all
     end
 
     # update user list
@@ -77,7 +77,7 @@ class Group < ApplicationRecord
 
     # delete all users which were not listed
     cache.each do |login_id, _gu|
-      GroupsUser.delete_all(['user_id = ? AND group_id = ?', login_id, self.id])
+      GroupsUser.where('user_id = ? AND group_id = ?', login_id, self.id).delete_all
     end
   end
 
@@ -100,7 +100,7 @@ class Group < ApplicationRecord
   end
 
   def remove_user(user)
-    GroupsUser.delete_all(['user_id = ? AND group_id = ?', user.id, self.id])
+    GroupsUser.where('user_id = ? AND group_id = ?', user.id, self.id).delete_all
   end
 
   def set_email(email)

--- a/src/api/app/models/project.rb
+++ b/src/api/app/models/project.rb
@@ -719,7 +719,7 @@ class Project < ApplicationRecord
   def update_repository_architectures(current_repo, xml_hash)
     # destroy architecture references
     logger.debug "delete all repository architectures of repository '#{self.id}'"
-    RepositoryArchitecture.delete_all(['repository_id = ?', current_repo.id])
+    RepositoryArchitecture.where('repository_id = ?', current_repo.id).delete_all
 
     position = 1
     xml_hash.elements('arch') do |arch|

--- a/src/api/app/models/project_log_entry.rb
+++ b/src/api/app/models/project_log_entry.rb
@@ -28,7 +28,7 @@ class ProjectLogEntry < ApplicationRecord
 
   # Delete old entries
   def self.clean_older_than(date)
-    delete_all(["datetime < ?", date])
+    where('datetime < ?', date).delete_all
   end
 
   # Human readable message, based in the event class


### PR DESCRIPTION
Passing conditions to `delete_all` is deprecated and will be removed in Rails 5.1. To achieve the same use `where(conditions).delete_all`