### PR TITLE
[api] Replace uniq by distinct

### DIFF
--- a/src/api/app/models/role.rb
+++ b/src/api/app/models/role.rb
@@ -32,11 +32,11 @@ class Role < ApplicationRecord
   belongs_to :roles_users
 
   # roles have n:m relations for users
-  has_and_belongs_to_many :users, -> { uniq() }
+  has_and_belongs_to_many :users, -> { distinct }
   # roles have n:m relations to groups
-  has_and_belongs_to_many :groups, -> { uniq() }
+  has_and_belongs_to_many :groups, -> { distinct }
   # roles have n:m relations to permissions
-  has_and_belongs_to_many :static_permissions, -> { uniq() }
+  has_and_belongs_to_many :static_permissions, -> { distinct }
 
   scope :global, -> { where(global: true) }
 

--- a/src/api/app/models/static_permission.rb
+++ b/src/api/app/models/static_permission.rb
@@ -6,7 +6,7 @@
 class StaticPermission < ApplicationRecord
   has_many :roles_static_permissions
 
-  has_and_belongs_to_many :roles, -> { uniq() }
+  has_and_belongs_to_many :roles, -> { distinct }
 
   # We want to validate a static permission's title pretty thoroughly.
   validates_uniqueness_of :title,


### PR DESCRIPTION
`uniq` is deprecated and will be removed from Rails 5.1 (use `distinct` instead). :bowtie: 

We have already replaced some of them: https://github.com/openSUSE/open-build-service/pull/2212 and https://github.com/openSUSE/open-build-service/pull/2144