### PR TITLE
Enable Rubocop for Vagrantfile and docs/

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -10,6 +10,11 @@ AllCops:
     - 'src/api/vendor/bundle/**/*'
     - 'docs/api/restility/**/*'
 
+# Find uses of alias where alias_method would be more appropriate (or is simply preferred due to configuration), and vice versa.
+# It also finds uses of alias :symbol rather than alias bareword.
+Style/Alias:
+  EnforcedStyle: 'prefer_alias_method'
+
 # Align the elements of a hash literal if they span more than one line.
 Style/AlignHash:
   # Alignment of entries using hash rocket as separator.

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -8,7 +8,6 @@ AllCops:
     - 'src/api/tmp/**/*'
     - 'src/api/lib/templates/**/*'
     - 'src/api/vendor/bundle/**/*'
-    - 'Vagrantfile'
     - 'docs/**/*'
 
 # Align the elements of a hash literal if they span more than one line.

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -8,7 +8,7 @@ AllCops:
     - 'src/api/tmp/**/*'
     - 'src/api/lib/templates/**/*'
     - 'src/api/vendor/bundle/**/*'
-    - 'docs/**/*'
+    - 'docs/api/restility/**/*'
 
 # Align the elements of a hash literal if they span more than one line.
 Style/AlignHash:

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -241,15 +241,6 @@ Style/AccessorMethodName:
     - 'src/api/app/models/user.rb'
     - 'src/api/test/functional/search_controller_test.rb'
 
-# Offense count: 5
-# Cop supports --auto-correct.
-# Configuration parameters: EnforcedStyle, SupportedStyles.
-# SupportedStyles: prefer_alias, prefer_alias_method
-Style/Alias:
-  Exclude:
-    - 'src/api/app/models/attrib.rb'
-    - 'src/api/lib/opensuse/backend.rb'
-
 # Offense count: 19
 # Cop supports --auto-correct.
 Style/AlignArray:

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,8 +1,8 @@
 # -*- mode: ruby -*-
 # vi: set ft=ruby :
 
-dev_mem = (ENV["OBS_VAGRANT_MEM"]) ? ENV["OBS_VAGRANT_MEM"] : 2048
-dev_cpu = (ENV["OBS_VAGRANT_CPU"]) ? ENV["OBS_VAGRANT_CPU"] : 2
+dev_mem = ENV["OBS_VAGRANT_MEM"] ? ENV["OBS_VAGRANT_MEM"] : 2048
+dev_cpu = ENV["OBS_VAGRANT_CPU"] ? ENV["OBS_VAGRANT_CPU"] : 2
 
 # Vagrantfile API/syntax version. Don't touch unless you know what you're doing!
 VAGRANTFILE_API_VERSION = '2'
@@ -12,9 +12,9 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   # options are documented and commented below. For a complete reference,
   # please see the online documentation at vagrantup.com.
 
-  #calculate memory allocation
+  # Calculate memory allocation
   # Every Vagrant virtual environment requires a box to build off of.
-  config.vm.define "development" , primary: true do |fe|
+  config.vm.define "development", primary: true do |fe|
     fe.vm.box = 'opensuse/openSUSE-42.1-x86_64'
     # Provision the box with a simple shell script
     fe.vm.provision :shell, inline: '/vagrant/contrib/bootstrap.sh'
@@ -78,5 +78,4 @@ SCRIPT
       # for documentation purpose
       # config.vm.synced_folder './', '/vagrant', type: '9p', disabled: false
   end
-
 end

--- a/docs/dev/controller_template_example.rb
+++ b/docs/dev/controller_template_example.rb
@@ -11,8 +11,8 @@ class Webui::DogsController < ApplicationController
   #### Callbacks macros: before_action, after_action, etc.
   before_action :set_dog, only: [:show, :edit, :update, :destroy]
   # Pundit authorization policies control
-  after_action :verify_authorized, :except => [:index, :blacks]
-  after_action :verify_policy_scoped, :only => [:index, :blacks]
+  after_action :verify_authorized, except: [:index, :blacks]
+  after_action :verify_policy_scoped, only: [:index, :blacks]
 
   #### CRUD actions
 
@@ -79,26 +79,25 @@ class Webui::DogsController < ApplicationController
     render :index
   end
 
-  #### Non actions methods 
+  #### Non actions methods
   # Use hide_action if they are not private
 
   def call_them(dogs = [])
     say("Hey!")
-    dogs.each do |dog|
-      dog.bark
-    end
+    dogs.each(&:bark)
   end
 
   hide_action :call_them
 
   private
-    # Use callbacks to share common setup or constraints between actions.
-    def set_dog
-      @dog = Dog.find(params[:id])
-    end
 
-    # Only allow a trusted parameter "white list" through.
-    def dog_params
-      params.require(:dog).permit(:name, :color)
-    end
+  # Use callbacks to share common setup or constraints between actions.
+  def set_dog
+    @dog = Dog.find(params[:id])
+  end
+
+  # Only allow a trusted parameter "white list" through.
+  def dog_params
+    params.require(:dog).permit(:name, :color)
+  end
 end

--- a/docs/dev/model_template_example.rb
+++ b/docs/dev/model_template_example.rb
@@ -78,7 +78,7 @@ class Dog < ActiveRecord::Base
 
   def bark
     say('Guau!')
-    @number_of_barks++
+    @number_of_barks += 1
   end
 
   def cry

--- a/docs/dev/model_template_example.rb
+++ b/docs/dev/model_template_example.rb
@@ -54,17 +54,12 @@ class Dog < ActiveRecord::Base
 
   def self.killall_by(attributes = {})
     say("Die!")
-    where(attributes).each do |dog|
-      dog.kill
-    end
+    where(attributes).each(&:kill)
   end
 
   def self.call_all
     say("Fiuuiuuuu!")
-    all.each do |dog|
-      dog.bark
-    end
-
+    all.each(&:bark)
   end
 
   #### private
@@ -75,8 +70,8 @@ class Dog < ActiveRecord::Base
 
   private_class_method :say
 
-  #### Instance methods (public and then protected/private) 
-  def initialize(attributes={})
+  #### Instance methods (public and then protected/private)
+  def initialize(attributes = {})
     super
     @number_of_barks = 0
   end
@@ -101,5 +96,4 @@ class Dog < ActiveRecord::Base
   def reset_attribute(attribute)
     send("#{attribute}=", 0)
   end
-
 end

--- a/src/api/app/models/attrib.rb
+++ b/src/api/app/models/attrib.rb
@@ -118,7 +118,7 @@ class Attrib < ApplicationRecord
   end
 
   #### Alias of methods
-  alias :values_addable? :values_removeable?
+  alias_method :values_addable?, :values_removeable?
 
   private
 

--- a/src/api/app/models/role.rb
+++ b/src/api/app/models/role.rb
@@ -70,7 +70,7 @@ class Role < ApplicationRecord
   def to_s
     title
   end
-  alias to_param to_s
+  alias_method :to_param, :to_s
 end
 
 # == Schema Information

--- a/src/api/test/test_helper.rb
+++ b/src/api/test/test_helper.rb
@@ -170,7 +170,7 @@ module ActionDispatch
         headers
       end
 
-      alias real_process process_with_kwargs
+      alias_method :real_process, :process_with_kwargs
 
       def process_with_kwargs(http_method, path, *args)
         CONFIG['global_write_through'] = true


### PR DESCRIPTION
Enable Rubocop for Vagrantfile.

Enable Rubocop for `docs/dev/*` files and fix Rubocop complains.

`docs/api/restility/*` files are left in the `Exclude` section. These files must be fixed by Rubocop upstream, in [restility](https://github.com/openSUSE/restility) project.

Pair programmed with @dkang.