### PR TITLE
[api][webui] remove the loading of 2.5 database for the migration check

### DIFF
--- a/src/api/script/api_test_in_spec.sh
+++ b/src/api/script/api_test_in_spec.sh
@@ -65,7 +65,6 @@ EOF
 # migration test
 export RAILS_ENV=migrate
 bundle.ruby2.4 exec rake.ruby2.4 db:create || exit 1
-xzcat test/dump_2.5.sql.xz | mysql  -u root --socket=$MYSQL_SOCKET
 cp db/structure.sql{,.git}
 bundle.ruby2.4 exec rake.ruby2.4 db:migrate db:structure:dump db:drop || exit 1
 if test `diff db/structure.sql{,.git} | wc -l` -gt 0 ; then


### PR DESCRIPTION
This should fix the migration check which is currently failing and preventing packages from being built.