### PR TITLE
[api] make jobs which call Package#update_if_dirty run in the default queue

### DIFF
--- a/src/api/app/jobs/update_backend_infos.rb
+++ b/src/api/app/jobs/update_backend_infos.rb
@@ -7,6 +7,11 @@ class UpdateBackendInfos < CreateJob
     self.checked_pkgs = {}
   end
 
+  # NOTE: Its important that this job run in queue 'default' in order to avoid concurrency
+  def self.job_queue
+    'default'
+  end
+
   def perform
     payload = event.payload
     package = Package.find_by_project_and_name(payload['project'], payload['package'])

--- a/src/api/app/jobs/update_package_meta_job.rb
+++ b/src/api/app/jobs/update_package_meta_job.rb
@@ -1,4 +1,7 @@
 class UpdatePackageMetaJob < ApplicationJob
+  # NOTE: Its important that this job run in queue 'default' in order to avoid concurrency
+  queue_as :default
+
   def scan_links
     names = Package.distinct.order(:name).pluck(:name)
     while !names.empty?

--- a/src/api/app/models/package.rb
+++ b/src/api/app/models/package.rb
@@ -456,7 +456,8 @@ class Package < ApplicationRecord
     else
       retries = 10
       begin
-        delay.update_if_dirty
+        # NOTE: Its important that this job run in queue 'default' in order to avoid concurrency
+        delay(queue: 'default').update_if_dirty
       rescue ActiveRecord::StatementInvalid
         # mysql lock errors in delayed job handling... we need to retry
         retries -= 1


### PR DESCRIPTION
In order to avoid them running concurrently. This a first step to fixing the mysql deadlock errors that occur for packages.