### PR TITLE
[ci] Shared example was defined twice

### DIFF
--- a/src/api/spec/models/bs_request_spec.rb
+++ b/src/api/spec/models/bs_request_spec.rb
@@ -90,7 +90,7 @@ RSpec.describe BsRequest do
   end
 
   describe '#update_cache' do
-    RSpec.shared_examples 'after_commit callback' do
+    RSpec.shared_examples 'bs_request after_commit callback' do
       it 'touches the user' do
         Timecop.travel(1.minute)
         cache_key = user.cache_key
@@ -105,7 +105,7 @@ RSpec.describe BsRequest do
       let!(:request) { create(:bs_request, creator: user.login) }
       let(:user) { create(:admin_user) }
 
-      include_examples 'after_commit callback'
+      include_examples 'bs_request after_commit callback'
     end
 
     context 'direct maintainer of a target_project' do
@@ -123,7 +123,7 @@ RSpec.describe BsRequest do
       let!(:relationship_project_user) { create(:relationship_project_user, project: target_project) }
       let(:user) { relationship_project_user.user }
 
-      include_examples 'after_commit callback'
+      include_examples 'bs_request after_commit callback'
     end
 
     context 'group maintainer of a target_project' do
@@ -143,7 +143,7 @@ RSpec.describe BsRequest do
       let!(:groups_user) { create(:groups_user, group: group) }
       let(:user) { groups_user.user }
 
-      include_examples 'after_commit callback'
+      include_examples 'bs_request after_commit callback'
     end
 
     context 'direct maintainer of a target_package' do
@@ -163,7 +163,7 @@ RSpec.describe BsRequest do
       let!(:relationship_package_user) { create(:relationship_package_user, package: target_package) }
       let(:user) { relationship_package_user.user }
 
-      include_examples 'after_commit callback'
+      include_examples 'bs_request after_commit callback'
     end
 
     context 'group maintainer of a target_package' do
@@ -185,7 +185,7 @@ RSpec.describe BsRequest do
       let!(:groups_user) { create(:groups_user, group: group) }
       let(:user) { groups_user.user }
 
-      include_examples 'after_commit callback'
+      include_examples 'bs_request after_commit callback'
     end
   end
 

--- a/src/api/spec/models/review_spec.rb
+++ b/src/api/spec/models/review_spec.rb
@@ -318,7 +318,7 @@ RSpec.describe Review do
   end
 
   describe '#update_caches' do
-    RSpec.shared_examples 'after_commit callback' do
+    RSpec.shared_examples 'review after_commit callback' do
       it 'touches the user' do
         Timecop.travel(1.minute)
         cache_key = user.cache_key
@@ -333,7 +333,7 @@ RSpec.describe Review do
       let!(:review) { create(:user_review) }
       let(:user) { review.user }
 
-      include_examples 'after_commit callback'
+      include_examples 'review after_commit callback'
     end
 
     context 'by_group' do
@@ -342,7 +342,7 @@ RSpec.describe Review do
       let(:user) { groups_user.user }
       let!(:review) { create(:review, by_group: group) }
 
-      include_examples 'after_commit callback'
+      include_examples 'review after_commit callback'
     end
 
     context 'by_package with a direct relationship' do
@@ -351,7 +351,7 @@ RSpec.describe Review do
       let(:user) { relationship_package_user.user }
       let!(:review) { create(:review, by_package: package, by_project: package.project) }
 
-      include_examples 'after_commit callback'
+      include_examples 'review after_commit callback'
     end
 
     context 'by_package with a group relationship' do
@@ -362,7 +362,7 @@ RSpec.describe Review do
       let!(:user) { groups_user.user }
       let!(:review) { create(:review, by_package: package, by_project: package.project) }
 
-      include_examples 'after_commit callback'
+      include_examples 'review after_commit callback'
     end
 
     context 'by_project with a direct relationship' do
@@ -371,7 +371,7 @@ RSpec.describe Review do
       let(:user) { relationship_project_user.user }
       let!(:review) { create(:review, by_project: project) }
 
-      include_examples 'after_commit callback'
+      include_examples 'review after_commit callback'
     end
 
     context 'by_project with a group relationship' do
@@ -382,7 +382,7 @@ RSpec.describe Review do
       let!(:user) { groups_user.user }
       let!(:review) { create(:review, by_project: project) }
 
-      include_examples 'after_commit callback'
+      include_examples 'review after_commit callback'
     end
   end
 end


### PR DESCRIPTION
The test suite was throwing this:

```
WARNING: Shared example group 'after_commit callback' has been previously defined at:
  /home/travis/build/openSUSE/open-build-service/src/api/spec/models/bs_request_spec.rb:93
...and you are now defining it at:
  /home/travis/build/openSUSE/open-build-service/src/api/spec/models/review_spec.rb:321
The new definition will overwrite the original one.
```

This pull request renames the different shared example groups, so the warning doesn't appear any more.