### PR TITLE
[api] check_is_child failed when type was nil

### DIFF
--- a/src/api/app/models/comment.rb
+++ b/src/api/app/models/comment.rb
@@ -83,7 +83,7 @@ class Comment < ApplicationRecord
   private
 
   def check_is_child
-    unless type.safe_constantize.try(:superclass) == Comment
+    if type && type.safe_constantize.try(:superclass) != Comment
       errors[:type] << "is reserved for storing the inheritance class which was not found"
     end
   end


### PR DESCRIPTION
The `check_is_child` validation failed when there was not type as the function `safe_constantize` is not defined for `nil`. :worried: 