### PR TITLE
Anonymous access for orderkiwirepos API call

### DIFF
--- a/src/api/app/controllers/source_controller.rb
+++ b/src/api/app/controllers/source_controller.rb
@@ -19,8 +19,8 @@ class SourceController < ApplicationController
   validate_action update_project_meta: { request: :project, response: :status}
   validate_action update_package_meta: { request: :package, response: :status}
 
-  skip_before_action :extract_user, only: [:lastevents_public]
-  skip_before_action :require_login, only: [:lastevents_public]
+  skip_before_action :extract_user, only: [:lastevents_public, :global_command_orderkiwirepos]
+  skip_before_action :require_login, only: [:lastevents_public, :global_command_orderkiwirepos]
 
   before_action :require_valid_project_name, except: [ :index, :lastevents, :lastevents_public,
                                                        :global_command_orderkiwirepos, :global_command_branch,

--- a/src/api/app/controllers/source_controller.rb
+++ b/src/api/app/controllers/source_controller.rb
@@ -22,7 +22,9 @@ class SourceController < ApplicationController
   skip_before_action :extract_user, only: [:lastevents_public]
   skip_before_action :require_login, only: [:lastevents_public]
 
-  before_action :require_valid_project_name, except: [:index, :lastevents, :lastevents_public, :global_command]
+  before_action :require_valid_project_name, except: [ :index, :lastevents, :lastevents_public,
+                                                       :global_command_orderkiwirepos, :global_command_branch,
+                                                       :global_command_createmaintenanceincident ]
 
   class NoPermissionForDeleted < APIException
     setup 403, 'only admins can see deleted projects'
@@ -44,14 +46,6 @@ class SourceController < ApplicationController
     else
       projectlist
     end
-  end
-
-  # POST /source
-  def global_command
-    unless %w(createmaintenanceincident branch orderkiwirepos).include? params[:cmd]
-      raise UnknownCommandError.new "Unknown command '#{params[:cmd]}' for path #{request.path}"
-    end
-    dispatch_command(:global_command, params[:cmd])
   end
 
   def projectlist
@@ -846,16 +840,6 @@ class SourceController < ApplicationController
     volley_backend_path(path) unless forward_from_backend(path)
   end
 
-  private
-
-  class AttributeNotFound < APIException
-    setup 'not_found', 404
-  end
-
-  class ModifyProjectNoPermission < APIException
-    setup 403
-  end
-
   # POST /source?cmd=createmaintenanceincident
   def global_command_createmaintenanceincident
     # set defaults
@@ -868,6 +852,26 @@ class SourceController < ApplicationController
     # find maintenance project via attribute
     prj = Project.get_maintenance_project(at)
     actually_create_incident(prj)
+  end
+
+  # POST /source?cmd=branch (aka osc mbranch)
+  def global_command_branch
+    private_branch_command
+  end
+
+  # POST /source?cmd=orderkiwirepos
+  def global_command_orderkiwirepos
+    pass_to_backend
+  end
+
+  private
+
+  class AttributeNotFound < APIException
+    setup 'not_found', 404
+  end
+
+  class ModifyProjectNoPermission < APIException
+    setup 403
   end
 
   def actually_create_incident(project)
@@ -886,16 +890,6 @@ class SourceController < ApplicationController
   end
 
   class RepoDependency < APIException
-  end
-
-  # POST /source?cmd=branch (aka osc mbranch)
-  def global_command_branch
-    private_branch_command
-  end
-
-  # POST /source?cmd=orderkiwirepos
-  def global_command_orderkiwirepos
-    pass_to_backend
   end
 
   # create a id collection of all projects doing a project link to this one

--- a/src/api/config/routes.rb
+++ b/src/api/config/routes.rb
@@ -637,7 +637,9 @@ OBSApi::Application.routes.draw do
 
   controller :source do
     get 'source' => :index
-    post 'source' => :global_command
+    post 'source' => :global_command_createmaintenanceincident, constraints: -> (req) { req.params[:cmd] == "createmaintenanceincident" }
+    post 'source' => :global_command_branch,                    constraints: -> (req) { req.params[:cmd] == "branch" }
+    post 'source' => :global_command_orderkiwirepos,            constraints: -> (req) { req.params[:cmd] == "orderkiwirepos" }
 
     # project level
     get 'source/:project' => :show_project, constraints: cons

--- a/src/api/test/functional/source_controller_test.rb
+++ b/src/api/test/functional/source_controller_test.rb
@@ -61,14 +61,22 @@ class SourceControllerTest < ActionDispatch::IntegrationTest
   end
 
   def test_post_orderkiwirepos
-    post '/source?cmd=orderkiwirepos'
-    assert_response 401
-
     login_tom
     post '/source?cmd=orderkiwirepos'
     assert_response 400
     assert_xml_tag tag: 'status', attributes: { code: "400", origin: "backend" }
     # api handed it over to backend, enough tested here
+  end
+
+  def test_anonymous_access_for_global_commands
+    post '/source?cmd=orderkiwirepos'
+    assert_response 401
+
+    post '/source?cmd=createmaintenanceincident'
+    assert_response 401
+
+    post '/source/kde4?cmd=branch'
+    assert_response 401
   end
 
   def test_get_packagelist_with_hidden_project

--- a/src/api/test/functional/source_controller_test.rb
+++ b/src/api/test/functional/source_controller_test.rb
@@ -70,7 +70,8 @@ class SourceControllerTest < ActionDispatch::IntegrationTest
 
   def test_anonymous_access_for_global_commands
     post '/source?cmd=orderkiwirepos'
-    assert_response 401
+    # anonymous access allowed here, just forwarding the request to backend fails
+    assert_response 400
 
     post '/source?cmd=createmaintenanceincident'
     assert_response 401


### PR DESCRIPTION
Per discussion with Adrian we should allow anonymous access to this API point. This will allow external tools, like osc and obs-services, to use this API call without handling credentials.