### PR TITLE
[ci] Enable Performance/RedundantBlockCall rubocop

### DIFF
--- a/src/api/.rubocop.yml
+++ b/src/api/.rubocop.yml
@@ -9,6 +9,10 @@ AllCops:
     - 'lib/templates/**/*'
     - 'vendor/bundle/**/*'
 
+# Use yield instead of having a &block parameter and block.call
+Performance/RedundantBlockCall:
+  Enabled: true
+
 # Align the elements of a hash literal if they span more than one line.
 Style/AlignHash:
   # Alignment of entries using hash rocket as separator.

--- a/src/api/.rubocop_todo.yml
+++ b/src/api/.rubocop_todo.yml
@@ -125,12 +125,6 @@ Metrics/ParameterLists:
 Metrics/PerceivedComplexity:
   Max: 73
 
-# Offense count: 1
-# Cop supports --auto-correct.
-Performance/RedundantBlockCall:
-  Exclude:
-    - 'lib/activexml/node.rb'
-
 # Offense count: 10
 # Cop supports --auto-correct.
 Performance/RedundantMatch:

--- a/src/api/lib/activexml/node.rb
+++ b/src/api/lib/activexml/node.rb
@@ -450,10 +450,10 @@ module ActiveXML
       return @value_cache[symbols] = nil
     end
 
-    def find( symbol, &block )
+    def find( symbol )
       symbols = symbol.to_s
       _data.xpath(symbols).each do |e|
-        block.call(create_node_with_relations(e))
+        yield create_node_with_relations(e)
       end
     end
 


### PR DESCRIPTION
This cop identifies the use of a &block parameter and block.call where yield would do just as well.