### PR TITLE
[api][webui] fix migration again

### DIFF
--- a/src/api/db/migrate/20170306084558_change_repositories_remote_project_name_to_not_null.rb
+++ b/src/api/db/migrate/20170306084558_change_repositories_remote_project_name_to_not_null.rb
@@ -13,20 +13,22 @@ class ChangeRepositoriesRemoteProjectNameToNotNull < ActiveRecord::Migration[5.0
 
       repos_with_duplicates = Repository.find_by_sql(sql)
 
-      sql = <<-SQL
-        SELECT b.*
-        FROM repositories a
-        LEFT JOIN repositories AS b
-        ON a.db_project_id = b.db_project_id
-        AND a.name = b.name
-        WHERE a.id != b.id
-        AND a.id IN (#{repos_with_duplicates.map(&:id).join(', ')})
-      SQL
+      if repos_with_duplicates.any?
+        sql = <<-SQL
+          SELECT b.*
+          FROM repositories a
+          LEFT JOIN repositories AS b
+          ON a.db_project_id = b.db_project_id
+          AND a.name = b.name
+          WHERE a.id != b.id
+          AND a.id IN (#{repos_with_duplicates.map(&:id).join(', ')})
+        SQL
 
-      duplicate_repos = Repository.find_by_sql(sql)
+        duplicate_repos = Repository.find_by_sql(sql)
 
-      # must be a ruby loop for the path_elements and reference cleanup
-      duplicate_repos.each(&:destroy)
+        # must be a ruby loop for the path_elements and reference cleanup
+        duplicate_repos.each(&:destroy)
+      end
 
       execute 'UPDATE repositories SET remote_project_name = "" WHERE remote_project_name is null'
 


### PR DESCRIPTION
While I tested this migration against data from the production server which has duplicate repositories, This migration will fail on any instances that don't have duplicate repos! This fixes the migration (again).