### PR TITLE
[webui] Change how to close Kiwi dialogs

### DIFF
--- a/src/api/app/assets/javascripts/webui/application/kiwi_editor.js
+++ b/src/api/app/assets/javascripts/webui/application/kiwi_editor.js
@@ -79,6 +79,7 @@ function closeDialog() {
   }
 
   fields.find(".ui-state-error").addClass('hidden');
+  dialog.removeClass('new_element');
 
   hideOverlay(dialog);
 }
@@ -87,7 +88,7 @@ function revertDialog() {
   var fields = $(this).parents('.nested-fields');
   var dialog = fields.find('.dialog');
 
-  if( /^Add/.test(dialog.find('.box-header').text())) {
+  if(dialog.hasClass('new_element')) {
     hideOverlay(dialog);
 
     fields.find('.remove_fields').click();

--- a/src/api/app/views/webui/kiwi/images/_package_fields.html.haml
+++ b/src/api/app/views/webui/kiwi/images/_package_fields.html.haml
@@ -8,7 +8,7 @@
     %span.kiwi_actions.hidden
       = link_to_remove_association sprite_tag("req-decline", title: 'remove'), f
 
-  .dialog.darkgrey_box{ style: "width: 500px; left: 45%;", class: "#{'hidden' if f.object.name.present?}" }
+  .dialog.darkgrey_box{ style: "width: 500px; left: 45%;", class: "#{'hidden' if f.object.name.present?} #{'new_element' if f.object.new_record?}"}
     .box.box-shadow
       %h2.box-header #{f.object.name.present? ? 'Edit' : 'Add'} package
 

--- a/src/api/app/views/webui/kiwi/images/_repository_fields.html.haml
+++ b/src/api/app/views/webui/kiwi/images/_repository_fields.html.haml
@@ -5,7 +5,7 @@
     %span.kiwi_actions.hidden
       = link_to_remove_association(sprite_tag("req-decline", title: 'Delete Repository'), f)
 
-  .dialog.darkgrey_box{ style: "width: 500px; left: 45%;", class: "#{'hidden' if f.object.source_path.present?}" }
+  .dialog.darkgrey_box{ style: "width: 500px; left: 45%;", class: "#{'hidden' if f.object.source_path.present?} #{'new_element' if f.object.new_record?}" }
     .box.box-shadow
       %h2.box-header #{f.object.source_path.present? ? 'Edit' : 'Add'} repository
 


### PR DESCRIPTION
To close a dialog of a new element, we check a class instead of the
title of the dialog.