### PR TITLE
[webui] Fix image templates page in Chrome

### DIFF
--- a/src/api/app/assets/stylesheets/webui/application/image_templates.sass
+++ b/src/api/app/assets/stylesheets/webui/application/image_templates.sass
@@ -67,6 +67,7 @@ dl.templateslist
         padding-bottom: 1px
 
       .description
+        margin-top: 1px
         color: #888a85
         font-size: 0.8em
         line-height: 1.4em


### PR DESCRIPTION
In https://github.com/openSUSE/open-build-service/pull/2380 this page was improved, but seems that it was not tested in Chrome. With this small changes it is properly rendered in Chrome and Firefox. :bowtie: 

## Before

#### Chrome (where the problem was)

![image](https://user-images.githubusercontent.com/16052290/28664892-30297d7e-72c2-11e7-9837-82a1138e4840.png)

#### Firefox
![image](https://user-images.githubusercontent.com/16052290/28664907-3c68d436-72c2-11e7-8358-b232f3944858.png)


## After

#### Chrome

![image](https://user-images.githubusercontent.com/16052290/28664933-4fd8b306-72c2-11e7-86ed-6fc81b214387.png)

#### Firefox

![image](https://user-images.githubusercontent.com/16052290/28664952-5d1cea64-72c2-11e7-99e2-5d7c9a0aab0e.png)
