### PR TITLE
Revert "[dist] Update simplecov to v0.13.0"

### DIFF
--- a/src/api/Gemfile.lock
+++ b/src/api/Gemfile.lock
@@ -286,7 +286,7 @@ GEM
     sexp_processor (4.7.0)
     shoulda-matchers (3.1.1)
       activesupport (>= 4.0.0)
-    simplecov (0.13.0)
+    simplecov (0.12.0)
       docile (~> 1.1.0)
       json (>= 1.8, < 3)
       simplecov-html (~> 0.10.0)


### PR DESCRIPTION
This reverts commit c145c128788c89711a72321431d5a076468d0716.

This was just wrong:blush:. We actually have to keep version 0.12.0 for now,
since simplecov requires it.