### PR TITLE
Git cop

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,6 +30,7 @@ We tag our commits depending on the area that is affected by the change. Those a
 * [api]     - Changes in api related parts of app/model/ and lib/ as well as app/controllers/\*.rb and it's views
 * [backend] - Changes in the perl-written backend of OBS
 * [ci]      - Changes that affect our test suite
+* [dist]    - Modifies something inside /dist directory
 * [doc]     - Any documentation related changes
 
 # How to contribute issues

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,13 +25,41 @@ In particular, this community seeks the following types of contributions:
 * A developer of the [open-build-service team](https://github.com/orgs/openSUSE/teams/open-build-service) will review your pull-request
   * If the pull request gets a positive review the reviewer will merge it
 
-We tag our commits depending on the area that is affected by the change. Those are
-* [webui]   - Changes in webui related parts of app/model/ and lib/ as well as app/controllers/webui/ and it's views
-* [api]     - Changes in api related parts of app/model/ and lib/ as well as app/controllers/\*.rb and it's views
-* [backend] - Changes in the perl-written backend of OBS
-* [ci]      - Changes that affect our test suite
-* [dist]    - Modifies something inside /dist directory
-* [doc]     - Any documentation related changes
+
+## How to write proper commit messages
+
+- **Tag your commits**
+
+  We tag our commits depending on the area that is affected by the change. All commits should start with at least one tag from:
+
+  * [api]     - Changes in api related parts of app/model/ and lib/ as well as app/controllers/\*.rb and it's views
+  * [backend] - Changes in the perl-written backend of OBS
+  * [ci]      - Changes that affect our test suite
+  * [dist]    - Modifies something inside /dist directory
+  * [doc]     - Any documentation related changes
+  * [webui]   - Changes in webui related parts of app/model/ and lib/ as well as app/controllers/webui/ and it's views
+
+  In case of having more than one tag, they should be alphabetically ordered.
+  
+- **Leave a blank line between the commit subject and body**
+
+  Tools like rebase could not work properly otherwise.
+
+- **Preferably include a commit description**
+  
+  There is always some useful information to add in your commit. If you don't include a commit description, more likely you are missing something.
+
+- **Try that the commit subject is not longer than 50 characters**
+
+- **Try that each line of the commit body is not longer than 72 characters**
+
+- **Try to avoid meaningless words/phrases**
+
+  When possible avoid using words/phrases such as _obviously_, _basically_, _simply_, _of course_, _everyone knows_ and _easy_.
+
+- **Preferably use `-` for lists**
+
+  Do not use `*` as it is also used for _emphasis_.
 
 # How to contribute issues
 * Prerequisites: familiarity with [GitHub Issues](https://guides.github.com/features/issues/).

--- a/dist/ci/travis_before_script.sh
+++ b/dist/ci/travis_before_script.sh
@@ -8,6 +8,10 @@ sed -i -e "s|my \$hostname = .*$|my \$hostname = 'localhost';|" \
 cp src/backend/BSConfig.pm.template src/backend/BSConfig.pm
 chmod a+x src/api/script/start_test_backend
 
+echo "Configuring git-cop"
+mkdir -p ~/.config/git-cop
+cp dist/git-cop_configuration.yml ~/.config/git-cop/configuration.yml
+
 pushd src/api
 echo "Creating database"
 mysql -e 'create database ci_api_test;'

--- a/dist/ci/travis_script.sh
+++ b/dist/ci/travis_script.sh
@@ -29,6 +29,7 @@ if test -z "$SUBTEST"; then
       make -C ../../ rubocop
       bundle exec rake haml_lint
       jshint .
+      bundle exec git-cop --police
       ;;
     rspec)
       bundle exec rails assets:precompile &> /dev/null

--- a/dist/git-cop_configuration.yml
+++ b/dist/git-cop_configuration.yml
@@ -1,0 +1,55 @@
+:commit_author_email:
+  :enabled: true
+  :severity: :error
+:commit_author_name_capitalization:
+  :enabled: false
+:commit_author_name_parts:
+  :enabled: false
+:commit_body_bullet:
+  :enabled: true
+  :severity: :warn
+  :blacklist:
+    - "\\*"
+    - "•"
+:commit_body_bullet_capitalization:
+  :enabled: false
+:commit_body_issue_tracker_link:
+  :enabled: false
+:commit_body_leading_line:
+  :enabled: true
+  :severity: :error
+:commit_body_leading_space:
+  :enabled: false
+:commit_body_line_length:
+  :enabled: true
+  :severity: :warn
+  :length: 72
+:commit_body_paragraph_capitalization:
+  :enabled: false
+:commit_body_phrase:
+  :enabled: true
+  :severity: :warn
+  :blacklist:
+    - obviously
+    - basically
+    - simply
+    - of course
+    - everyone knows
+    - easy
+:commit_body_presence:
+  :enabled: true
+  :severity: :warn
+  :minimum: 1
+:commit_body_single_bullet:
+  :enabled: false
+:commit_subject_length:
+  :enabled: true
+  :severity: :warn
+  :length: 50
+:commit_subject_prefix:
+  :enabled: true
+  :severity: :error
+  :whitelist:
+    - \A(?!\s)(\[api\])?(\[backend\])?(\[ci\])?(\[dist\])?(\[doc\])?(\[webui\])? [a-zA-Z]
+:commit_subject_suffix:
+  :enabled: false

--- a/src/api/Gemfile
+++ b/src/api/Gemfile
@@ -119,6 +119,8 @@ group :test do
   gem 'rails-controller-testing'
   # To generate random data
   gem 'rantly', '>= 1.1.0'
+  # To ensure consistent Git commits
+  gem 'git-cop', '>=1.5.0'
 end
 
 # Gems used only during development not required in production environments by default.

--- a/src/api/Gemfile.lock
+++ b/src/api/Gemfile.lock
@@ -111,6 +111,7 @@ GEM
       delayed_job (>= 3.0, < 5)
     diff-lcs (1.3)
     docile (1.1.5)
+    equatable (0.5.0)
     erubi (1.6.0)
     escape_utils (1.2.1)
     execjs (2.7.0)
@@ -131,6 +132,11 @@ GEM
       jquery-rails
     font-awesome-rails (4.7.0.2)
       railties (>= 3.2, < 5.2)
+    git-cop (1.5.0)
+      pastel (~> 0.7)
+      refinements (~> 4.2)
+      runcom (~> 1.2)
+      thor (~> 0.19)
     globalid (0.4.0)
       activesupport (>= 4.2.0)
     gssapi (1.2.0)
@@ -211,6 +217,9 @@ GEM
     parallel (1.11.2)
     parser (2.4.0.0)
       ast (~> 2.2)
+    pastel (0.7.1)
+      equatable (~> 0.5.0)
+      tty-color (~> 0.4.0)
     path_expander (1.0.2)
     peek (1.0.1)
       concurrent-ruby (>= 0.9.0)
@@ -278,6 +287,7 @@ GEM
     rantly (1.1.0)
     rdoc (5.1.0)
     redcarpet (3.4.0)
+    refinements (4.2.0)
     responders (2.4.0)
       actionpack (>= 4.2.0, < 5.3)
       railties (>= 4.2.0, < 5.3)
@@ -314,6 +324,8 @@ GEM
     ruby-progressbar (1.8.1)
     ruby_parser (3.9.0)
       sexp_processor (~> 4.1)
+    runcom (1.2.0)
+      refinements (~> 4.2)
     safe_yaml (1.0.4)
     sanitize (4.5.0)
       crass (~> 1.0.2)
@@ -360,6 +372,7 @@ GEM
     thread_safe (0.3.6)
     tilt (2.0.8)
     timecop (0.9.1)
+    tty-color (0.4.2)
     tzinfo (1.2.3)
       thread_safe (~> 0.1)
     uglifier (3.2.0)
@@ -422,6 +435,7 @@ DEPENDENCIES
   flog (> 4.1.0)
   flot-rails
   font-awesome-rails
+  git-cop (>= 1.5.0)
   gssapi
   haml
   haml_lint


### PR DESCRIPTION
Adding `git-cop` gem to improve our commits.

### Enabled cops with error severity

- `commit_author_email`: Ensures author email address exists.

- `commit_body_leading_line`: Ensures there is blank line between the commit subject and body.

- `commit_subject_prefix`: Ensure that the commit has one or more tags (*api*, *app*, *backend*, *ci*, *dist*, *doc*, *webui*) alphabetically ordered.

### Enabled cops with warning severity (a message is render when executing git-cop but it doesn't fail)

- `commit_body_bullet`: enforce `-` for lists.

- `commit_body_line_length`:  Ensures each line of the commit body is not longer than 72 characters.

- `commit_body_phrase`: Avoid meaningless words/phrases.

- `commit_body_presence`: Ensures the commit has a description.

- `commit_subject_length`: Ensures the commit subject length is not more than 50 characters.


I also added a *How to write proper commit messages* section to the our contributing file which include the git-cop current configuration. :bowtie: 