### PR TITLE
[webui] Drop unused view code

### DIFF
--- a/src/api/app/views/webui/package/_no_repositories.html.erb
+++ b/src/api/app/views/webui/package/_no_repositories.html.erb
@@ -1,32 +1,7 @@
 <div id="package_buildstatus">
   <% if !@project.repositories.any? %>
     <p><i>The project this package belongs to currently has no <%= link_to "build targets", :controller => :repositories, :action => 'distributions', :project => @project %> defined. </i></p>
-  <% elsif @buildresult.elements('result').blank? %>
-    <p><i>No build result available</i></p>
   <% else %>
-
-    <table class="repostatus">
-      <% @buildresult.elements('result') do |r,archs|
-        index = 0
-        archs.each do |a|
-          -%>
-          <tr>
-            <% if index == 0 %>
-              <td class="nowrap" title="<%= r %>" rowspan="<%= archs.length %>">
-                <%= link_to(elide(r, 26), {:action => :binaries, :controller => :package, :project => @project, :package => @package, :repository => r}, {:title => "Binaries for #{r}"}) %>
-              </td>
-              <% index += 1 -%>
-            <% end # if -%>
-            <td class="arch">
-              <div class="nowrap" style="margin: 0 0.5ex">
-                <%= repo_status_icon(@repostatushash[r][a],@repostatusdetailshash[r][a]) %> <%= a %>
-              </div>
-            </td>
-            <%= arch_repo_table_cell r, a, @package.name %>
-          </tr>
-        <% end # all archs -%>
-      <% end # all builds -%>
-    </table>
-
-  <% end # if -%>
+    <p><i>No build result available</i></p>
+  <% end %>
 </div>


### PR DESCRIPTION
and fix error when requesting rpmlint_results with only excluded repositories in the package.
Introduced by ab58423d81900cee4b8a04e1176a40e7025d4c95.