### PR TITLE
[webui] Allow user to toggle full commit dates

### DIFF
--- a/src/api/app/helpers/webui/webui_helper.rb
+++ b/src/api/app/helpers/webui/webui_helper.rb
@@ -38,15 +38,24 @@ module Webui::WebuiHelper
               width: size, height: size, alt: alt, class: css_class)
   end
 
-  def fuzzy_time(time)
+  def fuzzy_time(time, opts = {})
+    output = nil
+
     if Time.now - time < 60
-      return 'now' # rails' 'less than a minute' is a bit long
+      output = 'now' # rails' 'less than a minute' is a bit long
+    else
+      output = time_ago_in_words(time) + ' ago'
     end
-    time_ago_in_words(time) + ' ago'
+
+    if opts["with_fulltime"]
+      output = safe_join(["<span title='#{Time.at(time).to_s}'>".html_safe, "</span>".html_safe], output)
+    end
+
+    output
   end
 
-  def fuzzy_time_string(timestring)
-    fuzzy_time(Time.parse(timestring))
+  def fuzzy_time_string(timestring, opts = {})
+    fuzzy_time(Time.parse(timestring), opts)
   end
 
   def format_projectname(prjname, login)

--- a/src/api/app/views/webui/comment/_show.html.erb
+++ b/src/api/app/views/webui/comment/_show.html.erb
@@ -2,7 +2,7 @@
   <% @comments.walk_tree do |comment, level| %>
     <div class="comment thread_level_<%= level >= 4 ? 4 : level %>">
       <%=  user_with_realname_and_icon(comment.user, no_icon: true, short: true) %>
-      wrote <span class="comment_time"><%= fuzzy_time(comment.created_at) %></span>
+      wrote <span class="comment_time"><%= fuzzy_time(comment.created_at, :with_fulltime) %></span>
       <%= comment_body(comment) %>
       <%= render :partial => 'webui/comment/links', :locals => { comment: comment } %>
       <%= render :partial => 'webui/comment/reply', :locals => { comment: comment, level: 0 } %>

--- a/src/api/app/views/webui/main/_latest_updates.erb
+++ b/src/api/app/views/webui/main/_latest_updates.erb
@@ -20,7 +20,7 @@
                 <%= link_to(elide(update[1], 20), :controller => 'project', :action => 'show', :project => update[1]) %>
             <% end %>
           </td>
-          <td class="nowrap" style="width: 1%"><%= fuzzy_time(update[0]) %></td>
+          <td class="nowrap" style="width: 1%"><%= fuzzy_time(update[0], :with_fulltime) %></td>
         </tr>
     <% end %>
     </tbody>

--- a/src/api/app/views/webui/package/_commit_item.html.erb
+++ b/src/api/app/views/webui/package/_commit_item.html.erb
@@ -21,7 +21,7 @@
             committed
         <% end %>
     <% end %>
-    <%= fuzzy_time(Time.at(commit['time'].to_i)) %> (revision <%= commit['rev'] %>)
+    <%= fuzzy_time(Time.at(commit['time'].to_i), :with_fulltime) %> (revision <%= commit['rev'] %>)
     <% unless commit['user'] == '_service' || commit['comment'].blank? %>
         <pre class="plain"><%= commit['comment'] %></pre>
     <% end %>

--- a/src/api/app/views/webui/package/_files_view.html.erb
+++ b/src/api/app/views/webui/package/_files_view.html.erb
@@ -20,7 +20,7 @@
             </td>
             <td><span class="hidden"><%= file[:size].rjust(10, '0') %></span><%= human_readable_fsize(file[:size]) %>
             </td>
-            <td><span class="hidden"><%= file[:mtime] %></span><%= fuzzy_time_string(Time.at(file[:mtime].to_i).to_s) %>
+            <td><span class="hidden"><%= file[:mtime] %></span><%= fuzzy_time_string(Time.at(file[:mtime].to_i).to_s, :with_fulltime) %>
             </td>
             <!-- limit download for anonymous user to avoid getting killed by crawlers -->
             <td><%= if !User.current.is_nobody? || file[:size].to_i < (4 * 1024 * 1024)

--- a/src/api/app/views/webui/package/binary.html.erb
+++ b/src/api/app/views/webui/package/binary.html.erb
@@ -32,7 +32,7 @@
   <p><strong>Architecture:</strong> <%= @fileinfo.value('arch') %></p>
   <p><strong>Size:</strong> <%= human_readable_fsize(@fileinfo.value(:size).to_i) %></p>
   <p><strong>Build Time:</strong> <%= btime = Time.at(@fileinfo.value(:mtime).to_i)
-  btime.to_s + " (" + fuzzy_time_string(btime.ctime) + ")" %></p>
+  btime.to_s + " (" + fuzzy_time_string(btime.ctime, :with_fulltime) + ")" %></p>
 </div>
 
 <%= render :partial => "deps" %>

--- a/src/api/app/views/webui/package/dependency.html.erb
+++ b/src/api/app/views/webui/package/dependency.html.erb
@@ -30,7 +30,7 @@
   <p><strong>Architecture:</strong> <%= @fileinfo.value :arch %></p>
   <p><strong>Size:</strong> <%= human_readable_fsize(@fileinfo.value(:size).to_i) %></p>
   <p><strong>Build Time:</strong> <%= btime = Time.at(@fileinfo.value(:mtime).to_i)
-  btime.to_s + " (" + fuzzy_time_string(btime.ctime) + ")" %></p>
+  btime.to_s + " (" + fuzzy_time_string(btime.ctime, :with_fulltime) + ")" %></p>
 
 </div>
 

--- a/src/api/app/views/webui/package/rdiff.html.erb
+++ b/src/api/app/views/webui/package/rdiff.html.erb
@@ -15,7 +15,7 @@
 <% unless @last_req.blank? %>
     <p class="error">
       The previous request <%= link_to(@last_req['id'], controller: 'request', action: 'show', id: @last_req['id']) %>
-      was declined <%= fuzzy_time_string(@last_req['when']) %> by
+      was declined <%= fuzzy_time_string(@last_req['when'], :with_fulltime) %> by
       <%= user_with_realname_and_icon(@last_req['decliner'], short: true) %>
       with the following message: </p>
     <pre><%= @last_req['comment'] %></pre>

--- a/src/api/app/views/webui/request/_recent_events_table.html.erb
+++ b/src/api/app/views/webui/request/_recent_events_table.html.erb
@@ -14,7 +14,7 @@
       </td>
       <td class="nowrap" style="width: 1%;">
         <span class="hidden"><%= @bsreq.created_at.to_i %></span>
-        <%= fuzzy_time(@bsreq.created_at) %>
+        <%= fuzzy_time(@bsreq.created_at, :with_fulltime) %>
       </td>
     </tr>
     <tr class="odd">
@@ -35,7 +35,7 @@
         </td>
         <td class="nowrap" style="width: 1%;">
           <span class="hidden"><%= element.created_at.to_i %></span>
-          <%= fuzzy_time(element.created_at) %>
+          <%= fuzzy_time(element.created_at, :with_fulltime) %>
         </td>
       </tr>
       <% unless element.comment.blank? %>

--- a/src/api/app/views/webui/request/_requests_small.html.haml
+++ b/src/api/app/views/webui/request/_requests_small.html.haml
@@ -10,4 +10,4 @@
             = link_to(req.number, controller: :request, action: :show, number: req.number)
             by
             = user_with_realname_and_icon(req.creator, short: true)
-            (#{fuzzy_time(req.created_at)})
+            (#{fuzzy_time(req.created_at, :with_fulltime)})

--- a/src/api/app/views/webui/request/show.html.erb
+++ b/src/api/app/views/webui/request/show.html.erb
@@ -34,7 +34,7 @@
   <div class="grid_6 omega">
     <%= possibly_empty_ul class: 'clean_list' do %>
         <li><%= sprite_tag('user_green') %> Created
-          by <%= user_with_realname_and_icon(@req['creator'], no_icon: true, short: true) %> <%= fuzzy_time(@req['created_at']) %></li>
+          by <%= user_with_realname_and_icon(@req['creator'], no_icon: true, short: true) %> <%= fuzzy_time(@req['created_at'], :with_fulltime) %></li>
         <li><%= sprite_tag('information') %> In
           state <%= link_to @state, { :anchor => 'request_history' }, { :style => "color: #{request_state_color(@state)};" } %></li>
         <% unless @package_maintainers.empty? %>

--- a/src/api/app/views/webui/theme/bratwurst/webui/package/_commit.html.haml
+++ b/src/api/app/views/webui/theme/bratwurst/webui/package/_commit.html.haml
@@ -28,7 +28,7 @@
           = link_to("request #{commit['requestid']}", {:controller => :request, :action => :show, :number => commit['requestid']})
         - else
           authored
-        = fuzzy_time(Time.at(commit['time'].to_i))
+        = fuzzy_time(Time.at(commit['time'].to_i, :with_fulltime))
     .col-md-2
       %span.pull-right
         = link_to({:controller => :package, :action => :rdiff, :package => @package, :project => @project, :rev => commit['rev'], :linkrev => 'base'}) do

--- a/src/api/app/views/webui/theme/bratwurst/webui/package/_files.html.haml
+++ b/src/api/app/views/webui/theme/bratwurst/webui/package/_files.html.haml
@@ -24,7 +24,7 @@
               %td
                 %span.hidden
                   #{file[:mtime]}
-                = fuzzy_time_string(Time.at(file[:mtime].to_i).to_s)
+                = fuzzy_time_string(Time.at(file[:mtime].to_i).to_s, :with_fulltime)
               / limit download for anonymous user to avoid getting killed by crawlers
     - else
       %p

--- a/src/api/spec/helpers/webui/webui_helper_spec.rb
+++ b/src/api/spec/helpers/webui/webui_helper_spec.rb
@@ -3,6 +3,21 @@ require 'rails_helper'
 RSpec.describe Webui::WebuiHelper do
   let(:input) { 'Rocking the Open Build Service' }
 
+  describe '#fuzzy_time' do
+    it 'returns "now" as fuzzy time' do
+      expect(fuzzy_time(Time.now)).to eq('now')
+    end
+
+    it 'makes sure that "now" will not be returned as fuzzy time after 60 seconds' do
+      expect(fuzzy_time(Time.now-61)).not_to eq('now')
+    end
+
+    it 'returns a fuzzy time with an html tag' do
+      time = Time.now
+      expect(fuzzy_time(time, :with_fulltime)).to eq("<span title='#{time}'>now</span>")
+    end
+  end
+
   describe '#elide' do
     it 'does not elide' do
       expect(input).to eq(elide(input, input.length))


### PR DESCRIPTION
This fixes #2164

This allows a user to show the full commit dates instead of just the
fuzzy time view.