### PR TITLE
Fixed issue #3665

### DIFF
--- a/src/api/app/models/project.rb
+++ b/src/api/app/models/project.rb
@@ -31,6 +31,7 @@ class Project < ApplicationRecord
   end
 
   before_destroy :cleanup_before_destroy
+  after_destroy_commit :delete_on_backend
 
   after_save :discard_cache
   after_rollback :reset_cache
@@ -245,7 +246,6 @@ class Project < ApplicationRecord
 
     revoke_requests # Revoke all requests that have this project as source/target
     cleanup_packages # Deletes packages (only in DB)
-    delete_on_backend # Deletes the project in the backend
   end
   private :cleanup_before_destroy
 
@@ -650,6 +650,7 @@ class Project < ApplicationRecord
     self.commit_opts = {}
     true
   end
+  private :delete_on_backend
 
   def store(opts = {})
     self.commit_opts = opts if opts.present?

--- a/src/api/spec/cassettes/Project/_destroy/avoid_regressions_of_the_issue_3665/1_11_1_1.yml
+++ b/src/api/spec/cassettes/Project/_destroy/avoid_regressions_of_the_issue_3665/1_11_1_1.yml
@@ -1,0 +1,359 @@
+---
+http_interactions:
+- request:
+    method: put
+    uri: http://localhost:3200/source/openSUSE_41/_meta
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="openSUSE_41">
+          <title>Eyeless in Gaza</title>
+          <description/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '103'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="openSUSE_41">
+          <title>Eyeless in Gaza</title>
+          <description></description>
+        </project>
+    http_version: 
+  recorded_at: Thu, 24 Aug 2017 12:22:03 GMT
+- request:
+    method: put
+    uri: http://localhost:3200/source/openSUSE_41/_config
+    body:
+      encoding: UTF-8
+      string: Quod dolores quis. Voluptas quo minima consequatur beatae. Blanditiis
+        sed sunt ullam ut laudantium quia assumenda. Rerum ducimus a fugiat.
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '21'
+    body:
+      encoding: UTF-8
+      string: '<status code="ok" />
+
+'
+    http_version: 
+  recorded_at: Thu, 24 Aug 2017 12:22:03 GMT
+- request:
+    method: put
+    uri: http://localhost:3200/source/project_1/_meta
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="project_1">
+          <title>Quo Vadis</title>
+          <description/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '95'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="project_1">
+          <title>Quo Vadis</title>
+          <description></description>
+        </project>
+    http_version: 
+  recorded_at: Thu, 24 Aug 2017 12:22:04 GMT
+- request:
+    method: put
+    uri: http://localhost:3200/source/project_1/_config
+    body:
+      encoding: UTF-8
+      string: Incidunt ut sed. Nobis nostrum ipsa dolorem sed voluptas aperiam laboriosam.
+        Impedit sapiente error delectus.
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '21'
+    body:
+      encoding: UTF-8
+      string: '<status code="ok" />
+
+'
+    http_version: 
+  recorded_at: Thu, 24 Aug 2017 12:22:04 GMT
+- request:
+    method: put
+    uri: http://localhost:3200/source/deleted/_meta?user=Admin
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="deleted">
+          <title>Place holder for a deleted project instance</title>
+          <description/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '127'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="deleted">
+          <title>Place holder for a deleted project instance</title>
+          <description></description>
+        </project>
+    http_version: 
+  recorded_at: Thu, 24 Aug 2017 12:22:04 GMT
+- request:
+    method: put
+    uri: http://localhost:3200/source/openSUSE_41/_meta?user=Admin
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="openSUSE_41">
+          <title>Eyeless in Gaza</title>
+          <description/>
+          <repository name="images">
+            <path project="deleted" repository="deleted"/>
+          </repository>
+          <repository name="Apache"/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '231'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="openSUSE_41">
+          <title>Eyeless in Gaza</title>
+          <description></description>
+          <repository name="images">
+            <path project="deleted" repository="deleted" />
+          </repository>
+          <repository name="Apache" />
+        </project>
+    http_version: 
+  recorded_at: Thu, 24 Aug 2017 12:22:04 GMT
+- request:
+    method: put
+    uri: http://localhost:3200/source/openSUSE_41/_meta?lowprio=1&user=Admin
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="openSUSE_41">
+          <title>Eyeless in Gaza</title>
+          <description/>
+          <repository name="images">
+            <path project="deleted" repository="deleted"/>
+          </repository>
+          <repository name="Apache"/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '231'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="openSUSE_41">
+          <title>Eyeless in Gaza</title>
+          <description></description>
+          <repository name="images">
+            <path project="deleted" repository="deleted" />
+          </repository>
+          <repository name="Apache" />
+        </project>
+    http_version: 
+  recorded_at: Thu, 24 Aug 2017 12:22:05 GMT
+- request:
+    method: delete
+    uri: http://localhost:3200/source/openSUSE_41?comment&user=Admin
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '21'
+    body:
+      encoding: UTF-8
+      string: '<status code="ok" />
+
+'
+    http_version: 
+  recorded_at: Thu, 24 Aug 2017 12:22:05 GMT
+- request:
+    method: get
+    uri: http://localhost:3200/source/openSUSE_41/_project/_history?deleted=1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '402'
+    body:
+      encoding: UTF-8
+      string: |
+        <revisionlist>
+          <revision rev="1" vrev="">
+            <srcmd5>c44dad4723832a8cb23a733482115d83</srcmd5>
+            <version></version>
+            <time>1503577323</time>
+            <user>unknown</user>
+          </revision>
+          <revision rev="2" vrev="">
+            <srcmd5>c44dad4723832a8cb23a733482115d83</srcmd5>
+            <version></version>
+            <time>1503577325</time>
+            <user>Admin</user>
+            <comment>1</comment>
+          </revision>
+        </revisionlist>
+    http_version: 
+  recorded_at: Thu, 24 Aug 2017 12:22:05 GMT
+recorded_with: VCR 3.0.3

--- a/src/api/spec/models/project_spec.rb
+++ b/src/api/spec/models/project_spec.rb
@@ -453,4 +453,20 @@ RSpec.describe Project, vcr: true do
       end
     end
   end
+
+  describe "#destroy" do
+    context 'avoid regressions of the issue #3665' do
+      let(:admin_user) { create(:admin_user, login: 'Admin') }
+      let(:images_repository) { create(:repository, name: "images", project: project) }
+      let(:apache_repository) { create(:repository, name: "Apache", project: project) }
+      let!(:path_element) { create(:path_element, parent_id: images_repository.id, repository_id: apache_repository.id, position: 1)}
+
+      before do
+        login admin_user
+        project.destroy!
+      end
+
+      it { expect(Project.deleted?(project.name)).to be_truthy }
+    end
+  end
 end


### PR DESCRIPTION
Delete project on backend at the end of the callbacks cycle, first cleanup everything (linking repos, linking projects, request, etc), then remove the database record and then the backend entry.

This avoids to store the project in the backend after removing it in the cleanup of the Project model.

It fixes #3665.