### PR TITLE
[dist] Use localhost instead of ${HOSTNAME}

### DIFF
--- a/dist/obsworker
+++ b/dist/obsworker
@@ -314,10 +314,13 @@ case "$1" in
             fi
 	    I_INDEX=$I
             I=$(( $I + 1 ))
+	    if [ "$OBS_USE_MULTIPLE_WORKERS" = 'no' ]; then WORKERNAME='localhost'
+	    else WORKERNAME=${HOSTNAME}
+            fi 
 	    if [ "$OBS_VM_TYPE" = 'zvm' ]; then
-		WORKERID="${HOSTNAME}:${WORKERS[$I_INDEX]}"
+		WORKERID="${WORKERNAME}:${WORKERS[$I_INDEX]}"
 	    else
-                WORKERID="${HOSTNAME}:$I"
+                WORKERID="${WORKERNAME}:$I"
 	    fi
             R=$OBS_WORKER_DIRECTORY/root_$I
             # prepare obsworker startup in screen...

--- a/dist/sysconfig.obs-server
+++ b/dist/sysconfig.obs-server
@@ -380,3 +380,12 @@ OBS_WORKER_SCRIPT_URL=""
 #
 #
 OBS_WORKER_CLEANUP_CHROOT=""
+
+## Path:        Applications/OBS
+## Description: Define whether multiple obs workers run or not
+## Type:        ("yes" | "no")
+## Default:     "no"
+## Config:      OBS
+#
+#
+OBS_USE_MULTIPLE_WORKERS="no"


### PR DESCRIPTION
The ${HOSTNAME} variable of obsworker  service daemon is dependent
on the /etc/hostname file. Sometimes, we have often got the abnormal
execution of obsworker service daemon because of the incorrect mapping
situation of ${HOSTNAME}. 

In order to keep the stable execution and more
portability of the obswork service, Let's use localhost instead of the
/etc/hostname by default such as the "localhost:{5352|5252}" of
repserver/srcserver.

Signed-off-by: Geunsik Lim geunsik.lim@samsung.com
