### PR TITLE
[ci] Disable InstanceVariables instead of exclude

### DIFF
--- a/src/api/.haml-lint.yml
+++ b/src/api/.haml-lint.yml
@@ -5,5 +5,4 @@ exclude:
 
 linters:
   InstanceVariables:
-    exclude:
-      - "app/views/**/*"
+    enabled: false


### PR DESCRIPTION
To disable a HAML-Lint linter `enabled: false` should be used instead of exclude all the HAML files.

@mdeniz you added this :sweat_smile: 