### PR TITLE
[ci] Avoid using localhost:3200 in test

### DIFF
--- a/src/api/config/environments/test.rb
+++ b/src/api/config/environments/test.rb
@@ -57,7 +57,7 @@ end
 
 CONFIG['source_host'] = "localhost"
 CONFIG['source_port'] = 3200
-CONFIG['url'] = "http://#{CONFIG['source_host']}:#{CONFIG['source_port']}"
+CONFIG['source_url'] = "http://#{CONFIG['source_host']}:#{CONFIG['source_port']}"
 
 CONFIG['response_schema_validation'] = true
 

--- a/src/api/spec/cassettes/Packages/triggering_package_rebuild/via_binaries_view.yml
+++ b/src/api/spec/cassettes/Packages/triggering_package_rebuild/via_binaries_view.yml
@@ -278,4 +278,41 @@ http_interactions:
         </status>
     http_version: 
   recorded_at: Tue, 30 Aug 2016 09:42:19 GMT
+- request:
+    method: post
+    uri: http://localhost:3200/build/home:package_test_user?arch=x86_64&cmd=rebuild&package=test_package&repository=repository_92
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Content-Type:
+      - application/octet-stream
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 404
+      message: project 'home package_test_user' does not exist
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '172'
+    body:
+      encoding: UTF-8
+      string: |
+        <status code="404">
+          <summary>project 'home:package_test_user' does not exist</summary>
+          <details>404 project 'home:package_test_user' does not exist</details>
+        </status>
+    http_version: 
+  recorded_at: Tue, 04 Oct 2016 10:52:28 GMT
 recorded_with: VCR 3.0.3

--- a/src/api/spec/cassettes/Packages/triggering_package_rebuild/via_live_build_log.yml
+++ b/src/api/spec/cassettes/Packages/triggering_package_rebuild/via_live_build_log.yml
@@ -426,4 +426,189 @@ http_interactions:
         </status>
     http_version: 
   recorded_at: Tue, 30 Aug 2016 09:42:27 GMT
+- request:
+    method: get
+    uri: http://localhost:3200/build/home:package_test_user/repository_93/x86_64/test_package/_jobstatus
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - text/plain
+      Accept-Encoding:
+      - identity
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 404
+      message: project 'home package_test_user' does not exist
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '172'
+    body:
+      encoding: UTF-8
+      string: |
+        <status code="404">
+          <summary>project 'home:package_test_user' does not exist</summary>
+          <details>404 project 'home:package_test_user' does not exist</details>
+        </status>
+    http_version: 
+  recorded_at: Tue, 04 Oct 2016 10:52:31 GMT
+- request:
+    method: get
+    uri: http://localhost:3200/build/home:package_test_user/repository_93/x86_64/test_package/_log?view=entry
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - text/plain
+      Accept-Encoding:
+      - identity
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 404
+      message: project 'home package_test_user' does not exist
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '172'
+    body:
+      encoding: UTF-8
+      string: |
+        <status code="404">
+          <summary>project 'home:package_test_user' does not exist</summary>
+          <details>404 project 'home:package_test_user' does not exist</details>
+        </status>
+    http_version: 
+  recorded_at: Tue, 04 Oct 2016 10:52:31 GMT
+- request:
+    method: get
+    uri: http://localhost:3200/build/home:package_test_user/repository_93/x86_64/test_package/_log?end=65536&nostream=1&start=0
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - text/plain
+      Accept-Encoding:
+      - identity
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 404
+      message: project 'home package_test_user' does not exist
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '172'
+    body:
+      encoding: UTF-8
+      string: |
+        <status code="404">
+          <summary>project 'home:package_test_user' does not exist</summary>
+          <details>404 project 'home:package_test_user' does not exist</details>
+        </status>
+    http_version: 
+  recorded_at: Tue, 04 Oct 2016 10:52:31 GMT
+- request:
+    method: post
+    uri: http://localhost:3200/build/home:package_test_user?arch=x86_64&cmd=rebuild&package=test_package&repository=repository_93
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Content-Type:
+      - application/octet-stream
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 404
+      message: project 'home package_test_user' does not exist
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '172'
+    body:
+      encoding: UTF-8
+      string: |
+        <status code="404">
+          <summary>project 'home:package_test_user' does not exist</summary>
+          <details>404 project 'home:package_test_user' does not exist</details>
+        </status>
+    http_version: 
+  recorded_at: Tue, 04 Oct 2016 10:52:31 GMT
+- request:
+    method: get
+    uri: http://localhost:3200/build/home:package_test_user/_result?package=test_package&repository=repository_93&view=status
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - text/plain
+      Accept-Encoding:
+      - identity
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 404
+      message: project 'home package_test_user' does not exist
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '172'
+    body:
+      encoding: UTF-8
+      string: |
+        <status code="404">
+          <summary>project 'home:package_test_user' does not exist</summary>
+          <details>404 project 'home:package_test_user' does not exist</details>
+        </status>
+    http_version: 
+  recorded_at: Tue, 04 Oct 2016 10:52:31 GMT
 recorded_with: VCR 3.0.3

--- a/src/api/spec/controllers/webui/package_controller_spec.rb
+++ b/src/api/spec/controllers/webui/package_controller_spec.rb
@@ -527,7 +527,7 @@ EOT
     end
 
     context 'with right params' do
-      let(:post_url) { "#{CONFIG['url']}/source/#{source_project}/#{service_package}?cmd=runservice&user=#{user}" }
+      let(:post_url) { "#{CONFIG['source_url']}/source/#{source_project}/#{service_package}?cmd=runservice&user=#{user}" }
 
       before do
         get :trigger_services, params: { project: source_project, package: service_package }
@@ -539,7 +539,7 @@ EOT
     end
 
     context "without a service file in the package" do
-      let(:post_url) { "#{CONFIG['url']}/source/#{source_project}/#{source_package}?cmd=runservice&user=#{user}" }
+      let(:post_url) { "#{CONFIG['source_url']}/source/#{source_project}/#{source_package}?cmd=runservice&user=#{user}" }
 
       before do
         get :trigger_services, params: { project: source_project, package: source_package }

--- a/src/api/spec/features/webui/packages_spec.rb
+++ b/src/api/spec/features/webui/packages_spec.rb
@@ -101,7 +101,7 @@ RSpec.feature "Packages", :type => :feature, :js => true do
   context "triggering package rebuild" do
     let(:repository) { create(:repository, architectures: ["x86_64"]) }
     let(:rebuild_url) {
-      "http://localhost:3200/build/#{user.home_project.name}?cmd=rebuild&arch=x86_64&package=#{package.name}&repository=#{repository.name}"
+      "#{CONFIG['source_url']}/build/#{user.home_project.name}?cmd=rebuild&arch=x86_64&package=#{package.name}&repository=#{repository.name}"
     }
     let(:fake_buildresult) {
       "<resultlist state='123'>

--- a/src/api/spec/models/package_spec.rb
+++ b/src/api/spec/models/package_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe Package, vcr: true do
 
   context '#delete_file' do
     let(:package_with_file) { create(:package_with_file, name: 'package_with_files', project: home_project)}
-    let(:url) { "http://localhost:3200/source/#{home_project.name}/#{package_with_file.name}" }
+    let(:url) { "#{CONFIG['source_url']}/source/#{home_project.name}/#{package_with_file.name}" }
 
     before do
       User.current = user

--- a/src/api/spec/models/service_spec.rb
+++ b/src/api/spec/models/service_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Service, vcr: true do
   let(:home_project) { user.home_project }
   let(:package) { create(:package, name: 'test_package', project: home_project) }
   let(:service) { package.services }
-  let(:url) { "http://localhost:3200/source/#{home_project.name}/#{package.name}" }
+  let(:url) { "#{CONFIG['source_url']}/source/#{home_project.name}/#{package.name}" }
 
   context '#addKiwiImport' do
     before do


### PR DESCRIPTION
As discussed in https://github.com/openSUSE/open-build-service/pull/2183 we should not use the port and host directly in the tests. I have changed it in the rest of the places where it is used.

As discussed with @mdeniz I have also renamed `CONFIG['url']` to be `CONFIG['source_url']`.