### PR TITLE
[backend] identify non-idle workers for constraints

### DIFF
--- a/src/backend/BSSched/EventHandler.pm
+++ b/src/backend/BSSched/EventHandler.pm
@@ -66,6 +66,7 @@ our %event_handlers = (
   'configuration'   => \&BSSched::EventHandler::event_configuration,
   'suspendproject'  => \&BSSched::EventHandler::event_suspendproject,
   'memstats'        => \&BSSched::EventHandler::event_memstats,
+  'dispatchdetails' => \&BSSched::EventHandler::event_dispatchdetails,
 );
 
 =head1 NAME
@@ -610,6 +611,21 @@ sub event_memstats {
   };
   warn($@) if $@;
   %$gctx = %gctx;
+}
+
+sub event_dispatchdetails {
+  my ($ectx, $ev) = @_;
+  my $gctx = $ectx->{'gctx'};
+  my $myarch = $gctx->{'arch'};
+  my $myjobsdir = $gctx->{'myjobsdir'};
+  my $reporoot = $gctx->{'reporoot'};
+  my $info = readxml("$myjobsdir/$ev->{'job'}", $BSXML::buildinfo, 1);
+  return unless $info;
+  return if -e "$myjobsdir/$ev->{'job'}:status";
+  my $job = $ev->{'job'};
+  $job =~ s/.*\///;
+  my $gdst = "$reporoot/$info->{'project'}/$info->{'repository'}/$myarch";
+  BSUtil::appendstr("$gdst/:packstatus.finished", "scheduled $info->{'package'}/$job/$ev->{'details'}\n");
 }
 
 1;

--- a/src/backend/BSXML.pm
+++ b/src/backend/BSXML.pm
@@ -651,6 +651,7 @@ our $event = [
 	'linksrcmd5',		# for type=servicedispatch
 	'projectservicesmd5',	# for type=servicedispatch
 	'oldsrcmd5',		# for type=servicedispatch
+        'details',              # for type=dispatchdetails
 ];
 
 our $events = [

--- a/src/backend/bs_dispatch
+++ b/src/backend/bs_dispatch
@@ -181,6 +181,7 @@ my %badhost;
 my %newestsrcchange;
 my %infocache;
 my %constraintscache;
+my %scheduleinfo;
 
 my %lastbuild;	# last time a job was build in that prpa
 
@@ -1020,6 +1021,9 @@ while (1) {
     for (grep {!$notlocked{$_} && !$locked{$_}} keys (%{$infocache{$arch} || {}})) {
       delete $infocache{$arch}->{$_};
     }
+    for (grep {!$notlocked{$_}} keys (%{$scheduleinfo{$arch} || {}})) {
+      delete $scheduleinfo{$arch}->{$_};
+    }
     # adapt load
     for my $job (keys %locked) {
       my $jn = $job;
@@ -1372,6 +1376,35 @@ while (1) {
 	$haveassigned = 1;
 	last;
       }
+      # we have jobs that could not be assigned and have constraints.
+      # check if non idle workers could build these job or if there are no
+      # workers that met the constraints
+      my @nonidlestates = qw(building away down dead);
+      if (!$haveassigned && $constraints) {
+        if ($info->{'allworkercheck'}++ % 5 == 0) {
+          my $details = "";
+          foreach my $nonidlestate (@nonidlestates) {
+            my $oraresult = 0;
+            my @workerarr = BSUtil::ls("$workersdir/$nonidlestate");
+            foreach my $workertooracle (@workerarr) {
+              my $worker = readxml("$workersdir/$nonidlestate/$workertooracle", $BSXML::worker, 1);
+              $oraresult++ if (oracle($worker,$constraints) == 1);
+            }
+            if (scalar(@workerarr) > 0 && $oraresult > 0) {
+              $details .= "$oraresult/" . scalar(@workerarr) . " $nonidlestate ";
+            }
+          }
+          if ($details eq "") {
+            $details = "no worker provides the capabilities to comply with the constraints";
+          }
+          $details =~ s/\s+$//;
+          if (!exists $scheduleinfo{$arch}->{$job} || $scheduleinfo{$arch}->{$job} ne $details) {
+            $scheduleinfo{$arch}->{$job} = $details;
+            setdispatchdetails($info,$arch,$job,$details);
+          }
+        }
+      }
+
       # Tricky, still increase load so that we don't assign
       # too many non-powerjobs. But only do that once for each powerjob.
       if (!$haveassigned && $powerjobs{$job} && !$extraload{"$arch/$job"}) {
@@ -1407,4 +1440,21 @@ while (1) {
     }
   }
   filechecks();
+}
+
+sub setdispatchdetails {
+  my ($info, $arch, $job, $details) = @_;
+  if ($info->{'masterdispatched'}) {
+    my $param = {
+      'uri' => "$info->{'reposerver'}/$arch/$job",
+      'request' => 'POST',
+    };
+    BSRPC::rpc($param, undef, "details=$details");
+  } else {
+    my $ev = { type => 'dispatchdetails', job => "$job", details => $details };
+    my $evname = "dispatchdetails:$job";
+    mkdir_p("$eventdir/$arch");
+    writexml("$eventdir/$arch/.$evname.$$", "$eventdir/$arch/$evname", $ev, $BSXML::event);
+    BSUtil::ping("$eventdir/$arch/.ping");
+  }
 }

--- a/src/backend/bs_repserver
+++ b/src/backend/bs_repserver
@@ -180,9 +180,16 @@ sub readpackstatus {
   if ($psf) {
     for (split("\n", $psf)) {
       my ($code, $packid) = split(' ', $_, 2);
-      next unless ($ps->{'packstatus'}->{$packid} || '') eq 'scheduled';
-      $ps->{'packstatus'}->{$packid} = 'finished';
-      $ps->{'packerror'}->{$packid} = $code;
+      if ($code eq 'scheduled') {
+        my ($job, $details);
+        ($packid, $job, $details) = split('/', $packid, 3);
+        next unless ($ps->{'packstatus'}->{$packid} || '') eq 'scheduled';
+        $ps->{'packerror'}->{$packid} = $details;
+      } else {
+        next unless ($ps->{'packstatus'}->{$packid} || '') eq 'scheduled';
+        $ps->{'packstatus'}->{$packid} = 'finished';
+        $ps->{'packerror'}->{$packid} = $code;
+      }
     }
   }
   return $ps;
@@ -3442,6 +3449,19 @@ sub idleworkerjob {
   return $BSStdServer::return_ok;
 }
 
+sub setdispatchdetails {
+  my ($cgi, $arch, $job) = @_;
+  my $info = readxml("$jobsdir/$arch/$job", $BSXML::buildinfo, 1);
+  if ($info) {
+    my $ev = { type => 'dispatchdetails', job => "$arch/$job", details => $cgi->{'details'}};
+    my $evname = "dispatchdetails:$job";
+    mkdir_p("$eventdir/$arch");
+    writexml("$eventdir/$arch/.$evname.$$", "$eventdir/$arch/$evname", $ev, $BSXML::event);
+    BSUtil::ping("$eventdir/$arch/.ping");
+  }
+  return $BSStdServer::return_ok;
+}
+
 sub putconfiguration {
   my ($cgi) = @_;
   mkdir_p($uploaddir);
@@ -3485,6 +3505,7 @@ my $dispatches = [
   '!- GET:' => undef,
   '!- HEAD:' => undef,
 
+  'POST:/build/$project cmd=move oproject:project' => \&moveproject,
   'POST:/build/$project/$repository/$arch/_repository match:' => \&postrepo,
   '/build/$project/$repository/$arch package* view:?' => \&getpackagelist_build,
   '/build/$project/$repository/$arch/_builddepinfo package* view:?' => \&getbuilddepinfo,
@@ -3492,7 +3513,6 @@ my $dispatches = [
   'POST:/build/$project/$repository/$arch/_relsync' => \&postrelsync,
   '/build/$project/$repository/$arch/_relsync' => \&getrelsync,
   'POST:/build/$project/$repository/$arch/$package cmd=copy oproject:project? opackage:package? orepository:repository? setupdateinfoid:? resign:bool? setrelease:?' => \&copybuild,
-  'POST:/build/$project cmd=move oproject:project' => \&moveproject,
   'POST:/build/$project/$repository/$arch/$package' => \&uploadbuild,
   '!worker,rw /build/$project/$repository/$arch/$package:package_repository view:? binary:filename* nometa:bool? noajax:bool? nosource:bool? noimport:bool? withmd5:bool?' => \&getbinarylist,
   'POST:/build/$project/$repository/$arch/$package_repository/_buildinfo add:* internal:bool? debug:bool? deps:bool?' => \&getbuildinfo_post,
@@ -3540,6 +3560,7 @@ my $dispatches = [
   '/jobs/$arch' => \&listjobs,
   'PUT:/jobs/$arch/$job' => \&addjob,
   'POST:/jobs/$arch/$job cmd=idleworker workerid jobid?' => \&idleworkerjob,
+  'POST:/jobs/$arch/$job cmd=setdispatchdetails details:' => \&setdispatchdetails,
   'DELETE:/jobs/$arch/$job' => \&deljob,
   '/jobs/$arch/$job view:?' => \&getjob,
 


### PR DESCRIPTION
**Problem**
If a constraint is not met by an idle worker the job is in state scheduled without giving a reason why. 
There is no check if currently building / away / down workers could meet the constraints later. 

**Solution**
If no suitable worker could be found within the idle workers the dispatcher checks periodically the building / away / down workers for a match. If there is a match the dispatcher sets an event to add the information to :packstatus.finished in the form: 
```1/35 building 3/4 away```
which means "1 out of 35 building workers will meet the constraints, 3 of 4 away workers could build this job"

If no worker can build the job the following string is returned: 
```no worker provides the capabilities to comply with the constraints```

In a final step the :packstatus.finished is patched into :packstatus on being requested. 

Can be queried with ```osc r -v ```:

_Job could be built on busy worker:_
```
osc r -v home:marco screen

openSUSE_Leap_42.1   x86_64     scheduled: 4/4 building 1/1 away 3/4 dead
```

_no worker provides capabilities:_
```
osc r -v home:marco cowsay

openSUSE_Leap_42.1   x86_64     scheduled: no worker provides the capabilities to comply with the constraints
```

