### PR TITLE
Fix lint parantheses as grouped expression

### DIFF
--- a/src/api/.rubocop.yml
+++ b/src/api/.rubocop.yml
@@ -210,6 +210,10 @@ Lint/UselessAssignment:
 Lint/InheritException:
   Enabled: true
 
+# Checks for space between a the name of a called method and a left parenthesis.
+Lint/ParenthesesAsGroupedExpression:
+  Enabled: true
+
 ##################### Performance ###############################
 
 # Use yield instead of having a &block parameter and block.call

--- a/src/api/.rubocop_todo.yml
+++ b/src/api/.rubocop_todo.yml
@@ -31,13 +31,6 @@ Lint/NonLocalExitFromIterator:
     - 'app/models/patchinfo.rb'
     - 'app/models/relationship.rb'
 
-# Offense count: 4
-Lint/ParenthesesAsGroupedExpression:
-  Exclude:
-    - 'app/models/project.rb'
-    - 'test/functional/webui/maintenance_workflow_test.rb'
-    - 'test/functional/webui/monitor_controller_test.rb'
-
 # Offense count: 10
 Lint/RescueException:
   Exclude:

--- a/src/api/app/models/project.rb
+++ b/src/api/app/models/project.rb
@@ -536,7 +536,7 @@ class Project < ApplicationRecord
   def check_weak_dependencies!
     # check all packages
     packages.each do |pkg|
-      pkg.check_weak_dependencies! (true) # ignore project local devel packages
+      pkg.check_weak_dependencies!(true) # ignore project local devel packages
     end
 
     # do not allow to remove maintenance master projects if there are incident projects
@@ -878,7 +878,7 @@ class Project < ApplicationRecord
   def check_for_empty_repo_list(list, error_prefix)
     return if list.empty?
     linking_repos = list.map { |x| x.repository.project.name + '/' + x.repository.name }.join "\n"
-    raise SaveError.new (error_prefix + "\n" + linking_repos)
+    raise SaveError.new(error_prefix + "\n" + linking_repos)
   end
 
   def write_to_backend

--- a/src/api/test/functional/webui/maintenance_workflow_test.rb
+++ b/src/api/test/functional/webui/maintenance_workflow_test.rb
@@ -58,7 +58,7 @@ class Webui::MaintenanceWorkflowTest < Webui::IntegrationTest
     find(:link, 'open request').click
     find("tbody tr:first-child a.request_link").click
     find(:id, 'description-text').text.must_equal 'I want the update'
-    find(:id, 'action_display_0').must_have_text ('Release in BaseDistro2.0:LinkedUpdateProject')
+    find(:id, 'action_display_0').must_have_text('Release in BaseDistro2.0:LinkedUpdateProject')
     fill_in 'reason', with: 'really? ok'
     find(:id, 'accept_request_button').click
     # rubocop:disable Metrics/LineLength

--- a/src/api/test/functional/webui/monitor_controller_test.rb
+++ b/src/api/test/functional/webui/monitor_controller_test.rb
@@ -42,6 +42,6 @@ class Webui::MonitorControllerTest < Webui::IntegrationTest
     # we can't use timecop as long as we have 2 processes
     page.must_have_selector(:xpath, '//div[text()="May" or text()="Mar" or text()="Jun"]')
     tickLabels = all('.tickLabel').each.map(&:text)
-    assert (tickLabels.include?('Mar') || tickLabels.include?('May') || tickLabels.include?('Jun'))
+    assert(tickLabels.include?('Mar') || tickLabels.include?('May') || tickLabels.include?('Jun'))
   end
 end


### PR DESCRIPTION
This cop checks for space between a the name of a called method and a left parenthesis.