### PR TITLE
[ci] Reload page before testing it

### DIFF
--- a/src/api/test/functional/webui/package_branch_test.rb
+++ b/src/api/test/functional/webui/package_branch_test.rb
@@ -81,7 +81,10 @@ class Webui::PackageBranchTest < Webui::IntegrationTest
       name: 'TestPack_double_branch',
       original_name: 'TestPack_link',
       original_project: 'home:Iggy')
+
     Suse::Backend.put('/source/home:Iggy/TestPack_double_branch/new_file', "test 2")
+    # Reload page after updating file (new revision)
+    visit page.current_path
 
     # submit
     click_link 'Submit package'


### PR DESCRIPTION
Between creating a branch and testing package submission we do a backend
request which creates a new package revision.
The revision is part of the package show page and might be needed by the
test (it actually is needed with pr #2829).