### PR TITLE
[frontend] Use new job trigger in old migrations

### DIFF
--- a/src/api/db/migrate/20141002130129_new_suse_bugzillas.rb
+++ b/src/api/db/migrate/20141002130129_new_suse_bugzillas.rb
@@ -10,7 +10,8 @@ class NewSuseBugzillas < ActiveRecord::Migration[4.2]
     t.show_url = "https://bugzilla.opensuse.org/show_bug.cgi?id=@@@"
     t.save
     Delayed::Worker.delay_jobs = true
-    IssueTracker.write_to_backend
+    # trigger IssueTracker delayed jobs
+    IssueTracker.first.try(:save)
   end
 
   def down
@@ -24,6 +25,7 @@ class NewSuseBugzillas < ActiveRecord::Migration[4.2]
     t.show_url = "https://bugzilla.novell.com/show_bug.cgi?id=@@@"
     t.save
     Delayed::Worker.delay_jobs = true
-    IssueTracker.write_to_backend
+    # trigger IssueTracker delayed jobs
+    IssueTracker.first.try(:save)
   end
 end

--- a/src/api/db/migrate/20150112135426_adapt_cve_tracker.rb
+++ b/src/api/db/migrate/20150112135426_adapt_cve_tracker.rb
@@ -7,7 +7,8 @@ class AdaptCveTracker < ActiveRecord::Migration[4.2]
       t.show_url = "http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-@@@"
       t.save
       Delayed::Worker.delay_jobs = true
-      IssueTracker.write_to_backend
+      # trigger IssueTracker delayed jobs
+      IssueTracker.first.try(:save)
 
       t.issues.each do |i|
         i.name.gsub!(/^CVE-/, '')
@@ -25,7 +26,8 @@ class AdaptCveTracker < ActiveRecord::Migration[4.2]
       t.show_url = "http://cve.mitre.org/cgi-bin/cvename.cgi?name=@@@"
       t.save
       Delayed::Worker.delay_jobs = true
-      IssueTracker.write_to_backend
+      # trigger IssueTracker delayed jobs
+      IssueTracker.first.try(:save)
 
       t.issues.each do |i|
         i.name = "CVE-" + i.name

--- a/src/api/db/migrate/20161117135426_extend_xamarin_matching.rb
+++ b/src/api/db/migrate/20161117135426_extend_xamarin_matching.rb
@@ -5,7 +5,8 @@ class ExtendXamarinMatching < ActiveRecord::Migration[4.2]
       t.regex = '(?:bxc|Xamarin)#(\d+)'
       t.save
       Delayed::Worker.delay_jobs = true
-      IssueTracker.write_to_backend
+      # trigger IssueTracker delayed jobs
+      IssueTracker.first.try(:save)
     end
   end
 
@@ -15,7 +16,8 @@ class ExtendXamarinMatching < ActiveRecord::Migration[4.2]
       t.regex = 'Xamarin#(\d+)'
       t.save
       Delayed::Worker.delay_jobs = true
-      IssueTracker.write_to_backend
+      # trigger IssueTracker delayed jobs
+      IssueTracker.first.try(:save)
     end
   end
 end


### PR DESCRIPTION
A classic example of why you should never use AR models in your migrations...

Fixes #3515