### PR TITLE
[ci] Render the failed example in property tests

### DIFF
--- a/src/api/Gemfile
+++ b/src/api/Gemfile
@@ -108,7 +108,7 @@ group :test do
   # assigns has been extracted to a gem
   gem 'rails-controller-testing'
   # To generate random data
-  gem 'rantly'
+  gem 'rantly', git: 'https://github.com/Ana06/rantly.git', branch: 'failures'
 end
 
 # Gems used only during development not required in production environments by default.

--- a/src/api/Gemfile.lock
+++ b/src/api/Gemfile.lock
@@ -1,3 +1,10 @@
+GIT
+  remote: https://github.com/Ana06/rantly.git
+  revision: 4a0b3881ead86b0a265c992607f815c4dd904427
+  branch: failures
+  specs:
+    rantly (1.0.0)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -231,7 +238,6 @@ GEM
     rainbow (2.1.0)
     raindrops (0.17.0)
     rake (12.0.0)
-    rantly (1.0.0)
     rdoc (5.0.0)
     redcarpet (3.3.4)
     responders (2.2.0)
@@ -392,7 +398,7 @@ DEPENDENCIES
   rails (~> 5.0.1)
   rails-controller-testing
   rails_tokeninput (>= 1.6.1.rc1)
-  rantly
+  rantly!
   rdoc
   redcarpet
   responders (~> 2.0)

--- a/src/api/spec/spec_helper.rb
+++ b/src/api/spec/spec_helper.rb
@@ -86,8 +86,8 @@ ENV['BACKEND_STARTED'] = '1'
 # Generate 30 tests for every property test
 ENV['RANTLY_COUNT'] = '30'
 
-# To have quiet output from Rantly, it looks horrible with the Unicorn
-ENV['RANTLY_VERBOSE'] = '0' unless ENV['TRAVIS'] || ENV['RPM_BUILD_ROOT']
+# To have quiet output from Rantly
+ENV['RANTLY_VERBOSE'] = '0'
 
 # support logging
 require 'support/logging'


### PR DESCRIPTION
The failed exampled is rendered without breaking rspec output:

![image](https://cloud.githubusercontent.com/assets/16052290/22155955/8fb3837c-df31-11e6-875e-7fdb808a0fd0.png)

Looks great :tada:. So we don't need to remove the :unicorn:.

@adrianschroeter will this work?