### PR TITLE
[backend] Refactor verify_packid

### DIFF
--- a/src/backend/BSVerify.pm
+++ b/src/backend/BSVerify.pm
@@ -44,20 +44,17 @@ sub verify_packid {
   my $packid = $_[0];
   die("packid is empty\n") unless defined($packid) && $packid ne '';
   die("packid '$packid' is too long\n") if length($packid) > 200;
-  if ($packid =~ /(?<!^_product)(?<!^_patchinfo):./) {
-    # multibuild case: both parts need to be a valid source package name
-    die("packid '$packid' is illegal\n") unless $packid =~ /^([^:]+):([^:]+)$/s;
-    my ($p1, $p2) = ($1, $2);
-    die("packid '$packid' is illegal\n") if $p1 eq '_project' || $p1 eq '_pattern';
-    verify_packid($p1);
-    verify_packid($p2);
-    return;
+
+  return if $packid =~ /\A(_product|_pattern|_project|_patchinfo)\z/;
+  return if $packid =~ /\A(_product:|_patchinfo:)?[^_\.\/:\000-\037][^\/:\000-\037]*\z/;
+
+  # multibuild case: both parts need to be a valid source package name
+  die("packid '$packid' is illegal\n") unless $packid =~ /\A([^:]+):([^:]+)\z/;
+  my ($p1, $p2) = ($1, $2);
+  die("packid '$packid' is illegal\n") unless $p1 =~ /\A[^_\.\/:\000-\037][^\/:\000-\037]*\z/;
+  unless ($p2 =~ /\A(_product|_pattern|_project|_patchinfo)\z/ || $p2 =~ /\A[^_\.\/:\000-\037][^\/:\000-\037]*\z/){
+    die("packid '$packid' is illegal\n");
   }
-  $packid =~ s/^_product://s;
-  $packid =~ s/^_patchinfo://s;
-  die("packid '$packid' is illegal\n") if $packid =~ /[\/:\000-\037]/;
-  die("packid '$packid' is illegal\n") if $packid =~ /^[_\.]/ && $packid ne '_product' && $packid ne '_pattern' && $packid ne '_project' && $packid ne '_patchinfo';
-  die("packid '$packid' is illegal\n") unless $packid;
 }
 
 sub verify_repoid {


### PR DESCRIPTION
It is not needed to call recursively to `verify_packid` when we can know if `$p1` and `$p2` are valid with a simple regular expression.

And also in the general case, at least in my opinion, it is simpler to use two regular expressions (could be one but less readable) than removing a part of the string and making that many checks. And it is also more splicit because it is written what we want to accept in just one place.

I think that the code is simpler and more readable like that. Moreover, in case that for the multibuild case we wanted to be more strict in the characters used (I think @adrianschroeter  mentioned that that could be needed) it would be easier to change it. It will also make easier to put the multibuild case in a separate method. :bowtie: 