### PR TITLE
[ci][api][webui] Enable the Lint/Eval cop in rubocop

### DIFF
--- a/src/api/.rubocop.yml
+++ b/src/api/.rubocop.yml
@@ -92,6 +92,10 @@ Lint/AssignmentInCondition:
 Lint/EndAlignment:
   AlignWith: variable
 
+# checks for the use of *Kernel#eval* as it is a serious security risk.
+Lint/Eval:
+  Enabled: true
+
 # checks for private or protected access modifiers which are applied to a
 # singleton method, as they do not make it private/protected.
 Lint/IneffectiveAccessModifier:

--- a/src/api/.rubocop_todo.yml
+++ b/src/api/.rubocop_todo.yml
@@ -14,8 +14,6 @@ Lint/EndAlignment:
   Exclude:
     - 'app/controllers/build_controller.rb'
 
-# Offense count: 1
-Lint/Eval:
   Exclude:
     - 'config/environments/development.rb'
 

--- a/src/api/app/controllers/build_controller.rb
+++ b/src/api/app/controllers/build_controller.rb
@@ -187,6 +187,7 @@ class BuildController < ApplicationController
       fsize = regexp[1]
       logger.info "streaming #{path}"
 
+      # rubocop:disable Lint/EndAlignment
       c_type = case params[:filename].split(/\./)[-1]
                when "rpm"
                  "application/x-rpm"
@@ -197,6 +198,7 @@ class BuildController < ApplicationController
                else
                  "application/octet-stream"
                end
+      # rubocop:enable Lint/EndAlignment
 
       headers.update(
         'Content-Disposition' => %(attachment; filename="#{params[:filename]}"),

--- a/src/api/config/environments/development.rb
+++ b/src/api/config/environments/development.rb
@@ -59,12 +59,3 @@ CONFIG['response_schema_validation'] = true
 
 CONFIG['frontend_host'] = "localhost"
 CONFIG['frontend_protocol'] = "http"
-
-require 'socket'
-fname = "#{Rails.root}/config/environments/development.#{Socket.gethostname}.rb"
-if File.exist? fname
-  STDERR.puts "Using local environment #{fname}"
-  eval File.read(fname)
-else
-  STDERR.puts "Custom development.#{Socket.gethostname}.rb not found - using defaults"
-end


### PR DESCRIPTION
This will remove some code evaluation in development mode which reads
in a .rb file.
This seems to be old unused code anyway. Besides it's a nasty hack.