### PR TITLE
[api] Configuration#delayed_write_to_backend now uses ActiveJob

### DIFF
--- a/src/api/app/jobs/configuration_write_to_backend_job.rb
+++ b/src/api/app/jobs/configuration_write_to_backend_job.rb
@@ -1,0 +1,5 @@
+class ConfigurationWriteToBackendJob < ApplicationJob
+  def perform(configuration_id)
+    Configuration.find(configuration_id).write_to_backend
+  end
+end

--- a/src/api/app/models/configuration.rb
+++ b/src/api/app/models/configuration.rb
@@ -96,7 +96,7 @@ class Configuration < ApplicationRecord
   # the database or in migrations when there is no backend
   # running
   def delayed_write_to_backend
-    delay.write_to_backend
+    ConfigurationWriteToBackendJob.perform_later(id)
   end
 
   def write_to_backend

--- a/src/api/spec/jobs/configuration_write_to_backend_job_spec.rb
+++ b/src/api/spec/jobs/configuration_write_to_backend_job_spec.rb
@@ -1,0 +1,25 @@
+require 'rails_helper'
+
+# WARNING: If you change tests make sure you uncomment this line
+# and start a test backend. Some of the actions
+# require real backend answers for projects/packages.
+# CONFIG['global_write_through'] = true
+
+RSpec.describe ConfigurationWriteToBackendJob, type: :job, vcr: true do
+  include ActiveJob::TestHelper
+
+  describe '#perform' do
+    let!(:configuration) { create(:configuration) }
+
+    before do
+      allow(Configuration).to receive(:find).and_return(configuration)
+      allow(configuration).to receive(:write_to_backend)
+    end
+
+    subject! { ConfigurationWriteToBackendJob.new.perform(configuration.id) }
+
+    it 'writes to the backend' do
+      expect(configuration).to have_received(:write_to_backend)
+    end
+  end
+end

--- a/src/api/spec/models/configuration_spec.rb
+++ b/src/api/spec/models/configuration_spec.rb
@@ -18,4 +18,14 @@ RSpec.describe Configuration do
     Configuration.title
     expect(Configuration.count).to eq(1)
   end
+
+  describe '#delayed_write_to_backend' do
+    let(:configuration) { create(:configuration) }
+
+    subject { configuration.delayed_write_to_backend }
+
+    it 'queues a job to write to the backend' do
+      expect { subject }.to have_enqueued_job(ConfigurationWriteToBackendJob).with(configuration.id)
+    end
+  end
 end


### PR DESCRIPTION
Part of this card: https://trello.com/c/Tx9d3bUb/467-5-p4-event-system-change-delayed-jobs-to-be-created-with-activejobs