### PR TITLE
[ci] asssert_nothing_raised is deprecated

### DIFF
--- a/src/api/test/functional/tag_controller_test.rb
+++ b/src/api/test/functional/tag_controller_test.rb
@@ -92,9 +92,7 @@ class TagControllerTest < ActionDispatch::IntegrationTest
     assert_kind_of Tag, t
 
     # create the relationship and store it in the join table
-    assert_nothing_raised ActiveRecord::StatementInvalid do
-      @controller.private_create_relationship(p, u, t)
-    end
+    @controller.private_create_relationship(p, u, t)
 
     # reload the user, seems to be necessary
     u = User.find_by_login("Iggy")
@@ -141,9 +139,7 @@ class TagControllerTest < ActionDispatch::IntegrationTest
     t << tx
     t << ty
 
-    assert_nothing_raised ActiveRecord::StatementInvalid do
-      @controller.private_save_tags(p, u, t)
-    end
+    @controller.private_save_tags(p, u, t)
 
     assert_kind_of Tag, u.tags.find_by_name("TagX")
     assert_kind_of Tag, u.tags.find_by_name("TagY")
@@ -184,9 +180,7 @@ class TagControllerTest < ActionDispatch::IntegrationTest
     unsaved_tags = Array.new
 
     # testing
-    assert_nothing_raised ActiveRecord::StatementInvalid do
-      tags, unsaved_tags = @controller.private_taglistXML_to_tags(xml.to_s)
-    end
+    tags, unsaved_tags = @controller.private_taglistXML_to_tags(xml.to_s)
 
     assert_kind_of Array, tags
     assert_kind_of Array, unsaved_tags


### PR DESCRIPTION
After reading some blog article advising against using `assert_nothing_raise` (like this one: [You Don't Need `assert_nothing_raised`](http://www.thagomizer.com/blog/2013/06/11/assert-nothing-raised.html)) I've tried what the difference between different kind of exceptions with and without using `assert_nothing_raise` in our project. It seems that it fails anyway (independently of the kind of exception), although the [documentation says it shouldn't](http://apidock.com/ruby/Test/Unit/Assertions/assert_nothing_raised). I am not sure why the behavior is different, but in any case we should remove it: It is useless and passing arguments to `assert_nothing_raised` is deprecated and will be removed in _Rails 5.1_.

This is what I tried:

**The kind of the exception is raised  is the same of the  `assert_nothing_raised` argument**

``` Ruby
def raise_something
  raise RuntimeError
end

class TagControllerTest < ActionDispatch::IntegrationTest
  def test_create_relationship
    assert_nothing_raised RuntimeError do
      raise_something
    end
  end
end
```

```
TagControllerTest
  test_create_relationship                                       ERROR (1.54s)
RuntimeError:         RuntimeError: RuntimeError
            test/functional/tag_controller_test.rb:6:in `raise_something'
            test/functional/tag_controller_test.rb:100:in `block in test_create_relationship'
            test/functional/tag_controller_test.rb:99:in `test_create_relationship'
            test/test_helper.rb:126:in `block in __run'
            test/test_helper.rb:126:in `map'
            test/test_helper.rb:126:in `__run'
```

**The kind of the exception is raised different from the  `assert_nothing_raised` argument**

``` Ruby
def raise_something
  raise Exception
end

class TagControllerTest < ActionDispatch::IntegrationTest
  def test_create_relationship
    assert_nothing_raised RuntimeError do
      raise_something
    end
  end
end
```

```
TagControllerTest
  test_create_relationship                                       ERROR (1.54s)
Exception:         Exception: Exception
            test/functional/tag_controller_test.rb:6:in `raise_something'
            test/functional/tag_controller_test.rb:100:in `block in test_create_relationship'
            test/functional/tag_controller_test.rb:99:in `test_create_relationship'
            test/test_helper.rb:126:in `block in __run'
            test/test_helper.rb:126:in `map'
            test/test_helper.rb:126:in `__run'
```


**Without using  `assert_nothing_raised`**

``` Ruby
def raise_something
  raise Exception
end

class TagControllerTest < ActionDispatch::IntegrationTest
  def test_create_relationship
    raise_something
  end
end
```

```
TagControllerTest
  test_create_relationship                                       ERROR (1.53s)
Exception:         Exception: Exception
            test/functional/tag_controller_test.rb:6:in `raise_something'
            test/functional/tag_controller_test.rb:99:in `test_create_relationship'
            test/test_helper.rb:126:in `block in __run'
            test/test_helper.rb:126:in `map'
```