### PR TITLE
[webui] User propper role addition

### DIFF
--- a/src/api/app/controllers/webui/user_controller.rb
+++ b/src/api/app/controllers/webui/user_controller.rb
@@ -122,7 +122,7 @@ class Webui::UserController < Webui::WebuiController
   end
 
   def admin
-    @displayed_user.update_globalroles(Role.where(title: 'Admin'))
+    @displayed_user.add_globalrole(Role.where(title: 'Admin'))
     @displayed_user.save
     redirect_back(fallback_location: { action: 'show', user: @displayed_user })
   end

--- a/src/api/app/models/user.rb
+++ b/src/api/app/models/user.rb
@@ -865,6 +865,10 @@ class User < ApplicationRecord
     roles.replace(global_roles + roles.where(global: false))
   end
 
+  def add_globalrole(global_role)
+    update_globalroles(global_role + roles.global)
+  end
+
   # returns the gravatar image as string or :none
   def gravatar_image(size)
     Rails.cache.fetch([self, 'home_face', size, Configuration.first]) do

--- a/src/api/spec/models/user_spec.rb
+++ b/src/api/spec/models/user_spec.rb
@@ -227,6 +227,21 @@ RSpec.describe User do
     end
   end
 
+  describe '#add_globalrole' do
+    before do
+      user.update_globalroles(Role.where(title: 'Staff'))
+      user.add_globalrole(Role.where(title: 'Admin'))
+    end
+
+    it 'adds a global role' do
+      expect(user.roles).to include(Role.find_by(title: 'Admin'))
+    end
+
+    it 'keeps old global roles' do
+      expect(user.roles).to include(Role.find_by(title: 'Staff'))
+    end
+  end
+
   describe '#declined_requests' do
     let(:target_package) { create(:package) }
     let(:source_package) { create(:package) }


### PR DESCRIPTION
`update_globalroles` just dropped old roles. To avoid this, a new method has been added called `add_globalrole` which keeps old and adds a new one.