### PR TITLE
[webui] Add vertical scrolling to codemirror diff

### DIFF
--- a/src/api/app/assets/stylesheets/webui/application/cm2/suse.scss
+++ b/src/api/app/assets/stylesheets/webui/application/cm2/suse.scss
@@ -4,6 +4,10 @@
   height: auto;
 }
 
+.action_display .CodeMirror-scroll {
+  max-height: 800px;
+}
+
 .CodeMirror-scroll {
   overflow-y: hidden;
   overflow-x: auto;


### PR DESCRIPTION
to fit on one page if the diff is really long.

Fixes #3186.

![request_diff_codemirror](https://user-images.githubusercontent.com/3799140/29169772-04ead814-7dd6-11e7-9d03-7cd111f10782.png)
