### PR TITLE
[api] Use proper :filename instead of :file in public_build route

### DIFF
--- a/src/api/app/views/webui/package/_live_log_controls.html.erb
+++ b/src/api/app/views/webui/package/_live_log_controls.html.erb
@@ -2,7 +2,7 @@
   <%= link_to sprited_text('script_lightning', 'Start refresh'), '#', class: 'start_refresh hidden' %>
   <%= link_to sprited_text('script_link', 'Stop refresh'), '#', class: 'stop_refresh' %>
   <% if User.current.is_nobody? %>
-    <%= link_to sprited_text('script', 'Download logfile'), public_build_path(package: @build_container, project: @project, arch: @arch, repository: @repo, file: '_log') %>
+    <%= link_to sprited_text('script', 'Download logfile'), public_build_path(package: @build_container, project: @project, arch: @arch, repository: @repo, filename: '_log') %>
   <% else %>
     <%= link_to sprited_text('script', 'Download logfile'), raw_logfile_path(package: @build_container, project: @project, arch: @arch, repository: @repo) %>
   <% end %>

--- a/src/api/config/routes.rb
+++ b/src/api/config/routes.rb
@@ -637,7 +637,7 @@ OBSApi::Application.routes.draw do
       get 'public/source/:project/:package/:filename' => :source_file, constraints: cons
       get 'public/distributions' => :distributions
       get 'public/binary_packages/:project/:package' => :binary_packages, constraints: cons
-      get 'public/build/:project(/:repository(/:arch(/:package(/:file))))' => 'public#build', constraints: cons, as: :public_build
+      get 'public/build/:project(/:repository(/:arch(/:package(/:filename))))' => 'public#build', constraints: cons, as: :public_build
     end
 
     get '/404' => 'main#notfound'

--- a/src/api/spec/routing/api_matcher_spec.rb
+++ b/src/api/spec/routing/api_matcher_spec.rb
@@ -17,14 +17,14 @@ RSpec.describe 'APIMatcher' do
     it { expect(get("/public/configuration?format=#{format}")).to route_to(controller: 'public', action: 'configuration_show', format: format) }
 
     it {
-      expect(get("/public/build/project/repository/arch/package/file.#{format}")).
+      expect(get("/public/build/project/repository/arch/package/filename?format=#{format}")).
         to route_to(controller: 'public',
                     action: 'build',
                     project: 'project',
                     repository: 'repository',
                     arch: 'arch',
                     package: 'package',
-                    file: 'file',
+                    filename: 'filename',
                     format: format)
     }
     it {

--- a/src/api/test/functional/public_controller_test.rb
+++ b/src/api/test/functional/public_controller_test.rb
@@ -141,6 +141,9 @@ class PublicControllerTest < ActionDispatch::IntegrationTest
     assert_xml_tag tag: "binary", attributes: { filename: "package-1.0-1.i586.rpm" }
 
     get "/public/build/home:Iggy/10.2/i586/TestPack/package-1.0-1.i586.rpm"
+    assert_response 200
+
+    get "/public/build/home:Iggy/10.2/i586/TestPack/not-existent.rpm"
     assert_response 404
   end
 end


### PR DESCRIPTION
Otherwise the filename constraint does not match and we end up
in rather random rails route matching.

Supersedes #2935 and fixes the failing tests.

cc @coolo