### PR TITLE
[webui] Rever fix file download button

### DIFF
--- a/src/api/app/views/webui/package/_files_view.html.erb
+++ b/src/api/app/views/webui/package/_files_view.html.erb
@@ -24,7 +24,7 @@
             </td>
             <!-- limit download for anonymous user to avoid getting killed by crawlers -->
             <td><%= if !User.current.is_nobody? || file[:size].to_i < (4 * 1024 * 1024)
-                      link_to sprite_tag('page_white_put', title: 'Download File'),
+                      link_to sprite_tag('page_white_get', title: 'Download File'),
                               file_url(@project.name, @package.name, file[:name], file[:srcmd5])
                     end %>
               <% unless file[:name] =~ /^_service:/ %>

--- a/src/api/script/update_bento.sh
+++ b/src/api/script/update_bento.sh
@@ -76,7 +76,7 @@ copy $themedir/bento/images/icons/page_refresh.png ./app/assets/icons/page_refre
 copy $themedir/bento/images/icons/page_save.png ./app/assets/icons/page_save.png
 copy $themedir/bento/images/icons/page_white_add.png ./app/assets/icons/page_white_add.png
 copy $themedir/bento/images/icons/page_white_delete.png ./app/assets/icons/page_white_delete.png
-copy $themedir/bento/images/icons/page_white_put.png ./app/assets/icons/page_white_put.png
+copy $themedir/bento/images/icons/page_white_get.png ./app/assets/icons/page_white_get.png
 copy $themedir/bento/images/icons/plugin_add.png ./app/assets/icons/plugin_add.png
 copy $themedir/bento/images/icons/script.png ./app/assets/icons/script.png
 copy $themedir/bento/images/icons/script_lightning.png ./app/assets/icons/script_lightning.png


### PR DESCRIPTION
This reverts commit a0a24d0467dd429a07fd38ddf0f26b164e8fc3d1.
The icons.scss gets generated, manually renaming icons has no effect.
Fixes #3431.