### PR TITLE
Fixes to support for https DoD repositories

### DIFF
--- a/src/backend/bs_repserver
+++ b/src/backend/bs_repserver
@@ -55,7 +55,7 @@ use BSXML;
 use BSVerify;
 use BSHandoff;
 use Build;
-use BSWatcher;
+use BSWatcher ":https";
 use BSStdServer;
 use BSXPath;
 use BSXPathKeys;


### PR DESCRIPTION
First patch fixes an issue we saw where on some https repositories read() would always fail due to ssl returning WANT_READ. The second simply adds https capabilities in the repserver through the BSWatcher use (to allow it to download the .debs over https)