### PR TITLE
[api] Maintenance statistics

### DIFF
--- a/src/api/app/models/history_element.rb
+++ b/src/api/app/models/history_element.rb
@@ -38,16 +38,6 @@ class HistoryElement::Request < ::HistoryElement::Base
   end
 end
 
-class HistoryElement::RequestCreated < HistoryElement::Request
-  def color
-    'black'
-  end
-
-  def description
-    'Request created'
-  end
-end
-
 class HistoryElement::RequestAccepted < HistoryElement::Request
   def color
     'green'

--- a/src/api/app/models/statistics/maintenance_statistic.rb
+++ b/src/api/app/models/statistics/maintenance_statistic.rb
@@ -1,7 +1,7 @@
 module Statistics
   class MaintenanceStatistic
     include ActiveModel::Model
-    attr_accessor :type, :when, :who, :name, :tracker, :id
+    attr_accessor :type, :when, :who, :name, :tracker, :id, :request
 
     def self.find_by_project(project)
       MaintenanceStatisticsCollection.new(project).build

--- a/src/api/app/models/statistics/maintenance_statistics_collection.rb
+++ b/src/api/app/models/statistics/maintenance_statistics_collection.rb
@@ -34,7 +34,7 @@ module Statistics
     end
 
     def release_request_created_statistic
-      MaintenanceStatistic.new(type: :release_request_created, when: request.created_at)
+      MaintenanceStatistic.new(type: :release_request_created, when: request.created_at, request: request.number)
     end
 
     def history_element_statistics
@@ -43,7 +43,8 @@ module Statistics
 
         MaintenanceStatistic.new(
           type: "release_request_#{history_element_type}",
-          when: history_element.created_at
+          when: history_element.created_at,
+          request: request.number
         )
       end
     end

--- a/src/api/app/models/statistics/maintenance_statistics_collection.rb
+++ b/src/api/app/models/statistics/maintenance_statistics_collection.rb
@@ -42,7 +42,7 @@ module Statistics
         history_element_type = history_element.class.name.demodulize.underscore
 
         MaintenanceStatistic.new(
-          type: "release_request_#{history_element_type}",
+          type: "release_#{history_element_type}",
           when: history_element.created_at,
           request: request.number
         )

--- a/src/api/spec/decorators/statistics/maintenance_statistic_decorator.rb
+++ b/src/api/spec/decorators/statistics/maintenance_statistic_decorator.rb
@@ -34,12 +34,6 @@ RSpec.describe Statistics::MaintenanceStatisticDecorator do
         when: maintenance_statistic2.when
       }
     end
-    let(:maintenance_statistic3) do
-      double(
-        type: :release_request_request_created,
-        when: Faker::Date.forward(10)
-      )
-    end
     let(:expected_xml_hash3) do
       {
         type: maintenance_statistic3.type,
@@ -50,8 +44,7 @@ RSpec.describe Statistics::MaintenanceStatisticDecorator do
     let(:test_data) do
       {
         maintenance_statistic1 => expected_xml_hash1,
-        maintenance_statistic2 => expected_xml_hash2,
-        maintenance_statistic3 => expected_xml_hash3
+        maintenance_statistic2 => expected_xml_hash2
       }
     end
 

--- a/src/api/spec/factories/history_elements.rb
+++ b/src/api/spec/factories/history_elements.rb
@@ -11,10 +11,6 @@ FactoryGirl.define do
     type { 'HistoryElement::ReviewDeclined' }
   end
 
-  factory :history_element_request_created, class: 'HistoryElement::RequestCreated' do
-    type { 'HistoryElement::RequestCreated' }
-  end
-
   factory :history_element_request_accepted, class: 'HistoryElement::RequestAccepted' do
     type { 'HistoryElement::RequestAccepted' }
   end

--- a/src/api/spec/factories/history_elements.rb
+++ b/src/api/spec/factories/history_elements.rb
@@ -14,4 +14,8 @@ FactoryGirl.define do
   factory :history_element_request_accepted, class: 'HistoryElement::RequestAccepted' do
     type { 'HistoryElement::RequestAccepted' }
   end
+
+  factory :history_element_request_revoked, class: 'HistoryElement::RequestRevoked' do
+    type { 'HistoryElement::RequestRevoked' }
+  end
 end

--- a/src/api/spec/models/statistics/maintenance_statistic_spec.rb
+++ b/src/api/spec/models/statistics/maintenance_statistic_spec.rb
@@ -8,28 +8,23 @@ RSpec.describe Statistics::MaintenanceStatistic do
       subject(:maintenance_statistics) { Statistics::MaintenanceStatistic.find_by_project(project) }
 
       it 'contains issue_created' do
-        expect(maintenance_statistics[-7].type).to eq(:issue_created)
-        expect(maintenance_statistics[-7].when).to eq(issue.created_at)
+        expect(maintenance_statistics[-6].type).to eq(:issue_created)
+        expect(maintenance_statistics[-6].when).to eq(issue.created_at)
       end
 
       it 'contains review_declined' do
-        expect(maintenance_statistics[-6].type).to eq(:review_declined)
-        expect(maintenance_statistics[-6].when).to eq(history_element_review_declined.created_at)
+        expect(maintenance_statistics[-5].type).to eq(:review_declined)
+        expect(maintenance_statistics[-5].when).to eq(history_element_review_declined.created_at)
       end
 
       it 'contains review_opened' do
-        expect(maintenance_statistics[-5].type).to eq(:review_opened)
-        expect(maintenance_statistics[-5].when).to eq(review.created_at)
+        expect(maintenance_statistics[-4].type).to eq(:review_opened)
+        expect(maintenance_statistics[-4].when).to eq(review.created_at)
       end
 
       it 'contains release_request_request_accepted' do
-        expect(maintenance_statistics[-4].type).to eq('release_request_request_accepted')
-        expect(maintenance_statistics[-4].when).to eq(history_element_request_accepted.created_at)
-      end
-
-      it 'contains release_request_request_created' do
-        expect(maintenance_statistics[-3].type).to eq('release_request_request_created')
-        expect(maintenance_statistics[-3].when).to eq(history_element_request_created.created_at)
+        expect(maintenance_statistics[-3].type).to eq('release_request_request_accepted')
+        expect(maintenance_statistics[-3].when).to eq(history_element_request_accepted.created_at)
       end
 
       it 'contains release_request_created' do

--- a/src/api/spec/models/statistics/maintenance_statistic_spec.rb
+++ b/src/api/spec/models/statistics/maintenance_statistic_spec.rb
@@ -25,11 +25,13 @@ RSpec.describe Statistics::MaintenanceStatistic do
       it 'contains release_request_request_accepted' do
         expect(maintenance_statistics[-3].type).to eq('release_request_request_accepted')
         expect(maintenance_statistics[-3].when).to eq(history_element_request_accepted.created_at)
+        expect(maintenance_statistics[-3].request).to eq(bs_request.number)
       end
 
       it 'contains release_request_created' do
         expect(maintenance_statistics[-2].type).to eq(:release_request_created)
         expect(maintenance_statistics[-2].when).to eq(bs_request.created_at)
+        expect(maintenance_statistics[-2].request).to eq(bs_request.number)
       end
 
       it 'contains project_created' do

--- a/src/api/spec/models/statistics/maintenance_statistic_spec.rb
+++ b/src/api/spec/models/statistics/maintenance_statistic_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe Statistics::MaintenanceStatistic do
       end
 
       it 'contains release_request_request_accepted' do
-        expect(maintenance_statistics[-3].type).to eq('release_request_request_accepted')
+        expect(maintenance_statistics[-3].type).to eq('release_request_accepted')
         expect(maintenance_statistics[-3].when).to eq(history_element_request_accepted.created_at)
         expect(maintenance_statistics[-3].request).to eq(bs_request.number)
       end

--- a/src/api/spec/support/shared_contexts/a_project_with_maintenance_statistics.rb
+++ b/src/api/spec/support/shared_contexts/a_project_with_maintenance_statistics.rb
@@ -15,14 +15,6 @@ RSpec.shared_context 'a project with maintenance statistics' do
       created_at: 9.days.ago
     )
   end
-  let!(:history_element_request_created) do
-    create(
-      :history_element_request_created,
-      request: bs_request,
-      user: user,
-      created_at: 8.days.ago
-    )
-  end
   let!(:history_element_request_accepted) do
     create(
       :history_element_request_accepted,

--- a/src/api/test/fixtures/history_elements.yml
+++ b/src/api/test/fixtures/history_elements.yml
@@ -1,15 +1,3 @@
-record_0:
-  op_object_id: 9994
-  type: HistoryElement::RequestCreated
-  comment: one group review
-  user_id: <%= ActiveRecord::FixtureSet.identify(:Iggy) %>
-  created_at: 2012-09-28 11:56:53.000000000 Z
-record_1:
-  op_object_id: 9994
-  type: HistoryElement::RequestCreated
-  comment: see if users can review
-  user_id: <%= ActiveRecord::FixtureSet.identify(:Iggy) %>
-  created_at: 2012-09-28 11:56:46.000000000 Z
 record_2:
   op_object_id: 9994
   type: HistoryElement::RequestAllReviewsApproved


### PR DESCRIPTION
This PR will fix the following issues of the maintenance statistics API:

- Removed HistoryElement:RequestCreated as it was never used. Checked also on build.o.o that no element exists
- Added ``:id`` attribute to ``:request_created`` as there is a ``has_many`` relation between Maintenance Project and Release Request
- Display all release requests not only the first one
- Removed duplicate request in tag description ``s/release_request_request_/release_request_``