### PR TITLE
Refactor and test codemirror editor in WebuiHelper

### DIFF
--- a/src/api/app/helpers/webui/webui_helper.rb
+++ b/src/api/app/helpers/webui/webui_helper.rb
@@ -219,28 +219,20 @@ module Webui::WebuiHelper
   end
 
   def next_codemirror_uid
+    return @codemirror_editor_setup = 0 unless @codemirror_editor_setup
     @codemirror_editor_setup += 1
-    @codemirror_editor_setup
   end
 
-  def setup_codemirror_editor(opts = {})
-    if @codemirror_editor_setup
-      return next_codemirror_uid
-    end
-    @codemirror_editor_setup = 0
-    opts.reverse_merge!({ read_only: false, no_border: false, width: 'auto' })
+  def codemirror_style(opts = {})
+    opts.reverse_merge!({ read_only: false, no_border: false, width: 'auto', height: 'auto' })
 
-    content_for(:content_for_head, javascript_include_tag('webui/application/cm2/index'))
-    style = ''
-    style += ".CodeMirror {\n"
+    style = ".CodeMirror {\n"
     if opts[:no_border] || opts[:read_only]
       style += "border-width: 0 0 0 0;\n"
     end
     style += "height: #{opts[:height]};\n" unless opts[:height] == 'auto'
     style += "width: #{opts[:width]}; \n" unless opts[:width] == 'auto'
-    style += "}\n"
-    content_for(:head_style, style)
-    @codemirror_editor_setup
+    style + "}\n"
   end
 
   def remove_dialog_tag(text)

--- a/src/api/app/views/shared/_editor.html.erb
+++ b/src/api/app/views/shared/_editor.html.erb
@@ -1,7 +1,10 @@
 <% save ||= {} %>
 <% read_only ||= false %>
 
-<% uid ||= setup_codemirror_editor(read_only: read_only) %>
+<% uid ||= next_codemirror_uid %>
+
+<% content_for(:content_for_head, javascript_include_tag('webui/application/cm2/index')) %>
+<% content_for(:head_style, codemirror_style(read_only: read_only)) %>
 
 <% unless read_only %>
     <div id="top_<%= uid %>">

--- a/src/api/app/views/shared/_sourcediff.html.erb
+++ b/src/api/app/views/shared/_sourcediff.html.erb
@@ -5,7 +5,9 @@
    div_opts[:id] = css_id
    div_opts[:class] = "table_wrapper #{css_class}" %>
 
-<% setup_codemirror_editor(height: 'auto', width: editor_width, no_border: true) # we need to have this here for ajax only diffs %>
+<% next_codemirror_uid %>
+<% content_for(:content_for_head, javascript_include_tag('webui/application/cm2/index')) %>
+<% content_for(:head_style, codemirror_style(height: 'auto', width: editor_width, no_border: true)) %>
 
 <%= content_tag(:div, div_opts) do %>
 <% if filenames && filenames.length > 0 %>

--- a/src/api/spec/helpers/webui/webui_helper_spec.rb
+++ b/src/api/spec/helpers/webui/webui_helper_spec.rb
@@ -330,8 +330,40 @@ RSpec.describe Webui::WebuiHelper do
     skip('Please add some tests')
   end
 
-  describe '#setup_codemirror_editor' do
-    skip('Please add some tests')
+  describe '#codemirror_style' do
+    context 'option height' do
+      it 'uses auto as default value' do
+        expect(codemirror_style).to_not include('height')
+      end
+
+      it 'get set properly' do
+        expect(codemirror_style(height: '250px')).to include('height: 250px;')
+      end
+    end
+
+    context 'option width' do
+      it 'uses auto as default value' do
+        expect(codemirror_style).to_not include('width')
+      end
+
+      it 'get set properly' do
+        expect(codemirror_style(width: '250px')).to include('width: 250px;')
+      end
+    end
+
+    context 'option border' do
+      it 'does not remove border' do
+        expect(codemirror_style).not_to include('border-width')
+      end
+
+      it 'removes the border if in read-only mode' do
+        expect(codemirror_style(read_only: true)).to include('border-width')
+      end
+
+      it 'removes the border if no_border is set' do
+        expect(codemirror_style(no_border: true)).to include('border-width')
+      end
+    end
   end
 
   describe '#package_link' do


### PR DESCRIPTION
Remove `#setup_codemirror_editor` method and introduce `#codemirror_style` method instead to have all the `head_style` parameters code separated in one method.

Also, add test for `#codemirror_style`.

The code can also be refactor more, but the testing part that was the main goal of this PR is working. :bowtie: 

Supersedes https://github.com/openSUSE/open-build-service/pull/3102