### PR TITLE
[webui] Fix link to binaries in multibuild result

### DIFF
--- a/src/api/app/views/webui/package/_buildstatus.html.erb
+++ b/src/api/app/views/webui/package/_buildstatus.html.erb
@@ -10,7 +10,7 @@
         <tr>
           <% if result.repository != previous_repo %>
             <td title="<%= result.repository %>" rowspan="<%= repository.architectures.length %>">
-            <%= link_to(word_break(result.repository, 22), { action: :binaries, controller: :package, project: @project, package: @package, repository: result.repository }, { title: "Binaries for #{result.repository}" }) %>
+            <%= link_to(word_break(result.repository, 22), { action: :binaries, controller: :package, project: @project, package: package, repository: result.repository }, { title: "Binaries for #{result.repository}" }) %>
           </td>
           <% end %>
           <td class="arch">


### PR DESCRIPTION
Each multibuild result should link to the repository for the respective
package, not for the containing one.