### PR TITLE
[dist] Script that makes gives a user admin rights

### DIFF
--- a/src/api/lib/tasks/make_user_an_admin.rake
+++ b/src/api/lib/tasks/make_user_an_admin.rake
@@ -1,0 +1,20 @@
+namespace :user do
+  desc "Give admin permissions to existing user"
+  task give_admin_rights: :environment do
+    login = ARGV[1]
+
+    user = User.where(login: login).first
+    if user
+      if user.roles.where(title: 'Admin').exists?
+        puts "Nothing to do here. User '#{user.login}' already is an admin."
+      else
+        puts "Making user '#{login}' an admin"
+        user.roles << Role.global.where(title: 'Admin').first
+      end
+    else
+      puts "Couldn't find user '#{login}'"
+    end
+
+    exit
+  end
+end


### PR DESCRIPTION
This is needed for OBS instances that are set up for LDAP. Once LDAP
mode got enabled local users can not log in anymore. This script allows
to make any user that logs in afterwards (via LDAP) an admin.