### PR TITLE
[webui] Let OBS admins configure the software.opensuse.org url (issue#2190)

### DIFF
--- a/src/api/app/views/webui/theme/bento/webui/package/_extra_actions.html.erb
+++ b/src/api/app/views/webui/theme/bento/webui/package/_extra_actions.html.erb
@@ -1,3 +1,5 @@
-<li>
-    <%= sprite_tag 'application_get' %> <a href="http://software.opensuse.org/download.html?project=<%= u @project.name %>&amp;package=<%= u @package.name %>">Download package</a>
-</li>
+<% if CONFIG['software_opensuse_url'] %>
+  <li>
+    <%= sprite_tag 'application_get' %> <a href="<%= CONFIG['software_opensuse_url'] %>/download.html?project=<%= u @project.name %>&amp;package=<%= u @package.name %>">Download package</a>
+  </li>
+<% end %>

--- a/src/api/test/functional/webui/application_controller_test.rb
+++ b/src/api/test/functional/webui/application_controller_test.rb
@@ -42,6 +42,11 @@ class Webui::ApplicationControllerTest < Webui::IntegrationTest
     end
 
     visit package_show_path(project: 'home:Iggy', package: 'TestPack')
+    assert page.has_no_link?('Download package')
+
+    CONFIG['software_opensuse_url'] = "http://software.opensuse.org"
+
+    visit package_show_path(project: 'home:Iggy', package: 'TestPack')
     page.must_have_link 'Download package'
     first(:link, 'Download package')['href'].must_equal 'http://software.opensuse.org/download.html?project=home%3AIggy&package=TestPack'
   end


### PR DESCRIPTION
This allows OBS admins to setup and refer their own software opensuse instance
in their local OBS instance.
If no instance url was set in the options.yml, the link won't be shown.