### PR TITLE
[backend] implemented debug logging

### DIFF
--- a/src/backend/BSConfig.pm.template
+++ b/src/backend/BSConfig.pm.template
@@ -221,4 +221,7 @@ if (-r $hostconfig) {
 # use modifyrepo_c instead of modifyrepo
 #our $modifyrepo = '/usr/bin/modifyrepo_c';
 
+# print all messages with a lower level than $debuglevel in addition to the normal log messages
+#our $debuglevel = 1;
+
 1;

--- a/src/backend/BSConfiguration.pm
+++ b/src/backend/BSConfiguration.pm
@@ -79,5 +79,5 @@ sub check_configuration_once {
 }
 
 update_from_configuration();
-
+BSUtil::setdebuglevel($BSConfig::debuglevel) if $BSConfig::debuglevel;
 1;

--- a/src/backend/BSUtil.pm
+++ b/src/backend/BSUtil.pm
@@ -754,16 +754,25 @@ sub isotime {
   return sprintf "%04d-%02d-%02d %02d:%02d:%02d", $lt[5] + 1900, $lt[4] + 1, @lt[3,2,1,0];
 }
 
+my $debuglevel;
+sub setdebuglevel {
+  my ($level) = @_;
+  $debuglevel = $level;
+}
+
+
 =head2 printlog - print unified log messages
 
- BSUtil::printlog($message);
+  BSUtil::printlog($message [, $level]);
 
 FORMAT: "YYYY-MM-DD hh:mm:ss [$pid] $message"
 
 =cut
 
 sub printlog {
-  my ($msg) = @_;
+  my ($msg, $level) = @_;
+  return if $level && !($debuglevel && $debuglevel >= $level);
+  $msg = "[debug $level] $msg" if $level;
   printf "%s: %-7s %s\n", isotime(time), "[$$]", $msg;
 }
 

--- a/src/backend/t/0004-BSUtil.t
+++ b/src/backend/t/0004-BSUtil.t
@@ -1,7 +1,11 @@
 use strict;
 use warnings;
 
-use Test::More tests => 43; 
+use Test::More tests => 50;
+use FindBin;
+
+use lib "$FindBin::Bin/lib/";
+use Test::Mock::BSConfig;
 
 require_ok('BSUtil');
 
@@ -172,5 +176,30 @@ my $latin1 = "m\x{c7}gtig";
 ok(BSUtil::checkutf8($latin1) == 0, "Checking if BSUtil spots $latin1 as non-utf8");
 my $utf8_con = BSUtil::str2utf8($latin1);
 ok(BSUtil::checkutf8($utf8_con) == 1, "Checking if BSUtil converts $latin1 to $utf8_con");
+
+my $log_print = "";
+my $test_log_string = "This is the test log string";
+
+# Test the printlog function without loglevel for backwards compatibility.
+do {
+  local *STDOUT;
+  open STDOUT, '>', \$log_print;
+  BSUtil::printlog($test_log_string);
+};
+like($log_print, qr/$test_log_string/, "BSUtil testing the printlog function without loglevel");
+
+# Test the printlog function with loglevel
+for(my $testcount = 0; $testcount <= ($BSConfig::debuglevel + 2); $testcount++) {
+  do {
+    local *STDOUT;
+    open STDOUT, '>', \$log_print;
+    BSUtil::printlog($test_log_string, $testcount);
+  };
+  if ($testcount <= $BSConfig::debuglevel) {
+    like($log_print, qr/$test_log_string/, "BSUtil testing the printlog function wih level $testcount");
+  } else {
+    unlike ($log_print, qr/$test_log_string/, "BSutil printlog should not print level $testcount");
+  }
+}
 
 exit 0;

--- a/src/backend/t/lib/Test/Mock/BSConfig.pm
+++ b/src/backend/t/lib/Test/Mock/BSConfig.pm
@@ -27,5 +27,6 @@ $BSConfig::bsdir = "$FindBin::Bin/data/shared";
 $BSConfig::srcserver = 'srcserver';
 $BSConfig::reposerver = 'reposerver';
 $BSConfig::repodownload = 'http://download.opensuse.org/repositories';
+$BSConfig::debuglevel = 3;
 
 1; 


### PR DESCRIPTION
In addition to default log messages, special debug output can now be generated. 
The configuration is in **_BSConfig.pm_**

```
our $debuglevel = 1;
```
This means all messages marked lower or equal to '1' are printed to the log. 

The call to print log messages with a debug level is. In the example a debug level 1 message is generated: 
```
BSUtil::printlog("This is a debug message", 1)
```

and the resulting log entry is: 
```
2016-10-26 15:11:09: [30375] [debug 1] This is a debug message
```
@M0ses @mlschroe please review

