### PR TITLE
[webui] Fix file download button

### DIFF
--- a/src/api/app/assets/stylesheets/webui/application/icons.scss
+++ b/src/api/app/assets/stylesheets/webui/application/icons.scss
@@ -119,7 +119,7 @@
 .icons-page_save { width: 16px; height: 16px; background: image-url('icons_sprite.png') -426px -242px no-repeat; }
 .icons-page_white_add { width: 16px; height: 16px; background: image-url('icons_sprite.png') -426px -262px no-repeat; }
 .icons-page_white_delete { width: 16px; height: 16px; background: image-url('icons_sprite.png') -426px -282px no-repeat; }
-.icons-page_white_get { width: 16px; height: 16px; background: image-url('icons_sprite.png') -426px -302px no-repeat; }
+.icons-page_white_put { width: 16px; height: 16px; background: image-url('icons_sprite.png') -426px -302px no-repeat; }
 .icons-plugin_add { width: 16px; height: 16px; background: image-url('icons_sprite.png') -426px -322px no-repeat; }
 .icons-project { width: 16px; height: 16px; background: image-url('icons_sprite.png') -426px -342px no-repeat; }
 .icons-publish_disable_blue { width: 24px; height: 24px; background: image-url('icons_sprite.png') -370px -298px no-repeat; }

--- a/src/api/app/views/webui/package/_files_view.html.erb
+++ b/src/api/app/views/webui/package/_files_view.html.erb
@@ -24,7 +24,7 @@
             </td>
             <!-- limit download for anonymous user to avoid getting killed by crawlers -->
             <td><%= if !User.current.is_nobody? || file[:size].to_i < (4 * 1024 * 1024)
-                      link_to sprite_tag('page_white_get', title: 'Download File'),
+                      link_to sprite_tag('page_white_put', title: 'Download File'),
                               file_url(@project.name, @package.name, file[:name], file[:srcmd5])
                     end %>
               <% unless file[:name] =~ /^_service:/ %>

--- a/src/api/script/update_bento.sh
+++ b/src/api/script/update_bento.sh
@@ -76,7 +76,7 @@ copy $themedir/bento/images/icons/page_refresh.png ./app/assets/icons/page_refre
 copy $themedir/bento/images/icons/page_save.png ./app/assets/icons/page_save.png
 copy $themedir/bento/images/icons/page_white_add.png ./app/assets/icons/page_white_add.png
 copy $themedir/bento/images/icons/page_white_delete.png ./app/assets/icons/page_white_delete.png
-copy $themedir/bento/images/icons/page_white_get.png ./app/assets/icons/page_white_get.png
+copy $themedir/bento/images/icons/page_white_put.png ./app/assets/icons/page_white_put.png
 copy $themedir/bento/images/icons/plugin_add.png ./app/assets/icons/plugin_add.png
 copy $themedir/bento/images/icons/script.png ./app/assets/icons/script.png
 copy $themedir/bento/images/icons/script_lightning.png ./app/assets/icons/script_lightning.png


### PR DESCRIPTION
The icon used for the file download button is currently an upload icon.
That's not good. The image almost seems to be misnamed in the
underlying icon theme, but perhaps these icons were just never
envisioned for use with upload/download buttons.

**Warning:** This is an **untested** drive-by pull request. We changed this icon in an ancient downstream fork of OBS. But I bet just changing the filename everywhere it's used will work for you too.