### PR TITLE
[dist] Restart services in a later RPM scriptlet

### DIFF
--- a/dist/obs-server.spec
+++ b/dist/obs-server.spec
@@ -515,13 +515,13 @@ sed -i -e 's,[ ]*adapter: mysql$,  adapter: mysql2,' /srv/www/obs/api/config/dat
 touch /srv/www/obs/api/log/production.log
 chown %{apache_user}:%{apache_group} /srv/www/obs/api/log/production.log
 
-%restart_on_update apache2
 %restart_on_update memcached
-%restart_on_update obsapisetup
-%restart_on_update obsapidelayed
 
 %postun -n obs-api
 %insserv_cleanup
+%restart_on_update obsapisetup
+%restart_on_update apache2
+%restart_on_update obsapidelayed
 
 %files
 %defattr(-,root,root)


### PR DESCRIPTION
This needs to reach 2.8 customers isolated so the next (version) update with a code change triggers %postun. Otherwise we run into the situation that the services are not restarted. See discussion in #3754