### PR TITLE
Enable Style/SignalException Rubocop cop

### DIFF
--- a/src/api/.rubocop.yml
+++ b/src/api/.rubocop.yml
@@ -125,6 +125,10 @@ Style/RedundantReturn:
 Style/RedundantSelf:
   Enabled: true
 
+# This cop checks for uses of `fail` and `raise`
+Style/SignalException:
+  Enabled: true
+
 # Checks for space after `!`
 Style/SpaceAfterNot:
   Enabled: true

--- a/src/api/.rubocop_todo.yml
+++ b/src/api/.rubocop_todo.yml
@@ -781,14 +781,6 @@ Style/Semicolon:
     - 'test/functional/build_controller_test.rb'
     - 'test/functional/zzz_post_consistency_test.rb'
 
-# Offense count: 1
-# Cop supports --auto-correct.
-# Configuration parameters: EnforcedStyle, SupportedStyles.
-# SupportedStyles: only_raise, only_fail, semantic
-Style/SignalException:
-  Exclude:
-    - 'test/functional/webui/search_controller_test.rb'
-
 # Offense count: 39
 # Cop supports --auto-correct.
 Style/SpaceAfterColon:

--- a/src/api/test/functional/webui/search_controller_test.rb
+++ b/src/api/test/functional/webui/search_controller_test.rb
@@ -73,7 +73,7 @@ class Webui::SearchControllerTest < Webui::IntegrationTest
           package_name: row.find('a.package').text
         }
       else
-        fail "Unrecognized result icon. #{theclass}"
+        raise "Unrecognized result icon. #{theclass}"
       end
     end
   end


### PR DESCRIPTION
This cop checks for uses of `fail` and `raise`.