### PR TITLE
Fix: make -C dist test failure

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,7 @@ install:
 
 test:
 	make -C src/api test
+	make -C dist/sysvinit test
 	make -C dist test
 	make -C src/backend test
 


### PR DESCRIPTION
This PR is to fix "make -C dist test failures".

before:
make -C dist test

after:
make -C dist/sysvinit test
make -C dist test

Signed-off-by: Geunsik Lim <geunsik.lim@samsung.com>