### PR TITLE
[api] don't require meta=1 for package/_meta

### DIFF
--- a/src/api/app/controllers/source_controller.rb
+++ b/src/api/app/controllers/source_controller.rb
@@ -641,7 +641,7 @@ class SourceController < ApplicationController
 
     pack = Package.get_by_project_and_name(@project_name, @package_name, use_source: false)
 
-    if params.has_key?(:meta) || pack.nil?
+    if params.has_key?(:meta) || params.has_key?(:rev) || params.has_key?(:view) || pack.nil?
        # check if this comes from a remote project, also true for _project package
        # or if meta is specified we need to fetch the meta from the backend
       path = request.path_info

--- a/src/api/test/functional/source_controller_test.rb
+++ b/src/api/test/functional/source_controller_test.rb
@@ -1864,6 +1864,10 @@ EOF
     get '/source/kde4/_project/_meta?view=blame&meta=1'
     assert_response :success
     assert_match(/^   1 \(king/, @response.body)
+    # should also work without the extra meta argument since it is _meta
+    get '/source/kde4/_project/_meta?view=blame'
+    assert_response :success
+    assert_match(/^   1 \(king/, @response.body)
 
     # cleanup
     delete '/source/kde4/BLAME'
@@ -3777,9 +3781,6 @@ EOF
 
     get '/source/home:Iggy/TestPack/_meta'
     assert_equal original, @response.body
-
-    get '/source/home:Iggy/TestPack/_meta?view=flagdetails'
-    assert_response :success
   end
 
   def test_project_remove_flag
@@ -3824,9 +3825,6 @@ EOF
 
     get '/source/home:Iggy/_meta'
     assert_equal original, @response.body
-
-    get '/source/home:Iggy/_meta?view=flagdetails'
-    assert_response :success
   end
 
   def test_wild_chars


### PR DESCRIPTION
This is in sync with backend behaviour and also with api project/_meta now.

This also drops the incomplete tests of view=flagdetails, which was retired in

 87e08a88d7b32709af17c71cff97e50fb7afbb73

but no one noticed the breakage due to HTTP code only checking.