### PR TITLE
[webui][ci] Remove uniq deprecation warnings

### DIFF
--- a/src/api/app/models/distribution.rb
+++ b/src/api/app/models/distribution.rb
@@ -1,8 +1,8 @@
 class Distribution < ApplicationRecord
   validates_presence_of :vendor, :version, :name, :reponame, :repository, :project
 
-  has_and_belongs_to_many :icons, -> { uniq() }, class_name: 'DistributionIcon'
-  has_and_belongs_to_many :architectures, -> { uniq() }, class_name: 'Architecture'
+  has_and_belongs_to_many :icons, -> { distinct() }, class_name: 'DistributionIcon'
+  has_and_belongs_to_many :architectures, -> { distinct() }, class_name: 'Architecture'
 
   def self.parse(xmlhash)
     Distribution.transaction do

--- a/src/api/spec/controllers/webui/repositories_controller_spec.rb
+++ b/src/api/spec/controllers/webui/repositories_controller_spec.rb
@@ -74,7 +74,7 @@ RSpec.describe Webui::RepositoriesController, vcr: true do
       it 'each repository has a different position' do
         id = user.home_project.repositories.pluck(:id)
         foo = RepositoryArchitecture.where(repository_id: id)
-        expect(foo.count).to eq(foo.uniq.count)
+        expect(foo.count).to eq(foo.distinct.count)
       end
 
       it { expect(repo_for_user_home.architectures.pluck(:name)).to match_array(['i586', 'x86_64']) }


### PR DESCRIPTION
Running all rspec tests results in 20 lines of this kind at the log/tests.log file:

DEPRECATION WARNING: uniq is deprecated and will be removed from Rails 5.1 (use distinct instead)