### PR TITLE
[ci][api] Adopt migration to recent changes

### DIFF
--- a/src/api/db/migrate/20141002130129_new_suse_bugzillas.rb
+++ b/src/api/db/migrate/20141002130129_new_suse_bugzillas.rb
@@ -10,7 +10,7 @@ class NewSuseBugzillas < ActiveRecord::Migration[4.2]
     t.show_url = "https://bugzilla.opensuse.org/show_bug.cgi?id=@@@"
     t.save
     Delayed::Worker.delay_jobs = true
-    IssueTracker.write_to_backend
+    IssueTrackerWriteToBackendJob.perform_later
   end
 
   def down
@@ -24,6 +24,6 @@ class NewSuseBugzillas < ActiveRecord::Migration[4.2]
     t.show_url = "https://bugzilla.novell.com/show_bug.cgi?id=@@@"
     t.save
     Delayed::Worker.delay_jobs = true
-    IssueTracker.write_to_backend
+    IssueTrackerWriteToBackendJob.perform_later
   end
 end


### PR DESCRIPTION
Updates the migration to run with the new way of writing to
backend (5d261f7b087381231a2c2a6c64bfe297d9c3d409).
This was breaking our package builds.