### PR TITLE
[frontend] Bugfix writing to backend

### DIFF
--- a/src/api/app/controllers/issue_trackers_controller.rb
+++ b/src/api/app/controllers/issue_trackers_controller.rb
@@ -55,7 +55,6 @@ class IssueTrackersController < ApplicationController
 
     respond_to do |format|
       if @issue_tracker
-        IssueTracker.write_to_backend
         format.xml  { render xml: @issue_tracker.to_xml(IssueTracker::DEFAULT_RENDER_PARAMS), status: :created, location: @issue_tracker }
         format.json { render json: @issue_tracker.to_json(IssueTracker::DEFAULT_RENDER_PARAMS), status: :created, location: @issue_tracker }
       else
@@ -94,7 +93,6 @@ class IssueTrackersController < ApplicationController
         ret = @issue_tracker.update_attributes(attribs)
       end
       if ret
-        IssueTracker.write_to_backend
         format.xml  { head :ok }
         format.json { head :ok }
       else
@@ -113,7 +111,6 @@ class IssueTrackersController < ApplicationController
       render_error(status: 404, errorcode: "not_found", message: "Unable to find issue tracker '#{params[:id]}'") && return
     end
     @issue_tracker.destroy
-    IssueTracker.write_to_backend
 
     respond_to do |format|
       format.xml  { head :ok }

--- a/src/api/app/jobs/issue_tracker_write_to_backend_job.rb
+++ b/src/api/app/jobs/issue_tracker_write_to_backend_job.rb
@@ -1,7 +1,9 @@
 class IssueTrackerWriteToBackendJob < ApplicationJob
   queue_as :quick
 
-  def perform(issue_tracker_id)
-    IssueTracker.find(issue_tracker_id).write_to_backend
+  def perform
+    path = "/issue_trackers"
+    logger.debug "Write issue tracker information to backend..."
+    Backend::Connection.put_source(path, IssueTracker.all.to_xml(IssueTracker::DEFAULT_RENDER_PARAMS))
   end
 end

--- a/src/api/lib/tasks/delayed_job.rake
+++ b/src/api/lib/tasks/delayed_job.rake
@@ -3,7 +3,7 @@ require 'workers/update_issues.rb'
 
 namespace :jobs do
   desc "Inject a job to write issue tracker information to backend"
-  task(issuetrackers: :environment) { IssueTracker.write_to_backend }
+  task(issuetrackers: :environment) { IssueTracker.first.save! }
 
   desc "Update issue data of all changed issues in remote tracker"
   task(updateissues: :environment) {

--- a/src/api/spec/jobs/issue_tracker_write_to_backend_job_spec.rb
+++ b/src/api/spec/jobs/issue_tracker_write_to_backend_job_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe IssueTrackerWriteToBackendJob, type: :job, vcr: true do
       allow(Backend::Connection).to receive(:put_source)
     end
 
-    subject! { IssueTrackerWriteToBackendJob.new.perform(issue_tracker.id) }
+    subject! { IssueTrackerWriteToBackendJob.new.perform }
 
     it 'writes to the backend' do
       expect(Backend::Connection).to have_received(:put_source)

--- a/src/api/spec/models/issue_tracker_spec.rb
+++ b/src/api/spec/models/issue_tracker_spec.rb
@@ -1,18 +1,6 @@
 require 'rails_helper'
 
 RSpec.describe IssueTracker do
-  describe '.write_to_backend' do
-    before do
-      allow(Backend::Connection).to receive(:put_source)
-    end
-
-    subject! { IssueTracker.write_to_backend }
-
-    it 'writes to the backend' do
-      expect(Backend::Connection).to have_received(:put_source)
-    end
-  end
-
   describe '.update_all_issues' do
     let!(:issue_tracker) { create(:issue_tracker, enable_fetch: true) }
 

--- a/src/api/test/functional/issue_trackers_controller_test.rb
+++ b/src/api/test/functional/issue_trackers_controller_test.rb
@@ -94,12 +94,4 @@ class IssueTrackersControllerTest < ActionDispatch::IntegrationTest
     delete '/issue_trackers/test'
     assert_response :success
   end
-
-  def test_update_job
-    IssueTracker.write_to_backend
-
-    f = IssueTracker.find_by_name!("RT")
-    f.update_issues
-    f.enforced_update_all_issues
-  end
 end


### PR DESCRIPTION
The class method always wrote all IssueTrackers to the backend, regardless of the id passed to the job. It should do so for all trackers when they change.