### PR TITLE
[webui] Add package to project with `<<` not needed

### DIFF
--- a/src/api/app/models/branch_package.rb
+++ b/src/api/app/models/branch_package.rb
@@ -115,7 +115,6 @@ class BranchPackage
           tpkg.bcntsynctag << '.' + p[:link_target_project].name.tr(':', '_')
         end
         tpkg.releasename = p[:release_name]
-        tprj.packages << tpkg
       end
       tpkg.store
 


### PR DESCRIPTION
The package doesn't need to be added twice. First it is added with
`new`. And then with `<<`.