### PR TITLE
[ci] rspec: Replace mocha with rspec-mocks

### DIFF
--- a/src/api/spec/controllers/webui/package_controller_spec.rb
+++ b/src/api/spec/controllers/webui/package_controller_spec.rb
@@ -219,7 +219,7 @@ RSpec.describe Webui::PackageController, vcr: true do
 
     context 'with a failure in the backend' do
       before do
-        Buildresult.stubs(:find_hashed).raises(ActiveXML::Transport::Error, 'fake message')
+        allow(Buildresult).to receive(:find_hashed).and_raise(ActiveXML::Transport::Error, 'fake message')
         post :binaries, params: { package: source_package, project: source_project, repository: repo_for_source_project }
       end
 
@@ -229,7 +229,7 @@ RSpec.describe Webui::PackageController, vcr: true do
 
     context 'without build results' do
       before do
-        Buildresult.stubs(:find_hashed).returns(nil)
+        allow(Buildresult).to receive(:find_hashed)
         post :binaries, params: { package: source_package, project: source_project, repository: repo_for_source_project }
       end
 
@@ -241,7 +241,7 @@ RSpec.describe Webui::PackageController, vcr: true do
       render_views
 
       before do
-        Buildresult.stubs(:find).returns(fake_build_results_without_binaries)
+        allow(Buildresult).to receive(:find).and_return(fake_build_results_without_binaries)
         post :binaries, params: { package: source_package, project: source_project, repository: repo_for_source_project }
       end
 
@@ -253,7 +253,7 @@ RSpec.describe Webui::PackageController, vcr: true do
       render_views
 
       before do
-        Buildresult.stubs(:find).returns(fake_build_results)
+        allow(Buildresult).to receive(:find).and_return(fake_build_results)
         post :binaries, params: { package: source_package, project: source_project, repository: repo_for_source_project }
       end
 
@@ -417,7 +417,7 @@ EOT
   describe "DELETE #remove_file" do
     before do
       login(user)
-      Package.any_instance.stubs(:delete_file).returns(true)
+      allow_any_instance_of(Package).to receive(:delete_file).and_return(true)
     end
 
     def remove_file_post
@@ -437,7 +437,7 @@ EOT
 
     context "with not successful backend call" do
       before do
-        Package.any_instance.stubs(:delete_file).raises(ActiveXML::Transport::NotFoundError)
+        allow_any_instance_of(Package).to receive(:delete_file).and_raise(ActiveXML::Transport::NotFoundError)
         remove_file_post
       end
 
@@ -452,7 +452,7 @@ EOT
     end
 
     it "calls delete_file method" do
-      Package.any_instance.expects(:delete_file).with('the_file')
+      allow_any_instance_of(Package).to receive(:delete_file).with('the_file')
       remove_file_post
     end
   end

--- a/src/api/spec/controllers/webui/patchinfo_controller_spec.rb
+++ b/src/api/spec/controllers/webui/patchinfo_controller_spec.rb
@@ -68,7 +68,7 @@ RSpec.describe Webui::PatchinfoController, vcr: true do
 
     context 'when it fails to create the patchinfo package' do
       before do
-        Patchinfo.any_instance.stubs(:create_patchinfo).returns(false)
+        allow_any_instance_of(Patchinfo).to receive(:create_patchinfo).and_return(false)
         post :new_patchinfo, params: { project: user.home_project }
       end
 
@@ -78,7 +78,7 @@ RSpec.describe Webui::PatchinfoController, vcr: true do
 
     context 'when the patchinfo package file is not found' do
       before do
-        Package.any_instance.stubs(:patchinfo).returns(nil)
+        allow_any_instance_of(Package).to receive(:patchinfo)
         post :new_patchinfo, params: { project: user.home_project }
       end
 
@@ -88,8 +88,8 @@ RSpec.describe Webui::PatchinfoController, vcr: true do
 
     context 'when is successfull creating the patchinfo package' do
       before do
-        Buildresult.stubs(:find).returns(fake_build_results)
-        Package.any_instance.stubs(:patchinfo).returns(fake_patchinfo_with_binaries)
+        allow(Buildresult).to receive(:find).and_return(fake_build_results)
+        allow_any_instance_of(Package).to receive(:patchinfo).and_return(fake_patchinfo_with_binaries)
         post :new_patchinfo, params: { project: user.home_project }
       end
 
@@ -117,7 +117,7 @@ RSpec.describe Webui::PatchinfoController, vcr: true do
 
     context 'with a valid patchinfo' do
       it 'updates and redirects to edit_patchinfo' do
-        Patchinfo.any_instance.expects(:cmd_update_patchinfo).with(user.home_project_name, patchinfo_package.name)
+        expect_any_instance_of(Patchinfo).to receive(:cmd_update_patchinfo).with(user.home_project_name, patchinfo_package.name)
         post :updatepatchinfo, params: { project: user.home_project_name, package: patchinfo_package.name }
         expect(response).to redirect_to(action: 'edit_patchinfo', project: user.home_project_name, package: patchinfo_package.name)
       end
@@ -218,7 +218,7 @@ RSpec.describe Webui::PatchinfoController, vcr: true do
     context "without permission to edit the patchinfo-file" do
       before do
         patchinfo_package
-        Suse::Backend.stubs(:put).raises(ActiveXML::Transport::ForbiddenError)
+        allow(Suse::Backend).to receive(:put).and_raise(ActiveXML::Transport::ForbiddenError)
         do_proper_post_save
       end
 
@@ -229,7 +229,7 @@ RSpec.describe Webui::PatchinfoController, vcr: true do
     context "putting the file is taking so long that will raise a timeout" do
       before do
         patchinfo_package
-        Suse::Backend.stubs(:put).raises(Timeout::Error)
+        allow(Suse::Backend).to receive(:put).and_raise(Timeout::Error)
         do_proper_post_save
       end
 
@@ -254,7 +254,7 @@ RSpec.describe Webui::PatchinfoController, vcr: true do
 
     context "if package can't be removed" do
       before do
-        Package.any_instance.stubs(:check_weak_dependencies?).returns(false)
+        allow_any_instance_of(Package).to receive(:check_weak_dependencies?).and_return(false)
         post :remove, params: { project: user.home_project_name, package: patchinfo_package.name }
       end
 

--- a/src/api/spec/controllers/webui/repositories_controller_spec.rb
+++ b/src/api/spec/controllers/webui/repositories_controller_spec.rb
@@ -244,7 +244,7 @@ RSpec.describe Webui::RepositoriesController, vcr: true do
     context "with a distribution called images" do
       before do
         login user
-        Project.any_instance.stubs(:prepend_kiwi_config).returns(true)
+        allow_any_instance_of(Project).to receive(:prepend_kiwi_config).and_return(true)
         post :create_image_repository, params: { project: user.home_project }
       end
 

--- a/src/api/spec/controllers/webui/request_controller_spec.rb
+++ b/src/api/spec/controllers/webui/request_controller_spec.rb
@@ -85,7 +85,7 @@ RSpec.describe Webui::RequestController, vcr: true do
 
     context "a request causing a APIException" do
       before do
-        BsRequest.any_instance.stubs(:save!).raises(APIException, "something happened")
+        allow_any_instance_of(BsRequest).to receive(:save!).and_raise(APIException, "something happened")
         post :delete_request, params: { project: target_project, package: target_package, description: "delete it!" }
       end
 

--- a/src/api/spec/controllers/webui/search_controller_spec.rb
+++ b/src/api/spec/controllers/webui/search_controller_spec.rb
@@ -62,7 +62,7 @@ RSpec.describe Webui::SearchController, vcr: true do
     context 'with search_text starting with obs://' do
       context 'and a package' do
         before do
-          Package.stubs(:exists_by_project_and_name).returns(true)
+          allow(Package).to receive(:exists_by_project_and_name).and_return(true)
           get :index, params: { search_text: "obs://build.opensuse.org/#{user.home_project.name}/i586/1-#{package.name}" }
         end
 
@@ -91,7 +91,7 @@ RSpec.describe Webui::SearchController, vcr: true do
 
     context 'with proper parameters but no results' do
       before do
-        ThinkingSphinx.stubs(:search).returns([])
+        allow(ThinkingSphinx).to receive(:search).and_return([])
         get :index, params: { search_text: 'whatever' }
       end
 
@@ -102,7 +102,7 @@ RSpec.describe Webui::SearchController, vcr: true do
 
     context 'with proper parameters and some results' do
       before do
-        ThinkingSphinx.stubs(:search).returns(["Fake result with #{package.name}"])
+        allow(ThinkingSphinx).to receive(:search).and_return(["Fake result with #{package.name}"])
         get :index, params: { search_text: package.name }
       end
 

--- a/src/api/spec/controllers/webui/user_controller_spec.rb
+++ b/src/api/spec/controllers/webui/user_controller_spec.rb
@@ -222,7 +222,7 @@ RSpec.describe Webui::UserController do
 
     context "when home project creation enabled" do
       before do
-        Configuration.stubs(:allow_user_to_create_home_project).returns(true)
+        allow(Configuration).to receive(:allow_user_to_create_home_project).and_return(true)
         post :register, params: { login: new_user.login, email: new_user.email, password: 'buildservice' }
       end
 
@@ -232,7 +232,7 @@ RSpec.describe Webui::UserController do
 
     context "when home project creation disabled" do
       before do
-        Configuration.stubs(:allow_user_to_create_home_project).returns(false)
+        allow(Configuration).to receive(:allow_user_to_create_home_project).and_return(false)
         post :register, params: { login: new_user.login, email: new_user.email, password: 'buildservice' }
       end
 

--- a/src/api/spec/features/webui/packages_spec.rb
+++ b/src/api/spec/features/webui/packages_spec.rb
@@ -123,9 +123,9 @@ RSpec.feature "Packages", :type => :feature, :js => true do
     end
 
     scenario "via binaries view" do
-      Buildresult.stubs(:find_hashed).
+      allow(Buildresult).to receive(:find_hashed).
         with(project: user.home_project, package: package, repository: repository.name, view: %w(binarylist status)).
-        returns(Xmlhash.parse(fake_buildresult))
+        and_return(Xmlhash.parse(fake_buildresult))
 
       visit package_binaries_path(project: user.home_project, package: package, repository: repository.name)
       click_link("Trigger")

--- a/src/api/spec/features/webui/projects_spec.rb
+++ b/src/api/spec/features/webui/projects_spec.rb
@@ -158,7 +158,7 @@ RSpec.feature "Projects", :type => :feature, :js => true do
     end
 
     scenario "unlock project" do
-      Project.any_instance.stubs(:can_be_unlocked?).returns(false)
+      allow_any_instance_of(Project).to receive(:can_be_unlocked?).and_return(false)
 
       click_link("Unlock project")
       fill_in "comment", with: "Freedom at last!"

--- a/src/api/spec/features/webui/sign_up_spec.rb
+++ b/src/api/spec/features/webui/sign_up_spec.rb
@@ -17,7 +17,7 @@ RSpec.feature "Sign up", :type => :feature do
 
   scenario "User with confirmation" do
     # Configure confirmation for signups
-    ::Configuration.stubs(:registration).returns("confirmation")
+    allow_any_instance_of(::Configuration).to receive(:registration).and_return("confirmation")
 
     visit root_path
 
@@ -31,7 +31,7 @@ RSpec.feature "Sign up", :type => :feature do
 
   scenario "User is denied" do
     # Deny signups
-    ::Configuration.stubs(:registration).returns("deny")
+    allow_any_instance_of(::Configuration).to receive(:registration).and_return("deny")
 
     visit user_register_user_path
 

--- a/src/api/spec/helpers/webui/webui_helper_spec.rb
+++ b/src/api/spec/helpers/webui/webui_helper_spec.rb
@@ -274,7 +274,7 @@ RSpec.describe Webui::WebuiHelper do
     context 'user is not registered' do
       before do
         User.current = create(:user)
-        UnregisteredUser.stubs(:can_register?).raises(APIException)
+        allow(UnregisteredUser).to receive(:can_register?).and_raise(APIException)
       end
 
       it { expect(can_register).to be(false) }

--- a/src/api/spec/mailers/event_mailer_spec.rb
+++ b/src/api/spec/mailers/event_mailer_spec.rb
@@ -2,7 +2,9 @@ require 'rails_helper'
 
 RSpec.describe EventMailer do
   # Needed for X-OBS-URL
-  before { Configuration.any_instance.stubs(:obs_url).returns('https://build.example.com') }
+  before do
+    allow_any_instance_of(Configuration).to receive(:obs_url).and_return('https://build.example.com')
+  end
 
   context 'comment mail' do
     let!(:receiver) { create(:confirmed_user) }

--- a/src/api/spec/models/package_spec.rb
+++ b/src/api/spec/models/package_spec.rb
@@ -19,12 +19,12 @@ RSpec.describe Package, vcr: true do
     end
 
     it 'calls #addKiwiImport if filename ends with kiwi.txz' do
-      Service.any_instance.expects(:addKiwiImport).once
+      expect_any_instance_of(Service).to receive(:addKiwiImport).once
       package.save_file({ filename: 'foo.kiwi.txz' })
     end
 
     it 'does not call #addKiwiImport if filename ends not with kiwi.txz' do
-      Service.any_instance.expects(:addKiwiImport).never
+      expect_any_instance_of(Service).not_to receive(:addKiwiImport)
       package.save_file({ filename: 'foo.spec' })
     end
   end

--- a/src/api/spec/models/project_spec.rb
+++ b/src/api/spec/models/project_spec.rb
@@ -329,8 +329,8 @@ RSpec.describe Project do
 
   describe "#store" do
     before do
-      project.stubs(:save!).returns(true)
-      project.stubs(:write_to_backend).returns(true)
+      allow(project).to receive(:save!).and_return(true)
+      allow(project).to receive(:write_to_backend).and_return(true)
       project.commit_opts = { comment: 'the comment' }
     end
 

--- a/src/api/spec/models/user_spec.rb
+++ b/src/api/spec/models/user_spec.rb
@@ -91,13 +91,13 @@ RSpec.describe User do
 
   describe 'home project creation' do
     it 'creates a home project by default if allow_user_to_create_home_project is enabled' do
-      Configuration.stubs(:allow_user_to_create_home_project).returns(true)
+      allow(Configuration).to receive(:allow_user_to_create_home_project).and_return(true)
       user = create(:confirmed_user, login: 'random_name')
       expect(user.home_project).not_to be_nil
     end
 
     it "doesn't creates a home project if allow_user_to_create_home_project is disabled" do
-      Configuration.stubs(:allow_user_to_create_home_project).returns(false)
+      allow(Configuration).to receive(:allow_user_to_create_home_project).and_return(false)
       user = create(:confirmed_user, login: 'another_random_name')
       expect(user.home_project).to be_nil
     end

--- a/src/api/spec/script/db_checker.rb
+++ b/src/api/spec/script/db_checker.rb
@@ -6,12 +6,12 @@ RSpec.describe DB::Checker do
 
   describe '#warn_for_rerun' do
     it 'shows a warning message if failed' do
-      checker.stubs(:failed).returns(true)
+      allow(checker).to receive(:failed).and_return(true)
       expect { checker.warn_for_rerun }.to output(/WARNING/).to_stdout
     end
 
     it 'shows a greeting message if worked' do
-      checker.stubs(:failed).returns(false)
+      allow(checker).to receive(:failed).and_return(false)
       expect { checker.warn_for_rerun }.to output(/All checks passed/).to_stdout
     end
   end
@@ -52,7 +52,7 @@ RSpec.describe DB::Checker do
   describe "#check_foreign_keys" do
     context "without inconsistent records" do
       before do
-        checker.stubs(:check_foreign_key).returns([])
+        allow(checker).to receive(:check_foreign_key).and_return([])
       end
 
       it { expect { checker.check_foreign_keys }.to output(/OK/).to_stdout }
@@ -61,8 +61,8 @@ RSpec.describe DB::Checker do
 
     context "with inconsistent records" do
       before do
-        checker.stubs(:check_foreign_key).returns([1, 2, 3])
-        checker.stubs(:ask_for_fixing).returns(nil)
+        allow(checker).to receive(:check_foreign_key).and_return([1, 2, 3])
+        allow(checker).to receive(:ask_for_fixing)
       end
 
       it { expect { checker.check_foreign_keys }.to output(/FAIL/).to_stdout }

--- a/src/api/spec/spec_helper.rb
+++ b/src/api/spec/spec_helper.rb
@@ -25,7 +25,6 @@ RSpec.configure do |config|
     expectations.syntax = :expect
   end
 
-  config.mock_framework = :mocha
   # rspec-mocks config goes here.
 
   # Allows RSpec to persist some state between runs in order to support


### PR DESCRIPTION
Once the old test suite is gone, we can even remove the mocha gem
dependency.

https://relishapp.com/rspec/rspec-mocks/v/3-5/docs/basics
https://github.com/rspec/rspec-mocks
