### PR TITLE
[ci] Fix storing update_project factory

### DIFF
--- a/src/api/spec/factories/project.rb
+++ b/src/api/spec/factories/project.rb
@@ -102,7 +102,7 @@ FactoryGirl.define do
           create(:build_flag, status: 'disable', project: evaluator.target_project)
           create(:publish_flag, status: 'disable', project: evaluator.target_project)
           update_project.projects_linking_to << evaluator.target_project
-          update_project.store
+          update_project.store if CONFIG['global_write_through']
           new_repository = create(:repository, project: update_project, architectures: ['i586'])
           create(:path_element, repository: new_repository, link: evaluator.target_project.repositories.first)
         end


### PR DESCRIPTION
As @ChrisBr  pointed out in https://github.com/openSUSE/open-build-service/pull/2407 the backend could fail if `CONFIG['global_write_through']` is not enabled.