### PR TITLE
Initial support for systemd unit files

### DIFF
--- a/dist/systemd/obsdispatcher.service
+++ b/dist/systemd/obsdispatcher.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=OBS job dispatcher
+After=network.target
+
+[Service]
+EnvironmentFile=/etc/sysconfig/obs-server
+ExecStart=/usr/lib/obs/server/bs_dispatch
+ExecReload=/bin/kill -HUP $MAINPID
+
+[Install]
+WantedBy=multi-user.target

--- a/dist/systemd/obsdodup.service
+++ b/dist/systemd/obsdodup.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=OBS dodup, updates download on demand metadata
+After=network.target
+
+[Service]
+EnvironmentFile=/etc/sysconfig/obs-server
+ExecStart=/usr/lib/obs/server/bs_dodup
+ExecStop=/usr/lib/obs/server/bs_dodup --stop
+ExecReload=/usr/lib/obs/server/bs_dodup --restart
+
+[Install]
+WantedBy=multi-user.target

--- a/dist/systemd/obspublisher.service
+++ b/dist/systemd/obspublisher.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=OBS repository publisher
+After=network.target
+
+[Service]
+EnvironmentFile=/etc/sysconfig/obs-server
+ExecStart=/usr/lib/obs/server/bs_publish
+ExecReload=/bin/kill -HUP $MAINPID
+
+[Install]
+WantedBy=multi-user.target

--- a/dist/systemd/obsrepserver.service
+++ b/dist/systemd/obsrepserver.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=OBS repository server
+After=network.target
+
+[Service]
+EnvironmentFile=/etc/sysconfig/obs-server
+ExecStart=/usr/lib/obs/server/bs_repserver
+ExecReload=/bin/kill -HUP $MAINPID
+
+[Install]
+WantedBy=multi-user.target

--- a/dist/systemd/obsscheduler@.service
+++ b/dist/systemd/obsscheduler@.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=OBS scheduler service for %I
+After=network.target
+
+[Service]
+EnvironmentFile=/etc/sysconfig/obs-server
+ExecStart=/usr/lib/obs/server/bs_sched %i
+ExecStop=/usr/lib/obs/server/bs_admin --shutdown-scheduler %i
+
+[Install]
+WantedBy=multi-user.target

--- a/dist/systemd/obsservice.service
+++ b/dist/systemd/obsservice.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=OBS source service server
+After=network.target
+
+[Service]
+EnvironmentFile=/etc/sysconfig/obs-server
+ExecStart=/usr/lib/obs/server/bs_service
+ExecReload=/bin/kill -HUP $MAINPID
+
+[Install]
+WantedBy=multi-user.target

--- a/dist/systemd/obssigner.service
+++ b/dist/systemd/obssigner.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=OBS signer service
+After=network.target
+
+[Service]
+EnvironmentFile=/etc/sysconfig/obs-server
+ExecStart=/usr/lib/obs/server/bs_signer
+ExecReload=/bin/kill -HUP $MAINPID
+
+[Install]
+WantedBy=multi-user.target

--- a/dist/systemd/obssrcserver.service
+++ b/dist/systemd/obssrcserver.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=OBS source repository server
+After=network.target
+
+[Service]
+EnvironmentFile=/etc/sysconfig/obs-server
+ExecStart=/usr/lib/obs/server/bs_srcserver
+ExecReload=/bin/kill -HUP $MAINPID
+
+[Install]
+WantedBy=multi-user.target

--- a/dist/systemd/obswarden.service
+++ b/dist/systemd/obswarden.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=OBS warden, monitors the workers
+After=network.target
+
+[Service]
+EnvironmentFile=/etc/sysconfig/obs-server
+ExecStart=/usr/lib/obs/server/bs_warden
+ExecReload=/bin/kill -HUP $MAINPID
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
This are the systemd unit files that we are using in open-build-service
Debian package. Most of the service units behave similar to the sysvinit
scripts, however it is to note that scheduler service is a templated
service unit to be able to launch an instance per architecture.

Note that logging facility changes to use systemd journal and drop the
wrapper support for logging in the OBSDIR/log directory.

Also note that not all services have been ported to systemd, so there are
a few services missing such obsworker.

In this patch, the systemd files are not being used in the packaging scripts.
Those would need to be enabled if someone wants to switch to them.

Signed-off-by: Héctor Orón Martínez <hector.oron@collabora.co.uk>