### PR TITLE
Branching image templates (ui)

### DIFF
--- a/src/api/app/assets/javascripts/webui/application.js
+++ b/src/api/app/assets/javascripts/webui/application.js
@@ -36,6 +36,7 @@
 //= require webui/application/attribute
 //= require webui/application/main
 //= require webui/application/repository_tab
+//= require webui/application/image_templates
 
 function remove_dialog() {
     $(".dialog").remove();

--- a/src/api/app/assets/javascripts/webui/application/image_templates.js
+++ b/src/api/app/assets/javascripts/webui/application/image_templates.js
@@ -1,0 +1,23 @@
+// Disable button if appliance name field is empty
+$(function() {
+  $('#target_package').on("input", function(e){
+    $(".create_appliance").attr('disabled', (this.value === ""));
+  });
+});
+
+// Change the package and project to the selected one before submiting the form to create an appliance
+$(function() {
+  $(".create_appliance").on("click", function(e){
+    e.preventDefault();
+    var checked_element = $("input[name=image]:checked");
+    var url = '/package/branch/' + checked_element.attr('data-project') + '/' + checked_element.attr('data-package');
+    $('#appliance_form').attr('action', url).submit();
+  });
+});
+
+// Change the appliance name when selecting a new template
+$(function() {
+  $(".image_template").on("click", function(e){
+    $('#target_package').val(this.getAttribute('data-package'));
+  });
+});

--- a/src/api/app/assets/stylesheets/webui/application/image_templates.sass
+++ b/src/api/app/assets/stylesheets/webui/application/image_templates.sass
@@ -103,3 +103,22 @@ dl.templateslist
     background: rgba(0, 0, 0, 0) image-url('radiobutton-checked.png') no-repeat scroll left top
     border: 0 none
     min-height: 16x
+  
+.templates_form
+  margin: 1em
+  
+.name_appliance
+  display: block
+  font-size: 13pt
+  
+.create_appliance
+  display: block
+  width: 9em
+  padding: 0.5em
+  text-align: center
+  margin-top: 2em
+
+.name_appliance_form
+  padding: 0.3em
+  margin: 1em 0.5em
+  width: 30em

--- a/src/api/app/controllers/webui/package_controller.rb
+++ b/src/api/app/controllers/webui/package_controller.rb
@@ -554,7 +554,15 @@ class Webui::PackageController < Webui::WebuiController
     #        project might differ from the one we check here.
     authorize Project.new(name: User.current.branch_project_name(@project)), :create?
 
-    branched_package = BranchPackage.new(project: @project.name, package: @package.name).branch
+    # The package/project name can not be an empty string, but it is set to the source name by default when it is `nil`
+    target_project = params[:target_project] unless params[:target_project].blank?
+    target_package = params[:target_package] unless params[:target_package].blank?
+
+    branched_package = BranchPackage.new(project: @project.name,
+                                         package: @package.name,
+                                         target_project: target_project,
+                                         target_package: target_package).branch
+
     created_project_name = branched_package[:data][:targetproject]
     created_package_name = branched_package[:data][:targetpackage]
 

--- a/src/api/app/views/webui/image_templates/index.html.haml
+++ b/src/api/app/views/webui/image_templates/index.html.haml
@@ -3,13 +3,15 @@
     Choose a base template
 
   %fieldset.templateslist
+    - first = true
     - @projects.each do |project|
       %dl.templateslist
         %dt
           = link_to(title_or_name(project), project_show_path(project))
         - project.packages.each do |template|
           %label
-            %input{ name: 'image', type: 'radio', class: 'hidden' }
+            %input{ name: 'image', type: 'radio', class: 'hidden', checked: first ? true : nil }
+            - first = false
             %dd
               %span.form-radio
               - if template.has_icon?

--- a/src/api/app/views/webui/image_templates/index.html.haml
+++ b/src/api/app/views/webui/image_templates/index.html.haml
@@ -3,15 +3,15 @@
     Choose a base template
 
   %fieldset.templateslist
-    - first = true
+    - first = nil
     - @projects.each do |project|
       %dl.templateslist
         %dt
           = link_to(title_or_name(project), project_show_path(project))
         - project.packages.each do |template|
           %label
-            %input{ name: 'image', type: 'radio', class: 'hidden', checked: first ? true : nil }
-            - first = false
+            %input{ name: 'image', type: 'radio', class: 'hidden image_template', "data-project": project, "data-package": template, checked: first ? nil : true }
+            - first = template unless first
             %dd
               %span.form-radio
               - if template.has_icon?
@@ -26,6 +26,12 @@
         - if project.packages.empty?
           %p
             There are currently no base image templates available for project <strong>#{title_or_name(project)}</strong>.
-  - if @projects.empty?
+  - if first
+    .templates_form
+      = form_tag({ controller: :package, :action => :branch, project: "placeholder", package: "placeholder"}, :method => :post, id: "appliance_form") do
+        = label_tag(:target_package, 'Name your appliance', class: "name_appliance")
+        = text_field_tag(:target_package, first, class: "name_appliance_form")
+        = submit_tag('Create appliance', class: "create_appliance")
+  - elsif @projects.empty?
     %p
       There are no templates yet, sorry.


### PR DESCRIPTION
Implement branching in the ui. It is possible to define the target
package name and the button is disabled if no name is given. By default the
name is filled in with the selected template name.

I also set the first template as default in the image templates page as it is in Studio.

![image](https://cloud.githubusercontent.com/assets/16052290/20965020/4468e28e-bc74-11e6-8dfa-9b4858ad000f.png)

To do:

- Consider what name do we want to show in the appliance name field by default and how to use it. Currently it is confusing because we are showing the `title` and asking for the `name`, that is different. In Studio there is not this problem because there is only one name. We could use the `title` and autogenerate the name, try to explain there the difference ading a text, ask both the `title` and the `name`. @adrianschroeter what do you think?

- Write tests.
