### PR TITLE
[ci] Fix flaky user_and_role helper spec

### DIFF
--- a/src/api/spec/helpers/webui/webui_helper_spec.rb
+++ b/src/api/spec/helpers/webui/webui_helper_spec.rb
@@ -360,8 +360,8 @@ RSpec.describe Webui::WebuiHelper do
 
       it 'does not link to user profiles' do
         expect(user_and_role(user.login)).to eq(
-          "<img width=\"20\" height=\"20\" alt=\"#{user.realname}\" " + \
-          "src=\"/user/icon/#{user.login}?size=20\" />#{user.realname} (#{user.login})"
+          "<img width=\"20\" height=\"20\" alt=\"#{CGI.escapeHTML(user.realname)}\" " + \
+          "src=\"/user/icon/#{user.login}?size=20\" />#{CGI.escapeHTML(user.realname)} (#{user.login})"
         )
       end
     end


### PR DESCRIPTION
and escape the realname.
Otherwise the test fails when FactoryGirl creates a user with special characters
in the realnme (e.g. Judy O'Donnel).