### PR TITLE
[api] don't allow to create requests with same target actions

### DIFF
--- a/src/api/app/models/bs_request.rb
+++ b/src/api/app/models/bs_request.rb
@@ -56,6 +56,7 @@ class BsRequest < ApplicationRecord
   validates :creator, presence: true
   validate :check_supersede_state
   validate :check_creator, on: [:create, :save!]
+  validate :conflicting_actions, on: [:create, :save!]
   validates :comment, length: { maximum: 300000 }
   validates :description, length: { maximum: 300000 }
 
@@ -105,6 +106,21 @@ class BsRequest < ApplicationRecord
     end
     return if user.is_active?
     errors.add(:creator, "Login #{user.login} is not an active user")
+  end
+
+  def conflicting_actions
+    bs_request_actions.each do |actionA|
+      bs_request_actions.each do |actionB|
+        next if actionA == actionB
+        next if actionA.type == "add_role" # the exception that proves the rule
+        next if actionA.type == "maintenance_incident" # we could extend the check for package link target
+        if actionA.type == actionB.type &&
+           actionA.target_project == actionB.target_project &&
+           actionA.target_package == actionB.target_package
+          errors.add(:invalid, "double action for #{actionB.try(:target_project)}/#{actionB.try(:target_package)} ")
+        end
+      end
+    end
   end
 
   def assign_number


### PR DESCRIPTION
It makes usually no sense to manipulate the same target with the same operation.
The one and only exception is "add_role" since you can requests to add multiple
roles to the same target.

We saw this kind of error happening multiple times when having broken source
setup. It can lead to all kind of follow up errors, so let's protect us and
tell the user his problem as early as possible