### PR TITLE
[api] Limit user comments route to the logged in user

### DIFF
--- a/src/api/app/controllers/comments_controller.rb
+++ b/src/api/app/controllers/comments_controller.rb
@@ -28,12 +28,12 @@ class CommentsController < ApplicationController
         @obj = Project.get_by_name(params[:project])
         @header = { project: @obj.name }
       end
-    elsif params[:user_login]
-      @obj = User.find_by!(login: params[:user_login])
-      @header = { user: @obj.login }
-    else
+    elsif params[:request_number]
       @obj = BsRequest.find_by_number!(params[:request_number])
       @header = { request: @obj.number }
+    else
+      @obj = User.current
+      @header = { user: @obj.login }
     end
   end
 end

--- a/src/api/config/routes.rb
+++ b/src/api/config/routes.rb
@@ -722,7 +722,7 @@ OBSApi::Application.routes.draw do
     post 'comments/package/:project/:package' => :create, constraints: cons, as: :create_package_comment
     get 'comments/project/:project' => :index, constraints: cons, as: :comments_project
     post 'comments/project/:project' => :create, constraints: cons, as: :create_project_comment
-    get 'comments/user/:user_login' => :index, constraints: cons, as: :comments_user
+    get 'comments/user' => :index, constraints: cons, as: :comments_user
 
     delete 'comment/:id' => :destroy, constraints: cons, as: :comment_delete
   end

--- a/src/api/spec/controllers/comments_controller_spec.rb
+++ b/src/api/spec/controllers/comments_controller_spec.rb
@@ -59,7 +59,7 @@ RSpec.describe CommentsController, type: :controller do
 
       before do
         login user
-        get :index, format: :xml, params: { user_login: user.login }
+        get :index, format: :xml
       end
 
       include_examples 'request comment index'


### PR DESCRIPTION
otherwise it would be possible to e.g. see comments of forbidden projects.