### PR TITLE
[frontend] Send app_version to errbit

### DIFF
--- a/src/api/config/initializers/airbrake.rb
+++ b/src/api/config/initializers/airbrake.rb
@@ -15,6 +15,7 @@ Airbrake.configure do |c|
   # https://github.com/airbrake/airbrake-ruby#project_id--project_key
   c.project_id  = CONFIG['errbit_project_id']
   c.project_key = CONFIG['errbit_api_key']
+  c.app_version = CONFIG['version']
 
   # Configures the root directory of your project. Expects a String or a
   # Pathname, which represents the path to your project. Providing this option


### PR DESCRIPTION
Errbit has dropped deploy tracking in errbit/errbit#913 so we need a way to
identify exceptions of an outdated deploy, so we can remove them.