### PR TITLE
[ci] Adapt spec to phantomjs 2.1.1

### DIFF
--- a/src/api/spec/features/webui/packages_spec.rb
+++ b/src/api/spec/features/webui/packages_spec.rb
@@ -120,7 +120,7 @@ RSpec.feature "Packages", type: :feature, js: true do
 
     scenario "via live build log" do
       visit package_live_build_log_path(project: user.home_project, package: package, repository: repository.name, arch: "x86_64")
-      first(:link, "Trigger Rebuild").click
+      click_link("Trigger Rebuild", match: :first)
       expect(a_request(:post, rebuild_url)).to have_been_made.once
     end
 


### PR DESCRIPTION
One spec was failing when running the specs with phantomjs 2.1.1, now is fixed.