### PR TITLE
[api] OBSEngine::Base#mount_it is not used

### DIFF
--- a/src/api/lib/engines/base.rb
+++ b/src/api/lib/engines/base.rb
@@ -2,7 +2,7 @@ module OBSEngine
   # base class for all engine hooks
   class Base
     # implement this function to patch the routes
-    def mount_it
+    def self.mount_it
     end
   end
 


### PR DESCRIPTION
We never create an instance of `OBSEngine::Base`, so having and instance method is pointless. :confounded: 

What we actually do is calling the class method with the same name in all the subclasses. So, the `mount_it` method in `OBSEngine::Base`, but I guess the idea was to leave the method also in the parent class as help. In this case, this method should be the class method and not the instance one.