### PR TITLE
Fix branching package for openQA tests

### DIFF
--- a/dist/t/spec/features/0040_package_spec.rb
+++ b/dist/t/spec/features/0040_package_spec.rb
@@ -48,7 +48,7 @@ RSpec.describe "Package" do
     # Do not wait for autocomplete
     page.execute_script("$('input[type=\"submit\"]').prop('disabled', false)")
     click_button('Create Branch')
-    expect(page).to have_content('Successfully branched package')
+    expect(page).to have_content('Service currently running')
   end
 
   it 'should be able to delete' do


### PR DESCRIPTION
Branching the build package will trigger a service run.
Therefore the flash is now "Service currently running" and not "Successfully branched package".