### PR TITLE
[webui] Use Ajax to delete comments

### DIFF
--- a/src/api/app/assets/javascripts/webui/application/comment.js
+++ b/src/api/app/assets/javascripts/webui/application/comment.js
@@ -22,3 +22,15 @@ function setup_comment_page() {
         $(this).find('input[type="submit"]').prop('disabled', true);
     });
 }
+
+$(document).ready(function(){
+    $('a.delete_link').on('ajax:success', function(event, data, status, xhr){
+        $('#flash-messages').remove();
+        $(data.flash).filter('#flash-messages').insertAfter('#subheader').fadeIn('slow');
+        $(this).parent().parent().parent().fadeOut("slow");
+    }).on('ajax:error',function(event, xhr, status, error){
+        var response = $.parseJSON(xhr.responseText);
+        $('#flash-messages').remove();
+        $(response.flash).filter('#flash-messages').insertAfter('#subheader').fadeIn('slow');
+    });
+});

--- a/src/api/app/views/webui/comment/_links.html.haml
+++ b/src/api/app/views/webui/comment/_links.html.haml
@@ -5,5 +5,5 @@
         = sprited_text('comment_add', 'Reply')
   - if policy(comment).destroy?
     %li
-      = link_to(sprited_text('comment_delete', 'Delete'), comment, method: :delete, id: "delete_link_id_#{comment.id}",
+      = link_to(sprited_text('comment_delete', 'Delete'), comment, method: :delete, id: "delete_link_id_#{comment.id}", class: 'delete_link', remote: true,
         'data-confirm': 'Do you really want delete this comment?')

--- a/src/api/spec/controllers/webui/comments_controller_spec.rb
+++ b/src/api/spec/controllers/webui/comments_controller_spec.rb
@@ -81,7 +81,7 @@ RSpec.describe Webui::CommentsController, type: :controller do
         delete :destroy, params: { id: comment.id }
       end
 
-      it { expect(flash[:notice]).to eq('Comment deleted successfully') }
+      it { expect(flash[:notice]).to eq('Comment deleted successfully.') }
       it { expect(Comment.where(id: comment.id)).to eq([]) }
     end
 
@@ -100,7 +100,7 @@ RSpec.describe Webui::CommentsController, type: :controller do
         delete :destroy, params: { id: other_comment.id }
       end
 
-      it { expect(flash[:notice]).to eq('Comment deleted successfully') }
+      it { expect(flash[:notice]).to eq('Comment deleted successfully.') }
       it { expect(Comment.where(id: other_comment.id)).to eq([]) }
     end
   end


### PR DESCRIPTION
like requested in #2573.

- Refactored webui/comments#destroy to respond to json format
- Use remote: true for the delete link
- Added javascript to handle flash and fade out of the comments