### PR TITLE
[webui] Remove build result icon

### DIFF
--- a/docs/ReleaseNotes-2.7
+++ b/docs/ReleaseNotes-2.7
@@ -106,6 +106,7 @@ Webui Features
   Without this fix, text files such as _log are served with
   `Content-Disposition: attachment`, which makes Firefox prompt the user to
   download the file rather than simply showing the text within the browser.
+* Improve load time when loading open requests for a user on profile page.
 
 
 Notes for systems using systemd:

--- a/src/api/app/views/shared/_single_request.html.erb
+++ b/src/api/app/views/shared/_single_request.html.erb
@@ -5,13 +5,6 @@
    request_type = cp[:request_type]
    target_package = cp[:target_package]
    target_project = cp[:target_project]
-   if source_package && source_package != :multiple && source_project != :multiple
-     source_url = url_for(controller: 'package', action: 'show', project: source_project, package: source_package)
-     buildresult_url = url_for(controller: 'project', action: 'package_buildresult', project: source_project, package: source_package)
-     source_exists = Package.exists_by_project_and_name(source_project, source_package)
-   else
-     source_exists = false
-   end
 -%>
 
 <tr id="tr_request_<%= "#{req.id}" %>" class="request-<%= req.priority %>">
@@ -53,11 +46,5 @@
   <td>
     <%= link_to(sprite_tag('req-showdiff', title: "Show request ##{req.number}"),
                 { :controller => :request, :action => :show, :number => req.number }, { :class => 'request_link' }) -%>
-    <% if source_package && source_package != :multiple && source_exists %>
-        <%= link_to(sprite_tag('information', title: 'Build results', number: "req_#{req.number}"), source_url) %>
-        <%= javascript_tag do %>
-            setup_buildresult_tooltip('<%= "req_#{req.number}" %>', '<%= buildresult_url %>')
-        <% end %>
-    <% end %>
   </td>
 </tr>


### PR DESCRIPTION
This removes the build result icon from the request table on the user profile. This improves the load time a little bit.

See Trello card for more information about the improvement.