### PR TITLE
[ci] render views by default in rspec controller tests

### DIFF
--- a/src/api/spec/controllers/about_controller_spec.rb
+++ b/src/api/spec/controllers/about_controller_spec.rb
@@ -2,8 +2,6 @@ require 'rails_helper'
 require 'webmock/rspec'
 
 RSpec.describe AboutController, type: :controller do
-  render_views # NOTE: This is required otherwise Suse::Validator.validate will fail
-
   describe '#index' do
     before do
       get :index, params: { format: :xml }

--- a/src/api/spec/controllers/webui/main_controller_spec.rb
+++ b/src/api/spec/controllers/webui/main_controller_spec.rb
@@ -88,8 +88,6 @@ RSpec.describe Webui::MainController do
   end
 
   describe "GET #sitemap" do
-    render_views
-
     before do
       get :sitemap
       @paths = Nokogiri::XML(response.body).xpath("//xmlns:loc").map do |url|
@@ -108,8 +106,6 @@ RSpec.describe Webui::MainController do
   end
 
   describe "GET #sitemap_projects" do
-    render_views
-
     before do
       create(:confirmed_user)
       @projects = create_list(:project, 5)
@@ -125,8 +121,6 @@ RSpec.describe Webui::MainController do
   end
 
   describe "GET #sitemap_packages" do
-    render_views
-
     before do
       create_list(:project_with_package, 5)
       get :sitemap_packages, params: { listaction: 'show' }

--- a/src/api/spec/controllers/webui/package_controller_spec.rb
+++ b/src/api/spec/controllers/webui/package_controller_spec.rb
@@ -250,8 +250,6 @@ RSpec.describe Webui::PackageController, vcr: true do
     end
 
     context 'with build results and no binaries' do
-      render_views
-
       before do
         allow(Buildresult).to receive(:find).and_return(fake_build_results_without_binaries)
         post :binaries, params: { package: source_package, project: source_project, repository: repo_for_source_project }
@@ -262,8 +260,6 @@ RSpec.describe Webui::PackageController, vcr: true do
     end
 
     context 'with build results and binaries' do
-      render_views
-
       before do
         allow(Buildresult).to receive(:find).and_return(fake_build_results)
         post :binaries, params: { package: source_package, project: source_project, repository: repo_for_source_project }

--- a/src/api/spec/rails_helper.rb
+++ b/src/api/spec/rails_helper.rb
@@ -28,6 +28,8 @@ RSpec.configure do |config|
   config.filter_rails_from_backtrace!
   # arbitrary gems may also be filtered via:
   # config.filter_gems_from_backtrace("gem name")
+
+  config.render_views # NOTE: This is required otherwise Suse::Validator.validate will fail
 end
 
 # support test coverage


### PR DESCRIPTION
Render views by default in rspec controller tests. This means that controller tests for API endpoints will work because `Suse::Validator` will not error like it does if `render_views` is disabled.

Solves issue https://github.com/openSUSE/open-build-service/issues/2734.