### PR TITLE
Spec coverage for CreateJob

### DIFF
--- a/src/api/spec/cassettes/UpdateReleasedBinaries/properly_set/1_1_2.yml
+++ b/src/api/spec/cassettes/UpdateReleasedBinaries/properly_set/1_1_2.yml
@@ -1,0 +1,38 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://localhost:3200/notificationpayload/fake_payload
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 404
+      message: payload does not exist!
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '124'
+    body:
+      encoding: UTF-8
+      string: |
+        <status code="404">
+          <summary>payload does not exist!</summary>
+          <details>404 payload does not exist!</details>
+        </status>
+    http_version: 
+  recorded_at: Mon, 05 Jun 2017 16:18:21 GMT
+recorded_with: VCR 3.0.3

--- a/src/api/spec/cassettes/UpdateReleasedBinaries/properly_set/1_1_3.yml
+++ b/src/api/spec/cassettes/UpdateReleasedBinaries/properly_set/1_1_3.yml
@@ -1,0 +1,73 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://localhost:3200/notificationpayload/fake_payload
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 404
+      message: payload does not exist!
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '124'
+    body:
+      encoding: UTF-8
+      string: |
+        <status code="404">
+          <summary>payload does not exist!</summary>
+          <details>404 payload does not exist!</details>
+        </status>
+    http_version: 
+  recorded_at: Mon, 05 Jun 2017 16:18:21 GMT
+- request:
+    method: get
+    uri: http://localhost:3200/notificationpayload/fake_payload
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 404
+      message: payload does not exist!
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '124'
+    body:
+      encoding: UTF-8
+      string: |
+        <status code="404">
+          <summary>payload does not exist!</summary>
+          <details>404 payload does not exist!</details>
+        </status>
+    http_version: 
+  recorded_at: Mon, 05 Jun 2017 16:18:21 GMT
+recorded_with: VCR 3.0.3

--- a/src/api/spec/jobs/update_released_binaries_spec.rb
+++ b/src/api/spec/jobs/update_released_binaries_spec.rb
@@ -1,0 +1,44 @@
+require 'rails_helper'
+
+RSpec.describe UpdateReleasedBinaries, vcr: true do
+  let(:project) { create(:project_with_repository) }
+  let(:repository) { project.repositories.first }
+  let(:event) { Event::Packtrack.new('project' => project.name, 'repo' => repository.name, 'payload' => 'fake_payload') }
+  let(:event_without_repo) { Event::Packtrack.new('project' => project.name, 'repo' => nil, 'payload' => 'fake_payload') }
+
+  context "properly set" do
+    subject { UpdateReleasedBinaries.new(event) }
+
+    after do
+      Delayed::Job.enqueue subject
+    end
+
+    it { expect(BinaryRelease).to receive(:update_binary_releases).twice }
+    it { expect(subject).to receive(:after) }
+    it { expect(subject).not_to receive(:error) }
+  end
+
+  context "without a repo properly set" do
+    subject { UpdateReleasedBinaries.new(event_without_repo) }
+
+    after do
+      Delayed::Job.enqueue subject
+    end
+
+    it { expect(subject.perform).to be_nil }
+    it { expect(BinaryRelease).not_to receive(:update_binary_releases) }
+  end
+
+  context "when perform raises an exception" do
+    before do
+      allow(BinaryRelease).to receive(:update_binary_releases).and_raise('FakeExceptionMessage')
+    end
+
+    subject { UpdateReleasedBinaries.new(event) }
+
+    it 'runs #error' do
+      is_expected.to receive(:error)
+      expect { Delayed::Job.enqueue subject }.to raise_error('FakeExceptionMessage')
+    end
+  end
+end

--- a/src/api/spec/rails_helper.rb
+++ b/src/api/spec/rails_helper.rb
@@ -52,3 +52,6 @@ require 'support/models/models_authentification'
 
 # support feature switch testing
 require 'feature/testing'
+
+# support Delayed Jobs
+require 'support/delayed_job'

--- a/src/api/spec/support/delayed_job.rb
+++ b/src/api/spec/support/delayed_job.rb
@@ -1,0 +1,6 @@
+# Disabling the delay on delayed jobs
+RSpec.configure do |config|
+  config.before do
+    Delayed::Worker.delay_jobs = false
+  end
+end


### PR DESCRIPTION
Subclass **UpdateReleasedBinaries** was used to test the underlying methods.

BTW, introduced specs for **Delayed Jobs**, so the delay needed to be disabled for running the **perform** method inmidiately