### PR TITLE
[ci] Constant ::Fixnum is deprecated

### DIFF
--- a/src/api/spec/helpers/webui/webui_helper_spec.rb
+++ b/src/api/spec/helpers/webui/webui_helper_spec.rb
@@ -244,7 +244,7 @@ RSpec.describe Webui::WebuiHelper do
       @codemirror_editor_setup = 0
     end
 
-    it { expect(next_codemirror_uid).to be_instance_of(Fixnum) }
+    it { expect(next_codemirror_uid).to be_instance_of(Integer) }
 
     context "if next_codemirror_uid get's called the first time" do
       it { expect(next_codemirror_uid).to eq(1) }

--- a/src/api/test/unit/webui/webui_helper_test.rb
+++ b/src/api/test/unit/webui/webui_helper_test.rb
@@ -34,7 +34,7 @@ class Webui::WebuiHelperTest < ActiveSupport::TestCase
   end
 
   def test_next_codemirror_uid
-    assert_kind_of Fixnum, next_codemirror_uid
+    assert_kind_of Integer, next_codemirror_uid
   end
 
   def test_escape_nested_list_escapes_forbidden_chars # spec/helpers/webui/webui_helper_spec.rb


### PR DESCRIPTION
Ruby 2.4 unifies Fixnum and Bignum classes into Integer. :bowtie: 