### PR TITLE
[webui][api][ci] Prohibit dotfiles

### DIFF
--- a/src/api/app/models/package.rb
+++ b/src/api/app/models/package.rb
@@ -1288,7 +1288,8 @@ class Package < ApplicationRecord
   end
 
   def self.verify_file!(pkg, name, content)
-    raise IllegalFileName, "'#{name}' is not a valid filename" if (!name.present? || !(name =~ %r{^[^\/]+$}))
+    # Prohibit dotfiles (files with leading .) and files with a / character in the name
+    raise IllegalFileName, "'#{name}' is not a valid filename" if (!name.present? || !(name =~ /^[^\.\/][^\/]+$/))
 
     # file is an ActionDispatch::Http::UploadedFile and Suse::Validator.validate
     # will call to_s therefore we have to read the content first

--- a/src/api/spec/controllers/webui/package_controller_spec.rb
+++ b/src/api/spec/controllers/webui/package_controller_spec.rb
@@ -383,7 +383,7 @@ RSpec.describe Webui::PackageController, vcr: true do
         it "fails with a backend error message" do
           do_request(project: source_project, package: source_package, filename: ".test")
           expect(response).to expected_failure_response
-          expect(flash[:error]).to eq("Error while creating '.test' file: filename '.test' is illegal.")
+          expect(flash[:error]).to eq("Error while creating '.test' file: '.test' is not a valid filename.")
         end
       end
 

--- a/src/api/spec/helpers/webui/package_helper_spec.rb
+++ b/src/api/spec/helpers/webui/package_helper_spec.rb
@@ -72,7 +72,7 @@ RSpec.describe Webui::PackageHelper, type: :helper do
     RSpec.shared_examples "file with extension" do |extension, extension_class|
       it "returns correct extension" do
         property_of {
-          sized(range(1, 190)) { string(/[\w+\-:\.]/) } + '.' + extension
+          sized(1) { string(/[\w+\-:]/) } + sized(range(0, 190)) { string(/[\w+\-:\.]/) } + '.' + extension
         }.check(3) { |filename|
           expect(guess_code_class(filename)).to eq(extension_class)
         }


### PR DESCRIPTION
to match BSVerify.pm.
Fixes also the property test for #guess_code_class which frequently failed
because of generated dotfile name as input.