### PR TITLE
[api] xpath_engine: support project.remoteurl.

### DIFF
--- a/src/api/lib/xpath_engine.rb
+++ b/src/api/lib/xpath_engine.rb
@@ -65,6 +65,7 @@ class XpathEngine
         'title' => {cpart: 'projects.title'},
         'description' => {cpart: 'projects.description'},
         'url' => {cpart: 'projects.url'},
+        'remoteurl' => {cpart: 'projects.remoteurl'},
         'maintenance/maintains/@project' => {cpart: 'maintains_prj.name', joins: [
           'LEFT JOIN maintained_projects AS maintained_prj ON projects.id = maintained_prj.maintenance_project_id',
           'LEFT JOIN projects AS maintains_prj ON maintained_prj.project_id = maintains_prj.id']},

--- a/src/api/test/functional/search_controller_test.rb
+++ b/src/api/test/functional/search_controller_test.rb
@@ -871,4 +871,17 @@ class SearchControllerTest < ActionDispatch::IntegrationTest
     assert_xml_tag tag: 'project', attributes: { name: 'home:adrian' }
     assert_xml_tag tag: 'collection', children: { count: 1 }
   end
+
+  def test_xpath_search_for_remoteurl
+    login_king
+
+    put '/source/openSUSE.org/_meta', '<project name="openSUSE.org">
+        <title/><description/>
+        <remoteurl>https://api.opensuse.org/public</remoteurl>
+      </project>'
+    get '/search/project', match: 'starts-with(remoteurl, "http")'
+    assert_response :success
+    assert_xml_tag tag: 'collection', children: { count: 3 }
+    assert_xml_tag child: { tag: 'project', attributes: { name: 'openSUSE.org'} }
+  end
 end


### PR DESCRIPTION
The intended use is to find projects that have a `remoteurl` to avoid static config needed by https://github.com/openSUSE/osc-plugin-factory/blob/master/check_source_in_factory.py. It works if each root-level project is checked by loading the `_meta` and checking for `remoteurl`, but it would be nice to be able to search for all such projects at once.

It looked simple enough to add since it seems to be in the same place as `url`, but if this is not sufficient let me know as I did not setup a development environment.