### PR TITLE
[ci] Fix storing update_project factory again

### DIFF
--- a/src/api/spec/factories/project.rb
+++ b/src/api/spec/factories/project.rb
@@ -102,7 +102,7 @@ FactoryGirl.define do
           create(:build_flag, status: 'disable', project: evaluator.target_project)
           create(:publish_flag, status: 'disable', project: evaluator.target_project)
           update_project.projects_linking_to << evaluator.target_project
-          update_project.store if CONFIG['global_write_through']
+          CONFIG['global_write_through'] ? update_project.store : update_project.save!
           new_repository = create(:repository, project: update_project, architectures: ['i586'])
           create(:path_element, repository: new_repository, link: evaluator.target_project.repositories.first)
         end


### PR DESCRIPTION
When the `global_write_through` is not enabled we still need to save it (I forgot it in https://github.com/openSUSE/open-build-service/pull/2409). :confounded: 