### PR TITLE
[webui][api] remove creation of notifications from SendEventEmails

### DIFF
--- a/src/api/app/jobs/send_event_emails.rb
+++ b/src/api/app/jobs/send_event_emails.rb
@@ -16,15 +16,6 @@ class SendEventEmails
       subscribers = event.subscribers
       next if subscribers.empty?
       EventMailer.event(subscribers, event).deliver_now
-
-      event.subscriptions.each do |subscription|
-        Notifications::RssFeedItem.create(
-          subscriber: subscription.subscriber,
-          event_type: event.eventtype,
-          event_payload: event.payload,
-          subscription_receiver_role: subscription.receiver_role
-        )
-      end
     end
     true
   end


### PR DESCRIPTION
because it makes the job take too long.

This error comes up in teh production logs:

> E, [2017-06-28T10:20:36.692810 #4418] ERROR -- : [4418:13142.18] 2017-06-28T10:20:36+0000: [Worker(delayed_job.0 host:api pid:4418)] Job SendEventEmails#perform (id=30509956) (queue=quick) FAILED (0 prior attempts) with ActiveRecord::StatementInvalid: Mysql2::Error: Lock wait timeout exceeded; try restarting transaction: SELECT  `events`.* FROM `events` WHERE `events`.`mails_sent` = 0 ORDER BY `events`.`created_at` ASC LIMIT 1000 FOR UPDATE


So it seems that the creation of notifications was making the block take too long for the mysql lock.