### PR TITLE
[ci] Migrate ldap tests to rspec

### DIFF
--- a/src/api/app/models/user_ldap_strategy.rb
+++ b/src/api/app/models/user_ldap_strategy.rb
@@ -162,9 +162,9 @@ class UserLdapStrategy
     ldap_password = entry[CONFIG['ldap_auth_attr']][0]
 
     case CONFIG['ldap_auth_mech']
-    when :cleartext then
+    when :cleartext
       ldap_password == password
-    when :md5 then
+    when :md5
       ldap_password == "{MD5}" + Base64.encode64(Digest::MD5.digest(password))
     else
       Rails.logger.error("Unknown ldap_auth_mech setting: #{CONFIG['ldap_auth_mech']}")

--- a/src/api/app/models/user_ldap_strategy.rb
+++ b/src/api/app/models/user_ldap_strategy.rb
@@ -159,23 +159,18 @@ class UserLdapStrategy
       return false
     end
 
-    authenticated = false
     ldap_password = entry[CONFIG['ldap_auth_attr']][0]
 
     case CONFIG['ldap_auth_mech']
     when :cleartext then
-      if ldap_password == password
-        authenticated = true
-      end
+      ldap_password == password
     when :md5 then
-      if ldap_password == "{MD5}" + Base64.encode64(Digest::MD5.digest(password))
-        authenticated = true
-      end
+      ldap_password == "{MD5}" + Base64.encode64(Digest::MD5.digest(password))
     else
       Rails.logger.error("Unknown ldap_auth_mech setting: #{CONFIG['ldap_auth_mech']}")
-    end
 
-    authenticated
+      false
+    end
   end
 
   # convert distinguished name to user principal name

--- a/src/api/test/unit/user_ldap_strategy_test.rb
+++ b/src/api/test/unit/user_ldap_strategy_test.rb
@@ -5,7 +5,7 @@ class UserLdapStrategyTest < ActiveSupport::TestCase
     # Rails.logger = Logger.new(STDOUT)
   end
 
-  def test_authenticate_with_local
+  def test_authenticate_with_local # spec/models/user_ldap_strategy_spec.rb
     a = UserLdapStrategy.authenticate_with_local("", {})
     assert a == false
 
@@ -36,7 +36,7 @@ class UserLdapStrategyTest < ActiveSupport::TestCase
     assert a == true
   end
 
-  def test_dn2user_principal_name
+  def test_dn2user_principal_name # spec/models/user_ldap_strategy_spec.rb
     a = UserLdapStrategy.dn2user_principal_name(["uid=jdoe", "ou=People", "dc=opensuse", "dc=org"])
     assert a == "jdoe@opensuse.org"
 


### PR DESCRIPTION
Migrates ldap user strategy tests from our old test suite to the new
rspec based test suite.