### PR TITLE
[webui] Handle ActiveXML::Transport::Error for rpmlint_log action

### DIFF
--- a/src/api/app/controllers/webui/package_controller.rb
+++ b/src/api/app/controllers/webui/package_controller.rb
@@ -964,7 +964,7 @@ class Webui::PackageController < Webui::WebuiController
       @log = get_rpmlint_log(params[:project], params[:package], params[:repository], params[:architecture])
       @log.encode!(xml: :text)
       render partial: 'rpmlint_log'
-    rescue ActiveXML::Transport::NotFoundError
+    rescue ActiveXML::Transport::NotFoundError, ActiveXML::Transport::Error
       render plain: 'No rpmlint log'
     end
   end


### PR DESCRIPTION
It's possible that this exception gets raised.

This closes #3699