### PR TITLE
[webui] Implement reload of user datatables

### DIFF
--- a/src/api/app/assets/javascripts/webui/application/user.js
+++ b/src/api/app/assets/javascripts/webui/application/user.js
@@ -33,4 +33,21 @@ $( document ).ready(function() {
 
     options.ajax.data.dataTableId = 'reviews_in_table';
     $('#reviews_in_table').dataTable(options);
+
+    $('.result_reload').click(function() {
+      var that = this;
+      $(this).hide();
+      $(this).siblings('.result_spinner').show();
+      var table = $(this).data('table');
+
+      $('#' + table).DataTable().ajax.reload(function(){
+        $(that).show();
+        $(that).siblings('.result_spinner').hide();
+      }, false);
+    });
+
+    $('#requests li a').click(function (event) {
+      $(this).parent().parent().find('.result_reload').hide();
+      $(this).siblings('.result_reload').show();
+    });
 });

--- a/src/api/app/views/webui/user/show.html.erb
+++ b/src/api/app/views/webui/user/show.html.erb
@@ -129,7 +129,11 @@
     <div id="reviews">
       <div class="box-header header-tabs">
         <ul>
-          <li><a href="#reviews_in" title="Requests that <%= @displayed_user.login %> has to review">Incoming Reviews</a></li>
+          <li>
+            <a href="#reviews_in" title="Requests that <%= @displayed_user.login %> has to review">Incoming Reviews</a>
+            <%= sprite_tag('reload', title: 'Reload', class: 'result_reload', data: { table: 'reviews_in_table' }) %>
+            <%= image_tag('ajax-loader.gif', class: 'result_spinner hidden') %>
+          </li>
         </ul>
       </div>
       <div id="reviews_in" class="tab">
@@ -142,10 +146,26 @@
     <div id="requests">
       <div class="box-header header-tabs">
         <ul>
-            <li><a id="requests_in_tab" href="#requests_in" title="Requests that <%= @displayed_user.login %> has to merge">Incoming Requests</a></li>
-            <li><a id="requests_out_tab" href="#requests_out" title="Requests that <%= @displayed_user.login %> has sent">Outgoing Requests</a></li>
-            <li><a id="requests_declined_tab" href="#requests_declined" title="Requests from <%= @displayed_user.login %> that are declined">Declined Requests</a></li>
-            <li><a id="all_requests_tab" href="#all_requests" title="All Requests from <%= @displayed_user.login %>">All Requests</a></li>
+            <li>
+              <a id="requests_in_tab" href="#requests_in" title="Requests that <%= @displayed_user.login %> has to merge">Incoming Requests</a>
+              <%= sprite_tag('reload', title: 'Reload', class: 'result_reload', data: { table: 'requests_in_table' }) %>
+              <%= image_tag('ajax-loader.gif', class: 'result_spinner hidden') %>
+            </li>
+            <li>
+              <a id="requests_out_tab" href="#requests_out" title="Requests that <%= @displayed_user.login %> has sent">Outgoing Requests</a>
+              <%= sprite_tag('reload', title: 'Reload', class: 'result_reload hidden', data: { table: 'requests_out_table' }) %>
+              <%= image_tag('ajax-loader.gif', class: 'result_spinner hidden') %>
+            </li>
+            <li>
+              <a id="requests_declined_tab" href="#requests_declined" title="Requests from <%= @displayed_user.login %> that are declined">Declined Requests</a>
+              <%= sprite_tag('reload', title: 'Reload', class: 'result_reload hidden', data: { table: 'requests_declined_table' }) %>
+              <%= image_tag('ajax-loader.gif', class: 'result_spinner hidden') %>
+            </li>
+            <li>
+              <a id="all_requests_tab" href="#all_requests" title="All Requests from <%= @displayed_user.login %>">All Requests</a>
+              <%= sprite_tag('reload', title: 'Reload', class: 'result_reload hidden', data: { table: 'all_requests_table' }) %>
+              <%= image_tag('ajax-loader.gif', class: 'result_spinner hidden') %>
+            </li>
         </ul>
       </div>
         <div id="requests_in" class="tab">


### PR DESCRIPTION
Reloading of the datatables on the user view page is now possible without reloading the whole page.
Requested in #2729

![user_datatables](https://cloud.githubusercontent.com/assets/3799140/24002856/18167e6c-0a62-11e7-9bc2-b63939ffe983.png)