### PR TITLE
[api] avoid crashes when operating on remote packages

### DIFF
--- a/src/api/app/helpers/validation_helper.rb
+++ b/src/api/app/helpers/validation_helper.rb
@@ -26,8 +26,10 @@ module ValidationHelper
   # load last package meta file and just check if sourceaccess flag was used at all, no per user checking atm
   def validate_read_access_of_deleted_package(project, name)
     prj = Project.get_by_name project
-    raise Project::ReadAccessError, project.to_s if prj.disabled_for? 'access', nil, nil
-    raise Package::ReadSourceAccessError, "#{target_project_name}/#{target_package_name}" if prj.disabled_for? 'sourceaccess', nil, nil
+    if prj.kind_of? Project
+      raise Project::ReadAccessError, project.to_s if prj.disabled_for? 'access', nil, nil
+      raise Package::ReadSourceAccessError, "#{target_project_name}/#{target_package_name}" if prj.disabled_for? 'sourceaccess', nil, nil
+    end
 
     begin
       r = Backend::Connection.get("/source/#{CGI.escape(project)}/#{name}/_history?deleted=1&meta=1")


### PR DESCRIPTION
Should fix eg:

undefined method `disabled_for?' for "openSUSE.org:openSUSE:Factory":String

app/helpers/validation_helper.rb:29
app/controllers/source_controller.rb:718