### PR TITLE
[webui][api] Fix EventMailer when sending an email to a group with no email address set

### DIFF
--- a/src/api/app/mailers/event_mailer.rb
+++ b/src/api/app/mailers/event_mailer.rb
@@ -36,6 +36,7 @@ class EventMailer < ActionMailer::Base
     # no need to tell user about this own actions
     # TODO: make configurable?
     subscribers.delete(orig)
+    subscribers.reject! { |subscriber| subscriber.email.blank? }
     return if subscribers.empty?
 
     tos = subscribers.map(&:display_name)


### PR DESCRIPTION
Should fix these two (identical) issues:

https://github.com/openSUSE/open-build-service/issues/3315
https://github.com/openSUSE/open-build-service/issues/3316