### PR TITLE
[api] fix BsRequestActionWebuiInfosJob 

### DIFF
--- a/src/api/app/controllers/request_controller.rb
+++ b/src/api/app/controllers/request_controller.rb
@@ -156,7 +156,7 @@ class RequestController < ApplicationController
 
     # cache the diff (in the backend)
     @req.bs_request_actions.each do |a|
-      BsRequestActionWebuiInfosJob.perform_later(a.id)
+      BsRequestActionWebuiInfosJob.perform_later(a)
     end
 
     render xml: xml

--- a/src/api/app/jobs/bs_request_action_webui_infos_job.rb
+++ b/src/api/app/jobs/bs_request_action_webui_infos_job.rb
@@ -1,7 +1,7 @@
 class BsRequestActionWebuiInfosJob < ApplicationJob
   queue_as :quick
 
-  def perform(request_action_id)
-    BsRequestAction.find(request_action_id).webui_infos
+  def perform(request_action)
+    request_action.webui_infos
   end
 end

--- a/src/api/spec/jobs/bs_request_action_webui_infos_job.rb
+++ b/src/api/spec/jobs/bs_request_action_webui_infos_job.rb
@@ -11,7 +11,7 @@ RSpec.describe BsRequestActionWebuiInfosJob, type: :job do
       allow(request_action).to receive(:webui_infos)
     end
 
-    subject! { BsRequestActionWebuiInfosJob.new.perform(request_action.id) }
+    subject! { BsRequestActionWebuiInfosJob.new.perform(request_action) }
 
     it 'calls webui_infos on the request_action' do
       expect(request_action).to have_received(:webui_infos)


### PR DESCRIPTION
by serialising the object and not just the id.

Otherwise BsRequestAction tries to call User.current which doesnt exist
in the delayed job context.