### PR TITLE
Give the user a hint that displayed sources are not from the same project

### DIFF
--- a/src/api/app/views/webui/package/show.html.erb
+++ b/src/api/app/views/webui/package/show.html.erb
@@ -38,6 +38,13 @@
               at <%= link_to(elide(dpackage.project.name, 44), :action => :show, :controller => :package, :project => dpackage.project.name, :package => dpackage.name) %>
             </li>
         <% end %>
+        <% if @package.project != @project %>
+            <li>
+              <%= sprite_tag 'information', title: '' %>
+              Sources inherited from project
+              <%= link_to("#{elide(@package.project.name, 40)}", :action => 'show', :project => @package.project.name, :package => @package.name) %>
+            </li>
+        <% end %>
         <% if @package.developed_packages.present? %>
             <li>
               <%= sprite_tag 'information', title: '' %>

--- a/src/api/app/views/webui/package/show.html.erb
+++ b/src/api/app/views/webui/package/show.html.erb
@@ -48,7 +48,7 @@
               <% end %>
             </li>
         <% end %>
-        <% if @package.name =~ %r{^_patchinfo} %>
+        <% if @package.is_patchinfo? %>
             <li>
               <%= sprite_tag 'information', title: '' %>
               Has


### PR DESCRIPTION
when using project linking (esp. with linkedbuild option)