### PR TITLE
[ci] Rake task to run git-cop locally

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -163,7 +163,13 @@ You can access the frontend at [localhost:3000](http://localhost:3000). Whatever
     vagrant exec make -C src/backend test
     ```
 
-12. Explore the development environment:
+12. Check your commits:
+
+    ```
+    vagrant exec rake git_cop
+    ```
+
+13. Explore the development environment:
 
     ```
     vagrant ssh

--- a/src/api/lib/tasks/git_cop.rake
+++ b/src/api/lib/tasks/git_cop.rake
@@ -1,0 +1,8 @@
+desc 'Run Git-cop locally'
+task :git_cop do
+  puts "\nCopying configuration file into ~/.config/git-cop/configuration.yml"
+  sh "mkdir -p ~/.config/git-cop"
+  sh "cp ../../dist/git-cop_configuration.yml ~/.config/git-cop/configuration.yml"
+  puts
+  sh "bundle exec git-cop --police"
+end


### PR DESCRIPTION
Create a rake task to run git-cop and document it. :bowtie: 

![image](https://user-images.githubusercontent.com/16052290/29810589-afc6b7f2-8ca0-11e7-80e3-0b4c913f7db8.png)
