### PR TITLE
[webui] Fix typo in confirmation message

### DIFF
--- a/src/api/app/views/webui/kiwi/repositories/edit.html.haml
+++ b/src/api/app/views/webui/kiwi/repositories/edit.html.haml
@@ -18,7 +18,7 @@
       dataType: 'json',
       success: function(json) {
         var is_outdated = json['is_outdated'];
-        if (is_outdated && !confirm("This repositories have been modified meanwhile you were editing.\nDo you want to apply the changes anyway?"))
+        if (is_outdated && !confirm("These repositories have been modified while you were editing them.\nDo you want to apply the changes anyway?"))
           return;
         $('#kiwi_repository_update_form').submit();
       }


### PR DESCRIPTION
Fix the confirmation message when editing an outdated kiwi image. :bowtie: 