### PR TITLE
[api][webui] Fix Event creation when comment is too long.

### DIFF
--- a/src/api/app/models/event/comment.rb
+++ b/src/api/app/models/event/comment.rb
@@ -3,6 +3,7 @@ module CommentEvent
     base.class_eval do
       payload_keys :commenters, :commenter, :comment_body, :comment_title
       receiver_roles :commenter
+      shortenable_key :comment_body
     end
   end
 

--- a/src/api/spec/models/event/comment_spec.rb
+++ b/src/api/spec/models/event/comment_spec.rb
@@ -1,0 +1,34 @@
+require 'rails_helper'
+
+RSpec.describe Event::CommentForProject do
+  describe '.shorten_payload_if_necessary' do
+    context 'with the comment body too long for the payload column' do
+      let!(:project) { create(:project) }
+      let!(:user) { create(:confirmed_user) }
+      let!(:comment_author) { create(:confirmed_user) }
+
+      # The events.payload column has a max char limit of 65,535 so this comment cannot fit
+      # in the payload unless it is shortened
+      let(:comment_body) { Faker::Lorem.characters(65535) }
+      let(:event) do
+        Event::CommentForProject.new(
+          project: project.name,
+          commenters: [comment_author.id, user.id],
+          commenter: comment_author.id,
+          comment_body: comment_body
+        )
+      end
+
+      subject! { event.save }
+
+      it 'creates the event with a shortened payload' do
+        expect(event).to be_persisted
+      end
+
+      it 'shortens the payload to fit in the database' do
+        raw_payload = event.attributes_before_type_cast['payload']
+        expect(raw_payload.length).to be <= 65535
+      end
+    end
+  end
+end


### PR DESCRIPTION
The max char length of comment.body is 65535 but the max char length of
events.payload is also 65535. Since the payload contains the comment
body and other data, its possible that the comment body will not fit in
the event payload. This commit adds a callback which shortens the
comment body if it is necessary to fit it in the payload.

Partially fixes https://github.com/openSUSE/open-build-service/issues/3638