### PR TITLE
[webui] Access Mime type via symbol

### DIFF
--- a/src/api/app/controllers/webui/package_controller.rb
+++ b/src/api/app/controllers/webui/package_controller.rb
@@ -181,7 +181,7 @@ class Webui::PackageController < Webui::WebuiController
     end
     logger.debug "accepting #{request.accepts.join(',')} format:#{request.format}"
     # little trick to give users eager to download binaries a single click
-    if request.format != Mime::HTML && @durl
+    if request.format != Mime[:html] && @durl
       redirect_to @durl
       return
     end


### PR DESCRIPTION
because accessing via constant is deprecated.