### PR TITLE
[api] StatusHistoryRescaler now uses ActiveJob

### DIFF
--- a/src/api/app/jobs/status_history_rescaler_job.rb
+++ b/src/api/app/jobs/status_history_rescaler_job.rb
@@ -1,6 +1,6 @@
-class StatusHistoryRescaler
+class StatusHistoryRescalerJob < ApplicationJob
   # this is called from a delayed job triggered by clockwork
-  def rescale
+  def perform
     maxtime = StatusHistory.maximum(:time)
     if maxtime
       StatusHistory.where("time < ?", maxtime - 365 * 24 * 3600).delete_all
@@ -43,7 +43,7 @@ class StatusHistoryRescaler
 
     curmintime = StatusHistory.minimum(:time)
 
-    while !allitems.empty?
+    until allitems.empty?
       items = find_start_items(allitems, curmintime + offset)
 
       if items.length > 1

--- a/src/api/config/clock.rb
+++ b/src/api/config/clock.rb
@@ -22,7 +22,7 @@ module Clockwork
   end
 
   every(49.minutes, 'rescale history') do
-    StatusHistoryRescaler.new.delay.rescale
+    StatusHistoryRescalerJob.perform_later
   end
 
   every(1.day, 'optimize history', thread: true) do

--- a/src/api/spec/jobs/status_history_rescaler_job_spec.rb
+++ b/src/api/spec/jobs/status_history_rescaler_job_spec.rb
@@ -1,0 +1,34 @@
+require 'rails_helper'
+
+RSpec.describe StatusHistoryRescalerJob, type: :job do
+  include ActiveJob::TestHelper
+
+  describe '#rescale' do
+    before do
+      Timecop.freeze(2010, 7, 12)
+
+      now = Time.now.to_i - 2.days
+      StatusHistory.transaction do
+        1000.times do |i|
+          StatusHistory.create time: now + i, key: 'idle_x86_64', value: i
+        end
+      end
+
+      StatusHistory.create time: Time.now.to_i, key: 'busy_x86_64', value: 100
+    end
+
+    after do
+      Timecop.return
+    end
+
+    subject! { StatusHistoryRescalerJob.new.perform }
+
+    it { expect(StatusHistory.count).to eq(2) }
+
+    it 'keeps the StatusHistory with key = idle_x86_64' do
+      status_histories = StatusHistory.where(key: 'idle_x86_64')
+      expect(status_histories.count).to eq(1)
+      expect(status_histories.first.value).to eq(499.5)
+    end
+  end
+end

--- a/src/api/test/models/status_history_test.rb
+++ b/src/api/test/models/status_history_test.rb
@@ -9,27 +9,6 @@ class StatusHistoryTest < ActiveSupport::TestCase
     Timecop.return
   end
 
-  test "rescale" do
-    Timecop.freeze(2010, 7, 12) do
-      now = Time.now.to_i - 2.days
-      StatusHistory.transaction do
-        1000.times do |i|
-          StatusHistory.create time: now + i, key: 'idle_x86_64', value: i
-        end
-      end
-
-      StatusHistory.create time: Time.now.to_i, key: 'busy_x86_64', value: 100
-
-      assert_equal 1001, StatusHistory.count
-      StatusHistoryRescaler.new.rescale
-      assert_equal 2, StatusHistory.count
-
-      rel = StatusHistory.where(key: 'idle_x86_64')
-      assert_equal 1, rel.count
-      assert_equal 499.5, rel.first.value
-    end
-  end
-
   test "history_by_key_and_hours" do
     Timecop.freeze(2010, 7, 12) do
       day_before_yesterday = Time.now.to_i - 2.days


### PR DESCRIPTION
Part of this card: https://trello.com/c/Tx9d3bUb/467-5-p4-event-system-change-delayed-jobs-to-be-created-with-activejobs