### PR TITLE
[ci] shorten runtime path where test suite runs

### DIFF
--- a/src/api/config/environments/test.rb
+++ b/src/api/config/environments/test.rb
@@ -1,6 +1,7 @@
 # Settings specified here will take precedence over those in config/environment.rb
 
 ENV['CACHENAMESPACE'] ||= "obs-api-test-#{Time.now.to_i}"
+ENV['OBS_BACKEND_TEMP'] ||= Dir.mktmpdir("obsbackend", '/var/tmp')
 
 Rails.application.configure do
   config.active_support.test_order = :sorted # switch to :random ?

--- a/src/api/script/start_test_backend
+++ b/src/api/script/start_test_backend
@@ -2,6 +2,7 @@
 ENV['RAILS_ENV'] ||= 'test'
 ENV['origin_RAILS_ENV'] ||= ENV['RAILS_ENV']
 ENV['LC_ALL'] = 'C'
+backendtempdir = ENV['OBS_BACKEND_TEMP']
 require File.expand_path(File.join(File.dirname(__FILE__), '..', 'config', 'environment'))
 require 'builder'
 
@@ -17,8 +18,8 @@ if ENV['origin_RAILS_ENV'] == 'development'
   port_service_server = 6202
   backend_dir_suffix = "_development"
 end
-backend_config = "#{Rails.root}/tmp/backend_config#{backend_dir_suffix}"
-backend_data   = "#{Rails.root}/tmp/backend_data#{backend_dir_suffix}"
+backend_config = "#{backendtempdir}/config#{backend_dir_suffix}"
+backend_data   = "#{backendtempdir}/data#{backend_dir_suffix}"
 require File.expand_path(File.dirname(__FILE__)) + '/../test/test_helper'
 
 Backend::Connection.do_not_start_test_backend

--- a/src/api/test/functional/backend_test.rb
+++ b/src/api/test/functional/backend_test.rb
@@ -40,7 +40,7 @@ class BackendTests < ActionDispatch::IntegrationTest
       end
 
       # rubocop:disable Metrics/LineLength
-      r = system("cd #{Rails.root}/tmp/backend_config; exec perl #{perlopts} -mXML::Structured -mBSXML -mBSUtil -e \"use XML::Structured ':bytes'; BSUtil::readxml('#{dir}#{f}', \\\$BSXML::#{schema}, 0);\" 2>&1")
+      r = system("cd #{ENV['OBS_BACKEND_TEMP']}/config; exec perl #{perlopts} -mXML::Structured -mBSXML -mBSUtil -e \"use XML::Structured ':bytes'; BSUtil::readxml('#{dir}#{f}', \\\$BSXML::#{schema}, 0);\" 2>&1")
       # rubocop:enable Metrics/LineLength
       assert_equal true, r
     end

--- a/src/api/test/functional/build_controller_test.rb
+++ b/src/api/test/functional/build_controller_test.rb
@@ -179,7 +179,7 @@ class BuildControllerTest < ActionDispatch::IntegrationTest
 
     # find scheduler job and compare it with buildinfo
 # FIXME: to be implemented, compare scheduler job with rep server job
-#   jobfile=File.new("#{Rails.root}/tmp/backend_data/jobs/i586/home:Iggy::10.2::TestPack-#{srcmd5}")
+#   jobfile=File.new("#{ENV['OBS_BACKEND_TEMP']}/data/jobs/i586/home:Iggy::10.2::TestPack-#{srcmd5}")
 #   schedulerjob = Document.new(jobfile).root
 #   schedulerjob.elements.each do |jobnode|
 #     puts "test", jobnode.inspect

--- a/src/api/test/functional/channel_maintenance_test.rb
+++ b/src/api/test/functional/channel_maintenance_test.rb
@@ -703,7 +703,7 @@ class ChannelMaintenanceTests < ActionDispatch::IntegrationTest
     assert_xml_tag tag: 'entry', attributes: { name: 'primary.xml.gz' }
     assert_xml_tag tag: 'entry', attributes: { name: 'repomd.xml' }
     assert_xml_tag tag: 'entry', attributes: { name: 'updateinfo.xml.gz' } # by modifyrepo
-    IO.popen("gunzip -cd #{Rails.root}/tmp/backend_data/repos/BaseDistro3Channel/channel_repo/repodata/updateinfo.xml.gz") do |io|
+    IO.popen("gunzip -cd #{ENV['OBS_BACKEND_TEMP']}/data/repos/BaseDistro3Channel/channel_repo/repodata/updateinfo.xml.gz") do |io|
       node = Xmlhash.parse(io.read)
     end
     assert_equal "UpdateInfoTagNew-patch_name-#{Time.now.year}-1", node['update']['id']

--- a/src/api/test/functional/maintenance_test.rb
+++ b/src/api/test/functional/maintenance_test.rb
@@ -1551,12 +1551,12 @@ class MaintenanceTests < ActionDispatch::IntegrationTest
     assert_xml_tag tag: 'description'
     assert_xml_tag tag: 'mtime'
     hashed = node = nil
-    IO.popen("gunzip -cd #{Rails.root}/tmp/backend_data/repos/BaseDistro2.0:/LinkedUpdateProject/BaseDistro2LinkedUpdateProject_repo/repodata/*-updateinfo.xml.gz") do |io|
+    IO.popen("gunzip -cd #{ENV['OBS_BACKEND_TEMP']}/data/repos/BaseDistro2.0:/LinkedUpdateProject/BaseDistro2LinkedUpdateProject_repo/repodata/*-updateinfo.xml.gz") do |io|
       node = REXML::Document.new( io.read )
     end
     assert_equal "My-oldname-#{Time.now.year}-1", node.elements['/updates/update/id'].first.to_s
     # verify meta data created by createrepo
-    IO.popen("gunzip -cd #{Rails.root}/tmp/backend_data/repos/BaseDistro2.0:/LinkedUpdateProject/BaseDistro2LinkedUpdateProject_repo/repodata/*-primary.xml.gz") do |io|
+    IO.popen("gunzip -cd #{ENV['OBS_BACKEND_TEMP']}/data/repos/BaseDistro2.0:/LinkedUpdateProject/BaseDistro2LinkedUpdateProject_repo/repodata/*-primary.xml.gz") do |io|
       hashed = Xmlhash.parse(io.read)
     end
     pac = nil
@@ -1590,13 +1590,13 @@ class MaintenanceTests < ActionDispatch::IntegrationTest
       puts "WARNING: some tests are skipped on non-SUSE systems. rpmmd meta data may not be complete."
     end
     # file lists
-    IO.popen("gunzip -cd #{Rails.root}/tmp/backend_data/repos/BaseDistro2.0:/LinkedUpdateProject/BaseDistro2LinkedUpdateProject_repo/repodata/*-filelists.xml.gz") do |io|
+    IO.popen("gunzip -cd #{ENV['OBS_BACKEND_TEMP']}/data/repos/BaseDistro2.0:/LinkedUpdateProject/BaseDistro2LinkedUpdateProject_repo/repodata/*-filelists.xml.gz") do |io|
       hashed = Xmlhash.parse(io.read)
     end
     # STDERR.puts JSON.pretty_generate(hashed)
     assert hashed['package'].map{|f| f['file']}.include? '/my_packaged_file'
     # master tags
-    IO.popen("cat #{Rails.root}/tmp/backend_data/repos/BaseDistro2.0:/LinkedUpdateProject/BaseDistro2LinkedUpdateProject_repo/repodata/repomd.xml") do |io|
+    IO.popen("cat #{ENV['OBS_BACKEND_TEMP']}/data/repos/BaseDistro2.0:/LinkedUpdateProject/BaseDistro2LinkedUpdateProject_repo/repodata/repomd.xml") do |io|
       hashed = Xmlhash.parse(io.read)
     end
     found = nil
@@ -2408,7 +2408,7 @@ class MaintenanceTests < ActionDispatch::IntegrationTest
 
   def test_copy_project_for_release_with_history
     # Backup
-    system("for i in #{Rails.root}/tmp/backend_data/projects/BaseDistro.pkg/*.rev; do cp $i $i.backup; done")
+    system("for i in #{ENV['OBS_BACKEND_TEMP']}/data/projects/BaseDistro.pkg/*.rev; do cp $i $i.backup; done")
 
     # store revisions before copy
     login_king
@@ -2468,7 +2468,7 @@ class MaintenanceTests < ActionDispatch::IntegrationTest
     assert_equal 'king', last_revision(copyhistory).value(:user)
 
     # cleanup
-    system("for i in #{Rails.root}/tmp/backend_data/projects/BaseDistro.pkg/*.rev; do mv $i.backup $i; done")
+    system("for i in #{ENV['OBS_BACKEND_TEMP']}/data/projects/BaseDistro.pkg/*.rev; do mv $i.backup $i; done")
     delete '/source/CopyOfBaseDistro'
     assert_response :success
   end
@@ -2490,7 +2490,7 @@ class MaintenanceTests < ActionDispatch::IntegrationTest
 
   def test_copy_project_for_release_using_makeoriginolder
     # Backup
-    system("for i in #{Rails.root}/tmp/backend_data/projects/BaseDistro.pkg/*.rev; do cp $i $i.backup; done")
+    system("for i in #{ENV['OBS_BACKEND_TEMP']}/data/projects/BaseDistro.pkg/*.rev; do cp $i $i.backup; done")
 
     # store revisions before copy
     login_tom
@@ -2551,7 +2551,7 @@ class MaintenanceTests < ActionDispatch::IntegrationTest
     assert_equal 'king', last_revision(copyhistory).value(:user)
 
     # cleanup
-    system("for i in #{Rails.root}/tmp/backend_data/projects/BaseDistro.pkg/*.rev; do mv $i.backup $i; done")
+    system("for i in #{ENV['OBS_BACKEND_TEMP']}/data/projects/BaseDistro.pkg/*.rev; do mv $i.backup $i; done")
     delete '/source/CopyOfBaseDistro'
     assert_response :success
   end

--- a/src/api/test/functional/published_controller_test.rb
+++ b/src/api/test/functional/published_controller_test.rb
@@ -101,7 +101,7 @@ class PublishedControllerTest < ActionDispatch::IntegrationTest
 
     # verify meta data created by create_package_descr
     package_seen = {}
-    IO.popen("gunzip -cd #{Rails.root}/tmp/backend_data/repos/BaseDistro3/BaseDistro3_repo/repodata/*-primary.xml.gz") do |io|
+    IO.popen("gunzip -cd #{ENV['OBS_BACKEND_TEMP']}/data/repos/BaseDistro3/BaseDistro3_repo/repodata/*-primary.xml.gz") do |io|
       hashed = Xmlhash.parse(io.read)
       hashed.elements("package").each do |p|
         next unless (p["name"] == "package" && p["arch"] == "i586") || (p["name"] == "package_newweaktags" && p["arch"] == "x86_64")
@@ -145,7 +145,7 @@ class PublishedControllerTest < ActionDispatch::IntegrationTest
 
     # master tags
     hashed = nil
-    IO.popen("cat #{Rails.root}/tmp/backend_data/repos/BaseDistro3/BaseDistro3_repo/repodata/repomd.xml") do |io|
+    IO.popen("cat #{ENV['OBS_BACKEND_TEMP']}/data/repos/BaseDistro3/BaseDistro3_repo/repodata/repomd.xml") do |io|
       hashed = Xmlhash.parse(io.read)
     end
     if File.exist? '/var/adm/fillup-templates'

--- a/src/api/test/functional/source_controller_test.rb
+++ b/src/api/test/functional/source_controller_test.rb
@@ -4038,7 +4038,7 @@ EOF
     assert_response :success
     before_deltastore = @response.body
 
-    deltastore = "#{Rails.root}/tmp/backend_data/sources/deltapack/deltastore"
+    deltastore = "#{ENV['OBS_BACKEND_TEMP']}/data/sources/deltapack/deltastore"
 
     assert_not File.exist?(deltastore)
     run_deltastore
@@ -4048,7 +4048,7 @@ EOF
     assert_response :success
     assert_equal before_deltastore, @response.body
 
-    assert 0, run_admin("--show-delta-file #{Rails.root}/tmp/backend_data/sources/deltapack/c1b8dd35488695c3c248f0acd447b4d5-archive.obscpio")
+    assert 0, run_admin("--show-delta-file #{ENV['OBS_BACKEND_TEMP']}/data/sources/deltapack/c1b8dd35488695c3c248f0acd447b4d5-archive.obscpio")
 
     delete '/source/home:tom:deltastore'
     assert_response :success

--- a/src/api/test/functional/zzz_post_consistency_test.rb
+++ b/src/api/test/functional/zzz_post_consistency_test.rb
@@ -38,7 +38,7 @@ class ZZZPostConsistency < ActionDispatch::IntegrationTest
     progress = nil
     failed = nil
     # rubocop:disable Metrics/LineLength
-    IO.popen("cd #{Rails.root}/tmp/backend_config; exec perl #{perlopts} ./bs_check_consistency --check-all --do-check-meta --do-check-signatures 2>&1") do |io|
+    IO.popen("cd #{ENV['OBS_BACKEND_TEMP']}/config; exec perl #{perlopts} ./bs_check_consistency --check-all --do-check-meta --do-check-signatures 2>&1") do |io|
       io.each do |line|
 #        puts ">#{line}<"
         next if line.blank?

--- a/src/api/test/test_helper.rb
+++ b/src/api/test/test_helper.rb
@@ -77,7 +77,7 @@ def backend_config
   if ENV['origin_RAILS_ENV'] == 'development'
     backend_dir_suffix = "_development"
   end
-  "#{Rails.root}/tmp/backend_config#{backend_dir_suffix}"
+  "#{ENV['OBS_BACKEND_TEMP']}/config#{backend_dir_suffix}"
 end
 
 def backend_data
@@ -85,7 +85,7 @@ def backend_data
   if ENV['origin_RAILS_ENV'] == 'development'
     backend_dir_suffix = "_development"
   end
-  "#{Rails.root}/tmp/backend_data#{backend_dir_suffix}"
+  "#{ENV['OBS_BACKEND_TEMP']}/data#{backend_dir_suffix}"
 end
 
 def inject_build_job(project, package, repo, arch, extrabinary = nil)


### PR DESCRIPTION
Will allow us to enable commit hash to packages again, since it does not make the path to deep.

(Backend AJAX server would not work since it can't reach the unix domain sockets otherwise)