### PR TITLE
[api] revert riddle version

### DIFF
--- a/src/api/Gemfile.lock
+++ b/src/api/Gemfile.lock
@@ -238,7 +238,7 @@ GEM
     redcarpet (3.3.4)
     responders (2.2.0)
       railties (>= 4.2.0, < 5.1)
-    riddle (2.1.0)
+    riddle (1.5.12)
     rspec (3.5.0)
       rspec-core (~> 3.5.0)
       rspec-expectations (~> 3.5.0)


### PR DESCRIPTION
Because in master we are having errors with riddle and thinking-sphinx. Until find and fix the problem we will revert to the previous version of riddle gem.