### PR TITLE
[webui][api] refactor EventFindSubscribers => EventFindSubscriptions

### DIFF
--- a/src/api/app/models/event/base.rb
+++ b/src/api/app/models/event/base.rb
@@ -190,8 +190,12 @@ module Event
       ret
     end
 
+    def subscriptions
+      EventFindSubscriptions.new(self).subscriptions
+    end
+
     def subscribers
-      EventFindSubscribers.new(self).subscribers
+      subscriptions.map(&:subscriber)
     end
 
     # to calculate expensive things we don't want to store in database (i.e. diffs)

--- a/src/api/app/models/event_subscription.rb
+++ b/src/api/app/models/event_subscription.rb
@@ -5,6 +5,14 @@ class EventSubscription < ApplicationRecord
   validates :receiver_role, inclusion: { in: [:all, :maintainer, :bugowner, :reader, :source_maintainer,
                                               :target_maintainer, :reviewer, :commenter, :creator] }
 
+  def subscriber
+    if user_id.present?
+      user
+    elsif group_id.present?
+      group
+    end
+  end
+
   def receiver_role
     read_attribute(:receiver_role).to_sym
   end

--- a/src/api/spec/jobs/send_event_emails_spec.rb
+++ b/src/api/spec/jobs/send_event_emails_spec.rb
@@ -1,0 +1,32 @@
+require 'rails_helper'
+
+RSpec.describe SendEventEmails, type: :job do
+  include ActiveJob::TestHelper
+
+  describe '#perform' do
+    before do
+      ActionMailer::Base.deliveries = []
+      # Needed for X-OBS-URL
+      allow_any_instance_of(Configuration).to receive(:obs_url).and_return('https://build.example.com')
+    end
+
+    let!(:user) { create(:confirmed_user) }
+    let!(:comment_author) { create(:confirmed_user) }
+    let!(:group) { create(:group) }
+
+    let!(:subscription1) { create(:event_subscription_comment_for_project, receiver_role: 'all', user: user) }
+    let!(:subscription2) { create(:event_subscription_comment_for_project, receiver_role: 'all', user: nil, group: group) }
+    let!(:subscription3) { create(:event_subscription_comment_for_project, receiver_role: 'all', user: comment_author) }
+
+    let!(:comment) { create(:comment_project, body: "Hey @#{user.login} how are things?", user: comment_author) }
+
+    subject! { SendEventEmails.new.perform }
+
+    it 'sends an email to the subscribers' do
+      email = ActionMailer::Base.deliveries.first
+
+      expect(email.to).to match_array([user.email, group.email])
+      expect(email.subject).to include('New comment')
+    end
+  end
+end

--- a/src/api/spec/models/event_find_subscriptions_spec.rb
+++ b/src/api/spec/models/event_find_subscriptions_spec.rb
@@ -1,0 +1,30 @@
+require 'rails_helper'
+
+RSpec.describe EventFindSubscriptions do
+  describe '#subscribers' do
+    let!(:comment_author) { create(:confirmed_user) }
+    let!(:user1) { create(:confirmed_user) }
+    let!(:user2) { create(:confirmed_user) }
+    let!(:group1) { create(:group) }
+    let!(:group2) { create(:group) }
+
+    let!(:subscription1) { create(:event_subscription_comment_for_project, receiver_role: 'all', user: comment_author) }
+    let!(:subscription2) { create(:event_subscription_comment_for_project, receiver_role: 'all', user: user1) }
+    let!(:subscription3) { create(:event_subscription_comment_for_project, receiver_role: 'all', user: user2) }
+    let!(:subscription4) { create(:event_subscription_comment_for_project, receiver_role: 'all', user: nil, group: group1) }
+    let!(:subscription5) { create(:event_subscription_comment_for_project, receiver_role: 'all', user: nil, group: group2) }
+
+    let!(:comment) { create(:comment_project, body: "Hey @#{user1.login} how are things?", user: comment_author) }
+    let(:event) { Event::CommentForProject.first }
+
+    subject! { EventFindSubscriptions.new(event).subscriptions }
+
+    it 'includes the users and groups subscribed to Event::CommentForProject' do
+      expect(subject).to include(subscription2, subscription3, subscription4, subscription5)
+    end
+
+    it 'does not include the author of the comment' do
+      expect(subject).not_to include(subscription1)
+    end
+  end
+end

--- a/src/api/test/models/event_test.rb
+++ b/src/api/test/models/event_test.rb
@@ -32,12 +32,12 @@ class EventTest < ActionDispatch::IntegrationTest
   end
 
   def users_for_event(e)
-    users = EventFindSubscribers.new(e).subscribers
+    users = EventFindSubscriptions.new(e).subscriptions.map(&:subscriber)
     User.where(id: users).pluck(:login).sort
   end
 
   def groups_for_event(e)
-    groups = EventFindSubscribers.new(e).subscribers
+    groups = EventFindSubscriptions.new(e).subscriptions.map(&:subscriber)
     Group.where(id: groups).pluck(:title).sort
   end
 


### PR DESCRIPTION
In order to complete the daily notifications card I need `EventFindSubscriptions` class to return instances of the `EventSubscription` model itself and not the `User` or `Group` that it belongs_to.

https://trello.com/c/UtWz4k0g/404-(8)-p2%3A-notification-frequency

Although @coolo has questioned if this feature is necessary to the product (see discussion in in https://github.com/openSUSE/open-build-service/pull/3189), this PR only refactors code and adds two more specs without changing any functionality, so this PR can be merged regardless of whether or not we want to implement this feature.