### PR TITLE
[dist] A custom git command to diff against a deployments

### DIFF
--- a/contrib/git-diff-to-deploy
+++ b/contrib/git-diff-to-deploy
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+if [ -z $1 ]; then
+  export api_url="https://api.opensuse.org"
+else
+  export api_url=$1
+fi
+
+DEPLOYED_REVISION=`osc -A $api_url api /about|awk -F'[<|>]' '/revision/{printf("%s\n",$3)}'|rev|cut -d . -f 1|rev`
+git log -p --reverse --no-merges $DEPLOYED_REVISION..master -- . ':!src/api/spec'


### PR DESCRIPTION
On a synced master branch...
```
git checkout master
git fetch upstream
git reset --hard upstream/master
```
you can diff against an API from your osc setup, default is api.opensuse.org

```
git diff-to-deploy
```
or 
```
git diff-to-deploy https://api-test.opensuse.org
```