### PR TITLE
Remove Ajax request for package maintainers

### DIFF
--- a/src/api/app/assets/javascripts/webui/application.js
+++ b/src/api/app/assets/javascripts/webui/application.js
@@ -246,3 +246,13 @@ function select_from_autocomplete(toselect) {
         if ($(this).text() == toselect) { $(this).trigger('mouseenter').click(); }
     });
 }
+
+$(function() {
+  $('.show_dialog').on('click', function() {
+    $($(this).data('target')).removeClass('hidden');
+  });
+
+  $('.close_dialog').on('click', function() {
+    $($(this).data('target')).addClass('hidden');
+  });
+});

--- a/src/api/app/assets/stylesheets/webui/application/dialog.scss
+++ b/src/api/app/assets/stylesheets/webui/application/dialog.scss
@@ -40,6 +40,13 @@
       font-weight: bold;
       font-size: 1.2em;
     }
+    .close_dialog {
+      border-radius: 5px;
+      border: 1px solid #eee;
+      padding: 8px;
+      /* Make it look like the default option*/
+      font-weight: bold;
+      font-size: 1.2em;
+    }
   }
 }
-

--- a/src/api/app/controllers/webui/request_controller.rb
+++ b/src/api/app/controllers/webui/request_controller.rb
@@ -133,11 +133,6 @@ class Webui::RequestController < Webui::WebuiController
     @comments = @bsreq.comments
   end
 
-  def package_maintainers_dialog
-    @maintainers = get_target_package_maintainers(params[:actions])
-    render_dialog unless @maintainers.empty?
-  end
-
   def sourcediff
     check_ajax
     render partial: 'shared/editor', locals: {text: params[:text],

--- a/src/api/app/helpers/webui/webui_helper.rb
+++ b/src/api/app/helpers/webui/webui_helper.rb
@@ -25,9 +25,11 @@ module Webui::WebuiHelper
     if email_list.length > 1
       cc = ('&cc=' + email_list[1..-1].join('&cc=')) if email_list
     end
-    # rubocop:disable Metrics/LineLength
-    URI.escape("#{@configuration['bugzilla_url']}/enter_bug.cgi?classification=7340&product=openSUSE.org&component=3rd party software&assigned_to=#{assignee}#{cc}&short_desc=#{desc}")
-    # rubocop:enable Metrics/LineLength
+
+    URI.escape(
+      "#{@configuration['bugzilla_url']}/enter_bug.cgi?classification=7340&product=openSUSE.org" \
+      "&component=3rd party software&assigned_to=#{assignee}#{cc}&short_desc=#{desc}"
+    )
   end
 
   def user_icon(user, size = 20, css_class = nil, alt = nil)
@@ -232,6 +234,10 @@ module Webui::WebuiHelper
 
   def remove_dialog_tag(text)
     link_to(text, '#', title: 'Close', id: 'remove_dialog')
+  end
+
+  def close_dialog_tag(text, target)
+    link_to(text, '#', title: 'Close', class: 'close_dialog', data: { target: target })
   end
 
   # @param [String] user login of the user

--- a/src/api/app/views/webui/request/_package_maintainers_dialog.html.erb
+++ b/src/api/app/views/webui/request/_package_maintainers_dialog.html.erb
@@ -1,14 +1,13 @@
-  <div class="dialog" id="disable_mask"></div>
-  <div class="dialog darkgrey_box" id="branch_dialog">
+  <div id="maintainers_dialog" class="dialog darkgrey_box hidden">
     <div class="box box-shadow">
-      <h2 class="box-header"><%= pluralize(@maintainers.size, "Package Maintainer") %></h2>
+      <h2 class="box-header"><%= pluralize(@package_maintainers.size, "Package Maintainer") %></h2>
       <div class="dialog-content">
         <table>
           <tbody>
-          <% @maintainers.each do |m| %>
+          <% @package_maintainers.each do |maintainer| %>
           <tr>
             <td>
-              <%= user_with_realname_and_icon(m, short: true) %>
+              <%= user_with_realname_and_icon(maintainer, short: true) %>
             </td>
           </tr>
           <% end %>
@@ -16,7 +15,7 @@
          </table>
         
         <div class="dialog-buttons">
-         <%= remove_dialog_tag('Close') %>
+         <%= close_dialog_tag('Close', '#maintainers_dialog') %>
         </div>
       </div>
     </div>

--- a/src/api/app/views/webui/request/show.html.erb
+++ b/src/api/app/views/webui/request/show.html.erb
@@ -39,7 +39,7 @@
           state <%= link_to @state, { :anchor => 'request_history' }, { :style => "color: #{request_state_color(@state)};" } %></li>
         <% unless @package_maintainers.empty? %>
         <li><%= sprite_tag('eye') %> <%= pluralize(@package_maintainers.size, "package maintainer") %>
-          (<%= link_to('show who', { :action => :package_maintainers_dialog, :actions => @actions }, :remote => true) %>)</li>
+          (<%= link_to('show who', '#', class: 'show_dialog', data: { target: '#maintainers_dialog' }) %>)</li>
         <% end %>
         <% if @superseding %>
             <li><%= sprite_tag('information', title: '') %> Supersedes
@@ -309,3 +309,5 @@
   <h2 class="box-header">Comments for request <%= @number %> (<%= @comments.length %>)</h2>
   <%= render :partial => 'webui/comment/show' %>
 </div>
+
+ <%= render :partial => 'webui/request/package_maintainers_dialog' %>

--- a/src/api/config/routes.rb
+++ b/src/api/config/routes.rb
@@ -275,7 +275,6 @@ OBSApi::Application.routes.draw do
       get 'request/set_incident_dialog' => :set_incident_dialog
       post 'request/set_incident' => :set_incident
       post 'request/comments/:number' => :save_comment
-      get 'request/package_maintainers_dialog' => :package_maintainers_dialog
     end
 
     controller 'webui/search' do


### PR DESCRIPTION
Fixes #2236 

The link to the package maintainers dialog was too long. With this PR, package maintainers are no longer loaded via an Ajax request and passed to the URL GET parameters. The dialog is now just disabled till the user clicks the link.