### PR TITLE
[rake] Fix regex in pull_requests.rake

### DIFF
--- a/src/api/lib/tasks/statistics/github/pull_requests.rake
+++ b/src/api/lib/tasks/statistics/github/pull_requests.rake
@@ -62,7 +62,7 @@ namespace :statistics do
     end
 
     def on_last_page?(links)
-      link_rel = links.first.match(/.*rel=\"(\w+*)\"/).captures.first
+      link_rel = links.first.match(/.*rel=\"(\w*)\"/).captures.first
       link_rel == 'first'
     end
 


### PR DESCRIPTION
There was an additional regex operator that caused the parser lib to
send a warning. This fixes it.

```
/usr/lib64/ruby/gems/2.4.0/gems/parser-2.3.3.1/lib/parser/builders/default.rb:1562: warning: nested repeat operator '+' and '*' was replaced with '*' in regular expression: /.*rel=\"(\w+*)\"/
```