### PR TITLE
Webui creates maintenance request without revision

### DIFF
--- a/src/api/app/controllers/webui/project_controller.rb
+++ b/src/api/app/controllers/webui/project_controller.rb
@@ -136,6 +136,7 @@ class Webui::ProjectController < Webui::WebuiController
         req.bs_request_actions << action
         action.bs_request = req
 
+        req.set_add_revision
         req.save!
       end
       flash[:success] = 'Created maintenance incident request'

--- a/src/api/spec/cassettes/MaintenanceWorkflow/maintenance_workflow.yml
+++ b/src/api/spec/cassettes/MaintenanceWorkflow/maintenance_workflow.yml
@@ -40,7 +40,7 @@ http_interactions:
           <person userid="user_1" role="maintainer" />
         </project>
     http_version: 
-  recorded_at: Mon, 21 Aug 2017 14:07:13 GMT
+  recorded_at: Tue, 22 Aug 2017 12:31:07 GMT
 - request:
     method: put
     uri: http://localhost:3200/source/ProjectWithRepo/_meta
@@ -48,7 +48,7 @@ http_interactions:
       encoding: UTF-8
       string: |
         <project name="ProjectWithRepo">
-          <title>Now Sleeps the Crimson Petal</title>
+          <title>The Moving Toyshop</title>
           <description/>
         </project>
     headers:
@@ -70,23 +70,23 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '120'
+      - '110'
     body:
       encoding: UTF-8
       string: |
         <project name="ProjectWithRepo">
-          <title>Now Sleeps the Crimson Petal</title>
+          <title>The Moving Toyshop</title>
           <description></description>
         </project>
     http_version: 
-  recorded_at: Mon, 21 Aug 2017 14:07:14 GMT
+  recorded_at: Tue, 22 Aug 2017 12:31:07 GMT
 - request:
     method: put
     uri: http://localhost:3200/source/ProjectWithRepo/_config
     body:
       encoding: UTF-8
-      string: Fugiat aspernatur maiores voluptates qui et. Incidunt eum expedita.
-        Ducimus et laboriosam iure et consequatur est dignissimos.
+      string: Minus maiores quaerat veritatis. Atque voluptate hic aut. Velit eos
+        quidem qui qui natus. Unde non eaque hic culpa et quos corrupti.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -113,7 +113,7 @@ http_interactions:
 
 '
     http_version: 
-  recorded_at: Mon, 21 Aug 2017 14:07:14 GMT
+  recorded_at: Tue, 22 Aug 2017 12:31:07 GMT
 - request:
     method: put
     uri: http://localhost:3200/source/ProjectWithRepo:Update/_meta
@@ -121,7 +121,7 @@ http_interactions:
       encoding: UTF-8
       string: |
         <project name="ProjectWithRepo:Update" kind="maintenance_release">
-          <title>The Wind's Twelve Quarters</title>
+          <title>Postern of Fate</title>
           <description/>
         </project>
     headers:
@@ -143,23 +143,24 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '152'
+      - '141'
     body:
       encoding: UTF-8
       string: |
         <project name="ProjectWithRepo:Update" kind="maintenance_release">
-          <title>The Wind's Twelve Quarters</title>
+          <title>Postern of Fate</title>
           <description></description>
         </project>
     http_version: 
-  recorded_at: Mon, 21 Aug 2017 14:07:14 GMT
+  recorded_at: Tue, 22 Aug 2017 12:31:08 GMT
 - request:
     method: put
     uri: http://localhost:3200/source/ProjectWithRepo:Update/_config
     body:
       encoding: UTF-8
-      string: Vel illo ea quod minus debitis voluptatem. Dolorem officiis rerum voluptates
-        libero. Temporibus a reprehenderit deserunt pariatur.
+      string: Natus ut quaerat. Dolor assumenda vel corrupti. Reprehenderit aut expedita
+        qui sapiente. Occaecati est voluptatum voluptatem aliquid nesciunt ut sit.
+        Dolorem nihil officiis illo possimus magnam.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -186,7 +187,7 @@ http_interactions:
 
 '
     http_version: 
-  recorded_at: Mon, 21 Aug 2017 14:07:14 GMT
+  recorded_at: Tue, 22 Aug 2017 12:31:08 GMT
 - request:
     method: put
     uri: http://localhost:3200/source/ProjectWithRepo:Update/_meta?user=user_1
@@ -194,7 +195,7 @@ http_interactions:
       encoding: UTF-8
       string: |
         <project name="ProjectWithRepo:Update" kind="maintenance_release">
-          <title>The Wind's Twelve Quarters</title>
+          <title>Postern of Fate</title>
           <description/>
           <link project="ProjectWithRepo"/>
         </project>
@@ -217,17 +218,17 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '189'
+      - '178'
     body:
       encoding: UTF-8
       string: |
         <project name="ProjectWithRepo:Update" kind="maintenance_release">
-          <title>The Wind's Twelve Quarters</title>
+          <title>Postern of Fate</title>
           <description></description>
           <link project="ProjectWithRepo" />
         </project>
     http_version: 
-  recorded_at: Mon, 21 Aug 2017 14:07:14 GMT
+  recorded_at: Tue, 22 Aug 2017 12:31:08 GMT
 - request:
     method: put
     uri: http://localhost:3200/source/home:maintenance_coord/_meta?user=maintenance_coord
@@ -268,7 +269,7 @@ http_interactions:
           <person userid="maintenance_coord" role="maintainer" />
         </project>
     http_version: 
-  recorded_at: Mon, 21 Aug 2017 14:07:14 GMT
+  recorded_at: Tue, 22 Aug 2017 12:31:08 GMT
 - request:
     method: put
     uri: http://localhost:3200/source/MaintenanceProject/_meta
@@ -307,14 +308,15 @@ http_interactions:
           <description></description>
         </project>
     http_version: 
-  recorded_at: Mon, 21 Aug 2017 14:07:14 GMT
+  recorded_at: Tue, 22 Aug 2017 12:31:08 GMT
 - request:
     method: put
     uri: http://localhost:3200/source/MaintenanceProject/_config
     body:
       encoding: UTF-8
-      string: Aut ut nemo molestias. Quae aut veritatis et quas eos. Quod facere nisi
-        est voluptas aut aut.
+      string: Maiores voluptatem eos. Blanditiis et velit quo magni. Aperiam qui delectus.
+        Suscipit aut dicta eligendi tempore quo. Repellat dolor sint enim libero ea
+        atque illo.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -341,7 +343,7 @@ http_interactions:
 
 '
     http_version: 
-  recorded_at: Mon, 21 Aug 2017 14:07:14 GMT
+  recorded_at: Tue, 22 Aug 2017 12:31:08 GMT
 - request:
     method: put
     uri: http://localhost:3200/source/MaintenanceProject/_meta?user=user_1
@@ -386,7 +388,7 @@ http_interactions:
           </maintenance>
         </project>
     http_version: 
-  recorded_at: Mon, 21 Aug 2017 14:07:14 GMT
+  recorded_at: Tue, 22 Aug 2017 12:31:08 GMT
 - request:
     method: put
     uri: http://localhost:3200/source/MaintenanceProject/patchinfo/_meta?user=maintenance_coord
@@ -443,7 +445,7 @@ http_interactions:
           </useforbuild>
         </package>
     http_version: 
-  recorded_at: Mon, 21 Aug 2017 14:07:14 GMT
+  recorded_at: Tue, 22 Aug 2017 12:31:08 GMT
 - request:
     method: put
     uri: http://localhost:3200/source/MaintenanceProject/patchinfo/_patchinfo?comment=generated%20by%20createpatchinfo%20call&user=maintenance_coord
@@ -480,16 +482,16 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <revision rev="2" vrev="2">
+        <revision rev="1" vrev="1">
           <srcmd5>7c79565cf2a5793c8092ebecfe0a912a</srcmd5>
           <version>unknown</version>
-          <time>1503324434</time>
+          <time>1503405068</time>
           <user>maintenance_coord</user>
           <comment>generated by createpatchinfo call</comment>
           <requestid/>
         </revision>
     http_version: 
-  recorded_at: Mon, 21 Aug 2017 14:07:14 GMT
+  recorded_at: Tue, 22 Aug 2017 12:31:08 GMT
 - request:
     method: put
     uri: http://localhost:3200/source/MaintenanceProject/patchinfo/_meta?user=maintenance_coord
@@ -546,7 +548,7 @@ http_interactions:
           </useforbuild>
         </package>
     http_version: 
-  recorded_at: Mon, 21 Aug 2017 14:07:15 GMT
+  recorded_at: Tue, 22 Aug 2017 12:31:08 GMT
 - request:
     method: get
     uri: http://localhost:3200/source/MaintenanceProject/patchinfo
@@ -576,11 +578,11 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="patchinfo" rev="2" vrev="2" srcmd5="7c79565cf2a5793c8092ebecfe0a912a">
-          <entry name="_patchinfo" md5="ea890f2483d4b7e7255d64ef4dbb1d43" size="174" mtime="1503324262" />
+        <directory name="patchinfo" rev="1" vrev="1" srcmd5="7c79565cf2a5793c8092ebecfe0a912a">
+          <entry name="_patchinfo" md5="ea890f2483d4b7e7255d64ef4dbb1d43" size="174" mtime="1503405068" />
         </directory>
     http_version: 
-  recorded_at: Mon, 21 Aug 2017 14:07:15 GMT
+  recorded_at: Tue, 22 Aug 2017 12:31:08 GMT
 - request:
     method: get
     uri: http://localhost:3200/source/MaintenanceProject/patchinfo?nofilename=1&view=info&withchangesmd5=1
@@ -610,11 +612,11 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <sourceinfo package="patchinfo" rev="2" vrev="2" srcmd5="7c79565cf2a5793c8092ebecfe0a912a" verifymd5="7c79565cf2a5793c8092ebecfe0a912a">
-          <revtime>1503324434</revtime>
+        <sourceinfo package="patchinfo" rev="1" vrev="1" srcmd5="7c79565cf2a5793c8092ebecfe0a912a" verifymd5="7c79565cf2a5793c8092ebecfe0a912a">
+          <revtime>1503405068</revtime>
         </sourceinfo>
     http_version: 
-  recorded_at: Mon, 21 Aug 2017 14:07:15 GMT
+  recorded_at: Tue, 22 Aug 2017 12:31:08 GMT
 - request:
     method: get
     uri: http://localhost:3200/source/MaintenanceProject/patchinfo
@@ -644,11 +646,11 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="patchinfo" rev="2" vrev="2" srcmd5="7c79565cf2a5793c8092ebecfe0a912a">
-          <entry name="_patchinfo" md5="ea890f2483d4b7e7255d64ef4dbb1d43" size="174" mtime="1503324262" />
+        <directory name="patchinfo" rev="1" vrev="1" srcmd5="7c79565cf2a5793c8092ebecfe0a912a">
+          <entry name="_patchinfo" md5="ea890f2483d4b7e7255d64ef4dbb1d43" size="174" mtime="1503405068" />
         </directory>
     http_version: 
-  recorded_at: Mon, 21 Aug 2017 14:07:15 GMT
+  recorded_at: Tue, 22 Aug 2017 12:31:08 GMT
 - request:
     method: get
     uri: http://localhost:3200/source/MaintenanceProject/patchinfo/_patchinfo
@@ -686,7 +688,7 @@ http_interactions:
           <description/>
         </patchinfo>
     http_version: 
-  recorded_at: Mon, 21 Aug 2017 14:07:15 GMT
+  recorded_at: Tue, 22 Aug 2017 12:31:09 GMT
 - request:
     method: put
     uri: http://localhost:3200/source/home:tom/_meta?user=tom
@@ -727,7 +729,7 @@ http_interactions:
           <person userid="tom" role="maintainer" />
         </project>
     http_version: 
-  recorded_at: Mon, 21 Aug 2017 14:07:15 GMT
+  recorded_at: Tue, 22 Aug 2017 12:31:09 GMT
 - request:
     method: put
     uri: http://localhost:3200/source/ProjectWithRepo/ProjectWithRepo_package/_meta?user=tom
@@ -735,8 +737,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="ProjectWithRepo_package" project="ProjectWithRepo">
-          <title>Moab Is My Washpot</title>
-          <description>Eius ut consequuntur nihil.</description>
+          <title>Have His Carcase</title>
+          <description>Molestiae eligendi asperiores quod voluptatibus totam non recusandae voluptas.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -757,16 +759,16 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '171'
+      - '220'
     body:
       encoding: UTF-8
       string: |
         <package name="ProjectWithRepo_package" project="ProjectWithRepo">
-          <title>Moab Is My Washpot</title>
-          <description>Eius ut consequuntur nihil.</description>
+          <title>Have His Carcase</title>
+          <description>Molestiae eligendi asperiores quod voluptatibus totam non recusandae voluptas.</description>
         </package>
     http_version: 
-  recorded_at: Mon, 21 Aug 2017 14:07:19 GMT
+  recorded_at: Tue, 22 Aug 2017 12:31:13 GMT
 - request:
     method: put
     uri: http://localhost:3200/source/ProjectWithRepo/ProjectWithRepo_package/_meta
@@ -774,8 +776,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="ProjectWithRepo_package" project="ProjectWithRepo">
-          <title>Moab Is My Washpot</title>
-          <description>Eius ut consequuntur nihil.</description>
+          <title>Have His Carcase</title>
+          <description>Molestiae eligendi asperiores quod voluptatibus totam non recusandae voluptas.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -796,23 +798,25 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '171'
+      - '220'
     body:
       encoding: UTF-8
       string: |
         <package name="ProjectWithRepo_package" project="ProjectWithRepo">
-          <title>Moab Is My Washpot</title>
-          <description>Eius ut consequuntur nihil.</description>
+          <title>Have His Carcase</title>
+          <description>Molestiae eligendi asperiores quod voluptatibus totam non recusandae voluptas.</description>
         </package>
     http_version: 
-  recorded_at: Mon, 21 Aug 2017 14:07:19 GMT
+  recorded_at: Tue, 22 Aug 2017 12:31:13 GMT
 - request:
     method: put
     uri: http://localhost:3200/source/ProjectWithRepo/ProjectWithRepo_package/_config
     body:
       encoding: UTF-8
-      string: Et sunt dolorum omnis. Sit suscipit ut blanditiis tenetur. Magnam cupiditate
-        et doloribus quis debitis.
+      string: Reprehenderit consequatur explicabo ipsam libero. Expedita minima quis
+        tempora facilis modi maiores. Eligendi molestiae eos neque id odio quae dolore.
+        Eligendi voluptatem distinctio sunt. Nisi laudantium exercitationem consequatur
+        soluta.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -836,24 +840,23 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <revision rev="3" vrev="3">
-          <srcmd5>c85c464f3c56eedbe4491ba8e71e6990</srcmd5>
+        <revision rev="1" vrev="1">
+          <srcmd5>0b2b3d3b538adcd945273f9f64080257</srcmd5>
           <version>unknown</version>
-          <time>1503324439</time>
+          <time>1503405073</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
     http_version: 
-  recorded_at: Mon, 21 Aug 2017 14:07:19 GMT
+  recorded_at: Tue, 22 Aug 2017 12:31:13 GMT
 - request:
     method: put
     uri: http://localhost:3200/source/ProjectWithRepo/ProjectWithRepo_package/somefile.txt
     body:
       encoding: UTF-8
-      string: Molestiae assumenda sunt. Non aperiam voluptatem et ipsam nesciunt voluptas.
-        Reiciendis est animi repudiandae voluptatibus qui modi ea. Repellat tempore
-        beatae.
+      string: Voluptate qui deserunt culpa laborum est delectus. Et ducimus necessitatibus
+        sint aut libero. Doloribus quasi culpa.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -877,16 +880,16 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <revision rev="4" vrev="4">
-          <srcmd5>09e82b0920e2079611427fc5ae96b076</srcmd5>
+        <revision rev="2" vrev="2">
+          <srcmd5>e9d965f2d319f4124109f14a13f4e431</srcmd5>
           <version>unknown</version>
-          <time>1503324439</time>
+          <time>1503405073</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
     http_version: 
-  recorded_at: Mon, 21 Aug 2017 14:07:19 GMT
+  recorded_at: Tue, 22 Aug 2017 12:31:13 GMT
 - request:
     method: get
     uri: http://localhost:3200/source/ProjectWithRepo/ProjectWithRepo_package?nofilename=1&view=info&withchangesmd5=1
@@ -916,11 +919,11 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <sourceinfo package="ProjectWithRepo_package" rev="4" vrev="4" srcmd5="09e82b0920e2079611427fc5ae96b076" verifymd5="09e82b0920e2079611427fc5ae96b076">
-          <revtime>1503324439</revtime>
+        <sourceinfo package="ProjectWithRepo_package" rev="2" vrev="2" srcmd5="e9d965f2d319f4124109f14a13f4e431" verifymd5="e9d965f2d319f4124109f14a13f4e431">
+          <revtime>1503405073</revtime>
         </sourceinfo>
     http_version: 
-  recorded_at: Mon, 21 Aug 2017 14:07:19 GMT
+  recorded_at: Tue, 22 Aug 2017 12:31:13 GMT
 - request:
     method: get
     uri: http://localhost:3200/source/ProjectWithRepo/ProjectWithRepo_package
@@ -950,12 +953,12 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="ProjectWithRepo_package" rev="4" vrev="4" srcmd5="09e82b0920e2079611427fc5ae96b076">
-          <entry name="_config" md5="55041d03ef8e31e551b3edd00464f7ea" size="103" mtime="1503324439" />
-          <entry name="somefile.txt" md5="72a89c51cb636651b1da704fa7b303ee" size="160" mtime="1503324439" />
+        <directory name="ProjectWithRepo_package" rev="2" vrev="2" srcmd5="e9d965f2d319f4124109f14a13f4e431">
+          <entry name="_config" md5="7159169868967997b7eabbd94d805185" size="238" mtime="1503405073" />
+          <entry name="somefile.txt" md5="b4b03ef7ef00ded93403c2c595500c4f" size="116" mtime="1503405073" />
         </directory>
     http_version: 
-  recorded_at: Mon, 21 Aug 2017 14:07:19 GMT
+  recorded_at: Tue, 22 Aug 2017 12:31:13 GMT
 - request:
     method: post
     uri: http://localhost:3200/source/ProjectWithRepo/ProjectWithRepo_package?cmd=diff&linkrev=base&onlyissues=1&orev=0&view=xml
@@ -987,15 +990,15 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="dbbb16df293f7ced721feb3a38b48ed4">
+        <sourcediff key="b35a4ebdb0aa27c1bb4981c75d3493f6">
           <old project="ProjectWithRepo" package="ProjectWithRepo_package" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e" />
-          <new project="ProjectWithRepo" package="ProjectWithRepo_package" rev="4" srcmd5="09e82b0920e2079611427fc5ae96b076" />
+          <new project="ProjectWithRepo" package="ProjectWithRepo_package" rev="2" srcmd5="e9d965f2d319f4124109f14a13f4e431" />
           <files />
           <issues>
           </issues>
         </sourcediff>
     http_version: 
-  recorded_at: Mon, 21 Aug 2017 14:07:19 GMT
+  recorded_at: Tue, 22 Aug 2017 12:31:13 GMT
 - request:
     method: get
     uri: http://localhost:3200/source/ProjectWithRepo/ProjectWithRepo_package
@@ -1025,15 +1028,15 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="ProjectWithRepo_package" rev="4" vrev="4" srcmd5="09e82b0920e2079611427fc5ae96b076">
-          <entry name="_config" md5="55041d03ef8e31e551b3edd00464f7ea" size="103" mtime="1503324439" />
-          <entry name="somefile.txt" md5="72a89c51cb636651b1da704fa7b303ee" size="160" mtime="1503324439" />
+        <directory name="ProjectWithRepo_package" rev="2" vrev="2" srcmd5="e9d965f2d319f4124109f14a13f4e431">
+          <entry name="_config" md5="7159169868967997b7eabbd94d805185" size="238" mtime="1503405073" />
+          <entry name="somefile.txt" md5="b4b03ef7ef00ded93403c2c595500c4f" size="116" mtime="1503405073" />
         </directory>
     http_version: 
-  recorded_at: Mon, 21 Aug 2017 14:07:19 GMT
+  recorded_at: Tue, 22 Aug 2017 12:31:13 GMT
 - request:
     method: get
-    uri: http://localhost:3200/source/ProjectWithRepo/ProjectWithRepo_package?expand=1&rev=4
+    uri: http://localhost:3200/source/ProjectWithRepo/ProjectWithRepo_package?expand=1&rev=2
     body:
       encoding: US-ASCII
       string: ''
@@ -1060,12 +1063,12 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="ProjectWithRepo_package" rev="4" vrev="4" srcmd5="09e82b0920e2079611427fc5ae96b076">
-          <entry name="_config" md5="55041d03ef8e31e551b3edd00464f7ea" size="103" mtime="1503324439" />
-          <entry name="somefile.txt" md5="72a89c51cb636651b1da704fa7b303ee" size="160" mtime="1503324439" />
+        <directory name="ProjectWithRepo_package" rev="2" vrev="2" srcmd5="e9d965f2d319f4124109f14a13f4e431">
+          <entry name="_config" md5="7159169868967997b7eabbd94d805185" size="238" mtime="1503405073" />
+          <entry name="somefile.txt" md5="b4b03ef7ef00ded93403c2c595500c4f" size="116" mtime="1503405073" />
         </directory>
     http_version: 
-  recorded_at: Mon, 21 Aug 2017 14:07:19 GMT
+  recorded_at: Tue, 22 Aug 2017 12:31:13 GMT
 - request:
     method: get
     uri: http://localhost:3200/source/ProjectWithRepo/ProjectWithRepo_package
@@ -1097,12 +1100,12 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="ProjectWithRepo_package" rev="4" vrev="4" srcmd5="09e82b0920e2079611427fc5ae96b076">
-          <entry name="_config" md5="55041d03ef8e31e551b3edd00464f7ea" size="103" mtime="1503324439" />
-          <entry name="somefile.txt" md5="72a89c51cb636651b1da704fa7b303ee" size="160" mtime="1503324439" />
+        <directory name="ProjectWithRepo_package" rev="2" vrev="2" srcmd5="e9d965f2d319f4124109f14a13f4e431">
+          <entry name="_config" md5="7159169868967997b7eabbd94d805185" size="238" mtime="1503405073" />
+          <entry name="somefile.txt" md5="b4b03ef7ef00ded93403c2c595500c4f" size="116" mtime="1503405073" />
         </directory>
     http_version: 
-  recorded_at: Mon, 21 Aug 2017 14:07:19 GMT
+  recorded_at: Tue, 22 Aug 2017 12:31:13 GMT
 - request:
     method: get
     uri: http://localhost:3200/source/ProjectWithRepo:Update/ProjectWithRepo_package/_service
@@ -1139,7 +1142,7 @@ http_interactions:
           <details>404 _service: no such file</details>
         </status>
     http_version: 
-  recorded_at: Mon, 21 Aug 2017 14:07:19 GMT
+  recorded_at: Tue, 22 Aug 2017 12:31:13 GMT
 - request:
     method: get
     uri: http://localhost:3200/source/ProjectWithRepo/ProjectWithRepo_package/_history
@@ -1165,38 +1168,26 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '759'
+      - '395'
     body:
       encoding: UTF-8
       string: |
         <revisionlist>
           <revision rev="1" vrev="1">
-            <srcmd5>ad3fe0389f8e0af1f15d078639553e4a</srcmd5>
+            <srcmd5>0b2b3d3b538adcd945273f9f64080257</srcmd5>
             <version>unknown</version>
-            <time>1503324266</time>
+            <time>1503405073</time>
             <user>unknown</user>
           </revision>
           <revision rev="2" vrev="2">
-            <srcmd5>aaec46c945d5814d65a0676b78ac7659</srcmd5>
+            <srcmd5>e9d965f2d319f4124109f14a13f4e431</srcmd5>
             <version>unknown</version>
-            <time>1503324266</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="3" vrev="3">
-            <srcmd5>c85c464f3c56eedbe4491ba8e71e6990</srcmd5>
-            <version>unknown</version>
-            <time>1503324439</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="4" vrev="4">
-            <srcmd5>09e82b0920e2079611427fc5ae96b076</srcmd5>
-            <version>unknown</version>
-            <time>1503324439</time>
+            <time>1503405073</time>
             <user>unknown</user>
           </revision>
         </revisionlist>
     http_version: 
-  recorded_at: Mon, 21 Aug 2017 14:07:19 GMT
+  recorded_at: Tue, 22 Aug 2017 12:31:13 GMT
 - request:
     method: get
     uri: http://localhost:3200/build/ProjectWithRepo:Update/_result?package=ProjectWithRepo_package&view=status
@@ -1231,7 +1222,7 @@ http_interactions:
 
 '
     http_version: 
-  recorded_at: Mon, 21 Aug 2017 14:07:20 GMT
+  recorded_at: Tue, 22 Aug 2017 12:31:14 GMT
 - request:
     method: get
     uri: http://localhost:3200/build/ProjectWithRepo:Update/_result?locallink=1&multibuild=1&package=ProjectWithRepo_package&view=status
@@ -1266,7 +1257,7 @@ http_interactions:
 
 '
     http_version: 
-  recorded_at: Mon, 21 Aug 2017 14:07:20 GMT
+  recorded_at: Tue, 22 Aug 2017 12:31:14 GMT
 - request:
     method: post
     uri: http://localhost:3200/search/package/id?match=(linkinfo/@package=%22ProjectWithRepo_package%22%20and%20linkinfo/@project=%22ProjectWithRepo:Update%22%20and%20starts-with(@project,%22MaintenanceProject:%22))
@@ -1294,15 +1285,14 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '126'
+      - '27'
     body:
       encoding: UTF-8
       string: |
         <collection>
-          <package name="ProjectWithRepo_package.ProjectWithRepo_Update" project="MaintenanceProject:0" />
         </collection>
     http_version: 
-  recorded_at: Mon, 21 Aug 2017 14:07:20 GMT
+  recorded_at: Tue, 22 Aug 2017 12:31:14 GMT
 - request:
     method: post
     uri: http://localhost:3200/search/package/id?match=(linkinfo/@package=%22ProjectWithRepo_package%22%20and%20linkinfo/@project=%22ProjectWithRepo%22%20and%20@project=%22ProjectWithRepo%22)
@@ -1337,7 +1327,7 @@ http_interactions:
         <collection>
         </collection>
     http_version: 
-  recorded_at: Mon, 21 Aug 2017 14:07:20 GMT
+  recorded_at: Tue, 22 Aug 2017 12:31:14 GMT
 - request:
     method: put
     uri: http://localhost:3200/source/home:tom:branches:ProjectWithRepo:Update/_meta?user=tom
@@ -1378,7 +1368,7 @@ http_interactions:
           <person userid="tom" role="maintainer" />
         </project>
     http_version: 
-  recorded_at: Mon, 21 Aug 2017 14:07:20 GMT
+  recorded_at: Tue, 22 Aug 2017 12:31:14 GMT
 - request:
     method: put
     uri: http://localhost:3200/source/home:tom:branches:ProjectWithRepo:Update/ProjectWithRepo_package/_meta?user=tom
@@ -1386,8 +1376,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="ProjectWithRepo_package" project="home:tom:branches:ProjectWithRepo:Update">
-          <title>Moab Is My Washpot</title>
-          <description>Eius ut consequuntur nihil.</description>
+          <title>Have His Carcase</title>
+          <description>Molestiae eligendi asperiores quod voluptatibus totam non recusandae voluptas.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -1408,16 +1398,16 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '196'
+      - '245'
     body:
       encoding: UTF-8
       string: |
         <package name="ProjectWithRepo_package" project="home:tom:branches:ProjectWithRepo:Update">
-          <title>Moab Is My Washpot</title>
-          <description>Eius ut consequuntur nihil.</description>
+          <title>Have His Carcase</title>
+          <description>Molestiae eligendi asperiores quod voluptatibus totam non recusandae voluptas.</description>
         </package>
     http_version: 
-  recorded_at: Mon, 21 Aug 2017 14:07:20 GMT
+  recorded_at: Tue, 22 Aug 2017 12:31:14 GMT
 - request:
     method: post
     uri: http://localhost:3200/source/home:tom:branches:ProjectWithRepo:Update/ProjectWithRepo_package?cmd=branch&opackage=ProjectWithRepo_package&oproject=ProjectWithRepo:Update&user=tom
@@ -1449,16 +1439,16 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <revision rev="3" vrev="3">
-          <srcmd5>defcef32689817852de9ed4fc08c1ec2</srcmd5>
+        <revision rev="1" vrev="1">
+          <srcmd5>9bcd667cba1fccb6f2edd222850b6994</srcmd5>
           <version>unknown</version>
-          <time>1503324440</time>
+          <time>1503405074</time>
           <user>tom</user>
           <comment></comment>
           <requestid/>
         </revision>
     http_version: 
-  recorded_at: Mon, 21 Aug 2017 14:07:20 GMT
+  recorded_at: Tue, 22 Aug 2017 12:31:14 GMT
 - request:
     method: put
     uri: http://localhost:3200/source/home:tom:branches:ProjectWithRepo:Update/ProjectWithRepo_package/_meta?user=tom
@@ -1466,8 +1456,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="ProjectWithRepo_package" project="home:tom:branches:ProjectWithRepo:Update">
-          <title>Moab Is My Washpot</title>
-          <description>Eius ut consequuntur nihil.</description>
+          <title>Have His Carcase</title>
+          <description>Molestiae eligendi asperiores quod voluptatibus totam non recusandae voluptas.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -1488,16 +1478,16 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '196'
+      - '245'
     body:
       encoding: UTF-8
       string: |
         <package name="ProjectWithRepo_package" project="home:tom:branches:ProjectWithRepo:Update">
-          <title>Moab Is My Washpot</title>
-          <description>Eius ut consequuntur nihil.</description>
+          <title>Have His Carcase</title>
+          <description>Molestiae eligendi asperiores quod voluptatibus totam non recusandae voluptas.</description>
         </package>
     http_version: 
-  recorded_at: Mon, 21 Aug 2017 14:07:20 GMT
+  recorded_at: Tue, 22 Aug 2017 12:31:14 GMT
 - request:
     method: get
     uri: http://localhost:3200/source/home:tom:branches:ProjectWithRepo:Update/ProjectWithRepo_package
@@ -1527,14 +1517,14 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="ProjectWithRepo_package" rev="3" vrev="3" srcmd5="defcef32689817852de9ed4fc08c1ec2">
-          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" srcmd5="09e82b0920e2079611427fc5ae96b076" baserev="09e82b0920e2079611427fc5ae96b076" xsrcmd5="09cc76faf05ef2b07f7f0238bf0c98b4" lsrcmd5="defcef32689817852de9ed4fc08c1ec2" />
-          <entry name="_config" md5="55041d03ef8e31e551b3edd00464f7ea" size="103" mtime="1503324439" />
-          <entry name="_link" md5="6ffab3981d3cd40f46924a3319a54098" size="130" mtime="1503324440" />
-          <entry name="somefile.txt" md5="72a89c51cb636651b1da704fa7b303ee" size="160" mtime="1503324439" />
+        <directory name="ProjectWithRepo_package" rev="1" vrev="1" srcmd5="9bcd667cba1fccb6f2edd222850b6994">
+          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" srcmd5="e9d965f2d319f4124109f14a13f4e431" baserev="e9d965f2d319f4124109f14a13f4e431" xsrcmd5="bd5b3338986f29cc911a8b873613bd70" lsrcmd5="9bcd667cba1fccb6f2edd222850b6994" />
+          <entry name="_config" md5="7159169868967997b7eabbd94d805185" size="238" mtime="1503405073" />
+          <entry name="_link" md5="11504ac69b4a7053159649a50cf86e1f" size="130" mtime="1503405074" />
+          <entry name="somefile.txt" md5="b4b03ef7ef00ded93403c2c595500c4f" size="116" mtime="1503405073" />
         </directory>
     http_version: 
-  recorded_at: Mon, 21 Aug 2017 14:07:20 GMT
+  recorded_at: Tue, 22 Aug 2017 12:31:14 GMT
 - request:
     method: get
     uri: http://localhost:3200/source/home:tom:branches:ProjectWithRepo:Update/ProjectWithRepo_package?nofilename=1&view=info&withchangesmd5=1
@@ -1564,13 +1554,13 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <sourceinfo package="ProjectWithRepo_package" rev="3" vrev="7" srcmd5="09cc76faf05ef2b07f7f0238bf0c98b4" lsrcmd5="defcef32689817852de9ed4fc08c1ec2" verifymd5="09e82b0920e2079611427fc5ae96b076">
+        <sourceinfo package="ProjectWithRepo_package" rev="1" vrev="3" srcmd5="bd5b3338986f29cc911a8b873613bd70" lsrcmd5="9bcd667cba1fccb6f2edd222850b6994" verifymd5="e9d965f2d319f4124109f14a13f4e431">
           <linked project="ProjectWithRepo:Update" package="ProjectWithRepo_package" />
           <linked project="ProjectWithRepo" package="ProjectWithRepo_package" />
-          <revtime>1503324440</revtime>
+          <revtime>1503405074</revtime>
         </sourceinfo>
     http_version: 
-  recorded_at: Mon, 21 Aug 2017 14:07:20 GMT
+  recorded_at: Tue, 22 Aug 2017 12:31:14 GMT
 - request:
     method: get
     uri: http://localhost:3200/source/home:tom:branches:ProjectWithRepo:Update/ProjectWithRepo_package
@@ -1600,14 +1590,14 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="ProjectWithRepo_package" rev="3" vrev="3" srcmd5="defcef32689817852de9ed4fc08c1ec2">
-          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" srcmd5="09e82b0920e2079611427fc5ae96b076" baserev="09e82b0920e2079611427fc5ae96b076" xsrcmd5="09cc76faf05ef2b07f7f0238bf0c98b4" lsrcmd5="defcef32689817852de9ed4fc08c1ec2" />
-          <entry name="_config" md5="55041d03ef8e31e551b3edd00464f7ea" size="103" mtime="1503324439" />
-          <entry name="_link" md5="6ffab3981d3cd40f46924a3319a54098" size="130" mtime="1503324440" />
-          <entry name="somefile.txt" md5="72a89c51cb636651b1da704fa7b303ee" size="160" mtime="1503324439" />
+        <directory name="ProjectWithRepo_package" rev="1" vrev="1" srcmd5="9bcd667cba1fccb6f2edd222850b6994">
+          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" srcmd5="e9d965f2d319f4124109f14a13f4e431" baserev="e9d965f2d319f4124109f14a13f4e431" xsrcmd5="bd5b3338986f29cc911a8b873613bd70" lsrcmd5="9bcd667cba1fccb6f2edd222850b6994" />
+          <entry name="_config" md5="7159169868967997b7eabbd94d805185" size="238" mtime="1503405073" />
+          <entry name="_link" md5="11504ac69b4a7053159649a50cf86e1f" size="130" mtime="1503405074" />
+          <entry name="somefile.txt" md5="b4b03ef7ef00ded93403c2c595500c4f" size="116" mtime="1503405073" />
         </directory>
     http_version: 
-  recorded_at: Mon, 21 Aug 2017 14:07:20 GMT
+  recorded_at: Tue, 22 Aug 2017 12:31:14 GMT
 - request:
     method: post
     uri: http://localhost:3200/source/home:tom:branches:ProjectWithRepo:Update/ProjectWithRepo_package?cmd=diff&linkrev=base&onlyissues=1&orev=0&view=xml
@@ -1639,15 +1629,15 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="d1e515a73057e4000d944b1e23932f0f">
+        <sourcediff key="249372be2812c622072b0e55faf8419e">
           <old project="home:tom:branches:ProjectWithRepo:Update" package="ProjectWithRepo_package" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e" />
-          <new project="home:tom:branches:ProjectWithRepo:Update" package="ProjectWithRepo_package" rev="3" srcmd5="defcef32689817852de9ed4fc08c1ec2" />
+          <new project="home:tom:branches:ProjectWithRepo:Update" package="ProjectWithRepo_package" rev="1" srcmd5="9bcd667cba1fccb6f2edd222850b6994" />
           <files />
           <issues>
           </issues>
         </sourcediff>
     http_version: 
-  recorded_at: Mon, 21 Aug 2017 14:07:20 GMT
+  recorded_at: Tue, 22 Aug 2017 12:31:14 GMT
 - request:
     method: post
     uri: http://localhost:3200/source/home:tom:branches:ProjectWithRepo:Update/ProjectWithRepo_package?cmd=linkdiff&linkrev=base&onlyissues=1&view=xml
@@ -1679,13 +1669,13 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="c24d674c1b14c81f99c1f38df612391d">
-          <old project="ProjectWithRepo:Update" package="ProjectWithRepo_package" rev="09e82b0920e2079611427fc5ae96b076" srcmd5="09e82b0920e2079611427fc5ae96b076" />
-          <new project="home:tom:branches:ProjectWithRepo:Update" package="ProjectWithRepo_package" rev="09cc76faf05ef2b07f7f0238bf0c98b4" srcmd5="09cc76faf05ef2b07f7f0238bf0c98b4" />
+        <sourcediff key="eec63aa8658132c1dd83fd34730a0153">
+          <old project="ProjectWithRepo:Update" package="ProjectWithRepo_package" rev="e9d965f2d319f4124109f14a13f4e431" srcmd5="e9d965f2d319f4124109f14a13f4e431" />
+          <new project="home:tom:branches:ProjectWithRepo:Update" package="ProjectWithRepo_package" rev="bd5b3338986f29cc911a8b873613bd70" srcmd5="bd5b3338986f29cc911a8b873613bd70" />
           <files />
         </sourcediff>
     http_version: 
-  recorded_at: Mon, 21 Aug 2017 14:07:20 GMT
+  recorded_at: Tue, 22 Aug 2017 12:31:14 GMT
 - request:
     method: put
     uri: http://localhost:3200/source/home:tom:branches:ProjectWithRepo:Update/_meta?user=tom
@@ -1742,7 +1732,7 @@ http_interactions:
           </repository>
         </project>
     http_version: 
-  recorded_at: Mon, 21 Aug 2017 14:07:21 GMT
+  recorded_at: Tue, 22 Aug 2017 12:31:15 GMT
 - request:
     method: get
     uri: http://localhost:3200/source/home:tom:branches:ProjectWithRepo:Update/ProjectWithRepo_package
@@ -1772,17 +1762,17 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="ProjectWithRepo_package" rev="3" vrev="3" srcmd5="defcef32689817852de9ed4fc08c1ec2">
-          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" srcmd5="09e82b0920e2079611427fc5ae96b076" baserev="09e82b0920e2079611427fc5ae96b076" xsrcmd5="09cc76faf05ef2b07f7f0238bf0c98b4" lsrcmd5="defcef32689817852de9ed4fc08c1ec2" />
-          <entry name="_config" md5="55041d03ef8e31e551b3edd00464f7ea" size="103" mtime="1503324439" />
-          <entry name="_link" md5="6ffab3981d3cd40f46924a3319a54098" size="130" mtime="1503324440" />
-          <entry name="somefile.txt" md5="72a89c51cb636651b1da704fa7b303ee" size="160" mtime="1503324439" />
+        <directory name="ProjectWithRepo_package" rev="1" vrev="1" srcmd5="9bcd667cba1fccb6f2edd222850b6994">
+          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" srcmd5="e9d965f2d319f4124109f14a13f4e431" baserev="e9d965f2d319f4124109f14a13f4e431" xsrcmd5="bd5b3338986f29cc911a8b873613bd70" lsrcmd5="9bcd667cba1fccb6f2edd222850b6994" />
+          <entry name="_config" md5="7159169868967997b7eabbd94d805185" size="238" mtime="1503405073" />
+          <entry name="_link" md5="11504ac69b4a7053159649a50cf86e1f" size="130" mtime="1503405074" />
+          <entry name="somefile.txt" md5="b4b03ef7ef00ded93403c2c595500c4f" size="116" mtime="1503405073" />
         </directory>
     http_version: 
-  recorded_at: Mon, 21 Aug 2017 14:07:21 GMT
+  recorded_at: Tue, 22 Aug 2017 12:31:15 GMT
 - request:
     method: get
-    uri: http://localhost:3200/source/home:tom:branches:ProjectWithRepo:Update/ProjectWithRepo_package?expand=1&rev=3
+    uri: http://localhost:3200/source/home:tom:branches:ProjectWithRepo:Update/ProjectWithRepo_package?expand=1&rev=1
     body:
       encoding: US-ASCII
       string: ''
@@ -1809,13 +1799,13 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="ProjectWithRepo_package" rev="09cc76faf05ef2b07f7f0238bf0c98b4" vrev="7" srcmd5="09cc76faf05ef2b07f7f0238bf0c98b4">
-          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" srcmd5="09e82b0920e2079611427fc5ae96b076" baserev="09e82b0920e2079611427fc5ae96b076" lsrcmd5="defcef32689817852de9ed4fc08c1ec2" />
-          <entry name="_config" md5="55041d03ef8e31e551b3edd00464f7ea" size="103" mtime="1503324439" />
-          <entry name="somefile.txt" md5="72a89c51cb636651b1da704fa7b303ee" size="160" mtime="1503324439" />
+        <directory name="ProjectWithRepo_package" rev="bd5b3338986f29cc911a8b873613bd70" vrev="3" srcmd5="bd5b3338986f29cc911a8b873613bd70">
+          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" srcmd5="e9d965f2d319f4124109f14a13f4e431" baserev="e9d965f2d319f4124109f14a13f4e431" lsrcmd5="9bcd667cba1fccb6f2edd222850b6994" />
+          <entry name="_config" md5="7159169868967997b7eabbd94d805185" size="238" mtime="1503405073" />
+          <entry name="somefile.txt" md5="b4b03ef7ef00ded93403c2c595500c4f" size="116" mtime="1503405073" />
         </directory>
     http_version: 
-  recorded_at: Mon, 21 Aug 2017 14:07:21 GMT
+  recorded_at: Tue, 22 Aug 2017 12:31:15 GMT
 - request:
     method: get
     uri: http://localhost:3200/source/home:tom:branches:ProjectWithRepo:Update/ProjectWithRepo_package
@@ -1847,14 +1837,14 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="ProjectWithRepo_package" rev="3" vrev="3" srcmd5="defcef32689817852de9ed4fc08c1ec2">
-          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" srcmd5="09e82b0920e2079611427fc5ae96b076" baserev="09e82b0920e2079611427fc5ae96b076" xsrcmd5="09cc76faf05ef2b07f7f0238bf0c98b4" lsrcmd5="defcef32689817852de9ed4fc08c1ec2" />
-          <entry name="_config" md5="55041d03ef8e31e551b3edd00464f7ea" size="103" mtime="1503324439" />
-          <entry name="_link" md5="6ffab3981d3cd40f46924a3319a54098" size="130" mtime="1503324440" />
-          <entry name="somefile.txt" md5="72a89c51cb636651b1da704fa7b303ee" size="160" mtime="1503324439" />
+        <directory name="ProjectWithRepo_package" rev="1" vrev="1" srcmd5="9bcd667cba1fccb6f2edd222850b6994">
+          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" srcmd5="e9d965f2d319f4124109f14a13f4e431" baserev="e9d965f2d319f4124109f14a13f4e431" xsrcmd5="bd5b3338986f29cc911a8b873613bd70" lsrcmd5="9bcd667cba1fccb6f2edd222850b6994" />
+          <entry name="_config" md5="7159169868967997b7eabbd94d805185" size="238" mtime="1503405073" />
+          <entry name="_link" md5="11504ac69b4a7053159649a50cf86e1f" size="130" mtime="1503405074" />
+          <entry name="somefile.txt" md5="b4b03ef7ef00ded93403c2c595500c4f" size="116" mtime="1503405073" />
         </directory>
     http_version: 
-  recorded_at: Mon, 21 Aug 2017 14:07:21 GMT
+  recorded_at: Tue, 22 Aug 2017 12:31:15 GMT
 - request:
     method: get
     uri: http://localhost:3200/source/home:tom:branches:ProjectWithRepo:Update/ProjectWithRepo_package/_service
@@ -1891,7 +1881,7 @@ http_interactions:
           <details>404 _service: no such file</details>
         </status>
     http_version: 
-  recorded_at: Mon, 21 Aug 2017 14:07:21 GMT
+  recorded_at: Tue, 22 Aug 2017 12:31:15 GMT
 - request:
     method: get
     uri: http://localhost:3200/source/home:tom:branches:ProjectWithRepo:Update/ProjectWithRepo_package
@@ -1921,14 +1911,14 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="ProjectWithRepo_package" rev="3" vrev="3" srcmd5="defcef32689817852de9ed4fc08c1ec2">
-          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" srcmd5="09e82b0920e2079611427fc5ae96b076" baserev="09e82b0920e2079611427fc5ae96b076" xsrcmd5="09cc76faf05ef2b07f7f0238bf0c98b4" lsrcmd5="defcef32689817852de9ed4fc08c1ec2" />
-          <entry name="_config" md5="55041d03ef8e31e551b3edd00464f7ea" size="103" mtime="1503324439" />
-          <entry name="_link" md5="6ffab3981d3cd40f46924a3319a54098" size="130" mtime="1503324440" />
-          <entry name="somefile.txt" md5="72a89c51cb636651b1da704fa7b303ee" size="160" mtime="1503324439" />
+        <directory name="ProjectWithRepo_package" rev="1" vrev="1" srcmd5="9bcd667cba1fccb6f2edd222850b6994">
+          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" srcmd5="e9d965f2d319f4124109f14a13f4e431" baserev="e9d965f2d319f4124109f14a13f4e431" xsrcmd5="bd5b3338986f29cc911a8b873613bd70" lsrcmd5="9bcd667cba1fccb6f2edd222850b6994" />
+          <entry name="_config" md5="7159169868967997b7eabbd94d805185" size="238" mtime="1503405073" />
+          <entry name="_link" md5="11504ac69b4a7053159649a50cf86e1f" size="130" mtime="1503405074" />
+          <entry name="somefile.txt" md5="b4b03ef7ef00ded93403c2c595500c4f" size="116" mtime="1503405073" />
         </directory>
     http_version: 
-  recorded_at: Mon, 21 Aug 2017 14:07:21 GMT
+  recorded_at: Tue, 22 Aug 2017 12:31:15 GMT
 - request:
     method: get
     uri: http://localhost:3200/source/home:tom:branches:ProjectWithRepo:Update/ProjectWithRepo_package/_history
@@ -1954,32 +1944,20 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '569'
+      - '209'
     body:
       encoding: UTF-8
       string: |
         <revisionlist>
           <revision rev="1" vrev="1">
-            <srcmd5>f540d2f25d290e11cc379462f85f4c31</srcmd5>
+            <srcmd5>9bcd667cba1fccb6f2edd222850b6994</srcmd5>
             <version>unknown</version>
-            <time>1503324267</time>
-            <user>tom</user>
-          </revision>
-          <revision rev="2" vrev="2">
-            <srcmd5>1b8377f25ebe75d5a7fb7cdd11519ce0</srcmd5>
-            <version>unknown</version>
-            <time>1503324268</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="3" vrev="3">
-            <srcmd5>defcef32689817852de9ed4fc08c1ec2</srcmd5>
-            <version>unknown</version>
-            <time>1503324440</time>
+            <time>1503405074</time>
             <user>tom</user>
           </revision>
         </revisionlist>
     http_version: 
-  recorded_at: Mon, 21 Aug 2017 14:07:21 GMT
+  recorded_at: Tue, 22 Aug 2017 12:31:15 GMT
 - request:
     method: get
     uri: http://localhost:3200/build/home:tom:branches:ProjectWithRepo:Update/_result?package=ProjectWithRepo_package&view=status
@@ -2015,7 +1993,7 @@ http_interactions:
           <result project="home:tom:branches:ProjectWithRepo:Update" repository="repository_2" arch="i586" code="unknown" state="unknown" />
         </resultlist>
     http_version: 
-  recorded_at: Mon, 21 Aug 2017 14:07:21 GMT
+  recorded_at: Tue, 22 Aug 2017 12:31:15 GMT
 - request:
     method: get
     uri: http://localhost:3200/build/home:tom:branches:ProjectWithRepo:Update/_result?locallink=1&multibuild=1&package=ProjectWithRepo_package&view=status
@@ -2051,7 +2029,7 @@ http_interactions:
           <result project="home:tom:branches:ProjectWithRepo:Update" repository="repository_2" arch="i586" code="unknown" state="unknown" />
         </resultlist>
     http_version: 
-  recorded_at: Mon, 21 Aug 2017 14:07:21 GMT
+  recorded_at: Tue, 22 Aug 2017 12:31:15 GMT
 - request:
     method: put
     uri: http://localhost:3200/source/home:tom:branches:ProjectWithRepo:Update/ProjectWithRepo_package/DUMMY_FILE
@@ -2081,16 +2059,16 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <revision rev="4" vrev="4">
-          <srcmd5>3b4a835fa1e497790f82e45048a78427</srcmd5>
+        <revision rev="2" vrev="2">
+          <srcmd5>5acba764a37a9bc6490f80deca372916</srcmd5>
           <version>unknown</version>
-          <time>1503324441</time>
+          <time>1503405075</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
     http_version: 
-  recorded_at: Mon, 21 Aug 2017 14:07:21 GMT
+  recorded_at: Tue, 22 Aug 2017 12:31:15 GMT
 - request:
     method: get
     uri: http://localhost:3200/build/home:tom:branches:ProjectWithRepo:Update/_result?code=unresolvable&view=status
@@ -2126,7 +2104,7 @@ http_interactions:
           <result project="home:tom:branches:ProjectWithRepo:Update" repository="repository_2" arch="i586" code="unknown" state="unknown" />
         </resultlist>
     http_version: 
-  recorded_at: Mon, 21 Aug 2017 14:07:21 GMT
+  recorded_at: Tue, 22 Aug 2017 12:31:15 GMT
 - request:
     method: get
     uri: http://localhost:3200/source/home:tom:branches:ProjectWithRepo:Update/_keyinfo?donotcreatecert=1&withsslcert=1
@@ -2157,7 +2135,7 @@ http_interactions:
       encoding: UTF-8
       string: "<keyinfo />\n"
     http_version: 
-  recorded_at: Mon, 21 Aug 2017 14:07:22 GMT
+  recorded_at: Tue, 22 Aug 2017 12:31:15 GMT
 - request:
     method: get
     uri: http://localhost:3200/build/home:tom:branches:ProjectWithRepo:Update/_result?view=summary
@@ -2195,7 +2173,7 @@ http_interactions:
           </result>
         </resultlist>
     http_version: 
-  recorded_at: Mon, 21 Aug 2017 14:07:22 GMT
+  recorded_at: Tue, 22 Aug 2017 12:31:16 GMT
 - request:
     method: get
     uri: http://localhost:3200/source/home:tom:branches:ProjectWithRepo:Update/ProjectWithRepo_package
@@ -2225,15 +2203,15 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="ProjectWithRepo_package" rev="4" vrev="4" srcmd5="3b4a835fa1e497790f82e45048a78427">
-          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" srcmd5="09e82b0920e2079611427fc5ae96b076" baserev="09e82b0920e2079611427fc5ae96b076" xsrcmd5="015a0a0d39a8e944210a9d525dc6ae91" lsrcmd5="3b4a835fa1e497790f82e45048a78427" />
-          <entry name="DUMMY_FILE" md5="275876e34cf609db118f3d84b799a790" size="5" mtime="1503324268" />
-          <entry name="_config" md5="55041d03ef8e31e551b3edd00464f7ea" size="103" mtime="1503324439" />
-          <entry name="_link" md5="6ffab3981d3cd40f46924a3319a54098" size="130" mtime="1503324440" />
-          <entry name="somefile.txt" md5="72a89c51cb636651b1da704fa7b303ee" size="160" mtime="1503324439" />
+        <directory name="ProjectWithRepo_package" rev="2" vrev="2" srcmd5="5acba764a37a9bc6490f80deca372916">
+          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" srcmd5="e9d965f2d319f4124109f14a13f4e431" baserev="e9d965f2d319f4124109f14a13f4e431" xsrcmd5="6d8b4e042078d289ced39a1738e21c95" lsrcmd5="5acba764a37a9bc6490f80deca372916" />
+          <entry name="DUMMY_FILE" md5="275876e34cf609db118f3d84b799a790" size="5" mtime="1503405075" />
+          <entry name="_config" md5="7159169868967997b7eabbd94d805185" size="238" mtime="1503405073" />
+          <entry name="_link" md5="11504ac69b4a7053159649a50cf86e1f" size="130" mtime="1503405074" />
+          <entry name="somefile.txt" md5="b4b03ef7ef00ded93403c2c595500c4f" size="116" mtime="1503405073" />
         </directory>
     http_version: 
-  recorded_at: Mon, 21 Aug 2017 14:07:22 GMT
+  recorded_at: Tue, 22 Aug 2017 12:31:16 GMT
 - request:
     method: get
     uri: http://localhost:3200/source/home:tom:branches:ProjectWithRepo:Update/ProjectWithRepo_package
@@ -2263,15 +2241,15 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="ProjectWithRepo_package" rev="4" vrev="4" srcmd5="3b4a835fa1e497790f82e45048a78427">
-          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" srcmd5="09e82b0920e2079611427fc5ae96b076" baserev="09e82b0920e2079611427fc5ae96b076" xsrcmd5="015a0a0d39a8e944210a9d525dc6ae91" lsrcmd5="3b4a835fa1e497790f82e45048a78427" />
-          <entry name="DUMMY_FILE" md5="275876e34cf609db118f3d84b799a790" size="5" mtime="1503324268" />
-          <entry name="_config" md5="55041d03ef8e31e551b3edd00464f7ea" size="103" mtime="1503324439" />
-          <entry name="_link" md5="6ffab3981d3cd40f46924a3319a54098" size="130" mtime="1503324440" />
-          <entry name="somefile.txt" md5="72a89c51cb636651b1da704fa7b303ee" size="160" mtime="1503324439" />
+        <directory name="ProjectWithRepo_package" rev="2" vrev="2" srcmd5="5acba764a37a9bc6490f80deca372916">
+          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" srcmd5="e9d965f2d319f4124109f14a13f4e431" baserev="e9d965f2d319f4124109f14a13f4e431" xsrcmd5="6d8b4e042078d289ced39a1738e21c95" lsrcmd5="5acba764a37a9bc6490f80deca372916" />
+          <entry name="DUMMY_FILE" md5="275876e34cf609db118f3d84b799a790" size="5" mtime="1503405075" />
+          <entry name="_config" md5="7159169868967997b7eabbd94d805185" size="238" mtime="1503405073" />
+          <entry name="_link" md5="11504ac69b4a7053159649a50cf86e1f" size="130" mtime="1503405074" />
+          <entry name="somefile.txt" md5="b4b03ef7ef00ded93403c2c595500c4f" size="116" mtime="1503405073" />
         </directory>
     http_version: 
-  recorded_at: Mon, 21 Aug 2017 14:07:22 GMT
+  recorded_at: Tue, 22 Aug 2017 12:31:16 GMT
 - request:
     method: get
     uri: http://localhost:3200/source/home:tom:branches:ProjectWithRepo:Update/ProjectWithRepo_package
@@ -2303,15 +2281,15 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="ProjectWithRepo_package" rev="4" vrev="4" srcmd5="3b4a835fa1e497790f82e45048a78427">
-          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" srcmd5="09e82b0920e2079611427fc5ae96b076" baserev="09e82b0920e2079611427fc5ae96b076" xsrcmd5="015a0a0d39a8e944210a9d525dc6ae91" lsrcmd5="3b4a835fa1e497790f82e45048a78427" />
-          <entry name="DUMMY_FILE" md5="275876e34cf609db118f3d84b799a790" size="5" mtime="1503324268" />
-          <entry name="_config" md5="55041d03ef8e31e551b3edd00464f7ea" size="103" mtime="1503324439" />
-          <entry name="_link" md5="6ffab3981d3cd40f46924a3319a54098" size="130" mtime="1503324440" />
-          <entry name="somefile.txt" md5="72a89c51cb636651b1da704fa7b303ee" size="160" mtime="1503324439" />
+        <directory name="ProjectWithRepo_package" rev="2" vrev="2" srcmd5="5acba764a37a9bc6490f80deca372916">
+          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" srcmd5="e9d965f2d319f4124109f14a13f4e431" baserev="e9d965f2d319f4124109f14a13f4e431" xsrcmd5="6d8b4e042078d289ced39a1738e21c95" lsrcmd5="5acba764a37a9bc6490f80deca372916" />
+          <entry name="DUMMY_FILE" md5="275876e34cf609db118f3d84b799a790" size="5" mtime="1503405075" />
+          <entry name="_config" md5="7159169868967997b7eabbd94d805185" size="238" mtime="1503405073" />
+          <entry name="_link" md5="11504ac69b4a7053159649a50cf86e1f" size="130" mtime="1503405074" />
+          <entry name="somefile.txt" md5="b4b03ef7ef00ded93403c2c595500c4f" size="116" mtime="1503405073" />
         </directory>
     http_version: 
-  recorded_at: Mon, 21 Aug 2017 14:07:23 GMT
+  recorded_at: Tue, 22 Aug 2017 12:31:16 GMT
 - request:
     method: post
     uri: http://localhost:3200/source/home:tom:branches:ProjectWithRepo:Update/ProjectWithRepo_package?cmd=diff&expand=1&filelimit=10000&opackage=ProjectWithRepo_package&oproject=ProjectWithRepo:Update
@@ -2358,7 +2336,7 @@ http_interactions:
         +dummy
         \ No newline at end of file
     http_version: 
-  recorded_at: Mon, 21 Aug 2017 14:07:23 GMT
+  recorded_at: Tue, 22 Aug 2017 12:31:16 GMT
 - request:
     method: get
     uri: http://localhost:3200/source/home:tom:branches:ProjectWithRepo:Update/ProjectWithRepo_package?expand=1
@@ -2388,14 +2366,14 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="ProjectWithRepo_package" rev="015a0a0d39a8e944210a9d525dc6ae91" vrev="8" srcmd5="015a0a0d39a8e944210a9d525dc6ae91">
-          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" srcmd5="09e82b0920e2079611427fc5ae96b076" baserev="09e82b0920e2079611427fc5ae96b076" lsrcmd5="3b4a835fa1e497790f82e45048a78427" />
-          <entry name="DUMMY_FILE" md5="275876e34cf609db118f3d84b799a790" size="5" mtime="1503324268" />
-          <entry name="_config" md5="55041d03ef8e31e551b3edd00464f7ea" size="103" mtime="1503324439" />
-          <entry name="somefile.txt" md5="72a89c51cb636651b1da704fa7b303ee" size="160" mtime="1503324439" />
+        <directory name="ProjectWithRepo_package" rev="6d8b4e042078d289ced39a1738e21c95" vrev="4" srcmd5="6d8b4e042078d289ced39a1738e21c95">
+          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" srcmd5="e9d965f2d319f4124109f14a13f4e431" baserev="e9d965f2d319f4124109f14a13f4e431" lsrcmd5="5acba764a37a9bc6490f80deca372916" />
+          <entry name="DUMMY_FILE" md5="275876e34cf609db118f3d84b799a790" size="5" mtime="1503405075" />
+          <entry name="_config" md5="7159169868967997b7eabbd94d805185" size="238" mtime="1503405073" />
+          <entry name="somefile.txt" md5="b4b03ef7ef00ded93403c2c595500c4f" size="116" mtime="1503405073" />
         </directory>
     http_version: 
-  recorded_at: Mon, 21 Aug 2017 14:07:23 GMT
+  recorded_at: Tue, 22 Aug 2017 12:31:17 GMT
 - request:
     method: get
     uri: http://localhost:3200/build/home:tom:branches:ProjectWithRepo:Update/_result?code=unresolvable&view=status
@@ -2431,7 +2409,7 @@ http_interactions:
           <result project="home:tom:branches:ProjectWithRepo:Update" repository="repository_2" arch="i586" code="unknown" state="unknown" />
         </resultlist>
     http_version: 
-  recorded_at: Mon, 21 Aug 2017 14:07:23 GMT
+  recorded_at: Tue, 22 Aug 2017 12:31:17 GMT
 - request:
     method: get
     uri: http://localhost:3200/build/home:tom:branches:ProjectWithRepo:Update/_result?view=summary
@@ -2469,7 +2447,7 @@ http_interactions:
           </result>
         </resultlist>
     http_version: 
-  recorded_at: Mon, 21 Aug 2017 14:07:23 GMT
+  recorded_at: Tue, 22 Aug 2017 12:31:17 GMT
 - request:
     method: get
     uri: http://localhost:3200/build/_workerstatus
@@ -2510,21 +2488,21 @@ http_interactions:
           <buildavg arch="i586" buildavg="1200" />
           <buildavg arch="x86_64" buildavg="1200" />
           <partition>
-            <daemon type="srcserver" state="running" starttime="1503323652" />
-            <daemon type="servicedispatch" state="running" starttime="1503323652" />
-            <daemon type="service" state="running" starttime="1503323652" />
+            <daemon type="srcserver" state="running" starttime="1503405031" />
+            <daemon type="servicedispatch" state="running" starttime="1503405031" />
+            <daemon type="service" state="running" starttime="1503405031" />
             <daemon type="scheduler" arch="i586" state="dead">
               <queue high="0" med="0" low="3" next="0" />
             </daemon>
             <daemon type="scheduler" arch="x86_64" state="dead">
               <queue high="39" med="0" low="7" next="0" />
             </daemon>
-            <daemon type="repserver" state="running" starttime="1503323652" />
+            <daemon type="repserver" state="running" starttime="1503405031" />
             <daemon type="publisher" state="dead" />
           </partition>
         </workerstatus>
     http_version: 
-  recorded_at: Mon, 21 Aug 2017 14:07:23 GMT
+  recorded_at: Tue, 22 Aug 2017 12:31:17 GMT
 - request:
     method: get
     uri: http://localhost:3200/source/home:tom:branches:ProjectWithRepo:Update/ProjectWithRepo_package
@@ -2556,18 +2534,18 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="ProjectWithRepo_package" rev="4" vrev="4" srcmd5="3b4a835fa1e497790f82e45048a78427">
-          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" srcmd5="09e82b0920e2079611427fc5ae96b076" baserev="09e82b0920e2079611427fc5ae96b076" xsrcmd5="015a0a0d39a8e944210a9d525dc6ae91" lsrcmd5="3b4a835fa1e497790f82e45048a78427" />
-          <entry name="DUMMY_FILE" md5="275876e34cf609db118f3d84b799a790" size="5" mtime="1503324268" />
-          <entry name="_config" md5="55041d03ef8e31e551b3edd00464f7ea" size="103" mtime="1503324439" />
-          <entry name="_link" md5="6ffab3981d3cd40f46924a3319a54098" size="130" mtime="1503324440" />
-          <entry name="somefile.txt" md5="72a89c51cb636651b1da704fa7b303ee" size="160" mtime="1503324439" />
+        <directory name="ProjectWithRepo_package" rev="2" vrev="2" srcmd5="5acba764a37a9bc6490f80deca372916">
+          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" srcmd5="e9d965f2d319f4124109f14a13f4e431" baserev="e9d965f2d319f4124109f14a13f4e431" xsrcmd5="6d8b4e042078d289ced39a1738e21c95" lsrcmd5="5acba764a37a9bc6490f80deca372916" />
+          <entry name="DUMMY_FILE" md5="275876e34cf609db118f3d84b799a790" size="5" mtime="1503405075" />
+          <entry name="_config" md5="7159169868967997b7eabbd94d805185" size="238" mtime="1503405073" />
+          <entry name="_link" md5="11504ac69b4a7053159649a50cf86e1f" size="130" mtime="1503405074" />
+          <entry name="somefile.txt" md5="b4b03ef7ef00ded93403c2c595500c4f" size="116" mtime="1503405073" />
         </directory>
     http_version: 
-  recorded_at: Mon, 21 Aug 2017 14:07:24 GMT
+  recorded_at: Tue, 22 Aug 2017 12:31:19 GMT
 - request:
     method: post
-    uri: http://localhost:3200/source/home:tom:branches:ProjectWithRepo:Update/ProjectWithRepo_package?cmd=diff&expand=1&filelimit=10000&opackage=ProjectWithRepo_package&oproject=ProjectWithRepo:Update&view=xml&withissues=1
+    uri: http://localhost:3200/source/home:tom:branches:ProjectWithRepo:Update/ProjectWithRepo_package?cmd=diff&expand=1&filelimit=10000&opackage=ProjectWithRepo_package&oproject=ProjectWithRepo:Update&rev=6d8b4e042078d289ced39a1738e21c95&view=xml&withissues=1
     body:
       encoding: UTF-8
       string: ''
@@ -2592,13 +2570,13 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '580'
+      - '611'
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="d88621a8275d9ad55d7fee27df34b557">
-          <old project="ProjectWithRepo:Update" package="ProjectWithRepo_package" rev="4" srcmd5="09e82b0920e2079611427fc5ae96b076" />
-          <new project="home:tom:branches:ProjectWithRepo:Update" package="ProjectWithRepo_package" rev="4" srcmd5="015a0a0d39a8e944210a9d525dc6ae91" />
+        <sourcediff key="5fc708afda388d0d4ddeaa33bda7c0df">
+          <old project="ProjectWithRepo:Update" package="ProjectWithRepo_package" rev="2" srcmd5="e9d965f2d319f4124109f14a13f4e431" />
+          <new project="home:tom:branches:ProjectWithRepo:Update" package="ProjectWithRepo_package" rev="6d8b4e042078d289ced39a1738e21c95" srcmd5="6d8b4e042078d289ced39a1738e21c95" />
           <files>
             <file state="added">
               <new name="DUMMY_FILE" md5="275876e34cf609db118f3d84b799a790" size="5" />
@@ -2612,7 +2590,7 @@ http_interactions:
           </issues>
         </sourcediff>
     http_version: 
-  recorded_at: Mon, 21 Aug 2017 14:07:25 GMT
+  recorded_at: Tue, 22 Aug 2017 12:31:19 GMT
 - request:
     method: get
     uri: http://localhost:3200/build/home:tom:branches:ProjectWithRepo:Update/_result?package=ProjectWithRepo_package&view=status
@@ -2648,7 +2626,7 @@ http_interactions:
           <result project="home:tom:branches:ProjectWithRepo:Update" repository="repository_2" arch="i586" code="unknown" state="unknown" />
         </resultlist>
     http_version: 
-  recorded_at: Mon, 21 Aug 2017 14:07:25 GMT
+  recorded_at: Tue, 22 Aug 2017 12:31:19 GMT
 - request:
     method: get
     uri: http://localhost:3200/build/home:tom:branches:ProjectWithRepo:Update/_result?locallink=1&multibuild=1&package=ProjectWithRepo_package&view=status
@@ -2684,7 +2662,7 @@ http_interactions:
           <result project="home:tom:branches:ProjectWithRepo:Update" repository="repository_2" arch="i586" code="unknown" state="unknown" />
         </resultlist>
     http_version: 
-  recorded_at: Mon, 21 Aug 2017 14:07:25 GMT
+  recorded_at: Tue, 22 Aug 2017 12:31:19 GMT
 - request:
     method: get
     uri: http://localhost:3200/source/home:tom:branches:ProjectWithRepo:Update/ProjectWithRepo_package
@@ -2714,18 +2692,18 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="ProjectWithRepo_package" rev="4" vrev="4" srcmd5="3b4a835fa1e497790f82e45048a78427">
-          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" srcmd5="09e82b0920e2079611427fc5ae96b076" baserev="09e82b0920e2079611427fc5ae96b076" xsrcmd5="015a0a0d39a8e944210a9d525dc6ae91" lsrcmd5="3b4a835fa1e497790f82e45048a78427" />
-          <entry name="DUMMY_FILE" md5="275876e34cf609db118f3d84b799a790" size="5" mtime="1503324268" />
-          <entry name="_config" md5="55041d03ef8e31e551b3edd00464f7ea" size="103" mtime="1503324439" />
-          <entry name="_link" md5="6ffab3981d3cd40f46924a3319a54098" size="130" mtime="1503324440" />
-          <entry name="somefile.txt" md5="72a89c51cb636651b1da704fa7b303ee" size="160" mtime="1503324439" />
+        <directory name="ProjectWithRepo_package" rev="2" vrev="2" srcmd5="5acba764a37a9bc6490f80deca372916">
+          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" srcmd5="e9d965f2d319f4124109f14a13f4e431" baserev="e9d965f2d319f4124109f14a13f4e431" xsrcmd5="6d8b4e042078d289ced39a1738e21c95" lsrcmd5="5acba764a37a9bc6490f80deca372916" />
+          <entry name="DUMMY_FILE" md5="275876e34cf609db118f3d84b799a790" size="5" mtime="1503405075" />
+          <entry name="_config" md5="7159169868967997b7eabbd94d805185" size="238" mtime="1503405073" />
+          <entry name="_link" md5="11504ac69b4a7053159649a50cf86e1f" size="130" mtime="1503405074" />
+          <entry name="somefile.txt" md5="b4b03ef7ef00ded93403c2c595500c4f" size="116" mtime="1503405073" />
         </directory>
     http_version: 
-  recorded_at: Mon, 21 Aug 2017 14:07:25 GMT
+  recorded_at: Tue, 22 Aug 2017 12:31:19 GMT
 - request:
     method: get
-    uri: http://localhost:3200/source/home:tom:branches:ProjectWithRepo:Update/ProjectWithRepo_package?expand=1
+    uri: http://localhost:3200/source/home:tom:branches:ProjectWithRepo:Update/ProjectWithRepo_package?expand=1&rev=6d8b4e042078d289ced39a1738e21c95
     body:
       encoding: US-ASCII
       string: ''
@@ -2750,21 +2728,21 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '650'
+      - '641'
     body:
       encoding: UTF-8
       string: |
-        <directory name="ProjectWithRepo_package" rev="015a0a0d39a8e944210a9d525dc6ae91" vrev="8" srcmd5="015a0a0d39a8e944210a9d525dc6ae91">
-          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" srcmd5="09e82b0920e2079611427fc5ae96b076" baserev="09e82b0920e2079611427fc5ae96b076" lsrcmd5="3b4a835fa1e497790f82e45048a78427" />
-          <entry name="DUMMY_FILE" md5="275876e34cf609db118f3d84b799a790" size="5" mtime="1503324268" />
-          <entry name="_config" md5="55041d03ef8e31e551b3edd00464f7ea" size="103" mtime="1503324439" />
-          <entry name="somefile.txt" md5="72a89c51cb636651b1da704fa7b303ee" size="160" mtime="1503324439" />
+        <directory name="ProjectWithRepo_package" rev="6d8b4e042078d289ced39a1738e21c95" srcmd5="6d8b4e042078d289ced39a1738e21c95">
+          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" srcmd5="e9d965f2d319f4124109f14a13f4e431" baserev="e9d965f2d319f4124109f14a13f4e431" lsrcmd5="5acba764a37a9bc6490f80deca372916" />
+          <entry name="DUMMY_FILE" md5="275876e34cf609db118f3d84b799a790" size="5" mtime="1503405075" />
+          <entry name="_config" md5="7159169868967997b7eabbd94d805185" size="238" mtime="1503405073" />
+          <entry name="somefile.txt" md5="b4b03ef7ef00ded93403c2c595500c4f" size="116" mtime="1503405073" />
         </directory>
     http_version: 
-  recorded_at: Mon, 21 Aug 2017 14:07:25 GMT
+  recorded_at: Tue, 22 Aug 2017 12:31:19 GMT
 - request:
     method: get
-    uri: http://localhost:3200/source/home:tom:branches:ProjectWithRepo:Update/ProjectWithRepo_package?expand=1
+    uri: http://localhost:3200/source/home:tom:branches:ProjectWithRepo:Update/ProjectWithRepo_package?expand=1&rev=6d8b4e042078d289ced39a1738e21c95
     body:
       encoding: US-ASCII
       string: ''
@@ -2787,18 +2765,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '650'
+      - '641'
     body:
       encoding: UTF-8
       string: |
-        <directory name="ProjectWithRepo_package" rev="015a0a0d39a8e944210a9d525dc6ae91" vrev="8" srcmd5="015a0a0d39a8e944210a9d525dc6ae91">
-          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" srcmd5="09e82b0920e2079611427fc5ae96b076" baserev="09e82b0920e2079611427fc5ae96b076" lsrcmd5="3b4a835fa1e497790f82e45048a78427" />
-          <entry name="DUMMY_FILE" md5="275876e34cf609db118f3d84b799a790" size="5" mtime="1503324268" />
-          <entry name="_config" md5="55041d03ef8e31e551b3edd00464f7ea" size="103" mtime="1503324439" />
-          <entry name="somefile.txt" md5="72a89c51cb636651b1da704fa7b303ee" size="160" mtime="1503324439" />
+        <directory name="ProjectWithRepo_package" rev="6d8b4e042078d289ced39a1738e21c95" srcmd5="6d8b4e042078d289ced39a1738e21c95">
+          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" srcmd5="e9d965f2d319f4124109f14a13f4e431" baserev="e9d965f2d319f4124109f14a13f4e431" lsrcmd5="5acba764a37a9bc6490f80deca372916" />
+          <entry name="DUMMY_FILE" md5="275876e34cf609db118f3d84b799a790" size="5" mtime="1503405075" />
+          <entry name="_config" md5="7159169868967997b7eabbd94d805185" size="238" mtime="1503405073" />
+          <entry name="somefile.txt" md5="b4b03ef7ef00ded93403c2c595500c4f" size="116" mtime="1503405073" />
         </directory>
     http_version: 
-  recorded_at: Mon, 21 Aug 2017 14:07:25 GMT
+  recorded_at: Tue, 22 Aug 2017 12:31:19 GMT
 - request:
     method: put
     uri: http://localhost:3200/source/MaintenanceProject:0/_meta?requestid=1&user=maintenance_coord
@@ -2853,7 +2831,7 @@ http_interactions:
           </publish>
         </project>
     http_version: 
-  recorded_at: Mon, 21 Aug 2017 14:07:25 GMT
+  recorded_at: Tue, 22 Aug 2017 12:31:19 GMT
 - request:
     method: get
     uri: http://localhost:3200/source/home:tom:branches:ProjectWithRepo:Update/ProjectWithRepo_package
@@ -2883,15 +2861,15 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="ProjectWithRepo_package" rev="4" vrev="4" srcmd5="3b4a835fa1e497790f82e45048a78427">
-          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" srcmd5="09e82b0920e2079611427fc5ae96b076" baserev="09e82b0920e2079611427fc5ae96b076" xsrcmd5="015a0a0d39a8e944210a9d525dc6ae91" lsrcmd5="3b4a835fa1e497790f82e45048a78427" />
-          <entry name="DUMMY_FILE" md5="275876e34cf609db118f3d84b799a790" size="5" mtime="1503324268" />
-          <entry name="_config" md5="55041d03ef8e31e551b3edd00464f7ea" size="103" mtime="1503324439" />
-          <entry name="_link" md5="6ffab3981d3cd40f46924a3319a54098" size="130" mtime="1503324440" />
-          <entry name="somefile.txt" md5="72a89c51cb636651b1da704fa7b303ee" size="160" mtime="1503324439" />
+        <directory name="ProjectWithRepo_package" rev="2" vrev="2" srcmd5="5acba764a37a9bc6490f80deca372916">
+          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" srcmd5="e9d965f2d319f4124109f14a13f4e431" baserev="e9d965f2d319f4124109f14a13f4e431" xsrcmd5="6d8b4e042078d289ced39a1738e21c95" lsrcmd5="5acba764a37a9bc6490f80deca372916" />
+          <entry name="DUMMY_FILE" md5="275876e34cf609db118f3d84b799a790" size="5" mtime="1503405075" />
+          <entry name="_config" md5="7159169868967997b7eabbd94d805185" size="238" mtime="1503405073" />
+          <entry name="_link" md5="11504ac69b4a7053159649a50cf86e1f" size="130" mtime="1503405074" />
+          <entry name="somefile.txt" md5="b4b03ef7ef00ded93403c2c595500c4f" size="116" mtime="1503405073" />
         </directory>
     http_version: 
-  recorded_at: Mon, 21 Aug 2017 14:07:25 GMT
+  recorded_at: Tue, 22 Aug 2017 12:31:19 GMT
 - request:
     method: post
     uri: http://localhost:3200/search/package/id?match=(linkinfo/@package=%22ProjectWithRepo_package%22%20and%20linkinfo/@project=%22ProjectWithRepo:Update%22%20and%20starts-with(@project,%22MaintenanceProject:%22))
@@ -2919,15 +2897,14 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '126'
+      - '27'
     body:
       encoding: UTF-8
       string: |
         <collection>
-          <package name="ProjectWithRepo_package.ProjectWithRepo_Update" project="MaintenanceProject:0" />
         </collection>
     http_version: 
-  recorded_at: Mon, 21 Aug 2017 14:07:25 GMT
+  recorded_at: Tue, 22 Aug 2017 12:31:19 GMT
 - request:
     method: post
     uri: http://localhost:3200/search/package/id?match=(linkinfo/@package=%22ProjectWithRepo_package%22%20and%20linkinfo/@project=%22ProjectWithRepo%22%20and%20@project=%22ProjectWithRepo%22)
@@ -2962,7 +2939,7 @@ http_interactions:
         <collection>
         </collection>
     http_version: 
-  recorded_at: Mon, 21 Aug 2017 14:07:25 GMT
+  recorded_at: Tue, 22 Aug 2017 12:31:19 GMT
 - request:
     method: put
     uri: http://localhost:3200/source/MaintenanceProject:0/ProjectWithRepo_package.ProjectWithRepo_Update/_meta?user=maintenance_coord
@@ -2970,8 +2947,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="ProjectWithRepo_package.ProjectWithRepo_Update" project="MaintenanceProject:0">
-          <title>Moab Is My Washpot</title>
-          <description>Eius ut consequuntur nihil.</description>
+          <title>Have His Carcase</title>
+          <description>Molestiae eligendi asperiores quod voluptatibus totam non recusandae voluptas.</description>
           <releasename>ProjectWithRepo_package</releasename>
         </package>
     headers:
@@ -2993,17 +2970,17 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '252'
+      - '301'
     body:
       encoding: UTF-8
       string: |
         <package name="ProjectWithRepo_package.ProjectWithRepo_Update" project="MaintenanceProject:0">
-          <title>Moab Is My Washpot</title>
-          <description>Eius ut consequuntur nihil.</description>
+          <title>Have His Carcase</title>
+          <description>Molestiae eligendi asperiores quod voluptatibus totam non recusandae voluptas.</description>
           <releasename>ProjectWithRepo_package</releasename>
         </package>
     http_version: 
-  recorded_at: Mon, 21 Aug 2017 14:07:25 GMT
+  recorded_at: Tue, 22 Aug 2017 12:31:19 GMT
 - request:
     method: post
     uri: http://localhost:3200/source/MaintenanceProject:0/ProjectWithRepo_package.ProjectWithRepo_Update?cmd=branch&opackage=ProjectWithRepo_package&oproject=ProjectWithRepo:Update&user=maintenance_coord
@@ -3035,16 +3012,16 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <revision rev="5" vrev="5">
-          <srcmd5>86a991e1d0fb1e255e605e346b8c71b2</srcmd5>
+        <revision rev="1" vrev="1">
+          <srcmd5>8f207ebc6846b26ebb947a0d4399345e</srcmd5>
           <version>unknown</version>
-          <time>1503324445</time>
+          <time>1503405079</time>
           <user>maintenance_coord</user>
           <comment></comment>
           <requestid/>
         </revision>
     http_version: 
-  recorded_at: Mon, 21 Aug 2017 14:07:25 GMT
+  recorded_at: Tue, 22 Aug 2017 12:31:19 GMT
 - request:
     method: put
     uri: http://localhost:3200/source/MaintenanceProject:0/ProjectWithRepo_package.ProjectWithRepo_Update/_meta?user=maintenance_coord
@@ -3052,8 +3029,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="ProjectWithRepo_package.ProjectWithRepo_Update" project="MaintenanceProject:0">
-          <title>Moab Is My Washpot</title>
-          <description>Eius ut consequuntur nihil.</description>
+          <title>Have His Carcase</title>
+          <description>Molestiae eligendi asperiores quod voluptatibus totam non recusandae voluptas.</description>
           <releasename>ProjectWithRepo_package</releasename>
         </package>
     headers:
@@ -3075,17 +3052,17 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '252'
+      - '301'
     body:
       encoding: UTF-8
       string: |
         <package name="ProjectWithRepo_package.ProjectWithRepo_Update" project="MaintenanceProject:0">
-          <title>Moab Is My Washpot</title>
-          <description>Eius ut consequuntur nihil.</description>
+          <title>Have His Carcase</title>
+          <description>Molestiae eligendi asperiores quod voluptatibus totam non recusandae voluptas.</description>
           <releasename>ProjectWithRepo_package</releasename>
         </package>
     http_version: 
-  recorded_at: Mon, 21 Aug 2017 14:07:26 GMT
+  recorded_at: Tue, 22 Aug 2017 12:31:20 GMT
 - request:
     method: get
     uri: http://localhost:3200/source/MaintenanceProject:0/ProjectWithRepo_package.ProjectWithRepo_Update
@@ -3115,14 +3092,14 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="ProjectWithRepo_package.ProjectWithRepo_Update" rev="5" vrev="5" srcmd5="86a991e1d0fb1e255e605e346b8c71b2">
-          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" srcmd5="09e82b0920e2079611427fc5ae96b076" baserev="09e82b0920e2079611427fc5ae96b076" xsrcmd5="dd8fee4cd9676519d6bc95db70858eac" lsrcmd5="86a991e1d0fb1e255e605e346b8c71b2" />
-          <entry name="_config" md5="55041d03ef8e31e551b3edd00464f7ea" size="103" mtime="1503324439" />
-          <entry name="_link" md5="3f7843b2f03812aa3a4c42dd85f1b177" size="164" mtime="1503324445" />
-          <entry name="somefile.txt" md5="72a89c51cb636651b1da704fa7b303ee" size="160" mtime="1503324439" />
+        <directory name="ProjectWithRepo_package.ProjectWithRepo_Update" rev="1" vrev="1" srcmd5="8f207ebc6846b26ebb947a0d4399345e">
+          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" srcmd5="e9d965f2d319f4124109f14a13f4e431" baserev="e9d965f2d319f4124109f14a13f4e431" xsrcmd5="ef9928a63930d4797ced0ef2ad58ed0c" lsrcmd5="8f207ebc6846b26ebb947a0d4399345e" />
+          <entry name="_config" md5="7159169868967997b7eabbd94d805185" size="238" mtime="1503405073" />
+          <entry name="_link" md5="ad672afb37ca2f6a039ad35297d226d1" size="164" mtime="1503405079" />
+          <entry name="somefile.txt" md5="b4b03ef7ef00ded93403c2c595500c4f" size="116" mtime="1503405073" />
         </directory>
     http_version: 
-  recorded_at: Mon, 21 Aug 2017 14:07:26 GMT
+  recorded_at: Tue, 22 Aug 2017 12:31:20 GMT
 - request:
     method: get
     uri: http://localhost:3200/source/MaintenanceProject:0/ProjectWithRepo_package.ProjectWithRepo_Update?nofilename=1&view=info&withchangesmd5=1
@@ -3152,13 +3129,13 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <sourceinfo package="ProjectWithRepo_package.ProjectWithRepo_Update" rev="5" vrev="9" srcmd5="dd8fee4cd9676519d6bc95db70858eac" lsrcmd5="86a991e1d0fb1e255e605e346b8c71b2" verifymd5="09e82b0920e2079611427fc5ae96b076">
+        <sourceinfo package="ProjectWithRepo_package.ProjectWithRepo_Update" rev="1" vrev="3" srcmd5="ef9928a63930d4797ced0ef2ad58ed0c" lsrcmd5="8f207ebc6846b26ebb947a0d4399345e" verifymd5="e9d965f2d319f4124109f14a13f4e431">
           <linked project="ProjectWithRepo:Update" package="ProjectWithRepo_package" />
           <linked project="ProjectWithRepo" package="ProjectWithRepo_package" />
-          <revtime>1503324445</revtime>
+          <revtime>1503405079</revtime>
         </sourceinfo>
     http_version: 
-  recorded_at: Mon, 21 Aug 2017 14:07:26 GMT
+  recorded_at: Tue, 22 Aug 2017 12:31:20 GMT
 - request:
     method: get
     uri: http://localhost:3200/source/MaintenanceProject:0/ProjectWithRepo_package.ProjectWithRepo_Update
@@ -3188,14 +3165,14 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="ProjectWithRepo_package.ProjectWithRepo_Update" rev="5" vrev="5" srcmd5="86a991e1d0fb1e255e605e346b8c71b2">
-          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" srcmd5="09e82b0920e2079611427fc5ae96b076" baserev="09e82b0920e2079611427fc5ae96b076" xsrcmd5="dd8fee4cd9676519d6bc95db70858eac" lsrcmd5="86a991e1d0fb1e255e605e346b8c71b2" />
-          <entry name="_config" md5="55041d03ef8e31e551b3edd00464f7ea" size="103" mtime="1503324439" />
-          <entry name="_link" md5="3f7843b2f03812aa3a4c42dd85f1b177" size="164" mtime="1503324445" />
-          <entry name="somefile.txt" md5="72a89c51cb636651b1da704fa7b303ee" size="160" mtime="1503324439" />
+        <directory name="ProjectWithRepo_package.ProjectWithRepo_Update" rev="1" vrev="1" srcmd5="8f207ebc6846b26ebb947a0d4399345e">
+          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" srcmd5="e9d965f2d319f4124109f14a13f4e431" baserev="e9d965f2d319f4124109f14a13f4e431" xsrcmd5="ef9928a63930d4797ced0ef2ad58ed0c" lsrcmd5="8f207ebc6846b26ebb947a0d4399345e" />
+          <entry name="_config" md5="7159169868967997b7eabbd94d805185" size="238" mtime="1503405073" />
+          <entry name="_link" md5="ad672afb37ca2f6a039ad35297d226d1" size="164" mtime="1503405079" />
+          <entry name="somefile.txt" md5="b4b03ef7ef00ded93403c2c595500c4f" size="116" mtime="1503405073" />
         </directory>
     http_version: 
-  recorded_at: Mon, 21 Aug 2017 14:07:26 GMT
+  recorded_at: Tue, 22 Aug 2017 12:31:20 GMT
 - request:
     method: post
     uri: http://localhost:3200/source/MaintenanceProject:0/ProjectWithRepo_package.ProjectWithRepo_Update?cmd=diff&linkrev=base&onlyissues=1&orev=0&view=xml
@@ -3227,15 +3204,15 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="00a8f538a8458c1ee8cd1af5b5a9da0b">
+        <sourcediff key="b61c34ff40308ddf8f623d6890654428">
           <old project="MaintenanceProject:0" package="ProjectWithRepo_package.ProjectWithRepo_Update" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e" />
-          <new project="MaintenanceProject:0" package="ProjectWithRepo_package.ProjectWithRepo_Update" rev="5" srcmd5="86a991e1d0fb1e255e605e346b8c71b2" />
+          <new project="MaintenanceProject:0" package="ProjectWithRepo_package.ProjectWithRepo_Update" rev="1" srcmd5="8f207ebc6846b26ebb947a0d4399345e" />
           <files />
           <issues>
           </issues>
         </sourcediff>
     http_version: 
-  recorded_at: Mon, 21 Aug 2017 14:07:26 GMT
+  recorded_at: Tue, 22 Aug 2017 12:31:20 GMT
 - request:
     method: post
     uri: http://localhost:3200/source/MaintenanceProject:0/ProjectWithRepo_package.ProjectWithRepo_Update?cmd=linkdiff&linkrev=base&onlyissues=1&view=xml
@@ -3267,13 +3244,13 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="c2d0ce4eef4d88842741edf1dd777bce">
-          <old project="ProjectWithRepo:Update" package="ProjectWithRepo_package" rev="09e82b0920e2079611427fc5ae96b076" srcmd5="09e82b0920e2079611427fc5ae96b076" />
-          <new project="MaintenanceProject:0" package="ProjectWithRepo_package.ProjectWithRepo_Update" rev="dd8fee4cd9676519d6bc95db70858eac" srcmd5="dd8fee4cd9676519d6bc95db70858eac" />
+        <sourcediff key="2bd7c5fd0453c368b796a8f70d681186">
+          <old project="ProjectWithRepo:Update" package="ProjectWithRepo_package" rev="e9d965f2d319f4124109f14a13f4e431" srcmd5="e9d965f2d319f4124109f14a13f4e431" />
+          <new project="MaintenanceProject:0" package="ProjectWithRepo_package.ProjectWithRepo_Update" rev="ef9928a63930d4797ced0ef2ad58ed0c" srcmd5="ef9928a63930d4797ced0ef2ad58ed0c" />
           <files />
         </sourcediff>
     http_version: 
-  recorded_at: Mon, 21 Aug 2017 14:07:26 GMT
+  recorded_at: Tue, 22 Aug 2017 12:31:20 GMT
 - request:
     method: put
     uri: http://localhost:3200/source/MaintenanceProject:0/ProjectWithRepo_package.ProjectWithRepo_Update/_meta?user=maintenance_coord
@@ -3281,8 +3258,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="ProjectWithRepo_package.ProjectWithRepo_Update" project="MaintenanceProject:0">
-          <title>Moab Is My Washpot</title>
-          <description>Eius ut consequuntur nihil.</description>
+          <title>Have His Carcase</title>
+          <description>Molestiae eligendi asperiores quod voluptatibus totam non recusandae voluptas.</description>
           <releasename>ProjectWithRepo_package</releasename>
           <build>
             <enable repository="ProjectWithRepo_Update"/>
@@ -3307,20 +3284,20 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '324'
+      - '373'
     body:
       encoding: UTF-8
       string: |
         <package name="ProjectWithRepo_package.ProjectWithRepo_Update" project="MaintenanceProject:0">
-          <title>Moab Is My Washpot</title>
-          <description>Eius ut consequuntur nihil.</description>
+          <title>Have His Carcase</title>
+          <description>Molestiae eligendi asperiores quod voluptatibus totam non recusandae voluptas.</description>
           <releasename>ProjectWithRepo_package</releasename>
           <build>
             <enable repository="ProjectWithRepo_Update" />
           </build>
         </package>
     http_version: 
-  recorded_at: Mon, 21 Aug 2017 14:07:26 GMT
+  recorded_at: Tue, 22 Aug 2017 12:31:20 GMT
 - request:
     method: get
     uri: http://localhost:3200/source/MaintenanceProject:0/ProjectWithRepo_package.ProjectWithRepo_Update
@@ -3350,14 +3327,14 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="ProjectWithRepo_package.ProjectWithRepo_Update" rev="5" vrev="5" srcmd5="86a991e1d0fb1e255e605e346b8c71b2">
-          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" srcmd5="09e82b0920e2079611427fc5ae96b076" baserev="09e82b0920e2079611427fc5ae96b076" xsrcmd5="dd8fee4cd9676519d6bc95db70858eac" lsrcmd5="86a991e1d0fb1e255e605e346b8c71b2" />
-          <entry name="_config" md5="55041d03ef8e31e551b3edd00464f7ea" size="103" mtime="1503324439" />
-          <entry name="_link" md5="3f7843b2f03812aa3a4c42dd85f1b177" size="164" mtime="1503324445" />
-          <entry name="somefile.txt" md5="72a89c51cb636651b1da704fa7b303ee" size="160" mtime="1503324439" />
+        <directory name="ProjectWithRepo_package.ProjectWithRepo_Update" rev="1" vrev="1" srcmd5="8f207ebc6846b26ebb947a0d4399345e">
+          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" srcmd5="e9d965f2d319f4124109f14a13f4e431" baserev="e9d965f2d319f4124109f14a13f4e431" xsrcmd5="ef9928a63930d4797ced0ef2ad58ed0c" lsrcmd5="8f207ebc6846b26ebb947a0d4399345e" />
+          <entry name="_config" md5="7159169868967997b7eabbd94d805185" size="238" mtime="1503405073" />
+          <entry name="_link" md5="ad672afb37ca2f6a039ad35297d226d1" size="164" mtime="1503405079" />
+          <entry name="somefile.txt" md5="b4b03ef7ef00ded93403c2c595500c4f" size="116" mtime="1503405073" />
         </directory>
     http_version: 
-  recorded_at: Mon, 21 Aug 2017 14:07:26 GMT
+  recorded_at: Tue, 22 Aug 2017 12:31:20 GMT
 - request:
     method: get
     uri: http://localhost:3200/source/MaintenanceProject:0/ProjectWithRepo_package.ProjectWithRepo_Update
@@ -3387,14 +3364,14 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="ProjectWithRepo_package.ProjectWithRepo_Update" rev="5" vrev="5" srcmd5="86a991e1d0fb1e255e605e346b8c71b2">
-          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" srcmd5="09e82b0920e2079611427fc5ae96b076" baserev="09e82b0920e2079611427fc5ae96b076" xsrcmd5="dd8fee4cd9676519d6bc95db70858eac" lsrcmd5="86a991e1d0fb1e255e605e346b8c71b2" />
-          <entry name="_config" md5="55041d03ef8e31e551b3edd00464f7ea" size="103" mtime="1503324439" />
-          <entry name="_link" md5="3f7843b2f03812aa3a4c42dd85f1b177" size="164" mtime="1503324445" />
-          <entry name="somefile.txt" md5="72a89c51cb636651b1da704fa7b303ee" size="160" mtime="1503324439" />
+        <directory name="ProjectWithRepo_package.ProjectWithRepo_Update" rev="1" vrev="1" srcmd5="8f207ebc6846b26ebb947a0d4399345e">
+          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" srcmd5="e9d965f2d319f4124109f14a13f4e431" baserev="e9d965f2d319f4124109f14a13f4e431" xsrcmd5="ef9928a63930d4797ced0ef2ad58ed0c" lsrcmd5="8f207ebc6846b26ebb947a0d4399345e" />
+          <entry name="_config" md5="7159169868967997b7eabbd94d805185" size="238" mtime="1503405073" />
+          <entry name="_link" md5="ad672afb37ca2f6a039ad35297d226d1" size="164" mtime="1503405079" />
+          <entry name="somefile.txt" md5="b4b03ef7ef00ded93403c2c595500c4f" size="116" mtime="1503405073" />
         </directory>
     http_version: 
-  recorded_at: Mon, 21 Aug 2017 14:07:26 GMT
+  recorded_at: Tue, 22 Aug 2017 12:31:20 GMT
 - request:
     method: get
     uri: http://localhost:3200/source/MaintenanceProject:0/ProjectWithRepo_package.ProjectWithRepo_Update
@@ -3424,14 +3401,14 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="ProjectWithRepo_package.ProjectWithRepo_Update" rev="5" vrev="5" srcmd5="86a991e1d0fb1e255e605e346b8c71b2">
-          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" srcmd5="09e82b0920e2079611427fc5ae96b076" baserev="09e82b0920e2079611427fc5ae96b076" xsrcmd5="dd8fee4cd9676519d6bc95db70858eac" lsrcmd5="86a991e1d0fb1e255e605e346b8c71b2" />
-          <entry name="_config" md5="55041d03ef8e31e551b3edd00464f7ea" size="103" mtime="1503324439" />
-          <entry name="_link" md5="3f7843b2f03812aa3a4c42dd85f1b177" size="164" mtime="1503324445" />
-          <entry name="somefile.txt" md5="72a89c51cb636651b1da704fa7b303ee" size="160" mtime="1503324439" />
+        <directory name="ProjectWithRepo_package.ProjectWithRepo_Update" rev="1" vrev="1" srcmd5="8f207ebc6846b26ebb947a0d4399345e">
+          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" srcmd5="e9d965f2d319f4124109f14a13f4e431" baserev="e9d965f2d319f4124109f14a13f4e431" xsrcmd5="ef9928a63930d4797ced0ef2ad58ed0c" lsrcmd5="8f207ebc6846b26ebb947a0d4399345e" />
+          <entry name="_config" md5="7159169868967997b7eabbd94d805185" size="238" mtime="1503405073" />
+          <entry name="_link" md5="ad672afb37ca2f6a039ad35297d226d1" size="164" mtime="1503405079" />
+          <entry name="somefile.txt" md5="b4b03ef7ef00ded93403c2c595500c4f" size="116" mtime="1503405073" />
         </directory>
     http_version: 
-  recorded_at: Mon, 21 Aug 2017 14:07:26 GMT
+  recorded_at: Tue, 22 Aug 2017 12:31:20 GMT
 - request:
     method: post
     uri: http://localhost:3200/search/package/id?match=(linkinfo/@package=%22ProjectWithRepo_package%22%20and%20linkinfo/@project=%22ProjectWithRepo%22%20and%20@project=%22ProjectWithRepo%22)
@@ -3466,7 +3443,7 @@ http_interactions:
         <collection>
         </collection>
     http_version: 
-  recorded_at: Mon, 21 Aug 2017 14:07:26 GMT
+  recorded_at: Tue, 22 Aug 2017 12:31:20 GMT
 - request:
     method: put
     uri: http://localhost:3200/source/MaintenanceProject:0/_meta?user=maintenance_coord
@@ -3531,7 +3508,7 @@ http_interactions:
           </repository>
         </project>
     http_version: 
-  recorded_at: Mon, 21 Aug 2017 14:07:26 GMT
+  recorded_at: Tue, 22 Aug 2017 12:31:20 GMT
 - request:
     method: put
     uri: http://localhost:3200/source/MaintenanceProject:0/_meta?user=maintenance_coord
@@ -3596,10 +3573,10 @@ http_interactions:
           </repository>
         </project>
     http_version: 
-  recorded_at: Mon, 21 Aug 2017 14:07:26 GMT
+  recorded_at: Tue, 22 Aug 2017 12:31:20 GMT
 - request:
     method: post
-    uri: http://localhost:3200/source/MaintenanceProject:0/ProjectWithRepo_package.ProjectWithRepo_Update?cmd=copy&comment=Maintenance%20incident%20copy%20from%20project%20home:tom:branches:ProjectWithRepo:Update&expand=1&keeplink=1&opackage=ProjectWithRepo_package&oproject=home:tom:branches:ProjectWithRepo:Update&requestid=1&user=maintenance_coord&withacceptinfo=1
+    uri: http://localhost:3200/source/MaintenanceProject:0/ProjectWithRepo_package.ProjectWithRepo_Update?cmd=copy&comment=Maintenance%20incident%20copy%20from%20project%20home:tom:branches:ProjectWithRepo:Update&expand=1&keeplink=1&opackage=ProjectWithRepo_package&oproject=home:tom:branches:ProjectWithRepo:Update&orev=6d8b4e042078d289ced39a1738e21c95&requestid=1&user=maintenance_coord&withacceptinfo=1
     body:
       encoding: UTF-8
       string: ''
@@ -3628,17 +3605,17 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <revision rev="6" vrev="6">
-          <srcmd5>8c95ac173db372e4ec3afc73fe679c4a</srcmd5>
+        <revision rev="2" vrev="2">
+          <srcmd5>3bc4d536be0f4724dd0defa094f247cf</srcmd5>
           <version>unknown</version>
-          <time>1503324446</time>
+          <time>1503405080</time>
           <user>maintenance_coord</user>
           <comment>Maintenance incident copy from project home:tom:branches:ProjectWithRepo:Update</comment>
           <requestid>1</requestid>
-          <acceptinfo rev="6" srcmd5="8c95ac173db372e4ec3afc73fe679c4a" osrcmd5="86a991e1d0fb1e255e605e346b8c71b2" xsrcmd5="6c2a823ba5d861d74d5c25e6ef62df17" oxsrcmd5="dd8fee4cd9676519d6bc95db70858eac" />
+          <acceptinfo rev="2" srcmd5="3bc4d536be0f4724dd0defa094f247cf" osrcmd5="8f207ebc6846b26ebb947a0d4399345e" xsrcmd5="96b1040600ed3f57e960243b55548162" oxsrcmd5="ef9928a63930d4797ced0ef2ad58ed0c" />
         </revision>
     http_version: 
-  recorded_at: Mon, 21 Aug 2017 14:07:26 GMT
+  recorded_at: Tue, 22 Aug 2017 12:31:20 GMT
 - request:
     method: put
     uri: http://localhost:3200/source/MaintenanceProject:0/ProjectWithRepo_package.ProjectWithRepo_Update/_meta?user=maintenance_coord
@@ -3646,8 +3623,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="ProjectWithRepo_package.ProjectWithRepo_Update" project="MaintenanceProject:0">
-          <title>Moab Is My Washpot</title>
-          <description>Eius ut consequuntur nihil.</description>
+          <title>Have His Carcase</title>
+          <description>Molestiae eligendi asperiores quod voluptatibus totam non recusandae voluptas.</description>
           <releasename>ProjectWithRepo_package</releasename>
           <build>
             <enable repository="ProjectWithRepo_Update"/>
@@ -3672,20 +3649,20 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '324'
+      - '373'
     body:
       encoding: UTF-8
       string: |
         <package name="ProjectWithRepo_package.ProjectWithRepo_Update" project="MaintenanceProject:0">
-          <title>Moab Is My Washpot</title>
-          <description>Eius ut consequuntur nihil.</description>
+          <title>Have His Carcase</title>
+          <description>Molestiae eligendi asperiores quod voluptatibus totam non recusandae voluptas.</description>
           <releasename>ProjectWithRepo_package</releasename>
           <build>
             <enable repository="ProjectWithRepo_Update" />
           </build>
         </package>
     http_version: 
-  recorded_at: Mon, 21 Aug 2017 14:07:26 GMT
+  recorded_at: Tue, 22 Aug 2017 12:31:20 GMT
 - request:
     method: get
     uri: http://localhost:3200/source/MaintenanceProject:0/ProjectWithRepo_package.ProjectWithRepo_Update
@@ -3715,15 +3692,15 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="ProjectWithRepo_package.ProjectWithRepo_Update" rev="6" vrev="6" srcmd5="8c95ac173db372e4ec3afc73fe679c4a">
-          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" srcmd5="09e82b0920e2079611427fc5ae96b076" baserev="09e82b0920e2079611427fc5ae96b076" xsrcmd5="6c2a823ba5d861d74d5c25e6ef62df17" lsrcmd5="8c95ac173db372e4ec3afc73fe679c4a" />
-          <entry name="DUMMY_FILE" md5="275876e34cf609db118f3d84b799a790" size="5" mtime="1503324268" />
-          <entry name="_config" md5="55041d03ef8e31e551b3edd00464f7ea" size="103" mtime="1503324439" />
-          <entry name="_link" md5="3f7843b2f03812aa3a4c42dd85f1b177" size="164" mtime="1503324445" />
-          <entry name="somefile.txt" md5="72a89c51cb636651b1da704fa7b303ee" size="160" mtime="1503324439" />
+        <directory name="ProjectWithRepo_package.ProjectWithRepo_Update" rev="2" vrev="2" srcmd5="3bc4d536be0f4724dd0defa094f247cf">
+          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" srcmd5="e9d965f2d319f4124109f14a13f4e431" baserev="e9d965f2d319f4124109f14a13f4e431" xsrcmd5="96b1040600ed3f57e960243b55548162" lsrcmd5="3bc4d536be0f4724dd0defa094f247cf" />
+          <entry name="DUMMY_FILE" md5="275876e34cf609db118f3d84b799a790" size="5" mtime="1503405075" />
+          <entry name="_config" md5="7159169868967997b7eabbd94d805185" size="238" mtime="1503405073" />
+          <entry name="_link" md5="ad672afb37ca2f6a039ad35297d226d1" size="164" mtime="1503405079" />
+          <entry name="somefile.txt" md5="b4b03ef7ef00ded93403c2c595500c4f" size="116" mtime="1503405073" />
         </directory>
     http_version: 
-  recorded_at: Mon, 21 Aug 2017 14:07:26 GMT
+  recorded_at: Tue, 22 Aug 2017 12:31:20 GMT
 - request:
     method: get
     uri: http://localhost:3200/source/MaintenanceProject:0/ProjectWithRepo_package.ProjectWithRepo_Update?nofilename=1&view=info&withchangesmd5=1
@@ -3749,17 +3726,17 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '417'
+      - '416'
     body:
       encoding: UTF-8
       string: |
-        <sourceinfo package="ProjectWithRepo_package.ProjectWithRepo_Update" rev="6" vrev="10" srcmd5="6c2a823ba5d861d74d5c25e6ef62df17" lsrcmd5="8c95ac173db372e4ec3afc73fe679c4a" verifymd5="20df9d21809f8c811abf5fe64b26d948">
+        <sourceinfo package="ProjectWithRepo_package.ProjectWithRepo_Update" rev="2" vrev="4" srcmd5="96b1040600ed3f57e960243b55548162" lsrcmd5="3bc4d536be0f4724dd0defa094f247cf" verifymd5="227e65861e6374ec8a0776883967906a">
           <linked project="ProjectWithRepo:Update" package="ProjectWithRepo_package" />
           <linked project="ProjectWithRepo" package="ProjectWithRepo_package" />
-          <revtime>1503324446</revtime>
+          <revtime>1503405080</revtime>
         </sourceinfo>
     http_version: 
-  recorded_at: Mon, 21 Aug 2017 14:07:26 GMT
+  recorded_at: Tue, 22 Aug 2017 12:31:20 GMT
 - request:
     method: get
     uri: http://localhost:3200/source/MaintenanceProject:0/ProjectWithRepo_package.ProjectWithRepo_Update
@@ -3789,15 +3766,15 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="ProjectWithRepo_package.ProjectWithRepo_Update" rev="6" vrev="6" srcmd5="8c95ac173db372e4ec3afc73fe679c4a">
-          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" srcmd5="09e82b0920e2079611427fc5ae96b076" baserev="09e82b0920e2079611427fc5ae96b076" xsrcmd5="6c2a823ba5d861d74d5c25e6ef62df17" lsrcmd5="8c95ac173db372e4ec3afc73fe679c4a" />
-          <entry name="DUMMY_FILE" md5="275876e34cf609db118f3d84b799a790" size="5" mtime="1503324268" />
-          <entry name="_config" md5="55041d03ef8e31e551b3edd00464f7ea" size="103" mtime="1503324439" />
-          <entry name="_link" md5="3f7843b2f03812aa3a4c42dd85f1b177" size="164" mtime="1503324445" />
-          <entry name="somefile.txt" md5="72a89c51cb636651b1da704fa7b303ee" size="160" mtime="1503324439" />
+        <directory name="ProjectWithRepo_package.ProjectWithRepo_Update" rev="2" vrev="2" srcmd5="3bc4d536be0f4724dd0defa094f247cf">
+          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" srcmd5="e9d965f2d319f4124109f14a13f4e431" baserev="e9d965f2d319f4124109f14a13f4e431" xsrcmd5="96b1040600ed3f57e960243b55548162" lsrcmd5="3bc4d536be0f4724dd0defa094f247cf" />
+          <entry name="DUMMY_FILE" md5="275876e34cf609db118f3d84b799a790" size="5" mtime="1503405075" />
+          <entry name="_config" md5="7159169868967997b7eabbd94d805185" size="238" mtime="1503405073" />
+          <entry name="_link" md5="ad672afb37ca2f6a039ad35297d226d1" size="164" mtime="1503405079" />
+          <entry name="somefile.txt" md5="b4b03ef7ef00ded93403c2c595500c4f" size="116" mtime="1503405073" />
         </directory>
     http_version: 
-  recorded_at: Mon, 21 Aug 2017 14:07:26 GMT
+  recorded_at: Tue, 22 Aug 2017 12:31:20 GMT
 - request:
     method: post
     uri: http://localhost:3200/source/MaintenanceProject:0/ProjectWithRepo_package.ProjectWithRepo_Update?cmd=diff&linkrev=base&onlyissues=1&orev=0&view=xml
@@ -3829,15 +3806,15 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="19494ad5fd9a44aa388f5358268d23f5">
+        <sourcediff key="bbccdf3aeea2076b584883bbd16cc8c8">
           <old project="MaintenanceProject:0" package="ProjectWithRepo_package.ProjectWithRepo_Update" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e" />
-          <new project="MaintenanceProject:0" package="ProjectWithRepo_package.ProjectWithRepo_Update" rev="6" srcmd5="8c95ac173db372e4ec3afc73fe679c4a" />
+          <new project="MaintenanceProject:0" package="ProjectWithRepo_package.ProjectWithRepo_Update" rev="2" srcmd5="3bc4d536be0f4724dd0defa094f247cf" />
           <files />
           <issues>
           </issues>
         </sourcediff>
     http_version: 
-  recorded_at: Mon, 21 Aug 2017 14:07:26 GMT
+  recorded_at: Tue, 22 Aug 2017 12:31:20 GMT
 - request:
     method: post
     uri: http://localhost:3200/source/MaintenanceProject:0/ProjectWithRepo_package.ProjectWithRepo_Update?cmd=linkdiff&linkrev=base&onlyissues=1&view=xml
@@ -3869,15 +3846,15 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="ace3a4b15a241d14542026ae3c8365c9">
-          <old project="ProjectWithRepo:Update" package="ProjectWithRepo_package" rev="09e82b0920e2079611427fc5ae96b076" srcmd5="09e82b0920e2079611427fc5ae96b076" />
-          <new project="MaintenanceProject:0" package="ProjectWithRepo_package.ProjectWithRepo_Update" rev="6c2a823ba5d861d74d5c25e6ef62df17" srcmd5="6c2a823ba5d861d74d5c25e6ef62df17" />
+        <sourcediff key="aa393379f0698c4b78a41bf61e79e894">
+          <old project="ProjectWithRepo:Update" package="ProjectWithRepo_package" rev="e9d965f2d319f4124109f14a13f4e431" srcmd5="e9d965f2d319f4124109f14a13f4e431" />
+          <new project="MaintenanceProject:0" package="ProjectWithRepo_package.ProjectWithRepo_Update" rev="96b1040600ed3f57e960243b55548162" srcmd5="96b1040600ed3f57e960243b55548162" />
           <files />
           <issues>
           </issues>
         </sourcediff>
     http_version: 
-  recorded_at: Mon, 21 Aug 2017 14:07:26 GMT
+  recorded_at: Tue, 22 Aug 2017 12:31:20 GMT
 - request:
     method: put
     uri: http://localhost:3200/source/MaintenanceProject:0/_meta?comment=maintenance_incident%20request%201&requestid=1&user=maintenance_coord
@@ -3942,7 +3919,7 @@ http_interactions:
           </repository>
         </project>
     http_version: 
-  recorded_at: Mon, 21 Aug 2017 14:07:26 GMT
+  recorded_at: Tue, 22 Aug 2017 12:31:20 GMT
 - request:
     method: put
     uri: http://localhost:3200/source/MaintenanceProject:0/patchinfo/_meta?user=maintenance_coord
@@ -3999,7 +3976,7 @@ http_interactions:
           </useforbuild>
         </package>
     http_version: 
-  recorded_at: Mon, 21 Aug 2017 14:07:26 GMT
+  recorded_at: Tue, 22 Aug 2017 12:31:20 GMT
 - request:
     method: put
     uri: http://localhost:3200/source/MaintenanceProject:0/patchinfo/_patchinfo?comment=generated%20by%20request%20id%201%20accept%20call&user=maintenance_coord
@@ -4036,16 +4013,16 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <revision rev="4" vrev="4">
+        <revision rev="1" vrev="1">
           <srcmd5>53b684c8c2dbc9672bb230d024c87a14</srcmd5>
           <version>unknown</version>
-          <time>1503324446</time>
+          <time>1503405080</time>
           <user>maintenance_coord</user>
           <comment>generated by request id 1 accept call</comment>
           <requestid/>
         </revision>
     http_version: 
-  recorded_at: Mon, 21 Aug 2017 14:07:26 GMT
+  recorded_at: Tue, 22 Aug 2017 12:31:20 GMT
 - request:
     method: put
     uri: http://localhost:3200/source/MaintenanceProject:0/patchinfo/_meta?user=maintenance_coord
@@ -4102,7 +4079,7 @@ http_interactions:
           </useforbuild>
         </package>
     http_version: 
-  recorded_at: Mon, 21 Aug 2017 14:07:26 GMT
+  recorded_at: Tue, 22 Aug 2017 12:31:20 GMT
 - request:
     method: get
     uri: http://localhost:3200/source/MaintenanceProject:0/patchinfo
@@ -4132,11 +4109,11 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="patchinfo" rev="4" vrev="4" srcmd5="53b684c8c2dbc9672bb230d024c87a14">
-          <entry name="_patchinfo" md5="34e0b04fccfd75faea0577efe7cd9ead" size="208" mtime="1503324275" />
+        <directory name="patchinfo" rev="1" vrev="1" srcmd5="53b684c8c2dbc9672bb230d024c87a14">
+          <entry name="_patchinfo" md5="34e0b04fccfd75faea0577efe7cd9ead" size="208" mtime="1503405080" />
         </directory>
     http_version: 
-  recorded_at: Mon, 21 Aug 2017 14:07:26 GMT
+  recorded_at: Tue, 22 Aug 2017 12:31:21 GMT
 - request:
     method: get
     uri: http://localhost:3200/source/MaintenanceProject:0/patchinfo?nofilename=1&view=info&withchangesmd5=1
@@ -4166,11 +4143,11 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <sourceinfo package="patchinfo" rev="4" vrev="4" srcmd5="53b684c8c2dbc9672bb230d024c87a14" verifymd5="53b684c8c2dbc9672bb230d024c87a14">
-          <revtime>1503324446</revtime>
+        <sourceinfo package="patchinfo" rev="1" vrev="1" srcmd5="53b684c8c2dbc9672bb230d024c87a14" verifymd5="53b684c8c2dbc9672bb230d024c87a14">
+          <revtime>1503405080</revtime>
         </sourceinfo>
     http_version: 
-  recorded_at: Mon, 21 Aug 2017 14:07:26 GMT
+  recorded_at: Tue, 22 Aug 2017 12:31:21 GMT
 - request:
     method: get
     uri: http://localhost:3200/source/MaintenanceProject:0/patchinfo
@@ -4200,11 +4177,11 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="patchinfo" rev="4" vrev="4" srcmd5="53b684c8c2dbc9672bb230d024c87a14">
-          <entry name="_patchinfo" md5="34e0b04fccfd75faea0577efe7cd9ead" size="208" mtime="1503324275" />
+        <directory name="patchinfo" rev="1" vrev="1" srcmd5="53b684c8c2dbc9672bb230d024c87a14">
+          <entry name="_patchinfo" md5="34e0b04fccfd75faea0577efe7cd9ead" size="208" mtime="1503405080" />
         </directory>
     http_version: 
-  recorded_at: Mon, 21 Aug 2017 14:07:26 GMT
+  recorded_at: Tue, 22 Aug 2017 12:31:21 GMT
 - request:
     method: get
     uri: http://localhost:3200/source/MaintenanceProject:0/patchinfo/_patchinfo
@@ -4242,10 +4219,10 @@ http_interactions:
           <description>I want the update</description>
         </patchinfo>
     http_version: 
-  recorded_at: Mon, 21 Aug 2017 14:07:26 GMT
+  recorded_at: Tue, 22 Aug 2017 12:31:21 GMT
 - request:
     method: post
-    uri: http://localhost:3200/source/MaintenanceProject:0/ProjectWithRepo_package.ProjectWithRepo_Update?cmd=diff&orev=dd8fee4cd9676519d6bc95db70858eac&rev=6c2a823ba5d861d74d5c25e6ef62df17&view=xml&withissues=1
+    uri: http://localhost:3200/source/MaintenanceProject:0/ProjectWithRepo_package.ProjectWithRepo_Update?cmd=diff&orev=ef9928a63930d4797ced0ef2ad58ed0c&rev=96b1040600ed3f57e960243b55548162&view=xml&withissues=1
     body:
       encoding: UTF-8
       string: ''
@@ -4274,9 +4251,9 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="42b22c4ac987fc87d14e33de37bd0f10">
-          <old project="MaintenanceProject:0" package="ProjectWithRepo_package.ProjectWithRepo_Update" rev="dd8fee4cd9676519d6bc95db70858eac" srcmd5="dd8fee4cd9676519d6bc95db70858eac" />
-          <new project="MaintenanceProject:0" package="ProjectWithRepo_package.ProjectWithRepo_Update" rev="6c2a823ba5d861d74d5c25e6ef62df17" srcmd5="6c2a823ba5d861d74d5c25e6ef62df17" />
+        <sourcediff key="63bb8ae8e41021e19f94a688fab094a2">
+          <old project="MaintenanceProject:0" package="ProjectWithRepo_package.ProjectWithRepo_Update" rev="ef9928a63930d4797ced0ef2ad58ed0c" srcmd5="ef9928a63930d4797ced0ef2ad58ed0c" />
+          <new project="MaintenanceProject:0" package="ProjectWithRepo_package.ProjectWithRepo_Update" rev="96b1040600ed3f57e960243b55548162" srcmd5="96b1040600ed3f57e960243b55548162" />
           <files>
             <file state="added">
               <new name="DUMMY_FILE" md5="275876e34cf609db118f3d84b799a790" size="5" />
@@ -4290,7 +4267,7 @@ http_interactions:
           </issues>
         </sourcediff>
     http_version: 
-  recorded_at: Mon, 21 Aug 2017 14:07:27 GMT
+  recorded_at: Tue, 22 Aug 2017 12:31:21 GMT
 - request:
     method: get
     uri: http://localhost:3200/build/home:tom:branches:ProjectWithRepo:Update/_result?package=ProjectWithRepo_package&view=status
@@ -4326,7 +4303,7 @@ http_interactions:
           <result project="home:tom:branches:ProjectWithRepo:Update" repository="repository_2" arch="i586" code="unknown" state="unknown" />
         </resultlist>
     http_version: 
-  recorded_at: Mon, 21 Aug 2017 14:07:27 GMT
+  recorded_at: Tue, 22 Aug 2017 12:31:21 GMT
 - request:
     method: get
     uri: http://localhost:3200/build/home:tom:branches:ProjectWithRepo:Update/_result?locallink=1&multibuild=1&package=ProjectWithRepo_package&view=status
@@ -4362,7 +4339,7 @@ http_interactions:
           <result project="home:tom:branches:ProjectWithRepo:Update" repository="repository_2" arch="i586" code="unknown" state="unknown" />
         </resultlist>
     http_version: 
-  recorded_at: Mon, 21 Aug 2017 14:07:27 GMT
+  recorded_at: Tue, 22 Aug 2017 12:31:21 GMT
 - request:
     method: get
     uri: http://localhost:3200/build/MaintenanceProject:0/_result?view=binarylist
@@ -4398,7 +4375,7 @@ http_interactions:
           <result project="MaintenanceProject:0" repository="ProjectWithRepo_Update" arch="i586" code="unknown" state="unknown" />
         </resultlist>
     http_version: 
-  recorded_at: Mon, 21 Aug 2017 14:07:27 GMT
+  recorded_at: Tue, 22 Aug 2017 12:31:21 GMT
 - request:
     method: get
     uri: http://localhost:3200/source/MaintenanceProject:0/patchinfo/_patchinfo
@@ -4436,7 +4413,7 @@ http_interactions:
           <description>I want the update</description>
         </patchinfo>
     http_version: 
-  recorded_at: Mon, 21 Aug 2017 14:07:27 GMT
+  recorded_at: Tue, 22 Aug 2017 12:31:21 GMT
 - request:
     method: get
     uri: http://localhost:3200/source/MaintenanceProject:0/patchinfo/_patchinfo
@@ -4474,7 +4451,7 @@ http_interactions:
           <description>I want the update</description>
         </patchinfo>
     http_version: 
-  recorded_at: Mon, 21 Aug 2017 14:07:27 GMT
+  recorded_at: Tue, 22 Aug 2017 12:31:21 GMT
 - request:
     method: get
     uri: http://localhost:3200/build/MaintenanceProject:0/_result?view=binarylist
@@ -4510,7 +4487,7 @@ http_interactions:
           <result project="MaintenanceProject:0" repository="ProjectWithRepo_Update" arch="i586" code="unknown" state="unknown" />
         </resultlist>
     http_version: 
-  recorded_at: Mon, 21 Aug 2017 14:07:28 GMT
+  recorded_at: Tue, 22 Aug 2017 12:31:22 GMT
 - request:
     method: get
     uri: http://localhost:3200/source/MaintenanceProject:0/patchinfo/_patchinfo
@@ -4548,7 +4525,7 @@ http_interactions:
           <description>I want the update</description>
         </patchinfo>
     http_version: 
-  recorded_at: Mon, 21 Aug 2017 14:07:28 GMT
+  recorded_at: Tue, 22 Aug 2017 12:31:22 GMT
 - request:
     method: get
     uri: http://localhost:3200/source/MaintenanceProject:0/patchinfo/_patchinfo
@@ -4586,7 +4563,7 @@ http_interactions:
           <description>I want the update</description>
         </patchinfo>
     http_version: 
-  recorded_at: Mon, 21 Aug 2017 14:07:28 GMT
+  recorded_at: Tue, 22 Aug 2017 12:31:22 GMT
 - request:
     method: put
     uri: http://localhost:3200/source/MaintenanceProject:0/patchinfo/_patchinfo?user=maintenance_coord
@@ -4624,16 +4601,16 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <revision rev="5" vrev="5">
+        <revision rev="2" vrev="2">
           <srcmd5>d07dfcdc0bb71ab61e7d0c85c4a68c71</srcmd5>
           <version>unknown</version>
-          <time>1503324448</time>
+          <time>1503405082</time>
           <user>maintenance_coord</user>
           <comment></comment>
           <requestid/>
         </revision>
     http_version: 
-  recorded_at: Mon, 21 Aug 2017 14:07:28 GMT
+  recorded_at: Tue, 22 Aug 2017 12:31:22 GMT
 - request:
     method: put
     uri: http://localhost:3200/source/MaintenanceProject:0/patchinfo/_meta?user=maintenance_coord
@@ -4690,7 +4667,7 @@ http_interactions:
           </useforbuild>
         </package>
     http_version: 
-  recorded_at: Mon, 21 Aug 2017 14:07:28 GMT
+  recorded_at: Tue, 22 Aug 2017 12:31:22 GMT
 - request:
     method: get
     uri: http://localhost:3200/source/MaintenanceProject:0/patchinfo
@@ -4720,11 +4697,11 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="patchinfo" rev="5" vrev="5" srcmd5="d07dfcdc0bb71ab61e7d0c85c4a68c71">
-          <entry name="_patchinfo" md5="7fd692cf9ae54961b5c5a22aa13e29c0" size="347" mtime="1503324276" />
+        <directory name="patchinfo" rev="2" vrev="2" srcmd5="d07dfcdc0bb71ab61e7d0c85c4a68c71">
+          <entry name="_patchinfo" md5="7fd692cf9ae54961b5c5a22aa13e29c0" size="347" mtime="1503405082" />
         </directory>
     http_version: 
-  recorded_at: Mon, 21 Aug 2017 14:07:28 GMT
+  recorded_at: Tue, 22 Aug 2017 12:31:22 GMT
 - request:
     method: get
     uri: http://localhost:3200/source/MaintenanceProject:0/patchinfo?nofilename=1&view=info&withchangesmd5=1
@@ -4754,11 +4731,11 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <sourceinfo package="patchinfo" rev="5" vrev="5" srcmd5="d07dfcdc0bb71ab61e7d0c85c4a68c71" verifymd5="d07dfcdc0bb71ab61e7d0c85c4a68c71">
-          <revtime>1503324448</revtime>
+        <sourceinfo package="patchinfo" rev="2" vrev="2" srcmd5="d07dfcdc0bb71ab61e7d0c85c4a68c71" verifymd5="d07dfcdc0bb71ab61e7d0c85c4a68c71">
+          <revtime>1503405082</revtime>
         </sourceinfo>
     http_version: 
-  recorded_at: Mon, 21 Aug 2017 14:07:28 GMT
+  recorded_at: Tue, 22 Aug 2017 12:31:22 GMT
 - request:
     method: get
     uri: http://localhost:3200/source/MaintenanceProject:0/patchinfo
@@ -4788,11 +4765,11 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="patchinfo" rev="5" vrev="5" srcmd5="d07dfcdc0bb71ab61e7d0c85c4a68c71">
-          <entry name="_patchinfo" md5="7fd692cf9ae54961b5c5a22aa13e29c0" size="347" mtime="1503324276" />
+        <directory name="patchinfo" rev="2" vrev="2" srcmd5="d07dfcdc0bb71ab61e7d0c85c4a68c71">
+          <entry name="_patchinfo" md5="7fd692cf9ae54961b5c5a22aa13e29c0" size="347" mtime="1503405082" />
         </directory>
     http_version: 
-  recorded_at: Mon, 21 Aug 2017 14:07:28 GMT
+  recorded_at: Tue, 22 Aug 2017 12:31:22 GMT
 - request:
     method: get
     uri: http://localhost:3200/source/MaintenanceProject:0/patchinfo/_patchinfo
@@ -4831,7 +4808,7 @@ http_interactions:
           <stopped>locked!</stopped>
         </patchinfo>
     http_version: 
-  recorded_at: Mon, 21 Aug 2017 14:07:28 GMT
+  recorded_at: Tue, 22 Aug 2017 12:31:22 GMT
 - request:
     method: get
     uri: http://localhost:3200/source/MaintenanceProject:0/patchinfo/_patchinfo
@@ -4870,7 +4847,7 @@ http_interactions:
           <stopped>locked!</stopped>
         </patchinfo>
     http_version: 
-  recorded_at: Mon, 21 Aug 2017 14:07:28 GMT
+  recorded_at: Tue, 22 Aug 2017 12:31:22 GMT
 - request:
     method: get
     uri: http://localhost:3200/source/MaintenanceProject:0/patchinfo/_patchinfo
@@ -4909,7 +4886,7 @@ http_interactions:
           <stopped>locked!</stopped>
         </patchinfo>
     http_version: 
-  recorded_at: Mon, 21 Aug 2017 14:07:28 GMT
+  recorded_at: Tue, 22 Aug 2017 12:31:22 GMT
 - request:
     method: get
     uri: http://localhost:3200/build/MaintenanceProject:0/_result?view=binarylist
@@ -4945,7 +4922,7 @@ http_interactions:
           <result project="MaintenanceProject:0" repository="ProjectWithRepo_Update" arch="i586" code="unknown" state="unknown" />
         </resultlist>
     http_version: 
-  recorded_at: Mon, 21 Aug 2017 14:07:28 GMT
+  recorded_at: Tue, 22 Aug 2017 12:31:22 GMT
 - request:
     method: get
     uri: http://localhost:3200/source/MaintenanceProject:0/patchinfo/_patchinfo
@@ -4984,7 +4961,7 @@ http_interactions:
           <stopped>locked!</stopped>
         </patchinfo>
     http_version: 
-  recorded_at: Mon, 21 Aug 2017 14:07:28 GMT
+  recorded_at: Tue, 22 Aug 2017 12:31:22 GMT
 - request:
     method: get
     uri: http://localhost:3200/source/MaintenanceProject:0/patchinfo/_patchinfo
@@ -5023,7 +5000,7 @@ http_interactions:
           <stopped>locked!</stopped>
         </patchinfo>
     http_version: 
-  recorded_at: Mon, 21 Aug 2017 14:07:28 GMT
+  recorded_at: Tue, 22 Aug 2017 12:31:22 GMT
 - request:
     method: get
     uri: http://localhost:3200/build/MaintenanceProject:0/_result?view=binarylist
@@ -5059,7 +5036,7 @@ http_interactions:
           <result project="MaintenanceProject:0" repository="ProjectWithRepo_Update" arch="i586" code="unknown" state="unknown" />
         </resultlist>
     http_version: 
-  recorded_at: Mon, 21 Aug 2017 14:07:28 GMT
+  recorded_at: Tue, 22 Aug 2017 12:31:22 GMT
 - request:
     method: get
     uri: http://localhost:3200/source/MaintenanceProject:0/patchinfo/_patchinfo
@@ -5098,7 +5075,7 @@ http_interactions:
           <stopped>locked!</stopped>
         </patchinfo>
     http_version: 
-  recorded_at: Mon, 21 Aug 2017 14:07:28 GMT
+  recorded_at: Tue, 22 Aug 2017 12:31:22 GMT
 - request:
     method: get
     uri: http://localhost:3200/source/MaintenanceProject:0/patchinfo/_patchinfo
@@ -5137,7 +5114,7 @@ http_interactions:
           <stopped>locked!</stopped>
         </patchinfo>
     http_version: 
-  recorded_at: Mon, 21 Aug 2017 14:07:28 GMT
+  recorded_at: Tue, 22 Aug 2017 12:31:22 GMT
 - request:
     method: put
     uri: http://localhost:3200/source/MaintenanceProject:0/patchinfo/_patchinfo?user=maintenance_coord
@@ -5174,16 +5151,16 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <revision rev="6" vrev="6">
+        <revision rev="3" vrev="3">
           <srcmd5>177d57906eba63ae56a64a367592144a</srcmd5>
           <version>unknown</version>
-          <time>1503324448</time>
+          <time>1503405082</time>
           <user>maintenance_coord</user>
           <comment></comment>
           <requestid/>
         </revision>
     http_version: 
-  recorded_at: Mon, 21 Aug 2017 14:07:28 GMT
+  recorded_at: Tue, 22 Aug 2017 12:31:22 GMT
 - request:
     method: put
     uri: http://localhost:3200/source/MaintenanceProject:0/patchinfo/_meta?user=maintenance_coord
@@ -5240,7 +5217,7 @@ http_interactions:
           </useforbuild>
         </package>
     http_version: 
-  recorded_at: Mon, 21 Aug 2017 14:07:28 GMT
+  recorded_at: Tue, 22 Aug 2017 12:31:23 GMT
 - request:
     method: get
     uri: http://localhost:3200/source/MaintenanceProject:0/patchinfo
@@ -5270,11 +5247,11 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="patchinfo" rev="6" vrev="6" srcmd5="177d57906eba63ae56a64a367592144a">
-          <entry name="_patchinfo" md5="ac29f7f1abd9ef43afeb43fc7737c007" size="318" mtime="1503324277" />
+        <directory name="patchinfo" rev="3" vrev="3" srcmd5="177d57906eba63ae56a64a367592144a">
+          <entry name="_patchinfo" md5="ac29f7f1abd9ef43afeb43fc7737c007" size="318" mtime="1503405082" />
         </directory>
     http_version: 
-  recorded_at: Mon, 21 Aug 2017 14:07:28 GMT
+  recorded_at: Tue, 22 Aug 2017 12:31:23 GMT
 - request:
     method: get
     uri: http://localhost:3200/source/MaintenanceProject:0/patchinfo?nofilename=1&view=info&withchangesmd5=1
@@ -5304,11 +5281,11 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <sourceinfo package="patchinfo" rev="6" vrev="6" srcmd5="177d57906eba63ae56a64a367592144a" verifymd5="177d57906eba63ae56a64a367592144a">
-          <revtime>1503324448</revtime>
+        <sourceinfo package="patchinfo" rev="3" vrev="3" srcmd5="177d57906eba63ae56a64a367592144a" verifymd5="177d57906eba63ae56a64a367592144a">
+          <revtime>1503405082</revtime>
         </sourceinfo>
     http_version: 
-  recorded_at: Mon, 21 Aug 2017 14:07:28 GMT
+  recorded_at: Tue, 22 Aug 2017 12:31:23 GMT
 - request:
     method: get
     uri: http://localhost:3200/source/MaintenanceProject:0/patchinfo
@@ -5338,11 +5315,11 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="patchinfo" rev="6" vrev="6" srcmd5="177d57906eba63ae56a64a367592144a">
-          <entry name="_patchinfo" md5="ac29f7f1abd9ef43afeb43fc7737c007" size="318" mtime="1503324277" />
+        <directory name="patchinfo" rev="3" vrev="3" srcmd5="177d57906eba63ae56a64a367592144a">
+          <entry name="_patchinfo" md5="ac29f7f1abd9ef43afeb43fc7737c007" size="318" mtime="1503405082" />
         </directory>
     http_version: 
-  recorded_at: Mon, 21 Aug 2017 14:07:28 GMT
+  recorded_at: Tue, 22 Aug 2017 12:31:23 GMT
 - request:
     method: get
     uri: http://localhost:3200/source/MaintenanceProject:0/patchinfo/_patchinfo
@@ -5380,7 +5357,7 @@ http_interactions:
           <description>Fixes nothing, Fixes nothing, Fixes nothing, Fixes nothing, Fixes nothing, Fixes nothing</description>
         </patchinfo>
     http_version: 
-  recorded_at: Mon, 21 Aug 2017 14:07:28 GMT
+  recorded_at: Tue, 22 Aug 2017 12:31:23 GMT
 - request:
     method: get
     uri: http://localhost:3200/source/MaintenanceProject:0/patchinfo/_patchinfo
@@ -5418,7 +5395,7 @@ http_interactions:
           <description>Fixes nothing, Fixes nothing, Fixes nothing, Fixes nothing, Fixes nothing, Fixes nothing</description>
         </patchinfo>
     http_version: 
-  recorded_at: Mon, 21 Aug 2017 14:07:29 GMT
+  recorded_at: Tue, 22 Aug 2017 12:31:23 GMT
 - request:
     method: get
     uri: http://localhost:3200/source/MaintenanceProject:0/patchinfo/_patchinfo
@@ -5456,7 +5433,7 @@ http_interactions:
           <description>Fixes nothing, Fixes nothing, Fixes nothing, Fixes nothing, Fixes nothing, Fixes nothing</description>
         </patchinfo>
     http_version: 
-  recorded_at: Mon, 21 Aug 2017 14:07:29 GMT
+  recorded_at: Tue, 22 Aug 2017 12:31:23 GMT
 - request:
     method: get
     uri: http://localhost:3200/build/home:tom:branches:ProjectWithRepo:Update/_result?code=unresolvable&view=status
@@ -5492,7 +5469,7 @@ http_interactions:
           <result project="home:tom:branches:ProjectWithRepo:Update" repository="repository_2" arch="i586" code="unknown" state="unknown" />
         </resultlist>
     http_version: 
-  recorded_at: Mon, 21 Aug 2017 14:07:30 GMT
+  recorded_at: Tue, 22 Aug 2017 12:31:24 GMT
 - request:
     method: get
     uri: http://localhost:3200/build/home:tom:branches:ProjectWithRepo:Update/_result?view=summary
@@ -5530,7 +5507,7 @@ http_interactions:
           </result>
         </resultlist>
     http_version: 
-  recorded_at: Mon, 21 Aug 2017 14:07:30 GMT
+  recorded_at: Tue, 22 Aug 2017 12:31:24 GMT
 - request:
     method: get
     uri: http://localhost:3200/source/home:tom:branches:ProjectWithRepo:Update/ProjectWithRepo_package
@@ -5560,15 +5537,15 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="ProjectWithRepo_package" rev="4" vrev="4" srcmd5="3b4a835fa1e497790f82e45048a78427">
-          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" srcmd5="09e82b0920e2079611427fc5ae96b076" baserev="09e82b0920e2079611427fc5ae96b076" xsrcmd5="015a0a0d39a8e944210a9d525dc6ae91" lsrcmd5="3b4a835fa1e497790f82e45048a78427" />
-          <entry name="DUMMY_FILE" md5="275876e34cf609db118f3d84b799a790" size="5" mtime="1503324268" />
-          <entry name="_config" md5="55041d03ef8e31e551b3edd00464f7ea" size="103" mtime="1503324439" />
-          <entry name="_link" md5="6ffab3981d3cd40f46924a3319a54098" size="130" mtime="1503324440" />
-          <entry name="somefile.txt" md5="72a89c51cb636651b1da704fa7b303ee" size="160" mtime="1503324439" />
+        <directory name="ProjectWithRepo_package" rev="2" vrev="2" srcmd5="5acba764a37a9bc6490f80deca372916">
+          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" srcmd5="e9d965f2d319f4124109f14a13f4e431" baserev="e9d965f2d319f4124109f14a13f4e431" xsrcmd5="6d8b4e042078d289ced39a1738e21c95" lsrcmd5="5acba764a37a9bc6490f80deca372916" />
+          <entry name="DUMMY_FILE" md5="275876e34cf609db118f3d84b799a790" size="5" mtime="1503405075" />
+          <entry name="_config" md5="7159169868967997b7eabbd94d805185" size="238" mtime="1503405073" />
+          <entry name="_link" md5="11504ac69b4a7053159649a50cf86e1f" size="130" mtime="1503405074" />
+          <entry name="somefile.txt" md5="b4b03ef7ef00ded93403c2c595500c4f" size="116" mtime="1503405073" />
         </directory>
     http_version: 
-  recorded_at: Mon, 21 Aug 2017 14:07:30 GMT
+  recorded_at: Tue, 22 Aug 2017 12:31:24 GMT
 - request:
     method: get
     uri: http://localhost:3200/source/home:tom:branches:ProjectWithRepo:Update/ProjectWithRepo_package
@@ -5598,15 +5575,15 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="ProjectWithRepo_package" rev="4" vrev="4" srcmd5="3b4a835fa1e497790f82e45048a78427">
-          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" srcmd5="09e82b0920e2079611427fc5ae96b076" baserev="09e82b0920e2079611427fc5ae96b076" xsrcmd5="015a0a0d39a8e944210a9d525dc6ae91" lsrcmd5="3b4a835fa1e497790f82e45048a78427" />
-          <entry name="DUMMY_FILE" md5="275876e34cf609db118f3d84b799a790" size="5" mtime="1503324268" />
-          <entry name="_config" md5="55041d03ef8e31e551b3edd00464f7ea" size="103" mtime="1503324439" />
-          <entry name="_link" md5="6ffab3981d3cd40f46924a3319a54098" size="130" mtime="1503324440" />
-          <entry name="somefile.txt" md5="72a89c51cb636651b1da704fa7b303ee" size="160" mtime="1503324439" />
+        <directory name="ProjectWithRepo_package" rev="2" vrev="2" srcmd5="5acba764a37a9bc6490f80deca372916">
+          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" srcmd5="e9d965f2d319f4124109f14a13f4e431" baserev="e9d965f2d319f4124109f14a13f4e431" xsrcmd5="6d8b4e042078d289ced39a1738e21c95" lsrcmd5="5acba764a37a9bc6490f80deca372916" />
+          <entry name="DUMMY_FILE" md5="275876e34cf609db118f3d84b799a790" size="5" mtime="1503405075" />
+          <entry name="_config" md5="7159169868967997b7eabbd94d805185" size="238" mtime="1503405073" />
+          <entry name="_link" md5="11504ac69b4a7053159649a50cf86e1f" size="130" mtime="1503405074" />
+          <entry name="somefile.txt" md5="b4b03ef7ef00ded93403c2c595500c4f" size="116" mtime="1503405073" />
         </directory>
     http_version: 
-  recorded_at: Mon, 21 Aug 2017 14:07:30 GMT
+  recorded_at: Tue, 22 Aug 2017 12:31:24 GMT
 - request:
     method: get
     uri: http://localhost:3200/source/home:tom:branches:ProjectWithRepo:Update/ProjectWithRepo_package
@@ -5638,15 +5615,15 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="ProjectWithRepo_package" rev="4" vrev="4" srcmd5="3b4a835fa1e497790f82e45048a78427">
-          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" srcmd5="09e82b0920e2079611427fc5ae96b076" baserev="09e82b0920e2079611427fc5ae96b076" xsrcmd5="015a0a0d39a8e944210a9d525dc6ae91" lsrcmd5="3b4a835fa1e497790f82e45048a78427" />
-          <entry name="DUMMY_FILE" md5="275876e34cf609db118f3d84b799a790" size="5" mtime="1503324268" />
-          <entry name="_config" md5="55041d03ef8e31e551b3edd00464f7ea" size="103" mtime="1503324439" />
-          <entry name="_link" md5="6ffab3981d3cd40f46924a3319a54098" size="130" mtime="1503324440" />
-          <entry name="somefile.txt" md5="72a89c51cb636651b1da704fa7b303ee" size="160" mtime="1503324439" />
+        <directory name="ProjectWithRepo_package" rev="2" vrev="2" srcmd5="5acba764a37a9bc6490f80deca372916">
+          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" srcmd5="e9d965f2d319f4124109f14a13f4e431" baserev="e9d965f2d319f4124109f14a13f4e431" xsrcmd5="6d8b4e042078d289ced39a1738e21c95" lsrcmd5="5acba764a37a9bc6490f80deca372916" />
+          <entry name="DUMMY_FILE" md5="275876e34cf609db118f3d84b799a790" size="5" mtime="1503405075" />
+          <entry name="_config" md5="7159169868967997b7eabbd94d805185" size="238" mtime="1503405073" />
+          <entry name="_link" md5="11504ac69b4a7053159649a50cf86e1f" size="130" mtime="1503405074" />
+          <entry name="somefile.txt" md5="b4b03ef7ef00ded93403c2c595500c4f" size="116" mtime="1503405073" />
         </directory>
     http_version: 
-  recorded_at: Mon, 21 Aug 2017 14:07:30 GMT
+  recorded_at: Tue, 22 Aug 2017 12:31:24 GMT
 - request:
     method: post
     uri: http://localhost:3200/source/home:tom:branches:ProjectWithRepo:Update/ProjectWithRepo_package?cmd=diff&expand=1&filelimit=10000&opackage=ProjectWithRepo_package&oproject=ProjectWithRepo:Update
@@ -5693,7 +5670,7 @@ http_interactions:
         +dummy
         \ No newline at end of file
     http_version: 
-  recorded_at: Mon, 21 Aug 2017 14:07:30 GMT
+  recorded_at: Tue, 22 Aug 2017 12:31:24 GMT
 - request:
     method: get
     uri: http://localhost:3200/source/home:tom:branches:ProjectWithRepo:Update/ProjectWithRepo_package?expand=1
@@ -5723,14 +5700,14 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="ProjectWithRepo_package" rev="015a0a0d39a8e944210a9d525dc6ae91" vrev="8" srcmd5="015a0a0d39a8e944210a9d525dc6ae91">
-          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" srcmd5="09e82b0920e2079611427fc5ae96b076" baserev="09e82b0920e2079611427fc5ae96b076" lsrcmd5="3b4a835fa1e497790f82e45048a78427" />
-          <entry name="DUMMY_FILE" md5="275876e34cf609db118f3d84b799a790" size="5" mtime="1503324268" />
-          <entry name="_config" md5="55041d03ef8e31e551b3edd00464f7ea" size="103" mtime="1503324439" />
-          <entry name="somefile.txt" md5="72a89c51cb636651b1da704fa7b303ee" size="160" mtime="1503324439" />
+        <directory name="ProjectWithRepo_package" rev="6d8b4e042078d289ced39a1738e21c95" vrev="4" srcmd5="6d8b4e042078d289ced39a1738e21c95">
+          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" srcmd5="e9d965f2d319f4124109f14a13f4e431" baserev="e9d965f2d319f4124109f14a13f4e431" lsrcmd5="5acba764a37a9bc6490f80deca372916" />
+          <entry name="DUMMY_FILE" md5="275876e34cf609db118f3d84b799a790" size="5" mtime="1503405075" />
+          <entry name="_config" md5="7159169868967997b7eabbd94d805185" size="238" mtime="1503405073" />
+          <entry name="somefile.txt" md5="b4b03ef7ef00ded93403c2c595500c4f" size="116" mtime="1503405073" />
         </directory>
     http_version: 
-  recorded_at: Mon, 21 Aug 2017 14:07:30 GMT
+  recorded_at: Tue, 22 Aug 2017 12:31:24 GMT
 - request:
     method: get
     uri: http://localhost:3200/build/home:tom:branches:ProjectWithRepo:Update/_result?code=unresolvable&view=status
@@ -5766,7 +5743,7 @@ http_interactions:
           <result project="home:tom:branches:ProjectWithRepo:Update" repository="repository_2" arch="i586" code="unknown" state="unknown" />
         </resultlist>
     http_version: 
-  recorded_at: Mon, 21 Aug 2017 14:07:30 GMT
+  recorded_at: Tue, 22 Aug 2017 12:31:24 GMT
 - request:
     method: get
     uri: http://localhost:3200/build/home:tom:branches:ProjectWithRepo:Update/_result?view=summary
@@ -5804,7 +5781,7 @@ http_interactions:
           </result>
         </resultlist>
     http_version: 
-  recorded_at: Mon, 21 Aug 2017 14:07:31 GMT
+  recorded_at: Tue, 22 Aug 2017 12:31:25 GMT
 - request:
     method: get
     uri: http://localhost:3200/source/home:tom:branches:ProjectWithRepo:Update/ProjectWithRepo_package
@@ -5836,18 +5813,18 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="ProjectWithRepo_package" rev="4" vrev="4" srcmd5="3b4a835fa1e497790f82e45048a78427">
-          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" srcmd5="09e82b0920e2079611427fc5ae96b076" baserev="09e82b0920e2079611427fc5ae96b076" xsrcmd5="015a0a0d39a8e944210a9d525dc6ae91" lsrcmd5="3b4a835fa1e497790f82e45048a78427" />
-          <entry name="DUMMY_FILE" md5="275876e34cf609db118f3d84b799a790" size="5" mtime="1503324268" />
-          <entry name="_config" md5="55041d03ef8e31e551b3edd00464f7ea" size="103" mtime="1503324439" />
-          <entry name="_link" md5="6ffab3981d3cd40f46924a3319a54098" size="130" mtime="1503324440" />
-          <entry name="somefile.txt" md5="72a89c51cb636651b1da704fa7b303ee" size="160" mtime="1503324439" />
+        <directory name="ProjectWithRepo_package" rev="2" vrev="2" srcmd5="5acba764a37a9bc6490f80deca372916">
+          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" srcmd5="e9d965f2d319f4124109f14a13f4e431" baserev="e9d965f2d319f4124109f14a13f4e431" xsrcmd5="6d8b4e042078d289ced39a1738e21c95" lsrcmd5="5acba764a37a9bc6490f80deca372916" />
+          <entry name="DUMMY_FILE" md5="275876e34cf609db118f3d84b799a790" size="5" mtime="1503405075" />
+          <entry name="_config" md5="7159169868967997b7eabbd94d805185" size="238" mtime="1503405073" />
+          <entry name="_link" md5="11504ac69b4a7053159649a50cf86e1f" size="130" mtime="1503405074" />
+          <entry name="somefile.txt" md5="b4b03ef7ef00ded93403c2c595500c4f" size="116" mtime="1503405073" />
         </directory>
     http_version: 
-  recorded_at: Mon, 21 Aug 2017 14:07:32 GMT
+  recorded_at: Tue, 22 Aug 2017 12:31:26 GMT
 - request:
     method: post
-    uri: http://localhost:3200/source/home:tom:branches:ProjectWithRepo:Update/ProjectWithRepo_package?cmd=diff&expand=1&filelimit=10000&opackage=ProjectWithRepo_package&oproject=ProjectWithRepo:Update&view=xml&withissues=1
+    uri: http://localhost:3200/source/home:tom:branches:ProjectWithRepo:Update/ProjectWithRepo_package?cmd=diff&expand=1&filelimit=10000&opackage=ProjectWithRepo_package&oproject=ProjectWithRepo:Update&rev=6d8b4e042078d289ced39a1738e21c95&view=xml&withissues=1
     body:
       encoding: UTF-8
       string: ''
@@ -5868,7 +5845,7 @@ http_interactions:
       Content-Type:
       - text/xml
       Content-Length:
-      - '580'
+      - '611'
       Cache-Control:
       - no-cache
       Connection:
@@ -5876,9 +5853,9 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="d88621a8275d9ad55d7fee27df34b557">
-          <old project="ProjectWithRepo:Update" package="ProjectWithRepo_package" rev="4" srcmd5="09e82b0920e2079611427fc5ae96b076" />
-          <new project="home:tom:branches:ProjectWithRepo:Update" package="ProjectWithRepo_package" rev="4" srcmd5="015a0a0d39a8e944210a9d525dc6ae91" />
+        <sourcediff key="5fc708afda388d0d4ddeaa33bda7c0df">
+          <old project="ProjectWithRepo:Update" package="ProjectWithRepo_package" rev="2" srcmd5="e9d965f2d319f4124109f14a13f4e431" />
+          <new project="home:tom:branches:ProjectWithRepo:Update" package="ProjectWithRepo_package" rev="6d8b4e042078d289ced39a1738e21c95" srcmd5="6d8b4e042078d289ced39a1738e21c95" />
           <files>
             <file state="added">
               <new name="DUMMY_FILE" md5="275876e34cf609db118f3d84b799a790" size="5" />
@@ -5892,7 +5869,7 @@ http_interactions:
           </issues>
         </sourcediff>
     http_version: 
-  recorded_at: Mon, 21 Aug 2017 14:07:32 GMT
+  recorded_at: Tue, 22 Aug 2017 12:31:26 GMT
 - request:
     method: get
     uri: http://localhost:3200/build/home:tom:branches:ProjectWithRepo:Update/_result?package=ProjectWithRepo_package&view=status
@@ -5928,7 +5905,7 @@ http_interactions:
           <result project="home:tom:branches:ProjectWithRepo:Update" repository="repository_2" arch="i586" code="unknown" state="unknown" />
         </resultlist>
     http_version: 
-  recorded_at: Mon, 21 Aug 2017 14:07:32 GMT
+  recorded_at: Tue, 22 Aug 2017 12:31:26 GMT
 - request:
     method: get
     uri: http://localhost:3200/build/home:tom:branches:ProjectWithRepo:Update/_result?locallink=1&multibuild=1&package=ProjectWithRepo_package&view=status
@@ -5964,7 +5941,7 @@ http_interactions:
           <result project="home:tom:branches:ProjectWithRepo:Update" repository="repository_2" arch="i586" code="unknown" state="unknown" />
         </resultlist>
     http_version: 
-  recorded_at: Mon, 21 Aug 2017 14:07:32 GMT
+  recorded_at: Tue, 22 Aug 2017 12:31:26 GMT
 - request:
     method: get
     uri: http://localhost:3200/source/home:tom:branches:ProjectWithRepo:Update/ProjectWithRepo_package
@@ -5994,15 +5971,15 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="ProjectWithRepo_package" rev="4" vrev="4" srcmd5="3b4a835fa1e497790f82e45048a78427">
-          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" srcmd5="09e82b0920e2079611427fc5ae96b076" baserev="09e82b0920e2079611427fc5ae96b076" xsrcmd5="015a0a0d39a8e944210a9d525dc6ae91" lsrcmd5="3b4a835fa1e497790f82e45048a78427" />
-          <entry name="DUMMY_FILE" md5="275876e34cf609db118f3d84b799a790" size="5" mtime="1503324268" />
-          <entry name="_config" md5="55041d03ef8e31e551b3edd00464f7ea" size="103" mtime="1503324439" />
-          <entry name="_link" md5="6ffab3981d3cd40f46924a3319a54098" size="130" mtime="1503324440" />
-          <entry name="somefile.txt" md5="72a89c51cb636651b1da704fa7b303ee" size="160" mtime="1503324439" />
+        <directory name="ProjectWithRepo_package" rev="2" vrev="2" srcmd5="5acba764a37a9bc6490f80deca372916">
+          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" srcmd5="e9d965f2d319f4124109f14a13f4e431" baserev="e9d965f2d319f4124109f14a13f4e431" xsrcmd5="6d8b4e042078d289ced39a1738e21c95" lsrcmd5="5acba764a37a9bc6490f80deca372916" />
+          <entry name="DUMMY_FILE" md5="275876e34cf609db118f3d84b799a790" size="5" mtime="1503405075" />
+          <entry name="_config" md5="7159169868967997b7eabbd94d805185" size="238" mtime="1503405073" />
+          <entry name="_link" md5="11504ac69b4a7053159649a50cf86e1f" size="130" mtime="1503405074" />
+          <entry name="somefile.txt" md5="b4b03ef7ef00ded93403c2c595500c4f" size="116" mtime="1503405073" />
         </directory>
     http_version: 
-  recorded_at: Mon, 21 Aug 2017 14:07:32 GMT
+  recorded_at: Tue, 22 Aug 2017 12:31:26 GMT
 - request:
     method: get
     uri: http://localhost:3200/source/home:tom:branches:ProjectWithRepo:Update/ProjectWithRepo_package
@@ -6034,18 +6011,18 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="ProjectWithRepo_package" rev="4" vrev="4" srcmd5="3b4a835fa1e497790f82e45048a78427">
-          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" srcmd5="09e82b0920e2079611427fc5ae96b076" baserev="09e82b0920e2079611427fc5ae96b076" xsrcmd5="015a0a0d39a8e944210a9d525dc6ae91" lsrcmd5="3b4a835fa1e497790f82e45048a78427" />
-          <entry name="DUMMY_FILE" md5="275876e34cf609db118f3d84b799a790" size="5" mtime="1503324268" />
-          <entry name="_config" md5="55041d03ef8e31e551b3edd00464f7ea" size="103" mtime="1503324439" />
-          <entry name="_link" md5="6ffab3981d3cd40f46924a3319a54098" size="130" mtime="1503324440" />
-          <entry name="somefile.txt" md5="72a89c51cb636651b1da704fa7b303ee" size="160" mtime="1503324439" />
+        <directory name="ProjectWithRepo_package" rev="2" vrev="2" srcmd5="5acba764a37a9bc6490f80deca372916">
+          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" srcmd5="e9d965f2d319f4124109f14a13f4e431" baserev="e9d965f2d319f4124109f14a13f4e431" xsrcmd5="6d8b4e042078d289ced39a1738e21c95" lsrcmd5="5acba764a37a9bc6490f80deca372916" />
+          <entry name="DUMMY_FILE" md5="275876e34cf609db118f3d84b799a790" size="5" mtime="1503405075" />
+          <entry name="_config" md5="7159169868967997b7eabbd94d805185" size="238" mtime="1503405073" />
+          <entry name="_link" md5="11504ac69b4a7053159649a50cf86e1f" size="130" mtime="1503405074" />
+          <entry name="somefile.txt" md5="b4b03ef7ef00ded93403c2c595500c4f" size="116" mtime="1503405073" />
         </directory>
     http_version: 
-  recorded_at: Mon, 21 Aug 2017 14:07:33 GMT
+  recorded_at: Tue, 22 Aug 2017 12:31:26 GMT
 - request:
     method: post
-    uri: http://localhost:3200/source/home:tom:branches:ProjectWithRepo:Update/ProjectWithRepo_package?cmd=diff&expand=1&filelimit=10000&opackage=ProjectWithRepo_package&oproject=ProjectWithRepo:Update&view=xml&withissues=1
+    uri: http://localhost:3200/source/home:tom:branches:ProjectWithRepo:Update/ProjectWithRepo_package?cmd=diff&expand=1&filelimit=10000&opackage=ProjectWithRepo_package&oproject=ProjectWithRepo:Update&rev=6d8b4e042078d289ced39a1738e21c95&view=xml&withissues=1
     body:
       encoding: UTF-8
       string: ''
@@ -6066,7 +6043,7 @@ http_interactions:
       Content-Type:
       - text/xml
       Content-Length:
-      - '580'
+      - '611'
       Cache-Control:
       - no-cache
       Connection:
@@ -6074,9 +6051,9 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="d88621a8275d9ad55d7fee27df34b557">
-          <old project="ProjectWithRepo:Update" package="ProjectWithRepo_package" rev="4" srcmd5="09e82b0920e2079611427fc5ae96b076" />
-          <new project="home:tom:branches:ProjectWithRepo:Update" package="ProjectWithRepo_package" rev="4" srcmd5="015a0a0d39a8e944210a9d525dc6ae91" />
+        <sourcediff key="5fc708afda388d0d4ddeaa33bda7c0df">
+          <old project="ProjectWithRepo:Update" package="ProjectWithRepo_package" rev="2" srcmd5="e9d965f2d319f4124109f14a13f4e431" />
+          <new project="home:tom:branches:ProjectWithRepo:Update" package="ProjectWithRepo_package" rev="6d8b4e042078d289ced39a1738e21c95" srcmd5="6d8b4e042078d289ced39a1738e21c95" />
           <files>
             <file state="added">
               <new name="DUMMY_FILE" md5="275876e34cf609db118f3d84b799a790" size="5" />
@@ -6090,7 +6067,7 @@ http_interactions:
           </issues>
         </sourcediff>
     http_version: 
-  recorded_at: Mon, 21 Aug 2017 14:07:33 GMT
+  recorded_at: Tue, 22 Aug 2017 12:31:26 GMT
 - request:
     method: get
     uri: http://localhost:3200/build/home:tom:branches:ProjectWithRepo:Update/_result?package=ProjectWithRepo_package&view=status
@@ -6126,7 +6103,7 @@ http_interactions:
           <result project="home:tom:branches:ProjectWithRepo:Update" repository="repository_2" arch="i586" code="unknown" state="unknown" />
         </resultlist>
     http_version: 
-  recorded_at: Mon, 21 Aug 2017 14:07:33 GMT
+  recorded_at: Tue, 22 Aug 2017 12:31:27 GMT
 - request:
     method: get
     uri: http://localhost:3200/build/home:tom:branches:ProjectWithRepo:Update/_result?locallink=1&multibuild=1&package=ProjectWithRepo_package&view=status
@@ -6162,7 +6139,7 @@ http_interactions:
           <result project="home:tom:branches:ProjectWithRepo:Update" repository="repository_2" arch="i586" code="unknown" state="unknown" />
         </resultlist>
     http_version: 
-  recorded_at: Mon, 21 Aug 2017 14:07:33 GMT
+  recorded_at: Tue, 22 Aug 2017 12:31:27 GMT
 - request:
     method: get
     uri: http://localhost:3200/source/home:tom:branches:ProjectWithRepo:Update/ProjectWithRepo_package
@@ -6192,15 +6169,15 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="ProjectWithRepo_package" rev="4" vrev="4" srcmd5="3b4a835fa1e497790f82e45048a78427">
-          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" srcmd5="09e82b0920e2079611427fc5ae96b076" baserev="09e82b0920e2079611427fc5ae96b076" xsrcmd5="015a0a0d39a8e944210a9d525dc6ae91" lsrcmd5="3b4a835fa1e497790f82e45048a78427" />
-          <entry name="DUMMY_FILE" md5="275876e34cf609db118f3d84b799a790" size="5" mtime="1503324268" />
-          <entry name="_config" md5="55041d03ef8e31e551b3edd00464f7ea" size="103" mtime="1503324439" />
-          <entry name="_link" md5="6ffab3981d3cd40f46924a3319a54098" size="130" mtime="1503324440" />
-          <entry name="somefile.txt" md5="72a89c51cb636651b1da704fa7b303ee" size="160" mtime="1503324439" />
+        <directory name="ProjectWithRepo_package" rev="2" vrev="2" srcmd5="5acba764a37a9bc6490f80deca372916">
+          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" srcmd5="e9d965f2d319f4124109f14a13f4e431" baserev="e9d965f2d319f4124109f14a13f4e431" xsrcmd5="6d8b4e042078d289ced39a1738e21c95" lsrcmd5="5acba764a37a9bc6490f80deca372916" />
+          <entry name="DUMMY_FILE" md5="275876e34cf609db118f3d84b799a790" size="5" mtime="1503405075" />
+          <entry name="_config" md5="7159169868967997b7eabbd94d805185" size="238" mtime="1503405073" />
+          <entry name="_link" md5="11504ac69b4a7053159649a50cf86e1f" size="130" mtime="1503405074" />
+          <entry name="somefile.txt" md5="b4b03ef7ef00ded93403c2c595500c4f" size="116" mtime="1503405073" />
         </directory>
     http_version: 
-  recorded_at: Mon, 21 Aug 2017 14:07:33 GMT
+  recorded_at: Tue, 22 Aug 2017 12:31:27 GMT
 - request:
     method: get
     uri: http://localhost:3200/source/home:tom:branches:ProjectWithRepo:Update/ProjectWithRepo_package
@@ -6232,18 +6209,18 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="ProjectWithRepo_package" rev="4" vrev="4" srcmd5="3b4a835fa1e497790f82e45048a78427">
-          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" srcmd5="09e82b0920e2079611427fc5ae96b076" baserev="09e82b0920e2079611427fc5ae96b076" xsrcmd5="015a0a0d39a8e944210a9d525dc6ae91" lsrcmd5="3b4a835fa1e497790f82e45048a78427" />
-          <entry name="DUMMY_FILE" md5="275876e34cf609db118f3d84b799a790" size="5" mtime="1503324268" />
-          <entry name="_config" md5="55041d03ef8e31e551b3edd00464f7ea" size="103" mtime="1503324439" />
-          <entry name="_link" md5="6ffab3981d3cd40f46924a3319a54098" size="130" mtime="1503324440" />
-          <entry name="somefile.txt" md5="72a89c51cb636651b1da704fa7b303ee" size="160" mtime="1503324439" />
+        <directory name="ProjectWithRepo_package" rev="2" vrev="2" srcmd5="5acba764a37a9bc6490f80deca372916">
+          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" srcmd5="e9d965f2d319f4124109f14a13f4e431" baserev="e9d965f2d319f4124109f14a13f4e431" xsrcmd5="6d8b4e042078d289ced39a1738e21c95" lsrcmd5="5acba764a37a9bc6490f80deca372916" />
+          <entry name="DUMMY_FILE" md5="275876e34cf609db118f3d84b799a790" size="5" mtime="1503405075" />
+          <entry name="_config" md5="7159169868967997b7eabbd94d805185" size="238" mtime="1503405073" />
+          <entry name="_link" md5="11504ac69b4a7053159649a50cf86e1f" size="130" mtime="1503405074" />
+          <entry name="somefile.txt" md5="b4b03ef7ef00ded93403c2c595500c4f" size="116" mtime="1503405073" />
         </directory>
     http_version: 
-  recorded_at: Mon, 21 Aug 2017 14:07:33 GMT
+  recorded_at: Tue, 22 Aug 2017 12:31:27 GMT
 - request:
     method: post
-    uri: http://localhost:3200/source/home:tom:branches:ProjectWithRepo:Update/ProjectWithRepo_package?cmd=diff&expand=1&filelimit=10000&opackage=ProjectWithRepo_package&oproject=ProjectWithRepo:Update&view=xml&withissues=1
+    uri: http://localhost:3200/source/home:tom:branches:ProjectWithRepo:Update/ProjectWithRepo_package?cmd=diff&expand=1&filelimit=10000&opackage=ProjectWithRepo_package&oproject=ProjectWithRepo:Update&rev=6d8b4e042078d289ced39a1738e21c95&view=xml&withissues=1
     body:
       encoding: UTF-8
       string: ''
@@ -6264,7 +6241,7 @@ http_interactions:
       Content-Type:
       - text/xml
       Content-Length:
-      - '580'
+      - '611'
       Cache-Control:
       - no-cache
       Connection:
@@ -6272,9 +6249,9 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="d88621a8275d9ad55d7fee27df34b557">
-          <old project="ProjectWithRepo:Update" package="ProjectWithRepo_package" rev="4" srcmd5="09e82b0920e2079611427fc5ae96b076" />
-          <new project="home:tom:branches:ProjectWithRepo:Update" package="ProjectWithRepo_package" rev="4" srcmd5="015a0a0d39a8e944210a9d525dc6ae91" />
+        <sourcediff key="5fc708afda388d0d4ddeaa33bda7c0df">
+          <old project="ProjectWithRepo:Update" package="ProjectWithRepo_package" rev="2" srcmd5="e9d965f2d319f4124109f14a13f4e431" />
+          <new project="home:tom:branches:ProjectWithRepo:Update" package="ProjectWithRepo_package" rev="6d8b4e042078d289ced39a1738e21c95" srcmd5="6d8b4e042078d289ced39a1738e21c95" />
           <files>
             <file state="added">
               <new name="DUMMY_FILE" md5="275876e34cf609db118f3d84b799a790" size="5" />
@@ -6288,7 +6265,7 @@ http_interactions:
           </issues>
         </sourcediff>
     http_version: 
-  recorded_at: Mon, 21 Aug 2017 14:07:33 GMT
+  recorded_at: Tue, 22 Aug 2017 12:31:27 GMT
 - request:
     method: get
     uri: http://localhost:3200/build/home:tom:branches:ProjectWithRepo:Update/_result?package=ProjectWithRepo_package&view=status
@@ -6324,7 +6301,7 @@ http_interactions:
           <result project="home:tom:branches:ProjectWithRepo:Update" repository="repository_2" arch="i586" code="unknown" state="unknown" />
         </resultlist>
     http_version: 
-  recorded_at: Mon, 21 Aug 2017 14:07:33 GMT
+  recorded_at: Tue, 22 Aug 2017 12:31:27 GMT
 - request:
     method: get
     uri: http://localhost:3200/build/home:tom:branches:ProjectWithRepo:Update/_result?locallink=1&multibuild=1&package=ProjectWithRepo_package&view=status
@@ -6360,7 +6337,7 @@ http_interactions:
           <result project="home:tom:branches:ProjectWithRepo:Update" repository="repository_2" arch="i586" code="unknown" state="unknown" />
         </resultlist>
     http_version: 
-  recorded_at: Mon, 21 Aug 2017 14:07:33 GMT
+  recorded_at: Tue, 22 Aug 2017 12:31:27 GMT
 - request:
     method: get
     uri: http://localhost:3200/source/home:tom:branches:ProjectWithRepo:Update/ProjectWithRepo_package
@@ -6390,18 +6367,18 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="ProjectWithRepo_package" rev="4" vrev="4" srcmd5="3b4a835fa1e497790f82e45048a78427">
-          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" srcmd5="09e82b0920e2079611427fc5ae96b076" baserev="09e82b0920e2079611427fc5ae96b076" xsrcmd5="015a0a0d39a8e944210a9d525dc6ae91" lsrcmd5="3b4a835fa1e497790f82e45048a78427" />
-          <entry name="DUMMY_FILE" md5="275876e34cf609db118f3d84b799a790" size="5" mtime="1503324268" />
-          <entry name="_config" md5="55041d03ef8e31e551b3edd00464f7ea" size="103" mtime="1503324439" />
-          <entry name="_link" md5="6ffab3981d3cd40f46924a3319a54098" size="130" mtime="1503324440" />
-          <entry name="somefile.txt" md5="72a89c51cb636651b1da704fa7b303ee" size="160" mtime="1503324439" />
+        <directory name="ProjectWithRepo_package" rev="2" vrev="2" srcmd5="5acba764a37a9bc6490f80deca372916">
+          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" srcmd5="e9d965f2d319f4124109f14a13f4e431" baserev="e9d965f2d319f4124109f14a13f4e431" xsrcmd5="6d8b4e042078d289ced39a1738e21c95" lsrcmd5="5acba764a37a9bc6490f80deca372916" />
+          <entry name="DUMMY_FILE" md5="275876e34cf609db118f3d84b799a790" size="5" mtime="1503405075" />
+          <entry name="_config" md5="7159169868967997b7eabbd94d805185" size="238" mtime="1503405073" />
+          <entry name="_link" md5="11504ac69b4a7053159649a50cf86e1f" size="130" mtime="1503405074" />
+          <entry name="somefile.txt" md5="b4b03ef7ef00ded93403c2c595500c4f" size="116" mtime="1503405073" />
         </directory>
     http_version: 
-  recorded_at: Mon, 21 Aug 2017 14:07:33 GMT
+  recorded_at: Tue, 22 Aug 2017 12:31:27 GMT
 - request:
     method: get
-    uri: http://localhost:3200/source/home:tom:branches:ProjectWithRepo:Update/ProjectWithRepo_package?expand=1
+    uri: http://localhost:3200/source/home:tom:branches:ProjectWithRepo:Update/ProjectWithRepo_package?expand=1&rev=6d8b4e042078d289ced39a1738e21c95
     body:
       encoding: US-ASCII
       string: ''
@@ -6426,21 +6403,21 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '650'
+      - '641'
     body:
       encoding: UTF-8
       string: |
-        <directory name="ProjectWithRepo_package" rev="015a0a0d39a8e944210a9d525dc6ae91" vrev="8" srcmd5="015a0a0d39a8e944210a9d525dc6ae91">
-          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" srcmd5="09e82b0920e2079611427fc5ae96b076" baserev="09e82b0920e2079611427fc5ae96b076" lsrcmd5="3b4a835fa1e497790f82e45048a78427" />
-          <entry name="DUMMY_FILE" md5="275876e34cf609db118f3d84b799a790" size="5" mtime="1503324268" />
-          <entry name="_config" md5="55041d03ef8e31e551b3edd00464f7ea" size="103" mtime="1503324439" />
-          <entry name="somefile.txt" md5="72a89c51cb636651b1da704fa7b303ee" size="160" mtime="1503324439" />
+        <directory name="ProjectWithRepo_package" rev="6d8b4e042078d289ced39a1738e21c95" srcmd5="6d8b4e042078d289ced39a1738e21c95">
+          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" srcmd5="e9d965f2d319f4124109f14a13f4e431" baserev="e9d965f2d319f4124109f14a13f4e431" lsrcmd5="5acba764a37a9bc6490f80deca372916" />
+          <entry name="DUMMY_FILE" md5="275876e34cf609db118f3d84b799a790" size="5" mtime="1503405075" />
+          <entry name="_config" md5="7159169868967997b7eabbd94d805185" size="238" mtime="1503405073" />
+          <entry name="somefile.txt" md5="b4b03ef7ef00ded93403c2c595500c4f" size="116" mtime="1503405073" />
         </directory>
     http_version: 
-  recorded_at: Mon, 21 Aug 2017 14:07:34 GMT
+  recorded_at: Tue, 22 Aug 2017 12:31:27 GMT
 - request:
     method: get
-    uri: http://localhost:3200/source/home:tom:branches:ProjectWithRepo:Update/ProjectWithRepo_package?expand=1
+    uri: http://localhost:3200/source/home:tom:branches:ProjectWithRepo:Update/ProjectWithRepo_package?expand=1&rev=6d8b4e042078d289ced39a1738e21c95
     body:
       encoding: US-ASCII
       string: ''
@@ -6463,18 +6440,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '650'
+      - '641'
     body:
       encoding: UTF-8
       string: |
-        <directory name="ProjectWithRepo_package" rev="015a0a0d39a8e944210a9d525dc6ae91" vrev="8" srcmd5="015a0a0d39a8e944210a9d525dc6ae91">
-          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" srcmd5="09e82b0920e2079611427fc5ae96b076" baserev="09e82b0920e2079611427fc5ae96b076" lsrcmd5="3b4a835fa1e497790f82e45048a78427" />
-          <entry name="DUMMY_FILE" md5="275876e34cf609db118f3d84b799a790" size="5" mtime="1503324268" />
-          <entry name="_config" md5="55041d03ef8e31e551b3edd00464f7ea" size="103" mtime="1503324439" />
-          <entry name="somefile.txt" md5="72a89c51cb636651b1da704fa7b303ee" size="160" mtime="1503324439" />
+        <directory name="ProjectWithRepo_package" rev="6d8b4e042078d289ced39a1738e21c95" srcmd5="6d8b4e042078d289ced39a1738e21c95">
+          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" srcmd5="e9d965f2d319f4124109f14a13f4e431" baserev="e9d965f2d319f4124109f14a13f4e431" lsrcmd5="5acba764a37a9bc6490f80deca372916" />
+          <entry name="DUMMY_FILE" md5="275876e34cf609db118f3d84b799a790" size="5" mtime="1503405075" />
+          <entry name="_config" md5="7159169868967997b7eabbd94d805185" size="238" mtime="1503405073" />
+          <entry name="somefile.txt" md5="b4b03ef7ef00ded93403c2c595500c4f" size="116" mtime="1503405073" />
         </directory>
     http_version: 
-  recorded_at: Mon, 21 Aug 2017 14:07:34 GMT
+  recorded_at: Tue, 22 Aug 2017 12:31:28 GMT
 - request:
     method: get
     uri: http://localhost:3200/source/home:tom:branches:ProjectWithRepo:Update/ProjectWithRepo_package
@@ -6504,15 +6481,15 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="ProjectWithRepo_package" rev="4" vrev="4" srcmd5="3b4a835fa1e497790f82e45048a78427">
-          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" srcmd5="09e82b0920e2079611427fc5ae96b076" baserev="09e82b0920e2079611427fc5ae96b076" xsrcmd5="015a0a0d39a8e944210a9d525dc6ae91" lsrcmd5="3b4a835fa1e497790f82e45048a78427" />
-          <entry name="DUMMY_FILE" md5="275876e34cf609db118f3d84b799a790" size="5" mtime="1503324268" />
-          <entry name="_config" md5="55041d03ef8e31e551b3edd00464f7ea" size="103" mtime="1503324439" />
-          <entry name="_link" md5="6ffab3981d3cd40f46924a3319a54098" size="130" mtime="1503324440" />
-          <entry name="somefile.txt" md5="72a89c51cb636651b1da704fa7b303ee" size="160" mtime="1503324439" />
+        <directory name="ProjectWithRepo_package" rev="2" vrev="2" srcmd5="5acba764a37a9bc6490f80deca372916">
+          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" srcmd5="e9d965f2d319f4124109f14a13f4e431" baserev="e9d965f2d319f4124109f14a13f4e431" xsrcmd5="6d8b4e042078d289ced39a1738e21c95" lsrcmd5="5acba764a37a9bc6490f80deca372916" />
+          <entry name="DUMMY_FILE" md5="275876e34cf609db118f3d84b799a790" size="5" mtime="1503405075" />
+          <entry name="_config" md5="7159169868967997b7eabbd94d805185" size="238" mtime="1503405073" />
+          <entry name="_link" md5="11504ac69b4a7053159649a50cf86e1f" size="130" mtime="1503405074" />
+          <entry name="somefile.txt" md5="b4b03ef7ef00ded93403c2c595500c4f" size="116" mtime="1503405073" />
         </directory>
     http_version: 
-  recorded_at: Mon, 21 Aug 2017 14:07:34 GMT
+  recorded_at: Tue, 22 Aug 2017 12:31:28 GMT
 - request:
     method: post
     uri: http://localhost:3200/search/package/id?match=(linkinfo/@package=%22ProjectWithRepo_package%22%20and%20linkinfo/@project=%22ProjectWithRepo:Update%22%20and%20starts-with(@project,%22MaintenanceProject:%22))
@@ -6548,7 +6525,7 @@ http_interactions:
           <package name="ProjectWithRepo_package.ProjectWithRepo_Update" project="MaintenanceProject:0" />
         </collection>
     http_version: 
-  recorded_at: Mon, 21 Aug 2017 14:07:34 GMT
+  recorded_at: Tue, 22 Aug 2017 12:31:28 GMT
 - request:
     method: post
     uri: http://localhost:3200/search/package/id?match=(linkinfo/@package=%22ProjectWithRepo_package%22%20and%20linkinfo/@project=%22ProjectWithRepo%22%20and%20@project=%22ProjectWithRepo%22)
@@ -6583,7 +6560,7 @@ http_interactions:
         <collection>
         </collection>
     http_version: 
-  recorded_at: Mon, 21 Aug 2017 14:07:34 GMT
+  recorded_at: Tue, 22 Aug 2017 12:31:28 GMT
 - request:
     method: put
     uri: http://localhost:3200/source/MaintenanceProject:0/ProjectWithRepo_package.ProjectWithRepo_Update/_meta?user=maintenance_coord
@@ -6591,8 +6568,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="ProjectWithRepo_package.ProjectWithRepo_Update" project="MaintenanceProject:0">
-          <title>Moab Is My Washpot</title>
-          <description>Eius ut consequuntur nihil.</description>
+          <title>Have His Carcase</title>
+          <description>Molestiae eligendi asperiores quod voluptatibus totam non recusandae voluptas.</description>
           <releasename>ProjectWithRepo_package</releasename>
           <build>
             <enable repository="ProjectWithRepo_Update"/>
@@ -6617,20 +6594,20 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '324'
+      - '373'
     body:
       encoding: UTF-8
       string: |
         <package name="ProjectWithRepo_package.ProjectWithRepo_Update" project="MaintenanceProject:0">
-          <title>Moab Is My Washpot</title>
-          <description>Eius ut consequuntur nihil.</description>
+          <title>Have His Carcase</title>
+          <description>Molestiae eligendi asperiores quod voluptatibus totam non recusandae voluptas.</description>
           <releasename>ProjectWithRepo_package</releasename>
           <build>
             <enable repository="ProjectWithRepo_Update" />
           </build>
         </package>
     http_version: 
-  recorded_at: Mon, 21 Aug 2017 14:07:34 GMT
+  recorded_at: Tue, 22 Aug 2017 12:31:28 GMT
 - request:
     method: post
     uri: http://localhost:3200/source/MaintenanceProject:0/ProjectWithRepo_package.ProjectWithRepo_Update?cmd=branch&opackage=ProjectWithRepo_package&oproject=ProjectWithRepo:Update&user=maintenance_coord
@@ -6662,16 +6639,16 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <revision rev="7" vrev="7">
-          <srcmd5>86a991e1d0fb1e255e605e346b8c71b2</srcmd5>
+        <revision rev="3" vrev="3">
+          <srcmd5>8f207ebc6846b26ebb947a0d4399345e</srcmd5>
           <version>unknown</version>
-          <time>1503324454</time>
+          <time>1503405088</time>
           <user>maintenance_coord</user>
           <comment></comment>
           <requestid/>
         </revision>
     http_version: 
-  recorded_at: Mon, 21 Aug 2017 14:07:34 GMT
+  recorded_at: Tue, 22 Aug 2017 12:31:28 GMT
 - request:
     method: put
     uri: http://localhost:3200/source/MaintenanceProject:0/ProjectWithRepo_package.ProjectWithRepo_Update/_meta?user=maintenance_coord
@@ -6679,8 +6656,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="ProjectWithRepo_package.ProjectWithRepo_Update" project="MaintenanceProject:0">
-          <title>Moab Is My Washpot</title>
-          <description>Eius ut consequuntur nihil.</description>
+          <title>Have His Carcase</title>
+          <description>Molestiae eligendi asperiores quod voluptatibus totam non recusandae voluptas.</description>
           <releasename>ProjectWithRepo_package</releasename>
           <build>
             <enable repository="ProjectWithRepo_Update"/>
@@ -6705,20 +6682,20 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '324'
+      - '373'
     body:
       encoding: UTF-8
       string: |
         <package name="ProjectWithRepo_package.ProjectWithRepo_Update" project="MaintenanceProject:0">
-          <title>Moab Is My Washpot</title>
-          <description>Eius ut consequuntur nihil.</description>
+          <title>Have His Carcase</title>
+          <description>Molestiae eligendi asperiores quod voluptatibus totam non recusandae voluptas.</description>
           <releasename>ProjectWithRepo_package</releasename>
           <build>
             <enable repository="ProjectWithRepo_Update" />
           </build>
         </package>
     http_version: 
-  recorded_at: Mon, 21 Aug 2017 14:07:34 GMT
+  recorded_at: Tue, 22 Aug 2017 12:31:28 GMT
 - request:
     method: get
     uri: http://localhost:3200/source/MaintenanceProject:0/ProjectWithRepo_package.ProjectWithRepo_Update
@@ -6748,14 +6725,14 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="ProjectWithRepo_package.ProjectWithRepo_Update" rev="7" vrev="7" srcmd5="86a991e1d0fb1e255e605e346b8c71b2">
-          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" srcmd5="09e82b0920e2079611427fc5ae96b076" baserev="09e82b0920e2079611427fc5ae96b076" xsrcmd5="dd8fee4cd9676519d6bc95db70858eac" lsrcmd5="86a991e1d0fb1e255e605e346b8c71b2" />
-          <entry name="_config" md5="55041d03ef8e31e551b3edd00464f7ea" size="103" mtime="1503324439" />
-          <entry name="_link" md5="3f7843b2f03812aa3a4c42dd85f1b177" size="164" mtime="1503324445" />
-          <entry name="somefile.txt" md5="72a89c51cb636651b1da704fa7b303ee" size="160" mtime="1503324439" />
+        <directory name="ProjectWithRepo_package.ProjectWithRepo_Update" rev="3" vrev="3" srcmd5="8f207ebc6846b26ebb947a0d4399345e">
+          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" srcmd5="e9d965f2d319f4124109f14a13f4e431" baserev="e9d965f2d319f4124109f14a13f4e431" xsrcmd5="ef9928a63930d4797ced0ef2ad58ed0c" lsrcmd5="8f207ebc6846b26ebb947a0d4399345e" />
+          <entry name="_config" md5="7159169868967997b7eabbd94d805185" size="238" mtime="1503405073" />
+          <entry name="_link" md5="ad672afb37ca2f6a039ad35297d226d1" size="164" mtime="1503405079" />
+          <entry name="somefile.txt" md5="b4b03ef7ef00ded93403c2c595500c4f" size="116" mtime="1503405073" />
         </directory>
     http_version: 
-  recorded_at: Mon, 21 Aug 2017 14:07:34 GMT
+  recorded_at: Tue, 22 Aug 2017 12:31:28 GMT
 - request:
     method: get
     uri: http://localhost:3200/source/MaintenanceProject:0/ProjectWithRepo_package.ProjectWithRepo_Update?nofilename=1&view=info&withchangesmd5=1
@@ -6781,17 +6758,17 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '417'
+      - '416'
     body:
       encoding: UTF-8
       string: |
-        <sourceinfo package="ProjectWithRepo_package.ProjectWithRepo_Update" rev="7" vrev="11" srcmd5="dd8fee4cd9676519d6bc95db70858eac" lsrcmd5="86a991e1d0fb1e255e605e346b8c71b2" verifymd5="09e82b0920e2079611427fc5ae96b076">
+        <sourceinfo package="ProjectWithRepo_package.ProjectWithRepo_Update" rev="3" vrev="5" srcmd5="ef9928a63930d4797ced0ef2ad58ed0c" lsrcmd5="8f207ebc6846b26ebb947a0d4399345e" verifymd5="e9d965f2d319f4124109f14a13f4e431">
           <linked project="ProjectWithRepo:Update" package="ProjectWithRepo_package" />
           <linked project="ProjectWithRepo" package="ProjectWithRepo_package" />
-          <revtime>1503324454</revtime>
+          <revtime>1503405088</revtime>
         </sourceinfo>
     http_version: 
-  recorded_at: Mon, 21 Aug 2017 14:07:34 GMT
+  recorded_at: Tue, 22 Aug 2017 12:31:28 GMT
 - request:
     method: get
     uri: http://localhost:3200/source/MaintenanceProject:0/ProjectWithRepo_package.ProjectWithRepo_Update
@@ -6821,14 +6798,14 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="ProjectWithRepo_package.ProjectWithRepo_Update" rev="7" vrev="7" srcmd5="86a991e1d0fb1e255e605e346b8c71b2">
-          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" srcmd5="09e82b0920e2079611427fc5ae96b076" baserev="09e82b0920e2079611427fc5ae96b076" xsrcmd5="dd8fee4cd9676519d6bc95db70858eac" lsrcmd5="86a991e1d0fb1e255e605e346b8c71b2" />
-          <entry name="_config" md5="55041d03ef8e31e551b3edd00464f7ea" size="103" mtime="1503324439" />
-          <entry name="_link" md5="3f7843b2f03812aa3a4c42dd85f1b177" size="164" mtime="1503324445" />
-          <entry name="somefile.txt" md5="72a89c51cb636651b1da704fa7b303ee" size="160" mtime="1503324439" />
+        <directory name="ProjectWithRepo_package.ProjectWithRepo_Update" rev="3" vrev="3" srcmd5="8f207ebc6846b26ebb947a0d4399345e">
+          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" srcmd5="e9d965f2d319f4124109f14a13f4e431" baserev="e9d965f2d319f4124109f14a13f4e431" xsrcmd5="ef9928a63930d4797ced0ef2ad58ed0c" lsrcmd5="8f207ebc6846b26ebb947a0d4399345e" />
+          <entry name="_config" md5="7159169868967997b7eabbd94d805185" size="238" mtime="1503405073" />
+          <entry name="_link" md5="ad672afb37ca2f6a039ad35297d226d1" size="164" mtime="1503405079" />
+          <entry name="somefile.txt" md5="b4b03ef7ef00ded93403c2c595500c4f" size="116" mtime="1503405073" />
         </directory>
     http_version: 
-  recorded_at: Mon, 21 Aug 2017 14:07:34 GMT
+  recorded_at: Tue, 22 Aug 2017 12:31:28 GMT
 - request:
     method: post
     uri: http://localhost:3200/source/MaintenanceProject:0/ProjectWithRepo_package.ProjectWithRepo_Update?cmd=diff&linkrev=base&onlyissues=1&orev=0&view=xml
@@ -6860,15 +6837,15 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="00a8f538a8458c1ee8cd1af5b5a9da0b">
+        <sourcediff key="b61c34ff40308ddf8f623d6890654428">
           <old project="MaintenanceProject:0" package="ProjectWithRepo_package.ProjectWithRepo_Update" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e" />
-          <new project="MaintenanceProject:0" package="ProjectWithRepo_package.ProjectWithRepo_Update" rev="5" srcmd5="86a991e1d0fb1e255e605e346b8c71b2" />
+          <new project="MaintenanceProject:0" package="ProjectWithRepo_package.ProjectWithRepo_Update" rev="1" srcmd5="8f207ebc6846b26ebb947a0d4399345e" />
           <files />
           <issues>
           </issues>
         </sourcediff>
     http_version: 
-  recorded_at: Mon, 21 Aug 2017 14:07:34 GMT
+  recorded_at: Tue, 22 Aug 2017 12:31:28 GMT
 - request:
     method: post
     uri: http://localhost:3200/source/MaintenanceProject:0/ProjectWithRepo_package.ProjectWithRepo_Update?cmd=linkdiff&linkrev=base&onlyissues=1&view=xml
@@ -6900,13 +6877,13 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="c2d0ce4eef4d88842741edf1dd777bce">
-          <old project="ProjectWithRepo:Update" package="ProjectWithRepo_package" rev="09e82b0920e2079611427fc5ae96b076" srcmd5="09e82b0920e2079611427fc5ae96b076" />
-          <new project="MaintenanceProject:0" package="ProjectWithRepo_package.ProjectWithRepo_Update" rev="dd8fee4cd9676519d6bc95db70858eac" srcmd5="dd8fee4cd9676519d6bc95db70858eac" />
+        <sourcediff key="2bd7c5fd0453c368b796a8f70d681186">
+          <old project="ProjectWithRepo:Update" package="ProjectWithRepo_package" rev="e9d965f2d319f4124109f14a13f4e431" srcmd5="e9d965f2d319f4124109f14a13f4e431" />
+          <new project="MaintenanceProject:0" package="ProjectWithRepo_package.ProjectWithRepo_Update" rev="ef9928a63930d4797ced0ef2ad58ed0c" srcmd5="ef9928a63930d4797ced0ef2ad58ed0c" />
           <files />
         </sourcediff>
     http_version: 
-  recorded_at: Mon, 21 Aug 2017 14:07:34 GMT
+  recorded_at: Tue, 22 Aug 2017 12:31:28 GMT
 - request:
     method: put
     uri: http://localhost:3200/source/MaintenanceProject:0/ProjectWithRepo_package.ProjectWithRepo_Update/_meta?user=maintenance_coord
@@ -6914,8 +6891,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="ProjectWithRepo_package.ProjectWithRepo_Update" project="MaintenanceProject:0">
-          <title>Moab Is My Washpot</title>
-          <description>Eius ut consequuntur nihil.</description>
+          <title>Have His Carcase</title>
+          <description>Molestiae eligendi asperiores quod voluptatibus totam non recusandae voluptas.</description>
           <releasename>ProjectWithRepo_package</releasename>
           <build>
             <enable repository="ProjectWithRepo_Update"/>
@@ -6941,13 +6918,13 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '375'
+      - '424'
     body:
       encoding: UTF-8
       string: |
         <package name="ProjectWithRepo_package.ProjectWithRepo_Update" project="MaintenanceProject:0">
-          <title>Moab Is My Washpot</title>
-          <description>Eius ut consequuntur nihil.</description>
+          <title>Have His Carcase</title>
+          <description>Molestiae eligendi asperiores quod voluptatibus totam non recusandae voluptas.</description>
           <releasename>ProjectWithRepo_package</releasename>
           <build>
             <enable repository="ProjectWithRepo_Update" />
@@ -6955,7 +6932,7 @@ http_interactions:
           </build>
         </package>
     http_version: 
-  recorded_at: Mon, 21 Aug 2017 14:07:34 GMT
+  recorded_at: Tue, 22 Aug 2017 12:31:28 GMT
 - request:
     method: get
     uri: http://localhost:3200/source/MaintenanceProject:0/ProjectWithRepo_package.ProjectWithRepo_Update
@@ -6985,14 +6962,14 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="ProjectWithRepo_package.ProjectWithRepo_Update" rev="7" vrev="7" srcmd5="86a991e1d0fb1e255e605e346b8c71b2">
-          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" srcmd5="09e82b0920e2079611427fc5ae96b076" baserev="09e82b0920e2079611427fc5ae96b076" xsrcmd5="dd8fee4cd9676519d6bc95db70858eac" lsrcmd5="86a991e1d0fb1e255e605e346b8c71b2" />
-          <entry name="_config" md5="55041d03ef8e31e551b3edd00464f7ea" size="103" mtime="1503324439" />
-          <entry name="_link" md5="3f7843b2f03812aa3a4c42dd85f1b177" size="164" mtime="1503324445" />
-          <entry name="somefile.txt" md5="72a89c51cb636651b1da704fa7b303ee" size="160" mtime="1503324439" />
+        <directory name="ProjectWithRepo_package.ProjectWithRepo_Update" rev="3" vrev="3" srcmd5="8f207ebc6846b26ebb947a0d4399345e">
+          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" srcmd5="e9d965f2d319f4124109f14a13f4e431" baserev="e9d965f2d319f4124109f14a13f4e431" xsrcmd5="ef9928a63930d4797ced0ef2ad58ed0c" lsrcmd5="8f207ebc6846b26ebb947a0d4399345e" />
+          <entry name="_config" md5="7159169868967997b7eabbd94d805185" size="238" mtime="1503405073" />
+          <entry name="_link" md5="ad672afb37ca2f6a039ad35297d226d1" size="164" mtime="1503405079" />
+          <entry name="somefile.txt" md5="b4b03ef7ef00ded93403c2c595500c4f" size="116" mtime="1503405073" />
         </directory>
     http_version: 
-  recorded_at: Mon, 21 Aug 2017 14:07:34 GMT
+  recorded_at: Tue, 22 Aug 2017 12:31:28 GMT
 - request:
     method: get
     uri: http://localhost:3200/source/MaintenanceProject:0/ProjectWithRepo_package.ProjectWithRepo_Update
@@ -7022,14 +6999,14 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="ProjectWithRepo_package.ProjectWithRepo_Update" rev="7" vrev="7" srcmd5="86a991e1d0fb1e255e605e346b8c71b2">
-          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" srcmd5="09e82b0920e2079611427fc5ae96b076" baserev="09e82b0920e2079611427fc5ae96b076" xsrcmd5="dd8fee4cd9676519d6bc95db70858eac" lsrcmd5="86a991e1d0fb1e255e605e346b8c71b2" />
-          <entry name="_config" md5="55041d03ef8e31e551b3edd00464f7ea" size="103" mtime="1503324439" />
-          <entry name="_link" md5="3f7843b2f03812aa3a4c42dd85f1b177" size="164" mtime="1503324445" />
-          <entry name="somefile.txt" md5="72a89c51cb636651b1da704fa7b303ee" size="160" mtime="1503324439" />
+        <directory name="ProjectWithRepo_package.ProjectWithRepo_Update" rev="3" vrev="3" srcmd5="8f207ebc6846b26ebb947a0d4399345e">
+          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" srcmd5="e9d965f2d319f4124109f14a13f4e431" baserev="e9d965f2d319f4124109f14a13f4e431" xsrcmd5="ef9928a63930d4797ced0ef2ad58ed0c" lsrcmd5="8f207ebc6846b26ebb947a0d4399345e" />
+          <entry name="_config" md5="7159169868967997b7eabbd94d805185" size="238" mtime="1503405073" />
+          <entry name="_link" md5="ad672afb37ca2f6a039ad35297d226d1" size="164" mtime="1503405079" />
+          <entry name="somefile.txt" md5="b4b03ef7ef00ded93403c2c595500c4f" size="116" mtime="1503405073" />
         </directory>
     http_version: 
-  recorded_at: Mon, 21 Aug 2017 14:07:34 GMT
+  recorded_at: Tue, 22 Aug 2017 12:31:28 GMT
 - request:
     method: get
     uri: http://localhost:3200/source/MaintenanceProject:0/ProjectWithRepo_package.ProjectWithRepo_Update
@@ -7059,14 +7036,14 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="ProjectWithRepo_package.ProjectWithRepo_Update" rev="7" vrev="7" srcmd5="86a991e1d0fb1e255e605e346b8c71b2">
-          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" srcmd5="09e82b0920e2079611427fc5ae96b076" baserev="09e82b0920e2079611427fc5ae96b076" xsrcmd5="dd8fee4cd9676519d6bc95db70858eac" lsrcmd5="86a991e1d0fb1e255e605e346b8c71b2" />
-          <entry name="_config" md5="55041d03ef8e31e551b3edd00464f7ea" size="103" mtime="1503324439" />
-          <entry name="_link" md5="3f7843b2f03812aa3a4c42dd85f1b177" size="164" mtime="1503324445" />
-          <entry name="somefile.txt" md5="72a89c51cb636651b1da704fa7b303ee" size="160" mtime="1503324439" />
+        <directory name="ProjectWithRepo_package.ProjectWithRepo_Update" rev="3" vrev="3" srcmd5="8f207ebc6846b26ebb947a0d4399345e">
+          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" srcmd5="e9d965f2d319f4124109f14a13f4e431" baserev="e9d965f2d319f4124109f14a13f4e431" xsrcmd5="ef9928a63930d4797ced0ef2ad58ed0c" lsrcmd5="8f207ebc6846b26ebb947a0d4399345e" />
+          <entry name="_config" md5="7159169868967997b7eabbd94d805185" size="238" mtime="1503405073" />
+          <entry name="_link" md5="ad672afb37ca2f6a039ad35297d226d1" size="164" mtime="1503405079" />
+          <entry name="somefile.txt" md5="b4b03ef7ef00ded93403c2c595500c4f" size="116" mtime="1503405073" />
         </directory>
     http_version: 
-  recorded_at: Mon, 21 Aug 2017 14:07:34 GMT
+  recorded_at: Tue, 22 Aug 2017 12:31:28 GMT
 - request:
     method: post
     uri: http://localhost:3200/search/package/id?match=(linkinfo/@package=%22ProjectWithRepo_package%22%20and%20linkinfo/@project=%22ProjectWithRepo%22%20and%20@project=%22ProjectWithRepo%22)
@@ -7101,7 +7078,7 @@ http_interactions:
         <collection>
         </collection>
     http_version: 
-  recorded_at: Mon, 21 Aug 2017 14:07:34 GMT
+  recorded_at: Tue, 22 Aug 2017 12:31:28 GMT
 - request:
     method: put
     uri: http://localhost:3200/source/MaintenanceProject:0/_meta?user=maintenance_coord
@@ -7166,7 +7143,7 @@ http_interactions:
           </repository>
         </project>
     http_version: 
-  recorded_at: Mon, 21 Aug 2017 14:07:34 GMT
+  recorded_at: Tue, 22 Aug 2017 12:31:28 GMT
 - request:
     method: put
     uri: http://localhost:3200/source/MaintenanceProject:0/_meta?user=maintenance_coord
@@ -7231,10 +7208,10 @@ http_interactions:
           </repository>
         </project>
     http_version: 
-  recorded_at: Mon, 21 Aug 2017 14:07:34 GMT
+  recorded_at: Tue, 22 Aug 2017 12:31:28 GMT
 - request:
     method: post
-    uri: http://localhost:3200/source/MaintenanceProject:0/ProjectWithRepo_package.ProjectWithRepo_Update?cmd=copy&comment=Maintenance%20incident%20copy%20from%20project%20home:tom:branches:ProjectWithRepo:Update&expand=1&keeplink=1&opackage=ProjectWithRepo_package&oproject=home:tom:branches:ProjectWithRepo:Update&requestid=2&user=maintenance_coord&withacceptinfo=1
+    uri: http://localhost:3200/source/MaintenanceProject:0/ProjectWithRepo_package.ProjectWithRepo_Update?cmd=copy&comment=Maintenance%20incident%20copy%20from%20project%20home:tom:branches:ProjectWithRepo:Update&expand=1&keeplink=1&opackage=ProjectWithRepo_package&oproject=home:tom:branches:ProjectWithRepo:Update&orev=6d8b4e042078d289ced39a1738e21c95&requestid=2&user=maintenance_coord&withacceptinfo=1
     body:
       encoding: UTF-8
       string: ''
@@ -7263,17 +7240,17 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <revision rev="8" vrev="8">
-          <srcmd5>8c95ac173db372e4ec3afc73fe679c4a</srcmd5>
+        <revision rev="4" vrev="4">
+          <srcmd5>3bc4d536be0f4724dd0defa094f247cf</srcmd5>
           <version>unknown</version>
-          <time>1503324454</time>
+          <time>1503405088</time>
           <user>maintenance_coord</user>
           <comment>Maintenance incident copy from project home:tom:branches:ProjectWithRepo:Update</comment>
           <requestid>2</requestid>
-          <acceptinfo rev="8" srcmd5="8c95ac173db372e4ec3afc73fe679c4a" osrcmd5="86a991e1d0fb1e255e605e346b8c71b2" xsrcmd5="6c2a823ba5d861d74d5c25e6ef62df17" oxsrcmd5="dd8fee4cd9676519d6bc95db70858eac" />
+          <acceptinfo rev="4" srcmd5="3bc4d536be0f4724dd0defa094f247cf" osrcmd5="8f207ebc6846b26ebb947a0d4399345e" xsrcmd5="96b1040600ed3f57e960243b55548162" oxsrcmd5="ef9928a63930d4797ced0ef2ad58ed0c" />
         </revision>
     http_version: 
-  recorded_at: Mon, 21 Aug 2017 14:07:34 GMT
+  recorded_at: Tue, 22 Aug 2017 12:31:28 GMT
 - request:
     method: put
     uri: http://localhost:3200/source/MaintenanceProject:0/ProjectWithRepo_package.ProjectWithRepo_Update/_meta?user=maintenance_coord
@@ -7281,8 +7258,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="ProjectWithRepo_package.ProjectWithRepo_Update" project="MaintenanceProject:0">
-          <title>Moab Is My Washpot</title>
-          <description>Eius ut consequuntur nihil.</description>
+          <title>Have His Carcase</title>
+          <description>Molestiae eligendi asperiores quod voluptatibus totam non recusandae voluptas.</description>
           <releasename>ProjectWithRepo_package</releasename>
           <build>
             <enable repository="ProjectWithRepo_Update"/>
@@ -7308,13 +7285,13 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '375'
+      - '424'
     body:
       encoding: UTF-8
       string: |
         <package name="ProjectWithRepo_package.ProjectWithRepo_Update" project="MaintenanceProject:0">
-          <title>Moab Is My Washpot</title>
-          <description>Eius ut consequuntur nihil.</description>
+          <title>Have His Carcase</title>
+          <description>Molestiae eligendi asperiores quod voluptatibus totam non recusandae voluptas.</description>
           <releasename>ProjectWithRepo_package</releasename>
           <build>
             <enable repository="ProjectWithRepo_Update" />
@@ -7322,7 +7299,7 @@ http_interactions:
           </build>
         </package>
     http_version: 
-  recorded_at: Mon, 21 Aug 2017 14:07:34 GMT
+  recorded_at: Tue, 22 Aug 2017 12:31:28 GMT
 - request:
     method: get
     uri: http://localhost:3200/source/MaintenanceProject:0/ProjectWithRepo_package.ProjectWithRepo_Update
@@ -7352,15 +7329,15 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="ProjectWithRepo_package.ProjectWithRepo_Update" rev="8" vrev="8" srcmd5="8c95ac173db372e4ec3afc73fe679c4a">
-          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" srcmd5="09e82b0920e2079611427fc5ae96b076" baserev="09e82b0920e2079611427fc5ae96b076" xsrcmd5="6c2a823ba5d861d74d5c25e6ef62df17" lsrcmd5="8c95ac173db372e4ec3afc73fe679c4a" />
-          <entry name="DUMMY_FILE" md5="275876e34cf609db118f3d84b799a790" size="5" mtime="1503324268" />
-          <entry name="_config" md5="55041d03ef8e31e551b3edd00464f7ea" size="103" mtime="1503324439" />
-          <entry name="_link" md5="3f7843b2f03812aa3a4c42dd85f1b177" size="164" mtime="1503324445" />
-          <entry name="somefile.txt" md5="72a89c51cb636651b1da704fa7b303ee" size="160" mtime="1503324439" />
+        <directory name="ProjectWithRepo_package.ProjectWithRepo_Update" rev="4" vrev="4" srcmd5="3bc4d536be0f4724dd0defa094f247cf">
+          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" srcmd5="e9d965f2d319f4124109f14a13f4e431" baserev="e9d965f2d319f4124109f14a13f4e431" xsrcmd5="96b1040600ed3f57e960243b55548162" lsrcmd5="3bc4d536be0f4724dd0defa094f247cf" />
+          <entry name="DUMMY_FILE" md5="275876e34cf609db118f3d84b799a790" size="5" mtime="1503405075" />
+          <entry name="_config" md5="7159169868967997b7eabbd94d805185" size="238" mtime="1503405073" />
+          <entry name="_link" md5="ad672afb37ca2f6a039ad35297d226d1" size="164" mtime="1503405079" />
+          <entry name="somefile.txt" md5="b4b03ef7ef00ded93403c2c595500c4f" size="116" mtime="1503405073" />
         </directory>
     http_version: 
-  recorded_at: Mon, 21 Aug 2017 14:07:34 GMT
+  recorded_at: Tue, 22 Aug 2017 12:31:28 GMT
 - request:
     method: get
     uri: http://localhost:3200/source/MaintenanceProject:0/ProjectWithRepo_package.ProjectWithRepo_Update?nofilename=1&view=info&withchangesmd5=1
@@ -7386,17 +7363,17 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '417'
+      - '416'
     body:
       encoding: UTF-8
       string: |
-        <sourceinfo package="ProjectWithRepo_package.ProjectWithRepo_Update" rev="8" vrev="12" srcmd5="6c2a823ba5d861d74d5c25e6ef62df17" lsrcmd5="8c95ac173db372e4ec3afc73fe679c4a" verifymd5="20df9d21809f8c811abf5fe64b26d948">
+        <sourceinfo package="ProjectWithRepo_package.ProjectWithRepo_Update" rev="4" vrev="6" srcmd5="96b1040600ed3f57e960243b55548162" lsrcmd5="3bc4d536be0f4724dd0defa094f247cf" verifymd5="227e65861e6374ec8a0776883967906a">
           <linked project="ProjectWithRepo:Update" package="ProjectWithRepo_package" />
           <linked project="ProjectWithRepo" package="ProjectWithRepo_package" />
-          <revtime>1503324454</revtime>
+          <revtime>1503405088</revtime>
         </sourceinfo>
     http_version: 
-  recorded_at: Mon, 21 Aug 2017 14:07:34 GMT
+  recorded_at: Tue, 22 Aug 2017 12:31:28 GMT
 - request:
     method: get
     uri: http://localhost:3200/source/MaintenanceProject:0/ProjectWithRepo_package.ProjectWithRepo_Update
@@ -7426,15 +7403,15 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="ProjectWithRepo_package.ProjectWithRepo_Update" rev="8" vrev="8" srcmd5="8c95ac173db372e4ec3afc73fe679c4a">
-          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" srcmd5="09e82b0920e2079611427fc5ae96b076" baserev="09e82b0920e2079611427fc5ae96b076" xsrcmd5="6c2a823ba5d861d74d5c25e6ef62df17" lsrcmd5="8c95ac173db372e4ec3afc73fe679c4a" />
-          <entry name="DUMMY_FILE" md5="275876e34cf609db118f3d84b799a790" size="5" mtime="1503324268" />
-          <entry name="_config" md5="55041d03ef8e31e551b3edd00464f7ea" size="103" mtime="1503324439" />
-          <entry name="_link" md5="3f7843b2f03812aa3a4c42dd85f1b177" size="164" mtime="1503324445" />
-          <entry name="somefile.txt" md5="72a89c51cb636651b1da704fa7b303ee" size="160" mtime="1503324439" />
+        <directory name="ProjectWithRepo_package.ProjectWithRepo_Update" rev="4" vrev="4" srcmd5="3bc4d536be0f4724dd0defa094f247cf">
+          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" srcmd5="e9d965f2d319f4124109f14a13f4e431" baserev="e9d965f2d319f4124109f14a13f4e431" xsrcmd5="96b1040600ed3f57e960243b55548162" lsrcmd5="3bc4d536be0f4724dd0defa094f247cf" />
+          <entry name="DUMMY_FILE" md5="275876e34cf609db118f3d84b799a790" size="5" mtime="1503405075" />
+          <entry name="_config" md5="7159169868967997b7eabbd94d805185" size="238" mtime="1503405073" />
+          <entry name="_link" md5="ad672afb37ca2f6a039ad35297d226d1" size="164" mtime="1503405079" />
+          <entry name="somefile.txt" md5="b4b03ef7ef00ded93403c2c595500c4f" size="116" mtime="1503405073" />
         </directory>
     http_version: 
-  recorded_at: Mon, 21 Aug 2017 14:07:34 GMT
+  recorded_at: Tue, 22 Aug 2017 12:31:28 GMT
 - request:
     method: post
     uri: http://localhost:3200/source/MaintenanceProject:0/ProjectWithRepo_package.ProjectWithRepo_Update?cmd=diff&linkrev=base&onlyissues=1&orev=0&view=xml
@@ -7466,15 +7443,15 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="19494ad5fd9a44aa388f5358268d23f5">
+        <sourcediff key="bbccdf3aeea2076b584883bbd16cc8c8">
           <old project="MaintenanceProject:0" package="ProjectWithRepo_package.ProjectWithRepo_Update" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e" />
-          <new project="MaintenanceProject:0" package="ProjectWithRepo_package.ProjectWithRepo_Update" rev="6" srcmd5="8c95ac173db372e4ec3afc73fe679c4a" />
+          <new project="MaintenanceProject:0" package="ProjectWithRepo_package.ProjectWithRepo_Update" rev="2" srcmd5="3bc4d536be0f4724dd0defa094f247cf" />
           <files />
           <issues>
           </issues>
         </sourcediff>
     http_version: 
-  recorded_at: Mon, 21 Aug 2017 14:07:34 GMT
+  recorded_at: Tue, 22 Aug 2017 12:31:28 GMT
 - request:
     method: post
     uri: http://localhost:3200/source/MaintenanceProject:0/ProjectWithRepo_package.ProjectWithRepo_Update?cmd=linkdiff&linkrev=base&onlyissues=1&view=xml
@@ -7506,15 +7483,15 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="ace3a4b15a241d14542026ae3c8365c9">
-          <old project="ProjectWithRepo:Update" package="ProjectWithRepo_package" rev="09e82b0920e2079611427fc5ae96b076" srcmd5="09e82b0920e2079611427fc5ae96b076" />
-          <new project="MaintenanceProject:0" package="ProjectWithRepo_package.ProjectWithRepo_Update" rev="6c2a823ba5d861d74d5c25e6ef62df17" srcmd5="6c2a823ba5d861d74d5c25e6ef62df17" />
+        <sourcediff key="aa393379f0698c4b78a41bf61e79e894">
+          <old project="ProjectWithRepo:Update" package="ProjectWithRepo_package" rev="e9d965f2d319f4124109f14a13f4e431" srcmd5="e9d965f2d319f4124109f14a13f4e431" />
+          <new project="MaintenanceProject:0" package="ProjectWithRepo_package.ProjectWithRepo_Update" rev="96b1040600ed3f57e960243b55548162" srcmd5="96b1040600ed3f57e960243b55548162" />
           <files />
           <issues>
           </issues>
         </sourcediff>
     http_version: 
-  recorded_at: Mon, 21 Aug 2017 14:07:35 GMT
+  recorded_at: Tue, 22 Aug 2017 12:31:28 GMT
 - request:
     method: put
     uri: http://localhost:3200/source/MaintenanceProject:0/_meta?comment=maintenance_incident%20request%202&requestid=2&user=maintenance_coord
@@ -7579,10 +7556,10 @@ http_interactions:
           </repository>
         </project>
     http_version: 
-  recorded_at: Mon, 21 Aug 2017 14:07:35 GMT
+  recorded_at: Tue, 22 Aug 2017 12:31:29 GMT
 - request:
     method: post
-    uri: http://localhost:3200/source/MaintenanceProject:0/ProjectWithRepo_package.ProjectWithRepo_Update?cmd=diff&orev=dd8fee4cd9676519d6bc95db70858eac&rev=6c2a823ba5d861d74d5c25e6ef62df17&view=xml&withissues=1
+    uri: http://localhost:3200/source/MaintenanceProject:0/ProjectWithRepo_package.ProjectWithRepo_Update?cmd=diff&orev=ef9928a63930d4797ced0ef2ad58ed0c&rev=96b1040600ed3f57e960243b55548162&view=xml&withissues=1
     body:
       encoding: UTF-8
       string: ''
@@ -7611,9 +7588,9 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="42b22c4ac987fc87d14e33de37bd0f10">
-          <old project="MaintenanceProject:0" package="ProjectWithRepo_package.ProjectWithRepo_Update" rev="dd8fee4cd9676519d6bc95db70858eac" srcmd5="dd8fee4cd9676519d6bc95db70858eac" />
-          <new project="MaintenanceProject:0" package="ProjectWithRepo_package.ProjectWithRepo_Update" rev="6c2a823ba5d861d74d5c25e6ef62df17" srcmd5="6c2a823ba5d861d74d5c25e6ef62df17" />
+        <sourcediff key="63bb8ae8e41021e19f94a688fab094a2">
+          <old project="MaintenanceProject:0" package="ProjectWithRepo_package.ProjectWithRepo_Update" rev="ef9928a63930d4797ced0ef2ad58ed0c" srcmd5="ef9928a63930d4797ced0ef2ad58ed0c" />
+          <new project="MaintenanceProject:0" package="ProjectWithRepo_package.ProjectWithRepo_Update" rev="96b1040600ed3f57e960243b55548162" srcmd5="96b1040600ed3f57e960243b55548162" />
           <files>
             <file state="added">
               <new name="DUMMY_FILE" md5="275876e34cf609db118f3d84b799a790" size="5" />
@@ -7627,7 +7604,7 @@ http_interactions:
           </issues>
         </sourcediff>
     http_version: 
-  recorded_at: Mon, 21 Aug 2017 14:07:35 GMT
+  recorded_at: Tue, 22 Aug 2017 12:31:29 GMT
 - request:
     method: get
     uri: http://localhost:3200/build/home:tom:branches:ProjectWithRepo:Update/_result?package=ProjectWithRepo_package&view=status
@@ -7663,7 +7640,7 @@ http_interactions:
           <result project="home:tom:branches:ProjectWithRepo:Update" repository="repository_2" arch="i586" code="unknown" state="unknown" />
         </resultlist>
     http_version: 
-  recorded_at: Mon, 21 Aug 2017 14:07:35 GMT
+  recorded_at: Tue, 22 Aug 2017 12:31:29 GMT
 - request:
     method: get
     uri: http://localhost:3200/build/home:tom:branches:ProjectWithRepo:Update/_result?locallink=1&multibuild=1&package=ProjectWithRepo_package&view=status
@@ -7699,7 +7676,7 @@ http_interactions:
           <result project="home:tom:branches:ProjectWithRepo:Update" repository="repository_2" arch="i586" code="unknown" state="unknown" />
         </resultlist>
     http_version: 
-  recorded_at: Mon, 21 Aug 2017 14:07:35 GMT
+  recorded_at: Tue, 22 Aug 2017 12:31:29 GMT
 - request:
     method: get
     uri: http://localhost:3200/build/MaintenanceProject:0/_result?code=unresolvable&view=status
@@ -7735,7 +7712,7 @@ http_interactions:
           <result project="MaintenanceProject:0" repository="ProjectWithRepo_Update" arch="i586" code="unknown" state="unknown" />
         </resultlist>
     http_version: 
-  recorded_at: Mon, 21 Aug 2017 14:07:35 GMT
+  recorded_at: Tue, 22 Aug 2017 12:31:29 GMT
 - request:
     method: get
     uri: http://localhost:3200/source/MaintenanceProject:0/patchinfo
@@ -7765,11 +7742,11 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="patchinfo" rev="6" vrev="6" srcmd5="177d57906eba63ae56a64a367592144a">
-          <entry name="_patchinfo" md5="ac29f7f1abd9ef43afeb43fc7737c007" size="318" mtime="1503324277" />
+        <directory name="patchinfo" rev="3" vrev="3" srcmd5="177d57906eba63ae56a64a367592144a">
+          <entry name="_patchinfo" md5="ac29f7f1abd9ef43afeb43fc7737c007" size="318" mtime="1503405082" />
         </directory>
     http_version: 
-  recorded_at: Mon, 21 Aug 2017 14:07:35 GMT
+  recorded_at: Tue, 22 Aug 2017 12:31:29 GMT
 - request:
     method: get
     uri: http://localhost:3200/build/MaintenanceProject:0/_result?view=summary
@@ -7807,7 +7784,7 @@ http_interactions:
           </result>
         </resultlist>
     http_version: 
-  recorded_at: Mon, 21 Aug 2017 14:07:35 GMT
+  recorded_at: Tue, 22 Aug 2017 12:31:29 GMT
 - request:
     method: get
     uri: http://localhost:3200/source/MaintenanceProject:0/ProjectWithRepo_package.ProjectWithRepo_Update
@@ -7837,15 +7814,15 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="ProjectWithRepo_package.ProjectWithRepo_Update" rev="8" vrev="8" srcmd5="8c95ac173db372e4ec3afc73fe679c4a">
-          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" srcmd5="09e82b0920e2079611427fc5ae96b076" baserev="09e82b0920e2079611427fc5ae96b076" xsrcmd5="6c2a823ba5d861d74d5c25e6ef62df17" lsrcmd5="8c95ac173db372e4ec3afc73fe679c4a" />
-          <entry name="DUMMY_FILE" md5="275876e34cf609db118f3d84b799a790" size="5" mtime="1503324268" />
-          <entry name="_config" md5="55041d03ef8e31e551b3edd00464f7ea" size="103" mtime="1503324439" />
-          <entry name="_link" md5="3f7843b2f03812aa3a4c42dd85f1b177" size="164" mtime="1503324445" />
-          <entry name="somefile.txt" md5="72a89c51cb636651b1da704fa7b303ee" size="160" mtime="1503324439" />
+        <directory name="ProjectWithRepo_package.ProjectWithRepo_Update" rev="4" vrev="4" srcmd5="3bc4d536be0f4724dd0defa094f247cf">
+          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" srcmd5="e9d965f2d319f4124109f14a13f4e431" baserev="e9d965f2d319f4124109f14a13f4e431" xsrcmd5="96b1040600ed3f57e960243b55548162" lsrcmd5="3bc4d536be0f4724dd0defa094f247cf" />
+          <entry name="DUMMY_FILE" md5="275876e34cf609db118f3d84b799a790" size="5" mtime="1503405075" />
+          <entry name="_config" md5="7159169868967997b7eabbd94d805185" size="238" mtime="1503405073" />
+          <entry name="_link" md5="ad672afb37ca2f6a039ad35297d226d1" size="164" mtime="1503405079" />
+          <entry name="somefile.txt" md5="b4b03ef7ef00ded93403c2c595500c4f" size="116" mtime="1503405073" />
         </directory>
     http_version: 
-  recorded_at: Mon, 21 Aug 2017 14:07:36 GMT
+  recorded_at: Tue, 22 Aug 2017 12:31:29 GMT
 - request:
     method: get
     uri: http://localhost:3200/source/MaintenanceProject:0/patchinfo
@@ -7875,11 +7852,11 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="patchinfo" rev="6" vrev="6" srcmd5="177d57906eba63ae56a64a367592144a">
-          <entry name="_patchinfo" md5="ac29f7f1abd9ef43afeb43fc7737c007" size="318" mtime="1503324277" />
+        <directory name="patchinfo" rev="3" vrev="3" srcmd5="177d57906eba63ae56a64a367592144a">
+          <entry name="_patchinfo" md5="ac29f7f1abd9ef43afeb43fc7737c007" size="318" mtime="1503405082" />
         </directory>
     http_version: 
-  recorded_at: Mon, 21 Aug 2017 14:07:36 GMT
+  recorded_at: Tue, 22 Aug 2017 12:31:29 GMT
 - request:
     method: get
     uri: http://localhost:3200/build/MaintenanceProject:0/_result?view=versrel
@@ -7913,7 +7890,7 @@ http_interactions:
           <result project="MaintenanceProject:0" repository="ProjectWithRepo_Update" arch="i586" code="unknown" state="unknown" />
         </resultlist>
     http_version: 
-  recorded_at: Mon, 21 Aug 2017 14:07:36 GMT
+  recorded_at: Tue, 22 Aug 2017 12:31:29 GMT
 - request:
     method: get
     uri: http://localhost:3200/build/MaintenanceProject:0/_result?code=unresolvable&view=status
@@ -7949,7 +7926,7 @@ http_interactions:
           <result project="MaintenanceProject:0" repository="ProjectWithRepo_Update" arch="i586" code="unknown" state="unknown" />
         </resultlist>
     http_version: 
-  recorded_at: Mon, 21 Aug 2017 14:07:36 GMT
+  recorded_at: Tue, 22 Aug 2017 12:31:29 GMT
 - request:
     method: get
     uri: http://localhost:3200/source/MaintenanceProject:0/patchinfo
@@ -7979,11 +7956,11 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="patchinfo" rev="6" vrev="6" srcmd5="177d57906eba63ae56a64a367592144a">
-          <entry name="_patchinfo" md5="ac29f7f1abd9ef43afeb43fc7737c007" size="318" mtime="1503324277" />
+        <directory name="patchinfo" rev="3" vrev="3" srcmd5="177d57906eba63ae56a64a367592144a">
+          <entry name="_patchinfo" md5="ac29f7f1abd9ef43afeb43fc7737c007" size="318" mtime="1503405082" />
         </directory>
     http_version: 
-  recorded_at: Mon, 21 Aug 2017 14:07:36 GMT
+  recorded_at: Tue, 22 Aug 2017 12:31:29 GMT
 - request:
     method: get
     uri: http://localhost:3200/build/MaintenanceProject:0/_result?view=summary
@@ -8021,5 +7998,5 @@ http_interactions:
           </result>
         </resultlist>
     http_version: 
-  recorded_at: Mon, 21 Aug 2017 14:07:36 GMT
+  recorded_at: Tue, 22 Aug 2017 12:31:30 GMT
 recorded_with: VCR 3.0.3

--- a/src/api/spec/features/webui/maintenance_workflow_spec.rb
+++ b/src/api/spec/features/webui/maintenance_workflow_spec.rb
@@ -27,7 +27,7 @@ RSpec.feature 'MaintenanceWorkflow', type: :feature, js: true do
   end
 
   scenario 'maintenance workflow' do
-    # Step1: The user branches a package
+    # Step 1: The user branches a package
     ####################################
     login(user)
 
@@ -67,7 +67,7 @@ RSpec.feature 'MaintenanceWorkflow', type: :feature, js: true do
     click_button('accept_request_button')
     expect(page).to have_css("#flash-messages", text: "Request #{BsRequest.last.number} accepted")
 
-    # Step 3: The maintenance coordinator edits the patchinfo file
+    # Step 4: The maintenance coordinator edits the patchinfo file
     ##############################################################
     # FIXME: Editing patchinfos should be it's own spec...
     visit(patchinfo_edit_patchinfo_path(package: 'patchinfo', project: 'MaintenanceProject:0'))
@@ -89,7 +89,7 @@ RSpec.feature 'MaintenanceWorkflow', type: :feature, js: true do
 
     logout
 
-    # Step 4: The user adds an additional fix to the incident
+    # Step 5: The user adds an additional fix to the incident
     #########################################################
     login(user)
     visit project_show_path(project: 'home:tom:branches:ProjectWithRepo:Update')
@@ -102,7 +102,7 @@ RSpec.feature 'MaintenanceWorkflow', type: :feature, js: true do
 
     logout
 
-    # Step 5: The maintenance coordinator adds the new submit to the running incident
+    # Step 6: The maintenance coordinator adds the new submit to the running incident
     #################################################################################
     login(maintenance_coord_user)
 
@@ -127,7 +127,7 @@ RSpec.feature 'MaintenanceWorkflow', type: :feature, js: true do
 
     click_button('accept_request_button')
 
-    # Step 6: The maintenance coordinator releases the request
+    # Step 7: The maintenance coordinator releases the request
     ##########################################################
     visit project_show_path('MaintenanceProject:0')
     click_link('Request to release')

--- a/src/api/spec/features/webui/maintenance_workflow_spec.rb
+++ b/src/api/spec/features/webui/maintenance_workflow_spec.rb
@@ -54,6 +54,16 @@ RSpec.feature 'MaintenanceWorkflow', type: :feature, js: true do
     click_button('Ok')
     expect(page).to have_css("#flash-messages", text: "Created maintenance incident request")
 
+    # Check that sending maintenance updates adds the source revision
+    new_bs_request_action = BsRequestAction.where(
+      type:                  "maintenance_incident",
+      target_project:        maintenance_project.name,
+      target_releaseproject: update_project.name,
+      source_project:        "#{user.home_project}:branches:#{update_project.name}",
+      source_package:        package.name
+    )
+    expect(new_bs_request_action.pluck(:source_rev).first).not_to be nil
+
     logout
 
     # Step 3: The maintenance coordinator accepts the request


### PR DESCRIPTION
This should fix #3546.

Add missing `set_add_revision` call when creating a new incident request.

Add a check in the maintenance workflow for the source revision.