### PR TITLE
[dist] Add environments/migration.rb to rpm spec

### DIFF
--- a/dist/obs-server.spec
+++ b/dist/obs-server.spec
@@ -665,6 +665,7 @@ usermod -a -G docker obsservicerun
 %config /srv/www/obs/api/config/environments/production.rb
 %config /srv/www/obs/api/config/environments/test.rb
 %config /srv/www/obs/api/config/environments/stage.rb
+%config /srv/www/obs/api/config/environments/migration.rb
 
 %dir %attr(-,%{apache_user},%{apache_group}) /srv/www/obs/api/log
 %attr(-,%{apache_user},%{apache_group}) /srv/www/obs/api/tmp


### PR DESCRIPTION
This was missing in 47d5380954cacc21dbd41235e08cca3f3b3c11ea