### PR TITLE
Fix crash on projects without SSL

### DIFF
--- a/dist/obs-server.spec
+++ b/dist/obs-server.spec
@@ -340,14 +340,6 @@ export DESTDIR=$RPM_BUILD_ROOT
   perl -p -i -e 's/^APACHE_GROUP=.*/APACHE_GROUP=apache/' Makefile.include
 %endif
 
-# TODO: implement a clean way for fedora/rh
-#%if 0%{?fedora} || 0%{?rhel}
-#  # Fedora use different user:group for apache
-#  find -type f | xargs sed -i '1,$s/wwwrun\(.*\)www/apache\1apache/g'
-#  find -type f | xargs sed -i '1,$s/user wwwrun/user apache/g'
-#  find -type f | xargs sed -i '1,$s/group www/group apache/g'
-#%endif
-
 export OBS_VERSION="%{version}"
 DESTDIR=%{buildroot} make install
 
@@ -379,6 +371,13 @@ if ! test -L %{buildroot}/usr/lib/obs/server/build; then
 fi
 
 %check
+%if 0%{?disable_obs_test_suite}
+echo "WARNING:"
+echo "WARNING: OBS test suite got skipped!"
+echo "WARNING:"
+exit 0
+%endif
+
 ### TEMPORARY HACK
 # disabling this testsuite, since sphinx startup breaks unreliable in kvm
 # needs debugging and fixing

--- a/src/api/app/models/project/key_info.rb
+++ b/src/api/app/models/project/key_info.rb
@@ -8,7 +8,11 @@ class Project
 
     def self.find_by_project(project)
       response = Rails.cache.fetch("key_info_project_#{project.cache_key}", expires_in: CACHE_EXPIRY_TIME) do
-        Suse::Backend.get(backend_url(project.name)).body
+        begin
+          Suse::Backend.get(backend_url_with_ssl(project.name)).body
+        rescue ActiveXML::Transport::Error
+          Suse::Backend.get(backend_url(project.name)).body
+        end
       end
       parsed_response = Xmlhash.parse(response)
 
@@ -27,6 +31,10 @@ class Project
     end
 
     def self.backend_url(project_name)
+      "/source/#{project_name}/_keyinfo"
+    end
+
+    def self.backend_url_with_ssl(project_name)
       "/source/#{project_name}/_keyinfo?withsslcert=1"
     end
   end

--- a/src/api/spec/controllers/webui/projects/public_key_controller_spec.rb
+++ b/src/api/spec/controllers/webui/projects/public_key_controller_spec.rb
@@ -4,7 +4,7 @@ require 'webmock/rspec'
 RSpec.describe Webui::Projects::PublicKeyController, type: :controller do
   describe 'GET #show' do
     let(:project) { create(:project, name: "test_project", title: "Test Project") }
-    let(:backend_url) { "#{CONFIG['source_url']}#{Project::KeyInfo.backend_url(project.name)}" }
+    let(:backend_url) { "#{CONFIG['source_url']}#{Project::KeyInfo.backend_url_with_ssl(project.name)}" }
 
     before do
       Rails.cache.clear

--- a/src/api/spec/controllers/webui/projects/ssl_certificate_controller_spec.rb
+++ b/src/api/spec/controllers/webui/projects/ssl_certificate_controller_spec.rb
@@ -4,7 +4,7 @@ require 'webmock/rspec'
 RSpec.describe Webui::Projects::SslCertificateController, type: :controller do
   describe 'GET #show' do
     let(:project) { create(:project, name: "test_project", title: "Test Project") }
-    let(:backend_url) { "#{CONFIG['source_url']}#{Project::KeyInfo.backend_url(project.name)}" }
+    let(:backend_url) { "#{CONFIG['source_url']}#{Project::KeyInfo.backend_url_with_ssl(project.name)}" }
     let(:gpg_public_key) { Faker::Lorem.characters(1024) }
 
     before do


### PR DESCRIPTION
webui crashed on all projects without an SSL certificate.

Not sure if we really want to solve it on api side, because it means that we need to do two backend requests (on most projects) instead of one.

@mlschroe can you handle this in source server?

In any case we lack a test case for this situation.