### PR TITLE
[backend] readded 'repository' to $BSXML::packinfo

### DIFF
--- a/src/backend/BSXML.pm
+++ b/src/backend/BSXML.pm
@@ -189,7 +189,7 @@ our $packinfo = [
 	    'nosrcpkgs',	# kiwi
 	 [[ 'path' =>
 		'project',
-		'project',
+		'repository',
 		'priority',
 	]],
 	 [[ 'extrasource' =>


### PR DESCRIPTION
Without this patch all test cases which use BSXML::packinfo break.
E.g.

[  318s] t/0360-BSRepServer-BuildInfo-Package.t ......
[  318s] 1..3
[  318s] ok 1 - use BSRepServer::BuildInfo;
[  318s] ok 2 - buildinfo for screen
[  318s] fetching remote repository state for openSUSE.org:OBS:Server:Unstable/openSUSE_42.1
[  318s] fetching remote repository state for openSUSE.org:openSUSE:Leap:42.1/standard
[  318s] ok 3 - buildinfo for regular Package with remotemap
[  318s] ok
[  319s] unknown attribute: repository

This patch changes duplicate 'project' entry back to 'repository' as it looks like the change
happend accidently