### PR TITLE
[api] refactor request access check

### DIFF
--- a/src/api/app/models/bs_request.rb
+++ b/src/api/app/models/bs_request.rb
@@ -949,24 +949,14 @@ class BsRequest < ApplicationRecord
 
   # Check if 'user' is maintainer in _all_ request targets:
   def is_target_maintainer?(user = User.current)
-    has_target, is_target_maintainer = false, true
+    matched = false
     bs_request_actions.each do |a|
       next unless a.target_project
-      if a.target_package
-        tpkg = Package.find_by_project_and_name(a.target_project, a.target_package)
-        if tpkg
-          has_target = true
-          is_target_maintainer &= user.can_modify_package?(tpkg)
-          next
-        end
-      end
-      tprj = Project.find_by_name(a.target_project)
-      if tprj
-        has_target = true
-        is_target_maintainer &= user.can_modify_project?(tprj)
-      end
+      # avoid to become target maintainer if no target is defined.
+      matched = true
+      return false unless a.is_target_maintainer?(user)
     end
-    has_target && is_target_maintainer
+    matched
   end
 
   def sanitize!

--- a/src/api/app/models/package.rb
+++ b/src/api/app/models/package.rb
@@ -187,7 +187,11 @@ class Package < ApplicationRecord
     return pkg if pkg
 
     prj = internal_get_project(project)
-    return unless prj # remote prjs
+    unless prj
+      # access check according to remote project
+      raise ReadAccessError, project unless Project.find_remote_project(project)
+      return
+    end
 
     if pkg.nil? && opts[:follow_project_links]
       pkg = prj.find_package(package, opts[:check_update_project])


### PR DESCRIPTION
* Use standard implementation in package model
* handle hidden remote project definitions
* simplify and fix is_target_maintainer? method
  It is not true anymore when no target exists. Might cause a regression,
  but it is at least matching the method name now, so we should fix on the
  other side in case.