### PR TITLE
[api] Update notifications migration

### DIFF
--- a/src/api/db/migrate/20170619111734_alter_notifications_to_use_polymorphic.rb
+++ b/src/api/db/migrate/20170619111734_alter_notifications_to_use_polymorphic.rb
@@ -2,12 +2,9 @@ class AlterNotificationsToUsePolymorphic < ActiveRecord::Migration[5.0]
   def change
     add_reference :notifications, :subscriber, polymorphic: true
 
-    Notification.find_in_batches batch_size: 500 do |batch|
-      batch.each do |notification|
-        notification.subscriber = notification.user || notification.group
-        notification.save!
-      end
-    end
+    # Existing notifications would fail because of incompatible payload.
+    # Since this is for a feature that just got introduced we can drop them.
+    Notification.delete_all
 
     remove_reference :notifications, :group
     remove_reference :notifications, :user


### PR DESCRIPTION
Drop pre-existing notifications. Existing notifications would fail bacause
of incompatible payload. Since this is for a feature that just got introduced
we can drop them.

===

== 20170619111734 AlterNotificationsToUsePolymorphic: migrating ===============
rails aborted!
StandardError: An error has occurred, all later migrations canceled:

undefined method `primary_key' for Integer:Class
/srv/www/obs/api/db/migrate/20170619111734_alter_notifications_to_use_polymorphic.rb:7:in `block (2 levels) in change'
/srv/www/obs/api/db/migrate/20170619111734_alter_notifications_to_use_polymorphic.rb:6:in `each'
/srv/www/obs/api/db/migrate/20170619111734_alter_notifications_to_use_polymorphic.rb:6:in `block in change'
/srv/www/obs/api/db/migrate/20170619111734_alter_notifications_to_use_polymorphic.rb:5:in `change'
bin/rails:4:in `require'
bin/rails:4:in `<main>'