### PR TITLE
[api]  Plural as a positional argument deprecated

### DIFF
--- a/src/api/app/views/webui/project/new_package_branch.html.erb
+++ b/src/api/app/views/webui/project/new_package_branch.html.erb
@@ -13,7 +13,7 @@ package.</p>
 <% unless @remote_projects.empty? %>
   <p>
     Branches also work across interconnected OBS instances. This OBS has
-    <%= pluralize(@remote_projects.count, 'interconnect.', 'interconnects.') %>
+    <%= pluralize(@remote_projects.count, 'interconnect.', plural: 'interconnects.') %>
   </p>
   <ul>
   <% @remote_projects.each do |id,name,title| %>


### PR DESCRIPTION
Passing plural as a positional argument is deprecated and will be removed in Rails 5.1