### PR TITLE
[backend] Make symlink files into the directory of linking projects.

### DIFF
--- a/src/backend/BSSched/BuildJob.pm
+++ b/src/backend/BSSched/BuildJob.pm
@@ -314,6 +314,14 @@ sub writejob {
   add_crossmarker($ctx->{gctx}, $binfo->{'hostarch'}, $job) if $binfo->{'hostarch'};
   $ourjobs{$1}->{$job} = 1 if $job =~ /^(:.+?|[^:].*?::.+?)::/s;
   push @{$ctx->{'otherjobscache'}}, $job;
+
+  BSSymlinkForLinkedPackages::make_symlink_rpms(
+    $ctx->{gctx}->{'projpacks'},
+    $ctx->{gctx}->{'reporoot'},
+    $binfo->{'project'},
+    $binfo->{'repository'},
+    $binfo->{'arch'},
+    $binfo->{'package'});
 }
 
 =head2 find_otherjobs - find all jobs for the same build

--- a/src/backend/BSSymlinkForLinkedPackages.pm
+++ b/src/backend/BSSymlinkForLinkedPackages.pm
@@ -1,0 +1,131 @@
+#!/usr/bin/perl
+package BSSymlinkForLinkedPackages;
+
+use strict; use warnings;
+
+use Exporter qw(import);
+use File::Copy qw(copy);
+
+our @EXPORT_OK=qw(
+make_symlink_rpms
+);
+
+sub is_copy_linked_packages_enabled {
+  my ($config_str) = @_;
+  if( $config_str && $config_str =~ /CopyLinkedPackages:\s*yes/ ) {
+    return 1;
+  }
+
+  return 0;
+}
+
+sub is_rpmbuildstage_bb_enabled {
+  my ($config_str) = @_;
+  if( $config_str && $config_str =~ /Rpmbuildstage:\s*bb/ ) {
+    return 1;
+  }
+
+  return 0;
+}
+
+sub symlink_packages {
+  my ($src_dir, $dst_dir, $is_rpmbuildstage_bb) = @_;
+
+  my $make_symlink = 0;
+  my $file_found = 0;
+  if( File::Path::make_path($dst_dir, {mode=>0777}) ) {
+    # do nothing if the directory is newly created.
+    $make_symlink = 1;
+  } else {
+    # check if there is any symlinks.
+    my @unlink_files;
+    opendir( my $DST, $dst_dir );
+    while( my $file = readdir $DST ) {
+      if( $file =~ /.*.rpm/ || $file eq "rpmlint.log" ) {
+        $file_found = 1;
+        if( -l "$dst_dir/$file" ) {
+          $make_symlink = 1;
+          push @unlink_files, "$dst_dir/$file";
+        }
+      }
+    }
+    for my $f (@unlink_files) {
+      unlink($f);
+    }
+    # if we do not find any rpm, rpmlint.log, or logfile, we should make symlink!
+    if( $file_found == 0 ) {
+      $make_symlink = 1;
+    }
+    closedir($DST);
+  }
+
+  # make symlink only if the directory is newly created or any symlink is found.
+  if( $make_symlink ) {
+    opendir(my $D, $src_dir);
+    while( my $file = readdir $D ) {
+      if( $file =~ /.src.rpm/ ) {
+        if( ! $is_rpmbuildstage_bb ) {
+          symlink("$src_dir/$file", "$dst_dir/$file");
+        } else {
+          print "since <Rpmbuildstage: bb> is declared in project config, do not symlink src.rpm.\n";
+        }
+      } elsif( $file =~ /.*.rpm/ || $file eq "rpmlint.log" ) {
+        symlink("$src_dir/$file", "$dst_dir/$file");
+      } elsif( $file eq 'logfile' ) {
+        copy("$src_dir/$file", "$dst_dir/$file");
+      }
+    }
+    closedir($D);
+  }
+}
+
+sub is_package_in_project {
+  my ($projpacks, $packid, $linked_p) = @_;
+  for my $linked_p_package (keys %{$projpacks->{$linked_p}->{'package'}}) {
+    if( $linked_p_package eq $packid ) {
+      return 1;
+    }
+  }
+  return 0;
+}
+
+sub find_linked_project_for_package {
+  my ($projpacks, $linked_projects, $packid) = @_;
+
+  for my $l (@$linked_projects) {
+    my $linked_p = $l->{'project'};
+    if( is_package_in_project($projpacks, $packid, $linked_p) ) {
+      return $linked_p;
+    }
+  }
+
+  print "$packid: No such package in any linked projects.\n";
+  return 0;
+}
+
+sub make_symlink_rpms {
+  my ($projpacks, $reporoot, $projid, $repoid, $myarch, $packid) = @_;
+  # check if it has a linked project.
+  if( ! $projpacks->{$projid}->{'link'} ) {
+    print "NO link project.\n";
+    return ;
+  }
+
+  if( ! is_copy_linked_packages_enabled($projpacks->{$projid}->{'config'}) ) {
+    print "NOT copying packages from the linked project.\n";
+    return ;
+  }
+
+  my $is_rpmbuildstage_bb = is_rpmbuildstage_bb_enabled($projpacks->{$projid}->{'config'});
+
+  my $linked_projid = find_linked_project_for_package($projpacks, $projpacks->{$projid}->{'link'}, $packid);
+  if( $linked_projid ) {
+    print "linked project: $linked_projid\n";
+
+    my $src_dir = "$reporoot/$linked_projid/$repoid/$myarch/$packid";
+    my $dst_dir = "$reporoot/$projid/$repoid/$myarch/$packid";
+    symlink_packages($src_dir, $dst_dir, $is_rpmbuildstage_bb);
+  }
+}
+
+1;


### PR DESCRIPTION
To prevent unnecessary rebuilding,
I propose a symlink mechanism.

Consider the situation below.
1. There is a project P1. P1 has packages P1-A and P1-B.

2. A project P2 that has "path project of P1" and "linkedbuild=localdep".

3. P2 has packages P2-C and P2-D.

4. We have a package build dependency like below:
P2-C -> P2-D -> P1-A -> P1-B

*'P2-C -> P2-D' means P2-D buildrequires P2-C.
Hence, P2-D should be built after P2-C is built and its result has been changed.

5. As a result, we have a build sequence like below in P2.
P2-C -> P2-D -> P1-A -> P1-B

6. For P1, if the build result of P1-A has not been changed, P1-B will not be built.

7. For P2, for the first time, even if the build result of P1-A is the same as before,
P1-B should be built. It is because there is no binary for P1-B in P2's repo.

8. Since in our Tizen OBS system, we extensively exploit linking projects,
this can be a significant overhead especially for a lot of package dependency existed.

9. Therefore, to prevent this situation, I propose the technique.
RPMs for P1-B in P1's repo are symlinked to P2's repo.
Then, even for the first time, we can prevent rebuilding of P1-B.

Signed-off-by: Junghyun Kim <jh0822.kim@samsung.com>