### PR TITLE
Bugfix project touching

### DIFF
--- a/src/api/app/helpers/webui/webui_helper.rb
+++ b/src/api/app/helpers/webui/webui_helper.rb
@@ -322,7 +322,7 @@ module Webui::WebuiHelper
     # only care for database entries
     prj = Project.where(name: opts[:project]).select(:id, :name, :updated_at).first
     # Expires in 2 hours so that changes of local and remote packages eventually result in an update
-    Rails.cache.fetch(['project_or_package_link', prj.try(:cache_key), opts], expires_in: 2.hours) do
+    Rails.cache.fetch(['project_or_package_link', prj.try(:id), opts], expires_in: 2.hours) do
       if prj && opts[:creator]
         opts[:project_text] ||= format_projectname(opts[:project], opts[:creator])
       end

--- a/src/api/app/models/package.rb
+++ b/src/api/app/models/package.rb
@@ -42,7 +42,7 @@ class Package < ApplicationRecord
   class IllegalFileName < APIException; setup 'invalid_file_name_error'; end
   class PutFileNoPermission < APIException; setup 403; end
 
-  belongs_to :project, inverse_of: :packages, touch: true
+  belongs_to :project, inverse_of: :packages
   delegate :name, to: :project, prefix: true
   delegate :repositories, to: :project
   delegate :architectures, to: :project

--- a/src/api/app/models/project.rb
+++ b/src/api/app/models/project.rb
@@ -809,19 +809,14 @@ class Project < ApplicationRecord
     if opts[:follow_project_links]
       # Look for any package with name in all our linked projects
       pkg = Package.find_by(project: expand_linking_to, name: name)
-      # FIXME: Mimics the behavior of find_package below, but why is accesss only
-      # checked in the case of follow_project_links?
-      if pkg
-        return false unless Package.check_access?(pkg)
-      end
     else
       pkg = packages.find_by_name(name)
     end
     if pkg.nil?
       # local project, but package may be in a linked remote one
       opts[:allow_remote_packages] && Package.exists_on_backend?(name, self.name)
-    else # if we could fetch the project, the package is fine accesswise
-      true
+    else
+      pkg && Package.check_access?(pkg)
     end
   end
 

--- a/src/api/app/models/project.rb
+++ b/src/api/app/models/project.rb
@@ -806,18 +806,22 @@ class Project < ApplicationRecord
   end
 
   def exists_package?(name, opts = {})
-    Rails.cache.fetch(['exists_package', cache_key, name, opts]) do
-      if opts[:follow_project_links]
-        pkg = find_package(name)
-      else
-        pkg = packages.find_by_name(name)
+    if opts[:follow_project_links]
+      # Look for any package with name in all our linked projects
+      pkg = Package.find_by(project: expand_linking_to, name: name)
+      # FIXME: Mimics the behavior of find_package below, but why is accesss only
+      # checked in the case of follow_project_links?
+      if pkg
+        return false unless Package.check_access?(pkg)
       end
-      if pkg.nil?
-        # local project, but package may be in a linked remote one
-        opts[:allow_remote_packages] && Package.exists_on_backend?(name, self.name)
-      else # if we could fetch the project, the package is fine accesswise
-        true
-      end
+    else
+      pkg = packages.find_by_name(name)
+    end
+    if pkg.nil?
+      # local project, but package may be in a linked remote one
+      opts[:allow_remote_packages] && Package.exists_on_backend?(name, self.name)
+    else # if we could fetch the project, the package is fine accesswise
+      true
     end
   end
 
@@ -867,6 +871,10 @@ class Project < ApplicationRecord
       all_repositories.concat(repository.expand_all_repositories)
     end
     all_repositories.uniq
+  end
+
+  def expand_linking_to
+    expand_all_projects(allow_remote_projects: false).map(&:id)
   end
 
   def expand_all_projects(project_map: {}, allow_remote_projects: true)

--- a/src/api/app/models/project.rb
+++ b/src/api/app/models/project.rb
@@ -178,7 +178,7 @@ class Project < ApplicationRecord
   end
 
   def self.load_from_remote(project, path)
-    Rails.cache.fetch("remote_image_templates_#{project.cache_key}", expires_in: 1.hour) do
+    Rails.cache.fetch("remote_image_templates_#{project.id}", expires_in: 1.hour) do
       begin
         return ActiveXML.backend.load_external_url("#{project.remoteurl}#{path}")
       rescue OpenSSL::SSL::SSLError


### PR DESCRIPTION
Touching `Project` on all changes of `Package` turned out to be a huge source of SQL deadlocks because we have very long running transactions for `Project.

There where only two rather simple caches based on `Project.updated_at`, which got expired by the touch, both are removed in this PR so we won't have to touch anymore.