### PR TITLE
[webui] Render public/404 error page instead of raising an exception

### DIFF
--- a/src/api/app/controllers/webui/webui_controller.rb
+++ b/src/api/app/controllers/webui/webui_controller.rb
@@ -275,7 +275,8 @@ class Webui::WebuiController < ActionController::Base
   end
 
   def feature_active?(feature)
-    raise ActionController::RoutingError, 'Not found' if Feature.inactive?(feature)
+    return if Feature.active?(feature)
+    render file: Rails.root.join('public/404'), status: :not_found, layout: false
   end
 
   private


### PR DESCRIPTION
`ActionController::RoutingError` was never caught anywhere, thus we received entries in errbit. It's better to just render the public 404 page.