### PR TITLE
[api] fix another case in maintenance_incident target check

### DIFF
--- a/src/api/app/models/package.rb
+++ b/src/api/app/models/package.rb
@@ -856,7 +856,7 @@ class Package < ApplicationRecord
     directory_hash = Directory.hashed(project: project, package: package)
     linkinfo = directory_hash["linkinfo"] || {}
 
-    "#{package}.#{linkinfo['project'] || project}"
+    "#{linkinfo['package'] || package}.#{linkinfo['project'] || project}".gsub(/:/, '_')
   end
 
   def linkinfo


### PR DESCRIPTION
find the right target package also when source also used extended names