### PR TITLE
[webui] improve project monitor page

### DIFF
--- a/src/api/app/assets/stylesheets/webui/application/style.css.scss
+++ b/src/api/app/assets/stylesheets/webui/application/style.css.scss
@@ -71,6 +71,15 @@ span.build_result_title {
   }
 }
 
+.status_scheduled_warning a {
+  color: #f30ac4;
+  background-color: #bbb;
+  &:visited, &:hover {
+    color: #f30ac4;
+    background-color: #bbb;
+  }
+}
+
 .status_building a {
   color: #00f;
   background-color: #bbb;

--- a/src/api/app/helpers/webui/buildresult_helper.rb
+++ b/src/api/app/helpers/webui/buildresult_helper.rb
@@ -1,11 +1,13 @@
 module Webui::BuildresultHelper
-  def arch_repo_table_cell(repo, arch, package_name)
+  def arch_repo_table_cell(repo, arch, package_name, enable_help = true)
     status = @statushash[repo][arch][package_name] || { 'package' => package_name }
     status_id = valid_xml_id("id-#{package_name}_#{repo}_#{arch}")
     link_title = status['details']
     if status['code']
       code = status['code']
       theclass = 'status_' + code.gsub(/[- ]/, '_')
+      # special case for scheduled jobs with constraints limiting the workers a lot
+      theclass = "status_scheduled_warning" if code == "scheduled" && !link_title.blank?
     else
       code = ''
       theclass = ' '
@@ -24,7 +26,7 @@ module Webui::BuildresultHelper
                       )
       end
 
-      if status['code']
+      if enable_help && status['code']
         concat " "
         concat sprite_tag('help', title: Buildresult.status_description(status['code']))
       end

--- a/src/api/app/views/webui/project/monitor.html.erb
+++ b/src/api/app/views/webui/project/monitor.html.erb
@@ -108,7 +108,7 @@
             </td>
             <% @repohash.sort.each do |repo, archlist| -%>
               <% archlist.sort.each do |arch| -%>
-                <%= arch_repo_table_cell(repo, arch, packname) %>
+                <%= arch_repo_table_cell(repo, arch, packname, false) %>
               <% end -%>
             <% end -%>
           </tr>


### PR DESCRIPTION
* highlight scheduled jobs which can only be assigned to a minority of workers
  (they will fail soon in case none of the workers are suitable)
* avoid the question mark on project monitor page
  - made it harder to spot differences
  - increased the amount of data needed to be transfered
  - projects with many repos and archs become more collapsed again
  - we have the legend anyway at the bottom.

NOTE: I wasn't able to compile the assets on our test instance, so I couldn't see the color change. would be great if someone verifies that before merge :) thanks. But it is supposed to be orange: ;) 
http://www.spycolor.com/dd7711