### PR TITLE
[webui] Remove ajax call for loading branch dialog

### DIFF
--- a/src/api/app/controllers/webui/package_controller.rb
+++ b/src/api/app/controllers/webui/package_controller.rb
@@ -13,7 +13,7 @@ class Webui::PackageController < Webui::WebuiController
   before_action :set_project, only: [:show, :users, :linking_packages, :dependency, :binary, :binaries,
                                      :requests, :statistics, :commit, :revisions, :submit_request_dialog,
                                      :add_person, :add_group, :rdiff, :wizard_new, :wizard, :save_new,
-                                     :branch_dialog, :save, :delete_dialog,
+                                     :save, :delete_dialog,
                                      :remove, :add_file, :save_file, :remove_file, :save_person,
                                      :save_group, :remove_role, :view_file,
                                      :abort_build, :trigger_rebuild, :trigger_services,
@@ -23,7 +23,7 @@ class Webui::PackageController < Webui::WebuiController
   before_action :require_package, only: [:show, :linking_packages, :dependency, :binary, :binaries,
                                          :requests, :statistics, :commit, :revisions, :submit_request_dialog,
                                          :add_person, :add_group, :rdiff, :wizard_new, :wizard,
-                                         :branch_dialog, :save, :delete_dialog,
+                                         :save, :delete_dialog,
                                          :remove, :add_file, :save_file, :remove_file, :save_person,
                                          :save_group, :remove_role, :view_file,
                                          :abort_build, :trigger_rebuild, :trigger_services,
@@ -541,10 +541,6 @@ class Webui::PackageController < Webui::WebuiController
       return false
     end
     true
-  end
-
-  def branch_dialog
-    render_dialog
   end
 
   def branch

--- a/src/api/app/views/webui/package/_branch_dialog.html.erb
+++ b/src/api/app/views/webui/package/_branch_dialog.html.erb
@@ -1,5 +1,4 @@
-  <div class="dialog" id="disable_mask"></div>
-  <div class="dialog darkgrey_box" id="branch_dialog">
+  <div class="dialog darkgrey_box hidden" id="package_branch_dialog">
     <div class="box box-shadow">
       <h2 class="box-header">Branch Confirmation</h2>
       <div class="dialog-content">
@@ -11,7 +10,7 @@
         <%= hidden_field_tag(:linked_package, @package.name) %>
         <div class="dialog-buttons">
           <%= submit_tag('Ok') %>
-          <%= remove_dialog_tag('Cancel') %>
+          <%= link_to('Close', '#', title: 'Close', class: 'close-dialog', data: { target: '#package_branch_dialog' }) %>
         </div>
       <% end %>
     </div>

--- a/src/api/app/views/webui/package/show.html.erb
+++ b/src/api/app/views/webui/package/show.html.erb
@@ -99,7 +99,7 @@
         <% unless User.current.is_nobody? %>
             <% if @current_rev %>
                 <li>
-                  <%= link_to(sprited_text('arrow_branch', 'Branch package'), { :action => :branch_dialog, :project => @project, :package => @package }, :remote => true) %>
+                  <%= link_to(sprited_text('arrow_branch', 'Branch package'), '#', class: 'show_dialog', data: { target: '#package_branch_dialog' }) %>
                 </li>
                 <li>
                   <%= link_to(sprited_text('package_go', 'Submit package'), { :action => :submit_request_dialog, :project => @project, :package => @package }, :remote => true) %>
@@ -164,3 +164,5 @@
   <h2 class="box-header">Comments for <%= @project.name %> (<%= @comments.length %>)</h2>
   <%= render :partial => 'webui/comment/show', locals: { commentable: @package } %>
 </div>
+
+<%= render partial: 'webui/package/branch_dialog' %>

--- a/src/api/config/routes.rb
+++ b/src/api/config/routes.rb
@@ -118,7 +118,6 @@ OBSApi::Application.routes.draw do
       get 'package/wizard_new/:project' => :wizard_new, constraints: cons
       get 'package/wizard/:project/:package' => :wizard, constraints: cons
       post 'package/save_new/:project' => :save_new, constraints: cons
-      get 'package/branch_dialog/:project/:package' => :branch_dialog, constraints: cons
       post 'package/branch' => :branch, constraints: cons
       post 'package/save/:project/:package' => :save, constraints: cons
       get 'package/delete_dialog/:project/:package' => :delete_dialog, constraints: cons

--- a/src/api/spec/features/webui/maintenance_workflow_spec.rb
+++ b/src/api/spec/features/webui/maintenance_workflow_spec.rb
@@ -34,8 +34,7 @@ RSpec.feature 'MaintenanceWorkflow', type: :feature, js: true do
     visit package_show_path(project: update_project, package: package)
 
     click_link('Branch package')
-    # we need this find to wait for the dialog to appear
-    expect(find(:id, 'branch_dialog')).to have_text('Do you really want to branch package')
+    expect(page).to have_text('Do you really want to branch package')
 
     click_button('Ok')
     expect(page).to have_text('Successfully branched package')

--- a/src/api/test/functional/webui/maintenance_workflow_test.rb
+++ b/src/api/test/functional/webui/maintenance_workflow_test.rb
@@ -27,7 +27,7 @@ class Webui::MaintenanceWorkflowTest < Webui::IntegrationTest
     first(:link, 'pack2').click
     find(:link, 'Branch package').click
 
-    find(:css, '#branch_dialog').must_have_text %r{Do you really want to branch package}
+    find(:css, '#package_branch_dialog').must_have_text %r{Do you really want to branch package}
     find_button('Ok').click
 
     find(:css, '#flash-messages').must_have_text %r{Successfully branched package}


### PR DESCRIPTION
The branch dialog got loaded via an additional HTTP request. This is not required and makes it weird, when the user clicks the branch link and nothing happens for a while (for example when the server is hanging).