### PR TITLE
Improvements for rpmlint logs

### DIFF
--- a/src/api/app/controllers/webui/package_controller.rb
+++ b/src/api/app/controllers/webui/package_controller.rb
@@ -933,8 +933,8 @@ class Webui::PackageController < Webui::WebuiController
     @buildresult = Buildresult.find_hashed(project: @project.to_param, package: @package.to_param, view: 'status')
     repos = [] # Temp var
     @buildresult.elements('result') do |result|
-      if result.value('status') &&
-          result.value('status').value('code') != 'excluded'
+      if result.value('repository') != 'images' &&
+          (result.value('status') && result.value('status').value('code') != 'excluded')
         hash_key = valid_xml_id(elide(result.value('repository'), 30))
         @repo_arch_hash[hash_key] ||= []
         @repo_arch_hash[hash_key] << result['arch']

--- a/src/api/app/views/webui/package/_rpmlint_result.html.erb
+++ b/src/api/app/views/webui/package/_rpmlint_result.html.erb
@@ -4,7 +4,7 @@
   <%= select_tag("rpmlint_repo_select_#{index}", options_for_select(@repo_list)) %>
   <% i = 0 %>
   <% @repo_arch_hash.each do |repo, arches| %>
-    <%= select_tag("rpmlint_arch_select_#{index}_#{repo}", options_for_select(arches.sort), :class => "rpmlint_arch_select_#{index}") %>
+    <%= select_tag("rpmlint_arch_select_#{index}_#{repo}", options_for_select(arches.reverse), :class => "rpmlint_arch_select_#{index}") %>
   <% end %>
   <%= image_tag('ajax-loader.gif', :id => "rpmlint_spinner_#{index}", :class => 'hidden') %>
   <% end %>

--- a/src/api/spec/controllers/webui/package_controller_spec.rb
+++ b/src/api/spec/controllers/webui/package_controller_spec.rb
@@ -1173,7 +1173,10 @@ EOT
           <result project="home:tom" repository="openSUSE_Tumbleweed" arch="i586" code="building" state="building">
             <status package="my_package" code="excluded" />
           </result>
-          <result project="home:tom" repository="images" arch="armv7l" code="unknown" state="unknown" />
+          <result project="home:tom" repository="openSUSE_Leap_42.1" arch="armv7l" code="unknown" state="unknown" />
+          <result project="home:tom" repository="openSUSE_Leap_42.1" arch="x86_64" code="building" state="building">
+            <status package="my_package" code="signing" />
+          </result>
           <result project="home:tom" repository="images" arch="x86_64" code="building" state="building">
             <status package="my_package" code="signing" />
           </result>
@@ -1188,9 +1191,10 @@ EOT
     end
 
     it { expect(response).to have_http_status(:success) }
-    it { expect(assigns(:repo_list)).to include(['images', 'images']) }
+    it { expect(assigns(:repo_list)).to include(['openSUSE_Leap_42.1', 'openSUSE_Leap_42_1']) }
+    it { expect(assigns(:repo_list)).not_to include(['images', 'images']) }
     it { expect(assigns(:repo_list)).not_to include(['openSUSE_Tumbleweed', 'openSUSE_Tumbleweed']) }
-    it { expect(assigns(:repo_arch_hash)['images']).to include('x86_64') }
-    it { expect(assigns(:repo_arch_hash)['images']).not_to include('armv7l') }
+    it { expect(assigns(:repo_arch_hash)['openSUSE_Leap_42_1']).to include('x86_64') }
+    it { expect(assigns(:repo_arch_hash)['openSUSE_Leap_42_1']).not_to include('armv7l') }
   end
 end


### PR DESCRIPTION
- Drop images repositories -> images do not have an rpmlint log
- Reverse order the architectures to prefer x86_64