### PR TITLE
[webui] Switch dialog buttons position in Kiwi

### DIFF
--- a/src/api/app/views/webui/kiwi/images/_package_fields.html.haml
+++ b/src/api/app/views/webui/kiwi/images/_package_fields.html.haml
@@ -32,5 +32,5 @@
           The name can not be empty!
 
       .dialog-buttons
-        = link_to('Continue', '#', title: 'Continue', class: 'close-dialog')
         = link_to('Cancel', '#', title: 'Cancel', class: 'revert-dialog')
+        = link_to('Continue', '#', title: 'Continue', class: 'close-dialog')

--- a/src/api/app/views/webui/kiwi/images/_repository_fields.html.haml
+++ b/src/api/app/views/webui/kiwi/images/_repository_fields.html.haml
@@ -43,5 +43,5 @@
           The source path can not be empty!
 
       .dialog-buttons
-        = link_to('Continue', '#', title: 'Continue', class: 'close-dialog')
         = link_to('Cancel', '#', title: 'Cancel', class: 'revert-dialog')
+        = link_to('Continue', '#', title: 'Continue', class: 'close-dialog')


### PR DESCRIPTION
We switch the buttons position for usability.

##### Before
![screenshot from 2017-08-21 17-48-24](https://user-images.githubusercontent.com/1212806/29665254-9001b3de-88d3-11e7-9159-8ee9bfcbd7b2.png)

##### After
![screenshot from 2017-08-24 13-47-11](https://user-images.githubusercontent.com/1212806/29665262-9354e9f2-88d3-11e7-9cfc-c93fb532f2ca.png)
