### PR TITLE
Add new way to identify spider bots

### DIFF
--- a/docs/ReleaseNotes-2.7
+++ b/docs/ReleaseNotes-2.7
@@ -107,6 +107,8 @@ Webui Features
   `Content-Disposition: attachment`, which makes Firefox prompt the user to
   download the file rather than simply showing the text within the browser.
 * Improve load time when loading open requests for a user on profile page.
+* The way to identify spiders got changed. A separate configuration via
+  apache is no longer required. See the Administration Guide.
 
 
 Notes for systems using systemd:

--- a/src/api/Gemfile
+++ b/src/api/Gemfile
@@ -49,6 +49,8 @@ gem 'flot-rails'
 gem 'colorize', require: false
 # XML Serialization got moved here
 gem 'activemodel-serializers-xml'
+# Spider Identification
+gem 'voight_kampff'
 
 group :development, :production do
   # to have the delayed job daemon

--- a/src/api/Gemfile.lock
+++ b/src/api/Gemfile.lock
@@ -317,6 +317,8 @@ GEM
       rack
       unicorn
     vcr (3.0.3)
+    voight_kampff (1.1.1)
+      rack (>= 1.4, < 3.0)
     webmock (2.1.0)
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
@@ -396,7 +398,10 @@ DEPENDENCIES
   uglifier (>= 1.2.2)
   unicorn-rails
   vcr
+  voight_kampff
   webmock (>= 1.18.0)
   xmlhash (>= 1.3.6)
   yajl-ruby
 
+BUNDLED WITH
+   1.12.5

--- a/src/api/app/controllers/webui/webui_controller.rb
+++ b/src/api/app/controllers/webui/webui_controller.rb
@@ -180,7 +180,7 @@ class Webui::WebuiController < ActionController::Base
   # Needed to hide/render some views to well known spider bots
   # FIXME: We should get rid of it
   def check_spiders
-    @spider_bot = request.env.has_key?('HTTP_OBS_SPIDER')
+    @spider_bot = request.bot?
   end
   private :check_spiders
 

--- a/src/api/spec/controllers/webui/project_controller_spec.rb
+++ b/src/api/spec/controllers/webui/project_controller_spec.rb
@@ -61,7 +61,8 @@ RSpec.describe Webui::ProjectController, vcr: true do
 
     context 'showing projects being a spider bot' do
       before do
-        request.env['HTTP_OBS_SPIDER'] = true
+        # be a fake google bot
+        request.env['HTTP_USER_AGENT'] = 'Mozilla/5.0 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)'
         get :index
       end
 


### PR DESCRIPTION
This identifies spider bots more effectively and removes the old way to identify spiders (apache configuration).