### PR TITLE
[webui][ci] Remove `:nothing` deprecation warnings

### DIFF
--- a/src/api/app/controllers/webui/patchinfo_controller.rb
+++ b/src/api/app/controllers/webui/patchinfo_controller.rb
@@ -272,7 +272,7 @@ class Webui::PatchinfoController < Webui::WebuiController
       error += "#{invalid_format} has no valid format. (Correct formats are e.g. " +
                "boo#123456, CVE-1234-5678 and the string has to be a comma-separated list)"
     end
-    render nothing: true, json: { error: error, issues: issue_collection }
+    render json: { error: error, issues: issue_collection }
   end
 
   # returns issue summary of an issue

--- a/src/api/app/controllers/webui/webui_controller.rb
+++ b/src/api/app/controllers/webui/webui_controller.rb
@@ -196,8 +196,8 @@ class Webui::WebuiController < ActionController::Base
   def lockout_spiders
     check_spiders
     if @spider_bot
-       render :nothing => true
-       return true
+      head :ok
+      return true
     end
     return false
   end

--- a/src/api/lib/login_system.rb
+++ b/src/api/lib/login_system.rb
@@ -64,7 +64,7 @@ module LoginSystem
   # a popup window might just close itself for instance
   def access_denied
 # redirect_to :controller=>"account", :action =>"login"
-     render :nothing => true, :status => 401
+    head :unauthorized
   end
 
   # store current uri in  the session.


### PR DESCRIPTION
Running all rspec tests results in 4 lines of this kind at the log/tests.log file:

DEPRECATION WARNING: `:nothing` option is deprecated and will be removed in Rails 5.1. Use `head` method to respond with empty response body.

Moreover, if the response renders json, having 'nothing: true' makes
no sense.