### PR TITLE
Positional arguments are deprecated

### DIFF
--- a/src/api/spec/controllers/webui/configuration_controller_spec.rb
+++ b/src/api/spec/controllers/webui/configuration_controller_spec.rb
@@ -22,8 +22,8 @@ RSpec.describe Webui::ConfigurationController do
     context 'as admin' do
       before do
         login(admin_user)
-        patch :update, configuration: { name: 'obs', title: 'OBS', description: 'something',
-          unlisted_projects_filter: '^home:fake_user:.*', unlisted_projects_filter_description: "fake_user's home" }
+        patch :update, params: { configuration: { name: 'obs', title: 'OBS', description: 'something',
+          unlisted_projects_filter: '^home:fake_user:.*', unlisted_projects_filter_description: "fake_user's home" } }
       end
 
       it { expect(response).to redirect_to(configuration_path) }

--- a/src/api/spec/controllers/webui/download_on_demand_controller_spec.rb
+++ b/src/api/spec/controllers/webui/download_on_demand_controller_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe Webui::DownloadOnDemandController do
   it "uses strong parameters" do
     login(admin_user)
     should permit(:arch, :repotype, :url, :repository_id, :archfilter, :masterurl, :mastersslfingerprint, :pubkey).
-      for(:create, params: dod_parameters ).on(:download_repository)
+      for(:create, params: { params: dod_parameters } ).on(:download_repository)
   end
 
   describe "POST create" do

--- a/src/api/spec/controllers/webui/package_controller_spec.rb
+++ b/src/api/spec/controllers/webui/package_controller_spec.rb
@@ -720,7 +720,7 @@ EOT
 
     describe 'GET #package_live_build_log' do
       def do_request(params)
-        get :live_build_log, params
+        get :live_build_log, params: params
       end
 
       it_should_behave_like "build log"
@@ -728,7 +728,7 @@ EOT
 
     describe "GET #update_build_log" do
       def do_request(params)
-        xhr :get, :update_build_log, params
+        xhr :get, :update_build_log, params: params
       end
 
       it_should_behave_like "build log"


### PR DESCRIPTION
Using positional arguments in functional tests has been deprecated in favor of keyword arguments, and will be removed in Rails 5.1.

The change in `spec/controllers/webui/download_on_demand_controller_spec.rb:32` seems to
be something that must be solve in shoulda-matchers gem as it is said here: https://github.com/thoughtbot/shoulda-matchers/issues/867. In the meanwhile that solution works.