### PR TITLE
[ci] Check build status for openQA mail notifier

### DIFF
--- a/dist/openQA_mail_notification.rb
+++ b/dist/openQA_mail_notification.rb
@@ -72,7 +72,7 @@ store = YAML::Store.new('builds.yml')
 last_build = store.transaction { store[:name] }
 result = last_build <=> build['name']
 
-unless result == 0
+if result != 0 && build['state'] == 'done'
   modules = build['modules']
   successful_modules = modules.select { |m| m['result'] == 'passed' }
   failed_modules = modules.select { |m| m['result'] == 'failed' }


### PR DESCRIPTION
to avoid sending mails while openQA is still running.