### PR TITLE
[webui][ci] trigger service: Sanitize backend error message before exposing it to users

### DIFF
--- a/src/api/app/controllers/webui/package_controller.rb
+++ b/src/api/app/controllers/webui/package_controller.rb
@@ -667,8 +667,10 @@ class Webui::PackageController < Webui::WebuiController
     begin
       Suse::Backend.post "/source/#{URI.escape(@project.name)}/#{URI.escape(@package.name)}?cmd=runservice&user=#{User.current}"
       flash[:notice] = 'Services successfully triggered'
-    rescue Timeout::Error, ActiveXML::Transport::NotFoundError, ActiveXML::Transport::Error => e
+    rescue Timeout::Error => e
       flash[:error] = "Services couldn't be triggered: " + e.message
+    rescue ActiveXML::Transport::NotFoundError, ActiveXML::Transport::Error => e
+      flash[:error] = "Services couldn't be triggered: " + Xmlhash::XMLHash.new(error: e.summary)[:error]
     end
     redirect_to package_show_path(@project, @package)
   end

--- a/src/api/spec/controllers/webui/package_controller_spec.rb
+++ b/src/api/spec/controllers/webui/package_controller_spec.rb
@@ -540,17 +540,13 @@ EOT
 
     context "without a service file in the package" do
       let(:post_url) { "#{CONFIG['url']}/source/#{source_project}/#{source_package}?cmd=runservice&user=#{user}" }
-      let(:error) do
-        "Services couldn't be triggered: <status code=\"404\">\n  <summary>no source service defined!</summary>" \
-        "\n  <details>404 no source service defined!</details>\n</status>\n"
-      end
 
       before do
         get :trigger_services, params: { project: source_project, package: source_package }
       end
 
       it { expect(a_request(:post, post_url)).to have_been_made.once }
-      it { expect(flash[:error]).to eq(error) }
+      it { expect(flash[:error]).to eq("Services couldn't be triggered: no source service defined!") }
       it { is_expected.to redirect_to(action: :show, project: source_project, package: source_package) }
     end
   end


### PR DESCRIPTION
Previously the full backend repsonse was show to the user (xml format). With this commit
we just read out the summary from xml and show it via flash error.