### PR TITLE
Refactor routes

### DIFF
--- a/src/api/config/routes.rb
+++ b/src/api/config/routes.rb
@@ -99,7 +99,7 @@ OBSApi::Application.routes.draw do
     end
 
     controller 'webui/package', format: false, defaults: { format: "html" } do
-      get 'package/show/(:project/(:package))' => :show, as: 'package_show', constraints: cons
+      get 'package/show/:project/:package' => :show, as: 'package_show', constraints: cons
       get 'package/dependency/:project/:package' => :dependency, constraints: cons
       get 'package/binary/:project/:package' => :binary, constraints: cons, as: 'package_binary'
       get 'package/binaries/:project/:package' => :binaries, constraints: cons, as: 'package_binaries'
@@ -111,7 +111,7 @@ OBSApi::Application.routes.draw do
       post 'package/submit_request/:project/:package' => :submit_request, constraints: cons
       get 'package/add_person/:project/:package' => :add_person, constraints: cons
       get 'package/add_group/:project/:package' => :add_group, constraints: cons
-      get 'package/rdiff/(:project/(:package))' => :rdiff, constraints: cons
+      get 'package/rdiff/:project/:package' => :rdiff, constraints: cons
       post 'package/save_new/:project' => :save_new, constraints: cons
       post 'package/branch' => :branch, constraints: cons
       post 'package/save/:project/:package' => :save, constraints: cons
@@ -122,7 +122,7 @@ OBSApi::Application.routes.draw do
       post 'package/save_person/:project/:package' => :save_person, constraints: cons
       post 'package/save_group/:project/:package' => :save_group, constraints: cons
       post 'package/remove_role/:project/:package' => :remove_role, constraints: cons
-      get 'package/view_file/(:project/(:package/(:filename)))' => :view_file, constraints: cons, as: 'package_view_file'
+      get 'package/view_file/:project/:package/(:filename)' => :view_file, constraints: cons, as: 'package_view_file'
       get 'package/live_build_log/:project/:package/:repository/:arch' => :live_build_log, constraints: cons, as: 'package_live_build_log'
       defaults format: 'js' do
         get 'package/linking_packages/:project/:package' => :linking_packages, constraints: cons

--- a/src/api/test/functional/webui/package_controller_test.rb
+++ b/src/api/test/functional/webui/package_controller_test.rb
@@ -181,7 +181,7 @@ class Webui::PackageControllerTest < Webui::IntegrationTest
   def test_another_succesful_comment_creation # spec/features/webui/comments_spec.rb
     use_js
     login_Iggy
-    visit '/package/show?project=home:Iggy&package=TestPack'
+    visit '/package/show/home:Iggy/TestPack'
     # @Iggy works at the very beginning and requests are case insensitive
     fill_comment "@Iggy likes to mention himself and to write request#23 with capital 'R', like Request#23."
     within('div.thread_level_0') do


### PR DESCRIPTION
Project and package are required in some controller methods but we set
them as optional in the routes. Then we see a
`ActiveRecord::RecordNotFound` error instead of `No route matches`
error.

We are including `/` in the regular expression of the `id` parameters in
the routes. However, `/` is used a separator and this hasn't got any
effect. So it is better to use the more restrictive regular expression.