### PR TITLE
[api] fix review table locking on request review change

### DIFF
--- a/src/api/app/models/bs_request.rb
+++ b/src/api/app/models/bs_request.rb
@@ -608,6 +608,7 @@ class BsRequest < ApplicationRecord
 
   def change_review_state(new_review_state, opts = {})
     with_lock do
+    Review.transaction do
       new_review_state = new_review_state.to_sym
 
       unless state == :review || (state == :new && new_review_state == :new)
@@ -623,7 +624,7 @@ class BsRequest < ApplicationRecord
       found = false
 
       reviews_seen = Hash.new
-      reviews.reverse_each do |review|
+      reviews.lock(true).reverse_each do |review|
         matching = true
         matching = false if review.by_user && review.by_user != opts[:by_user]
         matching = false if review.by_group && review.by_group != opts[:by_group]
@@ -708,6 +709,7 @@ class BsRequest < ApplicationRecord
       if go_new_state == :new && accept_at
         Delayed::Job.enqueue AcceptRequestsJob.new
       end
+    end
     end
   end
 

--- a/src/api/test/unit/code_quality_test.rb
+++ b/src/api/test/unit/code_quality_test.rb
@@ -64,7 +64,7 @@ class CodeQualityTest < ActiveSupport::TestCase
       'BranchPackage#determine_details_about_package_to_branch'                 => 101.48,
       'BranchPackage#lookup_incident_pkg'                                       => 83.09,
       'BranchPackage#extend_packages_to_link'                                   => 80.23,
-      'BsRequest#change_review_state'                                           => 212.16,
+      'BsRequest#change_review_state'                                           => 227.53,
       'BsRequest#apply_default_reviewers'                                       => 129.52,
       'BsRequest#webui_actions'                                                 => 130.13,
       'BsRequest::new_from_xml'                                                 => 113.77,


### PR DESCRIPTION
hopefully...

Might be a fix for https://github.com/openSUSE/open-build-service/issues/2888 but done in a hurry without testing