### PR TITLE
[ci] Specify version of rubocop. Needed for Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ matrix:
       bundler: true
       directories:
         - tmp/rubocop_cache
-    before_install: gem install rubocop
+    before_install: gem install rubocop -v 0.47.1
     before_script: ''
 notifications:
   irc:


### PR DESCRIPTION
Travis works with version 0.48 of rubocop. Rubocop configuration was created for 0.47.1 rubocop version. This is a temporal fix for making the actual pull request to pass Travis without errors.