### PR TITLE
[ci] Remove deprecated 'raise_in_transactional_callbacks='

### DIFF
--- a/src/api/config/application.rb
+++ b/src/api/config/application.rb
@@ -74,9 +74,6 @@ module OBSApi
 
     config.cache_store = :dalli_store, 'localhost:11211', {namespace: 'obs-api', compress: true }
 
-    # will become default
-    config.active_record.raise_in_transactional_callbacks = true
-
     # required since rails 4.2
     config.active_job.queue_adapter = :delayed_job
 


### PR DESCRIPTION
'ActiveRecord::Base.raise_in_transactional_callbacks=' has been removed
because now by default is not swallowing errors in after_commit/after_rollback
callbacks