### PR TITLE
[api][webui] use the inline adapter for active job in test env

### DIFF
--- a/src/api/config/environments/test.rb
+++ b/src/api/config/environments/test.rb
@@ -62,7 +62,7 @@ OBSApi::Application.configure do
   # TODO: This shouldn't be needed when we switch to RSpec completely
   config.action_dispatch.rescue_responses['ActionController::InvalidAuthenticityToken'] = 950
 
-  config.active_job.queue_adapter = :test
+  config.active_job.queue_adapter = :inline
 end
 
 CONFIG['source_host'] = "localhost"

--- a/src/api/spec/cassettes/BackendPackage/_refresh_dirty/1_1_1.yml
+++ b/src/api/spec/cassettes/BackendPackage/_refresh_dirty/1_1_1.yml
@@ -107,4 +107,577 @@ http_interactions:
         </status>
     http_version: 
   recorded_at: Tue, 25 Jul 2017 12:21:00 GMT
+- request:
+    method: put
+    uri: http://localhost:3200/source/project_1/_meta
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="project_1">
+          <title>No Country for Old Men</title>
+          <description/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '108'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="project_1">
+          <title>No Country for Old Men</title>
+          <description></description>
+        </project>
+    http_version: 
+  recorded_at: Mon, 31 Jul 2017 16:18:32 GMT
+- request:
+    method: put
+    uri: http://localhost:3200/source/project_1/_config
+    body:
+      encoding: UTF-8
+      string: Ipsa corporis ducimus non. Fuga hic quisquam vitae nam nihil. Velit
+        qui dignissimos. Incidunt provident aut et.
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '21'
+    body:
+      encoding: UTF-8
+      string: '<status code="ok" />
+
+'
+    http_version: 
+  recorded_at: Mon, 31 Jul 2017 16:18:32 GMT
+- request:
+    method: put
+    uri: http://localhost:3200/source/project_1/package_1/_meta?user=_nobody_
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="package_1" project="project_1">
+          <title>Bury My Heart at Wounded Knee</title>
+          <description>Assumenda delectus consequuntur qui.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '171'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="package_1" project="project_1">
+          <title>Bury My Heart at Wounded Knee</title>
+          <description>Assumenda delectus consequuntur qui.</description>
+        </package>
+    http_version: 
+  recorded_at: Mon, 31 Jul 2017 16:18:32 GMT
+- request:
+    method: put
+    uri: http://localhost:3200/source/project_1/package_1/_meta
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="package_1" project="project_1">
+          <title>Bury My Heart at Wounded Knee</title>
+          <description>Assumenda delectus consequuntur qui.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '171'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="package_1" project="project_1">
+          <title>Bury My Heart at Wounded Knee</title>
+          <description>Assumenda delectus consequuntur qui.</description>
+        </package>
+    http_version: 
+  recorded_at: Mon, 31 Jul 2017 16:18:33 GMT
+- request:
+    method: put
+    uri: http://localhost:3200/source/project_1/package_1/_config
+    body:
+      encoding: UTF-8
+      string: Voluptatem vel rerum in atque. Rem omnis repellat assumenda. Quaerat
+        amet dicta ad omnis similique. Mollitia magnam nesciunt soluta. Rerum aut
+        sit necessitatibus laudantium.
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '207'
+    body:
+      encoding: UTF-8
+      string: |
+        <revision rev="1" vrev="1">
+          <srcmd5>5c441aa727e4257f441dd2646598fb20</srcmd5>
+          <version>unknown</version>
+          <time>1501517913</time>
+          <user>unknown</user>
+          <comment></comment>
+          <requestid/>
+        </revision>
+    http_version: 
+  recorded_at: Mon, 31 Jul 2017 16:18:33 GMT
+- request:
+    method: put
+    uri: http://localhost:3200/source/project_1/package_1/somefile.txt
+    body:
+      encoding: UTF-8
+      string: Veniam ducimus eligendi ad eos voluptatem. Ipsa dolorem blanditiis.
+        Accusantium molestiae hic reiciendis placeat rerum. Maxime quos odio voluptas
+        aut sed placeat. Blanditiis recusandae qui ut dolorum nostrum.
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '207'
+    body:
+      encoding: UTF-8
+      string: |
+        <revision rev="2" vrev="2">
+          <srcmd5>3e9979d77fe5634be73f9f223b639e27</srcmd5>
+          <version>unknown</version>
+          <time>1501517913</time>
+          <user>unknown</user>
+          <comment></comment>
+          <requestid/>
+        </revision>
+    http_version: 
+  recorded_at: Mon, 31 Jul 2017 16:18:33 GMT
+- request:
+    method: put
+    uri: http://localhost:3200/source/apache/_meta
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="apache">
+          <title>Absalom, Absalom!</title>
+          <description/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '100'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="apache">
+          <title>Absalom, Absalom!</title>
+          <description></description>
+        </project>
+    http_version: 
+  recorded_at: Tue, 01 Aug 2017 08:14:38 GMT
+- request:
+    method: put
+    uri: http://localhost:3200/source/apache/_config
+    body:
+      encoding: UTF-8
+      string: Omnis officiis est enim aut possimus nostrum. Reprehenderit fugiat quo
+        quaerat. Quisquam vel omnis.
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '21'
+    body:
+      encoding: UTF-8
+      string: '<status code="ok" />
+
+'
+    http_version: 
+  recorded_at: Tue, 01 Aug 2017 08:14:38 GMT
+- request:
+    method: put
+    uri: http://localhost:3200/source/apache/mod_ssl/_meta?user=_nobody_
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="mod_ssl" project="apache">
+          <title>No Country for Old Men</title>
+          <description>Ea et adipisci eveniet ducimus atque quis voluptas.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '174'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="mod_ssl" project="apache">
+          <title>No Country for Old Men</title>
+          <description>Ea et adipisci eveniet ducimus atque quis voluptas.</description>
+        </package>
+    http_version: 
+  recorded_at: Tue, 01 Aug 2017 08:14:38 GMT
+- request:
+    method: put
+    uri: http://localhost:3200/source/apache/mod_ssl/_meta
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="mod_ssl" project="apache">
+          <title>No Country for Old Men</title>
+          <description>Ea et adipisci eveniet ducimus atque quis voluptas.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '174'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="mod_ssl" project="apache">
+          <title>No Country for Old Men</title>
+          <description>Ea et adipisci eveniet ducimus atque quis voluptas.</description>
+        </package>
+    http_version: 
+  recorded_at: Tue, 01 Aug 2017 08:14:38 GMT
+- request:
+    method: put
+    uri: http://localhost:3200/source/apache/mod_ssl/_config
+    body:
+      encoding: UTF-8
+      string: Nostrum sunt eius quisquam nemo veritatis distinctio. Sint neque et
+        atque qui voluptatem. Vitae quam earum.
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '207'
+    body:
+      encoding: UTF-8
+      string: |
+        <revision rev="1" vrev="1">
+          <srcmd5>afd62566ea0171efa70bc5eb07d57135</srcmd5>
+          <version>unknown</version>
+          <time>1501575278</time>
+          <user>unknown</user>
+          <comment></comment>
+          <requestid/>
+        </revision>
+    http_version: 
+  recorded_at: Tue, 01 Aug 2017 08:14:38 GMT
+- request:
+    method: put
+    uri: http://localhost:3200/source/apache/mod_ssl/somefile.txt
+    body:
+      encoding: UTF-8
+      string: Aut dolor est quia ullam voluptatum quia odit. Odit reiciendis repellendus
+        fuga nihil error quo. Quis et eaque. Vero tempore autem qui.
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '207'
+    body:
+      encoding: UTF-8
+      string: |
+        <revision rev="2" vrev="2">
+          <srcmd5>090e77dd5205f90ba82bd69c3fccd749</srcmd5>
+          <version>unknown</version>
+          <time>1501575278</time>
+          <user>unknown</user>
+          <comment></comment>
+          <requestid/>
+        </revision>
+    http_version: 
+  recorded_at: Tue, 01 Aug 2017 08:14:39 GMT
+- request:
+    method: get
+    uri: http://localhost:3200/source/apache/mod_ssl?nofilename=1&view=info&withchangesmd5=1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '181'
+    body:
+      encoding: UTF-8
+      string: |
+        <sourceinfo package="mod_ssl" rev="2" vrev="2" srcmd5="090e77dd5205f90ba82bd69c3fccd749" verifymd5="090e77dd5205f90ba82bd69c3fccd749">
+          <revtime>1501575278</revtime>
+        </sourceinfo>
+    http_version: 
+  recorded_at: Tue, 01 Aug 2017 08:14:39 GMT
+- request:
+    method: get
+    uri: http://localhost:3200/source/apache/mod_ssl
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '296'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="mod_ssl" rev="2" vrev="2" srcmd5="090e77dd5205f90ba82bd69c3fccd749">
+          <entry name="_config" md5="59ddc561d3d35ca4d712d45b8b7c1545" size="107" mtime="1501575278" />
+          <entry name="somefile.txt" md5="97ee3e828c4b87009a8fc7984f11b071" size="135" mtime="1501575278" />
+        </directory>
+    http_version: 
+  recorded_at: Tue, 01 Aug 2017 08:14:39 GMT
+- request:
+    method: post
+    uri: http://localhost:3200/source/apache/mod_ssl?cmd=diff&linkrev=base&onlyissues=1&orev=0&view=xml
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Content-Type:
+      - application/octet-stream
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '291'
+    body:
+      encoding: UTF-8
+      string: |
+        <sourcediff key="c0138a4e984ba7915859fd554f34dc94">
+          <old project="apache" package="mod_ssl" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e" />
+          <new project="apache" package="mod_ssl" rev="2" srcmd5="090e77dd5205f90ba82bd69c3fccd749" />
+          <files />
+          <issues>
+          </issues>
+        </sourcediff>
+    http_version: 
+  recorded_at: Tue, 01 Aug 2017 08:14:39 GMT
 recorded_with: VCR 3.0.3

--- a/src/api/spec/models/backend_package_spec.rb
+++ b/src/api/spec/models/backend_package_spec.rb
@@ -1,14 +1,19 @@
 require 'rails_helper'
 
+# WARNING: If you change tests make sure you uncomment this line
+# and start a test backend. Some of the actions
+# require real backend answers for projects/packages.
+# CONFIG['global_write_through'] = true
+
 RSpec.describe BackendPackage, vcr: true do
   describe '.refresh_dirty' do
-    let!(:project) { create(:project) }
-    let!(:package) { create(:package_with_file, project: project) }
+    let!(:project) { create(:project, name: 'apache') }
+    let!(:package) { create(:package_with_file, project: project, name: 'mod_ssl') }
 
     subject { BackendPackage.refresh_dirty }
 
     it do
-      expect { subject }.to have_enqueued_job(UpdatePackagesIfDirtyJob).with(project.id)
+      expect { subject }.to change { BackendPackage.count }.by(1)
     end
   end
 end

--- a/src/api/spec/models/configuration_spec.rb
+++ b/src/api/spec/models/configuration_spec.rb
@@ -20,12 +20,17 @@ RSpec.describe Configuration do
   end
 
   describe '#delayed_write_to_backend' do
-    let(:configuration) { create(:configuration) }
+    let(:configuration) { build(:configuration) }
 
-    subject { configuration.delayed_write_to_backend }
+    before do
+      allow(Configuration).to receive(:find).and_return(configuration)
+      allow(configuration).to receive(:write_to_backend)
+    end
 
-    it 'queues a job to write to the backend' do
-      expect { subject }.to have_enqueued_job(ConfigurationWriteToBackendJob).with(configuration.id)
+    subject! { configuration.delayed_write_to_backend }
+
+    it 'writes to the backend' do
+      expect(configuration).to have_received(:write_to_backend)
     end
   end
 end


### PR DESCRIPTION
In PR https://github.com/openSUSE/open-build-service/pull/3441 I set the test environment to use the ActiveJob [TestAdapter](http://api.rubyonrails.org/v5.1.1/classes/ActiveJob/QueueAdapters/TestAdapter.html) however I now think its better that we use the [InlineAdapter](http://api.rubyonrails.org/classes/ActiveJob/QueueAdapters/InlineAdapter.html) for test environment.

The reason is that there are already lots of tests (both rspec and functional tests) which rely on the jobs being performed.