### PR TITLE
[api] Solve `password_changes_with_hash_type` bug

### DIFF
--- a/src/api/app/models/user.rb
+++ b/src/api/app/models/user.rb
@@ -100,7 +100,7 @@ class User < ApplicationRecord
   # Checks that the password got updated after password hash type changed
   def password_changes_with_hash_type
     # rubocop:disable Style/GuardClause
-    if password_hash_type_changed? && (!password_changed? || password_was.nil?)
+    if password_hash_type_changed? && !password_was.nil? && !password_changed?
       errors.add(:password_hash_type, 'cannot be changed unless a new password has been provided.')
     end
     # rubocop:enable Style/GuardClause


### PR DESCRIPTION
When the hash type is changed, the password should be updated, except if it was `nil?`. In that case we don't care if it is updated or not. But that was not what the method was doing. It failed when the password was not changed and and when it was changed but it was `nil` before, as `!password_changed` was `false` but `password_was.nil?` was `true`. :bowtie: 