### PR TITLE
[backend] compatibility with 2.8 worker

### DIFF
--- a/src/backend/BSXML.pm
+++ b/src/backend/BSXML.pm
@@ -709,6 +709,7 @@ our $worker = [
 	'hostarch',
 	'ip',
 	'port',
+	'registerserver',   # compat for OBS 2.8 worker
 	'workerid',
       [ 'buildarch' ],
       [ 'hostlabel' ],


### PR DESCRIPTION
Support 'registerserver' attribute when 2.8 worker sends its state.
Without this change, when a 2.8 worker sends its state, the following
message is logged in rep_server.log:

'unknown attribute: registerserver'

This 'registerserver' attribute was introduced in 2.8 commit 4e821a3.