### PR TITLE
[webui] Feature - Improve Accept/Decline buttons #2327

### DIFF
--- a/src/api/app/views/webui/request/show.html.erb
+++ b/src/api/app/views/webui/request/show.html.erb
@@ -284,8 +284,8 @@
                   <%= hidden_field_tag("review_by_group_#{index}", review[:by_group]) if review[:by_group] %>
                   <%= hidden_field_tag("review_by_project_#{index}", review[:by_project]) if review[:by_project] %>
                   <%= hidden_field_tag("review_by_package_#{index}", review[:by_package]) if review[:by_package] %>
-                  <%= submit_tag 'Approve', name: 'accepted', id: "review_accept_button_#{index}", title: 'Give this request your blessing, it will continue.' %>
-                  <%= submit_tag 'Disregard', name: 'declined', id: "review_decline_button_#{index}", title: 'Veto this request, it will be declined.' %>
+                  <%= submit_tag 'Approve', name: 'accepted', id: "review_accept_button_#{index}", title: 'Give this request your blessing, it will continue.', :style => 'margin-right: 4em; background-color: #4CAF50; color: #000000' %>
+                  <%= submit_tag 'Disregard', name: 'declined', id: "review_decline_button_#{index}", title: 'Veto this request, it will be declined.', :style => 'background-color: #f2391d; color: #000000' %>
                 </p>
             <% end %>
           </div>


### PR DESCRIPTION
As per requested feature related to 'Approve'/'Disregard' buttons in Improve Accept/Decline buttons #2327 
![buttons_change](https://cloud.githubusercontent.com/assets/1436212/20382911/1968316e-acae-11e6-9266-7417ace48a64.png)
,  added spacing between buttons and changed colours (green for 'Approve', red for 'Disregard'). 
See attached image.