### PR TITLE
[app][webui] generalize rescue in update_from_xml

### DIFF
--- a/src/api/app/jobs/consistency_check.rb
+++ b/src/api/app/jobs/consistency_check.rb
@@ -140,9 +140,11 @@ class ConsistencyCheckJob < ApplicationJob
     meta = Backend::Connection.get("/source/#{project}/_meta").body
     project = Project.new(name: project)
     project.commit_opts = {no_backend_write: 1}
-    project.update_from_xml(Xmlhash.parse(meta))
+    project.update_from_xml!(Xmlhash.parse(meta))
     project.save!
     return ""
+  rescue APIException
+    # FIXME: Check if we want to do something in this case
   rescue ActiveRecord::RecordInvalid
     Backend::Connection.delete("/source/#{project}")
     return "DELETED #{project} on backend due to invalid data\n"

--- a/src/api/app/models/project.rb
+++ b/src/api/app/models/project.rb
@@ -570,7 +570,7 @@ class Project < ApplicationRecord
   def update_from_xml(xmlhash, force = nil)
     update_from_xml!(xmlhash, force)
     { }
-  rescue APIException => e
+  rescue APIException, ActiveRecord::RecordInvalid => e
     { error: e.message }
   end
 


### PR DESCRIPTION
The `update_from_xml` method is only used from ProjectController#save_meta and
ConsistencyCheckJob#import_project_from_backend. In the first one we want to get the error instead of rescuing the `APIException` to show the error to the UI. In the second case, we are just ignoring this Exception. So I changed `update_from_xml` by `update_from_xml!` in this case and rescue the `APIException` there. It is missed to decide if we want to keep ignoring this exception
or not, so I added a FIXME message there.

Fixes https://github.com/openSUSE/open-build-service/issues/3140