### PR TITLE
[webui] use request number in parameter for maintainers dialog

### DIFF
--- a/src/api/app/controllers/webui/request_controller.rb
+++ b/src/api/app/controllers/webui/request_controller.rb
@@ -134,8 +134,15 @@ class Webui::RequestController < Webui::WebuiController
   end
 
   def package_maintainers_dialog
-    @maintainers = get_target_package_maintainers(params[:actions])
-    render_dialog unless @maintainers.empty?
+    bs_request = BsRequest.find_by_number(params[:request_number])
+
+    if bs_request
+      request = bs_request.webui_infos
+      actions = request['actions']
+
+      @maintainers = get_target_package_maintainers(actions)
+      render_dialog unless @maintainers.empty?
+    end
   end
 
   def sourcediff

--- a/src/api/app/views/webui/request/show.html.erb
+++ b/src/api/app/views/webui/request/show.html.erb
@@ -39,7 +39,7 @@
           state <%= link_to @state, { :anchor => 'request_history' }, { :style => "color: #{request_state_color(@state)};" } %></li>
         <% unless @package_maintainers.empty? %>
         <li><%= sprite_tag('eye') %> <%= pluralize(@package_maintainers.size, "package maintainer") %>
-          (<%= link_to('show who', { :action => :package_maintainers_dialog, :actions => @actions }, :remote => true) %>)</li>
+          (<%= link_to('show who', { action: :package_maintainers_dialog, request_number: @number }, remote: true) %>)</li>
         <% end %>
         <% if @superseding %>
             <li><%= sprite_tag('information', title: '') %> Supersedes


### PR DESCRIPTION
This closes #2236 

We now use the request number instead of passing all actions to the URL.