### PR TITLE
[ci] Precompile assets in all test suites

### DIFF
--- a/dist/ci/travis_script.sh
+++ b/dist/ci/travis_script.sh
@@ -20,13 +20,16 @@ if test -z "$SUBTEST"; then
   export TESTOPTS="-v"
   case $TEST_SUITE in
     api)
+      bundle exec rails assets:precompile &> /dev/null
       bundle exec rails test:api
       ;;
     webui)
+      bundle exec rails assets:precompile &> /dev/null
       bundle exec rails test:webui
       ;;
     spider)
       unset DO_COVERAGE
+      bundle exec rails assets:precompile &> /dev/null
       bundle exec rails test:spider
       ;;
     linter)
@@ -44,6 +47,7 @@ if test -z "$SUBTEST"; then
       ;;
     *)
       make -C ../../ rubocop
+      bundle exec rails assets:precompile &> /dev/null
       bundle exec rails test:api
       bundle exec rails test:webui
       bundle exec rspec

--- a/src/api/script/api_test_in_spec.sh
+++ b/src/api/script/api_test_in_spec.sh
@@ -80,6 +80,7 @@ bundle.ruby2.4 exec rake.ruby2.4 db:create db:setup || exit 1
 
 for suite in "rake.ruby2.4 test:api" "rake.ruby2.4 test:webui" "rake.ruby2.4 test:spider" "rspec.ruby2.4"; do
   rm -f log/test.log
+  bundle.ruby2.4 exec rails assets:precompile
   if ! bundle.ruby2.4 exec $suite; then
     # dump log only in package builds
     [[ -n "$RPM_BUILD_ROOT" ]] && cat log/test.log


### PR DESCRIPTION
We already did that with our rspec tests in e0db5f0223 to reduce the
chance that the actual test suite fails due to timeouts.
For the same reason we should do that for any test.