### PR TITLE
[api] Bugfix: Check for packages without a build reason

### DIFF
--- a/src/api/app/controllers/webui/packages/build_reason_controller.rb
+++ b/src/api/app/controllers/webui/packages/build_reason_controller.rb
@@ -8,6 +8,11 @@ module Webui
 
       def index
         @details = @package.last_build_reason(@repository, @architecture.name)
+
+        unless @details.explain
+          flash[:error] = "No build reason found for #{@repository.name}:#{@architecture.name}"
+          redirect_back(fallback_location: { action: :binaries, controller: '/webui/package', project: @project, package: @package, repository: @repository.name })
+        end
       end
 
       private

--- a/src/api/spec/cassettes/Webui_Packages_BuildReasonController/GET_index/for_packages_without_a_build_reason/1_1_3_1.yml
+++ b/src/api/spec/cassettes/Webui_Packages_BuildReasonController/GET_index/for_packages_without_a_build_reason/1_1_3_1.yml
@@ -1,0 +1,38 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://localhost:3200/source/home:tom/package
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 404
+      message: package 'package' does not exist
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '142'
+    body:
+      encoding: UTF-8
+      string: |
+        <status code="404">
+          <summary>package 'package' does not exist</summary>
+          <details>404 package 'package' does not exist</details>
+        </status>
+    http_version: 
+  recorded_at: Thu, 08 Jun 2017 12:16:53 GMT
+recorded_with: VCR 3.0.3

--- a/src/api/spec/cassettes/Webui_Packages_BuildReasonController/GET_index/for_packages_without_a_build_reason/should_redirect_to_package_binaries_path.yml
+++ b/src/api/spec/cassettes/Webui_Packages_BuildReasonController/GET_index/for_packages_without_a_build_reason/should_redirect_to_package_binaries_path.yml
@@ -1,0 +1,38 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://localhost:3200/source/home:tom/package
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 404
+      message: package 'package' does not exist
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '142'
+    body:
+      encoding: UTF-8
+      string: |
+        <status code="404">
+          <summary>package 'package' does not exist</summary>
+          <details>404 package 'package' does not exist</details>
+        </status>
+    http_version: 
+  recorded_at: Thu, 08 Jun 2017 12:16:52 GMT
+recorded_with: VCR 3.0.3


### PR DESCRIPTION
There can be packages that do not have any build reason, thus the API of the backend responds with empty XML fields.

How it currently looks in OBS:
![alt](https://user-images.githubusercontent.com/8287131/26928294-e741be74-4c55-11e7-8251-db3f4391d4b6.png)

How it will look after merging:
![neu](https://user-images.githubusercontent.com/8287131/26928339-16b8ca8a-4c56-11e7-9f15-9ca4e3383bdf.png)
