### PR TITLE
Show outdated results for package in a different manner

### DIFF
--- a/src/api/app/assets/stylesheets/webui/application/package.scss
+++ b/src/api/app/assets/stylesheets/webui/application/package.scss
@@ -44,3 +44,11 @@ table.repostatus td {
     text-decoration-color: #690;
   }
 }
+
+.no_border_bottom {
+  border-bottom: none;
+}
+
+.no_border_top {
+  border-top: none;
+}

--- a/src/api/app/views/webui/package/_buildstatus.html.erb
+++ b/src/api/app/views/webui/package/_buildstatus.html.erb
@@ -5,17 +5,20 @@
       <% previous_repo = nil %>
       <% results.each do |result| %>
         <% repository = @project.repositories.find_by_name(result.repository) %>
-        <% next unless repository %>
-        <% next unless repository.architectures.pluck(:name).include?(result.architecture) %>
         <tr>
+          <td title="<%= result.repository %>" class="no_border_bottom <%= (result.repository == previous_repo) ? " no_border_top" : " "%>">
           <% if result.repository != previous_repo %>
-            <td title="<%= result.repository %>" rowspan="<%= repository.architectures.length %>">
             <%= link_to(word_break(result.repository, 22), { action: :binaries, controller: :package, project: @project, package: package, repository: result.repository }, { title: "Binaries for #{result.repository}" }) %>
-          </td>
           <% end %>
+          </td>
           <td class="arch">
             <div class="nowrap" style="margin: 0 0.5ex">
-              <%= repo_status_icon(result.state, result.details) %> <%= result.architecture %>
+            <% if !(repository && repository.architectures.pluck(:name).include?(result.architecture)) %>
+              <%= sprite_tag "time_error", alt: "Outdated result", title: "This result is outdated"%>
+            <% else %>
+              <%= repo_status_icon(result.state, result.details) %>
+            <% end %>
+            <%= result.architecture %>
             </div>
           </td>
           <%= arch_repo_table_cell(result.repository, result.architecture, package, { "code" => result.code, "details" => result.details }) %>
@@ -26,8 +29,8 @@
   </div>
 <% end %>
 <%= javascript_tag do %>
-    $('.unresolvable, .blocked').click(function() {
-        var title = $(this).attr('title');
-        alert(title);
-    });
+  $('.unresolvable, .blocked').click(function() {
+    var title = $(this).attr('title');
+    alert(title);
+  });
 <% end %>


### PR DESCRIPTION
Now if the repository or the architecture are missing in the database the row will show a lightgray background and the time_error icon:

![buildresults_with_outdated_results](https://cloud.githubusercontent.com/assets/11314634/23560930/6e639794-003c-11e7-9e0c-a0bc00ee8363.png)

This closes #2654.
This fixes #2725.