### PR TITLE
[api][webui] Add polymorphic association to review

### DIFF
--- a/src/api/app/models/group.rb
+++ b/src/api/app/models/group.rb
@@ -9,6 +9,7 @@ class Group < ApplicationRecord
   has_many :group_maintainers, inverse_of: :group, dependent: :destroy
   has_many :relationships, dependent: :destroy, inverse_of: :group
   has_many :event_subscriptions, dependent: :destroy, inverse_of: :group
+  has_many :reviews, dependent: :nullify, as: :reviewable
 
   validates :title,
             format: { with:    %r{\A[\w\.\-]*\z},

--- a/src/api/app/models/package.rb
+++ b/src/api/app/models/package.rb
@@ -74,6 +74,8 @@ class Package < ApplicationRecord
 
   has_many :binary_releases, dependent: :delete_all, foreign_key: 'release_package_id'
 
+  has_many :reviews, dependent: :nullify, as: :reviewable
+
   before_destroy :delete_on_backend
   before_destroy :close_requests
   before_destroy :update_project_for_product

--- a/src/api/app/models/project.rb
+++ b/src/api/app/models/project.rb
@@ -89,6 +89,8 @@ class Project < ApplicationRecord
 
   has_many :project_log_entries, dependent: :delete_all
 
+  has_many :reviews, dependent: :nullify, as: :reviewable
+
   default_scope { where('projects.id not in (?)', Relationship.forbidden_project_ids ) }
 
   scope :maintenance, -> { where("kind = 'maintenance'") }

--- a/src/api/app/models/user.rb
+++ b/src/api/app/models/user.rb
@@ -39,6 +39,8 @@ class User < ApplicationRecord
   has_many :messages
   has_many :tokens, dependent: :destroy, inverse_of: :user
 
+  has_many :reviews, dependent: :nullify, as: :reviewable
+
   has_many :event_subscriptions, inverse_of: :user
 
   belongs_to :owner, class_name: 'User'

--- a/src/api/db/migrate/20170426153510_add_references_to_review.rb
+++ b/src/api/db/migrate/20170426153510_add_references_to_review.rb
@@ -1,0 +1,57 @@
+class AddReferencesToReview < ActiveRecord::Migration[5.0]
+  def up
+    # COLLATE for by_user, by_group, by_package and by_project was utf8_unicode_ci which made it impossible to perform a JOIN on these fields
+    # Furthermore on build.opensuse.org the COLLATE was already changed to utf8_general_ci manually in the past
+    execute('ALTER TABLE reviews MODIFY by_user VARCHAR(255) CHARACTER SET utf8 COLLATE utf8_general_ci;')
+    execute('ALTER TABLE reviews MODIFY by_group VARCHAR(255) CHARACTER SET utf8 COLLATE utf8_general_ci;')
+    execute('ALTER TABLE reviews MODIFY by_project VARCHAR(255) CHARACTER SET utf8 COLLATE utf8_general_ci;')
+    execute('ALTER TABLE reviews MODIFY by_package VARCHAR(255) CHARACTER SET utf8 COLLATE utf8_general_ci;')
+
+    add_reference(:reviews, :reviewable, polymorphic: true)
+
+    # Migrate by_user reviews
+    sql = <<-SQL
+      UPDATE reviews
+      INNER JOIN users ON users.login = reviews.by_user
+      SET reviews.reviewable_id = users.id, reviews.reviewable_type = 'User'
+      WHERE reviews.by_user IS NOT NULL
+    SQL
+    execute(sql)
+
+    # migrate by_group reviews
+    sql = <<-SQL
+      UPDATE reviews
+      INNER JOIN groups ON groups.title = reviews.by_group
+      SET reviews.reviewable_id = groups.id, reviews.reviewable_type = 'Group'
+      WHERE reviews.by_group IS NOT NULL
+    SQL
+    execute(sql)
+
+    # migrate by_project reviews
+    sql = <<-SQL
+      UPDATE reviews
+      INNER JOIN projects ON projects.name = reviews.by_project
+      SET reviews.reviewable_id = projects.id, reviews.reviewable_type = 'Project'
+      WHERE reviews.by_project IS NOT NULL AND reviews.by_package IS NULL
+    SQL
+    execute(sql)
+
+    # migrate by_package reviews
+    sql = <<-SQL
+      UPDATE reviews
+      INNER JOIN projects ON projects.name = reviews.by_project
+      INNER JOIN packages ON packages.name = reviews.by_package AND packages.project_id = projects.id
+      SET reviews.reviewable_id = packages.id, reviews.reviewable_type = 'Package'
+      WHERE reviews.by_project IS NOT NULL AND reviews.by_package IS NOT NULL
+    SQL
+    execute(sql)
+  end
+
+  def down
+    remove_reference(:reviews, :reviewable, polymorphic: true)
+    execute('ALTER TABLE reviews MODIFY by_user VARCHAR(255) CHARACTER SET utf8 COLLATE utf8_unicode_ci;')
+    execute('ALTER TABLE reviews MODIFY by_group VARCHAR(255) CHARACTER SET utf8 COLLATE utf8_unicode_ci;')
+    execute('ALTER TABLE reviews MODIFY by_project VARCHAR(255) CHARACTER SET utf8 COLLATE utf8_unicode_ci;')
+    execute('ALTER TABLE reviews MODIFY by_package VARCHAR(255) CHARACTER SET utf8 COLLATE utf8_unicode_ci;')
+  end
+end

--- a/src/api/db/structure.sql
+++ b/src/api/db/structure.sql
@@ -908,13 +908,15 @@ CREATE TABLE `reviews` (
   `reviewer` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
   `reason` text COLLATE utf8_unicode_ci,
   `state` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
-  `by_user` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
-  `by_group` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
-  `by_project` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
-  `by_package` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
+  `by_user` varchar(255) CHARACTER SET utf8 DEFAULT NULL,
+  `by_group` varchar(255) CHARACTER SET utf8 DEFAULT NULL,
+  `by_project` varchar(255) CHARACTER SET utf8 DEFAULT NULL,
+  `by_package` varchar(255) CHARACTER SET utf8 DEFAULT NULL,
   `created_at` datetime NOT NULL,
   `updated_at` datetime NOT NULL,
   `review_id` int(11) DEFAULT NULL,
+  `reviewable_type` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
+  `reviewable_id` int(11) DEFAULT NULL,
   PRIMARY KEY (`id`),
   KEY `bs_request_id` (`bs_request_id`) USING BTREE,
   KEY `index_reviews_on_by_group` (`by_group`) USING BTREE,
@@ -926,6 +928,7 @@ CREATE TABLE `reviews` (
   KEY `index_reviews_on_state_and_by_project` (`state`,`by_project`) USING BTREE,
   KEY `index_reviews_on_state_and_by_user` (`state`,`by_user`) USING BTREE,
   KEY `index_reviews_on_review_id` (`review_id`),
+  KEY `index_reviews_on_reviewable_type_and_reviewable_id` (`reviewable_type`,`reviewable_id`),
   CONSTRAINT `fk_rails_813a4fb24f` FOREIGN KEY (`review_id`) REFERENCES `reviews` (`id`),
   CONSTRAINT `reviews_ibfk_1` FOREIGN KEY (`bs_request_id`) REFERENCES `bs_requests` (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
@@ -1178,6 +1181,7 @@ INSERT INTO schema_migrations (version) VALUES
 ('20170315200936'),
 ('20170316090223'),
 ('20170317094221'),
-('20170320151300');
+('20170320151300'),
+('20170426153510');
 
 

--- a/src/api/spec/models/review_spec.rb
+++ b/src/api/spec/models/review_spec.rb
@@ -23,7 +23,30 @@ RSpec.shared_context 'some assigned reviews and some unassigned reviews' do
 end
 
 RSpec.describe Review do
+  let(:project) { create(:project_with_package, name: 'Apache', package_name: 'apache2') }
+  let(:package) { project.packages.first }
+  let(:user) { create(:user, login: 'King') }
+  let(:group) { create(:group, title: 'Staff') }
+
   it { should belong_to(:bs_request).touch(true) }
+
+  describe 'validations' do
+    it 'is not allowed to specify by_user and any other reviewable' do
+      [:by_group, :by_project, :by_package].each do |reviewable|
+        review = Review.create(:by_user => user.login, reviewable => 'not-existent-reviewable')
+        expect(review.errors.messages[:base]).
+          to eq(['it is not allowed to have more than one reviewer entity: by_user, by_group, by_project, by_package.'])
+      end
+    end
+
+    it 'is not allowed to specify by_group and any other reviewable' do
+      [:by_project, :by_package].each do |reviewable|
+        review = Review.create(:by_group => group.title, reviewable => 'not-existent-reviewable')
+        expect(review.errors.messages[:base]).
+          to eq(['it is not allowed to have more than one reviewer entity: by_user, by_group, by_project, by_package.'])
+      end
+    end
+  end
 
   describe '.assigned' do
     include_context 'some assigned reviews and some unassigned reviews'
@@ -37,6 +60,68 @@ RSpec.describe Review do
 
     subject { Review.unassigned }
     it { is_expected.to match_array([review_unassigned1, review_unassigned2]) }
+  end
+
+  describe '.set_associations' do
+    context 'with valid attributes' do
+      it 'sets user association when by_user object exists' do
+        review = create(:review, by_user: user.login)
+        expect(review.reviewable).to eq(user)
+        expect(review.by_user).to eq(user.login)
+      end
+
+      it 'sets group association when by_group object exists' do
+        review = create(:review, by_group: group.title)
+        expect(review.reviewable).to eq(group)
+        expect(review.by_group).to eq(group.title)
+      end
+
+      it 'sets project association when by_project object exists' do
+        review = create(:review, by_project: project.name)
+        expect(review.reviewable).to eq(project)
+        expect(review.by_project).to eq(project.name)
+      end
+
+      it 'sets package and project associations when by_package and by_project object exists' do
+        review = create(:review, by_project: project.name, by_package: package.name)
+        expect(review.reviewable).to eq(package)
+        expect(review.by_package).to eq(package.name)
+        expect(review.reviewable.project).to eq(project)
+        expect(review.by_project).to eq(project.name)
+      end
+    end
+
+    context 'with invalid attributes' do
+      it 'does not set user association when by_user object does not exist' do
+        review = Review.new(by_user: 'not-existent')
+        expect(review.reviewable).to eq(nil)
+        expect(review.valid?).to eq(false)
+      end
+
+      it 'does not set group association when by_group object does not exist' do
+        review = Review.new(by_group: 'not-existent')
+        expect(review.reviewable).to eq(nil)
+        expect(review.valid?).to eq(false)
+      end
+
+      it 'does not set project association when by_project object does not exist' do
+        review = Review.new(by_project: 'not-existent')
+        expect(review.reviewable).to eq(nil)
+        expect(review.valid?).to eq(false)
+      end
+
+      it 'does not set project and package associations when by_project and by_package object does not exist' do
+        review = Review.new(by_project: 'not-existent', by_package: 'not-existent')
+        expect(review.reviewable).to eq(nil)
+        expect(review.valid?).to eq(false)
+      end
+
+      it 'does not set package association when by_project parameter is missing' do
+        review = Review.new(by_package: package.name)
+        expect(review.reviewable).to eq(nil)
+        expect(review.valid?).to eq(false)
+      end
+    end
   end
 
   describe '#accepted_at' do


### PR DESCRIPTION
entities are user, group, project and package.
This makes ActiveModel queries more simple and efficient.
Also introduced validation that setting only one entity is allowed.
Furthermore changed the collation of the by_ fields to utf8_general_ci
as joining on these fields was not possible (e.g. group#title had
a mismatched collation).
This was already done on build.o.o manually in the past so
this commit will make the structures more consistent.