### PR TITLE
[webui] fix a crash regression

### DIFF
--- a/src/api/app/controllers/webui/package_controller.rb
+++ b/src/api/app/controllers/webui/package_controller.rb
@@ -853,14 +853,15 @@ class Webui::PackageController < Webui::WebuiController
 
     set_initial_offset if @offset.zero?
 
-    package_object = Package.find_by(name: params[:package])
-    if package_object.nil? || !package_object.check_source_access?
+    package_object = @project.find_package(params[:package])
+    # remote package sources are always fine to show
+    if package_object && !package_object.check_source_access?
       flash[:error] = "Could not access revisions"
       redirect_back(fallback_location: package_show_path(project: @project, package: package_object.name))
       return
     end
 
-    @package = package_object.name
+    @package = params[:package]
     begin
       @log_chunk = get_log_chunk(@project, @package, @repo, @arch, @offset, @offset + @maxsize)
 


### PR DESCRIPTION
Don't use package object when it is nil