### PR TITLE
Fix 100% cpu load in development backend script

### DIFF
--- a/contrib/start_development_backend
+++ b/contrib/start_development_backend
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+trap clean_up SIGHUP SIGINT SIGTERM SIGKILL
+
 #function to help with the usage
 function _print_syntax() {
   me=`basename "$0"`
@@ -50,6 +52,7 @@ while getopts "l:d:w:r:h?" opt; do
   h|\?)
     _print_syntax
     exit 0
+    ;;
   esac
 done
 
@@ -170,7 +173,4 @@ if [ -n "$REDIR_LOG" ]; then
 fi
 echo "If you want to terminate the backend, just hit Ctrl-C"
 
-while true; do
-  trap clean_up SIGHUP SIGINT SIGTERM SIGKILL
-done
-
+wait


### PR DESCRIPTION
Fix "trap" definition, moving it outside the while true loop.

Substitution of while true loop with "wait".

These two changes prevents a loop of 100% cpu load.

Also added ";;" in last option of case.
