### PR TITLE
[webui][api] Fix EventFindSubscriptions for a group with no email set

### DIFF
--- a/src/api/app/models/event_find_subscriptions.rb
+++ b/src/api/app/models/event_find_subscriptions.rb
@@ -106,6 +106,7 @@ class EventFindSubscriptions
     subscribers_and_subscriptions = Hash.new
 
     @toconsider.each do |subscription|
+      next if subscription.subscriber.email.blank?
       subscribers_and_subscriptions[subscription.subscriber] ||= []
       subscribers_and_subscriptions[subscription.subscriber] << subscription
     end

--- a/src/api/config/clock.rb
+++ b/src/api/config/clock.rb
@@ -37,7 +37,7 @@ module Clockwork
 
   every(30.seconds, 'send notifications') do
     ::Event::NotifyBackends.trigger_delayed_sent
-    SendEventEmails.new.delay.perform
+    SendEventEmails.new.delay(queue: 'mailers').perform
   end
 
   every(17.seconds, 'fetch notifications', thread: true) do

--- a/src/api/spec/models/event_find_subscriptions_spec.rb
+++ b/src/api/spec/models/event_find_subscriptions_spec.rb
@@ -7,12 +7,14 @@ RSpec.describe EventFindSubscriptions do
     let!(:user2) { create(:confirmed_user) }
     let!(:group1) { create(:group) }
     let!(:group2) { create(:group) }
+    let!(:group3) { create(:group, email: '') }
 
     let!(:subscription1) { create(:event_subscription_comment_for_project, receiver_role: 'all', user: comment_author) }
     let!(:subscription2) { create(:event_subscription_comment_for_project, receiver_role: 'all', user: user1) }
     let!(:subscription3) { create(:event_subscription_comment_for_project, receiver_role: 'all', user: user2) }
     let!(:subscription4) { create(:event_subscription_comment_for_project, receiver_role: 'all', user: nil, group: group1) }
     let!(:subscription5) { create(:event_subscription_comment_for_project, receiver_role: 'all', user: nil, group: group2) }
+    let!(:subscription6) { create(:event_subscription_comment_for_project, receiver_role: 'all', user: nil, group: group3) }
 
     let!(:comment) { create(:comment_project, body: "Hey @#{user1.login} how are things?", user: comment_author) }
     let(:event) { Event::CommentForProject.first }
@@ -25,6 +27,10 @@ RSpec.describe EventFindSubscriptions do
 
     it 'does not include the author of the comment' do
       expect(subject).not_to include(subscription1)
+    end
+
+    it 'does not include the group with no email set' do
+      expect(subject).not_to include(subscription6)
     end
   end
 end


### PR DESCRIPTION
Should fix https://github.com/openSUSE/open-build-service/issues/3315

When I refactored `EventFindSubscriptions` in this [commit](https://github.com/openSUSE/open-build-service/commit/84696444cfcc9df2ad495e8c12718b72d81debf1) you can see that in `filter_toconsider` on line 95 (before the change) there was this line:

```ruby
next if group.email.blank?		
```

However that behaviour did not get implemented in the new refactored version of the class so I'm adding it now.