### PR TITLE
[api] fix raising permissions as admin

### DIFF
--- a/src/api/app/controllers/source_controller.rb
+++ b/src/api/app/controllers/source_controller.rb
@@ -689,7 +689,7 @@ class SourceController < ApplicationController
       end
 
       if pkg && !pkg.disabled_for?('sourceaccess', nil, nil)
-        if FlagHelper.xml_disabled_for?(rdata, 'sourceaccess')
+        if FlagHelper.xml_disabled_for?(rdata, 'sourceaccess') && !User.current.is_admin?
           render_error status: 403, errorcode: 'change_package_protection_level',
                        message: 'admin rights are required to raise the protection level of a package'
           return

--- a/src/api/app/models/project.rb
+++ b/src/api/app/models/project.rb
@@ -517,18 +517,18 @@ class Project < ApplicationRecord
 
     # check for raising read access permissions, which can't get ensured atm
     unless new_record? || disabled_for?('access', nil, nil)
-      if FlagHelper.xml_disabled_for?(xmlhash, 'access')
+      if FlagHelper.xml_disabled_for?(xmlhash, 'access') && !User.current.is_admin?
         raise ForbiddenError.new
       end
     end
     unless new_record? || disabled_for?('sourceaccess', nil, nil)
-      if FlagHelper.xml_disabled_for?(xmlhash, 'sourceaccess')
+      if FlagHelper.xml_disabled_for?(xmlhash, 'sourceaccess') && !User.current.is_admin?
         raise ForbiddenError.new
       end
     end
     new_record = new_record?
     if ::Configuration.default_access_disabled == true && !new_record
-      if disabled_for?('access', nil, nil) && !FlagHelper.xml_disabled_for?(xmlhash, 'access')
+      if disabled_for?('access', nil, nil) && !FlagHelper.xml_disabled_for?(xmlhash, 'access') && !User.current.is_admin?
         raise ForbiddenError.new
       end
     end

--- a/src/api/test/functional/read_permission_test.rb
+++ b/src/api/test/functional/read_permission_test.rb
@@ -503,6 +503,11 @@ class ReadPermissionTest < ActionDispatch::IntegrationTest
         '<package name="pack" project="home:adrian:PublicProject"> <title/> <description/>  <sourceaccess><disable/></sourceaccess>  </package>'
     assert_response 403
     assert_xml_tag tag: "status", attributes: { code: "change_package_protection_level" }
+    # but works as admin
+    login_king
+    put url_for(controller: :source, action: :update_package_meta, project: "home:adrian:PublicProject", package: "pack"),
+        '<package name="pack" project="home:adrian:PublicProject"> <title/> <description/>  <sourceaccess><disable/></sourceaccess>  </package>'
+    assert_response :success
     delete "/source/home:adrian:Project"
     assert_response :success
     delete "/source/home:adrian:PublicProject"
@@ -519,6 +524,10 @@ class ReadPermissionTest < ActionDispatch::IntegrationTest
         '<project name="home:adrian:Project"> <title/> <description/> <access><disable/></access> </project>'
     assert_response 403
     assert_xml_tag tag: "status", attributes: { code: "change_project_protection_level" }
+    login_king
+    put url_for(controller: :source, action: :update_project_meta, project: "home:adrian:Project"),
+        '<project name="home:adrian:Project"> <title/> <description/> <access><disable/></access> </project>'
+    assert_response :success
     delete "/source/home:adrian:Project"
     assert_response :success
   end


### PR DESCRIPTION
Hiding sources later on was allowed for admins (though it is still not secure
and a bad idea)
