### PR TITLE
Blame feature: proof of concept implementation

### DIFF
--- a/src/backend/BSBlame/BlameStorage.pm
+++ b/src/backend/BSBlame/BlameStorage.pm
@@ -1,0 +1,22 @@
+package BSBlame::BlameStorage;
+
+use strict;
+use warnings;
+
+sub new {
+  my ($class) = @_;
+  return bless {}, $class;
+}
+
+sub retrieve {
+  my ($self, $rev, $filename) = @_;
+  return $self->{$rev->cookie()}->{$filename};
+}
+
+sub store {
+  my ($self, $rev, $filename, $blamedata) = @_;
+  die("already present\n") if $self->retrieve($rev, $filename);
+  $self->{$rev->cookie()}->{$filename} = $blamedata;
+}
+
+1;

--- a/src/backend/BSBlame/Blamer.pm
+++ b/src/backend/BSBlame/Blamer.pm
@@ -1,0 +1,191 @@
+package BSBlame::Blamer;
+
+use strict;
+use warnings;
+
+use Data::Dumper;
+
+use BSBlame::Diff3;
+
+# Performs the actual blame of a revision.
+
+sub new {
+  my ($class, $rev, $storage) = @_;
+  my $self = {'rev' => $rev, 'storage' => $storage};
+  bless $self, $class;
+  $self->setupdeps_expanded() if $rev->isexpanded();
+  $self->setupdeps_branch() if $rev->isbranch();
+  $self->setupdeps_plain() if $rev->isplain();
+  die("plain link not supported\n") if $rev->islink() && !$rev->isbranch();
+  return $self;
+}
+
+sub setupdeps_expanded {
+  my ($self) = @_;
+  die("plain links are not yet supported\n")
+    unless $self->{'rev'}->localrev()->isbranch();
+  push @{$self->{'deps'}}, $self->{'rev'}->targetrev();
+  push @{$self->{'deps'}}, $self->{'rev'}->localrev()->targetrev();
+  push @{$self->{'deps'}}, $self->{'rev'}->localrev();
+}
+
+sub setupdeps_branch {
+  my ($self) = @_;
+  push @{$self->{'deps'}}, $self->{'rev'}->targetrev();
+  my $range = $self->{'rev'}->revmgr()->range($self->{'rev'});
+  my $plrev = $range->pred($self->{'rev'});
+  return unless $plrev;
+  push @{$self->{'deps'}}, $plrev->targetrev();
+  push @{$self->{'deps'}}, $plrev;
+}
+
+sub setupdeps_plain {
+  my ($self) = @_;
+  my $range = $self->{'rev'}->revmgr()->range($self->{'rev'});
+  my $prev = $range->pred($self->{'rev'});
+  push @{$self->{'deps'}}, $prev if $prev;
+}
+
+sub hasconflict {
+  my ($self) = @_;
+  return 0 if $self->{'rev'}->isplain() || $self->{'rev'}->isexpanded();
+  return $self->{'conflict'} if exists $self->{'conflict'};
+  # need to check this only for a branch (or a link...)
+  my $revmgr = $self->{'rev'}->revmgr();
+  my ($brev, $pbrev, $plrev) = @{$self->{'deps'}};
+  # no predecessor => start of a branch, hence, no conflict
+  return $self->{'conflict'} = 0 unless $plrev;
+  my $rev = $revmgr->expand($plrev, $brev);
+  return $self->{'conflict'} = !defined($rev);
+}
+
+sub deps {
+  my ($self) = @_;
+  my @deps = @{$self->{'deps'} || []};
+  push @deps, $self->{'lastworking'} if $self->{'lastworking'};
+  return \@deps;
+}
+
+sub lastworking {
+  my ($self, $rev) = @_;
+  $self->{'lastworking'} = $rev;
+}
+
+sub ready {
+  my ($self, $filename) = @_;
+  my $storage = $self->{'storage'};
+  return 1 if $storage->retrieve($self->{'rev'}, $filename);
+  return !grep {!$storage->retrieve($_, $filename)} @{$self->{'deps'}};
+}
+
+sub blame {
+  my ($self, $filename) = @_;
+  die("deps not blamed\n") unless $self->ready($filename);
+  my $rev = $self->{'rev'};
+  my $storage = $self->{'storage'};
+  return $storage->retrieve($rev, $filename)
+    if $storage->retrieve($rev, $filename);
+  my $blamedata;
+  ($blamedata) = $self->blame_expanded($filename) if $rev->isexpanded();
+  ($blamedata) = $self->blame_branch($filename) if $rev->isbranch();
+  ($blamedata) = $self->blame_plain($filename) if $rev->isplain();
+  die("plain link not supported\n") if $rev->islink() && !$rev->isbranch();
+  die("XXX\n") unless $blamedata;
+  $storage->store($rev, $filename, $blamedata);
+  return $blamedata;
+}
+
+sub blame_expanded {
+  my ($self, $filename) = @_;
+  my $rev = $self->{'rev'};
+  my $lrev = $rev->localrev();
+  my $trev = $rev->targetrev();
+  my $brev = $rev->localrev()->targetrev();
+  return $self->calcblame($filename, $lrev, $trev, $brev);
+}
+
+sub blame_branch {
+  my ($self, $filename) = @_;
+  return $self->blame_branch_conflict($filename) if $self->hasconflict();
+  my $storage = $self->{'storage'};
+  my ($brev, $pbrev, $plrev) = @{$self->{'deps'}};
+  # no predecessor => start of a branch, hence, just take the baserev's
+  # blamedata (assumption: no keepcontent case branch)
+  return $storage->retrieve($brev, $filename) unless $plrev;
+  # calculate blame for last working expanded predecessor
+  my ($pblame) = $self->calcblame($filename, $plrev, $brev, $pbrev);
+  # next diff my rev against its last working expanded predecessor
+  # 2-way diff: diff prev lrev
+  my $lrev = $self->{'rev'};
+  my $prev = $lrev->revmgr()->expand($plrev, $brev, 1);
+  $storage->store($prev, $filename, $pblame);
+  return $self->calcblame($filename, $prev, $lrev, $prev);
+}
+
+sub blame_branch_conflict {
+  my ($self, $filename) = @_;
+  die("there is no conflict\n") unless $self->hasconflict();
+  die("no last working automerge\n") unless $self->{'lastworking'};
+  my $storage = $self->{'storage'};
+  my $lrev = $self->{'rev'};
+  my ($brev, $pbrev, $plrev) = @{$self->{'deps'}};
+  my $prev = $lrev->revmgr()->expand($plrev, $self->{'lastworking'}, 1);
+  my ($pblame) = $self->calcblame($filename, $plrev, $self->{'lastworking'},
+                                  $pbrev);
+  $storage->store($prev, $filename, $pblame);
+  my ($brevblamedata, $brevblame) = $self->calcblame($filename, $brev, $lrev,
+                                                     $brev);
+  my ($prevblamedata, $prevblame) = $self->calcblame($filename, $prev, $lrev,
+                                                     $prev);
+  my @blame;
+  my @blamedata;
+  for (my $i = 0; $i < @$brevblame; $i++) {
+    if ($brevblame->[$i]->[0] == $BSBlame::Diff3::FY) {
+      $blame[$i] = $prevblame->[$i];
+      $blamedata[$i] = $prevblamedata->[$i];
+    } else {
+      $blame[$i] = $brevblame->[$i];
+      $blamedata[$i] = $brevblamedata->[$i];
+    }
+  }
+  return (\@blamedata, \@blame);
+}
+
+sub blame_plain {
+  my ($self, $filename) = @_;
+  my $lrev = $self->{'rev'};
+  # if lrev is the first rev in the range, plrev is undefined
+  my $plrev = $self->{'deps'}->[0];
+  # 2-way diff of myrev against its predecessor
+  return $self->calcblame($filename, $plrev, $lrev, $plrev);
+}
+
+# could be static, but this way subclasses can override it
+sub calcblame {
+  my ($self, $filename, $myrev, $yourrev, $commonrev) = @_;
+  my $storage = $self->{'storage'};
+  my @blames = (
+    $myrev ? $storage->retrieve($myrev, $filename) : undef,
+    $yourrev ? $storage->retrieve($yourrev, $filename) : undef,
+    $commonrev ? $storage->retrieve($commonrev, $filename) : undef
+  );
+  my @blame;
+  if ($myrev && $yourrev && $commonrev) {
+    @blame = BSBlame::Diff3::merge($myrev->file($filename) || '/dev/null',
+                                   $yourrev->file($filename) || '/dev/null',
+                                   $commonrev->file($filename) || '/dev/null',
+                                   scalar(@{$blames[2]}) - 1);
+  } elsif (!$myrev && $yourrev && !$commonrev) {
+    @blame = BSBlame::Diff3::merge('/dev/null',
+                                   $yourrev->file($filename) || '/dev/null',
+                                   '/dev/null');
+  } else {
+    die("calcblame: illegal argument combination\n");
+  }
+  return (
+    [map {$blames[$_->[0]] ? $blames[$_->[0]]->[$_->[1]] : $yourrev} @blame],
+    \@blame
+  );
+}
+
+1;

--- a/src/backend/BSBlame/Constraint.pm
+++ b/src/backend/BSBlame/Constraint.pm
@@ -1,0 +1,77 @@
+package BSBlame::Constraint;
+
+use strict;
+use warnings;
+
+use Data::Dumper;
+
+my $opmap = {
+  '<' => sub { !defined($_[0]) ? 1 : ($_[0] + 0 < $_[1] + 0) },
+  '<=' => sub { !defined($_[0]) ? 1 : ($_[0] + 0 <= $_[1] + 0) },
+  '=' => sub { !defined($_[0]) ? 1 : ($_[0] eq $_[1]) },
+  '>=' => sub { !defined($_[0]) ? 1 : ($_[0] + 0 >= $_[1] + 0) },
+  '>' => sub { !defined($_[0]) ? 1 : ($_[0] + 0 > $_[1] + 0) }
+};
+
+my $opre = join('|',
+                map {"\Q$_\E"} sort {length($b) <=> length($a)} keys(%$opmap));
+
+sub new {
+  my ($class, $expr, $global, @preexprs) = @_;
+  my $self = {};
+  bless $self, $class;
+  $self->parse($expr);
+  $self->{'global'} = $global;
+  for my $preexpr (@preexprs) {
+    push @{$self->{'preconditions'}}, BSBlame::Constraint->new($preexpr);
+  }
+  return $self;
+}
+
+sub parse {
+  my ($self, $expr) = @_;
+  die("illegal expression: \"$expr\"\n")
+    unless $expr =~ /^([^\s]+)\s*($opre)\s*(.*)/;
+  $self->{'attr'} = $1;
+  $self->{'op'} = $2;
+  $self->{'val'} = $3;
+}
+
+sub eval {
+  my ($self, $rev) = @_;
+  my $meth = $rev->can($self->{'attr'});
+  die("unknown attribute $self->{'attr'}\n") unless $meth;
+  return $opmap->{$self->{'op'}}->($rev->$meth(), $self->{'val'});
+}
+
+sub isfor {
+  my ($self, $rev) = @_;
+  for my $precondition (@{$self->{'preconditions'} || []}) {
+    return 0 if !$precondition->eval($rev);
+  }
+  return 1;
+}
+
+sub isglobal {
+  my ($self) = @_;
+  return $self->{'global'};
+}
+
+# needed? (only for constraint merging, contradiction checking etc.)
+
+sub attr {
+  my ($self) = @_;
+  return $self->{'attr'};
+}
+
+sub op {
+  my ($self) = @_;
+  return $self->{'op'};
+}
+
+sub val {
+  my ($self) = @_;
+  return $self->{'val'};
+}
+
+1;

--- a/src/backend/BSBlame/Diff3.pm
+++ b/src/backend/BSBlame/Diff3.pm
@@ -1,0 +1,100 @@
+package BSBlame::Diff3;
+
+use strict;
+use warnings;
+
+use Data::Dumper;
+
+sub diff3 {
+  my ($my, $your, $common) = @_;
+  open(D, "-|", 'diff3', '-T', $my, $your, $common) || die("diff3: $!\n");
+  my $diff3; # current diff3 block
+  my @diff3; # all diff3 blocks
+  my $lines; # all this line handling is just a sanity check...
+  while (<D>) {
+    chomp;
+    if (/^\t/ && defined($lines)) {
+      $lines--;
+    } elsif (/====(\d)?$/) {
+      die("illegal format: $_ (data expected)\n") if defined($lines) && $lines != 0;
+      push @diff3, $diff3 if $diff3;
+      $diff3 = {};
+      $diff3->{'odd'} = $1 ? $1 - 1 : undef;
+      $lines = undef;
+    } elsif (/(\d):(\d+)(?:,(\d+))?(a|c)/) {
+      die("illegal format: $_\n") if defined($lines) && $lines != 0;
+      my ($fno, $lo, $hi) = ($1 - 1, $2 - 1, (defined($3) ? $3 : $2) - 1);
+      $diff3->{'data'}->[$fno] = [$lo, $hi, $4];
+      $lines = $hi - $lo;
+      $lines++ if $lines || $4 eq 'c';
+      undef $lines if defined($diff3->{'odd'}) && $fno == ($diff3->{'odd'} == 0);
+    } else {
+      die("illegal format: $_\n") unless $_ eq '\ No newline at end of file';
+    }
+  }
+  die("unexpected eof\n") if $lines;
+  push @diff3, $diff3 if $diff3;
+  close(D) || die("close: $!\n");
+  return @diff3;
+}
+
+our $FM = 0; # my file
+our $FY = 1; # your file
+our $FC = 2; # common file
+
+sub merge {
+  my ($my, $your, $common, $cnumlines, $ctie) = @_;
+  my @diff3 = diff3($my, $your, $common);
+  return undef if grep {!defined($_->{'odd'})} @diff3;
+  $ctie = $FY unless defined($ctie);
+  die("illegal ctie value: $ctie\n") unless $ctie == $FY || $ctie == $FM;
+  my @merge;
+  my $off = 0;
+  for my $diff3 (@diff3) {
+    my ($low, $high, $type) = @{$diff3->{'data'}->[$FC]};
+    my $lo = $low;
+    $lo-- if $type eq 'c'; # stop one line before the change starts
+    while ($off <= $lo) {
+      push @merge, [$FC, $off];
+      $off++;
+    }
+    # the change affects high - low + 1 lines (inclusive)
+    $off += $high - $low + 1 if $type eq 'c';
+    my $odd = $diff3->{'odd'};
+    # nothing todo, if common is the odd file and if the diff
+    # block of my and common has the type "add" ("a") 
+    # (note: since we have no conflicts, the diff block of
+    # your and common also has the type "add" (that's why we
+    # just check the type of the my ($FM) block))
+    next if $odd == $FC && $diff3->{'data'}->[$FM]->[2] eq 'a';
+    # nothing todo, if my/your is the odd file and the diff
+    # block of my/your and common has type "add" ("a")
+    # (that is, lines were removed from the my/your file and, hence,
+    # there is nothing to merge)
+    next if $odd != $FC && $diff3->{'data'}->[$odd]->[2] eq 'a';
+    # if common is the odd file, the my file and the your
+    # file have the "same" diff - so we can either take the
+    # information from the my file or from the your file.
+    # so, $ctie acts as tie breaker (it represents the
+    # choice)
+    $odd = $ctie if $odd == $FC;
+    ($low, $high, $type) = @{$diff3->{'data'}->[$odd]};
+    while ($low <= $high) {
+      push @merge, [$odd, $low];
+      $low++;
+    }
+  }
+  unless (defined($cnumlines)) {
+    # fancy way to compute the number of lines for the common file
+    @diff3 = diff3($common, '/dev/null', '/dev/null');
+    $cnumlines = @diff3 ? $diff3[0]->{'data'}->[$FM]->[1] : -1;
+  }
+  # take the rest from the common file
+  while ($off <= $cnumlines) {
+    push @merge, [$FC, $off];
+    $off++;
+  }
+  return @merge;
+}
+
+1;

--- a/src/backend/BSBlame/Iterator.pm
+++ b/src/backend/BSBlame/Iterator.pm
@@ -1,0 +1,45 @@
+package BSBlame::Iterator;
+
+use strict;
+use warnings;
+
+use Data::Dumper;
+
+sub new {
+  my ($class, $data, @constraints) = @_;
+  return bless {
+    'data' => $data,
+    'constraints' => \@constraints,
+    'cur' => -1
+  }, $class;
+}
+
+sub item {
+  my ($self) = @_;
+  my $cur = $self->{'cur'};
+  return undef if $cur < 0 || $cur > @{$self->{'data'}};
+  return $self->{'data'}->[$cur];
+}
+
+sub next {
+  my ($self, @constraints) = @_;
+  push @constraints, @{$self->{'constraints'}};
+  my $i = \$self->{'cur'};
+  my $data = $self->{'data'};
+  for ($$i++; $$i < @$data; $$i++) {
+    my $item = $self->item();
+    # item should always be defined
+    return $item if defined($item) && $item->satisfies(@constraints);
+  }
+  # not needed (just to be explicit)
+  return undef;
+}
+
+sub find {
+  my ($self, @constraints) = @_;
+  my $item = $self->item();
+  return $item if defined($item) && $item->satisfies(@constraints);
+  return $self->next(@constraints);
+}
+
+1;

--- a/src/backend/BSBlame/Range.pm
+++ b/src/backend/BSBlame/Range.pm
@@ -1,0 +1,85 @@
+package BSBlame::Range;
+
+use strict;
+use warnings;
+
+use Data::Dumper;
+
+use BSBlame::Constraint;
+use BSBlame::Iterator;
+
+# A range is a contiguous ordered set of _local revision_ objects that refer
+# to the same $projid/$packid and have the same type (possible types: plain
+# revision or branch revision (see docs of BSBlame::Revision)).
+# For a range that contains branch revisions the following property holds:
+# - all branch revisions in this range have the same target (target project
+#   and target package)
+#
+# Note: it is possible that during the resolve step (see
+#       BSBlame::RangeFirstStrategy::resolve) an existing range is split into
+#       two different ranges.
+
+sub new {
+  my ($class, $start, $data) = @_;
+  return bless {
+    'start' => $start,
+    # don't even dare to modify data (we could also use a list but well...
+    # this class behaves;) )
+    'data' => $data
+  }, $class;
+}
+
+sub end {
+  my ($self, $end) = @_;
+  die("illegal end\n") unless defined($end);
+  my $oldend = $self->{'end'};
+  $self->{'end'} = $end;
+  return $oldend;
+}
+
+sub contains {
+  my ($self, $lrev) = @_;
+  die("illegal rev\n") if !defined($lrev) || $lrev->isexpanded();
+  return 0 unless $lrev->idx() >= $self->{'start'};
+  return 0 unless !defined($self->{'end'}) || $lrev->idx() <= $self->{'end'};
+  # representant of the whole range
+  my $lrrev = $self->{'data'}->[$self->{'start'}];
+  return 0 unless $lrrev->project() eq $lrev->project();
+  return 0 unless $lrrev->package() eq $lrev->package();
+  for (qw(islink isbranch)) {
+    return 0 if $lrrev->$_() && !$lrev->$_();
+    return 0 if !$lrrev->$_() && $lrev->$_();
+  }
+  if ($lrrev->islink()) {
+    # TODO: plain link handling
+    die("branches only\n") unless $lrrev->isbranch();
+    my $tlrrev = $lrrev->targetrev();
+    my $tlrev = $lrev->targetrev();
+    return 0 unless $tlrrev->project() eq $tlrev->project();
+    return 0 unless $tlrrev->package() eq $tlrev->package();
+  }
+  return 1;
+}
+
+sub pred {
+  my ($self, $lrev) = @_;
+  die("rev not in range\n") unless $self->contains($lrev);
+  return undef unless $lrev->idx() < $self->{'end'};
+  return $self->{'data'}->[$lrev->idx() + 1];
+}
+
+sub iter {
+  my ($self) = @_;
+  my $start = $self->{'start'};
+  my $end = $self->{'end'};
+  die("inconsistent range state\n") unless defined($start) && defined($end);
+  # hmm introduce special constraints such that we can pass
+  # start and end as a reference (so that the iterator is consistent
+  # after a range split)?
+  # TODO: testcase that demonstrates why we need non-global constraints here
+  return BSBlame::Iterator->new($self->{'data'},
+                                BSBlame::Constraint->new("idx >= $start", 0),
+                                BSBlame::Constraint->new("idx <= $end", 0));
+}
+
+1;

--- a/src/backend/BSBlame/RangeFirstStrategy.pm
+++ b/src/backend/BSBlame/RangeFirstStrategy.pm
@@ -1,0 +1,261 @@
+package BSBlame::RangeFirstStrategy;
+
+use strict;
+use warnings;
+
+use Data::Dumper;
+
+use BSBlame::Blamer;
+use BSBlame::Constraint;
+use BSBlame::Revision;
+use BSBlame::RevisionManager;
+
+# basically, this could be plain module with functions instead
+# of a class (it's a class for reusability reasons...)
+
+sub new {
+  my ($class, $storage) = @_;
+  return bless {'storage' => $storage}, $class;
+}
+
+sub blame {
+  my ($self, $rev, $filename) = @_;
+  $self->resolve($rev);
+  my @blamers;
+  my @deps = BSBlame::Blamer->new($rev, $self->{'storage'});
+  my %seen;
+  while (@deps) {
+    my $blamer = shift(@deps);
+    push @blamers, $blamer;
+    $self->lastworkingautomerge($blamer) if $blamer->hasconflict();
+    for my $rev (@{$blamer->deps()}) {
+      next if $seen{$rev->cookie()};
+      $seen{$rev->cookie()} = 1;
+      push @deps, BSBlame::Blamer->new($rev, $self->{'storage'});
+    }
+    # potential inifinite loop?
+  }
+  while (@blamers) {
+    my @ready = grep {$_->ready($filename)} @blamers;
+    die("ready queue empty\n") unless @ready;
+    for my $blamer (@ready) {
+      $blamer->blame($filename);
+    }
+    my $ready = {map {$_ => 1} @ready};
+    @blamers = grep {!$ready->{$_}} @blamers;
+  }
+}
+
+# The goal of this step is to associate $rev and all its deps to a
+# corresponding localrev (cf. BSBlame::Revision for a localrev
+# "definition").
+# Note: this is just a heuristic that can "easily" fooled:
+# - play with different commit times (affects only branches)
+# - play with the "olinkrev" parameter when creating branches
+# - manually specified _links
+# - etc.
+# TODO: create testcases for these scenarios
+sub resolve {
+  my ($self, $rev) = @_;
+  my @todo = $rev;
+  while (@todo) {
+    $rev = shift(@todo);
+    my @deps;
+    @deps = $self->resolve_expanded($rev) if $rev->isexpanded();
+    @deps = $self->resolve_branch($rev) if $rev->isbranch();
+    @deps = $self->resolve_plain($rev) if $rev->isplain();
+    die("todo: plain links\n") if $rev->islink() && !$rev->isbranch();
+    push @todo, @deps;
+  }
+}
+
+sub resolve_expanded {
+  my ($self, $rev) = @_;
+  my $revmgr = $rev->revmgr();
+  my ($projid, $packid) = ($rev->project(), $rev->package());
+  dbgprint("resolve expanded: $projid/$packid" . " (" . ($rev + 0) . ")\n");
+  my @deps;
+  if ($rev->localrev()) {
+    dbgprint(" localrev set\n");
+    push @deps, $rev->targetrev();
+    push @deps, $rev->localrev() unless $rev->localrev()->resolved();
+    $rev->resolved(1);
+    return @deps;
+  }
+  dbgprint(" srcmd5: " . $rev->srcmd5() . "\n");
+  dbgprint(" lsrcmd5: " . $rev->lsrcmd5() . "\n");
+  my $lrev = $revmgr->find($rev->project(), $rev->package(), $rev->lsrcmd5(),
+                           $rev->constraints());
+  die("unable to find lrev\n") unless $lrev;
+  # merge constraints and install lrev
+  $lrev->constraints($rev->constraints());
+  $rev->localrev($lrev);
+  $rev->resolved(1);
+  push @deps, $rev->targetrev();
+  push @deps, $lrev unless $lrev->resolved();
+  dbgprint(" push " . ($rev->targetrev() + 0) . "\n");
+  dbgprint(" push " . ($lrev + 0) . "\n") unless $lrev->resolved();
+  return @deps;
+}
+
+sub resolve_branch {
+  my ($self, $primarylrev) = @_;
+  my $revmgr = $primarylrev->revmgr();
+  my $lprojid = $primarylrev->project();
+  my $lpackid = $primarylrev->package();
+  my $tprojid = $primarylrev->targetrev()->project();
+  my $tpackid = $primarylrev->targetrev()->package();
+  my @deps;
+  dbgprint("resolve branch: $lprojid/$lpackid\n");
+  while (!$primarylrev->resolved()) {
+    # by construction of the range all local revs are branches to same target
+    my $it = $revmgr->range($primarylrev)->iter();
+    my $tit = $revmgr->iter($tprojid, $tpackid);
+    # successor lrev
+    my $slrev;
+    while (my $lrev = $it->next()) {
+      dbgprint(" resolve rev: $lprojid/$lpackid/r" . $lrev->intrev()->{'rev'});
+      dbgprint("\n");
+      my @constraints = $lrev->constraints();
+      push @constraints, $slrev->constraints() if $slrev;
+      my ($time, $idx) = ($lrev->time(), $lrev->idx());
+      push @constraints, BSBlame::Constraint->new("time <= $time", 1);
+      push @constraints, BSBlame::Constraint->new("idx > $idx", 1,
+                                                  "project = $lprojid",
+                                                  "package = $lpackid");
+      my $blsrcmd5 = $lrev->targetrev()->lsrcmd5();
+      dbgprint("              blsrcmd5: $blsrcmd5\n");
+      my $blrev = $tit->find(BSBlame::Constraint->new("lsrcmd5 = $blsrcmd5", 0,
+                                                      "project = $tprojid",
+                                                      "package = $tpackid"),
+                             @constraints);
+      if (!$blrev) {
+        die("unable to resolve first elm in range\n") unless $slrev;
+        # ok, let's hope that $lrev is really the start of a new range
+        $revmgr->rangesplit($lrev);
+        last;
+      }
+      dbgprint("              -> $tprojid/$tpackid/r");
+      dbgprint($blrev->intrev()->{'rev'} . "\n");
+      # install blrev and merge constraints
+      # (constraints are installed to blrev _and_ the targetrev)
+      $lrev->targetrev()->localrev($blrev);
+      $lrev->targetrev()->constraints(@constraints);
+      $lrev->resolved(1);
+      push @deps, $lrev->targetrev();
+      dbgprint("                push " . ($lrev->targetrev() + 0) . "\n");
+      $slrev = $lrev;
+    }
+  }
+  return @deps;
+}
+
+sub resolve_plain {
+  my ($self, $rev) = @_;
+  my $revmgr = $rev->revmgr();
+  my ($projid, $packid) = ($rev->project(), $rev->package());
+  dbgprint("resolve plain: $projid/$packid\n");
+  return () if $rev->resolved();
+  my $lrev = $revmgr->find($rev->project(), $rev->package(), $rev->lsrcmd5(),
+                           $rev->constraints());
+  die("unable to resolve plain rev\n") unless $lrev;
+  $rev->localrev($lrev);
+  $rev->resolved(1);
+  my $it = $revmgr->range($lrev)->iter();
+  while ($lrev = $it->next()) {
+    dbgprint(" rev: " . $lrev->intrev()->{'rev'} . "\n");
+    last if $lrev->resolved();
+    $lrev->resolved(1);
+  }
+  return ();
+}
+
+sub lastworkingautomerge {
+  my ($self, $blamer) = @_;
+  my $lrev = $blamer->{'rev'};
+  die("branch expected\n") unless $lrev->isbranch();
+  my $plrev = $blamer->deps()->[2];
+  my $rev = findlastworkingautomerge($plrev, $lrev->time(), []);
+  die("no last working automerge found\n") unless $rev;
+  die("not expanded\n") unless $rev->isexpanded();
+  dbgprint(Dumper($rev->intrev()));
+  $self->resolve($rev);
+  $blamer->lastworking($rev->targetrev());
+}
+
+# assumption: all revisions that we encounter during calls to
+# findlastworkingautomerge satisfy the following properties:
+# - either "isbranch" or "isplain" holds
+# - in case of a branch, no linkrev attribute is set (in the _link file)
+#   and no "olinkrev" parameter was used when creating the branch (and of
+#   course no manually specified _link file etc.)
+sub findlastworkingautomerge {
+  my ($lrev, $stime, $revs, @idxconstraints) = @_;
+  my $lprojid = $lrev->project();
+  my $lpackid = $lrev->package();
+  dbgprint("findcandidate: $lprojid/$lpackid/r");
+  dbgprint($lrev->intrev()->{'rev'} . "\n");
+  my $revmgr = $lrev->revmgr();
+  if ($lrev->isplain()) {
+    my $rev = $lrev;
+    for my $lrev (@$revs) {
+      $rev = $revmgr->expand($lrev, $rev);
+      return undef unless $rev;
+    }
+    return $rev;
+  }
+  die("expanded rev makes no sense\n") if $lrev->isexpanded();
+  # idx is always defined
+  my $idx = $lrev->idx();
+  die("logic error (idx undefined)\n") unless defined($idx);
+  push @idxconstraints, BSBlame::Constraint->new("idx > $idx", 1,
+                                                 "project = $lprojid",
+                                                 "package = $lpackid");
+  my $ltime = $lrev->time();
+  my @tconstraints = (
+    BSBlame::Constraint->new("time <= $stime", 0),
+    BSBlame::Constraint->new("time >= $ltime", 0)
+  );
+
+  unshift @$revs, $lrev;
+  my $tprojid = $lrev->targetrev()->project();
+  my $tpackid = $lrev->targetrev()->package();
+  my $tit = $revmgr->iter($tprojid, $tpackid, @idxconstraints, @tconstraints);
+  # successor target lrev
+  my $stlrev;
+  my $rev;
+  while ((my $tlrev = $tit->next()) && !$rev) {
+    $rev = findlastworkingautomerge($tlrev, $stlrev ? $stlrev->time() : $stime,
+                                    $revs, @idxconstraints);
+    $stlrev = $tlrev;
+  }
+
+  if (!$rev) {
+    # we tried all target revs in the time range from ltime to stime;
+    # next we try the first target rev whose commit time is strictly less
+    # than ltime (with our assumptions, this rev is supposed to be a
+    # part of lrev's baserev (note: if all commits happened at the same time,
+    # we already found a part of lrev's baserev in the previous while loop and
+    # this codepath shouldn't be reached)).
+    @tconstraints = BSBlame::Constraint->new("time < $ltime", 0);
+    $tit = $revmgr->iter($tprojid, $tpackid, @idxconstraints, @tconstraints);
+    my $tlrev = $tit->next();
+    if ($tlrev) {
+      # TODO: come up with a reasonable testcase for the case where $stlrev
+      #       is undefined
+      $stime = $stlrev->time() if $stlrev;
+      $rev = findlastworkingautomerge($tlrev, $stime, $revs, @idxconstraints);
+    }
+  }
+  shift @$revs;
+  return $rev;
+}
+
+our $DEBUG = 0;
+
+sub dbgprint {
+  my ($msg) = @_;
+  print $msg if $DEBUG;
+}
+
+1;

--- a/src/backend/BSBlame/Revision.pm
+++ b/src/backend/BSBlame/Revision.pm
@@ -1,0 +1,271 @@
+package BSBlame::Revision;
+
+use strict;
+use warnings;
+
+use Data::Dumper;
+use Digest::MD5 ();
+
+use BSRevision;
+use BSXML;
+
+# This code needs a bit more love (get rid of this stupid $self->{'data'}
+# indirection etc.)
+
+# This class represents a revision. A revision object will be associated to
+# a corresponding local revision (localrev), which is also a revision object.
+# The association is done in BSBlame::RangeFirstStrategy::resolve.
+# A local revision is a revision object that corresponds to a certain commit,
+# which is tracked in a $projid.pkg/$packid.rev file.
+#
+# Currently, we support three types of revisions:
+#
+# 1. Plain Revision
+# A plain revision is a BSBlame::Revision object that corresponds to a package
+# that has no _link file. From a conceptual point of view, a plain
+# BSBlame::Revision $rev can either be a _local revision_ itself or "normal"
+# plain revision object that has to be associated to a correponding plain
+# _local revision_ BSBlame::Revision object. For instance, all
+# BSBlame::Revision objects that are created in BSBlame::Revision::init can
+# be interpreted as a "normal" plain revision.
+# Note: from a code POV, there is no difference between a plain local revision
+#       and "normal" plain revision.
+#
+# 2. Expanded Revision
+# An expanded obs revision refers to two other obs revisions: the local
+# revision (lsrcmd5) (/LOCAL) and the link revision (srcmd5) (/LINK).
+# The lsrcmd5, which contains the _link file, corresponds to one or more
+# commits in the $projid.pkg/$packid.rev. The srcmd5 corresponds to a
+# plain rev or an expanded rev of the link target.
+# Both concepts are mapped to a BSBlame::Revision object $rev as follows:
+#
+# - lsrcmd5 -> $rev->localrev()
+# - srcmd5  -> $rev->targetrev()
+#
+# (Note: $rev->localrev() can only be accessed once $rev is resolved
+#        (otherwise undef is returned))
+#
+# Keep in mind that a lsrcmd5 might correspond to more commits and, hence,
+# it might be possible that an expanded revision is associated to a
+# "wrong" local revision.
+#
+# 3. Branch Revision
+# A branch revision _is_ a _local revision_ whose file set contains a _link
+# file that represents an obs branch. The _link's baserev is either a plain
+# rev or an expanded rev of the link target. This is mapped to a
+# BSBlame::Revision object $lrev as follows:
+#
+# - $lrev -> $lrev->localrev() (remember that a branch revision _is_ a local
+#                               revision => $lrev->localrev() returns itself)
+# - baserev -> $lrev->targetrev()
+
+
+# Variable naming conventions:
+#
+# $lrev:  local revision
+# $plrev: preceeding local revision (e.g., $plrev->idx() == $lrev->idx() + 1)
+# $slrev: succeeding local revision (e.g., $slrev->idx() == $lrev->idx() - 1)
+# $tlrev: target local revision
+# $rev:   expanded revision or a normal plain revision
+
+sub new {
+  my ($class, $rev, $revmgr, $idx) = @_;
+  return bless {
+    'data' => {
+      'rev' => $rev,
+      'revmgr' => $revmgr,
+      'idx' => $idx
+    }
+  }, $class;
+}
+
+sub init {
+  my ($self, $lrev, $trev) = @_;
+  return if $self->{'data'}->{'lsrcmd5'};
+  die("trev without lrev makes no sense\n") if $trev && !$lrev;
+  my $data = $self->{'data'};
+  $data->{'lsrcmd5'} = $data->{'rev'}->{'srcmd5'};
+  my %li;
+  my $files = BSRevision::lsrev($data->{'rev'}, \%li);
+  my ($l, $tsrcmd5);
+  if (%li) {
+    $data->{'lsrcmd5'} = $li{'lsrcmd5'};
+    $data->{'expanded'} = 1;
+    my $lrev = $data->{'revmgr'}->intgetrev($data->{'rev'}->{'project'},
+                                            $data->{'rev'}->{'package'},
+                                            $data->{'lsrcmd5'});
+    $files = BSRevision::lsrev($lrev);
+    $l = BSRevision::revreadxml($lrev, '_link', $files->{'_link'},
+                                $BSXML::link);
+    $tsrcmd5 = $li{'srcmd5'};
+  } elsif ($files->{'_link'}) {
+    $data->{'link'} = 1;
+    $l = BSRevision::revreadxml($data->{'rev'}, '_link', $files->{'_link'},
+                                $BSXML::link);
+    my @patches = @{$l->{'patches'}->{''} || []};
+    $data->{'branch'} = grep {(keys %$_)[0] eq 'branch'} @patches;
+    $tsrcmd5 = $l->{'baserev'};
+  }
+  if ($l && !$trev) {
+    my $tprojid = $l->{'project'} || $data->{'rev'}->{'project'};
+    my $tpackid = $l->{'package'} || $data->{'rev'}->{'package'};
+    $trev = $data->{'revmgr'}->intgetrev($tprojid, $tpackid, $tsrcmd5);
+    $data->{'targetrev'} = BSBlame::Revision->new($trev, $data->{'revmgr'});
+  } elsif ($trev) {
+    $self->localrev($lrev);
+    $data->{'targetrev'} = $trev;
+    $self->resolved(1);
+  }
+}
+
+sub project {
+  my ($self) = @_;
+  return $self->{'data'}->{'rev'}->{'project'};
+}
+
+sub package {
+  my ($self) = @_;
+  return $self->{'data'}->{'rev'}->{'package'};
+}
+
+sub isexpanded {
+  my ($self) = @_;
+  $self->init();
+  return exists $self->{'data'}->{'expanded'};
+}
+
+sub isbranch {
+  my ($self) = @_;
+  $self->init();
+  return $self->islink() && $self->{'data'}->{'branch'};
+}
+
+sub islink {
+  my ($self) = @_;
+  $self->init();
+  return exists $self->{'data'}->{'link'};
+}
+
+sub isplain {
+  my ($self) = @_;
+  return !$self->islink() && !$self->isexpanded();
+}
+
+sub lsrcmd5 {
+  my ($self) = @_;
+  $self->init();
+  return $self->{'data'}->{'lsrcmd5'};
+}
+
+sub srcmd5 {
+  my ($self) = @_;
+  return $self->{'data'}->{'rev'}->{'srcmd5'};
+}
+
+sub time {
+  my ($self) = @_;
+  if ($self->isexpanded()) {
+    my $lrev = $self->localrev();
+    # lrev itself is not necessarily resolved
+    return $lrev->time() if $self->resolved();
+    die("time cannot be requested for an expanded rev\n");
+  }
+  return $self->{'data'}->{'rev'}->{'time'};
+}
+
+sub localrev {
+  my ($self, $lrev) = @_;
+  $self->init();
+  my $data = $self->{'data'};
+  if ($lrev) {
+    die("localrev cannot be changed\n") if $data->{'localrev'}
+      && $data->{'localrev'} != $lrev; # XXX: use ref comparison
+    $data->{'localrev'} = $lrev;
+  }
+  return $self if $self->resolved() && !$data->{'localrev'};
+  return $data->{'localrev'};
+}
+
+sub targetrev {
+  my ($self) = @_;
+  $self->init();
+  die("targetrev makes no sense for a non link\n") if $self->isplain();
+  return $self->{'data'}->{'targetrev'};
+}
+
+sub intrev {
+  my ($self) = @_;
+  my $lrev = $self->localrev();
+  return $lrev->intrev() if $lrev && !$self->isexpanded() && $lrev != $self;
+  return $self->{'data'}->{'rev'};
+}
+
+sub resolved {
+  my ($self, $status) = @_;
+  $self->{'data'}->{'resolved'} = 1 if $status;
+  return $self->{'data'}->{'resolved'};
+}
+
+sub idx {
+  my ($self) = @_;
+  my $lrev = $self->localrev();
+  return $self->{'data'}->{'idx'} if !$lrev || $lrev == $self;
+  return $lrev->idx();
+}
+
+sub satisfies {
+  my ($self, @constraints) = @_;
+  for my $c (@constraints) {
+    next unless $c->isfor($self);
+    return 0 unless $c->eval($self);
+  }
+  $self->init();
+  if ($self->resolved() && ($self->islink() || $self->isexpanded())) {
+    @constraints = grep {$_->isglobal()} @constraints;
+    my $trev = $self->targetrev();
+    return $trev->satisfies(@constraints) if $trev->resolved();
+  }
+  return 1;
+}
+
+sub constraints {
+  my ($self, @constraints) = @_;
+  # TODO: instead of just pushing the @constraints, it would be more
+  #       reasonable to "merge" the constraints
+  my $data = $self->{'data'};
+  push @{$data->{'constraints'}}, @constraints;
+  $data->{'targetrev'}->constraints(@constraints) if $data->{'targetrev'};
+  return @{$data->{'constraints'}};
+}
+
+sub revmgr {
+  my ($self) = @_;
+  return $self->{'data'}->{'revmgr'};
+}
+
+sub files {
+  my ($self) = @_;
+  return $self->revmgr()->lsrev($self);
+}
+
+sub file {
+  my ($self, $filename) = @_;
+  return $self->revmgr()->revfilename($self, $filename);
+}
+
+sub cookie {
+  my ($self) = @_;
+  die("rev has to be resolved\n") unless $self->resolved();
+  return $self->{'data'}->{'cookie'} if $self->{'data'}->{'cookie'};
+  my $cookie = $self->project() . '/' . $self->package;
+  $cookie .= '/' . $self->localrev()->intrev()->{'rev'};
+  # idx is needed in the future if we support deleted revisions...
+  $cookie .= '/' . $self->localrev()->idx();
+  if ($self->isexpanded()) {
+    $cookie .= "\n" . $self->targetrev()->cookie();
+  }
+  $self->{'data'}->{'cookie'} = Digest::MD5::md5_hex($cookie);
+  return $self->{'data'}->{'cookie'};
+}
+
+1;

--- a/src/backend/BSBlame/RevisionManager.pm
+++ b/src/backend/BSBlame/RevisionManager.pm
@@ -1,0 +1,136 @@
+package BSBlame::RevisionManager;
+
+use strict;
+use warnings;
+
+use Data::Dumper;
+
+use BSFileDB;
+use BSBlame::Revision;
+use BSBlame::Range;
+use BSBlame::Constraint;
+use BSBlame::Iterator;
+
+# Manages local revision objects and ranges. Moreover, it encapsulates the
+# access to source files etc.
+
+sub new {
+  my ($class, $projectsdir, $srcrevlay, $getrev, $lsrev, $revfilename,
+      $expand) = @_;
+  return bless {
+    'projectsdir' => $projectsdir,
+    'srcrevlay' => $srcrevlay,
+    'getrev' => $getrev,
+    'lsrev' => $lsrev,
+    'revfilename' => $revfilename,
+    'expand' => $expand
+  }, $class;
+}
+
+# private
+sub read {
+  my ($self, $projid, $packid) = @_;
+  my $key = "$projid/$packid";
+  return $self->{'revs'}->{$key} if $self->{'revs'}->{$key};
+  my $dbfn = "$self->{'projectsdir'}/$projid.pkg/$packid.rev";
+  my @orevs = BSFileDB::fdb_getall($dbfn, $self->{'srcrevlay'});
+  my (@revs, @ranges);
+  my $i = 0;
+  my $range = BSBlame::Range->new(0, \@revs);
+  while (@orevs) {
+    my $orev = pop @orevs;
+    $orev->{'project'} = $projid;
+    $orev->{'package'} = $packid;
+    my $lrev = BSBlame::Revision->new($orev, $self, $i);
+    push @revs, $lrev;
+    if (!$range->contains($lrev)) {
+      $range->end($i - 1);
+      push @ranges, $range;
+      $range = BSBlame::Range->new($i, \@revs);
+    }
+    $i++;
+  }
+  if (@revs) {
+    $range->end($i - 1);
+    push @ranges, $range;
+  }
+  $self->{'revs'}->{$key} = \@revs;
+  $self->{'ranges'}->{$key} = \@ranges;
+  return \@revs;
+}
+
+# returns an "internal" revision (part of the _public_ api)
+sub intgetrev {
+  my ($self, @args) = @_;
+  return $self->{'getrev'}->(@args);
+}
+
+sub lsrev {
+  my ($self, $rev) = @_;
+  return $self->{'lsrev'}->($rev->intrev());
+}
+
+sub expand {
+  my ($self, $lrev, $trev, $fatal) = @_;
+  die("rev must be a branch\n") unless $lrev->isbranch();
+  my $lfiles = $lrev->files();
+  my %lrev = %{$lrev->intrev()};
+  $lrev{'linkrev'} = $trev->srcmd5();
+  my $files = $self->{'expand'}->(\%lrev, $lfiles);
+  if (!ref($files)) {
+    die("cannot be expanded\n") if $fatal;
+    return undef;
+  }
+  my $rev = BSBlame::Revision->new(\%lrev, $self);
+  $rev->init($lrev, $trev);
+  return $rev;
+}
+
+sub revfilename {
+  my ($self, $rev, $filename) = @_;
+  my $md5 = $self->lsrev($rev)->{$filename};
+  return '' unless $md5;
+  return $self->{'revfilename'}->($rev->intrev(), $filename, $md5);
+}
+
+sub iter {
+  my ($self, $projid, $packid, @constraints) = @_;
+  my $revs = $self->read($projid, $packid);
+  return BSBlame::Iterator->new($revs, @constraints);
+}
+
+sub find {
+  my ($self, $projid, $packid, $lsrcmd5, @constraints) = @_;
+  push @constraints, BSBlame::Constraint->new("lsrcmd5 = $lsrcmd5", 0,
+                                              "project = $projid",
+                                              "package = $packid");
+  my $it = $self->iter($projid, $packid, @constraints);
+  return $it->next();
+}
+
+sub range {
+  my ($self, $lrev) = @_;
+  my $key = $lrev->project() . '/' . $lrev->package();
+  $self->read($lrev->project(), $lrev->package());
+  die("$key not known\n") unless $self->{'ranges'}->{$key};
+  for my $range (@{$self->{'ranges'}->{$key}}) {
+    return $range if $range->contains($lrev);
+  }
+  # we could print more details, but this code path shouldn't be
+  # reached in the first place...
+  die("unknown rev\n");
+}
+
+sub rangesplit {
+  my ($self, $lrev) = @_;
+  my $range = $self->range($lrev);
+  my $revs = $self->read($lrev->project(), $lrev->package());
+  my $oldend = $range->end($lrev->idx() - 1);
+  my $newrange = BSBlame::Range->new($lrev->idx(), $revs);
+  $newrange->end($oldend);
+  my $key = $lrev->project() . '/' . $lrev->package();
+  # we do not care about the ordering
+  push @{$self->{'ranges'}->{$key}}, $newrange;
+}
+
+1;

--- a/src/backend/BSBlameTest.pm
+++ b/src/backend/BSBlameTest.pm
@@ -1,0 +1,225 @@
+package BSBlameTest;
+
+use strict;
+use warnings;
+use Data::Dumper;
+use Digest::MD5 ();
+use Test::More;
+
+use BSRPC;
+use BSXML;
+use BSXPath;
+use BSConfig;
+use BSUtil;
+
+require Exporter;
+our @ISA = qw(Exporter);
+our @EXPORT_OK = qw(blame_is list_like commit branch create del list);
+
+# Some testing infrastructure code...
+
+sub blame_is {
+  my ($test_name, $projid, $packid, $filename, %opts) = @_;
+  my $code = delete $opts{'code'} || 200;
+  die("'expected' option required\n")
+    unless exists $opts{'expected'} || $code != 200;
+  my $exp = delete $opts{'expected'};
+  $exp .= 'NUMLINES: ' . split("\n", $exp) if $exp;
+  # by default, we always expand
+  $opts{'expand'} = 1 unless exists $opts{'expand'};
+  my $blamedata;
+  eval {
+    $blamedata = blame($projid, $packid, $filename, %opts);
+  };
+  if ($code && $code != 200) {
+    like($@, qr/^$code/, $test_name);
+    return;
+  }
+  my $file = getfile($projid, $packid, $filename, %opts);
+  my @lines = split("\n", $file);
+  for (my $i = 0; $i < @lines; $i++) {
+    my $blamerev = $blamedata->{'revision'}->[$i];
+    my $project = $blamerev->{'project'} || '';
+    my $package = $blamerev->{'package'} || '';
+    my $rev = $blamerev->{'rev'} || '';
+    $lines[$i] = "$project/$package/r$rev: $lines[$i]";
+  }
+  $lines[@lines] = 'NUMLINES: ' . @lines;
+  $file = join("\n", @lines);
+  is($file, $exp, $test_name);
+}
+
+sub list_like {
+  my ($test_name, $projid, $packid, %opts) = @_;
+  die("'xpath' option required\n") unless exists $opts{'xpath'};
+  my $xpath = delete $opts{'xpath'};
+  my $dir = list($projid, $packid, hash2query(%opts));
+  my $match = BSXPath::match($dir, $xpath);
+  ok(@$match, $test_name);
+}
+
+## helpers
+
+# add User-Agent header (unless present), because if the BSRPC UA is used,
+# the backend might use different codepath (even though this shouldn't harm...)
+sub rpc {
+  my ($uri, @args) = @_;
+  $uri = {'uri' => $uri} unless ref($uri) eq 'HASH';
+  push @{$uri->{'headers'}}, "User-Agent: BSBlameTest"
+    unless grep { /'^User-Agent:'/si } @{$uri->{'headers'} || []};
+  return BSRPC::rpc($uri, @args);
+}
+
+# eek: ls is already imported from BSUtil
+sub list {
+  my ($projid, $packid, @query) = @_;
+  my $uri = "$BSConfig::srcserver/source/$projid";
+  $uri .= "/$packid" if $packid;
+  return rpc($uri, $BSXML::dir, @query);
+}
+
+sub getfile {
+  my ($projid, $packid, $filename, %opts) = @_;
+  return rpc("$BSConfig::srcserver/source/$projid/$packid/$filename", undef,
+             hash2query(%opts));
+}
+
+sub putdata {
+  my ($uri, $dtd, $data, @query) = @_;
+  my $param = {
+    'uri' => $uri,
+    'request' => 'PUT',
+    'data' => $data,
+    'headers' => [ 'Content-Type: application/octet-stream' ]
+  };
+  return rpc($param, $dtd, @query);
+}
+
+sub putfile {
+  my ($projid, $packid, $filename, $data, @query) = @_;
+  my $uri = "$BSConfig::srcserver/source/$projid/$packid/$filename";
+  return putdata($uri, $BSXML::revision, $data, @query);
+  }
+
+sub putproject {
+  my ($projid, @query) = @_;
+  my $uri = "$BSConfig::srcserver/source/$projid/_meta";
+  my $data = BSUtil::toxml({'name' => $projid}, $BSXML::proj);
+  return putdata($uri, $BSXML::proj, $data, @query);
+}
+
+sub putpackage {
+  my ($projid, $packid, @query) = @_;
+  my $uri = "$BSConfig::srcserver/source/$projid/$packid/_meta";
+  my $data = BSUtil::toxml({'project' => $projid, 'name' => $packid},
+                           $BSXML::pack);
+  return putdata($uri, $BSXML::pack, $data, @query);
+}
+
+# make sure projid or projid/packid exist
+# returns true if projid or projid/packid already exists
+# XXX: we always delete $packid, (for the current use cases this is
+#      the more "reasonable" behavior)
+sub create {
+  my ($projid, $packid, @query) = @_;
+  my $exists;
+  # check if projid exists
+  eval {
+    $exists = list($projid);
+  };
+  if ($@) {
+    die($@) unless $@ =~ /^404/;
+    putproject($projid, @query);
+  }
+  return defined($exists) unless $packid;
+  $exists = undef;
+  eval {
+    $exists = list($projid, $packid);
+  };
+  if ($@) {
+    die($@) unless $@ =~ /^404/;
+  }
+  del($projid, $packid) if $exists;
+  putpackage($projid, $packid, @query);
+  return defined($exists);
+}
+
+sub del {
+  my ($projid, $packid, @query) = @_;
+  my $uri = "$BSConfig::srcserver/source/$projid";
+  $uri .= "/$packid" if $packid;
+  my $param = {
+    'uri' => $uri,
+    'request' => 'DELETE'
+  };
+  return rpc($param, undef, @query);
+}
+
+sub hash2query {
+  my (%opts) = @_;
+  return map { "$_=$opts{$_}" } keys %opts;
+}
+
+sub commitfilelist {
+  my ($projid, $packid, $entries, @query) = @_;
+  my $param = {
+    'uri' => "$BSConfig::srcserver/source/$projid/$packid",
+    'request' => 'POST',
+    'data' => BSUtil::toxml({'entry' => $entries}, $BSXML::dir),
+    'headers' => [ 'Content-Type: application/octet-stream' ]
+  };
+  return rpc($param, $BSXML::dir, "cmd=commitfilelist", @query);
+}
+
+sub commit {
+  my ($projid, $packid, $opts, %files) = @_;
+  my $newcontent = delete $opts->{'newcontent'};
+  my $orev = $opts->{'orev'} || 'latest';
+  my $ofiles;
+  $ofiles = list($projid, $packid, "rev=$orev", "expand=1") unless $newcontent;
+  my @entries = @{$ofiles->{'entry'} || []};
+  @entries = grep {!exists($files{$_->{'name'}})} @entries;
+  # only name and md5 attrs, please (the others don't harm, though)
+  for my $e (@entries) {
+    delete $e->{$_} for grep {$_ ne "name" && $_ ne "md5"} keys %$e;
+  }
+  delete $files{$_} for grep {!$files{$_}} keys %files;
+  for my $f (keys %files) {
+    push @entries, {'name' => $f, 'md5' => Digest::MD5::md5_hex($files{$f})};
+  }
+  my $todo = commitfilelist($projid, $packid, \@entries, hash2query(%$opts));
+  if ($todo->{'error'}) {
+    die("unexpected error: $todo->{'error'}\n") unless $todo->{'error'} eq 'missing';
+    for (@{$todo->{'entry'} || []}) {
+      die("origin files missing: $_->{'name'}\n") unless $files{$_->{'name'}};  # should never happen...
+      putfile($projid, $packid, $_->{'name'}, $files{$_->{'name'}}, "rev=repository");
+    }
+    $todo = commitfilelist($projid, $packid, \@entries, hash2query(%$opts));
+    die("cannot commit files: $todo->{'error'}\n") if $todo->{'error'};
+  }
+  return $todo;
+}
+
+sub branch {
+  my ($projid, $packid, $oprojid, $opackid, %query) = @_;
+  $query{'cmd'} = 'branch';
+  $query{'oproject'} = $oprojid;
+  $query{'opackage'} = $opackid;
+  my $param = {
+    'uri' => "$BSConfig::srcserver/source/$projid/$packid",
+    'request' => 'POST'
+  };
+  return rpc($param, $BSXML::revision_acceptinfo, hash2query(%query));
+}
+
+sub blame {
+  my ($projid, $packid, $filename, %query) = @_;
+  $query{'cmd'} = 'blame';
+  my $param = {
+    'uri' => "$BSConfig::srcserver/source/$projid/$packid/$filename",
+    'request' => 'POST'
+  };
+  return rpc($param, $BSXML::blamedata, hash2query(%query));
+}
+
+1;

--- a/src/backend/BSXML.pm
+++ b/src/backend/BSXML.pm
@@ -1770,4 +1770,13 @@ our $publishedpath = [
 	'url',
 ];
 
+our $blamerevision = [
+  map {$_ eq 'rev' ? ('rev', 'project', 'package') : $_} @$revision
+];
+
+our $blamedata = [
+    'blamedata' =>
+        [ $blamerevision ]
+];
+
 1;

--- a/src/backend/bs_srcserver
+++ b/src/backend/bs_srcserver
@@ -59,6 +59,11 @@ use BSSrcrep;
 use BSRevision;
 use BSKiwiXML;
 
+use BSBlame::BlameStorage;
+use BSBlame::Revision;
+use BSBlame::RevisionManager;
+use BSBlame::RangeFirstStrategy;
+
 use BSXPath;
 use BSXPathKeys;
 use BSDB;
@@ -2810,6 +2815,27 @@ sub servicediff {
   } else {
     die("no service was run for this revision\n");
   }
+}
+
+sub sourceblame {
+  my ($cgi, $projid, $packid, $filename) = @_;
+  my $rev = getrev($projid, $packid, $cgi->{'rev'});
+  my $files = BSRevision::lsrev($rev);
+  my %lrev = %$rev;
+  $files = BSSrcServer::Link::handlelinks(\%lrev, $files) if $cgi->{'expand'};
+  die("404 filename $filename does not exist\n") unless $files->{$filename};
+  my $revmgr = BSBlame::RevisionManager->new($projectsdir, $srcrevlay,
+                                             \&getrev, \&BSRevision::lsrev,
+                                             \&BSRevision::revfilename,
+                                             \&BSSrcServer::Link::handlelinks);
+  $rev = BSBlame::Revision->new(\%lrev, $revmgr);
+  my $storage =  BSBlame::BlameStorage->new();
+  my $strategy = BSBlame::RangeFirstStrategy->new($storage);
+  $strategy->blame($rev, $filename);
+  my $blamedata = $storage->retrieve($rev, $filename);
+  die("no blamedata available\n") unless $blamedata;
+  my @blamedata = map {$_->intrev()} @$blamedata;
+  return ({'revision' => \@blamedata}, $BSXML::blamedata);
 }
 
 sub sourcecommit {
@@ -5601,6 +5627,7 @@ my $dispatches = [
   'POST:/source/$project/$package cmd=mergeservice user:? comment:?' => \&mergeservicerun,
   'POST:/source/$project/$package cmd=getprojectservices' => \&getprojectservices,
   'POST:/source/$project/$package cmd=notifypackagechange' => \&notifypackagechange,
+  'POST:/source/$project/$package/$filename cmd=blame rev? expand:bool?' => \&sourceblame,
   'POST:/source/$project/$package cmd: *:*' => \&unknowncmd,
 
   'PUT:/source/$project/$package cmd: rev? user:? comment:?' => \&sourcecommitfilelist,	# obsolete

--- a/src/backend/t/01-blame.t
+++ b/src/backend/t/01-blame.t
@@ -1,0 +1,487 @@
+#!/usr/bin/perl
+
+use strict;
+use warnings;
+
+use Test::More tests => 31;
+
+use BSBlame::Diff3;
+
+our $fixtures_dir = 'fixtures';
+
+sub test_sub {
+  my ($test_name, $code_ref, $args, $expected) = @_;
+  die("code ref required\n") unless $code_ref;
+  is_deeply($code_ref->(@$args), $expected, $test_name);
+}
+
+sub fixture {
+  my ($filename) = @_;
+  my $dir = __FILE__;
+  $dir =~ s/\/[^\/]*$//;
+  return "$dir/$fixtures_dir/$filename";
+}
+
+sub test_diff3 {
+  my ($test_name, $args, @expected) = @_;
+  test_sub("diff3: " . $test_name,
+    sub { return [BSBlame::Diff3::diff3(@_)]; },
+    $args, \@expected);
+}
+
+sub test_merge {
+  my ($test_name, $args, @expected) = @_;
+  test_sub("merge: " . $test_name,
+    sub { return [BSBlame::Diff3::merge(@_)]; },
+    $args, \@expected);
+}
+
+# test cases for BSBlame::Diff3::diff3
+
+test_diff3("two-way diff of my and /dev/null",
+  ['/dev/null', fixture('my'), '/dev/null'],
+  (
+    {
+      'odd' => 1,
+      'data' => [
+        [-1, -1, 'a'],
+        [0, 11, 'c'],
+        [-1, -1, 'a']
+      ]
+    }
+  ));
+
+test_diff3("two-way diff of your and common",
+  [fixture('common'), fixture('your'), fixture('common')],
+  (
+    {
+      'odd' => 1,
+      'data' => [
+        [4, 5, 'c'],
+        [4, 5, 'c'],
+        [4, 5, 'c']
+      ]
+    },
+    {
+      'odd' => 1,
+      'data' => [
+        [9, 9, 'a'],
+        [10, 12, 'c'],
+        [9, 9, 'a']
+      ]
+    }
+  ));
+
+test_diff3("three-way diff of my, your and common",
+  [fixture('my'), fixture('your'), fixture('common')],
+  (
+    {
+      'odd' => 0,
+      'data' => [
+        [1, 2, 'c'],
+        [1, 1, 'c'],
+        [1, 1, 'c']
+      ]
+    },
+    {
+      'odd' => 1,
+      'data' => [
+        [5, 6, 'c'],
+        [4, 5, 'c'],
+        [4, 5, 'c']
+      ]
+    },
+    {
+      'odd' => 0,
+      'data' => [
+        [8, 10, 'c'],
+        [7, 8, 'c'],
+        [7, 8, 'c']
+      ]
+    },
+    {
+      'odd' => 1,
+      'data' => [
+        [11, 11, 'a'],
+        [10, 12, 'c'],
+        [9, 9, 'a']
+      ]
+    }
+  ));
+
+test_diff3("three-way diff of my, your.noeol and common (your.noeol has no EOL)",
+  [fixture('my'), fixture('your.noeol'), fixture('common')],
+  (
+    {
+      'odd' => 0,
+      'data' => [
+        [1, 2, 'c'],
+        [1, 1, 'c'],
+        [1, 1, 'c']
+      ]
+    },
+    {
+      'odd' => 1,
+      'data' => [
+        [5, 6, 'c'],
+        [4, 5, 'c'],
+        [4, 5, 'c']
+      ]
+    },
+    {
+      'odd' => 0,
+      'data' => [
+        [8, 10, 'c'],
+        [7, 8, 'c'],
+        [7, 8, 'c']
+      ]
+    },
+    {
+      'odd' => 1,
+      'data' => [
+        [11, 11, 'a'],
+        [10, 12, 'c'],
+        [9, 9, 'a']
+      ]
+    }
+  ));
+
+test_diff3("empty three-way diff",
+  [fixture('my'), fixture('my'), fixture('my')],
+  ());
+
+test_diff3("conflict in a three-way diff",
+  [fixture('common'), fixture('your'), fixture('my')],
+  (
+    {
+      'odd' => 2,
+      'data' => [
+        [1, 1, 'c'],
+        [1, 1, 'c'],
+        [1, 2, 'c']
+      ]
+    },
+    {
+      'odd' => 1,
+      'data' => [
+        [4, 5, 'c'],
+        [4, 5, 'c'],
+        [5, 6, 'c']
+      ]
+    },
+    {
+      'odd' => undef,
+      'data' => [
+        [7, 9, 'c'],
+        [7, 12, 'c'],
+        [8, 11, 'c']
+      ]
+    }
+  ));
+
+# test cases for BSBlame::Diff3::merge
+
+test_merge("my and /dev/null",
+  [fixture('my'), '/dev/null', '/dev/null'],
+  (
+    [0, 0],
+    [0, 1],
+    [0, 2],
+    [0, 3],
+    [0, 4],
+    [0, 5],
+    [0, 6],
+    [0, 7],
+    [0, 8],
+    [0, 9],
+    [0, 10],
+    [0, 11]
+  ));
+
+test_merge("/dev/null and common",
+  ['/dev/null', fixture('common'), fixture('common')],
+  ());
+
+test_merge("my, your and common",
+  [fixture('my'), fixture('your'), fixture('common')],
+  (
+    [2, 0],
+    [0, 1],
+    [0, 2],
+    [2, 2],
+    [2, 3],
+    [1, 4],
+    [1, 5],
+    [2, 6],
+    [0, 8],
+    [0, 9],
+    [0, 10],
+    [2, 9],
+    [1, 10],
+    [1, 11],
+    [1, 12]
+  ));
+
+# same result as above
+test_merge("my, your.noeol and common (your.noeol has no EOL)",
+  [fixture('my'), fixture('your.noeol'), fixture('common')],
+  (
+    [2, 0],
+    [0, 1],
+    [0, 2],
+    [2, 2],
+    [2, 3],
+    [1, 4],
+    [1, 5],
+    [2, 6],
+    [0, 8],
+    [0, 9],
+    [0, 10],
+    [2, 9],
+    [1, 10],
+    [1, 11],
+    [1, 12]
+  ));
+
+test_merge("only changes in the middle of the files (take rest from common)",
+  [fixture('my'), fixture('common'), fixture('common')],
+  (
+    [2, 0],
+    [0, 1],
+    [0, 2],
+    [2, 2],
+    [2, 3],
+    [2, 4],
+    [2, 5],
+    [2, 6],
+    [0, 8],
+    [0, 9],
+    [0, 10],
+    [2, 9]
+  ));
+
+test_merge("/dev/null /dev/null common",
+  ['/dev/null', '/dev/null', fixture('common')],
+  ());
+
+test_merge("no changes (real file)",
+  [fixture('my'), fixture('my'), fixture('my')],
+  (
+    [2, 0],
+    [2, 1],
+    [2, 2],
+    [2, 3],
+    [2, 4],
+    [2, 5],
+    [2, 6],
+    [2, 7],
+    [2, 8],
+    [2, 9],
+    [2, 10],
+    [2, 11]
+  ));
+
+test_merge("no changes (/dev/null)",
+  ['/dev/null', '/dev/null', '/dev/null'],
+  ());
+
+test_merge("numlines for the common file",
+  [fixture('my'), fixture('common'), fixture('common'), 9],
+  (
+    [2, 0],
+    [0, 1],
+    [0, 2],
+    [2, 2],
+    [2, 3],
+    [2, 4],
+    [2, 5],
+    [2, 6],
+    [0, 8],
+    [0, 9],
+    [0, 10],
+    [2, 9]
+  ));
+
+test_merge("numlines for the common file (one line less)",
+  [fixture('my'), fixture('common'), fixture('common'), 8],
+  (
+    [2, 0],
+    [0, 1],
+    [0, 2],
+    [2, 2],
+    [2, 3],
+    [2, 4],
+    [2, 5],
+    [2, 6],
+    [0, 8],
+    [0, 9],
+    [0, 10]
+  ));
+
+test_merge("pretend that the common file comprises one line (numlines 0)",
+  [fixture('my'), fixture('my'), fixture('my'), 0],
+  (
+    [2, 0]
+  ));
+
+test_merge("pretend that the common file is empty (numlines -1)",
+  [fixture('my'), fixture('my'), fixture('my'), -1],
+  ());
+
+test_merge("conflict",
+  [fixture('common'), fixture('your'), fixture('my')],
+  undef);
+
+test_merge("my2.sdel my2.sdel common2 (deletes a single line from common2)",
+  [fixture('my2.sdel'), fixture('my2.sdel'), fixture('common2')],
+  (
+    [2, 0],
+    [2, 1],
+    [2, 3],
+    [2, 4]
+  ));
+
+test_merge("my2.mdel my2.mdel common2 (deletes multiple lines from common2)",
+  [fixture('my2.mdel'), fixture('my2.mdel'), fixture('common2')],
+  (
+    [2, 0],
+    [2, 1],
+    [2, 4]
+  ));
+
+test_merge("my2.sadd my2.sadd common2 (adds a single line from the my file)",
+  [fixture('my2.sadd'), fixture('my2.sadd'), fixture('common2'), undef, $BSBlame::Diff3::FM],
+  (
+    [2, 0],
+    [2, 1],
+    [2, 2],
+    [0, 3],
+    [2, 3],
+    [2, 4]
+  ));
+
+test_merge("my2.sadd my2.sadd common2 (adds a single line from the your file)",
+  [fixture('my2.sadd'), fixture('my2.sadd'), fixture('common2'), undef, $BSBlame::Diff3::FY],
+  (
+    [2, 0],
+    [2, 1],
+    [2, 2],
+    [1, 3],
+    [2, 3],
+    [2, 4]
+  ));
+
+# same as above, but the ctie is omitted
+test_merge("my2.sadd my2.sadd common2 (adds a single line from the your file)",
+  [fixture('my2.sadd'), fixture('my2.sadd'), fixture('common2')],
+  (
+    [2, 0],
+    [2, 1],
+    [2, 2],
+    [1, 3],
+    [2, 3],
+    [2, 4]
+  ));
+
+test_merge("my2.madd my2.madd common2 (adds multiple lines from the my file)",
+  [fixture('my2.madd'), fixture('my2.madd'), fixture('common2'), undef, $BSBlame::Diff3::FM],
+  (
+    [2, 0],
+    [2, 1],
+    [2, 2],
+    [0, 3],
+    [0, 4],
+    [0, 5],
+    [2, 3],
+    [2, 4]
+  ));
+
+test_merge("my2.madd my2.madd common2 (adds multiple lines from the your file)",
+  [fixture('my2.madd'), fixture('my2.madd'), fixture('common2')],
+  (
+    [2, 0],
+    [2, 1],
+    [2, 2],
+    [1, 3],
+    [1, 4],
+    [1, 5],
+    [2, 3],
+    [2, 4]
+  ));
+
+test_merge("my2.change my2.change common2 (adds + deletes from the my file)",
+  [fixture('my2.change'), fixture('my2.change'), fixture('common2'), undef, $BSBlame::Diff3::FM],
+  (
+    [2, 0],
+    [2, 1],
+    [0, 2],
+    [0, 3],
+    [0, 4],
+    [2, 4]
+  ));
+
+test_merge("my2.change my2.change common2 (adds + deletes from the your file)",
+  [fixture('my2.change'), fixture('my2.change'), fixture('common2')],
+  (
+    [2, 0],
+    [2, 1],
+    [1, 2],
+    [1, 3],
+    [1, 4],
+    [2, 4]
+  ));
+
+test_merge("my3 your3 common3 (adds + deletes + changes)",
+  [fixture('my3'), fixture('your3'), fixture('common3')],
+  (
+    [0, 0],
+    [2, 1],
+    [1, 2],
+    [2, 3],
+    [2, 6],
+    [2, 7],
+    [0, 6],
+    [0, 7],
+    [2, 8],
+    [1, 7],
+    [1, 8],
+    [2, 9],
+    [0, 10],
+    [0, 11],
+    [2, 10]
+  ));
+
+test_merge("common2 my2.mdel common2 (basically a two-way diff)",
+  [fixture('common2'), fixture('my2.mdel'), fixture('common2')],
+  (
+    [2, 0],
+    [2, 1],
+    [2, 4]
+  ));
+
+test_merge("my2.sdel common2 common2 (my2.sdel just removes a single line)",
+  [fixture('my2.sdel'), fixture('common2'), fixture('common2')],
+  (
+    [2, 0],
+    [2, 1],
+    [2, 3],
+    [2, 4]
+  ));
+
+#test_merge("my2, your2 and common (my2 and your2 share a new line)",
+#  [fixture('my2'), fixture('common'), fixture('your2')],
+#  (
+#    [2, 0],
+#    [2, 1],
+#    [2, 2],
+#    [1, 3],
+#    [2, 3],
+#    [2, 0],
+#    [0, 6],
+#    [0, 7],
+#    [0, 8],
+#    [2, 9],
+#    [1, 9],
+#    [1, 10],
+#    [1, 11]
+#  ));

--- a/src/backend/t/02-blame-simple.t
+++ b/src/backend/t/02-blame-simple.t
@@ -1,0 +1,143 @@
+#!/usr/bin/perl
+
+use strict;
+use warnings;
+use Test::More tests => 13;
+
+use BSBlameTest qw(blame_is create commit del);
+
+create("simple", "pkg1");
+commit("simple", "pkg1", {}, testfile => <<EOF);
+This is a very
+simple test
+file.
+EOF
+blame_is("blame initial commit", "simple", "pkg1", "testfile", expected => <<EOF);
+simple/pkg1/r1: This is a very
+simple/pkg1/r1: simple test
+simple/pkg1/r1: file.
+EOF
+
+commit("simple", "pkg1", {}, testfile => <<EOF);
+This is still a very
+simple test
+file.
+EOF
+blame_is("changed first line", "simple", "pkg1", "testfile", expected => <<EOF);
+simple/pkg1/r2: This is still a very
+simple/pkg1/r1: simple test
+simple/pkg1/r1: file.
+EOF
+
+commit("simple", "pkg1", {}, otherfile => "some content");
+blame_is("changed first line", "simple", "pkg1", "testfile", expected => <<EOF);
+simple/pkg1/r2: This is still a very
+simple/pkg1/r1: simple test
+simple/pkg1/r1: file.
+EOF
+
+commit("simple", "pkg1", {}, testfile => <<EOF);
+This is still a very
+simple test
+file.
+
+Added some
+new content
+here.
+EOF
+blame_is("new content in r4", "simple", "pkg1", "testfile", expected => <<EOF);
+simple/pkg1/r2: This is still a very
+simple/pkg1/r1: simple test
+simple/pkg1/r1: file.
+simple/pkg1/r4: 
+simple/pkg1/r4: Added some
+simple/pkg1/r4: new content
+simple/pkg1/r4: here.
+EOF
+
+commit("simple", "pkg1", {}, testfile => undef);
+blame_is("testfile was removed", "simple", "pkg1", "testfile", code => 404);
+
+commit("simple", "pkg1", {}, testfile => <<EOF);
+A brand
+new first
+section.
+
+Old:
+Added some
+new content
+here.
+EOF
+blame_is("readd in r6", "simple", "pkg1", "testfile", expected => <<EOF);
+simple/pkg1/r6: A brand
+simple/pkg1/r6: new first
+simple/pkg1/r6: section.
+simple/pkg1/r6: 
+simple/pkg1/r6: Old:
+simple/pkg1/r6: Added some
+simple/pkg1/r6: new content
+simple/pkg1/r6: here.
+EOF
+
+commit("simple", "pkg1", {}, testfile => <<EOF);
+This is the first
+section.
+
+With some changes.
+
+Old:
+Added some
+content and
+changed some content
+here.
+EOF
+blame_is("various changes in r7", "simple", "pkg1", "testfile", expected => <<EOF);
+simple/pkg1/r7: This is the first
+simple/pkg1/r6: section.
+simple/pkg1/r6: 
+simple/pkg1/r7: With some changes.
+simple/pkg1/r7: 
+simple/pkg1/r6: Old:
+simple/pkg1/r6: Added some
+simple/pkg1/r7: content and
+simple/pkg1/r7: changed some content
+simple/pkg1/r6: here.
+EOF
+
+blame_is("testfile in r4", "simple", "pkg1", "testfile", rev => 4, expected => <<EOF);
+simple/pkg1/r2: This is still a very
+simple/pkg1/r1: simple test
+simple/pkg1/r1: file.
+simple/pkg1/r4: 
+simple/pkg1/r4: Added some
+simple/pkg1/r4: new content
+simple/pkg1/r4: here.
+EOF
+
+del("simple", "pkg1");
+blame_is("nonexistent pkg1", "simple", "pkg1", "testfile", code => 404);
+
+create("simple", "pkg1");
+# add content from previous r4 again
+commit("simple", "pkg1", {}, testfile => <<EOF);
+This is still a very
+simple test
+file.
+
+Added some
+new content
+here.
+EOF
+blame_is("initial commit after deletion", "simple", "pkg1", "testfile", expected => <<EOF);
+simple/pkg1/r1: This is still a very
+simple/pkg1/r1: simple test
+simple/pkg1/r1: file.
+simple/pkg1/r1: 
+simple/pkg1/r1: Added some
+simple/pkg1/r1: new content
+simple/pkg1/r1: here.
+EOF
+
+blame_is("nonexistent file", "simple", "pkg1", "otherfile", code => 404);
+blame_is("nonexistent pkg", "simple", "pkgnonexistent", "testfile", code => 404);
+blame_is("nonexistent prj", "prjnonexistent", "pkg1", "testfile", code => 404);

--- a/src/backend/t/03-blame-branch-simple.t
+++ b/src/backend/t/03-blame-branch-simple.t
@@ -1,0 +1,173 @@
+#!/usr/bin/perl
+
+use strict;
+use warnings;
+use Test::More tests => 11;
+
+use BSBlameTest qw(blame_is list_like create commit del branch);
+
+create("origin", "opkg1");
+commit("origin", "opkg1", {}, testfile => <<EOF);
+We start with
+a very very
+simple text
+file.
+EOF
+commit("origin", "opkg1", {}, testfile => <<EOF);
+We start with
+a very
+very
+simple text
+file.
+EOF
+blame_is("blame origin", "origin", "opkg1", "testfile", expected => <<EOF);
+origin/opkg1/r1: We start with
+origin/opkg1/r2: a very
+origin/opkg1/r2: very
+origin/opkg1/r1: simple text
+origin/opkg1/r1: file.
+EOF
+
+create("branch", "pkg1");
+branch("branch", "pkg1", "origin", "opkg1");
+list_like("check baserev", "branch", "pkg1", xpath => './linkinfo[@baserev = "6c23f5262aaeec2e50d46c9a630f1fd0"]');
+blame_is("branch at r1", "branch", "pkg1", "testfile", expected => <<EOF);
+origin/opkg1/r1: We start with
+origin/opkg1/r2: a very
+origin/opkg1/r2: very
+origin/opkg1/r1: simple text
+origin/opkg1/r1: file.
+EOF
+
+commit("branch", "pkg1", {keeplink => 1}, testfile => <<EOF);
+We start with
+a very
+very
+simple text
+file.
+
+And add some
+new lines in
+the branch.
+EOF
+blame_is("branch at r2", "branch", "pkg1", "testfile", expected => <<EOF);
+origin/opkg1/r1: We start with
+origin/opkg1/r2: a very
+origin/opkg1/r2: very
+origin/opkg1/r1: simple text
+origin/opkg1/r1: file.
+branch/pkg1/r2: 
+branch/pkg1/r2: And add some
+branch/pkg1/r2: new lines in
+branch/pkg1/r2: the branch.
+EOF
+
+commit("branch", "pkg1", {keeplink => 1}, testfile => <<EOF);
+We start with
+three lines that were first added in
+the branch and will be added to the
+origin in a future commit. However, this is still
+a very
+very
+simple text
+file.
+
+This is a very cool line.
+
+And add some
+new lines and modify
+a line in
+the branch.
+EOF
+blame_is("branch at r3", "branch", "pkg1", "testfile", expected => <<EOF);
+origin/opkg1/r1: We start with
+branch/pkg1/r3: three lines that were first added in
+branch/pkg1/r3: the branch and will be added to the
+branch/pkg1/r3: origin in a future commit. However, this is still
+origin/opkg1/r2: a very
+origin/opkg1/r2: very
+origin/opkg1/r1: simple text
+origin/opkg1/r1: file.
+branch/pkg1/r2: 
+branch/pkg1/r3: This is a very cool line.
+branch/pkg1/r3: 
+branch/pkg1/r2: And add some
+branch/pkg1/r3: new lines and modify
+branch/pkg1/r3: a line in
+branch/pkg1/r2: the branch.
+EOF
+
+commit("origin", "opkg1", {}, testfile => <<EOF);
+We start with
+a very
+simple text
+file.
+EOF
+list_like("baserev still at r2", "branch", "pkg1", xpath => './linkinfo[@baserev = "6c23f5262aaeec2e50d46c9a630f1fd0" and not(@error)]');
+blame_is("origin changed (a line was removed)", "branch", "pkg1", "testfile", expected => <<EOF);
+origin/opkg1/r1: We start with
+branch/pkg1/r3: three lines that were first added in
+branch/pkg1/r3: the branch and will be added to the
+branch/pkg1/r3: origin in a future commit. However, this is still
+origin/opkg1/r2: a very
+origin/opkg1/r1: simple text
+origin/opkg1/r1: file.
+branch/pkg1/r2: 
+branch/pkg1/r3: This is a very cool line.
+branch/pkg1/r3: 
+branch/pkg1/r2: And add some
+branch/pkg1/r3: new lines and modify
+branch/pkg1/r3: a line in
+branch/pkg1/r2: the branch.
+EOF
+
+commit("origin", "opkg1", {}, testfile => <<EOF);
+We start with
+three lines that were first added in
+the branch and will be added to the
+origin in a future commit. However, this is still
+a very
+simple text
+file.
+EOF
+list_like("baserev still at r2", "branch", "pkg1", xpath => './linkinfo[@baserev = "6c23f5262aaeec2e50d46c9a630f1fd0" and not(@error)]');
+blame_is("origin changed (the three lines were added)", "branch", "pkg1", "testfile", expected => <<EOF);
+origin/opkg1/r1: We start with
+origin/opkg1/r4: three lines that were first added in
+origin/opkg1/r4: the branch and will be added to the
+origin/opkg1/r4: origin in a future commit. However, this is still
+origin/opkg1/r2: a very
+origin/opkg1/r1: simple text
+origin/opkg1/r1: file.
+branch/pkg1/r2: 
+branch/pkg1/r3: This is a very cool line.
+branch/pkg1/r3: 
+branch/pkg1/r2: And add some
+branch/pkg1/r3: new lines and modify
+branch/pkg1/r3: a line in
+branch/pkg1/r2: the branch.
+EOF
+
+commit("branch", "pkg1", {keeplink => 1}, otherfile => "added otherfile in r5");
+commit("branch", "pkg1", {keeplink => 1}, otherfile => "changed otherfile in r6");
+commit("branch", "pkg1", {keeplink => 1}, testfile => <<EOF);
+We start with
+some text and realize that
+this file changed
+quite a lot and evolved into
+a not so
+simple text
+file.
+This is a very cool line.
+EOF
+list_like("baserev points to r4", "branch", "pkg1", xpath => '@rev = 6 and ./linkinfo[@baserev = "701a3c4af1cdebd05bdf0c40e12dbb3d" and not(@error)]');
+blame_is("branch at r6", "branch", "pkg1", "testfile", expected => <<EOF);
+origin/opkg1/r1: We start with
+branch/pkg1/r6: some text and realize that
+branch/pkg1/r6: this file changed
+branch/pkg1/r6: quite a lot and evolved into
+branch/pkg1/r6: a not so
+origin/opkg1/r1: simple text
+origin/opkg1/r1: file.
+branch/pkg1/r3: This is a very cool line.
+EOF

--- a/src/backend/t/04-blame-branch-adds_deletes.t
+++ b/src/backend/t/04-blame-branch-adds_deletes.t
@@ -1,0 +1,141 @@
+#!/usr/bin/perl
+
+use strict;
+use warnings;
+use Test::More tests => 17;
+
+use BSBlameTest qw(blame_is list_like create commit del branch);
+
+create("origin", "opkg2");
+commit("origin", "opkg2", {}, filea => <<EOF);
+This is
+some content
+for file
+filea.
+EOF
+
+create("branch", "pkg2");
+branch("branch", "pkg2", "origin", "opkg2");
+blame_is("branch at r1", "branch", "pkg2", "filea", expected => <<EOF);
+origin/opkg2/r1: This is
+origin/opkg2/r1: some content
+origin/opkg2/r1: for file
+origin/opkg2/r1: filea.
+EOF
+
+commit("origin", "opkg2", {}, fileb => <<EOF);
+This is
+the new file
+fileb.
+EOF
+list_like("origin/opkg2 is at r2", "origin", "opkg2",
+  xpath => '@rev = 2 and srcmd5 = "f5a596008989db5e881fcdade1781a6d"');
+list_like("check baserev at r1", "branch", "pkg2",
+  xpath => './linkinfo[@baserev = "cfc4c51c6700fe920459c6022af1c5b8"]');
+blame_is("branch at r1 (origin changed)", "branch", "pkg2", "fileb", expected => <<EOF);
+origin/opkg2/r2: This is
+origin/opkg2/r2: the new file
+origin/opkg2/r2: fileb.
+EOF
+
+commit("branch", "pkg2", {keeplink => 1}, fileb => <<EOF);
+This is
+the
+modified file
+fileb.
+EOF
+list_like("check baserev at r2", "branch", "pkg2",
+  xpath => './linkinfo[@baserev = "f5a596008989db5e881fcdade1781a6d"]');
+blame_is("branch at r2 (fileb changed)", "branch", "pkg2", "fileb", expected => <<EOF);
+origin/opkg2/r2: This is
+branch/pkg2/r2: the
+branch/pkg2/r2: modified file
+origin/opkg2/r2: fileb.
+EOF
+
+commit("branch", "pkg2", {keeplink => 1}, fileb => undef);
+blame_is("fileb does not exist in branch", "branch", "pkg2", "fileb", code => 404);
+
+commit("branch", "pkg2", {keeplink => 1}, fileb => <<EOF);
+This is
+a quite different
+file fileb.
+EOF
+blame_is("fileb was added to branch again", "branch", "pkg2", "fileb", expected => <<EOF);
+origin/opkg2/r2: This is
+branch/pkg2/r4: a quite different
+branch/pkg2/r4: file fileb.
+EOF
+
+commit("origin", "opkg2", {}, filea => undef);
+blame_is("filea was removed from origin", "branch", "pkg2", "filea", code => 404);
+
+commit("branch", "pkg2", {keeplink => 1}, filea => <<EOF);
+This is
+the new
+file
+filea.
+EOF
+blame_is("branch at r5", "branch", "pkg2", "filea", expected => <<EOF);
+branch/pkg2/r5: This is
+branch/pkg2/r5: the new
+branch/pkg2/r5: file
+branch/pkg2/r5: filea.
+EOF
+
+commit("origin", "opkg2", {}, filea => <<EOF);
+This is
+the new
+file
+filea that causes a conflict.
+EOF
+list_like("conflict in the branch", "branch", "pkg2", xpath => '@rev = 5 and ./linkinfo/@error');
+commit("origin", "opkg2", {}, filea => <<EOF);
+This is
+the new
+file
+filea.
+EOF
+list_like("no conflict in the branch", "branch", "pkg2", xpath => 'not(./linkinfo/@error)');
+# filea in the branch and filea in the origin have the same content
+# (hence, all changes common from the filea in the origin (due to the
+# default for $ctie in BSSrcBlame::merge))
+blame_is("branch at r5 (after origin changed)", "branch", "pkg2", "filea", expected => <<EOF);
+origin/opkg2/r4: This is
+origin/opkg2/r4: the new
+origin/opkg2/r4: file
+origin/opkg2/r5: filea.
+EOF
+
+commit("branch", "pkg2", {keeplink => 1}, filec => <<EOF);
+The file
+filec was firstly added
+to the branch and then
+to the origin.
+EOF
+blame_is("branch at r6", "branch", "pkg2", "filec", expected => <<EOF);
+branch/pkg2/r6: The file
+branch/pkg2/r6: filec was firstly added
+branch/pkg2/r6: to the branch and then
+branch/pkg2/r6: to the origin.
+EOF
+
+commit("origin", "opkg2", {}, filec => <<EOF);
+This commit (r6)
+causes a conflict
+which we won't notice.
+EOF
+list_like("conflict in the branch at r6", "branch", "pkg2", xpath => './linkinfo/@error');
+commit("origin", "opkg2", {}, filec => <<EOF);
+The file
+filec was firstly added
+to the branch and then
+to the origin.
+EOF
+list_like("conflict in the branch at r6", "branch", "pkg2", xpath => 'not(./linkinfo/@error)');
+blame_is("branch at r6 (origin changed)", "branch", "pkg2", "filec", expected => <<EOF);
+origin/opkg2/r7: The file
+origin/opkg2/r7: filec was firstly added
+origin/opkg2/r7: to the branch and then
+origin/opkg2/r7: to the origin.
+EOF

--- a/src/backend/t/05-blame-branch-conflict_simple.t
+++ b/src/backend/t/05-blame-branch-conflict_simple.t
@@ -1,0 +1,270 @@
+#!/usr/bin/perl
+
+use strict;
+use warnings;
+use Test::More tests => 22;
+
+use BSBlameTest qw(blame_is list_like create commit del branch);
+
+create("origin", "opkg3");
+commit("origin", "opkg3", {}, filea => <<EOF);
+This is
+a file.
+
+Section start:
+Here, we will have a conflict.
+Section end.
+EOF
+
+create("branch", "pkg3");
+branch("branch", "pkg3", "origin", "opkg3");
+list_like("check baserev after branch", "branch", "pkg3",
+  xpath => './linkinfo[@baserev = "638615aab4e0cca145e5fab193bb8ad5" and not(@error)]');
+blame_is("branch at r1", "branch", "pkg3", "filea", expected => <<EOF);
+origin/opkg3/r1: This is
+origin/opkg3/r1: a file.
+origin/opkg3/r1: 
+origin/opkg3/r1: Section start:
+origin/opkg3/r1: Here, we will have a conflict.
+origin/opkg3/r1: Section end.
+EOF
+
+commit("branch", "pkg3", {keeplink => 1}, filea => <<EOF);
+This is
+a file.
+
+Section start:
+A line from the branch.
+Section end.
+EOF
+blame_is("branch at r2", "branch", "pkg3", "filea", expected => <<EOF);
+origin/opkg3/r1: This is
+origin/opkg3/r1: a file.
+origin/opkg3/r1: 
+origin/opkg3/r1: Section start:
+branch/pkg3/r2: A line from the branch.
+origin/opkg3/r1: Section end.
+EOF
+
+commit("origin", "opkg3", {}, filea => <<EOF);
+This is
+a file.
+
+Section start:
+A line from the origin.
+Section end.
+EOF
+list_like("check baserev and conflict", "branch", "pkg3",
+  xpath => './linkinfo[@baserev = "638615aab4e0cca145e5fab193bb8ad5" and @error]');
+list_like("origin at r2", "origin", "opkg3",
+  xpath => '@rev = 2 and @srcmd5 = "871c68cb49eb4224a2b89bd188709b33"');
+
+# resolve conflict in branch/pkg3
+commit("branch", "pkg3", {keeplink => 1, repairlink => 1, linkrev => "871c68cb49eb4224a2b89bd188709b33", newcontent => 1},
+  filea => <<EOF);
+This is
+a file after conflict resolution.
+
+Section start:
+Resolved:
+A line from the branch.
+A line from the origin.
+Section end.
+EOF
+blame_is("branch at r3 (resolved conflict)", "branch", "pkg3", "filea", expected => <<EOF);
+origin/opkg3/r1: This is
+branch/pkg3/r3: a file after conflict resolution.
+origin/opkg3/r1: 
+origin/opkg3/r1: Section start:
+branch/pkg3/r3: Resolved:
+branch/pkg3/r2: A line from the branch.
+origin/opkg3/r2: A line from the origin.
+origin/opkg3/r1: Section end.
+EOF
+list_like("check baserev and no conflict at r3", "branch", "pkg3",
+  xpath => './linkinfo[@baserev = "871c68cb49eb4224a2b89bd188709b33" and not(@error)]');
+
+# introduce a new conflict
+commit("origin", "opkg3", {}, filea => <<EOF);
+This is
+a quite simple file.
+
+Section start:
+A line from the origin.
+Section end.
+EOF
+list_like("check baserev and conflict", "branch", "pkg3",
+  xpath => './linkinfo[@baserev = "871c68cb49eb4224a2b89bd188709b33" and @error]');
+list_like("origin at r3", "origin", "opkg3",
+  xpath => '@rev = 3 and @srcmd5 = "f3a9ffdb44276cf4fa7e30ac873a2ca6"');
+
+# resolve conflict in branch/pkg3
+commit("branch", "pkg3", {keeplink => 1, repairlink => 1, linkrev => "f3a9ffdb44276cf4fa7e30ac873a2ca6", newcontent => 1},
+  filea => <<EOF);
+This is
+a file after conflict resolution.
+But still
+a quite simple file.
+
+Section start:
+Resolved:
+A line from the branch.
+A line from the origin.
+Section end.
+EOF
+blame_is("branch at r4", "branch", "pkg3", "filea", expected => <<EOF);
+origin/opkg3/r1: This is
+branch/pkg3/r3: a file after conflict resolution.
+branch/pkg3/r4: But still
+origin/opkg3/r3: a quite simple file.
+origin/opkg3/r1: 
+origin/opkg3/r1: Section start:
+branch/pkg3/r3: Resolved:
+branch/pkg3/r2: A line from the branch.
+origin/opkg3/r2: A line from the origin.
+origin/opkg3/r1: Section end.
+EOF
+list_like("check baserev and no conflict at r4", "branch", "pkg3",
+  xpath => './linkinfo[@baserev = "f3a9ffdb44276cf4fa7e30ac873a2ca6" and not(@error)]');
+
+# introduce a new conflict by removing filea from origin
+commit("origin", "opkg3", {}, filea => undef);
+list_like("origin at r4", "origin", "opkg3",
+  xpath => '@rev = 4 and srcmd5 = "d41d8cd98f00b204e9800998ecf8427e"');
+list_like("branch at r4 (conflict: filea removed in origin)", "branch", "pkg3",
+  xpath => './linkinfo/@error');
+
+# resolve conflict in branch/pkg3 by simply keeping the file
+commit("branch", "pkg3", {keeplink => 1, repairlink => 1, linkrev => "d41d8cd98f00b204e9800998ecf8427e", newcontent => 1},
+  filea => <<EOF);
+This is
+a file after conflict resolution.
+But still
+a quite simple file.
+
+Section start:
+Resolved:
+A line from the branch.
+A line from the origin.
+Section end.
+EOF
+list_like("check baserev and no conflict at r5", "branch", "pkg3",
+  xpath => './linkinfo[@baserev = "d41d8cd98f00b204e9800998ecf8427e" and not(@error)]');
+blame_is("branch at r5 (same as in r4)", "branch", "pkg3", "filea", expected => <<EOF);
+origin/opkg3/r1: This is
+branch/pkg3/r3: a file after conflict resolution.
+branch/pkg3/r4: But still
+origin/opkg3/r3: a quite simple file.
+origin/opkg3/r1: 
+origin/opkg3/r1: Section start:
+branch/pkg3/r3: Resolved:
+branch/pkg3/r2: A line from the branch.
+origin/opkg3/r2: A line from the origin.
+origin/opkg3/r1: Section end.
+EOF
+
+# introduce a new filea and fileb and add some conflicts
+# to fileb
+commit("branch", "pkg3", {keeplink => 1}, filea => <<EOF);
+This is filea with 2 sections.
+Section start:
+Section end.
+Section start:
+Section end.
+EOF
+# readd filea to the origin (r5) (the same file as in the branch)
+commit("origin", "opkg3", {}, filea => <<EOF);
+This is filea with 2 sections.
+Section start:
+Section end.
+Section start:
+Section end.
+EOF
+# change filea in the branch (r7)
+commit("branch", "pkg3", {keeplink => 1}, filea => <<EOF);
+This is filea with 2 sections.
+Section start:
+Section end.
+Section start:
+A line from the branch.
+Here ends the last section.
+EOF
+# change filea in the origin (r6)
+commit("origin", "opkg3", {}, filea => <<EOF);
+This is filea with 2 sections.
+Section 1 start:
+A line from the origin.
+Section 1 end.
+Section start:
+Section end.
+EOF
+blame_is("simple blame for filea at r7", "branch", "pkg3", "filea", expected => <<EOF);
+origin/opkg3/r5: This is filea with 2 sections.
+origin/opkg3/r6: Section 1 start:
+origin/opkg3/r6: A line from the origin.
+origin/opkg3/r6: Section 1 end.
+origin/opkg3/r5: Section start:
+branch/pkg3/r7: A line from the branch.
+branch/pkg3/r7: Here ends the last section.
+EOF
+
+# add a new fileb to the branch
+commit("branch", "pkg3", {keeplink => 1}, fileb => <<EOF);
+This is
+the new
+fileb.
+EOF
+blame_is("branch at r8", "branch", "pkg3", "fileb", expected => <<EOF);
+branch/pkg3/r8: This is
+branch/pkg3/r8: the new
+branch/pkg3/r8: fileb.
+EOF
+
+# introduce a conflict by adding a new/different fileb to the origin
+commit("origin", "opkg3", {}, fileb => <<EOF);
+This is
+the new/different
+fileb.
+EOF
+list_like("origin at r7", "origin", "opkg3",
+  xpath => '@rev = "7" and @srcmd5 = "508d66737cb3da3e8b00b8b3bbae5982"');
+list_like("check baserev and conflict", "branch", "pkg3",
+  xpath => './linkinfo[@baserev = "d914a0356a47580f85b43216cae19f72" and @error]');
+
+# resolve conflict in branch/pkg3
+# (no changes to filea (from the expanded POV), we just keep it as it was)
+commit("branch", "pkg3", {keeplink => 1, repairlink => 1, linkrev => "508d66737cb3da3e8b00b8b3bbae5982", newcontent => 1},
+  filea => <<EOF, fileb => <<EOF);
+This is filea with 2 sections.
+Section 1 start:
+A line from the origin.
+Section 1 end.
+Section start:
+A line from the branch.
+Here ends the last section.
+EOF
+This is
+the new
+resolved
+fileb.
+EOF
+list_like("check baserev and no conflict at r9", "branch", "pkg3",
+  xpath => '@rev = "9" and ./linkinfo[@baserev = "508d66737cb3da3e8b00b8b3bbae5982" and not(@error)]');
+blame_is("branch at r9", "branch", "pkg3", "fileb", expected => <<EOF);
+origin/opkg3/r7: This is
+branch/pkg3/r8: the new
+branch/pkg3/r9: resolved
+origin/opkg3/r7: fileb.
+EOF
+# same blame for filea as in r7 of the branch
+# (filea was not affected by the conflict, but its blame was computed
+# by the automerge code)
+blame_is("filea at r9 (after conflict in fileb)", "branch", "pkg3", "filea", expected => <<EOF);
+origin/opkg3/r5: This is filea with 2 sections.
+origin/opkg3/r6: Section 1 start:
+origin/opkg3/r6: A line from the origin.
+origin/opkg3/r6: Section 1 end.
+origin/opkg3/r5: Section start:
+branch/pkg3/r7: A line from the branch.
+branch/pkg3/r7: Here ends the last section.
+EOF

--- a/src/backend/t/06-blame-branch-conflict_automerge.t
+++ b/src/backend/t/06-blame-branch-conflict_automerge.t
@@ -1,0 +1,346 @@
+#!/usr/bin/perl
+
+use strict;
+use warnings;
+use Test::More tests => 27;
+
+use BSBlameTest qw(blame_is list_like create commit del branch);
+
+create("origin", "opkg4");
+commit("origin", "opkg4", {}, testfile => <<EOF);
+This is a
+simple text.
+
+Section start:
+Here, we will have a conflict soon.
+Section end.
+EOF
+
+create("branch", "pkg4");
+branch("branch", "pkg4", "origin", "opkg4");
+list_like("check baserev", "branch", "pkg4", xpath => './linkinfo[@baserev = "14d20514b8eb04c5477b0a31df2a32b8"]');
+blame_is("directly after branch", "branch", "pkg4", "testfile", expected => <<EOF);
+origin/opkg4/r1: This is a
+origin/opkg4/r1: simple text.
+origin/opkg4/r1: 
+origin/opkg4/r1: Section start:
+origin/opkg4/r1: Here, we will have a conflict soon.
+origin/opkg4/r1: Section end.
+EOF
+
+commit("branch", "pkg4", {keeplink => 1}, testfile => <<EOF);
+This is a
+simple text.
+
+Section start:
+A line from the branch.
+Section end.
+EOF
+blame_is("branch at r2", "branch", "pkg4", "testfile", expected => <<EOF);
+origin/opkg4/r1: This is a
+origin/opkg4/r1: simple text.
+origin/opkg4/r1: 
+origin/opkg4/r1: Section start:
+branch/pkg4/r2: A line from the branch.
+origin/opkg4/r1: Section end.
+EOF
+
+commit("origin", "opkg4", {}, testfile => <<EOF);
+This is a
+simple text.
+
+Section start:
+Here, we will have a conflict soon.
+Section end.
+
+This line does not cause a conflict.
+EOF
+blame_is("branch at r1 (origin changed)", "branch", "pkg4", "testfile", expected => <<EOF);
+origin/opkg4/r1: This is a
+origin/opkg4/r1: simple text.
+origin/opkg4/r1: 
+origin/opkg4/r1: Section start:
+branch/pkg4/r2: A line from the branch.
+origin/opkg4/r1: Section end.
+origin/opkg4/r2: 
+origin/opkg4/r2: This line does not cause a conflict.
+EOF
+
+commit("origin", "opkg4", {}, testfile => undef);
+list_like("conflict since testfile was removed from origin", "branch", "pkg4", xpath => './linkinfo/@error');
+commit("origin", "opkg4", {}, testfile => <<EOF);
+This is a
+simple text.
+
+Section start:
+A line from the origin.
+Section end.
+EOF
+list_like("origin/opkg4 is at r4", "origin", "opkg4",
+  xpath => '@rev = 4 and @srcmd5 = "2b4b0e8d610f44d9fb9d6b934cef4c39"');
+list_like("check baserev and conflict", "branch", "pkg4",
+  xpath => './linkinfo[@baserev = "14d20514b8eb04c5477b0a31df2a32b8" and @error]');
+
+# resolve conflict in the branch
+commit("branch", "pkg4", {keeplink => 1, repairlink => 1, linkrev => "2b4b0e8d610f44d9fb9d6b934cef4c39", newcontent => 1},
+  testfile => <<EOF);
+This is a
+simple text.
+
+Section start:
+Resolved:
+A line from the branch.
+A line from the origin.
+Section end.
+
+This line does not cause a conflict.
+EOF
+list_like("check baserev and no conflict", "branch", "pkg4",
+  xpath => './linkinfo[@baserev = "2b4b0e8d610f44d9fb9d6b934cef4c39" and not(@error)]');
+
+# the last two lines come from the last working automerge
+blame_is("branch at r3 (resolved conflict)", "branch", "pkg4", "testfile", expected => <<EOF);
+origin/opkg4/r4: This is a
+origin/opkg4/r4: simple text.
+origin/opkg4/r4: 
+origin/opkg4/r4: Section start:
+branch/pkg4/r3: Resolved:
+branch/pkg4/r2: A line from the branch.
+origin/opkg4/r4: A line from the origin.
+origin/opkg4/r4: Section end.
+origin/opkg4/r2: 
+origin/opkg4/r2: This line does not cause a conflict.
+EOF
+
+# change file in the branch
+commit("branch", "pkg4", {keeplink => 1}, testfile => <<EOF);
+This is a
+quite
+simple text.
+
+Section start:
+Resolved:
+A line from the branch.
+Another line from the branch.
+A line from the origin.
+Section end.
+EOF
+# change file in origin
+commit("origin", "opkg4", {}, testfile => <<EOF);
+This is a
+simple text.
+
+Section start:
+A line from the origin.
+Section end.
+EOF
+list_like("check baserev and no conflict in r4", "branch", "pkg4",
+  xpath => './linkinfo[@baserev = "2b4b0e8d610f44d9fb9d6b934cef4c39" and not(@error)]');
+# introduce a conflict
+commit("origin", "opkg4", {}, testfile => <<EOF);
+This is a
+short file.
+EOF
+list_like("conflict (origin at r6)", "branch", "pkg4",
+  xpath => './linkinfo/@error');
+# introduce another conflict
+commit("origin", "opkg4", {}, testfile => <<EOF);
+This is a
+simple text.
+
+Section 1 start:
+Nested section start:
+Nested section end.
+Section 1 end.
+
+Section start:
+Conflict.
+Section end.
+EOF
+list_like("conflict (origin at r7)", "branch", "pkg4",
+  xpath => './linkinfo/@error');
+# "resolve" conflict in the origin
+commit("origin", "opkg4", {}, testfile => <<EOF);
+This is a
+simple text.
+
+Section 1 start:
+Nested section start:
+Nested section end.
+Section 1 end.
+
+Section start:
+A line from the origin.
+Section end.
+
+Yet another line from the origin.
+EOF
+# this is only needed for understanding the testcase
+blame_is("origin at r8", "origin", "opkg4", "testfile", expected => <<EOF);
+origin/opkg4/r4: This is a
+origin/opkg4/r7: simple text.
+origin/opkg4/r7: 
+origin/opkg4/r7: Section 1 start:
+origin/opkg4/r7: Nested section start:
+origin/opkg4/r7: Nested section end.
+origin/opkg4/r7: Section 1 end.
+origin/opkg4/r7: 
+origin/opkg4/r7: Section start:
+origin/opkg4/r8: A line from the origin.
+origin/opkg4/r7: Section end.
+origin/opkg4/r8: 
+origin/opkg4/r8: Yet another line from the origin.
+EOF
+
+list_like("no conflict (origin at r8)", "branch", "pkg4",
+  xpath => 'not(./linkinfo/@error)');
+# introduce yet another conflict
+commit("origin", "opkg4", {}, testfile => <<EOF);
+This is a
+simple text.
+
+Section 1 start:
+Nested section start:
+Nested section end.
+Section 1 end.
+
+Section start:
+Another line from the origin.
+Section end.
+EOF
+list_like("origin at r9", "origin", "opkg4",
+  xpath => '@rev = 9 and @srcmd5 = "417a4a60603b8f8fdb0bca16ecafa910"');
+list_like("check baserev and conflict in r4 (origin at r9)", "branch", "pkg4",
+  xpath => '@rev = 4 and ./linkinfo[@baserev = "2b4b0e8d610f44d9fb9d6b934cef4c39" and @error]');
+
+# resolve conflict in the branch
+commit("branch", "pkg4", {keeplink => 1, repairlink => 1, linkrev => "417a4a60603b8f8fdb0bca16ecafa910", newcontent => 1},
+  testfile => <<EOF);
+This is a
+simple text.
+
+Section 1 start:
+A line from the branch.
+Section 1 end.
+
+Section start:
+Resolved:
+A line from the branch.
+Another line from the branch.
+A line from the origin.
+Another line from the origin.
+Section end.
+
+Yet another line from the origin.
+EOF
+list_like("check baserev and no conflict in r5", "branch", "pkg4",
+  xpath => './linkinfo[@baserev = "417a4a60603b8f8fdb0bca16ecafa910" and not(@error)]');
+blame_is("branch at r5", "branch", "pkg4", "testfile", expected => <<EOF);
+origin/opkg4/r4: This is a
+origin/opkg4/r7: simple text.
+origin/opkg4/r7: 
+origin/opkg4/r7: Section 1 start:
+branch/pkg4/r5: A line from the branch.
+origin/opkg4/r7: Section 1 end.
+origin/opkg4/r7: 
+origin/opkg4/r7: Section start:
+branch/pkg4/r3: Resolved:
+branch/pkg4/r2: A line from the branch.
+branch/pkg4/r4: Another line from the branch.
+origin/opkg4/r4: A line from the origin.
+origin/opkg4/r9: Another line from the origin.
+origin/opkg4/r7: Section end.
+origin/opkg4/r8: 
+origin/opkg4/r8: Yet another line from the origin.
+EOF
+
+# check that we associate the last working automerge with
+# the correct rev
+
+# simplify the testfile
+commit("branch", "pkg4", {keeplink => 1}, testfile => <<EOF);
+A simple file.
+Section start:
+A line.
+Section end.
+EOF
+# commit the same file to the origin
+commit("origin", "opkg4", {}, testfile => <<EOF);
+A simple file.
+Section start:
+A line.
+Section end.
+EOF
+list_like("check origin's srcmd5 at r10", "origin", "opkg4",
+  xpath => '@rev = 10 and @srcmd5 = "ce715b27f97e1f246fc37676dc6a58c7"');
+blame_is("branch at r6", "branch", "pkg4", "testfile", expected => <<EOF);
+origin/opkg4/r10: A simple file.
+origin/opkg4/r7: Section start:
+origin/opkg4/r10: A line.
+origin/opkg4/r7: Section end.
+EOF
+
+# introduce a conflict
+commit("origin", "opkg4", {}, testfile => <<EOF);
+A simple file.
+A line.
+EOF
+list_like("conflict (origin at r11)", "branch", "pkg4",
+  xpath => './linkinfo/@error');
+# resolve conflict in origin again (same content as in r10)
+commit("origin", "opkg4", {}, testfile => <<EOF);
+A simple file.
+Section start:
+A line.
+Section end.
+EOF
+list_like("check origin's srcmd5 at r12", "origin", "opkg4",
+  xpath => '@rev = 12 and @srcmd5 = "ce715b27f97e1f246fc37676dc6a58c7"');
+# just do a "pseudo" commit to bump the rev (same content as in r12 and r10)
+commit("origin", "opkg4", {}, testfile => <<EOF);
+A simple file.
+Section start:
+A line.
+Section end.
+EOF
+list_like("check origin's srcmd5 at r13", "origin", "opkg4",
+  xpath => '@rev = 13 and @srcmd5 = "ce715b27f97e1f246fc37676dc6a58c7"');
+# same as in r13 (and r12 and r10), except the last line was added
+commit("origin", "opkg4", {}, testfile => <<EOF);
+A simple file.
+Section start:
+A line.
+Section end.
+Yet another line from the origin.
+EOF
+# introduce a conflict
+commit("origin", "opkg4", {}, testfile => <<EOF);
+A line from the origin.
+EOF
+list_like("origin at r15", "origin", "opkg4",
+  xpath => '@rev = 15 and @srcmd5 = "0c8c56d65146aea45eea2c3dd3cbf5a4"');
+list_like("check baserev and conflict in r7", "branch", "pkg4",
+  xpath => './linkinfo[@baserev = "417a4a60603b8f8fdb0bca16ecafa910" and @error]');
+
+# resolve conflict in the branch
+commit("branch", "pkg4", {keeplink => 1, repairlink => 1, linkrev => "0c8c56d65146aea45eea2c3dd3cbf5a4", newcontent => 1},
+  testfile => <<EOF);
+Resolved file:
+A line from the origin.
+A simple file.
+Section start:
+A line.
+Section end.
+Yet another line from the origin.
+EOF
+list_like("check baserev and no conflict at r7", "branch", "pkg4",
+  xpath => './linkinfo[@baserev = "0c8c56d65146aea45eea2c3dd3cbf5a4" and not(@error)]');
+blame_is("branch at r7 (resolved conflict)", "branch", "pkg4", "testfile", expected => <<EOF);
+branch/pkg4/r7: Resolved file:
+origin/opkg4/r15: A line from the origin.
+origin/opkg4/r10: A simple file.
+origin/opkg4/r7: Section start:
+origin/opkg4/r10: A line.
+origin/opkg4/r7: Section end.
+origin/opkg4/r14: Yet another line from the origin.
+EOF

--- a/src/backend/t/07-blame-branch-hierarchy.t
+++ b/src/backend/t/07-blame-branch-hierarchy.t
@@ -1,0 +1,518 @@
+#!/usr/bin/perl
+
+use strict;
+use warnings;
+use Test::More tests => 25;
+
+use BSBlameTest qw(blame_is list_like create commit branch);
+
+# This testcase tests different levels of branch hierarchies (a branch of
+# a branch etc.) and the latest automerge code in such scenarios.
+
+create("origin", "opkg5");
+commit("origin", "opkg5", {time => 1}, testfile => <<EOF);
+This will be a file with
+three sections.
+EOF
+commit("origin", "opkg5", {time => 3}, testfile => <<EOF);
+This is a file with
+three sections.
+Section 1 start:
+Section 1 end.
+Section 2 start:
+Section 2 end.
+Section 3 start:
+Section 3 end.
+EOF
+
+create("branch", "pkg51");
+branch("branch", "pkg51", "origin", "opkg5", time => 4);
+commit("branch", "pkg51", {keeplink => 1, time => 5}, testfile => <<EOF);
+This is a file with
+three sections.
+Section 1 start:
+Section 1 end.
+Section 2 start:
+A line from branch/pkg51.
+Section 2 end.
+Section 3 start:
+Section 3 end.
+EOF
+commit("origin", "opkg5", {time => 7}, testfile => <<EOF);
+This is a file with
+three sections.
+Section 1 start:
+A line from origin/opkg5.
+Section 1 end.
+Section 2 start:
+Section 2 end.
+Section 3 start:
+Section 3 end.
+EOF
+blame_is("pkg51 at r2", "branch", "pkg51", "testfile", expected => <<EOF);
+origin/opkg5/r2: This is a file with
+origin/opkg5/r1: three sections.
+origin/opkg5/r2: Section 1 start:
+origin/opkg5/r3: A line from origin/opkg5.
+origin/opkg5/r2: Section 1 end.
+origin/opkg5/r2: Section 2 start:
+branch/pkg51/r2: A line from branch/pkg51.
+origin/opkg5/r2: Section 2 end.
+origin/opkg5/r2: Section 3 start:
+origin/opkg5/r2: Section 3 end.
+EOF
+
+create("branch", "pkg52");
+branch("branch", "pkg52", "branch", "pkg51", time => 8);
+list_like("opkg52 at r1: check baserev", "branch", "pkg52",
+  xpath => './linkinfo[@baserev = "ac8101a21ae17c3e6ed9fce8aa525d2a"]');
+commit("branch", "pkg52", {keeplink => 1, time => 10}, testfile => <<EOF);
+This is a file with
+three sections.
+Section 1 start:
+A line from origin/opkg5.
+Section 1 end.
+Section 2 start:
+A line from branch/pkg51.
+Section 2 end.
+Section 3 start:
+A line from branch/pkg52.
+Section 3 end.
+EOF
+list_like("pkg52 at r2: check baserev", "branch", "pkg52",
+  xpath => './linkinfo[@baserev = "ac8101a21ae17c3e6ed9fce8aa525d2a"]');
+blame_is("pkg52 at r2", "branch", "pkg52", "testfile", expected => <<EOF);
+origin/opkg5/r2: This is a file with
+origin/opkg5/r1: three sections.
+origin/opkg5/r2: Section 1 start:
+origin/opkg5/r3: A line from origin/opkg5.
+origin/opkg5/r2: Section 1 end.
+origin/opkg5/r2: Section 2 start:
+branch/pkg51/r2: A line from branch/pkg51.
+origin/opkg5/r2: Section 2 end.
+origin/opkg5/r2: Section 3 start:
+branch/pkg52/r2: A line from branch/pkg52.
+origin/opkg5/r2: Section 3 end.
+EOF
+
+# change origin
+commit("origin", "opkg5", {time => 17}, testfile => <<EOF);
+This is a file with
+three sections.
+Section 1 start:
+A line from origin/opkg5.
+Yet another line from origin/opkg5.
+Section 1 end.
+Section 2 start:
+Section 2 end.
+Section 3 start:
+Section 3 end.
+EOF
+list_like("origin at r4", "origin", "opkg5",
+  xpath => '@rev = 4 and @srcmd5 = "0651c080ed80a45fbbb5bbc5aca5a292"');
+blame_is("pkg52 at r2 (origin changed)", "branch", "pkg52", "testfile", expected => <<EOF);
+origin/opkg5/r2: This is a file with
+origin/opkg5/r1: three sections.
+origin/opkg5/r2: Section 1 start:
+origin/opkg5/r3: A line from origin/opkg5.
+origin/opkg5/r4: Yet another line from origin/opkg5.
+origin/opkg5/r2: Section 1 end.
+origin/opkg5/r2: Section 2 start:
+branch/pkg51/r2: A line from branch/pkg51.
+origin/opkg5/r2: Section 2 end.
+origin/opkg5/r2: Section 3 start:
+branch/pkg52/r2: A line from branch/pkg52.
+origin/opkg5/r2: Section 3 end.
+EOF
+
+# change branch/pkg51
+commit("branch", "pkg51", {keeplink => 1, time => 18}, testfile => <<EOF);
+This is a file with
+three sections.
+Section 1 start:
+A line from origin/opkg5.
+Yet another line from origin/opkg5.
+Section 1 end.
+Section 2 start:
+A line from branch/pkg51.
+Yet another line from branch/pkg51.
+Section 2 end.
+Section 3 start:
+Section 3 end.
+EOF
+# and another change to branch/pkg51
+commit("branch", "pkg51", {keeplink => 1, time => 22}, testfile => <<EOF);
+This is a file with
+three sections.
+Section 1 start:
+A line from origin/opkg5.
+Yet another line from origin/opkg5.
+Section 1 end.
+Section 2 start:
+A line from branch/pkg51.
+Yet another line from branch/pkg51.
+A third line from branch/pkg51.
+Section 2 end.
+Section 3 start:
+Section 3 end.
+EOF
+list_like("pkg51: check baserev at r4", "branch", "pkg51",
+  xpath => '@rev = 4 and ./linkinfo[@baserev = "0651c080ed80a45fbbb5bbc5aca5a292"]');
+blame_is("pkg52 at r2 (pkg51 changed)", "branch", "pkg52", "testfile", expected => <<EOF);
+origin/opkg5/r2: This is a file with
+origin/opkg5/r1: three sections.
+origin/opkg5/r2: Section 1 start:
+origin/opkg5/r3: A line from origin/opkg5.
+origin/opkg5/r4: Yet another line from origin/opkg5.
+origin/opkg5/r2: Section 1 end.
+origin/opkg5/r2: Section 2 start:
+branch/pkg51/r2: A line from branch/pkg51.
+branch/pkg51/r3: Yet another line from branch/pkg51.
+branch/pkg51/r4: A third line from branch/pkg51.
+origin/opkg5/r2: Section 2 end.
+origin/opkg5/r2: Section 3 start:
+branch/pkg52/r2: A line from branch/pkg52.
+origin/opkg5/r2: Section 3 end.
+EOF
+
+# construct several conflicts to test the "latest automerge" code
+# no conflict
+commit("origin", "opkg5", {time => 29}, testfile => <<EOF);
+This is a file with
+three sections.
+Section 1 start:
+A line from origin/opkg5.
+Yet another line from origin/opkg5.
+Section 1 end.
+Section 2 start:
+Section 2 end.
+Section 3 start:
+Section 3 end.
+EOF
+list_like("pkg52 at r2: no conflict (origin changed)", "branch", "pkg52",
+  xpath => 'not(./linkinfo/@error)');
+# conflict
+commit("origin", "opkg5", {time => 30}, testfile => <<EOF);
+This is a file with
+three sections.
+Section 1 start:
+A line from origin/opkg5.
+A temporary line.
+Section 1 end.
+Section 2 start:
+Section 2 end.
+Section 3 start:
+Conflict from origin.
+Section 3 end.
+A line from the origin at EOF.
+EOF
+list_like("origin at r6", "origin", "opkg5", xpath => '@rev = 6');
+list_like("pkg52 at r2: conflict (origin changed)", "branch", "pkg52",
+  xpath => './linkinfo/@error');
+# no conflict
+commit("origin", "opkg5", {time => 33}, testfile => <<EOF);
+This is a file with
+three sections.
+Section 1 start:
+A line from origin/opkg5.
+Yet another line from origin/opkg5.
+Section 1 end.
+Section 2 start:
+Section 2 end.
+Section 3 start:
+Section 3 end.
+A line from the origin at EOF.
+A second line from the origin at EOF.
+EOF
+list_like("pkg52 at r2: no conflict (origin changed)", "branch", "pkg52",
+  xpath => 'not(./linkinfo/@error)');
+# and a conflict again (without the last two lines)
+commit("origin", "opkg5", {time => 34}, testfile => <<EOF);
+This is a file with
+three sections.
+Section 1 start:
+A line from origin/opkg5.
+Yet another line from origin/opkg5.
+Section 1 end.
+Section 2 start:
+Section 2 end.
+Section 3 start:
+Conflict from origin.
+Section 3 end.
+EOF
+# r8 ^^
+# add the two last lines again (still a conflict)
+commit("origin", "opkg5", {time => 35}, testfile => <<EOF);
+This is a file with
+three sections.
+Section 1 start:
+A line from origin/opkg5.
+Yet another line from origin/opkg5.
+Section 1 end.
+Section 2 start:
+Section 2 end.
+Section 3 start:
+Conflict from origin.
+Section 3 end.
+A line from the origin at EOF.
+A second line from the origin at EOF.
+EOF
+# remove the last two lines again (same as in r8)
+commit("origin", "opkg5", {time => 37}, testfile => <<EOF);
+This is a file with
+three sections.
+Section 1 start:
+A line from origin/opkg5.
+Yet another line from origin/opkg5.
+Section 1 end.
+Section 2 start:
+Section 2 end.
+Section 3 start:
+Conflict from origin.
+Section 3 end.
+EOF
+list_like("origin at r10", "origin", "opkg5", xpath => '@rev = 10');
+list_like("pkg52 at r2: conflict (origin changed)", "branch", "pkg52",
+  xpath => './linkinfo/@error');
+# but no conflict in pkg51
+list_like("pkg51 at r4: no conflict (origin changed)", "branch", "pkg51",
+  xpath => 'not(./linkinfo/@error)');
+# commit in pkg51
+commit("branch", "pkg51", {keeplink => 1, time => 39}, testfile => <<EOF);
+This is a file with
+three sections.
+Section 1 start:
+A line from origin/opkg5.
+Yet another line from origin/opkg5.
+Section 1 end.
+Section 2 start:
+A line from branch/pkg51.
+Yet another line from branch/pkg51.
+A third line from branch/pkg51.
+A fourth line from branch/pkg51.
+Section 2 end.
+Section 3 start:
+Conflict from origin.
+Section 3 end.
+EOF
+# yet another commit in pkg51
+commit("branch", "pkg51", {keeplink => 1, time => 41}, testfile => <<EOF);
+This is a file with
+three sections.
+Section 1 start:
+A line from origin/opkg5.
+Yet another line from origin/opkg5.
+Section 1 end.
+Section 2 start:
+A line from branch/pkg51.
+Yet another line from branch/pkg51.
+A third line from branch/pkg51.
+A fourth line from branch/pkg51.
+A fifth line from branch/pkg51.
+Section 2 end.
+Section 3 start:
+Conflict from branch/pkg51.
+Section 3 end.
+EOF
+list_like("pkg51 at r6: check baserev", "branch", "pkg51",
+  xpath => '@rev = 6 and ./linkinfo[@baserev = "ec10c813e05d7852616cedb7618455e7"]');
+# introduce a conflict for pkg51 (conflict in section 3)
+commit("origin", "opkg5", {time => 42}, testfile => <<EOF);
+This is a file with
+three sections.
+Section 1 start:
+A line from origin/opkg5.
+Yet another line from origin/opkg5.
+Section 1 end.
+Section 2 start:
+Section 2 end.
+Section 3 start:
+Conflict from origin.
+(Affects: pkg51 and pkg52).
+Section 3 end.
+EOF
+list_like("origin at r11", "origin", "opkg5", xpath => '@rev = 11');
+list_like("pkg51 at r6: conflict (origin changed)", "branch", "pkg51",
+  xpath => '@rev = 6 and ./linkinfo/@error');
+# resolve conflict in pkg51
+commit("branch", "pkg51", {keeplink => 1, repairlink => 1, linkrev => "cbdda8e56f0cbc572b41551e6044e0a7", time => 47, newcontent => 1},
+  testfile => <<EOF);
+This is a file with
+three sections.
+Section 1 start:
+A line from origin/opkg5.
+Yet another line from origin/opkg5.
+Section 1 end.
+Section 2 start:
+A line from branch/pkg51.
+Yet another line from branch/pkg51.
+A third line from branch/pkg51.
+A fourth line from branch/pkg51.
+A fifth line from branch/pkg51.
+Section 2 end.
+Section 3 start:
+Resolved pkg51:
+Conflict from branch/pkg51.
+Conflict from origin.
+(Affects: pkg51 and pkg52).
+Resolved pkg51 end.
+Section 3 end.
+EOF
+blame_is("pkg51 at r7 (resolved conflict)", "branch", "pkg51", "testfile", expected => <<EOF);
+origin/opkg5/r2: This is a file with
+origin/opkg5/r1: three sections.
+origin/opkg5/r2: Section 1 start:
+origin/opkg5/r3: A line from origin/opkg5.
+origin/opkg5/r7: Yet another line from origin/opkg5.
+origin/opkg5/r2: Section 1 end.
+origin/opkg5/r2: Section 2 start:
+branch/pkg51/r2: A line from branch/pkg51.
+branch/pkg51/r3: Yet another line from branch/pkg51.
+branch/pkg51/r4: A third line from branch/pkg51.
+branch/pkg51/r5: A fourth line from branch/pkg51.
+branch/pkg51/r6: A fifth line from branch/pkg51.
+origin/opkg5/r2: Section 2 end.
+origin/opkg5/r2: Section 3 start:
+branch/pkg51/r7: Resolved pkg51:
+branch/pkg51/r6: Conflict from branch/pkg51.
+origin/opkg5/r8: Conflict from origin.
+origin/opkg5/r11: (Affects: pkg51 and pkg52).
+branch/pkg51/r7: Resolved pkg51 end.
+origin/opkg5/r2: Section 3 end.
+EOF
+
+# still a conflict in pkg52
+list_like("pkg52 at r2: conflict (origin changed)", "branch", "pkg52",
+  xpath => './linkinfo/@error');
+# resolve conflict in pkg52
+commit("branch", "pkg52", {keeplink => 1, repairlink => 1, linkrev => "4992dda291552daaccd2d9ed31717634", time => 50, newcontent => 1},
+  testfile => <<EOF);
+This is a file with
+three sections.
+Section 1 start:
+A line from origin/opkg5.
+Yet another line from origin/opkg5.
+Section 1 end.
+Section 2 start:
+A line from branch/pkg51.
+Yet another line from branch/pkg51.
+A third line from branch/pkg51.
+A fourth line from branch/pkg51.
+A fifth line from branch/pkg51.
+Section 2 end.
+Section 3 start:
+Resolved pkg52:
+Resolved pkg51:
+Conflict from branch/pkg51.
+Conflict from origin.
+(Affects: pkg51 and pkg52).
+Resolved pkg51 end.
+A line from branch/pkg52.
+Resolved pkg52 end.
+Section 3 end.
+A line from the origin at EOF.
+A second line from the origin at EOF.
+EOF
+list_like("pkg52 at r3: check baserev and no conflict", "branch", "pkg52",
+  xpath => './linkinfo[@baserev = "4992dda291552daaccd2d9ed31717634" and not(@error)]');
+
+blame_is("pkg52 at r3 (resolved conflict)", "branch", "pkg52", "testfile",
+  expected => <<EOF);
+origin/opkg5/r2: This is a file with
+origin/opkg5/r1: three sections.
+origin/opkg5/r2: Section 1 start:
+origin/opkg5/r3: A line from origin/opkg5.
+origin/opkg5/r7: Yet another line from origin/opkg5.
+origin/opkg5/r2: Section 1 end.
+origin/opkg5/r2: Section 2 start:
+branch/pkg51/r2: A line from branch/pkg51.
+branch/pkg51/r3: Yet another line from branch/pkg51.
+branch/pkg51/r4: A third line from branch/pkg51.
+branch/pkg51/r5: A fourth line from branch/pkg51.
+branch/pkg51/r6: A fifth line from branch/pkg51.
+origin/opkg5/r2: Section 2 end.
+origin/opkg5/r2: Section 3 start:
+branch/pkg52/r3: Resolved pkg52:
+branch/pkg51/r7: Resolved pkg51:
+branch/pkg51/r6: Conflict from branch/pkg51.
+origin/opkg5/r8: Conflict from origin.
+origin/opkg5/r11: (Affects: pkg51 and pkg52).
+branch/pkg51/r7: Resolved pkg51 end.
+branch/pkg52/r2: A line from branch/pkg52.
+branch/pkg52/r3: Resolved pkg52 end.
+origin/opkg5/r2: Section 3 end.
+origin/opkg5/r6: A line from the origin at EOF.
+origin/opkg5/r7: A second line from the origin at EOF.
+EOF
+
+# introduce two more hierarchy levels
+create("branch", "pkg53");
+create("branch", "pkg54");
+branch("branch", "pkg53", "branch", "pkg52", time => 51);
+branch("branch", "pkg54", "branch", "pkg53", time => 57);
+# simplify testfile in pkg54 a bit
+commit("branch", "pkg54", {keeplink => 1, time => 61}, testfile => <<EOF);
+Section 1 start:
+A line from origin/opkg5.
+Yet another line from origin/opkg5.
+Section 1 end.
+Section 2 start:
+A line from branch/pkg51.
+Yet another line from branch/pkg51.
+A third line from branch/pkg51.
+A fourth line from branch/pkg51.
+A fifth line from branch/pkg51.
+Section 2 end.
+A line from the origin at EOF.
+A second line from the origin at EOF.
+EOF
+# change origin
+commit("origin", "opkg5", {time => 82}, testfile => <<EOF);
+This is a file with
+three sections.
+Section 1 start:
+A line from origin/opkg5.
+Yet another line from origin/opkg5.
+Section 1 end.
+Section 2 start:
+Section 2 end.
+Section 3 start:
+Conflict from origin.
+(Affects: pkg51 and pkg52).
+Section 3 end.
+A line from the origin at EOF.
+A second line from the origin at EOF.
+EOF
+list_like("origin at r12", "origin", "opkg5", xpath => '@rev = 12');
+# change pkg51
+commit("branch", "pkg51", {keeplink => 1, time => 99}, testfile => <<EOF);
+This is a file with
+three sections.
+Section 1 start:
+A line from origin/opkg5.
+Yet another line from origin/opkg5.
+Section 1 end.
+Section 2 start:
+Only this line is left.
+Section 2 end.
+Section 3 start:
+Resolved pkg51:
+Conflict from branch/pkg51.
+Conflict from origin.
+(Affects: pkg51 and pkg52).
+Resolved pkg51 end.
+Section 3 end.
+EOF
+list_like("pkg51 at r8", "branch", "pkg51", xpath => '@rev = 8');
+
+blame_is("pkg54 at r2", "branch", "pkg54", "testfile", expected => <<EOF);
+origin/opkg5/r2: Section 1 start:
+origin/opkg5/r3: A line from origin/opkg5.
+origin/opkg5/r7: Yet another line from origin/opkg5.
+origin/opkg5/r2: Section 1 end.
+origin/opkg5/r2: Section 2 start:
+branch/pkg51/r8: Only this line is left.
+origin/opkg5/r2: Section 2 end.
+origin/opkg5/r6: A line from the origin at EOF.
+origin/opkg5/r7: A second line from the origin at EOF.
+EOF

--- a/src/backend/t/08-blame-branch-conflict_automerge_baserev.t
+++ b/src/backend/t/08-blame-branch-conflict_automerge_baserev.t
@@ -1,0 +1,346 @@
+#!/usr/bin/perl
+
+use strict;
+use warnings;
+
+use Test::More tests => 16;
+
+use BSBlameTest qw(blame_is list_like create commit branch);
+
+# The goal of this testcase is to construct a scenario where the latest
+# automerge code is only able to return the baserev. Also, we sneak in an
+# expandable rev that violates the latest automerge semantics (hence, it is
+# not supposed to be found by the latest automerge code).
+
+create("branch", "pkg61");
+commit("branch", "pkg61", {time => 1}, testfile => <<EOF);
+Section 1 start:
+First line.
+Section 1 end.
+Section 2 start:
+Section 2 end.
+Section 3 start:
+Section 3 end.
+Section 4 start:
+Section 4 end.
+EOF
+create("branch", "pkg62");
+branch("branch", "pkg62", "branch", "pkg61", time => 3);
+commit("branch", "pkg61", {time => 4}, testfile => <<EOF);
+Section 1 start:
+First line changed.
+Section 1 end.
+Section 2 start:
+Section 2 end.
+Section 3 start:
+Section 3 end.
+Section 4 start:
+Section 4 end.
+EOF
+commit("branch", "pkg62", {keeplink => 1, time => 8}, testfile => <<EOF);
+Section 1 start:
+First line changed.
+Section 1 end.
+Section 2 start:
+Second line.
+Section 2 end.
+Section 3 start:
+Section 3 end.
+Section 4 start:
+Section 4 end.
+EOF
+create("branch", "pkg63");
+branch("branch", "pkg63", "branch", "pkg62", time => 9);
+commit("branch", "pkg62", {keeplink => 1, time => 10}, testfile => <<EOF);
+Section 1 start:
+First line changed.
+Section 1 end.
+Section 2 start:
+Second line changed again.
+Section 2 end.
+Section 3 start:
+Section 3 end.
+Section 4 start:
+Section 4 end.
+EOF
+commit("branch", "pkg63", {keeplink => 1, time => 12}, testfile => <<EOF);
+Section 1 start:
+First line changed.
+Section 1 end.
+Section 2 start:
+Second line changed again.
+Section 2 end.
+Section 3 start:
+Third line.
+Section 3 end.
+Section 4 start:
+Section 4 end.
+EOF
+create("branch", "pkg64");
+branch("branch", "pkg64", "branch", "pkg63", time => 15);
+commit("branch", "pkg64", {keeplink => 1, time => 17}, testfile => <<EOF);
+Section 1 start:
+First line changed.
+Section 1 end.
+Section 2 start:
+Second line changed again.
+Section 2 end.
+Section 3 start:
+Third line.
+Section 3 end.
+Section 4 start:
+Fourth line.
+Section 4 end.
+EOF
+# later, we construct a conflict such that the automerge code is only able
+# to return pkg64's baserev
+blame_is("blame: pkg64 at r2 (against baserev)", "branch", "pkg64", "testfile", expected => <<EOF);
+branch/pkg61/r1: Section 1 start:
+branch/pkg61/r2: First line changed.
+branch/pkg61/r1: Section 1 end.
+branch/pkg61/r1: Section 2 start:
+branch/pkg62/r3: Second line changed again.
+branch/pkg61/r1: Section 2 end.
+branch/pkg61/r1: Section 3 start:
+branch/pkg63/r2: Third line.
+branch/pkg61/r1: Section 3 end.
+branch/pkg61/r1: Section 4 start:
+branch/pkg64/r2: Fourth line.
+branch/pkg61/r1: Section 4 end.
+EOF
+
+commit("branch", "pkg61", {time => 20}, testfile => <<EOF);
+Section 1 start:
+First line changed again.
+This line occurs in the resolved file.
+Section 1 end.
+Section 2 start:
+Section 2 end.
+Section 3 start:
+Section 3 end.
+Section 4 start:
+Conflict.
+Section 4 end.
+EOF
+list_like("pkg61 at r3: check rev", "branch", "pkg61",
+  xpath => '@rev = 3');
+commit("branch", "pkg62", {keeplink => 1, time => 24}, testfile => <<EOF);
+Section 1 start:
+First line changed again.
+This line occurs in the resolved file.
+Section 1 end.
+Section 2 start:
+Yet another change in the second line.
+Section 2 end.
+Section 3 start:
+Section 3 end.
+Section 4 start:
+Conflict.
+Section 4 end.
+EOF
+commit("branch", "pkg62", {keeplink => 1, time => 27}, testfile => <<EOF);
+Section 1 start:
+First line changed again.
+This line occurs in the resolved file.
+Section 1 end.
+Section 2 start:
+Last change in the second line.
+Section 2 end.
+Section 3 start:
+Section 3 end.
+Section 4 start:
+Conflict.
+Section 4 end.
+EOF
+
+# pkg61 at r4: introduce a change that conflicts with pkg62/r2,
+#              pkg62/r4, pkg62/r5, but not with pkg62/r3
+commit("branch", "pkg61", {time => 30}, testfile => <<EOF);
+Section 1 start:
+First line changed again.
+This line occurs in the resolved file.
+Section 1 end.
+Section 2 start:
+Second line changed again.
+Section 2 end.
+Section 3 start:
+Section 3 end.
+Section 4 start:
+Section 4 end.
+EOF
+list_like("pkg62 at r3: no conflict", "branch", "pkg62", rev => '3',
+  xpath => '@rev = 3 and not(./linkinfo/@error)');
+list_like("pkg62 at r4: conflict", "branch", "pkg62", rev => '4',
+  xpath => '@rev = 4 and ./linkinfo/@error');
+list_like("pkg62 at r5: conflict", "branch", "pkg62",
+  xpath => '@rev = 5 and ./linkinfo/@error');
+# remove conflict for pkg62, but introduce conflict line for pkg64 again
+commit("branch", "pkg61", {time => 30}, testfile => <<EOF);
+Section 1 start:
+First line changed again.
+This line occurs in the resolved file.
+Section 1 end.
+Section 2 start:
+Section 2 end.
+Section 3 start:
+Section 3 end.
+Section 4 start:
+Conflict.
+Section 4 end.
+EOF
+
+list_like("pkg62 at r5: no conflict", "branch", "pkg62",
+  xpath => '@rev = 5 and not(./linkinfo/@error)');
+
+commit("branch", "pkg63", {keeplink => 1, time => 35}, testfile => <<EOF);
+Section 1 start:
+First line changed again.
+This line occurs in the resolved file.
+Section 1 end.
+Section 2 start:
+Last change in the second line.
+Section 2 end.
+Section 3 start:
+Third line changed.
+Section 3 end.
+Section 4 start:
+Conflict.
+Section 4 end.
+EOF
+list_like("pkg63 at r3: no conflict", "branch", "pkg63",
+  xpath => '@rev = 3 and not(./linkinfo/@error)');
+blame_is("blame: pkg63 at r3", "branch", "pkg63", "testfile", expected => <<EOF);
+branch/pkg61/r1: Section 1 start:
+branch/pkg61/r3: First line changed again.
+branch/pkg61/r3: This line occurs in the resolved file.
+branch/pkg61/r1: Section 1 end.
+branch/pkg61/r1: Section 2 start:
+branch/pkg62/r5: Last change in the second line.
+branch/pkg61/r1: Section 2 end.
+branch/pkg61/r1: Section 3 start:
+branch/pkg63/r3: Third line changed.
+branch/pkg61/r1: Section 3 end.
+branch/pkg61/r1: Section 4 start:
+branch/pkg61/r3: Conflict.
+branch/pkg61/r1: Section 4 end.
+EOF
+
+list_like("pkg64 at r2: conflict", "branch", "pkg64",
+  xpath => '@rev = 2 and ./linkinfo/@error');
+# note that the line "This line occurs in the resolved file." is removed
+commit("branch", "pkg61", {time => 37}, testfile => <<EOF);
+Section 1 start:
+Yet another change in the first line.
+Section 1 end.
+Section 2 start:
+Section 2 end.
+Section 3 start:
+Section 3 end.
+Section 4 start:
+Conflict.
+Section 4 end.
+EOF
+commit("branch", "pkg63", {keeplink => 1, time => 39}, testfile => <<EOF);
+Section 1 start:
+Yet another change in the first line.
+Section 1 end.
+Section 2 start:
+Last change in the second line.
+Section 2 end.
+Section 3 start:
+Last change in the third line.
+Section 3 end.
+Section 4 start:
+Conflict.
+Section 4 end.
+EOF
+commit("branch", "pkg61", {time => 42}, testfile => <<EOF);
+Section 1 start:
+Last change in the first line.
+Section 1 end.
+Section 2 start:
+Section 2 end.
+Section 3 start:
+Section 3 end.
+Section 4 start:
+Conflict.
+Section 4 end.
+EOF
+list_like("pkg63 at r4: no conflict", "branch", "pkg63",
+  xpath => '@rev = 4 and not(./linkinfo/@error)');
+blame_is("blame: pkg63 at r4", "branch", "pkg63", "testfile", expected => <<EOF);
+branch/pkg61/r1: Section 1 start:
+branch/pkg61/r7: Last change in the first line.
+branch/pkg61/r1: Section 1 end.
+branch/pkg61/r1: Section 2 start:
+branch/pkg62/r5: Last change in the second line.
+branch/pkg61/r1: Section 2 end.
+branch/pkg61/r1: Section 3 start:
+branch/pkg63/r4: Last change in the third line.
+branch/pkg61/r1: Section 3 end.
+branch/pkg61/r1: Section 4 start:
+branch/pkg61/r3: Conflict.
+branch/pkg61/r1: Section 4 end.
+EOF
+#list_like("pkg63 at r4: check xsrcmd5", "branch", "pkg63",
+#  xpath => './linkinfo[@xsrcmd5 = "ebe6004cc0ec9690ea35e25823ab3846"]');
+list_like("pkg63 at r4: check xsrcmd5", "branch", "pkg63",
+  xpath => './linkinfo[@xsrcmd5 = "1551eb8db01539dd0dfd87760f5e1714"]');
+list_like("pkg64 at r2: conflict", "branch", "pkg64",
+  xpath => '@rev = 2 and ./linkinfo/@error');
+# now resolve the conflict
+#commit("branch", "pkg64", {keeplink => 1, repairlink => 1, linkrev => "ebe6004cc0ec9690ea35e25823ab3846", time => 47, newcontent => 1},
+commit("branch", "pkg64", {keeplink => 1, repairlink => 1, linkrev => "1551eb8db01539dd0dfd87760f5e1714", time => 47, newcontent => 1},
+  testfile => <<EOF);
+Section 1 start:
+Last change in the first line.
+This line occurs in the resolved file.
+Section 1 end.
+Section 2 start:
+Last change in the second line.
+Second line changed again.
+Section 2 end.
+Section 3 start:
+Last change in the third line.
+Third line.
+Section 3 end.
+Section 4 start:
+Conflict.
+Fourth line.
+Section 4 end.
+And an additional last line.
+EOF
+list_like("pkg64 at r3 and no conflict", "branch", "pkg64",
+  xpath => '@rev = 3 and not(./linkinfo/@error)');
+# pkg64/496280d71af069b9d08f862dc56f13ca represents an expanded rev and
+# the "testfile" file, which is part of this rev, contains the line
+# "This line occurs in the resolved file.". The latest automerge code is
+# not supposed to find this rev (if it would, the following blame_is will
+# fail, because the line "This line occurs in the resolved file." would
+# originate from pkg61/r3).
+# This rev "comprises": pkg64/r2, pkg63/r2, pkg62/r3, pkg61/r4
+# (pkg61/r4 "violates" the automerge semantics)
+list_like("pkg64: illegal rev has no conflict", "branch", "pkg64",
+  rev => '496280d71af069b9d08f862dc56f13ca',
+  xpath => 'not(./linkinfo/@error)');
+# here, the latest automerge code is supposed to find the baserev
+blame_is("blame: pkg64 at r3 after conflict resolution", "branch", "pkg64",
+  "testfile", expected => <<EOF);
+branch/pkg61/r1: Section 1 start:
+branch/pkg61/r7: Last change in the first line.
+branch/pkg64/r3: This line occurs in the resolved file.
+branch/pkg61/r1: Section 1 end.
+branch/pkg61/r1: Section 2 start:
+branch/pkg62/r5: Last change in the second line.
+branch/pkg62/r3: Second line changed again.
+branch/pkg61/r1: Section 2 end.
+branch/pkg61/r1: Section 3 start:
+branch/pkg63/r4: Last change in the third line.
+branch/pkg63/r2: Third line.
+branch/pkg61/r1: Section 3 end.
+branch/pkg61/r1: Section 4 start:
+branch/pkg61/r3: Conflict.
+branch/pkg64/r2: Fourth line.
+branch/pkg61/r1: Section 4 end.
+branch/pkg64/r3: And an additional last line.
+EOF

--- a/src/backend/t/09-blame-branch-fully_resolved_lrev.t
+++ b/src/backend/t/09-blame-branch-fully_resolved_lrev.t
@@ -1,0 +1,48 @@
+#!/usr/bin/perl
+
+use strict;
+use warnings;
+
+use Test::More tests => 1;
+
+use BSBlameTest qw(blame_is create commit branch);
+
+# This testcase just documents that it is possible to encounter a "fully"
+# resolved localrev during the initial resolving
+# (BSBlame::RangeFirstStrategy::resolve) - a fully resolved localrev means
+# that the localrev is resolved, and its targetrev is resolved (+ the
+# targetrev's localrev), and its targetrev's targetrev is resolved...
+#
+# In this testcase, we eventually try to resolve the expanded rev
+# pkg73/096db417ca7c61531058c33e436c4771 (its lsrcmd5 corresponds to
+# pkg73/r1). At this point, pkg73/r1 is fully resolved and satisfies
+# all constraints. Hence, it is checked whether pkg73/r1's targetrev,
+# which is an expanded rev, also satisfies all constraints. Since the
+# constraints also include time constraints, an expanded rev should be
+# able to support the "time()" method.
+
+create("branch", "pkg71");
+commit("branch", "pkg71", {time => 1}, testfile => <<EOF);
+foo
+EOF
+
+create("branch", "pkg72");
+branch("branch", "pkg72", "branch", "pkg71", time => 1);
+create("branch", "pkg73");
+branch("branch", "pkg73", "branch", "pkg72", time => 1);
+
+create("branch", "pkg70");
+branch("branch", "pkg70", "branch", "pkg73", time => 1);
+
+branch("branch", "pkg71", "branch", "pkg70", time => 1);
+branch("branch", "pkg72", "branch", "pkg71", time => 1, olinkrev => 'base');
+branch("branch", "pkg73", "branch", "pkg72", time => 1, olinkrev => 'base');
+
+# needed in order to expand pkg73
+commit("branch", "pkg72", {time=> 2, newcontent => 1}, testfile => <<EOF);
+foo
+EOF
+
+blame_is("blame: pkg73 at r2", "branch", "pkg73", "testfile", expected => <<EOF);
+branch/pkg71/r1: foo
+EOF

--- a/src/backend/t/10-blame-branch-partially_resolved_lrev.t
+++ b/src/backend/t/10-blame-branch-partially_resolved_lrev.t
@@ -1,0 +1,51 @@
+#!/usr/bin/perl
+
+use strict;
+use warnings;
+
+use Test::More tests => 1;
+
+use BSBlameTest qw(blame_is create commit branch);
+
+# This testcase just documents that it is possible to encounter a "partially"
+# resolved localrev during the initial resolving
+# (BSBlame::RangeFirstStrategy::resolve) - a partially resolved resolved
+# localrev means that the localrev itself is resolved, but a direct or indirect
+# targetrev is not resolved
+#
+# In this testcase, we eventually try to resolve the expanded rev
+# pkg85/e78beea74b88e7b6f38df59cc7ebc4a4 (its lsrcmd5 corresponds to
+# pkg85/r1). pkg85/r1 is resolved, its targetrev is resolved, and its
+# targetrev's targetrev is resolved. However, the targetrev's targetrev's
+# targetrev (pkg72/f07cfaa85605d996f2f9957b0130a928) is not resolved.
+# Hence, we need to take this situation into account when implementing the
+# constraint handling ("satisfies" method) for an expanded rev (e.g., how
+# to handle a time constraint in this case (cf. test
+# 09-blame-branch-fully_resolved_lrev.t)).
+
+create("branch", "pkg81");
+commit("branch", "pkg81", {time => 1}, testfile => <<EOF);
+foo
+EOF
+
+create("branch", "pkg82");
+branch("branch", "pkg82", "branch", "pkg81", time => 1);
+create("branch", "pkg83");
+branch("branch", "pkg83", "branch", "pkg82", time => 1);
+create("branch", "pkg84");
+branch("branch", "pkg84", "branch", "pkg83", time => 1);
+create("branch", "pkg85");
+branch("branch", "pkg85", "branch", "pkg84", time => 1);
+
+branch("branch", "pkg83", "branch", "pkg85", time => 1);
+branch("branch", "pkg84", "branch", "pkg83", time => 1, olinkrev => 'base');
+branch("branch", "pkg85", "branch", "pkg84", time => 1, olinkrev => 'base');
+
+# needed in order to expand pkg85
+commit("branch", "pkg84", {time => 2, newcontent => 1}, testfile => <<EOF);
+foo
+EOF
+
+blame_is("blame: pkg85 at r2", "branch", "pkg85", "testfile", expected => <<EOF);
+branch/pkg81/r1: foo
+EOF

--- a/src/backend/t/11-blame-branch-non_global_constraint.t
+++ b/src/backend/t/11-blame-branch-non_global_constraint.t
@@ -1,0 +1,65 @@
+#!/usr/bin/perl
+
+use strict;
+use warnings;
+
+use Test::More tests => 1;
+
+use BSBlameTest qw(blame_is create commit branch);
+
+# This testcase documents the need for non-global constraints. In particular,
+# it shows that we need a non-global constraint when resolving an expanded
+# rev (see BSBlame::RangeFirstStrategy::resolve_expanded) and when resolving
+# a branch rev (see BSBlame::RangeFirstStrategy::resolve_branch).
+
+# When resolving the expanded rev pkg92/27b4125b2c30e7dcff96382d81c33345,
+# the corresponding localrev (pkg92/r2), which we are trying to find, is
+# already fully resolved _and_ the localrev's targetrev's targetrev is pkg92/r1
+# (see t/09-blame-resolved_expandedrev.t for an explanation of
+# "fully resolved). Hence, it is crucial that the lsrcmd5 constraint,
+# which is generated in BSBlame::RevisionManager::find, is non-global,
+# because otherwise we would check whether pkg92/r1 satisfies the lsrcmd5
+# constraint as well (which it does not) => we are unable to find the
+# localrev.
+# When resolving the branch rev pkg93/r1, the targetrev's localrev is
+# pkg92/r2 (which are trying to find) is already fully resolved (see above).
+# By the same line of argument, the lsrcmd5 constraint, which is generated
+# in BSBlame::RangeFirstStrategy::resolve_branch, has to be non-global.
+
+create("branch", "pkg91");
+create("branch", "pkg92");
+commit("branch", "pkg92", {time => 1}, testfile => <<EOF);
+foobar
+EOF
+
+branch("branch", "pkg91", "branch", "pkg92", time => 2);
+branch("branch", "pkg92", "branch", "pkg91", time => 3);
+
+# intermediate packages (we need some intermediate packages so that
+# pkg93/r1's targetrev's localrev is fully resolved (when we try to
+# resolve pkg93/r1's targetrev (BSBlame::RangeFirstStrategy::resolve_branch
+# codepath))
+create("branch", "pkg93");
+branch("branch", "pkg93", "branch", "pkg92", time => 4, olinkrev => 'base');
+create("branch", "pkg931");
+branch("branch", "pkg931", "branch", "pkg93", time => 4, olinkrev => 'base');
+create("branch", "pkg932");
+branch("branch", "pkg932", "branch", "pkg931", time => 4, olinkrev => 'base');
+# end intermediate packages
+
+create("branch", "pkg94");
+branch("branch", "pkg94", "branch", "pkg932", time => 5, olinkrev => 'base');
+
+create("branch", "pkg95");
+branch("branch", "pkg95", "branch", "pkg94", time => 6, olinkrev => 'base');
+
+branch("branch", "pkg94", "branch", "pkg92", time => 6, olinkrev => 'base');
+branch("branch", "pkg95", "branch", "pkg94", time => 6, olinkrev => 'base');
+
+commit("branch", "pkg92", {time => 9, newcontent => 1}, testfile => <<EOF);
+foobar
+EOF
+
+blame_is("blame: pkg95 at r2", "branch", "pkg95", "testfile", expected => <<EOF);
+branch/pkg92/r1: foobar
+EOF

--- a/src/backend/t/fixtures/common
+++ b/src/backend/t/fixtures/common
@@ -1,0 +1,10 @@
+This is
+a simple
+test file.
+With some
+sentences and
+words.
+
+xxx
+yyy
+zzz

--- a/src/backend/t/fixtures/common2
+++ b/src/backend/t/fixtures/common2
@@ -1,0 +1,5 @@
+This is
+a
+very
+simple
+file.

--- a/src/backend/t/fixtures/common3
+++ b/src/backend/t/fixtures/common3
@@ -1,0 +1,11 @@
+This is
+a simple
+test file.
+With some
+sentences and
+words.
+
+xxx
+yyy
+zzz
+EOF

--- a/src/backend/t/fixtures/my
+++ b/src/backend/t/fixtures/my
@@ -1,0 +1,12 @@
+This is
+my
+simple
+test file.
+With some
+sentences and
+words.
+
+foo
+bar
+
+zzz

--- a/src/backend/t/fixtures/my2.change
+++ b/src/backend/t/fixtures/my2.change
@@ -1,0 +1,6 @@
+This is
+a
+stupid
+but still
+quite simple
+file.

--- a/src/backend/t/fixtures/my2.madd
+++ b/src/backend/t/fixtures/my2.madd
@@ -1,0 +1,8 @@
+This is
+a
+very
+stupid
+but
+very
+simple
+file.

--- a/src/backend/t/fixtures/my2.mdel
+++ b/src/backend/t/fixtures/my2.mdel
@@ -1,0 +1,3 @@
+This is
+a
+file.

--- a/src/backend/t/fixtures/my2.sadd
+++ b/src/backend/t/fixtures/my2.sadd
@@ -1,0 +1,6 @@
+This is
+a
+very
+very
+simple
+file.

--- a/src/backend/t/fixtures/my2.sdel
+++ b/src/backend/t/fixtures/my2.sdel
@@ -1,0 +1,4 @@
+This is
+a
+simple
+file.

--- a/src/backend/t/fixtures/my3
+++ b/src/backend/t/fixtures/my3
@@ -1,0 +1,13 @@
+File start: This is
+a simple
+file.
+With some
+
+xxx
+my my my
+my my my
+yyy
+zzz
+
+lines.
+EOF

--- a/src/backend/t/fixtures/your
+++ b/src/backend/t/fixtures/your
@@ -1,0 +1,13 @@
+This is
+a simple
+test file.
+With some
+sentences and a lot
+more words.
+
+xxx
+yyy
+zzz
+
+And a bit more
+text.

--- a/src/backend/t/fixtures/your.noeol
+++ b/src/backend/t/fixtures/your.noeol
@@ -1,0 +1,13 @@
+This is
+a simple
+test file.
+With some
+sentences and a lot
+more words.
+
+xxx
+yyy
+zzz
+
+And a bit more
+text and no EOL.

--- a/src/backend/t/fixtures/your3
+++ b/src/backend/t/fixtures/your3
@@ -1,0 +1,11 @@
+This is
+a simple
+file.
+With some
+
+xxx
+yyy
+your your your
+your your your
+zzz
+EOF

--- a/src/backend/timeline.pl
+++ b/src/backend/timeline.pl
@@ -1,0 +1,262 @@
+#!/usr/bin/perl
+
+use strict;
+use warnings;
+use Data::Dumper;
+
+# This is far from being complete. We only
+# support the OPs that are needed for our (quite limited)
+# use case.
+sub parse_subcalls {
+  my ($filename) = @_;
+  open(F, "-|", 'perl', '-MO=Concise,-terse', $filename) || die("tree: $@\n");
+  my $level = 0;
+  my $ctx;
+  my @subs;
+  my @contexts;
+  while (<F>) {
+    s/\s*$//;
+    my $lcnt = 0;
+    $lcnt++ while s/^(?:    )//;
+    next unless $lcnt;
+    if ($level > $lcnt) {
+      while ($level > $lcnt) {
+        $level--;
+        next unless @contexts;
+        pop @contexts;
+        $ctx = $contexts[-1];
+        $ctx = $ctx->{''} if ref($ctx) eq 'HASH';
+      }
+    } elsif ($level == $lcnt - 1) {
+      $level++;
+    } elsif ($level != $lcnt) {
+      die("level mismatch (current: $level, got: $lcnt)\n");
+    }
+    die("illegal format: $_\n") unless s/^([^ ]+) \([^ ]+\) ([^ ]+)\s*//;
+    my ($op, $kind) = ($1, $2);
+    if ($op eq 'SVOP' && $kind eq 'const') {
+      next unless @contexts;
+      #print "svop\n";
+      /^\[[^ ]+\] ([^ ]+) \([^ ]+\) (.*)$/;
+      my ($type, $data) = ($1, $2);
+      if ($type eq 'IV') {
+        $data = 0 + $data;
+      } elsif ($type eq 'PV') {
+        $data =~ s/^"(.*)"$/$1/;
+      }
+      die("no data found: $_\n") unless defined($data);
+      push @$ctx, $data;
+    } elsif ($op eq 'BINOP') {
+      next unless @contexts;
+      # we don't handle a binary op
+      print "unhandled binary operator: $kind\n";
+      # just push a dummy context
+      # note: the binop won't appear in the original context!
+      push @contexts, [];
+      $ctx = $contexts[-1];
+    } elsif ($op eq 'LISTOP' && $kind =~ '^anon(?:list|hash)$' || $op eq 'UNOP' && $kind eq 'entersub') {
+      next if $kind ne 'entersub' && !@contexts;
+      #print "$kind\n";
+      my $tmp = [];
+      if ($kind eq 'anonhash' || $kind eq 'entersub') {
+        push @$ctx, {'' => $tmp};
+      } else {
+        push @$ctx, $tmp;
+      }
+      $ctx = $ctx->[-1];
+      push @contexts, $ctx;
+      $ctx = $tmp;
+    } elsif ($op eq 'OP' && $kind eq 'undef') {
+      next unless @contexts;
+      #print "undef\n";
+      push @$ctx, undef;
+    } elsif ($op eq 'UNOP' && $kind eq 'scalar') {
+      next unless @contexts;
+      # (probably) a heredoc 
+      # just push a dummy context
+      #print "unop\n";
+      push @contexts, '';
+    } elsif ($op eq 'PADOP') {
+      next unless @contexts;
+      #print "padop\n";
+      /GV \([^ ]+\) \*(.*)$/;
+      die("unexpected PADOP: $_\n") unless $1;
+      $level -= 3;
+      my $func = pop @contexts;
+      die("illegal state (contexts is empty): $_\n") unless $func;
+      $func->{$1} = delete $func->{''};
+      push @subs, $func unless @contexts;
+      $ctx = $contexts[-1];
+      $ctx = $ctx->{''} if ref($ctx) eq 'HASH';
+    }
+  }
+  close(F) || die("close: $@\n");
+  die("pending contexts: " . @contexts . "\n") if @contexts;
+  return @subs;
+}
+
+# It just replaces an anon hash like {'' => ['a', 1, 'b', 2]}
+# with the anon hash {'a' => 1, 'b' => 2}
+sub harmonize_args {
+  my ($todo) = @_;
+  for my $data (@$todo) {
+    if (ref($data) eq 'HASH' && !exists($data->{''})) {
+      harmonize_args($data->{$_}) for keys %$data;
+      next;
+    }
+    if (ref($data) eq 'HASH') {
+        harmonize_args($data->{''});
+        $data = {@{$data->{''}}};
+    } elsif (ref($data) eq 'ARRAY') {
+        harmonize_args($data);
+    }
+  }
+}
+
+sub handle_create {
+  my ($ctx, $projid, $packid) = @_;
+  my $s = '';
+  $s .= ' ' x $ctx->{'hwm'} . "$projid/$packid";
+  $ctx->{'hwm'} = length($s);
+  $ctx->{'pdata'}->{"$projid/$packid"} = \$s;
+  push @{$ctx->{'rows'}}, \$s;
+  my $s2 = '';
+  push @{$ctx->{'rows'}}, \$s2;
+}
+
+sub handle_commit {
+  my ($ctx, $projid, $packid, $opts, %files) = @_;
+  my $r = $ctx->{'pdata'}->{"$projid/$packid"};
+  die("package $projid/$packid was never created\n") unless $r;
+  # if the right op of the repetition op ('x') is <= 0,
+  # it evaluates to the empty str ('')
+  $$r .= ' ' . '-' x ($ctx->{'hwm'} - length($$r) - 2) . "--> C";
+  if ($ctx->{'opts'}->{'with-files'}) {
+    $$r .= '(';
+    $$r .= join(', ', map { defined($files{$_}) ? $_ : $_ . ' (D)' } sort keys %files);
+    $$r .= ')';
+  }
+  $ctx->{'hwm'} = length($$r);
+  if ($ctx->{'opts'}->{'verbose'}) {
+    for (sort keys %files) {
+      next unless defined($files{$_});
+      # hrm better do this when parsing there heredoc?
+      # (this might produce wrong results for a non-heredoc str)
+      my %tr = ('n' => "\n", 't' => "\t");
+      $files{$_} =~ s/\\([nt])/$tr{$1}/g;
+      my $s = "$projid/$packid/$_ <<EOF\n" . $files{$_} . 'EOF';
+      push @{$ctx->{'vrows'}}, $s;
+    }
+  }
+}
+
+sub handle_branch {
+  my ($ctx, $projid, $packid, $oprojid, $opackid, %query) = @_;
+  die("cannot handle orev parameter\n") if $query{'orev'} && !$ctx->{'opts'}->{'ignore-orev'};
+  my $or = $ctx->{'pdata'}->{"$oprojid/$opackid"};
+  my $r = $ctx->{'pdata'}->{"$projid/$packid"};
+  die("package $oprojid/$opackid was never created\n") unless $or;
+  die("package $projid/$packid was never created\n") unless $r;
+  my $rows = @{$ctx->{'rows'}} - 1;
+  my %r2idx = map { $ctx->{'rows'}->[$_] => $_ } 0 .. $rows;
+  my %r2p = map { $ctx->{'pdata'}->{$_} => 1 } keys %{$ctx->{'pdata'}};
+  my $oidx = $r2idx{$or};
+  my $idx = $r2idx{$r};
+  my $incr = $idx < $oidx ? 1 : -1;
+  my $hwm = $ctx->{'hwm'};
+  # format branch line for the origin
+  $$or .= ' ' . '-' x ($hwm - length($$or)) . '\\';
+  # format branch line for the branch
+  $$r .= ' ' . '-' x ($hwm - length($$r)) . '/';
+  # format all lines in between
+  $idx += $incr;
+  while ($idx > $oidx || $idx < $oidx) {
+    my $tr = $ctx->{'rows'}->[$idx];
+    $$tr .= ' ' . ($r2p{$tr} ? '-' : ' ') x ($hwm - length($$tr)) . '|';
+    $idx += $incr;
+  }
+  $ctx->{'hwm'} = length($$r);
+}
+
+sub handle_test {
+  my ($ctx) = @_;
+  $ctx->{'testno'}++;
+}
+
+my $legend = <<EOF;
+Legend:
+C                    -- commit
+C(file1, ..., filen) -- commit file1, ..., filen
+C(file1, file2 (D))  -- commit file1 and delete file2
+
+oprj/opkg ....\\
+              |
+branch/pkg .../      -- a branch originating at oprj/opkg
+
+
+EOF
+
+sub print_timeline {
+  my ($handler, $opts, @subs) = @_;
+  my $ctx = {'hwm' => 0, 'testno' => 0, 'opts' => $opts};
+  my $until = exists $opts->{'until-test'} ? $opts->{'until-test'} + 0 : -1;
+  for (@subs) {
+    last if $until == $ctx->{'testno'};
+    my $name = (keys %$_)[0];
+    $handler->{$name}->($ctx, @{$_->{$name}}) if exists $handler->{$name};
+  }
+  for (@{$ctx->{'rows'} || []}) {
+    print "$$_\n";
+  }
+  print $legend if $opts->{'legend'};
+  for (@{$ctx->{'vrows'} || []}) {
+    print "$_\n\n";
+  }
+}
+
+sub usage {
+  print <<EOF;
+$0 <options> /path/to/testcase.t
+
+Note: this script just statically analyzes the given /path/to/testcase.t file
+      (the testcase is NOT executed). Moreover, it does not "visualize"
+      branches that are created with the "olinkrev" param.
+
+Options:
+--help/-h            display help/usage
+--until-test number  stop printing the timeline after test "number"
+--with-files         print information whether a file is added/kept or deleted
+                     during a commit
+--ignore-orev        this script cannot visualize a branch that is create with
+                     an orev param and aborts by default (with this option,
+                     it does not abort and will print a "wrong" timeline)
+--legend             print a legend
+--verbose            print file content during a commit
+
+EOF
+  exit(0);
+}
+
+my $handler = {
+  'create' => \&handle_create,
+  'commit' => \&handle_commit,
+  'branch' => \&handle_branch,
+  'blame_is' => \&handle_test,
+  'list_like' => \&handle_test
+};
+
+my $filename = pop @ARGV;
+usage() if !defined($filename) || $filename eq '-h' || $filename eq '--help';
+
+my $opts = {};
+# quick and dirty: perl will (hopefully) complain if an illegal
+# opt was specified (e.g. a str where an int was expected etc.)
+# so, do it right:)
+while (@ARGV) {
+  my $opt = shift @ARGV;
+  die("$opt is not an option\n") unless $opt =~ s/^--//;
+  $opts->{$opt} = @ARGV && $ARGV[0] !~ /^--/ ? shift @ARGV : 1;
+}
+my @subs = parse_subcalls($filename);
+harmonize_args(\@subs);
+print_timeline($handler, $opts, @subs);


### PR DESCRIPTION
The main purpose of this PR is to get some feedback on the proof of concept
implementation of the blame feature.

The blame feature can be used to "blame" a file in given project/package.

Example:

```
marcus@linux:~> curl -X POST -d '' 'http://localhost:5352/source/branch/pkg64/testfile?cmd=blame&expand=1'
<blamedata>
  <revision rev="1" project="branch" package="pkg61" vrev="1">
    <srcmd5>d818673a6e48b3606ffb79db08defc66</srcmd5>
    <version>unknown</version>
    <time>1</time>
    <user>foo</user>
  </revision>
  <revision rev="7" project="branch" package="pkg61" vrev="7">
    <srcmd5>b7dcf466ad19d53e663e731865053db4</srcmd5>
    <version>unknown</version>
    <time>42</time>
    <user>bar</user>
  </revision>
  <revision rev="3" project="branch" package="pkg64" vrev="3">
    <srcmd5>ec90bda4beea8c801193e23a952ae325</srcmd5>
    <version>unknown</version>
    <time>47</time>
    <user>xyz</user>
  </revision>
  ...
</blamedata>
marcus@linux:~>
```

That is,
- the first line was introduced by user "foo" in revision 1 of branch/pkg61
- the second line was introduced by user "bar" in revision 7 of branch/pkg61
- the third line was introduced by user "xyz" in revision 3 of branch/pkg64
  ...

Features:
- a blame can be computed for plain packages and simple "branches" (see
  limitations)
- blame calculation also works for repairlink=1 commits

Limitations:
- no support for non-branch links
- no support for branches that have a linkrev attribute in the _link file
- it is possible that the heuristic, which is used in
  BSBlame::RangeFirstStrategy::resolve, yields "incorrect" results [1];
  we could get rid of the whole heuristic approach, if the backend tracks
  to which commit an expanded rev's lsrcmd5 belongs.

TODOs:
- evaluate if it is possible to somehow reuse the DAG that is computed
  by BSBlame::RangeFirstStrategy::resolve
- add a cache to BSBlame::Storage?
- support constraint merging in BSBlame::Revision::constraint
- die in case of a binary file
- only compute blames for the relevant parts of the DAG (see
  BSBlame::RangeFirstStrategy::blame)
- see also the code comments for more TODOs

Outlook:
- blame support for a source copy operation? (if so, the backend needs to
  track source copy operations)
- blame support for accepted submit requests? (we could "easily" support
  this if the current blame code also considers deleted revs)

Now the questions... :)
- Do we want to have such a feature? (see also
  https://github.com/openSUSE/osc/issues/22)
- If so, which limitation/TODO/outlook items should be fixed?
- Any objections to the approach/merge semantics etc.?

Any feedback is welcome!:)

Ps. if you have a look at the testcases the timeline.pl script might be
handy to visualize the commit "timeline" (for details see
"perl timeline.pl -h")

[1] I haven't written a testcase for this yet, but I think we could fool
    the heuristic when creating branches with "olinkrev=..."
