### PR TITLE
[webui] Set the default format of package routes to html

### DIFF
--- a/src/api/config/routes.rb
+++ b/src/api/config/routes.rb
@@ -63,7 +63,7 @@ OBSApi::Application.routes.draw do
       collection do
         get ':project(/:package)/new' => :new, constraints: cons, as: 'new'
         get ':project(/:package)/:attribute/edit' => :edit, constraints: cons, as: 'edit'
-        get ':project(/:package)' => :index, constraints: cons, as: 'index'
+        get ':project(/:package)' => :index, constraints: cons, as: 'index', defaults: { format: "html" }
       end
     end
 
@@ -97,9 +97,8 @@ OBSApi::Application.routes.draw do
       get 'monitor/events' => :events
     end
 
-    controller 'webui/package' do
+    controller 'webui/package', format: false, defaults: { format: "html" } do
       get 'package/show/(:project/(:package))' => :show, as: 'package_show', constraints: cons
-      get 'package/linking_packages/:project/:package' => :linking_packages, constraints: cons
       get 'package/dependency/:project/:package' => :dependency, constraints: cons
       get 'package/binary/:project/:package' => :binary, constraints: cons, as: 'package_binary'
       get 'package/binaries/:project/:package' => :binaries, constraints: cons, as: 'package_binaries'
@@ -108,7 +107,6 @@ OBSApi::Application.routes.draw do
       get 'package/statistics/:project/:package' => :statistics, as: 'package_statistics', constraints: cons
       get 'package/commit/:project/:package' => :commit, as: 'package_commit', constraints: cons
       get 'package/revisions/:project/:package' => :revisions, constraints: cons, as: 'package_view_revisions'
-      get 'package/submit_request_dialog/:project/:package' => :submit_request_dialog, constraints: cons
       post 'package/submit_request/:project/:package' => :submit_request, constraints: cons
       get 'package/add_person/:project/:package' => :add_person, constraints: cons
       get 'package/add_group/:project/:package' => :add_group, constraints: cons
@@ -116,7 +114,6 @@ OBSApi::Application.routes.draw do
       post 'package/save_new/:project' => :save_new, constraints: cons
       post 'package/branch' => :branch, constraints: cons
       post 'package/save/:project/:package' => :save, constraints: cons
-      get 'package/delete_dialog/:project/:package' => :delete_dialog, constraints: cons
       post 'package/remove/:project/:package' => :remove, constraints: cons
       get 'package/add_file/:project/:package' => :add_file, constraints: cons
       post 'package/save_file/:project/:package' => :save_file, constraints: cons
@@ -124,13 +121,18 @@ OBSApi::Application.routes.draw do
       post 'package/save_person/:project/:package' => :save_person, constraints: cons
       post 'package/save_group/:project/:package' => :save_group, constraints: cons
       post 'package/remove_role/:project/:package' => :remove_role, constraints: cons
-      get 'package/view_file/(:project/(:package/(:filename)))' => :view_file, constraints: cons, as: 'package_view_file', defaults: {format: "html"}
+      get 'package/view_file/(:project/(:package/(:filename)))' => :view_file, constraints: cons, as: 'package_view_file'
       get 'package/live_build_log/:project/:package/:repository/:arch' => :live_build_log, constraints: cons, as: 'package_live_build_log'
-      get 'package/update_build_log/:project/:package/:repository/:arch' => :update_build_log, constraints: cons
-      get 'package/abort_build/:project/:package' => :abort_build, constraints: cons
-      post 'package/trigger_services/:project/:package' => :trigger_services, constraints: cons
-      post 'package/trigger_rebuild/:project/:package' => :trigger_rebuild, constraints: cons
-      delete 'package/wipe_binaries/:project/:package' => :wipe_binaries, constraints: cons
+      defaults format: 'js' do
+        get 'package/linking_packages/:project/:package' => :linking_packages, constraints: cons
+        get 'package/update_build_log/:project/:package/:repository/:arch' => :update_build_log, constraints: cons
+        get 'package/submit_request_dialog/:project/:package' => :submit_request_dialog, constraints: cons
+        get 'package/delete_dialog/:project/:package' => :delete_dialog, constraints: cons
+        post 'package/trigger_rebuild/:project/:package' => :trigger_rebuild, constraints: cons
+        get 'package/abort_build/:project/:package' => :abort_build, constraints: cons
+        post 'package/trigger_services/:project/:package' => :trigger_services, constraints: cons
+        delete 'package/wipe_binaries/:project/:package' => :wipe_binaries, constraints: cons
+      end
       get 'package/devel_project/:project/:package' => :devel_project, constraints: cons
       get 'package/buildresult' => :buildresult, constraints: cons
       get 'package/rpmlint_result' => :rpmlint_result, constraints: cons
@@ -157,7 +159,7 @@ OBSApi::Application.routes.draw do
       post 'patchinfo/new_patchinfo' => :new_patchinfo
       post 'patchinfo/updatepatchinfo' => :updatepatchinfo
       get 'patchinfo/edit_patchinfo' => :edit_patchinfo
-      get 'patchinfo/show/:project/:package' => :show, as: 'patchinfo_show', constraints: cons
+      get 'patchinfo/show/:project/:package' => :show, as: 'patchinfo_show', constraints: cons, defaults: { format: "html" }
       get 'patchinfo/read_patchinfo' => :read_patchinfo
       post 'patchinfo/save' => :save
       post 'patchinfo/remove' => :remove
@@ -166,7 +168,7 @@ OBSApi::Application.routes.draw do
     end
     #
     controller 'webui/repositories' do
-      get 'repositories/:project(/:package)' => :index, constraints: cons, as: 'repositories'
+      get 'repositories/:project(/:package)' => :index, constraints: cons, as: 'repositories', defaults: { format: "html" }
       get 'project/repositories/:project' => :index, constraints: cons, as: 'project_repositories'
       get 'project/add_repository/:project' => :new, constraints: cons
       get 'project/add_repository_from_default_list/:project' => :distributions, constraints: cons

--- a/src/api/spec/cassettes/Packages/Viewing_a_package_that/has_a_mime_like_suffix_in_it_s_name.yml
+++ b/src/api/spec/cassettes/Packages/Viewing_a_package_that/has_a_mime_like_suffix_in_it_s_name.yml
@@ -1,0 +1,293 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://localhost:3200/source/home:package_test_user/test.json?nofilename=1&view=info&withchangesmd5=1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 404
+      message: project 'home package_test_user' does not exist
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '172'
+    body:
+      encoding: UTF-8
+      string: |
+        <status code="404">
+          <summary>project 'home:package_test_user' does not exist</summary>
+          <details>404 project 'home:package_test_user' does not exist</details>
+        </status>
+    http_version: 
+  recorded_at: Thu, 04 May 2017 10:24:20 GMT
+- request:
+    method: get
+    uri: http://localhost:3200/source/home:package_test_user/test.json
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 404
+      message: project 'home package_test_user' does not exist
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '172'
+    body:
+      encoding: UTF-8
+      string: |
+        <status code="404">
+          <summary>project 'home:package_test_user' does not exist</summary>
+          <details>404 project 'home:package_test_user' does not exist</details>
+        </status>
+    http_version: 
+  recorded_at: Thu, 04 May 2017 10:24:20 GMT
+- request:
+    method: post
+    uri: http://localhost:3200/source/home:package_test_user/test.json?cmd=diff&linkrev=base&onlyissues=1&orev=0&view=xml
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Content-Type:
+      - application/octet-stream
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 404
+      message: project 'home package_test_user' does not exist
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '172'
+    body:
+      encoding: UTF-8
+      string: |
+        <status code="404">
+          <summary>project 'home:package_test_user' does not exist</summary>
+          <details>404 project 'home:package_test_user' does not exist</details>
+        </status>
+    http_version: 
+  recorded_at: Thu, 04 May 2017 10:24:20 GMT
+- request:
+    method: get
+    uri: http://localhost:3200/source/home:package_test_user/test.json
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 404
+      message: project 'home package_test_user' does not exist
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '172'
+    body:
+      encoding: UTF-8
+      string: |
+        <status code="404">
+          <summary>project 'home:package_test_user' does not exist</summary>
+          <details>404 project 'home:package_test_user' does not exist</details>
+        </status>
+    http_version: 
+  recorded_at: Thu, 04 May 2017 10:24:20 GMT
+- request:
+    method: get
+    uri: http://localhost:3200/source/home:package_test_user/test.json?expand=1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - text/plain
+      Accept-Encoding:
+      - identity
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 404
+      message: project 'home package_test_user' does not exist
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '172'
+    body:
+      encoding: UTF-8
+      string: |
+        <status code="404">
+          <summary>project 'home:package_test_user' does not exist</summary>
+          <details>404 project 'home:package_test_user' does not exist</details>
+        </status>
+    http_version: 
+  recorded_at: Thu, 04 May 2017 10:24:20 GMT
+- request:
+    method: get
+    uri: http://localhost:3200/source/home:package_test_user/test.json
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - text/plain
+      Accept-Encoding:
+      - identity
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 404
+      message: project 'home package_test_user' does not exist
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '172'
+    body:
+      encoding: UTF-8
+      string: |
+        <status code="404">
+          <summary>project 'home:package_test_user' does not exist</summary>
+          <details>404 project 'home:package_test_user' does not exist</details>
+        </status>
+    http_version: 
+  recorded_at: Thu, 04 May 2017 10:24:20 GMT
+- request:
+    method: get
+    uri: http://localhost:3200/source/home:package_test_user/test.json/_service
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - text/plain
+      Accept-Encoding:
+      - identity
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 404
+      message: project 'home package_test_user' does not exist
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '172'
+    body:
+      encoding: UTF-8
+      string: |
+        <status code="404">
+          <summary>project 'home:package_test_user' does not exist</summary>
+          <details>404 project 'home:package_test_user' does not exist</details>
+        </status>
+    http_version: 
+  recorded_at: Thu, 04 May 2017 10:24:20 GMT
+- request:
+    method: get
+    uri: http://localhost:3200/build/home:package_test_user/_result?package=test.json&view=status
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - text/plain
+      Accept-Encoding:
+      - identity
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 404
+      message: project 'home package_test_user' does not exist
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '172'
+    body:
+      encoding: UTF-8
+      string: |
+        <status code="404">
+          <summary>project 'home:package_test_user' does not exist</summary>
+          <details>404 project 'home:package_test_user' does not exist</details>
+        </status>
+    http_version: 
+  recorded_at: Thu, 04 May 2017 10:24:23 GMT
+recorded_with: VCR 3.0.3

--- a/src/api/spec/features/webui/packages_spec.rb
+++ b/src/api/spec/features/webui/packages_spec.rb
@@ -26,10 +26,19 @@ RSpec.feature "Packages", type: :feature, js: true do
   describe 'Viewing a package that' do
     let(:branching_data) { BranchPackage.new(project: user.home_project.name, package: package.name).branch }
     let(:branched_project) { Project.where(name: branching_data[:data][:targetproject]).first }
+    let(:package_mime) do
+      create(:package, name: 'test.json', project: user.home_project, description: 'A package with a mime type suffix')
+    end
 
     before do
       # Needed for branching
       User.current = user
+    end
+
+    scenario "has a mime like suffix in it's name" do
+      visit package_show_path(project: user.home_project, package: package_mime)
+      expect(page).to have_text('test.json')
+      expect(page).to have_text('A package with a mime type suffix')
     end
 
     scenario 'was branched' do


### PR DESCRIPTION
Fixes #2900

Since Rails 5 the routing changed to support the new API application
feature in Rails. For OBS that meant that packages with a mime-like
suffix, like .yaml, caused Rails to handle the response as "mime-type"
format, eg. yaml, instead of html.

To fix this we have to explicitly set the default format to html to
route properly.

Comment from the rails guys:
  https://github.com/rails/rails/issues/28901#event-1060620644