### PR TITLE
[webui] Drop ObsRepository as it reimplemented the gem

### DIFF
--- a/src/api/config/feature.yml
+++ b/src/api/config/feature.yml
@@ -1,14 +1,14 @@
-production: &default
-  features:
+production:
+  features: &default
     image_templates: true
     kiwi_image_editor: false
 
 development:
-  <<: *default
   features:
+    <<: *default
     kiwi_image_editor: true
 
 test:
-  <<: *default
   features:
+    <<: *default
     kiwi_image_editor: true

--- a/src/api/lib/feature_switch/obs_repository.rb
+++ b/src/api/lib/feature_switch/obs_repository.rb
@@ -14,7 +14,6 @@ module Feature
       def active_features
         data = read_file(@yaml_file_name).with_indifferent_access
         data[@environment]['features'] = DEFAULTS.merge(data[@environment]['features'])
-        data['features'] = DEFAULTS.merge(data[@environment]['features'])
         get_active_features(data, @environment)
       end
     end


### PR DESCRIPTION
- Fix YAML inheritance, hash merge is not recursive so defaults were not inherited
- After fixing the YAML it was not necessary to merge with defaults in the Repository anymore
- Defaults should be now defined in the defaults production hash in the feature.yml

Now we can use the standard YamlRepository