### PR TITLE
[api] RequestController uses ActiveJob

### DIFF
--- a/src/api/app/controllers/request_controller.rb
+++ b/src/api/app/controllers/request_controller.rb
@@ -156,7 +156,7 @@ class RequestController < ApplicationController
 
     # cache the diff (in the backend)
     @req.bs_request_actions.each do |a|
-      a.delay.webui_infos
+      BsRequestActionWebuiInfosJob.perform_later(a.id)
     end
 
     render xml: xml

--- a/src/api/app/jobs/bs_request_action_webui_infos_job.rb
+++ b/src/api/app/jobs/bs_request_action_webui_infos_job.rb
@@ -1,0 +1,7 @@
+class BsRequestActionWebuiInfosJob < ApplicationJob
+  queue_as :quick
+
+  def perform(request_action_id)
+    BsRequestAction.find(request_action_id).webui_infos
+  end
+end

--- a/src/api/spec/jobs/bs_request_action_webui_infos_job.rb
+++ b/src/api/spec/jobs/bs_request_action_webui_infos_job.rb
@@ -1,0 +1,20 @@
+require 'rails_helper'
+
+RSpec.describe BsRequestActionWebuiInfosJob, type: :job do
+  include ActiveJob::TestHelper
+
+  describe '#perform' do
+    let!(:request_action) { create(:bs_request_action) }
+
+    before do
+      allow(BsRequestAction).to receive(:find).and_return(request_action)
+      allow(request_action).to receive(:webui_infos)
+    end
+
+    subject! { BsRequestActionWebuiInfosJob.new.perform(request_action.id) }
+
+    it 'calls webui_infos on the request_action' do
+      expect(request_action).to have_received(:webui_infos)
+    end
+  end
+end


### PR DESCRIPTION
Part of this card: https://trello.com/c/Tx9d3bUb/467-5-p4-event-system-change-delayed-jobs-to-be-created-with-activejobs