### PR TITLE
[webui] Display architecture name of a running worker

### DIFF
--- a/src/api/app/views/webui/monitor/_events.html.erb
+++ b/src/api/app/views/webui/monitor/_events.html.erb
@@ -6,7 +6,19 @@
     <%= form_tag(:controller => "main", :action => "index") do %>
       <p>
         <strong>Architecture:</strong>
-        <%= select_tag(:architecture_display, options_for_select(@available_arch_list, @default_architecture)) %><br/>
+        <% wcount = 0 %>
+        <% @workerstatus.elements("partition") do |part|
+            part.elements("daemon") do |daemon|
+              if daemon["type"] == "scheduler" and daemon["state"] == "running"
+                 wcount = wcount + 1 %>
+                 <%= select_tag(:architecture_display, options_for_select(@available_arch_list, daemon["arch"])) %><br/>
+                 <% break %>
+              <% end -%>
+            <% end -%>
+        <% end -%>
+        <% if wcount < 1 %>
+            <%= select_tag(:architecture_display, options_for_select(@available_arch_list, @default_architecture)) %><br/>
+        <% end -%>
         <strong>Timeframe:</strong>
         <%= select_tag(:time_display, options_for_select([["1 day", "24"], ["1 hour", 1], ["1 week", "168"], ["1 month", "720"], ["1 year", "8760"]], "24")) %>
       </p> 


### PR DESCRIPTION
This PR is to display an architecture information of a running worker
by default instead of a sorted architecture name (e.g., armv7l) as
a "selected" html tag among the available architecture names that are
configured at the http://ip-address/architectures.

Ver2.
 - Handle in case that all schedulers stopped.

Signed-off-by: Geunsik Lim <geunsik.lim@samsung.com>

\CC: @myungjoo , @jang798 , @jerrynoid