### PR TITLE
Passing string to if and unless

### DIFF
--- a/src/api/app/models/attrib.rb
+++ b/src/api/app/models/attrib.rb
@@ -27,9 +27,9 @@ class Attrib < ApplicationRecord
   validates_associated :issues
   validates :attrib_type, presence: true
   # Either we belong to a project or to a package
-  validates :package, presence: true, if: "project_id.nil?"
-  validates :package_id, absence: {message: "can't also be present"}, if: "project_id.present?"
-  validates :project, presence: true, if: "package_id.nil?"
+  validates :package, presence: true, if: Proc.new { |attrib| attrib.project_id.nil? }
+  validates :package_id, absence: {message: "can't also be present"}, if: Proc.new { |attrib| attrib.project_id.present? }
+  validates :project, presence: true, if: Proc.new { |attrib| attrib.package_id.nil? }
 
   validate :validate_value_count,
            :validate_issues,

--- a/src/api/app/models/attrib.rb
+++ b/src/api/app/models/attrib.rb
@@ -27,9 +27,9 @@ class Attrib < ApplicationRecord
   validates_associated :issues
   validates :attrib_type, presence: true
   # Either we belong to a project or to a package
-  validates :package, presence: true, if: Proc.new { |attrib| attrib.project_id.nil? }
-  validates :package_id, absence: {message: "can't also be present"}, if: Proc.new { |attrib| attrib.project_id.present? }
-  validates :project, presence: true, if: Proc.new { |attrib| attrib.package_id.nil? }
+  validates :package, presence: true, if: proc { |attrib| attrib.project_id.nil? }
+  validates :package_id, absence: {message: "can't also be present"}, if: proc { |attrib| attrib.project_id.present? }
+  validates :project, presence: true, if: proc { |attrib| attrib.package_id.nil? }
 
   validate :validate_value_count,
            :validate_issues,

--- a/src/api/app/models/relationship.rb
+++ b/src/api/app/models/relationship.rb
@@ -26,17 +26,17 @@ class Relationship < ApplicationRecord
 
   validates :package, presence: {
     message: "Neither package nor project exists"
-  }, unless: Proc.new { |relationship| relationship.project.present? }
+  }, unless: proc { |relationship| relationship.project.present? }
   validates :package, absence: {
     message: "Package and project can not exist at the same time"
-  }, if: Proc.new { |relationship| relationship.project.present? }
+  }, if: proc { |relationship| relationship.project.present? }
 
   validates :user, presence: {
     message: "Neither user nor group exists"
-  }, unless: Proc.new { |relationship| relationship.group.present? }
+  }, unless: proc { |relationship| relationship.group.present? }
   validates :user, absence: {
     message: "User and group can not exist at the same time"
-  }, if: Proc.new { |relationship| relationship.group.present? }
+  }, if: proc { |relationship| relationship.group.present? }
 
   # don't use "is not null" - it won't be in index
   scope :projects, -> { where.not(project_id: nil) }

--- a/src/api/app/models/relationship.rb
+++ b/src/api/app/models/relationship.rb
@@ -26,17 +26,17 @@ class Relationship < ApplicationRecord
 
   validates :package, presence: {
     message: "Neither package nor project exists"
-  }, unless: 'project.present?'
+  }, unless: Proc.new { |relationship| relationship.project.present? }
   validates :package, absence: {
     message: "Package and project can not exist at the same time"
-  }, if: 'project.present?'
+  }, if: Proc.new { |relationship| relationship.project.present? }
 
   validates :user, presence: {
     message: "Neither user nor group exists"
-  }, unless: 'group.present?'
+  }, unless: Proc.new { |relationship| relationship.group.present? }
   validates :user, absence: {
     message: "User and group can not exist at the same time"
-  }, if: 'group.present?'
+  }, if: Proc.new { |relationship| relationship.group.present? }
 
   # don't use "is not null" - it won't be in index
   scope :projects, -> { where.not(project_id: nil) }


### PR DESCRIPTION
Write string parameter as `Proc` block in `:if` and `:unless` clauses in validations. Get rid of:

'DEPRECATION WARNING: Passing string to :if and :unless conditional options is deprecated and will be removed in Rails 5.2 without replacement.'