### PR TITLE
[webui][ci] Remove render :text deprecation warnings

### DIFF
--- a/src/api/app/controllers/application_controller.rb
+++ b/src/api/app/controllers/application_controller.rb
@@ -360,7 +360,7 @@ class ApplicationController < ActionController::Base
       text = xml.dump_xml
     rescue ActiveXML::ParseError
     end
-    render text: text, status: http_status
+    render plain: text, status: http_status
   end
 
   rescue_from Project::WritePermissionError do |exception|

--- a/src/api/app/controllers/request_controller.rb
+++ b/src/api/app/controllers/request_controller.rb
@@ -190,7 +190,7 @@ class RequestController < ApplicationController
       xml_request.set_attribute('actions', "0")
       render xml: xml_request.dump_xml
     else
-      render text: diff_text
+      render plain: diff_text
     end
   end
 

--- a/src/api/app/controllers/webui/package_controller.rb
+++ b/src/api/app/controllers/webui/package_controller.rb
@@ -944,9 +944,9 @@ class Webui::PackageController < Webui::WebuiController
     required_parameters :package, :project
     tgt_pkg = Package.find_by_project_and_name( params[:project], params[:package] )
     if tgt_pkg and tgt_pkg.develpackage
-      render text: tgt_pkg.develpackage.project
+      render plain: tgt_pkg.develpackage.project
     else
-      render text: ''
+      render plain: ''
     end
   end
 

--- a/src/api/app/controllers/webui/project_controller.rb
+++ b/src/api/app/controllers/webui/project_controller.rb
@@ -623,7 +623,7 @@ class Webui::ProjectController < Webui::WebuiController
 
     respond_to do |format|
       format.html { redirect_to({ :action => :status, project: @project }, notice: 'Cleared comments for packages.') }
-      format.js { render text: '<em>Cleared comments for packages</em>' }
+      format.js { render js: '<em>Cleared comments for packages</em>' }
     end
   end
 

--- a/src/api/app/controllers/webui/user_controller.rb
+++ b/src/api/app/controllers/webui/user_controller.rb
@@ -179,7 +179,7 @@ class Webui::UserController < Webui::WebuiController
 
     expires_in 5.hours, public: true
     if stale?(etag: Digest::MD5.hexdigest(content))
-      render text: content, layout: false, content_type: 'image/png'
+      render body: content, layout: false, content_type: 'image/png'
     end
   end
 

--- a/src/api/spec/controllers/webui/webui_controller_spec.rb
+++ b/src/api/spec/controllers/webui/webui_controller_spec.rb
@@ -10,21 +10,21 @@ RSpec.describe Webui::WebuiController do
     before_action :set_project, only: :edit
 
     def index
-      render text: 'anonymous controller'
+      render plain: 'anonymous controller'
     end
 
     # RSpec anonymous controller only support RESTful routes
     # http://stackoverflow.com/questions/7027518/no-route-matches-rspecs-anonymous-controller
     def new
-      render text: 'anonymous controller - requires_admin_privileges'
+      render plain: 'anonymous controller - requires_admin_privileges'
     end
 
     def show
-      render text: 'anonymous controller - requires_login'
+      render plain: 'anonymous controller - requires_login'
     end
 
     def edit
-      render text: 'anonymous controller - set_project'
+      render plain: 'anonymous controller - set_project'
     end
   end
 


### PR DESCRIPTION
Running all rspec tests results in 50 lines of this kind at the log/tests.log file:

`render :text` is deprecated because it does not actually render a `text/plain` response. Switch to `render plain: 'plain text'` to render as `text/plain`, `render html: '<strong>HTML</strong>'` to render as `text/html`, or `render body: 'raw'` to match the deprecated behavior and render with the default Content-Type, which is `text/plain`.