### PR TITLE
[ci] Make regex we use for git-cop more flexible

### DIFF
--- a/dist/git-cop_configuration.yml
+++ b/dist/git-cop_configuration.yml
@@ -50,6 +50,8 @@
   :enabled: true
   :severity: :error
   :whitelist:
+    # Allow api, backend, ci, dist, doc, frontend and webui tags in edgy brackets in any order,
+    # followed by the actual commit message of alphabetical characters
     - \A(?!\s)(?:\[api\]|\[backend\]|\[ci\]|\[dist\]|\[doc\]|\[frontend\]|\[webui\])+ [a-zA-Z]
 :commit_subject_suffix:
   :enabled: false

--- a/dist/git-cop_configuration.yml
+++ b/dist/git-cop_configuration.yml
@@ -50,6 +50,6 @@
   :enabled: true
   :severity: :error
   :whitelist:
-    - \A(?!\s)(\[api\])?(\[backend\])?(\[ci\])?(\[dist\])?(\[doc\])?(\[webui\])? [a-zA-Z]
+    - \A(?!\s)(?:\[api\]|\[backend\]|\[ci\]|\[dist\]|\[doc\]|\[frontend\]|\[webui\])+ [a-zA-Z]
 :commit_subject_suffix:
   :enabled: false

--- a/dist/git-cop_configuration.yml
+++ b/dist/git-cop_configuration.yml
@@ -54,7 +54,7 @@
     #   * api, backend, ci, dist, doc, frontend and webui tags in edgy brackets in any order
     # or
     #   * 'Update' or 'Upgrade' (needed by depfu gem)
-    # In both cases they should be followed by the actual commit message of alphabetical characters
-    - \A(?!\s)(?:Update|Upgrade|\[api\]|\[backend\]|\[ci\]|\[dist\]|\[doc\]|\[frontend\]|\[webui\])+ [a-zA-Z]
+    # In both cases they should be followed by the actual commit message subject
+    - \A(?!\s)(?:Update|Upgrade|\[api\]|\[backend\]|\[ci\]|\[dist\]|\[doc\]|\[frontend\]|\[webui\])+ \S+
 :commit_subject_suffix:
   :enabled: false

--- a/dist/git-cop_configuration.yml
+++ b/dist/git-cop_configuration.yml
@@ -50,8 +50,11 @@
   :enabled: true
   :severity: :error
   :whitelist:
-    # Allow api, backend, ci, dist, doc, frontend and webui tags in edgy brackets in any order,
-    # followed by the actual commit message of alphabetical characters
-    - \A(?!\s)(?:\[api\]|\[backend\]|\[ci\]|\[dist\]|\[doc\]|\[frontend\]|\[webui\])+ [a-zA-Z]
+    # Commit header is allowed to start with either
+    #   * api, backend, ci, dist, doc, frontend and webui tags in edgy brackets in any order
+    # or
+    #   * 'Update' or 'Upgrade' (needed by depfu gem)
+    # In both cases they should be followed by the actual commit message of alphabetical characters
+    - \A(?!\s)(?:Update|Upgrade|\[api\]|\[backend\]|\[ci\]|\[dist\]|\[doc\]|\[frontend\]|\[webui\])+ [a-zA-Z]
 :commit_subject_suffix:
   :enabled: false


### PR DESCRIPTION
* Allows tags that are not sorted alphabetically.
* Adds frontend tag as to valid tags list