### PR TITLE
Refactor Backend::Connection (move start test backend and logger, etc)

### DIFF
--- a/src/api/app/controllers/application_controller.rb
+++ b/src/api/app/controllers/application_controller.rb
@@ -116,7 +116,7 @@ class ApplicationController < ActionController::Base
 
   def volley_backend_path(path)
     logger.debug "[backend] VOLLEY: #{path}"
-    Backend::Connection.start_test_backend
+    Backend::Test.start
     backend_http = Net::HTTP.new(CONFIG['source_host'], CONFIG['source_port'])
     backend_http.read_timeout = 1000
 
@@ -361,7 +361,7 @@ class ApplicationController < ActionController::Base
   end
 
   def backend
-    Backend::Connection.start_test_backend if Rails.env.test?
+    Backend::Test.start if Rails.env.test?
     @backend ||= ActiveXML.backend
   end
 

--- a/src/api/app/controllers/application_controller.rb
+++ b/src/api/app/controllers/application_controller.rb
@@ -23,7 +23,6 @@ class ApplicationController < ActionController::Base
 
   # skip the filter for the user stuff
   before_action :extract_user
-  before_action :setup_backend
   before_action :shutup_rails
   before_action :validate_params
   before_action :require_login
@@ -102,12 +101,6 @@ class ApplicationController < ActionController::Base
     valid_project_name!(params[:project])
     # important because otherwise the filter chain is stopped
     true
-  end
-
-  def setup_backend
-    # initialize backend on every request
-    Backend::Connection.host = CONFIG['source_host']
-    Backend::Connection.port = CONFIG['source_port']
   end
 
   def add_api_version

--- a/src/api/app/controllers/application_controller.rb
+++ b/src/api/app/controllers/application_controller.rb
@@ -106,8 +106,8 @@ class ApplicationController < ActionController::Base
 
   def setup_backend
     # initialize backend on every request
-    Backend::Connection.source_host = CONFIG['source_host']
-    Backend::Connection.source_port = CONFIG['source_port']
+    Backend::Connection.host = CONFIG['source_host']
+    Backend::Connection.port = CONFIG['source_port']
   end
 
   def add_api_version

--- a/src/api/app/controllers/search_controller.rb
+++ b/src/api/app/controllers/search_controller.rb
@@ -72,7 +72,7 @@ class SearchController < ApplicationController
   end
 
   def owner
-    Backend::Connection.start_test_backend if Rails.env.test?
+    Backend::Test.start if Rails.env.test?
 
     obj = nil
     obj = params[:binary] unless params[:binary].blank?

--- a/src/api/app/controllers/status_controller.rb
+++ b/src/api/app/controllers/status_controller.rb
@@ -134,7 +134,7 @@ class StatusController < ApplicationController
 
   def bsrequest
     required_parameters :id
-    Backend::Connection.start_test_backend if Rails.env.test?
+    Backend::Test.start if Rails.env.test?
     @id = params[:id]
 
     @result = Hash.new

--- a/src/api/app/controllers/webui/search_controller.rb
+++ b/src/api/app/controllers/webui/search_controller.rb
@@ -8,7 +8,7 @@ class Webui::SearchController < Webui::WebuiController
   end
 
   def owner
-    Backend::Connection.start_test_backend if Rails.env.test?
+    Backend::Test.start if Rails.env.test?
 
     # If the search is too short, return
     return if @search_text.blank?

--- a/src/api/app/helpers/maintenance_helper.rb
+++ b/src/api/app/helpers/maintenance_helper.rb
@@ -303,7 +303,7 @@ module MaintenanceHelper
 
     query = { user: User.current_login }
     query[:comment] = "channel import function"
-    Backend::Connection.put_source(pkg.source_path('_channel', query), channel.to_s)
+    Backend::Connection.put(pkg.source_path('_channel', query), channel.to_s)
 
     pkg.sources_changed
     # enforce updated channel list in database:

--- a/src/api/app/jobs/issue_tracker_write_to_backend_job.rb
+++ b/src/api/app/jobs/issue_tracker_write_to_backend_job.rb
@@ -6,6 +6,6 @@ class IssueTrackerWriteToBackendJob < ApplicationJob
   def perform
     path = "/issue_trackers"
     logger.debug "Write issue tracker information to backend..."
-    Backend::Connection.put_source(path, IssueTracker.all.to_xml(IssueTracker::DEFAULT_RENDER_PARAMS))
+    Backend::Connection.put(path, IssueTracker.all.to_xml(IssueTracker::DEFAULT_RENDER_PARAMS))
   end
 end

--- a/src/api/app/mixins/has_attributes.rb
+++ b/src/api/app/mixins/has_attributes.rb
@@ -14,7 +14,7 @@ module HasAttributes
     path = attribute_url + "?meta=1&user=#{CGI.escape(login)}"
     path += "&comment=#{CGI.escape(comment)}" if comment
     begin
-      Backend::Connection.put_source(path, render_attribute_axml)
+      Backend::Connection.put(path, render_attribute_axml)
     rescue ActiveXML::Transport::Error => e
       raise AttributeSaveError, e.summary
     end

--- a/src/api/app/models/configuration.rb
+++ b/src/api/app/models/configuration.rb
@@ -117,7 +117,7 @@ class Configuration < ApplicationRecord
 
     path = '/configuration'
     logger.debug 'Writing configuration.xml to backend...'
-    Backend::Connection.put_source(path, render_xml)
+    Backend::Connection.put(path, render_xml)
   end
 end
 

--- a/src/api/app/models/package.rb
+++ b/src/api/app/models/package.rb
@@ -818,7 +818,7 @@ class Package < ApplicationRecord
       query[:comment] = @commit_opts[:comment] unless @commit_opts[:comment].blank?
       # the request number is the requestid parameter in the backend api
       query[:requestid] = @commit_opts[:request].number if @commit_opts[:request]
-      Backend::Connection.put_source(source_path('_meta', query), to_axml)
+      Backend::Connection.put(source_path('_meta', query), to_axml)
       logger.tagged('backend_sync') { logger.debug "Saved Package #{project.name}/#{name}" }
     elsif @commit_opts[:no_backend_write]
       logger.tagged('backend_sync') { logger.warn "Not saving Package #{project.name}/#{name}, backend_write is off " }

--- a/src/api/app/models/project.rb
+++ b/src/api/app/models/project.rb
@@ -620,7 +620,7 @@ class Project < ApplicationRecord
       query[:requestid] = @commit_opts[:request].number if @commit_opts[:request]
       query[:lowprio] = '1' if @commit_opts[:lowprio]
       logger.debug "Writing #{name} to backend"
-      Backend::Connection.put_source(source_path('_meta', query), to_axml)
+      Backend::Connection.put(source_path('_meta', query), to_axml)
       logger.tagged('backend_sync') { logger.debug "Saved Project #{name}" }
     elsif @commit_opts[:no_backend_write]
       logger.tagged('backend_sync') { logger.warn "Not saving Project #{name}, backend_write is off " }
@@ -1063,7 +1063,7 @@ class Project < ApplicationRecord
         prjconf = source_file('_config')
         unless prjconf =~ /^Type:/
           prjconf = "%if \"%_repository\" == \"images\"\nType: kiwi\nRepotype: none\nPatterntype: none\n%endif\n" << prjconf
-          Backend::Connection.put_source(source_path('_config'), prjconf)
+          Backend::Connection.put(source_path('_config'), prjconf)
         end
       else
         path_elements = local_project_meta.create_element("path")
@@ -1524,7 +1524,7 @@ class Project < ApplicationRecord
     prjconf = source_file('_config')
     return if prjconf =~ /^Type:/
     prjconf = "%if \"%_repository\" == \"images\"\nType: kiwi\nRepotype: none\nPatterntype: none\n%endif\n" << prjconf
-    Backend::Connection.put_source(source_path('_config'), prjconf)
+    Backend::Connection.put(source_path('_config'), prjconf)
   end
 
   def self.validate_remote_permissions(request_data)

--- a/src/api/app/models/repository.rb
+++ b/src/api/app/models/repository.rb
@@ -199,7 +199,7 @@ class Repository < ApplicationRecord
       prjconf = project.source_file('_config')
       unless prjconf =~ /^Type:/
         prjconf = "%if \"%_repository\" == \"images\"\nType: kiwi\nRepotype: none\nPatterntype: none\n%endif\n" << prjconf
-        Backend::Connection.put_source(project.source_path('_config'), prjconf)
+        Backend::Connection.put(project.source_path('_config'), prjconf)
       end
       return
     end

--- a/src/api/config/initializers/logging.rb
+++ b/src/api/config/initializers/logging.rb
@@ -6,9 +6,9 @@ module APIInstrumentation
 
     def append_info_to_payload(payload)
       super
-      payload[:backend_runtime] = Backend::Connection.runtime * 1000
+      payload[:backend_runtime] = Backend::Logger.runtime * 1000
       payload[:xml_runtime] = ActiveXML::Node.runtime * 1000
-      Backend::Connection.reset_runtime
+      Backend::Logger.reset_runtime
       ActiveXML::Node.reset_runtime
       runtime = { view: payload[:view_runtime], db: payload[:db_runtime], backend: payload[:backend_runtime], xml: payload[:xml_runtime] }
       response.headers["X-Opensuse-Runtimes"] = Yajl::Encoder.encode(runtime)

--- a/src/api/lib/backend/backend.rb
+++ b/src/api/lib/backend/backend.rb
@@ -1,3 +1,6 @@
+require 'benchmark'
+require 'api_exception'
+require_dependency 'logger'
 require_dependency 'connection'
 require_dependency 'file'
 require_dependency 'api'

--- a/src/api/lib/backend/backend.rb
+++ b/src/api/lib/backend/backend.rb
@@ -1,3 +1,4 @@
 require_dependency 'connection'
 require_dependency 'file'
 require_dependency 'api'
+require_dependency 'test'

--- a/src/api/lib/backend/connection.rb
+++ b/src/api/lib/backend/connection.rb
@@ -1,144 +1,133 @@
 # HTTP methods for connecting to the backend
 module Backend
   class Connection
-    @source_host = CONFIG['source_host']
-    @source_port = CONFIG['source_port']
-
-    def initialize
-      Rails.logger.debug "init backend"
+    cattr_accessor :host, instance_accessor: false do
+      CONFIG['source_host']
     end
 
-    class << self
-      attr_accessor :source_host, :source_port
+    cattr_accessor :port, instance_accessor: false do
+      CONFIG['source_port']
+    end
 
-      def host
-        @source_host
+    def self.get(path, in_headers = {})
+      Backend::Test.start
+      start_time = Time.now
+      Rails.logger.debug "[backend] GET: #{path}"
+      timeout = in_headers.delete('Timeout') || 1000
+      backend_request = Net::HTTP::Get.new(path, in_headers)
+
+      response = Net::HTTP.start(host, port) do |http|
+        http.read_timeout = timeout
+        if block_given?
+          http.request(backend_request) do |backend_response|
+            yield(backend_response)
+          end
+        else
+          http.request(backend_request)
+        end
       end
 
-      def port
-        @source_port
+      Backend::Logger.info("GET", host, port, path, response, start_time)
+      handle_response(response)
+    end
+
+    def self.put(path, data, in_headers = {})
+      put_or_post("PUT", path, data, in_headers)
+    end
+
+    def self.post(path, data = nil, in_headers = {})
+      in_headers = {
+          'Content-Type' => 'application/octet-stream'
+      }.merge in_headers
+      put_or_post("POST", path, data, in_headers)
+    end
+
+    def self.delete(path, in_headers = {})
+      Backend::Test.start
+      start_time = Time.now
+      Rails.logger.debug "[backend] DELETE: #{path}"
+      timeout = in_headers.delete('Timeout') || 1000
+      backend_request = Net::HTTP::Delete.new(path, in_headers)
+      response = Net::HTTP.start(host, port) do |http|
+        http.read_timeout = timeout
+        http.request(backend_request)
       end
+      Backend::Logger.info("DELETE", host, port, path, response, start_time)
+      handle_response(response)
+    end
 
-      def get(path, in_headers = {})
-        Backend::Test.start
-        start_time = Time.now
-        Rails.logger.debug "[backend] GET: #{path}"
-        timeout = in_headers.delete('Timeout') || 1000
-        backend_request = Net::HTTP::Get.new(path, in_headers)
+    def self.build_query_from_hash(hash, key_list = nil)
+      key_list ||= hash.keys
+      query = key_list.map do |key|
+        if hash.has_key?(key)
+          str = hash[key].to_s
+          str.toutf8
 
-        response = Net::HTTP.start(host, port) do |http|
-          http.read_timeout = timeout
-          if block_given?
-            http.request(backend_request) do |backend_response|
-              yield(backend_response)
-            end
+          if hash[key].nil?
+            # just a boolean argument ?
+            [hash[key]].flat_map { key }.join("&")
           else
-            http.request(backend_request)
+            [hash[key]].flat_map { "#{key}=#{CGI.escape(hash[key].to_s)}" }.join("&")
           end
         end
+      end
+      query.empty? ? "" : "?#{query.compact.join('&')}"
+    end
 
-        Backend::Logger.info("GET", host, port, path, response, start_time)
-        handle_response response
+    #### To define class methods as private use private_class_method
+    #### private
+
+    def self.put_or_post(method, path, data, in_headers)
+      Backend::Test.start
+      start_time = Time.now
+      Rails.logger.debug "[backend] #{method}: #{path}"
+      timeout = in_headers.delete('Timeout')
+      if method == "PUT"
+        backend_request = Net::HTTP::Put.new(path, in_headers)
+      else
+        backend_request = Net::HTTP::Post.new(path, in_headers)
+      end
+      if data.respond_to?('read')
+        backend_request.content_length = data.size
+        backend_request.body_stream = data
+      else
+        backend_request.body = data
       end
 
-      def put(path, data, in_headers = {})
-        put_or_post("PUT", path, data, in_headers)
-      end
-
-      def post(path, data = nil, in_headers = {})
-        in_headers = {
-            'Content-Type' => 'application/octet-stream'
-        }.merge in_headers
-        put_or_post("POST", path, data, in_headers)
-      end
-
-      def delete(path, in_headers = {})
-        Backend::Test.start
-        start_time = Time.now
-        Rails.logger.debug "[backend] DELETE: #{path}"
-        timeout = in_headers.delete('Timeout') || 1000
-        backend_request = Net::HTTP::Delete.new(path, in_headers)
-        response = Net::HTTP.start(host, port) do |http|
-          http.read_timeout = timeout
-          http.request backend_request
-        end
-        Backend::Logger.info("DELETE", host, port, path, response, start_time)
-        handle_response response
-        # do_delete(source_host, source_port, path)
-      end
-
-      alias_method :get_source, :get
-      alias_method :put_source, :put
-      alias_method :post_source, :post
-      alias_method :delete_source, :delete
-
-      def build_query_from_hash(hash, key_list = nil)
-        key_list ||= hash.keys
-        query = key_list.map do |key|
-          if hash.has_key?(key)
-            str = hash[key].to_s
-            str.toutf8
-
-            if hash[key].nil?
-              # just a boolean argument ?
-              [hash[key]].flat_map { key }.join("&")
-            else
-              [hash[key]].flat_map { "#{key}=#{CGI.escape(hash[key].to_s)}" }.join("&")
-            end
-          end
-        end
-        query.empty? ? "" : "?#{query.compact.join('&')}"
-      end
-
-      private
-
-      def put_or_post(method, path, data, in_headers)
-        Backend::Test.start
-        start_time = Time.now
-        Rails.logger.debug "[backend] #{method}: #{path}"
-        timeout = in_headers.delete('Timeout')
-        if method == "PUT"
-          backend_request = Net::HTTP::Put.new(path, in_headers)
+      response = Net::HTTP.start(host, port) do |http|
+        if method == "POST"
+          # POST requests can be quite complicate and take some time ..
+          http.read_timeout = timeout || 100000
         else
-          backend_request = Net::HTTP::Post.new(path, in_headers)
+          http.read_timeout = timeout || 1000
         end
-        if data.respond_to?('read')
-          backend_request.content_length = data.size
-          backend_request.body_stream = data
-        else
-          backend_request.body = data
+        begin
+          http.request(backend_request)
+        # rubocop:disable Lint/ShadowedException
+        rescue Errno::EPIPE, Errno::ECONNRESET, SocketError, Errno::EINTR, EOFError, IOError, Errno::ETIMEDOUT
+          raise Timeout::Error
         end
-        response = Net::HTTP.start(host, port) do |http|
-          if method == "POST"
-            # POST requests can be quite complicate and take some time ..
-            http.read_timeout = timeout || 100000
-          else
-            http.read_timeout = timeout || 1000
-          end
-          begin
-            http.request backend_request
-          # rubocop:disable Lint/ShadowedException
-          rescue Errno::EPIPE, Errno::ECONNRESET, SocketError, Errno::EINTR, EOFError, IOError, Errno::ETIMEDOUT
-            raise Timeout::Error
-          end
-          # rubocop:enable Lint/ShadowedException
-        end
-        Backend::Logger.info(method, host, port, path, response, start_time)
-        handle_response response
+        # rubocop:enable Lint/ShadowedException
       end
+      Backend::Logger.info(method, host, port, path, response, start_time)
+      handle_response(response)
+    end
 
-      def handle_response(response)
-        case response
-        when Net::HTTPSuccess, Net::HTTPRedirection, Net::HTTPOK
-          return response
-        when Net::HTTPNotFound
-          raise ActiveXML::Transport::NotFoundError, response.read_body.force_encoding("UTF-8")
-        else
-          message = response.read_body
-          message = response.to_s if message.blank?
-          raise ActiveXML::Transport::Error, message.force_encoding("UTF-8")
-        end
+    private_class_method :put_or_post
+
+    def self.handle_response(response)
+      case response
+      when Net::HTTPSuccess, Net::HTTPRedirection, Net::HTTPOK
+        return response
+      when Net::HTTPNotFound
+        raise ActiveXML::Transport::NotFoundError, response.read_body.force_encoding("UTF-8")
+      else
+        message = response.read_body
+        message = response.to_s if message.blank?
+        raise ActiveXML::Transport::Error, message.force_encoding("UTF-8")
       end
     end
+
+    private_class_method :handle_response
   end
 end

--- a/src/api/lib/backend/connection.rb
+++ b/src/api/lib/backend/connection.rb
@@ -144,13 +144,10 @@ module Backend
 
       private
 
-      def now
-        Time.now.strftime "%Y%m%dT%H%M%S"
-      end
-
       def write_backend_log(method, host, port, path, response)
         raise "write backend log without start time" unless @start_of_last
         timedelta = Time.now - @start_of_last
+        now = Time.now.strftime "%Y%m%dT%H%M%S"
         @start_of_last = nil
         @backend_logger.info "#{now} #{method} #{host}:#{port}#{path} #{response.code} #{timedelta}"
         @backend_time += timedelta

--- a/src/api/lib/backend/connection.rb
+++ b/src/api/lib/backend/connection.rb
@@ -90,16 +90,6 @@ module Backend
         query.empty? ? "" : "?#{query.compact.join('&')}"
       end
 
-      def without_global_write_through
-        before = CONFIG['global_write_through']
-        CONFIG['global_write_through'] = false
-
-        yield
-
-      ensure
-        CONFIG['global_write_through'] = before
-      end
-
       private
 
       def put_or_post(method, path, data, in_headers)

--- a/src/api/lib/backend/logger.rb
+++ b/src/api/lib/backend/logger.rb
@@ -1,0 +1,34 @@
+# API for accessing to the backend
+module Backend
+  class Logger
+    @backend_logger = ::Logger.new("#{Rails.root}/log/backend_access.log")
+    @backend_time = 0
+
+    def self.reset_runtime
+      @backend_time = 0
+    end
+
+    def self.runtime
+      @backend_time
+    end
+
+    def self.info(method, host, port, path, response, start_time)
+      time_delta = Time.now - start_time
+      now = Time.now.strftime "%Y%m%dT%H%M%S"
+      @backend_logger.info "#{now} #{method} #{host}:#{port}#{path} #{response.code} #{time_delta}"
+      @backend_time += time_delta
+      Rails.logger.debug "request took #{time_delta} #{@backend_time}"
+
+      return unless CONFIG['extended_backend_log']
+
+      data = response.body
+      if data.nil?
+        @backend_logger.info "(no data)"
+      elsif data.class == 'String' && data[0, 1] == "<"
+        @backend_logger.info data
+      else
+        @backend_logger.info "(non-XML data) #{data.class}"
+      end
+    end
+  end
+end

--- a/src/api/lib/backend/test.rb
+++ b/src/api/lib/backend/test.rb
@@ -10,12 +10,12 @@ module Backend
       return if ENV['BACKEND_STARTED']
       print "Starting test backend..."
       @backend = IO.popen("#{Rails.root}/script/start_test_backend")
-      logger.debug "Test backend started with pid: #{@backend.pid}"
+      Rails.logger.debug "Test backend started with pid: #{@backend.pid}"
       loop do
         line = @backend.gets
         raise 'Backend died' unless line
         break if line =~ /DONE NOW/
-        logger.debug line.strip
+        Rails.logger.debug line.strip
       end
       puts "done"
       CONFIG['global_write_through'] = true

--- a/src/api/lib/backend/test.rb
+++ b/src/api/lib/backend/test.rb
@@ -43,5 +43,14 @@ module Backend
     def self.do_not_start_test_backend
       @backend = :dont
     end
+
+    # Run the block code deactivating the global_write_through flag
+    def self.without_global_write_through
+      before = CONFIG['global_write_through']
+      CONFIG['global_write_through'] = false
+      yield
+    ensure
+      CONFIG['global_write_through'] = before
+    end
   end
 end

--- a/src/api/lib/backend/test.rb
+++ b/src/api/lib/backend/test.rb
@@ -1,0 +1,47 @@
+# API for accessing to the backend
+module Backend
+  class Test
+    @backend = nil
+
+    # Starts the test backend
+    def self.start(options = {})
+      return unless Rails.env.test?
+      return if @backend
+      return if ENV['BACKEND_STARTED']
+      print "Starting test backend..."
+      @backend = IO.popen("#{Rails.root}/script/start_test_backend")
+      logger.debug "Test backend started with pid: #{@backend.pid}"
+      loop do
+        line = @backend.gets
+        raise 'Backend died' unless line
+        break if line =~ /DONE NOW/
+        logger.debug line.strip
+      end
+      puts "done"
+      CONFIG['global_write_through'] = true
+      WebMock.disable_net_connect!(allow_localhost: true)
+      ENV['BACKEND_STARTED'] = '1'
+      at_exit do
+        puts "Killing test backend"
+        Process.kill "INT", @backend.pid
+        @backend = nil
+      end
+
+      # make sure it's actually tried to start
+      return unless options[:wait_for_scheduler]
+      Rails.logger.debug 'Wait for scheduler thread to finish start'
+      counter = 0
+      marker = Rails.root.join('tmp', 'scheduler.done')
+      while counter < 100
+        return if ::File.exist?(marker)
+        sleep 0.5
+        counter += 1
+      end
+    end
+
+    # Avoid starting the test backend again
+    def self.do_not_start_test_backend
+      @backend = :dont
+    end
+  end
+end

--- a/src/api/script/start_test_backend
+++ b/src/api/script/start_test_backend
@@ -23,7 +23,7 @@ backend_config = "#{backendtempdir}/config#{backend_dir_suffix}"
 backend_data   = "#{backendtempdir}/data#{backend_dir_suffix}"
 require File.expand_path(File.dirname(__FILE__)) + '/../test/test_helper'
 
-Backend::Connection.do_not_start_test_backend
+Backend::Test.do_not_start_test_backend
 
 ENV['PERL5LIB'] = "#{Rails.root}/../backend:#{Rails.root}/../backend/build"
 

--- a/src/api/spec/jobs/issue_tracker_write_to_backend_job_spec.rb
+++ b/src/api/spec/jobs/issue_tracker_write_to_backend_job_spec.rb
@@ -12,13 +12,13 @@ RSpec.describe IssueTrackerWriteToBackendJob, type: :job, vcr: true do
     let!(:issue) { create(:issue, name: '123', issue_tracker_id: issue_tracker.id, created_at: 4.days.ago) }
 
     before do
-      allow(Backend::Connection).to receive(:put_source)
+      allow(Backend::Connection).to receive(:put)
     end
 
     subject! { IssueTrackerWriteToBackendJob.new.perform }
 
     it 'writes to the backend' do
-      expect(Backend::Connection).to have_received(:put_source)
+      expect(Backend::Connection).to have_received(:put)
     end
   end
 end

--- a/src/api/spec/support/backend.rb
+++ b/src/api/spec/support/backend.rb
@@ -4,7 +4,7 @@ WebMock.disable_net_connect!(allow_localhost: true)
 RSpec.configure do |config|
   # build each factory and call #valid? on it
   config.before(:suite) do
-    # Backend::Connection.start_test_backend
+    # Backend::Test.start
   end
 end
 

--- a/src/api/test/functional/aaa_pre_consistency_test.rb
+++ b/src/api/test/functional/aaa_pre_consistency_test.rb
@@ -5,7 +5,7 @@ class AAAPreConsistency < ActionDispatch::IntegrationTest
 
   def test_resubmit_fixtures
     login_king
-    wait_for_scheduler_start
+    Backend::Test.start(wait_for_scheduler: true)
 
     ConsistencyCheckJob.new.perform
 

--- a/src/api/test/functional/architectures_controller_test.rb
+++ b/src/api/test/functional/architectures_controller_test.rb
@@ -2,7 +2,7 @@ require File.expand_path(File.dirname(__FILE__) + "/..") + "/test_helper"
 
 class ArchitecturesControllerTest < ActionDispatch::IntegrationTest
   def setup
-    wait_for_scheduler_start
+    Backend::Test.start(wait_for_scheduler: true)
     reset_auth
   end
 

--- a/src/api/test/functional/attributes_test.rb
+++ b/src/api/test/functional/attributes_test.rb
@@ -6,7 +6,7 @@ class AttributeControllerTest < ActionDispatch::IntegrationTest
   fixtures :all
 
   def setup
-    wait_for_scheduler_start
+    Backend::Test.start(wait_for_scheduler: true)
     reset_auth
   end
 

--- a/src/api/test/functional/binary_release_test.rb
+++ b/src/api/test/functional/binary_release_test.rb
@@ -6,7 +6,7 @@ class BinaryReleaseTest < ActionDispatch::IntegrationTest
   fixtures :all
 
   def setup
-    wait_for_scheduler_start
+    Backend::Test.start(wait_for_scheduler: true)
     reset_auth
   end
 

--- a/src/api/test/functional/branch_publish_flag_test.rb
+++ b/src/api/test/functional/branch_publish_flag_test.rb
@@ -6,7 +6,7 @@ class BranchPublishFlagTest < ActionDispatch::IntegrationTest
   fixtures :all
 
   def setup
-    wait_for_scheduler_start
+    Backend::Test.start(wait_for_scheduler: true)
     reset_auth
   end
 

--- a/src/api/test/functional/build_controller_test.rb
+++ b/src/api/test/functional/build_controller_test.rb
@@ -7,7 +7,7 @@ class BuildControllerTest < ActionDispatch::IntegrationTest
 
   def setup
     prepare_request_valid_user
-    wait_for_scheduler_start
+    Backend::Test.start(wait_for_scheduler: true)
   end
 
   def test_index

--- a/src/api/test/functional/channel_maintenance_test.rb
+++ b/src/api/test/functional/channel_maintenance_test.rb
@@ -8,7 +8,7 @@ class ChannelMaintenanceTests < ActionDispatch::IntegrationTest
   fixtures :all
 
   def setup
-    wait_for_scheduler_start
+    Backend::Test.start(wait_for_scheduler: true)
     stub_request(:post, 'http://bugzilla.novell.com/xmlrpc.cgi').to_timeout
   end
 

--- a/src/api/test/functional/group_request_test.rb
+++ b/src/api/test/functional/group_request_test.rb
@@ -13,7 +13,7 @@ class GroupRequestTest < ActionDispatch::IntegrationTest
 
   def setup
     Timecop.freeze(2010, 7, 12)
-    wait_for_scheduler_start
+    Backend::Test.start(wait_for_scheduler: true)
     reset_auth
   end
 

--- a/src/api/test/functional/interconnect_test.rb
+++ b/src/api/test/functional/interconnect_test.rb
@@ -5,7 +5,7 @@ class InterConnectTests < ActionDispatch::IntegrationTest
   fixtures :all
 
   def setup
-    wait_for_scheduler_start
+    Backend::Test.start(wait_for_scheduler: true)
     reset_auth
   end
 

--- a/src/api/test/functional/kgraft_maintenance_test.rb
+++ b/src/api/test/functional/kgraft_maintenance_test.rb
@@ -8,7 +8,7 @@ class MaintenanceTests < ActionDispatch::IntegrationTest
   fixtures :all
 
   def setup
-    wait_for_scheduler_start
+    Backend::Test.start(wait_for_scheduler: true)
     stub_request(:post, 'http://bugzilla.novell.com/xmlrpc.cgi').to_timeout
   end
 

--- a/src/api/test/functional/maintenance_test.rb
+++ b/src/api/test/functional/maintenance_test.rb
@@ -9,7 +9,7 @@ class MaintenanceTests < ActionDispatch::IntegrationTest
   fixtures :all
 
   def setup
-    wait_for_scheduler_start
+    Backend::Test.start(wait_for_scheduler: true)
     stub_request(:post, 'http://bugzilla.novell.com/xmlrpc.cgi').to_timeout
   end
 

--- a/src/api/test/functional/product_test.rb
+++ b/src/api/test/functional/product_test.rb
@@ -6,7 +6,7 @@ class ProductTests < ActionDispatch::IntegrationTest
   fixtures :all
 
   def setup
-    wait_for_scheduler_start
+    Backend::Test.start(wait_for_scheduler: true)
     reset_auth
   end
 

--- a/src/api/test/functional/public_controller_test.rb
+++ b/src/api/test/functional/public_controller_test.rb
@@ -5,7 +5,7 @@ class PublicControllerTest < ActionDispatch::IntegrationTest
   fixtures :all
 
   def setup
-    wait_for_scheduler_start
+    Backend::Test.start(wait_for_scheduler: true)
     reset_auth
   end
 

--- a/src/api/test/functional/published_controller_test.rb
+++ b/src/api/test/functional/published_controller_test.rb
@@ -4,7 +4,7 @@ class PublishedControllerTest < ActionDispatch::IntegrationTest
   fixtures :all
 
   def setup
-    wait_for_scheduler_start
+    Backend::Test.start(wait_for_scheduler: true)
     run_publisher
     reset_auth
   end

--- a/src/api/test/functional/read_permission_test.rb
+++ b/src/api/test/functional/read_permission_test.rb
@@ -6,7 +6,7 @@ class ReadPermissionTest < ActionDispatch::IntegrationTest
   fixtures :all
 
   def setup
-    wait_for_scheduler_start
+    Backend::Test.start(wait_for_scheduler: true)
     reset_auth
   end
 

--- a/src/api/test/functional/release_management_test.rb
+++ b/src/api/test/functional/release_management_test.rb
@@ -6,7 +6,7 @@ class ReleaseManagementTests < ActionDispatch::IntegrationTest
 
   def setup
     reset_auth
-    wait_for_scheduler_start
+    Backend::Test.start(wait_for_scheduler: true)
   end
 
   def test_move_entire_project

--- a/src/api/test/functional/request_controller_test.rb
+++ b/src/api/test/functional/request_controller_test.rb
@@ -8,7 +8,7 @@ class RequestControllerTest < ActionDispatch::IntegrationTest
   fixtures :all
 
   def setup
-    wait_for_scheduler_start
+    Backend::Test.start(wait_for_scheduler: true)
     reset_auth
   end
 
@@ -201,7 +201,7 @@ XML
   end
 
   def test_submit_request_of_new_package
-    wait_for_scheduler_start
+    Backend::Test.start(wait_for_scheduler: true)
 
     prepare_request_with_user 'Iggy', 'buildservice'
     post '/source/home:Iggy/NEW_PACKAGE', params: { cmd: :branch }
@@ -2658,7 +2658,7 @@ XML
     # now time travel and accept
     Timecop.freeze(2.days)
     # the backend has to be up before we can accept
-    Backend::Connection.start_test_backend
+    Backend::Test.start
     BsRequest.delayed_auto_accept
     # Run delayed jobs for newly created bs request.
     # NOTE: bs requests are now identified by their number attribute

--- a/src/api/test/functional/search_controller_test.rb
+++ b/src/api/test/functional/search_controller_test.rb
@@ -5,7 +5,7 @@ class SearchControllerTest < ActionDispatch::IntegrationTest
   fixtures :all
 
   def setup
-    wait_for_scheduler_start
+    Backend::Test.start(wait_for_scheduler: true)
     reset_auth
   end
 

--- a/src/api/test/functional/source_controller_test.rb
+++ b/src/api/test/functional/source_controller_test.rb
@@ -8,7 +8,7 @@ class SourceControllerTest < ActionDispatch::IntegrationTest
   fixtures :all
 
   def setup
-    wait_for_scheduler_start
+    Backend::Test.start(wait_for_scheduler: true)
     reset_auth
   end
 

--- a/src/api/test/functional/source_services_test.rb
+++ b/src/api/test/functional/source_services_test.rb
@@ -5,7 +5,7 @@ class SourceServicesTest < ActionDispatch::IntegrationTest
   fixtures :all
 
   def setup
-    wait_for_scheduler_start
+    Backend::Test.start(wait_for_scheduler: true)
     reset_auth
   end
 

--- a/src/api/test/functional/webui/commits_feed_test.rb
+++ b/src/api/test/functional/webui/commits_feed_test.rb
@@ -2,7 +2,7 @@ require_relative '../../test_helper'
 
 class Webui::CommitsFeedTest < Webui::IntegrationTest
   def setup
-    wait_for_scheduler_start
+    Backend::Test.start(wait_for_scheduler: true)
     reset_auth
   end
 

--- a/src/api/test/functional/webui/owner_search_test.rb
+++ b/src/api/test/functional/webui/owner_search_test.rb
@@ -9,7 +9,7 @@ class Webui::OwnerSearchTest < Webui::IntegrationTest
   def setup
     @attrib = Attrib.find_or_create_by!(attrib_type: AttribType.where(name: "OwnerRootProject").first,
                    project: Project.where(name: "home:Iggy").first)
-    wait_for_scheduler_start
+    Backend::Test.start(wait_for_scheduler: true)
   end
 
   def visit_owner_search

--- a/src/api/test/functional/webui/spider_test.rb
+++ b/src/api/test/functional/webui/spider_test.rb
@@ -140,7 +140,7 @@ class Webui::SpiderTest < Webui::IntegrationTest
   end
 
   def setup
-    wait_for_scheduler_start
+    Backend::Test.start(wait_for_scheduler: true)
   end
 
   def test_spider_anonymously

--- a/src/api/test/functional/zzz_post_consistency_test.rb
+++ b/src/api/test/functional/zzz_post_consistency_test.rb
@@ -5,13 +5,13 @@ class ZZZPostConsistency < ActionDispatch::IntegrationTest
   fixtures :all
 
   def setup
-    wait_for_scheduler_start
+    Backend::Test.start(wait_for_scheduler: true)
     reset_auth
   end
 
   def test_resubmit_fixtures
     login_king
-    wait_for_scheduler_start
+    Backend::Test.start(wait_for_scheduler: true)
 
     ConsistencyCheckJob.new.perform
 

--- a/src/api/test/integration/last_events_test.rb
+++ b/src/api/test/integration/last_events_test.rb
@@ -5,7 +5,7 @@ class LastEventsTest < ActionDispatch::IntegrationTest
     # ensure that the backend got started or we read, process and forget the indexed data.
     # of course only if our timing is bad :/
     super
-    wait_for_scheduler_start
+    Backend::Test.start(wait_for_scheduler: true)
   end
 
   test "update lastevents" do

--- a/src/api/test/models/event_test.rb
+++ b/src/api/test/models/event_test.rb
@@ -10,7 +10,7 @@ class EventTest < ActionDispatch::IntegrationTest
     # ensure that the backend got started or we read, process and forget the indexed data.
     # of course only if our timing is bad :/
     super
-    Backend::Connection.start_test_backend
+    Backend::Test.start
   end
 
   test 'find nothing' do

--- a/src/api/test/test_helper.rb
+++ b/src/api/test/test_helper.rb
@@ -272,7 +272,7 @@ module Webui
       Capybara.current_driver = :rack_test
 # crude work around - one day I will dig into why this is necessary
       Minitest::Spec.new('MINE') unless Minitest::Spec.current
-      Backend::Connection.start_test_backend
+      Backend::Test.start
       # Capybara.current_driver = Capybara.javascript_driver
       @starttime = Time.now
       WebMock.disable_net_connect!(allow_localhost: true)
@@ -448,10 +448,6 @@ module ActionDispatch
       raise ArgumentError, 'we need a :controller' unless hash.has_key?(:controller)
       raise ArgumentError, 'we need a :action' unless hash.has_key?(:action)
       super(hash)
-    end
-
-    def wait_for_scheduler_start
-      Backend::Connection.wait_for_scheduler_start
     end
 
     def login_king

--- a/src/api/test/unit/bs_request_test.rb
+++ b/src/api/test/unit/bs_request_test.rb
@@ -142,7 +142,7 @@ eos
   end
 
   def check_user_targets(user, *trues)
-    Backend::Connection.start_test_backend
+    Backend::Test.start
     User.current = User.find_by_login(user)
     BsRequest.all.each do |r|
       # puts r.render_xml

--- a/src/api/test/unit/event_mailer_test.rb
+++ b/src/api/test/unit/event_mailer_test.rb
@@ -25,7 +25,7 @@ class EventMailerTest < ActionMailer::TestCase
 
     # just one subsciption
     EventSubscription.create eventtype: 'Event::BuildFail', receiver_role: :maintainer, user: users(:Iggy)
-    Backend::Connection.wait_for_scheduler_start
+    Backend::Test.start(wait_for_scheduler: true)
 
     mail = EventMailer.event([users(:Iggy)], events(:build_failure_for_iggy))
     verify_email('build_fail', mail)
@@ -37,7 +37,7 @@ class EventMailerTest < ActionMailer::TestCase
 
     # just one subsciption
     EventSubscription.create eventtype: 'Event::BuildFail', receiver_role: :reader, user: users(:fred)
-    Backend::Connection.wait_for_scheduler_start
+    Backend::Test.start(wait_for_scheduler: true)
 
     mail = EventMailer.event([users(:fred)], events(:build_failure_for_reader))
     verify_email('build_fail_reader', mail)

--- a/src/api/test/unit/package_remove_test.rb
+++ b/src/api/test/unit/package_remove_test.rb
@@ -5,7 +5,7 @@ class PackageRemoveTest < ActiveSupport::TestCase
   fixtures :all
 
   def setup
-    Backend::Connection.start_test_backend
+    Backend::Test.start
   end
 
   def test_delete_on_backend

--- a/src/api/test/unit/package_test.rb
+++ b/src/api/test/unit/package_test.rb
@@ -194,7 +194,7 @@ class PackageTest < ActiveSupport::TestCase
   end
 
   def test_names_are_case_sensitive
-    Backend::Connection.without_global_write_through do
+    Backend::Test.without_global_write_through do
       np = @package.project.packages.new(name: 'testpack')
       xh = Xmlhash.parse(@package.to_axml)
       np.save!
@@ -244,7 +244,7 @@ class PackageTest < ActiveSupport::TestCase
   end
 
   def test_activity
-    Backend::Connection.without_global_write_through do
+    Backend::Test.without_global_write_through do
       Timecop.freeze(2010, 1, 1)
       project = projects(:home_Iggy)
       newyear = project.packages.create!(name: 'newyear')

--- a/src/api/test/unit/product_test.rb
+++ b/src/api/test/unit/product_test.rb
@@ -6,7 +6,7 @@ class ProjectTest < ActiveSupport::TestCase
 
   def test_indexed_fixture
     # check that fixtures got indexed
-    Backend::Connection.start_test_backend
+    Backend::Test.start
 
     assert_equal 1, Product.all.count
     p = Product.find_by_name("fixed")

--- a/src/api/test/unit/project_remove_test.rb
+++ b/src/api/test/unit/project_remove_test.rb
@@ -6,7 +6,7 @@ class ProjectRemoveTest < ActiveSupport::TestCase
   fixtures :all
 
   def setup
-    Backend::Connection.start_test_backend
+    Backend::Test.start
   end
 
   def test_cleanup_linking_projects

--- a/src/api/test/unit/project_test.rb
+++ b/src/api/test/unit/project_test.rb
@@ -1232,7 +1232,7 @@ END
   end
 
   def test_all_packages_from_projects_inherited_by_two_levels_and_two_links_in_project
-    Backend::Connection.without_global_write_through do
+    Backend::Test.without_global_write_through do
       parent2 = projects('BaseDistro2.0')
       parent1 = projects('BaseDistro2.0_LinkedUpdateProject')
       child = projects('Apache')
@@ -1257,7 +1257,7 @@ END
   end
 
   def test_linked_packages_does_not_return_packages_overwritten_by_the_actual_project
-    Backend::Connection.without_global_write_through do
+    Backend::Test.without_global_write_through do
       parent = projects('BaseDistro2.0')
       child = projects('BaseDistro2.0_LinkedUpdateProject')
 
@@ -1272,7 +1272,7 @@ END
   end
 
   def test_linked_packages_does_not_return_packages_overwritten_by_the_actual_project_inherited_from_two_levels
-    Backend::Connection.without_global_write_through do
+    Backend::Test.without_global_write_through do
       parent2 = projects('BaseDistro2.0')
       parent1 = projects('BaseDistro2.0_LinkedUpdateProject')
       child = projects('Apache')
@@ -1296,7 +1296,7 @@ END
   end
 
   def test_linked_packages_returns_overwritten_packages_from_the_project_with_the_highest_position
-    Backend::Connection.without_global_write_through do
+    Backend::Test.without_global_write_through do
       base_distro = projects('BaseDistro2.0')
       base_distro_update = projects('BaseDistro2.0_LinkedUpdateProject')
 

--- a/src/api/test/unit/project_test.rb
+++ b/src/api/test/unit/project_test.rb
@@ -685,7 +685,7 @@ END
   end
 
   def test_handle_project_links
-    Backend::Connection.start_test_backend
+    Backend::Test.start
     User.current = users( :Iggy )
 
     # project A

--- a/src/api/test/unit/worker_status_test.rb
+++ b/src/api/test/unit/worker_status_test.rb
@@ -2,7 +2,7 @@ require 'test_helper'
 
 class WorkerStatusTest < ActiveSupport::TestCase
   test "update cache" do
-    Backend::Connection.wait_for_scheduler_start
+    Backend::Test.start(wait_for_scheduler: true)
     WorkerStatus.new.update_workerstatus_cache
   end
 end


### PR DESCRIPTION
Deep refactoring of the Backend::Connection class, moved the start_test_backend method and the logger methods  to their own classes. Moved all the test related stuff to the Backend::Test class. Stop using meta-programming for defining this class.