### PR TITLE
Solve live build log issue

### DIFF
--- a/src/api/app/controllers/webui/package_controller.rb
+++ b/src/api/app/controllers/webui/package_controller.rb
@@ -907,7 +907,8 @@ class Webui::PackageController < Webui::WebuiController
       redirect_to controller: :package, action: :show, project: @project, package: @package
     else
       flash[:error] = "Error while triggering abort build for #{@project.name}/#{@package.name}: #{@package.errors.full_messages.to_sentence}."
-      redirect_to controller: :package, action: :live_build_log, project: @project, package: @package, repository: params[:repository]
+      redirect_to controller: :package, action: :live_build_log, project: @project, package: @package,
+        repository: params[:repository], arch: params[:arch]
     end
   end
 

--- a/src/api/app/views/webui/package/update_build_log.js.erb
+++ b/src/api/app/views/webui/package/update_build_log.js.erb
@@ -1,16 +1,22 @@
-<% if @finished %>
-  $('#log_space').html('<%= escape_javascript(@log_chunk) %>');
-  autoscroll();
+<% if @errors %>
+  $('#flash-messages').
+    replaceWith("<%= escape_javascript(render(partial: "layouts/webui/flash", locals: { flash: { error: @errors } })) %>");
+  $("html, body").scrollTop(0);
   build_finished();
-  hide_abort();
 <% else %>
-  show_abort();
-  $('#log_space').append('<%= escape_javascript(@log_chunk) %>');
-<% if @log_chunk.length < @maxsize || @initial == 0 %>
-  autoscroll();
-  setTimeout(function() { refresh(<%= @offset %>, 0); },2000);
-<% else %>
-  refresh(<%= @offset %>, <%= @initial %> );
+  <% if @finished %>
+    $('#log_space').html('<%= escape_javascript(@log_chunk) %>');
+    autoscroll();
+    build_finished();
+    hide_abort();
+  <% else %>
+    show_abort();
+    $('#log_space').append('<%= escape_javascript(@log_chunk) %>');
+    <% if @log_chunk.length < @maxsize || @initial == 0 %>
+      autoscroll();
+      setTimeout(function() { refresh(<%= @offset %>, 0); },2000);
+    <% else %>
+      refresh(<%= @offset %>, <%= @initial %> );
+    <% end %>
+  <% end %>
 <% end %>
-<% end %>
-

--- a/src/api/config/routes.rb
+++ b/src/api/config/routes.rb
@@ -125,7 +125,7 @@ OBSApi::Application.routes.draw do
       post 'package/save_group/:project/:package' => :save_group, constraints: cons
       post 'package/remove_role/:project/:package' => :remove_role, constraints: cons
       get 'package/view_file/(:project/(:package/(:filename)))' => :view_file, constraints: cons, as: 'package_view_file', defaults: {format: "html"}
-      get 'package/live_build_log/(:project/(:package/(:repository/(:arch))))' => :live_build_log, constraints: cons, as: 'package_live_build_log'
+      get 'package/live_build_log/:project/:package/:repository/:arch' => :live_build_log, constraints: cons, as: 'package_live_build_log'
       get 'package/update_build_log/:project/:package' => :update_build_log, constraints: cons
       get 'package/abort_build/:project/:package' => :abort_build, constraints: cons
       delete 'package/trigger_rebuild/:project/:package' => :trigger_rebuild, constraints: cons

--- a/src/api/spec/cassettes/Webui_PackageController/build_logs/GET_package_live_build_log/it_should_behave_like_build_log/successfully/1_13_1_1_1_1.yml
+++ b/src/api/spec/cassettes/Webui_PackageController/build_logs/GET_package_live_build_log/it_should_behave_like_build_log/successfully/1_13_1_1_1_1.yml
@@ -155,4 +155,154 @@ http_interactions:
         </package>
     http_version: 
   recorded_at: Wed, 22 Mar 2017 10:25:05 GMT
+- request:
+    method: put
+    uri: http://localhost:3200/source/home:tom/_meta?user=tom
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:tom">
+          <title/>
+          <description/>
+          <person userid="tom" role="maintainer"/>
+          <repository name="leap_42.2">
+            <arch>i586</arch>
+          </repository>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '199'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:tom">
+          <title></title>
+          <description></description>
+          <person userid="tom" role="maintainer" />
+          <repository name="leap_42.2">
+            <arch>i586</arch>
+          </repository>
+        </project>
+    http_version: 
+  recorded_at: Tue, 11 Apr 2017 11:58:51 GMT
+- request:
+    method: put
+    uri: http://localhost:3200/source/home:tom/my_package/_meta?user=tom
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="my_package" project="home:tom">
+          <title/>
+          <description/>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '106'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="my_package" project="home:tom">
+          <title></title>
+          <description></description>
+        </package>
+    http_version: 
+  recorded_at: Tue, 11 Apr 2017 11:58:51 GMT
+- request:
+    method: get
+    uri: http://localhost:3200/build/home:tom/leap_42.2/i586/_builddepinfo?package=my_package&view=revpkgnames
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '17'
+    body:
+      encoding: UTF-8
+      string: "<builddepinfo />\n"
+    http_version: 
+  recorded_at: Tue, 11 Apr 2017 11:58:51 GMT
+- request:
+    method: get
+    uri: http://localhost:3200/build/home:tom/leap_42.2/i586/my_package/_jobstatus
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - text/plain
+      Accept-Encoding:
+      - identity
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '14'
+    body:
+      encoding: UTF-8
+      string: "<jobstatus />\n"
+    http_version: 
+  recorded_at: Tue, 11 Apr 2017 11:58:51 GMT
 recorded_with: VCR 3.0.3

--- a/src/api/spec/cassettes/Webui_PackageController/build_logs/GET_package_live_build_log/it_should_behave_like_build_log/successfully_with_a_package_which_name_that_includes_/1_13_1_1_2_1.yml
+++ b/src/api/spec/cassettes/Webui_PackageController/build_logs/GET_package_live_build_log/it_should_behave_like_build_log/successfully_with_a_package_which_name_that_includes_/1_13_1_1_2_1.yml
@@ -155,4 +155,190 @@ http_interactions:
         </status>
     http_version: 
   recorded_at: Wed, 22 Mar 2017 12:10:49 GMT
+- request:
+    method: put
+    uri: http://localhost:3200/source/home:tom/_meta?user=tom
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:tom">
+          <title/>
+          <description/>
+          <person userid="tom" role="maintainer"/>
+          <repository name="leap_42.2">
+            <arch>i586</arch>
+          </repository>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '199'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:tom">
+          <title></title>
+          <description></description>
+          <person userid="tom" role="maintainer" />
+          <repository name="leap_42.2">
+            <arch>i586</arch>
+          </repository>
+        </project>
+    http_version: 
+  recorded_at: Tue, 11 Apr 2017 11:58:50 GMT
+- request:
+    method: put
+    uri: http://localhost:3200/source/home:tom/my_package++special/_meta?user=tom
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="my_package++special" project="home:tom">
+          <title/>
+          <description/>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '115'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="my_package++special" project="home:tom">
+          <title></title>
+          <description></description>
+        </package>
+    http_version: 
+  recorded_at: Tue, 11 Apr 2017 11:58:50 GMT
+- request:
+    method: get
+    uri: http://localhost:3200/build/home:tom/_result?arch=i586&package=my_package%2B%2Bspecial&repository=leap_42.2&view=status
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - text/plain
+      Accept-Encoding:
+      - identity
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '166'
+    body:
+      encoding: UTF-8
+      string: |
+        <resultlist state="30960bcdca4c4bf3ca5780329f4d620b">
+          <result project="home:tom" repository="leap_42.2" arch="i586" code="unknown" state="unknown" />
+        </resultlist>
+    http_version: 
+  recorded_at: Tue, 11 Apr 2017 11:58:50 GMT
+- request:
+    method: get
+    uri: http://localhost:3200/build/home:tom/leap_42.2/i586/_builddepinfo?package=my_package%20%20special&view=revpkgnames
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '17'
+    body:
+      encoding: UTF-8
+      string: "<builddepinfo />\n"
+    http_version: 
+  recorded_at: Tue, 11 Apr 2017 11:58:50 GMT
+- request:
+    method: get
+    uri: http://localhost:3200/build/home:tom/leap_42.2/i586/my_package++special/_jobstatus
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - text/plain
+      Accept-Encoding:
+      - identity
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '14'
+    body:
+      encoding: UTF-8
+      string: "<jobstatus />\n"
+    http_version: 
+  recorded_at: Tue, 11 Apr 2017 11:58:50 GMT
 recorded_with: VCR 3.0.3

--- a/src/api/spec/cassettes/Webui_PackageController/build_logs/GET_package_live_build_log/it_should_behave_like_build_log/successfully_with_a_project_which_name_that_includes_/1_13_1_1_3_1.yml
+++ b/src/api/spec/cassettes/Webui_PackageController/build_logs/GET_package_live_build_log/it_should_behave_like_build_log/successfully_with_a_project_which_name_that_includes_/1_13_1_1_3_1.yml
@@ -342,4 +342,306 @@ http_interactions:
         </status>
     http_version: 
   recorded_at: Wed, 22 Mar 2017 12:15:08 GMT
+- request:
+    method: put
+    uri: http://localhost:3200/source/home:tom/_meta?user=tom
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:tom">
+          <title/>
+          <description/>
+          <person userid="tom" role="maintainer"/>
+          <repository name="leap_42.2">
+            <arch>i586</arch>
+          </repository>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '199'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:tom">
+          <title></title>
+          <description></description>
+          <person userid="tom" role="maintainer" />
+          <repository name="leap_42.2">
+            <arch>i586</arch>
+          </repository>
+        </project>
+    http_version: 
+  recorded_at: Tue, 11 Apr 2017 11:58:51 GMT
+- request:
+    method: put
+    uri: http://localhost:3200/source/foo++bar/some_package/_meta?user=tom
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="some_package" project="foo++bar">
+          <title/>
+          <description/>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '108'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="some_package" project="foo++bar">
+          <title></title>
+          <description></description>
+        </package>
+    http_version: 
+  recorded_at: Tue, 11 Apr 2017 11:58:51 GMT
+- request:
+    method: get
+    uri: http://localhost:3200/build/foo++bar/10.3/i586/_builddepinfo?package=some_package&view=revpkgnames
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 404
+      message: project 'foo++bar' has no repository '10.3'
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '164'
+    body:
+      encoding: UTF-8
+      string: |
+        <status code="404">
+          <summary>project 'foo++bar' has no repository '10.3'</summary>
+          <details>404 project 'foo++bar' has no repository '10.3'</details>
+        </status>
+    http_version: 
+  recorded_at: Tue, 11 Apr 2017 11:58:51 GMT
+- request:
+    method: get
+    uri: http://localhost:3200/build/foo++bar/10.3/i586/some_package/_jobstatus
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - text/plain
+      Accept-Encoding:
+      - identity
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 404
+      message: project 'foo++bar' has no repository '10.3'
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '164'
+    body:
+      encoding: UTF-8
+      string: |
+        <status code="404">
+          <summary>project 'foo++bar' has no repository '10.3'</summary>
+          <details>404 project 'foo++bar' has no repository '10.3'</details>
+        </status>
+    http_version: 
+  recorded_at: Tue, 11 Apr 2017 11:58:51 GMT
+- request:
+    method: get
+    uri: http://localhost:3200/build/foo++bar/leap_45.2/i586/_builddepinfo?package=some_package&view=revpkgnames
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 404
+      message: project 'foo++bar' does not exist
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '144'
+    body:
+      encoding: UTF-8
+      string: |
+        <status code="404">
+          <summary>project 'foo++bar' does not exist</summary>
+          <details>404 project 'foo++bar' does not exist</details>
+        </status>
+    http_version: 
+  recorded_at: Tue, 11 Apr 2017 15:17:38 GMT
+- request:
+    method: get
+    uri: http://localhost:3200/build/foo++bar/leap_45.2/i586/some_package/_jobstatus
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - text/plain
+      Accept-Encoding:
+      - identity
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 404
+      message: project 'foo++bar' does not exist
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '144'
+    body:
+      encoding: UTF-8
+      string: |
+        <status code="404">
+          <summary>project 'foo++bar' does not exist</summary>
+          <details>404 project 'foo++bar' does not exist</details>
+        </status>
+    http_version: 
+  recorded_at: Tue, 11 Apr 2017 15:17:38 GMT
+- request:
+    method: get
+    uri: http://localhost:3200/build/foo++bar/leap_45.1/i586/_builddepinfo?package=some_package&view=revpkgnames
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 404
+      message: project 'foo++bar' does not exist
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '144'
+    body:
+      encoding: UTF-8
+      string: |
+        <status code="404">
+          <summary>project 'foo++bar' does not exist</summary>
+          <details>404 project 'foo++bar' does not exist</details>
+        </status>
+    http_version: 
+  recorded_at: Wed, 12 Apr 2017 09:19:06 GMT
+- request:
+    method: get
+    uri: http://localhost:3200/build/foo++bar/leap_45.1/i586/some_package/_jobstatus
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - text/plain
+      Accept-Encoding:
+      - identity
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 404
+      message: project 'foo++bar' does not exist
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '144'
+    body:
+      encoding: UTF-8
+      string: |
+        <status code="404">
+          <summary>project 'foo++bar' does not exist</summary>
+          <details>404 project 'foo++bar' does not exist</details>
+        </status>
+    http_version: 
+  recorded_at: Wed, 12 Apr 2017 09:19:06 GMT
 recorded_with: VCR 3.0.3

--- a/src/api/spec/cassettes/Webui_PackageController/build_logs/GET_package_live_build_log/it_should_behave_like_build_log/with_a_non_existant_package/1_13_1_1_5_1.yml
+++ b/src/api/spec/cassettes/Webui_PackageController/build_logs/GET_package_live_build_log/it_should_behave_like_build_log/with_a_non_existant_package/1_13_1_1_5_1.yml
@@ -41,4 +41,51 @@ http_interactions:
         </project>
     http_version: 
   recorded_at: Wed, 22 Mar 2017 12:10:49 GMT
+- request:
+    method: put
+    uri: http://localhost:3200/source/home:tom/_meta?user=tom
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:tom">
+          <title/>
+          <description/>
+          <person userid="tom" role="maintainer"/>
+          <repository name="leap_42.2">
+            <arch>i586</arch>
+          </repository>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '199'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:tom">
+          <title></title>
+          <description></description>
+          <person userid="tom" role="maintainer" />
+          <repository name="leap_42.2">
+            <arch>i586</arch>
+          </repository>
+        </project>
+    http_version: 
+  recorded_at: Tue, 11 Apr 2017 11:58:50 GMT
 recorded_with: VCR 3.0.3

--- a/src/api/spec/cassettes/Webui_PackageController/build_logs/GET_package_live_build_log/it_should_behave_like_build_log/with_a_non_existant_package/1_13_1_1_5_2.yml
+++ b/src/api/spec/cassettes/Webui_PackageController/build_logs/GET_package_live_build_log/it_should_behave_like_build_log/with_a_non_existant_package/1_13_1_1_5_2.yml
@@ -41,4 +41,51 @@ http_interactions:
         </project>
     http_version: 
   recorded_at: Wed, 22 Mar 2017 12:10:49 GMT
+- request:
+    method: put
+    uri: http://localhost:3200/source/home:tom/_meta?user=tom
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:tom">
+          <title/>
+          <description/>
+          <person userid="tom" role="maintainer"/>
+          <repository name="leap_42.2">
+            <arch>i586</arch>
+          </repository>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '199'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:tom">
+          <title></title>
+          <description></description>
+          <person userid="tom" role="maintainer" />
+          <repository name="leap_42.2">
+            <arch>i586</arch>
+          </repository>
+        </project>
+    http_version: 
+  recorded_at: Tue, 11 Apr 2017 11:58:50 GMT
 recorded_with: VCR 3.0.3

--- a/src/api/spec/cassettes/Webui_PackageController/build_logs/GET_package_live_build_log/it_should_behave_like_build_log/with_a_non_existant_project/1_13_1_1_6_1.yml
+++ b/src/api/spec/cassettes/Webui_PackageController/build_logs/GET_package_live_build_log/it_should_behave_like_build_log/with_a_non_existant_project/1_13_1_1_6_1.yml
@@ -40,7 +40,7 @@ http_interactions:
           <person userid="tom" role="maintainer" />
         </project>
     http_version: 
-  recorded_at: Wed, 22 Mar 2017 12:10:47 GMT
+  recorded_at: Tue, 11 Apr 2017 11:58:51 GMT
 - request:
     method: put
     uri: http://localhost:3200/source/home:tom/_meta?user=tom
@@ -87,5 +87,5 @@ http_interactions:
           </repository>
         </project>
     http_version: 
-  recorded_at: Tue, 11 Apr 2017 11:58:22 GMT
+  recorded_at: Tue, 11 Apr 2017 11:58:51 GMT
 recorded_with: VCR 3.0.3

--- a/src/api/spec/cassettes/Webui_PackageController/build_logs/GET_package_live_build_log/it_should_behave_like_build_log/with_a_non_existant_project/1_13_1_1_6_2.yml
+++ b/src/api/spec/cassettes/Webui_PackageController/build_logs/GET_package_live_build_log/it_should_behave_like_build_log/with_a_non_existant_project/1_13_1_1_6_2.yml
@@ -40,7 +40,7 @@ http_interactions:
           <person userid="tom" role="maintainer" />
         </project>
     http_version: 
-  recorded_at: Wed, 22 Mar 2017 12:10:47 GMT
+  recorded_at: Tue, 11 Apr 2017 11:58:51 GMT
 - request:
     method: put
     uri: http://localhost:3200/source/home:tom/_meta?user=tom
@@ -87,5 +87,5 @@ http_interactions:
           </repository>
         </project>
     http_version: 
-  recorded_at: Tue, 11 Apr 2017 11:58:22 GMT
+  recorded_at: Tue, 11 Apr 2017 11:58:51 GMT
 recorded_with: VCR 3.0.3

--- a/src/api/spec/cassettes/Webui_PackageController/build_logs/GET_package_live_build_log/it_should_behave_like_build_log/with_a_nonexistant_repository/1_13_1_1_7_1.yml
+++ b/src/api/spec/cassettes/Webui_PackageController/build_logs/GET_package_live_build_log/it_should_behave_like_build_log/with_a_nonexistant_repository/1_13_1_1_7_1.yml
@@ -1,0 +1,39 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://localhost:3200/build/home:tom//i586/my_package/_jobstatus
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - text/plain
+      Accept-Encoding:
+      - identity
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 400
+      message: repoid is empty
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '67'
+    body:
+      encoding: UTF-8
+      string: |
+        <status code="400">
+          <summary>repoid is empty</summary>
+        </status>
+    http_version: 
+  recorded_at: Mon, 10 Apr 2017 15:28:28 GMT
+recorded_with: VCR 3.0.3

--- a/src/api/spec/cassettes/Webui_PackageController/build_logs/GET_package_live_build_log/it_should_behave_like_build_log/with_a_nonexistant_repository/1_13_1_1_7_2.yml
+++ b/src/api/spec/cassettes/Webui_PackageController/build_logs/GET_package_live_build_log/it_should_behave_like_build_log/with_a_nonexistant_repository/1_13_1_1_7_2.yml
@@ -1,0 +1,39 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://localhost:3200/build/home:tom//i586/my_package/_jobstatus
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - text/plain
+      Accept-Encoding:
+      - identity
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 400
+      message: repoid is empty
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '67'
+    body:
+      encoding: UTF-8
+      string: |
+        <status code="400">
+          <summary>repoid is empty</summary>
+        </status>
+    http_version: 
+  recorded_at: Mon, 10 Apr 2017 15:28:28 GMT
+recorded_with: VCR 3.0.3

--- a/src/api/spec/cassettes/Webui_PackageController/build_logs/GET_package_live_build_log/it_should_behave_like_build_log/with_a_protected_package/1_13_1_1_4_1.yml
+++ b/src/api/spec/cassettes/Webui_PackageController/build_logs/GET_package_live_build_log/it_should_behave_like_build_log/with_a_protected_package/1_13_1_1_4_1.yml
@@ -119,4 +119,90 @@ http_interactions:
         </package>
     http_version: 
   recorded_at: Wed, 22 Mar 2017 12:10:49 GMT
+- request:
+    method: put
+    uri: http://localhost:3200/source/home:tom/_meta?user=tom
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:tom">
+          <title/>
+          <description/>
+          <person userid="tom" role="maintainer"/>
+          <repository name="leap_42.2">
+            <arch>i586</arch>
+          </repository>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '199'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:tom">
+          <title></title>
+          <description></description>
+          <person userid="tom" role="maintainer" />
+          <repository name="leap_42.2">
+            <arch>i586</arch>
+          </repository>
+        </project>
+    http_version: 
+  recorded_at: Tue, 11 Apr 2017 11:58:49 GMT
+- request:
+    method: put
+    uri: http://localhost:3200/source/home:tom/my_package/_meta?user=tom
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="my_package" project="home:tom">
+          <title/>
+          <description/>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '106'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="my_package" project="home:tom">
+          <title></title>
+          <description></description>
+        </package>
+    http_version: 
+  recorded_at: Tue, 11 Apr 2017 11:58:49 GMT
 recorded_with: VCR 3.0.3

--- a/src/api/spec/cassettes/Webui_PackageController/build_logs/GET_package_live_build_log/it_should_behave_like_build_log/with_a_protected_package/1_13_1_1_4_2.yml
+++ b/src/api/spec/cassettes/Webui_PackageController/build_logs/GET_package_live_build_log/it_should_behave_like_build_log/with_a_protected_package/1_13_1_1_4_2.yml
@@ -119,4 +119,90 @@ http_interactions:
         </package>
     http_version: 
   recorded_at: Wed, 22 Mar 2017 12:10:49 GMT
+- request:
+    method: put
+    uri: http://localhost:3200/source/home:tom/_meta?user=tom
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:tom">
+          <title/>
+          <description/>
+          <person userid="tom" role="maintainer"/>
+          <repository name="leap_42.2">
+            <arch>i586</arch>
+          </repository>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '199'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:tom">
+          <title></title>
+          <description></description>
+          <person userid="tom" role="maintainer" />
+          <repository name="leap_42.2">
+            <arch>i586</arch>
+          </repository>
+        </project>
+    http_version: 
+  recorded_at: Tue, 11 Apr 2017 11:58:50 GMT
+- request:
+    method: put
+    uri: http://localhost:3200/source/home:tom/my_package/_meta?user=tom
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="my_package" project="home:tom">
+          <title/>
+          <description/>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '106'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="my_package" project="home:tom">
+          <title></title>
+          <description></description>
+        </package>
+    http_version: 
+  recorded_at: Tue, 11 Apr 2017 11:58:50 GMT
 recorded_with: VCR 3.0.3

--- a/src/api/spec/cassettes/Webui_PackageController/build_logs/GET_update_build_log/it_should_behave_like_build_log/successfully/1_13_2_1_1_1.yml
+++ b/src/api/spec/cassettes/Webui_PackageController/build_logs/GET_update_build_log/it_should_behave_like_build_log/successfully/1_13_2_1_1_1.yml
@@ -191,4 +191,164 @@ http_interactions:
         </package>
     http_version: 
   recorded_at: Wed, 22 Mar 2017 10:25:35 GMT
+- request:
+    method: put
+    uri: http://localhost:3200/source/home:tom/_meta?user=tom
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:tom">
+          <title/>
+          <description/>
+          <person userid="tom" role="maintainer"/>
+          <repository name="leap_42.2">
+            <arch>i586</arch>
+          </repository>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '199'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:tom">
+          <title></title>
+          <description></description>
+          <person userid="tom" role="maintainer" />
+          <repository name="leap_42.2">
+            <arch>i586</arch>
+          </repository>
+        </project>
+    http_version: 
+  recorded_at: Tue, 11 Apr 2017 11:58:22 GMT
+- request:
+    method: put
+    uri: http://localhost:3200/source/home:tom/my_package/_meta?user=tom
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="my_package" project="home:tom">
+          <title/>
+          <description/>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '106'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="my_package" project="home:tom">
+          <title></title>
+          <description></description>
+        </package>
+    http_version: 
+  recorded_at: Tue, 11 Apr 2017 11:58:22 GMT
+- request:
+    method: get
+    uri: http://localhost:3200/build/home:tom/leap_42.2/i586/my_package/_log?view=entry
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - text/plain
+      Accept-Encoding:
+      - identity
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 404
+      message: package 'my_package' has no logfile
+    headers:
+      Content-Type:
+      - text/xml
+      Content-Length:
+      - '148'
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+    body:
+      encoding: UTF-8
+      string: |
+        <status code="404">
+          <summary>package 'my_package' has no logfile</summary>
+          <details>404 package 'my_package' has no logfile</details>
+        </status>
+    http_version: 
+  recorded_at: Tue, 11 Apr 2017 11:58:22 GMT
+- request:
+    method: get
+    uri: http://localhost:3200/build/home:tom/leap_42.2/i586/my_package/_log?end=65536&nostream=1&start=0
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - text/plain
+      Accept-Encoding:
+      - identity
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 404
+      message: remote error  package 'my_package' has no logfile
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '176'
+    body:
+      encoding: UTF-8
+      string: |
+        <status code="404">
+          <summary>remote error: package 'my_package' has no logfile</summary>
+          <details>404 remote error: package 'my_package' has no logfile</details>
+        </status>
+    http_version: 
+  recorded_at: Tue, 11 Apr 2017 11:58:22 GMT
 recorded_with: VCR 3.0.3

--- a/src/api/spec/cassettes/Webui_PackageController/build_logs/GET_update_build_log/it_should_behave_like_build_log/successfully_with_a_package_which_name_that_includes_/1_13_2_1_2_1.yml
+++ b/src/api/spec/cassettes/Webui_PackageController/build_logs/GET_update_build_log/it_should_behave_like_build_log/successfully_with_a_package_which_name_that_includes_/1_13_2_1_2_1.yml
@@ -191,4 +191,164 @@ http_interactions:
         </status>
     http_version: 
   recorded_at: Wed, 22 Mar 2017 12:10:47 GMT
+- request:
+    method: put
+    uri: http://localhost:3200/source/home:tom/_meta?user=tom
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:tom">
+          <title/>
+          <description/>
+          <person userid="tom" role="maintainer"/>
+          <repository name="leap_42.2">
+            <arch>i586</arch>
+          </repository>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '199'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:tom">
+          <title></title>
+          <description></description>
+          <person userid="tom" role="maintainer" />
+          <repository name="leap_42.2">
+            <arch>i586</arch>
+          </repository>
+        </project>
+    http_version: 
+  recorded_at: Tue, 11 Apr 2017 11:58:22 GMT
+- request:
+    method: put
+    uri: http://localhost:3200/source/home:tom/my_package++special/_meta?user=tom
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="my_package++special" project="home:tom">
+          <title/>
+          <description/>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '115'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="my_package++special" project="home:tom">
+          <title></title>
+          <description></description>
+        </package>
+    http_version: 
+  recorded_at: Tue, 11 Apr 2017 11:58:22 GMT
+- request:
+    method: get
+    uri: http://localhost:3200/build/home:tom/leap_42.2/i586/my_package++special/_log?view=entry
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - text/plain
+      Accept-Encoding:
+      - identity
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 404
+      message: package 'my_package++special' has no logfile
+    headers:
+      Content-Type:
+      - text/xml
+      Content-Length:
+      - '166'
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+    body:
+      encoding: UTF-8
+      string: |
+        <status code="404">
+          <summary>package 'my_package++special' has no logfile</summary>
+          <details>404 package 'my_package++special' has no logfile</details>
+        </status>
+    http_version: 
+  recorded_at: Tue, 11 Apr 2017 11:58:22 GMT
+- request:
+    method: get
+    uri: http://localhost:3200/build/home:tom/leap_42.2/i586/my_package++special/_log?end=65536&nostream=1&start=0
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - text/plain
+      Accept-Encoding:
+      - identity
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 404
+      message: remote error  package 'my_package++special' has no logfile
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '194'
+    body:
+      encoding: UTF-8
+      string: |
+        <status code="404">
+          <summary>remote error: package 'my_package++special' has no logfile</summary>
+          <details>404 remote error: package 'my_package++special' has no logfile</details>
+        </status>
+    http_version: 
+  recorded_at: Tue, 11 Apr 2017 11:58:22 GMT
 recorded_with: VCR 3.0.3

--- a/src/api/spec/cassettes/Webui_PackageController/build_logs/GET_update_build_log/it_should_behave_like_build_log/successfully_with_a_project_which_name_that_includes_/1_13_2_1_3_1.yml
+++ b/src/api/spec/cassettes/Webui_PackageController/build_logs/GET_update_build_log/it_should_behave_like_build_log/successfully_with_a_project_which_name_that_includes_/1_13_2_1_3_1.yml
@@ -414,4 +414,312 @@ http_interactions:
         </status>
     http_version: 
   recorded_at: Wed, 22 Mar 2017 12:15:09 GMT
+- request:
+    method: put
+    uri: http://localhost:3200/source/home:tom/_meta?user=tom
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:tom">
+          <title/>
+          <description/>
+          <person userid="tom" role="maintainer"/>
+          <repository name="leap_42.2">
+            <arch>i586</arch>
+          </repository>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '199'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:tom">
+          <title></title>
+          <description></description>
+          <person userid="tom" role="maintainer" />
+          <repository name="leap_42.2">
+            <arch>i586</arch>
+          </repository>
+        </project>
+    http_version: 
+  recorded_at: Tue, 11 Apr 2017 11:58:23 GMT
+- request:
+    method: put
+    uri: http://localhost:3200/source/foo++bar/some_package/_meta?user=tom
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="some_package" project="foo++bar">
+          <title/>
+          <description/>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '108'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="some_package" project="foo++bar">
+          <title></title>
+          <description></description>
+        </package>
+    http_version: 
+  recorded_at: Tue, 11 Apr 2017 11:58:23 GMT
+- request:
+    method: get
+    uri: http://localhost:3200/build/foo++bar/10.3/i586/some_package/_log?view=entry
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - text/plain
+      Accept-Encoding:
+      - identity
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 404
+      message: project 'foo++bar' has no repository '10.3'
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '164'
+    body:
+      encoding: UTF-8
+      string: |
+        <status code="404">
+          <summary>project 'foo++bar' has no repository '10.3'</summary>
+          <details>404 project 'foo++bar' has no repository '10.3'</details>
+        </status>
+    http_version: 
+  recorded_at: Tue, 11 Apr 2017 11:58:23 GMT
+- request:
+    method: get
+    uri: http://localhost:3200/build/foo++bar/10.3/i586/some_package/_log?end=65536&nostream=1&start=0
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - text/plain
+      Accept-Encoding:
+      - identity
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 404
+      message: project 'foo++bar' has no repository '10.3'
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '164'
+    body:
+      encoding: UTF-8
+      string: |
+        <status code="404">
+          <summary>project 'foo++bar' has no repository '10.3'</summary>
+          <details>404 project 'foo++bar' has no repository '10.3'</details>
+        </status>
+    http_version: 
+  recorded_at: Tue, 11 Apr 2017 11:58:23 GMT
+- request:
+    method: get
+    uri: http://localhost:3200/build/foo++bar/leap_45.2/i586/some_package/_log?view=entry
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - text/plain
+      Accept-Encoding:
+      - identity
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 404
+      message: project 'foo++bar' does not exist
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '144'
+    body:
+      encoding: UTF-8
+      string: |
+        <status code="404">
+          <summary>project 'foo++bar' does not exist</summary>
+          <details>404 project 'foo++bar' does not exist</details>
+        </status>
+    http_version: 
+  recorded_at: Tue, 11 Apr 2017 15:18:07 GMT
+- request:
+    method: get
+    uri: http://localhost:3200/build/foo++bar/leap_45.2/i586/some_package/_log?end=65536&nostream=1&start=0
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - text/plain
+      Accept-Encoding:
+      - identity
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 404
+      message: project 'foo++bar' does not exist
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '144'
+    body:
+      encoding: UTF-8
+      string: |
+        <status code="404">
+          <summary>project 'foo++bar' does not exist</summary>
+          <details>404 project 'foo++bar' does not exist</details>
+        </status>
+    http_version: 
+  recorded_at: Tue, 11 Apr 2017 15:18:07 GMT
+- request:
+    method: get
+    uri: http://localhost:3200/build/foo++bar/leap_45.1/i586/some_package/_log?view=entry
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - text/plain
+      Accept-Encoding:
+      - identity
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 404
+      message: project 'foo++bar' does not exist
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '144'
+    body:
+      encoding: UTF-8
+      string: |
+        <status code="404">
+          <summary>project 'foo++bar' does not exist</summary>
+          <details>404 project 'foo++bar' does not exist</details>
+        </status>
+    http_version: 
+  recorded_at: Wed, 12 Apr 2017 09:19:08 GMT
+- request:
+    method: get
+    uri: http://localhost:3200/build/foo++bar/leap_45.1/i586/some_package/_log?end=65536&nostream=1&start=0
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - text/plain
+      Accept-Encoding:
+      - identity
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 404
+      message: project 'foo++bar' does not exist
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '144'
+    body:
+      encoding: UTF-8
+      string: |
+        <status code="404">
+          <summary>project 'foo++bar' does not exist</summary>
+          <details>404 project 'foo++bar' does not exist</details>
+        </status>
+    http_version: 
+  recorded_at: Wed, 12 Apr 2017 09:19:08 GMT
 recorded_with: VCR 3.0.3

--- a/src/api/spec/cassettes/Webui_PackageController/build_logs/GET_update_build_log/it_should_behave_like_build_log/with_a_non_existant_package/1_13_2_1_5_1.yml
+++ b/src/api/spec/cassettes/Webui_PackageController/build_logs/GET_update_build_log/it_should_behave_like_build_log/with_a_non_existant_package/1_13_2_1_5_1.yml
@@ -41,4 +41,51 @@ http_interactions:
         </project>
     http_version: 
   recorded_at: Wed, 22 Mar 2017 12:10:47 GMT
+- request:
+    method: put
+    uri: http://localhost:3200/source/home:tom/_meta?user=tom
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:tom">
+          <title/>
+          <description/>
+          <person userid="tom" role="maintainer"/>
+          <repository name="leap_42.2">
+            <arch>i586</arch>
+          </repository>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '199'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:tom">
+          <title></title>
+          <description></description>
+          <person userid="tom" role="maintainer" />
+          <repository name="leap_42.2">
+            <arch>i586</arch>
+          </repository>
+        </project>
+    http_version: 
+  recorded_at: Tue, 11 Apr 2017 11:58:23 GMT
 recorded_with: VCR 3.0.3

--- a/src/api/spec/cassettes/Webui_PackageController/build_logs/GET_update_build_log/it_should_behave_like_build_log/with_a_non_existant_project/1_13_2_1_6_1.yml
+++ b/src/api/spec/cassettes/Webui_PackageController/build_logs/GET_update_build_log/it_should_behave_like_build_log/with_a_non_existant_project/1_13_2_1_6_1.yml
@@ -40,7 +40,7 @@ http_interactions:
           <person userid="tom" role="maintainer" />
         </project>
     http_version: 
-  recorded_at: Wed, 22 Mar 2017 12:10:47 GMT
+  recorded_at: Tue, 11 Apr 2017 11:58:21 GMT
 - request:
     method: put
     uri: http://localhost:3200/source/home:tom/_meta?user=tom

--- a/src/api/spec/cassettes/Webui_PackageController/build_logs/GET_update_build_log/it_should_behave_like_build_log/with_a_non_existant_project/1_13_2_1_6_2.yml
+++ b/src/api/spec/cassettes/Webui_PackageController/build_logs/GET_update_build_log/it_should_behave_like_build_log/with_a_non_existant_project/1_13_2_1_6_2.yml
@@ -40,7 +40,7 @@ http_interactions:
           <person userid="tom" role="maintainer" />
         </project>
     http_version: 
-  recorded_at: Wed, 22 Mar 2017 12:10:47 GMT
+  recorded_at: Tue, 11 Apr 2017 11:58:22 GMT
 - request:
     method: put
     uri: http://localhost:3200/source/home:tom/_meta?user=tom

--- a/src/api/spec/cassettes/Webui_PackageController/build_logs/GET_update_build_log/it_should_behave_like_build_log/with_a_nonexistant_repository/1_13_2_1_7_1.yml
+++ b/src/api/spec/cassettes/Webui_PackageController/build_logs/GET_update_build_log/it_should_behave_like_build_log/with_a_nonexistant_repository/1_13_2_1_7_1.yml
@@ -1,0 +1,75 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://localhost:3200/build/home:tom//i586/my_package/_log?view=entry
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - text/plain
+      Accept-Encoding:
+      - identity
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 400
+      message: repoid is empty
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '67'
+    body:
+      encoding: UTF-8
+      string: |
+        <status code="400">
+          <summary>repoid is empty</summary>
+        </status>
+    http_version: 
+  recorded_at: Mon, 10 Apr 2017 15:28:28 GMT
+- request:
+    method: get
+    uri: http://localhost:3200/build/home:tom//i586/my_package/_log?end=65536&nostream=1&start=0
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - text/plain
+      Accept-Encoding:
+      - identity
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 400
+      message: repoid is empty
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '67'
+    body:
+      encoding: UTF-8
+      string: |
+        <status code="400">
+          <summary>repoid is empty</summary>
+        </status>
+    http_version: 
+  recorded_at: Mon, 10 Apr 2017 15:28:28 GMT
+recorded_with: VCR 3.0.3

--- a/src/api/spec/cassettes/Webui_PackageController/build_logs/GET_update_build_log/it_should_behave_like_build_log/with_a_nonexistant_repository/1_13_2_1_7_2.yml
+++ b/src/api/spec/cassettes/Webui_PackageController/build_logs/GET_update_build_log/it_should_behave_like_build_log/with_a_nonexistant_repository/1_13_2_1_7_2.yml
@@ -1,0 +1,75 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://localhost:3200/build/home:tom//i586/my_package/_log?view=entry
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - text/plain
+      Accept-Encoding:
+      - identity
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 400
+      message: repoid is empty
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '67'
+    body:
+      encoding: UTF-8
+      string: |
+        <status code="400">
+          <summary>repoid is empty</summary>
+        </status>
+    http_version: 
+  recorded_at: Mon, 10 Apr 2017 15:28:29 GMT
+- request:
+    method: get
+    uri: http://localhost:3200/build/home:tom//i586/my_package/_log?end=65536&nostream=1&start=0
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - text/plain
+      Accept-Encoding:
+      - identity
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 400
+      message: repoid is empty
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '67'
+    body:
+      encoding: UTF-8
+      string: |
+        <status code="400">
+          <summary>repoid is empty</summary>
+        </status>
+    http_version: 
+  recorded_at: Mon, 10 Apr 2017 15:28:29 GMT
+recorded_with: VCR 3.0.3

--- a/src/api/spec/cassettes/Webui_PackageController/build_logs/GET_update_build_log/it_should_behave_like_build_log/with_a_protected_package/1_13_2_1_4_1.yml
+++ b/src/api/spec/cassettes/Webui_PackageController/build_logs/GET_update_build_log/it_should_behave_like_build_log/with_a_protected_package/1_13_2_1_4_1.yml
@@ -119,4 +119,90 @@ http_interactions:
         </package>
     http_version: 
   recorded_at: Wed, 22 Mar 2017 12:10:48 GMT
+- request:
+    method: put
+    uri: http://localhost:3200/source/home:tom/_meta?user=tom
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:tom">
+          <title/>
+          <description/>
+          <person userid="tom" role="maintainer"/>
+          <repository name="leap_42.2">
+            <arch>i586</arch>
+          </repository>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '199'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:tom">
+          <title></title>
+          <description></description>
+          <person userid="tom" role="maintainer" />
+          <repository name="leap_42.2">
+            <arch>i586</arch>
+          </repository>
+        </project>
+    http_version: 
+  recorded_at: Tue, 11 Apr 2017 11:58:21 GMT
+- request:
+    method: put
+    uri: http://localhost:3200/source/home:tom/my_package/_meta?user=tom
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="my_package" project="home:tom">
+          <title/>
+          <description/>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '106'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="my_package" project="home:tom">
+          <title></title>
+          <description></description>
+        </package>
+    http_version: 
+  recorded_at: Tue, 11 Apr 2017 11:58:21 GMT
 recorded_with: VCR 3.0.3

--- a/src/api/spec/cassettes/Webui_PackageController/build_logs/GET_update_build_log/it_should_behave_like_build_log/with_a_protected_package/1_13_2_1_4_2.yml
+++ b/src/api/spec/cassettes/Webui_PackageController/build_logs/GET_update_build_log/it_should_behave_like_build_log/with_a_protected_package/1_13_2_1_4_2.yml
@@ -119,4 +119,90 @@ http_interactions:
         </package>
     http_version: 
   recorded_at: Wed, 22 Mar 2017 12:10:48 GMT
+- request:
+    method: put
+    uri: http://localhost:3200/source/home:tom/_meta?user=tom
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:tom">
+          <title/>
+          <description/>
+          <person userid="tom" role="maintainer"/>
+          <repository name="leap_42.2">
+            <arch>i586</arch>
+          </repository>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '199'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:tom">
+          <title></title>
+          <description></description>
+          <person userid="tom" role="maintainer" />
+          <repository name="leap_42.2">
+            <arch>i586</arch>
+          </repository>
+        </project>
+    http_version: 
+  recorded_at: Tue, 11 Apr 2017 11:58:21 GMT
+- request:
+    method: put
+    uri: http://localhost:3200/source/home:tom/my_package/_meta?user=tom
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="my_package" project="home:tom">
+          <title/>
+          <description/>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '106'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="my_package" project="home:tom">
+          <title></title>
+          <description></description>
+        </package>
+    http_version: 
+  recorded_at: Tue, 11 Apr 2017 11:58:21 GMT
 recorded_with: VCR 3.0.3

--- a/src/api/spec/controllers/webui/package_controller_spec.rb
+++ b/src/api/spec/controllers/webui/package_controller_spec.rb
@@ -685,18 +685,26 @@ EOT
     let(:source_project_with_plus) { create(:project, name: 'foo++bar') }
     let(:package_of_project_with_plus) { create(:package, name: 'some_package', project: source_project_with_plus) }
     let(:source_package_with_plus) { create(:package, name: 'my_package++special', project: source_project) }
+    let(:repo_leap_42_2) { create(:repository, name: 'leap_42.2', project: source_project, architectures: ['i586']) }
+
     RSpec.shared_examples "build log" do
+      before do
+        login user
+        repo_leap_42_2
+        source_project.store
+      end
+
       context "successfully" do
         before do
           path = "#{CONFIG['source_url']}/build/#{user.home_project}/_result?view=status" \
-                 "&package=#{source_package}&arch=i586&repository=10.2"
+                 "&package=#{source_package}&arch=i586&repository=#{repo_leap_42_2}"
           stub_request(:get, path).and_return(body:
             %(<resultlist state='123'>
-               <result project='#{user.home_project.name}' repository='10.2' arch='i586'>
+               <result project='#{user.home_project}' repository='#{repo_leap_42_2}' arch='i586'>
                  <binarylist/>
                </result>
               </resultlist>))
-          do_request project: source_project, package: source_package, repository: '10.2', arch: 'i586', format: 'js'
+          do_request project: source_project, package: source_package, repository: repo_leap_42_2.name, arch: 'i586', format: 'js'
         end
 
         it { expect(response).to have_http_status(:ok) }
@@ -705,30 +713,36 @@ EOT
       context "successfully with a package which name that includes '+'" do
         before do
           path = "#{CONFIG['source_url']}/build/#{user.home_project}/_result?view=status" \
-                 "&package=#{source_package_with_plus}&arch=i586&repository=10.2"
+                 "&package=#{source_package_with_plus}&arch=i586&repository=#{repo_leap_42_2}"
           stub_request(:get, path).and_return(body:
             %(<resultlist state='123'>
-               <result project='#{user.home_project.name}' repository='10.2' arch='i586'>
+               <result project='#{user.home_project}' repository='#{repo_leap_42_2}' arch='i586'>
                  <binarylist/>
                </result>
               </resultlist>))
-          do_request project: source_project, package: source_package_with_plus, repository: '10.2', arch: 'i586', format: 'js'
+          do_request project: source_project, package: source_package_with_plus, repository: repo_leap_42_2.name, arch: 'i586', format: 'js'
         end
 
         it { expect(response).to have_http_status(:ok) }
       end
 
       context "successfully with a project which name that includes '+'" do
+        let(:repo_leap_45_1) { create(:repository, name: 'leap_45.1', project: source_project_with_plus, architectures: ['i586']) }
+
         before do
+          repo_leap_45_1
+          source_project_with_plus.store
+
           path = "#{CONFIG['source_url']}/build/#{source_project_with_plus}/_result?view=status" \
-                 "&package=#{package_of_project_with_plus}&arch=i586&repository=10.2"
+                 "&package=#{package_of_project_with_plus}&arch=i586&repository=#{repo_leap_45_1}"
           stub_request(:get, path).and_return(body:
             %(<resultlist state='123'>
-               <result project='#{source_project_with_plus.name}' repository='10.2' arch='i586'>
+               <result project='#{source_project_with_plus}' repository='#{repo_leap_45_1}' arch='i586'>
                  <binarylist/>
                </result>
               </resultlist>))
-          do_request project: source_project_with_plus, package: package_of_project_with_plus, repository: '10.2', arch: 'i586', format: 'js'
+          do_request project: source_project_with_plus, package: package_of_project_with_plus,
+            repository: repo_leap_45_1.name, arch: 'i586', format: 'js'
         end
 
         it { expect(response).to have_http_status(:ok) }
@@ -738,7 +752,7 @@ EOT
         let!(:flag) { create(:sourceaccess_flag, project: source_project) }
 
         before do
-          do_request project: source_project, package: source_package, repository: '10.2', arch: 'i586', format: 'js'
+          do_request project: source_project, package: source_package, repository: repo_leap_42_2.name, arch: 'i586', format: 'js'
         end
 
         it { expect(flash[:error]).to eq('Could not access build log') }
@@ -747,7 +761,7 @@ EOT
 
       context "with a non existant package" do
         before do
-          do_request project: source_project, package: 'nonexistant', repository: '10.2', arch: 'i586'
+          do_request project: source_project, package: 'nonexistant', repository: repo_leap_42_2.name, arch: 'i586'
         end
 
         it { expect(flash[:error]).to eq("Couldn't find package 'nonexistant' in project '#{source_project}'. Are you sure it exists?") }
@@ -756,7 +770,7 @@ EOT
 
       context "with a non existant project" do
         before do
-          do_request project: 'home:foo', package: 'nonexistant', repository: '10.2', arch: 'i586'
+          do_request project: 'home:foo', package: 'nonexistant', repository: repo_leap_42_2.name, arch: 'i586'
         end
 
         it { expect(flash[:error]).to eq("Couldn't find project 'home:foo'. Are you sure it still exists?") }
@@ -770,6 +784,24 @@ EOT
       end
 
       it_should_behave_like "build log"
+
+      context "with a nonexistant repository" do
+        before do
+          do_request project: source_project, package: source_package, repository: 'nonrepository', arch: 'i586'
+        end
+
+        it { expect(flash[:error]).not_to be_nil }
+        it { expect(response).to redirect_to(package_show_path(source_project, source_package)) }
+      end
+
+      context "with a nonexistant architecture" do
+        before do
+          do_request project: source_project, package: source_package, repository: repo_leap_42_2.name, arch: 'i566'
+        end
+
+        it { expect(flash[:error]).not_to be_nil }
+        it { expect(response).to redirect_to(package_show_path(source_project, source_package)) }
+      end
     end
 
     describe "GET #update_build_log" do
@@ -778,6 +810,24 @@ EOT
       end
 
       it_should_behave_like "build log"
+
+      context "with a nonexistant repository" do
+        before do
+          do_request project: source_project, package: source_package, repository: 'nonrepository', arch: 'i586'
+        end
+
+        it { expect(assigns(:errors)).not_to be_nil }
+        it { expect(response).to have_http_status(:ok) }
+      end
+
+      context "with a nonexistant architecture" do
+        before do
+          do_request project: source_project, package: source_package, repository: repo_leap_42_2.name, arch: 'i566'
+        end
+
+        it { expect(assigns(:errors)).not_to be_nil }
+        it { expect(response).to have_http_status(:ok) }
+      end
     end
   end
 

--- a/src/api/test/fixtures/events.yml
+++ b/src/api/test/fixtures/events.yml
@@ -1,7 +1,7 @@
 build_fails_with_deleted_user_and_request:
   id: 1
   eventtype: Event::BuildFail
-  payload: '{"project":"BaseDistro","package":"pack1","requestid":"666","sender":"no_longer_there","rev":"5"}'
+  payload: '{"project":"BaseDistro","package":"pack1","repository":"10.2","arch":"i586","requestid":"666","sender":"no_longer_there","rev":"5"}'
   queued: 0
   lock_version: 0
   created_at: 2013-08-30 14:56:50.000000000 Z
@@ -18,7 +18,7 @@ build_failure_for_iggy:
   updated_at: 2013-08-31 14:56:52.000000000 Z
   project_logged: 0
 build_failure_for_reader:
-  id: 19 
+  id: 19
   eventtype: Event::BuildFail
   payload: '{"project":"home:Iggy","package":"TestPack","repository":"10.2","arch":"i586","release":"42.1","versrel":"1.0-42","readytime":"1377958901","srcmd5":"1ac07842727acaf13d0e2b3213b47785","rev":"2","revtime":"1377958897","reason":"new
     build","bcnt":"1","verifymd5":"1ac07842727acaf13d0e2b3213b47785","workerid":"build12"}'

--- a/src/api/test/models/project_log_entry_test.rb
+++ b/src/api/test/models/project_log_entry_test.rb
@@ -44,7 +44,7 @@ class ProjectLogEntryTest < ActiveSupport::TestCase
     assert_nil entry.user
     assert_equal "no_longer_there", entry.user_name
     assert_nil entry.bs_request
-    assert_equal({"rev" => "5"}, entry.additional_info)
+    assert_equal({"repository" => "10.2", "arch" => "i586", "rev" => "5"}, entry.additional_info)
   end
 
   test "#clean_older_than" do

--- a/src/api/test/unit/code_quality_test.rb
+++ b/src/api/test/unit/code_quality_test.rb
@@ -98,7 +98,7 @@ class CodeQualityTest < ActiveSupport::TestCase
       'Webui::PackageController#branch'                                         => 124.26,
       'Webui::PackageController#submit_request'                                 => 110.76,
       'Webui::PackageController#dependency'                                     => 83.57,
-      'Webui::PackageController#update_build_log'                               => 81.73,
+      'Webui::PackageController#update_build_log'                               => 87.0,
       'Webui::PatchinfoController#save'                                         => 256.25,
       'Webui::RequestController#show'                                           => 91.96,
       'Webui::SearchController#set_parameters'                                  => 98.04,


### PR DESCRIPTION
The problem was that you were allowed to enter the 'live build log' view with a repository or an invalid/nonexistent architecture, causing the log not been shown and URL to download and refresh will be generated incorrectly.