### PR TITLE
[ci] Add missing cassette for package controller test

### DIFF
--- a/src/api/spec/cassettes/Webui_PackageController/GET_show/with_a_package_that_have_derived_packages/1_7_3_1.yml
+++ b/src/api/spec/cassettes/Webui_PackageController/GET_show/with_a_package_that_have_derived_packages/1_7_3_1.yml
@@ -835,4 +835,41 @@ http_interactions:
         </directory>
     http_version: 
   recorded_at: Mon, 03 Oct 2016 11:25:27 GMT
+- request:
+    method: get
+    uri: http://localhost:3200/source/home:tom/package_with_file/_service
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - text/plain
+      Accept-Encoding:
+      - identity
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 404
+      message: package 'package_with_file' does not exist
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '162'
+    body:
+      encoding: UTF-8
+      string: |
+        <status code="404">
+          <summary>package 'package_with_file' does not exist</summary>
+          <details>404 package 'package_with_file' does not exist</details>
+        </status>
+    http_version: 
+  recorded_at: Thu, 06 Oct 2016 12:14:19 GMT
 recorded_with: VCR 3.0.3


### PR DESCRIPTION
This fixes tests that broke with 00c9380273a80d64cb92d52516ce0ecad580aef3