### PR TITLE
[ci] fix webui helper fuzzy_time spec

### DIFF
--- a/src/api/spec/helpers/webui/webui_helper_spec.rb
+++ b/src/api/spec/helpers/webui/webui_helper_spec.rb
@@ -301,8 +301,8 @@ RSpec.describe Webui::WebuiHelper do
     end
 
     context 'without_fulltime' do
-      time = Time.now - 1.month
-      it { expect(fuzzy_time(time, false)).to eq('about 1 month ago') }
+      time = Time.now - 3.hours
+      it { expect(fuzzy_time(time, false)).to eq('about 3 hours ago') }
     end
   end
 


### PR DESCRIPTION
The spec: `spec/helpers/webui/webui_helper_spec.rb` currently fails on master branch. This is because February is only 28 days long so the rails helper method time_ago_in_words is interpreting "1 month ago" as "28 days ago".

```
Failures:

  1) Webui::WebuiHelper#fuzzy_time without_fulltime should eq "about 1 month ago"
     Failure/Error: it { expect(fuzzy_time(time, false)).to eq('about 1 month ago') }
     
       expected: "about 1 month ago"
            got: "3 months ago"
     
       (compared using ==)
     # ./spec/helpers/webui/webui_helper_spec.rb:305:in `block (4 levels) in <top (required)>'
     # ./spec/support/logging.rb:4:in `block (2 levels) in <top (required)>'
```