### PR TITLE
New vrev update version scheme

### DIFF
--- a/ReleaseNotes-2.9
+++ b/ReleaseNotes-2.9
@@ -86,8 +86,8 @@ Bugfixes:
  * Fix huge bottleneck in notification emails.
  * Fix setting of new attributes to a project or package.
 
-Wanted changes:
-===============
+Intentional changes:
+====================
 
  * Creating of repositories on branching has changed if repositories of the source refer each other. This gets recreated in new project.
 
@@ -103,7 +103,10 @@ Wanted changes:
    - ldap_entry_base
    - ldap_sn_attr_required
 
- * Dropping of the project/package tag functionality/api.
+ * Extended build number scheme is enforced for maintenance updates via new project link
+   attribute extendvrev now
+
+ * Dropping of the project/package tag functionality/api
 
  * Password hashing algorithm was changed to bcrypt (blowfish).
 

--- a/docs/api/api/project.rng
+++ b/docs/api/api/project.rng
@@ -35,6 +35,14 @@
       <attribute name="project">
         <data type="string" />
       </attribute>
+      <optional>
+        <attribute name="vrevmode">
+         <choice>
+           <value>unextend</value>
+           <value>extend</value>
+         </choice>
+        </attribute>
+      </optional>
       <empty/>
     </element>
   </define>

--- a/src/api/app/models/branch_package.rb
+++ b/src/api/app/models/branch_package.rb
@@ -149,7 +149,7 @@ class BranchPackage
         oproject = p[:link_target_project].name if p[:link_target_project].is_a? Project
 
         # branch sources in backend
-        tpkg.branch_from(oproject, opackage, p[:rev], params[:missingok], nil, params[:linkrev])
+        tpkg.branch_from(oproject, opackage, p[:rev], params[:missingok], nil, params[:linkrev], params[:noservice])
         if response
           # multiple package transfers, just tell the target project
           response = { targetproject: tpkg.project.name }

--- a/src/api/app/models/branch_package.rb
+++ b/src/api/app/models/branch_package.rb
@@ -149,7 +149,17 @@ class BranchPackage
         oproject = p[:link_target_project].name if p[:link_target_project].is_a? Project
 
         # branch sources in backend
-        tpkg.branch_from(oproject, opackage, p[:rev], params[:missingok], nil, params[:linkrev], params[:noservice])
+        opts = {}
+        opts[:missingok] = '1' if params[:missingok].present?
+        opts[:noservice] = '1' if params[:noservice].present?
+        opts[:orev] = p[:rev] if p[:rev].present?
+        # New incident updates need the vrev extension
+        if tpkg.project.is_maintenance_incident? && p[:package].is_a?(Package) &&
+           p[:package].project != p[:link_target_project]
+          opts[:extendvrev] = '1'
+        end
+        tpkg.branch_from(oproject, opackage, opts)
+
         if response
           # multiple package transfers, just tell the target project
           response = { targetproject: tpkg.project.name }

--- a/src/api/app/models/channel.rb
+++ b/src/api/app/models/channel.rb
@@ -138,7 +138,7 @@ class Channel < ApplicationRecord
     target_package.store(comment: comment)
 
     # branch sources
-    target_package.branch_from(package.project.name, package.name, nil, nil, comment)
+    target_package.branch_from(package.project.name, package.name, comment: comment)
     target_package.sources_changed(wait_for_update: true)
 
     target_package

--- a/src/api/app/models/linked_project.rb
+++ b/src/api/app/models/linked_project.rb
@@ -28,6 +28,7 @@ end
 #  linked_db_project_id       :integer          indexed => [db_project_id]
 #  position                   :integer
 #  linked_remote_project_name :string(255)
+#  vrevmode                   :string(10)       default("standard")
 #
 # Indexes
 #

--- a/src/api/app/models/package.rb
+++ b/src/api/app/models/package.rb
@@ -1096,21 +1096,18 @@ class Package < ApplicationRecord
     errors.add(:name, 'is illegal') unless Package.valid_name?(name)
   end
 
-  def branch_from(origin_project, origin_package, rev = nil, missingok = nil, comment = nil, olinkrev = nil, noservice = nil)
+  def branch_from(origin_project, origin_package, opts)
     myparam = { cmd:       'branch',
                 noservice: '1',
                 oproject:  origin_project,
                 opackage:  origin_package,
                 user:      User.current.login }
-    myparam[:orev] = rev if rev.present?
-    myparam[:olinkrev] = olinkrev if olinkrev.present?
-    myparam[:missingok] = '1' if missingok
-    myparam[:noservice] = '1' if noservice
-    myparam[:comment] = comment if comment
+    # merge additional key/values, avoid overwrite. _ is needed for rubocop
+    myparam.merge!(opts) { |_key, v1, _v2| v1 }
     path = source_path
     path += Backend::Connection.build_query_from_hash(myparam,
                                                       [:cmd, :oproject, :opackage, :user, :comment,
-                                                       :orev, :missingok, :noservice, :olinkrev])
+                                                       :orev, :missingok, :noservice, :olinkrev, :extendvrev])
     # branch sources in backend
     Backend::Connection.post path
   end

--- a/src/api/app/models/package.rb
+++ b/src/api/app/models/package.rb
@@ -1096,7 +1096,7 @@ class Package < ApplicationRecord
     errors.add(:name, 'is illegal') unless Package.valid_name?(name)
   end
 
-  def branch_from(origin_project, origin_package, rev = nil, missingok = nil, comment = nil, olinkrev = nil)
+  def branch_from(origin_project, origin_package, rev = nil, missingok = nil, comment = nil, olinkrev = nil, noservice = nil)
     myparam = { cmd:       'branch',
                 noservice: '1',
                 oproject:  origin_project,
@@ -1105,9 +1105,12 @@ class Package < ApplicationRecord
     myparam[:orev] = rev if rev.present?
     myparam[:olinkrev] = olinkrev if olinkrev.present?
     myparam[:missingok] = '1' if missingok
+    myparam[:noservice] = '1' if noservice
     myparam[:comment] = comment if comment
     path = source_path
-    path += Backend::Connection.build_query_from_hash(myparam, [:cmd, :oproject, :opackage, :user, :comment, :orev, :missingok, :olinkrev])
+    path += Backend::Connection.build_query_from_hash(myparam,
+                                                      [:cmd, :oproject, :opackage, :user, :comment,
+                                                       :orev, :missingok, :noservice, :olinkrev])
     # branch sources in backend
     Backend::Connection.post path
   end

--- a/src/api/app/models/project/update_from_xml_command.rb
+++ b/src/api/app/models/project/update_from_xml_command.rb
@@ -72,6 +72,7 @@ class Project
           if Project.find_remote_project(l['project'])
             project.linking_to.create(project: project,
                                        linked_remote_project_name: l['project'],
+                                       vrevmode: l['vrevmode'],
                                        position: position)
           else
             raise SaveError, "unable to link against project '#{l['project']}'"
@@ -79,8 +80,9 @@ class Project
         else
           raise SaveError, 'unable to link against myself' if link == project
           project.linking_to.create!(project: project,
-                                      linked_db_project: link,
-                                      position: position)
+                                     linked_db_project: link,
+                                     vrevmode: l['vrevmode'],
+                                     position: position)
         end
         position += 1
       end

--- a/src/api/app/views/models/_project.xml.builder
+++ b/src/api/app/views/models/_project.xml.builder
@@ -7,11 +7,9 @@ xml.project(project_attributes) do
   xml.description(my_model.description)
 
   my_model.linking_to.each do |l|
-    if l.linked_db_project
-      xml.link(project: l.linked_db_project.name)
-    else
-      xml.link(project: l.linked_remote_project_name)
-    end
+    params = { project: l.linked_db_project ? l.linked_db_project.name : l.linked_remote_project_name }
+    params[:vrevmode] = l.vrevmode unless l.vrevmode == 'standard' || l.vrevmode.blank?
+    xml.link(params)
   end
 
   xml.url(my_model.url) if my_model.url.present?

--- a/src/api/db/migrate/20170413212201_add_vrevmode_attribute.rb
+++ b/src/api/db/migrate/20170413212201_add_vrevmode_attribute.rb
@@ -1,0 +1,10 @@
+class AddVrevmodeAttribute < ActiveRecord::Migration[5.1]
+  def self.up
+    add_column :linked_projects, :vrevmode, :integer
+    execute "alter table linked_projects modify column `vrevmode` enum('standard','unextend','extend') DEFAULT 'standard';"
+  end
+
+  def self.down
+    remove_column :linked_projects, :vrevmode
+  end
+end

--- a/src/api/db/structure.sql
+++ b/src/api/db/structure.sql
@@ -715,6 +715,7 @@ CREATE TABLE `linked_projects` (
   `linked_db_project_id` int(11) DEFAULT NULL,
   `position` int(11) DEFAULT NULL,
   `linked_remote_project_name` varchar(255) CHARACTER SET utf8 DEFAULT NULL,
+  `vrevmode` enum('standard','unextend','extend') COLLATE utf8_bin DEFAULT 'standard',
   PRIMARY KEY (`id`),
   UNIQUE KEY `linked_projects_index` (`db_project_id`,`linked_db_project_id`) USING BTREE
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin;
@@ -1271,6 +1272,7 @@ INSERT INTO `schema_migrations` (version) VALUES
 ('20170323123236'),
 ('20170412121601'),
 ('20170412121957'),
+('20170413212201'),
 ('20170426153510'),
 ('20170509123922'),
 ('20170511120355'),

--- a/src/api/spec/cassettes/BranchPackage/_branch/package_with_UpdateProject_attribute/should_create_home_tom_branches_BaseDistro_Update_project.yml
+++ b/src/api/spec/cassettes/BranchPackage/_branch/package_with_UpdateProject_attribute/should_create_home_tom_branches_BaseDistro_Update_project.yml
@@ -7,7 +7,232 @@ http_interactions:
       encoding: UTF-8
       string: |
         <project name="BaseDistro">
-          <title>Clouds of Witness</title>
+          <title>Terrible Swift Sword</title>
+          <description/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '107'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="BaseDistro">
+          <title>Terrible Swift Sword</title>
+          <description></description>
+        </project>
+    http_version: 
+  recorded_at: Fri, 15 Dec 2017 13:12:08 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/BaseDistro/_config
+    body:
+      encoding: UTF-8
+      string: Reiciendis provident dolorem aut. Quia eius odit. Minus perferendis
+        in. Qui error est vitae molestias. Illum quod sit dolorem consequatur soluta
+        reiciendis.
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '21'
+    body:
+      encoding: UTF-8
+      string: '<status code="ok" />
+
+'
+    http_version: 
+  recorded_at: Fri, 15 Dec 2017 13:12:08 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/BaseDistro/test_package/_meta?user=tom
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="test_package" project="BaseDistro">
+          <title>The Painted Veil</title>
+          <description>Eaque sed tenetur vel culpa sed ut eum.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '165'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="test_package" project="BaseDistro">
+          <title>The Painted Veil</title>
+          <description>Eaque sed tenetur vel culpa sed ut eum.</description>
+        </package>
+    http_version: 
+  recorded_at: Fri, 15 Dec 2017 13:12:08 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/BaseDistro/test_package/_meta
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="test_package" project="BaseDistro">
+          <title>The Painted Veil</title>
+          <description>Eaque sed tenetur vel culpa sed ut eum.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '165'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="test_package" project="BaseDistro">
+          <title>The Painted Veil</title>
+          <description>Eaque sed tenetur vel culpa sed ut eum.</description>
+        </package>
+    http_version: 
+  recorded_at: Fri, 15 Dec 2017 13:12:08 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/BaseDistro:Update/_meta
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="BaseDistro:Update">
+          <title>Tender Is the Night</title>
+          <description/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '113'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="BaseDistro:Update">
+          <title>Tender Is the Night</title>
+          <description></description>
+        </project>
+    http_version: 
+  recorded_at: Fri, 15 Dec 2017 13:12:08 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/BaseDistro:Update/_config
+    body:
+      encoding: UTF-8
+      string: Non fuga enim sed qui minima occaecati. Illo dolorem unde. Sint autem
+        reprehenderit hic. Nulla temporibus eaque.
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '21'
+    body:
+      encoding: UTF-8
+      string: '<status code="ok" />
+
+'
+    http_version: 
+  recorded_at: Fri, 15 Dec 2017 13:12:08 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/project_5/_meta
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="project_5">
+          <title>A Farewell to Arms</title>
           <description/>
         </project>
     headers:
@@ -33,20 +258,20 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <project name="BaseDistro">
-          <title>Clouds of Witness</title>
+        <project name="project_5">
+          <title>A Farewell to Arms</title>
           <description></description>
         </project>
     http_version: 
-  recorded_at: Wed, 16 Nov 2016 16:10:45 GMT
+  recorded_at: Fri, 15 Dec 2017 13:12:08 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/BaseDistro/_config
+    uri: http://backend:5352/source/project_5/_config
     body:
       encoding: UTF-8
-      string: Sit nam eum ea error repellat cumque sed. Autem quia placeat harum accusamus
-        itaque possimus commodi. Eum aspernatur dolorem. Dolores reiciendis est voluptatum
-        asperiores voluptatem.
+      string: Dolores non illum. Voluptatem et maxime autem recusandae. Veritatis
+        sed accusantium sapiente. Ex sed nulla pariatur. Voluptatem doloribus voluptatem
+        dolorem dolore maxime illum nam.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -73,158 +298,7 @@ http_interactions:
 
 '
     http_version: 
-  recorded_at: Wed, 16 Nov 2016 16:10:45 GMT
-- request:
-    method: put
-    uri: http://backend:5352/source/BaseDistro/test_package/_meta?user=tom
-    body:
-      encoding: UTF-8
-      string: |
-        <package name="test_package" project="BaseDistro">
-          <title/>
-          <description/>
-        </package>
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '110'
-    body:
-      encoding: UTF-8
-      string: |
-        <package name="test_package" project="BaseDistro">
-          <title></title>
-          <description></description>
-        </package>
-    http_version: 
-  recorded_at: Wed, 16 Nov 2016 16:10:45 GMT
-- request:
-    method: put
-    uri: http://backend:5352/source/BaseDistro/test_package/_meta
-    body:
-      encoding: UTF-8
-      string: |
-        <package name="test_package" project="BaseDistro">
-          <title/>
-          <description/>
-        </package>
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '110'
-    body:
-      encoding: UTF-8
-      string: |
-        <package name="test_package" project="BaseDistro">
-          <title></title>
-          <description></description>
-        </package>
-    http_version: 
-  recorded_at: Wed, 16 Nov 2016 16:10:45 GMT
-- request:
-    method: put
-    uri: http://backend:5352/source/BaseDistro:Update/_meta
-    body:
-      encoding: UTF-8
-      string: |
-        <project name="BaseDistro:Update">
-          <title>The Other Side of Silence</title>
-          <description/>
-        </project>
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '119'
-    body:
-      encoding: UTF-8
-      string: |
-        <project name="BaseDistro:Update">
-          <title>The Other Side of Silence</title>
-          <description></description>
-        </project>
-    http_version: 
-  recorded_at: Wed, 16 Nov 2016 16:10:45 GMT
-- request:
-    method: put
-    uri: http://backend:5352/source/BaseDistro:Update/_config
-    body:
-      encoding: UTF-8
-      string: Officiis nihil ipsa. Eligendi sed et enim voluptatem magni et iste.
-        Adipisci et tempore ea aspernatur asperiores maxime sunt.
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '21'
-    body:
-      encoding: UTF-8
-      string: '<status code="ok" />
-
-'
-    http_version: 
-  recorded_at: Wed, 16 Nov 2016 16:10:45 GMT
+  recorded_at: Fri, 15 Dec 2017 13:12:08 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom/_meta?user=tom
@@ -265,7 +339,7 @@ http_interactions:
           <person userid="tom" role="maintainer" />
         </project>
     http_version: 
-  recorded_at: Wed, 16 Nov 2016 16:10:45 GMT
+  recorded_at: Fri, 15 Dec 2017 13:12:08 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom:branches:BaseDistro:Update/_meta?user=tom
@@ -306,7 +380,7 @@ http_interactions:
           <person userid="tom" role="maintainer" />
         </project>
     http_version: 
-  recorded_at: Wed, 16 Nov 2016 16:10:46 GMT
+  recorded_at: Fri, 15 Dec 2017 13:12:08 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom:branches:BaseDistro:Update/test_package/_meta?user=tom
@@ -345,49 +419,10 @@ http_interactions:
           <description></description>
         </package>
     http_version: 
-  recorded_at: Wed, 16 Nov 2016 16:10:46 GMT
-- request:
-    method: put
-    uri: http://backend:5352/source/home:tom:branches:BaseDistro:Update/test_package/_meta?user=tom
-    body:
-      encoding: UTF-8
-      string: |
-        <package name="test_package" project="home:tom:branches:BaseDistro:Update">
-          <title/>
-          <description/>
-        </package>
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '135'
-    body:
-      encoding: UTF-8
-      string: |
-        <package name="test_package" project="home:tom:branches:BaseDistro:Update">
-          <title></title>
-          <description></description>
-        </package>
-    http_version: 
-  recorded_at: Wed, 16 Nov 2016 16:10:46 GMT
+  recorded_at: Fri, 15 Dec 2017 13:12:08 GMT
 - request:
     method: post
-    uri: http://backend:5352/source/home:tom:branches:BaseDistro:Update/test_package?cmd=branch&missingok=1&opackage=test_package&oproject=BaseDistro:Update&user=tom
+    uri: http://backend:5352/source/home:tom:branches:BaseDistro:Update/test_package?cmd=branch&missingok=1&noservice=1&opackage=test_package&oproject=BaseDistro:Update&user=tom
     body:
       encoding: UTF-8
       string: ''
@@ -419,13 +454,52 @@ http_interactions:
         <revision rev="1" vrev="1">
           <srcmd5>e3adf4aab58a4a6f27974d4a9fb88e5f</srcmd5>
           <version>unknown</version>
-          <time>1479312646</time>
+          <time>1513343528</time>
           <user>tom</user>
           <comment></comment>
           <requestid/>
         </revision>
     http_version: 
-  recorded_at: Wed, 16 Nov 2016 16:10:46 GMT
+  recorded_at: Fri, 15 Dec 2017 13:12:08 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:tom:branches:BaseDistro:Update/test_package/_meta?user=tom
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="test_package" project="home:tom:branches:BaseDistro:Update">
+          <title/>
+          <description/>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '135'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="test_package" project="home:tom:branches:BaseDistro:Update">
+          <title></title>
+          <description></description>
+        </package>
+    http_version: 
+  recorded_at: Fri, 15 Dec 2017 13:12:08 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:tom:branches:BaseDistro:Update/test_package
@@ -457,10 +531,10 @@ http_interactions:
       string: |
         <directory name="test_package" rev="1" vrev="1" srcmd5="e3adf4aab58a4a6f27974d4a9fb88e5f">
           <linkinfo project="BaseDistro:Update" package="test_package" srcmd5="d41d8cd98f00b204e9800998ecf8427e" baserev="d41d8cd98f00b204e9800998ecf8427e" missingok="true" xsrcmd5="add4a945697eee927c39061d8a0ab589" lsrcmd5="e3adf4aab58a4a6f27974d4a9fb88e5f" />
-          <entry name="_link" md5="463447c51c7a017092296988331b6862" size="142" mtime="1479305351" />
+          <entry name="_link" md5="463447c51c7a017092296988331b6862" size="142" mtime="1513343048" />
         </directory>
     http_version: 
-  recorded_at: Wed, 16 Nov 2016 16:10:46 GMT
+  recorded_at: Fri, 15 Dec 2017 13:12:08 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:tom:branches:BaseDistro:Update/test_package?nofilename=1&view=info&withchangesmd5=1
@@ -492,10 +566,10 @@ http_interactions:
       string: |
         <sourceinfo package="test_package" rev="1" vrev="1" srcmd5="add4a945697eee927c39061d8a0ab589" lsrcmd5="e3adf4aab58a4a6f27974d4a9fb88e5f" verifymd5="d41d8cd98f00b204e9800998ecf8427e">
           <linked project="BaseDistro:Update" package="test_package" />
-          <revtime>1479312646</revtime>
+          <revtime>1513343528</revtime>
         </sourceinfo>
     http_version: 
-  recorded_at: Wed, 16 Nov 2016 16:10:46 GMT
+  recorded_at: Fri, 15 Dec 2017 13:12:08 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:tom:branches:BaseDistro:Update/test_package
@@ -527,10 +601,10 @@ http_interactions:
       string: |
         <directory name="test_package" rev="1" vrev="1" srcmd5="e3adf4aab58a4a6f27974d4a9fb88e5f">
           <linkinfo project="BaseDistro:Update" package="test_package" srcmd5="d41d8cd98f00b204e9800998ecf8427e" baserev="d41d8cd98f00b204e9800998ecf8427e" missingok="true" xsrcmd5="add4a945697eee927c39061d8a0ab589" lsrcmd5="e3adf4aab58a4a6f27974d4a9fb88e5f" />
-          <entry name="_link" md5="463447c51c7a017092296988331b6862" size="142" mtime="1479305351" />
+          <entry name="_link" md5="463447c51c7a017092296988331b6862" size="142" mtime="1513343048" />
         </directory>
     http_version: 
-  recorded_at: Wed, 16 Nov 2016 16:10:46 GMT
+  recorded_at: Fri, 15 Dec 2017 13:12:08 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:tom:branches:BaseDistro:Update/test_package?cmd=diff&linkrev=base&onlyissues=1&orev=0&view=xml
@@ -553,16 +627,16 @@ http_interactions:
     headers:
       Content-Type:
       - text/xml
-      Content-Length:
-      - '359'
       Cache-Control:
       - no-cache
       Connection:
       - close
+      Content-Length:
+      - '359'
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="c9e41755ae4b8728a8c5f3fd11f9ba0c">
+        <sourcediff key="76cacf0fa374e517e018c7aa82ac1b8d">
           <old project="home:tom:branches:BaseDistro:Update" package="test_package" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e" />
           <new project="home:tom:branches:BaseDistro:Update" package="test_package" rev="1" srcmd5="e3adf4aab58a4a6f27974d4a9fb88e5f" />
           <files />
@@ -570,7 +644,7 @@ http_interactions:
           </issues>
         </sourcediff>
     http_version: 
-  recorded_at: Wed, 16 Nov 2016 16:10:46 GMT
+  recorded_at: Fri, 15 Dec 2017 13:12:08 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:tom:branches:BaseDistro:Update/test_package?cmd=linkdiff&linkrev=base&onlyissues=1&view=xml
@@ -602,13 +676,13 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="47efa601923a1c54fa652f20c4ccf8b7">
+        <sourcediff key="2c0c73d6722f5efdcf50897278f01fda">
           <old project="BaseDistro:Update" package="test_package" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e" />
           <new project="home:tom:branches:BaseDistro:Update" package="test_package" rev="add4a945697eee927c39061d8a0ab589" srcmd5="add4a945697eee927c39061d8a0ab589" />
           <files />
         </sourcediff>
     http_version: 
-  recorded_at: Wed, 16 Nov 2016 16:10:46 GMT
+  recorded_at: Fri, 15 Dec 2017 13:12:08 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom:branches:BaseDistro:Update/_meta?user=tom
@@ -655,7 +729,7 @@ http_interactions:
           </publish>
         </project>
     http_version: 
-  recorded_at: Wed, 16 Nov 2016 16:10:46 GMT
+  recorded_at: Fri, 15 Dec 2017 13:12:08 GMT
 - request:
     method: delete
     uri: http://backend:5352/source/home:tom:branches:BaseDistro:Update?comment&user=tom

--- a/src/api/spec/cassettes/BranchPackage/_branch/package_with_UpdateProject_attribute/should_increase_Package_by_one.yml
+++ b/src/api/spec/cassettes/BranchPackage/_branch/package_with_UpdateProject_attribute/should_increase_Package_by_one.yml
@@ -7,7 +7,7 @@ http_interactions:
       encoding: UTF-8
       string: |
         <project name="BaseDistro">
-          <title>Paths of Glory</title>
+          <title>To Your Scattered Bodies Go</title>
           <description/>
         </project>
     headers:
@@ -29,23 +29,23 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '101'
+      - '114'
     body:
       encoding: UTF-8
       string: |
         <project name="BaseDistro">
-          <title>Paths of Glory</title>
+          <title>To Your Scattered Bodies Go</title>
           <description></description>
         </project>
     http_version: 
-  recorded_at: Wed, 16 Nov 2016 16:10:46 GMT
+  recorded_at: Fri, 15 Dec 2017 13:12:09 GMT
 - request:
     method: put
     uri: http://backend:5352/source/BaseDistro/_config
     body:
       encoding: UTF-8
-      string: Sit iste est sequi. Et vel at dolores asperiores. Et et cum sed labore
-        nemo. Nam odit cum veritatis at est.
+      string: Quisquam quibusdam quas. Architecto qui recusandae saepe ex debitis.
+        Vel veniam dolor distinctio aliquam perspiciatis.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -72,7 +72,7 @@ http_interactions:
 
 '
     http_version: 
-  recorded_at: Wed, 16 Nov 2016 16:10:46 GMT
+  recorded_at: Fri, 15 Dec 2017 13:12:09 GMT
 - request:
     method: put
     uri: http://backend:5352/source/BaseDistro/test_package/_meta?user=tom
@@ -80,8 +80,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="test_package" project="BaseDistro">
-          <title/>
-          <description/>
+          <title>In a Dry Season</title>
+          <description>Ab ut non velit.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -102,16 +102,16 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '110'
+      - '141'
     body:
       encoding: UTF-8
       string: |
         <package name="test_package" project="BaseDistro">
-          <title></title>
-          <description></description>
+          <title>In a Dry Season</title>
+          <description>Ab ut non velit.</description>
         </package>
     http_version: 
-  recorded_at: Wed, 16 Nov 2016 16:10:46 GMT
+  recorded_at: Fri, 15 Dec 2017 13:12:09 GMT
 - request:
     method: put
     uri: http://backend:5352/source/BaseDistro/test_package/_meta
@@ -119,8 +119,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="test_package" project="BaseDistro">
-          <title/>
-          <description/>
+          <title>In a Dry Season</title>
+          <description>Ab ut non velit.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -141,16 +141,16 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '110'
+      - '141'
     body:
       encoding: UTF-8
       string: |
         <package name="test_package" project="BaseDistro">
-          <title></title>
-          <description></description>
+          <title>In a Dry Season</title>
+          <description>Ab ut non velit.</description>
         </package>
     http_version: 
-  recorded_at: Wed, 16 Nov 2016 16:10:46 GMT
+  recorded_at: Fri, 15 Dec 2017 13:12:09 GMT
 - request:
     method: put
     uri: http://backend:5352/source/BaseDistro:Update/_meta
@@ -158,7 +158,7 @@ http_interactions:
       encoding: UTF-8
       string: |
         <project name="BaseDistro:Update">
-          <title>Far From the Madding Crowd</title>
+          <title>The Skull Beneath the Skin</title>
           <description/>
         </project>
     headers:
@@ -185,19 +185,19 @@ http_interactions:
       encoding: UTF-8
       string: |
         <project name="BaseDistro:Update">
-          <title>Far From the Madding Crowd</title>
+          <title>The Skull Beneath the Skin</title>
           <description></description>
         </project>
     http_version: 
-  recorded_at: Wed, 16 Nov 2016 16:10:47 GMT
+  recorded_at: Fri, 15 Dec 2017 13:12:09 GMT
 - request:
     method: put
     uri: http://backend:5352/source/BaseDistro:Update/_config
     body:
       encoding: UTF-8
-      string: Porro rerum minus omnis incidunt. Magni animi repudiandae doloribus
-        et consequatur et sed. Reprehenderit nobis autem sint labore rem odit iste.
-        Autem sed atque ipsa enim velit molestias.
+      string: Nihil nisi debitis. Minima porro qui et tenetur molestiae incidunt ad.
+        Officiis ducimus praesentium inventore non quae. Aut ut neque itaque consequatur
+        quis. Delectus sunt aut architecto voluptas perspiciatis maxime vitae.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -224,7 +224,80 @@ http_interactions:
 
 '
     http_version: 
-  recorded_at: Wed, 16 Nov 2016 16:10:47 GMT
+  recorded_at: Fri, 15 Dec 2017 13:12:09 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/project_6/_meta
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="project_6">
+          <title>The Green Bay Tree</title>
+          <description/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '104'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="project_6">
+          <title>The Green Bay Tree</title>
+          <description></description>
+        </project>
+    http_version: 
+  recorded_at: Fri, 15 Dec 2017 13:12:09 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/project_6/_config
+    body:
+      encoding: UTF-8
+      string: Voluptas id et distinctio illum. Rerum aut suscipit laborum. Veniam
+        enim ut pariatur neque.
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '21'
+    body:
+      encoding: UTF-8
+      string: '<status code="ok" />
+
+'
+    http_version: 
+  recorded_at: Fri, 15 Dec 2017 13:12:09 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom/_meta?user=tom
@@ -265,7 +338,7 @@ http_interactions:
           <person userid="tom" role="maintainer" />
         </project>
     http_version: 
-  recorded_at: Wed, 16 Nov 2016 16:10:47 GMT
+  recorded_at: Fri, 15 Dec 2017 13:12:09 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom:branches:BaseDistro:Update/_meta?user=tom
@@ -306,7 +379,7 @@ http_interactions:
           <person userid="tom" role="maintainer" />
         </project>
     http_version: 
-  recorded_at: Wed, 16 Nov 2016 16:10:47 GMT
+  recorded_at: Fri, 15 Dec 2017 13:12:09 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom:branches:BaseDistro:Update/test_package/_meta?user=tom
@@ -345,49 +418,10 @@ http_interactions:
           <description></description>
         </package>
     http_version: 
-  recorded_at: Wed, 16 Nov 2016 16:10:47 GMT
-- request:
-    method: put
-    uri: http://backend:5352/source/home:tom:branches:BaseDistro:Update/test_package/_meta?user=tom
-    body:
-      encoding: UTF-8
-      string: |
-        <package name="test_package" project="home:tom:branches:BaseDistro:Update">
-          <title/>
-          <description/>
-        </package>
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '135'
-    body:
-      encoding: UTF-8
-      string: |
-        <package name="test_package" project="home:tom:branches:BaseDistro:Update">
-          <title></title>
-          <description></description>
-        </package>
-    http_version: 
-  recorded_at: Wed, 16 Nov 2016 16:10:47 GMT
+  recorded_at: Fri, 15 Dec 2017 13:12:09 GMT
 - request:
     method: post
-    uri: http://backend:5352/source/home:tom:branches:BaseDistro:Update/test_package?cmd=branch&missingok=1&opackage=test_package&oproject=BaseDistro:Update&user=tom
+    uri: http://backend:5352/source/home:tom:branches:BaseDistro:Update/test_package?cmd=branch&missingok=1&noservice=1&opackage=test_package&oproject=BaseDistro:Update&user=tom
     body:
       encoding: UTF-8
       string: ''
@@ -419,13 +453,52 @@ http_interactions:
         <revision rev="1" vrev="1">
           <srcmd5>e3adf4aab58a4a6f27974d4a9fb88e5f</srcmd5>
           <version>unknown</version>
-          <time>1479312647</time>
+          <time>1513343529</time>
           <user>tom</user>
           <comment></comment>
           <requestid/>
         </revision>
     http_version: 
-  recorded_at: Wed, 16 Nov 2016 16:10:47 GMT
+  recorded_at: Fri, 15 Dec 2017 13:12:09 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:tom:branches:BaseDistro:Update/test_package/_meta?user=tom
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="test_package" project="home:tom:branches:BaseDistro:Update">
+          <title/>
+          <description/>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '135'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="test_package" project="home:tom:branches:BaseDistro:Update">
+          <title></title>
+          <description></description>
+        </package>
+    http_version: 
+  recorded_at: Fri, 15 Dec 2017 13:12:09 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:tom:branches:BaseDistro:Update/test_package
@@ -457,10 +530,10 @@ http_interactions:
       string: |
         <directory name="test_package" rev="1" vrev="1" srcmd5="e3adf4aab58a4a6f27974d4a9fb88e5f">
           <linkinfo project="BaseDistro:Update" package="test_package" srcmd5="d41d8cd98f00b204e9800998ecf8427e" baserev="d41d8cd98f00b204e9800998ecf8427e" missingok="true" xsrcmd5="add4a945697eee927c39061d8a0ab589" lsrcmd5="e3adf4aab58a4a6f27974d4a9fb88e5f" />
-          <entry name="_link" md5="463447c51c7a017092296988331b6862" size="142" mtime="1479305351" />
+          <entry name="_link" md5="463447c51c7a017092296988331b6862" size="142" mtime="1513343048" />
         </directory>
     http_version: 
-  recorded_at: Wed, 16 Nov 2016 16:10:47 GMT
+  recorded_at: Fri, 15 Dec 2017 13:12:09 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:tom:branches:BaseDistro:Update/test_package?nofilename=1&view=info&withchangesmd5=1
@@ -492,10 +565,10 @@ http_interactions:
       string: |
         <sourceinfo package="test_package" rev="1" vrev="1" srcmd5="add4a945697eee927c39061d8a0ab589" lsrcmd5="e3adf4aab58a4a6f27974d4a9fb88e5f" verifymd5="d41d8cd98f00b204e9800998ecf8427e">
           <linked project="BaseDistro:Update" package="test_package" />
-          <revtime>1479312647</revtime>
+          <revtime>1513343529</revtime>
         </sourceinfo>
     http_version: 
-  recorded_at: Wed, 16 Nov 2016 16:10:47 GMT
+  recorded_at: Fri, 15 Dec 2017 13:12:09 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:tom:branches:BaseDistro:Update/test_package
@@ -527,10 +600,10 @@ http_interactions:
       string: |
         <directory name="test_package" rev="1" vrev="1" srcmd5="e3adf4aab58a4a6f27974d4a9fb88e5f">
           <linkinfo project="BaseDistro:Update" package="test_package" srcmd5="d41d8cd98f00b204e9800998ecf8427e" baserev="d41d8cd98f00b204e9800998ecf8427e" missingok="true" xsrcmd5="add4a945697eee927c39061d8a0ab589" lsrcmd5="e3adf4aab58a4a6f27974d4a9fb88e5f" />
-          <entry name="_link" md5="463447c51c7a017092296988331b6862" size="142" mtime="1479305351" />
+          <entry name="_link" md5="463447c51c7a017092296988331b6862" size="142" mtime="1513343048" />
         </directory>
     http_version: 
-  recorded_at: Wed, 16 Nov 2016 16:10:47 GMT
+  recorded_at: Fri, 15 Dec 2017 13:12:09 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:tom:branches:BaseDistro:Update/test_package?cmd=diff&linkrev=base&onlyissues=1&orev=0&view=xml
@@ -562,7 +635,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="c9e41755ae4b8728a8c5f3fd11f9ba0c">
+        <sourcediff key="76cacf0fa374e517e018c7aa82ac1b8d">
           <old project="home:tom:branches:BaseDistro:Update" package="test_package" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e" />
           <new project="home:tom:branches:BaseDistro:Update" package="test_package" rev="1" srcmd5="e3adf4aab58a4a6f27974d4a9fb88e5f" />
           <files />
@@ -570,7 +643,7 @@ http_interactions:
           </issues>
         </sourcediff>
     http_version: 
-  recorded_at: Wed, 16 Nov 2016 16:10:47 GMT
+  recorded_at: Fri, 15 Dec 2017 13:12:09 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:tom:branches:BaseDistro:Update/test_package?cmd=linkdiff&linkrev=base&onlyissues=1&view=xml
@@ -602,13 +675,13 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="47efa601923a1c54fa652f20c4ccf8b7">
+        <sourcediff key="2c0c73d6722f5efdcf50897278f01fda">
           <old project="BaseDistro:Update" package="test_package" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e" />
           <new project="home:tom:branches:BaseDistro:Update" package="test_package" rev="add4a945697eee927c39061d8a0ab589" srcmd5="add4a945697eee927c39061d8a0ab589" />
           <files />
         </sourcediff>
     http_version: 
-  recorded_at: Wed, 16 Nov 2016 16:10:47 GMT
+  recorded_at: Fri, 15 Dec 2017 13:12:09 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom:branches:BaseDistro:Update/_meta?user=tom
@@ -655,7 +728,7 @@ http_interactions:
           </publish>
         </project>
     http_version: 
-  recorded_at: Wed, 16 Nov 2016 16:10:47 GMT
+  recorded_at: Fri, 15 Dec 2017 13:12:10 GMT
 - request:
     method: delete
     uri: http://backend:5352/source/home:tom:branches:BaseDistro:Update?comment&user=tom

--- a/src/api/spec/cassettes/BranchPackage/_branch/project_with_ImageTemplates_attribute/auto_cleanup_attribute/is_set_to_14_if_there_is_no_default.yml
+++ b/src/api/spec/cassettes/BranchPackage/_branch/project_with_ImageTemplates_attribute/auto_cleanup_attribute/is_set_to_14_if_there_is_no_default.yml
@@ -7,7 +7,7 @@ http_interactions:
       encoding: UTF-8
       string: |
         <project name="BaseDistro">
-          <title>Blood's a Rover</title>
+          <title>Ah, Wilderness!</title>
           <description/>
         </project>
     headers:
@@ -34,18 +34,19 @@ http_interactions:
       encoding: UTF-8
       string: |
         <project name="BaseDistro">
-          <title>Blood's a Rover</title>
+          <title>Ah, Wilderness!</title>
           <description></description>
         </project>
     http_version: 
-  recorded_at: Wed, 16 Nov 2016 16:10:39 GMT
+  recorded_at: Fri, 15 Dec 2017 13:12:06 GMT
 - request:
     method: put
     uri: http://backend:5352/source/BaseDistro/_config
     body:
       encoding: UTF-8
-      string: Dignissimos quo omnis porro quae tempora. Quas maiores nisi aut in ratione.
-        Atque rerum iusto aut. Ut consequatur ipsam dolorem eos incidunt numquam.
+      string: Aut quibusdam quis eaque in. Rerum quo necessitatibus et ut eum iusto.
+        Provident optio ab adipisci et enim iure. Optio temporibus dignissimos aut
+        odio ipsam sed.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -72,16 +73,16 @@ http_interactions:
 
 '
     http_version: 
-  recorded_at: Wed, 16 Nov 2016 16:10:39 GMT
+  recorded_at: Fri, 15 Dec 2017 13:12:06 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/BaseDistro/test_package/_meta?user=_nobody_
+    uri: http://backend:5352/source/BaseDistro/test_package/_meta?user=tom
     body:
       encoding: UTF-8
       string: |
         <package name="test_package" project="BaseDistro">
-          <title/>
-          <description/>
+          <title>A Darkling Plain</title>
+          <description>Illo in corporis deleniti fugiat.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -102,16 +103,16 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '110'
+      - '159'
     body:
       encoding: UTF-8
       string: |
         <package name="test_package" project="BaseDistro">
-          <title></title>
-          <description></description>
+          <title>A Darkling Plain</title>
+          <description>Illo in corporis deleniti fugiat.</description>
         </package>
     http_version: 
-  recorded_at: Wed, 16 Nov 2016 16:10:39 GMT
+  recorded_at: Fri, 15 Dec 2017 13:12:06 GMT
 - request:
     method: put
     uri: http://backend:5352/source/BaseDistro/test_package/_meta
@@ -119,8 +120,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="test_package" project="BaseDistro">
-          <title/>
-          <description/>
+          <title>A Darkling Plain</title>
+          <description>Illo in corporis deleniti fugiat.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -141,16 +142,16 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '110'
+      - '159'
     body:
       encoding: UTF-8
       string: |
         <package name="test_package" project="BaseDistro">
-          <title></title>
-          <description></description>
+          <title>A Darkling Plain</title>
+          <description>Illo in corporis deleniti fugiat.</description>
         </package>
     http_version: 
-  recorded_at: Wed, 16 Nov 2016 16:10:39 GMT
+  recorded_at: Fri, 15 Dec 2017 13:12:06 GMT
 - request:
     method: put
     uri: http://backend:5352/source/BaseDistro:Update/_meta
@@ -158,7 +159,7 @@ http_interactions:
       encoding: UTF-8
       string: |
         <project name="BaseDistro:Update">
-          <title>The Moon by Night</title>
+          <title>Alone on a Wide, Wide Sea</title>
           <description/>
         </project>
     headers:
@@ -180,23 +181,24 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '111'
+      - '119'
     body:
       encoding: UTF-8
       string: |
         <project name="BaseDistro:Update">
-          <title>The Moon by Night</title>
+          <title>Alone on a Wide, Wide Sea</title>
           <description></description>
         </project>
     http_version: 
-  recorded_at: Wed, 16 Nov 2016 16:10:39 GMT
+  recorded_at: Fri, 15 Dec 2017 13:12:06 GMT
 - request:
     method: put
     uri: http://backend:5352/source/BaseDistro:Update/_config
     body:
       encoding: UTF-8
-      string: Quasi non voluptatem voluptates. Nulla officia omnis quia. Voluptatem
-        rem incidunt modi consequatur est. Ex hic amet est ut quo.
+      string: Reprehenderit nesciunt a expedita ad harum eligendi nam. Et necessitatibus
+        impedit mollitia tempora hic. Molestiae temporibus ut et rem perferendis et.
+        Optio aut soluta in ea nemo. Qui harum mollitia modi qui omnis corrupti placeat.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -223,7 +225,81 @@ http_interactions:
 
 '
     http_version: 
-  recorded_at: Wed, 16 Nov 2016 16:10:39 GMT
+  recorded_at: Fri, 15 Dec 2017 13:12:06 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/project_4/_meta
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="project_4">
+          <title>Oh! To be in England</title>
+          <description/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '106'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="project_4">
+          <title>Oh! To be in England</title>
+          <description></description>
+        </project>
+    http_version: 
+  recorded_at: Fri, 15 Dec 2017 13:12:07 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/project_4/_config
+    body:
+      encoding: UTF-8
+      string: Assumenda officia eum aspernatur qui. Qui voluptatem eum sit modi eius.
+        Dicta nulla autem deserunt aut ut vel. Consequuntur deleniti id qui enim doloremque
+        voluptas atque. Id eaque quo tenetur quis quo.
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '21'
+    body:
+      encoding: UTF-8
+      string: '<status code="ok" />
+
+'
+    http_version: 
+  recorded_at: Fri, 15 Dec 2017 13:12:07 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom/_meta?user=tom
@@ -264,7 +340,7 @@ http_interactions:
           <person userid="tom" role="maintainer" />
         </project>
     http_version: 
-  recorded_at: Wed, 16 Nov 2016 16:10:40 GMT
+  recorded_at: Fri, 15 Dec 2017 13:12:07 GMT
 - request:
     method: put
     uri: http://backend:5352/source/openSUSE_Leap/_meta
@@ -272,7 +348,7 @@ http_interactions:
       encoding: UTF-8
       string: |
         <project name="openSUSE_Leap">
-          <title>Surprised by Joy</title>
+          <title>Recalled to Life</title>
           <description/>
         </project>
     headers:
@@ -299,20 +375,18 @@ http_interactions:
       encoding: UTF-8
       string: |
         <project name="openSUSE_Leap">
-          <title>Surprised by Joy</title>
+          <title>Recalled to Life</title>
           <description></description>
         </project>
     http_version: 
-  recorded_at: Wed, 16 Nov 2016 16:10:40 GMT
+  recorded_at: Fri, 15 Dec 2017 13:12:07 GMT
 - request:
     method: put
     uri: http://backend:5352/source/openSUSE_Leap/_config
     body:
       encoding: UTF-8
-      string: Quidem velit laborum quia repellendus quas officiis porro. Officiis
-        reprehenderit aspernatur eveniet autem velit dignissimos. Expedita quidem
-        praesentium rerum perferendis dolorum qui id. Repellat aut in aut ab. Officiis
-        veritatis aut eos ad repudiandae in.
+      string: Qui quidem sit voluptas at. Nobis est earum quidem. A molestiae nam
+        numquam. Nemo omnis ea placeat fugit tempore.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -339,7 +413,7 @@ http_interactions:
 
 '
     http_version: 
-  recorded_at: Wed, 16 Nov 2016 16:10:40 GMT
+  recorded_at: Fri, 15 Dec 2017 13:12:07 GMT
 - request:
     method: put
     uri: http://backend:5352/source/openSUSE_Leap/apache2/_meta?user=tom
@@ -347,8 +421,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="apache2" project="openSUSE_Leap">
-          <title/>
-          <description/>
+          <title>The Grapes of Wrath</title>
+          <description>Molestias omnis eos molestiae velit.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -369,16 +443,16 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '108'
+      - '163'
     body:
       encoding: UTF-8
       string: |
         <package name="apache2" project="openSUSE_Leap">
-          <title></title>
-          <description></description>
+          <title>The Grapes of Wrath</title>
+          <description>Molestias omnis eos molestiae velit.</description>
         </package>
     http_version: 
-  recorded_at: Wed, 16 Nov 2016 16:10:40 GMT
+  recorded_at: Fri, 15 Dec 2017 13:12:07 GMT
 - request:
     method: put
     uri: http://backend:5352/source/openSUSE_Leap/apache2/_meta
@@ -386,8 +460,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="apache2" project="openSUSE_Leap">
-          <title/>
-          <description/>
+          <title>The Grapes of Wrath</title>
+          <description>Molestias omnis eos molestiae velit.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -408,16 +482,16 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '108'
+      - '163'
     body:
       encoding: UTF-8
       string: |
         <package name="apache2" project="openSUSE_Leap">
-          <title></title>
-          <description></description>
+          <title>The Grapes of Wrath</title>
+          <description>Molestias omnis eos molestiae velit.</description>
         </package>
     http_version: 
-  recorded_at: Wed, 16 Nov 2016 16:10:40 GMT
+  recorded_at: Fri, 15 Dec 2017 13:12:07 GMT
 - request:
     method: post
     uri: http://backend:5352/search/package/id?match=(linkinfo/@package=%22apache2%22%20and%20linkinfo/@project=%22openSUSE_Leap%22%20and%20@project=%22openSUSE_Leap%22)
@@ -452,7 +526,7 @@ http_interactions:
         <collection>
         </collection>
     http_version: 
-  recorded_at: Wed, 16 Nov 2016 16:10:40 GMT
+  recorded_at: Fri, 15 Dec 2017 13:12:07 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom:branches:openSUSE_Leap/_meta?user=tom
@@ -493,7 +567,7 @@ http_interactions:
           <person userid="tom" role="maintainer" />
         </project>
     http_version: 
-  recorded_at: Wed, 16 Nov 2016 16:10:40 GMT
+  recorded_at: Fri, 15 Dec 2017 13:12:07 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom:branches:openSUSE_Leap/apache2/_meta?user=tom
@@ -501,8 +575,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="apache2" project="home:tom:branches:openSUSE_Leap">
-          <title/>
-          <description/>
+          <title>The Grapes of Wrath</title>
+          <description>Molestias omnis eos molestiae velit.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -523,58 +597,19 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '126'
+      - '181'
     body:
       encoding: UTF-8
       string: |
         <package name="apache2" project="home:tom:branches:openSUSE_Leap">
-          <title></title>
-          <description></description>
+          <title>The Grapes of Wrath</title>
+          <description>Molestias omnis eos molestiae velit.</description>
         </package>
     http_version: 
-  recorded_at: Wed, 16 Nov 2016 16:10:40 GMT
-- request:
-    method: put
-    uri: http://backend:5352/source/home:tom:branches:openSUSE_Leap/apache2/_meta?user=tom
-    body:
-      encoding: UTF-8
-      string: |
-        <package name="apache2" project="home:tom:branches:openSUSE_Leap">
-          <title/>
-          <description/>
-        </package>
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '126'
-    body:
-      encoding: UTF-8
-      string: |
-        <package name="apache2" project="home:tom:branches:openSUSE_Leap">
-          <title></title>
-          <description></description>
-        </package>
-    http_version: 
-  recorded_at: Wed, 16 Nov 2016 16:10:40 GMT
+  recorded_at: Fri, 15 Dec 2017 13:12:07 GMT
 - request:
     method: post
-    uri: http://backend:5352/source/home:tom:branches:openSUSE_Leap/apache2?cmd=branch&opackage=apache2&oproject=openSUSE_Leap&user=tom
+    uri: http://backend:5352/source/home:tom:branches:openSUSE_Leap/apache2?cmd=branch&noservice=1&opackage=apache2&oproject=openSUSE_Leap&user=tom
     body:
       encoding: UTF-8
       string: ''
@@ -606,13 +641,52 @@ http_interactions:
         <revision rev="1" vrev="1">
           <srcmd5>f2b6eaf02987245b9003bcf47e0222dc</srcmd5>
           <version>unknown</version>
-          <time>1479312640</time>
+          <time>1513343527</time>
           <user>tom</user>
           <comment></comment>
           <requestid/>
         </revision>
     http_version: 
-  recorded_at: Wed, 16 Nov 2016 16:10:40 GMT
+  recorded_at: Fri, 15 Dec 2017 13:12:07 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:tom:branches:openSUSE_Leap/apache2/_meta?user=tom
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="apache2" project="home:tom:branches:openSUSE_Leap">
+          <title>The Grapes of Wrath</title>
+          <description>Molestias omnis eos molestiae velit.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '181'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="apache2" project="home:tom:branches:openSUSE_Leap">
+          <title>The Grapes of Wrath</title>
+          <description>Molestias omnis eos molestiae velit.</description>
+        </package>
+    http_version: 
+  recorded_at: Fri, 15 Dec 2017 13:12:07 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:tom:branches:openSUSE_Leap/apache2
@@ -644,10 +718,10 @@ http_interactions:
       string: |
         <directory name="apache2" rev="1" vrev="1" srcmd5="f2b6eaf02987245b9003bcf47e0222dc">
           <linkinfo project="openSUSE_Leap" package="apache2" srcmd5="d41d8cd98f00b204e9800998ecf8427e" baserev="d41d8cd98f00b204e9800998ecf8427e" xsrcmd5="2fbc15ae60271e3fe13b837e014a17ea" lsrcmd5="f2b6eaf02987245b9003bcf47e0222dc" />
-          <entry name="_link" md5="42ab2fdb360424b79deaaaec3dcd12ff" size="121" mtime="1479304500" />
+          <entry name="_link" md5="42ab2fdb360424b79deaaaec3dcd12ff" size="121" mtime="1513343013" />
         </directory>
     http_version: 
-  recorded_at: Wed, 16 Nov 2016 16:10:40 GMT
+  recorded_at: Fri, 15 Dec 2017 13:12:07 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:tom:branches:openSUSE_Leap/apache2?nofilename=1&view=info&withchangesmd5=1
@@ -679,10 +753,10 @@ http_interactions:
       string: |
         <sourceinfo package="apache2" rev="1" vrev="1" srcmd5="2fbc15ae60271e3fe13b837e014a17ea" lsrcmd5="f2b6eaf02987245b9003bcf47e0222dc" verifymd5="d41d8cd98f00b204e9800998ecf8427e">
           <linked project="openSUSE_Leap" package="apache2" />
-          <revtime>1479312640</revtime>
+          <revtime>1513343527</revtime>
         </sourceinfo>
     http_version: 
-  recorded_at: Wed, 16 Nov 2016 16:10:40 GMT
+  recorded_at: Fri, 15 Dec 2017 13:12:07 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:tom:branches:openSUSE_Leap/apache2
@@ -714,10 +788,10 @@ http_interactions:
       string: |
         <directory name="apache2" rev="1" vrev="1" srcmd5="f2b6eaf02987245b9003bcf47e0222dc">
           <linkinfo project="openSUSE_Leap" package="apache2" srcmd5="d41d8cd98f00b204e9800998ecf8427e" baserev="d41d8cd98f00b204e9800998ecf8427e" xsrcmd5="2fbc15ae60271e3fe13b837e014a17ea" lsrcmd5="f2b6eaf02987245b9003bcf47e0222dc" />
-          <entry name="_link" md5="42ab2fdb360424b79deaaaec3dcd12ff" size="121" mtime="1479304500" />
+          <entry name="_link" md5="42ab2fdb360424b79deaaaec3dcd12ff" size="121" mtime="1513343013" />
         </directory>
     http_version: 
-  recorded_at: Wed, 16 Nov 2016 16:10:40 GMT
+  recorded_at: Fri, 15 Dec 2017 13:12:07 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:tom:branches:openSUSE_Leap/apache2?cmd=diff&linkrev=base&onlyissues=1&orev=0&view=xml
@@ -749,7 +823,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="b4eb9aa75778707a23b6f6a8cfd9aced">
+        <sourcediff key="6b52695450ecc45fc1d605938d0aff06">
           <old project="home:tom:branches:openSUSE_Leap" package="apache2" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e" />
           <new project="home:tom:branches:openSUSE_Leap" package="apache2" rev="1" srcmd5="f2b6eaf02987245b9003bcf47e0222dc" />
           <files />
@@ -757,7 +831,7 @@ http_interactions:
           </issues>
         </sourcediff>
     http_version: 
-  recorded_at: Wed, 16 Nov 2016 16:10:41 GMT
+  recorded_at: Fri, 15 Dec 2017 13:12:07 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:tom:branches:openSUSE_Leap/apache2?cmd=linkdiff&linkrev=base&onlyissues=1&view=xml
@@ -789,13 +863,13 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="1c6621e539f5863fcf3a10f8baf9b790">
+        <sourcediff key="5d4e5de10a7da9b9f966d8bec322637f">
           <old project="openSUSE_Leap" package="apache2" rev="d41d8cd98f00b204e9800998ecf8427e" srcmd5="d41d8cd98f00b204e9800998ecf8427e" />
           <new project="home:tom:branches:openSUSE_Leap" package="apache2" rev="2fbc15ae60271e3fe13b837e014a17ea" srcmd5="2fbc15ae60271e3fe13b837e014a17ea" />
           <files />
         </sourcediff>
     http_version: 
-  recorded_at: Wed, 16 Nov 2016 16:10:41 GMT
+  recorded_at: Fri, 15 Dec 2017 13:12:07 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom:branches:openSUSE_Leap/_meta?user=tom
@@ -842,7 +916,7 @@ http_interactions:
           </publish>
         </project>
     http_version: 
-  recorded_at: Wed, 16 Nov 2016 16:10:41 GMT
+  recorded_at: Fri, 15 Dec 2017 13:12:07 GMT
 - request:
     method: delete
     uri: http://backend:5352/source/home:tom:branches:openSUSE_Leap?comment&user=tom

--- a/src/api/spec/cassettes/BranchPackage/_branch/project_with_ImageTemplates_attribute/auto_cleanup_attribute/is_set_to_the_default.yml
+++ b/src/api/spec/cassettes/BranchPackage/_branch/project_with_ImageTemplates_attribute/auto_cleanup_attribute/is_set_to_the_default.yml
@@ -7,7 +7,7 @@ http_interactions:
       encoding: UTF-8
       string: |
         <project name="BaseDistro">
-          <title>The Violent Bear It Away</title>
+          <title>The Sun Also Rises</title>
           <description/>
         </project>
     headers:
@@ -29,24 +29,24 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '111'
+      - '105'
     body:
       encoding: UTF-8
       string: |
         <project name="BaseDistro">
-          <title>The Violent Bear It Away</title>
+          <title>The Sun Also Rises</title>
           <description></description>
         </project>
     http_version: 
-  recorded_at: Wed, 16 Nov 2016 16:10:41 GMT
+  recorded_at: Fri, 15 Dec 2017 13:12:05 GMT
 - request:
     method: put
     uri: http://backend:5352/source/BaseDistro/_config
     body:
       encoding: UTF-8
-      string: Voluptatem odio velit et possimus nobis. Pariatur architecto amet exercitationem
-        aspernatur accusamus. Unde quisquam hic dolorum. Repudiandae dolorem vero
-        voluptatem distinctio.
+      string: Perferendis similique illo veritatis et. Praesentium voluptatibus odio
+        incidunt quibusdam omnis blanditiis. Alias sequi repudiandae nemo blanditiis
+        voluptas ut. Aliquid magnam consequatur incidunt. Illum atque nam iusto.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -73,7 +73,7 @@ http_interactions:
 
 '
     http_version: 
-  recorded_at: Wed, 16 Nov 2016 16:10:42 GMT
+  recorded_at: Fri, 15 Dec 2017 13:12:05 GMT
 - request:
     method: put
     uri: http://backend:5352/source/BaseDistro/test_package/_meta?user=tom
@@ -81,8 +81,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="test_package" project="BaseDistro">
-          <title/>
-          <description/>
+          <title>No Longer at Ease</title>
+          <description>Illo aspernatur ut nobis reiciendis voluptas animi.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -103,16 +103,16 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '110'
+      - '178'
     body:
       encoding: UTF-8
       string: |
         <package name="test_package" project="BaseDistro">
-          <title></title>
-          <description></description>
+          <title>No Longer at Ease</title>
+          <description>Illo aspernatur ut nobis reiciendis voluptas animi.</description>
         </package>
     http_version: 
-  recorded_at: Wed, 16 Nov 2016 16:10:42 GMT
+  recorded_at: Fri, 15 Dec 2017 13:12:05 GMT
 - request:
     method: put
     uri: http://backend:5352/source/BaseDistro/test_package/_meta
@@ -120,8 +120,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="test_package" project="BaseDistro">
-          <title/>
-          <description/>
+          <title>No Longer at Ease</title>
+          <description>Illo aspernatur ut nobis reiciendis voluptas animi.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -142,16 +142,16 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '110'
+      - '178'
     body:
       encoding: UTF-8
       string: |
         <package name="test_package" project="BaseDistro">
-          <title></title>
-          <description></description>
+          <title>No Longer at Ease</title>
+          <description>Illo aspernatur ut nobis reiciendis voluptas animi.</description>
         </package>
     http_version: 
-  recorded_at: Wed, 16 Nov 2016 16:10:42 GMT
+  recorded_at: Fri, 15 Dec 2017 13:12:05 GMT
 - request:
     method: put
     uri: http://backend:5352/source/BaseDistro:Update/_meta
@@ -159,7 +159,7 @@ http_interactions:
       encoding: UTF-8
       string: |
         <project name="BaseDistro:Update">
-          <title>Terrible Swift Sword</title>
+          <title>No Highway</title>
           <description/>
         </project>
     headers:
@@ -181,24 +181,23 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '114'
+      - '104'
     body:
       encoding: UTF-8
       string: |
         <project name="BaseDistro:Update">
-          <title>Terrible Swift Sword</title>
+          <title>No Highway</title>
           <description></description>
         </project>
     http_version: 
-  recorded_at: Wed, 16 Nov 2016 16:10:42 GMT
+  recorded_at: Fri, 15 Dec 2017 13:12:05 GMT
 - request:
     method: put
     uri: http://backend:5352/source/BaseDistro:Update/_config
     body:
       encoding: UTF-8
-      string: Atque neque excepturi et molestiae tenetur. Debitis doloribus iste.
-        Possimus quia ut omnis sed aut magnam. Eligendi dolorem ipsa unde ut. Enim
-        quis voluptas et saepe eum labore.
+      string: Possimus eius ducimus. Temporibus modi tempore voluptatum nesciunt dolores
+        enim. Expedita nobis laborum facilis non et.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -225,7 +224,80 @@ http_interactions:
 
 '
     http_version: 
-  recorded_at: Wed, 16 Nov 2016 16:10:42 GMT
+  recorded_at: Fri, 15 Dec 2017 13:12:05 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/project_3/_meta
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="project_3">
+          <title>The Sun Also Rises</title>
+          <description/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '104'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="project_3">
+          <title>The Sun Also Rises</title>
+          <description></description>
+        </project>
+    http_version: 
+  recorded_at: Fri, 15 Dec 2017 13:12:05 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/project_3/_config
+    body:
+      encoding: UTF-8
+      string: Cum voluptatem quis ut quaerat eaque unde nobis. Ipsum praesentium totam
+        autem. Ab velit non. Sunt iure harum. Minus voluptas ea qui.
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '21'
+    body:
+      encoding: UTF-8
+      string: '<status code="ok" />
+
+'
+    http_version: 
+  recorded_at: Fri, 15 Dec 2017 13:12:05 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom/_meta?user=tom
@@ -266,7 +338,7 @@ http_interactions:
           <person userid="tom" role="maintainer" />
         </project>
     http_version: 
-  recorded_at: Wed, 16 Nov 2016 16:10:42 GMT
+  recorded_at: Fri, 15 Dec 2017 13:12:06 GMT
 - request:
     method: put
     uri: http://backend:5352/source/openSUSE_Leap/_meta
@@ -274,7 +346,7 @@ http_interactions:
       encoding: UTF-8
       string: |
         <project name="openSUSE_Leap">
-          <title>Lilies of the Field</title>
+          <title>Look Homeward, Angel</title>
           <description/>
         </project>
     headers:
@@ -296,23 +368,24 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '109'
+      - '110'
     body:
       encoding: UTF-8
       string: |
         <project name="openSUSE_Leap">
-          <title>Lilies of the Field</title>
+          <title>Look Homeward, Angel</title>
           <description></description>
         </project>
     http_version: 
-  recorded_at: Wed, 16 Nov 2016 16:10:42 GMT
+  recorded_at: Fri, 15 Dec 2017 13:12:06 GMT
 - request:
     method: put
     uri: http://backend:5352/source/openSUSE_Leap/_config
     body:
       encoding: UTF-8
-      string: Ea vel id provident. Omnis veniam voluptatem recusandae nemo. Molestiae
-        sit aut eum et minima accusamus magnam.
+      string: Et aut non ab voluptatem voluptatem repellendus sed. Iste consequatur
+        ut et neque qui. Eum dicta laudantium. Cum id facere dolores neque labore
+        vel quis. Qui ab fugiat.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -339,7 +412,7 @@ http_interactions:
 
 '
     http_version: 
-  recorded_at: Wed, 16 Nov 2016 16:10:42 GMT
+  recorded_at: Fri, 15 Dec 2017 13:12:06 GMT
 - request:
     method: put
     uri: http://backend:5352/source/openSUSE_Leap/apache2/_meta?user=tom
@@ -347,8 +420,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="apache2" project="openSUSE_Leap">
-          <title/>
-          <description/>
+          <title>Of Human Bondage</title>
+          <description>Sit sapiente quo perspiciatis aperiam qui sint.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -369,16 +442,16 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '108'
+      - '171'
     body:
       encoding: UTF-8
       string: |
         <package name="apache2" project="openSUSE_Leap">
-          <title></title>
-          <description></description>
+          <title>Of Human Bondage</title>
+          <description>Sit sapiente quo perspiciatis aperiam qui sint.</description>
         </package>
     http_version: 
-  recorded_at: Wed, 16 Nov 2016 16:10:42 GMT
+  recorded_at: Fri, 15 Dec 2017 13:12:06 GMT
 - request:
     method: put
     uri: http://backend:5352/source/openSUSE_Leap/apache2/_meta
@@ -386,8 +459,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="apache2" project="openSUSE_Leap">
-          <title/>
-          <description/>
+          <title>Of Human Bondage</title>
+          <description>Sit sapiente quo perspiciatis aperiam qui sint.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -408,16 +481,16 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '108'
+      - '171'
     body:
       encoding: UTF-8
       string: |
         <package name="apache2" project="openSUSE_Leap">
-          <title></title>
-          <description></description>
+          <title>Of Human Bondage</title>
+          <description>Sit sapiente quo perspiciatis aperiam qui sint.</description>
         </package>
     http_version: 
-  recorded_at: Wed, 16 Nov 2016 16:10:42 GMT
+  recorded_at: Fri, 15 Dec 2017 13:12:06 GMT
 - request:
     method: post
     uri: http://backend:5352/search/package/id?match=(linkinfo/@package=%22apache2%22%20and%20linkinfo/@project=%22openSUSE_Leap%22%20and%20@project=%22openSUSE_Leap%22)
@@ -452,7 +525,7 @@ http_interactions:
         <collection>
         </collection>
     http_version: 
-  recorded_at: Wed, 16 Nov 2016 16:10:42 GMT
+  recorded_at: Fri, 15 Dec 2017 13:12:06 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom:branches:openSUSE_Leap/_meta?user=tom
@@ -493,7 +566,7 @@ http_interactions:
           <person userid="tom" role="maintainer" />
         </project>
     http_version: 
-  recorded_at: Wed, 16 Nov 2016 16:10:42 GMT
+  recorded_at: Fri, 15 Dec 2017 13:12:06 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom:branches:openSUSE_Leap/apache2/_meta?user=tom
@@ -501,8 +574,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="apache2" project="home:tom:branches:openSUSE_Leap">
-          <title/>
-          <description/>
+          <title>Of Human Bondage</title>
+          <description>Sit sapiente quo perspiciatis aperiam qui sint.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -523,58 +596,19 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '126'
+      - '189'
     body:
       encoding: UTF-8
       string: |
         <package name="apache2" project="home:tom:branches:openSUSE_Leap">
-          <title></title>
-          <description></description>
+          <title>Of Human Bondage</title>
+          <description>Sit sapiente quo perspiciatis aperiam qui sint.</description>
         </package>
     http_version: 
-  recorded_at: Wed, 16 Nov 2016 16:10:42 GMT
-- request:
-    method: put
-    uri: http://backend:5352/source/home:tom:branches:openSUSE_Leap/apache2/_meta?user=tom
-    body:
-      encoding: UTF-8
-      string: |
-        <package name="apache2" project="home:tom:branches:openSUSE_Leap">
-          <title/>
-          <description/>
-        </package>
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '126'
-    body:
-      encoding: UTF-8
-      string: |
-        <package name="apache2" project="home:tom:branches:openSUSE_Leap">
-          <title></title>
-          <description></description>
-        </package>
-    http_version: 
-  recorded_at: Wed, 16 Nov 2016 16:10:42 GMT
+  recorded_at: Fri, 15 Dec 2017 13:12:06 GMT
 - request:
     method: post
-    uri: http://backend:5352/source/home:tom:branches:openSUSE_Leap/apache2?cmd=branch&opackage=apache2&oproject=openSUSE_Leap&user=tom
+    uri: http://backend:5352/source/home:tom:branches:openSUSE_Leap/apache2?cmd=branch&noservice=1&opackage=apache2&oproject=openSUSE_Leap&user=tom
     body:
       encoding: UTF-8
       string: ''
@@ -606,13 +640,52 @@ http_interactions:
         <revision rev="1" vrev="1">
           <srcmd5>f2b6eaf02987245b9003bcf47e0222dc</srcmd5>
           <version>unknown</version>
-          <time>1479312642</time>
+          <time>1513343526</time>
           <user>tom</user>
           <comment></comment>
           <requestid/>
         </revision>
     http_version: 
-  recorded_at: Wed, 16 Nov 2016 16:10:42 GMT
+  recorded_at: Fri, 15 Dec 2017 13:12:06 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:tom:branches:openSUSE_Leap/apache2/_meta?user=tom
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="apache2" project="home:tom:branches:openSUSE_Leap">
+          <title>Of Human Bondage</title>
+          <description>Sit sapiente quo perspiciatis aperiam qui sint.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '189'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="apache2" project="home:tom:branches:openSUSE_Leap">
+          <title>Of Human Bondage</title>
+          <description>Sit sapiente quo perspiciatis aperiam qui sint.</description>
+        </package>
+    http_version: 
+  recorded_at: Fri, 15 Dec 2017 13:12:06 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:tom:branches:openSUSE_Leap/apache2
@@ -644,10 +717,10 @@ http_interactions:
       string: |
         <directory name="apache2" rev="1" vrev="1" srcmd5="f2b6eaf02987245b9003bcf47e0222dc">
           <linkinfo project="openSUSE_Leap" package="apache2" srcmd5="d41d8cd98f00b204e9800998ecf8427e" baserev="d41d8cd98f00b204e9800998ecf8427e" xsrcmd5="2fbc15ae60271e3fe13b837e014a17ea" lsrcmd5="f2b6eaf02987245b9003bcf47e0222dc" />
-          <entry name="_link" md5="42ab2fdb360424b79deaaaec3dcd12ff" size="121" mtime="1479304500" />
+          <entry name="_link" md5="42ab2fdb360424b79deaaaec3dcd12ff" size="121" mtime="1513343013" />
         </directory>
     http_version: 
-  recorded_at: Wed, 16 Nov 2016 16:10:42 GMT
+  recorded_at: Fri, 15 Dec 2017 13:12:06 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:tom:branches:openSUSE_Leap/apache2?nofilename=1&view=info&withchangesmd5=1
@@ -679,10 +752,10 @@ http_interactions:
       string: |
         <sourceinfo package="apache2" rev="1" vrev="1" srcmd5="2fbc15ae60271e3fe13b837e014a17ea" lsrcmd5="f2b6eaf02987245b9003bcf47e0222dc" verifymd5="d41d8cd98f00b204e9800998ecf8427e">
           <linked project="openSUSE_Leap" package="apache2" />
-          <revtime>1479312642</revtime>
+          <revtime>1513343526</revtime>
         </sourceinfo>
     http_version: 
-  recorded_at: Wed, 16 Nov 2016 16:10:42 GMT
+  recorded_at: Fri, 15 Dec 2017 13:12:06 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:tom:branches:openSUSE_Leap/apache2
@@ -714,10 +787,10 @@ http_interactions:
       string: |
         <directory name="apache2" rev="1" vrev="1" srcmd5="f2b6eaf02987245b9003bcf47e0222dc">
           <linkinfo project="openSUSE_Leap" package="apache2" srcmd5="d41d8cd98f00b204e9800998ecf8427e" baserev="d41d8cd98f00b204e9800998ecf8427e" xsrcmd5="2fbc15ae60271e3fe13b837e014a17ea" lsrcmd5="f2b6eaf02987245b9003bcf47e0222dc" />
-          <entry name="_link" md5="42ab2fdb360424b79deaaaec3dcd12ff" size="121" mtime="1479304500" />
+          <entry name="_link" md5="42ab2fdb360424b79deaaaec3dcd12ff" size="121" mtime="1513343013" />
         </directory>
     http_version: 
-  recorded_at: Wed, 16 Nov 2016 16:10:43 GMT
+  recorded_at: Fri, 15 Dec 2017 13:12:06 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:tom:branches:openSUSE_Leap/apache2?cmd=diff&linkrev=base&onlyissues=1&orev=0&view=xml
@@ -749,7 +822,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="b4eb9aa75778707a23b6f6a8cfd9aced">
+        <sourcediff key="6b52695450ecc45fc1d605938d0aff06">
           <old project="home:tom:branches:openSUSE_Leap" package="apache2" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e" />
           <new project="home:tom:branches:openSUSE_Leap" package="apache2" rev="1" srcmd5="f2b6eaf02987245b9003bcf47e0222dc" />
           <files />
@@ -757,7 +830,7 @@ http_interactions:
           </issues>
         </sourcediff>
     http_version: 
-  recorded_at: Wed, 16 Nov 2016 16:10:43 GMT
+  recorded_at: Fri, 15 Dec 2017 13:12:06 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:tom:branches:openSUSE_Leap/apache2?cmd=linkdiff&linkrev=base&onlyissues=1&view=xml
@@ -789,13 +862,13 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="1c6621e539f5863fcf3a10f8baf9b790">
+        <sourcediff key="5d4e5de10a7da9b9f966d8bec322637f">
           <old project="openSUSE_Leap" package="apache2" rev="d41d8cd98f00b204e9800998ecf8427e" srcmd5="d41d8cd98f00b204e9800998ecf8427e" />
           <new project="home:tom:branches:openSUSE_Leap" package="apache2" rev="2fbc15ae60271e3fe13b837e014a17ea" srcmd5="2fbc15ae60271e3fe13b837e014a17ea" />
           <files />
         </sourcediff>
     http_version: 
-  recorded_at: Wed, 16 Nov 2016 16:10:43 GMT
+  recorded_at: Fri, 15 Dec 2017 13:12:06 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom:branches:openSUSE_Leap/_meta?user=tom
@@ -842,7 +915,7 @@ http_interactions:
           </publish>
         </project>
     http_version: 
-  recorded_at: Wed, 16 Nov 2016 16:10:43 GMT
+  recorded_at: Fri, 15 Dec 2017 13:12:06 GMT
 - request:
     method: delete
     uri: http://backend:5352/source/home:tom:branches:openSUSE_Leap?comment&user=tom

--- a/src/api/spec/cassettes/BranchPackage/_branch/project_without_ImageTemplates_attribute/auto_cleanup_attribute/is_not_set.yml
+++ b/src/api/spec/cassettes/BranchPackage/_branch/project_without_ImageTemplates_attribute/auto_cleanup_attribute/is_not_set.yml
@@ -7,7 +7,7 @@ http_interactions:
       encoding: UTF-8
       string: |
         <project name="BaseDistro">
-          <title>The Sun Also Rises</title>
+          <title>The Last Enemy</title>
           <description/>
         </project>
     headers:
@@ -29,23 +29,24 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '105'
+      - '101'
     body:
       encoding: UTF-8
       string: |
         <project name="BaseDistro">
-          <title>The Sun Also Rises</title>
+          <title>The Last Enemy</title>
           <description></description>
         </project>
     http_version: 
-  recorded_at: Wed, 16 Nov 2016 16:10:43 GMT
+  recorded_at: Fri, 15 Dec 2017 13:12:03 GMT
 - request:
     method: put
     uri: http://backend:5352/source/BaseDistro/_config
     body:
       encoding: UTF-8
-      string: Dolor fugit et sapiente error quibusdam vero sunt. Provident eius voluptatem
-        qui eveniet. Modi et voluptas.
+      string: Debitis consequatur quod consequatur. Dolorem saepe doloremque sint
+        repellendus minima voluptatem mollitia. Deleniti quo et dolorem corporis nostrum
+        numquam. Vel enim eius error ut.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -72,16 +73,16 @@ http_interactions:
 
 '
     http_version: 
-  recorded_at: Wed, 16 Nov 2016 16:10:43 GMT
+  recorded_at: Fri, 15 Dec 2017 13:12:03 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/BaseDistro/test_package/_meta?user=tom
+    uri: http://backend:5352/source/BaseDistro/test_package/_meta?user=_nobody_
     body:
       encoding: UTF-8
       string: |
         <package name="test_package" project="BaseDistro">
-          <title/>
-          <description/>
+          <title>Dying of the Light</title>
+          <description>Molestias adipisci voluptatem vel a culpa similique enim.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -102,16 +103,16 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '110'
+      - '185'
     body:
       encoding: UTF-8
       string: |
         <package name="test_package" project="BaseDistro">
-          <title></title>
-          <description></description>
+          <title>Dying of the Light</title>
+          <description>Molestias adipisci voluptatem vel a culpa similique enim.</description>
         </package>
     http_version: 
-  recorded_at: Wed, 16 Nov 2016 16:10:43 GMT
+  recorded_at: Fri, 15 Dec 2017 13:12:03 GMT
 - request:
     method: put
     uri: http://backend:5352/source/BaseDistro/test_package/_meta
@@ -119,8 +120,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="test_package" project="BaseDistro">
-          <title/>
-          <description/>
+          <title>Dying of the Light</title>
+          <description>Molestias adipisci voluptatem vel a culpa similique enim.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -141,16 +142,16 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '110'
+      - '185'
     body:
       encoding: UTF-8
       string: |
         <package name="test_package" project="BaseDistro">
-          <title></title>
-          <description></description>
+          <title>Dying of the Light</title>
+          <description>Molestias adipisci voluptatem vel a culpa similique enim.</description>
         </package>
     http_version: 
-  recorded_at: Wed, 16 Nov 2016 16:10:43 GMT
+  recorded_at: Fri, 15 Dec 2017 13:12:03 GMT
 - request:
     method: put
     uri: http://backend:5352/source/BaseDistro:Update/_meta
@@ -158,7 +159,7 @@ http_interactions:
       encoding: UTF-8
       string: |
         <project name="BaseDistro:Update">
-          <title>A Scanner Darkly</title>
+          <title>The Doors of Perception</title>
           <description/>
         </project>
     headers:
@@ -180,24 +181,23 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '110'
+      - '117'
     body:
       encoding: UTF-8
       string: |
         <project name="BaseDistro:Update">
-          <title>A Scanner Darkly</title>
+          <title>The Doors of Perception</title>
           <description></description>
         </project>
     http_version: 
-  recorded_at: Wed, 16 Nov 2016 16:10:44 GMT
+  recorded_at: Fri, 15 Dec 2017 13:12:03 GMT
 - request:
     method: put
     uri: http://backend:5352/source/BaseDistro:Update/_config
     body:
       encoding: UTF-8
-      string: Reprehenderit eius est aliquam rerum libero aut sit. Voluptatibus et
-        consequuntur consequatur quia itaque. Inventore enim modi non. Ut est ab ex
-        omnis reprehenderit.
+      string: Quo qui dolorum atque consectetur. Sed necessitatibus aliquid qui adipisci.
+        Qui voluptatem voluptatum et qui corrupti repellat ut.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -224,7 +224,81 @@ http_interactions:
 
 '
     http_version: 
-  recorded_at: Wed, 16 Nov 2016 16:10:44 GMT
+  recorded_at: Fri, 15 Dec 2017 13:12:03 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/project_1/_meta
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="project_1">
+          <title>The Golden Bowl</title>
+          <description/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '101'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="project_1">
+          <title>The Golden Bowl</title>
+          <description></description>
+        </project>
+    http_version: 
+  recorded_at: Fri, 15 Dec 2017 13:12:03 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/project_1/_config
+    body:
+      encoding: UTF-8
+      string: Perspiciatis esse aliquid quasi et. Et maiores illum officia est. Non
+        quis illum molestias expedita aut. Aut tempora dolorem qui. Maiores quis minima
+        aspernatur facere mollitia.
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '21'
+    body:
+      encoding: UTF-8
+      string: '<status code="ok" />
+
+'
+    http_version: 
+  recorded_at: Fri, 15 Dec 2017 13:12:03 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom/_meta?user=tom
@@ -265,7 +339,7 @@ http_interactions:
           <person userid="tom" role="maintainer" />
         </project>
     http_version: 
-  recorded_at: Wed, 16 Nov 2016 16:10:44 GMT
+  recorded_at: Fri, 15 Dec 2017 13:12:03 GMT
 - request:
     method: put
     uri: http://backend:5352/source/openSUSE_Leap/_meta
@@ -273,7 +347,7 @@ http_interactions:
       encoding: UTF-8
       string: |
         <project name="openSUSE_Leap">
-          <title>The Wings of the Dove</title>
+          <title>All the King's Men</title>
           <description/>
         </project>
     headers:
@@ -295,23 +369,24 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '111'
+      - '108'
     body:
       encoding: UTF-8
       string: |
         <project name="openSUSE_Leap">
-          <title>The Wings of the Dove</title>
+          <title>All the King's Men</title>
           <description></description>
         </project>
     http_version: 
-  recorded_at: Wed, 16 Nov 2016 16:10:44 GMT
+  recorded_at: Fri, 15 Dec 2017 13:12:03 GMT
 - request:
     method: put
     uri: http://backend:5352/source/openSUSE_Leap/_config
     body:
       encoding: UTF-8
-      string: Molestiae error asperiores ab nisi. Blanditiis molestiae quas aspernatur
-        quia. Eum dignissimos in commodi.
+      string: Et enim cum vel. Repudiandae quisquam nesciunt in perferendis. Corrupti
+        nesciunt unde rem voluptatem a. Velit molestias sed aut beatae sit ea asperiores.
+        Et rerum quo sint illo ut.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -338,7 +413,7 @@ http_interactions:
 
 '
     http_version: 
-  recorded_at: Wed, 16 Nov 2016 16:10:44 GMT
+  recorded_at: Fri, 15 Dec 2017 13:12:03 GMT
 - request:
     method: put
     uri: http://backend:5352/source/openSUSE_Leap/apache2/_meta?user=tom
@@ -346,8 +421,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="apache2" project="openSUSE_Leap">
-          <title/>
-          <description/>
+          <title>Moab Is My Washpot</title>
+          <description>Exercitationem voluptate eius quasi quas.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -368,16 +443,16 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '108'
+      - '167'
     body:
       encoding: UTF-8
       string: |
         <package name="apache2" project="openSUSE_Leap">
-          <title></title>
-          <description></description>
+          <title>Moab Is My Washpot</title>
+          <description>Exercitationem voluptate eius quasi quas.</description>
         </package>
     http_version: 
-  recorded_at: Wed, 16 Nov 2016 16:10:44 GMT
+  recorded_at: Fri, 15 Dec 2017 13:12:03 GMT
 - request:
     method: put
     uri: http://backend:5352/source/openSUSE_Leap/apache2/_meta
@@ -385,8 +460,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="apache2" project="openSUSE_Leap">
-          <title/>
-          <description/>
+          <title>Moab Is My Washpot</title>
+          <description>Exercitationem voluptate eius quasi quas.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -407,16 +482,16 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '108'
+      - '167'
     body:
       encoding: UTF-8
       string: |
         <package name="apache2" project="openSUSE_Leap">
-          <title></title>
-          <description></description>
+          <title>Moab Is My Washpot</title>
+          <description>Exercitationem voluptate eius quasi quas.</description>
         </package>
     http_version: 
-  recorded_at: Wed, 16 Nov 2016 16:10:44 GMT
+  recorded_at: Fri, 15 Dec 2017 13:12:03 GMT
 - request:
     method: post
     uri: http://backend:5352/search/package/id?match=(linkinfo/@package=%22apache2%22%20and%20linkinfo/@project=%22openSUSE_Leap%22%20and%20@project=%22openSUSE_Leap%22)
@@ -451,7 +526,7 @@ http_interactions:
         <collection>
         </collection>
     http_version: 
-  recorded_at: Wed, 16 Nov 2016 16:10:44 GMT
+  recorded_at: Fri, 15 Dec 2017 13:12:03 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom:branches:openSUSE_Leap/_meta?user=tom
@@ -492,7 +567,7 @@ http_interactions:
           <person userid="tom" role="maintainer" />
         </project>
     http_version: 
-  recorded_at: Wed, 16 Nov 2016 16:10:44 GMT
+  recorded_at: Fri, 15 Dec 2017 13:12:03 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom:branches:openSUSE_Leap/apache2/_meta?user=tom
@@ -500,8 +575,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="apache2" project="home:tom:branches:openSUSE_Leap">
-          <title/>
-          <description/>
+          <title>Moab Is My Washpot</title>
+          <description>Exercitationem voluptate eius quasi quas.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -522,58 +597,19 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '126'
+      - '185'
     body:
       encoding: UTF-8
       string: |
         <package name="apache2" project="home:tom:branches:openSUSE_Leap">
-          <title></title>
-          <description></description>
+          <title>Moab Is My Washpot</title>
+          <description>Exercitationem voluptate eius quasi quas.</description>
         </package>
     http_version: 
-  recorded_at: Wed, 16 Nov 2016 16:10:44 GMT
-- request:
-    method: put
-    uri: http://backend:5352/source/home:tom:branches:openSUSE_Leap/apache2/_meta?user=tom
-    body:
-      encoding: UTF-8
-      string: |
-        <package name="apache2" project="home:tom:branches:openSUSE_Leap">
-          <title/>
-          <description/>
-        </package>
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '126'
-    body:
-      encoding: UTF-8
-      string: |
-        <package name="apache2" project="home:tom:branches:openSUSE_Leap">
-          <title></title>
-          <description></description>
-        </package>
-    http_version: 
-  recorded_at: Wed, 16 Nov 2016 16:10:44 GMT
+  recorded_at: Fri, 15 Dec 2017 13:12:03 GMT
 - request:
     method: post
-    uri: http://backend:5352/source/home:tom:branches:openSUSE_Leap/apache2?cmd=branch&opackage=apache2&oproject=openSUSE_Leap&user=tom
+    uri: http://backend:5352/source/home:tom:branches:openSUSE_Leap/apache2?cmd=branch&noservice=1&opackage=apache2&oproject=openSUSE_Leap&user=tom
     body:
       encoding: UTF-8
       string: ''
@@ -605,13 +641,52 @@ http_interactions:
         <revision rev="1" vrev="1">
           <srcmd5>f2b6eaf02987245b9003bcf47e0222dc</srcmd5>
           <version>unknown</version>
-          <time>1479312644</time>
+          <time>1513343523</time>
           <user>tom</user>
           <comment></comment>
           <requestid/>
         </revision>
     http_version: 
-  recorded_at: Wed, 16 Nov 2016 16:10:44 GMT
+  recorded_at: Fri, 15 Dec 2017 13:12:03 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:tom:branches:openSUSE_Leap/apache2/_meta?user=tom
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="apache2" project="home:tom:branches:openSUSE_Leap">
+          <title>Moab Is My Washpot</title>
+          <description>Exercitationem voluptate eius quasi quas.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '185'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="apache2" project="home:tom:branches:openSUSE_Leap">
+          <title>Moab Is My Washpot</title>
+          <description>Exercitationem voluptate eius quasi quas.</description>
+        </package>
+    http_version: 
+  recorded_at: Fri, 15 Dec 2017 13:12:03 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:tom:branches:openSUSE_Leap/apache2
@@ -643,10 +718,10 @@ http_interactions:
       string: |
         <directory name="apache2" rev="1" vrev="1" srcmd5="f2b6eaf02987245b9003bcf47e0222dc">
           <linkinfo project="openSUSE_Leap" package="apache2" srcmd5="d41d8cd98f00b204e9800998ecf8427e" baserev="d41d8cd98f00b204e9800998ecf8427e" xsrcmd5="2fbc15ae60271e3fe13b837e014a17ea" lsrcmd5="f2b6eaf02987245b9003bcf47e0222dc" />
-          <entry name="_link" md5="42ab2fdb360424b79deaaaec3dcd12ff" size="121" mtime="1479304500" />
+          <entry name="_link" md5="42ab2fdb360424b79deaaaec3dcd12ff" size="121" mtime="1513343013" />
         </directory>
     http_version: 
-  recorded_at: Wed, 16 Nov 2016 16:10:44 GMT
+  recorded_at: Fri, 15 Dec 2017 13:12:03 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:tom:branches:openSUSE_Leap/apache2?nofilename=1&view=info&withchangesmd5=1
@@ -678,10 +753,10 @@ http_interactions:
       string: |
         <sourceinfo package="apache2" rev="1" vrev="1" srcmd5="2fbc15ae60271e3fe13b837e014a17ea" lsrcmd5="f2b6eaf02987245b9003bcf47e0222dc" verifymd5="d41d8cd98f00b204e9800998ecf8427e">
           <linked project="openSUSE_Leap" package="apache2" />
-          <revtime>1479312644</revtime>
+          <revtime>1513343523</revtime>
         </sourceinfo>
     http_version: 
-  recorded_at: Wed, 16 Nov 2016 16:10:45 GMT
+  recorded_at: Fri, 15 Dec 2017 13:12:03 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:tom:branches:openSUSE_Leap/apache2
@@ -713,10 +788,10 @@ http_interactions:
       string: |
         <directory name="apache2" rev="1" vrev="1" srcmd5="f2b6eaf02987245b9003bcf47e0222dc">
           <linkinfo project="openSUSE_Leap" package="apache2" srcmd5="d41d8cd98f00b204e9800998ecf8427e" baserev="d41d8cd98f00b204e9800998ecf8427e" xsrcmd5="2fbc15ae60271e3fe13b837e014a17ea" lsrcmd5="f2b6eaf02987245b9003bcf47e0222dc" />
-          <entry name="_link" md5="42ab2fdb360424b79deaaaec3dcd12ff" size="121" mtime="1479304500" />
+          <entry name="_link" md5="42ab2fdb360424b79deaaaec3dcd12ff" size="121" mtime="1513343013" />
         </directory>
     http_version: 
-  recorded_at: Wed, 16 Nov 2016 16:10:45 GMT
+  recorded_at: Fri, 15 Dec 2017 13:12:03 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:tom:branches:openSUSE_Leap/apache2?cmd=diff&linkrev=base&onlyissues=1&orev=0&view=xml
@@ -739,16 +814,16 @@ http_interactions:
     headers:
       Content-Type:
       - text/xml
-      Content-Length:
-      - '341'
       Cache-Control:
       - no-cache
       Connection:
       - close
+      Content-Length:
+      - '341'
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="b4eb9aa75778707a23b6f6a8cfd9aced">
+        <sourcediff key="6b52695450ecc45fc1d605938d0aff06">
           <old project="home:tom:branches:openSUSE_Leap" package="apache2" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e" />
           <new project="home:tom:branches:openSUSE_Leap" package="apache2" rev="1" srcmd5="f2b6eaf02987245b9003bcf47e0222dc" />
           <files />
@@ -756,7 +831,7 @@ http_interactions:
           </issues>
         </sourcediff>
     http_version: 
-  recorded_at: Wed, 16 Nov 2016 16:10:45 GMT
+  recorded_at: Fri, 15 Dec 2017 13:12:04 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:tom:branches:openSUSE_Leap/apache2?cmd=linkdiff&linkrev=base&onlyissues=1&view=xml
@@ -788,13 +863,13 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="1c6621e539f5863fcf3a10f8baf9b790">
+        <sourcediff key="5d4e5de10a7da9b9f966d8bec322637f">
           <old project="openSUSE_Leap" package="apache2" rev="d41d8cd98f00b204e9800998ecf8427e" srcmd5="d41d8cd98f00b204e9800998ecf8427e" />
           <new project="home:tom:branches:openSUSE_Leap" package="apache2" rev="2fbc15ae60271e3fe13b837e014a17ea" srcmd5="2fbc15ae60271e3fe13b837e014a17ea" />
           <files />
         </sourcediff>
     http_version: 
-  recorded_at: Wed, 16 Nov 2016 16:10:45 GMT
+  recorded_at: Fri, 15 Dec 2017 13:12:04 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom:branches:openSUSE_Leap/_meta?user=tom
@@ -841,7 +916,7 @@ http_interactions:
           </publish>
         </project>
     http_version: 
-  recorded_at: Wed, 16 Nov 2016 16:10:45 GMT
+  recorded_at: Fri, 15 Dec 2017 13:12:04 GMT
 - request:
     method: delete
     uri: http://backend:5352/source/home:tom:branches:openSUSE_Leap?comment&user=tom

--- a/src/api/spec/cassettes/BranchPackage/_branch/project_without_ImageTemplates_attribute/auto_cleanup_attribute/is_set_to_the_default.yml
+++ b/src/api/spec/cassettes/BranchPackage/_branch/project_without_ImageTemplates_attribute/auto_cleanup_attribute/is_set_to_the_default.yml
@@ -7,7 +7,7 @@ http_interactions:
       encoding: UTF-8
       string: |
         <project name="BaseDistro">
-          <title>A Passage to India</title>
+          <title>Such, Such Were the Joys</title>
           <description/>
         </project>
     headers:
@@ -29,23 +29,24 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '105'
+      - '111'
     body:
       encoding: UTF-8
       string: |
         <project name="BaseDistro">
-          <title>A Passage to India</title>
+          <title>Such, Such Were the Joys</title>
           <description></description>
         </project>
     http_version: 
-  recorded_at: Wed, 16 Nov 2016 16:10:43 GMT
+  recorded_at: Fri, 15 Dec 2017 13:12:04 GMT
 - request:
     method: put
     uri: http://backend:5352/source/BaseDistro/_config
     body:
       encoding: UTF-8
-      string: Est id voluptatem ad. Vel placeat et dolor quia. Velit corporis vero
-        officiis soluta quo.
+      string: Voluptate eaque rem ipsum eligendi sit culpa. Sunt magni quos porro
+        perspiciatis. Eveniet magnam numquam rem. Itaque qui voluptatem inventore
+        aperiam non. Fugit qui occaecati neque vitae porro.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -72,7 +73,7 @@ http_interactions:
 
 '
     http_version: 
-  recorded_at: Wed, 16 Nov 2016 16:10:43 GMT
+  recorded_at: Fri, 15 Dec 2017 13:12:04 GMT
 - request:
     method: put
     uri: http://backend:5352/source/BaseDistro/test_package/_meta?user=tom
@@ -80,8 +81,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="test_package" project="BaseDistro">
-          <title/>
-          <description/>
+          <title>The Moving Toyshop</title>
+          <description>Impedit enim sint iusto.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -102,16 +103,16 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '110'
+      - '152'
     body:
       encoding: UTF-8
       string: |
         <package name="test_package" project="BaseDistro">
-          <title></title>
-          <description></description>
+          <title>The Moving Toyshop</title>
+          <description>Impedit enim sint iusto.</description>
         </package>
     http_version: 
-  recorded_at: Wed, 16 Nov 2016 16:10:43 GMT
+  recorded_at: Fri, 15 Dec 2017 13:12:04 GMT
 - request:
     method: put
     uri: http://backend:5352/source/BaseDistro/test_package/_meta
@@ -119,8 +120,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="test_package" project="BaseDistro">
-          <title/>
-          <description/>
+          <title>The Moving Toyshop</title>
+          <description>Impedit enim sint iusto.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -141,16 +142,16 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '110'
+      - '152'
     body:
       encoding: UTF-8
       string: |
         <package name="test_package" project="BaseDistro">
-          <title></title>
-          <description></description>
+          <title>The Moving Toyshop</title>
+          <description>Impedit enim sint iusto.</description>
         </package>
     http_version: 
-  recorded_at: Wed, 16 Nov 2016 16:10:43 GMT
+  recorded_at: Fri, 15 Dec 2017 13:12:04 GMT
 - request:
     method: put
     uri: http://backend:5352/source/BaseDistro:Update/_meta
@@ -158,7 +159,79 @@ http_interactions:
       encoding: UTF-8
       string: |
         <project name="BaseDistro:Update">
-          <title>The Green Bay Tree</title>
+          <title>The Skull Beneath the Skin</title>
+          <description/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '120'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="BaseDistro:Update">
+          <title>The Skull Beneath the Skin</title>
+          <description></description>
+        </project>
+    http_version: 
+  recorded_at: Fri, 15 Dec 2017 13:12:04 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/BaseDistro:Update/_config
+    body:
+      encoding: UTF-8
+      string: Quo ut sed ut. Officiis quia nemo. Harum distinctio incidunt.
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '21'
+    body:
+      encoding: UTF-8
+      string: '<status code="ok" />
+
+'
+    http_version: 
+  recorded_at: Fri, 15 Dec 2017 13:12:04 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/project_2/_meta
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="project_2">
+          <title>Where Angels Fear to Tread</title>
           <description/>
         </project>
     headers:
@@ -184,20 +257,19 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <project name="BaseDistro:Update">
-          <title>The Green Bay Tree</title>
+        <project name="project_2">
+          <title>Where Angels Fear to Tread</title>
           <description></description>
         </project>
     http_version: 
-  recorded_at: Wed, 16 Nov 2016 16:10:43 GMT
+  recorded_at: Fri, 15 Dec 2017 13:12:04 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/BaseDistro:Update/_config
+    uri: http://backend:5352/source/project_2/_config
     body:
       encoding: UTF-8
-      string: Dolor unde ex molestiae omnis quidem harum et. Voluptas adipisci tenetur
-        rerum mollitia doloribus et. Sed eos sit qui voluptatibus. In ut et cum et
-        velit laboriosam molestias. Sed nemo officia tempore.
+      string: Temporibus ex ut nam. Qui magni repellat consequatur iusto. Quibusdam
+        nesciunt et porro sint dolorum tempora in. Et ut et et.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -224,7 +296,7 @@ http_interactions:
 
 '
     http_version: 
-  recorded_at: Wed, 16 Nov 2016 16:10:43 GMT
+  recorded_at: Fri, 15 Dec 2017 13:12:04 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom/_meta?user=tom
@@ -265,7 +337,7 @@ http_interactions:
           <person userid="tom" role="maintainer" />
         </project>
     http_version: 
-  recorded_at: Wed, 16 Nov 2016 16:10:43 GMT
+  recorded_at: Fri, 15 Dec 2017 13:12:04 GMT
 - request:
     method: put
     uri: http://backend:5352/source/openSUSE_Leap/_meta
@@ -273,7 +345,7 @@ http_interactions:
       encoding: UTF-8
       string: |
         <project name="openSUSE_Leap">
-          <title>The Moon by Night</title>
+          <title>Beyond the Mexique Bay</title>
           <description/>
         </project>
     headers:
@@ -295,24 +367,24 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '107'
+      - '112'
     body:
       encoding: UTF-8
       string: |
         <project name="openSUSE_Leap">
-          <title>The Moon by Night</title>
+          <title>Beyond the Mexique Bay</title>
           <description></description>
         </project>
     http_version: 
-  recorded_at: Wed, 16 Nov 2016 16:11:15 GMT
+  recorded_at: Fri, 15 Dec 2017 13:12:04 GMT
 - request:
     method: put
     uri: http://backend:5352/source/openSUSE_Leap/_config
     body:
       encoding: UTF-8
-      string: Possimus vero ut et sequi asperiores et. Placeat dolorem a et quidem
-        modi optio nobis. Totam explicabo voluptas in ipsam molestiae sequi. Placeat
-        et unde quae iure ex.
+      string: Eos alias tempora magnam. Accusantium consequatur temporibus cupiditate
+        non. Est et esse voluptas explicabo voluptatem debitis. Accusantium dolore
+        cupiditate ut. Labore qui qui vitae.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -339,7 +411,7 @@ http_interactions:
 
 '
     http_version: 
-  recorded_at: Wed, 16 Nov 2016 16:11:15 GMT
+  recorded_at: Fri, 15 Dec 2017 13:12:04 GMT
 - request:
     method: put
     uri: http://backend:5352/source/openSUSE_Leap/apache2/_meta?user=tom
@@ -347,8 +419,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="apache2" project="openSUSE_Leap">
-          <title/>
-          <description/>
+          <title>Look to Windward</title>
+          <description>Et qui quo cumque.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -369,16 +441,16 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '108'
+      - '142'
     body:
       encoding: UTF-8
       string: |
         <package name="apache2" project="openSUSE_Leap">
-          <title></title>
-          <description></description>
+          <title>Look to Windward</title>
+          <description>Et qui quo cumque.</description>
         </package>
     http_version: 
-  recorded_at: Wed, 16 Nov 2016 16:11:15 GMT
+  recorded_at: Fri, 15 Dec 2017 13:12:04 GMT
 - request:
     method: put
     uri: http://backend:5352/source/openSUSE_Leap/apache2/_meta
@@ -386,8 +458,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="apache2" project="openSUSE_Leap">
-          <title/>
-          <description/>
+          <title>Look to Windward</title>
+          <description>Et qui quo cumque.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -408,16 +480,16 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '108'
+      - '142'
     body:
       encoding: UTF-8
       string: |
         <package name="apache2" project="openSUSE_Leap">
-          <title></title>
-          <description></description>
+          <title>Look to Windward</title>
+          <description>Et qui quo cumque.</description>
         </package>
     http_version: 
-  recorded_at: Wed, 16 Nov 2016 16:11:15 GMT
+  recorded_at: Fri, 15 Dec 2017 13:12:04 GMT
 - request:
     method: post
     uri: http://backend:5352/search/package/id?match=(linkinfo/@package=%22apache2%22%20and%20linkinfo/@project=%22openSUSE_Leap%22%20and%20@project=%22openSUSE_Leap%22)
@@ -452,7 +524,7 @@ http_interactions:
         <collection>
         </collection>
     http_version: 
-  recorded_at: Wed, 16 Nov 2016 16:11:15 GMT
+  recorded_at: Fri, 15 Dec 2017 13:12:05 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom:branches:openSUSE_Leap/_meta?user=tom
@@ -493,7 +565,7 @@ http_interactions:
           <person userid="tom" role="maintainer" />
         </project>
     http_version: 
-  recorded_at: Wed, 16 Nov 2016 16:11:15 GMT
+  recorded_at: Fri, 15 Dec 2017 13:12:05 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom:branches:openSUSE_Leap/apache2/_meta?user=tom
@@ -501,8 +573,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="apache2" project="home:tom:branches:openSUSE_Leap">
-          <title/>
-          <description/>
+          <title>Look to Windward</title>
+          <description>Et qui quo cumque.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -523,58 +595,19 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '126'
+      - '160'
     body:
       encoding: UTF-8
       string: |
         <package name="apache2" project="home:tom:branches:openSUSE_Leap">
-          <title></title>
-          <description></description>
+          <title>Look to Windward</title>
+          <description>Et qui quo cumque.</description>
         </package>
     http_version: 
-  recorded_at: Wed, 16 Nov 2016 16:11:16 GMT
-- request:
-    method: put
-    uri: http://backend:5352/source/home:tom:branches:openSUSE_Leap/apache2/_meta?user=tom
-    body:
-      encoding: UTF-8
-      string: |
-        <package name="apache2" project="home:tom:branches:openSUSE_Leap">
-          <title/>
-          <description/>
-        </package>
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '126'
-    body:
-      encoding: UTF-8
-      string: |
-        <package name="apache2" project="home:tom:branches:openSUSE_Leap">
-          <title></title>
-          <description></description>
-        </package>
-    http_version: 
-  recorded_at: Wed, 16 Nov 2016 16:11:16 GMT
+  recorded_at: Fri, 15 Dec 2017 13:12:05 GMT
 - request:
     method: post
-    uri: http://backend:5352/source/home:tom:branches:openSUSE_Leap/apache2?cmd=branch&opackage=apache2&oproject=openSUSE_Leap&user=tom
+    uri: http://backend:5352/source/home:tom:branches:openSUSE_Leap/apache2?cmd=branch&noservice=1&opackage=apache2&oproject=openSUSE_Leap&user=tom
     body:
       encoding: UTF-8
       string: ''
@@ -606,13 +639,52 @@ http_interactions:
         <revision rev="1" vrev="1">
           <srcmd5>f2b6eaf02987245b9003bcf47e0222dc</srcmd5>
           <version>unknown</version>
-          <time>1479312676</time>
+          <time>1513343525</time>
           <user>tom</user>
           <comment></comment>
           <requestid/>
         </revision>
     http_version: 
-  recorded_at: Wed, 16 Nov 2016 16:11:16 GMT
+  recorded_at: Fri, 15 Dec 2017 13:12:05 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:tom:branches:openSUSE_Leap/apache2/_meta?user=tom
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="apache2" project="home:tom:branches:openSUSE_Leap">
+          <title>Look to Windward</title>
+          <description>Et qui quo cumque.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '160'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="apache2" project="home:tom:branches:openSUSE_Leap">
+          <title>Look to Windward</title>
+          <description>Et qui quo cumque.</description>
+        </package>
+    http_version: 
+  recorded_at: Fri, 15 Dec 2017 13:12:05 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:tom:branches:openSUSE_Leap/apache2
@@ -644,10 +716,10 @@ http_interactions:
       string: |
         <directory name="apache2" rev="1" vrev="1" srcmd5="f2b6eaf02987245b9003bcf47e0222dc">
           <linkinfo project="openSUSE_Leap" package="apache2" srcmd5="d41d8cd98f00b204e9800998ecf8427e" baserev="d41d8cd98f00b204e9800998ecf8427e" xsrcmd5="2fbc15ae60271e3fe13b837e014a17ea" lsrcmd5="f2b6eaf02987245b9003bcf47e0222dc" />
-          <entry name="_link" md5="42ab2fdb360424b79deaaaec3dcd12ff" size="121" mtime="1479304500" />
+          <entry name="_link" md5="42ab2fdb360424b79deaaaec3dcd12ff" size="121" mtime="1513343013" />
         </directory>
     http_version: 
-  recorded_at: Wed, 16 Nov 2016 16:11:16 GMT
+  recorded_at: Fri, 15 Dec 2017 13:12:05 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:tom:branches:openSUSE_Leap/apache2?nofilename=1&view=info&withchangesmd5=1
@@ -679,10 +751,10 @@ http_interactions:
       string: |
         <sourceinfo package="apache2" rev="1" vrev="1" srcmd5="2fbc15ae60271e3fe13b837e014a17ea" lsrcmd5="f2b6eaf02987245b9003bcf47e0222dc" verifymd5="d41d8cd98f00b204e9800998ecf8427e">
           <linked project="openSUSE_Leap" package="apache2" />
-          <revtime>1479312676</revtime>
+          <revtime>1513343525</revtime>
         </sourceinfo>
     http_version: 
-  recorded_at: Wed, 16 Nov 2016 16:11:16 GMT
+  recorded_at: Fri, 15 Dec 2017 13:12:05 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:tom:branches:openSUSE_Leap/apache2
@@ -714,10 +786,10 @@ http_interactions:
       string: |
         <directory name="apache2" rev="1" vrev="1" srcmd5="f2b6eaf02987245b9003bcf47e0222dc">
           <linkinfo project="openSUSE_Leap" package="apache2" srcmd5="d41d8cd98f00b204e9800998ecf8427e" baserev="d41d8cd98f00b204e9800998ecf8427e" xsrcmd5="2fbc15ae60271e3fe13b837e014a17ea" lsrcmd5="f2b6eaf02987245b9003bcf47e0222dc" />
-          <entry name="_link" md5="42ab2fdb360424b79deaaaec3dcd12ff" size="121" mtime="1479304500" />
+          <entry name="_link" md5="42ab2fdb360424b79deaaaec3dcd12ff" size="121" mtime="1513343013" />
         </directory>
     http_version: 
-  recorded_at: Wed, 16 Nov 2016 16:11:16 GMT
+  recorded_at: Fri, 15 Dec 2017 13:12:05 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:tom:branches:openSUSE_Leap/apache2?cmd=diff&linkrev=base&onlyissues=1&orev=0&view=xml
@@ -749,7 +821,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="b4eb9aa75778707a23b6f6a8cfd9aced">
+        <sourcediff key="6b52695450ecc45fc1d605938d0aff06">
           <old project="home:tom:branches:openSUSE_Leap" package="apache2" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e" />
           <new project="home:tom:branches:openSUSE_Leap" package="apache2" rev="1" srcmd5="f2b6eaf02987245b9003bcf47e0222dc" />
           <files />
@@ -757,7 +829,7 @@ http_interactions:
           </issues>
         </sourcediff>
     http_version: 
-  recorded_at: Wed, 16 Nov 2016 16:11:16 GMT
+  recorded_at: Fri, 15 Dec 2017 13:12:05 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:tom:branches:openSUSE_Leap/apache2?cmd=linkdiff&linkrev=base&onlyissues=1&view=xml
@@ -789,13 +861,13 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="1c6621e539f5863fcf3a10f8baf9b790">
+        <sourcediff key="5d4e5de10a7da9b9f966d8bec322637f">
           <old project="openSUSE_Leap" package="apache2" rev="d41d8cd98f00b204e9800998ecf8427e" srcmd5="d41d8cd98f00b204e9800998ecf8427e" />
           <new project="home:tom:branches:openSUSE_Leap" package="apache2" rev="2fbc15ae60271e3fe13b837e014a17ea" srcmd5="2fbc15ae60271e3fe13b837e014a17ea" />
           <files />
         </sourcediff>
     http_version: 
-  recorded_at: Wed, 16 Nov 2016 16:11:16 GMT
+  recorded_at: Fri, 15 Dec 2017 13:12:05 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom:branches:openSUSE_Leap/_meta?user=tom
@@ -842,7 +914,7 @@ http_interactions:
           </publish>
         </project>
     http_version: 
-  recorded_at: Wed, 16 Nov 2016 16:11:16 GMT
+  recorded_at: Fri, 15 Dec 2017 13:12:05 GMT
 - request:
     method: delete
     uri: http://backend:5352/source/home:tom:branches:openSUSE_Leap?comment&user=tom

--- a/src/api/spec/cassettes/ImageTemplates/branching/branch_Kiwi_image_template.yml
+++ b/src/api/spec/cassettes/ImageTemplates/branching/branch_Kiwi_image_template.yml
@@ -40,7 +40,7 @@ http_interactions:
           <person userid="tom" role="maintainer" />
         </project>
     http_version: 
-  recorded_at: Thu, 19 Oct 2017 10:54:55 GMT
+  recorded_at: Tue, 16 Jan 2018 13:48:49 GMT
 - request:
     method: put
     uri: http://backend:5352/source/my_project/_meta
@@ -48,7 +48,7 @@ http_interactions:
       encoding: UTF-8
       string: |
         <project name="my_project">
-          <title>The World, the Flesh and the Devil</title>
+          <title>Far From the Madding Crowd</title>
           <description/>
         </project>
     headers:
@@ -70,23 +70,24 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '121'
+      - '113'
     body:
       encoding: UTF-8
       string: |
         <project name="my_project">
-          <title>The World, the Flesh and the Devil</title>
+          <title>Far From the Madding Crowd</title>
           <description></description>
         </project>
     http_version: 
-  recorded_at: Thu, 19 Oct 2017 10:54:57 GMT
+  recorded_at: Tue, 16 Jan 2018 13:48:49 GMT
 - request:
     method: put
     uri: http://backend:5352/source/my_project/_config
     body:
       encoding: UTF-8
-      string: Qui nemo recusandae. Non recusandae quae qui nostrum enim dolorum nihil.
-        Qui quod tempora ut molestiae.
+      string: Qui dolore quaerat perspiciatis. Molestiae aut debitis et rem harum
+        modi. Ut consectetur dolor praesentium in laudantium. Et eos veritatis non
+        laudantium. Deserunt libero rerum.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -113,16 +114,16 @@ http_interactions:
 
 '
     http_version: 
-  recorded_at: Thu, 19 Oct 2017 10:54:57 GMT
+  recorded_at: Tue, 16 Jan 2018 13:48:49 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/my_project/first_package/_meta?user=_nobody_
+    uri: http://backend:5352/source/my_project/first_package/_meta?user=tom
     body:
       encoding: UTF-8
       string: |
         <package name="first_package" project="my_project">
           <title>a</title>
-          <description>Omnis in error laudantium impedit nihil labore ut consequatur.</description>
+          <description>Odit at ad labore dolorem.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -143,16 +144,16 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '174'
+      - '138'
     body:
       encoding: UTF-8
       string: |
         <package name="first_package" project="my_project">
           <title>a</title>
-          <description>Omnis in error laudantium impedit nihil labore ut consequatur.</description>
+          <description>Odit at ad labore dolorem.</description>
         </package>
     http_version: 
-  recorded_at: Thu, 19 Oct 2017 10:54:59 GMT
+  recorded_at: Tue, 16 Jan 2018 13:48:49 GMT
 - request:
     method: put
     uri: http://backend:5352/source/my_project/first_package/_meta
@@ -161,7 +162,7 @@ http_interactions:
       string: |
         <package name="first_package" project="my_project">
           <title>a</title>
-          <description>Omnis in error laudantium impedit nihil labore ut consequatur.</description>
+          <description>Odit at ad labore dolorem.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -182,23 +183,24 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '174'
+      - '138'
     body:
       encoding: UTF-8
       string: |
         <package name="first_package" project="my_project">
           <title>a</title>
-          <description>Omnis in error laudantium impedit nihil labore ut consequatur.</description>
+          <description>Odit at ad labore dolorem.</description>
         </package>
     http_version: 
-  recorded_at: Thu, 19 Oct 2017 10:54:59 GMT
+  recorded_at: Tue, 16 Jan 2018 13:48:49 GMT
 - request:
     method: put
     uri: http://backend:5352/source/my_project/first_package/_config
     body:
       encoding: UTF-8
-      string: Dolores molestiae sed vitae laudantium ut magnam. Similique eos nobis
-        facere. Ipsum earum dolores molestiae. Exercitationem fugiat aut doloribus.
+      string: Ipsum non eligendi aut. Quasi et aspernatur et architecto molestiae
+        odit commodi. Nihil tempora fugiat delectus et. Molestiae ut dicta est sunt
+        vitae voluptas velit.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -222,23 +224,23 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <revision rev="1" vrev="1">
-          <srcmd5>001601fa352aa0c6453cc88801acc15b</srcmd5>
+        <revision rev="3" vrev="3">
+          <srcmd5>b4c0ae9b620ffffe08fb8ab428c76de5</srcmd5>
           <version>unknown</version>
-          <time>1508410499</time>
+          <time>1516110529</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
     http_version: 
-  recorded_at: Thu, 19 Oct 2017 10:55:00 GMT
+  recorded_at: Tue, 16 Jan 2018 13:48:49 GMT
 - request:
     method: put
     uri: http://backend:5352/source/my_project/first_package/somefile.txt
     body:
       encoding: UTF-8
-      string: Deleniti fuga nulla quisquam hic eos quos quis. Est et in eligendi deserunt
-        assumenda enim illum. Ut ab voluptas. Quis sapiente sit ipsum.
+      string: Autem laborum ratione. Porro ipsa provident et. Explicabo ipsa ipsum
+        odio quia. Rem ut eos animi non sit cupiditate nihil.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -262,25 +264,25 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <revision rev="2" vrev="2">
-          <srcmd5>cc00029be6782e27f489e5b49ab97e95</srcmd5>
+        <revision rev="4" vrev="4">
+          <srcmd5>b4c0ae9b620ffffe08fb8ab428c76de5</srcmd5>
           <version>unknown</version>
-          <time>1508410501</time>
+          <time>1516110529</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
     http_version: 
-  recorded_at: Thu, 19 Oct 2017 10:55:01 GMT
+  recorded_at: Tue, 16 Jan 2018 13:48:49 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/my_project/second_package/_meta?user=_nobody_
+    uri: http://backend:5352/source/my_project/second_package/_meta?user=tom
     body:
       encoding: UTF-8
       string: |
         <package name="second_package" project="my_project">
           <title>c</title>
-          <description>Labore nihil quia delectus.</description>
+          <description>Illo cum odit amet perspiciatis.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -301,16 +303,16 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '140'
+      - '145'
     body:
       encoding: UTF-8
       string: |
         <package name="second_package" project="my_project">
           <title>c</title>
-          <description>Labore nihil quia delectus.</description>
+          <description>Illo cum odit amet perspiciatis.</description>
         </package>
     http_version: 
-  recorded_at: Thu, 19 Oct 2017 10:55:02 GMT
+  recorded_at: Tue, 16 Jan 2018 13:48:49 GMT
 - request:
     method: put
     uri: http://backend:5352/source/my_project/second_package/_meta
@@ -319,7 +321,7 @@ http_interactions:
       string: |
         <package name="second_package" project="my_project">
           <title>c</title>
-          <description>Labore nihil quia delectus.</description>
+          <description>Illo cum odit amet perspiciatis.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -340,25 +342,23 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '140'
+      - '145'
     body:
       encoding: UTF-8
       string: |
         <package name="second_package" project="my_project">
           <title>c</title>
-          <description>Labore nihil quia delectus.</description>
+          <description>Illo cum odit amet perspiciatis.</description>
         </package>
     http_version: 
-  recorded_at: Thu, 19 Oct 2017 10:55:02 GMT
+  recorded_at: Tue, 16 Jan 2018 13:48:49 GMT
 - request:
     method: put
     uri: http://backend:5352/source/my_project/second_package/_config
     body:
       encoding: UTF-8
-      string: Et veniam tempore qui commodi ut doloribus totam. Sint explicabo ea.
-        Quo dolor illo nisi consequatur eum molestiae quis. Perspiciatis et quis dolore
-        molestias voluptatibus quae omnis. Maxime accusamus ea dignissimos quia culpa
-        nesciunt.
+      string: Assumenda ut enim voluptas voluptatem aut. Consequatur culpa voluptate
+        quibusdam commodi ut aut non. Non rerum et quibusdam. Itaque mollitia laudantium.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -382,24 +382,23 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <revision rev="1" vrev="1">
-          <srcmd5>0b0167f495a4253b907502f3489516df</srcmd5>
+        <revision rev="3" vrev="3">
+          <srcmd5>ca1046705dfbc246a31334b7a7d571a1</srcmd5>
           <version>unknown</version>
-          <time>1508410503</time>
+          <time>1516110529</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
     http_version: 
-  recorded_at: Thu, 19 Oct 2017 10:55:03 GMT
+  recorded_at: Tue, 16 Jan 2018 13:48:49 GMT
 - request:
     method: put
     uri: http://backend:5352/source/my_project/second_package/somefile.txt
     body:
       encoding: UTF-8
-      string: Aut fuga nihil molestiae vitae enim doloremque. Delectus totam quaerat
-        maxime. Voluptas odit sequi animi cupiditate. Iusto aperiam et nesciunt est
-        debitis.
+      string: Autem laborum ratione. Porro ipsa provident et. Explicabo ipsa ipsum
+        odio quia. Rem ut eos animi non sit cupiditate nihil.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -423,25 +422,25 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <revision rev="2" vrev="2">
-          <srcmd5>b12941a7628b8774e28f8302ebed5102</srcmd5>
+        <revision rev="4" vrev="4">
+          <srcmd5>ca1046705dfbc246a31334b7a7d571a1</srcmd5>
           <version>unknown</version>
-          <time>1508410503</time>
+          <time>1516110529</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
     http_version: 
-  recorded_at: Thu, 19 Oct 2017 10:55:03 GMT
+  recorded_at: Tue, 16 Jan 2018 13:48:49 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/my_project/third_package/_meta?user=_nobody_
+    uri: http://backend:5352/source/my_project/third_package/_meta?user=tom
     body:
       encoding: UTF-8
       string: |
         <package name="third_package" project="my_project">
           <title>b</title>
-          <description>Distinctio earum nobis enim enim iste nam voluptatem voluptatem.</description>
+          <description>Possimus occaecati labore a ad laborum.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -462,16 +461,16 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '176'
+      - '151'
     body:
       encoding: UTF-8
       string: |
         <package name="third_package" project="my_project">
           <title>b</title>
-          <description>Distinctio earum nobis enim enim iste nam voluptatem voluptatem.</description>
+          <description>Possimus occaecati labore a ad laborum.</description>
         </package>
     http_version: 
-  recorded_at: Thu, 19 Oct 2017 10:55:04 GMT
+  recorded_at: Tue, 16 Jan 2018 13:48:49 GMT
 - request:
     method: put
     uri: http://backend:5352/source/my_project/third_package/_meta
@@ -480,7 +479,7 @@ http_interactions:
       string: |
         <package name="third_package" project="my_project">
           <title>b</title>
-          <description>Distinctio earum nobis enim enim iste nam voluptatem voluptatem.</description>
+          <description>Possimus occaecati labore a ad laborum.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -501,24 +500,24 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '176'
+      - '151'
     body:
       encoding: UTF-8
       string: |
         <package name="third_package" project="my_project">
           <title>b</title>
-          <description>Distinctio earum nobis enim enim iste nam voluptatem voluptatem.</description>
+          <description>Possimus occaecati labore a ad laborum.</description>
         </package>
     http_version: 
-  recorded_at: Thu, 19 Oct 2017 10:55:04 GMT
+  recorded_at: Tue, 16 Jan 2018 13:48:49 GMT
 - request:
     method: put
     uri: http://backend:5352/source/my_project/third_package/_config
     body:
       encoding: UTF-8
-      string: Accusantium dolor expedita et. Est earum aperiam. Maiores dolores ipsum
-        est debitis. Qui officia ducimus doloribus quia voluptas quia et. Aperiam
-        magnam repellat voluptatem sint qui alias quia.
+      string: Et ut adipisci debitis. Totam qui ut nesciunt. Quis dolor error necessitatibus
+        molestiae. Modi dolorem nihil incidunt non ipsam nesciunt id. Est possimus
+        nihil sit quia.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -542,24 +541,143 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <revision rev="1" vrev="1">
-          <srcmd5>dee3c468a3ad28caeab50b83810f62f6</srcmd5>
+        <revision rev="3" vrev="3">
+          <srcmd5>dfe237fecac09bf00f3bb3f500b6e3e7</srcmd5>
           <version>unknown</version>
-          <time>1508410504</time>
+          <time>1516110529</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
     http_version: 
-  recorded_at: Thu, 19 Oct 2017 10:55:05 GMT
+  recorded_at: Tue, 16 Jan 2018 13:48:49 GMT
 - request:
     method: put
     uri: http://backend:5352/source/my_project/third_package/somefile.txt
     body:
       encoding: UTF-8
-      string: Non in minus. Numquam similique quidem unde dicta ipsa et. Et autem
-        eos. Necessitatibus voluptatibus sunt eius inventore. Ullam ut esse et nostrum
-        beatae.
+      string: Autem laborum ratione. Porro ipsa provident et. Explicabo ipsa ipsum
+        odio quia. Rem ut eos animi non sit cupiditate nihil.
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '207'
+    body:
+      encoding: UTF-8
+      string: |
+        <revision rev="4" vrev="4">
+          <srcmd5>dfe237fecac09bf00f3bb3f500b6e3e7</srcmd5>
+          <version>unknown</version>
+          <time>1516110529</time>
+          <user>unknown</user>
+          <comment></comment>
+          <requestid/>
+        </revision>
+    http_version: 
+  recorded_at: Tue, 16 Jan 2018 13:48:49 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/my_project/package_with_kiwi_image/_meta?user=tom
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="package_with_kiwi_image" project="my_project">
+          <title>To a God Unknown</title>
+          <description>Necessitatibus accusantium sint ratione qui et aut dolorem.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '196'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="package_with_kiwi_image" project="my_project">
+          <title>To a God Unknown</title>
+          <description>Necessitatibus accusantium sint ratione qui et aut dolorem.</description>
+        </package>
+    http_version: 
+  recorded_at: Tue, 16 Jan 2018 13:48:49 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/my_project/package_with_kiwi_image/_meta
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="package_with_kiwi_image" project="my_project">
+          <title>To a God Unknown</title>
+          <description>Necessitatibus accusantium sint ratione qui et aut dolorem.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '196'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="package_with_kiwi_image" project="my_project">
+          <title>To a God Unknown</title>
+          <description>Necessitatibus accusantium sint ratione qui et aut dolorem.</description>
+        </package>
+    http_version: 
+  recorded_at: Tue, 16 Jan 2018 13:48:49 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/my_project/package_with_kiwi_image/package_with_kiwi_image.kiwi
+    body:
+      encoding: UTF-8
+      string: "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n  <image schemaversion=\"6.2\"
+        name=\"suse-13.2-live\">\n    <description type=\"system\">\n    </description>\n
+        \   <preferences>\n      <type image=\"oem\" primary=\"true\" boot=\"oemboot/suse-13.2\"/>\n
+        \   </preferences>\n  </image>\n  "
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -584,24 +702,24 @@ http_interactions:
       encoding: UTF-8
       string: |
         <revision rev="2" vrev="2">
-          <srcmd5>b0ae2bb7f5c5bb943240a1cb83b101b2</srcmd5>
+          <srcmd5>e79574ec95865487aedacea760376ee3</srcmd5>
           <version>unknown</version>
-          <time>1508410505</time>
+          <time>1516110529</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
     http_version: 
-  recorded_at: Thu, 19 Oct 2017 10:55:05 GMT
+  recorded_at: Tue, 16 Jan 2018 13:48:49 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/my_project/package_with_kiwi_image/_meta?user=_nobody_
+    uri: http://backend:5352/source/my_project/package_with_kiwi_image/_meta?user=tom
     body:
       encoding: UTF-8
       string: |
         <package name="package_with_kiwi_image" project="my_project">
-          <title>Those Barren Leaves, Thrones, Dominations</title>
-          <description>Et veritatis non harum fuga similique et sint debitis.</description>
+          <title>To a God Unknown</title>
+          <description>Necessitatibus accusantium sint ratione qui et aut dolorem.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -622,141 +740,16 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '216'
+      - '196'
     body:
       encoding: UTF-8
       string: |
         <package name="package_with_kiwi_image" project="my_project">
-          <title>Those Barren Leaves, Thrones, Dominations</title>
-          <description>Et veritatis non harum fuga similique et sint debitis.</description>
+          <title>To a God Unknown</title>
+          <description>Necessitatibus accusantium sint ratione qui et aut dolorem.</description>
         </package>
     http_version: 
-  recorded_at: Thu, 19 Oct 2017 10:55:06 GMT
-- request:
-    method: put
-    uri: http://backend:5352/source/my_project/package_with_kiwi_image/_meta
-    body:
-      encoding: UTF-8
-      string: |
-        <package name="package_with_kiwi_image" project="my_project">
-          <title>Those Barren Leaves, Thrones, Dominations</title>
-          <description>Et veritatis non harum fuga similique et sint debitis.</description>
-        </package>
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '216'
-    body:
-      encoding: UTF-8
-      string: |
-        <package name="package_with_kiwi_image" project="my_project">
-          <title>Those Barren Leaves, Thrones, Dominations</title>
-          <description>Et veritatis non harum fuga similique et sint debitis.</description>
-        </package>
-    http_version: 
-  recorded_at: Thu, 19 Oct 2017 10:55:06 GMT
-- request:
-    method: put
-    uri: http://backend:5352/source/my_project/package_with_kiwi_image/package_with_kiwi_image.kiwi
-    body:
-      encoding: UTF-8
-      string: |
-        <?xml version="1.0" encoding="utf-8"?>
-        <image schemaversion="6.2" name="suse-13.2-live">
-          <description type="system">
-          </description>
-          <preferences>
-            <type image="oem" primary="true" boot="oemboot/suse-13.2"/>
-          </preferences>
-        </image>
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '207'
-    body:
-      encoding: UTF-8
-      string: |
-        <revision rev="1" vrev="1">
-          <srcmd5>82f39606fd3c729f7f16de7d227e6dae</srcmd5>
-          <version>unknown</version>
-          <time>1508410506</time>
-          <user>unknown</user>
-          <comment></comment>
-          <requestid/>
-        </revision>
-    http_version: 
-  recorded_at: Thu, 19 Oct 2017 10:55:06 GMT
-- request:
-    method: put
-    uri: http://backend:5352/source/my_project/package_with_kiwi_image/_meta?user=_nobody_
-    body:
-      encoding: UTF-8
-      string: |
-        <package name="package_with_kiwi_image" project="my_project">
-          <title>Those Barren Leaves, Thrones, Dominations</title>
-          <description>Et veritatis non harum fuga similique et sint debitis.</description>
-        </package>
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '216'
-    body:
-      encoding: UTF-8
-      string: |
-        <package name="package_with_kiwi_image" project="my_project">
-          <title>Those Barren Leaves, Thrones, Dominations</title>
-          <description>Et veritatis non harum fuga similique et sint debitis.</description>
-        </package>
-    http_version: 
-  recorded_at: Thu, 19 Oct 2017 10:55:06 GMT
+  recorded_at: Tue, 16 Jan 2018 13:48:49 GMT
 - request:
     method: get
     uri: http://backend:5352/source/my_project/package_with_kiwi_image
@@ -786,11 +779,11 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="package_with_kiwi_image" rev="1" vrev="1" srcmd5="82f39606fd3c729f7f16de7d227e6dae">
-          <entry name="package_with_kiwi_image.kiwi" md5="dda935f455dcd6607d83705328bee9df" size="242" mtime="1508410506" />
+        <directory name="package_with_kiwi_image" rev="2" vrev="2" srcmd5="e79574ec95865487aedacea760376ee3">
+          <entry name="package_with_kiwi_image.kiwi" md5="5f2d7b5465fbb78bd2d0a30c224f4254" size="258" mtime="1516110524" />
         </directory>
     http_version: 
-  recorded_at: Thu, 19 Oct 2017 10:55:06 GMT
+  recorded_at: Tue, 16 Jan 2018 13:48:49 GMT
 - request:
     method: get
     uri: http://backend:5352/source/my_project/first_package
@@ -820,12 +813,12 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="first_package" rev="2" vrev="2" srcmd5="cc00029be6782e27f489e5b49ab97e95">
-          <entry name="_config" md5="d3c20d772da0ebb1ba92df52e319dcdd" size="145" mtime="1508410499" />
-          <entry name="somefile.txt" md5="43aabf1133fb828b27051ab4b8aab3bb" size="138" mtime="1508410500" />
+        <directory name="first_package" rev="4" vrev="4" srcmd5="b4c0ae9b620ffffe08fb8ab428c76de5">
+          <entry name="_config" md5="8a57f6e840d4cd01fee7958d2b2eed52" size="165" mtime="1516110529" />
+          <entry name="somefile.txt" md5="de916512f7577e6a70f2b9971456a7ab" size="122" mtime="1516110523" />
         </directory>
     http_version: 
-  recorded_at: Thu, 19 Oct 2017 10:55:09 GMT
+  recorded_at: Tue, 16 Jan 2018 13:48:49 GMT
 - request:
     method: get
     uri: http://backend:5352/source/my_project/first_package
@@ -855,12 +848,12 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="first_package" rev="2" vrev="2" srcmd5="cc00029be6782e27f489e5b49ab97e95">
-          <entry name="_config" md5="d3c20d772da0ebb1ba92df52e319dcdd" size="145" mtime="1508410499" />
-          <entry name="somefile.txt" md5="43aabf1133fb828b27051ab4b8aab3bb" size="138" mtime="1508410500" />
+        <directory name="first_package" rev="4" vrev="4" srcmd5="b4c0ae9b620ffffe08fb8ab428c76de5">
+          <entry name="_config" md5="8a57f6e840d4cd01fee7958d2b2eed52" size="165" mtime="1516110529" />
+          <entry name="somefile.txt" md5="de916512f7577e6a70f2b9971456a7ab" size="122" mtime="1516110523" />
         </directory>
     http_version: 
-  recorded_at: Thu, 19 Oct 2017 10:55:09 GMT
+  recorded_at: Tue, 16 Jan 2018 13:48:49 GMT
 - request:
     method: get
     uri: http://backend:5352/source/my_project/second_package
@@ -890,12 +883,12 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="second_package" rev="2" vrev="2" srcmd5="b12941a7628b8774e28f8302ebed5102">
-          <entry name="_config" md5="3509213435a54f6047029d0fc43c854d" size="236" mtime="1508410502" />
-          <entry name="somefile.txt" md5="38dcce8203c0cc5be7f5f4dde94302f3" size="155" mtime="1508410503" />
+        <directory name="second_package" rev="4" vrev="4" srcmd5="ca1046705dfbc246a31334b7a7d571a1">
+          <entry name="_config" md5="f47c340a4ab32acec119a1fe1a7cd701" size="152" mtime="1516110529" />
+          <entry name="somefile.txt" md5="de916512f7577e6a70f2b9971456a7ab" size="122" mtime="1516110523" />
         </directory>
     http_version: 
-  recorded_at: Thu, 19 Oct 2017 10:55:27 GMT
+  recorded_at: Tue, 16 Jan 2018 13:48:49 GMT
 - request:
     method: get
     uri: http://backend:5352/source/my_project/second_package
@@ -925,12 +918,12 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="second_package" rev="2" vrev="2" srcmd5="b12941a7628b8774e28f8302ebed5102">
-          <entry name="_config" md5="3509213435a54f6047029d0fc43c854d" size="236" mtime="1508410502" />
-          <entry name="somefile.txt" md5="38dcce8203c0cc5be7f5f4dde94302f3" size="155" mtime="1508410503" />
+        <directory name="second_package" rev="4" vrev="4" srcmd5="ca1046705dfbc246a31334b7a7d571a1">
+          <entry name="_config" md5="f47c340a4ab32acec119a1fe1a7cd701" size="152" mtime="1516110529" />
+          <entry name="somefile.txt" md5="de916512f7577e6a70f2b9971456a7ab" size="122" mtime="1516110523" />
         </directory>
     http_version: 
-  recorded_at: Thu, 19 Oct 2017 10:55:27 GMT
+  recorded_at: Tue, 16 Jan 2018 13:48:49 GMT
 - request:
     method: get
     uri: http://backend:5352/source/my_project/third_package
@@ -960,12 +953,12 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="third_package" rev="2" vrev="2" srcmd5="b0ae2bb7f5c5bb943240a1cb83b101b2">
-          <entry name="_config" md5="a260b0daebc0f9c42583117e8e402ae3" size="193" mtime="1508410504" />
-          <entry name="somefile.txt" md5="d5c3fd845aefe83843dfc31118387fb0" size="154" mtime="1508410505" />
+        <directory name="third_package" rev="4" vrev="4" srcmd5="dfe237fecac09bf00f3bb3f500b6e3e7">
+          <entry name="_config" md5="c8f9257071b710d8a6bc7c6043271cff" size="169" mtime="1516110529" />
+          <entry name="somefile.txt" md5="de916512f7577e6a70f2b9971456a7ab" size="122" mtime="1516110523" />
         </directory>
     http_version: 
-  recorded_at: Thu, 19 Oct 2017 10:55:27 GMT
+  recorded_at: Tue, 16 Jan 2018 13:48:49 GMT
 - request:
     method: get
     uri: http://backend:5352/source/my_project/third_package
@@ -995,12 +988,12 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="third_package" rev="2" vrev="2" srcmd5="b0ae2bb7f5c5bb943240a1cb83b101b2">
-          <entry name="_config" md5="a260b0daebc0f9c42583117e8e402ae3" size="193" mtime="1508410504" />
-          <entry name="somefile.txt" md5="d5c3fd845aefe83843dfc31118387fb0" size="154" mtime="1508410505" />
+        <directory name="third_package" rev="4" vrev="4" srcmd5="dfe237fecac09bf00f3bb3f500b6e3e7">
+          <entry name="_config" md5="c8f9257071b710d8a6bc7c6043271cff" size="169" mtime="1516110529" />
+          <entry name="somefile.txt" md5="de916512f7577e6a70f2b9971456a7ab" size="122" mtime="1516110523" />
         </directory>
     http_version: 
-  recorded_at: Thu, 19 Oct 2017 10:55:27 GMT
+  recorded_at: Tue, 16 Jan 2018 13:48:49 GMT
 - request:
     method: get
     uri: http://backend:5352/source/my_project/package_with_kiwi_image
@@ -1030,11 +1023,11 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="package_with_kiwi_image" rev="1" vrev="1" srcmd5="82f39606fd3c729f7f16de7d227e6dae">
-          <entry name="package_with_kiwi_image.kiwi" md5="dda935f455dcd6607d83705328bee9df" size="242" mtime="1508410506" />
+        <directory name="package_with_kiwi_image" rev="2" vrev="2" srcmd5="e79574ec95865487aedacea760376ee3">
+          <entry name="package_with_kiwi_image.kiwi" md5="5f2d7b5465fbb78bd2d0a30c224f4254" size="258" mtime="1516110524" />
         </directory>
     http_version: 
-  recorded_at: Thu, 19 Oct 2017 10:55:27 GMT
+  recorded_at: Tue, 16 Jan 2018 13:48:49 GMT
 - request:
     method: get
     uri: http://backend:5352/source/my_project/package_with_kiwi_image
@@ -1064,66 +1057,11 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="package_with_kiwi_image" rev="1" vrev="1" srcmd5="82f39606fd3c729f7f16de7d227e6dae">
-          <entry name="package_with_kiwi_image.kiwi" md5="dda935f455dcd6607d83705328bee9df" size="242" mtime="1508410506" />
+        <directory name="package_with_kiwi_image" rev="2" vrev="2" srcmd5="e79574ec95865487aedacea760376ee3">
+          <entry name="package_with_kiwi_image.kiwi" md5="5f2d7b5465fbb78bd2d0a30c224f4254" size="258" mtime="1516110524" />
         </directory>
     http_version: 
-  recorded_at: Thu, 19 Oct 2017 10:55:27 GMT
-- request:
-    method: get
-    uri: http://backend:5352/build/_workerstatus
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '1131'
-    body:
-      encoding: UTF-8
-      string: |
-        <workerstatus clients="2">
-          <idle workerid="21bfc591c17f:1" hostarch="x86_64" />
-          <idle workerid="21bfc591c17f:2" hostarch="x86_64" />
-          <waiting arch="i586" jobs="0" />
-          <waiting arch="x86_64" jobs="0" />
-          <blocked arch="i586" jobs="0" />
-          <blocked arch="x86_64" jobs="0" />
-          <buildavg arch="i586" buildavg="1200" />
-          <buildavg arch="x86_64" buildavg="964.483" />
-          <partition>
-            <daemon type="srcserver" state="running" starttime="1508333502" />
-            <daemon type="service" state="running" starttime="1508333504" />
-            <daemon type="scheduler" arch="i586" state="running" starttime="1508333505">
-              <queue high="0" med="0" low="0" next="0" />
-            </daemon>
-            <daemon type="scheduler" arch="x86_64" state="running" starttime="1508333505">
-              <queue high="0" med="0" low="0" next="0" />
-            </daemon>
-            <daemon type="repserver" state="running" starttime="1508333503" />
-            <daemon type="dispatcher" state="running" starttime="1508333504" />
-            <daemon type="publisher" state="running" starttime="1508333504" />
-            <daemon type="signer" state="running" starttime="1508333504" />
-          </partition>
-        </workerstatus>
-    http_version: 
-  recorded_at: Thu, 19 Oct 2017 10:55:38 GMT
+  recorded_at: Tue, 16 Jan 2018 13:48:49 GMT
 - request:
     method: get
     uri: http://backend:5352/source/my_project/first_package
@@ -1153,12 +1091,12 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="first_package" rev="2" vrev="2" srcmd5="cc00029be6782e27f489e5b49ab97e95">
-          <entry name="_config" md5="d3c20d772da0ebb1ba92df52e319dcdd" size="145" mtime="1508410499" />
-          <entry name="somefile.txt" md5="43aabf1133fb828b27051ab4b8aab3bb" size="138" mtime="1508410500" />
+        <directory name="first_package" rev="4" vrev="4" srcmd5="b4c0ae9b620ffffe08fb8ab428c76de5">
+          <entry name="_config" md5="8a57f6e840d4cd01fee7958d2b2eed52" size="165" mtime="1516110529" />
+          <entry name="somefile.txt" md5="de916512f7577e6a70f2b9971456a7ab" size="122" mtime="1516110523" />
         </directory>
     http_version: 
-  recorded_at: Thu, 19 Oct 2017 10:55:39 GMT
+  recorded_at: Tue, 16 Jan 2018 13:48:50 GMT
 - request:
     method: get
     uri: http://backend:5352/source/my_project/first_package
@@ -1188,12 +1126,12 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="first_package" rev="2" vrev="2" srcmd5="cc00029be6782e27f489e5b49ab97e95">
-          <entry name="_config" md5="d3c20d772da0ebb1ba92df52e319dcdd" size="145" mtime="1508410499" />
-          <entry name="somefile.txt" md5="43aabf1133fb828b27051ab4b8aab3bb" size="138" mtime="1508410500" />
+        <directory name="first_package" rev="4" vrev="4" srcmd5="b4c0ae9b620ffffe08fb8ab428c76de5">
+          <entry name="_config" md5="8a57f6e840d4cd01fee7958d2b2eed52" size="165" mtime="1516110529" />
+          <entry name="somefile.txt" md5="de916512f7577e6a70f2b9971456a7ab" size="122" mtime="1516110523" />
         </directory>
     http_version: 
-  recorded_at: Thu, 19 Oct 2017 10:55:39 GMT
+  recorded_at: Tue, 16 Jan 2018 13:48:50 GMT
 - request:
     method: get
     uri: http://backend:5352/source/my_project/second_package
@@ -1223,12 +1161,12 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="second_package" rev="2" vrev="2" srcmd5="b12941a7628b8774e28f8302ebed5102">
-          <entry name="_config" md5="3509213435a54f6047029d0fc43c854d" size="236" mtime="1508410502" />
-          <entry name="somefile.txt" md5="38dcce8203c0cc5be7f5f4dde94302f3" size="155" mtime="1508410503" />
+        <directory name="second_package" rev="4" vrev="4" srcmd5="ca1046705dfbc246a31334b7a7d571a1">
+          <entry name="_config" md5="f47c340a4ab32acec119a1fe1a7cd701" size="152" mtime="1516110529" />
+          <entry name="somefile.txt" md5="de916512f7577e6a70f2b9971456a7ab" size="122" mtime="1516110523" />
         </directory>
     http_version: 
-  recorded_at: Thu, 19 Oct 2017 10:55:39 GMT
+  recorded_at: Tue, 16 Jan 2018 13:48:50 GMT
 - request:
     method: get
     uri: http://backend:5352/source/my_project/second_package
@@ -1258,12 +1196,12 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="second_package" rev="2" vrev="2" srcmd5="b12941a7628b8774e28f8302ebed5102">
-          <entry name="_config" md5="3509213435a54f6047029d0fc43c854d" size="236" mtime="1508410502" />
-          <entry name="somefile.txt" md5="38dcce8203c0cc5be7f5f4dde94302f3" size="155" mtime="1508410503" />
+        <directory name="second_package" rev="4" vrev="4" srcmd5="ca1046705dfbc246a31334b7a7d571a1">
+          <entry name="_config" md5="f47c340a4ab32acec119a1fe1a7cd701" size="152" mtime="1516110529" />
+          <entry name="somefile.txt" md5="de916512f7577e6a70f2b9971456a7ab" size="122" mtime="1516110523" />
         </directory>
     http_version: 
-  recorded_at: Thu, 19 Oct 2017 10:55:39 GMT
+  recorded_at: Tue, 16 Jan 2018 13:48:50 GMT
 - request:
     method: get
     uri: http://backend:5352/source/my_project/third_package
@@ -1293,12 +1231,12 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="third_package" rev="2" vrev="2" srcmd5="b0ae2bb7f5c5bb943240a1cb83b101b2">
-          <entry name="_config" md5="a260b0daebc0f9c42583117e8e402ae3" size="193" mtime="1508410504" />
-          <entry name="somefile.txt" md5="d5c3fd845aefe83843dfc31118387fb0" size="154" mtime="1508410505" />
+        <directory name="third_package" rev="4" vrev="4" srcmd5="dfe237fecac09bf00f3bb3f500b6e3e7">
+          <entry name="_config" md5="c8f9257071b710d8a6bc7c6043271cff" size="169" mtime="1516110529" />
+          <entry name="somefile.txt" md5="de916512f7577e6a70f2b9971456a7ab" size="122" mtime="1516110523" />
         </directory>
     http_version: 
-  recorded_at: Thu, 19 Oct 2017 10:55:39 GMT
+  recorded_at: Tue, 16 Jan 2018 13:48:50 GMT
 - request:
     method: get
     uri: http://backend:5352/source/my_project/third_package
@@ -1328,12 +1266,12 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="third_package" rev="2" vrev="2" srcmd5="b0ae2bb7f5c5bb943240a1cb83b101b2">
-          <entry name="_config" md5="a260b0daebc0f9c42583117e8e402ae3" size="193" mtime="1508410504" />
-          <entry name="somefile.txt" md5="d5c3fd845aefe83843dfc31118387fb0" size="154" mtime="1508410505" />
+        <directory name="third_package" rev="4" vrev="4" srcmd5="dfe237fecac09bf00f3bb3f500b6e3e7">
+          <entry name="_config" md5="c8f9257071b710d8a6bc7c6043271cff" size="169" mtime="1516110529" />
+          <entry name="somefile.txt" md5="de916512f7577e6a70f2b9971456a7ab" size="122" mtime="1516110523" />
         </directory>
     http_version: 
-  recorded_at: Thu, 19 Oct 2017 10:55:39 GMT
+  recorded_at: Tue, 16 Jan 2018 13:48:50 GMT
 - request:
     method: get
     uri: http://backend:5352/source/my_project/package_with_kiwi_image
@@ -1363,11 +1301,11 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="package_with_kiwi_image" rev="1" vrev="1" srcmd5="82f39606fd3c729f7f16de7d227e6dae">
-          <entry name="package_with_kiwi_image.kiwi" md5="dda935f455dcd6607d83705328bee9df" size="242" mtime="1508410506" />
+        <directory name="package_with_kiwi_image" rev="2" vrev="2" srcmd5="e79574ec95865487aedacea760376ee3">
+          <entry name="package_with_kiwi_image.kiwi" md5="5f2d7b5465fbb78bd2d0a30c224f4254" size="258" mtime="1516110524" />
         </directory>
     http_version: 
-  recorded_at: Thu, 19 Oct 2017 10:55:39 GMT
+  recorded_at: Tue, 16 Jan 2018 13:48:51 GMT
 - request:
     method: get
     uri: http://backend:5352/source/my_project/package_with_kiwi_image
@@ -1397,11 +1335,11 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="package_with_kiwi_image" rev="1" vrev="1" srcmd5="82f39606fd3c729f7f16de7d227e6dae">
-          <entry name="package_with_kiwi_image.kiwi" md5="dda935f455dcd6607d83705328bee9df" size="242" mtime="1508410506" />
+        <directory name="package_with_kiwi_image" rev="2" vrev="2" srcmd5="e79574ec95865487aedacea760376ee3">
+          <entry name="package_with_kiwi_image.kiwi" md5="5f2d7b5465fbb78bd2d0a30c224f4254" size="258" mtime="1516110524" />
         </directory>
     http_version: 
-  recorded_at: Thu, 19 Oct 2017 10:55:39 GMT
+  recorded_at: Tue, 16 Jan 2018 13:48:51 GMT
 - request:
     method: get
     uri: http://backend:5352/source/my_project/package_with_kiwi_image?expand=1
@@ -1431,14 +1369,14 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="package_with_kiwi_image" rev="1" vrev="1" srcmd5="82f39606fd3c729f7f16de7d227e6dae">
-          <entry name="package_with_kiwi_image.kiwi" md5="dda935f455dcd6607d83705328bee9df" size="242" mtime="1508410506" />
+        <directory name="package_with_kiwi_image" rev="2" vrev="2" srcmd5="e79574ec95865487aedacea760376ee3">
+          <entry name="package_with_kiwi_image.kiwi" md5="5f2d7b5465fbb78bd2d0a30c224f4254" size="258" mtime="1516110524" />
         </directory>
     http_version: 
-  recorded_at: Thu, 19 Oct 2017 10:55:39 GMT
+  recorded_at: Tue, 16 Jan 2018 13:48:51 GMT
 - request:
     method: get
-    uri: http://backend:5352/source/my_project/package_with_kiwi_image?rev=1
+    uri: http://backend:5352/source/my_project/package_with_kiwi_image?rev=2
     body:
       encoding: US-ASCII
       string: ''
@@ -1467,11 +1405,11 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="package_with_kiwi_image" rev="1" vrev="1" srcmd5="82f39606fd3c729f7f16de7d227e6dae">
-          <entry name="package_with_kiwi_image.kiwi" md5="dda935f455dcd6607d83705328bee9df" size="242" mtime="1508410506" />
+        <directory name="package_with_kiwi_image" rev="2" vrev="2" srcmd5="e79574ec95865487aedacea760376ee3">
+          <entry name="package_with_kiwi_image.kiwi" md5="5f2d7b5465fbb78bd2d0a30c224f4254" size="258" mtime="1516110524" />
         </directory>
     http_version: 
-  recorded_at: Thu, 19 Oct 2017 10:55:39 GMT
+  recorded_at: Tue, 16 Jan 2018 13:48:51 GMT
 - request:
     method: post
     uri: http://backend:5352/search/package/id?match=(linkinfo/@package=%22package_with_kiwi_image%22%20and%20linkinfo/@project=%22my_project%22%20and%20@project=%22my_project%22)
@@ -1506,7 +1444,7 @@ http_interactions:
         <collection>
         </collection>
     http_version: 
-  recorded_at: Thu, 19 Oct 2017 10:55:39 GMT
+  recorded_at: Tue, 16 Jan 2018 13:48:51 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom:branches:my_project/_meta?user=tom
@@ -1547,7 +1485,7 @@ http_interactions:
           <person userid="tom" role="maintainer" />
         </project>
     http_version: 
-  recorded_at: Thu, 19 Oct 2017 10:55:40 GMT
+  recorded_at: Tue, 16 Jan 2018 13:48:51 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom:branches:my_project/package_with_kiwi_image/_meta?user=tom
@@ -1555,8 +1493,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="package_with_kiwi_image" project="home:tom:branches:my_project">
-          <title>Those Barren Leaves, Thrones, Dominations</title>
-          <description>Et veritatis non harum fuga similique et sint debitis.</description>
+          <title>To a God Unknown</title>
+          <description>Necessitatibus accusantium sint ratione qui et aut dolorem.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -1577,19 +1515,19 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '234'
+      - '214'
     body:
       encoding: UTF-8
       string: |
         <package name="package_with_kiwi_image" project="home:tom:branches:my_project">
-          <title>Those Barren Leaves, Thrones, Dominations</title>
-          <description>Et veritatis non harum fuga similique et sint debitis.</description>
+          <title>To a God Unknown</title>
+          <description>Necessitatibus accusantium sint ratione qui et aut dolorem.</description>
         </package>
     http_version: 
-  recorded_at: Thu, 19 Oct 2017 10:55:41 GMT
+  recorded_at: Tue, 16 Jan 2018 13:48:51 GMT
 - request:
     method: post
-    uri: http://backend:5352/source/home:tom:branches:my_project/package_with_kiwi_image?cmd=branch&opackage=package_with_kiwi_image&oproject=my_project&orev=82f39606fd3c729f7f16de7d227e6dae&user=tom
+    uri: http://backend:5352/source/home:tom:branches:my_project/package_with_kiwi_image?cmd=branch&noservice=1&opackage=package_with_kiwi_image&oproject=my_project&orev=e79574ec95865487aedacea760376ee3&user=tom
     body:
       encoding: UTF-8
       string: ''
@@ -1619,15 +1557,15 @@ http_interactions:
       encoding: UTF-8
       string: |
         <revision rev="1" vrev="1">
-          <srcmd5>f9e72a69b66673610f3f29bf6aee9a3f</srcmd5>
+          <srcmd5>071d26b0e1ef9ec15eb80ded628674b7</srcmd5>
           <version>unknown</version>
-          <time>1508410541</time>
+          <time>1516110531</time>
           <user>tom</user>
           <comment></comment>
           <requestid/>
         </revision>
     http_version: 
-  recorded_at: Thu, 19 Oct 2017 10:55:41 GMT
+  recorded_at: Tue, 16 Jan 2018 13:48:51 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom:branches:my_project/package_with_kiwi_image/_meta?user=tom
@@ -1635,8 +1573,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="package_with_kiwi_image" project="home:tom:branches:my_project">
-          <title>Those Barren Leaves, Thrones, Dominations</title>
-          <description>Et veritatis non harum fuga similique et sint debitis.</description>
+          <title>To a God Unknown</title>
+          <description>Necessitatibus accusantium sint ratione qui et aut dolorem.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -1657,16 +1595,16 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '234'
+      - '214'
     body:
       encoding: UTF-8
       string: |
         <package name="package_with_kiwi_image" project="home:tom:branches:my_project">
-          <title>Those Barren Leaves, Thrones, Dominations</title>
-          <description>Et veritatis non harum fuga similique et sint debitis.</description>
+          <title>To a God Unknown</title>
+          <description>Necessitatibus accusantium sint ratione qui et aut dolorem.</description>
         </package>
     http_version: 
-  recorded_at: Thu, 19 Oct 2017 10:55:41 GMT
+  recorded_at: Tue, 16 Jan 2018 13:48:51 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:tom:branches:my_project/package_with_kiwi_image
@@ -1696,13 +1634,13 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="package_with_kiwi_image" rev="1" vrev="1" srcmd5="f9e72a69b66673610f3f29bf6aee9a3f">
-          <linkinfo project="my_project" package="package_with_kiwi_image" rev="82f39606fd3c729f7f16de7d227e6dae" srcmd5="82f39606fd3c729f7f16de7d227e6dae" baserev="82f39606fd3c729f7f16de7d227e6dae" xsrcmd5="62fa771ac871dbdedf5dd34e8344f74c" lsrcmd5="f9e72a69b66673610f3f29bf6aee9a3f" />
-          <entry name="_link" md5="db3b081d0577b839aef1ad245a72e9c2" size="157" mtime="1508410541" />
-          <entry name="package_with_kiwi_image.kiwi" md5="dda935f455dcd6607d83705328bee9df" size="242" mtime="1508410506" />
+        <directory name="package_with_kiwi_image" rev="1" vrev="1" srcmd5="071d26b0e1ef9ec15eb80ded628674b7">
+          <linkinfo project="my_project" package="package_with_kiwi_image" rev="e79574ec95865487aedacea760376ee3" srcmd5="e79574ec95865487aedacea760376ee3" baserev="e79574ec95865487aedacea760376ee3" xsrcmd5="74adbbd5936de3f849be21572fdf963d" lsrcmd5="071d26b0e1ef9ec15eb80ded628674b7" />
+          <entry name="_link" md5="431975361114e372ab9bf958a966a7ef" size="157" mtime="1516110531" />
+          <entry name="package_with_kiwi_image.kiwi" md5="5f2d7b5465fbb78bd2d0a30c224f4254" size="258" mtime="1516110524" />
         </directory>
     http_version: 
-  recorded_at: Thu, 19 Oct 2017 10:55:42 GMT
+  recorded_at: Tue, 16 Jan 2018 13:48:51 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:tom:branches:my_project/package_with_kiwi_image?nofilename=1&view=info&withchangesmd5=1
@@ -1732,12 +1670,12 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <sourceinfo package="package_with_kiwi_image" rev="1" vrev="1" srcmd5="62fa771ac871dbdedf5dd34e8344f74c" lsrcmd5="f9e72a69b66673610f3f29bf6aee9a3f" verifymd5="82f39606fd3c729f7f16de7d227e6dae">
+        <sourceinfo package="package_with_kiwi_image" rev="1" vrev="1" srcmd5="74adbbd5936de3f849be21572fdf963d" lsrcmd5="071d26b0e1ef9ec15eb80ded628674b7" verifymd5="e79574ec95865487aedacea760376ee3">
           <linked project="my_project" package="package_with_kiwi_image" />
-          <revtime>1508410541</revtime>
+          <revtime>1516110531</revtime>
         </sourceinfo>
     http_version: 
-  recorded_at: Thu, 19 Oct 2017 10:55:42 GMT
+  recorded_at: Tue, 16 Jan 2018 13:48:51 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:tom:branches:my_project/package_with_kiwi_image
@@ -1767,13 +1705,13 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="package_with_kiwi_image" rev="1" vrev="1" srcmd5="f9e72a69b66673610f3f29bf6aee9a3f">
-          <linkinfo project="my_project" package="package_with_kiwi_image" rev="82f39606fd3c729f7f16de7d227e6dae" srcmd5="82f39606fd3c729f7f16de7d227e6dae" baserev="82f39606fd3c729f7f16de7d227e6dae" xsrcmd5="62fa771ac871dbdedf5dd34e8344f74c" lsrcmd5="f9e72a69b66673610f3f29bf6aee9a3f" />
-          <entry name="_link" md5="db3b081d0577b839aef1ad245a72e9c2" size="157" mtime="1508410541" />
-          <entry name="package_with_kiwi_image.kiwi" md5="dda935f455dcd6607d83705328bee9df" size="242" mtime="1508410506" />
+        <directory name="package_with_kiwi_image" rev="1" vrev="1" srcmd5="071d26b0e1ef9ec15eb80ded628674b7">
+          <linkinfo project="my_project" package="package_with_kiwi_image" rev="e79574ec95865487aedacea760376ee3" srcmd5="e79574ec95865487aedacea760376ee3" baserev="e79574ec95865487aedacea760376ee3" xsrcmd5="74adbbd5936de3f849be21572fdf963d" lsrcmd5="071d26b0e1ef9ec15eb80ded628674b7" />
+          <entry name="_link" md5="431975361114e372ab9bf958a966a7ef" size="157" mtime="1516110531" />
+          <entry name="package_with_kiwi_image.kiwi" md5="5f2d7b5465fbb78bd2d0a30c224f4254" size="258" mtime="1516110524" />
         </directory>
     http_version: 
-  recorded_at: Thu, 19 Oct 2017 10:55:42 GMT
+  recorded_at: Tue, 16 Jan 2018 13:48:51 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:tom:branches:my_project/package_with_kiwi_image?cmd=diff&linkrev=base&onlyissues=1&orev=0&view=xml
@@ -1805,15 +1743,15 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="4ed69f0f1c4aaea86ef6facb50b63587">
+        <sourcediff key="e4f8db077dce7b1b80ad72ff10eb4528">
           <old project="home:tom:branches:my_project" package="package_with_kiwi_image" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e" />
-          <new project="home:tom:branches:my_project" package="package_with_kiwi_image" rev="1" srcmd5="f9e72a69b66673610f3f29bf6aee9a3f" />
+          <new project="home:tom:branches:my_project" package="package_with_kiwi_image" rev="1" srcmd5="071d26b0e1ef9ec15eb80ded628674b7" />
           <files />
           <issues>
           </issues>
         </sourcediff>
     http_version: 
-  recorded_at: Thu, 19 Oct 2017 10:55:42 GMT
+  recorded_at: Tue, 16 Jan 2018 13:48:51 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:tom:branches:my_project/package_with_kiwi_image?cmd=linkdiff&linkrev=base&onlyissues=1&view=xml
@@ -1845,13 +1783,13 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="806d4e466d5c595e55964d77fcc8c924">
-          <old project="my_project" package="package_with_kiwi_image" rev="82f39606fd3c729f7f16de7d227e6dae" srcmd5="82f39606fd3c729f7f16de7d227e6dae" />
-          <new project="home:tom:branches:my_project" package="package_with_kiwi_image" rev="62fa771ac871dbdedf5dd34e8344f74c" srcmd5="62fa771ac871dbdedf5dd34e8344f74c" />
+        <sourcediff key="47a3f000dd83fff2b3e7b95880006829">
+          <old project="my_project" package="package_with_kiwi_image" rev="e79574ec95865487aedacea760376ee3" srcmd5="e79574ec95865487aedacea760376ee3" />
+          <new project="home:tom:branches:my_project" package="package_with_kiwi_image" rev="74adbbd5936de3f849be21572fdf963d" srcmd5="74adbbd5936de3f849be21572fdf963d" />
           <files />
         </sourcediff>
     http_version: 
-  recorded_at: Thu, 19 Oct 2017 10:55:42 GMT
+  recorded_at: Tue, 16 Jan 2018 13:48:51 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom:branches:my_project/_meta?user=tom
@@ -1898,7 +1836,7 @@ http_interactions:
           </publish>
         </project>
     http_version: 
-  recorded_at: Thu, 19 Oct 2017 10:55:43 GMT
+  recorded_at: Tue, 16 Jan 2018 13:48:51 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:tom:branches:my_project/package_with_kiwi_image
@@ -1928,13 +1866,13 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="package_with_kiwi_image" rev="1" vrev="1" srcmd5="f9e72a69b66673610f3f29bf6aee9a3f">
-          <linkinfo project="my_project" package="package_with_kiwi_image" rev="82f39606fd3c729f7f16de7d227e6dae" srcmd5="82f39606fd3c729f7f16de7d227e6dae" baserev="82f39606fd3c729f7f16de7d227e6dae" xsrcmd5="62fa771ac871dbdedf5dd34e8344f74c" lsrcmd5="f9e72a69b66673610f3f29bf6aee9a3f" />
-          <entry name="_link" md5="db3b081d0577b839aef1ad245a72e9c2" size="157" mtime="1508410541" />
-          <entry name="package_with_kiwi_image.kiwi" md5="dda935f455dcd6607d83705328bee9df" size="242" mtime="1508410506" />
+        <directory name="package_with_kiwi_image" rev="1" vrev="1" srcmd5="071d26b0e1ef9ec15eb80ded628674b7">
+          <linkinfo project="my_project" package="package_with_kiwi_image" rev="e79574ec95865487aedacea760376ee3" srcmd5="e79574ec95865487aedacea760376ee3" baserev="e79574ec95865487aedacea760376ee3" xsrcmd5="74adbbd5936de3f849be21572fdf963d" lsrcmd5="071d26b0e1ef9ec15eb80ded628674b7" />
+          <entry name="_link" md5="431975361114e372ab9bf958a966a7ef" size="157" mtime="1516110531" />
+          <entry name="package_with_kiwi_image.kiwi" md5="5f2d7b5465fbb78bd2d0a30c224f4254" size="258" mtime="1516110524" />
         </directory>
     http_version: 
-  recorded_at: Thu, 19 Oct 2017 10:55:43 GMT
+  recorded_at: Tue, 16 Jan 2018 13:48:51 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:tom:branches:my_project/package_with_kiwi_image
@@ -1964,13 +1902,13 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="package_with_kiwi_image" rev="1" vrev="1" srcmd5="f9e72a69b66673610f3f29bf6aee9a3f">
-          <linkinfo project="my_project" package="package_with_kiwi_image" rev="82f39606fd3c729f7f16de7d227e6dae" srcmd5="82f39606fd3c729f7f16de7d227e6dae" baserev="82f39606fd3c729f7f16de7d227e6dae" xsrcmd5="62fa771ac871dbdedf5dd34e8344f74c" lsrcmd5="f9e72a69b66673610f3f29bf6aee9a3f" />
-          <entry name="_link" md5="db3b081d0577b839aef1ad245a72e9c2" size="157" mtime="1508410541" />
-          <entry name="package_with_kiwi_image.kiwi" md5="dda935f455dcd6607d83705328bee9df" size="242" mtime="1508410506" />
+        <directory name="package_with_kiwi_image" rev="1" vrev="1" srcmd5="071d26b0e1ef9ec15eb80ded628674b7">
+          <linkinfo project="my_project" package="package_with_kiwi_image" rev="e79574ec95865487aedacea760376ee3" srcmd5="e79574ec95865487aedacea760376ee3" baserev="e79574ec95865487aedacea760376ee3" xsrcmd5="74adbbd5936de3f849be21572fdf963d" lsrcmd5="071d26b0e1ef9ec15eb80ded628674b7" />
+          <entry name="_link" md5="431975361114e372ab9bf958a966a7ef" size="157" mtime="1516110531" />
+          <entry name="package_with_kiwi_image.kiwi" md5="5f2d7b5465fbb78bd2d0a30c224f4254" size="258" mtime="1516110524" />
         </directory>
     http_version: 
-  recorded_at: Thu, 19 Oct 2017 10:55:43 GMT
+  recorded_at: Tue, 16 Jan 2018 13:48:51 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:tom:branches:my_project/package_with_kiwi_image/package_with_kiwi_image.kiwi
@@ -1992,24 +1930,19 @@ http_interactions:
       Content-Type:
       - application/octet-stream
       Content-Length:
-      - '242'
+      - '258'
       Cache-Control:
       - no-cache
       Connection:
       - close
     body:
       encoding: UTF-8
-      string: |
-        <?xml version="1.0" encoding="utf-8"?>
-        <image schemaversion="6.2" name="suse-13.2-live">
-          <description type="system">
-          </description>
-          <preferences>
-            <type image="oem" primary="true" boot="oemboot/suse-13.2"/>
-          </preferences>
-        </image>
+      string: "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n  <image schemaversion=\"6.2\"
+        name=\"suse-13.2-live\">\n    <description type=\"system\">\n    </description>\n
+        \   <preferences>\n      <type image=\"oem\" primary=\"true\" boot=\"oemboot/suse-13.2\"/>\n
+        \   </preferences>\n  </image>\n  "
     http_version: 
-  recorded_at: Thu, 19 Oct 2017 10:55:43 GMT
+  recorded_at: Tue, 16 Jan 2018 13:48:51 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:tom:branches:my_project/package_with_kiwi_image
@@ -2039,13 +1972,13 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="package_with_kiwi_image" rev="1" vrev="1" srcmd5="f9e72a69b66673610f3f29bf6aee9a3f">
-          <linkinfo project="my_project" package="package_with_kiwi_image" rev="82f39606fd3c729f7f16de7d227e6dae" srcmd5="82f39606fd3c729f7f16de7d227e6dae" baserev="82f39606fd3c729f7f16de7d227e6dae" xsrcmd5="62fa771ac871dbdedf5dd34e8344f74c" lsrcmd5="f9e72a69b66673610f3f29bf6aee9a3f" />
-          <entry name="_link" md5="db3b081d0577b839aef1ad245a72e9c2" size="157" mtime="1508410541" />
-          <entry name="package_with_kiwi_image.kiwi" md5="dda935f455dcd6607d83705328bee9df" size="242" mtime="1508410506" />
+        <directory name="package_with_kiwi_image" rev="1" vrev="1" srcmd5="071d26b0e1ef9ec15eb80ded628674b7">
+          <linkinfo project="my_project" package="package_with_kiwi_image" rev="e79574ec95865487aedacea760376ee3" srcmd5="e79574ec95865487aedacea760376ee3" baserev="e79574ec95865487aedacea760376ee3" xsrcmd5="74adbbd5936de3f849be21572fdf963d" lsrcmd5="071d26b0e1ef9ec15eb80ded628674b7" />
+          <entry name="_link" md5="431975361114e372ab9bf958a966a7ef" size="157" mtime="1516110531" />
+          <entry name="package_with_kiwi_image.kiwi" md5="5f2d7b5465fbb78bd2d0a30c224f4254" size="258" mtime="1516110524" />
         </directory>
     http_version: 
-  recorded_at: Thu, 19 Oct 2017 10:55:43 GMT
+  recorded_at: Tue, 16 Jan 2018 13:48:51 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom:branches:my_project/package_with_kiwi_image/_meta?user=tom
@@ -2053,8 +1986,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="package_with_kiwi_image" project="home:tom:branches:my_project">
-          <title>Those Barren Leaves, Thrones, Dominations</title>
-          <description>Et veritatis non harum fuga similique et sint debitis.</description>
+          <title>To a God Unknown</title>
+          <description>Necessitatibus accusantium sint ratione qui et aut dolorem.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -2075,52 +2008,13 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '234'
+      - '214'
     body:
       encoding: UTF-8
       string: |
         <package name="package_with_kiwi_image" project="home:tom:branches:my_project">
-          <title>Those Barren Leaves, Thrones, Dominations</title>
-          <description>Et veritatis non harum fuga similique et sint debitis.</description>
-        </package>
-    http_version: 
-  recorded_at: Thu, 19 Oct 2017 10:55:43 GMT
-- request:
-    method: put
-    uri: http://backend:5352/source/home:tom:branches:my_project/package_with_kiwi_image/_meta?user=tom
-    body:
-      encoding: UTF-8
-      string: |
-        <package name="package_with_kiwi_image" project="home:tom:branches:my_project">
-          <title>Those Barren Leaves, Thrones, Dominations</title>
-          <description>Et veritatis non harum fuga similique et sint debitis.</description>
-        </package>
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '234'
-    body:
-      encoding: UTF-8
-      string: |
-        <package name="package_with_kiwi_image" project="home:tom:branches:my_project">
-          <title>Those Barren Leaves, Thrones, Dominations</title>
-          <description>Et veritatis non harum fuga similique et sint debitis.</description>
+          <title>To a God Unknown</title>
+          <description>Necessitatibus accusantium sint ratione qui et aut dolorem.</description>
         </package>
     http_version: 
   recorded_at: Thu, 19 Oct 2017 10:55:43 GMT
@@ -2159,4 +2053,99 @@ http_interactions:
         </status>
     http_version: 
   recorded_at: Tue, 16 Jan 2018 14:27:07 GMT
+- request:
+    method: get
+    uri: http://backend:5352/build/_workerstatus
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '1205'
+    body:
+      encoding: UTF-8
+      string: |
+        <workerstatus clients="2">
+          <idle workerid="2188dacd92d7:1" hostarch="x86_64" />
+          <idle workerid="2188dacd92d7:2" hostarch="x86_64" />
+          <waiting arch="i586" jobs="0" />
+          <waiting arch="x86_64" jobs="0" />
+          <blocked arch="i586" jobs="0" />
+          <blocked arch="x86_64" jobs="0" />
+          <buildavg arch="i586" buildavg="1200" />
+          <buildavg arch="x86_64" buildavg="1200" />
+          <partition>
+            <daemon type="srcserver" state="running" starttime="1517502292" />
+            <daemon type="servicedispatch" state="running" starttime="1517502298" />
+            <daemon type="service" state="running" starttime="1517502298" />
+            <daemon type="scheduler" arch="i586" state="running" starttime="1517502298">
+              <queue high="0" med="0" low="0" next="0" />
+            </daemon>
+            <daemon type="scheduler" arch="x86_64" state="running" starttime="1517502298">
+              <queue high="0" med="0" low="0" next="0" />
+            </daemon>
+            <daemon type="repserver" state="running" starttime="1517502296" />
+            <daemon type="dispatcher" state="running" starttime="1517502298" />
+            <daemon type="publisher" state="running" starttime="1517502298" />
+            <daemon type="signer" state="running" starttime="1517502299" />
+          </partition>
+        </workerstatus>
+    http_version: 
+  recorded_at: Thu, 01 Feb 2018 16:26:02 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/my_project/first_package/_meta?user=_nobody_
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="first_package" project="my_project">
+          <title>a</title>
+          <description>Alias ut dolores aut ipsam quisquam.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 404
+      message: project 'my_project' does not exist
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '148'
+    body:
+      encoding: UTF-8
+      string: |
+        <status code="404">
+          <summary>project 'my_project' does not exist</summary>
+          <details>404 project 'my_project' does not exist</details>
+        </status>
+    http_version: 
+  recorded_at: Thu, 01 Feb 2018 16:26:26 GMT
 recorded_with: VCR 4.0.0

--- a/src/api/spec/cassettes/ImageTemplates/branching/branch_image_template.yml
+++ b/src/api/spec/cassettes/ImageTemplates/branching/branch_image_template.yml
@@ -40,46 +40,7 @@ http_interactions:
           <person userid="tom" role="maintainer" />
         </project>
     http_version: 
-  recorded_at: Wed, 09 Aug 2017 15:30:54 GMT
-- request:
-    method: put
-    uri: http://backend:5352/source/my_project/_meta?user=admin
-    body:
-      encoding: UTF-8
-      string: |
-        <project name="my_project">
-          <title>The Wealth of Nations</title>
-          <description/>
-        </project>
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '108'
-    body:
-      encoding: UTF-8
-      string: |
-        <project name="my_project">
-          <title>The Wealth of Nations</title>
-          <description></description>
-        </project>
-    http_version: 
-  recorded_at: Wed, 09 Aug 2017 15:30:54 GMT
+  recorded_at: Tue, 16 Jan 2018 13:48:43 GMT
 - request:
     method: put
     uri: http://backend:5352/source/my_project/_meta
@@ -87,7 +48,7 @@ http_interactions:
       encoding: UTF-8
       string: |
         <project name="my_project">
-          <title>The Wealth of Nations</title>
+          <title>Far From the Madding Crowd</title>
           <description/>
         </project>
     headers:
@@ -109,24 +70,24 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '108'
+      - '113'
     body:
       encoding: UTF-8
       string: |
         <project name="my_project">
-          <title>The Wealth of Nations</title>
+          <title>Far From the Madding Crowd</title>
           <description></description>
         </project>
     http_version: 
-  recorded_at: Wed, 09 Aug 2017 15:30:54 GMT
+  recorded_at: Tue, 16 Jan 2018 13:48:43 GMT
 - request:
     method: put
     uri: http://backend:5352/source/my_project/_config
     body:
       encoding: UTF-8
-      string: Laboriosam suscipit est dolorum minima ratione. Ipsam omnis tempore
-        aut voluptatem. Saepe voluptates est corrupti quia asperiores fuga. Sit sapiente
-        et tenetur ut qui.
+      string: Sunt praesentium assumenda. Sit in minus omnis aut distinctio. Accusantium
+        dolores modi dolorem repellat sint porro quae. Autem ut est deleniti odio
+        fuga.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -153,16 +114,16 @@ http_interactions:
 
 '
     http_version: 
-  recorded_at: Wed, 09 Aug 2017 15:30:55 GMT
+  recorded_at: Tue, 16 Jan 2018 13:48:43 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/my_project/first_package/_meta?user=admin
+    uri: http://backend:5352/source/my_project/first_package/_meta?user=_nobody_
     body:
       encoding: UTF-8
       string: |
         <package name="first_package" project="my_project">
-          <title>Blue Remembered Earth</title>
-          <description>Nulla sequi cupiditate vero at eligendi.</description>
+          <title>a</title>
+          <description>Illo doloremque vitae corporis quibusdam impedit.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -183,16 +144,16 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '172'
+      - '161'
     body:
       encoding: UTF-8
       string: |
         <package name="first_package" project="my_project">
-          <title>Blue Remembered Earth</title>
-          <description>Nulla sequi cupiditate vero at eligendi.</description>
+          <title>a</title>
+          <description>Illo doloremque vitae corporis quibusdam impedit.</description>
         </package>
     http_version: 
-  recorded_at: Wed, 09 Aug 2017 15:30:55 GMT
+  recorded_at: Tue, 16 Jan 2018 13:48:43 GMT
 - request:
     method: put
     uri: http://backend:5352/source/my_project/first_package/_meta
@@ -200,8 +161,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="first_package" project="my_project">
-          <title>Blue Remembered Earth</title>
-          <description>Nulla sequi cupiditate vero at eligendi.</description>
+          <title>a</title>
+          <description>Illo doloremque vitae corporis quibusdam impedit.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -222,24 +183,23 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '172'
+      - '161'
     body:
       encoding: UTF-8
       string: |
         <package name="first_package" project="my_project">
-          <title>Blue Remembered Earth</title>
-          <description>Nulla sequi cupiditate vero at eligendi.</description>
+          <title>a</title>
+          <description>Illo doloremque vitae corporis quibusdam impedit.</description>
         </package>
     http_version: 
-  recorded_at: Wed, 09 Aug 2017 15:30:55 GMT
+  recorded_at: Tue, 16 Jan 2018 13:48:43 GMT
 - request:
     method: put
     uri: http://backend:5352/source/my_project/first_package/_config
     body:
       encoding: UTF-8
-      string: Illo hic optio officia. Sequi asperiores facere. Sint aut sed ex iusto
-        nesciunt. Et omnis cumque enim vero perspiciatis. Amet sint qui quas sapiente
-        doloribus vel.
+      string: Possimus quidem sunt saepe itaque. Aspernatur sit quos enim exercitationem
+        et error fugiat. Laborum asperiores itaque natus totam.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -263,23 +223,23 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <revision rev="3" vrev="3">
-          <srcmd5>d372f928d74c3afc24e7682fd4357543</srcmd5>
+        <revision rev="1" vrev="1">
+          <srcmd5>65c13728d335958dc996714b1dfd16a1</srcmd5>
           <version>unknown</version>
-          <time>1502292655</time>
+          <time>1516110523</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
     http_version: 
-  recorded_at: Wed, 09 Aug 2017 15:30:55 GMT
+  recorded_at: Tue, 16 Jan 2018 13:48:43 GMT
 - request:
     method: put
     uri: http://backend:5352/source/my_project/first_package/somefile.txt
     body:
       encoding: UTF-8
-      string: Nisi ab cupiditate quibusdam ipsum cum. Sed dolor cum qui esse hic.
-        Quibusdam nam mollitia ipsa quam.
+      string: Autem laborum ratione. Porro ipsa provident et. Explicabo ipsa ipsum
+        odio quia. Rem ut eos animi non sit cupiditate nihil.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -303,25 +263,25 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <revision rev="4" vrev="4">
-          <srcmd5>9cac2d547ab86ade39a4906e28752ada</srcmd5>
+        <revision rev="2" vrev="2">
+          <srcmd5>269bbef83a23062aa9992a03d512861f</srcmd5>
           <version>unknown</version>
-          <time>1502292655</time>
+          <time>1516110523</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
     http_version: 
-  recorded_at: Wed, 09 Aug 2017 15:30:55 GMT
+  recorded_at: Tue, 16 Jan 2018 13:48:43 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/my_project/second_package/_meta?user=admin
+    uri: http://backend:5352/source/my_project/second_package/_meta?user=_nobody_
     body:
       encoding: UTF-8
       string: |
         <package name="second_package" project="my_project">
-          <title>Some Buried Caesar</title>
-          <description>Sint quis deleniti quibusdam.</description>
+          <title>c</title>
+          <description>Aut rerum ut sunt velit voluptates eius quia.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -342,16 +302,16 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '159'
+      - '158'
     body:
       encoding: UTF-8
       string: |
         <package name="second_package" project="my_project">
-          <title>Some Buried Caesar</title>
-          <description>Sint quis deleniti quibusdam.</description>
+          <title>c</title>
+          <description>Aut rerum ut sunt velit voluptates eius quia.</description>
         </package>
     http_version: 
-  recorded_at: Wed, 09 Aug 2017 15:30:55 GMT
+  recorded_at: Tue, 16 Jan 2018 13:48:43 GMT
 - request:
     method: put
     uri: http://backend:5352/source/my_project/second_package/_meta
@@ -359,8 +319,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="second_package" project="my_project">
-          <title>Some Buried Caesar</title>
-          <description>Sint quis deleniti quibusdam.</description>
+          <title>c</title>
+          <description>Aut rerum ut sunt velit voluptates eius quia.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -381,24 +341,24 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '159'
+      - '158'
     body:
       encoding: UTF-8
       string: |
         <package name="second_package" project="my_project">
-          <title>Some Buried Caesar</title>
-          <description>Sint quis deleniti quibusdam.</description>
+          <title>c</title>
+          <description>Aut rerum ut sunt velit voluptates eius quia.</description>
         </package>
     http_version: 
-  recorded_at: Wed, 09 Aug 2017 15:30:55 GMT
+  recorded_at: Tue, 16 Jan 2018 13:48:43 GMT
 - request:
     method: put
     uri: http://backend:5352/source/my_project/second_package/_config
     body:
       encoding: UTF-8
-      string: Qui molestias iure ipsum. Voluptatem exercitationem aut maxime excepturi.
-        Omnis minus debitis. Aliquam quo voluptas dolores illum. Saepe quas aut deleniti
-        aut eos atque.
+      string: Quas eius nobis facilis in qui voluptas. At mollitia ad tenetur corrupti.
+        Aut soluta maxime repudiandae autem dolores laborum eum. Et iure non soluta
+        voluptatem et non. Repellat ut voluptates alias.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -422,23 +382,23 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <revision rev="3" vrev="3">
-          <srcmd5>46e181b0ab81eeea98b966bbce13032c</srcmd5>
+        <revision rev="1" vrev="1">
+          <srcmd5>ba4f96f0bfb2e437319571ab1c1cb2a5</srcmd5>
           <version>unknown</version>
-          <time>1502292655</time>
+          <time>1516110523</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
     http_version: 
-  recorded_at: Wed, 09 Aug 2017 15:30:55 GMT
+  recorded_at: Tue, 16 Jan 2018 13:48:43 GMT
 - request:
     method: put
     uri: http://backend:5352/source/my_project/second_package/somefile.txt
     body:
       encoding: UTF-8
-      string: Ipsam illo dolore deserunt occaecati qui consequuntur. Totam quia occaecati
-        et quidem. Ut eaque tempore. Commodi cumque in deleniti esse rerum in totam.
+      string: Autem laborum ratione. Porro ipsa provident et. Explicabo ipsa ipsum
+        odio quia. Rem ut eos animi non sit cupiditate nihil.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -462,16 +422,368 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <revision rev="4" vrev="4">
-          <srcmd5>4c02f372ddcd5ea37fa6b9f87093cb44</srcmd5>
+        <revision rev="2" vrev="2">
+          <srcmd5>01194bd0c7190247902e6b6194c8e78f</srcmd5>
           <version>unknown</version>
-          <time>1502292655</time>
+          <time>1516110523</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
     http_version: 
-  recorded_at: Wed, 09 Aug 2017 15:30:55 GMT
+  recorded_at: Tue, 16 Jan 2018 13:48:43 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/my_project/third_package/_meta?user=_nobody_
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="third_package" project="my_project">
+          <title>b</title>
+          <description>Fugiat dignissimos sequi qui est iure porro non.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '160'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="third_package" project="my_project">
+          <title>b</title>
+          <description>Fugiat dignissimos sequi qui est iure porro non.</description>
+        </package>
+    http_version: 
+  recorded_at: Tue, 16 Jan 2018 13:48:43 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/my_project/third_package/_meta
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="third_package" project="my_project">
+          <title>b</title>
+          <description>Fugiat dignissimos sequi qui est iure porro non.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '160'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="third_package" project="my_project">
+          <title>b</title>
+          <description>Fugiat dignissimos sequi qui est iure porro non.</description>
+        </package>
+    http_version: 
+  recorded_at: Tue, 16 Jan 2018 13:48:43 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/my_project/third_package/_config
+    body:
+      encoding: UTF-8
+      string: Quibusdam ut ut eius non enim assumenda omnis. Itaque quidem ipsum aspernatur
+        quo. Ipsam repellat enim voluptates qui laborum est iste. Saepe dolore mollitia
+        quam assumenda natus ut et. Consequatur excepturi quo sed a dolores.
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '207'
+    body:
+      encoding: UTF-8
+      string: |
+        <revision rev="1" vrev="1">
+          <srcmd5>1b11e4c0066d29a6bc2219bf06a8d934</srcmd5>
+          <version>unknown</version>
+          <time>1516110523</time>
+          <user>unknown</user>
+          <comment></comment>
+          <requestid/>
+        </revision>
+    http_version: 
+  recorded_at: Tue, 16 Jan 2018 13:48:43 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/my_project/third_package/somefile.txt
+    body:
+      encoding: UTF-8
+      string: Autem laborum ratione. Porro ipsa provident et. Explicabo ipsa ipsum
+        odio quia. Rem ut eos animi non sit cupiditate nihil.
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '207'
+    body:
+      encoding: UTF-8
+      string: |
+        <revision rev="2" vrev="2">
+          <srcmd5>068171cebc6f0c3de1417feff046b786</srcmd5>
+          <version>unknown</version>
+          <time>1516110523</time>
+          <user>unknown</user>
+          <comment></comment>
+          <requestid/>
+        </revision>
+    http_version: 
+  recorded_at: Tue, 16 Jan 2018 13:48:43 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/my_project/package_with_kiwi_image/_meta?user=_nobody_
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="package_with_kiwi_image" project="my_project">
+          <title>Absalom, Absalom!</title>
+          <description>Repudiandae laborum molestiae ut cumque.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '178'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="package_with_kiwi_image" project="my_project">
+          <title>Absalom, Absalom!</title>
+          <description>Repudiandae laborum molestiae ut cumque.</description>
+        </package>
+    http_version: 
+  recorded_at: Tue, 16 Jan 2018 13:48:44 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/my_project/package_with_kiwi_image/_meta
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="package_with_kiwi_image" project="my_project">
+          <title>Absalom, Absalom!</title>
+          <description>Repudiandae laborum molestiae ut cumque.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '178'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="package_with_kiwi_image" project="my_project">
+          <title>Absalom, Absalom!</title>
+          <description>Repudiandae laborum molestiae ut cumque.</description>
+        </package>
+    http_version: 
+  recorded_at: Tue, 16 Jan 2018 13:48:44 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/my_project/package_with_kiwi_image/package_with_kiwi_image.kiwi
+    body:
+      encoding: UTF-8
+      string: "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n  <image schemaversion=\"6.2\"
+        name=\"suse-13.2-live\">\n    <description type=\"system\">\n    </description>\n
+        \   <preferences>\n      <type image=\"oem\" primary=\"true\" boot=\"oemboot/suse-13.2\"/>\n
+        \   </preferences>\n  </image>\n  "
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '207'
+    body:
+      encoding: UTF-8
+      string: |
+        <revision rev="1" vrev="1">
+          <srcmd5>e79574ec95865487aedacea760376ee3</srcmd5>
+          <version>unknown</version>
+          <time>1516110524</time>
+          <user>unknown</user>
+          <comment></comment>
+          <requestid/>
+        </revision>
+    http_version: 
+  recorded_at: Tue, 16 Jan 2018 13:48:44 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/my_project/package_with_kiwi_image/_meta?user=_nobody_
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="package_with_kiwi_image" project="my_project">
+          <title>Absalom, Absalom!</title>
+          <description>Repudiandae laborum molestiae ut cumque.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '178'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="package_with_kiwi_image" project="my_project">
+          <title>Absalom, Absalom!</title>
+          <description>Repudiandae laborum molestiae ut cumque.</description>
+        </package>
+    http_version: 
+  recorded_at: Tue, 16 Jan 2018 13:48:44 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/my_project/package_with_kiwi_image
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '232'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="package_with_kiwi_image" rev="1" vrev="1" srcmd5="e79574ec95865487aedacea760376ee3">
+          <entry name="package_with_kiwi_image.kiwi" md5="5f2d7b5465fbb78bd2d0a30c224f4254" size="258" mtime="1516110524" />
+        </directory>
+    http_version: 
+  recorded_at: Tue, 16 Jan 2018 13:48:44 GMT
 - request:
     method: get
     uri: http://backend:5352/source/my_project/first_package
@@ -501,12 +813,12 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="first_package" rev="4" vrev="4" srcmd5="9cac2d547ab86ade39a4906e28752ada">
-          <entry name="_config" md5="14a142b8c8ec8157ef3b2fd7f17edec1" size="163" mtime="1502292655" />
-          <entry name="somefile.txt" md5="c83630db713cfc2eeee8b1b8eb1ef574" size="101" mtime="1502292655" />
+        <directory name="first_package" rev="2" vrev="2" srcmd5="269bbef83a23062aa9992a03d512861f">
+          <entry name="_config" md5="b67a253069bb6d1f80ea8e3168aaf6d1" size="130" mtime="1516110523" />
+          <entry name="somefile.txt" md5="de916512f7577e6a70f2b9971456a7ab" size="122" mtime="1516110523" />
         </directory>
     http_version: 
-  recorded_at: Wed, 09 Aug 2017 15:30:55 GMT
+  recorded_at: Tue, 16 Jan 2018 13:48:44 GMT
 - request:
     method: get
     uri: http://backend:5352/source/my_project/first_package
@@ -536,12 +848,12 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="first_package" rev="4" vrev="4" srcmd5="9cac2d547ab86ade39a4906e28752ada">
-          <entry name="_config" md5="14a142b8c8ec8157ef3b2fd7f17edec1" size="163" mtime="1502292655" />
-          <entry name="somefile.txt" md5="c83630db713cfc2eeee8b1b8eb1ef574" size="101" mtime="1502292655" />
+        <directory name="first_package" rev="2" vrev="2" srcmd5="269bbef83a23062aa9992a03d512861f">
+          <entry name="_config" md5="b67a253069bb6d1f80ea8e3168aaf6d1" size="130" mtime="1516110523" />
+          <entry name="somefile.txt" md5="de916512f7577e6a70f2b9971456a7ab" size="122" mtime="1516110523" />
         </directory>
     http_version: 
-  recorded_at: Wed, 09 Aug 2017 15:30:55 GMT
+  recorded_at: Tue, 16 Jan 2018 13:48:44 GMT
 - request:
     method: get
     uri: http://backend:5352/source/my_project/second_package
@@ -571,12 +883,12 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="second_package" rev="4" vrev="4" srcmd5="4c02f372ddcd5ea37fa6b9f87093cb44">
-          <entry name="_config" md5="11e44aa1c2a2e366b85a5db50ac7a716" size="169" mtime="1502292655" />
-          <entry name="somefile.txt" md5="c1e0265cf291873d2d6e86092f1e1138" size="152" mtime="1502292655" />
+        <directory name="second_package" rev="2" vrev="2" srcmd5="01194bd0c7190247902e6b6194c8e78f">
+          <entry name="_config" md5="27e7ef04c01f0aab8e5faac8aab0dfce" size="198" mtime="1516110523" />
+          <entry name="somefile.txt" md5="de916512f7577e6a70f2b9971456a7ab" size="122" mtime="1516110523" />
         </directory>
     http_version: 
-  recorded_at: Wed, 09 Aug 2017 15:30:55 GMT
+  recorded_at: Tue, 16 Jan 2018 13:48:45 GMT
 - request:
     method: get
     uri: http://backend:5352/source/my_project/second_package
@@ -606,12 +918,206 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="second_package" rev="4" vrev="4" srcmd5="4c02f372ddcd5ea37fa6b9f87093cb44">
-          <entry name="_config" md5="11e44aa1c2a2e366b85a5db50ac7a716" size="169" mtime="1502292655" />
-          <entry name="somefile.txt" md5="c1e0265cf291873d2d6e86092f1e1138" size="152" mtime="1502292655" />
+        <directory name="second_package" rev="2" vrev="2" srcmd5="01194bd0c7190247902e6b6194c8e78f">
+          <entry name="_config" md5="27e7ef04c01f0aab8e5faac8aab0dfce" size="198" mtime="1516110523" />
+          <entry name="somefile.txt" md5="de916512f7577e6a70f2b9971456a7ab" size="122" mtime="1516110523" />
         </directory>
     http_version: 
-  recorded_at: Wed, 09 Aug 2017 15:30:55 GMT
+  recorded_at: Tue, 16 Jan 2018 13:48:45 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/my_project/third_package
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '302'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="third_package" rev="2" vrev="2" srcmd5="068171cebc6f0c3de1417feff046b786">
+          <entry name="_config" md5="e57827649b5995ba90890d95b056f7d1" size="226" mtime="1516110523" />
+          <entry name="somefile.txt" md5="de916512f7577e6a70f2b9971456a7ab" size="122" mtime="1516110523" />
+        </directory>
+    http_version: 
+  recorded_at: Tue, 16 Jan 2018 13:48:45 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/my_project/third_package
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '302'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="third_package" rev="2" vrev="2" srcmd5="068171cebc6f0c3de1417feff046b786">
+          <entry name="_config" md5="e57827649b5995ba90890d95b056f7d1" size="226" mtime="1516110523" />
+          <entry name="somefile.txt" md5="de916512f7577e6a70f2b9971456a7ab" size="122" mtime="1516110523" />
+        </directory>
+    http_version: 
+  recorded_at: Tue, 16 Jan 2018 13:48:45 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/my_project/package_with_kiwi_image
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '232'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="package_with_kiwi_image" rev="1" vrev="1" srcmd5="e79574ec95865487aedacea760376ee3">
+          <entry name="package_with_kiwi_image.kiwi" md5="5f2d7b5465fbb78bd2d0a30c224f4254" size="258" mtime="1516110524" />
+        </directory>
+    http_version: 
+  recorded_at: Tue, 16 Jan 2018 13:48:45 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/my_project/package_with_kiwi_image
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '232'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="package_with_kiwi_image" rev="1" vrev="1" srcmd5="e79574ec95865487aedacea760376ee3">
+          <entry name="package_with_kiwi_image.kiwi" md5="5f2d7b5465fbb78bd2d0a30c224f4254" size="258" mtime="1516110524" />
+        </directory>
+    http_version: 
+  recorded_at: Tue, 16 Jan 2018 13:48:45 GMT
+- request:
+    method: get
+    uri: http://backend:5352/build/_workerstatus
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '1207'
+    body:
+      encoding: UTF-8
+      string: |
+        <workerstatus clients="2">
+          <idle workerid="ffe1e8f4c02a:1" hostarch="x86_64" />
+          <idle workerid="ffe1e8f4c02a:2" hostarch="x86_64" />
+          <waiting arch="i586" jobs="0" />
+          <waiting arch="x86_64" jobs="0" />
+          <blocked arch="i586" jobs="0" />
+          <blocked arch="x86_64" jobs="0" />
+          <buildavg arch="i586" buildavg="1200" />
+          <buildavg arch="x86_64" buildavg="1200" />
+          <partition>
+            <daemon type="srcserver" state="running" starttime="1516110322" />
+            <daemon type="servicedispatch" state="running" starttime="1516110328" />
+            <daemon type="service" state="running" starttime="1516110328" />
+            <daemon type="scheduler" arch="i586" state="running" starttime="1516110328">
+              <queue high="0" med="0" low="22" next="0" />
+            </daemon>
+            <daemon type="scheduler" arch="x86_64" state="running" starttime="1516110328">
+              <queue high="0" med="0" low="22" next="0" />
+            </daemon>
+            <daemon type="repserver" state="running" starttime="1516110326" />
+            <daemon type="dispatcher" state="running" starttime="1516110328" />
+            <daemon type="publisher" state="running" starttime="1516110328" />
+            <daemon type="signer" state="running" starttime="1516110328" />
+          </partition>
+        </workerstatus>
+    http_version: 
+  recorded_at: Tue, 16 Jan 2018 13:48:46 GMT
 - request:
     method: get
     uri: http://backend:5352/source/my_project/first_package
@@ -641,12 +1147,12 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="first_package" rev="4" vrev="4" srcmd5="9cac2d547ab86ade39a4906e28752ada">
-          <entry name="_config" md5="14a142b8c8ec8157ef3b2fd7f17edec1" size="163" mtime="1502292655" />
-          <entry name="somefile.txt" md5="c83630db713cfc2eeee8b1b8eb1ef574" size="101" mtime="1502292655" />
+        <directory name="first_package" rev="2" vrev="2" srcmd5="269bbef83a23062aa9992a03d512861f">
+          <entry name="_config" md5="b67a253069bb6d1f80ea8e3168aaf6d1" size="130" mtime="1516110523" />
+          <entry name="somefile.txt" md5="de916512f7577e6a70f2b9971456a7ab" size="122" mtime="1516110523" />
         </directory>
     http_version: 
-  recorded_at: Wed, 09 Aug 2017 15:30:57 GMT
+  recorded_at: Tue, 16 Jan 2018 13:48:46 GMT
 - request:
     method: get
     uri: http://backend:5352/source/my_project/first_package
@@ -676,12 +1182,12 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="first_package" rev="4" vrev="4" srcmd5="9cac2d547ab86ade39a4906e28752ada">
-          <entry name="_config" md5="14a142b8c8ec8157ef3b2fd7f17edec1" size="163" mtime="1502292655" />
-          <entry name="somefile.txt" md5="c83630db713cfc2eeee8b1b8eb1ef574" size="101" mtime="1502292655" />
+        <directory name="first_package" rev="2" vrev="2" srcmd5="269bbef83a23062aa9992a03d512861f">
+          <entry name="_config" md5="b67a253069bb6d1f80ea8e3168aaf6d1" size="130" mtime="1516110523" />
+          <entry name="somefile.txt" md5="de916512f7577e6a70f2b9971456a7ab" size="122" mtime="1516110523" />
         </directory>
     http_version: 
-  recorded_at: Wed, 09 Aug 2017 15:30:58 GMT
+  recorded_at: Tue, 16 Jan 2018 13:48:46 GMT
 - request:
     method: get
     uri: http://backend:5352/source/my_project/second_package
@@ -711,12 +1217,12 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="second_package" rev="4" vrev="4" srcmd5="4c02f372ddcd5ea37fa6b9f87093cb44">
-          <entry name="_config" md5="11e44aa1c2a2e366b85a5db50ac7a716" size="169" mtime="1502292655" />
-          <entry name="somefile.txt" md5="c1e0265cf291873d2d6e86092f1e1138" size="152" mtime="1502292655" />
+        <directory name="second_package" rev="2" vrev="2" srcmd5="01194bd0c7190247902e6b6194c8e78f">
+          <entry name="_config" md5="27e7ef04c01f0aab8e5faac8aab0dfce" size="198" mtime="1516110523" />
+          <entry name="somefile.txt" md5="de916512f7577e6a70f2b9971456a7ab" size="122" mtime="1516110523" />
         </directory>
     http_version: 
-  recorded_at: Wed, 09 Aug 2017 15:30:58 GMT
+  recorded_at: Tue, 16 Jan 2018 13:48:46 GMT
 - request:
     method: get
     uri: http://backend:5352/source/my_project/second_package
@@ -746,12 +1252,150 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="second_package" rev="4" vrev="4" srcmd5="4c02f372ddcd5ea37fa6b9f87093cb44">
-          <entry name="_config" md5="11e44aa1c2a2e366b85a5db50ac7a716" size="169" mtime="1502292655" />
-          <entry name="somefile.txt" md5="c1e0265cf291873d2d6e86092f1e1138" size="152" mtime="1502292655" />
+        <directory name="second_package" rev="2" vrev="2" srcmd5="01194bd0c7190247902e6b6194c8e78f">
+          <entry name="_config" md5="27e7ef04c01f0aab8e5faac8aab0dfce" size="198" mtime="1516110523" />
+          <entry name="somefile.txt" md5="de916512f7577e6a70f2b9971456a7ab" size="122" mtime="1516110523" />
         </directory>
     http_version: 
-  recorded_at: Wed, 09 Aug 2017 15:30:58 GMT
+  recorded_at: Tue, 16 Jan 2018 13:48:46 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/my_project/third_package
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '302'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="third_package" rev="2" vrev="2" srcmd5="068171cebc6f0c3de1417feff046b786">
+          <entry name="_config" md5="e57827649b5995ba90890d95b056f7d1" size="226" mtime="1516110523" />
+          <entry name="somefile.txt" md5="de916512f7577e6a70f2b9971456a7ab" size="122" mtime="1516110523" />
+        </directory>
+    http_version: 
+  recorded_at: Tue, 16 Jan 2018 13:48:46 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/my_project/third_package
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '302'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="third_package" rev="2" vrev="2" srcmd5="068171cebc6f0c3de1417feff046b786">
+          <entry name="_config" md5="e57827649b5995ba90890d95b056f7d1" size="226" mtime="1516110523" />
+          <entry name="somefile.txt" md5="de916512f7577e6a70f2b9971456a7ab" size="122" mtime="1516110523" />
+        </directory>
+    http_version: 
+  recorded_at: Tue, 16 Jan 2018 13:48:46 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/my_project/package_with_kiwi_image
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '232'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="package_with_kiwi_image" rev="1" vrev="1" srcmd5="e79574ec95865487aedacea760376ee3">
+          <entry name="package_with_kiwi_image.kiwi" md5="5f2d7b5465fbb78bd2d0a30c224f4254" size="258" mtime="1516110524" />
+        </directory>
+    http_version: 
+  recorded_at: Tue, 16 Jan 2018 13:48:46 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/my_project/package_with_kiwi_image
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '232'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="package_with_kiwi_image" rev="1" vrev="1" srcmd5="e79574ec95865487aedacea760376ee3">
+          <entry name="package_with_kiwi_image.kiwi" md5="5f2d7b5465fbb78bd2d0a30c224f4254" size="258" mtime="1516110524" />
+        </directory>
+    http_version: 
+  recorded_at: Tue, 16 Jan 2018 13:48:46 GMT
 - request:
     method: get
     uri: http://backend:5352/source/my_project/second_package?expand=1
@@ -781,15 +1425,15 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="second_package" rev="4" vrev="4" srcmd5="4c02f372ddcd5ea37fa6b9f87093cb44">
-          <entry name="_config" md5="11e44aa1c2a2e366b85a5db50ac7a716" size="169" mtime="1502292655" />
-          <entry name="somefile.txt" md5="c1e0265cf291873d2d6e86092f1e1138" size="152" mtime="1502292655" />
+        <directory name="second_package" rev="2" vrev="2" srcmd5="01194bd0c7190247902e6b6194c8e78f">
+          <entry name="_config" md5="27e7ef04c01f0aab8e5faac8aab0dfce" size="198" mtime="1516110523" />
+          <entry name="somefile.txt" md5="de916512f7577e6a70f2b9971456a7ab" size="122" mtime="1516110523" />
         </directory>
     http_version: 
-  recorded_at: Wed, 09 Aug 2017 15:30:58 GMT
+  recorded_at: Tue, 16 Jan 2018 13:48:47 GMT
 - request:
     method: get
-    uri: http://backend:5352/source/my_project/second_package?rev=4
+    uri: http://backend:5352/source/my_project/second_package?rev=2
     body:
       encoding: US-ASCII
       string: ''
@@ -818,12 +1462,12 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="second_package" rev="4" vrev="4" srcmd5="4c02f372ddcd5ea37fa6b9f87093cb44">
-          <entry name="_config" md5="11e44aa1c2a2e366b85a5db50ac7a716" size="169" mtime="1502292655" />
-          <entry name="somefile.txt" md5="c1e0265cf291873d2d6e86092f1e1138" size="152" mtime="1502292655" />
+        <directory name="second_package" rev="2" vrev="2" srcmd5="01194bd0c7190247902e6b6194c8e78f">
+          <entry name="_config" md5="27e7ef04c01f0aab8e5faac8aab0dfce" size="198" mtime="1516110523" />
+          <entry name="somefile.txt" md5="de916512f7577e6a70f2b9971456a7ab" size="122" mtime="1516110523" />
         </directory>
     http_version: 
-  recorded_at: Wed, 09 Aug 2017 15:30:58 GMT
+  recorded_at: Tue, 16 Jan 2018 13:48:47 GMT
 - request:
     method: post
     uri: http://backend:5352/search/package/id?match=(linkinfo/@package=%22second_package%22%20and%20linkinfo/@project=%22my_project%22%20and%20@project=%22my_project%22)
@@ -858,7 +1502,7 @@ http_interactions:
         <collection>
         </collection>
     http_version: 
-  recorded_at: Wed, 09 Aug 2017 15:30:58 GMT
+  recorded_at: Tue, 16 Jan 2018 13:48:47 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom:branches:my_project/_meta?user=tom
@@ -899,7 +1543,7 @@ http_interactions:
           <person userid="tom" role="maintainer" />
         </project>
     http_version: 
-  recorded_at: Wed, 09 Aug 2017 15:30:58 GMT
+  recorded_at: Tue, 16 Jan 2018 13:48:47 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom:branches:my_project/custom_name/_meta?user=tom
@@ -907,8 +1551,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="custom_name" project="home:tom:branches:my_project">
-          <title>Some Buried Caesar</title>
-          <description>Sint quis deleniti quibusdam.</description>
+          <title>c</title>
+          <description>Aut rerum ut sunt velit voluptates eius quia.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -929,19 +1573,19 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '174'
+      - '173'
     body:
       encoding: UTF-8
       string: |
         <package name="custom_name" project="home:tom:branches:my_project">
-          <title>Some Buried Caesar</title>
-          <description>Sint quis deleniti quibusdam.</description>
+          <title>c</title>
+          <description>Aut rerum ut sunt velit voluptates eius quia.</description>
         </package>
     http_version: 
-  recorded_at: Wed, 09 Aug 2017 15:30:59 GMT
+  recorded_at: Tue, 16 Jan 2018 13:48:47 GMT
 - request:
     method: post
-    uri: http://backend:5352/source/home:tom:branches:my_project/custom_name?cmd=branch&opackage=second_package&oproject=my_project&orev=4c02f372ddcd5ea37fa6b9f87093cb44&user=tom
+    uri: http://backend:5352/source/home:tom:branches:my_project/custom_name?cmd=branch&noservice=1&opackage=second_package&oproject=my_project&orev=01194bd0c7190247902e6b6194c8e78f&user=tom
     body:
       encoding: UTF-8
       string: ''
@@ -970,16 +1614,16 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <revision rev="2" vrev="2">
-          <srcmd5>c6281b321c53e45f4e7b27837f13db44</srcmd5>
+        <revision rev="1" vrev="1">
+          <srcmd5>b2d194240ea2c7d223a28557d86c86c2</srcmd5>
           <version>unknown</version>
-          <time>1502292659</time>
+          <time>1516110527</time>
           <user>tom</user>
           <comment></comment>
           <requestid/>
         </revision>
     http_version: 
-  recorded_at: Wed, 09 Aug 2017 15:30:59 GMT
+  recorded_at: Tue, 16 Jan 2018 13:48:47 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom:branches:my_project/custom_name/_meta?user=tom
@@ -987,8 +1631,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="custom_name" project="home:tom:branches:my_project">
-          <title>Some Buried Caesar</title>
-          <description>Sint quis deleniti quibusdam.</description>
+          <title>c</title>
+          <description>Aut rerum ut sunt velit voluptates eius quia.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -1009,16 +1653,16 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '174'
+      - '173'
     body:
       encoding: UTF-8
       string: |
         <package name="custom_name" project="home:tom:branches:my_project">
-          <title>Some Buried Caesar</title>
-          <description>Sint quis deleniti quibusdam.</description>
+          <title>c</title>
+          <description>Aut rerum ut sunt velit voluptates eius quia.</description>
         </package>
     http_version: 
-  recorded_at: Wed, 09 Aug 2017 15:30:59 GMT
+  recorded_at: Tue, 16 Jan 2018 13:48:47 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:tom:branches:my_project/custom_name
@@ -1048,14 +1692,14 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="custom_name" rev="2" vrev="2" srcmd5="c6281b321c53e45f4e7b27837f13db44">
-          <linkinfo project="my_project" package="second_package" rev="4c02f372ddcd5ea37fa6b9f87093cb44" srcmd5="4c02f372ddcd5ea37fa6b9f87093cb44" baserev="4c02f372ddcd5ea37fa6b9f87093cb44" xsrcmd5="320921ea456ac54fc662cd37c6d6b5a5" lsrcmd5="c6281b321c53e45f4e7b27837f13db44" />
-          <entry name="_config" md5="11e44aa1c2a2e366b85a5db50ac7a716" size="169" mtime="1502292655" />
-          <entry name="_link" md5="06fbed7764b8a646ffcbf2a34dbcc7c6" size="182" mtime="1502292659" />
-          <entry name="somefile.txt" md5="c1e0265cf291873d2d6e86092f1e1138" size="152" mtime="1502292655" />
+        <directory name="custom_name" rev="1" vrev="1" srcmd5="b2d194240ea2c7d223a28557d86c86c2">
+          <linkinfo project="my_project" package="second_package" rev="01194bd0c7190247902e6b6194c8e78f" srcmd5="01194bd0c7190247902e6b6194c8e78f" baserev="01194bd0c7190247902e6b6194c8e78f" xsrcmd5="72faca690753c4fea207c633cc47939a" lsrcmd5="b2d194240ea2c7d223a28557d86c86c2" />
+          <entry name="_config" md5="27e7ef04c01f0aab8e5faac8aab0dfce" size="198" mtime="1516110523" />
+          <entry name="_link" md5="fddf5d7ba78517188703272b436dc500" size="182" mtime="1516110527" />
+          <entry name="somefile.txt" md5="de916512f7577e6a70f2b9971456a7ab" size="122" mtime="1516110523" />
         </directory>
     http_version: 
-  recorded_at: Wed, 09 Aug 2017 15:30:59 GMT
+  recorded_at: Tue, 16 Jan 2018 13:48:47 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:tom:branches:my_project/custom_name?nofilename=1&view=info&withchangesmd5=1
@@ -1085,12 +1729,12 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <sourceinfo package="custom_name" rev="2" vrev="2" srcmd5="320921ea456ac54fc662cd37c6d6b5a5" lsrcmd5="c6281b321c53e45f4e7b27837f13db44" verifymd5="4c02f372ddcd5ea37fa6b9f87093cb44">
+        <sourceinfo package="custom_name" rev="1" vrev="1" srcmd5="72faca690753c4fea207c633cc47939a" lsrcmd5="b2d194240ea2c7d223a28557d86c86c2" verifymd5="01194bd0c7190247902e6b6194c8e78f">
           <linked project="my_project" package="second_package" />
-          <revtime>1502292659</revtime>
+          <revtime>1516110527</revtime>
         </sourceinfo>
     http_version: 
-  recorded_at: Wed, 09 Aug 2017 15:30:59 GMT
+  recorded_at: Tue, 16 Jan 2018 13:48:47 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:tom:branches:my_project/custom_name
@@ -1120,14 +1764,14 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="custom_name" rev="2" vrev="2" srcmd5="c6281b321c53e45f4e7b27837f13db44">
-          <linkinfo project="my_project" package="second_package" rev="4c02f372ddcd5ea37fa6b9f87093cb44" srcmd5="4c02f372ddcd5ea37fa6b9f87093cb44" baserev="4c02f372ddcd5ea37fa6b9f87093cb44" xsrcmd5="320921ea456ac54fc662cd37c6d6b5a5" lsrcmd5="c6281b321c53e45f4e7b27837f13db44" />
-          <entry name="_config" md5="11e44aa1c2a2e366b85a5db50ac7a716" size="169" mtime="1502292655" />
-          <entry name="_link" md5="06fbed7764b8a646ffcbf2a34dbcc7c6" size="182" mtime="1502292659" />
-          <entry name="somefile.txt" md5="c1e0265cf291873d2d6e86092f1e1138" size="152" mtime="1502292655" />
+        <directory name="custom_name" rev="1" vrev="1" srcmd5="b2d194240ea2c7d223a28557d86c86c2">
+          <linkinfo project="my_project" package="second_package" rev="01194bd0c7190247902e6b6194c8e78f" srcmd5="01194bd0c7190247902e6b6194c8e78f" baserev="01194bd0c7190247902e6b6194c8e78f" xsrcmd5="72faca690753c4fea207c633cc47939a" lsrcmd5="b2d194240ea2c7d223a28557d86c86c2" />
+          <entry name="_config" md5="27e7ef04c01f0aab8e5faac8aab0dfce" size="198" mtime="1516110523" />
+          <entry name="_link" md5="fddf5d7ba78517188703272b436dc500" size="182" mtime="1516110527" />
+          <entry name="somefile.txt" md5="de916512f7577e6a70f2b9971456a7ab" size="122" mtime="1516110523" />
         </directory>
     http_version: 
-  recorded_at: Wed, 09 Aug 2017 15:30:59 GMT
+  recorded_at: Tue, 16 Jan 2018 13:48:47 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:tom:branches:my_project/custom_name?cmd=diff&linkrev=base&onlyissues=1&orev=0&view=xml
@@ -1159,15 +1803,15 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="07b37b675e90553360d2bdb239b8035d">
+        <sourcediff key="6e922c84584cf7d033ed0c7c422671ae">
           <old project="home:tom:branches:my_project" package="custom_name" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e" />
-          <new project="home:tom:branches:my_project" package="custom_name" rev="2" srcmd5="c6281b321c53e45f4e7b27837f13db44" />
+          <new project="home:tom:branches:my_project" package="custom_name" rev="1" srcmd5="b2d194240ea2c7d223a28557d86c86c2" />
           <files />
           <issues>
           </issues>
         </sourcediff>
     http_version: 
-  recorded_at: Wed, 09 Aug 2017 15:30:59 GMT
+  recorded_at: Tue, 16 Jan 2018 13:48:47 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:tom:branches:my_project/custom_name?cmd=linkdiff&linkrev=base&onlyissues=1&view=xml
@@ -1199,13 +1843,13 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="168d62a2cb20149f1ddbe999a475f910">
-          <old project="my_project" package="second_package" rev="4c02f372ddcd5ea37fa6b9f87093cb44" srcmd5="4c02f372ddcd5ea37fa6b9f87093cb44" />
-          <new project="home:tom:branches:my_project" package="custom_name" rev="320921ea456ac54fc662cd37c6d6b5a5" srcmd5="320921ea456ac54fc662cd37c6d6b5a5" />
+        <sourcediff key="00583c98c246bbd217fd7249477742f1">
+          <old project="my_project" package="second_package" rev="01194bd0c7190247902e6b6194c8e78f" srcmd5="01194bd0c7190247902e6b6194c8e78f" />
+          <new project="home:tom:branches:my_project" package="custom_name" rev="72faca690753c4fea207c633cc47939a" srcmd5="72faca690753c4fea207c633cc47939a" />
           <files />
         </sourcediff>
     http_version: 
-  recorded_at: Wed, 09 Aug 2017 15:30:59 GMT
+  recorded_at: Tue, 16 Jan 2018 13:48:47 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom:branches:my_project/_meta?user=tom
@@ -1252,7 +1896,44 @@ http_interactions:
           </publish>
         </project>
     http_version: 
-  recorded_at: Wed, 09 Aug 2017 15:31:00 GMT
+  recorded_at: Tue, 16 Jan 2018 13:48:47 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:tom:branches:my_project/custom_name
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '665'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="custom_name" rev="1" vrev="1" srcmd5="b2d194240ea2c7d223a28557d86c86c2">
+          <linkinfo project="my_project" package="second_package" rev="01194bd0c7190247902e6b6194c8e78f" srcmd5="01194bd0c7190247902e6b6194c8e78f" baserev="01194bd0c7190247902e6b6194c8e78f" xsrcmd5="72faca690753c4fea207c633cc47939a" lsrcmd5="b2d194240ea2c7d223a28557d86c86c2" />
+          <entry name="_config" md5="27e7ef04c01f0aab8e5faac8aab0dfce" size="198" mtime="1516110523" />
+          <entry name="_link" md5="fddf5d7ba78517188703272b436dc500" size="182" mtime="1516110527" />
+          <entry name="somefile.txt" md5="de916512f7577e6a70f2b9971456a7ab" size="122" mtime="1516110523" />
+        </directory>
+    http_version: 
+  recorded_at: Tue, 16 Jan 2018 13:48:47 GMT
 - request:
     method: get
     uri: http://backend:5352/source/my_project/second_package?nofilename=1&view=info&withchangesmd5=1
@@ -1282,11 +1963,11 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <sourceinfo package="second_package" rev="4" vrev="4" srcmd5="4c02f372ddcd5ea37fa6b9f87093cb44" verifymd5="4c02f372ddcd5ea37fa6b9f87093cb44">
-          <revtime>1502292655</revtime>
+        <sourceinfo package="second_package" rev="2" vrev="2" srcmd5="01194bd0c7190247902e6b6194c8e78f" verifymd5="01194bd0c7190247902e6b6194c8e78f">
+          <revtime>1516110523</revtime>
         </sourceinfo>
     http_version: 
-  recorded_at: Wed, 09 Aug 2017 15:31:00 GMT
+  recorded_at: Tue, 16 Jan 2018 13:48:47 GMT
 - request:
     method: get
     uri: http://backend:5352/source/my_project/second_package
@@ -1316,12 +1997,12 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="second_package" rev="4" vrev="4" srcmd5="4c02f372ddcd5ea37fa6b9f87093cb44">
-          <entry name="_config" md5="11e44aa1c2a2e366b85a5db50ac7a716" size="169" mtime="1502292655" />
-          <entry name="somefile.txt" md5="c1e0265cf291873d2d6e86092f1e1138" size="152" mtime="1502292655" />
+        <directory name="second_package" rev="2" vrev="2" srcmd5="01194bd0c7190247902e6b6194c8e78f">
+          <entry name="_config" md5="27e7ef04c01f0aab8e5faac8aab0dfce" size="198" mtime="1516110523" />
+          <entry name="somefile.txt" md5="de916512f7577e6a70f2b9971456a7ab" size="122" mtime="1516110523" />
         </directory>
     http_version: 
-  recorded_at: Wed, 09 Aug 2017 15:31:00 GMT
+  recorded_at: Tue, 16 Jan 2018 13:48:47 GMT
 - request:
     method: post
     uri: http://backend:5352/source/my_project/second_package?cmd=diff&linkrev=base&onlyissues=1&orev=0&view=xml
@@ -1353,15 +2034,15 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="dec838dd1562943ab4969157921db775">
+        <sourcediff key="fd4995a0f8dd68c0eb7e5e2045e11108">
           <old project="my_project" package="second_package" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e" />
-          <new project="my_project" package="second_package" rev="4" srcmd5="4c02f372ddcd5ea37fa6b9f87093cb44" />
+          <new project="my_project" package="second_package" rev="2" srcmd5="01194bd0c7190247902e6b6194c8e78f" />
           <files />
           <issues>
           </issues>
         </sourcediff>
     http_version: 
-  recorded_at: Wed, 09 Aug 2017 15:31:00 GMT
+  recorded_at: Tue, 16 Jan 2018 13:48:47 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:tom:branches:my_project/custom_name
@@ -1391,17 +2072,17 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="custom_name" rev="2" vrev="2" srcmd5="c6281b321c53e45f4e7b27837f13db44">
-          <linkinfo project="my_project" package="second_package" rev="4c02f372ddcd5ea37fa6b9f87093cb44" srcmd5="4c02f372ddcd5ea37fa6b9f87093cb44" baserev="4c02f372ddcd5ea37fa6b9f87093cb44" xsrcmd5="320921ea456ac54fc662cd37c6d6b5a5" lsrcmd5="c6281b321c53e45f4e7b27837f13db44" />
-          <entry name="_config" md5="11e44aa1c2a2e366b85a5db50ac7a716" size="169" mtime="1502292655" />
-          <entry name="_link" md5="06fbed7764b8a646ffcbf2a34dbcc7c6" size="182" mtime="1502292659" />
-          <entry name="somefile.txt" md5="c1e0265cf291873d2d6e86092f1e1138" size="152" mtime="1502292655" />
+        <directory name="custom_name" rev="1" vrev="1" srcmd5="b2d194240ea2c7d223a28557d86c86c2">
+          <linkinfo project="my_project" package="second_package" rev="01194bd0c7190247902e6b6194c8e78f" srcmd5="01194bd0c7190247902e6b6194c8e78f" baserev="01194bd0c7190247902e6b6194c8e78f" xsrcmd5="72faca690753c4fea207c633cc47939a" lsrcmd5="b2d194240ea2c7d223a28557d86c86c2" />
+          <entry name="_config" md5="27e7ef04c01f0aab8e5faac8aab0dfce" size="198" mtime="1516110523" />
+          <entry name="_link" md5="fddf5d7ba78517188703272b436dc500" size="182" mtime="1516110527" />
+          <entry name="somefile.txt" md5="de916512f7577e6a70f2b9971456a7ab" size="122" mtime="1516110523" />
         </directory>
     http_version: 
-  recorded_at: Wed, 09 Aug 2017 15:31:00 GMT
+  recorded_at: Tue, 16 Jan 2018 13:48:47 GMT
 - request:
     method: get
-    uri: http://backend:5352/source/home:tom:branches:my_project/custom_name?expand=1&rev=2
+    uri: http://backend:5352/source/home:tom:branches:my_project/custom_name?expand=1&rev=1
     body:
       encoding: US-ASCII
       string: ''
@@ -1428,13 +2109,13 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="custom_name" rev="320921ea456ac54fc662cd37c6d6b5a5" vrev="2" srcmd5="320921ea456ac54fc662cd37c6d6b5a5">
-          <linkinfo project="my_project" package="second_package" rev="4c02f372ddcd5ea37fa6b9f87093cb44" srcmd5="4c02f372ddcd5ea37fa6b9f87093cb44" baserev="4c02f372ddcd5ea37fa6b9f87093cb44" lsrcmd5="c6281b321c53e45f4e7b27837f13db44" />
-          <entry name="_config" md5="11e44aa1c2a2e366b85a5db50ac7a716" size="169" mtime="1502292655" />
-          <entry name="somefile.txt" md5="c1e0265cf291873d2d6e86092f1e1138" size="152" mtime="1502292655" />
+        <directory name="custom_name" rev="72faca690753c4fea207c633cc47939a" vrev="1" srcmd5="72faca690753c4fea207c633cc47939a">
+          <linkinfo project="my_project" package="second_package" rev="01194bd0c7190247902e6b6194c8e78f" srcmd5="01194bd0c7190247902e6b6194c8e78f" baserev="01194bd0c7190247902e6b6194c8e78f" lsrcmd5="b2d194240ea2c7d223a28557d86c86c2" />
+          <entry name="_config" md5="27e7ef04c01f0aab8e5faac8aab0dfce" size="198" mtime="1516110523" />
+          <entry name="somefile.txt" md5="de916512f7577e6a70f2b9971456a7ab" size="122" mtime="1516110523" />
         </directory>
     http_version: 
-  recorded_at: Wed, 09 Aug 2017 15:31:00 GMT
+  recorded_at: Tue, 16 Jan 2018 13:48:47 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:tom:branches:my_project/custom_name
@@ -1466,14 +2147,14 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="custom_name" rev="2" vrev="2" srcmd5="c6281b321c53e45f4e7b27837f13db44">
-          <linkinfo project="my_project" package="second_package" rev="4c02f372ddcd5ea37fa6b9f87093cb44" srcmd5="4c02f372ddcd5ea37fa6b9f87093cb44" baserev="4c02f372ddcd5ea37fa6b9f87093cb44" xsrcmd5="320921ea456ac54fc662cd37c6d6b5a5" lsrcmd5="c6281b321c53e45f4e7b27837f13db44" />
-          <entry name="_config" md5="11e44aa1c2a2e366b85a5db50ac7a716" size="169" mtime="1502292655" />
-          <entry name="_link" md5="06fbed7764b8a646ffcbf2a34dbcc7c6" size="182" mtime="1502292659" />
-          <entry name="somefile.txt" md5="c1e0265cf291873d2d6e86092f1e1138" size="152" mtime="1502292655" />
+        <directory name="custom_name" rev="1" vrev="1" srcmd5="b2d194240ea2c7d223a28557d86c86c2">
+          <linkinfo project="my_project" package="second_package" rev="01194bd0c7190247902e6b6194c8e78f" srcmd5="01194bd0c7190247902e6b6194c8e78f" baserev="01194bd0c7190247902e6b6194c8e78f" xsrcmd5="72faca690753c4fea207c633cc47939a" lsrcmd5="b2d194240ea2c7d223a28557d86c86c2" />
+          <entry name="_config" md5="27e7ef04c01f0aab8e5faac8aab0dfce" size="198" mtime="1516110523" />
+          <entry name="_link" md5="fddf5d7ba78517188703272b436dc500" size="182" mtime="1516110527" />
+          <entry name="somefile.txt" md5="de916512f7577e6a70f2b9971456a7ab" size="122" mtime="1516110523" />
         </directory>
     http_version: 
-  recorded_at: Wed, 09 Aug 2017 15:31:00 GMT
+  recorded_at: Tue, 16 Jan 2018 13:48:47 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:tom:branches:my_project/custom_name/_service
@@ -1510,7 +2191,7 @@ http_interactions:
           <details>404 _service: no such file</details>
         </status>
     http_version: 
-  recorded_at: Wed, 09 Aug 2017 15:31:00 GMT
+  recorded_at: Tue, 16 Jan 2018 13:48:47 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:tom:branches:my_project/custom_name
@@ -1540,14 +2221,51 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="custom_name" rev="2" vrev="2" srcmd5="c6281b321c53e45f4e7b27837f13db44">
-          <linkinfo project="my_project" package="second_package" rev="4c02f372ddcd5ea37fa6b9f87093cb44" srcmd5="4c02f372ddcd5ea37fa6b9f87093cb44" baserev="4c02f372ddcd5ea37fa6b9f87093cb44" xsrcmd5="320921ea456ac54fc662cd37c6d6b5a5" lsrcmd5="c6281b321c53e45f4e7b27837f13db44" />
-          <entry name="_config" md5="11e44aa1c2a2e366b85a5db50ac7a716" size="169" mtime="1502292655" />
-          <entry name="_link" md5="06fbed7764b8a646ffcbf2a34dbcc7c6" size="182" mtime="1502292659" />
-          <entry name="somefile.txt" md5="c1e0265cf291873d2d6e86092f1e1138" size="152" mtime="1502292655" />
+        <directory name="custom_name" rev="1" vrev="1" srcmd5="b2d194240ea2c7d223a28557d86c86c2">
+          <linkinfo project="my_project" package="second_package" rev="01194bd0c7190247902e6b6194c8e78f" srcmd5="01194bd0c7190247902e6b6194c8e78f" baserev="01194bd0c7190247902e6b6194c8e78f" xsrcmd5="72faca690753c4fea207c633cc47939a" lsrcmd5="b2d194240ea2c7d223a28557d86c86c2" />
+          <entry name="_config" md5="27e7ef04c01f0aab8e5faac8aab0dfce" size="198" mtime="1516110523" />
+          <entry name="_link" md5="fddf5d7ba78517188703272b436dc500" size="182" mtime="1516110527" />
+          <entry name="somefile.txt" md5="de916512f7577e6a70f2b9971456a7ab" size="122" mtime="1516110523" />
         </directory>
     http_version: 
-  recorded_at: Wed, 09 Aug 2017 15:31:00 GMT
+  recorded_at: Tue, 16 Jan 2018 13:48:47 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:tom:branches:my_project/custom_name
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '665'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="custom_name" rev="1" vrev="1" srcmd5="b2d194240ea2c7d223a28557d86c86c2">
+          <linkinfo project="my_project" package="second_package" rev="01194bd0c7190247902e6b6194c8e78f" srcmd5="01194bd0c7190247902e6b6194c8e78f" baserev="01194bd0c7190247902e6b6194c8e78f" xsrcmd5="72faca690753c4fea207c633cc47939a" lsrcmd5="b2d194240ea2c7d223a28557d86c86c2" />
+          <entry name="_config" md5="27e7ef04c01f0aab8e5faac8aab0dfce" size="198" mtime="1516110523" />
+          <entry name="_link" md5="fddf5d7ba78517188703272b436dc500" size="182" mtime="1516110527" />
+          <entry name="somefile.txt" md5="de916512f7577e6a70f2b9971456a7ab" size="122" mtime="1516110523" />
+        </directory>
+    http_version: 
+  recorded_at: Tue, 16 Jan 2018 13:48:47 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:tom:branches:my_project/custom_name/_history
@@ -1573,26 +2291,20 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '387'
+      - '209'
     body:
       encoding: UTF-8
       string: |
         <revisionlist>
           <revision rev="1" vrev="1">
-            <srcmd5>d1ca3b0f141c7e99c87ef485612a388f</srcmd5>
+            <srcmd5>b2d194240ea2c7d223a28557d86c86c2</srcmd5>
             <version>unknown</version>
-            <time>1502292599</time>
-            <user>tom</user>
-          </revision>
-          <revision rev="2" vrev="2">
-            <srcmd5>c6281b321c53e45f4e7b27837f13db44</srcmd5>
-            <version>unknown</version>
-            <time>1502292659</time>
+            <time>1516110527</time>
             <user>tom</user>
           </revision>
         </revisionlist>
     http_version: 
-  recorded_at: Wed, 09 Aug 2017 15:31:00 GMT
+  recorded_at: Tue, 16 Jan 2018 13:48:47 GMT
 - request:
     method: get
     uri: http://backend:5352/build/home:tom:branches:my_project/_result?package=custom_name&view=status
@@ -1627,812 +2339,7 @@ http_interactions:
 
 '
     http_version: 
-  recorded_at: Wed, 09 Aug 2017 15:31:01 GMT
-- request:
-    method: put
-    uri: http://backend:5352/source/my_project/_meta?user=tom
-    body:
-      encoding: UTF-8
-      string: |
-        <project name="my_project">
-          <title>Absalom, Absalom!</title>
-          <description/>
-        </project>
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '104'
-    body:
-      encoding: UTF-8
-      string: |
-        <project name="my_project">
-          <title>Absalom, Absalom!</title>
-          <description></description>
-        </project>
-    http_version: 
-  recorded_at: Thu, 10 Aug 2017 05:56:21 GMT
-- request:
-    method: put
-    uri: http://backend:5352/source/my_project/first_package/_meta?user=tom
-    body:
-      encoding: UTF-8
-      string: |
-        <package name="first_package" project="my_project">
-          <title>In a Glass Darkly</title>
-          <description>Consequuntur est minima deserunt sed et ipsam accusamus amet.</description>
-        </package>
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '189'
-    body:
-      encoding: UTF-8
-      string: |
-        <package name="first_package" project="my_project">
-          <title>In a Glass Darkly</title>
-          <description>Consequuntur est minima deserunt sed et ipsam accusamus amet.</description>
-        </package>
-    http_version: 
-  recorded_at: Thu, 10 Aug 2017 05:56:22 GMT
-- request:
-    method: put
-    uri: http://backend:5352/source/my_project/second_package/_meta?user=tom
-    body:
-      encoding: UTF-8
-      string: |
-        <package name="second_package" project="my_project">
-          <title>Clouds of Witness</title>
-          <description>Quia officia laborum praesentium et itaque aspernatur.</description>
-        </package>
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '183'
-    body:
-      encoding: UTF-8
-      string: |
-        <package name="second_package" project="my_project">
-          <title>Clouds of Witness</title>
-          <description>Quia officia laborum praesentium et itaque aspernatur.</description>
-        </package>
-    http_version: 
-  recorded_at: Thu, 10 Aug 2017 05:56:22 GMT
-- request:
-    method: get
-    uri: http://backend:5352/build/_workerstatus
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Content-Type:
-      - text/plain
-      Accept-Encoding:
-      - identity
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '927'
-    body:
-      encoding: UTF-8
-      string: |
-        <workerstatus clients="1">
-          <idle workerid="worker:1" hostarch="x86_64" />
-          <waiting arch="i586" jobs="1" />
-          <waiting arch="x86_64" jobs="0" />
-          <blocked arch="i586" jobs="0" />
-          <blocked arch="x86_64" jobs="0" />
-          <buildavg arch="i586" buildavg="1200" />
-          <buildavg arch="x86_64" buildavg="1200" />
-          <partition>
-            <daemon type="srcserver" state="running" starttime="1502344528" />
-            <daemon type="servicedispatch" state="running" starttime="1502344529" />
-            <daemon type="service" state="running" starttime="1502344529" />
-            <daemon type="scheduler" arch="i586" state="dead">
-              <queue high="0" med="0" low="3" next="0" />
-            </daemon>
-            <daemon type="scheduler" arch="x86_64" state="dead">
-              <queue high="39" med="0" low="7" next="0" />
-            </daemon>
-            <daemon type="repserver" state="running" starttime="1502344528" />
-            <daemon type="publisher" state="dead" />
-          </partition>
-        </workerstatus>
-    http_version: 
-  recorded_at: Thu, 10 Aug 2017 05:56:27 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/my_project/third_package
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 404
-      message: project 'my_project' does not exist
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '148'
-    body:
-      encoding: UTF-8
-      string: |
-        <status code="404">
-          <summary>project 'my_project' does not exist</summary>
-          <details>404 project 'my_project' does not exist</details>
-        </status>
-    http_version: 
-  recorded_at: Tue, 10 Oct 2017 12:36:05 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/my_project/third_package
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 404
-      message: project 'my_project' does not exist
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '148'
-    body:
-      encoding: UTF-8
-      string: |
-        <status code="404">
-          <summary>project 'my_project' does not exist</summary>
-          <details>404 project 'my_project' does not exist</details>
-        </status>
-    http_version: 
-  recorded_at: Tue, 10 Oct 2017 12:36:11 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/home:tom:branches:my_project/custom_name
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 404
-      message: project 'home tom branches my_project' does not exist
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '184'
-    body:
-      encoding: UTF-8
-      string: |
-        <status code="404">
-          <summary>project 'home:tom:branches:my_project' does not exist</summary>
-          <details>404 project 'home:tom:branches:my_project' does not exist</details>
-        </status>
-    http_version: 
-  recorded_at: Thu, 19 Oct 2017 08:13:54 GMT
-- request:
-    method: put
-    uri: http://backend:5352/source/my_project/third_package/_meta?user=tom
-    body:
-      encoding: UTF-8
-      string: |
-        <package name="third_package" project="my_project">
-          <title>b</title>
-          <description>Provident a sed earum molestiae repellat.</description>
-        </package>
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '153'
-    body:
-      encoding: UTF-8
-      string: |
-        <package name="third_package" project="my_project">
-          <title>b</title>
-          <description>Provident a sed earum molestiae repellat.</description>
-        </package>
-    http_version: 
-  recorded_at: Thu, 19 Oct 2017 10:56:35 GMT
-- request:
-    method: put
-    uri: http://backend:5352/source/my_project/third_package/_meta
-    body:
-      encoding: UTF-8
-      string: |
-        <package name="third_package" project="my_project">
-          <title>b</title>
-          <description>Provident a sed earum molestiae repellat.</description>
-        </package>
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '153'
-    body:
-      encoding: UTF-8
-      string: |
-        <package name="third_package" project="my_project">
-          <title>b</title>
-          <description>Provident a sed earum molestiae repellat.</description>
-        </package>
-    http_version: 
-  recorded_at: Thu, 19 Oct 2017 10:56:35 GMT
-- request:
-    method: put
-    uri: http://backend:5352/source/my_project/third_package/_config
-    body:
-      encoding: UTF-8
-      string: Qui earum quaerat asperiores recusandae. Delectus illum quia eius architecto
-        voluptatem dolorem. Molestiae voluptas quia.
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '207'
-    body:
-      encoding: UTF-8
-      string: |
-        <revision rev="3" vrev="3">
-          <srcmd5>cef744a0d29b4f4a09dc6ee18414479d</srcmd5>
-          <version>unknown</version>
-          <time>1508410595</time>
-          <user>unknown</user>
-          <comment></comment>
-          <requestid/>
-        </revision>
-    http_version: 
-  recorded_at: Thu, 19 Oct 2017 10:56:36 GMT
-- request:
-    method: put
-    uri: http://backend:5352/source/my_project/third_package/somefile.txt
-    body:
-      encoding: UTF-8
-      string: Molestiae voluptatem et voluptatem maiores rerum recusandae. Quasi rerum
-        dolorem et iusto. Tempora est vitae iure assumenda ea consectetur. Sequi vitae
-        est quibusdam dolor eos odit. Magni sed eveniet ut iure.
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '207'
-    body:
-      encoding: UTF-8
-      string: |
-        <revision rev="4" vrev="4">
-          <srcmd5>be4fc691a25643abeac0ab5e41142c4e</srcmd5>
-          <version>unknown</version>
-          <time>1508410596</time>
-          <user>unknown</user>
-          <comment></comment>
-          <requestid/>
-        </revision>
-    http_version: 
-  recorded_at: Thu, 19 Oct 2017 10:56:36 GMT
-- request:
-    method: put
-    uri: http://backend:5352/source/my_project/package_with_kiwi_image/_meta?user=tom
-    body:
-      encoding: UTF-8
-      string: |
-        <package name="package_with_kiwi_image" project="my_project">
-          <title>His Dark Materials</title>
-          <description>Et molestiae voluptatem aperiam aliquid laboriosam.</description>
-        </package>
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '190'
-    body:
-      encoding: UTF-8
-      string: |
-        <package name="package_with_kiwi_image" project="my_project">
-          <title>His Dark Materials</title>
-          <description>Et molestiae voluptatem aperiam aliquid laboriosam.</description>
-        </package>
-    http_version: 
-  recorded_at: Thu, 19 Oct 2017 10:56:37 GMT
-- request:
-    method: put
-    uri: http://backend:5352/source/my_project/package_with_kiwi_image/_meta
-    body:
-      encoding: UTF-8
-      string: |
-        <package name="package_with_kiwi_image" project="my_project">
-          <title>His Dark Materials</title>
-          <description>Et molestiae voluptatem aperiam aliquid laboriosam.</description>
-        </package>
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '190'
-    body:
-      encoding: UTF-8
-      string: |
-        <package name="package_with_kiwi_image" project="my_project">
-          <title>His Dark Materials</title>
-          <description>Et molestiae voluptatem aperiam aliquid laboriosam.</description>
-        </package>
-    http_version: 
-  recorded_at: Thu, 19 Oct 2017 10:56:37 GMT
-- request:
-    method: put
-    uri: http://backend:5352/source/my_project/package_with_kiwi_image/package_with_kiwi_image.kiwi
-    body:
-      encoding: UTF-8
-      string: |
-        <?xml version="1.0" encoding="utf-8"?>
-        <image schemaversion="6.2" name="suse-13.2-live">
-          <description type="system">
-          </description>
-          <preferences>
-            <type image="oem" primary="true" boot="oemboot/suse-13.2"/>
-          </preferences>
-        </image>
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '207'
-    body:
-      encoding: UTF-8
-      string: |
-        <revision rev="2" vrev="2">
-          <srcmd5>82f39606fd3c729f7f16de7d227e6dae</srcmd5>
-          <version>unknown</version>
-          <time>1508410597</time>
-          <user>unknown</user>
-          <comment></comment>
-          <requestid/>
-        </revision>
-    http_version: 
-  recorded_at: Thu, 19 Oct 2017 10:56:37 GMT
-- request:
-    method: put
-    uri: http://backend:5352/source/my_project/package_with_kiwi_image/_meta?user=tom
-    body:
-      encoding: UTF-8
-      string: |
-        <package name="package_with_kiwi_image" project="my_project">
-          <title>His Dark Materials</title>
-          <description>Et molestiae voluptatem aperiam aliquid laboriosam.</description>
-        </package>
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '190'
-    body:
-      encoding: UTF-8
-      string: |
-        <package name="package_with_kiwi_image" project="my_project">
-          <title>His Dark Materials</title>
-          <description>Et molestiae voluptatem aperiam aliquid laboriosam.</description>
-        </package>
-    http_version: 
-  recorded_at: Thu, 19 Oct 2017 10:56:37 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/my_project/package_with_kiwi_image
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '232'
-    body:
-      encoding: UTF-8
-      string: |
-        <directory name="package_with_kiwi_image" rev="2" vrev="2" srcmd5="82f39606fd3c729f7f16de7d227e6dae">
-          <entry name="package_with_kiwi_image.kiwi" md5="dda935f455dcd6607d83705328bee9df" size="242" mtime="1508410506" />
-        </directory>
-    http_version: 
-  recorded_at: Thu, 19 Oct 2017 10:56:37 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/my_project/package_with_kiwi_image
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '232'
-    body:
-      encoding: UTF-8
-      string: |
-        <directory name="package_with_kiwi_image" rev="2" vrev="2" srcmd5="82f39606fd3c729f7f16de7d227e6dae">
-          <entry name="package_with_kiwi_image.kiwi" md5="dda935f455dcd6607d83705328bee9df" size="242" mtime="1508410506" />
-        </directory>
-    http_version: 
-  recorded_at: Thu, 19 Oct 2017 10:56:37 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/my_project/package_with_kiwi_image
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '232'
-    body:
-      encoding: UTF-8
-      string: |
-        <directory name="package_with_kiwi_image" rev="2" vrev="2" srcmd5="82f39606fd3c729f7f16de7d227e6dae">
-          <entry name="package_with_kiwi_image.kiwi" md5="dda935f455dcd6607d83705328bee9df" size="242" mtime="1508410506" />
-        </directory>
-    http_version: 
-  recorded_at: Thu, 19 Oct 2017 10:56:37 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/my_project/package_with_kiwi_image
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '232'
-    body:
-      encoding: UTF-8
-      string: |
-        <directory name="package_with_kiwi_image" rev="2" vrev="2" srcmd5="82f39606fd3c729f7f16de7d227e6dae">
-          <entry name="package_with_kiwi_image.kiwi" md5="dda935f455dcd6607d83705328bee9df" size="242" mtime="1508410506" />
-        </directory>
-    http_version: 
-  recorded_at: Thu, 19 Oct 2017 10:56:39 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/my_project/package_with_kiwi_image
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '232'
-    body:
-      encoding: UTF-8
-      string: |
-        <directory name="package_with_kiwi_image" rev="2" vrev="2" srcmd5="82f39606fd3c729f7f16de7d227e6dae">
-          <entry name="package_with_kiwi_image.kiwi" md5="dda935f455dcd6607d83705328bee9df" size="242" mtime="1508410506" />
-        </directory>
-    http_version: 
-  recorded_at: Thu, 19 Oct 2017 10:56:39 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/home:tom:branches:my_project/custom_name
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 404
-      message: project 'home tom branches my_project' does not exist
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '184'
-    body:
-      encoding: UTF-8
-      string: |
-        <status code="404">
-          <summary>project 'home:tom:branches:my_project' does not exist</summary>
-          <details>404 project 'home:tom:branches:my_project' does not exist</details>
-        </status>
-    http_version: 
-  recorded_at: Wed, 03 Jan 2018 14:29:21 GMT
+  recorded_at: Tue, 16 Jan 2018 13:48:48 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:tom:branches:my_project/custom_name?view=info
@@ -2467,7 +2374,7 @@ http_interactions:
           <details>404 project 'home:tom:branches:my_project' does not exist</details>
         </status>
     http_version: 
-  recorded_at: Tue, 16 Jan 2018 14:27:02 GMT
+  recorded_at: Thu, 01 Feb 2018 16:26:31 GMT
 - request:
     method: get
     uri: http://backend:5352/source/my_project/second_package?view=info
@@ -2502,5 +2409,5 @@ http_interactions:
           <details>404 project 'my_project' does not exist</details>
         </status>
     http_version: 
-  recorded_at: Tue, 16 Jan 2018 14:27:03 GMT
+  recorded_at: Thu, 01 Feb 2018 16:26:31 GMT
 recorded_with: VCR 4.0.0

--- a/src/api/spec/cassettes/MaintenanceWorkflow/maintenance_workflow.yml
+++ b/src/api/spec/cassettes/MaintenanceWorkflow/maintenance_workflow.yml
@@ -40,7 +40,7 @@ http_interactions:
           <person userid="user_1" role="maintainer" />
         </project>
     http_version: 
-  recorded_at: Tue, 22 Aug 2017 12:31:07 GMT
+  recorded_at: Tue, 16 Jan 2018 08:22:15 GMT
 - request:
     method: put
     uri: http://backend:5352/source/ProjectWithRepo/_meta
@@ -48,7 +48,7 @@ http_interactions:
       encoding: UTF-8
       string: |
         <project name="ProjectWithRepo">
-          <title>The Moving Toyshop</title>
+          <title>The Stars' Tennis Balls</title>
           <description/>
         </project>
     headers:
@@ -70,23 +70,23 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '110'
+      - '115'
     body:
       encoding: UTF-8
       string: |
         <project name="ProjectWithRepo">
-          <title>The Moving Toyshop</title>
+          <title>The Stars' Tennis Balls</title>
           <description></description>
         </project>
     http_version: 
-  recorded_at: Tue, 22 Aug 2017 12:31:07 GMT
+  recorded_at: Tue, 16 Jan 2018 08:22:15 GMT
 - request:
     method: put
     uri: http://backend:5352/source/ProjectWithRepo/_config
     body:
       encoding: UTF-8
-      string: Minus maiores quaerat veritatis. Atque voluptate hic aut. Velit eos
-        quidem qui qui natus. Unde non eaque hic culpa et quos corrupti.
+      string: Et rem odio est dolores nulla est doloremque. Eum mollitia commodi.
+        Libero et eligendi sint. Cupiditate ab minus omnis aut.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -113,7 +113,7 @@ http_interactions:
 
 '
     http_version: 
-  recorded_at: Tue, 22 Aug 2017 12:31:07 GMT
+  recorded_at: Tue, 16 Jan 2018 08:22:15 GMT
 - request:
     method: put
     uri: http://backend:5352/source/ProjectWithRepo:Update/_meta
@@ -121,7 +121,7 @@ http_interactions:
       encoding: UTF-8
       string: |
         <project name="ProjectWithRepo:Update" kind="maintenance_release">
-          <title>Postern of Fate</title>
+          <title>Have His Carcase</title>
           <description/>
         </project>
     headers:
@@ -143,24 +143,24 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '141'
+      - '142'
     body:
       encoding: UTF-8
       string: |
         <project name="ProjectWithRepo:Update" kind="maintenance_release">
-          <title>Postern of Fate</title>
+          <title>Have His Carcase</title>
           <description></description>
         </project>
     http_version: 
-  recorded_at: Tue, 22 Aug 2017 12:31:08 GMT
+  recorded_at: Tue, 16 Jan 2018 08:22:16 GMT
 - request:
     method: put
     uri: http://backend:5352/source/ProjectWithRepo:Update/_config
     body:
       encoding: UTF-8
-      string: Natus ut quaerat. Dolor assumenda vel corrupti. Reprehenderit aut expedita
-        qui sapiente. Occaecati est voluptatum voluptatem aliquid nesciunt ut sit.
-        Dolorem nihil officiis illo possimus magnam.
+      string: Laborum eligendi et pariatur. Porro dolor et debitis sunt eum perferendis.
+        Dolores non quo perferendis. Dolore ab eligendi temporibus deserunt voluptas
+        et debitis.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -187,17 +187,16 @@ http_interactions:
 
 '
     http_version: 
-  recorded_at: Tue, 22 Aug 2017 12:31:08 GMT
+  recorded_at: Tue, 16 Jan 2018 08:22:16 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/ProjectWithRepo:Update/_meta?user=user_1
+    uri: http://backend:5352/source/project_1/_meta
     body:
       encoding: UTF-8
       string: |
-        <project name="ProjectWithRepo:Update" kind="maintenance_release">
-          <title>Postern of Fate</title>
+        <project name="project_1">
+          <title>After Many a Summer Dies the Swan</title>
           <description/>
-          <link project="ProjectWithRepo"/>
         </project>
     headers:
       Accept-Encoding:
@@ -218,17 +217,91 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '178'
+      - '119'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="project_1">
+          <title>After Many a Summer Dies the Swan</title>
+          <description></description>
+        </project>
+    http_version: 
+  recorded_at: Tue, 16 Jan 2018 08:22:16 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/project_1/_config
+    body:
+      encoding: UTF-8
+      string: Et accusantium et quas porro ipsum vitae eveniet. Non sed ab fugit praesentium.
+        Aut quis quae qui magni.
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '21'
+    body:
+      encoding: UTF-8
+      string: '<status code="ok" />
+
+'
+    http_version: 
+  recorded_at: Tue, 16 Jan 2018 08:22:16 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/ProjectWithRepo:Update/_meta?user=user_1
     body:
       encoding: UTF-8
       string: |
         <project name="ProjectWithRepo:Update" kind="maintenance_release">
-          <title>Postern of Fate</title>
+          <title>Have His Carcase</title>
+          <description/>
+          <link project="ProjectWithRepo" vrevmode="unextend"/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '199'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="ProjectWithRepo:Update" kind="maintenance_release">
+          <title>Have His Carcase</title>
           <description></description>
-          <link project="ProjectWithRepo" />
+          <link project="ProjectWithRepo" vrevmode="unextend" />
         </project>
     http_version: 
-  recorded_at: Tue, 22 Aug 2017 12:31:08 GMT
+  recorded_at: Tue, 16 Jan 2018 08:22:16 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:maintenance_coord/_meta?user=maintenance_coord
@@ -269,7 +342,7 @@ http_interactions:
           <person userid="maintenance_coord" role="maintainer" />
         </project>
     http_version: 
-  recorded_at: Tue, 22 Aug 2017 12:31:08 GMT
+  recorded_at: Tue, 16 Jan 2018 08:22:16 GMT
 - request:
     method: put
     uri: http://backend:5352/source/MaintenanceProject/_meta
@@ -308,15 +381,15 @@ http_interactions:
           <description></description>
         </project>
     http_version: 
-  recorded_at: Tue, 22 Aug 2017 12:31:08 GMT
+  recorded_at: Tue, 16 Jan 2018 08:22:16 GMT
 - request:
     method: put
     uri: http://backend:5352/source/MaintenanceProject/_config
     body:
       encoding: UTF-8
-      string: Maiores voluptatem eos. Blanditiis et velit quo magni. Aperiam qui delectus.
-        Suscipit aut dicta eligendi tempore quo. Repellat dolor sint enim libero ea
-        atque illo.
+      string: Fugit aliquam porro neque quam impedit est. Sed eaque fuga corporis
+        placeat consequatur quisquam labore. Perspiciatis quam expedita. Aut velit
+        sapiente. Id at tempore cupiditate non autem nulla rem.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -343,7 +416,7 @@ http_interactions:
 
 '
     http_version: 
-  recorded_at: Tue, 22 Aug 2017 12:31:08 GMT
+  recorded_at: Tue, 16 Jan 2018 08:22:16 GMT
 - request:
     method: put
     uri: http://backend:5352/source/MaintenanceProject/_meta?user=user_1
@@ -353,6 +426,7 @@ http_interactions:
         <project name="MaintenanceProject" kind="maintenance">
           <title>official maintenance space</title>
           <description/>
+          <person userid="maintenance_coord" role="maintainer"/>
           <maintenance>
             <maintains project="ProjectWithRepo:Update"/>
           </maintenance>
@@ -376,19 +450,20 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '224'
+      - '282'
     body:
       encoding: UTF-8
       string: |
         <project name="MaintenanceProject" kind="maintenance">
           <title>official maintenance space</title>
           <description></description>
+          <person userid="maintenance_coord" role="maintainer" />
           <maintenance>
             <maintains project="ProjectWithRepo:Update" />
           </maintenance>
         </project>
     http_version: 
-  recorded_at: Tue, 22 Aug 2017 12:31:08 GMT
+  recorded_at: Tue, 16 Jan 2018 08:22:16 GMT
 - request:
     method: put
     uri: http://backend:5352/source/MaintenanceProject/patchinfo/_meta?user=maintenance_coord
@@ -445,7 +520,7 @@ http_interactions:
           </useforbuild>
         </package>
     http_version: 
-  recorded_at: Tue, 22 Aug 2017 12:31:08 GMT
+  recorded_at: Tue, 16 Jan 2018 08:22:16 GMT
 - request:
     method: put
     uri: http://backend:5352/source/MaintenanceProject/patchinfo/_patchinfo?comment=generated%20by%20createpatchinfo%20call&user=maintenance_coord
@@ -485,13 +560,13 @@ http_interactions:
         <revision rev="1" vrev="1">
           <srcmd5>7c79565cf2a5793c8092ebecfe0a912a</srcmd5>
           <version>unknown</version>
-          <time>1503405068</time>
+          <time>1516090936</time>
           <user>maintenance_coord</user>
           <comment>generated by createpatchinfo call</comment>
           <requestid/>
         </revision>
     http_version: 
-  recorded_at: Tue, 22 Aug 2017 12:31:08 GMT
+  recorded_at: Tue, 16 Jan 2018 08:22:16 GMT
 - request:
     method: put
     uri: http://backend:5352/source/MaintenanceProject/patchinfo/_meta?user=maintenance_coord
@@ -548,7 +623,7 @@ http_interactions:
           </useforbuild>
         </package>
     http_version: 
-  recorded_at: Tue, 22 Aug 2017 12:31:08 GMT
+  recorded_at: Tue, 16 Jan 2018 08:22:17 GMT
 - request:
     method: get
     uri: http://backend:5352/source/MaintenanceProject/patchinfo
@@ -579,10 +654,10 @@ http_interactions:
       encoding: UTF-8
       string: |
         <directory name="patchinfo" rev="1" vrev="1" srcmd5="7c79565cf2a5793c8092ebecfe0a912a">
-          <entry name="_patchinfo" md5="ea890f2483d4b7e7255d64ef4dbb1d43" size="174" mtime="1503405068" />
+          <entry name="_patchinfo" md5="ea890f2483d4b7e7255d64ef4dbb1d43" size="174" mtime="1516090936" />
         </directory>
     http_version: 
-  recorded_at: Tue, 22 Aug 2017 12:31:08 GMT
+  recorded_at: Tue, 16 Jan 2018 08:22:17 GMT
 - request:
     method: get
     uri: http://backend:5352/source/MaintenanceProject/patchinfo?nofilename=1&view=info&withchangesmd5=1
@@ -613,10 +688,10 @@ http_interactions:
       encoding: UTF-8
       string: |
         <sourceinfo package="patchinfo" rev="1" vrev="1" srcmd5="7c79565cf2a5793c8092ebecfe0a912a" verifymd5="7c79565cf2a5793c8092ebecfe0a912a">
-          <revtime>1503405068</revtime>
+          <revtime>1516090936</revtime>
         </sourceinfo>
     http_version: 
-  recorded_at: Tue, 22 Aug 2017 12:31:08 GMT
+  recorded_at: Tue, 16 Jan 2018 08:22:17 GMT
 - request:
     method: get
     uri: http://backend:5352/source/MaintenanceProject/patchinfo
@@ -647,10 +722,10 @@ http_interactions:
       encoding: UTF-8
       string: |
         <directory name="patchinfo" rev="1" vrev="1" srcmd5="7c79565cf2a5793c8092ebecfe0a912a">
-          <entry name="_patchinfo" md5="ea890f2483d4b7e7255d64ef4dbb1d43" size="174" mtime="1503405068" />
+          <entry name="_patchinfo" md5="ea890f2483d4b7e7255d64ef4dbb1d43" size="174" mtime="1516090936" />
         </directory>
     http_version: 
-  recorded_at: Tue, 22 Aug 2017 12:31:08 GMT
+  recorded_at: Tue, 16 Jan 2018 08:22:17 GMT
 - request:
     method: get
     uri: http://backend:5352/source/MaintenanceProject/patchinfo/_patchinfo
@@ -688,7 +763,7 @@ http_interactions:
           <description/>
         </patchinfo>
     http_version: 
-  recorded_at: Tue, 22 Aug 2017 12:31:09 GMT
+  recorded_at: Tue, 16 Jan 2018 08:22:17 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom/_meta?user=tom
@@ -729,7 +804,7 @@ http_interactions:
           <person userid="tom" role="maintainer" />
         </project>
     http_version: 
-  recorded_at: Tue, 22 Aug 2017 12:31:09 GMT
+  recorded_at: Tue, 16 Jan 2018 08:22:17 GMT
 - request:
     method: put
     uri: http://backend:5352/source/ProjectWithRepo/ProjectWithRepo_package/_meta?user=tom
@@ -737,8 +812,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="ProjectWithRepo_package" project="ProjectWithRepo">
-          <title>Have His Carcase</title>
-          <description>Molestiae eligendi asperiores quod voluptatibus totam non recusandae voluptas.</description>
+          <title>To a God Unknown</title>
+          <description>Sed voluptatum dolorem et omnis.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -759,16 +834,16 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '220'
+      - '174'
     body:
       encoding: UTF-8
       string: |
         <package name="ProjectWithRepo_package" project="ProjectWithRepo">
-          <title>Have His Carcase</title>
-          <description>Molestiae eligendi asperiores quod voluptatibus totam non recusandae voluptas.</description>
+          <title>To a God Unknown</title>
+          <description>Sed voluptatum dolorem et omnis.</description>
         </package>
     http_version: 
-  recorded_at: Tue, 22 Aug 2017 12:31:13 GMT
+  recorded_at: Tue, 16 Jan 2018 08:22:25 GMT
 - request:
     method: put
     uri: http://backend:5352/source/ProjectWithRepo/ProjectWithRepo_package/_meta
@@ -776,8 +851,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="ProjectWithRepo_package" project="ProjectWithRepo">
-          <title>Have His Carcase</title>
-          <description>Molestiae eligendi asperiores quod voluptatibus totam non recusandae voluptas.</description>
+          <title>To a God Unknown</title>
+          <description>Sed voluptatum dolorem et omnis.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -798,25 +873,23 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '220'
+      - '174'
     body:
       encoding: UTF-8
       string: |
         <package name="ProjectWithRepo_package" project="ProjectWithRepo">
-          <title>Have His Carcase</title>
-          <description>Molestiae eligendi asperiores quod voluptatibus totam non recusandae voluptas.</description>
+          <title>To a God Unknown</title>
+          <description>Sed voluptatum dolorem et omnis.</description>
         </package>
     http_version: 
-  recorded_at: Tue, 22 Aug 2017 12:31:13 GMT
+  recorded_at: Tue, 16 Jan 2018 08:22:25 GMT
 - request:
     method: put
     uri: http://backend:5352/source/ProjectWithRepo/ProjectWithRepo_package/_config
     body:
       encoding: UTF-8
-      string: Reprehenderit consequatur explicabo ipsam libero. Expedita minima quis
-        tempora facilis modi maiores. Eligendi molestiae eos neque id odio quae dolore.
-        Eligendi voluptatem distinctio sunt. Nisi laudantium exercitationem consequatur
-        soluta.
+      string: Aperiam voluptas explicabo. Velit ut quisquam. Ut qui alias sit similique
+        excepturi pariatur. Dolor delectus exercitationem magni veniam nihil.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -841,22 +914,23 @@ http_interactions:
       encoding: UTF-8
       string: |
         <revision rev="1" vrev="1">
-          <srcmd5>0b2b3d3b538adcd945273f9f64080257</srcmd5>
+          <srcmd5>7febb365f0e4a6b5ef82dd7fac91dca1</srcmd5>
           <version>unknown</version>
-          <time>1503405073</time>
+          <time>1516090945</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
     http_version: 
-  recorded_at: Tue, 22 Aug 2017 12:31:13 GMT
+  recorded_at: Tue, 16 Jan 2018 08:22:25 GMT
 - request:
     method: put
     uri: http://backend:5352/source/ProjectWithRepo/ProjectWithRepo_package/somefile.txt
     body:
       encoding: UTF-8
-      string: Voluptate qui deserunt culpa laborum est delectus. Et ducimus necessitatibus
-        sint aut libero. Doloribus quasi culpa.
+      string: Fugit illum vel. Qui ipsum impedit dolorum dolor minus possimus quas.
+        Quaerat molestias minus. Qui praesentium necessitatibus debitis suscipit fugiat
+        qui aperiam. Enim sit commodi aspernatur illo et tempora.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -881,15 +955,15 @@ http_interactions:
       encoding: UTF-8
       string: |
         <revision rev="2" vrev="2">
-          <srcmd5>e9d965f2d319f4124109f14a13f4e431</srcmd5>
+          <srcmd5>6e6fbc10551cfc8eb7c6ccfc373d323f</srcmd5>
           <version>unknown</version>
-          <time>1503405073</time>
+          <time>1516090945</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
     http_version: 
-  recorded_at: Tue, 22 Aug 2017 12:31:13 GMT
+  recorded_at: Tue, 16 Jan 2018 08:22:25 GMT
 - request:
     method: get
     uri: http://backend:5352/source/ProjectWithRepo/ProjectWithRepo_package?nofilename=1&view=info&withchangesmd5=1
@@ -919,11 +993,11 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <sourceinfo package="ProjectWithRepo_package" rev="2" vrev="2" srcmd5="e9d965f2d319f4124109f14a13f4e431" verifymd5="e9d965f2d319f4124109f14a13f4e431">
-          <revtime>1503405073</revtime>
+        <sourceinfo package="ProjectWithRepo_package" rev="2" vrev="2" srcmd5="6e6fbc10551cfc8eb7c6ccfc373d323f" verifymd5="6e6fbc10551cfc8eb7c6ccfc373d323f">
+          <revtime>1516090945</revtime>
         </sourceinfo>
     http_version: 
-  recorded_at: Tue, 22 Aug 2017 12:31:13 GMT
+  recorded_at: Tue, 16 Jan 2018 08:22:25 GMT
 - request:
     method: get
     uri: http://backend:5352/source/ProjectWithRepo/ProjectWithRepo_package
@@ -953,12 +1027,12 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="ProjectWithRepo_package" rev="2" vrev="2" srcmd5="e9d965f2d319f4124109f14a13f4e431">
-          <entry name="_config" md5="7159169868967997b7eabbd94d805185" size="238" mtime="1503405073" />
-          <entry name="somefile.txt" md5="b4b03ef7ef00ded93403c2c595500c4f" size="116" mtime="1503405073" />
+        <directory name="ProjectWithRepo_package" rev="2" vrev="2" srcmd5="6e6fbc10551cfc8eb7c6ccfc373d323f">
+          <entry name="_config" md5="e8ec9a29a8e74d4c7dfc73686c1576b5" size="143" mtime="1516090945" />
+          <entry name="somefile.txt" md5="95c4ebbcd6a901fc5e9a47439d5e6f92" size="207" mtime="1516090945" />
         </directory>
     http_version: 
-  recorded_at: Tue, 22 Aug 2017 12:31:13 GMT
+  recorded_at: Tue, 16 Jan 2018 08:22:25 GMT
 - request:
     method: post
     uri: http://backend:5352/source/ProjectWithRepo/ProjectWithRepo_package?cmd=diff&linkrev=base&onlyissues=1&orev=0&view=xml
@@ -990,15 +1064,15 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="b35a4ebdb0aa27c1bb4981c75d3493f6">
+        <sourcediff key="db1cc43b899e5cd75c91e14299da0c34">
           <old project="ProjectWithRepo" package="ProjectWithRepo_package" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e" />
-          <new project="ProjectWithRepo" package="ProjectWithRepo_package" rev="2" srcmd5="e9d965f2d319f4124109f14a13f4e431" />
+          <new project="ProjectWithRepo" package="ProjectWithRepo_package" rev="2" srcmd5="6e6fbc10551cfc8eb7c6ccfc373d323f" />
           <files />
           <issues>
           </issues>
         </sourcediff>
     http_version: 
-  recorded_at: Tue, 22 Aug 2017 12:31:13 GMT
+  recorded_at: Tue, 16 Jan 2018 08:22:25 GMT
 - request:
     method: get
     uri: http://backend:5352/source/ProjectWithRepo/ProjectWithRepo_package
@@ -1028,12 +1102,12 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="ProjectWithRepo_package" rev="2" vrev="2" srcmd5="e9d965f2d319f4124109f14a13f4e431">
-          <entry name="_config" md5="7159169868967997b7eabbd94d805185" size="238" mtime="1503405073" />
-          <entry name="somefile.txt" md5="b4b03ef7ef00ded93403c2c595500c4f" size="116" mtime="1503405073" />
+        <directory name="ProjectWithRepo_package" rev="2" vrev="2" srcmd5="6e6fbc10551cfc8eb7c6ccfc373d323f">
+          <entry name="_config" md5="e8ec9a29a8e74d4c7dfc73686c1576b5" size="143" mtime="1516090945" />
+          <entry name="somefile.txt" md5="95c4ebbcd6a901fc5e9a47439d5e6f92" size="207" mtime="1516090945" />
         </directory>
     http_version: 
-  recorded_at: Tue, 22 Aug 2017 12:31:13 GMT
+  recorded_at: Tue, 16 Jan 2018 08:22:25 GMT
 - request:
     method: get
     uri: http://backend:5352/source/ProjectWithRepo/ProjectWithRepo_package?expand=1&rev=2
@@ -1063,12 +1137,12 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="ProjectWithRepo_package" rev="2" vrev="2" srcmd5="e9d965f2d319f4124109f14a13f4e431">
-          <entry name="_config" md5="7159169868967997b7eabbd94d805185" size="238" mtime="1503405073" />
-          <entry name="somefile.txt" md5="b4b03ef7ef00ded93403c2c595500c4f" size="116" mtime="1503405073" />
+        <directory name="ProjectWithRepo_package" rev="2" vrev="2" srcmd5="6e6fbc10551cfc8eb7c6ccfc373d323f">
+          <entry name="_config" md5="e8ec9a29a8e74d4c7dfc73686c1576b5" size="143" mtime="1516090945" />
+          <entry name="somefile.txt" md5="95c4ebbcd6a901fc5e9a47439d5e6f92" size="207" mtime="1516090945" />
         </directory>
     http_version: 
-  recorded_at: Tue, 22 Aug 2017 12:31:13 GMT
+  recorded_at: Tue, 16 Jan 2018 08:22:25 GMT
 - request:
     method: get
     uri: http://backend:5352/source/ProjectWithRepo/ProjectWithRepo_package
@@ -1100,12 +1174,12 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="ProjectWithRepo_package" rev="2" vrev="2" srcmd5="e9d965f2d319f4124109f14a13f4e431">
-          <entry name="_config" md5="7159169868967997b7eabbd94d805185" size="238" mtime="1503405073" />
-          <entry name="somefile.txt" md5="b4b03ef7ef00ded93403c2c595500c4f" size="116" mtime="1503405073" />
+        <directory name="ProjectWithRepo_package" rev="2" vrev="2" srcmd5="6e6fbc10551cfc8eb7c6ccfc373d323f">
+          <entry name="_config" md5="e8ec9a29a8e74d4c7dfc73686c1576b5" size="143" mtime="1516090945" />
+          <entry name="somefile.txt" md5="95c4ebbcd6a901fc5e9a47439d5e6f92" size="207" mtime="1516090945" />
         </directory>
     http_version: 
-  recorded_at: Tue, 22 Aug 2017 12:31:13 GMT
+  recorded_at: Tue, 16 Jan 2018 08:22:25 GMT
 - request:
     method: get
     uri: http://backend:5352/source/ProjectWithRepo:Update/ProjectWithRepo_package/_service
@@ -1142,7 +1216,7 @@ http_interactions:
           <details>404 _service: no such file</details>
         </status>
     http_version: 
-  recorded_at: Tue, 22 Aug 2017 12:31:13 GMT
+  recorded_at: Tue, 16 Jan 2018 08:22:25 GMT
 - request:
     method: get
     uri: http://backend:5352/source/ProjectWithRepo/ProjectWithRepo_package/_history
@@ -1174,20 +1248,20 @@ http_interactions:
       string: |
         <revisionlist>
           <revision rev="1" vrev="1">
-            <srcmd5>0b2b3d3b538adcd945273f9f64080257</srcmd5>
+            <srcmd5>7febb365f0e4a6b5ef82dd7fac91dca1</srcmd5>
             <version>unknown</version>
-            <time>1503405073</time>
+            <time>1516090945</time>
             <user>unknown</user>
           </revision>
           <revision rev="2" vrev="2">
-            <srcmd5>e9d965f2d319f4124109f14a13f4e431</srcmd5>
+            <srcmd5>6e6fbc10551cfc8eb7c6ccfc373d323f</srcmd5>
             <version>unknown</version>
-            <time>1503405073</time>
+            <time>1516090945</time>
             <user>unknown</user>
           </revision>
         </revisionlist>
     http_version: 
-  recorded_at: Tue, 22 Aug 2017 12:31:13 GMT
+  recorded_at: Tue, 16 Jan 2018 08:22:25 GMT
 - request:
     method: get
     uri: http://backend:5352/build/ProjectWithRepo:Update/_result?package=ProjectWithRepo_package&view=status
@@ -1222,7 +1296,7 @@ http_interactions:
 
 '
     http_version: 
-  recorded_at: Tue, 22 Aug 2017 12:31:14 GMT
+  recorded_at: Tue, 16 Jan 2018 08:22:25 GMT
 - request:
     method: get
     uri: http://backend:5352/build/ProjectWithRepo:Update/_result?locallink=1&multibuild=1&package=ProjectWithRepo_package&view=status
@@ -1257,7 +1331,7 @@ http_interactions:
 
 '
     http_version: 
-  recorded_at: Tue, 22 Aug 2017 12:31:14 GMT
+  recorded_at: Tue, 16 Jan 2018 08:22:26 GMT
 - request:
     method: post
     uri: http://backend:5352/search/package/id?match=(linkinfo/@package=%22ProjectWithRepo_package%22%20and%20linkinfo/@project=%22ProjectWithRepo:Update%22%20and%20starts-with(@project,%22MaintenanceProject:%22))
@@ -1292,7 +1366,7 @@ http_interactions:
         <collection>
         </collection>
     http_version: 
-  recorded_at: Tue, 22 Aug 2017 12:31:14 GMT
+  recorded_at: Tue, 16 Jan 2018 08:22:26 GMT
 - request:
     method: post
     uri: http://backend:5352/search/package/id?match=(linkinfo/@package=%22ProjectWithRepo_package%22%20and%20linkinfo/@project=%22ProjectWithRepo%22%20and%20@project=%22ProjectWithRepo%22)
@@ -1327,7 +1401,7 @@ http_interactions:
         <collection>
         </collection>
     http_version: 
-  recorded_at: Tue, 22 Aug 2017 12:31:14 GMT
+  recorded_at: Tue, 16 Jan 2018 08:22:26 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom:branches:ProjectWithRepo:Update/_meta?user=tom
@@ -1368,7 +1442,7 @@ http_interactions:
           <person userid="tom" role="maintainer" />
         </project>
     http_version: 
-  recorded_at: Tue, 22 Aug 2017 12:31:14 GMT
+  recorded_at: Tue, 16 Jan 2018 08:22:26 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom:branches:ProjectWithRepo:Update/ProjectWithRepo_package/_meta?user=tom
@@ -1376,8 +1450,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="ProjectWithRepo_package" project="home:tom:branches:ProjectWithRepo:Update">
-          <title>Have His Carcase</title>
-          <description>Molestiae eligendi asperiores quod voluptatibus totam non recusandae voluptas.</description>
+          <title>To a God Unknown</title>
+          <description>Sed voluptatum dolorem et omnis.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -1398,19 +1472,19 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '245'
+      - '199'
     body:
       encoding: UTF-8
       string: |
         <package name="ProjectWithRepo_package" project="home:tom:branches:ProjectWithRepo:Update">
-          <title>Have His Carcase</title>
-          <description>Molestiae eligendi asperiores quod voluptatibus totam non recusandae voluptas.</description>
+          <title>To a God Unknown</title>
+          <description>Sed voluptatum dolorem et omnis.</description>
         </package>
     http_version: 
-  recorded_at: Tue, 22 Aug 2017 12:31:14 GMT
+  recorded_at: Tue, 16 Jan 2018 08:22:26 GMT
 - request:
     method: post
-    uri: http://backend:5352/source/home:tom:branches:ProjectWithRepo:Update/ProjectWithRepo_package?cmd=branch&opackage=ProjectWithRepo_package&oproject=ProjectWithRepo:Update&user=tom
+    uri: http://backend:5352/source/home:tom:branches:ProjectWithRepo:Update/ProjectWithRepo_package?cmd=branch&noservice=1&opackage=ProjectWithRepo_package&oproject=ProjectWithRepo:Update&user=tom
     body:
       encoding: UTF-8
       string: ''
@@ -1440,15 +1514,15 @@ http_interactions:
       encoding: UTF-8
       string: |
         <revision rev="1" vrev="1">
-          <srcmd5>9bcd667cba1fccb6f2edd222850b6994</srcmd5>
+          <srcmd5>abe3c0682de9656b46e4fa83de7abbb4</srcmd5>
           <version>unknown</version>
-          <time>1503405074</time>
+          <time>1516090946</time>
           <user>tom</user>
           <comment></comment>
           <requestid/>
         </revision>
     http_version: 
-  recorded_at: Tue, 22 Aug 2017 12:31:14 GMT
+  recorded_at: Tue, 16 Jan 2018 08:22:26 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom:branches:ProjectWithRepo:Update/ProjectWithRepo_package/_meta?user=tom
@@ -1456,8 +1530,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="ProjectWithRepo_package" project="home:tom:branches:ProjectWithRepo:Update">
-          <title>Have His Carcase</title>
-          <description>Molestiae eligendi asperiores quod voluptatibus totam non recusandae voluptas.</description>
+          <title>To a God Unknown</title>
+          <description>Sed voluptatum dolorem et omnis.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -1478,16 +1552,16 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '245'
+      - '199'
     body:
       encoding: UTF-8
       string: |
         <package name="ProjectWithRepo_package" project="home:tom:branches:ProjectWithRepo:Update">
-          <title>Have His Carcase</title>
-          <description>Molestiae eligendi asperiores quod voluptatibus totam non recusandae voluptas.</description>
+          <title>To a God Unknown</title>
+          <description>Sed voluptatum dolorem et omnis.</description>
         </package>
     http_version: 
-  recorded_at: Tue, 22 Aug 2017 12:31:14 GMT
+  recorded_at: Tue, 16 Jan 2018 08:22:26 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:tom:branches:ProjectWithRepo:Update/ProjectWithRepo_package
@@ -1517,14 +1591,14 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="ProjectWithRepo_package" rev="1" vrev="1" srcmd5="9bcd667cba1fccb6f2edd222850b6994">
-          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" srcmd5="e9d965f2d319f4124109f14a13f4e431" baserev="e9d965f2d319f4124109f14a13f4e431" xsrcmd5="bd5b3338986f29cc911a8b873613bd70" lsrcmd5="9bcd667cba1fccb6f2edd222850b6994" />
-          <entry name="_config" md5="7159169868967997b7eabbd94d805185" size="238" mtime="1503405073" />
-          <entry name="_link" md5="11504ac69b4a7053159649a50cf86e1f" size="130" mtime="1503405074" />
-          <entry name="somefile.txt" md5="b4b03ef7ef00ded93403c2c595500c4f" size="116" mtime="1503405073" />
+        <directory name="ProjectWithRepo_package" rev="1" vrev="1" srcmd5="abe3c0682de9656b46e4fa83de7abbb4">
+          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" srcmd5="6e6fbc10551cfc8eb7c6ccfc373d323f" baserev="6e6fbc10551cfc8eb7c6ccfc373d323f" xsrcmd5="89d23d961c6010378ec04f1a5ca82235" lsrcmd5="abe3c0682de9656b46e4fa83de7abbb4" />
+          <entry name="_config" md5="e8ec9a29a8e74d4c7dfc73686c1576b5" size="143" mtime="1516090945" />
+          <entry name="_link" md5="e409478924f3c1c27d895156ac5f39b0" size="130" mtime="1516090946" />
+          <entry name="somefile.txt" md5="95c4ebbcd6a901fc5e9a47439d5e6f92" size="207" mtime="1516090945" />
         </directory>
     http_version: 
-  recorded_at: Tue, 22 Aug 2017 12:31:14 GMT
+  recorded_at: Tue, 16 Jan 2018 08:22:26 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:tom:branches:ProjectWithRepo:Update/ProjectWithRepo_package?nofilename=1&view=info&withchangesmd5=1
@@ -1554,13 +1628,13 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <sourceinfo package="ProjectWithRepo_package" rev="1" vrev="3" srcmd5="bd5b3338986f29cc911a8b873613bd70" lsrcmd5="9bcd667cba1fccb6f2edd222850b6994" verifymd5="e9d965f2d319f4124109f14a13f4e431">
+        <sourceinfo package="ProjectWithRepo_package" rev="1" vrev="4" srcmd5="89d23d961c6010378ec04f1a5ca82235" lsrcmd5="abe3c0682de9656b46e4fa83de7abbb4" verifymd5="6e6fbc10551cfc8eb7c6ccfc373d323f">
           <linked project="ProjectWithRepo:Update" package="ProjectWithRepo_package" />
           <linked project="ProjectWithRepo" package="ProjectWithRepo_package" />
-          <revtime>1503405074</revtime>
+          <revtime>1516090946</revtime>
         </sourceinfo>
     http_version: 
-  recorded_at: Tue, 22 Aug 2017 12:31:14 GMT
+  recorded_at: Tue, 16 Jan 2018 08:22:26 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:tom:branches:ProjectWithRepo:Update/ProjectWithRepo_package
@@ -1590,14 +1664,14 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="ProjectWithRepo_package" rev="1" vrev="1" srcmd5="9bcd667cba1fccb6f2edd222850b6994">
-          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" srcmd5="e9d965f2d319f4124109f14a13f4e431" baserev="e9d965f2d319f4124109f14a13f4e431" xsrcmd5="bd5b3338986f29cc911a8b873613bd70" lsrcmd5="9bcd667cba1fccb6f2edd222850b6994" />
-          <entry name="_config" md5="7159169868967997b7eabbd94d805185" size="238" mtime="1503405073" />
-          <entry name="_link" md5="11504ac69b4a7053159649a50cf86e1f" size="130" mtime="1503405074" />
-          <entry name="somefile.txt" md5="b4b03ef7ef00ded93403c2c595500c4f" size="116" mtime="1503405073" />
+        <directory name="ProjectWithRepo_package" rev="1" vrev="1" srcmd5="abe3c0682de9656b46e4fa83de7abbb4">
+          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" srcmd5="6e6fbc10551cfc8eb7c6ccfc373d323f" baserev="6e6fbc10551cfc8eb7c6ccfc373d323f" xsrcmd5="89d23d961c6010378ec04f1a5ca82235" lsrcmd5="abe3c0682de9656b46e4fa83de7abbb4" />
+          <entry name="_config" md5="e8ec9a29a8e74d4c7dfc73686c1576b5" size="143" mtime="1516090945" />
+          <entry name="_link" md5="e409478924f3c1c27d895156ac5f39b0" size="130" mtime="1516090946" />
+          <entry name="somefile.txt" md5="95c4ebbcd6a901fc5e9a47439d5e6f92" size="207" mtime="1516090945" />
         </directory>
     http_version: 
-  recorded_at: Tue, 22 Aug 2017 12:31:14 GMT
+  recorded_at: Tue, 16 Jan 2018 08:22:26 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:tom:branches:ProjectWithRepo:Update/ProjectWithRepo_package?cmd=diff&linkrev=base&onlyissues=1&orev=0&view=xml
@@ -1629,15 +1703,15 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="249372be2812c622072b0e55faf8419e">
+        <sourcediff key="154640e25017c7abe1ccb3e733749e61">
           <old project="home:tom:branches:ProjectWithRepo:Update" package="ProjectWithRepo_package" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e" />
-          <new project="home:tom:branches:ProjectWithRepo:Update" package="ProjectWithRepo_package" rev="1" srcmd5="9bcd667cba1fccb6f2edd222850b6994" />
+          <new project="home:tom:branches:ProjectWithRepo:Update" package="ProjectWithRepo_package" rev="1" srcmd5="abe3c0682de9656b46e4fa83de7abbb4" />
           <files />
           <issues>
           </issues>
         </sourcediff>
     http_version: 
-  recorded_at: Tue, 22 Aug 2017 12:31:14 GMT
+  recorded_at: Tue, 16 Jan 2018 08:22:26 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:tom:branches:ProjectWithRepo:Update/ProjectWithRepo_package?cmd=linkdiff&linkrev=base&onlyissues=1&view=xml
@@ -1669,13 +1743,13 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="eec63aa8658132c1dd83fd34730a0153">
-          <old project="ProjectWithRepo:Update" package="ProjectWithRepo_package" rev="e9d965f2d319f4124109f14a13f4e431" srcmd5="e9d965f2d319f4124109f14a13f4e431" />
-          <new project="home:tom:branches:ProjectWithRepo:Update" package="ProjectWithRepo_package" rev="bd5b3338986f29cc911a8b873613bd70" srcmd5="bd5b3338986f29cc911a8b873613bd70" />
+        <sourcediff key="26f99fc59293f6b8f2943a87ed0d4b42">
+          <old project="ProjectWithRepo:Update" package="ProjectWithRepo_package" rev="6e6fbc10551cfc8eb7c6ccfc373d323f" srcmd5="6e6fbc10551cfc8eb7c6ccfc373d323f" />
+          <new project="home:tom:branches:ProjectWithRepo:Update" package="ProjectWithRepo_package" rev="89d23d961c6010378ec04f1a5ca82235" srcmd5="89d23d961c6010378ec04f1a5ca82235" />
           <files />
         </sourcediff>
     http_version: 
-  recorded_at: Tue, 22 Aug 2017 12:31:14 GMT
+  recorded_at: Tue, 16 Jan 2018 08:22:26 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom:branches:ProjectWithRepo:Update/_meta?user=tom
@@ -1732,7 +1806,7 @@ http_interactions:
           </repository>
         </project>
     http_version: 
-  recorded_at: Tue, 22 Aug 2017 12:31:15 GMT
+  recorded_at: Tue, 16 Jan 2018 08:22:26 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:tom:branches:ProjectWithRepo:Update/ProjectWithRepo_package
@@ -1762,14 +1836,14 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="ProjectWithRepo_package" rev="1" vrev="1" srcmd5="9bcd667cba1fccb6f2edd222850b6994">
-          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" srcmd5="e9d965f2d319f4124109f14a13f4e431" baserev="e9d965f2d319f4124109f14a13f4e431" xsrcmd5="bd5b3338986f29cc911a8b873613bd70" lsrcmd5="9bcd667cba1fccb6f2edd222850b6994" />
-          <entry name="_config" md5="7159169868967997b7eabbd94d805185" size="238" mtime="1503405073" />
-          <entry name="_link" md5="11504ac69b4a7053159649a50cf86e1f" size="130" mtime="1503405074" />
-          <entry name="somefile.txt" md5="b4b03ef7ef00ded93403c2c595500c4f" size="116" mtime="1503405073" />
+        <directory name="ProjectWithRepo_package" rev="1" vrev="1" srcmd5="abe3c0682de9656b46e4fa83de7abbb4">
+          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" srcmd5="6e6fbc10551cfc8eb7c6ccfc373d323f" baserev="6e6fbc10551cfc8eb7c6ccfc373d323f" xsrcmd5="89d23d961c6010378ec04f1a5ca82235" lsrcmd5="abe3c0682de9656b46e4fa83de7abbb4" />
+          <entry name="_config" md5="e8ec9a29a8e74d4c7dfc73686c1576b5" size="143" mtime="1516090945" />
+          <entry name="_link" md5="e409478924f3c1c27d895156ac5f39b0" size="130" mtime="1516090946" />
+          <entry name="somefile.txt" md5="95c4ebbcd6a901fc5e9a47439d5e6f92" size="207" mtime="1516090945" />
         </directory>
     http_version: 
-  recorded_at: Tue, 22 Aug 2017 12:31:15 GMT
+  recorded_at: Tue, 16 Jan 2018 08:22:27 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:tom:branches:ProjectWithRepo:Update/ProjectWithRepo_package?expand=1&rev=1
@@ -1799,13 +1873,13 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="ProjectWithRepo_package" rev="bd5b3338986f29cc911a8b873613bd70" vrev="3" srcmd5="bd5b3338986f29cc911a8b873613bd70">
-          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" srcmd5="e9d965f2d319f4124109f14a13f4e431" baserev="e9d965f2d319f4124109f14a13f4e431" lsrcmd5="9bcd667cba1fccb6f2edd222850b6994" />
-          <entry name="_config" md5="7159169868967997b7eabbd94d805185" size="238" mtime="1503405073" />
-          <entry name="somefile.txt" md5="b4b03ef7ef00ded93403c2c595500c4f" size="116" mtime="1503405073" />
+        <directory name="ProjectWithRepo_package" rev="89d23d961c6010378ec04f1a5ca82235" vrev="4" srcmd5="89d23d961c6010378ec04f1a5ca82235">
+          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" srcmd5="6e6fbc10551cfc8eb7c6ccfc373d323f" baserev="6e6fbc10551cfc8eb7c6ccfc373d323f" lsrcmd5="abe3c0682de9656b46e4fa83de7abbb4" />
+          <entry name="_config" md5="e8ec9a29a8e74d4c7dfc73686c1576b5" size="143" mtime="1516090945" />
+          <entry name="somefile.txt" md5="95c4ebbcd6a901fc5e9a47439d5e6f92" size="207" mtime="1516090945" />
         </directory>
     http_version: 
-  recorded_at: Tue, 22 Aug 2017 12:31:15 GMT
+  recorded_at: Tue, 16 Jan 2018 08:22:27 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:tom:branches:ProjectWithRepo:Update/ProjectWithRepo_package
@@ -1837,14 +1911,14 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="ProjectWithRepo_package" rev="1" vrev="1" srcmd5="9bcd667cba1fccb6f2edd222850b6994">
-          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" srcmd5="e9d965f2d319f4124109f14a13f4e431" baserev="e9d965f2d319f4124109f14a13f4e431" xsrcmd5="bd5b3338986f29cc911a8b873613bd70" lsrcmd5="9bcd667cba1fccb6f2edd222850b6994" />
-          <entry name="_config" md5="7159169868967997b7eabbd94d805185" size="238" mtime="1503405073" />
-          <entry name="_link" md5="11504ac69b4a7053159649a50cf86e1f" size="130" mtime="1503405074" />
-          <entry name="somefile.txt" md5="b4b03ef7ef00ded93403c2c595500c4f" size="116" mtime="1503405073" />
+        <directory name="ProjectWithRepo_package" rev="1" vrev="1" srcmd5="abe3c0682de9656b46e4fa83de7abbb4">
+          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" srcmd5="6e6fbc10551cfc8eb7c6ccfc373d323f" baserev="6e6fbc10551cfc8eb7c6ccfc373d323f" xsrcmd5="89d23d961c6010378ec04f1a5ca82235" lsrcmd5="abe3c0682de9656b46e4fa83de7abbb4" />
+          <entry name="_config" md5="e8ec9a29a8e74d4c7dfc73686c1576b5" size="143" mtime="1516090945" />
+          <entry name="_link" md5="e409478924f3c1c27d895156ac5f39b0" size="130" mtime="1516090946" />
+          <entry name="somefile.txt" md5="95c4ebbcd6a901fc5e9a47439d5e6f92" size="207" mtime="1516090945" />
         </directory>
     http_version: 
-  recorded_at: Tue, 22 Aug 2017 12:31:15 GMT
+  recorded_at: Tue, 16 Jan 2018 08:22:27 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:tom:branches:ProjectWithRepo:Update/ProjectWithRepo_package/_service
@@ -1881,7 +1955,7 @@ http_interactions:
           <details>404 _service: no such file</details>
         </status>
     http_version: 
-  recorded_at: Tue, 22 Aug 2017 12:31:15 GMT
+  recorded_at: Tue, 16 Jan 2018 08:22:27 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:tom:branches:ProjectWithRepo:Update/ProjectWithRepo_package
@@ -1911,14 +1985,51 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="ProjectWithRepo_package" rev="1" vrev="1" srcmd5="9bcd667cba1fccb6f2edd222850b6994">
-          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" srcmd5="e9d965f2d319f4124109f14a13f4e431" baserev="e9d965f2d319f4124109f14a13f4e431" xsrcmd5="bd5b3338986f29cc911a8b873613bd70" lsrcmd5="9bcd667cba1fccb6f2edd222850b6994" />
-          <entry name="_config" md5="7159169868967997b7eabbd94d805185" size="238" mtime="1503405073" />
-          <entry name="_link" md5="11504ac69b4a7053159649a50cf86e1f" size="130" mtime="1503405074" />
-          <entry name="somefile.txt" md5="b4b03ef7ef00ded93403c2c595500c4f" size="116" mtime="1503405073" />
+        <directory name="ProjectWithRepo_package" rev="1" vrev="1" srcmd5="abe3c0682de9656b46e4fa83de7abbb4">
+          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" srcmd5="6e6fbc10551cfc8eb7c6ccfc373d323f" baserev="6e6fbc10551cfc8eb7c6ccfc373d323f" xsrcmd5="89d23d961c6010378ec04f1a5ca82235" lsrcmd5="abe3c0682de9656b46e4fa83de7abbb4" />
+          <entry name="_config" md5="e8ec9a29a8e74d4c7dfc73686c1576b5" size="143" mtime="1516090945" />
+          <entry name="_link" md5="e409478924f3c1c27d895156ac5f39b0" size="130" mtime="1516090946" />
+          <entry name="somefile.txt" md5="95c4ebbcd6a901fc5e9a47439d5e6f92" size="207" mtime="1516090945" />
         </directory>
     http_version: 
-  recorded_at: Tue, 22 Aug 2017 12:31:15 GMT
+  recorded_at: Tue, 16 Jan 2018 08:22:27 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:tom:branches:ProjectWithRepo:Update/ProjectWithRepo_package
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '659'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="ProjectWithRepo_package" rev="1" vrev="1" srcmd5="abe3c0682de9656b46e4fa83de7abbb4">
+          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" srcmd5="6e6fbc10551cfc8eb7c6ccfc373d323f" baserev="6e6fbc10551cfc8eb7c6ccfc373d323f" xsrcmd5="89d23d961c6010378ec04f1a5ca82235" lsrcmd5="abe3c0682de9656b46e4fa83de7abbb4" />
+          <entry name="_config" md5="e8ec9a29a8e74d4c7dfc73686c1576b5" size="143" mtime="1516090945" />
+          <entry name="_link" md5="e409478924f3c1c27d895156ac5f39b0" size="130" mtime="1516090946" />
+          <entry name="somefile.txt" md5="95c4ebbcd6a901fc5e9a47439d5e6f92" size="207" mtime="1516090945" />
+        </directory>
+    http_version: 
+  recorded_at: Tue, 16 Jan 2018 08:22:27 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:tom:branches:ProjectWithRepo:Update/ProjectWithRepo_package/_history
@@ -1950,14 +2061,14 @@ http_interactions:
       string: |
         <revisionlist>
           <revision rev="1" vrev="1">
-            <srcmd5>9bcd667cba1fccb6f2edd222850b6994</srcmd5>
+            <srcmd5>abe3c0682de9656b46e4fa83de7abbb4</srcmd5>
             <version>unknown</version>
-            <time>1503405074</time>
+            <time>1516090946</time>
             <user>tom</user>
           </revision>
         </revisionlist>
     http_version: 
-  recorded_at: Tue, 22 Aug 2017 12:31:15 GMT
+  recorded_at: Tue, 16 Jan 2018 08:22:27 GMT
 - request:
     method: get
     uri: http://backend:5352/build/home:tom:branches:ProjectWithRepo:Update/_result?package=ProjectWithRepo_package&view=status
@@ -1993,7 +2104,7 @@ http_interactions:
           <result project="home:tom:branches:ProjectWithRepo:Update" repository="repository_2" arch="i586" code="unknown" state="unknown" />
         </resultlist>
     http_version: 
-  recorded_at: Tue, 22 Aug 2017 12:31:15 GMT
+  recorded_at: Tue, 16 Jan 2018 08:22:27 GMT
 - request:
     method: get
     uri: http://backend:5352/build/home:tom:branches:ProjectWithRepo:Update/_result?locallink=1&multibuild=1&package=ProjectWithRepo_package&view=status
@@ -2029,7 +2140,7 @@ http_interactions:
           <result project="home:tom:branches:ProjectWithRepo:Update" repository="repository_2" arch="i586" code="unknown" state="unknown" />
         </resultlist>
     http_version: 
-  recorded_at: Tue, 22 Aug 2017 12:31:15 GMT
+  recorded_at: Tue, 16 Jan 2018 08:22:27 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom:branches:ProjectWithRepo:Update/ProjectWithRepo_package/DUMMY_FILE
@@ -2060,15 +2171,15 @@ http_interactions:
       encoding: UTF-8
       string: |
         <revision rev="2" vrev="2">
-          <srcmd5>5acba764a37a9bc6490f80deca372916</srcmd5>
+          <srcmd5>fea0bed8284652f582f84d5ba0388c2e</srcmd5>
           <version>unknown</version>
-          <time>1503405075</time>
+          <time>1516090947</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
     http_version: 
-  recorded_at: Tue, 22 Aug 2017 12:31:15 GMT
+  recorded_at: Tue, 16 Jan 2018 08:22:27 GMT
 - request:
     method: get
     uri: http://backend:5352/build/home:tom:branches:ProjectWithRepo:Update/_result?code=unresolvable&view=status
@@ -2076,10 +2187,8 @@ http_interactions:
       encoding: US-ASCII
       string: ''
     headers:
-      Content-Type:
-      - text/plain
       Accept-Encoding:
-      - identity
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
       - "*/*"
       User-Agent:
@@ -2104,7 +2213,7 @@ http_interactions:
           <result project="home:tom:branches:ProjectWithRepo:Update" repository="repository_2" arch="i586" code="unknown" state="unknown" />
         </resultlist>
     http_version: 
-  recorded_at: Tue, 22 Aug 2017 12:31:15 GMT
+  recorded_at: Tue, 16 Jan 2018 08:22:27 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:tom:branches:ProjectWithRepo:Update/_keyinfo?donotcreatecert=1&withsslcert=1
@@ -2135,7 +2244,7 @@ http_interactions:
       encoding: UTF-8
       string: "<keyinfo />\n"
     http_version: 
-  recorded_at: Tue, 22 Aug 2017 12:31:15 GMT
+  recorded_at: Tue, 16 Jan 2018 08:22:28 GMT
 - request:
     method: get
     uri: http://backend:5352/build/home:tom:branches:ProjectWithRepo:Update/_result?view=summary
@@ -2173,7 +2282,7 @@ http_interactions:
           </result>
         </resultlist>
     http_version: 
-  recorded_at: Tue, 22 Aug 2017 12:31:16 GMT
+  recorded_at: Tue, 16 Jan 2018 08:22:28 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:tom:branches:ProjectWithRepo:Update/ProjectWithRepo_package
@@ -2203,15 +2312,15 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="ProjectWithRepo_package" rev="2" vrev="2" srcmd5="5acba764a37a9bc6490f80deca372916">
-          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" srcmd5="e9d965f2d319f4124109f14a13f4e431" baserev="e9d965f2d319f4124109f14a13f4e431" xsrcmd5="6d8b4e042078d289ced39a1738e21c95" lsrcmd5="5acba764a37a9bc6490f80deca372916" />
-          <entry name="DUMMY_FILE" md5="275876e34cf609db118f3d84b799a790" size="5" mtime="1503405075" />
-          <entry name="_config" md5="7159169868967997b7eabbd94d805185" size="238" mtime="1503405073" />
-          <entry name="_link" md5="11504ac69b4a7053159649a50cf86e1f" size="130" mtime="1503405074" />
-          <entry name="somefile.txt" md5="b4b03ef7ef00ded93403c2c595500c4f" size="116" mtime="1503405073" />
+        <directory name="ProjectWithRepo_package" rev="2" vrev="2" srcmd5="fea0bed8284652f582f84d5ba0388c2e">
+          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" srcmd5="6e6fbc10551cfc8eb7c6ccfc373d323f" baserev="6e6fbc10551cfc8eb7c6ccfc373d323f" xsrcmd5="8dcbf337ee5aa0aa89a7deaab7d763d6" lsrcmd5="fea0bed8284652f582f84d5ba0388c2e" />
+          <entry name="DUMMY_FILE" md5="275876e34cf609db118f3d84b799a790" size="5" mtime="1516090947" />
+          <entry name="_config" md5="e8ec9a29a8e74d4c7dfc73686c1576b5" size="143" mtime="1516090945" />
+          <entry name="_link" md5="e409478924f3c1c27d895156ac5f39b0" size="130" mtime="1516090946" />
+          <entry name="somefile.txt" md5="95c4ebbcd6a901fc5e9a47439d5e6f92" size="207" mtime="1516090945" />
         </directory>
     http_version: 
-  recorded_at: Tue, 22 Aug 2017 12:31:16 GMT
+  recorded_at: Tue, 16 Jan 2018 08:22:28 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:tom:branches:ProjectWithRepo:Update/ProjectWithRepo_package
@@ -2241,15 +2350,15 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="ProjectWithRepo_package" rev="2" vrev="2" srcmd5="5acba764a37a9bc6490f80deca372916">
-          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" srcmd5="e9d965f2d319f4124109f14a13f4e431" baserev="e9d965f2d319f4124109f14a13f4e431" xsrcmd5="6d8b4e042078d289ced39a1738e21c95" lsrcmd5="5acba764a37a9bc6490f80deca372916" />
-          <entry name="DUMMY_FILE" md5="275876e34cf609db118f3d84b799a790" size="5" mtime="1503405075" />
-          <entry name="_config" md5="7159169868967997b7eabbd94d805185" size="238" mtime="1503405073" />
-          <entry name="_link" md5="11504ac69b4a7053159649a50cf86e1f" size="130" mtime="1503405074" />
-          <entry name="somefile.txt" md5="b4b03ef7ef00ded93403c2c595500c4f" size="116" mtime="1503405073" />
+        <directory name="ProjectWithRepo_package" rev="2" vrev="2" srcmd5="fea0bed8284652f582f84d5ba0388c2e">
+          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" srcmd5="6e6fbc10551cfc8eb7c6ccfc373d323f" baserev="6e6fbc10551cfc8eb7c6ccfc373d323f" xsrcmd5="8dcbf337ee5aa0aa89a7deaab7d763d6" lsrcmd5="fea0bed8284652f582f84d5ba0388c2e" />
+          <entry name="DUMMY_FILE" md5="275876e34cf609db118f3d84b799a790" size="5" mtime="1516090947" />
+          <entry name="_config" md5="e8ec9a29a8e74d4c7dfc73686c1576b5" size="143" mtime="1516090945" />
+          <entry name="_link" md5="e409478924f3c1c27d895156ac5f39b0" size="130" mtime="1516090946" />
+          <entry name="somefile.txt" md5="95c4ebbcd6a901fc5e9a47439d5e6f92" size="207" mtime="1516090945" />
         </directory>
     http_version: 
-  recorded_at: Tue, 22 Aug 2017 12:31:16 GMT
+  recorded_at: Tue, 16 Jan 2018 08:22:28 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:tom:branches:ProjectWithRepo:Update/ProjectWithRepo_package
@@ -2257,10 +2366,8 @@ http_interactions:
       encoding: US-ASCII
       string: ''
     headers:
-      Content-Type:
-      - text/plain
       Accept-Encoding:
-      - identity
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
       - "*/*"
       User-Agent:
@@ -2281,18 +2388,18 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="ProjectWithRepo_package" rev="2" vrev="2" srcmd5="5acba764a37a9bc6490f80deca372916">
-          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" srcmd5="e9d965f2d319f4124109f14a13f4e431" baserev="e9d965f2d319f4124109f14a13f4e431" xsrcmd5="6d8b4e042078d289ced39a1738e21c95" lsrcmd5="5acba764a37a9bc6490f80deca372916" />
-          <entry name="DUMMY_FILE" md5="275876e34cf609db118f3d84b799a790" size="5" mtime="1503405075" />
-          <entry name="_config" md5="7159169868967997b7eabbd94d805185" size="238" mtime="1503405073" />
-          <entry name="_link" md5="11504ac69b4a7053159649a50cf86e1f" size="130" mtime="1503405074" />
-          <entry name="somefile.txt" md5="b4b03ef7ef00ded93403c2c595500c4f" size="116" mtime="1503405073" />
+        <directory name="ProjectWithRepo_package" rev="2" vrev="2" srcmd5="fea0bed8284652f582f84d5ba0388c2e">
+          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" srcmd5="6e6fbc10551cfc8eb7c6ccfc373d323f" baserev="6e6fbc10551cfc8eb7c6ccfc373d323f" xsrcmd5="8dcbf337ee5aa0aa89a7deaab7d763d6" lsrcmd5="fea0bed8284652f582f84d5ba0388c2e" />
+          <entry name="DUMMY_FILE" md5="275876e34cf609db118f3d84b799a790" size="5" mtime="1516090947" />
+          <entry name="_config" md5="e8ec9a29a8e74d4c7dfc73686c1576b5" size="143" mtime="1516090945" />
+          <entry name="_link" md5="e409478924f3c1c27d895156ac5f39b0" size="130" mtime="1516090946" />
+          <entry name="somefile.txt" md5="95c4ebbcd6a901fc5e9a47439d5e6f92" size="207" mtime="1516090945" />
         </directory>
     http_version: 
-  recorded_at: Tue, 22 Aug 2017 12:31:16 GMT
+  recorded_at: Tue, 16 Jan 2018 08:22:28 GMT
 - request:
     method: post
-    uri: http://backend:5352/source/home:tom:branches:ProjectWithRepo:Update/ProjectWithRepo_package?cmd=diff&expand=1&filelimit=10000&opackage=ProjectWithRepo_package&oproject=ProjectWithRepo:Update
+    uri: http://backend:5352/source/home:tom:branches:ProjectWithRepo:Update/ProjectWithRepo_package?cmd=diff&expand=1&filelimit=10000&opackage=ProjectWithRepo_package&oproject=ProjectWithRepo:Update&tarlimit=10000
     body:
       encoding: UTF-8
       string: ''
@@ -2336,7 +2443,7 @@ http_interactions:
         +dummy
         \ No newline at end of file
     http_version: 
-  recorded_at: Tue, 22 Aug 2017 12:31:16 GMT
+  recorded_at: Tue, 16 Jan 2018 08:22:28 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:tom:branches:ProjectWithRepo:Update/ProjectWithRepo_package?expand=1
@@ -2366,14 +2473,14 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="ProjectWithRepo_package" rev="6d8b4e042078d289ced39a1738e21c95" vrev="4" srcmd5="6d8b4e042078d289ced39a1738e21c95">
-          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" srcmd5="e9d965f2d319f4124109f14a13f4e431" baserev="e9d965f2d319f4124109f14a13f4e431" lsrcmd5="5acba764a37a9bc6490f80deca372916" />
-          <entry name="DUMMY_FILE" md5="275876e34cf609db118f3d84b799a790" size="5" mtime="1503405075" />
-          <entry name="_config" md5="7159169868967997b7eabbd94d805185" size="238" mtime="1503405073" />
-          <entry name="somefile.txt" md5="b4b03ef7ef00ded93403c2c595500c4f" size="116" mtime="1503405073" />
+        <directory name="ProjectWithRepo_package" rev="8dcbf337ee5aa0aa89a7deaab7d763d6" vrev="5" srcmd5="8dcbf337ee5aa0aa89a7deaab7d763d6">
+          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" srcmd5="6e6fbc10551cfc8eb7c6ccfc373d323f" baserev="6e6fbc10551cfc8eb7c6ccfc373d323f" lsrcmd5="fea0bed8284652f582f84d5ba0388c2e" />
+          <entry name="DUMMY_FILE" md5="275876e34cf609db118f3d84b799a790" size="5" mtime="1516090947" />
+          <entry name="_config" md5="e8ec9a29a8e74d4c7dfc73686c1576b5" size="143" mtime="1516090945" />
+          <entry name="somefile.txt" md5="95c4ebbcd6a901fc5e9a47439d5e6f92" size="207" mtime="1516090945" />
         </directory>
     http_version: 
-  recorded_at: Tue, 22 Aug 2017 12:31:17 GMT
+  recorded_at: Tue, 16 Jan 2018 08:22:28 GMT
 - request:
     method: get
     uri: http://backend:5352/build/home:tom:branches:ProjectWithRepo:Update/_result?code=unresolvable&view=status
@@ -2381,10 +2488,8 @@ http_interactions:
       encoding: US-ASCII
       string: ''
     headers:
-      Content-Type:
-      - text/plain
       Accept-Encoding:
-      - identity
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
       - "*/*"
       User-Agent:
@@ -2409,7 +2514,7 @@ http_interactions:
           <result project="home:tom:branches:ProjectWithRepo:Update" repository="repository_2" arch="i586" code="unknown" state="unknown" />
         </resultlist>
     http_version: 
-  recorded_at: Tue, 22 Aug 2017 12:31:17 GMT
+  recorded_at: Tue, 16 Jan 2018 08:22:28 GMT
 - request:
     method: get
     uri: http://backend:5352/build/home:tom:branches:ProjectWithRepo:Update/_result?view=summary
@@ -2447,7 +2552,7 @@ http_interactions:
           </result>
         </resultlist>
     http_version: 
-  recorded_at: Tue, 22 Aug 2017 12:31:17 GMT
+  recorded_at: Tue, 16 Jan 2018 08:22:29 GMT
 - request:
     method: get
     uri: http://backend:5352/build/_workerstatus
@@ -2455,10 +2560,8 @@ http_interactions:
       encoding: US-ASCII
       string: ''
     headers:
-      Content-Type:
-      - text/plain
       Accept-Encoding:
-      - identity
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
       - "*/*"
       User-Agent:
@@ -2488,21 +2591,21 @@ http_interactions:
           <buildavg arch="i586" buildavg="1200" />
           <buildavg arch="x86_64" buildavg="1200" />
           <partition>
-            <daemon type="srcserver" state="running" starttime="1503405031" />
-            <daemon type="servicedispatch" state="running" starttime="1503405031" />
-            <daemon type="service" state="running" starttime="1503405031" />
+            <daemon type="srcserver" state="running" starttime="1516090902" />
+            <daemon type="servicedispatch" state="running" starttime="1516090903" />
+            <daemon type="service" state="running" starttime="1516090903" />
             <daemon type="scheduler" arch="i586" state="dead">
               <queue high="0" med="0" low="3" next="0" />
             </daemon>
             <daemon type="scheduler" arch="x86_64" state="dead">
               <queue high="39" med="0" low="7" next="0" />
             </daemon>
-            <daemon type="repserver" state="running" starttime="1503405031" />
+            <daemon type="repserver" state="running" starttime="1516090902" />
             <daemon type="publisher" state="dead" />
           </partition>
         </workerstatus>
     http_version: 
-  recorded_at: Tue, 22 Aug 2017 12:31:17 GMT
+  recorded_at: Tue, 16 Jan 2018 08:22:29 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:tom:branches:ProjectWithRepo:Update/ProjectWithRepo_package
@@ -2510,10 +2613,8 @@ http_interactions:
       encoding: US-ASCII
       string: ''
     headers:
-      Content-Type:
-      - text/plain
       Accept-Encoding:
-      - identity
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
       - "*/*"
       User-Agent:
@@ -2534,18 +2635,18 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="ProjectWithRepo_package" rev="2" vrev="2" srcmd5="5acba764a37a9bc6490f80deca372916">
-          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" srcmd5="e9d965f2d319f4124109f14a13f4e431" baserev="e9d965f2d319f4124109f14a13f4e431" xsrcmd5="6d8b4e042078d289ced39a1738e21c95" lsrcmd5="5acba764a37a9bc6490f80deca372916" />
-          <entry name="DUMMY_FILE" md5="275876e34cf609db118f3d84b799a790" size="5" mtime="1503405075" />
-          <entry name="_config" md5="7159169868967997b7eabbd94d805185" size="238" mtime="1503405073" />
-          <entry name="_link" md5="11504ac69b4a7053159649a50cf86e1f" size="130" mtime="1503405074" />
-          <entry name="somefile.txt" md5="b4b03ef7ef00ded93403c2c595500c4f" size="116" mtime="1503405073" />
+        <directory name="ProjectWithRepo_package" rev="2" vrev="2" srcmd5="fea0bed8284652f582f84d5ba0388c2e">
+          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" srcmd5="6e6fbc10551cfc8eb7c6ccfc373d323f" baserev="6e6fbc10551cfc8eb7c6ccfc373d323f" xsrcmd5="8dcbf337ee5aa0aa89a7deaab7d763d6" lsrcmd5="fea0bed8284652f582f84d5ba0388c2e" />
+          <entry name="DUMMY_FILE" md5="275876e34cf609db118f3d84b799a790" size="5" mtime="1516090947" />
+          <entry name="_config" md5="e8ec9a29a8e74d4c7dfc73686c1576b5" size="143" mtime="1516090945" />
+          <entry name="_link" md5="e409478924f3c1c27d895156ac5f39b0" size="130" mtime="1516090946" />
+          <entry name="somefile.txt" md5="95c4ebbcd6a901fc5e9a47439d5e6f92" size="207" mtime="1516090945" />
         </directory>
     http_version: 
-  recorded_at: Tue, 22 Aug 2017 12:31:19 GMT
+  recorded_at: Tue, 16 Jan 2018 08:22:30 GMT
 - request:
     method: post
-    uri: http://backend:5352/source/home:tom:branches:ProjectWithRepo:Update/ProjectWithRepo_package?cmd=diff&expand=1&filelimit=10000&opackage=ProjectWithRepo_package&oproject=ProjectWithRepo:Update&rev=6d8b4e042078d289ced39a1738e21c95&view=xml&withissues=1
+    uri: http://backend:5352/source/home:tom:branches:ProjectWithRepo:Update/ProjectWithRepo_package?cmd=diff&expand=1&filelimit=10000&opackage=ProjectWithRepo_package&oproject=ProjectWithRepo:Update&rev=8dcbf337ee5aa0aa89a7deaab7d763d6&tarlimit=10000&view=xml&withissues=1
     body:
       encoding: UTF-8
       string: ''
@@ -2574,9 +2675,9 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="5fc708afda388d0d4ddeaa33bda7c0df">
-          <old project="ProjectWithRepo:Update" package="ProjectWithRepo_package" rev="2" srcmd5="e9d965f2d319f4124109f14a13f4e431" />
-          <new project="home:tom:branches:ProjectWithRepo:Update" package="ProjectWithRepo_package" rev="6d8b4e042078d289ced39a1738e21c95" srcmd5="6d8b4e042078d289ced39a1738e21c95" />
+        <sourcediff key="7454e4acd2860c3bd17651af79808cfa">
+          <old project="ProjectWithRepo:Update" package="ProjectWithRepo_package" rev="2" srcmd5="6e6fbc10551cfc8eb7c6ccfc373d323f" />
+          <new project="home:tom:branches:ProjectWithRepo:Update" package="ProjectWithRepo_package" rev="8dcbf337ee5aa0aa89a7deaab7d763d6" srcmd5="8dcbf337ee5aa0aa89a7deaab7d763d6" />
           <files>
             <file state="added">
               <new name="DUMMY_FILE" md5="275876e34cf609db118f3d84b799a790" size="5" />
@@ -2590,7 +2691,7 @@ http_interactions:
           </issues>
         </sourcediff>
     http_version: 
-  recorded_at: Tue, 22 Aug 2017 12:31:19 GMT
+  recorded_at: Tue, 16 Jan 2018 08:22:30 GMT
 - request:
     method: get
     uri: http://backend:5352/build/home:tom:branches:ProjectWithRepo:Update/_result?package=ProjectWithRepo_package&view=status
@@ -2626,7 +2727,7 @@ http_interactions:
           <result project="home:tom:branches:ProjectWithRepo:Update" repository="repository_2" arch="i586" code="unknown" state="unknown" />
         </resultlist>
     http_version: 
-  recorded_at: Tue, 22 Aug 2017 12:31:19 GMT
+  recorded_at: Tue, 16 Jan 2018 08:22:31 GMT
 - request:
     method: get
     uri: http://backend:5352/build/home:tom:branches:ProjectWithRepo:Update/_result?locallink=1&multibuild=1&package=ProjectWithRepo_package&view=status
@@ -2662,7 +2763,7 @@ http_interactions:
           <result project="home:tom:branches:ProjectWithRepo:Update" repository="repository_2" arch="i586" code="unknown" state="unknown" />
         </resultlist>
     http_version: 
-  recorded_at: Tue, 22 Aug 2017 12:31:19 GMT
+  recorded_at: Tue, 16 Jan 2018 08:22:31 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:tom:branches:ProjectWithRepo:Update/ProjectWithRepo_package
@@ -2692,57 +2793,18 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="ProjectWithRepo_package" rev="2" vrev="2" srcmd5="5acba764a37a9bc6490f80deca372916">
-          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" srcmd5="e9d965f2d319f4124109f14a13f4e431" baserev="e9d965f2d319f4124109f14a13f4e431" xsrcmd5="6d8b4e042078d289ced39a1738e21c95" lsrcmd5="5acba764a37a9bc6490f80deca372916" />
-          <entry name="DUMMY_FILE" md5="275876e34cf609db118f3d84b799a790" size="5" mtime="1503405075" />
-          <entry name="_config" md5="7159169868967997b7eabbd94d805185" size="238" mtime="1503405073" />
-          <entry name="_link" md5="11504ac69b4a7053159649a50cf86e1f" size="130" mtime="1503405074" />
-          <entry name="somefile.txt" md5="b4b03ef7ef00ded93403c2c595500c4f" size="116" mtime="1503405073" />
+        <directory name="ProjectWithRepo_package" rev="2" vrev="2" srcmd5="fea0bed8284652f582f84d5ba0388c2e">
+          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" srcmd5="6e6fbc10551cfc8eb7c6ccfc373d323f" baserev="6e6fbc10551cfc8eb7c6ccfc373d323f" xsrcmd5="8dcbf337ee5aa0aa89a7deaab7d763d6" lsrcmd5="fea0bed8284652f582f84d5ba0388c2e" />
+          <entry name="DUMMY_FILE" md5="275876e34cf609db118f3d84b799a790" size="5" mtime="1516090947" />
+          <entry name="_config" md5="e8ec9a29a8e74d4c7dfc73686c1576b5" size="143" mtime="1516090945" />
+          <entry name="_link" md5="e409478924f3c1c27d895156ac5f39b0" size="130" mtime="1516090946" />
+          <entry name="somefile.txt" md5="95c4ebbcd6a901fc5e9a47439d5e6f92" size="207" mtime="1516090945" />
         </directory>
     http_version: 
-  recorded_at: Tue, 22 Aug 2017 12:31:19 GMT
+  recorded_at: Tue, 16 Jan 2018 08:22:31 GMT
 - request:
     method: get
-    uri: http://backend:5352/source/home:tom:branches:ProjectWithRepo:Update/ProjectWithRepo_package?expand=1&rev=6d8b4e042078d289ced39a1738e21c95
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Content-Type:
-      - text/plain
-      Accept-Encoding:
-      - identity
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '641'
-    body:
-      encoding: UTF-8
-      string: |
-        <directory name="ProjectWithRepo_package" rev="6d8b4e042078d289ced39a1738e21c95" srcmd5="6d8b4e042078d289ced39a1738e21c95">
-          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" srcmd5="e9d965f2d319f4124109f14a13f4e431" baserev="e9d965f2d319f4124109f14a13f4e431" lsrcmd5="5acba764a37a9bc6490f80deca372916" />
-          <entry name="DUMMY_FILE" md5="275876e34cf609db118f3d84b799a790" size="5" mtime="1503405075" />
-          <entry name="_config" md5="7159169868967997b7eabbd94d805185" size="238" mtime="1503405073" />
-          <entry name="somefile.txt" md5="b4b03ef7ef00ded93403c2c595500c4f" size="116" mtime="1503405073" />
-        </directory>
-    http_version: 
-  recorded_at: Tue, 22 Aug 2017 12:31:19 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/home:tom:branches:ProjectWithRepo:Update/ProjectWithRepo_package?expand=1&rev=6d8b4e042078d289ced39a1738e21c95
+    uri: http://backend:5352/source/home:tom:branches:ProjectWithRepo:Update/ProjectWithRepo_package?expand=1&rev=8dcbf337ee5aa0aa89a7deaab7d763d6
     body:
       encoding: US-ASCII
       string: ''
@@ -2769,14 +2831,51 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="ProjectWithRepo_package" rev="6d8b4e042078d289ced39a1738e21c95" srcmd5="6d8b4e042078d289ced39a1738e21c95">
-          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" srcmd5="e9d965f2d319f4124109f14a13f4e431" baserev="e9d965f2d319f4124109f14a13f4e431" lsrcmd5="5acba764a37a9bc6490f80deca372916" />
-          <entry name="DUMMY_FILE" md5="275876e34cf609db118f3d84b799a790" size="5" mtime="1503405075" />
-          <entry name="_config" md5="7159169868967997b7eabbd94d805185" size="238" mtime="1503405073" />
-          <entry name="somefile.txt" md5="b4b03ef7ef00ded93403c2c595500c4f" size="116" mtime="1503405073" />
+        <directory name="ProjectWithRepo_package" rev="8dcbf337ee5aa0aa89a7deaab7d763d6" srcmd5="8dcbf337ee5aa0aa89a7deaab7d763d6">
+          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" srcmd5="6e6fbc10551cfc8eb7c6ccfc373d323f" baserev="6e6fbc10551cfc8eb7c6ccfc373d323f" lsrcmd5="fea0bed8284652f582f84d5ba0388c2e" />
+          <entry name="DUMMY_FILE" md5="275876e34cf609db118f3d84b799a790" size="5" mtime="1516090947" />
+          <entry name="_config" md5="e8ec9a29a8e74d4c7dfc73686c1576b5" size="143" mtime="1516090945" />
+          <entry name="somefile.txt" md5="95c4ebbcd6a901fc5e9a47439d5e6f92" size="207" mtime="1516090945" />
         </directory>
     http_version: 
-  recorded_at: Tue, 22 Aug 2017 12:31:19 GMT
+  recorded_at: Tue, 16 Jan 2018 08:22:31 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:tom:branches:ProjectWithRepo:Update/ProjectWithRepo_package?expand=1&rev=8dcbf337ee5aa0aa89a7deaab7d763d6
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '641'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="ProjectWithRepo_package" rev="8dcbf337ee5aa0aa89a7deaab7d763d6" srcmd5="8dcbf337ee5aa0aa89a7deaab7d763d6">
+          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" srcmd5="6e6fbc10551cfc8eb7c6ccfc373d323f" baserev="6e6fbc10551cfc8eb7c6ccfc373d323f" lsrcmd5="fea0bed8284652f582f84d5ba0388c2e" />
+          <entry name="DUMMY_FILE" md5="275876e34cf609db118f3d84b799a790" size="5" mtime="1516090947" />
+          <entry name="_config" md5="e8ec9a29a8e74d4c7dfc73686c1576b5" size="143" mtime="1516090945" />
+          <entry name="somefile.txt" md5="95c4ebbcd6a901fc5e9a47439d5e6f92" size="207" mtime="1516090945" />
+        </directory>
+    http_version: 
+  recorded_at: Tue, 16 Jan 2018 08:22:31 GMT
 - request:
     method: put
     uri: http://backend:5352/source/MaintenanceProject:0/_meta?requestid=1&user=maintenance_coord
@@ -2831,7 +2930,7 @@ http_interactions:
           </publish>
         </project>
     http_version: 
-  recorded_at: Tue, 22 Aug 2017 12:31:19 GMT
+  recorded_at: Tue, 16 Jan 2018 08:22:31 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:tom:branches:ProjectWithRepo:Update/ProjectWithRepo_package
@@ -2861,15 +2960,15 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="ProjectWithRepo_package" rev="2" vrev="2" srcmd5="5acba764a37a9bc6490f80deca372916">
-          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" srcmd5="e9d965f2d319f4124109f14a13f4e431" baserev="e9d965f2d319f4124109f14a13f4e431" xsrcmd5="6d8b4e042078d289ced39a1738e21c95" lsrcmd5="5acba764a37a9bc6490f80deca372916" />
-          <entry name="DUMMY_FILE" md5="275876e34cf609db118f3d84b799a790" size="5" mtime="1503405075" />
-          <entry name="_config" md5="7159169868967997b7eabbd94d805185" size="238" mtime="1503405073" />
-          <entry name="_link" md5="11504ac69b4a7053159649a50cf86e1f" size="130" mtime="1503405074" />
-          <entry name="somefile.txt" md5="b4b03ef7ef00ded93403c2c595500c4f" size="116" mtime="1503405073" />
+        <directory name="ProjectWithRepo_package" rev="2" vrev="2" srcmd5="fea0bed8284652f582f84d5ba0388c2e">
+          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" srcmd5="6e6fbc10551cfc8eb7c6ccfc373d323f" baserev="6e6fbc10551cfc8eb7c6ccfc373d323f" xsrcmd5="8dcbf337ee5aa0aa89a7deaab7d763d6" lsrcmd5="fea0bed8284652f582f84d5ba0388c2e" />
+          <entry name="DUMMY_FILE" md5="275876e34cf609db118f3d84b799a790" size="5" mtime="1516090947" />
+          <entry name="_config" md5="e8ec9a29a8e74d4c7dfc73686c1576b5" size="143" mtime="1516090945" />
+          <entry name="_link" md5="e409478924f3c1c27d895156ac5f39b0" size="130" mtime="1516090946" />
+          <entry name="somefile.txt" md5="95c4ebbcd6a901fc5e9a47439d5e6f92" size="207" mtime="1516090945" />
         </directory>
     http_version: 
-  recorded_at: Tue, 22 Aug 2017 12:31:19 GMT
+  recorded_at: Tue, 16 Jan 2018 08:22:31 GMT
 - request:
     method: post
     uri: http://backend:5352/search/package/id?match=(linkinfo/@package=%22ProjectWithRepo_package%22%20and%20linkinfo/@project=%22ProjectWithRepo:Update%22%20and%20starts-with(@project,%22MaintenanceProject:%22))
@@ -2904,7 +3003,7 @@ http_interactions:
         <collection>
         </collection>
     http_version: 
-  recorded_at: Tue, 22 Aug 2017 12:31:19 GMT
+  recorded_at: Tue, 16 Jan 2018 08:22:31 GMT
 - request:
     method: post
     uri: http://backend:5352/search/package/id?match=(linkinfo/@package=%22ProjectWithRepo_package%22%20and%20linkinfo/@project=%22ProjectWithRepo%22%20and%20@project=%22ProjectWithRepo%22)
@@ -2939,7 +3038,7 @@ http_interactions:
         <collection>
         </collection>
     http_version: 
-  recorded_at: Tue, 22 Aug 2017 12:31:19 GMT
+  recorded_at: Tue, 16 Jan 2018 08:22:31 GMT
 - request:
     method: put
     uri: http://backend:5352/source/MaintenanceProject:0/ProjectWithRepo_package.ProjectWithRepo_Update/_meta?user=maintenance_coord
@@ -2947,8 +3046,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="ProjectWithRepo_package.ProjectWithRepo_Update" project="MaintenanceProject:0">
-          <title>Have His Carcase</title>
-          <description>Molestiae eligendi asperiores quod voluptatibus totam non recusandae voluptas.</description>
+          <title>To a God Unknown</title>
+          <description>Sed voluptatum dolorem et omnis.</description>
           <releasename>ProjectWithRepo_package</releasename>
         </package>
     headers:
@@ -2970,20 +3069,20 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '301'
+      - '255'
     body:
       encoding: UTF-8
       string: |
         <package name="ProjectWithRepo_package.ProjectWithRepo_Update" project="MaintenanceProject:0">
-          <title>Have His Carcase</title>
-          <description>Molestiae eligendi asperiores quod voluptatibus totam non recusandae voluptas.</description>
+          <title>To a God Unknown</title>
+          <description>Sed voluptatum dolorem et omnis.</description>
           <releasename>ProjectWithRepo_package</releasename>
         </package>
     http_version: 
-  recorded_at: Tue, 22 Aug 2017 12:31:19 GMT
+  recorded_at: Tue, 16 Jan 2018 08:22:31 GMT
 - request:
     method: post
-    uri: http://backend:5352/source/MaintenanceProject:0/ProjectWithRepo_package.ProjectWithRepo_Update?cmd=branch&opackage=ProjectWithRepo_package&oproject=ProjectWithRepo:Update&user=maintenance_coord
+    uri: http://backend:5352/source/MaintenanceProject:0/ProjectWithRepo_package.ProjectWithRepo_Update?cmd=branch&extendvrev=1&noservice=1&opackage=ProjectWithRepo_package&oproject=ProjectWithRepo:Update&user=maintenance_coord
     body:
       encoding: UTF-8
       string: ''
@@ -3013,15 +3112,15 @@ http_interactions:
       encoding: UTF-8
       string: |
         <revision rev="1" vrev="1">
-          <srcmd5>8f207ebc6846b26ebb947a0d4399345e</srcmd5>
+          <srcmd5>012405659355f1fe41511515d788a6aa</srcmd5>
           <version>unknown</version>
-          <time>1503405079</time>
+          <time>1516090951</time>
           <user>maintenance_coord</user>
           <comment></comment>
           <requestid/>
         </revision>
     http_version: 
-  recorded_at: Tue, 22 Aug 2017 12:31:19 GMT
+  recorded_at: Tue, 16 Jan 2018 08:22:31 GMT
 - request:
     method: put
     uri: http://backend:5352/source/MaintenanceProject:0/ProjectWithRepo_package.ProjectWithRepo_Update/_meta?user=maintenance_coord
@@ -3029,8 +3128,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="ProjectWithRepo_package.ProjectWithRepo_Update" project="MaintenanceProject:0">
-          <title>Have His Carcase</title>
-          <description>Molestiae eligendi asperiores quod voluptatibus totam non recusandae voluptas.</description>
+          <title>To a God Unknown</title>
+          <description>Sed voluptatum dolorem et omnis.</description>
           <releasename>ProjectWithRepo_package</releasename>
         </package>
     headers:
@@ -3052,17 +3151,17 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '301'
+      - '255'
     body:
       encoding: UTF-8
       string: |
         <package name="ProjectWithRepo_package.ProjectWithRepo_Update" project="MaintenanceProject:0">
-          <title>Have His Carcase</title>
-          <description>Molestiae eligendi asperiores quod voluptatibus totam non recusandae voluptas.</description>
+          <title>To a God Unknown</title>
+          <description>Sed voluptatum dolorem et omnis.</description>
           <releasename>ProjectWithRepo_package</releasename>
         </package>
     http_version: 
-  recorded_at: Tue, 22 Aug 2017 12:31:20 GMT
+  recorded_at: Tue, 16 Jan 2018 08:22:31 GMT
 - request:
     method: get
     uri: http://backend:5352/source/MaintenanceProject:0/ProjectWithRepo_package.ProjectWithRepo_Update
@@ -3092,14 +3191,14 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="ProjectWithRepo_package.ProjectWithRepo_Update" rev="1" vrev="1" srcmd5="8f207ebc6846b26ebb947a0d4399345e">
-          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" srcmd5="e9d965f2d319f4124109f14a13f4e431" baserev="e9d965f2d319f4124109f14a13f4e431" xsrcmd5="ef9928a63930d4797ced0ef2ad58ed0c" lsrcmd5="8f207ebc6846b26ebb947a0d4399345e" />
-          <entry name="_config" md5="7159169868967997b7eabbd94d805185" size="238" mtime="1503405073" />
-          <entry name="_link" md5="ad672afb37ca2f6a039ad35297d226d1" size="164" mtime="1503405079" />
-          <entry name="somefile.txt" md5="b4b03ef7ef00ded93403c2c595500c4f" size="116" mtime="1503405073" />
+        <directory name="ProjectWithRepo_package.ProjectWithRepo_Update" rev="1" vrev="1" srcmd5="012405659355f1fe41511515d788a6aa">
+          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" srcmd5="6e6fbc10551cfc8eb7c6ccfc373d323f" baserev="6e6fbc10551cfc8eb7c6ccfc373d323f" xsrcmd5="39895c37617de8a93814934ec17f5508" lsrcmd5="012405659355f1fe41511515d788a6aa" />
+          <entry name="_config" md5="e8ec9a29a8e74d4c7dfc73686c1576b5" size="143" mtime="1516090945" />
+          <entry name="_link" md5="56994b1cc0c8cb5e1662d148e8d3ba70" size="175" mtime="1516090951" />
+          <entry name="somefile.txt" md5="95c4ebbcd6a901fc5e9a47439d5e6f92" size="207" mtime="1516090945" />
         </directory>
     http_version: 
-  recorded_at: Tue, 22 Aug 2017 12:31:20 GMT
+  recorded_at: Tue, 16 Jan 2018 08:22:31 GMT
 - request:
     method: get
     uri: http://backend:5352/source/MaintenanceProject:0/ProjectWithRepo_package.ProjectWithRepo_Update?nofilename=1&view=info&withchangesmd5=1
@@ -3125,17 +3224,17 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '416'
+      - '418'
     body:
       encoding: UTF-8
       string: |
-        <sourceinfo package="ProjectWithRepo_package.ProjectWithRepo_Update" rev="1" vrev="3" srcmd5="ef9928a63930d4797ced0ef2ad58ed0c" lsrcmd5="8f207ebc6846b26ebb947a0d4399345e" verifymd5="e9d965f2d319f4124109f14a13f4e431">
+        <sourceinfo package="ProjectWithRepo_package.ProjectWithRepo_Update" rev="1" vrev="4.2" srcmd5="39895c37617de8a93814934ec17f5508" lsrcmd5="012405659355f1fe41511515d788a6aa" verifymd5="6e6fbc10551cfc8eb7c6ccfc373d323f">
           <linked project="ProjectWithRepo:Update" package="ProjectWithRepo_package" />
           <linked project="ProjectWithRepo" package="ProjectWithRepo_package" />
-          <revtime>1503405079</revtime>
+          <revtime>1516090951</revtime>
         </sourceinfo>
     http_version: 
-  recorded_at: Tue, 22 Aug 2017 12:31:20 GMT
+  recorded_at: Tue, 16 Jan 2018 08:22:31 GMT
 - request:
     method: get
     uri: http://backend:5352/source/MaintenanceProject:0/ProjectWithRepo_package.ProjectWithRepo_Update
@@ -3165,14 +3264,14 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="ProjectWithRepo_package.ProjectWithRepo_Update" rev="1" vrev="1" srcmd5="8f207ebc6846b26ebb947a0d4399345e">
-          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" srcmd5="e9d965f2d319f4124109f14a13f4e431" baserev="e9d965f2d319f4124109f14a13f4e431" xsrcmd5="ef9928a63930d4797ced0ef2ad58ed0c" lsrcmd5="8f207ebc6846b26ebb947a0d4399345e" />
-          <entry name="_config" md5="7159169868967997b7eabbd94d805185" size="238" mtime="1503405073" />
-          <entry name="_link" md5="ad672afb37ca2f6a039ad35297d226d1" size="164" mtime="1503405079" />
-          <entry name="somefile.txt" md5="b4b03ef7ef00ded93403c2c595500c4f" size="116" mtime="1503405073" />
+        <directory name="ProjectWithRepo_package.ProjectWithRepo_Update" rev="1" vrev="1" srcmd5="012405659355f1fe41511515d788a6aa">
+          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" srcmd5="6e6fbc10551cfc8eb7c6ccfc373d323f" baserev="6e6fbc10551cfc8eb7c6ccfc373d323f" xsrcmd5="39895c37617de8a93814934ec17f5508" lsrcmd5="012405659355f1fe41511515d788a6aa" />
+          <entry name="_config" md5="e8ec9a29a8e74d4c7dfc73686c1576b5" size="143" mtime="1516090945" />
+          <entry name="_link" md5="56994b1cc0c8cb5e1662d148e8d3ba70" size="175" mtime="1516090951" />
+          <entry name="somefile.txt" md5="95c4ebbcd6a901fc5e9a47439d5e6f92" size="207" mtime="1516090945" />
         </directory>
     http_version: 
-  recorded_at: Tue, 22 Aug 2017 12:31:20 GMT
+  recorded_at: Tue, 16 Jan 2018 08:22:31 GMT
 - request:
     method: post
     uri: http://backend:5352/source/MaintenanceProject:0/ProjectWithRepo_package.ProjectWithRepo_Update?cmd=diff&linkrev=base&onlyissues=1&orev=0&view=xml
@@ -3204,15 +3303,15 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="b61c34ff40308ddf8f623d6890654428">
+        <sourcediff key="4f69c657ad64b4357dd230fc3e5828da">
           <old project="MaintenanceProject:0" package="ProjectWithRepo_package.ProjectWithRepo_Update" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e" />
-          <new project="MaintenanceProject:0" package="ProjectWithRepo_package.ProjectWithRepo_Update" rev="1" srcmd5="8f207ebc6846b26ebb947a0d4399345e" />
+          <new project="MaintenanceProject:0" package="ProjectWithRepo_package.ProjectWithRepo_Update" rev="1" srcmd5="012405659355f1fe41511515d788a6aa" />
           <files />
           <issues>
           </issues>
         </sourcediff>
     http_version: 
-  recorded_at: Tue, 22 Aug 2017 12:31:20 GMT
+  recorded_at: Tue, 16 Jan 2018 08:22:31 GMT
 - request:
     method: post
     uri: http://backend:5352/source/MaintenanceProject:0/ProjectWithRepo_package.ProjectWithRepo_Update?cmd=linkdiff&linkrev=base&onlyissues=1&view=xml
@@ -3244,13 +3343,13 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="2bd7c5fd0453c368b796a8f70d681186">
-          <old project="ProjectWithRepo:Update" package="ProjectWithRepo_package" rev="e9d965f2d319f4124109f14a13f4e431" srcmd5="e9d965f2d319f4124109f14a13f4e431" />
-          <new project="MaintenanceProject:0" package="ProjectWithRepo_package.ProjectWithRepo_Update" rev="ef9928a63930d4797ced0ef2ad58ed0c" srcmd5="ef9928a63930d4797ced0ef2ad58ed0c" />
+        <sourcediff key="27443efe80b045615f13f3a3eac0e487">
+          <old project="ProjectWithRepo:Update" package="ProjectWithRepo_package" rev="6e6fbc10551cfc8eb7c6ccfc373d323f" srcmd5="6e6fbc10551cfc8eb7c6ccfc373d323f" />
+          <new project="MaintenanceProject:0" package="ProjectWithRepo_package.ProjectWithRepo_Update" rev="39895c37617de8a93814934ec17f5508" srcmd5="39895c37617de8a93814934ec17f5508" />
           <files />
         </sourcediff>
     http_version: 
-  recorded_at: Tue, 22 Aug 2017 12:31:20 GMT
+  recorded_at: Tue, 16 Jan 2018 08:22:31 GMT
 - request:
     method: put
     uri: http://backend:5352/source/MaintenanceProject:0/ProjectWithRepo_package.ProjectWithRepo_Update/_meta?user=maintenance_coord
@@ -3258,8 +3357,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="ProjectWithRepo_package.ProjectWithRepo_Update" project="MaintenanceProject:0">
-          <title>Have His Carcase</title>
-          <description>Molestiae eligendi asperiores quod voluptatibus totam non recusandae voluptas.</description>
+          <title>To a God Unknown</title>
+          <description>Sed voluptatum dolorem et omnis.</description>
           <releasename>ProjectWithRepo_package</releasename>
           <build>
             <enable repository="ProjectWithRepo_Update"/>
@@ -3284,20 +3383,20 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '373'
+      - '327'
     body:
       encoding: UTF-8
       string: |
         <package name="ProjectWithRepo_package.ProjectWithRepo_Update" project="MaintenanceProject:0">
-          <title>Have His Carcase</title>
-          <description>Molestiae eligendi asperiores quod voluptatibus totam non recusandae voluptas.</description>
+          <title>To a God Unknown</title>
+          <description>Sed voluptatum dolorem et omnis.</description>
           <releasename>ProjectWithRepo_package</releasename>
           <build>
             <enable repository="ProjectWithRepo_Update" />
           </build>
         </package>
     http_version: 
-  recorded_at: Tue, 22 Aug 2017 12:31:20 GMT
+  recorded_at: Tue, 16 Jan 2018 08:22:32 GMT
 - request:
     method: get
     uri: http://backend:5352/source/MaintenanceProject:0/ProjectWithRepo_package.ProjectWithRepo_Update
@@ -3327,14 +3426,14 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="ProjectWithRepo_package.ProjectWithRepo_Update" rev="1" vrev="1" srcmd5="8f207ebc6846b26ebb947a0d4399345e">
-          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" srcmd5="e9d965f2d319f4124109f14a13f4e431" baserev="e9d965f2d319f4124109f14a13f4e431" xsrcmd5="ef9928a63930d4797ced0ef2ad58ed0c" lsrcmd5="8f207ebc6846b26ebb947a0d4399345e" />
-          <entry name="_config" md5="7159169868967997b7eabbd94d805185" size="238" mtime="1503405073" />
-          <entry name="_link" md5="ad672afb37ca2f6a039ad35297d226d1" size="164" mtime="1503405079" />
-          <entry name="somefile.txt" md5="b4b03ef7ef00ded93403c2c595500c4f" size="116" mtime="1503405073" />
+        <directory name="ProjectWithRepo_package.ProjectWithRepo_Update" rev="1" vrev="1" srcmd5="012405659355f1fe41511515d788a6aa">
+          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" srcmd5="6e6fbc10551cfc8eb7c6ccfc373d323f" baserev="6e6fbc10551cfc8eb7c6ccfc373d323f" xsrcmd5="39895c37617de8a93814934ec17f5508" lsrcmd5="012405659355f1fe41511515d788a6aa" />
+          <entry name="_config" md5="e8ec9a29a8e74d4c7dfc73686c1576b5" size="143" mtime="1516090945" />
+          <entry name="_link" md5="56994b1cc0c8cb5e1662d148e8d3ba70" size="175" mtime="1516090951" />
+          <entry name="somefile.txt" md5="95c4ebbcd6a901fc5e9a47439d5e6f92" size="207" mtime="1516090945" />
         </directory>
     http_version: 
-  recorded_at: Tue, 22 Aug 2017 12:31:20 GMT
+  recorded_at: Tue, 16 Jan 2018 08:22:32 GMT
 - request:
     method: get
     uri: http://backend:5352/source/MaintenanceProject:0/ProjectWithRepo_package.ProjectWithRepo_Update
@@ -3364,14 +3463,14 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="ProjectWithRepo_package.ProjectWithRepo_Update" rev="1" vrev="1" srcmd5="8f207ebc6846b26ebb947a0d4399345e">
-          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" srcmd5="e9d965f2d319f4124109f14a13f4e431" baserev="e9d965f2d319f4124109f14a13f4e431" xsrcmd5="ef9928a63930d4797ced0ef2ad58ed0c" lsrcmd5="8f207ebc6846b26ebb947a0d4399345e" />
-          <entry name="_config" md5="7159169868967997b7eabbd94d805185" size="238" mtime="1503405073" />
-          <entry name="_link" md5="ad672afb37ca2f6a039ad35297d226d1" size="164" mtime="1503405079" />
-          <entry name="somefile.txt" md5="b4b03ef7ef00ded93403c2c595500c4f" size="116" mtime="1503405073" />
+        <directory name="ProjectWithRepo_package.ProjectWithRepo_Update" rev="1" vrev="1" srcmd5="012405659355f1fe41511515d788a6aa">
+          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" srcmd5="6e6fbc10551cfc8eb7c6ccfc373d323f" baserev="6e6fbc10551cfc8eb7c6ccfc373d323f" xsrcmd5="39895c37617de8a93814934ec17f5508" lsrcmd5="012405659355f1fe41511515d788a6aa" />
+          <entry name="_config" md5="e8ec9a29a8e74d4c7dfc73686c1576b5" size="143" mtime="1516090945" />
+          <entry name="_link" md5="56994b1cc0c8cb5e1662d148e8d3ba70" size="175" mtime="1516090951" />
+          <entry name="somefile.txt" md5="95c4ebbcd6a901fc5e9a47439d5e6f92" size="207" mtime="1516090945" />
         </directory>
     http_version: 
-  recorded_at: Tue, 22 Aug 2017 12:31:20 GMT
+  recorded_at: Tue, 16 Jan 2018 08:22:32 GMT
 - request:
     method: get
     uri: http://backend:5352/source/MaintenanceProject:0/ProjectWithRepo_package.ProjectWithRepo_Update
@@ -3401,14 +3500,14 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="ProjectWithRepo_package.ProjectWithRepo_Update" rev="1" vrev="1" srcmd5="8f207ebc6846b26ebb947a0d4399345e">
-          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" srcmd5="e9d965f2d319f4124109f14a13f4e431" baserev="e9d965f2d319f4124109f14a13f4e431" xsrcmd5="ef9928a63930d4797ced0ef2ad58ed0c" lsrcmd5="8f207ebc6846b26ebb947a0d4399345e" />
-          <entry name="_config" md5="7159169868967997b7eabbd94d805185" size="238" mtime="1503405073" />
-          <entry name="_link" md5="ad672afb37ca2f6a039ad35297d226d1" size="164" mtime="1503405079" />
-          <entry name="somefile.txt" md5="b4b03ef7ef00ded93403c2c595500c4f" size="116" mtime="1503405073" />
+        <directory name="ProjectWithRepo_package.ProjectWithRepo_Update" rev="1" vrev="1" srcmd5="012405659355f1fe41511515d788a6aa">
+          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" srcmd5="6e6fbc10551cfc8eb7c6ccfc373d323f" baserev="6e6fbc10551cfc8eb7c6ccfc373d323f" xsrcmd5="39895c37617de8a93814934ec17f5508" lsrcmd5="012405659355f1fe41511515d788a6aa" />
+          <entry name="_config" md5="e8ec9a29a8e74d4c7dfc73686c1576b5" size="143" mtime="1516090945" />
+          <entry name="_link" md5="56994b1cc0c8cb5e1662d148e8d3ba70" size="175" mtime="1516090951" />
+          <entry name="somefile.txt" md5="95c4ebbcd6a901fc5e9a47439d5e6f92" size="207" mtime="1516090945" />
         </directory>
     http_version: 
-  recorded_at: Tue, 22 Aug 2017 12:31:20 GMT
+  recorded_at: Tue, 16 Jan 2018 08:22:32 GMT
 - request:
     method: post
     uri: http://backend:5352/search/package/id?match=(linkinfo/@package=%22ProjectWithRepo_package%22%20and%20linkinfo/@project=%22ProjectWithRepo%22%20and%20@project=%22ProjectWithRepo%22)
@@ -3443,7 +3542,7 @@ http_interactions:
         <collection>
         </collection>
     http_version: 
-  recorded_at: Tue, 22 Aug 2017 12:31:20 GMT
+  recorded_at: Tue, 16 Jan 2018 08:22:32 GMT
 - request:
     method: put
     uri: http://backend:5352/source/MaintenanceProject:0/_meta?user=maintenance_coord
@@ -3508,7 +3607,7 @@ http_interactions:
           </repository>
         </project>
     http_version: 
-  recorded_at: Tue, 22 Aug 2017 12:31:20 GMT
+  recorded_at: Tue, 16 Jan 2018 08:22:32 GMT
 - request:
     method: put
     uri: http://backend:5352/source/MaintenanceProject:0/_meta?user=maintenance_coord
@@ -3573,10 +3672,10 @@ http_interactions:
           </repository>
         </project>
     http_version: 
-  recorded_at: Tue, 22 Aug 2017 12:31:20 GMT
+  recorded_at: Tue, 16 Jan 2018 08:22:32 GMT
 - request:
     method: post
-    uri: http://backend:5352/source/MaintenanceProject:0/ProjectWithRepo_package.ProjectWithRepo_Update?cmd=copy&comment=Maintenance%20incident%20copy%20from%20project%20home:tom:branches:ProjectWithRepo:Update&expand=1&keeplink=1&opackage=ProjectWithRepo_package&oproject=home:tom:branches:ProjectWithRepo:Update&orev=6d8b4e042078d289ced39a1738e21c95&requestid=1&user=maintenance_coord&withacceptinfo=1
+    uri: http://backend:5352/source/MaintenanceProject:0/ProjectWithRepo_package.ProjectWithRepo_Update?cmd=copy&comment=Maintenance%20incident%20copy%20from%20project%20home:tom:branches:ProjectWithRepo:Update&expand=1&keeplink=1&opackage=ProjectWithRepo_package&oproject=home:tom:branches:ProjectWithRepo:Update&orev=8dcbf337ee5aa0aa89a7deaab7d763d6&requestid=1&user=maintenance_coord&withacceptinfo=1
     body:
       encoding: UTF-8
       string: ''
@@ -3606,16 +3705,16 @@ http_interactions:
       encoding: UTF-8
       string: |
         <revision rev="2" vrev="2">
-          <srcmd5>3bc4d536be0f4724dd0defa094f247cf</srcmd5>
+          <srcmd5>cf22b6ca4707e8afe3633d31126e5c64</srcmd5>
           <version>unknown</version>
-          <time>1503405080</time>
+          <time>1516090952</time>
           <user>maintenance_coord</user>
           <comment>Maintenance incident copy from project home:tom:branches:ProjectWithRepo:Update</comment>
           <requestid>1</requestid>
-          <acceptinfo rev="2" srcmd5="3bc4d536be0f4724dd0defa094f247cf" osrcmd5="8f207ebc6846b26ebb947a0d4399345e" xsrcmd5="96b1040600ed3f57e960243b55548162" oxsrcmd5="ef9928a63930d4797ced0ef2ad58ed0c" />
+          <acceptinfo rev="2" srcmd5="cf22b6ca4707e8afe3633d31126e5c64" osrcmd5="012405659355f1fe41511515d788a6aa" xsrcmd5="d6a5bbec579b568ed1fb0cf3f9931435" oxsrcmd5="39895c37617de8a93814934ec17f5508" />
         </revision>
     http_version: 
-  recorded_at: Tue, 22 Aug 2017 12:31:20 GMT
+  recorded_at: Tue, 16 Jan 2018 08:22:32 GMT
 - request:
     method: put
     uri: http://backend:5352/source/MaintenanceProject:0/ProjectWithRepo_package.ProjectWithRepo_Update/_meta?user=maintenance_coord
@@ -3623,8 +3722,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="ProjectWithRepo_package.ProjectWithRepo_Update" project="MaintenanceProject:0">
-          <title>Have His Carcase</title>
-          <description>Molestiae eligendi asperiores quod voluptatibus totam non recusandae voluptas.</description>
+          <title>To a God Unknown</title>
+          <description>Sed voluptatum dolorem et omnis.</description>
           <releasename>ProjectWithRepo_package</releasename>
           <build>
             <enable repository="ProjectWithRepo_Update"/>
@@ -3649,20 +3748,20 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '373'
+      - '327'
     body:
       encoding: UTF-8
       string: |
         <package name="ProjectWithRepo_package.ProjectWithRepo_Update" project="MaintenanceProject:0">
-          <title>Have His Carcase</title>
-          <description>Molestiae eligendi asperiores quod voluptatibus totam non recusandae voluptas.</description>
+          <title>To a God Unknown</title>
+          <description>Sed voluptatum dolorem et omnis.</description>
           <releasename>ProjectWithRepo_package</releasename>
           <build>
             <enable repository="ProjectWithRepo_Update" />
           </build>
         </package>
     http_version: 
-  recorded_at: Tue, 22 Aug 2017 12:31:20 GMT
+  recorded_at: Tue, 16 Jan 2018 08:22:32 GMT
 - request:
     method: get
     uri: http://backend:5352/source/MaintenanceProject:0/ProjectWithRepo_package.ProjectWithRepo_Update
@@ -3692,15 +3791,15 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="ProjectWithRepo_package.ProjectWithRepo_Update" rev="2" vrev="2" srcmd5="3bc4d536be0f4724dd0defa094f247cf">
-          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" srcmd5="e9d965f2d319f4124109f14a13f4e431" baserev="e9d965f2d319f4124109f14a13f4e431" xsrcmd5="96b1040600ed3f57e960243b55548162" lsrcmd5="3bc4d536be0f4724dd0defa094f247cf" />
-          <entry name="DUMMY_FILE" md5="275876e34cf609db118f3d84b799a790" size="5" mtime="1503405075" />
-          <entry name="_config" md5="7159169868967997b7eabbd94d805185" size="238" mtime="1503405073" />
-          <entry name="_link" md5="ad672afb37ca2f6a039ad35297d226d1" size="164" mtime="1503405079" />
-          <entry name="somefile.txt" md5="b4b03ef7ef00ded93403c2c595500c4f" size="116" mtime="1503405073" />
+        <directory name="ProjectWithRepo_package.ProjectWithRepo_Update" rev="2" vrev="2" srcmd5="cf22b6ca4707e8afe3633d31126e5c64">
+          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" srcmd5="6e6fbc10551cfc8eb7c6ccfc373d323f" baserev="6e6fbc10551cfc8eb7c6ccfc373d323f" xsrcmd5="d6a5bbec579b568ed1fb0cf3f9931435" lsrcmd5="cf22b6ca4707e8afe3633d31126e5c64" />
+          <entry name="DUMMY_FILE" md5="275876e34cf609db118f3d84b799a790" size="5" mtime="1516090947" />
+          <entry name="_config" md5="e8ec9a29a8e74d4c7dfc73686c1576b5" size="143" mtime="1516090945" />
+          <entry name="_link" md5="56994b1cc0c8cb5e1662d148e8d3ba70" size="175" mtime="1516090951" />
+          <entry name="somefile.txt" md5="95c4ebbcd6a901fc5e9a47439d5e6f92" size="207" mtime="1516090945" />
         </directory>
     http_version: 
-  recorded_at: Tue, 22 Aug 2017 12:31:20 GMT
+  recorded_at: Tue, 16 Jan 2018 08:22:32 GMT
 - request:
     method: get
     uri: http://backend:5352/source/MaintenanceProject:0/ProjectWithRepo_package.ProjectWithRepo_Update?nofilename=1&view=info&withchangesmd5=1
@@ -3726,17 +3825,17 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '416'
+      - '418'
     body:
       encoding: UTF-8
       string: |
-        <sourceinfo package="ProjectWithRepo_package.ProjectWithRepo_Update" rev="2" vrev="4" srcmd5="96b1040600ed3f57e960243b55548162" lsrcmd5="3bc4d536be0f4724dd0defa094f247cf" verifymd5="227e65861e6374ec8a0776883967906a">
+        <sourceinfo package="ProjectWithRepo_package.ProjectWithRepo_Update" rev="2" vrev="4.3" srcmd5="d6a5bbec579b568ed1fb0cf3f9931435" lsrcmd5="cf22b6ca4707e8afe3633d31126e5c64" verifymd5="c0a994f7069268062bdb56e9face0d28">
           <linked project="ProjectWithRepo:Update" package="ProjectWithRepo_package" />
           <linked project="ProjectWithRepo" package="ProjectWithRepo_package" />
-          <revtime>1503405080</revtime>
+          <revtime>1516090952</revtime>
         </sourceinfo>
     http_version: 
-  recorded_at: Tue, 22 Aug 2017 12:31:20 GMT
+  recorded_at: Tue, 16 Jan 2018 08:22:32 GMT
 - request:
     method: get
     uri: http://backend:5352/source/MaintenanceProject:0/ProjectWithRepo_package.ProjectWithRepo_Update
@@ -3766,15 +3865,15 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="ProjectWithRepo_package.ProjectWithRepo_Update" rev="2" vrev="2" srcmd5="3bc4d536be0f4724dd0defa094f247cf">
-          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" srcmd5="e9d965f2d319f4124109f14a13f4e431" baserev="e9d965f2d319f4124109f14a13f4e431" xsrcmd5="96b1040600ed3f57e960243b55548162" lsrcmd5="3bc4d536be0f4724dd0defa094f247cf" />
-          <entry name="DUMMY_FILE" md5="275876e34cf609db118f3d84b799a790" size="5" mtime="1503405075" />
-          <entry name="_config" md5="7159169868967997b7eabbd94d805185" size="238" mtime="1503405073" />
-          <entry name="_link" md5="ad672afb37ca2f6a039ad35297d226d1" size="164" mtime="1503405079" />
-          <entry name="somefile.txt" md5="b4b03ef7ef00ded93403c2c595500c4f" size="116" mtime="1503405073" />
+        <directory name="ProjectWithRepo_package.ProjectWithRepo_Update" rev="2" vrev="2" srcmd5="cf22b6ca4707e8afe3633d31126e5c64">
+          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" srcmd5="6e6fbc10551cfc8eb7c6ccfc373d323f" baserev="6e6fbc10551cfc8eb7c6ccfc373d323f" xsrcmd5="d6a5bbec579b568ed1fb0cf3f9931435" lsrcmd5="cf22b6ca4707e8afe3633d31126e5c64" />
+          <entry name="DUMMY_FILE" md5="275876e34cf609db118f3d84b799a790" size="5" mtime="1516090947" />
+          <entry name="_config" md5="e8ec9a29a8e74d4c7dfc73686c1576b5" size="143" mtime="1516090945" />
+          <entry name="_link" md5="56994b1cc0c8cb5e1662d148e8d3ba70" size="175" mtime="1516090951" />
+          <entry name="somefile.txt" md5="95c4ebbcd6a901fc5e9a47439d5e6f92" size="207" mtime="1516090945" />
         </directory>
     http_version: 
-  recorded_at: Tue, 22 Aug 2017 12:31:20 GMT
+  recorded_at: Tue, 16 Jan 2018 08:22:32 GMT
 - request:
     method: post
     uri: http://backend:5352/source/MaintenanceProject:0/ProjectWithRepo_package.ProjectWithRepo_Update?cmd=diff&linkrev=base&onlyissues=1&orev=0&view=xml
@@ -3806,15 +3905,15 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="bbccdf3aeea2076b584883bbd16cc8c8">
+        <sourcediff key="14ef11a36bd06142513a383d4e9dbea3">
           <old project="MaintenanceProject:0" package="ProjectWithRepo_package.ProjectWithRepo_Update" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e" />
-          <new project="MaintenanceProject:0" package="ProjectWithRepo_package.ProjectWithRepo_Update" rev="2" srcmd5="3bc4d536be0f4724dd0defa094f247cf" />
+          <new project="MaintenanceProject:0" package="ProjectWithRepo_package.ProjectWithRepo_Update" rev="2" srcmd5="cf22b6ca4707e8afe3633d31126e5c64" />
           <files />
           <issues>
           </issues>
         </sourcediff>
     http_version: 
-  recorded_at: Tue, 22 Aug 2017 12:31:20 GMT
+  recorded_at: Tue, 16 Jan 2018 08:22:32 GMT
 - request:
     method: post
     uri: http://backend:5352/source/MaintenanceProject:0/ProjectWithRepo_package.ProjectWithRepo_Update?cmd=linkdiff&linkrev=base&onlyissues=1&view=xml
@@ -3846,15 +3945,15 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="aa393379f0698c4b78a41bf61e79e894">
-          <old project="ProjectWithRepo:Update" package="ProjectWithRepo_package" rev="e9d965f2d319f4124109f14a13f4e431" srcmd5="e9d965f2d319f4124109f14a13f4e431" />
-          <new project="MaintenanceProject:0" package="ProjectWithRepo_package.ProjectWithRepo_Update" rev="96b1040600ed3f57e960243b55548162" srcmd5="96b1040600ed3f57e960243b55548162" />
+        <sourcediff key="46b27e5a3b383b4f31c7ddffb38c44bc">
+          <old project="ProjectWithRepo:Update" package="ProjectWithRepo_package" rev="6e6fbc10551cfc8eb7c6ccfc373d323f" srcmd5="6e6fbc10551cfc8eb7c6ccfc373d323f" />
+          <new project="MaintenanceProject:0" package="ProjectWithRepo_package.ProjectWithRepo_Update" rev="d6a5bbec579b568ed1fb0cf3f9931435" srcmd5="d6a5bbec579b568ed1fb0cf3f9931435" />
           <files />
           <issues>
           </issues>
         </sourcediff>
     http_version: 
-  recorded_at: Tue, 22 Aug 2017 12:31:20 GMT
+  recorded_at: Tue, 16 Jan 2018 08:22:32 GMT
 - request:
     method: put
     uri: http://backend:5352/source/MaintenanceProject:0/_meta?comment=maintenance_incident%20request%201&requestid=1&user=maintenance_coord
@@ -3919,7 +4018,7 @@ http_interactions:
           </repository>
         </project>
     http_version: 
-  recorded_at: Tue, 22 Aug 2017 12:31:20 GMT
+  recorded_at: Tue, 16 Jan 2018 08:22:32 GMT
 - request:
     method: put
     uri: http://backend:5352/source/MaintenanceProject:0/patchinfo/_meta?user=maintenance_coord
@@ -3976,7 +4075,7 @@ http_interactions:
           </useforbuild>
         </package>
     http_version: 
-  recorded_at: Tue, 22 Aug 2017 12:31:20 GMT
+  recorded_at: Tue, 16 Jan 2018 08:22:32 GMT
 - request:
     method: put
     uri: http://backend:5352/source/MaintenanceProject:0/patchinfo/_patchinfo?comment=generated%20by%20request%20id%201%20accept%20call&user=maintenance_coord
@@ -4016,13 +4115,13 @@ http_interactions:
         <revision rev="1" vrev="1">
           <srcmd5>53b684c8c2dbc9672bb230d024c87a14</srcmd5>
           <version>unknown</version>
-          <time>1503405080</time>
+          <time>1516090952</time>
           <user>maintenance_coord</user>
           <comment>generated by request id 1 accept call</comment>
           <requestid/>
         </revision>
     http_version: 
-  recorded_at: Tue, 22 Aug 2017 12:31:20 GMT
+  recorded_at: Tue, 16 Jan 2018 08:22:32 GMT
 - request:
     method: put
     uri: http://backend:5352/source/MaintenanceProject:0/patchinfo/_meta?user=maintenance_coord
@@ -4079,7 +4178,7 @@ http_interactions:
           </useforbuild>
         </package>
     http_version: 
-  recorded_at: Tue, 22 Aug 2017 12:31:20 GMT
+  recorded_at: Tue, 16 Jan 2018 08:22:32 GMT
 - request:
     method: get
     uri: http://backend:5352/source/MaintenanceProject:0/patchinfo
@@ -4110,10 +4209,10 @@ http_interactions:
       encoding: UTF-8
       string: |
         <directory name="patchinfo" rev="1" vrev="1" srcmd5="53b684c8c2dbc9672bb230d024c87a14">
-          <entry name="_patchinfo" md5="34e0b04fccfd75faea0577efe7cd9ead" size="208" mtime="1503405080" />
+          <entry name="_patchinfo" md5="34e0b04fccfd75faea0577efe7cd9ead" size="208" mtime="1516090952" />
         </directory>
     http_version: 
-  recorded_at: Tue, 22 Aug 2017 12:31:21 GMT
+  recorded_at: Tue, 16 Jan 2018 08:22:32 GMT
 - request:
     method: get
     uri: http://backend:5352/source/MaintenanceProject:0/patchinfo?nofilename=1&view=info&withchangesmd5=1
@@ -4144,10 +4243,10 @@ http_interactions:
       encoding: UTF-8
       string: |
         <sourceinfo package="patchinfo" rev="1" vrev="1" srcmd5="53b684c8c2dbc9672bb230d024c87a14" verifymd5="53b684c8c2dbc9672bb230d024c87a14">
-          <revtime>1503405080</revtime>
+          <revtime>1516090952</revtime>
         </sourceinfo>
     http_version: 
-  recorded_at: Tue, 22 Aug 2017 12:31:21 GMT
+  recorded_at: Tue, 16 Jan 2018 08:22:32 GMT
 - request:
     method: get
     uri: http://backend:5352/source/MaintenanceProject:0/patchinfo
@@ -4178,10 +4277,10 @@ http_interactions:
       encoding: UTF-8
       string: |
         <directory name="patchinfo" rev="1" vrev="1" srcmd5="53b684c8c2dbc9672bb230d024c87a14">
-          <entry name="_patchinfo" md5="34e0b04fccfd75faea0577efe7cd9ead" size="208" mtime="1503405080" />
+          <entry name="_patchinfo" md5="34e0b04fccfd75faea0577efe7cd9ead" size="208" mtime="1516090952" />
         </directory>
     http_version: 
-  recorded_at: Tue, 22 Aug 2017 12:31:21 GMT
+  recorded_at: Tue, 16 Jan 2018 08:22:32 GMT
 - request:
     method: get
     uri: http://backend:5352/source/MaintenanceProject:0/patchinfo/_patchinfo
@@ -4219,10 +4318,10 @@ http_interactions:
           <description>I want the update</description>
         </patchinfo>
     http_version: 
-  recorded_at: Tue, 22 Aug 2017 12:31:21 GMT
+  recorded_at: Tue, 16 Jan 2018 08:22:32 GMT
 - request:
     method: post
-    uri: http://backend:5352/source/MaintenanceProject:0/ProjectWithRepo_package.ProjectWithRepo_Update?cmd=diff&orev=ef9928a63930d4797ced0ef2ad58ed0c&rev=96b1040600ed3f57e960243b55548162&view=xml&withissues=1
+    uri: http://backend:5352/source/MaintenanceProject:0/ProjectWithRepo_package.ProjectWithRepo_Update?cmd=diff&orev=39895c37617de8a93814934ec17f5508&rev=d6a5bbec579b568ed1fb0cf3f9931435&view=xml&withissues=1
     body:
       encoding: UTF-8
       string: ''
@@ -4251,9 +4350,9 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="63bb8ae8e41021e19f94a688fab094a2">
-          <old project="MaintenanceProject:0" package="ProjectWithRepo_package.ProjectWithRepo_Update" rev="ef9928a63930d4797ced0ef2ad58ed0c" srcmd5="ef9928a63930d4797ced0ef2ad58ed0c" />
-          <new project="MaintenanceProject:0" package="ProjectWithRepo_package.ProjectWithRepo_Update" rev="96b1040600ed3f57e960243b55548162" srcmd5="96b1040600ed3f57e960243b55548162" />
+        <sourcediff key="93afe66f9636c42b56f56e7af1d2fc33">
+          <old project="MaintenanceProject:0" package="ProjectWithRepo_package.ProjectWithRepo_Update" rev="39895c37617de8a93814934ec17f5508" srcmd5="39895c37617de8a93814934ec17f5508" />
+          <new project="MaintenanceProject:0" package="ProjectWithRepo_package.ProjectWithRepo_Update" rev="d6a5bbec579b568ed1fb0cf3f9931435" srcmd5="d6a5bbec579b568ed1fb0cf3f9931435" />
           <files>
             <file state="added">
               <new name="DUMMY_FILE" md5="275876e34cf609db118f3d84b799a790" size="5" />
@@ -4267,7 +4366,7 @@ http_interactions:
           </issues>
         </sourcediff>
     http_version: 
-  recorded_at: Tue, 22 Aug 2017 12:31:21 GMT
+  recorded_at: Tue, 16 Jan 2018 08:22:33 GMT
 - request:
     method: get
     uri: http://backend:5352/build/home:tom:branches:ProjectWithRepo:Update/_result?package=ProjectWithRepo_package&view=status
@@ -4303,7 +4402,7 @@ http_interactions:
           <result project="home:tom:branches:ProjectWithRepo:Update" repository="repository_2" arch="i586" code="unknown" state="unknown" />
         </resultlist>
     http_version: 
-  recorded_at: Tue, 22 Aug 2017 12:31:21 GMT
+  recorded_at: Tue, 16 Jan 2018 08:22:33 GMT
 - request:
     method: get
     uri: http://backend:5352/build/home:tom:branches:ProjectWithRepo:Update/_result?locallink=1&multibuild=1&package=ProjectWithRepo_package&view=status
@@ -4339,7 +4438,7 @@ http_interactions:
           <result project="home:tom:branches:ProjectWithRepo:Update" repository="repository_2" arch="i586" code="unknown" state="unknown" />
         </resultlist>
     http_version: 
-  recorded_at: Tue, 22 Aug 2017 12:31:21 GMT
+  recorded_at: Tue, 16 Jan 2018 08:22:33 GMT
 - request:
     method: get
     uri: http://backend:5352/build/MaintenanceProject:0/_result?view=binarylist
@@ -4375,7 +4474,7 @@ http_interactions:
           <result project="MaintenanceProject:0" repository="ProjectWithRepo_Update" arch="i586" code="unknown" state="unknown" />
         </resultlist>
     http_version: 
-  recorded_at: Tue, 22 Aug 2017 12:31:21 GMT
+  recorded_at: Tue, 16 Jan 2018 08:22:33 GMT
 - request:
     method: get
     uri: http://backend:5352/source/MaintenanceProject:0/patchinfo/_patchinfo
@@ -4413,7 +4512,7 @@ http_interactions:
           <description>I want the update</description>
         </patchinfo>
     http_version: 
-  recorded_at: Tue, 22 Aug 2017 12:31:21 GMT
+  recorded_at: Tue, 16 Jan 2018 08:22:33 GMT
 - request:
     method: get
     uri: http://backend:5352/source/MaintenanceProject:0/patchinfo/_patchinfo
@@ -4451,7 +4550,7 @@ http_interactions:
           <description>I want the update</description>
         </patchinfo>
     http_version: 
-  recorded_at: Tue, 22 Aug 2017 12:31:21 GMT
+  recorded_at: Tue, 16 Jan 2018 08:22:33 GMT
 - request:
     method: get
     uri: http://backend:5352/build/MaintenanceProject:0/_result?view=binarylist
@@ -4487,7 +4586,7 @@ http_interactions:
           <result project="MaintenanceProject:0" repository="ProjectWithRepo_Update" arch="i586" code="unknown" state="unknown" />
         </resultlist>
     http_version: 
-  recorded_at: Tue, 22 Aug 2017 12:31:22 GMT
+  recorded_at: Tue, 16 Jan 2018 08:22:34 GMT
 - request:
     method: get
     uri: http://backend:5352/source/MaintenanceProject:0/patchinfo/_patchinfo
@@ -4525,7 +4624,7 @@ http_interactions:
           <description>I want the update</description>
         </patchinfo>
     http_version: 
-  recorded_at: Tue, 22 Aug 2017 12:31:22 GMT
+  recorded_at: Tue, 16 Jan 2018 08:22:34 GMT
 - request:
     method: get
     uri: http://backend:5352/source/MaintenanceProject:0/patchinfo/_patchinfo
@@ -4563,7 +4662,7 @@ http_interactions:
           <description>I want the update</description>
         </patchinfo>
     http_version: 
-  recorded_at: Tue, 22 Aug 2017 12:31:22 GMT
+  recorded_at: Tue, 16 Jan 2018 08:22:34 GMT
 - request:
     method: put
     uri: http://backend:5352/source/MaintenanceProject:0/patchinfo/_patchinfo?user=maintenance_coord
@@ -4604,13 +4703,13 @@ http_interactions:
         <revision rev="2" vrev="2">
           <srcmd5>d07dfcdc0bb71ab61e7d0c85c4a68c71</srcmd5>
           <version>unknown</version>
-          <time>1503405082</time>
+          <time>1516090954</time>
           <user>maintenance_coord</user>
           <comment></comment>
           <requestid/>
         </revision>
     http_version: 
-  recorded_at: Tue, 22 Aug 2017 12:31:22 GMT
+  recorded_at: Tue, 16 Jan 2018 08:22:34 GMT
 - request:
     method: put
     uri: http://backend:5352/source/MaintenanceProject:0/patchinfo/_meta?user=maintenance_coord
@@ -4667,7 +4766,7 @@ http_interactions:
           </useforbuild>
         </package>
     http_version: 
-  recorded_at: Tue, 22 Aug 2017 12:31:22 GMT
+  recorded_at: Tue, 16 Jan 2018 08:22:34 GMT
 - request:
     method: get
     uri: http://backend:5352/source/MaintenanceProject:0/patchinfo
@@ -4698,10 +4797,10 @@ http_interactions:
       encoding: UTF-8
       string: |
         <directory name="patchinfo" rev="2" vrev="2" srcmd5="d07dfcdc0bb71ab61e7d0c85c4a68c71">
-          <entry name="_patchinfo" md5="7fd692cf9ae54961b5c5a22aa13e29c0" size="347" mtime="1503405082" />
+          <entry name="_patchinfo" md5="7fd692cf9ae54961b5c5a22aa13e29c0" size="347" mtime="1516090954" />
         </directory>
     http_version: 
-  recorded_at: Tue, 22 Aug 2017 12:31:22 GMT
+  recorded_at: Tue, 16 Jan 2018 08:22:34 GMT
 - request:
     method: get
     uri: http://backend:5352/source/MaintenanceProject:0/patchinfo?nofilename=1&view=info&withchangesmd5=1
@@ -4732,10 +4831,10 @@ http_interactions:
       encoding: UTF-8
       string: |
         <sourceinfo package="patchinfo" rev="2" vrev="2" srcmd5="d07dfcdc0bb71ab61e7d0c85c4a68c71" verifymd5="d07dfcdc0bb71ab61e7d0c85c4a68c71">
-          <revtime>1503405082</revtime>
+          <revtime>1516090954</revtime>
         </sourceinfo>
     http_version: 
-  recorded_at: Tue, 22 Aug 2017 12:31:22 GMT
+  recorded_at: Tue, 16 Jan 2018 08:22:34 GMT
 - request:
     method: get
     uri: http://backend:5352/source/MaintenanceProject:0/patchinfo
@@ -4766,10 +4865,10 @@ http_interactions:
       encoding: UTF-8
       string: |
         <directory name="patchinfo" rev="2" vrev="2" srcmd5="d07dfcdc0bb71ab61e7d0c85c4a68c71">
-          <entry name="_patchinfo" md5="7fd692cf9ae54961b5c5a22aa13e29c0" size="347" mtime="1503405082" />
+          <entry name="_patchinfo" md5="7fd692cf9ae54961b5c5a22aa13e29c0" size="347" mtime="1516090954" />
         </directory>
     http_version: 
-  recorded_at: Tue, 22 Aug 2017 12:31:22 GMT
+  recorded_at: Tue, 16 Jan 2018 08:22:34 GMT
 - request:
     method: get
     uri: http://backend:5352/source/MaintenanceProject:0/patchinfo/_patchinfo
@@ -4808,7 +4907,7 @@ http_interactions:
           <stopped>locked!</stopped>
         </patchinfo>
     http_version: 
-  recorded_at: Tue, 22 Aug 2017 12:31:22 GMT
+  recorded_at: Tue, 16 Jan 2018 08:22:34 GMT
 - request:
     method: get
     uri: http://backend:5352/source/MaintenanceProject:0/patchinfo/_patchinfo
@@ -4847,7 +4946,7 @@ http_interactions:
           <stopped>locked!</stopped>
         </patchinfo>
     http_version: 
-  recorded_at: Tue, 22 Aug 2017 12:31:22 GMT
+  recorded_at: Tue, 16 Jan 2018 08:22:34 GMT
 - request:
     method: get
     uri: http://backend:5352/source/MaintenanceProject:0/patchinfo/_patchinfo
@@ -4886,7 +4985,7 @@ http_interactions:
           <stopped>locked!</stopped>
         </patchinfo>
     http_version: 
-  recorded_at: Tue, 22 Aug 2017 12:31:22 GMT
+  recorded_at: Tue, 16 Jan 2018 08:22:34 GMT
 - request:
     method: get
     uri: http://backend:5352/build/MaintenanceProject:0/_result?view=binarylist
@@ -4922,7 +5021,7 @@ http_interactions:
           <result project="MaintenanceProject:0" repository="ProjectWithRepo_Update" arch="i586" code="unknown" state="unknown" />
         </resultlist>
     http_version: 
-  recorded_at: Tue, 22 Aug 2017 12:31:22 GMT
+  recorded_at: Tue, 16 Jan 2018 08:22:34 GMT
 - request:
     method: get
     uri: http://backend:5352/source/MaintenanceProject:0/patchinfo/_patchinfo
@@ -4961,7 +5060,7 @@ http_interactions:
           <stopped>locked!</stopped>
         </patchinfo>
     http_version: 
-  recorded_at: Tue, 22 Aug 2017 12:31:22 GMT
+  recorded_at: Tue, 16 Jan 2018 08:22:34 GMT
 - request:
     method: get
     uri: http://backend:5352/source/MaintenanceProject:0/patchinfo/_patchinfo
@@ -5000,7 +5099,7 @@ http_interactions:
           <stopped>locked!</stopped>
         </patchinfo>
     http_version: 
-  recorded_at: Tue, 22 Aug 2017 12:31:22 GMT
+  recorded_at: Tue, 16 Jan 2018 08:22:34 GMT
 - request:
     method: get
     uri: http://backend:5352/build/MaintenanceProject:0/_result?view=binarylist
@@ -5036,7 +5135,7 @@ http_interactions:
           <result project="MaintenanceProject:0" repository="ProjectWithRepo_Update" arch="i586" code="unknown" state="unknown" />
         </resultlist>
     http_version: 
-  recorded_at: Tue, 22 Aug 2017 12:31:22 GMT
+  recorded_at: Tue, 16 Jan 2018 08:22:35 GMT
 - request:
     method: get
     uri: http://backend:5352/source/MaintenanceProject:0/patchinfo/_patchinfo
@@ -5075,7 +5174,7 @@ http_interactions:
           <stopped>locked!</stopped>
         </patchinfo>
     http_version: 
-  recorded_at: Tue, 22 Aug 2017 12:31:22 GMT
+  recorded_at: Tue, 16 Jan 2018 08:22:35 GMT
 - request:
     method: get
     uri: http://backend:5352/source/MaintenanceProject:0/patchinfo/_patchinfo
@@ -5114,7 +5213,7 @@ http_interactions:
           <stopped>locked!</stopped>
         </patchinfo>
     http_version: 
-  recorded_at: Tue, 22 Aug 2017 12:31:22 GMT
+  recorded_at: Tue, 16 Jan 2018 08:22:35 GMT
 - request:
     method: put
     uri: http://backend:5352/source/MaintenanceProject:0/patchinfo/_patchinfo?user=maintenance_coord
@@ -5154,13 +5253,13 @@ http_interactions:
         <revision rev="3" vrev="3">
           <srcmd5>177d57906eba63ae56a64a367592144a</srcmd5>
           <version>unknown</version>
-          <time>1503405082</time>
+          <time>1516090955</time>
           <user>maintenance_coord</user>
           <comment></comment>
           <requestid/>
         </revision>
     http_version: 
-  recorded_at: Tue, 22 Aug 2017 12:31:22 GMT
+  recorded_at: Tue, 16 Jan 2018 08:22:35 GMT
 - request:
     method: put
     uri: http://backend:5352/source/MaintenanceProject:0/patchinfo/_meta?user=maintenance_coord
@@ -5217,7 +5316,7 @@ http_interactions:
           </useforbuild>
         </package>
     http_version: 
-  recorded_at: Tue, 22 Aug 2017 12:31:23 GMT
+  recorded_at: Tue, 16 Jan 2018 08:22:35 GMT
 - request:
     method: get
     uri: http://backend:5352/source/MaintenanceProject:0/patchinfo
@@ -5248,10 +5347,10 @@ http_interactions:
       encoding: UTF-8
       string: |
         <directory name="patchinfo" rev="3" vrev="3" srcmd5="177d57906eba63ae56a64a367592144a">
-          <entry name="_patchinfo" md5="ac29f7f1abd9ef43afeb43fc7737c007" size="318" mtime="1503405082" />
+          <entry name="_patchinfo" md5="ac29f7f1abd9ef43afeb43fc7737c007" size="318" mtime="1516090955" />
         </directory>
     http_version: 
-  recorded_at: Tue, 22 Aug 2017 12:31:23 GMT
+  recorded_at: Tue, 16 Jan 2018 08:22:35 GMT
 - request:
     method: get
     uri: http://backend:5352/source/MaintenanceProject:0/patchinfo?nofilename=1&view=info&withchangesmd5=1
@@ -5282,10 +5381,10 @@ http_interactions:
       encoding: UTF-8
       string: |
         <sourceinfo package="patchinfo" rev="3" vrev="3" srcmd5="177d57906eba63ae56a64a367592144a" verifymd5="177d57906eba63ae56a64a367592144a">
-          <revtime>1503405082</revtime>
+          <revtime>1516090955</revtime>
         </sourceinfo>
     http_version: 
-  recorded_at: Tue, 22 Aug 2017 12:31:23 GMT
+  recorded_at: Tue, 16 Jan 2018 08:22:35 GMT
 - request:
     method: get
     uri: http://backend:5352/source/MaintenanceProject:0/patchinfo
@@ -5316,10 +5415,10 @@ http_interactions:
       encoding: UTF-8
       string: |
         <directory name="patchinfo" rev="3" vrev="3" srcmd5="177d57906eba63ae56a64a367592144a">
-          <entry name="_patchinfo" md5="ac29f7f1abd9ef43afeb43fc7737c007" size="318" mtime="1503405082" />
+          <entry name="_patchinfo" md5="ac29f7f1abd9ef43afeb43fc7737c007" size="318" mtime="1516090955" />
         </directory>
     http_version: 
-  recorded_at: Tue, 22 Aug 2017 12:31:23 GMT
+  recorded_at: Tue, 16 Jan 2018 08:22:35 GMT
 - request:
     method: get
     uri: http://backend:5352/source/MaintenanceProject:0/patchinfo/_patchinfo
@@ -5357,7 +5456,7 @@ http_interactions:
           <description>Fixes nothing, Fixes nothing, Fixes nothing, Fixes nothing, Fixes nothing, Fixes nothing</description>
         </patchinfo>
     http_version: 
-  recorded_at: Tue, 22 Aug 2017 12:31:23 GMT
+  recorded_at: Tue, 16 Jan 2018 08:22:35 GMT
 - request:
     method: get
     uri: http://backend:5352/source/MaintenanceProject:0/patchinfo/_patchinfo
@@ -5395,7 +5494,7 @@ http_interactions:
           <description>Fixes nothing, Fixes nothing, Fixes nothing, Fixes nothing, Fixes nothing, Fixes nothing</description>
         </patchinfo>
     http_version: 
-  recorded_at: Tue, 22 Aug 2017 12:31:23 GMT
+  recorded_at: Tue, 16 Jan 2018 08:22:35 GMT
 - request:
     method: get
     uri: http://backend:5352/source/MaintenanceProject:0/patchinfo/_patchinfo
@@ -5433,7 +5532,7 @@ http_interactions:
           <description>Fixes nothing, Fixes nothing, Fixes nothing, Fixes nothing, Fixes nothing, Fixes nothing</description>
         </patchinfo>
     http_version: 
-  recorded_at: Tue, 22 Aug 2017 12:31:23 GMT
+  recorded_at: Tue, 16 Jan 2018 08:22:35 GMT
 - request:
     method: get
     uri: http://backend:5352/build/home:tom:branches:ProjectWithRepo:Update/_result?code=unresolvable&view=status
@@ -5441,10 +5540,8 @@ http_interactions:
       encoding: US-ASCII
       string: ''
     headers:
-      Content-Type:
-      - text/plain
       Accept-Encoding:
-      - identity
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
       - "*/*"
       User-Agent:
@@ -5469,7 +5566,7 @@ http_interactions:
           <result project="home:tom:branches:ProjectWithRepo:Update" repository="repository_2" arch="i586" code="unknown" state="unknown" />
         </resultlist>
     http_version: 
-  recorded_at: Tue, 22 Aug 2017 12:31:24 GMT
+  recorded_at: Tue, 16 Jan 2018 08:22:36 GMT
 - request:
     method: get
     uri: http://backend:5352/build/home:tom:branches:ProjectWithRepo:Update/_result?view=summary
@@ -5507,7 +5604,7 @@ http_interactions:
           </result>
         </resultlist>
     http_version: 
-  recorded_at: Tue, 22 Aug 2017 12:31:24 GMT
+  recorded_at: Tue, 16 Jan 2018 08:22:36 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:tom:branches:ProjectWithRepo:Update/ProjectWithRepo_package
@@ -5537,15 +5634,15 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="ProjectWithRepo_package" rev="2" vrev="2" srcmd5="5acba764a37a9bc6490f80deca372916">
-          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" srcmd5="e9d965f2d319f4124109f14a13f4e431" baserev="e9d965f2d319f4124109f14a13f4e431" xsrcmd5="6d8b4e042078d289ced39a1738e21c95" lsrcmd5="5acba764a37a9bc6490f80deca372916" />
-          <entry name="DUMMY_FILE" md5="275876e34cf609db118f3d84b799a790" size="5" mtime="1503405075" />
-          <entry name="_config" md5="7159169868967997b7eabbd94d805185" size="238" mtime="1503405073" />
-          <entry name="_link" md5="11504ac69b4a7053159649a50cf86e1f" size="130" mtime="1503405074" />
-          <entry name="somefile.txt" md5="b4b03ef7ef00ded93403c2c595500c4f" size="116" mtime="1503405073" />
+        <directory name="ProjectWithRepo_package" rev="2" vrev="2" srcmd5="fea0bed8284652f582f84d5ba0388c2e">
+          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" srcmd5="6e6fbc10551cfc8eb7c6ccfc373d323f" baserev="6e6fbc10551cfc8eb7c6ccfc373d323f" xsrcmd5="8dcbf337ee5aa0aa89a7deaab7d763d6" lsrcmd5="fea0bed8284652f582f84d5ba0388c2e" />
+          <entry name="DUMMY_FILE" md5="275876e34cf609db118f3d84b799a790" size="5" mtime="1516090947" />
+          <entry name="_config" md5="e8ec9a29a8e74d4c7dfc73686c1576b5" size="143" mtime="1516090945" />
+          <entry name="_link" md5="e409478924f3c1c27d895156ac5f39b0" size="130" mtime="1516090946" />
+          <entry name="somefile.txt" md5="95c4ebbcd6a901fc5e9a47439d5e6f92" size="207" mtime="1516090945" />
         </directory>
     http_version: 
-  recorded_at: Tue, 22 Aug 2017 12:31:24 GMT
+  recorded_at: Tue, 16 Jan 2018 08:22:37 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:tom:branches:ProjectWithRepo:Update/ProjectWithRepo_package
@@ -5575,15 +5672,15 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="ProjectWithRepo_package" rev="2" vrev="2" srcmd5="5acba764a37a9bc6490f80deca372916">
-          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" srcmd5="e9d965f2d319f4124109f14a13f4e431" baserev="e9d965f2d319f4124109f14a13f4e431" xsrcmd5="6d8b4e042078d289ced39a1738e21c95" lsrcmd5="5acba764a37a9bc6490f80deca372916" />
-          <entry name="DUMMY_FILE" md5="275876e34cf609db118f3d84b799a790" size="5" mtime="1503405075" />
-          <entry name="_config" md5="7159169868967997b7eabbd94d805185" size="238" mtime="1503405073" />
-          <entry name="_link" md5="11504ac69b4a7053159649a50cf86e1f" size="130" mtime="1503405074" />
-          <entry name="somefile.txt" md5="b4b03ef7ef00ded93403c2c595500c4f" size="116" mtime="1503405073" />
+        <directory name="ProjectWithRepo_package" rev="2" vrev="2" srcmd5="fea0bed8284652f582f84d5ba0388c2e">
+          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" srcmd5="6e6fbc10551cfc8eb7c6ccfc373d323f" baserev="6e6fbc10551cfc8eb7c6ccfc373d323f" xsrcmd5="8dcbf337ee5aa0aa89a7deaab7d763d6" lsrcmd5="fea0bed8284652f582f84d5ba0388c2e" />
+          <entry name="DUMMY_FILE" md5="275876e34cf609db118f3d84b799a790" size="5" mtime="1516090947" />
+          <entry name="_config" md5="e8ec9a29a8e74d4c7dfc73686c1576b5" size="143" mtime="1516090945" />
+          <entry name="_link" md5="e409478924f3c1c27d895156ac5f39b0" size="130" mtime="1516090946" />
+          <entry name="somefile.txt" md5="95c4ebbcd6a901fc5e9a47439d5e6f92" size="207" mtime="1516090945" />
         </directory>
     http_version: 
-  recorded_at: Tue, 22 Aug 2017 12:31:24 GMT
+  recorded_at: Tue, 16 Jan 2018 08:22:37 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:tom:branches:ProjectWithRepo:Update/ProjectWithRepo_package
@@ -5591,10 +5688,8 @@ http_interactions:
       encoding: US-ASCII
       string: ''
     headers:
-      Content-Type:
-      - text/plain
       Accept-Encoding:
-      - identity
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
       - "*/*"
       User-Agent:
@@ -5615,18 +5710,18 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="ProjectWithRepo_package" rev="2" vrev="2" srcmd5="5acba764a37a9bc6490f80deca372916">
-          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" srcmd5="e9d965f2d319f4124109f14a13f4e431" baserev="e9d965f2d319f4124109f14a13f4e431" xsrcmd5="6d8b4e042078d289ced39a1738e21c95" lsrcmd5="5acba764a37a9bc6490f80deca372916" />
-          <entry name="DUMMY_FILE" md5="275876e34cf609db118f3d84b799a790" size="5" mtime="1503405075" />
-          <entry name="_config" md5="7159169868967997b7eabbd94d805185" size="238" mtime="1503405073" />
-          <entry name="_link" md5="11504ac69b4a7053159649a50cf86e1f" size="130" mtime="1503405074" />
-          <entry name="somefile.txt" md5="b4b03ef7ef00ded93403c2c595500c4f" size="116" mtime="1503405073" />
+        <directory name="ProjectWithRepo_package" rev="2" vrev="2" srcmd5="fea0bed8284652f582f84d5ba0388c2e">
+          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" srcmd5="6e6fbc10551cfc8eb7c6ccfc373d323f" baserev="6e6fbc10551cfc8eb7c6ccfc373d323f" xsrcmd5="8dcbf337ee5aa0aa89a7deaab7d763d6" lsrcmd5="fea0bed8284652f582f84d5ba0388c2e" />
+          <entry name="DUMMY_FILE" md5="275876e34cf609db118f3d84b799a790" size="5" mtime="1516090947" />
+          <entry name="_config" md5="e8ec9a29a8e74d4c7dfc73686c1576b5" size="143" mtime="1516090945" />
+          <entry name="_link" md5="e409478924f3c1c27d895156ac5f39b0" size="130" mtime="1516090946" />
+          <entry name="somefile.txt" md5="95c4ebbcd6a901fc5e9a47439d5e6f92" size="207" mtime="1516090945" />
         </directory>
     http_version: 
-  recorded_at: Tue, 22 Aug 2017 12:31:24 GMT
+  recorded_at: Tue, 16 Jan 2018 08:22:37 GMT
 - request:
     method: post
-    uri: http://backend:5352/source/home:tom:branches:ProjectWithRepo:Update/ProjectWithRepo_package?cmd=diff&expand=1&filelimit=10000&opackage=ProjectWithRepo_package&oproject=ProjectWithRepo:Update
+    uri: http://backend:5352/source/home:tom:branches:ProjectWithRepo:Update/ProjectWithRepo_package?cmd=diff&expand=1&filelimit=10000&opackage=ProjectWithRepo_package&oproject=ProjectWithRepo:Update&tarlimit=10000
     body:
       encoding: UTF-8
       string: ''
@@ -5670,7 +5765,7 @@ http_interactions:
         +dummy
         \ No newline at end of file
     http_version: 
-  recorded_at: Tue, 22 Aug 2017 12:31:24 GMT
+  recorded_at: Tue, 16 Jan 2018 08:22:37 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:tom:branches:ProjectWithRepo:Update/ProjectWithRepo_package?expand=1
@@ -5700,14 +5795,14 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="ProjectWithRepo_package" rev="6d8b4e042078d289ced39a1738e21c95" vrev="4" srcmd5="6d8b4e042078d289ced39a1738e21c95">
-          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" srcmd5="e9d965f2d319f4124109f14a13f4e431" baserev="e9d965f2d319f4124109f14a13f4e431" lsrcmd5="5acba764a37a9bc6490f80deca372916" />
-          <entry name="DUMMY_FILE" md5="275876e34cf609db118f3d84b799a790" size="5" mtime="1503405075" />
-          <entry name="_config" md5="7159169868967997b7eabbd94d805185" size="238" mtime="1503405073" />
-          <entry name="somefile.txt" md5="b4b03ef7ef00ded93403c2c595500c4f" size="116" mtime="1503405073" />
+        <directory name="ProjectWithRepo_package" rev="8dcbf337ee5aa0aa89a7deaab7d763d6" vrev="5" srcmd5="8dcbf337ee5aa0aa89a7deaab7d763d6">
+          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" srcmd5="6e6fbc10551cfc8eb7c6ccfc373d323f" baserev="6e6fbc10551cfc8eb7c6ccfc373d323f" lsrcmd5="fea0bed8284652f582f84d5ba0388c2e" />
+          <entry name="DUMMY_FILE" md5="275876e34cf609db118f3d84b799a790" size="5" mtime="1516090947" />
+          <entry name="_config" md5="e8ec9a29a8e74d4c7dfc73686c1576b5" size="143" mtime="1516090945" />
+          <entry name="somefile.txt" md5="95c4ebbcd6a901fc5e9a47439d5e6f92" size="207" mtime="1516090945" />
         </directory>
     http_version: 
-  recorded_at: Tue, 22 Aug 2017 12:31:24 GMT
+  recorded_at: Tue, 16 Jan 2018 08:22:37 GMT
 - request:
     method: get
     uri: http://backend:5352/build/home:tom:branches:ProjectWithRepo:Update/_result?code=unresolvable&view=status
@@ -5715,10 +5810,8 @@ http_interactions:
       encoding: US-ASCII
       string: ''
     headers:
-      Content-Type:
-      - text/plain
       Accept-Encoding:
-      - identity
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
       - "*/*"
       User-Agent:
@@ -5743,7 +5836,7 @@ http_interactions:
           <result project="home:tom:branches:ProjectWithRepo:Update" repository="repository_2" arch="i586" code="unknown" state="unknown" />
         </resultlist>
     http_version: 
-  recorded_at: Tue, 22 Aug 2017 12:31:24 GMT
+  recorded_at: Tue, 16 Jan 2018 08:22:37 GMT
 - request:
     method: get
     uri: http://backend:5352/build/home:tom:branches:ProjectWithRepo:Update/_result?view=summary
@@ -5781,7 +5874,7 @@ http_interactions:
           </result>
         </resultlist>
     http_version: 
-  recorded_at: Tue, 22 Aug 2017 12:31:25 GMT
+  recorded_at: Tue, 16 Jan 2018 08:22:37 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:tom:branches:ProjectWithRepo:Update/ProjectWithRepo_package
@@ -5789,10 +5882,8 @@ http_interactions:
       encoding: US-ASCII
       string: ''
     headers:
-      Content-Type:
-      - text/plain
       Accept-Encoding:
-      - identity
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
       - "*/*"
       User-Agent:
@@ -5813,18 +5904,18 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="ProjectWithRepo_package" rev="2" vrev="2" srcmd5="5acba764a37a9bc6490f80deca372916">
-          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" srcmd5="e9d965f2d319f4124109f14a13f4e431" baserev="e9d965f2d319f4124109f14a13f4e431" xsrcmd5="6d8b4e042078d289ced39a1738e21c95" lsrcmd5="5acba764a37a9bc6490f80deca372916" />
-          <entry name="DUMMY_FILE" md5="275876e34cf609db118f3d84b799a790" size="5" mtime="1503405075" />
-          <entry name="_config" md5="7159169868967997b7eabbd94d805185" size="238" mtime="1503405073" />
-          <entry name="_link" md5="11504ac69b4a7053159649a50cf86e1f" size="130" mtime="1503405074" />
-          <entry name="somefile.txt" md5="b4b03ef7ef00ded93403c2c595500c4f" size="116" mtime="1503405073" />
+        <directory name="ProjectWithRepo_package" rev="2" vrev="2" srcmd5="fea0bed8284652f582f84d5ba0388c2e">
+          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" srcmd5="6e6fbc10551cfc8eb7c6ccfc373d323f" baserev="6e6fbc10551cfc8eb7c6ccfc373d323f" xsrcmd5="8dcbf337ee5aa0aa89a7deaab7d763d6" lsrcmd5="fea0bed8284652f582f84d5ba0388c2e" />
+          <entry name="DUMMY_FILE" md5="275876e34cf609db118f3d84b799a790" size="5" mtime="1516090947" />
+          <entry name="_config" md5="e8ec9a29a8e74d4c7dfc73686c1576b5" size="143" mtime="1516090945" />
+          <entry name="_link" md5="e409478924f3c1c27d895156ac5f39b0" size="130" mtime="1516090946" />
+          <entry name="somefile.txt" md5="95c4ebbcd6a901fc5e9a47439d5e6f92" size="207" mtime="1516090945" />
         </directory>
     http_version: 
-  recorded_at: Tue, 22 Aug 2017 12:31:26 GMT
+  recorded_at: Tue, 16 Jan 2018 08:22:39 GMT
 - request:
     method: post
-    uri: http://backend:5352/source/home:tom:branches:ProjectWithRepo:Update/ProjectWithRepo_package?cmd=diff&expand=1&filelimit=10000&opackage=ProjectWithRepo_package&oproject=ProjectWithRepo:Update&rev=6d8b4e042078d289ced39a1738e21c95&view=xml&withissues=1
+    uri: http://backend:5352/source/home:tom:branches:ProjectWithRepo:Update/ProjectWithRepo_package?cmd=diff&expand=1&filelimit=10000&opackage=ProjectWithRepo_package&oproject=ProjectWithRepo:Update&rev=8dcbf337ee5aa0aa89a7deaab7d763d6&tarlimit=10000&view=xml&withissues=1
     body:
       encoding: UTF-8
       string: ''
@@ -5853,9 +5944,9 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="5fc708afda388d0d4ddeaa33bda7c0df">
-          <old project="ProjectWithRepo:Update" package="ProjectWithRepo_package" rev="2" srcmd5="e9d965f2d319f4124109f14a13f4e431" />
-          <new project="home:tom:branches:ProjectWithRepo:Update" package="ProjectWithRepo_package" rev="6d8b4e042078d289ced39a1738e21c95" srcmd5="6d8b4e042078d289ced39a1738e21c95" />
+        <sourcediff key="7454e4acd2860c3bd17651af79808cfa">
+          <old project="ProjectWithRepo:Update" package="ProjectWithRepo_package" rev="2" srcmd5="6e6fbc10551cfc8eb7c6ccfc373d323f" />
+          <new project="home:tom:branches:ProjectWithRepo:Update" package="ProjectWithRepo_package" rev="8dcbf337ee5aa0aa89a7deaab7d763d6" srcmd5="8dcbf337ee5aa0aa89a7deaab7d763d6" />
           <files>
             <file state="added">
               <new name="DUMMY_FILE" md5="275876e34cf609db118f3d84b799a790" size="5" />
@@ -5869,7 +5960,7 @@ http_interactions:
           </issues>
         </sourcediff>
     http_version: 
-  recorded_at: Tue, 22 Aug 2017 12:31:26 GMT
+  recorded_at: Tue, 16 Jan 2018 08:22:39 GMT
 - request:
     method: get
     uri: http://backend:5352/build/home:tom:branches:ProjectWithRepo:Update/_result?package=ProjectWithRepo_package&view=status
@@ -5905,7 +5996,7 @@ http_interactions:
           <result project="home:tom:branches:ProjectWithRepo:Update" repository="repository_2" arch="i586" code="unknown" state="unknown" />
         </resultlist>
     http_version: 
-  recorded_at: Tue, 22 Aug 2017 12:31:26 GMT
+  recorded_at: Tue, 16 Jan 2018 08:22:39 GMT
 - request:
     method: get
     uri: http://backend:5352/build/home:tom:branches:ProjectWithRepo:Update/_result?locallink=1&multibuild=1&package=ProjectWithRepo_package&view=status
@@ -5941,7 +6032,7 @@ http_interactions:
           <result project="home:tom:branches:ProjectWithRepo:Update" repository="repository_2" arch="i586" code="unknown" state="unknown" />
         </resultlist>
     http_version: 
-  recorded_at: Tue, 22 Aug 2017 12:31:26 GMT
+  recorded_at: Tue, 16 Jan 2018 08:22:39 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:tom:branches:ProjectWithRepo:Update/ProjectWithRepo_package
@@ -5971,15 +6062,15 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="ProjectWithRepo_package" rev="2" vrev="2" srcmd5="5acba764a37a9bc6490f80deca372916">
-          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" srcmd5="e9d965f2d319f4124109f14a13f4e431" baserev="e9d965f2d319f4124109f14a13f4e431" xsrcmd5="6d8b4e042078d289ced39a1738e21c95" lsrcmd5="5acba764a37a9bc6490f80deca372916" />
-          <entry name="DUMMY_FILE" md5="275876e34cf609db118f3d84b799a790" size="5" mtime="1503405075" />
-          <entry name="_config" md5="7159169868967997b7eabbd94d805185" size="238" mtime="1503405073" />
-          <entry name="_link" md5="11504ac69b4a7053159649a50cf86e1f" size="130" mtime="1503405074" />
-          <entry name="somefile.txt" md5="b4b03ef7ef00ded93403c2c595500c4f" size="116" mtime="1503405073" />
+        <directory name="ProjectWithRepo_package" rev="2" vrev="2" srcmd5="fea0bed8284652f582f84d5ba0388c2e">
+          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" srcmd5="6e6fbc10551cfc8eb7c6ccfc373d323f" baserev="6e6fbc10551cfc8eb7c6ccfc373d323f" xsrcmd5="8dcbf337ee5aa0aa89a7deaab7d763d6" lsrcmd5="fea0bed8284652f582f84d5ba0388c2e" />
+          <entry name="DUMMY_FILE" md5="275876e34cf609db118f3d84b799a790" size="5" mtime="1516090947" />
+          <entry name="_config" md5="e8ec9a29a8e74d4c7dfc73686c1576b5" size="143" mtime="1516090945" />
+          <entry name="_link" md5="e409478924f3c1c27d895156ac5f39b0" size="130" mtime="1516090946" />
+          <entry name="somefile.txt" md5="95c4ebbcd6a901fc5e9a47439d5e6f92" size="207" mtime="1516090945" />
         </directory>
     http_version: 
-  recorded_at: Tue, 22 Aug 2017 12:31:26 GMT
+  recorded_at: Tue, 16 Jan 2018 08:22:39 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:tom:branches:ProjectWithRepo:Update/ProjectWithRepo_package
@@ -5987,10 +6078,8 @@ http_interactions:
       encoding: US-ASCII
       string: ''
     headers:
-      Content-Type:
-      - text/plain
       Accept-Encoding:
-      - identity
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
       - "*/*"
       User-Agent:
@@ -6011,18 +6100,18 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="ProjectWithRepo_package" rev="2" vrev="2" srcmd5="5acba764a37a9bc6490f80deca372916">
-          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" srcmd5="e9d965f2d319f4124109f14a13f4e431" baserev="e9d965f2d319f4124109f14a13f4e431" xsrcmd5="6d8b4e042078d289ced39a1738e21c95" lsrcmd5="5acba764a37a9bc6490f80deca372916" />
-          <entry name="DUMMY_FILE" md5="275876e34cf609db118f3d84b799a790" size="5" mtime="1503405075" />
-          <entry name="_config" md5="7159169868967997b7eabbd94d805185" size="238" mtime="1503405073" />
-          <entry name="_link" md5="11504ac69b4a7053159649a50cf86e1f" size="130" mtime="1503405074" />
-          <entry name="somefile.txt" md5="b4b03ef7ef00ded93403c2c595500c4f" size="116" mtime="1503405073" />
+        <directory name="ProjectWithRepo_package" rev="2" vrev="2" srcmd5="fea0bed8284652f582f84d5ba0388c2e">
+          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" srcmd5="6e6fbc10551cfc8eb7c6ccfc373d323f" baserev="6e6fbc10551cfc8eb7c6ccfc373d323f" xsrcmd5="8dcbf337ee5aa0aa89a7deaab7d763d6" lsrcmd5="fea0bed8284652f582f84d5ba0388c2e" />
+          <entry name="DUMMY_FILE" md5="275876e34cf609db118f3d84b799a790" size="5" mtime="1516090947" />
+          <entry name="_config" md5="e8ec9a29a8e74d4c7dfc73686c1576b5" size="143" mtime="1516090945" />
+          <entry name="_link" md5="e409478924f3c1c27d895156ac5f39b0" size="130" mtime="1516090946" />
+          <entry name="somefile.txt" md5="95c4ebbcd6a901fc5e9a47439d5e6f92" size="207" mtime="1516090945" />
         </directory>
     http_version: 
-  recorded_at: Tue, 22 Aug 2017 12:31:26 GMT
+  recorded_at: Tue, 16 Jan 2018 08:22:39 GMT
 - request:
     method: post
-    uri: http://backend:5352/source/home:tom:branches:ProjectWithRepo:Update/ProjectWithRepo_package?cmd=diff&expand=1&filelimit=10000&opackage=ProjectWithRepo_package&oproject=ProjectWithRepo:Update&rev=6d8b4e042078d289ced39a1738e21c95&view=xml&withissues=1
+    uri: http://backend:5352/source/home:tom:branches:ProjectWithRepo:Update/ProjectWithRepo_package?cmd=diff&expand=1&filelimit=10000&opackage=ProjectWithRepo_package&oproject=ProjectWithRepo:Update&rev=8dcbf337ee5aa0aa89a7deaab7d763d6&tarlimit=10000&view=xml&withissues=1
     body:
       encoding: UTF-8
       string: ''
@@ -6051,9 +6140,9 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="5fc708afda388d0d4ddeaa33bda7c0df">
-          <old project="ProjectWithRepo:Update" package="ProjectWithRepo_package" rev="2" srcmd5="e9d965f2d319f4124109f14a13f4e431" />
-          <new project="home:tom:branches:ProjectWithRepo:Update" package="ProjectWithRepo_package" rev="6d8b4e042078d289ced39a1738e21c95" srcmd5="6d8b4e042078d289ced39a1738e21c95" />
+        <sourcediff key="7454e4acd2860c3bd17651af79808cfa">
+          <old project="ProjectWithRepo:Update" package="ProjectWithRepo_package" rev="2" srcmd5="6e6fbc10551cfc8eb7c6ccfc373d323f" />
+          <new project="home:tom:branches:ProjectWithRepo:Update" package="ProjectWithRepo_package" rev="8dcbf337ee5aa0aa89a7deaab7d763d6" srcmd5="8dcbf337ee5aa0aa89a7deaab7d763d6" />
           <files>
             <file state="added">
               <new name="DUMMY_FILE" md5="275876e34cf609db118f3d84b799a790" size="5" />
@@ -6067,7 +6156,7 @@ http_interactions:
           </issues>
         </sourcediff>
     http_version: 
-  recorded_at: Tue, 22 Aug 2017 12:31:26 GMT
+  recorded_at: Tue, 16 Jan 2018 08:22:39 GMT
 - request:
     method: get
     uri: http://backend:5352/build/home:tom:branches:ProjectWithRepo:Update/_result?package=ProjectWithRepo_package&view=status
@@ -6103,7 +6192,7 @@ http_interactions:
           <result project="home:tom:branches:ProjectWithRepo:Update" repository="repository_2" arch="i586" code="unknown" state="unknown" />
         </resultlist>
     http_version: 
-  recorded_at: Tue, 22 Aug 2017 12:31:27 GMT
+  recorded_at: Tue, 16 Jan 2018 08:22:39 GMT
 - request:
     method: get
     uri: http://backend:5352/build/home:tom:branches:ProjectWithRepo:Update/_result?locallink=1&multibuild=1&package=ProjectWithRepo_package&view=status
@@ -6139,7 +6228,7 @@ http_interactions:
           <result project="home:tom:branches:ProjectWithRepo:Update" repository="repository_2" arch="i586" code="unknown" state="unknown" />
         </resultlist>
     http_version: 
-  recorded_at: Tue, 22 Aug 2017 12:31:27 GMT
+  recorded_at: Tue, 16 Jan 2018 08:22:39 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:tom:branches:ProjectWithRepo:Update/ProjectWithRepo_package
@@ -6169,15 +6258,15 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="ProjectWithRepo_package" rev="2" vrev="2" srcmd5="5acba764a37a9bc6490f80deca372916">
-          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" srcmd5="e9d965f2d319f4124109f14a13f4e431" baserev="e9d965f2d319f4124109f14a13f4e431" xsrcmd5="6d8b4e042078d289ced39a1738e21c95" lsrcmd5="5acba764a37a9bc6490f80deca372916" />
-          <entry name="DUMMY_FILE" md5="275876e34cf609db118f3d84b799a790" size="5" mtime="1503405075" />
-          <entry name="_config" md5="7159169868967997b7eabbd94d805185" size="238" mtime="1503405073" />
-          <entry name="_link" md5="11504ac69b4a7053159649a50cf86e1f" size="130" mtime="1503405074" />
-          <entry name="somefile.txt" md5="b4b03ef7ef00ded93403c2c595500c4f" size="116" mtime="1503405073" />
+        <directory name="ProjectWithRepo_package" rev="2" vrev="2" srcmd5="fea0bed8284652f582f84d5ba0388c2e">
+          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" srcmd5="6e6fbc10551cfc8eb7c6ccfc373d323f" baserev="6e6fbc10551cfc8eb7c6ccfc373d323f" xsrcmd5="8dcbf337ee5aa0aa89a7deaab7d763d6" lsrcmd5="fea0bed8284652f582f84d5ba0388c2e" />
+          <entry name="DUMMY_FILE" md5="275876e34cf609db118f3d84b799a790" size="5" mtime="1516090947" />
+          <entry name="_config" md5="e8ec9a29a8e74d4c7dfc73686c1576b5" size="143" mtime="1516090945" />
+          <entry name="_link" md5="e409478924f3c1c27d895156ac5f39b0" size="130" mtime="1516090946" />
+          <entry name="somefile.txt" md5="95c4ebbcd6a901fc5e9a47439d5e6f92" size="207" mtime="1516090945" />
         </directory>
     http_version: 
-  recorded_at: Tue, 22 Aug 2017 12:31:27 GMT
+  recorded_at: Tue, 16 Jan 2018 08:22:40 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:tom:branches:ProjectWithRepo:Update/ProjectWithRepo_package
@@ -6185,10 +6274,8 @@ http_interactions:
       encoding: US-ASCII
       string: ''
     headers:
-      Content-Type:
-      - text/plain
       Accept-Encoding:
-      - identity
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
       - "*/*"
       User-Agent:
@@ -6209,18 +6296,18 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="ProjectWithRepo_package" rev="2" vrev="2" srcmd5="5acba764a37a9bc6490f80deca372916">
-          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" srcmd5="e9d965f2d319f4124109f14a13f4e431" baserev="e9d965f2d319f4124109f14a13f4e431" xsrcmd5="6d8b4e042078d289ced39a1738e21c95" lsrcmd5="5acba764a37a9bc6490f80deca372916" />
-          <entry name="DUMMY_FILE" md5="275876e34cf609db118f3d84b799a790" size="5" mtime="1503405075" />
-          <entry name="_config" md5="7159169868967997b7eabbd94d805185" size="238" mtime="1503405073" />
-          <entry name="_link" md5="11504ac69b4a7053159649a50cf86e1f" size="130" mtime="1503405074" />
-          <entry name="somefile.txt" md5="b4b03ef7ef00ded93403c2c595500c4f" size="116" mtime="1503405073" />
+        <directory name="ProjectWithRepo_package" rev="2" vrev="2" srcmd5="fea0bed8284652f582f84d5ba0388c2e">
+          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" srcmd5="6e6fbc10551cfc8eb7c6ccfc373d323f" baserev="6e6fbc10551cfc8eb7c6ccfc373d323f" xsrcmd5="8dcbf337ee5aa0aa89a7deaab7d763d6" lsrcmd5="fea0bed8284652f582f84d5ba0388c2e" />
+          <entry name="DUMMY_FILE" md5="275876e34cf609db118f3d84b799a790" size="5" mtime="1516090947" />
+          <entry name="_config" md5="e8ec9a29a8e74d4c7dfc73686c1576b5" size="143" mtime="1516090945" />
+          <entry name="_link" md5="e409478924f3c1c27d895156ac5f39b0" size="130" mtime="1516090946" />
+          <entry name="somefile.txt" md5="95c4ebbcd6a901fc5e9a47439d5e6f92" size="207" mtime="1516090945" />
         </directory>
     http_version: 
-  recorded_at: Tue, 22 Aug 2017 12:31:27 GMT
+  recorded_at: Tue, 16 Jan 2018 08:22:40 GMT
 - request:
     method: post
-    uri: http://backend:5352/source/home:tom:branches:ProjectWithRepo:Update/ProjectWithRepo_package?cmd=diff&expand=1&filelimit=10000&opackage=ProjectWithRepo_package&oproject=ProjectWithRepo:Update&rev=6d8b4e042078d289ced39a1738e21c95&view=xml&withissues=1
+    uri: http://backend:5352/source/home:tom:branches:ProjectWithRepo:Update/ProjectWithRepo_package?cmd=diff&expand=1&filelimit=10000&opackage=ProjectWithRepo_package&oproject=ProjectWithRepo:Update&rev=8dcbf337ee5aa0aa89a7deaab7d763d6&tarlimit=10000&view=xml&withissues=1
     body:
       encoding: UTF-8
       string: ''
@@ -6249,9 +6336,9 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="5fc708afda388d0d4ddeaa33bda7c0df">
-          <old project="ProjectWithRepo:Update" package="ProjectWithRepo_package" rev="2" srcmd5="e9d965f2d319f4124109f14a13f4e431" />
-          <new project="home:tom:branches:ProjectWithRepo:Update" package="ProjectWithRepo_package" rev="6d8b4e042078d289ced39a1738e21c95" srcmd5="6d8b4e042078d289ced39a1738e21c95" />
+        <sourcediff key="7454e4acd2860c3bd17651af79808cfa">
+          <old project="ProjectWithRepo:Update" package="ProjectWithRepo_package" rev="2" srcmd5="6e6fbc10551cfc8eb7c6ccfc373d323f" />
+          <new project="home:tom:branches:ProjectWithRepo:Update" package="ProjectWithRepo_package" rev="8dcbf337ee5aa0aa89a7deaab7d763d6" srcmd5="8dcbf337ee5aa0aa89a7deaab7d763d6" />
           <files>
             <file state="added">
               <new name="DUMMY_FILE" md5="275876e34cf609db118f3d84b799a790" size="5" />
@@ -6265,7 +6352,7 @@ http_interactions:
           </issues>
         </sourcediff>
     http_version: 
-  recorded_at: Tue, 22 Aug 2017 12:31:27 GMT
+  recorded_at: Tue, 16 Jan 2018 08:22:40 GMT
 - request:
     method: get
     uri: http://backend:5352/build/home:tom:branches:ProjectWithRepo:Update/_result?package=ProjectWithRepo_package&view=status
@@ -6301,7 +6388,7 @@ http_interactions:
           <result project="home:tom:branches:ProjectWithRepo:Update" repository="repository_2" arch="i586" code="unknown" state="unknown" />
         </resultlist>
     http_version: 
-  recorded_at: Tue, 22 Aug 2017 12:31:27 GMT
+  recorded_at: Tue, 16 Jan 2018 08:22:40 GMT
 - request:
     method: get
     uri: http://backend:5352/build/home:tom:branches:ProjectWithRepo:Update/_result?locallink=1&multibuild=1&package=ProjectWithRepo_package&view=status
@@ -6337,7 +6424,7 @@ http_interactions:
           <result project="home:tom:branches:ProjectWithRepo:Update" repository="repository_2" arch="i586" code="unknown" state="unknown" />
         </resultlist>
     http_version: 
-  recorded_at: Tue, 22 Aug 2017 12:31:27 GMT
+  recorded_at: Tue, 16 Jan 2018 08:22:40 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:tom:branches:ProjectWithRepo:Update/ProjectWithRepo_package
@@ -6367,57 +6454,18 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="ProjectWithRepo_package" rev="2" vrev="2" srcmd5="5acba764a37a9bc6490f80deca372916">
-          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" srcmd5="e9d965f2d319f4124109f14a13f4e431" baserev="e9d965f2d319f4124109f14a13f4e431" xsrcmd5="6d8b4e042078d289ced39a1738e21c95" lsrcmd5="5acba764a37a9bc6490f80deca372916" />
-          <entry name="DUMMY_FILE" md5="275876e34cf609db118f3d84b799a790" size="5" mtime="1503405075" />
-          <entry name="_config" md5="7159169868967997b7eabbd94d805185" size="238" mtime="1503405073" />
-          <entry name="_link" md5="11504ac69b4a7053159649a50cf86e1f" size="130" mtime="1503405074" />
-          <entry name="somefile.txt" md5="b4b03ef7ef00ded93403c2c595500c4f" size="116" mtime="1503405073" />
+        <directory name="ProjectWithRepo_package" rev="2" vrev="2" srcmd5="fea0bed8284652f582f84d5ba0388c2e">
+          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" srcmd5="6e6fbc10551cfc8eb7c6ccfc373d323f" baserev="6e6fbc10551cfc8eb7c6ccfc373d323f" xsrcmd5="8dcbf337ee5aa0aa89a7deaab7d763d6" lsrcmd5="fea0bed8284652f582f84d5ba0388c2e" />
+          <entry name="DUMMY_FILE" md5="275876e34cf609db118f3d84b799a790" size="5" mtime="1516090947" />
+          <entry name="_config" md5="e8ec9a29a8e74d4c7dfc73686c1576b5" size="143" mtime="1516090945" />
+          <entry name="_link" md5="e409478924f3c1c27d895156ac5f39b0" size="130" mtime="1516090946" />
+          <entry name="somefile.txt" md5="95c4ebbcd6a901fc5e9a47439d5e6f92" size="207" mtime="1516090945" />
         </directory>
     http_version: 
-  recorded_at: Tue, 22 Aug 2017 12:31:27 GMT
+  recorded_at: Tue, 16 Jan 2018 08:22:40 GMT
 - request:
     method: get
-    uri: http://backend:5352/source/home:tom:branches:ProjectWithRepo:Update/ProjectWithRepo_package?expand=1&rev=6d8b4e042078d289ced39a1738e21c95
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Content-Type:
-      - text/plain
-      Accept-Encoding:
-      - identity
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '641'
-    body:
-      encoding: UTF-8
-      string: |
-        <directory name="ProjectWithRepo_package" rev="6d8b4e042078d289ced39a1738e21c95" srcmd5="6d8b4e042078d289ced39a1738e21c95">
-          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" srcmd5="e9d965f2d319f4124109f14a13f4e431" baserev="e9d965f2d319f4124109f14a13f4e431" lsrcmd5="5acba764a37a9bc6490f80deca372916" />
-          <entry name="DUMMY_FILE" md5="275876e34cf609db118f3d84b799a790" size="5" mtime="1503405075" />
-          <entry name="_config" md5="7159169868967997b7eabbd94d805185" size="238" mtime="1503405073" />
-          <entry name="somefile.txt" md5="b4b03ef7ef00ded93403c2c595500c4f" size="116" mtime="1503405073" />
-        </directory>
-    http_version: 
-  recorded_at: Tue, 22 Aug 2017 12:31:27 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/home:tom:branches:ProjectWithRepo:Update/ProjectWithRepo_package?expand=1&rev=6d8b4e042078d289ced39a1738e21c95
+    uri: http://backend:5352/source/home:tom:branches:ProjectWithRepo:Update/ProjectWithRepo_package?expand=1&rev=8dcbf337ee5aa0aa89a7deaab7d763d6
     body:
       encoding: US-ASCII
       string: ''
@@ -6444,14 +6492,51 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="ProjectWithRepo_package" rev="6d8b4e042078d289ced39a1738e21c95" srcmd5="6d8b4e042078d289ced39a1738e21c95">
-          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" srcmd5="e9d965f2d319f4124109f14a13f4e431" baserev="e9d965f2d319f4124109f14a13f4e431" lsrcmd5="5acba764a37a9bc6490f80deca372916" />
-          <entry name="DUMMY_FILE" md5="275876e34cf609db118f3d84b799a790" size="5" mtime="1503405075" />
-          <entry name="_config" md5="7159169868967997b7eabbd94d805185" size="238" mtime="1503405073" />
-          <entry name="somefile.txt" md5="b4b03ef7ef00ded93403c2c595500c4f" size="116" mtime="1503405073" />
+        <directory name="ProjectWithRepo_package" rev="8dcbf337ee5aa0aa89a7deaab7d763d6" srcmd5="8dcbf337ee5aa0aa89a7deaab7d763d6">
+          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" srcmd5="6e6fbc10551cfc8eb7c6ccfc373d323f" baserev="6e6fbc10551cfc8eb7c6ccfc373d323f" lsrcmd5="fea0bed8284652f582f84d5ba0388c2e" />
+          <entry name="DUMMY_FILE" md5="275876e34cf609db118f3d84b799a790" size="5" mtime="1516090947" />
+          <entry name="_config" md5="e8ec9a29a8e74d4c7dfc73686c1576b5" size="143" mtime="1516090945" />
+          <entry name="somefile.txt" md5="95c4ebbcd6a901fc5e9a47439d5e6f92" size="207" mtime="1516090945" />
         </directory>
     http_version: 
-  recorded_at: Tue, 22 Aug 2017 12:31:28 GMT
+  recorded_at: Tue, 16 Jan 2018 08:22:41 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:tom:branches:ProjectWithRepo:Update/ProjectWithRepo_package?expand=1&rev=8dcbf337ee5aa0aa89a7deaab7d763d6
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '641'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="ProjectWithRepo_package" rev="8dcbf337ee5aa0aa89a7deaab7d763d6" srcmd5="8dcbf337ee5aa0aa89a7deaab7d763d6">
+          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" srcmd5="6e6fbc10551cfc8eb7c6ccfc373d323f" baserev="6e6fbc10551cfc8eb7c6ccfc373d323f" lsrcmd5="fea0bed8284652f582f84d5ba0388c2e" />
+          <entry name="DUMMY_FILE" md5="275876e34cf609db118f3d84b799a790" size="5" mtime="1516090947" />
+          <entry name="_config" md5="e8ec9a29a8e74d4c7dfc73686c1576b5" size="143" mtime="1516090945" />
+          <entry name="somefile.txt" md5="95c4ebbcd6a901fc5e9a47439d5e6f92" size="207" mtime="1516090945" />
+        </directory>
+    http_version: 
+  recorded_at: Tue, 16 Jan 2018 08:22:41 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:tom:branches:ProjectWithRepo:Update/ProjectWithRepo_package
@@ -6481,15 +6566,15 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="ProjectWithRepo_package" rev="2" vrev="2" srcmd5="5acba764a37a9bc6490f80deca372916">
-          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" srcmd5="e9d965f2d319f4124109f14a13f4e431" baserev="e9d965f2d319f4124109f14a13f4e431" xsrcmd5="6d8b4e042078d289ced39a1738e21c95" lsrcmd5="5acba764a37a9bc6490f80deca372916" />
-          <entry name="DUMMY_FILE" md5="275876e34cf609db118f3d84b799a790" size="5" mtime="1503405075" />
-          <entry name="_config" md5="7159169868967997b7eabbd94d805185" size="238" mtime="1503405073" />
-          <entry name="_link" md5="11504ac69b4a7053159649a50cf86e1f" size="130" mtime="1503405074" />
-          <entry name="somefile.txt" md5="b4b03ef7ef00ded93403c2c595500c4f" size="116" mtime="1503405073" />
+        <directory name="ProjectWithRepo_package" rev="2" vrev="2" srcmd5="fea0bed8284652f582f84d5ba0388c2e">
+          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" srcmd5="6e6fbc10551cfc8eb7c6ccfc373d323f" baserev="6e6fbc10551cfc8eb7c6ccfc373d323f" xsrcmd5="8dcbf337ee5aa0aa89a7deaab7d763d6" lsrcmd5="fea0bed8284652f582f84d5ba0388c2e" />
+          <entry name="DUMMY_FILE" md5="275876e34cf609db118f3d84b799a790" size="5" mtime="1516090947" />
+          <entry name="_config" md5="e8ec9a29a8e74d4c7dfc73686c1576b5" size="143" mtime="1516090945" />
+          <entry name="_link" md5="e409478924f3c1c27d895156ac5f39b0" size="130" mtime="1516090946" />
+          <entry name="somefile.txt" md5="95c4ebbcd6a901fc5e9a47439d5e6f92" size="207" mtime="1516090945" />
         </directory>
     http_version: 
-  recorded_at: Tue, 22 Aug 2017 12:31:28 GMT
+  recorded_at: Tue, 16 Jan 2018 08:22:41 GMT
 - request:
     method: post
     uri: http://backend:5352/search/package/id?match=(linkinfo/@package=%22ProjectWithRepo_package%22%20and%20linkinfo/@project=%22ProjectWithRepo:Update%22%20and%20starts-with(@project,%22MaintenanceProject:%22))
@@ -6525,7 +6610,7 @@ http_interactions:
           <package name="ProjectWithRepo_package.ProjectWithRepo_Update" project="MaintenanceProject:0" />
         </collection>
     http_version: 
-  recorded_at: Tue, 22 Aug 2017 12:31:28 GMT
+  recorded_at: Tue, 16 Jan 2018 08:22:41 GMT
 - request:
     method: post
     uri: http://backend:5352/search/package/id?match=(linkinfo/@package=%22ProjectWithRepo_package%22%20and%20linkinfo/@project=%22ProjectWithRepo%22%20and%20@project=%22ProjectWithRepo%22)
@@ -6560,7 +6645,7 @@ http_interactions:
         <collection>
         </collection>
     http_version: 
-  recorded_at: Tue, 22 Aug 2017 12:31:28 GMT
+  recorded_at: Tue, 16 Jan 2018 08:22:41 GMT
 - request:
     method: put
     uri: http://backend:5352/source/MaintenanceProject:0/ProjectWithRepo_package.ProjectWithRepo_Update/_meta?user=maintenance_coord
@@ -6568,8 +6653,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="ProjectWithRepo_package.ProjectWithRepo_Update" project="MaintenanceProject:0">
-          <title>Have His Carcase</title>
-          <description>Molestiae eligendi asperiores quod voluptatibus totam non recusandae voluptas.</description>
+          <title>To a God Unknown</title>
+          <description>Sed voluptatum dolorem et omnis.</description>
           <releasename>ProjectWithRepo_package</releasename>
           <build>
             <enable repository="ProjectWithRepo_Update"/>
@@ -6594,23 +6679,23 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '373'
+      - '327'
     body:
       encoding: UTF-8
       string: |
         <package name="ProjectWithRepo_package.ProjectWithRepo_Update" project="MaintenanceProject:0">
-          <title>Have His Carcase</title>
-          <description>Molestiae eligendi asperiores quod voluptatibus totam non recusandae voluptas.</description>
+          <title>To a God Unknown</title>
+          <description>Sed voluptatum dolorem et omnis.</description>
           <releasename>ProjectWithRepo_package</releasename>
           <build>
             <enable repository="ProjectWithRepo_Update" />
           </build>
         </package>
     http_version: 
-  recorded_at: Tue, 22 Aug 2017 12:31:28 GMT
+  recorded_at: Tue, 16 Jan 2018 08:22:41 GMT
 - request:
     method: post
-    uri: http://backend:5352/source/MaintenanceProject:0/ProjectWithRepo_package.ProjectWithRepo_Update?cmd=branch&opackage=ProjectWithRepo_package&oproject=ProjectWithRepo:Update&user=maintenance_coord
+    uri: http://backend:5352/source/MaintenanceProject:0/ProjectWithRepo_package.ProjectWithRepo_Update?cmd=branch&extendvrev=1&noservice=1&opackage=ProjectWithRepo_package&oproject=ProjectWithRepo:Update&user=maintenance_coord
     body:
       encoding: UTF-8
       string: ''
@@ -6640,15 +6725,15 @@ http_interactions:
       encoding: UTF-8
       string: |
         <revision rev="3" vrev="3">
-          <srcmd5>8f207ebc6846b26ebb947a0d4399345e</srcmd5>
+          <srcmd5>012405659355f1fe41511515d788a6aa</srcmd5>
           <version>unknown</version>
-          <time>1503405088</time>
+          <time>1516090961</time>
           <user>maintenance_coord</user>
           <comment></comment>
           <requestid/>
         </revision>
     http_version: 
-  recorded_at: Tue, 22 Aug 2017 12:31:28 GMT
+  recorded_at: Tue, 16 Jan 2018 08:22:41 GMT
 - request:
     method: put
     uri: http://backend:5352/source/MaintenanceProject:0/ProjectWithRepo_package.ProjectWithRepo_Update/_meta?user=maintenance_coord
@@ -6656,8 +6741,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="ProjectWithRepo_package.ProjectWithRepo_Update" project="MaintenanceProject:0">
-          <title>Have His Carcase</title>
-          <description>Molestiae eligendi asperiores quod voluptatibus totam non recusandae voluptas.</description>
+          <title>To a God Unknown</title>
+          <description>Sed voluptatum dolorem et omnis.</description>
           <releasename>ProjectWithRepo_package</releasename>
           <build>
             <enable repository="ProjectWithRepo_Update"/>
@@ -6682,20 +6767,20 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '373'
+      - '327'
     body:
       encoding: UTF-8
       string: |
         <package name="ProjectWithRepo_package.ProjectWithRepo_Update" project="MaintenanceProject:0">
-          <title>Have His Carcase</title>
-          <description>Molestiae eligendi asperiores quod voluptatibus totam non recusandae voluptas.</description>
+          <title>To a God Unknown</title>
+          <description>Sed voluptatum dolorem et omnis.</description>
           <releasename>ProjectWithRepo_package</releasename>
           <build>
             <enable repository="ProjectWithRepo_Update" />
           </build>
         </package>
     http_version: 
-  recorded_at: Tue, 22 Aug 2017 12:31:28 GMT
+  recorded_at: Tue, 16 Jan 2018 08:22:41 GMT
 - request:
     method: get
     uri: http://backend:5352/source/MaintenanceProject:0/ProjectWithRepo_package.ProjectWithRepo_Update
@@ -6725,14 +6810,14 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="ProjectWithRepo_package.ProjectWithRepo_Update" rev="3" vrev="3" srcmd5="8f207ebc6846b26ebb947a0d4399345e">
-          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" srcmd5="e9d965f2d319f4124109f14a13f4e431" baserev="e9d965f2d319f4124109f14a13f4e431" xsrcmd5="ef9928a63930d4797ced0ef2ad58ed0c" lsrcmd5="8f207ebc6846b26ebb947a0d4399345e" />
-          <entry name="_config" md5="7159169868967997b7eabbd94d805185" size="238" mtime="1503405073" />
-          <entry name="_link" md5="ad672afb37ca2f6a039ad35297d226d1" size="164" mtime="1503405079" />
-          <entry name="somefile.txt" md5="b4b03ef7ef00ded93403c2c595500c4f" size="116" mtime="1503405073" />
+        <directory name="ProjectWithRepo_package.ProjectWithRepo_Update" rev="3" vrev="3" srcmd5="012405659355f1fe41511515d788a6aa">
+          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" srcmd5="6e6fbc10551cfc8eb7c6ccfc373d323f" baserev="6e6fbc10551cfc8eb7c6ccfc373d323f" xsrcmd5="39895c37617de8a93814934ec17f5508" lsrcmd5="012405659355f1fe41511515d788a6aa" />
+          <entry name="_config" md5="e8ec9a29a8e74d4c7dfc73686c1576b5" size="143" mtime="1516090945" />
+          <entry name="_link" md5="56994b1cc0c8cb5e1662d148e8d3ba70" size="175" mtime="1516090951" />
+          <entry name="somefile.txt" md5="95c4ebbcd6a901fc5e9a47439d5e6f92" size="207" mtime="1516090945" />
         </directory>
     http_version: 
-  recorded_at: Tue, 22 Aug 2017 12:31:28 GMT
+  recorded_at: Tue, 16 Jan 2018 08:22:41 GMT
 - request:
     method: get
     uri: http://backend:5352/source/MaintenanceProject:0/ProjectWithRepo_package.ProjectWithRepo_Update?nofilename=1&view=info&withchangesmd5=1
@@ -6758,17 +6843,17 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '416'
+      - '418'
     body:
       encoding: UTF-8
       string: |
-        <sourceinfo package="ProjectWithRepo_package.ProjectWithRepo_Update" rev="3" vrev="5" srcmd5="ef9928a63930d4797ced0ef2ad58ed0c" lsrcmd5="8f207ebc6846b26ebb947a0d4399345e" verifymd5="e9d965f2d319f4124109f14a13f4e431">
+        <sourceinfo package="ProjectWithRepo_package.ProjectWithRepo_Update" rev="3" vrev="4.4" srcmd5="39895c37617de8a93814934ec17f5508" lsrcmd5="012405659355f1fe41511515d788a6aa" verifymd5="6e6fbc10551cfc8eb7c6ccfc373d323f">
           <linked project="ProjectWithRepo:Update" package="ProjectWithRepo_package" />
           <linked project="ProjectWithRepo" package="ProjectWithRepo_package" />
-          <revtime>1503405088</revtime>
+          <revtime>1516090961</revtime>
         </sourceinfo>
     http_version: 
-  recorded_at: Tue, 22 Aug 2017 12:31:28 GMT
+  recorded_at: Tue, 16 Jan 2018 08:22:41 GMT
 - request:
     method: get
     uri: http://backend:5352/source/MaintenanceProject:0/ProjectWithRepo_package.ProjectWithRepo_Update
@@ -6798,14 +6883,14 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="ProjectWithRepo_package.ProjectWithRepo_Update" rev="3" vrev="3" srcmd5="8f207ebc6846b26ebb947a0d4399345e">
-          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" srcmd5="e9d965f2d319f4124109f14a13f4e431" baserev="e9d965f2d319f4124109f14a13f4e431" xsrcmd5="ef9928a63930d4797ced0ef2ad58ed0c" lsrcmd5="8f207ebc6846b26ebb947a0d4399345e" />
-          <entry name="_config" md5="7159169868967997b7eabbd94d805185" size="238" mtime="1503405073" />
-          <entry name="_link" md5="ad672afb37ca2f6a039ad35297d226d1" size="164" mtime="1503405079" />
-          <entry name="somefile.txt" md5="b4b03ef7ef00ded93403c2c595500c4f" size="116" mtime="1503405073" />
+        <directory name="ProjectWithRepo_package.ProjectWithRepo_Update" rev="3" vrev="3" srcmd5="012405659355f1fe41511515d788a6aa">
+          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" srcmd5="6e6fbc10551cfc8eb7c6ccfc373d323f" baserev="6e6fbc10551cfc8eb7c6ccfc373d323f" xsrcmd5="39895c37617de8a93814934ec17f5508" lsrcmd5="012405659355f1fe41511515d788a6aa" />
+          <entry name="_config" md5="e8ec9a29a8e74d4c7dfc73686c1576b5" size="143" mtime="1516090945" />
+          <entry name="_link" md5="56994b1cc0c8cb5e1662d148e8d3ba70" size="175" mtime="1516090951" />
+          <entry name="somefile.txt" md5="95c4ebbcd6a901fc5e9a47439d5e6f92" size="207" mtime="1516090945" />
         </directory>
     http_version: 
-  recorded_at: Tue, 22 Aug 2017 12:31:28 GMT
+  recorded_at: Tue, 16 Jan 2018 08:22:41 GMT
 - request:
     method: post
     uri: http://backend:5352/source/MaintenanceProject:0/ProjectWithRepo_package.ProjectWithRepo_Update?cmd=diff&linkrev=base&onlyissues=1&orev=0&view=xml
@@ -6837,15 +6922,15 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="b61c34ff40308ddf8f623d6890654428">
+        <sourcediff key="4f69c657ad64b4357dd230fc3e5828da">
           <old project="MaintenanceProject:0" package="ProjectWithRepo_package.ProjectWithRepo_Update" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e" />
-          <new project="MaintenanceProject:0" package="ProjectWithRepo_package.ProjectWithRepo_Update" rev="1" srcmd5="8f207ebc6846b26ebb947a0d4399345e" />
+          <new project="MaintenanceProject:0" package="ProjectWithRepo_package.ProjectWithRepo_Update" rev="1" srcmd5="012405659355f1fe41511515d788a6aa" />
           <files />
           <issues>
           </issues>
         </sourcediff>
     http_version: 
-  recorded_at: Tue, 22 Aug 2017 12:31:28 GMT
+  recorded_at: Tue, 16 Jan 2018 08:22:41 GMT
 - request:
     method: post
     uri: http://backend:5352/source/MaintenanceProject:0/ProjectWithRepo_package.ProjectWithRepo_Update?cmd=linkdiff&linkrev=base&onlyissues=1&view=xml
@@ -6877,13 +6962,13 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="2bd7c5fd0453c368b796a8f70d681186">
-          <old project="ProjectWithRepo:Update" package="ProjectWithRepo_package" rev="e9d965f2d319f4124109f14a13f4e431" srcmd5="e9d965f2d319f4124109f14a13f4e431" />
-          <new project="MaintenanceProject:0" package="ProjectWithRepo_package.ProjectWithRepo_Update" rev="ef9928a63930d4797ced0ef2ad58ed0c" srcmd5="ef9928a63930d4797ced0ef2ad58ed0c" />
+        <sourcediff key="27443efe80b045615f13f3a3eac0e487">
+          <old project="ProjectWithRepo:Update" package="ProjectWithRepo_package" rev="6e6fbc10551cfc8eb7c6ccfc373d323f" srcmd5="6e6fbc10551cfc8eb7c6ccfc373d323f" />
+          <new project="MaintenanceProject:0" package="ProjectWithRepo_package.ProjectWithRepo_Update" rev="39895c37617de8a93814934ec17f5508" srcmd5="39895c37617de8a93814934ec17f5508" />
           <files />
         </sourcediff>
     http_version: 
-  recorded_at: Tue, 22 Aug 2017 12:31:28 GMT
+  recorded_at: Tue, 16 Jan 2018 08:22:41 GMT
 - request:
     method: put
     uri: http://backend:5352/source/MaintenanceProject:0/ProjectWithRepo_package.ProjectWithRepo_Update/_meta?user=maintenance_coord
@@ -6891,8 +6976,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="ProjectWithRepo_package.ProjectWithRepo_Update" project="MaintenanceProject:0">
-          <title>Have His Carcase</title>
-          <description>Molestiae eligendi asperiores quod voluptatibus totam non recusandae voluptas.</description>
+          <title>To a God Unknown</title>
+          <description>Sed voluptatum dolorem et omnis.</description>
           <releasename>ProjectWithRepo_package</releasename>
           <build>
             <enable repository="ProjectWithRepo_Update"/>
@@ -6918,13 +7003,13 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '424'
+      - '378'
     body:
       encoding: UTF-8
       string: |
         <package name="ProjectWithRepo_package.ProjectWithRepo_Update" project="MaintenanceProject:0">
-          <title>Have His Carcase</title>
-          <description>Molestiae eligendi asperiores quod voluptatibus totam non recusandae voluptas.</description>
+          <title>To a God Unknown</title>
+          <description>Sed voluptatum dolorem et omnis.</description>
           <releasename>ProjectWithRepo_package</releasename>
           <build>
             <enable repository="ProjectWithRepo_Update" />
@@ -6932,7 +7017,7 @@ http_interactions:
           </build>
         </package>
     http_version: 
-  recorded_at: Tue, 22 Aug 2017 12:31:28 GMT
+  recorded_at: Tue, 16 Jan 2018 08:22:41 GMT
 - request:
     method: get
     uri: http://backend:5352/source/MaintenanceProject:0/ProjectWithRepo_package.ProjectWithRepo_Update
@@ -6962,14 +7047,14 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="ProjectWithRepo_package.ProjectWithRepo_Update" rev="3" vrev="3" srcmd5="8f207ebc6846b26ebb947a0d4399345e">
-          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" srcmd5="e9d965f2d319f4124109f14a13f4e431" baserev="e9d965f2d319f4124109f14a13f4e431" xsrcmd5="ef9928a63930d4797ced0ef2ad58ed0c" lsrcmd5="8f207ebc6846b26ebb947a0d4399345e" />
-          <entry name="_config" md5="7159169868967997b7eabbd94d805185" size="238" mtime="1503405073" />
-          <entry name="_link" md5="ad672afb37ca2f6a039ad35297d226d1" size="164" mtime="1503405079" />
-          <entry name="somefile.txt" md5="b4b03ef7ef00ded93403c2c595500c4f" size="116" mtime="1503405073" />
+        <directory name="ProjectWithRepo_package.ProjectWithRepo_Update" rev="3" vrev="3" srcmd5="012405659355f1fe41511515d788a6aa">
+          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" srcmd5="6e6fbc10551cfc8eb7c6ccfc373d323f" baserev="6e6fbc10551cfc8eb7c6ccfc373d323f" xsrcmd5="39895c37617de8a93814934ec17f5508" lsrcmd5="012405659355f1fe41511515d788a6aa" />
+          <entry name="_config" md5="e8ec9a29a8e74d4c7dfc73686c1576b5" size="143" mtime="1516090945" />
+          <entry name="_link" md5="56994b1cc0c8cb5e1662d148e8d3ba70" size="175" mtime="1516090951" />
+          <entry name="somefile.txt" md5="95c4ebbcd6a901fc5e9a47439d5e6f92" size="207" mtime="1516090945" />
         </directory>
     http_version: 
-  recorded_at: Tue, 22 Aug 2017 12:31:28 GMT
+  recorded_at: Tue, 16 Jan 2018 08:22:41 GMT
 - request:
     method: get
     uri: http://backend:5352/source/MaintenanceProject:0/ProjectWithRepo_package.ProjectWithRepo_Update
@@ -6999,14 +7084,14 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="ProjectWithRepo_package.ProjectWithRepo_Update" rev="3" vrev="3" srcmd5="8f207ebc6846b26ebb947a0d4399345e">
-          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" srcmd5="e9d965f2d319f4124109f14a13f4e431" baserev="e9d965f2d319f4124109f14a13f4e431" xsrcmd5="ef9928a63930d4797ced0ef2ad58ed0c" lsrcmd5="8f207ebc6846b26ebb947a0d4399345e" />
-          <entry name="_config" md5="7159169868967997b7eabbd94d805185" size="238" mtime="1503405073" />
-          <entry name="_link" md5="ad672afb37ca2f6a039ad35297d226d1" size="164" mtime="1503405079" />
-          <entry name="somefile.txt" md5="b4b03ef7ef00ded93403c2c595500c4f" size="116" mtime="1503405073" />
+        <directory name="ProjectWithRepo_package.ProjectWithRepo_Update" rev="3" vrev="3" srcmd5="012405659355f1fe41511515d788a6aa">
+          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" srcmd5="6e6fbc10551cfc8eb7c6ccfc373d323f" baserev="6e6fbc10551cfc8eb7c6ccfc373d323f" xsrcmd5="39895c37617de8a93814934ec17f5508" lsrcmd5="012405659355f1fe41511515d788a6aa" />
+          <entry name="_config" md5="e8ec9a29a8e74d4c7dfc73686c1576b5" size="143" mtime="1516090945" />
+          <entry name="_link" md5="56994b1cc0c8cb5e1662d148e8d3ba70" size="175" mtime="1516090951" />
+          <entry name="somefile.txt" md5="95c4ebbcd6a901fc5e9a47439d5e6f92" size="207" mtime="1516090945" />
         </directory>
     http_version: 
-  recorded_at: Tue, 22 Aug 2017 12:31:28 GMT
+  recorded_at: Tue, 16 Jan 2018 08:22:41 GMT
 - request:
     method: get
     uri: http://backend:5352/source/MaintenanceProject:0/ProjectWithRepo_package.ProjectWithRepo_Update
@@ -7036,14 +7121,14 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="ProjectWithRepo_package.ProjectWithRepo_Update" rev="3" vrev="3" srcmd5="8f207ebc6846b26ebb947a0d4399345e">
-          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" srcmd5="e9d965f2d319f4124109f14a13f4e431" baserev="e9d965f2d319f4124109f14a13f4e431" xsrcmd5="ef9928a63930d4797ced0ef2ad58ed0c" lsrcmd5="8f207ebc6846b26ebb947a0d4399345e" />
-          <entry name="_config" md5="7159169868967997b7eabbd94d805185" size="238" mtime="1503405073" />
-          <entry name="_link" md5="ad672afb37ca2f6a039ad35297d226d1" size="164" mtime="1503405079" />
-          <entry name="somefile.txt" md5="b4b03ef7ef00ded93403c2c595500c4f" size="116" mtime="1503405073" />
+        <directory name="ProjectWithRepo_package.ProjectWithRepo_Update" rev="3" vrev="3" srcmd5="012405659355f1fe41511515d788a6aa">
+          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" srcmd5="6e6fbc10551cfc8eb7c6ccfc373d323f" baserev="6e6fbc10551cfc8eb7c6ccfc373d323f" xsrcmd5="39895c37617de8a93814934ec17f5508" lsrcmd5="012405659355f1fe41511515d788a6aa" />
+          <entry name="_config" md5="e8ec9a29a8e74d4c7dfc73686c1576b5" size="143" mtime="1516090945" />
+          <entry name="_link" md5="56994b1cc0c8cb5e1662d148e8d3ba70" size="175" mtime="1516090951" />
+          <entry name="somefile.txt" md5="95c4ebbcd6a901fc5e9a47439d5e6f92" size="207" mtime="1516090945" />
         </directory>
     http_version: 
-  recorded_at: Tue, 22 Aug 2017 12:31:28 GMT
+  recorded_at: Tue, 16 Jan 2018 08:22:41 GMT
 - request:
     method: post
     uri: http://backend:5352/search/package/id?match=(linkinfo/@package=%22ProjectWithRepo_package%22%20and%20linkinfo/@project=%22ProjectWithRepo%22%20and%20@project=%22ProjectWithRepo%22)
@@ -7078,7 +7163,7 @@ http_interactions:
         <collection>
         </collection>
     http_version: 
-  recorded_at: Tue, 22 Aug 2017 12:31:28 GMT
+  recorded_at: Tue, 16 Jan 2018 08:22:41 GMT
 - request:
     method: put
     uri: http://backend:5352/source/MaintenanceProject:0/_meta?user=maintenance_coord
@@ -7143,7 +7228,7 @@ http_interactions:
           </repository>
         </project>
     http_version: 
-  recorded_at: Tue, 22 Aug 2017 12:31:28 GMT
+  recorded_at: Tue, 16 Jan 2018 08:22:41 GMT
 - request:
     method: put
     uri: http://backend:5352/source/MaintenanceProject:0/_meta?user=maintenance_coord
@@ -7208,10 +7293,10 @@ http_interactions:
           </repository>
         </project>
     http_version: 
-  recorded_at: Tue, 22 Aug 2017 12:31:28 GMT
+  recorded_at: Tue, 16 Jan 2018 08:22:41 GMT
 - request:
     method: post
-    uri: http://backend:5352/source/MaintenanceProject:0/ProjectWithRepo_package.ProjectWithRepo_Update?cmd=copy&comment=Maintenance%20incident%20copy%20from%20project%20home:tom:branches:ProjectWithRepo:Update&expand=1&keeplink=1&opackage=ProjectWithRepo_package&oproject=home:tom:branches:ProjectWithRepo:Update&orev=6d8b4e042078d289ced39a1738e21c95&requestid=2&user=maintenance_coord&withacceptinfo=1
+    uri: http://backend:5352/source/MaintenanceProject:0/ProjectWithRepo_package.ProjectWithRepo_Update?cmd=copy&comment=Maintenance%20incident%20copy%20from%20project%20home:tom:branches:ProjectWithRepo:Update&expand=1&keeplink=1&opackage=ProjectWithRepo_package&oproject=home:tom:branches:ProjectWithRepo:Update&orev=8dcbf337ee5aa0aa89a7deaab7d763d6&requestid=2&user=maintenance_coord&withacceptinfo=1
     body:
       encoding: UTF-8
       string: ''
@@ -7241,16 +7326,16 @@ http_interactions:
       encoding: UTF-8
       string: |
         <revision rev="4" vrev="4">
-          <srcmd5>3bc4d536be0f4724dd0defa094f247cf</srcmd5>
+          <srcmd5>cf22b6ca4707e8afe3633d31126e5c64</srcmd5>
           <version>unknown</version>
-          <time>1503405088</time>
+          <time>1516090961</time>
           <user>maintenance_coord</user>
           <comment>Maintenance incident copy from project home:tom:branches:ProjectWithRepo:Update</comment>
           <requestid>2</requestid>
-          <acceptinfo rev="4" srcmd5="3bc4d536be0f4724dd0defa094f247cf" osrcmd5="8f207ebc6846b26ebb947a0d4399345e" xsrcmd5="96b1040600ed3f57e960243b55548162" oxsrcmd5="ef9928a63930d4797ced0ef2ad58ed0c" />
+          <acceptinfo rev="4" srcmd5="cf22b6ca4707e8afe3633d31126e5c64" osrcmd5="012405659355f1fe41511515d788a6aa" xsrcmd5="d6a5bbec579b568ed1fb0cf3f9931435" oxsrcmd5="39895c37617de8a93814934ec17f5508" />
         </revision>
     http_version: 
-  recorded_at: Tue, 22 Aug 2017 12:31:28 GMT
+  recorded_at: Tue, 16 Jan 2018 08:22:41 GMT
 - request:
     method: put
     uri: http://backend:5352/source/MaintenanceProject:0/ProjectWithRepo_package.ProjectWithRepo_Update/_meta?user=maintenance_coord
@@ -7258,8 +7343,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="ProjectWithRepo_package.ProjectWithRepo_Update" project="MaintenanceProject:0">
-          <title>Have His Carcase</title>
-          <description>Molestiae eligendi asperiores quod voluptatibus totam non recusandae voluptas.</description>
+          <title>To a God Unknown</title>
+          <description>Sed voluptatum dolorem et omnis.</description>
           <releasename>ProjectWithRepo_package</releasename>
           <build>
             <enable repository="ProjectWithRepo_Update"/>
@@ -7285,13 +7370,13 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '424'
+      - '378'
     body:
       encoding: UTF-8
       string: |
         <package name="ProjectWithRepo_package.ProjectWithRepo_Update" project="MaintenanceProject:0">
-          <title>Have His Carcase</title>
-          <description>Molestiae eligendi asperiores quod voluptatibus totam non recusandae voluptas.</description>
+          <title>To a God Unknown</title>
+          <description>Sed voluptatum dolorem et omnis.</description>
           <releasename>ProjectWithRepo_package</releasename>
           <build>
             <enable repository="ProjectWithRepo_Update" />
@@ -7299,7 +7384,7 @@ http_interactions:
           </build>
         </package>
     http_version: 
-  recorded_at: Tue, 22 Aug 2017 12:31:28 GMT
+  recorded_at: Tue, 16 Jan 2018 08:22:42 GMT
 - request:
     method: get
     uri: http://backend:5352/source/MaintenanceProject:0/ProjectWithRepo_package.ProjectWithRepo_Update
@@ -7329,15 +7414,15 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="ProjectWithRepo_package.ProjectWithRepo_Update" rev="4" vrev="4" srcmd5="3bc4d536be0f4724dd0defa094f247cf">
-          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" srcmd5="e9d965f2d319f4124109f14a13f4e431" baserev="e9d965f2d319f4124109f14a13f4e431" xsrcmd5="96b1040600ed3f57e960243b55548162" lsrcmd5="3bc4d536be0f4724dd0defa094f247cf" />
-          <entry name="DUMMY_FILE" md5="275876e34cf609db118f3d84b799a790" size="5" mtime="1503405075" />
-          <entry name="_config" md5="7159169868967997b7eabbd94d805185" size="238" mtime="1503405073" />
-          <entry name="_link" md5="ad672afb37ca2f6a039ad35297d226d1" size="164" mtime="1503405079" />
-          <entry name="somefile.txt" md5="b4b03ef7ef00ded93403c2c595500c4f" size="116" mtime="1503405073" />
+        <directory name="ProjectWithRepo_package.ProjectWithRepo_Update" rev="4" vrev="4" srcmd5="cf22b6ca4707e8afe3633d31126e5c64">
+          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" srcmd5="6e6fbc10551cfc8eb7c6ccfc373d323f" baserev="6e6fbc10551cfc8eb7c6ccfc373d323f" xsrcmd5="d6a5bbec579b568ed1fb0cf3f9931435" lsrcmd5="cf22b6ca4707e8afe3633d31126e5c64" />
+          <entry name="DUMMY_FILE" md5="275876e34cf609db118f3d84b799a790" size="5" mtime="1516090947" />
+          <entry name="_config" md5="e8ec9a29a8e74d4c7dfc73686c1576b5" size="143" mtime="1516090945" />
+          <entry name="_link" md5="56994b1cc0c8cb5e1662d148e8d3ba70" size="175" mtime="1516090951" />
+          <entry name="somefile.txt" md5="95c4ebbcd6a901fc5e9a47439d5e6f92" size="207" mtime="1516090945" />
         </directory>
     http_version: 
-  recorded_at: Tue, 22 Aug 2017 12:31:28 GMT
+  recorded_at: Tue, 16 Jan 2018 08:22:42 GMT
 - request:
     method: get
     uri: http://backend:5352/source/MaintenanceProject:0/ProjectWithRepo_package.ProjectWithRepo_Update?nofilename=1&view=info&withchangesmd5=1
@@ -7363,17 +7448,17 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '416'
+      - '418'
     body:
       encoding: UTF-8
       string: |
-        <sourceinfo package="ProjectWithRepo_package.ProjectWithRepo_Update" rev="4" vrev="6" srcmd5="96b1040600ed3f57e960243b55548162" lsrcmd5="3bc4d536be0f4724dd0defa094f247cf" verifymd5="227e65861e6374ec8a0776883967906a">
+        <sourceinfo package="ProjectWithRepo_package.ProjectWithRepo_Update" rev="4" vrev="4.5" srcmd5="d6a5bbec579b568ed1fb0cf3f9931435" lsrcmd5="cf22b6ca4707e8afe3633d31126e5c64" verifymd5="c0a994f7069268062bdb56e9face0d28">
           <linked project="ProjectWithRepo:Update" package="ProjectWithRepo_package" />
           <linked project="ProjectWithRepo" package="ProjectWithRepo_package" />
-          <revtime>1503405088</revtime>
+          <revtime>1516090961</revtime>
         </sourceinfo>
     http_version: 
-  recorded_at: Tue, 22 Aug 2017 12:31:28 GMT
+  recorded_at: Tue, 16 Jan 2018 08:22:42 GMT
 - request:
     method: get
     uri: http://backend:5352/source/MaintenanceProject:0/ProjectWithRepo_package.ProjectWithRepo_Update
@@ -7403,15 +7488,15 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="ProjectWithRepo_package.ProjectWithRepo_Update" rev="4" vrev="4" srcmd5="3bc4d536be0f4724dd0defa094f247cf">
-          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" srcmd5="e9d965f2d319f4124109f14a13f4e431" baserev="e9d965f2d319f4124109f14a13f4e431" xsrcmd5="96b1040600ed3f57e960243b55548162" lsrcmd5="3bc4d536be0f4724dd0defa094f247cf" />
-          <entry name="DUMMY_FILE" md5="275876e34cf609db118f3d84b799a790" size="5" mtime="1503405075" />
-          <entry name="_config" md5="7159169868967997b7eabbd94d805185" size="238" mtime="1503405073" />
-          <entry name="_link" md5="ad672afb37ca2f6a039ad35297d226d1" size="164" mtime="1503405079" />
-          <entry name="somefile.txt" md5="b4b03ef7ef00ded93403c2c595500c4f" size="116" mtime="1503405073" />
+        <directory name="ProjectWithRepo_package.ProjectWithRepo_Update" rev="4" vrev="4" srcmd5="cf22b6ca4707e8afe3633d31126e5c64">
+          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" srcmd5="6e6fbc10551cfc8eb7c6ccfc373d323f" baserev="6e6fbc10551cfc8eb7c6ccfc373d323f" xsrcmd5="d6a5bbec579b568ed1fb0cf3f9931435" lsrcmd5="cf22b6ca4707e8afe3633d31126e5c64" />
+          <entry name="DUMMY_FILE" md5="275876e34cf609db118f3d84b799a790" size="5" mtime="1516090947" />
+          <entry name="_config" md5="e8ec9a29a8e74d4c7dfc73686c1576b5" size="143" mtime="1516090945" />
+          <entry name="_link" md5="56994b1cc0c8cb5e1662d148e8d3ba70" size="175" mtime="1516090951" />
+          <entry name="somefile.txt" md5="95c4ebbcd6a901fc5e9a47439d5e6f92" size="207" mtime="1516090945" />
         </directory>
     http_version: 
-  recorded_at: Tue, 22 Aug 2017 12:31:28 GMT
+  recorded_at: Tue, 16 Jan 2018 08:22:42 GMT
 - request:
     method: post
     uri: http://backend:5352/source/MaintenanceProject:0/ProjectWithRepo_package.ProjectWithRepo_Update?cmd=diff&linkrev=base&onlyissues=1&orev=0&view=xml
@@ -7443,15 +7528,15 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="bbccdf3aeea2076b584883bbd16cc8c8">
+        <sourcediff key="14ef11a36bd06142513a383d4e9dbea3">
           <old project="MaintenanceProject:0" package="ProjectWithRepo_package.ProjectWithRepo_Update" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e" />
-          <new project="MaintenanceProject:0" package="ProjectWithRepo_package.ProjectWithRepo_Update" rev="2" srcmd5="3bc4d536be0f4724dd0defa094f247cf" />
+          <new project="MaintenanceProject:0" package="ProjectWithRepo_package.ProjectWithRepo_Update" rev="2" srcmd5="cf22b6ca4707e8afe3633d31126e5c64" />
           <files />
           <issues>
           </issues>
         </sourcediff>
     http_version: 
-  recorded_at: Tue, 22 Aug 2017 12:31:28 GMT
+  recorded_at: Tue, 16 Jan 2018 08:22:42 GMT
 - request:
     method: post
     uri: http://backend:5352/source/MaintenanceProject:0/ProjectWithRepo_package.ProjectWithRepo_Update?cmd=linkdiff&linkrev=base&onlyissues=1&view=xml
@@ -7483,15 +7568,15 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="aa393379f0698c4b78a41bf61e79e894">
-          <old project="ProjectWithRepo:Update" package="ProjectWithRepo_package" rev="e9d965f2d319f4124109f14a13f4e431" srcmd5="e9d965f2d319f4124109f14a13f4e431" />
-          <new project="MaintenanceProject:0" package="ProjectWithRepo_package.ProjectWithRepo_Update" rev="96b1040600ed3f57e960243b55548162" srcmd5="96b1040600ed3f57e960243b55548162" />
+        <sourcediff key="46b27e5a3b383b4f31c7ddffb38c44bc">
+          <old project="ProjectWithRepo:Update" package="ProjectWithRepo_package" rev="6e6fbc10551cfc8eb7c6ccfc373d323f" srcmd5="6e6fbc10551cfc8eb7c6ccfc373d323f" />
+          <new project="MaintenanceProject:0" package="ProjectWithRepo_package.ProjectWithRepo_Update" rev="d6a5bbec579b568ed1fb0cf3f9931435" srcmd5="d6a5bbec579b568ed1fb0cf3f9931435" />
           <files />
           <issues>
           </issues>
         </sourcediff>
     http_version: 
-  recorded_at: Tue, 22 Aug 2017 12:31:28 GMT
+  recorded_at: Tue, 16 Jan 2018 08:22:42 GMT
 - request:
     method: put
     uri: http://backend:5352/source/MaintenanceProject:0/_meta?comment=maintenance_incident%20request%202&requestid=2&user=maintenance_coord
@@ -7556,10 +7641,10 @@ http_interactions:
           </repository>
         </project>
     http_version: 
-  recorded_at: Tue, 22 Aug 2017 12:31:29 GMT
+  recorded_at: Tue, 16 Jan 2018 08:22:42 GMT
 - request:
     method: post
-    uri: http://backend:5352/source/MaintenanceProject:0/ProjectWithRepo_package.ProjectWithRepo_Update?cmd=diff&orev=ef9928a63930d4797ced0ef2ad58ed0c&rev=96b1040600ed3f57e960243b55548162&view=xml&withissues=1
+    uri: http://backend:5352/source/MaintenanceProject:0/ProjectWithRepo_package.ProjectWithRepo_Update?cmd=diff&orev=39895c37617de8a93814934ec17f5508&rev=d6a5bbec579b568ed1fb0cf3f9931435&view=xml&withissues=1
     body:
       encoding: UTF-8
       string: ''
@@ -7588,9 +7673,9 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="63bb8ae8e41021e19f94a688fab094a2">
-          <old project="MaintenanceProject:0" package="ProjectWithRepo_package.ProjectWithRepo_Update" rev="ef9928a63930d4797ced0ef2ad58ed0c" srcmd5="ef9928a63930d4797ced0ef2ad58ed0c" />
-          <new project="MaintenanceProject:0" package="ProjectWithRepo_package.ProjectWithRepo_Update" rev="96b1040600ed3f57e960243b55548162" srcmd5="96b1040600ed3f57e960243b55548162" />
+        <sourcediff key="93afe66f9636c42b56f56e7af1d2fc33">
+          <old project="MaintenanceProject:0" package="ProjectWithRepo_package.ProjectWithRepo_Update" rev="39895c37617de8a93814934ec17f5508" srcmd5="39895c37617de8a93814934ec17f5508" />
+          <new project="MaintenanceProject:0" package="ProjectWithRepo_package.ProjectWithRepo_Update" rev="d6a5bbec579b568ed1fb0cf3f9931435" srcmd5="d6a5bbec579b568ed1fb0cf3f9931435" />
           <files>
             <file state="added">
               <new name="DUMMY_FILE" md5="275876e34cf609db118f3d84b799a790" size="5" />
@@ -7604,7 +7689,7 @@ http_interactions:
           </issues>
         </sourcediff>
     http_version: 
-  recorded_at: Tue, 22 Aug 2017 12:31:29 GMT
+  recorded_at: Tue, 16 Jan 2018 08:22:42 GMT
 - request:
     method: get
     uri: http://backend:5352/build/home:tom:branches:ProjectWithRepo:Update/_result?package=ProjectWithRepo_package&view=status
@@ -7640,7 +7725,7 @@ http_interactions:
           <result project="home:tom:branches:ProjectWithRepo:Update" repository="repository_2" arch="i586" code="unknown" state="unknown" />
         </resultlist>
     http_version: 
-  recorded_at: Tue, 22 Aug 2017 12:31:29 GMT
+  recorded_at: Tue, 16 Jan 2018 08:22:42 GMT
 - request:
     method: get
     uri: http://backend:5352/build/home:tom:branches:ProjectWithRepo:Update/_result?locallink=1&multibuild=1&package=ProjectWithRepo_package&view=status
@@ -7676,7 +7761,7 @@ http_interactions:
           <result project="home:tom:branches:ProjectWithRepo:Update" repository="repository_2" arch="i586" code="unknown" state="unknown" />
         </resultlist>
     http_version: 
-  recorded_at: Tue, 22 Aug 2017 12:31:29 GMT
+  recorded_at: Tue, 16 Jan 2018 08:22:42 GMT
 - request:
     method: get
     uri: http://backend:5352/build/MaintenanceProject:0/_result?code=unresolvable&view=status
@@ -7684,10 +7769,8 @@ http_interactions:
       encoding: US-ASCII
       string: ''
     headers:
-      Content-Type:
-      - text/plain
       Accept-Encoding:
-      - identity
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
       - "*/*"
       User-Agent:
@@ -7712,7 +7795,7 @@ http_interactions:
           <result project="MaintenanceProject:0" repository="ProjectWithRepo_Update" arch="i586" code="unknown" state="unknown" />
         </resultlist>
     http_version: 
-  recorded_at: Tue, 22 Aug 2017 12:31:29 GMT
+  recorded_at: Tue, 16 Jan 2018 08:22:42 GMT
 - request:
     method: get
     uri: http://backend:5352/source/MaintenanceProject:0/patchinfo
@@ -7743,10 +7826,10 @@ http_interactions:
       encoding: UTF-8
       string: |
         <directory name="patchinfo" rev="3" vrev="3" srcmd5="177d57906eba63ae56a64a367592144a">
-          <entry name="_patchinfo" md5="ac29f7f1abd9ef43afeb43fc7737c007" size="318" mtime="1503405082" />
+          <entry name="_patchinfo" md5="ac29f7f1abd9ef43afeb43fc7737c007" size="318" mtime="1516090955" />
         </directory>
     http_version: 
-  recorded_at: Tue, 22 Aug 2017 12:31:29 GMT
+  recorded_at: Tue, 16 Jan 2018 08:22:42 GMT
 - request:
     method: get
     uri: http://backend:5352/build/MaintenanceProject:0/_result?view=summary
@@ -7784,7 +7867,7 @@ http_interactions:
           </result>
         </resultlist>
     http_version: 
-  recorded_at: Tue, 22 Aug 2017 12:31:29 GMT
+  recorded_at: Tue, 16 Jan 2018 08:22:42 GMT
 - request:
     method: get
     uri: http://backend:5352/source/MaintenanceProject:0/ProjectWithRepo_package.ProjectWithRepo_Update
@@ -7814,15 +7897,15 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="ProjectWithRepo_package.ProjectWithRepo_Update" rev="4" vrev="4" srcmd5="3bc4d536be0f4724dd0defa094f247cf">
-          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" srcmd5="e9d965f2d319f4124109f14a13f4e431" baserev="e9d965f2d319f4124109f14a13f4e431" xsrcmd5="96b1040600ed3f57e960243b55548162" lsrcmd5="3bc4d536be0f4724dd0defa094f247cf" />
-          <entry name="DUMMY_FILE" md5="275876e34cf609db118f3d84b799a790" size="5" mtime="1503405075" />
-          <entry name="_config" md5="7159169868967997b7eabbd94d805185" size="238" mtime="1503405073" />
-          <entry name="_link" md5="ad672afb37ca2f6a039ad35297d226d1" size="164" mtime="1503405079" />
-          <entry name="somefile.txt" md5="b4b03ef7ef00ded93403c2c595500c4f" size="116" mtime="1503405073" />
+        <directory name="ProjectWithRepo_package.ProjectWithRepo_Update" rev="4" vrev="4" srcmd5="cf22b6ca4707e8afe3633d31126e5c64">
+          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" srcmd5="6e6fbc10551cfc8eb7c6ccfc373d323f" baserev="6e6fbc10551cfc8eb7c6ccfc373d323f" xsrcmd5="d6a5bbec579b568ed1fb0cf3f9931435" lsrcmd5="cf22b6ca4707e8afe3633d31126e5c64" />
+          <entry name="DUMMY_FILE" md5="275876e34cf609db118f3d84b799a790" size="5" mtime="1516090947" />
+          <entry name="_config" md5="e8ec9a29a8e74d4c7dfc73686c1576b5" size="143" mtime="1516090945" />
+          <entry name="_link" md5="56994b1cc0c8cb5e1662d148e8d3ba70" size="175" mtime="1516090951" />
+          <entry name="somefile.txt" md5="95c4ebbcd6a901fc5e9a47439d5e6f92" size="207" mtime="1516090945" />
         </directory>
     http_version: 
-  recorded_at: Tue, 22 Aug 2017 12:31:29 GMT
+  recorded_at: Tue, 16 Jan 2018 08:22:43 GMT
 - request:
     method: get
     uri: http://backend:5352/source/MaintenanceProject:0/patchinfo
@@ -7853,10 +7936,10 @@ http_interactions:
       encoding: UTF-8
       string: |
         <directory name="patchinfo" rev="3" vrev="3" srcmd5="177d57906eba63ae56a64a367592144a">
-          <entry name="_patchinfo" md5="ac29f7f1abd9ef43afeb43fc7737c007" size="318" mtime="1503405082" />
+          <entry name="_patchinfo" md5="ac29f7f1abd9ef43afeb43fc7737c007" size="318" mtime="1516090955" />
         </directory>
     http_version: 
-  recorded_at: Tue, 22 Aug 2017 12:31:29 GMT
+  recorded_at: Tue, 16 Jan 2018 08:22:43 GMT
 - request:
     method: get
     uri: http://backend:5352/build/MaintenanceProject:0/_result?view=versrel
@@ -7890,7 +7973,7 @@ http_interactions:
           <result project="MaintenanceProject:0" repository="ProjectWithRepo_Update" arch="i586" code="unknown" state="unknown" />
         </resultlist>
     http_version: 
-  recorded_at: Tue, 22 Aug 2017 12:31:29 GMT
+  recorded_at: Tue, 16 Jan 2018 08:22:43 GMT
 - request:
     method: get
     uri: http://backend:5352/build/MaintenanceProject:0/_result?code=unresolvable&view=status
@@ -7898,10 +7981,8 @@ http_interactions:
       encoding: US-ASCII
       string: ''
     headers:
-      Content-Type:
-      - text/plain
       Accept-Encoding:
-      - identity
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
       - "*/*"
       User-Agent:
@@ -7926,7 +8007,7 @@ http_interactions:
           <result project="MaintenanceProject:0" repository="ProjectWithRepo_Update" arch="i586" code="unknown" state="unknown" />
         </resultlist>
     http_version: 
-  recorded_at: Tue, 22 Aug 2017 12:31:29 GMT
+  recorded_at: Tue, 16 Jan 2018 08:22:43 GMT
 - request:
     method: get
     uri: http://backend:5352/source/MaintenanceProject:0/patchinfo
@@ -7957,10 +8038,10 @@ http_interactions:
       encoding: UTF-8
       string: |
         <directory name="patchinfo" rev="3" vrev="3" srcmd5="177d57906eba63ae56a64a367592144a">
-          <entry name="_patchinfo" md5="ac29f7f1abd9ef43afeb43fc7737c007" size="318" mtime="1503405082" />
+          <entry name="_patchinfo" md5="ac29f7f1abd9ef43afeb43fc7737c007" size="318" mtime="1516090955" />
         </directory>
     http_version: 
-  recorded_at: Tue, 22 Aug 2017 12:31:29 GMT
+  recorded_at: Tue, 16 Jan 2018 08:22:43 GMT
 - request:
     method: get
     uri: http://backend:5352/build/MaintenanceProject:0/_result?view=summary

--- a/src/api/spec/cassettes/Packages/Viewing_a_package_that/has_a_mime_like_suffix_in_it_s_name.yml
+++ b/src/api/spec/cassettes/Packages/Viewing_a_package_that/has_a_mime_like_suffix_in_it_s_name.yml
@@ -1,331 +1,6 @@
 ---
 http_interactions:
 - request:
-    method: get
-    uri: http://backend:5352/source/home:package_test_user/test.json?nofilename=1&view=info&withchangesmd5=1
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 404
-      message: project 'home package_test_user' does not exist
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '172'
-    body:
-      encoding: UTF-8
-      string: |
-        <status code="404">
-          <summary>project 'home:package_test_user' does not exist</summary>
-          <details>404 project 'home:package_test_user' does not exist</details>
-        </status>
-    http_version: 
-  recorded_at: Thu, 04 May 2017 10:24:20 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/home:package_test_user/test.json
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 404
-      message: project 'home package_test_user' does not exist
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '172'
-    body:
-      encoding: UTF-8
-      string: |
-        <status code="404">
-          <summary>project 'home:package_test_user' does not exist</summary>
-          <details>404 project 'home:package_test_user' does not exist</details>
-        </status>
-    http_version: 
-  recorded_at: Thu, 04 May 2017 10:24:20 GMT
-- request:
-    method: post
-    uri: http://backend:5352/source/home:package_test_user/test.json?cmd=diff&linkrev=base&onlyissues=1&orev=0&view=xml
-    body:
-      encoding: UTF-8
-      string: ''
-    headers:
-      Content-Type:
-      - application/octet-stream
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 404
-      message: project 'home package_test_user' does not exist
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '172'
-    body:
-      encoding: UTF-8
-      string: |
-        <status code="404">
-          <summary>project 'home:package_test_user' does not exist</summary>
-          <details>404 project 'home:package_test_user' does not exist</details>
-        </status>
-    http_version: 
-  recorded_at: Thu, 04 May 2017 10:24:20 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/home:package_test_user/test.json
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 404
-      message: project 'home package_test_user' does not exist
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '172'
-    body:
-      encoding: UTF-8
-      string: |
-        <status code="404">
-          <summary>project 'home:package_test_user' does not exist</summary>
-          <details>404 project 'home:package_test_user' does not exist</details>
-        </status>
-    http_version: 
-  recorded_at: Thu, 04 May 2017 10:24:20 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/home:package_test_user/test.json?expand=1
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Content-Type:
-      - text/plain
-      Accept-Encoding:
-      - identity
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 404
-      message: project 'home package_test_user' does not exist
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '172'
-    body:
-      encoding: UTF-8
-      string: |
-        <status code="404">
-          <summary>project 'home:package_test_user' does not exist</summary>
-          <details>404 project 'home:package_test_user' does not exist</details>
-        </status>
-    http_version: 
-  recorded_at: Thu, 04 May 2017 10:24:20 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/home:package_test_user/test.json
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Content-Type:
-      - text/plain
-      Accept-Encoding:
-      - identity
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 404
-      message: project 'home package_test_user' does not exist
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '172'
-    body:
-      encoding: UTF-8
-      string: |
-        <status code="404">
-          <summary>project 'home:package_test_user' does not exist</summary>
-          <details>404 project 'home:package_test_user' does not exist</details>
-        </status>
-    http_version: 
-  recorded_at: Thu, 04 May 2017 10:24:20 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/home:package_test_user/test.json/_service
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Content-Type:
-      - text/plain
-      Accept-Encoding:
-      - identity
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 404
-      message: project 'home package_test_user' does not exist
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '172'
-    body:
-      encoding: UTF-8
-      string: |
-        <status code="404">
-          <summary>project 'home:package_test_user' does not exist</summary>
-          <details>404 project 'home:package_test_user' does not exist</details>
-        </status>
-    http_version: 
-  recorded_at: Thu, 04 May 2017 10:24:20 GMT
-- request:
-    method: get
-    uri: http://backend:5352/build/home:package_test_user/_result?package=test.json&view=status
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Content-Type:
-      - text/plain
-      Accept-Encoding:
-      - identity
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 404
-      message: project 'home package_test_user' does not exist
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '172'
-    body:
-      encoding: UTF-8
-      string: |
-        <status code="404">
-          <summary>project 'home:package_test_user' does not exist</summary>
-          <details>404 project 'home:package_test_user' does not exist</details>
-        </status>
-    http_version: 
-  recorded_at: Thu, 04 May 2017 10:24:23 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/home:package_test_user/test.json?expand=0
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 404
-      message: project 'home package_test_user' does not exist
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '172'
-    body:
-      encoding: UTF-8
-      string: |
-        <status code="404">
-          <summary>project 'home:package_test_user' does not exist</summary>
-          <details>404 project 'home:package_test_user' does not exist</details>
-        </status>
-    http_version: 
-  recorded_at: Tue, 16 May 2017 15:09:26 GMT
-- request:
     method: put
     uri: http://backend:5352/source/home:package_test_user/_meta?user=package_test_user
     body:
@@ -365,7 +40,7 @@ http_interactions:
           <person userid="package_test_user" role="maintainer" />
         </project>
     http_version: 
-  recorded_at: Wed, 03 Jan 2018 13:13:53 GMT
+  recorded_at: Tue, 16 Jan 2018 14:01:07 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:package_test_user/test_package/_meta?user=package_test_user
@@ -373,8 +48,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="test_package" project="home:package_test_user">
-          <title>Ego Dominus Tuus</title>
-          <description>Odio odit ratione commodi debitis non cumque molestias vero.</description>
+          <title>All the King's Men</title>
+          <description>Repudiandae et qui perferendis qui similique.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -395,16 +70,16 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '198'
+      - '185'
     body:
       encoding: UTF-8
       string: |
         <package name="test_package" project="home:package_test_user">
-          <title>Ego Dominus Tuus</title>
-          <description>Odio odit ratione commodi debitis non cumque molestias vero.</description>
+          <title>All the King's Men</title>
+          <description>Repudiandae et qui perferendis qui similique.</description>
         </package>
     http_version: 
-  recorded_at: Wed, 03 Jan 2018 13:13:53 GMT
+  recorded_at: Tue, 16 Jan 2018 14:01:07 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:package_test_user/test_package/_meta
@@ -412,8 +87,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="test_package" project="home:package_test_user">
-          <title>Ego Dominus Tuus</title>
-          <description>Odio odit ratione commodi debitis non cumque molestias vero.</description>
+          <title>All the King's Men</title>
+          <description>Repudiandae et qui perferendis qui similique.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -434,23 +109,23 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '198'
+      - '185'
     body:
       encoding: UTF-8
       string: |
         <package name="test_package" project="home:package_test_user">
-          <title>Ego Dominus Tuus</title>
-          <description>Odio odit ratione commodi debitis non cumque molestias vero.</description>
+          <title>All the King's Men</title>
+          <description>Repudiandae et qui perferendis qui similique.</description>
         </package>
     http_version: 
-  recorded_at: Wed, 03 Jan 2018 13:13:53 GMT
+  recorded_at: Tue, 16 Jan 2018 14:01:07 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:package_test_user/test_package/_config
     body:
       encoding: UTF-8
-      string: Dicta odio et nihil nostrum totam nihil. Quia minima ab molestiae. In
-        suscipit distinctio error ad labore est.
+      string: Placeat sit aut aliquid eum est est dolore. Voluptatem autem aspernatur
+        dolorum excepturi quo. Maiores omnis nobis occaecati.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -470,27 +145,28 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '207'
+      - '209'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="2" vrev="2">
-          <srcmd5>c849a1d9be425bd3c83769b5f2ca7c9f</srcmd5>
+        <revision rev="14" vrev="14">
+          <srcmd5>a4f8f316e23070dcf46b14d8c0922332</srcmd5>
           <version>unknown</version>
-          <time>1514985233</time>
+          <time>1516111267</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
     http_version: 
-  recorded_at: Wed, 03 Jan 2018 13:13:53 GMT
+  recorded_at: Tue, 16 Jan 2018 14:01:07 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:package_test_user/test_package/somefile.txt
     body:
       encoding: UTF-8
-      string: Consequatur ab nostrum. Blanditiis rerum eaque voluptates officiis sint
-        architecto. Quam consequuntur autem. Ut delectus omnis.
+      string: Officia quia repellendus quis. Velit ullam et. Praesentium dolorem quos
+        quae dolorum illum libero sit. Culpa officia autem voluptatem assumenda. Officiis
+        repudiandae et in.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -510,20 +186,20 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '207'
+      - '209'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="3" vrev="3">
-          <srcmd5>f69d66eae19594b626fe6cc073afcde5</srcmd5>
+        <revision rev="15" vrev="15">
+          <srcmd5>a4f8f316e23070dcf46b14d8c0922332</srcmd5>
           <version>unknown</version>
-          <time>1514985233</time>
+          <time>1516111267</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
     http_version: 
-  recorded_at: Wed, 03 Jan 2018 13:13:53 GMT
+  recorded_at: Tue, 16 Jan 2018 14:01:07 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:other_package_test_user/_meta?user=other_package_test_user
@@ -564,7 +240,7 @@ http_interactions:
           <person userid="other_package_test_user" role="maintainer" />
         </project>
     http_version: 
-  recorded_at: Wed, 03 Jan 2018 13:13:53 GMT
+  recorded_at: Tue, 16 Jan 2018 14:01:07 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:other_package_test_user/branch_test_package/_meta?user=package_test_user
@@ -572,8 +248,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="branch_test_package" project="home:other_package_test_user">
-          <title>To Your Scattered Bodies Go</title>
-          <description>Unde qui id aut sint ex.</description>
+          <title>Time To Murder And Create</title>
+          <description>Facilis occaecati et consequatur a voluptate enim autem.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -594,16 +270,16 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '186'
+      - '216'
     body:
       encoding: UTF-8
       string: |
         <package name="branch_test_package" project="home:other_package_test_user">
-          <title>To Your Scattered Bodies Go</title>
-          <description>Unde qui id aut sint ex.</description>
+          <title>Time To Murder And Create</title>
+          <description>Facilis occaecati et consequatur a voluptate enim autem.</description>
         </package>
     http_version: 
-  recorded_at: Wed, 03 Jan 2018 13:13:53 GMT
+  recorded_at: Tue, 16 Jan 2018 14:01:08 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:other_package_test_user/branch_test_package/_meta
@@ -611,8 +287,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="branch_test_package" project="home:other_package_test_user">
-          <title>To Your Scattered Bodies Go</title>
-          <description>Unde qui id aut sint ex.</description>
+          <title>Time To Murder And Create</title>
+          <description>Facilis occaecati et consequatur a voluptate enim autem.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -633,23 +309,24 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '186'
+      - '216'
     body:
       encoding: UTF-8
       string: |
         <package name="branch_test_package" project="home:other_package_test_user">
-          <title>To Your Scattered Bodies Go</title>
-          <description>Unde qui id aut sint ex.</description>
+          <title>Time To Murder And Create</title>
+          <description>Facilis occaecati et consequatur a voluptate enim autem.</description>
         </package>
     http_version: 
-  recorded_at: Wed, 03 Jan 2018 13:13:53 GMT
+  recorded_at: Tue, 16 Jan 2018 14:01:08 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:other_package_test_user/branch_test_package/_config
     body:
       encoding: UTF-8
-      string: Magnam qui commodi est nam fuga. Omnis voluptas praesentium excepturi
-        alias magnam omnis. Tenetur accusamus placeat autem sint autem.
+      string: Quo nostrum dolor itaque eum. Quasi esse ipsum sunt laborum necessitatibus
+        voluptates. Nam numquam eos et. Deleniti consequatur neque eveniet unde. Corporis
+        quia officiis repellat sit assumenda.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -673,23 +350,24 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <revision rev="4" vrev="4">
-          <srcmd5>61e2ab4eb2fa044c631926c905a877f3</srcmd5>
+        <revision rev="1" vrev="1">
+          <srcmd5>619ac57717db09d80315922eb57bb66a</srcmd5>
           <version>unknown</version>
-          <time>1514985233</time>
+          <time>1516111268</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
     http_version: 
-  recorded_at: Wed, 03 Jan 2018 13:13:53 GMT
+  recorded_at: Tue, 16 Jan 2018 14:01:08 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:other_package_test_user/branch_test_package/somefile.txt
     body:
       encoding: UTF-8
-      string: Consequatur ab nostrum. Blanditiis rerum eaque voluptates officiis sint
-        architecto. Quam consequuntur autem. Ut delectus omnis.
+      string: Officia quia repellendus quis. Velit ullam et. Praesentium dolorem quos
+        quae dolorum illum libero sit. Culpa officia autem voluptatem assumenda. Officiis
+        repudiandae et in.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -713,16 +391,16 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <revision rev="5" vrev="5">
-          <srcmd5>6e2fdcf66f8c0db09adf9aa631781ab7</srcmd5>
+        <revision rev="2" vrev="2">
+          <srcmd5>ea03fd8941ae34f72f68033de00a0b2e</srcmd5>
           <version>unknown</version>
-          <time>1514985233</time>
+          <time>1516111268</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
     http_version: 
-  recorded_at: Wed, 03 Jan 2018 13:13:53 GMT
+  recorded_at: Tue, 16 Jan 2018 14:01:08 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:package_test_user/test.json/_meta?user=package_test_user
@@ -730,7 +408,7 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="test.json" project="home:package_test_user">
-          <title>Françoise Sagan</title>
+          <title>If I Forget Thee Jerusalem</title>
           <description>A package with a mime type suffix</description>
         </package>
     headers:
@@ -752,13 +430,16 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '168'
+      - '178'
     body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        PHBhY2thZ2UgbmFtZT0idGVzdC5qc29uIiBwcm9qZWN0PSJob21lOnBhY2thZ2VfdGVzdF91c2VyIj4KICA8dGl0bGU+RnJhbsOnb2lzZSBTYWdhbjwvdGl0bGU+CiAgPGRlc2NyaXB0aW9uPkEgcGFja2FnZSB3aXRoIGEgbWltZSB0eXBlIHN1ZmZpeDwvZGVzY3JpcHRpb24+CjwvcGFja2FnZT4K
+      encoding: UTF-8
+      string: |
+        <package name="test.json" project="home:package_test_user">
+          <title>If I Forget Thee Jerusalem</title>
+          <description>A package with a mime type suffix</description>
+        </package>
     http_version: 
-  recorded_at: Wed, 03 Jan 2018 13:13:54 GMT
+  recorded_at: Tue, 16 Jan 2018 14:01:08 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:package_test_user/test.json/_meta
@@ -766,7 +447,7 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="test.json" project="home:package_test_user">
-          <title>Françoise Sagan</title>
+          <title>If I Forget Thee Jerusalem</title>
           <description>A package with a mime type suffix</description>
         </package>
     headers:
@@ -788,11 +469,292 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '168'
+      - '178'
     body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        PHBhY2thZ2UgbmFtZT0idGVzdC5qc29uIiBwcm9qZWN0PSJob21lOnBhY2thZ2VfdGVzdF91c2VyIj4KICA8dGl0bGU+RnJhbsOnb2lzZSBTYWdhbjwvdGl0bGU+CiAgPGRlc2NyaXB0aW9uPkEgcGFja2FnZSB3aXRoIGEgbWltZSB0eXBlIHN1ZmZpeDwvZGVzY3JpcHRpb24+CjwvcGFja2FnZT4K
+      encoding: UTF-8
+      string: |
+        <package name="test.json" project="home:package_test_user">
+          <title>If I Forget Thee Jerusalem</title>
+          <description>A package with a mime type suffix</description>
+        </package>
+    http_version: 
+  recorded_at: Tue, 16 Jan 2018 14:01:08 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:package_test_user/test.json?nofilename=1&view=info&withchangesmd5=1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '147'
+    body:
+      encoding: UTF-8
+      string: |
+        <sourceinfo package="test.json" srcmd5="d41d8cd98f00b204e9800998ecf8427e" verifymd5="d41d8cd98f00b204e9800998ecf8427e">
+          <revtime/>
+        </sourceinfo>
+    http_version: 
+  recorded_at: Tue, 16 Jan 2018 14:01:08 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:package_test_user/test.json
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '84'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="test.json" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
+        </directory>
+    http_version: 
+  recorded_at: Tue, 16 Jan 2018 14:01:08 GMT
+- request:
+    method: post
+    uri: http://backend:5352/source/home:package_test_user/test.json?cmd=diff&linkrev=base&onlyissues=1&orev=0&view=xml
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Content-Type:
+      - application/octet-stream
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '304'
+    body:
+      encoding: UTF-8
+      string: |
+        <sourcediff key="04429e5eb3523e7cb3e15ee88d1605d6">
+          <old project="home:package_test_user" package="test.json" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e" />
+          <new project="home:package_test_user" package="test.json" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e" />
+          <files />
+        </sourcediff>
+    http_version: 
+  recorded_at: Tue, 16 Jan 2018 14:01:08 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:package_test_user/test.json
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '84'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="test.json" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
+        </directory>
+    http_version: 
+  recorded_at: Tue, 16 Jan 2018 14:01:08 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:package_test_user/test.json?expand=1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '84'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="test.json" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
+        </directory>
+    http_version: 
+  recorded_at: Tue, 16 Jan 2018 14:01:08 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:package_test_user/test.json
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - text/plain
+      Accept-Encoding:
+      - identity
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '84'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="test.json" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
+        </directory>
+    http_version: 
+  recorded_at: Tue, 16 Jan 2018 14:01:08 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:package_test_user/test.json/_service
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - text/plain
+      Accept-Encoding:
+      - identity
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 404
+      message: _service  no such file
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '122'
+    body:
+      encoding: UTF-8
+      string: |
+        <status code="404">
+          <summary>_service: no such file</summary>
+          <details>404 _service: no such file</details>
+        </status>
+    http_version: 
+  recorded_at: Tue, 16 Jan 2018 14:01:08 GMT
+- request:
+    method: get
+    uri: http://backend:5352/build/home:package_test_user/_result?package=test.json&view=status
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - text/plain
+      Accept-Encoding:
+      - identity
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '56'
+    body:
+      encoding: UTF-8
+      string: '<resultlist state="00000000000000000000000000000000" />
+
+'
     http_version: 
   recorded_at: Wed, 03 Jan 2018 13:13:54 GMT
 - request:

--- a/src/api/spec/cassettes/Packages/Viewing_a_package_that/has_derived_packages.yml
+++ b/src/api/spec/cassettes/Packages/Viewing_a_package_that/has_derived_packages.yml
@@ -40,7 +40,7 @@ http_interactions:
           <person userid="package_test_user" role="maintainer" />
         </project>
     http_version: 
-  recorded_at: Fri, 28 Apr 2017 11:53:33 GMT
+  recorded_at: Tue, 16 Jan 2018 14:01:09 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:package_test_user/test_package/_meta?user=package_test_user
@@ -48,8 +48,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="test_package" project="home:package_test_user">
-          <title>The Waste Land</title>
-          <description>Ut quia eum accusamus qui.</description>
+          <title>A Passage to India</title>
+          <description>Delectus dolorem explicabo ut veritatis quia error.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -70,16 +70,16 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '162'
+      - '191'
     body:
       encoding: UTF-8
       string: |
         <package name="test_package" project="home:package_test_user">
-          <title>The Waste Land</title>
-          <description>Ut quia eum accusamus qui.</description>
+          <title>A Passage to India</title>
+          <description>Delectus dolorem explicabo ut veritatis quia error.</description>
         </package>
     http_version: 
-  recorded_at: Fri, 28 Apr 2017 11:53:33 GMT
+  recorded_at: Tue, 16 Jan 2018 14:01:09 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:package_test_user/test_package/_meta
@@ -87,8 +87,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="test_package" project="home:package_test_user">
-          <title>The Waste Land</title>
-          <description>Ut quia eum accusamus qui.</description>
+          <title>A Passage to India</title>
+          <description>Delectus dolorem explicabo ut veritatis quia error.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -109,23 +109,23 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '162'
+      - '191'
     body:
       encoding: UTF-8
       string: |
         <package name="test_package" project="home:package_test_user">
-          <title>The Waste Land</title>
-          <description>Ut quia eum accusamus qui.</description>
+          <title>A Passage to India</title>
+          <description>Delectus dolorem explicabo ut veritatis quia error.</description>
         </package>
     http_version: 
-  recorded_at: Fri, 28 Apr 2017 11:53:33 GMT
+  recorded_at: Tue, 16 Jan 2018 14:01:09 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:package_test_user/test_package/_config
     body:
       encoding: UTF-8
-      string: Non sit assumenda dolorem corrupti dolore. Fugiat consectetur quaerat
-        iusto. Assumenda asperiores omnis tempore.
+      string: Dignissimos eligendi voluptas est earum. Rerum ipsam aut ullam. Magni
+        ex rerum occaecati aspernatur. Eum et maxime blanditiis.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -145,28 +145,28 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '207'
+      - '209'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="3" vrev="3">
-          <srcmd5>5d1f16aed708643e2feac41e3baba70c</srcmd5>
+        <revision rev="16" vrev="16">
+          <srcmd5>aba3d257b955ecee415e9a5c2f741e95</srcmd5>
           <version>unknown</version>
-          <time>1493380413</time>
+          <time>1516111269</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
     http_version: 
-  recorded_at: Fri, 28 Apr 2017 11:53:33 GMT
+  recorded_at: Tue, 16 Jan 2018 14:01:09 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:package_test_user/test_package/somefile.txt
     body:
       encoding: UTF-8
-      string: Et quia debitis et nisi ducimus aut. Aut vel commodi corporis qui quidem.
-        Dolores et maxime distinctio. Non quia aut laudantium et commodi nemo voluptatem.
-        At beatae consequuntur velit ratione quasi eos molestias.
+      string: Officia quia repellendus quis. Velit ullam et. Praesentium dolorem quos
+        quae dolorum illum libero sit. Culpa officia autem voluptatem assumenda. Officiis
+        repudiandae et in.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -186,20 +186,20 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '207'
+      - '209'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="4" vrev="4">
-          <srcmd5>311e4352c2ab7812f9e2257ffa21bc28</srcmd5>
+        <revision rev="17" vrev="17">
+          <srcmd5>aba3d257b955ecee415e9a5c2f741e95</srcmd5>
           <version>unknown</version>
-          <time>1493380413</time>
+          <time>1516111269</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
     http_version: 
-  recorded_at: Fri, 28 Apr 2017 11:53:33 GMT
+  recorded_at: Tue, 16 Jan 2018 14:01:09 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:other_package_test_user/_meta?user=other_package_test_user
@@ -240,7 +240,7 @@ http_interactions:
           <person userid="other_package_test_user" role="maintainer" />
         </project>
     http_version: 
-  recorded_at: Fri, 28 Apr 2017 11:53:33 GMT
+  recorded_at: Tue, 16 Jan 2018 14:01:09 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:other_package_test_user/branch_test_package/_meta?user=package_test_user
@@ -248,8 +248,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="branch_test_package" project="home:other_package_test_user">
-          <title>Wildfire at Midnight</title>
-          <description>Et impedit quia quia.</description>
+          <title>The Widening Gyre</title>
+          <description>Omnis odio architecto enim minus voluptas fuga aut quia.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -270,16 +270,16 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '176'
+      - '208'
     body:
       encoding: UTF-8
       string: |
         <package name="branch_test_package" project="home:other_package_test_user">
-          <title>Wildfire at Midnight</title>
-          <description>Et impedit quia quia.</description>
+          <title>The Widening Gyre</title>
+          <description>Omnis odio architecto enim minus voluptas fuga aut quia.</description>
         </package>
     http_version: 
-  recorded_at: Fri, 28 Apr 2017 11:53:33 GMT
+  recorded_at: Tue, 16 Jan 2018 14:01:09 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:other_package_test_user/branch_test_package/_meta
@@ -287,8 +287,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="branch_test_package" project="home:other_package_test_user">
-          <title>Wildfire at Midnight</title>
-          <description>Et impedit quia quia.</description>
+          <title>The Widening Gyre</title>
+          <description>Omnis odio architecto enim minus voluptas fuga aut quia.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -309,23 +309,24 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '176'
+      - '208'
     body:
       encoding: UTF-8
       string: |
         <package name="branch_test_package" project="home:other_package_test_user">
-          <title>Wildfire at Midnight</title>
-          <description>Et impedit quia quia.</description>
+          <title>The Widening Gyre</title>
+          <description>Omnis odio architecto enim minus voluptas fuga aut quia.</description>
         </package>
     http_version: 
-  recorded_at: Fri, 28 Apr 2017 11:53:33 GMT
+  recorded_at: Tue, 16 Jan 2018 14:01:09 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:other_package_test_user/branch_test_package/_config
     body:
       encoding: UTF-8
-      string: Id ab magni consequatur. Molestiae temporibus harum et quidem et. Rem
-        vitae repudiandae aperiam atque ipsum officia voluptate.
+      string: Vel ut exercitationem voluptatibus minus sunt sed maxime. Cupiditate
+        dicta cum rem tenetur. Autem nobis non eum eligendi. Corporis sit molestiae
+        cumque.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -350,22 +351,23 @@ http_interactions:
       encoding: UTF-8
       string: |
         <revision rev="3" vrev="3">
-          <srcmd5>02d7d7e11d9a0371f7fab3f3cfaf292f</srcmd5>
+          <srcmd5>fea2e0106f45ebb31da493ce6f961987</srcmd5>
           <version>unknown</version>
-          <time>1493380413</time>
+          <time>1516111269</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
     http_version: 
-  recorded_at: Fri, 28 Apr 2017 11:53:33 GMT
+  recorded_at: Tue, 16 Jan 2018 14:01:09 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:other_package_test_user/branch_test_package/somefile.txt
     body:
       encoding: UTF-8
-      string: Ipsa velit est molestiae vel repellat tenetur in. Distinctio vel molestiae
-        animi aut nemo et cum. Laboriosam perferendis accusantium et.
+      string: Officia quia repellendus quis. Velit ullam et. Praesentium dolorem quos
+        quae dolorum illum libero sit. Culpa officia autem voluptatem assumenda. Officiis
+        repudiandae et in.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -390,15 +392,15 @@ http_interactions:
       encoding: UTF-8
       string: |
         <revision rev="4" vrev="4">
-          <srcmd5>ad7df5419e8868f1fc8da63bbfe37dd2</srcmd5>
+          <srcmd5>fea2e0106f45ebb31da493ce6f961987</srcmd5>
           <version>unknown</version>
-          <time>1493380413</time>
+          <time>1516111269</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
     http_version: 
-  recorded_at: Fri, 28 Apr 2017 11:53:33 GMT
+  recorded_at: Tue, 16 Jan 2018 14:01:09 GMT
 - request:
     method: post
     uri: http://backend:5352/search/package/id?match=(linkinfo/@package=%22test_package%22%20and%20linkinfo/@project=%22home:package_test_user%22%20and%20@project=%22home:package_test_user%22)
@@ -433,7 +435,7 @@ http_interactions:
         <collection>
         </collection>
     http_version: 
-  recorded_at: Fri, 28 Apr 2017 11:53:33 GMT
+  recorded_at: Tue, 16 Jan 2018 14:01:09 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:package_test_user:branches:home:package_test_user/_meta?user=package_test_user
@@ -474,7 +476,7 @@ http_interactions:
           <person userid="package_test_user" role="maintainer" />
         </project>
     http_version: 
-  recorded_at: Fri, 28 Apr 2017 11:53:34 GMT
+  recorded_at: Tue, 16 Jan 2018 14:01:09 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:package_test_user:branches:home:package_test_user/test_package/_meta?user=package_test_user
@@ -482,8 +484,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="test_package" project="home:package_test_user:branches:home:package_test_user">
-          <title>The Waste Land</title>
-          <description>Ut quia eum accusamus qui.</description>
+          <title>A Passage to India</title>
+          <description>Delectus dolorem explicabo ut veritatis quia error.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -504,19 +506,19 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '194'
+      - '223'
     body:
       encoding: UTF-8
       string: |
         <package name="test_package" project="home:package_test_user:branches:home:package_test_user">
-          <title>The Waste Land</title>
-          <description>Ut quia eum accusamus qui.</description>
+          <title>A Passage to India</title>
+          <description>Delectus dolorem explicabo ut veritatis quia error.</description>
         </package>
     http_version: 
-  recorded_at: Fri, 28 Apr 2017 11:53:34 GMT
+  recorded_at: Tue, 16 Jan 2018 14:01:09 GMT
 - request:
     method: post
-    uri: http://backend:5352/source/home:package_test_user:branches:home:package_test_user/test_package?cmd=branch&opackage=test_package&oproject=home:package_test_user&user=package_test_user
+    uri: http://backend:5352/source/home:package_test_user:branches:home:package_test_user/test_package?cmd=branch&noservice=1&opackage=test_package&oproject=home:package_test_user&user=package_test_user
     body:
       encoding: UTF-8
       string: ''
@@ -545,16 +547,16 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <revision rev="2" vrev="2">
-          <srcmd5>cfb5610b8989bcec5324936201952527</srcmd5>
+        <revision rev="3" vrev="3">
+          <srcmd5>fe2600104654231dc251c3e977c084d1</srcmd5>
           <version>unknown</version>
-          <time>1493380414</time>
+          <time>1516111269</time>
           <user>package_test_user</user>
           <comment></comment>
           <requestid/>
         </revision>
     http_version: 
-  recorded_at: Fri, 28 Apr 2017 11:53:34 GMT
+  recorded_at: Tue, 16 Jan 2018 14:01:09 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:package_test_user:branches:home:package_test_user/test_package/_meta?user=package_test_user
@@ -562,8 +564,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="test_package" project="home:package_test_user:branches:home:package_test_user">
-          <title>The Waste Land</title>
-          <description>Ut quia eum accusamus qui.</description>
+          <title>A Passage to India</title>
+          <description>Delectus dolorem explicabo ut veritatis quia error.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -584,16 +586,16 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '194'
+      - '223'
     body:
       encoding: UTF-8
       string: |
         <package name="test_package" project="home:package_test_user:branches:home:package_test_user">
-          <title>The Waste Land</title>
-          <description>Ut quia eum accusamus qui.</description>
+          <title>A Passage to India</title>
+          <description>Delectus dolorem explicabo ut veritatis quia error.</description>
         </package>
     http_version: 
-  recorded_at: Fri, 28 Apr 2017 11:53:34 GMT
+  recorded_at: Tue, 16 Jan 2018 14:01:09 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:package_test_user:branches:home:package_test_user/test_package
@@ -619,18 +621,19 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '637'
+      - '732'
     body:
       encoding: UTF-8
       string: |
-        <directory name="test_package" rev="2" vrev="2" srcmd5="cfb5610b8989bcec5324936201952527">
-          <linkinfo project="home:package_test_user" package="test_package" srcmd5="311e4352c2ab7812f9e2257ffa21bc28" baserev="311e4352c2ab7812f9e2257ffa21bc28" xsrcmd5="89577d444ca13b6baa8ccc823cdc5523" lsrcmd5="cfb5610b8989bcec5324936201952527" />
-          <entry name="_config" md5="9b25582342c855c3a7ba7d7c306ef9b0" size="112" mtime="1493380413" />
-          <entry name="_link" md5="50327cef2249bb905364f0fe2da2393b" size="130" mtime="1493380414" />
-          <entry name="somefile.txt" md5="9be44de8b228745e8287110b3ba75c97" size="213" mtime="1493380413" />
+        <directory name="test_package" rev="3" vrev="3" srcmd5="fe2600104654231dc251c3e977c084d1">
+          <linkinfo project="home:package_test_user" package="test_package" srcmd5="aba3d257b955ecee415e9a5c2f741e95" baserev="aba3d257b955ecee415e9a5c2f741e95" xsrcmd5="80c5b1a10ad261bb1a2080702a05cd4f" lsrcmd5="fe2600104654231dc251c3e977c084d1" />
+          <entry name="_config" md5="8a5b8805aeb78ad47358de0ece17d3fe" size="126" mtime="1516111269" />
+          <entry name="_link" md5="86b5fd001a064acafec5d9ae72c44206" size="130" mtime="1516111269" />
+          <entry name="new_file" md5="d41d8cd98f00b204e9800998ecf8427e" size="0" mtime="1516111025" />
+          <entry name="somefile.txt" md5="478bacb4eb86846967edfa64ec6a5f9a" size="172" mtime="1516111242" />
         </directory>
     http_version: 
-  recorded_at: Fri, 28 Apr 2017 11:53:34 GMT
+  recorded_at: Tue, 16 Jan 2018 14:01:09 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:package_test_user:branches:home:package_test_user/test_package?nofilename=1&view=info&withchangesmd5=1
@@ -656,16 +659,16 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '298'
+      - '299'
     body:
       encoding: UTF-8
       string: |
-        <sourceinfo package="test_package" rev="2" vrev="6" srcmd5="89577d444ca13b6baa8ccc823cdc5523" lsrcmd5="cfb5610b8989bcec5324936201952527" verifymd5="311e4352c2ab7812f9e2257ffa21bc28">
+        <sourceinfo package="test_package" rev="3" vrev="20" srcmd5="80c5b1a10ad261bb1a2080702a05cd4f" lsrcmd5="fe2600104654231dc251c3e977c084d1" verifymd5="aba3d257b955ecee415e9a5c2f741e95">
           <linked project="home:package_test_user" package="test_package" />
-          <revtime>1493380414</revtime>
+          <revtime>1516111269</revtime>
         </sourceinfo>
     http_version: 
-  recorded_at: Fri, 28 Apr 2017 11:53:34 GMT
+  recorded_at: Tue, 16 Jan 2018 14:01:09 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:package_test_user:branches:home:package_test_user/test_package
@@ -691,18 +694,19 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '637'
+      - '732'
     body:
       encoding: UTF-8
       string: |
-        <directory name="test_package" rev="2" vrev="2" srcmd5="cfb5610b8989bcec5324936201952527">
-          <linkinfo project="home:package_test_user" package="test_package" srcmd5="311e4352c2ab7812f9e2257ffa21bc28" baserev="311e4352c2ab7812f9e2257ffa21bc28" xsrcmd5="89577d444ca13b6baa8ccc823cdc5523" lsrcmd5="cfb5610b8989bcec5324936201952527" />
-          <entry name="_config" md5="9b25582342c855c3a7ba7d7c306ef9b0" size="112" mtime="1493380413" />
-          <entry name="_link" md5="50327cef2249bb905364f0fe2da2393b" size="130" mtime="1493380414" />
-          <entry name="somefile.txt" md5="9be44de8b228745e8287110b3ba75c97" size="213" mtime="1493380413" />
+        <directory name="test_package" rev="3" vrev="3" srcmd5="fe2600104654231dc251c3e977c084d1">
+          <linkinfo project="home:package_test_user" package="test_package" srcmd5="aba3d257b955ecee415e9a5c2f741e95" baserev="aba3d257b955ecee415e9a5c2f741e95" xsrcmd5="80c5b1a10ad261bb1a2080702a05cd4f" lsrcmd5="fe2600104654231dc251c3e977c084d1" />
+          <entry name="_config" md5="8a5b8805aeb78ad47358de0ece17d3fe" size="126" mtime="1516111269" />
+          <entry name="_link" md5="86b5fd001a064acafec5d9ae72c44206" size="130" mtime="1516111269" />
+          <entry name="new_file" md5="d41d8cd98f00b204e9800998ecf8427e" size="0" mtime="1516111025" />
+          <entry name="somefile.txt" md5="478bacb4eb86846967edfa64ec6a5f9a" size="172" mtime="1516111242" />
         </directory>
     http_version: 
-  recorded_at: Fri, 28 Apr 2017 11:53:34 GMT
+  recorded_at: Tue, 16 Jan 2018 14:01:09 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:package_test_user:branches:home:package_test_user/test_package?cmd=diff&linkrev=base&onlyissues=1&orev=0&view=xml
@@ -734,15 +738,15 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="e1154f5a403f941c3c7aa08fcffc767c">
+        <sourcediff key="b236bade9bcde6985e5702cf3fbfd04a">
           <old project="home:package_test_user:branches:home:package_test_user" package="test_package" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e" />
-          <new project="home:package_test_user:branches:home:package_test_user" package="test_package" rev="2" srcmd5="cfb5610b8989bcec5324936201952527" />
+          <new project="home:package_test_user:branches:home:package_test_user" package="test_package" rev="3" srcmd5="fe2600104654231dc251c3e977c084d1" />
           <files />
           <issues>
           </issues>
         </sourcediff>
     http_version: 
-  recorded_at: Fri, 28 Apr 2017 11:53:34 GMT
+  recorded_at: Tue, 16 Jan 2018 14:01:09 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:package_test_user:branches:home:package_test_user/test_package?cmd=linkdiff&linkrev=base&onlyissues=1&view=xml
@@ -774,13 +778,13 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="5d96416e779ad9177fad6aefdbcccb21">
-          <old project="home:package_test_user" package="test_package" rev="311e4352c2ab7812f9e2257ffa21bc28" srcmd5="311e4352c2ab7812f9e2257ffa21bc28" />
-          <new project="home:package_test_user:branches:home:package_test_user" package="test_package" rev="89577d444ca13b6baa8ccc823cdc5523" srcmd5="89577d444ca13b6baa8ccc823cdc5523" />
+        <sourcediff key="f41f6e7a16c972e41faa002de5bbc399">
+          <old project="home:package_test_user" package="test_package" rev="aba3d257b955ecee415e9a5c2f741e95" srcmd5="aba3d257b955ecee415e9a5c2f741e95" />
+          <new project="home:package_test_user:branches:home:package_test_user" package="test_package" rev="80c5b1a10ad261bb1a2080702a05cd4f" srcmd5="80c5b1a10ad261bb1a2080702a05cd4f" />
           <files />
         </sourcediff>
     http_version: 
-  recorded_at: Fri, 28 Apr 2017 11:53:34 GMT
+  recorded_at: Tue, 16 Jan 2018 14:01:09 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:package_test_user:branches:home:package_test_user/_meta?user=package_test_user
@@ -827,7 +831,7 @@ http_interactions:
           </publish>
         </project>
     http_version: 
-  recorded_at: Fri, 28 Apr 2017 11:53:34 GMT
+  recorded_at: Tue, 16 Jan 2018 14:01:09 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:package_test_user/test_package?nofilename=1&view=info&withchangesmd5=1
@@ -853,15 +857,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '186'
+      - '188'
     body:
       encoding: UTF-8
       string: |
-        <sourceinfo package="test_package" rev="4" vrev="4" srcmd5="311e4352c2ab7812f9e2257ffa21bc28" verifymd5="311e4352c2ab7812f9e2257ffa21bc28">
-          <revtime>1493380413</revtime>
+        <sourceinfo package="test_package" rev="17" vrev="17" srcmd5="aba3d257b955ecee415e9a5c2f741e95" verifymd5="aba3d257b955ecee415e9a5c2f741e95">
+          <revtime>1516111269</revtime>
         </sourceinfo>
     http_version: 
-  recorded_at: Fri, 28 Apr 2017 11:53:34 GMT
+  recorded_at: Tue, 16 Jan 2018 14:01:10 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:package_test_user/test_package
@@ -887,16 +891,17 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '301'
+      - '398'
     body:
       encoding: UTF-8
       string: |
-        <directory name="test_package" rev="4" vrev="4" srcmd5="311e4352c2ab7812f9e2257ffa21bc28">
-          <entry name="_config" md5="9b25582342c855c3a7ba7d7c306ef9b0" size="112" mtime="1493380413" />
-          <entry name="somefile.txt" md5="9be44de8b228745e8287110b3ba75c97" size="213" mtime="1493380413" />
+        <directory name="test_package" rev="17" vrev="17" srcmd5="aba3d257b955ecee415e9a5c2f741e95">
+          <entry name="_config" md5="8a5b8805aeb78ad47358de0ece17d3fe" size="126" mtime="1516111269" />
+          <entry name="new_file" md5="d41d8cd98f00b204e9800998ecf8427e" size="0" mtime="1516111025" />
+          <entry name="somefile.txt" md5="478bacb4eb86846967edfa64ec6a5f9a" size="172" mtime="1516111242" />
         </directory>
     http_version: 
-  recorded_at: Fri, 28 Apr 2017 11:53:34 GMT
+  recorded_at: Tue, 16 Jan 2018 14:01:10 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:package_test_user/test_package?cmd=diff&linkrev=base&onlyissues=1&orev=0&view=xml
@@ -924,19 +929,19 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '333'
+      - '334'
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="7d381d57136f5eec353ca8d32d2552e6">
+        <sourcediff key="cc5e4fb7ce3984e2094348cef146d5d0">
           <old project="home:package_test_user" package="test_package" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e" />
-          <new project="home:package_test_user" package="test_package" rev="4" srcmd5="311e4352c2ab7812f9e2257ffa21bc28" />
+          <new project="home:package_test_user" package="test_package" rev="17" srcmd5="aba3d257b955ecee415e9a5c2f741e95" />
           <files />
           <issues>
           </issues>
         </sourcediff>
     http_version: 
-  recorded_at: Fri, 28 Apr 2017 11:53:34 GMT
+  recorded_at: Tue, 16 Jan 2018 14:01:10 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:package_test_user/test_package
@@ -962,27 +967,26 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '301'
+      - '398'
     body:
       encoding: UTF-8
       string: |
-        <directory name="test_package" rev="4" vrev="4" srcmd5="311e4352c2ab7812f9e2257ffa21bc28">
-          <entry name="_config" md5="9b25582342c855c3a7ba7d7c306ef9b0" size="112" mtime="1493380413" />
-          <entry name="somefile.txt" md5="9be44de8b228745e8287110b3ba75c97" size="213" mtime="1493380413" />
+        <directory name="test_package" rev="17" vrev="17" srcmd5="aba3d257b955ecee415e9a5c2f741e95">
+          <entry name="_config" md5="8a5b8805aeb78ad47358de0ece17d3fe" size="126" mtime="1516111269" />
+          <entry name="new_file" md5="d41d8cd98f00b204e9800998ecf8427e" size="0" mtime="1516111025" />
+          <entry name="somefile.txt" md5="478bacb4eb86846967edfa64ec6a5f9a" size="172" mtime="1516111242" />
         </directory>
     http_version: 
-  recorded_at: Fri, 28 Apr 2017 11:53:34 GMT
+  recorded_at: Tue, 16 Jan 2018 14:01:10 GMT
 - request:
     method: get
-    uri: http://backend:5352/source/home:package_test_user/test_package?expand=1&rev=4
+    uri: http://backend:5352/source/home:package_test_user/test_package?expand=1&rev=17
     body:
       encoding: US-ASCII
       string: ''
     headers:
-      Content-Type:
-      - text/plain
       Accept-Encoding:
-      - identity
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
       - "*/*"
       User-Agent:
@@ -999,16 +1003,17 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '301'
+      - '398'
     body:
       encoding: UTF-8
       string: |
-        <directory name="test_package" rev="4" vrev="4" srcmd5="311e4352c2ab7812f9e2257ffa21bc28">
-          <entry name="_config" md5="9b25582342c855c3a7ba7d7c306ef9b0" size="112" mtime="1493380413" />
-          <entry name="somefile.txt" md5="9be44de8b228745e8287110b3ba75c97" size="213" mtime="1493380413" />
+        <directory name="test_package" rev="17" vrev="17" srcmd5="aba3d257b955ecee415e9a5c2f741e95">
+          <entry name="_config" md5="8a5b8805aeb78ad47358de0ece17d3fe" size="126" mtime="1516111269" />
+          <entry name="new_file" md5="d41d8cd98f00b204e9800998ecf8427e" size="0" mtime="1516111025" />
+          <entry name="somefile.txt" md5="478bacb4eb86846967edfa64ec6a5f9a" size="172" mtime="1516111242" />
         </directory>
     http_version: 
-  recorded_at: Fri, 28 Apr 2017 11:53:34 GMT
+  recorded_at: Tue, 16 Jan 2018 14:01:10 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:package_test_user/test_package
@@ -1036,16 +1041,17 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '301'
+      - '398'
     body:
       encoding: UTF-8
       string: |
-        <directory name="test_package" rev="4" vrev="4" srcmd5="311e4352c2ab7812f9e2257ffa21bc28">
-          <entry name="_config" md5="9b25582342c855c3a7ba7d7c306ef9b0" size="112" mtime="1493380413" />
-          <entry name="somefile.txt" md5="9be44de8b228745e8287110b3ba75c97" size="213" mtime="1493380413" />
+        <directory name="test_package" rev="17" vrev="17" srcmd5="aba3d257b955ecee415e9a5c2f741e95">
+          <entry name="_config" md5="8a5b8805aeb78ad47358de0ece17d3fe" size="126" mtime="1516111269" />
+          <entry name="new_file" md5="d41d8cd98f00b204e9800998ecf8427e" size="0" mtime="1516111025" />
+          <entry name="somefile.txt" md5="478bacb4eb86846967edfa64ec6a5f9a" size="172" mtime="1516111242" />
         </directory>
     http_version: 
-  recorded_at: Fri, 28 Apr 2017 11:53:34 GMT
+  recorded_at: Tue, 16 Jan 2018 14:01:10 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:package_test_user/test_package/_service
@@ -1082,7 +1088,7 @@ http_interactions:
           <details>404 _service: no such file</details>
         </status>
     http_version: 
-  recorded_at: Fri, 28 Apr 2017 11:53:34 GMT
+  recorded_at: Tue, 16 Jan 2018 14:01:10 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:package_test_user/test_package/_history
@@ -1108,38 +1114,116 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '759'
+      - '3151'
     body:
       encoding: UTF-8
       string: |
         <revisionlist>
           <revision rev="1" vrev="1">
-            <srcmd5>ad9176bb403973e59a0c565e678ddb6b</srcmd5>
+            <srcmd5>6c1a00da997ac81216c2927f5531d8a3</srcmd5>
             <version>unknown</version>
-            <time>1493380405</time>
+            <time>1516111250</time>
             <user>unknown</user>
           </revision>
           <revision rev="2" vrev="2">
-            <srcmd5>4924827000f7f3e9f422fc884f2355fc</srcmd5>
+            <srcmd5>67f925b0f945b8133bc1cfc378b9a1e4</srcmd5>
             <version>unknown</version>
-            <time>1493380405</time>
+            <time>1516111250</time>
             <user>unknown</user>
           </revision>
           <revision rev="3" vrev="3">
-            <srcmd5>5d1f16aed708643e2feac41e3baba70c</srcmd5>
+            <srcmd5>828f2044d4611f0d07fe08703257e7d7</srcmd5>
             <version>unknown</version>
-            <time>1493380413</time>
-            <user>unknown</user>
+            <time>1516111252</time>
+            <user>package_test_user</user>
           </revision>
           <revision rev="4" vrev="4">
-            <srcmd5>311e4352c2ab7812f9e2257ffa21bc28</srcmd5>
+            <srcmd5>029580729571eb701b38a5f6b40bb879</srcmd5>
             <version>unknown</version>
-            <time>1493380413</time>
+            <time>1516111253</time>
+            <user>unknown</user>
+          </revision>
+          <revision rev="5" vrev="5">
+            <srcmd5>029580729571eb701b38a5f6b40bb879</srcmd5>
+            <version>unknown</version>
+            <time>1516111253</time>
+            <user>unknown</user>
+          </revision>
+          <revision rev="6" vrev="6">
+            <srcmd5>b3a56ec31c57bd08b4461f66d056857f</srcmd5>
+            <version>unknown</version>
+            <time>1516111256</time>
+            <user>unknown</user>
+          </revision>
+          <revision rev="7" vrev="7">
+            <srcmd5>b3a56ec31c57bd08b4461f66d056857f</srcmd5>
+            <version>unknown</version>
+            <time>1516111256</time>
+            <user>unknown</user>
+          </revision>
+          <revision rev="8" vrev="8">
+            <srcmd5>658c809ff204a54691c073274d934b03</srcmd5>
+            <version>unknown</version>
+            <time>1516111259</time>
+            <user>unknown</user>
+          </revision>
+          <revision rev="9" vrev="9">
+            <srcmd5>658c809ff204a54691c073274d934b03</srcmd5>
+            <version>unknown</version>
+            <time>1516111259</time>
+            <user>unknown</user>
+          </revision>
+          <revision rev="10" vrev="10">
+            <srcmd5>b5364f6eec305c5523c95fa3df42271f</srcmd5>
+            <version>unknown</version>
+            <time>1516111262</time>
+            <user>unknown</user>
+          </revision>
+          <revision rev="11" vrev="11">
+            <srcmd5>b5364f6eec305c5523c95fa3df42271f</srcmd5>
+            <version>unknown</version>
+            <time>1516111262</time>
+            <user>unknown</user>
+          </revision>
+          <revision rev="12" vrev="12">
+            <srcmd5>6404275e267a696caf2cff1aed65d3a8</srcmd5>
+            <version>unknown</version>
+            <time>1516111264</time>
+            <user>unknown</user>
+          </revision>
+          <revision rev="13" vrev="13">
+            <srcmd5>6404275e267a696caf2cff1aed65d3a8</srcmd5>
+            <version>unknown</version>
+            <time>1516111264</time>
+            <user>unknown</user>
+          </revision>
+          <revision rev="14" vrev="14">
+            <srcmd5>a4f8f316e23070dcf46b14d8c0922332</srcmd5>
+            <version>unknown</version>
+            <time>1516111267</time>
+            <user>unknown</user>
+          </revision>
+          <revision rev="15" vrev="15">
+            <srcmd5>a4f8f316e23070dcf46b14d8c0922332</srcmd5>
+            <version>unknown</version>
+            <time>1516111267</time>
+            <user>unknown</user>
+          </revision>
+          <revision rev="16" vrev="16">
+            <srcmd5>aba3d257b955ecee415e9a5c2f741e95</srcmd5>
+            <version>unknown</version>
+            <time>1516111269</time>
+            <user>unknown</user>
+          </revision>
+          <revision rev="17" vrev="17">
+            <srcmd5>aba3d257b955ecee415e9a5c2f741e95</srcmd5>
+            <version>unknown</version>
+            <time>1516111269</time>
             <user>unknown</user>
           </revision>
         </revisionlist>
     http_version: 
-  recorded_at: Fri, 28 Apr 2017 11:53:34 GMT
+  recorded_at: Tue, 16 Jan 2018 14:01:10 GMT
 - request:
     method: get
     uri: http://backend:5352/build/home:package_test_user/_result?package=test_package&view=status
@@ -1174,7 +1258,7 @@ http_interactions:
 
 '
     http_version: 
-  recorded_at: Fri, 28 Apr 2017 11:53:34 GMT
+  recorded_at: Tue, 16 Jan 2018 14:01:10 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:package_test_user:branches:home:package_test_user/test_package
@@ -1200,29 +1284,28 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '637'
+      - '732'
     body:
       encoding: UTF-8
       string: |
-        <directory name="test_package" rev="2" vrev="2" srcmd5="cfb5610b8989bcec5324936201952527">
-          <linkinfo project="home:package_test_user" package="test_package" srcmd5="311e4352c2ab7812f9e2257ffa21bc28" baserev="311e4352c2ab7812f9e2257ffa21bc28" xsrcmd5="89577d444ca13b6baa8ccc823cdc5523" lsrcmd5="cfb5610b8989bcec5324936201952527" />
-          <entry name="_config" md5="9b25582342c855c3a7ba7d7c306ef9b0" size="112" mtime="1493380413" />
-          <entry name="_link" md5="50327cef2249bb905364f0fe2da2393b" size="130" mtime="1493380414" />
-          <entry name="somefile.txt" md5="9be44de8b228745e8287110b3ba75c97" size="213" mtime="1493380413" />
+        <directory name="test_package" rev="3" vrev="3" srcmd5="fe2600104654231dc251c3e977c084d1">
+          <linkinfo project="home:package_test_user" package="test_package" srcmd5="aba3d257b955ecee415e9a5c2f741e95" baserev="aba3d257b955ecee415e9a5c2f741e95" xsrcmd5="80c5b1a10ad261bb1a2080702a05cd4f" lsrcmd5="fe2600104654231dc251c3e977c084d1" />
+          <entry name="_config" md5="8a5b8805aeb78ad47358de0ece17d3fe" size="126" mtime="1516111269" />
+          <entry name="_link" md5="86b5fd001a064acafec5d9ae72c44206" size="130" mtime="1516111269" />
+          <entry name="new_file" md5="d41d8cd98f00b204e9800998ecf8427e" size="0" mtime="1516111025" />
+          <entry name="somefile.txt" md5="478bacb4eb86846967edfa64ec6a5f9a" size="172" mtime="1516111242" />
         </directory>
     http_version: 
-  recorded_at: Fri, 28 Apr 2017 11:53:35 GMT
+  recorded_at: Tue, 16 Jan 2018 14:01:10 GMT
 - request:
     method: get
-    uri: http://backend:5352/source/home:package_test_user:branches:home:package_test_user/test_package?expand=1&rev=2
+    uri: http://backend:5352/source/home:package_test_user:branches:home:package_test_user/test_package?expand=1&rev=3
     body:
       encoding: US-ASCII
       string: ''
     headers:
-      Content-Type:
-      - text/plain
       Accept-Encoding:
-      - identity
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
       - "*/*"
       User-Agent:
@@ -1239,17 +1322,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '531'
+      - '627'
     body:
       encoding: UTF-8
       string: |
-        <directory name="test_package" rev="89577d444ca13b6baa8ccc823cdc5523" vrev="6" srcmd5="89577d444ca13b6baa8ccc823cdc5523">
-          <linkinfo project="home:package_test_user" package="test_package" srcmd5="311e4352c2ab7812f9e2257ffa21bc28" baserev="311e4352c2ab7812f9e2257ffa21bc28" lsrcmd5="cfb5610b8989bcec5324936201952527" />
-          <entry name="_config" md5="9b25582342c855c3a7ba7d7c306ef9b0" size="112" mtime="1493380413" />
-          <entry name="somefile.txt" md5="9be44de8b228745e8287110b3ba75c97" size="213" mtime="1493380413" />
+        <directory name="test_package" rev="80c5b1a10ad261bb1a2080702a05cd4f" vrev="20" srcmd5="80c5b1a10ad261bb1a2080702a05cd4f">
+          <linkinfo project="home:package_test_user" package="test_package" srcmd5="aba3d257b955ecee415e9a5c2f741e95" baserev="aba3d257b955ecee415e9a5c2f741e95" lsrcmd5="fe2600104654231dc251c3e977c084d1" />
+          <entry name="_config" md5="8a5b8805aeb78ad47358de0ece17d3fe" size="126" mtime="1516111269" />
+          <entry name="new_file" md5="d41d8cd98f00b204e9800998ecf8427e" size="0" mtime="1516111025" />
+          <entry name="somefile.txt" md5="478bacb4eb86846967edfa64ec6a5f9a" size="172" mtime="1516111242" />
         </directory>
     http_version: 
-  recorded_at: Fri, 28 Apr 2017 11:53:35 GMT
+  recorded_at: Tue, 16 Jan 2018 14:01:10 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:package_test_user:branches:home:package_test_user/test_package
@@ -1277,18 +1361,19 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '637'
+      - '732'
     body:
       encoding: UTF-8
       string: |
-        <directory name="test_package" rev="2" vrev="2" srcmd5="cfb5610b8989bcec5324936201952527">
-          <linkinfo project="home:package_test_user" package="test_package" srcmd5="311e4352c2ab7812f9e2257ffa21bc28" baserev="311e4352c2ab7812f9e2257ffa21bc28" xsrcmd5="89577d444ca13b6baa8ccc823cdc5523" lsrcmd5="cfb5610b8989bcec5324936201952527" />
-          <entry name="_config" md5="9b25582342c855c3a7ba7d7c306ef9b0" size="112" mtime="1493380413" />
-          <entry name="_link" md5="50327cef2249bb905364f0fe2da2393b" size="130" mtime="1493380414" />
-          <entry name="somefile.txt" md5="9be44de8b228745e8287110b3ba75c97" size="213" mtime="1493380413" />
+        <directory name="test_package" rev="3" vrev="3" srcmd5="fe2600104654231dc251c3e977c084d1">
+          <linkinfo project="home:package_test_user" package="test_package" srcmd5="aba3d257b955ecee415e9a5c2f741e95" baserev="aba3d257b955ecee415e9a5c2f741e95" xsrcmd5="80c5b1a10ad261bb1a2080702a05cd4f" lsrcmd5="fe2600104654231dc251c3e977c084d1" />
+          <entry name="_config" md5="8a5b8805aeb78ad47358de0ece17d3fe" size="126" mtime="1516111269" />
+          <entry name="_link" md5="86b5fd001a064acafec5d9ae72c44206" size="130" mtime="1516111269" />
+          <entry name="new_file" md5="d41d8cd98f00b204e9800998ecf8427e" size="0" mtime="1516111025" />
+          <entry name="somefile.txt" md5="478bacb4eb86846967edfa64ec6a5f9a" size="172" mtime="1516111242" />
         </directory>
     http_version: 
-  recorded_at: Fri, 28 Apr 2017 11:53:35 GMT
+  recorded_at: Tue, 16 Jan 2018 14:01:10 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:package_test_user:branches:home:package_test_user/test_package/_service
@@ -1325,7 +1410,7 @@ http_interactions:
           <details>404 _service: no such file</details>
         </status>
     http_version: 
-  recorded_at: Fri, 28 Apr 2017 11:53:35 GMT
+  recorded_at: Tue, 16 Jan 2018 14:01:10 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:package_test_user:branches:home:package_test_user/test_package/_history
@@ -1351,26 +1436,32 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '415'
+      - '607'
     body:
       encoding: UTF-8
       string: |
         <revisionlist>
           <revision rev="1" vrev="1">
-            <srcmd5>afc6f2eac515eda05db7c4320c72c9d3</srcmd5>
+            <srcmd5>ed9fd8ff4fc3313c7f3c6757751cf231</srcmd5>
             <version>unknown</version>
-            <time>1493380406</time>
+            <time>1516111037</time>
             <user>package_test_user</user>
           </revision>
           <revision rev="2" vrev="2">
-            <srcmd5>cfb5610b8989bcec5324936201952527</srcmd5>
+            <srcmd5>9c53775171412be01f8e5f7a7fae0eb6</srcmd5>
             <version>unknown</version>
-            <time>1493380414</time>
+            <time>1516111039</time>
+            <user>package_test_user</user>
+          </revision>
+          <revision rev="3" vrev="3">
+            <srcmd5>fe2600104654231dc251c3e977c084d1</srcmd5>
+            <version>unknown</version>
+            <time>1516111269</time>
             <user>package_test_user</user>
           </revision>
         </revisionlist>
     http_version: 
-  recorded_at: Fri, 28 Apr 2017 11:53:35 GMT
+  recorded_at: Tue, 16 Jan 2018 14:01:10 GMT
 - request:
     method: get
     uri: http://backend:5352/build/home:package_test_user:branches:home:package_test_user/_result?package=test_package&view=status

--- a/src/api/spec/cassettes/Packages/Viewing_a_package_that/was_branched.yml
+++ b/src/api/spec/cassettes/Packages/Viewing_a_package_that/was_branched.yml
@@ -40,16 +40,16 @@ http_interactions:
           <person userid="package_test_user" role="maintainer" />
         </project>
     http_version: 
-  recorded_at: Fri, 28 Apr 2017 11:53:25 GMT
+  recorded_at: Tue, 16 Jan 2018 14:01:11 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:package_test_user/test_package/_meta?user=_nobody_
+    uri: http://backend:5352/source/home:package_test_user/test_package/_meta?user=package_test_user
     body:
       encoding: UTF-8
       string: |
         <package name="test_package" project="home:package_test_user">
-          <title>That Good Night</title>
-          <description>Soluta veritatis mollitia qui earum et.</description>
+          <title>The Needle's Eye</title>
+          <description>Laboriosam sed quia nihil eos.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -70,16 +70,16 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '176'
+      - '168'
     body:
       encoding: UTF-8
       string: |
         <package name="test_package" project="home:package_test_user">
-          <title>That Good Night</title>
-          <description>Soluta veritatis mollitia qui earum et.</description>
+          <title>The Needle's Eye</title>
+          <description>Laboriosam sed quia nihil eos.</description>
         </package>
     http_version: 
-  recorded_at: Fri, 28 Apr 2017 11:53:25 GMT
+  recorded_at: Tue, 16 Jan 2018 14:01:11 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:package_test_user/test_package/_meta
@@ -87,8 +87,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="test_package" project="home:package_test_user">
-          <title>That Good Night</title>
-          <description>Soluta veritatis mollitia qui earum et.</description>
+          <title>The Needle's Eye</title>
+          <description>Laboriosam sed quia nihil eos.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -109,23 +109,23 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '176'
+      - '168'
     body:
       encoding: UTF-8
       string: |
         <package name="test_package" project="home:package_test_user">
-          <title>That Good Night</title>
-          <description>Soluta veritatis mollitia qui earum et.</description>
+          <title>The Needle's Eye</title>
+          <description>Laboriosam sed quia nihil eos.</description>
         </package>
     http_version: 
-  recorded_at: Fri, 28 Apr 2017 11:53:25 GMT
+  recorded_at: Tue, 16 Jan 2018 14:01:11 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:package_test_user/test_package/_config
     body:
       encoding: UTF-8
-      string: Doloremque quis dolorem saepe perferendis at commodi. Nostrum dignissimos
-        qui. Officiis ex praesentium est accusantium enim. Enim quos ut.
+      string: Illum a iste qui aut ex fugit. Sunt laboriosam sed. Aliquid aperiam
+        aut est.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -145,27 +145,28 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '207'
+      - '209'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="1" vrev="1">
-          <srcmd5>ad9176bb403973e59a0c565e678ddb6b</srcmd5>
+        <revision rev="18" vrev="18">
+          <srcmd5>62c2d9dc1d0cb2fc8540d9aca0ec1dab</srcmd5>
           <version>unknown</version>
-          <time>1493380405</time>
+          <time>1516111271</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
     http_version: 
-  recorded_at: Fri, 28 Apr 2017 11:53:25 GMT
+  recorded_at: Tue, 16 Jan 2018 14:01:11 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:package_test_user/test_package/somefile.txt
     body:
       encoding: UTF-8
-      string: In ea molestiae. Quo sed qui. Incidunt qui unde voluptatum et debitis.
-        Aut quasi velit ratione.
+      string: Officia quia repellendus quis. Velit ullam et. Praesentium dolorem quos
+        quae dolorum illum libero sit. Culpa officia autem voluptatem assumenda. Officiis
+        repudiandae et in.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -185,20 +186,20 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '207'
+      - '209'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="2" vrev="2">
-          <srcmd5>4924827000f7f3e9f422fc884f2355fc</srcmd5>
+        <revision rev="19" vrev="19">
+          <srcmd5>62c2d9dc1d0cb2fc8540d9aca0ec1dab</srcmd5>
           <version>unknown</version>
-          <time>1493380405</time>
+          <time>1516111271</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
     http_version: 
-  recorded_at: Fri, 28 Apr 2017 11:53:25 GMT
+  recorded_at: Tue, 16 Jan 2018 14:01:11 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:other_package_test_user/_meta?user=other_package_test_user
@@ -239,16 +240,16 @@ http_interactions:
           <person userid="other_package_test_user" role="maintainer" />
         </project>
     http_version: 
-  recorded_at: Fri, 28 Apr 2017 11:53:26 GMT
+  recorded_at: Tue, 16 Jan 2018 14:01:11 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:other_package_test_user/branch_test_package/_meta?user=_nobody_
+    uri: http://backend:5352/source/home:other_package_test_user/branch_test_package/_meta?user=package_test_user
     body:
       encoding: UTF-8
       string: |
         <package name="branch_test_package" project="home:other_package_test_user">
-          <title>Recalled to Life</title>
-          <description>Aliquid aut dolores maiores.</description>
+          <title>An Acceptable Time</title>
+          <description>Voluptas quo tempora dolorem nam unde qui in.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -269,16 +270,16 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '179'
+      - '198'
     body:
       encoding: UTF-8
       string: |
         <package name="branch_test_package" project="home:other_package_test_user">
-          <title>Recalled to Life</title>
-          <description>Aliquid aut dolores maiores.</description>
+          <title>An Acceptable Time</title>
+          <description>Voluptas quo tempora dolorem nam unde qui in.</description>
         </package>
     http_version: 
-  recorded_at: Fri, 28 Apr 2017 11:53:26 GMT
+  recorded_at: Tue, 16 Jan 2018 14:01:11 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:other_package_test_user/branch_test_package/_meta
@@ -286,8 +287,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="branch_test_package" project="home:other_package_test_user">
-          <title>Recalled to Life</title>
-          <description>Aliquid aut dolores maiores.</description>
+          <title>An Acceptable Time</title>
+          <description>Voluptas quo tempora dolorem nam unde qui in.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -308,23 +309,23 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '179'
+      - '198'
     body:
       encoding: UTF-8
       string: |
         <package name="branch_test_package" project="home:other_package_test_user">
-          <title>Recalled to Life</title>
-          <description>Aliquid aut dolores maiores.</description>
+          <title>An Acceptable Time</title>
+          <description>Voluptas quo tempora dolorem nam unde qui in.</description>
         </package>
     http_version: 
-  recorded_at: Fri, 28 Apr 2017 11:53:26 GMT
+  recorded_at: Tue, 16 Jan 2018 14:01:12 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:other_package_test_user/branch_test_package/_config
     body:
       encoding: UTF-8
-      string: Eligendi dolor autem. Error rem accusantium sint. Perferendis ipsa id
-        quo libero non.
+      string: Repellendus suscipit velit id. Excepturi repudiandae eum debitis sed.
+        Est accusantium ipsam deserunt exercitationem tempora accusamus.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -348,23 +349,24 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <revision rev="1" vrev="1">
-          <srcmd5>c53ca0699c23fcefedeb31adbb65fc9c</srcmd5>
+        <revision rev="5" vrev="5">
+          <srcmd5>947702431ee1116ce1f52912883aac66</srcmd5>
           <version>unknown</version>
-          <time>1493380406</time>
+          <time>1516111272</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
     http_version: 
-  recorded_at: Fri, 28 Apr 2017 11:53:26 GMT
+  recorded_at: Tue, 16 Jan 2018 14:01:12 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:other_package_test_user/branch_test_package/somefile.txt
     body:
       encoding: UTF-8
-      string: Et molestias amet ipsa laborum animi qui quas. Eligendi maiores in nihil
-        necessitatibus enim ducimus. Enim neque voluptas est aliquam.
+      string: Officia quia repellendus quis. Velit ullam et. Praesentium dolorem quos
+        quae dolorum illum libero sit. Culpa officia autem voluptatem assumenda. Officiis
+        repudiandae et in.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -388,16 +390,16 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <revision rev="2" vrev="2">
-          <srcmd5>d632f75e9fd2e9eec8ca0c4b32f27102</srcmd5>
+        <revision rev="6" vrev="6">
+          <srcmd5>947702431ee1116ce1f52912883aac66</srcmd5>
           <version>unknown</version>
-          <time>1493380406</time>
+          <time>1516111272</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
     http_version: 
-  recorded_at: Fri, 28 Apr 2017 11:53:26 GMT
+  recorded_at: Tue, 16 Jan 2018 14:01:12 GMT
 - request:
     method: post
     uri: http://backend:5352/search/package/id?match=(linkinfo/@package=%22test_package%22%20and%20linkinfo/@project=%22home:package_test_user%22%20and%20@project=%22home:package_test_user%22)
@@ -432,7 +434,7 @@ http_interactions:
         <collection>
         </collection>
     http_version: 
-  recorded_at: Fri, 28 Apr 2017 11:53:26 GMT
+  recorded_at: Tue, 16 Jan 2018 14:01:12 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:package_test_user:branches:home:package_test_user/_meta?user=package_test_user
@@ -473,7 +475,7 @@ http_interactions:
           <person userid="package_test_user" role="maintainer" />
         </project>
     http_version: 
-  recorded_at: Fri, 28 Apr 2017 11:53:26 GMT
+  recorded_at: Tue, 16 Jan 2018 14:01:12 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:package_test_user:branches:home:package_test_user/test_package/_meta?user=package_test_user
@@ -481,8 +483,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="test_package" project="home:package_test_user:branches:home:package_test_user">
-          <title>That Good Night</title>
-          <description>Soluta veritatis mollitia qui earum et.</description>
+          <title>The Needle's Eye</title>
+          <description>Laboriosam sed quia nihil eos.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -503,19 +505,19 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '208'
+      - '200'
     body:
       encoding: UTF-8
       string: |
         <package name="test_package" project="home:package_test_user:branches:home:package_test_user">
-          <title>That Good Night</title>
-          <description>Soluta veritatis mollitia qui earum et.</description>
+          <title>The Needle's Eye</title>
+          <description>Laboriosam sed quia nihil eos.</description>
         </package>
     http_version: 
-  recorded_at: Fri, 28 Apr 2017 11:53:26 GMT
+  recorded_at: Tue, 16 Jan 2018 14:01:12 GMT
 - request:
     method: post
-    uri: http://backend:5352/source/home:package_test_user:branches:home:package_test_user/test_package?cmd=branch&opackage=test_package&oproject=home:package_test_user&user=package_test_user
+    uri: http://backend:5352/source/home:package_test_user:branches:home:package_test_user/test_package?cmd=branch&noservice=1&opackage=test_package&oproject=home:package_test_user&user=package_test_user
     body:
       encoding: UTF-8
       string: ''
@@ -544,16 +546,16 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <revision rev="1" vrev="1">
-          <srcmd5>afc6f2eac515eda05db7c4320c72c9d3</srcmd5>
+        <revision rev="4" vrev="4">
+          <srcmd5>d111e2a1fb888c9f68ae95926e07a00d</srcmd5>
           <version>unknown</version>
-          <time>1493380406</time>
+          <time>1516111272</time>
           <user>package_test_user</user>
           <comment></comment>
           <requestid/>
         </revision>
     http_version: 
-  recorded_at: Fri, 28 Apr 2017 11:53:26 GMT
+  recorded_at: Tue, 16 Jan 2018 14:01:12 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:package_test_user:branches:home:package_test_user/test_package/_meta?user=package_test_user
@@ -561,8 +563,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="test_package" project="home:package_test_user:branches:home:package_test_user">
-          <title>That Good Night</title>
-          <description>Soluta veritatis mollitia qui earum et.</description>
+          <title>The Needle's Eye</title>
+          <description>Laboriosam sed quia nihil eos.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -583,16 +585,16 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '208'
+      - '200'
     body:
       encoding: UTF-8
       string: |
         <package name="test_package" project="home:package_test_user:branches:home:package_test_user">
-          <title>That Good Night</title>
-          <description>Soluta veritatis mollitia qui earum et.</description>
+          <title>The Needle's Eye</title>
+          <description>Laboriosam sed quia nihil eos.</description>
         </package>
     http_version: 
-  recorded_at: Fri, 28 Apr 2017 11:53:26 GMT
+  recorded_at: Tue, 16 Jan 2018 14:01:12 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:package_test_user:branches:home:package_test_user/test_package
@@ -618,18 +620,19 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '636'
+      - '731'
     body:
       encoding: UTF-8
       string: |
-        <directory name="test_package" rev="1" vrev="1" srcmd5="afc6f2eac515eda05db7c4320c72c9d3">
-          <linkinfo project="home:package_test_user" package="test_package" srcmd5="4924827000f7f3e9f422fc884f2355fc" baserev="4924827000f7f3e9f422fc884f2355fc" xsrcmd5="f70da50f7b30aea1018b08e7845d9296" lsrcmd5="afc6f2eac515eda05db7c4320c72c9d3" />
-          <entry name="_config" md5="bddd97bab291296233ecbc17c4dce966" size="138" mtime="1493380405" />
-          <entry name="_link" md5="9608398184e12d4599f3d75e7e643ba7" size="130" mtime="1493380406" />
-          <entry name="somefile.txt" md5="62b28ae55f1c49beaefcdeb7002ba8ea" size="95" mtime="1493380405" />
+        <directory name="test_package" rev="4" vrev="4" srcmd5="d111e2a1fb888c9f68ae95926e07a00d">
+          <linkinfo project="home:package_test_user" package="test_package" srcmd5="62c2d9dc1d0cb2fc8540d9aca0ec1dab" baserev="62c2d9dc1d0cb2fc8540d9aca0ec1dab" xsrcmd5="e8c899f1f091a2445b1e492c8378945e" lsrcmd5="d111e2a1fb888c9f68ae95926e07a00d" />
+          <entry name="_config" md5="c4e0b762dfdda92c8a40bd96690ba617" size="76" mtime="1516111271" />
+          <entry name="_link" md5="21a39f738334cc12901ee0bd7f56c0c4" size="130" mtime="1516111272" />
+          <entry name="new_file" md5="d41d8cd98f00b204e9800998ecf8427e" size="0" mtime="1516111025" />
+          <entry name="somefile.txt" md5="478bacb4eb86846967edfa64ec6a5f9a" size="172" mtime="1516111242" />
         </directory>
     http_version: 
-  recorded_at: Fri, 28 Apr 2017 11:53:26 GMT
+  recorded_at: Tue, 16 Jan 2018 14:01:12 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:package_test_user:branches:home:package_test_user/test_package?nofilename=1&view=info&withchangesmd5=1
@@ -655,16 +658,16 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '298'
+      - '299'
     body:
       encoding: UTF-8
       string: |
-        <sourceinfo package="test_package" rev="1" vrev="3" srcmd5="f70da50f7b30aea1018b08e7845d9296" lsrcmd5="afc6f2eac515eda05db7c4320c72c9d3" verifymd5="4924827000f7f3e9f422fc884f2355fc">
+        <sourceinfo package="test_package" rev="4" vrev="23" srcmd5="e8c899f1f091a2445b1e492c8378945e" lsrcmd5="d111e2a1fb888c9f68ae95926e07a00d" verifymd5="62c2d9dc1d0cb2fc8540d9aca0ec1dab">
           <linked project="home:package_test_user" package="test_package" />
-          <revtime>1493380406</revtime>
+          <revtime>1516111272</revtime>
         </sourceinfo>
     http_version: 
-  recorded_at: Fri, 28 Apr 2017 11:53:26 GMT
+  recorded_at: Tue, 16 Jan 2018 14:01:12 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:package_test_user:branches:home:package_test_user/test_package
@@ -690,18 +693,19 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '636'
+      - '731'
     body:
       encoding: UTF-8
       string: |
-        <directory name="test_package" rev="1" vrev="1" srcmd5="afc6f2eac515eda05db7c4320c72c9d3">
-          <linkinfo project="home:package_test_user" package="test_package" srcmd5="4924827000f7f3e9f422fc884f2355fc" baserev="4924827000f7f3e9f422fc884f2355fc" xsrcmd5="f70da50f7b30aea1018b08e7845d9296" lsrcmd5="afc6f2eac515eda05db7c4320c72c9d3" />
-          <entry name="_config" md5="bddd97bab291296233ecbc17c4dce966" size="138" mtime="1493380405" />
-          <entry name="_link" md5="9608398184e12d4599f3d75e7e643ba7" size="130" mtime="1493380406" />
-          <entry name="somefile.txt" md5="62b28ae55f1c49beaefcdeb7002ba8ea" size="95" mtime="1493380405" />
+        <directory name="test_package" rev="4" vrev="4" srcmd5="d111e2a1fb888c9f68ae95926e07a00d">
+          <linkinfo project="home:package_test_user" package="test_package" srcmd5="62c2d9dc1d0cb2fc8540d9aca0ec1dab" baserev="62c2d9dc1d0cb2fc8540d9aca0ec1dab" xsrcmd5="e8c899f1f091a2445b1e492c8378945e" lsrcmd5="d111e2a1fb888c9f68ae95926e07a00d" />
+          <entry name="_config" md5="c4e0b762dfdda92c8a40bd96690ba617" size="76" mtime="1516111271" />
+          <entry name="_link" md5="21a39f738334cc12901ee0bd7f56c0c4" size="130" mtime="1516111272" />
+          <entry name="new_file" md5="d41d8cd98f00b204e9800998ecf8427e" size="0" mtime="1516111025" />
+          <entry name="somefile.txt" md5="478bacb4eb86846967edfa64ec6a5f9a" size="172" mtime="1516111242" />
         </directory>
     http_version: 
-  recorded_at: Fri, 28 Apr 2017 11:53:26 GMT
+  recorded_at: Tue, 16 Jan 2018 14:01:12 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:package_test_user:branches:home:package_test_user/test_package?cmd=diff&linkrev=base&onlyissues=1&orev=0&view=xml
@@ -733,15 +737,15 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="4009827b59a4181a6498363fbd7e5b76">
+        <sourcediff key="ba596d678a32ed5f3aeed7d037643d91">
           <old project="home:package_test_user:branches:home:package_test_user" package="test_package" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e" />
-          <new project="home:package_test_user:branches:home:package_test_user" package="test_package" rev="1" srcmd5="afc6f2eac515eda05db7c4320c72c9d3" />
+          <new project="home:package_test_user:branches:home:package_test_user" package="test_package" rev="4" srcmd5="d111e2a1fb888c9f68ae95926e07a00d" />
           <files />
           <issues>
           </issues>
         </sourcediff>
     http_version: 
-  recorded_at: Fri, 28 Apr 2017 11:53:26 GMT
+  recorded_at: Tue, 16 Jan 2018 14:01:12 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:package_test_user:branches:home:package_test_user/test_package?cmd=linkdiff&linkrev=base&onlyissues=1&view=xml
@@ -773,13 +777,13 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="0d782f9b15f3c7ec5df7fdf2d20c5266">
-          <old project="home:package_test_user" package="test_package" rev="4924827000f7f3e9f422fc884f2355fc" srcmd5="4924827000f7f3e9f422fc884f2355fc" />
-          <new project="home:package_test_user:branches:home:package_test_user" package="test_package" rev="f70da50f7b30aea1018b08e7845d9296" srcmd5="f70da50f7b30aea1018b08e7845d9296" />
+        <sourcediff key="3446674f3e1f91f119097f8ff6b279a6">
+          <old project="home:package_test_user" package="test_package" rev="62c2d9dc1d0cb2fc8540d9aca0ec1dab" srcmd5="62c2d9dc1d0cb2fc8540d9aca0ec1dab" />
+          <new project="home:package_test_user:branches:home:package_test_user" package="test_package" rev="e8c899f1f091a2445b1e492c8378945e" srcmd5="e8c899f1f091a2445b1e492c8378945e" />
           <files />
         </sourcediff>
     http_version: 
-  recorded_at: Fri, 28 Apr 2017 11:53:27 GMT
+  recorded_at: Tue, 16 Jan 2018 14:01:12 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:package_test_user:branches:home:package_test_user/_meta?user=package_test_user
@@ -826,7 +830,7 @@ http_interactions:
           </publish>
         </project>
     http_version: 
-  recorded_at: Fri, 28 Apr 2017 11:53:27 GMT
+  recorded_at: Tue, 16 Jan 2018 14:01:12 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:package_test_user/test_package?nofilename=1&view=info&withchangesmd5=1
@@ -852,15 +856,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '186'
+      - '188'
     body:
       encoding: UTF-8
       string: |
-        <sourceinfo package="test_package" rev="2" vrev="2" srcmd5="4924827000f7f3e9f422fc884f2355fc" verifymd5="4924827000f7f3e9f422fc884f2355fc">
-          <revtime>1493380405</revtime>
+        <sourceinfo package="test_package" rev="19" vrev="19" srcmd5="62c2d9dc1d0cb2fc8540d9aca0ec1dab" verifymd5="62c2d9dc1d0cb2fc8540d9aca0ec1dab">
+          <revtime>1516111271</revtime>
         </sourceinfo>
     http_version: 
-  recorded_at: Fri, 28 Apr 2017 11:53:28 GMT
+  recorded_at: Tue, 16 Jan 2018 14:01:12 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:package_test_user/test_package
@@ -886,16 +890,17 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '300'
+      - '397'
     body:
       encoding: UTF-8
       string: |
-        <directory name="test_package" rev="2" vrev="2" srcmd5="4924827000f7f3e9f422fc884f2355fc">
-          <entry name="_config" md5="bddd97bab291296233ecbc17c4dce966" size="138" mtime="1493380405" />
-          <entry name="somefile.txt" md5="62b28ae55f1c49beaefcdeb7002ba8ea" size="95" mtime="1493380405" />
+        <directory name="test_package" rev="19" vrev="19" srcmd5="62c2d9dc1d0cb2fc8540d9aca0ec1dab">
+          <entry name="_config" md5="c4e0b762dfdda92c8a40bd96690ba617" size="76" mtime="1516111271" />
+          <entry name="new_file" md5="d41d8cd98f00b204e9800998ecf8427e" size="0" mtime="1516111025" />
+          <entry name="somefile.txt" md5="478bacb4eb86846967edfa64ec6a5f9a" size="172" mtime="1516111242" />
         </directory>
     http_version: 
-  recorded_at: Fri, 28 Apr 2017 11:53:28 GMT
+  recorded_at: Tue, 16 Jan 2018 14:01:12 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:package_test_user/test_package?cmd=diff&linkrev=base&onlyissues=1&orev=0&view=xml
@@ -923,19 +928,19 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '333'
+      - '334'
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="cf304170f4aab469b8e2e924ad2dc142">
+        <sourcediff key="80169f5cc8b4072e4fd7dd2689973d5b">
           <old project="home:package_test_user" package="test_package" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e" />
-          <new project="home:package_test_user" package="test_package" rev="2" srcmd5="4924827000f7f3e9f422fc884f2355fc" />
+          <new project="home:package_test_user" package="test_package" rev="19" srcmd5="62c2d9dc1d0cb2fc8540d9aca0ec1dab" />
           <files />
           <issues>
           </issues>
         </sourcediff>
     http_version: 
-  recorded_at: Fri, 28 Apr 2017 11:53:28 GMT
+  recorded_at: Tue, 16 Jan 2018 14:01:12 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:package_test_user:branches:home:package_test_user/test_package
@@ -961,29 +966,28 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '636'
+      - '731'
     body:
       encoding: UTF-8
       string: |
-        <directory name="test_package" rev="1" vrev="1" srcmd5="afc6f2eac515eda05db7c4320c72c9d3">
-          <linkinfo project="home:package_test_user" package="test_package" srcmd5="4924827000f7f3e9f422fc884f2355fc" baserev="4924827000f7f3e9f422fc884f2355fc" xsrcmd5="f70da50f7b30aea1018b08e7845d9296" lsrcmd5="afc6f2eac515eda05db7c4320c72c9d3" />
-          <entry name="_config" md5="bddd97bab291296233ecbc17c4dce966" size="138" mtime="1493380405" />
-          <entry name="_link" md5="9608398184e12d4599f3d75e7e643ba7" size="130" mtime="1493380406" />
-          <entry name="somefile.txt" md5="62b28ae55f1c49beaefcdeb7002ba8ea" size="95" mtime="1493380405" />
+        <directory name="test_package" rev="4" vrev="4" srcmd5="d111e2a1fb888c9f68ae95926e07a00d">
+          <linkinfo project="home:package_test_user" package="test_package" srcmd5="62c2d9dc1d0cb2fc8540d9aca0ec1dab" baserev="62c2d9dc1d0cb2fc8540d9aca0ec1dab" xsrcmd5="e8c899f1f091a2445b1e492c8378945e" lsrcmd5="d111e2a1fb888c9f68ae95926e07a00d" />
+          <entry name="_config" md5="c4e0b762dfdda92c8a40bd96690ba617" size="76" mtime="1516111271" />
+          <entry name="_link" md5="21a39f738334cc12901ee0bd7f56c0c4" size="130" mtime="1516111272" />
+          <entry name="new_file" md5="d41d8cd98f00b204e9800998ecf8427e" size="0" mtime="1516111025" />
+          <entry name="somefile.txt" md5="478bacb4eb86846967edfa64ec6a5f9a" size="172" mtime="1516111242" />
         </directory>
     http_version: 
-  recorded_at: Fri, 28 Apr 2017 11:53:28 GMT
+  recorded_at: Tue, 16 Jan 2018 14:01:12 GMT
 - request:
     method: get
-    uri: http://backend:5352/source/home:package_test_user:branches:home:package_test_user/test_package?expand=1&rev=1
+    uri: http://backend:5352/source/home:package_test_user:branches:home:package_test_user/test_package?expand=1&rev=4
     body:
       encoding: US-ASCII
       string: ''
     headers:
-      Content-Type:
-      - text/plain
       Accept-Encoding:
-      - identity
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
       - "*/*"
       User-Agent:
@@ -1000,17 +1004,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '530'
+      - '626'
     body:
       encoding: UTF-8
       string: |
-        <directory name="test_package" rev="f70da50f7b30aea1018b08e7845d9296" vrev="3" srcmd5="f70da50f7b30aea1018b08e7845d9296">
-          <linkinfo project="home:package_test_user" package="test_package" srcmd5="4924827000f7f3e9f422fc884f2355fc" baserev="4924827000f7f3e9f422fc884f2355fc" lsrcmd5="afc6f2eac515eda05db7c4320c72c9d3" />
-          <entry name="_config" md5="bddd97bab291296233ecbc17c4dce966" size="138" mtime="1493380405" />
-          <entry name="somefile.txt" md5="62b28ae55f1c49beaefcdeb7002ba8ea" size="95" mtime="1493380405" />
+        <directory name="test_package" rev="e8c899f1f091a2445b1e492c8378945e" vrev="23" srcmd5="e8c899f1f091a2445b1e492c8378945e">
+          <linkinfo project="home:package_test_user" package="test_package" srcmd5="62c2d9dc1d0cb2fc8540d9aca0ec1dab" baserev="62c2d9dc1d0cb2fc8540d9aca0ec1dab" lsrcmd5="d111e2a1fb888c9f68ae95926e07a00d" />
+          <entry name="_config" md5="c4e0b762dfdda92c8a40bd96690ba617" size="76" mtime="1516111271" />
+          <entry name="new_file" md5="d41d8cd98f00b204e9800998ecf8427e" size="0" mtime="1516111025" />
+          <entry name="somefile.txt" md5="478bacb4eb86846967edfa64ec6a5f9a" size="172" mtime="1516111242" />
         </directory>
     http_version: 
-  recorded_at: Fri, 28 Apr 2017 11:53:28 GMT
+  recorded_at: Tue, 16 Jan 2018 14:01:12 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:package_test_user:branches:home:package_test_user/test_package
@@ -1038,18 +1043,19 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '636'
+      - '731'
     body:
       encoding: UTF-8
       string: |
-        <directory name="test_package" rev="1" vrev="1" srcmd5="afc6f2eac515eda05db7c4320c72c9d3">
-          <linkinfo project="home:package_test_user" package="test_package" srcmd5="4924827000f7f3e9f422fc884f2355fc" baserev="4924827000f7f3e9f422fc884f2355fc" xsrcmd5="f70da50f7b30aea1018b08e7845d9296" lsrcmd5="afc6f2eac515eda05db7c4320c72c9d3" />
-          <entry name="_config" md5="bddd97bab291296233ecbc17c4dce966" size="138" mtime="1493380405" />
-          <entry name="_link" md5="9608398184e12d4599f3d75e7e643ba7" size="130" mtime="1493380406" />
-          <entry name="somefile.txt" md5="62b28ae55f1c49beaefcdeb7002ba8ea" size="95" mtime="1493380405" />
+        <directory name="test_package" rev="4" vrev="4" srcmd5="d111e2a1fb888c9f68ae95926e07a00d">
+          <linkinfo project="home:package_test_user" package="test_package" srcmd5="62c2d9dc1d0cb2fc8540d9aca0ec1dab" baserev="62c2d9dc1d0cb2fc8540d9aca0ec1dab" xsrcmd5="e8c899f1f091a2445b1e492c8378945e" lsrcmd5="d111e2a1fb888c9f68ae95926e07a00d" />
+          <entry name="_config" md5="c4e0b762dfdda92c8a40bd96690ba617" size="76" mtime="1516111271" />
+          <entry name="_link" md5="21a39f738334cc12901ee0bd7f56c0c4" size="130" mtime="1516111272" />
+          <entry name="new_file" md5="d41d8cd98f00b204e9800998ecf8427e" size="0" mtime="1516111025" />
+          <entry name="somefile.txt" md5="478bacb4eb86846967edfa64ec6a5f9a" size="172" mtime="1516111242" />
         </directory>
     http_version: 
-  recorded_at: Fri, 28 Apr 2017 11:53:28 GMT
+  recorded_at: Tue, 16 Jan 2018 14:01:12 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:package_test_user:branches:home:package_test_user/test_package/_service
@@ -1086,7 +1092,7 @@ http_interactions:
           <details>404 _service: no such file</details>
         </status>
     http_version: 
-  recorded_at: Fri, 28 Apr 2017 11:53:28 GMT
+  recorded_at: Tue, 16 Jan 2018 14:01:12 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:package_test_user:branches:home:package_test_user/test_package/_history
@@ -1112,20 +1118,38 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '223'
+      - '799'
     body:
       encoding: UTF-8
       string: |
         <revisionlist>
           <revision rev="1" vrev="1">
-            <srcmd5>afc6f2eac515eda05db7c4320c72c9d3</srcmd5>
+            <srcmd5>ed9fd8ff4fc3313c7f3c6757751cf231</srcmd5>
             <version>unknown</version>
-            <time>1493380406</time>
+            <time>1516111037</time>
+            <user>package_test_user</user>
+          </revision>
+          <revision rev="2" vrev="2">
+            <srcmd5>9c53775171412be01f8e5f7a7fae0eb6</srcmd5>
+            <version>unknown</version>
+            <time>1516111039</time>
+            <user>package_test_user</user>
+          </revision>
+          <revision rev="3" vrev="3">
+            <srcmd5>fe2600104654231dc251c3e977c084d1</srcmd5>
+            <version>unknown</version>
+            <time>1516111269</time>
+            <user>package_test_user</user>
+          </revision>
+          <revision rev="4" vrev="4">
+            <srcmd5>d111e2a1fb888c9f68ae95926e07a00d</srcmd5>
+            <version>unknown</version>
+            <time>1516111272</time>
             <user>package_test_user</user>
           </revision>
         </revisionlist>
     http_version: 
-  recorded_at: Fri, 28 Apr 2017 11:53:30 GMT
+  recorded_at: Tue, 16 Jan 2018 14:01:12 GMT
 - request:
     method: get
     uri: http://backend:5352/build/home:package_test_user:branches:home:package_test_user/_result?package=test_package&view=status

--- a/src/api/spec/cassettes/Packages/adding_a_valid_file.yml
+++ b/src/api/spec/cassettes/Packages/adding_a_valid_file.yml
@@ -40,16 +40,16 @@ http_interactions:
           <person userid="package_test_user" role="maintainer" />
         </project>
     http_version: 
-  recorded_at: Wed, 03 May 2017 09:53:52 GMT
+  recorded_at: Tue, 16 Jan 2018 14:00:50 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:package_test_user/test_package/_meta?user=_nobody_
+    uri: http://backend:5352/source/home:package_test_user/test_package/_meta?user=package_test_user
     body:
       encoding: UTF-8
       string: |
         <package name="test_package" project="home:package_test_user">
-          <title>The Grapes of Wrath</title>
-          <description>Voluptatem aut aut molestiae dolores explicabo.</description>
+          <title>Dance Dance Dance</title>
+          <description>Et placeat itaque voluptatem delectus temporibus fuga rerum.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -70,16 +70,16 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '188'
+      - '199'
     body:
       encoding: UTF-8
       string: |
         <package name="test_package" project="home:package_test_user">
-          <title>The Grapes of Wrath</title>
-          <description>Voluptatem aut aut molestiae dolores explicabo.</description>
+          <title>Dance Dance Dance</title>
+          <description>Et placeat itaque voluptatem delectus temporibus fuga rerum.</description>
         </package>
     http_version: 
-  recorded_at: Wed, 03 May 2017 09:53:53 GMT
+  recorded_at: Tue, 16 Jan 2018 14:00:50 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:package_test_user/test_package/_meta
@@ -87,8 +87,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="test_package" project="home:package_test_user">
-          <title>The Grapes of Wrath</title>
-          <description>Voluptatem aut aut molestiae dolores explicabo.</description>
+          <title>Dance Dance Dance</title>
+          <description>Et placeat itaque voluptatem delectus temporibus fuga rerum.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -109,24 +109,23 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '188'
+      - '199'
     body:
       encoding: UTF-8
       string: |
         <package name="test_package" project="home:package_test_user">
-          <title>The Grapes of Wrath</title>
-          <description>Voluptatem aut aut molestiae dolores explicabo.</description>
+          <title>Dance Dance Dance</title>
+          <description>Et placeat itaque voluptatem delectus temporibus fuga rerum.</description>
         </package>
     http_version: 
-  recorded_at: Wed, 03 May 2017 09:53:53 GMT
+  recorded_at: Tue, 16 Jan 2018 14:00:50 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:package_test_user/test_package/_config
     body:
       encoding: UTF-8
-      string: Laudantium ut non velit. Repellat assumenda voluptatem ut. Sit officia
-        necessitatibus eius. Et quo sequi a suscipit. Ut nobis consectetur consequuntur
-        nihil quia officiis optio.
+      string: Fugiat accusantium quis voluptates. Et incidunt facere vel. Tenetur
+        minima exercitationem praesentium nihil omnis et. Possimus et a consectetur.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -150,23 +149,24 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <revision rev="4" vrev="4">
-          <srcmd5>dda1b945bf0ca918d12799b1e06cb143</srcmd5>
+        <revision rev="1" vrev="1">
+          <srcmd5>6c1a00da997ac81216c2927f5531d8a3</srcmd5>
           <version>unknown</version>
-          <time>1493805233</time>
+          <time>1516111250</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
     http_version: 
-  recorded_at: Wed, 03 May 2017 09:53:53 GMT
+  recorded_at: Tue, 16 Jan 2018 14:00:50 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:package_test_user/test_package/somefile.txt
     body:
       encoding: UTF-8
-      string: Ab consequatur sit dignissimos blanditiis. Iste est enim excepturi omnis
-        aut. Totam eius ut et impedit. A laborum cumque illum iusto nesciunt.
+      string: Officia quia repellendus quis. Velit ullam et. Praesentium dolorem quos
+        quae dolorum illum libero sit. Culpa officia autem voluptatem assumenda. Officiis
+        repudiandae et in.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -190,16 +190,16 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <revision rev="5" vrev="5">
-          <srcmd5>7b4289cee6697eac87cc00f69319cd01</srcmd5>
+        <revision rev="2" vrev="2">
+          <srcmd5>67f925b0f945b8133bc1cfc378b9a1e4</srcmd5>
           <version>unknown</version>
-          <time>1493805233</time>
+          <time>1516111250</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
     http_version: 
-  recorded_at: Wed, 03 May 2017 09:53:53 GMT
+  recorded_at: Tue, 16 Jan 2018 14:00:50 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:other_package_test_user/_meta?user=other_package_test_user
@@ -240,16 +240,16 @@ http_interactions:
           <person userid="other_package_test_user" role="maintainer" />
         </project>
     http_version: 
-  recorded_at: Wed, 03 May 2017 09:53:53 GMT
+  recorded_at: Tue, 16 Jan 2018 14:00:50 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:other_package_test_user/branch_test_package/_meta?user=_nobody_
+    uri: http://backend:5352/source/home:other_package_test_user/branch_test_package/_meta?user=package_test_user
     body:
       encoding: UTF-8
       string: |
         <package name="branch_test_package" project="home:other_package_test_user">
-          <title>Brandy of the Damned</title>
-          <description>Consequuntur ut voluptatem ut.</description>
+          <title>The Needle's Eye</title>
+          <description>Dignissimos necessitatibus natus quis molestiae suscipit eaque impedit.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -270,16 +270,16 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '185'
+      - '222'
     body:
       encoding: UTF-8
       string: |
         <package name="branch_test_package" project="home:other_package_test_user">
-          <title>Brandy of the Damned</title>
-          <description>Consequuntur ut voluptatem ut.</description>
+          <title>The Needle's Eye</title>
+          <description>Dignissimos necessitatibus natus quis molestiae suscipit eaque impedit.</description>
         </package>
     http_version: 
-  recorded_at: Wed, 03 May 2017 09:53:53 GMT
+  recorded_at: Tue, 16 Jan 2018 14:00:50 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:other_package_test_user/branch_test_package/_meta
@@ -287,8 +287,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="branch_test_package" project="home:other_package_test_user">
-          <title>Brandy of the Damned</title>
-          <description>Consequuntur ut voluptatem ut.</description>
+          <title>The Needle's Eye</title>
+          <description>Dignissimos necessitatibus natus quis molestiae suscipit eaque impedit.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -309,24 +309,24 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '185'
+      - '222'
     body:
       encoding: UTF-8
       string: |
         <package name="branch_test_package" project="home:other_package_test_user">
-          <title>Brandy of the Damned</title>
-          <description>Consequuntur ut voluptatem ut.</description>
+          <title>The Needle's Eye</title>
+          <description>Dignissimos necessitatibus natus quis molestiae suscipit eaque impedit.</description>
         </package>
     http_version: 
-  recorded_at: Wed, 03 May 2017 09:53:53 GMT
+  recorded_at: Tue, 16 Jan 2018 14:00:50 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:other_package_test_user/branch_test_package/_config
     body:
       encoding: UTF-8
-      string: Voluptas sint saepe nostrum. Hic voluptas delectus nobis. Pariatur sunt
-        aspernatur officia qui. Aut provident voluptatem consectetur velit sunt. Porro
-        est delectus consequatur consequatur voluptates omnis.
+      string: Voluptas porro eum beatae alias. Delectus architecto eligendi totam
+        sit harum. Fugiat necessitatibus fugit ut cum. Non sequi accusamus. Soluta
+        quae aliquam.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -346,27 +346,28 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '207'
+      - '209'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="3" vrev="3">
-          <srcmd5>a1d31f89c7391a68e2aa32722ed35dfe</srcmd5>
+        <revision rev="11" vrev="11">
+          <srcmd5>67882ce9cf0b9cd0c6e66d4fe5ca3aa3</srcmd5>
           <version>unknown</version>
-          <time>1493805233</time>
+          <time>1516111250</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
     http_version: 
-  recorded_at: Wed, 03 May 2017 09:53:53 GMT
+  recorded_at: Tue, 16 Jan 2018 14:00:50 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:other_package_test_user/branch_test_package/somefile.txt
     body:
       encoding: UTF-8
-      string: Enim deserunt repellat maxime ut inventore iusto. Ut quae qui harum
-        suscipit reiciendis qui quas. Nisi qui exercitationem quis sed et consequatur.
+      string: Officia quia repellendus quis. Velit ullam et. Praesentium dolorem quos
+        quae dolorum illum libero sit. Culpa officia autem voluptatem assumenda. Officiis
+        repudiandae et in.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -386,20 +387,20 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '207'
+      - '209'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="4" vrev="4">
-          <srcmd5>0bcbda6e3c5594a49d8e2c318d37ac94</srcmd5>
+        <revision rev="12" vrev="12">
+          <srcmd5>67882ce9cf0b9cd0c6e66d4fe5ca3aa3</srcmd5>
           <version>unknown</version>
-          <time>1493805233</time>
+          <time>1516111250</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
     http_version: 
-  recorded_at: Wed, 03 May 2017 09:53:53 GMT
+  recorded_at: Tue, 16 Jan 2018 14:00:50 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:package_test_user/test_package?nofilename=1&view=info&withchangesmd5=1
@@ -429,11 +430,11 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <sourceinfo package="test_package" rev="5" vrev="5" srcmd5="7b4289cee6697eac87cc00f69319cd01" verifymd5="7b4289cee6697eac87cc00f69319cd01">
-          <revtime>1493805233</revtime>
+        <sourceinfo package="test_package" rev="2" vrev="2" srcmd5="67f925b0f945b8133bc1cfc378b9a1e4" verifymd5="67f925b0f945b8133bc1cfc378b9a1e4">
+          <revtime>1516111250</revtime>
         </sourceinfo>
     http_version: 
-  recorded_at: Wed, 03 May 2017 09:53:58 GMT
+  recorded_at: Tue, 16 Jan 2018 14:00:51 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:package_test_user/test_package
@@ -459,17 +460,16 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '396'
+      - '301'
     body:
       encoding: UTF-8
       string: |
-        <directory name="test_package" rev="5" vrev="5" srcmd5="7b4289cee6697eac87cc00f69319cd01">
-          <entry name="_config" md5="99bae428fcb0b38c5a30a2abf0b2e2f2" size="177" mtime="1493805233" />
-          <entry name="new_file" md5="d41d8cd98f00b204e9800998ecf8427e" size="0" mtime="1493804926" />
-          <entry name="somefile.txt" md5="f75c44ef3eba688225f91ff914301b35" size="142" mtime="1493805233" />
+        <directory name="test_package" rev="2" vrev="2" srcmd5="67f925b0f945b8133bc1cfc378b9a1e4">
+          <entry name="_config" md5="e3fa422b2124745f8833c22d103cbd23" size="144" mtime="1516111250" />
+          <entry name="somefile.txt" md5="478bacb4eb86846967edfa64ec6a5f9a" size="172" mtime="1516111242" />
         </directory>
     http_version: 
-  recorded_at: Wed, 03 May 2017 09:53:58 GMT
+  recorded_at: Tue, 16 Jan 2018 14:00:51 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:package_test_user/test_package?cmd=diff&linkrev=base&onlyissues=1&orev=0&view=xml
@@ -501,15 +501,15 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="f505b93f3775be8d0a85901835db4edd">
+        <sourcediff key="9f940a5eda00a16b8fb7733e0d7ce12c">
           <old project="home:package_test_user" package="test_package" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e" />
-          <new project="home:package_test_user" package="test_package" rev="5" srcmd5="7b4289cee6697eac87cc00f69319cd01" />
+          <new project="home:package_test_user" package="test_package" rev="2" srcmd5="67f925b0f945b8133bc1cfc378b9a1e4" />
           <files />
           <issues>
           </issues>
         </sourcediff>
     http_version: 
-  recorded_at: Wed, 03 May 2017 09:53:58 GMT
+  recorded_at: Tue, 16 Jan 2018 14:00:51 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:package_test_user/test_package
@@ -535,28 +535,25 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '396'
+      - '301'
     body:
       encoding: UTF-8
       string: |
-        <directory name="test_package" rev="5" vrev="5" srcmd5="7b4289cee6697eac87cc00f69319cd01">
-          <entry name="_config" md5="99bae428fcb0b38c5a30a2abf0b2e2f2" size="177" mtime="1493805233" />
-          <entry name="new_file" md5="d41d8cd98f00b204e9800998ecf8427e" size="0" mtime="1493804926" />
-          <entry name="somefile.txt" md5="f75c44ef3eba688225f91ff914301b35" size="142" mtime="1493805233" />
+        <directory name="test_package" rev="2" vrev="2" srcmd5="67f925b0f945b8133bc1cfc378b9a1e4">
+          <entry name="_config" md5="e3fa422b2124745f8833c22d103cbd23" size="144" mtime="1516111250" />
+          <entry name="somefile.txt" md5="478bacb4eb86846967edfa64ec6a5f9a" size="172" mtime="1516111242" />
         </directory>
     http_version: 
-  recorded_at: Wed, 03 May 2017 09:53:58 GMT
+  recorded_at: Tue, 16 Jan 2018 14:00:51 GMT
 - request:
     method: get
-    uri: http://backend:5352/source/home:package_test_user/test_package?expand=1&rev=5
+    uri: http://backend:5352/source/home:package_test_user/test_package?expand=1&rev=2
     body:
       encoding: US-ASCII
       string: ''
     headers:
-      Content-Type:
-      - text/plain
       Accept-Encoding:
-      - identity
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
       - "*/*"
       User-Agent:
@@ -573,17 +570,16 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '396'
+      - '301'
     body:
       encoding: UTF-8
       string: |
-        <directory name="test_package" rev="5" vrev="5" srcmd5="7b4289cee6697eac87cc00f69319cd01">
-          <entry name="_config" md5="99bae428fcb0b38c5a30a2abf0b2e2f2" size="177" mtime="1493805233" />
-          <entry name="new_file" md5="d41d8cd98f00b204e9800998ecf8427e" size="0" mtime="1493804926" />
-          <entry name="somefile.txt" md5="f75c44ef3eba688225f91ff914301b35" size="142" mtime="1493805233" />
+        <directory name="test_package" rev="2" vrev="2" srcmd5="67f925b0f945b8133bc1cfc378b9a1e4">
+          <entry name="_config" md5="e3fa422b2124745f8833c22d103cbd23" size="144" mtime="1516111250" />
+          <entry name="somefile.txt" md5="478bacb4eb86846967edfa64ec6a5f9a" size="172" mtime="1516111242" />
         </directory>
     http_version: 
-  recorded_at: Wed, 03 May 2017 09:53:58 GMT
+  recorded_at: Tue, 16 Jan 2018 14:00:51 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:package_test_user/test_package
@@ -611,17 +607,16 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '396'
+      - '301'
     body:
       encoding: UTF-8
       string: |
-        <directory name="test_package" rev="5" vrev="5" srcmd5="7b4289cee6697eac87cc00f69319cd01">
-          <entry name="_config" md5="99bae428fcb0b38c5a30a2abf0b2e2f2" size="177" mtime="1493805233" />
-          <entry name="new_file" md5="d41d8cd98f00b204e9800998ecf8427e" size="0" mtime="1493804926" />
-          <entry name="somefile.txt" md5="f75c44ef3eba688225f91ff914301b35" size="142" mtime="1493805233" />
+        <directory name="test_package" rev="2" vrev="2" srcmd5="67f925b0f945b8133bc1cfc378b9a1e4">
+          <entry name="_config" md5="e3fa422b2124745f8833c22d103cbd23" size="144" mtime="1516111250" />
+          <entry name="somefile.txt" md5="478bacb4eb86846967edfa64ec6a5f9a" size="172" mtime="1516111242" />
         </directory>
     http_version: 
-  recorded_at: Wed, 03 May 2017 09:53:58 GMT
+  recorded_at: Tue, 16 Jan 2018 14:00:51 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:package_test_user/test_package/_service
@@ -658,7 +653,77 @@ http_interactions:
           <details>404 _service: no such file</details>
         </status>
     http_version: 
-  recorded_at: Wed, 03 May 2017 09:53:58 GMT
+  recorded_at: Tue, 16 Jan 2018 14:00:51 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:package_test_user/test_package
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '301'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="test_package" rev="2" vrev="2" srcmd5="67f925b0f945b8133bc1cfc378b9a1e4">
+          <entry name="_config" md5="e3fa422b2124745f8833c22d103cbd23" size="144" mtime="1516111250" />
+          <entry name="somefile.txt" md5="478bacb4eb86846967edfa64ec6a5f9a" size="172" mtime="1516111242" />
+        </directory>
+    http_version: 
+  recorded_at: Tue, 16 Jan 2018 14:00:51 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:package_test_user/test_package
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '301'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="test_package" rev="2" vrev="2" srcmd5="67f925b0f945b8133bc1cfc378b9a1e4">
+          <entry name="_config" md5="e3fa422b2124745f8833c22d103cbd23" size="144" mtime="1516111250" />
+          <entry name="somefile.txt" md5="478bacb4eb86846967edfa64ec6a5f9a" size="172" mtime="1516111242" />
+        </directory>
+    http_version: 
+  recorded_at: Tue, 16 Jan 2018 14:00:51 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:package_test_user/test_package/_history
@@ -684,44 +749,26 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '951'
+      - '395'
     body:
       encoding: UTF-8
       string: |
         <revisionlist>
           <revision rev="1" vrev="1">
-            <srcmd5>7569b1317080d3a53c0512ca16217cf9</srcmd5>
+            <srcmd5>6c1a00da997ac81216c2927f5531d8a3</srcmd5>
             <version>unknown</version>
-            <time>1493804920</time>
+            <time>1516111250</time>
             <user>unknown</user>
           </revision>
           <revision rev="2" vrev="2">
-            <srcmd5>57bc2cd2981ffaf86387cbf0614d90d8</srcmd5>
+            <srcmd5>67f925b0f945b8133bc1cfc378b9a1e4</srcmd5>
             <version>unknown</version>
-            <time>1493804920</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="3" vrev="3">
-            <srcmd5>c82f638d93ae4eee021498de8b63503d</srcmd5>
-            <version>unknown</version>
-            <time>1493804926</time>
-            <user>package_test_user</user>
-          </revision>
-          <revision rev="4" vrev="4">
-            <srcmd5>dda1b945bf0ca918d12799b1e06cb143</srcmd5>
-            <version>unknown</version>
-            <time>1493805233</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="5" vrev="5">
-            <srcmd5>7b4289cee6697eac87cc00f69319cd01</srcmd5>
-            <version>unknown</version>
-            <time>1493805233</time>
+            <time>1516111250</time>
             <user>unknown</user>
           </revision>
         </revisionlist>
     http_version: 
-  recorded_at: Wed, 03 May 2017 09:53:59 GMT
+  recorded_at: Tue, 16 Jan 2018 14:00:51 GMT
 - request:
     method: get
     uri: http://backend:5352/build/home:package_test_user/_result?package=test_package&view=status
@@ -756,7 +803,7 @@ http_interactions:
 
 '
     http_version: 
-  recorded_at: Wed, 03 May 2017 09:53:59 GMT
+  recorded_at: Tue, 16 Jan 2018 14:00:51 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:package_test_user/test_package
@@ -782,28 +829,25 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '396'
+      - '301'
     body:
       encoding: UTF-8
       string: |
-        <directory name="test_package" rev="5" vrev="5" srcmd5="7b4289cee6697eac87cc00f69319cd01">
-          <entry name="_config" md5="99bae428fcb0b38c5a30a2abf0b2e2f2" size="177" mtime="1493805233" />
-          <entry name="new_file" md5="d41d8cd98f00b204e9800998ecf8427e" size="0" mtime="1493804926" />
-          <entry name="somefile.txt" md5="f75c44ef3eba688225f91ff914301b35" size="142" mtime="1493805233" />
+        <directory name="test_package" rev="2" vrev="2" srcmd5="67f925b0f945b8133bc1cfc378b9a1e4">
+          <entry name="_config" md5="e3fa422b2124745f8833c22d103cbd23" size="144" mtime="1516111250" />
+          <entry name="somefile.txt" md5="478bacb4eb86846967edfa64ec6a5f9a" size="172" mtime="1516111242" />
         </directory>
     http_version: 
-  recorded_at: Wed, 03 May 2017 09:53:59 GMT
+  recorded_at: Tue, 16 Jan 2018 14:00:51 GMT
 - request:
     method: get
-    uri: http://backend:5352/source/home:package_test_user/test_package?rev=5
+    uri: http://backend:5352/source/home:package_test_user/test_package?rev=2
     body:
       encoding: US-ASCII
       string: ''
     headers:
-      Content-Type:
-      - text/plain
       Accept-Encoding:
-      - identity
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
       - "*/*"
       User-Agent:
@@ -820,17 +864,16 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '396'
+      - '301'
     body:
       encoding: UTF-8
       string: |
-        <directory name="test_package" rev="5" vrev="5" srcmd5="7b4289cee6697eac87cc00f69319cd01">
-          <entry name="_config" md5="99bae428fcb0b38c5a30a2abf0b2e2f2" size="177" mtime="1493805233" />
-          <entry name="new_file" md5="d41d8cd98f00b204e9800998ecf8427e" size="0" mtime="1493804926" />
-          <entry name="somefile.txt" md5="f75c44ef3eba688225f91ff914301b35" size="142" mtime="1493805233" />
+        <directory name="test_package" rev="2" vrev="2" srcmd5="67f925b0f945b8133bc1cfc378b9a1e4">
+          <entry name="_config" md5="e3fa422b2124745f8833c22d103cbd23" size="144" mtime="1516111250" />
+          <entry name="somefile.txt" md5="478bacb4eb86846967edfa64ec6a5f9a" size="172" mtime="1516111242" />
         </directory>
     http_version: 
-  recorded_at: Wed, 03 May 2017 09:53:59 GMT
+  recorded_at: Tue, 16 Jan 2018 14:00:51 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:package_test_user/test_package
@@ -858,17 +901,16 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '396'
+      - '301'
     body:
       encoding: UTF-8
       string: |
-        <directory name="test_package" rev="5" vrev="5" srcmd5="7b4289cee6697eac87cc00f69319cd01">
-          <entry name="_config" md5="99bae428fcb0b38c5a30a2abf0b2e2f2" size="177" mtime="1493805233" />
-          <entry name="new_file" md5="d41d8cd98f00b204e9800998ecf8427e" size="0" mtime="1493804926" />
-          <entry name="somefile.txt" md5="f75c44ef3eba688225f91ff914301b35" size="142" mtime="1493805233" />
+        <directory name="test_package" rev="2" vrev="2" srcmd5="67f925b0f945b8133bc1cfc378b9a1e4">
+          <entry name="_config" md5="e3fa422b2124745f8833c22d103cbd23" size="144" mtime="1516111250" />
+          <entry name="somefile.txt" md5="478bacb4eb86846967edfa64ec6a5f9a" size="172" mtime="1516111242" />
         </directory>
     http_version: 
-  recorded_at: Wed, 03 May 2017 09:53:59 GMT
+  recorded_at: Tue, 16 Jan 2018 14:00:51 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:package_test_user/test_package/new_file?user=package_test_user
@@ -902,16 +944,16 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <revision rev="6" vrev="6">
-          <srcmd5>7b4289cee6697eac87cc00f69319cd01</srcmd5>
+        <revision rev="3" vrev="3">
+          <srcmd5>828f2044d4611f0d07fe08703257e7d7</srcmd5>
           <version>unknown</version>
-          <time>1493805240</time>
+          <time>1516111252</time>
           <user>package_test_user</user>
           <comment></comment>
           <requestid/>
         </revision>
     http_version: 
-  recorded_at: Wed, 03 May 2017 09:54:00 GMT
+  recorded_at: Tue, 16 Jan 2018 14:00:52 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:package_test_user/test_package/_meta?user=package_test_user
@@ -919,8 +961,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="test_package" project="home:package_test_user">
-          <title>The Grapes of Wrath</title>
-          <description>Voluptatem aut aut molestiae dolores explicabo.</description>
+          <title>Dance Dance Dance</title>
+          <description>Et placeat itaque voluptatem delectus temporibus fuga rerum.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -941,16 +983,16 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '188'
+      - '199'
     body:
       encoding: UTF-8
       string: |
         <package name="test_package" project="home:package_test_user">
-          <title>The Grapes of Wrath</title>
-          <description>Voluptatem aut aut molestiae dolores explicabo.</description>
+          <title>Dance Dance Dance</title>
+          <description>Et placeat itaque voluptatem delectus temporibus fuga rerum.</description>
         </package>
     http_version: 
-  recorded_at: Wed, 03 May 2017 09:54:00 GMT
+  recorded_at: Tue, 16 Jan 2018 14:00:52 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:package_test_user/test_package
@@ -980,13 +1022,13 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="test_package" rev="6" vrev="6" srcmd5="7b4289cee6697eac87cc00f69319cd01">
-          <entry name="_config" md5="99bae428fcb0b38c5a30a2abf0b2e2f2" size="177" mtime="1493805233" />
-          <entry name="new_file" md5="d41d8cd98f00b204e9800998ecf8427e" size="0" mtime="1493804926" />
-          <entry name="somefile.txt" md5="f75c44ef3eba688225f91ff914301b35" size="142" mtime="1493805233" />
+        <directory name="test_package" rev="3" vrev="3" srcmd5="828f2044d4611f0d07fe08703257e7d7">
+          <entry name="_config" md5="e3fa422b2124745f8833c22d103cbd23" size="144" mtime="1516111250" />
+          <entry name="new_file" md5="d41d8cd98f00b204e9800998ecf8427e" size="0" mtime="1516111025" />
+          <entry name="somefile.txt" md5="478bacb4eb86846967edfa64ec6a5f9a" size="172" mtime="1516111242" />
         </directory>
     http_version: 
-  recorded_at: Wed, 03 May 2017 09:54:00 GMT
+  recorded_at: Tue, 16 Jan 2018 14:00:52 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:package_test_user/test_package?nofilename=1&view=info&withchangesmd5=1
@@ -1016,11 +1058,11 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <sourceinfo package="test_package" rev="6" vrev="6" srcmd5="7b4289cee6697eac87cc00f69319cd01" verifymd5="7b4289cee6697eac87cc00f69319cd01">
-          <revtime>1493805240</revtime>
+        <sourceinfo package="test_package" rev="3" vrev="3" srcmd5="828f2044d4611f0d07fe08703257e7d7" verifymd5="828f2044d4611f0d07fe08703257e7d7">
+          <revtime>1516111252</revtime>
         </sourceinfo>
     http_version: 
-  recorded_at: Wed, 03 May 2017 09:54:00 GMT
+  recorded_at: Tue, 16 Jan 2018 14:00:52 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:package_test_user/test_package
@@ -1050,13 +1092,13 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="test_package" rev="6" vrev="6" srcmd5="7b4289cee6697eac87cc00f69319cd01">
-          <entry name="_config" md5="99bae428fcb0b38c5a30a2abf0b2e2f2" size="177" mtime="1493805233" />
-          <entry name="new_file" md5="d41d8cd98f00b204e9800998ecf8427e" size="0" mtime="1493804926" />
-          <entry name="somefile.txt" md5="f75c44ef3eba688225f91ff914301b35" size="142" mtime="1493805233" />
+        <directory name="test_package" rev="3" vrev="3" srcmd5="828f2044d4611f0d07fe08703257e7d7">
+          <entry name="_config" md5="e3fa422b2124745f8833c22d103cbd23" size="144" mtime="1516111250" />
+          <entry name="new_file" md5="d41d8cd98f00b204e9800998ecf8427e" size="0" mtime="1516111025" />
+          <entry name="somefile.txt" md5="478bacb4eb86846967edfa64ec6a5f9a" size="172" mtime="1516111242" />
         </directory>
     http_version: 
-  recorded_at: Wed, 03 May 2017 09:54:00 GMT
+  recorded_at: Tue, 16 Jan 2018 14:00:52 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:package_test_user/test_package?cmd=diff&linkrev=base&onlyissues=1&orev=0&view=xml
@@ -1079,24 +1121,24 @@ http_interactions:
     headers:
       Content-Type:
       - text/xml
-      Content-Length:
-      - '333'
       Cache-Control:
       - no-cache
       Connection:
       - close
+      Content-Length:
+      - '333'
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="f505b93f3775be8d0a85901835db4edd">
+        <sourcediff key="59482cfb48b4cc3e59cfc5bb4ca90c9d">
           <old project="home:package_test_user" package="test_package" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e" />
-          <new project="home:package_test_user" package="test_package" rev="5" srcmd5="7b4289cee6697eac87cc00f69319cd01" />
+          <new project="home:package_test_user" package="test_package" rev="3" srcmd5="828f2044d4611f0d07fe08703257e7d7" />
           <files />
           <issues>
           </issues>
         </sourcediff>
     http_version: 
-  recorded_at: Wed, 03 May 2017 09:54:00 GMT
+  recorded_at: Tue, 16 Jan 2018 14:00:52 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:package_test_user/test_package
@@ -1126,24 +1168,22 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="test_package" rev="6" vrev="6" srcmd5="7b4289cee6697eac87cc00f69319cd01">
-          <entry name="_config" md5="99bae428fcb0b38c5a30a2abf0b2e2f2" size="177" mtime="1493805233" />
-          <entry name="new_file" md5="d41d8cd98f00b204e9800998ecf8427e" size="0" mtime="1493804926" />
-          <entry name="somefile.txt" md5="f75c44ef3eba688225f91ff914301b35" size="142" mtime="1493805233" />
+        <directory name="test_package" rev="3" vrev="3" srcmd5="828f2044d4611f0d07fe08703257e7d7">
+          <entry name="_config" md5="e3fa422b2124745f8833c22d103cbd23" size="144" mtime="1516111250" />
+          <entry name="new_file" md5="d41d8cd98f00b204e9800998ecf8427e" size="0" mtime="1516111025" />
+          <entry name="somefile.txt" md5="478bacb4eb86846967edfa64ec6a5f9a" size="172" mtime="1516111242" />
         </directory>
     http_version: 
-  recorded_at: Wed, 03 May 2017 09:54:00 GMT
+  recorded_at: Tue, 16 Jan 2018 14:00:52 GMT
 - request:
     method: get
-    uri: http://backend:5352/source/home:package_test_user/test_package?expand=1&rev=6
+    uri: http://backend:5352/source/home:package_test_user/test_package?expand=1&rev=3
     body:
       encoding: US-ASCII
       string: ''
     headers:
-      Content-Type:
-      - text/plain
       Accept-Encoding:
-      - identity
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
       - "*/*"
       User-Agent:
@@ -1164,13 +1204,13 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="test_package" rev="6" vrev="6" srcmd5="7b4289cee6697eac87cc00f69319cd01">
-          <entry name="_config" md5="99bae428fcb0b38c5a30a2abf0b2e2f2" size="177" mtime="1493805233" />
-          <entry name="new_file" md5="d41d8cd98f00b204e9800998ecf8427e" size="0" mtime="1493804926" />
-          <entry name="somefile.txt" md5="f75c44ef3eba688225f91ff914301b35" size="142" mtime="1493805233" />
+        <directory name="test_package" rev="3" vrev="3" srcmd5="828f2044d4611f0d07fe08703257e7d7">
+          <entry name="_config" md5="e3fa422b2124745f8833c22d103cbd23" size="144" mtime="1516111250" />
+          <entry name="new_file" md5="d41d8cd98f00b204e9800998ecf8427e" size="0" mtime="1516111025" />
+          <entry name="somefile.txt" md5="478bacb4eb86846967edfa64ec6a5f9a" size="172" mtime="1516111242" />
         </directory>
     http_version: 
-  recorded_at: Wed, 03 May 2017 09:54:00 GMT
+  recorded_at: Tue, 16 Jan 2018 14:00:52 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:package_test_user/test_package
@@ -1202,13 +1242,13 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="test_package" rev="6" vrev="6" srcmd5="7b4289cee6697eac87cc00f69319cd01">
-          <entry name="_config" md5="99bae428fcb0b38c5a30a2abf0b2e2f2" size="177" mtime="1493805233" />
-          <entry name="new_file" md5="d41d8cd98f00b204e9800998ecf8427e" size="0" mtime="1493804926" />
-          <entry name="somefile.txt" md5="f75c44ef3eba688225f91ff914301b35" size="142" mtime="1493805233" />
+        <directory name="test_package" rev="3" vrev="3" srcmd5="828f2044d4611f0d07fe08703257e7d7">
+          <entry name="_config" md5="e3fa422b2124745f8833c22d103cbd23" size="144" mtime="1516111250" />
+          <entry name="new_file" md5="d41d8cd98f00b204e9800998ecf8427e" size="0" mtime="1516111025" />
+          <entry name="somefile.txt" md5="478bacb4eb86846967edfa64ec6a5f9a" size="172" mtime="1516111242" />
         </directory>
     http_version: 
-  recorded_at: Wed, 03 May 2017 09:54:00 GMT
+  recorded_at: Tue, 16 Jan 2018 14:00:52 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:package_test_user/test_package/_service
@@ -1245,7 +1285,79 @@ http_interactions:
           <details>404 _service: no such file</details>
         </status>
     http_version: 
-  recorded_at: Wed, 03 May 2017 09:54:00 GMT
+  recorded_at: Tue, 16 Jan 2018 14:00:52 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:package_test_user/test_package
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '396'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="test_package" rev="3" vrev="3" srcmd5="828f2044d4611f0d07fe08703257e7d7">
+          <entry name="_config" md5="e3fa422b2124745f8833c22d103cbd23" size="144" mtime="1516111250" />
+          <entry name="new_file" md5="d41d8cd98f00b204e9800998ecf8427e" size="0" mtime="1516111025" />
+          <entry name="somefile.txt" md5="478bacb4eb86846967edfa64ec6a5f9a" size="172" mtime="1516111242" />
+        </directory>
+    http_version: 
+  recorded_at: Tue, 16 Jan 2018 14:00:52 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:package_test_user/test_package
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '396'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="test_package" rev="3" vrev="3" srcmd5="828f2044d4611f0d07fe08703257e7d7">
+          <entry name="_config" md5="e3fa422b2124745f8833c22d103cbd23" size="144" mtime="1516111250" />
+          <entry name="new_file" md5="d41d8cd98f00b204e9800998ecf8427e" size="0" mtime="1516111025" />
+          <entry name="somefile.txt" md5="478bacb4eb86846967edfa64ec6a5f9a" size="172" mtime="1516111242" />
+        </directory>
+    http_version: 
+  recorded_at: Tue, 16 Jan 2018 14:00:52 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:package_test_user/test_package/_history
@@ -1271,50 +1383,32 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '1143'
+      - '587'
     body:
       encoding: UTF-8
       string: |
         <revisionlist>
           <revision rev="1" vrev="1">
-            <srcmd5>7569b1317080d3a53c0512ca16217cf9</srcmd5>
+            <srcmd5>6c1a00da997ac81216c2927f5531d8a3</srcmd5>
             <version>unknown</version>
-            <time>1493804920</time>
+            <time>1516111250</time>
             <user>unknown</user>
           </revision>
           <revision rev="2" vrev="2">
-            <srcmd5>57bc2cd2981ffaf86387cbf0614d90d8</srcmd5>
+            <srcmd5>67f925b0f945b8133bc1cfc378b9a1e4</srcmd5>
             <version>unknown</version>
-            <time>1493804920</time>
+            <time>1516111250</time>
             <user>unknown</user>
           </revision>
           <revision rev="3" vrev="3">
-            <srcmd5>c82f638d93ae4eee021498de8b63503d</srcmd5>
+            <srcmd5>828f2044d4611f0d07fe08703257e7d7</srcmd5>
             <version>unknown</version>
-            <time>1493804926</time>
-            <user>package_test_user</user>
-          </revision>
-          <revision rev="4" vrev="4">
-            <srcmd5>dda1b945bf0ca918d12799b1e06cb143</srcmd5>
-            <version>unknown</version>
-            <time>1493805233</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="5" vrev="5">
-            <srcmd5>7b4289cee6697eac87cc00f69319cd01</srcmd5>
-            <version>unknown</version>
-            <time>1493805233</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="6" vrev="6">
-            <srcmd5>7b4289cee6697eac87cc00f69319cd01</srcmd5>
-            <version>unknown</version>
-            <time>1493805240</time>
+            <time>1516111252</time>
             <user>package_test_user</user>
           </revision>
         </revisionlist>
     http_version: 
-  recorded_at: Wed, 03 May 2017 09:54:00 GMT
+  recorded_at: Tue, 16 Jan 2018 14:00:52 GMT
 - request:
     method: get
     uri: http://backend:5352/build/home:package_test_user/_result?package=test_package&view=status
@@ -1349,231 +1443,16 @@ http_interactions:
 
 '
     http_version: 
-  recorded_at: Wed, 03 May 2017 09:54:00 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/home:package_test_user/test_package?expand=1
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Content-Type:
-      - text/plain
-      Accept-Encoding:
-      - identity
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '396'
-    body:
-      encoding: UTF-8
-      string: |
-        <directory name="test_package" rev="6" vrev="6" srcmd5="7b4289cee6697eac87cc00f69319cd01">
-          <entry name="_config" md5="99bae428fcb0b38c5a30a2abf0b2e2f2" size="177" mtime="1493805233" />
-          <entry name="new_file" md5="d41d8cd98f00b204e9800998ecf8427e" size="0" mtime="1493804926" />
-          <entry name="somefile.txt" md5="f75c44ef3eba688225f91ff914301b35" size="142" mtime="1493805233" />
-        </directory>
-    http_version: 
-  recorded_at: Wed, 03 May 2017 09:54:01 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/home:package_test_user/test_package/new_file?expand=1
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/octet-stream
-      Content-Length:
-      - '0'
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-    body:
-      encoding: UTF-8
-      string: ''
-    http_version: 
-  recorded_at: Wed, 03 May 2017 09:54:01 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/home:package_test_user/test_package
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Content-Type:
-      - text/plain
-      Accept-Encoding:
-      - identity
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 404
-      message: project 'home package_test_user' does not exist
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '172'
-    body:
-      encoding: UTF-8
-      string: |
-        <status code="404">
-          <summary>project 'home:package_test_user' does not exist</summary>
-          <details>404 project 'home:package_test_user' does not exist</details>
-        </status>
-    http_version: 
-  recorded_at: Fri, 16 Jun 2017 14:23:11 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/home:package_test_user/test_package
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 404
-      message: project 'home package_test_user' does not exist
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '172'
-    body:
-      encoding: UTF-8
-      string: |
-        <status code="404">
-          <summary>project 'home:package_test_user' does not exist</summary>
-          <details>404 project 'home:package_test_user' does not exist</details>
-        </status>
-    http_version: 
-  recorded_at: Fri, 16 Jun 2017 14:23:11 GMT
+  recorded_at: Tue, 16 Jan 2018 14:00:52 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:other_package_test_user/branch_test_package/_meta?user=package_test_user
-    body:
-      encoding: UTF-8
-      string: |
-        <package name="branch_test_package" project="home:other_package_test_user">
-          <title>This Side of Paradise</title>
-          <description>Minus est iste sit voluptas deleniti.</description>
-        </package>
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '193'
-    body:
-      encoding: UTF-8
-      string: |
-        <package name="branch_test_package" project="home:other_package_test_user">
-          <title>This Side of Paradise</title>
-          <description>Minus est iste sit voluptas deleniti.</description>
-        </package>
-    http_version: 
-  recorded_at: Wed, 03 Jan 2018 13:13:18 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/home:package_test_user/test_package?rev=6
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 404
-      message: package 'test_package' does not exist
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '152'
-    body:
-      encoding: UTF-8
-      string: |
-        <status code="404">
-          <summary>package 'test_package' does not exist</summary>
-          <details>404 package 'test_package' does not exist</details>
-        </status>
-    http_version: 
-  recorded_at: Wed, 03 Jan 2018 13:13:20 GMT
-- request:
-    method: put
-    uri: http://backend:5352/source/home:package_test_user/test_package/_meta?user=package_test_user
+    uri: http://backend:5352/source/home:package_test_user/test_package/_meta?user=_nobody_
     body:
       encoding: UTF-8
       string: |
         <package name="test_package" project="home:package_test_user">
-          <title>Butter In a Lordly Dish</title>
-          <description>Tempore corporis odit dolorem.</description>
+          <title>Behold the Man</title>
+          <description>Quis quia et ducimus necessitatibus et perferendis iste.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -1594,22 +1473,26 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '175'
+      - '192'
     body:
       encoding: UTF-8
       string: |
         <package name="test_package" project="home:package_test_user">
-          <title>Butter In a Lordly Dish</title>
-          <description>Tempore corporis odit dolorem.</description>
+          <title>Behold the Man</title>
+          <description>Quis quia et ducimus necessitatibus et perferendis iste.</description>
         </package>
     http_version: 
-  recorded_at: Wed, 03 Jan 2018 13:13:21 GMT
+  recorded_at: Tue, 16 Jan 2018 14:03:06 GMT
 - request:
-    method: get
-    uri: http://backend:5352/source/home:package_test_user/test_package
+    method: put
+    uri: http://backend:5352/source/home:other_package_test_user/branch_test_package/_meta?user=_nobody_
     body:
-      encoding: US-ASCII
-      string: ''
+      encoding: UTF-8
+      string: |
+        <package name="branch_test_package" project="home:other_package_test_user">
+          <title>When the Green Woods Laugh</title>
+          <description>Sunt ullam omnis sed iusto ex voluptatibus vel aut.</description>
+        </package>
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -1629,12 +1512,14 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '87'
+      - '212'
     body:
       encoding: UTF-8
       string: |
-        <directory name="test_package" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
-        </directory>
+        <package name="branch_test_package" project="home:other_package_test_user">
+          <title>When the Green Woods Laugh</title>
+          <description>Sunt ullam omnis sed iusto ex voluptatibus vel aut.</description>
+        </package>
     http_version: 
   recorded_at: Wed, 03 Jan 2018 13:13:21 GMT
 - request:

--- a/src/api/spec/cassettes/Packages/adding_an_invalid_file.yml
+++ b/src/api/spec/cassettes/Packages/adding_an_invalid_file.yml
@@ -40,16 +40,16 @@ http_interactions:
           <person userid="package_test_user" role="maintainer" />
         </project>
     http_version: 
-  recorded_at: Wed, 03 May 2017 10:00:13 GMT
+  recorded_at: Tue, 16 Jan 2018 14:00:56 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:package_test_user/test_package/_meta?user=_nobody_
+    uri: http://backend:5352/source/home:package_test_user/test_package/_meta?user=package_test_user
     body:
       encoding: UTF-8
       string: |
         <package name="test_package" project="home:package_test_user">
-          <title>Those Barren Leaves, Thrones, Dominations</title>
-          <description>Officia est et deleniti veritatis esse molestiae.</description>
+          <title>The House of Mirth</title>
+          <description>Rerum soluta saepe tempore fugiat fugit.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -70,16 +70,16 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '212'
+      - '180'
     body:
       encoding: UTF-8
       string: |
         <package name="test_package" project="home:package_test_user">
-          <title>Those Barren Leaves, Thrones, Dominations</title>
-          <description>Officia est et deleniti veritatis esse molestiae.</description>
+          <title>The House of Mirth</title>
+          <description>Rerum soluta saepe tempore fugiat fugit.</description>
         </package>
     http_version: 
-  recorded_at: Wed, 03 May 2017 10:00:13 GMT
+  recorded_at: Tue, 16 Jan 2018 14:00:56 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:package_test_user/test_package/_meta
@@ -87,8 +87,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="test_package" project="home:package_test_user">
-          <title>Those Barren Leaves, Thrones, Dominations</title>
-          <description>Officia est et deleniti veritatis esse molestiae.</description>
+          <title>The House of Mirth</title>
+          <description>Rerum soluta saepe tempore fugiat fugit.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -109,24 +109,23 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '212'
+      - '180'
     body:
       encoding: UTF-8
       string: |
         <package name="test_package" project="home:package_test_user">
-          <title>Those Barren Leaves, Thrones, Dominations</title>
-          <description>Officia est et deleniti veritatis esse molestiae.</description>
+          <title>The House of Mirth</title>
+          <description>Rerum soluta saepe tempore fugiat fugit.</description>
         </package>
     http_version: 
-  recorded_at: Wed, 03 May 2017 10:00:13 GMT
+  recorded_at: Tue, 16 Jan 2018 14:00:56 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:package_test_user/test_package/_config
     body:
       encoding: UTF-8
-      string: Reiciendis veniam cum. Ipsam tenetur qui et deleniti. Dolor dolorum
-        voluptas nesciunt ratione perspiciatis vel. Nihil quo temporibus. Ipsa debitis
-        cumque laudantium voluptatem sunt sed voluptas.
+      string: Reprehenderit nulla dolores molestias quis inventore suscipit quam.
+        Voluptas labore est impedit iure ut voluptatem. Pariatur autem consectetur.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -146,28 +145,28 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '209'
+      - '207'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="10" vrev="10">
-          <srcmd5>b8033f0450075fbc0fa2c8e2399ea859</srcmd5>
+        <revision rev="6" vrev="6">
+          <srcmd5>b3a56ec31c57bd08b4461f66d056857f</srcmd5>
           <version>unknown</version>
-          <time>1493805613</time>
+          <time>1516111256</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
     http_version: 
-  recorded_at: Wed, 03 May 2017 10:00:13 GMT
+  recorded_at: Tue, 16 Jan 2018 14:00:56 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:package_test_user/test_package/somefile.txt
     body:
       encoding: UTF-8
-      string: Enim molestiae nihil officia fuga aut. Aut sed est. Dicta unde officia
-        et qui doloremque. Voluptatibus et eius. Beatae necessitatibus quibusdam veniam
-        iusto repudiandae reiciendis cum.
+      string: Officia quia repellendus quis. Velit ullam et. Praesentium dolorem quos
+        quae dolorum illum libero sit. Culpa officia autem voluptatem assumenda. Officiis
+        repudiandae et in.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -187,20 +186,20 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '209'
+      - '207'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="11" vrev="11">
-          <srcmd5>94d6538c9c5ba94932bc034e7115ba7b</srcmd5>
+        <revision rev="7" vrev="7">
+          <srcmd5>b3a56ec31c57bd08b4461f66d056857f</srcmd5>
           <version>unknown</version>
-          <time>1493805613</time>
+          <time>1516111256</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
     http_version: 
-  recorded_at: Wed, 03 May 2017 10:00:13 GMT
+  recorded_at: Tue, 16 Jan 2018 14:00:56 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:other_package_test_user/_meta?user=other_package_test_user
@@ -241,16 +240,16 @@ http_interactions:
           <person userid="other_package_test_user" role="maintainer" />
         </project>
     http_version: 
-  recorded_at: Wed, 03 May 2017 10:00:14 GMT
+  recorded_at: Tue, 16 Jan 2018 14:00:56 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:other_package_test_user/branch_test_package/_meta?user=_nobody_
+    uri: http://backend:5352/source/home:other_package_test_user/branch_test_package/_meta?user=package_test_user
     body:
       encoding: UTF-8
       string: |
         <package name="branch_test_package" project="home:other_package_test_user">
-          <title>Clouds of Witness</title>
-          <description>Quo omnis est eligendi dignissimos reprehenderit et debitis.</description>
+          <title>The Road Less Traveled</title>
+          <description>Ducimus officia ex nostrum veritatis et.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -271,16 +270,16 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '212'
+      - '197'
     body:
       encoding: UTF-8
       string: |
         <package name="branch_test_package" project="home:other_package_test_user">
-          <title>Clouds of Witness</title>
-          <description>Quo omnis est eligendi dignissimos reprehenderit et debitis.</description>
+          <title>The Road Less Traveled</title>
+          <description>Ducimus officia ex nostrum veritatis et.</description>
         </package>
     http_version: 
-  recorded_at: Wed, 03 May 2017 10:00:14 GMT
+  recorded_at: Tue, 16 Jan 2018 14:00:56 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:other_package_test_user/branch_test_package/_meta
@@ -288,8 +287,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="branch_test_package" project="home:other_package_test_user">
-          <title>Clouds of Witness</title>
-          <description>Quo omnis est eligendi dignissimos reprehenderit et debitis.</description>
+          <title>The Road Less Traveled</title>
+          <description>Ducimus officia ex nostrum veritatis et.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -310,24 +309,24 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '212'
+      - '197'
     body:
       encoding: UTF-8
       string: |
         <package name="branch_test_package" project="home:other_package_test_user">
-          <title>Clouds of Witness</title>
-          <description>Quo omnis est eligendi dignissimos reprehenderit et debitis.</description>
+          <title>The Road Less Traveled</title>
+          <description>Ducimus officia ex nostrum veritatis et.</description>
         </package>
     http_version: 
-  recorded_at: Wed, 03 May 2017 10:00:14 GMT
+  recorded_at: Tue, 16 Jan 2018 14:00:56 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:other_package_test_user/branch_test_package/_config
     body:
       encoding: UTF-8
-      string: Minima ratione nisi ea dolores. Officia illo quam error id. Eius quia
-        distinctio veniam consequatur quis molestiae. Architecto id et enim hic. Et
-        aut voluptate et.
+      string: Ad facere ab voluptas. Aut et numquam qui sit eligendi. Itaque fuga
+        quam ipsa officia. Sed et autem facilis incidunt dolores deserunt. Temporibus
+        et eaque.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -347,27 +346,28 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '207'
+      - '209'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="7" vrev="7">
-          <srcmd5>16de48c6f0f2f944a3de065d0015eafd</srcmd5>
+        <revision rev="15" vrev="15">
+          <srcmd5>a769cf3068078df20b20258ebc5774d4</srcmd5>
           <version>unknown</version>
-          <time>1493805614</time>
+          <time>1516111256</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
     http_version: 
-  recorded_at: Wed, 03 May 2017 10:00:14 GMT
+  recorded_at: Tue, 16 Jan 2018 14:00:56 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:other_package_test_user/branch_test_package/somefile.txt
     body:
       encoding: UTF-8
-      string: Ullam vitae maiores totam. Aut nulla mollitia tenetur ad assumenda temporibus.
-        Beatae non quas ea sed ad.
+      string: Officia quia repellendus quis. Velit ullam et. Praesentium dolorem quos
+        quae dolorum illum libero sit. Culpa officia autem voluptatem assumenda. Officiis
+        repudiandae et in.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -387,20 +387,20 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '207'
+      - '209'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="8" vrev="8">
-          <srcmd5>7e786a9e90601b894fa41eecedc426c5</srcmd5>
+        <revision rev="16" vrev="16">
+          <srcmd5>a769cf3068078df20b20258ebc5774d4</srcmd5>
           <version>unknown</version>
-          <time>1493805614</time>
+          <time>1516111256</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
     http_version: 
-  recorded_at: Wed, 03 May 2017 10:00:14 GMT
+  recorded_at: Tue, 16 Jan 2018 14:00:56 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:package_test_user/test_package?nofilename=1&view=info&withchangesmd5=1
@@ -426,15 +426,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '188'
+      - '186'
     body:
       encoding: UTF-8
       string: |
-        <sourceinfo package="test_package" rev="11" vrev="11" srcmd5="94d6538c9c5ba94932bc034e7115ba7b" verifymd5="94d6538c9c5ba94932bc034e7115ba7b">
-          <revtime>1493805613</revtime>
+        <sourceinfo package="test_package" rev="7" vrev="7" srcmd5="b3a56ec31c57bd08b4461f66d056857f" verifymd5="b3a56ec31c57bd08b4461f66d056857f">
+          <revtime>1516111256</revtime>
         </sourceinfo>
     http_version: 
-  recorded_at: Wed, 03 May 2017 10:00:19 GMT
+  recorded_at: Tue, 16 Jan 2018 14:00:57 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:package_test_user/test_package
@@ -460,18 +460,17 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '498'
+      - '396'
     body:
       encoding: UTF-8
       string: |
-        <directory name="test_package" rev="11" vrev="11" srcmd5="94d6538c9c5ba94932bc034e7115ba7b">
-          <entry name="_config" md5="987fd35006ffa84b8480bc8e63371630" size="194" mtime="1493805613" />
-          <entry name="_invalid_file" md5="d41d8cd98f00b204e9800998ecf8427e" size="0" mtime="1493805327" />
-          <entry name="new_file" md5="d41d8cd98f00b204e9800998ecf8427e" size="0" mtime="1493804926" />
-          <entry name="somefile.txt" md5="d3e04ff6e702e1677847fc385e775c0a" size="184" mtime="1493805613" />
+        <directory name="test_package" rev="7" vrev="7" srcmd5="b3a56ec31c57bd08b4461f66d056857f">
+          <entry name="_config" md5="87f6bb90bf562adbd404890911424a30" size="143" mtime="1516111256" />
+          <entry name="new_file" md5="d41d8cd98f00b204e9800998ecf8427e" size="0" mtime="1516111025" />
+          <entry name="somefile.txt" md5="478bacb4eb86846967edfa64ec6a5f9a" size="172" mtime="1516111242" />
         </directory>
     http_version: 
-  recorded_at: Wed, 03 May 2017 10:00:19 GMT
+  recorded_at: Tue, 16 Jan 2018 14:00:57 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:package_test_user/test_package?cmd=diff&linkrev=base&onlyissues=1&orev=0&view=xml
@@ -499,19 +498,19 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '334'
+      - '333'
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="31da62fc26f81552d01df4c4550f1581">
+        <sourcediff key="6920c8639b158ffd2cf39287f1465256">
           <old project="home:package_test_user" package="test_package" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e" />
-          <new project="home:package_test_user" package="test_package" rev="11" srcmd5="94d6538c9c5ba94932bc034e7115ba7b" />
+          <new project="home:package_test_user" package="test_package" rev="7" srcmd5="b3a56ec31c57bd08b4461f66d056857f" />
           <files />
           <issues>
           </issues>
         </sourcediff>
     http_version: 
-  recorded_at: Wed, 03 May 2017 10:00:19 GMT
+  recorded_at: Tue, 16 Jan 2018 14:00:57 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:package_test_user/test_package
@@ -537,29 +536,26 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '498'
+      - '396'
     body:
       encoding: UTF-8
       string: |
-        <directory name="test_package" rev="11" vrev="11" srcmd5="94d6538c9c5ba94932bc034e7115ba7b">
-          <entry name="_config" md5="987fd35006ffa84b8480bc8e63371630" size="194" mtime="1493805613" />
-          <entry name="_invalid_file" md5="d41d8cd98f00b204e9800998ecf8427e" size="0" mtime="1493805327" />
-          <entry name="new_file" md5="d41d8cd98f00b204e9800998ecf8427e" size="0" mtime="1493804926" />
-          <entry name="somefile.txt" md5="d3e04ff6e702e1677847fc385e775c0a" size="184" mtime="1493805613" />
+        <directory name="test_package" rev="7" vrev="7" srcmd5="b3a56ec31c57bd08b4461f66d056857f">
+          <entry name="_config" md5="87f6bb90bf562adbd404890911424a30" size="143" mtime="1516111256" />
+          <entry name="new_file" md5="d41d8cd98f00b204e9800998ecf8427e" size="0" mtime="1516111025" />
+          <entry name="somefile.txt" md5="478bacb4eb86846967edfa64ec6a5f9a" size="172" mtime="1516111242" />
         </directory>
     http_version: 
-  recorded_at: Wed, 03 May 2017 10:00:19 GMT
+  recorded_at: Tue, 16 Jan 2018 14:00:57 GMT
 - request:
     method: get
-    uri: http://backend:5352/source/home:package_test_user/test_package?expand=1&rev=11
+    uri: http://backend:5352/source/home:package_test_user/test_package?expand=1&rev=7
     body:
       encoding: US-ASCII
       string: ''
     headers:
-      Content-Type:
-      - text/plain
       Accept-Encoding:
-      - identity
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
       - "*/*"
       User-Agent:
@@ -576,18 +572,17 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '498'
+      - '396'
     body:
       encoding: UTF-8
       string: |
-        <directory name="test_package" rev="11" vrev="11" srcmd5="94d6538c9c5ba94932bc034e7115ba7b">
-          <entry name="_config" md5="987fd35006ffa84b8480bc8e63371630" size="194" mtime="1493805613" />
-          <entry name="_invalid_file" md5="d41d8cd98f00b204e9800998ecf8427e" size="0" mtime="1493805327" />
-          <entry name="new_file" md5="d41d8cd98f00b204e9800998ecf8427e" size="0" mtime="1493804926" />
-          <entry name="somefile.txt" md5="d3e04ff6e702e1677847fc385e775c0a" size="184" mtime="1493805613" />
+        <directory name="test_package" rev="7" vrev="7" srcmd5="b3a56ec31c57bd08b4461f66d056857f">
+          <entry name="_config" md5="87f6bb90bf562adbd404890911424a30" size="143" mtime="1516111256" />
+          <entry name="new_file" md5="d41d8cd98f00b204e9800998ecf8427e" size="0" mtime="1516111025" />
+          <entry name="somefile.txt" md5="478bacb4eb86846967edfa64ec6a5f9a" size="172" mtime="1516111242" />
         </directory>
     http_version: 
-  recorded_at: Wed, 03 May 2017 10:00:19 GMT
+  recorded_at: Tue, 16 Jan 2018 14:00:57 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:package_test_user/test_package
@@ -615,18 +610,17 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '498'
+      - '396'
     body:
       encoding: UTF-8
       string: |
-        <directory name="test_package" rev="11" vrev="11" srcmd5="94d6538c9c5ba94932bc034e7115ba7b">
-          <entry name="_config" md5="987fd35006ffa84b8480bc8e63371630" size="194" mtime="1493805613" />
-          <entry name="_invalid_file" md5="d41d8cd98f00b204e9800998ecf8427e" size="0" mtime="1493805327" />
-          <entry name="new_file" md5="d41d8cd98f00b204e9800998ecf8427e" size="0" mtime="1493804926" />
-          <entry name="somefile.txt" md5="d3e04ff6e702e1677847fc385e775c0a" size="184" mtime="1493805613" />
+        <directory name="test_package" rev="7" vrev="7" srcmd5="b3a56ec31c57bd08b4461f66d056857f">
+          <entry name="_config" md5="87f6bb90bf562adbd404890911424a30" size="143" mtime="1516111256" />
+          <entry name="new_file" md5="d41d8cd98f00b204e9800998ecf8427e" size="0" mtime="1516111025" />
+          <entry name="somefile.txt" md5="478bacb4eb86846967edfa64ec6a5f9a" size="172" mtime="1516111242" />
         </directory>
     http_version: 
-  recorded_at: Wed, 03 May 2017 10:00:19 GMT
+  recorded_at: Tue, 16 Jan 2018 14:00:57 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:package_test_user/test_package/_service
@@ -663,7 +657,79 @@ http_interactions:
           <details>404 _service: no such file</details>
         </status>
     http_version: 
-  recorded_at: Wed, 03 May 2017 10:00:19 GMT
+  recorded_at: Tue, 16 Jan 2018 14:00:57 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:package_test_user/test_package
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '396'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="test_package" rev="7" vrev="7" srcmd5="b3a56ec31c57bd08b4461f66d056857f">
+          <entry name="_config" md5="87f6bb90bf562adbd404890911424a30" size="143" mtime="1516111256" />
+          <entry name="new_file" md5="d41d8cd98f00b204e9800998ecf8427e" size="0" mtime="1516111025" />
+          <entry name="somefile.txt" md5="478bacb4eb86846967edfa64ec6a5f9a" size="172" mtime="1516111242" />
+        </directory>
+    http_version: 
+  recorded_at: Tue, 16 Jan 2018 14:00:57 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:package_test_user/test_package
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '396'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="test_package" rev="7" vrev="7" srcmd5="b3a56ec31c57bd08b4461f66d056857f">
+          <entry name="_config" md5="87f6bb90bf562adbd404890911424a30" size="143" mtime="1516111256" />
+          <entry name="new_file" md5="d41d8cd98f00b204e9800998ecf8427e" size="0" mtime="1516111025" />
+          <entry name="somefile.txt" md5="478bacb4eb86846967edfa64ec6a5f9a" size="172" mtime="1516111242" />
+        </directory>
+    http_version: 
+  recorded_at: Tue, 16 Jan 2018 14:00:57 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:package_test_user/test_package/_history
@@ -689,80 +755,56 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '2067'
+      - '1315'
     body:
       encoding: UTF-8
       string: |
         <revisionlist>
           <revision rev="1" vrev="1">
-            <srcmd5>7569b1317080d3a53c0512ca16217cf9</srcmd5>
+            <srcmd5>6c1a00da997ac81216c2927f5531d8a3</srcmd5>
             <version>unknown</version>
-            <time>1493804920</time>
+            <time>1516111250</time>
             <user>unknown</user>
           </revision>
           <revision rev="2" vrev="2">
-            <srcmd5>57bc2cd2981ffaf86387cbf0614d90d8</srcmd5>
+            <srcmd5>67f925b0f945b8133bc1cfc378b9a1e4</srcmd5>
             <version>unknown</version>
-            <time>1493804920</time>
+            <time>1516111250</time>
             <user>unknown</user>
           </revision>
           <revision rev="3" vrev="3">
-            <srcmd5>c82f638d93ae4eee021498de8b63503d</srcmd5>
+            <srcmd5>828f2044d4611f0d07fe08703257e7d7</srcmd5>
             <version>unknown</version>
-            <time>1493804926</time>
+            <time>1516111252</time>
             <user>package_test_user</user>
           </revision>
           <revision rev="4" vrev="4">
-            <srcmd5>dda1b945bf0ca918d12799b1e06cb143</srcmd5>
+            <srcmd5>029580729571eb701b38a5f6b40bb879</srcmd5>
             <version>unknown</version>
-            <time>1493805233</time>
+            <time>1516111253</time>
             <user>unknown</user>
           </revision>
           <revision rev="5" vrev="5">
-            <srcmd5>7b4289cee6697eac87cc00f69319cd01</srcmd5>
+            <srcmd5>029580729571eb701b38a5f6b40bb879</srcmd5>
             <version>unknown</version>
-            <time>1493805233</time>
+            <time>1516111253</time>
             <user>unknown</user>
           </revision>
           <revision rev="6" vrev="6">
-            <srcmd5>7b4289cee6697eac87cc00f69319cd01</srcmd5>
+            <srcmd5>b3a56ec31c57bd08b4461f66d056857f</srcmd5>
             <version>unknown</version>
-            <time>1493805240</time>
-            <user>package_test_user</user>
+            <time>1516111256</time>
+            <user>unknown</user>
           </revision>
           <revision rev="7" vrev="7">
-            <srcmd5>acb9456344d81dbf3da90039d3b3ca82</srcmd5>
+            <srcmd5>b3a56ec31c57bd08b4461f66d056857f</srcmd5>
             <version>unknown</version>
-            <time>1493805320</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="8" vrev="8">
-            <srcmd5>357a0bb0d8e4ec407de6c432e8fd954b</srcmd5>
-            <version>unknown</version>
-            <time>1493805320</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="9" vrev="9">
-            <srcmd5>9c459128e6548c2db6d6e516ce8c9c26</srcmd5>
-            <version>unknown</version>
-            <time>1493805327</time>
-            <user>package_test_user</user>
-          </revision>
-          <revision rev="10" vrev="10">
-            <srcmd5>b8033f0450075fbc0fa2c8e2399ea859</srcmd5>
-            <version>unknown</version>
-            <time>1493805613</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="11" vrev="11">
-            <srcmd5>94d6538c9c5ba94932bc034e7115ba7b</srcmd5>
-            <version>unknown</version>
-            <time>1493805613</time>
+            <time>1516111256</time>
             <user>unknown</user>
           </revision>
         </revisionlist>
     http_version: 
-  recorded_at: Wed, 03 May 2017 10:00:19 GMT
+  recorded_at: Tue, 16 Jan 2018 14:00:57 GMT
 - request:
     method: get
     uri: http://backend:5352/build/home:package_test_user/_result?package=test_package&view=status
@@ -797,7 +839,7 @@ http_interactions:
 
 '
     http_version: 
-  recorded_at: Wed, 03 May 2017 10:00:19 GMT
+  recorded_at: Tue, 16 Jan 2018 14:00:57 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:package_test_user/test_package
@@ -823,29 +865,26 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '498'
+      - '396'
     body:
       encoding: UTF-8
       string: |
-        <directory name="test_package" rev="11" vrev="11" srcmd5="94d6538c9c5ba94932bc034e7115ba7b">
-          <entry name="_config" md5="987fd35006ffa84b8480bc8e63371630" size="194" mtime="1493805613" />
-          <entry name="_invalid_file" md5="d41d8cd98f00b204e9800998ecf8427e" size="0" mtime="1493805327" />
-          <entry name="new_file" md5="d41d8cd98f00b204e9800998ecf8427e" size="0" mtime="1493804926" />
-          <entry name="somefile.txt" md5="d3e04ff6e702e1677847fc385e775c0a" size="184" mtime="1493805613" />
+        <directory name="test_package" rev="7" vrev="7" srcmd5="b3a56ec31c57bd08b4461f66d056857f">
+          <entry name="_config" md5="87f6bb90bf562adbd404890911424a30" size="143" mtime="1516111256" />
+          <entry name="new_file" md5="d41d8cd98f00b204e9800998ecf8427e" size="0" mtime="1516111025" />
+          <entry name="somefile.txt" md5="478bacb4eb86846967edfa64ec6a5f9a" size="172" mtime="1516111242" />
         </directory>
     http_version: 
-  recorded_at: Wed, 03 May 2017 10:00:20 GMT
+  recorded_at: Tue, 16 Jan 2018 14:00:58 GMT
 - request:
     method: get
-    uri: http://backend:5352/source/home:package_test_user/test_package?rev=11
+    uri: http://backend:5352/source/home:package_test_user/test_package?rev=7
     body:
       encoding: US-ASCII
       string: ''
     headers:
-      Content-Type:
-      - text/plain
       Accept-Encoding:
-      - identity
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
       - "*/*"
       User-Agent:
@@ -862,18 +901,17 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '498'
+      - '396'
     body:
       encoding: UTF-8
       string: |
-        <directory name="test_package" rev="11" vrev="11" srcmd5="94d6538c9c5ba94932bc034e7115ba7b">
-          <entry name="_config" md5="987fd35006ffa84b8480bc8e63371630" size="194" mtime="1493805613" />
-          <entry name="_invalid_file" md5="d41d8cd98f00b204e9800998ecf8427e" size="0" mtime="1493805327" />
-          <entry name="new_file" md5="d41d8cd98f00b204e9800998ecf8427e" size="0" mtime="1493804926" />
-          <entry name="somefile.txt" md5="d3e04ff6e702e1677847fc385e775c0a" size="184" mtime="1493805613" />
+        <directory name="test_package" rev="7" vrev="7" srcmd5="b3a56ec31c57bd08b4461f66d056857f">
+          <entry name="_config" md5="87f6bb90bf562adbd404890911424a30" size="143" mtime="1516111256" />
+          <entry name="new_file" md5="d41d8cd98f00b204e9800998ecf8427e" size="0" mtime="1516111025" />
+          <entry name="somefile.txt" md5="478bacb4eb86846967edfa64ec6a5f9a" size="172" mtime="1516111242" />
         </directory>
     http_version: 
-  recorded_at: Wed, 03 May 2017 10:00:20 GMT
+  recorded_at: Tue, 16 Jan 2018 14:00:58 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:package_test_user/test_package
@@ -901,18 +939,17 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '498'
+      - '396'
     body:
       encoding: UTF-8
       string: |
-        <directory name="test_package" rev="11" vrev="11" srcmd5="94d6538c9c5ba94932bc034e7115ba7b">
-          <entry name="_config" md5="987fd35006ffa84b8480bc8e63371630" size="194" mtime="1493805613" />
-          <entry name="_invalid_file" md5="d41d8cd98f00b204e9800998ecf8427e" size="0" mtime="1493805327" />
-          <entry name="new_file" md5="d41d8cd98f00b204e9800998ecf8427e" size="0" mtime="1493804926" />
-          <entry name="somefile.txt" md5="d3e04ff6e702e1677847fc385e775c0a" size="184" mtime="1493805613" />
+        <directory name="test_package" rev="7" vrev="7" srcmd5="b3a56ec31c57bd08b4461f66d056857f">
+          <entry name="_config" md5="87f6bb90bf562adbd404890911424a30" size="143" mtime="1516111256" />
+          <entry name="new_file" md5="d41d8cd98f00b204e9800998ecf8427e" size="0" mtime="1516111025" />
+          <entry name="somefile.txt" md5="478bacb4eb86846967edfa64ec6a5f9a" size="172" mtime="1516111242" />
         </directory>
     http_version: 
-  recorded_at: Wed, 03 May 2017 10:00:20 GMT
+  recorded_at: Tue, 16 Jan 2018 14:00:58 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:package_test_user/test_package
@@ -938,29 +975,26 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '498'
+      - '396'
     body:
       encoding: UTF-8
       string: |
-        <directory name="test_package" rev="11" vrev="11" srcmd5="94d6538c9c5ba94932bc034e7115ba7b">
-          <entry name="_config" md5="987fd35006ffa84b8480bc8e63371630" size="194" mtime="1493805613" />
-          <entry name="_invalid_file" md5="d41d8cd98f00b204e9800998ecf8427e" size="0" mtime="1493805327" />
-          <entry name="new_file" md5="d41d8cd98f00b204e9800998ecf8427e" size="0" mtime="1493804926" />
-          <entry name="somefile.txt" md5="d3e04ff6e702e1677847fc385e775c0a" size="184" mtime="1493805613" />
+        <directory name="test_package" rev="7" vrev="7" srcmd5="b3a56ec31c57bd08b4461f66d056857f">
+          <entry name="_config" md5="87f6bb90bf562adbd404890911424a30" size="143" mtime="1516111256" />
+          <entry name="new_file" md5="d41d8cd98f00b204e9800998ecf8427e" size="0" mtime="1516111025" />
+          <entry name="somefile.txt" md5="478bacb4eb86846967edfa64ec6a5f9a" size="172" mtime="1516111242" />
         </directory>
     http_version: 
-  recorded_at: Wed, 03 May 2017 10:00:20 GMT
+  recorded_at: Tue, 16 Jan 2018 14:00:58 GMT
 - request:
     method: get
-    uri: http://backend:5352/source/home:package_test_user/test_package?rev=11
+    uri: http://backend:5352/source/home:package_test_user/test_package?rev=7
     body:
       encoding: US-ASCII
       string: ''
     headers:
-      Content-Type:
-      - text/plain
       Accept-Encoding:
-      - identity
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
       - "*/*"
       User-Agent:
@@ -977,18 +1011,17 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '498'
+      - '396'
     body:
       encoding: UTF-8
       string: |
-        <directory name="test_package" rev="11" vrev="11" srcmd5="94d6538c9c5ba94932bc034e7115ba7b">
-          <entry name="_config" md5="987fd35006ffa84b8480bc8e63371630" size="194" mtime="1493805613" />
-          <entry name="_invalid_file" md5="d41d8cd98f00b204e9800998ecf8427e" size="0" mtime="1493805327" />
-          <entry name="new_file" md5="d41d8cd98f00b204e9800998ecf8427e" size="0" mtime="1493804926" />
-          <entry name="somefile.txt" md5="d3e04ff6e702e1677847fc385e775c0a" size="184" mtime="1493805613" />
+        <directory name="test_package" rev="7" vrev="7" srcmd5="b3a56ec31c57bd08b4461f66d056857f">
+          <entry name="_config" md5="87f6bb90bf562adbd404890911424a30" size="143" mtime="1516111256" />
+          <entry name="new_file" md5="d41d8cd98f00b204e9800998ecf8427e" size="0" mtime="1516111025" />
+          <entry name="somefile.txt" md5="478bacb4eb86846967edfa64ec6a5f9a" size="172" mtime="1516111242" />
         </directory>
     http_version: 
-  recorded_at: Wed, 03 May 2017 10:00:20 GMT
+  recorded_at: Tue, 16 Jan 2018 14:00:58 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:package_test_user/test_package
@@ -1016,18 +1049,17 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '498'
+      - '396'
     body:
       encoding: UTF-8
       string: |
-        <directory name="test_package" rev="11" vrev="11" srcmd5="94d6538c9c5ba94932bc034e7115ba7b">
-          <entry name="_config" md5="987fd35006ffa84b8480bc8e63371630" size="194" mtime="1493805613" />
-          <entry name="_invalid_file" md5="d41d8cd98f00b204e9800998ecf8427e" size="0" mtime="1493805327" />
-          <entry name="new_file" md5="d41d8cd98f00b204e9800998ecf8427e" size="0" mtime="1493804926" />
-          <entry name="somefile.txt" md5="d3e04ff6e702e1677847fc385e775c0a" size="184" mtime="1493805613" />
+        <directory name="test_package" rev="7" vrev="7" srcmd5="b3a56ec31c57bd08b4461f66d056857f">
+          <entry name="_config" md5="87f6bb90bf562adbd404890911424a30" size="143" mtime="1516111256" />
+          <entry name="new_file" md5="d41d8cd98f00b204e9800998ecf8427e" size="0" mtime="1516111025" />
+          <entry name="somefile.txt" md5="478bacb4eb86846967edfa64ec6a5f9a" size="172" mtime="1516111242" />
         </directory>
     http_version: 
-  recorded_at: Wed, 03 May 2017 10:00:20 GMT
+  recorded_at: Tue, 16 Jan 2018 14:00:58 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:package_test_user/test_package
@@ -1053,29 +1085,26 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '498'
+      - '396'
     body:
       encoding: UTF-8
       string: |
-        <directory name="test_package" rev="11" vrev="11" srcmd5="94d6538c9c5ba94932bc034e7115ba7b">
-          <entry name="_config" md5="987fd35006ffa84b8480bc8e63371630" size="194" mtime="1493805613" />
-          <entry name="_invalid_file" md5="d41d8cd98f00b204e9800998ecf8427e" size="0" mtime="1493805327" />
-          <entry name="new_file" md5="d41d8cd98f00b204e9800998ecf8427e" size="0" mtime="1493804926" />
-          <entry name="somefile.txt" md5="d3e04ff6e702e1677847fc385e775c0a" size="184" mtime="1493805613" />
+        <directory name="test_package" rev="7" vrev="7" srcmd5="b3a56ec31c57bd08b4461f66d056857f">
+          <entry name="_config" md5="87f6bb90bf562adbd404890911424a30" size="143" mtime="1516111256" />
+          <entry name="new_file" md5="d41d8cd98f00b204e9800998ecf8427e" size="0" mtime="1516111025" />
+          <entry name="somefile.txt" md5="478bacb4eb86846967edfa64ec6a5f9a" size="172" mtime="1516111242" />
         </directory>
     http_version: 
-  recorded_at: Wed, 03 May 2017 10:00:20 GMT
+  recorded_at: Tue, 16 Jan 2018 14:00:58 GMT
 - request:
     method: get
-    uri: http://backend:5352/source/home:package_test_user/test_package?expand=1&rev=11
+    uri: http://backend:5352/source/home:package_test_user/test_package?expand=1&rev=7
     body:
       encoding: US-ASCII
       string: ''
     headers:
-      Content-Type:
-      - text/plain
       Accept-Encoding:
-      - identity
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
       - "*/*"
       User-Agent:
@@ -1092,18 +1121,17 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '498'
+      - '396'
     body:
       encoding: UTF-8
       string: |
-        <directory name="test_package" rev="11" vrev="11" srcmd5="94d6538c9c5ba94932bc034e7115ba7b">
-          <entry name="_config" md5="987fd35006ffa84b8480bc8e63371630" size="194" mtime="1493805613" />
-          <entry name="_invalid_file" md5="d41d8cd98f00b204e9800998ecf8427e" size="0" mtime="1493805327" />
-          <entry name="new_file" md5="d41d8cd98f00b204e9800998ecf8427e" size="0" mtime="1493804926" />
-          <entry name="somefile.txt" md5="d3e04ff6e702e1677847fc385e775c0a" size="184" mtime="1493805613" />
+        <directory name="test_package" rev="7" vrev="7" srcmd5="b3a56ec31c57bd08b4461f66d056857f">
+          <entry name="_config" md5="87f6bb90bf562adbd404890911424a30" size="143" mtime="1516111256" />
+          <entry name="new_file" md5="d41d8cd98f00b204e9800998ecf8427e" size="0" mtime="1516111025" />
+          <entry name="somefile.txt" md5="478bacb4eb86846967edfa64ec6a5f9a" size="172" mtime="1516111242" />
         </directory>
     http_version: 
-  recorded_at: Wed, 03 May 2017 10:00:20 GMT
+  recorded_at: Tue, 16 Jan 2018 14:00:58 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:package_test_user/test_package
@@ -1131,18 +1159,17 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '498'
+      - '396'
     body:
       encoding: UTF-8
       string: |
-        <directory name="test_package" rev="11" vrev="11" srcmd5="94d6538c9c5ba94932bc034e7115ba7b">
-          <entry name="_config" md5="987fd35006ffa84b8480bc8e63371630" size="194" mtime="1493805613" />
-          <entry name="_invalid_file" md5="d41d8cd98f00b204e9800998ecf8427e" size="0" mtime="1493805327" />
-          <entry name="new_file" md5="d41d8cd98f00b204e9800998ecf8427e" size="0" mtime="1493804926" />
-          <entry name="somefile.txt" md5="d3e04ff6e702e1677847fc385e775c0a" size="184" mtime="1493805613" />
+        <directory name="test_package" rev="7" vrev="7" srcmd5="b3a56ec31c57bd08b4461f66d056857f">
+          <entry name="_config" md5="87f6bb90bf562adbd404890911424a30" size="143" mtime="1516111256" />
+          <entry name="new_file" md5="d41d8cd98f00b204e9800998ecf8427e" size="0" mtime="1516111025" />
+          <entry name="somefile.txt" md5="478bacb4eb86846967edfa64ec6a5f9a" size="172" mtime="1516111242" />
         </directory>
     http_version: 
-  recorded_at: Wed, 03 May 2017 10:00:20 GMT
+  recorded_at: Tue, 16 Jan 2018 14:00:58 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:package_test_user/test_package/_service
@@ -1179,7 +1206,79 @@ http_interactions:
           <details>404 _service: no such file</details>
         </status>
     http_version: 
-  recorded_at: Wed, 03 May 2017 10:00:20 GMT
+  recorded_at: Tue, 16 Jan 2018 14:00:58 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:package_test_user/test_package
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '396'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="test_package" rev="7" vrev="7" srcmd5="b3a56ec31c57bd08b4461f66d056857f">
+          <entry name="_config" md5="87f6bb90bf562adbd404890911424a30" size="143" mtime="1516111256" />
+          <entry name="new_file" md5="d41d8cd98f00b204e9800998ecf8427e" size="0" mtime="1516111025" />
+          <entry name="somefile.txt" md5="478bacb4eb86846967edfa64ec6a5f9a" size="172" mtime="1516111242" />
+        </directory>
+    http_version: 
+  recorded_at: Tue, 16 Jan 2018 14:00:58 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:package_test_user/test_package
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '396'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="test_package" rev="7" vrev="7" srcmd5="b3a56ec31c57bd08b4461f66d056857f">
+          <entry name="_config" md5="87f6bb90bf562adbd404890911424a30" size="143" mtime="1516111256" />
+          <entry name="new_file" md5="d41d8cd98f00b204e9800998ecf8427e" size="0" mtime="1516111025" />
+          <entry name="somefile.txt" md5="478bacb4eb86846967edfa64ec6a5f9a" size="172" mtime="1516111242" />
+        </directory>
+    http_version: 
+  recorded_at: Tue, 16 Jan 2018 14:00:58 GMT
 - request:
     method: get
     uri: http://backend:5352/build/home:package_test_user/_result?package=test_package&view=status
@@ -1213,294 +1312,6 @@ http_interactions:
       string: '<resultlist state="00000000000000000000000000000000" />
 
 '
-    http_version: 
-  recorded_at: Wed, 03 May 2017 10:00:21 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/home:package_test_user/test_package?expand=1
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Content-Type:
-      - text/plain
-      Accept-Encoding:
-      - identity
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '498'
-    body:
-      encoding: UTF-8
-      string: |
-        <directory name="test_package" rev="11" vrev="11" srcmd5="94d6538c9c5ba94932bc034e7115ba7b">
-          <entry name="_config" md5="987fd35006ffa84b8480bc8e63371630" size="194" mtime="1493805613" />
-          <entry name="_invalid_file" md5="d41d8cd98f00b204e9800998ecf8427e" size="0" mtime="1493805327" />
-          <entry name="new_file" md5="d41d8cd98f00b204e9800998ecf8427e" size="0" mtime="1493804926" />
-          <entry name="somefile.txt" md5="d3e04ff6e702e1677847fc385e775c0a" size="184" mtime="1493805613" />
-        </directory>
-    http_version: 
-  recorded_at: Wed, 03 May 2017 10:00:58 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/home:package_test_user/test_package/new_file?expand=1
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/octet-stream
-      Content-Length:
-      - '0'
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-    body:
-      encoding: UTF-8
-      string: ''
-    http_version: 
-  recorded_at: Wed, 03 May 2017 10:00:58 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/home:package_test_user/test_package
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Content-Type:
-      - text/plain
-      Accept-Encoding:
-      - identity
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 404
-      message: project 'home package_test_user' does not exist
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '172'
-    body:
-      encoding: UTF-8
-      string: |
-        <status code="404">
-          <summary>project 'home:package_test_user' does not exist</summary>
-          <details>404 project 'home:package_test_user' does not exist</details>
-        </status>
-    http_version: 
-  recorded_at: Fri, 16 Jun 2017 14:23:08 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/home:package_test_user/test_package
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 404
-      message: project 'home package_test_user' does not exist
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '172'
-    body:
-      encoding: UTF-8
-      string: |
-        <status code="404">
-          <summary>project 'home:package_test_user' does not exist</summary>
-          <details>404 project 'home:package_test_user' does not exist</details>
-        </status>
-    http_version: 
-  recorded_at: Fri, 16 Jun 2017 14:23:08 GMT
-- request:
-    method: put
-    uri: http://backend:5352/source/home:package_test_user/test_package/_meta?user=package_test_user
-    body:
-      encoding: UTF-8
-      string: |
-        <package name="test_package" project="home:package_test_user">
-          <title>Surprised by Joy</title>
-          <description>Corrupti numquam placeat suscipit ipsum quia sed rerum.</description>
-        </package>
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '193'
-    body:
-      encoding: UTF-8
-      string: |
-        <package name="test_package" project="home:package_test_user">
-          <title>Surprised by Joy</title>
-          <description>Corrupti numquam placeat suscipit ipsum quia sed rerum.</description>
-        </package>
-    http_version: 
-  recorded_at: Wed, 03 Jan 2018 13:13:41 GMT
-- request:
-    method: put
-    uri: http://backend:5352/source/home:other_package_test_user/branch_test_package/_meta?user=package_test_user
-    body:
-      encoding: UTF-8
-      string: |
-        <package name="branch_test_package" project="home:other_package_test_user">
-          <title>The Lathe of Heaven</title>
-          <description>Ea deleniti nisi ut qui ut ut qui repellat.</description>
-        </package>
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '197'
-    body:
-      encoding: UTF-8
-      string: |
-        <package name="branch_test_package" project="home:other_package_test_user">
-          <title>The Lathe of Heaven</title>
-          <description>Ea deleniti nisi ut qui ut ut qui repellat.</description>
-        </package>
-    http_version: 
-  recorded_at: Wed, 03 Jan 2018 13:13:42 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/home:package_test_user/test_package
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '200'
-    body:
-      encoding: UTF-8
-      string: |
-        <directory name="test_package" rev="1" vrev="1" srcmd5="76f14d7f71d84f62e33056b3e088d941">
-          <entry name="_config" md5="59b46c46338e845890c00a2811779a58" size="102" mtime="1514985210" />
-        </directory>
-    http_version: 
-  recorded_at: Wed, 03 Jan 2018 13:13:44 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/home:package_test_user/test_package
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '200'
-    body:
-      encoding: UTF-8
-      string: |
-        <directory name="test_package" rev="1" vrev="1" srcmd5="76f14d7f71d84f62e33056b3e088d941">
-          <entry name="_config" md5="59b46c46338e845890c00a2811779a58" size="102" mtime="1514985210" />
-        </directory>
     http_version: 
   recorded_at: Wed, 03 Jan 2018 13:13:44 GMT
 - request:

--- a/src/api/spec/cassettes/Packages/behaves_like_user_tab/group_roles/Add_group_to_package_/_project.yml
+++ b/src/api/spec/cassettes/Packages/behaves_like_user_tab/group_roles/Add_group_to_package_/_project.yml
@@ -2,597 +2,6 @@
 http_interactions:
 - request:
     method: put
-    uri: http://backend:5352/source/home:other_user/_meta
-    body:
-      encoding: UTF-8
-      string: |
-        <project name="home:other_user">
-          <title/>
-          <description/>
-          <person userid="other_user" role="maintainer"/>
-        </project>
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '143'
-    body:
-      encoding: UTF-8
-      string: |
-        <project name="home:other_user">
-          <title></title>
-          <description></description>
-          <person userid="other_user" role="maintainer" />
-        </project>
-    http_version: 
-  recorded_at: Wed, 17 Aug 2016 11:20:35 GMT
-- request:
-    method: put
-    uri: http://backend:5352/source/home:other_user/branch_test_package/_meta
-    body:
-      encoding: UTF-8
-      string: |
-        <package name="branch_test_package" project="home:other_user">
-          <title/>
-          <description/>
-        </package>
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '122'
-    body:
-      encoding: UTF-8
-      string: |
-        <package name="branch_test_package" project="home:other_user">
-          <title></title>
-          <description></description>
-        </package>
-    http_version: 
-  recorded_at: Wed, 17 Aug 2016 11:20:35 GMT
-- request:
-    method: put
-    uri: http://backend:5352/source/home:other_user/branch_test_package/somefile.txt
-    body:
-      encoding: UTF-8
-      string: Dolor aut repellat. Laboriosam corporis aut quam. Eveniet eum nam. Exercitationem
-        sunt illum ut.
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '207'
-    body:
-      encoding: UTF-8
-      string: |
-        <revision rev="7" vrev="7">
-          <srcmd5>cbbdd156bedf9dc5e0672961a028a6a3</srcmd5>
-          <version>unknown</version>
-          <time>1471432835</time>
-          <user>unknown</user>
-          <comment></comment>
-          <requestid/>
-        </revision>
-    http_version: 
-  recorded_at: Wed, 17 Aug 2016 11:20:35 GMT
-- request:
-    method: get
-    uri: http://backend:5352/build/home:user_tab_user/_result?package=group_test_package&view=status
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Content-Type:
-      - text/plain
-      Accept-Encoding:
-      - identity
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 404
-      message: project 'home user_tab_user' does not exist
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '164'
-    body:
-      encoding: UTF-8
-      string: |
-        <status code="404">
-          <summary>project 'home:user_tab_user' does not exist</summary>
-          <details>404 project 'home:user_tab_user' does not exist</details>
-        </status>
-    http_version: 
-  recorded_at: Wed, 17 Aug 2016 11:20:35 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/home:user_tab_user/group_test_package?nofilename=1&view=info&withchangesmd5=1
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 404
-      message: project 'home user_tab_user' does not exist
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '164'
-    body:
-      encoding: UTF-8
-      string: |
-        <status code="404">
-          <summary>project 'home:user_tab_user' does not exist</summary>
-          <details>404 project 'home:user_tab_user' does not exist</details>
-        </status>
-    http_version: 
-  recorded_at: Wed, 17 Aug 2016 11:20:35 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/home:user_tab_user/group_test_package
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 404
-      message: project 'home user_tab_user' does not exist
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '164'
-    body:
-      encoding: UTF-8
-      string: |
-        <status code="404">
-          <summary>project 'home:user_tab_user' does not exist</summary>
-          <details>404 project 'home:user_tab_user' does not exist</details>
-        </status>
-    http_version: 
-  recorded_at: Wed, 17 Aug 2016 11:20:35 GMT
-- request:
-    method: post
-    uri: http://backend:5352/source/home:user_tab_user/group_test_package?cmd=diff&linkrev=base&onlyissues=1&orev=0&view=xml
-    body:
-      encoding: UTF-8
-      string: ''
-    headers:
-      Content-Type:
-      - application/octet-stream
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 404
-      message: project 'home user_tab_user' does not exist
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '164'
-    body:
-      encoding: UTF-8
-      string: |
-        <status code="404">
-          <summary>project 'home:user_tab_user' does not exist</summary>
-          <details>404 project 'home:user_tab_user' does not exist</details>
-        </status>
-    http_version: 
-  recorded_at: Wed, 17 Aug 2016 11:20:35 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/home:user_tab_user/group_test_package
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 404
-      message: project 'home user_tab_user' does not exist
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '164'
-    body:
-      encoding: UTF-8
-      string: |
-        <status code="404">
-          <summary>project 'home:user_tab_user' does not exist</summary>
-          <details>404 project 'home:user_tab_user' does not exist</details>
-        </status>
-    http_version: 
-  recorded_at: Wed, 17 Aug 2016 11:20:35 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/home:user_tab_user/group_test_package?expand=1
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Content-Type:
-      - text/plain
-      Accept-Encoding:
-      - identity
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 404
-      message: project 'home user_tab_user' does not exist
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '164'
-    body:
-      encoding: UTF-8
-      string: |
-        <status code="404">
-          <summary>project 'home:user_tab_user' does not exist</summary>
-          <details>404 project 'home:user_tab_user' does not exist</details>
-        </status>
-    http_version: 
-  recorded_at: Wed, 17 Aug 2016 11:20:35 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/home:user_tab_user/group_test_package
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Content-Type:
-      - text/plain
-      Accept-Encoding:
-      - identity
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 404
-      message: project 'home user_tab_user' does not exist
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '164'
-    body:
-      encoding: UTF-8
-      string: |
-        <status code="404">
-          <summary>project 'home:user_tab_user' does not exist</summary>
-          <details>404 project 'home:user_tab_user' does not exist</details>
-        </status>
-    http_version: 
-  recorded_at: Wed, 17 Aug 2016 11:20:35 GMT
-- request:
-    method: get
-    uri: http://backend:5352/build/home:user_tab_user/_result?package=group_test_package&view=status
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Content-Type:
-      - text/plain
-      Accept-Encoding:
-      - identity
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 404
-      message: project 'home user_tab_user' does not exist
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '164'
-    body:
-      encoding: UTF-8
-      string: |
-        <status code="404">
-          <summary>project 'home:user_tab_user' does not exist</summary>
-          <details>404 project 'home:user_tab_user' does not exist</details>
-        </status>
-    http_version: 
-  recorded_at: Wed, 17 Aug 2016 11:20:36 GMT
-- request:
-    method: get
-    uri: http://backend:5352/build/home:user_tab_user/_result?package=group_test_package&view=status
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Content-Type:
-      - text/plain
-      Accept-Encoding:
-      - identity
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 404
-      message: project 'home user_tab_user' does not exist
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '164'
-    body:
-      encoding: UTF-8
-      string: |
-        <status code="404">
-          <summary>project 'home:user_tab_user' does not exist</summary>
-          <details>404 project 'home:user_tab_user' does not exist</details>
-        </status>
-    http_version: 
-  recorded_at: Wed, 17 Aug 2016 11:20:36 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/home:user_tab_user/group_test_package/_service
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Content-Type:
-      - text/plain
-      Accept-Encoding:
-      - identity
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 404
-      message: project 'home user_tab_user' does not exist
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '164'
-    body:
-      encoding: UTF-8
-      string: |
-        <status code="404">
-          <summary>project 'home:user_tab_user' does not exist</summary>
-          <details>404 project 'home:user_tab_user' does not exist</details>
-        </status>
-    http_version: 
-  recorded_at: Wed, 05 Oct 2016 09:08:43 GMT
-- request:
-    method: get
-    uri: http://backend:5352/build/home:user_tab_user/_result?locallink=1&multibuild=1&package=group_test_package&view=status
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Content-Type:
-      - text/plain
-      Accept-Encoding:
-      - identity
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 404
-      message: project 'home user_tab_user' does not exist
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '164'
-    body:
-      encoding: UTF-8
-      string: |
-        <status code="404">
-          <summary>project 'home:user_tab_user' does not exist</summary>
-          <details>404 project 'home:user_tab_user' does not exist</details>
-        </status>
-    http_version: 
-  recorded_at: Fri, 20 Jan 2017 02:55:27 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/home:user_tab_user/group_test_package?expand=0
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 404
-      message: project 'home user_tab_user' does not exist
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '164'
-    body:
-      encoding: UTF-8
-      string: |
-        <status code="404">
-          <summary>project 'home:user_tab_user' does not exist</summary>
-          <details>404 project 'home:user_tab_user' does not exist</details>
-        </status>
-    http_version: 
-  recorded_at: Tue, 16 May 2017 15:09:37 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/home:user_tab_user/group_test_package
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 404
-      message: project 'home user_tab_user' does not exist
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '164'
-    body:
-      encoding: UTF-8
-      string: |
-        <status code="404">
-          <summary>project 'home:user_tab_user' does not exist</summary>
-          <details>404 project 'home:user_tab_user' does not exist</details>
-        </status>
-    http_version: 
-  recorded_at: Fri, 16 Jun 2017 14:23:39 GMT
-- request:
-    method: put
     uri: http://backend:5352/source/home:package_test_user/_meta?user=package_test_user
     body:
       encoding: UTF-8
@@ -631,7 +40,7 @@ http_interactions:
           <person userid="package_test_user" role="maintainer" />
         </project>
     http_version: 
-  recorded_at: Wed, 03 Jan 2018 13:15:06 GMT
+  recorded_at: Tue, 16 Jan 2018 14:01:17 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:user_tab_user/_meta?user=user_tab_user
@@ -672,16 +81,16 @@ http_interactions:
           <person userid="user_tab_user" role="maintainer" />
         </project>
     http_version: 
-  recorded_at: Wed, 03 Jan 2018 13:15:06 GMT
+  recorded_at: Tue, 16 Jan 2018 14:01:17 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:user_tab_user/group_test_package/_meta?user=package_test_user
+    uri: http://backend:5352/source/home:user_tab_user/group_test_package/_meta?user=user_tab_user
     body:
       encoding: UTF-8
       string: |
         <package name="group_test_package" project="home:user_tab_user">
-          <title>Mr Standfast</title>
-          <description>Quis dolores veniam velit sit.</description>
+          <title>I Know Why the Caged Bird Sings</title>
+          <description>Et voluptatum nihil quia.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -702,16 +111,16 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '166'
+      - '180'
     body:
       encoding: UTF-8
       string: |
         <package name="group_test_package" project="home:user_tab_user">
-          <title>Mr Standfast</title>
-          <description>Quis dolores veniam velit sit.</description>
+          <title>I Know Why the Caged Bird Sings</title>
+          <description>Et voluptatum nihil quia.</description>
         </package>
     http_version: 
-  recorded_at: Wed, 03 Jan 2018 13:15:06 GMT
+  recorded_at: Tue, 16 Jan 2018 14:01:17 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:user_tab_user/group_test_package/_meta
@@ -719,8 +128,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="group_test_package" project="home:user_tab_user">
-          <title>Mr Standfast</title>
-          <description>Quis dolores veniam velit sit.</description>
+          <title>I Know Why the Caged Bird Sings</title>
+          <description>Et voluptatum nihil quia.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -741,16 +150,16 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '166'
+      - '180'
     body:
       encoding: UTF-8
       string: |
         <package name="group_test_package" project="home:user_tab_user">
-          <title>Mr Standfast</title>
-          <description>Quis dolores veniam velit sit.</description>
+          <title>I Know Why the Caged Bird Sings</title>
+          <description>Et voluptatum nihil quia.</description>
         </package>
     http_version: 
-  recorded_at: Wed, 03 Jan 2018 13:15:06 GMT
+  recorded_at: Tue, 16 Jan 2018 14:01:17 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:other_user/_meta?user=other_user
@@ -791,16 +200,16 @@ http_interactions:
           <person userid="other_user" role="maintainer" />
         </project>
     http_version: 
-  recorded_at: Wed, 03 Jan 2018 13:15:07 GMT
+  recorded_at: Tue, 16 Jan 2018 14:01:17 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:other_user/branch_test_package/_meta?user=package_test_user
+    uri: http://backend:5352/source/home:other_user/branch_test_package/_meta?user=user_tab_user
     body:
       encoding: UTF-8
       string: |
         <package name="branch_test_package" project="home:other_user">
-          <title>A Confederacy of Dunces</title>
-          <description>Numquam velit aut non qui.</description>
+          <title>Stranger in a Strange Land</title>
+          <description>Accusamus ipsam assumenda et.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -821,24 +230,62 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '171'
+      - '177'
     body:
       encoding: UTF-8
       string: |
         <package name="branch_test_package" project="home:other_user">
-          <title>A Confederacy of Dunces</title>
-          <description>Numquam velit aut non qui.</description>
+          <title>Stranger in a Strange Land</title>
+          <description>Accusamus ipsam assumenda et.</description>
         </package>
     http_version: 
-  recorded_at: Wed, 03 Jan 2018 13:15:07 GMT
+  recorded_at: Tue, 16 Jan 2018 14:01:17 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:other_user/branch_test_package/_meta
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="branch_test_package" project="home:other_user">
+          <title>Stranger in a Strange Land</title>
+          <description>Accusamus ipsam assumenda et.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '177'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="branch_test_package" project="home:other_user">
+          <title>Stranger in a Strange Land</title>
+          <description>Accusamus ipsam assumenda et.</description>
+        </package>
+    http_version: 
+  recorded_at: Tue, 16 Jan 2018 14:01:17 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:other_user/branch_test_package/_config
     body:
       encoding: UTF-8
-      string: Dicta nobis sit laborum possimus fugit voluptas. Sint dolor dolores
-        qui eligendi assumenda. Quas quod assumenda voluptatem dolorum hic eos quasi.
-        Minus ipsam sunt et.
+      string: Iure quae sint dicta odio. Et voluptatibus ut saepe quasi nemo vitae.
+        Sed qui aperiam. Aut quia ratione. Minus dicta quia.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -858,20 +305,95 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '207'
+      - '209'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="1" vrev="1">
-          <srcmd5>f81f412cfa23a3de75150944af0d8ca4</srcmd5>
+        <revision rev="21" vrev="21">
+          <srcmd5>f04a0cb1ece141dcf22ee7455d1edda0</srcmd5>
           <version>unknown</version>
-          <time>1514985307</time>
+          <time>1516111277</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
     http_version: 
-  recorded_at: Wed, 03 Jan 2018 13:15:07 GMT
+  recorded_at: Tue, 16 Jan 2018 14:01:17 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:other_user/branch_test_package/somefile.txt
+    body:
+      encoding: UTF-8
+      string: Officia quia repellendus quis. Velit ullam et. Praesentium dolorem quos
+        quae dolorum illum libero sit. Culpa officia autem voluptatem assumenda. Officiis
+        repudiandae et in.
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '209'
+    body:
+      encoding: UTF-8
+      string: |
+        <revision rev="22" vrev="22">
+          <srcmd5>f04a0cb1ece141dcf22ee7455d1edda0</srcmd5>
+          <version>unknown</version>
+          <time>1516111277</time>
+          <user>unknown</user>
+          <comment></comment>
+          <requestid/>
+        </revision>
+    http_version: 
+  recorded_at: Tue, 16 Jan 2018 14:01:17 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:user_tab_user/group_test_package?nofilename=1&view=info&withchangesmd5=1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '156'
+    body:
+      encoding: UTF-8
+      string: |
+        <sourceinfo package="group_test_package" srcmd5="d41d8cd98f00b204e9800998ecf8427e" verifymd5="d41d8cd98f00b204e9800998ecf8427e">
+          <revtime/>
+        </sourceinfo>
+    http_version: 
+  recorded_at: Tue, 16 Jan 2018 14:01:18 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:user_tab_user/group_test_package
@@ -904,7 +426,284 @@ http_interactions:
         <directory name="group_test_package" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
         </directory>
     http_version: 
-  recorded_at: Wed, 03 Jan 2018 13:15:09 GMT
+  recorded_at: Tue, 16 Jan 2018 14:01:18 GMT
+- request:
+    method: post
+    uri: http://backend:5352/source/home:user_tab_user/group_test_package?cmd=diff&linkrev=base&onlyissues=1&orev=0&view=xml
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Content-Type:
+      - application/octet-stream
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '314'
+    body:
+      encoding: UTF-8
+      string: |
+        <sourcediff key="04429e5eb3523e7cb3e15ee88d1605d6">
+          <old project="home:user_tab_user" package="group_test_package" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e" />
+          <new project="home:user_tab_user" package="group_test_package" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e" />
+          <files />
+        </sourcediff>
+    http_version: 
+  recorded_at: Tue, 16 Jan 2018 14:01:18 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:user_tab_user/group_test_package
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '93'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="group_test_package" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
+        </directory>
+    http_version: 
+  recorded_at: Tue, 16 Jan 2018 14:01:18 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:user_tab_user/group_test_package?expand=1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '93'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="group_test_package" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
+        </directory>
+    http_version: 
+  recorded_at: Tue, 16 Jan 2018 14:01:18 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:user_tab_user/group_test_package
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - text/plain
+      Accept-Encoding:
+      - identity
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '93'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="group_test_package" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
+        </directory>
+    http_version: 
+  recorded_at: Tue, 16 Jan 2018 14:01:18 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:user_tab_user/group_test_package/_service
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - text/plain
+      Accept-Encoding:
+      - identity
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 404
+      message: _service  no such file
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '122'
+    body:
+      encoding: UTF-8
+      string: |
+        <status code="404">
+          <summary>_service: no such file</summary>
+          <details>404 _service: no such file</details>
+        </status>
+    http_version: 
+  recorded_at: Tue, 16 Jan 2018 14:01:18 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:user_tab_user/group_test_package
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '93'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="group_test_package" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
+        </directory>
+    http_version: 
+  recorded_at: Tue, 16 Jan 2018 14:01:18 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:user_tab_user/group_test_package
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '93'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="group_test_package" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
+        </directory>
+    http_version: 
+  recorded_at: Tue, 16 Jan 2018 14:01:18 GMT
+- request:
+    method: get
+    uri: http://backend:5352/build/home:user_tab_user/_result?package=group_test_package&view=status
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - text/plain
+      Accept-Encoding:
+      - identity
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '56'
+    body:
+      encoding: UTF-8
+      string: '<resultlist state="00000000000000000000000000000000" />
+
+'
+    http_version: 
+  recorded_at: Tue, 16 Jan 2018 14:01:18 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:user_tab_user/group_test_package/_meta?user=user_tab_user
@@ -912,8 +711,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="group_test_package" project="home:user_tab_user">
-          <title>Mr Standfast</title>
-          <description>Quis dolores veniam velit sit.</description>
+          <title>I Know Why the Caged Bird Sings</title>
+          <description>Et voluptatum nihil quia.</description>
           <person userid="user_tab_user" role="maintainer"/>
           <group groupid="existing_group" role="bugowner"/>
           <group groupid="existing_group" role="maintainer"/>
@@ -938,17 +737,95 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '380'
+      - '394'
     body:
       encoding: UTF-8
       string: |
         <package name="group_test_package" project="home:user_tab_user">
-          <title>Mr Standfast</title>
-          <description>Quis dolores veniam velit sit.</description>
+          <title>I Know Why the Caged Bird Sings</title>
+          <description>Et voluptatum nihil quia.</description>
           <person userid="user_tab_user" role="maintainer" />
           <group groupid="existing_group" role="bugowner" />
           <group groupid="existing_group" role="maintainer" />
           <group groupid="other_group" role="maintainer" />
+        </package>
+    http_version: 
+  recorded_at: Tue, 16 Jan 2018 14:01:19 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:user_tab_user/group_test_package/_meta?user=package_test_user
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="group_test_package" project="home:user_tab_user">
+          <title>A Time of Gifts</title>
+          <description>In rerum dolore nulla.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '161'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="group_test_package" project="home:user_tab_user">
+          <title>A Time of Gifts</title>
+          <description>In rerum dolore nulla.</description>
+        </package>
+    http_version: 
+  recorded_at: Tue, 16 Jan 2018 14:03:21 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:other_user/branch_test_package/_meta?user=package_test_user
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="branch_test_package" project="home:other_user">
+          <title>Carrion Comfort</title>
+          <description>Dolor architecto beatae maiores nihil recusandae est veniam temporibus.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '208'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="branch_test_package" project="home:other_user">
+          <title>Carrion Comfort</title>
+          <description>Dolor architecto beatae maiores nihil recusandae est veniam temporibus.</description>
         </package>
     http_version: 
   recorded_at: Wed, 03 Jan 2018 13:15:10 GMT

--- a/src/api/spec/cassettes/Packages/behaves_like_user_tab/group_roles/Add_role_to_group.yml
+++ b/src/api/spec/cassettes/Packages/behaves_like_user_tab/group_roles/Add_role_to_group.yml
@@ -2,961 +2,6 @@
 http_interactions:
 - request:
     method: put
-    uri: http://backend:5352/source/home:other_user/_meta
-    body:
-      encoding: UTF-8
-      string: |
-        <project name="home:other_user">
-          <title/>
-          <description/>
-          <person userid="other_user" role="maintainer"/>
-        </project>
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '143'
-    body:
-      encoding: UTF-8
-      string: |
-        <project name="home:other_user">
-          <title></title>
-          <description></description>
-          <person userid="other_user" role="maintainer" />
-        </project>
-    http_version: 
-  recorded_at: Wed, 17 Aug 2016 11:20:27 GMT
-- request:
-    method: put
-    uri: http://backend:5352/source/home:other_user/branch_test_package/_meta
-    body:
-      encoding: UTF-8
-      string: |
-        <package name="branch_test_package" project="home:other_user">
-          <title/>
-          <description/>
-        </package>
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '122'
-    body:
-      encoding: UTF-8
-      string: |
-        <package name="branch_test_package" project="home:other_user">
-          <title></title>
-          <description></description>
-        </package>
-    http_version: 
-  recorded_at: Wed, 17 Aug 2016 11:20:27 GMT
-- request:
-    method: put
-    uri: http://backend:5352/source/home:other_user/branch_test_package/somefile.txt
-    body:
-      encoding: UTF-8
-      string: Et ut ut aut sequi. Tenetur nam velit error vero. Dolore et magni ut
-        quis dolor sequi. Iure aut omnis id alias temporibus esse.
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '207'
-    body:
-      encoding: UTF-8
-      string: |
-        <revision rev="5" vrev="5">
-          <srcmd5>1fe3a0d7d72c9fc26d8a47c2ba88d5aa</srcmd5>
-          <version>unknown</version>
-          <time>1471432827</time>
-          <user>unknown</user>
-          <comment></comment>
-          <requestid/>
-        </revision>
-    http_version: 
-  recorded_at: Wed, 17 Aug 2016 11:20:27 GMT
-- request:
-    method: get
-    uri: http://backend:5352/build/home:user_tab_user/_result?package=group_test_package&view=status
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Content-Type:
-      - text/plain
-      Accept-Encoding:
-      - identity
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 404
-      message: project 'home user_tab_user' does not exist
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '164'
-    body:
-      encoding: UTF-8
-      string: |
-        <status code="404">
-          <summary>project 'home:user_tab_user' does not exist</summary>
-          <details>404 project 'home:user_tab_user' does not exist</details>
-        </status>
-    http_version: 
-  recorded_at: Wed, 17 Aug 2016 11:20:28 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/home:user_tab_user/group_test_package?nofilename=1&view=info&withchangesmd5=1
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 404
-      message: project 'home user_tab_user' does not exist
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '164'
-    body:
-      encoding: UTF-8
-      string: |
-        <status code="404">
-          <summary>project 'home:user_tab_user' does not exist</summary>
-          <details>404 project 'home:user_tab_user' does not exist</details>
-        </status>
-    http_version: 
-  recorded_at: Wed, 17 Aug 2016 11:20:28 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/home:user_tab_user/group_test_package
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 404
-      message: project 'home user_tab_user' does not exist
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '164'
-    body:
-      encoding: UTF-8
-      string: |
-        <status code="404">
-          <summary>project 'home:user_tab_user' does not exist</summary>
-          <details>404 project 'home:user_tab_user' does not exist</details>
-        </status>
-    http_version: 
-  recorded_at: Wed, 17 Aug 2016 11:20:28 GMT
-- request:
-    method: post
-    uri: http://backend:5352/source/home:user_tab_user/group_test_package?cmd=diff&linkrev=base&onlyissues=1&orev=0&view=xml
-    body:
-      encoding: UTF-8
-      string: ''
-    headers:
-      Content-Type:
-      - application/octet-stream
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 404
-      message: project 'home user_tab_user' does not exist
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '164'
-    body:
-      encoding: UTF-8
-      string: |
-        <status code="404">
-          <summary>project 'home:user_tab_user' does not exist</summary>
-          <details>404 project 'home:user_tab_user' does not exist</details>
-        </status>
-    http_version: 
-  recorded_at: Wed, 17 Aug 2016 11:20:28 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/home:user_tab_user/group_test_package
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 404
-      message: project 'home user_tab_user' does not exist
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '164'
-    body:
-      encoding: UTF-8
-      string: |
-        <status code="404">
-          <summary>project 'home:user_tab_user' does not exist</summary>
-          <details>404 project 'home:user_tab_user' does not exist</details>
-        </status>
-    http_version: 
-  recorded_at: Wed, 17 Aug 2016 11:20:28 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/home:user_tab_user/group_test_package?expand=1
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Content-Type:
-      - text/plain
-      Accept-Encoding:
-      - identity
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 404
-      message: project 'home user_tab_user' does not exist
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '164'
-    body:
-      encoding: UTF-8
-      string: |
-        <status code="404">
-          <summary>project 'home:user_tab_user' does not exist</summary>
-          <details>404 project 'home:user_tab_user' does not exist</details>
-        </status>
-    http_version: 
-  recorded_at: Wed, 17 Aug 2016 11:20:28 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/home:user_tab_user/group_test_package
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Content-Type:
-      - text/plain
-      Accept-Encoding:
-      - identity
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 404
-      message: project 'home user_tab_user' does not exist
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '164'
-    body:
-      encoding: UTF-8
-      string: |
-        <status code="404">
-          <summary>project 'home:user_tab_user' does not exist</summary>
-          <details>404 project 'home:user_tab_user' does not exist</details>
-        </status>
-    http_version: 
-  recorded_at: Wed, 17 Aug 2016 11:20:28 GMT
-- request:
-    method: get
-    uri: http://backend:5352/build/home:user_tab_user/_result?package=group_test_package&view=status
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Content-Type:
-      - text/plain
-      Accept-Encoding:
-      - identity
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 404
-      message: project 'home user_tab_user' does not exist
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '164'
-    body:
-      encoding: UTF-8
-      string: |
-        <status code="404">
-          <summary>project 'home:user_tab_user' does not exist</summary>
-          <details>404 project 'home:user_tab_user' does not exist</details>
-        </status>
-    http_version: 
-  recorded_at: Wed, 17 Aug 2016 11:20:28 GMT
-- request:
-    method: get
-    uri: http://backend:5352/build/home:user_tab_user/_result?package=group_test_package&view=status
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Content-Type:
-      - text/plain
-      Accept-Encoding:
-      - identity
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 404
-      message: project 'home user_tab_user' does not exist
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '164'
-    body:
-      encoding: UTF-8
-      string: |
-        <status code="404">
-          <summary>project 'home:user_tab_user' does not exist</summary>
-          <details>404 project 'home:user_tab_user' does not exist</details>
-        </status>
-    http_version: 
-  recorded_at: Wed, 17 Aug 2016 11:20:28 GMT
-- request:
-    method: get
-    uri: http://backend:5352/build/home:user_tab_user/_result?package=group_test_package&view=status
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Content-Type:
-      - text/plain
-      Accept-Encoding:
-      - identity
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 404
-      message: project 'home user_tab_user' does not exist
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '164'
-    body:
-      encoding: UTF-8
-      string: |
-        <status code="404">
-          <summary>project 'home:user_tab_user' does not exist</summary>
-          <details>404 project 'home:user_tab_user' does not exist</details>
-        </status>
-    http_version: 
-  recorded_at: Wed, 17 Aug 2016 11:20:29 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/home:user_tab_user/group_test_package
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 404
-      message: project 'home user_tab_user' does not exist
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '164'
-    body:
-      encoding: UTF-8
-      string: |
-        <status code="404">
-          <summary>project 'home:user_tab_user' does not exist</summary>
-          <details>404 project 'home:user_tab_user' does not exist</details>
-        </status>
-    http_version: 
-  recorded_at: Wed, 17 Aug 2016 11:20:29 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/home:user_tab_user/group_test_package?expand=1
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Content-Type:
-      - text/plain
-      Accept-Encoding:
-      - identity
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 404
-      message: project 'home user_tab_user' does not exist
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '164'
-    body:
-      encoding: UTF-8
-      string: |
-        <status code="404">
-          <summary>project 'home:user_tab_user' does not exist</summary>
-          <details>404 project 'home:user_tab_user' does not exist</details>
-        </status>
-    http_version: 
-  recorded_at: Wed, 17 Aug 2016 11:20:29 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/home:user_tab_user/group_test_package
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Content-Type:
-      - text/plain
-      Accept-Encoding:
-      - identity
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 404
-      message: project 'home user_tab_user' does not exist
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '164'
-    body:
-      encoding: UTF-8
-      string: |
-        <status code="404">
-          <summary>project 'home:user_tab_user' does not exist</summary>
-          <details>404 project 'home:user_tab_user' does not exist</details>
-        </status>
-    http_version: 
-  recorded_at: Wed, 17 Aug 2016 11:20:29 GMT
-- request:
-    method: get
-    uri: http://backend:5352/build/home:user_tab_user/_result?package=group_test_package&view=status
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Content-Type:
-      - text/plain
-      Accept-Encoding:
-      - identity
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 404
-      message: project 'home user_tab_user' does not exist
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '164'
-    body:
-      encoding: UTF-8
-      string: |
-        <status code="404">
-          <summary>project 'home:user_tab_user' does not exist</summary>
-          <details>404 project 'home:user_tab_user' does not exist</details>
-        </status>
-    http_version: 
-  recorded_at: Wed, 17 Aug 2016 11:20:29 GMT
-- request:
-    method: get
-    uri: http://backend:5352/build/home:user_tab_user/_result?package=group_test_package&view=status
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Content-Type:
-      - text/plain
-      Accept-Encoding:
-      - identity
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 404
-      message: project 'home user_tab_user' does not exist
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '164'
-    body:
-      encoding: UTF-8
-      string: |
-        <status code="404">
-          <summary>project 'home:user_tab_user' does not exist</summary>
-          <details>404 project 'home:user_tab_user' does not exist</details>
-        </status>
-    http_version: 
-  recorded_at: Wed, 17 Aug 2016 11:20:29 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/home:user_tab_user/group_test_package/_service
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Content-Type:
-      - text/plain
-      Accept-Encoding:
-      - identity
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 404
-      message: project 'home user_tab_user' does not exist
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '164'
-    body:
-      encoding: UTF-8
-      string: |
-        <status code="404">
-          <summary>project 'home:user_tab_user' does not exist</summary>
-          <details>404 project 'home:user_tab_user' does not exist</details>
-        </status>
-    http_version: 
-  recorded_at: Wed, 05 Oct 2016 09:08:47 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/home:user_tab_user/group_test_package/_service
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Content-Type:
-      - text/plain
-      Accept-Encoding:
-      - identity
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 404
-      message: project 'home user_tab_user' does not exist
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '164'
-    body:
-      encoding: UTF-8
-      string: |
-        <status code="404">
-          <summary>project 'home:user_tab_user' does not exist</summary>
-          <details>404 project 'home:user_tab_user' does not exist</details>
-        </status>
-    http_version: 
-  recorded_at: Wed, 05 Oct 2016 09:08:48 GMT
-- request:
-    method: get
-    uri: http://backend:5352/build/home:user_tab_user/_result?locallink=1&multibuild=1&package=group_test_package&view=status
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Content-Type:
-      - text/plain
-      Accept-Encoding:
-      - identity
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 404
-      message: project 'home user_tab_user' does not exist
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '164'
-    body:
-      encoding: UTF-8
-      string: |
-        <status code="404">
-          <summary>project 'home:user_tab_user' does not exist</summary>
-          <details>404 project 'home:user_tab_user' does not exist</details>
-        </status>
-    http_version: 
-  recorded_at: Fri, 20 Jan 2017 02:55:32 GMT
-- request:
-    method: get
-    uri: http://backend:5352/build/home:user_tab_user/_result?locallink=1&multibuild=1&package=group_test_package&view=status
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Content-Type:
-      - text/plain
-      Accept-Encoding:
-      - identity
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 404
-      message: project 'home user_tab_user' does not exist
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '164'
-    body:
-      encoding: UTF-8
-      string: |
-        <status code="404">
-          <summary>project 'home:user_tab_user' does not exist</summary>
-          <details>404 project 'home:user_tab_user' does not exist</details>
-        </status>
-    http_version: 
-  recorded_at: Fri, 20 Jan 2017 02:55:33 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/home:user_tab_user/group_test_package?expand=0
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 404
-      message: project 'home user_tab_user' does not exist
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '164'
-    body:
-      encoding: UTF-8
-      string: |
-        <status code="404">
-          <summary>project 'home:user_tab_user' does not exist</summary>
-          <details>404 project 'home:user_tab_user' does not exist</details>
-        </status>
-    http_version: 
-  recorded_at: Tue, 16 May 2017 15:09:45 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/home:user_tab_user/group_test_package?expand=0
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 404
-      message: project 'home user_tab_user' does not exist
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '164'
-    body:
-      encoding: UTF-8
-      string: |
-        <status code="404">
-          <summary>project 'home:user_tab_user' does not exist</summary>
-          <details>404 project 'home:user_tab_user' does not exist</details>
-        </status>
-    http_version: 
-  recorded_at: Tue, 16 May 2017 15:09:45 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/home:user_tab_user/group_test_package
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 404
-      message: project 'home user_tab_user' does not exist
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '164'
-    body:
-      encoding: UTF-8
-      string: |
-        <status code="404">
-          <summary>project 'home:user_tab_user' does not exist</summary>
-          <details>404 project 'home:user_tab_user' does not exist</details>
-        </status>
-    http_version: 
-  recorded_at: Fri, 16 Jun 2017 14:23:36 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/home:user_tab_user/group_test_package
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 404
-      message: project 'home user_tab_user' does not exist
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '164'
-    body:
-      encoding: UTF-8
-      string: |
-        <status code="404">
-          <summary>project 'home:user_tab_user' does not exist</summary>
-          <details>404 project 'home:user_tab_user' does not exist</details>
-        </status>
-    http_version: 
-  recorded_at: Fri, 16 Jun 2017 14:23:36 GMT
-- request:
-    method: put
     uri: http://backend:5352/source/home:package_test_user/_meta?user=package_test_user
     body:
       encoding: UTF-8
@@ -995,7 +40,7 @@ http_interactions:
           <person userid="package_test_user" role="maintainer" />
         </project>
     http_version: 
-  recorded_at: Wed, 03 Jan 2018 13:15:50 GMT
+  recorded_at: Tue, 16 Jan 2018 14:01:24 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:user_tab_user/_meta?user=user_tab_user
@@ -1036,7 +81,7 @@ http_interactions:
           <person userid="user_tab_user" role="maintainer" />
         </project>
     http_version: 
-  recorded_at: Wed, 03 Jan 2018 13:15:50 GMT
+  recorded_at: Tue, 16 Jan 2018 14:01:24 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:user_tab_user/group_test_package/_meta?user=user_tab_user
@@ -1044,8 +89,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="group_test_package" project="home:user_tab_user">
-          <title>Dulce et Decorum Est</title>
-          <description>Natus est dolor qui illo rerum autem ex.</description>
+          <title>Down to a Sunless Sea</title>
+          <description>Unde debitis praesentium et beatae quae adipisci et.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -1066,16 +111,16 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '184'
+      - '197'
     body:
       encoding: UTF-8
       string: |
         <package name="group_test_package" project="home:user_tab_user">
-          <title>Dulce et Decorum Est</title>
-          <description>Natus est dolor qui illo rerum autem ex.</description>
+          <title>Down to a Sunless Sea</title>
+          <description>Unde debitis praesentium et beatae quae adipisci et.</description>
         </package>
     http_version: 
-  recorded_at: Wed, 03 Jan 2018 13:15:50 GMT
+  recorded_at: Tue, 16 Jan 2018 14:01:24 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:user_tab_user/group_test_package/_meta
@@ -1083,8 +128,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="group_test_package" project="home:user_tab_user">
-          <title>Dulce et Decorum Est</title>
-          <description>Natus est dolor qui illo rerum autem ex.</description>
+          <title>Down to a Sunless Sea</title>
+          <description>Unde debitis praesentium et beatae quae adipisci et.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -1105,16 +150,16 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '184'
+      - '197'
     body:
       encoding: UTF-8
       string: |
         <package name="group_test_package" project="home:user_tab_user">
-          <title>Dulce et Decorum Est</title>
-          <description>Natus est dolor qui illo rerum autem ex.</description>
+          <title>Down to a Sunless Sea</title>
+          <description>Unde debitis praesentium et beatae quae adipisci et.</description>
         </package>
     http_version: 
-  recorded_at: Wed, 03 Jan 2018 13:15:50 GMT
+  recorded_at: Tue, 16 Jan 2018 14:01:24 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:other_user/_meta?user=other_user
@@ -1155,7 +200,7 @@ http_interactions:
           <person userid="other_user" role="maintainer" />
         </project>
     http_version: 
-  recorded_at: Wed, 03 Jan 2018 13:15:50 GMT
+  recorded_at: Tue, 16 Jan 2018 14:01:24 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:other_user/branch_test_package/_meta?user=user_tab_user
@@ -1163,9 +208,164 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="branch_test_package" project="home:other_user">
-          <title>Paths of Glory</title>
-          <description>Eius est sed ex qui.</description>
+          <title>For a Breath I Tarry</title>
+          <description>Et nulla voluptas excepturi ratione.</description>
         </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '178'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="branch_test_package" project="home:other_user">
+          <title>For a Breath I Tarry</title>
+          <description>Et nulla voluptas excepturi ratione.</description>
+        </package>
+    http_version: 
+  recorded_at: Tue, 16 Jan 2018 14:01:24 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:other_user/branch_test_package/_meta
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="branch_test_package" project="home:other_user">
+          <title>For a Breath I Tarry</title>
+          <description>Et nulla voluptas excepturi ratione.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '178'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="branch_test_package" project="home:other_user">
+          <title>For a Breath I Tarry</title>
+          <description>Et nulla voluptas excepturi ratione.</description>
+        </package>
+    http_version: 
+  recorded_at: Tue, 16 Jan 2018 14:01:24 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:other_user/branch_test_package/_config
+    body:
+      encoding: UTF-8
+      string: Quia velit eos suscipit nobis blanditiis. Delectus sunt labore et debitis
+        autem. Recusandae unde quia. Hic vitae labore numquam. Neque facilis sit tempora.
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '209'
+    body:
+      encoding: UTF-8
+      string: |
+        <revision rev="25" vrev="25">
+          <srcmd5>1d7563bc594c39c9833582218e5a11ef</srcmd5>
+          <version>unknown</version>
+          <time>1516111284</time>
+          <user>unknown</user>
+          <comment></comment>
+          <requestid/>
+        </revision>
+    http_version: 
+  recorded_at: Tue, 16 Jan 2018 14:01:24 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:other_user/branch_test_package/somefile.txt
+    body:
+      encoding: UTF-8
+      string: Officia quia repellendus quis. Velit ullam et. Praesentium dolorem quos
+        quae dolorum illum libero sit. Culpa officia autem voluptatem assumenda. Officiis
+        repudiandae et in.
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '209'
+    body:
+      encoding: UTF-8
+      string: |
+        <revision rev="26" vrev="26">
+          <srcmd5>1d7563bc594c39c9833582218e5a11ef</srcmd5>
+          <version>unknown</version>
+          <time>1516111284</time>
+          <user>unknown</user>
+          <comment></comment>
+          <requestid/>
+        </revision>
+    http_version: 
+  recorded_at: Tue, 16 Jan 2018 14:01:24 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:user_tab_user/group_test_package?nofilename=1&view=info&withchangesmd5=1
+    body:
+      encoding: US-ASCII
+      string: ''
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -1189,20 +389,17 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <package name="branch_test_package" project="home:other_user">
-          <title>Paths of Glory</title>
-          <description>Eius est sed ex qui.</description>
-        </package>
+        <sourceinfo package="group_test_package" srcmd5="d41d8cd98f00b204e9800998ecf8427e" verifymd5="d41d8cd98f00b204e9800998ecf8427e">
+          <revtime/>
+        </sourceinfo>
     http_version: 
-  recorded_at: Wed, 03 Jan 2018 13:15:50 GMT
+  recorded_at: Tue, 16 Jan 2018 14:01:25 GMT
 - request:
-    method: put
-    uri: http://backend:5352/source/home:other_user/branch_test_package/_config
+    method: get
+    uri: http://backend:5352/source/home:user_tab_user/group_test_package
     body:
-      encoding: UTF-8
-      string: Placeat et reiciendis officia enim dolorum. Ducimus alias consequuntur.
-        Dolorem quas quasi beatae commodi. Magnam cupiditate minima sunt. Est eaque
-        eveniet.
+      encoding: US-ASCII
+      string: ''
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -1222,20 +419,291 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '207'
+      - '93'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="4" vrev="4">
-          <srcmd5>2fe9cd2c9f3861154d92e8a8b97629a4</srcmd5>
-          <version>unknown</version>
-          <time>1514985350</time>
-          <user>unknown</user>
-          <comment></comment>
-          <requestid/>
-        </revision>
+        <directory name="group_test_package" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
+        </directory>
     http_version: 
-  recorded_at: Wed, 03 Jan 2018 13:15:50 GMT
+  recorded_at: Tue, 16 Jan 2018 14:01:25 GMT
+- request:
+    method: post
+    uri: http://backend:5352/source/home:user_tab_user/group_test_package?cmd=diff&linkrev=base&onlyissues=1&orev=0&view=xml
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Content-Type:
+      - application/octet-stream
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '314'
+    body:
+      encoding: UTF-8
+      string: |
+        <sourcediff key="04429e5eb3523e7cb3e15ee88d1605d6">
+          <old project="home:user_tab_user" package="group_test_package" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e" />
+          <new project="home:user_tab_user" package="group_test_package" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e" />
+          <files />
+        </sourcediff>
+    http_version: 
+  recorded_at: Tue, 16 Jan 2018 14:01:25 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:user_tab_user/group_test_package
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '93'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="group_test_package" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
+        </directory>
+    http_version: 
+  recorded_at: Tue, 16 Jan 2018 14:01:25 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:user_tab_user/group_test_package?expand=1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '93'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="group_test_package" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
+        </directory>
+    http_version: 
+  recorded_at: Tue, 16 Jan 2018 14:01:25 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:user_tab_user/group_test_package
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - text/plain
+      Accept-Encoding:
+      - identity
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '93'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="group_test_package" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
+        </directory>
+    http_version: 
+  recorded_at: Tue, 16 Jan 2018 14:01:25 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:user_tab_user/group_test_package/_service
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - text/plain
+      Accept-Encoding:
+      - identity
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 404
+      message: _service  no such file
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '122'
+    body:
+      encoding: UTF-8
+      string: |
+        <status code="404">
+          <summary>_service: no such file</summary>
+          <details>404 _service: no such file</details>
+        </status>
+    http_version: 
+  recorded_at: Tue, 16 Jan 2018 14:01:25 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:user_tab_user/group_test_package
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '93'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="group_test_package" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
+        </directory>
+    http_version: 
+  recorded_at: Tue, 16 Jan 2018 14:01:25 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:user_tab_user/group_test_package
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '93'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="group_test_package" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
+        </directory>
+    http_version: 
+  recorded_at: Tue, 16 Jan 2018 14:01:25 GMT
+- request:
+    method: get
+    uri: http://backend:5352/build/home:user_tab_user/_result?package=group_test_package&view=status
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - text/plain
+      Accept-Encoding:
+      - identity
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '56'
+    body:
+      encoding: UTF-8
+      string: '<resultlist state="00000000000000000000000000000000" />
+
+'
+    http_version: 
+  recorded_at: Tue, 16 Jan 2018 14:01:25 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:user_tab_user/group_test_package/_meta?user=user_tab_user
@@ -1243,8 +711,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="group_test_package" project="home:user_tab_user">
-          <title>Dulce et Decorum Est</title>
-          <description>Natus est dolor qui illo rerum autem ex.</description>
+          <title>Down to a Sunless Sea</title>
+          <description>Unde debitis praesentium et beatae quae adipisci et.</description>
           <person userid="user_tab_user" role="maintainer"/>
           <group groupid="existing_group" role="bugowner"/>
           <group groupid="existing_group" role="maintainer"/>
@@ -1269,20 +737,20 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '399'
+      - '412'
     body:
       encoding: UTF-8
       string: |
         <package name="group_test_package" project="home:user_tab_user">
-          <title>Dulce et Decorum Est</title>
-          <description>Natus est dolor qui illo rerum autem ex.</description>
+          <title>Down to a Sunless Sea</title>
+          <description>Unde debitis praesentium et beatae quae adipisci et.</description>
           <person userid="user_tab_user" role="maintainer" />
           <group groupid="existing_group" role="bugowner" />
           <group groupid="existing_group" role="maintainer" />
           <group groupid="existing_group" role="reviewer" />
         </package>
     http_version: 
-  recorded_at: Wed, 03 Jan 2018 13:15:52 GMT
+  recorded_at: Tue, 16 Jan 2018 14:01:25 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:user_tab_user/group_test_package
@@ -1315,7 +783,112 @@ http_interactions:
         <directory name="group_test_package" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
         </directory>
     http_version: 
-  recorded_at: Wed, 03 Jan 2018 13:15:52 GMT
+  recorded_at: Tue, 16 Jan 2018 14:01:26 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:user_tab_user/group_test_package?expand=1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '93'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="group_test_package" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
+        </directory>
+    http_version: 
+  recorded_at: Tue, 16 Jan 2018 14:01:26 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:user_tab_user/group_test_package
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - text/plain
+      Accept-Encoding:
+      - identity
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '93'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="group_test_package" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
+        </directory>
+    http_version: 
+  recorded_at: Tue, 16 Jan 2018 14:01:26 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:user_tab_user/group_test_package/_service
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - text/plain
+      Accept-Encoding:
+      - identity
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 404
+      message: _service  no such file
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '122'
+    body:
+      encoding: UTF-8
+      string: |
+        <status code="404">
+          <summary>_service: no such file</summary>
+          <details>404 _service: no such file</details>
+        </status>
+    http_version: 
+  recorded_at: Tue, 16 Jan 2018 14:01:26 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:user_tab_user/group_test_package
@@ -1347,6 +920,74 @@ http_interactions:
       string: |
         <directory name="group_test_package" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
         </directory>
+    http_version: 
+  recorded_at: Tue, 16 Jan 2018 14:01:26 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:user_tab_user/group_test_package
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '93'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="group_test_package" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
+        </directory>
+    http_version: 
+  recorded_at: Tue, 16 Jan 2018 14:01:26 GMT
+- request:
+    method: get
+    uri: http://backend:5352/build/home:user_tab_user/_result?package=group_test_package&view=status
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - text/plain
+      Accept-Encoding:
+      - identity
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '56'
+    body:
+      encoding: UTF-8
+      string: '<resultlist state="00000000000000000000000000000000" />
+
+'
     http_version: 
   recorded_at: Wed, 03 Jan 2018 13:15:52 GMT
 - request:

--- a/src/api/spec/cassettes/Packages/behaves_like_user_tab/group_roles/Remove_role_from_group.yml
+++ b/src/api/spec/cassettes/Packages/behaves_like_user_tab/group_roles/Remove_role_from_group.yml
@@ -2,962 +2,6 @@
 http_interactions:
 - request:
     method: put
-    uri: http://backend:5352/source/home:other_user/_meta
-    body:
-      encoding: UTF-8
-      string: |
-        <project name="home:other_user">
-          <title/>
-          <description/>
-          <person userid="other_user" role="maintainer"/>
-        </project>
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '143'
-    body:
-      encoding: UTF-8
-      string: |
-        <project name="home:other_user">
-          <title></title>
-          <description></description>
-          <person userid="other_user" role="maintainer" />
-        </project>
-    http_version: 
-  recorded_at: Wed, 17 Aug 2016 11:20:31 GMT
-- request:
-    method: put
-    uri: http://backend:5352/source/home:other_user/branch_test_package/_meta
-    body:
-      encoding: UTF-8
-      string: |
-        <package name="branch_test_package" project="home:other_user">
-          <title/>
-          <description/>
-        </package>
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '122'
-    body:
-      encoding: UTF-8
-      string: |
-        <package name="branch_test_package" project="home:other_user">
-          <title></title>
-          <description></description>
-        </package>
-    http_version: 
-  recorded_at: Wed, 17 Aug 2016 11:20:31 GMT
-- request:
-    method: put
-    uri: http://backend:5352/source/home:other_user/branch_test_package/somefile.txt
-    body:
-      encoding: UTF-8
-      string: Similique aut quis omnis molestiae natus aliquid. Impedit voluptatem
-        autem. Sed quia molestiae ut. Est et odio aut. A quas velit ipsum voluptatem
-        delectus ratione.
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '207'
-    body:
-      encoding: UTF-8
-      string: |
-        <revision rev="6" vrev="6">
-          <srcmd5>79fe84ac13dd131e84530db9759cbdc2</srcmd5>
-          <version>unknown</version>
-          <time>1471432831</time>
-          <user>unknown</user>
-          <comment></comment>
-          <requestid/>
-        </revision>
-    http_version: 
-  recorded_at: Wed, 17 Aug 2016 11:20:31 GMT
-- request:
-    method: get
-    uri: http://backend:5352/build/home:user_tab_user/_result?package=group_test_package&view=status
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Content-Type:
-      - text/plain
-      Accept-Encoding:
-      - identity
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 404
-      message: project 'home user_tab_user' does not exist
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '164'
-    body:
-      encoding: UTF-8
-      string: |
-        <status code="404">
-          <summary>project 'home:user_tab_user' does not exist</summary>
-          <details>404 project 'home:user_tab_user' does not exist</details>
-        </status>
-    http_version: 
-  recorded_at: Wed, 17 Aug 2016 11:20:32 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/home:user_tab_user/group_test_package?nofilename=1&view=info&withchangesmd5=1
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 404
-      message: project 'home user_tab_user' does not exist
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '164'
-    body:
-      encoding: UTF-8
-      string: |
-        <status code="404">
-          <summary>project 'home:user_tab_user' does not exist</summary>
-          <details>404 project 'home:user_tab_user' does not exist</details>
-        </status>
-    http_version: 
-  recorded_at: Wed, 17 Aug 2016 11:20:32 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/home:user_tab_user/group_test_package
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 404
-      message: project 'home user_tab_user' does not exist
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '164'
-    body:
-      encoding: UTF-8
-      string: |
-        <status code="404">
-          <summary>project 'home:user_tab_user' does not exist</summary>
-          <details>404 project 'home:user_tab_user' does not exist</details>
-        </status>
-    http_version: 
-  recorded_at: Wed, 17 Aug 2016 11:20:32 GMT
-- request:
-    method: post
-    uri: http://backend:5352/source/home:user_tab_user/group_test_package?cmd=diff&linkrev=base&onlyissues=1&orev=0&view=xml
-    body:
-      encoding: UTF-8
-      string: ''
-    headers:
-      Content-Type:
-      - application/octet-stream
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 404
-      message: project 'home user_tab_user' does not exist
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '164'
-    body:
-      encoding: UTF-8
-      string: |
-        <status code="404">
-          <summary>project 'home:user_tab_user' does not exist</summary>
-          <details>404 project 'home:user_tab_user' does not exist</details>
-        </status>
-    http_version: 
-  recorded_at: Wed, 17 Aug 2016 11:20:32 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/home:user_tab_user/group_test_package
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 404
-      message: project 'home user_tab_user' does not exist
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '164'
-    body:
-      encoding: UTF-8
-      string: |
-        <status code="404">
-          <summary>project 'home:user_tab_user' does not exist</summary>
-          <details>404 project 'home:user_tab_user' does not exist</details>
-        </status>
-    http_version: 
-  recorded_at: Wed, 17 Aug 2016 11:20:32 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/home:user_tab_user/group_test_package?expand=1
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Content-Type:
-      - text/plain
-      Accept-Encoding:
-      - identity
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 404
-      message: project 'home user_tab_user' does not exist
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '164'
-    body:
-      encoding: UTF-8
-      string: |
-        <status code="404">
-          <summary>project 'home:user_tab_user' does not exist</summary>
-          <details>404 project 'home:user_tab_user' does not exist</details>
-        </status>
-    http_version: 
-  recorded_at: Wed, 17 Aug 2016 11:20:32 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/home:user_tab_user/group_test_package
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Content-Type:
-      - text/plain
-      Accept-Encoding:
-      - identity
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 404
-      message: project 'home user_tab_user' does not exist
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '164'
-    body:
-      encoding: UTF-8
-      string: |
-        <status code="404">
-          <summary>project 'home:user_tab_user' does not exist</summary>
-          <details>404 project 'home:user_tab_user' does not exist</details>
-        </status>
-    http_version: 
-  recorded_at: Wed, 17 Aug 2016 11:20:32 GMT
-- request:
-    method: get
-    uri: http://backend:5352/build/home:user_tab_user/_result?package=group_test_package&view=status
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Content-Type:
-      - text/plain
-      Accept-Encoding:
-      - identity
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 404
-      message: project 'home user_tab_user' does not exist
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '164'
-    body:
-      encoding: UTF-8
-      string: |
-        <status code="404">
-          <summary>project 'home:user_tab_user' does not exist</summary>
-          <details>404 project 'home:user_tab_user' does not exist</details>
-        </status>
-    http_version: 
-  recorded_at: Wed, 17 Aug 2016 11:20:32 GMT
-- request:
-    method: get
-    uri: http://backend:5352/build/home:user_tab_user/_result?package=group_test_package&view=status
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Content-Type:
-      - text/plain
-      Accept-Encoding:
-      - identity
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 404
-      message: project 'home user_tab_user' does not exist
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '164'
-    body:
-      encoding: UTF-8
-      string: |
-        <status code="404">
-          <summary>project 'home:user_tab_user' does not exist</summary>
-          <details>404 project 'home:user_tab_user' does not exist</details>
-        </status>
-    http_version: 
-  recorded_at: Wed, 17 Aug 2016 11:20:32 GMT
-- request:
-    method: get
-    uri: http://backend:5352/build/home:user_tab_user/_result?package=group_test_package&view=status
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Content-Type:
-      - text/plain
-      Accept-Encoding:
-      - identity
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 404
-      message: project 'home user_tab_user' does not exist
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '164'
-    body:
-      encoding: UTF-8
-      string: |
-        <status code="404">
-          <summary>project 'home:user_tab_user' does not exist</summary>
-          <details>404 project 'home:user_tab_user' does not exist</details>
-        </status>
-    http_version: 
-  recorded_at: Wed, 17 Aug 2016 11:20:32 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/home:user_tab_user/group_test_package
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 404
-      message: project 'home user_tab_user' does not exist
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '164'
-    body:
-      encoding: UTF-8
-      string: |
-        <status code="404">
-          <summary>project 'home:user_tab_user' does not exist</summary>
-          <details>404 project 'home:user_tab_user' does not exist</details>
-        </status>
-    http_version: 
-  recorded_at: Wed, 17 Aug 2016 11:20:32 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/home:user_tab_user/group_test_package?expand=1
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Content-Type:
-      - text/plain
-      Accept-Encoding:
-      - identity
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 404
-      message: project 'home user_tab_user' does not exist
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '164'
-    body:
-      encoding: UTF-8
-      string: |
-        <status code="404">
-          <summary>project 'home:user_tab_user' does not exist</summary>
-          <details>404 project 'home:user_tab_user' does not exist</details>
-        </status>
-    http_version: 
-  recorded_at: Wed, 17 Aug 2016 11:20:33 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/home:user_tab_user/group_test_package
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Content-Type:
-      - text/plain
-      Accept-Encoding:
-      - identity
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 404
-      message: project 'home user_tab_user' does not exist
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '164'
-    body:
-      encoding: UTF-8
-      string: |
-        <status code="404">
-          <summary>project 'home:user_tab_user' does not exist</summary>
-          <details>404 project 'home:user_tab_user' does not exist</details>
-        </status>
-    http_version: 
-  recorded_at: Wed, 17 Aug 2016 11:20:33 GMT
-- request:
-    method: get
-    uri: http://backend:5352/build/home:user_tab_user/_result?package=group_test_package&view=status
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Content-Type:
-      - text/plain
-      Accept-Encoding:
-      - identity
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 404
-      message: project 'home user_tab_user' does not exist
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '164'
-    body:
-      encoding: UTF-8
-      string: |
-        <status code="404">
-          <summary>project 'home:user_tab_user' does not exist</summary>
-          <details>404 project 'home:user_tab_user' does not exist</details>
-        </status>
-    http_version: 
-  recorded_at: Wed, 17 Aug 2016 11:20:33 GMT
-- request:
-    method: get
-    uri: http://backend:5352/build/home:user_tab_user/_result?package=group_test_package&view=status
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Content-Type:
-      - text/plain
-      Accept-Encoding:
-      - identity
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 404
-      message: project 'home user_tab_user' does not exist
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '164'
-    body:
-      encoding: UTF-8
-      string: |
-        <status code="404">
-          <summary>project 'home:user_tab_user' does not exist</summary>
-          <details>404 project 'home:user_tab_user' does not exist</details>
-        </status>
-    http_version: 
-  recorded_at: Wed, 17 Aug 2016 11:20:33 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/home:user_tab_user/group_test_package/_service
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Content-Type:
-      - text/plain
-      Accept-Encoding:
-      - identity
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 404
-      message: project 'home user_tab_user' does not exist
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '164'
-    body:
-      encoding: UTF-8
-      string: |
-        <status code="404">
-          <summary>project 'home:user_tab_user' does not exist</summary>
-          <details>404 project 'home:user_tab_user' does not exist</details>
-        </status>
-    http_version: 
-  recorded_at: Wed, 05 Oct 2016 09:08:40 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/home:user_tab_user/group_test_package/_service
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Content-Type:
-      - text/plain
-      Accept-Encoding:
-      - identity
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 404
-      message: project 'home user_tab_user' does not exist
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '164'
-    body:
-      encoding: UTF-8
-      string: |
-        <status code="404">
-          <summary>project 'home:user_tab_user' does not exist</summary>
-          <details>404 project 'home:user_tab_user' does not exist</details>
-        </status>
-    http_version: 
-  recorded_at: Wed, 05 Oct 2016 09:08:40 GMT
-- request:
-    method: get
-    uri: http://backend:5352/build/home:user_tab_user/_result?locallink=1&multibuild=1&package=group_test_package&view=status
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Content-Type:
-      - text/plain
-      Accept-Encoding:
-      - identity
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 404
-      message: project 'home user_tab_user' does not exist
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '164'
-    body:
-      encoding: UTF-8
-      string: |
-        <status code="404">
-          <summary>project 'home:user_tab_user' does not exist</summary>
-          <details>404 project 'home:user_tab_user' does not exist</details>
-        </status>
-    http_version: 
-  recorded_at: Fri, 20 Jan 2017 02:55:39 GMT
-- request:
-    method: get
-    uri: http://backend:5352/build/home:user_tab_user/_result?locallink=1&multibuild=1&package=group_test_package&view=status
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Content-Type:
-      - text/plain
-      Accept-Encoding:
-      - identity
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 404
-      message: project 'home user_tab_user' does not exist
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '164'
-    body:
-      encoding: UTF-8
-      string: |
-        <status code="404">
-          <summary>project 'home:user_tab_user' does not exist</summary>
-          <details>404 project 'home:user_tab_user' does not exist</details>
-        </status>
-    http_version: 
-  recorded_at: Fri, 20 Jan 2017 02:55:40 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/home:user_tab_user/group_test_package?expand=0
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 404
-      message: project 'home user_tab_user' does not exist
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '164'
-    body:
-      encoding: UTF-8
-      string: |
-        <status code="404">
-          <summary>project 'home:user_tab_user' does not exist</summary>
-          <details>404 project 'home:user_tab_user' does not exist</details>
-        </status>
-    http_version: 
-  recorded_at: Tue, 16 May 2017 15:09:51 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/home:user_tab_user/group_test_package?expand=0
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 404
-      message: project 'home user_tab_user' does not exist
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '164'
-    body:
-      encoding: UTF-8
-      string: |
-        <status code="404">
-          <summary>project 'home:user_tab_user' does not exist</summary>
-          <details>404 project 'home:user_tab_user' does not exist</details>
-        </status>
-    http_version: 
-  recorded_at: Tue, 16 May 2017 15:09:52 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/home:user_tab_user/group_test_package
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 404
-      message: project 'home user_tab_user' does not exist
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '164'
-    body:
-      encoding: UTF-8
-      string: |
-        <status code="404">
-          <summary>project 'home:user_tab_user' does not exist</summary>
-          <details>404 project 'home:user_tab_user' does not exist</details>
-        </status>
-    http_version: 
-  recorded_at: Fri, 16 Jun 2017 14:23:43 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/home:user_tab_user/group_test_package
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 404
-      message: project 'home user_tab_user' does not exist
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '164'
-    body:
-      encoding: UTF-8
-      string: |
-        <status code="404">
-          <summary>project 'home:user_tab_user' does not exist</summary>
-          <details>404 project 'home:user_tab_user' does not exist</details>
-        </status>
-    http_version: 
-  recorded_at: Fri, 16 Jun 2017 14:23:44 GMT
-- request:
-    method: put
     uri: http://backend:5352/source/home:package_test_user/_meta?user=package_test_user
     body:
       encoding: UTF-8
@@ -996,7 +40,7 @@ http_interactions:
           <person userid="package_test_user" role="maintainer" />
         </project>
     http_version: 
-  recorded_at: Wed, 03 Jan 2018 13:15:21 GMT
+  recorded_at: Tue, 16 Jan 2018 14:01:13 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:user_tab_user/_meta?user=user_tab_user
@@ -1037,16 +81,16 @@ http_interactions:
           <person userid="user_tab_user" role="maintainer" />
         </project>
     http_version: 
-  recorded_at: Wed, 03 Jan 2018 13:15:21 GMT
+  recorded_at: Tue, 16 Jan 2018 14:01:14 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:user_tab_user/group_test_package/_meta?user=user_tab_user
+    uri: http://backend:5352/source/home:user_tab_user/group_test_package/_meta?user=package_test_user
     body:
       encoding: UTF-8
       string: |
         <package name="group_test_package" project="home:user_tab_user">
-          <title>If Not Now, When?</title>
-          <description>Eius illum provident omnis perspiciatis voluptate.</description>
+          <title>Consider Phlebas</title>
+          <description>Pariatur explicabo deleniti aut quia ut magni.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -1067,16 +111,16 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '191'
+      - '186'
     body:
       encoding: UTF-8
       string: |
         <package name="group_test_package" project="home:user_tab_user">
-          <title>If Not Now, When?</title>
-          <description>Eius illum provident omnis perspiciatis voluptate.</description>
+          <title>Consider Phlebas</title>
+          <description>Pariatur explicabo deleniti aut quia ut magni.</description>
         </package>
     http_version: 
-  recorded_at: Wed, 03 Jan 2018 13:15:21 GMT
+  recorded_at: Tue, 16 Jan 2018 14:01:14 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:user_tab_user/group_test_package/_meta
@@ -1084,8 +128,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="group_test_package" project="home:user_tab_user">
-          <title>If Not Now, When?</title>
-          <description>Eius illum provident omnis perspiciatis voluptate.</description>
+          <title>Consider Phlebas</title>
+          <description>Pariatur explicabo deleniti aut quia ut magni.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -1106,16 +150,16 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '191'
+      - '186'
     body:
       encoding: UTF-8
       string: |
         <package name="group_test_package" project="home:user_tab_user">
-          <title>If Not Now, When?</title>
-          <description>Eius illum provident omnis perspiciatis voluptate.</description>
+          <title>Consider Phlebas</title>
+          <description>Pariatur explicabo deleniti aut quia ut magni.</description>
         </package>
     http_version: 
-  recorded_at: Wed, 03 Jan 2018 13:15:21 GMT
+  recorded_at: Tue, 16 Jan 2018 14:01:14 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:other_user/_meta?user=other_user
@@ -1156,16 +200,16 @@ http_interactions:
           <person userid="other_user" role="maintainer" />
         </project>
     http_version: 
-  recorded_at: Wed, 03 Jan 2018 13:15:21 GMT
+  recorded_at: Tue, 16 Jan 2018 14:01:14 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:other_user/branch_test_package/_meta?user=user_tab_user
+    uri: http://backend:5352/source/home:other_user/branch_test_package/_meta?user=package_test_user
     body:
       encoding: UTF-8
       string: |
         <package name="branch_test_package" project="home:other_user">
-          <title>The Violent Bear It Away</title>
-          <description>Sint dolores asperiores ea esse atque.</description>
+          <title>A Swiftly Tilting Planet</title>
+          <description>Totam in aut cum tempore vitae.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -1186,23 +230,64 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '184'
+      - '177'
     body:
       encoding: UTF-8
       string: |
         <package name="branch_test_package" project="home:other_user">
-          <title>The Violent Bear It Away</title>
-          <description>Sint dolores asperiores ea esse atque.</description>
+          <title>A Swiftly Tilting Planet</title>
+          <description>Totam in aut cum tempore vitae.</description>
         </package>
     http_version: 
-  recorded_at: Wed, 03 Jan 2018 13:15:22 GMT
+  recorded_at: Tue, 16 Jan 2018 14:01:14 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:other_user/branch_test_package/_meta
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="branch_test_package" project="home:other_user">
+          <title>A Swiftly Tilting Planet</title>
+          <description>Totam in aut cum tempore vitae.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '177'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="branch_test_package" project="home:other_user">
+          <title>A Swiftly Tilting Planet</title>
+          <description>Totam in aut cum tempore vitae.</description>
+        </package>
+    http_version: 
+  recorded_at: Tue, 16 Jan 2018 14:01:14 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:other_user/branch_test_package/_config
     body:
       encoding: UTF-8
-      string: In occaecati debitis ut. Ut error reprehenderit qui cupiditate excepturi
-        autem velit. Cumque porro repellendus quam possimus assumenda.
+      string: Est explicabo qui facilis dicta occaecati illum suscipit. Consequatur
+        doloremque culpa exercitationem ullam doloribus. Ut dolores suscipit quia
+        ducimus rem. Voluptatem minima sit repellat consequuntur dolorem ut vel. Blanditiis
+        numquam perspiciatis omnis totam error autem.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -1222,20 +307,405 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '207'
+      - '209'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="2" vrev="2">
-          <srcmd5>1bcb8f5d71287384f62055cb0e354363</srcmd5>
+        <revision rev="19" vrev="19">
+          <srcmd5>d749f37df7fa9f9a7809aa7c4b736174</srcmd5>
           <version>unknown</version>
-          <time>1514985322</time>
+          <time>1516111274</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
     http_version: 
-  recorded_at: Wed, 03 Jan 2018 13:15:22 GMT
+  recorded_at: Tue, 16 Jan 2018 14:01:14 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:other_user/branch_test_package/somefile.txt
+    body:
+      encoding: UTF-8
+      string: Officia quia repellendus quis. Velit ullam et. Praesentium dolorem quos
+        quae dolorum illum libero sit. Culpa officia autem voluptatem assumenda. Officiis
+        repudiandae et in.
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '209'
+    body:
+      encoding: UTF-8
+      string: |
+        <revision rev="20" vrev="20">
+          <srcmd5>0ccdc8eeb030a75fc6cee80f6cc88ce3</srcmd5>
+          <version>unknown</version>
+          <time>1516111274</time>
+          <user>unknown</user>
+          <comment></comment>
+          <requestid/>
+        </revision>
+    http_version: 
+  recorded_at: Tue, 16 Jan 2018 14:01:14 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:user_tab_user/group_test_package?nofilename=1&view=info&withchangesmd5=1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '156'
+    body:
+      encoding: UTF-8
+      string: |
+        <sourceinfo package="group_test_package" srcmd5="d41d8cd98f00b204e9800998ecf8427e" verifymd5="d41d8cd98f00b204e9800998ecf8427e">
+          <revtime/>
+        </sourceinfo>
+    http_version: 
+  recorded_at: Tue, 16 Jan 2018 14:01:15 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:user_tab_user/group_test_package
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '93'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="group_test_package" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
+        </directory>
+    http_version: 
+  recorded_at: Tue, 16 Jan 2018 14:01:15 GMT
+- request:
+    method: post
+    uri: http://backend:5352/source/home:user_tab_user/group_test_package?cmd=diff&linkrev=base&onlyissues=1&orev=0&view=xml
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Content-Type:
+      - application/octet-stream
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '314'
+    body:
+      encoding: UTF-8
+      string: |
+        <sourcediff key="04429e5eb3523e7cb3e15ee88d1605d6">
+          <old project="home:user_tab_user" package="group_test_package" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e" />
+          <new project="home:user_tab_user" package="group_test_package" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e" />
+          <files />
+        </sourcediff>
+    http_version: 
+  recorded_at: Tue, 16 Jan 2018 14:01:15 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:user_tab_user/group_test_package
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '93'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="group_test_package" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
+        </directory>
+    http_version: 
+  recorded_at: Tue, 16 Jan 2018 14:01:15 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:user_tab_user/group_test_package?expand=1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '93'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="group_test_package" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
+        </directory>
+    http_version: 
+  recorded_at: Tue, 16 Jan 2018 14:01:15 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:user_tab_user/group_test_package
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - text/plain
+      Accept-Encoding:
+      - identity
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '93'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="group_test_package" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
+        </directory>
+    http_version: 
+  recorded_at: Tue, 16 Jan 2018 14:01:15 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:user_tab_user/group_test_package/_service
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - text/plain
+      Accept-Encoding:
+      - identity
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 404
+      message: _service  no such file
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '122'
+    body:
+      encoding: UTF-8
+      string: |
+        <status code="404">
+          <summary>_service: no such file</summary>
+          <details>404 _service: no such file</details>
+        </status>
+    http_version: 
+  recorded_at: Tue, 16 Jan 2018 14:01:15 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:user_tab_user/group_test_package
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '93'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="group_test_package" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
+        </directory>
+    http_version: 
+  recorded_at: Tue, 16 Jan 2018 14:01:15 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:user_tab_user/group_test_package
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '93'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="group_test_package" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
+        </directory>
+    http_version: 
+  recorded_at: Tue, 16 Jan 2018 14:01:15 GMT
+- request:
+    method: get
+    uri: http://backend:5352/build/home:user_tab_user/_result?package=group_test_package&view=status
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - text/plain
+      Accept-Encoding:
+      - identity
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '56'
+    body:
+      encoding: UTF-8
+      string: '<resultlist state="00000000000000000000000000000000" />
+
+'
+    http_version: 
+  recorded_at: Tue, 16 Jan 2018 14:01:15 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:user_tab_user/group_test_package/_meta?user=user_tab_user
@@ -1243,8 +713,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="group_test_package" project="home:user_tab_user">
-          <title>If Not Now, When?</title>
-          <description>Eius illum provident omnis perspiciatis voluptate.</description>
+          <title>Consider Phlebas</title>
+          <description>Pariatur explicabo deleniti aut quia ut magni.</description>
           <person userid="user_tab_user" role="maintainer"/>
           <group groupid="existing_group" role="maintainer"/>
         </package>
@@ -1267,13 +737,377 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '300'
+      - '295'
     body:
       encoding: UTF-8
       string: |
         <package name="group_test_package" project="home:user_tab_user">
-          <title>If Not Now, When?</title>
-          <description>Eius illum provident omnis perspiciatis voluptate.</description>
+          <title>Consider Phlebas</title>
+          <description>Pariatur explicabo deleniti aut quia ut magni.</description>
+          <person userid="user_tab_user" role="maintainer" />
+          <group groupid="existing_group" role="maintainer" />
+        </package>
+    http_version: 
+  recorded_at: Tue, 16 Jan 2018 14:01:16 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:user_tab_user/group_test_package/_meta?user=user_tab_user
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="group_test_package" project="home:user_tab_user">
+          <title>Consider Phlebas</title>
+          <description>Pariatur explicabo deleniti aut quia ut magni.</description>
+          <person userid="user_tab_user" role="maintainer"/>
+          <group groupid="existing_group" role="maintainer"/>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '295'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="group_test_package" project="home:user_tab_user">
+          <title>Consider Phlebas</title>
+          <description>Pariatur explicabo deleniti aut quia ut magni.</description>
+          <person userid="user_tab_user" role="maintainer" />
+          <group groupid="existing_group" role="maintainer" />
+        </package>
+    http_version: 
+  recorded_at: Tue, 16 Jan 2018 14:01:16 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:user_tab_user/group_test_package
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '93'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="group_test_package" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
+        </directory>
+    http_version: 
+  recorded_at: Tue, 16 Jan 2018 14:01:16 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:user_tab_user/group_test_package?expand=1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '93'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="group_test_package" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
+        </directory>
+    http_version: 
+  recorded_at: Tue, 16 Jan 2018 14:01:16 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:user_tab_user/group_test_package
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - text/plain
+      Accept-Encoding:
+      - identity
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '93'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="group_test_package" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
+        </directory>
+    http_version: 
+  recorded_at: Tue, 16 Jan 2018 14:01:16 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:user_tab_user/group_test_package/_service
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - text/plain
+      Accept-Encoding:
+      - identity
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 404
+      message: _service  no such file
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '122'
+    body:
+      encoding: UTF-8
+      string: |
+        <status code="404">
+          <summary>_service: no such file</summary>
+          <details>404 _service: no such file</details>
+        </status>
+    http_version: 
+  recorded_at: Tue, 16 Jan 2018 14:01:16 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:user_tab_user/group_test_package
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '93'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="group_test_package" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
+        </directory>
+    http_version: 
+  recorded_at: Tue, 16 Jan 2018 14:01:16 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:user_tab_user/group_test_package
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '93'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="group_test_package" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
+        </directory>
+    http_version: 
+  recorded_at: Tue, 16 Jan 2018 14:01:16 GMT
+- request:
+    method: get
+    uri: http://backend:5352/build/home:user_tab_user/_result?package=group_test_package&view=status
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - text/plain
+      Accept-Encoding:
+      - identity
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '56'
+    body:
+      encoding: UTF-8
+      string: '<resultlist state="00000000000000000000000000000000" />
+
+'
+    http_version: 
+  recorded_at: Tue, 16 Jan 2018 14:01:16 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:other_user/branch_test_package/_meta?user=user_tab_user
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="branch_test_package" project="home:other_user">
+          <title>The Sun Also Rises</title>
+          <description>Sequi eum velit ut explicabo excepturi.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '179'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="branch_test_package" project="home:other_user">
+          <title>The Sun Also Rises</title>
+          <description>Sequi eum velit ut explicabo excepturi.</description>
+        </package>
+    http_version: 
+  recorded_at: Tue, 16 Jan 2018 14:03:31 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:user_tab_user/group_test_package/_meta?user=user_tab_user
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="group_test_package" project="home:user_tab_user">
+          <title>The Daffodil Sky</title>
+          <description>Ut corrupti maiores odio voluptas qui quia nisi laudantium.</description>
+          <person userid="user_tab_user" role="maintainer"/>
+          <group groupid="existing_group" role="maintainer"/>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '308'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="group_test_package" project="home:user_tab_user">
+          <title>The Daffodil Sky</title>
+          <description>Ut corrupti maiores odio voluptas qui quia nisi laudantium.</description>
           <person userid="user_tab_user" role="maintainer" />
           <group groupid="existing_group" role="maintainer" />
         </package>

--- a/src/api/spec/cassettes/Packages/behaves_like_user_tab/group_roles/Viewing_group_roles.yml
+++ b/src/api/spec/cassettes/Packages/behaves_like_user_tab/group_roles/Viewing_group_roles.yml
@@ -2,597 +2,6 @@
 http_interactions:
 - request:
     method: put
-    uri: http://backend:5352/source/home:other_user/_meta
-    body:
-      encoding: UTF-8
-      string: |
-        <project name="home:other_user">
-          <title/>
-          <description/>
-          <person userid="other_user" role="maintainer"/>
-        </project>
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '143'
-    body:
-      encoding: UTF-8
-      string: |
-        <project name="home:other_user">
-          <title></title>
-          <description></description>
-          <person userid="other_user" role="maintainer" />
-        </project>
-    http_version: 
-  recorded_at: Wed, 17 Aug 2016 11:20:39 GMT
-- request:
-    method: put
-    uri: http://backend:5352/source/home:other_user/branch_test_package/_meta
-    body:
-      encoding: UTF-8
-      string: |
-        <package name="branch_test_package" project="home:other_user">
-          <title/>
-          <description/>
-        </package>
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '122'
-    body:
-      encoding: UTF-8
-      string: |
-        <package name="branch_test_package" project="home:other_user">
-          <title></title>
-          <description></description>
-        </package>
-    http_version: 
-  recorded_at: Wed, 17 Aug 2016 11:20:39 GMT
-- request:
-    method: put
-    uri: http://backend:5352/source/home:other_user/branch_test_package/somefile.txt
-    body:
-      encoding: UTF-8
-      string: Neque officiis quos dolor animi saepe quam sit. Qui est veniam inventore.
-        Expedita debitis dolore doloribus et quas.
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '207'
-    body:
-      encoding: UTF-8
-      string: |
-        <revision rev="8" vrev="8">
-          <srcmd5>282e862b21f069cb85f9b6af3761f804</srcmd5>
-          <version>unknown</version>
-          <time>1471432839</time>
-          <user>unknown</user>
-          <comment></comment>
-          <requestid/>
-        </revision>
-    http_version: 
-  recorded_at: Wed, 17 Aug 2016 11:20:39 GMT
-- request:
-    method: get
-    uri: http://backend:5352/build/home:user_tab_user/_result?package=group_test_package&view=status
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Content-Type:
-      - text/plain
-      Accept-Encoding:
-      - identity
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 404
-      message: project 'home user_tab_user' does not exist
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '164'
-    body:
-      encoding: UTF-8
-      string: |
-        <status code="404">
-          <summary>project 'home:user_tab_user' does not exist</summary>
-          <details>404 project 'home:user_tab_user' does not exist</details>
-        </status>
-    http_version: 
-  recorded_at: Wed, 17 Aug 2016 11:20:40 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/home:user_tab_user/group_test_package?nofilename=1&view=info&withchangesmd5=1
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 404
-      message: project 'home user_tab_user' does not exist
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '164'
-    body:
-      encoding: UTF-8
-      string: |
-        <status code="404">
-          <summary>project 'home:user_tab_user' does not exist</summary>
-          <details>404 project 'home:user_tab_user' does not exist</details>
-        </status>
-    http_version: 
-  recorded_at: Wed, 17 Aug 2016 11:20:40 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/home:user_tab_user/group_test_package
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 404
-      message: project 'home user_tab_user' does not exist
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '164'
-    body:
-      encoding: UTF-8
-      string: |
-        <status code="404">
-          <summary>project 'home:user_tab_user' does not exist</summary>
-          <details>404 project 'home:user_tab_user' does not exist</details>
-        </status>
-    http_version: 
-  recorded_at: Wed, 17 Aug 2016 11:20:40 GMT
-- request:
-    method: post
-    uri: http://backend:5352/source/home:user_tab_user/group_test_package?cmd=diff&linkrev=base&onlyissues=1&orev=0&view=xml
-    body:
-      encoding: UTF-8
-      string: ''
-    headers:
-      Content-Type:
-      - application/octet-stream
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 404
-      message: project 'home user_tab_user' does not exist
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '164'
-    body:
-      encoding: UTF-8
-      string: |
-        <status code="404">
-          <summary>project 'home:user_tab_user' does not exist</summary>
-          <details>404 project 'home:user_tab_user' does not exist</details>
-        </status>
-    http_version: 
-  recorded_at: Wed, 17 Aug 2016 11:20:40 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/home:user_tab_user/group_test_package
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 404
-      message: project 'home user_tab_user' does not exist
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '164'
-    body:
-      encoding: UTF-8
-      string: |
-        <status code="404">
-          <summary>project 'home:user_tab_user' does not exist</summary>
-          <details>404 project 'home:user_tab_user' does not exist</details>
-        </status>
-    http_version: 
-  recorded_at: Wed, 17 Aug 2016 11:20:40 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/home:user_tab_user/group_test_package?expand=1
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Content-Type:
-      - text/plain
-      Accept-Encoding:
-      - identity
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 404
-      message: project 'home user_tab_user' does not exist
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '164'
-    body:
-      encoding: UTF-8
-      string: |
-        <status code="404">
-          <summary>project 'home:user_tab_user' does not exist</summary>
-          <details>404 project 'home:user_tab_user' does not exist</details>
-        </status>
-    http_version: 
-  recorded_at: Wed, 17 Aug 2016 11:20:40 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/home:user_tab_user/group_test_package
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Content-Type:
-      - text/plain
-      Accept-Encoding:
-      - identity
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 404
-      message: project 'home user_tab_user' does not exist
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '164'
-    body:
-      encoding: UTF-8
-      string: |
-        <status code="404">
-          <summary>project 'home:user_tab_user' does not exist</summary>
-          <details>404 project 'home:user_tab_user' does not exist</details>
-        </status>
-    http_version: 
-  recorded_at: Wed, 17 Aug 2016 11:20:40 GMT
-- request:
-    method: get
-    uri: http://backend:5352/build/home:user_tab_user/_result?package=group_test_package&view=status
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Content-Type:
-      - text/plain
-      Accept-Encoding:
-      - identity
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 404
-      message: project 'home user_tab_user' does not exist
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '164'
-    body:
-      encoding: UTF-8
-      string: |
-        <status code="404">
-          <summary>project 'home:user_tab_user' does not exist</summary>
-          <details>404 project 'home:user_tab_user' does not exist</details>
-        </status>
-    http_version: 
-  recorded_at: Wed, 17 Aug 2016 11:20:40 GMT
-- request:
-    method: get
-    uri: http://backend:5352/build/home:user_tab_user/_result?package=group_test_package&view=status
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Content-Type:
-      - text/plain
-      Accept-Encoding:
-      - identity
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 404
-      message: project 'home user_tab_user' does not exist
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '164'
-    body:
-      encoding: UTF-8
-      string: |
-        <status code="404">
-          <summary>project 'home:user_tab_user' does not exist</summary>
-          <details>404 project 'home:user_tab_user' does not exist</details>
-        </status>
-    http_version: 
-  recorded_at: Wed, 17 Aug 2016 11:20:40 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/home:user_tab_user/group_test_package/_service
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Content-Type:
-      - text/plain
-      Accept-Encoding:
-      - identity
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 404
-      message: project 'home user_tab_user' does not exist
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '164'
-    body:
-      encoding: UTF-8
-      string: |
-        <status code="404">
-          <summary>project 'home:user_tab_user' does not exist</summary>
-          <details>404 project 'home:user_tab_user' does not exist</details>
-        </status>
-    http_version: 
-  recorded_at: Wed, 05 Oct 2016 09:08:36 GMT
-- request:
-    method: get
-    uri: http://backend:5352/build/home:user_tab_user/_result?locallink=1&multibuild=1&package=group_test_package&view=status
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Content-Type:
-      - text/plain
-      Accept-Encoding:
-      - identity
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 404
-      message: project 'home user_tab_user' does not exist
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '164'
-    body:
-      encoding: UTF-8
-      string: |
-        <status code="404">
-          <summary>project 'home:user_tab_user' does not exist</summary>
-          <details>404 project 'home:user_tab_user' does not exist</details>
-        </status>
-    http_version: 
-  recorded_at: Fri, 20 Jan 2017 02:55:36 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/home:user_tab_user/group_test_package?expand=0
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 404
-      message: project 'home user_tab_user' does not exist
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '164'
-    body:
-      encoding: UTF-8
-      string: |
-        <status code="404">
-          <summary>project 'home:user_tab_user' does not exist</summary>
-          <details>404 project 'home:user_tab_user' does not exist</details>
-        </status>
-    http_version: 
-  recorded_at: Tue, 16 May 2017 15:09:58 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/home:user_tab_user/group_test_package
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 404
-      message: project 'home user_tab_user' does not exist
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '164'
-    body:
-      encoding: UTF-8
-      string: |
-        <status code="404">
-          <summary>project 'home:user_tab_user' does not exist</summary>
-          <details>404 project 'home:user_tab_user' does not exist</details>
-        </status>
-    http_version: 
-  recorded_at: Fri, 16 Jun 2017 14:23:32 GMT
-- request:
-    method: put
     uri: http://backend:5352/source/home:package_test_user/_meta?user=package_test_user
     body:
       encoding: UTF-8
@@ -631,7 +40,7 @@ http_interactions:
           <person userid="package_test_user" role="maintainer" />
         </project>
     http_version: 
-  recorded_at: Wed, 03 Jan 2018 13:15:36 GMT
+  recorded_at: Tue, 16 Jan 2018 14:01:21 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:user_tab_user/_meta?user=user_tab_user
@@ -672,7 +81,7 @@ http_interactions:
           <person userid="user_tab_user" role="maintainer" />
         </project>
     http_version: 
-  recorded_at: Wed, 03 Jan 2018 13:15:36 GMT
+  recorded_at: Tue, 16 Jan 2018 14:01:21 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:user_tab_user/group_test_package/_meta?user=user_tab_user
@@ -680,8 +89,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="group_test_package" project="home:user_tab_user">
-          <title>The Cricket on the Hearth</title>
-          <description>Blanditiis autem similique ut eaque.</description>
+          <title>Mr Standfast</title>
+          <description>Dolorem aut eos accusamus voluptatibus quaerat accusantium sed amet.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -702,16 +111,16 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '185'
+      - '204'
     body:
       encoding: UTF-8
       string: |
         <package name="group_test_package" project="home:user_tab_user">
-          <title>The Cricket on the Hearth</title>
-          <description>Blanditiis autem similique ut eaque.</description>
+          <title>Mr Standfast</title>
+          <description>Dolorem aut eos accusamus voluptatibus quaerat accusantium sed amet.</description>
         </package>
     http_version: 
-  recorded_at: Wed, 03 Jan 2018 13:15:37 GMT
+  recorded_at: Tue, 16 Jan 2018 14:01:21 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:user_tab_user/group_test_package/_meta
@@ -719,8 +128,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="group_test_package" project="home:user_tab_user">
-          <title>The Cricket on the Hearth</title>
-          <description>Blanditiis autem similique ut eaque.</description>
+          <title>Mr Standfast</title>
+          <description>Dolorem aut eos accusamus voluptatibus quaerat accusantium sed amet.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -741,16 +150,16 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '185'
+      - '204'
     body:
       encoding: UTF-8
       string: |
         <package name="group_test_package" project="home:user_tab_user">
-          <title>The Cricket on the Hearth</title>
-          <description>Blanditiis autem similique ut eaque.</description>
+          <title>Mr Standfast</title>
+          <description>Dolorem aut eos accusamus voluptatibus quaerat accusantium sed amet.</description>
         </package>
     http_version: 
-  recorded_at: Wed, 03 Jan 2018 13:15:37 GMT
+  recorded_at: Tue, 16 Jan 2018 14:01:21 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:other_user/_meta?user=other_user
@@ -791,7 +200,7 @@ http_interactions:
           <person userid="other_user" role="maintainer" />
         </project>
     http_version: 
-  recorded_at: Wed, 03 Jan 2018 13:15:37 GMT
+  recorded_at: Tue, 16 Jan 2018 14:01:21 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:other_user/branch_test_package/_meta?user=user_tab_user
@@ -799,8 +208,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="branch_test_package" project="home:other_user">
-          <title>Look Homeward, Angel</title>
-          <description>Eveniet sit possimus maiores ea quisquam aut maxime.</description>
+          <title>Endless Night</title>
+          <description>Delectus quis fugiat atque sed placeat repudiandae eius.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -821,23 +230,63 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '194'
+      - '191'
     body:
       encoding: UTF-8
       string: |
         <package name="branch_test_package" project="home:other_user">
-          <title>Look Homeward, Angel</title>
-          <description>Eveniet sit possimus maiores ea quisquam aut maxime.</description>
+          <title>Endless Night</title>
+          <description>Delectus quis fugiat atque sed placeat repudiandae eius.</description>
         </package>
     http_version: 
-  recorded_at: Wed, 03 Jan 2018 13:15:37 GMT
+  recorded_at: Tue, 16 Jan 2018 14:01:21 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:other_user/branch_test_package/_meta
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="branch_test_package" project="home:other_user">
+          <title>Endless Night</title>
+          <description>Delectus quis fugiat atque sed placeat repudiandae eius.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '191'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="branch_test_package" project="home:other_user">
+          <title>Endless Night</title>
+          <description>Delectus quis fugiat atque sed placeat repudiandae eius.</description>
+        </package>
+    http_version: 
+  recorded_at: Tue, 16 Jan 2018 14:01:21 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:other_user/branch_test_package/_config
     body:
       encoding: UTF-8
-      string: Est est tempora omnis sapiente eius. In et praesentium. At quis aut
-        inventore. Hic quidem ratione debitis quibusdam amet numquam ex.
+      string: Pariatur perferendis at provident. Quibusdam dolore aliquam doloribus
+        aperiam. Sit ex et. Fugiat laboriosam cupiditate aut iusto qui tempore eum.
+        Explicabo minus veritatis.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -857,20 +306,95 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '207'
+      - '209'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="3" vrev="3">
-          <srcmd5>c649e8ed3c30e5f01941986fd2e4ec83</srcmd5>
+        <revision rev="23" vrev="23">
+          <srcmd5>130fa0f79cf2c90949cbde2e2f56c290</srcmd5>
           <version>unknown</version>
-          <time>1514985338</time>
+          <time>1516111281</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
     http_version: 
-  recorded_at: Wed, 03 Jan 2018 13:15:38 GMT
+  recorded_at: Tue, 16 Jan 2018 14:01:21 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:other_user/branch_test_package/somefile.txt
+    body:
+      encoding: UTF-8
+      string: Officia quia repellendus quis. Velit ullam et. Praesentium dolorem quos
+        quae dolorum illum libero sit. Culpa officia autem voluptatem assumenda. Officiis
+        repudiandae et in.
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '209'
+    body:
+      encoding: UTF-8
+      string: |
+        <revision rev="24" vrev="24">
+          <srcmd5>130fa0f79cf2c90949cbde2e2f56c290</srcmd5>
+          <version>unknown</version>
+          <time>1516111281</time>
+          <user>unknown</user>
+          <comment></comment>
+          <requestid/>
+        </revision>
+    http_version: 
+  recorded_at: Tue, 16 Jan 2018 14:01:21 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:user_tab_user/group_test_package?nofilename=1&view=info&withchangesmd5=1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '156'
+    body:
+      encoding: UTF-8
+      string: |
+        <sourceinfo package="group_test_package" srcmd5="d41d8cd98f00b204e9800998ecf8427e" verifymd5="d41d8cd98f00b204e9800998ecf8427e">
+          <revtime/>
+        </sourceinfo>
+    http_version: 
+  recorded_at: Tue, 16 Jan 2018 14:01:22 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:user_tab_user/group_test_package
@@ -902,6 +426,283 @@ http_interactions:
       string: |
         <directory name="group_test_package" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
         </directory>
+    http_version: 
+  recorded_at: Tue, 16 Jan 2018 14:01:22 GMT
+- request:
+    method: post
+    uri: http://backend:5352/source/home:user_tab_user/group_test_package?cmd=diff&linkrev=base&onlyissues=1&orev=0&view=xml
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Content-Type:
+      - application/octet-stream
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '314'
+    body:
+      encoding: UTF-8
+      string: |
+        <sourcediff key="04429e5eb3523e7cb3e15ee88d1605d6">
+          <old project="home:user_tab_user" package="group_test_package" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e" />
+          <new project="home:user_tab_user" package="group_test_package" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e" />
+          <files />
+        </sourcediff>
+    http_version: 
+  recorded_at: Tue, 16 Jan 2018 14:01:22 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:user_tab_user/group_test_package
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '93'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="group_test_package" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
+        </directory>
+    http_version: 
+  recorded_at: Tue, 16 Jan 2018 14:01:22 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:user_tab_user/group_test_package?expand=1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '93'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="group_test_package" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
+        </directory>
+    http_version: 
+  recorded_at: Tue, 16 Jan 2018 14:01:22 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:user_tab_user/group_test_package
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - text/plain
+      Accept-Encoding:
+      - identity
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '93'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="group_test_package" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
+        </directory>
+    http_version: 
+  recorded_at: Tue, 16 Jan 2018 14:01:22 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:user_tab_user/group_test_package/_service
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - text/plain
+      Accept-Encoding:
+      - identity
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 404
+      message: _service  no such file
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '122'
+    body:
+      encoding: UTF-8
+      string: |
+        <status code="404">
+          <summary>_service: no such file</summary>
+          <details>404 _service: no such file</details>
+        </status>
+    http_version: 
+  recorded_at: Tue, 16 Jan 2018 14:01:22 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:user_tab_user/group_test_package
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '93'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="group_test_package" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
+        </directory>
+    http_version: 
+  recorded_at: Tue, 16 Jan 2018 14:01:22 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:user_tab_user/group_test_package
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '93'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="group_test_package" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
+        </directory>
+    http_version: 
+  recorded_at: Tue, 16 Jan 2018 14:01:22 GMT
+- request:
+    method: get
+    uri: http://backend:5352/build/home:user_tab_user/_result?package=group_test_package&view=status
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - text/plain
+      Accept-Encoding:
+      - identity
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '56'
+    body:
+      encoding: UTF-8
+      string: '<resultlist state="00000000000000000000000000000000" />
+
+'
     http_version: 
   recorded_at: Wed, 03 Jan 2018 13:15:39 GMT
 - request:

--- a/src/api/spec/cassettes/Packages/behaves_like_user_tab/user_roles/Add_role_to_user.yml
+++ b/src/api/spec/cassettes/Packages/behaves_like_user_tab/user_roles/Add_role_to_user.yml
@@ -2,961 +2,6 @@
 http_interactions:
 - request:
     method: put
-    uri: http://backend:5352/source/home:other_user/_meta
-    body:
-      encoding: UTF-8
-      string: |
-        <project name="home:other_user">
-          <title/>
-          <description/>
-          <person userid="other_user" role="maintainer"/>
-        </project>
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '143'
-    body:
-      encoding: UTF-8
-      string: |
-        <project name="home:other_user">
-          <title></title>
-          <description></description>
-          <person userid="other_user" role="maintainer" />
-        </project>
-    http_version: 
-  recorded_at: Wed, 17 Aug 2016 11:20:15 GMT
-- request:
-    method: put
-    uri: http://backend:5352/source/home:other_user/branch_test_package/_meta
-    body:
-      encoding: UTF-8
-      string: |
-        <package name="branch_test_package" project="home:other_user">
-          <title/>
-          <description/>
-        </package>
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '122'
-    body:
-      encoding: UTF-8
-      string: |
-        <package name="branch_test_package" project="home:other_user">
-          <title></title>
-          <description></description>
-        </package>
-    http_version: 
-  recorded_at: Wed, 17 Aug 2016 11:20:15 GMT
-- request:
-    method: put
-    uri: http://backend:5352/source/home:other_user/branch_test_package/somefile.txt
-    body:
-      encoding: UTF-8
-      string: Itaque suscipit modi. Non ut hic et ullam molestiae eos. Ipsum consectetur
-        rerum. Ducimus dolores rem nemo mollitia. Sed qui animi dolor fuga.
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '207'
-    body:
-      encoding: UTF-8
-      string: |
-        <revision rev="2" vrev="2">
-          <srcmd5>c9122eb67a64527f57c1abe405d72d37</srcmd5>
-          <version>unknown</version>
-          <time>1471432815</time>
-          <user>unknown</user>
-          <comment></comment>
-          <requestid/>
-        </revision>
-    http_version: 
-  recorded_at: Wed, 17 Aug 2016 11:20:15 GMT
-- request:
-    method: get
-    uri: http://backend:5352/build/home:user_tab_user/_result?package=group_test_package&view=status
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Content-Type:
-      - text/plain
-      Accept-Encoding:
-      - identity
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 404
-      message: project 'home user_tab_user' does not exist
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '164'
-    body:
-      encoding: UTF-8
-      string: |
-        <status code="404">
-          <summary>project 'home:user_tab_user' does not exist</summary>
-          <details>404 project 'home:user_tab_user' does not exist</details>
-        </status>
-    http_version: 
-  recorded_at: Wed, 17 Aug 2016 11:20:16 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/home:user_tab_user/group_test_package?nofilename=1&view=info&withchangesmd5=1
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 404
-      message: project 'home user_tab_user' does not exist
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '164'
-    body:
-      encoding: UTF-8
-      string: |
-        <status code="404">
-          <summary>project 'home:user_tab_user' does not exist</summary>
-          <details>404 project 'home:user_tab_user' does not exist</details>
-        </status>
-    http_version: 
-  recorded_at: Wed, 17 Aug 2016 11:20:16 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/home:user_tab_user/group_test_package
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 404
-      message: project 'home user_tab_user' does not exist
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '164'
-    body:
-      encoding: UTF-8
-      string: |
-        <status code="404">
-          <summary>project 'home:user_tab_user' does not exist</summary>
-          <details>404 project 'home:user_tab_user' does not exist</details>
-        </status>
-    http_version: 
-  recorded_at: Wed, 17 Aug 2016 11:20:16 GMT
-- request:
-    method: post
-    uri: http://backend:5352/source/home:user_tab_user/group_test_package?cmd=diff&linkrev=base&onlyissues=1&orev=0&view=xml
-    body:
-      encoding: UTF-8
-      string: ''
-    headers:
-      Content-Type:
-      - application/octet-stream
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 404
-      message: project 'home user_tab_user' does not exist
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '164'
-    body:
-      encoding: UTF-8
-      string: |
-        <status code="404">
-          <summary>project 'home:user_tab_user' does not exist</summary>
-          <details>404 project 'home:user_tab_user' does not exist</details>
-        </status>
-    http_version: 
-  recorded_at: Wed, 17 Aug 2016 11:20:16 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/home:user_tab_user/group_test_package
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 404
-      message: project 'home user_tab_user' does not exist
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '164'
-    body:
-      encoding: UTF-8
-      string: |
-        <status code="404">
-          <summary>project 'home:user_tab_user' does not exist</summary>
-          <details>404 project 'home:user_tab_user' does not exist</details>
-        </status>
-    http_version: 
-  recorded_at: Wed, 17 Aug 2016 11:20:16 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/home:user_tab_user/group_test_package?expand=1
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Content-Type:
-      - text/plain
-      Accept-Encoding:
-      - identity
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 404
-      message: project 'home user_tab_user' does not exist
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '164'
-    body:
-      encoding: UTF-8
-      string: |
-        <status code="404">
-          <summary>project 'home:user_tab_user' does not exist</summary>
-          <details>404 project 'home:user_tab_user' does not exist</details>
-        </status>
-    http_version: 
-  recorded_at: Wed, 17 Aug 2016 11:20:16 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/home:user_tab_user/group_test_package
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Content-Type:
-      - text/plain
-      Accept-Encoding:
-      - identity
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 404
-      message: project 'home user_tab_user' does not exist
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '164'
-    body:
-      encoding: UTF-8
-      string: |
-        <status code="404">
-          <summary>project 'home:user_tab_user' does not exist</summary>
-          <details>404 project 'home:user_tab_user' does not exist</details>
-        </status>
-    http_version: 
-  recorded_at: Wed, 17 Aug 2016 11:20:16 GMT
-- request:
-    method: get
-    uri: http://backend:5352/build/home:user_tab_user/_result?package=group_test_package&view=status
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Content-Type:
-      - text/plain
-      Accept-Encoding:
-      - identity
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 404
-      message: project 'home user_tab_user' does not exist
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '164'
-    body:
-      encoding: UTF-8
-      string: |
-        <status code="404">
-          <summary>project 'home:user_tab_user' does not exist</summary>
-          <details>404 project 'home:user_tab_user' does not exist</details>
-        </status>
-    http_version: 
-  recorded_at: Wed, 17 Aug 2016 11:20:16 GMT
-- request:
-    method: get
-    uri: http://backend:5352/build/home:user_tab_user/_result?package=group_test_package&view=status
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Content-Type:
-      - text/plain
-      Accept-Encoding:
-      - identity
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 404
-      message: project 'home user_tab_user' does not exist
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '164'
-    body:
-      encoding: UTF-8
-      string: |
-        <status code="404">
-          <summary>project 'home:user_tab_user' does not exist</summary>
-          <details>404 project 'home:user_tab_user' does not exist</details>
-        </status>
-    http_version: 
-  recorded_at: Wed, 17 Aug 2016 11:20:16 GMT
-- request:
-    method: get
-    uri: http://backend:5352/build/home:user_tab_user/_result?package=group_test_package&view=status
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Content-Type:
-      - text/plain
-      Accept-Encoding:
-      - identity
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 404
-      message: project 'home user_tab_user' does not exist
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '164'
-    body:
-      encoding: UTF-8
-      string: |
-        <status code="404">
-          <summary>project 'home:user_tab_user' does not exist</summary>
-          <details>404 project 'home:user_tab_user' does not exist</details>
-        </status>
-    http_version: 
-  recorded_at: Wed, 17 Aug 2016 11:20:16 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/home:user_tab_user/group_test_package
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 404
-      message: project 'home user_tab_user' does not exist
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '164'
-    body:
-      encoding: UTF-8
-      string: |
-        <status code="404">
-          <summary>project 'home:user_tab_user' does not exist</summary>
-          <details>404 project 'home:user_tab_user' does not exist</details>
-        </status>
-    http_version: 
-  recorded_at: Wed, 17 Aug 2016 11:20:16 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/home:user_tab_user/group_test_package?expand=1
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Content-Type:
-      - text/plain
-      Accept-Encoding:
-      - identity
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 404
-      message: project 'home user_tab_user' does not exist
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '164'
-    body:
-      encoding: UTF-8
-      string: |
-        <status code="404">
-          <summary>project 'home:user_tab_user' does not exist</summary>
-          <details>404 project 'home:user_tab_user' does not exist</details>
-        </status>
-    http_version: 
-  recorded_at: Wed, 17 Aug 2016 11:20:16 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/home:user_tab_user/group_test_package
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Content-Type:
-      - text/plain
-      Accept-Encoding:
-      - identity
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 404
-      message: project 'home user_tab_user' does not exist
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '164'
-    body:
-      encoding: UTF-8
-      string: |
-        <status code="404">
-          <summary>project 'home:user_tab_user' does not exist</summary>
-          <details>404 project 'home:user_tab_user' does not exist</details>
-        </status>
-    http_version: 
-  recorded_at: Wed, 17 Aug 2016 11:20:16 GMT
-- request:
-    method: get
-    uri: http://backend:5352/build/home:user_tab_user/_result?package=group_test_package&view=status
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Content-Type:
-      - text/plain
-      Accept-Encoding:
-      - identity
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 404
-      message: project 'home user_tab_user' does not exist
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '164'
-    body:
-      encoding: UTF-8
-      string: |
-        <status code="404">
-          <summary>project 'home:user_tab_user' does not exist</summary>
-          <details>404 project 'home:user_tab_user' does not exist</details>
-        </status>
-    http_version: 
-  recorded_at: Wed, 17 Aug 2016 11:20:17 GMT
-- request:
-    method: get
-    uri: http://backend:5352/build/home:user_tab_user/_result?package=group_test_package&view=status
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Content-Type:
-      - text/plain
-      Accept-Encoding:
-      - identity
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 404
-      message: project 'home user_tab_user' does not exist
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '164'
-    body:
-      encoding: UTF-8
-      string: |
-        <status code="404">
-          <summary>project 'home:user_tab_user' does not exist</summary>
-          <details>404 project 'home:user_tab_user' does not exist</details>
-        </status>
-    http_version: 
-  recorded_at: Wed, 17 Aug 2016 11:20:17 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/home:user_tab_user/group_test_package/_service
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Content-Type:
-      - text/plain
-      Accept-Encoding:
-      - identity
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 404
-      message: project 'home user_tab_user' does not exist
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '164'
-    body:
-      encoding: UTF-8
-      string: |
-        <status code="404">
-          <summary>project 'home:user_tab_user' does not exist</summary>
-          <details>404 project 'home:user_tab_user' does not exist</details>
-        </status>
-    http_version: 
-  recorded_at: Wed, 05 Oct 2016 09:08:54 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/home:user_tab_user/group_test_package/_service
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Content-Type:
-      - text/plain
-      Accept-Encoding:
-      - identity
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 404
-      message: project 'home user_tab_user' does not exist
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '164'
-    body:
-      encoding: UTF-8
-      string: |
-        <status code="404">
-          <summary>project 'home:user_tab_user' does not exist</summary>
-          <details>404 project 'home:user_tab_user' does not exist</details>
-        </status>
-    http_version: 
-  recorded_at: Wed, 05 Oct 2016 09:08:56 GMT
-- request:
-    method: get
-    uri: http://backend:5352/build/home:user_tab_user/_result?locallink=1&multibuild=1&package=group_test_package&view=status
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Content-Type:
-      - text/plain
-      Accept-Encoding:
-      - identity
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 404
-      message: project 'home user_tab_user' does not exist
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '164'
-    body:
-      encoding: UTF-8
-      string: |
-        <status code="404">
-          <summary>project 'home:user_tab_user' does not exist</summary>
-          <details>404 project 'home:user_tab_user' does not exist</details>
-        </status>
-    http_version: 
-  recorded_at: Fri, 20 Jan 2017 02:55:23 GMT
-- request:
-    method: get
-    uri: http://backend:5352/build/home:user_tab_user/_result?locallink=1&multibuild=1&package=group_test_package&view=status
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Content-Type:
-      - text/plain
-      Accept-Encoding:
-      - identity
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 404
-      message: project 'home user_tab_user' does not exist
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '164'
-    body:
-      encoding: UTF-8
-      string: |
-        <status code="404">
-          <summary>project 'home:user_tab_user' does not exist</summary>
-          <details>404 project 'home:user_tab_user' does not exist</details>
-        </status>
-    http_version: 
-  recorded_at: Fri, 20 Jan 2017 02:55:23 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/home:user_tab_user/group_test_package?expand=0
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 404
-      message: project 'home user_tab_user' does not exist
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '164'
-    body:
-      encoding: UTF-8
-      string: |
-        <status code="404">
-          <summary>project 'home:user_tab_user' does not exist</summary>
-          <details>404 project 'home:user_tab_user' does not exist</details>
-        </status>
-    http_version: 
-  recorded_at: Tue, 16 May 2017 15:10:23 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/home:user_tab_user/group_test_package?expand=0
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 404
-      message: project 'home user_tab_user' does not exist
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '164'
-    body:
-      encoding: UTF-8
-      string: |
-        <status code="404">
-          <summary>project 'home:user_tab_user' does not exist</summary>
-          <details>404 project 'home:user_tab_user' does not exist</details>
-        </status>
-    http_version: 
-  recorded_at: Tue, 16 May 2017 15:10:24 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/home:user_tab_user/group_test_package
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 404
-      message: project 'home user_tab_user' does not exist
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '164'
-    body:
-      encoding: UTF-8
-      string: |
-        <status code="404">
-          <summary>project 'home:user_tab_user' does not exist</summary>
-          <details>404 project 'home:user_tab_user' does not exist</details>
-        </status>
-    http_version: 
-  recorded_at: Fri, 16 Jun 2017 14:23:47 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/home:user_tab_user/group_test_package
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 404
-      message: project 'home user_tab_user' does not exist
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '164'
-    body:
-      encoding: UTF-8
-      string: |
-        <status code="404">
-          <summary>project 'home:user_tab_user' does not exist</summary>
-          <details>404 project 'home:user_tab_user' does not exist</details>
-        </status>
-    http_version: 
-  recorded_at: Fri, 16 Jun 2017 14:23:47 GMT
-- request:
-    method: put
     uri: http://backend:5352/source/home:package_test_user/_meta?user=package_test_user
     body:
       encoding: UTF-8
@@ -995,7 +40,7 @@ http_interactions:
           <person userid="package_test_user" role="maintainer" />
         </project>
     http_version: 
-  recorded_at: Wed, 03 Jan 2018 13:16:40 GMT
+  recorded_at: Tue, 16 Jan 2018 14:01:31 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:user_tab_user/_meta?user=user_tab_user
@@ -1036,7 +81,7 @@ http_interactions:
           <person userid="user_tab_user" role="maintainer" />
         </project>
     http_version: 
-  recorded_at: Wed, 03 Jan 2018 13:16:40 GMT
+  recorded_at: Tue, 16 Jan 2018 14:01:31 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:user_tab_user/group_test_package/_meta?user=user_tab_user
@@ -1045,7 +90,7 @@ http_interactions:
       string: |
         <package name="group_test_package" project="home:user_tab_user">
           <title>Shall not Perish</title>
-          <description>Qui possimus omnis accusantium.</description>
+          <description>Voluptatibus in ut nobis numquam similique sapiente blanditiis dolorem.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -1066,16 +111,16 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '171'
+      - '211'
     body:
       encoding: UTF-8
       string: |
         <package name="group_test_package" project="home:user_tab_user">
           <title>Shall not Perish</title>
-          <description>Qui possimus omnis accusantium.</description>
+          <description>Voluptatibus in ut nobis numquam similique sapiente blanditiis dolorem.</description>
         </package>
     http_version: 
-  recorded_at: Wed, 03 Jan 2018 13:16:40 GMT
+  recorded_at: Tue, 16 Jan 2018 14:01:31 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:user_tab_user/group_test_package/_meta
@@ -1084,7 +129,7 @@ http_interactions:
       string: |
         <package name="group_test_package" project="home:user_tab_user">
           <title>Shall not Perish</title>
-          <description>Qui possimus omnis accusantium.</description>
+          <description>Voluptatibus in ut nobis numquam similique sapiente blanditiis dolorem.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -1105,16 +150,16 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '171'
+      - '211'
     body:
       encoding: UTF-8
       string: |
         <package name="group_test_package" project="home:user_tab_user">
           <title>Shall not Perish</title>
-          <description>Qui possimus omnis accusantium.</description>
+          <description>Voluptatibus in ut nobis numquam similique sapiente blanditiis dolorem.</description>
         </package>
     http_version: 
-  recorded_at: Wed, 03 Jan 2018 13:16:40 GMT
+  recorded_at: Tue, 16 Jan 2018 14:01:31 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:other_user/_meta?user=other_user
@@ -1155,7 +200,7 @@ http_interactions:
           <person userid="other_user" role="maintainer" />
         </project>
     http_version: 
-  recorded_at: Wed, 03 Jan 2018 13:16:40 GMT
+  recorded_at: Tue, 16 Jan 2018 14:01:31 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:other_user/branch_test_package/_meta?user=user_tab_user
@@ -1163,8 +208,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="branch_test_package" project="home:other_user">
-          <title>Butter In a Lordly Dish</title>
-          <description>Omnis eum earum et culpa cumque sint.</description>
+          <title>The Monkey's Raincoat</title>
+          <description>Voluptate autem impedit maiores dolore optio cumque exercitationem rerum.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -1185,23 +230,63 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '182'
+      - '216'
     body:
       encoding: UTF-8
       string: |
         <package name="branch_test_package" project="home:other_user">
-          <title>Butter In a Lordly Dish</title>
-          <description>Omnis eum earum et culpa cumque sint.</description>
+          <title>The Monkey's Raincoat</title>
+          <description>Voluptate autem impedit maiores dolore optio cumque exercitationem rerum.</description>
         </package>
     http_version: 
-  recorded_at: Wed, 03 Jan 2018 13:16:40 GMT
+  recorded_at: Tue, 16 Jan 2018 14:01:31 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:other_user/branch_test_package/_meta
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="branch_test_package" project="home:other_user">
+          <title>The Monkey's Raincoat</title>
+          <description>Voluptate autem impedit maiores dolore optio cumque exercitationem rerum.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '216'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="branch_test_package" project="home:other_user">
+          <title>The Monkey's Raincoat</title>
+          <description>Voluptate autem impedit maiores dolore optio cumque exercitationem rerum.</description>
+        </package>
+    http_version: 
+  recorded_at: Tue, 16 Jan 2018 14:01:31 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:other_user/branch_test_package/_config
     body:
       encoding: UTF-8
-      string: Ut sed voluptas dicta id vitae ipsum repellat. Natus voluptas doloribus
-        distinctio. Quo ex eum dolor debitis. Fuga molestias dolorem.
+      string: Sit possimus cupiditate doloremque temporibus. Illo ea sit eligendi
+        corporis saepe consequatur voluptas. Aut et in magni vitae. Voluptas et aut
+        in autem ratione.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -1221,20 +306,61 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '207'
+      - '209'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="8" vrev="8">
-          <srcmd5>d837c43b42a66704b978a58bb82003ca</srcmd5>
+        <revision rev="29" vrev="29">
+          <srcmd5>11fbc3c61de5148c79488617d2487a87</srcmd5>
           <version>unknown</version>
-          <time>1514985400</time>
+          <time>1516111291</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
     http_version: 
-  recorded_at: Wed, 03 Jan 2018 13:16:40 GMT
+  recorded_at: Tue, 16 Jan 2018 14:01:31 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:other_user/branch_test_package/somefile.txt
+    body:
+      encoding: UTF-8
+      string: Officia quia repellendus quis. Velit ullam et. Praesentium dolorem quos
+        quae dolorum illum libero sit. Culpa officia autem voluptatem assumenda. Officiis
+        repudiandae et in.
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '209'
+    body:
+      encoding: UTF-8
+      string: |
+        <revision rev="30" vrev="30">
+          <srcmd5>11fbc3c61de5148c79488617d2487a87</srcmd5>
+          <version>unknown</version>
+          <time>1516111291</time>
+          <user>unknown</user>
+          <comment></comment>
+          <requestid/>
+        </revision>
+    http_version: 
+  recorded_at: Tue, 16 Jan 2018 14:01:32 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:reader_user/_meta?user=reader_user
@@ -1275,7 +401,351 @@ http_interactions:
           <person userid="reader_user" role="maintainer" />
         </project>
     http_version: 
-  recorded_at: Wed, 03 Jan 2018 13:16:40 GMT
+  recorded_at: Tue, 16 Jan 2018 14:01:32 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:user_tab_user/group_test_package?nofilename=1&view=info&withchangesmd5=1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '156'
+    body:
+      encoding: UTF-8
+      string: |
+        <sourceinfo package="group_test_package" srcmd5="d41d8cd98f00b204e9800998ecf8427e" verifymd5="d41d8cd98f00b204e9800998ecf8427e">
+          <revtime/>
+        </sourceinfo>
+    http_version: 
+  recorded_at: Tue, 16 Jan 2018 14:01:32 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:user_tab_user/group_test_package
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '93'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="group_test_package" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
+        </directory>
+    http_version: 
+  recorded_at: Tue, 16 Jan 2018 14:01:32 GMT
+- request:
+    method: post
+    uri: http://backend:5352/source/home:user_tab_user/group_test_package?cmd=diff&linkrev=base&onlyissues=1&orev=0&view=xml
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Content-Type:
+      - application/octet-stream
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '314'
+    body:
+      encoding: UTF-8
+      string: |
+        <sourcediff key="04429e5eb3523e7cb3e15ee88d1605d6">
+          <old project="home:user_tab_user" package="group_test_package" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e" />
+          <new project="home:user_tab_user" package="group_test_package" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e" />
+          <files />
+        </sourcediff>
+    http_version: 
+  recorded_at: Tue, 16 Jan 2018 14:01:32 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:user_tab_user/group_test_package
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '93'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="group_test_package" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
+        </directory>
+    http_version: 
+  recorded_at: Tue, 16 Jan 2018 14:01:32 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:user_tab_user/group_test_package?expand=1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '93'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="group_test_package" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
+        </directory>
+    http_version: 
+  recorded_at: Tue, 16 Jan 2018 14:01:32 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:user_tab_user/group_test_package
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - text/plain
+      Accept-Encoding:
+      - identity
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '93'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="group_test_package" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
+        </directory>
+    http_version: 
+  recorded_at: Tue, 16 Jan 2018 14:01:32 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:user_tab_user/group_test_package/_service
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - text/plain
+      Accept-Encoding:
+      - identity
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 404
+      message: _service  no such file
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '122'
+    body:
+      encoding: UTF-8
+      string: |
+        <status code="404">
+          <summary>_service: no such file</summary>
+          <details>404 _service: no such file</details>
+        </status>
+    http_version: 
+  recorded_at: Tue, 16 Jan 2018 14:01:32 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:user_tab_user/group_test_package
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '93'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="group_test_package" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
+        </directory>
+    http_version: 
+  recorded_at: Tue, 16 Jan 2018 14:01:32 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:user_tab_user/group_test_package
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '93'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="group_test_package" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
+        </directory>
+    http_version: 
+  recorded_at: Tue, 16 Jan 2018 14:01:32 GMT
+- request:
+    method: get
+    uri: http://backend:5352/build/home:user_tab_user/_result?package=group_test_package&view=status
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - text/plain
+      Accept-Encoding:
+      - identity
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '56'
+    body:
+      encoding: UTF-8
+      string: '<resultlist state="00000000000000000000000000000000" />
+
+'
+    http_version: 
+  recorded_at: Tue, 16 Jan 2018 14:01:33 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:user_tab_user/group_test_package/_meta?user=user_tab_user
@@ -1284,7 +754,7 @@ http_interactions:
       string: |
         <package name="group_test_package" project="home:user_tab_user">
           <title>Shall not Perish</title>
-          <description>Qui possimus omnis accusantium.</description>
+          <description>Voluptatibus in ut nobis numquam similique sapiente blanditiis dolorem.</description>
           <person userid="user_tab_user" role="bugowner"/>
           <person userid="user_tab_user" role="maintainer"/>
           <person userid="reader_user" role="reader"/>
@@ -1309,20 +779,20 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '377'
+      - '417'
     body:
       encoding: UTF-8
       string: |
         <package name="group_test_package" project="home:user_tab_user">
           <title>Shall not Perish</title>
-          <description>Qui possimus omnis accusantium.</description>
+          <description>Voluptatibus in ut nobis numquam similique sapiente blanditiis dolorem.</description>
           <person userid="user_tab_user" role="bugowner" />
           <person userid="user_tab_user" role="maintainer" />
           <person userid="reader_user" role="reader" />
           <person userid="user_tab_user" role="reviewer" />
         </package>
     http_version: 
-  recorded_at: Wed, 03 Jan 2018 13:16:42 GMT
+  recorded_at: Tue, 16 Jan 2018 14:01:33 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:user_tab_user/group_test_package
@@ -1355,7 +825,112 @@ http_interactions:
         <directory name="group_test_package" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
         </directory>
     http_version: 
-  recorded_at: Wed, 03 Jan 2018 13:16:43 GMT
+  recorded_at: Tue, 16 Jan 2018 14:01:33 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:user_tab_user/group_test_package?expand=1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '93'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="group_test_package" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
+        </directory>
+    http_version: 
+  recorded_at: Tue, 16 Jan 2018 14:01:33 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:user_tab_user/group_test_package
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - text/plain
+      Accept-Encoding:
+      - identity
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '93'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="group_test_package" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
+        </directory>
+    http_version: 
+  recorded_at: Tue, 16 Jan 2018 14:01:33 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:user_tab_user/group_test_package/_service
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - text/plain
+      Accept-Encoding:
+      - identity
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 404
+      message: _service  no such file
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '122'
+    body:
+      encoding: UTF-8
+      string: |
+        <status code="404">
+          <summary>_service: no such file</summary>
+          <details>404 _service: no such file</details>
+        </status>
+    http_version: 
+  recorded_at: Tue, 16 Jan 2018 14:01:33 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:user_tab_user/group_test_package
@@ -1387,6 +962,74 @@ http_interactions:
       string: |
         <directory name="group_test_package" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
         </directory>
+    http_version: 
+  recorded_at: Tue, 16 Jan 2018 14:01:33 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:user_tab_user/group_test_package
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '93'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="group_test_package" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
+        </directory>
+    http_version: 
+  recorded_at: Tue, 16 Jan 2018 14:01:33 GMT
+- request:
+    method: get
+    uri: http://backend:5352/build/home:user_tab_user/_result?package=group_test_package&view=status
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - text/plain
+      Accept-Encoding:
+      - identity
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '56'
+    body:
+      encoding: UTF-8
+      string: '<resultlist state="00000000000000000000000000000000" />
+
+'
     http_version: 
   recorded_at: Wed, 03 Jan 2018 13:16:43 GMT
 - request:

--- a/src/api/spec/cassettes/Packages/behaves_like_user_tab/user_roles/Add_user_to_package_/_project.yml
+++ b/src/api/spec/cassettes/Packages/behaves_like_user_tab/user_roles/Add_user_to_package_/_project.yml
@@ -2,598 +2,6 @@
 http_interactions:
 - request:
     method: put
-    uri: http://backend:5352/source/home:other_user/_meta
-    body:
-      encoding: UTF-8
-      string: |
-        <project name="home:other_user">
-          <title/>
-          <description/>
-          <person userid="other_user" role="maintainer"/>
-        </project>
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '143'
-    body:
-      encoding: UTF-8
-      string: |
-        <project name="home:other_user">
-          <title></title>
-          <description></description>
-          <person userid="other_user" role="maintainer" />
-        </project>
-    http_version: 
-  recorded_at: Wed, 17 Aug 2016 11:20:19 GMT
-- request:
-    method: put
-    uri: http://backend:5352/source/home:other_user/branch_test_package/_meta
-    body:
-      encoding: UTF-8
-      string: |
-        <package name="branch_test_package" project="home:other_user">
-          <title/>
-          <description/>
-        </package>
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '122'
-    body:
-      encoding: UTF-8
-      string: |
-        <package name="branch_test_package" project="home:other_user">
-          <title></title>
-          <description></description>
-        </package>
-    http_version: 
-  recorded_at: Wed, 17 Aug 2016 11:20:19 GMT
-- request:
-    method: put
-    uri: http://backend:5352/source/home:other_user/branch_test_package/somefile.txt
-    body:
-      encoding: UTF-8
-      string: Quaerat voluptatem repudiandae repellat doloribus iusto quidem. Similique
-        fuga possimus et. Rerum accusamus optio ea quo sunt impedit. Facere veniam
-        qui porro odit laudantium modi. Consequatur reprehenderit est maiores.
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '207'
-    body:
-      encoding: UTF-8
-      string: |
-        <revision rev="3" vrev="3">
-          <srcmd5>0c759152b4d76d7340da602fce104253</srcmd5>
-          <version>unknown</version>
-          <time>1471432819</time>
-          <user>unknown</user>
-          <comment></comment>
-          <requestid/>
-        </revision>
-    http_version: 
-  recorded_at: Wed, 17 Aug 2016 11:20:19 GMT
-- request:
-    method: get
-    uri: http://backend:5352/build/home:user_tab_user/_result?package=group_test_package&view=status
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Content-Type:
-      - text/plain
-      Accept-Encoding:
-      - identity
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 404
-      message: project 'home user_tab_user' does not exist
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '164'
-    body:
-      encoding: UTF-8
-      string: |
-        <status code="404">
-          <summary>project 'home:user_tab_user' does not exist</summary>
-          <details>404 project 'home:user_tab_user' does not exist</details>
-        </status>
-    http_version: 
-  recorded_at: Wed, 17 Aug 2016 11:20:20 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/home:user_tab_user/group_test_package?nofilename=1&view=info&withchangesmd5=1
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 404
-      message: project 'home user_tab_user' does not exist
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '164'
-    body:
-      encoding: UTF-8
-      string: |
-        <status code="404">
-          <summary>project 'home:user_tab_user' does not exist</summary>
-          <details>404 project 'home:user_tab_user' does not exist</details>
-        </status>
-    http_version: 
-  recorded_at: Wed, 17 Aug 2016 11:20:20 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/home:user_tab_user/group_test_package
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 404
-      message: project 'home user_tab_user' does not exist
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '164'
-    body:
-      encoding: UTF-8
-      string: |
-        <status code="404">
-          <summary>project 'home:user_tab_user' does not exist</summary>
-          <details>404 project 'home:user_tab_user' does not exist</details>
-        </status>
-    http_version: 
-  recorded_at: Wed, 17 Aug 2016 11:20:20 GMT
-- request:
-    method: post
-    uri: http://backend:5352/source/home:user_tab_user/group_test_package?cmd=diff&linkrev=base&onlyissues=1&orev=0&view=xml
-    body:
-      encoding: UTF-8
-      string: ''
-    headers:
-      Content-Type:
-      - application/octet-stream
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 404
-      message: project 'home user_tab_user' does not exist
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '164'
-    body:
-      encoding: UTF-8
-      string: |
-        <status code="404">
-          <summary>project 'home:user_tab_user' does not exist</summary>
-          <details>404 project 'home:user_tab_user' does not exist</details>
-        </status>
-    http_version: 
-  recorded_at: Wed, 17 Aug 2016 11:20:20 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/home:user_tab_user/group_test_package
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 404
-      message: project 'home user_tab_user' does not exist
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '164'
-    body:
-      encoding: UTF-8
-      string: |
-        <status code="404">
-          <summary>project 'home:user_tab_user' does not exist</summary>
-          <details>404 project 'home:user_tab_user' does not exist</details>
-        </status>
-    http_version: 
-  recorded_at: Wed, 17 Aug 2016 11:20:20 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/home:user_tab_user/group_test_package?expand=1
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Content-Type:
-      - text/plain
-      Accept-Encoding:
-      - identity
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 404
-      message: project 'home user_tab_user' does not exist
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '164'
-    body:
-      encoding: UTF-8
-      string: |
-        <status code="404">
-          <summary>project 'home:user_tab_user' does not exist</summary>
-          <details>404 project 'home:user_tab_user' does not exist</details>
-        </status>
-    http_version: 
-  recorded_at: Wed, 17 Aug 2016 11:20:20 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/home:user_tab_user/group_test_package
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Content-Type:
-      - text/plain
-      Accept-Encoding:
-      - identity
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 404
-      message: project 'home user_tab_user' does not exist
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '164'
-    body:
-      encoding: UTF-8
-      string: |
-        <status code="404">
-          <summary>project 'home:user_tab_user' does not exist</summary>
-          <details>404 project 'home:user_tab_user' does not exist</details>
-        </status>
-    http_version: 
-  recorded_at: Wed, 17 Aug 2016 11:20:20 GMT
-- request:
-    method: get
-    uri: http://backend:5352/build/home:user_tab_user/_result?package=group_test_package&view=status
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Content-Type:
-      - text/plain
-      Accept-Encoding:
-      - identity
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 404
-      message: project 'home user_tab_user' does not exist
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '164'
-    body:
-      encoding: UTF-8
-      string: |
-        <status code="404">
-          <summary>project 'home:user_tab_user' does not exist</summary>
-          <details>404 project 'home:user_tab_user' does not exist</details>
-        </status>
-    http_version: 
-  recorded_at: Wed, 17 Aug 2016 11:20:20 GMT
-- request:
-    method: get
-    uri: http://backend:5352/build/home:user_tab_user/_result?package=group_test_package&view=status
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Content-Type:
-      - text/plain
-      Accept-Encoding:
-      - identity
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 404
-      message: project 'home user_tab_user' does not exist
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '164'
-    body:
-      encoding: UTF-8
-      string: |
-        <status code="404">
-          <summary>project 'home:user_tab_user' does not exist</summary>
-          <details>404 project 'home:user_tab_user' does not exist</details>
-        </status>
-    http_version: 
-  recorded_at: Wed, 17 Aug 2016 11:20:20 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/home:user_tab_user/group_test_package/_service
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Content-Type:
-      - text/plain
-      Accept-Encoding:
-      - identity
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 404
-      message: project 'home user_tab_user' does not exist
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '164'
-    body:
-      encoding: UTF-8
-      string: |
-        <status code="404">
-          <summary>project 'home:user_tab_user' does not exist</summary>
-          <details>404 project 'home:user_tab_user' does not exist</details>
-        </status>
-    http_version: 
-  recorded_at: Wed, 05 Oct 2016 09:09:07 GMT
-- request:
-    method: get
-    uri: http://backend:5352/build/home:user_tab_user/_result?locallink=1&multibuild=1&package=group_test_package&view=status
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Content-Type:
-      - text/plain
-      Accept-Encoding:
-      - identity
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 404
-      message: project 'home user_tab_user' does not exist
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '164'
-    body:
-      encoding: UTF-8
-      string: |
-        <status code="404">
-          <summary>project 'home:user_tab_user' does not exist</summary>
-          <details>404 project 'home:user_tab_user' does not exist</details>
-        </status>
-    http_version: 
-  recorded_at: Fri, 20 Jan 2017 02:55:18 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/home:user_tab_user/group_test_package?expand=0
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 404
-      message: project 'home user_tab_user' does not exist
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '164'
-    body:
-      encoding: UTF-8
-      string: |
-        <status code="404">
-          <summary>project 'home:user_tab_user' does not exist</summary>
-          <details>404 project 'home:user_tab_user' does not exist</details>
-        </status>
-    http_version: 
-  recorded_at: Tue, 16 May 2017 15:10:04 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/home:user_tab_user/group_test_package
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 404
-      message: project 'home user_tab_user' does not exist
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '164'
-    body:
-      encoding: UTF-8
-      string: |
-        <status code="404">
-          <summary>project 'home:user_tab_user' does not exist</summary>
-          <details>404 project 'home:user_tab_user' does not exist</details>
-        </status>
-    http_version: 
-  recorded_at: Fri, 16 Jun 2017 14:23:50 GMT
-- request:
-    method: put
     uri: http://backend:5352/source/home:package_test_user/_meta?user=package_test_user
     body:
       encoding: UTF-8
@@ -632,7 +40,7 @@ http_interactions:
           <person userid="package_test_user" role="maintainer" />
         </project>
     http_version: 
-  recorded_at: Wed, 03 Jan 2018 13:16:14 GMT
+  recorded_at: Tue, 16 Jan 2018 14:01:27 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:user_tab_user/_meta?user=user_tab_user
@@ -673,7 +81,7 @@ http_interactions:
           <person userid="user_tab_user" role="maintainer" />
         </project>
     http_version: 
-  recorded_at: Wed, 03 Jan 2018 13:16:14 GMT
+  recorded_at: Tue, 16 Jan 2018 14:01:27 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:user_tab_user/group_test_package/_meta?user=user_tab_user
@@ -681,8 +89,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="group_test_package" project="home:user_tab_user">
-          <title>The Needle's Eye</title>
-          <description>Consequatur ex deserunt qui.</description>
+          <title>The Wings of the Dove</title>
+          <description>Veniam quia incidunt quaerat ipsam repudiandae.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -703,16 +111,16 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '168'
+      - '192'
     body:
       encoding: UTF-8
       string: |
         <package name="group_test_package" project="home:user_tab_user">
-          <title>The Needle's Eye</title>
-          <description>Consequatur ex deserunt qui.</description>
+          <title>The Wings of the Dove</title>
+          <description>Veniam quia incidunt quaerat ipsam repudiandae.</description>
         </package>
     http_version: 
-  recorded_at: Wed, 03 Jan 2018 13:16:14 GMT
+  recorded_at: Tue, 16 Jan 2018 14:01:27 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:user_tab_user/group_test_package/_meta
@@ -720,8 +128,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="group_test_package" project="home:user_tab_user">
-          <title>The Needle's Eye</title>
-          <description>Consequatur ex deserunt qui.</description>
+          <title>The Wings of the Dove</title>
+          <description>Veniam quia incidunt quaerat ipsam repudiandae.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -742,16 +150,16 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '168'
+      - '192'
     body:
       encoding: UTF-8
       string: |
         <package name="group_test_package" project="home:user_tab_user">
-          <title>The Needle's Eye</title>
-          <description>Consequatur ex deserunt qui.</description>
+          <title>The Wings of the Dove</title>
+          <description>Veniam quia incidunt quaerat ipsam repudiandae.</description>
         </package>
     http_version: 
-  recorded_at: Wed, 03 Jan 2018 13:16:14 GMT
+  recorded_at: Tue, 16 Jan 2018 14:01:27 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:other_user/_meta?user=other_user
@@ -792,7 +200,7 @@ http_interactions:
           <person userid="other_user" role="maintainer" />
         </project>
     http_version: 
-  recorded_at: Wed, 03 Jan 2018 13:16:14 GMT
+  recorded_at: Tue, 16 Jan 2018 14:01:27 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:other_user/branch_test_package/_meta?user=user_tab_user
@@ -800,8 +208,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="branch_test_package" project="home:other_user">
-          <title>From Here to Eternity</title>
-          <description>Reiciendis est ut in voluptate rerum corporis porro.</description>
+          <title>Look to Windward</title>
+          <description>Adipisci nulla harum nobis et rem.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -822,24 +230,62 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '195'
+      - '172'
     body:
       encoding: UTF-8
       string: |
         <package name="branch_test_package" project="home:other_user">
-          <title>From Here to Eternity</title>
-          <description>Reiciendis est ut in voluptate rerum corporis porro.</description>
+          <title>Look to Windward</title>
+          <description>Adipisci nulla harum nobis et rem.</description>
         </package>
     http_version: 
-  recorded_at: Wed, 03 Jan 2018 13:16:14 GMT
+  recorded_at: Tue, 16 Jan 2018 14:01:27 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:other_user/branch_test_package/_meta
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="branch_test_package" project="home:other_user">
+          <title>Look to Windward</title>
+          <description>Adipisci nulla harum nobis et rem.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '172'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="branch_test_package" project="home:other_user">
+          <title>Look to Windward</title>
+          <description>Adipisci nulla harum nobis et rem.</description>
+        </package>
+    http_version: 
+  recorded_at: Tue, 16 Jan 2018 14:01:27 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:other_user/branch_test_package/_config
     body:
       encoding: UTF-8
-      string: Dolores minus quia dolor qui aliquid ex. Quas ab dolores non libero.
-        Iste animi necessitatibus itaque. Qui veritatis rerum sed et ut fuga. Eos
-        possimus nulla eveniet amet.
+      string: Officiis ea magnam qui qui deleniti. Earum non deserunt est est. Quia
+        sit et qui. Unde est harum.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -859,20 +305,61 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '207'
+      - '209'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="6" vrev="6">
-          <srcmd5>9ea52f1dc5b29976cfc9f14d1e1828a3</srcmd5>
+        <revision rev="27" vrev="27">
+          <srcmd5>a90ffa63108aebf6383ce94f99fb62b9</srcmd5>
           <version>unknown</version>
-          <time>1514985374</time>
+          <time>1516111287</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
     http_version: 
-  recorded_at: Wed, 03 Jan 2018 13:16:14 GMT
+  recorded_at: Tue, 16 Jan 2018 14:01:27 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:other_user/branch_test_package/somefile.txt
+    body:
+      encoding: UTF-8
+      string: Officia quia repellendus quis. Velit ullam et. Praesentium dolorem quos
+        quae dolorum illum libero sit. Culpa officia autem voluptatem assumenda. Officiis
+        repudiandae et in.
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '209'
+    body:
+      encoding: UTF-8
+      string: |
+        <revision rev="28" vrev="28">
+          <srcmd5>a90ffa63108aebf6383ce94f99fb62b9</srcmd5>
+          <version>unknown</version>
+          <time>1516111287</time>
+          <user>unknown</user>
+          <comment></comment>
+          <requestid/>
+        </revision>
+    http_version: 
+  recorded_at: Tue, 16 Jan 2018 14:01:27 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:reader_user/_meta?user=reader_user
@@ -913,7 +400,41 @@ http_interactions:
           <person userid="reader_user" role="maintainer" />
         </project>
     http_version: 
-  recorded_at: Wed, 03 Jan 2018 13:16:15 GMT
+  recorded_at: Tue, 16 Jan 2018 14:01:27 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:user_tab_user/group_test_package?nofilename=1&view=info&withchangesmd5=1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '156'
+    body:
+      encoding: UTF-8
+      string: |
+        <sourceinfo package="group_test_package" srcmd5="d41d8cd98f00b204e9800998ecf8427e" verifymd5="d41d8cd98f00b204e9800998ecf8427e">
+          <revtime/>
+        </sourceinfo>
+    http_version: 
+  recorded_at: Tue, 16 Jan 2018 14:01:28 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:user_tab_user/group_test_package
@@ -946,7 +467,284 @@ http_interactions:
         <directory name="group_test_package" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
         </directory>
     http_version: 
-  recorded_at: Wed, 03 Jan 2018 13:16:16 GMT
+  recorded_at: Tue, 16 Jan 2018 14:01:28 GMT
+- request:
+    method: post
+    uri: http://backend:5352/source/home:user_tab_user/group_test_package?cmd=diff&linkrev=base&onlyissues=1&orev=0&view=xml
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Content-Type:
+      - application/octet-stream
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '314'
+    body:
+      encoding: UTF-8
+      string: |
+        <sourcediff key="04429e5eb3523e7cb3e15ee88d1605d6">
+          <old project="home:user_tab_user" package="group_test_package" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e" />
+          <new project="home:user_tab_user" package="group_test_package" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e" />
+          <files />
+        </sourcediff>
+    http_version: 
+  recorded_at: Tue, 16 Jan 2018 14:01:28 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:user_tab_user/group_test_package
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '93'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="group_test_package" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
+        </directory>
+    http_version: 
+  recorded_at: Tue, 16 Jan 2018 14:01:28 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:user_tab_user/group_test_package?expand=1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '93'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="group_test_package" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
+        </directory>
+    http_version: 
+  recorded_at: Tue, 16 Jan 2018 14:01:28 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:user_tab_user/group_test_package
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - text/plain
+      Accept-Encoding:
+      - identity
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '93'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="group_test_package" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
+        </directory>
+    http_version: 
+  recorded_at: Tue, 16 Jan 2018 14:01:28 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:user_tab_user/group_test_package/_service
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - text/plain
+      Accept-Encoding:
+      - identity
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 404
+      message: _service  no such file
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '122'
+    body:
+      encoding: UTF-8
+      string: |
+        <status code="404">
+          <summary>_service: no such file</summary>
+          <details>404 _service: no such file</details>
+        </status>
+    http_version: 
+  recorded_at: Tue, 16 Jan 2018 14:01:28 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:user_tab_user/group_test_package
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '93'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="group_test_package" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
+        </directory>
+    http_version: 
+  recorded_at: Tue, 16 Jan 2018 14:01:28 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:user_tab_user/group_test_package
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '93'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="group_test_package" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
+        </directory>
+    http_version: 
+  recorded_at: Tue, 16 Jan 2018 14:01:28 GMT
+- request:
+    method: get
+    uri: http://backend:5352/build/home:user_tab_user/_result?package=group_test_package&view=status
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - text/plain
+      Accept-Encoding:
+      - identity
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '56'
+    body:
+      encoding: UTF-8
+      string: '<resultlist state="00000000000000000000000000000000" />
+
+'
+    http_version: 
+  recorded_at: Tue, 16 Jan 2018 14:01:28 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:user_tab_user/group_test_package/_meta?user=user_tab_user
@@ -954,8 +752,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="group_test_package" project="home:user_tab_user">
-          <title>The Needle's Eye</title>
-          <description>Consequatur ex deserunt qui.</description>
+          <title>The Wings of the Dove</title>
+          <description>Veniam quia incidunt quaerat ipsam repudiandae.</description>
           <person userid="user_tab_user" role="bugowner"/>
           <person userid="other_user" role="maintainer"/>
           <person userid="user_tab_user" role="maintainer"/>
@@ -980,13 +778,13 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '373'
+      - '397'
     body:
       encoding: UTF-8
       string: |
         <package name="group_test_package" project="home:user_tab_user">
-          <title>The Needle's Eye</title>
-          <description>Consequatur ex deserunt qui.</description>
+          <title>The Wings of the Dove</title>
+          <description>Veniam quia incidunt quaerat ipsam repudiandae.</description>
           <person userid="user_tab_user" role="bugowner" />
           <person userid="other_user" role="maintainer" />
           <person userid="user_tab_user" role="maintainer" />

--- a/src/api/spec/cassettes/Packages/behaves_like_user_tab/user_roles/Remove_role_from_user.yml
+++ b/src/api/spec/cassettes/Packages/behaves_like_user_tab/user_roles/Remove_role_from_user.yml
@@ -2,962 +2,6 @@
 http_interactions:
 - request:
     method: put
-    uri: http://backend:5352/source/home:other_user/_meta
-    body:
-      encoding: UTF-8
-      string: |
-        <project name="home:other_user">
-          <title/>
-          <description/>
-          <person userid="other_user" role="maintainer"/>
-        </project>
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '143'
-    body:
-      encoding: UTF-8
-      string: |
-        <project name="home:other_user">
-          <title></title>
-          <description></description>
-          <person userid="other_user" role="maintainer" />
-        </project>
-    http_version: 
-  recorded_at: Wed, 17 Aug 2016 11:20:11 GMT
-- request:
-    method: put
-    uri: http://backend:5352/source/home:other_user/branch_test_package/_meta
-    body:
-      encoding: UTF-8
-      string: |
-        <package name="branch_test_package" project="home:other_user">
-          <title/>
-          <description/>
-        </package>
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '122'
-    body:
-      encoding: UTF-8
-      string: |
-        <package name="branch_test_package" project="home:other_user">
-          <title></title>
-          <description></description>
-        </package>
-    http_version: 
-  recorded_at: Wed, 17 Aug 2016 11:20:11 GMT
-- request:
-    method: put
-    uri: http://backend:5352/source/home:other_user/branch_test_package/somefile.txt
-    body:
-      encoding: UTF-8
-      string: Tenetur aut cupiditate qui qui doloribus ut quod. Non vel consequuntur
-        quo consequatur qui voluptas. Mollitia minus officiis. Quis sit rerum numquam
-        mollitia.
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '207'
-    body:
-      encoding: UTF-8
-      string: |
-        <revision rev="1" vrev="1">
-          <srcmd5>c396d5ebb7ed412c4ca92ec0471030d1</srcmd5>
-          <version>unknown</version>
-          <time>1471432811</time>
-          <user>unknown</user>
-          <comment></comment>
-          <requestid/>
-        </revision>
-    http_version: 
-  recorded_at: Wed, 17 Aug 2016 11:20:11 GMT
-- request:
-    method: get
-    uri: http://backend:5352/build/home:user_tab_user/_result?package=group_test_package&view=status
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Content-Type:
-      - text/plain
-      Accept-Encoding:
-      - identity
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 404
-      message: project 'home user_tab_user' does not exist
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '164'
-    body:
-      encoding: UTF-8
-      string: |
-        <status code="404">
-          <summary>project 'home:user_tab_user' does not exist</summary>
-          <details>404 project 'home:user_tab_user' does not exist</details>
-        </status>
-    http_version: 
-  recorded_at: Wed, 17 Aug 2016 11:20:12 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/home:user_tab_user/group_test_package?nofilename=1&view=info&withchangesmd5=1
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 404
-      message: project 'home user_tab_user' does not exist
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '164'
-    body:
-      encoding: UTF-8
-      string: |
-        <status code="404">
-          <summary>project 'home:user_tab_user' does not exist</summary>
-          <details>404 project 'home:user_tab_user' does not exist</details>
-        </status>
-    http_version: 
-  recorded_at: Wed, 17 Aug 2016 11:20:12 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/home:user_tab_user/group_test_package
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 404
-      message: project 'home user_tab_user' does not exist
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '164'
-    body:
-      encoding: UTF-8
-      string: |
-        <status code="404">
-          <summary>project 'home:user_tab_user' does not exist</summary>
-          <details>404 project 'home:user_tab_user' does not exist</details>
-        </status>
-    http_version: 
-  recorded_at: Wed, 17 Aug 2016 11:20:12 GMT
-- request:
-    method: post
-    uri: http://backend:5352/source/home:user_tab_user/group_test_package?cmd=diff&linkrev=base&onlyissues=1&orev=0&view=xml
-    body:
-      encoding: UTF-8
-      string: ''
-    headers:
-      Content-Type:
-      - application/octet-stream
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 404
-      message: project 'home user_tab_user' does not exist
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '164'
-    body:
-      encoding: UTF-8
-      string: |
-        <status code="404">
-          <summary>project 'home:user_tab_user' does not exist</summary>
-          <details>404 project 'home:user_tab_user' does not exist</details>
-        </status>
-    http_version: 
-  recorded_at: Wed, 17 Aug 2016 11:20:12 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/home:user_tab_user/group_test_package
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 404
-      message: project 'home user_tab_user' does not exist
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '164'
-    body:
-      encoding: UTF-8
-      string: |
-        <status code="404">
-          <summary>project 'home:user_tab_user' does not exist</summary>
-          <details>404 project 'home:user_tab_user' does not exist</details>
-        </status>
-    http_version: 
-  recorded_at: Wed, 17 Aug 2016 11:20:12 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/home:user_tab_user/group_test_package?expand=1
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Content-Type:
-      - text/plain
-      Accept-Encoding:
-      - identity
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 404
-      message: project 'home user_tab_user' does not exist
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '164'
-    body:
-      encoding: UTF-8
-      string: |
-        <status code="404">
-          <summary>project 'home:user_tab_user' does not exist</summary>
-          <details>404 project 'home:user_tab_user' does not exist</details>
-        </status>
-    http_version: 
-  recorded_at: Wed, 17 Aug 2016 11:20:12 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/home:user_tab_user/group_test_package
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Content-Type:
-      - text/plain
-      Accept-Encoding:
-      - identity
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 404
-      message: project 'home user_tab_user' does not exist
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '164'
-    body:
-      encoding: UTF-8
-      string: |
-        <status code="404">
-          <summary>project 'home:user_tab_user' does not exist</summary>
-          <details>404 project 'home:user_tab_user' does not exist</details>
-        </status>
-    http_version: 
-  recorded_at: Wed, 17 Aug 2016 11:20:12 GMT
-- request:
-    method: get
-    uri: http://backend:5352/build/home:user_tab_user/_result?package=group_test_package&view=status
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Content-Type:
-      - text/plain
-      Accept-Encoding:
-      - identity
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 404
-      message: project 'home user_tab_user' does not exist
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '164'
-    body:
-      encoding: UTF-8
-      string: |
-        <status code="404">
-          <summary>project 'home:user_tab_user' does not exist</summary>
-          <details>404 project 'home:user_tab_user' does not exist</details>
-        </status>
-    http_version: 
-  recorded_at: Wed, 17 Aug 2016 11:20:12 GMT
-- request:
-    method: get
-    uri: http://backend:5352/build/home:user_tab_user/_result?package=group_test_package&view=status
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Content-Type:
-      - text/plain
-      Accept-Encoding:
-      - identity
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 404
-      message: project 'home user_tab_user' does not exist
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '164'
-    body:
-      encoding: UTF-8
-      string: |
-        <status code="404">
-          <summary>project 'home:user_tab_user' does not exist</summary>
-          <details>404 project 'home:user_tab_user' does not exist</details>
-        </status>
-    http_version: 
-  recorded_at: Wed, 17 Aug 2016 11:20:12 GMT
-- request:
-    method: get
-    uri: http://backend:5352/build/home:user_tab_user/_result?package=group_test_package&view=status
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Content-Type:
-      - text/plain
-      Accept-Encoding:
-      - identity
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 404
-      message: project 'home user_tab_user' does not exist
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '164'
-    body:
-      encoding: UTF-8
-      string: |
-        <status code="404">
-          <summary>project 'home:user_tab_user' does not exist</summary>
-          <details>404 project 'home:user_tab_user' does not exist</details>
-        </status>
-    http_version: 
-  recorded_at: Wed, 17 Aug 2016 11:20:13 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/home:user_tab_user/group_test_package
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 404
-      message: project 'home user_tab_user' does not exist
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '164'
-    body:
-      encoding: UTF-8
-      string: |
-        <status code="404">
-          <summary>project 'home:user_tab_user' does not exist</summary>
-          <details>404 project 'home:user_tab_user' does not exist</details>
-        </status>
-    http_version: 
-  recorded_at: Wed, 17 Aug 2016 11:20:13 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/home:user_tab_user/group_test_package?expand=1
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Content-Type:
-      - text/plain
-      Accept-Encoding:
-      - identity
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 404
-      message: project 'home user_tab_user' does not exist
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '164'
-    body:
-      encoding: UTF-8
-      string: |
-        <status code="404">
-          <summary>project 'home:user_tab_user' does not exist</summary>
-          <details>404 project 'home:user_tab_user' does not exist</details>
-        </status>
-    http_version: 
-  recorded_at: Wed, 17 Aug 2016 11:20:13 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/home:user_tab_user/group_test_package
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Content-Type:
-      - text/plain
-      Accept-Encoding:
-      - identity
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 404
-      message: project 'home user_tab_user' does not exist
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '164'
-    body:
-      encoding: UTF-8
-      string: |
-        <status code="404">
-          <summary>project 'home:user_tab_user' does not exist</summary>
-          <details>404 project 'home:user_tab_user' does not exist</details>
-        </status>
-    http_version: 
-  recorded_at: Wed, 17 Aug 2016 11:20:13 GMT
-- request:
-    method: get
-    uri: http://backend:5352/build/home:user_tab_user/_result?package=group_test_package&view=status
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Content-Type:
-      - text/plain
-      Accept-Encoding:
-      - identity
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 404
-      message: project 'home user_tab_user' does not exist
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '164'
-    body:
-      encoding: UTF-8
-      string: |
-        <status code="404">
-          <summary>project 'home:user_tab_user' does not exist</summary>
-          <details>404 project 'home:user_tab_user' does not exist</details>
-        </status>
-    http_version: 
-  recorded_at: Wed, 17 Aug 2016 11:20:13 GMT
-- request:
-    method: get
-    uri: http://backend:5352/build/home:user_tab_user/_result?package=group_test_package&view=status
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Content-Type:
-      - text/plain
-      Accept-Encoding:
-      - identity
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 404
-      message: project 'home user_tab_user' does not exist
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '164'
-    body:
-      encoding: UTF-8
-      string: |
-        <status code="404">
-          <summary>project 'home:user_tab_user' does not exist</summary>
-          <details>404 project 'home:user_tab_user' does not exist</details>
-        </status>
-    http_version: 
-  recorded_at: Wed, 17 Aug 2016 11:20:13 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/home:user_tab_user/group_test_package/_service
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Content-Type:
-      - text/plain
-      Accept-Encoding:
-      - identity
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 404
-      message: project 'home user_tab_user' does not exist
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '164'
-    body:
-      encoding: UTF-8
-      string: |
-        <status code="404">
-          <summary>project 'home:user_tab_user' does not exist</summary>
-          <details>404 project 'home:user_tab_user' does not exist</details>
-        </status>
-    http_version: 
-  recorded_at: Wed, 05 Oct 2016 09:09:14 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/home:user_tab_user/group_test_package/_service
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Content-Type:
-      - text/plain
-      Accept-Encoding:
-      - identity
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 404
-      message: project 'home user_tab_user' does not exist
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '164'
-    body:
-      encoding: UTF-8
-      string: |
-        <status code="404">
-          <summary>project 'home:user_tab_user' does not exist</summary>
-          <details>404 project 'home:user_tab_user' does not exist</details>
-        </status>
-    http_version: 
-  recorded_at: Wed, 05 Oct 2016 09:09:15 GMT
-- request:
-    method: get
-    uri: http://backend:5352/build/home:user_tab_user/_result?locallink=1&multibuild=1&package=group_test_package&view=status
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Content-Type:
-      - text/plain
-      Accept-Encoding:
-      - identity
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 404
-      message: project 'home user_tab_user' does not exist
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '164'
-    body:
-      encoding: UTF-8
-      string: |
-        <status code="404">
-          <summary>project 'home:user_tab_user' does not exist</summary>
-          <details>404 project 'home:user_tab_user' does not exist</details>
-        </status>
-    http_version: 
-  recorded_at: Fri, 20 Jan 2017 02:55:11 GMT
-- request:
-    method: get
-    uri: http://backend:5352/build/home:user_tab_user/_result?locallink=1&multibuild=1&package=group_test_package&view=status
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Content-Type:
-      - text/plain
-      Accept-Encoding:
-      - identity
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 404
-      message: project 'home user_tab_user' does not exist
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '164'
-    body:
-      encoding: UTF-8
-      string: |
-        <status code="404">
-          <summary>project 'home:user_tab_user' does not exist</summary>
-          <details>404 project 'home:user_tab_user' does not exist</details>
-        </status>
-    http_version: 
-  recorded_at: Fri, 20 Jan 2017 02:55:12 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/home:user_tab_user/group_test_package?expand=0
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 404
-      message: project 'home user_tab_user' does not exist
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '164'
-    body:
-      encoding: UTF-8
-      string: |
-        <status code="404">
-          <summary>project 'home:user_tab_user' does not exist</summary>
-          <details>404 project 'home:user_tab_user' does not exist</details>
-        </status>
-    http_version: 
-  recorded_at: Tue, 16 May 2017 15:10:11 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/home:user_tab_user/group_test_package?expand=0
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 404
-      message: project 'home user_tab_user' does not exist
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '164'
-    body:
-      encoding: UTF-8
-      string: |
-        <status code="404">
-          <summary>project 'home:user_tab_user' does not exist</summary>
-          <details>404 project 'home:user_tab_user' does not exist</details>
-        </status>
-    http_version: 
-  recorded_at: Tue, 16 May 2017 15:10:11 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/home:user_tab_user/group_test_package
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 404
-      message: project 'home user_tab_user' does not exist
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '164'
-    body:
-      encoding: UTF-8
-      string: |
-        <status code="404">
-          <summary>project 'home:user_tab_user' does not exist</summary>
-          <details>404 project 'home:user_tab_user' does not exist</details>
-        </status>
-    http_version: 
-  recorded_at: Fri, 16 Jun 2017 14:23:55 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/home:user_tab_user/group_test_package
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 404
-      message: project 'home user_tab_user' does not exist
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '164'
-    body:
-      encoding: UTF-8
-      string: |
-        <status code="404">
-          <summary>project 'home:user_tab_user' does not exist</summary>
-          <details>404 project 'home:user_tab_user' does not exist</details>
-        </status>
-    http_version: 
-  recorded_at: Fri, 16 Jun 2017 14:23:55 GMT
-- request:
-    method: put
     uri: http://backend:5352/source/home:package_test_user/_meta?user=package_test_user
     body:
       encoding: UTF-8
@@ -996,7 +40,7 @@ http_interactions:
           <person userid="package_test_user" role="maintainer" />
         </project>
     http_version: 
-  recorded_at: Wed, 03 Jan 2018 13:16:02 GMT
+  recorded_at: Tue, 16 Jan 2018 14:01:34 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:user_tab_user/_meta?user=user_tab_user
@@ -1037,7 +81,7 @@ http_interactions:
           <person userid="user_tab_user" role="maintainer" />
         </project>
     http_version: 
-  recorded_at: Wed, 03 Jan 2018 13:16:02 GMT
+  recorded_at: Tue, 16 Jan 2018 14:01:34 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:user_tab_user/group_test_package/_meta?user=user_tab_user
@@ -1045,8 +89,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="group_test_package" project="home:user_tab_user">
-          <title>Unweaving the Rainbow</title>
-          <description>Incidunt veniam repudiandae architecto autem deserunt qui accusamus.</description>
+          <title>It's a Battlefield</title>
+          <description>Sapiente et qui consequatur dicta et eveniet.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -1067,16 +111,16 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '213'
+      - '187'
     body:
       encoding: UTF-8
       string: |
         <package name="group_test_package" project="home:user_tab_user">
-          <title>Unweaving the Rainbow</title>
-          <description>Incidunt veniam repudiandae architecto autem deserunt qui accusamus.</description>
+          <title>It's a Battlefield</title>
+          <description>Sapiente et qui consequatur dicta et eveniet.</description>
         </package>
     http_version: 
-  recorded_at: Wed, 03 Jan 2018 13:16:02 GMT
+  recorded_at: Tue, 16 Jan 2018 14:01:34 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:user_tab_user/group_test_package/_meta
@@ -1084,8 +128,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="group_test_package" project="home:user_tab_user">
-          <title>Unweaving the Rainbow</title>
-          <description>Incidunt veniam repudiandae architecto autem deserunt qui accusamus.</description>
+          <title>It's a Battlefield</title>
+          <description>Sapiente et qui consequatur dicta et eveniet.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -1106,16 +150,16 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '213'
+      - '187'
     body:
       encoding: UTF-8
       string: |
         <package name="group_test_package" project="home:user_tab_user">
-          <title>Unweaving the Rainbow</title>
-          <description>Incidunt veniam repudiandae architecto autem deserunt qui accusamus.</description>
+          <title>It's a Battlefield</title>
+          <description>Sapiente et qui consequatur dicta et eveniet.</description>
         </package>
     http_version: 
-  recorded_at: Wed, 03 Jan 2018 13:16:02 GMT
+  recorded_at: Tue, 16 Jan 2018 14:01:35 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:other_user/_meta?user=other_user
@@ -1156,7 +200,7 @@ http_interactions:
           <person userid="other_user" role="maintainer" />
         </project>
     http_version: 
-  recorded_at: Wed, 03 Jan 2018 13:16:02 GMT
+  recorded_at: Tue, 16 Jan 2018 14:01:35 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:other_user/branch_test_package/_meta?user=user_tab_user
@@ -1164,8 +208,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="branch_test_package" project="home:other_user">
-          <title>Paths of Glory</title>
-          <description>Et necessitatibus voluptatum voluptatem voluptas quas voluptatibus.</description>
+          <title>Eyeless in Gaza</title>
+          <description>Laboriosam similique iste dolorem.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -1186,24 +230,62 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '203'
+      - '171'
     body:
       encoding: UTF-8
       string: |
         <package name="branch_test_package" project="home:other_user">
-          <title>Paths of Glory</title>
-          <description>Et necessitatibus voluptatum voluptatem voluptas quas voluptatibus.</description>
+          <title>Eyeless in Gaza</title>
+          <description>Laboriosam similique iste dolorem.</description>
         </package>
     http_version: 
-  recorded_at: Wed, 03 Jan 2018 13:16:02 GMT
+  recorded_at: Tue, 16 Jan 2018 14:01:35 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:other_user/branch_test_package/_meta
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="branch_test_package" project="home:other_user">
+          <title>Eyeless in Gaza</title>
+          <description>Laboriosam similique iste dolorem.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '171'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="branch_test_package" project="home:other_user">
+          <title>Eyeless in Gaza</title>
+          <description>Laboriosam similique iste dolorem.</description>
+        </package>
+    http_version: 
+  recorded_at: Tue, 16 Jan 2018 14:01:35 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:other_user/branch_test_package/_config
     body:
       encoding: UTF-8
-      string: Nulla praesentium quia eum omnis cupiditate voluptatibus qui. Sed asperiores
-        eum ratione sunt dolorum deleniti enim. Iusto deserunt quia accusamus voluptate
-        voluptas dolores ab. Quos sed omnis nemo alias non.
+      string: Ea exercitationem blanditiis id libero. Expedita voluptate nemo. Dolor
+        voluptas quo provident.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -1223,20 +305,61 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '207'
+      - '209'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="5" vrev="5">
-          <srcmd5>c5fafe128b9ddaf0f3776a22fbb1cd98</srcmd5>
+        <revision rev="31" vrev="31">
+          <srcmd5>5fe77c34aa5980a3da7ebd4b2a6d419c</srcmd5>
           <version>unknown</version>
-          <time>1514985362</time>
+          <time>1516111295</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
     http_version: 
-  recorded_at: Wed, 03 Jan 2018 13:16:02 GMT
+  recorded_at: Tue, 16 Jan 2018 14:01:35 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:other_user/branch_test_package/somefile.txt
+    body:
+      encoding: UTF-8
+      string: Officia quia repellendus quis. Velit ullam et. Praesentium dolorem quos
+        quae dolorum illum libero sit. Culpa officia autem voluptatem assumenda. Officiis
+        repudiandae et in.
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '209'
+    body:
+      encoding: UTF-8
+      string: |
+        <revision rev="32" vrev="32">
+          <srcmd5>5fe77c34aa5980a3da7ebd4b2a6d419c</srcmd5>
+          <version>unknown</version>
+          <time>1516111295</time>
+          <user>unknown</user>
+          <comment></comment>
+          <requestid/>
+        </revision>
+    http_version: 
+  recorded_at: Tue, 16 Jan 2018 14:01:35 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:reader_user/_meta?user=reader_user
@@ -1277,19 +400,13 @@ http_interactions:
           <person userid="reader_user" role="maintainer" />
         </project>
     http_version: 
-  recorded_at: Wed, 03 Jan 2018 13:16:02 GMT
+  recorded_at: Tue, 16 Jan 2018 14:01:35 GMT
 - request:
-    method: put
-    uri: http://backend:5352/source/home:user_tab_user/group_test_package/_meta?user=user_tab_user
+    method: get
+    uri: http://backend:5352/source/home:user_tab_user/group_test_package?nofilename=1&view=info&withchangesmd5=1
     body:
-      encoding: UTF-8
-      string: |
-        <package name="group_test_package" project="home:user_tab_user">
-          <title>Unweaving the Rainbow</title>
-          <description>Incidunt veniam repudiandae architecto autem deserunt qui accusamus.</description>
-          <person userid="user_tab_user" role="maintainer"/>
-          <person userid="reader_user" role="reader"/>
-        </package>
+      encoding: US-ASCII
+      string: ''
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -1309,61 +426,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '315'
+      - '156'
     body:
       encoding: UTF-8
       string: |
-        <package name="group_test_package" project="home:user_tab_user">
-          <title>Unweaving the Rainbow</title>
-          <description>Incidunt veniam repudiandae architecto autem deserunt qui accusamus.</description>
-          <person userid="user_tab_user" role="maintainer" />
-          <person userid="reader_user" role="reader" />
-        </package>
+        <sourceinfo package="group_test_package" srcmd5="d41d8cd98f00b204e9800998ecf8427e" verifymd5="d41d8cd98f00b204e9800998ecf8427e">
+          <revtime/>
+        </sourceinfo>
     http_version: 
-  recorded_at: Wed, 03 Jan 2018 13:16:04 GMT
-- request:
-    method: put
-    uri: http://backend:5352/source/home:user_tab_user/group_test_package/_meta?user=user_tab_user
-    body:
-      encoding: UTF-8
-      string: |
-        <package name="group_test_package" project="home:user_tab_user">
-          <title>Unweaving the Rainbow</title>
-          <description>Incidunt veniam repudiandae architecto autem deserunt qui accusamus.</description>
-          <person userid="user_tab_user" role="maintainer"/>
-          <person userid="reader_user" role="reader"/>
-        </package>
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '315'
-    body:
-      encoding: UTF-8
-      string: |
-        <package name="group_test_package" project="home:user_tab_user">
-          <title>Unweaving the Rainbow</title>
-          <description>Incidunt veniam repudiandae architecto autem deserunt qui accusamus.</description>
-          <person userid="user_tab_user" role="maintainer" />
-          <person userid="reader_user" role="reader" />
-        </package>
-    http_version: 
-  recorded_at: Wed, 03 Jan 2018 13:16:04 GMT
+  recorded_at: Tue, 16 Jan 2018 14:01:35 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:user_tab_user/group_test_package
@@ -1396,7 +467,45 @@ http_interactions:
         <directory name="group_test_package" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
         </directory>
     http_version: 
-  recorded_at: Wed, 03 Jan 2018 13:16:04 GMT
+  recorded_at: Tue, 16 Jan 2018 14:01:36 GMT
+- request:
+    method: post
+    uri: http://backend:5352/source/home:user_tab_user/group_test_package?cmd=diff&linkrev=base&onlyissues=1&orev=0&view=xml
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Content-Type:
+      - application/octet-stream
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '314'
+    body:
+      encoding: UTF-8
+      string: |
+        <sourcediff key="04429e5eb3523e7cb3e15ee88d1605d6">
+          <old project="home:user_tab_user" package="group_test_package" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e" />
+          <new project="home:user_tab_user" package="group_test_package" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e" />
+          <files />
+        </sourcediff>
+    http_version: 
+  recorded_at: Tue, 16 Jan 2018 14:01:36 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:user_tab_user/group_test_package
@@ -1428,6 +537,537 @@ http_interactions:
       string: |
         <directory name="group_test_package" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
         </directory>
+    http_version: 
+  recorded_at: Tue, 16 Jan 2018 14:01:36 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:user_tab_user/group_test_package?expand=1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '93'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="group_test_package" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
+        </directory>
+    http_version: 
+  recorded_at: Tue, 16 Jan 2018 14:01:36 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:user_tab_user/group_test_package
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - text/plain
+      Accept-Encoding:
+      - identity
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '93'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="group_test_package" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
+        </directory>
+    http_version: 
+  recorded_at: Tue, 16 Jan 2018 14:01:36 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:user_tab_user/group_test_package/_service
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - text/plain
+      Accept-Encoding:
+      - identity
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 404
+      message: _service  no such file
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '122'
+    body:
+      encoding: UTF-8
+      string: |
+        <status code="404">
+          <summary>_service: no such file</summary>
+          <details>404 _service: no such file</details>
+        </status>
+    http_version: 
+  recorded_at: Tue, 16 Jan 2018 14:01:36 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:user_tab_user/group_test_package
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '93'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="group_test_package" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
+        </directory>
+    http_version: 
+  recorded_at: Tue, 16 Jan 2018 14:01:36 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:user_tab_user/group_test_package
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '93'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="group_test_package" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
+        </directory>
+    http_version: 
+  recorded_at: Tue, 16 Jan 2018 14:01:36 GMT
+- request:
+    method: get
+    uri: http://backend:5352/build/home:user_tab_user/_result?package=group_test_package&view=status
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - text/plain
+      Accept-Encoding:
+      - identity
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '56'
+    body:
+      encoding: UTF-8
+      string: '<resultlist state="00000000000000000000000000000000" />
+
+'
+    http_version: 
+  recorded_at: Tue, 16 Jan 2018 14:01:36 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:user_tab_user/group_test_package/_meta?user=user_tab_user
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="group_test_package" project="home:user_tab_user">
+          <title>It's a Battlefield</title>
+          <description>Sapiente et qui consequatur dicta et eveniet.</description>
+          <person userid="user_tab_user" role="maintainer"/>
+          <person userid="reader_user" role="reader"/>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '289'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="group_test_package" project="home:user_tab_user">
+          <title>It's a Battlefield</title>
+          <description>Sapiente et qui consequatur dicta et eveniet.</description>
+          <person userid="user_tab_user" role="maintainer" />
+          <person userid="reader_user" role="reader" />
+        </package>
+    http_version: 
+  recorded_at: Tue, 16 Jan 2018 14:01:36 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:user_tab_user/group_test_package/_meta?user=user_tab_user
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="group_test_package" project="home:user_tab_user">
+          <title>It's a Battlefield</title>
+          <description>Sapiente et qui consequatur dicta et eveniet.</description>
+          <person userid="user_tab_user" role="maintainer"/>
+          <person userid="reader_user" role="reader"/>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '289'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="group_test_package" project="home:user_tab_user">
+          <title>It's a Battlefield</title>
+          <description>Sapiente et qui consequatur dicta et eveniet.</description>
+          <person userid="user_tab_user" role="maintainer" />
+          <person userid="reader_user" role="reader" />
+        </package>
+    http_version: 
+  recorded_at: Tue, 16 Jan 2018 14:01:36 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:user_tab_user/group_test_package
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '93'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="group_test_package" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
+        </directory>
+    http_version: 
+  recorded_at: Tue, 16 Jan 2018 14:01:36 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:user_tab_user/group_test_package?expand=1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '93'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="group_test_package" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
+        </directory>
+    http_version: 
+  recorded_at: Tue, 16 Jan 2018 14:01:36 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:user_tab_user/group_test_package
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - text/plain
+      Accept-Encoding:
+      - identity
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '93'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="group_test_package" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
+        </directory>
+    http_version: 
+  recorded_at: Tue, 16 Jan 2018 14:01:36 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:user_tab_user/group_test_package/_service
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - text/plain
+      Accept-Encoding:
+      - identity
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 404
+      message: _service  no such file
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '122'
+    body:
+      encoding: UTF-8
+      string: |
+        <status code="404">
+          <summary>_service: no such file</summary>
+          <details>404 _service: no such file</details>
+        </status>
+    http_version: 
+  recorded_at: Tue, 16 Jan 2018 14:01:36 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:user_tab_user/group_test_package
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '93'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="group_test_package" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
+        </directory>
+    http_version: 
+  recorded_at: Tue, 16 Jan 2018 14:01:36 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:user_tab_user/group_test_package
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '93'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="group_test_package" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
+        </directory>
+    http_version: 
+  recorded_at: Tue, 16 Jan 2018 14:01:36 GMT
+- request:
+    method: get
+    uri: http://backend:5352/build/home:user_tab_user/_result?package=group_test_package&view=status
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - text/plain
+      Accept-Encoding:
+      - identity
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '56'
+    body:
+      encoding: UTF-8
+      string: '<resultlist state="00000000000000000000000000000000" />
+
+'
     http_version: 
   recorded_at: Wed, 03 Jan 2018 13:16:04 GMT
 - request:

--- a/src/api/spec/cassettes/Packages/behaves_like_user_tab/user_roles/Remove_user_from_package_/_project.yml
+++ b/src/api/spec/cassettes/Packages/behaves_like_user_tab/user_roles/Remove_user_from_package_/_project.yml
@@ -1,362 +1,6 @@
 ---
 http_interactions:
 - request:
-    method: get
-    uri: http://backend:5352/source/home:user_tab_user/group_test_package?nofilename=1&view=info&withchangesmd5=1
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 404
-      message: project 'home user_tab_user' does not exist
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '164'
-    body:
-      encoding: UTF-8
-      string: |
-        <status code="404">
-          <summary>project 'home:user_tab_user' does not exist</summary>
-          <details>404 project 'home:user_tab_user' does not exist</details>
-        </status>
-    http_version: 
-  recorded_at: Fri, 11 Aug 2017 08:26:47 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/home:user_tab_user/group_test_package
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 404
-      message: project 'home user_tab_user' does not exist
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '164'
-    body:
-      encoding: UTF-8
-      string: |
-        <status code="404">
-          <summary>project 'home:user_tab_user' does not exist</summary>
-          <details>404 project 'home:user_tab_user' does not exist</details>
-        </status>
-    http_version: 
-  recorded_at: Fri, 11 Aug 2017 08:26:47 GMT
-- request:
-    method: post
-    uri: http://backend:5352/source/home:user_tab_user/group_test_package?cmd=diff&linkrev=base&onlyissues=1&orev=0&view=xml
-    body:
-      encoding: UTF-8
-      string: ''
-    headers:
-      Content-Type:
-      - application/octet-stream
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 404
-      message: project 'home user_tab_user' does not exist
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '164'
-    body:
-      encoding: UTF-8
-      string: |
-        <status code="404">
-          <summary>project 'home:user_tab_user' does not exist</summary>
-          <details>404 project 'home:user_tab_user' does not exist</details>
-        </status>
-    http_version: 
-  recorded_at: Fri, 11 Aug 2017 08:26:47 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/home:user_tab_user/group_test_package
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 404
-      message: project 'home user_tab_user' does not exist
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '164'
-    body:
-      encoding: UTF-8
-      string: |
-        <status code="404">
-          <summary>project 'home:user_tab_user' does not exist</summary>
-          <details>404 project 'home:user_tab_user' does not exist</details>
-        </status>
-    http_version: 
-  recorded_at: Fri, 11 Aug 2017 08:26:47 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/home:user_tab_user/group_test_package?expand=1
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 404
-      message: project 'home user_tab_user' does not exist
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '164'
-    body:
-      encoding: UTF-8
-      string: |
-        <status code="404">
-          <summary>project 'home:user_tab_user' does not exist</summary>
-          <details>404 project 'home:user_tab_user' does not exist</details>
-        </status>
-    http_version: 
-  recorded_at: Fri, 11 Aug 2017 08:26:47 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/home:user_tab_user/group_test_package
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 404
-      message: project 'home user_tab_user' does not exist
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '164'
-    body:
-      encoding: UTF-8
-      string: |
-        <status code="404">
-          <summary>project 'home:user_tab_user' does not exist</summary>
-          <details>404 project 'home:user_tab_user' does not exist</details>
-        </status>
-    http_version: 
-  recorded_at: Fri, 11 Aug 2017 08:26:47 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/home:user_tab_user/group_test_package?expand=0
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 404
-      message: project 'home user_tab_user' does not exist
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '164'
-    body:
-      encoding: UTF-8
-      string: |
-        <status code="404">
-          <summary>project 'home:user_tab_user' does not exist</summary>
-          <details>404 project 'home:user_tab_user' does not exist</details>
-        </status>
-    http_version: 
-  recorded_at: Fri, 11 Aug 2017 08:26:47 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/home:user_tab_user/group_test_package/_service
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Content-Type:
-      - text/plain
-      Accept-Encoding:
-      - identity
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 404
-      message: project 'home user_tab_user' does not exist
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '164'
-    body:
-      encoding: UTF-8
-      string: |
-        <status code="404">
-          <summary>project 'home:user_tab_user' does not exist</summary>
-          <details>404 project 'home:user_tab_user' does not exist</details>
-        </status>
-    http_version: 
-  recorded_at: Fri, 11 Aug 2017 08:26:47 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/home:user_tab_user/group_test_package
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 404
-      message: project 'home user_tab_user' does not exist
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '164'
-    body:
-      encoding: UTF-8
-      string: |
-        <status code="404">
-          <summary>project 'home:user_tab_user' does not exist</summary>
-          <details>404 project 'home:user_tab_user' does not exist</details>
-        </status>
-    http_version: 
-  recorded_at: Fri, 11 Aug 2017 08:26:47 GMT
-- request:
-    method: get
-    uri: http://backend:5352/build/home:user_tab_user/_result?package=group_test_package&view=status
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Content-Type:
-      - text/plain
-      Accept-Encoding:
-      - identity
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 404
-      message: project 'home user_tab_user' does not exist
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '164'
-    body:
-      encoding: UTF-8
-      string: |
-        <status code="404">
-          <summary>project 'home:user_tab_user' does not exist</summary>
-          <details>404 project 'home:user_tab_user' does not exist</details>
-        </status>
-    http_version: 
-  recorded_at: Fri, 11 Aug 2017 08:26:47 GMT
-- request:
     method: put
     uri: http://backend:5352/source/home:package_test_user/_meta?user=package_test_user
     body:
@@ -396,7 +40,7 @@ http_interactions:
           <person userid="package_test_user" role="maintainer" />
         </project>
     http_version: 
-  recorded_at: Wed, 03 Jan 2018 13:16:51 GMT
+  recorded_at: Tue, 16 Jan 2018 14:01:38 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:user_tab_user/_meta?user=user_tab_user
@@ -437,7 +81,7 @@ http_interactions:
           <person userid="user_tab_user" role="maintainer" />
         </project>
     http_version: 
-  recorded_at: Wed, 03 Jan 2018 13:16:51 GMT
+  recorded_at: Tue, 16 Jan 2018 14:01:38 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:user_tab_user/group_test_package/_meta?user=user_tab_user
@@ -445,8 +89,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="group_test_package" project="home:user_tab_user">
-          <title>The Heart Is a Lonely Hunter</title>
-          <description>Hic sequi voluptatibus esse reprehenderit et.</description>
+          <title>If Not Now, When?</title>
+          <description>Velit ut aut temporibus rerum reprehenderit et.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -467,16 +111,16 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '197'
+      - '188'
     body:
       encoding: UTF-8
       string: |
         <package name="group_test_package" project="home:user_tab_user">
-          <title>The Heart Is a Lonely Hunter</title>
-          <description>Hic sequi voluptatibus esse reprehenderit et.</description>
+          <title>If Not Now, When?</title>
+          <description>Velit ut aut temporibus rerum reprehenderit et.</description>
         </package>
     http_version: 
-  recorded_at: Wed, 03 Jan 2018 13:16:51 GMT
+  recorded_at: Tue, 16 Jan 2018 14:01:38 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:user_tab_user/group_test_package/_meta
@@ -484,8 +128,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="group_test_package" project="home:user_tab_user">
-          <title>The Heart Is a Lonely Hunter</title>
-          <description>Hic sequi voluptatibus esse reprehenderit et.</description>
+          <title>If Not Now, When?</title>
+          <description>Velit ut aut temporibus rerum reprehenderit et.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -506,16 +150,16 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '197'
+      - '188'
     body:
       encoding: UTF-8
       string: |
         <package name="group_test_package" project="home:user_tab_user">
-          <title>The Heart Is a Lonely Hunter</title>
-          <description>Hic sequi voluptatibus esse reprehenderit et.</description>
+          <title>If Not Now, When?</title>
+          <description>Velit ut aut temporibus rerum reprehenderit et.</description>
         </package>
     http_version: 
-  recorded_at: Wed, 03 Jan 2018 13:16:51 GMT
+  recorded_at: Tue, 16 Jan 2018 14:01:38 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:other_user/_meta?user=other_user
@@ -556,7 +200,7 @@ http_interactions:
           <person userid="other_user" role="maintainer" />
         </project>
     http_version: 
-  recorded_at: Wed, 03 Jan 2018 13:16:51 GMT
+  recorded_at: Tue, 16 Jan 2018 14:01:38 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:other_user/branch_test_package/_meta?user=user_tab_user
@@ -564,8 +208,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="branch_test_package" project="home:other_user">
-          <title>No Highway</title>
-          <description>Similique odio omnis provident id et suscipit eum.</description>
+          <title>The Moving Toyshop</title>
+          <description>Est magni at rem fuga.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -586,16 +230,16 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '182'
+      - '162'
     body:
       encoding: UTF-8
       string: |
         <package name="branch_test_package" project="home:other_user">
-          <title>No Highway</title>
-          <description>Similique odio omnis provident id et suscipit eum.</description>
+          <title>The Moving Toyshop</title>
+          <description>Est magni at rem fuga.</description>
         </package>
     http_version: 
-  recorded_at: Wed, 03 Jan 2018 13:16:51 GMT
+  recorded_at: Tue, 16 Jan 2018 14:01:38 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:other_user/branch_test_package/_meta
@@ -603,8 +247,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="branch_test_package" project="home:other_user">
-          <title>No Highway</title>
-          <description>Similique odio omnis provident id et suscipit eum.</description>
+          <title>The Moving Toyshop</title>
+          <description>Est magni at rem fuga.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -625,64 +269,23 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '182'
+      - '162'
     body:
       encoding: UTF-8
       string: |
         <package name="branch_test_package" project="home:other_user">
-          <title>No Highway</title>
-          <description>Similique odio omnis provident id et suscipit eum.</description>
+          <title>The Moving Toyshop</title>
+          <description>Est magni at rem fuga.</description>
         </package>
     http_version: 
-  recorded_at: Wed, 03 Jan 2018 13:16:51 GMT
+  recorded_at: Tue, 16 Jan 2018 14:01:38 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:other_user/branch_test_package/_config
     body:
       encoding: UTF-8
-      string: Et delectus dolorem nobis nemo. Velit voluptatem corrupti. Optio autem
-        eos accusantium. Exercitationem et dolor dolores sint. Nihil delectus dolore
-        ipsam aut iure similique consequatur.
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '207'
-    body:
-      encoding: UTF-8
-      string: |
-        <revision rev="9" vrev="9">
-          <srcmd5>425f0f10015c9ff36f3e52d84898ba64</srcmd5>
-          <version>unknown</version>
-          <time>1514985411</time>
-          <user>unknown</user>
-          <comment></comment>
-          <requestid/>
-        </revision>
-    http_version: 
-  recorded_at: Wed, 03 Jan 2018 13:16:51 GMT
-- request:
-    method: put
-    uri: http://backend:5352/source/home:other_user/branch_test_package/somefile.txt
-    body:
-      encoding: UTF-8
-      string: Consequatur ab nostrum. Blanditiis rerum eaque voluptates officiis sint
-        architecto. Quam consequuntur autem. Ut delectus omnis.
+      string: Est suscipit sed sunt cupiditate nihil quam. Dolores molestias id hic
+        sed. Sapiente ratione omnis velit ea nostrum doloremque.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -706,16 +309,57 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <revision rev="10" vrev="10">
-          <srcmd5>4c0ac11b3d615b74d6d623d0d006f0e1</srcmd5>
+        <revision rev="33" vrev="33">
+          <srcmd5>5d1a1744e6e794bdf07c83ab2ed4717a</srcmd5>
           <version>unknown</version>
-          <time>1514985411</time>
+          <time>1516111298</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
     http_version: 
-  recorded_at: Wed, 03 Jan 2018 13:16:51 GMT
+  recorded_at: Tue, 16 Jan 2018 14:01:38 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:other_user/branch_test_package/somefile.txt
+    body:
+      encoding: UTF-8
+      string: Officia quia repellendus quis. Velit ullam et. Praesentium dolorem quos
+        quae dolorum illum libero sit. Culpa officia autem voluptatem assumenda. Officiis
+        repudiandae et in.
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '209'
+    body:
+      encoding: UTF-8
+      string: |
+        <revision rev="34" vrev="34">
+          <srcmd5>5d1a1744e6e794bdf07c83ab2ed4717a</srcmd5>
+          <version>unknown</version>
+          <time>1516111298</time>
+          <user>unknown</user>
+          <comment></comment>
+          <requestid/>
+        </revision>
+    http_version: 
+  recorded_at: Tue, 16 Jan 2018 14:01:38 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:reader_user/_meta?user=reader_user
@@ -756,7 +400,41 @@ http_interactions:
           <person userid="reader_user" role="maintainer" />
         </project>
     http_version: 
-  recorded_at: Wed, 03 Jan 2018 13:16:51 GMT
+  recorded_at: Tue, 16 Jan 2018 14:01:38 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:user_tab_user/group_test_package?nofilename=1&view=info&withchangesmd5=1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '156'
+    body:
+      encoding: UTF-8
+      string: |
+        <sourceinfo package="group_test_package" srcmd5="d41d8cd98f00b204e9800998ecf8427e" verifymd5="d41d8cd98f00b204e9800998ecf8427e">
+          <revtime/>
+        </sourceinfo>
+    http_version: 
+  recorded_at: Tue, 16 Jan 2018 14:01:39 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:user_tab_user/group_test_package
@@ -789,7 +467,284 @@ http_interactions:
         <directory name="group_test_package" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
         </directory>
     http_version: 
-  recorded_at: Wed, 03 Jan 2018 13:16:52 GMT
+  recorded_at: Tue, 16 Jan 2018 14:01:39 GMT
+- request:
+    method: post
+    uri: http://backend:5352/source/home:user_tab_user/group_test_package?cmd=diff&linkrev=base&onlyissues=1&orev=0&view=xml
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Content-Type:
+      - application/octet-stream
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '314'
+    body:
+      encoding: UTF-8
+      string: |
+        <sourcediff key="04429e5eb3523e7cb3e15ee88d1605d6">
+          <old project="home:user_tab_user" package="group_test_package" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e" />
+          <new project="home:user_tab_user" package="group_test_package" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e" />
+          <files />
+        </sourcediff>
+    http_version: 
+  recorded_at: Tue, 16 Jan 2018 14:01:39 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:user_tab_user/group_test_package
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '93'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="group_test_package" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
+        </directory>
+    http_version: 
+  recorded_at: Tue, 16 Jan 2018 14:01:39 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:user_tab_user/group_test_package?expand=1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '93'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="group_test_package" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
+        </directory>
+    http_version: 
+  recorded_at: Tue, 16 Jan 2018 14:01:39 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:user_tab_user/group_test_package
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - text/plain
+      Accept-Encoding:
+      - identity
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '93'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="group_test_package" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
+        </directory>
+    http_version: 
+  recorded_at: Tue, 16 Jan 2018 14:01:39 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:user_tab_user/group_test_package/_service
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - text/plain
+      Accept-Encoding:
+      - identity
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 404
+      message: _service  no such file
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '122'
+    body:
+      encoding: UTF-8
+      string: |
+        <status code="404">
+          <summary>_service: no such file</summary>
+          <details>404 _service: no such file</details>
+        </status>
+    http_version: 
+  recorded_at: Tue, 16 Jan 2018 14:01:39 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:user_tab_user/group_test_package
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '93'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="group_test_package" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
+        </directory>
+    http_version: 
+  recorded_at: Tue, 16 Jan 2018 14:01:39 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:user_tab_user/group_test_package
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '93'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="group_test_package" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
+        </directory>
+    http_version: 
+  recorded_at: Tue, 16 Jan 2018 14:01:39 GMT
+- request:
+    method: get
+    uri: http://backend:5352/build/home:user_tab_user/_result?package=group_test_package&view=status
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - text/plain
+      Accept-Encoding:
+      - identity
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '56'
+    body:
+      encoding: UTF-8
+      string: '<resultlist state="00000000000000000000000000000000" />
+
+'
+    http_version: 
+  recorded_at: Tue, 16 Jan 2018 14:01:39 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:user_tab_user/group_test_package/_meta?user=user_tab_user
@@ -797,8 +752,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="group_test_package" project="home:user_tab_user">
-          <title>The Heart Is a Lonely Hunter</title>
-          <description>Hic sequi voluptatibus esse reprehenderit et.</description>
+          <title>If Not Now, When?</title>
+          <description>Velit ut aut temporibus rerum reprehenderit et.</description>
           <person userid="user_tab_user" role="bugowner"/>
           <person userid="user_tab_user" role="maintainer"/>
         </package>
@@ -821,18 +776,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '303'
+      - '294'
     body:
       encoding: UTF-8
       string: |
         <package name="group_test_package" project="home:user_tab_user">
-          <title>The Heart Is a Lonely Hunter</title>
-          <description>Hic sequi voluptatibus esse reprehenderit et.</description>
+          <title>If Not Now, When?</title>
+          <description>Velit ut aut temporibus rerum reprehenderit et.</description>
           <person userid="user_tab_user" role="bugowner" />
           <person userid="user_tab_user" role="maintainer" />
         </package>
     http_version: 
-  recorded_at: Wed, 03 Jan 2018 13:16:53 GMT
+  recorded_at: Tue, 16 Jan 2018 14:01:39 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:user_tab_user/group_test_package/_meta?user=user_tab_user
@@ -840,8 +795,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="group_test_package" project="home:user_tab_user">
-          <title>The Heart Is a Lonely Hunter</title>
-          <description>Hic sequi voluptatibus esse reprehenderit et.</description>
+          <title>If Not Now, When?</title>
+          <description>Velit ut aut temporibus rerum reprehenderit et.</description>
           <person userid="user_tab_user" role="bugowner"/>
           <person userid="user_tab_user" role="maintainer"/>
         </package>
@@ -864,13 +819,13 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '303'
+      - '294'
     body:
       encoding: UTF-8
       string: |
         <package name="group_test_package" project="home:user_tab_user">
-          <title>The Heart Is a Lonely Hunter</title>
-          <description>Hic sequi voluptatibus esse reprehenderit et.</description>
+          <title>If Not Now, When?</title>
+          <description>Velit ut aut temporibus rerum reprehenderit et.</description>
           <person userid="user_tab_user" role="bugowner" />
           <person userid="user_tab_user" role="maintainer" />
         </package>

--- a/src/api/spec/cassettes/Packages/behaves_like_user_tab/user_roles/Viewing_user_roles.yml
+++ b/src/api/spec/cassettes/Packages/behaves_like_user_tab/user_roles/Viewing_user_roles.yml
@@ -2,598 +2,6 @@
 http_interactions:
 - request:
     method: put
-    uri: http://backend:5352/source/home:other_user/_meta
-    body:
-      encoding: UTF-8
-      string: |
-        <project name="home:other_user">
-          <title/>
-          <description/>
-          <person userid="other_user" role="maintainer"/>
-        </project>
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '143'
-    body:
-      encoding: UTF-8
-      string: |
-        <project name="home:other_user">
-          <title></title>
-          <description></description>
-          <person userid="other_user" role="maintainer" />
-        </project>
-    http_version: 
-  recorded_at: Wed, 17 Aug 2016 11:20:24 GMT
-- request:
-    method: put
-    uri: http://backend:5352/source/home:other_user/branch_test_package/_meta
-    body:
-      encoding: UTF-8
-      string: |
-        <package name="branch_test_package" project="home:other_user">
-          <title/>
-          <description/>
-        </package>
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '122'
-    body:
-      encoding: UTF-8
-      string: |
-        <package name="branch_test_package" project="home:other_user">
-          <title></title>
-          <description></description>
-        </package>
-    http_version: 
-  recorded_at: Wed, 17 Aug 2016 11:20:24 GMT
-- request:
-    method: put
-    uri: http://backend:5352/source/home:other_user/branch_test_package/somefile.txt
-    body:
-      encoding: UTF-8
-      string: Similique reiciendis optio corrupti aut illo ea voluptate. Accusantium
-        velit aliquid accusamus tenetur sequi consequatur. Aperiam non aliquam natus
-        et ullam alias.
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '207'
-    body:
-      encoding: UTF-8
-      string: |
-        <revision rev="4" vrev="4">
-          <srcmd5>b79c9e099d51a13cea7b15e9817a8c0c</srcmd5>
-          <version>unknown</version>
-          <time>1471432824</time>
-          <user>unknown</user>
-          <comment></comment>
-          <requestid/>
-        </revision>
-    http_version: 
-  recorded_at: Wed, 17 Aug 2016 11:20:24 GMT
-- request:
-    method: get
-    uri: http://backend:5352/build/home:user_tab_user/_result?package=group_test_package&view=status
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Content-Type:
-      - text/plain
-      Accept-Encoding:
-      - identity
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 404
-      message: project 'home user_tab_user' does not exist
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '164'
-    body:
-      encoding: UTF-8
-      string: |
-        <status code="404">
-          <summary>project 'home:user_tab_user' does not exist</summary>
-          <details>404 project 'home:user_tab_user' does not exist</details>
-        </status>
-    http_version: 
-  recorded_at: Wed, 17 Aug 2016 11:20:25 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/home:user_tab_user/group_test_package?nofilename=1&view=info&withchangesmd5=1
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 404
-      message: project 'home user_tab_user' does not exist
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '164'
-    body:
-      encoding: UTF-8
-      string: |
-        <status code="404">
-          <summary>project 'home:user_tab_user' does not exist</summary>
-          <details>404 project 'home:user_tab_user' does not exist</details>
-        </status>
-    http_version: 
-  recorded_at: Wed, 17 Aug 2016 11:20:25 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/home:user_tab_user/group_test_package
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 404
-      message: project 'home user_tab_user' does not exist
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '164'
-    body:
-      encoding: UTF-8
-      string: |
-        <status code="404">
-          <summary>project 'home:user_tab_user' does not exist</summary>
-          <details>404 project 'home:user_tab_user' does not exist</details>
-        </status>
-    http_version: 
-  recorded_at: Wed, 17 Aug 2016 11:20:25 GMT
-- request:
-    method: post
-    uri: http://backend:5352/source/home:user_tab_user/group_test_package?cmd=diff&linkrev=base&onlyissues=1&orev=0&view=xml
-    body:
-      encoding: UTF-8
-      string: ''
-    headers:
-      Content-Type:
-      - application/octet-stream
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 404
-      message: project 'home user_tab_user' does not exist
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '164'
-    body:
-      encoding: UTF-8
-      string: |
-        <status code="404">
-          <summary>project 'home:user_tab_user' does not exist</summary>
-          <details>404 project 'home:user_tab_user' does not exist</details>
-        </status>
-    http_version: 
-  recorded_at: Wed, 17 Aug 2016 11:20:25 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/home:user_tab_user/group_test_package
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 404
-      message: project 'home user_tab_user' does not exist
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '164'
-    body:
-      encoding: UTF-8
-      string: |
-        <status code="404">
-          <summary>project 'home:user_tab_user' does not exist</summary>
-          <details>404 project 'home:user_tab_user' does not exist</details>
-        </status>
-    http_version: 
-  recorded_at: Wed, 17 Aug 2016 11:20:25 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/home:user_tab_user/group_test_package?expand=1
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Content-Type:
-      - text/plain
-      Accept-Encoding:
-      - identity
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 404
-      message: project 'home user_tab_user' does not exist
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '164'
-    body:
-      encoding: UTF-8
-      string: |
-        <status code="404">
-          <summary>project 'home:user_tab_user' does not exist</summary>
-          <details>404 project 'home:user_tab_user' does not exist</details>
-        </status>
-    http_version: 
-  recorded_at: Wed, 17 Aug 2016 11:20:25 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/home:user_tab_user/group_test_package
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Content-Type:
-      - text/plain
-      Accept-Encoding:
-      - identity
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 404
-      message: project 'home user_tab_user' does not exist
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '164'
-    body:
-      encoding: UTF-8
-      string: |
-        <status code="404">
-          <summary>project 'home:user_tab_user' does not exist</summary>
-          <details>404 project 'home:user_tab_user' does not exist</details>
-        </status>
-    http_version: 
-  recorded_at: Wed, 17 Aug 2016 11:20:25 GMT
-- request:
-    method: get
-    uri: http://backend:5352/build/home:user_tab_user/_result?package=group_test_package&view=status
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Content-Type:
-      - text/plain
-      Accept-Encoding:
-      - identity
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 404
-      message: project 'home user_tab_user' does not exist
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '164'
-    body:
-      encoding: UTF-8
-      string: |
-        <status code="404">
-          <summary>project 'home:user_tab_user' does not exist</summary>
-          <details>404 project 'home:user_tab_user' does not exist</details>
-        </status>
-    http_version: 
-  recorded_at: Wed, 17 Aug 2016 11:20:25 GMT
-- request:
-    method: get
-    uri: http://backend:5352/build/home:user_tab_user/_result?package=group_test_package&view=status
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Content-Type:
-      - text/plain
-      Accept-Encoding:
-      - identity
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 404
-      message: project 'home user_tab_user' does not exist
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '164'
-    body:
-      encoding: UTF-8
-      string: |
-        <status code="404">
-          <summary>project 'home:user_tab_user' does not exist</summary>
-          <details>404 project 'home:user_tab_user' does not exist</details>
-        </status>
-    http_version: 
-  recorded_at: Wed, 17 Aug 2016 11:20:25 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/home:user_tab_user/group_test_package/_service
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Content-Type:
-      - text/plain
-      Accept-Encoding:
-      - identity
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 404
-      message: project 'home user_tab_user' does not exist
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '164'
-    body:
-      encoding: UTF-8
-      string: |
-        <status code="404">
-          <summary>project 'home:user_tab_user' does not exist</summary>
-          <details>404 project 'home:user_tab_user' does not exist</details>
-        </status>
-    http_version: 
-  recorded_at: Wed, 05 Oct 2016 09:09:02 GMT
-- request:
-    method: get
-    uri: http://backend:5352/build/home:user_tab_user/_result?locallink=1&multibuild=1&package=group_test_package&view=status
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Content-Type:
-      - text/plain
-      Accept-Encoding:
-      - identity
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 404
-      message: project 'home user_tab_user' does not exist
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '164'
-    body:
-      encoding: UTF-8
-      string: |
-        <status code="404">
-          <summary>project 'home:user_tab_user' does not exist</summary>
-          <details>404 project 'home:user_tab_user' does not exist</details>
-        </status>
-    http_version: 
-  recorded_at: Fri, 20 Jan 2017 02:55:15 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/home:user_tab_user/group_test_package?expand=0
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 404
-      message: project 'home user_tab_user' does not exist
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '164'
-    body:
-      encoding: UTF-8
-      string: |
-        <status code="404">
-          <summary>project 'home:user_tab_user' does not exist</summary>
-          <details>404 project 'home:user_tab_user' does not exist</details>
-        </status>
-    http_version: 
-  recorded_at: Tue, 16 May 2017 15:10:17 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/home:user_tab_user/group_test_package
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 404
-      message: project 'home user_tab_user' does not exist
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '164'
-    body:
-      encoding: UTF-8
-      string: |
-        <status code="404">
-          <summary>project 'home:user_tab_user' does not exist</summary>
-          <details>404 project 'home:user_tab_user' does not exist</details>
-        </status>
-    http_version: 
-  recorded_at: Fri, 16 Jun 2017 14:23:58 GMT
-- request:
-    method: put
     uri: http://backend:5352/source/home:package_test_user/_meta?user=package_test_user
     body:
       encoding: UTF-8
@@ -632,7 +40,7 @@ http_interactions:
           <person userid="package_test_user" role="maintainer" />
         </project>
     http_version: 
-  recorded_at: Wed, 03 Jan 2018 13:16:29 GMT
+  recorded_at: Tue, 16 Jan 2018 14:01:41 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:user_tab_user/_meta?user=user_tab_user
@@ -673,7 +81,7 @@ http_interactions:
           <person userid="user_tab_user" role="maintainer" />
         </project>
     http_version: 
-  recorded_at: Wed, 03 Jan 2018 13:16:29 GMT
+  recorded_at: Tue, 16 Jan 2018 14:01:41 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:user_tab_user/group_test_package/_meta?user=user_tab_user
@@ -681,8 +89,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="group_test_package" project="home:user_tab_user">
-          <title>For Whom the Bell Tolls</title>
-          <description>Et necessitatibus vel quo repudiandae quia tempore.</description>
+          <title>It's a Battlefield</title>
+          <description>Ut ratione natus amet dolores est at.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -703,16 +111,16 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '198'
+      - '179'
     body:
       encoding: UTF-8
       string: |
         <package name="group_test_package" project="home:user_tab_user">
-          <title>For Whom the Bell Tolls</title>
-          <description>Et necessitatibus vel quo repudiandae quia tempore.</description>
+          <title>It's a Battlefield</title>
+          <description>Ut ratione natus amet dolores est at.</description>
         </package>
     http_version: 
-  recorded_at: Wed, 03 Jan 2018 13:16:29 GMT
+  recorded_at: Tue, 16 Jan 2018 14:01:41 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:user_tab_user/group_test_package/_meta
@@ -720,8 +128,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="group_test_package" project="home:user_tab_user">
-          <title>For Whom the Bell Tolls</title>
-          <description>Et necessitatibus vel quo repudiandae quia tempore.</description>
+          <title>It's a Battlefield</title>
+          <description>Ut ratione natus amet dolores est at.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -742,16 +150,16 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '198'
+      - '179'
     body:
       encoding: UTF-8
       string: |
         <package name="group_test_package" project="home:user_tab_user">
-          <title>For Whom the Bell Tolls</title>
-          <description>Et necessitatibus vel quo repudiandae quia tempore.</description>
+          <title>It's a Battlefield</title>
+          <description>Ut ratione natus amet dolores est at.</description>
         </package>
     http_version: 
-  recorded_at: Wed, 03 Jan 2018 13:16:29 GMT
+  recorded_at: Tue, 16 Jan 2018 14:01:41 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:other_user/_meta?user=other_user
@@ -792,7 +200,7 @@ http_interactions:
           <person userid="other_user" role="maintainer" />
         </project>
     http_version: 
-  recorded_at: Wed, 03 Jan 2018 13:16:29 GMT
+  recorded_at: Tue, 16 Jan 2018 14:01:41 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:other_user/branch_test_package/_meta?user=user_tab_user
@@ -800,8 +208,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="branch_test_package" project="home:other_user">
-          <title>Everything is Illuminated</title>
-          <description>Voluptas magni doloribus sint impedit pariatur itaque ut cupiditate.</description>
+          <title>By Grand Central Station I Sat Down and Wept</title>
+          <description>Quis minima harum dolorem.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -822,23 +230,62 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '215'
+      - '192'
     body:
       encoding: UTF-8
       string: |
         <package name="branch_test_package" project="home:other_user">
-          <title>Everything is Illuminated</title>
-          <description>Voluptas magni doloribus sint impedit pariatur itaque ut cupiditate.</description>
+          <title>By Grand Central Station I Sat Down and Wept</title>
+          <description>Quis minima harum dolorem.</description>
         </package>
     http_version: 
-  recorded_at: Wed, 03 Jan 2018 13:16:29 GMT
+  recorded_at: Tue, 16 Jan 2018 14:01:41 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:other_user/branch_test_package/_meta
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="branch_test_package" project="home:other_user">
+          <title>By Grand Central Station I Sat Down and Wept</title>
+          <description>Quis minima harum dolorem.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '192'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="branch_test_package" project="home:other_user">
+          <title>By Grand Central Station I Sat Down and Wept</title>
+          <description>Quis minima harum dolorem.</description>
+        </package>
+    http_version: 
+  recorded_at: Tue, 16 Jan 2018 14:01:41 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:other_user/branch_test_package/_config
     body:
       encoding: UTF-8
-      string: Repellat quo eligendi qui. Porro esse in aliquid et quis facere. Provident
-        ad voluptates eaque adipisci voluptatum alias quibusdam.
+      string: Non repellat incidunt in aspernatur sit. Voluptas non animi. Unde deleniti
+        perferendis et repellendus officia. Corporis qui voluptas autem quia.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -858,20 +305,61 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '207'
+      - '209'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="7" vrev="7">
-          <srcmd5>077287b9cd573f8f18998eb5db37be30</srcmd5>
+        <revision rev="35" vrev="35">
+          <srcmd5>b02596b90d754e0b7d732c0d8f4c2c1d</srcmd5>
           <version>unknown</version>
-          <time>1514985389</time>
+          <time>1516111301</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
     http_version: 
-  recorded_at: Wed, 03 Jan 2018 13:16:29 GMT
+  recorded_at: Tue, 16 Jan 2018 14:01:41 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:other_user/branch_test_package/somefile.txt
+    body:
+      encoding: UTF-8
+      string: Officia quia repellendus quis. Velit ullam et. Praesentium dolorem quos
+        quae dolorum illum libero sit. Culpa officia autem voluptatem assumenda. Officiis
+        repudiandae et in.
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '209'
+    body:
+      encoding: UTF-8
+      string: |
+        <revision rev="36" vrev="36">
+          <srcmd5>b02596b90d754e0b7d732c0d8f4c2c1d</srcmd5>
+          <version>unknown</version>
+          <time>1516111301</time>
+          <user>unknown</user>
+          <comment></comment>
+          <requestid/>
+        </revision>
+    http_version: 
+  recorded_at: Tue, 16 Jan 2018 14:01:41 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:reader_user/_meta?user=reader_user
@@ -912,7 +400,41 @@ http_interactions:
           <person userid="reader_user" role="maintainer" />
         </project>
     http_version: 
-  recorded_at: Wed, 03 Jan 2018 13:16:30 GMT
+  recorded_at: Tue, 16 Jan 2018 14:01:41 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:user_tab_user/group_test_package?nofilename=1&view=info&withchangesmd5=1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '156'
+    body:
+      encoding: UTF-8
+      string: |
+        <sourceinfo package="group_test_package" srcmd5="d41d8cd98f00b204e9800998ecf8427e" verifymd5="d41d8cd98f00b204e9800998ecf8427e">
+          <revtime/>
+        </sourceinfo>
+    http_version: 
+  recorded_at: Tue, 16 Jan 2018 14:01:42 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:user_tab_user/group_test_package
@@ -944,6 +466,283 @@ http_interactions:
       string: |
         <directory name="group_test_package" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
         </directory>
+    http_version: 
+  recorded_at: Tue, 16 Jan 2018 14:01:42 GMT
+- request:
+    method: post
+    uri: http://backend:5352/source/home:user_tab_user/group_test_package?cmd=diff&linkrev=base&onlyissues=1&orev=0&view=xml
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Content-Type:
+      - application/octet-stream
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '314'
+    body:
+      encoding: UTF-8
+      string: |
+        <sourcediff key="04429e5eb3523e7cb3e15ee88d1605d6">
+          <old project="home:user_tab_user" package="group_test_package" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e" />
+          <new project="home:user_tab_user" package="group_test_package" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e" />
+          <files />
+        </sourcediff>
+    http_version: 
+  recorded_at: Tue, 16 Jan 2018 14:01:42 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:user_tab_user/group_test_package
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '93'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="group_test_package" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
+        </directory>
+    http_version: 
+  recorded_at: Tue, 16 Jan 2018 14:01:42 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:user_tab_user/group_test_package?expand=1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '93'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="group_test_package" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
+        </directory>
+    http_version: 
+  recorded_at: Tue, 16 Jan 2018 14:01:42 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:user_tab_user/group_test_package
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - text/plain
+      Accept-Encoding:
+      - identity
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '93'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="group_test_package" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
+        </directory>
+    http_version: 
+  recorded_at: Tue, 16 Jan 2018 14:01:42 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:user_tab_user/group_test_package/_service
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - text/plain
+      Accept-Encoding:
+      - identity
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 404
+      message: _service  no such file
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '122'
+    body:
+      encoding: UTF-8
+      string: |
+        <status code="404">
+          <summary>_service: no such file</summary>
+          <details>404 _service: no such file</details>
+        </status>
+    http_version: 
+  recorded_at: Tue, 16 Jan 2018 14:01:42 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:user_tab_user/group_test_package
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '93'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="group_test_package" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
+        </directory>
+    http_version: 
+  recorded_at: Tue, 16 Jan 2018 14:01:42 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:user_tab_user/group_test_package
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '93'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="group_test_package" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
+        </directory>
+    http_version: 
+  recorded_at: Tue, 16 Jan 2018 14:01:42 GMT
+- request:
+    method: get
+    uri: http://backend:5352/build/home:user_tab_user/_result?package=group_test_package&view=status
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - text/plain
+      Accept-Encoding:
+      - identity
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '56'
+    body:
+      encoding: UTF-8
+      string: '<resultlist state="00000000000000000000000000000000" />
+
+'
     http_version: 
   recorded_at: Wed, 03 Jan 2018 13:16:31 GMT
 - request:

--- a/src/api/spec/cassettes/Packages/branching_a_package/from_another_user_s_project.yml
+++ b/src/api/spec/cassettes/Packages/branching_a_package/from_another_user_s_project.yml
@@ -40,16 +40,16 @@ http_interactions:
           <person userid="package_test_user" role="maintainer" />
         </project>
     http_version: 
-  recorded_at: Wed, 03 Jan 2018 13:11:11 GMT
+  recorded_at: Tue, 16 Jan 2018 14:01:04 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:package_test_user/test_package/_meta?user=_nobody_
+    uri: http://backend:5352/source/home:package_test_user/test_package/_meta?user=package_test_user
     body:
       encoding: UTF-8
       string: |
         <package name="test_package" project="home:package_test_user">
-          <title>The Sun Also Rises</title>
-          <description>Ut in est ea omnis incidunt sunt consequatur.</description>
+          <title>Where Angels Fear to Tread</title>
+          <description>Nisi temporibus aut sint a libero.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -70,16 +70,16 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '185'
+      - '182'
     body:
       encoding: UTF-8
       string: |
         <package name="test_package" project="home:package_test_user">
-          <title>The Sun Also Rises</title>
-          <description>Ut in est ea omnis incidunt sunt consequatur.</description>
+          <title>Where Angels Fear to Tread</title>
+          <description>Nisi temporibus aut sint a libero.</description>
         </package>
     http_version: 
-  recorded_at: Wed, 03 Jan 2018 13:11:12 GMT
+  recorded_at: Tue, 16 Jan 2018 14:01:04 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:package_test_user/test_package/_meta
@@ -87,8 +87,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="test_package" project="home:package_test_user">
-          <title>The Sun Also Rises</title>
-          <description>Ut in est ea omnis incidunt sunt consequatur.</description>
+          <title>Where Angels Fear to Tread</title>
+          <description>Nisi temporibus aut sint a libero.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -109,24 +109,23 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '185'
+      - '182'
     body:
       encoding: UTF-8
       string: |
         <package name="test_package" project="home:package_test_user">
-          <title>The Sun Also Rises</title>
-          <description>Ut in est ea omnis incidunt sunt consequatur.</description>
+          <title>Where Angels Fear to Tread</title>
+          <description>Nisi temporibus aut sint a libero.</description>
         </package>
     http_version: 
-  recorded_at: Wed, 03 Jan 2018 13:11:12 GMT
+  recorded_at: Tue, 16 Jan 2018 14:01:04 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:package_test_user/test_package/_config
     body:
       encoding: UTF-8
-      string: Necessitatibus vitae quasi distinctio iusto facilis perferendis. Ipsum
-        velit impedit expedita. Consequatur ullam amet doloremque et dolores eos.
-        Ut consectetur nemo. Unde hic itaque voluptate aliquid molestias est enim.
+      string: Veniam itaque in incidunt rerum aut. Rerum repudiandae ab modi reprehenderit
+        velit. Vel rerum omnis consequatur earum. Consequatur corporis et et eum distinctio.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -146,27 +145,28 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '207'
+      - '209'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="1" vrev="1">
-          <srcmd5>ee6e743dcc7a95ae0cd84ca0290032cf</srcmd5>
+        <revision rev="12" vrev="12">
+          <srcmd5>6404275e267a696caf2cff1aed65d3a8</srcmd5>
           <version>unknown</version>
-          <time>1514985072</time>
+          <time>1516111264</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
     http_version: 
-  recorded_at: Wed, 03 Jan 2018 13:11:12 GMT
+  recorded_at: Tue, 16 Jan 2018 14:01:04 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:package_test_user/test_package/somefile.txt
     body:
       encoding: UTF-8
-      string: Similique fugit ex accusamus et impedit. Non non neque quo saepe quaerat.
-        Sit aut minus vitae ut enim. Eum corrupti rerum.
+      string: Officia quia repellendus quis. Velit ullam et. Praesentium dolorem quos
+        quae dolorum illum libero sit. Culpa officia autem voluptatem assumenda. Officiis
+        repudiandae et in.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -186,20 +186,20 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '207'
+      - '209'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="2" vrev="2">
-          <srcmd5>540199cabe28ebba68e0846c0083a396</srcmd5>
+        <revision rev="13" vrev="13">
+          <srcmd5>6404275e267a696caf2cff1aed65d3a8</srcmd5>
           <version>unknown</version>
-          <time>1514985072</time>
+          <time>1516111264</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
     http_version: 
-  recorded_at: Wed, 03 Jan 2018 13:11:12 GMT
+  recorded_at: Tue, 16 Jan 2018 14:01:04 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:other_package_test_user/_meta?user=other_package_test_user
@@ -240,16 +240,16 @@ http_interactions:
           <person userid="other_package_test_user" role="maintainer" />
         </project>
     http_version: 
-  recorded_at: Wed, 03 Jan 2018 13:11:12 GMT
+  recorded_at: Tue, 16 Jan 2018 14:01:04 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:other_package_test_user/branch_test_package/_meta?user=_nobody_
+    uri: http://backend:5352/source/home:other_package_test_user/branch_test_package/_meta?user=package_test_user
     body:
       encoding: UTF-8
       string: |
         <package name="branch_test_package" project="home:other_package_test_user">
-          <title>A Passage to India</title>
-          <description>Sit iure qui illo.</description>
+          <title>Shall not Perish</title>
+          <description>Sint et fugit modi cum maiores.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -270,16 +270,16 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '171'
+      - '182'
     body:
       encoding: UTF-8
       string: |
         <package name="branch_test_package" project="home:other_package_test_user">
-          <title>A Passage to India</title>
-          <description>Sit iure qui illo.</description>
+          <title>Shall not Perish</title>
+          <description>Sint et fugit modi cum maiores.</description>
         </package>
     http_version: 
-  recorded_at: Wed, 03 Jan 2018 13:11:13 GMT
+  recorded_at: Tue, 16 Jan 2018 14:01:04 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:other_package_test_user/branch_test_package/_meta
@@ -287,8 +287,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="branch_test_package" project="home:other_package_test_user">
-          <title>A Passage to India</title>
-          <description>Sit iure qui illo.</description>
+          <title>Shall not Perish</title>
+          <description>Sint et fugit modi cum maiores.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -309,24 +309,24 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '171'
+      - '182'
     body:
       encoding: UTF-8
       string: |
         <package name="branch_test_package" project="home:other_package_test_user">
-          <title>A Passage to India</title>
-          <description>Sit iure qui illo.</description>
+          <title>Shall not Perish</title>
+          <description>Sint et fugit modi cum maiores.</description>
         </package>
     http_version: 
-  recorded_at: Wed, 03 Jan 2018 13:11:13 GMT
+  recorded_at: Tue, 16 Jan 2018 14:01:04 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:other_package_test_user/branch_test_package/_config
     body:
       encoding: UTF-8
-      string: Assumenda error laborum dicta modi sint. Eligendi velit soluta minima
-        aperiam consequatur praesentium. Nesciunt voluptas et. Qui quia assumenda
-        ea.
+      string: Quia labore sit accusamus eveniet quisquam. Doloremque eos nemo. Harum
+        deserunt at. Debitis dolores tempora. Magni ipsa dolorum esse ad quisquam
+        qui ipsam.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -346,27 +346,28 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '207'
+      - '209'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="1" vrev="1">
-          <srcmd5>b161c441e2cf81edb19709342225248b</srcmd5>
+        <revision rev="21" vrev="21">
+          <srcmd5>e0a419cdd6b132720fbd69aae112f115</srcmd5>
           <version>unknown</version>
-          <time>1514985073</time>
+          <time>1516111264</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
     http_version: 
-  recorded_at: Wed, 03 Jan 2018 13:11:13 GMT
+  recorded_at: Tue, 16 Jan 2018 14:01:04 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:other_package_test_user/branch_test_package/somefile.txt
     body:
       encoding: UTF-8
-      string: Similique fugit ex accusamus et impedit. Non non neque quo saepe quaerat.
-        Sit aut minus vitae ut enim. Eum corrupti rerum.
+      string: Officia quia repellendus quis. Velit ullam et. Praesentium dolorem quos
+        quae dolorum illum libero sit. Culpa officia autem voluptatem assumenda. Officiis
+        repudiandae et in.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -386,20 +387,20 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '207'
+      - '209'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="2" vrev="2">
-          <srcmd5>ce797e25ce29c7f947fb59950d437fb5</srcmd5>
+        <revision rev="22" vrev="22">
+          <srcmd5>e0a419cdd6b132720fbd69aae112f115</srcmd5>
           <version>unknown</version>
-          <time>1514985073</time>
+          <time>1516111264</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
     http_version: 
-  recorded_at: Wed, 03 Jan 2018 13:11:13 GMT
+  recorded_at: Tue, 16 Jan 2018 14:01:04 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:other_package_test_user/branch_test_package?nofilename=1&view=info&withchangesmd5=1
@@ -425,15 +426,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '193'
+      - '195'
     body:
       encoding: UTF-8
       string: |
-        <sourceinfo package="branch_test_package" rev="2" vrev="2" srcmd5="ce797e25ce29c7f947fb59950d437fb5" verifymd5="ce797e25ce29c7f947fb59950d437fb5">
-          <revtime>1514985073</revtime>
+        <sourceinfo package="branch_test_package" rev="22" vrev="22" srcmd5="e0a419cdd6b132720fbd69aae112f115" verifymd5="e0a419cdd6b132720fbd69aae112f115">
+          <revtime>1516111264</revtime>
         </sourceinfo>
     http_version: 
-  recorded_at: Wed, 03 Jan 2018 13:11:16 GMT
+  recorded_at: Tue, 16 Jan 2018 14:01:05 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:other_package_test_user/branch_test_package
@@ -459,16 +460,16 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '308'
+      - '310'
     body:
       encoding: UTF-8
       string: |
-        <directory name="branch_test_package" rev="2" vrev="2" srcmd5="ce797e25ce29c7f947fb59950d437fb5">
-          <entry name="_config" md5="6e88f0a236426e4194060bebe6777b79" size="147" mtime="1514985073" />
-          <entry name="somefile.txt" md5="a50059593b79508e188300cd51ee2155" size="122" mtime="1514985073" />
+        <directory name="branch_test_package" rev="22" vrev="22" srcmd5="e0a419cdd6b132720fbd69aae112f115">
+          <entry name="_config" md5="72b585f92ace1b4b11fc7f4e6261ac7a" size="155" mtime="1516111264" />
+          <entry name="somefile.txt" md5="478bacb4eb86846967edfa64ec6a5f9a" size="172" mtime="1516111242" />
         </directory>
     http_version: 
-  recorded_at: Wed, 03 Jan 2018 13:11:16 GMT
+  recorded_at: Tue, 16 Jan 2018 14:01:05 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:other_package_test_user/branch_test_package?cmd=diff&linkrev=base&onlyissues=1&orev=0&view=xml
@@ -496,19 +497,19 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '359'
+      - '360'
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="894bf3862a20c9c387c128b3dccaa5a5">
+        <sourcediff key="0195025bea3eab25d15d9f073b6557fc">
           <old project="home:other_package_test_user" package="branch_test_package" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e" />
-          <new project="home:other_package_test_user" package="branch_test_package" rev="2" srcmd5="ce797e25ce29c7f947fb59950d437fb5" />
+          <new project="home:other_package_test_user" package="branch_test_package" rev="22" srcmd5="e0a419cdd6b132720fbd69aae112f115" />
           <files />
           <issues>
           </issues>
         </sourcediff>
     http_version: 
-  recorded_at: Wed, 03 Jan 2018 13:11:16 GMT
+  recorded_at: Tue, 16 Jan 2018 14:01:05 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:other_package_test_user/branch_test_package
@@ -534,19 +535,19 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '308'
+      - '310'
     body:
       encoding: UTF-8
       string: |
-        <directory name="branch_test_package" rev="2" vrev="2" srcmd5="ce797e25ce29c7f947fb59950d437fb5">
-          <entry name="_config" md5="6e88f0a236426e4194060bebe6777b79" size="147" mtime="1514985073" />
-          <entry name="somefile.txt" md5="a50059593b79508e188300cd51ee2155" size="122" mtime="1514985073" />
+        <directory name="branch_test_package" rev="22" vrev="22" srcmd5="e0a419cdd6b132720fbd69aae112f115">
+          <entry name="_config" md5="72b585f92ace1b4b11fc7f4e6261ac7a" size="155" mtime="1516111264" />
+          <entry name="somefile.txt" md5="478bacb4eb86846967edfa64ec6a5f9a" size="172" mtime="1516111242" />
         </directory>
     http_version: 
-  recorded_at: Wed, 03 Jan 2018 13:11:16 GMT
+  recorded_at: Tue, 16 Jan 2018 14:01:05 GMT
 - request:
     method: get
-    uri: http://backend:5352/source/home:other_package_test_user/branch_test_package?expand=1&rev=2
+    uri: http://backend:5352/source/home:other_package_test_user/branch_test_package?expand=1&rev=22
     body:
       encoding: US-ASCII
       string: ''
@@ -569,16 +570,16 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '308'
+      - '310'
     body:
       encoding: UTF-8
       string: |
-        <directory name="branch_test_package" rev="2" vrev="2" srcmd5="ce797e25ce29c7f947fb59950d437fb5">
-          <entry name="_config" md5="6e88f0a236426e4194060bebe6777b79" size="147" mtime="1514985073" />
-          <entry name="somefile.txt" md5="a50059593b79508e188300cd51ee2155" size="122" mtime="1514985073" />
+        <directory name="branch_test_package" rev="22" vrev="22" srcmd5="e0a419cdd6b132720fbd69aae112f115">
+          <entry name="_config" md5="72b585f92ace1b4b11fc7f4e6261ac7a" size="155" mtime="1516111264" />
+          <entry name="somefile.txt" md5="478bacb4eb86846967edfa64ec6a5f9a" size="172" mtime="1516111242" />
         </directory>
     http_version: 
-  recorded_at: Wed, 03 Jan 2018 13:11:16 GMT
+  recorded_at: Tue, 16 Jan 2018 14:01:05 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:other_package_test_user/branch_test_package
@@ -606,16 +607,16 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '308'
+      - '310'
     body:
       encoding: UTF-8
       string: |
-        <directory name="branch_test_package" rev="2" vrev="2" srcmd5="ce797e25ce29c7f947fb59950d437fb5">
-          <entry name="_config" md5="6e88f0a236426e4194060bebe6777b79" size="147" mtime="1514985073" />
-          <entry name="somefile.txt" md5="a50059593b79508e188300cd51ee2155" size="122" mtime="1514985073" />
+        <directory name="branch_test_package" rev="22" vrev="22" srcmd5="e0a419cdd6b132720fbd69aae112f115">
+          <entry name="_config" md5="72b585f92ace1b4b11fc7f4e6261ac7a" size="155" mtime="1516111264" />
+          <entry name="somefile.txt" md5="478bacb4eb86846967edfa64ec6a5f9a" size="172" mtime="1516111242" />
         </directory>
     http_version: 
-  recorded_at: Wed, 03 Jan 2018 13:11:16 GMT
+  recorded_at: Tue, 16 Jan 2018 14:01:05 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:other_package_test_user/branch_test_package/_service
@@ -652,7 +653,7 @@ http_interactions:
           <details>404 _service: no such file</details>
         </status>
     http_version: 
-  recorded_at: Wed, 03 Jan 2018 13:11:17 GMT
+  recorded_at: Tue, 16 Jan 2018 14:01:05 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:other_package_test_user/branch_test_package/_history
@@ -678,26 +679,146 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '395'
+      - '4061'
     body:
       encoding: UTF-8
       string: |
         <revisionlist>
           <revision rev="1" vrev="1">
-            <srcmd5>b161c441e2cf81edb19709342225248b</srcmd5>
+            <srcmd5>c211fa8e0ecbddb0e43c6354cd2ddc99</srcmd5>
             <version>unknown</version>
-            <time>1514985073</time>
+            <time>1516111046</time>
             <user>unknown</user>
           </revision>
           <revision rev="2" vrev="2">
-            <srcmd5>ce797e25ce29c7f947fb59950d437fb5</srcmd5>
+            <srcmd5>cd0ca6cb388a8fe2c4ca194f705a406f</srcmd5>
             <version>unknown</version>
-            <time>1514985073</time>
+            <time>1516111046</time>
+            <user>unknown</user>
+          </revision>
+          <revision rev="3" vrev="3">
+            <srcmd5>c7661241d46ab4d3107f558906ba8499</srcmd5>
+            <version>unknown</version>
+            <time>1516111048</time>
+            <user>unknown</user>
+          </revision>
+          <revision rev="4" vrev="4">
+            <srcmd5>c7661241d46ab4d3107f558906ba8499</srcmd5>
+            <version>unknown</version>
+            <time>1516111048</time>
+            <user>unknown</user>
+          </revision>
+          <revision rev="5" vrev="5">
+            <srcmd5>09e5d891f18466e6c5f36c3c6b39f5cb</srcmd5>
+            <version>unknown</version>
+            <time>1516111080</time>
+            <user>unknown</user>
+          </revision>
+          <revision rev="6" vrev="6">
+            <srcmd5>09e5d891f18466e6c5f36c3c6b39f5cb</srcmd5>
+            <version>unknown</version>
+            <time>1516111080</time>
+            <user>unknown</user>
+          </revision>
+          <revision rev="7" vrev="7">
+            <srcmd5>2c5620272ba1a91887c04cf7b9babcb7</srcmd5>
+            <version>unknown</version>
+            <time>1516111242</time>
+            <user>unknown</user>
+          </revision>
+          <revision rev="8" vrev="8">
+            <srcmd5>1cbc5d6e148177dbd287922fecddaddf</srcmd5>
+            <version>unknown</version>
+            <time>1516111242</time>
+            <user>unknown</user>
+          </revision>
+          <revision rev="9" vrev="9">
+            <srcmd5>3848a43990f3779b1a5518f3834289e8</srcmd5>
+            <version>unknown</version>
+            <time>1516111247</time>
+            <user>unknown</user>
+          </revision>
+          <revision rev="10" vrev="10">
+            <srcmd5>3848a43990f3779b1a5518f3834289e8</srcmd5>
+            <version>unknown</version>
+            <time>1516111247</time>
+            <user>unknown</user>
+          </revision>
+          <revision rev="11" vrev="11">
+            <srcmd5>67882ce9cf0b9cd0c6e66d4fe5ca3aa3</srcmd5>
+            <version>unknown</version>
+            <time>1516111250</time>
+            <user>unknown</user>
+          </revision>
+          <revision rev="12" vrev="12">
+            <srcmd5>67882ce9cf0b9cd0c6e66d4fe5ca3aa3</srcmd5>
+            <version>unknown</version>
+            <time>1516111250</time>
+            <user>unknown</user>
+          </revision>
+          <revision rev="13" vrev="13">
+            <srcmd5>00c3ce9e544c71f7395c1b44116e1717</srcmd5>
+            <version>unknown</version>
+            <time>1516111253</time>
+            <user>unknown</user>
+          </revision>
+          <revision rev="14" vrev="14">
+            <srcmd5>00c3ce9e544c71f7395c1b44116e1717</srcmd5>
+            <version>unknown</version>
+            <time>1516111253</time>
+            <user>unknown</user>
+          </revision>
+          <revision rev="15" vrev="15">
+            <srcmd5>a769cf3068078df20b20258ebc5774d4</srcmd5>
+            <version>unknown</version>
+            <time>1516111256</time>
+            <user>unknown</user>
+          </revision>
+          <revision rev="16" vrev="16">
+            <srcmd5>a769cf3068078df20b20258ebc5774d4</srcmd5>
+            <version>unknown</version>
+            <time>1516111256</time>
+            <user>unknown</user>
+          </revision>
+          <revision rev="17" vrev="17">
+            <srcmd5>5975a950c9f2ec7e65c0afb2f659358a</srcmd5>
+            <version>unknown</version>
+            <time>1516111259</time>
+            <user>unknown</user>
+          </revision>
+          <revision rev="18" vrev="18">
+            <srcmd5>5975a950c9f2ec7e65c0afb2f659358a</srcmd5>
+            <version>unknown</version>
+            <time>1516111259</time>
+            <user>unknown</user>
+          </revision>
+          <revision rev="19" vrev="19">
+            <srcmd5>888d6acceba892b52be84f8cec4e9429</srcmd5>
+            <version>unknown</version>
+            <time>1516111262</time>
+            <user>unknown</user>
+          </revision>
+          <revision rev="20" vrev="20">
+            <srcmd5>888d6acceba892b52be84f8cec4e9429</srcmd5>
+            <version>unknown</version>
+            <time>1516111262</time>
+            <user>unknown</user>
+          </revision>
+          <revision rev="21" vrev="21">
+            <srcmd5>e0a419cdd6b132720fbd69aae112f115</srcmd5>
+            <version>unknown</version>
+            <time>1516111264</time>
+            <user>unknown</user>
+          </revision>
+          <revision rev="22" vrev="22">
+            <srcmd5>e0a419cdd6b132720fbd69aae112f115</srcmd5>
+            <version>unknown</version>
+            <time>1516111264</time>
             <user>unknown</user>
           </revision>
         </revisionlist>
     http_version: 
-  recorded_at: Wed, 03 Jan 2018 13:11:17 GMT
+  recorded_at: Tue, 16 Jan 2018 14:01:05 GMT
 - request:
     method: get
     uri: http://backend:5352/build/home:other_package_test_user/_result?package=branch_test_package&view=status
@@ -732,7 +853,7 @@ http_interactions:
 
 '
     http_version: 
-  recorded_at: Wed, 03 Jan 2018 13:11:17 GMT
+  recorded_at: Tue, 16 Jan 2018 14:01:05 GMT
 - request:
     method: post
     uri: http://backend:5352/search/package/id?match=(linkinfo/@package=%22branch_test_package%22%20and%20linkinfo/@project=%22home:other_package_test_user%22%20and%20@project=%22home:other_package_test_user%22)
@@ -767,7 +888,7 @@ http_interactions:
         <collection>
         </collection>
     http_version: 
-  recorded_at: Wed, 03 Jan 2018 13:11:17 GMT
+  recorded_at: Tue, 16 Jan 2018 14:01:05 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:package_test_user:branches:home:other_package_test_user/_meta?user=package_test_user
@@ -808,7 +929,7 @@ http_interactions:
           <person userid="package_test_user" role="maintainer" />
         </project>
     http_version: 
-  recorded_at: Wed, 03 Jan 2018 13:11:18 GMT
+  recorded_at: Tue, 16 Jan 2018 14:01:06 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:package_test_user:branches:home:other_package_test_user/branch_test_package/_meta?user=package_test_user
@@ -816,8 +937,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="branch_test_package" project="home:package_test_user:branches:home:other_package_test_user">
-          <title>A Passage to India</title>
-          <description>Sit iure qui illo.</description>
+          <title>Shall not Perish</title>
+          <description>Sint et fugit modi cum maiores.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -838,19 +959,19 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '203'
+      - '214'
     body:
       encoding: UTF-8
       string: |
         <package name="branch_test_package" project="home:package_test_user:branches:home:other_package_test_user">
-          <title>A Passage to India</title>
-          <description>Sit iure qui illo.</description>
+          <title>Shall not Perish</title>
+          <description>Sint et fugit modi cum maiores.</description>
         </package>
     http_version: 
-  recorded_at: Wed, 03 Jan 2018 13:11:18 GMT
+  recorded_at: Tue, 16 Jan 2018 14:01:06 GMT
 - request:
     method: post
-    uri: http://backend:5352/source/home:package_test_user:branches:home:other_package_test_user/branch_test_package?cmd=branch&opackage=branch_test_package&oproject=home:other_package_test_user&user=package_test_user
+    uri: http://backend:5352/source/home:package_test_user:branches:home:other_package_test_user/branch_test_package?cmd=branch&noservice=1&opackage=branch_test_package&oproject=home:other_package_test_user&user=package_test_user
     body:
       encoding: UTF-8
       string: ''
@@ -880,15 +1001,15 @@ http_interactions:
       encoding: UTF-8
       string: |
         <revision rev="1" vrev="1">
-          <srcmd5>9fc49634e40649e5b47462f2937ad5c7</srcmd5>
+          <srcmd5>a2913af47def37dfd19fde1df798a63e</srcmd5>
           <version>unknown</version>
-          <time>1514985078</time>
+          <time>1516111266</time>
           <user>package_test_user</user>
           <comment></comment>
           <requestid/>
         </revision>
     http_version: 
-  recorded_at: Wed, 03 Jan 2018 13:11:18 GMT
+  recorded_at: Tue, 16 Jan 2018 14:01:06 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:package_test_user:branches:home:other_package_test_user/branch_test_package/_meta?user=package_test_user
@@ -896,8 +1017,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="branch_test_package" project="home:package_test_user:branches:home:other_package_test_user">
-          <title>A Passage to India</title>
-          <description>Sit iure qui illo.</description>
+          <title>Shall not Perish</title>
+          <description>Sint et fugit modi cum maiores.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -918,16 +1039,16 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '203'
+      - '214'
     body:
       encoding: UTF-8
       string: |
         <package name="branch_test_package" project="home:package_test_user:branches:home:other_package_test_user">
-          <title>A Passage to India</title>
-          <description>Sit iure qui illo.</description>
+          <title>Shall not Perish</title>
+          <description>Sint et fugit modi cum maiores.</description>
         </package>
     http_version: 
-  recorded_at: Wed, 03 Jan 2018 13:11:18 GMT
+  recorded_at: Tue, 16 Jan 2018 14:01:06 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:package_test_user:branches:home:other_package_test_user/branch_test_package
@@ -957,14 +1078,14 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="branch_test_package" rev="1" vrev="1" srcmd5="9fc49634e40649e5b47462f2937ad5c7">
-          <linkinfo project="home:other_package_test_user" package="branch_test_package" srcmd5="ce797e25ce29c7f947fb59950d437fb5" baserev="ce797e25ce29c7f947fb59950d437fb5" xsrcmd5="d54f71d2c6d8bf1c69d24a66a887c979" lsrcmd5="9fc49634e40649e5b47462f2937ad5c7" />
-          <entry name="_config" md5="6e88f0a236426e4194060bebe6777b79" size="147" mtime="1514985073" />
-          <entry name="_link" md5="61f413f7278da621038ecba3f505fb1c" size="136" mtime="1514985078" />
-          <entry name="somefile.txt" md5="a50059593b79508e188300cd51ee2155" size="122" mtime="1514985073" />
+        <directory name="branch_test_package" rev="1" vrev="1" srcmd5="a2913af47def37dfd19fde1df798a63e">
+          <linkinfo project="home:other_package_test_user" package="branch_test_package" srcmd5="e0a419cdd6b132720fbd69aae112f115" baserev="e0a419cdd6b132720fbd69aae112f115" xsrcmd5="b7b250cf84552a6b4ea677b775add451" lsrcmd5="a2913af47def37dfd19fde1df798a63e" />
+          <entry name="_config" md5="72b585f92ace1b4b11fc7f4e6261ac7a" size="155" mtime="1516111264" />
+          <entry name="_link" md5="73cd2127ba2c279f6a411d9d5552046a" size="136" mtime="1516111266" />
+          <entry name="somefile.txt" md5="478bacb4eb86846967edfa64ec6a5f9a" size="172" mtime="1516111242" />
         </directory>
     http_version: 
-  recorded_at: Wed, 03 Jan 2018 13:11:18 GMT
+  recorded_at: Tue, 16 Jan 2018 14:01:06 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:package_test_user:branches:home:other_package_test_user/branch_test_package?nofilename=1&view=info&withchangesmd5=1
@@ -990,16 +1111,16 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '318'
+      - '319'
     body:
       encoding: UTF-8
       string: |
-        <sourceinfo package="branch_test_package" rev="1" vrev="3" srcmd5="d54f71d2c6d8bf1c69d24a66a887c979" lsrcmd5="9fc49634e40649e5b47462f2937ad5c7" verifymd5="ce797e25ce29c7f947fb59950d437fb5">
+        <sourceinfo package="branch_test_package" rev="1" vrev="23" srcmd5="b7b250cf84552a6b4ea677b775add451" lsrcmd5="a2913af47def37dfd19fde1df798a63e" verifymd5="e0a419cdd6b132720fbd69aae112f115">
           <linked project="home:other_package_test_user" package="branch_test_package" />
-          <revtime>1514985078</revtime>
+          <revtime>1516111266</revtime>
         </sourceinfo>
     http_version: 
-  recorded_at: Wed, 03 Jan 2018 13:11:18 GMT
+  recorded_at: Tue, 16 Jan 2018 14:01:06 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:package_test_user:branches:home:other_package_test_user/branch_test_package
@@ -1029,14 +1150,14 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="branch_test_package" rev="1" vrev="1" srcmd5="9fc49634e40649e5b47462f2937ad5c7">
-          <linkinfo project="home:other_package_test_user" package="branch_test_package" srcmd5="ce797e25ce29c7f947fb59950d437fb5" baserev="ce797e25ce29c7f947fb59950d437fb5" xsrcmd5="d54f71d2c6d8bf1c69d24a66a887c979" lsrcmd5="9fc49634e40649e5b47462f2937ad5c7" />
-          <entry name="_config" md5="6e88f0a236426e4194060bebe6777b79" size="147" mtime="1514985073" />
-          <entry name="_link" md5="61f413f7278da621038ecba3f505fb1c" size="136" mtime="1514985078" />
-          <entry name="somefile.txt" md5="a50059593b79508e188300cd51ee2155" size="122" mtime="1514985073" />
+        <directory name="branch_test_package" rev="1" vrev="1" srcmd5="a2913af47def37dfd19fde1df798a63e">
+          <linkinfo project="home:other_package_test_user" package="branch_test_package" srcmd5="e0a419cdd6b132720fbd69aae112f115" baserev="e0a419cdd6b132720fbd69aae112f115" xsrcmd5="b7b250cf84552a6b4ea677b775add451" lsrcmd5="a2913af47def37dfd19fde1df798a63e" />
+          <entry name="_config" md5="72b585f92ace1b4b11fc7f4e6261ac7a" size="155" mtime="1516111264" />
+          <entry name="_link" md5="73cd2127ba2c279f6a411d9d5552046a" size="136" mtime="1516111266" />
+          <entry name="somefile.txt" md5="478bacb4eb86846967edfa64ec6a5f9a" size="172" mtime="1516111242" />
         </directory>
     http_version: 
-  recorded_at: Wed, 03 Jan 2018 13:11:18 GMT
+  recorded_at: Tue, 16 Jan 2018 14:01:06 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:package_test_user:branches:home:other_package_test_user/branch_test_package?cmd=diff&linkrev=base&onlyissues=1&orev=0&view=xml
@@ -1068,15 +1189,15 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="c98305b452f986945d4b5de0fe630e11">
+        <sourcediff key="69551efd07a9212d4f76e3bafe53ca74">
           <old project="home:package_test_user:branches:home:other_package_test_user" package="branch_test_package" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e" />
-          <new project="home:package_test_user:branches:home:other_package_test_user" package="branch_test_package" rev="1" srcmd5="9fc49634e40649e5b47462f2937ad5c7" />
+          <new project="home:package_test_user:branches:home:other_package_test_user" package="branch_test_package" rev="1" srcmd5="a2913af47def37dfd19fde1df798a63e" />
           <files />
           <issues>
           </issues>
         </sourcediff>
     http_version: 
-  recorded_at: Wed, 03 Jan 2018 13:11:18 GMT
+  recorded_at: Tue, 16 Jan 2018 14:01:06 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:package_test_user:branches:home:other_package_test_user/branch_test_package?cmd=linkdiff&linkrev=base&onlyissues=1&view=xml
@@ -1108,13 +1229,13 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="e7b8da93ecf9a4aefb32990f70e37965">
-          <old project="home:other_package_test_user" package="branch_test_package" rev="ce797e25ce29c7f947fb59950d437fb5" srcmd5="ce797e25ce29c7f947fb59950d437fb5" />
-          <new project="home:package_test_user:branches:home:other_package_test_user" package="branch_test_package" rev="d54f71d2c6d8bf1c69d24a66a887c979" srcmd5="d54f71d2c6d8bf1c69d24a66a887c979" />
+        <sourcediff key="45a9d0de4f3c833d077ddb4900c00075">
+          <old project="home:other_package_test_user" package="branch_test_package" rev="e0a419cdd6b132720fbd69aae112f115" srcmd5="e0a419cdd6b132720fbd69aae112f115" />
+          <new project="home:package_test_user:branches:home:other_package_test_user" package="branch_test_package" rev="b7b250cf84552a6b4ea677b775add451" srcmd5="b7b250cf84552a6b4ea677b775add451" />
           <files />
         </sourcediff>
     http_version: 
-  recorded_at: Wed, 03 Jan 2018 13:11:18 GMT
+  recorded_at: Tue, 16 Jan 2018 14:01:06 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:package_test_user:branches:home:other_package_test_user/_meta?user=package_test_user
@@ -1161,7 +1282,7 @@ http_interactions:
           </publish>
         </project>
     http_version: 
-  recorded_at: Wed, 03 Jan 2018 13:11:18 GMT
+  recorded_at: Tue, 16 Jan 2018 14:01:06 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:package_test_user:branches:home:other_package_test_user/branch_test_package
@@ -1191,14 +1312,14 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="branch_test_package" rev="1" vrev="1" srcmd5="9fc49634e40649e5b47462f2937ad5c7">
-          <linkinfo project="home:other_package_test_user" package="branch_test_package" srcmd5="ce797e25ce29c7f947fb59950d437fb5" baserev="ce797e25ce29c7f947fb59950d437fb5" xsrcmd5="d54f71d2c6d8bf1c69d24a66a887c979" lsrcmd5="9fc49634e40649e5b47462f2937ad5c7" />
-          <entry name="_config" md5="6e88f0a236426e4194060bebe6777b79" size="147" mtime="1514985073" />
-          <entry name="_link" md5="61f413f7278da621038ecba3f505fb1c" size="136" mtime="1514985078" />
-          <entry name="somefile.txt" md5="a50059593b79508e188300cd51ee2155" size="122" mtime="1514985073" />
+        <directory name="branch_test_package" rev="1" vrev="1" srcmd5="a2913af47def37dfd19fde1df798a63e">
+          <linkinfo project="home:other_package_test_user" package="branch_test_package" srcmd5="e0a419cdd6b132720fbd69aae112f115" baserev="e0a419cdd6b132720fbd69aae112f115" xsrcmd5="b7b250cf84552a6b4ea677b775add451" lsrcmd5="a2913af47def37dfd19fde1df798a63e" />
+          <entry name="_config" md5="72b585f92ace1b4b11fc7f4e6261ac7a" size="155" mtime="1516111264" />
+          <entry name="_link" md5="73cd2127ba2c279f6a411d9d5552046a" size="136" mtime="1516111266" />
+          <entry name="somefile.txt" md5="478bacb4eb86846967edfa64ec6a5f9a" size="172" mtime="1516111242" />
         </directory>
     http_version: 
-  recorded_at: Wed, 03 Jan 2018 13:11:18 GMT
+  recorded_at: Tue, 16 Jan 2018 14:01:06 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:package_test_user:branches:home:other_package_test_user/branch_test_package?expand=1&rev=1
@@ -1224,17 +1345,17 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '551'
+      - '552'
     body:
       encoding: UTF-8
       string: |
-        <directory name="branch_test_package" rev="d54f71d2c6d8bf1c69d24a66a887c979" vrev="3" srcmd5="d54f71d2c6d8bf1c69d24a66a887c979">
-          <linkinfo project="home:other_package_test_user" package="branch_test_package" srcmd5="ce797e25ce29c7f947fb59950d437fb5" baserev="ce797e25ce29c7f947fb59950d437fb5" lsrcmd5="9fc49634e40649e5b47462f2937ad5c7" />
-          <entry name="_config" md5="6e88f0a236426e4194060bebe6777b79" size="147" mtime="1514985073" />
-          <entry name="somefile.txt" md5="a50059593b79508e188300cd51ee2155" size="122" mtime="1514985073" />
+        <directory name="branch_test_package" rev="b7b250cf84552a6b4ea677b775add451" vrev="23" srcmd5="b7b250cf84552a6b4ea677b775add451">
+          <linkinfo project="home:other_package_test_user" package="branch_test_package" srcmd5="e0a419cdd6b132720fbd69aae112f115" baserev="e0a419cdd6b132720fbd69aae112f115" lsrcmd5="a2913af47def37dfd19fde1df798a63e" />
+          <entry name="_config" md5="72b585f92ace1b4b11fc7f4e6261ac7a" size="155" mtime="1516111264" />
+          <entry name="somefile.txt" md5="478bacb4eb86846967edfa64ec6a5f9a" size="172" mtime="1516111242" />
         </directory>
     http_version: 
-  recorded_at: Wed, 03 Jan 2018 13:11:18 GMT
+  recorded_at: Tue, 16 Jan 2018 14:01:06 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:package_test_user:branches:home:other_package_test_user/branch_test_package
@@ -1266,14 +1387,14 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="branch_test_package" rev="1" vrev="1" srcmd5="9fc49634e40649e5b47462f2937ad5c7">
-          <linkinfo project="home:other_package_test_user" package="branch_test_package" srcmd5="ce797e25ce29c7f947fb59950d437fb5" baserev="ce797e25ce29c7f947fb59950d437fb5" xsrcmd5="d54f71d2c6d8bf1c69d24a66a887c979" lsrcmd5="9fc49634e40649e5b47462f2937ad5c7" />
-          <entry name="_config" md5="6e88f0a236426e4194060bebe6777b79" size="147" mtime="1514985073" />
-          <entry name="_link" md5="61f413f7278da621038ecba3f505fb1c" size="136" mtime="1514985078" />
-          <entry name="somefile.txt" md5="a50059593b79508e188300cd51ee2155" size="122" mtime="1514985073" />
+        <directory name="branch_test_package" rev="1" vrev="1" srcmd5="a2913af47def37dfd19fde1df798a63e">
+          <linkinfo project="home:other_package_test_user" package="branch_test_package" srcmd5="e0a419cdd6b132720fbd69aae112f115" baserev="e0a419cdd6b132720fbd69aae112f115" xsrcmd5="b7b250cf84552a6b4ea677b775add451" lsrcmd5="a2913af47def37dfd19fde1df798a63e" />
+          <entry name="_config" md5="72b585f92ace1b4b11fc7f4e6261ac7a" size="155" mtime="1516111264" />
+          <entry name="_link" md5="73cd2127ba2c279f6a411d9d5552046a" size="136" mtime="1516111266" />
+          <entry name="somefile.txt" md5="478bacb4eb86846967edfa64ec6a5f9a" size="172" mtime="1516111242" />
         </directory>
     http_version: 
-  recorded_at: Wed, 03 Jan 2018 13:11:18 GMT
+  recorded_at: Tue, 16 Jan 2018 14:01:06 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:package_test_user:branches:home:other_package_test_user/branch_test_package/_service
@@ -1310,7 +1431,7 @@ http_interactions:
           <details>404 _service: no such file</details>
         </status>
     http_version: 
-  recorded_at: Wed, 03 Jan 2018 13:11:18 GMT
+  recorded_at: Tue, 16 Jan 2018 14:01:06 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:package_test_user:branches:home:other_package_test_user/branch_test_package
@@ -1340,14 +1461,14 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="branch_test_package" rev="1" vrev="1" srcmd5="9fc49634e40649e5b47462f2937ad5c7">
-          <linkinfo project="home:other_package_test_user" package="branch_test_package" srcmd5="ce797e25ce29c7f947fb59950d437fb5" baserev="ce797e25ce29c7f947fb59950d437fb5" xsrcmd5="d54f71d2c6d8bf1c69d24a66a887c979" lsrcmd5="9fc49634e40649e5b47462f2937ad5c7" />
-          <entry name="_config" md5="6e88f0a236426e4194060bebe6777b79" size="147" mtime="1514985073" />
-          <entry name="_link" md5="61f413f7278da621038ecba3f505fb1c" size="136" mtime="1514985078" />
-          <entry name="somefile.txt" md5="a50059593b79508e188300cd51ee2155" size="122" mtime="1514985073" />
+        <directory name="branch_test_package" rev="1" vrev="1" srcmd5="a2913af47def37dfd19fde1df798a63e">
+          <linkinfo project="home:other_package_test_user" package="branch_test_package" srcmd5="e0a419cdd6b132720fbd69aae112f115" baserev="e0a419cdd6b132720fbd69aae112f115" xsrcmd5="b7b250cf84552a6b4ea677b775add451" lsrcmd5="a2913af47def37dfd19fde1df798a63e" />
+          <entry name="_config" md5="72b585f92ace1b4b11fc7f4e6261ac7a" size="155" mtime="1516111264" />
+          <entry name="_link" md5="73cd2127ba2c279f6a411d9d5552046a" size="136" mtime="1516111266" />
+          <entry name="somefile.txt" md5="478bacb4eb86846967edfa64ec6a5f9a" size="172" mtime="1516111242" />
         </directory>
     http_version: 
-  recorded_at: Wed, 03 Jan 2018 13:11:19 GMT
+  recorded_at: Tue, 16 Jan 2018 14:01:06 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:package_test_user:branches:home:other_package_test_user/branch_test_package
@@ -1377,14 +1498,14 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="branch_test_package" rev="1" vrev="1" srcmd5="9fc49634e40649e5b47462f2937ad5c7">
-          <linkinfo project="home:other_package_test_user" package="branch_test_package" srcmd5="ce797e25ce29c7f947fb59950d437fb5" baserev="ce797e25ce29c7f947fb59950d437fb5" xsrcmd5="d54f71d2c6d8bf1c69d24a66a887c979" lsrcmd5="9fc49634e40649e5b47462f2937ad5c7" />
-          <entry name="_config" md5="6e88f0a236426e4194060bebe6777b79" size="147" mtime="1514985073" />
-          <entry name="_link" md5="61f413f7278da621038ecba3f505fb1c" size="136" mtime="1514985078" />
-          <entry name="somefile.txt" md5="a50059593b79508e188300cd51ee2155" size="122" mtime="1514985073" />
+        <directory name="branch_test_package" rev="1" vrev="1" srcmd5="a2913af47def37dfd19fde1df798a63e">
+          <linkinfo project="home:other_package_test_user" package="branch_test_package" srcmd5="e0a419cdd6b132720fbd69aae112f115" baserev="e0a419cdd6b132720fbd69aae112f115" xsrcmd5="b7b250cf84552a6b4ea677b775add451" lsrcmd5="a2913af47def37dfd19fde1df798a63e" />
+          <entry name="_config" md5="72b585f92ace1b4b11fc7f4e6261ac7a" size="155" mtime="1516111264" />
+          <entry name="_link" md5="73cd2127ba2c279f6a411d9d5552046a" size="136" mtime="1516111266" />
+          <entry name="somefile.txt" md5="478bacb4eb86846967edfa64ec6a5f9a" size="172" mtime="1516111242" />
         </directory>
     http_version: 
-  recorded_at: Wed, 03 Jan 2018 13:11:19 GMT
+  recorded_at: Tue, 16 Jan 2018 14:01:06 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:package_test_user:branches:home:other_package_test_user/branch_test_package/_history
@@ -1416,14 +1537,14 @@ http_interactions:
       string: |
         <revisionlist>
           <revision rev="1" vrev="1">
-            <srcmd5>9fc49634e40649e5b47462f2937ad5c7</srcmd5>
+            <srcmd5>a2913af47def37dfd19fde1df798a63e</srcmd5>
             <version>unknown</version>
-            <time>1514985078</time>
+            <time>1516111266</time>
             <user>package_test_user</user>
           </revision>
         </revisionlist>
     http_version: 
-  recorded_at: Wed, 03 Jan 2018 13:11:19 GMT
+  recorded_at: Tue, 16 Jan 2018 14:01:06 GMT
 - request:
     method: get
     uri: http://backend:5352/build/home:package_test_user:branches:home:other_package_test_user/_result?package=branch_test_package&view=status
@@ -1458,7 +1579,7 @@ http_interactions:
 
 '
     http_version: 
-  recorded_at: Wed, 03 Jan 2018 13:11:19 GMT
+  recorded_at: Tue, 16 Jan 2018 14:01:06 GMT
 - request:
     method: delete
     uri: http://backend:5352/source/home:other_package_test_user
@@ -1489,7 +1610,7 @@ http_interactions:
 
 '
     http_version: 
-  recorded_at: Wed, 03 Jan 2018 13:11:20 GMT
+  recorded_at: Tue, 16 Jan 2018 14:01:06 GMT
 - request:
     method: delete
     uri: http://backend:5352/source/home:package_test_user:branches:home:other_package_test_user

--- a/src/api/spec/cassettes/Packages/changing_the_package_s_devel_project.yml
+++ b/src/api/spec/cassettes/Packages/changing_the_package_s_devel_project.yml
@@ -2,718 +2,6 @@
 http_interactions:
 - request:
     method: put
-    uri: http://backend:5352/source/home:package_test_user/_meta
-    body:
-      encoding: UTF-8
-      string: |
-        <project name="home:package_test_user">
-          <title/>
-          <description/>
-          <person userid="package_test_user" role="maintainer"/>
-        </project>
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '157'
-    body:
-      encoding: UTF-8
-      string: |
-        <project name="home:package_test_user">
-          <title></title>
-          <description></description>
-          <person userid="package_test_user" role="maintainer" />
-        </project>
-    http_version: 
-  recorded_at: Fri, 19 Aug 2016 16:01:53 GMT
-- request:
-    method: put
-    uri: http://backend:5352/source/home:package_test_user/test_package/_meta
-    body:
-      encoding: UTF-8
-      string: |
-        <package name="test_package" project="home:package_test_user">
-          <title/>
-          <description/>
-        </package>
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '122'
-    body:
-      encoding: UTF-8
-      string: |
-        <package name="test_package" project="home:package_test_user">
-          <title></title>
-          <description></description>
-        </package>
-    http_version: 
-  recorded_at: Fri, 19 Aug 2016 16:01:53 GMT
-- request:
-    method: put
-    uri: http://backend:5352/source/home:package_test_user/test_package/somefile.txt
-    body:
-      encoding: UTF-8
-      string: Similique rem deserunt magnam et tenetur totam. Voluptatum distinctio
-        aliquid alias. Illo consequatur quidem harum rerum laborum. Aliquid facilis
-        illum maxime corrupti molestiae a. Dolor nobis sequi esse.
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '207'
-    body:
-      encoding: UTF-8
-      string: |
-        <revision rev="7" vrev="7">
-          <srcmd5>641d46bb3e2217bcdd41928a0ccf5b81</srcmd5>
-          <version>unknown</version>
-          <time>1471622513</time>
-          <user>unknown</user>
-          <comment></comment>
-          <requestid/>
-        </revision>
-    http_version: 
-  recorded_at: Fri, 19 Aug 2016 16:01:53 GMT
-- request:
-    method: put
-    uri: http://backend:5352/source/home:other_package_test_user/_meta
-    body:
-      encoding: UTF-8
-      string: |
-        <project name="home:other_package_test_user">
-          <title/>
-          <description/>
-          <person userid="other_package_test_user" role="maintainer"/>
-        </project>
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '169'
-    body:
-      encoding: UTF-8
-      string: |
-        <project name="home:other_package_test_user">
-          <title></title>
-          <description></description>
-          <person userid="other_package_test_user" role="maintainer" />
-        </project>
-    http_version: 
-  recorded_at: Fri, 19 Aug 2016 16:01:53 GMT
-- request:
-    method: put
-    uri: http://backend:5352/source/home:other_package_test_user/branch_test_package/_meta
-    body:
-      encoding: UTF-8
-      string: |
-        <package name="branch_test_package" project="home:other_package_test_user">
-          <title/>
-          <description/>
-        </package>
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '135'
-    body:
-      encoding: UTF-8
-      string: |
-        <package name="branch_test_package" project="home:other_package_test_user">
-          <title></title>
-          <description></description>
-        </package>
-    http_version: 
-  recorded_at: Fri, 19 Aug 2016 16:01:53 GMT
-- request:
-    method: put
-    uri: http://backend:5352/source/home:other_package_test_user/branch_test_package/somefile.txt
-    body:
-      encoding: UTF-8
-      string: Voluptate aspernatur et neque laboriosam animi non et. Aliquid voluptas
-        dolores nulla qui quae. Tempora voluptates consequatur. Voluptas rerum omnis
-        aperiam inventore excepturi velit. Consequuntur ipsum quidem hic nulla eligendi.
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '207'
-    body:
-      encoding: UTF-8
-      string: |
-        <revision rev="7" vrev="7">
-          <srcmd5>d701e8d04b654562d81a66a5f9fd4421</srcmd5>
-          <version>unknown</version>
-          <time>1471622513</time>
-          <user>unknown</user>
-          <comment></comment>
-          <requestid/>
-        </revision>
-    http_version: 
-  recorded_at: Fri, 19 Aug 2016 16:01:53 GMT
-- request:
-    method: get
-    uri: http://backend:5352/build/home:package_test_user/_result?package=develpackage&view=status
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Content-Type:
-      - text/plain
-      Accept-Encoding:
-      - identity
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 404
-      message: unknown package 'develpackage'
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '138'
-    body:
-      encoding: UTF-8
-      string: |
-        <status code="404">
-          <summary>unknown package 'develpackage'</summary>
-          <details>404 unknown package 'develpackage'</details>
-        </status>
-    http_version: 
-  recorded_at: Fri, 19 Aug 2016 16:01:55 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/home:package_test_user/develpackage?nofilename=1&view=info&withchangesmd5=1
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '109'
-    body:
-      encoding: UTF-8
-      string: |
-        <sourceinfo package="develpackage">
-          <error>404 package 'develpackage' does not exist</error>
-        </sourceinfo>
-    http_version: 
-  recorded_at: Fri, 19 Aug 2016 16:01:55 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/home:package_test_user/develpackage
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 404
-      message: package 'develpackage' does not exist
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '152'
-    body:
-      encoding: UTF-8
-      string: |
-        <status code="404">
-          <summary>package 'develpackage' does not exist</summary>
-          <details>404 package 'develpackage' does not exist</details>
-        </status>
-    http_version: 
-  recorded_at: Fri, 19 Aug 2016 16:01:55 GMT
-- request:
-    method: post
-    uri: http://backend:5352/source/home:package_test_user/develpackage?cmd=diff&linkrev=base&onlyissues=1&orev=0&view=xml
-    body:
-      encoding: UTF-8
-      string: ''
-    headers:
-      Content-Type:
-      - application/octet-stream
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 404
-      message: package 'develpackage' does not exist
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '152'
-    body:
-      encoding: UTF-8
-      string: |
-        <status code="404">
-          <summary>package 'develpackage' does not exist</summary>
-          <details>404 package 'develpackage' does not exist</details>
-        </status>
-    http_version: 
-  recorded_at: Fri, 19 Aug 2016 16:01:55 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/home:package_test_user/develpackage
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 404
-      message: package 'develpackage' does not exist
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '152'
-    body:
-      encoding: UTF-8
-      string: |
-        <status code="404">
-          <summary>package 'develpackage' does not exist</summary>
-          <details>404 package 'develpackage' does not exist</details>
-        </status>
-    http_version: 
-  recorded_at: Fri, 19 Aug 2016 16:01:56 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/home:package_test_user/develpackage?expand=1
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Content-Type:
-      - text/plain
-      Accept-Encoding:
-      - identity
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 404
-      message: package 'develpackage' does not exist
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '152'
-    body:
-      encoding: UTF-8
-      string: |
-        <status code="404">
-          <summary>package 'develpackage' does not exist</summary>
-          <details>404 package 'develpackage' does not exist</details>
-        </status>
-    http_version: 
-  recorded_at: Fri, 19 Aug 2016 16:01:56 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/home:package_test_user/develpackage
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Content-Type:
-      - text/plain
-      Accept-Encoding:
-      - identity
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 404
-      message: package 'develpackage' does not exist
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '152'
-    body:
-      encoding: UTF-8
-      string: |
-        <status code="404">
-          <summary>package 'develpackage' does not exist</summary>
-          <details>404 package 'develpackage' does not exist</details>
-        </status>
-    http_version: 
-  recorded_at: Fri, 19 Aug 2016 16:01:56 GMT
-- request:
-    method: get
-    uri: http://backend:5352/build/home:package_test_user/_result?package=develpackage&view=status
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Content-Type:
-      - text/plain
-      Accept-Encoding:
-      - identity
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 404
-      message: unknown package 'develpackage'
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '138'
-    body:
-      encoding: UTF-8
-      string: |
-        <status code="404">
-          <summary>unknown package 'develpackage'</summary>
-          <details>404 unknown package 'develpackage'</details>
-        </status>
-    http_version: 
-  recorded_at: Fri, 19 Aug 2016 16:01:56 GMT
-- request:
-    method: get
-    uri: http://backend:5352/build/home:package_test_user/_result?package=develpackage&view=status
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Content-Type:
-      - text/plain
-      Accept-Encoding:
-      - identity
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 404
-      message: unknown package 'develpackage'
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '138'
-    body:
-      encoding: UTF-8
-      string: |
-        <status code="404">
-          <summary>unknown package 'develpackage'</summary>
-          <details>404 unknown package 'develpackage'</details>
-        </status>
-    http_version: 
-  recorded_at: Fri, 19 Aug 2016 16:01:56 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/home:package_test_user/develpackage/_service
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Content-Type:
-      - text/plain
-      Accept-Encoding:
-      - identity
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 404
-      message: project 'home package_test_user' does not exist
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '172'
-    body:
-      encoding: UTF-8
-      string: |
-        <status code="404">
-          <summary>project 'home:package_test_user' does not exist</summary>
-          <details>404 project 'home:package_test_user' does not exist</details>
-        </status>
-    http_version: 
-  recorded_at: Wed, 05 Oct 2016 09:08:21 GMT
-- request:
-    method: get
-    uri: http://backend:5352/build/home:package_test_user/_result?locallink=1&multibuild=1&package=develpackage&view=status
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Content-Type:
-      - text/plain
-      Accept-Encoding:
-      - identity
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 404
-      message: project 'home package_test_user' does not exist
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '172'
-    body:
-      encoding: UTF-8
-      string: |
-        <status code="404">
-          <summary>project 'home:package_test_user' does not exist</summary>
-          <details>404 project 'home:package_test_user' does not exist</details>
-        </status>
-    http_version: 
-  recorded_at: Fri, 20 Jan 2017 02:54:51 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/home:package_test_user/develpackage?expand=0
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 404
-      message: project 'home package_test_user' does not exist
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '172'
-    body:
-      encoding: UTF-8
-      string: |
-        <status code="404">
-          <summary>project 'home:package_test_user' does not exist</summary>
-          <details>404 project 'home:package_test_user' does not exist</details>
-        </status>
-    http_version: 
-  recorded_at: Tue, 16 May 2017 15:08:46 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/home:package_test_user/develpackage
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 404
-      message: project 'home package_test_user' does not exist
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '172'
-    body:
-      encoding: UTF-8
-      string: |
-        <status code="404">
-          <summary>project 'home:package_test_user' does not exist</summary>
-          <details>404 project 'home:package_test_user' does not exist</details>
-        </status>
-    http_version: 
-  recorded_at: Fri, 16 Jun 2017 14:23:14 GMT
-- request:
-    method: put
     uri: http://backend:5352/source/home:package_test_user/_meta?user=package_test_user
     body:
       encoding: UTF-8
@@ -752,7 +40,7 @@ http_interactions:
           <person userid="package_test_user" role="maintainer" />
         </project>
     http_version: 
-  recorded_at: Wed, 03 Jan 2018 13:13:30 GMT
+  recorded_at: Tue, 16 Jan 2018 14:00:53 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:package_test_user/test_package/_meta?user=package_test_user
@@ -760,8 +48,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="test_package" project="home:package_test_user">
-          <title>The Painted Veil</title>
-          <description>Ipsum provident omnis sunt nihil.</description>
+          <title>Pale Kings and Princes</title>
+          <description>Ratione laboriosam omnis odit dignissimos.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -782,23 +70,62 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '171'
+      - '186'
     body:
       encoding: UTF-8
       string: |
         <package name="test_package" project="home:package_test_user">
-          <title>The Painted Veil</title>
-          <description>Ipsum provident omnis sunt nihil.</description>
+          <title>Pale Kings and Princes</title>
+          <description>Ratione laboriosam omnis odit dignissimos.</description>
         </package>
     http_version: 
-  recorded_at: Wed, 03 Jan 2018 13:13:30 GMT
+  recorded_at: Tue, 16 Jan 2018 14:00:53 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:package_test_user/test_package/_meta
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="test_package" project="home:package_test_user">
+          <title>Pale Kings and Princes</title>
+          <description>Ratione laboriosam omnis odit dignissimos.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '186'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="test_package" project="home:package_test_user">
+          <title>Pale Kings and Princes</title>
+          <description>Ratione laboriosam omnis odit dignissimos.</description>
+        </package>
+    http_version: 
+  recorded_at: Tue, 16 Jan 2018 14:00:53 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:package_test_user/test_package/_config
     body:
       encoding: UTF-8
-      string: Voluptatum ut fugiat dignissimos qui et. Sapiente accusamus iusto magnam
-        architecto iste. Id odio nam.
+      string: Veritatis id aliquam esse amet. Aut ut aut. Qui eius adipisci quaerat
+        et. Qui nisi asperiores fugit ut. Consequatur qui numquam voluptatibus.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -822,16 +149,57 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <revision rev="1" vrev="1">
-          <srcmd5>76f14d7f71d84f62e33056b3e088d941</srcmd5>
+        <revision rev="4" vrev="4">
+          <srcmd5>029580729571eb701b38a5f6b40bb879</srcmd5>
           <version>unknown</version>
-          <time>1514985210</time>
+          <time>1516111253</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
     http_version: 
-  recorded_at: Wed, 03 Jan 2018 13:13:30 GMT
+  recorded_at: Tue, 16 Jan 2018 14:00:53 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:package_test_user/test_package/somefile.txt
+    body:
+      encoding: UTF-8
+      string: Officia quia repellendus quis. Velit ullam et. Praesentium dolorem quos
+        quae dolorum illum libero sit. Culpa officia autem voluptatem assumenda. Officiis
+        repudiandae et in.
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '207'
+    body:
+      encoding: UTF-8
+      string: |
+        <revision rev="5" vrev="5">
+          <srcmd5>029580729571eb701b38a5f6b40bb879</srcmd5>
+          <version>unknown</version>
+          <time>1516111253</time>
+          <user>unknown</user>
+          <comment></comment>
+          <requestid/>
+        </revision>
+    http_version: 
+  recorded_at: Tue, 16 Jan 2018 14:00:53 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:other_package_test_user/_meta?user=other_package_test_user
@@ -872,7 +240,7 @@ http_interactions:
           <person userid="other_package_test_user" role="maintainer" />
         </project>
     http_version: 
-  recorded_at: Wed, 03 Jan 2018 13:13:30 GMT
+  recorded_at: Tue, 16 Jan 2018 14:00:53 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:other_package_test_user/branch_test_package/_meta?user=package_test_user
@@ -880,45 +248,9 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="branch_test_package" project="home:other_package_test_user">
-          <title>The Golden Bowl</title>
-          <description>Repudiandae id soluta eum ratione distinctio.</description>
+          <title>Infinite Jest</title>
+          <description>Consequatur non explicabo hic consequatur dolorum corrupti.</description>
         </package>
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '195'
-    body:
-      encoding: UTF-8
-      string: |
-        <package name="branch_test_package" project="home:other_package_test_user">
-          <title>The Golden Bowl</title>
-          <description>Repudiandae id soluta eum ratione distinctio.</description>
-        </package>
-    http_version: 
-  recorded_at: Wed, 03 Jan 2018 13:13:30 GMT
-- request:
-    method: put
-    uri: http://backend:5352/source/home:other_package_test_user/branch_test_package/_config
-    body:
-      encoding: UTF-8
-      string: Quo et exercitationem et qui. Ratione est assumenda. Rem ipsa iste.
-        Minus ea delectus.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -942,16 +274,132 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <revision rev="3" vrev="3">
-          <srcmd5>c2bcf70eebb202a5a1b7c6f5d94f9298</srcmd5>
+        <package name="branch_test_package" project="home:other_package_test_user">
+          <title>Infinite Jest</title>
+          <description>Consequatur non explicabo hic consequatur dolorum corrupti.</description>
+        </package>
+    http_version: 
+  recorded_at: Tue, 16 Jan 2018 14:00:53 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:other_package_test_user/branch_test_package/_meta
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="branch_test_package" project="home:other_package_test_user">
+          <title>Infinite Jest</title>
+          <description>Consequatur non explicabo hic consequatur dolorum corrupti.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '207'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="branch_test_package" project="home:other_package_test_user">
+          <title>Infinite Jest</title>
+          <description>Consequatur non explicabo hic consequatur dolorum corrupti.</description>
+        </package>
+    http_version: 
+  recorded_at: Tue, 16 Jan 2018 14:00:53 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:other_package_test_user/branch_test_package/_config
+    body:
+      encoding: UTF-8
+      string: Assumenda explicabo et in. Sunt quis facilis odio. Quia eum accusantium
+        recusandae qui vel sit. Vel facere incidunt.
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '209'
+    body:
+      encoding: UTF-8
+      string: |
+        <revision rev="13" vrev="13">
+          <srcmd5>00c3ce9e544c71f7395c1b44116e1717</srcmd5>
           <version>unknown</version>
-          <time>1514985210</time>
+          <time>1516111253</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
     http_version: 
-  recorded_at: Wed, 03 Jan 2018 13:13:30 GMT
+  recorded_at: Tue, 16 Jan 2018 14:00:53 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:other_package_test_user/branch_test_package/somefile.txt
+    body:
+      encoding: UTF-8
+      string: Officia quia repellendus quis. Velit ullam et. Praesentium dolorem quos
+        quae dolorum illum libero sit. Culpa officia autem voluptatem assumenda. Officiis
+        repudiandae et in.
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '209'
+    body:
+      encoding: UTF-8
+      string: |
+        <revision rev="14" vrev="14">
+          <srcmd5>00c3ce9e544c71f7395c1b44116e1717</srcmd5>
+          <version>unknown</version>
+          <time>1516111253</time>
+          <user>unknown</user>
+          <comment></comment>
+          <requestid/>
+        </revision>
+    http_version: 
+  recorded_at: Tue, 16 Jan 2018 14:00:53 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:package_test_user/develpackage/_meta?user=package_test_user
@@ -959,8 +407,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="develpackage" project="home:package_test_user">
-          <title>The Cricket on the Hearth</title>
-          <description>Labore totam iusto numquam quis ea.</description>
+          <title>Ring of Bright Water</title>
+          <description>Porro vel et quia occaecati et qui ut autem.</description>
           <devel project="home:other_package_test_user" package="branch_test_package"/>
         </package>
     headers:
@@ -982,17 +430,17 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '263'
+      - '267'
     body:
       encoding: UTF-8
       string: |
         <package name="develpackage" project="home:package_test_user">
-          <title>The Cricket on the Hearth</title>
-          <description>Labore totam iusto numquam quis ea.</description>
+          <title>Ring of Bright Water</title>
+          <description>Porro vel et quia occaecati et qui ut autem.</description>
           <devel project="home:other_package_test_user" package="branch_test_package" />
         </package>
     http_version: 
-  recorded_at: Wed, 03 Jan 2018 13:13:31 GMT
+  recorded_at: Tue, 16 Jan 2018 14:00:54 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:package_test_user/develpackage/_meta
@@ -1000,8 +448,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="develpackage" project="home:package_test_user">
-          <title>The Cricket on the Hearth</title>
-          <description>Labore totam iusto numquam quis ea.</description>
+          <title>Ring of Bright Water</title>
+          <description>Porro vel et quia occaecati et qui ut autem.</description>
           <devel project="home:other_package_test_user" package="branch_test_package"/>
         </package>
     headers:
@@ -1023,17 +471,51 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '263'
+      - '267'
     body:
       encoding: UTF-8
       string: |
         <package name="develpackage" project="home:package_test_user">
-          <title>The Cricket on the Hearth</title>
-          <description>Labore totam iusto numquam quis ea.</description>
+          <title>Ring of Bright Water</title>
+          <description>Porro vel et quia occaecati et qui ut autem.</description>
           <devel project="home:other_package_test_user" package="branch_test_package" />
         </package>
     http_version: 
-  recorded_at: Wed, 03 Jan 2018 13:13:31 GMT
+  recorded_at: Tue, 16 Jan 2018 14:00:54 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:package_test_user/develpackage?nofilename=1&view=info&withchangesmd5=1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '150'
+    body:
+      encoding: UTF-8
+      string: |
+        <sourceinfo package="develpackage" srcmd5="d41d8cd98f00b204e9800998ecf8427e" verifymd5="d41d8cd98f00b204e9800998ecf8427e">
+          <revtime/>
+        </sourceinfo>
+    http_version: 
+  recorded_at: Tue, 16 Jan 2018 14:00:54 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:package_test_user/develpackage
@@ -1066,7 +548,284 @@ http_interactions:
         <directory name="develpackage" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
         </directory>
     http_version: 
-  recorded_at: Wed, 03 Jan 2018 13:13:31 GMT
+  recorded_at: Tue, 16 Jan 2018 14:00:54 GMT
+- request:
+    method: post
+    uri: http://backend:5352/source/home:package_test_user/develpackage?cmd=diff&linkrev=base&onlyissues=1&orev=0&view=xml
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Content-Type:
+      - application/octet-stream
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '310'
+    body:
+      encoding: UTF-8
+      string: |
+        <sourcediff key="04429e5eb3523e7cb3e15ee88d1605d6">
+          <old project="home:package_test_user" package="develpackage" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e" />
+          <new project="home:package_test_user" package="develpackage" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e" />
+          <files />
+        </sourcediff>
+    http_version: 
+  recorded_at: Tue, 16 Jan 2018 14:00:54 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:package_test_user/develpackage
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '87'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="develpackage" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
+        </directory>
+    http_version: 
+  recorded_at: Tue, 16 Jan 2018 14:00:54 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:package_test_user/develpackage?expand=1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '87'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="develpackage" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
+        </directory>
+    http_version: 
+  recorded_at: Tue, 16 Jan 2018 14:00:54 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:package_test_user/develpackage
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - text/plain
+      Accept-Encoding:
+      - identity
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '87'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="develpackage" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
+        </directory>
+    http_version: 
+  recorded_at: Tue, 16 Jan 2018 14:00:54 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:package_test_user/develpackage/_service
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - text/plain
+      Accept-Encoding:
+      - identity
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 404
+      message: _service  no such file
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '122'
+    body:
+      encoding: UTF-8
+      string: |
+        <status code="404">
+          <summary>_service: no such file</summary>
+          <details>404 _service: no such file</details>
+        </status>
+    http_version: 
+  recorded_at: Tue, 16 Jan 2018 14:00:54 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:package_test_user/develpackage
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '87'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="develpackage" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
+        </directory>
+    http_version: 
+  recorded_at: Tue, 16 Jan 2018 14:00:54 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:package_test_user/develpackage
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '87'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="develpackage" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
+        </directory>
+    http_version: 
+  recorded_at: Tue, 16 Jan 2018 14:00:54 GMT
+- request:
+    method: get
+    uri: http://backend:5352/build/home:package_test_user/_result?package=develpackage&view=status
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - text/plain
+      Accept-Encoding:
+      - identity
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '56'
+    body:
+      encoding: UTF-8
+      string: '<resultlist state="00000000000000000000000000000000" />
+
+'
+    http_version: 
+  recorded_at: Tue, 16 Jan 2018 14:00:54 GMT
 - request:
     method: put
     uri: http://backend:5352/source/project_1/_meta
@@ -1074,7 +833,7 @@ http_interactions:
       encoding: UTF-8
       string: |
         <project name="project_1">
-          <title>Recalled to Life</title>
+          <title>Behold the Man</title>
           <description/>
         </project>
     headers:
@@ -1096,24 +855,25 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '102'
+      - '100'
     body:
       encoding: UTF-8
       string: |
         <project name="project_1">
-          <title>Recalled to Life</title>
+          <title>Behold the Man</title>
           <description></description>
         </project>
     http_version: 
-  recorded_at: Wed, 03 Jan 2018 13:13:32 GMT
+  recorded_at: Tue, 16 Jan 2018 14:00:55 GMT
 - request:
     method: put
     uri: http://backend:5352/source/project_1/_config
     body:
       encoding: UTF-8
-      string: Voluptas et quae maxime nobis corrupti illo. Blanditiis possimus reiciendis
-        corrupti. Dicta qui qui dolorem incidunt. Aperiam omnis qui totam atque animi
-        accusantium excepturi.
+      string: Ut repellendus fugit accusantium asperiores sequi voluptate exercitationem.
+        Esse et et aut harum amet unde possimus. Architecto possimus sunt cum repellendus
+        est consequatur. Quia beatae odit rerum earum incidunt nihil. Omnis quasi
+        qui aut adipisci.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -1140,7 +900,7 @@ http_interactions:
 
 '
     http_version: 
-  recorded_at: Wed, 03 Jan 2018 13:13:32 GMT
+  recorded_at: Tue, 16 Jan 2018 14:00:55 GMT
 - request:
     method: put
     uri: http://backend:5352/source/project_1/develpackage/_meta?user=package_test_user
@@ -1148,8 +908,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="develpackage" project="project_1">
-          <title>Specimen Days</title>
-          <description>Velit qui qui nemo sunt doloremque.</description>
+          <title>The Lathe of Heaven</title>
+          <description>Natus dicta autem cum odio et aliquid dolores.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -1170,16 +930,16 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '157'
+      - '174'
     body:
       encoding: UTF-8
       string: |
         <package name="develpackage" project="project_1">
-          <title>Specimen Days</title>
-          <description>Velit qui qui nemo sunt doloremque.</description>
+          <title>The Lathe of Heaven</title>
+          <description>Natus dicta autem cum odio et aliquid dolores.</description>
         </package>
     http_version: 
-  recorded_at: Wed, 03 Jan 2018 13:13:32 GMT
+  recorded_at: Tue, 16 Jan 2018 14:00:55 GMT
 - request:
     method: put
     uri: http://backend:5352/source/project_1/develpackage/_meta
@@ -1187,8 +947,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="develpackage" project="project_1">
-          <title>Specimen Days</title>
-          <description>Velit qui qui nemo sunt doloremque.</description>
+          <title>The Lathe of Heaven</title>
+          <description>Natus dicta autem cum odio et aliquid dolores.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -1209,16 +969,16 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '157'
+      - '174'
     body:
       encoding: UTF-8
       string: |
         <package name="develpackage" project="project_1">
-          <title>Specimen Days</title>
-          <description>Velit qui qui nemo sunt doloremque.</description>
+          <title>The Lathe of Heaven</title>
+          <description>Natus dicta autem cum odio et aliquid dolores.</description>
         </package>
     http_version: 
-  recorded_at: Wed, 03 Jan 2018 13:13:32 GMT
+  recorded_at: Tue, 16 Jan 2018 14:00:55 GMT
 - request:
     method: put
     uri: http://backend:5352/source/project_1/develpackage/_meta?user=package_test_user
@@ -1226,8 +986,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="develpackage" project="project_1">
-          <title>Specimen Days</title>
-          <description>Velit qui qui nemo sunt doloremque.</description>
+          <title>The Lathe of Heaven</title>
+          <description>Natus dicta autem cum odio et aliquid dolores.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -1248,13 +1008,13 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '157'
+      - '174'
     body:
       encoding: UTF-8
       string: |
         <package name="develpackage" project="project_1">
-          <title>Specimen Days</title>
-          <description>Velit qui qui nemo sunt doloremque.</description>
+          <title>The Lathe of Heaven</title>
+          <description>Natus dicta autem cum odio et aliquid dolores.</description>
         </package>
     http_version: 
   recorded_at: Wed, 03 Jan 2018 13:13:32 GMT

--- a/src/api/spec/cassettes/Packages/deleting_a_package.yml
+++ b/src/api/spec/cassettes/Packages/deleting_a_package.yml
@@ -2,909 +2,6 @@
 http_interactions:
 - request:
     method: put
-    uri: http://backend:5352/source/home:package_test_user/_meta
-    body:
-      encoding: UTF-8
-      string: |
-        <project name="home:package_test_user">
-          <title/>
-          <description/>
-          <person userid="package_test_user" role="maintainer"/>
-        </project>
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '157'
-    body:
-      encoding: UTF-8
-      string: |
-        <project name="home:package_test_user">
-          <title></title>
-          <description></description>
-          <person userid="package_test_user" role="maintainer" />
-        </project>
-    http_version: 
-  recorded_at: Wed, 17 Aug 2016 11:19:57 GMT
-- request:
-    method: put
-    uri: http://backend:5352/source/home:package_test_user/test_package/_meta
-    body:
-      encoding: UTF-8
-      string: |
-        <package name="test_package" project="home:package_test_user">
-          <title/>
-          <description/>
-        </package>
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '122'
-    body:
-      encoding: UTF-8
-      string: |
-        <package name="test_package" project="home:package_test_user">
-          <title></title>
-          <description></description>
-        </package>
-    http_version: 
-  recorded_at: Wed, 17 Aug 2016 11:19:57 GMT
-- request:
-    method: put
-    uri: http://backend:5352/source/home:package_test_user/test_package/somefile.txt
-    body:
-      encoding: UTF-8
-      string: Nihil saepe aspernatur eaque maxime voluptate enim omnis. Qui laborum
-        inventore vel nemo quia voluptatem. Omnis iure laudantium voluptates voluptate.
-        Doloribus quod odio quibusdam.
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '207'
-    body:
-      encoding: UTF-8
-      string: |
-        <revision rev="1" vrev="1">
-          <srcmd5>a3eb1b9e298b092dbc956d4c27d12729</srcmd5>
-          <version>unknown</version>
-          <time>1471432797</time>
-          <user>unknown</user>
-          <comment></comment>
-          <requestid/>
-        </revision>
-    http_version: 
-  recorded_at: Wed, 17 Aug 2016 11:19:57 GMT
-- request:
-    method: put
-    uri: http://backend:5352/source/home:other_package_test_user/_meta
-    body:
-      encoding: UTF-8
-      string: |
-        <project name="home:other_package_test_user">
-          <title/>
-          <description/>
-          <person userid="other_package_test_user" role="maintainer"/>
-        </project>
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '169'
-    body:
-      encoding: UTF-8
-      string: |
-        <project name="home:other_package_test_user">
-          <title></title>
-          <description></description>
-          <person userid="other_package_test_user" role="maintainer" />
-        </project>
-    http_version: 
-  recorded_at: Wed, 17 Aug 2016 11:19:57 GMT
-- request:
-    method: put
-    uri: http://backend:5352/source/home:other_package_test_user/branch_test_package/_meta
-    body:
-      encoding: UTF-8
-      string: |
-        <package name="branch_test_package" project="home:other_package_test_user">
-          <title/>
-          <description/>
-        </package>
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '135'
-    body:
-      encoding: UTF-8
-      string: |
-        <package name="branch_test_package" project="home:other_package_test_user">
-          <title></title>
-          <description></description>
-        </package>
-    http_version: 
-  recorded_at: Wed, 17 Aug 2016 11:19:57 GMT
-- request:
-    method: put
-    uri: http://backend:5352/source/home:other_package_test_user/branch_test_package/somefile.txt
-    body:
-      encoding: UTF-8
-      string: Esse similique officia dolorem. Aliquid dolorem harum commodi voluptatem
-        dolor. Quidem dolorem nostrum. Dolorum molestiae reiciendis non amet magnam
-        perferendis. Enim ipsum dicta corrupti harum odio occaecati.
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '207'
-    body:
-      encoding: UTF-8
-      string: |
-        <revision rev="1" vrev="1">
-          <srcmd5>54f5371c1526525f9e71b49a02d72268</srcmd5>
-          <version>unknown</version>
-          <time>1471432797</time>
-          <user>unknown</user>
-          <comment></comment>
-          <requestid/>
-        </revision>
-    http_version: 
-  recorded_at: Wed, 17 Aug 2016 11:19:57 GMT
-- request:
-    method: get
-    uri: http://backend:5352/build/home:package_test_user/_result?package=test_package&view=status
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Content-Type:
-      - text/plain
-      Accept-Encoding:
-      - identity
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '56'
-    body:
-      encoding: UTF-8
-      string: '<resultlist state="00000000000000000000000000000000" />
-
-'
-    http_version: 
-  recorded_at: Wed, 17 Aug 2016 11:19:59 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/home:package_test_user/test_package?nofilename=1&view=info&withchangesmd5=1
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '186'
-    body:
-      encoding: UTF-8
-      string: |
-        <sourceinfo package="test_package" rev="1" vrev="1" srcmd5="a3eb1b9e298b092dbc956d4c27d12729" verifymd5="a3eb1b9e298b092dbc956d4c27d12729">
-          <revtime>1471432797</revtime>
-        </sourceinfo>
-    http_version: 
-  recorded_at: Wed, 17 Aug 2016 11:20:00 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/home:package_test_user/test_package
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '205'
-    body:
-      encoding: UTF-8
-      string: |
-        <directory name="test_package" rev="1" vrev="1" srcmd5="a3eb1b9e298b092dbc956d4c27d12729">
-          <entry name="somefile.txt" md5="baf14d736228969635ca18fd7b68072a" size="180" mtime="1471432797" />
-        </directory>
-    http_version: 
-  recorded_at: Wed, 17 Aug 2016 11:20:00 GMT
-- request:
-    method: post
-    uri: http://backend:5352/source/home:package_test_user/test_package?cmd=diff&linkrev=base&onlyissues=1&orev=0&view=xml
-    body:
-      encoding: UTF-8
-      string: ''
-    headers:
-      Content-Type:
-      - application/octet-stream
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '333'
-    body:
-      encoding: UTF-8
-      string: |
-        <sourcediff key="a1aad373c51d85b1c22f0efd73e905e4">
-          <old project="home:package_test_user" package="test_package" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e" />
-          <new project="home:package_test_user" package="test_package" rev="1" srcmd5="a3eb1b9e298b092dbc956d4c27d12729" />
-          <files />
-          <issues>
-          </issues>
-        </sourcediff>
-    http_version: 
-  recorded_at: Wed, 17 Aug 2016 11:20:00 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/home:package_test_user/test_package
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '205'
-    body:
-      encoding: UTF-8
-      string: |
-        <directory name="test_package" rev="1" vrev="1" srcmd5="a3eb1b9e298b092dbc956d4c27d12729">
-          <entry name="somefile.txt" md5="baf14d736228969635ca18fd7b68072a" size="180" mtime="1471432797" />
-        </directory>
-    http_version: 
-  recorded_at: Wed, 17 Aug 2016 11:20:00 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/home:package_test_user/test_package?expand=1&rev=1
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Content-Type:
-      - text/plain
-      Accept-Encoding:
-      - identity
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '205'
-    body:
-      encoding: UTF-8
-      string: |
-        <directory name="test_package" rev="1" vrev="1" srcmd5="a3eb1b9e298b092dbc956d4c27d12729">
-          <entry name="somefile.txt" md5="baf14d736228969635ca18fd7b68072a" size="180" mtime="1471432797" />
-        </directory>
-    http_version: 
-  recorded_at: Wed, 17 Aug 2016 11:20:00 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/home:package_test_user/test_package
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Content-Type:
-      - text/plain
-      Accept-Encoding:
-      - identity
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '205'
-    body:
-      encoding: UTF-8
-      string: |
-        <directory name="test_package" rev="1" vrev="1" srcmd5="a3eb1b9e298b092dbc956d4c27d12729">
-          <entry name="somefile.txt" md5="baf14d736228969635ca18fd7b68072a" size="180" mtime="1471432797" />
-        </directory>
-    http_version: 
-  recorded_at: Wed, 17 Aug 2016 11:20:00 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/home:package_test_user/test_package/_history
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '213'
-    body:
-      encoding: UTF-8
-      string: |
-        <revisionlist>
-          <revision rev="1" vrev="1">
-            <srcmd5>a3eb1b9e298b092dbc956d4c27d12729</srcmd5>
-            <version>unknown</version>
-            <time>1471432797</time>
-            <user>unknown</user>
-          </revision>
-        </revisionlist>
-    http_version: 
-  recorded_at: Wed, 17 Aug 2016 11:20:00 GMT
-- request:
-    method: get
-    uri: http://backend:5352/build/home:package_test_user/_result?package=test_package&view=status
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Content-Type:
-      - text/plain
-      Accept-Encoding:
-      - identity
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '56'
-    body:
-      encoding: UTF-8
-      string: '<resultlist state="00000000000000000000000000000000" />
-
-'
-    http_version: 
-  recorded_at: Wed, 17 Aug 2016 11:20:00 GMT
-- request:
-    method: get
-    uri: http://backend:5352/build/home:package_test_user/_result?package=test_package&view=status
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Content-Type:
-      - text/plain
-      Accept-Encoding:
-      - identity
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '56'
-    body:
-      encoding: UTF-8
-      string: '<resultlist state="00000000000000000000000000000000" />
-
-'
-    http_version: 
-  recorded_at: Wed, 17 Aug 2016 11:20:00 GMT
-- request:
-    method: get
-    uri: http://backend:5352/build/home:package_test_user/_result?code=unresolvable&view=status
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Content-Type:
-      - text/plain
-      Accept-Encoding:
-      - identity
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '56'
-    body:
-      encoding: UTF-8
-      string: '<resultlist state="00000000000000000000000000000000" />
-
-'
-    http_version: 
-  recorded_at: Wed, 17 Aug 2016 11:20:01 GMT
-- request:
-    method: get
-    uri: http://backend:5352/build/home:package_test_user/_result?view=summary
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Content-Type:
-      - text/plain
-      Accept-Encoding:
-      - identity
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '56'
-    body:
-      encoding: UTF-8
-      string: '<resultlist state="00000000000000000000000000000000" />
-
-'
-    http_version: 
-  recorded_at: Wed, 17 Aug 2016 11:20:01 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/home:package_test_user/test_package/_service
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Content-Type:
-      - text/plain
-      Accept-Encoding:
-      - identity
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 404
-      message: project 'home package_test_user' does not exist
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '172'
-    body:
-      encoding: UTF-8
-      string: |
-        <status code="404">
-          <summary>project 'home:package_test_user' does not exist</summary>
-          <details>404 project 'home:package_test_user' does not exist</details>
-        </status>
-    http_version: 
-  recorded_at: Wed, 05 Oct 2016 09:08:26 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/home:package_test_user/_keyinfo?withsslcert=1
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '12'
-    body:
-      encoding: UTF-8
-      string: "<keyinfo />\n"
-    http_version: 
-  recorded_at: Mon, 09 Jan 2017 11:08:31 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/home:package_test_user/_keyinfo?withsslcert=1
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '12'
-    body:
-      encoding: UTF-8
-      string: "<keyinfo />\n"
-    http_version: 
-  recorded_at: Mon, 09 Jan 2017 11:08:31 GMT
-- request:
-    method: get
-    uri: http://backend:5352/build/home:package_test_user/_result?locallink=1&multibuild=1&package=test_package&view=status
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Content-Type:
-      - text/plain
-      Accept-Encoding:
-      - identity
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 404
-      message: project 'home package_test_user' does not exist
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '172'
-    body:
-      encoding: UTF-8
-      string: |
-        <status code="404">
-          <summary>project 'home:package_test_user' does not exist</summary>
-          <details>404 project 'home:package_test_user' does not exist</details>
-        </status>
-    http_version: 
-  recorded_at: Fri, 20 Jan 2017 02:54:47 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/home:package_test_user/_keyinfo
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '12'
-    body:
-      encoding: UTF-8
-      string: "<keyinfo />\n"
-    http_version: 
-  recorded_at: Mon, 13 Feb 2017 16:30:43 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/home:package_test_user/_keyinfo?donotcreatecert=1&withsslcert=1
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '12'
-    body:
-      encoding: UTF-8
-      string: "<keyinfo />\n"
-    http_version: 
-  recorded_at: Mon, 08 May 2017 22:00:54 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/home:package_test_user/test_package
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 404
-      message: project 'home package_test_user' does not exist
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '172'
-    body:
-      encoding: UTF-8
-      string: |
-        <status code="404">
-          <summary>project 'home:package_test_user' does not exist</summary>
-          <details>404 project 'home:package_test_user' does not exist</details>
-        </status>
-    http_version: 
-  recorded_at: Fri, 16 Jun 2017 14:23:22 GMT
-- request:
-    method: put
     uri: http://backend:5352/source/home:package_test_user/_meta?user=package_test_user
     body:
       encoding: UTF-8
@@ -943,7 +40,7 @@ http_interactions:
           <person userid="package_test_user" role="maintainer" />
         </project>
     http_version: 
-  recorded_at: Wed, 03 Jan 2018 13:13:06 GMT
+  recorded_at: Tue, 16 Jan 2018 14:00:47 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:package_test_user/test_package/_meta?user=package_test_user
@@ -951,8 +48,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="test_package" project="home:package_test_user">
-          <title>The Green Bay Tree</title>
-          <description>Est qui fugit error et.</description>
+          <title>Alone on a Wide, Wide Sea</title>
+          <description>Ullam voluptas inventore qui consequatur quis optio.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -973,24 +70,63 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '163'
+      - '199'
     body:
       encoding: UTF-8
       string: |
         <package name="test_package" project="home:package_test_user">
-          <title>The Green Bay Tree</title>
-          <description>Est qui fugit error et.</description>
+          <title>Alone on a Wide, Wide Sea</title>
+          <description>Ullam voluptas inventore qui consequatur quis optio.</description>
         </package>
     http_version: 
-  recorded_at: Wed, 03 Jan 2018 13:13:06 GMT
+  recorded_at: Tue, 16 Jan 2018 14:00:47 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:package_test_user/test_package/_meta
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="test_package" project="home:package_test_user">
+          <title>Alone on a Wide, Wide Sea</title>
+          <description>Ullam voluptas inventore qui consequatur quis optio.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '199'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="test_package" project="home:package_test_user">
+          <title>Alone on a Wide, Wide Sea</title>
+          <description>Ullam voluptas inventore qui consequatur quis optio.</description>
+        </package>
+    http_version: 
+  recorded_at: Tue, 16 Jan 2018 14:00:47 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:package_test_user/test_package/_config
     body:
       encoding: UTF-8
-      string: Accusantium iure accusamus sed provident delectus. Non doloremque eaque
-        beatae excepturi. Aperiam cupiditate ut. Qui sed eius ut distinctio excepturi
-        libero ut.
+      string: Est dolorum omnis. Et tempora rem. Neque similique quis ut molestiae
+        aut vero. Rerum harum ipsa accusantium sit placeat cum. Sed ut eos ea voluptate
+        totam tenetur doloremque.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -1010,20 +146,61 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '207'
+      - '209'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="4" vrev="4">
-          <srcmd5>384e270dbbc35a76c084a2a52fd779a7</srcmd5>
+        <revision rev="28" vrev="28">
+          <srcmd5>d2edad3196218f3149f3931885191fbc</srcmd5>
           <version>unknown</version>
-          <time>1514985186</time>
+          <time>1516111247</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
     http_version: 
-  recorded_at: Wed, 03 Jan 2018 13:13:06 GMT
+  recorded_at: Tue, 16 Jan 2018 14:00:47 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:package_test_user/test_package/somefile.txt
+    body:
+      encoding: UTF-8
+      string: Officia quia repellendus quis. Velit ullam et. Praesentium dolorem quos
+        quae dolorum illum libero sit. Culpa officia autem voluptatem assumenda. Officiis
+        repudiandae et in.
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '209'
+    body:
+      encoding: UTF-8
+      string: |
+        <revision rev="29" vrev="29">
+          <srcmd5>d2edad3196218f3149f3931885191fbc</srcmd5>
+          <version>unknown</version>
+          <time>1516111247</time>
+          <user>unknown</user>
+          <comment></comment>
+          <requestid/>
+        </revision>
+    http_version: 
+  recorded_at: Tue, 16 Jan 2018 14:00:47 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:other_package_test_user/_meta?user=other_package_test_user
@@ -1064,7 +241,7 @@ http_interactions:
           <person userid="other_package_test_user" role="maintainer" />
         </project>
     http_version: 
-  recorded_at: Wed, 03 Jan 2018 13:13:06 GMT
+  recorded_at: Tue, 16 Jan 2018 14:00:47 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:other_package_test_user/branch_test_package/_meta?user=package_test_user
@@ -1072,45 +249,9 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="branch_test_package" project="home:other_package_test_user">
-          <title>The Far-Distant Oxus</title>
-          <description>Deleniti est architecto soluta recusandae maxime sint sed.</description>
+          <title>Let Us Now Praise Famous Men</title>
+          <description>Iusto autem perferendis et enim consectetur.</description>
         </package>
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '213'
-    body:
-      encoding: UTF-8
-      string: |
-        <package name="branch_test_package" project="home:other_package_test_user">
-          <title>The Far-Distant Oxus</title>
-          <description>Deleniti est architecto soluta recusandae maxime sint sed.</description>
-        </package>
-    http_version: 
-  recorded_at: Wed, 03 Jan 2018 13:13:06 GMT
-- request:
-    method: put
-    uri: http://backend:5352/source/home:other_package_test_user/branch_test_package/_config
-    body:
-      encoding: UTF-8
-      string: Incidunt et sed cum consectetur. Velit voluptatum explicabo veritatis
-        qui quibusdam ut. Id iure repudiandae quibusdam minus.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -1134,16 +275,168 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <revision rev="2" vrev="2">
-          <srcmd5>69a6cfdaa399a261a38394f90bdb0453</srcmd5>
+        <package name="branch_test_package" project="home:other_package_test_user">
+          <title>Let Us Now Praise Famous Men</title>
+          <description>Iusto autem perferendis et enim consectetur.</description>
+        </package>
+    http_version: 
+  recorded_at: Tue, 16 Jan 2018 14:00:47 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:other_package_test_user/branch_test_package/_meta
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="branch_test_package" project="home:other_package_test_user">
+          <title>Let Us Now Praise Famous Men</title>
+          <description>Iusto autem perferendis et enim consectetur.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '207'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="branch_test_package" project="home:other_package_test_user">
+          <title>Let Us Now Praise Famous Men</title>
+          <description>Iusto autem perferendis et enim consectetur.</description>
+        </package>
+    http_version: 
+  recorded_at: Tue, 16 Jan 2018 14:00:47 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:other_package_test_user/branch_test_package/_config
+    body:
+      encoding: UTF-8
+      string: Nisi magnam iste autem voluptatem voluptas. At mollitia quae consequatur
+        veritatis a libero est. Tenetur sint minus amet minima repudiandae. Et optio
+        tenetur sit quos beatae. Rerum exercitationem voluptas facere distinctio est
+        saepe qui.
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '207'
+    body:
+      encoding: UTF-8
+      string: |
+        <revision rev="9" vrev="9">
+          <srcmd5>3848a43990f3779b1a5518f3834289e8</srcmd5>
           <version>unknown</version>
-          <time>1514985186</time>
+          <time>1516111247</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
     http_version: 
-  recorded_at: Wed, 03 Jan 2018 13:13:06 GMT
+  recorded_at: Tue, 16 Jan 2018 14:00:47 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:other_package_test_user/branch_test_package/somefile.txt
+    body:
+      encoding: UTF-8
+      string: Officia quia repellendus quis. Velit ullam et. Praesentium dolorem quos
+        quae dolorum illum libero sit. Culpa officia autem voluptatem assumenda. Officiis
+        repudiandae et in.
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '209'
+    body:
+      encoding: UTF-8
+      string: |
+        <revision rev="10" vrev="10">
+          <srcmd5>3848a43990f3779b1a5518f3834289e8</srcmd5>
+          <version>unknown</version>
+          <time>1516111247</time>
+          <user>unknown</user>
+          <comment></comment>
+          <requestid/>
+        </revision>
+    http_version: 
+  recorded_at: Tue, 16 Jan 2018 14:00:47 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:package_test_user/test_package?nofilename=1&view=info&withchangesmd5=1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '188'
+    body:
+      encoding: UTF-8
+      string: |
+        <sourceinfo package="test_package" rev="29" vrev="29" srcmd5="d2edad3196218f3149f3931885191fbc" verifymd5="d2edad3196218f3149f3931885191fbc">
+          <revtime>1516111247</revtime>
+        </sourceinfo>
+    http_version: 
+  recorded_at: Tue, 16 Jan 2018 14:00:48 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:package_test_user/test_package
@@ -1169,16 +462,518 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '301'
+      - '398'
     body:
       encoding: UTF-8
       string: |
-        <directory name="test_package" rev="4" vrev="4" srcmd5="384e270dbbc35a76c084a2a52fd779a7">
-          <entry name="_config" md5="b1babe1f9cd77ea581172e345d1ee1af" size="160" mtime="1514985186" />
-          <entry name="somefile.txt" md5="a50059593b79508e188300cd51ee2155" size="122" mtime="1514985072" />
+        <directory name="test_package" rev="29" vrev="29" srcmd5="d2edad3196218f3149f3931885191fbc">
+          <entry name="_config" md5="3e2914e07be3e7590e116a77411d147a" size="174" mtime="1516111247" />
+          <entry name="new_file" md5="d41d8cd98f00b204e9800998ecf8427e" size="0" mtime="1516111025" />
+          <entry name="somefile.txt" md5="478bacb4eb86846967edfa64ec6a5f9a" size="172" mtime="1516111242" />
         </directory>
     http_version: 
-  recorded_at: Wed, 03 Jan 2018 13:13:07 GMT
+  recorded_at: Tue, 16 Jan 2018 14:00:48 GMT
+- request:
+    method: post
+    uri: http://backend:5352/source/home:package_test_user/test_package?cmd=diff&linkrev=base&onlyissues=1&orev=0&view=xml
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Content-Type:
+      - application/octet-stream
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '334'
+    body:
+      encoding: UTF-8
+      string: |
+        <sourcediff key="49c7c3e64dc1ffe9c6b270b2de87eeec">
+          <old project="home:package_test_user" package="test_package" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e" />
+          <new project="home:package_test_user" package="test_package" rev="29" srcmd5="d2edad3196218f3149f3931885191fbc" />
+          <files />
+          <issues>
+          </issues>
+        </sourcediff>
+    http_version: 
+  recorded_at: Tue, 16 Jan 2018 14:00:48 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:package_test_user/test_package
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '398'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="test_package" rev="29" vrev="29" srcmd5="d2edad3196218f3149f3931885191fbc">
+          <entry name="_config" md5="3e2914e07be3e7590e116a77411d147a" size="174" mtime="1516111247" />
+          <entry name="new_file" md5="d41d8cd98f00b204e9800998ecf8427e" size="0" mtime="1516111025" />
+          <entry name="somefile.txt" md5="478bacb4eb86846967edfa64ec6a5f9a" size="172" mtime="1516111242" />
+        </directory>
+    http_version: 
+  recorded_at: Tue, 16 Jan 2018 14:00:48 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:package_test_user/test_package?expand=1&rev=29
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '398'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="test_package" rev="29" vrev="29" srcmd5="d2edad3196218f3149f3931885191fbc">
+          <entry name="_config" md5="3e2914e07be3e7590e116a77411d147a" size="174" mtime="1516111247" />
+          <entry name="new_file" md5="d41d8cd98f00b204e9800998ecf8427e" size="0" mtime="1516111025" />
+          <entry name="somefile.txt" md5="478bacb4eb86846967edfa64ec6a5f9a" size="172" mtime="1516111242" />
+        </directory>
+    http_version: 
+  recorded_at: Tue, 16 Jan 2018 14:00:48 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:package_test_user/test_package
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - text/plain
+      Accept-Encoding:
+      - identity
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '398'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="test_package" rev="29" vrev="29" srcmd5="d2edad3196218f3149f3931885191fbc">
+          <entry name="_config" md5="3e2914e07be3e7590e116a77411d147a" size="174" mtime="1516111247" />
+          <entry name="new_file" md5="d41d8cd98f00b204e9800998ecf8427e" size="0" mtime="1516111025" />
+          <entry name="somefile.txt" md5="478bacb4eb86846967edfa64ec6a5f9a" size="172" mtime="1516111242" />
+        </directory>
+    http_version: 
+  recorded_at: Tue, 16 Jan 2018 14:00:48 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:package_test_user/test_package/_service
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - text/plain
+      Accept-Encoding:
+      - identity
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 404
+      message: _service  no such file
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '122'
+    body:
+      encoding: UTF-8
+      string: |
+        <status code="404">
+          <summary>_service: no such file</summary>
+          <details>404 _service: no such file</details>
+        </status>
+    http_version: 
+  recorded_at: Tue, 16 Jan 2018 14:00:48 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:package_test_user/test_package
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '398'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="test_package" rev="29" vrev="29" srcmd5="d2edad3196218f3149f3931885191fbc">
+          <entry name="_config" md5="3e2914e07be3e7590e116a77411d147a" size="174" mtime="1516111247" />
+          <entry name="new_file" md5="d41d8cd98f00b204e9800998ecf8427e" size="0" mtime="1516111025" />
+          <entry name="somefile.txt" md5="478bacb4eb86846967edfa64ec6a5f9a" size="172" mtime="1516111242" />
+        </directory>
+    http_version: 
+  recorded_at: Tue, 16 Jan 2018 14:00:48 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:package_test_user/test_package
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '398'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="test_package" rev="29" vrev="29" srcmd5="d2edad3196218f3149f3931885191fbc">
+          <entry name="_config" md5="3e2914e07be3e7590e116a77411d147a" size="174" mtime="1516111247" />
+          <entry name="new_file" md5="d41d8cd98f00b204e9800998ecf8427e" size="0" mtime="1516111025" />
+          <entry name="somefile.txt" md5="478bacb4eb86846967edfa64ec6a5f9a" size="172" mtime="1516111242" />
+        </directory>
+    http_version: 
+  recorded_at: Tue, 16 Jan 2018 14:00:48 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:package_test_user/test_package/_history
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '5359'
+    body:
+      encoding: UTF-8
+      string: |
+        <revisionlist>
+          <revision rev="1" vrev="1">
+            <srcmd5>9a2ae169c3428000a200cc94e56b4913</srcmd5>
+            <version>unknown</version>
+            <time>1516111023</time>
+            <user>unknown</user>
+          </revision>
+          <revision rev="2" vrev="2">
+            <srcmd5>057f4cd8fcce4c8a068ae87f311bc57f</srcmd5>
+            <version>unknown</version>
+            <time>1516111023</time>
+            <user>unknown</user>
+          </revision>
+          <revision rev="3" vrev="3">
+            <srcmd5>27eea8e89efc9857491eecdfc0bf32e7</srcmd5>
+            <version>unknown</version>
+            <time>1516111025</time>
+            <user>package_test_user</user>
+          </revision>
+          <revision rev="4" vrev="4">
+            <srcmd5>33355129bf6d24120cfd98eb42124dd0</srcmd5>
+            <version>unknown</version>
+            <time>1516111026</time>
+            <user>unknown</user>
+          </revision>
+          <revision rev="5" vrev="5">
+            <srcmd5>33355129bf6d24120cfd98eb42124dd0</srcmd5>
+            <version>unknown</version>
+            <time>1516111026</time>
+            <user>unknown</user>
+          </revision>
+          <revision rev="6" vrev="6">
+            <srcmd5>cdadbff42329bf737f08711c379d31fb</srcmd5>
+            <version>unknown</version>
+            <time>1516111029</time>
+            <user>unknown</user>
+          </revision>
+          <revision rev="7" vrev="7">
+            <srcmd5>cdadbff42329bf737f08711c379d31fb</srcmd5>
+            <version>unknown</version>
+            <time>1516111029</time>
+            <user>unknown</user>
+          </revision>
+          <revision rev="8" vrev="8">
+            <srcmd5>0945c572935b8d8f98738765a5d9e005</srcmd5>
+            <version>unknown</version>
+            <time>1516111032</time>
+            <user>unknown</user>
+          </revision>
+          <revision rev="9" vrev="9">
+            <srcmd5>0945c572935b8d8f98738765a5d9e005</srcmd5>
+            <version>unknown</version>
+            <time>1516111032</time>
+            <user>unknown</user>
+          </revision>
+          <revision rev="10" vrev="10">
+            <srcmd5>055b0c1eeedfe7d470f0ac99054a2187</srcmd5>
+            <version>unknown</version>
+            <time>1516111034</time>
+            <user>unknown</user>
+          </revision>
+          <revision rev="11" vrev="11">
+            <srcmd5>055b0c1eeedfe7d470f0ac99054a2187</srcmd5>
+            <version>unknown</version>
+            <time>1516111034</time>
+            <user>unknown</user>
+          </revision>
+          <revision rev="12" vrev="12">
+            <srcmd5>c0b6e7b811d0d22dafbe0926310213d1</srcmd5>
+            <version>unknown</version>
+            <time>1516111037</time>
+            <user>unknown</user>
+          </revision>
+          <revision rev="13" vrev="13">
+            <srcmd5>c0b6e7b811d0d22dafbe0926310213d1</srcmd5>
+            <version>unknown</version>
+            <time>1516111037</time>
+            <user>unknown</user>
+          </revision>
+          <revision rev="14" vrev="14">
+            <srcmd5>a54d4952d46530011f99ce36cfe7d4f1</srcmd5>
+            <version>unknown</version>
+            <time>1516111039</time>
+            <user>unknown</user>
+          </revision>
+          <revision rev="15" vrev="15">
+            <srcmd5>a54d4952d46530011f99ce36cfe7d4f1</srcmd5>
+            <version>unknown</version>
+            <time>1516111039</time>
+            <user>unknown</user>
+          </revision>
+          <revision rev="16" vrev="16">
+            <srcmd5>69b4d72a5e6fd8149945276389b240d7</srcmd5>
+            <version>unknown</version>
+            <time>1516111041</time>
+            <user>unknown</user>
+          </revision>
+          <revision rev="17" vrev="17">
+            <srcmd5>69b4d72a5e6fd8149945276389b240d7</srcmd5>
+            <version>unknown</version>
+            <time>1516111042</time>
+            <user>unknown</user>
+          </revision>
+          <revision rev="18" vrev="18">
+            <srcmd5>db4534b729c97fbbe036691597e5f51e</srcmd5>
+            <version>unknown</version>
+            <time>1516111043</time>
+            <user>unknown</user>
+          </revision>
+          <revision rev="19" vrev="19">
+            <srcmd5>db4534b729c97fbbe036691597e5f51e</srcmd5>
+            <version>unknown</version>
+            <time>1516111043</time>
+            <user>unknown</user>
+          </revision>
+          <revision rev="20" vrev="20">
+            <srcmd5>0d7ae0430384bc63b286e8130030c445</srcmd5>
+            <version>unknown</version>
+            <time>1516111046</time>
+            <user>unknown</user>
+          </revision>
+          <revision rev="21" vrev="21">
+            <srcmd5>0d7ae0430384bc63b286e8130030c445</srcmd5>
+            <version>unknown</version>
+            <time>1516111046</time>
+            <user>unknown</user>
+          </revision>
+          <revision rev="22" vrev="22">
+            <srcmd5>4966dd3df3f9e7e3d73c39d2d597225c</srcmd5>
+            <version>unknown</version>
+            <time>1516111048</time>
+            <user>unknown</user>
+          </revision>
+          <revision rev="23" vrev="23">
+            <srcmd5>4966dd3df3f9e7e3d73c39d2d597225c</srcmd5>
+            <version>unknown</version>
+            <time>1516111048</time>
+            <user>unknown</user>
+          </revision>
+          <revision rev="24" vrev="24">
+            <srcmd5>2c126c8eb8106241dc1d887d1fd50304</srcmd5>
+            <version>unknown</version>
+            <time>1516111079</time>
+            <user>unknown</user>
+          </revision>
+          <revision rev="25" vrev="25">
+            <srcmd5>2c126c8eb8106241dc1d887d1fd50304</srcmd5>
+            <version>unknown</version>
+            <time>1516111079</time>
+            <user>unknown</user>
+          </revision>
+          <revision rev="26" vrev="26">
+            <srcmd5>69bbce5ca8c7a87c5b69c9453392e69c</srcmd5>
+            <version>unknown</version>
+            <time>1516111242</time>
+            <user>unknown</user>
+          </revision>
+          <revision rev="27" vrev="27">
+            <srcmd5>f95cfa97035a1d7f8e8a8a81c67009f7</srcmd5>
+            <version>unknown</version>
+            <time>1516111242</time>
+            <user>unknown</user>
+          </revision>
+          <revision rev="28" vrev="28">
+            <srcmd5>d2edad3196218f3149f3931885191fbc</srcmd5>
+            <version>unknown</version>
+            <time>1516111247</time>
+            <user>unknown</user>
+          </revision>
+          <revision rev="29" vrev="29">
+            <srcmd5>d2edad3196218f3149f3931885191fbc</srcmd5>
+            <version>unknown</version>
+            <time>1516111247</time>
+            <user>unknown</user>
+          </revision>
+        </revisionlist>
+    http_version: 
+  recorded_at: Tue, 16 Jan 2018 14:00:48 GMT
+- request:
+    method: get
+    uri: http://backend:5352/build/home:package_test_user/_result?package=test_package&view=status
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - text/plain
+      Accept-Encoding:
+      - identity
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '56'
+    body:
+      encoding: UTF-8
+      string: '<resultlist state="00000000000000000000000000000000" />
+
+'
+    http_version: 
+  recorded_at: Tue, 16 Jan 2018 14:00:48 GMT
 - request:
     method: delete
     uri: http://backend:5352/source/home:package_test_user/test_package?comment&user=package_test_user
@@ -1208,6 +1003,105 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '<status code="ok" />
+
+'
+    http_version: 
+  recorded_at: Tue, 16 Jan 2018 14:00:49 GMT
+- request:
+    method: get
+    uri: http://backend:5352/build/home:package_test_user/_result?code=unresolvable&view=status
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '56'
+    body:
+      encoding: UTF-8
+      string: '<resultlist state="00000000000000000000000000000000" />
+
+'
+    http_version: 
+  recorded_at: Tue, 16 Jan 2018 14:00:49 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:package_test_user/_keyinfo?donotcreatecert=1&withsslcert=1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '12'
+    body:
+      encoding: UTF-8
+      string: "<keyinfo />\n"
+    http_version: 
+  recorded_at: Tue, 16 Jan 2018 14:00:49 GMT
+- request:
+    method: get
+    uri: http://backend:5352/build/home:package_test_user/_result?view=summary
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - text/plain
+      Accept-Encoding:
+      - identity
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '56'
+    body:
+      encoding: UTF-8
+      string: '<resultlist state="00000000000000000000000000000000" />
 
 '
     http_version: 

--- a/src/api/spec/cassettes/Packages/editing_package_files/editing_an_existing_file.yml
+++ b/src/api/spec/cassettes/Packages/editing_package_files/editing_an_existing_file.yml
@@ -2,1082 +2,6 @@
 http_interactions:
 - request:
     method: put
-    uri: http://backend:5352/source/home:package_test_user/_meta
-    body:
-      encoding: UTF-8
-      string: |
-        <project name="home:package_test_user">
-          <title/>
-          <description/>
-          <person userid="package_test_user" role="maintainer"/>
-        </project>
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '157'
-    body:
-      encoding: UTF-8
-      string: |
-        <project name="home:package_test_user">
-          <title></title>
-          <description></description>
-          <person userid="package_test_user" role="maintainer" />
-        </project>
-    http_version: 
-  recorded_at: Fri, 19 Aug 2016 08:33:30 GMT
-- request:
-    method: put
-    uri: http://backend:5352/source/home:package_test_user/test_package/_meta
-    body:
-      encoding: UTF-8
-      string: |
-        <package name="test_package" project="home:package_test_user">
-          <title/>
-          <description/>
-        </package>
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '122'
-    body:
-      encoding: UTF-8
-      string: |
-        <package name="test_package" project="home:package_test_user">
-          <title></title>
-          <description></description>
-        </package>
-    http_version: 
-  recorded_at: Fri, 19 Aug 2016 08:33:30 GMT
-- request:
-    method: put
-    uri: http://backend:5352/source/home:package_test_user/test_package/somefile.txt
-    body:
-      encoding: UTF-8
-      string: Iste illum ut id inventore repudiandae quis culpa. Repudiandae id temporibus
-        qui maxime tempore nostrum voluptas. Aut dolor earum similique ipsum repellat.
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '207'
-    body:
-      encoding: UTF-8
-      string: |
-        <revision rev="1" vrev="1">
-          <srcmd5>1e69a07ba4da1ef16afc5036916f3f0d</srcmd5>
-          <version>unknown</version>
-          <time>1471595610</time>
-          <user>unknown</user>
-          <comment></comment>
-          <requestid/>
-        </revision>
-    http_version: 
-  recorded_at: Fri, 19 Aug 2016 08:33:30 GMT
-- request:
-    method: put
-    uri: http://backend:5352/source/home:other_package_test_user/_meta
-    body:
-      encoding: UTF-8
-      string: |
-        <project name="home:other_package_test_user">
-          <title/>
-          <description/>
-          <person userid="other_package_test_user" role="maintainer"/>
-        </project>
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '169'
-    body:
-      encoding: UTF-8
-      string: |
-        <project name="home:other_package_test_user">
-          <title></title>
-          <description></description>
-          <person userid="other_package_test_user" role="maintainer" />
-        </project>
-    http_version: 
-  recorded_at: Fri, 19 Aug 2016 08:33:30 GMT
-- request:
-    method: put
-    uri: http://backend:5352/source/home:other_package_test_user/branch_test_package/_meta
-    body:
-      encoding: UTF-8
-      string: |
-        <package name="branch_test_package" project="home:other_package_test_user">
-          <title/>
-          <description/>
-        </package>
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '135'
-    body:
-      encoding: UTF-8
-      string: |
-        <package name="branch_test_package" project="home:other_package_test_user">
-          <title></title>
-          <description></description>
-        </package>
-    http_version: 
-  recorded_at: Fri, 19 Aug 2016 08:33:30 GMT
-- request:
-    method: put
-    uri: http://backend:5352/source/home:other_package_test_user/branch_test_package/somefile.txt
-    body:
-      encoding: UTF-8
-      string: Nihil aliquam nobis ea. Ducimus quam maiores odit ut. Et vel et sed
-        qui qui aut. Non blanditiis est mollitia.
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '207'
-    body:
-      encoding: UTF-8
-      string: |
-        <revision rev="1" vrev="1">
-          <srcmd5>456c5784ae9d2d872c25920b6fd61459</srcmd5>
-          <version>unknown</version>
-          <time>1471595610</time>
-          <user>unknown</user>
-          <comment></comment>
-          <requestid/>
-        </revision>
-    http_version: 
-  recorded_at: Fri, 19 Aug 2016 08:33:30 GMT
-- request:
-    method: put
-    uri: http://backend:5352/source/home:package_test_user/_meta
-    body:
-      encoding: UTF-8
-      string: |
-        <project name="home:package_test_user">
-          <title/>
-          <description/>
-          <person userid="package_test_user" role="maintainer"/>
-        </project>
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '157'
-    body:
-      encoding: UTF-8
-      string: |
-        <project name="home:package_test_user">
-          <title></title>
-          <description></description>
-          <person userid="package_test_user" role="maintainer" />
-        </project>
-    http_version: 
-  recorded_at: Fri, 19 Aug 2016 08:33:31 GMT
-- request:
-    method: put
-    uri: http://backend:5352/source/home:package_test_user/file_edit_test_package/_meta
-    body:
-      encoding: UTF-8
-      string: |
-        <package name="file_edit_test_package" project="home:package_test_user">
-          <title/>
-          <description/>
-        </package>
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '132'
-    body:
-      encoding: UTF-8
-      string: |
-        <package name="file_edit_test_package" project="home:package_test_user">
-          <title></title>
-          <description></description>
-        </package>
-    http_version: 
-  recorded_at: Fri, 19 Aug 2016 08:33:31 GMT
-- request:
-    method: put
-    uri: http://backend:5352/source/home:package_test_user/file_edit_test_package/somefile.txt
-    body:
-      encoding: UTF-8
-      string: Deleniti et qui placeat harum eaque unde. Atque reprehenderit velit
-        unde. Et nihil optio voluptates.
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '207'
-    body:
-      encoding: UTF-8
-      string: |
-        <revision rev="1" vrev="1">
-          <srcmd5>02418d1b2672a3d92eff53f06dbb3011</srcmd5>
-          <version>unknown</version>
-          <time>1471595611</time>
-          <user>unknown</user>
-          <comment></comment>
-          <requestid/>
-        </revision>
-    http_version: 
-  recorded_at: Fri, 19 Aug 2016 08:33:31 GMT
-- request:
-    method: get
-    uri: http://backend:5352/build/home:package_test_user/_result?package=file_edit_test_package&view=status
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Content-Type:
-      - text/plain
-      Accept-Encoding:
-      - identity
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '56'
-    body:
-      encoding: UTF-8
-      string: '<resultlist state="00000000000000000000000000000000" />
-
-'
-    http_version: 
-  recorded_at: Fri, 19 Aug 2016 08:33:31 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/home:package_test_user/file_edit_test_package?nofilename=1&view=info&withchangesmd5=1
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '196'
-    body:
-      encoding: UTF-8
-      string: |
-        <sourceinfo package="file_edit_test_package" rev="1" vrev="1" srcmd5="02418d1b2672a3d92eff53f06dbb3011" verifymd5="02418d1b2672a3d92eff53f06dbb3011">
-          <revtime>1471595611</revtime>
-        </sourceinfo>
-    http_version: 
-  recorded_at: Fri, 19 Aug 2016 08:33:31 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/home:package_test_user/file_edit_test_package
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '215'
-    body:
-      encoding: UTF-8
-      string: |
-        <directory name="file_edit_test_package" rev="1" vrev="1" srcmd5="02418d1b2672a3d92eff53f06dbb3011">
-          <entry name="somefile.txt" md5="444112975a496b561c98deceaaa69231" size="100" mtime="1471595611" />
-        </directory>
-    http_version: 
-  recorded_at: Fri, 19 Aug 2016 08:33:31 GMT
-- request:
-    method: post
-    uri: http://backend:5352/source/home:package_test_user/file_edit_test_package?cmd=diff&linkrev=base&onlyissues=1&orev=0&view=xml
-    body:
-      encoding: UTF-8
-      string: ''
-    headers:
-      Content-Type:
-      - application/octet-stream
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '353'
-    body:
-      encoding: UTF-8
-      string: |
-        <sourcediff key="4667754897e002a71e5ae396be52e8ec">
-          <old project="home:package_test_user" package="file_edit_test_package" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e" />
-          <new project="home:package_test_user" package="file_edit_test_package" rev="1" srcmd5="02418d1b2672a3d92eff53f06dbb3011" />
-          <files />
-          <issues>
-          </issues>
-        </sourcediff>
-    http_version: 
-  recorded_at: Fri, 19 Aug 2016 08:33:31 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/home:package_test_user/file_edit_test_package
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '215'
-    body:
-      encoding: UTF-8
-      string: |
-        <directory name="file_edit_test_package" rev="1" vrev="1" srcmd5="02418d1b2672a3d92eff53f06dbb3011">
-          <entry name="somefile.txt" md5="444112975a496b561c98deceaaa69231" size="100" mtime="1471595611" />
-        </directory>
-    http_version: 
-  recorded_at: Fri, 19 Aug 2016 08:33:31 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/home:package_test_user/file_edit_test_package?expand=1&rev=1
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Content-Type:
-      - text/plain
-      Accept-Encoding:
-      - identity
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '215'
-    body:
-      encoding: UTF-8
-      string: |
-        <directory name="file_edit_test_package" rev="1" vrev="1" srcmd5="02418d1b2672a3d92eff53f06dbb3011">
-          <entry name="somefile.txt" md5="444112975a496b561c98deceaaa69231" size="100" mtime="1471595611" />
-        </directory>
-    http_version: 
-  recorded_at: Fri, 19 Aug 2016 08:33:31 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/home:package_test_user/file_edit_test_package
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Content-Type:
-      - text/plain
-      Accept-Encoding:
-      - identity
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '215'
-    body:
-      encoding: UTF-8
-      string: |
-        <directory name="file_edit_test_package" rev="1" vrev="1" srcmd5="02418d1b2672a3d92eff53f06dbb3011">
-          <entry name="somefile.txt" md5="444112975a496b561c98deceaaa69231" size="100" mtime="1471595611" />
-        </directory>
-    http_version: 
-  recorded_at: Fri, 19 Aug 2016 08:33:31 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/home:package_test_user/file_edit_test_package/_history
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '213'
-    body:
-      encoding: UTF-8
-      string: |
-        <revisionlist>
-          <revision rev="1" vrev="1">
-            <srcmd5>02418d1b2672a3d92eff53f06dbb3011</srcmd5>
-            <version>unknown</version>
-            <time>1471595611</time>
-            <user>unknown</user>
-          </revision>
-        </revisionlist>
-    http_version: 
-  recorded_at: Fri, 19 Aug 2016 08:33:31 GMT
-- request:
-    method: get
-    uri: http://backend:5352/build/home:package_test_user/_result?package=file_edit_test_package&view=status
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Content-Type:
-      - text/plain
-      Accept-Encoding:
-      - identity
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '56'
-    body:
-      encoding: UTF-8
-      string: '<resultlist state="00000000000000000000000000000000" />
-
-'
-    http_version: 
-  recorded_at: Fri, 19 Aug 2016 08:33:31 GMT
-- request:
-    method: get
-    uri: http://backend:5352/build/home:package_test_user/_result?package=file_edit_test_package&view=status
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Content-Type:
-      - text/plain
-      Accept-Encoding:
-      - identity
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '56'
-    body:
-      encoding: UTF-8
-      string: '<resultlist state="00000000000000000000000000000000" />
-
-'
-    http_version: 
-  recorded_at: Fri, 19 Aug 2016 08:33:31 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/home:package_test_user/file_edit_test_package?expand=1
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Content-Type:
-      - text/plain
-      Accept-Encoding:
-      - identity
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '215'
-    body:
-      encoding: UTF-8
-      string: |
-        <directory name="file_edit_test_package" rev="1" vrev="1" srcmd5="02418d1b2672a3d92eff53f06dbb3011">
-          <entry name="somefile.txt" md5="444112975a496b561c98deceaaa69231" size="100" mtime="1471595611" />
-        </directory>
-    http_version: 
-  recorded_at: Fri, 19 Aug 2016 08:33:31 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/home:package_test_user/file_edit_test_package/somefile.txt?expand=1
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/octet-stream
-      Content-Length:
-      - '100'
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-    body:
-      encoding: UTF-8
-      string: Deleniti et qui placeat harum eaque unde. Atque reprehenderit velit
-        unde. Et nihil optio voluptates.
-    http_version: 
-  recorded_at: Fri, 19 Aug 2016 08:33:31 GMT
-- request:
-    method: put
-    uri: http://backend:5352/source/home:package_test_user/file_edit_test_package/somefile.txt?comment=&user=package_test_user
-    body:
-      encoding: UTF-8
-      string: added some new text
-    headers:
-      Content-Type:
-      - text/plain
-      Accept-Encoding:
-      - identity
-      Content-Length:
-      - '19'
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '217'
-    body:
-      encoding: UTF-8
-      string: |
-        <revision rev="2" vrev="2">
-          <srcmd5>81f959e15917ac6af90d3dd3a66193a6</srcmd5>
-          <version>unknown</version>
-          <time>1471595612</time>
-          <user>package_test_user</user>
-          <comment></comment>
-          <requestid/>
-        </revision>
-    http_version: 
-  recorded_at: Fri, 19 Aug 2016 08:33:32 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/home:package_test_user/file_edit_test_package
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '214'
-    body:
-      encoding: UTF-8
-      string: |
-        <directory name="file_edit_test_package" rev="2" vrev="2" srcmd5="81f959e15917ac6af90d3dd3a66193a6">
-          <entry name="somefile.txt" md5="c2dcd3738b5c9e18215917e07a27d974" size="19" mtime="1471595612" />
-        </directory>
-    http_version: 
-  recorded_at: Fri, 19 Aug 2016 08:33:32 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/home:package_test_user/file_edit_test_package?nofilename=1&view=info&withchangesmd5=1
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '196'
-    body:
-      encoding: UTF-8
-      string: |
-        <sourceinfo package="file_edit_test_package" rev="2" vrev="2" srcmd5="81f959e15917ac6af90d3dd3a66193a6" verifymd5="81f959e15917ac6af90d3dd3a66193a6">
-          <revtime>1471595612</revtime>
-        </sourceinfo>
-    http_version: 
-  recorded_at: Fri, 19 Aug 2016 08:33:32 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/home:package_test_user/file_edit_test_package
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '214'
-    body:
-      encoding: UTF-8
-      string: |
-        <directory name="file_edit_test_package" rev="2" vrev="2" srcmd5="81f959e15917ac6af90d3dd3a66193a6">
-          <entry name="somefile.txt" md5="c2dcd3738b5c9e18215917e07a27d974" size="19" mtime="1471595612" />
-        </directory>
-    http_version: 
-  recorded_at: Fri, 19 Aug 2016 08:33:32 GMT
-- request:
-    method: post
-    uri: http://backend:5352/source/home:package_test_user/file_edit_test_package?cmd=diff&linkrev=base&onlyissues=1&orev=0&view=xml
-    body:
-      encoding: UTF-8
-      string: ''
-    headers:
-      Content-Type:
-      - application/octet-stream
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '353'
-    body:
-      encoding: UTF-8
-      string: |
-        <sourcediff key="ee6f352d2e6903a6cdb3023902fc0b5d">
-          <old project="home:package_test_user" package="file_edit_test_package" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e" />
-          <new project="home:package_test_user" package="file_edit_test_package" rev="2" srcmd5="81f959e15917ac6af90d3dd3a66193a6" />
-          <files />
-          <issues>
-          </issues>
-        </sourcediff>
-    http_version: 
-  recorded_at: Fri, 19 Aug 2016 08:33:32 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/home:package_test_user/file_edit_test_package/somefile.txt
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/octet-stream
-      Content-Length:
-      - '19'
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-    body:
-      encoding: UTF-8
-      string: added some new text
-    http_version: 
-  recorded_at: Fri, 19 Aug 2016 08:33:32 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/home:package_test_user/file_edit_test_package/_service
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Content-Type:
-      - text/plain
-      Accept-Encoding:
-      - identity
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 404
-      message: project 'home package_test_user' does not exist
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '172'
-    body:
-      encoding: UTF-8
-      string: |
-        <status code="404">
-          <summary>project 'home:package_test_user' does not exist</summary>
-          <details>404 project 'home:package_test_user' does not exist</details>
-        </status>
-    http_version: 
-  recorded_at: Wed, 05 Oct 2016 09:08:33 GMT
-- request:
-    method: get
-    uri: http://backend:5352/build/home:package_test_user/_result?locallink=1&multibuild=1&package=file_edit_test_package&view=status
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Content-Type:
-      - text/plain
-      Accept-Encoding:
-      - identity
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 404
-      message: project 'home package_test_user' does not exist
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '172'
-    body:
-      encoding: UTF-8
-      string: |
-        <status code="404">
-          <summary>project 'home:package_test_user' does not exist</summary>
-          <details>404 project 'home:package_test_user' does not exist</details>
-        </status>
-    http_version: 
-  recorded_at: Fri, 20 Jan 2017 02:54:54 GMT
-- request:
-    method: put
     uri: http://backend:5352/source/home:package_test_user/_meta?user=package_test_user
     body:
       encoding: UTF-8
@@ -1116,16 +40,16 @@ http_interactions:
           <person userid="package_test_user" role="maintainer" />
         </project>
     http_version: 
-  recorded_at: Wed, 03 Jan 2018 13:14:56 GMT
+  recorded_at: Tue, 16 Jan 2018 14:01:43 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:package_test_user/test_package/_meta?user=package_test_user
+    uri: http://backend:5352/source/home:package_test_user/test_package/_meta?user=user_tab_user
     body:
       encoding: UTF-8
       string: |
         <package name="test_package" project="home:package_test_user">
-          <title>The Wings of the Dove</title>
-          <description>Et culpa non totam dolores fugiat.</description>
+          <title>O Pioneers!</title>
+          <description>Iusto dicta rerum voluptatem fugiat.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -1146,23 +70,63 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '177'
+      - '169'
     body:
       encoding: UTF-8
       string: |
         <package name="test_package" project="home:package_test_user">
-          <title>The Wings of the Dove</title>
-          <description>Et culpa non totam dolores fugiat.</description>
+          <title>O Pioneers!</title>
+          <description>Iusto dicta rerum voluptatem fugiat.</description>
         </package>
     http_version: 
-  recorded_at: Wed, 03 Jan 2018 13:14:56 GMT
+  recorded_at: Tue, 16 Jan 2018 14:01:43 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:package_test_user/test_package/_meta
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="test_package" project="home:package_test_user">
+          <title>O Pioneers!</title>
+          <description>Iusto dicta rerum voluptatem fugiat.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '169'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="test_package" project="home:package_test_user">
+          <title>O Pioneers!</title>
+          <description>Iusto dicta rerum voluptatem fugiat.</description>
+        </package>
+    http_version: 
+  recorded_at: Tue, 16 Jan 2018 14:01:43 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:package_test_user/test_package/_config
     body:
       encoding: UTF-8
-      string: Necessitatibus veritatis debitis vel ab ut et commodi. Quia odio quae
-        non. Autem voluptatem ut ut.
+      string: Laudantium eos fugiat. Repudiandae quia minus dolores eos non. Corrupti
+        nemo est saepe aut illo nam. Aut non fugiat dolores inventore dicta. Dolor
+        aliquid aspernatur non quaerat est ratione.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -1182,20 +146,61 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '207'
+      - '209'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="4" vrev="4">
-          <srcmd5>8ec47b05aea6b87554e460f6f6ac5cff</srcmd5>
+        <revision rev="20" vrev="20">
+          <srcmd5>daa7d13fedd51580c85a587ba9e15dc3</srcmd5>
           <version>unknown</version>
-          <time>1514985296</time>
+          <time>1516111303</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
     http_version: 
-  recorded_at: Wed, 03 Jan 2018 13:14:56 GMT
+  recorded_at: Tue, 16 Jan 2018 14:01:43 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:package_test_user/test_package/somefile.txt
+    body:
+      encoding: UTF-8
+      string: Officia quia repellendus quis. Velit ullam et. Praesentium dolorem quos
+        quae dolorum illum libero sit. Culpa officia autem voluptatem assumenda. Officiis
+        repudiandae et in.
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '209'
+    body:
+      encoding: UTF-8
+      string: |
+        <revision rev="21" vrev="21">
+          <srcmd5>daa7d13fedd51580c85a587ba9e15dc3</srcmd5>
+          <version>unknown</version>
+          <time>1516111303</time>
+          <user>unknown</user>
+          <comment></comment>
+          <requestid/>
+        </revision>
+    http_version: 
+  recorded_at: Tue, 16 Jan 2018 14:01:43 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:other_package_test_user/_meta?user=other_package_test_user
@@ -1236,16 +241,16 @@ http_interactions:
           <person userid="other_package_test_user" role="maintainer" />
         </project>
     http_version: 
-  recorded_at: Wed, 03 Jan 2018 13:14:56 GMT
+  recorded_at: Tue, 16 Jan 2018 14:01:43 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:other_package_test_user/branch_test_package/_meta?user=package_test_user
+    uri: http://backend:5352/source/home:other_package_test_user/branch_test_package/_meta?user=user_tab_user
     body:
       encoding: UTF-8
       string: |
         <package name="branch_test_package" project="home:other_package_test_user">
-          <title>Vanity Fair</title>
-          <description>Sapiente quibusdam ipsum qui officia.</description>
+          <title>Cover Her Face</title>
+          <description>Aut optio doloremque nobis in aut ab.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -1266,23 +271,62 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '183'
+      - '186'
     body:
       encoding: UTF-8
       string: |
         <package name="branch_test_package" project="home:other_package_test_user">
-          <title>Vanity Fair</title>
-          <description>Sapiente quibusdam ipsum qui officia.</description>
+          <title>Cover Her Face</title>
+          <description>Aut optio doloremque nobis in aut ab.</description>
         </package>
     http_version: 
-  recorded_at: Wed, 03 Jan 2018 13:14:56 GMT
+  recorded_at: Tue, 16 Jan 2018 14:01:43 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:other_package_test_user/branch_test_package/_meta
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="branch_test_package" project="home:other_package_test_user">
+          <title>Cover Her Face</title>
+          <description>Aut optio doloremque nobis in aut ab.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '186'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="branch_test_package" project="home:other_package_test_user">
+          <title>Cover Her Face</title>
+          <description>Aut optio doloremque nobis in aut ab.</description>
+        </package>
+    http_version: 
+  recorded_at: Tue, 16 Jan 2018 14:01:43 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:other_package_test_user/branch_test_package/_config
     body:
       encoding: UTF-8
-      string: Similique laborum facilis. Nesciunt deleniti voluptatem maxime aut.
-        Deleniti animi vero quia et itaque velit. Cumque aut repudiandae laudantium.
+      string: Quasi at quis. Alias inventore earum eum. Perferendis ut rerum. Nobis
+        praesentium quidem ut. Provident hic quod nihil neque voluptatem qui.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -1306,16 +350,57 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <revision rev="6" vrev="6">
-          <srcmd5>5f04707a9e2df4510f9dc515196b12c6</srcmd5>
+        <revision rev="7" vrev="7">
+          <srcmd5>6ceb81703d36ba7759c217f1f414d69a</srcmd5>
           <version>unknown</version>
-          <time>1514985296</time>
+          <time>1516111303</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
     http_version: 
-  recorded_at: Wed, 03 Jan 2018 13:14:56 GMT
+  recorded_at: Tue, 16 Jan 2018 14:01:43 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:other_package_test_user/branch_test_package/somefile.txt
+    body:
+      encoding: UTF-8
+      string: Officia quia repellendus quis. Velit ullam et. Praesentium dolorem quos
+        quae dolorum illum libero sit. Culpa officia autem voluptatem assumenda. Officiis
+        repudiandae et in.
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '207'
+    body:
+      encoding: UTF-8
+      string: |
+        <revision rev="8" vrev="8">
+          <srcmd5>6ceb81703d36ba7759c217f1f414d69a</srcmd5>
+          <version>unknown</version>
+          <time>1516111303</time>
+          <user>unknown</user>
+          <comment></comment>
+          <requestid/>
+        </revision>
+    http_version: 
+  recorded_at: Tue, 16 Jan 2018 14:01:43 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:package_test_user/file_edit_test_package/_meta?user=package_test_user
@@ -1323,8 +408,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="file_edit_test_package" project="home:package_test_user">
-          <title>Oh! To be in England</title>
-          <description>Modi exercitationem atque veniam eum quos.</description>
+          <title>The Parliament of Man</title>
+          <description>Qui unde ut et fugit nobis.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -1345,13 +430,626 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '194'
+      - '180'
     body:
       encoding: UTF-8
       string: |
         <package name="file_edit_test_package" project="home:package_test_user">
-          <title>Oh! To be in England</title>
-          <description>Modi exercitationem atque veniam eum quos.</description>
+          <title>The Parliament of Man</title>
+          <description>Qui unde ut et fugit nobis.</description>
+        </package>
+    http_version: 
+  recorded_at: Tue, 16 Jan 2018 14:01:44 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:package_test_user/file_edit_test_package/_meta
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="file_edit_test_package" project="home:package_test_user">
+          <title>The Parliament of Man</title>
+          <description>Qui unde ut et fugit nobis.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '180'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="file_edit_test_package" project="home:package_test_user">
+          <title>The Parliament of Man</title>
+          <description>Qui unde ut et fugit nobis.</description>
+        </package>
+    http_version: 
+  recorded_at: Tue, 16 Jan 2018 14:01:44 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:package_test_user/file_edit_test_package/_config
+    body:
+      encoding: UTF-8
+      string: Assumenda nemo laborum nisi tempora cupiditate. Et voluptates non. Non
+        blanditiis maxime nam qui dicta. Ut eveniet quo. Quae cumque corporis possimus.
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '207'
+    body:
+      encoding: UTF-8
+      string: |
+        <revision rev="3" vrev="3">
+          <srcmd5>4af630c0acd2446b47cf25a0cb69e7e2</srcmd5>
+          <version>unknown</version>
+          <time>1516111304</time>
+          <user>unknown</user>
+          <comment></comment>
+          <requestid/>
+        </revision>
+    http_version: 
+  recorded_at: Tue, 16 Jan 2018 14:01:44 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:package_test_user/file_edit_test_package/somefile.txt
+    body:
+      encoding: UTF-8
+      string: Officia quia repellendus quis. Velit ullam et. Praesentium dolorem quos
+        quae dolorum illum libero sit. Culpa officia autem voluptatem assumenda. Officiis
+        repudiandae et in.
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '207'
+    body:
+      encoding: UTF-8
+      string: |
+        <revision rev="4" vrev="4">
+          <srcmd5>69c59696459641131e90bcf8be78d67a</srcmd5>
+          <version>unknown</version>
+          <time>1516111304</time>
+          <user>unknown</user>
+          <comment></comment>
+          <requestid/>
+        </revision>
+    http_version: 
+  recorded_at: Tue, 16 Jan 2018 14:01:44 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:package_test_user/file_edit_test_package?nofilename=1&view=info&withchangesmd5=1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '196'
+    body:
+      encoding: UTF-8
+      string: |
+        <sourceinfo package="file_edit_test_package" rev="4" vrev="4" srcmd5="69c59696459641131e90bcf8be78d67a" verifymd5="69c59696459641131e90bcf8be78d67a">
+          <revtime>1516111304</revtime>
+        </sourceinfo>
+    http_version: 
+  recorded_at: Tue, 16 Jan 2018 14:01:44 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:package_test_user/file_edit_test_package
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '311'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="file_edit_test_package" rev="4" vrev="4" srcmd5="69c59696459641131e90bcf8be78d67a">
+          <entry name="_config" md5="7cc176369e328cbca910b78321ef558e" size="150" mtime="1516111304" />
+          <entry name="somefile.txt" md5="478bacb4eb86846967edfa64ec6a5f9a" size="172" mtime="1516111304" />
+        </directory>
+    http_version: 
+  recorded_at: Tue, 16 Jan 2018 14:01:44 GMT
+- request:
+    method: post
+    uri: http://backend:5352/source/home:package_test_user/file_edit_test_package?cmd=diff&linkrev=base&onlyissues=1&orev=0&view=xml
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Content-Type:
+      - application/octet-stream
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '353'
+    body:
+      encoding: UTF-8
+      string: |
+        <sourcediff key="e6fb39f0744e3fda15ab186503400855">
+          <old project="home:package_test_user" package="file_edit_test_package" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e" />
+          <new project="home:package_test_user" package="file_edit_test_package" rev="4" srcmd5="69c59696459641131e90bcf8be78d67a" />
+          <files />
+          <issues>
+          </issues>
+        </sourcediff>
+    http_version: 
+  recorded_at: Tue, 16 Jan 2018 14:01:44 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:package_test_user/file_edit_test_package
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '311'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="file_edit_test_package" rev="4" vrev="4" srcmd5="69c59696459641131e90bcf8be78d67a">
+          <entry name="_config" md5="7cc176369e328cbca910b78321ef558e" size="150" mtime="1516111304" />
+          <entry name="somefile.txt" md5="478bacb4eb86846967edfa64ec6a5f9a" size="172" mtime="1516111304" />
+        </directory>
+    http_version: 
+  recorded_at: Tue, 16 Jan 2018 14:01:44 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:package_test_user/file_edit_test_package?expand=1&rev=4
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '311'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="file_edit_test_package" rev="4" vrev="4" srcmd5="69c59696459641131e90bcf8be78d67a">
+          <entry name="_config" md5="7cc176369e328cbca910b78321ef558e" size="150" mtime="1516111304" />
+          <entry name="somefile.txt" md5="478bacb4eb86846967edfa64ec6a5f9a" size="172" mtime="1516111304" />
+        </directory>
+    http_version: 
+  recorded_at: Tue, 16 Jan 2018 14:01:44 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:package_test_user/file_edit_test_package
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - text/plain
+      Accept-Encoding:
+      - identity
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '311'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="file_edit_test_package" rev="4" vrev="4" srcmd5="69c59696459641131e90bcf8be78d67a">
+          <entry name="_config" md5="7cc176369e328cbca910b78321ef558e" size="150" mtime="1516111304" />
+          <entry name="somefile.txt" md5="478bacb4eb86846967edfa64ec6a5f9a" size="172" mtime="1516111304" />
+        </directory>
+    http_version: 
+  recorded_at: Tue, 16 Jan 2018 14:01:44 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:package_test_user/file_edit_test_package/_service
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - text/plain
+      Accept-Encoding:
+      - identity
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 404
+      message: _service  no such file
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '122'
+    body:
+      encoding: UTF-8
+      string: |
+        <status code="404">
+          <summary>_service: no such file</summary>
+          <details>404 _service: no such file</details>
+        </status>
+    http_version: 
+  recorded_at: Tue, 16 Jan 2018 14:01:44 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:package_test_user/file_edit_test_package
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '311'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="file_edit_test_package" rev="4" vrev="4" srcmd5="69c59696459641131e90bcf8be78d67a">
+          <entry name="_config" md5="7cc176369e328cbca910b78321ef558e" size="150" mtime="1516111304" />
+          <entry name="somefile.txt" md5="478bacb4eb86846967edfa64ec6a5f9a" size="172" mtime="1516111304" />
+        </directory>
+    http_version: 
+  recorded_at: Tue, 16 Jan 2018 14:01:44 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:package_test_user/file_edit_test_package
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '311'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="file_edit_test_package" rev="4" vrev="4" srcmd5="69c59696459641131e90bcf8be78d67a">
+          <entry name="_config" md5="7cc176369e328cbca910b78321ef558e" size="150" mtime="1516111304" />
+          <entry name="somefile.txt" md5="478bacb4eb86846967edfa64ec6a5f9a" size="172" mtime="1516111304" />
+        </directory>
+    http_version: 
+  recorded_at: Tue, 16 Jan 2018 14:01:44 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:package_test_user/file_edit_test_package/_history
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '759'
+    body:
+      encoding: UTF-8
+      string: |
+        <revisionlist>
+          <revision rev="1" vrev="1">
+            <srcmd5>9475371f9653521a65d833709c5e4c9f</srcmd5>
+            <version>unknown</version>
+            <time>1516111080</time>
+            <user>unknown</user>
+          </revision>
+          <revision rev="2" vrev="2">
+            <srcmd5>40e7b37651f434b1bfe3f685bcb2dedb</srcmd5>
+            <version>unknown</version>
+            <time>1516111080</time>
+            <user>unknown</user>
+          </revision>
+          <revision rev="3" vrev="3">
+            <srcmd5>4af630c0acd2446b47cf25a0cb69e7e2</srcmd5>
+            <version>unknown</version>
+            <time>1516111304</time>
+            <user>unknown</user>
+          </revision>
+          <revision rev="4" vrev="4">
+            <srcmd5>69c59696459641131e90bcf8be78d67a</srcmd5>
+            <version>unknown</version>
+            <time>1516111304</time>
+            <user>unknown</user>
+          </revision>
+        </revisionlist>
+    http_version: 
+  recorded_at: Tue, 16 Jan 2018 14:01:44 GMT
+- request:
+    method: get
+    uri: http://backend:5352/build/home:package_test_user/_result?package=file_edit_test_package&view=status
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - text/plain
+      Accept-Encoding:
+      - identity
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '56'
+    body:
+      encoding: UTF-8
+      string: '<resultlist state="00000000000000000000000000000000" />
+
+'
+    http_version: 
+  recorded_at: Tue, 16 Jan 2018 14:01:44 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:package_test_user/test_package/_meta?user=package_test_user
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="test_package" project="home:package_test_user">
+          <title>Vile Bodies</title>
+          <description>Et pariatur aperiam quo.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '157'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="test_package" project="home:package_test_user">
+          <title>Vile Bodies</title>
+          <description>Et pariatur aperiam quo.</description>
+        </package>
+    http_version: 
+  recorded_at: Tue, 16 Jan 2018 14:04:04 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:other_package_test_user/branch_test_package/_meta?user=package_test_user
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="branch_test_package" project="home:other_package_test_user">
+          <title>Where Angels Fear to Tread</title>
+          <description>Non facilis veritatis voluptas.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '192'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="branch_test_package" project="home:other_package_test_user">
+          <title>Where Angels Fear to Tread</title>
+          <description>Non facilis veritatis voluptas.</description>
         </package>
     http_version: 
   recorded_at: Wed, 03 Jan 2018 13:14:57 GMT

--- a/src/api/spec/cassettes/Packages/log/download_logfile_succesfully.yml
+++ b/src/api/spec/cassettes/Packages/log/download_logfile_succesfully.yml
@@ -40,16 +40,16 @@ http_interactions:
           <person userid="package_test_user" role="maintainer" />
         </project>
     http_version: 
-  recorded_at: Tue, 29 Aug 2017 15:42:59 GMT
+  recorded_at: Tue, 16 Jan 2018 14:00:59 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:package_test_user/test_package/_meta?user=_nobody_
+    uri: http://backend:5352/source/home:package_test_user/test_package/_meta?user=package_test_user
     body:
       encoding: UTF-8
       string: |
         <package name="test_package" project="home:package_test_user">
-          <title>The Wind's Twelve Quarters</title>
-          <description>Tenetur quaerat velit temporibus voluptatem aut rerum.</description>
+          <title>Pale Kings and Princes</title>
+          <description>Voluptatem aliquam aliquid quas omnis exercitationem sed.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -70,16 +70,16 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '202'
+      - '201'
     body:
       encoding: UTF-8
       string: |
         <package name="test_package" project="home:package_test_user">
-          <title>The Wind's Twelve Quarters</title>
-          <description>Tenetur quaerat velit temporibus voluptatem aut rerum.</description>
+          <title>Pale Kings and Princes</title>
+          <description>Voluptatem aliquam aliquid quas omnis exercitationem sed.</description>
         </package>
     http_version: 
-  recorded_at: Tue, 29 Aug 2017 15:42:59 GMT
+  recorded_at: Tue, 16 Jan 2018 14:00:59 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:package_test_user/test_package/_meta
@@ -87,8 +87,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="test_package" project="home:package_test_user">
-          <title>The Wind's Twelve Quarters</title>
-          <description>Tenetur quaerat velit temporibus voluptatem aut rerum.</description>
+          <title>Pale Kings and Princes</title>
+          <description>Voluptatem aliquam aliquid quas omnis exercitationem sed.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -109,23 +109,24 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '202'
+      - '201'
     body:
       encoding: UTF-8
       string: |
         <package name="test_package" project="home:package_test_user">
-          <title>The Wind's Twelve Quarters</title>
-          <description>Tenetur quaerat velit temporibus voluptatem aut rerum.</description>
+          <title>Pale Kings and Princes</title>
+          <description>Voluptatem aliquam aliquid quas omnis exercitationem sed.</description>
         </package>
     http_version: 
-  recorded_at: Tue, 29 Aug 2017 15:42:59 GMT
+  recorded_at: Tue, 16 Jan 2018 14:00:59 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:package_test_user/test_package/_config
     body:
       encoding: UTF-8
-      string: Facere illo commodi quis et est maxime. Nulla ullam rerum ut. Ullam
-        modi inventore perferendis voluptatibus sit. Quia magnam et omnis.
+      string: Quis accusantium debitis. Ea sit atque voluptatibus voluptatum est architecto.
+        Excepturi molestias ut et aperiam cupiditate. Error dolores autem quis eum
+        voluptatem. Recusandae officiis et est.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -149,23 +150,24 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <revision rev="1" vrev="1">
-          <srcmd5>2e88478fbed2b1aff6e84b1474d7e740</srcmd5>
+        <revision rev="8" vrev="8">
+          <srcmd5>658c809ff204a54691c073274d934b03</srcmd5>
           <version>unknown</version>
-          <time>1504021379</time>
+          <time>1516111259</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
     http_version: 
-  recorded_at: Tue, 29 Aug 2017 15:42:59 GMT
+  recorded_at: Tue, 16 Jan 2018 14:00:59 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:package_test_user/test_package/somefile.txt
     body:
       encoding: UTF-8
-      string: Minus similique animi quas dolorum. Nobis inventore quam. Similique
-        asperiores sit iste at qui. Sunt magnam et dolores cumque.
+      string: Officia quia repellendus quis. Velit ullam et. Praesentium dolorem quos
+        quae dolorum illum libero sit. Culpa officia autem voluptatem assumenda. Officiis
+        repudiandae et in.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -189,16 +191,16 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <revision rev="2" vrev="2">
-          <srcmd5>28ef7e52414845f687a034a5febe6382</srcmd5>
+        <revision rev="9" vrev="9">
+          <srcmd5>658c809ff204a54691c073274d934b03</srcmd5>
           <version>unknown</version>
-          <time>1504021379</time>
+          <time>1516111259</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
     http_version: 
-  recorded_at: Tue, 29 Aug 2017 15:42:59 GMT
+  recorded_at: Tue, 16 Jan 2018 14:00:59 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:other_package_test_user/_meta?user=other_package_test_user
@@ -239,16 +241,16 @@ http_interactions:
           <person userid="other_package_test_user" role="maintainer" />
         </project>
     http_version: 
-  recorded_at: Tue, 29 Aug 2017 15:42:59 GMT
+  recorded_at: Tue, 16 Jan 2018 14:00:59 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:other_package_test_user/branch_test_package/_meta?user=_nobody_
+    uri: http://backend:5352/source/home:other_package_test_user/branch_test_package/_meta?user=package_test_user
     body:
       encoding: UTF-8
       string: |
         <package name="branch_test_package" project="home:other_package_test_user">
-          <title>That Good Night</title>
-          <description>Ducimus enim et vitae dolore.</description>
+          <title>The Mirror Crack'd from Side to Side</title>
+          <description>Qui dignissimos pariatur enim maxime ipsam velit commodi voluptas.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -269,16 +271,16 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '179'
+      - '237'
     body:
       encoding: UTF-8
       string: |
         <package name="branch_test_package" project="home:other_package_test_user">
-          <title>That Good Night</title>
-          <description>Ducimus enim et vitae dolore.</description>
+          <title>The Mirror Crack'd from Side to Side</title>
+          <description>Qui dignissimos pariatur enim maxime ipsam velit commodi voluptas.</description>
         </package>
     http_version: 
-  recorded_at: Tue, 29 Aug 2017 15:42:59 GMT
+  recorded_at: Tue, 16 Jan 2018 14:00:59 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:other_package_test_user/branch_test_package/_meta
@@ -286,8 +288,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="branch_test_package" project="home:other_package_test_user">
-          <title>That Good Night</title>
-          <description>Ducimus enim et vitae dolore.</description>
+          <title>The Mirror Crack'd from Side to Side</title>
+          <description>Qui dignissimos pariatur enim maxime ipsam velit commodi voluptas.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -308,24 +310,23 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '179'
+      - '237'
     body:
       encoding: UTF-8
       string: |
         <package name="branch_test_package" project="home:other_package_test_user">
-          <title>That Good Night</title>
-          <description>Ducimus enim et vitae dolore.</description>
+          <title>The Mirror Crack'd from Side to Side</title>
+          <description>Qui dignissimos pariatur enim maxime ipsam velit commodi voluptas.</description>
         </package>
     http_version: 
-  recorded_at: Tue, 29 Aug 2017 15:42:59 GMT
+  recorded_at: Tue, 16 Jan 2018 14:00:59 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:other_package_test_user/branch_test_package/_config
     body:
       encoding: UTF-8
-      string: Aliquam voluptas minima animi. Sint debitis id quas. Suscipit repellat
-        molestiae blanditiis quod unde aut eum. Cum ut fugit mollitia est voluptatum.
-        Sequi quidem magnam.
+      string: Delectus quasi culpa sunt repellat aut minus. Voluptate aliquid sit
+        est. Dolorem ut enim ut voluptatem eius et.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -345,28 +346,28 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '207'
+      - '209'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="1" vrev="1">
-          <srcmd5>7bf9fe6635dc954f4469f6b019828289</srcmd5>
+        <revision rev="17" vrev="17">
+          <srcmd5>5975a950c9f2ec7e65c0afb2f659358a</srcmd5>
           <version>unknown</version>
-          <time>1504021379</time>
+          <time>1516111259</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
     http_version: 
-  recorded_at: Tue, 29 Aug 2017 15:42:59 GMT
+  recorded_at: Tue, 16 Jan 2018 14:00:59 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:other_package_test_user/branch_test_package/somefile.txt
     body:
       encoding: UTF-8
-      string: Nam ex omnis inventore dolor dolore maxime. Unde sint repellendus et
-        sed nesciunt eum. Vitae ducimus cumque aspernatur. Tenetur quis est quam consequatur.
-        Libero hic est beatae.
+      string: Officia quia repellendus quis. Velit ullam et. Praesentium dolorem quos
+        quae dolorum illum libero sit. Culpa officia autem voluptatem assumenda. Officiis
+        repudiandae et in.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -386,20 +387,20 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '207'
+      - '209'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="2" vrev="2">
-          <srcmd5>ed9c5fa22670df49186fdcf729eb8cf3</srcmd5>
+        <revision rev="18" vrev="18">
+          <srcmd5>5975a950c9f2ec7e65c0afb2f659358a</srcmd5>
           <version>unknown</version>
-          <time>1504021379</time>
+          <time>1516111259</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
     http_version: 
-  recorded_at: Tue, 29 Aug 2017 15:42:59 GMT
+  recorded_at: Tue, 16 Jan 2018 14:00:59 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:package_test_user/test_package?nofilename=1&view=info&withchangesmd5=1
@@ -429,11 +430,11 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <sourceinfo package="test_package" rev="2" vrev="2" srcmd5="28ef7e52414845f687a034a5febe6382" verifymd5="28ef7e52414845f687a034a5febe6382">
-          <revtime>1504021379</revtime>
+        <sourceinfo package="test_package" rev="9" vrev="9" srcmd5="658c809ff204a54691c073274d934b03" verifymd5="658c809ff204a54691c073274d934b03">
+          <revtime>1516111259</revtime>
         </sourceinfo>
     http_version: 
-  recorded_at: Tue, 29 Aug 2017 15:43:04 GMT
+  recorded_at: Tue, 16 Jan 2018 14:01:00 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:package_test_user/test_package
@@ -459,16 +460,17 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '301'
+      - '396'
     body:
       encoding: UTF-8
       string: |
-        <directory name="test_package" rev="2" vrev="2" srcmd5="28ef7e52414845f687a034a5febe6382">
-          <entry name="_config" md5="27a40af3f15a9168ee9dbf35d9a83feb" size="134" mtime="1504021379" />
-          <entry name="somefile.txt" md5="d542484704000bf4291a7ed5cb70af8e" size="126" mtime="1504021379" />
+        <directory name="test_package" rev="9" vrev="9" srcmd5="658c809ff204a54691c073274d934b03">
+          <entry name="_config" md5="88521ce68f2a82c965e4f5847ade4d29" size="193" mtime="1516111259" />
+          <entry name="new_file" md5="d41d8cd98f00b204e9800998ecf8427e" size="0" mtime="1516111025" />
+          <entry name="somefile.txt" md5="478bacb4eb86846967edfa64ec6a5f9a" size="172" mtime="1516111242" />
         </directory>
     http_version: 
-  recorded_at: Tue, 29 Aug 2017 15:43:04 GMT
+  recorded_at: Tue, 16 Jan 2018 14:01:00 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:package_test_user/test_package?cmd=diff&linkrev=base&onlyissues=1&orev=0&view=xml
@@ -500,15 +502,15 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="8cc00b69d7095a65269543672f7af295">
+        <sourcediff key="d52645973dd19d9a890151311d7bfd33">
           <old project="home:package_test_user" package="test_package" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e" />
-          <new project="home:package_test_user" package="test_package" rev="2" srcmd5="28ef7e52414845f687a034a5febe6382" />
+          <new project="home:package_test_user" package="test_package" rev="9" srcmd5="658c809ff204a54691c073274d934b03" />
           <files />
           <issues>
           </issues>
         </sourcediff>
     http_version: 
-  recorded_at: Tue, 29 Aug 2017 15:43:04 GMT
+  recorded_at: Tue, 16 Jan 2018 14:01:00 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:package_test_user/test_package
@@ -534,19 +536,20 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '301'
+      - '396'
     body:
       encoding: UTF-8
       string: |
-        <directory name="test_package" rev="2" vrev="2" srcmd5="28ef7e52414845f687a034a5febe6382">
-          <entry name="_config" md5="27a40af3f15a9168ee9dbf35d9a83feb" size="134" mtime="1504021379" />
-          <entry name="somefile.txt" md5="d542484704000bf4291a7ed5cb70af8e" size="126" mtime="1504021379" />
+        <directory name="test_package" rev="9" vrev="9" srcmd5="658c809ff204a54691c073274d934b03">
+          <entry name="_config" md5="88521ce68f2a82c965e4f5847ade4d29" size="193" mtime="1516111259" />
+          <entry name="new_file" md5="d41d8cd98f00b204e9800998ecf8427e" size="0" mtime="1516111025" />
+          <entry name="somefile.txt" md5="478bacb4eb86846967edfa64ec6a5f9a" size="172" mtime="1516111242" />
         </directory>
     http_version: 
-  recorded_at: Tue, 29 Aug 2017 15:43:04 GMT
+  recorded_at: Tue, 16 Jan 2018 14:01:00 GMT
 - request:
     method: get
-    uri: http://backend:5352/source/home:package_test_user/test_package?expand=1&rev=2
+    uri: http://backend:5352/source/home:package_test_user/test_package?expand=1&rev=9
     body:
       encoding: US-ASCII
       string: ''
@@ -569,16 +572,17 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '301'
+      - '396'
     body:
       encoding: UTF-8
       string: |
-        <directory name="test_package" rev="2" vrev="2" srcmd5="28ef7e52414845f687a034a5febe6382">
-          <entry name="_config" md5="27a40af3f15a9168ee9dbf35d9a83feb" size="134" mtime="1504021379" />
-          <entry name="somefile.txt" md5="d542484704000bf4291a7ed5cb70af8e" size="126" mtime="1504021379" />
+        <directory name="test_package" rev="9" vrev="9" srcmd5="658c809ff204a54691c073274d934b03">
+          <entry name="_config" md5="88521ce68f2a82c965e4f5847ade4d29" size="193" mtime="1516111259" />
+          <entry name="new_file" md5="d41d8cd98f00b204e9800998ecf8427e" size="0" mtime="1516111025" />
+          <entry name="somefile.txt" md5="478bacb4eb86846967edfa64ec6a5f9a" size="172" mtime="1516111242" />
         </directory>
     http_version: 
-  recorded_at: Tue, 29 Aug 2017 15:43:04 GMT
+  recorded_at: Tue, 16 Jan 2018 14:01:00 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:package_test_user/test_package
@@ -606,16 +610,17 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '301'
+      - '396'
     body:
       encoding: UTF-8
       string: |
-        <directory name="test_package" rev="2" vrev="2" srcmd5="28ef7e52414845f687a034a5febe6382">
-          <entry name="_config" md5="27a40af3f15a9168ee9dbf35d9a83feb" size="134" mtime="1504021379" />
-          <entry name="somefile.txt" md5="d542484704000bf4291a7ed5cb70af8e" size="126" mtime="1504021379" />
+        <directory name="test_package" rev="9" vrev="9" srcmd5="658c809ff204a54691c073274d934b03">
+          <entry name="_config" md5="88521ce68f2a82c965e4f5847ade4d29" size="193" mtime="1516111259" />
+          <entry name="new_file" md5="d41d8cd98f00b204e9800998ecf8427e" size="0" mtime="1516111025" />
+          <entry name="somefile.txt" md5="478bacb4eb86846967edfa64ec6a5f9a" size="172" mtime="1516111242" />
         </directory>
     http_version: 
-  recorded_at: Tue, 29 Aug 2017 15:43:04 GMT
+  recorded_at: Tue, 16 Jan 2018 14:01:00 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:package_test_user/test_package/_service
@@ -652,7 +657,7 @@ http_interactions:
           <details>404 _service: no such file</details>
         </status>
     http_version: 
-  recorded_at: Tue, 29 Aug 2017 15:43:04 GMT
+  recorded_at: Tue, 16 Jan 2018 14:01:00 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:package_test_user/test_package
@@ -678,16 +683,53 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '301'
+      - '396'
     body:
       encoding: UTF-8
       string: |
-        <directory name="test_package" rev="2" vrev="2" srcmd5="28ef7e52414845f687a034a5febe6382">
-          <entry name="_config" md5="27a40af3f15a9168ee9dbf35d9a83feb" size="134" mtime="1504021379" />
-          <entry name="somefile.txt" md5="d542484704000bf4291a7ed5cb70af8e" size="126" mtime="1504021379" />
+        <directory name="test_package" rev="9" vrev="9" srcmd5="658c809ff204a54691c073274d934b03">
+          <entry name="_config" md5="88521ce68f2a82c965e4f5847ade4d29" size="193" mtime="1516111259" />
+          <entry name="new_file" md5="d41d8cd98f00b204e9800998ecf8427e" size="0" mtime="1516111025" />
+          <entry name="somefile.txt" md5="478bacb4eb86846967edfa64ec6a5f9a" size="172" mtime="1516111242" />
         </directory>
     http_version: 
-  recorded_at: Tue, 29 Aug 2017 15:43:04 GMT
+  recorded_at: Tue, 16 Jan 2018 14:01:00 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:package_test_user/test_package
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '396'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="test_package" rev="9" vrev="9" srcmd5="658c809ff204a54691c073274d934b03">
+          <entry name="_config" md5="88521ce68f2a82c965e4f5847ade4d29" size="193" mtime="1516111259" />
+          <entry name="new_file" md5="d41d8cd98f00b204e9800998ecf8427e" size="0" mtime="1516111025" />
+          <entry name="somefile.txt" md5="478bacb4eb86846967edfa64ec6a5f9a" size="172" mtime="1516111242" />
+        </directory>
+    http_version: 
+  recorded_at: Tue, 16 Jan 2018 14:01:00 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:package_test_user/test_package/_history
@@ -713,26 +755,68 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '395'
+      - '1679'
     body:
       encoding: UTF-8
       string: |
         <revisionlist>
           <revision rev="1" vrev="1">
-            <srcmd5>2e88478fbed2b1aff6e84b1474d7e740</srcmd5>
+            <srcmd5>6c1a00da997ac81216c2927f5531d8a3</srcmd5>
             <version>unknown</version>
-            <time>1504021379</time>
+            <time>1516111250</time>
             <user>unknown</user>
           </revision>
           <revision rev="2" vrev="2">
-            <srcmd5>28ef7e52414845f687a034a5febe6382</srcmd5>
+            <srcmd5>67f925b0f945b8133bc1cfc378b9a1e4</srcmd5>
             <version>unknown</version>
-            <time>1504021379</time>
+            <time>1516111250</time>
+            <user>unknown</user>
+          </revision>
+          <revision rev="3" vrev="3">
+            <srcmd5>828f2044d4611f0d07fe08703257e7d7</srcmd5>
+            <version>unknown</version>
+            <time>1516111252</time>
+            <user>package_test_user</user>
+          </revision>
+          <revision rev="4" vrev="4">
+            <srcmd5>029580729571eb701b38a5f6b40bb879</srcmd5>
+            <version>unknown</version>
+            <time>1516111253</time>
+            <user>unknown</user>
+          </revision>
+          <revision rev="5" vrev="5">
+            <srcmd5>029580729571eb701b38a5f6b40bb879</srcmd5>
+            <version>unknown</version>
+            <time>1516111253</time>
+            <user>unknown</user>
+          </revision>
+          <revision rev="6" vrev="6">
+            <srcmd5>b3a56ec31c57bd08b4461f66d056857f</srcmd5>
+            <version>unknown</version>
+            <time>1516111256</time>
+            <user>unknown</user>
+          </revision>
+          <revision rev="7" vrev="7">
+            <srcmd5>b3a56ec31c57bd08b4461f66d056857f</srcmd5>
+            <version>unknown</version>
+            <time>1516111256</time>
+            <user>unknown</user>
+          </revision>
+          <revision rev="8" vrev="8">
+            <srcmd5>658c809ff204a54691c073274d934b03</srcmd5>
+            <version>unknown</version>
+            <time>1516111259</time>
+            <user>unknown</user>
+          </revision>
+          <revision rev="9" vrev="9">
+            <srcmd5>658c809ff204a54691c073274d934b03</srcmd5>
+            <version>unknown</version>
+            <time>1516111259</time>
             <user>unknown</user>
           </revision>
         </revisionlist>
     http_version: 
-  recorded_at: Tue, 29 Aug 2017 15:43:04 GMT
+  recorded_at: Tue, 16 Jan 2018 14:01:00 GMT
 - request:
     method: get
     uri: http://backend:5352/build/home:package_test_user/_result?package=test_package&view=status
@@ -767,7 +851,7 @@ http_interactions:
 
 '
     http_version: 
-  recorded_at: Tue, 29 Aug 2017 15:43:05 GMT
+  recorded_at: Tue, 16 Jan 2018 14:01:01 GMT
 - request:
     method: get
     uri: http://backend:5352/build/home:package_test_user/package_test_repository/i586/test_package/_jobstatus
@@ -775,10 +859,8 @@ http_interactions:
       encoding: US-ASCII
       string: ''
     headers:
-      Content-Type:
-      - text/plain
       Accept-Encoding:
-      - identity
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
       - "*/*"
       User-Agent:
@@ -804,16 +886,16 @@ http_interactions:
           <details>404 project 'home:package_test_user' has no repository 'package_test_repository'</details>
         </status>
     http_version: 
-  recorded_at: Tue, 29 Aug 2017 15:43:05 GMT
+  recorded_at: Tue, 16 Jan 2018 14:01:01 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:package_test_user/test_package/_meta?user=package_test_user
+    uri: http://backend:5352/source/home:package_test_user/test_package/_meta?user=user_tab_user
     body:
       encoding: UTF-8
       string: |
         <package name="test_package" project="home:package_test_user">
-          <title>The Curious Incident of the Dog in the Night-Time</title>
-          <description>Et nostrum est officiis.</description>
+          <title>Fame Is the Spur</title>
+          <description>Tempora sint harum repellendus quod est natus.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -834,25 +916,25 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '195'
+      - '184'
     body:
       encoding: UTF-8
       string: |
         <package name="test_package" project="home:package_test_user">
-          <title>The Curious Incident of the Dog in the Night-Time</title>
-          <description>Et nostrum est officiis.</description>
+          <title>Fame Is the Spur</title>
+          <description>Tempora sint harum repellendus quod est natus.</description>
         </package>
     http_version: 
-  recorded_at: Wed, 03 Jan 2018 13:14:23 GMT
+  recorded_at: Tue, 16 Jan 2018 14:03:48 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:other_package_test_user/branch_test_package/_meta?user=package_test_user
+    uri: http://backend:5352/source/home:other_package_test_user/branch_test_package/_meta?user=user_tab_user
     body:
       encoding: UTF-8
       string: |
         <package name="branch_test_package" project="home:other_package_test_user">
-          <title>The Wings of the Dove</title>
-          <description>Aut autem magnam veniam possimus.</description>
+          <title>The Little Foxes</title>
+          <description>Eos delectus eius repudiandae at.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -873,13 +955,13 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '189'
+      - '184'
     body:
       encoding: UTF-8
       string: |
         <package name="branch_test_package" project="home:other_package_test_user">
-          <title>The Wings of the Dove</title>
-          <description>Aut autem magnam veniam possimus.</description>
+          <title>The Little Foxes</title>
+          <description>Eos delectus eius repudiandae at.</description>
         </package>
     http_version: 
   recorded_at: Wed, 03 Jan 2018 13:14:23 GMT

--- a/src/api/spec/cassettes/Packages/log/live_build_finishes_succesfully.yml
+++ b/src/api/spec/cassettes/Packages/log/live_build_finishes_succesfully.yml
@@ -40,16 +40,16 @@ http_interactions:
           <person userid="package_test_user" role="maintainer" />
         </project>
     http_version: 
-  recorded_at: Tue, 29 Aug 2017 12:36:14 GMT
+  recorded_at: Tue, 16 Jan 2018 14:01:02 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:package_test_user/test_package/_meta?user=_nobody_
+    uri: http://backend:5352/source/home:package_test_user/test_package/_meta?user=package_test_user
     body:
       encoding: UTF-8
       string: |
         <package name="test_package" project="home:package_test_user">
-          <title>Tiger! Tiger!</title>
-          <description>Voluptas quia exercitationem quod.</description>
+          <title>Edna O'Brien</title>
+          <description>Minus laborum ducimus non aut asperiores.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -70,16 +70,16 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '169'
+      - '175'
     body:
       encoding: UTF-8
       string: |
         <package name="test_package" project="home:package_test_user">
-          <title>Tiger! Tiger!</title>
-          <description>Voluptas quia exercitationem quod.</description>
+          <title>Edna O'Brien</title>
+          <description>Minus laborum ducimus non aut asperiores.</description>
         </package>
     http_version: 
-  recorded_at: Tue, 29 Aug 2017 12:36:14 GMT
+  recorded_at: Tue, 16 Jan 2018 14:01:02 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:package_test_user/test_package/_meta
@@ -87,8 +87,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="test_package" project="home:package_test_user">
-          <title>Tiger! Tiger!</title>
-          <description>Voluptas quia exercitationem quod.</description>
+          <title>Edna O'Brien</title>
+          <description>Minus laborum ducimus non aut asperiores.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -109,23 +109,24 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '169'
+      - '175'
     body:
       encoding: UTF-8
       string: |
         <package name="test_package" project="home:package_test_user">
-          <title>Tiger! Tiger!</title>
-          <description>Voluptas quia exercitationem quod.</description>
+          <title>Edna O'Brien</title>
+          <description>Minus laborum ducimus non aut asperiores.</description>
         </package>
     http_version: 
-  recorded_at: Tue, 29 Aug 2017 12:36:14 GMT
+  recorded_at: Tue, 16 Jan 2018 14:01:02 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:package_test_user/test_package/_config
     body:
       encoding: UTF-8
-      string: Numquam recusandae amet officia quaerat dolorem. Qui reprehenderit praesentium
-        voluptatem reiciendis magni. In repudiandae iste ad autem sed ipsam.
+      string: Voluptatem eum perferendis dolores consequuntur ullam. Et laboriosam
+        vel dolores quo. Est voluptatem reprehenderit. Aliquid et sint nemo nisi molestias
+        ullam perspiciatis.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -145,27 +146,28 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '207'
+      - '209'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="1" vrev="1">
-          <srcmd5>19f1d847bc025b6f96993395c8382f2f</srcmd5>
+        <revision rev="10" vrev="10">
+          <srcmd5>b5364f6eec305c5523c95fa3df42271f</srcmd5>
           <version>unknown</version>
-          <time>1504010174</time>
+          <time>1516111262</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
     http_version: 
-  recorded_at: Tue, 29 Aug 2017 12:36:14 GMT
+  recorded_at: Tue, 16 Jan 2018 14:01:02 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:package_test_user/test_package/somefile.txt
     body:
       encoding: UTF-8
-      string: Perferendis magnam deleniti velit soluta aut dolores est. Facere sit
-        in modi laboriosam reiciendis enim. Doloremque assumenda occaecati blanditiis.
+      string: Officia quia repellendus quis. Velit ullam et. Praesentium dolorem quos
+        quae dolorum illum libero sit. Culpa officia autem voluptatem assumenda. Officiis
+        repudiandae et in.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -185,20 +187,20 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '207'
+      - '209'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="2" vrev="2">
-          <srcmd5>8cb0aa31d5877a8618404ea0fd9e9951</srcmd5>
+        <revision rev="11" vrev="11">
+          <srcmd5>b5364f6eec305c5523c95fa3df42271f</srcmd5>
           <version>unknown</version>
-          <time>1504010174</time>
+          <time>1516111262</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
     http_version: 
-  recorded_at: Tue, 29 Aug 2017 12:36:14 GMT
+  recorded_at: Tue, 16 Jan 2018 14:01:02 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:other_package_test_user/_meta?user=other_package_test_user
@@ -239,16 +241,16 @@ http_interactions:
           <person userid="other_package_test_user" role="maintainer" />
         </project>
     http_version: 
-  recorded_at: Tue, 29 Aug 2017 12:36:14 GMT
+  recorded_at: Tue, 16 Jan 2018 14:01:02 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:other_package_test_user/branch_test_package/_meta?user=_nobody_
+    uri: http://backend:5352/source/home:other_package_test_user/branch_test_package/_meta?user=package_test_user
     body:
       encoding: UTF-8
       string: |
         <package name="branch_test_package" project="home:other_package_test_user">
-          <title>As I Lay Dying</title>
-          <description>Cupiditate saepe dicta assumenda iusto ea neque accusantium vero.</description>
+          <title>Butter In a Lordly Dish</title>
+          <description>Commodi quas ut et.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -269,16 +271,16 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '214'
+      - '177'
     body:
       encoding: UTF-8
       string: |
         <package name="branch_test_package" project="home:other_package_test_user">
-          <title>As I Lay Dying</title>
-          <description>Cupiditate saepe dicta assumenda iusto ea neque accusantium vero.</description>
+          <title>Butter In a Lordly Dish</title>
+          <description>Commodi quas ut et.</description>
         </package>
     http_version: 
-  recorded_at: Tue, 29 Aug 2017 12:36:14 GMT
+  recorded_at: Tue, 16 Jan 2018 14:01:02 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:other_package_test_user/branch_test_package/_meta
@@ -286,8 +288,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="branch_test_package" project="home:other_package_test_user">
-          <title>As I Lay Dying</title>
-          <description>Cupiditate saepe dicta assumenda iusto ea neque accusantium vero.</description>
+          <title>Butter In a Lordly Dish</title>
+          <description>Commodi quas ut et.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -308,24 +310,23 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '214'
+      - '177'
     body:
       encoding: UTF-8
       string: |
         <package name="branch_test_package" project="home:other_package_test_user">
-          <title>As I Lay Dying</title>
-          <description>Cupiditate saepe dicta assumenda iusto ea neque accusantium vero.</description>
+          <title>Butter In a Lordly Dish</title>
+          <description>Commodi quas ut et.</description>
         </package>
     http_version: 
-  recorded_at: Tue, 29 Aug 2017 12:36:14 GMT
+  recorded_at: Tue, 16 Jan 2018 14:01:02 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:other_package_test_user/branch_test_package/_config
     body:
       encoding: UTF-8
-      string: Sit at vero nostrum ex deleniti quia. Excepturi et inventore molestiae.
-        Quia non itaque. Debitis voluptatem occaecati incidunt eos necessitatibus
-        impedit optio. Tempore nisi autem illo officia voluptate.
+      string: Eos soluta blanditiis. Ipsum qui modi. Cupiditate cumque dolore. Aut
+        expedita et eius autem modi. Dolor iusto enim tempore non.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -345,27 +346,28 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '207'
+      - '209'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="1" vrev="1">
-          <srcmd5>e294c9878c70bb6d552fc1b7a28e5f19</srcmd5>
+        <revision rev="19" vrev="19">
+          <srcmd5>888d6acceba892b52be84f8cec4e9429</srcmd5>
           <version>unknown</version>
-          <time>1504010174</time>
+          <time>1516111262</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
     http_version: 
-  recorded_at: Tue, 29 Aug 2017 12:36:14 GMT
+  recorded_at: Tue, 16 Jan 2018 14:01:02 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:other_package_test_user/branch_test_package/somefile.txt
     body:
       encoding: UTF-8
-      string: Eos numquam dicta. Aut doloribus est. Rerum sunt autem neque repudiandae
-        quo sed. Praesentium est occaecati. Quisquam quis ut est.
+      string: Officia quia repellendus quis. Velit ullam et. Praesentium dolorem quos
+        quae dolorum illum libero sit. Culpa officia autem voluptatem assumenda. Officiis
+        repudiandae et in.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -385,20 +387,20 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '207'
+      - '209'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="2" vrev="2">
-          <srcmd5>2a9c4e03eb28f19d2bb2b63bb790c284</srcmd5>
+        <revision rev="20" vrev="20">
+          <srcmd5>888d6acceba892b52be84f8cec4e9429</srcmd5>
           <version>unknown</version>
-          <time>1504010174</time>
+          <time>1516111262</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
     http_version: 
-  recorded_at: Tue, 29 Aug 2017 12:36:14 GMT
+  recorded_at: Tue, 16 Jan 2018 14:01:02 GMT
 - request:
     method: get
     uri: http://backend:5352/build/home:package_test_user/package_test_repository/i586/test_package/_jobstatus
@@ -406,10 +408,8 @@ http_interactions:
       encoding: US-ASCII
       string: ''
     headers:
-      Content-Type:
-      - text/plain
       Accept-Encoding:
-      - identity
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
       - "*/*"
       User-Agent:
@@ -435,83 +435,5 @@ http_interactions:
           <details>404 project 'home:package_test_user' has no repository 'package_test_repository'</details>
         </status>
     http_version: 
-  recorded_at: Tue, 29 Aug 2017 12:36:18 GMT
-- request:
-    method: put
-    uri: http://backend:5352/source/home:package_test_user/test_package/_meta?user=package_test_user
-    body:
-      encoding: UTF-8
-      string: |
-        <package name="test_package" project="home:package_test_user">
-          <title>A Passage to India</title>
-          <description>Id iure et nesciunt placeat.</description>
-        </package>
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '168'
-    body:
-      encoding: UTF-8
-      string: |
-        <package name="test_package" project="home:package_test_user">
-          <title>A Passage to India</title>
-          <description>Id iure et nesciunt placeat.</description>
-        </package>
-    http_version: 
-  recorded_at: Wed, 03 Jan 2018 13:14:35 GMT
-- request:
-    method: put
-    uri: http://backend:5352/source/home:other_package_test_user/branch_test_package/_meta?user=package_test_user
-    body:
-      encoding: UTF-8
-      string: |
-        <package name="branch_test_package" project="home:other_package_test_user">
-          <title>A Scanner Darkly</title>
-          <description>Quis consequatur impedit itaque est.</description>
-        </package>
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '187'
-    body:
-      encoding: UTF-8
-      string: |
-        <package name="branch_test_package" project="home:other_package_test_user">
-          <title>A Scanner Darkly</title>
-          <description>Quis consequatur impedit itaque est.</description>
-        </package>
-    http_version: 
-  recorded_at: Wed, 03 Jan 2018 13:14:35 GMT
+  recorded_at: Tue, 16 Jan 2018 14:01:03 GMT
 recorded_with: VCR 4.0.0

--- a/src/api/spec/cassettes/Packages/requesting_package_deletion.yml
+++ b/src/api/spec/cassettes/Packages/requesting_package_deletion.yml
@@ -2,777 +2,6 @@
 http_interactions:
 - request:
     method: put
-    uri: http://backend:5352/source/home:package_test_user/_meta
-    body:
-      encoding: UTF-8
-      string: |
-        <project name="home:package_test_user">
-          <title/>
-          <description/>
-          <person userid="package_test_user" role="maintainer"/>
-        </project>
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '157'
-    body:
-      encoding: UTF-8
-      string: |
-        <project name="home:package_test_user">
-          <title></title>
-          <description></description>
-          <person userid="package_test_user" role="maintainer" />
-        </project>
-    http_version: 
-  recorded_at: Wed, 17 Aug 2016 11:03:40 GMT
-- request:
-    method: put
-    uri: http://backend:5352/source/home:package_test_user/test_package/_meta
-    body:
-      encoding: UTF-8
-      string: |
-        <package name="test_package" project="home:package_test_user">
-          <title/>
-          <description/>
-        </package>
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '122'
-    body:
-      encoding: UTF-8
-      string: |
-        <package name="test_package" project="home:package_test_user">
-          <title></title>
-          <description></description>
-        </package>
-    http_version: 
-  recorded_at: Wed, 17 Aug 2016 11:03:40 GMT
-- request:
-    method: put
-    uri: http://backend:5352/source/home:package_test_user/test_package/somefile.txt
-    body:
-      encoding: UTF-8
-      string: Sed animi dolorem similique cumque deleniti. Dolorem autem repellendus
-        aut mollitia doloribus qui harum. Aspernatur natus eius.
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '207'
-    body:
-      encoding: UTF-8
-      string: |
-        <revision rev="1" vrev="1">
-          <srcmd5>93c4308366d343310e49524bdc0f5231</srcmd5>
-          <version>unknown</version>
-          <time>1471431820</time>
-          <user>unknown</user>
-          <comment></comment>
-          <requestid/>
-        </revision>
-    http_version: 
-  recorded_at: Wed, 17 Aug 2016 11:03:40 GMT
-- request:
-    method: put
-    uri: http://backend:5352/source/home:other_package_test_user/_meta
-    body:
-      encoding: UTF-8
-      string: |
-        <project name="home:other_package_test_user">
-          <title/>
-          <description/>
-          <person userid="other_package_test_user" role="maintainer"/>
-        </project>
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '169'
-    body:
-      encoding: UTF-8
-      string: |
-        <project name="home:other_package_test_user">
-          <title></title>
-          <description></description>
-          <person userid="other_package_test_user" role="maintainer" />
-        </project>
-    http_version: 
-  recorded_at: Wed, 17 Aug 2016 11:03:40 GMT
-- request:
-    method: put
-    uri: http://backend:5352/source/home:other_package_test_user/branch_test_package/_meta
-    body:
-      encoding: UTF-8
-      string: |
-        <package name="branch_test_package" project="home:other_package_test_user">
-          <title/>
-          <description/>
-        </package>
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '135'
-    body:
-      encoding: UTF-8
-      string: |
-        <package name="branch_test_package" project="home:other_package_test_user">
-          <title></title>
-          <description></description>
-        </package>
-    http_version: 
-  recorded_at: Wed, 17 Aug 2016 11:03:40 GMT
-- request:
-    method: put
-    uri: http://backend:5352/source/home:other_package_test_user/branch_test_package/somefile.txt
-    body:
-      encoding: UTF-8
-      string: Culpa harum fugiat minus dolorem corporis a accusantium. Ipsam quis
-        aut qui recusandae mollitia perferendis. Qui id sit. Ut eaque autem neque
-        ipsa est modi.
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '207'
-    body:
-      encoding: UTF-8
-      string: |
-        <revision rev="2" vrev="2">
-          <srcmd5>6dcb48c84ae0bca529ec91fbb50f49e4</srcmd5>
-          <version>unknown</version>
-          <time>1471431820</time>
-          <user>unknown</user>
-          <comment></comment>
-          <requestid/>
-        </revision>
-    http_version: 
-  recorded_at: Wed, 17 Aug 2016 11:03:41 GMT
-- request:
-    method: get
-    uri: http://backend:5352/build/home:other_package_test_user/_result?package=branch_test_package&view=status
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Content-Type:
-      - text/plain
-      Accept-Encoding:
-      - identity
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '56'
-    body:
-      encoding: UTF-8
-      string: '<resultlist state="00000000000000000000000000000000" />
-
-'
-    http_version: 
-  recorded_at: Wed, 17 Aug 2016 11:03:41 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/home:other_package_test_user/branch_test_package?nofilename=1&view=info&withchangesmd5=1
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '193'
-    body:
-      encoding: UTF-8
-      string: |
-        <sourceinfo package="branch_test_package" rev="2" vrev="2" srcmd5="6dcb48c84ae0bca529ec91fbb50f49e4" verifymd5="6dcb48c84ae0bca529ec91fbb50f49e4">
-          <revtime>1471431820</revtime>
-        </sourceinfo>
-    http_version: 
-  recorded_at: Wed, 17 Aug 2016 11:03:41 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/home:other_package_test_user/branch_test_package
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '212'
-    body:
-      encoding: UTF-8
-      string: |
-        <directory name="branch_test_package" rev="2" vrev="2" srcmd5="6dcb48c84ae0bca529ec91fbb50f49e4">
-          <entry name="somefile.txt" md5="9bef6470585325ab56dcc4863e6da080" size="156" mtime="1471431820" />
-        </directory>
-    http_version: 
-  recorded_at: Wed, 17 Aug 2016 11:03:41 GMT
-- request:
-    method: post
-    uri: http://backend:5352/source/home:other_package_test_user/branch_test_package?cmd=diff&linkrev=base&onlyissues=1&orev=0&view=xml
-    body:
-      encoding: UTF-8
-      string: ''
-    headers:
-      Content-Type:
-      - application/octet-stream
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '359'
-    body:
-      encoding: UTF-8
-      string: |
-        <sourcediff key="c3f8c3053fb22922ad18b27145f3b963">
-          <old project="home:other_package_test_user" package="branch_test_package" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e" />
-          <new project="home:other_package_test_user" package="branch_test_package" rev="2" srcmd5="6dcb48c84ae0bca529ec91fbb50f49e4" />
-          <files />
-          <issues>
-          </issues>
-        </sourcediff>
-    http_version: 
-  recorded_at: Wed, 17 Aug 2016 11:03:41 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/home:other_package_test_user/branch_test_package
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '212'
-    body:
-      encoding: UTF-8
-      string: |
-        <directory name="branch_test_package" rev="2" vrev="2" srcmd5="6dcb48c84ae0bca529ec91fbb50f49e4">
-          <entry name="somefile.txt" md5="9bef6470585325ab56dcc4863e6da080" size="156" mtime="1471431820" />
-        </directory>
-    http_version: 
-  recorded_at: Wed, 17 Aug 2016 11:03:41 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/home:other_package_test_user/branch_test_package?expand=1&rev=2
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Content-Type:
-      - text/plain
-      Accept-Encoding:
-      - identity
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '212'
-    body:
-      encoding: UTF-8
-      string: |
-        <directory name="branch_test_package" rev="2" vrev="2" srcmd5="6dcb48c84ae0bca529ec91fbb50f49e4">
-          <entry name="somefile.txt" md5="9bef6470585325ab56dcc4863e6da080" size="156" mtime="1471431820" />
-        </directory>
-    http_version: 
-  recorded_at: Wed, 17 Aug 2016 11:03:41 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/home:other_package_test_user/branch_test_package
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Content-Type:
-      - text/plain
-      Accept-Encoding:
-      - identity
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '212'
-    body:
-      encoding: UTF-8
-      string: |
-        <directory name="branch_test_package" rev="2" vrev="2" srcmd5="6dcb48c84ae0bca529ec91fbb50f49e4">
-          <entry name="somefile.txt" md5="9bef6470585325ab56dcc4863e6da080" size="156" mtime="1471431820" />
-        </directory>
-    http_version: 
-  recorded_at: Wed, 17 Aug 2016 11:03:41 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/home:other_package_test_user/branch_test_package/_history
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '395'
-    body:
-      encoding: UTF-8
-      string: |
-        <revisionlist>
-          <revision rev="1" vrev="1">
-            <srcmd5>b3277ebc00aa1f24e179ce3f891c0d62</srcmd5>
-            <version>unknown</version>
-            <time>1471431814</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="2" vrev="2">
-            <srcmd5>6dcb48c84ae0bca529ec91fbb50f49e4</srcmd5>
-            <version>unknown</version>
-            <time>1471431820</time>
-            <user>unknown</user>
-          </revision>
-        </revisionlist>
-    http_version: 
-  recorded_at: Wed, 17 Aug 2016 11:03:41 GMT
-- request:
-    method: get
-    uri: http://backend:5352/build/home:other_package_test_user/_result?package=branch_test_package&view=status
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Content-Type:
-      - text/plain
-      Accept-Encoding:
-      - identity
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '56'
-    body:
-      encoding: UTF-8
-      string: '<resultlist state="00000000000000000000000000000000" />
-
-'
-    http_version: 
-  recorded_at: Wed, 17 Aug 2016 11:03:41 GMT
-- request:
-    method: get
-    uri: http://backend:5352/build/home:other_package_test_user/_result?package=branch_test_package&view=status
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Content-Type:
-      - text/plain
-      Accept-Encoding:
-      - identity
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '56'
-    body:
-      encoding: UTF-8
-      string: '<resultlist state="00000000000000000000000000000000" />
-
-'
-    http_version: 
-  recorded_at: Wed, 17 Aug 2016 11:03:41 GMT
-- request:
-    method: post
-    uri: http://backend:5352/source/home:other_package_test_user/branch_test_package?cmd=diff&expand=1&filelimit=0&rev=0&view=xml
-    body:
-      encoding: UTF-8
-      string: ''
-    headers:
-      Content-Type:
-      - application/octet-stream
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '698'
-    body:
-      encoding: UTF-8
-      string: |
-        <sourcediff key="b053b7b883cfad0abcb3fd7738b911d5">
-          <old project="home:other_package_test_user" package="branch_test_package" rev="2" srcmd5="6dcb48c84ae0bca529ec91fbb50f49e4" />
-          <new project="home:other_package_test_user" package="branch_test_package" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e" />
-          <files>
-            <file state="deleted">
-              <old name="somefile.txt" md5="9bef6470585325ab56dcc4863e6da080" size="156" />
-              <diff lines="3">@@ -1 +0,0 @@
-        -Culpa harum fugiat minus dolorem corporis a accusantium. Ipsam quis aut qui recusandae mollitia perferendis. Qui id sit. Ut eaque autem neque ipsa est modi.
-        \ No newline at end of file
-        </diff>
-            </file>
-          </files>
-        </sourcediff>
-    http_version: 
-  recorded_at: Wed, 17 Aug 2016 11:03:42 GMT
-- request:
-    method: post
-    uri: http://backend:5352/source/home:other_package_test_user/branch_test_package?cmd=diff&expand=1&filelimit=0&rev=0&view=xml
-    body:
-      encoding: UTF-8
-      string: ''
-    headers:
-      Content-Type:
-      - application/octet-stream
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Content-Length:
-      - '698'
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-    body:
-      encoding: UTF-8
-      string: |
-        <sourcediff key="b053b7b883cfad0abcb3fd7738b911d5">
-          <old project="home:other_package_test_user" package="branch_test_package" rev="2" srcmd5="6dcb48c84ae0bca529ec91fbb50f49e4" />
-          <new project="home:other_package_test_user" package="branch_test_package" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e" />
-          <files>
-            <file state="deleted">
-              <old name="somefile.txt" md5="9bef6470585325ab56dcc4863e6da080" size="156" />
-              <diff lines="3">@@ -1 +0,0 @@
-        -Culpa harum fugiat minus dolorem corporis a accusantium. Ipsam quis aut qui recusandae mollitia perferendis. Qui id sit. Ut eaque autem neque ipsa est modi.
-        \ No newline at end of file
-        </diff>
-            </file>
-          </files>
-        </sourcediff>
-    http_version: 
-  recorded_at: Wed, 17 Aug 2016 11:03:43 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/home:other_package_test_user/branch_test_package/_service
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Content-Type:
-      - text/plain
-      Accept-Encoding:
-      - identity
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 404
-      message: project 'home other_package_test_user' does not exist
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '184'
-    body:
-      encoding: UTF-8
-      string: |
-        <status code="404">
-          <summary>project 'home:other_package_test_user' does not exist</summary>
-          <details>404 project 'home:other_package_test_user' does not exist</details>
-        </status>
-    http_version: 
-  recorded_at: Wed, 05 Oct 2016 09:08:29 GMT
-- request:
-    method: get
-    uri: http://backend:5352/build/home:other_package_test_user/_result?locallink=1&multibuild=1&package=branch_test_package&view=status
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Content-Type:
-      - text/plain
-      Accept-Encoding:
-      - identity
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 404
-      message: project 'home other_package_test_user' does not exist
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '184'
-    body:
-      encoding: UTF-8
-      string: |
-        <status code="404">
-          <summary>project 'home:other_package_test_user' does not exist</summary>
-          <details>404 project 'home:other_package_test_user' does not exist</details>
-        </status>
-    http_version: 
-  recorded_at: Fri, 20 Jan 2017 02:54:42 GMT
-- request:
-    method: put
     uri: http://backend:5352/source/home:package_test_user/_meta?user=package_test_user
     body:
       encoding: UTF-8
@@ -811,7 +40,7 @@ http_interactions:
           <person userid="package_test_user" role="maintainer" />
         </project>
     http_version: 
-  recorded_at: Wed, 03 Jan 2018 13:12:51 GMT
+  recorded_at: Tue, 16 Jan 2018 14:00:42 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:package_test_user/test_package/_meta?user=_nobody_
@@ -819,8 +48,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="test_package" project="home:package_test_user">
-          <title>Infinite Jest</title>
-          <description>Exercitationem distinctio consectetur sed qui in aut dolores.</description>
+          <title>No Highway</title>
+          <description>Illo harum voluptas ducimus repellat.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -841,23 +70,63 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '196'
+      - '169'
     body:
       encoding: UTF-8
       string: |
         <package name="test_package" project="home:package_test_user">
-          <title>Infinite Jest</title>
-          <description>Exercitationem distinctio consectetur sed qui in aut dolores.</description>
+          <title>No Highway</title>
+          <description>Illo harum voluptas ducimus repellat.</description>
         </package>
     http_version: 
-  recorded_at: Wed, 03 Jan 2018 13:12:51 GMT
+  recorded_at: Tue, 16 Jan 2018 14:00:42 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:package_test_user/test_package/_meta
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="test_package" project="home:package_test_user">
+          <title>No Highway</title>
+          <description>Illo harum voluptas ducimus repellat.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '169'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="test_package" project="home:package_test_user">
+          <title>No Highway</title>
+          <description>Illo harum voluptas ducimus repellat.</description>
+        </package>
+    http_version: 
+  recorded_at: Tue, 16 Jan 2018 14:00:42 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:package_test_user/test_package/_config
     body:
       encoding: UTF-8
-      string: Natus maxime ab. Voluptas sint nostrum ad sit. Dolore fugiat deleniti
-        iste quod odio voluptatibus.
+      string: In excepturi voluptas necessitatibus ut rerum dolore sequi. Voluptatem
+        quas delectus alias nostrum. Non enim velit quia eum consequatur in. Velit
+        necessitatibus dolorum maxime quo.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -877,20 +146,61 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '207'
+      - '209'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="3" vrev="3">
-          <srcmd5>b3b13d2a351c137961818c7a1eefc3e3</srcmd5>
+        <revision rev="26" vrev="26">
+          <srcmd5>69bbce5ca8c7a87c5b69c9453392e69c</srcmd5>
           <version>unknown</version>
-          <time>1514985171</time>
+          <time>1516111242</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
     http_version: 
-  recorded_at: Wed, 03 Jan 2018 13:12:51 GMT
+  recorded_at: Tue, 16 Jan 2018 14:00:42 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:package_test_user/test_package/somefile.txt
+    body:
+      encoding: UTF-8
+      string: Officia quia repellendus quis. Velit ullam et. Praesentium dolorem quos
+        quae dolorum illum libero sit. Culpa officia autem voluptatem assumenda. Officiis
+        repudiandae et in.
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '209'
+    body:
+      encoding: UTF-8
+      string: |
+        <revision rev="27" vrev="27">
+          <srcmd5>f95cfa97035a1d7f8e8a8a81c67009f7</srcmd5>
+          <version>unknown</version>
+          <time>1516111242</time>
+          <user>unknown</user>
+          <comment></comment>
+          <requestid/>
+        </revision>
+    http_version: 
+  recorded_at: Tue, 16 Jan 2018 14:00:42 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:other_package_test_user/_meta?user=other_package_test_user
@@ -931,7 +241,7 @@ http_interactions:
           <person userid="other_package_test_user" role="maintainer" />
         </project>
     http_version: 
-  recorded_at: Wed, 03 Jan 2018 13:12:51 GMT
+  recorded_at: Tue, 16 Jan 2018 14:00:42 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:other_package_test_user/branch_test_package/_meta?user=_nobody_
@@ -939,9 +249,165 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="branch_test_package" project="home:other_package_test_user">
-          <title>The Lathe of Heaven</title>
-          <description>Ratione repudiandae incidunt eos saepe.</description>
+          <title>Infinite Jest</title>
+          <description>Nihil officia est quod repellendus voluptas laboriosam.</description>
         </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '203'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="branch_test_package" project="home:other_package_test_user">
+          <title>Infinite Jest</title>
+          <description>Nihil officia est quod repellendus voluptas laboriosam.</description>
+        </package>
+    http_version: 
+  recorded_at: Tue, 16 Jan 2018 14:00:42 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:other_package_test_user/branch_test_package/_meta
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="branch_test_package" project="home:other_package_test_user">
+          <title>Infinite Jest</title>
+          <description>Nihil officia est quod repellendus voluptas laboriosam.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '203'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="branch_test_package" project="home:other_package_test_user">
+          <title>Infinite Jest</title>
+          <description>Nihil officia est quod repellendus voluptas laboriosam.</description>
+        </package>
+    http_version: 
+  recorded_at: Tue, 16 Jan 2018 14:00:42 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:other_package_test_user/branch_test_package/_config
+    body:
+      encoding: UTF-8
+      string: Tenetur ut ab aliquam. Voluptas nihil enim. Eum voluptas sunt voluptas
+        alias laboriosam exercitationem. Autem veniam voluptate earum. Sit quam expedita
+        in sint neque.
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '207'
+    body:
+      encoding: UTF-8
+      string: |
+        <revision rev="7" vrev="7">
+          <srcmd5>2c5620272ba1a91887c04cf7b9babcb7</srcmd5>
+          <version>unknown</version>
+          <time>1516111242</time>
+          <user>unknown</user>
+          <comment></comment>
+          <requestid/>
+        </revision>
+    http_version: 
+  recorded_at: Tue, 16 Jan 2018 14:00:42 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:other_package_test_user/branch_test_package/somefile.txt
+    body:
+      encoding: UTF-8
+      string: Officia quia repellendus quis. Velit ullam et. Praesentium dolorem quos
+        quae dolorum illum libero sit. Culpa officia autem voluptatem assumenda. Officiis
+        repudiandae et in.
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '207'
+    body:
+      encoding: UTF-8
+      string: |
+        <revision rev="8" vrev="8">
+          <srcmd5>1cbc5d6e148177dbd287922fecddaddf</srcmd5>
+          <version>unknown</version>
+          <time>1516111242</time>
+          <user>unknown</user>
+          <comment></comment>
+          <requestid/>
+        </revision>
+    http_version: 
+  recorded_at: Tue, 16 Jan 2018 14:00:42 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:other_package_test_user/branch_test_package?nofilename=1&view=info&withchangesmd5=1
+    body:
+      encoding: US-ASCII
+      string: ''
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -965,9 +431,527 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
+        <sourceinfo package="branch_test_package" rev="8" vrev="8" srcmd5="1cbc5d6e148177dbd287922fecddaddf" verifymd5="1cbc5d6e148177dbd287922fecddaddf">
+          <revtime>1516111242</revtime>
+        </sourceinfo>
+    http_version: 
+  recorded_at: Tue, 16 Jan 2018 14:00:45 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:other_package_test_user/branch_test_package
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '308'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="branch_test_package" rev="8" vrev="8" srcmd5="1cbc5d6e148177dbd287922fecddaddf">
+          <entry name="_config" md5="0c4c349b107fb2231b7e058f19ea7d06" size="166" mtime="1516111242" />
+          <entry name="somefile.txt" md5="478bacb4eb86846967edfa64ec6a5f9a" size="172" mtime="1516111242" />
+        </directory>
+    http_version: 
+  recorded_at: Tue, 16 Jan 2018 14:00:45 GMT
+- request:
+    method: post
+    uri: http://backend:5352/source/home:other_package_test_user/branch_test_package?cmd=diff&linkrev=base&onlyissues=1&orev=0&view=xml
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Content-Type:
+      - application/octet-stream
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '359'
+    body:
+      encoding: UTF-8
+      string: |
+        <sourcediff key="25dd6d04f8d5dde8fb9efa3faeee390a">
+          <old project="home:other_package_test_user" package="branch_test_package" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e" />
+          <new project="home:other_package_test_user" package="branch_test_package" rev="8" srcmd5="1cbc5d6e148177dbd287922fecddaddf" />
+          <files />
+          <issues>
+          </issues>
+        </sourcediff>
+    http_version: 
+  recorded_at: Tue, 16 Jan 2018 14:00:45 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:other_package_test_user/branch_test_package
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '308'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="branch_test_package" rev="8" vrev="8" srcmd5="1cbc5d6e148177dbd287922fecddaddf">
+          <entry name="_config" md5="0c4c349b107fb2231b7e058f19ea7d06" size="166" mtime="1516111242" />
+          <entry name="somefile.txt" md5="478bacb4eb86846967edfa64ec6a5f9a" size="172" mtime="1516111242" />
+        </directory>
+    http_version: 
+  recorded_at: Tue, 16 Jan 2018 14:00:45 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:other_package_test_user/branch_test_package?expand=1&rev=8
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '308'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="branch_test_package" rev="8" vrev="8" srcmd5="1cbc5d6e148177dbd287922fecddaddf">
+          <entry name="_config" md5="0c4c349b107fb2231b7e058f19ea7d06" size="166" mtime="1516111242" />
+          <entry name="somefile.txt" md5="478bacb4eb86846967edfa64ec6a5f9a" size="172" mtime="1516111242" />
+        </directory>
+    http_version: 
+  recorded_at: Tue, 16 Jan 2018 14:00:45 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:other_package_test_user/branch_test_package
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - text/plain
+      Accept-Encoding:
+      - identity
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '308'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="branch_test_package" rev="8" vrev="8" srcmd5="1cbc5d6e148177dbd287922fecddaddf">
+          <entry name="_config" md5="0c4c349b107fb2231b7e058f19ea7d06" size="166" mtime="1516111242" />
+          <entry name="somefile.txt" md5="478bacb4eb86846967edfa64ec6a5f9a" size="172" mtime="1516111242" />
+        </directory>
+    http_version: 
+  recorded_at: Tue, 16 Jan 2018 14:00:45 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:other_package_test_user/branch_test_package/_service
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - text/plain
+      Accept-Encoding:
+      - identity
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 404
+      message: _service  no such file
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '122'
+    body:
+      encoding: UTF-8
+      string: |
+        <status code="404">
+          <summary>_service: no such file</summary>
+          <details>404 _service: no such file</details>
+        </status>
+    http_version: 
+  recorded_at: Tue, 16 Jan 2018 14:00:45 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:other_package_test_user/branch_test_package/_history
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '1487'
+    body:
+      encoding: UTF-8
+      string: |
+        <revisionlist>
+          <revision rev="1" vrev="1">
+            <srcmd5>c211fa8e0ecbddb0e43c6354cd2ddc99</srcmd5>
+            <version>unknown</version>
+            <time>1516111046</time>
+            <user>unknown</user>
+          </revision>
+          <revision rev="2" vrev="2">
+            <srcmd5>cd0ca6cb388a8fe2c4ca194f705a406f</srcmd5>
+            <version>unknown</version>
+            <time>1516111046</time>
+            <user>unknown</user>
+          </revision>
+          <revision rev="3" vrev="3">
+            <srcmd5>c7661241d46ab4d3107f558906ba8499</srcmd5>
+            <version>unknown</version>
+            <time>1516111048</time>
+            <user>unknown</user>
+          </revision>
+          <revision rev="4" vrev="4">
+            <srcmd5>c7661241d46ab4d3107f558906ba8499</srcmd5>
+            <version>unknown</version>
+            <time>1516111048</time>
+            <user>unknown</user>
+          </revision>
+          <revision rev="5" vrev="5">
+            <srcmd5>09e5d891f18466e6c5f36c3c6b39f5cb</srcmd5>
+            <version>unknown</version>
+            <time>1516111080</time>
+            <user>unknown</user>
+          </revision>
+          <revision rev="6" vrev="6">
+            <srcmd5>09e5d891f18466e6c5f36c3c6b39f5cb</srcmd5>
+            <version>unknown</version>
+            <time>1516111080</time>
+            <user>unknown</user>
+          </revision>
+          <revision rev="7" vrev="7">
+            <srcmd5>2c5620272ba1a91887c04cf7b9babcb7</srcmd5>
+            <version>unknown</version>
+            <time>1516111242</time>
+            <user>unknown</user>
+          </revision>
+          <revision rev="8" vrev="8">
+            <srcmd5>1cbc5d6e148177dbd287922fecddaddf</srcmd5>
+            <version>unknown</version>
+            <time>1516111242</time>
+            <user>unknown</user>
+          </revision>
+        </revisionlist>
+    http_version: 
+  recorded_at: Tue, 16 Jan 2018 14:00:45 GMT
+- request:
+    method: get
+    uri: http://backend:5352/build/home:other_package_test_user/_result?package=branch_test_package&view=status
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - text/plain
+      Accept-Encoding:
+      - identity
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '56'
+    body:
+      encoding: UTF-8
+      string: '<resultlist state="00000000000000000000000000000000" />
+
+'
+    http_version: 
+  recorded_at: Tue, 16 Jan 2018 14:00:45 GMT
+- request:
+    method: post
+    uri: http://backend:5352/source/home:other_package_test_user/branch_test_package?cmd=diff&expand=1&filelimit=0&rev=0&view=xml
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Content-Type:
+      - application/octet-stream
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '1076'
+    body:
+      encoding: UTF-8
+      string: |
+        <sourcediff key="f2be0d6978e8b176ae1e418d300ca2de">
+          <old project="home:other_package_test_user" package="branch_test_package" rev="8" srcmd5="1cbc5d6e148177dbd287922fecddaddf" />
+          <new project="home:other_package_test_user" package="branch_test_package" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e" />
+          <files>
+            <file state="deleted">
+              <old name="_config" md5="0c4c349b107fb2231b7e058f19ea7d06" size="166" />
+              <diff lines="3">@@ -1,1 +0,0 @@
+        -Tenetur ut ab aliquam. Voluptas nihil enim. Eum voluptas sunt voluptas alias laboriosam exercitationem. Autem veniam voluptate earum. Sit quam expedita in sint neque.
+        \ No newline at end of file
+        </diff>
+            </file>
+            <file state="deleted">
+              <old name="somefile.txt" md5="478bacb4eb86846967edfa64ec6a5f9a" size="172" />
+              <diff lines="3">@@ -1,1 +0,0 @@
+        -Officia quia repellendus quis. Velit ullam et. Praesentium dolorem quos quae dolorum illum libero sit. Culpa officia autem voluptatem assumenda. Officiis repudiandae et in.
+        \ No newline at end of file
+        </diff>
+            </file>
+          </files>
+        </sourcediff>
+    http_version: 
+  recorded_at: Tue, 16 Jan 2018 14:00:46 GMT
+- request:
+    method: post
+    uri: http://backend:5352/source/home:other_package_test_user/branch_test_package?cmd=diff&expand=1&filelimit=0&rev=0&view=xml
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Content-Type:
+      - application/octet-stream
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Content-Length:
+      - '1076'
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+    body:
+      encoding: UTF-8
+      string: |
+        <sourcediff key="f2be0d6978e8b176ae1e418d300ca2de">
+          <old project="home:other_package_test_user" package="branch_test_package" rev="8" srcmd5="1cbc5d6e148177dbd287922fecddaddf" />
+          <new project="home:other_package_test_user" package="branch_test_package" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e" />
+          <files>
+            <file state="deleted">
+              <old name="_config" md5="0c4c349b107fb2231b7e058f19ea7d06" size="166" />
+              <diff lines="3">@@ -1,1 +0,0 @@
+        -Tenetur ut ab aliquam. Voluptas nihil enim. Eum voluptas sunt voluptas alias laboriosam exercitationem. Autem veniam voluptate earum. Sit quam expedita in sint neque.
+        \ No newline at end of file
+        </diff>
+            </file>
+            <file state="deleted">
+              <old name="somefile.txt" md5="478bacb4eb86846967edfa64ec6a5f9a" size="172" />
+              <diff lines="3">@@ -1,1 +0,0 @@
+        -Officia quia repellendus quis. Velit ullam et. Praesentium dolorem quos quae dolorum illum libero sit. Culpa officia autem voluptatem assumenda. Officiis repudiandae et in.
+        \ No newline at end of file
+        </diff>
+            </file>
+          </files>
+        </sourcediff>
+    http_version: 
+  recorded_at: Tue, 16 Jan 2018 14:00:46 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:package_test_user/test_package/_meta?user=package_test_user
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="test_package" project="home:package_test_user">
+          <title>Death Be Not Proud</title>
+          <description>Omnis earum ut culpa.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '161'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="test_package" project="home:package_test_user">
+          <title>Death Be Not Proud</title>
+          <description>Omnis earum ut culpa.</description>
+        </package>
+    http_version: 
+  recorded_at: Tue, 16 Jan 2018 14:03:13 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:other_package_test_user/branch_test_package/_meta?user=package_test_user
+    body:
+      encoding: UTF-8
+      string: |
         <package name="branch_test_package" project="home:other_package_test_user">
-          <title>The Lathe of Heaven</title>
-          <description>Ratione repudiandae incidunt eos saepe.</description>
+          <title>The Line of Beauty</title>
+          <description>Voluptatem aut nemo eius minima ipsam et.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '194'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="branch_test_package" project="home:other_package_test_user">
+          <title>The Line of Beauty</title>
+          <description>Voluptatem aut nemo eius minima ipsam et.</description>
         </package>
     http_version: 
   recorded_at: Wed, 03 Jan 2018 13:12:51 GMT

--- a/src/api/spec/cassettes/Packages/triggering_package_rebuild/via_binaries_view.yml
+++ b/src/api/spec/cassettes/Packages/triggering_package_rebuild/via_binaries_view.yml
@@ -40,16 +40,16 @@ http_interactions:
           <person userid="package_test_user" role="maintainer" />
         </project>
     http_version: 
-  recorded_at: Tue, 29 Aug 2017 12:41:37 GMT
+  recorded_at: Tue, 16 Jan 2018 14:01:45 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:package_test_user/test_package/_meta?user=_nobody_
+    uri: http://backend:5352/source/home:package_test_user/test_package/_meta?user=package_test_user
     body:
       encoding: UTF-8
       string: |
         <package name="test_package" project="home:package_test_user">
-          <title>To Say Nothing of the Dog</title>
-          <description>Id ullam quaerat dolor fuga consequatur dolores occaecati.</description>
+          <title>Stranger in a Strange Land</title>
+          <description>Odio voluptas quam qui aspernatur quia qui.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -70,16 +70,16 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '205'
+      - '191'
     body:
       encoding: UTF-8
       string: |
         <package name="test_package" project="home:package_test_user">
-          <title>To Say Nothing of the Dog</title>
-          <description>Id ullam quaerat dolor fuga consequatur dolores occaecati.</description>
+          <title>Stranger in a Strange Land</title>
+          <description>Odio voluptas quam qui aspernatur quia qui.</description>
         </package>
     http_version: 
-  recorded_at: Tue, 29 Aug 2017 12:41:38 GMT
+  recorded_at: Tue, 16 Jan 2018 14:01:45 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:package_test_user/test_package/_meta
@@ -87,8 +87,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="test_package" project="home:package_test_user">
-          <title>To Say Nothing of the Dog</title>
-          <description>Id ullam quaerat dolor fuga consequatur dolores occaecati.</description>
+          <title>Stranger in a Strange Land</title>
+          <description>Odio voluptas quam qui aspernatur quia qui.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -109,23 +109,23 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '205'
+      - '191'
     body:
       encoding: UTF-8
       string: |
         <package name="test_package" project="home:package_test_user">
-          <title>To Say Nothing of the Dog</title>
-          <description>Id ullam quaerat dolor fuga consequatur dolores occaecati.</description>
+          <title>Stranger in a Strange Land</title>
+          <description>Odio voluptas quam qui aspernatur quia qui.</description>
         </package>
     http_version: 
-  recorded_at: Tue, 29 Aug 2017 12:41:38 GMT
+  recorded_at: Tue, 16 Jan 2018 14:01:45 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:package_test_user/test_package/_config
     body:
       encoding: UTF-8
-      string: Voluptatum cum possimus facere inventore. Dolores eaque accusamus quia
-        suscipit praesentium magnam et. Placeat ducimus et et dolores.
+      string: Impedit illum sequi. Nam accusantium architecto amet quia ipsum. Iusto
+        fuga quos harum officiis.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -145,29 +145,28 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '207'
+      - '209'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="1" vrev="1">
-          <srcmd5>9ff386f2bb4706133109a554088cd402</srcmd5>
+        <revision rev="22" vrev="22">
+          <srcmd5>0c34e1b7d3a302b69119c838aacb2e22</srcmd5>
           <version>unknown</version>
-          <time>1504010498</time>
+          <time>1516111305</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
     http_version: 
-  recorded_at: Tue, 29 Aug 2017 12:41:38 GMT
+  recorded_at: Tue, 16 Jan 2018 14:01:45 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:package_test_user/test_package/somefile.txt
     body:
       encoding: UTF-8
-      string: Perferendis rerum alias est recusandae non. Fugiat qui voluptatem molestiae
-        nulla iste porro. Ut qui voluptatem dolor soluta ut autem sequi. Explicabo
-        ex qui voluptatem omnis ut. Sapiente dolore nulla consectetur omnis reprehenderit
-        officia iusto.
+      string: Officia quia repellendus quis. Velit ullam et. Praesentium dolorem quos
+        quae dolorum illum libero sit. Culpa officia autem voluptatem assumenda. Officiis
+        repudiandae et in.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -187,20 +186,20 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '207'
+      - '209'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="2" vrev="2">
-          <srcmd5>89e9a957a6fd56e5e236e394a47ec370</srcmd5>
+        <revision rev="23" vrev="23">
+          <srcmd5>0c34e1b7d3a302b69119c838aacb2e22</srcmd5>
           <version>unknown</version>
-          <time>1504010498</time>
+          <time>1516111305</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
     http_version: 
-  recorded_at: Tue, 29 Aug 2017 12:41:38 GMT
+  recorded_at: Tue, 16 Jan 2018 14:01:45 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:other_package_test_user/_meta?user=other_package_test_user
@@ -241,16 +240,16 @@ http_interactions:
           <person userid="other_package_test_user" role="maintainer" />
         </project>
     http_version: 
-  recorded_at: Tue, 29 Aug 2017 12:41:38 GMT
+  recorded_at: Tue, 16 Jan 2018 14:01:45 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:other_package_test_user/branch_test_package/_meta?user=_nobody_
+    uri: http://backend:5352/source/home:other_package_test_user/branch_test_package/_meta?user=package_test_user
     body:
       encoding: UTF-8
       string: |
         <package name="branch_test_package" project="home:other_package_test_user">
-          <title>Little Hands Clapping</title>
-          <description>Cumque aut vel nam quas porro.</description>
+          <title>Arms and the Man</title>
+          <description>Non commodi id voluptatem at optio maiores.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -271,16 +270,16 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '186'
+      - '194'
     body:
       encoding: UTF-8
       string: |
         <package name="branch_test_package" project="home:other_package_test_user">
-          <title>Little Hands Clapping</title>
-          <description>Cumque aut vel nam quas porro.</description>
+          <title>Arms and the Man</title>
+          <description>Non commodi id voluptatem at optio maiores.</description>
         </package>
     http_version: 
-  recorded_at: Tue, 29 Aug 2017 12:41:38 GMT
+  recorded_at: Tue, 16 Jan 2018 14:01:46 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:other_package_test_user/branch_test_package/_meta
@@ -288,8 +287,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="branch_test_package" project="home:other_package_test_user">
-          <title>Little Hands Clapping</title>
-          <description>Cumque aut vel nam quas porro.</description>
+          <title>Arms and the Man</title>
+          <description>Non commodi id voluptatem at optio maiores.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -310,24 +309,24 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '186'
+      - '194'
     body:
       encoding: UTF-8
       string: |
         <package name="branch_test_package" project="home:other_package_test_user">
-          <title>Little Hands Clapping</title>
-          <description>Cumque aut vel nam quas porro.</description>
+          <title>Arms and the Man</title>
+          <description>Non commodi id voluptatem at optio maiores.</description>
         </package>
     http_version: 
-  recorded_at: Tue, 29 Aug 2017 12:41:38 GMT
+  recorded_at: Tue, 16 Jan 2018 14:01:46 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:other_package_test_user/branch_test_package/_config
     body:
       encoding: UTF-8
-      string: Dignissimos neque nobis ea. Delectus necessitatibus labore a error id
-        omnis assumenda. Aspernatur facere quia similique accusamus omnis. Velit numquam
-        eos neque et itaque.
+      string: Fugit architecto inventore libero ut excepturi. Quo perspiciatis iure
+        numquam voluptatem. Sed cum quibusdam temporibus dolor velit. Quod occaecati
+        repudiandae atque et. Excepturi ad non consectetur similique debitis quis.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -351,23 +350,24 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <revision rev="1" vrev="1">
-          <srcmd5>720d1a1638489c0c0341720e02dc2159</srcmd5>
+        <revision rev="9" vrev="9">
+          <srcmd5>2a982c28559dd8aad6fbe7e46836e458</srcmd5>
           <version>unknown</version>
-          <time>1504010498</time>
+          <time>1516111306</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
     http_version: 
-  recorded_at: Tue, 29 Aug 2017 12:41:38 GMT
+  recorded_at: Tue, 16 Jan 2018 14:01:46 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:other_package_test_user/branch_test_package/somefile.txt
     body:
       encoding: UTF-8
-      string: A exercitationem fuga at et error. Voluptatem in debitis et dolores
-        ratione et. Qui deleniti natus cum ad accusamus.
+      string: Officia quia repellendus quis. Velit ullam et. Praesentium dolorem quos
+        quae dolorum illum libero sit. Culpa officia autem voluptatem assumenda. Officiis
+        repudiandae et in.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -387,20 +387,20 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '207'
+      - '209'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="2" vrev="2">
-          <srcmd5>e8d9dd7e680d0d628e4e6852abadb486</srcmd5>
+        <revision rev="10" vrev="10">
+          <srcmd5>2a982c28559dd8aad6fbe7e46836e458</srcmd5>
           <version>unknown</version>
-          <time>1504010498</time>
+          <time>1516111306</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
     http_version: 
-  recorded_at: Tue, 29 Aug 2017 12:41:38 GMT
+  recorded_at: Tue, 16 Jan 2018 14:01:46 GMT
 - request:
     method: post
     uri: http://backend:5352/build/home:package_test_user?arch=x86_64&cmd=rebuild&package=test_package&repository=package_test_repository
@@ -436,83 +436,5 @@ http_interactions:
           <summary>no repository defined</summary>
         </status>
     http_version: 
-  recorded_at: Tue, 29 Aug 2017 12:41:42 GMT
-- request:
-    method: put
-    uri: http://backend:5352/source/home:package_test_user/test_package/_meta?user=package_test_user
-    body:
-      encoding: UTF-8
-      string: |
-        <package name="test_package" project="home:package_test_user">
-          <title>The Other Side of Silence</title>
-          <description>Magnam et laudantium recusandae.</description>
-        </package>
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '179'
-    body:
-      encoding: UTF-8
-      string: |
-        <package name="test_package" project="home:package_test_user">
-          <title>The Other Side of Silence</title>
-          <description>Magnam et laudantium recusandae.</description>
-        </package>
-    http_version: 
-  recorded_at: Wed, 03 Jan 2018 13:17:12 GMT
-- request:
-    method: put
-    uri: http://backend:5352/source/home:other_package_test_user/branch_test_package/_meta?user=package_test_user
-    body:
-      encoding: UTF-8
-      string: |
-        <package name="branch_test_package" project="home:other_package_test_user">
-          <title>The Monkey's Raincoat</title>
-          <description>Eligendi animi explicabo et nemo in ut.</description>
-        </package>
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '195'
-    body:
-      encoding: UTF-8
-      string: |
-        <package name="branch_test_package" project="home:other_package_test_user">
-          <title>The Monkey's Raincoat</title>
-          <description>Eligendi animi explicabo et nemo in ut.</description>
-        </package>
-    http_version: 
-  recorded_at: Wed, 03 Jan 2018 13:17:13 GMT
+  recorded_at: Tue, 16 Jan 2018 14:01:47 GMT
 recorded_with: VCR 4.0.0

--- a/src/api/spec/cassettes/Packages/triggering_package_rebuild/via_live_build_log.yml
+++ b/src/api/spec/cassettes/Packages/triggering_package_rebuild/via_live_build_log.yml
@@ -40,7 +40,7 @@ http_interactions:
           <person userid="package_test_user" role="maintainer" />
         </project>
     http_version: 
-  recorded_at: Tue, 29 Aug 2017 12:41:44 GMT
+  recorded_at: Tue, 16 Jan 2018 14:01:47 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:package_test_user/test_package/_meta?user=package_test_user
@@ -48,8 +48,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="test_package" project="home:package_test_user">
-          <title>O Pioneers!</title>
-          <description>Repellendus nisi quisquam similique.</description>
+          <title>In Dubious Battle</title>
+          <description>Alias nulla dignissimos deserunt enim accusamus.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -70,16 +70,16 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '169'
+      - '187'
     body:
       encoding: UTF-8
       string: |
         <package name="test_package" project="home:package_test_user">
-          <title>O Pioneers!</title>
-          <description>Repellendus nisi quisquam similique.</description>
+          <title>In Dubious Battle</title>
+          <description>Alias nulla dignissimos deserunt enim accusamus.</description>
         </package>
     http_version: 
-  recorded_at: Tue, 29 Aug 2017 12:41:44 GMT
+  recorded_at: Tue, 16 Jan 2018 14:01:47 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:package_test_user/test_package/_meta
@@ -87,8 +87,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="test_package" project="home:package_test_user">
-          <title>O Pioneers!</title>
-          <description>Repellendus nisi quisquam similique.</description>
+          <title>In Dubious Battle</title>
+          <description>Alias nulla dignissimos deserunt enim accusamus.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -109,23 +109,23 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '169'
+      - '187'
     body:
       encoding: UTF-8
       string: |
         <package name="test_package" project="home:package_test_user">
-          <title>O Pioneers!</title>
-          <description>Repellendus nisi quisquam similique.</description>
+          <title>In Dubious Battle</title>
+          <description>Alias nulla dignissimos deserunt enim accusamus.</description>
         </package>
     http_version: 
-  recorded_at: Tue, 29 Aug 2017 12:41:44 GMT
+  recorded_at: Tue, 16 Jan 2018 14:01:48 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:package_test_user/test_package/_config
     body:
       encoding: UTF-8
-      string: Et sint maiores. Nulla minus fugiat sed esse autem. Commodi magni error
-        facere.
+      string: Ex provident velit dignissimos. Expedita velit est. Quidem qui laboriosam
+        iste.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -145,27 +145,28 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '207'
+      - '209'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="3" vrev="3">
-          <srcmd5>7e01aedaf0a2d170443e532710a970f0</srcmd5>
+        <revision rev="24" vrev="24">
+          <srcmd5>6971a68e85941fe035670cab7224fa2b</srcmd5>
           <version>unknown</version>
-          <time>1504010504</time>
+          <time>1516111308</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
     http_version: 
-  recorded_at: Tue, 29 Aug 2017 12:41:44 GMT
+  recorded_at: Tue, 16 Jan 2018 14:01:48 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:package_test_user/test_package/somefile.txt
     body:
       encoding: UTF-8
-      string: Et ratione qui soluta est. Voluptas qui ratione dicta et repellendus.
-        Mollitia dolor cupiditate.
+      string: Officia quia repellendus quis. Velit ullam et. Praesentium dolorem quos
+        quae dolorum illum libero sit. Culpa officia autem voluptatem assumenda. Officiis
+        repudiandae et in.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -185,20 +186,20 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '207'
+      - '209'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="4" vrev="4">
-          <srcmd5>b276f9d3417285f84032fc7eab4c0cae</srcmd5>
+        <revision rev="25" vrev="25">
+          <srcmd5>6971a68e85941fe035670cab7224fa2b</srcmd5>
           <version>unknown</version>
-          <time>1504010504</time>
+          <time>1516111308</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
     http_version: 
-  recorded_at: Tue, 29 Aug 2017 12:41:44 GMT
+  recorded_at: Tue, 16 Jan 2018 14:01:48 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:other_package_test_user/_meta?user=other_package_test_user
@@ -239,7 +240,7 @@ http_interactions:
           <person userid="other_package_test_user" role="maintainer" />
         </project>
     http_version: 
-  recorded_at: Tue, 29 Aug 2017 12:41:44 GMT
+  recorded_at: Tue, 16 Jan 2018 14:01:48 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:other_package_test_user/branch_test_package/_meta?user=package_test_user
@@ -247,8 +248,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="branch_test_package" project="home:other_package_test_user">
-          <title>The Widening Gyre</title>
-          <description>Neque placeat necessitatibus delectus quis voluptatem.</description>
+          <title>The Stars' Tennis Balls</title>
+          <description>Est dolorem corrupti veniam sed.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -269,16 +270,16 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '206'
+      - '190'
     body:
       encoding: UTF-8
       string: |
         <package name="branch_test_package" project="home:other_package_test_user">
-          <title>The Widening Gyre</title>
-          <description>Neque placeat necessitatibus delectus quis voluptatem.</description>
+          <title>The Stars' Tennis Balls</title>
+          <description>Est dolorem corrupti veniam sed.</description>
         </package>
     http_version: 
-  recorded_at: Tue, 29 Aug 2017 12:41:44 GMT
+  recorded_at: Tue, 16 Jan 2018 14:01:48 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:other_package_test_user/branch_test_package/_meta
@@ -286,8 +287,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="branch_test_package" project="home:other_package_test_user">
-          <title>The Widening Gyre</title>
-          <description>Neque placeat necessitatibus delectus quis voluptatem.</description>
+          <title>The Stars' Tennis Balls</title>
+          <description>Est dolorem corrupti veniam sed.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -308,24 +309,24 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '206'
+      - '190'
     body:
       encoding: UTF-8
       string: |
         <package name="branch_test_package" project="home:other_package_test_user">
-          <title>The Widening Gyre</title>
-          <description>Neque placeat necessitatibus delectus quis voluptatem.</description>
+          <title>The Stars' Tennis Balls</title>
+          <description>Est dolorem corrupti veniam sed.</description>
         </package>
     http_version: 
-  recorded_at: Tue, 29 Aug 2017 12:41:44 GMT
+  recorded_at: Tue, 16 Jan 2018 14:01:48 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:other_package_test_user/branch_test_package/_config
     body:
       encoding: UTF-8
-      string: Error fugit ut odio a. Veniam optio labore est in. Dolorem sit officia
-        hic. Iusto laborum aut odit reiciendis accusamus optio autem. Quos ducimus
-        odio quas soluta.
+      string: Nesciunt ducimus fugit et et qui mollitia. Asperiores quibusdam et.
+        Adipisci vero dolor cumque ut eos. Eos ut ipsa unde earum ut quis. Itaque
+        natus beatae perferendis facilis.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -345,27 +346,28 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '207'
+      - '209'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="3" vrev="3">
-          <srcmd5>41067ab8bc8b37552536e0f5abe691c2</srcmd5>
+        <revision rev="11" vrev="11">
+          <srcmd5>036a47ea8b014dc89ec1544921b9ad4c</srcmd5>
           <version>unknown</version>
-          <time>1504010504</time>
+          <time>1516111308</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
     http_version: 
-  recorded_at: Tue, 29 Aug 2017 12:41:44 GMT
+  recorded_at: Tue, 16 Jan 2018 14:01:48 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:other_package_test_user/branch_test_package/somefile.txt
     body:
       encoding: UTF-8
-      string: Fugiat autem aspernatur illum a in. Amet ratione dolor a quo. Ipsum
-        magnam incidunt. Perferendis at eos sit. Nemo deserunt nihil molestiae.
+      string: Officia quia repellendus quis. Velit ullam et. Praesentium dolorem quos
+        quae dolorum illum libero sit. Culpa officia autem voluptatem assumenda. Officiis
+        repudiandae et in.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -385,20 +387,20 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '207'
+      - '209'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="4" vrev="4">
-          <srcmd5>86949eda263372da87396df95092f9be</srcmd5>
+        <revision rev="12" vrev="12">
+          <srcmd5>036a47ea8b014dc89ec1544921b9ad4c</srcmd5>
           <version>unknown</version>
-          <time>1504010504</time>
+          <time>1516111308</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
     http_version: 
-  recorded_at: Tue, 29 Aug 2017 12:41:44 GMT
+  recorded_at: Tue, 16 Jan 2018 14:01:48 GMT
 - request:
     method: get
     uri: http://backend:5352/build/home:package_test_user/package_test_repository/x86_64/test_package/_jobstatus
@@ -406,10 +408,8 @@ http_interactions:
       encoding: US-ASCII
       string: ''
     headers:
-      Content-Type:
-      - text/plain
       Accept-Encoding:
-      - identity
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
       - "*/*"
       User-Agent:
@@ -435,7 +435,7 @@ http_interactions:
           <details>404 project 'home:package_test_user' has no repository 'package_test_repository'</details>
         </status>
     http_version: 
-  recorded_at: Tue, 29 Aug 2017 12:41:45 GMT
+  recorded_at: Tue, 16 Jan 2018 14:01:48 GMT
 - request:
     method: get
     uri: http://backend:5352/build/home:package_test_user/package_test_repository/x86_64/test_package/_log?view=entry
@@ -443,10 +443,8 @@ http_interactions:
       encoding: US-ASCII
       string: ''
     headers:
-      Content-Type:
-      - text/plain
       Accept-Encoding:
-      - identity
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
       - "*/*"
       User-Agent:
@@ -472,7 +470,7 @@ http_interactions:
           <details>404 project 'home:package_test_user' has no repository 'package_test_repository'</details>
         </status>
     http_version: 
-  recorded_at: Tue, 29 Aug 2017 12:41:45 GMT
+  recorded_at: Tue, 16 Jan 2018 14:01:49 GMT
 - request:
     method: get
     uri: http://backend:5352/build/home:package_test_user/package_test_repository/x86_64/test_package/_log?end=65536&nostream=1&start=0
@@ -480,10 +478,8 @@ http_interactions:
       encoding: US-ASCII
       string: ''
     headers:
-      Content-Type:
-      - text/plain
       Accept-Encoding:
-      - identity
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
       - "*/*"
       User-Agent:
@@ -509,7 +505,7 @@ http_interactions:
           <details>404 project 'home:package_test_user' has no repository 'package_test_repository'</details>
         </status>
     http_version: 
-  recorded_at: Tue, 29 Aug 2017 12:41:45 GMT
+  recorded_at: Tue, 16 Jan 2018 14:01:49 GMT
 - request:
     method: post
     uri: http://backend:5352/build/home:package_test_user?arch=x86_64&cmd=rebuild&package=test_package&repository=package_test_repository
@@ -545,7 +541,7 @@ http_interactions:
           <summary>no repository defined</summary>
         </status>
     http_version: 
-  recorded_at: Tue, 29 Aug 2017 12:41:45 GMT
+  recorded_at: Tue, 16 Jan 2018 14:01:49 GMT
 - request:
     method: get
     uri: http://backend:5352/build/home:package_test_user/_result?package=test_package&repository=package_test_repository&view=status
@@ -582,83 +578,5 @@ http_interactions:
           <details>404 unknown repository 'package_test_repository'</details>
         </status>
     http_version: 
-  recorded_at: Tue, 29 Aug 2017 12:41:45 GMT
-- request:
-    method: put
-    uri: http://backend:5352/source/home:package_test_user/test_package/_meta?user=user_tab_user
-    body:
-      encoding: UTF-8
-      string: |
-        <package name="test_package" project="home:package_test_user">
-          <title>Brandy of the Damned</title>
-          <description>Voluptas vel nihil error.</description>
-        </package>
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '167'
-    body:
-      encoding: UTF-8
-      string: |
-        <package name="test_package" project="home:package_test_user">
-          <title>Brandy of the Damned</title>
-          <description>Voluptas vel nihil error.</description>
-        </package>
-    http_version: 
-  recorded_at: Wed, 03 Jan 2018 13:17:01 GMT
-- request:
-    method: put
-    uri: http://backend:5352/source/home:other_package_test_user/branch_test_package/_meta?user=user_tab_user
-    body:
-      encoding: UTF-8
-      string: |
-        <package name="branch_test_package" project="home:other_package_test_user">
-          <title>Paths of Glory</title>
-          <description>Qui soluta reiciendis ex fuga.</description>
-        </package>
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '179'
-    body:
-      encoding: UTF-8
-      string: |
-        <package name="branch_test_package" project="home:other_package_test_user">
-          <title>Paths of Glory</title>
-          <description>Qui soluta reiciendis ex fuga.</description>
-        </package>
-    http_version: 
-  recorded_at: Wed, 03 Jan 2018 13:17:01 GMT
+  recorded_at: Tue, 16 Jan 2018 14:01:49 GMT
 recorded_with: VCR 4.0.0

--- a/src/api/spec/cassettes/Projects/branching/a_package_and_select_current_revision.yml
+++ b/src/api/spec/cassettes/Projects/branching/a_package_and_select_current_revision.yml
@@ -542,7 +542,7 @@ http_interactions:
   recorded_at: Wed, 28 Dec 2016 12:37:21 GMT
 - request:
     method: post
-    uri: http://backend:5352/source/home:Jane/branch_test_package?cmd=branch&opackage=branch_test_package&oproject=home:other_user&orev=2b2438f74ba72c60e01836dadcfd8b71&user=Jane
+    uri: http://backend:5352/source/home:Jane/branch_test_package?cmd=branch&noservice=1&opackage=branch_test_package&oproject=home:other_user&orev=2b2438f74ba72c60e01836dadcfd8b71&user=Jane
     body:
       encoding: UTF-8
       string: ''

--- a/src/api/spec/cassettes/Projects/branching/an_existing_package.yml
+++ b/src/api/spec/cassettes/Projects/branching/an_existing_package.yml
@@ -347,7 +347,7 @@ http_interactions:
   recorded_at: Wed, 25 May 2016 17:07:26 GMT
 - request:
     method: post
-    uri: http://backend:5352/source/home:Jane/branch_test_package?cmd=branch&opackage=branch_test_package&oproject=home:other_user&user=Jane
+    uri: http://backend:5352/source/home:Jane/branch_test_package?cmd=branch&noservice=1&opackage=branch_test_package&oproject=home:other_user&user=Jane
     body:
       encoding: UTF-8
       string: ''

--- a/src/api/spec/cassettes/Projects/branching/an_existing_package_but_chose_a_different_target_package_name.yml
+++ b/src/api/spec/cassettes/Projects/branching/an_existing_package_but_chose_a_different_target_package_name.yml
@@ -346,7 +346,7 @@ http_interactions:
   recorded_at: Wed, 25 May 2016 17:07:15 GMT
 - request:
     method: post
-    uri: http://backend:5352/source/home:Jane/some_different_name?cmd=branch&opackage=branch_test_package&oproject=home:other_user&user=Jane
+    uri: http://backend:5352/source/home:Jane/some_different_name?cmd=branch&noservice=1&opackage=branch_test_package&oproject=home:other_user&user=Jane
     body:
       encoding: UTF-8
       string: ''

--- a/src/api/spec/cassettes/Requests/for_role_addition/for_packages/can_be_accepted.yml
+++ b/src/api/spec/cassettes/Requests/for_role_addition/for_packages/can_be_accepted.yml
@@ -40,7 +40,7 @@ http_interactions:
           <person userid="kugelblitz" role="maintainer" />
         </project>
     http_version: 
-  recorded_at: Tue, 12 Apr 2016 15:07:17 GMT
+  recorded_at: Mon, 05 Feb 2018 12:07:58 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:titan/_meta?user=titan
@@ -81,7 +81,7 @@ http_interactions:
           <person userid="titan" role="maintainer" />
         </project>
     http_version: 
-  recorded_at: Tue, 12 Apr 2016 15:07:17 GMT
+  recorded_at: Mon, 05 Feb 2018 12:07:58 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:titan/goal/_meta?user=_nobody_
@@ -89,8 +89,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="goal" project="home:titan">
-          <title/>
-          <description/>
+          <title>A Farewell to Arms</title>
+          <description>Rerum eaque qui nihil voluptas fugiat laudantium nemo et.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -111,25 +111,25 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '102'
+      - '177'
     body:
       encoding: UTF-8
       string: |
         <package name="goal" project="home:titan">
-          <title></title>
-          <description></description>
+          <title>A Farewell to Arms</title>
+          <description>Rerum eaque qui nihil voluptas fugiat laudantium nemo et.</description>
         </package>
     http_version: 
-  recorded_at: Tue, 12 Apr 2016 15:07:17 GMT
+  recorded_at: Mon, 05 Feb 2018 12:07:58 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:kugelblitz/ball/_meta?user=_nobody_
+    uri: http://backend:5352/source/home:titan/goal/_meta
     body:
       encoding: UTF-8
       string: |
-        <package name="ball" project="home:kugelblitz">
-          <title/>
-          <description/>
+        <package name="goal" project="home:titan">
+          <title>A Farewell to Arms</title>
+          <description>Rerum eaque qui nihil voluptas fugiat laudantium nemo et.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -150,16 +150,16 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '107'
+      - '177'
     body:
       encoding: UTF-8
       string: |
-        <package name="ball" project="home:kugelblitz">
-          <title></title>
-          <description></description>
+        <package name="goal" project="home:titan">
+          <title>A Farewell to Arms</title>
+          <description>Rerum eaque qui nihil voluptas fugiat laudantium nemo et.</description>
         </package>
     http_version: 
-  recorded_at: Tue, 12 Apr 2016 15:07:17 GMT
+  recorded_at: Mon, 05 Feb 2018 12:07:58 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:titan/goal/_meta?comment=add_role%20request%201&requestid=1&user=titan
@@ -167,8 +167,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="goal" project="home:titan">
-          <title/>
-          <description/>
+          <title>A Farewell to Arms</title>
+          <description>Rerum eaque qui nihil voluptas fugiat laudantium nemo et.</description>
           <person userid="kugelblitz" role="maintainer"/>
         </package>
     headers:
@@ -190,15 +190,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '153'
+      - '228'
     body:
       encoding: UTF-8
       string: |
         <package name="goal" project="home:titan">
-          <title></title>
-          <description></description>
+          <title>A Farewell to Arms</title>
+          <description>Rerum eaque qui nihil voluptas fugiat laudantium nemo et.</description>
           <person userid="kugelblitz" role="maintainer" />
         </package>
     http_version: 
-  recorded_at: Tue, 12 Apr 2016 15:07:19 GMT
-recorded_with: VCR 3.0.1
+  recorded_at: Mon, 05 Feb 2018 12:08:00 GMT
+recorded_with: VCR 4.0.0

--- a/src/api/spec/cassettes/Requests/for_role_addition/for_packages/can_be_submitted.yml
+++ b/src/api/spec/cassettes/Requests/for_role_addition/for_packages/can_be_submitted.yml
@@ -40,7 +40,7 @@ http_interactions:
           <person userid="kugelblitz" role="maintainer" />
         </project>
     http_version: 
-  recorded_at: Tue, 12 Apr 2016 15:07:24 GMT
+  recorded_at: Mon, 05 Feb 2018 12:07:56 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:titan/_meta?user=titan
@@ -81,16 +81,16 @@ http_interactions:
           <person userid="titan" role="maintainer" />
         </project>
     http_version: 
-  recorded_at: Tue, 12 Apr 2016 15:07:24 GMT
+  recorded_at: Mon, 05 Feb 2018 12:07:56 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:titan/goal/_meta?user=_nobody_
+    uri: http://backend:5352/source/home:titan/goal/_meta?user=kugelblitz
     body:
       encoding: UTF-8
       string: |
         <package name="goal" project="home:titan">
-          <title/>
-          <description/>
+          <title>The Man Within</title>
+          <description>Fugiat dignissimos aliquam commodi.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -111,25 +111,25 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '102'
+      - '151'
     body:
       encoding: UTF-8
       string: |
         <package name="goal" project="home:titan">
-          <title></title>
-          <description></description>
+          <title>The Man Within</title>
+          <description>Fugiat dignissimos aliquam commodi.</description>
         </package>
     http_version: 
-  recorded_at: Tue, 12 Apr 2016 15:07:24 GMT
+  recorded_at: Mon, 05 Feb 2018 12:07:56 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:kugelblitz/ball/_meta?user=_nobody_
+    uri: http://backend:5352/source/home:titan/goal/_meta
     body:
       encoding: UTF-8
       string: |
-        <package name="ball" project="home:kugelblitz">
-          <title/>
-          <description/>
+        <package name="goal" project="home:titan">
+          <title>The Man Within</title>
+          <description>Fugiat dignissimos aliquam commodi.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -150,54 +150,19 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '107'
+      - '151'
     body:
       encoding: UTF-8
       string: |
-        <package name="ball" project="home:kugelblitz">
-          <title></title>
-          <description></description>
+        <package name="goal" project="home:titan">
+          <title>The Man Within</title>
+          <description>Fugiat dignissimos aliquam commodi.</description>
         </package>
     http_version: 
-  recorded_at: Tue, 12 Apr 2016 15:07:24 GMT
+  recorded_at: Mon, 05 Feb 2018 12:07:56 GMT
 - request:
     method: get
-    uri: http://backend:5352/build/home:titan/_result?package=goal&view=status
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Content-Type:
-      - text/plain
-      Accept-Encoding:
-      - identity
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '56'
-    body:
-      encoding: UTF-8
-      string: '<resultlist state="00000000000000000000000000000000" />
-
-'
-    http_version: 
-  recorded_at: Tue, 12 Apr 2016 15:07:25 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/home:titan/goal?nofilename=1&view=info&withchangesmd5=1
+    uri: http://backend:5352/source/home:titan/goal?view=info
     body:
       encoding: US-ASCII
       string: ''
@@ -220,15 +185,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '142'
+      - '120'
     body:
       encoding: UTF-8
       string: |
-        <sourceinfo package="goal" srcmd5="d41d8cd98f00b204e9800998ecf8427e" verifymd5="d41d8cd98f00b204e9800998ecf8427e">
-          <revtime/>
+        <sourceinfo package="goal" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
+          <error>no source uploaded</error>
         </sourceinfo>
     http_version: 
-  recorded_at: Tue, 12 Apr 2016 15:07:25 GMT
+  recorded_at: Mon, 05 Feb 2018 12:07:56 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:titan/goal
@@ -261,7 +226,7 @@ http_interactions:
         <directory name="goal" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
         </directory>
     http_version: 
-  recorded_at: Tue, 12 Apr 2016 15:07:25 GMT
+  recorded_at: Mon, 05 Feb 2018 12:07:56 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:titan/goal?cmd=diff&linkrev=base&onlyissues=1&orev=0&view=xml
@@ -293,13 +258,13 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="a85a4371390da3396934b393e06db648">
+        <sourcediff key="cd06a9511b642c96cd8df241ef1d8e93">
           <old project="home:titan" package="goal" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e" />
           <new project="home:titan" package="goal" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e" />
           <files />
         </sourcediff>
     http_version: 
-  recorded_at: Tue, 12 Apr 2016 15:07:25 GMT
+  recorded_at: Mon, 05 Feb 2018 12:07:56 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:titan/goal
@@ -332,7 +297,7 @@ http_interactions:
         <directory name="goal" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
         </directory>
     http_version: 
-  recorded_at: Tue, 12 Apr 2016 15:07:25 GMT
+  recorded_at: Mon, 05 Feb 2018 12:07:57 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:titan/goal?expand=1
@@ -340,10 +305,8 @@ http_interactions:
       encoding: US-ASCII
       string: ''
     headers:
-      Content-Type:
-      - text/plain
       Accept-Encoding:
-      - identity
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
       - "*/*"
       User-Agent:
@@ -367,7 +330,7 @@ http_interactions:
         <directory name="goal" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
         </directory>
     http_version: 
-  recorded_at: Tue, 12 Apr 2016 15:07:25 GMT
+  recorded_at: Mon, 05 Feb 2018 12:07:57 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:titan/goal
@@ -402,77 +365,7 @@ http_interactions:
         <directory name="goal" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
         </directory>
     http_version: 
-  recorded_at: Tue, 12 Apr 2016 15:07:25 GMT
-- request:
-    method: get
-    uri: http://backend:5352/build/home:titan/_result?package=goal&view=status
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Content-Type:
-      - text/plain
-      Accept-Encoding:
-      - identity
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '56'
-    body:
-      encoding: UTF-8
-      string: '<resultlist state="00000000000000000000000000000000" />
-
-'
-    http_version: 
-  recorded_at: Tue, 12 Apr 2016 15:07:25 GMT
-- request:
-    method: get
-    uri: http://backend:5352/build/home:titan/_result?package=goal&view=status
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Content-Type:
-      - text/plain
-      Accept-Encoding:
-      - identity
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '56'
-    body:
-      encoding: UTF-8
-      string: '<resultlist state="00000000000000000000000000000000" />
-
-'
-    http_version: 
-  recorded_at: Tue, 12 Apr 2016 15:07:25 GMT
+  recorded_at: Mon, 05 Feb 2018 12:07:57 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:titan/goal/_service
@@ -491,7 +384,7 @@ http_interactions:
   response:
     status:
       code: 404
-      message: project 'home titan' does not exist
+      message: _service  no such file
     headers:
       Content-Type:
       - text/xml
@@ -500,19 +393,19 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '148'
+      - '122'
     body:
       encoding: UTF-8
       string: |
         <status code="404">
-          <summary>project 'home:titan' does not exist</summary>
-          <details>404 project 'home:titan' does not exist</details>
+          <summary>_service: no such file</summary>
+          <details>404 _service: no such file</details>
         </status>
     http_version: 
-  recorded_at: Wed, 05 Oct 2016 09:10:00 GMT
+  recorded_at: Mon, 05 Feb 2018 12:07:57 GMT
 - request:
     method: get
-    uri: http://backend:5352/build/home:titan/_result?locallink=1&multibuild=1&package=goal&view=status
+    uri: http://backend:5352/build/home:titan/_result?package=goal&view=status
     body:
       encoding: US-ASCII
       string: ''
@@ -527,8 +420,8 @@ http_interactions:
       - Ruby
   response:
     status:
-      code: 404
-      message: project 'home titan' does not exist
+      code: 200
+      message: OK
     headers:
       Content-Type:
       - text/xml
@@ -537,49 +430,12 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '148'
+      - '56'
     body:
       encoding: UTF-8
-      string: |
-        <status code="404">
-          <summary>project 'home:titan' does not exist</summary>
-          <details>404 project 'home:titan' does not exist</details>
-        </status>
+      string: '<resultlist state="00000000000000000000000000000000" />
+
+'
     http_version: 
-  recorded_at: Mon, 13 Feb 2017 15:56:58 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/home:titan/goal?view=info
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 404
-      message: project 'home titan' does not exist
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '148'
-    body:
-      encoding: UTF-8
-      string: |
-        <status code="404">
-          <summary>project 'home:titan' does not exist</summary>
-          <details>404 project 'home:titan' does not exist</details>
-        </status>
-    http_version: 
-  recorded_at: Tue, 16 Jan 2018 14:36:16 GMT
+  recorded_at: Mon, 05 Feb 2018 12:07:57 GMT
 recorded_with: VCR 4.0.0

--- a/src/api/spec/cassettes/Requests/project_with_list_of_requests/going_through_a_request_list.yml
+++ b/src/api/spec/cassettes/Requests/project_with_list_of_requests/going_through_a_request_list.yml
@@ -237,4 +237,45 @@ http_interactions:
         </project>
     http_version: 
   recorded_at: Thu, 04 May 2017 14:16:04 GMT
-recorded_with: VCR 3.0.3
+- request:
+    method: put
+    uri: http://backend:5352/source/home:user_4/_meta?user=user_4
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:user_4">
+          <title/>
+          <description/>
+          <person userid="user_4" role="maintainer"/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '135'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:user_4">
+          <title></title>
+          <description></description>
+          <person userid="user_4" role="maintainer" />
+        </project>
+    http_version: 
+  recorded_at: Mon, 05 Feb 2018 12:07:19 GMT
+recorded_with: VCR 4.0.0

--- a/src/api/spec/cassettes/Requests/review/for_package/opens_a_review.yml
+++ b/src/api/spec/cassettes/Requests/review/for_package/opens_a_review.yml
@@ -80,4 +80,43 @@ http_interactions:
         </package>
     http_version: 
   recorded_at: Tue, 20 Sep 2016 13:19:12 GMT
-recorded_with: VCR 3.0.3
+- request:
+    method: put
+    uri: http://backend:5352/source/home:kugelblitz/package_1/_meta
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="package_1" project="home:kugelblitz">
+          <title>The Mirror Crack'd from Side to Side</title>
+          <description>Nam sed aut non.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '164'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="package_1" project="home:kugelblitz">
+          <title>The Mirror Crack'd from Side to Side</title>
+          <description>Nam sed aut non.</description>
+        </package>
+    http_version: 
+  recorded_at: Mon, 05 Feb 2018 12:07:17 GMT
+recorded_with: VCR 4.0.0

--- a/src/api/spec/cassettes/Requests/review/for_user/opens_a_review_and_accepts_it.yml
+++ b/src/api/spec/cassettes/Requests/review/for_user/opens_a_review_and_accepts_it.yml
@@ -55,4 +55,127 @@ http_interactions:
         </workerstatus>
     http_version: 
   recorded_at: Fri, 16 Jun 2017 14:31:50 GMT
-recorded_with: VCR 3.0.3
+- request:
+    method: put
+    uri: http://backend:5352/source/home:kugelblitz/_meta?user=kugelblitz
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:kugelblitz">
+          <title/>
+          <description/>
+          <person userid="kugelblitz" role="maintainer"/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '143'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:kugelblitz">
+          <title></title>
+          <description></description>
+          <person userid="kugelblitz" role="maintainer" />
+        </project>
+    http_version: 
+  recorded_at: Mon, 05 Feb 2018 12:07:09 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:user_1/_meta?user=user_1
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:user_1">
+          <title/>
+          <description/>
+          <person userid="user_1" role="maintainer"/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '135'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:user_1">
+          <title></title>
+          <description></description>
+          <person userid="user_1" role="maintainer" />
+        </project>
+    http_version: 
+  recorded_at: Mon, 05 Feb 2018 12:07:10 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:user_4/_meta?user=user_4
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:user_4">
+          <title/>
+          <description/>
+          <person userid="user_4" role="maintainer"/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '135'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:user_4">
+          <title></title>
+          <description></description>
+          <person userid="user_4" role="maintainer" />
+        </project>
+    http_version: 
+  recorded_at: Mon, 05 Feb 2018 12:08:10 GMT
+recorded_with: VCR 4.0.0

--- a/src/api/spec/cassettes/UpdatePackageMetaJob/_perform/should_remove_BackendPackage_with_links_to_ids_is_nil_and_package_kind_is_patchinfo.yml
+++ b/src/api/spec/cassettes/UpdatePackageMetaJob/_perform/should_remove_BackendPackage_with_links_to_ids_is_nil_and_package_kind_is_patchinfo.yml
@@ -314,7 +314,7 @@ http_interactions:
   recorded_at: Mon, 14 Aug 2017 13:16:59 GMT
 - request:
     method: post
-    uri: http://backend:5352/source/home:tom:branches:home:tom/package_1?cmd=branch&opackage=package_1&oproject=home:tom&user=tom
+    uri: http://backend:5352/source/home:tom:branches:home:tom/package_1?cmd=branch&noservice=1&opackage=package_1&oproject=home:tom&user=tom
     body:
       encoding: UTF-8
       string: ''

--- a/src/api/spec/cassettes/UpdatePackageMetaJob/_scan_links/with_a_BranchPackage_that_does_have_an_entry_in_BackendPackage/1_3_1_1.yml
+++ b/src/api/spec/cassettes/UpdatePackageMetaJob/_scan_links/with_a_BranchPackage_that_does_have_an_entry_in_BackendPackage/1_3_1_1.yml
@@ -236,7 +236,7 @@ http_interactions:
   recorded_at: Mon, 14 Aug 2017 13:16:58 GMT
 - request:
     method: post
-    uri: http://backend:5352/source/home:tom:branches:home:tom/package_1?cmd=branch&opackage=package_1&oproject=home:tom&user=tom
+    uri: http://backend:5352/source/home:tom:branches:home:tom/package_1?cmd=branch&noservice=1&opackage=package_1&oproject=home:tom&user=tom
     body:
       encoding: UTF-8
       string: ''

--- a/src/api/spec/cassettes/UpdatePackageMetaJob/_scan_links/with_a_BranchPackage_that_doesn_t_have_an_entry_in_BackendPackage/1_3_2_1.yml
+++ b/src/api/spec/cassettes/UpdatePackageMetaJob/_scan_links/with_a_BranchPackage_that_doesn_t_have_an_entry_in_BackendPackage/1_3_2_1.yml
@@ -236,7 +236,7 @@ http_interactions:
   recorded_at: Mon, 14 Aug 2017 13:16:57 GMT
 - request:
     method: post
-    uri: http://backend:5352/source/home:tom:branches:home:tom/package_1?cmd=branch&opackage=package_1&oproject=home:tom&user=tom
+    uri: http://backend:5352/source/home:tom:branches:home:tom/package_1?cmd=branch&noservice=1&opackage=package_1&oproject=home:tom&user=tom
     body:
       encoding: UTF-8
       string: ''

--- a/src/api/spec/models/branch_package_spec.rb
+++ b/src/api/spec/models/branch_package_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-CONFIG['global_write_through'] = true
+# CONFIG['global_write_through'] = true
 
 RSpec.describe BranchPackage, vcr: true do
   let(:user) { create(:confirmed_user, login: 'tom') }

--- a/src/api/spec/models/branch_package_spec.rb
+++ b/src/api/spec/models/branch_package_spec.rb
@@ -1,5 +1,7 @@
 require 'rails_helper'
 
+CONFIG['global_write_through'] = true
+
 RSpec.describe BranchPackage, vcr: true do
   let(:user) { create(:confirmed_user, login: 'tom') }
   let(:home_project) { user.home_project }
@@ -57,6 +59,7 @@ RSpec.describe BranchPackage, vcr: true do
     context 'project without ImageTemplates attribute' do
       context 'auto cleanup attribute' do
         it 'is set to the default' do
+          leap_project
           allow(Configuration).to receive(:cleanup_after_days).and_return(42)
           branch_apache_package.branch
           project = Project.find_by_name(user.branch_project_name('openSUSE_Leap'))

--- a/src/api/test/fixtures/linked_projects.yml
+++ b/src/api/test/fixtures/linked_projects.yml
@@ -12,12 +12,14 @@ UseRemoteInstanceIndirect_to_UseRemoteInstance:
 linked_db_projects_42:
   id: 42
   position: 1
+  vrevmode: 'extend'
   linked_remote_project_name: nil
   project: BaseDistro2.0_LinkedUpdateProject
   linked_db_project: BaseDistro2.0
 linked_db_projects_44:
   id: 44
   position: 1
+  vrevmode: 'extend'
   linked_remote_project_name: nil
   project: BaseDistro_Update
   linked_db_project: BaseDistro

--- a/src/api/test/unit/project_test.rb
+++ b/src/api/test/unit/project_test.rb
@@ -704,7 +704,7 @@ class ProjectTest < ActiveSupport::TestCase
       "<project name='home:Iggy:B'>
         <title>Iggy's Home Project</title>
         <description>dummy</description>
-        <link project='home:Iggy:A' />
+        <link project='home:Iggy:A' vrevmode='extend' />
       </project>"
     )
     project_b = Project.create(name: 'home:Iggy:B')

--- a/src/backend/BSVerify.pm
+++ b/src/backend/BSVerify.pm
@@ -262,7 +262,7 @@ sub verify_proj {
   for my $link (@{$proj->{'link'} || []}) {
     verify_projid($link->{'project'});
     if (exists($link->{'vrevmode'})) {
-      die("bad vrevmode attribute\n") unless $link->{'vrevmode'} && ($link->{'vrevmode'} eq 'extend' || $link->{'vrevmode'} eq 'unextend');
+      die("bad vrevmode attribute: $link->{'vrevmode'}\n") unless $link->{'vrevmode'} && ($link->{'vrevmode'} eq 'extend' || $link->{'vrevmode'} eq 'unextend');
     }
   }
   for my $f ('build', 'publish', 'debuginfo', 'useforbuild', 'lock', 'binarydownload', 'sourceaccess', 'access') {


### PR DESCRIPTION
Still discussing this general solution for the vrev version race of build rpms when instantiating a new package update at the same time in next SP and in incident. This change avoids the race by enforcing the wanted scheme.

Other changes were depending on it, but actual change is the usage of extendrev parameter during
branching into an incident. (most code changes were due to rubocop complains)

This will get deployed when commitment from all stake holders is there.

This will lead to an enforced vrev scheme of

SP-M:GA   X.Y
SP-M:Update X.(Y+1).Z
SP-(M+1):GA X.(Y+2)

or real life

SP-2:GA 2.5
SP-2:Update 2.6.2
SP-3:GA 2.7

