### PR TITLE
Added loading indicator for Request tables

### DIFF
--- a/src/api/app/assets/javascripts/webui/application/requests_table.js.erb
+++ b/src/api/app/assets/javascripts/webui/application/requests_table.js.erb
@@ -19,6 +19,9 @@ $( document ).ready(function() {
       pageLength: 25,
       pagingType: "full_numbers",
       processing: true,
+      language: {
+         processing: '<img src="<%= asset_path "ajax-loader.gif" %>"> Processing...'
+      },
       serverSide: true,
       ajax: {
         url: url,


### PR DESCRIPTION
The ajax-loader.gif now is shown in the message of Processing.

![loader_for_request_tables](https://user-images.githubusercontent.com/11314634/29456671-1452d706-8417-11e7-80ae-219181fa4325.png)
