### PR TITLE
[ci] Fix openQA specs

### DIFF
--- a/dist/t/spec/features/0040_package_spec.rb
+++ b/dist/t/spec/features/0040_package_spec.rb
@@ -43,7 +43,7 @@ RSpec.describe "Package" do
       click_link('Home Project')
     end
     click_link('Branch existing package')
-    fill_in 'linked_project', with: 'openSUSE.org:OBS:Server:Unstable'
+    fill_in 'linked_project', with: 'openSUSE.org:openSUSE:Tools'
     fill_in 'linked_package', with: 'build'
     # Do not wait for autocomplete
     page.execute_script("$('input[type=\"submit\"]').prop('disabled', false)")


### PR DESCRIPTION
* Branch from openSUSE.org:openSUSE:Tools/build instead from O:S:U as the package is broken and resulted in a 500