### PR TITLE
Show kiwi image packages list

### DIFF
--- a/src/api/app/assets/stylesheets/webui/application/kiwi_image.scss
+++ b/src/api/app/assets/stylesheets/webui/application/kiwi_image.scss
@@ -48,3 +48,7 @@
 #kiwi_repository_update_form_save {
   margin-left: 1em;
 }
+
+.kiwi_packages_table {
+  width: 98%
+}

--- a/src/api/app/helpers/webui/kiwi/image_helper.rb
+++ b/src/api/app/helpers/webui/kiwi/image_helper.rb
@@ -1,0 +1,12 @@
+module Webui::Kiwi::ImageHelper
+  include Webui::ProjectHelper
+
+  def kiwi_image_breadcrumb(kiwi_image, *args)
+    @project = kiwi_image.package.try(:project)
+    return unless @project
+
+    args.insert(0, link_to_if(params['action'] != 'show', 'Image',
+                              kiwi_image_path(id: kiwi_image)))
+    project_bread_crumb( *args )
+  end
+end

--- a/src/api/app/models/kiwi/image.rb
+++ b/src/api/app/models/kiwi/image.rb
@@ -22,7 +22,9 @@ class Kiwi::Image < ApplicationRecord
   #### Associations macros (Belongs to, Has one, Has many)
   has_one :package, foreign_key: 'kiwi_image_id', class_name: '::Package', dependent: :nullify, inverse_of: :kiwi_image
   has_many :repositories, -> { order(order: :asc) }, dependent: :destroy, index_errors: true
-  has_many :package_groups, dependent: :destroy, index_errors: true
+  has_many :package_groups, -> { order(:id) }, dependent: :destroy, index_errors: true
+  has_many :kiwi_packages, -> { where(kiwi_package_groups: { kiwi_type: Kiwi::PackageGroup.kiwi_types[:image], pattern_type: 'onlyRequired' }) },
+           through: :package_groups, source: :packages
 
   #### Callbacks macros: before_save, after_save, etc.
 

--- a/src/api/app/models/kiwi/image.rb
+++ b/src/api/app/models/kiwi/image.rb
@@ -20,8 +20,9 @@ class Kiwi::Image < ApplicationRecord
   #### Attributes
 
   #### Associations macros (Belongs to, Has one, Has many)
-  has_one :package, foreign_key: 'kiwi_image_id', dependent: :nullify, inverse_of: :kiwi_image
+  has_one :package, foreign_key: 'kiwi_image_id', class_name: '::Package', dependent: :nullify, inverse_of: :kiwi_image
   has_many :repositories, -> { order(order: :asc) }, dependent: :destroy, index_errors: true
+  has_many :package_groups, dependent: :destroy, index_errors: true
 
   #### Callbacks macros: before_save, after_save, etc.
 

--- a/src/api/app/models/kiwi/image.rb
+++ b/src/api/app/models/kiwi/image.rb
@@ -63,6 +63,27 @@ class Kiwi::Image < ApplicationRecord
       new_image.repositories.build(attributes)
       order += 1
     end
+    package_groups = xml["packages"]
+    package_groups = [xml["packages"]] if xml["packages"].is_a?(Hash)
+    package_groups.each do |package_group_xml|
+      attributes = {
+        kiwi_type:    package_group_xml['type'],
+        profiles:     package_group_xml['profiles '],
+        pattern_type: package_group_xml['patternType']
+      }
+      package_group = Kiwi::PackageGroup.new(attributes)
+      package_group_xml['package'].each do |package|
+        attributes = {
+          name:     package['name'],
+          arch:     package['arch'],
+          replaces: package['replaces']
+        }
+        attributes['bootinclude'] = package['bootinclude'] == 'true' if package.key?('bootinclude')
+        attributes['bootdelete'] = package['bootdelete'] == 'true' if package.key?('bootdelete')
+        package_group.packages.build(attributes)
+      end
+      new_image.package_groups << package_group
+    end
     new_image
   end
 

--- a/src/api/app/models/kiwi/package.rb
+++ b/src/api/app/models/kiwi/package.rb
@@ -1,0 +1,24 @@
+class Kiwi::Package < ApplicationRecord
+  belongs_to :package_group
+
+  validates :name, presence: true
+end
+
+# == Schema Information
+#
+# Table name: kiwi_packages
+#
+#  id               :integer          not null, primary key
+#  name             :string(255)      not null
+#  arch             :string(255)
+#  replaces         :string(255)
+#  bootinclude      :boolean
+#  bootdelete       :boolean
+#  package_group_id :integer          indexed
+#  created_at       :datetime         not null
+#  updated_at       :datetime         not null
+#
+# Indexes
+#
+#  index_kiwi_packages_on_package_group_id  (package_group_id)
+#

--- a/src/api/app/models/kiwi/package_group.rb
+++ b/src/api/app/models/kiwi/package_group.rb
@@ -1,0 +1,27 @@
+class Kiwi::PackageGroup < ApplicationRecord
+  has_many :packages
+  belongs_to :image
+
+  # we need to add a prefix, to avoid generating class methods that already
+  # exist in Active Record, such as "delete"
+  enum kiwi_type: %i[bootstrap delete docker image iso lxc oem pxe split testsuite vmx], _prefix: :type
+
+  validates :kiwi_type, presence: true, inclusion: { in: kiwi_types.keys }
+end
+
+# == Schema Information
+#
+# Table name: kiwi_package_groups
+#
+#  id           :integer          not null, primary key
+#  kiwi_type    :integer          not null
+#  profiles     :string(255)
+#  pattern_type :string(255)
+#  image_id     :integer          indexed
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
+#
+# Indexes
+#
+#  index_kiwi_package_groups_on_image_id  (image_id)
+#

--- a/src/api/app/views/webui/kiwi/_tabs.html.erb
+++ b/src/api/app/views/webui/kiwi/_tabs.html.erb
@@ -6,6 +6,8 @@
   });
 <% end %>
 
+<% kiwi_image_breadcrumb(@image, @image.name) %>
+
 <div class="box-header header-tabs" id="package_tabs">
   <ul>
     <%= tab 'kiwi', 'Kiwi', controller: 'kiwi/images', action: 'show', selected: true %>

--- a/src/api/app/views/webui/kiwi/images/show.html.haml
+++ b/src/api/app/views/webui/kiwi/images/show.html.haml
@@ -10,3 +10,11 @@
     - @image.repositories.each do |repository|
       = render partial: 'repository_entry', locals: {repository: repository}
     = button_to('Edit', edit_kiwi_image_path(@image), method: :get)
+
+%h3 Packages
+- if @image.kiwi_packages.empty?
+  %p There are no packages.
+- else
+  %p
+    %strong
+      = @image.kiwi_packages.pluck(:name).join(', ')

--- a/src/api/db/migrate/20170710133627_create_kiwi_package_groups.rb
+++ b/src/api/db/migrate/20170710133627_create_kiwi_package_groups.rb
@@ -1,0 +1,12 @@
+class CreateKiwiPackageGroups < ActiveRecord::Migration[5.1]
+  def change
+    create_table :kiwi_package_groups do |t|
+      t.integer :kiwi_type, null: false
+      t.string :profiles
+      t.string :pattern_type
+      t.belongs_to :image, index: true
+
+      t.timestamps
+    end
+  end
+end

--- a/src/api/db/migrate/20170710134059_create_kiwi_packages.rb
+++ b/src/api/db/migrate/20170710134059_create_kiwi_packages.rb
@@ -1,0 +1,14 @@
+class CreateKiwiPackages < ActiveRecord::Migration[5.1]
+  def change
+    create_table :kiwi_packages do |t|
+      t.string :name, null: false
+      t.string :arch
+      t.string :replaces
+      t.boolean :bootinclude
+      t.boolean :bootdelete
+      t.belongs_to :package_group, index: true
+
+      t.timestamps
+    end
+  end
+end

--- a/src/api/db/structure.sql
+++ b/src/api/db/structure.sql
@@ -628,6 +628,32 @@ CREATE TABLE `kiwi_images` (
   PRIMARY KEY (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
+CREATE TABLE `kiwi_package_groups` (
+  `id` bigint(20) NOT NULL AUTO_INCREMENT,
+  `kiwi_type` int(11) NOT NULL,
+  `profiles` varchar(255) DEFAULT NULL,
+  `pattern_type` varchar(255) DEFAULT NULL,
+  `image_id` bigint(20) DEFAULT NULL,
+  `created_at` datetime NOT NULL,
+  `updated_at` datetime NOT NULL,
+  PRIMARY KEY (`id`),
+  KEY `index_kiwi_package_groups_on_image_id` (`image_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+CREATE TABLE `kiwi_packages` (
+  `id` bigint(20) NOT NULL AUTO_INCREMENT,
+  `name` varchar(255) NOT NULL,
+  `arch` varchar(255) DEFAULT NULL,
+  `replaces` varchar(255) DEFAULT NULL,
+  `bootinclude` tinyint(1) DEFAULT NULL,
+  `bootdelete` tinyint(1) DEFAULT NULL,
+  `package_group_id` bigint(20) DEFAULT NULL,
+  `created_at` datetime NOT NULL,
+  `updated_at` datetime NOT NULL,
+  PRIMARY KEY (`id`),
+  KEY `index_kiwi_packages_on_package_group_id` (`package_group_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
 CREATE TABLE `kiwi_repositories` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `image_id` int(11) DEFAULT NULL,
@@ -1248,6 +1274,8 @@ INSERT INTO `schema_migrations` (version) VALUES
 ('20170630144825'),
 ('20170704125123'),
 ('20170704133728'),
-('20170704212201');
+('20170704212201'),
+('20170710133627'),
+('20170710134059');
 
 

--- a/src/api/spec/models/kiwi/image_spec.rb
+++ b/src/api/spec/models/kiwi/image_spec.rb
@@ -75,6 +75,25 @@ RSpec.describe Kiwi::Image, type: :model, vcr: true do
           replaceable: false,
           username: nil
         )
+        expect(subject.package_groups.first).to have_attributes(
+          kiwi_type: 'image',
+          pattern_type: 'onlyRequired',
+          profiles: nil
+        )
+        expect(subject.package_groups.first.packages.first).to have_attributes(
+          name: 'e2fsprogs',
+          arch: nil,
+          replaces: nil,
+          bootinclude: nil,
+          bootdelete: nil
+        )
+        expect(subject.package_groups.first.packages.last).to have_attributes(
+          name: 'gfxboot-devel',
+          arch: nil,
+          replaces: nil,
+          bootinclude: true,
+          bootdelete: nil
+        )
       end
     end
 

--- a/src/api/spec/models/kiwi/package_group_spec.rb
+++ b/src/api/spec/models/kiwi/package_group_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Kiwi::PackageGroup, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/src/api/spec/models/kiwi/package_spec.rb
+++ b/src/api/spec/models/kiwi/package_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Kiwi::Package, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end


### PR DESCRIPTION
Kiwi package list is now render in the kiwi::Image show page. :bowtie: For that we:

- Added migrations for Kiwi Packages and introduced the needed validations in the models.
- Added Kiwi Image breadcrumb
- Imported also packages in the `Kiwi::Image#import_from_package` method.
- Add packages list for the package groups with `image` type and `onlyRequired` pattern type to the Kiwi::Image show page. (As it is currently done like that in Studio.

The view looks like:

![image](https://user-images.githubusercontent.com/16052290/28171691-8095b8ce-67e9-11e7-87ad-7460e98211b6.png)

The Edit button would be moved down when editing is also available for packages. Feedback about how to improve the view and the information that should render is welcome (although some of the change may be better done in a different PR to avoid making this too big).

Mob-programmed by @DavidKang and @Ana06, and part with @mdeniz too.








