### PR TITLE
[backend] fixed spelling error in bs_publish

### DIFF
--- a/src/backend/bs_publish
+++ b/src/backend/bs_publish
@@ -2313,7 +2313,7 @@ sub publishevent {
     clear_repoinfo_state($prp);
     set_publish_retry($req, time() + 60);
     db_sync();
-    BSUtil::printlog("pushlish failed for $prp") if $req->{'forked'};
+    BSUtil::printlog("publish failed for $prp") if $req->{'forked'};
     return 0;
   }
 
@@ -2323,7 +2323,7 @@ sub publishevent {
   writepublishtimeevent($projid, $repoid, $now, $now - $starttime) if $req->{'forked'};
   notify_state($projid, $repoid, 'published');
   db_sync();
-  BSUtil::printlog("pushlish done for $prp") if $req->{'forked'};
+  BSUtil::printlog("publish done for $prp") if $req->{'forked'};
   return 1;
 }
 


### PR DESCRIPTION
changed "pushlish" to "publish" in log output