### PR TITLE
[ci] Enable ClassesBeforeIds HAML-Lint linter

### DIFF
--- a/src/api/.haml-lint_todo.yml
+++ b/src/api/.haml-lint_todo.yml
@@ -7,30 +7,6 @@
 # versions of Haml-Lint, may require this file to be generated again.
 
 linters:
-
-  # Offense count: 26
-  ClassesBeforeIds:
-    exclude:
-      - "app/views/shared/_requests.html.haml"
-      - "app/views/webui/attribute/new.html.haml"
-      - "app/views/webui/configuration/_tabs.html.haml"
-      - "app/views/webui/groups/index.html.haml"
-      - "app/views/webui/main/_add_news_dialog.html.haml"
-      - "app/views/webui/main/_delete_message_dialog.html.haml"
-      - "app/views/webui/main/_news.html.haml"
-      - "app/views/webui/main/_systemstatus.html.haml"
-      - "app/views/webui/monitor/_building_table.html.haml"
-      - "app/views/webui/monitor/_events.html.haml"
-      - "app/views/webui/monitor/_lights.html.haml"
-      - "app/views/webui/monitor/_workers_table.html.haml"
-      - "app/views/webui/package/_submit_request_dialog.html.haml"
-      - "app/views/webui/patchinfo/_delete_dialog.html.haml"
-      - "app/views/webui/project/subprojects.html.haml"
-      - "app/views/webui/search/_tabs.html.haml"
-      - "app/views/webui/theme/bento/layouts/webui/_header.html.haml"
-      - "app/views/webui/user/_password_dialog.html.haml"
-      - "app/views/webui/user/show.html.haml"
-
   # Offense count: 63
   IdNames:
     exclude:

--- a/src/api/app/views/shared/_requests.html.haml
+++ b/src/api/app/views/shared/_requests.html.haml
@@ -1,7 +1,7 @@
 - if requests.blank?
   %p No requests.
 - else
-  %table#request_table.compact{:width => '100%'}
+  %table.compact#request_table{:width => '100%'}
     %thead
       %tr
         %th Created

--- a/src/api/app/views/webui/attribute/new.html.haml
+++ b/src/api/app/views/webui/attribute/new.html.haml
@@ -18,7 +18,7 @@
       = f.select :attrib_type_id, AttribType.all.collect { |a| [ a.fullname, a.id] }.sort, include_blank: false
       = hidden_field_tag("attrib[project_id]", @attribute.project_id)
       = hidden_field_tag("attrib[package_id]", @attribute.package_id) if @attribute.package_id
-  %p#first-help.help-block
+  %p.help-block#first-help
     = AttribType.all.to_a.sort_by { |t| t.fullname }.first.description
     = "Sorry, this attribute has no description" if AttribType.all.to_a.sort_by { |t| t.fullname }.first.description.blank?
   - AttribType.all.each do |type|

--- a/src/api/app/views/webui/configuration/_tabs.html.haml
+++ b/src/api/app/views/webui/configuration/_tabs.html.haml
@@ -1,4 +1,4 @@
-#configuration_tabs.box-header.header-tabs
+.box-header.header-tabs#configuration_tabs
   %ul
     = tab 'configuration', 'Configuration', controller: :configuration, action: :index
     = tab 'architectures', 'Architectures', controller: :architectures, action: :index

--- a/src/api/app/views/webui/groups/index.html.haml
+++ b/src/api/app/views/webui/groups/index.html.haml
@@ -6,7 +6,7 @@
   %p
     Manage groups.
   - unless @groups.empty?
-    %table#group_table.compact
+    %table.compact#group_table
       %thead
         %tr
           %th Group name

--- a/src/api/app/views/webui/main/_add_news_dialog.html.haml
+++ b/src/api/app/views/webui/main/_add_news_dialog.html.haml
@@ -1,4 +1,4 @@
-#disable_mask.dialog
+.dialog#disable_mask
 .dialog.darkgrey_box
   .box.box-shadow
     %h2.box-header Add New Message

--- a/src/api/app/views/webui/main/_delete_message_dialog.html.haml
+++ b/src/api/app/views/webui/main/_delete_message_dialog.html.haml
@@ -1,4 +1,4 @@
-#disable_mask.dialog
+.dialog#disable_mask
 .dialog.darkgrey_box
   .box.box-shadow
     %h2.box-header Delete Confirmation

--- a/src/api/app/views/webui/main/_news.html.haml
+++ b/src/api/app/views/webui/main/_news.html.haml
@@ -1,5 +1,5 @@
 - if @news.present? || User.current.is_admin?
-  #messages.box.box-shadow
+  .box.box-shadow#messages
     %h2.box-header
       Announcements
       \#{link_to('', news_feed_path(format: 'rss'), { class: 'alignright icons-feeds', title: "RSS Feed" })}

--- a/src/api/app/views/webui/main/_systemstatus.html.haml
+++ b/src/api/app/views/webui/main/_systemstatus.html.haml
@@ -1,7 +1,7 @@
 .box.box-shadow
   %h2.box-header System Status
   - if @busy
-    #overallgraph.aligncenter{ style: "height:250px; margin: 0px 20px 20px 20px" }
+    .aligncenter#overallgraph{ style: "height:250px; margin: 0px 20px 20px 20px" }
     %p.description
       The above graphs show the number of active build jobs last week,
       currently #{@building_workers} of #{@overall_workers} build hosts

--- a/src/api/app/views/webui/monitor/_building_table.html.haml
+++ b/src/api/app/views/webui/monitor/_building_table.html.haml
@@ -1,6 +1,6 @@
 #building_list
   - if @workerstatus.has_key? 'building'
-    %table#building_table.building
+    %table.building#building_table
       %thead
         %tr
           %th Project

--- a/src/api/app/views/webui/monitor/_events.html.haml
+++ b/src/api/app/views/webui/monitor/_events.html.haml
@@ -14,20 +14,20 @@
   #building{ style: "height:250px; margin-right: 20px" }
   .centered
     Workers
-    %span#legend_building.flot_legend
+    %span.flot_legend#legend_building
   .plotspinner= image_tag('ajax-loader.gif')
 .clear
 .grid_8.alpha
   #events{ style: "height:250px; margin-left: 20px; margin-right: 20px" }
   .centered
     Repositories to recalculate
-    %span#legend_events.flot_legend
+    %span.flot_legend#legend_events
   .plotspinner= image_tag('ajax-loader.gif')
 .grid_8.omega
   #jobs{ style: "height:250px; margin-right: 20px" }
   .centered
     Packages scheduled for building
-    %span#legend_jobs.flot_legend
+    %span.flot_legend#legend_jobs
   .plotspinner= image_tag('ajax-loader.gif')
 .clear
 

--- a/src/api/app/views/webui/monitor/_lights.html.haml
+++ b/src/api/app/views/webui/monitor/_lights.html.haml
@@ -1,7 +1,7 @@
 = content_for :ready_function do
   monitor_ready();
 
-#serverstatus.statuslights
+.statuslights#serverstatus
   %h2 Server Status
   - @workerstatus.elements("partition") do |part|
     - unless part["name"].blank?

--- a/src/api/app/views/webui/monitor/_workers_table.html.haml
+++ b/src/api/app/views/webui/monitor/_workers_table.html.haml
@@ -81,9 +81,9 @@
           %option{ value: "project" } Project
           %option{ value: "repository" } Repository
           %option{ value: "arch" } Architecture
-%h2#workers_title.nowrap
+%h2.nowrap#workers_title
   Workers
-  %span#workers_updating.hidden (updating...)
+  %span.hidden#workers_updating (updating...)
 %div
   %p
     This shows the single workers and their jobs. The

--- a/src/api/app/views/webui/package/_submit_request_dialog.html.haml
+++ b/src/api/app/views/webui/package/_submit_request_dialog.html.haml
@@ -1,4 +1,4 @@
-#disable_mask.dialog
+.dialog#disable_mask
 .dialog.darkgrey_box
   .box.box-shadow
     %h2.box-header Create Submit Request
@@ -38,7 +38,7 @@
         ~ text_area_tag(:description, '', size: '40x3')
         %br/
 
-        %span#supersede_display.hidden
+        %span.hidden#supersede_display
           = label_tag(:supersede_requests, 'Supersede requests:')
           %br/
           %span#supersede_requests
@@ -47,7 +47,7 @@
           = check_box_tag(:sourceupdate, 'cleanup', @cleanup_source)
           = label_tag(:sourceupdate, 'Remove local package if request is accepted')
 
-      %p#devel_project_warning.hidden
+      %p.hidden#devel_project_warning
         You are about to bypass the devel project, please submit to
         %b#devel_project_name
         instead.

--- a/src/api/app/views/webui/patchinfo/_delete_dialog.html.haml
+++ b/src/api/app/views/webui/patchinfo/_delete_dialog.html.haml
@@ -1,5 +1,5 @@
-#disable_mask.dialog
-#del_dialog.dialog.darkgrey_box
+.dialog#disable_mask
+.darkgrey_box.dialog#del_dialog
   .box.box-shadow
     %h2.box-header Delete Confirmation
     .dialog-content

--- a/src/api/app/views/webui/project/subprojects.html.haml
+++ b/src/api/app/views/webui/project/subprojects.html.haml
@@ -49,7 +49,7 @@
 - if User.current.can_modify_project?(@project)
   %p
     = link_to sprite_tag('brick_add', title: 'New subproject') + ' New subproject', '#', id: 'create_subproject_link'
-    #create_subproject.hidden
+    .hidden#create_subproject
       = render partial: 'form', locals: { project: Project.new, configuration: @configuration, ns: @project.name }
 
 - if @subprojects.present? || @parentprojects.present?

--- a/src/api/app/views/webui/search/_tabs.html.haml
+++ b/src/api/app/views/webui/search/_tabs.html.haml
@@ -1,4 +1,4 @@
-#search_tabs.box-header.header-tabs
+.box-header.header-tabs#search_tabs
   %ul
     = tab 'index', 'Packages/Projects', controller: 'search', action: 'index'
     = tab 'owner', 'Owners', controller: 'search', action: 'owner'

--- a/src/api/app/views/webui/theme/bento/layouts/webui/_header.html.haml
+++ b/src/api/app/views/webui/theme/bento/layouts/webui/_header.html.haml
@@ -1,6 +1,6 @@
 / Start: Header
 #header
-  #header-content.container_12
+  .container_12#header-content
     = link_to sprite_tag( "header-logo" ), root_path, { id: "header-logo" }
     %ul#global-navigation
       %li#item-downloads

--- a/src/api/app/views/webui/user/_password_dialog.html.haml
+++ b/src/api/app/views/webui/user/_password_dialog.html.haml
@@ -1,4 +1,4 @@
-#disable_mask.dialog
+.dialog#disable_mask
 .dialog.darkgrey_box
   .box.box-shadow
     %h2.box-header Change Your Password

--- a/src/api/app/views/webui/user/show.html.haml
+++ b/src/api/app/views/webui/user/show.html.haml
@@ -2,7 +2,7 @@
 - @layouttype = 'custom'
 - @crumb_list = [@pagetitle]
 / user
-#userinfo.grid_4.alpha.box.box-shadow
+.grid_4.alpha.box.box-shadow#userinfo
   / avatar
   = user_icon(@displayed_user, 200, 'home-avatar') if @displayed_user.email
   / info
@@ -56,7 +56,7 @@
           %a{href: "#iprojects", title: "Projects that you are involved with"} Involved Projects
         %li
           %a{href: "#iowned", title: "Projects/Packages where you are responsible for the maintenance"} Owned Project/Packages
-    #ipackages.tab
+    .tab#ipackages
       - if @ipackages.length > 0
         #ipackages_wrapper{ "data-url": url_for(controller: 'package', action: 'show', project: 'REPLACEPRJ', package: 'REPLACEPKG') }
           - content_for :ready_function do


### PR DESCRIPTION
Classes should be listed before than IDs in tags.

HAML-Lint doesn't provide autocorrect so the offenses were manually solved. :bowtie: 