### PR TITLE
[backend] implemented new workerstates dead/away

### DIFF
--- a/src/backend/BSXML.pm
+++ b/src/backend/BSXML.pm
@@ -734,6 +734,7 @@ our $worker = [
 	'hostarch',
 	'ip',
 	'port',
+        'registerserver',
 	'workerid',
       [ 'buildarch' ],
       [ 'hostlabel' ],

--- a/src/backend/bs_dispatch
+++ b/src/backend/bs_dispatch
@@ -249,6 +249,7 @@ sub assignjob {
   $worker->{'hardware'}->{'nativeonly'} = undef if $worker->{'hardware'} && exists($worker->{'hardware'}->{'nativeonly'});
 
   my @args = ("port=$port", "workercode=$workercode", "buildcode=$buildcode");
+  push @args, "registerserver=$worker->{'registerserver'}" if $worker->{'registerserver'};
   my $attempt = 0;
   if ($badhost{"$info->{'arch'}/$job"}) {
     my $id = "$info->{'arch'}/$job";
@@ -286,10 +287,12 @@ sub assignjob {
     if ($err =~ /bad job/) {
       return 'badjob';
     }
-    unlink("$workersdir/idle/$idlename");	# broken client or rebooting
+    mkdir_p("$workersdir/dead");
+    rename("$workersdir/idle/$idlename", "$workersdir/dead/$idlename");	# broken client or rebooting
     return undef;
   }
   unlink("$workersdir/idle/$idlename");	# no longer idle
+  unlink("$workersdir/dead/$idlename") if -e "$workersdir/dead/$idlename"; #no longer dead
   $jobstatus->{'code'} = 'building';
   $jobstatus->{'uri'} = "http://$worker->{'ip'}:$worker->{'port'}";
   $jobstatus->{'workerid'} = $worker->{'workerid'} if defined $worker->{'workerid'};

--- a/src/backend/bs_repserver
+++ b/src/backend/bs_repserver
@@ -1285,7 +1285,8 @@ sub workerstate {
   my $idlename = "$harch:$workerid";
   $idlename =~ s/\//_/g;
   if ($state eq 'building' || $state eq 'exit') {
-    unlink("$workersdir/idle/$idlename");
+    mkdir_p("$workersdir/away");
+    rename("$workersdir/idle/$idlename", "$workersdir/away/$idlename");
   } elsif ($state eq 'idle') {
     if (-e "$workersdir/building/$idlename") {
       # worker must have crashed, discard old job...
@@ -1314,6 +1315,8 @@ sub workerstate {
       }
     }
     unlink("$workersdir/building/$idlename");
+    unlink("$workersdir/away/$idlename");
+    unlink("$workersdir/dead/$idlename");
 
     # make sure that we can connect to the client
     if ($BSConfig::checkclientconnectivity || $BSConfig::checkclientconnectivity) {

--- a/src/backend/bs_warden
+++ b/src/backend/bs_warden
@@ -122,6 +122,7 @@ while (1) {
 	eval {
 	  BSRPC::rpc($param, undef, 'cmd=idleworker', "workerid=$worker->{'workerid'}", "jobid=$js->{'jobid'}");
 	  unlink("$workersdir/building/$wname");
+	  unlink("$workersdir/away/$wname");
 	  delete $building{$wname};
 	};
 	warn($@) if $@;

--- a/src/backend/bs_worker
+++ b/src/backend/bs_worker
@@ -761,7 +761,7 @@ sub send_state {
     };
     if ($state eq 'idle') {
       $param->{'request'} = 'POST';
-      $param->{'data'} = BSUtil::toxml($workerinfo, $BSXML::worker);
+      $param->{'data'} = BSUtil::toxml({ %$workerinfo, 'registerserver' => $server}, $BSXML::worker);
     }
     eval {
       BSRPC::rpc($param, undef, @args);
@@ -3151,7 +3151,7 @@ sub startbuild {
   $buildinfo->{'nobadhost'} = $cgi->{'nobadhost'} if $cgi->{'nobadhost'};
 
   # make the BSServer::server() call return
-  $BSServer::request->{'returnfromserver'} = [$state, $buildinfo];
+  $BSServer::request->{'returnfromserver'} = [$state, $buildinfo, $cgi->{'registerserver'}];
 
   return ("<status code=\"failed\">\n  <details>testmode activated</details>\n</status>\n", 'Status: 400 Testmode', 'Content-Type: text/xml') if $testmode;
   return "<status code=\"ok\">\n  <details>so much work, so little time...</details>\n</status>\n";
@@ -3330,7 +3330,7 @@ my $dispatches = [
   '/logfile $jobid:? nostream:? start:? end:? view:?' => \&getlogfile,
   '/kill $jobid:?' => \&killjob,
   '/discard $jobid:?' => \&discardjob,
-  'PUT:/build $jobid:? buildcode:? workercode:? port:? nobadhost:? *:?' => \&startbuild,
+  'PUT:/build $jobid:? buildcode:? workercode:? port:? registerserver:? nobadhost:? *:?' => \&startbuild,
 ];
 
 my $conf = {
@@ -3348,7 +3348,7 @@ $conf->{'dispatch'} ||= \&BSDispatch::dispatch;
 
 # run the server, this will return only for /build requests
 # see returnfromserver setting above
-my ($state, $buildinfo) = BSServer::server($conf);
+my ($state, $buildinfo, $registerserver) = BSServer::server($conf);
 
 print "got job, run build...\n";
 BSServer::done(1);
@@ -3364,7 +3364,7 @@ $state->{'pid'} = $$;
 commitstate($state);
 
 hardstatus("$buildinfo->{'arch'} $buildinfo->{'package'}");
-send_state('building', $port, $hostarch, $buildinfo->{'reposerver'});
+send_state('building', $port, $hostarch, $registerserver || $buildinfo->{'reposerver'});
 
 my $ex;
 eval {


### PR DESCRIPTION
Introducing new workerstates

- **dead:** worker is not reachable or broken and cannot be used for building.
- **away:** worker is building for another reposerver.