### PR TITLE
[webui] Remove build result icon

### DIFF
--- a/src/api/app/views/shared/_single_request.html.erb
+++ b/src/api/app/views/shared/_single_request.html.erb
@@ -53,11 +53,5 @@
   <td>
     <%= link_to(sprite_tag('req-showdiff', title: "Show request ##{req.number}"),
                 { :controller => :request, :action => :show, :number => req.number }, { :class => 'request_link' }) -%>
-    <% if source_package && source_package != :multiple && source_exists %>
-        <%= link_to(sprite_tag('information', title: 'Build results', number: "req_#{req.number}"), source_url) %>
-        <%= javascript_tag do %>
-            setup_buildresult_tooltip('<%= "req_#{req.number}" %>', '<%= buildresult_url %>')
-        <% end %>
-    <% end %>
   </td>
 </tr>


### PR DESCRIPTION
This removes the build result icon from the request table on the user profile. This improves the load time a little bit.

See Trello card for more information about the improvement.