### PR TITLE
[dist] Fix bash syntax

### DIFF
--- a/contrib/common.sh
+++ b/contrib/common.sh
@@ -28,7 +28,6 @@ function install_common_packages() {
     ruby2.4-rubygem-ruby-ldap \
     ruby2.4-rubygem-xmlhash \
     ruby2.4-rubygem-thinking-sphinx\
-    # Temporary workaround to install our patched gem version
     ruby2.4-rubygem-rantly\
     perl-GD \
     perl-XML-Parser \


### PR DESCRIPTION
Inline comments are not supported in bash. Fixes #2637