### PR TITLE
[webui] extend the temporary hack of with an extra protection

### DIFF
--- a/src/api/app/controllers/webui/package_controller.rb
+++ b/src/api/app/controllers/webui/package_controller.rb
@@ -955,6 +955,8 @@ class Webui::PackageController < Webui::WebuiController
 
     # FIXME: OMG, if you call Package.get_by_project_and_name( 'blah', 'blubb', {follow_project_links: true} )
     # then @package.project might not be 'blah' but another project...
+    # NOTE: you may need an extra permission check when using this object beside show build state
+    @package.commit_opts = { NO_SAVE: true }
     @package.project = @project
 
     render partial: 'buildstatus'

--- a/src/api/app/models/package.rb
+++ b/src/api/app/models/package.rb
@@ -42,6 +42,9 @@ class Package < ApplicationRecord
 
   belongs_to :project, inverse_of: :packages
   delegate :name, to: :project, prefix: true
+  # NOTE: these are the arch/repos from the project hosting the source. They are
+  #       not the ones from the build containers (nor the architectures specified in source)
+  #       this means an extra permission check may be needed when using them.
   delegate :repositories, to: :project
   delegate :architectures, to: :project
 
@@ -82,6 +85,7 @@ class Package < ApplicationRecord
 
   after_destroy :delete_cache_lines
 
+  before_save :shield_save
   after_save :write_to_backend
   before_update :update_activity
   after_rollback :reset_cache
@@ -1374,5 +1378,13 @@ class Package < ApplicationRecord
 
   def has_icon?
     file_exists?("_icon")
+  end
+
+  def shield_save
+    # There is a hack webui/package_controller.rb#buildresult for app/views/webui/package/_buildstatus.html.erb
+    # which patches the project id of this package meta object to match the derived any if its derived
+    # build container instances. We must never store that by accident to avoid corrupted database and
+    # broken foreign projects. So better double check here (can be dropped again when the hack went away)
+    raise InvalidProjectNameError.new 'Must not be saved due to project hack' if @commit_opts.has_key? :NO_SAVE
   end
 end


### PR DESCRIPTION
if this wents wrong (because some implicit save via some depending
objects) we will only notice later due to corrupted projects, but we
won't have anything in the history of these projects. Means it will be
really hard to debug and to find. Given that this would be also a
grave security issue which gives me sleepless night a protection for
that seems to be a good idea.

Can go away again when the "FIXME" issue in webui package controller get solved.