### PR TITLE
[backend] fix problem with empty param for service

### DIFF
--- a/src/backend/bs_service
+++ b/src/backend/bs_service
@@ -164,10 +164,13 @@ sub run_source_update {
       push @run, "$servicedir/$name";
       for my $param (@{$service->{'param'}}) {
         next if $param->{'name'} eq 'outdir';
-        next unless $param->{'_content'};
         die("$name: service parameter \"$param->{'name'}\" is not defined\n") unless grep {$_->{'name'} eq $param->{'name'}} @{$servicedef->{'parameter'}};
-        push @run, "--$param->{'name'}";
-        push @run, $param->{'_content'};
+        if ($param->{'_content'}) {
+          push @run, "--$param->{'name'}";
+          push @run, $param->{'_content'};
+        } else {
+          push @run, "--$param->{'name'}=";
+        }
       }
       push @run, "--outdir";
       push @run, "$myworkdir/out";


### PR DESCRIPTION
@mlschroe Please review - This PR has a high risk to break various service definitions in obs as it strongly depends on the used argument parser of the service. Maybe you can provide a better solution

The basic problem is, that services running in osc behave different to the backend. osc can also use empty args (params) for services whilst bs_service skips them.