### PR TITLE
[dist] Add a simple DJ queue stat script

### DIFF
--- a/src/api/script/delayed_job_stats.rb
+++ b/src/api/script/delayed_job_stats.rb
@@ -1,0 +1,14 @@
+puts "-------------DJ-STATS-------------"
+puts "There are currently #{Delayed::Job.count} jobs in the queues"
+puts "-----------Jobs by type-----------"
+(::ApplicationJob.subclasses + ::CreateJob.subclasses).each do |dj_name|
+  job_count = Delayed::Job.where("handler like '%#{dj_name}%'").count
+  puts "#{dj_name.to_s.ljust(30)} #{job_count}" if job_count > 0
+end
+puts "-----------Jobs by queue----------"
+queues = %w(quick releasetracking issuetracking mailers default project_log_rotate)
+queues.each do |dj_queue|
+  job_count = Delayed::Job.where(queue: dj_queue).count
+  puts "#{dj_queue.to_s.ljust(30)} #{job_count}" if job_count > 0
+end
+


### PR DESCRIPTION
```
$ rails runner script/delayed_job_stats.rb
-------------DJ-STATS-------------
There are currently 606 jobs in the queues
-----------Jobs by type-----------
CleanupNotifications           3
EventNotifyBackendJob          198
IssueTrackerUpdateIssuesJob    4
PackageUpdateIfDirtyJob        219
ProjectLogRotateJob            1
StatusHistoryRescalerJob       2
UpdatePackagesIfDirtyJob       3
-----------Jobs by queue----------
quick                          3
issuetracking                  4
default                        598
project_log_rotate             1