### PR TITLE
[backend] fixed whitespace in rpc call

### DIFF
--- a/src/backend/bs_repserver
+++ b/src/backend/bs_repserver
@@ -3579,7 +3579,7 @@ sub checkconstraints {
     $constraints = readxml("$uploaddir/$$", $BSXML::constraints);
     unlink("$uploaddir/$$");
   }
-  my $pconf = BSRPC::rpc("$BSConfig::srcserver/getconfig", undef, "project=$projid ", "repository=$repoid");
+  my $pconf = BSRPC::rpc("$BSConfig::srcserver/getconfig", undef, "project=$projid", "repository=$repoid");
   my $bconf = Build::read_config($arch, [ split("\n", $pconf)] );
   my @list = map { [ split(' ', $_) ] } @{$bconf->{'constraint'}};
   my $prjconfconstraint = BSDispatcher::Constraints::list2struct($BSXML::constraints, \@list);


### PR DESCRIPTION
resulted in misinterpretation of given projid

"home:bla" --> "home bla "