### PR TITLE
[webui] Help the user to introduce valid kiwi data

### DIFF
--- a/src/api/app/assets/javascripts/webui/application/kiwi_editor.js
+++ b/src/api/app/assets/javascripts/webui/application/kiwi_editor.js
@@ -28,22 +28,38 @@ function editDialog(){
 
 function closeDialog() {
   var fields = $(this).parents('.nested-fields');
+  var is_repository = fields.parents('#kiwi-repositories-list').size() == 1;
   var name = fields.find('.kiwi_element_name');
   var dialog = fields.find('.dialog');
-  var namePackage = dialog.find("[id$='name']").val();
-  if (namePackage != '') {
-    name.text(namePackage);
-  }
-  else {
-    var alias = dialog.find("[id$='alias']");
-    if (alias.val() != '') {
-      name.text(alias.val());
+  
+  if(is_repository) {
+    var source_path = dialog.find("[id$='source_path']");
+    if(source_path.val() != '') {
+      var alias = dialog.find("[id$='alias']");
+      if (alias.val() != '') {
+        name.text(alias.val());
+      }
+      else {
+        name.text(source_path.val().replace(/\//g, '_'));
+      }
     }
     else {
-      var source_path = dialog.find("[id$='source_path']");
-      name.text(source_path.val().replace(/\//g, '_'));
+      fields.find(".ui-state-error").removeClass('hidden');
+      return false;
     }
   }
+  else {
+    var namePackage = dialog.find("[id$='name']").val();
+    if(namePackage != '') {
+      name.text(namePackage);
+    }
+    else {
+      fields.find(".ui-state-error").removeClass('hidden');
+      return false;
+    }
+  }
+  
+  fields.find(".ui-state-error").addClass('hidden');
   $('.overlay').hide();
   dialog.addClass('hidden');
 }

--- a/src/api/app/assets/stylesheets/webui/application/kiwi_image.scss
+++ b/src/api/app/assets/stylesheets/webui/application/kiwi_image.scss
@@ -26,6 +26,8 @@
   margin-left: 10px;
   margin-top: 5px;
   display: inline-block;
+  
+  .small-text{ font-size: x-small; }
 }
 
 .kiwi_list_item {

--- a/src/api/app/views/webui/kiwi/images/_package_fields.html.haml
+++ b/src/api/app/views/webui/kiwi/images/_package_fields.html.haml
@@ -24,5 +24,9 @@
         = f.check_box :bootdelete
         = f.label :bootdelete
 
+      %p#flash-messages
+        %p.ui-state-error.ui-widget-shadow.hidden
+          The name can not be empty!
+
       .dialog-buttons
         = link_to('Continue', '#', title: 'Continue', class: 'close-dialog')

--- a/src/api/app/views/webui/kiwi/images/_repository_fields.html.haml
+++ b/src/api/app/views/webui/kiwi/images/_repository_fields.html.haml
@@ -21,6 +21,8 @@
         %p
           = f.label :source_path, 'Source:'
           = f.text_field :source_path
+          %span.small-text
+            Write a valid source path
 
         %p
           = f.label :username, 'User:'
@@ -35,6 +37,10 @@
         = f.label :imageinclude, 'Image include'
         = f.check_box :replaceable
         = f.label :replaceable
+
+      %p#flash-messages
+        %p.ui-state-error.ui-widget-shadow.hidden
+          The source path can not be empty!
 
       .dialog-buttons
         = link_to('Continue', '#', title: 'Continue', class: 'close-dialog')


### PR DESCRIPTION
Add help and error messages in the kiwi repository and package dialog. Any error was before rendered until clicking the Save button, which is confusing and annoying for the user. :bowtie: 

![image](https://user-images.githubusercontent.com/16052290/28925040-f798a136-7863-11e7-9bbb-b9d7421db657.png)

![image](https://user-images.githubusercontent.com/16052290/28925063-0ab10d58-7864-11e7-91ea-888455bf9a02.png)

Pair-programmed by @DavidKang and @Ana06.