### PR TITLE
[webui][api] fix migration by added the column type

### DIFF
--- a/src/api/db/migrate/20170704125123_remove_lock_version_from_events.rb
+++ b/src/api/db/migrate/20170704125123_remove_lock_version_from_events.rb
@@ -1,5 +1,5 @@
 class RemoveLockVersionFromEvents < ActiveRecord::Migration[5.1]
   def change
-    remove_column :events, :lock_version, default: 0, null: false
+    remove_column :events, :lock_version, :integer, default: 0, null: false
   end
 end


### PR DESCRIPTION
It seems that `rake db:migrate` worked because it ignores the arguments after `:lock_version` but if you do `rake db:rollback` it fails because the type is not specified, see remove_column docs:

https://apidock.com/rails/ActiveRecord/ConnectionAdapters/SchemaStatements/remove_column