### PR TITLE
[dist] Remove warning from options.yml.example

### DIFF
--- a/src/api/config/options.yml.example
+++ b/src/api/config/options.yml.example
@@ -61,9 +61,7 @@ proxy_auth_test_email: coolguy@example.com
 # LDAP options
 ##################
 
-#### WARNING: LDAP mode is not official supported by OBS!
 ldap_mode: :off
-#### WARNING: LDAP mode is not official supported by OBS!
 
 # LDAP Servers separated by ':'.
 # OVERRIDE with your company's ldap servers. Servers are picked randomly for


### PR DESCRIPTION
We now support LDAP mode. So we can get rid of the warning.