### PR TITLE
[webui] give the user a hint about hidden build results

### DIFF
--- a/src/api/app/views/webui/package/_buildstatus.html.erb
+++ b/src/api/app/views/webui/package/_buildstatus.html.erb
@@ -8,8 +8,10 @@
         <% previous_repo = nil %>
         <% results.each do |result| %>
           <% repository = @project.repositories.find_by_name(result.repository) %>
-          <% next unless repository %>
-          <% next unless repository.architectures.pluck(:name).include?(result.architecture) %>
+          <% unless repository && repository.architectures.pluck(:name).include?(result.architecture) %>
+            <tr><td>Note: hidden build results exist</td></tr>
+          <%   next %>
+          <% end %>
           <tr>
             <% if result.repository != previous_repo %>
               <td title="<%= result.repository %>" rowspan="<%= repository.architectures.length %>">


### PR DESCRIPTION
Please take this just as a discussion proposal, any different solution is of course also okay.

NOTE: I have not tested this at all therefore

from commit message:
Can happen in case of infra structure problems, bugs, stopped schedulers,
lost events or administrator config changes for example. A remaining build
result may still have an effect to others builds and publishing (esp. in cross
architecture cases). We need to give the user at least a hint that the data
is not complete or he would get leaded now to look in a wrong direction.
The hint gives him a chance to use "osc" in that case to see the remaining results/files.

FIXME: @project.repository.any? with build results case is not handled