### PR TITLE
[backend] enable worker to wipe buildroot

### DIFF
--- a/dist/obsworker
+++ b/dist/obsworker
@@ -83,6 +83,9 @@ fi
 if [ -n "$OBS_WORKER_CLEANUP_CHROOT" ]; then
     OBS_CLEANUP_CHROOT="--cleanup-chroot"
 fi
+if [ -n "$OBS_WORKER_WIPE_AFTER_BUILD" ]; then
+    OBS_WIPE_AFTER_BUILD="--wipeafterbuild"
+fi
 
 if [ -n "OBS_WORKER_SECURITY_LEVEL" ]; then
     OBS_WORKER_HOSTLABELS="OBS_WORKER_SECURITY_LEVEL_${OBS_WORKER_SECURITY_LEVEL} $OBS_WORKER_HOSTLABELS"
@@ -356,7 +359,7 @@ case "$1" in
 	    echo "screen -t $WORKERID nice -n $OBS_NICE ./bs_worker --hardstatus $vmopt $port --root $R" \
                 "--statedir $workerdir/$I --id $WORKERID $REPO_PARAM $HUGETLBFS $HOSTLABELS" \
                 "$HOSTOWNER $OBS_JOBS $OBS_THREADS $OBS_TEST $OBS_WORKER_OPT $TMPFS $DEVICE $SWAP $MEMORY" \
-                "$OBS_CLEANUP_CHROOT $ARCH $EMULATOR" \
+                "$OBS_CLEANUP_CHROOT $OBS_WIPE_AFTER_BUILD $ARCH $EMULATOR" \
                 >> $screenrc
 	    mkdir -p $workerdir/$I
         done

--- a/dist/sysconfig.obs-server
+++ b/dist/sysconfig.obs-server
@@ -380,3 +380,12 @@ OBS_WORKER_SCRIPT_URL=""
 #
 #
 OBS_WORKER_CLEANUP_CHROOT=""
+
+##Path:         Application/OBS
+## Description: wipes the build environment of the worker after the build
+## Type:        ("yes" | "")
+## Default:     ""
+## Config:      OBS
+#
+#
+OBS_WORKER_WIPE_AFTER_BUILD=""

--- a/src/backend/bs_worker
+++ b/src/backend/bs_worker
@@ -95,6 +95,7 @@ my $threads;
 my $cachedir;
 my $cachesize;
 my $cleanup_chroot;
+my $wipeafterbuild;
 
 # current XEN has no xenstore anymore
 my $xenstore_maxsize = 20 * 1000000;
@@ -218,6 +219,18 @@ sub kill_job {
   return 1;
 }
 
+sub wipe_all {
+  my @args;
+  if ($vm =~ /(xen|kvm|zvm|emulator)/) {
+    push @args, '--root', "$buildroot/.mount";
+  } else {
+    push @args, '--root', $buildroot;
+  }
+  if (system("$statedir/build/build", @args, "--wipe")) {
+    return 0;
+  }
+  return 1;
+}
 sub usage {
   my ($ret) = @_;
 
@@ -561,6 +574,11 @@ while (@ARGV) {
   if ($ARGV[0] eq '--cleanup-chroot') {
     shift @ARGV;
     $cleanup_chroot = 1;
+    next;
+  }
+  if ($ARGV[0] eq '--wipeafterbuild') {
+    shift @ARGV;
+    $wipeafterbuild = 1;
     next;
   }
   last;
@@ -3353,6 +3371,7 @@ my ($state, $buildinfo, $registerserver) = BSServer::server($conf);
 print "got job, run build...\n";
 BSServer::done(1);
 
+mkdir_p($buildroot) if ( ! -e $buildroot);
 unlink("$buildroot/.build.meta");
 unlink("$buildroot/.build.packages");
 unlink("$buildroot/.build.log");
@@ -3590,6 +3609,8 @@ if (!$testmode) {
     sleep(60);
   } else {
     print "sent, all done...\n";
+    # do the wipe
+    wipe_all() if $wipeafterbuild;
   }
 } else {
   print "testmode, not sending anything\n";


### PR DESCRIPTION
If the worker is started with --wipeafterbuild the build script is called with the --wipe switch at the end of the run.
This will wipe the buildroot. 

Unfortunately following build jobs will not start until the worker is rebooted. Therefore the check for the buildroot is needed: 

```
mkdir_p($buildroot) if ( ! -e $buildroot);
```

@mlschroe @adrianschroeter please review