### PR TITLE
[api] Handle multibuilds in API call to _result

### DIFF
--- a/src/api/app/controllers/build_controller.rb
+++ b/src/api/app/controllers/build_controller.rb
@@ -169,11 +169,12 @@ class BuildController < ApplicationController
     required_parameters :package, :pathproject
 
     pkg = Package.get_by_project_and_name(params[:project], params[:package],
-                                          {use_source: false, follow_project_links: true})
+                                          {use_source: false, follow_project_links: true, follow_multibuild: true})
     raise RemoteProjectError, 'The package lifes in a remote project, this is not supported atm' unless pkg
 
     tprj = Project.get_by_name params[:pathproject]
-    bs = PackageBuildStatus.new(pkg).result(target_project: tprj, srcmd5: params[:srcmd5])
+    multibuild_package = params[:package] if params[:package].include?(':')
+    bs = PackageBuildStatus.new(pkg).result(target_project: tprj, srcmd5: params[:srcmd5], multibuild_pkg: multibuild_package)
     @result = []
     bs.each do |repo, status|
       archs = []

--- a/src/api/app/models/package_build_status.rb
+++ b/src/api/app/models/package_build_status.rb
@@ -13,6 +13,7 @@ class PackageBuildStatus
 
   def result(opts = {})
     @srcmd5 = opts[:srcmd5]
+    @multibuild_pkg = opts[:multibuild_pkg]
     gather_md5sums
 
     tocheck_repos = @pkg.project.repositories_linking_project(opts[:target_project])
@@ -90,9 +91,8 @@ class PackageBuildStatus
   def gather_current_buildcode(srep, arch)
     @buildcode = "unknown"
     begin
-      # rubocop:disable Metrics/LineLength
-      uri = URI("/build/#{CGI.escape(@pkg.project.name)}/_result?package=#{CGI.escape(@pkg.name)}&repository=#{CGI.escape(srep['name'])}&arch=#{CGI.escape(arch)}")
-      # rubocop:enable Metrics/LineLength
+      package = CGI.escape(@multibuild_pkg || @pkg.name)
+      uri = URI("/build/#{CGI.escape(@pkg.project.name)}/_result?package=#{package}&repository=#{CGI.escape(srep['name'])}&arch=#{CGI.escape(arch)}")
       resultlist = Xmlhash.parse(ActiveXML.backend.direct_http(uri))
       currentcode = nil
       resultlist.elements('result') do |r|


### PR DESCRIPTION
Fixes #3026

In case of multibuilds we need to fetch the sources of the package
container, but the build results of the queried multibuild package.
This commit should do the trick.

Kudos to Michael for pointing me towards the right direction.