### PR TITLE
[api] raise a specific error when IssueTracker cant connect to github.

### DIFF
--- a/src/api/app/models/issue_tracker.rb
+++ b/src/api/app/models/issue_tracker.rb
@@ -100,6 +100,12 @@ class IssueTracker < ApplicationRecord
     mtime = Time.now
 
     response = follow_redirects(url)
+
+    if response.code != '200'
+      logger.debug "[IssueTracker#update_issues_github] ##{id} could not connect to github.\nUrl: #{url}\nResponse: #{response.body}"
+      return
+    end
+
     return if response.blank?
 
     parse_github_issues(ActiveSupport::JSON.decode(response.body))

--- a/src/api/spec/support/shared_contexts/a_github_issue_response.rb
+++ b/src/api/spec/support/shared_contexts/a_github_issue_response.rb
@@ -1,55 +1,72 @@
 RSpec.shared_context 'a github issue response' do
-  let(:js) do
-    {
-     'url'            => 'https://api.github.com/repos/openSUSE/open-build-service/issues/3607',
-     'repository_url' => 'https://api.github.com/repos/openSUSE/open-build-service',
-     'labels_url'     => 'https://api.github.com/repos/openSUSE/open-build-service/issues/3607/labels{/name}',
-     'comments_url'   => 'https://api.github.com/repos/openSUSE/open-build-service/issues/3607/comments',
-     'events_url'     => 'https://api.github.com/repos/openSUSE/open-build-service/issues/3607/events',
-     'html_url'       => 'https://github.com/openSUSE/open-build-service/issues/3607',
-     'id'             => 250_551_816,
-     'number'         => 3607,
-     'title'          => 'Statistics::MaintenanceStatisticsController GET #index with a project with
- maintenance statistics with a remote project forwards the request to the remote instance',
-     'user'           =>
-                         {'login'               => 'hennevogel',
-                          'id'                  => 514785,
-                          'avatar_url'          => 'https://avatars1.githubusercontent.com/u/514785?v=4',
-                          'gravatar_id'         => '',
-                          'url'                 => 'https://api.github.com/users/hennevogel',
-                          'html_url'            => 'https://github.com/hennevogel',
-                          'followers_url'       => 'https://api.github.com/users/hennevogel/followers',
-                          'following_url'       => 'https://api.github.com/users/hennevogel/following{/other_user}',
-                          'gists_url'           => 'https://api.github.com/users/hennevogel/gists{/gist_id}',
-                          'starred_url'         => 'https://api.github.com/users/hennevogel/starred{/owner}{/repo}',
-                          'subscriptions_url'   => 'https://api.github.com/users/hennevogel/subscriptions',
-                          'organizations_url'   => 'https://api.github.com/users/hennevogel/orgs',
-                          'repos_url'           => 'https://api.github.com/users/hennevogel/repos',
-                          'events_url'          => 'https://api.github.com/users/hennevogel/events{/privacy}',
-                          'received_events_url' => 'https://api.github.com/users/hennevogel/received_events',
-                          'type'                => 'User',
-                          'site_admin'          => false},
-     'labels'         =>
-                         [{'id'      => 661_901_824,
-                           'url'     => 'https://api.github.com/repos/openSUSE/open-build-service/labels/flickering',
-                           'name'    => 'flickering',
-                           'color'   => 'FF0080',
-                           'default' => false},
-                          {'id'      => 273_955_462,
-                           'url'     => 'https://api.github.com/repos/openSUSE/open-build-service/labels/Test%20Suite',
-                           'name'    => 'Test Suite',
-                           'color'   => 'FEE0C6',
-                           'default' => false}],
-     'state'          => 'open',
-     'locked'         => false,
-     'assignee'       => nil,
-     'assignees'      => [],
-     'milestone'      => nil,
-     'comments'       => 0,
-     'created_at'     => '2017-08-16T08:38:59Z',
-     'updated_at'     => '2017-08-16T08:39:11Z',
-     'closed_at'      => nil,
-     'body'           => 'it fails'
-    }
+  let(:github_issues_json) do
+    <<-JSON
+    [
+      {
+        "url": "https://api.github.com/repos/openSUSE/open-build-service/issues/3628",
+        "repository_url": "https://api.github.com/repos/openSUSE/open-build-service",
+        "labels_url": "https://api.github.com/repos/openSUSE/open-build-service/issues/3628/labels{/name}",
+        "comments_url": "https://api.github.com/repos/openSUSE/open-build-service/issues/3628/comments",
+        "events_url": "https://api.github.com/repos/openSUSE/open-build-service/issues/3628/events",
+        "html_url": "https://github.com/openSUSE/open-build-service/pull/3628",
+        "id": 250934596,
+        "number": 3628,
+        "title": "[ci] Trying fix flickering test in test_helper",
+        "user": {
+          "login": "obsdev",
+          "id": 1212806,
+          "avatar_url": "https://avatars3.githubusercontent.com/u/1212806?v=4",
+          "gravatar_id": "",
+          "url": "https://api.github.com/users/obsdev",
+          "html_url": "https://github.com/obsdev",
+          "followers_url": "https://api.github.com/users/obsdev/followers",
+          "following_url": "https://api.github.com/users/obsdev/following{/other_user}",
+          "gists_url": "https://api.github.com/users/obsdev/gists{/gist_id}",
+          "starred_url": "https://api.github.com/users/obsdev/starred{/owner}{/repo}",
+          "subscriptions_url": "https://api.github.com/users/obsdev/subscriptions",
+          "organizations_url": "https://api.github.com/users/obsdev/orgs",
+          "repos_url": "https://api.github.com/users/obsdev/repos",
+          "events_url": "https://api.github.com/users/obsdev/events{/privacy}",
+          "received_events_url": "https://api.github.com/users/obsdev/received_events",
+          "type": "User",
+          "site_admin": false
+        },
+        "labels": [
+          {
+            "id": 21922370,
+            "url": "https://api.github.com/repos/openSUSE/open-build-service/labels/frontend",
+            "name": "frontend",
+            "color": "c7def8",
+            "default": false
+          },
+          {
+            "id": 273955462,
+            "url": "https://api.github.com/repos/openSUSE/open-build-service/labels/Test%20Suite",
+            "name": "Test Suite",
+            "color": "FEE0C6",
+            "default": false
+          }
+        ],
+        "state": "open",
+        "locked": false,
+        "assignee": null,
+        "assignees": [
+
+        ],
+        "milestone": null,
+        "comments": 0,
+        "created_at": "2017-08-17T12:56:38Z",
+        "updated_at": "2017-08-17T12:59:17Z",
+        "closed_at": null,
+        "pull_request": {
+          "url": "https://api.github.com/repos/openSUSE/open-build-service/pulls/3628",
+          "html_url": "https://github.com/openSUSE/open-build-service/pull/3628",
+          "diff_url": "https://github.com/openSUSE/open-build-service/pull/3628.diff",
+          "patch_url": "https://github.com/openSUSE/open-build-service/pull/3628.patch"
+        },
+        "body": "Trying to fix issue #3533"
+      }
+    ]
+    JSON
   end
 end


### PR DESCRIPTION
It seems that a less specific TypeError is being raised further down the
line when we cant connect to github so hopefully this change will help
us see whats going on better.