### PR TITLE
[webui] remove use of soon-to-be deprecated `render: :nothing`

### DIFF
--- a/src/api/app/controllers/webui/projects/public_key_controller.rb
+++ b/src/api/app/controllers/webui/projects/public_key_controller.rb
@@ -11,7 +11,8 @@ module Webui
             filename: "#{project.title}_key.pub"
           )
         else
-          render nothing: true, status: :not_found
+          flash[:error] = "Project #{params[:project_name]} does not have a public key"
+          redirect_to project_show_path(project: project)
         end
       end
     end

--- a/src/api/app/controllers/webui/projects/ssl_certificate_controller.rb
+++ b/src/api/app/controllers/webui/projects/ssl_certificate_controller.rb
@@ -11,7 +11,8 @@ module Webui
             filename: "#{project.title}_ssl.cert"
           )
         else
-          render nothing: true, status: :not_found
+          flash[:error] = "Project #{params[:project_name]} does not have an SSL certificate"
+          redirect_to project_show_path(project: project)
         end
       end
     end

--- a/src/api/spec/controllers/webui/projects/public_key_controller_spec.rb
+++ b/src/api/spec/controllers/webui/projects/public_key_controller_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe Webui::Projects::PublicKeyController, type: :controller do
       let(:keyinfo_response) { '<keyinfo />' }
 
       it { is_expected.to redirect_to(project_show_path(project)) }
-      it { expect(flash[:error]).not_to be_nil }
+      it { expect(flash[:error]).not_to be_empty }
     end
   end
 end

--- a/src/api/spec/controllers/webui/projects/public_key_controller_spec.rb
+++ b/src/api/spec/controllers/webui/projects/public_key_controller_spec.rb
@@ -27,7 +27,8 @@ RSpec.describe Webui::Projects::PublicKeyController, type: :controller do
     context 'with a project that has no public key' do
       let(:keyinfo_response) { '<keyinfo />' }
 
-      it { expect(response.status).to eq(404) }
+      it { is_expected.to redirect_to(project_show_path(project)) }
+      it { expect(flash[:error]).not_to be_nil }
     end
   end
 end

--- a/src/api/spec/controllers/webui/projects/ssl_certificate_controller_spec.rb
+++ b/src/api/spec/controllers/webui/projects/ssl_certificate_controller_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe Webui::Projects::SslCertificateController, type: :controller do
       end
 
       it { is_expected.to redirect_to(project_show_path(project)) }
-      it { expect(flash[:error]).not_to be_nil }
+      it { expect(flash[:error]).not_to be_empty }
     end
   end
 end

--- a/src/api/spec/controllers/webui/projects/ssl_certificate_controller_spec.rb
+++ b/src/api/spec/controllers/webui/projects/ssl_certificate_controller_spec.rb
@@ -30,7 +30,8 @@ RSpec.describe Webui::Projects::SslCertificateController, type: :controller do
         %(<keyinfo project="Test"><pubkey algo="rsa">#{gpg_public_key}</pubkey></keyinfo>)
       end
 
-      it { expect(response.status).to eq(404) }
+      it { is_expected.to redirect_to(project_show_path(project)) }
+      it { expect(flash[:error]).not_to be_nil }
     end
   end
 end


### PR DESCRIPTION
https://trello.com/c/BdIj9OVV/206-deprecation-warning-nothing-option-is-deprecated-and-will-be-removed-in-rails-5-1