### PR TITLE
[webui] Fix breadcrumb with long project name

### DIFF
--- a/src/api/app/assets/stylesheets/webui/application/style.scss
+++ b/src/api/app/assets/stylesheets/webui/application/style.scss
@@ -408,3 +408,7 @@ div.dataTables_wrapper:after {
 .padding-10pt {
   padding: 10pt;
 }
+
+#subheader #breadcrump {
+  line-height: 1.3em;
+}


### PR DESCRIPTION
We add a line-height to see the underscores when we have two lines in the
breadcrumb

Before:
![screenshot before](https://cloud.githubusercontent.com/assets/1212806/21565861/0e385998-ce9d-11e6-97da-07bb2a5462f4.png)

After:
![screenshot after](https://cloud.githubusercontent.com/assets/1212806/21565864/160f9118-ce9d-11e6-9e28-9284356f64b8.png)

