### PR TITLE
Improve job queue handling

### DIFF
--- a/dist/obsapidelayed
+++ b/dist/obsapidelayed
@@ -67,6 +67,7 @@ case "$1" in
         # The default queue used by ActiveJob (jobs scheduled with .perform_later)
         run_in_api script/delayed_job.api.rb --queue=default start -i 1030
         run_in_api script/delayed_job.api.rb --queue=project_log_rotate start -i 1040
+        run_in_api script/delayed_job.api.rb --queue=consistency_check start -i 1050
 	rc_status -v
 	echo -n "Starting OBS api clock daemon "
         run_in_api $CLOCKWORKD --log-dir=log -l -c config/clock.rb start
@@ -81,6 +82,7 @@ case "$1" in
         run_in_api script/delayed_job.api.rb --queue=mailers stop -i 1020
         run_in_api script/delayed_job.api.rb --queue=default stop -i 1030
         run_in_api script/delayed_job.api.rb --queue=project_log_rotate stop -i 1040
+        run_in_api script/delayed_job.api.rb --queue=consistency_check stop -i 1050
 	rc_status -v
 	echo -n "Shutting down OBS api clock daemon "
         run_in_api $CLOCKWORKD -l -c config/clock.rb stop

--- a/src/api/Rakefile
+++ b/src/api/Rakefile
@@ -20,7 +20,6 @@ require 'workers/import_requests'
 task(importrequests: :environment) { ImportRequestsDelayedJob.new.perform }
 
 require(File.join(File.dirname(__FILE__), 'app/jobs/application_job.rb'))
-require(File.join(File.dirname(__FILE__), 'app/jobs/consistency_check.rb'))
 task(check_project: :environment) { ConsistencyCheckJob.new.check_project }
 task(fix_project: :environment) { ConsistencyCheckJob.new.fix_project }
 

--- a/src/api/app/jobs/consistency_check_job.rb
+++ b/src/api/app/jobs/consistency_check_job.rb
@@ -2,14 +2,7 @@ require 'api_exception'
 require 'xmlhash'
 
 class ConsistencyCheckJob < ApplicationJob
-  def fix
-    perform(true)
-  end
-
-  def init
-    User.current ||= User.get_default_admin
-    @errors = ""
-  end
+  queue_as :consistency_check
 
   def perform(fix = nil)
     init
@@ -68,6 +61,17 @@ class ConsistencyCheckJob < ApplicationJob
     end
     @errors << package_existence_consistency_check(project, fix)
     puts @errors unless @errors.blank?
+  end
+
+  private
+
+  def fix
+    perform(true)
+  end
+
+  def init
+    User.current ||= User.get_default_admin
+    @errors = ""
   end
 
   def project_meta_check(project, fix = nil)

--- a/src/api/app/jobs/issue_tracker_write_to_backend_job.rb
+++ b/src/api/app/jobs/issue_tracker_write_to_backend_job.rb
@@ -1,4 +1,6 @@
 class IssueTrackerWriteToBackendJob < ApplicationJob
+  queue_as :quick
+
   def perform(issue_tracker_id)
     IssueTracker.find(issue_tracker_id).write_to_backend
   end

--- a/src/api/app/jobs/update_packages_if_dirty_job.rb
+++ b/src/api/app/jobs/update_packages_if_dirty_job.rb
@@ -1,4 +1,6 @@
 class UpdatePackagesIfDirtyJob < ApplicationJob
+  queue_as :quick
+
   self.priority = 10
 
   def perform(project_id)

--- a/src/api/config/clock.rb
+++ b/src/api/config/clock.rb
@@ -72,6 +72,6 @@ module Clockwork
 
   # check for new breakages between api and backend due to dull code
   every(1.week, 'consistency check') do
-    ConsistencyCheckJob.new.delay.perform
+    ConsistencyCheckJob.perform_later
   end
 end

--- a/src/api/test/functional/aaa_pre_consistency_test.rb
+++ b/src/api/test/functional/aaa_pre_consistency_test.rb
@@ -1,5 +1,4 @@
 require File.expand_path(File.dirname(__FILE__) + "/..") + "/test_consistency_helper"
-require File.join(Rails.root, 'app/jobs/consistency_check.rb')
 
 class AAAPreConsistency < ActionDispatch::IntegrationTest
   fixtures :all

--- a/src/api/test/functional/channel_maintenance_test.rb
+++ b/src/api/test/functional/channel_maintenance_test.rb
@@ -2,7 +2,6 @@
 # rubocop:disable Metrics/AbcSize
 # rubocop:disable Metrics/MethodLength
 require File.expand_path(File.dirname(__FILE__) + '/..') + '/test_helper'
-require File.join(Rails.root, 'app/jobs/consistency_check.rb')
 require 'source_controller'
 
 class ChannelMaintenanceTests < ActionDispatch::IntegrationTest

--- a/src/api/test/functional/zzz_post_consistency_test.rb
+++ b/src/api/test/functional/zzz_post_consistency_test.rb
@@ -1,5 +1,4 @@
 require File.expand_path(File.dirname(__FILE__) + "/..") + "/test_consistency_helper"
-require File.join(Rails.root, 'app/jobs/consistency_check.rb')
 
 class ZZZPostConsistency < ActionDispatch::IntegrationTest
   require 'source_controller'


### PR DESCRIPTION
This PR does three things:
1. IssueTrackerWriteToBackendJob uses the "quick" queue, instead of the "default" queue
2. UpdatePackagesIfDirtyJob uses the "quick" queue, instead of the "default" queue
3. ConsistencyCheckJob uses its own "consitency_check" queue in order to stop it from blocking the default queue.

Change 1 and 2 are monkey patched on production.