### PR TITLE
[ci] Increase Capybara Poltergeist timeout

### DIFF
--- a/dist/t/spec/support/capybara.rb
+++ b/dist/t/spec/support/capybara.rb
@@ -4,7 +4,7 @@ require 'capybara/poltergeist'
 require 'socket'
 
 Capybara.register_driver :poltergeist do |app|
-  Capybara::Poltergeist::Driver.new(app, debug: false, timeout: 60)
+  Capybara::Poltergeist::Driver.new(app, debug: false, timeout: 120)
 end
 
 Capybara.default_driver = :poltergeist


### PR DESCRIPTION
I think this will solve this kind of errors: :bowtie: 

```
Capybara::Poltergeist::StatusFailError:
  Request to 'http://127.0.0.1:32839/user/login' failed to reach server,
  check DNS and/or server status - Timed out with no open resource
  requests
```