### PR TITLE
[webui] Allow user to toggle full commit dates

### DIFF
--- a/src/api/app/assets/javascripts/webui/application.js
+++ b/src/api/app/assets/javascripts/webui/application.js
@@ -246,3 +246,36 @@ function select_from_autocomplete(toselect) {
         if ($(this).text() == toselect) { $(this).trigger('mouseenter').click(); }
     });
 }
+
+// convert timestamps to real dates
+$(function() {
+  $('.convert-dates').on('click', function() {
+    var targets = $('.'+$(this).data('target'));
+
+    if (typeof $(this).data('showtext') === typeof undefined)
+    {
+        $(this).data('showtext', $(this).html());
+        $(this).html($(this).data('hidetext'));
+    }
+    else
+    {
+        $(this).html($(this).data('showtext'));
+        $(this).removeData('showtext');
+    }
+
+    for (var i = 0; i < targets.length; i++) {
+        var element = $(targets[i]);
+        if (typeof element.data('old') == typeof undefined)
+        {
+            var date = new Date(parseInt(element.data('timestamp'))*1000);
+            element.data('old', element.html());
+            element.html(date.toDateString() + ' ' + date.toTimeString());
+        }
+        else
+        {
+            element.html(element.data('old'));
+            element.removeData('old');
+        }
+    }
+  });
+});

--- a/src/api/app/views/webui/package/_commit_item.html.erb
+++ b/src/api/app/views/webui/package/_commit_item.html.erb
@@ -21,7 +21,7 @@
             committed
         <% end %>
     <% end %>
-    <%= fuzzy_time(Time.at(commit['time'].to_i)) %> (revision <%= commit['rev'] %>)
+    <span data-timestamp="<%= commit['time'] %>" class="revision-date"><%= fuzzy_time(Time.at(commit['time'].to_i)) %></span> (revision <%= commit['rev'] %>)
     <% unless commit['user'] == '_service' or commit['comment'].blank? %>
         <pre class="plain"><%= commit['comment'] %></pre>
     <% end %>

--- a/src/api/app/views/webui/package/_files_view.html.erb
+++ b/src/api/app/views/webui/package/_files_view.html.erb
@@ -60,6 +60,9 @@
     <% else %>
         <h3>Latest Revision</h3>
     <% end %>
+    <p>
+     <a data-target="revision-date" data-hidetext="Hide full commit date" class="convert-dates">Show full commit date</a>
+    </p>
     <div style="margin-left: 1.2em">
       <%= render :partial => 'commit_item', :locals => {:rev => @revision} %>
     </div>

--- a/src/api/app/views/webui/package/revisions.html.erb
+++ b/src/api/app/views/webui/package/revisions.html.erb
@@ -13,7 +13,10 @@
     <% end %>
   </div>
   <% unless params[:showall] %>
-    <p><%= link_to('Show all', :action  => 'revisions', :project => @project, :package => @package, :showall => 1) %></p>
+    <p>
+     <%= link_to('Show all', :action  => 'revisions', :project => @project, :package => @package, :showall => 1) %> |
+     <a data-target="revision-date" data-hidetext="Hide full commit dates" class="convert-dates">Show full commit dates</a>
+    </p>
   <% end %>
 <% else %>
   <h3><%= @pagetitle %></h3>


### PR DESCRIPTION
This fixes #2164

This allows a user to show the full commit dates instead of just the
fuzzy time view.

![after1](https://cloud.githubusercontent.com/assets/8287131/19231106/79cea7d4-8ed8-11e6-8937-e386203a4140.png)

![after-2](https://cloud.githubusercontent.com/assets/8287131/19231111/7cdc436e-8ed8-11e6-91f9-8b802849043f.png)
