### PR TITLE
[api] Hide sourcediffs in event mails in case of remote projects

### DIFF
--- a/src/api/app/models/event/request.rb
+++ b/src/api/app/models/event/request.rb
@@ -71,6 +71,11 @@ class Event::Request < ::Event::Base
   end
 
   def payload_with_diff
+    source_projects = payload['actions'].map { |action| action[:source_project] }.uniq.compact
+    source_projects.each do |source_project|
+      return payload if Project.unscoped.is_remote_project?(source_project, true)
+    end
+
     ret = payload
     payload['actions'].each do |a|
       diff = calculate_diff(a)


### PR DESCRIPTION
Fixes #3587

When generating a sourcediff OBS checks the source access. In case of
remote projects this access check includes checking the write access of
the logged in user. Since event mails are sent by delayed jobs, there is no
user available to run the source access check against, which causes the
delayed job to crash.

A proper would require a bigger refactoring of the code that is involved
here. For the time being we work around the issue by skipping the source
diff generation for event emails that involve remote projects.