### PR TITLE
Fix build targets

### DIFF
--- a/src/api/app/controllers/webui/package_controller.rb
+++ b/src/api/app/controllers/webui/package_controller.rb
@@ -957,7 +957,11 @@ class Webui::PackageController < Webui::WebuiController
     # then @package.project might not be 'blah' but another project...
     @package.project = @project
 
-    render partial: 'buildstatus'
+    if @project.repositories.any?
+      render partial: 'buildstatus'
+    else
+      render partial: 'no_repositories'
+    end
   end
 
   def rpmlint_result

--- a/src/api/app/views/shared/_buildresult_box.html.erb
+++ b/src/api/app/views/shared/_buildresult_box.html.erb
@@ -54,7 +54,6 @@
 	  <%= raw("'index': '#{index}',") if defined?(index) %>
         },
         success: function(data) {
-          $('#result_display_<%= index %>_1').show();
           $('#result_display_<%= index %>_1').html(data);
         },
         error: function(data) {

--- a/src/api/app/views/webui/package/_buildstatus.html.erb
+++ b/src/api/app/views/webui/package/_buildstatus.html.erb
@@ -1,32 +1,28 @@
 <% @package.buildresults.each_pair do |package, results| %>
   <h3><%= package %></h3>
   <div id="package_buildstatus">
-    <% if !@project.repositories.any? %>
-      <%= render "no_repositories" %>
-    <% else %>
-      <table>
-        <% previous_repo = nil %>
-        <% results.each do |result| %>
-          <% repository = @project.repositories.find_by_name(result.repository) %>
-          <% next unless repository %>
-          <% next unless repository.architectures.pluck(:name).include?(result.architecture) %>
-          <tr>
-            <% if result.repository != previous_repo %>
-              <td title="<%= result.repository %>" rowspan="<%= repository.architectures.length %>">
-              <%= link_to(word_break(result.repository, 22), { action: :binaries, controller: :package, project: @project, package: @package, repository: result.repository }, { title: "Binaries for #{result.repository}" }) %>
-            </td>
-            <% end %>
-            <td class="arch">
-              <div class="nowrap" style="margin: 0 0.5ex">
-                <%= repo_status_icon(result.state, result.details) %> <%= result.architecture %>
-              </div>
-            </td>
-            <%= arch_repo_table_cell(result.repository, result.architecture, package, { "code" => result.code, "details" => result.details }) %>
-          </tr>
-          <% previous_repo = result.repository %>
-        <% end %>
-      </table>
-    <% end %>
+    <table>
+      <% previous_repo = nil %>
+      <% results.each do |result| %>
+        <% repository = @project.repositories.find_by_name(result.repository) %>
+        <% next unless repository %>
+        <% next unless repository.architectures.pluck(:name).include?(result.architecture) %>
+        <tr>
+          <% if result.repository != previous_repo %>
+            <td title="<%= result.repository %>" rowspan="<%= repository.architectures.length %>">
+            <%= link_to(word_break(result.repository, 22), { action: :binaries, controller: :package, project: @project, package: @package, repository: result.repository }, { title: "Binaries for #{result.repository}" }) %>
+          </td>
+          <% end %>
+          <td class="arch">
+            <div class="nowrap" style="margin: 0 0.5ex">
+              <%= repo_status_icon(result.state, result.details) %> <%= result.architecture %>
+            </div>
+          </td>
+          <%= arch_repo_table_cell(result.repository, result.architecture, package, { "code" => result.code, "details" => result.details }) %>
+        </tr>
+        <% previous_repo = result.repository %>
+      <% end %>
+    </table>
   </div>
 <% end %>
 <%= javascript_tag do %>


### PR DESCRIPTION
Introduced by the multibuild feature.
Packages without repositories will never have buildresultes thus they will never enter the loop and render the no_repositories partial.
Therefore moved no_repositories render conditional outside of the buildresult view.