### PR TITLE
EventSubscription uses channel:string column instead of receive:boolean

### DIFF
--- a/src/api/app/assets/stylesheets/webui/application/notifications.scss
+++ b/src/api/app/assets/stylesheets/webui/application/notifications.scss
@@ -1,10 +1,10 @@
 #notification_form fieldset {
-  margin-top: 10px; 
+  margin-top: 10px;
   margin-left: 10px;
   ul {
     margin-top: 0;
 
-    li {  width: 15em; }
+    li {  margin-bottom: 3px; }
   }
 
   legend { font-size: 110%; font-weight: bold; }

--- a/src/api/app/models/event_subscription.rb
+++ b/src/api/app/models/event_subscription.rb
@@ -1,10 +1,10 @@
 class EventSubscription < ApplicationRecord
+  enum channel: %i(disabled instant_email)
+
   belongs_to :user, inverse_of: :event_subscriptions
   belongs_to :group, inverse_of: :event_subscriptions
 
-  validates :receiver_role, inclusion: { in: [:all, :maintainer, :bugowner, :reader, :source_maintainer,
-                                              :target_maintainer, :reviewer, :commenter, :creator] }
-  validates :channel, inclusion: { in: ['disabled', 'instant_email', 'daily_email'] }
+  validates :receiver_role, inclusion: { in: %i(all maintainer bugowner reader source_maintainer target_maintainer reviewer commenter creator) }
 
   scope :for_eventtype, ->(eventtype) { where(eventtype: eventtype) }
   scope :defaults, ->{ where(user_id: nil, group_id: nil) }
@@ -43,6 +43,10 @@ class EventSubscription < ApplicationRecord
   def receiver_role
     read_attribute(:receiver_role).to_sym
   end
+
+  def enabled?
+    !disabled?
+  end
 end
 
 # == Schema Information
@@ -55,9 +59,9 @@ end
 #  user_id       :integer          indexed
 #  created_at    :datetime
 #  updated_at    :datetime
-#  receive       :boolean          default(TRUE), not null
 #  group_id      :integer          indexed
-#  channel       :string(255)      not null
+#  receive       :boolean
+#  channel       :integer          default("disabled"), not null
 #
 # Indexes
 #

--- a/src/api/app/models/event_subscription.rb
+++ b/src/api/app/models/event_subscription.rb
@@ -4,6 +4,7 @@ class EventSubscription < ApplicationRecord
 
   validates :receiver_role, inclusion: { in: [:all, :maintainer, :bugowner, :reader, :source_maintainer,
                                               :target_maintainer, :reviewer, :commenter, :creator] }
+  validates :channel, inclusion: { in: ['disabled', 'instant_email', 'daily_email'] }
 
   scope :for_eventtype, ->(eventtype) { where(eventtype: eventtype) }
   scope :defaults, ->{ where(user_id: nil, group_id: nil) }
@@ -56,6 +57,7 @@ end
 #  updated_at    :datetime
 #  receive       :boolean          default(TRUE), not null
 #  group_id      :integer          indexed
+#  channel       :string(255)      not null
 #
 # Indexes
 #

--- a/src/api/app/models/event_subscription/form.rb
+++ b/src/api/app/models/event_subscription/form.rb
@@ -16,7 +16,7 @@ class EventSubscription
           subscription_params[:eventtype],
           subscription_params[:receiver_role]
         )
-        subscription.receive = subscription_params[:receive]
+        subscription.channel = subscription_params[:channel]
         subscription.save!
       end
     end

--- a/src/api/app/models/event_subscription/generate_hash_for_subscriber.rb
+++ b/src/api/app/models/event_subscription/generate_hash_for_subscriber.rb
@@ -40,7 +40,7 @@ class EventSubscription
           subscriber: subscriber,
           eventtype: event_class.to_s,
           receiver_role: role,
-          receive: false
+          channel: 'disabled'
         )
       end
     end

--- a/src/api/app/models/notifications/rss_feed_item.rb
+++ b/src/api/app/models/notifications/rss_feed_item.rb
@@ -21,3 +21,24 @@ class Notifications::RssFeedItem < Notifications::Base
     end
   end
 end
+
+# == Schema Information
+#
+# Table name: notifications
+#
+#  id                         :integer          not null, primary key
+#  user_id                    :integer          indexed
+#  group_id                   :integer          indexed
+#  type                       :string(255)      not null
+#  event_type                 :string(255)      not null
+#  event_payload              :text(65535)      not null
+#  subscription_receiver_role :string(255)      not null
+#  delivered                  :boolean          default(FALSE)
+#  created_at                 :datetime         not null
+#  updated_at                 :datetime         not null
+#
+# Indexes
+#
+#  index_notifications_on_group_id  (group_id)
+#  index_notifications_on_user_id   (user_id)
+#

--- a/src/api/app/views/webui/subscriptions/_subscriptions_form.html.haml
+++ b/src/api/app/views/webui/subscriptions/_subscriptions_form.html.haml
@@ -2,12 +2,12 @@
 - i = 0
 - @subscriptions_form.subscriptions_by_event.each do |event_class, subscriptions|
   = field_set_tag event_class.description do
-    %ul.horizontal-list
+    %ul
       - subscriptions.each do |subscription|
         = fields_for "subscriptions[#{i}]", subscription do |f|
           %li
-            = f.check_box :receive
+            = f.label :receive, subscription.receiver_role
+            = f.select :channel, EventSubscription.channels.keys
             = f.hidden_field :eventtype
             = f.hidden_field :receiver_role
-            = f.label :receive, subscription.receiver_role
             - i += 1

--- a/src/api/db/migrate/20170621100321_add_channel_to_event_subscriptions.rb
+++ b/src/api/db/migrate/20170621100321_add_channel_to_event_subscriptions.rb
@@ -1,0 +1,8 @@
+class AddChannelToEventSubscriptions < ActiveRecord::Migration[5.0]
+  def change
+    add_column :event_subscriptions, :channel, :string
+    EventSubscription.where(receive: false).update_all(channel: 'disabled')
+    EventSubscription.where(receive: true).update_all(channel: 'instant_email')
+    change_column :event_subscriptions, :channel, :string, null: false
+  end
+end

--- a/src/api/db/migrate/20170621100321_add_channel_to_event_subscriptions.rb
+++ b/src/api/db/migrate/20170621100321_add_channel_to_event_subscriptions.rb
@@ -1,8 +1,12 @@
 class AddChannelToEventSubscriptions < ActiveRecord::Migration[5.0]
-  def change
-    add_column :event_subscriptions, :channel, :string
-    EventSubscription.where(receive: false).update_all(channel: 'disabled')
-    EventSubscription.where(receive: true).update_all(channel: 'instant_email')
-    change_column :event_subscriptions, :channel, :string, null: false
+  def up
+    EventSubscription.transaction do
+      add_column :event_subscriptions, :channel, :integer, default: 0, null: false
+      EventSubscription.where(receive: true).update_all(channel: :instant_email)
+    end
+  end
+
+  def down
+    remove_column :event_subscriptions, :channel
   end
 end

--- a/src/api/db/migrate/20170621103748_remove_receive_from_event_subscriptions.rb
+++ b/src/api/db/migrate/20170621103748_remove_receive_from_event_subscriptions.rb
@@ -1,0 +1,5 @@
+class RemoveReceiveFromEventSubscriptions < ActiveRecord::Migration[5.0]
+  def change
+    remove_column :event_subscriptions, :receive, :boolean
+  end
+end

--- a/src/api/db/structure.sql
+++ b/src/api/db/structure.sql
@@ -467,9 +467,8 @@ CREATE TABLE `event_subscriptions` (
   `user_id` int(11) DEFAULT NULL,
   `created_at` datetime DEFAULT NULL,
   `updated_at` datetime DEFAULT NULL,
-  `receive` tinyint(1) NOT NULL DEFAULT '1',
   `group_id` int(11) DEFAULT NULL,
-  `channel` varchar(255) COLLATE utf8_unicode_ci NOT NULL,
+  `channel` int(11) NOT NULL DEFAULT '0',
   PRIMARY KEY (`id`),
   KEY `index_event_subscriptions_on_user_id` (`user_id`) USING BTREE,
   KEY `index_event_subscriptions_on_group_id` (`group_id`)
@@ -1479,6 +1478,7 @@ INSERT INTO schema_migrations (version) VALUES
 ('20170607110443'),
 ('20170614083014'),
 ('20170621100321'),
+('20170621103748'),
 ('21'),
 ('22'),
 ('23'),

--- a/src/api/db/structure.sql
+++ b/src/api/db/structure.sql
@@ -469,6 +469,7 @@ CREATE TABLE `event_subscriptions` (
   `updated_at` datetime DEFAULT NULL,
   `receive` tinyint(1) NOT NULL DEFAULT '1',
   `group_id` int(11) DEFAULT NULL,
+  `channel` varchar(255) COLLATE utf8_unicode_ci NOT NULL,
   PRIMARY KEY (`id`),
   KEY `index_event_subscriptions_on_user_id` (`user_id`) USING BTREE,
   KEY `index_event_subscriptions_on_group_id` (`group_id`)
@@ -1477,6 +1478,7 @@ INSERT INTO schema_migrations (version) VALUES
 ('20170516140442'),
 ('20170607110443'),
 ('20170614083014'),
+('20170621100321'),
 ('21'),
 ('22'),
 ('23'),

--- a/src/api/spec/factories/event_subscriptions.rb
+++ b/src/api/spec/factories/event_subscriptions.rb
@@ -3,7 +3,7 @@ FactoryGirl.define do
     factory :event_subscription_comment_for_project do
       eventtype 'Event::CommentForProject'
       receiver_role "commenter"
-      receive true
+      channel :instant_email
     end
 
     user

--- a/src/api/spec/features/webui/notifications_spec.rb
+++ b/src/api/spec/features/webui/notifications_spec.rb
@@ -8,12 +8,12 @@ RSpec.feature 'Notifications', type: :feature, js: true do
 
       expect(page).to have_content('Events to get email for')
 
-      %w(subscriptions_8_receive
-         subscriptions_7_receive
-         subscriptions_14_receive
-         subscriptions_15_receive
-      ).each do |checkbox|
-        check(checkbox)
+      %w(subscriptions_8_channel
+         subscriptions_7_channel
+         subscriptions_14_channel
+         subscriptions_15_channel
+      ).each do |select_id|
+        select('instant_email', from: select_id)
       end
 
       click_button 'Update'
@@ -23,13 +23,13 @@ RSpec.feature 'Notifications', type: :feature, js: true do
       user_id = user.is_admin? ? nil : user.id
 
       expect(EventSubscription.exists?(user_id: user_id, eventtype: 'Event::CommentForPackage',
-                                       receiver_role: 'commenter', receive: true)).to be true
+                                       receiver_role: 'commenter', channel: 'instant_email')).to be true
       expect(EventSubscription.exists?(user_id: user_id, eventtype: 'Event::CommentForProject',
-                                      receiver_role: 'maintainer', receive: true)).to be true
+                                      receiver_role: 'maintainer', channel: 'instant_email')).to be true
       expect(EventSubscription.exists?(user_id: user_id, eventtype: 'Event::CommentForRequest',
-                                       receiver_role: 'reviewer', receive: true)).to be true
+                                       receiver_role: 'reviewer', channel: 'instant_email')).to be true
       expect(EventSubscription.exists?(user_id: user_id, eventtype: 'Event::BuildFail',
-                                       receiver_role: 'maintainer', receive: true)).to be true
+                                       receiver_role: 'maintainer', channel: 'instant_email')).to be true
     end
   end
 

--- a/src/api/spec/models/event_subscription/generate_hash_for_subscriber_spec.rb
+++ b/src/api/spec/models/event_subscription/generate_hash_for_subscriber_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe EventSubscription::GenerateHashForSubscriber do
             expect(subscription.persisted?).to be_falsey
             expect(subscription.subscriber).to eq(user)
             expect(subscription.eventtype).to eq(event_class.to_s)
-            expect(subscription.receive).to be_falsey
+            expect(subscription.channel).to eq('disabled')
           end
         end
       end
@@ -57,7 +57,7 @@ RSpec.describe EventSubscription::GenerateHashForSubscriber do
             expect(subscription.user).to be_nil
             expect(subscription.group).to be_nil
             expect(subscription.eventtype).to eq(event_class.to_s)
-            expect(subscription.receive).to be_falsey
+            expect(subscription.channel).to eq('disabled')
           end
         end
       end

--- a/src/api/spec/support/shared_contexts/a_user_and_subscriptions_with_defaults.rb
+++ b/src/api/spec/support/shared_contexts/a_user_and_subscriptions_with_defaults.rb
@@ -7,7 +7,7 @@ RSpec.shared_context 'a user and subscriptions with defaults' do
       eventtype: 'Event::RequestStatechange',
       receiver_role: :source_maintainer,
       user: user,
-      receive: true
+      channel: 'instant_email'
     )
   end
   let!(:user_subscription2) do
@@ -16,7 +16,7 @@ RSpec.shared_context 'a user and subscriptions with defaults' do
       eventtype: 'Event::RequestStatechange',
       receiver_role: :target_maintainer,
       user: user,
-      receive: true
+      channel: 'instant_email'
     )
   end
   let!(:default_subscription1) do
@@ -26,7 +26,7 @@ RSpec.shared_context 'a user and subscriptions with defaults' do
       receiver_role: :source_maintainer,
       user: nil,
       group: nil,
-      receive: true
+      channel: 'instant_email'
     )
   end
   let!(:default_subscription2) do
@@ -36,16 +36,16 @@ RSpec.shared_context 'a user and subscriptions with defaults' do
       receiver_role: :target_maintainer,
       user: nil,
       group: nil,
-      receive: true
+      channel: 'instant_email'
     )
   end
 
   let(:subscription_params) do
     {
-      '0' => { receive: "0", eventtype: "Event::RequestStatechange", receiver_role: "source_maintainer"},
-      '1' => { receive: "0", eventtype: "Event::RequestStatechange", receiver_role: "target_maintainer"},
-      '2' => { receive: "1", eventtype: "Event::RequestStatechange", receiver_role: "creator"},
-      '3' => { receive: "1", eventtype: "Event::RequestStatechange", receiver_role: "reviewer"}
+      '0' => { channel: 'disabled', eventtype: 'Event::RequestStatechange', receiver_role: 'source_maintainer'},
+      '1' => { channel: 'disabled', eventtype: 'Event::RequestStatechange', receiver_role: 'target_maintainer'},
+      '2' => { channel: 'instant_email', eventtype: 'Event::RequestStatechange', receiver_role: 'creator'},
+      '3' => { channel: 'instant_email', eventtype: 'Event::RequestStatechange', receiver_role: 'reviewer'}
     }
   end
 end

--- a/src/api/spec/support/shared_examples/a_subscriptions_form_for_subscriber.rb
+++ b/src/api/spec/support/shared_examples/a_subscriptions_form_for_subscriber.rb
@@ -1,43 +1,43 @@
 RSpec.shared_examples 'a subscriptions form for subscriber' do
-  it 'updates the source_maintainer subscription to receive = true' do
+  it 'updates the source_maintainer subscription to channel = disabled' do
     subscription = EventSubscription.for_eventtype('Event::RequestStatechange').for_subscriber(user).find_by(receiver_role: 'source_maintainer')
-    expect(subscription.receive).to be_falsey
+    expect(subscription.channel).to eq('disabled')
   end
 
-  it 'updates the target_maintainer subscription to receive = true' do
+  it 'updates the target_maintainer subscription to channel = disabled' do
     subscription = EventSubscription.for_eventtype('Event::RequestStatechange').for_subscriber(user).find_by(receiver_role: 'target_maintainer')
-    expect(subscription.receive).to be_falsey
+    expect(subscription.channel).to eq('disabled')
   end
 
-  it 'creates the creator subscription with receive = false' do
+  it 'creates the creator subscription with channel = instant_email' do
     subscription = EventSubscription.for_eventtype('Event::RequestStatechange').for_subscriber(user).find_by(receiver_role: 'creator')
-    expect(subscription.receive).to be_truthy
+    expect(subscription.channel).to eq('instant_email')
   end
 
-  it 'creates the reviewer subscription with receive = false' do
+  it 'creates the reviewer subscription with channel = instant_email' do
     subscription = EventSubscription.for_eventtype('Event::RequestStatechange').for_subscriber(user).find_by(receiver_role: 'reviewer')
-    expect(subscription.receive).to be_truthy
+    expect(subscription.channel).to eq('instant_email')
   end
 end
 
 RSpec.shared_examples 'a subscriptions form for default' do
-  it 'updates the source_maintainer subscription to receive = true' do
+  it 'updates the source_maintainer subscription to channel = disabled' do
     subscription = EventSubscription.for_eventtype('Event::RequestStatechange').for_subscriber(nil).find_by(receiver_role: 'source_maintainer')
-    expect(subscription.receive).to be_falsey
+    expect(subscription.channel).to eq('disabled')
   end
 
-  it 'updates the target_maintainer subscription to receive = true' do
+  it 'updates the target_maintainer subscription to channel = disabled' do
     subscription = EventSubscription.for_eventtype('Event::RequestStatechange').for_subscriber(nil).find_by(receiver_role: 'target_maintainer')
-    expect(subscription.receive).to be_falsey
+    expect(subscription.channel).to eq('disabled')
   end
 
-  it 'creates the creator subscription with receive = false' do
+  it 'creates the creator subscription with channel = instant_email' do
     subscription = EventSubscription.for_eventtype('Event::RequestStatechange').for_subscriber(nil).find_by(receiver_role: 'creator')
-    expect(subscription.receive).to be_truthy
+    expect(subscription.channel).to eq('instant_email')
   end
 
-  it 'creates the reviewer subscription with receive = false' do
+  it 'creates the reviewer subscription with channel = instant_email' do
     subscription = EventSubscription.for_eventtype('Event::RequestStatechange').for_subscriber(nil).find_by(receiver_role: 'reviewer')
-    expect(subscription.receive).to be_truthy
+    expect(subscription.channel).to eq('instant_email')
   end
 end

--- a/src/api/test/fixtures/event_subscriptions.yml
+++ b/src/api/test/fixtures/event_subscriptions.yml
@@ -3,72 +3,72 @@ record_0:
   receiver_role: maintainer
   created_at: 2013-08-20 17:45:46.000000000 Z
   updated_at: 2013-08-20 17:45:46.000000000 Z
-  receive: 1
+  channel: 1
 record_1:
   eventtype: Event::CommentForRequest
   receiver_role: reviewer
   created_at: 2013-08-20 17:45:46.000000000 Z
   updated_at: 2013-08-20 17:45:46.000000000 Z
-  receive: 1
+  channel: 1
 record_2:
   eventtype: Event::CommentForRequest
   receiver_role: creator
   created_at: 2013-08-20 17:45:46.000000000 Z
   updated_at: 2013-08-20 17:45:46.000000000 Z
-  receive: 1
+  channel: 1
 record_3:
   eventtype: Event::ReviewWanted
   receiver_role: reviewer
   created_at: 2013-08-20 17:45:46.000000000 Z
   updated_at: 2013-08-20 17:45:46.000000000 Z
-  receive: 1
+  channel: 1
 record_4:
   eventtype: Event::CommentForProject
   receiver_role: maintainer
   created_at: 2013-08-20 17:45:46.000000000 Z
   updated_at: 2013-08-20 17:45:46.000000000 Z
-  receive: 1
+  channel: 1
 record_5:
   eventtype: Event::RequestStateChange
   receiver_role: creator
   created_at: 2013-11-29 16:20:19.000000000 Z
   updated_at: 2013-11-29 16:20:19.000000000 Z
-  receive: 1
+  channel: 1
 record_6:
   eventtype: Event::Request
   receiver_role: maintainer
   created_at: 2013-08-20 17:45:23.000000000 Z
   updated_at: 2013-12-10 19:00:58.000000000 Z
-  receive: 0
+  channel: 0
   user: tom
 record_7:
   eventtype: Event::Build
   receiver_role: all
   created_at: 2013-08-20 17:45:46.000000000 Z
   updated_at: 2013-08-20 17:45:46.000000000 Z
-  receive: 1
+  channel: 1
   user: fred
 record_8:
   eventtype: Event::CommentForRequest
   receiver_role: commenter
   created_at: 2013-08-20 17:45:46.000000000 Z
   updated_at: 2013-08-20 17:45:46.000000000 Z
-  receive: 1
+  channel: 1
 record_9:
   eventtype: Event::RequestCreate
   receiver_role: target_maintainer
   created_at: 2013-08-20 15:32:05.000000000 Z
   updated_at: 2013-08-20 15:32:05.000000000 Z
-  receive: 1
+  channel: 1
 record_10:
   eventtype: Event::CommentForProject
   receiver_role: commenter
   created_at: 2013-08-20 17:45:46.000000000 Z
   updated_at: 2013-08-20 17:45:46.000000000 Z
-  receive: 1
+  channel: 1
 record_11:
   eventtype: Event::CommentForPackage
   receiver_role: commenter
   created_at: 2013-08-20 17:45:46.000000000 Z
   updated_at: 2013-08-20 17:45:46.000000000 Z
-  receive: 1
+  channel: 1

--- a/src/api/test/functional/maintenance_test.rb
+++ b/src/api/test/functional/maintenance_test.rb
@@ -1394,7 +1394,7 @@ class MaintenanceTests < ActionDispatch::IntegrationTest
     assert_equal %w(dirkmueller@example.com fred@feuerstein.de test_group@testsuite.org), email.to.sort
 
     EventSubscription.create eventtype: 'Event::CommentForRequest', receiver_role: :source_maintainer,
-                             user: users(:maintenance_assi), receive: true
+                             user: users(:maintenance_assi), channel: :instant_email
 
     # now leave another comment and hope the assi gets it too
     assert_difference 'ActionMailer::Base.deliveries.size', +1 do


### PR DESCRIPTION
The notifications page now uses a drop down to select between 'disabled' and 'instant_email'. Effectively the same as checking/unchecking a checkbox but this allows us to add in a third option (daily_email) which will happen in the next PR.

Here is what the notifications page looks like after this change:
![screenshot from 2017-06-21 13-32-01](https://user-images.githubusercontent.com/9274/27384350-7597f546-5686-11e7-9346-c1a4918fd514.png)
