### PR TITLE
[api] fix raising permissions as admin

### DIFF
--- a/src/api/app/controllers/source_controller.rb
+++ b/src/api/app/controllers/source_controller.rb
@@ -689,10 +689,10 @@ class SourceController < ApplicationController
         return
       end
 
-      if pkg and not pkg.disabled_for?('sourceaccess', nil, nil)
-        if FlagHelper.xml_disabled_for?(rdata, 'sourceaccess')
-          render_error :status => 403, :errorcode => 'change_package_protection_level',
-                       :message => 'admin rights are required to raise the protection level of a package'
+      if pkg && !pkg.disabled_for?('sourceaccess', nil, nil)
+        if FlagHelper.xml_disabled_for?(rdata, 'sourceaccess') && !User.current.is_admin?
+          render_error status: 403, errorcode: 'change_package_protection_level',
+                       message: 'admin rights are required to raise the protection level of a package'
           return
         end
       end

--- a/src/api/app/models/project.rb
+++ b/src/api/app/models/project.rb
@@ -527,18 +527,18 @@ class Project < ActiveRecord::Base
 
     # check for raising read access permissions, which can't get ensured atm
     unless self.new_record? || self.disabled_for?('access', nil, nil)
-      if FlagHelper.xml_disabled_for?(xmlhash, 'access')
+      if FlagHelper.xml_disabled_for?(xmlhash, 'access') && !User.current.is_admin?
         raise ForbiddenError.new
       end
     end
     unless self.new_record? || self.disabled_for?('sourceaccess', nil, nil)
-      if FlagHelper.xml_disabled_for?(xmlhash, 'sourceaccess')
+      if FlagHelper.xml_disabled_for?(xmlhash, 'sourceaccess') && !User.current.is_admin?
         raise ForbiddenError.new
       end
     end
     new_record = self.new_record?
-    if ::Configuration.default_access_disabled == true and not new_record
-      if self.disabled_for?('access', nil, nil) and not FlagHelper.xml_disabled_for?(xmlhash, 'access')
+    if ::Configuration.default_access_disabled == true && !new_record
+      if self.disabled_for?('access', nil, nil) && !FlagHelper.xml_disabled_for?(xmlhash, 'access') && !User.current.is_admin?
         raise ForbiddenError.new
       end
     end

--- a/src/api/test/functional/read_permission_test.rb
+++ b/src/api/test/functional/read_permission_test.rb
@@ -502,7 +502,12 @@ class ReadPermissionTest < ActionDispatch::IntegrationTest
     put url_for(:controller => :source, :action => :update_package_meta, :project => "home:adrian:PublicProject", :package => "pack"),
         '<package name="pack" project="home:adrian:PublicProject"> <title/> <description/>  <sourceaccess><disable/></sourceaccess>  </package>'
     assert_response 403
-    assert_xml_tag :tag => "status", :attributes => { :code => "change_package_protection_level" }
+    assert_xml_tag tag: "status", attributes: { code: "change_package_protection_level" }
+    # but works as admin
+    login_king
+    put url_for(controller: :source, action: :update_package_meta, project: "home:adrian:PublicProject", package: "pack"),
+        '<package name="pack" project="home:adrian:PublicProject"> <title/> <description/>  <sourceaccess><disable/></sourceaccess>  </package>'
+    assert_response :success
     delete "/source/home:adrian:Project"
     assert_response :success
     delete "/source/home:adrian:PublicProject"
@@ -518,7 +523,11 @@ class ReadPermissionTest < ActionDispatch::IntegrationTest
     put url_for(:controller => :source, :action => :update_project_meta, :project => "home:adrian:Project"),
         '<project name="home:adrian:Project"> <title/> <description/> <access><disable/></access> </project>'
     assert_response 403
-    assert_xml_tag :tag => "status", :attributes => { :code => "change_project_protection_level" }
+    assert_xml_tag tag: "status", attributes: { code: "change_project_protection_level" }
+    login_king
+    put url_for(controller: :source, action: :update_project_meta, project: "home:adrian:Project"),
+        '<project name="home:adrian:Project"> <title/> <description/> <access><disable/></access> </project>'
+    assert_response :success
     delete "/source/home:adrian:Project"
     assert_response :success
   end


### PR DESCRIPTION
Hiding sources later on was allowed for admins (though it is still not secure
and a bad idea)

Conflicts:
	src/api/app/controllers/source_controller.rb
	src/api/app/models/project.rb
	src/api/test/functional/read_permission_test.rb