### PR TITLE
[webui] Drop editing LDAP user accounts

### DIFF
--- a/ReleaseNotes-2.9
+++ b/ReleaseNotes-2.9
@@ -53,6 +53,8 @@ Wanted changes:
 
  * service dispatcher is used by default now
 
+ * The editing of a user's realname, email adress or password is no longer possible if LDAP mode is activated
+
 Other changes
 =============
 

--- a/src/api/app/controllers/person_controller.rb
+++ b/src/api/app/controllers/person_controller.rb
@@ -51,7 +51,7 @@ class PersonController < ApplicationController
     if params[:cmd] == "change_password"
       login ||= User.current.login
       password = request.raw_post.to_s.chomp
-      if login != User.current.login && !User.current.is_admin?
+      if (login != User.current.login && !User.current.is_admin?) || !::Configuration.passwords_changable?
         render_error status: 403, errorcode: "change_password_no_permission",
                      message: "No permission to change password for user #{login}"
         return

--- a/src/api/app/models/configuration.rb
+++ b/src/api/app/models/configuration.rb
@@ -71,6 +71,19 @@ class Configuration < ApplicationRecord
   end
   # End of class methods
 
+  def ldap_enabled?
+    CONFIG['ldap_mode'] == :on
+  end
+
+  def passwords_changable?
+    change_password && CONFIG['proxy_auth_mode'] != :on && CONFIG['ldap_mode'] != :on
+  end
+
+  def accounts_editable?
+    (CONFIG['proxy_auth_mode'] != :on || (CONFIG['proxy_auth_mode'] == :on && !CONFIG['proxy_auth_account_page'].blank?)) && \
+      CONFIG['ldap_mode'] != :on
+  end
+
   def update_from_options_yml
     # strip the not set ones
     attribs = ::Configuration::OPTIONS_YML.clone

--- a/src/api/app/views/webui/user/edit.html.haml
+++ b/src/api/app/views/webui/user/edit.html.haml
@@ -9,14 +9,15 @@
 
 = form_for(@displayed_user, url: user_save_path, method: 'post') do |f|
   = f.hidden_field(:login)
-  %p
-    = f.label(:realname, "Name:")
-    %br
-    = f.text_field(:realname)
-  %p
-    = f.label(:email, "e-Mail:")
-    %br
-    = f.text_field(:email, required: true, email: true)
+  - unless @configuration.ldap_enabled?
+    %p
+      = f.label(:realname, "Name:")
+      %br
+      = f.text_field(:realname)
+    %p
+      = f.label(:email, "e-Mail:")
+      %br
+      = f.text_field(:email, required: true, email: true)
   %p
     = f.collection_check_boxes(:role_ids, Role.global, :id, :title)
   %p

--- a/src/api/app/views/webui/user/show.html.haml
+++ b/src/api/app/views/webui/user/show.html.haml
@@ -33,14 +33,14 @@
   / edit
   - if @is_displayed_user
     %p
-      - if CONFIG['proxy_auth_mode'] == :on
-        - unless CONFIG['proxy_auth_account_page'].blank?
-          = link_to sprited_text('user_edit', 'Edit your account'), "#{CONFIG['proxy_auth_account_page']}"
+      - if @configuration.accounts_editable?
+        - if @account_edit_link.present?
+          = link_to sprited_text('user_edit', 'Edit your account'), @account_edit_link
           %br/
-      - else
-        = link_to(sprited_text('user_edit', 'Edit your account'), { controller: 'user', action: 'save_dialog', user: User.current }, {id: 'save_dialog', remote: true})
+        - else
+          = link_to(sprited_text('user_edit', 'Edit your account'), { controller: 'user', action: 'save_dialog', user: User.current }, {id: 'save_dialog', remote: true})
         %br/
-      - if @configuration['change_password'] && CONFIG['proxy_auth_mode'] != :on
+      - if @configuration.passwords_changable?
         = link_to(sprited_text('key', 'Change your password'), { controller: 'user', action: 'password_dialog', user: User.current }, {id: 'password_dialog', remote: true})
         %br/
       = link_to(sprited_text('email', 'Change your notifications'), user_notifications_path)

--- a/src/api/spec/controllers/person_controller_spec.rb
+++ b/src/api/spec/controllers/person_controller_spec.rb
@@ -1,0 +1,23 @@
+require 'rails_helper'
+# WARNING: If you change tests make sure you uncomment this line
+# and start a test backend. Some of the actions
+# require real backend answers for projects/packages.
+# CONFIG['global_write_through'] = true
+
+RSpec.describe PersonController, vcr: false do
+  describe 'POST #post_userinfo' do
+    let(:user) { create(:confirmed_user) }
+
+    context 'when in LDAP mode' do
+      before do
+        login user
+        stub_const('CONFIG', CONFIG.merge({ 'ldap_mode' => :on }))
+        post :post_userinfo, params: { login: user.login, cmd: 'change_password', format: :xml }
+      end
+
+      it 'user is not allowed to change their password' do
+        expect(response.header['X-Opensuse-Errorcode']).to eq('change_password_no_permission')
+      end
+    end
+  end
+end

--- a/src/api/spec/controllers/webui/user_controller_spec.rb
+++ b/src/api/spec/controllers/webui/user_controller_spec.rb
@@ -220,6 +220,43 @@ RSpec.describe Webui::UserController do
         expect(user.roles).to match_array old_global_role
       end
     end
+
+    context "when LDAP mode is enabled" do
+      let!(:old_realname) { user.realname }
+      let!(:old_email) { user.email }
+      let(:http_request) {
+        post :save, params: { user: { login: user.login, realname: 'another real name', email: 'new_valid@email.es' } }
+      }
+
+      before do
+        stub_const('CONFIG', CONFIG.merge({ 'ldap_mode' => :on }))
+      end
+
+      describe "as an admin user" do
+        before do
+          login admin_user
+
+          http_request
+          user.reload
+        end
+
+        it { expect(user.realname).to eq(old_realname) }
+        it { expect(user.email).to eq(old_email) }
+      end
+
+      describe "as a user" do
+        before do
+          login user
+
+          http_request
+          user.reload
+        end
+
+        it { expect(controller).to set_flash[:error] }
+        it { expect(user.realname).to eq(old_realname) }
+        it { expect(user.email).to eq(old_email) }
+      end
+    end
   end
 
   describe "GET #delete" do
@@ -292,8 +329,17 @@ RSpec.describe Webui::UserController do
     skip
   end
 
-  describe "GET #change_password" do
-    skip
+  describe "POST #change_password" do
+    before do
+      login non_admin_user
+
+      stub_const('CONFIG', CONFIG.merge({ 'ldap_mode' => :on }))
+      post :change_password
+    end
+
+    it 'shows an error message when in LDAP mode' do
+      expect(controller).to set_flash[:error]
+    end
   end
 
   describe "GET #autocomplete" do

--- a/src/api/spec/models/configuration_spec.rb
+++ b/src/api/spec/models/configuration_spec.rb
@@ -33,4 +33,74 @@ RSpec.describe Configuration do
       expect(configuration).to have_received(:write_to_backend)
     end
   end
+
+  describe '#ldap_enabled?' do
+    let(:config) { Configuration.first }
+
+    it 'returns true if config option `ldap_mode` is set to :on' do
+      stub_const('CONFIG', CONFIG.merge({ 'ldap_mode' => :on }))
+      expect(config.ldap_enabled?).to eq(true)
+    end
+
+    it 'returns false if config option `ldap_mode` is not set to :on' do
+      stub_const('CONFIG', CONFIG.merge({ 'ldap_mode' => :off }))
+      expect(config.ldap_enabled?).to eq(false)
+    end
+  end
+
+  describe '#passwords_changable?' do
+    let(:config) { Configuration.first }
+
+    it 'returns false if config option `change_password` is set to false' do
+      allow(config).to receive(:change_password).and_return(false)
+      expect(config.passwords_changable?).to eq(false)
+    end
+
+    context 'external authentication services' do
+      it 'returns false if config option `proxy_auth_mode` is set to :on' do
+        stub_const('CONFIG', CONFIG.merge({ 'proxy_auth_mode' => :on }))
+        expect(config.passwords_changable?).to eq(false)
+      end
+
+      it 'returns false if config option `ldap_mode` is set to :on' do
+        stub_const('CONFIG', CONFIG.merge({ 'ldap_mode' => :on }))
+        expect(config.passwords_changable?).to eq(false)
+      end
+    end
+
+    context 'without external authentication services' do
+      it 'returns true' do
+        expect(config.passwords_changable?).to eq(true)
+      end
+    end
+  end
+
+  describe '#accounts_editable?' do
+    let(:config) { Configuration.first }
+
+    context 'proxy_auth_mode is enabled' do
+      before do
+        stub_const('CONFIG', CONFIG.merge({ 'proxy_auth_mode' => :on }))
+      end
+
+      it 'returns false if proxy_auth_account_page is not present' do
+        expect(config.accounts_editable?).to eq(false)
+      end
+
+      it 'returns true if proxy_auth_account_page is present' do
+        stub_const('CONFIG', CONFIG.merge({ 'proxy_auth_account_page' => 'https://opensuse.org' }))
+        expect(config.accounts_editable?).to eq(true)
+      end
+    end
+
+    context 'ldap_mode is enabled' do
+      before do
+        stub_const('CONFIG', CONFIG.merge({ 'ldap_mode' => :on }))
+      end
+
+      it 'returns false' do
+        expect(config.accounts_editable?).to eq(false)
+      end
+    end
+  end
 end


### PR DESCRIPTION
If the administrator activated the LDAP mode, it should no longer be possible to edit the user's realname, email address, and password.

The whole checks for access permissions and so on should be moved to Pundit. I started but it turned out it would be too big for this PR. So I propose the changes as requested in P3 and will work on refactoring after this was merged.