### PR TITLE
Feature/daily digest emails

### DIFF
--- a/src/api/app/jobs/cleanup_events.rb
+++ b/src/api/app/jobs/cleanup_events.rb
@@ -1,7 +1,23 @@
 class CleanupEvents < ApplicationJob
   def perform
     Event::Base.transaction do
-      Event::Base.where(project_logged: true, queued: true, undone_jobs: 0).lock(true).delete_all
+      events_to_be_deleted.lock(true).delete_all
     end
+  end
+
+  private
+
+  def events_to_be_deleted
+    # delete_all will not work with this query so we need to find again by id
+    events_to_be_deleted_array =
+      Event::Base.left_outer_joins(:digest_emails)
+        .select('events.*, MIN(digest_emails.email_sent) AS has_all_digest_emails_sent')
+        .where(project_logged: true, queued: true, undone_jobs: 0)
+        .group('events.id')
+        .having('has_all_digest_emails_sent = 1 OR has_all_digest_emails_sent IS NULL')
+
+    event_ids = events_to_be_deleted_array.map(&:id)
+
+    Event::Base.where(id: event_ids)
   end
 end

--- a/src/api/app/jobs/send_event_emails.rb
+++ b/src/api/app/jobs/send_event_emails.rb
@@ -13,9 +13,28 @@ class SendEventEmails
         # if someone else saved it too, better don't continue - we're not alone
         return false
       end
-      subscribers = event.subscribers
-      next if subscribers.empty?
-      EventMailer.event(subscribers, event).deliver_now
+
+      next if event.subscribers.empty?
+
+      subscribers = event.subscribers.select { |subscriber| subscriber.digest_email_enabled == false }
+      digest_subscribers = event.subscribers.select { |subscriber| subscriber.digest_email_enabled == true }
+
+      # Send an email to the subscribers with digest_email_enabled == false
+      if subscribers.any?
+        EventMailer.event(subscribers, event).deliver_now
+      end
+
+      # Add to a digest email for the subscribers with digest_email_enabled == true
+      digest_subscribers.each do |subscriber|
+        digest_email =
+          if subscriber.is_a? User
+            DigestEmail.find_or_create_by(user: subscriber, sent_at: nil)
+          elsif subscriber.is_a? Group
+            DigestEmail.find_or_create_by(group: subscriber, sent_at: nil)
+          end
+
+        digest_email.events << event
+      end
     end
     true
   end

--- a/src/api/app/mailers/event_mailer.rb
+++ b/src/api/app/mailers/event_mailer.rb
@@ -17,7 +17,7 @@ class EventMailer < ActionMailer::Base
     'OBS Notification <' + ::Configuration.admin_email + '>'
   end
 
-  def event(subscribers, event)
+  def email_for_event(subscribers, event)
     begin
       @e = event.expanded_payload
     rescue Project::UnknownObjectError, Package::UnknownObjectError

--- a/src/api/app/models/digest_email.rb
+++ b/src/api/app/models/digest_email.rb
@@ -1,5 +1,6 @@
 class DigestEmail < ApplicationRecord
-  belongs_to :event_subscription
+  belongs_to :user
+  belongs_to :group
   has_and_belongs_to_many :events, through: :digest_email_events,
                                    class_name: 'Event::Base',
                                    foreign_key: :digest_email_id,
@@ -10,9 +11,15 @@ end
 #
 # Table name: digest_emails
 #
-#  id                    :integer          not null, primary key
-#  event_subscription_id :integer          not null
-#  sent_at               :datetime
-#  created_at            :datetime         not null
-#  updated_at            :datetime         not null
+#  id         :integer          not null, primary key
+#  user_id    :integer          indexed
+#  group_id   :integer          indexed
+#  sent_at    :datetime
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#
+# Indexes
+#
+#  index_digest_emails_on_group_id  (group_id)
+#  index_digest_emails_on_user_id   (user_id)
 #

--- a/src/api/app/models/digest_email.rb
+++ b/src/api/app/models/digest_email.rb
@@ -10,7 +10,7 @@ end
 #
 #  id                    :integer          not null, primary key
 #  event_subscription_id :integer          indexed
-#  sent_at               :datetime
+#  email_sent            :boolean          default(FALSE), not null
 #  created_at            :datetime         not null
 #  updated_at            :datetime         not null
 #

--- a/src/api/app/models/digest_email.rb
+++ b/src/api/app/models/digest_email.rb
@@ -1,25 +1,20 @@
 class DigestEmail < ApplicationRecord
-  belongs_to :user
-  belongs_to :group
-  has_and_belongs_to_many :events, through: :digest_email_events,
-                                   class_name: 'Event::Base',
-                                   foreign_key: :digest_email_id,
-                                   association_foreign_key: :event_id
+  belongs_to :event_subscription
+  has_many :digest_email_events
+  has_many :events, through: :digest_email_events, class_name: 'Event::Base'
 end
 
 # == Schema Information
 #
 # Table name: digest_emails
 #
-#  id         :integer          not null, primary key
-#  user_id    :integer          indexed
-#  group_id   :integer          indexed
-#  sent_at    :datetime
-#  created_at :datetime         not null
-#  updated_at :datetime         not null
+#  id                    :integer          not null, primary key
+#  event_subscription_id :integer          indexed
+#  sent_at               :datetime
+#  created_at            :datetime         not null
+#  updated_at            :datetime         not null
 #
 # Indexes
 #
-#  index_digest_emails_on_group_id  (group_id)
-#  index_digest_emails_on_user_id   (user_id)
+#  index_digest_emails_on_event_subscription_id  (event_subscription_id)
 #

--- a/src/api/app/models/digest_email.rb
+++ b/src/api/app/models/digest_email.rb
@@ -1,0 +1,18 @@
+class DigestEmail < ApplicationRecord
+  belongs_to :event_subscription
+  has_and_belongs_to_many :events, through: :digest_email_events,
+                                   class_name: 'Event::Base',
+                                   foreign_key: :digest_email_id,
+                                   association_foreign_key: :event_id
+end
+
+# == Schema Information
+#
+# Table name: digest_emails
+#
+#  id                    :integer          not null, primary key
+#  event_subscription_id :integer          not null
+#  sent_at               :datetime
+#  created_at            :datetime         not null
+#  updated_at            :datetime         not null
+#

--- a/src/api/app/models/digest_email_event.rb
+++ b/src/api/app/models/digest_email_event.rb
@@ -1,0 +1,13 @@
+class DigestEmailEvent < ApplicationRecord
+  belongs_to :digest_email
+  belongs_to :event, class_name: 'Event::Base', foreign_key: :event_id
+end
+
+# == Schema Information
+#
+# Table name: digest_email_events
+#
+#  id              :integer          not null, primary key
+#  digest_email_id :integer          not null
+#  event_id        :integer          not null
+#

--- a/src/api/app/models/event/base.rb
+++ b/src/api/app/models/event/base.rb
@@ -2,6 +2,9 @@
 # that users (or services) would like to know about
 module Event
   class Base < ApplicationRecord
+    has_many :digest_email_events, foreign_key: :event_id
+    has_many :digest_emails, through: :digest_email_events
+
     scope :not_in_queue, -> { where(queued: false) }
 
     self.inheritance_column = 'eventtype'

--- a/src/api/app/models/event_subscription.rb
+++ b/src/api/app/models/event_subscription.rb
@@ -13,6 +13,10 @@ class EventSubscription < ApplicationRecord
     end
   end
 
+  def digest_email_enabled?
+    subscriber.digest_email_enabled
+  end
+
   def receiver_role
     read_attribute(:receiver_role).to_sym
   end

--- a/src/api/app/models/group.rb
+++ b/src/api/app/models/group.rb
@@ -161,12 +161,13 @@ end
 #
 # Table name: groups
 #
-#  id         :integer          not null, primary key
-#  created_at :datetime
-#  updated_at :datetime
-#  title      :string(200)      default(""), not null, indexed
-#  parent_id  :integer          indexed
-#  email      :string(255)
+#  id                   :integer          not null, primary key
+#  created_at           :datetime
+#  updated_at           :datetime
+#  title                :string(200)      default(""), not null, indexed
+#  parent_id            :integer          indexed
+#  email                :string(255)
+#  digest_email_enabled :boolean          default(FALSE)
 #
 # Indexes
 #

--- a/src/api/app/models/unregistered_user.rb
+++ b/src/api/app/models/unregistered_user.rb
@@ -73,20 +73,21 @@ end
 #
 # Table name: users
 #
-#  id                  :integer          not null, primary key
-#  created_at          :datetime
-#  updated_at          :datetime
-#  last_logged_in_at   :datetime
-#  login_failure_count :integer          default(0), not null
-#  login               :text(65535)      indexed
-#  email               :string(200)      default(""), not null
-#  realname            :string(200)      default(""), not null
-#  password            :string(100)      default(""), not null, indexed
-#  password_hash_type  :string(20)       default("md5"), not null
-#  password_salt       :string(10)       default("1234512345"), not null
-#  adminnote           :text(65535)
-#  state               :string(11)       default("unconfirmed")
-#  owner_id            :integer
+#  id                   :integer          not null, primary key
+#  created_at           :datetime
+#  updated_at           :datetime
+#  last_logged_in_at    :datetime
+#  login_failure_count  :integer          default(0), not null
+#  login                :text(65535)      indexed
+#  email                :string(200)      default(""), not null
+#  realname             :string(200)      default(""), not null
+#  password             :string(100)      default(""), not null, indexed
+#  password_hash_type   :string(20)       default("md5"), not null
+#  password_salt        :string(10)       default("1234512345"), not null
+#  adminnote            :text(65535)
+#  state                :string(11)       default("unconfirmed")
+#  owner_id             :integer
+#  digest_email_enabled :boolean          default(FALSE)
 #
 # Indexes
 #

--- a/src/api/app/models/user.rb
+++ b/src/api/app/models/user.rb
@@ -933,20 +933,21 @@ end
 #
 # Table name: users
 #
-#  id                  :integer          not null, primary key
-#  created_at          :datetime
-#  updated_at          :datetime
-#  last_logged_in_at   :datetime
-#  login_failure_count :integer          default(0), not null
-#  login               :text(65535)      indexed
-#  email               :string(200)      default(""), not null
-#  realname            :string(200)      default(""), not null
-#  password            :string(100)      default(""), not null, indexed
-#  password_hash_type  :string(20)       default("md5"), not null
-#  password_salt       :string(10)       default("1234512345"), not null
-#  adminnote           :text(65535)
-#  state               :string(11)       default("unconfirmed")
-#  owner_id            :integer
+#  id                   :integer          not null, primary key
+#  created_at           :datetime
+#  updated_at           :datetime
+#  last_logged_in_at    :datetime
+#  login_failure_count  :integer          default(0), not null
+#  login                :text(65535)      indexed
+#  email                :string(200)      default(""), not null
+#  realname             :string(200)      default(""), not null
+#  password             :string(100)      default(""), not null, indexed
+#  password_hash_type   :string(20)       default("md5"), not null
+#  password_salt        :string(10)       default("1234512345"), not null
+#  adminnote            :text(65535)
+#  state                :string(11)       default("unconfirmed")
+#  owner_id             :integer
+#  digest_email_enabled :boolean          default(FALSE)
 #
 # Indexes
 #

--- a/src/api/db/migrate/20170601083100_create_digest_emails.rb
+++ b/src/api/db/migrate/20170601083100_create_digest_emails.rb
@@ -1,8 +1,7 @@
 class CreateDigestEmails < ActiveRecord::Migration[5.0]
   def change
     create_table :digest_emails do |t|
-      t.references :user
-      t.references :group
+      t.references :event_subscription
       t.datetime :sent_at
 
       t.timestamps

--- a/src/api/db/migrate/20170601083100_create_digest_emails.rb
+++ b/src/api/db/migrate/20170601083100_create_digest_emails.rb
@@ -1,0 +1,10 @@
+class CreateDigestEmails < ActiveRecord::Migration[5.0]
+  def change
+    create_table :digest_emails do |t|
+      t.integer :event_subscription_id, null: false
+      t.datetime :sent_at
+
+      t.timestamps
+    end
+  end
+end

--- a/src/api/db/migrate/20170601083100_create_digest_emails.rb
+++ b/src/api/db/migrate/20170601083100_create_digest_emails.rb
@@ -1,7 +1,8 @@
 class CreateDigestEmails < ActiveRecord::Migration[5.0]
   def change
     create_table :digest_emails do |t|
-      t.integer :event_subscription_id, null: false
+      t.references :user
+      t.references :group
       t.datetime :sent_at
 
       t.timestamps

--- a/src/api/db/migrate/20170601083100_create_digest_emails.rb
+++ b/src/api/db/migrate/20170601083100_create_digest_emails.rb
@@ -2,7 +2,7 @@ class CreateDigestEmails < ActiveRecord::Migration[5.0]
   def change
     create_table :digest_emails do |t|
       t.references :event_subscription
-      t.datetime :sent_at
+      t.boolean :email_sent, null: false, default: false
 
       t.timestamps
     end

--- a/src/api/db/migrate/20170601083322_create_digest_email_events.rb
+++ b/src/api/db/migrate/20170601083322_create_digest_email_events.rb
@@ -1,6 +1,6 @@
-class CreateDigestEmailsEvents < ActiveRecord::Migration[5.0]
+class CreateDigestEmailEvents < ActiveRecord::Migration[5.0]
   def change
-    create_table :digest_emails_events do |t|
+    create_table :digest_email_events do |t|
       t.integer :digest_email_id, null: false
       t.integer :event_id, null: false
     end

--- a/src/api/db/migrate/20170601083322_create_digest_emails_events.rb
+++ b/src/api/db/migrate/20170601083322_create_digest_emails_events.rb
@@ -1,0 +1,8 @@
+class CreateDigestEmailsEvents < ActiveRecord::Migration[5.0]
+  def change
+    create_table :digest_emails_events do |t|
+      t.integer :digest_email_id, null: false
+      t.integer :event_id, null: false
+    end
+  end
+end

--- a/src/api/db/migrate/20170601123232_add_digest_email_enabled_to_users.rb
+++ b/src/api/db/migrate/20170601123232_add_digest_email_enabled_to_users.rb
@@ -1,0 +1,5 @@
+class AddDigestEmailEnabledToUsers < ActiveRecord::Migration[5.0]
+  def change
+    add_column :users, :digest_email_enabled, :boolean, default: false
+  end
+end

--- a/src/api/db/migrate/20170601123244_add_digest_email_enabled_to_groups.rb
+++ b/src/api/db/migrate/20170601123244_add_digest_email_enabled_to_groups.rb
@@ -1,0 +1,5 @@
+class AddDigestEmailEnabledToGroups < ActiveRecord::Migration[5.0]
+  def change
+    add_column :groups, :digest_email_enabled, :boolean, default: false
+  end
+end

--- a/src/api/db/structure.sql
+++ b/src/api/db/structure.sql
@@ -420,11 +420,14 @@ CREATE TABLE `delayed_jobs` (
 
 CREATE TABLE `digest_emails` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
-  `event_subscription_id` int(11) NOT NULL,
+  `user_id` int(11) DEFAULT NULL,
+  `group_id` int(11) DEFAULT NULL,
   `sent_at` datetime DEFAULT NULL,
   `created_at` datetime NOT NULL,
   `updated_at` datetime NOT NULL,
-  PRIMARY KEY (`id`)
+  PRIMARY KEY (`id`),
+  KEY `index_digest_emails_on_user_id` (`user_id`),
+  KEY `index_digest_emails_on_group_id` (`group_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 CREATE TABLE `digest_emails_events` (

--- a/src/api/db/structure.sql
+++ b/src/api/db/structure.sql
@@ -418,6 +418,22 @@ CREATE TABLE `delayed_jobs` (
   KEY `index_delayed_jobs_on_queue` (`queue`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin;
 
+CREATE TABLE `digest_emails` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `event_subscription_id` int(11) NOT NULL,
+  `sent_at` datetime DEFAULT NULL,
+  `created_at` datetime NOT NULL,
+  `updated_at` datetime NOT NULL,
+  PRIMARY KEY (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+CREATE TABLE `digest_emails_events` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `digest_email_id` int(11) NOT NULL,
+  `event_id` int(11) NOT NULL,
+  PRIMARY KEY (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
 CREATE TABLE `distribution_icons` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `url` varchar(255) COLLATE utf8_unicode_ci NOT NULL,
@@ -1227,5 +1243,8 @@ INSERT INTO schema_migrations (version) VALUES
 ('20170426153510'),
 ('20170509123922'),
 ('20170511120355'),
-('20170516140442');
+('20170516140442'),
+('20170601083100'),
+('20170601083322');
+
 

--- a/src/api/db/structure.sql
+++ b/src/api/db/structure.sql
@@ -428,7 +428,7 @@ CREATE TABLE `digest_email_events` (
 CREATE TABLE `digest_emails` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `event_subscription_id` int(11) DEFAULT NULL,
-  `sent_at` datetime DEFAULT NULL,
+  `email_sent` tinyint(1) NOT NULL DEFAULT '0',
   `created_at` datetime NOT NULL,
   `updated_at` datetime NOT NULL,
   PRIMARY KEY (`id`),

--- a/src/api/db/structure.sql
+++ b/src/api/db/structure.sql
@@ -418,23 +418,21 @@ CREATE TABLE `delayed_jobs` (
   KEY `index_delayed_jobs_on_queue` (`queue`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin;
 
-CREATE TABLE `digest_emails` (
-  `id` int(11) NOT NULL AUTO_INCREMENT,
-  `user_id` int(11) DEFAULT NULL,
-  `group_id` int(11) DEFAULT NULL,
-  `sent_at` datetime DEFAULT NULL,
-  `created_at` datetime NOT NULL,
-  `updated_at` datetime NOT NULL,
-  PRIMARY KEY (`id`),
-  KEY `index_digest_emails_on_user_id` (`user_id`),
-  KEY `index_digest_emails_on_group_id` (`group_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
-
-CREATE TABLE `digest_emails_events` (
+CREATE TABLE `digest_email_events` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `digest_email_id` int(11) NOT NULL,
   `event_id` int(11) NOT NULL,
   PRIMARY KEY (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+CREATE TABLE `digest_emails` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `event_subscription_id` int(11) DEFAULT NULL,
+  `sent_at` datetime DEFAULT NULL,
+  `created_at` datetime NOT NULL,
+  `updated_at` datetime NOT NULL,
+  PRIMARY KEY (`id`),
+  KEY `index_digest_emails_on_event_subscription_id` (`event_subscription_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 CREATE TABLE `distribution_icons` (

--- a/src/api/db/structure.sql
+++ b/src/api/db/structure.sql
@@ -555,6 +555,7 @@ CREATE TABLE `groups` (
   `title` varchar(200) CHARACTER SET utf8 NOT NULL DEFAULT '',
   `parent_id` int(11) DEFAULT NULL,
   `email` varchar(255) COLLATE utf8_bin DEFAULT NULL,
+  `digest_email_enabled` tinyint(1) DEFAULT '0',
   PRIMARY KEY (`id`),
   KEY `groups_parent_id_index` (`parent_id`) USING BTREE,
   KEY `index_groups_on_title` (`title`) USING BTREE
@@ -1140,6 +1141,7 @@ CREATE TABLE `users` (
   `adminnote` text CHARACTER SET utf8,
   `state` enum('unconfirmed','confirmed','locked','deleted','subaccount') COLLATE utf8_bin DEFAULT 'unconfirmed',
   `owner_id` int(11) DEFAULT NULL,
+  `digest_email_enabled` tinyint(1) DEFAULT '0',
   PRIMARY KEY (`id`),
   UNIQUE KEY `users_login_index` (`login`(255)) USING BTREE,
   KEY `users_password_index` (`password`) USING BTREE
@@ -1245,6 +1247,8 @@ INSERT INTO schema_migrations (version) VALUES
 ('20170511120355'),
 ('20170516140442'),
 ('20170601083100'),
-('20170601083322');
+('20170601083322'),
+('20170601123232'),
+('20170601123244');
 
 

--- a/src/api/spec/factories/digest_emails.rb
+++ b/src/api/spec/factories/digest_emails.rb
@@ -1,0 +1,5 @@
+FactoryGirl.define do
+  factory :digest_email do
+    email_sent false
+  end
+end

--- a/src/api/spec/jobs/cleanup_events_spec.rb
+++ b/src/api/spec/jobs/cleanup_events_spec.rb
@@ -1,0 +1,41 @@
+require 'rails_helper'
+
+RSpec.describe CleanupEvents, type: :job do
+  include ActiveJob::TestHelper
+
+  describe '#perform' do
+    let!(:user) { create(:confirmed_user, digest_email_enabled: true) }
+    let!(:subscription1) { create(:event_subscription_comment_for_project, receiver_role: 'all', user: user) }
+
+    let!(:event1) { Event::Base.create(eventtype: 'Event::CommentForProject') }
+    let!(:event2) { Event::Base.create(eventtype: 'Event::CommentForProject') }
+    let!(:event3) { Event::Base.create(eventtype: 'Event::CommentForProject') }
+
+    before do
+      # Do this here becuase Event::Base overrides ActiveRecord::Base.initialize which means we can't set these attrs on create
+      event1.update_attributes!(project_logged: true, queued: true, undone_jobs: 0)
+      event2.update_attributes!(project_logged: true, queued: true, undone_jobs: 0)
+      event3.update_attributes!(project_logged: true, queued: true, undone_jobs: 0)
+    end
+
+    let!(:digest_email1) { create(:digest_email, event_subscription: subscription1, events: [event1], email_sent: false) }
+    let!(:digest_email2) { create(:digest_email, event_subscription: subscription1, events: [event1], email_sent: true) }
+
+    let!(:digest_email3) { create(:digest_email, event_subscription: subscription1, events: [event2], email_sent: true) }
+    let!(:digest_email4) { create(:digest_email, event_subscription: subscription1, events: [event2], email_sent: true) }
+
+    subject! { CleanupEvents.new.perform }
+
+    it 'keeps the event which has at least one unsent digest_email' do
+      expect(Event::Base.exists?(id: event1.id)).to be_truthy
+    end
+
+    it 'deletes the event which has all of its digest_emails sent' do
+      expect(Event::Base.exists?(id: event2.id)).to be_falsey
+    end
+
+    it 'deletes the event which has no digest_emails' do
+      expect(Event::Base.exists?(id: event3.id)).to be_falsey
+    end
+  end
+end

--- a/src/api/spec/jobs/send_event_emails_spec.rb
+++ b/src/api/spec/jobs/send_event_emails_spec.rb
@@ -11,22 +11,36 @@ RSpec.describe SendEventEmails, type: :job do
     end
 
     let!(:user) { create(:confirmed_user) }
+    let!(:digest_user) { create(:confirmed_user, digest_email_enabled: true) }
     let!(:comment_author) { create(:confirmed_user) }
     let!(:group) { create(:group) }
+    let!(:digest_group) { create(:group, digest_email_enabled: true) }
 
     let!(:subscription1) { create(:event_subscription_comment_for_project, receiver_role: 'all', user: user) }
     let!(:subscription2) { create(:event_subscription_comment_for_project, receiver_role: 'all', user: nil, group: group) }
     let!(:subscription3) { create(:event_subscription_comment_for_project, receiver_role: 'all', user: comment_author) }
+    let!(:subscription4) { create(:event_subscription_comment_for_project, receiver_role: 'all', user: digest_user) }
+    let!(:subscription5) { create(:event_subscription_comment_for_project, receiver_role: 'all', user: nil, group: digest_group) }
 
     let!(:comment) { create(:comment_project, body: "Hey @#{user.login} how are things?", user: comment_author) }
 
     subject! { SendEventEmails.new.perform }
 
-    it 'sends an email to the subscribers' do
+    it 'sends an email to the subscribers which have digest_email_enabled = false' do
       email = ActionMailer::Base.deliveries.first
 
-      expect(email.to).to match_array([user.email, group.email])
+      expect(email.to).to eq([user.email, group.email])
       expect(email.subject).to include('New comment')
+    end
+
+    it 'creates digest emails with this event for the subscribers which have digest_email_enabled = true' do
+      expect(DigestEmail.all.count).to eq(2)
+
+      digest_email_for_user = DigestEmail.find_by(user: digest_user)
+      digest_email_for_group = DigestEmail.find_by(group: digest_group)
+
+      expect(digest_email_for_user.events.count).to eq(1)
+      expect(digest_email_for_group.events.count).to eq(1)
     end
   end
 end

--- a/src/api/spec/jobs/send_event_emails_spec.rb
+++ b/src/api/spec/jobs/send_event_emails_spec.rb
@@ -29,15 +29,15 @@ RSpec.describe SendEventEmails, type: :job do
     it 'sends an email to the subscribers which have digest_email_enabled = false' do
       email = ActionMailer::Base.deliveries.first
 
-      expect(email.to).to eq([user.email, group.email])
+      expect(email.to).to match_array([user.email, group.email])
       expect(email.subject).to include('New comment')
     end
 
     it 'creates digest emails with this event for the subscribers which have digest_email_enabled = true' do
       expect(DigestEmail.all.count).to eq(2)
 
-      digest_email_for_user = DigestEmail.find_by(user: digest_user)
-      digest_email_for_group = DigestEmail.find_by(group: digest_group)
+      digest_email_for_user = DigestEmail.find_by(event_subscription: subscription4)
+      digest_email_for_group = DigestEmail.find_by(event_subscription: subscription5)
 
       expect(digest_email_for_user.events.count).to eq(1)
       expect(digest_email_for_group.events.count).to eq(1)

--- a/src/api/spec/mailers/event_mailer_spec.rb
+++ b/src/api/spec/mailers/event_mailer_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe EventMailer do
     let!(:receiver) { create(:confirmed_user) }
     let!(:subscription) { create(:event_subscription_comment_for_project, user: receiver) }
     let!(:comment) { create(:comment_project, body: "Hey @#{receiver.login} how are things?") }
-    let(:mail) { EventMailer.event(Event::CommentForProject.last.subscribers, Event::CommentForProject.last).deliver_now }
+    let(:mail) { EventMailer.email_for_event(Event::CommentForProject.last.subscribers, Event::CommentForProject.last).deliver_now }
 
     it 'gets delivered' do
       expect(ActionMailer::Base.deliveries).to include(mail)


### PR DESCRIPTION
This PR is part of the implementation of P2: Notification frequency.

If a user or group has digest_email_enabled set to true, then instead of sending the event email instantly we add it to a digest_email, which is a record in the database, and then send the digest emails once per day.

The sending of the digest emails will be done in a separate PR.

https://trello.com/c/UtWz4k0g/404-(8)-p2%3A-notification-frequency