### PR TITLE
[webui][api] update to yajl 1.3.0

### DIFF
--- a/src/api/Gemfile.lock
+++ b/src/api/Gemfile.lock
@@ -340,7 +340,7 @@ GEM
       pkg-config
     xpath (2.0.0)
       nokogiri (~> 1.3)
-    yajl-ruby (1.2.1)
+    yajl-ruby (1.3.0)
 
 PLATFORMS
   ruby
@@ -417,4 +417,4 @@ DEPENDENCIES
   yajl-ruby
 
 BUNDLED WITH
-   1.13.6
+   1.12.5


### PR DESCRIPTION
To fix builds with ruby 2.4, even when still use 2.3 as default for now