### PR TITLE
[backend] timeout for services

### DIFF
--- a/src/backend/BSConfiguration.pm
+++ b/src/backend/BSConfiguration.pm
@@ -88,5 +88,6 @@ $BSConfig::rundir                   = $BSConfig::rundir                   || "$B
 $BSConfig::servicetempdir           = $BSConfig::servicetempdir           || "$BSConfig::bsdir/service";
 $BSConfig::scm_cache_high_watermark = $BSConfig::scm_cache_high_watermark || 80;
 $BSConfig::scm_cache_low_watermark  = $BSConfig::scm_cache_low_watermark  || 70;
+$BSConfig::service_timeout          = $BSConfig::service_timeout          || 3600;
 
 1;

--- a/src/backend/bs_service
+++ b/src/backend/bs_service
@@ -176,11 +176,23 @@ sub run_source_update {
 
       BSUtil::printlog("Running command '@run'");
       # call the service
-      if (! open(SERVICE, '-|')) {
+      my $child_pid = open(SERVICE, '-|');
+      die "500 Unable to open pipe: $!\n" unless defined($child_pid);
+      if (! $child_pid) {
         open(STDERR, ">&STDOUT");
         exec(@run);
         die("$run[0]: $!\n");
       }
+
+      local $SIG{ALRM} = sub {
+	kill 'TERM', $child_pid;
+	die "500 timeout while execution of $name\n";
+      };
+
+      # Wait $BSConfig::service_timeout or per default 7200 sec (2 hours) for
+      # service to finish
+      BSUtil::printlog("Waiting $BSConfig::service_timeout for service($child_pid) to finish\n") if $verbose;
+      alarm($BSConfig::service_timeout);
 
       # collect output
       my $output = '';
@@ -192,6 +204,7 @@ sub run_source_update {
 
       if (close SERVICE) {
         # SUCCESS, move files inside and add prefix
+        BSUtil::printlog('Service succeed') if $verbose;
         for my $file (grep {!/^[:\.]/} ls("$myworkdir/out")) {
 	  next if -l "$myworkdir/out/$file" || ! -f _;	# only plain files for now
 	  my $tfile = $file;
@@ -201,12 +214,15 @@ sub run_source_update {
         }
       } else { 
         # FAILURE, Create error file
+        BSUtil::printlog("Service failed: $!") if $verbose;
 	$output =~ s/[\r\n\s]+$//s;
         BSUtil::cleandir('.');
         die("500 remote execution error in $name detected\n") if $? >> 8 == 3;
 	BSUtil::writestr('_service_error', undef, "service $name failed:\n$output\n");
 	$error = 1;
       }
+
+      alarm(0);
 
       # delete no longer needed outdir
       rm_rf("$myworkdir/out");

--- a/src/backend/bs_servicedispatch
+++ b/src/backend/bs_servicedispatch
@@ -146,7 +146,7 @@ sub runservice {
       'data'      => \&BSHTTP::cpio_sender,
       'cpiofiles' => \@send,
       'directory' => $odir,
-      'timeout'   => 3600,
+      'timeout'   => $BSConfig::service_timeout,
       'withmd5'   => 1,
       'receiver' => \&BSHTTP::cpio_receiver,
     }, undef);


### PR DESCRIPTION
Without this patch hanging services will run forever and the service dispatcher
will perodically retry the service until the maximum of running service is
reeached.

This patch sets an configurable alarm (default 7200 sec) for services to
finish, otherwise the child process gets killed and an error 500 is returned

SEE ALSO https://github.com/openSUSE/open-build-service/issues/3214