### PR TITLE
[dist][api[webui] Never ever edit Gemfile.lock by hand

### DIFF
--- a/src/api/Gemfile.lock
+++ b/src/api/Gemfile.lock
@@ -116,11 +116,11 @@ GEM
     faker (1.7.3)
       i18n (~> 0.5)
     feature (1.4.0)
-    ffi (1.9.17)
+    flog (4.6.1)
       path_expander (~> 1.0)
       ruby_parser (~> 3.1, > 3.1.0)
       sexp_processor (~> 4.8)
-    flog (4.6.1)
+    ffi (1.9.17)
     flot-rails (0.0.7)
       jquery-rails
     font-awesome-rails (4.7.0.1)


### PR DESCRIPTION
The dependencies of flog and ffi got messed up by 8f8c507ead94a15058f4d2c9bd0e95fb06e505c7.
Probably by editing the Gemfile.lock by hand.