### PR TITLE
[webui] Change buttons position in dialogs

### DIFF
--- a/src/api/app/views/webui/main/_add_news_dialog.html.haml
+++ b/src/api/app/views/webui/main/_add_news_dialog.html.haml
@@ -11,6 +11,4 @@
           = label_tag(:severity, "Severity:")
           %br/
           = select_tag(:severity, options_for_select([['Information', 0], ['Green', 1], ['Yellow', 2], ['Red', 3]]))
-        .dialog-buttons
-          = submit_tag('Ok')
-          = remove_dialog_tag('Cancel')
+        = render partial: '/webui/shared/dialog_action_buttons'

--- a/src/api/app/views/webui/main/_delete_message_dialog.html.haml
+++ b/src/api/app/views/webui/main/_delete_message_dialog.html.haml
@@ -5,6 +5,4 @@
       %p Really delete this message?
     = form_tag({ controller: 'main', action: 'delete_message' }, method: 'post') do
       = hidden_field_tag(:message_id, params[:message_id])
-      .dialog-buttons
-        = submit_tag('Ok')
-        = remove_dialog_tag('Cancel')
+      = render partial: '/webui/shared/dialog_action_buttons'

--- a/src/api/app/views/webui/package/_branch_dialog.html.erb
+++ b/src/api/app/views/webui/package/_branch_dialog.html.erb
@@ -14,8 +14,8 @@
         </div>
 
         <div class="dialog-buttons">
-          <%= submit_tag('Ok') %>
           <%= link_to('Close', '#', title: 'Close', class: 'close-dialog', data: { target: '#package_branch_dialog' }) %>
+          <%= submit_tag('Ok') %>
         </div>
       <% end %>
     </div>

--- a/src/api/app/views/webui/package/_delete_dialog.html.erb
+++ b/src/api/app/views/webui/package/_delete_dialog.html.erb
@@ -17,20 +17,17 @@
       <% end %>
     </div>
       <%= form_tag({:controller => :package, :action => :remove}, :method => :post) do %>
-          <%= hidden_field_tag(:project, @project) %>
-          <%= hidden_field_tag(:package, @package) %>
-          <%- if @package.develpackages.any? %>
-            <p>
-              <label for="force">
-                Delete anyway?
-              </label>
-              <input id="force" name="force" type="checkbox" />
-            </p>
-          <% end %>
-          <div class="dialog-buttons">
-            <%= submit_tag('Ok') %>
-            <%= remove_dialog_tag('Cancel') %>
-          </div>
+        <%= hidden_field_tag(:project, @project) %>
+        <%= hidden_field_tag(:package, @package) %>
+        <%- if @package.develpackages.any? %>
+          <p>
+            <label for="force">
+              Delete anyway?
+            </label>
+            <input id="force" name="force" type="checkbox" />
+          </p>
+        <% end %>
+        <%= render partial: '/webui/shared/dialog_action_buttons' %>
       <% end %>
   </div>
 </div>

--- a/src/api/app/views/webui/package/_submit_request_dialog.html.haml
+++ b/src/api/app/views/webui/package/_submit_request_dialog.html.haml
@@ -51,8 +51,6 @@
         %b#devel-project-name
         instead.
 
-      .dialog-buttons
-        = submit_tag('Ok')
-        = remove_dialog_tag('Cancel')
+      = render partial: '/webui/shared/dialog_action_buttons'
 
 = javascript_tag 'setup_request_dialog();'

--- a/src/api/app/views/webui/patchinfo/_delete_dialog.html.haml
+++ b/src/api/app/views/webui/patchinfo/_delete_dialog.html.haml
@@ -8,6 +8,4 @@
         %div
           = hidden_field_tag(:project, @project)
           = hidden_field_tag(:package, @package)
-          .dialog-buttons
-            = submit_tag('Ok')
-            = remove_dialog_tag('Cancel')
+          = render partial: '/webui/shared/dialog_action_buttons'

--- a/src/api/app/views/webui/project/_add_maintained_project_dialog.html.erb
+++ b/src/api/app/views/webui/project/_add_maintained_project_dialog.html.erb
@@ -8,17 +8,14 @@
       <h2 class="box-header">Add Project to Maintenance</h2>
       <div class="dialog-content">
         <p>Do you want to maintain <%= project_or_package_link project: @project.name %>?</p>
-  
+
         <%= form_tag({:controller => 'project', :action => 'add_maintained_project'}) do %>
           <%= hidden_field_tag(:project, @project) %>
           <p>
             <%= label_tag(:maintained_project, 'Project to maintain:') %><br/>
             <%= text_field_tag(:maintained_project, '', :size => 40) %>
           </p>
-          <div class="dialog-buttons">
-            <%= submit_tag('Ok') %>
-            <%= remove_dialog_tag('Cancel') %>
-          </div>
+          <%= render partial: '/webui/shared/dialog_action_buttons' %>
         <% end %>
       </div>
     </div>

--- a/src/api/app/views/webui/project/_delete_dialog.html.erb
+++ b/src/api/app/views/webui/project/_delete_dialog.html.erb
@@ -3,7 +3,7 @@
       <h2 class="box-header">Delete Confirmation</h2>
       <div class="dialog-content">
         <p>Do you really want to delete <%= project_or_package_link project: @project.name %>?</p>
-  
+
         <%= form_tag({:controller => 'project', :action => 'destroy'}, :method => 'delete') do %>
           <%= hidden_field_tag(:project, @project) %>
           <% if @linking_projects && @linking_projects.length > 0 %>
@@ -14,11 +14,8 @@
               <% end %>
             </ul>
           <% end %>
-  
-          <div class="dialog-buttons">
-            <%= submit_tag('Ok') %>
-            <%= remove_dialog_tag('Cancel') %>
-          </div>
+
+          <%= render partial: '/webui/shared/dialog_action_buttons' %>
         <% end %>
       </div>
     </div>

--- a/src/api/app/views/webui/project/_incident_request_dialog.html.erb
+++ b/src/api/app/views/webui/project/_incident_request_dialog.html.erb
@@ -8,7 +8,7 @@
           <p>
             <%= label_tag(:sourceproject, 'Project submitted as Update:') %><br/>
             <%= text_field_tag(:sourceproject, format_projectname(@project.name, User.current.login), :size => 40, :disabled => true) %><br/>
-  
+
             <%= label_tag(:sourceproject, 'Release Targets:') %><br/>
             <% @releasetargets.each do |rt| %>
               <%= text_field_tag(:releasetarget, rt, :size=> 40, :disabled => true) %>
@@ -17,10 +17,7 @@
             <%= label_tag(:description, 'Description:') %><br/>
             <%= text_area_tag(:description, '', :size => '40x3') %>
           </p>
-          <div class="dialog-buttons">
-            <%= submit_tag('Ok') %>
-            <%= remove_dialog_tag('Cancel') %>
-          </div>
+          <%= render partial: '/webui/shared/dialog_action_buttons' %>
         <% end %>
       </div>
     </div>

--- a/src/api/app/views/webui/project/_release_request_dialog.html.erb
+++ b/src/api/app/views/webui/project/_release_request_dialog.html.erb
@@ -17,10 +17,7 @@
               <%= check_box_tag(:supersede) %> Supersede pending requests<br/>
             </span>
           </p>
-          <div class="dialog-buttons">
-            <%= submit_tag('Ok') %>
-            <%= remove_dialog_tag('Cancel') %>
-          </div>
+          <%= render partial: '/webui/shared/dialog_action_buttons' %>
         <% end %>
       </div>
     </div>

--- a/src/api/app/views/webui/project/_remove_target_request_dialog.html.erb
+++ b/src/api/app/views/webui/project/_remove_target_request_dialog.html.erb
@@ -3,7 +3,7 @@
       <h2 class="box-header">Create Repository Delete Request</h2>
       <div class="dialog-content">
         <p>Do you really want to request the deletion of repository <i><%= params[:repository] %></i>?</p>
-  
+
         <%= form_tag({:controller => 'project', :action => 'remove_target_request'}, :method => 'post') do %>
           <%= hidden_field_tag(:project, params[:project]) %>
           <%= hidden_field_tag(:repository, params[:repository]) %>
@@ -11,10 +11,7 @@
             <%= label_tag(:description, 'Description:') %><br/>
             <%= text_area_tag(:description, '', :size => '40x3') %>
           </p>
-          <div class="dialog-buttons">
-            <%= submit_tag('Ok') %>
-            <%= remove_dialog_tag('Cancel') %>
-          </div>
+          <%= render partial: '/webui/shared/dialog_action_buttons' %>
         <% end %>
       </div>
     </div>

--- a/src/api/app/views/webui/project/_unlock_dialog.html.erb
+++ b/src/api/app/views/webui/project/_unlock_dialog.html.erb
@@ -3,17 +3,14 @@
       <h2 class="box-header">Unlock Confirmation</h2>
       <div class="dialog-content">
         <p>Do you really want to unlock <%= project_or_package_link project: @project.name %>?</p>
-  
+
         <%= form_tag({:controller => 'project', project: @project, :action => 'unlock'}, :method => 'post') do %>
           <%= hidden_field_tag(:project, @project) %>
           <p>
             <%= label_tag(:comment, 'Comment:') %><br/>
             <%= text_area_tag(:comment, '', :size => '40x3') %><br/>
           </p>
-          <div class="dialog-buttons">
-            <%= submit_tag('Ok') %>
-            <%= remove_dialog_tag('Cancel') %>
-          </div>
+          <%= render partial: '/webui/shared/dialog_action_buttons' %>
         <% end %>
       </div>
     </div>

--- a/src/api/app/views/webui/projects/public_key/_key_dialog.html.haml
+++ b/src/api/app/views/webui/projects/public_key/_key_dialog.html.haml
@@ -32,7 +32,7 @@
         %pre
           = @project.key_info.fingerprint
       .dialog-buttons
+        = remove_dialog_tag('Close')
         = link_to('GPG Key', project_public_key_path(project_name: @project.name), class: 'close-dialog')
         - if @project.key_info.ssl_certificate.present?
           = link_to('SSL Cert.', project_ssl_certificate_path(project_name: @project.name), class: 'close-dialog')
-        = remove_dialog_tag('Close')

--- a/src/api/app/views/webui/request/_add_reviewer_dialog.html.erb
+++ b/src/api/app/views/webui/request/_add_reviewer_dialog.html.erb
@@ -3,37 +3,34 @@
     <h2 class="box-header">Add Reviewer</h2>
     <div class="dialog-content">
       <p>Add a reviewer to request <%= @request_number %></p>
-  
+
       <%= form_tag(:action => "add_reviewer") do %>
-          <%= hidden_field_tag(:number, @request_number) %>
-          <p>
-            <%= label_tag(:review_type, "Type:") %><br/>
-            <%= select_tag(:review_type, options_for_select([%w(User user), %w(Group group), %w(Project project), %w(Package package)])) %>
-            <br/>
-            <span id="review_user_span">
-              <%= label_tag(:review_user, "User:") %><br/>
-              <%= text_field_tag(:review_user) %><br/>
-            </span>
-            <span id="review_group_span" class="hidden">
-              <%= label_tag(:review_group, "Group:") %><br/>
-              <%= text_field_tag(:review_group) %><br/>
-            </span>
-            <span id="review_project_span" class="hidden">
-              <%= label_tag(:review_project, "Project:") %><br/>
-              <%= text_field_tag(:review_project) %><br/>
-            </span>
-            <span id="review_package_span" class="hidden">
-              <%= label_tag(:review_package, "Package:") %><br/>
-              <%= text_field_tag(:review_package) %><br/>
-            </span>
-            <%= label_tag(:review_comment, "Comment for reviewer:") %><br/>
-            <%= text_area_tag('review_comment', nil, :size => '80x3') %>
-          </p>
-  
-          <div class="dialog-buttons">
-            <%= submit_tag("Ok") %>
-            <%= remove_dialog_tag('Cancel') %>
-          </div>
+        <%= hidden_field_tag(:number, @request_number) %>
+        <p>
+          <%= label_tag(:review_type, "Type:") %><br/>
+          <%= select_tag(:review_type, options_for_select([%w(User user), %w(Group group), %w(Project project), %w(Package package)])) %>
+          <br/>
+          <span id="review_user_span">
+            <%= label_tag(:review_user, "User:") %><br/>
+            <%= text_field_tag(:review_user) %><br/>
+          </span>
+          <span id="review_group_span" class="hidden">
+            <%= label_tag(:review_group, "Group:") %><br/>
+            <%= text_field_tag(:review_group) %><br/>
+          </span>
+          <span id="review_project_span" class="hidden">
+            <%= label_tag(:review_project, "Project:") %><br/>
+            <%= text_field_tag(:review_project) %><br/>
+          </span>
+          <span id="review_package_span" class="hidden">
+            <%= label_tag(:review_package, "Package:") %><br/>
+            <%= text_field_tag(:review_package) %><br/>
+          </span>
+          <%= label_tag(:review_comment, "Comment for reviewer:") %><br/>
+          <%= text_area_tag('review_comment', nil, :size => '80x3') %>
+        </p>
+
+        <%= render partial: '/webui/shared/dialog_action_buttons' %>
       <% end %>
     </div>
   </div>

--- a/src/api/app/views/webui/request/_add_role_request_dialog.html.erb
+++ b/src/api/app/views/webui/request/_add_role_request_dialog.html.erb
@@ -3,7 +3,7 @@
       <h2 class="box-header">Add Role Request</h2>
       <div class="dialog-content">
         <p>Do you want to request a role addition to <%= project_or_package_link project: @project, package: @package %>?</p>
-  
+
         <%= form_tag(:action => 'add_role_request') do %>
           <%= hidden_field_tag(:project, @project) %>
           <%= hidden_field_tag(:package, @package) if defined? @package %>
@@ -19,10 +19,7 @@
             <%= label_tag(:description, 'Description:') %><br/>
             <%= text_area_tag(:description, '', :size => '40x3') %>
           </p>
-          <div class="dialog-buttons">
-            <%= submit_tag('Ok') %>
-            <%= remove_dialog_tag('Cancel') %>
-          </div>
+          <%= render partial: '/webui/shared/dialog_action_buttons' %>
         <% end %>
       </div>
     </div>

--- a/src/api/app/views/webui/request/_change_devel_request_dialog.html.erb
+++ b/src/api/app/views/webui/request/_change_devel_request_dialog.html.erb
@@ -22,10 +22,7 @@
             <%= label_tag(:description, 'Description:') %><br/>
             <%= text_area_tag(:description, '', :size => '40x3') %>
           </p>
-          <div class="dialog-buttons">
-            <%= submit_tag('Ok') %>
-            <%= remove_dialog_tag('Cancel') %>
-          </div>
+          <%= render partial: '/webui/shared/dialog_action_buttons' %>
         <% end %>
       </div>
     </div>

--- a/src/api/app/views/webui/request/_delete_request_dialog.html.erb
+++ b/src/api/app/views/webui/request/_delete_request_dialog.html.erb
@@ -3,7 +3,7 @@
       <h2 class="box-header">Create Delete Request</h2>
       <div class="dialog-content">
         <p>Do you really want to request the deletion of <%= project_or_package_link project: @project, package: @package %>?</p>
-  
+
         <%= form_tag(:action => 'delete_request', :method => 'post') do %>
           <%= hidden_field_tag(:project, @project) %>
           <%= hidden_field_tag(:package, @package) if defined? @package %>
@@ -15,10 +15,7 @@
             <%= label_tag(:description, 'Please explain why:') %><br/>
             <%= text_area_tag(:description, '', :size => '40x3') %>
           </p>
-          <div class="dialog-buttons">
-            <%= submit_tag('Ok') %>
-            <%= remove_dialog_tag('Cancel') %>
-          </div>
+          <%= render partial: '/webui/shared/dialog_action_buttons' %>
         <% end %>
       </div>
     </div>

--- a/src/api/app/views/webui/request/_package_maintainers_dialog.html.erb
+++ b/src/api/app/views/webui/request/_package_maintainers_dialog.html.erb
@@ -13,7 +13,7 @@
           <% end %>
           </tbody>
          </table>
-        
+
         <div class="dialog-buttons">
           <%= link_to('close', '#', title: 'Close', class: 'close-dialog', data: { target: '#maintainers_dialog' }) %>
         </div>

--- a/src/api/app/views/webui/request/_set_bugowner_request_dialog.html.erb
+++ b/src/api/app/views/webui/request/_set_bugowner_request_dialog.html.erb
@@ -31,10 +31,7 @@
             <%= label_tag(:description, "Description:") %><br/>
             <%= text_area_tag(:description, "", :size => "40x3") %>
           </p>
-          <div class="dialog-buttons">
-            <%= submit_tag("Ok") %>
-            <%= remove_dialog_tag('Cancel') %>
-          </div>
+          <%= render partial: '/webui/shared/dialog_action_buttons' %>
         <% end %>
       </div>
     </div>

--- a/src/api/app/views/webui/request/_set_incident_dialog.html.erb
+++ b/src/api/app/views/webui/request/_set_incident_dialog.html.erb
@@ -11,10 +11,7 @@
               <%= label_tag(:incident_project, 'Incident:') %><br/>
               <%= text_field_tag(:incident_project, '', :size => 40) %><br/>
             </p>
-            <div class="dialog-buttons">
-              <%= submit_tag('Ok') %>
-              <%= remove_dialog_tag('Cancel') %>
-            </div>
+            <%= render partial: '/webui/shared/dialog_action_buttons' %>
           <% end %>
         </div>
       </div>

--- a/src/api/app/views/webui/shared/_dialog_action_buttons.html.haml
+++ b/src/api/app/views/webui/shared/_dialog_action_buttons.html.haml
@@ -1,0 +1,3 @@
+.dialog-buttons
+  = remove_dialog_tag('Cancel')
+  = submit_tag('Ok')

--- a/src/api/app/views/webui/user/_password_dialog.html.haml
+++ b/src/api/app/views/webui/user/_password_dialog.html.haml
@@ -16,6 +16,4 @@
           %br/
           = text_field_tag :repeat_password, nil, type: 'password', autocomplete: 'off', required: 'true'
         %input#user{ name: "user", type: "hidden", value: "#{User.current.login}" }/
-        .dialog-buttons
-          = submit_tag("Ok")
-          = remove_dialog_tag('Cancel')
+        = render partial: '/webui/shared/dialog_action_buttons'

--- a/src/api/app/views/webui/user/_save_dialog.html.haml
+++ b/src/api/app/views/webui/user/_save_dialog.html.haml
@@ -11,6 +11,4 @@
         %p
           = f.label(:email, "e-Mail:")
           = f.text_field(:email, required: true, email: true)
-        .dialog-buttons
-          = submit_tag("Ok")
-          = remove_dialog_tag('Cancel')
+        = render partial: '/webui/shared/dialog_action_buttons'


### PR DESCRIPTION
We changed the position of the buttons for usability.

#### Before
![screenshot from 2017-08-24 14-24-35](https://user-images.githubusercontent.com/1212806/29666327-1f8a401c-88d8-11e7-80c0-072d7c1704ff.png)


#### After
![screenshot from 2017-08-24 14-22-58](https://user-images.githubusercontent.com/1212806/29666280-ec617da4-88d7-11e7-87b4-0d3e2f0ffb7a.png)

These changes come from the following comment in PR [#3651](https://github.com/openSUSE/open-build-service/pull/3651#pullrequestreview-57682896) from @Ana06 and by this article http://uxmovement.com/buttons/why-ok-buttons-in-dialog-boxes-work-best-on-the-right