### PR TITLE
[api] fixed job from failing in spec

### DIFF
--- a/src/api/app/jobs/issue_tracker_write_to_backend_job.rb
+++ b/src/api/app/jobs/issue_tracker_write_to_backend_job.rb
@@ -1,3 +1,5 @@
+require 'builder'
+
 class IssueTrackerWriteToBackendJob < ApplicationJob
   queue_as :quick
 


### PR DESCRIPTION
Before if you set `CONFIG['global_write_through'] = true` then you would get this error when running the spec:
https://gist.github.com/ChrisBr/6eae00555805143f73ea5f5fa0b5184c