### PR TITLE
[doc] Remove documentation of schema from models

### DIFF
--- a/src/api/app/models/architecture.rb
+++ b/src/api/app/models/architecture.rb
@@ -43,15 +43,3 @@ class Architecture < ApplicationRecord
   #### Alias of methods
 end
 
-# == Schema Information
-#
-# Table name: architectures
-#
-#  id        :integer          not null, primary key
-#  name      :string(255)      not null
-#  available :boolean          default("0")
-#
-# Indexes
-#
-#  arch_name_index  (name) UNIQUE
-#

--- a/src/api/app/models/attrib.rb
+++ b/src/api/app/models/attrib.rb
@@ -144,20 +144,3 @@ class Attrib < ApplicationRecord
   end
 end
 
-# == Schema Information
-#
-# Table name: attribs
-#
-#  id             :integer          not null, primary key
-#  attrib_type_id :integer          not null
-#  package_id     :integer
-#  binary         :string(255)
-#  project_id     :integer
-#
-# Indexes
-#
-#  attribs_index                (attrib_type_id,package_id,project_id,binary) UNIQUE
-#  attribs_on_proj_and_pack     (attrib_type_id,project_id,package_id,binary) UNIQUE
-#  index_attribs_on_package_id  (package_id)
-#  index_attribs_on_project_id  (project_id)
-#

--- a/src/api/app/models/attrib_allowed_value.rb
+++ b/src/api/app/models/attrib_allowed_value.rb
@@ -2,15 +2,3 @@ class AttribAllowedValue < ApplicationRecord
   belongs_to :attrib_type
 end
 
-# == Schema Information
-#
-# Table name: attrib_allowed_values
-#
-#  id             :integer          not null, primary key
-#  attrib_type_id :integer          not null
-#  value          :text(65535)
-#
-# Indexes
-#
-#  attrib_type_id  (attrib_type_id)
-#

--- a/src/api/app/models/attrib_default_value.rb
+++ b/src/api/app/models/attrib_default_value.rb
@@ -3,16 +3,3 @@ class AttribDefaultValue < ApplicationRecord
   acts_as_list scope: :attrib_type
 end
 
-# == Schema Information
-#
-# Table name: attrib_default_values
-#
-#  id             :integer          not null, primary key
-#  attrib_type_id :integer          not null
-#  value          :text(65535)      not null
-#  position       :integer          not null
-#
-# Indexes
-#
-#  attrib_type_id  (attrib_type_id)
-#

--- a/src/api/app/models/attrib_issue.rb
+++ b/src/api/app/models/attrib_issue.rb
@@ -5,16 +5,3 @@ class AttribIssue < ApplicationRecord
   accepts_nested_attributes_for :issue
 end
 
-# == Schema Information
-#
-# Table name: attrib_issues
-#
-#  id        :integer          not null, primary key
-#  attrib_id :integer          not null
-#  issue_id  :integer          not null
-#
-# Indexes
-#
-#  index_attrib_issues_on_attrib_id_and_issue_id  (attrib_id,issue_id) UNIQUE
-#  issue_id                                       (issue_id)
-#

--- a/src/api/app/models/attrib_namespace.rb
+++ b/src/api/app/models/attrib_namespace.rb
@@ -44,14 +44,3 @@ class AttribNamespace < ApplicationRecord
   #### Alias of methods
 end
 
-# == Schema Information
-#
-# Table name: attrib_namespaces
-#
-#  id   :integer          not null, primary key
-#  name :string(255)
-#
-# Indexes
-#
-#  index_attrib_namespaces_on_name  (name)
-#

--- a/src/api/app/models/attrib_namespace_modifiable_by.rb
+++ b/src/api/app/models/attrib_namespace_modifiable_by.rb
@@ -4,19 +4,3 @@ class AttribNamespaceModifiableBy < ApplicationRecord
   belongs_to :group
 end
 
-# == Schema Information
-#
-# Table name: attrib_namespace_modifiable_bies
-#
-#  id                  :integer          not null, primary key
-#  attrib_namespace_id :integer          not null
-#  user_id             :integer
-#  group_id            :integer
-#
-# Indexes
-#
-#  attrib_namespace_user_role_all_index                           (attrib_namespace_id,user_id,group_id) UNIQUE
-#  bs_group_id                                                    (group_id)
-#  bs_user_id                                                     (user_id)
-#  index_attrib_namespace_modifiable_bies_on_attrib_namespace_id  (attrib_namespace_id)
-#

--- a/src/api/app/models/attrib_type.rb
+++ b/src/api/app/models/attrib_type.rb
@@ -143,21 +143,3 @@ class AttribType < ApplicationRecord
   #### Alias of methods
 end
 
-# == Schema Information
-#
-# Table name: attrib_types
-#
-#  id                  :integer          not null, primary key
-#  name                :string(255)      not null
-#  description         :string(255)
-#  type                :string(255)
-#  value_count         :integer
-#  attrib_namespace_id :integer          not null
-#  issue_list          :boolean          default("0")
-#
-# Indexes
-#
-#  attrib_namespace_id                                 (attrib_namespace_id)
-#  index_attrib_types_on_attrib_namespace_id_and_name  (attrib_namespace_id,name) UNIQUE
-#  index_attrib_types_on_name                          (name)
-#

--- a/src/api/app/models/attrib_type_modifiable_by.rb
+++ b/src/api/app/models/attrib_type_modifiable_by.rb
@@ -5,20 +5,3 @@ class AttribTypeModifiableBy < ApplicationRecord
   belongs_to :role
 end
 
-# == Schema Information
-#
-# Table name: attrib_type_modifiable_bies
-#
-#  id             :integer          not null, primary key
-#  attrib_type_id :integer          not null
-#  user_id        :integer
-#  group_id       :integer
-#  role_id        :integer
-#
-# Indexes
-#
-#  attrib_type_user_role_all_index  (attrib_type_id,user_id,group_id,role_id) UNIQUE
-#  group_id                         (group_id)
-#  role_id                          (role_id)
-#  user_id                          (user_id)
-#

--- a/src/api/app/models/attrib_value.rb
+++ b/src/api/app/models/attrib_value.rb
@@ -45,16 +45,3 @@ class AttribValue < ApplicationRecord
   #### Alias of methods
 end
 
-# == Schema Information
-#
-# Table name: attrib_values
-#
-#  id        :integer          not null, primary key
-#  attrib_id :integer          not null
-#  value     :text(65535)      not null
-#  position  :integer          not null
-#
-# Indexes
-#
-#  index_attrib_values_on_attrib_id  (attrib_id)
-#

--- a/src/api/app/models/backend_info.rb
+++ b/src/api/app/models/backend_info.rb
@@ -38,13 +38,3 @@ class BackendInfo < ApplicationRecord
   #### Alias of methods
 end
 
-# == Schema Information
-#
-# Table name: backend_infos
-#
-#  id         :integer          not null, primary key
-#  key        :string(255)      not null
-#  value      :string(255)      not null
-#  created_at :datetime
-#  updated_at :datetime
-#

--- a/src/api/app/models/backend_package.rb
+++ b/src/api/app/models/backend_package.rb
@@ -30,21 +30,3 @@ class BackendPackage < ApplicationRecord
   #### Alias of methods
 end
 
-# == Schema Information
-#
-# Table name: backend_packages
-#
-#  package_id  :integer          not null, primary key
-#  links_to_id :integer
-#  updated_at  :datetime
-#  srcmd5      :string(255)
-#  changesmd5  :string(255)
-#  verifymd5   :string(255)
-#  expandedmd5 :string(255)
-#  error       :text(65535)
-#  maxmtime    :datetime
-#
-# Indexes
-#
-#  index_backend_packages_on_links_to_id  (links_to_id)
-#

--- a/src/api/app/models/binary_release.rb
+++ b/src/api/app/models/binary_release.rb
@@ -192,37 +192,3 @@ class BinaryRelease < ApplicationRecord
   #### Alias of methods
 end
 
-# == Schema Information
-#
-# Table name: binary_releases
-#
-#  id                        :integer          not null, primary key
-#  repository_id             :integer          not null
-#  operation                 :string(8)        default("added")
-#  obsolete_time             :datetime
-#  release_package_id        :integer
-#  binary_name               :string(255)      not null
-#  binary_epoch              :string(64)
-#  binary_version            :string(64)       not null
-#  binary_release            :string(64)       not null
-#  binary_arch               :string(64)       not null
-#  binary_disturl            :string(255)
-#  binary_buildtime          :datetime
-#  binary_releasetime        :datetime         not null
-#  binary_supportstatus      :string(255)
-#  binary_maintainer         :string(255)
-#  medium                    :string(255)
-#  binary_updateinfo         :string(255)
-#  binary_updateinfo_version :string(255)
-#  modify_time               :datetime
-#
-# Indexes
-#
-#  exact_search_index                                    (binary_name,binary_epoch,binary_version,binary_release,binary_arch)
-#  index_binary_releases_on_binary_name                  (binary_name)
-#  index_binary_releases_on_binary_name_and_binary_arch  (binary_name,binary_arch)
-#  index_binary_releases_on_binary_updateinfo            (binary_updateinfo)
-#  index_binary_releases_on_medium                       (medium)
-#  ra_name_index                                         (repository_id,binary_name)
-#  release_package_id                                    (release_package_id)
-#

--- a/src/api/app/models/blacklist_tag.rb
+++ b/src/api/app/models/blacklist_tag.rb
@@ -1,11 +1,3 @@
 class BlacklistTag < ApplicationRecord
 end
 
-# == Schema Information
-#
-# Table name: blacklist_tags
-#
-#  id         :integer          not null, primary key
-#  name       :string(255)
-#  created_at :datetime
-#

--- a/src/api/app/models/bs_request.rb
+++ b/src/api/app/models/bs_request.rb
@@ -1308,27 +1308,3 @@ class BsRequest < ApplicationRecord
   end
 end
 
-# == Schema Information
-#
-# Table name: bs_requests
-#
-#  id            :integer          not null, primary key
-#  description   :text(65535)
-#  creator       :string(255)
-#  state         :string(255)
-#  comment       :text(65535)
-#  commenter     :string(255)
-#  superseded_by :integer
-#  created_at    :datetime         not null
-#  updated_at    :datetime         not null
-#  accept_at     :datetime
-#  priority      :string(9)        default("moderate")
-#  number        :integer          not null
-#
-# Indexes
-#
-#  index_bs_requests_on_creator        (creator)
-#  index_bs_requests_on_number         (number) UNIQUE
-#  index_bs_requests_on_state          (state)
-#  index_bs_requests_on_superseded_by  (superseded_by)
-#

--- a/src/api/app/models/bs_request_action.rb
+++ b/src/api/app/models/bs_request_action.rb
@@ -961,34 +961,3 @@ class BsRequestAction < ApplicationRecord
   #### Alias of methods
 end
 
-# == Schema Information
-#
-# Table name: bs_request_actions
-#
-#  id                    :integer          not null, primary key
-#  bs_request_id         :integer
-#  type                  :string(255)
-#  target_project        :string(255)
-#  target_package        :string(255)
-#  target_releaseproject :string(255)
-#  source_project        :string(255)
-#  source_package        :string(255)
-#  source_rev            :string(255)
-#  sourceupdate          :string(255)
-#  updatelink            :boolean          default("0")
-#  person_name           :string(255)
-#  group_name            :string(255)
-#  role                  :string(255)
-#  created_at            :datetime
-#  target_repository     :string(255)
-#  makeoriginolder       :boolean          default("0")
-#
-# Indexes
-#
-#  bs_request_id                                                  (bs_request_id)
-#  index_bs_request_actions_on_source_package                     (source_package)
-#  index_bs_request_actions_on_source_project                     (source_project)
-#  index_bs_request_actions_on_target_package                     (target_package)
-#  index_bs_request_actions_on_target_project                     (target_project)
-#  index_bs_request_actions_on_target_project_and_source_project  (target_project,source_project)
-#

--- a/src/api/app/models/bs_request_action_accept_info.rb
+++ b/src/api/app/models/bs_request_action_accept_info.rb
@@ -1,4 +1,3 @@
-#
 class BsRequestActionAcceptInfo < ApplicationRecord
   #### Includes and extends
   #### Constants
@@ -29,22 +28,3 @@ class BsRequestActionAcceptInfo < ApplicationRecord
   #### Alias of methods
 end
 
-# == Schema Information
-#
-# Table name: bs_request_action_accept_infos
-#
-#  id                   :integer          not null, primary key
-#  bs_request_action_id :integer
-#  rev                  :string(255)
-#  srcmd5               :string(255)
-#  xsrcmd5              :string(255)
-#  osrcmd5              :string(255)
-#  oxsrcmd5             :string(255)
-#  created_at           :datetime
-#  oproject             :string(255)
-#  opackage             :string(255)
-#
-# Indexes
-#
-#  bs_request_action_id  (bs_request_action_id)
-#

--- a/src/api/app/models/bs_request_action_add_role.rb
+++ b/src/api/app/models/bs_request_action_add_role.rb
@@ -1,4 +1,3 @@
-#
 class BsRequestActionAddRole < BsRequestAction
   #### Includes and extends
   #### Constants
@@ -54,34 +53,3 @@ class BsRequestActionAddRole < BsRequestAction
   #### Alias of methods
 end
 
-# == Schema Information
-#
-# Table name: bs_request_actions
-#
-#  id                    :integer          not null, primary key
-#  bs_request_id         :integer
-#  type                  :string(255)
-#  target_project        :string(255)
-#  target_package        :string(255)
-#  target_releaseproject :string(255)
-#  source_project        :string(255)
-#  source_package        :string(255)
-#  source_rev            :string(255)
-#  sourceupdate          :string(255)
-#  updatelink            :boolean          default("0")
-#  person_name           :string(255)
-#  group_name            :string(255)
-#  role                  :string(255)
-#  created_at            :datetime
-#  target_repository     :string(255)
-#  makeoriginolder       :boolean          default("0")
-#
-# Indexes
-#
-#  bs_request_id                                                  (bs_request_id)
-#  index_bs_request_actions_on_source_package                     (source_package)
-#  index_bs_request_actions_on_source_project                     (source_project)
-#  index_bs_request_actions_on_target_package                     (target_package)
-#  index_bs_request_actions_on_target_project                     (target_project)
-#  index_bs_request_actions_on_target_project_and_source_project  (target_project,source_project)
-#

--- a/src/api/app/models/bs_request_action_change_devel.rb
+++ b/src/api/app/models/bs_request_action_change_devel.rb
@@ -1,4 +1,3 @@
-#
 class BsRequestActionChangeDevel < BsRequestAction
   #### Includes and extends
   #### Constants
@@ -30,34 +29,3 @@ class BsRequestActionChangeDevel < BsRequestAction
   #### Alias of methods
 end
 
-# == Schema Information
-#
-# Table name: bs_request_actions
-#
-#  id                    :integer          not null, primary key
-#  bs_request_id         :integer
-#  type                  :string(255)
-#  target_project        :string(255)
-#  target_package        :string(255)
-#  target_releaseproject :string(255)
-#  source_project        :string(255)
-#  source_package        :string(255)
-#  source_rev            :string(255)
-#  sourceupdate          :string(255)
-#  updatelink            :boolean          default("0")
-#  person_name           :string(255)
-#  group_name            :string(255)
-#  role                  :string(255)
-#  created_at            :datetime
-#  target_repository     :string(255)
-#  makeoriginolder       :boolean          default("0")
-#
-# Indexes
-#
-#  bs_request_id                                                  (bs_request_id)
-#  index_bs_request_actions_on_source_package                     (source_package)
-#  index_bs_request_actions_on_source_project                     (source_project)
-#  index_bs_request_actions_on_target_package                     (target_package)
-#  index_bs_request_actions_on_target_project                     (target_project)
-#  index_bs_request_actions_on_target_project_and_source_project  (target_project,source_project)
-#

--- a/src/api/app/models/bs_request_action_delete.rb
+++ b/src/api/app/models/bs_request_action_delete.rb
@@ -1,4 +1,3 @@
-#
 class BsRequestActionDelete < BsRequestAction
   #### Includes and extends
   #### Constants
@@ -77,34 +76,3 @@ class BsRequestActionDelete < BsRequestAction
   #### Alias of methods
 end
 
-# == Schema Information
-#
-# Table name: bs_request_actions
-#
-#  id                    :integer          not null, primary key
-#  bs_request_id         :integer
-#  type                  :string(255)
-#  target_project        :string(255)
-#  target_package        :string(255)
-#  target_releaseproject :string(255)
-#  source_project        :string(255)
-#  source_package        :string(255)
-#  source_rev            :string(255)
-#  sourceupdate          :string(255)
-#  updatelink            :boolean          default("0")
-#  person_name           :string(255)
-#  group_name            :string(255)
-#  role                  :string(255)
-#  created_at            :datetime
-#  target_repository     :string(255)
-#  makeoriginolder       :boolean          default("0")
-#
-# Indexes
-#
-#  bs_request_id                                                  (bs_request_id)
-#  index_bs_request_actions_on_source_package                     (source_package)
-#  index_bs_request_actions_on_source_project                     (source_project)
-#  index_bs_request_actions_on_target_package                     (target_package)
-#  index_bs_request_actions_on_target_project                     (target_project)
-#  index_bs_request_actions_on_target_project_and_source_project  (target_project,source_project)
-#

--- a/src/api/app/models/bs_request_action_group.rb
+++ b/src/api/app/models/bs_request_action_group.rb
@@ -1,4 +1,3 @@
-#
 class BsRequestActionGroup < BsRequestAction
   #### Includes and extends
   #### Constants
@@ -184,34 +183,3 @@ class BsRequestActionGroup < BsRequestAction
   #### Alias of methods
 end
 
-# == Schema Information
-#
-# Table name: bs_request_actions
-#
-#  id                    :integer          not null, primary key
-#  bs_request_id         :integer
-#  type                  :string(255)
-#  target_project        :string(255)
-#  target_package        :string(255)
-#  target_releaseproject :string(255)
-#  source_project        :string(255)
-#  source_package        :string(255)
-#  source_rev            :string(255)
-#  sourceupdate          :string(255)
-#  updatelink            :boolean          default("0")
-#  person_name           :string(255)
-#  group_name            :string(255)
-#  role                  :string(255)
-#  created_at            :datetime
-#  target_repository     :string(255)
-#  makeoriginolder       :boolean          default("0")
-#
-# Indexes
-#
-#  bs_request_id                                                  (bs_request_id)
-#  index_bs_request_actions_on_source_package                     (source_package)
-#  index_bs_request_actions_on_source_project                     (source_project)
-#  index_bs_request_actions_on_target_package                     (target_package)
-#  index_bs_request_actions_on_target_project                     (target_project)
-#  index_bs_request_actions_on_target_project_and_source_project  (target_project,source_project)
-#

--- a/src/api/app/models/bs_request_action_maintenance_incident.rb
+++ b/src/api/app/models/bs_request_action_maintenance_incident.rb
@@ -1,4 +1,3 @@
-#
 class BsRequestActionMaintenanceIncident < BsRequestAction
   #### Includes and extends
   include RequestSourceDiff
@@ -214,34 +213,3 @@ class BsRequestActionMaintenanceIncident < BsRequestAction
   #### Alias of methods
 end
 
-# == Schema Information
-#
-# Table name: bs_request_actions
-#
-#  id                    :integer          not null, primary key
-#  bs_request_id         :integer
-#  type                  :string(255)
-#  target_project        :string(255)
-#  target_package        :string(255)
-#  target_releaseproject :string(255)
-#  source_project        :string(255)
-#  source_package        :string(255)
-#  source_rev            :string(255)
-#  sourceupdate          :string(255)
-#  updatelink            :boolean          default("0")
-#  person_name           :string(255)
-#  group_name            :string(255)
-#  role                  :string(255)
-#  created_at            :datetime
-#  target_repository     :string(255)
-#  makeoriginolder       :boolean          default("0")
-#
-# Indexes
-#
-#  bs_request_id                                                  (bs_request_id)
-#  index_bs_request_actions_on_source_package                     (source_package)
-#  index_bs_request_actions_on_source_project                     (source_project)
-#  index_bs_request_actions_on_target_package                     (target_package)
-#  index_bs_request_actions_on_target_project                     (target_project)
-#  index_bs_request_actions_on_target_project_and_source_project  (target_project,source_project)
-#

--- a/src/api/app/models/bs_request_action_maintenance_release.rb
+++ b/src/api/app/models/bs_request_action_maintenance_release.rb
@@ -1,4 +1,3 @@
-#
 class BsRequestActionMaintenanceRelease < BsRequestAction
   #### Includes and extends
   include RequestSourceDiff
@@ -180,34 +179,3 @@ class BsRequestActionMaintenanceRelease < BsRequestAction
   #### Alias of methods
 end
 
-# == Schema Information
-#
-# Table name: bs_request_actions
-#
-#  id                    :integer          not null, primary key
-#  bs_request_id         :integer
-#  type                  :string(255)
-#  target_project        :string(255)
-#  target_package        :string(255)
-#  target_releaseproject :string(255)
-#  source_project        :string(255)
-#  source_package        :string(255)
-#  source_rev            :string(255)
-#  sourceupdate          :string(255)
-#  updatelink            :boolean          default("0")
-#  person_name           :string(255)
-#  group_name            :string(255)
-#  role                  :string(255)
-#  created_at            :datetime
-#  target_repository     :string(255)
-#  makeoriginolder       :boolean          default("0")
-#
-# Indexes
-#
-#  bs_request_id                                                  (bs_request_id)
-#  index_bs_request_actions_on_source_package                     (source_package)
-#  index_bs_request_actions_on_source_project                     (source_project)
-#  index_bs_request_actions_on_target_package                     (target_package)
-#  index_bs_request_actions_on_target_project                     (target_project)
-#  index_bs_request_actions_on_target_project_and_source_project  (target_project,source_project)
-#

--- a/src/api/app/models/bs_request_action_set_bugowner.rb
+++ b/src/api/app/models/bs_request_action_set_bugowner.rb
@@ -1,4 +1,3 @@
-#
 class BsRequestActionSetBugowner < BsRequestAction
   #### Includes and extends
   #### Constants
@@ -46,34 +45,3 @@ class BsRequestActionSetBugowner < BsRequestAction
   #### Alias of methods
 end
 
-# == Schema Information
-#
-# Table name: bs_request_actions
-#
-#  id                    :integer          not null, primary key
-#  bs_request_id         :integer
-#  type                  :string(255)
-#  target_project        :string(255)
-#  target_package        :string(255)
-#  target_releaseproject :string(255)
-#  source_project        :string(255)
-#  source_package        :string(255)
-#  source_rev            :string(255)
-#  sourceupdate          :string(255)
-#  updatelink            :boolean          default("0")
-#  person_name           :string(255)
-#  group_name            :string(255)
-#  role                  :string(255)
-#  created_at            :datetime
-#  target_repository     :string(255)
-#  makeoriginolder       :boolean          default("0")
-#
-# Indexes
-#
-#  bs_request_id                                                  (bs_request_id)
-#  index_bs_request_actions_on_source_package                     (source_package)
-#  index_bs_request_actions_on_source_project                     (source_project)
-#  index_bs_request_actions_on_target_package                     (target_package)
-#  index_bs_request_actions_on_target_project                     (target_project)
-#  index_bs_request_actions_on_target_project_and_source_project  (target_project,source_project)
-#

--- a/src/api/app/models/bs_request_action_submit.rb
+++ b/src/api/app/models/bs_request_action_submit.rb
@@ -122,34 +122,3 @@ class BsRequestActionSubmit < BsRequestAction
   #### Alias of methods
 end
 
-# == Schema Information
-#
-# Table name: bs_request_actions
-#
-#  id                    :integer          not null, primary key
-#  bs_request_id         :integer
-#  type                  :string(255)
-#  target_project        :string(255)
-#  target_package        :string(255)
-#  target_releaseproject :string(255)
-#  source_project        :string(255)
-#  source_package        :string(255)
-#  source_rev            :string(255)
-#  sourceupdate          :string(255)
-#  updatelink            :boolean          default("0")
-#  person_name           :string(255)
-#  group_name            :string(255)
-#  role                  :string(255)
-#  created_at            :datetime
-#  target_repository     :string(255)
-#  makeoriginolder       :boolean          default("0")
-#
-# Indexes
-#
-#  bs_request_id                                                  (bs_request_id)
-#  index_bs_request_actions_on_source_package                     (source_package)
-#  index_bs_request_actions_on_source_project                     (source_project)
-#  index_bs_request_actions_on_target_package                     (target_package)
-#  index_bs_request_actions_on_target_project                     (target_project)
-#  index_bs_request_actions_on_target_project_and_source_project  (target_project,source_project)
-#

--- a/src/api/app/models/bs_request_counter.rb
+++ b/src/api/app/models/bs_request_counter.rb
@@ -5,10 +5,3 @@ class BsRequestCounter < ActiveRecord::Base
   self.table_name = "bs_request_counter"
 end
 
-# == Schema Information
-#
-# Table name: bs_request_counter
-#
-#  id      :integer          not null, primary key
-#  counter :integer          default("1")
-#

--- a/src/api/app/models/cache_line.rb
+++ b/src/api/app/models/cache_line.rb
@@ -60,19 +60,3 @@ class CacheLine < ApplicationRecord
   end
 end
 
-# == Schema Information
-#
-# Table name: cache_lines
-#
-#  id         :integer          not null, primary key
-#  key        :string(4096)     not null
-#  package    :string(255)
-#  project    :string(255)
-#  request    :integer
-#  created_at :datetime
-#
-# Indexes
-#
-#  index_cache_lines_on_project              (project)
-#  index_cache_lines_on_project_and_package  (project,package)
-#

--- a/src/api/app/models/channel.rb
+++ b/src/api/app/models/channel.rb
@@ -176,15 +176,3 @@ class Channel < ApplicationRecord
   end
 end
 
-# == Schema Information
-#
-# Table name: channels
-#
-#  id         :integer          not null, primary key
-#  package_id :integer          not null
-#
-# Indexes
-#
-#  index_unique  (package_id) UNIQUE
-#  package_id    (package_id)
-#

--- a/src/api/app/models/channel_binary.rb
+++ b/src/api/app/models/channel_binary.rb
@@ -107,25 +107,3 @@ class ChannelBinary < ApplicationRecord
   end
 end
 
-# == Schema Information
-#
-# Table name: channel_binaries
-#
-#  id                     :integer          not null, primary key
-#  name                   :string(255)      not null
-#  channel_binary_list_id :integer          not null
-#  project_id             :integer
-#  repository_id          :integer
-#  architecture_id        :integer
-#  package                :string(255)
-#  binaryarch             :string(255)
-#  supportstatus          :string(255)
-#
-# Indexes
-#
-#  architecture_id                                            (architecture_id)
-#  channel_binary_list_id                                     (channel_binary_list_id)
-#  index_channel_binaries_on_name_and_channel_binary_list_id  (name,channel_binary_list_id)
-#  index_channel_binaries_on_project_id_and_package           (project_id,package)
-#  repository_id                                              (repository_id)
-#

--- a/src/api/app/models/channel_binary_list.rb
+++ b/src/api/app/models/channel_binary_list.rb
@@ -10,20 +10,3 @@ class ChannelBinaryList < ApplicationRecord
   end
 end
 
-# == Schema Information
-#
-# Table name: channel_binary_lists
-#
-#  id              :integer          not null, primary key
-#  channel_id      :integer          not null
-#  project_id      :integer
-#  repository_id   :integer
-#  architecture_id :integer
-#
-# Indexes
-#
-#  architecture_id  (architecture_id)
-#  channel_id       (channel_id)
-#  project_id       (project_id)
-#  repository_id    (repository_id)
-#

--- a/src/api/app/models/channel_target.rb
+++ b/src/api/app/models/channel_target.rb
@@ -18,19 +18,3 @@ class ChannelTarget < ApplicationRecord
   end
 end
 
-# == Schema Information
-#
-# Table name: channel_targets
-#
-#  id             :integer          not null, primary key
-#  channel_id     :integer          not null
-#  repository_id  :integer          not null
-#  id_template    :string(255)
-#  disabled       :boolean          default("0")
-#  requires_issue :boolean
-#
-# Indexes
-#
-#  index_channel_targets_on_channel_id_and_repository_id  (channel_id,repository_id) UNIQUE
-#  repository_id                                          (repository_id)
-#

--- a/src/api/app/models/comment.rb
+++ b/src/api/app/models/comment.rb
@@ -98,26 +98,3 @@ class Comment < ApplicationRecord
   end
 end
 
-# == Schema Information
-#
-# Table name: comments
-#
-#  id            :integer          not null, primary key
-#  project_id    :integer
-#  package_id    :integer
-#  bs_request_id :integer
-#  body          :text(65535)
-#  parent_id     :integer
-#  type          :string(255)
-#  created_at    :datetime
-#  updated_at    :datetime
-#  user_id       :integer          not null
-#
-# Indexes
-#
-#  index_comments_on_bs_request_id  (bs_request_id)
-#  index_comments_on_package_id     (package_id)
-#  index_comments_on_project_id     (project_id)
-#  parent_id                        (parent_id)
-#  user_id                          (user_id)
-#

--- a/src/api/app/models/configuration.rb
+++ b/src/api/app/models/configuration.rb
@@ -109,37 +109,3 @@ class Configuration < ApplicationRecord
   end
 end
 
-# == Schema Information
-#
-# Table name: configurations
-#
-#  id                                :integer          not null, primary key
-#  title                             :string(255)      default("")
-#  description                       :text(65535)
-#  created_at                        :datetime
-#  updated_at                        :datetime
-#  name                              :string(255)      default("")
-#  registration                      :string(12)       default("allow")
-#  anonymous                         :boolean          default("1")
-#  default_access_disabled           :boolean          default("0")
-#  allow_user_to_create_home_project :boolean          default("1")
-#  disallow_group_creation           :boolean          default("0")
-#  change_password                   :boolean          default("1")
-#  hide_private_options              :boolean          default("0")
-#  gravatar                          :boolean          default("1")
-#  enforce_project_keys              :boolean          default("0")
-#  download_on_demand                :boolean          default("1")
-#  download_url                      :string(255)
-#  ymp_url                           :string(255)
-#  bugzilla_url                      :string(255)
-#  http_proxy                        :string(255)
-#  no_proxy                          :string(255)
-#  theme                             :string(255)
-#  obs_url                           :string(255)
-#  cleanup_after_days                :integer
-#  cleanup_empty_projects            :boolean          default("1")
-#  disable_publish_for_branches      :boolean          default("1")
-#  admin_email                       :string(255)      default("unconfigured@openbuildservice.org")
-#  default_tracker                   :string(255)      default("bnc")
-#  api_url                           :string(255)
-#

--- a/src/api/app/models/distribution.rb
+++ b/src/api/app/models/distribution.rb
@@ -70,16 +70,3 @@ class Distribution < ApplicationRecord
   end
 end
 
-# == Schema Information
-#
-# Table name: distributions
-#
-#  id         :integer          not null, primary key
-#  vendor     :string(255)      not null
-#  version    :string(255)      not null
-#  name       :string(255)      not null
-#  project    :string(255)      not null
-#  reponame   :string(255)      not null
-#  repository :string(255)      not null
-#  link       :string(255)
-#

--- a/src/api/app/models/distribution_icon.rb
+++ b/src/api/app/models/distribution_icon.rb
@@ -5,12 +5,3 @@ class DistributionIcon < ApplicationRecord
   has_and_belongs_to_many :distributions
 end
 
-# == Schema Information
-#
-# Table name: distribution_icons
-#
-#  id     :integer          not null, primary key
-#  url    :string(255)      not null
-#  width  :integer
-#  height :integer
-#

--- a/src/api/app/models/download_repository.rb
+++ b/src/api/app/models/download_repository.rb
@@ -20,21 +20,3 @@ class DownloadRepository < ApplicationRecord
   end
 end
 
-# == Schema Information
-#
-# Table name: download_repositories
-#
-#  id                   :integer          not null, primary key
-#  repository_id        :integer          not null
-#  arch                 :string(255)      not null
-#  url                  :string(255)      not null
-#  repotype             :string(255)
-#  archfilter           :string(255)
-#  masterurl            :string(255)
-#  mastersslfingerprint :string(255)
-#  pubkey               :text(65535)
-#
-# Indexes
-#
-#  repository_id  (repository_id)
-#

--- a/src/api/app/models/event/base.rb
+++ b/src/api/app/models/event/base.rb
@@ -262,25 +262,3 @@ module Event
   end
 end
 
-# == Schema Information
-#
-# Table name: events
-#
-#  id             :integer          not null, primary key
-#  eventtype      :string(255)      not null
-#  payload        :text(65535)
-#  queued         :boolean          default("0"), not null
-#  lock_version   :integer          default("0"), not null
-#  created_at     :datetime
-#  updated_at     :datetime
-#  project_logged :boolean          default("0")
-#  undone_jobs    :integer          default("0")
-#  mails_sent     :boolean          default("0")
-#
-# Indexes
-#
-#  index_events_on_created_at      (created_at)
-#  index_events_on_eventtype       (eventtype)
-#  index_events_on_project_logged  (project_logged)
-#  index_events_on_queued          (queued)
-#

--- a/src/api/app/models/event/comment.rb
+++ b/src/api/app/models/event/comment.rb
@@ -64,26 +64,3 @@ class Event::CommentForRequest < ::Event::Request
   end
 end
 
-# == Schema Information
-#
-# Table name: comments
-#
-#  id            :integer          not null, primary key
-#  project_id    :integer
-#  package_id    :integer
-#  bs_request_id :integer
-#  body          :text(65535)
-#  parent_id     :integer
-#  type          :string(255)
-#  created_at    :datetime
-#  updated_at    :datetime
-#  user_id       :integer          not null
-#
-# Indexes
-#
-#  index_comments_on_bs_request_id  (bs_request_id)
-#  index_comments_on_package_id     (package_id)
-#  index_comments_on_project_id     (project_id)
-#  parent_id                        (parent_id)
-#  user_id                          (user_id)
-#

--- a/src/api/app/models/event/factory.rb
+++ b/src/api/app/models/event/factory.rb
@@ -1,5 +1,4 @@
 # those contain tons of others
-
 module Event
   # generate an Event class
   class Factory

--- a/src/api/app/models/event/package.rb
+++ b/src/api/app/models/event/package.rb
@@ -133,25 +133,3 @@ module Event
   end
 end
 
-# == Schema Information
-#
-# Table name: events
-#
-#  id             :integer          not null, primary key
-#  eventtype      :string(255)      not null
-#  payload        :text(65535)
-#  queued         :boolean          default("0"), not null
-#  lock_version   :integer          default("0"), not null
-#  created_at     :datetime
-#  updated_at     :datetime
-#  project_logged :boolean          default("0")
-#  undone_jobs    :integer          default("0")
-#  mails_sent     :boolean          default("0")
-#
-# Indexes
-#
-#  index_events_on_created_at      (created_at)
-#  index_events_on_eventtype       (eventtype)
-#  index_events_on_project_logged  (project_logged)
-#  index_events_on_queued          (queued)
-#

--- a/src/api/app/models/event/packtrack.rb
+++ b/src/api/app/models/event/packtrack.rb
@@ -7,25 +7,3 @@ class Event::Packtrack < Event::Base
   create_jobs :update_released_binaries
 end
 
-# == Schema Information
-#
-# Table name: events
-#
-#  id             :integer          not null, primary key
-#  eventtype      :string(255)      not null
-#  payload        :text(65535)
-#  queued         :boolean          default("0"), not null
-#  lock_version   :integer          default("0"), not null
-#  created_at     :datetime
-#  updated_at     :datetime
-#  project_logged :boolean          default("0")
-#  undone_jobs    :integer          default("0")
-#  mails_sent     :boolean          default("0")
-#
-# Indexes
-#
-#  index_events_on_created_at      (created_at)
-#  index_events_on_eventtype       (eventtype)
-#  index_events_on_project_logged  (project_logged)
-#  index_events_on_queued          (queued)
-#

--- a/src/api/app/models/event/project.rb
+++ b/src/api/app/models/event/project.rb
@@ -45,25 +45,3 @@ module Event
   end
 end
 
-# == Schema Information
-#
-# Table name: events
-#
-#  id             :integer          not null, primary key
-#  eventtype      :string(255)      not null
-#  payload        :text(65535)
-#  queued         :boolean          default("0"), not null
-#  lock_version   :integer          default("0"), not null
-#  created_at     :datetime
-#  updated_at     :datetime
-#  project_logged :boolean          default("0")
-#  undone_jobs    :integer          default("0")
-#  mails_sent     :boolean          default("0")
-#
-# Indexes
-#
-#  index_events_on_created_at      (created_at)
-#  index_events_on_eventtype       (eventtype)
-#  index_events_on_project_logged  (project_logged)
-#  index_events_on_queued          (queued)
-#

--- a/src/api/app/models/event/repo_publish_state.rb
+++ b/src/api/app/models/event/repo_publish_state.rb
@@ -4,25 +4,3 @@ class Event::RepoPublishState < Event::Base
   payload_keys :project, :repo, :state
 end
 
-# == Schema Information
-#
-# Table name: events
-#
-#  id             :integer          not null, primary key
-#  eventtype      :string(255)      not null
-#  payload        :text(65535)
-#  queued         :boolean          default("0"), not null
-#  lock_version   :integer          default("0"), not null
-#  created_at     :datetime
-#  updated_at     :datetime
-#  project_logged :boolean          default("0")
-#  undone_jobs    :integer          default("0")
-#  mails_sent     :boolean          default("0")
-#
-# Indexes
-#
-#  index_events_on_created_at      (created_at)
-#  index_events_on_eventtype       (eventtype)
-#  index_events_on_project_logged  (project_logged)
-#  index_events_on_queued          (queued)
-#

--- a/src/api/app/models/event/repo_published.rb
+++ b/src/api/app/models/event/repo_published.rb
@@ -4,25 +4,3 @@ class Event::RepoPublished < Event::Base
   payload_keys :project, :repo
 end
 
-# == Schema Information
-#
-# Table name: events
-#
-#  id             :integer          not null, primary key
-#  eventtype      :string(255)      not null
-#  payload        :text(65535)
-#  queued         :boolean          default("0"), not null
-#  lock_version   :integer          default("0"), not null
-#  created_at     :datetime
-#  updated_at     :datetime
-#  project_logged :boolean          default("0")
-#  undone_jobs    :integer          default("0")
-#  mails_sent     :boolean          default("0")
-#
-# Indexes
-#
-#  index_events_on_created_at      (created_at)
-#  index_events_on_eventtype       (eventtype)
-#  index_events_on_project_logged  (project_logged)
-#  index_events_on_queued          (queued)
-#

--- a/src/api/app/models/event_subscription.rb
+++ b/src/api/app/models/event_subscription.rb
@@ -61,21 +61,3 @@ class EventSubscription < ApplicationRecord
   end
 end
 
-# == Schema Information
-#
-# Table name: event_subscriptions
-#
-#  id            :integer          not null, primary key
-#  eventtype     :string(255)      not null
-#  receiver_role :string(255)      not null
-#  user_id       :integer
-#  created_at    :datetime
-#  updated_at    :datetime
-#  receive       :boolean          default("1"), not null
-#  group_id      :integer
-#
-# Indexes
-#
-#  index_event_subscriptions_on_group_id  (group_id)
-#  index_event_subscriptions_on_user_id   (user_id)
-#

--- a/src/api/app/models/flag.rb
+++ b/src/api/app/models/flag.rb
@@ -176,23 +176,3 @@ class Flag < ApplicationRecord
   end
 end
 
-# == Schema Information
-#
-# Table name: flags
-#
-#  id              :integer          not null, primary key
-#  status          :string(7)        not null
-#  repo            :string(255)
-#  project_id      :integer
-#  package_id      :integer
-#  architecture_id :integer
-#  position        :integer          not null
-#  flag            :string(14)       not null
-#
-# Indexes
-#
-#  architecture_id            (architecture_id)
-#  index_flags_on_flag        (flag)
-#  index_flags_on_package_id  (package_id)
-#  index_flags_on_project_id  (project_id)
-#

--- a/src/api/app/models/group.rb
+++ b/src/api/app/models/group.rb
@@ -1,9 +1,8 @@
 require_dependency 'api_exception'
-
+ 
 # The Group class represents a group record in the database and thus a group
 # in the ActiveRbac model. Groups are arranged in trees and have a title.
 # Groups have an arbitrary number of roles and users assigned to them.
-#
 class Group < ApplicationRecord
   has_many :groups_users, inverse_of: :group, dependent: :destroy
   has_many :group_maintainers, inverse_of: :group, dependent: :destroy
@@ -156,19 +155,3 @@ class Group < ApplicationRecord
   end
 end
 
-# == Schema Information
-#
-# Table name: groups
-#
-#  id         :integer          not null, primary key
-#  created_at :datetime
-#  updated_at :datetime
-#  title      :string(200)      default(""), not null
-#  parent_id  :integer
-#  email      :string(255)
-#
-# Indexes
-#
-#  groups_parent_id_index  (parent_id)
-#  index_groups_on_title   (title)
-#

--- a/src/api/app/models/group_maintainer.rb
+++ b/src/api/app/models/group_maintainer.rb
@@ -15,16 +15,3 @@ class GroupMaintainer < ApplicationRecord
   end
 end
 
-# == Schema Information
-#
-# Table name: group_maintainers
-#
-#  id       :integer          not null, primary key
-#  group_id :integer
-#  user_id  :integer
-#
-# Indexes
-#
-#  group_id  (group_id)
-#  user_id   (user_id)
-#

--- a/src/api/app/models/groups_user.rb
+++ b/src/api/app/models/groups_user.rb
@@ -15,18 +15,3 @@ class GroupsUser < ApplicationRecord
   end
 end
 
-# == Schema Information
-#
-# Table name: groups_users
-#
-#  group_id   :integer          default("0"), not null
-#  user_id    :integer          default("0"), not null
-#  created_at :datetime
-#  email      :boolean          default("1")
-#  id         :integer          not null, primary key
-#
-# Indexes
-#
-#  groups_users_all_index  (group_id,user_id) UNIQUE
-#  user_id                 (user_id)
-#

--- a/src/api/app/models/incident_updateinfo_counter_value.rb
+++ b/src/api/app/models/incident_updateinfo_counter_value.rb
@@ -14,18 +14,3 @@ class IncidentUpdateinfoCounterValue < ApplicationRecord
   end
 end
 
-# == Schema Information
-#
-# Table name: incident_updateinfo_counter_values
-#
-#  id                    :integer          not null, primary key
-#  updateinfo_counter_id :integer          not null
-#  project_id            :integer          not null
-#  value                 :integer          not null
-#  released_at           :datetime         not null
-#
-# Indexes
-#
-#  project_id     (project_id)
-#  uniq_id_index  (updateinfo_counter_id,project_id)
-#

--- a/src/api/app/models/issue.rb
+++ b/src/api/app/models/issue.rb
@@ -142,22 +142,3 @@ class Issue < ApplicationRecord
   end
 end
 
-# == Schema Information
-#
-# Table name: issues
-#
-#  id               :integer          not null, primary key
-#  name             :string(255)      not null
-#  issue_tracker_id :integer          not null
-#  summary          :string(255)
-#  owner_id         :integer
-#  created_at       :datetime
-#  updated_at       :datetime
-#  state            :string(7)
-#
-# Indexes
-#
-#  index_issues_on_name_and_issue_tracker_id  (name,issue_tracker_id)
-#  issue_tracker_id                           (issue_tracker_id)
-#  owner_id                                   (owner_id)
-#

--- a/src/api/app/models/issue_tracker.rb
+++ b/src/api/app/models/issue_tracker.rb
@@ -219,10 +219,10 @@ class IssueTracker < ApplicationRecord
     end
 
     if bugzilla_response["creation_time"].present?
-# rubocop:disable Rails/Date
-# rubocop bug, this is XMLRPC/DateTime not Rails/Date
+      # rubocop:disable Rails/Date
+      # rubocop bug, this is XMLRPC/DateTime not Rails/Date
       issue.created_at = bugzilla_response["creation_time"].to_time
-# rubocop:enable Rails/Date
+      # rubocop:enable Rails/Date
     else
       issue.created_at = Time.now
     end
@@ -371,20 +371,3 @@ class CVEparser < Nokogiri::XML::SAX::Document
   end
 end
 
-# == Schema Information
-#
-# Table name: issue_trackers
-#
-#  id             :integer          not null, primary key
-#  name           :string(255)      not null
-#  kind           :string(11)       not null
-#  description    :string(255)
-#  url            :string(255)      not null
-#  show_url       :string(255)
-#  regex          :string(255)      not null
-#  user           :string(255)
-#  password       :string(255)
-#  label          :text(65535)      not null
-#  issues_updated :datetime         not null
-#  enable_fetch   :boolean          default("0")
-#

--- a/src/api/app/models/linked_project.rb
+++ b/src/api/app/models/linked_project.rb
@@ -19,17 +19,3 @@ class LinkedProject < ApplicationRecord
   end
 end
 
-# == Schema Information
-#
-# Table name: linked_projects
-#
-#  id                         :integer          not null, primary key
-#  db_project_id              :integer          not null
-#  linked_db_project_id       :integer
-#  position                   :integer
-#  linked_remote_project_name :string(255)
-#
-# Indexes
-#
-#  linked_projects_index  (db_project_id,linked_db_project_id) UNIQUE
-#

--- a/src/api/app/models/maintained_project.rb
+++ b/src/api/app/models/maintained_project.rb
@@ -3,16 +3,3 @@ class MaintainedProject < ApplicationRecord
   belongs_to :maintenance_project, class_name: "Project", foreign_key: :maintenance_project_id
 end
 
-# == Schema Information
-#
-# Table name: maintained_projects
-#
-#  id                     :integer          not null, primary key
-#  project_id             :integer          not null
-#  maintenance_project_id :integer          not null
-#
-# Indexes
-#
-#  maintenance_project_id  (maintenance_project_id)
-#  uniq_index              (project_id,maintenance_project_id) UNIQUE
-#

--- a/src/api/app/models/maintenance_incident.rb
+++ b/src/api/app/models/maintenance_incident.rb
@@ -1,5 +1,4 @@
 # The maintenance incident class represents the entry in the database.
-#
 class MaintenanceIncident < ApplicationRecord
   belongs_to :project, class_name: "Project", foreign_key: :db_project_id
   belongs_to :maintenance_db_project, class_name: "Project"
@@ -99,19 +98,3 @@ class MaintenanceIncident < ApplicationRecord
   end
 end
 
-# == Schema Information
-#
-# Table name: maintenance_incidents
-#
-#  id                        :integer          not null, primary key
-#  db_project_id             :integer
-#  maintenance_db_project_id :integer
-#  updateinfo_id             :string(255)
-#  incident_id               :integer
-#  released_at               :datetime
-#
-# Indexes
-#
-#  index_maintenance_incidents_on_db_project_id              (db_project_id)
-#  index_maintenance_incidents_on_maintenance_db_project_id  (maintenance_db_project_id)
-#

--- a/src/api/app/models/message.rb
+++ b/src/api/app/models/message.rb
@@ -4,23 +4,3 @@ class Message < ApplicationRecord
   belongs_to :user
 end
 
-# == Schema Information
-#
-# Table name: messages
-#
-#  id             :integer          not null, primary key
-#  db_object_id   :integer
-#  db_object_type :string(255)
-#  user_id        :integer
-#  created_at     :datetime
-#  send_mail      :boolean
-#  sent_at        :datetime
-#  private        :boolean
-#  severity       :integer
-#  text           :text(65535)
-#
-# Indexes
-#
-#  object  (db_object_id)
-#  user    (user_id)
-#

--- a/src/api/app/models/package.rb
+++ b/src/api/app/models/package.rb
@@ -1390,29 +1390,3 @@ class Package < ApplicationRecord
   end
 end
 
-# == Schema Information
-#
-# Table name: packages
-#
-#  id              :integer          not null, primary key
-#  project_id      :integer          not null
-#  name            :text(65535)
-#  title           :string(255)
-#  description     :text(65535)
-#  created_at      :datetime         default("0000-00-00 00:00:00")
-#  updated_at      :datetime         default("0000-00-00 00:00:00")
-#  url             :string(255)
-#  update_counter  :integer          default("0")
-#  activity_index  :float(24)        default("100")
-#  bcntsynctag     :string(255)
-#  develpackage_id :integer
-#  delta           :boolean          default("1"), not null
-#  releasename     :string(255)
-#
-# Indexes
-#
-#  devel_package_id_index        (develpackage_id)
-#  index_packages_on_project_id  (project_id)
-#  packages_all_index            (project_id,name) UNIQUE
-#  updated_at_index              (updated_at)
-#

--- a/src/api/app/models/package_issue.rb
+++ b/src/api/app/models/package_issue.rb
@@ -35,18 +35,3 @@ class PackageIssue < ApplicationRecord
   end
 end
 
-# == Schema Information
-#
-# Table name: package_issues
-#
-#  id         :integer          not null, primary key
-#  package_id :integer          not null
-#  issue_id   :integer          not null
-#  change     :string(7)
-#
-# Indexes
-#
-#  index_package_issues_on_issue_id                 (issue_id)
-#  index_package_issues_on_package_id               (package_id)
-#  index_package_issues_on_package_id_and_issue_id  (package_id,issue_id)
-#

--- a/src/api/app/models/package_kind.rb
+++ b/src/api/app/models/package_kind.rb
@@ -2,15 +2,3 @@ class PackageKind < ApplicationRecord
   belongs_to :package
 end
 
-# == Schema Information
-#
-# Table name: package_kinds
-#
-#  id         :integer          not null, primary key
-#  package_id :integer
-#  kind       :string(9)        not null
-#
-# Indexes
-#
-#  index_package_kinds_on_package_id  (package_id)
-#

--- a/src/api/app/models/path_element.rb
+++ b/src/api/app/models/path_element.rb
@@ -8,17 +8,3 @@ class PathElement < ApplicationRecord
   validates :repository, uniqueness: { scope: :link }
 end
 
-# == Schema Information
-#
-# Table name: path_elements
-#
-#  id            :integer          not null, primary key
-#  parent_id     :integer          not null
-#  repository_id :integer          not null
-#  position      :integer          not null
-#
-# Indexes
-#
-#  parent_repository_index  (parent_id,repository_id) UNIQUE
-#  repository_id            (repository_id)
-#

--- a/src/api/app/models/product.rb
+++ b/src/api/app/models/product.rb
@@ -163,21 +163,3 @@ class Product < ApplicationRecord
   end
 end
 
-# == Schema Information
-#
-# Table name: products
-#
-#  id          :integer          not null, primary key
-#  name        :string(255)      not null
-#  package_id  :integer          not null
-#  cpe         :string(255)
-#  version     :string(255)
-#  baseversion :string(255)
-#  patchlevel  :string(255)
-#  release     :string(255)
-#
-# Indexes
-#
-#  index_products_on_name_and_package_id  (name,package_id) UNIQUE
-#  package_id                             (package_id)
-#

--- a/src/api/app/models/product_medium.rb
+++ b/src/api/app/models/product_medium.rb
@@ -4,21 +4,3 @@ class ProductMedium < ApplicationRecord
   belongs_to :arch_filter, foreign_key: :arch_filter_id, class_name: "Architecture"
 end
 
-# == Schema Information
-#
-# Table name: product_media
-#
-#  id             :integer          not null, primary key
-#  product_id     :integer
-#  repository_id  :integer
-#  name           :string(255)
-#  arch_filter_id :integer
-#
-# Indexes
-#
-#  index_product_media_on_arch_filter_id  (arch_filter_id)
-#  index_product_media_on_name            (name)
-#  index_unique                           (product_id,repository_id,name,arch_filter_id) UNIQUE
-#  product_id                             (product_id)
-#  repository_id                          (repository_id)
-#

--- a/src/api/app/models/product_update_repository.rb
+++ b/src/api/app/models/product_update_repository.rb
@@ -4,19 +4,3 @@ class ProductUpdateRepository < ApplicationRecord
   belongs_to :arch_filter, foreign_key: :arch_filter_id, class_name: "Architecture"
 end
 
-# == Schema Information
-#
-# Table name: product_update_repositories
-#
-#  id             :integer          not null, primary key
-#  product_id     :integer
-#  repository_id  :integer
-#  arch_filter_id :integer
-#
-# Indexes
-#
-#  index_product_update_repositories_on_arch_filter_id  (arch_filter_id)
-#  index_unique                                         (product_id,repository_id,arch_filter_id) UNIQUE
-#  product_id                                           (product_id)
-#  repository_id                                        (repository_id)
-#

--- a/src/api/app/models/project.rb
+++ b/src/api/app/models/project.rb
@@ -1630,25 +1630,3 @@ class Project < ApplicationRecord
   end
 end
 
-# == Schema Information
-#
-# Table name: projects
-#
-#  id              :integer          not null, primary key
-#  name            :text(65535)
-#  title           :string(255)
-#  description     :text(65535)
-#  created_at      :datetime         default("0000-00-00 00:00:00")
-#  updated_at      :datetime         default("0000-00-00 00:00:00")
-#  remoteurl       :string(255)
-#  remoteproject   :string(255)
-#  develproject_id :integer
-#  delta           :boolean          default("1"), not null
-#  kind            :string(20)       default("standard")
-#
-# Indexes
-#
-#  devel_project_id_index  (develproject_id)
-#  projects_name_index     (name) UNIQUE
-#  updated_at_index        (updated_at)
-#

--- a/src/api/app/models/project_log_entry.rb
+++ b/src/api/app/models/project_log_entry.rb
@@ -70,25 +70,3 @@ class ProjectLogEntry < ApplicationRecord
   end
 end
 
-# == Schema Information
-#
-# Table name: project_log_entries
-#
-#  id              :integer          not null, primary key
-#  project_id      :integer
-#  user_name       :string(255)
-#  package_name    :string(255)
-#  bs_request_id   :integer
-#  datetime        :datetime
-#  event_type      :string(255)
-#  additional_info :text(65535)
-#
-# Indexes
-#
-#  index_project_log_entries_on_bs_request_id  (bs_request_id)
-#  index_project_log_entries_on_datetime       (datetime)
-#  index_project_log_entries_on_event_type     (event_type)
-#  index_project_log_entries_on_package_name   (package_name)
-#  index_project_log_entries_on_user_name      (user_name)
-#  project_id                                  (project_id)
-#

--- a/src/api/app/models/rating.rb
+++ b/src/api/app/models/rating.rb
@@ -3,19 +3,3 @@ class Rating < ApplicationRecord
   belongs_to :packages, class_name: "Package", foreign_key: "db_object_id"
 end
 
-# == Schema Information
-#
-# Table name: ratings
-#
-#  id             :integer          not null, primary key
-#  score          :integer
-#  db_object_id   :integer
-#  db_object_type :string(255)
-#  created_at     :datetime
-#  user_id        :integer
-#
-# Indexes
-#
-#  object  (db_object_id)
-#  user    (user_id)
-#

--- a/src/api/app/models/relationship.rb
+++ b/src/api/app/models/relationship.rb
@@ -177,24 +177,3 @@ class Relationship < ApplicationRecord
   end
 end
 
-# == Schema Information
-#
-# Table name: relationships
-#
-#  id         :integer          not null, primary key
-#  package_id :integer
-#  project_id :integer
-#  role_id    :integer          not null
-#  user_id    :integer
-#  group_id   :integer
-#
-# Indexes
-#
-#  group_id                                                    (group_id)
-#  index_relationships_on_package_id_and_role_id_and_group_id  (package_id,role_id,group_id) UNIQUE
-#  index_relationships_on_package_id_and_role_id_and_user_id   (package_id,role_id,user_id) UNIQUE
-#  index_relationships_on_project_id_and_role_id_and_group_id  (project_id,role_id,group_id) UNIQUE
-#  index_relationships_on_project_id_and_role_id_and_user_id   (project_id,role_id,user_id) UNIQUE
-#  role_id                                                     (role_id)
-#  user_id                                                     (user_id)
-#

--- a/src/api/app/models/release_target.rb
+++ b/src/api/app/models/release_target.rb
@@ -3,17 +3,3 @@ class ReleaseTarget < ApplicationRecord
   belongs_to :target_repository, class_name: 'Repository'
 end
 
-# == Schema Information
-#
-# Table name: release_targets
-#
-#  id                   :integer          not null, primary key
-#  repository_id        :integer          not null
-#  target_repository_id :integer          not null
-#  trigger              :string(12)
-#
-# Indexes
-#
-#  index_release_targets_on_target_repository_id  (target_repository_id)
-#  repository_id_index                            (repository_id)
-#

--- a/src/api/app/models/remote_project.rb
+++ b/src/api/app/models/remote_project.rb
@@ -9,25 +9,3 @@ class RemoteProject < Project
   end
 end
 
-# == Schema Information
-#
-# Table name: projects
-#
-#  id              :integer          not null, primary key
-#  name            :text(65535)
-#  title           :string(255)
-#  description     :text(65535)
-#  created_at      :datetime         default("0000-00-00 00:00:00")
-#  updated_at      :datetime         default("0000-00-00 00:00:00")
-#  remoteurl       :string(255)
-#  remoteproject   :string(255)
-#  develproject_id :integer
-#  delta           :boolean          default("1"), not null
-#  kind            :string(20)       default("standard")
-#
-# Indexes
-#
-#  devel_project_id_index  (develproject_id)
-#  projects_name_index     (name) UNIQUE
-#  updated_at_index        (updated_at)
-#

--- a/src/api/app/models/repository.rb
+++ b/src/api/app/models/repository.rb
@@ -228,22 +228,3 @@ class Repository < ApplicationRecord
   end
 end
 
-# == Schema Information
-#
-# Table name: repositories
-#
-#  id                  :integer          not null, primary key
-#  db_project_id       :integer          not null
-#  name                :string(255)      not null
-#  remote_project_name :string(255)
-#  rebuild             :string(10)
-#  block               :string(5)
-#  linkedbuild         :string(8)
-#  hostsystem_id       :integer
-#
-# Indexes
-#
-#  hostsystem_id              (hostsystem_id)
-#  projects_name_index        (db_project_id,name,remote_project_name) UNIQUE
-#  remote_project_name_index  (remote_project_name)
-#

--- a/src/api/app/models/repository_architecture.rb
+++ b/src/api/app/models/repository_architecture.rb
@@ -8,17 +8,3 @@ class RepositoryArchitecture < ApplicationRecord
   validates :repository, uniqueness: { scope: :architecture }
 end
 
-# == Schema Information
-#
-# Table name: repository_architectures
-#
-#  repository_id   :integer          not null
-#  architecture_id :integer          not null
-#  position        :integer          default("0"), not null
-#  id              :integer          not null, primary key
-#
-# Indexes
-#
-#  arch_repo_index  (repository_id,architecture_id) UNIQUE
-#  architecture_id  (architecture_id)
-#

--- a/src/api/app/models/review.rb
+++ b/src/api/app/models/review.rb
@@ -206,33 +206,3 @@ class Review < ApplicationRecord
   end
 end
 
-# == Schema Information
-#
-# Table name: reviews
-#
-#  id            :integer          not null, primary key
-#  bs_request_id :integer
-#  creator       :string(255)
-#  reviewer      :string(255)
-#  reason        :text(65535)
-#  state         :string(255)
-#  by_user       :string(255)
-#  by_group      :string(255)
-#  by_project    :string(255)
-#  by_package    :string(255)
-#  created_at    :datetime         not null
-#  updated_at    :datetime         not null
-#
-# Indexes
-#
-#  bs_request_id                               (bs_request_id)
-#  index_reviews_on_by_group                   (by_group)
-#  index_reviews_on_by_package_and_by_project  (by_package,by_project)
-#  index_reviews_on_by_project                 (by_project)
-#  index_reviews_on_by_user                    (by_user)
-#  index_reviews_on_creator                    (creator)
-#  index_reviews_on_reviewer                   (reviewer)
-#  index_reviews_on_state                      (state)
-#  index_reviews_on_state_and_by_project       (state,by_project)
-#  index_reviews_on_state_and_by_user          (state,by_user)
-#

--- a/src/api/app/models/role.rb
+++ b/src/api/app/models/role.rb
@@ -91,16 +91,3 @@ class Role < ApplicationRecord
   end
 end
 
-# == Schema Information
-#
-# Table name: roles
-#
-#  id        :integer          not null, primary key
-#  title     :string(100)      default(""), not null
-#  parent_id :integer
-#  global    :boolean          default("0")
-#
-# Indexes
-#
-#  roles_parent_id_index  (parent_id)
-#

--- a/src/api/app/models/roles_static_permission.rb
+++ b/src/api/app/models/roles_static_permission.rb
@@ -3,15 +3,3 @@ class RolesStaticPermission < ApplicationRecord
   belongs_to :static_permission
 end
 
-# == Schema Information
-#
-# Table name: roles_static_permissions
-#
-#  role_id              :integer          default("0"), not null
-#  static_permission_id :integer          default("0"), not null
-#
-# Indexes
-#
-#  role_id                             (role_id)
-#  roles_static_permissions_all_index  (static_permission_id,role_id) UNIQUE
-#

--- a/src/api/app/models/roles_user.rb
+++ b/src/api/app/models/roles_user.rb
@@ -3,17 +3,3 @@ class RolesUser < ApplicationRecord
   belongs_to :role
 end
 
-# == Schema Information
-#
-# Table name: roles_users
-#
-#  user_id    :integer          default("0"), not null
-#  role_id    :integer          default("0"), not null
-#  created_at :datetime
-#  id         :integer          not null, primary key
-#
-# Indexes
-#
-#  role_id                (role_id)
-#  roles_users_all_index  (user_id,role_id) UNIQUE
-#

--- a/src/api/app/models/static_permission.rb
+++ b/src/api/app/models/static_permission.rb
@@ -2,7 +2,6 @@
 # static permission basically only is a string that can be attached to a
 # role. You can then check for it being assigned to a role in your application
 # code.
-#
 class StaticPermission < ApplicationRecord
   has_many :roles_static_permissions
 
@@ -19,14 +18,3 @@ class StaticPermission < ApplicationRecord
   alias_attribute :fixtures_name, :title
 end
 
-# == Schema Information
-#
-# Table name: static_permissions
-#
-#  id    :integer          not null, primary key
-#  title :string(200)      default(""), not null
-#
-# Indexes
-#
-#  static_permissions_title_index  (title) UNIQUE
-#

--- a/src/api/app/models/status_history.rb
+++ b/src/api/app/models/status_history.rb
@@ -8,17 +8,3 @@ class StatusHistory < ApplicationRecord
   end
 end
 
-# == Schema Information
-#
-# Table name: status_histories
-#
-#  id    :integer          not null, primary key
-#  time  :integer
-#  key   :string(255)
-#  value :float(24)        not null
-#
-# Indexes
-#
-#  index_status_histories_on_key           (key)
-#  index_status_histories_on_time_and_key  (time,key)
-#

--- a/src/api/app/models/status_message.rb
+++ b/src/api/app/models/status_message.rb
@@ -9,19 +9,3 @@ class StatusMessage < ApplicationRecord
   end
 end
 
-# == Schema Information
-#
-# Table name: status_messages
-#
-#  id         :integer          not null, primary key
-#  created_at :datetime
-#  deleted_at :datetime
-#  message    :text(65535)
-#  user_id    :integer
-#  severity   :integer
-#
-# Indexes
-#
-#  index_status_messages_on_deleted_at_and_created_at  (deleted_at,created_at)
-#  user                                                (user_id)
-#

--- a/src/api/app/models/tag.rb
+++ b/src/api/app/models/tag.rb
@@ -42,15 +42,3 @@ class Tag < ApplicationRecord
   end
 end
 
-# == Schema Information
-#
-# Table name: tags
-#
-#  id         :integer          not null, primary key
-#  name       :string(255)      not null
-#  created_at :datetime
-#
-# Indexes
-#
-#  tags_name_unique_index  (name) UNIQUE
-#

--- a/src/api/app/models/tagging.rb
+++ b/src/api/app/models/tagging.rb
@@ -9,20 +9,3 @@ class Tagging < ApplicationRecord
                             foreign_key: "taggable_id"
 end
 
-# == Schema Information
-#
-# Table name: taggings
-#
-#  id            :integer          not null, primary key
-#  taggable_id   :integer
-#  taggable_type :string(255)
-#  tag_id        :integer
-#  user_id       :integer
-#
-# Indexes
-#
-#  index_taggings_on_taggable_type  (taggable_type)
-#  tag_id                           (tag_id)
-#  taggings_taggable_id_index       (taggable_id,taggable_type,tag_id,user_id) UNIQUE
-#  user_id                          (user_id)
-#

--- a/src/api/app/models/token.rb
+++ b/src/api/app/models/token.rb
@@ -20,18 +20,3 @@ class Token < ApplicationRecord
   end
 end
 
-# == Schema Information
-#
-# Table name: tokens
-#
-#  id         :integer          not null, primary key
-#  string     :string(255)
-#  user_id    :integer          not null
-#  package_id :integer
-#
-# Indexes
-#
-#  index_tokens_on_string  (string) UNIQUE
-#  package_id              (package_id)
-#  user_id                 (user_id)
-#

--- a/src/api/app/models/unregistered_user.rb
+++ b/src/api/app/models/unregistered_user.rb
@@ -69,27 +69,3 @@ class UnregisteredUser < User
   end
 end
 
-# == Schema Information
-#
-# Table name: users
-#
-#  id                  :integer          not null, primary key
-#  created_at          :datetime
-#  updated_at          :datetime
-#  last_logged_in_at   :datetime
-#  login_failure_count :integer          default("0"), not null
-#  login               :text(65535)
-#  email               :string(200)      default(""), not null
-#  realname            :string(200)      default(""), not null
-#  password            :string(100)      default(""), not null
-#  password_hash_type  :string(20)       default(""), not null
-#  password_salt       :string(10)       default("1234512345"), not null
-#  adminnote           :text(65535)
-#  state               :string(11)       default("unconfirmed")
-#  owner_id            :integer
-#
-# Indexes
-#
-#  users_login_index     (login) UNIQUE
-#  users_password_index  (password)
-#

--- a/src/api/app/models/updateinfo_counter.rb
+++ b/src/api/app/models/updateinfo_counter.rb
@@ -20,14 +20,3 @@ class UpdateinfoCounter < ApplicationRecord
   end
 end
 
-# == Schema Information
-#
-# Table name: updateinfo_counters
-#
-#  id                        :integer          not null, primary key
-#  maintenance_db_project_id :integer
-#  day                       :integer
-#  month                     :integer
-#  year                      :integer
-#  counter                   :integer          default("0")
-#

--- a/src/api/app/models/user.rb
+++ b/src/api/app/models/user.rb
@@ -930,27 +930,3 @@ class User < ApplicationRecord
   end
 end
 
-# == Schema Information
-#
-# Table name: users
-#
-#  id                  :integer          not null, primary key
-#  created_at          :datetime
-#  updated_at          :datetime
-#  last_logged_in_at   :datetime
-#  login_failure_count :integer          default("0"), not null
-#  login               :text(65535)
-#  email               :string(200)      default(""), not null
-#  realname            :string(200)      default(""), not null
-#  password            :string(100)      default(""), not null
-#  password_hash_type  :string(20)       default(""), not null
-#  password_salt       :string(10)       default("1234512345"), not null
-#  adminnote           :text(65535)
-#  state               :string(11)       default("unconfirmed")
-#  owner_id            :integer
-#
-# Indexes
-#
-#  users_login_index     (login) UNIQUE
-#  users_password_index  (password)
-#

--- a/src/api/app/models/watched_project.rb
+++ b/src/api/app/models/watched_project.rb
@@ -7,15 +7,3 @@ class WatchedProject < ApplicationRecord
   validates :user, presence: true
 end
 
-# == Schema Information
-#
-# Table name: watched_projects
-#
-#  id         :integer          not null, primary key
-#  user_id    :integer          default("0"), not null
-#  project_id :integer          not null
-#
-# Indexes
-#
-#  watched_projects_users_fk_1  (user_id)
-#


### PR DESCRIPTION
For unknown reasons we used to have "Schema Information" for each model.
Since this is neither used nor maintained and thus outdated, it's not
worth to keep this around.
If it turns out that we want to have a schema, we should use Rails's
schema.rb anyway.