### PR TITLE
[webui] Flip comment and accept boxes

### DIFF
--- a/src/api/app/views/webui/comment/_new.html.haml
+++ b/src/api/app/views/webui/comment/_new.html.haml
@@ -2,5 +2,5 @@
   = form_for @comment, method: :post do |f|
     = hidden_field_tag :commentable_type, commentable.class
     = hidden_field_tag :commentable_id, commentable.id
-    ~ f.text_area :body, size: '80x4', onkeyup: 'sz(this);', onclick: 'sz(this);', style: 'width: 90%;', placeholder: 'Add a new comment (markdown markup supported)', required: 'required'
+    ~ f.text_area :body, size: '80x4', onkeyup: 'sz(this);', onclick: 'sz(this);', placeholder: 'Add a new comment (markdown markup supported)', required: 'required'
     = f.submit 'Add comment'

--- a/src/api/app/views/webui/comment/_show.html.haml
+++ b/src/api/app/views/webui/comment/_show.html.haml
@@ -8,7 +8,7 @@
       = comment_body(comment)
       = render partial: 'webui/comment/links', locals: { comment: comment }
       = render partial: 'webui/comment/reply', locals: { comment: comment, level: 0, commentable: commentable }
-  .comment_new.grid_16.alpha.omega
+  .comment_new.alpha.omega
     = render partial: 'webui/comment/new', locals: { commentable: commentable }
 - content_for :ready_function do
   setup_comment_page();

--- a/src/api/app/views/webui/request/show.html.erb
+++ b/src/api/app/views/webui/request/show.html.erb
@@ -205,87 +205,95 @@
 
 <div class="grid_16 alpha omega">
   <div class="grid_10 alpha">
-    <div class="box box-shadow">
-      <div class="box-header header-tabs">
-        <%= possibly_empty_ul id: 'review_descision_select', fallback: "<p><i>There's nothing to be done right now</i></p>".html_safe do %>
-            <% if @can_handle_request %>
-                <li class="<%= 'selected' if !@can_add_reviews || @my_open_reviews.empty? %>">
-                  <a class="review_descision_link" id="review_descision_link_-1" href="#">My Decision</a>
-                </li>
-            <% end %>
-            <% if @my_open_reviews.length > 0 %>
-                <% @my_open_reviews.each_with_index do |open_review, index| %>
-                    <li class="<%= 'selected' if @my_open_reviews.length > 0 && index == 0 %>">
-                      <a class="review_descision_link" id="review_descision_link_<%= index %>" href="#">Review
-                        for <%= render :partial => 'reviewer', :locals => { :review => open_review, :no_icon => true } %></a>
-                    </li>
-                <% end %>
-            <% end %>
-            <% content_for :ready_function do %>
-                requestShowReview();
-            <% end %>
-        <% end %>
-      </div>
-      <div class="review_descision_display" style="<%= 'display: none;' if @can_add_reviews && @my_open_reviews.length > 0 %>" id="review_descision_display_-1">
-        <% if @can_handle_request %>
-            <%= form_tag({ :action => 'changerequest' }, { id: 'request_handle_form' }) do %>
-                <% if @show_project_maintainer_hint %>
-                    <div class="ui-state-highlight ui-corner-all ui-widget-shadow padding-10pt">
-                      <span class="ui-icon ui-icon-info">
-                        You are a <strong>project maintainer</strong> but not a <strong>package maintainer</strong>. This package
-                        has <strong><%= pluralize(@package_maintainers.size, "package maintainer") %></strong> assigned. Please keep
-                        in mind that also package maintainers would like to review this request.
-                      </span>
-                    </div>
-                <% end %>
-                <p><%= text_area_tag(:reason, nil, :placeholder => 'Please add a comment', :size => '80x2', :style => 'width: 99%') %></p>
 
-                <p>
-                  <%= hidden_field_tag(:number, @number) %>
-                  <% if @state.in?(["new", "review"]) && @is_target_maintainer %>
-                      <% if @state == 'review' %>
-                          <%= submit_tag 'Accept request', name: 'accepted', id: 'accept_request_button', data: { confirm: 'Do you really want to approve this request, despite of open review requests?' } %>
-                      <% else %>
+    <div class="grid_10 box box-shadow alpha omega">
+      <h2 class="box-header">Comments for request <%= @number %> (<%= @comments.length %>)</h2>
+      <%= render :partial => 'webui/comment/show', locals: { commentable: @bsreq } %>
+    </div>
 
-                          <%= submit_tag 'Accept request', name: 'accepted', id: 'accept_request_button' %>
-                      <% end %>
-                      <%= submit_tag 'Decline request', name: 'declined' if !@is_author %>
+    <div class="grid_10 alpha">
+      <div class="box box-shadow">
+        <div class="box-header header-tabs">
+          <%= possibly_empty_ul id: 'review_descision_select', fallback: "<p><i>There's nothing to be done right now</i></p>".html_safe do %>
+              <% if @can_handle_request %>
+                  <li class="<%= 'selected' if !@can_add_reviews || @my_open_reviews.empty? %>">
+                    <a class="review_descision_link" id="review_descision_link_-1" href="#">My Decision</a>
+                  </li>
+              <% end %>
+              <% if @my_open_reviews.length > 0 %>
+                  <% @my_open_reviews.each_with_index do |open_review, index| %>
+                      <li class="<%= 'selected' if @my_open_reviews.length > 0 && index == 0 %>">
+                        <a class="review_descision_link" id="review_descision_link_<%= index %>" href="#">Review
+                          for <%= render :partial => 'reviewer', :locals => { :review => open_review, :no_icon => true } %></a>
+                      </li>
                   <% end %>
-                  <% if @state.in?(["new", "review", "declined"]) && @is_author %>
-                      <%= submit_tag 'Revoke request', name: 'revoked', id: 'revoke_request_button' %>
+              <% end %>
+              <% content_for :ready_function do %>
+                  requestShowReview();
+              <% end %>
+          <% end %>
+        </div>
+        <div class="review_descision_display" style="<%= 'display: none;' if @can_add_reviews && @my_open_reviews.length > 0 %>" id="review_descision_display_-1">
+          <% if @can_handle_request %>
+              <%= form_tag({ :action => 'changerequest' }, { id: 'request_handle_form' }) do %>
+                  <% if @show_project_maintainer_hint %>
+                      <div class="ui-state-highlight ui-corner-all ui-widget-shadow padding-10pt">
+                        <span class="ui-icon ui-icon-info">
+                          You are a <strong>project maintainer</strong> but not a <strong>package maintainer</strong>. This package
+                          has <strong><%= pluralize(@package_maintainers.size, "package maintainer") %></strong> assigned. Please keep
+                          in mind that also package maintainers would like to review this request.
+                        </span>
+                      </div>
                   <% end %>
-                  <% if @state == 'declined' %>
-                      <%= submit_tag 'Reopen request', name: 'new', id: 'reopen_request_button' %>
-                  <% end %>
-                  <span style="float: right;">
-                        <% if @req['actions'].first[:type] == :maintenance_incident %>
-                            <%= link_to(sprited_text('package_link', 'Merge with existing incident'), { :controller => 'request', :action => 'set_incident_dialog', number: @number }, :remote => true) %>
+                  <p><%= text_area_tag(:reason, nil, :placeholder => 'Please add a comment', :size => '80x2', :style => 'width: 99%') %></p>
+
+                  <p>
+                    <%= hidden_field_tag(:number, @number) %>
+                    <% if @state.in?(["new", "review"]) && @is_target_maintainer %>
+                        <% if @state == 'review' %>
+                            <%= submit_tag 'Accept request', name: 'accepted', id: 'accept_request_button', data: { confirm: 'Do you really want to approve this request, despite of open review requests?' } %>
+                        <% else %>
+
+                            <%= submit_tag 'Accept request', name: 'accepted', id: 'accept_request_button' %>
                         <% end %>
-                      </span>
-                </p>
-            <% end %>
-            <% content_for :ready_function do %>
-                requestAddAcceptRequestButton();
-            <% end %>
+                        <%= submit_tag 'Decline request', name: 'declined' if !@is_author %>
+                    <% end %>
+                    <% if @state.in?(["new", "review", "declined"]) && @is_author %>
+                        <%= submit_tag 'Revoke request', name: 'revoked', id: 'revoke_request_button' %>
+                    <% end %>
+                    <% if @state == 'declined' %>
+                        <%= submit_tag 'Reopen request', name: 'new', id: 'reopen_request_button' %>
+                    <% end %>
+                    <span style="float: right;">
+                          <% if @req['actions'].first[:type] == :maintenance_incident %>
+                              <%= link_to(sprited_text('package_link', 'Merge with existing incident'), { :controller => 'request', :action => 'set_incident_dialog', number: @number }, :remote => true) %>
+                          <% end %>
+                        </span>
+                  </p>
+              <% end %>
+              <% content_for :ready_function do %>
+                  requestAddAcceptRequestButton();
+              <% end %>
+          <% end %>
+        </div>
+        <% @my_open_reviews.each_with_index do |review, index| %>
+            <div class="review_descision_display <%= 'hidden' if index != 0 %>" id="review_descision_display_<%= index %>">
+              <%= form_tag(:action => 'modify_review') do %>
+                  <p><%= text_area_tag("review_comment_#{index}", review[:reason], :size => '80x2', :style => 'width: 99%', :class => 'review_comment', :placeholder => 'Please comment on your decision') %></p>
+
+                  <p>
+                    <%= hidden_field_tag("review_request_number_#{index}", @number) %>
+                    <%= hidden_field_tag("review_by_user_#{index}", review[:by_user]) if review[:by_user] %>
+                    <%= hidden_field_tag("review_by_group_#{index}", review[:by_group]) if review[:by_group] %>
+                    <%= hidden_field_tag("review_by_project_#{index}", review[:by_project]) if review[:by_project] %>
+                    <%= hidden_field_tag("review_by_package_#{index}", review[:by_package]) if review[:by_package] %>
+                    <%= submit_tag 'Approve', name: 'accepted', id: "review_accept_button_#{index}", title: 'Give this request your blessing, it will continue.' %>
+                    <%= submit_tag 'Disregard', name: 'declined', id: "review_decline_button_#{index}", title: 'Veto this request, it will be declined.' %>
+                  </p>
+              <% end %>
+            </div>
         <% end %>
       </div>
-      <% @my_open_reviews.each_with_index do |review, index| %>
-          <div class="review_descision_display <%= 'hidden' if index != 0 %>" id="review_descision_display_<%= index %>">
-            <%= form_tag(:action => 'modify_review') do %>
-                <p><%= text_area_tag("review_comment_#{index}", review[:reason], :size => '80x2', :style => 'width: 99%', :class => 'review_comment', :placeholder => 'Please comment on your decision') %></p>
-
-                <p>
-                  <%= hidden_field_tag("review_request_number_#{index}", @number) %>
-                  <%= hidden_field_tag("review_by_user_#{index}", review[:by_user]) if review[:by_user] %>
-                  <%= hidden_field_tag("review_by_group_#{index}", review[:by_group]) if review[:by_group] %>
-                  <%= hidden_field_tag("review_by_project_#{index}", review[:by_project]) if review[:by_project] %>
-                  <%= hidden_field_tag("review_by_package_#{index}", review[:by_package]) if review[:by_package] %>
-                  <%= submit_tag 'Approve', name: 'accepted', id: "review_accept_button_#{index}", title: 'Give this request your blessing, it will continue.' %>
-                  <%= submit_tag 'Disregard', name: 'declined', id: "review_decline_button_#{index}", title: 'Veto this request, it will be declined.' %>
-                </p>
-            <% end %>
-          </div>
-      <% end %>
     </div>
   </div>
 
@@ -296,11 +304,6 @@
       <%= render :partial => 'recent_events_table' %>
     </div>
   </div>
-</div>
-
-<div class="grid_16 box box-shadow alpha omega" style="margin-top: 15px;">
-  <h2 class="box-header">Comments for request <%= @number %> (<%= @comments.length %>)</h2>
-  <%= render :partial => 'webui/comment/show', locals: { commentable: @bsreq } %>
 </div>
 
  <%= render :partial => 'webui/request/package_maintainers_dialog' %>


### PR DESCRIPTION
on request#show view because before it was easy to oversee comments.
#3184

![request_comments](https://user-images.githubusercontent.com/3799140/27682554-524e0e16-5cc3-11e7-81cc-46d6e48770fd.png)

