### PR TITLE
[webui] Enable peek gem for production

### DIFF
--- a/src/api/app/controllers/application_controller.rb
+++ b/src/api/app/controllers/application_controller.rb
@@ -44,6 +44,10 @@ class ApplicationController < ActionController::Base
     return User.current unless User.current.is_nobody?
   end
 
+  def peek_enabled?
+    User.current && (User.current.is_admin? || User.current.is_staff?)
+  end
+
   def permissions
     authenticator.user_permissions
   end

--- a/src/api/config/environments/production.rb
+++ b/src/api/config/environments/production.rb
@@ -66,6 +66,8 @@ OBSApi::Application.configure do
 
   # Do not dump schema after migrations.
   config.active_record.dump_schema_after_migration = false
+
+  config.peek.adapter = :memcache
 end
 
 # disabled on production for performance reasons

--- a/src/api/config/routes.rb
+++ b/src/api/config/routes.rb
@@ -25,6 +25,8 @@ class APIMatcher
 end
 
 OBSApi::Application.routes.draw do
+  mount Peek::Railtie => '/peek'
+
   cons = {
     arch:       %r{[^\/]*},
     binary:     %r{[^\/]*},
@@ -704,8 +706,3 @@ OBSApi::Application.routes.draw do
 end
 
 OBSEngine::Base.subclasses.each(&:mount_it)
-
-OBSApi::Application.routes.draw do
-  mount Peek::Railtie => '/peek'
-  root :to => 'home#show'
-end


### PR DESCRIPTION
The peek ResultsController inheritates from ApplicationController, therefore we also need peek_enabled in ApplicationController.