### PR TITLE
[api] Merge! is deprecated

### DIFF
--- a/src/api/app/controllers/request_controller.rb
+++ b/src/api/app/controllers/request_controller.rb
@@ -29,12 +29,12 @@ class RequestController < ApplicationController
     raise RequireFilter.new if [:project, :user, :states, :types, :reviewstates, :ids].all? { |f| params[f].blank? }
 
     # convert comma seperated values into arrays
-    roles = params[:roles].split(',') if params[:roles]
-    types = params[:types].split(',') if params[:types]
-    states = params[:states].split(',') if params[:states]
-    review_states = params[:reviewstates].split(',') if params[:reviewstates]
-    ids = params[:ids].split(',').map { |i| i.to_i } if params[:ids]
-    params.merge!({states: states, types: types, review_states: review_states, roles: roles, ids: ids})
+    params[:roles] = params[:roles].split(',') if params[:roles]
+    params[:types] = params[:types].split(',') if params[:types]
+    params[:states] = params[:states].split(',') if params[:states]
+    params[:review_states] = params[:reviewstates].split(',') if params[:reviewstates]
+    params[:ids] = params[:ids].split(',').map { |i| i.to_i } if params[:ids]
+
     rel = BsRequest.collection(params).includes([:reviews]).
           includes({bs_request_actions: :bs_request_action_accept_info}).
           order('bs_requests.id').references(:bs_requests)

--- a/src/api/test/unit/code_quality_test.rb
+++ b/src/api/test/unit/code_quality_test.rb
@@ -90,7 +90,7 @@ class CodeQualityTest < ActiveSupport::TestCase
       'Flag#default_status'                                                     => 90.56,
       'PublicController#binary_packages'                                        => 126.16,
       'Repository#cleanup_before_destroy'                                       => 82.98,
-      'RequestController#render_request_collection'                             => 82.38,
+      'RequestController#render_request_collection'                             => 85.91,
       'SearchController#find_attribute'                                         => 97.33,
       'SearchController#search'                                                 => 81.15,
       'SourceController#project_command_copy'                                   => 140.04,


### PR DESCRIPTION
Method merge! is deprecated and will be removed in Rails 5.1, as  no longer inherits from hash. Using this deprecated behavior exposes potential security problems. If you continue to use this method you may be creating a security vulnerability in your app that can be exploited. Instead, consider using one of these documented methods which are not deprecated: http://api.rubyonrails.org/v5.0.0.1/classes/ActionController/Parameters.html