### PR TITLE
Add support for hostlabel based job filtering for workers

### DIFF
--- a/dist/obsworker
+++ b/dist/obsworker
@@ -355,6 +355,7 @@ case "$1" in
             fi
 	    echo "screen -t $WORKERID nice -n $OBS_NICE ./bs_worker --hardstatus $vmopt $port --root $R" \
                 "--statedir $workerdir/$I --id $WORKERID $REPO_PARAM $HUGETLBFS $HOSTLABELS" \
+                "${OBS_WORKER_HOSTLABEL_FILTER:+--hostlabel-filtering $OBS_WORKER_HOSTLABEL_FILTER}" \
                 "$HOSTOWNER $OBS_JOBS $OBS_THREADS $OBS_TEST $OBS_WORKER_OPT $TMPFS $DEVICE $SWAP $MEMORY" \
                 "$OBS_CLEANUP_CHROOT $ARCH $EMULATOR" \
                 >> $screenrc

--- a/dist/sysconfig.obs-server
+++ b/dist/sysconfig.obs-server
@@ -159,6 +159,20 @@ OBS_WORKER_HOSTLABELS=""
 OBS_WORKER_SECURITY_LEVEL=""
 
 ## Path:        Applications/OBS
+## Description: define whether host labels should filter accepted jobs.
+## Type:        ("and" | "or" | "")
+## Default:     ""
+## Config:      OBS
+#
+# Hostlabels can be used to filter accpeted jobs. When
+# OBS_WORKER_HOSTLABEL_FILTER is set to "and" all host labels must be
+# defined for the incoming job to be accepted. When
+# OBS_WORKER_HOSTLABEL_FILTER is set to "or" it is enough for the
+# incoming jobs to have at least one of the worker's host labels.
+#
+OBS_WORKER_HOSTLABEL_FILTER=""
+
+## Path:        Applications/OBS
 ## Description: Register in SLP server
 ## Type:        ("yes" | "no")
 ## Default:     "yes"

--- a/src/backend/BSXML.pm
+++ b/src/backend/BSXML.pm
@@ -744,6 +744,7 @@ our $worker = [
 	'workerid',
       [ 'buildarch' ],
       [ 'hostlabel' ],
+	'hostlabelfiltermode',
 	'sandbox',
       [ 'linux' =>
         [],

--- a/src/backend/bs_dispatch
+++ b/src/backend/bs_dispatch
@@ -690,7 +690,7 @@ sub checkconstraints {
       $workerseen{$workername} = 1;
       push @all_workers, $worker;
       next if $BSConfig::dispatch_constraint && !$BSConfig::dispatch_constraint->($info, $worker, $constraints);
-      next unless !$constraints || BSDispatcher::Constraints::oracle($worker, $constraints) > 0;
+      next unless BSDispatcher::Constraints::oracle($worker, $constraints);
       $sumworkers++;
       $downworkers++ if $workerstate eq 'down';
     }
@@ -1240,7 +1240,7 @@ while (1) {
         if ($harchcando{"$harch/$arch"} && $worker->{hardware} && exists($worker->{hardware}->{nativeonly})) {
            next;	# worker is not supporting the needed personality change
         }
-	next if $constraints && !BSDispatcher::Constraints::oracle($worker, $constraints);
+	next unless BSDispatcher::Constraints::oracle($worker, $constraints);
 	last unless -e "$jobsdir/$arch/$job";
 	last if $assigned && $tries >= 5;
 	$tries++;
@@ -1266,10 +1266,10 @@ while (1) {
 	$haveassigned = 1;
 	last;
       }
-      # we have jobs that could not be assigned and have constraints.
+      # we have jobs that could not be assigned.
       # check if non idle workers could build these job or if there are no
       # workers that met the constraints
-      if (!$haveassigned && $constraints) {
+      if (!$haveassigned) {
         if ($info->{'allworkercheck'}++ % 5 == 0) {
 	  if (!$info->{'allworkerchecktime'} || $now - $info->{'allworkerchecktime'} > 300) {
 	    $info->{'allworkerchecktime'} = $now;

--- a/src/backend/bs_dispatch
+++ b/src/backend/bs_dispatch
@@ -1190,8 +1190,6 @@ while (1) {
       my $tries = 0;
       my $haveassigned;
       my ($project, $repository, $arch) = split('/', $prpa, 3);
-      my $lastoracle = 0;
-      my $lastoracleidle;
       my $constraints;
       if ($info->{'constraintsmd5'}) {
 	my $constraintsmd5 = $ic->{$job}->{'constraintsmd5'};
@@ -1217,13 +1215,7 @@ while (1) {
 	}
       }
       undef $constraints if $constraints && !%$constraints;
-      push @idle, '__lastoracle' if $constraints;
       for my $idle (@idle) {
-	if ($idle eq '__lastoracle') {
-	  last unless $lastoracleidle;
-	  $idle = $lastoracleidle;
-	  $lastoracleidle = '__lastoracle';
-	}
 	next if $badhost{"$project/$info->{'package'}/$arch/$idle"};
 	next if $badhost{"$project/:repo:$info->{'repository'}/$arch/$idle"};
 	my ($harch, $hname) = split(':', $idle, 2);
@@ -1248,25 +1240,7 @@ while (1) {
         if ($harchcando{"$harch/$arch"} && $worker->{hardware} && exists($worker->{hardware}->{nativeonly})) {
            next;	# worker is not supporting the needed personality change
         }
-	if ($constraints) {
-	  my $ora = BSDispatcher::Constraints::oracle($worker, $constraints);
-	  next unless defined($ora) && $ora > 0;
-	  if ($ora < 1) {
-	    if ($lastoracleidle && $lastoracleidle eq '__lastoracle') {
-	      my $widle = $now - $workerinfo_mtime{$idle};
-	      my $jwait = $now - $info->{'readytime'};
-	      $widle = 0 if $widle < 0;
-	      $jwait = 0 if $jwait < 0;
-	      next if $widle / 60 < 1 - $ora && $jwait / 300 < 1 - $ora;
-	    } else {
-	      if ($ora > $lastoracle) {
-		$lastoracleidle = $idle;
-		$lastoracle = $ora;
-	      }
-	      next;
-	    }
-	  }
-	}
+	next if $constraints && !BSDispatcher::Constraints::oracle($worker, $constraints);
 	last unless -e "$jobsdir/$arch/$job";
 	last if $assigned && $tries >= 5;
 	$tries++;

--- a/src/backend/bs_worker
+++ b/src/backend/bs_worker
@@ -87,6 +87,7 @@ my $hostcheck;
 my $localkiwi;
 my $owner;
 my @hostlabel;
+my $hostlabelfiltermode;
 my $getbinariesproxy;
 my $hardstatus;
 
@@ -260,6 +261,8 @@ Usage: $0 [OPTION] --root <directory> --statedir <directory>
 
        --hostlabel : define a host label for build constraints, can be used multiple times
 
+       --hostlabel-filtering : define a host label filtering mode ("and" | "or" | "") (default: "")
+
        --vm-kernel : set kernel to use (xen/kvm)
 
        --vm-initrd : set initrd to use (xen/kvm)
@@ -389,6 +392,16 @@ while (@ARGV) {
     shift @ARGV;
     my $label = shift @ARGV;
     push @hostlabel, $label unless grep {$_ eq $label} @hostlabel;
+    next;
+  }
+  if ($ARGV[0] eq '--hostlabel-filtering') {
+    shift @ARGV;
+    $hostlabelfiltermode = shift @ARGV;
+    undef $hostlabelfiltermode if $hostlabelfiltermode eq "";
+    if ($hostlabelfiltermode !~ /^(or|and)?$/) {
+      print "Error: Invalid host label filter mode '$hostlabelfiltermode'.";
+      undef $hostlabelfiltermode;
+    }
     next;
   }
   if ($ARGV[0] eq '--id') {
@@ -656,6 +669,8 @@ sub device_size($) {
 my $workerinfo = {};
 # host labels
 $workerinfo->{'hostlabel'} = \@hostlabel if @hostlabel;
+# host labelfiltermode
+$workerinfo->{'hostlabelfiltermode'} = $hostlabelfiltermode if $hostlabelfiltermode;
 # sandbox
 $workerinfo->{'sandbox'} = 'chroot';
 $workerinfo->{'sandbox'} = $1 if $vm =~ /(xen|kvm|emulator|lxc|zvm|docker|pvm)/;


### PR DESCRIPTION
Add support for configuring workers such that they will only get jobs that meet the their hostlabel requirements. Previously it has only been possible to set hostlabels for jobs so that the jobs will be run on workers that have the same hostlabels but it has not been possible to filter jobs from the worker's point of view.

This change implements two filtering modes for the hostlabels. The "and" mode requires that an incoming job has all the same hostlabels as the worker and the "or" mode requires the incoming jobs to have at least on of the worker's hostlabels.

The first commit removes some dead code that was found during this' development (pay attention to the lines 1363 and 1364).