### PR TITLE
[dist] Use fixed hostname for development backend

### DIFF
--- a/contrib/start_development_backend
+++ b/contrib/start_development_backend
@@ -101,6 +101,7 @@ if [ ! -f $GIT_HOME/src/backend/BSConfig.pm ]; then
   cp $GIT_HOME/src/backend/BSConfig.pm.template $GIT_HOME/src/backend/BSConfig.pm
 fi
 perl -pi -e 's/our \$bsserviceuser.*/our \$bsserviceuser="obsrun";/' $GIT_HOME/src/backend/BSConfig.pm
+perl -pi -e 's/my \$hostname.*/my \$hostname="localhost";/' $GIT_HOME/src/backend/BSConfig.pm
 
 
 #start backend services (the minimum needed) with two arch(i586/x86_64) schedulers and one worker


### PR DESCRIPTION
Otherwise 87c5c0e081 breaks new development environments