### PR TITLE
[ci] redirect_to back is deprecated

### DIFF
--- a/src/api/spec/controllers/webui/project_controller_spec.rb
+++ b/src/api/spec/controllers/webui/project_controller_spec.rb
@@ -557,7 +557,7 @@ RSpec.describe Webui::ProjectController, vcr: true do
       end
 
       it { expect(flash[:error]).to start_with('Failed to save project') }
-      it { is_expected.to redirect_to(:back) }
+      it { is_expected.to redirect_to(root_url) }
     end
   end
 
@@ -659,7 +659,7 @@ RSpec.describe Webui::ProjectController, vcr: true do
       end
 
       it { expect(flash[:error]).to eq("Can not remove path: ") }
-      it { is_expected.to redirect_to(:back) }
+      it { is_expected.to redirect_to(root_url) }
       it { expect(assigns(:project).repositories.count).to eq(1)}
     end
   end
@@ -683,7 +683,7 @@ RSpec.describe Webui::ProjectController, vcr: true do
     it "redirects to back if a referer is there" do
       request.env["HTTP_REFERER"] = root_url # Needed for the redirect_to :back
       get :toggle_watch, params: { project: user.home_project }
-      is_expected.to redirect_to(:back)
+      is_expected.to redirect_to(root_url)
     end
 
     it "redirects to project#show" do
@@ -768,7 +768,7 @@ RSpec.describe Webui::ProjectController, vcr: true do
         end
 
         it { expect(flash[:error]).to eq("Failed to remove #{user.home_project.name} from maintenance") }
-        it { is_expected.to redirect_to(:back) }
+        it { is_expected.to redirect_to(root_url) }
       end
 
       # raise the exception in the before_action set_maintained_project
@@ -847,7 +847,7 @@ RSpec.describe Webui::ProjectController, vcr: true do
       end
 
       it { expect(flash[:error]).to eq("MaintenanceHelper::MissingAction") }
-      it { is_expected.to redirect_to(:back) }
+      it { is_expected.to redirect_to(root_url) }
     end
 
     context "with the proper params" do

--- a/src/api/spec/controllers/webui/repositories_controller_spec.rb
+++ b/src/api/spec/controllers/webui/repositories_controller_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe Webui::RepositoriesController, vcr: true do
 
       it { expect(assigns(:repocycles)).to be_a(Hash) }
       it { expect(assigns(:repository)).to be_falsey }
-      it { is_expected.to redirect_to(:back) }
+      it { is_expected.to redirect_to(root_url) }
     end
   end
 
@@ -132,7 +132,7 @@ RSpec.describe Webui::RepositoriesController, vcr: true do
         expect(flash[:error]).to eq("Can not add repository: Name must not start with '_' or contain any of these characters ':/'")
       end
 
-      it { expect(action).to redirect_to(:back) }
+      it { expect(action).to redirect_to(root_url) }
       it { expect{ action }.to_not change(Repository, :count) }
     end
 
@@ -142,7 +142,7 @@ RSpec.describe Webui::RepositoriesController, vcr: true do
       end
 
       it { expect(flash[:error]).to eq("Can not add repository: Path elements is invalid and Path Element: Link can't be blank") }
-      it { is_expected.to redirect_to(:back) }
+      it { is_expected.to redirect_to(root_url) }
     end
 
     context "with a valid repository but with a non valid architecture" do
@@ -152,7 +152,7 @@ RSpec.describe Webui::RepositoriesController, vcr: true do
       end
 
       it { expect(flash[:error]).to start_with("Can not add repository: Repository ") }
-      it { is_expected.to redirect_to(:back) }
+      it { is_expected.to redirect_to(root_url) }
     end
 
     context "with a valid repository" do
@@ -179,7 +179,7 @@ RSpec.describe Webui::RepositoriesController, vcr: true do
           "Name is too short (minimum is 1 character) and " \
           "Name must not start with '_' or contain any of these characters ':/'")
       }
-      it { is_expected.to redirect_to(:back) }
+      it { is_expected.to redirect_to(root_url) }
       it { expect(assigns(:project).repositories.count).to eq(0) }
     end
   end

--- a/src/api/spec/controllers/webui/search_controller_spec.rb
+++ b/src/api/spec/controllers/webui/search_controller_spec.rb
@@ -76,7 +76,7 @@ RSpec.describe Webui::SearchController, vcr: true do
         end
 
         it { expect(flash[:notice]).to eq('Sorry, this disturl does not compute...') }
-        it { is_expected.to redirect_to(:back) }
+        it { is_expected.to redirect_to(root_url) }
       end
     end
 

--- a/src/api/spec/controllers/webui/user_controller_spec.rb
+++ b/src/api/spec/controllers/webui/user_controller_spec.rb
@@ -22,12 +22,12 @@ RSpec.describe Webui::UserController do
   describe "GET #show" do
     shared_examples "a non existent account" do
       before do
-        request.env["HTTP_REFERER"] = root_url # Needed for the redirect_to :back
+        request.env["HTTP_REFERER"] = root_url # Needed for the redirect_to(root_url)
         get :show, params: { user: user }
       end
 
       it { expect(controller).to set_flash[:error].to("User not found #{user}") }
-      it { expect(response).to redirect_to :back }
+      it { expect(response).to redirect_to(root_url) }
     end
 
     context "when the current user is admin" do
@@ -82,7 +82,7 @@ RSpec.describe Webui::UserController do
 
   describe "POST #do_login" do
     before do
-      request.env["HTTP_REFERER"] = search_url # Needed for the redirect_to :back
+      request.env["HTTP_REFERER"] = search_url # Needed for the redirect_to(root_url)
     end
 
     it 'logs in users with correct credentials' do
@@ -155,7 +155,7 @@ RSpec.describe Webui::UserController do
     context "when user is trying to update another user's profile" do
       before do
         login user
-        request.env["HTTP_REFERER"] = root_url # Needed for the redirect_to :back
+        request.env["HTTP_REFERER"] = root_url # Needed for the redirect_to(root_url)
         post :save, params: { user: non_admin_user, realname: 'another real name', email: 'new_valid@email.es' }
         non_admin_user.reload
       end
@@ -163,7 +163,7 @@ RSpec.describe Webui::UserController do
       it { expect(non_admin_user.realname).not_to eq('another real name') }
       it { expect(non_admin_user.email).not_to eq('new_valid@email.es') }
       it { expect(flash[:error]).to eq("Can't edit #{non_admin_user.login}") }
-      it { is_expected.to redirect_to :back }
+      it { is_expected.to redirect_to(root_url) }
     end
 
     context "when admin is updating another user's profile" do


### PR DESCRIPTION
`redirect_to back` was replaced by `redirect_back` in https://github.com/openSUSE/open-build-service/pull/2215/files except in the Rspec tests.

According to https://github.com/rspec/rspec-rails/issues/1659 Rspec is not going to provide an alternative for `redirect_to back` as it can be checked that it redirects to the path defined in `request.env["HTTP_REFERER"]`.