### PR TITLE
[api] ProjectLogRotate and SendEventEmails now use ActiveJob

### DIFF
--- a/src/api/app/jobs/project_log_rotate_job.rb
+++ b/src/api/app/jobs/project_log_rotate_job.rb
@@ -1,4 +1,6 @@
-class ProjectLogRotate
+class ProjectLogRotateJob < ApplicationJob
+  queue_as :project_log_rotate
+
   def perform
     event_classes = [Event::Package, Event::Project]
     event_types = event_classes.flat_map(&:descendants).map(&:name)
@@ -18,6 +20,5 @@ class ProjectLogRotate
 
     # Clean up old entries
     ProjectLogEntry.clean_older_than oldest_date
-    true
   end
 end

--- a/src/api/app/jobs/send_event_emails_job.rb
+++ b/src/api/app/jobs/send_event_emails_job.rb
@@ -1,8 +1,5 @@
-class SendEventEmails
-  # we don't need this outside of the migration - but we need to be able
-  # to load old jobs from the database (and mark their events) before deleting
-  # (see 20151030130011_mark_events)
-  attr_accessor :event
+class SendEventEmailsJob < ApplicationJob
+  queue_as :mailers
 
   def perform
     Event::Base.where(mails_sent: false).order(created_at: :asc).limit(1000).each do |event|

--- a/src/api/config/clock.rb
+++ b/src/api/config/clock.rb
@@ -58,7 +58,7 @@ module Clockwork
   end
 
   every(10.minutes, 'project log rotates') do
-    ProjectLogRotate.new.delay(queue: 'project_log_rotate').perform
+    ProjectLogRotateJob.perform_later
   end
 
   every(1.day, 'clean old events') do

--- a/src/api/config/clock.rb
+++ b/src/api/config/clock.rb
@@ -37,7 +37,7 @@ module Clockwork
 
   every(30.seconds, 'send notifications') do
     EventNotifyBackend.perform_later
-    SendEventEmails.new.delay(queue: 'mailers').perform
+    SendEventEmailsJob.perform_later
   end
 
   every(17.seconds, 'fetch notifications', thread: true) do

--- a/src/api/spec/jobs/project_log_rotate_job_spec.rb
+++ b/src/api/spec/jobs/project_log_rotate_job_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe ProjectLogRotate, type: :job do
+RSpec.describe ProjectLogRotateJob, type: :job do
   include ActiveJob::TestHelper
 
   describe '#perform' do
@@ -19,7 +19,7 @@ RSpec.describe ProjectLogRotate, type: :job do
       end
     end
 
-    subject! { ProjectLogRotate.new.perform }
+    subject! { ProjectLogRotateJob.new.perform }
 
     it 'creates a ProjectLogEntry' do
       expect(ProjectLogEntry.count).to eq(10)

--- a/src/api/spec/jobs/send_event_emails_job_spec.rb
+++ b/src/api/spec/jobs/send_event_emails_job_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe SendEventEmails, type: :job do
+RSpec.describe SendEventEmailsJob, type: :job do
   include ActiveJob::TestHelper
 
   describe '#perform' do
@@ -21,7 +21,7 @@ RSpec.describe SendEventEmails, type: :job do
       let!(:subscription2) { create(:event_subscription_comment_for_project, receiver_role: 'all', user: nil, group: group) }
       let!(:subscription3) { create(:event_subscription_comment_for_project, receiver_role: 'all', user: comment_author) }
 
-      subject! { SendEventEmails.new.perform }
+      subject! { SendEventEmailsJob.new.perform }
 
       it 'sends an email to the subscribers' do
         email = ActionMailer::Base.deliveries.first
@@ -65,7 +65,7 @@ RSpec.describe SendEventEmails, type: :job do
         allow(Airbrake).to receive(:notify)
       end
 
-      subject! { SendEventEmails.new.perform }
+      subject! { SendEventEmailsJob.new.perform }
 
       it 'updates the event mails_sent = true' do
         event = Event::CommentForProject.first
@@ -78,7 +78,7 @@ RSpec.describe SendEventEmails, type: :job do
     end
 
     context 'with no subscriptions for the event' do
-      subject! { SendEventEmails.new.perform }
+      subject! { SendEventEmailsJob.new.perform }
 
       it 'updates the event mails_sent = true' do
         event = Event::CommentForProject.first

--- a/src/api/test/functional/comments_controller_test.rb
+++ b/src/api/test/functional/comments_controller_test.rb
@@ -87,11 +87,11 @@ class CommentsControllerTest < ActionDispatch::IntegrationTest
     # body can't be empty
     assert_xml_tag tag: 'status', attributes: { code: 'invalid_record' }
 
-    SendEventEmails.new.perform
+    SendEventEmailsJob.new.perform
     assert_difference 'ActionMailer::Base.deliveries.size', +1 do
       post create_request_comment_path(id: 2), params: 'Hallo'
       assert_response :success
-      SendEventEmails.new.perform
+      SendEventEmailsJob.new.perform
     end
 
     email = ActionMailer::Base.deliveries.last
@@ -103,11 +103,11 @@ class CommentsControllerTest < ActionDispatch::IntegrationTest
 
     # just check if adrian gets the mail too - he's a commenter now
     login_dmayr
-    SendEventEmails.new.perform
+    SendEventEmailsJob.new.perform
     assert_difference 'ActionMailer::Base.deliveries.size', +1 do
       post create_request_comment_path(id: 2), params: 'Hallo'
       assert_response :success
-      SendEventEmails.new.perform
+      SendEventEmailsJob.new.perform
     end
 
     email = ActionMailer::Base.deliveries.last
@@ -117,7 +117,7 @@ class CommentsControllerTest < ActionDispatch::IntegrationTest
     assert_difference 'ActionMailer::Base.deliveries.size', +1 do
       post create_request_comment_path(id: 2), params: 'Hallo @fred'
       assert_response :success
-      SendEventEmails.new.perform
+      SendEventEmailsJob.new.perform
     end
 
     email = ActionMailer::Base.deliveries.last
@@ -127,7 +127,7 @@ class CommentsControllerTest < ActionDispatch::IntegrationTest
     assert_difference 'ActionMailer::Base.deliveries.size', +1 do
       post create_request_comment_path(id: 2), params: 'Is Fred listening now?'
       assert_response :success
-      SendEventEmails.new.perform
+      SendEventEmailsJob.new.perform
     end
 
     email = ActionMailer::Base.deliveries.last
@@ -144,11 +144,11 @@ class CommentsControllerTest < ActionDispatch::IntegrationTest
     # body can't be empty
     assert_xml_tag tag: 'status', attributes: { code: 'invalid_record' }
 
-    SendEventEmails.new.perform
+    SendEventEmailsJob.new.perform
     assert_difference 'ActionMailer::Base.deliveries.size', +1 do
       post create_project_comment_path(project: 'Apache'), params: 'Beautiful project'
       assert_response :success
-      SendEventEmails.new.perform
+      SendEventEmailsJob.new.perform
     end
 
     email = ActionMailer::Base.deliveries.last
@@ -170,11 +170,11 @@ class CommentsControllerTest < ActionDispatch::IntegrationTest
     # body can't be empty
     assert_xml_tag tag: 'status', attributes: { code: 'invalid_record' }
 
-    SendEventEmails.new.perform
+    SendEventEmailsJob.new.perform
     assert_difference 'ActionMailer::Base.deliveries.size', +1 do
       post create_package_comment_path(project: 'kde4', package: 'kdebase'), params: "Hola, estoy aprendiendo español"
       assert_response :success
-      SendEventEmails.new.perform
+      SendEventEmailsJob.new.perform
     end
 
     email = ActionMailer::Base.deliveries.last
@@ -187,12 +187,12 @@ class CommentsControllerTest < ActionDispatch::IntegrationTest
 
   def test_create_a_comment_that_only_mentioned_people_will_notice
     login_tom
-    SendEventEmails.new.perform
+    SendEventEmailsJob.new.perform
     assert_difference 'ActionMailer::Base.deliveries.size', +1 do
       # Trolling
       post create_package_comment_path(project: 'BaseDistro', package: 'pack1'), params: "I preffer Apache1, don't you? @fred"
       assert_response :success
-      SendEventEmails.new.perform
+      SendEventEmailsJob.new.perform
     end
 
     email = ActionMailer::Base.deliveries.last

--- a/src/api/test/functional/maintenance_test.rb
+++ b/src/api/test/functional/maintenance_test.rb
@@ -1380,14 +1380,14 @@ class MaintenanceTests < ActionDispatch::IntegrationTest
     assert_response :success
     assert_xml_tag( parent: { tag: 'state' }, tag: 'comment', content: 'blahfasel')
 
-    SendEventEmails.new.perform
+    SendEventEmailsJob.new.perform
     ActionMailer::Base.deliveries.clear
 
     # leave a comment
     assert_difference 'ActionMailer::Base.deliveries.size', +1 do
       post create_request_comment_path(id: reqid), params: 'Release it now!'
       assert_response :success
-      SendEventEmails.new.perform
+      SendEventEmailsJob.new.perform
     end
 
     email = ActionMailer::Base.deliveries.last
@@ -1400,7 +1400,7 @@ class MaintenanceTests < ActionDispatch::IntegrationTest
     assert_difference 'ActionMailer::Base.deliveries.size', +1 do
       post create_request_comment_path(id: reqid), params: 'Slave, can you release it? The master is gone'
       assert_response :success
-      SendEventEmails.new.perform
+      SendEventEmailsJob.new.perform
     end
 
     email = ActionMailer::Base.deliveries.last

--- a/src/api/test/functional/request_events_test.rb
+++ b/src/api/test/functional/request_events_test.rb
@@ -23,13 +23,13 @@ class RequestEventsTest < ActionDispatch::IntegrationTest
 
     Timecop.travel(2013, 8, 20, 12, 0, 0)
     myid = 0
-    SendEventEmails.new.perform
+    SendEventEmailsJob.new.perform
     assert_difference 'ActionMailer::Base.deliveries.size', +1 do
       post '/request?cmd=create',
            params: "<request><action type='add_role'><target project='home:tom'/><person name='Iggy' role='reviewer'/></action></request>"
       assert_response :success
       myid = Xmlhash.parse(@response.body)['id']
-      SendEventEmails.new.perform
+      SendEventEmailsJob.new.perform
     end
 
     email = ActionMailer::Base.deliveries.last
@@ -44,7 +44,7 @@ class RequestEventsTest < ActionDispatch::IntegrationTest
 
     Timecop.travel(2013, 8, 20, 12, 0, 0)
     myid = 0
-    SendEventEmails.new.perform
+    SendEventEmailsJob.new.perform
     assert_difference 'ActionMailer::Base.deliveries.size', +1 do
       body = "<request>\n"
       actions = 1000
@@ -57,7 +57,7 @@ class RequestEventsTest < ActionDispatch::IntegrationTest
       req = Xmlhash.parse(@response.body)
       assert_equal actions, req['action'].count
       myid = req['id']
-      SendEventEmails.new.perform
+      SendEventEmailsJob.new.perform
     end
 
     email = ActionMailer::Base.deliveries.last
@@ -71,12 +71,12 @@ class RequestEventsTest < ActionDispatch::IntegrationTest
 
     Timecop.travel(2013, 8, 20, 12, 0, 0)
     myid = 0
-    SendEventEmails.new.perform
+    SendEventEmailsJob.new.perform
     assert_difference 'ActionMailer::Base.deliveries.size', +1 do
       post '/request?cmd=create', params: "<request><action type='set_bugowner'><target project='home:tom'/><person name='Iggy'/></action></request>"
       assert_response :success
       myid = Xmlhash.parse(@response.body)['id']
-      SendEventEmails.new.perform
+      SendEventEmailsJob.new.perform
     end
 
     email = ActionMailer::Base.deliveries.last
@@ -93,7 +93,7 @@ class RequestEventsTest < ActionDispatch::IntegrationTest
     assert_difference 'ActionMailer::Base.deliveries.size', +1 do
       post "/request/#{myid}?cmd=changestate&newstate=declined", params: ''
       assert_response :success
-      SendEventEmails.new.perform
+      SendEventEmailsJob.new.perform
     end
     email = nil
     ActionMailer::Base.deliveries.each do |m|
@@ -113,14 +113,14 @@ class RequestEventsTest < ActionDispatch::IntegrationTest
 
     Timecop.travel(2013, 8, 20, 12, 0, 0)
     myid = ''
-    SendEventEmails.new.perform
+    SendEventEmailsJob.new.perform
     assert_difference 'ActionMailer::Base.deliveries.size', +1 do
       post '/request?cmd=create',
            params: "<request><action type='add_role'><target project='kde4' package='kdelibs'/><person name='Iggy' role='reviewer'/></action>"\
                    "</request>"
       assert_response :success
       myid = Xmlhash.parse(@response.body)['id']
-      SendEventEmails.new.perform
+      SendEventEmailsJob.new.perform
     end
 
     email = ActionMailer::Base.deliveries.last
@@ -133,12 +133,12 @@ class RequestEventsTest < ActionDispatch::IntegrationTest
 
     Timecop.travel(2013, 8, 20, 12, 0, 0)
     myid = ''
-    SendEventEmails.new.perform
+    SendEventEmailsJob.new.perform
     assert_difference 'ActionMailer::Base.deliveries.size', +1 do
       post '/request?cmd=create', params: "<request><action type='delete'><target project='home:coolo' repository='standard'/></action></request>"
       assert_response :success
       myid = Xmlhash.parse(@response.body)['id']
-      SendEventEmails.new.perform
+      SendEventEmailsJob.new.perform
     end
 
     email = ActionMailer::Base.deliveries.last

--- a/src/api/test/functional/webui/project_controller_test.rb
+++ b/src/api/test/functional/webui/project_controller_test.rb
@@ -496,12 +496,12 @@ XML
 
   def test_successful_comment_creation
     login_tom to: '/project/show/home:Iggy'
-    SendEventEmails.new.perform
+    SendEventEmailsJob.new.perform
     assert_difference 'ActionMailer::Base.deliveries.size', +1 do
       fill_in 'comment_body', with: 'Comment Body'
       find_button('Add comment').click
       find('#flash-messages').must_have_text 'Comment was successfully created.'
-      SendEventEmails.new.perform
+      SendEventEmailsJob.new.perform
     end
     email = ActionMailer::Base.deliveries.last
     verify_email('project_comment', email)

--- a/src/api/test/models/event_test.rb
+++ b/src/api/test/models/event_test.rb
@@ -80,10 +80,10 @@ class EventTest < ActionDispatch::IntegrationTest
     User.current = users(:Iggy)
     req = bs_requests(:submit_from_home_project)
     myid = req.number
-    SendEventEmails.new.perform # empty queue
+    SendEventEmailsJob.new.perform # empty queue
     assert_difference 'ActionMailer::Base.deliveries.size', +1 do
       req.addreview by_user: 'tom', comment: 'Can you check that?'
-      SendEventEmails.new.perform
+      SendEventEmailsJob.new.perform
     end
     email = ActionMailer::Base.deliveries.last
 
@@ -156,10 +156,10 @@ class EventTest < ActionDispatch::IntegrationTest
     User.current = users(:Iggy)
     req = bs_requests(:submit_from_home_project)
     myid = req.number
-    SendEventEmails.new.perform # empty queue
+    SendEventEmailsJob.new.perform # empty queue
     assert_difference 'ActionMailer::Base.deliveries.size', +1 do
       req.addreview by_project: 'home:Iggy', by_package: 'TestPack', comment: 'Can you check that?'
-      SendEventEmails.new.perform
+      SendEventEmailsJob.new.perform
     end
     email = ActionMailer::Base.deliveries.last
 
@@ -171,7 +171,7 @@ class EventTest < ActionDispatch::IntegrationTest
     ActionMailer::Base.deliveries.clear
     assert_difference 'ActionMailer::Base.deliveries.size', +1 do
       req.addreview by_project: 'Apache', by_package: 'apache2', comment: 'Can you check that?'
-      SendEventEmails.new.perform
+      SendEventEmailsJob.new.perform
     end
     email = ActionMailer::Base.deliveries.last
 

--- a/src/api/test/models/project_log_rotate_job_test.rb
+++ b/src/api/test/models/project_log_rotate_job_test.rb
@@ -1,6 +1,6 @@
 require_relative '../test_helper'
 
-class ProjectLogRotateTest < ActiveSupport::TestCase
+class ProjectLogRotateJobTest < ActiveSupport::TestCase
   fixtures :all
 
   test "#perform" do
@@ -27,7 +27,7 @@ class ProjectLogRotateTest < ActiveSupport::TestCase
       assert recent_logged_events > 0
       assert old_entries > 0
 
-      ProjectLogRotate.new.perform
+      ProjectLogRotateJob.new.perform
 
       # -1 because one event points to a deleted project
       expected_entries = total_entries - old_entries + recent_events - recent_logged_events - 1

--- a/src/api/test/unit/event_mailer_test.rb
+++ b/src/api/test/unit/event_mailer_test.rb
@@ -50,11 +50,11 @@ class EventMailerTest < ActionMailer::TestCase
     req = bs_requests(:submit_from_home_project)
     Timecop.travel(2013, 8, 20, 12, 0, 0)
     myid = req.number
-    SendEventEmails.new.perform # empty queue
+    SendEventEmailsJob.new.perform # empty queue
     assert_difference 'ActionMailer::Base.deliveries.size', +1 do
       req.addreview(by_group: 'test_group', comment: 'does it look ok?')
       # trigger the send job
-      SendEventEmails.new.perform
+      SendEventEmailsJob.new.perform
     end
 
     email = ActionMailer::Base.deliveries.last


### PR DESCRIPTION
Part of this card: https://trello.com/c/Tx9d3bUb/467-5-p4-event-system-change-delayed-jobs-to-be-created-with-activejobs