### PR TITLE
[webui] Fix enable revert/save button in KIWI.

### DIFF
--- a/src/api/app/assets/javascripts/webui/application/kiwi_editor.js
+++ b/src/api/app/assets/javascripts/webui/application/kiwi_editor.js
@@ -81,6 +81,10 @@ function closeDialog() {
   fields.find(".ui-state-error").addClass('hidden');
   dialog.removeClass('new_element');
 
+  if (!canSave) {
+    enableSave();
+  }
+
   hideOverlay(dialog);
 }
 
@@ -132,7 +136,6 @@ $(document).ready(function(){
   });
 
   // Enable save button
-  $('#kiwi-image-update-form').change(enableSave);
   $('.remove_fields').click(enableSave);
 
   // Edit dialog for Repositories and Packages


### PR DESCRIPTION
Now, when we change some values in a new dialog these doesn't enable by
the default the revert/save button, only if we "save" the dialog.