### PR TITLE
Move Rails/Output to rubocop.yml

### DIFF
--- a/src/api/.rubocop.yml
+++ b/src/api/.rubocop.yml
@@ -214,6 +214,14 @@ Rails:
 # Use `find_by` instead `where.first` and `where.take`
 Rails/FindBy:
   Enabled: true
+  
+# Checks for the use of output calls like puts and print
+Rails/Output:
+  Exclude:
+    - 'app/jobs/*'
+    - 'config/*'
+    - 'db/**/*'
+    - 'lib/**/*'
 
 # Checks for the use of old-style attribute validation macros.
 Rails/Validation:

--- a/src/api/.rubocop_todo.yml
+++ b/src/api/.rubocop_todo.yml
@@ -205,24 +205,6 @@ Rails/NotNullColumn:
     - 'db/migrate/20131027122410_add_primary_to_repository_architectures.rb'
     - 'db/migrate/20131209103450_add_primary_to_groups_users.rb'
 
-# Offense count: 38
-# Configuration parameters: Include.
-# Include: app/**/*.rb, config/**/*.rb, db/**/*.rb, lib/**/*.rb
-Rails/Output:
-  Exclude:
-    - 'app/jobs/create_job.rb'
-    - 'app/models/bs_request_action_group.rb'
-    - 'app/models/full_text_search.rb'
-    - 'app/models/update_notification_events.rb'
-    - 'config/deploy.rb'
-    - 'config/environment.rb'
-    - 'db/migrate/001_initial_database.rb'
-    - 'db/migrate/20130301100000_add_release_target_constraints.rb'
-    - 'db/migrate/20140908125426_convert_request_history.rb'
-    - 'db/seeds.rb'
-    - 'lib/opensuse/backend.rb'
-    - 'lib/workers/import_requests.rb'
-
 # Offense count: 28
 Rails/OutputSafety:
   Exclude:

--- a/src/api/app/jobs/consistency_check.rb
+++ b/src/api/app/jobs/consistency_check.rb
@@ -45,7 +45,6 @@ class ConsistencyCheckJob < ApplicationJob
   end
 
   def check_project(fix = nil)
-    # rubocop:disable Output
     init
     if ENV['project'].blank?
       puts "Please specify the project with 'project=MyProject' on CLI"
@@ -61,7 +60,6 @@ class ConsistencyCheckJob < ApplicationJob
     end
     @errors << package_existence_consistency_check(project, fix)
     puts @errors unless @errors.blank?
-    # rubocop:enable Output
   end
 
   def project_meta_check(project, fix = nil)

--- a/src/api/app/models/bs_request_action_group.rb
+++ b/src/api/app/models/bs_request_action_group.rb
@@ -85,7 +85,7 @@ class BsRequestActionGroup < BsRequestAction
   end
 
   def execute_accept(opts)
-    puts "changestate #{opts.inspect}"
+    logger.info "changestate #{opts.inspect}"
     # TODO
   end
 

--- a/src/api/app/models/full_text_search.rb
+++ b/src/api/app/models/full_text_search.rb
@@ -85,8 +85,8 @@ class FullTextSearch
         interface.index
       rescue => e
         # Something failed, let's try again
-        puts "Indexing failed: #{e.message}"
-        puts "Retying indexing."
+        logger.info "Indexing failed: #{e.message}"
+        logger.info "Retying indexing."
         interface.index
       end
       begin
@@ -94,7 +94,7 @@ class FullTextSearch
       rescue RuntimeError => e
         # Most likely, this means that searchd is already running.
         # Nothing to worry about
-        puts "Handled exception: #{e.message}"
+        logger.info "Handled exception: #{e.message}"
       end
     end
     true

--- a/src/api/app/models/update_notification_events.rb
+++ b/src/api/app/models/update_notification_events.rb
@@ -31,7 +31,8 @@ class UpdateNotificationEvents
       if Rails.env.test?
         # make debug output useful in test suite, not just showing backtrace to HoptoaddNotifier
         Rails.logger.error "ERROR: #{e.inspect}: #{e.backtrace}"
-        puts e.inspect, e.backtrace
+        logger.info e.inspect
+        logger.info o e.backtrace
       end
       HoptoadNotifier.notify(e, {failed_job: type.inspect})
       return

--- a/src/api/db/checker.rb
+++ b/src/api/db/checker.rb
@@ -1,4 +1,3 @@
-# rubocop:disable Rails/Output
 require 'colorize'
 
 module DB


### PR DESCRIPTION
Move `Rails/Output` to rubocop.yml and enable it in the models files where it was disabled before.

Not sure if we want to enable for the other files I left in the Exclude section. I would say it is fine to have `puts` there.