### PR TITLE
[ci][webui] Fix handling global roles in user edit

### DIFF
--- a/src/api/app/controllers/person_controller.rb
+++ b/src/api/app/controllers/person_controller.rb
@@ -201,7 +201,7 @@ class PersonController < ApplicationController
       new_globalroles << e.to_s
     end
 
-    user.update_globalroles( new_globalroles )
+    user.update_globalroles(Role.global.where(title: new_globalroles))
   end
 
   private :update_globalroles

--- a/src/api/app/controllers/webui/user_controller.rb
+++ b/src/api/app/controllers/webui/user_controller.rb
@@ -1,7 +1,7 @@
 require 'event'
 
 class Webui::UserController < Webui::WebuiController
-  before_action :check_display_user, only: [:show, :edit, :list_my, :delete, :save, :confirm, :admin, :lock]
+  before_action :check_display_user, only: [:show, :edit, :list_my, :delete, :confirm, :admin, :lock]
   before_action :require_login, only: [:edit, :save, :notifications, :update_notifications, :index]
   before_action :require_admin, only: [:edit, :delete, :lock, :confirm, :admin, :index]
   before_action :kerberos_auth, only: [:login]
@@ -70,18 +70,20 @@ class Webui::UserController < Webui::WebuiController
   end
 
   def save
+    @displayed_user = User.find_by_login(params[:user][:login])
+
     unless User.current.is_admin?
       if User.current != @displayed_user
         flash[:error] = "Can't edit #{@displayed_user.login}"
-        redirect_back(fallback_location: root_path) && return
+        redirect_back(fallback_location: root_path)
+        return
       end
     end
-    @displayed_user.realname = params[:realname]
-    @displayed_user.email = params[:email]
+
+    @displayed_user.assign_attributes(params[:user].slice(:realname, :email).permit!)
     if User.current.is_admin?
-      @displayed_user.state = params[:state] if params[:state]
-      # FIXME: If we ever have more than one global this, and the view, has to be fixed
-      @displayed_user.update_globalroles([params[:globalrole]].compact)
+      @displayed_user.assign_attributes(params[:user].slice(:state).permit!)
+      @displayed_user.update_globalroles(Role.global.where(id: params[:user][:role_ids])) unless params[:user][:role_ids].nil?
     end
 
     begin
@@ -95,8 +97,6 @@ class Webui::UserController < Webui::WebuiController
   end
 
   def edit
-    @roles = Role.global_roles
-    @states = %w(confirmed unconfirmed deleted locked)
   end
 
   def delete
@@ -124,7 +124,6 @@ class Webui::UserController < Webui::WebuiController
   end
 
   def save_dialog
-    @roles = Role.global_roles
     render_dialog
   end
 

--- a/src/api/app/helpers/webui/user_helper.rb
+++ b/src/api/app/helpers/webui/user_helper.rb
@@ -1,0 +1,5 @@
+module Webui::UserHelper
+  def user_states_for_edit
+    %w(confirmed unconfirmed deleted locked)
+  end
+end

--- a/src/api/app/models/user.rb
+++ b/src/api/app/models/user.rb
@@ -869,10 +869,8 @@ class User < ApplicationRecord
     watched_project_names.include? name
   end
 
-  def update_globalroles(global_role_titles)
-    roles.replace(
-      Role.where(title: global_role_titles) + roles.where(global: false)
-    )
+  def update_globalroles(global_roles)
+    roles.replace(global_roles + roles.where(global: false))
   end
 
   # returns the gravatar image as string or :none

--- a/src/api/app/views/webui/user/_save_dialog.html.haml
+++ b/src/api/app/views/webui/user/_save_dialog.html.haml
@@ -2,16 +2,15 @@
   .box.box-shadow
     %h2.box-header Edit your account
     .dialog-content
-      = form_tag(action: 'save') do
-        %input#user{name: "user", type: "hidden", value: "#{User.current.login}"}/
+      = form_for(User.current, url: user_save_path, method: 'post') do |f|
+        = f.hidden_field(:login, id: 'user')
         %p
-          = label_tag :realname, 'Name:'
-          %br/
-          = text_field_tag :realname, User.current.realname
+          = f.label(:realname, "Name:")
+          %br
+          = f.text_field(:realname)
         %p
-          = label_tag :email, 'e-Mail:'
-          %br/
-          = email_field_tag :email, User.current.email, required: true, email: true
+          = f.label(:email, "e-Mail:")
+          = f.text_field(:email, required: true, email: true)
         .dialog-buttons
           = submit_tag("Ok")
           = remove_dialog_tag('Cancel')

--- a/src/api/app/views/webui/user/edit.html.haml
+++ b/src/api/app/views/webui/user/edit.html.haml
@@ -7,22 +7,19 @@
 %h2
   = "Editing User Data for User #{@displayed_user.login}"
 
-= form_tag(action: "save") do
+= form_for(@displayed_user, url: user_save_path, method: 'post') do |f|
+  = f.hidden_field(:login)
   %p
-    = hidden_field_tag("user", @displayed_user.login)
-    = label_tag(:realname, "Name:")
+    = f.label(:realname, "Name:")
     %br
-    = text_field_tag(:realname, @displayed_user.realname)
+    = f.text_field(:realname)
   %p
-    = label_tag(:email, "e-Mail:")
+    = f.label(:email, "e-Mail:")
     %br
-    = text_field_tag(:email, @displayed_user.email, required: true, email: true)
+    = f.text_field(:email, required: true, email: true)
   %p
-    = label_tag(:globalrole, "Admin:")
-    = check_box_tag("globalrole", "Admin", @displayed_user.is_admin?)
+    = f.collection_check_boxes(:role_ids, Role.global, :id, :title)
   %p
-    - @states.each do |state|
-      = label_tag("state_#{state}", state)
-      = radio_button_tag(:state, state, (state.to_s == @displayed_user.state))
+    = f.collection_radio_buttons(:state, user_states_for_edit, :to_s, :to_s)
   %p
-    = submit_tag("Update")
+    = f.submit("Update")

--- a/src/api/spec/controllers/webui/user_controller_spec.rb
+++ b/src/api/spec/controllers/webui/user_controller_spec.rb
@@ -112,26 +112,28 @@ RSpec.describe Webui::UserController do
       context "with valid data" do
         before do
           login user
-          post :save, params: { user: user, realname: 'another real name', email: 'new_valid@email.es' }
+          post :save, params: { user: { login: user.login, realname: 'another real name', email: 'new_valid@email.es', state: 'locked' }}
           user.reload
         end
 
         it { expect(flash[:success]).to eq("User data for user '#{user.login}' successfully updated.") }
         it { expect(user.realname).to eq('another real name') }
         it { expect(user.email).to eq('new_valid@email.es') }
+        it { expect(user.state).to eq('confirmed') }
         it { is_expected.to redirect_to user_show_path(user) }
       end
 
       context "with invalid data" do
         before do
           login user
-          post :save, params: { user: user, realname: "another real name", email: "invalid" }
+          post :save, params: { user: { login: user.login, realname: "another real name", email: "invalid" }}
           user.reload
         end
 
         it { expect(flash[:error]).to eq("Couldn't update user: Validation failed: Email must be a valid email address..") }
         it { expect(user.realname).to eq(user.realname) }
         it { expect(user.email).to eq(user.email) }
+        it { expect(user.state).to eq('confirmed') }
         it { is_expected.to redirect_to user_show_path(user) }
       end
     end
@@ -139,8 +141,7 @@ RSpec.describe Webui::UserController do
     context "when user is trying to update another user's profile" do
       before do
         login user
-        request.env["HTTP_REFERER"] = root_url # Needed for the redirect_to(root_url)
-        post :save, params: { user: non_admin_user, realname: 'another real name', email: 'new_valid@email.es' }
+        post :save, params: { user: { login: non_admin_user.login, realname: 'another real name', email: 'new_valid@email.es' }}
         non_admin_user.reload
       end
 
@@ -151,15 +152,73 @@ RSpec.describe Webui::UserController do
     end
 
     context "when admin is updating another user's profile" do
+      let(:old_global_role)  { create(:role, global: true, title: 'old_global_role') }
+      let(:new_global_roles) { create_list(:role, 2, global: true) }
+      let(:local_roles)      { create_list(:role, 2) }
+
       before do
+        user.roles << old_global_role
+        user.roles << local_roles
+
         login admin_user
-        post :save, params: { user: user, realname: 'another real name', email: 'new_valid@email.es' }
+        post :save, params: {
+          user: {
+            login: user.login, realname: 'another real name', email: 'new_valid@email.es', state: 'locked', role_ids: new_global_roles.pluck(:id)
+          }
+        }
         user.reload
       end
 
       it { expect(user.realname).to eq('another real name') }
       it { expect(user.email).to eq('new_valid@email.es') }
+      it { expect(user.state).to eq('locked') }
       it { is_expected.to redirect_to user_show_path(user) }
+      it "updates the user's roles" do
+        expect(user.roles).not_to include(old_global_role)
+        expect(user.roles).to include(*new_global_roles)
+      end
+      it 'does not remove non global roles' do
+        expect(user.roles).to include(*local_roles)
+      end
+    end
+
+    context 'when roles parameter is empty' do
+      let(:old_global_role) { create(:role, global: true, title: 'old_global_role') }
+      let(:local_roles)     { create_list(:role, 2) }
+
+      before do
+        user.roles << old_global_role
+        user.roles << local_roles
+
+        login admin_user
+        # Rails form helper sends an empty string in an array if no checkbox was marked
+        post :save, params: { user: { login: user.login, email: 'new_valid@email.es', role_ids: [""] }}
+        user.reload
+      end
+
+      it "drops all global roles" do
+        expect(user.roles).to match_array local_roles
+      end
+    end
+
+    context "when state and roles are not passed as parameter" do
+      let(:old_global_role) { create(:role, global: true, title: 'old_global_role') }
+
+      before do
+        user.roles << old_global_role
+
+        login admin_user
+        post :save, params: { user: { login: user.login, email: 'new_valid@email.es' }}
+        user.reload
+      end
+
+      it 'keeps the old state' do
+        expect(user.state).to eq('confirmed')
+      end
+
+      it "does not drop the roles" do
+        expect(user.roles).to match_array old_global_role
+      end
     end
   end
 

--- a/src/api/spec/features/webui/users/user_admin_edit_spec.rb
+++ b/src/api/spec/features/webui/users/user_admin_edit_spec.rb
@@ -10,7 +10,8 @@ RSpec.feature "User's admin edit page", type: :feature, js: true do
 
     expect(page).to have_field("Name:", with: "John Doe")
     expect(page).to have_field("e-Mail:", with: "john@suse.de")
-    expect(find_field("Admin:")).not_to be_checked
+
+    expect(find_field("Admin")).not_to be_checked
     expect(find_field("confirmed")).to be_checked
     expect(find_field("unconfirmed")).not_to be_checked
     expect(find_field("deleted")).not_to be_checked
@@ -20,7 +21,7 @@ RSpec.feature "User's admin edit page", type: :feature, js: true do
   scenario "make user admin" do
     login(admin)
     visit user_edit_path(user: user.login)
-    check("Admin:")
+    check("Admin")
     click_button("Update")
     expect(user.is_admin?).to be true
   end
@@ -28,7 +29,7 @@ RSpec.feature "User's admin edit page", type: :feature, js: true do
   scenario "remove admin rights from user" do
     login(admin)
     visit user_edit_path(user: admin.login)
-    uncheck("Admin:")
+    uncheck("Admin")
     click_button("Update")
     expect(admin.is_admin?).to be false
   end

--- a/src/api/test/functional/webui/login_test.rb
+++ b/src/api/test/functional/webui/login_test.rb
@@ -19,7 +19,7 @@ class Webui::LoginTest < Webui::IntegrationTest
   def change_user_real_name(new_name)
     find(:id, 'save_dialog').click
 
-    fill_in "realname", with: new_name
+    fill_in "Name:", with: new_name
     find(:css, "form[action='#{user_save_path}'] input[name='commit']").click
 
     flash_message.must_equal "User data for user '#{current_user}' successfully updated."

--- a/src/api/test/functional/webui/user_controller_test.rb
+++ b/src/api/test/functional/webui/user_controller_test.rb
@@ -4,7 +4,7 @@ class Webui::UserControllerTest < Webui::IntegrationTest
   def test_edit # spec/controllers/webui/user_controller_spec.rb
     login_king to: user_edit_path(user: 'tom')
 
-    fill_in 'realname', with: 'Tom Thunder'
+    fill_in 'Name:', with: 'Tom Thunder'
     click_button 'Update'
 
     find('#flash-messages').must_have_text("User data for user 'tom' successfully updated.")

--- a/src/api/test/unit/user_test.rb
+++ b/src/api/test/unit/user_test.rb
@@ -121,11 +121,11 @@ class UserTest < ActiveSupport::TestCase
     user = User.find_by(login: "tom")
     user.roles << Role.create(title: "local_role", global: false)
     user.roles << Role.create(title: "global_role_1", global: true)
-    user.roles << Role.create(title: "global_role_2", global: true)
-    user.save!
+    global_role2 = Role.create(title: "global_role_2", global: true)
+    user.roles << global_role2
 
-    user.update_globalroles(["global_role_2", "Admin"])
-    user.save!
+    user.update_globalroles([global_role2, Role.global.where(title: 'Admin').first])
+
     updated_roles = user.reload.roles.map(&:title)
     assert updated_roles.include?("global_role_2")
     assert updated_roles.include?("Admin")


### PR DESCRIPTION
Fixes #3566

The user save action is handling editing user accounts by users that want
to update their account as well as admins that edit other user's
accounts or their own.
In the latter case the code was accidentally dropping all global roles
of the admin user.

In addition there was a mismatch between the model implementation (allows
multiple roles) and the views (only showed the Admin role).
Since this changed recently with the introduction of the 'staff' role,
we had to fix this.
We now show all available global roles in the admin user edit page.

Or in short:

* Fixes dropping of global roles when an admin edits his own account (#3566)
* Allow admins to see and edit all global roles available for a user
* Improve tests for save action