### PR TITLE
[backend] deleted deprecated vars from template

### DIFF
--- a/src/backend/BSConfig.pm.template
+++ b/src/backend/BSConfig.pm.template
@@ -69,10 +69,6 @@ our $servicedir = "/usr/lib/obs/service/";
 #our $notification_plugin = "notify_hermes notify_rabbitmq";
 #
 
-# For the workers only, it is possible to define multiple repository servers here.
-# But only one source server is possible yet.
-our @reposervers = ("http://$hostname:5252");
-
 # Package defaults
 our $bsdir = '/srv/obs';
 our $bsuser = 'obsrun';


### PR DESCRIPTION
deprecated variable in BSConfig template was removed. It is not needed anymore, because the init script gets the reposervers from /etc/sysconfig/obs-server and even if OBS_REPO_SERVERS is empty the default points to localhost