### PR TITLE
[ci] Test errors in Package#backend_build_command

### DIFF
--- a/src/api/spec/models/package_spec.rb
+++ b/src/api/spec/models/package_spec.rb
@@ -440,12 +440,22 @@ RSpec.describe Package, vcr: true do
       before { stub_request(:post, backend_url) }
 
       it { is_expected.to be_truthy }
+
+      it 'has no errors' do
+        subject
+        expect(package.errors.details).to eq({})
+      end
     end
 
     context 'backend response fails' do
       before { stub_request(:post, backend_url).and_raise(ActiveXML::Transport::Error) }
 
       it { is_expected.to be_falsey }
+
+      it 'has errors' do
+        subject
+        expect(package.errors.details).to eq({:base => [{:error => "Exception from WebMock"}]})
+      end
     end
 
     context 'user has no access rights for the project' do
@@ -463,6 +473,11 @@ RSpec.describe Package, vcr: true do
       subject { package.backend_build_command(:rebuild, other_project.name, params) }
 
       it { is_expected.to be_falsey }
+
+      it 'has errors' do
+        subject
+        expect(package.errors.details).to eq({:base=>[{:error=>"No permission to modify project '#{other_project}' for user '#{user}'"}]})
+      end
     end
   end
 


### PR DESCRIPTION
This apart from make the test more accurate, could help us to solve the flickering error related with this test. This way we would have more information about why it is failing. :mag: 

I am taking about this error:

```
  1) Package#backend_build_command backend response is successful should be truthy
     Failure/Error: it { is_expected.to be_truthy }
     
       expected: truthy value
            got: false
     # ./spec/models/package_spec.rb:442:in `block (4 levels) in <top (required)>'
     # ./spec/support/logging.rb:4:in `block (2 levels) in <top (required)>'
```