### PR TITLE
[api][webui] Fix LDAP login when registration=deny

### DIFF
--- a/src/api/app/models/user.rb
+++ b/src/api/app/models/user.rb
@@ -255,11 +255,6 @@ class User < ApplicationRecord
         return user
       end
 
-      # still in LDAP mode, user authentificated, but not existing in OBS yet
-      if ::Configuration.registration == "deny"
-        logger.debug( "No user found in database, creation disabled" )
-        return
-      end
       logger.debug( "No user found in database, creating" )
       logger.debug( "Email: #{ldap_info[0]}" )
       logger.debug( "Name : #{ldap_info[1]}" )


### PR DESCRIPTION
If you have registration set to 'deny' in the config then a user who
exists in LDAP but not in the local database will not be able to login
because of a check in find_with_credentials_via_ldap. This commit
removes that check.

Fixes the problem described by @Jellyfrog in issue https://github.com/openSUSE/open-build-service/issues/3743