### PR TITLE
[api] add logging to try and debug IssueTracker#parse_github_issue

### DIFF
--- a/src/api/app/models/issue_tracker.rb
+++ b/src/api/app/models/issue_tracker.rb
@@ -259,8 +259,8 @@ class IssueTracker < ApplicationRecord
         issue = Issue.find_by_name_and_tracker(js["number"].to_s, name)
         return if issue.nil?
       end
-    rescue TypeError => e
-      Airbrake.notify(e, { json_data: js })
+    rescue TypeError
+      logger.debug "[IssueTracker#parse_github_issue] cannot parse json response:\n#{js}"
       raise
     end
     if js["state"] == "open"

--- a/src/api/spec/models/issue_tracker_spec.rb
+++ b/src/api/spec/models/issue_tracker_spec.rb
@@ -15,4 +15,32 @@ RSpec.describe IssueTracker do
       expect(issue_tracker).to have_received(:update_issues)
     end
   end
+
+  describe '#parse_github_issue' do
+    context 'with a valid response from github' do
+      include_context 'a github issue response'
+
+      let!(:issue_tracker) { create(:issue_tracker, enable_fetch: true) }
+      let!(:issue) { create(:issue, name: js['number'], issue_tracker: issue_tracker) }
+
+      subject! { issue_tracker.send(:parse_github_issue, js) }
+
+      it 'updates issue' do
+        issue.reload
+        expect(issue.summary).to eq(js['title'])
+      end
+    end
+
+    context 'with an invalid response from github' do
+      let(:js) { [] }
+      let!(:issue_tracker) { create(:issue_tracker, enable_fetch: true) }
+      let!(:issue) { create(:issue, name: '123', issue_tracker: issue_tracker) }
+
+      subject { issue_tracker.send(:parse_github_issue, js) }
+
+      it 'raises TypeError' do
+        expect{ subject }.to raise_error(TypeError)
+      end
+    end
+  end
 end

--- a/src/api/spec/support/shared_contexts/a_github_issue_response.rb
+++ b/src/api/spec/support/shared_contexts/a_github_issue_response.rb
@@ -1,0 +1,55 @@
+RSpec.shared_context 'a github issue response' do
+  let(:js) do
+    {
+     'url'            => 'https://api.github.com/repos/openSUSE/open-build-service/issues/3607',
+     'repository_url' => 'https://api.github.com/repos/openSUSE/open-build-service',
+     'labels_url'     => 'https://api.github.com/repos/openSUSE/open-build-service/issues/3607/labels{/name}',
+     'comments_url'   => 'https://api.github.com/repos/openSUSE/open-build-service/issues/3607/comments',
+     'events_url'     => 'https://api.github.com/repos/openSUSE/open-build-service/issues/3607/events',
+     'html_url'       => 'https://github.com/openSUSE/open-build-service/issues/3607',
+     'id'             => 250_551_816,
+     'number'         => 3607,
+     'title'          => 'Statistics::MaintenanceStatisticsController GET #index with a project with
+ maintenance statistics with a remote project forwards the request to the remote instance',
+     'user'           =>
+                         {'login'               => 'hennevogel',
+                          'id'                  => 514785,
+                          'avatar_url'          => 'https://avatars1.githubusercontent.com/u/514785?v=4',
+                          'gravatar_id'         => '',
+                          'url'                 => 'https://api.github.com/users/hennevogel',
+                          'html_url'            => 'https://github.com/hennevogel',
+                          'followers_url'       => 'https://api.github.com/users/hennevogel/followers',
+                          'following_url'       => 'https://api.github.com/users/hennevogel/following{/other_user}',
+                          'gists_url'           => 'https://api.github.com/users/hennevogel/gists{/gist_id}',
+                          'starred_url'         => 'https://api.github.com/users/hennevogel/starred{/owner}{/repo}',
+                          'subscriptions_url'   => 'https://api.github.com/users/hennevogel/subscriptions',
+                          'organizations_url'   => 'https://api.github.com/users/hennevogel/orgs',
+                          'repos_url'           => 'https://api.github.com/users/hennevogel/repos',
+                          'events_url'          => 'https://api.github.com/users/hennevogel/events{/privacy}',
+                          'received_events_url' => 'https://api.github.com/users/hennevogel/received_events',
+                          'type'                => 'User',
+                          'site_admin'          => false},
+     'labels'         =>
+                         [{'id'      => 661_901_824,
+                           'url'     => 'https://api.github.com/repos/openSUSE/open-build-service/labels/flickering',
+                           'name'    => 'flickering',
+                           'color'   => 'FF0080',
+                           'default' => false},
+                          {'id'      => 273_955_462,
+                           'url'     => 'https://api.github.com/repos/openSUSE/open-build-service/labels/Test%20Suite',
+                           'name'    => 'Test Suite',
+                           'color'   => 'FEE0C6',
+                           'default' => false}],
+     'state'          => 'open',
+     'locked'         => false,
+     'assignee'       => nil,
+     'assignees'      => [],
+     'milestone'      => nil,
+     'comments'       => 0,
+     'created_at'     => '2017-08-16T08:38:59Z',
+     'updated_at'     => '2017-08-16T08:39:11Z',
+     'closed_at'      => nil,
+     'body'           => 'it fails'
+    }
+  end
+end


### PR DESCRIPTION
Sometimes it gets a response from github which it cannot parse but we
dont know what that response is or why it gets it so I've added logging
to try and figure out whats going on. The previous Airbrake logging
wasn't working.