### PR TITLE
[frontend] Move jobs back to the quick queue

### DIFF
--- a/src/api/app/jobs/configuration_write_to_backend_job.rb
+++ b/src/api/app/jobs/configuration_write_to_backend_job.rb
@@ -1,4 +1,6 @@
 class ConfigurationWriteToBackendJob < ApplicationJob
+  queue_as :quick
+
   def perform(configuration_id)
     Configuration.find(configuration_id).write_to_backend
   end

--- a/src/api/app/jobs/event_notify_backend_job.rb
+++ b/src/api/app/jobs/event_notify_backend_job.rb
@@ -1,4 +1,6 @@
 class EventNotifyBackendJob < ApplicationJob
+  queue_as :quick
+
   def perform
     Event::Base.not_in_queue.find_each(&:notify_backend)
   end

--- a/src/api/app/jobs/status_history_rescaler_job.rb
+++ b/src/api/app/jobs/status_history_rescaler_job.rb
@@ -1,4 +1,6 @@
 class StatusHistoryRescalerJob < ApplicationJob
+  queue_as :quick
+
   # this is called from a delayed job triggered by clockwork
   def perform
     maxtime = StatusHistory.maximum(:time)


### PR DESCRIPTION
The recent changes to schedule jobs with ActiveJob resulted
in the default queue being 'default' and not quick anymore.