### PR TITLE
[api] Remove overwritten 'maintenance_incidents' associations

### DIFF
--- a/src/api/app/models/project.rb
+++ b/src/api/app/models/project.rb
@@ -80,8 +80,6 @@ class Project < ApplicationRecord
   has_many :maintenance_projects, class_name: 'MaintainedProject', foreign_key: :project_id, dependent: :delete_all
 
   has_many :incident_updateinfo_counter_values, foreign_key: :project_id, dependent: :delete_all
-  has_many :maintenance_incidents, foreign_key: :project_id, dependent: :delete_all
-  has_many :maintenance_incidents, foreign_key: :maintenance_db_project_id, dependent: :delete_all
 
   # develproject is history, use develpackage instead. FIXME3.0: clean this up
   has_many :develprojects, class_name: 'Project', foreign_key: 'develproject_id'


### PR DESCRIPTION
They are being overwritten by [maintenance_incidentes](https://github.com/DavidKang/open-build-service/blob/abe4800ddccca9deb7fceeebd56ece1d34b12ea8/src/api/app/models/project.rb#L1306-L1311) method