### PR TITLE
[webui] Add end_date parameter to monitor events

### DIFF
--- a/src/api/app/controllers/webui/monitor_controller.rb
+++ b/src/api/app/controllers/webui/monitor_controller.rb
@@ -85,12 +85,15 @@ class Webui::MonitorController < Webui::WebuiController
     render json: workers
   end
 
-  def gethistory(key, range, cache = 1)
-    cachekey = key + "-#{range}"
-    Rails.cache.delete(cachekey, shared: true) unless cache
-    Rails.cache.fetch(cachekey, expires_in: (range.to_i * 3600) / 150, shared: true) do
-      hash = StatusHistory.history_by_key_and_hours(key, range)
-      hash.sort { |a, b| a[0] <=> b[0] }
+  def gethistory(key, range, end_date, cache = 1)
+    if end_date.present?
+      StatusHistory.history_by_key_and_hours(key, range, end_date).sort { |a, b| a[0] <=> b[0] }
+    else
+      cachekey = key + "-#{range}"
+      Rails.cache.delete(cachekey, shared: true) unless cache
+      Rails.cache.fetch(cachekey, expires_in: (range.to_i * 3600) / 150, shared: true) do
+        StatusHistory.history_by_key_and_hours(key, range).sort { |a, b| a[0] <=> b[0] }
+      end
     end
   end
 
@@ -101,18 +104,19 @@ class Webui::MonitorController < Webui::WebuiController
 
     arch = params[:arch]
     range = params[:range]
+    end_date = params[:end_date] || ''
     %w{waiting blocked squeue_high squeue_med}.each do |prefix|
-      data[prefix] = gethistory(prefix + '_' + arch, range, !discard_cache?).map { |time, value| [time * 1000, value] }
+      data[prefix] = gethistory(prefix + '_' + arch, range, end_date, !discard_cache?).map { |time, value| [time * 1000, value] }
     end
     %w{idle building away down dead}.each do |prefix|
-      data[prefix] = gethistory(prefix + '_' + map_to_workers(arch), range, !discard_cache?).map { |time, value| [time * 1000, value] }
+      data[prefix] = gethistory(prefix + '_' + map_to_workers(arch), range, end_date, !discard_cache?).map { |time, value| [time * 1000, value] }
     end
     low = Hash.new
-    gethistory("squeue_low_#{arch}", range).each do |time, value|
+    gethistory("squeue_low_#{arch}", range, end_date).each do |time, value|
       low[time] = value
     end
     comb = Array.new
-    gethistory("squeue_next_#{arch}", range).each do |time, value|
+    gethistory("squeue_next_#{arch}", range, end_date).each do |time, value|
       clow = low[time] || 0
       comb << [1000 * time, clow + value]
     end

--- a/src/api/app/models/status_history.rb
+++ b/src/api/app/models/status_history.rb
@@ -1,10 +1,14 @@
 class StatusHistory < ApplicationRecord
-  def self.history_by_key_and_hours(key, hours = 24)
-    starttime = Time.now.to_i - hours.to_i * 3600
-
-    where("time >= ? AND \`key\` = ?", starttime, key).
-      pluck(:time, :value).
-      collect { |time, value| [time.to_i, value.to_f] }
+  def self.history_by_key_and_hours(key, hours = 24, end_date = '')
+    result = if end_date.empty?
+      start_time = Time.now.to_i - hours.to_i * 3600
+      where("time >= ? AND \`key\` = ?", start_time, key)
+    else
+      end_time = Time.strptime(end_date, "%Y%m%d").to_i
+      start_time = end_time - hours.to_i * 3600
+      where("time >= ? AND time <= ? AND \`key\` = ?", start_time, end_time, key)
+    end
+    result.pluck(:time, :value).collect { |time, value| [time.to_i, value.to_f] }
   end
 end
 


### PR DESCRIPTION
Add a 'end_date' parameter to monitor events' query.
The 'end_date' paramenter expects a date (in YYYYMMDD format).
When defined it will return results from that date backwards.