### PR TITLE
[webui][ci] Remove `HTTP request methods` deprecation warnings

### DIFF
--- a/src/api/spec/controllers/public_controller_spec.rb
+++ b/src/api/spec/controllers/public_controller_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe PublicController, vcr: true do
 
   describe "GET #source_file" do
     it "sends the requested file" do
-      get :source_file, project: project.name, package: package.name, filename: "somefile.txt"
+      get :source_file, params: { project: project.name, package: package.name, filename: "somefile.txt" }
       expect(response).to have_http_status(:success)
       expect(response.body).to eq(package.source_file("somefile.txt"))
     end

--- a/src/api/spec/controllers/webui/architectures_controller_spec.rb
+++ b/src/api/spec/controllers/webui/architectures_controller_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe Webui::ArchitecturesController do
       it 'creates the architectures' do
         login(admin_user)
 
-        post :bulk_update_availability, archs: { i586: '0', s390x: '1' }
+        post :bulk_update_availability, params: { archs: { i586: '0', s390x: '1' } }
         expect(response).to redirect_to(architectures_path)
         expect(flash[:notice]).to eq('Architectures successfully updated.')
         expect(Architecture.find_by_name('i586').available).to be false

--- a/src/api/spec/controllers/webui/attributes_spec.rb
+++ b/src/api/spec/controllers/webui/attributes_spec.rb
@@ -5,13 +5,13 @@ RSpec.describe Webui::AttributeController do
 
   describe 'GET index' do
     it 'shows an error message when package does not exist' do
-      get :index, project: user.home_project, package: "Pok"
+      get :index, params: { project: user.home_project, package: "Pok" }
       expect(response).to redirect_to(project_show_path(user.home_project))
       expect(flash[:error]).to eq("Package Pok not found")
     end
 
     it 'shows an error message when project does not exist' do
-      get :index, project: "Does:Not:Exist"
+      get :index, params: { project: "Does:Not:Exist" }
       expect(response).to redirect_to(projects_path)
       expect(flash[:error]).to eq("Project not found: Does:Not:Exist")
     end

--- a/src/api/spec/controllers/webui/configuration_controller_spec.rb
+++ b/src/api/spec/controllers/webui/configuration_controller_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe Webui::ConfigurationController do
     context 'as admin' do
       it 'creates a new remote project' do
         login(admin_user)
-        post :create_interconnect, project: attributes_for(:remote_project, name: 'MyRemoteProject')
+        post :create_interconnect, params: { project: attributes_for(:remote_project, name: 'MyRemoteProject') }
         expect(response).to redirect_to(project_show_path('MyRemoteProject'))
         expect(flash[:notice]).to eq("Project 'MyRemoteProject' was created successfully")
         expect(RemoteProject.exists?(name: 'MyRemoteProject')).to be true

--- a/src/api/spec/controllers/webui/download_on_demand_controller_spec.rb
+++ b/src/api/spec/controllers/webui/download_on_demand_controller_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe Webui::DownloadOnDemandController do
   it "uses strong parameters" do
     login(admin_user)
     should permit(:arch, :repotype, :url, :repository_id, :archfilter, :masterurl, :mastersslfingerprint, :pubkey).
-              for(:create, params: dod_parameters).on(:download_repository)
+      for(:create, params: dod_parameters ).on(:download_repository)
   end
 
   describe "POST create" do
@@ -41,7 +41,7 @@ RSpec.describe Webui::DownloadOnDemandController do
     context "for non-admin users" do
       before do
         login(create(:confirmed_user))
-        post :create, dod_parameters
+        post :create, params: dod_parameters
       end
 
       it { is_expected.to redirect_to(root_path) }
@@ -52,7 +52,7 @@ RSpec.describe Webui::DownloadOnDemandController do
     context "valid requests" do
       before do
         login(admin_user)
-        post :create, dod_parameters
+        post :create, params: dod_parameters
       end
 
       it { is_expected.to redirect_to(project_repositories_path(project)) }
@@ -65,7 +65,7 @@ RSpec.describe Webui::DownloadOnDemandController do
       before do
         dod_parameters[:download_repository][:arch] = ""
         login(admin_user)
-        post :create, dod_parameters
+        post :create, params: dod_parameters
       end
 
       it { is_expected.to redirect_to(root_path) }
@@ -81,7 +81,7 @@ RSpec.describe Webui::DownloadOnDemandController do
     context "for non-admin users" do
       before do
         login(create(:confirmed_user))
-        delete :destroy, id: dod_repository.id, project: project.name
+        delete :destroy, params: { id: dod_repository.id, project: project.name }
       end
 
       it { is_expected.to redirect_to(root_path) }
@@ -94,7 +94,7 @@ RSpec.describe Webui::DownloadOnDemandController do
 
       before do
         login(admin_user)
-        delete :destroy, id: dod_repository.id, project: project.name
+        delete :destroy, params: { id: dod_repository.id, project: project.name }
       end
 
       it { is_expected.to redirect_to(project_repositories_path(project)) }
@@ -105,7 +105,7 @@ RSpec.describe Webui::DownloadOnDemandController do
     context "invalid requests" do
       before do
         login(admin_user)
-        delete :destroy, id: dod_repository.id, project: project.name
+        delete :destroy, params: { id: dod_repository.id, project: project.name }
       end
 
       it { is_expected.to redirect_to(root_path) }
@@ -123,7 +123,7 @@ RSpec.describe Webui::DownloadOnDemandController do
         dod_parameters[:id] = dod_repository.id
         dod_parameters[:download_repository][:url] = "http://opensuse.org"
 
-        post :update, dod_parameters
+        post :update, params: dod_parameters
       end
 
       it { is_expected.to redirect_to(root_path) }
@@ -141,7 +141,7 @@ RSpec.describe Webui::DownloadOnDemandController do
         dod_parameters[:download_repository][:url] = "http://opensuse.org"
         dod_parameters[:download_repository][:repository_id] = dod_repository.repository.id
 
-        post :update, dod_parameters
+        post :update, params: dod_parameters
       end
 
       it { is_expected.to redirect_to(project_repositories_path(project)) }

--- a/src/api/spec/controllers/webui/feeds_controller_spec.rb
+++ b/src/api/spec/controllers/webui/feeds_controller_spec.rb
@@ -8,35 +8,35 @@ RSpec.describe Webui::FeedsController do
 
   describe "GET commits" do
     it "assigns @commits" do
-      get(:commits, { project: project, format: 'atom' })
+      get :commits, params: { project: project, format: 'atom' }
       expect(assigns(:commits)).to eq([commit])
     end
 
     it "assigns @project" do
-      get(:commits, { project: project, format: 'atom' })
+      get :commits, params: { project: project, format: 'atom' }
       expect(assigns(:project)).to eq(project)
     end
 
     it "fails if project is not existent" do
       expect do
-        get(:commits, { project: 'DoesNotExist', format: 'atom' })
+        get :commits, params: { project: 'DoesNotExist', format: 'atom' }
       end.to raise_error ActiveRecord::RecordNotFound
     end
 
     it "renders the rss template" do
-      get(:commits, { project: project, format: 'atom' })
+      get :commits, params: { project: project, format: 'atom' }
       expect(response).to render_template("webui/feeds/commits")
     end
 
     it "honors time parameters" do
-      get(:commits, { project: project, format: 'atom', starting_at: "2015-02-09", ending_at: "2015-02-10" })
+      get :commits, params: { project: project, format: 'atom', starting_at: "2015-02-09", ending_at: "2015-02-10" }
       expect(assigns(:commits)).to eq([old_commit])
     end
 
     it "honors sourceaccess flag" do
       create(:sourceaccess_flag, project: project)
 
-      get(:commits, { project: project, format: 'atom' })
+      get :commits, params: { project: project, format: 'atom' }
       expect(response).to have_http_status(:forbidden)
     end
   end
@@ -49,7 +49,7 @@ RSpec.describe Webui::FeedsController do
         Timecop.travel(1.second)
       end
 
-      get(:news, { project: project, format: 'rss' })
+      get :news, params: { project: project, format: 'rss' }
     end
 
     it "provides a rss feed" do

--- a/src/api/spec/controllers/webui/groups_controller_spec.rb
+++ b/src/api/spec/controllers/webui/groups_controller_spec.rb
@@ -13,17 +13,17 @@ RSpec.describe Webui::GroupsController do
 
   describe 'GET show' do
     it 'is successful as nobody' do
-      get :show, title: group.title
+      get :show, params: { title: group.title }
       expect(response).to have_http_status(:success)
     end
 
     it 'assigns @group' do
-      get :show, title: group.title
+      get :show, params: { title: group.title }
       expect(assigns(:group)).to eq(group)
     end
 
     it 'redirects to root_path if group does not exist' do
-      get :show, title: 'Foobar'
+      get :show, params: { title: 'Foobar' }
       expect(flash[:error]).to eq("Group 'Foobar' does not exist")
       expect(response).to redirect_to(root_path)
     end
@@ -31,36 +31,36 @@ RSpec.describe Webui::GroupsController do
 
   describe 'GET tokens' do
     it 'returns a hash with one group for a match' do
-      get :tokens, q: group.title
+      get :tokens, params: { q: group.title }
       expect(response.body).to eq([{ name: group.title }].to_json)
     end
 
     it 'returns a hash with more than one group for a match' do
       another_group # necessary for initialization
-      get :tokens, q: group.title
+      get :tokens, params: { q: group.title }
       expect(response.body).to eq([{ name: group.title }, { name: another_group.title }].to_json)
     end
 
     it 'returns empty hash if no match' do
-      get :tokens, q: 'no_group'
+      get :tokens, params: { q: 'no_group' }
       expect(response.body).to eq([].to_json)
     end
   end
 
   describe 'GET autocomplete' do
     it 'returns list with one group for a match' do
-      get :autocomplete, term: group.title
+      get :autocomplete, params: { term: group.title }
       expect(response.body).to eq([group.title].to_json)
     end
 
     it 'returns list with more than one group for a match' do
       another_group # necessary for initialization
-      get :autocomplete, term: group.title
+      get :autocomplete, params: { term: group.title }
       expect(response.body).to eq([group.title, another_group.title].to_json)
     end
 
     it 'returns empty list if no match' do
-      get :autocomplete, term: 'no_group'
+      get :autocomplete, params: { term: 'no_group' }
       expect(response.body).to eq([].to_json)
     end
   end

--- a/src/api/spec/controllers/webui/main_controller_spec.rb
+++ b/src/api/spec/controllers/webui/main_controller_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Webui::MainController do
     it "create a status message" do
       login(admin_user)
 
-      post :add_news, message: "Some message", severity: "Green"
+      post :add_news, params: { message: "Some message", severity: "Green" }
       expect(response).to redirect_to(root_path)
       message = StatusMessage.where(user: admin_user, message: "Some message", severity: "Green")
       expect(message).to exist
@@ -18,13 +18,13 @@ RSpec.describe Webui::MainController do
       login(admin_user)
 
       expect {
-        post :add_news, message: "Some message"
+        post :add_news, params: { message: "Some message" }
       }.to_not change(StatusMessage, :count)
       expect(response).to redirect_to(root_path)
       expect(flash[:error]).to eq("Please provide a message and severity")
 
       expect {
-        post :add_news, severity: "Green"
+        post :add_news, params: { severity: "Green" }
       }.to_not change(StatusMessage, :count)
       expect(response).to redirect_to(root_path)
       expect(flash[:error]).to eq("Please provide a message and severity")
@@ -34,7 +34,7 @@ RSpec.describe Webui::MainController do
       before do
         login(user)
 
-        post :add_news, message: "Some message", severity: "Green"
+        post :add_news, params: { message: "Some message", severity: "Green" }
       end
 
       it "does not create a status message" do
@@ -47,7 +47,7 @@ RSpec.describe Webui::MainController do
     context "empty message" do
       before do
         login(admin_user)
-        post :add_news, severity: "Green"
+        post :add_news, params: { severity: "Green" }
       end
 
       it { expect(flash[:error]).to eq("Please provide a message and severity") }
@@ -56,7 +56,7 @@ RSpec.describe Webui::MainController do
     context "empty severity" do
       before do
         login(admin_user)
-        post :add_news, message: "Some message"
+        post :add_news, params: { message: "Some message" }
       end
 
       it { expect(flash[:error]).to eq("Please provide a message and severity") }
@@ -69,7 +69,7 @@ RSpec.describe Webui::MainController do
     it "marks a message as deleted" do
       login(admin_user)
 
-      post :delete_message, message_id: message.id
+      post :delete_message, params: { message_id: message.id }
       expect(response).to redirect_to(root_path)
       expect(message.reload.deleted_at).to be_a_kind_of(ActiveSupport::TimeWithZone)
     end
@@ -77,7 +77,7 @@ RSpec.describe Webui::MainController do
     context "non-admin users" do
       before do
         login(user)
-        post :delete_message, message_id: message.id
+        post :delete_message, params: { message_id: message.id }
       end
 
       it "can't delete messages" do
@@ -129,7 +129,7 @@ RSpec.describe Webui::MainController do
 
     before do
       create_list(:project_with_package, 5)
-      get :sitemap_packages, {listaction: 'show'}
+      get :sitemap_packages, params: { listaction: 'show' }
       @package_paths = Nokogiri::XML(response.body).xpath("//xmlns:loc").map { |url| URI.parse(url).path }
     end
 

--- a/src/api/spec/controllers/webui/patchinfo_controller_spec.rb
+++ b/src/api/spec/controllers/webui/patchinfo_controller_spec.rb
@@ -14,17 +14,11 @@ RSpec.describe Webui::PatchinfoController, vcr: true do
   end
 
   def do_proper_post_save
-    post :save, project: user.home_project_name,
-                package: patchinfo_package.name,
-                summary: 'long enough summary is ok',
-                description: 'long enough description is also ok' * 5,
-                issueid: [769484],
-                issuetracker: ['bgo'],
-                issuesum: [nil],
-                issueurl: ['https://bugzilla.gnome.org/show_bug.cgi?id=769484'],
-                category: 'recommended',
-                rating: 'low',
-                packager: user.login
+    post :save, params: {
+        project: user.home_project_name, package: patchinfo_package.name, summary: 'long enough summary is ok',
+        description: 'long enough description is also ok' * 5, issueid: [769484], issuetracker: ['bgo'], issuesum: [nil],
+        issueurl: ['https://bugzilla.gnome.org/show_bug.cgi?id=769484'], category: 'recommended', rating: 'low', packager: user.login
+      }
   end
 
   let(:fake_build_results) do
@@ -65,7 +59,7 @@ RSpec.describe Webui::PatchinfoController, vcr: true do
 
     context 'without permission to create the patchinfo package' do
       before do
-        post :new_patchinfo, project: other_user.home_project
+        post :new_patchinfo, params: { project: other_user.home_project }
       end
 
       it { expect(response).to redirect_to(project_show_path(other_user.home_project)) }
@@ -75,7 +69,7 @@ RSpec.describe Webui::PatchinfoController, vcr: true do
     context 'when it fails to create the patchinfo package' do
       before do
         Patchinfo.any_instance.stubs(:create_patchinfo).returns(false)
-        post :new_patchinfo, project: user.home_project
+        post :new_patchinfo, params: { project: user.home_project }
       end
 
       it { expect(response).to redirect_to(project_show_path(user.home_project)) }
@@ -85,7 +79,7 @@ RSpec.describe Webui::PatchinfoController, vcr: true do
     context 'when the patchinfo package file is not found' do
       before do
         Package.any_instance.stubs(:patchinfo).returns(nil)
-        post :new_patchinfo, project: user.home_project
+        post :new_patchinfo, params: { project: user.home_project }
       end
 
       it { expect(response).to redirect_to(package_show_path(project: user.home_project, package: 'patchinfo')) }
@@ -96,7 +90,7 @@ RSpec.describe Webui::PatchinfoController, vcr: true do
       before do
         Buildresult.stubs(:find).returns(fake_build_results)
         Package.any_instance.stubs(:patchinfo).returns(fake_patchinfo_with_binaries)
-        post :new_patchinfo, project: user.home_project
+        post :new_patchinfo, params: { project: user.home_project }
       end
 
       it { expect(response).to have_http_status(:success) }
@@ -114,7 +108,7 @@ RSpec.describe Webui::PatchinfoController, vcr: true do
 
     context 'without a valid patchinfo' do
       before do
-        post :updatepatchinfo, project: user.home_project_name, package: other_package.name
+        post :updatepatchinfo, params: { project: user.home_project_name, package: other_package.name }
       end
 
       it { expect(flash[:error]).to eq("Patchinfo not found for #{user.home_project_name}") }
@@ -124,7 +118,7 @@ RSpec.describe Webui::PatchinfoController, vcr: true do
     context 'with a valid patchinfo' do
       it 'updates and redirects to edit_patchinfo' do
         Patchinfo.any_instance.expects(:cmd_update_patchinfo).with(user.home_project_name, patchinfo_package.name)
-        post :updatepatchinfo, project: user.home_project_name, package: patchinfo_package.name
+        post :updatepatchinfo, params: { project: user.home_project_name, package: patchinfo_package.name }
         expect(response).to redirect_to(action: 'edit_patchinfo', project: user.home_project_name, package: patchinfo_package.name)
       end
     end
@@ -133,7 +127,7 @@ RSpec.describe Webui::PatchinfoController, vcr: true do
   describe 'GET #edit_patchinfo' do
     before do
       login user
-      post :edit_patchinfo, project: user.home_project_name, package: patchinfo_package.name
+      post :edit_patchinfo, params: { project: user.home_project_name, package: patchinfo_package.name }
     end
 
     it { expect(response).to have_http_status(:success) }
@@ -144,7 +138,7 @@ RSpec.describe Webui::PatchinfoController, vcr: true do
   describe 'GET #show' do
     before do
       login user
-      get :show, project: user.home_project_name, package: patchinfo_package.name
+      get :show, params: { project: user.home_project_name, package: patchinfo_package.name }
     end
 
     it { expect(response).to have_http_status(:success) }
@@ -161,7 +155,9 @@ RSpec.describe Webui::PatchinfoController, vcr: true do
     # This validation is performed at controller level and outside the model
     context 'with a short summary' do
       before do
-        post :save, project: user.home_project_name, package: patchinfo_package.name, summary: 'short', description: 'long description ' * 10
+        post :save, params: {
+            project: user.home_project_name, package: patchinfo_package.name, summary: 'short', description: 'long description ' * 10
+          }
       end
 
       it { expect(flash[:error]).to eq("|| Summary is too short (should have more than 10 signs)") }
@@ -171,7 +167,9 @@ RSpec.describe Webui::PatchinfoController, vcr: true do
     # This validation is performed at controller level and outside the model
     context 'with a short description' do
       before do
-        post :save, project: user.home_project_name, package: patchinfo_package.name, summary: 'long enough summary is ok', description: 'short'
+        post :save, params: {
+            project: user.home_project_name, package: patchinfo_package.name, summary: 'long enough summary is ok', description: 'short'
+          }
       end
 
       it { expect(flash[:error]).to eq(" || Description is too short (should have more than 50 signs and longer than summary)") }
@@ -180,14 +178,11 @@ RSpec.describe Webui::PatchinfoController, vcr: true do
 
     context 'with an unknown issue tracker' do
       before do
-        post :save, project: user.home_project_name,
-                    package: patchinfo_package.name,
-                    summary: 'long enough summary is ok',
-                    description: 'long enough description is also ok' * 5,
-                    issueid: [769484],
-                    issuetracker: ['NonExistingTracker'],
-                    issuesum: [nil],
-                    issueurl: ['https://bugzilla.gnome.org/show_bug.cgi?id=769484']
+        post :save, params: {
+            project: user.home_project_name, package: patchinfo_package.name, summary: 'long enough summary is ok',
+            description: 'long enough description is also ok' * 5, issueid: [769484], issuetracker: ['NonExistingTracker'], issuesum: [nil],
+            issueurl: ['https://bugzilla.gnome.org/show_bug.cgi?id=769484']
+          }
       end
 
       it { expect(flash[:error]).to eq("Unknown Issue tracker NonExistingTracker") }
@@ -196,14 +191,11 @@ RSpec.describe Webui::PatchinfoController, vcr: true do
 
     context "when the patchinfo's xml is invalid" do
       before do
-        post :save, project: user.home_project_name,
-                    package: patchinfo_package.name,
-                    summary: 'long enough summary is ok',
-                    description: 'long enough description is also ok' * 5,
-                    issueid: [769484],
-                    issuetracker: ['bgo'],
-                    issuesum: [nil],
-                    issueurl: ['https://bugzilla.gnome.org/show_bug.cgi?id=769484']
+        post :save, params: {
+            project: user.home_project_name, package: patchinfo_package.name,
+            summary: 'long enough summary is ok', description: 'long enough description is also ok' * 5,
+            issueid: [769484], issuetracker: ['bgo'], issuesum: [nil], issueurl: ['https://bugzilla.gnome.org/show_bug.cgi?id=769484']
+          }
       end
 
       it { expect(flash[:error]).to start_with("patchinfo is invalid: ") }
@@ -212,7 +204,7 @@ RSpec.describe Webui::PatchinfoController, vcr: true do
 
     context "when the patchinfo's xml is valid" do
       before do
-        post :new_patchinfo, project: user.home_project # this creates the patchinfo without summary and description
+        post :new_patchinfo, params: { project: user.home_project } # this creates the patchinfo without summary and description
         do_proper_post_save
         @patchinfo = Package.get_by_project_and_name(user.home_project_name, 'patchinfo', use_source: false).patchinfo.to_hash
       end
@@ -253,7 +245,7 @@ RSpec.describe Webui::PatchinfoController, vcr: true do
 
     context 'if package can be removed' do
       before do
-        post :remove, project: user.home_project_name, package: patchinfo_package.name
+        post :remove, params: { project: user.home_project_name, package: patchinfo_package.name }
       end
 
       it { expect(flash[:notice]).to eq("Patchinfo was successfully removed.") }
@@ -263,7 +255,7 @@ RSpec.describe Webui::PatchinfoController, vcr: true do
     context "if package can't be removed" do
       before do
         Package.any_instance.stubs(:check_weak_dependencies?).returns(false)
-        post :remove, project: user.home_project_name, package: patchinfo_package.name
+        post :remove, params: { project: user.home_project_name, package: patchinfo_package.name }
       end
 
       it { expect(flash[:notice]).to eq("Patchinfo can't be removed: ") }
@@ -278,7 +270,7 @@ RSpec.describe Webui::PatchinfoController, vcr: true do
 
     context 'if issues are ok' do
       before do
-        get :new_tracker, project: user.home_project_name, package: patchinfo_package.name, issues: ['bgo#132412']
+        get :new_tracker, params: { project: user.home_project_name, package: patchinfo_package.name, issues: ['bgo#132412'] }
       end
 
       it do
@@ -292,7 +284,7 @@ RSpec.describe Webui::PatchinfoController, vcr: true do
 
     context "if issues are wrongly formatted" do
       before do
-        get :new_tracker, project: user.home_project_name, package: patchinfo_package.name, issues: ['hell#666']
+        get :new_tracker, params: { project: user.home_project_name, package: patchinfo_package.name, issues: ['hell#666'] }
       end
 
       it { expect(JSON.parse(response.body)).to eq({"error" => "hell is not a valid tracker.\n", "issues" => []}) }

--- a/src/api/spec/controllers/webui/repositories_controller_spec.rb
+++ b/src/api/spec/controllers/webui/repositories_controller_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Webui::RepositoriesController, vcr: true do
 
   describe 'GET #index' do
     before do
-      get :index, project: apache_project
+      get :index, params: { project: apache_project }
     end
 
     it { expect(assigns(:build).to_s).to eq(apache_project.get_flags('build').to_s) }
@@ -22,7 +22,7 @@ RSpec.describe Webui::RepositoriesController, vcr: true do
   describe 'GET #state' do
     context 'with a valid repository param' do
       before do
-        get :state, project: user.home_project, repository: repo_for_user_home.name
+        get :state, params: { project: user.home_project, repository: repo_for_user_home.name }
       end
 
       it { expect(assigns(:repocycles)).to be_a(Hash) }
@@ -33,7 +33,7 @@ RSpec.describe Webui::RepositoriesController, vcr: true do
     context 'with a non valid repository param' do
       before do
         request.env["HTTP_REFERER"] = root_url # Needed for the redirect_to :back
-        get :state, project: user.home_project, repository: 'non_valid_repo_name'
+        get :state, params: { project: user.home_project, repository: 'non_valid_repo_name' }
       end
 
       it { expect(assigns(:repocycles)).to be_a(Hash) }
@@ -50,14 +50,14 @@ RSpec.describe Webui::RepositoriesController, vcr: true do
     context 'updating non existent repository' do
       it 'will raise a NoMethodError' do
         expect do
-          post :update, project: user.home_project, repo: 'standard'
+          post :update, params: { project: user.home_project, repo: 'standard' }
         end.to raise_error(NoMethodError)
       end
     end
 
     context 'updating the repository without architectures' do
       before do
-        post :update, project: user.home_project, repo: repo_for_user_home.name
+        post :update, params: { project: user.home_project, repo: repo_for_user_home.name }
       end
 
       it { expect(repo_for_user_home.architectures.pluck(:name)).to be_empty }
@@ -68,7 +68,7 @@ RSpec.describe Webui::RepositoriesController, vcr: true do
 
     context 'updating the repository with architectures' do
       before do
-        post :update, project: user.home_project, repo: repo_for_user_home.name, arch: {'i586' => true, 'x86_64' => true}
+        post :update, params: { project: user.home_project, repo: repo_for_user_home.name, arch: {'i586' => true, 'x86_64' => true} }
       end
 
       it 'each repository has a different position' do
@@ -91,7 +91,7 @@ RSpec.describe Webui::RepositoriesController, vcr: true do
         login user
         create_list(:distribution, 4, vendor: 'vendor1')
         create_list(:distribution, 2, vendor: 'vendor2')
-        get :distributions, project: apache_project
+        get :distributions, params: { project: apache_project }
         expect(assigns(:distributions).length).to eq(2)
       end
     end
@@ -99,7 +99,7 @@ RSpec.describe Webui::RepositoriesController, vcr: true do
     context 'without any distribution and being normal user' do
       before do
         login user
-        get :distributions, project: apache_project
+        get :distributions, params: { project: apache_project }
       end
 
       it { is_expected.to redirect_to(action: 'new', project: apache_project) }
@@ -109,7 +109,7 @@ RSpec.describe Webui::RepositoriesController, vcr: true do
     context 'without any distribution and being admin user' do
       before do
         login admin_user
-        get :distributions, project: apache_project
+        get :distributions, params: { project: apache_project }
       end
 
       it { is_expected.to redirect_to(configuration_interconnect_path) }
@@ -125,7 +125,7 @@ RSpec.describe Webui::RepositoriesController, vcr: true do
     end
 
     context "with a non valid repository name" do
-      let(:action) { post :create, project: user.home_project, repository: '_not/valid/name' }
+      let(:action) { post :create, params: { project: user.home_project, repository: '_not/valid/name' } }
 
       it 'should eq Successfully added repositories' do
         action
@@ -138,7 +138,7 @@ RSpec.describe Webui::RepositoriesController, vcr: true do
 
     context "with a non valid target repository" do
       before do
-        post :create, project: user.home_project, repository: 'valid_name', target_project: another_project, target_repo: 'non_valid_repo'
+        post :create, params: { project: user.home_project, repository: 'valid_name', target_project: another_project, target_repo: 'non_valid_repo' }
       end
 
       it { expect(flash[:error]).to eq("Can not add repository: Path elements is invalid and Path Element: Link can't be blank") }
@@ -148,7 +148,7 @@ RSpec.describe Webui::RepositoriesController, vcr: true do
     context "with a valid repository but with a non valid architecture" do
       before do
         create(:repository, project: another_project)
-        post :create, project: user.home_project, repository: 'valid_name', architectures: ['non_existent_arch']
+        post :create, params: { project: user.home_project, repository: 'valid_name', architectures: ['non_existent_arch'] }
       end
 
       it { expect(flash[:error]).to start_with("Can not add repository: Repository ") }
@@ -158,8 +158,10 @@ RSpec.describe Webui::RepositoriesController, vcr: true do
     context "with a valid repository" do
       before do
         target_repo = create(:repository, project: another_project)
-        post :create, project: user.home_project, repository: 'valid_name', target_project: another_project, target_repo: target_repo.name,
-          architectures: ['i586']
+        post :create, params: {
+            project: user.home_project, repository: 'valid_name',
+            target_project: another_project, target_repo: target_repo.name, architectures: ['i586']
+          }
       end
 
       it { expect(flash[:success]).to eq("Successfully added repository 'valid_name'") }
@@ -169,7 +171,7 @@ RSpec.describe Webui::RepositoriesController, vcr: true do
 
     context "without any repository passed" do
       before do
-        post :create, project: user.home_project
+        post :create, params: { project: user.home_project }
       end
 
       it {
@@ -243,7 +245,7 @@ RSpec.describe Webui::RepositoriesController, vcr: true do
       before do
         login user
         Project.any_instance.stubs(:prepend_kiwi_config).returns(true)
-        post :create_image_repository, project: user.home_project
+        post :create_image_repository, params: { project: user.home_project }
       end
 
       it { expect(flash[:success]).to eq('Successfully added image repository') }

--- a/src/api/spec/controllers/webui/request_controller_spec.rb
+++ b/src/api/spec/controllers/webui/request_controller_spec.rb
@@ -22,18 +22,18 @@ RSpec.describe Webui::RequestController, vcr: true do
 
   describe 'GET show' do
     it 'is successful as nobody' do
-      get :show, number: bs_request.number
+      get :show, params: { number: bs_request.number }
       expect(response).to have_http_status(:success)
     end
 
     it 'assigns @bsreq' do
-      get :show, number: bs_request.number
+      get :show, params: { number: bs_request.number }
       expect(assigns(:bsreq)).to eq(bs_request)
     end
 
     it 'redirects to root_path if request does not exist' do
       login submitter
-      get :show, number: '200000'
+      get :show, params: { number: '200000' }
       expect(flash[:error]).to eq("Can't find request 200000")
       expect(response).to redirect_to(user_show_path(User.current))
     end
@@ -47,7 +47,7 @@ RSpec.describe Webui::RequestController, vcr: true do
       # maintainer. so we'll gonna add a maintainer to the target package
       create(:relationship_package_user, user: submitter, package: target_package)
 
-      get :show, number: bs_request.number
+      get :show, params: { number: bs_request.number }
 
       expect(assigns(:show_project_maintainer_hint)).to eq(true)
     end
@@ -57,7 +57,7 @@ RSpec.describe Webui::RequestController, vcr: true do
 
       create_submit_request
 
-      get :show, number: bs_request.number
+      get :show, params: { number: bs_request.number }
 
       expect(assigns(:show_project_maintainer_hint)).to eq(false)
     end
@@ -70,7 +70,7 @@ RSpec.describe Webui::RequestController, vcr: true do
 
     context "a valid request" do
       before do
-        post :delete_request, project: target_project, package: target_package, description: "delete it!"
+        post :delete_request, params: { project: target_project, package: target_package, description: "delete it!" }
         @bs_request = BsRequest.joins(:bs_request_actions).
           where("bs_request_actions.target_project=? AND bs_request_actions.target_package=? AND type=?",
                 target_project.to_s, target_package.to_s, "delete"
@@ -86,7 +86,7 @@ RSpec.describe Webui::RequestController, vcr: true do
     context "a request causing a APIException" do
       before do
         BsRequest.any_instance.stubs(:save!).raises(APIException, "something happened")
-        post :delete_request, project: target_project, package: target_package, description: "delete it!"
+        post :delete_request, params: { project: target_project, package: target_package, description: "delete it!" }
       end
 
       it { expect(flash[:error]).to eq("something happened") }
@@ -102,8 +102,10 @@ RSpec.describe Webui::RequestController, vcr: true do
     context "with valid parameters" do
       before do
         login(submitter)
-        post :change_devel_request, project: target_project.name, package: target_package.name,
-          devel_project: source_project.name, devel_package: source_package.name, description: "change it!"
+        post :change_devel_request, params: {
+            project: target_project.name, package: target_package.name,
+            devel_project: source_project.name, devel_package: source_package.name, description: "change it!"
+          }
         @bs_request = BsRequest.where(description: "change it!", creator: submitter.login, state: "new").first
       end
 
@@ -127,8 +129,10 @@ RSpec.describe Webui::RequestController, vcr: true do
     context "with invalid devel_package parameter" do
       before do
         login(submitter)
-        post :change_devel_request, project: target_project.name, package: target_package.name,
-          devel_project: source_project.name, devel_package: "non-existant", description: "change it!"
+        post :change_devel_request, params: {
+            project: target_project.name, package: target_package.name,
+            devel_project: source_project.name, devel_package: "non-existant", description: "change it!"
+          }
         @bs_request = BsRequest.where(description: "change it!", creator: submitter.login, state: "new").first
       end
 

--- a/src/api/spec/controllers/webui/search_controller_spec.rb
+++ b/src/api/spec/controllers/webui/search_controller_spec.rb
@@ -13,24 +13,24 @@ RSpec.describe Webui::SearchController, vcr: true do
 
   describe "GET #owner" do
     it 'just returns with blank search text' do
-      get(:owner, { search_text: '', owner: 1 })
+      get :owner, params: { search_text: '', owner: 1 }
       expect(response).to have_http_status(:success)
     end
 
     it 'warns about short search text' do
-      get(:owner, { search_text: 'a', owner: 1 })
+      get :owner, params: { search_text: 'a', owner: 1 }
       expect(controller).to set_flash[:error].to("Search string must contain at least two characters.")
     end
 
     it 'assigns results' do
-      get(:owner, { search_text: 'package', owner: 1 })
+      get :owner, params: { search_text: 'package', owner: 1 }
       expect(assigns(:results)[0].users).to eq({"maintainer"=>["Iggy"]})
     end
 
     it 'assigns results for devel package' do
       package.update_attributes(develpackage: develpackage)
 
-      get(:owner, { search_text: 'package', owner: 1, devel: 'on' })
+      get :owner, params: { search_text: 'package', owner: 1, devel: 'on' }
       expect(assigns(:results)[0].users).to eq({"maintainer"=>["DevelIggy"]})
       expect(assigns(:results)[0].users).not_to eq({"maintainer"=>["Iggy"]})
     end
@@ -44,7 +44,7 @@ RSpec.describe Webui::SearchController, vcr: true do
 
     context 'with a short search text' do
       before do
-        get :index, { search_text: 'a' }
+        get :index, params: { search_text: 'a' }
       end
 
       it { expect(flash[:error]).to eq('Search string must contain at least two characters.') }
@@ -53,7 +53,7 @@ RSpec.describe Webui::SearchController, vcr: true do
 
     context 'request number when string starts with a #' do
       before do
-        get :index, { search_text: '#1' }
+        get :index, params: { search_text: '#1' }
       end
 
       it { is_expected.to redirect_to(controller: :request, action: :show, number: 1) }
@@ -63,7 +63,7 @@ RSpec.describe Webui::SearchController, vcr: true do
       context 'and a package' do
         before do
           Package.stubs(:exists_by_project_and_name).returns(true)
-          get :index, { search_text: "obs://build.opensuse.org/#{user.home_project.name}/i586/1-#{package.name}" }
+          get :index, params: { search_text: "obs://build.opensuse.org/#{user.home_project.name}/i586/1-#{package.name}" }
         end
 
         it { is_expected.to redirect_to(controller: :package, action: :show, project: user.home_project, package: package.name, rev: 1) }
@@ -72,7 +72,7 @@ RSpec.describe Webui::SearchController, vcr: true do
       context 'and a non existent package' do
         before do
           request.env["HTTP_REFERER"] = root_url # Needed for the redirect_to :back
-          get :index, { search_text: "obs://build.opensuse.org/#{user.home_project.name}/i586/1-non_existent_package" }
+          get :index, params: { search_text: "obs://build.opensuse.org/#{user.home_project.name}/i586/1-non_existent_package" }
         end
 
         it { expect(flash[:notice]).to eq('Sorry, this disturl does not compute...') }
@@ -82,7 +82,7 @@ RSpec.describe Webui::SearchController, vcr: true do
 
     context 'with bad search_where' do
       before do
-        get :index, { search_text: 'whatever', name: '0' }
+        get :index, params: { search_text: 'whatever', name: '0' }
       end
 
       it { expect(flash[:error]).to eq("You have to search for whatever in something. Click the advanced button...") }
@@ -92,7 +92,7 @@ RSpec.describe Webui::SearchController, vcr: true do
     context 'with proper parameters but no results' do
       before do
         ThinkingSphinx.stubs(:search).returns([])
-        get :index, { search_text: 'whatever' }
+        get :index, params: { search_text: 'whatever' }
       end
 
       it { expect(flash[:notice]).to eq('Your search did not return any results.') }
@@ -103,7 +103,7 @@ RSpec.describe Webui::SearchController, vcr: true do
     context 'with proper parameters and some results' do
       before do
         ThinkingSphinx.stubs(:search).returns(["Fake result with #{package.name}"])
-        get :index, { search_text: package.name }
+        get :index, params: { search_text: package.name }
       end
 
       it { expect(response).to have_http_status(:success) }

--- a/src/api/spec/controllers/webui/user_controller_spec.rb
+++ b/src/api/spec/controllers/webui/user_controller_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe Webui::UserController do
     shared_examples "a non existent account" do
       before do
         request.env["HTTP_REFERER"] = root_url # Needed for the redirect_to :back
-        get :show, {user: user}
+        get :show, params: { user: user }
       end
 
       it { expect(controller).to set_flash[:error].to("User not found #{user}") }
@@ -34,7 +34,7 @@ RSpec.describe Webui::UserController do
       before { login admin_user }
 
       it "deleted users are shown" do
-        get :show, { user: deleted_user }
+        get :show, params: { user: deleted_user }
         expect(response).to render_template("webui/user/show")
       end
 
@@ -58,13 +58,13 @@ RSpec.describe Webui::UserController do
       end
       describe "showing self" do
         it 'includes requests' do
-          get :show, {user: non_admin_user}
+          get :show, params: { user: non_admin_user }
           expect(assigns(:requests_out)).to eq non_admin_user.outgouing_requests
         end
       end
       describe "showing someone else" do
         it 'does not include requests' do
-          get :show, {user: admin_user}
+          get :show, params: { user: admin_user }
           expect(assigns(:reviews)).to be_nil
         end
       end
@@ -74,7 +74,7 @@ RSpec.describe Webui::UserController do
   describe "GET #user_edit" do
     before do
       login admin_user
-      get :edit, {user: user}
+      get :edit, params: { user: user }
     end
 
     it { is_expected.to render_template("webui/user/edit") }
@@ -86,25 +86,25 @@ RSpec.describe Webui::UserController do
     end
 
     it 'logs in users with correct credentials' do
-      post :do_login, {username: user.login, password: 'buildservice'}
+      post :do_login, params: { username: user.login, password: 'buildservice' }
       expect(response).to redirect_to search_url
     end
 
     it 'tells users about wrong credentials' do
-      post :do_login, {username: user.login, password: 'password123'}
+      post :do_login, params: { username: user.login, password: 'password123' }
       expect(response).to redirect_to user_login_path
       expect(flash[:error]).to eq("Authentication failed")
     end
 
     it 'tells users about wrong state' do
       user.update_attribute('state', :locked)
-      post :do_login, {username: user.login, password: 'buildservice'}
+      post :do_login, params: { username: user.login, password: 'buildservice' }
       expect(response).to redirect_to root_path
       expect(flash[:error]).to eq("Your account is disabled. Please contact the adminsitrator for details.")
     end
 
     it 'assigns the current user' do
-      post :do_login, {username: user.login, password: 'buildservice'}
+      post :do_login, params: { username: user.login, password: 'buildservice' }
       expect(User.current).to eq(user)
       expect(session[:login]).to eq(user.login)
     end
@@ -128,7 +128,7 @@ RSpec.describe Webui::UserController do
       context "with valid data" do
         before do
           login user
-          post :save, { user: user, realname: 'another real name', email: 'new_valid@email.es' }
+          post :save, params: { user: user, realname: 'another real name', email: 'new_valid@email.es' }
           user.reload
         end
 
@@ -141,7 +141,7 @@ RSpec.describe Webui::UserController do
       context "with invalid data" do
         before do
           login user
-          post :save, { user: user, realname: "another real name", email: "" }
+          post :save, params: { user: user, realname: "another real name", email: "" }
           user.reload
         end
 
@@ -156,7 +156,7 @@ RSpec.describe Webui::UserController do
       before do
         login user
         request.env["HTTP_REFERER"] = root_url # Needed for the redirect_to :back
-        post :save, {user: non_admin_user, realname: 'another real name', email: 'new_valid@email.es' }
+        post :save, params: { user: non_admin_user, realname: 'another real name', email: 'new_valid@email.es' }
         non_admin_user.reload
       end
 
@@ -169,7 +169,7 @@ RSpec.describe Webui::UserController do
     context "when admin is updating another user's profile" do
       before do
         login admin_user
-        post :save, {user: user, realname: 'another real name', email: 'new_valid@email.es' }
+        post :save, params: { user: user, realname: 'another real name', email: 'new_valid@email.es' }
         user.reload
       end
 
@@ -213,7 +213,7 @@ RSpec.describe Webui::UserController do
     context "when existing user is already registered with this login" do
       before do
         already_registered_user = create(:confirmed_user, login: 'previous_user')
-        post :register, { login: already_registered_user.login, email: already_registered_user.email, password: 'buildservice' }
+        post :register, params: { login: already_registered_user.login, email: already_registered_user.email, password: 'buildservice' }
       end
 
       it { expect(flash[:error]).not_to be nil }
@@ -223,7 +223,7 @@ RSpec.describe Webui::UserController do
     context "when home project creation enabled" do
       before do
         Configuration.stubs(:allow_user_to_create_home_project).returns(true)
-        post :register, { login: new_user.login, email: new_user.email, password: 'buildservice' }
+        post :register, params: { login: new_user.login, email: new_user.email, password: 'buildservice' }
       end
 
       it { expect(flash[:success]).to eq("The account '#{new_user.login}' is now active.") }
@@ -233,7 +233,7 @@ RSpec.describe Webui::UserController do
     context "when home project creation disabled" do
       before do
         Configuration.stubs(:allow_user_to_create_home_project).returns(false)
-        post :register, { login: new_user.login, email: new_user.email, password: 'buildservice' }
+        post :register, params: { login: new_user.login, email: new_user.email, password: 'buildservice' }
       end
 
       it { expect(flash[:success]).to eq("The account '#{new_user.login}' is now active.") }

--- a/src/api/spec/controllers/webui/webui_controller_spec.rb
+++ b/src/api/spec/controllers/webui/webui_controller_spec.rb
@@ -82,14 +82,14 @@ RSpec.describe Webui::WebuiController do
 
   describe 'require_login before filter' do
     it 'redirects to main page for new users' do
-      get :show, id: 1
+      get :show, params: { id: 1 }
       expect(response).to redirect_to(user_login_path)
       expect(flash[:error]).to eq('Please login to access the requested page.')
     end
 
     it 'does not redirect for a confirmed user' do
       login(create(:confirmed_user, login: 'eisendieter'))
-      get :show, id: 1
+      get :show, params: { id: 1 }
       expect(response).to have_http_status(:success)
     end
   end
@@ -121,7 +121,7 @@ RSpec.describe Webui::WebuiController do
     context 'with invalid project parameter' do
       it 'raises an ActiveRecord::RecordNotFound exception' do
         expect{
-          get :edit, id: 1, project: 'invalid'
+          get :edit, params: { id: 1, project: 'invalid' }
         }.to raise_error(ActiveRecord::RecordNotFound )
       end
     end
@@ -130,7 +130,7 @@ RSpec.describe Webui::WebuiController do
       let(:project) { create(:project) }
 
       it 'sets the correct project' do
-        get :edit, id: 1, project: project.name
+        get :edit, params: { id: 1, project: project.name }
         expect(assigns(:project)).to eq(project)
       end
     end


### PR DESCRIPTION
Running all rspec tests results in several lines of this kind at the
log/tests.log file:

DEPRECATION WARNING: ActionController::TestCase HTTP request methods will accept only
keyword arguments in future Rails versions.

Examples:

get :show, params: { id: 1 }, session: { user_id: 1 }
process :update, method: :post, params: { id: 1 }
 (called from block (2 levels) in <top (required)> at ...