### PR TITLE
[dist] Restart services in a later RPM scriptlet

### DIFF
--- a/dist/obs-server.spec
+++ b/dist/obs-server.spec
@@ -490,13 +490,13 @@ sed -i -e 's,[ ]*adapter: mysql$,  adapter: mysql2,' /srv/www/obs/api/config/dat
 touch /srv/www/obs/api/log/production.log
 chown %{apache_user}:%{apache_group} /srv/www/obs/api/log/production.log
 
-%restart_on_update apache2
 %restart_on_update memcached
-%restart_on_update obsapisetup
-%restart_on_update obsapidelayed
 
 %postun -n obs-api
 %insserv_cleanup
+%restart_on_update obsapisetup
+%restart_on_update apache2
+%restart_on_update obsapidelayed
 
 %files
 %defattr(-,root,root)


### PR DESCRIPTION
%post runs before removal of the old package files. Rails does not know about the distinction of old/new files and will just autoload everything. %postun runs after old files are removed.

Discussed with @bugfinder as he also also ran into http://openbuildservice.org/2017/08/28/post-mortem-3/