### PR TITLE
[webui] Extend KIWI repository source_path

### DIFF
--- a/src/api/app/models/kiwi/repository.rb
+++ b/src/api/app/models/kiwi/repository.rb
@@ -40,6 +40,7 @@ class Kiwi::Repository < ApplicationRecord
   end
 
   def source_path_format
+    return if source_path == 'obsrepositories:/'
     return if source_path =~ /^(dir|iso|smb|this):\/\/.+/
     return if source_path =~ /\A#{URI.regexp(['ftp', 'http', 'https', 'plain'])}\z/
     if source_path =~ /^obs:\/\/([^\/]+)\/([^\/]+)$/

--- a/src/api/spec/models/kiwi/repository_spec.rb
+++ b/src/api/spec/models/kiwi/repository_spec.rb
@@ -22,6 +22,10 @@ RSpec.describe Kiwi::Repository, type: :model do
     context 'for source_path' do
       it { is_expected.to validate_presence_of(:source_path) }
 
+      it "obsrepositories should be valid" do
+        is_expected.to allow_value('obsrepositories:/').for(:source_path)
+      end
+
       ['dir', 'iso', 'smb', 'this'].each do |protocol|
         it "valid" do
           property_of {


### PR DESCRIPTION
For source_path 'obsrepositories:/' is also valid.