### PR TITLE
[ci] Make LDAP coverage of user model visible

### DIFF
--- a/src/api/spec/support/coverage.rb
+++ b/src/api/spec/support/coverage.rb
@@ -3,7 +3,6 @@ SimpleCov.start 'rails' do
   ENV['CODECOV_FLAG'] = ENV['TEST_SUITE']
   # NOTE: Keep filters in sync with test/test_helper.rb
   add_filter '/app/indices/'
-  add_filter '/app/models/user_ldap_strategy.rb'
   add_filter '/lib/templates/'
   add_filter '/lib/memory_debugger.rb'
   add_filter '/lib/memory_dumper.rb'

--- a/src/api/test/test_helper.rb
+++ b/src/api/test/test_helper.rb
@@ -14,7 +14,6 @@ if ENV['DO_COVERAGE']
   SimpleCov.start 'rails' do
     # NOTE: Keep filters in sync with spec/support/coverage.rb
     add_filter '/app/indices/'
-    add_filter '/app/models/user_ldap_strategy.rb'
     add_filter '/lib/templates/'
     add_filter '/lib/memory_debugger.rb'
     add_filter '/lib/memory_dumper.rb'


### PR DESCRIPTION
This commit removes user_ldap_strategy.rb from the coverage filter list,
which will allow us to see the actual coverage of this file in
codecov.io.