### PR TITLE
Use proper :filename instead of :file in public_build route

### DIFF
--- a/src/api/config/routes.rb
+++ b/src/api/config/routes.rb
@@ -635,7 +635,7 @@ OBSApi::Application.routes.draw do
       get 'public/source/:project/:package/:filename' => :source_file, constraints: cons
       get 'public/distributions' => :distributions
       get 'public/binary_packages/:project/:package' => :binary_packages, constraints: cons
-      get 'public/build/:project(/:repository(/:arch(/:package(/:file))))' => 'public#build', constraints: cons, as: :public_build
+      get 'public/build/:project(/:repository(/:arch(/:package(/:filename))))' => 'public#build', constraints: cons, as: :public_build
     end
 
     get '/404' => 'main#notfound'


### PR DESCRIPTION
Otherwise the filename constraint does not match and we end up
in rather random rails route matching