### PR TITLE
[webui][api] redirect_to back -> redirect_back

### DIFF
--- a/src/api/app/controllers/application_controller.rb
+++ b/src/api/app/controllers/application_controller.rb
@@ -440,12 +440,10 @@ class ApplicationController < ActionController::Base
       format.xml { render template: 'status', status: @status }
       format.json { render json: { errorcode: @errorcode, summary: @summary }, status: @status }
       format.html do
-        if request.env['HTTP_REFERER']
-          redirect_to(:back)
-        else
+        unless request.env['HTTP_REFERER']
           flash[:error] = "#{@errorcode}(#{@summary}): #{@message}"
-          redirect_to root_path
         end
+        redirect_back(fallback_location: root_path)
       end
     end
   end

--- a/src/api/app/controllers/webui/apidocs_controller.rb
+++ b/src/api/app/controllers/webui/apidocs_controller.rb
@@ -18,7 +18,7 @@ class Webui::ApidocsController < Webui::WebuiController
       send_file( file, :type => "text/xml", :disposition => "inline" )
     else
       flash[:error] = "File not found: #{params[:filename]}"
-      redirect_back(fallback_location: {:controller => 'apidocs', :action => 'index'})
+      redirect_back(fallback_location: {controller: 'apidocs', action: 'index'})
     end
     return
   end

--- a/src/api/app/controllers/webui/apidocs_controller.rb
+++ b/src/api/app/controllers/webui/apidocs_controller.rb
@@ -6,7 +6,7 @@ class Webui::ApidocsController < Webui::WebuiController
     else
       logger.error "Unable to load apidocs index file from #{CONFIG['apidocs_location'] }. Did you create the apidocs?"
       flash[:error] = "Unable to load API documentation."
-      redirect_back_or_to root_path
+      redirect_back(fallback_location: root_path)
     end
   end
 
@@ -18,7 +18,7 @@ class Webui::ApidocsController < Webui::WebuiController
       send_file( file, :type => "text/xml", :disposition => "inline" )
     else
       flash[:error] = "File not found: #{params[:filename]}"
-      redirect_back_or_to :controller => 'apidocs', :action => 'index'
+      redirect_back(fallback_location: {:controller => 'apidocs', :action => 'index'})
     end
     return
   end

--- a/src/api/app/controllers/webui/architectures_controller.rb
+++ b/src/api/app/controllers/webui/architectures_controller.rb
@@ -20,7 +20,7 @@ class Webui::ArchitecturesController < Webui::WebuiController
       if all_valid
         format.html { redirect_to architectures_path, notice: 'Architectures successfully updated.' }
       else
-        format.html { redirect_to :back, error: 'Not all architectures could be saved' }
+        format.html { redirect_back(fallback_location: root_path, error: 'Not all architectures could be saved') }
       end
     end
   end

--- a/src/api/app/controllers/webui/attribute_controller.rb
+++ b/src/api/app/controllers/webui/attribute_controller.rb
@@ -53,7 +53,7 @@ class Webui::AttributeController < Webui::WebuiController
                     notice: 'Attribute was successfully created.'
       end
     else
-      redirect_to :back, error: "Saving attribute failed: #{@attribute.errors.full_messages.join(', ')}"
+      redirect_back(fallback_location: root_path, error: "Saving attribute failed: #{@attribute.errors.full_messages.join(', ')}")
     end
   end
 
@@ -64,7 +64,7 @@ class Webui::AttributeController < Webui::WebuiController
       redirect_to edit_attribs_path(:project => @attribute.project.to_s, :package => @attribute.package.to_s, :attribute => @attribute.fullname),
                   notice: 'Attribute was successfully updated.'
     else
-      redirect_to :back, error: "Updating attribute failed: #{@attribute.errors.full_messages.join(', ')}"
+      redirect_back(fallback_location: root_path, error: "Updating attribute failed: #{@attribute.errors.full_messages.join(', ')}" )
     end
   end
 
@@ -72,7 +72,7 @@ class Webui::AttributeController < Webui::WebuiController
     authorize @attribute
 
     @attribute.destroy
-    redirect_to :back, notice: 'Attribute sucessfully deleted!'
+    redirect_back(fallback_location: root_path, notice: 'Attribute sucessfully deleted!')
   end
 
   private

--- a/src/api/app/controllers/webui/comments_controller.rb
+++ b/src/api/app/controllers/webui/comments_controller.rb
@@ -3,7 +3,7 @@ class Webui::CommentsController < Webui::WebuiController
     comment = Comment.find(params[:id])
     unless comment.check_delete_permissions
       flash[:error] = 'No permissions to delete comment'
-      redirect_to :back
+      redirect_back(fallback_location: root_path)
       return
     end
     comment.blank_or_destroy
@@ -14,6 +14,6 @@ class Webui::CommentsController < Webui::WebuiController
         flash[:notice] = 'Comment deleted successfully'
       end
     end
-    redirect_to :back
+    redirect_back(fallback_location: root_path)
   end
 end

--- a/src/api/app/controllers/webui/configuration_controller.rb
+++ b/src/api/app/controllers/webui/configuration_controller.rb
@@ -15,7 +15,7 @@ class Webui::ConfigurationController < Webui::WebuiController
       logger.debug "New remote project with url #{@project.remoteurl}"
       redirect_to controller: :project, action: 'show', project: @project.name
     else
-      redirect_to :back, error: "Project can't be saved: #{@project.errors.full_messages.to_sentence}"
+      redirect_back(fallback_location: root_path, error: "Project can't be saved: #{@project.errors.full_messages.to_sentence}")
     end
   end
 
@@ -24,7 +24,9 @@ class Webui::ConfigurationController < Webui::WebuiController
       if @configuration.update(configuration_params)
         format.html { redirect_to configuration_path, notice: 'Configuration was successfully updated.' }
       else
-        format.html { redirect_to :back, error: "Configuration can't be saved: #{@configuration.errors.full_messages.to_sentence}" }
+        format.html do
+          redirect_back(fallback_location: root_path, error: "Configuration can't be saved: #{@configuration.errors.full_messages.to_sentence}")
+        end
       end
     end
   end

--- a/src/api/app/controllers/webui/download_on_demand_controller.rb
+++ b/src/api/app/controllers/webui/download_on_demand_controller.rb
@@ -15,7 +15,7 @@ class Webui::DownloadOnDemandController < Webui::WebuiController
         @project.store
       end
     rescue ActiveRecord::RecordInvalid, ActiveXML::Transport::Error => exception
-      redirect_to :back, error: "Download on Demand can't be created: #{exception.message}"
+      redirect_back(fallback_location: root_path, error: "Download on Demand can't be created: #{exception.message}")
       return
     end
 
@@ -36,7 +36,7 @@ class Webui::DownloadOnDemandController < Webui::WebuiController
         @project.store
       end
     rescue ActiveRecord::RecordInvalid, ActiveXML::Transport::Error => exception
-      redirect_to :back, error: "Download on Demand can't be updated: #{exception.message}"
+      redirect_back(fallback_location: root_path, error: "Download on Demand can't be updated: #{exception.message}")
       return
     end
 
@@ -48,7 +48,7 @@ class Webui::DownloadOnDemandController < Webui::WebuiController
     authorize @download_on_demand
 
     if @download_on_demand.repository.download_repositories.count <= 1
-      redirect_to :back, error: "Download on Demand can't be removed: DoD Repositories must have at least one repository."
+      redirect_back(fallback_location: root_path, error: "Download on Demand can't be removed: DoD Repositories must have at least one repository.")
       return
     end
 
@@ -58,7 +58,7 @@ class Webui::DownloadOnDemandController < Webui::WebuiController
         @project.store
       end
     rescue ActiveRecord::RecordInvalid, ActiveXML::Transport::Error => exception
-      redirect_to :back, error: "Download on Demand can't be removed: #{exception.message}"
+      redirect_back(fallback_location: root_path, error: "Download on Demand can't be removed: #{exception.message}")
       return
     end
 

--- a/src/api/app/controllers/webui/groups_controller.rb
+++ b/src/api/app/controllers/webui/groups_controller.rb
@@ -32,7 +32,7 @@ class Webui::GroupsController < Webui::WebuiController
       flash[:success] = "Group '#{group.title}' successfully updated."
       redirect_to controller: :groups, action: :index
     else
-      redirect_to :back, error: "Group can't be saved: #{group.errors.full_messages.to_sentence}"
+      redirect_back(fallback_location: root_path, error: "Group can't be saved: #{group.errors.full_messages.to_sentence}")
     end
   end
 
@@ -43,7 +43,7 @@ class Webui::GroupsController < Webui::WebuiController
       flash[:success] = "Group '#{@group.title}' successfully updated."
       redirect_to controller: :groups, action: :index
     else
-      redirect_to :back, error: "Group can't be saved: #{@group.errors.full_messages.to_sentence}"
+      redirect_back(fallback_location: root_path, error: "Group can't be saved: #{@group.errors.full_messages.to_sentence}")
     end
   end
 
@@ -72,7 +72,7 @@ class Webui::GroupsController < Webui::WebuiController
     # Group.find_by_title! is self implemented and would raise an 500 error
     unless @group
       flash[:error] = "Group '#{params[:title]}' does not exist"
-      redirect_back_or_to controller: 'main', action: 'index'
+      redirect_back(fallback_location: {controller: 'main', action: 'index'})
     end
   end
 end

--- a/src/api/app/controllers/webui/project_controller.rb
+++ b/src/api/app/controllers/webui/project_controller.rb
@@ -136,7 +136,7 @@ class Webui::ProjectController < Webui::WebuiController
            BsRequestAction::UnknownProject,
            BsRequestAction::UnknownTargetPackage => e
       flash[:error] = e.message
-      redirect_back(fallback_location: { :action => 'show', :project => params[:project] }) and return
+      redirect_back(fallback_location: { action: 'show', project: params[:project] }) && return
     end
     redirect_to :action => 'show', :project => params[:project]
   end
@@ -173,10 +173,10 @@ class Webui::ProjectController < Webui::WebuiController
              BsRequestAction::UnknownTargetProject,
              BsRequestAction::UnknownTargetPackage => e
         flash[:error] = e.message
-        redirect_back(fallback_location: { :action => 'show', :project => params[:project] }) and return
+        redirect_back(fallback_location: { action: 'show', project: params[:project] }) && return
       rescue APIException
         flash[:error] = 'Internal problem while release request creation'
-        redirect_back(fallback_location: { :action => 'show', :project => params[:project] }) and return
+        redirect_back(fallback_location: { action: 'show', project: params[:project] }) && return
       end
     end
     redirect_to :action => 'show', :project => params[:project]
@@ -789,7 +789,7 @@ class Webui::ProjectController < Webui::WebuiController
 
   def require_maintenance_project
     unless @is_maintenance_project
-      redirect_back(fallback_location: { :action => 'show', :project => @project })
+      redirect_back(fallback_location: { action: 'show', project: @project })
       return false
     end
     return true

--- a/src/api/app/controllers/webui/project_controller.rb
+++ b/src/api/app/controllers/webui/project_controller.rb
@@ -136,7 +136,7 @@ class Webui::ProjectController < Webui::WebuiController
            BsRequestAction::UnknownProject,
            BsRequestAction::UnknownTargetPackage => e
       flash[:error] = e.message
-      redirect_back_or_to :action => 'show', :project => params[:project] and return
+      redirect_back(fallback_location: { :action => 'show', :project => params[:project] }) and return
     end
     redirect_to :action => 'show', :project => params[:project]
   end
@@ -173,10 +173,10 @@ class Webui::ProjectController < Webui::WebuiController
              BsRequestAction::UnknownTargetProject,
              BsRequestAction::UnknownTargetPackage => e
         flash[:error] = e.message
-        redirect_back_or_to :action => 'show', :project => params[:project] and return
+        redirect_back(fallback_location: { :action => 'show', :project => params[:project] }) and return
       rescue APIException
         flash[:error] = 'Internal problem while release request creation'
-        redirect_back_or_to :action => 'show', :project => params[:project] and return
+        redirect_back(fallback_location: { :action => 'show', :project => params[:project] }) and return
       end
     end
     redirect_to :action => 'show', :project => params[:project]
@@ -350,7 +350,7 @@ class Webui::ProjectController < Webui::WebuiController
       redirect_to :action => 'show', :project => @project.name
     else
       flash[:error] = "Failed to save project '#{@project}'. #{@project.errors.full_messages.to_sentence}."
-      redirect_to :back
+      redirect_back(fallback_location: root_path)
     end
   end
 
@@ -406,7 +406,7 @@ class Webui::ProjectController < Webui::WebuiController
       @project.store
       redirect_to({ action: :index, controller: :repositories, project: @project }, success: "Successfully removed path")
     else
-      redirect_to :back, error: "Can not remove path: #{@project.errors.full_messages.to_sentence}"
+      redirect_back(fallback_location: root_path, error: "Can not remove path: #{@project.errors.full_messages.to_sentence}")
     end
   end
 
@@ -534,7 +534,7 @@ class Webui::ProjectController < Webui::WebuiController
     end
 
     if request.env['HTTP_REFERER']
-      redirect_to :back
+      redirect_back(fallback_location: root_path)
     else
       redirect_to :action => :show, :project => @project
     end
@@ -705,7 +705,7 @@ class Webui::ProjectController < Webui::WebuiController
       redirect_to({action: 'maintained_projects', project: @project}, notice: "Added #{params[:maintained_project]} to maintenance")
     else
       # TODO: Better redirect to the project (maintained project tab), where the user actually came from
-      redirect_to(:back, error: "Failed to add #{params[:maintained_project]} to maintenance")
+      redirect_back(fallback_location: root_path, error: "Failed to add #{params[:maintained_project]} to maintenance")
     end
   end
 
@@ -716,7 +716,7 @@ class Webui::ProjectController < Webui::WebuiController
       @project.store
       redirect_to({:action => 'maintained_projects', :project => @project}, notice: "Removed #{@maintained_project} from maintenance")
     else
-      redirect_to :back, error: "Failed to remove #{@maintained_project} from maintenance"
+      redirect_back(fallback_location: root_path, error: "Failed to remove #{@maintained_project} from maintenance")
     end
   end
 
@@ -789,7 +789,7 @@ class Webui::ProjectController < Webui::WebuiController
 
   def require_maintenance_project
     unless @is_maintenance_project
-      redirect_back_or_to :action => 'show', :project => @project
+      redirect_back(fallback_location: { :action => 'show', :project => @project })
       return false
     end
     return true

--- a/src/api/app/controllers/webui/repositories_controller.rb
+++ b/src/api/app/controllers/webui/repositories_controller.rb
@@ -62,7 +62,7 @@ class Webui::RepositoriesController < Webui::WebuiController
     else
       flash[:error] = "Can not add repository: #{repository.errors.full_messages.to_sentence}"
       respond_to do |format|
-        format.html { redirect_to :back }
+        format.html { redirect_back(fallback_location: root_path) }
         format.js
       end
     end
@@ -103,7 +103,7 @@ class Webui::RepositoriesController < Webui::WebuiController
       msg << 'Repository not found.' if @project.valid? && !result
       respond_to do |format|
         flash[:error] = msg
-        format.html { redirect_to :back }
+        format.html { redirect_back(fallback_location: root_path) }
         format.js
       end
     end
@@ -119,7 +119,7 @@ class Webui::RepositoriesController < Webui::WebuiController
     @repository = @project.repositories.where(name: params[:repository]).first
 
     unless @repository
-      redirect_to :back, alert: "Repository '#{params[:repository]}' not found"
+      redirect_back(fallback_location: root_path, alert: "Repository '#{params[:repository]}' not found")
       return
     end
 
@@ -168,7 +168,7 @@ class Webui::RepositoriesController < Webui::WebuiController
     else
       flash[:error] = "Can not add image repository: #{repository.errors.full_messages.to_sentence}"
       respond_to do |format|
-        format.html { redirect_to :back }
+        format.html { redirect_back(fallback_location: root_path) }
         format.js { render 'create' }
       end
     end

--- a/src/api/app/controllers/webui/request_controller.rb
+++ b/src/api/app/controllers/webui/request_controller.rb
@@ -87,7 +87,7 @@ class Webui::RequestController < Webui::WebuiController
     @bsreq = BsRequest.find_by_number(params[:number])
     unless @bsreq
       flash[:error] = "Can't find request #{params[:number]}"
-      redirect_back(fallback_location: user_show_path(User.current)) and return
+      redirect_back(fallback_location: user_show_path(User.current)) && return
     end
 
     @req = @bsreq.webui_infos
@@ -151,7 +151,7 @@ class Webui::RequestController < Webui::WebuiController
     @req = BsRequest.find_by_number params[:number]
     unless @req
       flash[:error] = "Can't find request #{params[:number]}"
-      redirect_back(fallback_location: user_show_path(User.current)) and return
+      redirect_back(fallback_location: user_show_path(User.current)) && return
     end
   end
 
@@ -159,7 +159,7 @@ class Webui::RequestController < Webui::WebuiController
     @req = BsRequest.find_by_number(params[:number])
     unless @req
       flash[:error] = "Can't find request #{params[:number]}"
-      redirect_back(fallback_location: user_show_path(User.current)) and return
+      redirect_back(fallback_location: user_show_path(User.current)) && return
     end
 
     changestate = nil

--- a/src/api/app/controllers/webui/request_controller.rb
+++ b/src/api/app/controllers/webui/request_controller.rb
@@ -65,7 +65,7 @@ class Webui::RequestController < Webui::WebuiController
 
     if req.nil?
       flash[:error] = "Unable to load request"
-      redirect_back_or_to user_show_path(User.current)
+      redirect_back(fallback_location: user_show_path(User.current))
       return
     elsif state.nil?
       flash[:error] = "Unknown state to set"
@@ -87,7 +87,7 @@ class Webui::RequestController < Webui::WebuiController
     @bsreq = BsRequest.find_by_number(params[:number])
     unless @bsreq
       flash[:error] = "Can't find request #{params[:number]}"
-      redirect_back_or_to user_show_path(User.current) and return
+      redirect_back(fallback_location: user_show_path(User.current)) and return
     end
 
     @req = @bsreq.webui_infos
@@ -151,7 +151,7 @@ class Webui::RequestController < Webui::WebuiController
     @req = BsRequest.find_by_number params[:number]
     unless @req
       flash[:error] = "Can't find request #{params[:number]}"
-      redirect_back_or_to user_show_path(User.current) and return
+      redirect_back(fallback_location: user_show_path(User.current)) and return
     end
   end
 
@@ -159,7 +159,7 @@ class Webui::RequestController < Webui::WebuiController
     @req = BsRequest.find_by_number(params[:number])
     unless @req
       flash[:error] = "Can't find request #{params[:number]}"
-      redirect_back_or_to user_show_path(User.current) and return
+      redirect_back(fallback_location: user_show_path(User.current)) and return
     end
 
     changestate = nil

--- a/src/api/app/controllers/webui/search_controller.rb
+++ b/src/api/app/controllers/webui/search_controller.rb
@@ -60,7 +60,7 @@ class Webui::SearchController < Webui::WebuiController
         redirect_to controller: 'package', action: 'show', project: disturl_project, package: disturl_package, rev: disturl_rev
         return
       else
-        redirect_to :back, notice: 'Sorry, this disturl does not compute...'
+        redirect_back(fallback_location: root_path, notice: 'Sorry, this disturl does not compute...')
         return
       end
     end

--- a/src/api/app/controllers/webui/user_controller.rb
+++ b/src/api/app/controllers/webui/user_controller.rb
@@ -107,7 +107,7 @@ class Webui::UserController < Webui::WebuiController
     unless User.current.is_admin?
       if User.current != @displayed_user
         flash[:error] = "Can't edit #{@displayed_user.login}"
-        redirect_back(fallback_location: root_path) and return
+        redirect_back(fallback_location: root_path) && return
       end
     end
     @displayed_user.realname = params[:realname]
@@ -125,7 +125,7 @@ class Webui::UserController < Webui::WebuiController
       flash[:error] = "Couldn't update user: #{e.message}."
     end
 
-    redirect_back(fallback_location: { :action => 'show', user: @displayed_user })
+    redirect_back(fallback_location: { action: 'show', user: @displayed_user })
   end
 
   def edit
@@ -136,25 +136,25 @@ class Webui::UserController < Webui::WebuiController
   def delete
     @displayed_user.state = 'deleted'
     @displayed_user.save
-    redirect_back(fallback_location: { :action => 'show', user: @displayed_user })
+    redirect_back(fallback_location: { action: 'show', user: @displayed_user })
   end
 
   def confirm
     @displayed_user.state = 'confirmed'
     @displayed_user.save
-    redirect_back(fallback_location: { :action => 'show', user: @displayed_user })
+    redirect_back(fallback_location: { action: 'show', user: @displayed_user })
   end
 
   def lock
     @displayed_user.state = 'locked'
     @displayed_user.save
-    redirect_back(fallback_location: { :action => 'show', user: @displayed_user })
+    redirect_back(fallback_location: { action: 'show', user: @displayed_user })
   end
 
   def admin
     @displayed_user.update_globalroles(%w(Admin))
     @displayed_user.save
-    redirect_back(fallback_location: { :action => 'show', user: @displayed_user })
+    redirect_back(fallback_location: { action: 'show', user: @displayed_user })
   end
 
   def save_dialog

--- a/src/api/app/controllers/webui/user_controller.rb
+++ b/src/api/app/controllers/webui/user_controller.rb
@@ -47,7 +47,7 @@ class Webui::UserController < Webui::WebuiController
     if request.referer.end_with?("/user/login")
       redirect_to home_path
     else
-      redirect_back_or_to root_path
+      redirect_back(fallback_location: root_path)
     end
   end
 
@@ -107,7 +107,7 @@ class Webui::UserController < Webui::WebuiController
     unless User.current.is_admin?
       if User.current != @displayed_user
         flash[:error] = "Can't edit #{@displayed_user.login}"
-        redirect_to(:back) and return
+        redirect_back(fallback_location: root_path) and return
       end
     end
     @displayed_user.realname = params[:realname]
@@ -125,7 +125,7 @@ class Webui::UserController < Webui::WebuiController
       flash[:error] = "Couldn't update user: #{e.message}."
     end
 
-    redirect_back_or_to :action => 'show', user: @displayed_user
+    redirect_back(fallback_location: { :action => 'show', user: @displayed_user })
   end
 
   def edit
@@ -136,25 +136,25 @@ class Webui::UserController < Webui::WebuiController
   def delete
     @displayed_user.state = 'deleted'
     @displayed_user.save
-    redirect_back_or_to :action => 'show', user: @displayed_user
+    redirect_back(fallback_location: { :action => 'show', user: @displayed_user })
   end
 
   def confirm
     @displayed_user.state = 'confirmed'
     @displayed_user.save
-    redirect_back_or_to :action => 'show', user: @displayed_user
+    redirect_back(fallback_location: { :action => 'show', user: @displayed_user })
   end
 
   def lock
     @displayed_user.state = 'locked'
     @displayed_user.save
-    redirect_back_or_to :action => 'show', user: @displayed_user
+    redirect_back(fallback_location: { :action => 'show', user: @displayed_user })
   end
 
   def admin
     @displayed_user.update_globalroles(%w(Admin))
     @displayed_user.save
-    redirect_back_or_to :action => 'show', user: @displayed_user
+    redirect_back(fallback_location: { :action => 'show', user: @displayed_user })
   end
 
   def save_dialog
@@ -193,7 +193,7 @@ class Webui::UserController < Webui::WebuiController
       UnregisteredUser.register(opts)
     rescue APIException => e
       flash[:error] = e.message
-      redirect_back_or_to root_path
+      redirect_back(fallback_location: root_path)
       return
     end
 

--- a/src/api/app/controllers/webui/webui_controller.rb
+++ b/src/api/app/controllers/webui/webui_controller.rb
@@ -47,7 +47,7 @@ class Webui::WebuiController < ActionController::Base
       render json: { error: message }, status: 400
     else
       flash[:error] = message
-      redirect_back_or_to root_path
+      redirect_back(fallback_location: root_path)
     end
   end
 
@@ -113,15 +113,6 @@ class Webui::WebuiController < ActionController::Base
   end
 
   protected
-
-  # Same as redirect_to(:back) if there is a valid HTTP referer, otherwise redirect_to()
-  def redirect_back_or_to(options = {}, response_status = {})
-    if request.env['HTTP_REFERER']
-      redirect_to(:back)
-    else
-      redirect_to(options, response_status)
-    end
-  end
 
   # Renders a json response for jquery dataTables
   def render_json_response_for_dataTable(options)
@@ -248,7 +239,7 @@ class Webui::WebuiController < ActionController::Base
       rescue NotFoundError
         # admins can see deleted users
         @displayed_user = User.find_by_login(params['user']) if User.current and User.current.is_admin?
-        redirect_to :back, error: "User not found #{params['user']}" unless @displayed_user
+        redirect_back(fallback_location: root_path, error: "User not found #{params['user']}") unless @displayed_user
       end
     else
         @displayed_user = User.current
@@ -284,7 +275,7 @@ class Webui::WebuiController < ActionController::Base
   def require_admin
     if User.current.nil? || !User.current.is_admin?
       flash[:error] = 'Requires admin privileges'
-      redirect_back_or_to :controller => 'main', :action => 'index'
+      redirect_back(fallback_location: { :controller => 'main', :action => 'index' })
       return
     end
   end
@@ -294,7 +285,7 @@ class Webui::WebuiController < ActionController::Base
     if User.current and User.current.is_nobody?
       unless ::Configuration.anonymous
         flash[:error] = "No anonymous access. Please log in!"
-        redirect_back_or_to root_path
+        redirect_back(fallback_location: root_path)
       end
     else
       false

--- a/src/api/app/controllers/webui/webui_controller.rb
+++ b/src/api/app/controllers/webui/webui_controller.rb
@@ -275,7 +275,7 @@ class Webui::WebuiController < ActionController::Base
   def require_admin
     if User.current.nil? || !User.current.is_admin?
       flash[:error] = 'Requires admin privileges'
-      redirect_back(fallback_location: { :controller => 'main', :action => 'index' })
+      redirect_back(fallback_location: { controller: 'main', action: 'index' })
       return
     end
   end

--- a/src/api/app/mixins/webui/has_comments.rb
+++ b/src/api/app/mixins/webui/has_comments.rb
@@ -8,10 +8,10 @@ module Webui::HasComments
 
     respond_to do |format|
       if comment.save
-        format.html { redirect_to :back, notice: 'Comment was successfully created.' }
+        format.html { redirect_back(fallback_location: root_path, notice: 'Comment was successfully created.') }
         format.json { render json: 'ok' }
       else
-        format.html { redirect_to :back, error: "Comment can't be saved: #{comment.errors.full_messages.to_sentence}." }
+        format.html { redirect_back(fallback_location: root_path, error: "Comment can't be saved: #{comment.errors.full_messages.to_sentence}.") }
         format.json { render json: comment.errors, status: :unprocessable_entity }
       end
     end

--- a/src/api/test/unit/code_quality_test.rb
+++ b/src/api/test/unit/code_quality_test.rb
@@ -97,6 +97,7 @@ class CodeQualityTest < ActiveSupport::TestCase
       'User::find_with_credentials'                                             => 101.42,
       'UserLdapStrategy::render_grouplist_ldap'                                 => 100.3,
       'Webui::DriverUpdateController#save'                                      => 91.69,
+      'Webui::PackageController#save_new_link'                                  => 82.3,
       'Webui::PackageController#submit_request'                                 => 104.32,
       'Webui::PackageController#dependency'                                     => 83.57,
       'Webui::PatchinfoController#save'                                         => 256.25,


### PR DESCRIPTION
`redirect_to. Back` is deprecated and will be removed from Rails 5.1.

I used `redirect_back` instead. I also eliminated the `redirect_back_or_to` method as the **required** option `fallback_location` of `redirect_back` does the same.