### PR TITLE
Refactor project exists package

### DIFF
--- a/src/api/app/models/owner.rb
+++ b/src/api/app/models/owner.rb
@@ -87,7 +87,7 @@ class Owner
   end
 
   def self.find_assignees(rootproject, binary_name, limit = 1, devel = true, filter = %w(maintainer bugowner), webui_mode = false)
-    projects = rootproject.expand_all_projects
+    projects = rootproject.expand_all_projects(allow_remote_projects: false)
     instances_without_definition = []
     maintainers = []
     pkg = nil
@@ -146,7 +146,7 @@ class Owner
   end
 
   def self.find_containers_without_definition(rootproject, devel = true, filter = %w(maintainer bugowner))
-    projects = rootproject.expand_all_projects
+    projects = rootproject.expand_all_projects(allow_remote_projects: false)
     roles = []
     filter.each do |f|
       roles << Role.find_by_title!(f)
@@ -204,7 +204,7 @@ class Owner
   end
 
   def self.find_containers(rootproject, owner, devel = true, filter = %w(maintainer bugowner))
-    projects = rootproject.expand_all_projects
+    projects = rootproject.expand_all_projects(allow_remote_projects: false)
 
     roles = []
     filter.each do |f|
@@ -288,7 +288,7 @@ class Owner
     return m, (limit - 1), already_checked if m
 
     # no match, loop about projects below with this package container name
-    pkg.project.expand_all_projects.each do |prj|
+    pkg.project.expand_all_projects(allow_remote_projects: false).each do |prj|
       p = prj.packages.find_by_name(pkg.name )
       next if p.nil? || already_checked[p.id]
 

--- a/src/api/app/models/package.rb
+++ b/src/api/app/models/package.rb
@@ -191,6 +191,9 @@ class Package < ApplicationRecord
       pkg = prj.packages.find_by_name(package) if pkg.nil?
     end
 
+    # FIXME: Why is this returning nil (the package is not found) if _ANY_ of the
+    # linking projects is remote? What if one of the linking projects is local
+    # and the other one remote?
     if pkg.nil? && opts[:follow_project_links]
       # in case we link to a remote project we need to assume that the
       # backend may be able to find it even when we don't have the package local

--- a/src/api/app/models/project.rb
+++ b/src/api/app/models/project.rb
@@ -896,7 +896,7 @@ class Project < ApplicationRecord
     projects = []
 
     maintained_projects.each do |mp|
-      mp.project.expand_all_projects.each do |p|
+      mp.project.expand_all_projects(allow_remote_projects: false).each do |p|
         projects << p
       end
     end

--- a/src/api/app/models/project.rb
+++ b/src/api/app/models/project.rb
@@ -869,7 +869,7 @@ class Project < ApplicationRecord
     all_repositories.uniq
   end
 
-  def expand_all_projects(project_map = {}, allow_remote_projects = true)
+  def expand_all_projects(project_map: {}, allow_remote_projects: true)
     # cycle check
     return [] if project_map[self]
     project_map[self] = 1
@@ -883,7 +883,7 @@ class Project < ApplicationRecord
           projects << lp.linked_remote_project_name
         end
       else
-        lp.linked_db_project.expand_all_projects(project_map, allow_remote_projects).each do |p|
+        lp.linked_db_project.expand_all_projects(project_map: project_map, allow_remote_projects: allow_remote_projects).each do |p|
           projects << p
         end
       end


### PR DESCRIPTION
Only follow remote projects in `Project.expand_all_projects` if the result is treated as such...