### PR TITLE
dynamic :action segment is deprecated & unexpected routes are available

### DIFF
--- a/src/api/config/routes.rb
+++ b/src/api/config/routes.rb
@@ -622,7 +622,19 @@ OBSApi::Application.routes.draw do
       get 'public/build/:project(/:repository(/:arch(/:package(/:file))))' => 'public#build', constraints: cons, as: :public_build
     end
 
-    get 'public/status/:action' => 'status#index'
+    get 'public/status/list_messages' => 'status#list_messages'
+    get 'public/status/show_message' => 'status#show_message'
+    get 'public/status/update_messages' => 'status#update_messages'
+    get 'public/status/save_new_message' => 'status#save_new_message'
+    get 'public/status/delete_message' => 'status#delete_message'
+    get 'public/status/workerstatus' => 'status#workerstatus'
+    get 'public/status/history' => 'status#history'
+    get 'public/status/role_from_cache' => 'status#role_from_cache'
+    get 'public/status/user_from_cache' => 'status#user_from_cache'
+    get 'public/status/group_from_cache' => 'status#group_from_cache'
+    get 'public/status/find_relationships_for_packages' => 'status#find_relationships_for_packages'
+    get 'public/status/project' => 'status#project'
+    get 'public/status/bsrequest' => 'status#bsrequest'
 
     get '/404' => 'main#notfound'
   end

--- a/src/api/config/routes.rb
+++ b/src/api/config/routes.rb
@@ -534,6 +534,20 @@ OBSApi::Application.routes.draw do
       get 'status/history' => :history
       get 'status/project/:project' => :project, constraints: cons
       get 'status/bsrequest' => :bsrequest
+
+      get 'public/status/list_messages' => :list_messages
+      get 'public/status/show_message' => :show_message
+      get 'public/status/update_messages' => :update_messages
+      get 'public/status/save_new_message' => :save_new_message
+      get 'public/status/delete_message' => :delete_message
+      get 'public/status/workerstatus' => :workerstatus
+      get 'public/status/history' => :history
+      get 'public/status/role_from_cache' => :role_from_cache
+      get 'public/status/user_from_cache' => :user_from_cache
+      get 'public/status/group_from_cache' => :group_from_cache
+      get 'public/status/find_relationships_for_packages' => :find_relationships_for_packages
+      get 'public/status/project' => :project
+      get 'public/status/bsrequest' => :bsrequest
     end
 
     ### /message
@@ -621,20 +635,6 @@ OBSApi::Application.routes.draw do
       get 'public/binary_packages/:project/:package' => :binary_packages, constraints: cons
       get 'public/build/:project(/:repository(/:arch(/:package(/:file))))' => 'public#build', constraints: cons, as: :public_build
     end
-
-    get 'public/status/list_messages' => 'status#list_messages'
-    get 'public/status/show_message' => 'status#show_message'
-    get 'public/status/update_messages' => 'status#update_messages'
-    get 'public/status/save_new_message' => 'status#save_new_message'
-    get 'public/status/delete_message' => 'status#delete_message'
-    get 'public/status/workerstatus' => 'status#workerstatus'
-    get 'public/status/history' => 'status#history'
-    get 'public/status/role_from_cache' => 'status#role_from_cache'
-    get 'public/status/user_from_cache' => 'status#user_from_cache'
-    get 'public/status/group_from_cache' => 'status#group_from_cache'
-    get 'public/status/find_relationships_for_packages' => 'status#find_relationships_for_packages'
-    get 'public/status/project' => 'status#project'
-    get 'public/status/bsrequest' => 'status#bsrequest'
 
     get '/404' => 'main#notfound'
   end


### PR DESCRIPTION
Using a dynamic :action segment in a route is deprecated and will be removed in _Rails 5.1_. I have changed

``` Ruby
get 'public/status/:action' => 'status#index'`
```

by

``` Ruby
get "public/status/method_name" => "status#method_name"
```
for any of the method in the status controller.

Note that this is not exactly the same as what we used to have, as before routes like `public/status/permitted_attributes` and `public/status/auth_method` were available. An equivalent alternative would be:

``` Ruby
StatusController.action_methods.each do |action|
  get "public/status/#{action}" => "status##{action}"
end
```

But I doubt that we want this routes to be available. And also, as I discussed with @ChrisBr, making the routes explicit makes easier to understand and to find the routes in the file. 

So this fix the deprecation warning and the fact that this kind of routes are available. I also moved the `public/status` routes to the `:status` controller section as all this routes are using methods in this controller, so from my point of view it makes more sense that they are there. 