### PR TITLE
Make gpg public key & ssl cert downloads available to anonymous users

### DIFF
--- a/src/api/app/views/webui/project/show.html.erb
+++ b/src/api/app/views/webui/project/show.html.erb
@@ -141,16 +141,7 @@
                             <%= link_to(sprited_text('brick_go', 'Submit as update'), { controller: 'project', action: 'incident_request_dialog', project: @project }, remote: true) %>
                           </li>
                       <% end %>
-                      <% if @project.key_info.present? %>
-                        <li>
-                          <%= link_to(sprited_text('key', 'Download GPG Key'), project_public_key_path(project_name: @project.name)) %>
-                        </li>
-                      <% end %>
-                      <% if @project.key_info.present? && @project.key_info.ssl_certificate.present? %>
-                        <li>
-                          <%= link_to(sprited_text('key', 'Download SSL Certificate'), project_ssl_certificate_path(project_name: @project.name)) %>
-                        </li>
-                      <% end %>
+                      <%= render partial: 'webui/project/show/encryption_key_download_links' %>
                   <% end %>
               <% end %>
               <li>
@@ -169,7 +160,12 @@
           <% end %>
         </ul>
       </div>
-
+  <% else %>
+    <div class="grid_16 alpha omega">
+      <ul class="horizontal-list">
+        <%= render partial: 'webui/project/show/encryption_key_download_links' %>
+      </ul>
+    </div>
   <% end %>
 </div>
 

--- a/src/api/app/views/webui/project/show/_encryption_key_download_links.html.erb
+++ b/src/api/app/views/webui/project/show/_encryption_key_download_links.html.erb
@@ -1,0 +1,10 @@
+<% if @project.key_info.present? %>
+  <li>
+    <%= link_to(sprited_text('key', 'Download GPG Key'), project_public_key_path(project_name: @project.name)) %>
+  </li>
+<% end %>
+<% if @project.key_info.present? && @project.key_info.ssl_certificate.present? %>
+  <li>
+    <%= link_to(sprited_text('key', 'Download SSL Certificate'), project_ssl_certificate_path(project_name: @project.name)) %>
+  </li>
+<% end %>


### PR DESCRIPTION
Add these two new links for public users when viewing a project:

![screenshot from 2017-01-20 14-44-27](https://cloud.githubusercontent.com/assets/9274/22155469/6feaf124-df27-11e6-9d76-53d4fc774f55.png)
