### PR TITLE
[api] BackendFile should return "" instead of nil for invalid file.

### DIFF
--- a/src/api/app/models/backend_file.rb
+++ b/src/api/app/models/backend_file.rb
@@ -57,7 +57,7 @@ class BackendFile
   # Converts file into a String if it's valid
   def to_s(query = {})
     file(query)
-    !@file.nil? && valid? ? File.open(@file.path).read : nil
+    !@file.nil? && valid? ? File.open(@file.path).read : ""
   end
 
   # Reloads from Backend the file content


### PR DESCRIPTION
See [usage in `obs_factory` for context](https://github.com/openSUSE/obs_factory/pull/72#discussion_r106800262). Suffice to say, returning `nil` from `to_s` seems to break the interface.