### PR TITLE
[webui] Do not set the default project for buildresults in the contro…

### DIFF
--- a/src/api/app/controllers/webui/package_controller.rb
+++ b/src/api/app/controllers/webui/package_controller.rb
@@ -952,12 +952,8 @@ class Webui::PackageController < Webui::WebuiController
 
   def buildresult
     check_ajax
-
-    # FIXME: OMG, if you call Package.get_by_project_and_name( 'blah', 'blubb', {follow_project_links: true} )
-    # then @package.project might not be 'blah' but another project...
-    @package.project = @project
-
     if @project.repositories.any?
+      @buildresults = @package.buildresults(@project)
       render partial: 'buildstatus'
     else
       render partial: 'no_repositories'

--- a/src/api/app/models/package.rb
+++ b/src/api/app/models/package.rb
@@ -878,8 +878,8 @@ class Package < ApplicationRecord
     Buildresult.find(project: project, package: self, repository: repository, view: view)
   end
 
-  def buildresults
-    results = Buildresult.find_hashed(project: project.name, package: name, view: 'status', multibuild: '1', locallink: '1')
+  def buildresults(prj = project)
+    results = Buildresult.find_hashed(project: prj, package: name, view: 'status', multibuild: '1', locallink: '1')
 
     local_build_results = {}
     results.elements('result').sort {|a, b| a['repository'] <=> b['repository']}.each do |result|

--- a/src/api/app/views/webui/package/_buildstatus.html.erb
+++ b/src/api/app/views/webui/package/_buildstatus.html.erb
@@ -1,4 +1,4 @@
-<% @package.buildresults.each_pair do |package, results| %>
+<% @buildresults.each_pair do |package, results| %>
   <h3><%= package %></h3>
   <div id="package_buildstatus">
     <table>


### PR DESCRIPTION
…ller

Set it in the model method to avoid that developers accidently save the @package with a 'wrong' project.