### PR TITLE
[api] SourceController#project_command_release uses ActiveJob

### DIFF
--- a/src/api/app/controllers/source_controller.rb
+++ b/src/api/app/controllers/source_controller.rb
@@ -1006,7 +1006,10 @@ class SourceController < ApplicationController
       render_ok
     else
       # inject as job
-      @project.delay.do_project_release(params)
+      ProjectDoProjectReleaseJob.perform_later(
+        @project.id,
+        params.slice(:project, :targetproject, :targetreposiory, :repository, :setrelease, :user).permit!.to_h
+      )
       render_invoked
     end
   end

--- a/src/api/app/jobs/project_do_project_release_job.rb
+++ b/src/api/app/jobs/project_do_project_release_job.rb
@@ -1,0 +1,7 @@
+class ProjectDoProjectReleaseJob < ApplicationJob
+  queue_as :quick
+
+  def perform(project_id, params)
+    Project.find(project_id).do_project_release(params)
+  end
+end


### PR DESCRIPTION
Part of this card: https://trello.com/c/Tx9d3bUb/467-5-p4-event-system-change-delayed-jobs-to-be-created-with-activejobs