### PR TITLE
Solve bug due to operator precedence

### DIFF
--- a/src/api/app/models/bs_request_permission_check.rb
+++ b/src/api/app/models/bs_request_permission_check.rb
@@ -201,7 +201,7 @@ class BsRequestPermissionCheck
     # general write permission check on the target on accept
     @write_permission_in_this_action = false
     # meta data change shall also be allowed after freezing a project using force:
-    (ignoreLock = opts[:force]) && [:set_bugowner].include?(action.action_type)
+    ignoreLock = opts[:force] && action.action_type == :set_bugowner
     if @target_package
       if User.current.can_modify_package?(@target_package, ignoreLock)
         @write_permission_in_target = true


### PR DESCRIPTION
Solve the bug that @mdeniz pointed out in https://github.com/openSUSE/open-build-service/pull/2241 cause for having misinterpreted the operator precedence. `&&` has higher precedence than `=` which has higher precendence than `and`.

So [here](https://github.com/openSUSE/open-build-service/pull/2241/files#diff-ad86da524d581bdbabc2cff91e0362e0L204) it was written like that:

``` Ruby
ignoreLock = opts[:force] and [:set_bugowner].include? action.action_type
```

which is equivalent to:

``` Ruby
(ignoreLock = opts[:force]) and ([:set_bugowner].include? action.action_type)
```

but it should be any of the next equivalent lines:

``` Ruby
ignoreLock = (opts[:force] and [:set_bugowner].include? action.action_type)
ignoreLock = opts[:force] && [:set_bugowner].include? action.action_type
```

It was not needed to use `include?` neither.