### PR TITLE
Backend API class

### DIFF
--- a/src/api/app/controllers/attribute_controller.rb
+++ b/src/api/app/controllers/attribute_controller.rb
@@ -184,10 +184,7 @@ class AttributeController < ApplicationController
     # exec
     if params[:rev] || @attribute_container.nil?
       # old or remote instance entry
-      path = "/source/#{URI.escape(params[:project])}/#{URI.escape(params[:package] || '_project')}/_attribute?meta=1"
-      path += "&rev=#{CGI.escape(params[:rev])}" if params[:rev]
-      answer = Backend::Connection.get(path)
-      render xml: answer.body.to_s
+      render xml: Backend::Api.attribute(params[:project], params[:package], params[:rev])
       return
     end
 

--- a/src/api/app/controllers/build/file_controller.rb
+++ b/src/api/app/controllers/build/file_controller.rb
@@ -84,14 +84,11 @@ module Build
     end
 
     def regexp
-      @regexp ||=
-        # if there is a query, we can't assume it's a simple download, so better leave out the logic (e.g. view=fileinfo)
-        unless request.query_string
-          # check if binary exists and for size
-          fpath = "/build/" + [:project, :repository, :arch, :package].map {|x| params[x]}.join("/")
-          file_list = Backend::Connection.get(fpath)
-          file_list.body.match(/name=["']#{Regexp.quote params[:filename]}["'].*size=["']([^"']*)["']/)
-        end
+      # if there is a query, we can't assume it's a simple download, so better leave out the logic (e.g. view=fileinfo)
+      return if request.query_string
+      # check if binary exists and for size
+      regexp = /name=["']#{Regexp.quote params[:filename]}["'].*size=["']([^"']*)["']/
+      @regexp ||= Backend::Api.file_list(params[:project], params[:repository], params[:arch], params[:package]).match(regexp)
     end
 
     def process_regexp

--- a/src/api/lib/backend/api.rb
+++ b/src/api/lib/backend/api.rb
@@ -1,0 +1,16 @@
+# API for accessing to the backend
+module Backend
+  class Api
+    # Returns the attribute content (from src/api/app/controllers/attribute_controller.rb)
+    def self.attribute(project, package, revision)
+      path = "/source/#{CGI.escape(project)}/#{CGI.escape(package || '_project')}/_attribute?meta=1"
+      path += "&rev=#{CGI.escape(revision)}" if revision
+      Backend::Connection.get(path).body
+    end
+
+    # Returns a file list filtered by a regexp (from src/api/app/controllers/build/file_controller.rb)
+    def self.file_list_by_regexp(project, repository, arch, package, regexp)
+      Backend::Connection.get("/build/#{project}/#{repository}/#{arch}/#{package}").body.match(regexp)
+    end
+  end
+end

--- a/src/api/lib/backend/api.rb
+++ b/src/api/lib/backend/api.rb
@@ -8,9 +8,9 @@ module Backend
       Backend::Connection.get(path).body
     end
 
-    # Returns a file list filtered by a regexp (from src/api/app/controllers/build/file_controller.rb)
-    def self.file_list_by_regexp(project, repository, arch, package, regexp)
-      Backend::Connection.get("/build/#{project}/#{repository}/#{arch}/#{package}").body.match(regexp)
+    # Returns a file list (from src/api/app/controllers/build/file_controller.rb)
+    def self.file_list(project, repository, arch, package)
+      Backend::Connection.get("/build/#{CGI.escape(project)}/#{CGI.escape(repository)}/#{CGI.escape(arch)}/#{CGI.escape(package)}").body
     end
   end
 end

--- a/src/api/lib/backend/backend.rb
+++ b/src/api/lib/backend/backend.rb
@@ -1,2 +1,3 @@
 require_dependency 'connection'
 require_dependency 'file'
+require_dependency 'api'


### PR DESCRIPTION
The idea behind is moving all the calls to `Backend::Connection` inside this class (at least as the first step to have all together here). That way we will have the calculations of the urls for the endpoints of the backend, and the logic of the params needed to do the calls properly is in the side of this "wrapper" for the backend.

This class could be splitted in the future to structure it better and also could be refactored to avoid duplication of calls.