### PR TITLE
[dist] commented why xorg-x11-server is needed

### DIFF
--- a/dist/obs-server.spec
+++ b/dist/obs-server.spec
@@ -85,6 +85,7 @@ BuildRequires:  perl-XML-Simple
 BuildRequires:  perl(Devel::Cover)
 BuildRequires:  perl(Test::Simple) > 1
 BuildRequires:  procps
+# Required by the test suite (contains /usr/bin/Xvfb)
 BuildRequires:  xorg-x11-server
 PreReq:         /usr/sbin/useradd /usr/sbin/groupadd
 BuildArch:      noarch


### PR DESCRIPTION
just a small comment why xorg-x11-server is needed to build obs-server