### PR TITLE
show sibling projects in subprojects view

### DIFF
--- a/src/api/app/assets/javascripts/webui/application/project.js
+++ b/src/api/app/assets/javascripts/webui/application/project.js
@@ -146,12 +146,13 @@ function setup_subprojects_tables() {
     $('#parentprojects_table').dataTable({
         'paging': false,
         'searching': false,
-        'info': false
+        'info': false,
+        "autoWidth": false
     });
     $('#subprojects_table').dataTable({
         'paging': false,
         'searching': false,
-        'info': false
+        'info': false,
+        "autoWidth": false
     });
-
 }

--- a/src/api/app/assets/javascripts/webui/application/project.js
+++ b/src/api/app/assets/javascripts/webui/application/project.js
@@ -149,6 +149,14 @@ function setup_subprojects_tables() {
         'info': false,
         "autoWidth": false
     });
+    if ($('#siblingprojects_table').length) {
+        $('#siblingprojects_table').dataTable({
+        'paging': false,
+        'searching': false,
+        'info': false,
+        "autoWidth": false
+        });
+    }
     $('#subprojects_table').dataTable({
         'paging': false,
         'searching': false,

--- a/src/api/app/assets/stylesheets/webui/application.css.erb
+++ b/src/api/app/assets/stylesheets/webui/application.css.erb
@@ -42,6 +42,12 @@ table.dataTable.compact {
   border-collapse: collapse;
 }
 
+table.dataTable.compact.fit {
+  table-layout: auto;
+  width: 100%;
+  word-wrap: break-word;
+}
+
 a.paginate_button.next {
   width: 51px;
 }

--- a/src/api/app/assets/stylesheets/webui/application/project.scss
+++ b/src/api/app/assets/stylesheets/webui/application/project.scss
@@ -94,6 +94,18 @@ table.buildstatus {
   width: 1%;
 }
 
+/* subproject view table column widths */
+
+td.project_name {
+  max-width: 20em;
+  min-width: 20em;
+}
+
+td.project_title {
+  max-width: 30em;
+  min-width: 30em;
+}
+
 /* move the image back into the line */
 
 th.buildstatus img {

--- a/src/api/app/controllers/webui/project_controller.rb
+++ b/src/api/app/controllers/webui/project_controller.rb
@@ -82,6 +82,9 @@ class Webui::ProjectController < Webui::WebuiController
   def subprojects
     @subprojects = @project.subprojects.order(:name)
     @parentprojects = @project.ancestors.order(:name)
+    parent = @project.parent
+    @parent_name = parent.name unless parent.nil?
+    @siblings = @project.siblingprojects
   end
 
   def new

--- a/src/api/app/helpers/webui/project_helper.rb
+++ b/src/api/app/helpers/webui/project_helper.rb
@@ -103,6 +103,10 @@ module Webui::ProjectHelper
     end
   end
 
+  def remove_parent_name(project_name, parent_name)
+    project_name.slice(parent_name.length + 1, project_name.length)
+  end
+
   STATE_ICONS = {
       'new'      => 'flag_green',
       'review'   => 'flag_yellow',

--- a/src/api/app/models/project.rb
+++ b/src/api/app/models/project.rb
@@ -214,6 +214,18 @@ class Project < ApplicationRecord
     Project.where("name like ?", "#{name}:%")
   end
 
+  def siblingprojects
+    parent_name = parent.try(:name)
+    siblings = Array.new
+    if parent_name
+      Project.where("name like (?) and name != (?)", "#{parent_name}:%", name).order(:name).each do |sib|
+        sib_parent = sib.possible_ancestor_names.first
+        siblings << sib if sib_parent == parent_name
+      end
+    end
+    siblings
+  end
+
   def maintained_project_names
     maintained_projects.includes(:project).pluck("projects.name")
   end

--- a/src/api/app/views/webui/project/subprojects.html.haml
+++ b/src/api/app/views/webui/project/subprojects.html.haml
@@ -33,6 +33,19 @@
   %p
     %i This project has no subprojects
 
+- if @siblings.present?
+  %h3 Sibling projects of #{@project}
+  %table.compact.fit.stripe.no-footer#siblingprojects_table
+    %thead
+      %tr
+        %th Sibling project
+        %th Title
+    %tbody
+      - @siblings.each do |project|
+        %tr
+          %td.project_name= link_to(remove_parent_name(project.name, @parent_name), {:action => 'show', :project => project.name})
+          %td.project_title= project.title
+
 - if User.current.can_modify_project?(@project)
   %p
     = link_to sprite_tag('brick_add', title: 'New subproject') + ' New subproject', '#', id: 'create_subproject_link'

--- a/src/api/app/views/webui/project/subprojects.html.haml
+++ b/src/api/app/views/webui/project/subprojects.html.haml
@@ -6,30 +6,29 @@
 
 - if @parentprojects.present?
   %h3 Parent projects of #{@project}
-  %table.compact.stripe.no-footer#parentprojects_table
+  %table.compact.fit.stripe.no-footer#parentprojects_table
     %thead
       %tr
         %th Parent project
-        %th Description
+        %th Title
     %tbody
       - @parentprojects.each do |project|
         %tr
-          %td= link_to project.name, :action => 'show', :project => project.name
-          %td= project.title
+          %td.project_name= link_to(project.name, {:action => 'show', :project => project.name})
+          %td.project_title= project.title
 
 %h3= @pagetitle
-- prjlen = @project.name.length
 - if @subprojects.present?
-  %table.compact.stripe.no-footer#subprojects_table
+  %table.compact.fit.stripe.no-footer#subprojects_table
     %thead
       %tr
         %th Subproject
-        %th Description
+        %th Title
     %tbody
       - @subprojects.each do |project|
         %tr
-          %td= link_to project.name.slice(prjlen + 1, project.name.length), :action => 'show', :project => project.name
-          %td= project.title
+          %td.project_name= link_to(remove_parent_name(project.name, @project.name), {:action => 'show', :project => project.name})
+          %td.project_title= project.title
 - else
   %p
     %i This project has no subprojects

--- a/src/api/spec/controllers/webui/project_controller_spec.rb
+++ b/src/api/spec/controllers/webui/project_controller_spec.rb
@@ -202,14 +202,33 @@ RSpec.describe Webui::ProjectController, vcr: true do
     before do
       apache_project
       @project = create(:project, name: 'Apache:Apache2')
-      create(:project, name: 'Apache:Apache2:TestSubproject')
-      create(:project, name: 'Apache:Apache2:TestSubproject2')
-      another_project
-      get :subprojects, params: { project: @project }
+      @subproject1 = create(:project, name: 'Apache:Apache2:TestSubproject')
+      @subproject2 = create(:project, name: 'Apache:Apache2:TestSubproject2')
     end
 
-    it { expect(assigns(:subprojects)).to match_array(@project.subprojects) }
-    it { expect(assigns(:parentprojects)).to match_array(@project.ancestors) }
+    context 'subprojects' do
+      before do
+        get :subprojects, params: { project: @project }
+      end
+
+      it "has subprojects" do
+        expect(assigns(:subprojects)).to match_array([@subproject1, @subproject2])
+        expect(assigns(:parentprojects)).to contain_exactly(apache_project)
+        expect(assigns(:siblings)).to be_empty
+      end
+    end
+
+    context 'siblingprojects' do
+      before do
+        get :subprojects, params: { project: @subproject1 }
+      end
+
+      it "has siblingprojects" do
+        expect(assigns(:subprojects)).to be_empty
+        expect(assigns(:parentprojects)).to match_array([apache_project, @project])
+        expect(assigns(:siblings)).to contain_exactly(@subproject2)
+      end
+    end
   end
 
   describe 'GET #new' do


### PR DESCRIPTION
This will add a new table to subprojects view, which shows a list of sibling projects (if exists). This makes navigation easier, when switching view between subprojects. Siblings for home and root level projects are not shown.

Parent and subproject table column widths are also adjusted to same width in order to have more uniform look. Also "Description" column is renamed to "Title", because it was showing project title in the table cell.