### PR TITLE
[ci] Fix flickering test: backend_build_command

### DIFF
--- a/src/api/spec/cassettes/Package/_backend_build_command/backend_response_fails/1_13_2_1.yml
+++ b/src/api/spec/cassettes/Package/_backend_build_command/backend_response_fails/1_13_2_1.yml
@@ -40,85 +40,7 @@ http_interactions:
           <person userid="tom" role="maintainer" />
         </project>
     http_version: 
-  recorded_at: Wed, 03 May 2017 20:07:57 GMT
-- request:
-    method: put
-    uri: http://localhost:3200/source/home:tom/test_package/_meta?user=_nobody_
-    body:
-      encoding: UTF-8
-      string: |
-        <package name="test_package" project="home:tom">
-          <title>It's a Battlefield</title>
-          <description>Est molestiae tempore et.</description>
-        </package>
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '151'
-    body:
-      encoding: UTF-8
-      string: |
-        <package name="test_package" project="home:tom">
-          <title>It's a Battlefield</title>
-          <description>Est molestiae tempore et.</description>
-        </package>
-    http_version: 
-  recorded_at: Wed, 03 May 2017 20:07:58 GMT
-- request:
-    method: put
-    uri: http://localhost:3200/source/home:tom/test_package/_meta
-    body:
-      encoding: UTF-8
-      string: |
-        <package name="test_package" project="home:tom">
-          <title>It's a Battlefield</title>
-          <description>Est molestiae tempore et.</description>
-        </package>
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '151'
-    body:
-      encoding: UTF-8
-      string: |
-        <package name="test_package" project="home:tom">
-          <title>It's a Battlefield</title>
-          <description>Est molestiae tempore et.</description>
-        </package>
-    http_version: 
-  recorded_at: Wed, 03 May 2017 20:07:58 GMT
+  recorded_at: Fri, 30 Jun 2017 12:16:05 GMT
 - request:
     method: put
     uri: http://localhost:3200/source/home:tom/test_package/_meta?user=tom
@@ -126,8 +48,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="test_package" project="home:tom">
-          <title>Eyeless in Gaza</title>
-          <description>Omnis nesciunt deserunt dolor quos adipisci animi.</description>
+          <title>A Monstrous Regiment of Women</title>
+          <description>Est perspiciatis illum ut.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -148,14 +70,53 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '173'
+      - '163'
     body:
       encoding: UTF-8
       string: |
         <package name="test_package" project="home:tom">
-          <title>Eyeless in Gaza</title>
-          <description>Omnis nesciunt deserunt dolor quos adipisci animi.</description>
+          <title>A Monstrous Regiment of Women</title>
+          <description>Est perspiciatis illum ut.</description>
         </package>
     http_version: 
-  recorded_at: Fri, 30 Jun 2017 12:16:12 GMT
+  recorded_at: Fri, 30 Jun 2017 12:16:05 GMT
+- request:
+    method: put
+    uri: http://localhost:3200/source/home:tom/test_package/_meta
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="test_package" project="home:tom">
+          <title>A Monstrous Regiment of Women</title>
+          <description>Est perspiciatis illum ut.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '163'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="test_package" project="home:tom">
+          <title>A Monstrous Regiment of Women</title>
+          <description>Est perspiciatis illum ut.</description>
+        </package>
+    http_version: 
+  recorded_at: Fri, 30 Jun 2017 12:16:05 GMT
 recorded_with: VCR 3.0.3

--- a/src/api/spec/cassettes/Package/_backend_build_command/backend_response_is_successful/1_13_1_1.yml
+++ b/src/api/spec/cassettes/Package/_backend_build_command/backend_response_is_successful/1_13_1_1.yml
@@ -40,85 +40,7 @@ http_interactions:
           <person userid="tom" role="maintainer" />
         </project>
     http_version: 
-  recorded_at: Wed, 03 May 2017 20:07:57 GMT
-- request:
-    method: put
-    uri: http://localhost:3200/source/home:tom/test_package/_meta?user=_nobody_
-    body:
-      encoding: UTF-8
-      string: |
-        <package name="test_package" project="home:tom">
-          <title>It's a Battlefield</title>
-          <description>Est molestiae tempore et.</description>
-        </package>
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '151'
-    body:
-      encoding: UTF-8
-      string: |
-        <package name="test_package" project="home:tom">
-          <title>It's a Battlefield</title>
-          <description>Est molestiae tempore et.</description>
-        </package>
-    http_version: 
-  recorded_at: Wed, 03 May 2017 20:07:58 GMT
-- request:
-    method: put
-    uri: http://localhost:3200/source/home:tom/test_package/_meta
-    body:
-      encoding: UTF-8
-      string: |
-        <package name="test_package" project="home:tom">
-          <title>It's a Battlefield</title>
-          <description>Est molestiae tempore et.</description>
-        </package>
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '151'
-    body:
-      encoding: UTF-8
-      string: |
-        <package name="test_package" project="home:tom">
-          <title>It's a Battlefield</title>
-          <description>Est molestiae tempore et.</description>
-        </package>
-    http_version: 
-  recorded_at: Wed, 03 May 2017 20:07:58 GMT
+  recorded_at: Fri, 30 Jun 2017 12:16:05 GMT
 - request:
     method: put
     uri: http://localhost:3200/source/home:tom/test_package/_meta?user=tom
@@ -126,8 +48,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="test_package" project="home:tom">
-          <title>Eyeless in Gaza</title>
-          <description>Omnis nesciunt deserunt dolor quos adipisci animi.</description>
+          <title>The Green Bay Tree</title>
+          <description>Rerum esse est culpa voluptatem neque atque.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -148,14 +70,53 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '173'
+      - '170'
     body:
       encoding: UTF-8
       string: |
         <package name="test_package" project="home:tom">
-          <title>Eyeless in Gaza</title>
-          <description>Omnis nesciunt deserunt dolor quos adipisci animi.</description>
+          <title>The Green Bay Tree</title>
+          <description>Rerum esse est culpa voluptatem neque atque.</description>
         </package>
     http_version: 
-  recorded_at: Fri, 30 Jun 2017 12:16:12 GMT
+  recorded_at: Fri, 30 Jun 2017 12:16:06 GMT
+- request:
+    method: put
+    uri: http://localhost:3200/source/home:tom/test_package/_meta
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="test_package" project="home:tom">
+          <title>The Green Bay Tree</title>
+          <description>Rerum esse est culpa voluptatem neque atque.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '170'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="test_package" project="home:tom">
+          <title>The Green Bay Tree</title>
+          <description>Rerum esse est culpa voluptatem neque atque.</description>
+        </package>
+    http_version: 
+  recorded_at: Fri, 30 Jun 2017 12:16:06 GMT
 recorded_with: VCR 3.0.3

--- a/src/api/spec/cassettes/Package/_backend_build_command/user_has_no_access_rights_for_the_project/1_13_3_1.yml
+++ b/src/api/spec/cassettes/Package/_backend_build_command/user_has_no_access_rights_for_the_project/1_13_3_1.yml
@@ -40,122 +40,7 @@ http_interactions:
           <person userid="tom" role="maintainer" />
         </project>
     http_version: 
-  recorded_at: Wed, 03 May 2017 14:37:41 GMT
-- request:
-    method: put
-    uri: http://localhost:3200/source/home:tom/test_package/_meta?user=_nobody_
-    body:
-      encoding: UTF-8
-      string: |
-        <package name="test_package" project="home:tom">
-          <title>Cover Her Face</title>
-          <description>Earum dicta consectetur omnis itaque beatae provident.</description>
-        </package>
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '176'
-    body:
-      encoding: UTF-8
-      string: |
-        <package name="test_package" project="home:tom">
-          <title>Cover Her Face</title>
-          <description>Earum dicta consectetur omnis itaque beatae provident.</description>
-        </package>
-    http_version: 
-  recorded_at: Wed, 03 May 2017 14:37:41 GMT
-- request:
-    method: put
-    uri: http://localhost:3200/source/home:tom/test_package/_meta
-    body:
-      encoding: UTF-8
-      string: |
-        <package name="test_package" project="home:tom">
-          <title>Cover Her Face</title>
-          <description>Earum dicta consectetur omnis itaque beatae provident.</description>
-        </package>
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '176'
-    body:
-      encoding: UTF-8
-      string: |
-        <package name="test_package" project="home:tom">
-          <title>Cover Her Face</title>
-          <description>Earum dicta consectetur omnis itaque beatae provident.</description>
-        </package>
-    http_version: 
-  recorded_at: Wed, 03 May 2017 14:37:41 GMT
-- request:
-    method: get
-    uri: http://localhost:3200/build/home:tom/openSUSE_Tumbleweed/x86_64/_jobhistory?limit=100&package=test_package
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Content-Type:
-      - text/plain
-      Accept-Encoding:
-      - identity
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 404
-      message: project 'home tom' has no repository 'openSUSE_Tumbleweed'
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '194'
-    body:
-      encoding: UTF-8
-      string: |
-        <status code="404">
-          <summary>project 'home:tom' has no repository 'openSUSE_Tumbleweed'</summary>
-          <details>404 project 'home:tom' has no repository 'openSUSE_Tumbleweed'</details>
-        </status>
-    http_version: 
-  recorded_at: Wed, 03 May 2017 14:37:41 GMT
+  recorded_at: Fri, 30 Jun 2017 12:16:05 GMT
 - request:
     method: put
     uri: http://localhost:3200/source/home:tom/test_package/_meta?user=tom
@@ -163,8 +48,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="test_package" project="home:tom">
-          <title>In Dubious Battle</title>
-          <description>Tenetur quos ipsam rerum veritatis excepturi.</description>
+          <title>Where Angels Fear to Tread</title>
+          <description>Nesciunt labore architecto eveniet in dolor nihil accusantium et.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -185,14 +70,126 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '170'
+      - '199'
     body:
       encoding: UTF-8
       string: |
         <package name="test_package" project="home:tom">
-          <title>In Dubious Battle</title>
-          <description>Tenetur quos ipsam rerum veritatis excepturi.</description>
+          <title>Where Angels Fear to Tread</title>
+          <description>Nesciunt labore architecto eveniet in dolor nihil accusantium et.</description>
         </package>
     http_version: 
-  recorded_at: Fri, 30 Jun 2017 12:16:11 GMT
+  recorded_at: Fri, 30 Jun 2017 12:16:05 GMT
+- request:
+    method: put
+    uri: http://localhost:3200/source/home:tom/test_package/_meta
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="test_package" project="home:tom">
+          <title>Where Angels Fear to Tread</title>
+          <description>Nesciunt labore architecto eveniet in dolor nihil accusantium et.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '199'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="test_package" project="home:tom">
+          <title>Where Angels Fear to Tread</title>
+          <description>Nesciunt labore architecto eveniet in dolor nihil accusantium et.</description>
+        </package>
+    http_version: 
+  recorded_at: Fri, 30 Jun 2017 12:16:05 GMT
+- request:
+    method: put
+    uri: http://localhost:3200/source/project_1/_meta
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="project_1">
+          <title>The Millstone</title>
+          <description/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '99'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="project_1">
+          <title>The Millstone</title>
+          <description></description>
+        </project>
+    http_version: 
+  recorded_at: Fri, 30 Jun 2017 12:16:05 GMT
+- request:
+    method: put
+    uri: http://localhost:3200/source/project_1/_config
+    body:
+      encoding: UTF-8
+      string: Consequatur nam consequatur. Et dicta eaque non eius modi qui vitae.
+        Sint beatae expedita et cumque.
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '21'
+    body:
+      encoding: UTF-8
+      string: '<status code="ok" />
+
+'
+    http_version: 
+  recorded_at: Fri, 30 Jun 2017 12:16:05 GMT
 recorded_with: VCR 3.0.3

--- a/src/api/spec/cassettes/Package/_buildresults/1_9_1.yml
+++ b/src/api/spec/cassettes/Package/_buildresults/1_9_1.yml
@@ -40,85 +40,7 @@ http_interactions:
           <person userid="tom" role="maintainer" />
         </project>
     http_version: 
-  recorded_at: Wed, 03 May 2017 20:07:57 GMT
-- request:
-    method: put
-    uri: http://localhost:3200/source/home:tom/test_package/_meta?user=_nobody_
-    body:
-      encoding: UTF-8
-      string: |
-        <package name="test_package" project="home:tom">
-          <title>It's a Battlefield</title>
-          <description>Est molestiae tempore et.</description>
-        </package>
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '151'
-    body:
-      encoding: UTF-8
-      string: |
-        <package name="test_package" project="home:tom">
-          <title>It's a Battlefield</title>
-          <description>Est molestiae tempore et.</description>
-        </package>
-    http_version: 
-  recorded_at: Wed, 03 May 2017 20:07:58 GMT
-- request:
-    method: put
-    uri: http://localhost:3200/source/home:tom/test_package/_meta
-    body:
-      encoding: UTF-8
-      string: |
-        <package name="test_package" project="home:tom">
-          <title>It's a Battlefield</title>
-          <description>Est molestiae tempore et.</description>
-        </package>
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '151'
-    body:
-      encoding: UTF-8
-      string: |
-        <package name="test_package" project="home:tom">
-          <title>It's a Battlefield</title>
-          <description>Est molestiae tempore et.</description>
-        </package>
-    http_version: 
-  recorded_at: Wed, 03 May 2017 20:07:58 GMT
+  recorded_at: Fri, 30 Jun 2017 12:15:58 GMT
 - request:
     method: put
     uri: http://localhost:3200/source/home:tom/test_package/_meta?user=tom
@@ -126,8 +48,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="test_package" project="home:tom">
-          <title>Eyeless in Gaza</title>
-          <description>Omnis nesciunt deserunt dolor quos adipisci animi.</description>
+          <title>Arms and the Man</title>
+          <description>Perferendis voluptates quia veniam aut voluptatum velit aliquid voluptatem.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -148,14 +70,53 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '173'
+      - '199'
     body:
       encoding: UTF-8
       string: |
         <package name="test_package" project="home:tom">
-          <title>Eyeless in Gaza</title>
-          <description>Omnis nesciunt deserunt dolor quos adipisci animi.</description>
+          <title>Arms and the Man</title>
+          <description>Perferendis voluptates quia veniam aut voluptatum velit aliquid voluptatem.</description>
         </package>
     http_version: 
-  recorded_at: Fri, 30 Jun 2017 12:16:12 GMT
+  recorded_at: Fri, 30 Jun 2017 12:15:58 GMT
+- request:
+    method: put
+    uri: http://localhost:3200/source/home:tom/test_package/_meta
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="test_package" project="home:tom">
+          <title>Arms and the Man</title>
+          <description>Perferendis voluptates quia veniam aut voluptatum velit aliquid voluptatem.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '199'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="test_package" project="home:tom">
+          <title>Arms and the Man</title>
+          <description>Perferendis voluptates quia veniam aut voluptatum velit aliquid voluptatem.</description>
+        </package>
+    http_version: 
+  recorded_at: Fri, 30 Jun 2017 12:15:58 GMT
 recorded_with: VCR 3.0.3

--- a/src/api/spec/cassettes/Package/_buildresults/1_9_10.yml
+++ b/src/api/spec/cassettes/Package/_buildresults/1_9_10.yml
@@ -40,85 +40,7 @@ http_interactions:
           <person userid="tom" role="maintainer" />
         </project>
     http_version: 
-  recorded_at: Wed, 03 May 2017 20:07:57 GMT
-- request:
-    method: put
-    uri: http://localhost:3200/source/home:tom/test_package/_meta?user=_nobody_
-    body:
-      encoding: UTF-8
-      string: |
-        <package name="test_package" project="home:tom">
-          <title>It's a Battlefield</title>
-          <description>Est molestiae tempore et.</description>
-        </package>
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '151'
-    body:
-      encoding: UTF-8
-      string: |
-        <package name="test_package" project="home:tom">
-          <title>It's a Battlefield</title>
-          <description>Est molestiae tempore et.</description>
-        </package>
-    http_version: 
-  recorded_at: Wed, 03 May 2017 20:07:58 GMT
-- request:
-    method: put
-    uri: http://localhost:3200/source/home:tom/test_package/_meta
-    body:
-      encoding: UTF-8
-      string: |
-        <package name="test_package" project="home:tom">
-          <title>It's a Battlefield</title>
-          <description>Est molestiae tempore et.</description>
-        </package>
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '151'
-    body:
-      encoding: UTF-8
-      string: |
-        <package name="test_package" project="home:tom">
-          <title>It's a Battlefield</title>
-          <description>Est molestiae tempore et.</description>
-        </package>
-    http_version: 
-  recorded_at: Wed, 03 May 2017 20:07:58 GMT
+  recorded_at: Fri, 30 Jun 2017 12:16:00 GMT
 - request:
     method: put
     uri: http://localhost:3200/source/home:tom/test_package/_meta?user=tom
@@ -126,8 +48,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="test_package" project="home:tom">
-          <title>Eyeless in Gaza</title>
-          <description>Omnis nesciunt deserunt dolor quos adipisci animi.</description>
+          <title>Behold the Man</title>
+          <description>Velit et hic aperiam corporis.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -148,14 +70,53 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '173'
+      - '152'
     body:
       encoding: UTF-8
       string: |
         <package name="test_package" project="home:tom">
-          <title>Eyeless in Gaza</title>
-          <description>Omnis nesciunt deserunt dolor quos adipisci animi.</description>
+          <title>Behold the Man</title>
+          <description>Velit et hic aperiam corporis.</description>
         </package>
     http_version: 
-  recorded_at: Fri, 30 Jun 2017 12:16:12 GMT
+  recorded_at: Fri, 30 Jun 2017 12:16:00 GMT
+- request:
+    method: put
+    uri: http://localhost:3200/source/home:tom/test_package/_meta
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="test_package" project="home:tom">
+          <title>Behold the Man</title>
+          <description>Velit et hic aperiam corporis.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '152'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="test_package" project="home:tom">
+          <title>Behold the Man</title>
+          <description>Velit et hic aperiam corporis.</description>
+        </package>
+    http_version: 
+  recorded_at: Fri, 30 Jun 2017 12:16:00 GMT
 recorded_with: VCR 3.0.3

--- a/src/api/spec/cassettes/Package/_buildresults/1_9_11.yml
+++ b/src/api/spec/cassettes/Package/_buildresults/1_9_11.yml
@@ -40,85 +40,7 @@ http_interactions:
           <person userid="tom" role="maintainer" />
         </project>
     http_version: 
-  recorded_at: Wed, 03 May 2017 20:07:57 GMT
-- request:
-    method: put
-    uri: http://localhost:3200/source/home:tom/test_package/_meta?user=_nobody_
-    body:
-      encoding: UTF-8
-      string: |
-        <package name="test_package" project="home:tom">
-          <title>It's a Battlefield</title>
-          <description>Est molestiae tempore et.</description>
-        </package>
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '151'
-    body:
-      encoding: UTF-8
-      string: |
-        <package name="test_package" project="home:tom">
-          <title>It's a Battlefield</title>
-          <description>Est molestiae tempore et.</description>
-        </package>
-    http_version: 
-  recorded_at: Wed, 03 May 2017 20:07:58 GMT
-- request:
-    method: put
-    uri: http://localhost:3200/source/home:tom/test_package/_meta
-    body:
-      encoding: UTF-8
-      string: |
-        <package name="test_package" project="home:tom">
-          <title>It's a Battlefield</title>
-          <description>Est molestiae tempore et.</description>
-        </package>
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '151'
-    body:
-      encoding: UTF-8
-      string: |
-        <package name="test_package" project="home:tom">
-          <title>It's a Battlefield</title>
-          <description>Est molestiae tempore et.</description>
-        </package>
-    http_version: 
-  recorded_at: Wed, 03 May 2017 20:07:58 GMT
+  recorded_at: Fri, 30 Jun 2017 12:15:59 GMT
 - request:
     method: put
     uri: http://localhost:3200/source/home:tom/test_package/_meta?user=tom
@@ -126,8 +48,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="test_package" project="home:tom">
-          <title>Eyeless in Gaza</title>
-          <description>Omnis nesciunt deserunt dolor quos adipisci animi.</description>
+          <title>Tiger! Tiger!</title>
+          <description>Fuga qui error veritatis recusandae eos.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -148,14 +70,53 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '173'
+      - '161'
     body:
       encoding: UTF-8
       string: |
         <package name="test_package" project="home:tom">
-          <title>Eyeless in Gaza</title>
-          <description>Omnis nesciunt deserunt dolor quos adipisci animi.</description>
+          <title>Tiger! Tiger!</title>
+          <description>Fuga qui error veritatis recusandae eos.</description>
         </package>
     http_version: 
-  recorded_at: Fri, 30 Jun 2017 12:16:12 GMT
+  recorded_at: Fri, 30 Jun 2017 12:15:59 GMT
+- request:
+    method: put
+    uri: http://localhost:3200/source/home:tom/test_package/_meta
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="test_package" project="home:tom">
+          <title>Tiger! Tiger!</title>
+          <description>Fuga qui error veritatis recusandae eos.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '161'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="test_package" project="home:tom">
+          <title>Tiger! Tiger!</title>
+          <description>Fuga qui error veritatis recusandae eos.</description>
+        </package>
+    http_version: 
+  recorded_at: Fri, 30 Jun 2017 12:15:59 GMT
 recorded_with: VCR 3.0.3

--- a/src/api/spec/cassettes/Package/_buildresults/1_9_12.yml
+++ b/src/api/spec/cassettes/Package/_buildresults/1_9_12.yml
@@ -40,85 +40,7 @@ http_interactions:
           <person userid="tom" role="maintainer" />
         </project>
     http_version: 
-  recorded_at: Wed, 03 May 2017 20:07:57 GMT
-- request:
-    method: put
-    uri: http://localhost:3200/source/home:tom/test_package/_meta?user=_nobody_
-    body:
-      encoding: UTF-8
-      string: |
-        <package name="test_package" project="home:tom">
-          <title>It's a Battlefield</title>
-          <description>Est molestiae tempore et.</description>
-        </package>
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '151'
-    body:
-      encoding: UTF-8
-      string: |
-        <package name="test_package" project="home:tom">
-          <title>It's a Battlefield</title>
-          <description>Est molestiae tempore et.</description>
-        </package>
-    http_version: 
-  recorded_at: Wed, 03 May 2017 20:07:58 GMT
-- request:
-    method: put
-    uri: http://localhost:3200/source/home:tom/test_package/_meta
-    body:
-      encoding: UTF-8
-      string: |
-        <package name="test_package" project="home:tom">
-          <title>It's a Battlefield</title>
-          <description>Est molestiae tempore et.</description>
-        </package>
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '151'
-    body:
-      encoding: UTF-8
-      string: |
-        <package name="test_package" project="home:tom">
-          <title>It's a Battlefield</title>
-          <description>Est molestiae tempore et.</description>
-        </package>
-    http_version: 
-  recorded_at: Wed, 03 May 2017 20:07:58 GMT
+  recorded_at: Fri, 30 Jun 2017 12:15:58 GMT
 - request:
     method: put
     uri: http://localhost:3200/source/home:tom/test_package/_meta?user=tom
@@ -126,8 +48,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="test_package" project="home:tom">
-          <title>Eyeless in Gaza</title>
-          <description>Omnis nesciunt deserunt dolor quos adipisci animi.</description>
+          <title>To Your Scattered Bodies Go</title>
+          <description>Quae sit aliquam qui.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -148,14 +70,53 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '173'
+      - '156'
     body:
       encoding: UTF-8
       string: |
         <package name="test_package" project="home:tom">
-          <title>Eyeless in Gaza</title>
-          <description>Omnis nesciunt deserunt dolor quos adipisci animi.</description>
+          <title>To Your Scattered Bodies Go</title>
+          <description>Quae sit aliquam qui.</description>
         </package>
     http_version: 
-  recorded_at: Fri, 30 Jun 2017 12:16:12 GMT
+  recorded_at: Fri, 30 Jun 2017 12:15:58 GMT
+- request:
+    method: put
+    uri: http://localhost:3200/source/home:tom/test_package/_meta
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="test_package" project="home:tom">
+          <title>To Your Scattered Bodies Go</title>
+          <description>Quae sit aliquam qui.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '156'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="test_package" project="home:tom">
+          <title>To Your Scattered Bodies Go</title>
+          <description>Quae sit aliquam qui.</description>
+        </package>
+    http_version: 
+  recorded_at: Fri, 30 Jun 2017 12:15:58 GMT
 recorded_with: VCR 3.0.3

--- a/src/api/spec/cassettes/Package/_buildresults/1_9_13.yml
+++ b/src/api/spec/cassettes/Package/_buildresults/1_9_13.yml
@@ -40,85 +40,7 @@ http_interactions:
           <person userid="tom" role="maintainer" />
         </project>
     http_version: 
-  recorded_at: Wed, 03 May 2017 20:07:57 GMT
-- request:
-    method: put
-    uri: http://localhost:3200/source/home:tom/test_package/_meta?user=_nobody_
-    body:
-      encoding: UTF-8
-      string: |
-        <package name="test_package" project="home:tom">
-          <title>It's a Battlefield</title>
-          <description>Est molestiae tempore et.</description>
-        </package>
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '151'
-    body:
-      encoding: UTF-8
-      string: |
-        <package name="test_package" project="home:tom">
-          <title>It's a Battlefield</title>
-          <description>Est molestiae tempore et.</description>
-        </package>
-    http_version: 
-  recorded_at: Wed, 03 May 2017 20:07:58 GMT
-- request:
-    method: put
-    uri: http://localhost:3200/source/home:tom/test_package/_meta
-    body:
-      encoding: UTF-8
-      string: |
-        <package name="test_package" project="home:tom">
-          <title>It's a Battlefield</title>
-          <description>Est molestiae tempore et.</description>
-        </package>
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '151'
-    body:
-      encoding: UTF-8
-      string: |
-        <package name="test_package" project="home:tom">
-          <title>It's a Battlefield</title>
-          <description>Est molestiae tempore et.</description>
-        </package>
-    http_version: 
-  recorded_at: Wed, 03 May 2017 20:07:58 GMT
+  recorded_at: Fri, 30 Jun 2017 12:15:59 GMT
 - request:
     method: put
     uri: http://localhost:3200/source/home:tom/test_package/_meta?user=tom
@@ -126,8 +48,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="test_package" project="home:tom">
-          <title>Eyeless in Gaza</title>
-          <description>Omnis nesciunt deserunt dolor quos adipisci animi.</description>
+          <title>A Scanner Darkly</title>
+          <description>Asperiores consequatur eum tempora.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -148,14 +70,53 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '173'
+      - '159'
     body:
       encoding: UTF-8
       string: |
         <package name="test_package" project="home:tom">
-          <title>Eyeless in Gaza</title>
-          <description>Omnis nesciunt deserunt dolor quos adipisci animi.</description>
+          <title>A Scanner Darkly</title>
+          <description>Asperiores consequatur eum tempora.</description>
         </package>
     http_version: 
-  recorded_at: Fri, 30 Jun 2017 12:16:12 GMT
+  recorded_at: Fri, 30 Jun 2017 12:15:59 GMT
+- request:
+    method: put
+    uri: http://localhost:3200/source/home:tom/test_package/_meta
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="test_package" project="home:tom">
+          <title>A Scanner Darkly</title>
+          <description>Asperiores consequatur eum tempora.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '159'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="test_package" project="home:tom">
+          <title>A Scanner Darkly</title>
+          <description>Asperiores consequatur eum tempora.</description>
+        </package>
+    http_version: 
+  recorded_at: Fri, 30 Jun 2017 12:15:59 GMT
 recorded_with: VCR 3.0.3

--- a/src/api/spec/cassettes/Package/_buildresults/1_9_2.yml
+++ b/src/api/spec/cassettes/Package/_buildresults/1_9_2.yml
@@ -40,85 +40,7 @@ http_interactions:
           <person userid="tom" role="maintainer" />
         </project>
     http_version: 
-  recorded_at: Wed, 03 May 2017 20:07:57 GMT
-- request:
-    method: put
-    uri: http://localhost:3200/source/home:tom/test_package/_meta?user=_nobody_
-    body:
-      encoding: UTF-8
-      string: |
-        <package name="test_package" project="home:tom">
-          <title>It's a Battlefield</title>
-          <description>Est molestiae tempore et.</description>
-        </package>
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '151'
-    body:
-      encoding: UTF-8
-      string: |
-        <package name="test_package" project="home:tom">
-          <title>It's a Battlefield</title>
-          <description>Est molestiae tempore et.</description>
-        </package>
-    http_version: 
-  recorded_at: Wed, 03 May 2017 20:07:58 GMT
-- request:
-    method: put
-    uri: http://localhost:3200/source/home:tom/test_package/_meta
-    body:
-      encoding: UTF-8
-      string: |
-        <package name="test_package" project="home:tom">
-          <title>It's a Battlefield</title>
-          <description>Est molestiae tempore et.</description>
-        </package>
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '151'
-    body:
-      encoding: UTF-8
-      string: |
-        <package name="test_package" project="home:tom">
-          <title>It's a Battlefield</title>
-          <description>Est molestiae tempore et.</description>
-        </package>
-    http_version: 
-  recorded_at: Wed, 03 May 2017 20:07:58 GMT
+  recorded_at: Fri, 30 Jun 2017 12:16:01 GMT
 - request:
     method: put
     uri: http://localhost:3200/source/home:tom/test_package/_meta?user=tom
@@ -126,8 +48,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="test_package" project="home:tom">
-          <title>Eyeless in Gaza</title>
-          <description>Omnis nesciunt deserunt dolor quos adipisci animi.</description>
+          <title>No Highway</title>
+          <description>Sint doloribus ipsum sed quia ratione voluptatem.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -148,14 +70,53 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '173'
+      - '167'
     body:
       encoding: UTF-8
       string: |
         <package name="test_package" project="home:tom">
-          <title>Eyeless in Gaza</title>
-          <description>Omnis nesciunt deserunt dolor quos adipisci animi.</description>
+          <title>No Highway</title>
+          <description>Sint doloribus ipsum sed quia ratione voluptatem.</description>
         </package>
     http_version: 
-  recorded_at: Fri, 30 Jun 2017 12:16:12 GMT
+  recorded_at: Fri, 30 Jun 2017 12:16:01 GMT
+- request:
+    method: put
+    uri: http://localhost:3200/source/home:tom/test_package/_meta
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="test_package" project="home:tom">
+          <title>No Highway</title>
+          <description>Sint doloribus ipsum sed quia ratione voluptatem.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '167'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="test_package" project="home:tom">
+          <title>No Highway</title>
+          <description>Sint doloribus ipsum sed quia ratione voluptatem.</description>
+        </package>
+    http_version: 
+  recorded_at: Fri, 30 Jun 2017 12:16:01 GMT
 recorded_with: VCR 3.0.3

--- a/src/api/spec/cassettes/Package/_buildresults/1_9_3.yml
+++ b/src/api/spec/cassettes/Package/_buildresults/1_9_3.yml
@@ -40,85 +40,7 @@ http_interactions:
           <person userid="tom" role="maintainer" />
         </project>
     http_version: 
-  recorded_at: Wed, 03 May 2017 20:07:57 GMT
-- request:
-    method: put
-    uri: http://localhost:3200/source/home:tom/test_package/_meta?user=_nobody_
-    body:
-      encoding: UTF-8
-      string: |
-        <package name="test_package" project="home:tom">
-          <title>It's a Battlefield</title>
-          <description>Est molestiae tempore et.</description>
-        </package>
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '151'
-    body:
-      encoding: UTF-8
-      string: |
-        <package name="test_package" project="home:tom">
-          <title>It's a Battlefield</title>
-          <description>Est molestiae tempore et.</description>
-        </package>
-    http_version: 
-  recorded_at: Wed, 03 May 2017 20:07:58 GMT
-- request:
-    method: put
-    uri: http://localhost:3200/source/home:tom/test_package/_meta
-    body:
-      encoding: UTF-8
-      string: |
-        <package name="test_package" project="home:tom">
-          <title>It's a Battlefield</title>
-          <description>Est molestiae tempore et.</description>
-        </package>
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '151'
-    body:
-      encoding: UTF-8
-      string: |
-        <package name="test_package" project="home:tom">
-          <title>It's a Battlefield</title>
-          <description>Est molestiae tempore et.</description>
-        </package>
-    http_version: 
-  recorded_at: Wed, 03 May 2017 20:07:58 GMT
+  recorded_at: Fri, 30 Jun 2017 12:16:00 GMT
 - request:
     method: put
     uri: http://localhost:3200/source/home:tom/test_package/_meta?user=tom
@@ -126,8 +48,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="test_package" project="home:tom">
-          <title>Eyeless in Gaza</title>
-          <description>Omnis nesciunt deserunt dolor quos adipisci animi.</description>
+          <title>A Monstrous Regiment of Women</title>
+          <description>Harum error dolore quasi quia explicabo et.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -148,14 +70,53 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '173'
+      - '180'
     body:
       encoding: UTF-8
       string: |
         <package name="test_package" project="home:tom">
-          <title>Eyeless in Gaza</title>
-          <description>Omnis nesciunt deserunt dolor quos adipisci animi.</description>
+          <title>A Monstrous Regiment of Women</title>
+          <description>Harum error dolore quasi quia explicabo et.</description>
         </package>
     http_version: 
-  recorded_at: Fri, 30 Jun 2017 12:16:12 GMT
+  recorded_at: Fri, 30 Jun 2017 12:16:00 GMT
+- request:
+    method: put
+    uri: http://localhost:3200/source/home:tom/test_package/_meta
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="test_package" project="home:tom">
+          <title>A Monstrous Regiment of Women</title>
+          <description>Harum error dolore quasi quia explicabo et.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '180'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="test_package" project="home:tom">
+          <title>A Monstrous Regiment of Women</title>
+          <description>Harum error dolore quasi quia explicabo et.</description>
+        </package>
+    http_version: 
+  recorded_at: Fri, 30 Jun 2017 12:16:00 GMT
 recorded_with: VCR 3.0.3

--- a/src/api/spec/cassettes/Package/_buildresults/1_9_4.yml
+++ b/src/api/spec/cassettes/Package/_buildresults/1_9_4.yml
@@ -40,85 +40,7 @@ http_interactions:
           <person userid="tom" role="maintainer" />
         </project>
     http_version: 
-  recorded_at: Wed, 03 May 2017 20:07:57 GMT
-- request:
-    method: put
-    uri: http://localhost:3200/source/home:tom/test_package/_meta?user=_nobody_
-    body:
-      encoding: UTF-8
-      string: |
-        <package name="test_package" project="home:tom">
-          <title>It's a Battlefield</title>
-          <description>Est molestiae tempore et.</description>
-        </package>
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '151'
-    body:
-      encoding: UTF-8
-      string: |
-        <package name="test_package" project="home:tom">
-          <title>It's a Battlefield</title>
-          <description>Est molestiae tempore et.</description>
-        </package>
-    http_version: 
-  recorded_at: Wed, 03 May 2017 20:07:58 GMT
-- request:
-    method: put
-    uri: http://localhost:3200/source/home:tom/test_package/_meta
-    body:
-      encoding: UTF-8
-      string: |
-        <package name="test_package" project="home:tom">
-          <title>It's a Battlefield</title>
-          <description>Est molestiae tempore et.</description>
-        </package>
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '151'
-    body:
-      encoding: UTF-8
-      string: |
-        <package name="test_package" project="home:tom">
-          <title>It's a Battlefield</title>
-          <description>Est molestiae tempore et.</description>
-        </package>
-    http_version: 
-  recorded_at: Wed, 03 May 2017 20:07:58 GMT
+  recorded_at: Fri, 30 Jun 2017 12:16:01 GMT
 - request:
     method: put
     uri: http://localhost:3200/source/home:tom/test_package/_meta?user=tom
@@ -126,8 +48,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="test_package" project="home:tom">
-          <title>Eyeless in Gaza</title>
-          <description>Omnis nesciunt deserunt dolor quos adipisci animi.</description>
+          <title>The Heart Is a Lonely Hunter</title>
+          <description>Quia dolor aut illo mollitia aut.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -148,14 +70,53 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '173'
+      - '169'
     body:
       encoding: UTF-8
       string: |
         <package name="test_package" project="home:tom">
-          <title>Eyeless in Gaza</title>
-          <description>Omnis nesciunt deserunt dolor quos adipisci animi.</description>
+          <title>The Heart Is a Lonely Hunter</title>
+          <description>Quia dolor aut illo mollitia aut.</description>
         </package>
     http_version: 
-  recorded_at: Fri, 30 Jun 2017 12:16:12 GMT
+  recorded_at: Fri, 30 Jun 2017 12:16:01 GMT
+- request:
+    method: put
+    uri: http://localhost:3200/source/home:tom/test_package/_meta
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="test_package" project="home:tom">
+          <title>The Heart Is a Lonely Hunter</title>
+          <description>Quia dolor aut illo mollitia aut.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '169'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="test_package" project="home:tom">
+          <title>The Heart Is a Lonely Hunter</title>
+          <description>Quia dolor aut illo mollitia aut.</description>
+        </package>
+    http_version: 
+  recorded_at: Fri, 30 Jun 2017 12:16:01 GMT
 recorded_with: VCR 3.0.3

--- a/src/api/spec/cassettes/Package/_buildresults/1_9_5.yml
+++ b/src/api/spec/cassettes/Package/_buildresults/1_9_5.yml
@@ -40,85 +40,7 @@ http_interactions:
           <person userid="tom" role="maintainer" />
         </project>
     http_version: 
-  recorded_at: Wed, 03 May 2017 20:07:57 GMT
-- request:
-    method: put
-    uri: http://localhost:3200/source/home:tom/test_package/_meta?user=_nobody_
-    body:
-      encoding: UTF-8
-      string: |
-        <package name="test_package" project="home:tom">
-          <title>It's a Battlefield</title>
-          <description>Est molestiae tempore et.</description>
-        </package>
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '151'
-    body:
-      encoding: UTF-8
-      string: |
-        <package name="test_package" project="home:tom">
-          <title>It's a Battlefield</title>
-          <description>Est molestiae tempore et.</description>
-        </package>
-    http_version: 
-  recorded_at: Wed, 03 May 2017 20:07:58 GMT
-- request:
-    method: put
-    uri: http://localhost:3200/source/home:tom/test_package/_meta
-    body:
-      encoding: UTF-8
-      string: |
-        <package name="test_package" project="home:tom">
-          <title>It's a Battlefield</title>
-          <description>Est molestiae tempore et.</description>
-        </package>
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '151'
-    body:
-      encoding: UTF-8
-      string: |
-        <package name="test_package" project="home:tom">
-          <title>It's a Battlefield</title>
-          <description>Est molestiae tempore et.</description>
-        </package>
-    http_version: 
-  recorded_at: Wed, 03 May 2017 20:07:58 GMT
+  recorded_at: Fri, 30 Jun 2017 12:16:00 GMT
 - request:
     method: put
     uri: http://localhost:3200/source/home:tom/test_package/_meta?user=tom
@@ -126,8 +48,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="test_package" project="home:tom">
-          <title>Eyeless in Gaza</title>
-          <description>Omnis nesciunt deserunt dolor quos adipisci animi.</description>
+          <title>Vile Bodies</title>
+          <description>Voluptatem consectetur facere aut.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -148,14 +70,53 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '173'
+      - '153'
     body:
       encoding: UTF-8
       string: |
         <package name="test_package" project="home:tom">
-          <title>Eyeless in Gaza</title>
-          <description>Omnis nesciunt deserunt dolor quos adipisci animi.</description>
+          <title>Vile Bodies</title>
+          <description>Voluptatem consectetur facere aut.</description>
         </package>
     http_version: 
-  recorded_at: Fri, 30 Jun 2017 12:16:12 GMT
+  recorded_at: Fri, 30 Jun 2017 12:16:00 GMT
+- request:
+    method: put
+    uri: http://localhost:3200/source/home:tom/test_package/_meta
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="test_package" project="home:tom">
+          <title>Vile Bodies</title>
+          <description>Voluptatem consectetur facere aut.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '153'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="test_package" project="home:tom">
+          <title>Vile Bodies</title>
+          <description>Voluptatem consectetur facere aut.</description>
+        </package>
+    http_version: 
+  recorded_at: Fri, 30 Jun 2017 12:16:00 GMT
 recorded_with: VCR 3.0.3

--- a/src/api/spec/cassettes/Package/_buildresults/1_9_6.yml
+++ b/src/api/spec/cassettes/Package/_buildresults/1_9_6.yml
@@ -40,85 +40,7 @@ http_interactions:
           <person userid="tom" role="maintainer" />
         </project>
     http_version: 
-  recorded_at: Wed, 03 May 2017 20:07:57 GMT
-- request:
-    method: put
-    uri: http://localhost:3200/source/home:tom/test_package/_meta?user=_nobody_
-    body:
-      encoding: UTF-8
-      string: |
-        <package name="test_package" project="home:tom">
-          <title>It's a Battlefield</title>
-          <description>Est molestiae tempore et.</description>
-        </package>
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '151'
-    body:
-      encoding: UTF-8
-      string: |
-        <package name="test_package" project="home:tom">
-          <title>It's a Battlefield</title>
-          <description>Est molestiae tempore et.</description>
-        </package>
-    http_version: 
-  recorded_at: Wed, 03 May 2017 20:07:58 GMT
-- request:
-    method: put
-    uri: http://localhost:3200/source/home:tom/test_package/_meta
-    body:
-      encoding: UTF-8
-      string: |
-        <package name="test_package" project="home:tom">
-          <title>It's a Battlefield</title>
-          <description>Est molestiae tempore et.</description>
-        </package>
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '151'
-    body:
-      encoding: UTF-8
-      string: |
-        <package name="test_package" project="home:tom">
-          <title>It's a Battlefield</title>
-          <description>Est molestiae tempore et.</description>
-        </package>
-    http_version: 
-  recorded_at: Wed, 03 May 2017 20:07:58 GMT
+  recorded_at: Fri, 30 Jun 2017 12:15:59 GMT
 - request:
     method: put
     uri: http://localhost:3200/source/home:tom/test_package/_meta?user=tom
@@ -126,8 +48,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="test_package" project="home:tom">
-          <title>Eyeless in Gaza</title>
-          <description>Omnis nesciunt deserunt dolor quos adipisci animi.</description>
+          <title>The Daffodil Sky</title>
+          <description>Rerum qui et omnis.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -148,14 +70,53 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '173'
+      - '143'
     body:
       encoding: UTF-8
       string: |
         <package name="test_package" project="home:tom">
-          <title>Eyeless in Gaza</title>
-          <description>Omnis nesciunt deserunt dolor quos adipisci animi.</description>
+          <title>The Daffodil Sky</title>
+          <description>Rerum qui et omnis.</description>
         </package>
     http_version: 
-  recorded_at: Fri, 30 Jun 2017 12:16:12 GMT
+  recorded_at: Fri, 30 Jun 2017 12:15:59 GMT
+- request:
+    method: put
+    uri: http://localhost:3200/source/home:tom/test_package/_meta
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="test_package" project="home:tom">
+          <title>The Daffodil Sky</title>
+          <description>Rerum qui et omnis.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '143'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="test_package" project="home:tom">
+          <title>The Daffodil Sky</title>
+          <description>Rerum qui et omnis.</description>
+        </package>
+    http_version: 
+  recorded_at: Fri, 30 Jun 2017 12:15:59 GMT
 recorded_with: VCR 3.0.3

--- a/src/api/spec/cassettes/Package/_buildresults/1_9_7.yml
+++ b/src/api/spec/cassettes/Package/_buildresults/1_9_7.yml
@@ -40,85 +40,7 @@ http_interactions:
           <person userid="tom" role="maintainer" />
         </project>
     http_version: 
-  recorded_at: Wed, 03 May 2017 20:07:57 GMT
-- request:
-    method: put
-    uri: http://localhost:3200/source/home:tom/test_package/_meta?user=_nobody_
-    body:
-      encoding: UTF-8
-      string: |
-        <package name="test_package" project="home:tom">
-          <title>It's a Battlefield</title>
-          <description>Est molestiae tempore et.</description>
-        </package>
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '151'
-    body:
-      encoding: UTF-8
-      string: |
-        <package name="test_package" project="home:tom">
-          <title>It's a Battlefield</title>
-          <description>Est molestiae tempore et.</description>
-        </package>
-    http_version: 
-  recorded_at: Wed, 03 May 2017 20:07:58 GMT
-- request:
-    method: put
-    uri: http://localhost:3200/source/home:tom/test_package/_meta
-    body:
-      encoding: UTF-8
-      string: |
-        <package name="test_package" project="home:tom">
-          <title>It's a Battlefield</title>
-          <description>Est molestiae tempore et.</description>
-        </package>
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '151'
-    body:
-      encoding: UTF-8
-      string: |
-        <package name="test_package" project="home:tom">
-          <title>It's a Battlefield</title>
-          <description>Est molestiae tempore et.</description>
-        </package>
-    http_version: 
-  recorded_at: Wed, 03 May 2017 20:07:58 GMT
+  recorded_at: Fri, 30 Jun 2017 12:15:58 GMT
 - request:
     method: put
     uri: http://localhost:3200/source/home:tom/test_package/_meta?user=tom
@@ -126,8 +48,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="test_package" project="home:tom">
-          <title>Eyeless in Gaza</title>
-          <description>Omnis nesciunt deserunt dolor quos adipisci animi.</description>
+          <title>The Skull Beneath the Skin</title>
+          <description>Aut voluptatem qui assumenda ea.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -148,14 +70,53 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '173'
+      - '166'
     body:
       encoding: UTF-8
       string: |
         <package name="test_package" project="home:tom">
-          <title>Eyeless in Gaza</title>
-          <description>Omnis nesciunt deserunt dolor quos adipisci animi.</description>
+          <title>The Skull Beneath the Skin</title>
+          <description>Aut voluptatem qui assumenda ea.</description>
         </package>
     http_version: 
-  recorded_at: Fri, 30 Jun 2017 12:16:12 GMT
+  recorded_at: Fri, 30 Jun 2017 12:15:58 GMT
+- request:
+    method: put
+    uri: http://localhost:3200/source/home:tom/test_package/_meta
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="test_package" project="home:tom">
+          <title>The Skull Beneath the Skin</title>
+          <description>Aut voluptatem qui assumenda ea.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '166'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="test_package" project="home:tom">
+          <title>The Skull Beneath the Skin</title>
+          <description>Aut voluptatem qui assumenda ea.</description>
+        </package>
+    http_version: 
+  recorded_at: Fri, 30 Jun 2017 12:15:58 GMT
 recorded_with: VCR 3.0.3

--- a/src/api/spec/cassettes/Package/_buildresults/1_9_8.yml
+++ b/src/api/spec/cassettes/Package/_buildresults/1_9_8.yml
@@ -40,85 +40,7 @@ http_interactions:
           <person userid="tom" role="maintainer" />
         </project>
     http_version: 
-  recorded_at: Wed, 03 May 2017 20:07:57 GMT
-- request:
-    method: put
-    uri: http://localhost:3200/source/home:tom/test_package/_meta?user=_nobody_
-    body:
-      encoding: UTF-8
-      string: |
-        <package name="test_package" project="home:tom">
-          <title>It's a Battlefield</title>
-          <description>Est molestiae tempore et.</description>
-        </package>
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '151'
-    body:
-      encoding: UTF-8
-      string: |
-        <package name="test_package" project="home:tom">
-          <title>It's a Battlefield</title>
-          <description>Est molestiae tempore et.</description>
-        </package>
-    http_version: 
-  recorded_at: Wed, 03 May 2017 20:07:58 GMT
-- request:
-    method: put
-    uri: http://localhost:3200/source/home:tom/test_package/_meta
-    body:
-      encoding: UTF-8
-      string: |
-        <package name="test_package" project="home:tom">
-          <title>It's a Battlefield</title>
-          <description>Est molestiae tempore et.</description>
-        </package>
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '151'
-    body:
-      encoding: UTF-8
-      string: |
-        <package name="test_package" project="home:tom">
-          <title>It's a Battlefield</title>
-          <description>Est molestiae tempore et.</description>
-        </package>
-    http_version: 
-  recorded_at: Wed, 03 May 2017 20:07:58 GMT
+  recorded_at: Fri, 30 Jun 2017 12:15:59 GMT
 - request:
     method: put
     uri: http://localhost:3200/source/home:tom/test_package/_meta?user=tom
@@ -126,8 +48,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="test_package" project="home:tom">
-          <title>Eyeless in Gaza</title>
-          <description>Omnis nesciunt deserunt dolor quos adipisci animi.</description>
+          <title>Precious Bane</title>
+          <description>Id cumque maiores dolorem aperiam similique.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -148,14 +70,53 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '173'
+      - '165'
     body:
       encoding: UTF-8
       string: |
         <package name="test_package" project="home:tom">
-          <title>Eyeless in Gaza</title>
-          <description>Omnis nesciunt deserunt dolor quos adipisci animi.</description>
+          <title>Precious Bane</title>
+          <description>Id cumque maiores dolorem aperiam similique.</description>
         </package>
     http_version: 
-  recorded_at: Fri, 30 Jun 2017 12:16:12 GMT
+  recorded_at: Fri, 30 Jun 2017 12:15:59 GMT
+- request:
+    method: put
+    uri: http://localhost:3200/source/home:tom/test_package/_meta
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="test_package" project="home:tom">
+          <title>Precious Bane</title>
+          <description>Id cumque maiores dolorem aperiam similique.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '165'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="test_package" project="home:tom">
+          <title>Precious Bane</title>
+          <description>Id cumque maiores dolorem aperiam similique.</description>
+        </package>
+    http_version: 
+  recorded_at: Fri, 30 Jun 2017 12:15:59 GMT
 recorded_with: VCR 3.0.3

--- a/src/api/spec/cassettes/Package/_buildresults/1_9_9.yml
+++ b/src/api/spec/cassettes/Package/_buildresults/1_9_9.yml
@@ -40,85 +40,7 @@ http_interactions:
           <person userid="tom" role="maintainer" />
         </project>
     http_version: 
-  recorded_at: Wed, 03 May 2017 20:07:57 GMT
-- request:
-    method: put
-    uri: http://localhost:3200/source/home:tom/test_package/_meta?user=_nobody_
-    body:
-      encoding: UTF-8
-      string: |
-        <package name="test_package" project="home:tom">
-          <title>It's a Battlefield</title>
-          <description>Est molestiae tempore et.</description>
-        </package>
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '151'
-    body:
-      encoding: UTF-8
-      string: |
-        <package name="test_package" project="home:tom">
-          <title>It's a Battlefield</title>
-          <description>Est molestiae tempore et.</description>
-        </package>
-    http_version: 
-  recorded_at: Wed, 03 May 2017 20:07:58 GMT
-- request:
-    method: put
-    uri: http://localhost:3200/source/home:tom/test_package/_meta
-    body:
-      encoding: UTF-8
-      string: |
-        <package name="test_package" project="home:tom">
-          <title>It's a Battlefield</title>
-          <description>Est molestiae tempore et.</description>
-        </package>
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '151'
-    body:
-      encoding: UTF-8
-      string: |
-        <package name="test_package" project="home:tom">
-          <title>It's a Battlefield</title>
-          <description>Est molestiae tempore et.</description>
-        </package>
-    http_version: 
-  recorded_at: Wed, 03 May 2017 20:07:58 GMT
+  recorded_at: Fri, 30 Jun 2017 12:16:00 GMT
 - request:
     method: put
     uri: http://localhost:3200/source/home:tom/test_package/_meta?user=tom
@@ -126,8 +48,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="test_package" project="home:tom">
-          <title>Eyeless in Gaza</title>
-          <description>Omnis nesciunt deserunt dolor quos adipisci animi.</description>
+          <title>The Lathe of Heaven</title>
+          <description>Dolor esse eum explicabo eius.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -148,14 +70,53 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '173'
+      - '157'
     body:
       encoding: UTF-8
       string: |
         <package name="test_package" project="home:tom">
-          <title>Eyeless in Gaza</title>
-          <description>Omnis nesciunt deserunt dolor quos adipisci animi.</description>
+          <title>The Lathe of Heaven</title>
+          <description>Dolor esse eum explicabo eius.</description>
         </package>
     http_version: 
-  recorded_at: Fri, 30 Jun 2017 12:16:12 GMT
+  recorded_at: Fri, 30 Jun 2017 12:16:00 GMT
+- request:
+    method: put
+    uri: http://localhost:3200/source/home:tom/test_package/_meta
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="test_package" project="home:tom">
+          <title>The Lathe of Heaven</title>
+          <description>Dolor esse eum explicabo eius.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '157'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="test_package" project="home:tom">
+          <title>The Lathe of Heaven</title>
+          <description>Dolor esse eum explicabo eius.</description>
+        </package>
+    http_version: 
+  recorded_at: Fri, 30 Jun 2017 12:16:00 GMT
 recorded_with: VCR 3.0.3

--- a/src/api/spec/cassettes/Package/_delete_file/with_delete_permission/with_custom_options/sets_options_correct.yml
+++ b/src/api/spec/cassettes/Package/_delete_file/with_delete_permission/with_custom_options/sets_options_correct.yml
@@ -418,4 +418,43 @@ http_interactions:
         </revision>
     http_version: 
   recorded_at: Wed, 16 Nov 2016 10:58:33 GMT
+- request:
+    method: put
+    uri: http://localhost:3200/source/home:tom/package_with_files/_meta?user=tom
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="package_with_files" project="home:tom">
+          <title>Jesting Pilate</title>
+          <description>Ut sit aperiam ducimus nemo voluptatem animi consectetur.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '185'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="package_with_files" project="home:tom">
+          <title>Jesting Pilate</title>
+          <description>Ut sit aperiam ducimus nemo voluptatem animi consectetur.</description>
+        </package>
+    http_version: 
+  recorded_at: Fri, 30 Jun 2017 12:15:57 GMT
 recorded_with: VCR 3.0.3

--- a/src/api/spec/cassettes/Package/_delete_file/with_delete_permission/with_default_options/deletes_file.yml
+++ b/src/api/spec/cassettes/Package/_delete_file/with_delete_permission/with_default_options/deletes_file.yml
@@ -454,4 +454,43 @@ http_interactions:
         </revision>
     http_version: 
   recorded_at: Wed, 16 Nov 2016 10:58:32 GMT
+- request:
+    method: put
+    uri: http://localhost:3200/source/home:tom/package_with_files/_meta?user=tom
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="package_with_files" project="home:tom">
+          <title>The Wives of Bath</title>
+          <description>Facere facilis hic maxime veritatis sunt.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '172'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="package_with_files" project="home:tom">
+          <title>The Wives of Bath</title>
+          <description>Facere facilis hic maxime veritatis sunt.</description>
+        </package>
+    http_version: 
+  recorded_at: Fri, 30 Jun 2017 12:15:57 GMT
 recorded_with: VCR 3.0.3

--- a/src/api/spec/cassettes/Package/_delete_file/with_delete_permission/with_default_options/sets_options_correct.yml
+++ b/src/api/spec/cassettes/Package/_delete_file/with_delete_permission/with_default_options/sets_options_correct.yml
@@ -419,4 +419,43 @@ http_interactions:
         </revision>
     http_version: 
   recorded_at: Wed, 16 Nov 2016 10:58:33 GMT
+- request:
+    method: put
+    uri: http://localhost:3200/source/home:tom/package_with_files/_meta?user=tom
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="package_with_files" project="home:tom">
+          <title>From Here to Eternity</title>
+          <description>Rerum sed alias nobis enim cum.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '166'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="package_with_files" project="home:tom">
+          <title>From Here to Eternity</title>
+          <description>Rerum sed alias nobis enim cum.</description>
+        </package>
+    http_version: 
+  recorded_at: Fri, 30 Jun 2017 12:15:56 GMT
 recorded_with: VCR 3.0.3

--- a/src/api/spec/cassettes/Package/_delete_file/with_no_delete_permission/does_not_delete_file.yml
+++ b/src/api/spec/cassettes/Package/_delete_file/with_no_delete_permission/does_not_delete_file.yml
@@ -428,4 +428,84 @@ http_interactions:
         </package>
     http_version: 
   recorded_at: Wed, 16 Nov 2016 11:02:38 GMT
+- request:
+    method: put
+    uri: http://localhost:3200/source/home:other_user/_meta?user=other_user
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:other_user">
+          <title/>
+          <description/>
+          <person userid="other_user" role="maintainer"/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '143'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:other_user">
+          <title></title>
+          <description></description>
+          <person userid="other_user" role="maintainer" />
+        </project>
+    http_version: 
+  recorded_at: Fri, 30 Jun 2017 12:15:55 GMT
+- request:
+    method: put
+    uri: http://localhost:3200/source/home:tom/package_with_files/_meta?user=other_user
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="package_with_files" project="home:tom">
+          <title>As I Lay Dying</title>
+          <description>Nostrum perspiciatis aut est deserunt.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '166'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="package_with_files" project="home:tom">
+          <title>As I Lay Dying</title>
+          <description>Nostrum perspiciatis aut est deserunt.</description>
+        </package>
+    http_version: 
+  recorded_at: Fri, 30 Jun 2017 12:15:56 GMT
 recorded_with: VCR 3.0.3

--- a/src/api/spec/cassettes/Package/_delete_file/with_no_delete_permission/raises_DeleteFileNoPermission_exception.yml
+++ b/src/api/spec/cassettes/Package/_delete_file/with_no_delete_permission/raises_DeleteFileNoPermission_exception.yml
@@ -363,4 +363,84 @@ http_interactions:
         </package>
     http_version: 
   recorded_at: Wed, 16 Nov 2016 11:02:38 GMT
+- request:
+    method: put
+    uri: http://localhost:3200/source/home:other_user/_meta?user=other_user
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:other_user">
+          <title/>
+          <description/>
+          <person userid="other_user" role="maintainer"/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '143'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:other_user">
+          <title></title>
+          <description></description>
+          <person userid="other_user" role="maintainer" />
+        </project>
+    http_version: 
+  recorded_at: Fri, 30 Jun 2017 12:15:56 GMT
+- request:
+    method: put
+    uri: http://localhost:3200/source/home:tom/package_with_files/_meta?user=other_user
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="package_with_files" project="home:tom">
+          <title>Oh! To be in England</title>
+          <description>Magnam et quisquam aut iure.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '162'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="package_with_files" project="home:tom">
+          <title>Oh! To be in England</title>
+          <description>Magnam et quisquam aut iure.</description>
+        </package>
+    http_version: 
+  recorded_at: Fri, 30 Jun 2017 12:15:56 GMT
 recorded_with: VCR 3.0.3

--- a/src/api/spec/cassettes/Package/_jobhistory_list/when_response_fails/1_14_2_1.yml
+++ b/src/api/spec/cassettes/Package/_jobhistory_list/when_response_fails/1_14_2_1.yml
@@ -156,4 +156,43 @@ http_interactions:
         </status>
     http_version: 
   recorded_at: Wed, 03 May 2017 14:37:41 GMT
+- request:
+    method: put
+    uri: http://localhost:3200/source/home:tom/test_package/_meta?user=tom
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="test_package" project="home:tom">
+          <title>The Man Within</title>
+          <description>Temporibus quia excepturi iste optio.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '159'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="test_package" project="home:tom">
+          <title>The Man Within</title>
+          <description>Temporibus quia excepturi iste optio.</description>
+        </package>
+    http_version: 
+  recorded_at: Fri, 30 Jun 2017 12:16:11 GMT
 recorded_with: VCR 3.0.3

--- a/src/api/spec/cassettes/Package/_jobhistory_list/when_response_is_successful/1_14_1_2.yml
+++ b/src/api/spec/cassettes/Package/_jobhistory_list/when_response_is_successful/1_14_1_2.yml
@@ -119,4 +119,43 @@ http_interactions:
         </package>
     http_version: 
   recorded_at: Wed, 03 May 2017 20:07:57 GMT
+- request:
+    method: put
+    uri: http://localhost:3200/source/home:tom/test_package/_meta?user=tom
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="test_package" project="home:tom">
+          <title>Frequent Hearses</title>
+          <description>Consequuntur nesciunt nihil velit.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '158'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="test_package" project="home:tom">
+          <title>Frequent Hearses</title>
+          <description>Consequuntur nesciunt nihil velit.</description>
+        </package>
+    http_version: 
+  recorded_at: Fri, 30 Jun 2017 12:16:12 GMT
 recorded_with: VCR 3.0.3

--- a/src/api/spec/cassettes/Package/_last_build_reason/returns_a_PackageBuildReason_object.yml
+++ b/src/api/spec/cassettes/Package/_last_build_reason/returns_a_PackageBuildReason_object.yml
@@ -40,85 +40,7 @@ http_interactions:
           <person userid="tom" role="maintainer" />
         </project>
     http_version: 
-  recorded_at: Wed, 03 May 2017 20:07:57 GMT
-- request:
-    method: put
-    uri: http://localhost:3200/source/home:tom/test_package/_meta?user=_nobody_
-    body:
-      encoding: UTF-8
-      string: |
-        <package name="test_package" project="home:tom">
-          <title>It's a Battlefield</title>
-          <description>Est molestiae tempore et.</description>
-        </package>
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '151'
-    body:
-      encoding: UTF-8
-      string: |
-        <package name="test_package" project="home:tom">
-          <title>It's a Battlefield</title>
-          <description>Est molestiae tempore et.</description>
-        </package>
-    http_version: 
-  recorded_at: Wed, 03 May 2017 20:07:58 GMT
-- request:
-    method: put
-    uri: http://localhost:3200/source/home:tom/test_package/_meta
-    body:
-      encoding: UTF-8
-      string: |
-        <package name="test_package" project="home:tom">
-          <title>It's a Battlefield</title>
-          <description>Est molestiae tempore et.</description>
-        </package>
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '151'
-    body:
-      encoding: UTF-8
-      string: |
-        <package name="test_package" project="home:tom">
-          <title>It's a Battlefield</title>
-          <description>Est molestiae tempore et.</description>
-        </package>
-    http_version: 
-  recorded_at: Wed, 03 May 2017 20:07:58 GMT
+  recorded_at: Fri, 30 Jun 2017 12:16:03 GMT
 - request:
     method: put
     uri: http://localhost:3200/source/home:tom/test_package/_meta?user=tom
@@ -126,8 +48,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="test_package" project="home:tom">
-          <title>Eyeless in Gaza</title>
-          <description>Omnis nesciunt deserunt dolor quos adipisci animi.</description>
+          <title>The Doors of Perception</title>
+          <description>Aut natus accusantium fuga.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -148,14 +70,53 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '173'
+      - '158'
     body:
       encoding: UTF-8
       string: |
         <package name="test_package" project="home:tom">
-          <title>Eyeless in Gaza</title>
-          <description>Omnis nesciunt deserunt dolor quos adipisci animi.</description>
+          <title>The Doors of Perception</title>
+          <description>Aut natus accusantium fuga.</description>
         </package>
     http_version: 
-  recorded_at: Fri, 30 Jun 2017 12:16:12 GMT
+  recorded_at: Fri, 30 Jun 2017 12:16:03 GMT
+- request:
+    method: put
+    uri: http://localhost:3200/source/home:tom/test_package/_meta
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="test_package" project="home:tom">
+          <title>The Doors of Perception</title>
+          <description>Aut natus accusantium fuga.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '158'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="test_package" project="home:tom">
+          <title>The Doors of Perception</title>
+          <description>Aut natus accusantium fuga.</description>
+        </package>
+    http_version: 
+  recorded_at: Fri, 30 Jun 2017 12:16:03 GMT
 recorded_with: VCR 3.0.3

--- a/src/api/spec/cassettes/Package/_last_build_reason/validation_of_data/for_explain.yml
+++ b/src/api/spec/cassettes/Package/_last_build_reason/validation_of_data/for_explain.yml
@@ -40,85 +40,7 @@ http_interactions:
           <person userid="tom" role="maintainer" />
         </project>
     http_version: 
-  recorded_at: Wed, 03 May 2017 20:07:57 GMT
-- request:
-    method: put
-    uri: http://localhost:3200/source/home:tom/test_package/_meta?user=_nobody_
-    body:
-      encoding: UTF-8
-      string: |
-        <package name="test_package" project="home:tom">
-          <title>It's a Battlefield</title>
-          <description>Est molestiae tempore et.</description>
-        </package>
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '151'
-    body:
-      encoding: UTF-8
-      string: |
-        <package name="test_package" project="home:tom">
-          <title>It's a Battlefield</title>
-          <description>Est molestiae tempore et.</description>
-        </package>
-    http_version: 
-  recorded_at: Wed, 03 May 2017 20:07:58 GMT
-- request:
-    method: put
-    uri: http://localhost:3200/source/home:tom/test_package/_meta
-    body:
-      encoding: UTF-8
-      string: |
-        <package name="test_package" project="home:tom">
-          <title>It's a Battlefield</title>
-          <description>Est molestiae tempore et.</description>
-        </package>
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '151'
-    body:
-      encoding: UTF-8
-      string: |
-        <package name="test_package" project="home:tom">
-          <title>It's a Battlefield</title>
-          <description>Est molestiae tempore et.</description>
-        </package>
-    http_version: 
-  recorded_at: Wed, 03 May 2017 20:07:58 GMT
+  recorded_at: Fri, 30 Jun 2017 12:16:04 GMT
 - request:
     method: put
     uri: http://localhost:3200/source/home:tom/test_package/_meta?user=tom
@@ -126,8 +48,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="test_package" project="home:tom">
-          <title>Eyeless in Gaza</title>
-          <description>Omnis nesciunt deserunt dolor quos adipisci animi.</description>
+          <title>O Pioneers!</title>
+          <description>Perferendis dolorem aut porro nam occaecati.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -148,14 +70,53 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '173'
+      - '163'
     body:
       encoding: UTF-8
       string: |
         <package name="test_package" project="home:tom">
-          <title>Eyeless in Gaza</title>
-          <description>Omnis nesciunt deserunt dolor quos adipisci animi.</description>
+          <title>O Pioneers!</title>
+          <description>Perferendis dolorem aut porro nam occaecati.</description>
         </package>
     http_version: 
-  recorded_at: Fri, 30 Jun 2017 12:16:12 GMT
+  recorded_at: Fri, 30 Jun 2017 12:16:04 GMT
+- request:
+    method: put
+    uri: http://localhost:3200/source/home:tom/test_package/_meta
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="test_package" project="home:tom">
+          <title>O Pioneers!</title>
+          <description>Perferendis dolorem aut porro nam occaecati.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '163'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="test_package" project="home:tom">
+          <title>O Pioneers!</title>
+          <description>Perferendis dolorem aut porro nam occaecati.</description>
+        </package>
+    http_version: 
+  recorded_at: Fri, 30 Jun 2017 12:16:04 GMT
 recorded_with: VCR 3.0.3

--- a/src/api/spec/cassettes/Package/_last_build_reason/validation_of_data/for_oldsource.yml
+++ b/src/api/spec/cassettes/Package/_last_build_reason/validation_of_data/for_oldsource.yml
@@ -40,85 +40,7 @@ http_interactions:
           <person userid="tom" role="maintainer" />
         </project>
     http_version: 
-  recorded_at: Wed, 03 May 2017 20:07:57 GMT
-- request:
-    method: put
-    uri: http://localhost:3200/source/home:tom/test_package/_meta?user=_nobody_
-    body:
-      encoding: UTF-8
-      string: |
-        <package name="test_package" project="home:tom">
-          <title>It's a Battlefield</title>
-          <description>Est molestiae tempore et.</description>
-        </package>
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '151'
-    body:
-      encoding: UTF-8
-      string: |
-        <package name="test_package" project="home:tom">
-          <title>It's a Battlefield</title>
-          <description>Est molestiae tempore et.</description>
-        </package>
-    http_version: 
-  recorded_at: Wed, 03 May 2017 20:07:58 GMT
-- request:
-    method: put
-    uri: http://localhost:3200/source/home:tom/test_package/_meta
-    body:
-      encoding: UTF-8
-      string: |
-        <package name="test_package" project="home:tom">
-          <title>It's a Battlefield</title>
-          <description>Est molestiae tempore et.</description>
-        </package>
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '151'
-    body:
-      encoding: UTF-8
-      string: |
-        <package name="test_package" project="home:tom">
-          <title>It's a Battlefield</title>
-          <description>Est molestiae tempore et.</description>
-        </package>
-    http_version: 
-  recorded_at: Wed, 03 May 2017 20:07:58 GMT
+  recorded_at: Fri, 30 Jun 2017 12:16:03 GMT
 - request:
     method: put
     uri: http://localhost:3200/source/home:tom/test_package/_meta?user=tom
@@ -126,8 +48,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="test_package" project="home:tom">
-          <title>Eyeless in Gaza</title>
-          <description>Omnis nesciunt deserunt dolor quos adipisci animi.</description>
+          <title>All the King's Men</title>
+          <description>Quia aut officia commodi unde facere eos vel qui.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -148,14 +70,53 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '173'
+      - '175'
     body:
       encoding: UTF-8
       string: |
         <package name="test_package" project="home:tom">
-          <title>Eyeless in Gaza</title>
-          <description>Omnis nesciunt deserunt dolor quos adipisci animi.</description>
+          <title>All the King's Men</title>
+          <description>Quia aut officia commodi unde facere eos vel qui.</description>
         </package>
     http_version: 
-  recorded_at: Fri, 30 Jun 2017 12:16:12 GMT
+  recorded_at: Fri, 30 Jun 2017 12:16:03 GMT
+- request:
+    method: put
+    uri: http://localhost:3200/source/home:tom/test_package/_meta
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="test_package" project="home:tom">
+          <title>All the King's Men</title>
+          <description>Quia aut officia commodi unde facere eos vel qui.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '175'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="test_package" project="home:tom">
+          <title>All the King's Men</title>
+          <description>Quia aut officia commodi unde facere eos vel qui.</description>
+        </package>
+    http_version: 
+  recorded_at: Fri, 30 Jun 2017 12:16:04 GMT
 recorded_with: VCR 3.0.3

--- a/src/api/spec/cassettes/Package/_last_build_reason/validation_of_data/for_packagechange_multiple_elements_.yml
+++ b/src/api/spec/cassettes/Package/_last_build_reason/validation_of_data/for_packagechange_multiple_elements_.yml
@@ -40,85 +40,7 @@ http_interactions:
           <person userid="tom" role="maintainer" />
         </project>
     http_version: 
-  recorded_at: Wed, 03 May 2017 20:07:57 GMT
-- request:
-    method: put
-    uri: http://localhost:3200/source/home:tom/test_package/_meta?user=_nobody_
-    body:
-      encoding: UTF-8
-      string: |
-        <package name="test_package" project="home:tom">
-          <title>It's a Battlefield</title>
-          <description>Est molestiae tempore et.</description>
-        </package>
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '151'
-    body:
-      encoding: UTF-8
-      string: |
-        <package name="test_package" project="home:tom">
-          <title>It's a Battlefield</title>
-          <description>Est molestiae tempore et.</description>
-        </package>
-    http_version: 
-  recorded_at: Wed, 03 May 2017 20:07:58 GMT
-- request:
-    method: put
-    uri: http://localhost:3200/source/home:tom/test_package/_meta
-    body:
-      encoding: UTF-8
-      string: |
-        <package name="test_package" project="home:tom">
-          <title>It's a Battlefield</title>
-          <description>Est molestiae tempore et.</description>
-        </package>
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '151'
-    body:
-      encoding: UTF-8
-      string: |
-        <package name="test_package" project="home:tom">
-          <title>It's a Battlefield</title>
-          <description>Est molestiae tempore et.</description>
-        </package>
-    http_version: 
-  recorded_at: Wed, 03 May 2017 20:07:58 GMT
+  recorded_at: Fri, 30 Jun 2017 12:16:04 GMT
 - request:
     method: put
     uri: http://localhost:3200/source/home:tom/test_package/_meta?user=tom
@@ -126,8 +48,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="test_package" project="home:tom">
-          <title>Eyeless in Gaza</title>
-          <description>Omnis nesciunt deserunt dolor quos adipisci animi.</description>
+          <title>Consider Phlebas</title>
+          <description>Dolorum nihil molestias necessitatibus dolores adipisci vel assumenda repudiandae.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -148,14 +70,53 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '173'
+      - '206'
     body:
       encoding: UTF-8
       string: |
         <package name="test_package" project="home:tom">
-          <title>Eyeless in Gaza</title>
-          <description>Omnis nesciunt deserunt dolor quos adipisci animi.</description>
+          <title>Consider Phlebas</title>
+          <description>Dolorum nihil molestias necessitatibus dolores adipisci vel assumenda repudiandae.</description>
         </package>
     http_version: 
-  recorded_at: Fri, 30 Jun 2017 12:16:12 GMT
+  recorded_at: Fri, 30 Jun 2017 12:16:04 GMT
+- request:
+    method: put
+    uri: http://localhost:3200/source/home:tom/test_package/_meta
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="test_package" project="home:tom">
+          <title>Consider Phlebas</title>
+          <description>Dolorum nihil molestias necessitatibus dolores adipisci vel assumenda repudiandae.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '206'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="test_package" project="home:tom">
+          <title>Consider Phlebas</title>
+          <description>Dolorum nihil molestias necessitatibus dolores adipisci vel assumenda repudiandae.</description>
+        </package>
+    http_version: 
+  recorded_at: Fri, 30 Jun 2017 12:16:04 GMT
 recorded_with: VCR 3.0.3

--- a/src/api/spec/cassettes/Package/_last_build_reason/validation_of_data/for_packagechange_one_element_.yml
+++ b/src/api/spec/cassettes/Package/_last_build_reason/validation_of_data/for_packagechange_one_element_.yml
@@ -40,85 +40,7 @@ http_interactions:
           <person userid="tom" role="maintainer" />
         </project>
     http_version: 
-  recorded_at: Wed, 03 May 2017 20:07:57 GMT
-- request:
-    method: put
-    uri: http://localhost:3200/source/home:tom/test_package/_meta?user=_nobody_
-    body:
-      encoding: UTF-8
-      string: |
-        <package name="test_package" project="home:tom">
-          <title>It's a Battlefield</title>
-          <description>Est molestiae tempore et.</description>
-        </package>
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '151'
-    body:
-      encoding: UTF-8
-      string: |
-        <package name="test_package" project="home:tom">
-          <title>It's a Battlefield</title>
-          <description>Est molestiae tempore et.</description>
-        </package>
-    http_version: 
-  recorded_at: Wed, 03 May 2017 20:07:58 GMT
-- request:
-    method: put
-    uri: http://localhost:3200/source/home:tom/test_package/_meta
-    body:
-      encoding: UTF-8
-      string: |
-        <package name="test_package" project="home:tom">
-          <title>It's a Battlefield</title>
-          <description>Est molestiae tempore et.</description>
-        </package>
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '151'
-    body:
-      encoding: UTF-8
-      string: |
-        <package name="test_package" project="home:tom">
-          <title>It's a Battlefield</title>
-          <description>Est molestiae tempore et.</description>
-        </package>
-    http_version: 
-  recorded_at: Wed, 03 May 2017 20:07:58 GMT
+  recorded_at: Fri, 30 Jun 2017 12:16:04 GMT
 - request:
     method: put
     uri: http://localhost:3200/source/home:tom/test_package/_meta?user=tom
@@ -126,8 +48,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="test_package" project="home:tom">
-          <title>Eyeless in Gaza</title>
-          <description>Omnis nesciunt deserunt dolor quos adipisci animi.</description>
+          <title>The Torment of Others</title>
+          <description>Tempora voluptatum et atque et.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -148,14 +70,53 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '173'
+      - '160'
     body:
       encoding: UTF-8
       string: |
         <package name="test_package" project="home:tom">
-          <title>Eyeless in Gaza</title>
-          <description>Omnis nesciunt deserunt dolor quos adipisci animi.</description>
+          <title>The Torment of Others</title>
+          <description>Tempora voluptatum et atque et.</description>
         </package>
     http_version: 
-  recorded_at: Fri, 30 Jun 2017 12:16:12 GMT
+  recorded_at: Fri, 30 Jun 2017 12:16:04 GMT
+- request:
+    method: put
+    uri: http://localhost:3200/source/home:tom/test_package/_meta
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="test_package" project="home:tom">
+          <title>The Torment of Others</title>
+          <description>Tempora voluptatum et atque et.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '160'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="test_package" project="home:tom">
+          <title>The Torment of Others</title>
+          <description>Tempora voluptatum et atque et.</description>
+        </package>
+    http_version: 
+  recorded_at: Fri, 30 Jun 2017 12:16:04 GMT
 recorded_with: VCR 3.0.3

--- a/src/api/spec/cassettes/Package/_last_build_reason/validation_of_data/for_time.yml
+++ b/src/api/spec/cassettes/Package/_last_build_reason/validation_of_data/for_time.yml
@@ -40,85 +40,7 @@ http_interactions:
           <person userid="tom" role="maintainer" />
         </project>
     http_version: 
-  recorded_at: Wed, 03 May 2017 20:07:57 GMT
-- request:
-    method: put
-    uri: http://localhost:3200/source/home:tom/test_package/_meta?user=_nobody_
-    body:
-      encoding: UTF-8
-      string: |
-        <package name="test_package" project="home:tom">
-          <title>It's a Battlefield</title>
-          <description>Est molestiae tempore et.</description>
-        </package>
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '151'
-    body:
-      encoding: UTF-8
-      string: |
-        <package name="test_package" project="home:tom">
-          <title>It's a Battlefield</title>
-          <description>Est molestiae tempore et.</description>
-        </package>
-    http_version: 
-  recorded_at: Wed, 03 May 2017 20:07:58 GMT
-- request:
-    method: put
-    uri: http://localhost:3200/source/home:tom/test_package/_meta
-    body:
-      encoding: UTF-8
-      string: |
-        <package name="test_package" project="home:tom">
-          <title>It's a Battlefield</title>
-          <description>Est molestiae tempore et.</description>
-        </package>
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '151'
-    body:
-      encoding: UTF-8
-      string: |
-        <package name="test_package" project="home:tom">
-          <title>It's a Battlefield</title>
-          <description>Est molestiae tempore et.</description>
-        </package>
-    http_version: 
-  recorded_at: Wed, 03 May 2017 20:07:58 GMT
+  recorded_at: Fri, 30 Jun 2017 12:16:04 GMT
 - request:
     method: put
     uri: http://localhost:3200/source/home:tom/test_package/_meta?user=tom
@@ -126,8 +48,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="test_package" project="home:tom">
-          <title>Eyeless in Gaza</title>
-          <description>Omnis nesciunt deserunt dolor quos adipisci animi.</description>
+          <title>I Know Why the Caged Bird Sings</title>
+          <description>Atque voluptatem facere est laborum.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -148,14 +70,53 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '173'
+      - '175'
     body:
       encoding: UTF-8
       string: |
         <package name="test_package" project="home:tom">
-          <title>Eyeless in Gaza</title>
-          <description>Omnis nesciunt deserunt dolor quos adipisci animi.</description>
+          <title>I Know Why the Caged Bird Sings</title>
+          <description>Atque voluptatem facere est laborum.</description>
         </package>
     http_version: 
-  recorded_at: Fri, 30 Jun 2017 12:16:12 GMT
+  recorded_at: Fri, 30 Jun 2017 12:16:05 GMT
+- request:
+    method: put
+    uri: http://localhost:3200/source/home:tom/test_package/_meta
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="test_package" project="home:tom">
+          <title>I Know Why the Caged Bird Sings</title>
+          <description>Atque voluptatem facere est laborum.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '175'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="test_package" project="home:tom">
+          <title>I Know Why the Caged Bird Sings</title>
+          <description>Atque voluptatem facere est laborum.</description>
+        </package>
+    http_version: 
+  recorded_at: Fri, 30 Jun 2017 12:16:05 GMT
 recorded_with: VCR 3.0.3

--- a/src/api/spec/cassettes/Package/_maintainers/makes_sure_that_no_user_is_listed_more_than_one_time.yml
+++ b/src/api/spec/cassettes/Package/_maintainers/makes_sure_that_no_user_is_listed_more_than_one_time.yml
@@ -40,85 +40,7 @@ http_interactions:
           <person userid="tom" role="maintainer" />
         </project>
     http_version: 
-  recorded_at: Wed, 03 May 2017 20:07:57 GMT
-- request:
-    method: put
-    uri: http://localhost:3200/source/home:tom/test_package/_meta?user=_nobody_
-    body:
-      encoding: UTF-8
-      string: |
-        <package name="test_package" project="home:tom">
-          <title>It's a Battlefield</title>
-          <description>Est molestiae tempore et.</description>
-        </package>
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '151'
-    body:
-      encoding: UTF-8
-      string: |
-        <package name="test_package" project="home:tom">
-          <title>It's a Battlefield</title>
-          <description>Est molestiae tempore et.</description>
-        </package>
-    http_version: 
-  recorded_at: Wed, 03 May 2017 20:07:58 GMT
-- request:
-    method: put
-    uri: http://localhost:3200/source/home:tom/test_package/_meta
-    body:
-      encoding: UTF-8
-      string: |
-        <package name="test_package" project="home:tom">
-          <title>It's a Battlefield</title>
-          <description>Est molestiae tempore et.</description>
-        </package>
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '151'
-    body:
-      encoding: UTF-8
-      string: |
-        <package name="test_package" project="home:tom">
-          <title>It's a Battlefield</title>
-          <description>Est molestiae tempore et.</description>
-        </package>
-    http_version: 
-  recorded_at: Wed, 03 May 2017 20:07:58 GMT
+  recorded_at: Fri, 30 Jun 2017 12:16:09 GMT
 - request:
     method: put
     uri: http://localhost:3200/source/home:tom/test_package/_meta?user=tom
@@ -126,8 +48,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="test_package" project="home:tom">
-          <title>Eyeless in Gaza</title>
-          <description>Omnis nesciunt deserunt dolor quos adipisci animi.</description>
+          <title>Terrible Swift Sword</title>
+          <description>Maxime aspernatur tempora unde velit ea.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -148,14 +70,53 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '173'
+      - '168'
     body:
       encoding: UTF-8
       string: |
         <package name="test_package" project="home:tom">
-          <title>Eyeless in Gaza</title>
-          <description>Omnis nesciunt deserunt dolor quos adipisci animi.</description>
+          <title>Terrible Swift Sword</title>
+          <description>Maxime aspernatur tempora unde velit ea.</description>
         </package>
     http_version: 
-  recorded_at: Fri, 30 Jun 2017 12:16:12 GMT
+  recorded_at: Fri, 30 Jun 2017 12:16:09 GMT
+- request:
+    method: put
+    uri: http://localhost:3200/source/home:tom/test_package/_meta
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="test_package" project="home:tom">
+          <title>Terrible Swift Sword</title>
+          <description>Maxime aspernatur tempora unde velit ea.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '168'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="test_package" project="home:tom">
+          <title>Terrible Swift Sword</title>
+          <description>Maxime aspernatur tempora unde velit ea.</description>
+        </package>
+    http_version: 
+  recorded_at: Fri, 30 Jun 2017 12:16:09 GMT
 recorded_with: VCR 3.0.3

--- a/src/api/spec/cassettes/Package/_maintainers/resolves_groups_properly.yml
+++ b/src/api/spec/cassettes/Package/_maintainers/resolves_groups_properly.yml
@@ -40,17 +40,18 @@ http_interactions:
           <person userid="tom" role="maintainer" />
         </project>
     http_version: 
-  recorded_at: Wed, 03 May 2017 14:37:41 GMT
+  recorded_at: Fri, 30 Jun 2017 12:16:09 GMT
 - request:
     method: put
-    uri: http://localhost:3200/source/home:tom/test_package/_meta?user=_nobody_
+    uri: http://localhost:3200/source/home:other_user/_meta?user=other_user
     body:
       encoding: UTF-8
       string: |
-        <package name="test_package" project="home:tom">
-          <title>Cover Her Face</title>
-          <description>Earum dicta consectetur omnis itaque beatae provident.</description>
-        </package>
+        <project name="home:other_user">
+          <title/>
+          <description/>
+          <person userid="other_user" role="maintainer"/>
+        </project>
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -70,26 +71,28 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '176'
+      - '143'
     body:
       encoding: UTF-8
       string: |
-        <package name="test_package" project="home:tom">
-          <title>Cover Her Face</title>
-          <description>Earum dicta consectetur omnis itaque beatae provident.</description>
-        </package>
+        <project name="home:other_user">
+          <title></title>
+          <description></description>
+          <person userid="other_user" role="maintainer" />
+        </project>
     http_version: 
-  recorded_at: Wed, 03 May 2017 14:37:41 GMT
+  recorded_at: Fri, 30 Jun 2017 12:16:09 GMT
 - request:
     method: put
-    uri: http://localhost:3200/source/home:tom/test_package/_meta
+    uri: http://localhost:3200/source/home:other_user2/_meta?user=other_user2
     body:
       encoding: UTF-8
       string: |
-        <package name="test_package" project="home:tom">
-          <title>Cover Her Face</title>
-          <description>Earum dicta consectetur omnis itaque beatae provident.</description>
-        </package>
+        <project name="home:other_user2">
+          <title/>
+          <description/>
+          <person userid="other_user2" role="maintainer"/>
+        </project>
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -109,35 +112,39 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '176'
+      - '145'
     body:
       encoding: UTF-8
       string: |
-        <package name="test_package" project="home:tom">
-          <title>Cover Her Face</title>
-          <description>Earum dicta consectetur omnis itaque beatae provident.</description>
-        </package>
+        <project name="home:other_user2">
+          <title></title>
+          <description></description>
+          <person userid="other_user2" role="maintainer" />
+        </project>
     http_version: 
-  recorded_at: Wed, 03 May 2017 14:37:41 GMT
+  recorded_at: Fri, 30 Jun 2017 12:16:09 GMT
 - request:
-    method: get
-    uri: http://localhost:3200/build/home:tom/openSUSE_Tumbleweed/x86_64/_jobhistory?limit=100&package=test_package
+    method: put
+    uri: http://localhost:3200/source/home:other_user3/_meta?user=other_user3
     body:
-      encoding: US-ASCII
-      string: ''
+      encoding: UTF-8
+      string: |
+        <project name="home:other_user3">
+          <title/>
+          <description/>
+          <person userid="other_user3" role="maintainer"/>
+        </project>
     headers:
-      Content-Type:
-      - text/plain
       Accept-Encoding:
-      - identity
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
       - "*/*"
       User-Agent:
       - Ruby
   response:
     status:
-      code: 404
-      message: project 'home tom' has no repository 'openSUSE_Tumbleweed'
+      code: 200
+      message: OK
     headers:
       Content-Type:
       - text/xml
@@ -146,16 +153,17 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '194'
+      - '145'
     body:
       encoding: UTF-8
       string: |
-        <status code="404">
-          <summary>project 'home:tom' has no repository 'openSUSE_Tumbleweed'</summary>
-          <details>404 project 'home:tom' has no repository 'openSUSE_Tumbleweed'</details>
-        </status>
+        <project name="home:other_user3">
+          <title></title>
+          <description></description>
+          <person userid="other_user3" role="maintainer" />
+        </project>
     http_version: 
-  recorded_at: Wed, 03 May 2017 14:37:41 GMT
+  recorded_at: Fri, 30 Jun 2017 12:16:10 GMT
 - request:
     method: put
     uri: http://localhost:3200/source/home:tom/test_package/_meta?user=tom
@@ -163,8 +171,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="test_package" project="home:tom">
-          <title>In Dubious Battle</title>
-          <description>Tenetur quos ipsam rerum veritatis excepturi.</description>
+          <title>Many Waters</title>
+          <description>Error magnam recusandae quam modi quidem tempora.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -185,14 +193,53 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '170'
+      - '168'
     body:
       encoding: UTF-8
       string: |
         <package name="test_package" project="home:tom">
-          <title>In Dubious Battle</title>
-          <description>Tenetur quos ipsam rerum veritatis excepturi.</description>
+          <title>Many Waters</title>
+          <description>Error magnam recusandae quam modi quidem tempora.</description>
         </package>
     http_version: 
-  recorded_at: Fri, 30 Jun 2017 12:16:11 GMT
+  recorded_at: Fri, 30 Jun 2017 12:16:10 GMT
+- request:
+    method: put
+    uri: http://localhost:3200/source/home:tom/test_package/_meta
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="test_package" project="home:tom">
+          <title>Many Waters</title>
+          <description>Error magnam recusandae quam modi quidem tempora.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '168'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="test_package" project="home:tom">
+          <title>Many Waters</title>
+          <description>Error magnam recusandae quam modi quidem tempora.</description>
+        </package>
+    http_version: 
+  recorded_at: Fri, 30 Jun 2017 12:16:10 GMT
 recorded_with: VCR 3.0.3

--- a/src/api/spec/cassettes/Package/_maintainers/returns_an_array_with_user_objects_to_all_maintainers_for_a_package.yml
+++ b/src/api/spec/cassettes/Package/_maintainers/returns_an_array_with_user_objects_to_all_maintainers_for_a_package.yml
@@ -40,17 +40,18 @@ http_interactions:
           <person userid="tom" role="maintainer" />
         </project>
     http_version: 
-  recorded_at: Wed, 03 May 2017 14:37:41 GMT
+  recorded_at: Fri, 30 Jun 2017 12:16:10 GMT
 - request:
     method: put
-    uri: http://localhost:3200/source/home:tom/test_package/_meta?user=_nobody_
+    uri: http://localhost:3200/source/home:other_user2/_meta?user=other_user2
     body:
       encoding: UTF-8
       string: |
-        <package name="test_package" project="home:tom">
-          <title>Cover Her Face</title>
-          <description>Earum dicta consectetur omnis itaque beatae provident.</description>
-        </package>
+        <project name="home:other_user2">
+          <title/>
+          <description/>
+          <person userid="other_user2" role="maintainer"/>
+        </project>
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -70,92 +71,17 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '176'
+      - '145'
     body:
       encoding: UTF-8
       string: |
-        <package name="test_package" project="home:tom">
-          <title>Cover Her Face</title>
-          <description>Earum dicta consectetur omnis itaque beatae provident.</description>
-        </package>
+        <project name="home:other_user2">
+          <title></title>
+          <description></description>
+          <person userid="other_user2" role="maintainer" />
+        </project>
     http_version: 
-  recorded_at: Wed, 03 May 2017 14:37:41 GMT
-- request:
-    method: put
-    uri: http://localhost:3200/source/home:tom/test_package/_meta
-    body:
-      encoding: UTF-8
-      string: |
-        <package name="test_package" project="home:tom">
-          <title>Cover Her Face</title>
-          <description>Earum dicta consectetur omnis itaque beatae provident.</description>
-        </package>
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '176'
-    body:
-      encoding: UTF-8
-      string: |
-        <package name="test_package" project="home:tom">
-          <title>Cover Her Face</title>
-          <description>Earum dicta consectetur omnis itaque beatae provident.</description>
-        </package>
-    http_version: 
-  recorded_at: Wed, 03 May 2017 14:37:41 GMT
-- request:
-    method: get
-    uri: http://localhost:3200/build/home:tom/openSUSE_Tumbleweed/x86_64/_jobhistory?limit=100&package=test_package
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Content-Type:
-      - text/plain
-      Accept-Encoding:
-      - identity
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 404
-      message: project 'home tom' has no repository 'openSUSE_Tumbleweed'
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '194'
-    body:
-      encoding: UTF-8
-      string: |
-        <status code="404">
-          <summary>project 'home:tom' has no repository 'openSUSE_Tumbleweed'</summary>
-          <details>404 project 'home:tom' has no repository 'openSUSE_Tumbleweed'</details>
-        </status>
-    http_version: 
-  recorded_at: Wed, 03 May 2017 14:37:41 GMT
+  recorded_at: Fri, 30 Jun 2017 12:16:11 GMT
 - request:
     method: put
     uri: http://localhost:3200/source/home:tom/test_package/_meta?user=tom
@@ -163,8 +89,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="test_package" project="home:tom">
-          <title>In Dubious Battle</title>
-          <description>Tenetur quos ipsam rerum veritatis excepturi.</description>
+          <title>Great Work of Time</title>
+          <description>Doloremque illo aut sint et ipsum maiores nam.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -185,14 +111,94 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '170'
+      - '172'
     body:
       encoding: UTF-8
       string: |
         <package name="test_package" project="home:tom">
-          <title>In Dubious Battle</title>
-          <description>Tenetur quos ipsam rerum veritatis excepturi.</description>
+          <title>Great Work of Time</title>
+          <description>Doloremque illo aut sint et ipsum maiores nam.</description>
         </package>
+    http_version: 
+  recorded_at: Fri, 30 Jun 2017 12:16:11 GMT
+- request:
+    method: put
+    uri: http://localhost:3200/source/home:tom/test_package/_meta
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="test_package" project="home:tom">
+          <title>Great Work of Time</title>
+          <description>Doloremque illo aut sint et ipsum maiores nam.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '172'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="test_package" project="home:tom">
+          <title>Great Work of Time</title>
+          <description>Doloremque illo aut sint et ipsum maiores nam.</description>
+        </package>
+    http_version: 
+  recorded_at: Fri, 30 Jun 2017 12:16:11 GMT
+- request:
+    method: put
+    uri: http://localhost:3200/source/home:other_user/_meta?user=other_user
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:other_user">
+          <title/>
+          <description/>
+          <person userid="other_user" role="maintainer"/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '143'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:other_user">
+          <title></title>
+          <description></description>
+          <person userid="other_user" role="maintainer" />
+        </project>
     http_version: 
   recorded_at: Fri, 30 Jun 2017 12:16:11 GMT
 recorded_with: VCR 3.0.3

--- a/src/api/spec/cassettes/Package/_maintainers/returns_users_and_the_users_of_resolved_groups.yml
+++ b/src/api/spec/cassettes/Package/_maintainers/returns_users_and_the_users_of_resolved_groups.yml
@@ -40,17 +40,18 @@ http_interactions:
           <person userid="tom" role="maintainer" />
         </project>
     http_version: 
-  recorded_at: Wed, 03 May 2017 14:37:41 GMT
+  recorded_at: Fri, 30 Jun 2017 12:16:10 GMT
 - request:
     method: put
-    uri: http://localhost:3200/source/home:tom/test_package/_meta?user=_nobody_
+    uri: http://localhost:3200/source/home:other_user/_meta?user=other_user
     body:
       encoding: UTF-8
       string: |
-        <package name="test_package" project="home:tom">
-          <title>Cover Her Face</title>
-          <description>Earum dicta consectetur omnis itaque beatae provident.</description>
-        </package>
+        <project name="home:other_user">
+          <title/>
+          <description/>
+          <person userid="other_user" role="maintainer"/>
+        </project>
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -70,92 +71,17 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '176'
+      - '143'
     body:
       encoding: UTF-8
       string: |
-        <package name="test_package" project="home:tom">
-          <title>Cover Her Face</title>
-          <description>Earum dicta consectetur omnis itaque beatae provident.</description>
-        </package>
+        <project name="home:other_user">
+          <title></title>
+          <description></description>
+          <person userid="other_user" role="maintainer" />
+        </project>
     http_version: 
-  recorded_at: Wed, 03 May 2017 14:37:41 GMT
-- request:
-    method: put
-    uri: http://localhost:3200/source/home:tom/test_package/_meta
-    body:
-      encoding: UTF-8
-      string: |
-        <package name="test_package" project="home:tom">
-          <title>Cover Her Face</title>
-          <description>Earum dicta consectetur omnis itaque beatae provident.</description>
-        </package>
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '176'
-    body:
-      encoding: UTF-8
-      string: |
-        <package name="test_package" project="home:tom">
-          <title>Cover Her Face</title>
-          <description>Earum dicta consectetur omnis itaque beatae provident.</description>
-        </package>
-    http_version: 
-  recorded_at: Wed, 03 May 2017 14:37:41 GMT
-- request:
-    method: get
-    uri: http://localhost:3200/build/home:tom/openSUSE_Tumbleweed/x86_64/_jobhistory?limit=100&package=test_package
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Content-Type:
-      - text/plain
-      Accept-Encoding:
-      - identity
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 404
-      message: project 'home tom' has no repository 'openSUSE_Tumbleweed'
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '194'
-    body:
-      encoding: UTF-8
-      string: |
-        <status code="404">
-          <summary>project 'home:tom' has no repository 'openSUSE_Tumbleweed'</summary>
-          <details>404 project 'home:tom' has no repository 'openSUSE_Tumbleweed'</details>
-        </status>
-    http_version: 
-  recorded_at: Wed, 03 May 2017 14:37:41 GMT
+  recorded_at: Fri, 30 Jun 2017 12:16:10 GMT
 - request:
     method: put
     uri: http://localhost:3200/source/home:tom/test_package/_meta?user=tom
@@ -163,8 +89,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="test_package" project="home:tom">
-          <title>In Dubious Battle</title>
-          <description>Tenetur quos ipsam rerum veritatis excepturi.</description>
+          <title>Noli Me Tangere</title>
+          <description>Sint eum ad sed hic.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -185,14 +111,94 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '170'
+      - '143'
     body:
       encoding: UTF-8
       string: |
         <package name="test_package" project="home:tom">
-          <title>In Dubious Battle</title>
-          <description>Tenetur quos ipsam rerum veritatis excepturi.</description>
+          <title>Noli Me Tangere</title>
+          <description>Sint eum ad sed hic.</description>
         </package>
     http_version: 
-  recorded_at: Fri, 30 Jun 2017 12:16:11 GMT
+  recorded_at: Fri, 30 Jun 2017 12:16:10 GMT
+- request:
+    method: put
+    uri: http://localhost:3200/source/home:tom/test_package/_meta
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="test_package" project="home:tom">
+          <title>Noli Me Tangere</title>
+          <description>Sint eum ad sed hic.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '143'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="test_package" project="home:tom">
+          <title>Noli Me Tangere</title>
+          <description>Sint eum ad sed hic.</description>
+        </package>
+    http_version: 
+  recorded_at: Fri, 30 Jun 2017 12:16:10 GMT
+- request:
+    method: put
+    uri: http://localhost:3200/source/home:other_user2/_meta?user=other_user2
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:other_user2">
+          <title/>
+          <description/>
+          <person userid="other_user2" role="maintainer"/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '145'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:other_user2">
+          <title></title>
+          <description></description>
+          <person userid="other_user2" role="maintainer" />
+        </project>
+    http_version: 
+  recorded_at: Fri, 30 Jun 2017 12:16:10 GMT
 recorded_with: VCR 3.0.3

--- a/src/api/spec/cassettes/Package/_public_source_path/1_11_1.yml
+++ b/src/api/spec/cassettes/Package/_public_source_path/1_11_1.yml
@@ -40,16 +40,16 @@ http_interactions:
           <person userid="tom" role="maintainer" />
         </project>
     http_version: 
-  recorded_at: Wed, 03 May 2017 14:37:41 GMT
+  recorded_at: Fri, 30 Jun 2017 12:16:08 GMT
 - request:
     method: put
-    uri: http://localhost:3200/source/home:tom/test_package/_meta?user=_nobody_
+    uri: http://localhost:3200/source/home:tom/package_with_files/_meta?user=tom
     body:
       encoding: UTF-8
       string: |
-        <package name="test_package" project="home:tom">
-          <title>Cover Her Face</title>
-          <description>Earum dicta consectetur omnis itaque beatae provident.</description>
+        <package name="package_with_files" project="home:tom">
+          <title>Unweaving the Rainbow</title>
+          <description>Officiis exercitationem temporibus quas fuga iusto pariatur ut.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -70,25 +70,25 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '176'
+      - '198'
     body:
       encoding: UTF-8
       string: |
-        <package name="test_package" project="home:tom">
-          <title>Cover Her Face</title>
-          <description>Earum dicta consectetur omnis itaque beatae provident.</description>
+        <package name="package_with_files" project="home:tom">
+          <title>Unweaving the Rainbow</title>
+          <description>Officiis exercitationem temporibus quas fuga iusto pariatur ut.</description>
         </package>
     http_version: 
-  recorded_at: Wed, 03 May 2017 14:37:41 GMT
+  recorded_at: Fri, 30 Jun 2017 12:16:08 GMT
 - request:
     method: put
-    uri: http://localhost:3200/source/home:tom/test_package/_meta
+    uri: http://localhost:3200/source/home:tom/package_with_files/_meta
     body:
       encoding: UTF-8
       string: |
-        <package name="test_package" project="home:tom">
-          <title>Cover Her Face</title>
-          <description>Earum dicta consectetur omnis itaque beatae provident.</description>
+        <package name="package_with_files" project="home:tom">
+          <title>Unweaving the Rainbow</title>
+          <description>Officiis exercitationem temporibus quas fuga iusto pariatur ut.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -109,63 +109,23 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '176'
+      - '198'
     body:
       encoding: UTF-8
       string: |
-        <package name="test_package" project="home:tom">
-          <title>Cover Her Face</title>
-          <description>Earum dicta consectetur omnis itaque beatae provident.</description>
+        <package name="package_with_files" project="home:tom">
+          <title>Unweaving the Rainbow</title>
+          <description>Officiis exercitationem temporibus quas fuga iusto pariatur ut.</description>
         </package>
     http_version: 
-  recorded_at: Wed, 03 May 2017 14:37:41 GMT
-- request:
-    method: get
-    uri: http://localhost:3200/build/home:tom/openSUSE_Tumbleweed/x86_64/_jobhistory?limit=100&package=test_package
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Content-Type:
-      - text/plain
-      Accept-Encoding:
-      - identity
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 404
-      message: project 'home tom' has no repository 'openSUSE_Tumbleweed'
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '194'
-    body:
-      encoding: UTF-8
-      string: |
-        <status code="404">
-          <summary>project 'home:tom' has no repository 'openSUSE_Tumbleweed'</summary>
-          <details>404 project 'home:tom' has no repository 'openSUSE_Tumbleweed'</details>
-        </status>
-    http_version: 
-  recorded_at: Wed, 03 May 2017 14:37:41 GMT
+  recorded_at: Fri, 30 Jun 2017 12:16:08 GMT
 - request:
     method: put
-    uri: http://localhost:3200/source/home:tom/test_package/_meta?user=tom
+    uri: http://localhost:3200/source/home:tom/package_with_files/_config
     body:
       encoding: UTF-8
-      string: |
-        <package name="test_package" project="home:tom">
-          <title>In Dubious Battle</title>
-          <description>Tenetur quos ipsam rerum veritatis excepturi.</description>
-        </package>
+      string: Perspiciatis molestiae magnam. Quis quam qui vel numquam. Sed minus
+        totam rerum dolorem saepe. Sit eveniet corrupti voluptates eum.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -185,14 +145,59 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '170'
+      - '207'
     body:
       encoding: UTF-8
       string: |
-        <package name="test_package" project="home:tom">
-          <title>In Dubious Battle</title>
-          <description>Tenetur quos ipsam rerum veritatis excepturi.</description>
-        </package>
+        <revision rev="9" vrev="9">
+          <srcmd5>b39478852c9ceca268a8c9988794e187</srcmd5>
+          <version>unknown</version>
+          <time>1498824968</time>
+          <user>unknown</user>
+          <comment></comment>
+          <requestid/>
+        </revision>
     http_version: 
-  recorded_at: Fri, 30 Jun 2017 12:16:11 GMT
+  recorded_at: Fri, 30 Jun 2017 12:16:08 GMT
+- request:
+    method: put
+    uri: http://localhost:3200/source/home:tom/package_with_files/somefile.txt
+    body:
+      encoding: UTF-8
+      string: Facilis aspernatur non autem voluptatibus distinctio. Repudiandae qui
+        sunt doloremque occaecati ut molestiae reprehenderit. Illum qui dignissimos
+        beatae. Non quia eius et.
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '209'
+    body:
+      encoding: UTF-8
+      string: |
+        <revision rev="10" vrev="10">
+          <srcmd5>daee6105864afd9c7d9297b793dc620a</srcmd5>
+          <version>unknown</version>
+          <time>1498824968</time>
+          <user>unknown</user>
+          <comment></comment>
+          <requestid/>
+        </revision>
+    http_version: 
+  recorded_at: Fri, 30 Jun 2017 12:16:08 GMT
 recorded_with: VCR 3.0.3

--- a/src/api/spec/cassettes/Package/_public_source_path/1_11_2.yml
+++ b/src/api/spec/cassettes/Package/_public_source_path/1_11_2.yml
@@ -40,16 +40,16 @@ http_interactions:
           <person userid="tom" role="maintainer" />
         </project>
     http_version: 
-  recorded_at: Wed, 03 May 2017 14:37:41 GMT
+  recorded_at: Fri, 30 Jun 2017 12:16:08 GMT
 - request:
     method: put
-    uri: http://localhost:3200/source/home:tom/test_package/_meta?user=_nobody_
+    uri: http://localhost:3200/source/home:tom/package_with_files/_meta?user=tom
     body:
       encoding: UTF-8
       string: |
-        <package name="test_package" project="home:tom">
-          <title>Cover Her Face</title>
-          <description>Earum dicta consectetur omnis itaque beatae provident.</description>
+        <package name="package_with_files" project="home:tom">
+          <title>Cabbages and Kings</title>
+          <description>Harum consequatur unde explicabo vel.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -70,25 +70,25 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '176'
+      - '169'
     body:
       encoding: UTF-8
       string: |
-        <package name="test_package" project="home:tom">
-          <title>Cover Her Face</title>
-          <description>Earum dicta consectetur omnis itaque beatae provident.</description>
+        <package name="package_with_files" project="home:tom">
+          <title>Cabbages and Kings</title>
+          <description>Harum consequatur unde explicabo vel.</description>
         </package>
     http_version: 
-  recorded_at: Wed, 03 May 2017 14:37:41 GMT
+  recorded_at: Fri, 30 Jun 2017 12:16:08 GMT
 - request:
     method: put
-    uri: http://localhost:3200/source/home:tom/test_package/_meta
+    uri: http://localhost:3200/source/home:tom/package_with_files/_meta
     body:
       encoding: UTF-8
       string: |
-        <package name="test_package" project="home:tom">
-          <title>Cover Her Face</title>
-          <description>Earum dicta consectetur omnis itaque beatae provident.</description>
+        <package name="package_with_files" project="home:tom">
+          <title>Cabbages and Kings</title>
+          <description>Harum consequatur unde explicabo vel.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -109,63 +109,24 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '176'
+      - '169'
     body:
       encoding: UTF-8
       string: |
-        <package name="test_package" project="home:tom">
-          <title>Cover Her Face</title>
-          <description>Earum dicta consectetur omnis itaque beatae provident.</description>
+        <package name="package_with_files" project="home:tom">
+          <title>Cabbages and Kings</title>
+          <description>Harum consequatur unde explicabo vel.</description>
         </package>
     http_version: 
-  recorded_at: Wed, 03 May 2017 14:37:41 GMT
-- request:
-    method: get
-    uri: http://localhost:3200/build/home:tom/openSUSE_Tumbleweed/x86_64/_jobhistory?limit=100&package=test_package
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Content-Type:
-      - text/plain
-      Accept-Encoding:
-      - identity
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 404
-      message: project 'home tom' has no repository 'openSUSE_Tumbleweed'
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '194'
-    body:
-      encoding: UTF-8
-      string: |
-        <status code="404">
-          <summary>project 'home:tom' has no repository 'openSUSE_Tumbleweed'</summary>
-          <details>404 project 'home:tom' has no repository 'openSUSE_Tumbleweed'</details>
-        </status>
-    http_version: 
-  recorded_at: Wed, 03 May 2017 14:37:41 GMT
+  recorded_at: Fri, 30 Jun 2017 12:16:08 GMT
 - request:
     method: put
-    uri: http://localhost:3200/source/home:tom/test_package/_meta?user=tom
+    uri: http://localhost:3200/source/home:tom/package_with_files/_config
     body:
       encoding: UTF-8
-      string: |
-        <package name="test_package" project="home:tom">
-          <title>In Dubious Battle</title>
-          <description>Tenetur quos ipsam rerum veritatis excepturi.</description>
-        </package>
+      string: Deleniti animi repellat quia similique occaecati aliquid. Exercitationem
+        voluptas rem veniam at et id consectetur. Illum neque molestiae quibusdam
+        porro laboriosam. Quasi est accusantium quibusdam qui magni consectetur.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -185,14 +146,58 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '170'
+      - '209'
     body:
       encoding: UTF-8
       string: |
-        <package name="test_package" project="home:tom">
-          <title>In Dubious Battle</title>
-          <description>Tenetur quos ipsam rerum veritatis excepturi.</description>
-        </package>
+        <revision rev="11" vrev="11">
+          <srcmd5>cb8eb263b4b9fecd91ef3a1a7a2c21ca</srcmd5>
+          <version>unknown</version>
+          <time>1498824968</time>
+          <user>unknown</user>
+          <comment></comment>
+          <requestid/>
+        </revision>
     http_version: 
-  recorded_at: Fri, 30 Jun 2017 12:16:11 GMT
+  recorded_at: Fri, 30 Jun 2017 12:16:08 GMT
+- request:
+    method: put
+    uri: http://localhost:3200/source/home:tom/package_with_files/somefile.txt
+    body:
+      encoding: UTF-8
+      string: Harum nam est fuga sed. Doloribus explicabo facere qui voluptatibus.
+        Ipsa facilis aut aspernatur eum sapiente odit.
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '209'
+    body:
+      encoding: UTF-8
+      string: |
+        <revision rev="12" vrev="12">
+          <srcmd5>a446c8d6d1bc9e4e186e867588684efc</srcmd5>
+          <version>unknown</version>
+          <time>1498824968</time>
+          <user>unknown</user>
+          <comment></comment>
+          <requestid/>
+        </revision>
+    http_version: 
+  recorded_at: Fri, 30 Jun 2017 12:16:08 GMT
 recorded_with: VCR 3.0.3

--- a/src/api/spec/cassettes/Package/_public_source_path/1_11_3.yml
+++ b/src/api/spec/cassettes/Package/_public_source_path/1_11_3.yml
@@ -40,131 +40,16 @@ http_interactions:
           <person userid="tom" role="maintainer" />
         </project>
     http_version: 
-  recorded_at: Wed, 03 May 2017 14:37:41 GMT
+  recorded_at: Fri, 30 Jun 2017 12:16:08 GMT
 - request:
     method: put
-    uri: http://localhost:3200/source/home:tom/test_package/_meta?user=_nobody_
+    uri: http://localhost:3200/source/home:tom/package_with_files/_meta?user=tom
     body:
       encoding: UTF-8
       string: |
-        <package name="test_package" project="home:tom">
-          <title>Cover Her Face</title>
-          <description>Earum dicta consectetur omnis itaque beatae provident.</description>
-        </package>
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '176'
-    body:
-      encoding: UTF-8
-      string: |
-        <package name="test_package" project="home:tom">
-          <title>Cover Her Face</title>
-          <description>Earum dicta consectetur omnis itaque beatae provident.</description>
-        </package>
-    http_version: 
-  recorded_at: Wed, 03 May 2017 14:37:41 GMT
-- request:
-    method: put
-    uri: http://localhost:3200/source/home:tom/test_package/_meta
-    body:
-      encoding: UTF-8
-      string: |
-        <package name="test_package" project="home:tom">
-          <title>Cover Her Face</title>
-          <description>Earum dicta consectetur omnis itaque beatae provident.</description>
-        </package>
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '176'
-    body:
-      encoding: UTF-8
-      string: |
-        <package name="test_package" project="home:tom">
-          <title>Cover Her Face</title>
-          <description>Earum dicta consectetur omnis itaque beatae provident.</description>
-        </package>
-    http_version: 
-  recorded_at: Wed, 03 May 2017 14:37:41 GMT
-- request:
-    method: get
-    uri: http://localhost:3200/build/home:tom/openSUSE_Tumbleweed/x86_64/_jobhistory?limit=100&package=test_package
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Content-Type:
-      - text/plain
-      Accept-Encoding:
-      - identity
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 404
-      message: project 'home tom' has no repository 'openSUSE_Tumbleweed'
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '194'
-    body:
-      encoding: UTF-8
-      string: |
-        <status code="404">
-          <summary>project 'home:tom' has no repository 'openSUSE_Tumbleweed'</summary>
-          <details>404 project 'home:tom' has no repository 'openSUSE_Tumbleweed'</details>
-        </status>
-    http_version: 
-  recorded_at: Wed, 03 May 2017 14:37:41 GMT
-- request:
-    method: put
-    uri: http://localhost:3200/source/home:tom/test_package/_meta?user=tom
-    body:
-      encoding: UTF-8
-      string: |
-        <package name="test_package" project="home:tom">
-          <title>In Dubious Battle</title>
-          <description>Tenetur quos ipsam rerum veritatis excepturi.</description>
+        <package name="package_with_files" project="home:tom">
+          <title>Fame Is the Spur</title>
+          <description>Rerum numquam quia qui natus doloremque.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -189,10 +74,129 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <package name="test_package" project="home:tom">
-          <title>In Dubious Battle</title>
-          <description>Tenetur quos ipsam rerum veritatis excepturi.</description>
+        <package name="package_with_files" project="home:tom">
+          <title>Fame Is the Spur</title>
+          <description>Rerum numquam quia qui natus doloremque.</description>
         </package>
     http_version: 
-  recorded_at: Fri, 30 Jun 2017 12:16:11 GMT
+  recorded_at: Fri, 30 Jun 2017 12:16:08 GMT
+- request:
+    method: put
+    uri: http://localhost:3200/source/home:tom/package_with_files/_meta
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="package_with_files" project="home:tom">
+          <title>Fame Is the Spur</title>
+          <description>Rerum numquam quia qui natus doloremque.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '170'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="package_with_files" project="home:tom">
+          <title>Fame Is the Spur</title>
+          <description>Rerum numquam quia qui natus doloremque.</description>
+        </package>
+    http_version: 
+  recorded_at: Fri, 30 Jun 2017 12:16:08 GMT
+- request:
+    method: put
+    uri: http://localhost:3200/source/home:tom/package_with_files/_config
+    body:
+      encoding: UTF-8
+      string: Est dicta distinctio. Totam voluptates placeat unde. Sunt deserunt nesciunt.
+        Et omnis magni fugit.
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '207'
+    body:
+      encoding: UTF-8
+      string: |
+        <revision rev="7" vrev="7">
+          <srcmd5>43efe6d5332bf0f4295d4acbf9143fe1</srcmd5>
+          <version>unknown</version>
+          <time>1498824968</time>
+          <user>unknown</user>
+          <comment></comment>
+          <requestid/>
+        </revision>
+    http_version: 
+  recorded_at: Fri, 30 Jun 2017 12:16:08 GMT
+- request:
+    method: put
+    uri: http://localhost:3200/source/home:tom/package_with_files/somefile.txt
+    body:
+      encoding: UTF-8
+      string: Ut repellat sunt. Similique qui blanditiis inventore saepe eaque. Aperiam
+        repellendus voluptas.
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '207'
+    body:
+      encoding: UTF-8
+      string: |
+        <revision rev="8" vrev="8">
+          <srcmd5>341aca18c66920a618e4a5283a1648c0</srcmd5>
+          <version>unknown</version>
+          <time>1498824968</time>
+          <user>unknown</user>
+          <comment></comment>
+          <requestid/>
+        </revision>
+    http_version: 
+  recorded_at: Fri, 30 Jun 2017 12:16:08 GMT
 recorded_with: VCR 3.0.3

--- a/src/api/spec/cassettes/Package/_save_file/calls_addKiwiImport_if_filename_ends_with_kiwi_txz.yml
+++ b/src/api/spec/cassettes/Package/_save_file/calls_addKiwiImport_if_filename_ends_with_kiwi_txz.yml
@@ -341,4 +341,43 @@ http_interactions:
         </package>
     http_version: 
   recorded_at: Wed, 16 Nov 2016 10:58:27 GMT
+- request:
+    method: put
+    uri: http://localhost:3200/source/home:tom/test_package/_meta?user=tom
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="test_package" project="home:tom">
+          <title>Down to a Sunless Sea</title>
+          <description>Repudiandae temporibus enim iusto.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '163'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="test_package" project="home:tom">
+          <title>Down to a Sunless Sea</title>
+          <description>Repudiandae temporibus enim iusto.</description>
+        </package>
+    http_version: 
+  recorded_at: Fri, 30 Jun 2017 12:16:06 GMT
 recorded_with: VCR 3.0.3

--- a/src/api/spec/cassettes/Package/_save_file/does_not_call_addKiwiImport_if_filename_ends_not_with_kiwi_txz.yml
+++ b/src/api/spec/cassettes/Package/_save_file/does_not_call_addKiwiImport_if_filename_ends_not_with_kiwi_txz.yml
@@ -306,4 +306,43 @@ http_interactions:
         </package>
     http_version: 
   recorded_at: Wed, 16 Nov 2016 10:58:27 GMT
+- request:
+    method: put
+    uri: http://localhost:3200/source/home:tom/test_package/_meta?user=tom
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="test_package" project="home:tom">
+          <title>Ring of Bright Water</title>
+          <description>Quaerat harum recusandae labore voluptas dicta.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '175'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="test_package" project="home:tom">
+          <title>Ring of Bright Water</title>
+          <description>Quaerat harum recusandae labore voluptas dicta.</description>
+        </package>
+    http_version: 
+  recorded_at: Fri, 30 Jun 2017 12:16:06 GMT
 recorded_with: VCR 3.0.3

--- a/src/api/spec/cassettes/Package/_service_error/with_error/1_7_2_1.yml
+++ b/src/api/spec/cassettes/Package/_service_error/with_error/1_7_2_1.yml
@@ -230,4 +230,43 @@ http_interactions:
 '
     http_version: 
   recorded_at: Tue, 07 Mar 2017 09:33:33 GMT
+- request:
+    method: put
+    uri: http://localhost:3200/source/home:tom/package_with_broken_service/_meta?user=tom
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="package_with_broken_service" project="home:tom">
+          <title>A Swiftly Tilting Planet</title>
+          <description>Qui non culpa ratione.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '169'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="package_with_broken_service" project="home:tom">
+          <title>A Swiftly Tilting Planet</title>
+          <description>Qui non culpa ratione.</description>
+        </package>
+    http_version: 
+  recorded_at: Fri, 30 Jun 2017 12:16:12 GMT
 recorded_with: VCR 3.0.3

--- a/src/api/spec/cassettes/Package/_service_error/without_error/1_7_1_1.yml
+++ b/src/api/spec/cassettes/Package/_service_error/without_error/1_7_1_1.yml
@@ -232,4 +232,43 @@ http_interactions:
         </status>
     http_version: 
   recorded_at: Tue, 07 Mar 2017 09:33:33 GMT
+- request:
+    method: put
+    uri: http://localhost:3200/source/home:tom/package_with_service/_meta?user=tom
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="package_with_service" project="home:tom">
+          <title>Sleep the Brave</title>
+          <description>Omnis velit neque consectetur facere sequi.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '174'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="package_with_service" project="home:tom">
+          <title>Sleep the Brave</title>
+          <description>Omnis velit neque consectetur facere sequi.</description>
+        </package>
+    http_version: 
+  recorded_at: Fri, 30 Jun 2017 12:16:12 GMT
 recorded_with: VCR 3.0.3

--- a/src/api/spec/cassettes/Package/_source_path/1_10_1.yml
+++ b/src/api/spec/cassettes/Package/_source_path/1_10_1.yml
@@ -40,16 +40,16 @@ http_interactions:
           <person userid="tom" role="maintainer" />
         </project>
     http_version: 
-  recorded_at: Wed, 03 May 2017 14:37:41 GMT
+  recorded_at: Fri, 30 Jun 2017 12:16:07 GMT
 - request:
     method: put
-    uri: http://localhost:3200/source/home:tom/test_package/_meta?user=_nobody_
+    uri: http://localhost:3200/source/home:tom/package_with_files/_meta?user=tom
     body:
       encoding: UTF-8
       string: |
-        <package name="test_package" project="home:tom">
-          <title>Cover Her Face</title>
-          <description>Earum dicta consectetur omnis itaque beatae provident.</description>
+        <package name="package_with_files" project="home:tom">
+          <title>Precious Bane</title>
+          <description>Est odit ut aut quia.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -70,25 +70,25 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '176'
+      - '148'
     body:
       encoding: UTF-8
       string: |
-        <package name="test_package" project="home:tom">
-          <title>Cover Her Face</title>
-          <description>Earum dicta consectetur omnis itaque beatae provident.</description>
+        <package name="package_with_files" project="home:tom">
+          <title>Precious Bane</title>
+          <description>Est odit ut aut quia.</description>
         </package>
     http_version: 
-  recorded_at: Wed, 03 May 2017 14:37:41 GMT
+  recorded_at: Fri, 30 Jun 2017 12:16:07 GMT
 - request:
     method: put
-    uri: http://localhost:3200/source/home:tom/test_package/_meta
+    uri: http://localhost:3200/source/home:tom/package_with_files/_meta
     body:
       encoding: UTF-8
       string: |
-        <package name="test_package" project="home:tom">
-          <title>Cover Her Face</title>
-          <description>Earum dicta consectetur omnis itaque beatae provident.</description>
+        <package name="package_with_files" project="home:tom">
+          <title>Precious Bane</title>
+          <description>Est odit ut aut quia.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -109,63 +109,24 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '176'
+      - '148'
     body:
       encoding: UTF-8
       string: |
-        <package name="test_package" project="home:tom">
-          <title>Cover Her Face</title>
-          <description>Earum dicta consectetur omnis itaque beatae provident.</description>
+        <package name="package_with_files" project="home:tom">
+          <title>Precious Bane</title>
+          <description>Est odit ut aut quia.</description>
         </package>
     http_version: 
-  recorded_at: Wed, 03 May 2017 14:37:41 GMT
-- request:
-    method: get
-    uri: http://localhost:3200/build/home:tom/openSUSE_Tumbleweed/x86_64/_jobhistory?limit=100&package=test_package
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Content-Type:
-      - text/plain
-      Accept-Encoding:
-      - identity
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 404
-      message: project 'home tom' has no repository 'openSUSE_Tumbleweed'
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '194'
-    body:
-      encoding: UTF-8
-      string: |
-        <status code="404">
-          <summary>project 'home:tom' has no repository 'openSUSE_Tumbleweed'</summary>
-          <details>404 project 'home:tom' has no repository 'openSUSE_Tumbleweed'</details>
-        </status>
-    http_version: 
-  recorded_at: Wed, 03 May 2017 14:37:41 GMT
+  recorded_at: Fri, 30 Jun 2017 12:16:07 GMT
 - request:
     method: put
-    uri: http://localhost:3200/source/home:tom/test_package/_meta?user=tom
+    uri: http://localhost:3200/source/home:tom/package_with_files/_config
     body:
       encoding: UTF-8
-      string: |
-        <package name="test_package" project="home:tom">
-          <title>In Dubious Battle</title>
-          <description>Tenetur quos ipsam rerum veritatis excepturi.</description>
-        </package>
+      string: Quaerat non minus dignissimos iure et. Explicabo dicta laboriosam ut
+        occaecati soluta consectetur. Nobis iste quia quam modi sint et. Dicta commodi
+        at unde quo. Suscipit expedita laudantium provident ex hic ducimus illo.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -185,14 +146,58 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '170'
+      - '207'
     body:
       encoding: UTF-8
       string: |
-        <package name="test_package" project="home:tom">
-          <title>In Dubious Battle</title>
-          <description>Tenetur quos ipsam rerum veritatis excepturi.</description>
-        </package>
+        <revision rev="3" vrev="3">
+          <srcmd5>faec995ef23146dcd7c585515d99afd4</srcmd5>
+          <version>unknown</version>
+          <time>1498824967</time>
+          <user>unknown</user>
+          <comment></comment>
+          <requestid/>
+        </revision>
     http_version: 
-  recorded_at: Fri, 30 Jun 2017 12:16:11 GMT
+  recorded_at: Fri, 30 Jun 2017 12:16:07 GMT
+- request:
+    method: put
+    uri: http://localhost:3200/source/home:tom/package_with_files/somefile.txt
+    body:
+      encoding: UTF-8
+      string: Dolorem atque praesentium quis magnam beatae eveniet aliquid. Id labore
+        eius aut recusandae tempora neque. Ipsa neque qui consequatur.
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '207'
+    body:
+      encoding: UTF-8
+      string: |
+        <revision rev="4" vrev="4">
+          <srcmd5>46dfa4afdc51e7aff1af2befc1789329</srcmd5>
+          <version>unknown</version>
+          <time>1498824967</time>
+          <user>unknown</user>
+          <comment></comment>
+          <requestid/>
+        </revision>
+    http_version: 
+  recorded_at: Fri, 30 Jun 2017 12:16:07 GMT
 recorded_with: VCR 3.0.3

--- a/src/api/spec/cassettes/Package/_source_path/1_10_2.yml
+++ b/src/api/spec/cassettes/Package/_source_path/1_10_2.yml
@@ -40,16 +40,16 @@ http_interactions:
           <person userid="tom" role="maintainer" />
         </project>
     http_version: 
-  recorded_at: Wed, 03 May 2017 14:37:41 GMT
+  recorded_at: Fri, 30 Jun 2017 12:16:07 GMT
 - request:
     method: put
-    uri: http://localhost:3200/source/home:tom/test_package/_meta?user=_nobody_
+    uri: http://localhost:3200/source/home:tom/package_with_files/_meta?user=tom
     body:
       encoding: UTF-8
       string: |
-        <package name="test_package" project="home:tom">
-          <title>Cover Her Face</title>
-          <description>Earum dicta consectetur omnis itaque beatae provident.</description>
+        <package name="package_with_files" project="home:tom">
+          <title>A Many-Splendoured Thing</title>
+          <description>Aut rerum expedita laboriosam dolorum animi quas officia in.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -70,25 +70,25 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '176'
+      - '198'
     body:
       encoding: UTF-8
       string: |
-        <package name="test_package" project="home:tom">
-          <title>Cover Her Face</title>
-          <description>Earum dicta consectetur omnis itaque beatae provident.</description>
+        <package name="package_with_files" project="home:tom">
+          <title>A Many-Splendoured Thing</title>
+          <description>Aut rerum expedita laboriosam dolorum animi quas officia in.</description>
         </package>
     http_version: 
-  recorded_at: Wed, 03 May 2017 14:37:41 GMT
+  recorded_at: Fri, 30 Jun 2017 12:16:07 GMT
 - request:
     method: put
-    uri: http://localhost:3200/source/home:tom/test_package/_meta
+    uri: http://localhost:3200/source/home:tom/package_with_files/_meta
     body:
       encoding: UTF-8
       string: |
-        <package name="test_package" project="home:tom">
-          <title>Cover Her Face</title>
-          <description>Earum dicta consectetur omnis itaque beatae provident.</description>
+        <package name="package_with_files" project="home:tom">
+          <title>A Many-Splendoured Thing</title>
+          <description>Aut rerum expedita laboriosam dolorum animi quas officia in.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -109,63 +109,24 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '176'
+      - '198'
     body:
       encoding: UTF-8
       string: |
-        <package name="test_package" project="home:tom">
-          <title>Cover Her Face</title>
-          <description>Earum dicta consectetur omnis itaque beatae provident.</description>
+        <package name="package_with_files" project="home:tom">
+          <title>A Many-Splendoured Thing</title>
+          <description>Aut rerum expedita laboriosam dolorum animi quas officia in.</description>
         </package>
     http_version: 
-  recorded_at: Wed, 03 May 2017 14:37:41 GMT
-- request:
-    method: get
-    uri: http://localhost:3200/build/home:tom/openSUSE_Tumbleweed/x86_64/_jobhistory?limit=100&package=test_package
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Content-Type:
-      - text/plain
-      Accept-Encoding:
-      - identity
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 404
-      message: project 'home tom' has no repository 'openSUSE_Tumbleweed'
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '194'
-    body:
-      encoding: UTF-8
-      string: |
-        <status code="404">
-          <summary>project 'home:tom' has no repository 'openSUSE_Tumbleweed'</summary>
-          <details>404 project 'home:tom' has no repository 'openSUSE_Tumbleweed'</details>
-        </status>
-    http_version: 
-  recorded_at: Wed, 03 May 2017 14:37:41 GMT
+  recorded_at: Fri, 30 Jun 2017 12:16:07 GMT
 - request:
     method: put
-    uri: http://localhost:3200/source/home:tom/test_package/_meta?user=tom
+    uri: http://localhost:3200/source/home:tom/package_with_files/_config
     body:
       encoding: UTF-8
-      string: |
-        <package name="test_package" project="home:tom">
-          <title>In Dubious Battle</title>
-          <description>Tenetur quos ipsam rerum veritatis excepturi.</description>
-        </package>
+      string: Qui voluptas quo ut. Sed dolorem aut perspiciatis qui autem quos. Et
+        saepe omnis nisi voluptates aperiam. Qui quis dignissimos repudiandae enim
+        voluptatem. Totam et ut ut atque.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -185,14 +146,59 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '170'
+      - '207'
     body:
       encoding: UTF-8
       string: |
-        <package name="test_package" project="home:tom">
-          <title>In Dubious Battle</title>
-          <description>Tenetur quos ipsam rerum veritatis excepturi.</description>
-        </package>
+        <revision rev="5" vrev="5">
+          <srcmd5>c4a1ddb94adbd9c08a75df06f5ac279f</srcmd5>
+          <version>unknown</version>
+          <time>1498824967</time>
+          <user>unknown</user>
+          <comment></comment>
+          <requestid/>
+        </revision>
     http_version: 
-  recorded_at: Fri, 30 Jun 2017 12:16:11 GMT
+  recorded_at: Fri, 30 Jun 2017 12:16:07 GMT
+- request:
+    method: put
+    uri: http://localhost:3200/source/home:tom/package_with_files/somefile.txt
+    body:
+      encoding: UTF-8
+      string: Quidem voluptas officiis et qui. Incidunt qui harum temporibus in. Minima
+        libero nihil quia dolor. Sunt nesciunt enim distinctio est ut sed voluptatem.
+        Magni libero non saepe atque voluptas facere quas.
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '207'
+    body:
+      encoding: UTF-8
+      string: |
+        <revision rev="6" vrev="6">
+          <srcmd5>ca6a77e59f124bd177a199fee663e6da</srcmd5>
+          <version>unknown</version>
+          <time>1498824967</time>
+          <user>unknown</user>
+          <comment></comment>
+          <requestid/>
+        </revision>
+    http_version: 
+  recorded_at: Fri, 30 Jun 2017 12:16:07 GMT
 recorded_with: VCR 3.0.3

--- a/src/api/spec/cassettes/Package/_source_path/1_10_3.yml
+++ b/src/api/spec/cassettes/Package/_source_path/1_10_3.yml
@@ -40,16 +40,16 @@ http_interactions:
           <person userid="tom" role="maintainer" />
         </project>
     http_version: 
-  recorded_at: Wed, 03 May 2017 14:37:41 GMT
+  recorded_at: Fri, 30 Jun 2017 12:16:06 GMT
 - request:
     method: put
-    uri: http://localhost:3200/source/home:tom/test_package/_meta?user=_nobody_
+    uri: http://localhost:3200/source/home:tom/package_with_files/_meta?user=tom
     body:
       encoding: UTF-8
       string: |
-        <package name="test_package" project="home:tom">
-          <title>Cover Her Face</title>
-          <description>Earum dicta consectetur omnis itaque beatae provident.</description>
+        <package name="package_with_files" project="home:tom">
+          <title>Look to Windward</title>
+          <description>Facere iste voluptas molestiae incidunt repellendus ea iusto.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -70,25 +70,25 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '176'
+      - '191'
     body:
       encoding: UTF-8
       string: |
-        <package name="test_package" project="home:tom">
-          <title>Cover Her Face</title>
-          <description>Earum dicta consectetur omnis itaque beatae provident.</description>
+        <package name="package_with_files" project="home:tom">
+          <title>Look to Windward</title>
+          <description>Facere iste voluptas molestiae incidunt repellendus ea iusto.</description>
         </package>
     http_version: 
-  recorded_at: Wed, 03 May 2017 14:37:41 GMT
+  recorded_at: Fri, 30 Jun 2017 12:16:07 GMT
 - request:
     method: put
-    uri: http://localhost:3200/source/home:tom/test_package/_meta
+    uri: http://localhost:3200/source/home:tom/package_with_files/_meta
     body:
       encoding: UTF-8
       string: |
-        <package name="test_package" project="home:tom">
-          <title>Cover Her Face</title>
-          <description>Earum dicta consectetur omnis itaque beatae provident.</description>
+        <package name="package_with_files" project="home:tom">
+          <title>Look to Windward</title>
+          <description>Facere iste voluptas molestiae incidunt repellendus ea iusto.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -109,63 +109,23 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '176'
+      - '191'
     body:
       encoding: UTF-8
       string: |
-        <package name="test_package" project="home:tom">
-          <title>Cover Her Face</title>
-          <description>Earum dicta consectetur omnis itaque beatae provident.</description>
+        <package name="package_with_files" project="home:tom">
+          <title>Look to Windward</title>
+          <description>Facere iste voluptas molestiae incidunt repellendus ea iusto.</description>
         </package>
     http_version: 
-  recorded_at: Wed, 03 May 2017 14:37:41 GMT
-- request:
-    method: get
-    uri: http://localhost:3200/build/home:tom/openSUSE_Tumbleweed/x86_64/_jobhistory?limit=100&package=test_package
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Content-Type:
-      - text/plain
-      Accept-Encoding:
-      - identity
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 404
-      message: project 'home tom' has no repository 'openSUSE_Tumbleweed'
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '194'
-    body:
-      encoding: UTF-8
-      string: |
-        <status code="404">
-          <summary>project 'home:tom' has no repository 'openSUSE_Tumbleweed'</summary>
-          <details>404 project 'home:tom' has no repository 'openSUSE_Tumbleweed'</details>
-        </status>
-    http_version: 
-  recorded_at: Wed, 03 May 2017 14:37:41 GMT
+  recorded_at: Fri, 30 Jun 2017 12:16:07 GMT
 - request:
     method: put
-    uri: http://localhost:3200/source/home:tom/test_package/_meta?user=tom
+    uri: http://localhost:3200/source/home:tom/package_with_files/_config
     body:
       encoding: UTF-8
-      string: |
-        <package name="test_package" project="home:tom">
-          <title>In Dubious Battle</title>
-          <description>Tenetur quos ipsam rerum veritatis excepturi.</description>
-        </package>
+      string: Minus soluta est dolores voluptas autem odio. Sunt omnis fugiat et ab.
+        Reiciendis id dolor. Ea totam voluptatem alias. Maxime et facere nihil sit.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -185,14 +145,58 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '170'
+      - '207'
     body:
       encoding: UTF-8
       string: |
-        <package name="test_package" project="home:tom">
-          <title>In Dubious Battle</title>
-          <description>Tenetur quos ipsam rerum veritatis excepturi.</description>
-        </package>
+        <revision rev="1" vrev="1">
+          <srcmd5>0153028d5d433648525fad5ee4371fa2</srcmd5>
+          <version>unknown</version>
+          <time>1498824967</time>
+          <user>unknown</user>
+          <comment></comment>
+          <requestid/>
+        </revision>
     http_version: 
-  recorded_at: Fri, 30 Jun 2017 12:16:11 GMT
+  recorded_at: Fri, 30 Jun 2017 12:16:07 GMT
+- request:
+    method: put
+    uri: http://localhost:3200/source/home:tom/package_with_files/somefile.txt
+    body:
+      encoding: UTF-8
+      string: Praesentium est et. Alias autem totam iste voluptatem laboriosam. Et
+        beatae reprehenderit quo error.
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '207'
+    body:
+      encoding: UTF-8
+      string: |
+        <revision rev="2" vrev="2">
+          <srcmd5>c4d8c021482383db47da76f7b6c63c6a</srcmd5>
+          <version>unknown</version>
+          <time>1498824967</time>
+          <user>unknown</user>
+          <comment></comment>
+          <requestid/>
+        </revision>
+    http_version: 
+  recorded_at: Fri, 30 Jun 2017 12:16:07 GMT
 recorded_with: VCR 3.0.3

--- a/src/api/spec/cassettes/Package/_what_depends_on/builds_backend_path_correct.yml
+++ b/src/api/spec/cassettes/Package/_what_depends_on/builds_backend_path_correct.yml
@@ -40,85 +40,7 @@ http_interactions:
           <person userid="tom" role="maintainer" />
         </project>
     http_version: 
-  recorded_at: Wed, 03 May 2017 20:07:57 GMT
-- request:
-    method: put
-    uri: http://localhost:3200/source/home:tom/test_package/_meta?user=_nobody_
-    body:
-      encoding: UTF-8
-      string: |
-        <package name="test_package" project="home:tom">
-          <title>It's a Battlefield</title>
-          <description>Est molestiae tempore et.</description>
-        </package>
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '151'
-    body:
-      encoding: UTF-8
-      string: |
-        <package name="test_package" project="home:tom">
-          <title>It's a Battlefield</title>
-          <description>Est molestiae tempore et.</description>
-        </package>
-    http_version: 
-  recorded_at: Wed, 03 May 2017 20:07:58 GMT
-- request:
-    method: put
-    uri: http://localhost:3200/source/home:tom/test_package/_meta
-    body:
-      encoding: UTF-8
-      string: |
-        <package name="test_package" project="home:tom">
-          <title>It's a Battlefield</title>
-          <description>Est molestiae tempore et.</description>
-        </package>
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '151'
-    body:
-      encoding: UTF-8
-      string: |
-        <package name="test_package" project="home:tom">
-          <title>It's a Battlefield</title>
-          <description>Est molestiae tempore et.</description>
-        </package>
-    http_version: 
-  recorded_at: Wed, 03 May 2017 20:07:58 GMT
+  recorded_at: Fri, 30 Jun 2017 12:16:02 GMT
 - request:
     method: put
     uri: http://localhost:3200/source/home:tom/test_package/_meta?user=tom
@@ -126,8 +48,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="test_package" project="home:tom">
-          <title>Eyeless in Gaza</title>
-          <description>Omnis nesciunt deserunt dolor quos adipisci animi.</description>
+          <title>The Last Temptation</title>
+          <description>Officia quia in et.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -148,14 +70,53 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '173'
+      - '146'
     body:
       encoding: UTF-8
       string: |
         <package name="test_package" project="home:tom">
-          <title>Eyeless in Gaza</title>
-          <description>Omnis nesciunt deserunt dolor quos adipisci animi.</description>
+          <title>The Last Temptation</title>
+          <description>Officia quia in et.</description>
         </package>
     http_version: 
-  recorded_at: Fri, 30 Jun 2017 12:16:12 GMT
+  recorded_at: Fri, 30 Jun 2017 12:16:02 GMT
+- request:
+    method: put
+    uri: http://localhost:3200/source/home:tom/test_package/_meta
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="test_package" project="home:tom">
+          <title>The Last Temptation</title>
+          <description>Officia quia in et.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '146'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="test_package" project="home:tom">
+          <title>The Last Temptation</title>
+          <description>Officia quia in et.</description>
+        </package>
+    http_version: 
+  recorded_at: Fri, 30 Jun 2017 12:16:02 GMT
 recorded_with: VCR 3.0.3

--- a/src/api/spec/cassettes/Package/_what_depends_on/with_invalid_repository_or_architecture/returns_an_empty_array.yml
+++ b/src/api/spec/cassettes/Package/_what_depends_on/with_invalid_repository_or_architecture/returns_an_empty_array.yml
@@ -40,85 +40,7 @@ http_interactions:
           <person userid="tom" role="maintainer" />
         </project>
     http_version: 
-  recorded_at: Wed, 03 May 2017 20:07:57 GMT
-- request:
-    method: put
-    uri: http://localhost:3200/source/home:tom/test_package/_meta?user=_nobody_
-    body:
-      encoding: UTF-8
-      string: |
-        <package name="test_package" project="home:tom">
-          <title>It's a Battlefield</title>
-          <description>Est molestiae tempore et.</description>
-        </package>
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '151'
-    body:
-      encoding: UTF-8
-      string: |
-        <package name="test_package" project="home:tom">
-          <title>It's a Battlefield</title>
-          <description>Est molestiae tempore et.</description>
-        </package>
-    http_version: 
-  recorded_at: Wed, 03 May 2017 20:07:58 GMT
-- request:
-    method: put
-    uri: http://localhost:3200/source/home:tom/test_package/_meta
-    body:
-      encoding: UTF-8
-      string: |
-        <package name="test_package" project="home:tom">
-          <title>It's a Battlefield</title>
-          <description>Est molestiae tempore et.</description>
-        </package>
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '151'
-    body:
-      encoding: UTF-8
-      string: |
-        <package name="test_package" project="home:tom">
-          <title>It's a Battlefield</title>
-          <description>Est molestiae tempore et.</description>
-        </package>
-    http_version: 
-  recorded_at: Wed, 03 May 2017 20:07:58 GMT
+  recorded_at: Fri, 30 Jun 2017 12:16:03 GMT
 - request:
     method: put
     uri: http://localhost:3200/source/home:tom/test_package/_meta?user=tom
@@ -126,8 +48,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="test_package" project="home:tom">
-          <title>Eyeless in Gaza</title>
-          <description>Omnis nesciunt deserunt dolor quos adipisci animi.</description>
+          <title>The Yellow Meads of Asphodel</title>
+          <description>Impedit placeat alias sequi suscipit voluptatem a aspernatur ducimus.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -148,14 +70,53 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '173'
+      - '205'
     body:
       encoding: UTF-8
       string: |
         <package name="test_package" project="home:tom">
-          <title>Eyeless in Gaza</title>
-          <description>Omnis nesciunt deserunt dolor quos adipisci animi.</description>
+          <title>The Yellow Meads of Asphodel</title>
+          <description>Impedit placeat alias sequi suscipit voluptatem a aspernatur ducimus.</description>
         </package>
     http_version: 
-  recorded_at: Fri, 30 Jun 2017 12:16:12 GMT
+  recorded_at: Fri, 30 Jun 2017 12:16:03 GMT
+- request:
+    method: put
+    uri: http://localhost:3200/source/home:tom/test_package/_meta
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="test_package" project="home:tom">
+          <title>The Yellow Meads of Asphodel</title>
+          <description>Impedit placeat alias sequi suscipit voluptatem a aspernatur ducimus.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '205'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="test_package" project="home:tom">
+          <title>The Yellow Meads of Asphodel</title>
+          <description>Impedit placeat alias sequi suscipit voluptatem a aspernatur ducimus.</description>
+        </package>
+    http_version: 
+  recorded_at: Fri, 30 Jun 2017 12:16:03 GMT
 recorded_with: VCR 3.0.3

--- a/src/api/spec/cassettes/Package/_what_depends_on/with_more_than_one_build_dependency/returns_an_array_with_the_dependencies.yml
+++ b/src/api/spec/cassettes/Package/_what_depends_on/with_more_than_one_build_dependency/returns_an_array_with_the_dependencies.yml
@@ -40,85 +40,7 @@ http_interactions:
           <person userid="tom" role="maintainer" />
         </project>
     http_version: 
-  recorded_at: Wed, 03 May 2017 20:07:57 GMT
-- request:
-    method: put
-    uri: http://localhost:3200/source/home:tom/test_package/_meta?user=_nobody_
-    body:
-      encoding: UTF-8
-      string: |
-        <package name="test_package" project="home:tom">
-          <title>It's a Battlefield</title>
-          <description>Est molestiae tempore et.</description>
-        </package>
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '151'
-    body:
-      encoding: UTF-8
-      string: |
-        <package name="test_package" project="home:tom">
-          <title>It's a Battlefield</title>
-          <description>Est molestiae tempore et.</description>
-        </package>
-    http_version: 
-  recorded_at: Wed, 03 May 2017 20:07:58 GMT
-- request:
-    method: put
-    uri: http://localhost:3200/source/home:tom/test_package/_meta
-    body:
-      encoding: UTF-8
-      string: |
-        <package name="test_package" project="home:tom">
-          <title>It's a Battlefield</title>
-          <description>Est molestiae tempore et.</description>
-        </package>
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '151'
-    body:
-      encoding: UTF-8
-      string: |
-        <package name="test_package" project="home:tom">
-          <title>It's a Battlefield</title>
-          <description>Est molestiae tempore et.</description>
-        </package>
-    http_version: 
-  recorded_at: Wed, 03 May 2017 20:07:58 GMT
+  recorded_at: Fri, 30 Jun 2017 12:16:02 GMT
 - request:
     method: put
     uri: http://localhost:3200/source/home:tom/test_package/_meta?user=tom
@@ -127,7 +49,7 @@ http_interactions:
       string: |
         <package name="test_package" project="home:tom">
           <title>Eyeless in Gaza</title>
-          <description>Omnis nesciunt deserunt dolor quos adipisci animi.</description>
+          <description>Enim necessitatibus inventore dolorem.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -148,14 +70,53 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '173'
+      - '161'
     body:
       encoding: UTF-8
       string: |
         <package name="test_package" project="home:tom">
           <title>Eyeless in Gaza</title>
-          <description>Omnis nesciunt deserunt dolor quos adipisci animi.</description>
+          <description>Enim necessitatibus inventore dolorem.</description>
         </package>
     http_version: 
-  recorded_at: Fri, 30 Jun 2017 12:16:12 GMT
+  recorded_at: Fri, 30 Jun 2017 12:16:03 GMT
+- request:
+    method: put
+    uri: http://localhost:3200/source/home:tom/test_package/_meta
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="test_package" project="home:tom">
+          <title>Eyeless in Gaza</title>
+          <description>Enim necessitatibus inventore dolorem.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '161'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="test_package" project="home:tom">
+          <title>Eyeless in Gaza</title>
+          <description>Enim necessitatibus inventore dolorem.</description>
+        </package>
+    http_version: 
+  recorded_at: Fri, 30 Jun 2017 12:16:03 GMT
 recorded_with: VCR 3.0.3

--- a/src/api/spec/cassettes/Package/_what_depends_on/with_no_build_dependencies/returns_an_empty_array.yml
+++ b/src/api/spec/cassettes/Package/_what_depends_on/with_no_build_dependencies/returns_an_empty_array.yml
@@ -40,85 +40,7 @@ http_interactions:
           <person userid="tom" role="maintainer" />
         </project>
     http_version: 
-  recorded_at: Wed, 03 May 2017 20:07:57 GMT
-- request:
-    method: put
-    uri: http://localhost:3200/source/home:tom/test_package/_meta?user=_nobody_
-    body:
-      encoding: UTF-8
-      string: |
-        <package name="test_package" project="home:tom">
-          <title>It's a Battlefield</title>
-          <description>Est molestiae tempore et.</description>
-        </package>
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '151'
-    body:
-      encoding: UTF-8
-      string: |
-        <package name="test_package" project="home:tom">
-          <title>It's a Battlefield</title>
-          <description>Est molestiae tempore et.</description>
-        </package>
-    http_version: 
-  recorded_at: Wed, 03 May 2017 20:07:58 GMT
-- request:
-    method: put
-    uri: http://localhost:3200/source/home:tom/test_package/_meta
-    body:
-      encoding: UTF-8
-      string: |
-        <package name="test_package" project="home:tom">
-          <title>It's a Battlefield</title>
-          <description>Est molestiae tempore et.</description>
-        </package>
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '151'
-    body:
-      encoding: UTF-8
-      string: |
-        <package name="test_package" project="home:tom">
-          <title>It's a Battlefield</title>
-          <description>Est molestiae tempore et.</description>
-        </package>
-    http_version: 
-  recorded_at: Wed, 03 May 2017 20:07:58 GMT
+  recorded_at: Fri, 30 Jun 2017 12:16:02 GMT
 - request:
     method: put
     uri: http://localhost:3200/source/home:tom/test_package/_meta?user=tom
@@ -126,8 +48,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="test_package" project="home:tom">
-          <title>Eyeless in Gaza</title>
-          <description>Omnis nesciunt deserunt dolor quos adipisci animi.</description>
+          <title>The Green Bay Tree</title>
+          <description>Itaque est delectus ullam vel quidem soluta eligendi.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -148,14 +70,53 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '173'
+      - '179'
     body:
       encoding: UTF-8
       string: |
         <package name="test_package" project="home:tom">
-          <title>Eyeless in Gaza</title>
-          <description>Omnis nesciunt deserunt dolor quos adipisci animi.</description>
+          <title>The Green Bay Tree</title>
+          <description>Itaque est delectus ullam vel quidem soluta eligendi.</description>
         </package>
     http_version: 
-  recorded_at: Fri, 30 Jun 2017 12:16:12 GMT
+  recorded_at: Fri, 30 Jun 2017 12:16:02 GMT
+- request:
+    method: put
+    uri: http://localhost:3200/source/home:tom/test_package/_meta
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="test_package" project="home:tom">
+          <title>The Green Bay Tree</title>
+          <description>Itaque est delectus ullam vel quidem soluta eligendi.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '179'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="test_package" project="home:tom">
+          <title>The Green Bay Tree</title>
+          <description>Itaque est delectus ullam vel quidem soluta eligendi.</description>
+        </package>
+    http_version: 
+  recorded_at: Fri, 30 Jun 2017 12:16:02 GMT
 recorded_with: VCR 3.0.3

--- a/src/api/spec/cassettes/Package/_what_depends_on/with_one_build_dependency/returns_an_array_with_the_dependency.yml
+++ b/src/api/spec/cassettes/Package/_what_depends_on/with_one_build_dependency/returns_an_array_with_the_dependency.yml
@@ -40,16 +40,16 @@ http_interactions:
           <person userid="tom" role="maintainer" />
         </project>
     http_version: 
-  recorded_at: Wed, 03 May 2017 20:07:57 GMT
+  recorded_at: Fri, 30 Jun 2017 12:16:03 GMT
 - request:
     method: put
-    uri: http://localhost:3200/source/home:tom/test_package/_meta?user=_nobody_
+    uri: http://localhost:3200/source/home:tom/test_package/_meta?user=tom
     body:
       encoding: UTF-8
       string: |
         <package name="test_package" project="home:tom">
           <title>It's a Battlefield</title>
-          <description>Est molestiae tempore et.</description>
+          <description>Aut unde beatae non nostrum iste repellat.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -70,16 +70,16 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '151'
+      - '168'
     body:
       encoding: UTF-8
       string: |
         <package name="test_package" project="home:tom">
           <title>It's a Battlefield</title>
-          <description>Est molestiae tempore et.</description>
+          <description>Aut unde beatae non nostrum iste repellat.</description>
         </package>
     http_version: 
-  recorded_at: Wed, 03 May 2017 20:07:58 GMT
+  recorded_at: Fri, 30 Jun 2017 12:16:03 GMT
 - request:
     method: put
     uri: http://localhost:3200/source/home:tom/test_package/_meta
@@ -88,7 +88,7 @@ http_interactions:
       string: |
         <package name="test_package" project="home:tom">
           <title>It's a Battlefield</title>
-          <description>Est molestiae tempore et.</description>
+          <description>Aut unde beatae non nostrum iste repellat.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -109,53 +109,14 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '151'
+      - '168'
     body:
       encoding: UTF-8
       string: |
         <package name="test_package" project="home:tom">
           <title>It's a Battlefield</title>
-          <description>Est molestiae tempore et.</description>
+          <description>Aut unde beatae non nostrum iste repellat.</description>
         </package>
     http_version: 
-  recorded_at: Wed, 03 May 2017 20:07:58 GMT
-- request:
-    method: put
-    uri: http://localhost:3200/source/home:tom/test_package/_meta?user=tom
-    body:
-      encoding: UTF-8
-      string: |
-        <package name="test_package" project="home:tom">
-          <title>Eyeless in Gaza</title>
-          <description>Omnis nesciunt deserunt dolor quos adipisci animi.</description>
-        </package>
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '173'
-    body:
-      encoding: UTF-8
-      string: |
-        <package name="test_package" project="home:tom">
-          <title>Eyeless in Gaza</title>
-          <description>Omnis nesciunt deserunt dolor quos adipisci animi.</description>
-        </package>
-    http_version: 
-  recorded_at: Fri, 30 Jun 2017 12:16:12 GMT
+  recorded_at: Fri, 30 Jun 2017 12:16:03 GMT
 recorded_with: VCR 3.0.3

--- a/src/api/spec/cassettes/Package/is_admin_/returns_false_for_non-admins.yml
+++ b/src/api/spec/cassettes/Package/is_admin_/returns_false_for_non-admins.yml
@@ -1,0 +1,44 @@
+---
+http_interactions:
+- request:
+    method: put
+    uri: http://localhost:3200/source/home:tom/_meta?user=tom
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:tom">
+          <title/>
+          <description/>
+          <person userid="tom" role="maintainer"/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '129'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:tom">
+          <title></title>
+          <description></description>
+          <person userid="tom" role="maintainer" />
+        </project>
+    http_version: 
+  recorded_at: Fri, 30 Jun 2017 12:16:12 GMT
+recorded_with: VCR 3.0.3

--- a/src/api/spec/cassettes/Package/is_admin_/returns_true_for_admins.yml
+++ b/src/api/spec/cassettes/Package/is_admin_/returns_true_for_admins.yml
@@ -1,0 +1,44 @@
+---
+http_interactions:
+- request:
+    method: put
+    uri: http://localhost:3200/source/home:user_1/_meta?user=user_1
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:user_1">
+          <title/>
+          <description/>
+          <person userid="user_1" role="maintainer"/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '135'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:user_1">
+          <title></title>
+          <description></description>
+          <person userid="user_1" role="maintainer" />
+        </project>
+    http_version: 
+  recorded_at: Fri, 30 Jun 2017 12:16:13 GMT
+recorded_with: VCR 3.0.3

--- a/src/api/spec/models/package_spec.rb
+++ b/src/api/spec/models/package_spec.rb
@@ -99,8 +99,6 @@ RSpec.describe Package, vcr: true do
     end
 
     context 'with no delete permission' do
-      let(:other_user) { create(:user) }
-
       before do
         login(other_user)
       end
@@ -433,6 +431,10 @@ RSpec.describe Package, vcr: true do
   describe '#backend_build_command' do
     let(:params) { ActionController::Parameters.new(arch: 'x86') }
     let(:backend_url) { "#{CONFIG['source_url']}/build/#{package.project.name}?cmd=rebuild&arch=x86" }
+
+    before do
+      login(user)
+    end
 
     subject { package.backend_build_command(:rebuild, package.project.name, params) }
 


### PR DESCRIPTION
Fix flickering test: `Package#backend_build_command`.

In most tests for package model we had this:

``` Ruby
before do
  login(user)
end
```

where `user.login` is `tom`

And there is one test which had instead:

``` Ruby
let(:other_user) { create(:user) }

before do
  login(other_user)
end
```

So in this case `user.login` is not fixed.

For the `Package#backend_build_command` we didn't login any user, so there were three options:

- The user was not logged in -> `nobody_user`
- `tom` is logged in -> `tom` (most of the cases)
- `other_user` is logged in -> not fixed name

So, the cassets were generating with `tom` as user, so in the other two cases this fail. You can see an example of failure here: https://github.com/openSUSE/open-build-service/pull/3300#issuecomment-312222370

To fix it I just log `tom` for this tests. I also remove `let(:other_user) { create(:user) }` as there is up
already an `other_user` and with a fixed name`. I regenerate all the cassettes for Package and check that `other_user` is only there for the test using it. :bowtie: 