### PR TITLE
[webui] Allow edit kiwi package attributes

### DIFF
--- a/src/api/app/assets/javascripts/webui/application/kiwi_editor.js
+++ b/src/api/app/assets/javascripts/webui/application/kiwi_editor.js
@@ -21,17 +21,23 @@ function editDialog(){
   $('.overlay').show();
 }
 
-function closeDialog(){
+function closeDialog() {
   var fields = $(this).parents('.nested-fields');
-  var name = fields.find(".kiwi_repository_name");
+  var name = fields.find('.kiwi_element_name');
   var dialog = fields.find('.dialog');
-  var alias = dialog.find("[id$='alias']");
-  if (alias.val() != '') {
-    name.text(alias.val());
+  var name_package = dialog.find("[id$='name']").val();
+  if (name_package != '') {
+    name.text(name_package);
   }
   else {
-    var source_path = dialog.find("[id$='source_path']");
-    name.text(source_path.val().replace(/\//g, '_'));
+    var alias = dialog.find("[id$='alias']");
+    if (alias.val() != '') {
+      name.text(alias.val());
+    }
+    else {
+      var source_path = dialog.find("[id$='source_path']");
+      name.text(source_path.val().replace(/\//g, '_'));
+    }
   }
   $('.overlay').hide();
   dialog.addClass('hidden');
@@ -56,15 +62,23 @@ $(document).ready(function(){
     $('.overlay').show();
   });
 
-  // Edit dialog for Repositories
-  $('.repository_edit').click(editDialog);
-  $('#kiwi-repositories-list .close-dialog').click(closeDialog);
-  $('.kiwi_list_item').hover(hoverListItem, hoverListItem);
+  // Edit dialog for Repositories and Packages
+  $('.repository_edit, .package_edit').click(editDialog);
+  $('#kiwi-repositories-list .close-dialog, #kiwi-packages-list .close-dialog').click(closeDialog);
+  $('#kiwi-repositories-list .kiwi_list_item, #kiwi-packages-list .kiwi_list_item').hover(hoverListItem, hoverListItem);
 
   // After inserting new repositories add the Callbacks
   $('#kiwi-repositories-list').on('cocoon:after-insert', function(e, addedFields) {
     $('.overlay').show();
     $(addedFields).find('.repository_edit').click(editDialog);
+    $(addedFields).find('.close-dialog').click(closeDialog);
+    $(addedFields).find('.kiwi_list_item').hover(hoverListItem, hoverListItem);
+  });
+
+  // After inserting new packages add the Callbacks
+  $('#kiwi-packages-list').on('cocoon:after-insert', function(e, addedFields) {
+    $('.overlay').show();
+    $(addedFields).find('.package_edit').click(editDialog);
     $(addedFields).find('.close-dialog').click(closeDialog);
     $(addedFields).find('.kiwi_list_item').hover(hoverListItem, hoverListItem);
   });

--- a/src/api/app/assets/javascripts/webui/application/kiwi_editor.js
+++ b/src/api/app/assets/javascripts/webui/application/kiwi_editor.js
@@ -55,13 +55,6 @@ $(document).ready(function(){
   $('#kiwi-image-update-form').change(enableSave);
   $('.remove_fields').click(enableSave);
 
-  // Show edit dialog
-  $('.repository_edit').click(function(){
-    var dialog = $("#repository_edit_" + $(this).attr("data-id"));
-    dialog.removeClass('hidden');
-    $('.overlay').show();
-  });
-
   // Edit dialog for Repositories and Packages
   $('.repository_edit, .package_edit').click(editDialog);
   $('#kiwi-repositories-list .close-dialog, #kiwi-packages-list .close-dialog').click(closeDialog);

--- a/src/api/app/views/webui/kiwi/images/_package_fields.html.haml
+++ b/src/api/app/views/webui/kiwi/images/_package_fields.html.haml
@@ -1,7 +1,28 @@
 .nested-fields.kiwi_fields
   .kiwi_list_item
-    %span.kiwi_repository_name
-      = f.object.name
-      = f.text_field :name, class: "#{'hidden' if f.object.name.present? }"
+    %span.kiwi_element_name= f.object.name
     %span.kiwi_actions.hidden
+      = link_to sprite_tag("drive_edit", title: 'Edit Package'), '#', class: "package_edit"
       = link_to_remove_association sprite_tag("req-decline", title: 'remove'), f
+
+  .dialog.darkgrey_box{ style: "width: 500px; left: 45%;", class: "#{'hidden' if f.object.name.present?}" }
+    .box.box-shadow
+      %h2.box-header #{f.object.name.present? ? 'Edit' : 'Add'} package
+
+      .dialog-content
+        %p
+          = f.label :name, 'Name:'
+          = f.text_field :name
+        %p
+          = f.label :arch, 'Arch:'
+          = f.text_field :arch
+          = f.label :replaces, 'Replaces:'
+          = f.text_field :replaces
+      %p
+        = f.check_box :bootinclude
+        = f.label :bootinclude
+        = f.check_box :bootdelete
+        = f.label :bootdelete
+
+      .dialog-buttons
+        = link_to('Continue', '#', title: 'Continue', class: 'close-dialog')

--- a/src/api/app/views/webui/kiwi/images/_repository_fields.html.haml
+++ b/src/api/app/views/webui/kiwi/images/_repository_fields.html.haml
@@ -1,6 +1,6 @@
 .nested-fields.kiwi_fields
   .kiwi_list_item
-    %span.kiwi_repository_name= f.object.name
+    %span.kiwi_element_name= f.object.name
     %span.kiwi_actions.hidden
       = link_to sprite_tag("drive_edit", title: 'Edit Repository'), '#', class: "repository_edit"
       = link_to_remove_association(sprite_tag("req-decline", title: 'Delete Repository'), f)


### PR DESCRIPTION
Allow edit kiwi package attributes in the same way as in Kiwi repositories.
![screenshot from 2017-08-02 17-00-57](https://user-images.githubusercontent.com/1212806/28880071-2f5cab14-77a4-11e7-9fce-4380147a49e0.png)

Pair-programmed by: @Ana06 and @DavidKang.