### PR TITLE
[ci] Make the test database consistent

### DIFF
--- a/src/api/spec/support/database_cleaner.rb
+++ b/src/api/spec/support/database_cleaner.rb
@@ -1,6 +1,8 @@
 require 'database_cleaner'
 
 RSpec.configure do |config|
+  # We are using factory_girl to set up everything the test needs up front,
+  # instead of loading a set of fixtures in the beginning of the suite
   config.use_transactional_fixtures = false
 
   config.before(:suite) do
@@ -11,18 +13,23 @@ RSpec.configure do |config|
     # and is seeded
     load "#{Rails.root}/db/seeds.rb"
     Rails.logger.level = log_level
+    # Truncate all tables loaded in db/seeds.rb, except the static ones, in the
+    # beginning to be consistent.
+    DatabaseCleaner.clean_with(:truncation, except: %w(roles roles_static_permissions
+                                                       static_permissions configurations
+                                                       architectures attrib_types
+                                                       attrib_namespaces issue_trackers))
   end
 
   config.before(:each) do |example|
-    # For feature test we use truncation instead of transactions
-    # because the test suite and the capybara driver do not use
-    # the same server thread.
+    # For feature test we use truncation instead of transactions because the
+    # test suite and the capybara driver do not use the same server thread.
     if example.metadata[:type] == :feature
-      # omit truncating what we have set up in db/seeds.rb
+      # Omit truncating what we have set up in db/seeds.rb except users and roles_user
       DatabaseCleaner.strategy = :truncation, { except: %w(roles roles_static_permissions
                                                            static_permissions configurations
-                                                           architectures attrib_types attrib_namespaces
-                                                           issue_trackers) }
+                                                           architectures attrib_types
+                                                           attrib_namespaces issue_trackers) }
     else
       DatabaseCleaner.strategy = :transaction
     end


### PR DESCRIPTION
The database content was not the same at the beginning of every test. The `users` and `roles_users` tables had what they loads from the seeds in the first test and it kept like that until a feature was run. After that there was nothing in this two tables when a new test starts.

I also added some comments to help to understand how the development table is loaded.