### PR TITLE
[ci] Make git-cop allow merge commits

### DIFF
--- a/dist/git-cop_configuration.yml
+++ b/dist/git-cop_configuration.yml
@@ -56,6 +56,6 @@
     #   * 'Update' or 'Upgrade' (needed by depfu gem)
     #   * Revert (for revert commits)
     # In both cases they should be followed by the actual commit message subject
-    - \A(?!\s)(?:Revert|Update|Upgrade|\[api\]|\[backend\]|\[ci\]|\[dist\]|\[doc\]|\[frontend\]|\[webui\])+ \S+
+    - \A(?!\s)(?:Merge|Revert|Update|Upgrade|\[api\]|\[backend\]|\[ci\]|\[dist\]|\[doc\]|\[frontend\]|\[webui\])+ \S+
 :commit_subject_suffix:
   :enabled: false


### PR DESCRIPTION
In our linter test suite git-cop checks all commits that were newer than
master branch. When running travis in a fork with an older state of master,
git-cop will check all commits older than master.

That means merge commits were also checked and cause git-cop to fail.

This commit fixes it.