### PR TITLE
[api] use rails tmp dir instead of system one

### DIFF
--- a/src/api/app/controllers/application_controller.rb
+++ b/src/api/app/controllers/application_controller.rb
@@ -277,7 +277,7 @@ class ApplicationController < ActionController::Base
     # as the send_file function only references the path to it. So we keep it
     # for ourselves. And once the controller is garbage collected, it should
     # be fine to unlink the data
-    @volleyfile = Tempfile.new 'volley', encoding: 'ascii-8bit'
+    @volleyfile = Tempfile.new('volley', "#{Rails.root}/tmp", encoding: 'ascii-8bit')
     opts = { url_based_filename: true }
 
     backend_http.request_get(path) do |res|
@@ -297,7 +297,7 @@ class ApplicationController < ActionController::Base
   end
 
   def download_request
-    file = Tempfile.new 'volley', encoding: 'ascii-8bit'
+    file = Tempfile.new('volley', "#{Rails.root}/tmp", encoding: 'ascii-8bit')
     b = request.body
     buffer = String.new
     file.write(buffer) while b.read(40960, buffer)

--- a/src/api/app/controllers/webui/webui_controller.rb
+++ b/src/api/app/controllers/webui/webui_controller.rb
@@ -259,7 +259,7 @@ class Webui::WebuiController < ActionController::Base
   private
 
   def put_body_to_tempfile(xmlbody)
-    file = Tempfile.new('xml').path
+    file = Tempfile.new('xml', "#{Rails.root}/tmp").path
     file = File.open(file + '.xml', 'w')
     file.write(xmlbody)
     file.close

--- a/src/api/app/models/backend_file.rb
+++ b/src/api/app/models/backend_file.rb
@@ -19,7 +19,7 @@ class BackendFile
 
   # Sets the content File object for that model instance, calculates the right response data
   def file=(input_stream)
-    Tempfile.open('backend_file', Dir.tmpdir, encoding: 'ascii-8bit') do |tempfile|
+    Tempfile.open('backend_file', "#{Rails.root}/tmp", encoding: 'ascii-8bit') do |tempfile|
       buffer = ''
       tempfile.write(buffer) while input_stream.read(BUFFER_SIZE, buffer)
       @file = tempfile

--- a/src/api/config/initializers/tempdir.rb
+++ b/src/api/config/initializers/tempdir.rb
@@ -1,0 +1,6 @@
+
+class Dir
+  def self.tmpdir
+    "#{Rails.root}/tmp"
+  end
+end


### PR DESCRIPTION
We use the rails environment tmp dir only in some cases so far.
This might create problems when the system tmp dir has way less space
than the one supposed to be used for the rails app.