### PR TITLE
[ci] Use const_stub instead of temporarely overwriting CONFIG

### DIFF
--- a/src/api/spec/controllers/webui/apidocs_controller_spec.rb
+++ b/src/api/spec/controllers/webui/apidocs_controller_spec.rb
@@ -2,12 +2,6 @@ require 'rails_helper'
 
 RSpec.describe Webui::ApidocsController, type: :controller do
   describe "GET #index" do
-    let!(:previous_apidocs_location) { CONFIG['apidocs_location'] }
-
-    after do
-      CONFIG['apidocs_location'] = previous_apidocs_location
-    end
-
     context "correct setup" do
       let(:tmp_dir) { Dir.mktmpdir }
       let(:tmp_file) { "#{tmp_dir}/index.html" }
@@ -34,7 +28,7 @@ RSpec.describe Webui::ApidocsController, type: :controller do
 
     context "broken setup" do
       before do
-        CONFIG['apidocs_location'] = 'non/existent/subdirectory'
+        stub_const('CONFIG', CONFIG.merge('apidocs_location' => 'non/existent/subdirectory'))
       end
 
       it "errors and redirects" do
@@ -58,15 +52,10 @@ RSpec.describe Webui::ApidocsController, type: :controller do
           f
         end
       end
-      let!(:previous_schema_location) { CONFIG['schema_location'] }
 
       before do
-        CONFIG['schema_location'] = Dir.tmpdir
+        stub_const('CONFIG', CONFIG.merge('schema_location' => Dir.tmpdir))
         get :file, params: { filename: File.basename(tmp_file.path) }
-      end
-
-      after do
-        CONFIG['schema_location'] = previous_schema_location
       end
 
       it "reponses without error" do

--- a/src/api/spec/features/webui/login_spec.rb
+++ b/src/api/spec/features/webui/login_spec.rb
@@ -5,13 +5,8 @@ RSpec.feature "Login", type: :feature, js: true do
 
   context "In proxy mode" do
     before do
-      @before = CONFIG["proxy_auth_mode"]
       # Fake proxy mode
-      CONFIG["proxy_auth_mode"] = :on
-    end
-
-    after do
-      CONFIG["proxy_auth_mode"] = @before
+      stub_const('CONFIG', CONFIG.merge('proxy_auth_mode' => :on))
     end
 
     scenario "should log in a user when the header is set" do

--- a/src/api/spec/requests/kerberos_login_spec.rb
+++ b/src/api/spec/requests/kerberos_login_spec.rb
@@ -1,4 +1,5 @@
 require 'rails_helper'
+
 require 'gssapi'
 
 RSpec.describe 'Kerberos login', vcr: false, type: :request do
@@ -7,17 +8,10 @@ RSpec.describe 'Kerberos login', vcr: false, type: :request do
     let(:user) { create(:confirmed_user) }
 
     before do
-      @before = {
-        kerberos_service_principal: CONFIG['kerberos_service_principal'],
-        kerberos_realm:             CONFIG['kerberos_realm']
-      }
-      CONFIG['kerberos_service_principal'] = 'HTTP/obs.test.com@test_realm.com'
-      CONFIG['kerberos_realm']             = 'test_realm.com'
-    end
-
-    after do
-      CONFIG['kerberos_service_principal'] = @before[:kerberos_service_principal]
-      CONFIG['kerberos_realm'] = @before[:kerberos_realm]
+      stub_const('CONFIG', CONFIG.merge({
+        'kerberos_service_principal' => 'HTTP/obs.test.com@test_realm.com',
+        'kerberos_realm'             => 'test_realm.com'
+      }))
     end
 
     context 'with valid ticket' do


### PR DESCRIPTION
This spares us from manually setting and re-setting the constant via
before and after filter.