### PR TITLE
[api] TEMPORARY FIX Show packages with dot in name

### DIFF
--- a/src/api/config/routes.rb
+++ b/src/api/config/routes.rb
@@ -97,7 +97,7 @@ OBSApi::Application.routes.draw do
     end
 
     controller 'webui/package' do
-      get 'package/show/(:project/(:package))' => :show, as: 'package_show', constraints: cons
+      get 'package/show/(:project/(:package))' => :show, as: 'package_show', constraints: cons, format: "html"
       get 'package/linking_packages/:project/:package' => :linking_packages, constraints: cons
       get 'package/dependency/:project/:package' => :dependency, constraints: cons
       get 'package/binary/:project/:package' => :binary, constraints: cons, as: 'package_binary'


### PR DESCRIPTION
If we have for a example a package called `ana.yaml`, `/package/show/home:Admin/ana.yaml` will be processed as YAML althought the `.yaml` is part of the package name and it is not intended to be the request format. :confounded: 

This seems to be a Rails bug, this is just a temporarly fix. Other routes are also affected, but these is the more visible for user, so I think that at least here it is worthwhile to provide a temporary fix. :bowtie: 

Fixes https://github.com/openSUSE/open-build-service/issues/2900