### PR TITLE
Fix/support product indexing with service based products

### DIFF
--- a/src/api/app/models/product.rb
+++ b/src/api/app/models/product.rb
@@ -21,7 +21,7 @@ class Product < ApplicationRecord
   def self.all_products( project, expand = nil )
     return project.expand_all_products if expand
 
-    joins(:package).where("packages.project_id = ? and packages.name = '_product'", project.id)
+    joins(package: :package_kinds).where(packages: {project: project}, package_kinds: {kind: 'product'})
   end
 
   def to_axml(_opts = {})

--- a/src/api/app/views/models/_product.xml.builder
+++ b/src/api/app/views/models/_product.xml.builder
@@ -1,4 +1,6 @@
-xml.product(name: my_model.name, originproject: my_model.package.project.name) do
+xml.product(name: my_model.name,
+            originproject: my_model.package.project.name,
+            originpackage: my_model.package.name) do
 
   xml.cpe(my_model.cpe)
 

--- a/src/api/app/views/source/productlist.xml.builder
+++ b/src/api/app/views/source/productlist.xml.builder
@@ -1,6 +1,7 @@
 xml.productlist( count: @products.count ) do
   @products.map { |p| xml.product(name: p.name, cpe: p.cpe, 
                                   originproject: p.package.project.name,
+                                  originpackage: p.package.name,
                                   mtime: p.package.updated_at.to_i) }
 end
 

--- a/src/api/test/functional/product_test.rb
+++ b/src/api/test/functional/product_test.rb
@@ -16,13 +16,15 @@ class ProductTests < ActionDispatch::IntegrationTest
     assert_response :success
     assert_xml_tag parent: {
       tag:        "product",
-      attributes: { name: "simple", originproject: "home:tom:temporary" }
+      attributes: { name: "simple", originproject: "home:tom:temporary", originpackage: "_product" }
     },
       tag: "cpe", content: "cpe:/o:obs_fuzzies:simple:13.1"
     get "#{prefix}/source/home:tom:temporary?view=verboseproductlist&expand=1"
     assert_response :success
     assert_xml_tag parent: { tag:        "product",
-                             attributes: { name: "simple", originproject: "home:tom:temporary" } },
+                             attributes: { name:          "simple",
+                                           originproject: "home:tom:temporary",
+                                           originpackage: "_product" } },
                    tag: "cpe", content: "cpe:/o:obs_fuzzies:simple:13.1"
 
     # product views via project links
@@ -32,7 +34,10 @@ class ProductTests < ActionDispatch::IntegrationTest
     get "#{prefix}/source/home:tom:temporary:link?view=productlist&expand=1"
     assert_response :success
     assert_xml_tag tag: "product",
-                   attributes: { name: "simple", cpe: "cpe:/o:obs_fuzzies:simple:13.1", originproject: "home:tom:temporary" }
+                   attributes: { name:          "simple",
+                                 cpe:           "cpe:/o:obs_fuzzies:simple:13.1",
+                                 originproject: "home:tom:temporary",
+                                 originpackage: "_product" }
 
     # productrepositories
     get "#{prefix}/source/home:tom:temporary:link/_product?view=productrepositories"


### PR DESCRIPTION
next generation products won't use hardcoded "_product" master package + auto-generated source packages anymore, but handle this in any average package container using source service and multibuild.

We detect the package kind already correct there, but don't find them in product listing calls. Also we need to report the package container name now, since you can't assume "_product" anymore.