### PR TITLE
Edit kiwi image packages & nice UI for kiwi image

### DIFF
--- a/src/api/app/assets/stylesheets/webui/application/kiwi_image.scss
+++ b/src/api/app/assets/stylesheets/webui/application/kiwi_image.scss
@@ -52,3 +52,8 @@
 .kiwi_packages_table {
   width: 98%
 }
+
+.package_group_table {
+  width: 910px;
+  text-align: center;
+}

--- a/src/api/app/assets/stylesheets/webui/application/kiwi_image.scss
+++ b/src/api/app/assets/stylesheets/webui/application/kiwi_image.scss
@@ -45,7 +45,7 @@
   }
 }
 
-#kiwi_repository_update_form_save {
+#kiwi_image_update_form_save {
   margin-left: 1em;
 }
 

--- a/src/api/app/assets/stylesheets/webui/application/kiwi_image.scss
+++ b/src/api/app/assets/stylesheets/webui/application/kiwi_image.scss
@@ -45,7 +45,7 @@
   }
 }
 
-#kiwi_image_update_form_save {
+#kiwi-image-update-form-save {
   margin-left: 1em;
 }
 

--- a/src/api/app/controllers/webui/kiwi/images_controller.rb
+++ b/src/api/app/controllers/webui/kiwi/images_controller.rb
@@ -43,7 +43,7 @@ module Webui
         end
         redirect_to action: :show
       rescue ActiveRecord::RecordInvalid, Timeout::Error => e
-        flash[:error] = "Cannot update repositories for kiwi image: #{@image.errors.full_messages.to_sentence} #{e.message}"
+        flash[:error] = "Cannot update kiwi image: #{@image.errors.full_messages.to_sentence} #{e.message}"
         redirect_back(fallback_location: root_path)
       end
 

--- a/src/api/app/controllers/webui/kiwi/images_controller.rb
+++ b/src/api/app/controllers/webui/kiwi/images_controller.rb
@@ -50,9 +50,29 @@ module Webui
       private
 
       def image_params
-        params.require(:kiwi_image).permit(repositories_attributes:
-                                      [:id, :priority, :repo_type, :source_path, :alias,
-                                       :username, :password, :prefer_license, :imageinclude, :replaceable])
+        repositories_attributes = [
+          :id,
+          :priority,
+          :repo_type,
+          :source_path,
+          :alias,
+          :username,
+          :password,
+          :prefer_license,
+          :imageinclude,
+          :replaceable
+        ]
+
+        package_groups_attributes = [
+          :id,
+          :_destroy,
+          packages_attributes: [:id, :name, :arch, :replaces, :bootdelete, :bootinclude, :_destroy]
+        ]
+
+        params.require(:kiwi_image).permit(
+          repositories_attributes: repositories_attributes,
+          package_groups_attributes: package_groups_attributes
+        )
       end
 
       def set_image

--- a/src/api/app/models/kiwi/image.rb
+++ b/src/api/app/models/kiwi/image.rb
@@ -24,7 +24,7 @@ class Kiwi::Image < ApplicationRecord
   has_many :repositories, -> { order(order: :asc) }, dependent: :destroy, index_errors: true
   has_many :package_groups, -> { order(:id) }, dependent: :destroy, index_errors: true
   has_many :kiwi_packages, -> { where(kiwi_package_groups: { kiwi_type: Kiwi::PackageGroup.kiwi_types[:image], pattern_type: 'onlyRequired' }) },
-           through: :package_groups, source: :packages
+           through: :package_groups, source: :packages, inverse_of: :kiwi_image
 
   #### Callbacks macros: before_save, after_save, etc.
 
@@ -33,6 +33,8 @@ class Kiwi::Image < ApplicationRecord
   #### Validations macros
   validates :name, presence: true
   accepts_nested_attributes_for :repositories
+  accepts_nested_attributes_for :package_groups, allow_destroy: true
+  accepts_nested_attributes_for :kiwi_packages, allow_destroy: true
 
   #### Class methods using self. (public and then private)
 

--- a/src/api/app/models/kiwi/package.rb
+++ b/src/api/app/models/kiwi/package.rb
@@ -1,5 +1,6 @@
 class Kiwi::Package < ApplicationRecord
   belongs_to :package_group
+  has_one :kiwi_image, through: :package_groups
 
   validates :name, presence: true
 end

--- a/src/api/app/models/kiwi/package_group.rb
+++ b/src/api/app/models/kiwi/package_group.rb
@@ -7,6 +7,8 @@ class Kiwi::PackageGroup < ApplicationRecord
   enum kiwi_type: %i[bootstrap delete docker image iso lxc oem pxe split testsuite vmx], _prefix: :type
 
   validates :kiwi_type, presence: true, inclusion: { in: kiwi_types.keys }
+
+  accepts_nested_attributes_for :packages, reject_if: :all_blank, allow_destroy: true
 end
 
 # == Schema Information

--- a/src/api/app/views/webui/kiwi/images/_package_fields.html.haml
+++ b/src/api/app/views/webui/kiwi/images/_package_fields.html.haml
@@ -1,0 +1,7 @@
+%tr.nested-fields
+  %td= link_to_remove_association "Remove", f
+  %td= f.text_field :name
+  %td= f.text_field :arch
+  %td= f.text_field :replaces
+  %td= f.check_box :bootinclude
+  %td= f.check_box :bootdelete

--- a/src/api/app/views/webui/kiwi/images/edit.html.haml
+++ b/src/api/app/views/webui/kiwi/images/edit.html.haml
@@ -1,19 +1,50 @@
-= render partial: 'webui/kiwi/tabs'
-
-%h2
-  = @image.name
+- @layouttype = 'custom'
 
 = form_for @image, html: { id: 'kiwi_image_update_form' } do |f|
 
-  %h3 Repositories
-  - if @image.repositories.empty?
-    %p There are no repositories.
-  - else
-    %div
-      = f.fields_for :repositories do |repository_fields|
-        = render 'repository_fields', f: repository_fields
+  .grid_16.alpha.omega.box.box-shadow
+    = render partial: 'webui/kiwi/tabs'
+    %h2
+      = @image.name
+    %ul.horizontal-list
+      %li
+        = button_tag('Save', id: 'kiwi_image_update_form_save', type: 'button', disabled: true)
 
-  = button_tag('Save', id: 'kiwi_image_update_form_save', type: 'button', disabled: true)
+  .grid_16.alpha.omega.box.box-shadow
+    %h3 Repositories
+    - if @image.repositories.empty?
+      %p There are no repositories.
+    - else
+      %div
+        = f.fields_for :repositories do |repository_fields|
+          = render 'repository_fields', f: repository_fields
+
+  .grid_16.alpha.omega.box.box-shadow
+    %h3 Packages
+    - if @image.kiwi_packages.empty?
+      %p There are no packages.
+    - else
+      %div
+        = f.fields_for :package_groups do |package_group_fields|
+          %h6
+            = package_group_fields.object.kiwi_type
+            = package_group_fields.object.profiles
+            = package_group_fields.object.pattern_type
+          %table.package_group_table
+            %thead
+              %tr
+                %th Action
+                %th Name
+                %th Arch
+                %th Replaces
+                %th bootinclude
+                %th bootdelete
+            %tbody
+              = package_group_fields.fields_for :packages do |kiwi_package_fields|
+                = render 'package_fields', f: kiwi_package_fields
+          %p
+            = link_to_add_association 'Add package', package_group_fields, :packages, data: {"association-insertion-node" => "tbody", "association-insertion-method" => "append"}
+
 
 :javascript
   function save_image() {

--- a/src/api/app/views/webui/kiwi/images/edit.html.haml
+++ b/src/api/app/views/webui/kiwi/images/edit.html.haml
@@ -1,6 +1,6 @@
 - @layouttype = 'custom'
 
-= form_for @image, html: { id: 'kiwi_image_update_form' } do |f|
+= form_for @image, html: { id: 'kiwi-image-update-form' } do |f|
 
   .grid_16.alpha.omega.box.box-shadow
     = render partial: 'webui/kiwi/tabs'
@@ -8,7 +8,7 @@
       = @image.name
     %ul.horizontal-list
       %li
-        = button_tag('Save', id: 'kiwi_image_update_form_save', type: 'button', disabled: true)
+        = button_tag('Save', id: 'kiwi-image-update-form-save', type: 'button', disabled: true)
 
   .grid_16.alpha.omega.box.box-shadow
     %h3 Repositories
@@ -54,13 +54,13 @@
         var is_outdated = json['is_outdated'];
         if (is_outdated && !confirm("This image has been modified while you were editing it.\nDo you want to apply the changes anyway?"))
           return;
-        $('#kiwi_image_update_form').submit();
+        $('#kiwi-image-update-form').submit();
       }
     });
   }
 
-  $('#kiwi_image_update_form_save').click(save_image);
+  $('#kiwi-image-update-form-save').click(save_image);
 
-  $('#kiwi_image_update_form').change(function() {
-    $(this).find('#kiwi_image_update_form_save').prop('disabled', false);
+  $('#kiwi-image-update-form').change(function() {
+    $(this).find('#kiwi-image-update-form-save').prop('disabled', false);
   });

--- a/src/api/app/views/webui/kiwi/images/edit.html.haml
+++ b/src/api/app/views/webui/kiwi/images/edit.html.haml
@@ -2,31 +2,34 @@
 
 %h2
   = @image.name
-%h3 Repositories
-- if @image.repositories.empty?
-  %p There are no repositories.
-- else
-  %div
-    = form_for @image, html: { id: 'kiwi_repository_update_form' } do |f|
+
+= form_for @image, html: { id: 'kiwi_image_update_form' } do |f|
+
+  %h3 Repositories
+  - if @image.repositories.empty?
+    %p There are no repositories.
+  - else
+    %div
       = f.fields_for :repositories do |repository_fields|
         = render 'repository_fields', f: repository_fields
-      = button_tag('Save', id: 'kiwi_repository_update_form_save', type: 'button', disabled: true)
+
+  = button_tag('Save', id: 'kiwi_image_update_form_save', type: 'button', disabled: true)
 
 :javascript
-  function save_repositories() {
+  function save_image() {
     $.ajax({ url: "#{url_for(controller: 'kiwi/images', action: :show, id: @image)}",
       dataType: 'json',
       success: function(json) {
         var is_outdated = json['is_outdated'];
-        if (is_outdated && !confirm("These repositories have been modified while you were editing them.\nDo you want to apply the changes anyway?"))
+        if (is_outdated && !confirm("This image has been modified while you were editing it.\nDo you want to apply the changes anyway?"))
           return;
-        $('#kiwi_repository_update_form').submit();
+        $('#kiwi_image_update_form').submit();
       }
     });
   }
 
-  $('#kiwi_repository_update_form_save').click(save_repositories);
+  $('#kiwi_image_update_form_save').click(save_image);
 
-  $('#kiwi_repository_update_form').change(function() {
-    $(this).find('#kiwi_repository_update_form_save').prop('disabled', false);
+  $('#kiwi_image_update_form').change(function() {
+    $(this).find('#kiwi_image_update_form_save').prop('disabled', false);
   });

--- a/src/api/app/views/webui/kiwi/images/show.html.haml
+++ b/src/api/app/views/webui/kiwi/images/show.html.haml
@@ -1,20 +1,27 @@
-= render partial: 'webui/kiwi/tabs'
+- @layouttype = 'custom'
 
-%h2
-  = @image.name
-%h3 Repositories
-- if @image.repositories.empty?
-  %p There are no repositories.
-- else
-  %ul
-    - @image.repositories.each do |repository|
-      = render partial: 'repository_entry', locals: {repository: repository}
-    = button_to('Edit', edit_kiwi_image_path(@image), method: :get)
+.grid_16.alpha.omega.box.box-shadow
+  = render partial: 'webui/kiwi/tabs'
+  %h2
+    = @image.name
+  %ul.horizontal-list
+    %li
+      = link_to(sprited_text('brick_edit', 'Edit image'), edit_kiwi_image_path(@image))
 
-%h3 Packages
-- if @image.kiwi_packages.empty?
-  %p There are no packages.
-- else
-  %p
-    %strong
-      = @image.kiwi_packages.pluck(:name).join(', ')
+.grid_16.alpha.omega.box.box-shadow
+  %h3 Repositories
+  - if @image.repositories.empty?
+    %p There are no repositories.
+  - else
+    %ul
+      - @image.repositories.each do |repository|
+        = render partial: 'repository_entry', locals: {repository: repository}
+
+.grid_16.alpha.omega.box.box-shadow
+  %h3 Packages
+  - if @image.kiwi_packages.empty?
+    %p There are no packages.
+  - else
+    %p
+      %strong
+        = @image.kiwi_packages.pluck(:name).join(', ')

--- a/src/api/spec/controllers/webui/kiwi/images_controller_spec.rb
+++ b/src/api/spec/controllers/webui/kiwi/images_controller_spec.rb
@@ -106,7 +106,7 @@ RSpec.describe Webui::Kiwi::ImagesController, type: :controller, vcr: true do
 
       it do
         expect(subject.request.flash[:error]).to(
-          start_with('Cannot update repositories for kiwi image: Repositories[0] repo type is not included in the list')
+          start_with('Cannot update kiwi image: Repositories[0] repo type is not included in the list')
         )
       end
       it { expect(subject).to redirect_to(root_path) }


### PR DESCRIPTION
Allow to edit the attributes of kiwi image packages, as well as removing them and adding new packages.  

Make the show/edit page UI nice and consistent with the rest of OBS: :bowtie: 

### Show page

![image](https://user-images.githubusercontent.com/16052290/28374066-f22010f2-6ca3-11e7-976b-15e53dc16518.png)


### Edit page

![image](https://user-images.githubusercontent.com/16052290/28374193-4fa49810-6ca4-11e7-8c1a-1a3ee875c46b.png)

![image](https://user-images.githubusercontent.com/16052290/28374140-28ccc53c-6ca4-11e7-89c6-dc9dbd545534.png)


**DISCUSSION:** Currently in the show page only the packages from a section with `image` type and `onlyRequired` patternType are shown (as in SUSE Studio). However in the edit package there is a table for each section and all of them can be edited. We thought that it was fine like that, but maybe there are different opinions.

Things missed that **will be done in another PR** as they are not indispensable for this feature and will make this PR to big and difficult to review:

- Save button is not activated when removing a package.
- The breadcrumb need to be improved


Mob-programmed by @DavidKang, @mdeniz and @Ana06.


