### PR TITLE
[webui] Fix build log for multibuild and local link packages

### DIFF
--- a/ReleaseNotes-2.8
+++ b/ReleaseNotes-2.8
@@ -3,13 +3,6 @@
 # Open Build Service 2.8
 #
 
-WARNING:
-WARNING: This is a development release, not for production usage!
-WARNING:
-
-
-
-
 Please read the README.SETUP file for initial installation
 instructions or use the OBS Appliance from
 

--- a/ReleaseNotes-2.8.1
+++ b/ReleaseNotes-2.8.1
@@ -19,4 +19,4 @@ Changes:
 Bugfixes:
 =========
 
-* none
+* [webui] Fixing live log view for multibuild and local link packages

--- a/src/api/app/controllers/webui/package_controller.rb
+++ b/src/api/app/controllers/webui/package_controller.rb
@@ -783,7 +783,7 @@ class Webui::PackageController < Webui::WebuiController
     @percent = nil
 
     begin
-      jobstatus = get_job_status( @project, @package, @repo, @arch )
+      jobstatus = get_job_status( @project, @build_container, @repo, @arch )
       unless jobstatus.blank?
         js = Xmlhash.parse(jobstatus)
         @workerid = js.get('workerid')
@@ -805,7 +805,7 @@ class Webui::PackageController < Webui::WebuiController
     @arch = params[:arch] if Architecture.archcache[params[:arch]]
     @repo = @project.repositories.find_by(name: params[:repository]).try(:name)
     @offset = 0
-    @status = get_status(@project, @package, @repo, @arch) if @project && @package && @repo && @arch
+    @status = get_status(@project, @build_container, @repo, @arch) if @project && @package && @repo && @arch
 
     set_job_status
   end
@@ -827,6 +827,7 @@ class Webui::PackageController < Webui::WebuiController
 
     check_ajax
 
+    @package = params[:package]
     # Make sure objects don't contain invalid chars (eg. '../')
     @arch = params[:arch] if Architecture.archcache[params[:arch]]
     @repo = @project.repositories.find_by(name: params[:repository]).try(:name)
@@ -848,7 +849,6 @@ class Webui::PackageController < Webui::WebuiController
       return
     end
 
-    @package = params[:package]
     begin
       chunk = get_log_chunk(@project, @package, @repo, @arch, @offset, @offset + @maxsize)
 

--- a/src/api/spec/controllers/webui/package_controller_spec.rb
+++ b/src/api/spec/controllers/webui/package_controller_spec.rb
@@ -769,4 +769,33 @@ EOT
       it_should_behave_like "build log"
     end
   end
+
+  describe 'GET #update_build_log' do
+    let(:architecture) { repo_for_source_project.architectures.first }
+    let(:params) {
+      { project:    source_project,
+        package:    "#{source_package}:multibuild-package",
+        repository: repo_for_source_project.name,
+        arch:       architecture.name}
+    }
+
+    context 'for multibuild package' do
+      context 'instance variables' do
+        before do
+          get :update_build_log, params: params, xhr: true
+        end
+
+        # This is fine as backend does not need to run to test this. Otherwise it would be necessary to create first a multibuild package in the backend
+        it { expect(assigns(:log_chunk)).to match(/No live log available:/) }
+        it { expect(assigns(:package)).to eq("#{source_package}:multibuild-package") }
+        it { expect(assigns(:project)).to eq(source_project) }
+      end
+
+      it "should call 'get_size_of_log' with appropriate arguments" do
+        expect(controller).to receive(:get_size_of_log).
+          with(source_project, "#{source_package}:multibuild-package", repo_for_source_project.name, architecture.name)
+        get :update_build_log, params: params, xhr: true
+      end
+    end
+  end
 end


### PR DESCRIPTION
The @package variable was set in the check_build_log_access before filter.
However, for multibuild and local link packages this was set to the parent package (follow_mulitbuild / follow_project_links)
which does not contain a log file. This resulted that set_initial_offset returned an empty log and calculated no offset
which eventually resulted in cutting the end of the log files.
Fix #2651.