### PR TITLE
Kerberos authentication via webui and some minor improvements

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -111,7 +111,7 @@ Metrics/MethodLength:
 # Offense count: 7
 # Configuration parameters: CountComments.
 Metrics/ModuleLength:
-  Max: 351
+  Max: 352
 
 # Offense count: 16
 # Configuration parameters: CountKeywordArgs.

--- a/ReleaseNotes-2.9
+++ b/ReleaseNotes-2.9
@@ -28,9 +28,11 @@ Features
 ========
 
 UI:
- *
+ * Kerberos authentication mode. Allow OBS admins to setup their instance for
+   kerberos authentication. Read more in the OBS Admin Guide.
 
 API:
+ * Kerberos authentication mode
  * api_relative_url_root option was removed
 
 Backend:

--- a/src/api/app/controllers/application_controller.rb
+++ b/src/api/app/controllers/application_controller.rb
@@ -306,7 +306,7 @@ class ApplicationController < ActionController::Base
 
     if @status == 401
       unless response.headers["WWW-Authenticate"]
-        if CONFIG['kerberos_service_principal']
+        if CONFIG['kerberos_mode']
           response.headers["WWW-Authenticate"] = 'Negotiate'
         else
           response.headers["WWW-Authenticate"] = 'basic realm="API login"'

--- a/src/api/app/controllers/webui/user_controller.rb
+++ b/src/api/app/controllers/webui/user_controller.rb
@@ -5,6 +5,7 @@ class Webui::UserController < Webui::WebuiController
   before_action :check_display_user, only: [:show, :edit, :list_my, :delete, :save, :confirm, :admin, :lock]
   before_action :require_login, only: [:edit, :save, :notifications, :update_notifications, :index]
   before_action :require_admin, only: [:edit, :delete, :lock, :confirm, :admin, :index]
+  before_action :kerberos_auth, only: [:login]
 
   skip_before_action :check_anonymous, only: [:do_login]
 

--- a/src/api/app/controllers/webui/webui_controller.rb
+++ b/src/api/app/controllers/webui/webui_controller.rb
@@ -104,7 +104,7 @@ class Webui::WebuiController < ActionController::Base
   protected
 
   def require_login
-    if CONFIG['kerberos_service_principal']
+    if CONFIG['kerberos_mode']
       kerberos_auth
     else
       if User.current.nil? || User.current.is_nobody?
@@ -165,7 +165,7 @@ class Webui::WebuiController < ActionController::Base
   end
 
   def kerberos_auth
-    return true unless CONFIG['kerberos_service_principal'] && (User.current.nil? || User.current.is_nobody?)
+    return true unless CONFIG['kerberos_mode'] && (User.current.nil? || User.current.is_nobody?)
 
     authorization = authenticator.authorization_infos || []
     if authorization[0].to_s != "Negotiate"

--- a/src/api/app/helpers/webui/webui_helper.rb
+++ b/src/api/app/helpers/webui/webui_helper.rb
@@ -379,6 +379,7 @@ module Webui::WebuiHelper
   end
 
   def can_register
+    return false if CONFIG['kerberos_service_principal']
     return true if User.current.try(:is_admin?)
 
     begin

--- a/src/api/app/helpers/webui/webui_helper.rb
+++ b/src/api/app/helpers/webui/webui_helper.rb
@@ -379,7 +379,7 @@ module Webui::WebuiHelper
   end
 
   def can_register
-    return false if CONFIG['kerberos_service_principal']
+    return false if CONFIG['kerberos_mode']
     return true if User.current.try(:is_admin?)
 
     begin

--- a/src/api/app/models/user.rb
+++ b/src/api/app/models/user.rb
@@ -53,7 +53,7 @@ class User < ApplicationRecord
 
   scope :all_without_nobody, -> { where("login != ?", nobody_login) }
 
-  validates :login, :email, :password, :password_hash_type, :state,
+  validates :login, :password, :password_hash_type, :state,
             presence: { message: 'must be given' }
 
   validates :login,
@@ -73,8 +73,9 @@ class User < ApplicationRecord
   # However, this is not *so* bad since users have to answer on their email
   # to confirm their registration.
   validates :email,
-            format: { with:    %r{\A([\w\-\.\#\$%&!?*\'\+=(){}|~]+)@([0-9a-zA-Z\-\.\#\$%&!?*\'=(){}|~]+)+\z},
-                      message: 'must be a valid email address.' }
+            format: { with:        %r{\A([\w\-\.\#\$%&!?*\'\+=(){}|~]+)@([0-9a-zA-Z\-\.\#\$%&!?*\'=(){}|~]+)+\z},
+                      message:     'must be a valid email address.',
+                      allow_blank: true }
 
   # We want to validate the format of the password and only allow alphanumeric
   # and some punctiation/base64 characters.

--- a/src/api/app/models/user.rb
+++ b/src/api/app/models/user.rb
@@ -231,8 +231,7 @@ class User < ApplicationRecord
       password = SecureRandom.base64
       user = User.create( login: login,
                           password: password,
-                          email: ldap_info[0],
-                          last_logged_in_at: Time.now)
+                          email: ldap_info[0])
       unless user.errors.empty?
         logger.debug("Creating User failed with: ")
         all_errors = user.errors.full_messages.map do |msg|

--- a/src/api/app/views/layouts/webui/_personal_navigation.html.erb
+++ b/src/api/app/views/layouts/webui/_personal_navigation.html.erb
@@ -19,6 +19,8 @@
         <%= link_to "Create Home", new_project_path(name: User.current.home_project_name) %>
       <% end %> |
     <%= link_to 'Logout', user_logout_path, method: :post, id: 'logout-link' %>
+  <% elsif CONFIG['kerberos_mode'] %>
+    <%= link_to 'Log In', user_login_path %>
   <% else %>
     <% if CONFIG['proxy_auth_mode'] == :on %>
       <% unless CONFIG['proxy_auth_register_page'].blank? %>

--- a/src/api/app/views/webui/user/login.html.haml
+++ b/src/api/app/views/webui/user/login.html.haml
@@ -6,6 +6,14 @@
       %input{name: "proxypath", type: "hidden", value: "reverse"}/
       %input{name: "message", type: "hidden", value: "Please log In"}/
       = render partial: 'login_form'
+- elsif CONFIG['kerberos_mode']
+  %h2
+    Kerberos authentication required
+  %div
+    %p
+      You are seeing this page, because you are not authenticated in the kerberos realm ('#{CONFIG['kerberos_realm']}').
+    %p
+      Please ensure you have a valid ticket and try again.
 - else
   = form_tag controller: :user, action: :do_login, method: :post do
     = render partial: 'login_form'

--- a/src/api/config/options.yml.example
+++ b/src/api/config/options.yml.example
@@ -34,11 +34,6 @@ frontend_protocol: https
 #external_frontend_port: 443
 #external_frontend_protocol: https
 
-# Kerberos authentication
-#kerberos_keytab: "/etc/krb5.keytab"
-#kerberos_service_principal: "HTTP/hostname.example.com@EXAMPLE.COM"
-#kerberos_realm: "EXAMPLE.COM"
-
 extended_backend_log: false
 
 # proxy_auth_mode can be :off, :on or :simulate
@@ -49,6 +44,16 @@ proxy_auth_mode: :off
 # valid user does no further authentication. So take care...
 proxy_auth_test_user: coolguy
 proxy_auth_test_email: coolguy@example.com
+
+### Kerberos configuration
+
+# can be true or false
+kerberos_mode: false
+
+#kerberos_keytab: "/etc/krb5.keytab"
+#kerberos_service_principal: "HTTP/hostname.example.com@EXAMPLE.COM"
+#kerberos_realm: "EXAMPLE.COM"
+
 
 #schema_location
 

--- a/src/api/lib/authenticator.rb
+++ b/src/api/lib/authenticator.rb
@@ -138,7 +138,8 @@ class Authenticator
       @login = krb.display_name.partition("@")[0]
       @http_user = User.find_by_login(@login)
       unless @http_user
-        raise AuthenticationRequiredError, "User '#{@login}' has no account on the server."
+        Rails.logger.debug "Creating account for user '#{@login}'"
+        @http_user = User.create_user_with_fake_pw!(login: @login, state: User.default_user_state)
       end
     rescue GSSAPI::GssApiError => error
       raise AuthenticationRequiredError, "Received a GSSAPI exception; #{error.message}."

--- a/src/api/lib/authenticator.rb
+++ b/src/api/lib/authenticator.rb
@@ -87,6 +87,18 @@ class Authenticator
     true
   end
 
+  def authorization_infos
+    # 1. try to get it where mod_rewrite might have put it
+    # 2. for Apache/mod_fastcgi with -pass-header Authorization
+    # 3. regular location
+    %w(X-HTTP_AUTHORIZATION Authorization HTTP_AUTHORIZATION).each do |header|
+      if request.env.has_key? header
+        return request.env[header].to_s.split
+      end
+    end
+    return
+  end
+
   private
 
   def initialize_krb_session
@@ -204,18 +216,6 @@ class Authenticator
     else
       Rails.logger.debug "No authentication string was received."
     end
-  end
-
-  def authorization_infos
-    # 1. try to get it where mod_rewrite might have put it
-    # 2. for Apace/mod_fastcgi with -pass-header Authorization
-    # 3. regular location
-    %w(X-HTTP_AUTHORIZATION Authorization HTTP_AUTHORIZATION).each do |header|
-      if request.env.has_key? header
-        return request.env[header].to_s.split
-      end
-    end
-    return
   end
 
   def check_extracted_user

--- a/src/api/spec/cassettes/Login/in_kerberos_mode/for_a_normal_request_that_requires_login/and_Negotiate_header_is_not_set/informs_the_client_tool_browser_that_kerberos_authentication_is_required.yml
+++ b/src/api/spec/cassettes/Login/in_kerberos_mode/for_a_normal_request_that_requires_login/and_Negotiate_header_is_not_set/informs_the_client_tool_browser_that_kerberos_authentication_is_required.yml
@@ -1,0 +1,58 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://localhost:3200/build/_workerstatus
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - text/plain
+      Accept-Encoding:
+      - identity
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '927'
+    body:
+      encoding: UTF-8
+      string: |
+        <workerstatus clients="1">
+          <idle workerid="worker:1" hostarch="x86_64" />
+          <waiting arch="i586" jobs="1" />
+          <waiting arch="x86_64" jobs="0" />
+          <blocked arch="i586" jobs="0" />
+          <blocked arch="x86_64" jobs="0" />
+          <buildavg arch="i586" buildavg="1200" />
+          <buildavg arch="x86_64" buildavg="1200" />
+          <partition>
+            <daemon type="srcserver" state="running" starttime="1492526484" />
+            <daemon type="servicedispatch" state="running" starttime="1492526485" />
+            <daemon type="service" state="running" starttime="1492526485" />
+            <daemon type="scheduler" arch="i586" state="dead">
+              <queue high="0" med="0" low="3" next="0" />
+            </daemon>
+            <daemon type="scheduler" arch="x86_64" state="dead">
+              <queue high="39" med="0" low="7" next="0" />
+            </daemon>
+            <daemon type="repserver" state="running" starttime="1492526484" />
+            <daemon type="publisher" state="dead" />
+          </partition>
+        </workerstatus>
+    http_version: 
+  recorded_at: Wed, 19 Apr 2017 07:34:07 GMT
+recorded_with: VCR 3.0.3

--- a/src/api/spec/cassettes/Login/in_kerberos_mode/for_a_normal_request_that_requires_login/and_Negotiate_header_is_not_set/informs_users_about_failed_kerberos_authentication_and_possible_cause.yml
+++ b/src/api/spec/cassettes/Login/in_kerberos_mode/for_a_normal_request_that_requires_login/and_Negotiate_header_is_not_set/informs_users_about_failed_kerberos_authentication_and_possible_cause.yml
@@ -1,0 +1,58 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://localhost:3200/build/_workerstatus
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - text/plain
+      Accept-Encoding:
+      - identity
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '927'
+    body:
+      encoding: UTF-8
+      string: |
+        <workerstatus clients="1">
+          <idle workerid="worker:1" hostarch="x86_64" />
+          <waiting arch="i586" jobs="1" />
+          <waiting arch="x86_64" jobs="0" />
+          <blocked arch="i586" jobs="0" />
+          <blocked arch="x86_64" jobs="0" />
+          <buildavg arch="i586" buildavg="1200" />
+          <buildavg arch="x86_64" buildavg="1200" />
+          <partition>
+            <daemon type="srcserver" state="running" starttime="1492526484" />
+            <daemon type="servicedispatch" state="running" starttime="1492526485" />
+            <daemon type="service" state="running" starttime="1492526485" />
+            <daemon type="scheduler" arch="i586" state="dead">
+              <queue high="0" med="0" low="3" next="0" />
+            </daemon>
+            <daemon type="scheduler" arch="x86_64" state="dead">
+              <queue high="39" med="0" low="7" next="0" />
+            </daemon>
+            <daemon type="repserver" state="running" starttime="1492526484" />
+            <daemon type="publisher" state="dead" />
+          </partition>
+        </workerstatus>
+    http_version: 
+  recorded_at: Tue, 18 Apr 2017 16:10:41 GMT
+recorded_with: VCR 3.0.3

--- a/src/api/spec/cassettes/Login/in_kerberos_mode/for_a_request_where_GSSAPI_raises_an_exception/does_not_authenticate_the_user.yml
+++ b/src/api/spec/cassettes/Login/in_kerberos_mode/for_a_request_where_GSSAPI_raises_an_exception/does_not_authenticate_the_user.yml
@@ -1,0 +1,58 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://localhost:3200/build/_workerstatus
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - text/plain
+      Accept-Encoding:
+      - identity
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '927'
+    body:
+      encoding: UTF-8
+      string: |
+        <workerstatus clients="1">
+          <idle workerid="worker:1" hostarch="x86_64" />
+          <waiting arch="i586" jobs="1" />
+          <waiting arch="x86_64" jobs="0" />
+          <blocked arch="i586" jobs="0" />
+          <blocked arch="x86_64" jobs="0" />
+          <buildavg arch="i586" buildavg="1200" />
+          <buildavg arch="x86_64" buildavg="1200" />
+          <partition>
+            <daemon type="srcserver" state="running" starttime="1492526484" />
+            <daemon type="servicedispatch" state="running" starttime="1492526485" />
+            <daemon type="service" state="running" starttime="1492526485" />
+            <daemon type="scheduler" arch="i586" state="dead">
+              <queue high="0" med="0" low="3" next="0" />
+            </daemon>
+            <daemon type="scheduler" arch="x86_64" state="dead">
+              <queue high="39" med="0" low="7" next="0" />
+            </daemon>
+            <daemon type="repserver" state="running" starttime="1492526484" />
+            <daemon type="publisher" state="dead" />
+          </partition>
+        </workerstatus>
+    http_version: 
+  recorded_at: Tue, 18 Apr 2017 15:16:03 GMT
+recorded_with: VCR 3.0.3

--- a/src/api/spec/controllers/webui/user_controller_spec.rb
+++ b/src/api/spec/controllers/webui/user_controller_spec.rb
@@ -125,11 +125,11 @@ RSpec.describe Webui::UserController do
       context "with invalid data" do
         before do
           login user
-          post :save, params: { user: user, realname: "another real name", email: "" }
+          post :save, params: { user: user, realname: "another real name", email: "invalid" }
           user.reload
         end
 
-        it { expect(flash[:error]).to eq("Couldn't update user: Validation failed: Email must be given, Email must be a valid email address..") }
+        it { expect(flash[:error]).to eq("Couldn't update user: Validation failed: Email must be a valid email address..") }
         it { expect(user.realname).to eq(user.realname) }
         it { expect(user.email).to eq(user.email) }
         it { is_expected.to redirect_to user_show_path(user) }

--- a/src/api/spec/features/webui/login_spec.rb
+++ b/src/api/spec/features/webui/login_spec.rb
@@ -1,4 +1,5 @@
 require "browser_helper"
+require 'gssapi'
 
 RSpec.feature "Login", type: :feature, js: true do
   let!(:user) { create(:confirmed_user, login: "proxy_user") }
@@ -90,5 +91,81 @@ RSpec.feature "Login", type: :feature, js: true do
 
     expect(page).not_to have_css("a#link-to-user-home")
     expect(page).to have_link("Log")
+  end
+
+  context 'in kerberos mode' do
+    before do
+      stub_const('CONFIG', CONFIG.merge({
+        'kerberos_service_principal' => 'HTTP/obs.test.com@test_realm.com',
+        'kerberos_realm'             => 'test_realm.com',
+        'kerberos_mode'              => true
+      }))
+    end
+
+    context 'for a request that requires authentication' do
+      before do
+        visit root_path
+        click_link("Log In")
+      end
+
+      context "and 'Negotiate' header is not set" do
+        it 'informs the client tool (browser) that kerberos authentication is required' do
+          expect(page.response_headers['WWW-Authenticate']).to eq('Negotiate')
+          expect(page.status_code).to eq(401)
+        end
+
+        it 'informs users about failed kerberos authentication and possible cause' do
+          expect(page).to have_text('Kerberos authentication required')
+          expect(page).to have_text('You are seeing this page, because you are ' +
+                                    "not authenticated in the kerberos realm ('test_realm.com').")
+        end
+      end
+    end
+
+    context 'for a request with valid kerberos ticket' do
+      include_context 'a kerberos mock for' do
+        let(:login) { user.login }
+      end
+
+      before do
+        allow(GSSAPI::Simple).to receive(:new).with(
+          'obs.test.com', 'HTTP', '/etc/krb5.keytab'
+        ).and_return(gssapi_mock)
+      end
+
+      it 'authenticates the user' do
+        visit project_list_path
+
+        # In real life done by the browser / client
+        page.driver.add_header("AUTHORIZATION", "Negotiate #{Base64.strict_encode64(ticket)}")
+
+        click_link("Log In")
+        expect(page).to have_content "#{login} | Home Project | Logout"
+      end
+    end
+
+    context 'for a request where GSSAPI raises an exception' do
+      let(:gssapi_mock) { double(:gssapi) }
+
+      before do
+        allow(gssapi_mock).to receive(:acquire_credentials).
+          and_raise(GSSAPI::GssApiError, "couldn't validate ticket")
+
+        allow(GSSAPI::Simple).to receive(:new).with(
+          'obs.test.com', 'HTTP', '/etc/krb5.keytab'
+        ).and_return(gssapi_mock)
+      end
+
+      it 'does not authenticate the user' do
+        visit project_list_path
+
+        page.driver.add_header("AUTHORIZATION", "Negotiate #{Base64.strict_encode64('ticket')}")
+
+        click_link("Log In")
+        expect(page).not_to have_content "| Home Project | Logout"
+        expect(find('.flash-content')).to have_text "Authentication failed: 'Received a GSSAPI exception"
+        expect(find('.flash-content')).to have_text "couldn't validate ticket"
+      end
+    end
   end
 end

--- a/src/api/spec/lib/authenticator_spec.rb
+++ b/src/api/spec/lib/authenticator_spec.rb
@@ -1,0 +1,88 @@
+require 'rails_helper'
+require 'authenticator'
+require 'gssapi'
+
+RSpec.describe Authenticator do
+  let(:gssapi_mock) { double(:gssapi) }
+
+  before do
+    stub_const('CONFIG', CONFIG.merge({
+      'kerberos_service_principal' => 'HTTP/obs.test.com@test_realm.com',
+      'kerberos_realm'             => 'test_realm.com',
+      'kerberos_mode'              => true,
+      'kerberos_keytab'            => '/etc/keytab'
+    }))
+  end
+
+  describe '#extract_user' do
+    context 'in kerberos mode' do
+      let(:request_mock) { double(:request, env: { 'Authorization' => 'Negotiate'}) }
+      let(:session_mock) { double(:session) }
+      let(:response_mock) { double(:response, headers: {} ) }
+
+      before do
+        allow(session_mock).to receive(:[]).with(:login)
+      end
+
+      context 'with an invalid ticket' do
+        let(:authenticator) { Authenticator.new(request_mock, session_mock, response_mock) }
+
+        it 'raises an error' do
+          expect { authenticator.extract_user }.to raise_error(Authenticator::AuthenticationRequiredError,
+                                                               'GSSAPI negotiation failed.')
+        end
+      end
+
+      context 'with a valid ticket' do
+        let(:user) { create(:confirmed_user) }
+        let(:request_mock) { double(:request, env: { 'Authorization' => "Negotiate #{Base64.strict_encode64('krb_ticket')}" }) }
+        let(:authenticator) { Authenticator.new(request_mock, session_mock, response_mock) }
+
+        before do
+          allow(gssapi_mock).to receive(:acquire_credentials)
+          allow(gssapi_mock).to receive(:accept_context).
+            with('krb_ticket').and_return(true)
+          allow(gssapi_mock).to receive(:display_name).
+            and_return("#{user.login}@test_realm.com")
+
+          allow(GSSAPI::Simple).to receive(:new).with(
+            'obs.test.com', 'HTTP', '/etc/keytab'
+          ).and_return(gssapi_mock)
+        end
+
+        context 'and confirmed user' do
+          it 'authenticates the user' do
+            authenticator.extract_user
+            expect(authenticator.http_user).to eq(user)
+          end
+        end
+
+        context 'and the user does not exist yet' do
+          before do
+            user.destroy
+          end
+
+          it 'creates a new account' do
+            authenticator.extract_user
+
+            new_user = User.where(login: user.login)
+            expect(new_user).to exist
+            expect(authenticator.http_user).to eq(new_user.first)
+          end
+        end
+
+        context 'but user is unconfirmed' do
+          before do
+            user.update(state: 'unconfirmed')
+          end
+
+          it 'does not authenticate the user' do
+            expect { authenticator.extract_user }.to raise_error(Authenticator::UnconfirmedUserError,
+                                                                 'User is registered but not yet approved. Your account is a registered account, ' +
+                                                                 'but it is not yet approved for the OBS by admin.')
+          end
+        end
+      end
+    end
+  end
+end

--- a/src/api/spec/models/user_spec.rb
+++ b/src/api/spec/models/user_spec.rb
@@ -11,7 +11,6 @@ RSpec.describe User do
     it { is_expected.to validate_length_of(:login).is_at_least(2).with_message('must have more than two characters.') }
     it { is_expected.to validate_length_of(:login).is_at_most(100).with_message('must have less than 100 characters.') }
 
-    it { is_expected.to validate_presence_of(:email).with_message('must be given') }
     it { is_expected.to allow_value('king@opensuse.org').for(:email) }
     it { is_expected.to_not allow_values('king.opensuse.org', 'opensuse.org', 'opensuse').for(:email) }
 

--- a/src/api/spec/requests/kerberos_login_spec.rb
+++ b/src/api/spec/requests/kerberos_login_spec.rb
@@ -25,22 +25,18 @@ RSpec.describe 'Kerberos login', vcr: false, type: :request do
       end
 
       context "authorization header contains 'Negotiate' with a ticket" do
-        let(:gssapi_mock) { double(:gssapi) }
+        include_context 'a kerberos mock for' do
+          let(:login) { user.login }
+        end
 
         before do
-          allow(gssapi_mock).to receive(:acquire_credentials)
-          allow(gssapi_mock).to receive(:accept_context).
-            with('ticket').and_return(true)
-          allow(gssapi_mock).to receive(:display_name).
-            and_return("#{user.login}@test_realm.com")
-
           allow(GSSAPI::Simple).to receive(:new).with(
             'obs.test.com', 'HTTP', '/etc/krb5.keytab'
           ).and_return(gssapi_mock)
         end
 
         it 'authenticates the user' do
-          get "/source.xml", headers: { 'X-HTTP_AUTHORIZATION' => "Negotiate #{Base64.strict_encode64('ticket')}" }
+          get "/source.xml", headers: { 'X-HTTP_AUTHORIZATION' => "Negotiate #{Base64.strict_encode64(ticket)}" }
           expect(response).to have_http_status(:success)
         end
       end

--- a/src/api/spec/requests/kerberos_login_spec.rb
+++ b/src/api/spec/requests/kerberos_login_spec.rb
@@ -1,82 +1,64 @@
 require 'rails_helper'
-
+require 'authenticator'
 require 'gssapi'
 
 RSpec.describe 'Kerberos login', vcr: false, type: :request do
   describe 'authentication in kerberos mode' do
-    let(:gssapi_mock) { double }
     let(:user) { create(:confirmed_user) }
 
     before do
       stub_const('CONFIG', CONFIG.merge({
         'kerberos_service_principal' => 'HTTP/obs.test.com@test_realm.com',
-        'kerberos_realm'             => 'test_realm.com'
+        'kerberos_realm'             => 'test_realm.com',
+        'kerberos_mode'              => true
       }))
     end
 
-    context 'with valid ticket' do
-      before do
-        allow(gssapi_mock).to receive(:acquire_credentials)
-        allow(gssapi_mock).to receive(:accept_context).
-          with('fake_ticket').and_return(true)
-        allow(gssapi_mock).to receive(:display_name).
-          and_return("#{user.login}@test_realm.com")
-
-        allow(GSSAPI::Simple).to receive(:new).with(
-          'obs.test.com', 'HTTP', '/etc/krb5.keytab'
-        ).and_return(gssapi_mock)
-      end
-
-      context 'and confirmed user' do
-        it 'authenticates the user' do
-          get "/source.xml", headers: { 'X-HTTP_AUTHORIZATION' => "Negotiate #{Base64.strict_encode64('fake_ticket')}" }
-          expect(response).to have_http_status(:success)
-        end
-      end
-
-      context 'but user is unconfirmed' do
+    context "calling a controller with 'extract_user' before filter" do
+      context "authorization header does not contain 'Negotiate'" do
         before do
-          user.update(state: 'unconfirmed')
+          get "/source.xml"
         end
 
-        it 'does not authenticate the user' do
-          get "/source.xml", headers: { 'X-HTTP_AUTHORIZATION' => "Negotiate #{Base64.strict_encode64('fake_ticket')}" }
-          expect(response).to have_http_status(:forbidden)
-          expect(response.body).to match('User is registered but not yet approved. Your account is a registered account, ' +
-            'but it is not yet approved for the OBS by admin.')
-        end
+        it { expect(response).to have_http_status(:unauthorized) }
+        it { expect(response.header["WWW-Authenticate"]).to eq('Negotiate') }
       end
 
-      context 'but for a diferent realm' do
+      context "authorization header contains 'Negotiate' with a ticket" do
+        let(:gssapi_mock) { double(:gssapi) }
+
         before do
+          allow(gssapi_mock).to receive(:acquire_credentials)
+          allow(gssapi_mock).to receive(:accept_context).
+            with('ticket').and_return(true)
           allow(gssapi_mock).to receive(:display_name).
-            and_return("#{user.login}@my_other_realm.com")
+            and_return("#{user.login}@test_realm.com")
 
           allow(GSSAPI::Simple).to receive(:new).with(
             'obs.test.com', 'HTTP', '/etc/krb5.keytab'
           ).and_return(gssapi_mock)
         end
 
-        it 'does not authenticate the user' do
-          get "/source.xml", headers: { 'X-HTTP_AUTHORIZATION' => "Negotiate #{Base64.strict_encode64('fake_ticket')}" }
-          expect(response).to have_http_status(:unauthorized)
-          expect(response.body).to match('User authenticated in wrong Kerberos realm.')
+        it 'authenticates the user' do
+          get "/source.xml", headers: { 'X-HTTP_AUTHORIZATION' => "Negotiate #{Base64.strict_encode64('ticket')}" }
+          expect(response).to have_http_status(:success)
         end
       end
-    end
 
-    context 'with invalid ticket' do
-      before do
-        allow(gssapi_mock).to receive(:acquire_credentials).and_raise(GSSAPI::GssApiError)
-        allow(GSSAPI::Simple).to receive(:new).with(
-          'obs.test.com', 'HTTP', '/etc/krb5.keytab'
-        ).and_return(gssapi_mock)
-      end
+      context 'authenticator raises an error while fetching user' do
+        let(:auth_header) { "Negotiate #{Base64.strict_encode64('ticket')}" }
 
-      it 'does not authenticate the user' do
-        get "/source.xml", headers: { 'X-HTTP_AUTHORIZATION' => "Negotiate #{Base64.strict_encode64('fake_ticket')}" }
-        expect(response).to have_http_status(:unauthorized)
-        expect(response.body).to match('Received a GSSAPI exception')
+        before do
+          allow_any_instance_of(Authenticator).to receive(:extract_krb_user).
+            with(auth_header.to_s.split).
+            and_raise(Authenticator::AuthenticationRequiredError, 'something happened')
+        end
+
+        it 'does not authenticate the user' do
+          get "/source.xml", headers: { 'X-HTTP_AUTHORIZATION' => auth_header }
+          expect(response).to have_http_status(:unauthorized)
+          expect(response.body).to match('something happened')
+        end
       end
     end
   end

--- a/src/api/spec/support/shared_contexts/a_kerberos_mock.rb
+++ b/src/api/spec/support/shared_contexts/a_kerberos_mock.rb
@@ -1,0 +1,14 @@
+RSpec.shared_context 'a kerberos mock for' do
+  let(:gssapi_mock) { double(:gssapi) }
+  let(:ticket) { SecureRandom.hex }
+  let(:realm) { 'test_realm.com' }
+  let(:login) { 'tux' }
+
+  before do
+    allow(gssapi_mock).to receive(:acquire_credentials)
+    allow(gssapi_mock).to receive(:accept_context).
+      with(ticket).and_return(true)
+    allow(gssapi_mock).to receive(:display_name).
+      and_return("#{login}@#{realm}")
+  end
+end


### PR DESCRIPTION
This PR implements authentication via kerberos in the webui.

With kerberos authentication enabled, users authenticate via a kerberos ticket to the OBS. In case of authentication via browser, users have to configure their browser to use kerberos auth for the domain of the OBS server.

Users that have not done that or do not have a kerberos ticket will be redirected to a login page that informs them about enabled kerberos mode.

OBS creates a new account, when a users logs in the first time.

In addition it:
* Introduces a kerberos_mode flag
* Cleans up setting of last_logged_in_at
* Removes validation of email presence. Kerberos doesn't provide an email, which would mean that newly created users are invalid.

Pair-programmed with @eduardoj 