### PR TITLE
[api] SourceController#project_command_copy uses ActiveJob

### DIFF
--- a/src/api/app/controllers/source_controller.rb
+++ b/src/api/app/controllers/source_controller.rb
@@ -1138,8 +1138,12 @@ class SourceController < ApplicationController
       @project.do_project_copy(params)
       render_ok
     else
-      # inject as job
-      @project.delay.do_project_copy(params)
+      job_params =
+        params.slice(
+          :cmd, :user, :comment, :oproject, :withbinaries, :withhistory, :makeolder, :makeoriginolder, :noservice
+        ).permit!.to_h
+
+      ProjectDoProjectCopyJob.perform_later(@project.id, job_params)
       render_invoked
     end
   end

--- a/src/api/app/jobs/project_do_project_copy_job.rb
+++ b/src/api/app/jobs/project_do_project_copy_job.rb
@@ -1,0 +1,7 @@
+class ProjectDoProjectCopyJob < ApplicationJob
+  queue_as :quick
+
+  def perform(project_id, params)
+    Project.find(project_id).do_project_copy(params)
+  end
+end

--- a/src/api/test/unit/code_quality_test.rb
+++ b/src/api/test/unit/code_quality_test.rb
@@ -89,7 +89,7 @@ class CodeQualityTest < ActiveSupport::TestCase
       'RequestController#render_request_collection'                             => 85.91,
       'SearchController#find_attribute'                                         => 97.33,
       'SearchController#search'                                                 => 81.15,
-      'SourceController#project_command_copy'                                   => 133.93,
+      'SourceController#project_command_copy'                                   => 138.83,
       'SourceController#update_project_meta'                                    => 98.09,
       'UserLdapStrategy::find_with_ldap'                                        => 122.14,
       'User::find_with_credentials'                                             => 101.42,


### PR DESCRIPTION
Part of this card: https://trello.com/c/Tx9d3bUb/467-5-p4-event-system-change-delayed-jobs-to-be-created-with-activejobs