### PR TITLE
[webui][api] remove pesimistic locking from SendEventEmails

### DIFF
--- a/src/api/app/jobs/send_event_emails.rb
+++ b/src/api/app/jobs/send_event_emails.rb
@@ -5,7 +5,7 @@ class SendEventEmails
   attr_accessor :event
 
   def perform
-    Event::Base.where(mails_sent: false).order(:created_at).limit(1000).lock(true).each do |event|
+    Event::Base.where(mails_sent: false).order(:created_at).limit(1000).each do |event|
       event.mails_sent = true
       begin
         event.save!


### PR DESCRIPTION
This job is failing to execute because the time takes to complete is exceeded the mysql lock time limit:

https://errbit-opensuse.herokuapp.com/apps/5620ca2bdc71fa00b1000000/problems/595381fcec877400063a687a

That lock is an implementation of [pessimistic locking](http://api.rubyonrails.org/classes/ActiveRecord/Locking/Pessimistic.html) but we already have [optimistic locking](http://api.rubyonrails.org/classes/ActiveRecord/Locking/Optimistic.html) on line 12:

```ruby
rescue ActiveRecord::StaleObjectError
```

So we are removing the pessimistic locking to avoid this mysql error.