### PR TITLE
[api] Prohibit creating and editing of users via API

### DIFF
--- a/src/api/app/controllers/person_controller.rb
+++ b/src/api/app/controllers/person_controller.rb
@@ -87,6 +87,12 @@ class PersonController < ApplicationController
     login = params[:login]
     user = User.find_by_login(login) if login
 
+    unless ::Configuration.accounts_editable?
+      render_error(status: 403, errorcode: 'change_userinfo_no_permission',
+                   message: "no permission to change userinfo for user #{user.login}")
+      return
+    end
+
     if user
       unless user.login == User.current.login || User.current.is_admin?
         logger.debug "User has no permission to change userinfo"

--- a/src/api/spec/controllers/person_controller_spec.rb
+++ b/src/api/spec/controllers/person_controller_spec.rb
@@ -5,9 +5,27 @@ require 'rails_helper'
 # CONFIG['global_write_through'] = true
 
 RSpec.describe PersonController, vcr: false do
-  describe 'POST #post_userinfo' do
-    let(:user) { create(:confirmed_user) }
+  let(:user) { create(:confirmed_user) }
+  let(:admin_user) { create(:admin_user) }
 
+  let!(:old_realname) { user.realname }
+  let!(:old_email) { user.email }
+
+  shared_examples "not allowed to change user details" do
+    it 'sets an error code' do
+      expect(response.header['X-Opensuse-Errorcode']).to eq('change_userinfo_no_permission')
+    end
+
+    it 'does not change users real name' do
+      expect(user.realname).to eq(old_realname)
+    end
+
+    it 'does not change users email address' do
+      expect(user.email).to eq(old_email)
+    end
+  end
+
+  describe 'POST #post_userinfo' do
     context 'when in LDAP mode' do
       before do
         login user
@@ -17,6 +35,46 @@ RSpec.describe PersonController, vcr: false do
 
       it 'user is not allowed to change their password' do
         expect(response.header['X-Opensuse-Errorcode']).to eq('change_password_no_permission')
+      end
+    end
+  end
+
+  describe 'PUT #put_userinfo' do
+    let(:xml) {
+      <<-XML_DATA
+        <userinfo>
+          <realname>test name</realname>
+          <email>test@test.de</email>
+        </userinfo>
+      XML_DATA
+    }
+
+    context 'when in LDAP mode' do
+      before do
+        stub_const('CONFIG', CONFIG.merge({ 'ldap_mode' => :on }))
+        request.env["RAW_POST_DATA"] = xml
+      end
+
+      context 'as an admin' do
+        before do
+          login admin_user
+
+          put :put_userinfo, params: { login: user.login, format: :xml }
+          user.reload
+        end
+
+        it_should_behave_like "not allowed to change user details"
+      end
+
+      context 'as a user' do
+        before do
+          login user
+
+          put :put_userinfo, params: { login: user.login, format: :xml }
+          user.reload
+        end
+
+        it_should_behave_like "not allowed to change user details"
       end
     end
   end


### PR DESCRIPTION
Since d1c5b6cdd3d42e30f207040b88e829a919607ebb we shall no longer allow to edit or create users via the API.