### PR TITLE
Preparation for having RSS Notifications

### DIFF
--- a/src/api/app/jobs/cleanup_notifications.rb
+++ b/src/api/app/jobs/cleanup_notifications.rb
@@ -1,0 +1,5 @@
+class CleanupNotifications < ApplicationJob
+  def perform
+    Notifications::RssFeedItem.cleanup
+  end
+end

--- a/src/api/app/jobs/send_event_emails.rb
+++ b/src/api/app/jobs/send_event_emails.rb
@@ -16,6 +16,15 @@ class SendEventEmails
       subscribers = event.subscribers
       next if subscribers.empty?
       EventMailer.event(subscribers, event).deliver_now
+
+      event.subscriptions.each do |subscription|
+        Notifications::RssFeedItem.create(
+          subscriber: subscription.subscriber,
+          event_type: event.eventtype,
+          event_payload: event.payload,
+          subscription_receiver_role: subscription.receiver_role
+        )
+      end
     end
     true
   end

--- a/src/api/app/models/group.rb
+++ b/src/api/app/models/group.rb
@@ -11,6 +11,8 @@ class Group < ApplicationRecord
   has_many :event_subscriptions, dependent: :destroy, inverse_of: :group
   has_many :reviews, dependent: :nullify, as: :reviewable
 
+  has_many :rss_feed_items, -> { order(created_at: :desc) }, class_name: 'Notifications::RssFeedItem', dependent: :destroy
+
   validates :title,
             format: { with:    %r{\A[\w\.\-]*\z},
                       message: 'must not contain invalid characters.' }

--- a/src/api/app/models/notifications/base.rb
+++ b/src/api/app/models/notifications/base.rb
@@ -1,0 +1,35 @@
+class Notifications::Base < ApplicationRecord
+  self.table_name = "notifications"
+
+  belongs_to :user
+  belongs_to :group
+
+  def subscriber=(subscriber)
+    if subscriber.is_a? User
+      self.user = subscriber
+    elsif subscriber.is_a? Group
+      self.group = subscriber
+    end
+  end
+end
+
+# == Schema Information
+#
+# Table name: notifications
+#
+#  id                         :integer          not null, primary key
+#  user_id                    :integer          indexed
+#  group_id                   :integer          indexed
+#  type                       :string(255)      not null
+#  event_type                 :string(255)      not null
+#  event_payload              :text(65535)      not null
+#  subscription_receiver_role :string(255)      not null
+#  delivered                  :boolean          default(FALSE)
+#  created_at                 :datetime         not null
+#  updated_at                 :datetime         not null
+#
+# Indexes
+#
+#  index_notifications_on_group_id  (group_id)
+#  index_notifications_on_user_id   (user_id)
+#

--- a/src/api/app/models/notifications/rss_feed_item.rb
+++ b/src/api/app/models/notifications/rss_feed_item.rb
@@ -1,0 +1,23 @@
+class Notifications::RssFeedItem < Notifications::Base
+  MAX_ITEMS_PER_USER = 10
+  MAX_ITEMS_PER_GROUP = 10
+
+  def self.cleanup
+    User.all_without_nobody.find_in_batches batch_size: 500 do |batch|
+      batch.each do |user|
+        if user.is_active?
+          ids = user.rss_feed_items.pluck(:id).slice(MAX_ITEMS_PER_USER..-1)
+          user.rss_feed_items.where(id: ids).delete_all
+        else
+          user.rss_feed_items.delete_all
+        end
+      end
+    end
+    Group.find_in_batches batch_size: 500 do |batch|
+      batch.each do |group|
+        ids = group.rss_feed_items.pluck(:id).slice(MAX_ITEMS_PER_GROUP..-1)
+        group.rss_feed_items.where(id: ids).delete_all
+      end
+    end
+  end
+end

--- a/src/api/app/models/user.rb
+++ b/src/api/app/models/user.rb
@@ -54,6 +54,8 @@ class User < ApplicationRecord
   # users have 0..1 user_registration records assigned to them
   has_one :user_registration
 
+  has_many :rss_feed_items, -> { order(created_at: :desc) }, class_name: 'Notifications::RssFeedItem', dependent: :destroy
+
   scope :all_without_nobody, -> { where("login != ?", nobody_login) }
 
   validates :login, :password, :password_hash_type, :state,

--- a/src/api/config/clock.rb
+++ b/src/api/config/clock.rb
@@ -31,6 +31,10 @@ module Clockwork
     end
   end
 
+  every(1.hour, 'cleanup notifications') do
+    CleanupNotifications.perform_later
+  end
+
   every(30.seconds, 'send notifications') do
     ::Event::NotifyBackends.trigger_delayed_sent
     SendEventEmails.new.delay.perform

--- a/src/api/db/migrate/20170614083014_create_notifications.rb
+++ b/src/api/db/migrate/20170614083014_create_notifications.rb
@@ -1,0 +1,15 @@
+class CreateNotifications < ActiveRecord::Migration[5.0]
+  def change
+    create_table :notifications do |t|
+      t.references :user
+      t.references :group
+      t.string :type, null: false
+      t.string :event_type, null: false
+      t.text :event_payload, null: false
+      t.string :subscription_receiver_role, null: false
+      t.boolean :delivered, default: false
+
+      t.timestamps
+    end
+  end
+end

--- a/src/api/db/structure.sql
+++ b/src/api/db/structure.sql
@@ -711,6 +711,22 @@ CREATE TABLE `messages` (
   KEY `user` (`user_id`) USING BTREE
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin;
 
+CREATE TABLE `notifications` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `user_id` int(11) DEFAULT NULL,
+  `group_id` int(11) DEFAULT NULL,
+  `type` varchar(255) NOT NULL,
+  `event_type` varchar(255) NOT NULL,
+  `event_payload` text NOT NULL,
+  `subscription_receiver_role` varchar(255) NOT NULL,
+  `delivered` tinyint(1) DEFAULT '0',
+  `created_at` datetime NOT NULL,
+  `updated_at` datetime NOT NULL,
+  PRIMARY KEY (`id`),
+  KEY `index_notifications_on_user_id` (`user_id`),
+  KEY `index_notifications_on_group_id` (`group_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
 CREATE TABLE `package_issues` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `package_id` int(11) NOT NULL,
@@ -1228,6 +1244,5 @@ INSERT INTO schema_migrations (version) VALUES
 ('20170509123922'),
 ('20170511120355'),
 ('20170516140442'),
-('20170607110443');
-
-
+('20170607110443'),
+('20170614083014');

--- a/src/api/spec/factories/notification.rb
+++ b/src/api/spec/factories/notification.rb
@@ -1,0 +1,10 @@
+FactoryGirl.define do
+  factory :notification, class: 'Notifications::Base' do
+    event_type 'FakeEventType'
+    event_payload 'FakeJsonPayload'
+    subscription_receiver_role 'owner'
+  end
+
+  factory :rss_notification, parent: :notification, class: 'Notifications::RssFeedItem' do
+  end
+end

--- a/src/api/spec/jobs/send_event_emails_spec.rb
+++ b/src/api/spec/jobs/send_event_emails_spec.rb
@@ -28,5 +28,29 @@ RSpec.describe SendEventEmails, type: :job do
       expect(email.to).to match_array([user.email, group.email])
       expect(email.subject).to include('New comment')
     end
+
+    it "creates an rss notification for user's email" do
+      notification = Notifications::Base.find_by(user: user)
+
+      expect(notification.type).to eq('Notifications::RssFeedItem')
+      expect(notification.event_type).to eq('Event::CommentForProject')
+      expect(notification.event_payload).to include('how are things?')
+      expect(notification.subscription_receiver_role).to eq('all')
+      expect(notification.delivered).to be_falsey
+    end
+
+    it "creates an rss notification for group's email" do
+      notification = Notifications::RssFeedItem.find_by(group: group)
+
+      expect(notification.type).to eq('Notifications::RssFeedItem')
+      expect(notification.event_type).to eq('Event::CommentForProject')
+      expect(notification.event_payload).to include('how are things?')
+      expect(notification.subscription_receiver_role).to eq('all')
+      expect(notification.delivered).to be_falsey
+    end
+
+    it 'only creates two notifications' do
+      expect(Notifications::Base.count).to eq(2)
+    end
   end
 end

--- a/src/api/spec/models/notification_rss_feed_item.rb
+++ b/src/api/spec/models/notification_rss_feed_item.rb
@@ -1,0 +1,82 @@
+require "rails_helper"
+
+RSpec.describe Notifications::RssFeedItem do
+  describe '.cleanup' do
+    let(:user) { create(:confirmed_user) }
+    let(:user2) { create(:confirmed_user) }
+    let(:group) { create(:group, users: [user, user2]) }
+    let(:unconfirmed_user) { create(:user) }
+    let(:max_items_per_user) { Notifications::RssFeedItem::MAX_ITEMS_PER_USER }
+    let(:max_items_per_group) { Notifications::RssFeedItem::MAX_ITEMS_PER_GROUP }
+    let(:greater_than_max_items_per_user) { max_items_per_user + 3 }
+    let(:greater_than_max_items_per_group) { max_items_per_group + 5 }
+
+    context 'without any RSS items' do
+      it { expect { Notifications::RssFeedItem.cleanup }.not_to change { Notifications::RssFeedItem.count } }
+    end
+
+    context 'with a single users' do
+      context 'and not enough RSS items' do
+        before do
+          create_list(:rss_notification, max_items_per_user, user: user)
+        end
+
+        it { expect { Notifications::RssFeedItem.cleanup }.not_to change { Notifications::RssFeedItem.count } }
+      end
+
+      context 'and enough RSS items' do
+        context 'for an active user' do
+          before do
+            create_list(:rss_notification, greater_than_max_items_per_user, user: user)
+          end
+
+          it { expect { Notifications::RssFeedItem.cleanup }.to change { Notifications::RssFeedItem.count }.by(-3) }
+        end
+
+        context 'for a non active user' do
+          before do
+            create_list(:rss_notification, greater_than_max_items_per_user, user: unconfirmed_user)
+          end
+
+          it { expect { Notifications::RssFeedItem.cleanup }.to change { Notifications::RssFeedItem.count }.by(-greater_than_max_items_per_user) }
+        end
+      end
+    end
+
+    context 'with multiple users' do
+      context 'all of them active' do
+        before do
+          create_list(:rss_notification, greater_than_max_items_per_user, user: user)
+          create_list(:rss_notification, greater_than_max_items_per_user, user: user2)
+        end
+
+        it { expect { Notifications::RssFeedItem.cleanup }.to change { user.rss_feed_items.count }.by(-3) }
+        it { expect { Notifications::RssFeedItem.cleanup }.to change { user2.rss_feed_items.count }.by(-3) }
+      end
+
+      context 'being a mixture of active and non active users' do
+        before do
+          create_list(:rss_notification, greater_than_max_items_per_user, user: user)
+          create_list(:rss_notification, greater_than_max_items_per_user, user: unconfirmed_user)
+        end
+
+        it { expect { Notifications::RssFeedItem.cleanup }.to change { user.rss_feed_items.count }.by(-3) }
+        it { expect { Notifications::RssFeedItem.cleanup }.to change { unconfirmed_user.rss_feed_items.count }.by(-greater_than_max_items_per_user) }
+      end
+    end
+
+    context 'with users and group notifications' do
+      before do
+        create_list(:rss_notification, greater_than_max_items_per_user, user: user)
+        create_list(:rss_notification, greater_than_max_items_per_user, user: user2)
+        create_list(:rss_notification, greater_than_max_items_per_user, user: unconfirmed_user)
+        create_list(:rss_notification, greater_than_max_items_per_group, group: group)
+      end
+
+      it { expect { Notifications::RssFeedItem.cleanup }.to change { user.rss_feed_items.count }.by(-3) }
+      it { expect { Notifications::RssFeedItem.cleanup }.to change { user2.rss_feed_items.count }.by(-3) }
+      it { expect { Notifications::RssFeedItem.cleanup }.to change { group.rss_feed_items.count }.by(-5) }
+      it { expect { Notifications::RssFeedItem.cleanup }.to change { unconfirmed_user.rss_feed_items.count }.by(-greater_than_max_items_per_user) }
+    end
+  end
+end


### PR DESCRIPTION
Now we need to store events info per user/group in a new table to be able to show them in RSS format.
The events stored as RSS Notifications are those that each user has configured at the notifications page.