### PR TITLE
[ci] Use consistent syntax in property tests

### DIFF
--- a/src/api/spec/helpers/webui/package_helper_spec.rb
+++ b/src/api/spec/helpers/webui/package_helper_spec.rb
@@ -86,7 +86,7 @@ RSpec.describe Webui::PackageHelper, type: :helper do
 
       it "when it ends by .service" do
         property_of {
-          sized(range(1, 191)){ string(/./) } + '.service'
+          sized(range(1, 191)) { string(/./) } + '.service'
         }.check(3) { |filename|
           expect(guess_code_class(filename)).to eq('xml')
         }
@@ -101,7 +101,7 @@ RSpec.describe Webui::PackageHelper, type: :helper do
     context "is shell" do
       it "with rc-scripts" do
         property_of {
-          'rc' + sized(range(1, 197)){ string(/[\w-]/) }
+          'rc' + sized(range(1, 197)) { string(/[\w-]/) }
         }.check(3) { |filename|
           expect(guess_code_class(filename)).to eq('shell')
         }
@@ -111,7 +111,7 @@ RSpec.describe Webui::PackageHelper, type: :helper do
     context "is python" do
       it "when it ends in rpmlintrc" do
         property_of {
-          sized(range(0, 190)){ string(/./) } + 'rpmlintrc'
+          sized(range(0, 190)) { string(/./) } + 'rpmlintrc'
         }.check(3) { |filename|
           expect(guess_code_class(filename)).to eq('python')
         }
@@ -129,7 +129,7 @@ RSpec.describe Webui::PackageHelper, type: :helper do
     context "is spec" do
       it "when it starts with macros." do
         property_of {
-          'macros.' + sized(range(1, 192)){ string(/\w/) }
+          'macros.' + sized(range(1, 192)) { string(/\w/) }
         }.check(3) { |filename|
           expect(guess_code_class(filename)).to eq('spec')
         }

--- a/src/api/spec/models/package_spec.rb
+++ b/src/api/spec/models/package_spec.rb
@@ -236,7 +236,7 @@ RSpec.describe Package, vcr: true do
 
       it "has an invalid character in first position" do
         property_of {
-          string = sized(1){ string(/[-+_\.]/) } + sized(range(0, 199)){ string(/[-+\w\.]/) }
+          string = sized(1) { string(/[-+_\.]/) } + sized(range(0, 199)) { string(/[-+\w\.]/) }
           guard string !~ /^(_product|_product:\w|_patchinfo|_patchinfo:\w|_pattern|_project)/
           string
         }.check { |string|
@@ -246,7 +246,7 @@ RSpec.describe Package, vcr: true do
 
       it "has more than 200 characters" do
         property_of {
-          sized(1){ string(/[a-zA-Z0-9]/) } + sized(200) { string(/[-+\w\.:]/) }
+          sized(1) { string(/[a-zA-Z0-9]/) } + sized(200) { string(/[-+\w\.:]/) }
         }.check(3) { |string|
           expect(Package.valid_name?(string)).to be(false)
         }

--- a/src/api/spec/models/project_spec.rb
+++ b/src/api/spec/models/project_spec.rb
@@ -234,7 +234,7 @@ RSpec.describe Project, vcr: true do
 
       it "has ::" do
         property_of {
-          string = sized(1){ string(/[a-zA-Z0-9]/) } + sized(range(1, 199)){ string(/[-+\w\.]/) }
+          string = sized(1) { string(/[a-zA-Z0-9]/) } + sized(range(1, 199)) { string(/[-+\w\.]/) }
           index = range(0, (string.length - 2))
           string[index] = string[index + 1] = ':'
           string
@@ -245,7 +245,7 @@ RSpec.describe Project, vcr: true do
 
       it "end with :" do
         property_of {
-          string = sized(1){ string(/[a-zA-Z0-9]/) } + sized(range(0, 198)){ string(/[-+\w\.:]/) } + ':'
+          string = sized(1) { string(/[a-zA-Z0-9]/) } + sized(range(0, 198)) { string(/[-+\w\.:]/) } + ':'
           guard string !~ /::/
           string
         }.check { |string|
@@ -255,7 +255,7 @@ RSpec.describe Project, vcr: true do
 
       it "has an invalid character in first position" do
         property_of {
-          string = sized(1){ string(/[-+\.:_]/) } + sized(range(0, 199)){ string(/[-+\w\.:]/) }
+          string = sized(1) { string(/[-+\.:_]/) } + sized(range(0, 199)) { string(/[-+\w\.:]/) }
           guard !(string[-1] == ':' && string.length > 1) && string !~ /::/
           string
         }.check { |string|
@@ -265,7 +265,7 @@ RSpec.describe Project, vcr: true do
 
       it "has more than 200 characters" do
         property_of {
-          string = sized(1){ string(/[a-zA-Z0-9]/) } + sized(200) { string(/[-+\w\.:]/) }
+          string = sized(1) { string(/[a-zA-Z0-9]/) } + sized(200) { string(/[-+\w\.:]/) }
           guard string[-1] != ':' && string !~ /::/
           string
         }.check(3) { |string|
@@ -279,7 +279,7 @@ RSpec.describe Project, vcr: true do
 
     it "valid" do
       property_of {
-        string = sized(1){ string(/[a-zA-Z0-9]/) } + sized(range(0, 199)){ string(/[-+\w\.:]/) }
+        string = sized(1) { string(/[a-zA-Z0-9]/) } + sized(range(0, 199)) { string(/[-+\w\.:]/) }
         guard string != '0' && string[-1] != ':' && !(/::/ =~ string)
         string
       }.check { |string|


### PR DESCRIPTION
Add some spaces to use the same syntax that it is used in Rantly documentation everywhere. :bowtie: 