### PR TITLE
[contrib] extended start_development_backend script

### DIFF
--- a/contrib/start_development_backend
+++ b/contrib/start_development_backend
@@ -3,10 +3,11 @@
 #function to help with the usage
 function _print_syntax() {
   me=`basename "$0"`
-  echo "Usage: $me [-d <dir> -l <dir>]"
+  echo "Usage: $me [-d <dir> -l <dir> -w <num> -r <server>]"
   echo -e "\t-d <dir>\tDirectory of source code. If not provided /vagrant ist used"
   echo -e "\t-l <dir>\tDirectory where the logfiles should be put. If not set STDERR and STDOUT will be printed to console"
   echo -e "\t-w <num>\tNumber of workers that should be spawned. This can reduce the performance of the system!"
+  echo -e "\t-r <server>\tRegister to this reposerver. Can be used multiple times."
 }
 
 #reset OPTIND
@@ -18,8 +19,12 @@ GIT_HOME="/vagrant"
 #preset WORKER_COUNT
 WORKER_N=1
 
+#preset reg_server
+haverep=0
+REP_SERVER_STRING="--reposerver http://localhost:5252"
+
 #get options and check if there is a space in the dir arguments
-while getopts "l:d:w:h?" opt; do
+while getopts "l:d:w:r:h?" opt; do
   case "$opt" in
   l)
     REDIR_LOG=$OPTARG
@@ -37,6 +42,10 @@ while getopts "l:d:w:h?" opt; do
     ;;
   w)
     WORKER_N=$OPTARG
+    ;;
+  r)
+    rep_server+=("$OPTARG")
+    haverep=1
     ;;
   h|\?)
     _print_syntax
@@ -67,6 +76,16 @@ if [ -n "$REDIR_LOG" ]; then
   done
 fi
 
+if [[ "$haverep" -eq "1" ]]; then
+  REP_SERVER_STRING=""
+  REP_PREFIX="--reposerver http://"
+  REP_POSTFIX=":5252 "
+  for server in "${rep_server[@]}"
+  do
+    REP_SERVER_STRING=$REP_SERVER_STRING$REP_PREFIX$server$REP_POSTFIX
+  done
+fi
+
 #check if GIT_HOME exists. If not it does not make any sense to continue.
 if [ ! -d "$GIT_HOME" ]; then
   echo "There seems to be something wrong. Directory $GIT_HOME not found."
@@ -74,15 +93,10 @@ if [ ! -d "$GIT_HOME" ]; then
   exit 1
 fi
 
-#set perl include path to our development backend
-PERL5LIB=$GIT_HOME/src/backend
-export PERL5LIB
-
 #create BSConfig.pm and change hostname to localhost
 if [ ! -f $GIT_HOME/src/backend/BSConfig.pm ]; then
   cp $GIT_HOME/src/backend/BSConfig.pm.template $GIT_HOME/src/backend/BSConfig.pm
 fi
-perl -pi -e 's/my \$hostname.*/my \$hostname="localhost";/' $GIT_HOME/src/backend/BSConfig.pm
 perl -pi -e 's/our \$bsserviceuser.*/our \$bsserviceuser="obsrun";/' $GIT_HOME/src/backend/BSConfig.pm
 
 
@@ -123,7 +137,8 @@ do
 
   index=$w_count+6;
   echo "Starting bs_worker"
-  COMMAND_STRING="sudo $GIT_HOME/src/backend/bs_worker --hardstatus --root /var/cache/obs/worker/root_$w_count --statedir /srv/obs/run/worker/$w_count --id $HOSTNAME:$w_count --reposerver http://localhost:5252 --hostlabel OBS_WORKER_SECURITY_LEVEL_ --jobs 1 --cachedir /var/cache/obs/worker/cache --cachesize 3967 ${APPEND_ARR[$index]} &"
+ 
+  COMMAND_STRING="sudo $GIT_HOME/src/backend/bs_worker --hardstatus --root /var/cache/obs/worker/root_$w_count --statedir /srv/obs/run/worker/$w_count --id $HOSTNAME:$w_count $REP_SERVER_STRING --hostlabel OBS_WORKER_SECURITY_LEVEL_ --jobs 1 --cachedir /var/cache/obs/worker/cache --cachesize 3967 ${APPEND_ARR[$index]} &"
   eval $COMMAND_STRING
   let w_count=$w_count+1
 done


### PR DESCRIPTION
 * hostname is no longer set to localhost by default.
 * exporting PERL5LIB not needed
 * added function to register workers to multiple reposervers

```
    start_development_backend -r reposrv1 -r reposrv2 -r reposrv3
```
if no -r option is given localhost is used by default.