### PR TITLE
Fixed the Xamarin bugzilla bxc# shortcut.

### DIFF
--- a/docs/api/api/issue_trackers.xml
+++ b/docs/api/api/issue_trackers.xml
@@ -200,13 +200,13 @@
     <enable-fetch>false</enable-fetch>
   </issue-tracker>
   <issue-tracker>
-    <name>Xamarin</name>
+    <name>bxc</name>
     <kind>bugzilla</kind>
     <description>Xamarin Bugzilla</description>
     <url>http://bugzilla.xamarin.com/index.cgi</url>
     <show-url>http://bugzilla.xamarin.com/show_bug.cgi?id=@@@</show-url>
-    <regex>Xamarin#(\d+)</regex>
-    <label>Xamarin#@@@</label>
+    <regex>bxc#(\d+)</regex>
+    <label>bxc#@@@</label>
     <enable-fetch>false</enable-fetch>
   </issue-tracker>
   <issue-tracker>


### PR DESCRIPTION
See https://en.opensuse.org/openSUSE:Packaging_Patches_guidelines#Current_set_of_abbreviations which listed this as `bxc#12345` all the time and which was also used since 2014 in https://build.opensuse.org/package/view_file/Mono:Factory/mono-core/mono-core.changes Now I finally figured why this doesn't work as promised. Seems to be a simple misconfiguration.