### PR TITLE
Partial revert of pundit cleanup

### DIFF
--- a/src/api/app/policies/attrib_policy.rb
+++ b/src/api/app/policies/attrib_policy.rb
@@ -3,11 +3,14 @@ class AttribPolicy < ApplicationPolicy
     # Admins can write everything
     return true if @user.is_admin?
 
-    # No specific rules set for the attribute, check if the user can modify the container
-    return true if @record.container.try(:can_be_modified_by?, @user)
-
-    # check for modifiable_by rules
-    permissions_for_modifiables?(modifiables)
+    at_modifiables = modifiables
+    if at_modifiables.empty? && @record.container.present?
+      # No specific rules set for the attribute, check if the user can modify the container
+      @record.container.can_be_modified_by?(@user)
+    else
+      # check for modifiable_by rules
+      permissions_for_modifiables?(at_modifiables)
+    end
   end
 
   def update?

--- a/src/api/spec/features/webui/attributes_spec.rb
+++ b/src/api/spec/features/webui/attributes_spec.rb
@@ -53,6 +53,21 @@ RSpec.feature "Attributes", type: :feature, js: true do
         click_link("add-new-attribute")
         expect(page).to have_content("Sorry, you are not authorized to create this Attrib.")
       end
+
+      scenario "add valid attribute with lack of permissions" do
+        # Database cleaner deletes these tables. But we need them for the
+        # permission to function.
+        attrib_type = AttribType.where(name: "VeryImportantProject").first
+        attrib_type.attrib_type_modifiable_bies.create(role: Role.where(title: "Admin").first)
+
+        login user
+
+        visit index_attribs_path(project: user.home_project_name)
+        click_link("Add a new attribute")
+        find("select#attrib_attrib_type_id").select("OBS:VeryImportantProject")
+        click_button("Create Attribute")
+        expect(page).to have_content("Sorry, you are not authorized to create this Attrib.")
+      end
     end
 
     scenario "remove attribute" do

--- a/src/api/spec/support/database_cleaner.rb
+++ b/src/api/spec/support/database_cleaner.rb
@@ -1,6 +1,11 @@
 require 'database_cleaner'
 
 RSpec.configure do |config|
+  STATIC_TABLES = %w(roles roles_static_permissions
+                     static_permissions configurations
+                     architectures attrib_types
+                     attrib_namespaces issue_trackers)
+
   # We are using factory_girl to set up everything the test needs up front,
   # instead of loading a set of fixtures in the beginning of the suite
   config.use_transactional_fixtures = false
@@ -15,10 +20,7 @@ RSpec.configure do |config|
     Rails.logger.level = log_level
     # Truncate all tables loaded in db/seeds.rb, except the static ones, in the
     # beginning to be consistent.
-    DatabaseCleaner.clean_with(:truncation, except: %w(roles roles_static_permissions
-                                                       static_permissions configurations
-                                                       architectures attrib_types
-                                                       attrib_namespaces issue_trackers))
+    DatabaseCleaner.clean_with(:truncation, except: STATIC_TABLES)
   end
 
   config.before(:each) do |example|
@@ -26,10 +28,7 @@ RSpec.configure do |config|
     # test suite and the capybara driver do not use the same server thread.
     if example.metadata[:type] == :feature
       # Omit truncating what we have set up in db/seeds.rb except users and roles_user
-      DatabaseCleaner.strategy = :truncation, { except: %w(roles roles_static_permissions
-                                                           static_permissions configurations
-                                                           architectures attrib_types
-                                                           attrib_namespaces issue_trackers) }
+      DatabaseCleaner.strategy = :truncation, { except: STATIC_TABLES }
     else
       DatabaseCleaner.strategy = :transaction
     end


### PR DESCRIPTION
Apparently my previous commit (fc126da42483a23fe3d8ff4cc59) was breaking the attribute permission checks in the webui. This PR reverts the faulty commit and adds a test to cover the problem in the future.

