### PR TITLE
[ci] Move RedundantMatch cop to `.rubocop.yml`

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -219,6 +219,10 @@ Lint/UselessAssignment:
 Performance/RedundantBlockCall:
   Enabled: true
 
+# Identifies uses of `Regexp#match` and `String#match where `=~` could be used as well
+Performance/RedundantMatch:
+  Enabled: true
+
 # Identifies places where Hash#merge! can be replaced by Hash#[]=
 Performance/RedundantMerge:
   Enabled: true

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -189,13 +189,6 @@ Rails/ReadWriteAttribute:
     - 'src/api/app/models/review.rb'
     - 'src/api/app/models/user.rb'
 
-# Offense count: 1
-# Cop supports --auto-correct.
-# Identifies uses of `Regexp#match` and `String#match where `=~` could be used as well
-Performance/RedundantMatch:
-  Exclude:
-    - 'dist/t/spec/features/0040_prepare_package_building_spec.rb'
-
 # Offense count: 51
 # Configuration parameters: Include.
 # Include: db/migrate/*.rb


### PR DESCRIPTION
There are no offenses of this cop anymore. :bowtie: 