### PR TITLE
[ci] Add 'bullet' gem and its configuration

### DIFF
--- a/src/api/Gemfile
+++ b/src/api/Gemfile
@@ -150,6 +150,8 @@ group :development, :test do
   gem 'launchy'
   # for calling single testd
   gem 'single_test'
+  # to find n+1 queries
+  gem 'bullet'
 end
 
 # Gems used only for assets and not required in production environments by default.

--- a/src/api/Gemfile.lock
+++ b/src/api/Gemfile.lock
@@ -60,6 +60,9 @@ GEM
     ast (2.3.0)
     atomic (1.1.99)
     builder (3.2.3)
+    bullet (5.5.1)
+      activesupport (>= 3.0.0)
+      uniform_notifier (~> 1.10.0)
     capybara (2.14.3)
       addressable
       mime-types (>= 1.16)
@@ -368,6 +371,7 @@ GEM
     unicorn-rails (2.2.1)
       rack
       unicorn
+    uniform_notifier (1.10.0)
     url (0.3.2)
     vcr (3.0.3)
     voight_kampff (1.1.1)
@@ -395,6 +399,7 @@ DEPENDENCIES
   acts_as_tree
   airbrake
   annotate
+  bullet
   bundler
   capybara
   capybara_minitest_spec

--- a/src/api/config/environments/development.rb
+++ b/src/api/config/environments/development.rb
@@ -54,6 +54,13 @@ OBSApi::Application.configure do
   # config.file_watcher = ActiveSupport::EventedFileUpdateChecker
 
   config.peek.adapter = :memcache
+  # Bullet configuration
+  config.after_initialize do
+    Bullet.enable = true
+    Bullet.bullet_logger = true
+    Bullet.console = true
+    Bullet.add_footer = true
+  end
 end
 
 CONFIG['extended_backend_log'] = true

--- a/src/api/config/environments/test.rb
+++ b/src/api/config/environments/test.rb
@@ -51,6 +51,13 @@ OBSApi::Application.configure do
   config.secret_key_base = '92b2ed725cb4d68cc5fbf86d6ba204f1dec4172086ee7eac8f083fb62ef34057f1b770e0722ade7b298837be7399c6152938627e7d15aca5fcda7a4faef91fc7'
   # rubocop:enable Metrics/LineLength
 
+  # Bullet configuration
+  config.after_initialize do
+    Bullet.enable = true
+    Bullet.bullet_logger = true
+    Bullet.raise = false # raise an error if n+1 query occurs
+  end
+
   # TODO: This shouldn't be needed when we switch to RSpec completely
   config.action_dispatch.rescue_responses.merge!('ActionController::InvalidAuthenticityToken' => 950 )
 end

--- a/src/api/spec/rails_helper.rb
+++ b/src/api/spec/rails_helper.rb
@@ -27,6 +27,18 @@ RSpec.configure do |config|
   config.filter_rails_from_backtrace!
   # arbitrary gems may also be filtered via:
   # config.filter_gems_from_backtrace("gem name")
+
+  # Wrap each test in Bullet api.
+  if Bullet.enable?
+    config.before(:each) do
+      Bullet.start_request
+    end
+
+    config.after(:each) do
+      Bullet.perform_out_of_channel_notifications if Bullet.notification?
+      Bullet.end_request
+    end
+  end
 end
 
 # support test coverage


### PR DESCRIPTION
In test environment we enable bullet log, without raising exceptions.
In development environment we enable bullet log and messages in browser.

Originally introduced in 7af0aad75aa360725e2c3189641cf2c7e4a5d1f5 but then temporally reverted in  67e6cb2c5be16eb23b317f03650c3aa76adf9f20.

Do not merge till we have all gems in O:S:U