### PR TITLE
[webui] Drop caching of LDAP user logins

### DIFF
--- a/src/api/app/controllers/webui/user_controller.rb
+++ b/src/api/app/controllers/webui/user_controller.rb
@@ -14,7 +14,6 @@ class Webui::UserController < Webui::WebuiController
 
   def logout
     logger.info "Logging out: #{session[:login]}"
-    Rails.cache.delete("ldap_cache_userpasswd:#{session[:login]}")
     reset_session
     User.current = nil
     if CONFIG['proxy_auth_mode'] == :on

--- a/src/api/app/models/user_ldap_strategy.rb
+++ b/src/api/app/models/user_ldap_strategy.rb
@@ -193,17 +193,6 @@ class UserLdapStrategy
   def self.find_with_ldap(login, password)
     Rails.logger.debug("Looking for #{login} using ldap")
     ldap_info = Array.new
-    # use cache to check the password firstly
-    key = "ldap_cache_userpasswd:" + login
-    if Rails.cache.exist?(key)
-      ar = Rails.cache.read(key)
-      if ar[0] == Digest::MD5.digest(password)
-        ldap_info[0] = ar[1]
-        ldap_info[1] = ar[2]
-        Rails.logger.debug("login success for checking with ldap cache")
-        return ldap_info
-      end
-    end
 
     # When the server closes the connection, @@ldap_search_con.nil? doesn't catch it
     # @@ldap_search_con.bound? doesn't catch it as well. So when an error occurs, we


### PR DESCRIPTION
This isn't needed since we use sessions. Also we should always query the
LDAP server when in doubt. Caching user credentials is no option.