### PR TITLE
[webui] improved fix for 'build targets' link

### DIFF
--- a/src/api/app/views/shared/_buildresult_box.html.erb
+++ b/src/api/app/views/shared/_buildresult_box.html.erb
@@ -54,7 +54,6 @@
 	  <%= raw("'index': '#{index}',") if defined?(index) %>
         },
         success: function(data) {
-          $('#result_display_<%= index %>_1').show();
           $('#result_display_<%= index %>_1').html(data);
         },
         error: function(data) {
@@ -84,7 +83,11 @@
 	<%= raw("'index': '#{index}',") if defined?(index) %>
       },
       success: function(data) {
-        $('#result_display_<%= index %>_0').html(data);
+        if ( data ) {
+            $('#result_display_<%= index %>_0').html(data);
+        } else {
+            $('#result_display_<%= index %>_1').show();
+        }
       },
       error: function(data) {
         $('#result_display_<%= index %>_0').html('<p>No build results available</p>');

--- a/src/api/app/views/webui/package/_buildstatus.html.erb
+++ b/src/api/app/views/webui/package/_buildstatus.html.erb
@@ -29,9 +29,11 @@
     <% end %>
   </div>
 <% end %>
+<% if @package.buildresults.any? %>
 <%= javascript_tag do %>
     $('.unresolvable, .blocked').click(function() {
         var title = $(this).attr('title');
         alert(title);
     });
+<% end %>
 <% end %>


### PR DESCRIPTION
My last PR #2658 caused another regression. The text with the link "build targets" is now always shown, even if repositories are configured. This PR should fix it.

@ChrisBr Please review