### PR TITLE
[webui][ci] Get rid of mime deprecation warnings

### DIFF
--- a/src/api/app/controllers/webui/feeds_controller.rb
+++ b/src/api/app/controllers/webui/feeds_controller.rb
@@ -6,11 +6,11 @@ class Webui::FeedsController < Webui::WebuiController
 
   def news
     @news = StatusMessage.alive.limit(5)
-    raise ActionController::RoutingError.new('expected application/rss') unless request.format == Mime::RSS
+    raise ActionController::RoutingError.new('expected application/rss') unless request.format == Mime[:rss]
   end
 
   def latest_updates
-    raise ActionController::RoutingError.new('expected application/rss') unless request.format == Mime::RSS
+    raise ActionController::RoutingError.new('expected application/rss') unless request.format == Mime[:rss]
     @latest_updates = get_latest_updated(10)
   end
 

--- a/src/api/config/initializers/fast_json.rb
+++ b/src/api/config/initializers/fast_json.rb
@@ -4,6 +4,6 @@ require 'yajl'
 
 ActionController::Renderers.add :json do |json, _|
     json = Yajl::Encoder.encode(json) unless json.kind_of?(String)
-    self.content_type ||= Mime::JSON
+    self.content_type ||= Mime[:json]
     json
 end

--- a/src/api/config/initializers/nokogiri_builder.rb
+++ b/src/api/config/initializers/nokogiri_builder.rb
@@ -5,7 +5,7 @@ module ActionView
   module Template::Handlers
     class NokogiriBuilder
       class_attribute :default_format
-      self.default_format = Mime::XML
+      self.default_format = Mime[:xml]
 
       def call(template)
         "xml = ::Nokogiri::XML::Builder.new { |xml|" +

--- a/src/api/config/initializers/wrap_parameters.rb
+++ b/src/api/config/initializers/wrap_parameters.rb
@@ -46,7 +46,7 @@ class MyParamsParser
     end
 
     case request.content_mime_type
-    when Mime::JSON
+    when Mime[:json]
       begin
         data = Yajl::Parser.parse(request.raw_post)
       rescue Yajl::ParseError => e
@@ -56,7 +56,7 @@ class MyParamsParser
       request.body.rewind if request.body.respond_to?(:rewind)
       data = {:_json => data} unless data.is_a?(Hash)
       data.with_indifferent_access
-    when Mime::XML
+    when Mime[:xml]
       data = Xmlhash.parse(request.body.read)
       request.body.rewind if request.body.respond_to?(:rewind)
       if data


### PR DESCRIPTION
Running all rspec tests results in almost 500 lines of this kind at the log/tests.log file:

DEPRECATION WARNING: Accessing mime types via constants is deprecated. Please change `Mime::JSON` to `Mime[:json]`. (called from block in <top (required)> at /vagrant/src/api/config/initializers/fast_json.rb:7)
DEPRECATION WARNING: Accessing mime types via constants is deprecated. Please change `Mime::JSON` to `Mime[:json]`. (called from parse_parameters at /vagrant/src/api/config/initializers/wrap_parameters.rb:49)
DEPRECATION WARNING: Accessing mime types via constants is deprecated. Please change `Mime::RSS` to `Mime[:rss]`. (called from news at /vagrant/src/api/app/controllers/webui/feeds_controller.rb:9)
DEPRECATION WARNING: Accessing mime types via constants is deprecated. Please change `Mime::XML` to `Mime[:xml]`. (called from parse_parameters at /vagrant/src/api/config/initializers/wrap_parameters.rb:59)
DEPRECATION WARNING: Accessing mime types via constants is deprecated. Please change `Mime::XML` to `Mime[:xml]`. (called from <class:NokogiriBuilder> at /vagrant/src/api/config/initializers/nokogiri_builder.rb:8)