### PR TITLE
Fix maintenance workflow cassettes

### DIFF
--- a/src/api/spec/cassettes/MaintenanceWorkflow/maintenance_workflow.yml
+++ b/src/api/spec/cassettes/MaintenanceWorkflow/maintenance_workflow.yml
@@ -40,7 +40,7 @@ http_interactions:
           <person userid="user_1" role="maintainer" />
         </project>
     http_version: 
-  recorded_at: Mon, 19 Dec 2016 16:16:33 GMT
+  recorded_at: Mon, 21 Aug 2017 14:07:13 GMT
 - request:
     method: put
     uri: http://localhost:3200/source/ProjectWithRepo/_meta
@@ -48,7 +48,7 @@ http_interactions:
       encoding: UTF-8
       string: |
         <project name="ProjectWithRepo">
-          <title>Number the Stars</title>
+          <title>Now Sleeps the Crimson Petal</title>
           <description/>
         </project>
     headers:
@@ -70,24 +70,23 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '108'
+      - '120'
     body:
       encoding: UTF-8
       string: |
         <project name="ProjectWithRepo">
-          <title>Number the Stars</title>
+          <title>Now Sleeps the Crimson Petal</title>
           <description></description>
         </project>
     http_version: 
-  recorded_at: Mon, 19 Dec 2016 16:16:33 GMT
+  recorded_at: Mon, 21 Aug 2017 14:07:14 GMT
 - request:
     method: put
     uri: http://localhost:3200/source/ProjectWithRepo/_config
     body:
       encoding: UTF-8
-      string: Voluptatem sed aliquam ut quo blanditiis perferendis. Molestiae vel
-        dolore incidunt quo. Dolorem voluptas consequatur deleniti non quo assumenda
-        fugit. Neque qui quod voluptatem fugit. Quia est qui officiis aut natus enim.
+      string: Fugiat aspernatur maiores voluptates qui et. Incidunt eum expedita.
+        Ducimus et laboriosam iure et consequatur est dignissimos.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -114,7 +113,7 @@ http_interactions:
 
 '
     http_version: 
-  recorded_at: Mon, 19 Dec 2016 16:16:33 GMT
+  recorded_at: Mon, 21 Aug 2017 14:07:14 GMT
 - request:
     method: put
     uri: http://localhost:3200/source/ProjectWithRepo:Update/_meta
@@ -122,7 +121,7 @@ http_interactions:
       encoding: UTF-8
       string: |
         <project name="ProjectWithRepo:Update" kind="maintenance_release">
-          <title>A Monstrous Regiment of Women</title>
+          <title>The Wind's Twelve Quarters</title>
           <description/>
         </project>
     headers:
@@ -144,24 +143,23 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '155'
+      - '152'
     body:
       encoding: UTF-8
       string: |
         <project name="ProjectWithRepo:Update" kind="maintenance_release">
-          <title>A Monstrous Regiment of Women</title>
+          <title>The Wind's Twelve Quarters</title>
           <description></description>
         </project>
     http_version: 
-  recorded_at: Mon, 19 Dec 2016 16:16:34 GMT
+  recorded_at: Mon, 21 Aug 2017 14:07:14 GMT
 - request:
     method: put
     uri: http://localhost:3200/source/ProjectWithRepo:Update/_config
     body:
       encoding: UTF-8
-      string: Assumenda saepe quam qui quisquam. Quae harum omnis. Dolorum enim dolorem
-        aut voluptatem ullam blanditiis quos. Quasi et eaque eum. Sunt quia odit tempore
-        incidunt sint explicabo.
+      string: Vel illo ea quod minus debitis voluptatem. Dolorem officiis rerum voluptates
+        libero. Temporibus a reprehenderit deserunt pariatur.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -188,7 +186,7 @@ http_interactions:
 
 '
     http_version: 
-  recorded_at: Mon, 19 Dec 2016 16:16:34 GMT
+  recorded_at: Mon, 21 Aug 2017 14:07:14 GMT
 - request:
     method: put
     uri: http://localhost:3200/source/ProjectWithRepo:Update/_meta?user=user_1
@@ -196,7 +194,7 @@ http_interactions:
       encoding: UTF-8
       string: |
         <project name="ProjectWithRepo:Update" kind="maintenance_release">
-          <title>A Monstrous Regiment of Women</title>
+          <title>The Wind's Twelve Quarters</title>
           <description/>
           <link project="ProjectWithRepo"/>
         </project>
@@ -219,17 +217,17 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '192'
+      - '189'
     body:
       encoding: UTF-8
       string: |
         <project name="ProjectWithRepo:Update" kind="maintenance_release">
-          <title>A Monstrous Regiment of Women</title>
+          <title>The Wind's Twelve Quarters</title>
           <description></description>
           <link project="ProjectWithRepo" />
         </project>
     http_version: 
-  recorded_at: Mon, 19 Dec 2016 16:16:34 GMT
+  recorded_at: Mon, 21 Aug 2017 14:07:14 GMT
 - request:
     method: put
     uri: http://localhost:3200/source/home:maintenance_coord/_meta?user=maintenance_coord
@@ -270,7 +268,7 @@ http_interactions:
           <person userid="maintenance_coord" role="maintainer" />
         </project>
     http_version: 
-  recorded_at: Mon, 19 Dec 2016 16:16:34 GMT
+  recorded_at: Mon, 21 Aug 2017 14:07:14 GMT
 - request:
     method: put
     uri: http://localhost:3200/source/MaintenanceProject/_meta
@@ -309,14 +307,14 @@ http_interactions:
           <description></description>
         </project>
     http_version: 
-  recorded_at: Mon, 19 Dec 2016 16:16:34 GMT
+  recorded_at: Mon, 21 Aug 2017 14:07:14 GMT
 - request:
     method: put
     uri: http://localhost:3200/source/MaintenanceProject/_config
     body:
       encoding: UTF-8
-      string: Esse ut nostrum animi eum. Iure corrupti animi id fugit consequatur
-        eius. Rerum dolores explicabo est enim voluptatem mollitia nesciunt.
+      string: Aut ut nemo molestias. Quae aut veritatis et quas eos. Quod facere nisi
+        est voluptas aut aut.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -343,7 +341,7 @@ http_interactions:
 
 '
     http_version: 
-  recorded_at: Mon, 19 Dec 2016 16:16:34 GMT
+  recorded_at: Mon, 21 Aug 2017 14:07:14 GMT
 - request:
     method: put
     uri: http://localhost:3200/source/MaintenanceProject/_meta?user=user_1
@@ -388,7 +386,7 @@ http_interactions:
           </maintenance>
         </project>
     http_version: 
-  recorded_at: Mon, 19 Dec 2016 16:16:34 GMT
+  recorded_at: Mon, 21 Aug 2017 14:07:14 GMT
 - request:
     method: put
     uri: http://localhost:3200/source/MaintenanceProject/patchinfo/_meta?user=maintenance_coord
@@ -445,12 +443,12 @@ http_interactions:
           </useforbuild>
         </package>
     http_version: 
-  recorded_at: Mon, 19 Dec 2016 16:16:34 GMT
+  recorded_at: Mon, 21 Aug 2017 14:07:14 GMT
 - request:
     method: put
     uri: http://localhost:3200/source/MaintenanceProject/patchinfo/_patchinfo?comment=generated%20by%20createpatchinfo%20call&user=maintenance_coord
     body:
-      encoding: UTF-8
+      encoding: ASCII-8BIT
       string: |-
         <patchinfo>
           <category>recommended</category>
@@ -482,16 +480,73 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <revision rev="1" vrev="1">
+        <revision rev="2" vrev="2">
           <srcmd5>7c79565cf2a5793c8092ebecfe0a912a</srcmd5>
           <version>unknown</version>
-          <time>1482164194</time>
+          <time>1503324434</time>
           <user>maintenance_coord</user>
           <comment>generated by createpatchinfo call</comment>
           <requestid/>
         </revision>
     http_version: 
-  recorded_at: Mon, 19 Dec 2016 16:16:34 GMT
+  recorded_at: Mon, 21 Aug 2017 14:07:14 GMT
+- request:
+    method: put
+    uri: http://localhost:3200/source/MaintenanceProject/patchinfo/_meta?user=maintenance_coord
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="patchinfo" project="MaintenanceProject">
+          <title>Patchinfo</title>
+          <description>Collected packages for update</description>
+          <build>
+            <enable/>
+          </build>
+          <publish>
+            <enable/>
+          </publish>
+          <useforbuild>
+            <disable/>
+          </useforbuild>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '278'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="patchinfo" project="MaintenanceProject">
+          <title>Patchinfo</title>
+          <description>Collected packages for update</description>
+          <build>
+            <enable />
+          </build>
+          <publish>
+            <enable />
+          </publish>
+          <useforbuild>
+            <disable />
+          </useforbuild>
+        </package>
+    http_version: 
+  recorded_at: Mon, 21 Aug 2017 14:07:15 GMT
 - request:
     method: get
     uri: http://localhost:3200/source/MaintenanceProject/patchinfo
@@ -521,11 +576,11 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="patchinfo" rev="1" vrev="1" srcmd5="7c79565cf2a5793c8092ebecfe0a912a">
-          <entry name="_patchinfo" md5="ea890f2483d4b7e7255d64ef4dbb1d43" size="174" mtime="1482164194" />
+        <directory name="patchinfo" rev="2" vrev="2" srcmd5="7c79565cf2a5793c8092ebecfe0a912a">
+          <entry name="_patchinfo" md5="ea890f2483d4b7e7255d64ef4dbb1d43" size="174" mtime="1503324262" />
         </directory>
     http_version: 
-  recorded_at: Mon, 19 Dec 2016 16:16:35 GMT
+  recorded_at: Mon, 21 Aug 2017 14:07:15 GMT
 - request:
     method: get
     uri: http://localhost:3200/source/MaintenanceProject/patchinfo?nofilename=1&view=info&withchangesmd5=1
@@ -555,11 +610,11 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <sourceinfo package="patchinfo" rev="1" vrev="1" srcmd5="7c79565cf2a5793c8092ebecfe0a912a" verifymd5="7c79565cf2a5793c8092ebecfe0a912a">
-          <revtime>1482164194</revtime>
+        <sourceinfo package="patchinfo" rev="2" vrev="2" srcmd5="7c79565cf2a5793c8092ebecfe0a912a" verifymd5="7c79565cf2a5793c8092ebecfe0a912a">
+          <revtime>1503324434</revtime>
         </sourceinfo>
     http_version: 
-  recorded_at: Mon, 19 Dec 2016 16:16:35 GMT
+  recorded_at: Mon, 21 Aug 2017 14:07:15 GMT
 - request:
     method: get
     uri: http://localhost:3200/source/MaintenanceProject/patchinfo
@@ -589,11 +644,11 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="patchinfo" rev="1" vrev="1" srcmd5="7c79565cf2a5793c8092ebecfe0a912a">
-          <entry name="_patchinfo" md5="ea890f2483d4b7e7255d64ef4dbb1d43" size="174" mtime="1482164194" />
+        <directory name="patchinfo" rev="2" vrev="2" srcmd5="7c79565cf2a5793c8092ebecfe0a912a">
+          <entry name="_patchinfo" md5="ea890f2483d4b7e7255d64ef4dbb1d43" size="174" mtime="1503324262" />
         </directory>
     http_version: 
-  recorded_at: Mon, 19 Dec 2016 16:16:35 GMT
+  recorded_at: Mon, 21 Aug 2017 14:07:15 GMT
 - request:
     method: get
     uri: http://localhost:3200/source/MaintenanceProject/patchinfo/_patchinfo
@@ -631,7 +686,7 @@ http_interactions:
           <description/>
         </patchinfo>
     http_version: 
-  recorded_at: Mon, 19 Dec 2016 16:16:35 GMT
+  recorded_at: Mon, 21 Aug 2017 14:07:15 GMT
 - request:
     method: put
     uri: http://localhost:3200/source/home:tom/_meta?user=tom
@@ -672,7 +727,7 @@ http_interactions:
           <person userid="tom" role="maintainer" />
         </project>
     http_version: 
-  recorded_at: Mon, 19 Dec 2016 16:16:35 GMT
+  recorded_at: Mon, 21 Aug 2017 14:07:15 GMT
 - request:
     method: put
     uri: http://localhost:3200/source/ProjectWithRepo/ProjectWithRepo_package/_meta?user=tom
@@ -680,8 +735,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="ProjectWithRepo_package" project="ProjectWithRepo">
-          <title/>
-          <description/>
+          <title>Moab Is My Washpot</title>
+          <description>Eius ut consequuntur nihil.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -702,16 +757,16 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '126'
+      - '171'
     body:
       encoding: UTF-8
       string: |
         <package name="ProjectWithRepo_package" project="ProjectWithRepo">
-          <title></title>
-          <description></description>
+          <title>Moab Is My Washpot</title>
+          <description>Eius ut consequuntur nihil.</description>
         </package>
     http_version: 
-  recorded_at: Mon, 19 Dec 2016 16:16:40 GMT
+  recorded_at: Mon, 21 Aug 2017 14:07:19 GMT
 - request:
     method: put
     uri: http://localhost:3200/source/ProjectWithRepo/ProjectWithRepo_package/_meta
@@ -719,8 +774,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="ProjectWithRepo_package" project="ProjectWithRepo">
-          <title/>
-          <description/>
+          <title>Moab Is My Washpot</title>
+          <description>Eius ut consequuntur nihil.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -741,23 +796,23 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '126'
+      - '171'
     body:
       encoding: UTF-8
       string: |
         <package name="ProjectWithRepo_package" project="ProjectWithRepo">
-          <title></title>
-          <description></description>
+          <title>Moab Is My Washpot</title>
+          <description>Eius ut consequuntur nihil.</description>
         </package>
     http_version: 
-  recorded_at: Mon, 19 Dec 2016 16:16:40 GMT
+  recorded_at: Mon, 21 Aug 2017 14:07:19 GMT
 - request:
     method: put
     uri: http://localhost:3200/source/ProjectWithRepo/ProjectWithRepo_package/_config
     body:
       encoding: UTF-8
-      string: Incidunt quas cumque soluta ea. Soluta quo est. Animi maiores optio
-        facere mollitia autem ullam sit. Pariatur iusto necessitatibus.
+      string: Et sunt dolorum omnis. Sit suscipit ut blanditiis tenetur. Magnam cupiditate
+        et doloribus quis debitis.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -781,24 +836,24 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <revision rev="1" vrev="1">
-          <srcmd5>696449df02abcfb7392cfa7d692cadf2</srcmd5>
+        <revision rev="3" vrev="3">
+          <srcmd5>c85c464f3c56eedbe4491ba8e71e6990</srcmd5>
           <version>unknown</version>
-          <time>1482164200</time>
+          <time>1503324439</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
     http_version: 
-  recorded_at: Mon, 19 Dec 2016 16:16:40 GMT
+  recorded_at: Mon, 21 Aug 2017 14:07:19 GMT
 - request:
     method: put
     uri: http://localhost:3200/source/ProjectWithRepo/ProjectWithRepo_package/somefile.txt
     body:
       encoding: UTF-8
-      string: Occaecati quasi sint doloribus vitae sed consectetur. Aut alias aut
-        vero. Et eligendi libero dicta fugiat maiores ratione provident. Ipsam quia
-        error.
+      string: Molestiae assumenda sunt. Non aperiam voluptatem et ipsam nesciunt voluptas.
+        Reiciendis est animi repudiandae voluptatibus qui modi ea. Repellat tempore
+        beatae.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -822,51 +877,16 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <revision rev="2" vrev="2">
-          <srcmd5>93f9e495c18a6fc43a1efa793a3aa72f</srcmd5>
+        <revision rev="4" vrev="4">
+          <srcmd5>09e82b0920e2079611427fc5ae96b076</srcmd5>
           <version>unknown</version>
-          <time>1482164200</time>
+          <time>1503324439</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
     http_version: 
-  recorded_at: Mon, 19 Dec 2016 16:16:40 GMT
-- request:
-    method: get
-    uri: http://localhost:3200/build/ProjectWithRepo:Update/_result?package=ProjectWithRepo_package&view=status
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Content-Type:
-      - text/plain
-      Accept-Encoding:
-      - identity
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '56'
-    body:
-      encoding: UTF-8
-      string: '<resultlist state="00000000000000000000000000000000" />
-
-'
-    http_version: 
-  recorded_at: Mon, 19 Dec 2016 16:16:40 GMT
+  recorded_at: Mon, 21 Aug 2017 14:07:19 GMT
 - request:
     method: get
     uri: http://localhost:3200/source/ProjectWithRepo/ProjectWithRepo_package?nofilename=1&view=info&withchangesmd5=1
@@ -896,11 +916,11 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <sourceinfo package="ProjectWithRepo_package" rev="2" vrev="2" srcmd5="93f9e495c18a6fc43a1efa793a3aa72f" verifymd5="93f9e495c18a6fc43a1efa793a3aa72f">
-          <revtime>1482164200</revtime>
+        <sourceinfo package="ProjectWithRepo_package" rev="4" vrev="4" srcmd5="09e82b0920e2079611427fc5ae96b076" verifymd5="09e82b0920e2079611427fc5ae96b076">
+          <revtime>1503324439</revtime>
         </sourceinfo>
     http_version: 
-  recorded_at: Mon, 19 Dec 2016 16:16:40 GMT
+  recorded_at: Mon, 21 Aug 2017 14:07:19 GMT
 - request:
     method: get
     uri: http://localhost:3200/source/ProjectWithRepo/ProjectWithRepo_package
@@ -930,12 +950,12 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="ProjectWithRepo_package" rev="2" vrev="2" srcmd5="93f9e495c18a6fc43a1efa793a3aa72f">
-          <entry name="_config" md5="822bf2a29d1fd3fb4a6518a86e9dcd2b" size="131" mtime="1482164200" />
-          <entry name="somefile.txt" md5="791025267dcc9c8ad8c462c3835a8c2f" size="150" mtime="1482164200" />
+        <directory name="ProjectWithRepo_package" rev="4" vrev="4" srcmd5="09e82b0920e2079611427fc5ae96b076">
+          <entry name="_config" md5="55041d03ef8e31e551b3edd00464f7ea" size="103" mtime="1503324439" />
+          <entry name="somefile.txt" md5="72a89c51cb636651b1da704fa7b303ee" size="160" mtime="1503324439" />
         </directory>
     http_version: 
-  recorded_at: Mon, 19 Dec 2016 16:16:40 GMT
+  recorded_at: Mon, 21 Aug 2017 14:07:19 GMT
 - request:
     method: post
     uri: http://localhost:3200/source/ProjectWithRepo/ProjectWithRepo_package?cmd=diff&linkrev=base&onlyissues=1&orev=0&view=xml
@@ -967,15 +987,15 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="075631913040a5c1e396faa216996aa5">
+        <sourcediff key="dbbb16df293f7ced721feb3a38b48ed4">
           <old project="ProjectWithRepo" package="ProjectWithRepo_package" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e" />
-          <new project="ProjectWithRepo" package="ProjectWithRepo_package" rev="2" srcmd5="93f9e495c18a6fc43a1efa793a3aa72f" />
+          <new project="ProjectWithRepo" package="ProjectWithRepo_package" rev="4" srcmd5="09e82b0920e2079611427fc5ae96b076" />
           <files />
           <issues>
           </issues>
         </sourcediff>
     http_version: 
-  recorded_at: Mon, 19 Dec 2016 16:16:40 GMT
+  recorded_at: Mon, 21 Aug 2017 14:07:19 GMT
 - request:
     method: get
     uri: http://localhost:3200/source/ProjectWithRepo/ProjectWithRepo_package
@@ -1005,23 +1025,21 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="ProjectWithRepo_package" rev="2" vrev="2" srcmd5="93f9e495c18a6fc43a1efa793a3aa72f">
-          <entry name="_config" md5="822bf2a29d1fd3fb4a6518a86e9dcd2b" size="131" mtime="1482164200" />
-          <entry name="somefile.txt" md5="791025267dcc9c8ad8c462c3835a8c2f" size="150" mtime="1482164200" />
+        <directory name="ProjectWithRepo_package" rev="4" vrev="4" srcmd5="09e82b0920e2079611427fc5ae96b076">
+          <entry name="_config" md5="55041d03ef8e31e551b3edd00464f7ea" size="103" mtime="1503324439" />
+          <entry name="somefile.txt" md5="72a89c51cb636651b1da704fa7b303ee" size="160" mtime="1503324439" />
         </directory>
     http_version: 
-  recorded_at: Mon, 19 Dec 2016 16:16:40 GMT
+  recorded_at: Mon, 21 Aug 2017 14:07:19 GMT
 - request:
     method: get
-    uri: http://localhost:3200/source/ProjectWithRepo/ProjectWithRepo_package?expand=1&rev=2
+    uri: http://localhost:3200/source/ProjectWithRepo/ProjectWithRepo_package?expand=1&rev=4
     body:
       encoding: US-ASCII
       string: ''
     headers:
-      Content-Type:
-      - text/plain
       Accept-Encoding:
-      - identity
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
       - "*/*"
       User-Agent:
@@ -1042,12 +1060,12 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="ProjectWithRepo_package" rev="2" vrev="2" srcmd5="93f9e495c18a6fc43a1efa793a3aa72f">
-          <entry name="_config" md5="822bf2a29d1fd3fb4a6518a86e9dcd2b" size="131" mtime="1482164200" />
-          <entry name="somefile.txt" md5="791025267dcc9c8ad8c462c3835a8c2f" size="150" mtime="1482164200" />
+        <directory name="ProjectWithRepo_package" rev="4" vrev="4" srcmd5="09e82b0920e2079611427fc5ae96b076">
+          <entry name="_config" md5="55041d03ef8e31e551b3edd00464f7ea" size="103" mtime="1503324439" />
+          <entry name="somefile.txt" md5="72a89c51cb636651b1da704fa7b303ee" size="160" mtime="1503324439" />
         </directory>
     http_version: 
-  recorded_at: Mon, 19 Dec 2016 16:16:40 GMT
+  recorded_at: Mon, 21 Aug 2017 14:07:19 GMT
 - request:
     method: get
     uri: http://localhost:3200/source/ProjectWithRepo/ProjectWithRepo_package
@@ -1079,12 +1097,12 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="ProjectWithRepo_package" rev="2" vrev="2" srcmd5="93f9e495c18a6fc43a1efa793a3aa72f">
-          <entry name="_config" md5="822bf2a29d1fd3fb4a6518a86e9dcd2b" size="131" mtime="1482164200" />
-          <entry name="somefile.txt" md5="791025267dcc9c8ad8c462c3835a8c2f" size="150" mtime="1482164200" />
+        <directory name="ProjectWithRepo_package" rev="4" vrev="4" srcmd5="09e82b0920e2079611427fc5ae96b076">
+          <entry name="_config" md5="55041d03ef8e31e551b3edd00464f7ea" size="103" mtime="1503324439" />
+          <entry name="somefile.txt" md5="72a89c51cb636651b1da704fa7b303ee" size="160" mtime="1503324439" />
         </directory>
     http_version: 
-  recorded_at: Mon, 19 Dec 2016 16:16:40 GMT
+  recorded_at: Mon, 21 Aug 2017 14:07:19 GMT
 - request:
     method: get
     uri: http://localhost:3200/source/ProjectWithRepo:Update/ProjectWithRepo_package/_service
@@ -1121,7 +1139,7 @@ http_interactions:
           <details>404 _service: no such file</details>
         </status>
     http_version: 
-  recorded_at: Mon, 19 Dec 2016 16:16:40 GMT
+  recorded_at: Mon, 21 Aug 2017 14:07:19 GMT
 - request:
     method: get
     uri: http://localhost:3200/source/ProjectWithRepo/ProjectWithRepo_package/_history
@@ -1147,26 +1165,38 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '395'
+      - '759'
     body:
       encoding: UTF-8
       string: |
         <revisionlist>
           <revision rev="1" vrev="1">
-            <srcmd5>696449df02abcfb7392cfa7d692cadf2</srcmd5>
+            <srcmd5>ad3fe0389f8e0af1f15d078639553e4a</srcmd5>
             <version>unknown</version>
-            <time>1482164200</time>
+            <time>1503324266</time>
             <user>unknown</user>
           </revision>
           <revision rev="2" vrev="2">
-            <srcmd5>93f9e495c18a6fc43a1efa793a3aa72f</srcmd5>
+            <srcmd5>aaec46c945d5814d65a0676b78ac7659</srcmd5>
             <version>unknown</version>
-            <time>1482164200</time>
+            <time>1503324266</time>
+            <user>unknown</user>
+          </revision>
+          <revision rev="3" vrev="3">
+            <srcmd5>c85c464f3c56eedbe4491ba8e71e6990</srcmd5>
+            <version>unknown</version>
+            <time>1503324439</time>
+            <user>unknown</user>
+          </revision>
+          <revision rev="4" vrev="4">
+            <srcmd5>09e82b0920e2079611427fc5ae96b076</srcmd5>
+            <version>unknown</version>
+            <time>1503324439</time>
             <user>unknown</user>
           </revision>
         </revisionlist>
     http_version: 
-  recorded_at: Mon, 19 Dec 2016 16:16:40 GMT
+  recorded_at: Mon, 21 Aug 2017 14:07:19 GMT
 - request:
     method: get
     uri: http://localhost:3200/build/ProjectWithRepo:Update/_result?package=ProjectWithRepo_package&view=status
@@ -1201,10 +1231,10 @@ http_interactions:
 
 '
     http_version: 
-  recorded_at: Mon, 19 Dec 2016 16:16:41 GMT
+  recorded_at: Mon, 21 Aug 2017 14:07:20 GMT
 - request:
     method: get
-    uri: http://localhost:3200/build/ProjectWithRepo:Update/_result?package=ProjectWithRepo_package&view=status
+    uri: http://localhost:3200/build/ProjectWithRepo:Update/_result?locallink=1&multibuild=1&package=ProjectWithRepo_package&view=status
     body:
       encoding: US-ASCII
       string: ''
@@ -1236,7 +1266,7 @@ http_interactions:
 
 '
     http_version: 
-  recorded_at: Mon, 19 Dec 2016 16:16:41 GMT
+  recorded_at: Mon, 21 Aug 2017 14:07:20 GMT
 - request:
     method: post
     uri: http://localhost:3200/search/package/id?match=(linkinfo/@package=%22ProjectWithRepo_package%22%20and%20linkinfo/@project=%22ProjectWithRepo:Update%22%20and%20starts-with(@project,%22MaintenanceProject:%22))
@@ -1264,14 +1294,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '27'
+      - '126'
     body:
       encoding: UTF-8
       string: |
         <collection>
+          <package name="ProjectWithRepo_package.ProjectWithRepo_Update" project="MaintenanceProject:0" />
         </collection>
     http_version: 
-  recorded_at: Mon, 19 Dec 2016 16:16:42 GMT
+  recorded_at: Mon, 21 Aug 2017 14:07:20 GMT
 - request:
     method: post
     uri: http://localhost:3200/search/package/id?match=(linkinfo/@package=%22ProjectWithRepo_package%22%20and%20linkinfo/@project=%22ProjectWithRepo%22%20and%20@project=%22ProjectWithRepo%22)
@@ -1306,7 +1337,7 @@ http_interactions:
         <collection>
         </collection>
     http_version: 
-  recorded_at: Mon, 19 Dec 2016 16:16:42 GMT
+  recorded_at: Mon, 21 Aug 2017 14:07:20 GMT
 - request:
     method: put
     uri: http://localhost:3200/source/home:tom:branches:ProjectWithRepo:Update/_meta?user=tom
@@ -1347,7 +1378,7 @@ http_interactions:
           <person userid="tom" role="maintainer" />
         </project>
     http_version: 
-  recorded_at: Mon, 19 Dec 2016 16:16:42 GMT
+  recorded_at: Mon, 21 Aug 2017 14:07:20 GMT
 - request:
     method: put
     uri: http://localhost:3200/source/home:tom:branches:ProjectWithRepo:Update/ProjectWithRepo_package/_meta?user=tom
@@ -1355,8 +1386,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="ProjectWithRepo_package" project="home:tom:branches:ProjectWithRepo:Update">
-          <title/>
-          <description/>
+          <title>Moab Is My Washpot</title>
+          <description>Eius ut consequuntur nihil.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -1377,16 +1408,16 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '151'
+      - '196'
     body:
       encoding: UTF-8
       string: |
         <package name="ProjectWithRepo_package" project="home:tom:branches:ProjectWithRepo:Update">
-          <title></title>
-          <description></description>
+          <title>Moab Is My Washpot</title>
+          <description>Eius ut consequuntur nihil.</description>
         </package>
     http_version: 
-  recorded_at: Mon, 19 Dec 2016 16:16:42 GMT
+  recorded_at: Mon, 21 Aug 2017 14:07:20 GMT
 - request:
     method: post
     uri: http://localhost:3200/source/home:tom:branches:ProjectWithRepo:Update/ProjectWithRepo_package?cmd=branch&opackage=ProjectWithRepo_package&oproject=ProjectWithRepo:Update&user=tom
@@ -1418,16 +1449,55 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <revision rev="1" vrev="1">
-          <srcmd5>406424891d32d60f6718634748460adf</srcmd5>
+        <revision rev="3" vrev="3">
+          <srcmd5>defcef32689817852de9ed4fc08c1ec2</srcmd5>
           <version>unknown</version>
-          <time>1482164202</time>
+          <time>1503324440</time>
           <user>tom</user>
           <comment></comment>
           <requestid/>
         </revision>
     http_version: 
-  recorded_at: Mon, 19 Dec 2016 16:16:42 GMT
+  recorded_at: Mon, 21 Aug 2017 14:07:20 GMT
+- request:
+    method: put
+    uri: http://localhost:3200/source/home:tom:branches:ProjectWithRepo:Update/ProjectWithRepo_package/_meta?user=tom
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="ProjectWithRepo_package" project="home:tom:branches:ProjectWithRepo:Update">
+          <title>Moab Is My Washpot</title>
+          <description>Eius ut consequuntur nihil.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '196'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="ProjectWithRepo_package" project="home:tom:branches:ProjectWithRepo:Update">
+          <title>Moab Is My Washpot</title>
+          <description>Eius ut consequuntur nihil.</description>
+        </package>
+    http_version: 
+  recorded_at: Mon, 21 Aug 2017 14:07:20 GMT
 - request:
     method: get
     uri: http://localhost:3200/source/home:tom:branches:ProjectWithRepo:Update/ProjectWithRepo_package
@@ -1457,14 +1527,14 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="ProjectWithRepo_package" rev="1" vrev="1" srcmd5="406424891d32d60f6718634748460adf">
-          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" srcmd5="93f9e495c18a6fc43a1efa793a3aa72f" baserev="93f9e495c18a6fc43a1efa793a3aa72f" xsrcmd5="ee13701103cfce791a6ffa915bf65e75" lsrcmd5="406424891d32d60f6718634748460adf" />
-          <entry name="_config" md5="822bf2a29d1fd3fb4a6518a86e9dcd2b" size="131" mtime="1482164200" />
-          <entry name="_link" md5="0a82b9fa0797930f466dca66ce9a1137" size="130" mtime="1482164202" />
-          <entry name="somefile.txt" md5="791025267dcc9c8ad8c462c3835a8c2f" size="150" mtime="1482164200" />
+        <directory name="ProjectWithRepo_package" rev="3" vrev="3" srcmd5="defcef32689817852de9ed4fc08c1ec2">
+          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" srcmd5="09e82b0920e2079611427fc5ae96b076" baserev="09e82b0920e2079611427fc5ae96b076" xsrcmd5="09cc76faf05ef2b07f7f0238bf0c98b4" lsrcmd5="defcef32689817852de9ed4fc08c1ec2" />
+          <entry name="_config" md5="55041d03ef8e31e551b3edd00464f7ea" size="103" mtime="1503324439" />
+          <entry name="_link" md5="6ffab3981d3cd40f46924a3319a54098" size="130" mtime="1503324440" />
+          <entry name="somefile.txt" md5="72a89c51cb636651b1da704fa7b303ee" size="160" mtime="1503324439" />
         </directory>
     http_version: 
-  recorded_at: Mon, 19 Dec 2016 16:16:42 GMT
+  recorded_at: Mon, 21 Aug 2017 14:07:20 GMT
 - request:
     method: get
     uri: http://localhost:3200/source/home:tom:branches:ProjectWithRepo:Update/ProjectWithRepo_package?nofilename=1&view=info&withchangesmd5=1
@@ -1494,13 +1564,13 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <sourceinfo package="ProjectWithRepo_package" rev="1" vrev="3" srcmd5="ee13701103cfce791a6ffa915bf65e75" lsrcmd5="406424891d32d60f6718634748460adf" verifymd5="93f9e495c18a6fc43a1efa793a3aa72f">
+        <sourceinfo package="ProjectWithRepo_package" rev="3" vrev="7" srcmd5="09cc76faf05ef2b07f7f0238bf0c98b4" lsrcmd5="defcef32689817852de9ed4fc08c1ec2" verifymd5="09e82b0920e2079611427fc5ae96b076">
           <linked project="ProjectWithRepo:Update" package="ProjectWithRepo_package" />
           <linked project="ProjectWithRepo" package="ProjectWithRepo_package" />
-          <revtime>1482164202</revtime>
+          <revtime>1503324440</revtime>
         </sourceinfo>
     http_version: 
-  recorded_at: Mon, 19 Dec 2016 16:16:42 GMT
+  recorded_at: Mon, 21 Aug 2017 14:07:20 GMT
 - request:
     method: get
     uri: http://localhost:3200/source/home:tom:branches:ProjectWithRepo:Update/ProjectWithRepo_package
@@ -1530,14 +1600,14 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="ProjectWithRepo_package" rev="1" vrev="1" srcmd5="406424891d32d60f6718634748460adf">
-          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" srcmd5="93f9e495c18a6fc43a1efa793a3aa72f" baserev="93f9e495c18a6fc43a1efa793a3aa72f" xsrcmd5="ee13701103cfce791a6ffa915bf65e75" lsrcmd5="406424891d32d60f6718634748460adf" />
-          <entry name="_config" md5="822bf2a29d1fd3fb4a6518a86e9dcd2b" size="131" mtime="1482164200" />
-          <entry name="_link" md5="0a82b9fa0797930f466dca66ce9a1137" size="130" mtime="1482164202" />
-          <entry name="somefile.txt" md5="791025267dcc9c8ad8c462c3835a8c2f" size="150" mtime="1482164200" />
+        <directory name="ProjectWithRepo_package" rev="3" vrev="3" srcmd5="defcef32689817852de9ed4fc08c1ec2">
+          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" srcmd5="09e82b0920e2079611427fc5ae96b076" baserev="09e82b0920e2079611427fc5ae96b076" xsrcmd5="09cc76faf05ef2b07f7f0238bf0c98b4" lsrcmd5="defcef32689817852de9ed4fc08c1ec2" />
+          <entry name="_config" md5="55041d03ef8e31e551b3edd00464f7ea" size="103" mtime="1503324439" />
+          <entry name="_link" md5="6ffab3981d3cd40f46924a3319a54098" size="130" mtime="1503324440" />
+          <entry name="somefile.txt" md5="72a89c51cb636651b1da704fa7b303ee" size="160" mtime="1503324439" />
         </directory>
     http_version: 
-  recorded_at: Mon, 19 Dec 2016 16:16:42 GMT
+  recorded_at: Mon, 21 Aug 2017 14:07:20 GMT
 - request:
     method: post
     uri: http://localhost:3200/source/home:tom:branches:ProjectWithRepo:Update/ProjectWithRepo_package?cmd=diff&linkrev=base&onlyissues=1&orev=0&view=xml
@@ -1569,15 +1639,15 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="f01ab794f12389a818907fd7720325c6">
+        <sourcediff key="d1e515a73057e4000d944b1e23932f0f">
           <old project="home:tom:branches:ProjectWithRepo:Update" package="ProjectWithRepo_package" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e" />
-          <new project="home:tom:branches:ProjectWithRepo:Update" package="ProjectWithRepo_package" rev="1" srcmd5="406424891d32d60f6718634748460adf" />
+          <new project="home:tom:branches:ProjectWithRepo:Update" package="ProjectWithRepo_package" rev="3" srcmd5="defcef32689817852de9ed4fc08c1ec2" />
           <files />
           <issues>
           </issues>
         </sourcediff>
     http_version: 
-  recorded_at: Mon, 19 Dec 2016 16:16:42 GMT
+  recorded_at: Mon, 21 Aug 2017 14:07:20 GMT
 - request:
     method: post
     uri: http://localhost:3200/source/home:tom:branches:ProjectWithRepo:Update/ProjectWithRepo_package?cmd=linkdiff&linkrev=base&onlyissues=1&view=xml
@@ -1609,13 +1679,13 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="a96129c066fdd8b25d9b8bca7c812706">
-          <old project="ProjectWithRepo:Update" package="ProjectWithRepo_package" rev="93f9e495c18a6fc43a1efa793a3aa72f" srcmd5="93f9e495c18a6fc43a1efa793a3aa72f" />
-          <new project="home:tom:branches:ProjectWithRepo:Update" package="ProjectWithRepo_package" rev="ee13701103cfce791a6ffa915bf65e75" srcmd5="ee13701103cfce791a6ffa915bf65e75" />
+        <sourcediff key="c24d674c1b14c81f99c1f38df612391d">
+          <old project="ProjectWithRepo:Update" package="ProjectWithRepo_package" rev="09e82b0920e2079611427fc5ae96b076" srcmd5="09e82b0920e2079611427fc5ae96b076" />
+          <new project="home:tom:branches:ProjectWithRepo:Update" package="ProjectWithRepo_package" rev="09cc76faf05ef2b07f7f0238bf0c98b4" srcmd5="09cc76faf05ef2b07f7f0238bf0c98b4" />
           <files />
         </sourcediff>
     http_version: 
-  recorded_at: Mon, 19 Dec 2016 16:16:42 GMT
+  recorded_at: Mon, 21 Aug 2017 14:07:20 GMT
 - request:
     method: put
     uri: http://localhost:3200/source/home:tom:branches:ProjectWithRepo:Update/_meta?user=tom
@@ -1672,43 +1742,7 @@ http_interactions:
           </repository>
         </project>
     http_version: 
-  recorded_at: Mon, 19 Dec 2016 16:16:43 GMT
-- request:
-    method: get
-    uri: http://localhost:3200/build/home:tom:branches:ProjectWithRepo:Update/_result?package=ProjectWithRepo_package&view=status
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Content-Type:
-      - text/plain
-      Accept-Encoding:
-      - identity
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '201'
-    body:
-      encoding: UTF-8
-      string: |
-        <resultlist state="02b5d621c3429470ea6cea78ab32d5ff">
-          <result project="home:tom:branches:ProjectWithRepo:Update" repository="repository_2" arch="i586" code="unknown" state="unknown" />
-        </resultlist>
-    http_version: 
-  recorded_at: Mon, 19 Dec 2016 16:16:43 GMT
+  recorded_at: Mon, 21 Aug 2017 14:07:21 GMT
 - request:
     method: get
     uri: http://localhost:3200/source/home:tom:branches:ProjectWithRepo:Update/ProjectWithRepo_package
@@ -1738,25 +1772,23 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="ProjectWithRepo_package" rev="1" vrev="1" srcmd5="406424891d32d60f6718634748460adf">
-          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" srcmd5="93f9e495c18a6fc43a1efa793a3aa72f" baserev="93f9e495c18a6fc43a1efa793a3aa72f" xsrcmd5="ee13701103cfce791a6ffa915bf65e75" lsrcmd5="406424891d32d60f6718634748460adf" />
-          <entry name="_config" md5="822bf2a29d1fd3fb4a6518a86e9dcd2b" size="131" mtime="1482164200" />
-          <entry name="_link" md5="0a82b9fa0797930f466dca66ce9a1137" size="130" mtime="1482164202" />
-          <entry name="somefile.txt" md5="791025267dcc9c8ad8c462c3835a8c2f" size="150" mtime="1482164200" />
+        <directory name="ProjectWithRepo_package" rev="3" vrev="3" srcmd5="defcef32689817852de9ed4fc08c1ec2">
+          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" srcmd5="09e82b0920e2079611427fc5ae96b076" baserev="09e82b0920e2079611427fc5ae96b076" xsrcmd5="09cc76faf05ef2b07f7f0238bf0c98b4" lsrcmd5="defcef32689817852de9ed4fc08c1ec2" />
+          <entry name="_config" md5="55041d03ef8e31e551b3edd00464f7ea" size="103" mtime="1503324439" />
+          <entry name="_link" md5="6ffab3981d3cd40f46924a3319a54098" size="130" mtime="1503324440" />
+          <entry name="somefile.txt" md5="72a89c51cb636651b1da704fa7b303ee" size="160" mtime="1503324439" />
         </directory>
     http_version: 
-  recorded_at: Mon, 19 Dec 2016 16:16:43 GMT
+  recorded_at: Mon, 21 Aug 2017 14:07:21 GMT
 - request:
     method: get
-    uri: http://localhost:3200/source/home:tom:branches:ProjectWithRepo:Update/ProjectWithRepo_package?expand=1&rev=1
+    uri: http://localhost:3200/source/home:tom:branches:ProjectWithRepo:Update/ProjectWithRepo_package?expand=1&rev=3
     body:
       encoding: US-ASCII
       string: ''
     headers:
-      Content-Type:
-      - text/plain
       Accept-Encoding:
-      - identity
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
       - "*/*"
       User-Agent:
@@ -1777,13 +1809,13 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="ProjectWithRepo_package" rev="ee13701103cfce791a6ffa915bf65e75" vrev="3" srcmd5="ee13701103cfce791a6ffa915bf65e75">
-          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" srcmd5="93f9e495c18a6fc43a1efa793a3aa72f" baserev="93f9e495c18a6fc43a1efa793a3aa72f" lsrcmd5="406424891d32d60f6718634748460adf" />
-          <entry name="_config" md5="822bf2a29d1fd3fb4a6518a86e9dcd2b" size="131" mtime="1482164200" />
-          <entry name="somefile.txt" md5="791025267dcc9c8ad8c462c3835a8c2f" size="150" mtime="1482164200" />
+        <directory name="ProjectWithRepo_package" rev="09cc76faf05ef2b07f7f0238bf0c98b4" vrev="7" srcmd5="09cc76faf05ef2b07f7f0238bf0c98b4">
+          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" srcmd5="09e82b0920e2079611427fc5ae96b076" baserev="09e82b0920e2079611427fc5ae96b076" lsrcmd5="defcef32689817852de9ed4fc08c1ec2" />
+          <entry name="_config" md5="55041d03ef8e31e551b3edd00464f7ea" size="103" mtime="1503324439" />
+          <entry name="somefile.txt" md5="72a89c51cb636651b1da704fa7b303ee" size="160" mtime="1503324439" />
         </directory>
     http_version: 
-  recorded_at: Mon, 19 Dec 2016 16:16:43 GMT
+  recorded_at: Mon, 21 Aug 2017 14:07:21 GMT
 - request:
     method: get
     uri: http://localhost:3200/source/home:tom:branches:ProjectWithRepo:Update/ProjectWithRepo_package
@@ -1815,14 +1847,14 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="ProjectWithRepo_package" rev="1" vrev="1" srcmd5="406424891d32d60f6718634748460adf">
-          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" srcmd5="93f9e495c18a6fc43a1efa793a3aa72f" baserev="93f9e495c18a6fc43a1efa793a3aa72f" xsrcmd5="ee13701103cfce791a6ffa915bf65e75" lsrcmd5="406424891d32d60f6718634748460adf" />
-          <entry name="_config" md5="822bf2a29d1fd3fb4a6518a86e9dcd2b" size="131" mtime="1482164200" />
-          <entry name="_link" md5="0a82b9fa0797930f466dca66ce9a1137" size="130" mtime="1482164202" />
-          <entry name="somefile.txt" md5="791025267dcc9c8ad8c462c3835a8c2f" size="150" mtime="1482164200" />
+        <directory name="ProjectWithRepo_package" rev="3" vrev="3" srcmd5="defcef32689817852de9ed4fc08c1ec2">
+          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" srcmd5="09e82b0920e2079611427fc5ae96b076" baserev="09e82b0920e2079611427fc5ae96b076" xsrcmd5="09cc76faf05ef2b07f7f0238bf0c98b4" lsrcmd5="defcef32689817852de9ed4fc08c1ec2" />
+          <entry name="_config" md5="55041d03ef8e31e551b3edd00464f7ea" size="103" mtime="1503324439" />
+          <entry name="_link" md5="6ffab3981d3cd40f46924a3319a54098" size="130" mtime="1503324440" />
+          <entry name="somefile.txt" md5="72a89c51cb636651b1da704fa7b303ee" size="160" mtime="1503324439" />
         </directory>
     http_version: 
-  recorded_at: Mon, 19 Dec 2016 16:16:43 GMT
+  recorded_at: Mon, 21 Aug 2017 14:07:21 GMT
 - request:
     method: get
     uri: http://localhost:3200/source/home:tom:branches:ProjectWithRepo:Update/ProjectWithRepo_package/_service
@@ -1859,7 +1891,44 @@ http_interactions:
           <details>404 _service: no such file</details>
         </status>
     http_version: 
-  recorded_at: Mon, 19 Dec 2016 16:16:43 GMT
+  recorded_at: Mon, 21 Aug 2017 14:07:21 GMT
+- request:
+    method: get
+    uri: http://localhost:3200/source/home:tom:branches:ProjectWithRepo:Update/ProjectWithRepo_package
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '659'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="ProjectWithRepo_package" rev="3" vrev="3" srcmd5="defcef32689817852de9ed4fc08c1ec2">
+          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" srcmd5="09e82b0920e2079611427fc5ae96b076" baserev="09e82b0920e2079611427fc5ae96b076" xsrcmd5="09cc76faf05ef2b07f7f0238bf0c98b4" lsrcmd5="defcef32689817852de9ed4fc08c1ec2" />
+          <entry name="_config" md5="55041d03ef8e31e551b3edd00464f7ea" size="103" mtime="1503324439" />
+          <entry name="_link" md5="6ffab3981d3cd40f46924a3319a54098" size="130" mtime="1503324440" />
+          <entry name="somefile.txt" md5="72a89c51cb636651b1da704fa7b303ee" size="160" mtime="1503324439" />
+        </directory>
+    http_version: 
+  recorded_at: Mon, 21 Aug 2017 14:07:21 GMT
 - request:
     method: get
     uri: http://localhost:3200/source/home:tom:branches:ProjectWithRepo:Update/ProjectWithRepo_package/_history
@@ -1885,20 +1954,32 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '209'
+      - '569'
     body:
       encoding: UTF-8
       string: |
         <revisionlist>
           <revision rev="1" vrev="1">
-            <srcmd5>406424891d32d60f6718634748460adf</srcmd5>
+            <srcmd5>f540d2f25d290e11cc379462f85f4c31</srcmd5>
             <version>unknown</version>
-            <time>1482164202</time>
+            <time>1503324267</time>
+            <user>tom</user>
+          </revision>
+          <revision rev="2" vrev="2">
+            <srcmd5>1b8377f25ebe75d5a7fb7cdd11519ce0</srcmd5>
+            <version>unknown</version>
+            <time>1503324268</time>
+            <user>unknown</user>
+          </revision>
+          <revision rev="3" vrev="3">
+            <srcmd5>defcef32689817852de9ed4fc08c1ec2</srcmd5>
+            <version>unknown</version>
+            <time>1503324440</time>
             <user>tom</user>
           </revision>
         </revisionlist>
     http_version: 
-  recorded_at: Mon, 19 Dec 2016 16:16:43 GMT
+  recorded_at: Mon, 21 Aug 2017 14:07:21 GMT
 - request:
     method: get
     uri: http://localhost:3200/build/home:tom:branches:ProjectWithRepo:Update/_result?package=ProjectWithRepo_package&view=status
@@ -1934,10 +2015,10 @@ http_interactions:
           <result project="home:tom:branches:ProjectWithRepo:Update" repository="repository_2" arch="i586" code="unknown" state="unknown" />
         </resultlist>
     http_version: 
-  recorded_at: Mon, 19 Dec 2016 16:16:43 GMT
+  recorded_at: Mon, 21 Aug 2017 14:07:21 GMT
 - request:
     method: get
-    uri: http://localhost:3200/build/home:tom:branches:ProjectWithRepo:Update/_result?package=ProjectWithRepo_package&view=status
+    uri: http://localhost:3200/build/home:tom:branches:ProjectWithRepo:Update/_result?locallink=1&multibuild=1&package=ProjectWithRepo_package&view=status
     body:
       encoding: US-ASCII
       string: ''
@@ -1970,44 +2051,7 @@ http_interactions:
           <result project="home:tom:branches:ProjectWithRepo:Update" repository="repository_2" arch="i586" code="unknown" state="unknown" />
         </resultlist>
     http_version: 
-  recorded_at: Mon, 19 Dec 2016 16:16:43 GMT
-- request:
-    method: get
-    uri: http://localhost:3200/build/home:tom:branches:ProjectWithRepo:Update/repository_2/i586/ProjectWithRepo_package/rpmlint.log
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Content-Type:
-      - text/plain
-      Accept-Encoding:
-      - identity
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 404
-      message: rpmlint.log  No such file or directory
-    headers:
-      Content-Type:
-      - text/xml
-      Content-Length:
-      - '154'
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-    body:
-      encoding: UTF-8
-      string: |
-        <status code="404">
-          <summary>rpmlint.log: No such file or directory</summary>
-          <details>404 rpmlint.log: No such file or directory</details>
-        </status>
-    http_version: 
-  recorded_at: Mon, 19 Dec 2016 16:16:44 GMT
+  recorded_at: Mon, 21 Aug 2017 14:07:21 GMT
 - request:
     method: put
     uri: http://localhost:3200/source/home:tom:branches:ProjectWithRepo:Update/ProjectWithRepo_package/DUMMY_FILE
@@ -2037,16 +2081,16 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <revision rev="2" vrev="2">
-          <srcmd5>fbe8bb742fb36043896666826676c016</srcmd5>
+        <revision rev="4" vrev="4">
+          <srcmd5>3b4a835fa1e497790f82e45048a78427</srcmd5>
           <version>unknown</version>
-          <time>1482164204</time>
+          <time>1503324441</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
     http_version: 
-  recorded_at: Mon, 19 Dec 2016 16:16:44 GMT
+  recorded_at: Mon, 21 Aug 2017 14:07:21 GMT
 - request:
     method: get
     uri: http://localhost:3200/build/home:tom:branches:ProjectWithRepo:Update/_result?code=unresolvable&view=status
@@ -2082,7 +2126,38 @@ http_interactions:
           <result project="home:tom:branches:ProjectWithRepo:Update" repository="repository_2" arch="i586" code="unknown" state="unknown" />
         </resultlist>
     http_version: 
-  recorded_at: Mon, 19 Dec 2016 16:16:44 GMT
+  recorded_at: Mon, 21 Aug 2017 14:07:21 GMT
+- request:
+    method: get
+    uri: http://localhost:3200/source/home:tom:branches:ProjectWithRepo:Update/_keyinfo?donotcreatecert=1&withsslcert=1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '12'
+    body:
+      encoding: UTF-8
+      string: "<keyinfo />\n"
+    http_version: 
+  recorded_at: Mon, 21 Aug 2017 14:07:22 GMT
 - request:
     method: get
     uri: http://localhost:3200/build/home:tom:branches:ProjectWithRepo:Update/_result?view=summary
@@ -2120,7 +2195,7 @@ http_interactions:
           </result>
         </resultlist>
     http_version: 
-  recorded_at: Mon, 19 Dec 2016 16:16:44 GMT
+  recorded_at: Mon, 21 Aug 2017 14:07:22 GMT
 - request:
     method: get
     uri: http://localhost:3200/source/home:tom:branches:ProjectWithRepo:Update/ProjectWithRepo_package
@@ -2150,15 +2225,15 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="ProjectWithRepo_package" rev="2" vrev="2" srcmd5="fbe8bb742fb36043896666826676c016">
-          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" srcmd5="93f9e495c18a6fc43a1efa793a3aa72f" baserev="93f9e495c18a6fc43a1efa793a3aa72f" xsrcmd5="61eac18a9428762e28d6e950c057388e" lsrcmd5="fbe8bb742fb36043896666826676c016" />
-          <entry name="DUMMY_FILE" md5="275876e34cf609db118f3d84b799a790" size="5" mtime="1482164204" />
-          <entry name="_config" md5="822bf2a29d1fd3fb4a6518a86e9dcd2b" size="131" mtime="1482164200" />
-          <entry name="_link" md5="0a82b9fa0797930f466dca66ce9a1137" size="130" mtime="1482164202" />
-          <entry name="somefile.txt" md5="791025267dcc9c8ad8c462c3835a8c2f" size="150" mtime="1482164200" />
+        <directory name="ProjectWithRepo_package" rev="4" vrev="4" srcmd5="3b4a835fa1e497790f82e45048a78427">
+          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" srcmd5="09e82b0920e2079611427fc5ae96b076" baserev="09e82b0920e2079611427fc5ae96b076" xsrcmd5="015a0a0d39a8e944210a9d525dc6ae91" lsrcmd5="3b4a835fa1e497790f82e45048a78427" />
+          <entry name="DUMMY_FILE" md5="275876e34cf609db118f3d84b799a790" size="5" mtime="1503324268" />
+          <entry name="_config" md5="55041d03ef8e31e551b3edd00464f7ea" size="103" mtime="1503324439" />
+          <entry name="_link" md5="6ffab3981d3cd40f46924a3319a54098" size="130" mtime="1503324440" />
+          <entry name="somefile.txt" md5="72a89c51cb636651b1da704fa7b303ee" size="160" mtime="1503324439" />
         </directory>
     http_version: 
-  recorded_at: Mon, 19 Dec 2016 16:16:45 GMT
+  recorded_at: Mon, 21 Aug 2017 14:07:22 GMT
 - request:
     method: get
     uri: http://localhost:3200/source/home:tom:branches:ProjectWithRepo:Update/ProjectWithRepo_package
@@ -2188,15 +2263,15 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="ProjectWithRepo_package" rev="2" vrev="2" srcmd5="fbe8bb742fb36043896666826676c016">
-          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" srcmd5="93f9e495c18a6fc43a1efa793a3aa72f" baserev="93f9e495c18a6fc43a1efa793a3aa72f" xsrcmd5="61eac18a9428762e28d6e950c057388e" lsrcmd5="fbe8bb742fb36043896666826676c016" />
-          <entry name="DUMMY_FILE" md5="275876e34cf609db118f3d84b799a790" size="5" mtime="1482164204" />
-          <entry name="_config" md5="822bf2a29d1fd3fb4a6518a86e9dcd2b" size="131" mtime="1482164200" />
-          <entry name="_link" md5="0a82b9fa0797930f466dca66ce9a1137" size="130" mtime="1482164202" />
-          <entry name="somefile.txt" md5="791025267dcc9c8ad8c462c3835a8c2f" size="150" mtime="1482164200" />
+        <directory name="ProjectWithRepo_package" rev="4" vrev="4" srcmd5="3b4a835fa1e497790f82e45048a78427">
+          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" srcmd5="09e82b0920e2079611427fc5ae96b076" baserev="09e82b0920e2079611427fc5ae96b076" xsrcmd5="015a0a0d39a8e944210a9d525dc6ae91" lsrcmd5="3b4a835fa1e497790f82e45048a78427" />
+          <entry name="DUMMY_FILE" md5="275876e34cf609db118f3d84b799a790" size="5" mtime="1503324268" />
+          <entry name="_config" md5="55041d03ef8e31e551b3edd00464f7ea" size="103" mtime="1503324439" />
+          <entry name="_link" md5="6ffab3981d3cd40f46924a3319a54098" size="130" mtime="1503324440" />
+          <entry name="somefile.txt" md5="72a89c51cb636651b1da704fa7b303ee" size="160" mtime="1503324439" />
         </directory>
     http_version: 
-  recorded_at: Mon, 19 Dec 2016 16:16:45 GMT
+  recorded_at: Mon, 21 Aug 2017 14:07:22 GMT
 - request:
     method: get
     uri: http://localhost:3200/source/home:tom:branches:ProjectWithRepo:Update/ProjectWithRepo_package
@@ -2228,15 +2303,15 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="ProjectWithRepo_package" rev="2" vrev="2" srcmd5="fbe8bb742fb36043896666826676c016">
-          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" srcmd5="93f9e495c18a6fc43a1efa793a3aa72f" baserev="93f9e495c18a6fc43a1efa793a3aa72f" xsrcmd5="61eac18a9428762e28d6e950c057388e" lsrcmd5="fbe8bb742fb36043896666826676c016" />
-          <entry name="DUMMY_FILE" md5="275876e34cf609db118f3d84b799a790" size="5" mtime="1482164204" />
-          <entry name="_config" md5="822bf2a29d1fd3fb4a6518a86e9dcd2b" size="131" mtime="1482164200" />
-          <entry name="_link" md5="0a82b9fa0797930f466dca66ce9a1137" size="130" mtime="1482164202" />
-          <entry name="somefile.txt" md5="791025267dcc9c8ad8c462c3835a8c2f" size="150" mtime="1482164200" />
+        <directory name="ProjectWithRepo_package" rev="4" vrev="4" srcmd5="3b4a835fa1e497790f82e45048a78427">
+          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" srcmd5="09e82b0920e2079611427fc5ae96b076" baserev="09e82b0920e2079611427fc5ae96b076" xsrcmd5="015a0a0d39a8e944210a9d525dc6ae91" lsrcmd5="3b4a835fa1e497790f82e45048a78427" />
+          <entry name="DUMMY_FILE" md5="275876e34cf609db118f3d84b799a790" size="5" mtime="1503324268" />
+          <entry name="_config" md5="55041d03ef8e31e551b3edd00464f7ea" size="103" mtime="1503324439" />
+          <entry name="_link" md5="6ffab3981d3cd40f46924a3319a54098" size="130" mtime="1503324440" />
+          <entry name="somefile.txt" md5="72a89c51cb636651b1da704fa7b303ee" size="160" mtime="1503324439" />
         </directory>
     http_version: 
-  recorded_at: Mon, 19 Dec 2016 16:16:45 GMT
+  recorded_at: Mon, 21 Aug 2017 14:07:23 GMT
 - request:
     method: post
     uri: http://localhost:3200/source/home:tom:branches:ProjectWithRepo:Update/ProjectWithRepo_package?cmd=diff&expand=1&filelimit=10000&opackage=ProjectWithRepo_package&oproject=ProjectWithRepo:Update
@@ -2264,7 +2339,7 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '159'
+      - '161'
     body:
       encoding: UTF-8
       string: |2
@@ -2279,11 +2354,11 @@ http_interactions:
         ++++++ DUMMY_FILE (new)
         --- DUMMY_FILE
         +++ DUMMY_FILE
-        @@ -0,0 +1 @@
+        @@ -0,0 +1,1 @@
         +dummy
         \ No newline at end of file
     http_version: 
-  recorded_at: Mon, 19 Dec 2016 16:16:45 GMT
+  recorded_at: Mon, 21 Aug 2017 14:07:23 GMT
 - request:
     method: get
     uri: http://localhost:3200/source/home:tom:branches:ProjectWithRepo:Update/ProjectWithRepo_package?expand=1
@@ -2313,14 +2388,14 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="ProjectWithRepo_package" rev="61eac18a9428762e28d6e950c057388e" vrev="4" srcmd5="61eac18a9428762e28d6e950c057388e">
-          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" srcmd5="93f9e495c18a6fc43a1efa793a3aa72f" baserev="93f9e495c18a6fc43a1efa793a3aa72f" lsrcmd5="fbe8bb742fb36043896666826676c016" />
-          <entry name="DUMMY_FILE" md5="275876e34cf609db118f3d84b799a790" size="5" mtime="1482164204" />
-          <entry name="_config" md5="822bf2a29d1fd3fb4a6518a86e9dcd2b" size="131" mtime="1482164200" />
-          <entry name="somefile.txt" md5="791025267dcc9c8ad8c462c3835a8c2f" size="150" mtime="1482164200" />
+        <directory name="ProjectWithRepo_package" rev="015a0a0d39a8e944210a9d525dc6ae91" vrev="8" srcmd5="015a0a0d39a8e944210a9d525dc6ae91">
+          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" srcmd5="09e82b0920e2079611427fc5ae96b076" baserev="09e82b0920e2079611427fc5ae96b076" lsrcmd5="3b4a835fa1e497790f82e45048a78427" />
+          <entry name="DUMMY_FILE" md5="275876e34cf609db118f3d84b799a790" size="5" mtime="1503324268" />
+          <entry name="_config" md5="55041d03ef8e31e551b3edd00464f7ea" size="103" mtime="1503324439" />
+          <entry name="somefile.txt" md5="72a89c51cb636651b1da704fa7b303ee" size="160" mtime="1503324439" />
         </directory>
     http_version: 
-  recorded_at: Mon, 19 Dec 2016 16:16:45 GMT
+  recorded_at: Mon, 21 Aug 2017 14:07:23 GMT
 - request:
     method: get
     uri: http://localhost:3200/build/home:tom:branches:ProjectWithRepo:Update/_result?code=unresolvable&view=status
@@ -2356,7 +2431,7 @@ http_interactions:
           <result project="home:tom:branches:ProjectWithRepo:Update" repository="repository_2" arch="i586" code="unknown" state="unknown" />
         </resultlist>
     http_version: 
-  recorded_at: Mon, 19 Dec 2016 16:16:45 GMT
+  recorded_at: Mon, 21 Aug 2017 14:07:23 GMT
 - request:
     method: get
     uri: http://localhost:3200/build/home:tom:branches:ProjectWithRepo:Update/_result?view=summary
@@ -2394,7 +2469,7 @@ http_interactions:
           </result>
         </resultlist>
     http_version: 
-  recorded_at: Mon, 19 Dec 2016 16:16:46 GMT
+  recorded_at: Mon, 21 Aug 2017 14:07:23 GMT
 - request:
     method: get
     uri: http://localhost:3200/build/_workerstatus
@@ -2422,11 +2497,12 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '801'
+      - '927'
     body:
       encoding: UTF-8
       string: |
-        <workerstatus clients="0">
+        <workerstatus clients="1">
+          <idle workerid="worker:1" hostarch="x86_64" />
           <waiting arch="i586" jobs="1" />
           <waiting arch="x86_64" jobs="0" />
           <blocked arch="i586" jobs="0" />
@@ -2434,20 +2510,21 @@ http_interactions:
           <buildavg arch="i586" buildavg="1200" />
           <buildavg arch="x86_64" buildavg="1200" />
           <partition>
-            <daemon type="srcserver" state="running" starttime="1482164153" />
-            <daemon type="service" state="running" starttime="1482164153" />
+            <daemon type="srcserver" state="running" starttime="1503323652" />
+            <daemon type="servicedispatch" state="running" starttime="1503323652" />
+            <daemon type="service" state="running" starttime="1503323652" />
             <daemon type="scheduler" arch="i586" state="dead">
               <queue high="0" med="0" low="3" next="0" />
             </daemon>
             <daemon type="scheduler" arch="x86_64" state="dead">
               <queue high="39" med="0" low="7" next="0" />
             </daemon>
-            <daemon type="repserver" state="running" starttime="1482164153" />
+            <daemon type="repserver" state="running" starttime="1503323652" />
             <daemon type="publisher" state="dead" />
           </partition>
         </workerstatus>
     http_version: 
-  recorded_at: Mon, 19 Dec 2016 16:16:46 GMT
+  recorded_at: Mon, 21 Aug 2017 14:07:23 GMT
 - request:
     method: get
     uri: http://localhost:3200/source/home:tom:branches:ProjectWithRepo:Update/ProjectWithRepo_package
@@ -2479,15 +2556,15 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="ProjectWithRepo_package" rev="2" vrev="2" srcmd5="fbe8bb742fb36043896666826676c016">
-          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" srcmd5="93f9e495c18a6fc43a1efa793a3aa72f" baserev="93f9e495c18a6fc43a1efa793a3aa72f" xsrcmd5="61eac18a9428762e28d6e950c057388e" lsrcmd5="fbe8bb742fb36043896666826676c016" />
-          <entry name="DUMMY_FILE" md5="275876e34cf609db118f3d84b799a790" size="5" mtime="1482164204" />
-          <entry name="_config" md5="822bf2a29d1fd3fb4a6518a86e9dcd2b" size="131" mtime="1482164200" />
-          <entry name="_link" md5="0a82b9fa0797930f466dca66ce9a1137" size="130" mtime="1482164202" />
-          <entry name="somefile.txt" md5="791025267dcc9c8ad8c462c3835a8c2f" size="150" mtime="1482164200" />
+        <directory name="ProjectWithRepo_package" rev="4" vrev="4" srcmd5="3b4a835fa1e497790f82e45048a78427">
+          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" srcmd5="09e82b0920e2079611427fc5ae96b076" baserev="09e82b0920e2079611427fc5ae96b076" xsrcmd5="015a0a0d39a8e944210a9d525dc6ae91" lsrcmd5="3b4a835fa1e497790f82e45048a78427" />
+          <entry name="DUMMY_FILE" md5="275876e34cf609db118f3d84b799a790" size="5" mtime="1503324268" />
+          <entry name="_config" md5="55041d03ef8e31e551b3edd00464f7ea" size="103" mtime="1503324439" />
+          <entry name="_link" md5="6ffab3981d3cd40f46924a3319a54098" size="130" mtime="1503324440" />
+          <entry name="somefile.txt" md5="72a89c51cb636651b1da704fa7b303ee" size="160" mtime="1503324439" />
         </directory>
     http_version: 
-  recorded_at: Mon, 19 Dec 2016 16:16:47 GMT
+  recorded_at: Mon, 21 Aug 2017 14:07:24 GMT
 - request:
     method: post
     uri: http://localhost:3200/source/home:tom:branches:ProjectWithRepo:Update/ProjectWithRepo_package?cmd=diff&expand=1&filelimit=10000&opackage=ProjectWithRepo_package&oproject=ProjectWithRepo:Update&view=xml&withissues=1
@@ -2515,17 +2592,17 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '578'
+      - '580'
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="e14c1d3f0365a80c57580c86c4fdcac4">
-          <old project="ProjectWithRepo:Update" package="ProjectWithRepo_package" rev="2" srcmd5="93f9e495c18a6fc43a1efa793a3aa72f" />
-          <new project="home:tom:branches:ProjectWithRepo:Update" package="ProjectWithRepo_package" rev="2" srcmd5="61eac18a9428762e28d6e950c057388e" />
+        <sourcediff key="d88621a8275d9ad55d7fee27df34b557">
+          <old project="ProjectWithRepo:Update" package="ProjectWithRepo_package" rev="4" srcmd5="09e82b0920e2079611427fc5ae96b076" />
+          <new project="home:tom:branches:ProjectWithRepo:Update" package="ProjectWithRepo_package" rev="4" srcmd5="015a0a0d39a8e944210a9d525dc6ae91" />
           <files>
             <file state="added">
               <new name="DUMMY_FILE" md5="275876e34cf609db118f3d84b799a790" size="5" />
-              <diff lines="3">@@ -0,0 +1 @@
+              <diff lines="3">@@ -0,0 +1,1 @@
         +dummy
         \ No newline at end of file
         </diff>
@@ -2535,7 +2612,7 @@ http_interactions:
           </issues>
         </sourcediff>
     http_version: 
-  recorded_at: Mon, 19 Dec 2016 16:16:47 GMT
+  recorded_at: Mon, 21 Aug 2017 14:07:25 GMT
 - request:
     method: get
     uri: http://localhost:3200/build/home:tom:branches:ProjectWithRepo:Update/_result?package=ProjectWithRepo_package&view=status
@@ -2571,10 +2648,10 @@ http_interactions:
           <result project="home:tom:branches:ProjectWithRepo:Update" repository="repository_2" arch="i586" code="unknown" state="unknown" />
         </resultlist>
     http_version: 
-  recorded_at: Mon, 19 Dec 2016 16:16:48 GMT
+  recorded_at: Mon, 21 Aug 2017 14:07:25 GMT
 - request:
     method: get
-    uri: http://localhost:3200/build/home:tom:branches:ProjectWithRepo:Update/_result?package=ProjectWithRepo_package&view=status
+    uri: http://localhost:3200/build/home:tom:branches:ProjectWithRepo:Update/_result?locallink=1&multibuild=1&package=ProjectWithRepo_package&view=status
     body:
       encoding: US-ASCII
       string: ''
@@ -2607,44 +2684,7 @@ http_interactions:
           <result project="home:tom:branches:ProjectWithRepo:Update" repository="repository_2" arch="i586" code="unknown" state="unknown" />
         </resultlist>
     http_version: 
-  recorded_at: Mon, 19 Dec 2016 16:16:48 GMT
-- request:
-    method: get
-    uri: http://localhost:3200/build/home:tom:branches:ProjectWithRepo:Update/repository_2/i586/ProjectWithRepo_package/rpmlint.log
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Content-Type:
-      - text/plain
-      Accept-Encoding:
-      - identity
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 404
-      message: rpmlint.log  No such file or directory
-    headers:
-      Content-Type:
-      - text/xml
-      Content-Length:
-      - '154'
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-    body:
-      encoding: UTF-8
-      string: |
-        <status code="404">
-          <summary>rpmlint.log: No such file or directory</summary>
-          <details>404 rpmlint.log: No such file or directory</details>
-        </status>
-    http_version: 
-  recorded_at: Mon, 19 Dec 2016 16:16:48 GMT
+  recorded_at: Mon, 21 Aug 2017 14:07:25 GMT
 - request:
     method: get
     uri: http://localhost:3200/source/home:tom:branches:ProjectWithRepo:Update/ProjectWithRepo_package
@@ -2674,15 +2714,15 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="ProjectWithRepo_package" rev="2" vrev="2" srcmd5="fbe8bb742fb36043896666826676c016">
-          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" srcmd5="93f9e495c18a6fc43a1efa793a3aa72f" baserev="93f9e495c18a6fc43a1efa793a3aa72f" xsrcmd5="61eac18a9428762e28d6e950c057388e" lsrcmd5="fbe8bb742fb36043896666826676c016" />
-          <entry name="DUMMY_FILE" md5="275876e34cf609db118f3d84b799a790" size="5" mtime="1482164204" />
-          <entry name="_config" md5="822bf2a29d1fd3fb4a6518a86e9dcd2b" size="131" mtime="1482164200" />
-          <entry name="_link" md5="0a82b9fa0797930f466dca66ce9a1137" size="130" mtime="1482164202" />
-          <entry name="somefile.txt" md5="791025267dcc9c8ad8c462c3835a8c2f" size="150" mtime="1482164200" />
+        <directory name="ProjectWithRepo_package" rev="4" vrev="4" srcmd5="3b4a835fa1e497790f82e45048a78427">
+          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" srcmd5="09e82b0920e2079611427fc5ae96b076" baserev="09e82b0920e2079611427fc5ae96b076" xsrcmd5="015a0a0d39a8e944210a9d525dc6ae91" lsrcmd5="3b4a835fa1e497790f82e45048a78427" />
+          <entry name="DUMMY_FILE" md5="275876e34cf609db118f3d84b799a790" size="5" mtime="1503324268" />
+          <entry name="_config" md5="55041d03ef8e31e551b3edd00464f7ea" size="103" mtime="1503324439" />
+          <entry name="_link" md5="6ffab3981d3cd40f46924a3319a54098" size="130" mtime="1503324440" />
+          <entry name="somefile.txt" md5="72a89c51cb636651b1da704fa7b303ee" size="160" mtime="1503324439" />
         </directory>
     http_version: 
-  recorded_at: Mon, 19 Dec 2016 16:16:48 GMT
+  recorded_at: Mon, 21 Aug 2017 14:07:25 GMT
 - request:
     method: get
     uri: http://localhost:3200/source/home:tom:branches:ProjectWithRepo:Update/ProjectWithRepo_package?expand=1
@@ -2714,14 +2754,14 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="ProjectWithRepo_package" rev="61eac18a9428762e28d6e950c057388e" vrev="4" srcmd5="61eac18a9428762e28d6e950c057388e">
-          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" srcmd5="93f9e495c18a6fc43a1efa793a3aa72f" baserev="93f9e495c18a6fc43a1efa793a3aa72f" lsrcmd5="fbe8bb742fb36043896666826676c016" />
-          <entry name="DUMMY_FILE" md5="275876e34cf609db118f3d84b799a790" size="5" mtime="1482164204" />
-          <entry name="_config" md5="822bf2a29d1fd3fb4a6518a86e9dcd2b" size="131" mtime="1482164200" />
-          <entry name="somefile.txt" md5="791025267dcc9c8ad8c462c3835a8c2f" size="150" mtime="1482164200" />
+        <directory name="ProjectWithRepo_package" rev="015a0a0d39a8e944210a9d525dc6ae91" vrev="8" srcmd5="015a0a0d39a8e944210a9d525dc6ae91">
+          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" srcmd5="09e82b0920e2079611427fc5ae96b076" baserev="09e82b0920e2079611427fc5ae96b076" lsrcmd5="3b4a835fa1e497790f82e45048a78427" />
+          <entry name="DUMMY_FILE" md5="275876e34cf609db118f3d84b799a790" size="5" mtime="1503324268" />
+          <entry name="_config" md5="55041d03ef8e31e551b3edd00464f7ea" size="103" mtime="1503324439" />
+          <entry name="somefile.txt" md5="72a89c51cb636651b1da704fa7b303ee" size="160" mtime="1503324439" />
         </directory>
     http_version: 
-  recorded_at: Mon, 19 Dec 2016 16:16:48 GMT
+  recorded_at: Mon, 21 Aug 2017 14:07:25 GMT
 - request:
     method: get
     uri: http://localhost:3200/source/home:tom:branches:ProjectWithRepo:Update/ProjectWithRepo_package?expand=1
@@ -2751,14 +2791,14 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="ProjectWithRepo_package" rev="61eac18a9428762e28d6e950c057388e" vrev="4" srcmd5="61eac18a9428762e28d6e950c057388e">
-          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" srcmd5="93f9e495c18a6fc43a1efa793a3aa72f" baserev="93f9e495c18a6fc43a1efa793a3aa72f" lsrcmd5="fbe8bb742fb36043896666826676c016" />
-          <entry name="DUMMY_FILE" md5="275876e34cf609db118f3d84b799a790" size="5" mtime="1482164204" />
-          <entry name="_config" md5="822bf2a29d1fd3fb4a6518a86e9dcd2b" size="131" mtime="1482164200" />
-          <entry name="somefile.txt" md5="791025267dcc9c8ad8c462c3835a8c2f" size="150" mtime="1482164200" />
+        <directory name="ProjectWithRepo_package" rev="015a0a0d39a8e944210a9d525dc6ae91" vrev="8" srcmd5="015a0a0d39a8e944210a9d525dc6ae91">
+          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" srcmd5="09e82b0920e2079611427fc5ae96b076" baserev="09e82b0920e2079611427fc5ae96b076" lsrcmd5="3b4a835fa1e497790f82e45048a78427" />
+          <entry name="DUMMY_FILE" md5="275876e34cf609db118f3d84b799a790" size="5" mtime="1503324268" />
+          <entry name="_config" md5="55041d03ef8e31e551b3edd00464f7ea" size="103" mtime="1503324439" />
+          <entry name="somefile.txt" md5="72a89c51cb636651b1da704fa7b303ee" size="160" mtime="1503324439" />
         </directory>
     http_version: 
-  recorded_at: Mon, 19 Dec 2016 16:16:48 GMT
+  recorded_at: Mon, 21 Aug 2017 14:07:25 GMT
 - request:
     method: put
     uri: http://localhost:3200/source/MaintenanceProject:0/_meta?requestid=1&user=maintenance_coord
@@ -2813,7 +2853,7 @@ http_interactions:
           </publish>
         </project>
     http_version: 
-  recorded_at: Mon, 19 Dec 2016 16:16:48 GMT
+  recorded_at: Mon, 21 Aug 2017 14:07:25 GMT
 - request:
     method: get
     uri: http://localhost:3200/source/home:tom:branches:ProjectWithRepo:Update/ProjectWithRepo_package
@@ -2843,15 +2883,15 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="ProjectWithRepo_package" rev="2" vrev="2" srcmd5="fbe8bb742fb36043896666826676c016">
-          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" srcmd5="93f9e495c18a6fc43a1efa793a3aa72f" baserev="93f9e495c18a6fc43a1efa793a3aa72f" xsrcmd5="61eac18a9428762e28d6e950c057388e" lsrcmd5="fbe8bb742fb36043896666826676c016" />
-          <entry name="DUMMY_FILE" md5="275876e34cf609db118f3d84b799a790" size="5" mtime="1482164204" />
-          <entry name="_config" md5="822bf2a29d1fd3fb4a6518a86e9dcd2b" size="131" mtime="1482164200" />
-          <entry name="_link" md5="0a82b9fa0797930f466dca66ce9a1137" size="130" mtime="1482164202" />
-          <entry name="somefile.txt" md5="791025267dcc9c8ad8c462c3835a8c2f" size="150" mtime="1482164200" />
+        <directory name="ProjectWithRepo_package" rev="4" vrev="4" srcmd5="3b4a835fa1e497790f82e45048a78427">
+          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" srcmd5="09e82b0920e2079611427fc5ae96b076" baserev="09e82b0920e2079611427fc5ae96b076" xsrcmd5="015a0a0d39a8e944210a9d525dc6ae91" lsrcmd5="3b4a835fa1e497790f82e45048a78427" />
+          <entry name="DUMMY_FILE" md5="275876e34cf609db118f3d84b799a790" size="5" mtime="1503324268" />
+          <entry name="_config" md5="55041d03ef8e31e551b3edd00464f7ea" size="103" mtime="1503324439" />
+          <entry name="_link" md5="6ffab3981d3cd40f46924a3319a54098" size="130" mtime="1503324440" />
+          <entry name="somefile.txt" md5="72a89c51cb636651b1da704fa7b303ee" size="160" mtime="1503324439" />
         </directory>
     http_version: 
-  recorded_at: Mon, 19 Dec 2016 16:16:48 GMT
+  recorded_at: Mon, 21 Aug 2017 14:07:25 GMT
 - request:
     method: post
     uri: http://localhost:3200/search/package/id?match=(linkinfo/@package=%22ProjectWithRepo_package%22%20and%20linkinfo/@project=%22ProjectWithRepo:Update%22%20and%20starts-with(@project,%22MaintenanceProject:%22))
@@ -2879,14 +2919,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '27'
+      - '126'
     body:
       encoding: UTF-8
       string: |
         <collection>
+          <package name="ProjectWithRepo_package.ProjectWithRepo_Update" project="MaintenanceProject:0" />
         </collection>
     http_version: 
-  recorded_at: Mon, 19 Dec 2016 16:16:49 GMT
+  recorded_at: Mon, 21 Aug 2017 14:07:25 GMT
 - request:
     method: post
     uri: http://localhost:3200/search/package/id?match=(linkinfo/@package=%22ProjectWithRepo_package%22%20and%20linkinfo/@project=%22ProjectWithRepo%22%20and%20@project=%22ProjectWithRepo%22)
@@ -2921,7 +2962,7 @@ http_interactions:
         <collection>
         </collection>
     http_version: 
-  recorded_at: Mon, 19 Dec 2016 16:16:49 GMT
+  recorded_at: Mon, 21 Aug 2017 14:07:25 GMT
 - request:
     method: put
     uri: http://localhost:3200/source/MaintenanceProject:0/ProjectWithRepo_package.ProjectWithRepo_Update/_meta?user=maintenance_coord
@@ -2929,8 +2970,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="ProjectWithRepo_package.ProjectWithRepo_Update" project="MaintenanceProject:0">
-          <title/>
-          <description/>
+          <title>Moab Is My Washpot</title>
+          <description>Eius ut consequuntur nihil.</description>
           <releasename>ProjectWithRepo_package</releasename>
         </package>
     headers:
@@ -2952,17 +2993,17 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '207'
+      - '252'
     body:
       encoding: UTF-8
       string: |
         <package name="ProjectWithRepo_package.ProjectWithRepo_Update" project="MaintenanceProject:0">
-          <title></title>
-          <description></description>
+          <title>Moab Is My Washpot</title>
+          <description>Eius ut consequuntur nihil.</description>
           <releasename>ProjectWithRepo_package</releasename>
         </package>
     http_version: 
-  recorded_at: Mon, 19 Dec 2016 16:16:49 GMT
+  recorded_at: Mon, 21 Aug 2017 14:07:25 GMT
 - request:
     method: post
     uri: http://localhost:3200/source/MaintenanceProject:0/ProjectWithRepo_package.ProjectWithRepo_Update?cmd=branch&opackage=ProjectWithRepo_package&oproject=ProjectWithRepo:Update&user=maintenance_coord
@@ -2994,16 +3035,57 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <revision rev="1" vrev="1">
-          <srcmd5>0053dbbf7ed92619a79c971b291714f6</srcmd5>
+        <revision rev="5" vrev="5">
+          <srcmd5>86a991e1d0fb1e255e605e346b8c71b2</srcmd5>
           <version>unknown</version>
-          <time>1482164209</time>
+          <time>1503324445</time>
           <user>maintenance_coord</user>
           <comment></comment>
           <requestid/>
         </revision>
     http_version: 
-  recorded_at: Mon, 19 Dec 2016 16:16:49 GMT
+  recorded_at: Mon, 21 Aug 2017 14:07:25 GMT
+- request:
+    method: put
+    uri: http://localhost:3200/source/MaintenanceProject:0/ProjectWithRepo_package.ProjectWithRepo_Update/_meta?user=maintenance_coord
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="ProjectWithRepo_package.ProjectWithRepo_Update" project="MaintenanceProject:0">
+          <title>Moab Is My Washpot</title>
+          <description>Eius ut consequuntur nihil.</description>
+          <releasename>ProjectWithRepo_package</releasename>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '252'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="ProjectWithRepo_package.ProjectWithRepo_Update" project="MaintenanceProject:0">
+          <title>Moab Is My Washpot</title>
+          <description>Eius ut consequuntur nihil.</description>
+          <releasename>ProjectWithRepo_package</releasename>
+        </package>
+    http_version: 
+  recorded_at: Mon, 21 Aug 2017 14:07:26 GMT
 - request:
     method: get
     uri: http://localhost:3200/source/MaintenanceProject:0/ProjectWithRepo_package.ProjectWithRepo_Update
@@ -3033,14 +3115,14 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="ProjectWithRepo_package.ProjectWithRepo_Update" rev="1" vrev="1" srcmd5="0053dbbf7ed92619a79c971b291714f6">
-          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" srcmd5="93f9e495c18a6fc43a1efa793a3aa72f" baserev="93f9e495c18a6fc43a1efa793a3aa72f" xsrcmd5="48c3d6c78f0296d44dda7b080229f33e" lsrcmd5="0053dbbf7ed92619a79c971b291714f6" />
-          <entry name="_config" md5="822bf2a29d1fd3fb4a6518a86e9dcd2b" size="131" mtime="1482164200" />
-          <entry name="_link" md5="3df31df42a72a87eda7d83111e64ec3e" size="164" mtime="1482164209" />
-          <entry name="somefile.txt" md5="791025267dcc9c8ad8c462c3835a8c2f" size="150" mtime="1482164200" />
+        <directory name="ProjectWithRepo_package.ProjectWithRepo_Update" rev="5" vrev="5" srcmd5="86a991e1d0fb1e255e605e346b8c71b2">
+          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" srcmd5="09e82b0920e2079611427fc5ae96b076" baserev="09e82b0920e2079611427fc5ae96b076" xsrcmd5="dd8fee4cd9676519d6bc95db70858eac" lsrcmd5="86a991e1d0fb1e255e605e346b8c71b2" />
+          <entry name="_config" md5="55041d03ef8e31e551b3edd00464f7ea" size="103" mtime="1503324439" />
+          <entry name="_link" md5="3f7843b2f03812aa3a4c42dd85f1b177" size="164" mtime="1503324445" />
+          <entry name="somefile.txt" md5="72a89c51cb636651b1da704fa7b303ee" size="160" mtime="1503324439" />
         </directory>
     http_version: 
-  recorded_at: Mon, 19 Dec 2016 16:16:49 GMT
+  recorded_at: Mon, 21 Aug 2017 14:07:26 GMT
 - request:
     method: get
     uri: http://localhost:3200/source/MaintenanceProject:0/ProjectWithRepo_package.ProjectWithRepo_Update?nofilename=1&view=info&withchangesmd5=1
@@ -3070,13 +3152,13 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <sourceinfo package="ProjectWithRepo_package.ProjectWithRepo_Update" rev="1" vrev="3" srcmd5="48c3d6c78f0296d44dda7b080229f33e" lsrcmd5="0053dbbf7ed92619a79c971b291714f6" verifymd5="93f9e495c18a6fc43a1efa793a3aa72f">
+        <sourceinfo package="ProjectWithRepo_package.ProjectWithRepo_Update" rev="5" vrev="9" srcmd5="dd8fee4cd9676519d6bc95db70858eac" lsrcmd5="86a991e1d0fb1e255e605e346b8c71b2" verifymd5="09e82b0920e2079611427fc5ae96b076">
           <linked project="ProjectWithRepo:Update" package="ProjectWithRepo_package" />
           <linked project="ProjectWithRepo" package="ProjectWithRepo_package" />
-          <revtime>1482164209</revtime>
+          <revtime>1503324445</revtime>
         </sourceinfo>
     http_version: 
-  recorded_at: Mon, 19 Dec 2016 16:16:49 GMT
+  recorded_at: Mon, 21 Aug 2017 14:07:26 GMT
 - request:
     method: get
     uri: http://localhost:3200/source/MaintenanceProject:0/ProjectWithRepo_package.ProjectWithRepo_Update
@@ -3106,14 +3188,14 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="ProjectWithRepo_package.ProjectWithRepo_Update" rev="1" vrev="1" srcmd5="0053dbbf7ed92619a79c971b291714f6">
-          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" srcmd5="93f9e495c18a6fc43a1efa793a3aa72f" baserev="93f9e495c18a6fc43a1efa793a3aa72f" xsrcmd5="48c3d6c78f0296d44dda7b080229f33e" lsrcmd5="0053dbbf7ed92619a79c971b291714f6" />
-          <entry name="_config" md5="822bf2a29d1fd3fb4a6518a86e9dcd2b" size="131" mtime="1482164200" />
-          <entry name="_link" md5="3df31df42a72a87eda7d83111e64ec3e" size="164" mtime="1482164209" />
-          <entry name="somefile.txt" md5="791025267dcc9c8ad8c462c3835a8c2f" size="150" mtime="1482164200" />
+        <directory name="ProjectWithRepo_package.ProjectWithRepo_Update" rev="5" vrev="5" srcmd5="86a991e1d0fb1e255e605e346b8c71b2">
+          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" srcmd5="09e82b0920e2079611427fc5ae96b076" baserev="09e82b0920e2079611427fc5ae96b076" xsrcmd5="dd8fee4cd9676519d6bc95db70858eac" lsrcmd5="86a991e1d0fb1e255e605e346b8c71b2" />
+          <entry name="_config" md5="55041d03ef8e31e551b3edd00464f7ea" size="103" mtime="1503324439" />
+          <entry name="_link" md5="3f7843b2f03812aa3a4c42dd85f1b177" size="164" mtime="1503324445" />
+          <entry name="somefile.txt" md5="72a89c51cb636651b1da704fa7b303ee" size="160" mtime="1503324439" />
         </directory>
     http_version: 
-  recorded_at: Mon, 19 Dec 2016 16:16:49 GMT
+  recorded_at: Mon, 21 Aug 2017 14:07:26 GMT
 - request:
     method: post
     uri: http://localhost:3200/source/MaintenanceProject:0/ProjectWithRepo_package.ProjectWithRepo_Update?cmd=diff&linkrev=base&onlyissues=1&orev=0&view=xml
@@ -3145,15 +3227,15 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="62c8e1dae9f723cb831335db09106923">
+        <sourcediff key="00a8f538a8458c1ee8cd1af5b5a9da0b">
           <old project="MaintenanceProject:0" package="ProjectWithRepo_package.ProjectWithRepo_Update" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e" />
-          <new project="MaintenanceProject:0" package="ProjectWithRepo_package.ProjectWithRepo_Update" rev="1" srcmd5="0053dbbf7ed92619a79c971b291714f6" />
+          <new project="MaintenanceProject:0" package="ProjectWithRepo_package.ProjectWithRepo_Update" rev="5" srcmd5="86a991e1d0fb1e255e605e346b8c71b2" />
           <files />
           <issues>
           </issues>
         </sourcediff>
     http_version: 
-  recorded_at: Mon, 19 Dec 2016 16:16:49 GMT
+  recorded_at: Mon, 21 Aug 2017 14:07:26 GMT
 - request:
     method: post
     uri: http://localhost:3200/source/MaintenanceProject:0/ProjectWithRepo_package.ProjectWithRepo_Update?cmd=linkdiff&linkrev=base&onlyissues=1&view=xml
@@ -3185,13 +3267,13 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="5d12888185c489c5f3224f3e2c5b1c26">
-          <old project="ProjectWithRepo:Update" package="ProjectWithRepo_package" rev="93f9e495c18a6fc43a1efa793a3aa72f" srcmd5="93f9e495c18a6fc43a1efa793a3aa72f" />
-          <new project="MaintenanceProject:0" package="ProjectWithRepo_package.ProjectWithRepo_Update" rev="48c3d6c78f0296d44dda7b080229f33e" srcmd5="48c3d6c78f0296d44dda7b080229f33e" />
+        <sourcediff key="c2d0ce4eef4d88842741edf1dd777bce">
+          <old project="ProjectWithRepo:Update" package="ProjectWithRepo_package" rev="09e82b0920e2079611427fc5ae96b076" srcmd5="09e82b0920e2079611427fc5ae96b076" />
+          <new project="MaintenanceProject:0" package="ProjectWithRepo_package.ProjectWithRepo_Update" rev="dd8fee4cd9676519d6bc95db70858eac" srcmd5="dd8fee4cd9676519d6bc95db70858eac" />
           <files />
         </sourcediff>
     http_version: 
-  recorded_at: Mon, 19 Dec 2016 16:16:49 GMT
+  recorded_at: Mon, 21 Aug 2017 14:07:26 GMT
 - request:
     method: put
     uri: http://localhost:3200/source/MaintenanceProject:0/ProjectWithRepo_package.ProjectWithRepo_Update/_meta?user=maintenance_coord
@@ -3199,8 +3281,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="ProjectWithRepo_package.ProjectWithRepo_Update" project="MaintenanceProject:0">
-          <title/>
-          <description/>
+          <title>Moab Is My Washpot</title>
+          <description>Eius ut consequuntur nihil.</description>
           <releasename>ProjectWithRepo_package</releasename>
           <build>
             <enable repository="ProjectWithRepo_Update"/>
@@ -3225,20 +3307,20 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '279'
+      - '324'
     body:
       encoding: UTF-8
       string: |
         <package name="ProjectWithRepo_package.ProjectWithRepo_Update" project="MaintenanceProject:0">
-          <title></title>
-          <description></description>
+          <title>Moab Is My Washpot</title>
+          <description>Eius ut consequuntur nihil.</description>
           <releasename>ProjectWithRepo_package</releasename>
           <build>
             <enable repository="ProjectWithRepo_Update" />
           </build>
         </package>
     http_version: 
-  recorded_at: Mon, 19 Dec 2016 16:16:49 GMT
+  recorded_at: Mon, 21 Aug 2017 14:07:26 GMT
 - request:
     method: get
     uri: http://localhost:3200/source/MaintenanceProject:0/ProjectWithRepo_package.ProjectWithRepo_Update
@@ -3268,14 +3350,14 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="ProjectWithRepo_package.ProjectWithRepo_Update" rev="1" vrev="1" srcmd5="0053dbbf7ed92619a79c971b291714f6">
-          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" srcmd5="93f9e495c18a6fc43a1efa793a3aa72f" baserev="93f9e495c18a6fc43a1efa793a3aa72f" xsrcmd5="48c3d6c78f0296d44dda7b080229f33e" lsrcmd5="0053dbbf7ed92619a79c971b291714f6" />
-          <entry name="_config" md5="822bf2a29d1fd3fb4a6518a86e9dcd2b" size="131" mtime="1482164200" />
-          <entry name="_link" md5="3df31df42a72a87eda7d83111e64ec3e" size="164" mtime="1482164209" />
-          <entry name="somefile.txt" md5="791025267dcc9c8ad8c462c3835a8c2f" size="150" mtime="1482164200" />
+        <directory name="ProjectWithRepo_package.ProjectWithRepo_Update" rev="5" vrev="5" srcmd5="86a991e1d0fb1e255e605e346b8c71b2">
+          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" srcmd5="09e82b0920e2079611427fc5ae96b076" baserev="09e82b0920e2079611427fc5ae96b076" xsrcmd5="dd8fee4cd9676519d6bc95db70858eac" lsrcmd5="86a991e1d0fb1e255e605e346b8c71b2" />
+          <entry name="_config" md5="55041d03ef8e31e551b3edd00464f7ea" size="103" mtime="1503324439" />
+          <entry name="_link" md5="3f7843b2f03812aa3a4c42dd85f1b177" size="164" mtime="1503324445" />
+          <entry name="somefile.txt" md5="72a89c51cb636651b1da704fa7b303ee" size="160" mtime="1503324439" />
         </directory>
     http_version: 
-  recorded_at: Mon, 19 Dec 2016 16:16:49 GMT
+  recorded_at: Mon, 21 Aug 2017 14:07:26 GMT
 - request:
     method: get
     uri: http://localhost:3200/source/MaintenanceProject:0/ProjectWithRepo_package.ProjectWithRepo_Update
@@ -3305,14 +3387,14 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="ProjectWithRepo_package.ProjectWithRepo_Update" rev="1" vrev="1" srcmd5="0053dbbf7ed92619a79c971b291714f6">
-          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" srcmd5="93f9e495c18a6fc43a1efa793a3aa72f" baserev="93f9e495c18a6fc43a1efa793a3aa72f" xsrcmd5="48c3d6c78f0296d44dda7b080229f33e" lsrcmd5="0053dbbf7ed92619a79c971b291714f6" />
-          <entry name="_config" md5="822bf2a29d1fd3fb4a6518a86e9dcd2b" size="131" mtime="1482164200" />
-          <entry name="_link" md5="3df31df42a72a87eda7d83111e64ec3e" size="164" mtime="1482164209" />
-          <entry name="somefile.txt" md5="791025267dcc9c8ad8c462c3835a8c2f" size="150" mtime="1482164200" />
+        <directory name="ProjectWithRepo_package.ProjectWithRepo_Update" rev="5" vrev="5" srcmd5="86a991e1d0fb1e255e605e346b8c71b2">
+          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" srcmd5="09e82b0920e2079611427fc5ae96b076" baserev="09e82b0920e2079611427fc5ae96b076" xsrcmd5="dd8fee4cd9676519d6bc95db70858eac" lsrcmd5="86a991e1d0fb1e255e605e346b8c71b2" />
+          <entry name="_config" md5="55041d03ef8e31e551b3edd00464f7ea" size="103" mtime="1503324439" />
+          <entry name="_link" md5="3f7843b2f03812aa3a4c42dd85f1b177" size="164" mtime="1503324445" />
+          <entry name="somefile.txt" md5="72a89c51cb636651b1da704fa7b303ee" size="160" mtime="1503324439" />
         </directory>
     http_version: 
-  recorded_at: Mon, 19 Dec 2016 16:16:49 GMT
+  recorded_at: Mon, 21 Aug 2017 14:07:26 GMT
 - request:
     method: get
     uri: http://localhost:3200/source/MaintenanceProject:0/ProjectWithRepo_package.ProjectWithRepo_Update
@@ -3342,14 +3424,14 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="ProjectWithRepo_package.ProjectWithRepo_Update" rev="1" vrev="1" srcmd5="0053dbbf7ed92619a79c971b291714f6">
-          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" srcmd5="93f9e495c18a6fc43a1efa793a3aa72f" baserev="93f9e495c18a6fc43a1efa793a3aa72f" xsrcmd5="48c3d6c78f0296d44dda7b080229f33e" lsrcmd5="0053dbbf7ed92619a79c971b291714f6" />
-          <entry name="_config" md5="822bf2a29d1fd3fb4a6518a86e9dcd2b" size="131" mtime="1482164200" />
-          <entry name="_link" md5="3df31df42a72a87eda7d83111e64ec3e" size="164" mtime="1482164209" />
-          <entry name="somefile.txt" md5="791025267dcc9c8ad8c462c3835a8c2f" size="150" mtime="1482164200" />
+        <directory name="ProjectWithRepo_package.ProjectWithRepo_Update" rev="5" vrev="5" srcmd5="86a991e1d0fb1e255e605e346b8c71b2">
+          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" srcmd5="09e82b0920e2079611427fc5ae96b076" baserev="09e82b0920e2079611427fc5ae96b076" xsrcmd5="dd8fee4cd9676519d6bc95db70858eac" lsrcmd5="86a991e1d0fb1e255e605e346b8c71b2" />
+          <entry name="_config" md5="55041d03ef8e31e551b3edd00464f7ea" size="103" mtime="1503324439" />
+          <entry name="_link" md5="3f7843b2f03812aa3a4c42dd85f1b177" size="164" mtime="1503324445" />
+          <entry name="somefile.txt" md5="72a89c51cb636651b1da704fa7b303ee" size="160" mtime="1503324439" />
         </directory>
     http_version: 
-  recorded_at: Mon, 19 Dec 2016 16:16:49 GMT
+  recorded_at: Mon, 21 Aug 2017 14:07:26 GMT
 - request:
     method: post
     uri: http://localhost:3200/search/package/id?match=(linkinfo/@package=%22ProjectWithRepo_package%22%20and%20linkinfo/@project=%22ProjectWithRepo%22%20and%20@project=%22ProjectWithRepo%22)
@@ -3384,7 +3466,7 @@ http_interactions:
         <collection>
         </collection>
     http_version: 
-  recorded_at: Mon, 19 Dec 2016 16:16:49 GMT
+  recorded_at: Mon, 21 Aug 2017 14:07:26 GMT
 - request:
     method: put
     uri: http://localhost:3200/source/MaintenanceProject:0/_meta?user=maintenance_coord
@@ -3449,7 +3531,7 @@ http_interactions:
           </repository>
         </project>
     http_version: 
-  recorded_at: Mon, 19 Dec 2016 16:16:49 GMT
+  recorded_at: Mon, 21 Aug 2017 14:07:26 GMT
 - request:
     method: put
     uri: http://localhost:3200/source/MaintenanceProject:0/_meta?user=maintenance_coord
@@ -3514,7 +3596,7 @@ http_interactions:
           </repository>
         </project>
     http_version: 
-  recorded_at: Mon, 19 Dec 2016 16:16:49 GMT
+  recorded_at: Mon, 21 Aug 2017 14:07:26 GMT
 - request:
     method: post
     uri: http://localhost:3200/source/MaintenanceProject:0/ProjectWithRepo_package.ProjectWithRepo_Update?cmd=copy&comment=Maintenance%20incident%20copy%20from%20project%20home:tom:branches:ProjectWithRepo:Update&expand=1&keeplink=1&opackage=ProjectWithRepo_package&oproject=home:tom:branches:ProjectWithRepo:Update&requestid=1&user=maintenance_coord&withacceptinfo=1
@@ -3546,17 +3628,64 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <revision rev="2" vrev="2">
-          <srcmd5>e7c498767ab7fa6a266e609e36388ce6</srcmd5>
+        <revision rev="6" vrev="6">
+          <srcmd5>8c95ac173db372e4ec3afc73fe679c4a</srcmd5>
           <version>unknown</version>
-          <time>1482164209</time>
+          <time>1503324446</time>
           <user>maintenance_coord</user>
           <comment>Maintenance incident copy from project home:tom:branches:ProjectWithRepo:Update</comment>
           <requestid>1</requestid>
-          <acceptinfo rev="2" srcmd5="e7c498767ab7fa6a266e609e36388ce6" osrcmd5="0053dbbf7ed92619a79c971b291714f6" xsrcmd5="944396236b51ae1a97683a3eceb14d7f" oxsrcmd5="48c3d6c78f0296d44dda7b080229f33e" />
+          <acceptinfo rev="6" srcmd5="8c95ac173db372e4ec3afc73fe679c4a" osrcmd5="86a991e1d0fb1e255e605e346b8c71b2" xsrcmd5="6c2a823ba5d861d74d5c25e6ef62df17" oxsrcmd5="dd8fee4cd9676519d6bc95db70858eac" />
         </revision>
     http_version: 
-  recorded_at: Mon, 19 Dec 2016 16:16:49 GMT
+  recorded_at: Mon, 21 Aug 2017 14:07:26 GMT
+- request:
+    method: put
+    uri: http://localhost:3200/source/MaintenanceProject:0/ProjectWithRepo_package.ProjectWithRepo_Update/_meta?user=maintenance_coord
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="ProjectWithRepo_package.ProjectWithRepo_Update" project="MaintenanceProject:0">
+          <title>Moab Is My Washpot</title>
+          <description>Eius ut consequuntur nihil.</description>
+          <releasename>ProjectWithRepo_package</releasename>
+          <build>
+            <enable repository="ProjectWithRepo_Update"/>
+          </build>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '324'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="ProjectWithRepo_package.ProjectWithRepo_Update" project="MaintenanceProject:0">
+          <title>Moab Is My Washpot</title>
+          <description>Eius ut consequuntur nihil.</description>
+          <releasename>ProjectWithRepo_package</releasename>
+          <build>
+            <enable repository="ProjectWithRepo_Update" />
+          </build>
+        </package>
+    http_version: 
+  recorded_at: Mon, 21 Aug 2017 14:07:26 GMT
 - request:
     method: get
     uri: http://localhost:3200/source/MaintenanceProject:0/ProjectWithRepo_package.ProjectWithRepo_Update
@@ -3586,15 +3715,15 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="ProjectWithRepo_package.ProjectWithRepo_Update" rev="2" vrev="2" srcmd5="e7c498767ab7fa6a266e609e36388ce6">
-          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" srcmd5="93f9e495c18a6fc43a1efa793a3aa72f" baserev="93f9e495c18a6fc43a1efa793a3aa72f" xsrcmd5="944396236b51ae1a97683a3eceb14d7f" lsrcmd5="e7c498767ab7fa6a266e609e36388ce6" />
-          <entry name="DUMMY_FILE" md5="275876e34cf609db118f3d84b799a790" size="5" mtime="1482164204" />
-          <entry name="_config" md5="822bf2a29d1fd3fb4a6518a86e9dcd2b" size="131" mtime="1482164200" />
-          <entry name="_link" md5="3df31df42a72a87eda7d83111e64ec3e" size="164" mtime="1482164209" />
-          <entry name="somefile.txt" md5="791025267dcc9c8ad8c462c3835a8c2f" size="150" mtime="1482164200" />
+        <directory name="ProjectWithRepo_package.ProjectWithRepo_Update" rev="6" vrev="6" srcmd5="8c95ac173db372e4ec3afc73fe679c4a">
+          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" srcmd5="09e82b0920e2079611427fc5ae96b076" baserev="09e82b0920e2079611427fc5ae96b076" xsrcmd5="6c2a823ba5d861d74d5c25e6ef62df17" lsrcmd5="8c95ac173db372e4ec3afc73fe679c4a" />
+          <entry name="DUMMY_FILE" md5="275876e34cf609db118f3d84b799a790" size="5" mtime="1503324268" />
+          <entry name="_config" md5="55041d03ef8e31e551b3edd00464f7ea" size="103" mtime="1503324439" />
+          <entry name="_link" md5="3f7843b2f03812aa3a4c42dd85f1b177" size="164" mtime="1503324445" />
+          <entry name="somefile.txt" md5="72a89c51cb636651b1da704fa7b303ee" size="160" mtime="1503324439" />
         </directory>
     http_version: 
-  recorded_at: Mon, 19 Dec 2016 16:16:49 GMT
+  recorded_at: Mon, 21 Aug 2017 14:07:26 GMT
 - request:
     method: get
     uri: http://localhost:3200/source/MaintenanceProject:0/ProjectWithRepo_package.ProjectWithRepo_Update?nofilename=1&view=info&withchangesmd5=1
@@ -3620,17 +3749,17 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '416'
+      - '417'
     body:
       encoding: UTF-8
       string: |
-        <sourceinfo package="ProjectWithRepo_package.ProjectWithRepo_Update" rev="2" vrev="4" srcmd5="944396236b51ae1a97683a3eceb14d7f" lsrcmd5="e7c498767ab7fa6a266e609e36388ce6" verifymd5="9516aebf6b10ac890d8c2905f7a35185">
+        <sourceinfo package="ProjectWithRepo_package.ProjectWithRepo_Update" rev="6" vrev="10" srcmd5="6c2a823ba5d861d74d5c25e6ef62df17" lsrcmd5="8c95ac173db372e4ec3afc73fe679c4a" verifymd5="20df9d21809f8c811abf5fe64b26d948">
           <linked project="ProjectWithRepo:Update" package="ProjectWithRepo_package" />
           <linked project="ProjectWithRepo" package="ProjectWithRepo_package" />
-          <revtime>1482164209</revtime>
+          <revtime>1503324446</revtime>
         </sourceinfo>
     http_version: 
-  recorded_at: Mon, 19 Dec 2016 16:16:50 GMT
+  recorded_at: Mon, 21 Aug 2017 14:07:26 GMT
 - request:
     method: get
     uri: http://localhost:3200/source/MaintenanceProject:0/ProjectWithRepo_package.ProjectWithRepo_Update
@@ -3660,15 +3789,15 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="ProjectWithRepo_package.ProjectWithRepo_Update" rev="2" vrev="2" srcmd5="e7c498767ab7fa6a266e609e36388ce6">
-          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" srcmd5="93f9e495c18a6fc43a1efa793a3aa72f" baserev="93f9e495c18a6fc43a1efa793a3aa72f" xsrcmd5="944396236b51ae1a97683a3eceb14d7f" lsrcmd5="e7c498767ab7fa6a266e609e36388ce6" />
-          <entry name="DUMMY_FILE" md5="275876e34cf609db118f3d84b799a790" size="5" mtime="1482164204" />
-          <entry name="_config" md5="822bf2a29d1fd3fb4a6518a86e9dcd2b" size="131" mtime="1482164200" />
-          <entry name="_link" md5="3df31df42a72a87eda7d83111e64ec3e" size="164" mtime="1482164209" />
-          <entry name="somefile.txt" md5="791025267dcc9c8ad8c462c3835a8c2f" size="150" mtime="1482164200" />
+        <directory name="ProjectWithRepo_package.ProjectWithRepo_Update" rev="6" vrev="6" srcmd5="8c95ac173db372e4ec3afc73fe679c4a">
+          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" srcmd5="09e82b0920e2079611427fc5ae96b076" baserev="09e82b0920e2079611427fc5ae96b076" xsrcmd5="6c2a823ba5d861d74d5c25e6ef62df17" lsrcmd5="8c95ac173db372e4ec3afc73fe679c4a" />
+          <entry name="DUMMY_FILE" md5="275876e34cf609db118f3d84b799a790" size="5" mtime="1503324268" />
+          <entry name="_config" md5="55041d03ef8e31e551b3edd00464f7ea" size="103" mtime="1503324439" />
+          <entry name="_link" md5="3f7843b2f03812aa3a4c42dd85f1b177" size="164" mtime="1503324445" />
+          <entry name="somefile.txt" md5="72a89c51cb636651b1da704fa7b303ee" size="160" mtime="1503324439" />
         </directory>
     http_version: 
-  recorded_at: Mon, 19 Dec 2016 16:16:50 GMT
+  recorded_at: Mon, 21 Aug 2017 14:07:26 GMT
 - request:
     method: post
     uri: http://localhost:3200/source/MaintenanceProject:0/ProjectWithRepo_package.ProjectWithRepo_Update?cmd=diff&linkrev=base&onlyissues=1&orev=0&view=xml
@@ -3700,15 +3829,15 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="e5cbd42a6dc89f546d979ae6b035355b">
+        <sourcediff key="19494ad5fd9a44aa388f5358268d23f5">
           <old project="MaintenanceProject:0" package="ProjectWithRepo_package.ProjectWithRepo_Update" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e" />
-          <new project="MaintenanceProject:0" package="ProjectWithRepo_package.ProjectWithRepo_Update" rev="2" srcmd5="e7c498767ab7fa6a266e609e36388ce6" />
+          <new project="MaintenanceProject:0" package="ProjectWithRepo_package.ProjectWithRepo_Update" rev="6" srcmd5="8c95ac173db372e4ec3afc73fe679c4a" />
           <files />
           <issues>
           </issues>
         </sourcediff>
     http_version: 
-  recorded_at: Mon, 19 Dec 2016 16:16:50 GMT
+  recorded_at: Mon, 21 Aug 2017 14:07:26 GMT
 - request:
     method: post
     uri: http://localhost:3200/source/MaintenanceProject:0/ProjectWithRepo_package.ProjectWithRepo_Update?cmd=linkdiff&linkrev=base&onlyissues=1&view=xml
@@ -3740,15 +3869,15 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="092e38953ee0bc92c035219689a05d5d">
-          <old project="ProjectWithRepo:Update" package="ProjectWithRepo_package" rev="93f9e495c18a6fc43a1efa793a3aa72f" srcmd5="93f9e495c18a6fc43a1efa793a3aa72f" />
-          <new project="MaintenanceProject:0" package="ProjectWithRepo_package.ProjectWithRepo_Update" rev="944396236b51ae1a97683a3eceb14d7f" srcmd5="944396236b51ae1a97683a3eceb14d7f" />
+        <sourcediff key="ace3a4b15a241d14542026ae3c8365c9">
+          <old project="ProjectWithRepo:Update" package="ProjectWithRepo_package" rev="09e82b0920e2079611427fc5ae96b076" srcmd5="09e82b0920e2079611427fc5ae96b076" />
+          <new project="MaintenanceProject:0" package="ProjectWithRepo_package.ProjectWithRepo_Update" rev="6c2a823ba5d861d74d5c25e6ef62df17" srcmd5="6c2a823ba5d861d74d5c25e6ef62df17" />
           <files />
           <issues>
           </issues>
         </sourcediff>
     http_version: 
-  recorded_at: Mon, 19 Dec 2016 16:16:50 GMT
+  recorded_at: Mon, 21 Aug 2017 14:07:26 GMT
 - request:
     method: put
     uri: http://localhost:3200/source/MaintenanceProject:0/_meta?comment=maintenance_incident%20request%201&requestid=1&user=maintenance_coord
@@ -3813,7 +3942,7 @@ http_interactions:
           </repository>
         </project>
     http_version: 
-  recorded_at: Mon, 19 Dec 2016 16:16:50 GMT
+  recorded_at: Mon, 21 Aug 2017 14:07:26 GMT
 - request:
     method: put
     uri: http://localhost:3200/source/MaintenanceProject:0/patchinfo/_meta?user=maintenance_coord
@@ -3870,12 +3999,12 @@ http_interactions:
           </useforbuild>
         </package>
     http_version: 
-  recorded_at: Mon, 19 Dec 2016 16:16:50 GMT
+  recorded_at: Mon, 21 Aug 2017 14:07:26 GMT
 - request:
     method: put
     uri: http://localhost:3200/source/MaintenanceProject:0/patchinfo/_patchinfo?comment=generated%20by%20request%20id%201%20accept%20call&user=maintenance_coord
     body:
-      encoding: UTF-8
+      encoding: ASCII-8BIT
       string: |-
         <patchinfo incident="0">
           <category>recommended</category>
@@ -3907,16 +4036,73 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <revision rev="1" vrev="1">
+        <revision rev="4" vrev="4">
           <srcmd5>53b684c8c2dbc9672bb230d024c87a14</srcmd5>
           <version>unknown</version>
-          <time>1482164210</time>
+          <time>1503324446</time>
           <user>maintenance_coord</user>
           <comment>generated by request id 1 accept call</comment>
           <requestid/>
         </revision>
     http_version: 
-  recorded_at: Mon, 19 Dec 2016 16:16:50 GMT
+  recorded_at: Mon, 21 Aug 2017 14:07:26 GMT
+- request:
+    method: put
+    uri: http://localhost:3200/source/MaintenanceProject:0/patchinfo/_meta?user=maintenance_coord
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="patchinfo" project="MaintenanceProject:0">
+          <title>Patchinfo</title>
+          <description>Collected packages for update</description>
+          <build>
+            <enable/>
+          </build>
+          <publish>
+            <enable/>
+          </publish>
+          <useforbuild>
+            <disable/>
+          </useforbuild>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '280'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="patchinfo" project="MaintenanceProject:0">
+          <title>Patchinfo</title>
+          <description>Collected packages for update</description>
+          <build>
+            <enable />
+          </build>
+          <publish>
+            <enable />
+          </publish>
+          <useforbuild>
+            <disable />
+          </useforbuild>
+        </package>
+    http_version: 
+  recorded_at: Mon, 21 Aug 2017 14:07:26 GMT
 - request:
     method: get
     uri: http://localhost:3200/source/MaintenanceProject:0/patchinfo
@@ -3946,11 +4132,11 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="patchinfo" rev="1" vrev="1" srcmd5="53b684c8c2dbc9672bb230d024c87a14">
-          <entry name="_patchinfo" md5="34e0b04fccfd75faea0577efe7cd9ead" size="208" mtime="1482164210" />
+        <directory name="patchinfo" rev="4" vrev="4" srcmd5="53b684c8c2dbc9672bb230d024c87a14">
+          <entry name="_patchinfo" md5="34e0b04fccfd75faea0577efe7cd9ead" size="208" mtime="1503324275" />
         </directory>
     http_version: 
-  recorded_at: Mon, 19 Dec 2016 16:16:50 GMT
+  recorded_at: Mon, 21 Aug 2017 14:07:26 GMT
 - request:
     method: get
     uri: http://localhost:3200/source/MaintenanceProject:0/patchinfo?nofilename=1&view=info&withchangesmd5=1
@@ -3980,11 +4166,11 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <sourceinfo package="patchinfo" rev="1" vrev="1" srcmd5="53b684c8c2dbc9672bb230d024c87a14" verifymd5="53b684c8c2dbc9672bb230d024c87a14">
-          <revtime>1482164210</revtime>
+        <sourceinfo package="patchinfo" rev="4" vrev="4" srcmd5="53b684c8c2dbc9672bb230d024c87a14" verifymd5="53b684c8c2dbc9672bb230d024c87a14">
+          <revtime>1503324446</revtime>
         </sourceinfo>
     http_version: 
-  recorded_at: Mon, 19 Dec 2016 16:16:50 GMT
+  recorded_at: Mon, 21 Aug 2017 14:07:26 GMT
 - request:
     method: get
     uri: http://localhost:3200/source/MaintenanceProject:0/patchinfo
@@ -4014,11 +4200,11 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="patchinfo" rev="1" vrev="1" srcmd5="53b684c8c2dbc9672bb230d024c87a14">
-          <entry name="_patchinfo" md5="34e0b04fccfd75faea0577efe7cd9ead" size="208" mtime="1482164210" />
+        <directory name="patchinfo" rev="4" vrev="4" srcmd5="53b684c8c2dbc9672bb230d024c87a14">
+          <entry name="_patchinfo" md5="34e0b04fccfd75faea0577efe7cd9ead" size="208" mtime="1503324275" />
         </directory>
     http_version: 
-  recorded_at: Mon, 19 Dec 2016 16:16:50 GMT
+  recorded_at: Mon, 21 Aug 2017 14:07:26 GMT
 - request:
     method: get
     uri: http://localhost:3200/source/MaintenanceProject:0/patchinfo/_patchinfo
@@ -4056,10 +4242,10 @@ http_interactions:
           <description>I want the update</description>
         </patchinfo>
     http_version: 
-  recorded_at: Mon, 19 Dec 2016 16:16:50 GMT
+  recorded_at: Mon, 21 Aug 2017 14:07:26 GMT
 - request:
     method: post
-    uri: http://localhost:3200/source/MaintenanceProject:0/ProjectWithRepo_package.ProjectWithRepo_Update?cmd=diff&orev=48c3d6c78f0296d44dda7b080229f33e&rev=944396236b51ae1a97683a3eceb14d7f&view=xml&withissues=1
+    uri: http://localhost:3200/source/MaintenanceProject:0/ProjectWithRepo_package.ProjectWithRepo_Update?cmd=diff&orev=dd8fee4cd9676519d6bc95db70858eac&rev=6c2a823ba5d861d74d5c25e6ef62df17&view=xml&withissues=1
     body:
       encoding: UTF-8
       string: ''
@@ -4084,17 +4270,17 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '664'
+      - '666'
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="66060ac80e33a39fe7d10c079abc4ce2">
-          <old project="MaintenanceProject:0" package="ProjectWithRepo_package.ProjectWithRepo_Update" rev="48c3d6c78f0296d44dda7b080229f33e" srcmd5="48c3d6c78f0296d44dda7b080229f33e" />
-          <new project="MaintenanceProject:0" package="ProjectWithRepo_package.ProjectWithRepo_Update" rev="944396236b51ae1a97683a3eceb14d7f" srcmd5="944396236b51ae1a97683a3eceb14d7f" />
+        <sourcediff key="42b22c4ac987fc87d14e33de37bd0f10">
+          <old project="MaintenanceProject:0" package="ProjectWithRepo_package.ProjectWithRepo_Update" rev="dd8fee4cd9676519d6bc95db70858eac" srcmd5="dd8fee4cd9676519d6bc95db70858eac" />
+          <new project="MaintenanceProject:0" package="ProjectWithRepo_package.ProjectWithRepo_Update" rev="6c2a823ba5d861d74d5c25e6ef62df17" srcmd5="6c2a823ba5d861d74d5c25e6ef62df17" />
           <files>
             <file state="added">
               <new name="DUMMY_FILE" md5="275876e34cf609db118f3d84b799a790" size="5" />
-              <diff lines="3">@@ -0,0 +1 @@
+              <diff lines="3">@@ -0,0 +1,1 @@
         +dummy
         \ No newline at end of file
         </diff>
@@ -4104,7 +4290,7 @@ http_interactions:
           </issues>
         </sourcediff>
     http_version: 
-  recorded_at: Mon, 19 Dec 2016 16:16:50 GMT
+  recorded_at: Mon, 21 Aug 2017 14:07:27 GMT
 - request:
     method: get
     uri: http://localhost:3200/build/home:tom:branches:ProjectWithRepo:Update/_result?package=ProjectWithRepo_package&view=status
@@ -4140,10 +4326,10 @@ http_interactions:
           <result project="home:tom:branches:ProjectWithRepo:Update" repository="repository_2" arch="i586" code="unknown" state="unknown" />
         </resultlist>
     http_version: 
-  recorded_at: Mon, 19 Dec 2016 16:16:50 GMT
+  recorded_at: Mon, 21 Aug 2017 14:07:27 GMT
 - request:
     method: get
-    uri: http://localhost:3200/build/home:tom:branches:ProjectWithRepo:Update/_result?package=ProjectWithRepo_package&view=status
+    uri: http://localhost:3200/build/home:tom:branches:ProjectWithRepo:Update/_result?locallink=1&multibuild=1&package=ProjectWithRepo_package&view=status
     body:
       encoding: US-ASCII
       string: ''
@@ -4176,44 +4362,7 @@ http_interactions:
           <result project="home:tom:branches:ProjectWithRepo:Update" repository="repository_2" arch="i586" code="unknown" state="unknown" />
         </resultlist>
     http_version: 
-  recorded_at: Mon, 19 Dec 2016 16:16:50 GMT
-- request:
-    method: get
-    uri: http://localhost:3200/build/home:tom:branches:ProjectWithRepo:Update/repository_2/i586/ProjectWithRepo_package/rpmlint.log
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Content-Type:
-      - text/plain
-      Accept-Encoding:
-      - identity
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 404
-      message: rpmlint.log  No such file or directory
-    headers:
-      Content-Type:
-      - text/xml
-      Content-Length:
-      - '154'
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-    body:
-      encoding: UTF-8
-      string: |
-        <status code="404">
-          <summary>rpmlint.log: No such file or directory</summary>
-          <details>404 rpmlint.log: No such file or directory</details>
-        </status>
-    http_version: 
-  recorded_at: Mon, 19 Dec 2016 16:16:51 GMT
+  recorded_at: Mon, 21 Aug 2017 14:07:27 GMT
 - request:
     method: get
     uri: http://localhost:3200/build/MaintenanceProject:0/_result?view=binarylist
@@ -4249,7 +4398,7 @@ http_interactions:
           <result project="MaintenanceProject:0" repository="ProjectWithRepo_Update" arch="i586" code="unknown" state="unknown" />
         </resultlist>
     http_version: 
-  recorded_at: Mon, 19 Dec 2016 16:16:51 GMT
+  recorded_at: Mon, 21 Aug 2017 14:07:27 GMT
 - request:
     method: get
     uri: http://localhost:3200/source/MaintenanceProject:0/patchinfo/_patchinfo
@@ -4287,7 +4436,7 @@ http_interactions:
           <description>I want the update</description>
         </patchinfo>
     http_version: 
-  recorded_at: Mon, 19 Dec 2016 16:16:51 GMT
+  recorded_at: Mon, 21 Aug 2017 14:07:27 GMT
 - request:
     method: get
     uri: http://localhost:3200/source/MaintenanceProject:0/patchinfo/_patchinfo
@@ -4325,7 +4474,7 @@ http_interactions:
           <description>I want the update</description>
         </patchinfo>
     http_version: 
-  recorded_at: Mon, 19 Dec 2016 16:16:51 GMT
+  recorded_at: Mon, 21 Aug 2017 14:07:27 GMT
 - request:
     method: get
     uri: http://localhost:3200/build/MaintenanceProject:0/_result?view=binarylist
@@ -4361,7 +4510,7 @@ http_interactions:
           <result project="MaintenanceProject:0" repository="ProjectWithRepo_Update" arch="i586" code="unknown" state="unknown" />
         </resultlist>
     http_version: 
-  recorded_at: Mon, 19 Dec 2016 16:16:51 GMT
+  recorded_at: Mon, 21 Aug 2017 14:07:28 GMT
 - request:
     method: get
     uri: http://localhost:3200/source/MaintenanceProject:0/patchinfo/_patchinfo
@@ -4399,7 +4548,7 @@ http_interactions:
           <description>I want the update</description>
         </patchinfo>
     http_version: 
-  recorded_at: Mon, 19 Dec 2016 16:16:52 GMT
+  recorded_at: Mon, 21 Aug 2017 14:07:28 GMT
 - request:
     method: get
     uri: http://localhost:3200/source/MaintenanceProject:0/patchinfo/_patchinfo
@@ -4437,7 +4586,7 @@ http_interactions:
           <description>I want the update</description>
         </patchinfo>
     http_version: 
-  recorded_at: Mon, 19 Dec 2016 16:16:52 GMT
+  recorded_at: Mon, 21 Aug 2017 14:07:28 GMT
 - request:
     method: put
     uri: http://localhost:3200/source/MaintenanceProject:0/patchinfo/_patchinfo?user=maintenance_coord
@@ -4475,16 +4624,73 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <revision rev="2" vrev="2">
+        <revision rev="5" vrev="5">
           <srcmd5>d07dfcdc0bb71ab61e7d0c85c4a68c71</srcmd5>
           <version>unknown</version>
-          <time>1482164212</time>
+          <time>1503324448</time>
           <user>maintenance_coord</user>
           <comment></comment>
           <requestid/>
         </revision>
     http_version: 
-  recorded_at: Mon, 19 Dec 2016 16:16:52 GMT
+  recorded_at: Mon, 21 Aug 2017 14:07:28 GMT
+- request:
+    method: put
+    uri: http://localhost:3200/source/MaintenanceProject:0/patchinfo/_meta?user=maintenance_coord
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="patchinfo" project="MaintenanceProject:0">
+          <title>Patchinfo</title>
+          <description>Collected packages for update</description>
+          <build>
+            <enable/>
+          </build>
+          <publish>
+            <enable/>
+          </publish>
+          <useforbuild>
+            <disable/>
+          </useforbuild>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '280'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="patchinfo" project="MaintenanceProject:0">
+          <title>Patchinfo</title>
+          <description>Collected packages for update</description>
+          <build>
+            <enable />
+          </build>
+          <publish>
+            <enable />
+          </publish>
+          <useforbuild>
+            <disable />
+          </useforbuild>
+        </package>
+    http_version: 
+  recorded_at: Mon, 21 Aug 2017 14:07:28 GMT
 - request:
     method: get
     uri: http://localhost:3200/source/MaintenanceProject:0/patchinfo
@@ -4514,11 +4720,11 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="patchinfo" rev="2" vrev="2" srcmd5="d07dfcdc0bb71ab61e7d0c85c4a68c71">
-          <entry name="_patchinfo" md5="7fd692cf9ae54961b5c5a22aa13e29c0" size="347" mtime="1482164212" />
+        <directory name="patchinfo" rev="5" vrev="5" srcmd5="d07dfcdc0bb71ab61e7d0c85c4a68c71">
+          <entry name="_patchinfo" md5="7fd692cf9ae54961b5c5a22aa13e29c0" size="347" mtime="1503324276" />
         </directory>
     http_version: 
-  recorded_at: Mon, 19 Dec 2016 16:16:52 GMT
+  recorded_at: Mon, 21 Aug 2017 14:07:28 GMT
 - request:
     method: get
     uri: http://localhost:3200/source/MaintenanceProject:0/patchinfo?nofilename=1&view=info&withchangesmd5=1
@@ -4548,11 +4754,11 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <sourceinfo package="patchinfo" rev="2" vrev="2" srcmd5="d07dfcdc0bb71ab61e7d0c85c4a68c71" verifymd5="d07dfcdc0bb71ab61e7d0c85c4a68c71">
-          <revtime>1482164212</revtime>
+        <sourceinfo package="patchinfo" rev="5" vrev="5" srcmd5="d07dfcdc0bb71ab61e7d0c85c4a68c71" verifymd5="d07dfcdc0bb71ab61e7d0c85c4a68c71">
+          <revtime>1503324448</revtime>
         </sourceinfo>
     http_version: 
-  recorded_at: Mon, 19 Dec 2016 16:16:52 GMT
+  recorded_at: Mon, 21 Aug 2017 14:07:28 GMT
 - request:
     method: get
     uri: http://localhost:3200/source/MaintenanceProject:0/patchinfo
@@ -4582,11 +4788,11 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="patchinfo" rev="2" vrev="2" srcmd5="d07dfcdc0bb71ab61e7d0c85c4a68c71">
-          <entry name="_patchinfo" md5="7fd692cf9ae54961b5c5a22aa13e29c0" size="347" mtime="1482164212" />
+        <directory name="patchinfo" rev="5" vrev="5" srcmd5="d07dfcdc0bb71ab61e7d0c85c4a68c71">
+          <entry name="_patchinfo" md5="7fd692cf9ae54961b5c5a22aa13e29c0" size="347" mtime="1503324276" />
         </directory>
     http_version: 
-  recorded_at: Mon, 19 Dec 2016 16:16:52 GMT
+  recorded_at: Mon, 21 Aug 2017 14:07:28 GMT
 - request:
     method: get
     uri: http://localhost:3200/source/MaintenanceProject:0/patchinfo/_patchinfo
@@ -4625,7 +4831,7 @@ http_interactions:
           <stopped>locked!</stopped>
         </patchinfo>
     http_version: 
-  recorded_at: Mon, 19 Dec 2016 16:16:52 GMT
+  recorded_at: Mon, 21 Aug 2017 14:07:28 GMT
 - request:
     method: get
     uri: http://localhost:3200/source/MaintenanceProject:0/patchinfo/_patchinfo
@@ -4664,7 +4870,7 @@ http_interactions:
           <stopped>locked!</stopped>
         </patchinfo>
     http_version: 
-  recorded_at: Mon, 19 Dec 2016 16:16:52 GMT
+  recorded_at: Mon, 21 Aug 2017 14:07:28 GMT
 - request:
     method: get
     uri: http://localhost:3200/source/MaintenanceProject:0/patchinfo/_patchinfo
@@ -4703,7 +4909,7 @@ http_interactions:
           <stopped>locked!</stopped>
         </patchinfo>
     http_version: 
-  recorded_at: Mon, 19 Dec 2016 16:16:52 GMT
+  recorded_at: Mon, 21 Aug 2017 14:07:28 GMT
 - request:
     method: get
     uri: http://localhost:3200/build/MaintenanceProject:0/_result?view=binarylist
@@ -4739,7 +4945,7 @@ http_interactions:
           <result project="MaintenanceProject:0" repository="ProjectWithRepo_Update" arch="i586" code="unknown" state="unknown" />
         </resultlist>
     http_version: 
-  recorded_at: Mon, 19 Dec 2016 16:16:52 GMT
+  recorded_at: Mon, 21 Aug 2017 14:07:28 GMT
 - request:
     method: get
     uri: http://localhost:3200/source/MaintenanceProject:0/patchinfo/_patchinfo
@@ -4778,7 +4984,7 @@ http_interactions:
           <stopped>locked!</stopped>
         </patchinfo>
     http_version: 
-  recorded_at: Mon, 19 Dec 2016 16:16:52 GMT
+  recorded_at: Mon, 21 Aug 2017 14:07:28 GMT
 - request:
     method: get
     uri: http://localhost:3200/source/MaintenanceProject:0/patchinfo/_patchinfo
@@ -4817,7 +5023,7 @@ http_interactions:
           <stopped>locked!</stopped>
         </patchinfo>
     http_version: 
-  recorded_at: Mon, 19 Dec 2016 16:16:52 GMT
+  recorded_at: Mon, 21 Aug 2017 14:07:28 GMT
 - request:
     method: get
     uri: http://localhost:3200/build/MaintenanceProject:0/_result?view=binarylist
@@ -4853,7 +5059,7 @@ http_interactions:
           <result project="MaintenanceProject:0" repository="ProjectWithRepo_Update" arch="i586" code="unknown" state="unknown" />
         </resultlist>
     http_version: 
-  recorded_at: Mon, 19 Dec 2016 16:16:53 GMT
+  recorded_at: Mon, 21 Aug 2017 14:07:28 GMT
 - request:
     method: get
     uri: http://localhost:3200/source/MaintenanceProject:0/patchinfo/_patchinfo
@@ -4892,7 +5098,7 @@ http_interactions:
           <stopped>locked!</stopped>
         </patchinfo>
     http_version: 
-  recorded_at: Mon, 19 Dec 2016 16:16:53 GMT
+  recorded_at: Mon, 21 Aug 2017 14:07:28 GMT
 - request:
     method: get
     uri: http://localhost:3200/source/MaintenanceProject:0/patchinfo/_patchinfo
@@ -4931,7 +5137,7 @@ http_interactions:
           <stopped>locked!</stopped>
         </patchinfo>
     http_version: 
-  recorded_at: Mon, 19 Dec 2016 16:16:53 GMT
+  recorded_at: Mon, 21 Aug 2017 14:07:28 GMT
 - request:
     method: put
     uri: http://localhost:3200/source/MaintenanceProject:0/patchinfo/_patchinfo?user=maintenance_coord
@@ -4968,16 +5174,73 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <revision rev="3" vrev="3">
+        <revision rev="6" vrev="6">
           <srcmd5>177d57906eba63ae56a64a367592144a</srcmd5>
           <version>unknown</version>
-          <time>1482164213</time>
+          <time>1503324448</time>
           <user>maintenance_coord</user>
           <comment></comment>
           <requestid/>
         </revision>
     http_version: 
-  recorded_at: Mon, 19 Dec 2016 16:16:53 GMT
+  recorded_at: Mon, 21 Aug 2017 14:07:28 GMT
+- request:
+    method: put
+    uri: http://localhost:3200/source/MaintenanceProject:0/patchinfo/_meta?user=maintenance_coord
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="patchinfo" project="MaintenanceProject:0">
+          <title>Patchinfo</title>
+          <description>Collected packages for update</description>
+          <build>
+            <enable/>
+          </build>
+          <publish>
+            <enable/>
+          </publish>
+          <useforbuild>
+            <disable/>
+          </useforbuild>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '280'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="patchinfo" project="MaintenanceProject:0">
+          <title>Patchinfo</title>
+          <description>Collected packages for update</description>
+          <build>
+            <enable />
+          </build>
+          <publish>
+            <enable />
+          </publish>
+          <useforbuild>
+            <disable />
+          </useforbuild>
+        </package>
+    http_version: 
+  recorded_at: Mon, 21 Aug 2017 14:07:28 GMT
 - request:
     method: get
     uri: http://localhost:3200/source/MaintenanceProject:0/patchinfo
@@ -5007,11 +5270,11 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="patchinfo" rev="3" vrev="3" srcmd5="177d57906eba63ae56a64a367592144a">
-          <entry name="_patchinfo" md5="ac29f7f1abd9ef43afeb43fc7737c007" size="318" mtime="1482164213" />
+        <directory name="patchinfo" rev="6" vrev="6" srcmd5="177d57906eba63ae56a64a367592144a">
+          <entry name="_patchinfo" md5="ac29f7f1abd9ef43afeb43fc7737c007" size="318" mtime="1503324277" />
         </directory>
     http_version: 
-  recorded_at: Mon, 19 Dec 2016 16:16:53 GMT
+  recorded_at: Mon, 21 Aug 2017 14:07:28 GMT
 - request:
     method: get
     uri: http://localhost:3200/source/MaintenanceProject:0/patchinfo?nofilename=1&view=info&withchangesmd5=1
@@ -5041,11 +5304,11 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <sourceinfo package="patchinfo" rev="3" vrev="3" srcmd5="177d57906eba63ae56a64a367592144a" verifymd5="177d57906eba63ae56a64a367592144a">
-          <revtime>1482164213</revtime>
+        <sourceinfo package="patchinfo" rev="6" vrev="6" srcmd5="177d57906eba63ae56a64a367592144a" verifymd5="177d57906eba63ae56a64a367592144a">
+          <revtime>1503324448</revtime>
         </sourceinfo>
     http_version: 
-  recorded_at: Mon, 19 Dec 2016 16:16:53 GMT
+  recorded_at: Mon, 21 Aug 2017 14:07:28 GMT
 - request:
     method: get
     uri: http://localhost:3200/source/MaintenanceProject:0/patchinfo
@@ -5075,11 +5338,11 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="patchinfo" rev="3" vrev="3" srcmd5="177d57906eba63ae56a64a367592144a">
-          <entry name="_patchinfo" md5="ac29f7f1abd9ef43afeb43fc7737c007" size="318" mtime="1482164213" />
+        <directory name="patchinfo" rev="6" vrev="6" srcmd5="177d57906eba63ae56a64a367592144a">
+          <entry name="_patchinfo" md5="ac29f7f1abd9ef43afeb43fc7737c007" size="318" mtime="1503324277" />
         </directory>
     http_version: 
-  recorded_at: Mon, 19 Dec 2016 16:16:53 GMT
+  recorded_at: Mon, 21 Aug 2017 14:07:28 GMT
 - request:
     method: get
     uri: http://localhost:3200/source/MaintenanceProject:0/patchinfo/_patchinfo
@@ -5117,7 +5380,7 @@ http_interactions:
           <description>Fixes nothing, Fixes nothing, Fixes nothing, Fixes nothing, Fixes nothing, Fixes nothing</description>
         </patchinfo>
     http_version: 
-  recorded_at: Mon, 19 Dec 2016 16:16:53 GMT
+  recorded_at: Mon, 21 Aug 2017 14:07:28 GMT
 - request:
     method: get
     uri: http://localhost:3200/source/MaintenanceProject:0/patchinfo/_patchinfo
@@ -5155,7 +5418,7 @@ http_interactions:
           <description>Fixes nothing, Fixes nothing, Fixes nothing, Fixes nothing, Fixes nothing, Fixes nothing</description>
         </patchinfo>
     http_version: 
-  recorded_at: Mon, 19 Dec 2016 16:16:53 GMT
+  recorded_at: Mon, 21 Aug 2017 14:07:29 GMT
 - request:
     method: get
     uri: http://localhost:3200/source/MaintenanceProject:0/patchinfo/_patchinfo
@@ -5193,7 +5456,7 @@ http_interactions:
           <description>Fixes nothing, Fixes nothing, Fixes nothing, Fixes nothing, Fixes nothing, Fixes nothing</description>
         </patchinfo>
     http_version: 
-  recorded_at: Mon, 19 Dec 2016 16:16:53 GMT
+  recorded_at: Mon, 21 Aug 2017 14:07:29 GMT
 - request:
     method: get
     uri: http://localhost:3200/build/home:tom:branches:ProjectWithRepo:Update/_result?code=unresolvable&view=status
@@ -5229,7 +5492,7 @@ http_interactions:
           <result project="home:tom:branches:ProjectWithRepo:Update" repository="repository_2" arch="i586" code="unknown" state="unknown" />
         </resultlist>
     http_version: 
-  recorded_at: Mon, 19 Dec 2016 16:16:54 GMT
+  recorded_at: Mon, 21 Aug 2017 14:07:30 GMT
 - request:
     method: get
     uri: http://localhost:3200/build/home:tom:branches:ProjectWithRepo:Update/_result?view=summary
@@ -5267,7 +5530,7 @@ http_interactions:
           </result>
         </resultlist>
     http_version: 
-  recorded_at: Mon, 19 Dec 2016 16:16:54 GMT
+  recorded_at: Mon, 21 Aug 2017 14:07:30 GMT
 - request:
     method: get
     uri: http://localhost:3200/source/home:tom:branches:ProjectWithRepo:Update/ProjectWithRepo_package
@@ -5297,15 +5560,15 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="ProjectWithRepo_package" rev="2" vrev="2" srcmd5="fbe8bb742fb36043896666826676c016">
-          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" srcmd5="93f9e495c18a6fc43a1efa793a3aa72f" baserev="93f9e495c18a6fc43a1efa793a3aa72f" xsrcmd5="61eac18a9428762e28d6e950c057388e" lsrcmd5="fbe8bb742fb36043896666826676c016" />
-          <entry name="DUMMY_FILE" md5="275876e34cf609db118f3d84b799a790" size="5" mtime="1482164204" />
-          <entry name="_config" md5="822bf2a29d1fd3fb4a6518a86e9dcd2b" size="131" mtime="1482164200" />
-          <entry name="_link" md5="0a82b9fa0797930f466dca66ce9a1137" size="130" mtime="1482164202" />
-          <entry name="somefile.txt" md5="791025267dcc9c8ad8c462c3835a8c2f" size="150" mtime="1482164200" />
+        <directory name="ProjectWithRepo_package" rev="4" vrev="4" srcmd5="3b4a835fa1e497790f82e45048a78427">
+          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" srcmd5="09e82b0920e2079611427fc5ae96b076" baserev="09e82b0920e2079611427fc5ae96b076" xsrcmd5="015a0a0d39a8e944210a9d525dc6ae91" lsrcmd5="3b4a835fa1e497790f82e45048a78427" />
+          <entry name="DUMMY_FILE" md5="275876e34cf609db118f3d84b799a790" size="5" mtime="1503324268" />
+          <entry name="_config" md5="55041d03ef8e31e551b3edd00464f7ea" size="103" mtime="1503324439" />
+          <entry name="_link" md5="6ffab3981d3cd40f46924a3319a54098" size="130" mtime="1503324440" />
+          <entry name="somefile.txt" md5="72a89c51cb636651b1da704fa7b303ee" size="160" mtime="1503324439" />
         </directory>
     http_version: 
-  recorded_at: Mon, 19 Dec 2016 16:16:55 GMT
+  recorded_at: Mon, 21 Aug 2017 14:07:30 GMT
 - request:
     method: get
     uri: http://localhost:3200/source/home:tom:branches:ProjectWithRepo:Update/ProjectWithRepo_package
@@ -5335,15 +5598,15 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="ProjectWithRepo_package" rev="2" vrev="2" srcmd5="fbe8bb742fb36043896666826676c016">
-          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" srcmd5="93f9e495c18a6fc43a1efa793a3aa72f" baserev="93f9e495c18a6fc43a1efa793a3aa72f" xsrcmd5="61eac18a9428762e28d6e950c057388e" lsrcmd5="fbe8bb742fb36043896666826676c016" />
-          <entry name="DUMMY_FILE" md5="275876e34cf609db118f3d84b799a790" size="5" mtime="1482164204" />
-          <entry name="_config" md5="822bf2a29d1fd3fb4a6518a86e9dcd2b" size="131" mtime="1482164200" />
-          <entry name="_link" md5="0a82b9fa0797930f466dca66ce9a1137" size="130" mtime="1482164202" />
-          <entry name="somefile.txt" md5="791025267dcc9c8ad8c462c3835a8c2f" size="150" mtime="1482164200" />
+        <directory name="ProjectWithRepo_package" rev="4" vrev="4" srcmd5="3b4a835fa1e497790f82e45048a78427">
+          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" srcmd5="09e82b0920e2079611427fc5ae96b076" baserev="09e82b0920e2079611427fc5ae96b076" xsrcmd5="015a0a0d39a8e944210a9d525dc6ae91" lsrcmd5="3b4a835fa1e497790f82e45048a78427" />
+          <entry name="DUMMY_FILE" md5="275876e34cf609db118f3d84b799a790" size="5" mtime="1503324268" />
+          <entry name="_config" md5="55041d03ef8e31e551b3edd00464f7ea" size="103" mtime="1503324439" />
+          <entry name="_link" md5="6ffab3981d3cd40f46924a3319a54098" size="130" mtime="1503324440" />
+          <entry name="somefile.txt" md5="72a89c51cb636651b1da704fa7b303ee" size="160" mtime="1503324439" />
         </directory>
     http_version: 
-  recorded_at: Mon, 19 Dec 2016 16:16:55 GMT
+  recorded_at: Mon, 21 Aug 2017 14:07:30 GMT
 - request:
     method: get
     uri: http://localhost:3200/source/home:tom:branches:ProjectWithRepo:Update/ProjectWithRepo_package
@@ -5375,15 +5638,15 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="ProjectWithRepo_package" rev="2" vrev="2" srcmd5="fbe8bb742fb36043896666826676c016">
-          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" srcmd5="93f9e495c18a6fc43a1efa793a3aa72f" baserev="93f9e495c18a6fc43a1efa793a3aa72f" xsrcmd5="61eac18a9428762e28d6e950c057388e" lsrcmd5="fbe8bb742fb36043896666826676c016" />
-          <entry name="DUMMY_FILE" md5="275876e34cf609db118f3d84b799a790" size="5" mtime="1482164204" />
-          <entry name="_config" md5="822bf2a29d1fd3fb4a6518a86e9dcd2b" size="131" mtime="1482164200" />
-          <entry name="_link" md5="0a82b9fa0797930f466dca66ce9a1137" size="130" mtime="1482164202" />
-          <entry name="somefile.txt" md5="791025267dcc9c8ad8c462c3835a8c2f" size="150" mtime="1482164200" />
+        <directory name="ProjectWithRepo_package" rev="4" vrev="4" srcmd5="3b4a835fa1e497790f82e45048a78427">
+          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" srcmd5="09e82b0920e2079611427fc5ae96b076" baserev="09e82b0920e2079611427fc5ae96b076" xsrcmd5="015a0a0d39a8e944210a9d525dc6ae91" lsrcmd5="3b4a835fa1e497790f82e45048a78427" />
+          <entry name="DUMMY_FILE" md5="275876e34cf609db118f3d84b799a790" size="5" mtime="1503324268" />
+          <entry name="_config" md5="55041d03ef8e31e551b3edd00464f7ea" size="103" mtime="1503324439" />
+          <entry name="_link" md5="6ffab3981d3cd40f46924a3319a54098" size="130" mtime="1503324440" />
+          <entry name="somefile.txt" md5="72a89c51cb636651b1da704fa7b303ee" size="160" mtime="1503324439" />
         </directory>
     http_version: 
-  recorded_at: Mon, 19 Dec 2016 16:16:55 GMT
+  recorded_at: Mon, 21 Aug 2017 14:07:30 GMT
 - request:
     method: post
     uri: http://localhost:3200/source/home:tom:branches:ProjectWithRepo:Update/ProjectWithRepo_package?cmd=diff&expand=1&filelimit=10000&opackage=ProjectWithRepo_package&oproject=ProjectWithRepo:Update
@@ -5407,7 +5670,7 @@ http_interactions:
       Content-Type:
       - text/plain
       Content-Length:
-      - '159'
+      - '161'
       Cache-Control:
       - no-cache
       Connection:
@@ -5426,11 +5689,11 @@ http_interactions:
         ++++++ DUMMY_FILE (new)
         --- DUMMY_FILE
         +++ DUMMY_FILE
-        @@ -0,0 +1 @@
+        @@ -0,0 +1,1 @@
         +dummy
         \ No newline at end of file
     http_version: 
-  recorded_at: Mon, 19 Dec 2016 16:16:55 GMT
+  recorded_at: Mon, 21 Aug 2017 14:07:30 GMT
 - request:
     method: get
     uri: http://localhost:3200/source/home:tom:branches:ProjectWithRepo:Update/ProjectWithRepo_package?expand=1
@@ -5460,14 +5723,14 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="ProjectWithRepo_package" rev="61eac18a9428762e28d6e950c057388e" vrev="4" srcmd5="61eac18a9428762e28d6e950c057388e">
-          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" srcmd5="93f9e495c18a6fc43a1efa793a3aa72f" baserev="93f9e495c18a6fc43a1efa793a3aa72f" lsrcmd5="fbe8bb742fb36043896666826676c016" />
-          <entry name="DUMMY_FILE" md5="275876e34cf609db118f3d84b799a790" size="5" mtime="1482164204" />
-          <entry name="_config" md5="822bf2a29d1fd3fb4a6518a86e9dcd2b" size="131" mtime="1482164200" />
-          <entry name="somefile.txt" md5="791025267dcc9c8ad8c462c3835a8c2f" size="150" mtime="1482164200" />
+        <directory name="ProjectWithRepo_package" rev="015a0a0d39a8e944210a9d525dc6ae91" vrev="8" srcmd5="015a0a0d39a8e944210a9d525dc6ae91">
+          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" srcmd5="09e82b0920e2079611427fc5ae96b076" baserev="09e82b0920e2079611427fc5ae96b076" lsrcmd5="3b4a835fa1e497790f82e45048a78427" />
+          <entry name="DUMMY_FILE" md5="275876e34cf609db118f3d84b799a790" size="5" mtime="1503324268" />
+          <entry name="_config" md5="55041d03ef8e31e551b3edd00464f7ea" size="103" mtime="1503324439" />
+          <entry name="somefile.txt" md5="72a89c51cb636651b1da704fa7b303ee" size="160" mtime="1503324439" />
         </directory>
     http_version: 
-  recorded_at: Mon, 19 Dec 2016 16:16:55 GMT
+  recorded_at: Mon, 21 Aug 2017 14:07:30 GMT
 - request:
     method: get
     uri: http://localhost:3200/build/home:tom:branches:ProjectWithRepo:Update/_result?code=unresolvable&view=status
@@ -5503,7 +5766,7 @@ http_interactions:
           <result project="home:tom:branches:ProjectWithRepo:Update" repository="repository_2" arch="i586" code="unknown" state="unknown" />
         </resultlist>
     http_version: 
-  recorded_at: Mon, 19 Dec 2016 16:16:55 GMT
+  recorded_at: Mon, 21 Aug 2017 14:07:30 GMT
 - request:
     method: get
     uri: http://localhost:3200/build/home:tom:branches:ProjectWithRepo:Update/_result?view=summary
@@ -5541,7 +5804,7 @@ http_interactions:
           </result>
         </resultlist>
     http_version: 
-  recorded_at: Mon, 19 Dec 2016 16:16:55 GMT
+  recorded_at: Mon, 21 Aug 2017 14:07:31 GMT
 - request:
     method: get
     uri: http://localhost:3200/source/home:tom:branches:ProjectWithRepo:Update/ProjectWithRepo_package
@@ -5573,15 +5836,15 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="ProjectWithRepo_package" rev="2" vrev="2" srcmd5="fbe8bb742fb36043896666826676c016">
-          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" srcmd5="93f9e495c18a6fc43a1efa793a3aa72f" baserev="93f9e495c18a6fc43a1efa793a3aa72f" xsrcmd5="61eac18a9428762e28d6e950c057388e" lsrcmd5="fbe8bb742fb36043896666826676c016" />
-          <entry name="DUMMY_FILE" md5="275876e34cf609db118f3d84b799a790" size="5" mtime="1482164204" />
-          <entry name="_config" md5="822bf2a29d1fd3fb4a6518a86e9dcd2b" size="131" mtime="1482164200" />
-          <entry name="_link" md5="0a82b9fa0797930f466dca66ce9a1137" size="130" mtime="1482164202" />
-          <entry name="somefile.txt" md5="791025267dcc9c8ad8c462c3835a8c2f" size="150" mtime="1482164200" />
+        <directory name="ProjectWithRepo_package" rev="4" vrev="4" srcmd5="3b4a835fa1e497790f82e45048a78427">
+          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" srcmd5="09e82b0920e2079611427fc5ae96b076" baserev="09e82b0920e2079611427fc5ae96b076" xsrcmd5="015a0a0d39a8e944210a9d525dc6ae91" lsrcmd5="3b4a835fa1e497790f82e45048a78427" />
+          <entry name="DUMMY_FILE" md5="275876e34cf609db118f3d84b799a790" size="5" mtime="1503324268" />
+          <entry name="_config" md5="55041d03ef8e31e551b3edd00464f7ea" size="103" mtime="1503324439" />
+          <entry name="_link" md5="6ffab3981d3cd40f46924a3319a54098" size="130" mtime="1503324440" />
+          <entry name="somefile.txt" md5="72a89c51cb636651b1da704fa7b303ee" size="160" mtime="1503324439" />
         </directory>
     http_version: 
-  recorded_at: Mon, 19 Dec 2016 16:16:57 GMT
+  recorded_at: Mon, 21 Aug 2017 14:07:32 GMT
 - request:
     method: post
     uri: http://localhost:3200/source/home:tom:branches:ProjectWithRepo:Update/ProjectWithRepo_package?cmd=diff&expand=1&filelimit=10000&opackage=ProjectWithRepo_package&oproject=ProjectWithRepo:Update&view=xml&withissues=1
@@ -5605,7 +5868,7 @@ http_interactions:
       Content-Type:
       - text/xml
       Content-Length:
-      - '578'
+      - '580'
       Cache-Control:
       - no-cache
       Connection:
@@ -5613,13 +5876,13 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="e14c1d3f0365a80c57580c86c4fdcac4">
-          <old project="ProjectWithRepo:Update" package="ProjectWithRepo_package" rev="2" srcmd5="93f9e495c18a6fc43a1efa793a3aa72f" />
-          <new project="home:tom:branches:ProjectWithRepo:Update" package="ProjectWithRepo_package" rev="2" srcmd5="61eac18a9428762e28d6e950c057388e" />
+        <sourcediff key="d88621a8275d9ad55d7fee27df34b557">
+          <old project="ProjectWithRepo:Update" package="ProjectWithRepo_package" rev="4" srcmd5="09e82b0920e2079611427fc5ae96b076" />
+          <new project="home:tom:branches:ProjectWithRepo:Update" package="ProjectWithRepo_package" rev="4" srcmd5="015a0a0d39a8e944210a9d525dc6ae91" />
           <files>
             <file state="added">
               <new name="DUMMY_FILE" md5="275876e34cf609db118f3d84b799a790" size="5" />
-              <diff lines="3">@@ -0,0 +1 @@
+              <diff lines="3">@@ -0,0 +1,1 @@
         +dummy
         \ No newline at end of file
         </diff>
@@ -5629,7 +5892,7 @@ http_interactions:
           </issues>
         </sourcediff>
     http_version: 
-  recorded_at: Mon, 19 Dec 2016 16:16:57 GMT
+  recorded_at: Mon, 21 Aug 2017 14:07:32 GMT
 - request:
     method: get
     uri: http://localhost:3200/build/home:tom:branches:ProjectWithRepo:Update/_result?package=ProjectWithRepo_package&view=status
@@ -5665,10 +5928,10 @@ http_interactions:
           <result project="home:tom:branches:ProjectWithRepo:Update" repository="repository_2" arch="i586" code="unknown" state="unknown" />
         </resultlist>
     http_version: 
-  recorded_at: Mon, 19 Dec 2016 16:16:57 GMT
+  recorded_at: Mon, 21 Aug 2017 14:07:32 GMT
 - request:
     method: get
-    uri: http://localhost:3200/build/home:tom:branches:ProjectWithRepo:Update/_result?package=ProjectWithRepo_package&view=status
+    uri: http://localhost:3200/build/home:tom:branches:ProjectWithRepo:Update/_result?locallink=1&multibuild=1&package=ProjectWithRepo_package&view=status
     body:
       encoding: US-ASCII
       string: ''
@@ -5701,44 +5964,7 @@ http_interactions:
           <result project="home:tom:branches:ProjectWithRepo:Update" repository="repository_2" arch="i586" code="unknown" state="unknown" />
         </resultlist>
     http_version: 
-  recorded_at: Mon, 19 Dec 2016 16:16:57 GMT
-- request:
-    method: get
-    uri: http://localhost:3200/build/home:tom:branches:ProjectWithRepo:Update/repository_2/i586/ProjectWithRepo_package/rpmlint.log
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Content-Type:
-      - text/plain
-      Accept-Encoding:
-      - identity
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 404
-      message: rpmlint.log  No such file or directory
-    headers:
-      Content-Type:
-      - text/xml
-      Content-Length:
-      - '154'
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-    body:
-      encoding: UTF-8
-      string: |
-        <status code="404">
-          <summary>rpmlint.log: No such file or directory</summary>
-          <details>404 rpmlint.log: No such file or directory</details>
-        </status>
-    http_version: 
-  recorded_at: Mon, 19 Dec 2016 16:16:57 GMT
+  recorded_at: Mon, 21 Aug 2017 14:07:32 GMT
 - request:
     method: get
     uri: http://localhost:3200/source/home:tom:branches:ProjectWithRepo:Update/ProjectWithRepo_package
@@ -5768,15 +5994,15 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="ProjectWithRepo_package" rev="2" vrev="2" srcmd5="fbe8bb742fb36043896666826676c016">
-          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" srcmd5="93f9e495c18a6fc43a1efa793a3aa72f" baserev="93f9e495c18a6fc43a1efa793a3aa72f" xsrcmd5="61eac18a9428762e28d6e950c057388e" lsrcmd5="fbe8bb742fb36043896666826676c016" />
-          <entry name="DUMMY_FILE" md5="275876e34cf609db118f3d84b799a790" size="5" mtime="1482164204" />
-          <entry name="_config" md5="822bf2a29d1fd3fb4a6518a86e9dcd2b" size="131" mtime="1482164200" />
-          <entry name="_link" md5="0a82b9fa0797930f466dca66ce9a1137" size="130" mtime="1482164202" />
-          <entry name="somefile.txt" md5="791025267dcc9c8ad8c462c3835a8c2f" size="150" mtime="1482164200" />
+        <directory name="ProjectWithRepo_package" rev="4" vrev="4" srcmd5="3b4a835fa1e497790f82e45048a78427">
+          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" srcmd5="09e82b0920e2079611427fc5ae96b076" baserev="09e82b0920e2079611427fc5ae96b076" xsrcmd5="015a0a0d39a8e944210a9d525dc6ae91" lsrcmd5="3b4a835fa1e497790f82e45048a78427" />
+          <entry name="DUMMY_FILE" md5="275876e34cf609db118f3d84b799a790" size="5" mtime="1503324268" />
+          <entry name="_config" md5="55041d03ef8e31e551b3edd00464f7ea" size="103" mtime="1503324439" />
+          <entry name="_link" md5="6ffab3981d3cd40f46924a3319a54098" size="130" mtime="1503324440" />
+          <entry name="somefile.txt" md5="72a89c51cb636651b1da704fa7b303ee" size="160" mtime="1503324439" />
         </directory>
     http_version: 
-  recorded_at: Mon, 19 Dec 2016 16:16:58 GMT
+  recorded_at: Mon, 21 Aug 2017 14:07:32 GMT
 - request:
     method: get
     uri: http://localhost:3200/source/home:tom:branches:ProjectWithRepo:Update/ProjectWithRepo_package
@@ -5808,15 +6034,15 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="ProjectWithRepo_package" rev="2" vrev="2" srcmd5="fbe8bb742fb36043896666826676c016">
-          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" srcmd5="93f9e495c18a6fc43a1efa793a3aa72f" baserev="93f9e495c18a6fc43a1efa793a3aa72f" xsrcmd5="61eac18a9428762e28d6e950c057388e" lsrcmd5="fbe8bb742fb36043896666826676c016" />
-          <entry name="DUMMY_FILE" md5="275876e34cf609db118f3d84b799a790" size="5" mtime="1482164204" />
-          <entry name="_config" md5="822bf2a29d1fd3fb4a6518a86e9dcd2b" size="131" mtime="1482164200" />
-          <entry name="_link" md5="0a82b9fa0797930f466dca66ce9a1137" size="130" mtime="1482164202" />
-          <entry name="somefile.txt" md5="791025267dcc9c8ad8c462c3835a8c2f" size="150" mtime="1482164200" />
+        <directory name="ProjectWithRepo_package" rev="4" vrev="4" srcmd5="3b4a835fa1e497790f82e45048a78427">
+          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" srcmd5="09e82b0920e2079611427fc5ae96b076" baserev="09e82b0920e2079611427fc5ae96b076" xsrcmd5="015a0a0d39a8e944210a9d525dc6ae91" lsrcmd5="3b4a835fa1e497790f82e45048a78427" />
+          <entry name="DUMMY_FILE" md5="275876e34cf609db118f3d84b799a790" size="5" mtime="1503324268" />
+          <entry name="_config" md5="55041d03ef8e31e551b3edd00464f7ea" size="103" mtime="1503324439" />
+          <entry name="_link" md5="6ffab3981d3cd40f46924a3319a54098" size="130" mtime="1503324440" />
+          <entry name="somefile.txt" md5="72a89c51cb636651b1da704fa7b303ee" size="160" mtime="1503324439" />
         </directory>
     http_version: 
-  recorded_at: Mon, 19 Dec 2016 16:16:58 GMT
+  recorded_at: Mon, 21 Aug 2017 14:07:33 GMT
 - request:
     method: post
     uri: http://localhost:3200/source/home:tom:branches:ProjectWithRepo:Update/ProjectWithRepo_package?cmd=diff&expand=1&filelimit=10000&opackage=ProjectWithRepo_package&oproject=ProjectWithRepo:Update&view=xml&withissues=1
@@ -5840,7 +6066,7 @@ http_interactions:
       Content-Type:
       - text/xml
       Content-Length:
-      - '578'
+      - '580'
       Cache-Control:
       - no-cache
       Connection:
@@ -5848,13 +6074,13 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="e14c1d3f0365a80c57580c86c4fdcac4">
-          <old project="ProjectWithRepo:Update" package="ProjectWithRepo_package" rev="2" srcmd5="93f9e495c18a6fc43a1efa793a3aa72f" />
-          <new project="home:tom:branches:ProjectWithRepo:Update" package="ProjectWithRepo_package" rev="2" srcmd5="61eac18a9428762e28d6e950c057388e" />
+        <sourcediff key="d88621a8275d9ad55d7fee27df34b557">
+          <old project="ProjectWithRepo:Update" package="ProjectWithRepo_package" rev="4" srcmd5="09e82b0920e2079611427fc5ae96b076" />
+          <new project="home:tom:branches:ProjectWithRepo:Update" package="ProjectWithRepo_package" rev="4" srcmd5="015a0a0d39a8e944210a9d525dc6ae91" />
           <files>
             <file state="added">
               <new name="DUMMY_FILE" md5="275876e34cf609db118f3d84b799a790" size="5" />
-              <diff lines="3">@@ -0,0 +1 @@
+              <diff lines="3">@@ -0,0 +1,1 @@
         +dummy
         \ No newline at end of file
         </diff>
@@ -5864,7 +6090,7 @@ http_interactions:
           </issues>
         </sourcediff>
     http_version: 
-  recorded_at: Mon, 19 Dec 2016 16:16:58 GMT
+  recorded_at: Mon, 21 Aug 2017 14:07:33 GMT
 - request:
     method: get
     uri: http://localhost:3200/build/home:tom:branches:ProjectWithRepo:Update/_result?package=ProjectWithRepo_package&view=status
@@ -5900,10 +6126,10 @@ http_interactions:
           <result project="home:tom:branches:ProjectWithRepo:Update" repository="repository_2" arch="i586" code="unknown" state="unknown" />
         </resultlist>
     http_version: 
-  recorded_at: Mon, 19 Dec 2016 16:16:58 GMT
+  recorded_at: Mon, 21 Aug 2017 14:07:33 GMT
 - request:
     method: get
-    uri: http://localhost:3200/build/home:tom:branches:ProjectWithRepo:Update/_result?package=ProjectWithRepo_package&view=status
+    uri: http://localhost:3200/build/home:tom:branches:ProjectWithRepo:Update/_result?locallink=1&multibuild=1&package=ProjectWithRepo_package&view=status
     body:
       encoding: US-ASCII
       string: ''
@@ -5936,44 +6162,7 @@ http_interactions:
           <result project="home:tom:branches:ProjectWithRepo:Update" repository="repository_2" arch="i586" code="unknown" state="unknown" />
         </resultlist>
     http_version: 
-  recorded_at: Mon, 19 Dec 2016 16:16:58 GMT
-- request:
-    method: get
-    uri: http://localhost:3200/build/home:tom:branches:ProjectWithRepo:Update/repository_2/i586/ProjectWithRepo_package/rpmlint.log
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Content-Type:
-      - text/plain
-      Accept-Encoding:
-      - identity
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 404
-      message: rpmlint.log  No such file or directory
-    headers:
-      Content-Type:
-      - text/xml
-      Content-Length:
-      - '154'
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-    body:
-      encoding: UTF-8
-      string: |
-        <status code="404">
-          <summary>rpmlint.log: No such file or directory</summary>
-          <details>404 rpmlint.log: No such file or directory</details>
-        </status>
-    http_version: 
-  recorded_at: Mon, 19 Dec 2016 16:16:58 GMT
+  recorded_at: Mon, 21 Aug 2017 14:07:33 GMT
 - request:
     method: get
     uri: http://localhost:3200/source/home:tom:branches:ProjectWithRepo:Update/ProjectWithRepo_package
@@ -6003,15 +6192,15 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="ProjectWithRepo_package" rev="2" vrev="2" srcmd5="fbe8bb742fb36043896666826676c016">
-          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" srcmd5="93f9e495c18a6fc43a1efa793a3aa72f" baserev="93f9e495c18a6fc43a1efa793a3aa72f" xsrcmd5="61eac18a9428762e28d6e950c057388e" lsrcmd5="fbe8bb742fb36043896666826676c016" />
-          <entry name="DUMMY_FILE" md5="275876e34cf609db118f3d84b799a790" size="5" mtime="1482164204" />
-          <entry name="_config" md5="822bf2a29d1fd3fb4a6518a86e9dcd2b" size="131" mtime="1482164200" />
-          <entry name="_link" md5="0a82b9fa0797930f466dca66ce9a1137" size="130" mtime="1482164202" />
-          <entry name="somefile.txt" md5="791025267dcc9c8ad8c462c3835a8c2f" size="150" mtime="1482164200" />
+        <directory name="ProjectWithRepo_package" rev="4" vrev="4" srcmd5="3b4a835fa1e497790f82e45048a78427">
+          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" srcmd5="09e82b0920e2079611427fc5ae96b076" baserev="09e82b0920e2079611427fc5ae96b076" xsrcmd5="015a0a0d39a8e944210a9d525dc6ae91" lsrcmd5="3b4a835fa1e497790f82e45048a78427" />
+          <entry name="DUMMY_FILE" md5="275876e34cf609db118f3d84b799a790" size="5" mtime="1503324268" />
+          <entry name="_config" md5="55041d03ef8e31e551b3edd00464f7ea" size="103" mtime="1503324439" />
+          <entry name="_link" md5="6ffab3981d3cd40f46924a3319a54098" size="130" mtime="1503324440" />
+          <entry name="somefile.txt" md5="72a89c51cb636651b1da704fa7b303ee" size="160" mtime="1503324439" />
         </directory>
     http_version: 
-  recorded_at: Mon, 19 Dec 2016 16:16:59 GMT
+  recorded_at: Mon, 21 Aug 2017 14:07:33 GMT
 - request:
     method: get
     uri: http://localhost:3200/source/home:tom:branches:ProjectWithRepo:Update/ProjectWithRepo_package
@@ -6043,15 +6232,15 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="ProjectWithRepo_package" rev="2" vrev="2" srcmd5="fbe8bb742fb36043896666826676c016">
-          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" srcmd5="93f9e495c18a6fc43a1efa793a3aa72f" baserev="93f9e495c18a6fc43a1efa793a3aa72f" xsrcmd5="61eac18a9428762e28d6e950c057388e" lsrcmd5="fbe8bb742fb36043896666826676c016" />
-          <entry name="DUMMY_FILE" md5="275876e34cf609db118f3d84b799a790" size="5" mtime="1482164204" />
-          <entry name="_config" md5="822bf2a29d1fd3fb4a6518a86e9dcd2b" size="131" mtime="1482164200" />
-          <entry name="_link" md5="0a82b9fa0797930f466dca66ce9a1137" size="130" mtime="1482164202" />
-          <entry name="somefile.txt" md5="791025267dcc9c8ad8c462c3835a8c2f" size="150" mtime="1482164200" />
+        <directory name="ProjectWithRepo_package" rev="4" vrev="4" srcmd5="3b4a835fa1e497790f82e45048a78427">
+          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" srcmd5="09e82b0920e2079611427fc5ae96b076" baserev="09e82b0920e2079611427fc5ae96b076" xsrcmd5="015a0a0d39a8e944210a9d525dc6ae91" lsrcmd5="3b4a835fa1e497790f82e45048a78427" />
+          <entry name="DUMMY_FILE" md5="275876e34cf609db118f3d84b799a790" size="5" mtime="1503324268" />
+          <entry name="_config" md5="55041d03ef8e31e551b3edd00464f7ea" size="103" mtime="1503324439" />
+          <entry name="_link" md5="6ffab3981d3cd40f46924a3319a54098" size="130" mtime="1503324440" />
+          <entry name="somefile.txt" md5="72a89c51cb636651b1da704fa7b303ee" size="160" mtime="1503324439" />
         </directory>
     http_version: 
-  recorded_at: Mon, 19 Dec 2016 16:16:59 GMT
+  recorded_at: Mon, 21 Aug 2017 14:07:33 GMT
 - request:
     method: post
     uri: http://localhost:3200/source/home:tom:branches:ProjectWithRepo:Update/ProjectWithRepo_package?cmd=diff&expand=1&filelimit=10000&opackage=ProjectWithRepo_package&oproject=ProjectWithRepo:Update&view=xml&withissues=1
@@ -6075,7 +6264,7 @@ http_interactions:
       Content-Type:
       - text/xml
       Content-Length:
-      - '578'
+      - '580'
       Cache-Control:
       - no-cache
       Connection:
@@ -6083,13 +6272,13 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="e14c1d3f0365a80c57580c86c4fdcac4">
-          <old project="ProjectWithRepo:Update" package="ProjectWithRepo_package" rev="2" srcmd5="93f9e495c18a6fc43a1efa793a3aa72f" />
-          <new project="home:tom:branches:ProjectWithRepo:Update" package="ProjectWithRepo_package" rev="2" srcmd5="61eac18a9428762e28d6e950c057388e" />
+        <sourcediff key="d88621a8275d9ad55d7fee27df34b557">
+          <old project="ProjectWithRepo:Update" package="ProjectWithRepo_package" rev="4" srcmd5="09e82b0920e2079611427fc5ae96b076" />
+          <new project="home:tom:branches:ProjectWithRepo:Update" package="ProjectWithRepo_package" rev="4" srcmd5="015a0a0d39a8e944210a9d525dc6ae91" />
           <files>
             <file state="added">
               <new name="DUMMY_FILE" md5="275876e34cf609db118f3d84b799a790" size="5" />
-              <diff lines="3">@@ -0,0 +1 @@
+              <diff lines="3">@@ -0,0 +1,1 @@
         +dummy
         \ No newline at end of file
         </diff>
@@ -6099,7 +6288,7 @@ http_interactions:
           </issues>
         </sourcediff>
     http_version: 
-  recorded_at: Mon, 19 Dec 2016 16:16:59 GMT
+  recorded_at: Mon, 21 Aug 2017 14:07:33 GMT
 - request:
     method: get
     uri: http://localhost:3200/build/home:tom:branches:ProjectWithRepo:Update/_result?package=ProjectWithRepo_package&view=status
@@ -6135,10 +6324,10 @@ http_interactions:
           <result project="home:tom:branches:ProjectWithRepo:Update" repository="repository_2" arch="i586" code="unknown" state="unknown" />
         </resultlist>
     http_version: 
-  recorded_at: Mon, 19 Dec 2016 16:16:59 GMT
+  recorded_at: Mon, 21 Aug 2017 14:07:33 GMT
 - request:
     method: get
-    uri: http://localhost:3200/build/home:tom:branches:ProjectWithRepo:Update/_result?package=ProjectWithRepo_package&view=status
+    uri: http://localhost:3200/build/home:tom:branches:ProjectWithRepo:Update/_result?locallink=1&multibuild=1&package=ProjectWithRepo_package&view=status
     body:
       encoding: US-ASCII
       string: ''
@@ -6171,44 +6360,7 @@ http_interactions:
           <result project="home:tom:branches:ProjectWithRepo:Update" repository="repository_2" arch="i586" code="unknown" state="unknown" />
         </resultlist>
     http_version: 
-  recorded_at: Mon, 19 Dec 2016 16:16:59 GMT
-- request:
-    method: get
-    uri: http://localhost:3200/build/home:tom:branches:ProjectWithRepo:Update/repository_2/i586/ProjectWithRepo_package/rpmlint.log
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Content-Type:
-      - text/plain
-      Accept-Encoding:
-      - identity
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 404
-      message: rpmlint.log  No such file or directory
-    headers:
-      Content-Type:
-      - text/xml
-      Content-Length:
-      - '154'
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-    body:
-      encoding: UTF-8
-      string: |
-        <status code="404">
-          <summary>rpmlint.log: No such file or directory</summary>
-          <details>404 rpmlint.log: No such file or directory</details>
-        </status>
-    http_version: 
-  recorded_at: Mon, 19 Dec 2016 16:16:59 GMT
+  recorded_at: Mon, 21 Aug 2017 14:07:33 GMT
 - request:
     method: get
     uri: http://localhost:3200/source/home:tom:branches:ProjectWithRepo:Update/ProjectWithRepo_package
@@ -6238,15 +6390,15 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="ProjectWithRepo_package" rev="2" vrev="2" srcmd5="fbe8bb742fb36043896666826676c016">
-          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" srcmd5="93f9e495c18a6fc43a1efa793a3aa72f" baserev="93f9e495c18a6fc43a1efa793a3aa72f" xsrcmd5="61eac18a9428762e28d6e950c057388e" lsrcmd5="fbe8bb742fb36043896666826676c016" />
-          <entry name="DUMMY_FILE" md5="275876e34cf609db118f3d84b799a790" size="5" mtime="1482164204" />
-          <entry name="_config" md5="822bf2a29d1fd3fb4a6518a86e9dcd2b" size="131" mtime="1482164200" />
-          <entry name="_link" md5="0a82b9fa0797930f466dca66ce9a1137" size="130" mtime="1482164202" />
-          <entry name="somefile.txt" md5="791025267dcc9c8ad8c462c3835a8c2f" size="150" mtime="1482164200" />
+        <directory name="ProjectWithRepo_package" rev="4" vrev="4" srcmd5="3b4a835fa1e497790f82e45048a78427">
+          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" srcmd5="09e82b0920e2079611427fc5ae96b076" baserev="09e82b0920e2079611427fc5ae96b076" xsrcmd5="015a0a0d39a8e944210a9d525dc6ae91" lsrcmd5="3b4a835fa1e497790f82e45048a78427" />
+          <entry name="DUMMY_FILE" md5="275876e34cf609db118f3d84b799a790" size="5" mtime="1503324268" />
+          <entry name="_config" md5="55041d03ef8e31e551b3edd00464f7ea" size="103" mtime="1503324439" />
+          <entry name="_link" md5="6ffab3981d3cd40f46924a3319a54098" size="130" mtime="1503324440" />
+          <entry name="somefile.txt" md5="72a89c51cb636651b1da704fa7b303ee" size="160" mtime="1503324439" />
         </directory>
     http_version: 
-  recorded_at: Mon, 19 Dec 2016 16:17:00 GMT
+  recorded_at: Mon, 21 Aug 2017 14:07:33 GMT
 - request:
     method: get
     uri: http://localhost:3200/source/home:tom:branches:ProjectWithRepo:Update/ProjectWithRepo_package?expand=1
@@ -6278,14 +6430,14 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="ProjectWithRepo_package" rev="61eac18a9428762e28d6e950c057388e" vrev="4" srcmd5="61eac18a9428762e28d6e950c057388e">
-          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" srcmd5="93f9e495c18a6fc43a1efa793a3aa72f" baserev="93f9e495c18a6fc43a1efa793a3aa72f" lsrcmd5="fbe8bb742fb36043896666826676c016" />
-          <entry name="DUMMY_FILE" md5="275876e34cf609db118f3d84b799a790" size="5" mtime="1482164204" />
-          <entry name="_config" md5="822bf2a29d1fd3fb4a6518a86e9dcd2b" size="131" mtime="1482164200" />
-          <entry name="somefile.txt" md5="791025267dcc9c8ad8c462c3835a8c2f" size="150" mtime="1482164200" />
+        <directory name="ProjectWithRepo_package" rev="015a0a0d39a8e944210a9d525dc6ae91" vrev="8" srcmd5="015a0a0d39a8e944210a9d525dc6ae91">
+          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" srcmd5="09e82b0920e2079611427fc5ae96b076" baserev="09e82b0920e2079611427fc5ae96b076" lsrcmd5="3b4a835fa1e497790f82e45048a78427" />
+          <entry name="DUMMY_FILE" md5="275876e34cf609db118f3d84b799a790" size="5" mtime="1503324268" />
+          <entry name="_config" md5="55041d03ef8e31e551b3edd00464f7ea" size="103" mtime="1503324439" />
+          <entry name="somefile.txt" md5="72a89c51cb636651b1da704fa7b303ee" size="160" mtime="1503324439" />
         </directory>
     http_version: 
-  recorded_at: Mon, 19 Dec 2016 16:17:00 GMT
+  recorded_at: Mon, 21 Aug 2017 14:07:34 GMT
 - request:
     method: get
     uri: http://localhost:3200/source/home:tom:branches:ProjectWithRepo:Update/ProjectWithRepo_package?expand=1
@@ -6315,14 +6467,14 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="ProjectWithRepo_package" rev="61eac18a9428762e28d6e950c057388e" vrev="4" srcmd5="61eac18a9428762e28d6e950c057388e">
-          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" srcmd5="93f9e495c18a6fc43a1efa793a3aa72f" baserev="93f9e495c18a6fc43a1efa793a3aa72f" lsrcmd5="fbe8bb742fb36043896666826676c016" />
-          <entry name="DUMMY_FILE" md5="275876e34cf609db118f3d84b799a790" size="5" mtime="1482164204" />
-          <entry name="_config" md5="822bf2a29d1fd3fb4a6518a86e9dcd2b" size="131" mtime="1482164200" />
-          <entry name="somefile.txt" md5="791025267dcc9c8ad8c462c3835a8c2f" size="150" mtime="1482164200" />
+        <directory name="ProjectWithRepo_package" rev="015a0a0d39a8e944210a9d525dc6ae91" vrev="8" srcmd5="015a0a0d39a8e944210a9d525dc6ae91">
+          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" srcmd5="09e82b0920e2079611427fc5ae96b076" baserev="09e82b0920e2079611427fc5ae96b076" lsrcmd5="3b4a835fa1e497790f82e45048a78427" />
+          <entry name="DUMMY_FILE" md5="275876e34cf609db118f3d84b799a790" size="5" mtime="1503324268" />
+          <entry name="_config" md5="55041d03ef8e31e551b3edd00464f7ea" size="103" mtime="1503324439" />
+          <entry name="somefile.txt" md5="72a89c51cb636651b1da704fa7b303ee" size="160" mtime="1503324439" />
         </directory>
     http_version: 
-  recorded_at: Mon, 19 Dec 2016 16:17:00 GMT
+  recorded_at: Mon, 21 Aug 2017 14:07:34 GMT
 - request:
     method: get
     uri: http://localhost:3200/source/home:tom:branches:ProjectWithRepo:Update/ProjectWithRepo_package
@@ -6352,15 +6504,15 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="ProjectWithRepo_package" rev="2" vrev="2" srcmd5="fbe8bb742fb36043896666826676c016">
-          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" srcmd5="93f9e495c18a6fc43a1efa793a3aa72f" baserev="93f9e495c18a6fc43a1efa793a3aa72f" xsrcmd5="61eac18a9428762e28d6e950c057388e" lsrcmd5="fbe8bb742fb36043896666826676c016" />
-          <entry name="DUMMY_FILE" md5="275876e34cf609db118f3d84b799a790" size="5" mtime="1482164204" />
-          <entry name="_config" md5="822bf2a29d1fd3fb4a6518a86e9dcd2b" size="131" mtime="1482164200" />
-          <entry name="_link" md5="0a82b9fa0797930f466dca66ce9a1137" size="130" mtime="1482164202" />
-          <entry name="somefile.txt" md5="791025267dcc9c8ad8c462c3835a8c2f" size="150" mtime="1482164200" />
+        <directory name="ProjectWithRepo_package" rev="4" vrev="4" srcmd5="3b4a835fa1e497790f82e45048a78427">
+          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" srcmd5="09e82b0920e2079611427fc5ae96b076" baserev="09e82b0920e2079611427fc5ae96b076" xsrcmd5="015a0a0d39a8e944210a9d525dc6ae91" lsrcmd5="3b4a835fa1e497790f82e45048a78427" />
+          <entry name="DUMMY_FILE" md5="275876e34cf609db118f3d84b799a790" size="5" mtime="1503324268" />
+          <entry name="_config" md5="55041d03ef8e31e551b3edd00464f7ea" size="103" mtime="1503324439" />
+          <entry name="_link" md5="6ffab3981d3cd40f46924a3319a54098" size="130" mtime="1503324440" />
+          <entry name="somefile.txt" md5="72a89c51cb636651b1da704fa7b303ee" size="160" mtime="1503324439" />
         </directory>
     http_version: 
-  recorded_at: Mon, 19 Dec 2016 16:17:00 GMT
+  recorded_at: Mon, 21 Aug 2017 14:07:34 GMT
 - request:
     method: post
     uri: http://localhost:3200/search/package/id?match=(linkinfo/@package=%22ProjectWithRepo_package%22%20and%20linkinfo/@project=%22ProjectWithRepo:Update%22%20and%20starts-with(@project,%22MaintenanceProject:%22))
@@ -6396,7 +6548,7 @@ http_interactions:
           <package name="ProjectWithRepo_package.ProjectWithRepo_Update" project="MaintenanceProject:0" />
         </collection>
     http_version: 
-  recorded_at: Mon, 19 Dec 2016 16:17:00 GMT
+  recorded_at: Mon, 21 Aug 2017 14:07:34 GMT
 - request:
     method: post
     uri: http://localhost:3200/search/package/id?match=(linkinfo/@package=%22ProjectWithRepo_package%22%20and%20linkinfo/@project=%22ProjectWithRepo%22%20and%20@project=%22ProjectWithRepo%22)
@@ -6431,7 +6583,7 @@ http_interactions:
         <collection>
         </collection>
     http_version: 
-  recorded_at: Mon, 19 Dec 2016 16:17:00 GMT
+  recorded_at: Mon, 21 Aug 2017 14:07:34 GMT
 - request:
     method: put
     uri: http://localhost:3200/source/MaintenanceProject:0/ProjectWithRepo_package.ProjectWithRepo_Update/_meta?user=maintenance_coord
@@ -6439,8 +6591,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="ProjectWithRepo_package.ProjectWithRepo_Update" project="MaintenanceProject:0">
-          <title/>
-          <description/>
+          <title>Moab Is My Washpot</title>
+          <description>Eius ut consequuntur nihil.</description>
           <releasename>ProjectWithRepo_package</releasename>
           <build>
             <enable repository="ProjectWithRepo_Update"/>
@@ -6465,20 +6617,20 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '279'
+      - '324'
     body:
       encoding: UTF-8
       string: |
         <package name="ProjectWithRepo_package.ProjectWithRepo_Update" project="MaintenanceProject:0">
-          <title></title>
-          <description></description>
+          <title>Moab Is My Washpot</title>
+          <description>Eius ut consequuntur nihil.</description>
           <releasename>ProjectWithRepo_package</releasename>
           <build>
             <enable repository="ProjectWithRepo_Update" />
           </build>
         </package>
     http_version: 
-  recorded_at: Mon, 19 Dec 2016 16:17:00 GMT
+  recorded_at: Mon, 21 Aug 2017 14:07:34 GMT
 - request:
     method: post
     uri: http://localhost:3200/source/MaintenanceProject:0/ProjectWithRepo_package.ProjectWithRepo_Update?cmd=branch&opackage=ProjectWithRepo_package&oproject=ProjectWithRepo:Update&user=maintenance_coord
@@ -6510,16 +6662,63 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <revision rev="3" vrev="3">
-          <srcmd5>0053dbbf7ed92619a79c971b291714f6</srcmd5>
+        <revision rev="7" vrev="7">
+          <srcmd5>86a991e1d0fb1e255e605e346b8c71b2</srcmd5>
           <version>unknown</version>
-          <time>1482164220</time>
+          <time>1503324454</time>
           <user>maintenance_coord</user>
           <comment></comment>
           <requestid/>
         </revision>
     http_version: 
-  recorded_at: Mon, 19 Dec 2016 16:17:00 GMT
+  recorded_at: Mon, 21 Aug 2017 14:07:34 GMT
+- request:
+    method: put
+    uri: http://localhost:3200/source/MaintenanceProject:0/ProjectWithRepo_package.ProjectWithRepo_Update/_meta?user=maintenance_coord
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="ProjectWithRepo_package.ProjectWithRepo_Update" project="MaintenanceProject:0">
+          <title>Moab Is My Washpot</title>
+          <description>Eius ut consequuntur nihil.</description>
+          <releasename>ProjectWithRepo_package</releasename>
+          <build>
+            <enable repository="ProjectWithRepo_Update"/>
+          </build>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '324'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="ProjectWithRepo_package.ProjectWithRepo_Update" project="MaintenanceProject:0">
+          <title>Moab Is My Washpot</title>
+          <description>Eius ut consequuntur nihil.</description>
+          <releasename>ProjectWithRepo_package</releasename>
+          <build>
+            <enable repository="ProjectWithRepo_Update" />
+          </build>
+        </package>
+    http_version: 
+  recorded_at: Mon, 21 Aug 2017 14:07:34 GMT
 - request:
     method: get
     uri: http://localhost:3200/source/MaintenanceProject:0/ProjectWithRepo_package.ProjectWithRepo_Update
@@ -6549,14 +6748,14 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="ProjectWithRepo_package.ProjectWithRepo_Update" rev="3" vrev="3" srcmd5="0053dbbf7ed92619a79c971b291714f6">
-          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" srcmd5="93f9e495c18a6fc43a1efa793a3aa72f" baserev="93f9e495c18a6fc43a1efa793a3aa72f" xsrcmd5="48c3d6c78f0296d44dda7b080229f33e" lsrcmd5="0053dbbf7ed92619a79c971b291714f6" />
-          <entry name="_config" md5="822bf2a29d1fd3fb4a6518a86e9dcd2b" size="131" mtime="1482164200" />
-          <entry name="_link" md5="3df31df42a72a87eda7d83111e64ec3e" size="164" mtime="1482164209" />
-          <entry name="somefile.txt" md5="791025267dcc9c8ad8c462c3835a8c2f" size="150" mtime="1482164200" />
+        <directory name="ProjectWithRepo_package.ProjectWithRepo_Update" rev="7" vrev="7" srcmd5="86a991e1d0fb1e255e605e346b8c71b2">
+          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" srcmd5="09e82b0920e2079611427fc5ae96b076" baserev="09e82b0920e2079611427fc5ae96b076" xsrcmd5="dd8fee4cd9676519d6bc95db70858eac" lsrcmd5="86a991e1d0fb1e255e605e346b8c71b2" />
+          <entry name="_config" md5="55041d03ef8e31e551b3edd00464f7ea" size="103" mtime="1503324439" />
+          <entry name="_link" md5="3f7843b2f03812aa3a4c42dd85f1b177" size="164" mtime="1503324445" />
+          <entry name="somefile.txt" md5="72a89c51cb636651b1da704fa7b303ee" size="160" mtime="1503324439" />
         </directory>
     http_version: 
-  recorded_at: Mon, 19 Dec 2016 16:17:00 GMT
+  recorded_at: Mon, 21 Aug 2017 14:07:34 GMT
 - request:
     method: get
     uri: http://localhost:3200/source/MaintenanceProject:0/ProjectWithRepo_package.ProjectWithRepo_Update?nofilename=1&view=info&withchangesmd5=1
@@ -6582,17 +6781,17 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '416'
+      - '417'
     body:
       encoding: UTF-8
       string: |
-        <sourceinfo package="ProjectWithRepo_package.ProjectWithRepo_Update" rev="3" vrev="5" srcmd5="48c3d6c78f0296d44dda7b080229f33e" lsrcmd5="0053dbbf7ed92619a79c971b291714f6" verifymd5="93f9e495c18a6fc43a1efa793a3aa72f">
+        <sourceinfo package="ProjectWithRepo_package.ProjectWithRepo_Update" rev="7" vrev="11" srcmd5="dd8fee4cd9676519d6bc95db70858eac" lsrcmd5="86a991e1d0fb1e255e605e346b8c71b2" verifymd5="09e82b0920e2079611427fc5ae96b076">
           <linked project="ProjectWithRepo:Update" package="ProjectWithRepo_package" />
           <linked project="ProjectWithRepo" package="ProjectWithRepo_package" />
-          <revtime>1482164220</revtime>
+          <revtime>1503324454</revtime>
         </sourceinfo>
     http_version: 
-  recorded_at: Mon, 19 Dec 2016 16:17:00 GMT
+  recorded_at: Mon, 21 Aug 2017 14:07:34 GMT
 - request:
     method: get
     uri: http://localhost:3200/source/MaintenanceProject:0/ProjectWithRepo_package.ProjectWithRepo_Update
@@ -6622,14 +6821,14 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="ProjectWithRepo_package.ProjectWithRepo_Update" rev="3" vrev="3" srcmd5="0053dbbf7ed92619a79c971b291714f6">
-          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" srcmd5="93f9e495c18a6fc43a1efa793a3aa72f" baserev="93f9e495c18a6fc43a1efa793a3aa72f" xsrcmd5="48c3d6c78f0296d44dda7b080229f33e" lsrcmd5="0053dbbf7ed92619a79c971b291714f6" />
-          <entry name="_config" md5="822bf2a29d1fd3fb4a6518a86e9dcd2b" size="131" mtime="1482164200" />
-          <entry name="_link" md5="3df31df42a72a87eda7d83111e64ec3e" size="164" mtime="1482164209" />
-          <entry name="somefile.txt" md5="791025267dcc9c8ad8c462c3835a8c2f" size="150" mtime="1482164200" />
+        <directory name="ProjectWithRepo_package.ProjectWithRepo_Update" rev="7" vrev="7" srcmd5="86a991e1d0fb1e255e605e346b8c71b2">
+          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" srcmd5="09e82b0920e2079611427fc5ae96b076" baserev="09e82b0920e2079611427fc5ae96b076" xsrcmd5="dd8fee4cd9676519d6bc95db70858eac" lsrcmd5="86a991e1d0fb1e255e605e346b8c71b2" />
+          <entry name="_config" md5="55041d03ef8e31e551b3edd00464f7ea" size="103" mtime="1503324439" />
+          <entry name="_link" md5="3f7843b2f03812aa3a4c42dd85f1b177" size="164" mtime="1503324445" />
+          <entry name="somefile.txt" md5="72a89c51cb636651b1da704fa7b303ee" size="160" mtime="1503324439" />
         </directory>
     http_version: 
-  recorded_at: Mon, 19 Dec 2016 16:17:00 GMT
+  recorded_at: Mon, 21 Aug 2017 14:07:34 GMT
 - request:
     method: post
     uri: http://localhost:3200/source/MaintenanceProject:0/ProjectWithRepo_package.ProjectWithRepo_Update?cmd=diff&linkrev=base&onlyissues=1&orev=0&view=xml
@@ -6661,15 +6860,15 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="62c8e1dae9f723cb831335db09106923">
+        <sourcediff key="00a8f538a8458c1ee8cd1af5b5a9da0b">
           <old project="MaintenanceProject:0" package="ProjectWithRepo_package.ProjectWithRepo_Update" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e" />
-          <new project="MaintenanceProject:0" package="ProjectWithRepo_package.ProjectWithRepo_Update" rev="1" srcmd5="0053dbbf7ed92619a79c971b291714f6" />
+          <new project="MaintenanceProject:0" package="ProjectWithRepo_package.ProjectWithRepo_Update" rev="5" srcmd5="86a991e1d0fb1e255e605e346b8c71b2" />
           <files />
           <issues>
           </issues>
         </sourcediff>
     http_version: 
-  recorded_at: Mon, 19 Dec 2016 16:17:00 GMT
+  recorded_at: Mon, 21 Aug 2017 14:07:34 GMT
 - request:
     method: post
     uri: http://localhost:3200/source/MaintenanceProject:0/ProjectWithRepo_package.ProjectWithRepo_Update?cmd=linkdiff&linkrev=base&onlyissues=1&view=xml
@@ -6701,13 +6900,13 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="5d12888185c489c5f3224f3e2c5b1c26">
-          <old project="ProjectWithRepo:Update" package="ProjectWithRepo_package" rev="93f9e495c18a6fc43a1efa793a3aa72f" srcmd5="93f9e495c18a6fc43a1efa793a3aa72f" />
-          <new project="MaintenanceProject:0" package="ProjectWithRepo_package.ProjectWithRepo_Update" rev="48c3d6c78f0296d44dda7b080229f33e" srcmd5="48c3d6c78f0296d44dda7b080229f33e" />
+        <sourcediff key="c2d0ce4eef4d88842741edf1dd777bce">
+          <old project="ProjectWithRepo:Update" package="ProjectWithRepo_package" rev="09e82b0920e2079611427fc5ae96b076" srcmd5="09e82b0920e2079611427fc5ae96b076" />
+          <new project="MaintenanceProject:0" package="ProjectWithRepo_package.ProjectWithRepo_Update" rev="dd8fee4cd9676519d6bc95db70858eac" srcmd5="dd8fee4cd9676519d6bc95db70858eac" />
           <files />
         </sourcediff>
     http_version: 
-  recorded_at: Mon, 19 Dec 2016 16:17:00 GMT
+  recorded_at: Mon, 21 Aug 2017 14:07:34 GMT
 - request:
     method: put
     uri: http://localhost:3200/source/MaintenanceProject:0/ProjectWithRepo_package.ProjectWithRepo_Update/_meta?user=maintenance_coord
@@ -6715,8 +6914,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="ProjectWithRepo_package.ProjectWithRepo_Update" project="MaintenanceProject:0">
-          <title/>
-          <description/>
+          <title>Moab Is My Washpot</title>
+          <description>Eius ut consequuntur nihil.</description>
           <releasename>ProjectWithRepo_package</releasename>
           <build>
             <enable repository="ProjectWithRepo_Update"/>
@@ -6742,13 +6941,13 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '330'
+      - '375'
     body:
       encoding: UTF-8
       string: |
         <package name="ProjectWithRepo_package.ProjectWithRepo_Update" project="MaintenanceProject:0">
-          <title></title>
-          <description></description>
+          <title>Moab Is My Washpot</title>
+          <description>Eius ut consequuntur nihil.</description>
           <releasename>ProjectWithRepo_package</releasename>
           <build>
             <enable repository="ProjectWithRepo_Update" />
@@ -6756,7 +6955,7 @@ http_interactions:
           </build>
         </package>
     http_version: 
-  recorded_at: Mon, 19 Dec 2016 16:17:01 GMT
+  recorded_at: Mon, 21 Aug 2017 14:07:34 GMT
 - request:
     method: get
     uri: http://localhost:3200/source/MaintenanceProject:0/ProjectWithRepo_package.ProjectWithRepo_Update
@@ -6786,14 +6985,14 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="ProjectWithRepo_package.ProjectWithRepo_Update" rev="3" vrev="3" srcmd5="0053dbbf7ed92619a79c971b291714f6">
-          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" srcmd5="93f9e495c18a6fc43a1efa793a3aa72f" baserev="93f9e495c18a6fc43a1efa793a3aa72f" xsrcmd5="48c3d6c78f0296d44dda7b080229f33e" lsrcmd5="0053dbbf7ed92619a79c971b291714f6" />
-          <entry name="_config" md5="822bf2a29d1fd3fb4a6518a86e9dcd2b" size="131" mtime="1482164200" />
-          <entry name="_link" md5="3df31df42a72a87eda7d83111e64ec3e" size="164" mtime="1482164209" />
-          <entry name="somefile.txt" md5="791025267dcc9c8ad8c462c3835a8c2f" size="150" mtime="1482164200" />
+        <directory name="ProjectWithRepo_package.ProjectWithRepo_Update" rev="7" vrev="7" srcmd5="86a991e1d0fb1e255e605e346b8c71b2">
+          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" srcmd5="09e82b0920e2079611427fc5ae96b076" baserev="09e82b0920e2079611427fc5ae96b076" xsrcmd5="dd8fee4cd9676519d6bc95db70858eac" lsrcmd5="86a991e1d0fb1e255e605e346b8c71b2" />
+          <entry name="_config" md5="55041d03ef8e31e551b3edd00464f7ea" size="103" mtime="1503324439" />
+          <entry name="_link" md5="3f7843b2f03812aa3a4c42dd85f1b177" size="164" mtime="1503324445" />
+          <entry name="somefile.txt" md5="72a89c51cb636651b1da704fa7b303ee" size="160" mtime="1503324439" />
         </directory>
     http_version: 
-  recorded_at: Mon, 19 Dec 2016 16:17:01 GMT
+  recorded_at: Mon, 21 Aug 2017 14:07:34 GMT
 - request:
     method: get
     uri: http://localhost:3200/source/MaintenanceProject:0/ProjectWithRepo_package.ProjectWithRepo_Update
@@ -6823,14 +7022,14 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="ProjectWithRepo_package.ProjectWithRepo_Update" rev="3" vrev="3" srcmd5="0053dbbf7ed92619a79c971b291714f6">
-          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" srcmd5="93f9e495c18a6fc43a1efa793a3aa72f" baserev="93f9e495c18a6fc43a1efa793a3aa72f" xsrcmd5="48c3d6c78f0296d44dda7b080229f33e" lsrcmd5="0053dbbf7ed92619a79c971b291714f6" />
-          <entry name="_config" md5="822bf2a29d1fd3fb4a6518a86e9dcd2b" size="131" mtime="1482164200" />
-          <entry name="_link" md5="3df31df42a72a87eda7d83111e64ec3e" size="164" mtime="1482164209" />
-          <entry name="somefile.txt" md5="791025267dcc9c8ad8c462c3835a8c2f" size="150" mtime="1482164200" />
+        <directory name="ProjectWithRepo_package.ProjectWithRepo_Update" rev="7" vrev="7" srcmd5="86a991e1d0fb1e255e605e346b8c71b2">
+          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" srcmd5="09e82b0920e2079611427fc5ae96b076" baserev="09e82b0920e2079611427fc5ae96b076" xsrcmd5="dd8fee4cd9676519d6bc95db70858eac" lsrcmd5="86a991e1d0fb1e255e605e346b8c71b2" />
+          <entry name="_config" md5="55041d03ef8e31e551b3edd00464f7ea" size="103" mtime="1503324439" />
+          <entry name="_link" md5="3f7843b2f03812aa3a4c42dd85f1b177" size="164" mtime="1503324445" />
+          <entry name="somefile.txt" md5="72a89c51cb636651b1da704fa7b303ee" size="160" mtime="1503324439" />
         </directory>
     http_version: 
-  recorded_at: Mon, 19 Dec 2016 16:17:01 GMT
+  recorded_at: Mon, 21 Aug 2017 14:07:34 GMT
 - request:
     method: get
     uri: http://localhost:3200/source/MaintenanceProject:0/ProjectWithRepo_package.ProjectWithRepo_Update
@@ -6860,14 +7059,14 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="ProjectWithRepo_package.ProjectWithRepo_Update" rev="3" vrev="3" srcmd5="0053dbbf7ed92619a79c971b291714f6">
-          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" srcmd5="93f9e495c18a6fc43a1efa793a3aa72f" baserev="93f9e495c18a6fc43a1efa793a3aa72f" xsrcmd5="48c3d6c78f0296d44dda7b080229f33e" lsrcmd5="0053dbbf7ed92619a79c971b291714f6" />
-          <entry name="_config" md5="822bf2a29d1fd3fb4a6518a86e9dcd2b" size="131" mtime="1482164200" />
-          <entry name="_link" md5="3df31df42a72a87eda7d83111e64ec3e" size="164" mtime="1482164209" />
-          <entry name="somefile.txt" md5="791025267dcc9c8ad8c462c3835a8c2f" size="150" mtime="1482164200" />
+        <directory name="ProjectWithRepo_package.ProjectWithRepo_Update" rev="7" vrev="7" srcmd5="86a991e1d0fb1e255e605e346b8c71b2">
+          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" srcmd5="09e82b0920e2079611427fc5ae96b076" baserev="09e82b0920e2079611427fc5ae96b076" xsrcmd5="dd8fee4cd9676519d6bc95db70858eac" lsrcmd5="86a991e1d0fb1e255e605e346b8c71b2" />
+          <entry name="_config" md5="55041d03ef8e31e551b3edd00464f7ea" size="103" mtime="1503324439" />
+          <entry name="_link" md5="3f7843b2f03812aa3a4c42dd85f1b177" size="164" mtime="1503324445" />
+          <entry name="somefile.txt" md5="72a89c51cb636651b1da704fa7b303ee" size="160" mtime="1503324439" />
         </directory>
     http_version: 
-  recorded_at: Mon, 19 Dec 2016 16:17:01 GMT
+  recorded_at: Mon, 21 Aug 2017 14:07:34 GMT
 - request:
     method: post
     uri: http://localhost:3200/search/package/id?match=(linkinfo/@package=%22ProjectWithRepo_package%22%20and%20linkinfo/@project=%22ProjectWithRepo%22%20and%20@project=%22ProjectWithRepo%22)
@@ -6902,7 +7101,7 @@ http_interactions:
         <collection>
         </collection>
     http_version: 
-  recorded_at: Mon, 19 Dec 2016 16:17:01 GMT
+  recorded_at: Mon, 21 Aug 2017 14:07:34 GMT
 - request:
     method: put
     uri: http://localhost:3200/source/MaintenanceProject:0/_meta?user=maintenance_coord
@@ -6967,7 +7166,7 @@ http_interactions:
           </repository>
         </project>
     http_version: 
-  recorded_at: Mon, 19 Dec 2016 16:17:01 GMT
+  recorded_at: Mon, 21 Aug 2017 14:07:34 GMT
 - request:
     method: put
     uri: http://localhost:3200/source/MaintenanceProject:0/_meta?user=maintenance_coord
@@ -7032,7 +7231,7 @@ http_interactions:
           </repository>
         </project>
     http_version: 
-  recorded_at: Mon, 19 Dec 2016 16:17:01 GMT
+  recorded_at: Mon, 21 Aug 2017 14:07:34 GMT
 - request:
     method: post
     uri: http://localhost:3200/source/MaintenanceProject:0/ProjectWithRepo_package.ProjectWithRepo_Update?cmd=copy&comment=Maintenance%20incident%20copy%20from%20project%20home:tom:branches:ProjectWithRepo:Update&expand=1&keeplink=1&opackage=ProjectWithRepo_package&oproject=home:tom:branches:ProjectWithRepo:Update&requestid=2&user=maintenance_coord&withacceptinfo=1
@@ -7064,17 +7263,66 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <revision rev="4" vrev="4">
-          <srcmd5>e7c498767ab7fa6a266e609e36388ce6</srcmd5>
+        <revision rev="8" vrev="8">
+          <srcmd5>8c95ac173db372e4ec3afc73fe679c4a</srcmd5>
           <version>unknown</version>
-          <time>1482164221</time>
+          <time>1503324454</time>
           <user>maintenance_coord</user>
           <comment>Maintenance incident copy from project home:tom:branches:ProjectWithRepo:Update</comment>
           <requestid>2</requestid>
-          <acceptinfo rev="4" srcmd5="e7c498767ab7fa6a266e609e36388ce6" osrcmd5="0053dbbf7ed92619a79c971b291714f6" xsrcmd5="944396236b51ae1a97683a3eceb14d7f" oxsrcmd5="48c3d6c78f0296d44dda7b080229f33e" />
+          <acceptinfo rev="8" srcmd5="8c95ac173db372e4ec3afc73fe679c4a" osrcmd5="86a991e1d0fb1e255e605e346b8c71b2" xsrcmd5="6c2a823ba5d861d74d5c25e6ef62df17" oxsrcmd5="dd8fee4cd9676519d6bc95db70858eac" />
         </revision>
     http_version: 
-  recorded_at: Mon, 19 Dec 2016 16:17:01 GMT
+  recorded_at: Mon, 21 Aug 2017 14:07:34 GMT
+- request:
+    method: put
+    uri: http://localhost:3200/source/MaintenanceProject:0/ProjectWithRepo_package.ProjectWithRepo_Update/_meta?user=maintenance_coord
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="ProjectWithRepo_package.ProjectWithRepo_Update" project="MaintenanceProject:0">
+          <title>Moab Is My Washpot</title>
+          <description>Eius ut consequuntur nihil.</description>
+          <releasename>ProjectWithRepo_package</releasename>
+          <build>
+            <enable repository="ProjectWithRepo_Update"/>
+            <enable repository="ProjectWithRepo_Update"/>
+          </build>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '375'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="ProjectWithRepo_package.ProjectWithRepo_Update" project="MaintenanceProject:0">
+          <title>Moab Is My Washpot</title>
+          <description>Eius ut consequuntur nihil.</description>
+          <releasename>ProjectWithRepo_package</releasename>
+          <build>
+            <enable repository="ProjectWithRepo_Update" />
+            <enable repository="ProjectWithRepo_Update" />
+          </build>
+        </package>
+    http_version: 
+  recorded_at: Mon, 21 Aug 2017 14:07:34 GMT
 - request:
     method: get
     uri: http://localhost:3200/source/MaintenanceProject:0/ProjectWithRepo_package.ProjectWithRepo_Update
@@ -7104,15 +7352,15 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="ProjectWithRepo_package.ProjectWithRepo_Update" rev="4" vrev="4" srcmd5="e7c498767ab7fa6a266e609e36388ce6">
-          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" srcmd5="93f9e495c18a6fc43a1efa793a3aa72f" baserev="93f9e495c18a6fc43a1efa793a3aa72f" xsrcmd5="944396236b51ae1a97683a3eceb14d7f" lsrcmd5="e7c498767ab7fa6a266e609e36388ce6" />
-          <entry name="DUMMY_FILE" md5="275876e34cf609db118f3d84b799a790" size="5" mtime="1482164204" />
-          <entry name="_config" md5="822bf2a29d1fd3fb4a6518a86e9dcd2b" size="131" mtime="1482164200" />
-          <entry name="_link" md5="3df31df42a72a87eda7d83111e64ec3e" size="164" mtime="1482164209" />
-          <entry name="somefile.txt" md5="791025267dcc9c8ad8c462c3835a8c2f" size="150" mtime="1482164200" />
+        <directory name="ProjectWithRepo_package.ProjectWithRepo_Update" rev="8" vrev="8" srcmd5="8c95ac173db372e4ec3afc73fe679c4a">
+          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" srcmd5="09e82b0920e2079611427fc5ae96b076" baserev="09e82b0920e2079611427fc5ae96b076" xsrcmd5="6c2a823ba5d861d74d5c25e6ef62df17" lsrcmd5="8c95ac173db372e4ec3afc73fe679c4a" />
+          <entry name="DUMMY_FILE" md5="275876e34cf609db118f3d84b799a790" size="5" mtime="1503324268" />
+          <entry name="_config" md5="55041d03ef8e31e551b3edd00464f7ea" size="103" mtime="1503324439" />
+          <entry name="_link" md5="3f7843b2f03812aa3a4c42dd85f1b177" size="164" mtime="1503324445" />
+          <entry name="somefile.txt" md5="72a89c51cb636651b1da704fa7b303ee" size="160" mtime="1503324439" />
         </directory>
     http_version: 
-  recorded_at: Mon, 19 Dec 2016 16:17:01 GMT
+  recorded_at: Mon, 21 Aug 2017 14:07:34 GMT
 - request:
     method: get
     uri: http://localhost:3200/source/MaintenanceProject:0/ProjectWithRepo_package.ProjectWithRepo_Update?nofilename=1&view=info&withchangesmd5=1
@@ -7138,17 +7386,17 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '416'
+      - '417'
     body:
       encoding: UTF-8
       string: |
-        <sourceinfo package="ProjectWithRepo_package.ProjectWithRepo_Update" rev="4" vrev="6" srcmd5="944396236b51ae1a97683a3eceb14d7f" lsrcmd5="e7c498767ab7fa6a266e609e36388ce6" verifymd5="9516aebf6b10ac890d8c2905f7a35185">
+        <sourceinfo package="ProjectWithRepo_package.ProjectWithRepo_Update" rev="8" vrev="12" srcmd5="6c2a823ba5d861d74d5c25e6ef62df17" lsrcmd5="8c95ac173db372e4ec3afc73fe679c4a" verifymd5="20df9d21809f8c811abf5fe64b26d948">
           <linked project="ProjectWithRepo:Update" package="ProjectWithRepo_package" />
           <linked project="ProjectWithRepo" package="ProjectWithRepo_package" />
-          <revtime>1482164221</revtime>
+          <revtime>1503324454</revtime>
         </sourceinfo>
     http_version: 
-  recorded_at: Mon, 19 Dec 2016 16:17:01 GMT
+  recorded_at: Mon, 21 Aug 2017 14:07:34 GMT
 - request:
     method: get
     uri: http://localhost:3200/source/MaintenanceProject:0/ProjectWithRepo_package.ProjectWithRepo_Update
@@ -7178,15 +7426,15 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="ProjectWithRepo_package.ProjectWithRepo_Update" rev="4" vrev="4" srcmd5="e7c498767ab7fa6a266e609e36388ce6">
-          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" srcmd5="93f9e495c18a6fc43a1efa793a3aa72f" baserev="93f9e495c18a6fc43a1efa793a3aa72f" xsrcmd5="944396236b51ae1a97683a3eceb14d7f" lsrcmd5="e7c498767ab7fa6a266e609e36388ce6" />
-          <entry name="DUMMY_FILE" md5="275876e34cf609db118f3d84b799a790" size="5" mtime="1482164204" />
-          <entry name="_config" md5="822bf2a29d1fd3fb4a6518a86e9dcd2b" size="131" mtime="1482164200" />
-          <entry name="_link" md5="3df31df42a72a87eda7d83111e64ec3e" size="164" mtime="1482164209" />
-          <entry name="somefile.txt" md5="791025267dcc9c8ad8c462c3835a8c2f" size="150" mtime="1482164200" />
+        <directory name="ProjectWithRepo_package.ProjectWithRepo_Update" rev="8" vrev="8" srcmd5="8c95ac173db372e4ec3afc73fe679c4a">
+          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" srcmd5="09e82b0920e2079611427fc5ae96b076" baserev="09e82b0920e2079611427fc5ae96b076" xsrcmd5="6c2a823ba5d861d74d5c25e6ef62df17" lsrcmd5="8c95ac173db372e4ec3afc73fe679c4a" />
+          <entry name="DUMMY_FILE" md5="275876e34cf609db118f3d84b799a790" size="5" mtime="1503324268" />
+          <entry name="_config" md5="55041d03ef8e31e551b3edd00464f7ea" size="103" mtime="1503324439" />
+          <entry name="_link" md5="3f7843b2f03812aa3a4c42dd85f1b177" size="164" mtime="1503324445" />
+          <entry name="somefile.txt" md5="72a89c51cb636651b1da704fa7b303ee" size="160" mtime="1503324439" />
         </directory>
     http_version: 
-  recorded_at: Mon, 19 Dec 2016 16:17:01 GMT
+  recorded_at: Mon, 21 Aug 2017 14:07:34 GMT
 - request:
     method: post
     uri: http://localhost:3200/source/MaintenanceProject:0/ProjectWithRepo_package.ProjectWithRepo_Update?cmd=diff&linkrev=base&onlyissues=1&orev=0&view=xml
@@ -7218,15 +7466,15 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="e5cbd42a6dc89f546d979ae6b035355b">
+        <sourcediff key="19494ad5fd9a44aa388f5358268d23f5">
           <old project="MaintenanceProject:0" package="ProjectWithRepo_package.ProjectWithRepo_Update" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e" />
-          <new project="MaintenanceProject:0" package="ProjectWithRepo_package.ProjectWithRepo_Update" rev="2" srcmd5="e7c498767ab7fa6a266e609e36388ce6" />
+          <new project="MaintenanceProject:0" package="ProjectWithRepo_package.ProjectWithRepo_Update" rev="6" srcmd5="8c95ac173db372e4ec3afc73fe679c4a" />
           <files />
           <issues>
           </issues>
         </sourcediff>
     http_version: 
-  recorded_at: Mon, 19 Dec 2016 16:17:01 GMT
+  recorded_at: Mon, 21 Aug 2017 14:07:34 GMT
 - request:
     method: post
     uri: http://localhost:3200/source/MaintenanceProject:0/ProjectWithRepo_package.ProjectWithRepo_Update?cmd=linkdiff&linkrev=base&onlyissues=1&view=xml
@@ -7258,15 +7506,15 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="092e38953ee0bc92c035219689a05d5d">
-          <old project="ProjectWithRepo:Update" package="ProjectWithRepo_package" rev="93f9e495c18a6fc43a1efa793a3aa72f" srcmd5="93f9e495c18a6fc43a1efa793a3aa72f" />
-          <new project="MaintenanceProject:0" package="ProjectWithRepo_package.ProjectWithRepo_Update" rev="944396236b51ae1a97683a3eceb14d7f" srcmd5="944396236b51ae1a97683a3eceb14d7f" />
+        <sourcediff key="ace3a4b15a241d14542026ae3c8365c9">
+          <old project="ProjectWithRepo:Update" package="ProjectWithRepo_package" rev="09e82b0920e2079611427fc5ae96b076" srcmd5="09e82b0920e2079611427fc5ae96b076" />
+          <new project="MaintenanceProject:0" package="ProjectWithRepo_package.ProjectWithRepo_Update" rev="6c2a823ba5d861d74d5c25e6ef62df17" srcmd5="6c2a823ba5d861d74d5c25e6ef62df17" />
           <files />
           <issues>
           </issues>
         </sourcediff>
     http_version: 
-  recorded_at: Mon, 19 Dec 2016 16:17:01 GMT
+  recorded_at: Mon, 21 Aug 2017 14:07:35 GMT
 - request:
     method: put
     uri: http://localhost:3200/source/MaintenanceProject:0/_meta?comment=maintenance_incident%20request%202&requestid=2&user=maintenance_coord
@@ -7331,10 +7579,10 @@ http_interactions:
           </repository>
         </project>
     http_version: 
-  recorded_at: Mon, 19 Dec 2016 16:17:02 GMT
+  recorded_at: Mon, 21 Aug 2017 14:07:35 GMT
 - request:
     method: post
-    uri: http://localhost:3200/source/MaintenanceProject:0/ProjectWithRepo_package.ProjectWithRepo_Update?cmd=diff&orev=48c3d6c78f0296d44dda7b080229f33e&rev=944396236b51ae1a97683a3eceb14d7f&view=xml&withissues=1
+    uri: http://localhost:3200/source/MaintenanceProject:0/ProjectWithRepo_package.ProjectWithRepo_Update?cmd=diff&orev=dd8fee4cd9676519d6bc95db70858eac&rev=6c2a823ba5d861d74d5c25e6ef62df17&view=xml&withissues=1
     body:
       encoding: UTF-8
       string: ''
@@ -7355,7 +7603,7 @@ http_interactions:
       Content-Type:
       - text/xml
       Content-Length:
-      - '664'
+      - '666'
       Cache-Control:
       - no-cache
       Connection:
@@ -7363,13 +7611,13 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="66060ac80e33a39fe7d10c079abc4ce2">
-          <old project="MaintenanceProject:0" package="ProjectWithRepo_package.ProjectWithRepo_Update" rev="48c3d6c78f0296d44dda7b080229f33e" srcmd5="48c3d6c78f0296d44dda7b080229f33e" />
-          <new project="MaintenanceProject:0" package="ProjectWithRepo_package.ProjectWithRepo_Update" rev="944396236b51ae1a97683a3eceb14d7f" srcmd5="944396236b51ae1a97683a3eceb14d7f" />
+        <sourcediff key="42b22c4ac987fc87d14e33de37bd0f10">
+          <old project="MaintenanceProject:0" package="ProjectWithRepo_package.ProjectWithRepo_Update" rev="dd8fee4cd9676519d6bc95db70858eac" srcmd5="dd8fee4cd9676519d6bc95db70858eac" />
+          <new project="MaintenanceProject:0" package="ProjectWithRepo_package.ProjectWithRepo_Update" rev="6c2a823ba5d861d74d5c25e6ef62df17" srcmd5="6c2a823ba5d861d74d5c25e6ef62df17" />
           <files>
             <file state="added">
               <new name="DUMMY_FILE" md5="275876e34cf609db118f3d84b799a790" size="5" />
-              <diff lines="3">@@ -0,0 +1 @@
+              <diff lines="3">@@ -0,0 +1,1 @@
         +dummy
         \ No newline at end of file
         </diff>
@@ -7379,7 +7627,7 @@ http_interactions:
           </issues>
         </sourcediff>
     http_version: 
-  recorded_at: Mon, 19 Dec 2016 16:17:02 GMT
+  recorded_at: Mon, 21 Aug 2017 14:07:35 GMT
 - request:
     method: get
     uri: http://localhost:3200/build/home:tom:branches:ProjectWithRepo:Update/_result?package=ProjectWithRepo_package&view=status
@@ -7415,10 +7663,10 @@ http_interactions:
           <result project="home:tom:branches:ProjectWithRepo:Update" repository="repository_2" arch="i586" code="unknown" state="unknown" />
         </resultlist>
     http_version: 
-  recorded_at: Mon, 19 Dec 2016 16:17:02 GMT
+  recorded_at: Mon, 21 Aug 2017 14:07:35 GMT
 - request:
     method: get
-    uri: http://localhost:3200/build/home:tom:branches:ProjectWithRepo:Update/_result?package=ProjectWithRepo_package&view=status
+    uri: http://localhost:3200/build/home:tom:branches:ProjectWithRepo:Update/_result?locallink=1&multibuild=1&package=ProjectWithRepo_package&view=status
     body:
       encoding: US-ASCII
       string: ''
@@ -7451,44 +7699,7 @@ http_interactions:
           <result project="home:tom:branches:ProjectWithRepo:Update" repository="repository_2" arch="i586" code="unknown" state="unknown" />
         </resultlist>
     http_version: 
-  recorded_at: Mon, 19 Dec 2016 16:17:02 GMT
-- request:
-    method: get
-    uri: http://localhost:3200/build/home:tom:branches:ProjectWithRepo:Update/repository_2/i586/ProjectWithRepo_package/rpmlint.log
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Content-Type:
-      - text/plain
-      Accept-Encoding:
-      - identity
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 404
-      message: rpmlint.log  No such file or directory
-    headers:
-      Content-Type:
-      - text/xml
-      Content-Length:
-      - '154'
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-    body:
-      encoding: UTF-8
-      string: |
-        <status code="404">
-          <summary>rpmlint.log: No such file or directory</summary>
-          <details>404 rpmlint.log: No such file or directory</details>
-        </status>
-    http_version: 
-  recorded_at: Mon, 19 Dec 2016 16:17:02 GMT
+  recorded_at: Mon, 21 Aug 2017 14:07:35 GMT
 - request:
     method: get
     uri: http://localhost:3200/build/MaintenanceProject:0/_result?code=unresolvable&view=status
@@ -7524,7 +7735,7 @@ http_interactions:
           <result project="MaintenanceProject:0" repository="ProjectWithRepo_Update" arch="i586" code="unknown" state="unknown" />
         </resultlist>
     http_version: 
-  recorded_at: Mon, 19 Dec 2016 16:17:02 GMT
+  recorded_at: Mon, 21 Aug 2017 14:07:35 GMT
 - request:
     method: get
     uri: http://localhost:3200/source/MaintenanceProject:0/patchinfo
@@ -7554,11 +7765,11 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="patchinfo" rev="3" vrev="3" srcmd5="177d57906eba63ae56a64a367592144a">
-          <entry name="_patchinfo" md5="ac29f7f1abd9ef43afeb43fc7737c007" size="318" mtime="1482164213" />
+        <directory name="patchinfo" rev="6" vrev="6" srcmd5="177d57906eba63ae56a64a367592144a">
+          <entry name="_patchinfo" md5="ac29f7f1abd9ef43afeb43fc7737c007" size="318" mtime="1503324277" />
         </directory>
     http_version: 
-  recorded_at: Mon, 19 Dec 2016 16:17:02 GMT
+  recorded_at: Mon, 21 Aug 2017 14:07:35 GMT
 - request:
     method: get
     uri: http://localhost:3200/build/MaintenanceProject:0/_result?view=summary
@@ -7596,7 +7807,7 @@ http_interactions:
           </result>
         </resultlist>
     http_version: 
-  recorded_at: Mon, 19 Dec 2016 16:17:02 GMT
+  recorded_at: Mon, 21 Aug 2017 14:07:35 GMT
 - request:
     method: get
     uri: http://localhost:3200/source/MaintenanceProject:0/ProjectWithRepo_package.ProjectWithRepo_Update
@@ -7626,15 +7837,15 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="ProjectWithRepo_package.ProjectWithRepo_Update" rev="4" vrev="4" srcmd5="e7c498767ab7fa6a266e609e36388ce6">
-          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" srcmd5="93f9e495c18a6fc43a1efa793a3aa72f" baserev="93f9e495c18a6fc43a1efa793a3aa72f" xsrcmd5="944396236b51ae1a97683a3eceb14d7f" lsrcmd5="e7c498767ab7fa6a266e609e36388ce6" />
-          <entry name="DUMMY_FILE" md5="275876e34cf609db118f3d84b799a790" size="5" mtime="1482164204" />
-          <entry name="_config" md5="822bf2a29d1fd3fb4a6518a86e9dcd2b" size="131" mtime="1482164200" />
-          <entry name="_link" md5="3df31df42a72a87eda7d83111e64ec3e" size="164" mtime="1482164209" />
-          <entry name="somefile.txt" md5="791025267dcc9c8ad8c462c3835a8c2f" size="150" mtime="1482164200" />
+        <directory name="ProjectWithRepo_package.ProjectWithRepo_Update" rev="8" vrev="8" srcmd5="8c95ac173db372e4ec3afc73fe679c4a">
+          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" srcmd5="09e82b0920e2079611427fc5ae96b076" baserev="09e82b0920e2079611427fc5ae96b076" xsrcmd5="6c2a823ba5d861d74d5c25e6ef62df17" lsrcmd5="8c95ac173db372e4ec3afc73fe679c4a" />
+          <entry name="DUMMY_FILE" md5="275876e34cf609db118f3d84b799a790" size="5" mtime="1503324268" />
+          <entry name="_config" md5="55041d03ef8e31e551b3edd00464f7ea" size="103" mtime="1503324439" />
+          <entry name="_link" md5="3f7843b2f03812aa3a4c42dd85f1b177" size="164" mtime="1503324445" />
+          <entry name="somefile.txt" md5="72a89c51cb636651b1da704fa7b303ee" size="160" mtime="1503324439" />
         </directory>
     http_version: 
-  recorded_at: Mon, 19 Dec 2016 16:17:03 GMT
+  recorded_at: Mon, 21 Aug 2017 14:07:36 GMT
 - request:
     method: get
     uri: http://localhost:3200/source/MaintenanceProject:0/patchinfo
@@ -7664,11 +7875,11 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="patchinfo" rev="3" vrev="3" srcmd5="177d57906eba63ae56a64a367592144a">
-          <entry name="_patchinfo" md5="ac29f7f1abd9ef43afeb43fc7737c007" size="318" mtime="1482164213" />
+        <directory name="patchinfo" rev="6" vrev="6" srcmd5="177d57906eba63ae56a64a367592144a">
+          <entry name="_patchinfo" md5="ac29f7f1abd9ef43afeb43fc7737c007" size="318" mtime="1503324277" />
         </directory>
     http_version: 
-  recorded_at: Mon, 19 Dec 2016 16:17:03 GMT
+  recorded_at: Mon, 21 Aug 2017 14:07:36 GMT
 - request:
     method: get
     uri: http://localhost:3200/build/MaintenanceProject:0/_result?view=versrel
@@ -7702,7 +7913,7 @@ http_interactions:
           <result project="MaintenanceProject:0" repository="ProjectWithRepo_Update" arch="i586" code="unknown" state="unknown" />
         </resultlist>
     http_version: 
-  recorded_at: Mon, 19 Dec 2016 16:17:03 GMT
+  recorded_at: Mon, 21 Aug 2017 14:07:36 GMT
 - request:
     method: get
     uri: http://localhost:3200/build/MaintenanceProject:0/_result?code=unresolvable&view=status
@@ -7738,7 +7949,7 @@ http_interactions:
           <result project="MaintenanceProject:0" repository="ProjectWithRepo_Update" arch="i586" code="unknown" state="unknown" />
         </resultlist>
     http_version: 
-  recorded_at: Mon, 19 Dec 2016 16:17:03 GMT
+  recorded_at: Mon, 21 Aug 2017 14:07:36 GMT
 - request:
     method: get
     uri: http://localhost:3200/source/MaintenanceProject:0/patchinfo
@@ -7768,11 +7979,11 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="patchinfo" rev="3" vrev="3" srcmd5="177d57906eba63ae56a64a367592144a">
-          <entry name="_patchinfo" md5="ac29f7f1abd9ef43afeb43fc7737c007" size="318" mtime="1482164213" />
+        <directory name="patchinfo" rev="6" vrev="6" srcmd5="177d57906eba63ae56a64a367592144a">
+          <entry name="_patchinfo" md5="ac29f7f1abd9ef43afeb43fc7737c007" size="318" mtime="1503324277" />
         </directory>
     http_version: 
-  recorded_at: Mon, 19 Dec 2016 16:17:03 GMT
+  recorded_at: Mon, 21 Aug 2017 14:07:36 GMT
 - request:
     method: get
     uri: http://localhost:3200/build/MaintenanceProject:0/_result?view=summary
@@ -7810,648 +8021,5 @@ http_interactions:
           </result>
         </resultlist>
     http_version: 
-  recorded_at: Mon, 19 Dec 2016 16:17:03 GMT
-- request:
-    method: get
-    uri: http://localhost:3200/source/home:tom:branches:ProjectWithRepo:Update/_keyinfo?withsslcert=1
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '12'
-    body:
-      encoding: UTF-8
-      string: "<keyinfo />\n"
-    http_version: 
-  recorded_at: Mon, 09 Jan 2017 12:00:48 GMT
-- request:
-    method: get
-    uri: http://localhost:3200/source/home:tom:branches:ProjectWithRepo:Update/_keyinfo?withsslcert=1
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '12'
-    body:
-      encoding: UTF-8
-      string: "<keyinfo />\n"
-    http_version: 
-  recorded_at: Mon, 09 Jan 2017 12:00:48 GMT
-- request:
-    method: get
-    uri: http://localhost:3200/source/home:tom:branches:ProjectWithRepo:Update/_keyinfo?withsslcert=1
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '12'
-    body:
-      encoding: UTF-8
-      string: "<keyinfo />\n"
-    http_version: 
-  recorded_at: Mon, 09 Jan 2017 12:00:49 GMT
-- request:
-    method: get
-    uri: http://localhost:3200/source/home:tom:branches:ProjectWithRepo:Update/_keyinfo?withsslcert=1
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '12'
-    body:
-      encoding: UTF-8
-      string: "<keyinfo />\n"
-    http_version: 
-  recorded_at: Mon, 09 Jan 2017 12:00:49 GMT
-- request:
-    method: get
-    uri: http://localhost:3200/source/home:tom:branches:ProjectWithRepo:Update/_keyinfo?withsslcert=1
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '12'
-    body:
-      encoding: UTF-8
-      string: "<keyinfo />\n"
-    http_version: 
-  recorded_at: Mon, 09 Jan 2017 12:00:56 GMT
-- request:
-    method: get
-    uri: http://localhost:3200/source/home:tom:branches:ProjectWithRepo:Update/_keyinfo?withsslcert=1
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '12'
-    body:
-      encoding: UTF-8
-      string: "<keyinfo />\n"
-    http_version: 
-  recorded_at: Mon, 09 Jan 2017 12:00:56 GMT
-- request:
-    method: get
-    uri: http://localhost:3200/source/home:tom:branches:ProjectWithRepo:Update/_keyinfo?withsslcert=1
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '12'
-    body:
-      encoding: UTF-8
-      string: "<keyinfo />\n"
-    http_version: 
-  recorded_at: Mon, 09 Jan 2017 12:00:56 GMT
-- request:
-    method: get
-    uri: http://localhost:3200/source/home:tom:branches:ProjectWithRepo:Update/_keyinfo?withsslcert=1
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '12'
-    body:
-      encoding: UTF-8
-      string: "<keyinfo />\n"
-    http_version: 
-  recorded_at: Mon, 09 Jan 2017 12:00:56 GMT
-- request:
-    method: get
-    uri: http://localhost:3200/build/ProjectWithRepo/_result?locallink=1&multibuild=1&package=ProjectWithRepo_package&view=status
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Content-Type:
-      - text/plain
-      Accept-Encoding:
-      - identity
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 404
-      message: project 'ProjectWithRepo' does not exist
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '158'
-    body:
-      encoding: UTF-8
-      string: |
-        <status code="404">
-          <summary>project 'ProjectWithRepo' does not exist</summary>
-          <details>404 project 'ProjectWithRepo' does not exist</details>
-        </status>
-    http_version: 
-  recorded_at: Mon, 13 Feb 2017 15:58:30 GMT
-- request:
-    method: get
-    uri: http://localhost:3200/build/home:tom:branches:ProjectWithRepo:Update/_result?locallink=1&multibuild=1&package=ProjectWithRepo_package&view=status
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Content-Type:
-      - text/plain
-      Accept-Encoding:
-      - identity
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 404
-      message: project 'home tom branches ProjectWithRepo Update' does not exist
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '208'
-    body:
-      encoding: UTF-8
-      string: |
-        <status code="404">
-          <summary>project 'home:tom:branches:ProjectWithRepo:Update' does not exist</summary>
-          <details>404 project 'home:tom:branches:ProjectWithRepo:Update' does not exist</details>
-        </status>
-    http_version: 
-  recorded_at: Mon, 13 Feb 2017 15:58:32 GMT
-- request:
-    method: get
-    uri: http://localhost:3200/source/home:tom:branches:ProjectWithRepo:Update/_keyinfo
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '12'
-    body:
-      encoding: UTF-8
-      string: "<keyinfo />\n"
-    http_version: 
-  recorded_at: Mon, 13 Feb 2017 15:58:32 GMT
-- request:
-    method: get
-    uri: http://localhost:3200/build/home:tom:branches:ProjectWithRepo:Update/_result?locallink=1&multibuild=1&package=ProjectWithRepo_package&view=status
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Content-Type:
-      - text/plain
-      Accept-Encoding:
-      - identity
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 404
-      message: project 'home tom branches ProjectWithRepo Update' does not exist
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '208'
-    body:
-      encoding: UTF-8
-      string: |
-        <status code="404">
-          <summary>project 'home:tom:branches:ProjectWithRepo:Update' does not exist</summary>
-          <details>404 project 'home:tom:branches:ProjectWithRepo:Update' does not exist</details>
-        </status>
-    http_version: 
-  recorded_at: Mon, 13 Feb 2017 15:58:35 GMT
-- request:
-    method: get
-    uri: http://localhost:3200/build/home:tom:branches:ProjectWithRepo:Update/_result?locallink=1&multibuild=1&package=ProjectWithRepo_package&view=status
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Content-Type:
-      - text/plain
-      Accept-Encoding:
-      - identity
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 404
-      message: project 'home tom branches ProjectWithRepo Update' does not exist
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '208'
-    body:
-      encoding: UTF-8
-      string: |
-        <status code="404">
-          <summary>project 'home:tom:branches:ProjectWithRepo:Update' does not exist</summary>
-          <details>404 project 'home:tom:branches:ProjectWithRepo:Update' does not exist</details>
-        </status>
-    http_version: 
-  recorded_at: Mon, 13 Feb 2017 15:58:36 GMT
-- request:
-    method: get
-    uri: http://localhost:3200/build/home:tom:branches:ProjectWithRepo:Update/_result?locallink=1&multibuild=1&package=ProjectWithRepo_package&view=status
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Content-Type:
-      - text/plain
-      Accept-Encoding:
-      - identity
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 404
-      message: project 'home tom branches ProjectWithRepo Update' does not exist
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '208'
-    body:
-      encoding: UTF-8
-      string: |
-        <status code="404">
-          <summary>project 'home:tom:branches:ProjectWithRepo:Update' does not exist</summary>
-          <details>404 project 'home:tom:branches:ProjectWithRepo:Update' does not exist</details>
-        </status>
-    http_version: 
-  recorded_at: Mon, 13 Feb 2017 15:58:41 GMT
-- request:
-    method: get
-    uri: http://localhost:3200/build/home:tom:branches:ProjectWithRepo:Update/_result?locallink=1&multibuild=1&package=ProjectWithRepo_package&view=status
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Content-Type:
-      - text/plain
-      Accept-Encoding:
-      - identity
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 404
-      message: project 'home tom branches ProjectWithRepo Update' does not exist
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '208'
-    body:
-      encoding: UTF-8
-      string: |
-        <status code="404">
-          <summary>project 'home:tom:branches:ProjectWithRepo:Update' does not exist</summary>
-          <details>404 project 'home:tom:branches:ProjectWithRepo:Update' does not exist</details>
-        </status>
-    http_version: 
-  recorded_at: Mon, 13 Feb 2017 15:58:42 GMT
-- request:
-    method: get
-    uri: http://localhost:3200/build/home:tom:branches:ProjectWithRepo:Update/_result?locallink=1&multibuild=1&package=ProjectWithRepo_package&view=status
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Content-Type:
-      - text/plain
-      Accept-Encoding:
-      - identity
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 404
-      message: project 'home tom branches ProjectWithRepo Update' does not exist
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '208'
-    body:
-      encoding: UTF-8
-      string: |
-        <status code="404">
-          <summary>project 'home:tom:branches:ProjectWithRepo:Update' does not exist</summary>
-          <details>404 project 'home:tom:branches:ProjectWithRepo:Update' does not exist</details>
-        </status>
-    http_version: 
-  recorded_at: Mon, 13 Feb 2017 15:58:42 GMT
-- request:
-    method: get
-    uri: http://localhost:3200/build/home:tom:branches:ProjectWithRepo:Update/_result?locallink=1&multibuild=1&package=ProjectWithRepo_package&view=status
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Content-Type:
-      - text/plain
-      Accept-Encoding:
-      - identity
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 404
-      message: project 'home tom branches ProjectWithRepo Update' does not exist
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '208'
-    body:
-      encoding: UTF-8
-      string: |
-        <status code="404">
-          <summary>project 'home:tom:branches:ProjectWithRepo:Update' does not exist</summary>
-          <details>404 project 'home:tom:branches:ProjectWithRepo:Update' does not exist</details>
-        </status>
-    http_version: 
-  recorded_at: Mon, 13 Feb 2017 15:58:43 GMT
-- request:
-    method: get
-    uri: http://localhost:3200/build/ProjectWithRepo:Update/_result?locallink=1&multibuild=1&package=ProjectWithRepo_package&view=status
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Content-Type:
-      - text/plain
-      Accept-Encoding:
-      - identity
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 404
-      message: project 'ProjectWithRepo Update' does not exist
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '172'
-    body:
-      encoding: UTF-8
-      string: |
-        <status code="404">
-          <summary>project 'ProjectWithRepo:Update' does not exist</summary>
-          <details>404 project 'ProjectWithRepo:Update' does not exist</details>
-        </status>
-    http_version: 
-  recorded_at: Wed, 08 Mar 2017 15:39:19 GMT
-- request:
-    method: get
-    uri: http://localhost:3200/source/home:tom:branches:ProjectWithRepo:Update/_keyinfo?donotcreatecert=1&withsslcert=1
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '12'
-    body:
-      encoding: UTF-8
-      string: "<keyinfo />\n"
-    http_version: 
-  recorded_at: Mon, 08 May 2017 22:03:37 GMT
+  recorded_at: Mon, 21 Aug 2017 14:07:36 GMT
 recorded_with: VCR 3.0.3

--- a/src/api/spec/factories/attribs.rb
+++ b/src/api/spec/factories/attribs.rb
@@ -6,7 +6,7 @@ FactoryGirl.define do
       attrib_type { AttribType.find_by_namespace_and_name!('OBS', 'Maintained') }
     end
 
-    factory :maintainance_project_attrib do
+    factory :maintenance_project_attrib do
       attrib_type { AttribType.find_by_namespace_and_name!('OBS', 'MaintenanceProject') }
     end
 

--- a/src/api/spec/factories/project.rb
+++ b/src/api/spec/factories/project.rb
@@ -124,7 +124,7 @@ FactoryGirl.define do
       end
 
       after(:create) do |project, evaluator|
-        create(:maintainance_project_attrib, project: project)
+        create(:maintenance_project_attrib, project: project)
         if evaluator.target_project
           create(:maintained_project, project: evaluator.target_project, maintenance_project: project)
           CONFIG['global_write_through'] ? project.store : project.save!

--- a/src/api/spec/features/webui/maintenance_workflow_spec.rb
+++ b/src/api/spec/features/webui/maintenance_workflow_spec.rb
@@ -22,7 +22,7 @@ RSpec.feature 'MaintenanceWorkflow', type: :feature, js: true do
 
   before do
     User.current = admin_user
-    create(:maintainance_project_attrib, project: maintenance_project)
+    create(:maintenance_project_attrib, project: maintenance_project)
     User.current = nil
   end
 


### PR DESCRIPTION
Fix maintenance workflow cassettes. The file `spec/cassettes/MaintenanceWorkflow/maintenance_workflow.yml` was modified each time `spec/features/webui/maintenance_workflow_spec.rb` was run. After creating the cassettes again it isn't modified.