### PR TITLE
[api] Move require 'opensuse/permission' to authenticator class

### DIFF
--- a/src/api/app/controllers/application_controller.rb
+++ b/src/api/app/controllers/application_controller.rb
@@ -1,7 +1,6 @@
 # Filters added to this controller will be run for all controllers in the application.
 # Likewise, all the methods added will be available for all controllers.
 
-require_dependency 'opensuse/permission'
 require_dependency 'opensuse/validator'
 require_dependency 'api_exception'
 require_dependency 'authenticator'

--- a/src/api/lib/authenticator.rb
+++ b/src/api/lib/authenticator.rb
@@ -1,3 +1,4 @@
+require_dependency 'opensuse/permission'
 if CONFIG['kerberos_service_principal']
   require_dependency 'gssapi'
 end


### PR DESCRIPTION
The code needing it got moved there recently.