### PR TITLE
[dist] Fix migrate env for package builds

### DIFF
--- a/src/api/config/feature.yml
+++ b/src/api/config/feature.yml
@@ -12,3 +12,6 @@ test:
   <<: *default
   features:
     kiwi_image_editor: true
+
+migrate:
+  <<: *default


### PR DESCRIPTION
The migration test uses a 4th env (migrate) which
needs to know about features