### PR TITLE
[api] `render :text` is deprecated

### DIFF
--- a/src/api/app/controllers/attribute_controller.rb
+++ b/src/api/app/controllers/attribute_controller.rb
@@ -31,7 +31,7 @@ class AttributeController < ApplicationController
       end
     end
 
-    render text: xml, content_type: "text/xml"
+    render xml: xml
   end
 
   # /attribute/:namespace/_meta
@@ -181,11 +181,11 @@ class AttributeController < ApplicationController
       path = "/source/#{URI.escape(params[:project])}/#{URI.escape(params[:package]||'_project')}/_attribute?meta=1"
       path += "&rev=#{CGI.escape(params[:rev])}" if params[:rev]
       answer = Suse::Backend.get(path)
-      render text: answer.body.to_s, content_type: 'text/xml'
+      render xml: answer.body.to_s
       return
     end
 
-    render text: @attribute_container.render_attribute_axml(params), content_type: 'text/xml'
+    render xml: @attribute_container.render_attribute_axml(params)
   end
 
   # DELETE

--- a/src/api/app/controllers/issues_controller.rb
+++ b/src/api/app/controllers/issues_controller.rb
@@ -7,6 +7,6 @@ class IssuesController < ApplicationController
     # NOTE: issue_tracker_id is here actually the name
     issue = Issue.find_or_create_by_name_and_tracker( params[:id], params[:issue_tracker_id], params[:force_update] )
 
-    render text: issue.render_axml, content_type: 'text/xml'
+    render xml: issue.render_axml
   end
 end

--- a/src/api/app/controllers/person_controller.rb
+++ b/src/api/app/controllers/person_controller.rb
@@ -36,10 +36,10 @@ class PersonController < ApplicationController
 
     if user.login != @http_user.login
       logger.debug "Generating for user from parameter #{user.login}"
-      render text: user.render_axml(@http_user.is_admin?), content_type: "text/xml"
+      render xml: user.render_axml(@http_user.is_admin?)
     else
       logger.debug "Generating user info for logged in user #{@http_user.login}"
-      render text: @http_user.render_axml(true), content_type: "text/xml"
+      render xml: @http_user.render_axml(true)
     end
   end
 

--- a/src/api/app/controllers/search_controller.rb
+++ b/src/api/app/controllers/search_controller.rb
@@ -245,7 +245,7 @@ class SearchController < ApplicationController
     end
 
     output << "</collection>"
-    render text: output, content_type: "text/xml"
+    render xml: output
   end
 
   # specification of this function:
@@ -316,6 +316,6 @@ class SearchController < ApplicationController
         end
       end
     end
-    render text: xml, content_type: "text/xml"
+    render xml: xml
   end
 end

--- a/src/api/app/controllers/source_controller.rb
+++ b/src/api/app/controllers/source_controller.rb
@@ -659,7 +659,7 @@ class SourceController < ApplicationController
                                           # or if rev it specified we need to fetch the meta from the backend
       answer = Suse::Backend.get(request.path_info)
       if answer
-        render text: answer.body.to_s, content_type: 'text/xml'
+        render xml: answer.body.to_s
       else
         render_error status: 404, errorcode: 'unknown_package',
                      message: "Unknown package '#{@package_name}'"
@@ -910,7 +910,7 @@ class SourceController < ApplicationController
         c.project(p)
       end
     end
-    render text: xml, content_type: 'text/xml'
+    render xml: xml
   end
 
   # lock a project
@@ -1257,7 +1257,7 @@ class SourceController < ApplicationController
 #      path = "/search/package/id?match=(@linkinfo/package=\"#{CGI.escape(package_name)}\"+and+@linkinfo/project=\"#{CGI.escape(project_name)}\")"
 #      answer = Suse::Backend.post path
 #      render :text => answer.body, :content_type => 'text/xml'
-      render text: '<collection/>', content_type: 'text/xml'
+      render xml: '<collection/>'
       return
     end
 
@@ -1270,7 +1270,7 @@ class SourceController < ApplicationController
         c.package(p)
       end
     end
-    render text: xml, content_type: 'text/xml'
+    render xml: xml
   end
 
   # POST /source/<project>/<package>?cmd=collectbuildenv

--- a/src/api/app/controllers/statistics_controller.rb
+++ b/src/api/app/controllers/statistics_controller.rb
@@ -12,9 +12,7 @@ class StatisticsController < ApplicationController
   ]
 
   def index
-    text = "This is the statistics controller.<br />"
-    text += "See the api documentation for details."
-    render text: text
+    render plain: "This is the statistics controller.<br/>See the api documentation for details."
   end
 
   def min_votes_for_rating

--- a/src/api/app/controllers/webui/package_controller.rb
+++ b/src/api/app/controllers/webui/package_controller.rb
@@ -1001,9 +1001,9 @@ class Webui::PackageController < Webui::WebuiController
           res += line
         end
       end
-      render text: res, content_type: 'text/html'
+      render html: res
     rescue ActiveXML::Transport::NotFoundError
-      render text: 'No rpmlint log'
+      render plain: 'No rpmlint log'
     end
   end
 


### PR DESCRIPTION
`render :text` is deprecated because it does not actually render a `text/plain` response :bowtie: 