### PR TITLE
Fix makeadmin link for 2.8

### DIFF
--- a/ReleaseNotes-2.8
+++ b/ReleaseNotes-2.8
@@ -27,6 +27,7 @@ UI:
  * Main projects list is now filtered based on a configurable (by the admin) regular expression
  * Users can download the public key and SSL certificate for a project via the project home page
  * import of kiwi build descriptions is supported (obs-service-kiwi_import)
+ * Bugfix: `Make user admin` link was not working on `Manage Users` page
 
 API:
  * Allow admins to lock or delete users and their home projects via new command

--- a/src/api/app/controllers/webui/user_controller.rb
+++ b/src/api/app/controllers/webui/user_controller.rb
@@ -163,7 +163,7 @@ class Webui::UserController < Webui::WebuiController
   end
 
   def admin
-    @displayed_user.update_globalroles(%w(Admin))
+    @displayed_user.update_globalroles(Role.where(title: 'Admin'))
     @displayed_user.save
     redirect_back(fallback_location: { action: 'show', user: @displayed_user })
   end

--- a/src/api/spec/controllers/webui/user_controller_spec.rb
+++ b/src/api/spec/controllers/webui/user_controller_spec.rb
@@ -280,8 +280,15 @@ RSpec.describe Webui::UserController do
     skip
   end
 
-  describe "GET #admin" do
-    skip
+  describe "POST #admin" do
+    before do
+      login admin_user
+      post :admin, params: { user: user.login }
+    end
+
+    it 'applies the Admin role properly' do
+      expect(user.roles.find_by(title: 'Admin')).to_not be_nil
+    end
   end
 
   describe "GET #save_dialog" do


### PR DESCRIPTION
The `make admin` link did not work anymore.

This is a backport of #3711 