### PR TITLE
[dist] Fix regex evaluation in databases.rake

### DIFF
--- a/src/api/lib/tasks/databases.rake
+++ b/src/api/lib/tasks/databases.rake
@@ -62,7 +62,7 @@ namespace :db do
       constraints = Array.new
       added_comma = false
       structure.each_line do |line|
-        if line =~ %{[ ]*CONSTRAINT}
+        if line =~ /[ ]*CONSTRAINT/
           unless line.end_with?(",\n")
             added_comma = true
             line = line[0..-2] + ",\n"


### PR DESCRIPTION
While String#match converts strings into a regular expression before
parsing, =~ doesn't. This broke obs-server package builds because of
failing migrations.

This broke with b9f387ec96b89e8fe07f1d50f7ce614a5b1755ac