### PR TITLE
[webui] fix wrong repository errors in monitor

### DIFF
--- a/src/api/app/helpers/webui/webui_helper.rb
+++ b/src/api/app/helpers/webui/webui_helper.rb
@@ -118,7 +118,7 @@ module Webui::WebuiHelper
 
     description = REPO_STATUS_DESCRIPTIONS[status] || 'Unknown state of repository'
     description = 'State needs recalculations, former state was: ' + description if outdated
-    description << " (" + details + ")" if details
+    description += " (" + details + ")" if details
 
     sprite_tag icon, title: description
   end


### PR DESCRIPTION
Before:
![screenshot from 2017-04-03 01-27-13](https://cloud.githubusercontent.com/assets/1212806/24591986/50b30790-180e-11e7-93a9-0268a4515dfc.png)

After:
![screenshot from 2017-04-03 01-28-20](https://cloud.githubusercontent.com/assets/1212806/24591988/5af13bf0-180e-11e7-821b-af5b3714d5fc.png)
![screenshot from 2017-04-03 01-37-11](https://cloud.githubusercontent.com/assets/1212806/24591989/5f4bd35e-180e-11e7-9ecc-8439faa66d2b.png)
