### PR TITLE
[dist] Remove Require iputils from rpm spec file

### DIFF
--- a/dist/obs-server.spec
+++ b/dist/obs-server.spec
@@ -238,9 +238,6 @@ Requires:       perl(GD)
 
 Requires:       ghostscript-fonts-std
 
-# for user_ldap_strategy.rb (needs ping from iputils)
-Requires:       iputils
-
 %description -n obs-api
 This is the API server instance, and the web client for the
 OBS.


### PR DESCRIPTION
Partly reverts fec9c83ee037597c1d7d4d6dbcb88eb364499c76.

Ping isn't required anymore due to the changes made in
7fbf940af347b1e601d5f53a927e53ff9df5f31c.