### PR TITLE
Enable the Rails/FindBy cop in Rubocop && Refactor UpdateinfoCounter#find_or_create

### DIFF
--- a/src/api/.rubocop.yml
+++ b/src/api/.rubocop.yml
@@ -7,6 +7,9 @@ AllCops:
     - 'lib/templates/**/*'
     - 'vendor/bundle/**/*'
 
+Rails/FindBy:
+  Enabled: true
+
 # Someday we should add copyrights
 Style/Copyright:
   Enabled: false

--- a/src/api/.rubocop_todo.yml
+++ b/src/api/.rubocop_todo.yml
@@ -216,13 +216,6 @@ Rails/Exit:
     - 'config/deploy.rb'
     - 'lib/memory_dumper.rb'
 
-# Offense count: 25
-# Cop supports --auto-correct.
-# Configuration parameters: Include.
-# Include: app/models/**/*.rb
-Rails/FindBy:
-  Enabled: false
-
 # Offense count: 18
 # Cop supports --auto-correct.
 # Configuration parameters: Include.

--- a/src/api/app/controllers/attribute_controller.rb
+++ b/src/api/app/controllers/attribute_controller.rb
@@ -107,7 +107,7 @@ class AttributeController < ApplicationController
     end
 
     if request.get?
-      @at = ans.attrib_types.where(name: name).first
+      @at = ans.attrib_types.find_by(name: name)
       unless @at
         render_error message: "Unknown attribute '#{namespace}':'#{name}'",
           status: 404, errorcode: "unknown_attribute"

--- a/src/api/app/controllers/source_controller.rb
+++ b/src/api/app/controllers/source_controller.rb
@@ -1294,7 +1294,7 @@ class SourceController < ApplicationController
 
     opts={}
     at=AttribType.find_by_namespace_and_name!("OBS", "MakeOriginOlder")
-    opts[:makeoriginolder]=true if project.attribs.where(attrib_type_id: at.id).first # object or nil
+    opts[:makeoriginolder]=true if project.attribs.find_by(attrib_type: at) # object or nil
     opts[:makeoriginolder]=true if params[:makeoriginolder]
     instantiate_container(project, opackage.update_instance, opts)
     render_ok

--- a/src/api/app/jobs/consistency_check.rb
+++ b/src/api/app/jobs/consistency_check.rb
@@ -162,7 +162,7 @@ class ConsistencyCheckJob < ApplicationJob
           errors << "Invalid package name #{name} in project #{project.name}\n"
           if fix
             # just remove it, the backend won't accept it anyway
-            project.packages.where(name: name).first.destroy
+            project.packages.find_by(name: name).destroy
             next
           end
         end

--- a/src/api/app/models/attrib.rb
+++ b/src/api/app/models/attrib.rb
@@ -37,7 +37,7 @@ class Attrib < ApplicationRecord
 
   #### Class methods using self. (public and then private)
   def self.find_by_container_and_fullname( container, fullname )
-    container.attribs.where(attrib_type: AttribType.find_by_name!(fullname)).first
+    container.attribs.find_by(attrib_type: AttribType.find_by_name!(fullname))
   end
 
   #### To define class methods as private use private_class_method

--- a/src/api/app/models/binary_release.rb
+++ b/src/api/app/models/binary_release.rb
@@ -127,7 +127,7 @@ class BinaryRelease < ApplicationRecord
   end
 
   def product_medium
-    repository.product_medium.where(name: medium).first
+    repository.product_medium.find_by(name: medium)
   end
 
   # renders all values, which are used as identifier of a binary entry.

--- a/src/api/app/models/branch_package.rb
+++ b/src/api/app/models/branch_package.rb
@@ -230,7 +230,7 @@ class BranchPackage
       end
       if params[:request]
         ans = AttribNamespace.find_by_name 'OBS'
-        at = ans.attrib_types.where(name: 'RequestCloned').first
+        at = ans.attrib_types.find_by(name: 'RequestCloned')
 
         tprj = Project.get_by_name @target_project
         a = Attrib.new(project: tprj, attrib_type: at)
@@ -389,7 +389,7 @@ class BranchPackage
     update_project = update_project_for_project(prj)
     return unless update_project
 
-    pa = update_project.packages.where(name: pkg_name).first
+    pa = update_project.packages.find_by(name: pkg_name)
     if pa
       # We have a package in the update project already, take that
       p[:package] = pa

--- a/src/api/app/models/bs_request.rb
+++ b/src/api/app/models/bs_request.rb
@@ -419,7 +419,7 @@ class BsRequest < ApplicationRecord
       if action.source_project && action.is_maintenance_release?
         if source_project.kind_of?(Project)
           at = AttribType.find_by_namespace_and_name!('OBS', 'EmbargoDate')
-          attrib = source_project.attribs.where(attrib_type_id: at.id).first
+          attrib = source_project.attribs.find_by(attrib_type: at)
           v = attrib.values.first if attrib
           if defined?(v) && v
             begin

--- a/src/api/app/models/bs_request_action.rb
+++ b/src/api/app/models/bs_request_action.rb
@@ -808,7 +808,7 @@ class BsRequestAction < ApplicationRecord
       end
       if action_type == :submit && tprj.kind_of?(Project)
         at = AttribType.find_by_namespace_and_name!("OBS", "MakeOriginOlder")
-        self.makeoriginolder = true if tprj.attribs.where(attrib_type_id: at.id).first
+        self.makeoriginolder = true if tprj.attribs.find_by(attrib_type: at)
       end
       # allow cleanup only, if no devel package reference
       if sourceupdate == 'cleanup' && sprj.class != Project && !skip_source

--- a/src/api/app/models/event_find_subscribers.rb
+++ b/src/api/app/models/event_find_subscribers.rb
@@ -83,7 +83,7 @@ class EventFindSubscribers
   end
 
   def user_subscribed_to_group_email?(group, user)
-    GroupsUser.where(group: group, user: user).first.email
+    GroupsUser.find_by(group: group, user: user).email
   end
 
   def filter_toconsider

--- a/src/api/app/models/flag.rb
+++ b/src/api/app/models/flag.rb
@@ -55,20 +55,20 @@ class Flag < ApplicationRecord
   end
 
   def default_status
-    all_flag = main_object.flags.where("flag = ? AND repo IS NULL AND architecture_id IS NULL", flag).first
-    repo_flag = main_object.flags.where("flag = ? AND repo = ? AND architecture_id IS NULL", flag, repo).first
-    arch_flag = main_object.flags.where("flag = ? AND repo IS NULL AND architecture_id = ?", flag, architecture_id).first
-    same_flag = main_object.flags.where("flag = ? AND repo = ? AND architecture_id = ?", flag, repo, architecture_id).first
+    all_flag = main_object.flags.find_by("flag = ? AND repo IS NULL AND architecture_id IS NULL", flag)
+    repo_flag = main_object.flags.find_by("flag = ? AND repo = ? AND architecture_id IS NULL", flag, repo)
+    arch_flag = main_object.flags.find_by("flag = ? AND repo IS NULL AND architecture_id = ?", flag, architecture_id)
+    same_flag = main_object.flags.find_by("flag = ? AND repo = ? AND architecture_id = ?", flag, repo, architecture_id)
     # Package settings only override project settings...
     if main_object.kind_of? Package
       # do the same_flag check first to see if all_flag or same_flag had been set on package level, they *both* overwrite the project level
-      same_flag = main_object.project.flags.where("flag = ? AND repo = ? AND architecture_id = ?", flag, repo, architecture_id).first unless
+      same_flag = main_object.project.flags.find_by("flag = ? AND repo = ? AND architecture_id = ?", flag, repo, architecture_id) unless
         all_flag || same_flag || repo_flag || arch_flag
-      repo_flag = main_object.project.flags.where("flag = ? AND repo = ? AND architecture_id IS NULL", flag, repo).first unless
+      repo_flag = main_object.project.flags.find_by("flag = ? AND repo = ? AND architecture_id IS NULL", flag, repo) unless
         all_flag || repo_flag || arch_flag
-      arch_flag = main_object.project.flags.where("flag = ? AND repo IS NULL AND architecture_id = ?", flag, architecture_id).first unless
+      arch_flag = main_object.project.flags.find_by("flag = ? AND repo IS NULL AND architecture_id = ?", flag, architecture_id) unless
         all_flag || arch_flag
-      all_flag = main_object.project.flags.where("flag = ? AND repo IS NULL AND architecture_id IS NULL", flag).first unless all_flag
+      all_flag = main_object.project.flags.find_by("flag = ? AND repo IS NULL AND architecture_id IS NULL", flag) unless all_flag
     end
 
     return same_flag.status if same_flag

--- a/src/api/app/models/group_maintainer.rb
+++ b/src/api/app/models/group_maintainer.rb
@@ -10,7 +10,7 @@ class GroupMaintainer < ApplicationRecord
 
   validate :validate_duplicates, on: :create
   def validate_duplicates
-    if GroupMaintainer.where("user_id = ? AND group_id = ?", user, group).first
+    if GroupMaintainer.find_by(user: user, group: group)
       errors.add(:user, "Maintainer already has this group")
     end
   end

--- a/src/api/app/models/groups_user.rb
+++ b/src/api/app/models/groups_user.rb
@@ -10,7 +10,7 @@ class GroupsUser < ApplicationRecord
 
   validate :validate_duplicates, on: :create
   def validate_duplicates
-    if GroupsUser.where("user_id = ? AND group_id = ?", user, group).first
+    if GroupsUser.find_by(user: user, group: group)
       errors.add(:user, "User already has this group")
     end
   end

--- a/src/api/app/models/incident_updateinfo_counter_value.rb
+++ b/src/api/app/models/incident_updateinfo_counter_value.rb
@@ -3,7 +3,7 @@ class IncidentUpdateinfoCounterValue < ApplicationRecord
   belongs_to :project
 
   def self.find_or_create(time, updateinfo_counter, project)
-    icv = IncidentUpdateinfoCounterValue.where(updateinfo_counter:updateinfo_counter, project: project).first
+    icv = IncidentUpdateinfoCounterValue.find_by(updateinfo_counter: updateinfo_counter, project: project)
     return icv if icv
 
     # not yet released, get an uniq counter value for this incident and scheme

--- a/src/api/app/models/linked_project.rb
+++ b/src/api/app/models/linked_project.rb
@@ -13,7 +13,7 @@ class LinkedProject < ApplicationRecord
       errors.add(:linked_db_project, "It must be linked to somewhere")
     elsif linked_db_project && linked_remote_project_name
       errors.add(:linked_remote_project_name, "Can't have a local and a remote link")
-    elsif LinkedProject.where("db_project_id = ? AND linked_db_project_id = ?", project, linked_db_project).first
+    elsif LinkedProject.find_by(project: project, linked_db_project: linked_db_project)
       errors.add(:project, "Already linked with that project")
     end
   end

--- a/src/api/app/models/owner.rb
+++ b/src/api/app/models/owner.rb
@@ -51,7 +51,7 @@ class Owner
     # search in each marked project
     owners = []
     projects.each do |project|
-      attrib = project.attribs.where(attrib_type_id: at.id).first
+      attrib = project.attribs.find_by(attrib_type: at)
       filter = %w(maintainer bugowner)
       devel  = true
       if params[:filter]

--- a/src/api/app/models/package.rb
+++ b/src/api/app/models/package.rb
@@ -310,7 +310,7 @@ class Package < ApplicationRecord
   def check_write_access(ignoreLock = nil)
     # test _product permissions if any other _product: subcontainer is used
     obj = self
-    obj = project.packages.where(name: "_product").first if name =~ /\A_product:\w[-+\w\.]*\z/
+    obj = project.packages.find_by(name: "_product") if name =~ /\A_product:\w[-+\w\.]*\z/
     return true if User.current.can_modify_package? obj, ignoreLock
     false
   end

--- a/src/api/app/models/project.rb
+++ b/src/api/app/models/project.rb
@@ -370,7 +370,7 @@ class Project < ApplicationRecord
   # FIXME: to be obsoleted, this function is not throwing exceptions on problems
   # use get_by_name or exists_by_name instead
   def self.find_by_name(name, opts = {})
-    dbp = where(name: name).first
+    dbp = find_by(name: name)
 
     return if dbp.nil?
     return if !opts[:skip_check_access] && !check_access?(dbp)

--- a/src/api/app/models/repository.rb
+++ b/src/api/app/models/repository.rb
@@ -42,7 +42,7 @@ class Repository < ApplicationRecord
 
   # FIXME: Don't lie, it's find_or_create_by_project_and_name_if_project_is_remote
   def self.find_by_project_and_name( project, repo )
-    result = not_remote.joins(:project).where(projects: {name: project}, name: repo).first
+    result = not_remote.joins(:project).find_by(projects: {name: project}, name: repo)
     return result unless result.nil?
 
     # no local repository found, check if remote repo possible

--- a/src/api/app/models/tag.rb
+++ b/src/api/app/models/tag.rb
@@ -37,7 +37,7 @@ class Tag < ApplicationRecord
   protected
 
   def not_blacklisted
-    blacklist = BlacklistTag.where("name = ?", name).first
+    blacklist = BlacklistTag.find_by(name: name)
     errors.add(:name, "The tag is blacklisted!") if blacklist
   end
 end

--- a/src/api/app/models/updateinfo_counter.rb
+++ b/src/api/app/models/updateinfo_counter.rb
@@ -1,15 +1,10 @@
 class UpdateinfoCounter < ApplicationRecord
   def self.find_or_create(time, template)
-    year = month = day = nil
-
     year  = time.year  if template =~ /%Y/
     month = time.month if template =~ /%M/
     day   = time.day   if template =~ /%D/
 
-    r = UpdateinfoCounter.find_by(year: year, month: month, day: day)
-    r = UpdateinfoCounter.create(year: year, month: month, day: day) unless r
-
-    r
+    UpdateinfoCounter.find_or_create_by(year: year, month: month, day: day)
   end
 
   def increase

--- a/src/api/app/models/updateinfo_counter.rb
+++ b/src/api/app/models/updateinfo_counter.rb
@@ -6,7 +6,7 @@ class UpdateinfoCounter < ApplicationRecord
     month = time.month if template =~ /%M/
     day   = time.day   if template =~ /%D/
 
-    r = UpdateinfoCounter.where(year: year, month: month, day: day).first
+    r = UpdateinfoCounter.find_by(year: year, month: month, day: day)
     r = UpdateinfoCounter.create(year: year, month: month, day: day) unless r
 
     r

--- a/src/api/app/models/user.rb
+++ b/src/api/app/models/user.rb
@@ -542,7 +542,7 @@ class User < ApplicationRecord
   def has_global_permission?(perm_string)
     logger.debug "has_global_permission? #{perm_string}"
     roles.detect do |role|
-      return true if role.static_permissions.where('static_permissions.title = ?', perm_string).first
+      return true if role.static_permissions.find_by(title: perm_string)
     end
   end
 


### PR DESCRIPTION
Enable the `Rails/FindBy` cop in Rubocop: Note that `where(..).first` is not exactly the same as `find_by(...)` as they order records differently, so the "first" record can be different. Because of this reason the Rubocop auto-correct option doesn't work and all the changes have been done manually.

I've also refactored the `UpdateinfoCounter#find_or_create` method. :bowtie: 
