### PR TITLE
xhr is deprecated

### DIFF
--- a/src/api/spec/controllers/webui/package_controller_spec.rb
+++ b/src/api/spec/controllers/webui/package_controller_spec.rb
@@ -728,7 +728,7 @@ EOT
 
     describe "GET #update_build_log" do
       def do_request(params)
-        xhr :get, :update_build_log, params: params
+        get :update_build_log, params: params, xhr: true
       end
 
       it_should_behave_like "build log"


### PR DESCRIPTION
`xhr` and `xml_http_request` are deprecated and will be removed in Rails 5.1. :bowtie: 