### PR TITLE
[dist] Update the Vagrant box when setting up

### DIFF
--- a/contrib/common.sh
+++ b/contrib/common.sh
@@ -5,10 +5,12 @@ function allow_vendor_change() {
 }
 
 function add_common_repos() {
-  zypper -q ar -f http://download.opensuse.org/repositories/devel:/languages:/perl/openSUSE_Leap_42.1/devel:languages:perl.repo
+  zypper -q rr systemsmanagement-chef
+  zypper -q rr systemsmanagement-puppet
   zypper -q ar -f http://download.opensuse.org/repositories/OBS:/Server:/Unstable/openSUSE_42.1/OBS:Server:Unstable.repo
   zypper -q ar -f http://download.opensuse.org/repositories/openSUSE:/Tools/openSUSE_42.1/openSUSE:Tools.repo
   zypper -q --gpg-auto-import-keys refresh
+  zypper -q -n dup -l --replacefiles
 }
 
 function install_common_packages() {


### PR DESCRIPTION
openSUSE 42.1 got a GCC update that we need to pull in to mitigate problems
when building ruby binary extensions. Also remove the chef/puppet/dlp repos, we
do not use them.