### PR TITLE
[ci] Ignore memory helpers

### DIFF
--- a/src/api/spec/support/coverage.rb
+++ b/src/api/spec/support/coverage.rb
@@ -7,6 +7,8 @@ SimpleCov.start 'rails' do
   add_filter '/app/indices/'
   add_filter '/app/models/user_ldap_strategy.rb'
   add_filter '/lib/templates/'
+  add_filter '/lib/memory_debugger.rb'
+  add_filter '/lib/memory_dumper.rb'
   merge_timeout 3600
   formatter Coveralls::SimpleCov::Formatter
 end

--- a/src/api/test/test_helper.rb
+++ b/src/api/test/test_helper.rb
@@ -16,6 +16,8 @@ if ENV['DO_COVERAGE']
     add_filter '/app/indices/'
     add_filter '/app/models/user_ldap_strategy.rb'
     add_filter '/lib/templates/'
+    add_filter '/lib/memory_debugger.rb'
+    add_filter '/lib/memory_dumper.rb'
     merge_timeout 3600
     formatter Coveralls::SimpleCov::Formatter
   end


### PR DESCRIPTION
Those two files are only used for profiling / debugging. Therefor we can
ignore them in our test suite.