### PR TITLE
[webui] Bugfix: Change error message to notice for spiders

### DIFF
--- a/src/api/app/controllers/webui/packages/build_reason_controller.rb
+++ b/src/api/app/controllers/webui/packages/build_reason_controller.rb
@@ -9,10 +9,8 @@ module Webui
       def index
         @details = @package.last_build_reason(@repository, @architecture.name)
 
-        unless @details.explain
-          flash[:error] = "No build reason found for #{@repository.name}:#{@architecture.name}"
-          redirect_back(fallback_location: { action: :binaries, controller: '/webui/package', project: @project, package: @package, repository: @repository.name })
-        end
+        redirect_back(fallback_location: package_binaries_path(package: @package, project: @project, repository: @repository.name),
+                      notice: "No build reason found for #{@repository.name}:#{@architecture.name}") unless @details.explain
       end
 
       private

--- a/src/api/spec/controllers/webui/packages/build_reason_controller_spec.rb
+++ b/src/api/spec/controllers/webui/packages/build_reason_controller_spec.rb
@@ -57,7 +57,7 @@ RSpec.describe Webui::Packages::BuildReasonController, type: :controller, vcr: t
         get :index, params: valid_request_params
       end
 
-      it { expect(flash[:error]).not_to be_empty }
+      it { expect(flash[:notice]).not_to be_empty }
       it 'should redirect to package_binaries_path' do
         expect(response).to redirect_to(package_binaries_path(package: package,
                                                               project: source_project, repository: repo_for_source_project.name))


### PR DESCRIPTION
With commit 357fd7cddc040cb6527ddd20cc4a67ae8cdf3f3c I introduced a linter error (guard clause was not used) and a error in our spider test case because we showed them an error flash if the _reason file of a package is empty. This gets fixed with that commit. We're now using a notice since it's actually a notice and not an error.