### PR TITLE
[dist][api] Downgrade xmlrpc

### DIFF
--- a/src/api/Gemfile
+++ b/src/api/Gemfile
@@ -55,7 +55,7 @@ gem 'coffee-rails'
 # bind keyboard shortcuts to actions
 gem 'mousetrap-rails'
 # for issue tracker communication
-gem 'xmlrpc'
+gem 'xmlrpc', '~> 0.2.1'
 # Multiple feature switch
 gem 'feature'
 # for profiling

--- a/src/api/Gemfile.lock
+++ b/src/api/Gemfile.lock
@@ -381,7 +381,7 @@ GEM
     websocket-extensions (0.1.2)
     xmlhash (1.3.7)
       pkg-config
-    xmlrpc (0.3.0)
+    xmlrpc (0.2.1)
     xpath (2.1.0)
       nokogiri (~> 1.3)
     yajl-ruby (1.3.0)
@@ -466,7 +466,7 @@ DEPENDENCIES
   voight_kampff
   webmock (>= 2.3.0)
   xmlhash (>= 1.3.6)
-  xmlrpc
+  xmlrpc (~> 0.2.1)
   yajl-ruby
 
 BUNDLED WITH


### PR DESCRIPTION
This gem got upgraded with rails 5.1 update (f9d85babdb9ccc0).

For our obs-server packages we using packaged gems that build against
SLE_12_SP2. For that target the new xmlrpc package doesn't build due to
conflicts with the ruby version (xmlrpc v0.3 requires ruby v2.3, SLE 12
doesn't provide it).

We don't need the new version so we can just downgrade it again.