### PR TITLE
[webui] Further improve speed on user/show page (related to issue#2201)

### DIFF
--- a/src/api/app/controllers/webui/user_controller.rb
+++ b/src/api/app/controllers/webui/user_controller.rb
@@ -57,11 +57,11 @@ class Webui::UserController < Webui::WebuiController
     @owned = @displayed_user.owned_packages
 
     if User.current == @displayed_user
-        @reviews = @displayed_user.involved_reviews
+        @reviews = @displayed_user.involved_reviews.limit(25)
         @patchinfos = @displayed_user.involved_patchinfos
-        @requests_in = @displayed_user.incoming_requests
-        @requests_out = @displayed_user.outgoing_requests
-        @declined_requests = @displayed_user.declined_requests
+        @requests_in = @displayed_user.incoming_requests.limit(25)
+        @requests_out = @displayed_user.outgoing_requests.limit(25)
+        @declined_requests = @displayed_user.declined_requests.limit(25)
         @user_have_requests = @displayed_user.requests?
     end
   end

--- a/src/api/spec/controllers/webui/user_controller_spec.rb
+++ b/src/api/spec/controllers/webui/user_controller_spec.rb
@@ -59,7 +59,7 @@ RSpec.describe Webui::UserController do
       describe "showing self" do
         it 'includes requests' do
           get :show, params: { user: non_admin_user }
-          expect(assigns(:requests_out)).to eq non_admin_user.outgoing_requests
+          expect(assigns(:requests_out).pluck(:id)).to eq non_admin_user.outgoing_requests.pluck(:id)
         end
       end
       describe "showing someone else" do


### PR DESCRIPTION
Limit the amount of records to fetch from DB. We only show a limited numbers
in the table, 25 by default. Thus we can limit the SQL query as well.

This improved the page load time from 16 to 22 seconds down to 5 to 8 seconds.