### PR TITLE
[webui] Add `external` column to `users` table

### DIFF
--- a/src/api/app/models/unregistered_user.rb
+++ b/src/api/app/models/unregistered_user.rb
@@ -85,6 +85,7 @@ end
 #  password_hash_type  :string(20)       default("md5"), not null
 #  password_salt       :string(10)       default("1234512345"), not null
 #  adminnote           :text(65535)
+#  external            :boolean          default(FALSE)
 #  state               :string(11)       default("unconfirmed")
 #  owner_id            :integer
 #

--- a/src/api/app/models/user.rb
+++ b/src/api/app/models/user.rb
@@ -241,6 +241,7 @@ class User < ApplicationRecord
       user.realname = ldap_info[1]
       user.state = User.default_user_state
       user.adminnote = "User created via LDAP"
+      user.external = true
       logger.debug( "saving new user..." )
       user.save
     end
@@ -970,6 +971,7 @@ end
 #  password_hash_type  :string(20)       default("md5"), not null
 #  password_salt       :string(10)       default("1234512345"), not null
 #  adminnote           :text(65535)
+#  external            :boolean          default(FALSE)
 #  state               :string(11)       default("unconfirmed")
 #  owner_id            :integer
 #

--- a/src/api/db/migrate/20170809101453_add_ldap_column_to_users_table.rb
+++ b/src/api/db/migrate/20170809101453_add_ldap_column_to_users_table.rb
@@ -1,0 +1,10 @@
+class AddLdapColumnToUsersTable < ActiveRecord::Migration[5.1]
+  def change
+    add_column :users, :ldap, :boolean, after: :adminnote
+
+    # ldap users have a note in the `adminnote` column that states that the user is a ldap user.
+    # Let's transfer this information in a dedicated field since the adminnote field can also
+    # be used for something else
+    User.where(adminnote: 'User created via LDAP').update_all(ldap: true)
+  end
+end

--- a/src/api/db/migrate/20170809114854_add_default_value_for_ldap_column_in_users_table.rb
+++ b/src/api/db/migrate/20170809114854_add_default_value_for_ldap_column_in_users_table.rb
@@ -1,0 +1,7 @@
+class AddDefaultValueForLdapColumnInUsersTable < ActiveRecord::Migration[5.1]
+  def change
+    change_column :users, :ldap, :boolean, default: false, after: :adminnote
+
+    User.where(ldap: nil).update_all(ldap: false)
+  end
+end

--- a/src/api/db/migrate/20170809115240_rename_ldap_column_in_users_table.rb
+++ b/src/api/db/migrate/20170809115240_rename_ldap_column_in_users_table.rb
@@ -1,0 +1,5 @@
+class RenameLdapColumnInUsersTable < ActiveRecord::Migration[5.1]
+  def change
+    rename_column :users, :ldap, :external
+  end
+end

--- a/src/api/db/structure.sql
+++ b/src/api/db/structure.sql
@@ -1155,6 +1155,7 @@ CREATE TABLE `users` (
   `password_hash_type` varchar(20) COLLATE utf8_bin NOT NULL DEFAULT 'md5',
   `password_salt` varchar(10) CHARACTER SET utf8 NOT NULL DEFAULT '1234512345',
   `adminnote` text CHARACTER SET utf8,
+  `external` tinyint(1) DEFAULT '0',
   `state` enum('unconfirmed','confirmed','locked','deleted','subaccount') COLLATE utf8_bin DEFAULT 'unconfirmed',
   `owner_id` int(11) DEFAULT NULL,
   PRIMARY KEY (`id`),
@@ -1276,6 +1277,9 @@ INSERT INTO `schema_migrations` (version) VALUES
 ('20170704133728'),
 ('20170704212201'),
 ('20170710133627'),
-('20170710134059');
+('20170710134059'),
+('20170809101453'),
+('20170809114854'),
+('20170809115240');
 
 


### PR DESCRIPTION
It's not really clear if a user comes from extern or signed up locally.
This can harm us if we want to distinguish between users who signed up
locally (for example the Admin user) and people that come from LDAP or
some other service. For this, we need an extra column in the `users`
table. The field `adminnote` is not really a good idea to match against
it since it's a string and can also be used for different stuff in the
future.

Users which signed up externally have the field `adminnote` set to `User
created via LDAP`. We can safely migrate all existing users since the
field `adminnote` is not yet changable without directly manipulating the
field in the database. @adrianschroeter said it's a safe approach.