### PR TITLE
[api][webui] set cache_lines.key limit to 4096

### DIFF
--- a/src/api/db/migrate/20170317094221_change_cache_lines_key.rb
+++ b/src/api/db/migrate/20170317094221_change_cache_lines_key.rb
@@ -1,0 +1,5 @@
+class ChangeCacheLinesKey < ActiveRecord::Migration[5.0]
+  def change
+    change_column(:cache_lines, :key, :string, limit: 4096)
+  end
+end

--- a/src/api/db/structure.sql
+++ b/src/api/db/structure.sql
@@ -263,7 +263,7 @@ CREATE TABLE `bs_requests` (
 
 CREATE TABLE `cache_lines` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
-  `key` varchar(255) COLLATE utf8_unicode_ci NOT NULL,
+  `key` varchar(4096) COLLATE utf8_unicode_ci NOT NULL,
   `package` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
   `project` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
   `request` int(11) DEFAULT NULL,
@@ -1406,6 +1406,7 @@ INSERT INTO schema_migrations (version) VALUES
 ('20170306105300'),
 ('20170315190919'),
 ('20170315200936'),
+('20170317094221'),
 ('21'),
 ('22'),
 ('23'),


### PR DESCRIPTION
Fixes a change introduced by PR https://github.com/openSUSE/open-build-service/pull/2652