### PR TITLE
[ci] Add 'bullet' gem and its configuration

### DIFF
--- a/src/api/Gemfile
+++ b/src/api/Gemfile
@@ -133,6 +133,8 @@ group :development, :test do
   gem 'poltergeist'
   # to launch browser in test
   gem 'launchy'
+  # to find n+1 queries
+  gem 'bullet'
 end
 
 # Gems used only for assets and not required in production environments by default.

--- a/src/api/Gemfile.lock
+++ b/src/api/Gemfile.lock
@@ -52,6 +52,9 @@ GEM
     arel (7.1.1)
     ast (2.3.0)
     builder (3.2.2)
+    bullet (5.4.2)
+      activesupport (>= 3.0.0)
+      uniform_notifier (~> 1.10.0)
     capybara (2.10.1)
       addressable
       mime-types (>= 1.16)
@@ -326,6 +329,7 @@ GEM
     unicorn-rails (2.2.1)
       rack
       unicorn
+    uniform_notifier (1.10.0)
     vcr (3.0.3)
     voight_kampff (1.1.1)
       rack (>= 1.4, < 3.0)
@@ -350,6 +354,7 @@ DEPENDENCIES
   activemodel-serializers-xml
   acts_as_list
   acts_as_tree
+  bullet
   bundler
   capybara_minitest_spec
   chunky_png

--- a/src/api/config/environments/development.rb
+++ b/src/api/config/environments/development.rb
@@ -52,6 +52,14 @@ OBSApi::Application.configure do
   # Use an evented file watcher to asynchronously detect changes in source code,
   # routes, locales, etc. This feature depends on the listen gem.
   # config.file_watcher = ActiveSupport::EventedFileUpdateChecker
+
+  # Bullet configuration
+  config.after_initialize do
+    Bullet.enable = true
+    Bullet.bullet_logger = true
+    Bullet.console = true
+    Bullet.add_footer = true
+  end
 end
 
 CONFIG['extended_backend_log'] = true

--- a/src/api/config/environments/test.rb
+++ b/src/api/config/environments/test.rb
@@ -51,6 +51,13 @@ OBSApi::Application.configure do
   config.secret_key_base = '92b2ed725cb4d68cc5fbf86d6ba204f1dec4172086ee7eac8f083fb62ef34057f1b770e0722ade7b298837be7399c6152938627e7d15aca5fcda7a4faef91fc7'
   # rubocop:enable Metrics/LineLength
 
+  # Bullet configuration
+  config.after_initialize do
+    Bullet.enable = true
+    Bullet.bullet_logger = true
+    Bullet.raise = false # raise an error if n+1 query occurs
+  end
+
   # TODO: This shouldn't be needed when we switch to RSpec completely
   config.action_dispatch.rescue_responses.merge!('ActionController::InvalidAuthenticityToken' => 950 )
 end

--- a/src/api/spec/rails_helper.rb
+++ b/src/api/spec/rails_helper.rb
@@ -26,6 +26,18 @@ RSpec.configure do |config|
   config.filter_rails_from_backtrace!
   # arbitrary gems may also be filtered via:
   # config.filter_gems_from_backtrace("gem name")
+
+  # Wrap each test in Bullet api.
+  if Bullet.enable?
+    config.before(:each) do
+      Bullet.start_request
+    end
+
+    config.after(:each) do
+      Bullet.perform_out_of_channel_notifications if Bullet.notification?
+      Bullet.end_request
+    end
+  end
 end
 
 # support test coverage


### PR DESCRIPTION
In test environment we enable bullet log, without raising exceptions.
In development environment we enable bullet log and messages in browser.

![bullet_info](https://cloud.githubusercontent.com/assets/1212806/21056623/a4a09480-be36-11e6-823f-0120bce74022.png)

This is the first approach where we enable 'bullet' without fixing any queries n+1.
When we run `rails spec` then a bullet log with some errors (3MB) is created.