### PR TITLE
[api] `skip_action_callback` is deprecated

### DIFF
--- a/src/api/app/controllers/configurations_controller.rb
+++ b/src/api/app/controllers/configurations_controller.rb
@@ -3,7 +3,7 @@ require 'configuration'
 class ConfigurationsController < ApplicationController
   # Site-specific configuration is insensitive information, no login needed therefore
   before_action :require_admin, only: [:update]
-  skip_action_callback :validate_params, only: [:update] # we use an array for archs here
+  skip_before_action :validate_params, only: [:update] # we use an array for archs here
 
   validate_action show: {method: :get, response: :configuration}
 # webui is using this route with parameters instead of content

--- a/src/api/app/controllers/trigger_controller.rb
+++ b/src/api/app/controllers/trigger_controller.rb
@@ -8,7 +8,7 @@ class TriggerController < ApplicationController
   skip_before_action :require_login
 
   # github.com sends a hash payload
-  skip_action_callback :validate_params, only: [:runservice]
+  skip_before_action :validate_params, only: [:runservice]
 
   def runservice
     auth = request.env['HTTP_AUTHORIZATION']


### PR DESCRIPTION
`skip_action_callback` is deprecated and will be removed in Rails 5.1. I use `skip_before_action` instead.