### PR TITLE
Add some color to the status

### DIFF
--- a/src/api/app/assets/stylesheets/webui/application.css.erb
+++ b/src/api/app/assets/stylesheets/webui/application.css.erb
@@ -29,5 +29,6 @@
  *= require webui/application/attribute.css.scss
  *= require webui/application/request.css.scss
  *= require webui/application/datatable.css.scss
+ *= require webui/application/jobhistory.css.scss
 */
 <% require_asset 'webui/application/image_templates' if Feature.active?(:image_templates) %>

--- a/src/api/app/assets/stylesheets/webui/application/jobhistory.scss
+++ b/src/api/app/assets/stylesheets/webui/application/jobhistory.scss
@@ -1,0 +1,2 @@
+td.status_succeeded { color: #6EB927; }
+td.status_failed { color: #f00; }

--- a/src/api/app/views/webui/packages/job_history/index.html.haml
+++ b/src/api/app/views/webui/packages/job_history/index.html.haml
@@ -26,7 +26,7 @@
           = time_tag(Time.at(jobhistory.ready_time))
         %td
           = jobhistory.reason
-        %td
+        %td{ class: "status_#{jobhistory.code}" }
           = jobhistory.code
         %td
           = humanize_time(jobhistory.total_time)


### PR DESCRIPTION
We add some colour to the code status of the jobhistory :smile_cat: 

![screenshot from 2017-05-04 19-35-33](https://cloud.githubusercontent.com/assets/1212806/25716880/02f52162-3101-11e7-9291-7e895dbcff61.png)
