### PR TITLE
Add missed package needed in bootstrap

### DIFF
--- a/contrib/bootstrap.sh
+++ b/contrib/bootstrap.sh
@@ -77,6 +77,7 @@ zypper -q -n install --replacefiles \
   ruby2.4-rubygem-ruby-ldap \
   ruby2.4-rubygem-xmlhash \
   ruby2.4-rubygem-thinking-sphinx\
+  ruby2.4-rubygem-thor-0_19 \
   ruby2.4-rubygem-foreman\
   perl-GD \
   perl-XML-Parser \

--- a/contrib/bootstrap.sh
+++ b/contrib/bootstrap.sh
@@ -16,7 +16,7 @@ function copy_example_file {
 }
 
 function check_for_databases {
-  echo "show databases" | mysql -u root --password=opensuse|grep -q api_ && return 0 || return 1
+  echo "show databases" | mysql -u root --password=opensuse | grep -q api_ && return 0 || return 1
 }
 
 function _prepare_bound_directory() {
@@ -76,9 +76,9 @@ zypper -q -n install --replacefiles \
   ruby2.4-rubygem-nokogiri \
   ruby2.4-rubygem-ruby-ldap \
   ruby2.4-rubygem-xmlhash \
-  ruby2.4-rubygem-thinking-sphinx\
+  ruby2.4-rubygem-thinking-sphinx \
   ruby2.4-rubygem-thor-0_19 \
-  ruby2.4-rubygem-foreman\
+  ruby2.4-rubygem-foreman \
   perl-GD \
   perl-XML-Parser \
   perl-Devel-Cover \


### PR DESCRIPTION
thor gem got updated to version 0.20 when updating git-cop to 1.6.0 in #3641 but thor 0.19 is needed for installing foreman in the vagrant machine.

I also add some missed spaces for readability and style coherence. :bowtie: 