### PR TITLE
[webui] Fix make admin link

### DIFF
--- a/src/api/app/controllers/webui/user_controller.rb
+++ b/src/api/app/controllers/webui/user_controller.rb
@@ -122,7 +122,7 @@ class Webui::UserController < Webui::WebuiController
   end
 
   def admin
-    @displayed_user.update_globalroles(%w(Admin))
+    @displayed_user.update_globalroles(Role.where(title: 'Admin'))
     @displayed_user.save
     redirect_back(fallback_location: { action: 'show', user: @displayed_user })
   end

--- a/src/api/spec/controllers/webui/user_controller_spec.rb
+++ b/src/api/spec/controllers/webui/user_controller_spec.rb
@@ -271,8 +271,15 @@ RSpec.describe Webui::UserController do
     skip
   end
 
-  describe "GET #admin" do
-    skip
+  describe "POST #admin" do
+    before do
+      login admin_user
+      post :admin, params: { user: user.login }
+    end
+
+    it 'applies the Admin role properly' do
+      expect(user.roles.find_by(title: 'Admin')).to_not be_nil
+    end
   end
 
   describe "GET #save_dialog" do


### PR DESCRIPTION
The `make admin` link did not work anymore. This fixes #3705