### PR TITLE
[ci] Add a linter for the structure.sql

### DIFF
--- a/dist/ci/travis_script.sh
+++ b/dist/ci/travis_script.sh
@@ -33,6 +33,7 @@ if test -z "$SUBTEST"; then
       bundle exec rails test:spider
       ;;
     linter)
+      bundle exec rake db:structure:verify
       make -C ../../ rubocop
       bundle exec rake haml_lint
       jshint .

--- a/src/api/lib/tasks/databases.rake
+++ b/src/api/lib/tasks/databases.rake
@@ -83,6 +83,20 @@ namespace :db do
       end
       File.open("#{Rails.root}/db/structure.sql", "w+") { |f| f << new_structure }
     end
+
+    desc "Verify that structure.sql in git is up to date"
+    task verify: :environment do
+      puts "Running rails db:migrate"
+      Rake::Task["db:migrate"].invoke
+      puts "Diffing the db/structure.sql"
+      sh %{git diff --quiet db/structure.sql} do |ok, _|
+        unless ok
+          abort "Generated structure.sql differs from structure.sql stored in git. " +
+            "Please run rake db:migrate and check the differences."
+        end
+      end
+      puts "Everything looks fine!"
+    end
   end
 
   desc 'Create the database, load the structure, and initialize with the seed data'


### PR DESCRIPTION
In our rpm package builds we run a set of migrations, dump the
db structure afterwards and compare it with the one stored in git.

If they differ, the package builds fail.

Now it can happen that the structure.sql is not touched, but gems that
affect how the dumped strucutre.sql looks like changed and result in a
different format, eg. using different chars to mark keywords, adding the
indexing method even when it's the default one, etc. .

To avoid this from happening we add a new linter that runs in travis.