### PR TITLE
[api] Get rid of the nobody user thread caching

### DIFF
--- a/src/api/app/models/user.rb
+++ b/src/api/app/models/user.rb
@@ -299,11 +299,10 @@ class User < ApplicationRecord
   end
 
   def self.find_nobody!
-    Thread.current[:nobody_user] ||= User.create_with(email: "nobody@localhost",
-                                                      realname: "Anonymous User",
-                                                      state: 'locked',
-                                                      password: "123456").find_or_create_by(login: nobody_login)
-    Thread.current[:nobody_user]
+    User.create_with(email: "nobody@localhost",
+                     realname: "Anonymous User",
+                     state: 'locked',
+                     password: "123456").find_or_create_by(login: nobody_login)
   end
 
   def self.find_by_login!(login)


### PR DESCRIPTION
We are catching the nobody user in the `User#find_nobody` method and it is
only used here. It is confusing and  the Rails query cache will cache
this too, so we will only do one more query per thread.

Also, the https://github.com/openSUSE/open-build-service/pull/2247 PR is
failing because of this way of caching users and how the database is
cleaned, and it was difficult to get to know what the error was.