### PR TITLE
Update Rantly gem to 1.1.0

### DIFF
--- a/contrib/common.sh
+++ b/contrib/common.sh
@@ -28,7 +28,6 @@ function install_common_packages() {
     ruby2.4-rubygem-ruby-ldap \
     ruby2.4-rubygem-xmlhash \
     ruby2.4-rubygem-thinking-sphinx\
-    ruby2.4-rubygem-rantly\
     ruby2.4-rubygem-foreman\
     perl-GD \
     perl-XML-Parser \

--- a/src/api/Gemfile
+++ b/src/api/Gemfile
@@ -118,7 +118,7 @@ group :test do
   # assigns has been extracted to a gem
   gem 'rails-controller-testing'
   # To generate random data
-  gem 'rantly'
+  gem 'rantly', '>= 1.1.0'
 end
 
 # Gems used only during development not required in production environments by default.

--- a/src/api/Gemfile.lock
+++ b/src/api/Gemfile.lock
@@ -116,11 +116,11 @@ GEM
     faker (1.7.3)
       i18n (~> 0.5)
     feature (1.4.0)
+    ffi (1.9.17)
     flog (4.6.1)
       path_expander (~> 1.0)
       ruby_parser (~> 3.1, > 3.1.0)
       sexp_processor (~> 4.8)
-    ffi (1.9.17)
     flot-rails (0.0.7)
       jquery-rails
     font-awesome-rails (4.7.0.1)
@@ -260,7 +260,7 @@ GEM
     rainbow (2.2.1)
     raindrops (0.17.0)
     rake (12.0.0)
-    rantly (1.0.0)
+    rantly (1.1.0)
     rdoc (5.1.0)
     redcarpet (3.3.4)
     responders (2.2.0)
@@ -428,7 +428,7 @@ DEPENDENCIES
   rails (~> 5.0.1)
   rails-controller-testing
   rails_tokeninput (>= 1.6.1.rc1)
-  rantly
+  rantly (>= 1.1.0)
   rdoc
   redcarpet
   responders (~> 2.0)

--- a/src/api/spec/spec_helper.rb
+++ b/src/api/spec/spec_helper.rb
@@ -86,8 +86,8 @@ ENV['BACKEND_STARTED'] = '1'
 # Generate 30 tests for every property test
 ENV['RANTLY_COUNT'] = '30'
 
-# To have quiet output from Rantly, it looks horrible with the Unicorn
-ENV['RANTLY_VERBOSE'] = '0' unless ENV['TRAVIS'] || ENV['RPM_BUILD_ROOT']
+# To have quiet output from Rantly, it is not needed and looks horrible with the Unicorn
+ENV['RANTLY_VERBOSE'] = '0'
 
 # support logging
 require 'support/logging'


### PR DESCRIPTION
This version of Rantly includes two great improvements:

- Include failed example and number of example run in failure message.
- Improve run-time for generation of strings.

The first of them was the reason why we were installing our own patched gem version. See https://github.com/openSUSE/open-build-service/pull/2631/files

In Travis we were using Rantly 1.0.0 instead the patched version. So the Rantly output could not be disabled in this case as there was important information not rendered in the error message. Get disabled now.