### PR TITLE
[dist] Temporarely install patched rantly gem-rpm

### DIFF
--- a/contrib/common.sh
+++ b/contrib/common.sh
@@ -28,6 +28,8 @@ function install_common_packages() {
     ruby2.4-rubygem-ruby-ldap \
     ruby2.4-rubygem-xmlhash \
     ruby2.4-rubygem-thinking-sphinx\
+    # Temporary workaround to install our patched gem version
+    ruby2.4-rubygem-rantly\
     perl-GD \
     perl-XML-Parser \
     perl-Devel-Cover \


### PR DESCRIPTION
This ensures that we install our patched rantly version
  https://github.com/abargnesi/rantly/pull/22

This can be removed once the new rantly version got released.