### PR TITLE
[api] Delete nobody comments without children

### DIFF
--- a/src/api/app/models/comment.rb
+++ b/src/api/app/models/comment.rb
@@ -8,6 +8,7 @@ class Comment < ApplicationRecord
   validates :body, :commentable, :user, presence: true
 
   after_create :create_notification
+  after_destroy :delete_parent_if_unused
 
   has_many :children, dependent: :destroy, class_name: 'Comment', foreign_key: 'parent_id'
 
@@ -98,5 +99,11 @@ class Comment < ApplicationRecord
   # FIXME: This is to work around https://github.com/rails/rails/pull/12450/files
   def destroy
     super
+  end
+
+  private
+
+  def delete_parent_if_unused
+    parent.destroy if parent && parent.user == User.find_nobody! && parent.children.length.zero?
   end
 end

--- a/src/api/spec/models/comment_spec.rb
+++ b/src/api/spec/models/comment_spec.rb
@@ -3,6 +3,8 @@ require "rails_helper"
 RSpec.describe Comment do
   let(:comment_package) { create(:comment_package) }
   let(:comment_package_with_parent) { create(:comment_package, parent: comment_package) }
+  let(:comment_package_with_parent_2) { create(:comment_package, parent: comment_package) }
+  let(:comment_package_with_grandparent) { create(:comment_package, parent: comment_package_with_parent) }
 
   describe "has a valid Factory" do
     it { expect(comment_package).to be_valid }
@@ -63,6 +65,30 @@ RSpec.describe Comment do
 
       it 'should be destroyed' do
         expect { comment_package.blank_or_destroy }.to change { Comment.count }.by(-1)
+      end
+    end
+
+    context "with nobody parent and a brother" do
+      before do
+        comment_package_with_parent
+        comment_package_with_parent_2
+        comment_package.blank_or_destroy
+      end
+
+      it 'should be destroyed' do
+        expect { comment_package_with_parent.blank_or_destroy }.to change { Comment.count }.by(-1)
+      end
+    end
+
+    context "with nobody parent, nobody grandparent and no brother" do
+      before do
+        comment_package_with_grandparent
+        comment_package_with_parent.blank_or_destroy
+        comment_package.blank_or_destroy
+      end
+
+      it 'should be destroyed' do
+        expect { comment_package_with_grandparent.blank_or_destroy }.to change { Comment.count }.by(-3)
       end
     end
 


### PR DESCRIPTION
When deleting a comment with children, it is not deleted but belongs to
the nobody user. And then when the child comment was deleted, the nobody
comment used to be kept. Now it is also deleted. :relieved: 

Closes https://github.com/openSUSE/open-build-service/issues/2480