### PR TITLE
[webui] Drop escaper mixin

### DIFF
--- a/src/api/app/controllers/webui/package_controller.rb
+++ b/src/api/app/controllers/webui/package_controller.rb
@@ -5,7 +5,6 @@ class Webui::PackageController < Webui::WebuiController
   require_dependency 'opensuse/validator'
   include ParsePackageDiff
   include Webui::PackageHelper
-  include Escaper
   include Webui::LoadBuildresults
   include Webui::ManageRelationships
   include BuildLogSupport
@@ -950,7 +949,7 @@ class Webui::PackageController < Webui::WebuiController
   end
 
   def get_rpmlint_log(project, package, repository, architecture)
-    path = "/build/#{pesc project}/#{pesc repository}/#{pesc architecture}/#{pesc package}/rpmlint.log"
+    path = URI.escape("/build/#{project}/#{repository}/#{architecture}/#{package}/rpmlint.log")
     ActiveXML.backend.direct_http(URI(path), timeout: 500)
   end
 

--- a/src/api/app/mixins/build_log_support.rb
+++ b/src/api/app/mixins/build_log_support.rb
@@ -1,9 +1,7 @@
 module BuildLogSupport
-  include Escaper
-
   def raw_log_chunk( project, package, repo, arch, start, theend )
     logger.debug "get log chunk #{start}-#{theend}"
-    path = "/build/#{pesc project}/#{pesc repo}/#{pesc arch}/#{pesc package}/_log?nostream=1&start=#{start}&end=#{theend}"
+    path = URI.escape("/build/#{project}/#{repo}/#{arch}/#{package}/_log?nostream=1&start=#{start}&end=#{theend}")
     ActiveXML.backend.direct_http URI(path), timeout: 500
   end
 
@@ -29,7 +27,7 @@ module BuildLogSupport
 
   def get_size_of_log( project, package, repo, arch)
     logger.debug 'get log entry'
-    path = "/build/#{pesc project}/#{pesc repo}/#{pesc arch}/#{pesc package}/_log?view=entry"
+    path = URI.escape("/build/#{project}/#{repo}/#{arch}/#{package}/_log?view=entry")
     data = ActiveXML.backend.direct_http URI(path), timeout: 500
     return 0 unless data
     doc = Xmlhash.parse(data)
@@ -39,13 +37,13 @@ module BuildLogSupport
     0
   end
 
-  def get_job_status( project, package, repo, arch)
-    path = "/build/#{pesc project}/#{pesc repo}/#{pesc arch}/#{pesc package}/_jobstatus"
+  def get_job_status(project, package, repo, arch)
+    path = URI.escape("/build/#{project}/#{repo}/#{arch}/#{package}/_jobstatus")
     ActiveXML.backend.direct_http URI(path), timeout: 500
   end
 
   def get_status(project, package, repo, arch)
-    path = "/build/#{pesc project}/_result?view=status&package=#{pesc package}&arch=#{pesc arch}&repository=#{pesc repo}"
+    path = URI.escape("/build/#{project}/_result?view=status&package=#{package}&arch=#{arch}&repository=#{repo}")
     code = ""
     data = ActiveXML.backend.direct_http URI(path), timeout: 500
     return code unless data

--- a/src/api/app/mixins/escaper.rb
+++ b/src/api/app/mixins/escaper.rb
@@ -1,6 +1,0 @@
-module Escaper
-  # path escape
-  def pesc(str)
-    URI.escape str.to_s
-  end
-end


### PR DESCRIPTION
Uses the URI::escape directly, without wrapping it into a helper method.