### PR TITLE
[webui] Cache user#requests view

### DIFF
--- a/src/api/app/models/bs_request/data_table/row.rb
+++ b/src/api/app/models/bs_request/data_table/row.rb
@@ -2,7 +2,7 @@ class BsRequest
   module DataTable
     class Row
       attr_accessor :request
-      delegate :created_at, :number, :creator, :priority, to: :request
+      delegate :updated_at, :id, :created_at, :number, :creator, :priority, to: :request
 
       def initialize(request)
         @request = request

--- a/src/api/app/views/webui/users/bs_requests/index.json.erb
+++ b/src/api/app/views/webui/users/bs_requests/index.json.erb
@@ -5,13 +5,15 @@
   "data": [
     <% @requests_data_table.rows.each.with_index do |row,index | %>
       [
-        "<%= escape_javascript(fuzzy_time(row.created_at, false)) %>",
-        "<%= escape_javascript(project_or_package_link(project: row.source_project, package: row.source_package, creator: row.creator, trim_to: 40, short: true)) %>",
-        "<%= escape_javascript(target_project_link(row)) %>",
-        "<%= escape_javascript(user_with_realname_and_icon(row.creator, short: true)) %>",
-        "<%= escape_javascript(row.request_type) %>",
-        "<%= escape_javascript(row.priority) %>",
-        "<%= escape_javascript(link_to(sprite_tag('req-showdiff', title: "Show request ##{row.number}"), request_show_path(row.number), { class: :request_link })) %>"
+        <% cache "request-table-row-#{row.id}-#{row.updated_at.to_i}" do %>
+          "<%= escape_javascript(fuzzy_time(row.created_at, false)) %>",
+          "<%= escape_javascript(project_or_package_link(project: row.source_project, package: row.source_package, creator: row.creator, trim_to: 40, short: true)) %>",
+          "<%= escape_javascript(target_project_link(row)) %>",
+          "<%= escape_javascript(user_with_realname_and_icon(row.creator, short: true)) %>",
+          "<%= escape_javascript(row.request_type) %>",
+          "<%= escape_javascript(row.priority) %>",
+          "<%= escape_javascript(link_to(sprite_tag('req-showdiff', title: "Show request ##{row.number}"), request_show_path(row.number), { class: :request_link })) %>"
+        <% end %>
       ]
       <% unless index == @requests_data_table.rows.length - 1 %>
         ,


### PR DESCRIPTION
because the view calls user_with_realname_and_icon which causes n+1 queries to fetch the User
(needs to be fixed in a later commit, but this is another story...)"