### PR TITLE
Image templates rebuild

### DIFF
--- a/src/api/app/models/branch_package.rb
+++ b/src/api/app/models/branch_package.rb
@@ -352,11 +352,18 @@ class BranchPackage
     unless @target_project
       @target_project = User.current.branch_project_name(p[:link_target_project])
       @auto_cleanup = ::Configuration.cleanup_after_days
-      @auto_cleanup ||= 14 if p[:base_project].try(:image_template?)
+      set_image_template_configuration(p[:base_project])
     end
 
     # link against srcmd5 instead of plain revision
     expand_rev_to_srcmd5(p) if p[:rev]
+  end
+
+  def set_image_template_configuration(project)
+    if project.try(:image_template?)
+      @auto_cleanup ||= 14
+      @rebuild_policy ||= "local"
+    end
   end
 
   def expand_rev_to_srcmd5(p)

--- a/src/api/spec/cassettes/BranchPackage/_branch/project_with_ImageTemplates_attribute/publish_flag/is_disabled.yml
+++ b/src/api/spec/cassettes/BranchPackage/_branch/project_with_ImageTemplates_attribute/publish_flag/is_disabled.yml
@@ -1,0 +1,1534 @@
+---
+http_interactions:
+- request:
+    method: put
+    uri: http://localhost:3200/source/BaseDistro/_meta
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="BaseDistro">
+          <title>For Whom the Bell Tolls</title>
+          <description/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '110'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="BaseDistro">
+          <title>For Whom the Bell Tolls</title>
+          <description></description>
+        </project>
+    http_version: 
+  recorded_at: Wed, 16 Nov 2016 16:01:58 GMT
+- request:
+    method: put
+    uri: http://localhost:3200/source/BaseDistro/_config
+    body:
+      encoding: UTF-8
+      string: Aut cum est quos autem. Et nam quisquam aut et. Delectus doloribus et
+        suscipit aut corporis et.
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '21'
+    body:
+      encoding: UTF-8
+      string: '<status code="ok" />
+
+'
+    http_version: 
+  recorded_at: Wed, 16 Nov 2016 16:01:58 GMT
+- request:
+    method: put
+    uri: http://localhost:3200/source/BaseDistro/test_package/_meta?user=tom
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="test_package" project="BaseDistro">
+          <title/>
+          <description/>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '110'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="test_package" project="BaseDistro">
+          <title></title>
+          <description></description>
+        </package>
+    http_version: 
+  recorded_at: Wed, 16 Nov 2016 16:01:58 GMT
+- request:
+    method: put
+    uri: http://localhost:3200/source/BaseDistro/test_package/_meta
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="test_package" project="BaseDistro">
+          <title/>
+          <description/>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '110'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="test_package" project="BaseDistro">
+          <title></title>
+          <description></description>
+        </package>
+    http_version: 
+  recorded_at: Wed, 16 Nov 2016 16:01:58 GMT
+- request:
+    method: put
+    uri: http://localhost:3200/source/BaseDistro:Update/_meta
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="BaseDistro:Update">
+          <title>Some Buried Caesar</title>
+          <description/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '112'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="BaseDistro:Update">
+          <title>Some Buried Caesar</title>
+          <description></description>
+        </project>
+    http_version: 
+  recorded_at: Wed, 16 Nov 2016 16:01:58 GMT
+- request:
+    method: put
+    uri: http://localhost:3200/source/BaseDistro:Update/_config
+    body:
+      encoding: UTF-8
+      string: Illo quo ut doloremque veniam. Vero aut quas dolorum aperiam saepe fugiat
+        beatae. Rerum consequatur et qui.
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '21'
+    body:
+      encoding: UTF-8
+      string: '<status code="ok" />
+
+'
+    http_version: 
+  recorded_at: Wed, 16 Nov 2016 16:01:58 GMT
+- request:
+    method: put
+    uri: http://localhost:3200/source/home:tom/_meta?user=tom
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:tom">
+          <title/>
+          <description/>
+          <person userid="tom" role="maintainer"/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '129'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:tom">
+          <title></title>
+          <description></description>
+          <person userid="tom" role="maintainer" />
+        </project>
+    http_version: 
+  recorded_at: Wed, 16 Nov 2016 16:01:58 GMT
+- request:
+    method: put
+    uri: http://localhost:3200/source/openSUSE_13/_meta
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="openSUSE_13">
+          <title>Tirra Lirra by the River</title>
+          <description/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '112'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="openSUSE_13">
+          <title>Tirra Lirra by the River</title>
+          <description></description>
+        </project>
+    http_version: 
+  recorded_at: Wed, 16 Nov 2016 16:01:58 GMT
+- request:
+    method: put
+    uri: http://localhost:3200/source/openSUSE_13/_config
+    body:
+      encoding: UTF-8
+      string: Optio in aliquid. Ut sed similique nesciunt voluptatibus. Veniam nostrum
+        aspernatur alias et. Iure ullam deleniti nemo maiores. Quibusdam qui inventore
+        nesciunt molestiae et necessitatibus facere.
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '21'
+    body:
+      encoding: UTF-8
+      string: '<status code="ok" />
+
+'
+    http_version: 
+  recorded_at: Wed, 16 Nov 2016 16:01:58 GMT
+- request:
+    method: put
+    uri: http://localhost:3200/source/openSUSE_13/apache2/_meta?user=tom
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="apache2" project="openSUSE_13">
+          <title/>
+          <description/>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '106'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="apache2" project="openSUSE_13">
+          <title></title>
+          <description></description>
+        </package>
+    http_version: 
+  recorded_at: Wed, 16 Nov 2016 16:01:58 GMT
+- request:
+    method: put
+    uri: http://localhost:3200/source/openSUSE_13/apache2/_meta
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="apache2" project="openSUSE_13">
+          <title/>
+          <description/>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '106'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="apache2" project="openSUSE_13">
+          <title></title>
+          <description></description>
+        </package>
+    http_version: 
+  recorded_at: Wed, 16 Nov 2016 16:01:58 GMT
+- request:
+    method: put
+    uri: http://localhost:3200/source/openSUSE_13/apache2/_meta?user=tom
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="apache2" project="openSUSE_13">
+          <title/>
+          <description/>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '106'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="apache2" project="openSUSE_13">
+          <title></title>
+          <description></description>
+        </package>
+    http_version: 
+  recorded_at: Wed, 16 Nov 2016 16:01:59 GMT
+- request:
+    method: post
+    uri: http://localhost:3200/search/package/id?match=(linkinfo/@package=%22apache2%22%20and%20linkinfo/@project=%22openSUSE_13%22%20and%20@project=%22openSUSE_13%22)
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Content-Type:
+      - application/octet-stream
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '27'
+    body:
+      encoding: UTF-8
+      string: |
+        <collection>
+        </collection>
+    http_version: 
+  recorded_at: Wed, 16 Nov 2016 16:01:59 GMT
+- request:
+    method: put
+    uri: http://localhost:3200/source/home:tom:branches:openSUSE_13/_meta?user=tom
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:tom:branches:openSUSE_13">
+          <title>Branch project for package apache2</title>
+          <description>This project was created for package apache2 via attribute OBS:Maintained</description>
+          <person userid="tom" role="maintainer"/>
+          <publish>
+            <disable/>
+          </publish>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '298'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:tom:branches:openSUSE_13">
+          <title>Branch project for package apache2</title>
+          <description>This project was created for package apache2 via attribute OBS:Maintained</description>
+          <person userid="tom" role="maintainer" />
+          <publish>
+            <disable />
+          </publish>
+        </project>
+    http_version: 
+  recorded_at: Wed, 16 Nov 2016 16:01:59 GMT
+- request:
+    method: put
+    uri: http://localhost:3200/source/home:tom:branches:openSUSE_13/apache2/_meta?user=tom
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="apache2" project="home:tom:branches:openSUSE_13">
+          <title/>
+          <description/>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '124'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="apache2" project="home:tom:branches:openSUSE_13">
+          <title></title>
+          <description></description>
+        </package>
+    http_version: 
+  recorded_at: Wed, 16 Nov 2016 16:01:59 GMT
+- request:
+    method: put
+    uri: http://localhost:3200/source/home:tom:branches:openSUSE_13/apache2/_meta?user=tom
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="apache2" project="home:tom:branches:openSUSE_13">
+          <title/>
+          <description/>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '124'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="apache2" project="home:tom:branches:openSUSE_13">
+          <title></title>
+          <description></description>
+        </package>
+    http_version: 
+  recorded_at: Wed, 16 Nov 2016 16:01:59 GMT
+- request:
+    method: post
+    uri: http://localhost:3200/source/home:tom:branches:openSUSE_13/apache2?cmd=branch&opackage=apache2&oproject=openSUSE_13&user=tom
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Content-Type:
+      - application/octet-stream
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '203'
+    body:
+      encoding: UTF-8
+      string: |
+        <revision rev="1" vrev="1">
+          <srcmd5>2e9bda1e11a1379f8e25b8babaee88f9</srcmd5>
+          <version>unknown</version>
+          <time>1479312119</time>
+          <user>tom</user>
+          <comment></comment>
+          <requestid/>
+        </revision>
+    http_version: 
+  recorded_at: Wed, 16 Nov 2016 16:01:59 GMT
+- request:
+    method: get
+    uri: http://localhost:3200/source/home:tom:branches:openSUSE_13/apache2
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '419'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="apache2" rev="1" vrev="1" srcmd5="2e9bda1e11a1379f8e25b8babaee88f9">
+          <linkinfo project="openSUSE_13" package="apache2" srcmd5="d41d8cd98f00b204e9800998ecf8427e" baserev="d41d8cd98f00b204e9800998ecf8427e" xsrcmd5="92b3d648bcf2f85e4050424c0a981abe" lsrcmd5="2e9bda1e11a1379f8e25b8babaee88f9" />
+          <entry name="_link" md5="194911a662dfa88b6a38dcc39abbe2ad" size="119" mtime="1479309535" />
+        </directory>
+    http_version: 
+  recorded_at: Wed, 16 Nov 2016 16:01:59 GMT
+- request:
+    method: get
+    uri: http://localhost:3200/source/home:tom:branches:openSUSE_13/apache2?nofilename=1&view=info&withchangesmd5=1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '277'
+    body:
+      encoding: UTF-8
+      string: |
+        <sourceinfo package="apache2" rev="1" vrev="1" srcmd5="92b3d648bcf2f85e4050424c0a981abe" lsrcmd5="2e9bda1e11a1379f8e25b8babaee88f9" verifymd5="d41d8cd98f00b204e9800998ecf8427e">
+          <linked project="openSUSE_13" package="apache2" />
+          <revtime>1479312119</revtime>
+        </sourceinfo>
+    http_version: 
+  recorded_at: Wed, 16 Nov 2016 16:01:59 GMT
+- request:
+    method: get
+    uri: http://localhost:3200/source/home:tom:branches:openSUSE_13/apache2
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '419'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="apache2" rev="1" vrev="1" srcmd5="2e9bda1e11a1379f8e25b8babaee88f9">
+          <linkinfo project="openSUSE_13" package="apache2" srcmd5="d41d8cd98f00b204e9800998ecf8427e" baserev="d41d8cd98f00b204e9800998ecf8427e" xsrcmd5="92b3d648bcf2f85e4050424c0a981abe" lsrcmd5="2e9bda1e11a1379f8e25b8babaee88f9" />
+          <entry name="_link" md5="194911a662dfa88b6a38dcc39abbe2ad" size="119" mtime="1479309535" />
+        </directory>
+    http_version: 
+  recorded_at: Wed, 16 Nov 2016 16:01:59 GMT
+- request:
+    method: post
+    uri: http://localhost:3200/source/home:tom:branches:openSUSE_13/apache2?cmd=diff&linkrev=base&onlyissues=1&orev=0&view=xml
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Content-Type:
+      - application/octet-stream
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Content-Length:
+      - '337'
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+    body:
+      encoding: UTF-8
+      string: |
+        <sourcediff key="152e58fbe1a340415cfef532ec8cb21f">
+          <old project="home:tom:branches:openSUSE_13" package="apache2" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e" />
+          <new project="home:tom:branches:openSUSE_13" package="apache2" rev="1" srcmd5="2e9bda1e11a1379f8e25b8babaee88f9" />
+          <files />
+          <issues>
+          </issues>
+        </sourcediff>
+    http_version: 
+  recorded_at: Wed, 16 Nov 2016 16:01:59 GMT
+- request:
+    method: post
+    uri: http://localhost:3200/source/home:tom:branches:openSUSE_13/apache2?cmd=linkdiff&linkrev=base&onlyissues=1&view=xml
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Content-Type:
+      - application/octet-stream
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '358'
+    body:
+      encoding: UTF-8
+      string: |
+        <sourcediff key="2a074dbcff8f311ea1010d065a6b8ddd">
+          <old project="openSUSE_13" package="apache2" rev="d41d8cd98f00b204e9800998ecf8427e" srcmd5="d41d8cd98f00b204e9800998ecf8427e" />
+          <new project="home:tom:branches:openSUSE_13" package="apache2" rev="92b3d648bcf2f85e4050424c0a981abe" srcmd5="92b3d648bcf2f85e4050424c0a981abe" />
+          <files />
+        </sourcediff>
+    http_version: 
+  recorded_at: Wed, 16 Nov 2016 16:01:59 GMT
+- request:
+    method: put
+    uri: http://localhost:3200/source/home:tom:branches:openSUSE_13/_meta?user=tom
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:tom:branches:openSUSE_13">
+          <title>Branch project for package apache2</title>
+          <description>This project was created for package apache2 via attribute OBS:Maintained</description>
+          <person userid="tom" role="maintainer"/>
+          <publish>
+            <disable/>
+          </publish>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '298'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:tom:branches:openSUSE_13">
+          <title>Branch project for package apache2</title>
+          <description>This project was created for package apache2 via attribute OBS:Maintained</description>
+          <person userid="tom" role="maintainer" />
+          <publish>
+            <disable />
+          </publish>
+        </project>
+    http_version: 
+  recorded_at: Wed, 16 Nov 2016 16:01:59 GMT
+- request:
+    method: delete
+    uri: http://localhost:3200/source/home:tom:branches:openSUSE_13?comment&user=tom
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '21'
+    body:
+      encoding: UTF-8
+      string: '<status code="ok" />
+
+'
+    http_version: 
+  recorded_at: Wed, 16 Nov 2016 16:01:59 GMT
+- request:
+    method: put
+    uri: http://localhost:3200/source/openSUSE_Leap/_meta
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="openSUSE_Leap">
+          <title>The Lathe of Heaven</title>
+          <description/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '109'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="openSUSE_Leap">
+          <title>The Lathe of Heaven</title>
+          <description></description>
+        </project>
+    http_version: 
+  recorded_at: Wed, 16 Nov 2016 16:16:48 GMT
+- request:
+    method: put
+    uri: http://localhost:3200/source/openSUSE_Leap/_config
+    body:
+      encoding: UTF-8
+      string: Hic nesciunt sunt aut earum mollitia velit. Dolorum sunt minus rem quo.
+        Sed dolor expedita. Nam similique ea soluta est perspiciatis eveniet dicta.
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '21'
+    body:
+      encoding: UTF-8
+      string: '<status code="ok" />
+
+'
+    http_version: 
+  recorded_at: Wed, 16 Nov 2016 16:16:48 GMT
+- request:
+    method: put
+    uri: http://localhost:3200/source/openSUSE_Leap/apache2/_meta?user=tom
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="apache2" project="openSUSE_Leap">
+          <title/>
+          <description/>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '108'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="apache2" project="openSUSE_Leap">
+          <title></title>
+          <description></description>
+        </package>
+    http_version: 
+  recorded_at: Wed, 16 Nov 2016 16:16:48 GMT
+- request:
+    method: put
+    uri: http://localhost:3200/source/openSUSE_Leap/apache2/_meta
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="apache2" project="openSUSE_Leap">
+          <title/>
+          <description/>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '108'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="apache2" project="openSUSE_Leap">
+          <title></title>
+          <description></description>
+        </package>
+    http_version: 
+  recorded_at: Wed, 16 Nov 2016 16:16:48 GMT
+- request:
+    method: post
+    uri: http://localhost:3200/search/package/id?match=(linkinfo/@package=%22apache2%22%20and%20linkinfo/@project=%22openSUSE_Leap%22%20and%20@project=%22openSUSE_Leap%22)
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Content-Type:
+      - application/octet-stream
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '27'
+    body:
+      encoding: UTF-8
+      string: |
+        <collection>
+        </collection>
+    http_version: 
+  recorded_at: Wed, 16 Nov 2016 16:16:48 GMT
+- request:
+    method: put
+    uri: http://localhost:3200/source/home:tom:branches:openSUSE_Leap/_meta?user=tom
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:tom:branches:openSUSE_Leap">
+          <title>Branch project for package apache2</title>
+          <description>This project was created for package apache2 via attribute OBS:Maintained</description>
+          <person userid="tom" role="maintainer"/>
+          <publish>
+            <disable/>
+          </publish>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '300'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:tom:branches:openSUSE_Leap">
+          <title>Branch project for package apache2</title>
+          <description>This project was created for package apache2 via attribute OBS:Maintained</description>
+          <person userid="tom" role="maintainer" />
+          <publish>
+            <disable />
+          </publish>
+        </project>
+    http_version: 
+  recorded_at: Wed, 16 Nov 2016 16:16:48 GMT
+- request:
+    method: put
+    uri: http://localhost:3200/source/home:tom:branches:openSUSE_Leap/apache2/_meta?user=tom
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="apache2" project="home:tom:branches:openSUSE_Leap">
+          <title/>
+          <description/>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '126'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="apache2" project="home:tom:branches:openSUSE_Leap">
+          <title></title>
+          <description></description>
+        </package>
+    http_version: 
+  recorded_at: Wed, 16 Nov 2016 16:16:48 GMT
+- request:
+    method: put
+    uri: http://localhost:3200/source/home:tom:branches:openSUSE_Leap/apache2/_meta?user=tom
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="apache2" project="home:tom:branches:openSUSE_Leap">
+          <title/>
+          <description/>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '126'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="apache2" project="home:tom:branches:openSUSE_Leap">
+          <title></title>
+          <description></description>
+        </package>
+    http_version: 
+  recorded_at: Wed, 16 Nov 2016 16:16:48 GMT
+- request:
+    method: post
+    uri: http://localhost:3200/source/home:tom:branches:openSUSE_Leap/apache2?cmd=branch&opackage=apache2&oproject=openSUSE_Leap&user=tom
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Content-Type:
+      - application/octet-stream
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '203'
+    body:
+      encoding: UTF-8
+      string: |
+        <revision rev="1" vrev="1">
+          <srcmd5>f2b6eaf02987245b9003bcf47e0222dc</srcmd5>
+          <version>unknown</version>
+          <time>1479313008</time>
+          <user>tom</user>
+          <comment></comment>
+          <requestid/>
+        </revision>
+    http_version: 
+  recorded_at: Wed, 16 Nov 2016 16:16:48 GMT
+- request:
+    method: get
+    uri: http://localhost:3200/source/home:tom:branches:openSUSE_Leap/apache2
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '421'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="apache2" rev="1" vrev="1" srcmd5="f2b6eaf02987245b9003bcf47e0222dc">
+          <linkinfo project="openSUSE_Leap" package="apache2" srcmd5="d41d8cd98f00b204e9800998ecf8427e" baserev="d41d8cd98f00b204e9800998ecf8427e" xsrcmd5="2fbc15ae60271e3fe13b837e014a17ea" lsrcmd5="f2b6eaf02987245b9003bcf47e0222dc" />
+          <entry name="_link" md5="42ab2fdb360424b79deaaaec3dcd12ff" size="121" mtime="1479304500" />
+        </directory>
+    http_version: 
+  recorded_at: Wed, 16 Nov 2016 16:16:48 GMT
+- request:
+    method: get
+    uri: http://localhost:3200/source/home:tom:branches:openSUSE_Leap/apache2?nofilename=1&view=info&withchangesmd5=1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '279'
+    body:
+      encoding: UTF-8
+      string: |
+        <sourceinfo package="apache2" rev="1" vrev="1" srcmd5="2fbc15ae60271e3fe13b837e014a17ea" lsrcmd5="f2b6eaf02987245b9003bcf47e0222dc" verifymd5="d41d8cd98f00b204e9800998ecf8427e">
+          <linked project="openSUSE_Leap" package="apache2" />
+          <revtime>1479313008</revtime>
+        </sourceinfo>
+    http_version: 
+  recorded_at: Wed, 16 Nov 2016 16:16:48 GMT
+- request:
+    method: get
+    uri: http://localhost:3200/source/home:tom:branches:openSUSE_Leap/apache2
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '421'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="apache2" rev="1" vrev="1" srcmd5="f2b6eaf02987245b9003bcf47e0222dc">
+          <linkinfo project="openSUSE_Leap" package="apache2" srcmd5="d41d8cd98f00b204e9800998ecf8427e" baserev="d41d8cd98f00b204e9800998ecf8427e" xsrcmd5="2fbc15ae60271e3fe13b837e014a17ea" lsrcmd5="f2b6eaf02987245b9003bcf47e0222dc" />
+          <entry name="_link" md5="42ab2fdb360424b79deaaaec3dcd12ff" size="121" mtime="1479304500" />
+        </directory>
+    http_version: 
+  recorded_at: Wed, 16 Nov 2016 16:16:48 GMT
+- request:
+    method: post
+    uri: http://localhost:3200/source/home:tom:branches:openSUSE_Leap/apache2?cmd=diff&linkrev=base&onlyissues=1&orev=0&view=xml
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Content-Type:
+      - application/octet-stream
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Content-Length:
+      - '341'
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+    body:
+      encoding: UTF-8
+      string: |
+        <sourcediff key="b4eb9aa75778707a23b6f6a8cfd9aced">
+          <old project="home:tom:branches:openSUSE_Leap" package="apache2" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e" />
+          <new project="home:tom:branches:openSUSE_Leap" package="apache2" rev="1" srcmd5="f2b6eaf02987245b9003bcf47e0222dc" />
+          <files />
+          <issues>
+          </issues>
+        </sourcediff>
+    http_version: 
+  recorded_at: Wed, 16 Nov 2016 16:16:48 GMT
+- request:
+    method: post
+    uri: http://localhost:3200/source/home:tom:branches:openSUSE_Leap/apache2?cmd=linkdiff&linkrev=base&onlyissues=1&view=xml
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Content-Type:
+      - application/octet-stream
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '362'
+    body:
+      encoding: UTF-8
+      string: |
+        <sourcediff key="1c6621e539f5863fcf3a10f8baf9b790">
+          <old project="openSUSE_Leap" package="apache2" rev="d41d8cd98f00b204e9800998ecf8427e" srcmd5="d41d8cd98f00b204e9800998ecf8427e" />
+          <new project="home:tom:branches:openSUSE_Leap" package="apache2" rev="2fbc15ae60271e3fe13b837e014a17ea" srcmd5="2fbc15ae60271e3fe13b837e014a17ea" />
+          <files />
+        </sourcediff>
+    http_version: 
+  recorded_at: Wed, 16 Nov 2016 16:16:48 GMT
+- request:
+    method: put
+    uri: http://localhost:3200/source/home:tom:branches:openSUSE_Leap/_meta?user=tom
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:tom:branches:openSUSE_Leap">
+          <title>Branch project for package apache2</title>
+          <description>This project was created for package apache2 via attribute OBS:Maintained</description>
+          <person userid="tom" role="maintainer"/>
+          <publish>
+            <disable/>
+          </publish>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '300'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:tom:branches:openSUSE_Leap">
+          <title>Branch project for package apache2</title>
+          <description>This project was created for package apache2 via attribute OBS:Maintained</description>
+          <person userid="tom" role="maintainer" />
+          <publish>
+            <disable />
+          </publish>
+        </project>
+    http_version: 
+  recorded_at: Wed, 16 Nov 2016 16:16:49 GMT
+- request:
+    method: delete
+    uri: http://localhost:3200/source/home:tom:branches:openSUSE_Leap?comment&user=tom
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '21'
+    body:
+      encoding: UTF-8
+      string: '<status code="ok" />
+
+'
+    http_version: 
+  recorded_at: Wed, 16 Nov 2016 16:16:49 GMT
+recorded_with: VCR 3.0.3

--- a/src/api/spec/cassettes/BranchPackage/_branch/project_with_ImageTemplates_attribute/repository_rebuild_flag/is_set_to_local.yml
+++ b/src/api/spec/cassettes/BranchPackage/_branch/project_with_ImageTemplates_attribute/repository_rebuild_flag/is_set_to_local.yml
@@ -1,0 +1,882 @@
+---
+http_interactions:
+- request:
+    method: put
+    uri: http://localhost:3200/source/BaseDistro/_meta
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="BaseDistro">
+          <title>Many Waters</title>
+          <description/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '98'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="BaseDistro">
+          <title>Many Waters</title>
+          <description></description>
+        </project>
+    http_version: 
+  recorded_at: Tue, 22 Nov 2016 15:21:14 GMT
+- request:
+    method: put
+    uri: http://localhost:3200/source/BaseDistro/_config
+    body:
+      encoding: UTF-8
+      string: Illo asperiores et. Sunt ab velit veritatis. Quia sint voluptatem quia
+        cumque error non. Quibusdam aut aspernatur non laudantium soluta doloremque
+        voluptatem. Velit vel laborum mollitia quas quia veritatis.
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '21'
+    body:
+      encoding: UTF-8
+      string: '<status code="ok" />
+
+'
+    http_version: 
+  recorded_at: Tue, 22 Nov 2016 15:21:14 GMT
+- request:
+    method: put
+    uri: http://localhost:3200/source/BaseDistro/test_package/_meta?user=_nobody_
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="test_package" project="BaseDistro">
+          <title/>
+          <description/>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '110'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="test_package" project="BaseDistro">
+          <title></title>
+          <description></description>
+        </package>
+    http_version: 
+  recorded_at: Tue, 22 Nov 2016 15:21:14 GMT
+- request:
+    method: put
+    uri: http://localhost:3200/source/BaseDistro/test_package/_meta
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="test_package" project="BaseDistro">
+          <title/>
+          <description/>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '110'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="test_package" project="BaseDistro">
+          <title></title>
+          <description></description>
+        </package>
+    http_version: 
+  recorded_at: Tue, 22 Nov 2016 15:21:15 GMT
+- request:
+    method: put
+    uri: http://localhost:3200/source/BaseDistro:Update/_meta
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="BaseDistro:Update">
+          <title>The Wings of the Dove</title>
+          <description/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '115'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="BaseDistro:Update">
+          <title>The Wings of the Dove</title>
+          <description></description>
+        </project>
+    http_version: 
+  recorded_at: Tue, 22 Nov 2016 15:21:15 GMT
+- request:
+    method: put
+    uri: http://localhost:3200/source/BaseDistro:Update/_config
+    body:
+      encoding: UTF-8
+      string: Praesentium et consectetur. Aliquid reprehenderit distinctio sit fugit
+        odit quia. Corporis eos temporibus perferendis nulla.
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '21'
+    body:
+      encoding: UTF-8
+      string: '<status code="ok" />
+
+'
+    http_version: 
+  recorded_at: Tue, 22 Nov 2016 15:21:15 GMT
+- request:
+    method: put
+    uri: http://localhost:3200/source/home:tom/_meta?user=tom
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:tom">
+          <title/>
+          <description/>
+          <person userid="tom" role="maintainer"/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '129'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:tom">
+          <title></title>
+          <description></description>
+          <person userid="tom" role="maintainer" />
+        </project>
+    http_version: 
+  recorded_at: Tue, 22 Nov 2016 15:21:15 GMT
+- request:
+    method: put
+    uri: http://localhost:3200/source/openSUSE_Leap/_meta
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="openSUSE_Leap">
+          <title>The Wind's Twelve Quarters</title>
+          <description/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '116'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="openSUSE_Leap">
+          <title>The Wind's Twelve Quarters</title>
+          <description></description>
+        </project>
+    http_version: 
+  recorded_at: Tue, 22 Nov 2016 15:21:15 GMT
+- request:
+    method: put
+    uri: http://localhost:3200/source/openSUSE_Leap/_config
+    body:
+      encoding: UTF-8
+      string: Neque quia blanditiis. Quia ea rerum sunt. Ratione ut officiis quae
+        sed non quam error. Sunt nemo repellendus earum illum voluptatem dolor.
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '21'
+    body:
+      encoding: UTF-8
+      string: '<status code="ok" />
+
+'
+    http_version: 
+  recorded_at: Tue, 22 Nov 2016 15:21:15 GMT
+- request:
+    method: put
+    uri: http://localhost:3200/source/openSUSE_Leap/apache2/_meta?user=tom
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="apache2" project="openSUSE_Leap">
+          <title/>
+          <description/>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '108'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="apache2" project="openSUSE_Leap">
+          <title></title>
+          <description></description>
+        </package>
+    http_version: 
+  recorded_at: Tue, 22 Nov 2016 15:21:15 GMT
+- request:
+    method: put
+    uri: http://localhost:3200/source/openSUSE_Leap/apache2/_meta
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="apache2" project="openSUSE_Leap">
+          <title/>
+          <description/>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '108'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="apache2" project="openSUSE_Leap">
+          <title></title>
+          <description></description>
+        </package>
+    http_version: 
+  recorded_at: Tue, 22 Nov 2016 15:21:15 GMT
+- request:
+    method: post
+    uri: http://localhost:3200/search/package/id?match=(linkinfo/@package=%22apache2%22%20and%20linkinfo/@project=%22openSUSE_Leap%22%20and%20@project=%22openSUSE_Leap%22)
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Content-Type:
+      - application/octet-stream
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '27'
+    body:
+      encoding: UTF-8
+      string: |
+        <collection>
+        </collection>
+    http_version: 
+  recorded_at: Tue, 22 Nov 2016 15:21:15 GMT
+- request:
+    method: put
+    uri: http://localhost:3200/source/home:tom:branches:openSUSE_Leap/_meta?user=tom
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:tom:branches:openSUSE_Leap">
+          <title>Branch project for package apache2</title>
+          <description>This project was created for package apache2 via attribute OBS:Maintained</description>
+          <person userid="tom" role="maintainer"/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '259'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:tom:branches:openSUSE_Leap">
+          <title>Branch project for package apache2</title>
+          <description>This project was created for package apache2 via attribute OBS:Maintained</description>
+          <person userid="tom" role="maintainer" />
+        </project>
+    http_version: 
+  recorded_at: Tue, 22 Nov 2016 15:21:15 GMT
+- request:
+    method: put
+    uri: http://localhost:3200/source/home:tom:branches:openSUSE_Leap/apache2/_meta?user=tom
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="apache2" project="home:tom:branches:openSUSE_Leap">
+          <title/>
+          <description/>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '126'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="apache2" project="home:tom:branches:openSUSE_Leap">
+          <title></title>
+          <description></description>
+        </package>
+    http_version: 
+  recorded_at: Tue, 22 Nov 2016 15:21:15 GMT
+- request:
+    method: put
+    uri: http://localhost:3200/source/home:tom:branches:openSUSE_Leap/apache2/_meta?user=tom
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="apache2" project="home:tom:branches:openSUSE_Leap">
+          <title/>
+          <description/>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '126'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="apache2" project="home:tom:branches:openSUSE_Leap">
+          <title></title>
+          <description></description>
+        </package>
+    http_version: 
+  recorded_at: Tue, 22 Nov 2016 15:21:15 GMT
+- request:
+    method: post
+    uri: http://localhost:3200/source/home:tom:branches:openSUSE_Leap/apache2?cmd=branch&opackage=apache2&oproject=openSUSE_Leap&user=tom
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Content-Type:
+      - application/octet-stream
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '203'
+    body:
+      encoding: UTF-8
+      string: |
+        <revision rev="1" vrev="1">
+          <srcmd5>f2b6eaf02987245b9003bcf47e0222dc</srcmd5>
+          <version>unknown</version>
+          <time>1479828075</time>
+          <user>tom</user>
+          <comment></comment>
+          <requestid/>
+        </revision>
+    http_version: 
+  recorded_at: Tue, 22 Nov 2016 15:21:15 GMT
+- request:
+    method: get
+    uri: http://localhost:3200/source/home:tom:branches:openSUSE_Leap/apache2
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '421'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="apache2" rev="1" vrev="1" srcmd5="f2b6eaf02987245b9003bcf47e0222dc">
+          <linkinfo project="openSUSE_Leap" package="apache2" srcmd5="d41d8cd98f00b204e9800998ecf8427e" baserev="d41d8cd98f00b204e9800998ecf8427e" xsrcmd5="2fbc15ae60271e3fe13b837e014a17ea" lsrcmd5="f2b6eaf02987245b9003bcf47e0222dc" />
+          <entry name="_link" md5="42ab2fdb360424b79deaaaec3dcd12ff" size="121" mtime="1479828075" />
+        </directory>
+    http_version: 
+  recorded_at: Tue, 22 Nov 2016 15:21:15 GMT
+- request:
+    method: get
+    uri: http://localhost:3200/source/home:tom:branches:openSUSE_Leap/apache2?nofilename=1&view=info&withchangesmd5=1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '279'
+    body:
+      encoding: UTF-8
+      string: |
+        <sourceinfo package="apache2" rev="1" vrev="1" srcmd5="2fbc15ae60271e3fe13b837e014a17ea" lsrcmd5="f2b6eaf02987245b9003bcf47e0222dc" verifymd5="d41d8cd98f00b204e9800998ecf8427e">
+          <linked project="openSUSE_Leap" package="apache2" />
+          <revtime>1479828075</revtime>
+        </sourceinfo>
+    http_version: 
+  recorded_at: Tue, 22 Nov 2016 15:21:15 GMT
+- request:
+    method: get
+    uri: http://localhost:3200/source/home:tom:branches:openSUSE_Leap/apache2
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '421'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="apache2" rev="1" vrev="1" srcmd5="f2b6eaf02987245b9003bcf47e0222dc">
+          <linkinfo project="openSUSE_Leap" package="apache2" srcmd5="d41d8cd98f00b204e9800998ecf8427e" baserev="d41d8cd98f00b204e9800998ecf8427e" xsrcmd5="2fbc15ae60271e3fe13b837e014a17ea" lsrcmd5="f2b6eaf02987245b9003bcf47e0222dc" />
+          <entry name="_link" md5="42ab2fdb360424b79deaaaec3dcd12ff" size="121" mtime="1479828075" />
+        </directory>
+    http_version: 
+  recorded_at: Tue, 22 Nov 2016 15:21:15 GMT
+- request:
+    method: post
+    uri: http://localhost:3200/source/home:tom:branches:openSUSE_Leap/apache2?cmd=diff&linkrev=base&onlyissues=1&orev=0&view=xml
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Content-Type:
+      - application/octet-stream
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '341'
+    body:
+      encoding: UTF-8
+      string: |
+        <sourcediff key="93c7bee37132b6f09dd4dbac8fdd4631">
+          <old project="home:tom:branches:openSUSE_Leap" package="apache2" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e" />
+          <new project="home:tom:branches:openSUSE_Leap" package="apache2" rev="1" srcmd5="f2b6eaf02987245b9003bcf47e0222dc" />
+          <files />
+          <issues>
+          </issues>
+        </sourcediff>
+    http_version: 
+  recorded_at: Tue, 22 Nov 2016 15:21:16 GMT
+- request:
+    method: post
+    uri: http://localhost:3200/source/home:tom:branches:openSUSE_Leap/apache2?cmd=linkdiff&linkrev=base&onlyissues=1&view=xml
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Content-Type:
+      - application/octet-stream
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '362'
+    body:
+      encoding: UTF-8
+      string: |
+        <sourcediff key="03f1772da44ca95701e92c1b87578e9d">
+          <old project="openSUSE_Leap" package="apache2" rev="d41d8cd98f00b204e9800998ecf8427e" srcmd5="d41d8cd98f00b204e9800998ecf8427e" />
+          <new project="home:tom:branches:openSUSE_Leap" package="apache2" rev="2fbc15ae60271e3fe13b837e014a17ea" srcmd5="2fbc15ae60271e3fe13b837e014a17ea" />
+          <files />
+        </sourcediff>
+    http_version: 
+  recorded_at: Tue, 22 Nov 2016 15:21:16 GMT
+- request:
+    method: put
+    uri: http://localhost:3200/source/home:tom:branches:openSUSE_Leap/_meta?user=tom
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:tom:branches:openSUSE_Leap">
+          <title>Branch project for package apache2</title>
+          <description>This project was created for package apache2 via attribute OBS:Maintained</description>
+          <person userid="tom" role="maintainer"/>
+          <publish>
+            <disable/>
+          </publish>
+          <repository name="repository_1" rebuild="local">
+            <path project="openSUSE_Leap" repository="repository_1"/>
+          </repository>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '430'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:tom:branches:openSUSE_Leap">
+          <title>Branch project for package apache2</title>
+          <description>This project was created for package apache2 via attribute OBS:Maintained</description>
+          <person userid="tom" role="maintainer" />
+          <publish>
+            <disable />
+          </publish>
+          <repository name="repository_1" rebuild="local">
+            <path project="openSUSE_Leap" repository="repository_1" />
+          </repository>
+        </project>
+    http_version: 
+  recorded_at: Tue, 22 Nov 2016 15:21:16 GMT
+- request:
+    method: delete
+    uri: http://localhost:3200/source/home:tom:branches:openSUSE_Leap?comment&user=tom
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '21'
+    body:
+      encoding: UTF-8
+      string: '<status code="ok" />
+
+'
+    http_version: 
+  recorded_at: Tue, 22 Nov 2016 15:21:16 GMT
+recorded_with: VCR 3.0.3

--- a/src/api/spec/cassettes/BranchPackage/_branch/project_with_ImageTemplates_attribute/should_set_disable_publish_flag.yml
+++ b/src/api/spec/cassettes/BranchPackage/_branch/project_with_ImageTemplates_attribute/should_set_disable_publish_flag.yml
@@ -1,0 +1,1004 @@
+---
+http_interactions:
+- request:
+    method: put
+    uri: http://localhost:3200/source/BaseDistro/_meta
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="BaseDistro">
+          <title>The Golden Apples of the Sun</title>
+          <description/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '115'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="BaseDistro">
+          <title>The Golden Apples of the Sun</title>
+          <description></description>
+        </project>
+    http_version: 
+  recorded_at: Wed, 16 Nov 2016 13:33:16 GMT
+- request:
+    method: put
+    uri: http://localhost:3200/source/BaseDistro/_config
+    body:
+      encoding: UTF-8
+      string: Temporibus tempore sunt. Unde sed blanditiis sed et molestias odit.
+        Id numquam ut sapiente repudiandae consequatur sunt voluptas. Ut dolore omnis
+        voluptatum.
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '21'
+    body:
+      encoding: UTF-8
+      string: '<status code="ok" />
+
+'
+    http_version: 
+  recorded_at: Wed, 16 Nov 2016 13:33:16 GMT
+- request:
+    method: put
+    uri: http://localhost:3200/source/BaseDistro/test_package/_meta?user=_nobody_
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="test_package" project="BaseDistro">
+          <title/>
+          <description/>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '110'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="test_package" project="BaseDistro">
+          <title></title>
+          <description></description>
+        </package>
+    http_version: 
+  recorded_at: Wed, 16 Nov 2016 13:33:16 GMT
+- request:
+    method: put
+    uri: http://localhost:3200/source/BaseDistro/test_package/_meta
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="test_package" project="BaseDistro">
+          <title/>
+          <description/>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '110'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="test_package" project="BaseDistro">
+          <title></title>
+          <description></description>
+        </package>
+    http_version: 
+  recorded_at: Wed, 16 Nov 2016 13:33:17 GMT
+- request:
+    method: put
+    uri: http://localhost:3200/source/BaseDistro:Update/_meta
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="BaseDistro:Update">
+          <title>Ring of Bright Water</title>
+          <description/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '114'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="BaseDistro:Update">
+          <title>Ring of Bright Water</title>
+          <description></description>
+        </project>
+    http_version: 
+  recorded_at: Wed, 16 Nov 2016 13:33:17 GMT
+- request:
+    method: put
+    uri: http://localhost:3200/source/BaseDistro:Update/_config
+    body:
+      encoding: UTF-8
+      string: Nisi voluptatem optio sunt mollitia itaque et. Consequatur aperiam repellendus
+        ut. Voluptas dolorum aperiam animi. Reiciendis non corporis. Id ipsum eos
+        sed hic consequatur beatae commodi.
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '21'
+    body:
+      encoding: UTF-8
+      string: '<status code="ok" />
+
+'
+    http_version: 
+  recorded_at: Wed, 16 Nov 2016 13:33:17 GMT
+- request:
+    method: put
+    uri: http://localhost:3200/source/home:tom/_meta?user=tom
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:tom">
+          <title/>
+          <description/>
+          <person userid="tom" role="maintainer"/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '129'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:tom">
+          <title></title>
+          <description></description>
+          <person userid="tom" role="maintainer" />
+        </project>
+    http_version: 
+  recorded_at: Wed, 16 Nov 2016 13:33:17 GMT
+- request:
+    method: put
+    uri: http://localhost:3200/source/openSUSE_Leap/_meta
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="openSUSE_Leap">
+          <title>Unweaving the Rainbow</title>
+          <description/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '111'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="openSUSE_Leap">
+          <title>Unweaving the Rainbow</title>
+          <description></description>
+        </project>
+    http_version: 
+  recorded_at: Wed, 16 Nov 2016 13:33:17 GMT
+- request:
+    method: put
+    uri: http://localhost:3200/source/openSUSE_Leap/_config
+    body:
+      encoding: UTF-8
+      string: Ut harum porro unde quasi. Rem blanditiis dolores impedit. Sit neque
+        corrupti autem necessitatibus eum.
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '21'
+    body:
+      encoding: UTF-8
+      string: '<status code="ok" />
+
+'
+    http_version: 
+  recorded_at: Wed, 16 Nov 2016 13:33:17 GMT
+- request:
+    method: put
+    uri: http://localhost:3200/source/openSUSE_Leap/apache2/_meta?user=tom
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="apache2" project="openSUSE_Leap">
+          <title/>
+          <description/>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '108'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="apache2" project="openSUSE_Leap">
+          <title></title>
+          <description></description>
+        </package>
+    http_version: 
+  recorded_at: Wed, 16 Nov 2016 13:33:17 GMT
+- request:
+    method: put
+    uri: http://localhost:3200/source/openSUSE_Leap/apache2/_meta
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="apache2" project="openSUSE_Leap">
+          <title/>
+          <description/>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '108'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="apache2" project="openSUSE_Leap">
+          <title></title>
+          <description></description>
+        </package>
+    http_version: 
+  recorded_at: Wed, 16 Nov 2016 13:33:17 GMT
+- request:
+    method: put
+    uri: http://localhost:3200/source/openSUSE_tw/_meta
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="openSUSE_tw">
+          <title>To a God Unknown</title>
+          <description/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '104'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="openSUSE_tw">
+          <title>To a God Unknown</title>
+          <description></description>
+        </project>
+    http_version: 
+  recorded_at: Wed, 16 Nov 2016 13:33:17 GMT
+- request:
+    method: put
+    uri: http://localhost:3200/source/openSUSE_tw/_config
+    body:
+      encoding: UTF-8
+      string: Magnam quos nihil ut numquam rerum esse. Voluptas sit eaque rerum voluptate
+        quidem aliquid. Provident et excepturi eius aut accusamus quam quo. Quod magnam
+        ex et et dolorem non. Odit omnis fugit adipisci.
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '21'
+    body:
+      encoding: UTF-8
+      string: '<status code="ok" />
+
+'
+    http_version: 
+  recorded_at: Wed, 16 Nov 2016 13:33:17 GMT
+- request:
+    method: put
+    uri: http://localhost:3200/source/openSUSE_tw/foo/_meta?user=tom
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="foo" project="openSUSE_tw">
+          <title/>
+          <description/>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '102'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="foo" project="openSUSE_tw">
+          <title></title>
+          <description></description>
+        </package>
+    http_version: 
+  recorded_at: Wed, 16 Nov 2016 13:33:18 GMT
+- request:
+    method: put
+    uri: http://localhost:3200/source/openSUSE_tw/foo/_meta
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="foo" project="openSUSE_tw">
+          <title/>
+          <description/>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '102'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="foo" project="openSUSE_tw">
+          <title></title>
+          <description></description>
+        </package>
+    http_version: 
+  recorded_at: Wed, 16 Nov 2016 13:33:18 GMT
+- request:
+    method: post
+    uri: http://localhost:3200/search/package/id?match=(linkinfo/@package=%22foo%22%20and%20linkinfo/@project=%22openSUSE_tw%22%20and%20@project=%22openSUSE_tw%22)
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Content-Type:
+      - application/octet-stream
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '27'
+    body:
+      encoding: UTF-8
+      string: |
+        <collection>
+        </collection>
+    http_version: 
+  recorded_at: Wed, 16 Nov 2016 13:33:18 GMT
+- request:
+    method: put
+    uri: http://localhost:3200/source/home:tom:branches:openSUSE_tw/_meta?user=tom
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:tom:branches:openSUSE_tw">
+          <title>Branch project for package foo</title>
+          <description>This project was created for package foo via attribute OBS:Maintained</description>
+          <person userid="tom" role="maintainer"/>
+          <publish>
+            <disable/>
+          </publish>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '290'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:tom:branches:openSUSE_tw">
+          <title>Branch project for package foo</title>
+          <description>This project was created for package foo via attribute OBS:Maintained</description>
+          <person userid="tom" role="maintainer" />
+          <publish>
+            <disable />
+          </publish>
+        </project>
+    http_version: 
+  recorded_at: Wed, 16 Nov 2016 13:33:18 GMT
+- request:
+    method: put
+    uri: http://localhost:3200/source/home:tom:branches:openSUSE_tw/foo/_meta?user=tom
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="foo" project="home:tom:branches:openSUSE_tw">
+          <title/>
+          <description/>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '120'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="foo" project="home:tom:branches:openSUSE_tw">
+          <title></title>
+          <description></description>
+        </package>
+    http_version: 
+  recorded_at: Wed, 16 Nov 2016 13:33:18 GMT
+- request:
+    method: put
+    uri: http://localhost:3200/source/home:tom:branches:openSUSE_tw/foo/_meta?user=tom
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="foo" project="home:tom:branches:openSUSE_tw">
+          <title/>
+          <description/>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '120'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="foo" project="home:tom:branches:openSUSE_tw">
+          <title></title>
+          <description></description>
+        </package>
+    http_version: 
+  recorded_at: Wed, 16 Nov 2016 13:33:18 GMT
+- request:
+    method: post
+    uri: http://localhost:3200/source/home:tom:branches:openSUSE_tw/foo?cmd=branch&opackage=foo&oproject=openSUSE_tw&user=tom
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Content-Type:
+      - application/octet-stream
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '203'
+    body:
+      encoding: UTF-8
+      string: |
+        <revision rev="2" vrev="2">
+          <srcmd5>758b5c98e244a423d8cced9119759c74</srcmd5>
+          <version>unknown</version>
+          <time>1479303198</time>
+          <user>tom</user>
+          <comment></comment>
+          <requestid/>
+        </revision>
+    http_version: 
+  recorded_at: Wed, 16 Nov 2016 13:33:18 GMT
+- request:
+    method: get
+    uri: http://localhost:3200/source/home:tom:branches:openSUSE_tw/foo
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '411'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="foo" rev="2" vrev="2" srcmd5="758b5c98e244a423d8cced9119759c74">
+          <linkinfo project="openSUSE_tw" package="foo" srcmd5="d41d8cd98f00b204e9800998ecf8427e" baserev="d41d8cd98f00b204e9800998ecf8427e" xsrcmd5="2ff7ebca03c33454e5b27f2fd9fd3b7e" lsrcmd5="758b5c98e244a423d8cced9119759c74" />
+          <entry name="_link" md5="dd77ca022ead3d84e2e42f7345da573c" size="119" mtime="1479301675" />
+        </directory>
+    http_version: 
+  recorded_at: Wed, 16 Nov 2016 13:33:19 GMT
+- request:
+    method: get
+    uri: http://localhost:3200/source/home:tom:branches:openSUSE_tw/foo?nofilename=1&view=info&withchangesmd5=1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '269'
+    body:
+      encoding: UTF-8
+      string: |
+        <sourceinfo package="foo" rev="2" vrev="2" srcmd5="2ff7ebca03c33454e5b27f2fd9fd3b7e" lsrcmd5="758b5c98e244a423d8cced9119759c74" verifymd5="d41d8cd98f00b204e9800998ecf8427e">
+          <linked project="openSUSE_tw" package="foo" />
+          <revtime>1479303198</revtime>
+        </sourceinfo>
+    http_version: 
+  recorded_at: Wed, 16 Nov 2016 13:33:19 GMT
+- request:
+    method: get
+    uri: http://localhost:3200/source/home:tom:branches:openSUSE_tw/foo
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '411'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="foo" rev="2" vrev="2" srcmd5="758b5c98e244a423d8cced9119759c74">
+          <linkinfo project="openSUSE_tw" package="foo" srcmd5="d41d8cd98f00b204e9800998ecf8427e" baserev="d41d8cd98f00b204e9800998ecf8427e" xsrcmd5="2ff7ebca03c33454e5b27f2fd9fd3b7e" lsrcmd5="758b5c98e244a423d8cced9119759c74" />
+          <entry name="_link" md5="dd77ca022ead3d84e2e42f7345da573c" size="119" mtime="1479301675" />
+        </directory>
+    http_version: 
+  recorded_at: Wed, 16 Nov 2016 13:33:19 GMT
+- request:
+    method: post
+    uri: http://localhost:3200/source/home:tom:branches:openSUSE_tw/foo?cmd=diff&linkrev=base&onlyissues=1&orev=0&view=xml
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Content-Type:
+      - application/octet-stream
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Content-Length:
+      - '329'
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+    body:
+      encoding: UTF-8
+      string: |
+        <sourcediff key="1799be1abc19d158f6c2773e2f5b43c7">
+          <old project="home:tom:branches:openSUSE_tw" package="foo" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e" />
+          <new project="home:tom:branches:openSUSE_tw" package="foo" rev="1" srcmd5="758b5c98e244a423d8cced9119759c74" />
+          <files />
+          <issues>
+          </issues>
+        </sourcediff>
+    http_version: 
+  recorded_at: Wed, 16 Nov 2016 13:33:19 GMT
+- request:
+    method: post
+    uri: http://localhost:3200/source/home:tom:branches:openSUSE_tw/foo?cmd=linkdiff&linkrev=base&onlyissues=1&view=xml
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Content-Type:
+      - application/octet-stream
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '350'
+    body:
+      encoding: UTF-8
+      string: |
+        <sourcediff key="f2c16ffe7a480e924e71f2b23e5aace6">
+          <old project="openSUSE_tw" package="foo" rev="d41d8cd98f00b204e9800998ecf8427e" srcmd5="d41d8cd98f00b204e9800998ecf8427e" />
+          <new project="home:tom:branches:openSUSE_tw" package="foo" rev="2ff7ebca03c33454e5b27f2fd9fd3b7e" srcmd5="2ff7ebca03c33454e5b27f2fd9fd3b7e" />
+          <files />
+        </sourcediff>
+    http_version: 
+  recorded_at: Wed, 16 Nov 2016 13:33:19 GMT
+- request:
+    method: put
+    uri: http://localhost:3200/source/home:tom:branches:openSUSE_tw/_meta?user=tom
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:tom:branches:openSUSE_tw">
+          <title>Branch project for package foo</title>
+          <description>This project was created for package foo via attribute OBS:Maintained</description>
+          <person userid="tom" role="maintainer"/>
+          <publish>
+            <disable/>
+          </publish>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '290'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:tom:branches:openSUSE_tw">
+          <title>Branch project for package foo</title>
+          <description>This project was created for package foo via attribute OBS:Maintained</description>
+          <person userid="tom" role="maintainer" />
+          <publish>
+            <disable />
+          </publish>
+        </project>
+    http_version: 
+  recorded_at: Wed, 16 Nov 2016 13:33:19 GMT
+recorded_with: VCR 3.0.3

--- a/src/api/spec/cassettes/BranchPackage/_branch/project_without_ImageTemplates_attribute/publish_flag/is_disabled_when_Configuration_disable_publish_for_branches_is_false.yml
+++ b/src/api/spec/cassettes/BranchPackage/_branch/project_without_ImageTemplates_attribute/publish_flag/is_disabled_when_Configuration_disable_publish_for_branches_is_false.yml
@@ -1,0 +1,1548 @@
+---
+http_interactions:
+- request:
+    method: put
+    uri: http://localhost:3200/source/BaseDistro/_meta
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="BaseDistro">
+          <title>The Soldier's Art</title>
+          <description/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '104'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="BaseDistro">
+          <title>The Soldier's Art</title>
+          <description></description>
+        </project>
+    http_version: 
+  recorded_at: Wed, 16 Nov 2016 16:02:04 GMT
+- request:
+    method: put
+    uri: http://localhost:3200/source/BaseDistro/_config
+    body:
+      encoding: UTF-8
+      string: Culpa vel mollitia. Atque aut consequatur error ipsum. Repellat exercitationem
+        velit rem praesentium expedita autem illum. Dignissimos deleniti in ullam
+        ea eaque. Qui at et.
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '21'
+    body:
+      encoding: UTF-8
+      string: '<status code="ok" />
+
+'
+    http_version: 
+  recorded_at: Wed, 16 Nov 2016 16:02:04 GMT
+- request:
+    method: put
+    uri: http://localhost:3200/source/BaseDistro/test_package/_meta?user=tom
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="test_package" project="BaseDistro">
+          <title/>
+          <description/>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '110'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="test_package" project="BaseDistro">
+          <title></title>
+          <description></description>
+        </package>
+    http_version: 
+  recorded_at: Wed, 16 Nov 2016 16:02:04 GMT
+- request:
+    method: put
+    uri: http://localhost:3200/source/BaseDistro/test_package/_meta
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="test_package" project="BaseDistro">
+          <title/>
+          <description/>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '110'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="test_package" project="BaseDistro">
+          <title></title>
+          <description></description>
+        </package>
+    http_version: 
+  recorded_at: Wed, 16 Nov 2016 16:02:04 GMT
+- request:
+    method: put
+    uri: http://localhost:3200/source/BaseDistro:Update/_meta
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="BaseDistro:Update">
+          <title>nfinite Jest</title>
+          <description/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '106'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="BaseDistro:Update">
+          <title>nfinite Jest</title>
+          <description></description>
+        </project>
+    http_version: 
+  recorded_at: Wed, 16 Nov 2016 16:02:04 GMT
+- request:
+    method: put
+    uri: http://localhost:3200/source/BaseDistro:Update/_config
+    body:
+      encoding: UTF-8
+      string: Est voluptatum sunt ex dolorem id. Consequuntur a blanditiis et. Blanditiis
+        dolor minima.
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '21'
+    body:
+      encoding: UTF-8
+      string: '<status code="ok" />
+
+'
+    http_version: 
+  recorded_at: Wed, 16 Nov 2016 16:02:04 GMT
+- request:
+    method: put
+    uri: http://localhost:3200/source/home:tom/_meta?user=tom
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:tom">
+          <title/>
+          <description/>
+          <person userid="tom" role="maintainer"/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '129'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:tom">
+          <title></title>
+          <description></description>
+          <person userid="tom" role="maintainer" />
+        </project>
+    http_version: 
+  recorded_at: Wed, 16 Nov 2016 16:02:04 GMT
+- request:
+    method: put
+    uri: http://localhost:3200/source/openSUSE_13/_meta
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="openSUSE_13">
+          <title>The Cricket on the Hearth</title>
+          <description/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '113'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="openSUSE_13">
+          <title>The Cricket on the Hearth</title>
+          <description></description>
+        </project>
+    http_version: 
+  recorded_at: Wed, 16 Nov 2016 16:02:04 GMT
+- request:
+    method: put
+    uri: http://localhost:3200/source/openSUSE_13/_config
+    body:
+      encoding: UTF-8
+      string: Illum nihil assumenda voluptatem ut. Ipsum temporibus rem rerum. Molestiae
+        aut dolorem molestiae voluptate. Dignissimos vel facere similique quo at saepe.
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '21'
+    body:
+      encoding: UTF-8
+      string: '<status code="ok" />
+
+'
+    http_version: 
+  recorded_at: Wed, 16 Nov 2016 16:02:04 GMT
+- request:
+    method: put
+    uri: http://localhost:3200/source/openSUSE_13/apache2/_meta?user=tom
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="apache2" project="openSUSE_13">
+          <title/>
+          <description/>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '106'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="apache2" project="openSUSE_13">
+          <title></title>
+          <description></description>
+        </package>
+    http_version: 
+  recorded_at: Wed, 16 Nov 2016 16:02:04 GMT
+- request:
+    method: put
+    uri: http://localhost:3200/source/openSUSE_13/apache2/_meta
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="apache2" project="openSUSE_13">
+          <title/>
+          <description/>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '106'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="apache2" project="openSUSE_13">
+          <title></title>
+          <description></description>
+        </package>
+    http_version: 
+  recorded_at: Wed, 16 Nov 2016 16:02:04 GMT
+- request:
+    method: put
+    uri: http://localhost:3200/source/openSUSE_13/apache2/_meta?user=tom
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="apache2" project="openSUSE_13">
+          <title/>
+          <description/>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '106'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="apache2" project="openSUSE_13">
+          <title></title>
+          <description></description>
+        </package>
+    http_version: 
+  recorded_at: Wed, 16 Nov 2016 16:02:04 GMT
+- request:
+    method: post
+    uri: http://localhost:3200/search/package/id?match=(linkinfo/@package=%22apache2%22%20and%20linkinfo/@project=%22openSUSE_13%22%20and%20@project=%22openSUSE_13%22)
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Content-Type:
+      - application/octet-stream
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '27'
+    body:
+      encoding: UTF-8
+      string: |
+        <collection>
+        </collection>
+    http_version: 
+  recorded_at: Wed, 16 Nov 2016 16:02:04 GMT
+- request:
+    method: put
+    uri: http://localhost:3200/source/home:tom:branches:openSUSE_13/_meta?user=tom
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:tom:branches:openSUSE_13">
+          <title>Branch project for package apache2</title>
+          <description>This project was created for package apache2 via attribute OBS:Maintained</description>
+          <person userid="tom" role="maintainer"/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '257'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:tom:branches:openSUSE_13">
+          <title>Branch project for package apache2</title>
+          <description>This project was created for package apache2 via attribute OBS:Maintained</description>
+          <person userid="tom" role="maintainer" />
+        </project>
+    http_version: 
+  recorded_at: Wed, 16 Nov 2016 16:02:04 GMT
+- request:
+    method: put
+    uri: http://localhost:3200/source/home:tom:branches:openSUSE_13/apache2/_meta?user=tom
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="apache2" project="home:tom:branches:openSUSE_13">
+          <title/>
+          <description/>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '124'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="apache2" project="home:tom:branches:openSUSE_13">
+          <title></title>
+          <description></description>
+        </package>
+    http_version: 
+  recorded_at: Wed, 16 Nov 2016 16:02:05 GMT
+- request:
+    method: put
+    uri: http://localhost:3200/source/home:tom:branches:openSUSE_13/apache2/_meta?user=tom
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="apache2" project="home:tom:branches:openSUSE_13">
+          <title/>
+          <description/>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '124'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="apache2" project="home:tom:branches:openSUSE_13">
+          <title></title>
+          <description></description>
+        </package>
+    http_version: 
+  recorded_at: Wed, 16 Nov 2016 16:02:05 GMT
+- request:
+    method: post
+    uri: http://localhost:3200/source/home:tom:branches:openSUSE_13/apache2?cmd=branch&opackage=apache2&oproject=openSUSE_13&user=tom
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Content-Type:
+      - application/octet-stream
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '203'
+    body:
+      encoding: UTF-8
+      string: |
+        <revision rev="1" vrev="1">
+          <srcmd5>2e9bda1e11a1379f8e25b8babaee88f9</srcmd5>
+          <version>unknown</version>
+          <time>1479312125</time>
+          <user>tom</user>
+          <comment></comment>
+          <requestid/>
+        </revision>
+    http_version: 
+  recorded_at: Wed, 16 Nov 2016 16:02:05 GMT
+- request:
+    method: get
+    uri: http://localhost:3200/source/home:tom:branches:openSUSE_13/apache2
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '419'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="apache2" rev="1" vrev="1" srcmd5="2e9bda1e11a1379f8e25b8babaee88f9">
+          <linkinfo project="openSUSE_13" package="apache2" srcmd5="d41d8cd98f00b204e9800998ecf8427e" baserev="d41d8cd98f00b204e9800998ecf8427e" xsrcmd5="92b3d648bcf2f85e4050424c0a981abe" lsrcmd5="2e9bda1e11a1379f8e25b8babaee88f9" />
+          <entry name="_link" md5="194911a662dfa88b6a38dcc39abbe2ad" size="119" mtime="1479309535" />
+        </directory>
+    http_version: 
+  recorded_at: Wed, 16 Nov 2016 16:02:05 GMT
+- request:
+    method: get
+    uri: http://localhost:3200/source/home:tom:branches:openSUSE_13/apache2?nofilename=1&view=info&withchangesmd5=1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '277'
+    body:
+      encoding: UTF-8
+      string: |
+        <sourceinfo package="apache2" rev="1" vrev="1" srcmd5="92b3d648bcf2f85e4050424c0a981abe" lsrcmd5="2e9bda1e11a1379f8e25b8babaee88f9" verifymd5="d41d8cd98f00b204e9800998ecf8427e">
+          <linked project="openSUSE_13" package="apache2" />
+          <revtime>1479312125</revtime>
+        </sourceinfo>
+    http_version: 
+  recorded_at: Wed, 16 Nov 2016 16:02:05 GMT
+- request:
+    method: get
+    uri: http://localhost:3200/source/home:tom:branches:openSUSE_13/apache2
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '419'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="apache2" rev="1" vrev="1" srcmd5="2e9bda1e11a1379f8e25b8babaee88f9">
+          <linkinfo project="openSUSE_13" package="apache2" srcmd5="d41d8cd98f00b204e9800998ecf8427e" baserev="d41d8cd98f00b204e9800998ecf8427e" xsrcmd5="92b3d648bcf2f85e4050424c0a981abe" lsrcmd5="2e9bda1e11a1379f8e25b8babaee88f9" />
+          <entry name="_link" md5="194911a662dfa88b6a38dcc39abbe2ad" size="119" mtime="1479309535" />
+        </directory>
+    http_version: 
+  recorded_at: Wed, 16 Nov 2016 16:02:05 GMT
+- request:
+    method: post
+    uri: http://localhost:3200/source/home:tom:branches:openSUSE_13/apache2?cmd=diff&linkrev=base&onlyissues=1&orev=0&view=xml
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Content-Type:
+      - application/octet-stream
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Content-Length:
+      - '337'
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+    body:
+      encoding: UTF-8
+      string: |
+        <sourcediff key="152e58fbe1a340415cfef532ec8cb21f">
+          <old project="home:tom:branches:openSUSE_13" package="apache2" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e" />
+          <new project="home:tom:branches:openSUSE_13" package="apache2" rev="1" srcmd5="2e9bda1e11a1379f8e25b8babaee88f9" />
+          <files />
+          <issues>
+          </issues>
+        </sourcediff>
+    http_version: 
+  recorded_at: Wed, 16 Nov 2016 16:02:05 GMT
+- request:
+    method: post
+    uri: http://localhost:3200/source/home:tom:branches:openSUSE_13/apache2?cmd=linkdiff&linkrev=base&onlyissues=1&view=xml
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Content-Type:
+      - application/octet-stream
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '358'
+    body:
+      encoding: UTF-8
+      string: |
+        <sourcediff key="2a074dbcff8f311ea1010d065a6b8ddd">
+          <old project="openSUSE_13" package="apache2" rev="d41d8cd98f00b204e9800998ecf8427e" srcmd5="d41d8cd98f00b204e9800998ecf8427e" />
+          <new project="home:tom:branches:openSUSE_13" package="apache2" rev="92b3d648bcf2f85e4050424c0a981abe" srcmd5="92b3d648bcf2f85e4050424c0a981abe" />
+          <files />
+        </sourcediff>
+    http_version: 
+  recorded_at: Wed, 16 Nov 2016 16:02:05 GMT
+- request:
+    method: put
+    uri: http://localhost:3200/source/home:tom:branches:openSUSE_13/_meta?user=tom
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:tom:branches:openSUSE_13">
+          <title>Branch project for package apache2</title>
+          <description>This project was created for package apache2 via attribute OBS:Maintained</description>
+          <person userid="tom" role="maintainer"/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '257'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:tom:branches:openSUSE_13">
+          <title>Branch project for package apache2</title>
+          <description>This project was created for package apache2 via attribute OBS:Maintained</description>
+          <person userid="tom" role="maintainer" />
+        </project>
+    http_version: 
+  recorded_at: Wed, 16 Nov 2016 16:02:05 GMT
+- request:
+    method: delete
+    uri: http://localhost:3200/source/home:tom:branches:openSUSE_13?comment&user=tom
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '21'
+    body:
+      encoding: UTF-8
+      string: '<status code="ok" />
+
+'
+    http_version: 
+  recorded_at: Wed, 16 Nov 2016 16:02:05 GMT
+- request:
+    method: put
+    uri: http://localhost:3200/source/openSUSE_Leap/_meta
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="openSUSE_Leap">
+          <title>A Handful of Dust</title>
+          <description/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '107'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="openSUSE_Leap">
+          <title>A Handful of Dust</title>
+          <description></description>
+        </project>
+    http_version: 
+  recorded_at: Wed, 16 Nov 2016 16:16:42 GMT
+- request:
+    method: put
+    uri: http://localhost:3200/source/openSUSE_Leap/_config
+    body:
+      encoding: UTF-8
+      string: Sit cumque consequatur itaque aliquid et blanditiis. Amet eos maiores.
+        Est id eveniet dolorem minus sapiente quas. Exercitationem ipsa dolorem quis
+        consequatur magnam ad rerum. Enim et id dolorem voluptas.
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '21'
+    body:
+      encoding: UTF-8
+      string: '<status code="ok" />
+
+'
+    http_version: 
+  recorded_at: Wed, 16 Nov 2016 16:16:42 GMT
+- request:
+    method: put
+    uri: http://localhost:3200/source/openSUSE_Leap/apache2/_meta?user=tom
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="apache2" project="openSUSE_Leap">
+          <title/>
+          <description/>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '108'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="apache2" project="openSUSE_Leap">
+          <title></title>
+          <description></description>
+        </package>
+    http_version: 
+  recorded_at: Wed, 16 Nov 2016 16:16:43 GMT
+- request:
+    method: put
+    uri: http://localhost:3200/source/openSUSE_Leap/apache2/_meta
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="apache2" project="openSUSE_Leap">
+          <title/>
+          <description/>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '108'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="apache2" project="openSUSE_Leap">
+          <title></title>
+          <description></description>
+        </package>
+    http_version: 
+  recorded_at: Wed, 16 Nov 2016 16:16:43 GMT
+- request:
+    method: post
+    uri: http://localhost:3200/search/package/id?match=(linkinfo/@package=%22apache2%22%20and%20linkinfo/@project=%22openSUSE_Leap%22%20and%20@project=%22openSUSE_Leap%22)
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Content-Type:
+      - application/octet-stream
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '27'
+    body:
+      encoding: UTF-8
+      string: |
+        <collection>
+        </collection>
+    http_version: 
+  recorded_at: Wed, 16 Nov 2016 16:16:43 GMT
+- request:
+    method: put
+    uri: http://localhost:3200/source/home:tom:branches:openSUSE_Leap/_meta?user=tom
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:tom:branches:openSUSE_Leap">
+          <title>Branch project for package apache2</title>
+          <description>This project was created for package apache2 via attribute OBS:Maintained</description>
+          <person userid="tom" role="maintainer"/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '259'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:tom:branches:openSUSE_Leap">
+          <title>Branch project for package apache2</title>
+          <description>This project was created for package apache2 via attribute OBS:Maintained</description>
+          <person userid="tom" role="maintainer" />
+        </project>
+    http_version: 
+  recorded_at: Wed, 16 Nov 2016 16:16:43 GMT
+- request:
+    method: put
+    uri: http://localhost:3200/source/home:tom:branches:openSUSE_Leap/apache2/_meta?user=tom
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="apache2" project="home:tom:branches:openSUSE_Leap">
+          <title/>
+          <description/>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '126'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="apache2" project="home:tom:branches:openSUSE_Leap">
+          <title></title>
+          <description></description>
+        </package>
+    http_version: 
+  recorded_at: Wed, 16 Nov 2016 16:16:43 GMT
+- request:
+    method: put
+    uri: http://localhost:3200/source/home:tom:branches:openSUSE_Leap/apache2/_meta?user=tom
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="apache2" project="home:tom:branches:openSUSE_Leap">
+          <title/>
+          <description/>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '126'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="apache2" project="home:tom:branches:openSUSE_Leap">
+          <title></title>
+          <description></description>
+        </package>
+    http_version: 
+  recorded_at: Wed, 16 Nov 2016 16:16:43 GMT
+- request:
+    method: post
+    uri: http://localhost:3200/source/home:tom:branches:openSUSE_Leap/apache2?cmd=branch&opackage=apache2&oproject=openSUSE_Leap&user=tom
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Content-Type:
+      - application/octet-stream
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '203'
+    body:
+      encoding: UTF-8
+      string: |
+        <revision rev="1" vrev="1">
+          <srcmd5>f2b6eaf02987245b9003bcf47e0222dc</srcmd5>
+          <version>unknown</version>
+          <time>1479313003</time>
+          <user>tom</user>
+          <comment></comment>
+          <requestid/>
+        </revision>
+    http_version: 
+  recorded_at: Wed, 16 Nov 2016 16:16:43 GMT
+- request:
+    method: get
+    uri: http://localhost:3200/source/home:tom:branches:openSUSE_Leap/apache2
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '421'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="apache2" rev="1" vrev="1" srcmd5="f2b6eaf02987245b9003bcf47e0222dc">
+          <linkinfo project="openSUSE_Leap" package="apache2" srcmd5="d41d8cd98f00b204e9800998ecf8427e" baserev="d41d8cd98f00b204e9800998ecf8427e" xsrcmd5="2fbc15ae60271e3fe13b837e014a17ea" lsrcmd5="f2b6eaf02987245b9003bcf47e0222dc" />
+          <entry name="_link" md5="42ab2fdb360424b79deaaaec3dcd12ff" size="121" mtime="1479304500" />
+        </directory>
+    http_version: 
+  recorded_at: Wed, 16 Nov 2016 16:16:43 GMT
+- request:
+    method: get
+    uri: http://localhost:3200/source/home:tom:branches:openSUSE_Leap/apache2?nofilename=1&view=info&withchangesmd5=1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '279'
+    body:
+      encoding: UTF-8
+      string: |
+        <sourceinfo package="apache2" rev="1" vrev="1" srcmd5="2fbc15ae60271e3fe13b837e014a17ea" lsrcmd5="f2b6eaf02987245b9003bcf47e0222dc" verifymd5="d41d8cd98f00b204e9800998ecf8427e">
+          <linked project="openSUSE_Leap" package="apache2" />
+          <revtime>1479313003</revtime>
+        </sourceinfo>
+    http_version: 
+  recorded_at: Wed, 16 Nov 2016 16:16:43 GMT
+- request:
+    method: get
+    uri: http://localhost:3200/source/home:tom:branches:openSUSE_Leap/apache2
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '421'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="apache2" rev="1" vrev="1" srcmd5="f2b6eaf02987245b9003bcf47e0222dc">
+          <linkinfo project="openSUSE_Leap" package="apache2" srcmd5="d41d8cd98f00b204e9800998ecf8427e" baserev="d41d8cd98f00b204e9800998ecf8427e" xsrcmd5="2fbc15ae60271e3fe13b837e014a17ea" lsrcmd5="f2b6eaf02987245b9003bcf47e0222dc" />
+          <entry name="_link" md5="42ab2fdb360424b79deaaaec3dcd12ff" size="121" mtime="1479304500" />
+        </directory>
+    http_version: 
+  recorded_at: Wed, 16 Nov 2016 16:16:43 GMT
+- request:
+    method: post
+    uri: http://localhost:3200/source/home:tom:branches:openSUSE_Leap/apache2?cmd=diff&linkrev=base&onlyissues=1&orev=0&view=xml
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Content-Type:
+      - application/octet-stream
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Content-Length:
+      - '341'
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+    body:
+      encoding: UTF-8
+      string: |
+        <sourcediff key="b4eb9aa75778707a23b6f6a8cfd9aced">
+          <old project="home:tom:branches:openSUSE_Leap" package="apache2" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e" />
+          <new project="home:tom:branches:openSUSE_Leap" package="apache2" rev="1" srcmd5="f2b6eaf02987245b9003bcf47e0222dc" />
+          <files />
+          <issues>
+          </issues>
+        </sourcediff>
+    http_version: 
+  recorded_at: Wed, 16 Nov 2016 16:16:43 GMT
+- request:
+    method: post
+    uri: http://localhost:3200/source/home:tom:branches:openSUSE_Leap/apache2?cmd=linkdiff&linkrev=base&onlyissues=1&view=xml
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Content-Type:
+      - application/octet-stream
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '362'
+    body:
+      encoding: UTF-8
+      string: |
+        <sourcediff key="1c6621e539f5863fcf3a10f8baf9b790">
+          <old project="openSUSE_Leap" package="apache2" rev="d41d8cd98f00b204e9800998ecf8427e" srcmd5="d41d8cd98f00b204e9800998ecf8427e" />
+          <new project="home:tom:branches:openSUSE_Leap" package="apache2" rev="2fbc15ae60271e3fe13b837e014a17ea" srcmd5="2fbc15ae60271e3fe13b837e014a17ea" />
+          <files />
+        </sourcediff>
+    http_version: 
+  recorded_at: Wed, 16 Nov 2016 16:16:43 GMT
+- request:
+    method: put
+    uri: http://localhost:3200/source/home:tom:branches:openSUSE_Leap/_meta?user=tom
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:tom:branches:openSUSE_Leap">
+          <title>Branch project for package apache2</title>
+          <description>This project was created for package apache2 via attribute OBS:Maintained</description>
+          <person userid="tom" role="maintainer"/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '259'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:tom:branches:openSUSE_Leap">
+          <title>Branch project for package apache2</title>
+          <description>This project was created for package apache2 via attribute OBS:Maintained</description>
+          <person userid="tom" role="maintainer" />
+        </project>
+    http_version: 
+  recorded_at: Wed, 16 Nov 2016 16:16:43 GMT
+- request:
+    method: delete
+    uri: http://localhost:3200/source/home:tom:branches:openSUSE_Leap?comment&user=tom
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '21'
+    body:
+      encoding: UTF-8
+      string: '<status code="ok" />
+
+'
+    http_version: 
+  recorded_at: Wed, 16 Nov 2016 16:16:43 GMT
+- request:
+    method: post
+    uri: http://localhost:3200/source/home:tom:branches:BaseDistro:Update/test_package?cmd=branch&missingok=1&opackage=test_package&oproject=BaseDistro:Update&user=tom
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Content-Type:
+      - application/octet-stream
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 404
+      message: project 'home tom branches BaseDistro Update' does not exist
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '198'
+    body:
+      encoding: UTF-8
+      string: |
+        <status code="404">
+          <summary>project 'home:tom:branches:BaseDistro:Update' does not exist</summary>
+          <details>404 project 'home:tom:branches:BaseDistro:Update' does not exist</details>
+        </status>
+    http_version: 
+  recorded_at: Thu, 24 Nov 2016 20:55:26 GMT
+recorded_with: VCR 3.0.3

--- a/src/api/spec/cassettes/BranchPackage/_branch/project_without_ImageTemplates_attribute/publish_flag/is_enabled_by_default.yml
+++ b/src/api/spec/cassettes/BranchPackage/_branch/project_without_ImageTemplates_attribute/publish_flag/is_enabled_by_default.yml
@@ -1,0 +1,1560 @@
+---
+http_interactions:
+- request:
+    method: put
+    uri: http://localhost:3200/source/BaseDistro/_meta
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="BaseDistro">
+          <title>O Pioneers!</title>
+          <description/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '98'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="BaseDistro">
+          <title>O Pioneers!</title>
+          <description></description>
+        </project>
+    http_version: 
+  recorded_at: Wed, 16 Nov 2016 16:02:02 GMT
+- request:
+    method: put
+    uri: http://localhost:3200/source/BaseDistro/_config
+    body:
+      encoding: UTF-8
+      string: Et id asperiores ab. Et quae magnam voluptatem beatae nesciunt saepe.
+        Impedit nostrum natus error et. Quo et commodi.
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '21'
+    body:
+      encoding: UTF-8
+      string: '<status code="ok" />
+
+'
+    http_version: 
+  recorded_at: Wed, 16 Nov 2016 16:02:02 GMT
+- request:
+    method: put
+    uri: http://localhost:3200/source/BaseDistro/test_package/_meta?user=tom
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="test_package" project="BaseDistro">
+          <title/>
+          <description/>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '110'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="test_package" project="BaseDistro">
+          <title></title>
+          <description></description>
+        </package>
+    http_version: 
+  recorded_at: Wed, 16 Nov 2016 16:02:02 GMT
+- request:
+    method: put
+    uri: http://localhost:3200/source/BaseDistro/test_package/_meta
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="test_package" project="BaseDistro">
+          <title/>
+          <description/>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '110'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="test_package" project="BaseDistro">
+          <title></title>
+          <description></description>
+        </package>
+    http_version: 
+  recorded_at: Wed, 16 Nov 2016 16:02:02 GMT
+- request:
+    method: put
+    uri: http://localhost:3200/source/BaseDistro:Update/_meta
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="BaseDistro:Update">
+          <title>A Swiftly Tilting Planet</title>
+          <description/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '118'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="BaseDistro:Update">
+          <title>A Swiftly Tilting Planet</title>
+          <description></description>
+        </project>
+    http_version: 
+  recorded_at: Wed, 16 Nov 2016 16:02:02 GMT
+- request:
+    method: put
+    uri: http://localhost:3200/source/BaseDistro:Update/_config
+    body:
+      encoding: UTF-8
+      string: Aut ut sit nihil excepturi autem quos. A corrupti deserunt officiis
+        natus unde reiciendis. Quos in soluta asperiores dicta. Velit nisi corrupti
+        qui illum asperiores animi nulla.
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '21'
+    body:
+      encoding: UTF-8
+      string: '<status code="ok" />
+
+'
+    http_version: 
+  recorded_at: Wed, 16 Nov 2016 16:02:02 GMT
+- request:
+    method: put
+    uri: http://localhost:3200/source/home:tom/_meta?user=tom
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:tom">
+          <title/>
+          <description/>
+          <person userid="tom" role="maintainer"/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '129'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:tom">
+          <title></title>
+          <description></description>
+          <person userid="tom" role="maintainer" />
+        </project>
+    http_version: 
+  recorded_at: Wed, 16 Nov 2016 16:02:03 GMT
+- request:
+    method: put
+    uri: http://localhost:3200/source/openSUSE_13/_meta
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="openSUSE_13">
+          <title>The Stars' Tennis Balls</title>
+          <description/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '111'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="openSUSE_13">
+          <title>The Stars' Tennis Balls</title>
+          <description></description>
+        </project>
+    http_version: 
+  recorded_at: Wed, 16 Nov 2016 16:02:03 GMT
+- request:
+    method: put
+    uri: http://localhost:3200/source/openSUSE_13/_config
+    body:
+      encoding: UTF-8
+      string: Laudantium vel voluptas. Aliquid perferendis architecto. Illum quidem
+        qui quia nam ea reiciendis. Laudantium non deleniti enim.
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '21'
+    body:
+      encoding: UTF-8
+      string: '<status code="ok" />
+
+'
+    http_version: 
+  recorded_at: Wed, 16 Nov 2016 16:02:03 GMT
+- request:
+    method: put
+    uri: http://localhost:3200/source/openSUSE_13/apache2/_meta?user=tom
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="apache2" project="openSUSE_13">
+          <title/>
+          <description/>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '106'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="apache2" project="openSUSE_13">
+          <title></title>
+          <description></description>
+        </package>
+    http_version: 
+  recorded_at: Wed, 16 Nov 2016 16:02:03 GMT
+- request:
+    method: put
+    uri: http://localhost:3200/source/openSUSE_13/apache2/_meta
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="apache2" project="openSUSE_13">
+          <title/>
+          <description/>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '106'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="apache2" project="openSUSE_13">
+          <title></title>
+          <description></description>
+        </package>
+    http_version: 
+  recorded_at: Wed, 16 Nov 2016 16:02:03 GMT
+- request:
+    method: put
+    uri: http://localhost:3200/source/openSUSE_13/apache2/_meta?user=tom
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="apache2" project="openSUSE_13">
+          <title/>
+          <description/>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '106'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="apache2" project="openSUSE_13">
+          <title></title>
+          <description></description>
+        </package>
+    http_version: 
+  recorded_at: Wed, 16 Nov 2016 16:02:03 GMT
+- request:
+    method: post
+    uri: http://localhost:3200/search/package/id?match=(linkinfo/@package=%22apache2%22%20and%20linkinfo/@project=%22openSUSE_13%22%20and%20@project=%22openSUSE_13%22)
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Content-Type:
+      - application/octet-stream
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '27'
+    body:
+      encoding: UTF-8
+      string: |
+        <collection>
+        </collection>
+    http_version: 
+  recorded_at: Wed, 16 Nov 2016 16:02:03 GMT
+- request:
+    method: put
+    uri: http://localhost:3200/source/home:tom:branches:openSUSE_13/_meta?user=tom
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:tom:branches:openSUSE_13">
+          <title>Branch project for package apache2</title>
+          <description>This project was created for package apache2 via attribute OBS:Maintained</description>
+          <person userid="tom" role="maintainer"/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '257'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:tom:branches:openSUSE_13">
+          <title>Branch project for package apache2</title>
+          <description>This project was created for package apache2 via attribute OBS:Maintained</description>
+          <person userid="tom" role="maintainer" />
+        </project>
+    http_version: 
+  recorded_at: Wed, 16 Nov 2016 16:02:03 GMT
+- request:
+    method: put
+    uri: http://localhost:3200/source/home:tom:branches:openSUSE_13/apache2/_meta?user=tom
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="apache2" project="home:tom:branches:openSUSE_13">
+          <title/>
+          <description/>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '124'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="apache2" project="home:tom:branches:openSUSE_13">
+          <title></title>
+          <description></description>
+        </package>
+    http_version: 
+  recorded_at: Wed, 16 Nov 2016 16:02:03 GMT
+- request:
+    method: put
+    uri: http://localhost:3200/source/home:tom:branches:openSUSE_13/apache2/_meta?user=tom
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="apache2" project="home:tom:branches:openSUSE_13">
+          <title/>
+          <description/>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '124'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="apache2" project="home:tom:branches:openSUSE_13">
+          <title></title>
+          <description></description>
+        </package>
+    http_version: 
+  recorded_at: Wed, 16 Nov 2016 16:02:03 GMT
+- request:
+    method: post
+    uri: http://localhost:3200/source/home:tom:branches:openSUSE_13/apache2?cmd=branch&opackage=apache2&oproject=openSUSE_13&user=tom
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Content-Type:
+      - application/octet-stream
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '203'
+    body:
+      encoding: UTF-8
+      string: |
+        <revision rev="1" vrev="1">
+          <srcmd5>2e9bda1e11a1379f8e25b8babaee88f9</srcmd5>
+          <version>unknown</version>
+          <time>1479312123</time>
+          <user>tom</user>
+          <comment></comment>
+          <requestid/>
+        </revision>
+    http_version: 
+  recorded_at: Wed, 16 Nov 2016 16:02:03 GMT
+- request:
+    method: get
+    uri: http://localhost:3200/source/home:tom:branches:openSUSE_13/apache2
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '419'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="apache2" rev="1" vrev="1" srcmd5="2e9bda1e11a1379f8e25b8babaee88f9">
+          <linkinfo project="openSUSE_13" package="apache2" srcmd5="d41d8cd98f00b204e9800998ecf8427e" baserev="d41d8cd98f00b204e9800998ecf8427e" xsrcmd5="92b3d648bcf2f85e4050424c0a981abe" lsrcmd5="2e9bda1e11a1379f8e25b8babaee88f9" />
+          <entry name="_link" md5="194911a662dfa88b6a38dcc39abbe2ad" size="119" mtime="1479309535" />
+        </directory>
+    http_version: 
+  recorded_at: Wed, 16 Nov 2016 16:02:03 GMT
+- request:
+    method: get
+    uri: http://localhost:3200/source/home:tom:branches:openSUSE_13/apache2?nofilename=1&view=info&withchangesmd5=1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '277'
+    body:
+      encoding: UTF-8
+      string: |
+        <sourceinfo package="apache2" rev="1" vrev="1" srcmd5="92b3d648bcf2f85e4050424c0a981abe" lsrcmd5="2e9bda1e11a1379f8e25b8babaee88f9" verifymd5="d41d8cd98f00b204e9800998ecf8427e">
+          <linked project="openSUSE_13" package="apache2" />
+          <revtime>1479312123</revtime>
+        </sourceinfo>
+    http_version: 
+  recorded_at: Wed, 16 Nov 2016 16:02:03 GMT
+- request:
+    method: get
+    uri: http://localhost:3200/source/home:tom:branches:openSUSE_13/apache2
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '419'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="apache2" rev="1" vrev="1" srcmd5="2e9bda1e11a1379f8e25b8babaee88f9">
+          <linkinfo project="openSUSE_13" package="apache2" srcmd5="d41d8cd98f00b204e9800998ecf8427e" baserev="d41d8cd98f00b204e9800998ecf8427e" xsrcmd5="92b3d648bcf2f85e4050424c0a981abe" lsrcmd5="2e9bda1e11a1379f8e25b8babaee88f9" />
+          <entry name="_link" md5="194911a662dfa88b6a38dcc39abbe2ad" size="119" mtime="1479309535" />
+        </directory>
+    http_version: 
+  recorded_at: Wed, 16 Nov 2016 16:02:03 GMT
+- request:
+    method: post
+    uri: http://localhost:3200/source/home:tom:branches:openSUSE_13/apache2?cmd=diff&linkrev=base&onlyissues=1&orev=0&view=xml
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Content-Type:
+      - application/octet-stream
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Content-Length:
+      - '337'
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+    body:
+      encoding: UTF-8
+      string: |
+        <sourcediff key="152e58fbe1a340415cfef532ec8cb21f">
+          <old project="home:tom:branches:openSUSE_13" package="apache2" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e" />
+          <new project="home:tom:branches:openSUSE_13" package="apache2" rev="1" srcmd5="2e9bda1e11a1379f8e25b8babaee88f9" />
+          <files />
+          <issues>
+          </issues>
+        </sourcediff>
+    http_version: 
+  recorded_at: Wed, 16 Nov 2016 16:02:03 GMT
+- request:
+    method: post
+    uri: http://localhost:3200/source/home:tom:branches:openSUSE_13/apache2?cmd=linkdiff&linkrev=base&onlyissues=1&view=xml
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Content-Type:
+      - application/octet-stream
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '358'
+    body:
+      encoding: UTF-8
+      string: |
+        <sourcediff key="2a074dbcff8f311ea1010d065a6b8ddd">
+          <old project="openSUSE_13" package="apache2" rev="d41d8cd98f00b204e9800998ecf8427e" srcmd5="d41d8cd98f00b204e9800998ecf8427e" />
+          <new project="home:tom:branches:openSUSE_13" package="apache2" rev="92b3d648bcf2f85e4050424c0a981abe" srcmd5="92b3d648bcf2f85e4050424c0a981abe" />
+          <files />
+        </sourcediff>
+    http_version: 
+  recorded_at: Wed, 16 Nov 2016 16:02:03 GMT
+- request:
+    method: put
+    uri: http://localhost:3200/source/home:tom:branches:openSUSE_13/_meta?user=tom
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:tom:branches:openSUSE_13">
+          <title>Branch project for package apache2</title>
+          <description>This project was created for package apache2 via attribute OBS:Maintained</description>
+          <person userid="tom" role="maintainer"/>
+          <publish>
+            <disable/>
+          </publish>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '298'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:tom:branches:openSUSE_13">
+          <title>Branch project for package apache2</title>
+          <description>This project was created for package apache2 via attribute OBS:Maintained</description>
+          <person userid="tom" role="maintainer" />
+          <publish>
+            <disable />
+          </publish>
+        </project>
+    http_version: 
+  recorded_at: Wed, 16 Nov 2016 16:02:03 GMT
+- request:
+    method: delete
+    uri: http://localhost:3200/source/home:tom:branches:openSUSE_13?comment&user=tom
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '21'
+    body:
+      encoding: UTF-8
+      string: '<status code="ok" />
+
+'
+    http_version: 
+  recorded_at: Wed, 16 Nov 2016 16:02:04 GMT
+- request:
+    method: put
+    uri: http://localhost:3200/source/openSUSE_Leap/_meta
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="openSUSE_Leap">
+          <title>Oh! To be in England</title>
+          <description/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '110'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="openSUSE_Leap">
+          <title>Oh! To be in England</title>
+          <description></description>
+        </project>
+    http_version: 
+  recorded_at: Wed, 16 Nov 2016 16:16:44 GMT
+- request:
+    method: put
+    uri: http://localhost:3200/source/openSUSE_Leap/_config
+    body:
+      encoding: UTF-8
+      string: Molestiae recusandae facilis labore qui et. Quaerat voluptate a id odio
+        vero quo possimus. Voluptas laboriosam consequatur rerum ullam eveniet ea.
+        Aut et est ex iste alias ipsum modi.
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '21'
+    body:
+      encoding: UTF-8
+      string: '<status code="ok" />
+
+'
+    http_version: 
+  recorded_at: Wed, 16 Nov 2016 16:16:44 GMT
+- request:
+    method: put
+    uri: http://localhost:3200/source/openSUSE_Leap/apache2/_meta?user=tom
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="apache2" project="openSUSE_Leap">
+          <title/>
+          <description/>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '108'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="apache2" project="openSUSE_Leap">
+          <title></title>
+          <description></description>
+        </package>
+    http_version: 
+  recorded_at: Wed, 16 Nov 2016 16:16:44 GMT
+- request:
+    method: put
+    uri: http://localhost:3200/source/openSUSE_Leap/apache2/_meta
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="apache2" project="openSUSE_Leap">
+          <title/>
+          <description/>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '108'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="apache2" project="openSUSE_Leap">
+          <title></title>
+          <description></description>
+        </package>
+    http_version: 
+  recorded_at: Wed, 16 Nov 2016 16:16:44 GMT
+- request:
+    method: post
+    uri: http://localhost:3200/search/package/id?match=(linkinfo/@package=%22apache2%22%20and%20linkinfo/@project=%22openSUSE_Leap%22%20and%20@project=%22openSUSE_Leap%22)
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Content-Type:
+      - application/octet-stream
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '27'
+    body:
+      encoding: UTF-8
+      string: |
+        <collection>
+        </collection>
+    http_version: 
+  recorded_at: Wed, 16 Nov 2016 16:16:44 GMT
+- request:
+    method: put
+    uri: http://localhost:3200/source/home:tom:branches:openSUSE_Leap/_meta?user=tom
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:tom:branches:openSUSE_Leap">
+          <title>Branch project for package apache2</title>
+          <description>This project was created for package apache2 via attribute OBS:Maintained</description>
+          <person userid="tom" role="maintainer"/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '259'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:tom:branches:openSUSE_Leap">
+          <title>Branch project for package apache2</title>
+          <description>This project was created for package apache2 via attribute OBS:Maintained</description>
+          <person userid="tom" role="maintainer" />
+        </project>
+    http_version: 
+  recorded_at: Wed, 16 Nov 2016 16:16:44 GMT
+- request:
+    method: put
+    uri: http://localhost:3200/source/home:tom:branches:openSUSE_Leap/apache2/_meta?user=tom
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="apache2" project="home:tom:branches:openSUSE_Leap">
+          <title/>
+          <description/>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '126'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="apache2" project="home:tom:branches:openSUSE_Leap">
+          <title></title>
+          <description></description>
+        </package>
+    http_version: 
+  recorded_at: Wed, 16 Nov 2016 16:16:44 GMT
+- request:
+    method: put
+    uri: http://localhost:3200/source/home:tom:branches:openSUSE_Leap/apache2/_meta?user=tom
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="apache2" project="home:tom:branches:openSUSE_Leap">
+          <title/>
+          <description/>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '126'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="apache2" project="home:tom:branches:openSUSE_Leap">
+          <title></title>
+          <description></description>
+        </package>
+    http_version: 
+  recorded_at: Wed, 16 Nov 2016 16:16:44 GMT
+- request:
+    method: post
+    uri: http://localhost:3200/source/home:tom:branches:openSUSE_Leap/apache2?cmd=branch&opackage=apache2&oproject=openSUSE_Leap&user=tom
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Content-Type:
+      - application/octet-stream
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '203'
+    body:
+      encoding: UTF-8
+      string: |
+        <revision rev="1" vrev="1">
+          <srcmd5>f2b6eaf02987245b9003bcf47e0222dc</srcmd5>
+          <version>unknown</version>
+          <time>1479313004</time>
+          <user>tom</user>
+          <comment></comment>
+          <requestid/>
+        </revision>
+    http_version: 
+  recorded_at: Wed, 16 Nov 2016 16:16:44 GMT
+- request:
+    method: get
+    uri: http://localhost:3200/source/home:tom:branches:openSUSE_Leap/apache2
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '421'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="apache2" rev="1" vrev="1" srcmd5="f2b6eaf02987245b9003bcf47e0222dc">
+          <linkinfo project="openSUSE_Leap" package="apache2" srcmd5="d41d8cd98f00b204e9800998ecf8427e" baserev="d41d8cd98f00b204e9800998ecf8427e" xsrcmd5="2fbc15ae60271e3fe13b837e014a17ea" lsrcmd5="f2b6eaf02987245b9003bcf47e0222dc" />
+          <entry name="_link" md5="42ab2fdb360424b79deaaaec3dcd12ff" size="121" mtime="1479304500" />
+        </directory>
+    http_version: 
+  recorded_at: Wed, 16 Nov 2016 16:16:44 GMT
+- request:
+    method: get
+    uri: http://localhost:3200/source/home:tom:branches:openSUSE_Leap/apache2?nofilename=1&view=info&withchangesmd5=1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '279'
+    body:
+      encoding: UTF-8
+      string: |
+        <sourceinfo package="apache2" rev="1" vrev="1" srcmd5="2fbc15ae60271e3fe13b837e014a17ea" lsrcmd5="f2b6eaf02987245b9003bcf47e0222dc" verifymd5="d41d8cd98f00b204e9800998ecf8427e">
+          <linked project="openSUSE_Leap" package="apache2" />
+          <revtime>1479313004</revtime>
+        </sourceinfo>
+    http_version: 
+  recorded_at: Wed, 16 Nov 2016 16:16:45 GMT
+- request:
+    method: get
+    uri: http://localhost:3200/source/home:tom:branches:openSUSE_Leap/apache2
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '421'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="apache2" rev="1" vrev="1" srcmd5="f2b6eaf02987245b9003bcf47e0222dc">
+          <linkinfo project="openSUSE_Leap" package="apache2" srcmd5="d41d8cd98f00b204e9800998ecf8427e" baserev="d41d8cd98f00b204e9800998ecf8427e" xsrcmd5="2fbc15ae60271e3fe13b837e014a17ea" lsrcmd5="f2b6eaf02987245b9003bcf47e0222dc" />
+          <entry name="_link" md5="42ab2fdb360424b79deaaaec3dcd12ff" size="121" mtime="1479304500" />
+        </directory>
+    http_version: 
+  recorded_at: Wed, 16 Nov 2016 16:16:45 GMT
+- request:
+    method: post
+    uri: http://localhost:3200/source/home:tom:branches:openSUSE_Leap/apache2?cmd=diff&linkrev=base&onlyissues=1&orev=0&view=xml
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Content-Type:
+      - application/octet-stream
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Content-Length:
+      - '341'
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+    body:
+      encoding: UTF-8
+      string: |
+        <sourcediff key="b4eb9aa75778707a23b6f6a8cfd9aced">
+          <old project="home:tom:branches:openSUSE_Leap" package="apache2" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e" />
+          <new project="home:tom:branches:openSUSE_Leap" package="apache2" rev="1" srcmd5="f2b6eaf02987245b9003bcf47e0222dc" />
+          <files />
+          <issues>
+          </issues>
+        </sourcediff>
+    http_version: 
+  recorded_at: Wed, 16 Nov 2016 16:16:45 GMT
+- request:
+    method: post
+    uri: http://localhost:3200/source/home:tom:branches:openSUSE_Leap/apache2?cmd=linkdiff&linkrev=base&onlyissues=1&view=xml
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Content-Type:
+      - application/octet-stream
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '362'
+    body:
+      encoding: UTF-8
+      string: |
+        <sourcediff key="1c6621e539f5863fcf3a10f8baf9b790">
+          <old project="openSUSE_Leap" package="apache2" rev="d41d8cd98f00b204e9800998ecf8427e" srcmd5="d41d8cd98f00b204e9800998ecf8427e" />
+          <new project="home:tom:branches:openSUSE_Leap" package="apache2" rev="2fbc15ae60271e3fe13b837e014a17ea" srcmd5="2fbc15ae60271e3fe13b837e014a17ea" />
+          <files />
+        </sourcediff>
+    http_version: 
+  recorded_at: Wed, 16 Nov 2016 16:16:45 GMT
+- request:
+    method: put
+    uri: http://localhost:3200/source/home:tom:branches:openSUSE_Leap/_meta?user=tom
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:tom:branches:openSUSE_Leap">
+          <title>Branch project for package apache2</title>
+          <description>This project was created for package apache2 via attribute OBS:Maintained</description>
+          <person userid="tom" role="maintainer"/>
+          <publish>
+            <disable/>
+          </publish>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '300'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:tom:branches:openSUSE_Leap">
+          <title>Branch project for package apache2</title>
+          <description>This project was created for package apache2 via attribute OBS:Maintained</description>
+          <person userid="tom" role="maintainer" />
+          <publish>
+            <disable />
+          </publish>
+        </project>
+    http_version: 
+  recorded_at: Wed, 16 Nov 2016 16:16:45 GMT
+- request:
+    method: delete
+    uri: http://localhost:3200/source/home:tom:branches:openSUSE_Leap?comment&user=tom
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '21'
+    body:
+      encoding: UTF-8
+      string: '<status code="ok" />
+
+'
+    http_version: 
+  recorded_at: Wed, 16 Nov 2016 16:16:45 GMT
+- request:
+    method: post
+    uri: http://localhost:3200/source/home:tom:branches:BaseDistro:Update/test_package?cmd=branch&missingok=1&opackage=test_package&oproject=BaseDistro:Update&user=tom
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Content-Type:
+      - application/octet-stream
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 404
+      message: project 'home tom branches BaseDistro Update' does not exist
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '198'
+    body:
+      encoding: UTF-8
+      string: |
+        <status code="404">
+          <summary>project 'home:tom:branches:BaseDistro:Update' does not exist</summary>
+          <details>404 project 'home:tom:branches:BaseDistro:Update' does not exist</details>
+        </status>
+    http_version: 
+  recorded_at: Thu, 24 Nov 2016 20:55:26 GMT
+recorded_with: VCR 3.0.3

--- a/src/api/spec/models/branch_package_spec.rb
+++ b/src/api/spec/models/branch_package_spec.rb
@@ -35,10 +35,12 @@ RSpec.describe BranchPackage, vcr: true do
 
     context 'project with ImageTemplates attribute' do
       let(:attribute_type) { AttribType.find_by_namespace_and_name!('OBS', 'ImageTemplates') }
+      let(:leap_project) { create(:project, name: 'openSUSE_Leap') }
+      let(:apache) { create(:package, name: 'apache2', project: leap_project) }
+      let!(:image_templates_attrib) { create(:attrib, attrib_type: attribute_type, project: leap_project) }
+      let(:branch_package) { BranchPackage.new(project: leap_project.name, package: apache.name) }
 
       context 'auto cleanup attribute' do
-        let!(:image_templates_attrib) { create(:attrib, attrib_type: attribute_type, project: leap_project) }
-
         it 'is set to 14 if there is no default' do
           branch_apache_package.branch
           project = Project.find_by_name(user.branch_project_name("openSUSE_Leap"))
@@ -50,6 +52,15 @@ RSpec.describe BranchPackage, vcr: true do
           branch_apache_package.branch
           project = Project.find_by_name(user.branch_project_name("openSUSE_Leap"))
           expect(42.days.from_now - Time.zone.parse(project.attribs.first.values.first.value)).to be < 1.minute
+        end
+      end
+
+      context 'publish flag' do
+        it 'is disabled' do
+          allow(Configuration).to receive(:disable_publish_for_branches).and_return(false)
+          branch_package.branch
+          project = Project.find_by_name(user.branch_project_name("openSUSE_Leap"))
+          expect(project.flags.where(status: "disable", flag: "publish")).to exist
         end
       end
     end
@@ -67,6 +78,21 @@ RSpec.describe BranchPackage, vcr: true do
           branch_apache_package.branch
           project = Project.find_by_name(user.branch_project_name("openSUSE_Leap"))
           expect(project.attribs.length).to be(0)
+        end
+      end
+
+      context 'publish flag' do
+        it 'is disabled when Configuration.disable_publish_for_branches is false' do
+          allow(Configuration).to receive(:disable_publish_for_branches).and_return(false)
+          branch_apache_package.branch
+          project = Project.find_by_name(user.branch_project_name("openSUSE_Leap"))
+          expect(project.flags.where(status: "disable", flag: "publish")).to_not exist
+        end
+
+        it 'is enabled by default' do
+          branch_apache_package.branch
+          project = Project.find_by_name(user.branch_project_name("openSUSE_Leap"))
+          expect(project.flags.where(status: "disable", flag: "publish")).to exist
         end
       end
     end

--- a/src/api/spec/models/branch_package_spec.rb
+++ b/src/api/spec/models/branch_package_spec.rb
@@ -1,4 +1,8 @@
 require 'rails_helper'
+# WARNING: If you change tests make sure you uncomment this line
+# and start a test backend. Some of the actions
+# require real backend answers for projects/packages.
+# CONFIG['global_write_through'] = true
 
 RSpec.describe BranchPackage, vcr: true do
   let(:user) { create(:confirmed_user, login: 'tom') }
@@ -52,6 +56,16 @@ RSpec.describe BranchPackage, vcr: true do
           branch_apache_package.branch
           project = Project.find_by_name(user.branch_project_name("openSUSE_Leap"))
           expect(42.days.from_now - Time.zone.parse(project.attribs.first.values.first.value)).to be < 1.minute
+        end
+      end
+
+      context 'repository rebuild flag' do
+        let!(:repository) { create(:repository, rebuild: "transitive", project: leap_project) }
+
+        it 'is set to local' do
+          branch_package.branch
+          project = Project.find_by_name(user.branch_project_name("openSUSE_Leap"))
+          expect(project.repositories.first.rebuild).to eq("local")
         end
       end
 


### PR DESCRIPTION
Disable publish for image template branches. Set repository rebuild attribute to local when branching image template repositories. A separated method was created for the image_template related code.

Comment the `global_write_through` variable set to `true` line as it is in the other spec files.