### PR TITLE
[api] Fix bug in update notification event

### DIFF
--- a/src/api/app/models/update_notification_events.rb
+++ b/src/api/app/models/update_notification_events.rb
@@ -31,8 +31,8 @@ class UpdateNotificationEvents
       if Rails.env.test?
         # make debug output useful in test suite, not just showing backtrace to HoptoaddNotifier
         Rails.logger.error "ERROR: #{e.inspect}: #{e.backtrace}"
-        logger.info e.inspect
-        logger.info o e.backtrace
+        Rails.logger.info e.inspect
+        Rails.logger.info e.backtrace
       end
       HoptoadNotifier.notify(e, {failed_job: type.inspect})
       return


### PR DESCRIPTION
Fixes wrong calling of rails logger caused by 05787d6195.

Found by running vagrant exec rake test:functional/webui/package_create_test

=====

/vagrant/src/api/app/models/update_notification_events.rb:34:in `rescue in create_events': undefined local
  variable or method `logger' for #<UpdateNotificationEvents:0x000000092951e0> (NameError)
	from /vagrant/src/api/app/models/update_notification_events.rb:13:in `create_events'
	from /vagrant/src/api/app/models/update_notification_events.rb:71:in `block (2 levels) in perform'