### PR TITLE
Remote image templates

### DIFF
--- a/src/api/app/controllers/webui/image_templates_controller.rb
+++ b/src/api/app/controllers/webui/image_templates_controller.rb
@@ -1,7 +1,10 @@
 class Webui::ImageTemplatesController < Webui::WebuiController
-  before_action :require_login
-
   def index
     @projects = Project.image_templates
+
+    respond_to do |format|
+      format.html
+      format.xml
+    end
   end
 end

--- a/src/api/app/models/distribution.rb
+++ b/src/api/app/models/distribution.rb
@@ -38,8 +38,7 @@ class Distribution < ApplicationRecord
     list = Distribution.all_as_hash
     repositories = list.map{ |d| d['reponame'] }
 
-    remote_projects = Project.where("NOT ISNULL(projects.remoteurl)")
-    remote_projects.each do |prj|
+    Project.remote.each do |prj|
       body = Rails.cache.fetch("remote_distribution_#{prj.id}", expires_in: 1.hour) do
         begin
           ActiveXML.backend.load_external_url(prj.remoteurl + "/distributions.xml")

--- a/src/api/app/models/project.rb
+++ b/src/api/app/models/project.rb
@@ -102,7 +102,7 @@ class Project < ApplicationRecord
 
   # will return all projects with attribute 'OBS:ImageTemplates'
   scope :local_image_templates, lambda {
-    joins(attribs: { attrib_type: :attrib_namespace }).
+    includes(:packages).joins(attribs: { attrib_type: :attrib_namespace }).
       where(attrib_types: { name: 'ImageTemplates' }, attrib_namespaces: { name: 'OBS' })
   }
 

--- a/src/api/app/models/project.rb
+++ b/src/api/app/models/project.rb
@@ -98,6 +98,7 @@ class Project < ApplicationRecord
   scope :maintenance_release, -> { where("kind = 'maintenance_release'") }
   scope :home, -> { where("name like 'home:%'") }
   scope :not_home, -> { where.not("name like 'home:%'") }
+  scope :remote, -> { where('NOT ISNULL(projects.remoteurl)') }
 
   # will return all projects with attribute 'OBS:ImageTemplates'
   scope :local_image_templates, lambda {
@@ -115,9 +116,8 @@ class Project < ApplicationRecord
   end
 
   def self.remote_image_templates
-    remote_projects = Project.where('NOT ISNULL(projects.remoteurl)')
     result = []
-    remote_projects.each do |project|
+    Project.remote.each do |project|
       body = load_from_remote(project, '/image_templates.xml')
       next if body.blank?
 

--- a/src/api/app/models/project.rb
+++ b/src/api/app/models/project.rb
@@ -100,7 +100,7 @@ class Project < ApplicationRecord
   scope :not_home, -> { where.not("name like 'home:%'") }
 
   # will return all projects with attribute 'OBS:ImageTemplates'
-  scope :image_templates, lambda {
+  scope :local_image_templates, lambda {
     joins(attribs: { attrib_type: :attrib_namespace }).
       where(attrib_types: { name: 'ImageTemplates' }, attrib_namespaces: { name: 'OBS' })
   }
@@ -109,6 +109,45 @@ class Project < ApplicationRecord
   validates :title, length: { maximum: 250 }
   validate :valid_name
   validates :kind, inclusion: { in: %w(standard maintenance maintenance_incident maintenance_release) }
+
+  def self.image_templates
+    Project.local_image_templates + remote_image_templates
+  end
+
+  def self.remote_image_templates
+    remote_projects = Project.where('NOT ISNULL(projects.remoteurl)')
+    result = []
+    remote_projects.each do |project|
+      body = load_from_remote(project, '/image_templates.xml')
+      next if body.blank?
+
+      Xmlhash.parse(body).elements('image_template_project').each do |image_template_project|
+        result << remote_image_template_from_xml(project, image_template_project)
+      end
+    end
+    result
+  end
+
+  def self.load_from_remote(project, path)
+    Rails.cache.fetch("remote_image_templates_#{project.cache_key}", expires_in: 1.hour) do
+      begin
+        return ActiveXML.backend.load_external_url("#{project.remoteurl}#{path}")
+      rescue OpenSSL::SSL::SSLError
+        Rails.logger.error "Remote instance #{project.remoteurl} has no valid SSL certificate"
+      end
+    end
+  end
+
+  def self.remote_image_template_from_xml(remote_project, image_template_project)
+    # We don't store the project and packages objects because they're fetched from remote instances and stored in cache
+    project = Project.new(name: "#{remote_project.name}:#{image_template_project['name']}")
+    image_template_project.elements('image_template_package').each do |image_template_package|
+      project.packages.new(name: image_template_package['name'],
+                           title: image_template_package['title'],
+                           description: image_template_package['description'])
+    end
+    project
+  end
 
   def init
     # We often use select in a query which would raise a MissingAttributeError

--- a/src/api/app/views/webui/image_templates/index.html.haml
+++ b/src/api/app/views/webui/image_templates/index.html.haml
@@ -26,7 +26,7 @@
         - if project.packages.empty?
           %p
             There are currently no base image templates available for project <strong>#{title_or_name(project)}</strong>.
-  - if first_template
+  - if first_template && User.current
     .templates_form
       = form_tag({ controller: :package, action: :save_new_link, project: User.current.home_project_name }, method: :post, id: 'appliance_form') do
         = hidden_field_tag 'linked_project', first_template.project

--- a/src/api/app/views/webui/image_templates/index.xml.builder
+++ b/src/api/app/views/webui/image_templates/index.xml.builder
@@ -1,0 +1,13 @@
+xml.image_template_projects do
+  @projects.each do |image_template|
+    xml.image_template_project(name: image_template.name) do
+      image_template.packages.each do |package|
+        xml.image_template_package do
+          xml.name package.name
+          xml.title package.title
+          xml.description package.description
+        end
+      end
+    end
+  end
+end

--- a/src/api/config/routes.rb
+++ b/src/api/config/routes.rb
@@ -638,6 +638,12 @@ OBSApi::Application.routes.draw do
     end
 
     get '/404' => 'main#notfound'
+
+    scope 'public' do
+      resources :image_templates, constraints: cons, only: [:index], controller: 'webui/image_templates'
+    end
+
+    resources :image_templates, constraints: cons, only: [:index], controller: 'webui/image_templates'
   end
 
   controller :source do

--- a/src/api/spec/controllers/webui/image_templates_controller_spec.rb
+++ b/src/api/spec/controllers/webui/image_templates_controller_spec.rb
@@ -1,21 +1,38 @@
 require 'rails_helper'
 
 RSpec.describe Webui::ImageTemplatesController, type: :controller do
-  let(:user) { create(:confirmed_user, login: 'tom') }
-  let(:attribute_type) { AttribType.find_by_namespace_and_name!('OBS', 'ImageTemplates') }
-  let(:leap_project) { create(:project, name: 'openSUSE_Leap') }
-  let!(:attrib) { create(:attrib, attrib_type: attribute_type, project: leap_project) }
-  let!(:tumbleweed_project) { create(:project, name: 'openSUSE_Tumbleweed') }
-
-  it { is_expected.to use_before_action(:require_login) }
-
   describe 'GET #index' do
-    before do
-      login(user)
-      get :index
+    context 'without image templates' do
+      before do
+        get :index
+      end
+
+      it { is_expected.to render_template("webui/image_templates/index") }
+      it { is_expected.to respond_with(:success) }
+      it { expect(assigns(:projects)).to eq([]) }
     end
 
-    it { expect(assigns(:projects)).to eq([leap_project]) }
-    it { is_expected.to render_template("webui/image_templates/index") }
+    context 'with image templates' do
+      let(:attribute_type) { AttribType.find_by_namespace_and_name!('OBS', 'ImageTemplates') }
+      let(:leap_project) { create(:project, name: 'openSUSE_Leap') }
+      let!(:attrib) { create(:attrib, attrib_type: attribute_type, project: leap_project) }
+      let!(:tumbleweed_project) { create(:project, name: 'openSUSE_Tumbleweed') }
+
+      before do
+        get :index
+      end
+
+      it { is_expected.to respond_with(:success) }
+      it { expect(assigns(:projects)).to eq([leap_project]) }
+      it { is_expected.to render_template("webui/image_templates/index") }
+
+      context 'and format XML' do
+        before do
+          get :index, format: :xml
+        end
+
+        it { is_expected.to render_template("webui/image_templates/index") }
+      end
+    end
   end
 end

--- a/src/api/spec/models/image_template_spec.rb
+++ b/src/api/spec/models/image_template_spec.rb
@@ -1,0 +1,101 @@
+require "rails_helper"
+require "webmock/rspec"
+
+RSpec.describe Project do
+  describe '.remote_image_templates' do
+    let!(:remote_instance) { create(:project, name: 'RemoteProject', remoteurl: 'http://example.com/public') }
+
+    before do
+      stub_request(:get, 'http://example.com/public/image_templates.xml')
+        .and_return(body: %(<image_template_projects>
+                              <image_template_project name='Images'>
+                                <image_template_package>
+                                  <name>leap-42-1-jeos</name>
+                                   <title/>
+                                    <description/>
+                                </image_template_package>
+                              </image_template_project>
+                          </image_template_projects>
+                         )
+                   )
+      @images = Project.remote_image_templates
+    end
+
+    it { expect(@images.class).to eq(Array) }
+
+    context 'with one remote instance' do
+      context 'and one package' do
+        it { expect(@images.length).to eq(1) }
+        it { expect(@images.first.name).to eq('RemoteProject:Images') }
+        it { expect(@images.first.packages.first.name).to eq('leap-42-1-jeos') }
+      end
+
+      context 'and two projects' do
+        before do
+          stub_request(:get, 'http://example.com/public/image_templates.xml')
+            .and_return(body: %(<image_template_projects>
+                              <image_template_project name='Images'>
+                                <image_template_package>
+                                  <name>leap-42-1-jeos</name>
+                                   <title/>
+                                    <description/>
+                                </image_template_package>
+                              </image_template_project>
+                              <image_template_project name='Foobar'>
+                                <image_template_package>
+                                  <name>leap-42-2-jeos</name>
+                                   <title/>
+                                    <description/>
+                                </image_template_package>
+                              </image_template_project>
+                          </image_template_projects>
+                         )
+                       )
+          @images = Project.remote_image_templates
+        end
+
+        it { expect(@images.length).to eq(2) }
+        it { expect(@images.second.name).to eq('RemoteProject:Foobar') }
+        it { expect(@images.second.packages.first.name).to eq('leap-42-2-jeos') }
+      end
+
+      context 'and two packages' do
+        before do
+          stub_request(:get, 'http://example.com/public/image_templates.xml')
+            .and_return(body: %(<image_template_projects>
+                              <image_template_project name='Images'>
+                                <image_template_package>
+                                  <name>leap-42-1-jeos</name>
+                                   <title/>
+                                    <description/>
+                                </image_template_package>
+                                <image_template_package>
+                                  <name>leap-42-2-jeos</name>
+                                   <title/>
+                                    <description/>
+                                </image_template_package>
+                              </image_template_project>
+                          </image_template_projects>
+                         )
+                       )
+          @images = Project.remote_image_templates
+        end
+
+        it { expect(@images.first.packages.length).to eq(2) }
+        it { expect(@images.first.packages.second.name).to eq('leap-42-2-jeos') }
+      end
+    end
+
+    context 'with two remote instances' do
+      let!(:another_remote_instance) { create(:project, name: 'AnotherRemoteProject', remoteurl: 'http://example.com/public') }
+      before do
+        # The AnotherRemoteProject will simply take the request of RemoteInstance defined in the first before filter
+        @images = Project.remote_image_templates
+      end
+
+      it { expect(@images.length).to eq(2) }
+      it { expect(@images.second.name).to eq('AnotherRemoteProject:Images') }
+      it { expect(@images.second.packages.first.name).to eq('leap-42-1-jeos') }
+    end
+  end
+end


### PR DESCRIPTION
- Image templates are now available via /public/image_templates
- Splitted Project.image_templates into .local_image_templates and .remote_image_templates
- Fetching image templates is possible via Project.image_templates