### PR TITLE
[ci] Remove flickering attibute test from old test suite

### DIFF
--- a/src/api/test/functional/webui/attributes_test.rb
+++ b/src/api/test/functional/webui/attributes_test.rb
@@ -136,18 +136,6 @@ class Webui::AttributesTest < Webui::IntegrationTest
            name: 'OBS:ScreenShots')
   end
 
-  def test_package_attribute # spec/features/webui/attributes_spec.rb
-    login_king
-
-    add(project: 'Apache',
-        package: 'apache2',
-        name: 'OBS:ScreenShots',
-        value: 'Screenshot1.png')
-    delete(project: 'Apache',
-           package: 'apache2',
-           name: 'OBS:ScreenShots')
-  end
-
   def test_attrib_with_single_value
     login_king
 


### PR DESCRIPTION
The test already got migrated to spec/features/webui/attributes_spec.rb.
So we can drop the one from the old test suite.

===

test_package_attribute                                          FAIL (8.30s)
Minitest::Assertion:         --- expected
        +++ actual
        @@ -1 +1 @@
        -"Attribute sucessfully deleted!"
        +"none"
        test/functional/webui/attributes_test.rb:111:in `delete'
        test/functional/webui/attributes_test.rb:146:in `test_package_attribute'
        test/test_helper.rb:127:in `block in __run'
        test/test_helper.rb:127:in `map'
        test/test_helper.rb:127:in `__run'