### PR TITLE
[api] Move gssapi to default Gemfile group

### DIFF
--- a/src/api/Gemfile
+++ b/src/api/Gemfile
@@ -62,6 +62,8 @@ gem 'feature'
 gem 'peek'
 gem 'peek-dalli'
 gem 'peek-mysql2'
+# for kerberos authentication
+gem "gssapi", require: false
 
 group :development, :production do
   # to have the delayed job daemon
@@ -74,8 +76,6 @@ group :development, :production do
   gem 'clockwork', '>= 0.7'
   # as interface to LDAP
   gem 'ruby-ldap', require: false
-  # to enable GSSAPI / Kerberos authentication
-  gem "gssapi", require: false
 end
 
 group :production do


### PR DESCRIPTION
This is used in production when the config variable is set,
hence required.