### PR TITLE
[dist] Enable enforce_project_keys in Vagrant

### DIFF
--- a/contrib/bootstrap.sh
+++ b/contrib/bootstrap.sh
@@ -33,4 +33,6 @@ setup_data_dir
 
 chown_vagrant_owned_dirs
 
+configure_api
+
 exit 0

--- a/contrib/common.sh
+++ b/contrib/common.sh
@@ -82,6 +82,11 @@ function configure_app() {
   copy_example_file options.yml || return 1
 }
 
+function configure_api() {
+  echo -e "\nconfiguring your api...\n"
+  su - vagrant -c "cd /vagrant/src/api/; bundle exec rails runner 'Configuration.first.update(enforce_project_keys: true)'"
+}
+
 function configure_database() {
   copy_example_file database.yml || return 1
   check_for_databases && return 1


### PR DESCRIPTION
This is needed to create keys by default for the signer setup.