### PR TITLE
[webui][api] BsRequest.list: merge two queries into one

### DIFF
--- a/src/api/app/models/bs_request.rb
+++ b/src/api/app/models/bs_request.rb
@@ -1171,9 +1171,8 @@ class BsRequest < ApplicationRecord
     roles = opts[:roles] || []
     states = opts[:states] || []
 
-    # it's wiser to split the queries
     if opts[:project] && roles.empty? && (states.empty? || states.include?("review"))
-      (collection(opts.merge(roles: ["reviewer"])) + collection(opts.merge(roles: ["target", "source"]))).uniq
+      collection(opts.merge(roles: ["reviewer", "target", "source"])).uniq
     else
       collection(opts).uniq
     end


### PR DESCRIPTION
For some reason `BsRequest.list` is querying twice and merging the results. There is a comment that says `it's wiser to split the queries` but offers no explanation as to why its wiser and I cannot track done when/who implemented this split in the first place.

Unless anybody has a reason not to can we please merge this because I need this method to return an ActiveRecord relation and not just an array in order to do ordering, pagination and filtering for this card:

https://trello.com/c/ABmVsXfI/377-5-p4-refactor-package-project-requests-page