### PR TITLE
[api][webui] Fix attrib policy scope

### DIFF
--- a/src/api/app/policies/attrib_namespace_policy.rb
+++ b/src/api/app/policies/attrib_namespace_policy.rb
@@ -1,0 +1,21 @@
+class AttribNamespacePolicy < ApplicationPolicy
+  def create?
+    @user.is_admin? || access_to_namespace?
+  end
+
+  def update?
+    create?
+  end
+
+  def destroy?
+    create?
+  end
+
+  private
+
+  def access_to_namespace?
+    @record.attrib_namespace_modifiable_bies.any? do |rule|
+      rule.user == @user || @user.is_in_group?(rule.group)
+    end
+  end
+end

--- a/src/api/app/policies/attrib_policy.rb
+++ b/src/api/app/policies/attrib_policy.rb
@@ -3,13 +3,16 @@ class AttribPolicy < ApplicationPolicy
     # Admins can write everything
     return true if @user.is_admin?
 
-    at_modifiables = modifiables
-    if at_modifiables.empty? && @record.container.present?
+    if @record.attrib_type.nil? || @record.attrib_type.attrib_type_modifiable_bies.empty?
       # No specific rules set for the attribute, check if the user can modify the container
       @record.container.can_be_modified_by?(@user)
     else
-      # check for modifiable_by rules
-      permissions_for_modifiables?(at_modifiables)
+      # check for type modifiable_by rules
+      @record.attrib_type.attrib_type_modifiable_bies.any? do |rule|
+        rule.user == @user ||
+        @user.is_in_group?(rule.group) ||
+          (rule.try(:role) && @user.has_local_role?(rule.role, @record.container))
+      end
     end
   end
 
@@ -19,29 +22,5 @@ class AttribPolicy < ApplicationPolicy
 
   def destroy?
     create?
-  end
-
-  private
-
-  # Parses AttribTypeModifiableBy and AttribNamespaceModifiableBy association
-  # collections and checks the users permissions.
-  #
-  # Permission check is based on:
-  #   - User
-  #   - Group association of user
-  #   - Role association of user (Only for AttribTypeModifiableBy)
-  def permissions_for_modifiables?(attrib_modifiables)
-    attrib_modifiables.any? do |rule|
-      rule.user == @user ||
-      @user.is_in_group?(rule.group) ||
-        (rule.try(:role) && @user.has_local_role?(rule.role, @record.container))
-    end
-  end
-
-  # Collects AttribTypeModifiableBy and AttribNamespaceModifiableBy associated to
-  #  an AttribType object and returns them in an Array
-  def modifiables
-    @record.attrib_type.try(:attrib_type_modifiable_bies).to_a |
-      @record.attrib_type.try(:attrib_namespace).try(:attrib_namespace_modifiable_bies).to_a
   end
 end

--- a/src/api/test/functional/issue_controller_test.rb
+++ b/src/api/test/functional/issue_controller_test.rb
@@ -138,17 +138,6 @@ Aha bnc#123456\n
     assert_response :success
 
     # add some more via attribute
-    # as normal user
-    data = "<attributes><attribute namespace='OBS' name='Issues'>
-              <issue name='987' tracker='bnc'/>
-              <issue name='654' tracker='bnc'/>
-            </attribute></attributes>"
-    post "/source/home:Iggy:branches:BaseDistro/pack_new/_attribute", params: data
-    assert_response :forbidden
-
-    # when project maintainers are allowed to add Issue attribute
-    attrib_type = AttribType.where(name: "Issues").first
-    attrib_type.attrib_type_modifiable_bies.create(role: Role.where(title: "maintainer").first)
     data = "<attributes><attribute namespace='OBS' name='Issues'>
               <issue name='987' tracker='bnc'/>
               <issue name='654' tracker='bnc'/>

--- a/src/api/test/functional/maintenance_test.rb
+++ b/src/api/test/functional/maintenance_test.rb
@@ -967,12 +967,12 @@ class MaintenanceTests < ActionDispatch::IntegrationTest
     post "/source/#{incidentProject}/_attribute", params: "<attributes><attribute namespace='OBS' name='EmbargoDate'><value>INVALID_DATE_STRING</value></attribute></attributes>"
     assert_response :forbidden
 
-    # Note: EmbargoDate is needed for test for releasing packages
-    # Allow maintenance_coord user to change EmbargoDate
-    attrib_type = AttribType.where(name: "EmbargoDate").first
-    attrib_type.attrib_namespace.attrib_namespace_modifiable_bies.create(user: User.where(login: "maintenance_coord").first)
+    # EmbargoDate is needed for test for releasing packages
+    login_king
     post "/source/#{incidentProject}/_attribute", params: "<attributes><attribute namespace='OBS' name='EmbargoDate'><value>INVALID_DATE_STRING</value></attribute></attributes>"
     assert_response :success
+
+    prepare_request_with_user 'maintenance_coord', 'buildservice'
 
     # create some changes, including issue tracker references
     Timecop.freeze(1)

--- a/src/api/test/functional/maintenance_test.rb
+++ b/src/api/test/functional/maintenance_test.rb
@@ -963,6 +963,17 @@ class MaintenanceTests < ActionDispatch::IntegrationTest
     post "/source/#{incidentProject}?cmd=set_flag&flag=lock&status=disable"
     assert_response :success
 
+    # set an invalid
+    post "/source/#{incidentProject}/_attribute", params: "<attributes><attribute namespace='OBS' name='EmbargoDate'><value>INVALID_DATE_STRING</value></attribute></attributes>"
+    assert_response :forbidden
+
+    # Note: EmbargoDate is needed for test for releasing packages
+    # Allow maintenance_coord user to change EmbargoDate
+    attrib_type = AttribType.where(name: "EmbargoDate").first
+    attrib_type.attrib_namespace.attrib_namespace_modifiable_bies.create(user: User.where(login: "maintenance_coord").first)
+    post "/source/#{incidentProject}/_attribute", params: "<attributes><attribute namespace='OBS' name='EmbargoDate'><value>INVALID_DATE_STRING</value></attribute></attributes>"
+    assert_response :success
+
     # create some changes, including issue tracker references
     Timecop.freeze(1)
     put '/source/' + incidentProject + '/pack2.BaseDistro2.0_LinkedUpdateProject/dummy.changes', params: 'DUMMY bnc#1042'
@@ -1403,21 +1414,6 @@ class MaintenanceTests < ActionDispatch::IntegrationTest
     get comments_request_path(id: reqid)
     assert_xml_tag tag: 'comment', attributes: { who: 'king' }, content: 'Release it now!'
 
-    # Note: This is also preparation for testing release of packages, which
-    #       relies on EmbargoDate
-    # set an invalid embargo date first
-    prepare_request_with_user 'maintenance_coord', 'buildservice'
-    post "/source/#{incidentProject}/_attribute", params: "<attributes><attribute namespace='OBS' name='EmbargoDate'><value>INVALID_DATE_STRING</value></attribute></attributes>"
-    assert_response :forbidden
-
-    # Allow maintenance_coord user to change EmbargoDate
-    attrib_type = AttribType.where(name: "EmbargoDate").first
-    attrib_type.attrib_namespace.attrib_namespace_modifiable_bies.create(user: User.where(login: "maintenance_coord").first)
-    post "/source/#{incidentProject}/_attribute", params: "<attributes><attribute namespace='OBS' name='EmbargoDate'><value>INVALID_DATE_STRING</value></attribute></attributes>"
-    assert_response :success
-
-    login_king
-
     #### blocked attempt to release packages
     # block the release until tomorrow
     post "/request/#{reqid}?cmd=changestate&newstate=accepted&comment=releasing"
@@ -1434,8 +1430,7 @@ class MaintenanceTests < ActionDispatch::IntegrationTest
     post "/request/#{reqid}?cmd=changestate&newstate=accepted&comment=releasing"
     assert_response 400
     assert_xml_tag(tag: 'status', attributes: { code: "under_embargo" })
-
-    # set embargo date to yesterday, so it works below
+    # set it to yesterday, so it works below
     post "/source/#{incidentProject}/_attribute", params: "<attributes><attribute namespace='OBS' name='EmbargoDate'><value>#{DateTime.now.yesterday.year}-#{DateTime.now.yesterday.month}-#{DateTime.now.yesterday.day}</value></attribute></attributes>"
     assert_response :success
 

--- a/src/api/test/functional/maintenance_test.rb
+++ b/src/api/test/functional/maintenance_test.rb
@@ -963,12 +963,7 @@ class MaintenanceTests < ActionDispatch::IntegrationTest
     post "/source/#{incidentProject}?cmd=set_flag&flag=lock&status=disable"
     assert_response :success
 
-    # set an invalid
-    post "/source/#{incidentProject}/_attribute", params: "<attributes><attribute namespace='OBS' name='EmbargoDate'><value>INVALID_DATE_STRING</value></attribute></attributes>"
-    assert_response :forbidden
-
     # EmbargoDate is needed for test for releasing packages
-    login_king
     post "/source/#{incidentProject}/_attribute", params: "<attributes><attribute namespace='OBS' name='EmbargoDate'><value>INVALID_DATE_STRING</value></attribute></attributes>"
     assert_response :success
 

--- a/src/api/test/policies/attrib_policy_test.rb
+++ b/src/api/test/policies/attrib_policy_test.rb
@@ -41,22 +41,20 @@ class AttribPolicyTest < ActiveSupport::TestCase
 
   # AttribNamespaceModifiableBy
   test 'group can crud attrib_namespace' do
-    attrib = Attrib.new(attrib_type_id: 56, project: Project.find_by(name: 'Apache'))
     # user6 is in group honks
-    policy = AttribPolicy.new(users(:user6), attrib)
+    policy = AttribNamespacePolicy.new(users(:user6), attrib_namespaces(:obs))
     assert policy.create?, "#{users(:user6)} can't CRUD attrib_namespace"
     # Iggy is not
-    policy = AttribPolicy.new(users(:Iggy), attrib)
+    policy = AttribNamespacePolicy.new(users(:Iggy), attrib_namespaces(:obs))
     assert_not policy.create?, "#{users(:Iggy)} shouldn't be able to CURD attrib_namespace"
   end
 
   test 'user can crud attrib_namespace' do
-    attrib = attribs(:apache_issues)
     # Fred is explicitely set
-    policy = AttribPolicy.new(users(:fred), attrib)
+    policy = AttribNamespacePolicy.new(users(:fred), attrib_namespaces(:obs))
     assert policy.create?, "#{users(:fred)} can't CRUD attrib_namespace"
     # Iggy not
-    policy = AttribPolicy.new(users(:Iggy), attrib)
+    policy = AttribNamespacePolicy.new(users(:Iggy), attrib_namespaces(:obs))
     assert_not policy.create?, "#{users(:Iggy)} shouldn't be able to CURD attrib_namespace"
   end
 end


### PR DESCRIPTION
Only check AttribType rules and not AttribNamespace rules for
the Attrib policy. Fixes #2782 

This required to revert some of the changes @bgeuken did to adop the test suite to this...