### PR TITLE
[api] Allow all base64 encoding characters in passwords.

### DIFF
--- a/src/api/app/models/user.rb
+++ b/src/api/app/models/user.rb
@@ -78,11 +78,11 @@ class User < ApplicationRecord
                       message: 'must be a valid email address.'
 
   # We want to validate the format of the password and only allow alphanumeric
-  # and some punctiation characters.
+  # and some punctiation/base64 characters.
   # The format must only be checked if the password has been set and the record
   # has not been stored yet.
   validates_format_of :password,
-                      with: %r{\A[\w\.\- !?(){}|~*]+\z},
+                      with: %r{\A[\w\.\- /+=!?(){}|~*]+\z},
                       message: 'must not contain invalid characters.',
                       if: Proc.new { |user| user.new_password? && !user.password.nil? }
 


### PR DESCRIPTION
The automatically generated fake passwords might not get accepted
otherwise.


Saw this error when tried to log in for the first time via LDAP.

[ca9b2501-e035-412b-890d-5d82a0314e0e] [13954:1.68] No user found in database, creating
[ca9b2501-e035-412b-890d-5d82a0314e0e] [13954:1.68] Email: hemmo.nieminen@ericsson.com
[ca9b2501-e035-412b-890d-5d82a0314e0e] [13954:1.68] Name : Hemmo Nieminen
[ca9b2501-e035-412b-890d-5d82a0314e0e] [13954:1.68]    (0.1ms)  BEGIN
[ca9b2501-e035-412b-890d-5d82a0314e0e] [13954:1.72]   User Exists (0.8ms)  SELECT  1 AS one FROM `users` WHERE `users`. `login` = '$username_here' LIMIT 1
[ca9b2501-e035-412b-890d-5d82a0314e0e] [13954:1.72] Error - skipping to create user  #<ActiveModel::Errors:0x00000003b89018 @base=#<User id: nil, created_at: nil, updated_at: nil, last_logged_in_at: "2016-11-24 14:33:16", login_failure_count: 0, login: "$username_here", email: "hemmo.nieminen@ericsson.com", realname: "", password: "$base64_string_here", password_hash_type: "md5", password_salt: "1234512345", password_crypted: nil, adminnote: nil, state: "unconfirmed", owner_id: nil>, @messages={:password=>["must not contain invalid characters."]}, @details={:password=>[{:error=>:invalid, :value=>"$base64_string_here"}]}> true "$base64_string_here"
[ca9b2501-e035-412b-890d-5d82a0314e0e] [13954:1.72]    (0.5ms)  ROLLBACK
[ca9b2501-e035-412b-890d-5d82a0314e0e] [13954:1.72] Creating User failed with:
[ca9b2501-e035-412b-890d-5d82a0314e0e] [13954:1.72] Password must not contain invalid characters.
[ca9b2501-e035-412b-890d-5d82a0314e0e] [13954:1.73] Cannot create ldap userid: 'ehemnie' on OBS\<br>Password must not co ntain invalid characters.



This change seemed to fix it.