### PR TITLE
[webui] Set default pagination page length for bs requests to 25

### DIFF
--- a/src/api/app/assets/javascripts/webui/application/user.js
+++ b/src/api/app/assets/javascripts/webui/application/user.js
@@ -9,6 +9,7 @@ $( document ).ready(function() {
             { orderable: false, targets: [1,2,4,6,] }
         ],
         paging: 25,
+        pageLength: 25,
         pagingType: "full_numbers",
         processing: true,
         serverSide: true,


### PR DESCRIPTION
This got recently changed to 10, which probably was unintentionally and
happened due to a couple of refactorings (4f07d4c06c68aba15003).

Since the amount of requests can easily reach 50 to 100+ requests, it's better
to default to a pagination size that allows users to quickly view and
process their requests.

With this change the defaul pagination for bs requests rendered on the
/user/show page will be set to 25 like it used to be.