### PR TITLE
[frontend] Fix drop tags rolllback

### DIFF
--- a/src/api/db/migrate/20170821110918_remove_projects_tags.rb
+++ b/src/api/db/migrate/20170821110918_remove_projects_tags.rb
@@ -1,16 +1,8 @@
 class RemoveProjectsTags < ActiveRecord::Migration[5.1]
   def change
-    reversible do |dir|
-      dir.down do
-        add_foreign_key "db_projects_tags", "projects", column: "db_project_id", name: "db_projects_tags_ibfk_1"
-        add_foreign_key "db_projects_tags", "tags", name: "db_projects_tags_ibfk_2"
-      end
-    end
     drop_table "db_projects_tags", id: false, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
-      t.integer "db_project_id", null: false
-      t.integer "tag_id",        null: false
-      t.index ["db_project_id", "tag_id"], name: "projects_tags_all_index", unique: true, using: :btree
-      t.index ["tag_id"], name: "tag_id", using: :btree
+      t.references :db_project, type: :integer, index: { unique: true }, foreign_key: { to_table: :projects }
+      t.references :tag, index: { unique: true }, foreign_key: true
     end
   end
 end

--- a/src/api/db/migrate/20170821110941_remove_taggings.rb
+++ b/src/api/db/migrate/20170821110941_remove_taggings.rb
@@ -1,20 +1,11 @@
 class RemoveTaggings < ActiveRecord::Migration[5.1]
   def change
-    reversible do |dir|
-      dir.down do
-        add_foreign_key "taggings", "tags", name: "taggings_ibfk_1"
-        add_foreign_key "taggings", "users", name: "taggings_ibfk_2"
-      end
-    end
     drop_table "taggings", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin" do |t|
       t.integer "taggable_id"
       t.string  "taggable_type", collation: "utf8_general_ci"
-      t.integer "tag_id"
-      t.integer "user_id"
-      t.index ["taggable_id", "taggable_type", "tag_id", "user_id"], name: "taggings_taggable_id_index", unique: true, using: :btree
-      t.index ["taggable_type"], name: "index_taggings_on_taggable_type", using: :btree
-      t.index ["tag_id"], name: "tag_id", using: :btree
-      t.index ["user_id"], name: "user_id", using: :btree
+      t.references :tag, index: { unique: true }, foreign_key: true
+      t.references :user, index: { unique: true }, type: :integer, foreign_key: true
+      t.index ["taggable_id", "taggable_type"], name: "taggings_taggable_id_index", unique: true, using: :btree
     end
   end
 end


### PR DESCRIPTION
Tags where dropped in https://github.com/openSUSE/open-build-service/pull/3644

The problem is that from Rails 5.1 the default primary keys are BIGINT(20). That means that the references is trying to use BIGINT(20) while the old tables use INT(11). So we have to take this into account, otherwise the rollback will fail. :bowtie: 

We are supposing that the last 3 migrations are always run together. If not we can not know if the `tags` table is using INT(11) or BIGINT(20). But that a really rare case. Otherwise the alternatives are complicating the last migration so the `id` in `tags` is always INT(11) or removing the foreign keys in the two other migrations over this field. But this is unused code, so I think we shouldn't complicate it that much.

I also removed some duplicated indexes, as over some field we were creating an index and an unique index and I don't see any point on this. :confused: 