### PR TITLE
[dist] improve the portability of /etc/init.d/obsapidelayed

### DIFF
--- a/dist/obsapidelayed
+++ b/dist/obsapidelayed
@@ -1,4 +1,4 @@
-#! /bin/sh
+#! /usr/bin/env bash
 # Copyright (c) 2009 SUSE Linux AG, Nuernberg, Germany.
 # All rights reserved.
 #


### PR DESCRIPTION
The run_in_api function in the ./dist/obsapidelayed file is not compatible
in the 'dash' shell script environment. ('dash' is a default shell script on
up-to-date Ubuntu distribution).

For example,
In case of bash script: function run_in_api {...}
In case of dash script: run_in_api() {...}

This patch is to improve the protablility of obsapidelayed service by using shebang.

Signed-off-by: Geunsik Lim <geunsik.lim@samsung.com>