### PR TITLE
[api] Fix exception message

### DIFF
--- a/src/api/app/models/project/update_from_xml_command.rb
+++ b/src/api/app/models/project/update_from_xml_command.rb
@@ -245,7 +245,7 @@ class Project
         trigger    = release_target['trigger']
 
         unless project
-          raise SaveError, "Project '#{project}' does not exist."
+          raise SaveError, "Project '#{release_target['project']}' does not exist."
         end
 
         if project.defines_remote_instance?


### PR DESCRIPTION
If project doesn't exist, what we shouldn't render if the string we used to look for it and no the project itself, as an empty string will be rendered. :bowtie: 