### PR TITLE
[ci] use_transactional_fixtures deprecated

### DIFF
--- a/src/api/test/test_helper.rb
+++ b/src/api/test/test_helper.rb
@@ -270,7 +270,7 @@ module Webui
       load_fixture("backend/#{path}")
     end
 
-    self.use_transactional_fixtures = true
+    self.use_transactional_tests = true
     fixtures :all
 
     setup do


### PR DESCRIPTION
`use_transactional_fixtures=` is deprecated and will be removed from
Rails 5.1. Use `use_transactional_tests=` instead.

Note that `config.use_transactional_fixtures=` in _database_cleaner.rb_
doesn't have to be changed as Rspec is keeping that name and assigning
the correct variable internally depending on the Rails version:
https://github.com/rspec/rspec-rails/blob/e8054a1cd03044f725030fe8315952cf3799a395/lib/rspec/rails/fixture_support.rb#L26