### PR TITLE
[webui][api] refactor EventFindSubscribers => EventFindSubscriptions

### DIFF
--- a/src/api/app/jobs/send_event_emails.rb
+++ b/src/api/app/jobs/send_event_emails.rb
@@ -13,8 +13,9 @@ class SendEventEmails
         # if someone else saved it too, better don't continue - we're not alone
         return false
       end
-      subscribers = event.subscribers
-      next if subscribers.empty?
+      subscriptions = event.subscriptions
+      next if subscriptions.empty?
+      subscribers = subscriptions.map(&:subscriber)
       EventMailer.event(subscribers, event).deliver_now
     end
     true

--- a/src/api/app/models/event/base.rb
+++ b/src/api/app/models/event/base.rb
@@ -190,8 +190,8 @@ module Event
       ret
     end
 
-    def subscribers
-      EventFindSubscribers.new(self).subscribers
+    def subscriptions
+      EventFindSubscriptions.new(self).subscriptions
     end
 
     # to calculate expensive things we don't want to store in database (i.e. diffs)

--- a/src/api/app/models/event_find_subscriptions.rb
+++ b/src/api/app/models/event_find_subscriptions.rb
@@ -1,18 +1,39 @@
 # strategy class for the event model
-class EventFindSubscribers
+class EventFindSubscriptions
   def initialize(event)
     @event = event
   end
 
+  def subscriptions
+    @payload = @event.payload
+    @subscriptions = EventSubscription.where(eventtype: @event.class.classnames)
+
+    # 1. generic defaults
+    @toconsider = @subscriptions.where('user_id is null AND group_id is null').to_a
+    @event.class.receiver_roles.each do |r|
+      unless receiver_role_set(r)
+        @toconsider << EventSubscription.new(eventtype: @event.class.name, receiver_role: r, receive: false)
+      end
+    end
+
+    # 2. user and group specifics
+    generics = @subscriptions
+    @toconsider |= generics.where(receiver_role: :all).to_a
+
+    return [] if @toconsider.empty?
+
+    expand_toconsider
+    filter_toconsider
+  end
+
+  private
+
   def expand_toconsider
-    nt = []
-    @toconsider.each do |r|
-      nt.concat(expand_one_rule(r))
+    new_toconsider = []
+    @toconsider.each do |subscription|
+      new_toconsider.concat(expand_one_rule(subscription))
     end
-    @toconsider = nt
-    @toconsider.each do |t|
-      Rails.logger.debug "Expanded #{t.inspect}"
-    end
+    @toconsider = new_toconsider
   end
 
   def expand_one_rule(r)
@@ -21,9 +42,6 @@ class EventFindSubscribers
     end
 
     receivers = @event.send("#{r.receiver_role}s")
-    receivers.each do |u|
-      Rails.logger.debug "Event for receiver_role #{r.receiver_role} goes to #{u}"
-    end
 
     # fetch database settings
     user_ids = receivers.select { |rcv| rcv.kind_of? User }.map(&:id)
@@ -59,8 +77,8 @@ class EventFindSubscribers
     ret
   end
 
-  def compare_two_rules(x, y)
-    # prefer rules in the database
+  def compare_two_subscriptions(x, y)
+    # prefer subscriptions in the database
     return -1 if x.id && !y.id
     return 1 if !x.id && y.id
 
@@ -76,10 +94,8 @@ class EventFindSubscribers
     -1
   end
 
-  def check_rules?(rules)
-    rules.sort! { |x, y| compare_two_rules(x, y) }
-    return false unless rules[0].receive
-    true
+  def sort_subscriptions_by_priority(subscriptions)
+    subscriptions.sort { |x, y| compare_two_subscriptions(x, y) }
   end
 
   def user_subscribed_to_group_email?(group, user)
@@ -87,59 +103,27 @@ class EventFindSubscribers
   end
 
   def filter_toconsider
-    receivers = Hash.new
+    subscribers_and_subscriptions = Hash.new
 
-    @toconsider.each do |r|
-      if r.group_id
-        group = Group.find(r.group_id)
-        next if group.email.blank?
-        receivers[group] ||= Array.new
-        receivers[group] << r
-      end
-
-      # add users
-      next unless r.user_id
-      u = User.find(r.user_id)
-      receivers[u] ||= Array.new
-      receivers[u] << r
+    @toconsider.each do |subscription|
+      subscribers_and_subscriptions[subscription.subscriber] ||= []
+      subscribers_and_subscriptions[subscription.subscriber] << subscription
     end
 
-    ret = []
-    receivers.each do |rcv, rules|
-      if check_rules? rules
-        ret << rcv
-      end
+    subscriptions_to_receive = []
+    subscribers_and_subscriptions.each do |subscriber, subscriptions|
+      sorted_subscriptions = sort_subscriptions_by_priority(subscriptions)
+      subscriptions_to_receive << sorted_subscriptions.first
     end
 
-    ret
+    subscriptions_to_receive.reject! do |subscription|
+      subscription.subscriber == @event.originator
+    end
+
+    subscriptions_to_receive
   end
 
   def receiver_role_set(role)
     @toconsider.any? {|r| r.receiver_role.to_sym == role.to_sym}
-  end
-
-  def subscribers
-    @payload = @event.payload
-    @subscriptions = EventSubscription.where(eventtype: @event.class.classnames)
-
-    # 1. generic defaults
-    @toconsider = @subscriptions.where('user_id is null AND group_id is null').to_a
-    @event.class.receiver_roles.each do |r|
-      unless receiver_role_set(r)
-        @toconsider << EventSubscription.new(eventtype: @event.class.name, receiver_role: r, receive: false)
-      end
-    end
-
-    # 2. user and group specifics
-    generics = @subscriptions
-    @toconsider |= generics.where(receiver_role: :all).to_a
-
-    @toconsider.each do |t|
-      Rails.logger.debug "To consider #{t.inspect}"
-    end
-    return [] if @toconsider.empty?
-
-    expand_toconsider
-    filter_toconsider
   end
 end

--- a/src/api/app/models/event_subscription.rb
+++ b/src/api/app/models/event_subscription.rb
@@ -5,6 +5,14 @@ class EventSubscription < ApplicationRecord
   validates :receiver_role, inclusion: { in: [:all, :maintainer, :bugowner, :reader, :source_maintainer,
                                               :target_maintainer, :reviewer, :commenter, :creator] }
 
+  def subscriber
+    if user_id.present?
+      user
+    elsif group_id.present?
+      group
+    end
+  end
+
   def receiver_role
     read_attribute(:receiver_role).to_sym
   end

--- a/src/api/spec/jobs/send_event_emails_spec.rb
+++ b/src/api/spec/jobs/send_event_emails_spec.rb
@@ -1,0 +1,32 @@
+require 'rails_helper'
+
+RSpec.describe SendEventEmails, type: :job do
+  include ActiveJob::TestHelper
+
+  describe '#perform' do
+    before do
+      ActionMailer::Base.deliveries = []
+      # Needed for X-OBS-URL
+      allow_any_instance_of(Configuration).to receive(:obs_url).and_return('https://build.example.com')
+    end
+
+    let!(:user) { create(:confirmed_user) }
+    let!(:comment_author) { create(:confirmed_user) }
+    let!(:group) { create(:group) }
+
+    let!(:subscription1) { create(:event_subscription_comment_for_project, receiver_role: 'all', user: user) }
+    let!(:subscription2) { create(:event_subscription_comment_for_project, receiver_role: 'all', user: nil, group: group) }
+    let!(:subscription3) { create(:event_subscription_comment_for_project, receiver_role: 'all', user: comment_author) }
+
+    let!(:comment) { create(:comment_project, body: "Hey @#{user.login} how are things?", user: comment_author) }
+
+    subject! { SendEventEmails.new.perform }
+
+    it 'sends an email to the subscribers' do
+      email = ActionMailer::Base.deliveries.first
+
+      expect(email.to).to eq([user.email, group.email])
+      expect(email.subject).to include('New comment')
+    end
+  end
+end

--- a/src/api/spec/models/event_find_subscriptions_spec.rb
+++ b/src/api/spec/models/event_find_subscriptions_spec.rb
@@ -1,0 +1,30 @@
+require 'rails_helper'
+
+RSpec.describe EventFindSubscriptions do
+  describe '#subscribers' do
+    let!(:comment_author) { create(:confirmed_user) }
+    let!(:user1) { create(:confirmed_user) }
+    let!(:user2) { create(:confirmed_user) }
+    let!(:group1) { create(:group) }
+    let!(:group2) { create(:group) }
+
+    let!(:subscription1) { create(:event_subscription_comment_for_project, receiver_role: 'all', user: comment_author) }
+    let!(:subscription2) { create(:event_subscription_comment_for_project, receiver_role: 'all', user: user1) }
+    let!(:subscription3) { create(:event_subscription_comment_for_project, receiver_role: 'all', user: user2) }
+    let!(:subscription4) { create(:event_subscription_comment_for_project, receiver_role: 'all', user: nil, group: group1) }
+    let!(:subscription5) { create(:event_subscription_comment_for_project, receiver_role: 'all', user: nil, group: group2) }
+
+    let!(:comment) { create(:comment_project, body: "Hey @#{user1.login} how are things?", user: comment_author) }
+    let(:event) { Event::CommentForProject.first }
+
+    subject! { EventFindSubscriptions.new(event).subscriptions }
+
+    it 'includes the users and groups subscribed to Event::CommentForProject' do
+      expect(subject).to include(subscription2, subscription3, subscription4, subscription5)
+    end
+
+    it 'does not include the author of the comment' do
+      expect(subject).not_to include(subscription1)
+    end
+  end
+end


### PR DESCRIPTION
In order to complete the daily notifications card I need `EventFindSubscriptions` class to return instances of the `EventSubscription` model itself and not the `User` or `Group` and it belongs_to.

https://trello.com/c/UtWz4k0g/404-(8)-p2%3A-notification-frequency