### PR TITLE
Fix release note entry 2.8

### DIFF
--- a/ReleaseNotes-2.8
+++ b/ReleaseNotes-2.8
@@ -27,7 +27,6 @@ UI:
  * Main projects list is now filtered based on a configurable (by the admin) regular expression
  * Users can download the public key and SSL certificate for a project via the project home page
  * import of kiwi build descriptions is supported (obs-service-kiwi_import)
- * Bugfix: `Make user admin` link was not working on `Manage Users` page
 
 API:
  * Allow admins to lock or delete users and their home projects via new command

--- a/ReleaseNotes-2.8.3
+++ b/ReleaseNotes-2.8.3
@@ -24,6 +24,7 @@ Bugfixes:
 * [webui] Admins that edited their accounts via the user/show page lost their admin role
 * [api] fix config change of some /configuration values
 * [backend] fix for new linux version format in bs_worker
+* [webui] `Make user admin` link was not working on `Manage Users` page
 
 Notes for OBS setups with LDAP authentication:
 ==============================================


### PR DESCRIPTION
By accident, I put the release entry to the wrong `ReleaseNotes` file.