### PR TITLE
[webui] Drop reviewable polymorphic association

### DIFF
--- a/src/api/app/models/bs_request.rb
+++ b/src/api/app/models/bs_request.rb
@@ -48,11 +48,6 @@ class BsRequest < ApplicationRecord
 
   scope :with_actions_and_reviews, -> { joins(:bs_request_actions).left_outer_joins(:reviews).distinct.order(priority: :asc, id: :desc) }
 
-  scope :for_users, ->(user_ids) { where(reviews: { reviewable_id: user_ids, reviewable_type: 'User' }) }
-  scope :for_projects, ->(project_ids) { where(reviews: { reviewable_id: project_ids, reviewable_type: 'Project' }) }
-  scope :for_packages, ->(package_ids) { where(reviews: { reviewable_id: package_ids, reviewable_type: 'Package' }) }
-  scope :for_groups, ->(group_ids) { where(reviews: { reviewable_id: group_ids, reviewable_type: 'Group' }) }
-
   before_save :assign_number
   has_many :bs_request_actions, -> { includes([:bs_request_action_accept_info]) }, dependent: :destroy
   has_many :reviews, dependent: :delete_all

--- a/src/api/app/models/group.rb
+++ b/src/api/app/models/group.rb
@@ -9,7 +9,7 @@ class Group < ApplicationRecord
   has_many :group_maintainers, inverse_of: :group, dependent: :destroy
   has_many :relationships, dependent: :destroy, inverse_of: :group
   has_many :event_subscriptions, dependent: :destroy, inverse_of: :group
-  has_many :reviews, dependent: :nullify, as: :reviewable
+  has_many :reviews, dependent: :nullify, foreign_key: :by_group, primary_key: :title
 
   has_many :rss_feed_items, -> { order(created_at: :desc) }, class_name: 'Notifications::RssFeedItem', dependent: :destroy
 

--- a/src/api/app/models/package.rb
+++ b/src/api/app/models/package.rb
@@ -76,7 +76,7 @@ class Package < ApplicationRecord
 
   has_many :binary_releases, dependent: :delete_all, foreign_key: 'release_package_id'
 
-  has_many :reviews, dependent: :nullify, as: :reviewable
+  has_many :reviews, dependent: :nullify, foreign_key: :by_package, primary_key: :name
 
   has_many :target_of_bs_request_actions, class_name: 'BsRequestAction', foreign_key: 'target_package_id'
   has_many :target_of_bs_requests, through: :target_of_bs_request_actions, source: :bs_request

--- a/src/api/app/models/project.rb
+++ b/src/api/app/models/project.rb
@@ -89,7 +89,7 @@ class Project < ApplicationRecord
 
   has_many :project_log_entries, dependent: :delete_all
 
-  has_many :reviews, dependent: :nullify, as: :reviewable
+  has_many :reviews, dependent: :nullify, foreign_key: :by_project, primary_key: :name
 
   has_many :target_of_bs_request_actions, class_name: 'BsRequestAction', foreign_key: 'target_project_id'
   has_many :target_of_bs_requests, through: :target_of_bs_request_actions, source: :bs_request

--- a/src/api/spec/models/review_spec.rb
+++ b/src/api/spec/models/review_spec.rb
@@ -66,27 +66,27 @@ RSpec.describe Review do
     context 'with valid attributes' do
       it 'sets user association when by_user object exists' do
         review = create(:review, by_user: user.login)
-        expect(review.reviewable).to eq(user)
+        expect(review.user).to eq(user)
         expect(review.by_user).to eq(user.login)
       end
 
       it 'sets group association when by_group object exists' do
         review = create(:review, by_group: group.title)
-        expect(review.reviewable).to eq(group)
+        expect(review.group).to eq(group)
         expect(review.by_group).to eq(group.title)
       end
 
       it 'sets project association when by_project object exists' do
         review = create(:review, by_project: project.name)
-        expect(review.reviewable).to eq(project)
+        expect(review.project).to eq(project)
         expect(review.by_project).to eq(project.name)
       end
 
       it 'sets package and project associations when by_package and by_project object exists' do
         review = create(:review, by_project: project.name, by_package: package.name)
-        expect(review.reviewable).to eq(package)
+        expect(review.package).to eq(package)
         expect(review.by_package).to eq(package.name)
-        expect(review.reviewable.project).to eq(project)
+        expect(review.project).to eq(project)
         expect(review.by_project).to eq(project.name)
       end
     end
@@ -94,31 +94,31 @@ RSpec.describe Review do
     context 'with invalid attributes' do
       it 'does not set user association when by_user object does not exist' do
         review = Review.new(by_user: 'not-existent')
-        expect(review.reviewable).to eq(nil)
+        expect(review.user).to eq(nil)
         expect(review.valid?).to eq(false)
       end
 
       it 'does not set group association when by_group object does not exist' do
         review = Review.new(by_group: 'not-existent')
-        expect(review.reviewable).to eq(nil)
+        expect(review.group).to eq(nil)
         expect(review.valid?).to eq(false)
       end
 
       it 'does not set project association when by_project object does not exist' do
         review = Review.new(by_project: 'not-existent')
-        expect(review.reviewable).to eq(nil)
+        expect(review.project).to eq(nil)
         expect(review.valid?).to eq(false)
       end
 
       it 'does not set project and package associations when by_project and by_package object does not exist' do
         review = Review.new(by_project: 'not-existent', by_package: 'not-existent')
-        expect(review.reviewable).to eq(nil)
+        expect(review.package).to eq(nil)
         expect(review.valid?).to eq(false)
       end
 
       it 'does not set package association when by_project parameter is missing' do
         review = Review.new(by_package: package.name)
-        expect(review.reviewable).to eq(nil)
+        expect(review.package).to eq(nil)
         expect(review.valid?).to eq(false)
       end
     end

--- a/src/api/spec/models/user_spec.rb
+++ b/src/api/spec/models/user_spec.rb
@@ -538,6 +538,11 @@ RSpec.describe User do
         let!(:review_of_another_subject) {
           create(:review, by_project: other_package.project.name, by_package: other_package.name, bs_request: request_of_another_subject)
         }
+
+        let!(:relationship_project_user) { create(:relationship_project_user, user: admin_user, project: package.project) }
+        it 'show the reviews for project maintainer' do
+          expect(admin_user.involved_reviews).to include(request_with_same_creator_and_reviewer)
+        end
       end
     end
 


### PR DESCRIPTION
We need to have seperate associations for project and package because a Project maintainer should see Reviews by_package.
This was not the case with the polymorphic association as by_package reviews were only included
when the user is a package maintainer of this package.
Fixes #3282.