### PR TITLE
Fix bash syntax error (missing ']')

### DIFF
--- a/src/backend/call-service-in-docker.sh
+++ b/src/backend/call-service-in-docker.sh
@@ -164,7 +164,7 @@ if [ $RET_ERR -eq 0 ]; then
       fi
     done
   fi
-elif [ $RET_ERR -eq 125 ] || [ $RET_ERR -eq 126 ] || [ $RET_ERR -eq 127]; then
+elif [ $RET_ERR -eq 125 ] || [ $RET_ERR -eq 126 ] || [ $RET_ERR -eq 127 ]; then
   printlog "$CMD_OUT"
   echo "$CMD_OUT"
   RETURN="3"


### PR DESCRIPTION
There was a space missing between an expression and the ending ], so
I was getting:

service tar_scm failed:
/usr/lib/obs/server/call-service-in-docker.sh: line 168: [: missing `]'