### PR TITLE
Revert "[api] hotfix maintenance incident processing"

### DIFF
--- a/src/api/app/models/channel.rb
+++ b/src/api/app/models/channel.rb
@@ -143,10 +143,6 @@ class Channel < ApplicationRecord
     tpkg.branch_from(cp.project.name, cp.name, nil, nil, comment)
     tpkg.sources_changed(wait_for_update: true)
 
-    # rubocop:disable Rails/SkipsModelValidations
-    project.touch
-    # rubocop:enable Rails/SkipsModelValidations
-
     tpkg
   end
 


### PR DESCRIPTION
This reverts commit ee697db8041addb82b34b5e8826b94d99b05ee04.

This wasn't actually applied on our instance and doesn't seem to be
needed.