### PR TITLE
Live build log fixes

### DIFF
--- a/src/api/app/controllers/webui/package_controller.rb
+++ b/src/api/app/controllers/webui/package_controller.rb
@@ -822,6 +822,7 @@ class Webui::PackageController < Webui::WebuiController
     @arch = params[:arch] if Architecture.archcache[params[:arch]]
     @repo = @project.repositories.find_by(name: params[:repository]).try(:name)
     @offset = 0
+    @status = get_status(@project, @package, @repo, @arch) if @project && @package && @repo && @arch
 
     set_job_status
   end
@@ -848,8 +849,12 @@ class Webui::PackageController < Webui::WebuiController
     @repo = @project.repositories.find_by(name: params[:repository]).try(:name)
     @initial = params[:initial]
     @offset = params[:offset].to_i
+    @status = params[:status]
     @finished = false
     @maxsize = 1024 * 64
+
+    @finished = Buildresult.final_status? @status
+    @offset = 0 if @finished
 
     set_initial_offset if @offset.zero?
 
@@ -862,11 +867,15 @@ class Webui::PackageController < Webui::WebuiController
 
     @package = package_object.name
     begin
-      @log_chunk = get_log_chunk(@project, @package, @repo, @arch, @offset, @offset + @maxsize)
+      chunk = get_log_chunk(@project, @package, @repo, @arch, @offset, @offset + @maxsize)
 
-      if @log_chunk.length.zero?
+      if chunk.length.zero? && @initial == '0' && !@finished
+        # reset offset and fetch the last chunk again, because build compare overwrites last log lines
+        set_initial_offset
+        @log_chunk = get_log_chunk(@project, @package, @repo, @arch, @offset, @offset + @maxsize)
         @finished = true
       else
+        @log_chunk = chunk
         @offset += ActiveXML::backend.last_body_length
       end
 
@@ -876,6 +885,10 @@ class Webui::PackageController < Webui::WebuiController
     rescue ActiveXML::Transport::Error => e
       if e.summary =~ %r{Logfile is not that big}
         @log_chunk = ''
+      elsif e.summary =~ /start out of range/
+        # probably build compare has cut log and offset is wrong, reset offset
+        @log_chunk = ''
+        @offset = 0
       else
         @log_chunk = "No live log available: #{e.summary}\n"
         @finished = true

--- a/src/api/app/mixins/build_log_support.rb
+++ b/src/api/app/mixins/build_log_support.rb
@@ -43,4 +43,20 @@ module BuildLogSupport
     path = "/build/#{pesc project}/#{pesc repo}/#{pesc arch}/#{pesc package}/_jobstatus"
     ActiveXML::backend.direct_http URI("#{path}"), timeout: 500
   end
+
+  def get_status(project, package, repo, arch)
+    path = "/build/#{pesc project}/_result?view=status&package=#{pesc package}&arch=#{pesc arch}&repository=#{pesc repo}"
+    code = ""
+    data = ActiveXML::backend.direct_http URI("#{path}"), timeout: 500
+    return code unless data
+    doc = Xmlhash.parse(data)
+    if doc['result']
+      result = doc['result']
+      if result['status']
+        status = result['status']
+        code = status['code'] if status['code']
+      end
+    end
+    code
+  end
 end

--- a/src/api/app/models/buildresult.rb
+++ b/src/api/app/models/buildresult.rb
@@ -60,4 +60,8 @@ class Buildresult < ActiveXML::Node
   def self.index2code(index)
     AVAIL_STATUS_VALUES.key(index)
   end
+
+  def self.final_status?(status)
+    %w(succeeded failed unresolvable broken disabled excluded).include? status
+  end
 end

--- a/src/api/app/views/webui/package/live_build_log.html.erb
+++ b/src/api/app/views/webui/package/live_build_log.html.erb
@@ -23,7 +23,8 @@
      data-offset="<%= @offset %>"
      data-url="<%= url_for(action: :update_build_log,
 		   package: @build_container, project: @project,
-		   arch: @arch, repository: @repo) %>">
+                   status: @status,
+                   arch: @arch, repository: @repo) %>">
   <pre id="log_space"></pre>
 </div>
 

--- a/src/api/app/views/webui/package/update_build_log.js.erb
+++ b/src/api/app/views/webui/package/update_build_log.js.erb
@@ -1,5 +1,6 @@
 <% if @finished %>
-  $('#log_space').append('<%= escape_javascript(@log_chunk) %>');
+  $('#log_space').html('<%= escape_javascript(@log_chunk) %>');
+  autoscroll();
   build_finished();
   hide_abort();
 <% else %>

--- a/src/api/spec/controllers/webui/package_controller_spec.rb
+++ b/src/api/spec/controllers/webui/package_controller_spec.rb
@@ -662,6 +662,14 @@ EOT
     RSpec.shared_examples "build log" do
       context "successfully" do
         before do
+          path = "#{CONFIG['source_url']}/build/#{user.home_project}/_result?view=status" \
+                 "&package=#{source_package}&arch=i586&repository=10.2"
+          stub_request(:get, path).and_return(body:
+            %(<resultlist state='123'>
+               <result project='#{user.home_project.name}' repository='10.2' arch='i586'>
+                 <binarylist/>
+               </result>
+              </resultlist>))
           do_request project: source_project, package: source_package, repository: '10.2', arch: 'i586', format: 'js'
         end
 

--- a/src/api/test/unit/code_quality_test.rb
+++ b/src/api/test/unit/code_quality_test.rb
@@ -102,6 +102,7 @@ class CodeQualityTest < ActiveSupport::TestCase
       'Webui::PackageController#save_new_link'                                  => 82.3,
       'Webui::PackageController#submit_request'                                 => 110.76,
       'Webui::PackageController#dependency'                                     => 83.57,
+      'Webui::PackageController#update_build_log'                               => 81.73,
       'Webui::PatchinfoController#save'                                         => 256.25,
       'Webui::ProjectController#check_devel_package_status'                     => 81.95,
       'Webui::ProjectController#save_meta'                                      => 83.61,


### PR DESCRIPTION
fixes few issues which we noticed in live build log view:
- sometimes index goes out of range when downloading last log chunk when project is using build-compare ("remote error: start out of range..")
- live build log is cleared when fetching last log chunk: live build log would otherwise contain chunks from different build logs, if build-compare is used and build result is same
- build status is checked when fetching new log chunk: sometimes live build log view stops fetching logs too early (i.e. backend retruns zero size log) event though webui shows status as "building" and the build has not yet started in worker

