### PR TITLE
[webui] Rack::MiniProfiler lines not used anymore

### DIFF
--- a/src/api/config/initializers/activexml.rb
+++ b/src/api/config/initializers/activexml.rb
@@ -22,16 +22,6 @@ map.connect :statistic, 'rest:///build/:project/:repository/:arch/:package/_stat
 
 map.connect :service, 'rest:///source/:project/:package/_service?:user'
 
-if defined?(Rack::MiniProfiler)
-  ::Rack::MiniProfiler.profile_method(ActiveXML::Transport, :http_do) do |method, url|
-    if url.kind_of? String
-      "#{method.to_s.upcase} #{url}"
-    else
-      "#{method.to_s.upcase} #{url.path}?#{url.query}"
-    end
-  end
-end
-
 map = ActiveXML.setup_transport_api(CONFIG['frontend_protocol'], CONFIG['frontend_host'], CONFIG['frontend_port'])
 
 map.connect :webuiproject, 'rest:///source/:name/_meta?:view',


### PR DESCRIPTION
Time ago rack-mini-profiler gem was used. Now it is not used. These lines
were left and now they are not needed.