### PR TITLE
[webui] Fix rpmlint rendering

### DIFF
--- a/src/api/app/controllers/webui/package_controller.rb
+++ b/src/api/app/controllers/webui/package_controller.rb
@@ -990,19 +990,9 @@ class Webui::PackageController < Webui::WebuiController
   def rpmlint_log
     required_parameters :project, :package, :repository, :architecture
     begin
-      rpmlint_log = get_rpmlint_log(params[:project], params[:package], params[:repository], params[:architecture])
-      rpmlint_log.encode!(xml: :text)
-      res = ''
-      rpmlint_log.lines.each do |line|
-        if line.match(/\w+(?:\.\w+)+: W: /)
-          res += "<span style=\"color: olive;\">#{line}</span>"
-        elsif line.match(/\w+(?:\.\w+)+: E: /)
-          res += "<span style=\"color: red;\">#{line}</span>"
-        else
-          res += line
-        end
-      end
-      render html: res
+      @log = get_rpmlint_log(params[:project], params[:package], params[:repository], params[:architecture])
+      @log.encode!(xml: :text)
+      render partial: 'rpmlint_log'
     rescue ActiveXML::Transport::NotFoundError
       render plain: 'No rpmlint log'
     end

--- a/src/api/app/views/webui/package/rpmlint_log.html.haml
+++ b/src/api/app/views/webui/package/rpmlint_log.html.haml
@@ -1,0 +1,7 @@
+- @log.lines.each do |line|
+  - if line.match(/\w+(?:\.\w+)+: W: /)
+    = content_tag(:span, line.strip, style: 'color: olive;')
+  - elsif line.match(/\w+(?:\.\w+)+: E: /)
+    = content_tag(:span, line.strip, style: 'color: red;')
+  - else
+    = line.strip


### PR DESCRIPTION
Introduced by changing the rendering method in bdfb287c880f2b60718348471b06e3b74fd020c6.
Needs to be html_safe, otherwise the html gets escaped.
Fixes #2552.