### PR TITLE
[webui] Allow user to specify package name while branching

### DIFF
--- a/src/api/app/assets/javascripts/webui/application.js.erb
+++ b/src/api/app/assets/javascripts/webui/application.js.erb
@@ -260,3 +260,18 @@ $(function() {
 $(document).on('click','.close-dialog', function() {
   $($(this).data('target')).addClass('hidden');
 });
+
+// show/hide functionality for text
+$(function() {
+  $('.show-hide').on('click', function() {
+    var target = $(this).data('target');
+    $(target).toggle();
+
+    if ($(target).is(':hidden')) {
+      $(this).text($(this).data('showtext'));
+    }
+    else {
+      $(this).text($(this).data('hidetext'));
+    }
+  });
+});

--- a/src/api/app/assets/stylesheets/webui/application/dialog.scss
+++ b/src/api/app/assets/stylesheets/webui/application/dialog.scss
@@ -6,6 +6,10 @@
   height: 10em;
   width: 26em;
   margin-left: -13em;
+  /* TODO: Agree on a common way to use dialogs. Without this adjustment the width of 95% gets applied to the branching dialog and this looks weird */
+  input[name="target_package"] {
+    width: 300px;
+  }
   .dialog-content {
     overflow: auto;
     max-height: 400px;

--- a/src/api/app/views/shared/_package_branch_form.html.erb
+++ b/src/api/app/views/shared/_package_branch_form.html.erb
@@ -1,0 +1,17 @@
+<p>
+  <% if show_source_fields %>
+    <label for="linked_project"><strong>Name of original project:</strong></label><br/>
+    <%= text_field_tag 'linked_project', nil, size: 80, id: 'linked_project', required: true %><br/>
+    <label for="linked_package"><strong>Name of package in original project:</strong></label><br/>
+    <%= text_field_tag 'linked_package', nil, size: 80, id: 'linked_package', required: true %><br/>
+  <% else %>
+    <%= hidden_field_tag(:linked_project, @project.name) %>
+    <%= hidden_field_tag(:linked_package, @package.name) %>
+  <% end %>
+
+  <label for="target_package"><strong>New package name:</strong></label><br />
+  <%= text_field_tag 'target_package', @package.try(:name), size: 80, maxlength: 200 %><br />
+  <%= hidden_field_tag 'target_project', target_project.name if target_project %><br/>
+
+  <%= check_box_tag 'current_revision', false %>Stay on current revision
+</p>

--- a/src/api/app/views/webui/package/_branch_dialog.html.erb
+++ b/src/api/app/views/webui/package/_branch_dialog.html.erb
@@ -2,11 +2,16 @@
     <div class="box box-shadow">
       <h2 class="box-header">Branch Confirmation</h2>
       <div class="dialog-content">
-        <p>Do you really want to branch <%= package_link(@package) %>?</p>
+        <p>
+         Do you really want to branch <%= package_link(@package) %>?<br /><br />
+         <a data-target="#branching-options" data-hidetext="[-] Hide options" data-showtext="[+] More options" class="show-hide">[+] More options</a>
+        </p>
       </div>
 
       <%= form_tag({controller: :package, action: :branch}, method: :post) do %>
-        <%= render partial: 'shared/package_branch_form', locals: {show_source_fields: false, target_project: nil} %>
+        <div id="branching-options" class="hidden">
+          <%= render partial: 'shared/package_branch_form', locals: {show_source_fields: false, target_project: nil} %>
+        </div>
 
         <div class="dialog-buttons">
           <%= submit_tag('Ok') %>

--- a/src/api/app/views/webui/package/_branch_dialog.html.erb
+++ b/src/api/app/views/webui/package/_branch_dialog.html.erb
@@ -5,9 +5,9 @@
         <p>Do you really want to branch <%= package_link(@package) %>?</p>
       </div>
 
-      <%= form_tag({ controller: :package, action: :branch }, method: :post) do %>
-        <%= hidden_field_tag(:linked_project, @project.name) %>
-        <%= hidden_field_tag(:linked_package, @package.name) %>
+      <%= form_tag({controller: :package, action: :branch}, method: :post) do %>
+        <%= render partial: 'shared/package_branch_form', locals: {show_source_fields: false, target_project: nil} %>
+
         <div class="dialog-buttons">
           <%= submit_tag('Ok') %>
           <%= link_to('Close', '#', title: 'Close', class: 'close-dialog', data: { target: '#package_branch_dialog' }) %>

--- a/src/api/app/views/webui/project/new_package_branch.html.erb
+++ b/src/api/app/views/webui/project/new_package_branch.html.erb
@@ -22,24 +22,14 @@ package.</p>
   </ul>
 <% end %>
 <%= form_tag controller: :package, action: :branch do %>
-<p>
-  <label for="linked_project"><strong>Name of original project:</strong></label><br/>
-  <%= text_field_tag 'linked_project', nil, :size => 80, :id => 'linked_project', required: true %><br/>
-  <label for="linked_package"><strong>Name of package in original project:</strong></label><br/>
-  <%= text_field_tag 'linked_package', nil, :size => 80, :id => 'linked_package', required: true %><br/>
-  <label for="target_package"><strong>Name of branched package in target project:</strong></label> (Leave blank to use the
-  same name as in the original project) <br/>
-  <%= text_field_tag 'target_package', nil, :size => 80 %><br/>
-  <%= hidden_field_tag 'target_project', @project.name %><br/>
-  <%= check_box_tag 'current_revision', false %>Stay on current revision, don't merge future upstream changes automatically
-</p>
-<p><%= submit_tag "Create Branch" %></p>
+  <%= render partial: 'shared/package_branch_form', locals: {show_source_fields: true, target_project: @project} %>
+  <p><%= submit_tag "Create Branch" %></p>
 <% end %>
 
 <%= javascript_tag do %>
   $("#linked_project").autocomplete({source: '<%= url_for :controller => :project, :action => :autocomplete_projects %>', minLength: 2});
   $("#linked_package").autocomplete({
-    source: 
+    source:
     function (request, response) {
       $.ajax({
         url: '<%= url_for :controller => 'project', :action => 'autocomplete_packages' %>',

--- a/src/api/spec/features/webui/projects_spec.rb
+++ b/src/api/spec/features/webui/projects_spec.rb
@@ -312,7 +312,7 @@ RSpec.feature "Projects", type: :feature, js: true do
     scenario "an existing package, but chose a different target package name" do
       fill_in("Name of original project:", with: other_user.home_project_name)
       fill_in("Name of package in original project:", with: package_of_another_project.name)
-      fill_in("Name of branched package in target project:", with: "some_different_name")
+      fill_in("New package name:", with: "some_different_name")
       # This needs global write through
       click_button("Create Branch")
 
@@ -323,7 +323,7 @@ RSpec.feature "Projects", type: :feature, js: true do
     scenario "an existing package to an invalid target package or project" do
       fill_in("Name of original project:", with: other_user.home_project_name)
       fill_in("Name of package in original project:", with: package_of_another_project.name)
-      fill_in("Name of branched package in target project:", with: "something/illegal")
+      fill_in("New package name:", with: "something/illegal")
       # This needs global write through
       click_button("Create Branch")
 
@@ -358,7 +358,7 @@ RSpec.feature "Projects", type: :feature, js: true do
 
       fill_in("Name of original project:", with: other_user.home_project_name)
       fill_in("Name of package in original project:", with: package_of_another_project.name)
-      fill_in("Name of branched package in target project:", with: "some_different_name")
+      fill_in("New package name:", with: "some_different_name")
       # This needs global write through
       click_button("Create Branch")
 
@@ -371,7 +371,7 @@ RSpec.feature "Projects", type: :feature, js: true do
 
       fill_in("Name of original project:", with: other_user.home_project_name)
       fill_in("Name of package in original project:", with: package_of_another_project.name)
-      fill_in("Name of branched package in target project:", with: "some_different_name")
+      fill_in("New package name:", with: "some_different_name")
       # This needs global write through
       click_button("Create Branch")
 


### PR DESCRIPTION
Here is the new PR regarding the improvement of the branching dialog. It's now possible to specify if the user wants to stay on the current revision and to specify a new name for the branched package.

If you have a look in the SCSS file, I set a fixed width for the input field of the branching dialog. (This css matcher is only used in the branching dialog) I did this, because otherwise the width of 95 % gets applied and this literally explodes the input field of the branching dialog. This is just a temporary fix and we should maybe consider a generic scenario how to create dialogs since it's now a bit weird.

The outcome of this refactoring session:

![new_1](https://cloud.githubusercontent.com/assets/8287131/23132438/de0939d0-f78d-11e6-8e79-a2823c80e967.png)

Please have a look again since you guys reviewed the old PR 
@bgeuken @hennevogel @Ana06 