### PR TITLE
[webui] Refresh CodeMirror editor on switching request tabs

### DIFF
--- a/src/api/app/assets/javascripts/webui/application/request.js
+++ b/src/api/app/assets/javascripts/webui/application/request.js
@@ -171,6 +171,11 @@ function setupActionLink() {
         $('.action_display').hide();
         index = event.target.id.split('action_select_link_')[1];
         $('#action_display_' + index).show();
+        // It is necessary to refresh the CodeMirror editors after switching tabs to initialise the dimensions again.
+        // Otherwise the editors are empty after calling show().
+        $.each(editors, function() {
+          if (!!this) this.refresh();
+        });
         return false;
     });
 }


### PR DESCRIPTION
Otherwise the editor is empty till mouseclick happens inside the editor.
This is caused by hiding the editor while loading the page, so the editor does not know about it's dimensions and a refresh is necessary.
#2242.