### PR TITLE
Fix #3018: Allow simple emails to be used as logins to OBS

### DIFF
--- a/src/api/app/models/project.rb
+++ b/src/api/app/models/project.rb
@@ -1199,7 +1199,7 @@ class Project < ApplicationRecord
     return false if name == "0";
     return false if name =~ /::/
     return false if name.end_with?(':')
-    return true if name =~ /\A[a-zA-Z0-9][-+\w\.:]{0,199}\z/
+    return true if name =~ /\A[a-zA-Z0-9][-+\w\.:@]{0,199}\z/
     false
   end
 

--- a/src/api/app/models/user.rb
+++ b/src/api/app/models/user.rb
@@ -60,7 +60,7 @@ class User < ApplicationRecord
             uniqueness: { message: 'is the name of an already existing user.' }
 
   validates :login,
-            format: { with:    %r{\A[\w \$\^\-\.#\*\+&'"]*\z},
+            format: { with:    %r{\A[\w \$\^\-\.#\*\+&'"@]*\z},
                       message: 'must not contain invalid characters.' }
   validates :login,
             length: { in: 2..100, allow_nil: true,


### PR DESCRIPTION
Do so by relaxing the validator to accept the @ character.