### PR TITLE
[api] UpdatePackagesIfDirtyJob: serialise the project object instead of id

### DIFF
--- a/src/api/app/jobs/update_packages_if_dirty_job.rb
+++ b/src/api/app/jobs/update_packages_if_dirty_job.rb
@@ -4,6 +4,7 @@ class UpdatePackagesIfDirtyJob < ApplicationJob
   self.priority = 10
 
   def perform(project_id)
-    Project.find(project_id).update_packages_if_dirty
+    project = Project.find(project_id)
+    project.update_packages_if_dirty if project.present?
   end
 end


### PR DESCRIPTION
To avoid getting "project not found" when this gets called on a project
that is being deleted.