### PR TITLE
[api] hotfix maintenance incident processing

### DIFF
--- a/src/api/app/models/channel.rb
+++ b/src/api/app/models/channel.rb
@@ -143,6 +143,10 @@ class Channel < ApplicationRecord
     tpkg.branch_from(cp.project.name, cp.name, nil, nil, comment)
     tpkg.sources_changed(wait_for_update: true)
 
+    # rubocop:disable Rails/SkipsModelValidations
+    project.touch
+    # rubocop:enable Rails/SkipsModelValidations
+
     tpkg
   end
 


### PR DESCRIPTION
Fixes a crash when packages gets referenced mutiple times

It might be better to touch the project in Package.store, when
it creates a new instance. But I wanted to have something as small
as possible due to time pressure.