### PR TITLE
Kiwi Editor - project repositories

### DIFF
--- a/src/api/app/assets/javascripts/webui/application/kiwi_editor.js
+++ b/src/api/app/assets/javascripts/webui/application/kiwi_editor.js
@@ -22,8 +22,7 @@ function saveImage() {
 
 function enableSave(){
   canSave = true;
-  $('#kiwi-image-update-form-save').addClass('enabled');
-  $('#kiwi-image-update-form-revert').addClass('enabled');
+  $('#kiwi-image-update-form-save, #kiwi-image-update-form-revert').addClass('enabled');
 }
 
 function editDialog(){
@@ -60,6 +59,17 @@ function editDialog(){
   $('.overlay').show();
 }
 
+function addRepositoryErrorMessage(source_path, field) {
+  if (source_path == 'obsrepositories:/') {
+    field.text('If you want use obsrepositories:/ as source_path, please check the checkbox "use project repositories".');
+  }
+  else {
+    field.text('The source path can not be empty!');
+  }
+
+  field.removeClass('hidden');
+}
+
 function closeDialog() {
   var fields = $(this).parents('.nested-fields');
   var is_repository = fields.parents('#kiwi-repositories-list').size() == 1;
@@ -68,7 +78,7 @@ function closeDialog() {
 
   if(is_repository) {
     var source_path = dialog.find("[id$='source_path']");
-    if(source_path.val() !== '') {
+    if(source_path.val() !== '' && source_path.val() !== 'obsrepositories:/') {
       var alias = dialog.find("[id$='alias']");
       if (alias.val() !== '') {
         name.text(alias.val());
@@ -78,7 +88,7 @@ function closeDialog() {
       }
     }
     else {
-      fields.find(".ui-state-error").removeClass('hidden');
+      addRepositoryErrorMessage(source_path.val(), fields.find(".ui-state-error"));
       return false;
     }
   }
@@ -233,6 +243,10 @@ function kiwiRepositoriesSetupAutocomplete(fields) {
 $(document).ready(function(){
   // Save image
   $('#kiwi-image-update-form-save').click(saveImage);
+  $('#kiwi_image_use_project_repositories').click(function(){
+    $('#kiwi-repositories-list, #use-project-repositories-text').toggle();
+    enableSave();
+  });
 
   // Revert image
   $('#kiwi-image-update-form-revert').click(function(){

--- a/src/api/app/assets/javascripts/webui/application/kiwi_editor.js
+++ b/src/api/app/assets/javascripts/webui/application/kiwi_editor.js
@@ -1,6 +1,5 @@
 var canSave = false;
 
-
 function hideOverlay(dialog) {
   $('.overlay').hide();
   dialog.addClass('hidden');
@@ -101,7 +100,6 @@ function closeDialog() {
       if(arch != '') {
         name.append(" <small>(" + arch + ")</small>");
       }
-
     }
     else {
       fields.find(".ui-state-error").removeClass('hidden');
@@ -282,6 +280,13 @@ $(document).ready(function(){
     $(addedFields).find('.kiwi-repository-mode-toggle').click(repositoryModeToggle);
     $(addedFields).find('.kiwi_list_item').hover(hoverListItem, hoverListItem);
     kiwiRepositoriesSetupAutocomplete($(addedFields));
+    $('#no-repositories').hide();
+  });
+
+  $('#kiwi-repositories-list').on('cocoon:after-remove', function() {
+    if ($(this).find('.nested-fields:visible').size() === 0) {
+      $('#no-repositories').show();
+    }
   });
 
   // After inserting new packages add the Callbacks
@@ -291,5 +296,12 @@ $(document).ready(function(){
     $(addedFields).find('.close-dialog').click(closeDialog);
     $(addedFields).find('.revert-dialog').click(revertDialog);
     $(addedFields).find('.kiwi_list_item').hover(hoverListItem, hoverListItem);
+    $('#no-packages').hide();
+  });
+
+  $('#kiwi-packages-list').on('cocoon:after-remove', function() {
+    if ($(this).find('.nested-fields:visible').size() === 0) {
+      $('#no-packages').show();
+    }
   });
 });

--- a/src/api/app/assets/stylesheets/webui/application/kiwi_image.scss
+++ b/src/api/app/assets/stylesheets/webui/application/kiwi_image.scss
@@ -23,6 +23,18 @@
   }
 }
 
+#kiwi-use-project-repositories {
+  margin-bottom: 25px;
+
+  label { vertical-align: text-bottom; }
+
+  #use-project-repositories-text {
+    font-size: 14px;
+
+    img { vertical-align: text-bottom; }
+  }
+}
+
 #kiwi-repositories-list, #kiwi-packages-list {
   padding-left: 10px;
   padding-right: 10px;

--- a/src/api/app/models/kiwi/package_group.rb
+++ b/src/api/app/models/kiwi/package_group.rb
@@ -1,5 +1,5 @@
 class Kiwi::PackageGroup < ApplicationRecord
-  has_many :packages
+  has_many :packages, dependent: :destroy
   belongs_to :image
 
   # we need to add a prefix, to avoid generating class methods that already

--- a/src/api/app/views/webui/kiwi/images/_repository_fields.html.haml
+++ b/src/api/app/views/webui/kiwi/images/_repository_fields.html.haml
@@ -56,7 +56,6 @@
 
       %p#flash-messages
         %p.ui-state-error.ui-widget-shadow.hidden
-          The source path can not be empty!
 
       .dialog-buttons
         = link_to('Expert Mode', '#', title: 'Mode Toggle', class: 'kiwi-repository-mode-toggle')

--- a/src/api/app/views/webui/kiwi/images/show.html.haml
+++ b/src/api/app/views/webui/kiwi/images/show.html.haml
@@ -18,7 +18,7 @@
         This option will use the repositories from the current project. Others repositories set in this Kiwi Image will be REMOVED.
     #kiwi-repositories-list{ class: "#{'hidden' if f.object.use_project_repositories?}"}
       %hr
-      %p= 'There are no repositories.' if @image.repositories.empty?
+      %p#no-repositories{ class: "#{'hidden' if @image.repositories.present?}" }= 'There are no repositories.'
       = f.fields_for :repositories do |repository_fields|
         = render 'repository_fields', f: repository_fields
       %p
@@ -27,7 +27,7 @@
   .grid_16.alpha.omega.box.box-shadow
     %h3 Packages
     #kiwi-packages-list
-      %p= 'There are no packages.' if @image.kiwi_packages.empty?
+      %p#no-packages{ class: "#{'hidden' if @image.kiwi_packages.present?}" }= 'There are no packages.'
 
       = f.fields_for :package_groups, @image.default_package_group do |package_group_fields|
         = package_group_fields.fields_for :packages do |kiwi_package_fields|

--- a/src/api/app/views/webui/kiwi/images/show.html.haml
+++ b/src/api/app/views/webui/kiwi/images/show.html.haml
@@ -9,26 +9,31 @@
 
   .grid_16.alpha.omega.box.box-shadow
     %h3 Repositories
-    - if @image.repositories.empty?
-      %p There are no repositories.
-    - else
-      #kiwi-repositories-list
-        = f.fields_for :repositories do |repository_fields|
-          = render 'repository_fields', f: repository_fields
-        %p
-          = link_to_add_association(sprite_tag("drive_add", title: 'Add repository') + ' Add repository', f, :repositories)
+    #kiwi-use-project-repositories
+      %p
+        = f.check_box :use_project_repositories
+        = f.label :use_project_repositories
+      %p.ui-state-highlight#use-project-repositories-text{ class: "#{'hidden' unless f.object.use_project_repositories?}"}
+        = sprite_tag("info", title: 'Add package')
+        This option will use the repositories from the current project. Others repositories set in this Kiwi Image will be REMOVED.
+    #kiwi-repositories-list{ class: "#{'hidden' if f.object.use_project_repositories?}"}
+      %hr
+      %p= 'There are no repositories.' if @image.repositories.empty?
+      = f.fields_for :repositories do |repository_fields|
+        = render 'repository_fields', f: repository_fields
+      %p
+        = link_to_add_association(sprite_tag("drive_add", title: 'Add repository') + ' Add repository', f, :repositories)
 
   .grid_16.alpha.omega.box.box-shadow
     %h3 Packages
-    - if @image.kiwi_packages.empty?
-      %p There are no packages.
-    - else
-      #kiwi-packages-list
-        = f.fields_for :package_groups, @image.default_package_group do |package_group_fields|
-          = package_group_fields.fields_for :packages do |kiwi_package_fields|
-            = render 'package_fields', f: kiwi_package_fields
-          %p
-            = link_to_add_association(sprite_tag("package_add", title: 'Add package') + ' Add package', package_group_fields, :packages)
+    #kiwi-packages-list
+      %p= 'There are no packages.' if @image.kiwi_packages.empty?
+
+      = f.fields_for :package_groups, @image.default_package_group do |package_group_fields|
+        = package_group_fields.fields_for :packages do |kiwi_package_fields|
+          = render 'package_fields', f: kiwi_package_fields
+        %p
+          = link_to_add_association(sprite_tag("package_add", title: 'Add package') + ' Add package', package_group_fields, :packages)
 
   .grid_2.alpha.omega.box.box-shadow.kiwi-button
     %h3

--- a/src/api/db/migrate/20170905101113_add_use_project_repositories_to_image.rb
+++ b/src/api/db/migrate/20170905101113_add_use_project_repositories_to_image.rb
@@ -1,0 +1,5 @@
+class AddUseProjectRepositoriesToImage < ActiveRecord::Migration[5.1]
+  def change
+    add_column :kiwi_images, :use_project_repositories, :boolean, default: false
+  end
+end

--- a/src/api/db/structure.sql
+++ b/src/api/db/structure.sql
@@ -609,6 +609,7 @@ CREATE TABLE `kiwi_images` (
   `md5_last_revision` varchar(32) DEFAULT NULL,
   `created_at` datetime NOT NULL,
   `updated_at` datetime(6) NOT NULL,
+  `use_project_repositories` tinyint(1) DEFAULT '0',
   PRIMARY KEY (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
@@ -1244,6 +1245,7 @@ INSERT INTO `schema_migrations` (version) VALUES
 ('20170821110918'),
 ('20170821110941'),
 ('20170821110946'),
+('20170905101113'),
 ('20170911142301'),
 ('20170912140257'),
 ('20170912140713');

--- a/src/api/spec/cassettes/Webui_Kiwi_ImagesController/GET_import_from_package/with_a_kiwi_file/that_is_a_valid_kiwi_file/1_1_2_1_1.yml
+++ b/src/api/spec/cassettes/Webui_Kiwi_ImagesController/GET_import_from_package/with_a_kiwi_file/that_is_a_valid_kiwi_file/1_1_2_1_1.yml
@@ -7,7 +7,7 @@ http_interactions:
       encoding: UTF-8
       string: |
         <project name="fake_project">
-          <title>The Painted Veil</title>
+          <title>His Dark Materials</title>
           <description/>
         </project>
     headers:
@@ -29,23 +29,23 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '105'
+      - '107'
     body:
       encoding: UTF-8
       string: |
         <project name="fake_project">
-          <title>The Painted Veil</title>
+          <title>His Dark Materials</title>
           <description></description>
         </project>
     http_version: 
-  recorded_at: Thu, 13 Jul 2017 11:13:01 GMT
+  recorded_at: Mon, 11 Sep 2017 21:36:39 GMT
 - request:
     method: put
     uri: http://localhost:3200/source/fake_project/_config
     body:
       encoding: UTF-8
-      string: Qui animi cum. In quia libero. Cumque rerum dolores ipsam nostrum perspiciatis.
-        Perspiciatis enim autem voluptates laudantium. Accusamus nostrum qui.
+      string: Omnis in maxime dolores nihil modi ut. Possimus reprehenderit quia accusamus
+        est ex aut. Magnam voluptatem reiciendis maiores iure.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -72,7 +72,7 @@ http_interactions:
 
 '
     http_version: 
-  recorded_at: Thu, 13 Jul 2017 11:13:01 GMT
+  recorded_at: Mon, 11 Sep 2017 21:36:39 GMT
 - request:
     method: put
     uri: http://localhost:3200/source/fake_project/package_with_kiwi_image/_meta?user=_nobody_
@@ -80,8 +80,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="package_with_kiwi_image" project="fake_project">
-          <title>The House of Mirth</title>
-          <description>Dolores ab est occaecati sit quibusdam praesentium culpa.</description>
+          <title>Sleep the Brave</title>
+          <description>Laborum nesciunt quisquam dicta exercitationem deserunt.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -102,16 +102,16 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '198'
+      - '194'
     body:
       encoding: UTF-8
       string: |
         <package name="package_with_kiwi_image" project="fake_project">
-          <title>The House of Mirth</title>
-          <description>Dolores ab est occaecati sit quibusdam praesentium culpa.</description>
+          <title>Sleep the Brave</title>
+          <description>Laborum nesciunt quisquam dicta exercitationem deserunt.</description>
         </package>
     http_version: 
-  recorded_at: Thu, 13 Jul 2017 11:13:01 GMT
+  recorded_at: Mon, 11 Sep 2017 21:36:39 GMT
 - request:
     method: put
     uri: http://localhost:3200/source/fake_project/package_with_kiwi_image/_meta
@@ -119,8 +119,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="package_with_kiwi_image" project="fake_project">
-          <title>The House of Mirth</title>
-          <description>Dolores ab est occaecati sit quibusdam praesentium culpa.</description>
+          <title>Sleep the Brave</title>
+          <description>Laborum nesciunt quisquam dicta exercitationem deserunt.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -141,16 +141,16 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '198'
+      - '194'
     body:
       encoding: UTF-8
       string: |
         <package name="package_with_kiwi_image" project="fake_project">
-          <title>The House of Mirth</title>
-          <description>Dolores ab est occaecati sit quibusdam praesentium culpa.</description>
+          <title>Sleep the Brave</title>
+          <description>Laborum nesciunt quisquam dicta exercitationem deserunt.</description>
         </package>
     http_version: 
-  recorded_at: Thu, 13 Jul 2017 11:13:01 GMT
+  recorded_at: Mon, 11 Sep 2017 21:36:39 GMT
 - request:
     method: put
     uri: http://localhost:3200/source/fake_project/package_with_kiwi_image/package_with_kiwi_image.kiwi
@@ -164,8 +164,6 @@ http_interactions:
           <preferences>
             <type image="oem" primary="true" boot="oemboot/suse-13.2"/>
           </preferences>
-          <packages type="bootstrap">
-          </packages>
         </image>
     headers:
       Accept-Encoding:
@@ -190,16 +188,16 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <revision rev="1" vrev="1">
-          <srcmd5>3822662924706b810ffb158183355052</srcmd5>
+        <revision rev="5" vrev="5">
+          <srcmd5>82f39606fd3c729f7f16de7d227e6dae</srcmd5>
           <version>unknown</version>
-          <time>1499944381</time>
+          <time>1505165799</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
     http_version: 
-  recorded_at: Thu, 13 Jul 2017 11:13:01 GMT
+  recorded_at: Mon, 11 Sep 2017 21:36:39 GMT
 - request:
     method: put
     uri: http://localhost:3200/source/fake_project/package_with_kiwi_image/_meta?user=_nobody_
@@ -207,8 +205,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="package_with_kiwi_image" project="fake_project">
-          <title>The House of Mirth</title>
-          <description>Dolores ab est occaecati sit quibusdam praesentium culpa.</description>
+          <title>Sleep the Brave</title>
+          <description>Laborum nesciunt quisquam dicta exercitationem deserunt.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -229,16 +227,16 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '198'
+      - '194'
     body:
       encoding: UTF-8
       string: |
         <package name="package_with_kiwi_image" project="fake_project">
-          <title>The House of Mirth</title>
-          <description>Dolores ab est occaecati sit quibusdam praesentium culpa.</description>
+          <title>Sleep the Brave</title>
+          <description>Laborum nesciunt quisquam dicta exercitationem deserunt.</description>
         </package>
     http_version: 
-  recorded_at: Thu, 13 Jul 2017 11:13:02 GMT
+  recorded_at: Mon, 11 Sep 2017 21:36:39 GMT
 - request:
     method: get
     uri: http://localhost:3200/source/fake_project/package_with_kiwi_image
@@ -268,11 +266,11 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="package_with_kiwi_image" rev="1" vrev="1" srcmd5="3822662924706b810ffb158183355052">
-          <entry name="package_with_kiwi_image.kiwi" md5="3eb87e3299e4dbb72703842403c3dd21" size="286" mtime="1499944375" />
+        <directory name="package_with_kiwi_image" rev="5" vrev="5" srcmd5="82f39606fd3c729f7f16de7d227e6dae">
+          <entry name="package_with_kiwi_image.kiwi" md5="dda935f455dcd6607d83705328bee9df" size="242" mtime="1505142563" />
         </directory>
     http_version: 
-  recorded_at: Thu, 13 Jul 2017 11:13:02 GMT
+  recorded_at: Mon, 11 Sep 2017 21:36:39 GMT
 - request:
     method: get
     uri: http://localhost:3200/source/fake_project/package_with_kiwi_image
@@ -302,11 +300,11 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="package_with_kiwi_image" rev="1" vrev="1" srcmd5="3822662924706b810ffb158183355052">
-          <entry name="package_with_kiwi_image.kiwi" md5="3eb87e3299e4dbb72703842403c3dd21" size="286" mtime="1499944375" />
+        <directory name="package_with_kiwi_image" rev="5" vrev="5" srcmd5="82f39606fd3c729f7f16de7d227e6dae">
+          <entry name="package_with_kiwi_image.kiwi" md5="dda935f455dcd6607d83705328bee9df" size="242" mtime="1505142563" />
         </directory>
     http_version: 
-  recorded_at: Thu, 13 Jul 2017 11:13:02 GMT
+  recorded_at: Mon, 11 Sep 2017 21:36:39 GMT
 - request:
     method: get
     uri: http://localhost:3200/source/fake_project/package_with_kiwi_image
@@ -336,11 +334,11 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="package_with_kiwi_image" rev="1" vrev="1" srcmd5="3822662924706b810ffb158183355052">
-          <entry name="package_with_kiwi_image.kiwi" md5="3eb87e3299e4dbb72703842403c3dd21" size="286" mtime="1499944375" />
+        <directory name="package_with_kiwi_image" rev="5" vrev="5" srcmd5="82f39606fd3c729f7f16de7d227e6dae">
+          <entry name="package_with_kiwi_image.kiwi" md5="dda935f455dcd6607d83705328bee9df" size="242" mtime="1505142563" />
         </directory>
     http_version: 
-  recorded_at: Thu, 13 Jul 2017 11:13:02 GMT
+  recorded_at: Mon, 11 Sep 2017 21:36:39 GMT
 - request:
     method: get
     uri: http://localhost:3200/source/fake_project/package_with_kiwi_image
@@ -370,9 +368,9 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="package_with_kiwi_image" rev="1" vrev="1" srcmd5="3822662924706b810ffb158183355052">
-          <entry name="package_with_kiwi_image.kiwi" md5="3eb87e3299e4dbb72703842403c3dd21" size="286" mtime="1499944375" />
+        <directory name="package_with_kiwi_image" rev="5" vrev="5" srcmd5="82f39606fd3c729f7f16de7d227e6dae">
+          <entry name="package_with_kiwi_image.kiwi" md5="dda935f455dcd6607d83705328bee9df" size="242" mtime="1505142563" />
         </directory>
     http_version: 
-  recorded_at: Thu, 13 Jul 2017 11:13:02 GMT
+  recorded_at: Mon, 11 Sep 2017 21:36:39 GMT
 recorded_with: VCR 3.0.3

--- a/src/api/spec/cassettes/Webui_Kiwi_ImagesController/GET_import_from_package/with_a_kiwi_file/that_is_an_invalid_kiwi_file/redirect_to_package_view_file_path.yml
+++ b/src/api/spec/cassettes/Webui_Kiwi_ImagesController/GET_import_from_package/with_a_kiwi_file/that_is_an_invalid_kiwi_file/redirect_to_package_view_file_path.yml
@@ -7,7 +7,7 @@ http_interactions:
       encoding: UTF-8
       string: |
         <project name="fake_project">
-          <title>By Grand Central Station I Sat Down and Wept</title>
+          <title>The Last Temptation</title>
           <description/>
         </project>
     headers:
@@ -29,12 +29,12 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '133'
+      - '108'
     body:
       encoding: UTF-8
       string: |
         <project name="fake_project">
-          <title>By Grand Central Station I Sat Down and Wept</title>
+          <title>The Last Temptation</title>
           <description></description>
         </project>
     http_version: 
@@ -44,8 +44,10 @@ http_interactions:
     uri: http://localhost:3200/source/fake_project/_config
     body:
       encoding: UTF-8
-      string: Deserunt perspiciatis autem quas facilis molestias sint. Fugiat qui
-        libero. Molestias quo cum ut qui at quia.
+      string: Pariatur quod earum harum debitis quas. Dignissimos accusamus ut cum
+        nihil illo similique sed. Consequuntur aperiam culpa laboriosam est omnis
+        maiores aliquid. Voluptatum et voluptas ducimus ipsam. Necessitatibus laudantium
+        fuga.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -75,13 +77,13 @@ http_interactions:
   recorded_at: Mon, 11 Sep 2017 21:36:38 GMT
 - request:
     method: put
-    uri: http://localhost:3200/source/fake_project/package_with_invalid_kiwi_file/_meta?user=tom
+    uri: http://localhost:3200/source/fake_project/package_with_invalid_kiwi_file/_meta?user=_nobody_
     body:
       encoding: UTF-8
       string: |
         <package name="package_with_invalid_kiwi_file" project="fake_project">
-          <title>Absalom, Absalom!</title>
-          <description>Cupiditate repellat et optio ipsa.</description>
+          <title>Far From the Madding Crowd</title>
+          <description>Error voluptatem veniam illo sequi id sed qui.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -102,13 +104,13 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '181'
+      - '202'
     body:
       encoding: UTF-8
       string: |
         <package name="package_with_invalid_kiwi_file" project="fake_project">
-          <title>Absalom, Absalom!</title>
-          <description>Cupiditate repellat et optio ipsa.</description>
+          <title>Far From the Madding Crowd</title>
+          <description>Error voluptatem veniam illo sequi id sed qui.</description>
         </package>
     http_version: 
   recorded_at: Mon, 11 Sep 2017 21:36:38 GMT
@@ -119,8 +121,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="package_with_invalid_kiwi_file" project="fake_project">
-          <title>Absalom, Absalom!</title>
-          <description>Cupiditate repellat et optio ipsa.</description>
+          <title>Far From the Madding Crowd</title>
+          <description>Error voluptatem veniam illo sequi id sed qui.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -141,13 +143,13 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '181'
+      - '202'
     body:
       encoding: UTF-8
       string: |
         <package name="package_with_invalid_kiwi_file" project="fake_project">
-          <title>Absalom, Absalom!</title>
-          <description>Cupiditate repellat et optio ipsa.</description>
+          <title>Far From the Madding Crowd</title>
+          <description>Error voluptatem veniam illo sequi id sed qui.</description>
         </package>
     http_version: 
   recorded_at: Mon, 11 Sep 2017 21:36:38 GMT
@@ -222,16 +224,16 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <revision rev="20" vrev="20">
+        <revision rev="21" vrev="21">
           <srcmd5>6ccfa0805f62f6fba78db7bc8b4082ba</srcmd5>
           <version>unknown</version>
-          <time>1505165798</time>
+          <time>1505165799</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
     http_version: 
-  recorded_at: Mon, 11 Sep 2017 21:36:38 GMT
+  recorded_at: Mon, 11 Sep 2017 21:36:39 GMT
 - request:
     method: get
     uri: http://localhost:3200/source/fake_project/package_with_invalid_kiwi_file
@@ -261,11 +263,11 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="package_with_invalid_kiwi_file" rev="20" vrev="20" srcmd5="6ccfa0805f62f6fba78db7bc8b4082ba">
+        <directory name="package_with_invalid_kiwi_file" rev="21" vrev="21" srcmd5="6ccfa0805f62f6fba78db7bc8b4082ba">
           <entry name="package_with_invalid_kiwi_file.kiwi" md5="5a69f457207aa0e7d1cdc633164df54d" size="1791" mtime="1505142565" />
         </directory>
     http_version: 
-  recorded_at: Mon, 11 Sep 2017 21:36:38 GMT
+  recorded_at: Mon, 11 Sep 2017 21:36:39 GMT
 - request:
     method: get
     uri: http://localhost:3200/source/fake_project/package_with_invalid_kiwi_file/package_with_invalid_kiwi_file.kiwi
@@ -338,7 +340,7 @@ http_interactions:
           </repository>
         </image>
     http_version: 
-  recorded_at: Mon, 11 Sep 2017 21:36:38 GMT
+  recorded_at: Mon, 11 Sep 2017 21:36:39 GMT
 - request:
     method: get
     uri: http://localhost:3200/source/fake_project/package_with_invalid_kiwi_file
@@ -368,9 +370,9 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="package_with_invalid_kiwi_file" rev="20" vrev="20" srcmd5="6ccfa0805f62f6fba78db7bc8b4082ba">
+        <directory name="package_with_invalid_kiwi_file" rev="21" vrev="21" srcmd5="6ccfa0805f62f6fba78db7bc8b4082ba">
           <entry name="package_with_invalid_kiwi_file.kiwi" md5="5a69f457207aa0e7d1cdc633164df54d" size="1791" mtime="1505142565" />
         </directory>
     http_version: 
-  recorded_at: Mon, 11 Sep 2017 21:36:38 GMT
+  recorded_at: Mon, 11 Sep 2017 21:36:39 GMT
 recorded_with: VCR 3.0.3

--- a/src/api/spec/cassettes/Webui_Kiwi_ImagesController/GET_import_from_package/with_a_kiwi_file/with_source_path/with_obsrepository/redirect_to_kiwi_image_show.yml
+++ b/src/api/spec/cassettes/Webui_Kiwi_ImagesController/GET_import_from_package/with_a_kiwi_file/with_source_path/with_obsrepository/redirect_to_kiwi_image_show.yml
@@ -7,7 +7,7 @@ http_interactions:
       encoding: UTF-8
       string: |
         <project name="fake_project">
-          <title>By Grand Central Station I Sat Down and Wept</title>
+          <title>This Side of Paradise</title>
           <description/>
         </project>
     headers:
@@ -29,23 +29,24 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '133'
+      - '110'
     body:
       encoding: UTF-8
       string: |
         <project name="fake_project">
-          <title>By Grand Central Station I Sat Down and Wept</title>
+          <title>This Side of Paradise</title>
           <description></description>
         </project>
     http_version: 
-  recorded_at: Mon, 11 Sep 2017 21:36:38 GMT
+  recorded_at: Mon, 11 Sep 2017 21:36:40 GMT
 - request:
     method: put
     uri: http://localhost:3200/source/fake_project/_config
     body:
       encoding: UTF-8
-      string: Deserunt perspiciatis autem quas facilis molestias sint. Fugiat qui
-        libero. Molestias quo cum ut qui at quia.
+      string: Qui consequatur id totam enim inventore hic sunt. Dolores aliquid vel
+        optio minus aut esse ducimus. Voluptate nihil dolore consequuntur ex quis
+        animi. Tempore eum nostrum esse autem iusto et labore.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -72,16 +73,16 @@ http_interactions:
 
 '
     http_version: 
-  recorded_at: Mon, 11 Sep 2017 21:36:38 GMT
+  recorded_at: Mon, 11 Sep 2017 21:36:40 GMT
 - request:
     method: put
-    uri: http://localhost:3200/source/fake_project/package_with_invalid_kiwi_file/_meta?user=tom
+    uri: http://localhost:3200/source/fake_project/package_with_a_kiwi_file/_meta?user=_nobody_
     body:
       encoding: UTF-8
       string: |
-        <package name="package_with_invalid_kiwi_file" project="fake_project">
-          <title>Absalom, Absalom!</title>
-          <description>Cupiditate repellat et optio ipsa.</description>
+        <package name="package_with_a_kiwi_file" project="fake_project">
+          <title>The Parliament of Man</title>
+          <description>Numquam voluptas voluptatem libero.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -102,25 +103,25 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '181'
+      - '180'
     body:
       encoding: UTF-8
       string: |
-        <package name="package_with_invalid_kiwi_file" project="fake_project">
-          <title>Absalom, Absalom!</title>
-          <description>Cupiditate repellat et optio ipsa.</description>
+        <package name="package_with_a_kiwi_file" project="fake_project">
+          <title>The Parliament of Man</title>
+          <description>Numquam voluptas voluptatem libero.</description>
         </package>
     http_version: 
-  recorded_at: Mon, 11 Sep 2017 21:36:38 GMT
+  recorded_at: Mon, 11 Sep 2017 21:36:40 GMT
 - request:
     method: put
-    uri: http://localhost:3200/source/fake_project/package_with_invalid_kiwi_file/_meta
+    uri: http://localhost:3200/source/fake_project/package_with_a_kiwi_file/_meta
     body:
       encoding: UTF-8
       string: |
-        <package name="package_with_invalid_kiwi_file" project="fake_project">
-          <title>Absalom, Absalom!</title>
-          <description>Cupiditate repellat et optio ipsa.</description>
+        <package name="package_with_a_kiwi_file" project="fake_project">
+          <title>The Parliament of Man</title>
+          <description>Numquam voluptas voluptatem libero.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -141,19 +142,19 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '181'
+      - '180'
     body:
       encoding: UTF-8
       string: |
-        <package name="package_with_invalid_kiwi_file" project="fake_project">
-          <title>Absalom, Absalom!</title>
-          <description>Cupiditate repellat et optio ipsa.</description>
+        <package name="package_with_a_kiwi_file" project="fake_project">
+          <title>The Parliament of Man</title>
+          <description>Numquam voluptas voluptatem libero.</description>
         </package>
     http_version: 
-  recorded_at: Mon, 11 Sep 2017 21:36:38 GMT
+  recorded_at: Mon, 11 Sep 2017 21:36:40 GMT
 - request:
     method: put
-    uri: http://localhost:3200/source/fake_project/package_with_invalid_kiwi_file/package_with_invalid_kiwi_file.kiwi
+    uri: http://localhost:3200/source/fake_project/package_with_a_kiwi_file/package_with_a_kiwi_file.kiwi
     body:
       encoding: UTF-8
       string: |
@@ -186,17 +187,12 @@ http_interactions:
             <package name="openSUSE-release-dvd"/>
             <package name="gfxboot-devel" bootinclude="true"/>
           </packages>
-          <repository type="wrong" priority="10" alias="debian" imageinclude="true" password="123456" prefer-license="true" status="replaceable" username="Tom">
-            <source path="http://download.opensuse.org/update/13.2/"/>
-          </repository>
-          <repository type="rpm-dir" priority="wrong" imageinclude="false" prefer-license="false">
-            <source path="http://download.opensuse.org/distribution/13.2/repo/oss/"/>
-          </repository>
-          <repository type="rpm-md" priority="20">
-            <source path="wrong://download.opensuse.org/distribution/13.1/repo/oss/"/>
-          </repository>
+          <packages type="delete">
+            <package name="e2fsprogss"/>
+            <package name="bbb_base"/>
+          </packages>
           <repository type="rpm-md">
-            <source path="http://download.opensuse.org/distribution/12.1/repo/oss/"/>
+            <source path="obsrepositories:/"/>
           </repository>
         </image>
     headers:
@@ -218,23 +214,23 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '209'
+      - '207'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="20" vrev="20">
-          <srcmd5>6ccfa0805f62f6fba78db7bc8b4082ba</srcmd5>
+        <revision rev="6" vrev="6">
+          <srcmd5>15a2f6f67049560c511dba7a96144445</srcmd5>
           <version>unknown</version>
-          <time>1505165798</time>
+          <time>1505165800</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
     http_version: 
-  recorded_at: Mon, 11 Sep 2017 21:36:38 GMT
+  recorded_at: Mon, 11 Sep 2017 21:36:40 GMT
 - request:
     method: get
-    uri: http://localhost:3200/source/fake_project/package_with_invalid_kiwi_file
+    uri: http://localhost:3200/source/fake_project/package_with_a_kiwi_file
     body:
       encoding: US-ASCII
       string: ''
@@ -257,18 +253,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '249'
+      - '235'
     body:
       encoding: UTF-8
       string: |
-        <directory name="package_with_invalid_kiwi_file" rev="20" vrev="20" srcmd5="6ccfa0805f62f6fba78db7bc8b4082ba">
-          <entry name="package_with_invalid_kiwi_file.kiwi" md5="5a69f457207aa0e7d1cdc633164df54d" size="1791" mtime="1505142565" />
+        <directory name="package_with_a_kiwi_file" rev="6" vrev="6" srcmd5="15a2f6f67049560c511dba7a96144445">
+          <entry name="package_with_a_kiwi_file.kiwi" md5="b15285e545a4265f25349d8c4dee9919" size="1302" mtime="1505142565" />
         </directory>
     http_version: 
-  recorded_at: Mon, 11 Sep 2017 21:36:38 GMT
+  recorded_at: Mon, 11 Sep 2017 21:36:40 GMT
 - request:
     method: get
-    uri: http://localhost:3200/source/fake_project/package_with_invalid_kiwi_file/package_with_invalid_kiwi_file.kiwi
+    uri: http://localhost:3200/source/fake_project/package_with_a_kiwi_file/package_with_a_kiwi_file.kiwi
     body:
       encoding: US-ASCII
       string: ''
@@ -287,7 +283,7 @@ http_interactions:
       Content-Type:
       - application/octet-stream
       Content-Length:
-      - '1791'
+      - '1302'
       Cache-Control:
       - no-cache
       Connection:
@@ -324,24 +320,19 @@ http_interactions:
             <package name="openSUSE-release-dvd"/>
             <package name="gfxboot-devel" bootinclude="true"/>
           </packages>
-          <repository type="wrong" priority="10" alias="debian" imageinclude="true" password="123456" prefer-license="true" status="replaceable" username="Tom">
-            <source path="http://download.opensuse.org/update/13.2/"/>
-          </repository>
-          <repository type="rpm-dir" priority="wrong" imageinclude="false" prefer-license="false">
-            <source path="http://download.opensuse.org/distribution/13.2/repo/oss/"/>
-          </repository>
-          <repository type="rpm-md" priority="20">
-            <source path="wrong://download.opensuse.org/distribution/13.1/repo/oss/"/>
-          </repository>
+          <packages type="delete">
+            <package name="e2fsprogss"/>
+            <package name="bbb_base"/>
+          </packages>
           <repository type="rpm-md">
-            <source path="http://download.opensuse.org/distribution/12.1/repo/oss/"/>
+            <source path="obsrepositories:/"/>
           </repository>
         </image>
     http_version: 
-  recorded_at: Mon, 11 Sep 2017 21:36:38 GMT
+  recorded_at: Mon, 11 Sep 2017 21:36:40 GMT
 - request:
     method: get
-    uri: http://localhost:3200/source/fake_project/package_with_invalid_kiwi_file
+    uri: http://localhost:3200/source/fake_project/package_with_a_kiwi_file
     body:
       encoding: US-ASCII
       string: ''
@@ -364,13 +355,91 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '249'
+      - '235'
     body:
       encoding: UTF-8
       string: |
-        <directory name="package_with_invalid_kiwi_file" rev="20" vrev="20" srcmd5="6ccfa0805f62f6fba78db7bc8b4082ba">
-          <entry name="package_with_invalid_kiwi_file.kiwi" md5="5a69f457207aa0e7d1cdc633164df54d" size="1791" mtime="1505142565" />
+        <directory name="package_with_a_kiwi_file" rev="6" vrev="6" srcmd5="15a2f6f67049560c511dba7a96144445">
+          <entry name="package_with_a_kiwi_file.kiwi" md5="b15285e545a4265f25349d8c4dee9919" size="1302" mtime="1505142565" />
         </directory>
     http_version: 
-  recorded_at: Mon, 11 Sep 2017 21:36:38 GMT
+  recorded_at: Mon, 11 Sep 2017 21:36:40 GMT
+- request:
+    method: put
+    uri: http://localhost:3200/source/fake_project/package_with_a_kiwi_file/_meta?user=_nobody_
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="package_with_a_kiwi_file" project="fake_project">
+          <title>The Parliament of Man</title>
+          <description>Numquam voluptas voluptatem libero.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '180'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="package_with_a_kiwi_file" project="fake_project">
+          <title>The Parliament of Man</title>
+          <description>Numquam voluptas voluptatem libero.</description>
+        </package>
+    http_version: 
+  recorded_at: Mon, 11 Sep 2017 21:36:40 GMT
+- request:
+    method: put
+    uri: http://localhost:3200/source/fake_project/package_with_a_kiwi_file/_meta?user=_nobody_
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="package_with_a_kiwi_file" project="fake_project">
+          <title>The Parliament of Man</title>
+          <description>Numquam voluptas voluptatem libero.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '180'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="package_with_a_kiwi_file" project="fake_project">
+          <title>The Parliament of Man</title>
+          <description>Numquam voluptas voluptatem libero.</description>
+        </package>
+    http_version: 
+  recorded_at: Mon, 11 Sep 2017 21:36:40 GMT
 recorded_with: VCR 3.0.3

--- a/src/api/spec/cassettes/Webui_Kiwi_ImagesController/GET_import_from_package/with_a_kiwi_file/with_source_path/with_obsrepository_and_others/1_1_2_3_2_2.yml
+++ b/src/api/spec/cassettes/Webui_Kiwi_ImagesController/GET_import_from_package/with_a_kiwi_file/with_source_path/with_obsrepository_and_others/1_1_2_3_2_2.yml
@@ -7,7 +7,7 @@ http_interactions:
       encoding: UTF-8
       string: |
         <project name="fake_project">
-          <title>By Grand Central Station I Sat Down and Wept</title>
+          <title>To Sail Beyond the Sunset</title>
           <description/>
         </project>
     headers:
@@ -29,23 +29,24 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '133'
+      - '114'
     body:
       encoding: UTF-8
       string: |
         <project name="fake_project">
-          <title>By Grand Central Station I Sat Down and Wept</title>
+          <title>To Sail Beyond the Sunset</title>
           <description></description>
         </project>
     http_version: 
-  recorded_at: Mon, 11 Sep 2017 21:36:38 GMT
+  recorded_at: Mon, 11 Sep 2017 21:36:39 GMT
 - request:
     method: put
     uri: http://localhost:3200/source/fake_project/_config
     body:
       encoding: UTF-8
-      string: Deserunt perspiciatis autem quas facilis molestias sint. Fugiat qui
-        libero. Molestias quo cum ut qui at quia.
+      string: Provident a est nemo quisquam et odio et. Exercitationem et vero. A
+        quibusdam velit consequuntur voluptate. Non culpa laudantium consequatur qui
+        aut aut repellendus. Ut nihil suscipit veniam et ex dolor sed.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -72,16 +73,16 @@ http_interactions:
 
 '
     http_version: 
-  recorded_at: Mon, 11 Sep 2017 21:36:38 GMT
+  recorded_at: Mon, 11 Sep 2017 21:36:39 GMT
 - request:
     method: put
-    uri: http://localhost:3200/source/fake_project/package_with_invalid_kiwi_file/_meta?user=tom
+    uri: http://localhost:3200/source/fake_project/package_with_invalid_kiwi_file/_meta?user=_nobody_
     body:
       encoding: UTF-8
       string: |
         <package name="package_with_invalid_kiwi_file" project="fake_project">
-          <title>Absalom, Absalom!</title>
-          <description>Cupiditate repellat et optio ipsa.</description>
+          <title>A Passage to India</title>
+          <description>Tempore aperiam autem quis ut sed.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -102,16 +103,16 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '181'
+      - '182'
     body:
       encoding: UTF-8
       string: |
         <package name="package_with_invalid_kiwi_file" project="fake_project">
-          <title>Absalom, Absalom!</title>
-          <description>Cupiditate repellat et optio ipsa.</description>
+          <title>A Passage to India</title>
+          <description>Tempore aperiam autem quis ut sed.</description>
         </package>
     http_version: 
-  recorded_at: Mon, 11 Sep 2017 21:36:38 GMT
+  recorded_at: Mon, 11 Sep 2017 21:36:39 GMT
 - request:
     method: put
     uri: http://localhost:3200/source/fake_project/package_with_invalid_kiwi_file/_meta
@@ -119,8 +120,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="package_with_invalid_kiwi_file" project="fake_project">
-          <title>Absalom, Absalom!</title>
-          <description>Cupiditate repellat et optio ipsa.</description>
+          <title>A Passage to India</title>
+          <description>Tempore aperiam autem quis ut sed.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -141,16 +142,16 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '181'
+      - '182'
     body:
       encoding: UTF-8
       string: |
         <package name="package_with_invalid_kiwi_file" project="fake_project">
-          <title>Absalom, Absalom!</title>
-          <description>Cupiditate repellat et optio ipsa.</description>
+          <title>A Passage to India</title>
+          <description>Tempore aperiam autem quis ut sed.</description>
         </package>
     http_version: 
-  recorded_at: Mon, 11 Sep 2017 21:36:38 GMT
+  recorded_at: Mon, 11 Sep 2017 21:36:39 GMT
 - request:
     method: put
     uri: http://localhost:3200/source/fake_project/package_with_invalid_kiwi_file/package_with_invalid_kiwi_file.kiwi
@@ -186,17 +187,15 @@ http_interactions:
             <package name="openSUSE-release-dvd"/>
             <package name="gfxboot-devel" bootinclude="true"/>
           </packages>
-          <repository type="wrong" priority="10" alias="debian" imageinclude="true" password="123456" prefer-license="true" status="replaceable" username="Tom">
+          <packages type="delete">
+            <package name="e2fsprogss"/>
+            <package name="bbb_base"/>
+          </packages>
+          <repository type="apt-deb" priority="10" alias="debian" imageinclude="true" password="123456" prefer-license="true" status="replaceable" username="Tom">
             <source path="http://download.opensuse.org/update/13.2/"/>
           </repository>
-          <repository type="rpm-dir" priority="wrong" imageinclude="false" prefer-license="false">
-            <source path="http://download.opensuse.org/distribution/13.2/repo/oss/"/>
-          </repository>
-          <repository type="rpm-md" priority="20">
-            <source path="wrong://download.opensuse.org/distribution/13.1/repo/oss/"/>
-          </repository>
           <repository type="rpm-md">
-            <source path="http://download.opensuse.org/distribution/12.1/repo/oss/"/>
+            <source path="obsrepositories:/"/>
           </repository>
         </image>
     headers:
@@ -222,16 +221,16 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <revision rev="20" vrev="20">
-          <srcmd5>6ccfa0805f62f6fba78db7bc8b4082ba</srcmd5>
+        <revision rev="22" vrev="22">
+          <srcmd5>febd44ad0e6a0c4271b0197ea7a125e9</srcmd5>
           <version>unknown</version>
-          <time>1505165798</time>
+          <time>1505165799</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
     http_version: 
-  recorded_at: Mon, 11 Sep 2017 21:36:38 GMT
+  recorded_at: Mon, 11 Sep 2017 21:36:39 GMT
 - request:
     method: get
     uri: http://localhost:3200/source/fake_project/package_with_invalid_kiwi_file
@@ -261,11 +260,11 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="package_with_invalid_kiwi_file" rev="20" vrev="20" srcmd5="6ccfa0805f62f6fba78db7bc8b4082ba">
-          <entry name="package_with_invalid_kiwi_file.kiwi" md5="5a69f457207aa0e7d1cdc633164df54d" size="1791" mtime="1505142565" />
+        <directory name="package_with_invalid_kiwi_file" rev="22" vrev="22" srcmd5="febd44ad0e6a0c4271b0197ea7a125e9">
+          <entry name="package_with_invalid_kiwi_file.kiwi" md5="b766875b54bc4fbf48bbbf1017104e1e" size="1536" mtime="1505142564" />
         </directory>
     http_version: 
-  recorded_at: Mon, 11 Sep 2017 21:36:38 GMT
+  recorded_at: Mon, 11 Sep 2017 21:36:39 GMT
 - request:
     method: get
     uri: http://localhost:3200/source/fake_project/package_with_invalid_kiwi_file/package_with_invalid_kiwi_file.kiwi
@@ -287,7 +286,7 @@ http_interactions:
       Content-Type:
       - application/octet-stream
       Content-Length:
-      - '1791'
+      - '1536'
       Cache-Control:
       - no-cache
       Connection:
@@ -324,21 +323,19 @@ http_interactions:
             <package name="openSUSE-release-dvd"/>
             <package name="gfxboot-devel" bootinclude="true"/>
           </packages>
-          <repository type="wrong" priority="10" alias="debian" imageinclude="true" password="123456" prefer-license="true" status="replaceable" username="Tom">
+          <packages type="delete">
+            <package name="e2fsprogss"/>
+            <package name="bbb_base"/>
+          </packages>
+          <repository type="apt-deb" priority="10" alias="debian" imageinclude="true" password="123456" prefer-license="true" status="replaceable" username="Tom">
             <source path="http://download.opensuse.org/update/13.2/"/>
           </repository>
-          <repository type="rpm-dir" priority="wrong" imageinclude="false" prefer-license="false">
-            <source path="http://download.opensuse.org/distribution/13.2/repo/oss/"/>
-          </repository>
-          <repository type="rpm-md" priority="20">
-            <source path="wrong://download.opensuse.org/distribution/13.1/repo/oss/"/>
-          </repository>
           <repository type="rpm-md">
-            <source path="http://download.opensuse.org/distribution/12.1/repo/oss/"/>
+            <source path="obsrepositories:/"/>
           </repository>
         </image>
     http_version: 
-  recorded_at: Mon, 11 Sep 2017 21:36:38 GMT
+  recorded_at: Mon, 11 Sep 2017 21:36:39 GMT
 - request:
     method: get
     uri: http://localhost:3200/source/fake_project/package_with_invalid_kiwi_file
@@ -368,9 +365,9 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="package_with_invalid_kiwi_file" rev="20" vrev="20" srcmd5="6ccfa0805f62f6fba78db7bc8b4082ba">
-          <entry name="package_with_invalid_kiwi_file.kiwi" md5="5a69f457207aa0e7d1cdc633164df54d" size="1791" mtime="1505142565" />
+        <directory name="package_with_invalid_kiwi_file" rev="22" vrev="22" srcmd5="febd44ad0e6a0c4271b0197ea7a125e9">
+          <entry name="package_with_invalid_kiwi_file.kiwi" md5="b766875b54bc4fbf48bbbf1017104e1e" size="1536" mtime="1505142564" />
         </directory>
     http_version: 
-  recorded_at: Mon, 11 Sep 2017 21:36:38 GMT
+  recorded_at: Mon, 11 Sep 2017 21:36:39 GMT
 recorded_with: VCR 3.0.3

--- a/src/api/spec/cassettes/Webui_Kiwi_ImagesController/GET_import_from_package/with_a_kiwi_file/with_source_path/with_obsrepository_and_others/redirect_to_package_view_file_path.yml
+++ b/src/api/spec/cassettes/Webui_Kiwi_ImagesController/GET_import_from_package/with_a_kiwi_file/with_source_path/with_obsrepository_and_others/redirect_to_package_view_file_path.yml
@@ -7,7 +7,7 @@ http_interactions:
       encoding: UTF-8
       string: |
         <project name="fake_project">
-          <title>After Many a Summer Dies the Swan</title>
+          <title>Lilies of the Field</title>
           <description/>
         </project>
     headers:
@@ -29,23 +29,23 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '122'
+      - '108'
     body:
       encoding: UTF-8
       string: |
         <project name="fake_project">
-          <title>After Many a Summer Dies the Swan</title>
+          <title>Lilies of the Field</title>
           <description></description>
         </project>
     http_version: 
-  recorded_at: Thu, 13 Jul 2017 11:13:02 GMT
+  recorded_at: Mon, 11 Sep 2017 21:36:39 GMT
 - request:
     method: put
     uri: http://localhost:3200/source/fake_project/_config
     body:
       encoding: UTF-8
-      string: Ut cumque tempora sed. Est modi totam reiciendis sint est. Aliquid nisi
-        officiis amet ut labore est. At libero quam qui quidem deserunt.
+      string: Dolores corporis culpa voluptatem facere et. Aliquid recusandae facilis
+        quis ea saepe dolor. Id minima nam non fugit et maiores. Numquam vitae et.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -72,7 +72,7 @@ http_interactions:
 
 '
     http_version: 
-  recorded_at: Thu, 13 Jul 2017 11:13:02 GMT
+  recorded_at: Mon, 11 Sep 2017 21:36:39 GMT
 - request:
     method: put
     uri: http://localhost:3200/source/fake_project/package_with_invalid_kiwi_file/_meta?user=_nobody_
@@ -80,8 +80,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="package_with_invalid_kiwi_file" project="fake_project">
-          <title>The Widening Gyre</title>
-          <description>Dolorem in sed porro sunt ut.</description>
+          <title>A Confederacy of Dunces</title>
+          <description>Reiciendis laudantium ab consectetur facere impedit aut corporis.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -102,16 +102,16 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '176'
+      - '218'
     body:
       encoding: UTF-8
       string: |
         <package name="package_with_invalid_kiwi_file" project="fake_project">
-          <title>The Widening Gyre</title>
-          <description>Dolorem in sed porro sunt ut.</description>
+          <title>A Confederacy of Dunces</title>
+          <description>Reiciendis laudantium ab consectetur facere impedit aut corporis.</description>
         </package>
     http_version: 
-  recorded_at: Thu, 13 Jul 2017 11:13:02 GMT
+  recorded_at: Mon, 11 Sep 2017 21:36:39 GMT
 - request:
     method: put
     uri: http://localhost:3200/source/fake_project/package_with_invalid_kiwi_file/_meta
@@ -119,8 +119,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="package_with_invalid_kiwi_file" project="fake_project">
-          <title>The Widening Gyre</title>
-          <description>Dolorem in sed porro sunt ut.</description>
+          <title>A Confederacy of Dunces</title>
+          <description>Reiciendis laudantium ab consectetur facere impedit aut corporis.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -141,16 +141,16 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '176'
+      - '218'
     body:
       encoding: UTF-8
       string: |
         <package name="package_with_invalid_kiwi_file" project="fake_project">
-          <title>The Widening Gyre</title>
-          <description>Dolorem in sed porro sunt ut.</description>
+          <title>A Confederacy of Dunces</title>
+          <description>Reiciendis laudantium ab consectetur facere impedit aut corporis.</description>
         </package>
     http_version: 
-  recorded_at: Thu, 13 Jul 2017 11:13:02 GMT
+  recorded_at: Mon, 11 Sep 2017 21:36:39 GMT
 - request:
     method: put
     uri: http://localhost:3200/source/fake_project/package_with_invalid_kiwi_file/package_with_invalid_kiwi_file.kiwi
@@ -186,17 +186,15 @@ http_interactions:
             <package name="openSUSE-release-dvd"/>
             <package name="gfxboot-devel" bootinclude="true"/>
           </packages>
-          <repository type="wrong" priority="10" alias="debian" imageinclude="true" password="123456" prefer-license="true" status="replaceable" username="Tom">
+          <packages type="delete">
+            <package name="e2fsprogss"/>
+            <package name="bbb_base"/>
+          </packages>
+          <repository type="apt-deb" priority="10" alias="debian" imageinclude="true" password="123456" prefer-license="true" status="replaceable" username="Tom">
             <source path="http://download.opensuse.org/update/13.2/"/>
           </repository>
-          <repository type="rpm-dir" priority="wrong" imageinclude="false" prefer-license="false">
-            <source path="http://download.opensuse.org/distribution/13.2/repo/oss/"/>
-          </repository>
-          <repository type="rpm-md" priority="20">
-            <source path="wrong://download.opensuse.org/distribution/13.1/repo/oss/"/>
-          </repository>
           <repository type="rpm-md">
-            <source path="http://download.opensuse.org/distribution/12.1/repo/oss/"/>
+            <source path="obsrepositories:/"/>
           </repository>
         </image>
     headers:
@@ -218,20 +216,20 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '207'
+      - '209'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="1" vrev="1">
-          <srcmd5>6ccfa0805f62f6fba78db7bc8b4082ba</srcmd5>
+        <revision rev="23" vrev="23">
+          <srcmd5>febd44ad0e6a0c4271b0197ea7a125e9</srcmd5>
           <version>unknown</version>
-          <time>1499944382</time>
+          <time>1505165799</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
     http_version: 
-  recorded_at: Thu, 13 Jul 2017 11:13:02 GMT
+  recorded_at: Mon, 11 Sep 2017 21:36:39 GMT
 - request:
     method: get
     uri: http://localhost:3200/source/fake_project/package_with_invalid_kiwi_file
@@ -257,15 +255,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '247'
+      - '249'
     body:
       encoding: UTF-8
       string: |
-        <directory name="package_with_invalid_kiwi_file" rev="1" vrev="1" srcmd5="6ccfa0805f62f6fba78db7bc8b4082ba">
-          <entry name="package_with_invalid_kiwi_file.kiwi" md5="5a69f457207aa0e7d1cdc633164df54d" size="1791" mtime="1499944382" />
+        <directory name="package_with_invalid_kiwi_file" rev="23" vrev="23" srcmd5="febd44ad0e6a0c4271b0197ea7a125e9">
+          <entry name="package_with_invalid_kiwi_file.kiwi" md5="b766875b54bc4fbf48bbbf1017104e1e" size="1536" mtime="1505142564" />
         </directory>
     http_version: 
-  recorded_at: Thu, 13 Jul 2017 11:13:02 GMT
+  recorded_at: Mon, 11 Sep 2017 21:36:39 GMT
 - request:
     method: get
     uri: http://localhost:3200/source/fake_project/package_with_invalid_kiwi_file/package_with_invalid_kiwi_file.kiwi
@@ -287,7 +285,7 @@ http_interactions:
       Content-Type:
       - application/octet-stream
       Content-Length:
-      - '1791'
+      - '1536'
       Cache-Control:
       - no-cache
       Connection:
@@ -324,21 +322,19 @@ http_interactions:
             <package name="openSUSE-release-dvd"/>
             <package name="gfxboot-devel" bootinclude="true"/>
           </packages>
-          <repository type="wrong" priority="10" alias="debian" imageinclude="true" password="123456" prefer-license="true" status="replaceable" username="Tom">
+          <packages type="delete">
+            <package name="e2fsprogss"/>
+            <package name="bbb_base"/>
+          </packages>
+          <repository type="apt-deb" priority="10" alias="debian" imageinclude="true" password="123456" prefer-license="true" status="replaceable" username="Tom">
             <source path="http://download.opensuse.org/update/13.2/"/>
           </repository>
-          <repository type="rpm-dir" priority="wrong" imageinclude="false" prefer-license="false">
-            <source path="http://download.opensuse.org/distribution/13.2/repo/oss/"/>
-          </repository>
-          <repository type="rpm-md" priority="20">
-            <source path="wrong://download.opensuse.org/distribution/13.1/repo/oss/"/>
-          </repository>
           <repository type="rpm-md">
-            <source path="http://download.opensuse.org/distribution/12.1/repo/oss/"/>
+            <source path="obsrepositories:/"/>
           </repository>
         </image>
     http_version: 
-  recorded_at: Thu, 13 Jul 2017 11:13:02 GMT
+  recorded_at: Mon, 11 Sep 2017 21:36:39 GMT
 - request:
     method: get
     uri: http://localhost:3200/source/fake_project/package_with_invalid_kiwi_file
@@ -364,13 +360,13 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '247'
+      - '249'
     body:
       encoding: UTF-8
       string: |
-        <directory name="package_with_invalid_kiwi_file" rev="1" vrev="1" srcmd5="6ccfa0805f62f6fba78db7bc8b4082ba">
-          <entry name="package_with_invalid_kiwi_file.kiwi" md5="5a69f457207aa0e7d1cdc633164df54d" size="1791" mtime="1499944382" />
+        <directory name="package_with_invalid_kiwi_file" rev="23" vrev="23" srcmd5="febd44ad0e6a0c4271b0197ea7a125e9">
+          <entry name="package_with_invalid_kiwi_file.kiwi" md5="b766875b54bc4fbf48bbbf1017104e1e" size="1536" mtime="1505142564" />
         </directory>
     http_version: 
-  recorded_at: Thu, 13 Jul 2017 11:13:02 GMT
+  recorded_at: Mon, 11 Sep 2017 21:36:39 GMT
 recorded_with: VCR 3.0.3

--- a/src/api/spec/cassettes/Webui_Kiwi_ImagesController/GET_import_from_package/without_a_kiwi_file/1_1_1_1.yml
+++ b/src/api/spec/cassettes/Webui_Kiwi_ImagesController/GET_import_from_package/without_a_kiwi_file/1_1_1_1.yml
@@ -7,7 +7,7 @@ http_interactions:
       encoding: UTF-8
       string: |
         <project name="fake_project">
-          <title>A Catskill Eagle</title>
+          <title>The Wealth of Nations</title>
           <description/>
         </project>
     headers:
@@ -29,24 +29,24 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '105'
+      - '110'
     body:
       encoding: UTF-8
       string: |
         <project name="fake_project">
-          <title>A Catskill Eagle</title>
+          <title>The Wealth of Nations</title>
           <description></description>
         </project>
     http_version: 
-  recorded_at: Thu, 13 Jul 2017 11:13:03 GMT
+  recorded_at: Mon, 11 Sep 2017 21:36:40 GMT
 - request:
     method: put
     uri: http://localhost:3200/source/fake_project/_config
     body:
       encoding: UTF-8
-      string: Enim minus ut tempora assumenda rem. Necessitatibus odit qui mollitia
-        tenetur. Qui nemo possimus tempore dolore expedita eligendi nam. Qui odio
-        est molestiae est explicabo quisquam.
+      string: Rem maiores aut. Aut ab nihil nesciunt velit consequatur id adipisci.
+        Asperiores necessitatibus hic impedit ut quia. Eius aperiam iure temporibus
+        modi impedit amet tempora.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -73,7 +73,7 @@ http_interactions:
 
 '
     http_version: 
-  recorded_at: Thu, 13 Jul 2017 11:13:03 GMT
+  recorded_at: Mon, 11 Sep 2017 21:36:40 GMT
 - request:
     method: put
     uri: http://localhost:3200/source/fake_project/package_without_kiwi_file/_meta?user=_nobody_
@@ -81,8 +81,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="package_without_kiwi_file" project="fake_project">
-          <title>A Monstrous Regiment of Women</title>
-          <description>Molestiae et tenetur tempore.</description>
+          <title>An Acceptable Time</title>
+          <description>Et voluptatem reprehenderit non praesentium nostrum.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -103,16 +103,16 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '183'
+      - '195'
     body:
       encoding: UTF-8
       string: |
         <package name="package_without_kiwi_file" project="fake_project">
-          <title>A Monstrous Regiment of Women</title>
-          <description>Molestiae et tenetur tempore.</description>
+          <title>An Acceptable Time</title>
+          <description>Et voluptatem reprehenderit non praesentium nostrum.</description>
         </package>
     http_version: 
-  recorded_at: Thu, 13 Jul 2017 11:13:03 GMT
+  recorded_at: Mon, 11 Sep 2017 21:36:40 GMT
 - request:
     method: put
     uri: http://localhost:3200/source/fake_project/package_without_kiwi_file/_meta
@@ -120,8 +120,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="package_without_kiwi_file" project="fake_project">
-          <title>A Monstrous Regiment of Women</title>
-          <description>Molestiae et tenetur tempore.</description>
+          <title>An Acceptable Time</title>
+          <description>Et voluptatem reprehenderit non praesentium nostrum.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -142,16 +142,16 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '183'
+      - '195'
     body:
       encoding: UTF-8
       string: |
         <package name="package_without_kiwi_file" project="fake_project">
-          <title>A Monstrous Regiment of Women</title>
-          <description>Molestiae et tenetur tempore.</description>
+          <title>An Acceptable Time</title>
+          <description>Et voluptatem reprehenderit non praesentium nostrum.</description>
         </package>
     http_version: 
-  recorded_at: Thu, 13 Jul 2017 11:13:04 GMT
+  recorded_at: Mon, 11 Sep 2017 21:36:40 GMT
 - request:
     method: get
     uri: http://localhost:3200/source/fake_project/package_without_kiwi_file
@@ -184,5 +184,5 @@ http_interactions:
         <directory name="package_without_kiwi_file" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
         </directory>
     http_version: 
-  recorded_at: Thu, 13 Jul 2017 11:13:04 GMT
+  recorded_at: Mon, 11 Sep 2017 21:36:40 GMT
 recorded_with: VCR 3.0.3

--- a/src/api/spec/cassettes/Webui_Kiwi_ImagesController/GET_import_from_package/without_a_kiwi_file/1_1_1_2.yml
+++ b/src/api/spec/cassettes/Webui_Kiwi_ImagesController/GET_import_from_package/without_a_kiwi_file/1_1_1_2.yml
@@ -7,7 +7,7 @@ http_interactions:
       encoding: UTF-8
       string: |
         <project name="fake_project">
-          <title>Unweaving the Rainbow</title>
+          <title>Time of our Darkness</title>
           <description/>
         </project>
     headers:
@@ -29,23 +29,23 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '110'
+      - '109'
     body:
       encoding: UTF-8
       string: |
         <project name="fake_project">
-          <title>Unweaving the Rainbow</title>
+          <title>Time of our Darkness</title>
           <description></description>
         </project>
     http_version: 
-  recorded_at: Thu, 13 Jul 2017 11:13:03 GMT
+  recorded_at: Mon, 11 Sep 2017 21:36:40 GMT
 - request:
     method: put
     uri: http://localhost:3200/source/fake_project/_config
     body:
       encoding: UTF-8
-      string: Velit et maiores dignissimos. Id et vel. Officia ut in et hic architecto
-        aliquam mollitia.
+      string: Iste earum temporibus. Corporis in aut inventore vitae dolorem sequi.
+        Harum unde inventore.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -72,7 +72,7 @@ http_interactions:
 
 '
     http_version: 
-  recorded_at: Thu, 13 Jul 2017 11:13:03 GMT
+  recorded_at: Mon, 11 Sep 2017 21:36:40 GMT
 - request:
     method: put
     uri: http://localhost:3200/source/fake_project/package_without_kiwi_file/_meta?user=_nobody_
@@ -80,8 +80,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="package_without_kiwi_file" project="fake_project">
-          <title>Wildfire at Midnight</title>
-          <description>Fugit nostrum omnis unde eveniet accusamus neque pariatur et.</description>
+          <title>The Last Temptation</title>
+          <description>Dignissimos odit enim vero.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -102,16 +102,16 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '206'
+      - '171'
     body:
       encoding: UTF-8
       string: |
         <package name="package_without_kiwi_file" project="fake_project">
-          <title>Wildfire at Midnight</title>
-          <description>Fugit nostrum omnis unde eveniet accusamus neque pariatur et.</description>
+          <title>The Last Temptation</title>
+          <description>Dignissimos odit enim vero.</description>
         </package>
     http_version: 
-  recorded_at: Thu, 13 Jul 2017 11:13:03 GMT
+  recorded_at: Mon, 11 Sep 2017 21:36:40 GMT
 - request:
     method: put
     uri: http://localhost:3200/source/fake_project/package_without_kiwi_file/_meta
@@ -119,8 +119,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="package_without_kiwi_file" project="fake_project">
-          <title>Wildfire at Midnight</title>
-          <description>Fugit nostrum omnis unde eveniet accusamus neque pariatur et.</description>
+          <title>The Last Temptation</title>
+          <description>Dignissimos odit enim vero.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -141,16 +141,16 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '206'
+      - '171'
     body:
       encoding: UTF-8
       string: |
         <package name="package_without_kiwi_file" project="fake_project">
-          <title>Wildfire at Midnight</title>
-          <description>Fugit nostrum omnis unde eveniet accusamus neque pariatur et.</description>
+          <title>The Last Temptation</title>
+          <description>Dignissimos odit enim vero.</description>
         </package>
     http_version: 
-  recorded_at: Thu, 13 Jul 2017 11:13:03 GMT
+  recorded_at: Mon, 11 Sep 2017 21:36:40 GMT
 - request:
     method: get
     uri: http://localhost:3200/source/fake_project/package_without_kiwi_file
@@ -183,5 +183,5 @@ http_interactions:
         <directory name="package_without_kiwi_file" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
         </directory>
     http_version: 
-  recorded_at: Thu, 13 Jul 2017 11:13:03 GMT
+  recorded_at: Mon, 11 Sep 2017 21:36:40 GMT
 recorded_with: VCR 3.0.3

--- a/src/api/spec/cassettes/Webui_Kiwi_ImagesController/POST_update/with_valid_repositories_data/with_use_project_repositories/1_3_2_2_1.yml
+++ b/src/api/spec/cassettes/Webui_Kiwi_ImagesController/POST_update/with_valid_repositories_data/with_use_project_repositories/1_3_2_2_1.yml
@@ -1,0 +1,618 @@
+---
+http_interactions:
+- request:
+    method: put
+    uri: http://localhost:3200/source/home:tom/_meta?user=tom
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:tom">
+          <title/>
+          <description/>
+          <person userid="tom" role="maintainer"/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '129'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:tom">
+          <title></title>
+          <description></description>
+          <person userid="tom" role="maintainer" />
+        </project>
+    http_version: 
+  recorded_at: Tue, 12 Sep 2017 18:56:39 GMT
+- request:
+    method: put
+    uri: http://localhost:3200/source/home:tom/package_with_kiwi_image/_meta?user=tom
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="package_with_kiwi_image" project="home:tom">
+          <title>Nectar in a Sieve</title>
+          <description>Qui quo nihil saepe ut dolore necessitatibus.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '181'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="package_with_kiwi_image" project="home:tom">
+          <title>Nectar in a Sieve</title>
+          <description>Qui quo nihil saepe ut dolore necessitatibus.</description>
+        </package>
+    http_version: 
+  recorded_at: Tue, 12 Sep 2017 18:56:39 GMT
+- request:
+    method: put
+    uri: http://localhost:3200/source/home:tom/package_with_kiwi_image/_meta
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="package_with_kiwi_image" project="home:tom">
+          <title>Nectar in a Sieve</title>
+          <description>Qui quo nihil saepe ut dolore necessitatibus.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '181'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="package_with_kiwi_image" project="home:tom">
+          <title>Nectar in a Sieve</title>
+          <description>Qui quo nihil saepe ut dolore necessitatibus.</description>
+        </package>
+    http_version: 
+  recorded_at: Tue, 12 Sep 2017 18:56:39 GMT
+- request:
+    method: put
+    uri: http://localhost:3200/source/home:tom/package_with_kiwi_image/package_with_kiwi_image.kiwi
+    body:
+      encoding: UTF-8
+      string: |
+        <?xml version="1.0" encoding="utf-8"?>
+        <image schemaversion="6.2" name="suse-13.2-live">
+          <description type="system">
+          </description>
+          <preferences>
+            <type image="oem" primary="true" boot="oemboot/suse-13.2"/>
+          </preferences>
+        </image>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '209'
+    body:
+      encoding: UTF-8
+      string: |
+        <revision rev="77" vrev="77">
+          <srcmd5>82f39606fd3c729f7f16de7d227e6dae</srcmd5>
+          <version>unknown</version>
+          <time>1505242599</time>
+          <user>unknown</user>
+          <comment></comment>
+          <requestid/>
+        </revision>
+    http_version: 
+  recorded_at: Tue, 12 Sep 2017 18:56:39 GMT
+- request:
+    method: put
+    uri: http://localhost:3200/source/home:tom/package_with_kiwi_image/_meta?user=tom
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="package_with_kiwi_image" project="home:tom">
+          <title>Nectar in a Sieve</title>
+          <description>Qui quo nihil saepe ut dolore necessitatibus.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '181'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="package_with_kiwi_image" project="home:tom">
+          <title>Nectar in a Sieve</title>
+          <description>Qui quo nihil saepe ut dolore necessitatibus.</description>
+        </package>
+    http_version: 
+  recorded_at: Tue, 12 Sep 2017 18:56:39 GMT
+- request:
+    method: get
+    uri: http://localhost:3200/source/home:tom/package_with_kiwi_image
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '234'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="package_with_kiwi_image" rev="77" vrev="77" srcmd5="82f39606fd3c729f7f16de7d227e6dae">
+          <entry name="package_with_kiwi_image.kiwi" md5="dda935f455dcd6607d83705328bee9df" size="242" mtime="1505241815" />
+        </directory>
+    http_version: 
+  recorded_at: Tue, 12 Sep 2017 18:56:39 GMT
+- request:
+    method: get
+    uri: http://localhost:3200/source/home:tom/package_with_kiwi_image
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '234'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="package_with_kiwi_image" rev="77" vrev="77" srcmd5="82f39606fd3c729f7f16de7d227e6dae">
+          <entry name="package_with_kiwi_image.kiwi" md5="dda935f455dcd6607d83705328bee9df" size="242" mtime="1505241815" />
+        </directory>
+    http_version: 
+  recorded_at: Tue, 12 Sep 2017 18:56:39 GMT
+- request:
+    method: get
+    uri: http://localhost:3200/source/home:tom/package_with_kiwi_image
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '234'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="package_with_kiwi_image" rev="77" vrev="77" srcmd5="82f39606fd3c729f7f16de7d227e6dae">
+          <entry name="package_with_kiwi_image.kiwi" md5="dda935f455dcd6607d83705328bee9df" size="242" mtime="1505241815" />
+        </directory>
+    http_version: 
+  recorded_at: Tue, 12 Sep 2017 18:56:39 GMT
+- request:
+    method: get
+    uri: http://localhost:3200/source/home:tom/package_with_kiwi_image/package_with_kiwi_image.kiwi
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/octet-stream
+      Content-Length:
+      - '242'
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+    body:
+      encoding: UTF-8
+      string: |
+        <?xml version="1.0" encoding="utf-8"?>
+        <image schemaversion="6.2" name="suse-13.2-live">
+          <description type="system">
+          </description>
+          <preferences>
+            <type image="oem" primary="true" boot="oemboot/suse-13.2"/>
+          </preferences>
+        </image>
+    http_version: 
+  recorded_at: Tue, 12 Sep 2017 18:56:39 GMT
+- request:
+    method: put
+    uri: http://localhost:3200/source/home:tom/package_with_kiwi_image/package_with_kiwi_image.kiwi?user=tom
+    body:
+      encoding: UTF-8
+      string: |
+        <?xml version="1.0" encoding="utf-8"?>
+        <image schemaversion="6.2" name="suse-13.2-live">
+          <description type="system">
+          </description>
+          <repository type="rpm-md">
+            <source path="obsrepositories:/"/>
+          </repository>
+          <preferences>
+            <type image="oem" primary="true" boot="oemboot/suse-13.2"/>
+          </preferences>
+        </image>
+    headers:
+      Content-Type:
+      - text/plain
+      Accept-Encoding:
+      - identity
+      Content-Length:
+      - '326'
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '205'
+    body:
+      encoding: UTF-8
+      string: |
+        <revision rev="78" vrev="78">
+          <srcmd5>2bc4020e2c447b650e17866e9c21b783</srcmd5>
+          <version>unknown</version>
+          <time>1505242599</time>
+          <user>tom</user>
+          <comment></comment>
+          <requestid/>
+        </revision>
+    http_version: 
+  recorded_at: Tue, 12 Sep 2017 18:56:39 GMT
+- request:
+    method: put
+    uri: http://localhost:3200/source/home:tom/package_with_kiwi_image/_meta?user=tom
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="package_with_kiwi_image" project="home:tom">
+          <title>Nectar in a Sieve</title>
+          <description>Qui quo nihil saepe ut dolore necessitatibus.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '181'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="package_with_kiwi_image" project="home:tom">
+          <title>Nectar in a Sieve</title>
+          <description>Qui quo nihil saepe ut dolore necessitatibus.</description>
+        </package>
+    http_version: 
+  recorded_at: Tue, 12 Sep 2017 18:56:39 GMT
+- request:
+    method: get
+    uri: http://localhost:3200/source/home:tom/package_with_kiwi_image
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '234'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="package_with_kiwi_image" rev="78" vrev="78" srcmd5="2bc4020e2c447b650e17866e9c21b783">
+          <entry name="package_with_kiwi_image.kiwi" md5="467dff19a0eaab7288f65cf0a47cc1f3" size="326" mtime="1505241820" />
+        </directory>
+    http_version: 
+  recorded_at: Tue, 12 Sep 2017 18:56:39 GMT
+- request:
+    method: get
+    uri: http://localhost:3200/source/home:tom/package_with_kiwi_image?nofilename=1&view=info&withchangesmd5=1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '199'
+    body:
+      encoding: UTF-8
+      string: |
+        <sourceinfo package="package_with_kiwi_image" rev="78" vrev="78" srcmd5="2bc4020e2c447b650e17866e9c21b783" verifymd5="2bc4020e2c447b650e17866e9c21b783">
+          <revtime>1505242599</revtime>
+        </sourceinfo>
+    http_version: 
+  recorded_at: Tue, 12 Sep 2017 18:56:39 GMT
+- request:
+    method: get
+    uri: http://localhost:3200/source/home:tom/package_with_kiwi_image
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '234'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="package_with_kiwi_image" rev="78" vrev="78" srcmd5="2bc4020e2c447b650e17866e9c21b783">
+          <entry name="package_with_kiwi_image.kiwi" md5="467dff19a0eaab7288f65cf0a47cc1f3" size="326" mtime="1505241820" />
+        </directory>
+    http_version: 
+  recorded_at: Tue, 12 Sep 2017 18:56:39 GMT
+- request:
+    method: post
+    uri: http://localhost:3200/source/home:tom/package_with_kiwi_image?cmd=diff&linkrev=base&onlyissues=1&orev=0&view=xml
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Content-Type:
+      - application/octet-stream
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '328'
+    body:
+      encoding: UTF-8
+      string: |
+        <sourcediff key="4351d3ab1e86ca9bea7c24a2e45a2f35">
+          <old project="home:tom" package="package_with_kiwi_image" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e" />
+          <new project="home:tom" package="package_with_kiwi_image" rev="78" srcmd5="2bc4020e2c447b650e17866e9c21b783" />
+          <files />
+          <issues>
+          </issues>
+        </sourcediff>
+    http_version: 
+  recorded_at: Tue, 12 Sep 2017 18:56:40 GMT
+- request:
+    method: get
+    uri: http://localhost:3200/source/home:tom/package_with_kiwi_image
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '234'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="package_with_kiwi_image" rev="78" vrev="78" srcmd5="2bc4020e2c447b650e17866e9c21b783">
+          <entry name="package_with_kiwi_image.kiwi" md5="467dff19a0eaab7288f65cf0a47cc1f3" size="326" mtime="1505241820" />
+        </directory>
+    http_version: 
+  recorded_at: Tue, 12 Sep 2017 18:56:40 GMT
+recorded_with: VCR 3.0.3

--- a/src/api/spec/cassettes/Webui_Kiwi_ImagesController/POST_update/with_valid_repositories_data/with_use_project_repositories/1_3_2_2_2.yml
+++ b/src/api/spec/cassettes/Webui_Kiwi_ImagesController/POST_update/with_valid_repositories_data/with_use_project_repositories/1_3_2_2_2.yml
@@ -40,7 +40,7 @@ http_interactions:
           <person userid="tom" role="maintainer" />
         </project>
     http_version: 
-  recorded_at: Wed, 02 Aug 2017 12:37:50 GMT
+  recorded_at: Tue, 12 Sep 2017 18:56:40 GMT
 - request:
     method: put
     uri: http://localhost:3200/source/home:tom/package_with_kiwi_image/_meta?user=tom
@@ -48,8 +48,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="package_with_kiwi_image" project="home:tom">
-          <title>A Many-Splendoured Thing</title>
-          <description>Dolor id sit architecto quibusdam nulla modi ipsa.</description>
+          <title>No Highway</title>
+          <description>Quia architecto similique et dolore eum iure mollitia.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -70,16 +70,16 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '193'
+      - '183'
     body:
       encoding: UTF-8
       string: |
         <package name="package_with_kiwi_image" project="home:tom">
-          <title>A Many-Splendoured Thing</title>
-          <description>Dolor id sit architecto quibusdam nulla modi ipsa.</description>
+          <title>No Highway</title>
+          <description>Quia architecto similique et dolore eum iure mollitia.</description>
         </package>
     http_version: 
-  recorded_at: Wed, 02 Aug 2017 12:37:50 GMT
+  recorded_at: Tue, 12 Sep 2017 18:56:40 GMT
 - request:
     method: put
     uri: http://localhost:3200/source/home:tom/package_with_kiwi_image/_meta
@@ -87,8 +87,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="package_with_kiwi_image" project="home:tom">
-          <title>A Many-Splendoured Thing</title>
-          <description>Dolor id sit architecto quibusdam nulla modi ipsa.</description>
+          <title>No Highway</title>
+          <description>Quia architecto similique et dolore eum iure mollitia.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -109,16 +109,16 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '193'
+      - '183'
     body:
       encoding: UTF-8
       string: |
         <package name="package_with_kiwi_image" project="home:tom">
-          <title>A Many-Splendoured Thing</title>
-          <description>Dolor id sit architecto quibusdam nulla modi ipsa.</description>
+          <title>No Highway</title>
+          <description>Quia architecto similique et dolore eum iure mollitia.</description>
         </package>
     http_version: 
-  recorded_at: Wed, 02 Aug 2017 12:37:50 GMT
+  recorded_at: Tue, 12 Sep 2017 18:56:40 GMT
 - request:
     method: put
     uri: http://localhost:3200/source/home:tom/package_with_kiwi_image/package_with_kiwi_image.kiwi
@@ -132,8 +132,6 @@ http_interactions:
           <preferences>
             <type image="oem" primary="true" boot="oemboot/suse-13.2"/>
           </preferences>
-          <packages type="bootstrap">
-          </packages>
         </image>
     headers:
       Accept-Encoding:
@@ -154,20 +152,20 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '207'
+      - '209'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="5" vrev="5">
-          <srcmd5>3822662924706b810ffb158183355052</srcmd5>
+        <revision rev="79" vrev="79">
+          <srcmd5>82f39606fd3c729f7f16de7d227e6dae</srcmd5>
           <version>unknown</version>
-          <time>1501677470</time>
+          <time>1505242600</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
     http_version: 
-  recorded_at: Wed, 02 Aug 2017 12:37:50 GMT
+  recorded_at: Tue, 12 Sep 2017 18:56:40 GMT
 - request:
     method: put
     uri: http://localhost:3200/source/home:tom/package_with_kiwi_image/_meta?user=tom
@@ -175,8 +173,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="package_with_kiwi_image" project="home:tom">
-          <title>A Many-Splendoured Thing</title>
-          <description>Dolor id sit architecto quibusdam nulla modi ipsa.</description>
+          <title>No Highway</title>
+          <description>Quia architecto similique et dolore eum iure mollitia.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -197,16 +195,16 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '193'
+      - '183'
     body:
       encoding: UTF-8
       string: |
         <package name="package_with_kiwi_image" project="home:tom">
-          <title>A Many-Splendoured Thing</title>
-          <description>Dolor id sit architecto quibusdam nulla modi ipsa.</description>
+          <title>No Highway</title>
+          <description>Quia architecto similique et dolore eum iure mollitia.</description>
         </package>
     http_version: 
-  recorded_at: Wed, 02 Aug 2017 12:37:50 GMT
+  recorded_at: Tue, 12 Sep 2017 18:56:40 GMT
 - request:
     method: get
     uri: http://localhost:3200/source/home:tom/package_with_kiwi_image
@@ -232,15 +230,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '232'
+      - '234'
     body:
       encoding: UTF-8
       string: |
-        <directory name="package_with_kiwi_image" rev="5" vrev="5" srcmd5="3822662924706b810ffb158183355052">
-          <entry name="package_with_kiwi_image.kiwi" md5="3eb87e3299e4dbb72703842403c3dd21" size="286" mtime="1501677467" />
+        <directory name="package_with_kiwi_image" rev="79" vrev="79" srcmd5="82f39606fd3c729f7f16de7d227e6dae">
+          <entry name="package_with_kiwi_image.kiwi" md5="dda935f455dcd6607d83705328bee9df" size="242" mtime="1505241815" />
         </directory>
     http_version: 
-  recorded_at: Wed, 02 Aug 2017 12:37:50 GMT
+  recorded_at: Tue, 12 Sep 2017 18:56:40 GMT
 - request:
     method: get
     uri: http://localhost:3200/source/home:tom/package_with_kiwi_image
@@ -266,15 +264,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '232'
+      - '234'
     body:
       encoding: UTF-8
       string: |
-        <directory name="package_with_kiwi_image" rev="5" vrev="5" srcmd5="3822662924706b810ffb158183355052">
-          <entry name="package_with_kiwi_image.kiwi" md5="3eb87e3299e4dbb72703842403c3dd21" size="286" mtime="1501677467" />
+        <directory name="package_with_kiwi_image" rev="79" vrev="79" srcmd5="82f39606fd3c729f7f16de7d227e6dae">
+          <entry name="package_with_kiwi_image.kiwi" md5="dda935f455dcd6607d83705328bee9df" size="242" mtime="1505241815" />
         </directory>
     http_version: 
-  recorded_at: Wed, 02 Aug 2017 12:37:50 GMT
+  recorded_at: Tue, 12 Sep 2017 18:56:40 GMT
 - request:
     method: get
     uri: http://localhost:3200/source/home:tom/package_with_kiwi_image
@@ -300,15 +298,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '232'
+      - '234'
     body:
       encoding: UTF-8
       string: |
-        <directory name="package_with_kiwi_image" rev="5" vrev="5" srcmd5="3822662924706b810ffb158183355052">
-          <entry name="package_with_kiwi_image.kiwi" md5="3eb87e3299e4dbb72703842403c3dd21" size="286" mtime="1501677467" />
+        <directory name="package_with_kiwi_image" rev="79" vrev="79" srcmd5="82f39606fd3c729f7f16de7d227e6dae">
+          <entry name="package_with_kiwi_image.kiwi" md5="dda935f455dcd6607d83705328bee9df" size="242" mtime="1505241815" />
         </directory>
     http_version: 
-  recorded_at: Wed, 02 Aug 2017 12:37:50 GMT
+  recorded_at: Tue, 12 Sep 2017 18:56:40 GMT
 - request:
     method: get
     uri: http://localhost:3200/source/home:tom/package_with_kiwi_image/package_with_kiwi_image.kiwi
@@ -330,7 +328,7 @@ http_interactions:
       Content-Type:
       - application/octet-stream
       Content-Length:
-      - '286'
+      - '242'
       Cache-Control:
       - no-cache
       Connection:
@@ -345,11 +343,9 @@ http_interactions:
           <preferences>
             <type image="oem" primary="true" boot="oemboot/suse-13.2"/>
           </preferences>
-          <packages type="bootstrap">
-          </packages>
         </image>
     http_version: 
-  recorded_at: Wed, 02 Aug 2017 12:37:50 GMT
+  recorded_at: Tue, 12 Sep 2017 18:56:40 GMT
 - request:
     method: put
     uri: http://localhost:3200/source/home:tom/package_with_kiwi_image/package_with_kiwi_image.kiwi?user=tom
@@ -360,14 +356,12 @@ http_interactions:
         <image schemaversion="6.2" name="suse-13.2-live">
           <description type="system">
           </description>
-          <repository type="apt-deb">
-            <source path="http://"/>
+          <repository type="rpm-md">
+            <source path="obsrepositories:/"/>
           </repository>
           <preferences>
             <type image="oem" primary="true" boot="oemboot/suse-13.2"/>
           </preferences>
-          <packages type="bootstrap">
-          </packages>
         </image>
     headers:
       Content-Type:
@@ -375,7 +369,7 @@ http_interactions:
       Accept-Encoding:
       - identity
       Content-Length:
-      - '361'
+      - '326'
       Accept:
       - "*/*"
       User-Agent:
@@ -392,20 +386,20 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '203'
+      - '205'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="6" vrev="6">
-          <srcmd5>88792064750ef72970002ca9f6b87453</srcmd5>
+        <revision rev="80" vrev="80">
+          <srcmd5>2bc4020e2c447b650e17866e9c21b783</srcmd5>
           <version>unknown</version>
-          <time>1501677470</time>
+          <time>1505242600</time>
           <user>tom</user>
           <comment></comment>
           <requestid/>
         </revision>
     http_version: 
-  recorded_at: Wed, 02 Aug 2017 12:37:50 GMT
+  recorded_at: Tue, 12 Sep 2017 18:56:40 GMT
 - request:
     method: put
     uri: http://localhost:3200/source/home:tom/package_with_kiwi_image/_meta?user=tom
@@ -413,8 +407,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="package_with_kiwi_image" project="home:tom">
-          <title>A Many-Splendoured Thing</title>
-          <description>Dolor id sit architecto quibusdam nulla modi ipsa.</description>
+          <title>No Highway</title>
+          <description>Quia architecto similique et dolore eum iure mollitia.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -435,16 +429,16 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '193'
+      - '183'
     body:
       encoding: UTF-8
       string: |
         <package name="package_with_kiwi_image" project="home:tom">
-          <title>A Many-Splendoured Thing</title>
-          <description>Dolor id sit architecto quibusdam nulla modi ipsa.</description>
+          <title>No Highway</title>
+          <description>Quia architecto similique et dolore eum iure mollitia.</description>
         </package>
     http_version: 
-  recorded_at: Wed, 02 Aug 2017 12:37:50 GMT
+  recorded_at: Tue, 12 Sep 2017 18:56:40 GMT
 - request:
     method: get
     uri: http://localhost:3200/source/home:tom/package_with_kiwi_image
@@ -470,15 +464,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '232'
+      - '234'
     body:
       encoding: UTF-8
       string: |
-        <directory name="package_with_kiwi_image" rev="6" vrev="6" srcmd5="88792064750ef72970002ca9f6b87453">
-          <entry name="package_with_kiwi_image.kiwi" md5="4d00b9b2f2e5b4fa171a358f6896e0df" size="361" mtime="1501677470" />
+        <directory name="package_with_kiwi_image" rev="80" vrev="80" srcmd5="2bc4020e2c447b650e17866e9c21b783">
+          <entry name="package_with_kiwi_image.kiwi" md5="467dff19a0eaab7288f65cf0a47cc1f3" size="326" mtime="1505241820" />
         </directory>
     http_version: 
-  recorded_at: Wed, 02 Aug 2017 12:37:50 GMT
+  recorded_at: Tue, 12 Sep 2017 18:56:40 GMT
 - request:
     method: get
     uri: http://localhost:3200/source/home:tom/package_with_kiwi_image?nofilename=1&view=info&withchangesmd5=1
@@ -504,15 +498,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '197'
+      - '199'
     body:
       encoding: UTF-8
       string: |
-        <sourceinfo package="package_with_kiwi_image" rev="6" vrev="6" srcmd5="88792064750ef72970002ca9f6b87453" verifymd5="88792064750ef72970002ca9f6b87453">
-          <revtime>1501677470</revtime>
+        <sourceinfo package="package_with_kiwi_image" rev="80" vrev="80" srcmd5="2bc4020e2c447b650e17866e9c21b783" verifymd5="2bc4020e2c447b650e17866e9c21b783">
+          <revtime>1505242600</revtime>
         </sourceinfo>
     http_version: 
-  recorded_at: Wed, 02 Aug 2017 12:37:50 GMT
+  recorded_at: Tue, 12 Sep 2017 18:56:40 GMT
 - request:
     method: get
     uri: http://localhost:3200/source/home:tom/package_with_kiwi_image
@@ -538,15 +532,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '232'
+      - '234'
     body:
       encoding: UTF-8
       string: |
-        <directory name="package_with_kiwi_image" rev="6" vrev="6" srcmd5="88792064750ef72970002ca9f6b87453">
-          <entry name="package_with_kiwi_image.kiwi" md5="4d00b9b2f2e5b4fa171a358f6896e0df" size="361" mtime="1501677470" />
+        <directory name="package_with_kiwi_image" rev="80" vrev="80" srcmd5="2bc4020e2c447b650e17866e9c21b783">
+          <entry name="package_with_kiwi_image.kiwi" md5="467dff19a0eaab7288f65cf0a47cc1f3" size="326" mtime="1505241820" />
         </directory>
     http_version: 
-  recorded_at: Wed, 02 Aug 2017 12:37:50 GMT
+  recorded_at: Tue, 12 Sep 2017 18:56:40 GMT
 - request:
     method: post
     uri: http://localhost:3200/source/home:tom/package_with_kiwi_image?cmd=diff&linkrev=base&onlyissues=1&orev=0&view=xml
@@ -569,24 +563,24 @@ http_interactions:
     headers:
       Content-Type:
       - text/xml
+      Content-Length:
+      - '328'
       Cache-Control:
       - no-cache
       Connection:
       - close
-      Content-Length:
-      - '327'
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="6d51e9b385f6dd0d5fa00cba141d9fdf">
+        <sourcediff key="4351d3ab1e86ca9bea7c24a2e45a2f35">
           <old project="home:tom" package="package_with_kiwi_image" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e" />
-          <new project="home:tom" package="package_with_kiwi_image" rev="6" srcmd5="88792064750ef72970002ca9f6b87453" />
+          <new project="home:tom" package="package_with_kiwi_image" rev="78" srcmd5="2bc4020e2c447b650e17866e9c21b783" />
           <files />
           <issues>
           </issues>
         </sourcediff>
     http_version: 
-  recorded_at: Wed, 02 Aug 2017 12:37:51 GMT
+  recorded_at: Tue, 12 Sep 2017 18:56:40 GMT
 - request:
     method: get
     uri: http://localhost:3200/source/home:tom/package_with_kiwi_image
@@ -612,13 +606,13 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '232'
+      - '234'
     body:
       encoding: UTF-8
       string: |
-        <directory name="package_with_kiwi_image" rev="6" vrev="6" srcmd5="88792064750ef72970002ca9f6b87453">
-          <entry name="package_with_kiwi_image.kiwi" md5="4d00b9b2f2e5b4fa171a358f6896e0df" size="361" mtime="1501677470" />
+        <directory name="package_with_kiwi_image" rev="80" vrev="80" srcmd5="2bc4020e2c447b650e17866e9c21b783">
+          <entry name="package_with_kiwi_image.kiwi" md5="467dff19a0eaab7288f65cf0a47cc1f3" size="326" mtime="1505241820" />
         </directory>
     http_version: 
-  recorded_at: Wed, 02 Aug 2017 12:37:51 GMT
+  recorded_at: Tue, 12 Sep 2017 18:56:40 GMT
 recorded_with: VCR 3.0.3

--- a/src/api/spec/cassettes/Webui_Kiwi_ImagesController/POST_update/with_valid_repositories_data/with_use_project_repositories/1_3_2_2_3.yml
+++ b/src/api/spec/cassettes/Webui_Kiwi_ImagesController/POST_update/with_valid_repositories_data/with_use_project_repositories/1_3_2_2_3.yml
@@ -40,7 +40,7 @@ http_interactions:
           <person userid="tom" role="maintainer" />
         </project>
     http_version: 
-  recorded_at: Wed, 02 Aug 2017 12:37:51 GMT
+  recorded_at: Tue, 12 Sep 2017 18:56:40 GMT
 - request:
     method: put
     uri: http://localhost:3200/source/home:tom/package_with_kiwi_image/_meta?user=tom
@@ -48,8 +48,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="package_with_kiwi_image" project="home:tom">
-          <title>Look to Windward</title>
-          <description>Odio rerum beatae explicabo non minima pariatur nihil molestiae.</description>
+          <title>I Will Fear No Evil</title>
+          <description>Odio rerum architecto commodi in sed velit saepe.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -70,16 +70,16 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '199'
+      - '187'
     body:
       encoding: UTF-8
       string: |
         <package name="package_with_kiwi_image" project="home:tom">
-          <title>Look to Windward</title>
-          <description>Odio rerum beatae explicabo non minima pariatur nihil molestiae.</description>
+          <title>I Will Fear No Evil</title>
+          <description>Odio rerum architecto commodi in sed velit saepe.</description>
         </package>
     http_version: 
-  recorded_at: Wed, 02 Aug 2017 12:37:51 GMT
+  recorded_at: Tue, 12 Sep 2017 18:56:40 GMT
 - request:
     method: put
     uri: http://localhost:3200/source/home:tom/package_with_kiwi_image/_meta
@@ -87,8 +87,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="package_with_kiwi_image" project="home:tom">
-          <title>Look to Windward</title>
-          <description>Odio rerum beatae explicabo non minima pariatur nihil molestiae.</description>
+          <title>I Will Fear No Evil</title>
+          <description>Odio rerum architecto commodi in sed velit saepe.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -109,16 +109,16 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '199'
+      - '187'
     body:
       encoding: UTF-8
       string: |
         <package name="package_with_kiwi_image" project="home:tom">
-          <title>Look to Windward</title>
-          <description>Odio rerum beatae explicabo non minima pariatur nihil molestiae.</description>
+          <title>I Will Fear No Evil</title>
+          <description>Odio rerum architecto commodi in sed velit saepe.</description>
         </package>
     http_version: 
-  recorded_at: Wed, 02 Aug 2017 12:37:51 GMT
+  recorded_at: Tue, 12 Sep 2017 18:56:40 GMT
 - request:
     method: put
     uri: http://localhost:3200/source/home:tom/package_with_kiwi_image/package_with_kiwi_image.kiwi
@@ -132,8 +132,6 @@ http_interactions:
           <preferences>
             <type image="oem" primary="true" boot="oemboot/suse-13.2"/>
           </preferences>
-          <packages type="bootstrap">
-          </packages>
         </image>
     headers:
       Accept-Encoding:
@@ -154,20 +152,20 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '207'
+      - '209'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="7" vrev="7">
-          <srcmd5>3822662924706b810ffb158183355052</srcmd5>
+        <revision rev="81" vrev="81">
+          <srcmd5>82f39606fd3c729f7f16de7d227e6dae</srcmd5>
           <version>unknown</version>
-          <time>1501677471</time>
+          <time>1505242600</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
     http_version: 
-  recorded_at: Wed, 02 Aug 2017 12:37:51 GMT
+  recorded_at: Tue, 12 Sep 2017 18:56:40 GMT
 - request:
     method: put
     uri: http://localhost:3200/source/home:tom/package_with_kiwi_image/_meta?user=tom
@@ -175,8 +173,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="package_with_kiwi_image" project="home:tom">
-          <title>Look to Windward</title>
-          <description>Odio rerum beatae explicabo non minima pariatur nihil molestiae.</description>
+          <title>I Will Fear No Evil</title>
+          <description>Odio rerum architecto commodi in sed velit saepe.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -197,16 +195,16 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '199'
+      - '187'
     body:
       encoding: UTF-8
       string: |
         <package name="package_with_kiwi_image" project="home:tom">
-          <title>Look to Windward</title>
-          <description>Odio rerum beatae explicabo non minima pariatur nihil molestiae.</description>
+          <title>I Will Fear No Evil</title>
+          <description>Odio rerum architecto commodi in sed velit saepe.</description>
         </package>
     http_version: 
-  recorded_at: Wed, 02 Aug 2017 12:37:51 GMT
+  recorded_at: Tue, 12 Sep 2017 18:56:40 GMT
 - request:
     method: get
     uri: http://localhost:3200/source/home:tom/package_with_kiwi_image
@@ -232,15 +230,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '232'
+      - '234'
     body:
       encoding: UTF-8
       string: |
-        <directory name="package_with_kiwi_image" rev="7" vrev="7" srcmd5="3822662924706b810ffb158183355052">
-          <entry name="package_with_kiwi_image.kiwi" md5="3eb87e3299e4dbb72703842403c3dd21" size="286" mtime="1501677467" />
+        <directory name="package_with_kiwi_image" rev="81" vrev="81" srcmd5="82f39606fd3c729f7f16de7d227e6dae">
+          <entry name="package_with_kiwi_image.kiwi" md5="dda935f455dcd6607d83705328bee9df" size="242" mtime="1505241815" />
         </directory>
     http_version: 
-  recorded_at: Wed, 02 Aug 2017 12:37:51 GMT
+  recorded_at: Tue, 12 Sep 2017 18:56:40 GMT
 - request:
     method: get
     uri: http://localhost:3200/source/home:tom/package_with_kiwi_image
@@ -266,15 +264,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '232'
+      - '234'
     body:
       encoding: UTF-8
       string: |
-        <directory name="package_with_kiwi_image" rev="7" vrev="7" srcmd5="3822662924706b810ffb158183355052">
-          <entry name="package_with_kiwi_image.kiwi" md5="3eb87e3299e4dbb72703842403c3dd21" size="286" mtime="1501677467" />
+        <directory name="package_with_kiwi_image" rev="81" vrev="81" srcmd5="82f39606fd3c729f7f16de7d227e6dae">
+          <entry name="package_with_kiwi_image.kiwi" md5="dda935f455dcd6607d83705328bee9df" size="242" mtime="1505241815" />
         </directory>
     http_version: 
-  recorded_at: Wed, 02 Aug 2017 12:37:51 GMT
+  recorded_at: Tue, 12 Sep 2017 18:56:40 GMT
 - request:
     method: get
     uri: http://localhost:3200/source/home:tom/package_with_kiwi_image
@@ -300,15 +298,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '232'
+      - '234'
     body:
       encoding: UTF-8
       string: |
-        <directory name="package_with_kiwi_image" rev="7" vrev="7" srcmd5="3822662924706b810ffb158183355052">
-          <entry name="package_with_kiwi_image.kiwi" md5="3eb87e3299e4dbb72703842403c3dd21" size="286" mtime="1501677467" />
+        <directory name="package_with_kiwi_image" rev="81" vrev="81" srcmd5="82f39606fd3c729f7f16de7d227e6dae">
+          <entry name="package_with_kiwi_image.kiwi" md5="dda935f455dcd6607d83705328bee9df" size="242" mtime="1505241815" />
         </directory>
     http_version: 
-  recorded_at: Wed, 02 Aug 2017 12:37:51 GMT
+  recorded_at: Tue, 12 Sep 2017 18:56:40 GMT
 - request:
     method: get
     uri: http://localhost:3200/source/home:tom/package_with_kiwi_image/package_with_kiwi_image.kiwi
@@ -330,7 +328,7 @@ http_interactions:
       Content-Type:
       - application/octet-stream
       Content-Length:
-      - '286'
+      - '242'
       Cache-Control:
       - no-cache
       Connection:
@@ -345,11 +343,9 @@ http_interactions:
           <preferences>
             <type image="oem" primary="true" boot="oemboot/suse-13.2"/>
           </preferences>
-          <packages type="bootstrap">
-          </packages>
         </image>
     http_version: 
-  recorded_at: Wed, 02 Aug 2017 12:37:51 GMT
+  recorded_at: Tue, 12 Sep 2017 18:56:40 GMT
 - request:
     method: put
     uri: http://localhost:3200/source/home:tom/package_with_kiwi_image/package_with_kiwi_image.kiwi?user=tom
@@ -360,14 +356,12 @@ http_interactions:
         <image schemaversion="6.2" name="suse-13.2-live">
           <description type="system">
           </description>
-          <repository type="apt-deb">
-            <source path="http://"/>
+          <repository type="rpm-md">
+            <source path="obsrepositories:/"/>
           </repository>
           <preferences>
             <type image="oem" primary="true" boot="oemboot/suse-13.2"/>
           </preferences>
-          <packages type="bootstrap">
-          </packages>
         </image>
     headers:
       Content-Type:
@@ -375,7 +369,7 @@ http_interactions:
       Accept-Encoding:
       - identity
       Content-Length:
-      - '361'
+      - '326'
       Accept:
       - "*/*"
       User-Agent:
@@ -392,20 +386,20 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '203'
+      - '205'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="8" vrev="8">
-          <srcmd5>88792064750ef72970002ca9f6b87453</srcmd5>
+        <revision rev="82" vrev="82">
+          <srcmd5>2bc4020e2c447b650e17866e9c21b783</srcmd5>
           <version>unknown</version>
-          <time>1501677471</time>
+          <time>1505242600</time>
           <user>tom</user>
           <comment></comment>
           <requestid/>
         </revision>
     http_version: 
-  recorded_at: Wed, 02 Aug 2017 12:37:51 GMT
+  recorded_at: Tue, 12 Sep 2017 18:56:41 GMT
 - request:
     method: put
     uri: http://localhost:3200/source/home:tom/package_with_kiwi_image/_meta?user=tom
@@ -413,8 +407,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="package_with_kiwi_image" project="home:tom">
-          <title>Look to Windward</title>
-          <description>Odio rerum beatae explicabo non minima pariatur nihil molestiae.</description>
+          <title>I Will Fear No Evil</title>
+          <description>Odio rerum architecto commodi in sed velit saepe.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -435,16 +429,16 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '199'
+      - '187'
     body:
       encoding: UTF-8
       string: |
         <package name="package_with_kiwi_image" project="home:tom">
-          <title>Look to Windward</title>
-          <description>Odio rerum beatae explicabo non minima pariatur nihil molestiae.</description>
+          <title>I Will Fear No Evil</title>
+          <description>Odio rerum architecto commodi in sed velit saepe.</description>
         </package>
     http_version: 
-  recorded_at: Wed, 02 Aug 2017 12:37:51 GMT
+  recorded_at: Tue, 12 Sep 2017 18:56:41 GMT
 - request:
     method: get
     uri: http://localhost:3200/source/home:tom/package_with_kiwi_image
@@ -470,15 +464,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '232'
+      - '234'
     body:
       encoding: UTF-8
       string: |
-        <directory name="package_with_kiwi_image" rev="8" vrev="8" srcmd5="88792064750ef72970002ca9f6b87453">
-          <entry name="package_with_kiwi_image.kiwi" md5="4d00b9b2f2e5b4fa171a358f6896e0df" size="361" mtime="1501677470" />
+        <directory name="package_with_kiwi_image" rev="82" vrev="82" srcmd5="2bc4020e2c447b650e17866e9c21b783">
+          <entry name="package_with_kiwi_image.kiwi" md5="467dff19a0eaab7288f65cf0a47cc1f3" size="326" mtime="1505241820" />
         </directory>
     http_version: 
-  recorded_at: Wed, 02 Aug 2017 12:37:51 GMT
+  recorded_at: Tue, 12 Sep 2017 18:56:41 GMT
 - request:
     method: get
     uri: http://localhost:3200/source/home:tom/package_with_kiwi_image?nofilename=1&view=info&withchangesmd5=1
@@ -504,15 +498,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '197'
+      - '199'
     body:
       encoding: UTF-8
       string: |
-        <sourceinfo package="package_with_kiwi_image" rev="8" vrev="8" srcmd5="88792064750ef72970002ca9f6b87453" verifymd5="88792064750ef72970002ca9f6b87453">
-          <revtime>1501677471</revtime>
+        <sourceinfo package="package_with_kiwi_image" rev="82" vrev="82" srcmd5="2bc4020e2c447b650e17866e9c21b783" verifymd5="2bc4020e2c447b650e17866e9c21b783">
+          <revtime>1505242600</revtime>
         </sourceinfo>
     http_version: 
-  recorded_at: Wed, 02 Aug 2017 12:37:51 GMT
+  recorded_at: Tue, 12 Sep 2017 18:56:41 GMT
 - request:
     method: get
     uri: http://localhost:3200/source/home:tom/package_with_kiwi_image
@@ -538,15 +532,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '232'
+      - '234'
     body:
       encoding: UTF-8
       string: |
-        <directory name="package_with_kiwi_image" rev="8" vrev="8" srcmd5="88792064750ef72970002ca9f6b87453">
-          <entry name="package_with_kiwi_image.kiwi" md5="4d00b9b2f2e5b4fa171a358f6896e0df" size="361" mtime="1501677470" />
+        <directory name="package_with_kiwi_image" rev="82" vrev="82" srcmd5="2bc4020e2c447b650e17866e9c21b783">
+          <entry name="package_with_kiwi_image.kiwi" md5="467dff19a0eaab7288f65cf0a47cc1f3" size="326" mtime="1505241820" />
         </directory>
     http_version: 
-  recorded_at: Wed, 02 Aug 2017 12:37:51 GMT
+  recorded_at: Tue, 12 Sep 2017 18:56:41 GMT
 - request:
     method: post
     uri: http://localhost:3200/source/home:tom/package_with_kiwi_image?cmd=diff&linkrev=base&onlyissues=1&orev=0&view=xml
@@ -570,7 +564,7 @@ http_interactions:
       Content-Type:
       - text/xml
       Content-Length:
-      - '327'
+      - '328'
       Cache-Control:
       - no-cache
       Connection:
@@ -578,15 +572,15 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="6d51e9b385f6dd0d5fa00cba141d9fdf">
+        <sourcediff key="4351d3ab1e86ca9bea7c24a2e45a2f35">
           <old project="home:tom" package="package_with_kiwi_image" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e" />
-          <new project="home:tom" package="package_with_kiwi_image" rev="6" srcmd5="88792064750ef72970002ca9f6b87453" />
+          <new project="home:tom" package="package_with_kiwi_image" rev="78" srcmd5="2bc4020e2c447b650e17866e9c21b783" />
           <files />
           <issues>
           </issues>
         </sourcediff>
     http_version: 
-  recorded_at: Wed, 02 Aug 2017 12:37:51 GMT
+  recorded_at: Tue, 12 Sep 2017 18:56:41 GMT
 - request:
     method: get
     uri: http://localhost:3200/source/home:tom/package_with_kiwi_image
@@ -612,13 +606,13 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '232'
+      - '234'
     body:
       encoding: UTF-8
       string: |
-        <directory name="package_with_kiwi_image" rev="8" vrev="8" srcmd5="88792064750ef72970002ca9f6b87453">
-          <entry name="package_with_kiwi_image.kiwi" md5="4d00b9b2f2e5b4fa171a358f6896e0df" size="361" mtime="1501677470" />
+        <directory name="package_with_kiwi_image" rev="82" vrev="82" srcmd5="2bc4020e2c447b650e17866e9c21b783">
+          <entry name="package_with_kiwi_image.kiwi" md5="467dff19a0eaab7288f65cf0a47cc1f3" size="326" mtime="1505241820" />
         </directory>
     http_version: 
-  recorded_at: Wed, 02 Aug 2017 12:37:51 GMT
+  recorded_at: Tue, 12 Sep 2017 18:56:41 GMT
 recorded_with: VCR 3.0.3

--- a/src/api/spec/cassettes/Webui_Kiwi_ImagesController/POST_update/with_valid_repositories_data/without_use_project_repositories/1_3_2_1_1.yml
+++ b/src/api/spec/cassettes/Webui_Kiwi_ImagesController/POST_update/with_valid_repositories_data/without_use_project_repositories/1_3_2_1_1.yml
@@ -1,0 +1,618 @@
+---
+http_interactions:
+- request:
+    method: put
+    uri: http://localhost:3200/source/home:tom/_meta?user=tom
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:tom">
+          <title/>
+          <description/>
+          <person userid="tom" role="maintainer"/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '129'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:tom">
+          <title></title>
+          <description></description>
+          <person userid="tom" role="maintainer" />
+        </project>
+    http_version: 
+  recorded_at: Tue, 12 Sep 2017 18:56:37 GMT
+- request:
+    method: put
+    uri: http://localhost:3200/source/home:tom/package_with_kiwi_image/_meta?user=tom
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="package_with_kiwi_image" project="home:tom">
+          <title>The Wives of Bath</title>
+          <description>Tenetur sapiente neque illo quisquam saepe.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '179'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="package_with_kiwi_image" project="home:tom">
+          <title>The Wives of Bath</title>
+          <description>Tenetur sapiente neque illo quisquam saepe.</description>
+        </package>
+    http_version: 
+  recorded_at: Tue, 12 Sep 2017 18:56:38 GMT
+- request:
+    method: put
+    uri: http://localhost:3200/source/home:tom/package_with_kiwi_image/_meta
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="package_with_kiwi_image" project="home:tom">
+          <title>The Wives of Bath</title>
+          <description>Tenetur sapiente neque illo quisquam saepe.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '179'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="package_with_kiwi_image" project="home:tom">
+          <title>The Wives of Bath</title>
+          <description>Tenetur sapiente neque illo quisquam saepe.</description>
+        </package>
+    http_version: 
+  recorded_at: Tue, 12 Sep 2017 18:56:38 GMT
+- request:
+    method: put
+    uri: http://localhost:3200/source/home:tom/package_with_kiwi_image/package_with_kiwi_image.kiwi
+    body:
+      encoding: UTF-8
+      string: |
+        <?xml version="1.0" encoding="utf-8"?>
+        <image schemaversion="6.2" name="suse-13.2-live">
+          <description type="system">
+          </description>
+          <preferences>
+            <type image="oem" primary="true" boot="oemboot/suse-13.2"/>
+          </preferences>
+        </image>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '209'
+    body:
+      encoding: UTF-8
+      string: |
+        <revision rev="73" vrev="73">
+          <srcmd5>82f39606fd3c729f7f16de7d227e6dae</srcmd5>
+          <version>unknown</version>
+          <time>1505242598</time>
+          <user>unknown</user>
+          <comment></comment>
+          <requestid/>
+        </revision>
+    http_version: 
+  recorded_at: Tue, 12 Sep 2017 18:56:38 GMT
+- request:
+    method: put
+    uri: http://localhost:3200/source/home:tom/package_with_kiwi_image/_meta?user=tom
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="package_with_kiwi_image" project="home:tom">
+          <title>The Wives of Bath</title>
+          <description>Tenetur sapiente neque illo quisquam saepe.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '179'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="package_with_kiwi_image" project="home:tom">
+          <title>The Wives of Bath</title>
+          <description>Tenetur sapiente neque illo quisquam saepe.</description>
+        </package>
+    http_version: 
+  recorded_at: Tue, 12 Sep 2017 18:56:38 GMT
+- request:
+    method: get
+    uri: http://localhost:3200/source/home:tom/package_with_kiwi_image
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '234'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="package_with_kiwi_image" rev="73" vrev="73" srcmd5="82f39606fd3c729f7f16de7d227e6dae">
+          <entry name="package_with_kiwi_image.kiwi" md5="dda935f455dcd6607d83705328bee9df" size="242" mtime="1505241815" />
+        </directory>
+    http_version: 
+  recorded_at: Tue, 12 Sep 2017 18:56:38 GMT
+- request:
+    method: get
+    uri: http://localhost:3200/source/home:tom/package_with_kiwi_image
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '234'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="package_with_kiwi_image" rev="73" vrev="73" srcmd5="82f39606fd3c729f7f16de7d227e6dae">
+          <entry name="package_with_kiwi_image.kiwi" md5="dda935f455dcd6607d83705328bee9df" size="242" mtime="1505241815" />
+        </directory>
+    http_version: 
+  recorded_at: Tue, 12 Sep 2017 18:56:38 GMT
+- request:
+    method: get
+    uri: http://localhost:3200/source/home:tom/package_with_kiwi_image
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '234'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="package_with_kiwi_image" rev="73" vrev="73" srcmd5="82f39606fd3c729f7f16de7d227e6dae">
+          <entry name="package_with_kiwi_image.kiwi" md5="dda935f455dcd6607d83705328bee9df" size="242" mtime="1505241815" />
+        </directory>
+    http_version: 
+  recorded_at: Tue, 12 Sep 2017 18:56:38 GMT
+- request:
+    method: get
+    uri: http://localhost:3200/source/home:tom/package_with_kiwi_image/package_with_kiwi_image.kiwi
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/octet-stream
+      Content-Length:
+      - '242'
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+    body:
+      encoding: UTF-8
+      string: |
+        <?xml version="1.0" encoding="utf-8"?>
+        <image schemaversion="6.2" name="suse-13.2-live">
+          <description type="system">
+          </description>
+          <preferences>
+            <type image="oem" primary="true" boot="oemboot/suse-13.2"/>
+          </preferences>
+        </image>
+    http_version: 
+  recorded_at: Tue, 12 Sep 2017 18:56:38 GMT
+- request:
+    method: put
+    uri: http://localhost:3200/source/home:tom/package_with_kiwi_image/package_with_kiwi_image.kiwi?user=tom
+    body:
+      encoding: UTF-8
+      string: |
+        <?xml version="1.0" encoding="utf-8"?>
+        <image schemaversion="6.2" name="suse-13.2-live">
+          <description type="system">
+          </description>
+          <repository type="apt-deb">
+            <source path="http://"/>
+          </repository>
+          <preferences>
+            <type image="oem" primary="true" boot="oemboot/suse-13.2"/>
+          </preferences>
+        </image>
+    headers:
+      Content-Type:
+      - text/plain
+      Accept-Encoding:
+      - identity
+      Content-Length:
+      - '317'
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '205'
+    body:
+      encoding: UTF-8
+      string: |
+        <revision rev="74" vrev="74">
+          <srcmd5>991fe64afaa493a2c28cd732651edc5f</srcmd5>
+          <version>unknown</version>
+          <time>1505242598</time>
+          <user>tom</user>
+          <comment></comment>
+          <requestid/>
+        </revision>
+    http_version: 
+  recorded_at: Tue, 12 Sep 2017 18:56:38 GMT
+- request:
+    method: put
+    uri: http://localhost:3200/source/home:tom/package_with_kiwi_image/_meta?user=tom
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="package_with_kiwi_image" project="home:tom">
+          <title>The Wives of Bath</title>
+          <description>Tenetur sapiente neque illo quisquam saepe.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '179'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="package_with_kiwi_image" project="home:tom">
+          <title>The Wives of Bath</title>
+          <description>Tenetur sapiente neque illo quisquam saepe.</description>
+        </package>
+    http_version: 
+  recorded_at: Tue, 12 Sep 2017 18:56:38 GMT
+- request:
+    method: get
+    uri: http://localhost:3200/source/home:tom/package_with_kiwi_image
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '234'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="package_with_kiwi_image" rev="74" vrev="74" srcmd5="991fe64afaa493a2c28cd732651edc5f">
+          <entry name="package_with_kiwi_image.kiwi" md5="488c7ab58e125fd012fb488b9c0adf1b" size="317" mtime="1505241819" />
+        </directory>
+    http_version: 
+  recorded_at: Tue, 12 Sep 2017 18:56:38 GMT
+- request:
+    method: get
+    uri: http://localhost:3200/source/home:tom/package_with_kiwi_image?nofilename=1&view=info&withchangesmd5=1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '199'
+    body:
+      encoding: UTF-8
+      string: |
+        <sourceinfo package="package_with_kiwi_image" rev="74" vrev="74" srcmd5="991fe64afaa493a2c28cd732651edc5f" verifymd5="991fe64afaa493a2c28cd732651edc5f">
+          <revtime>1505242598</revtime>
+        </sourceinfo>
+    http_version: 
+  recorded_at: Tue, 12 Sep 2017 18:56:38 GMT
+- request:
+    method: get
+    uri: http://localhost:3200/source/home:tom/package_with_kiwi_image
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '234'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="package_with_kiwi_image" rev="74" vrev="74" srcmd5="991fe64afaa493a2c28cd732651edc5f">
+          <entry name="package_with_kiwi_image.kiwi" md5="488c7ab58e125fd012fb488b9c0adf1b" size="317" mtime="1505241819" />
+        </directory>
+    http_version: 
+  recorded_at: Tue, 12 Sep 2017 18:56:38 GMT
+- request:
+    method: post
+    uri: http://localhost:3200/source/home:tom/package_with_kiwi_image?cmd=diff&linkrev=base&onlyissues=1&orev=0&view=xml
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Content-Type:
+      - application/octet-stream
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '328'
+    body:
+      encoding: UTF-8
+      string: |
+        <sourcediff key="6658dc1e9e4e51e6fb22977508e93347">
+          <old project="home:tom" package="package_with_kiwi_image" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e" />
+          <new project="home:tom" package="package_with_kiwi_image" rev="74" srcmd5="991fe64afaa493a2c28cd732651edc5f" />
+          <files />
+          <issues>
+          </issues>
+        </sourcediff>
+    http_version: 
+  recorded_at: Tue, 12 Sep 2017 18:56:38 GMT
+- request:
+    method: get
+    uri: http://localhost:3200/source/home:tom/package_with_kiwi_image
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '234'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="package_with_kiwi_image" rev="74" vrev="74" srcmd5="991fe64afaa493a2c28cd732651edc5f">
+          <entry name="package_with_kiwi_image.kiwi" md5="488c7ab58e125fd012fb488b9c0adf1b" size="317" mtime="1505241819" />
+        </directory>
+    http_version: 
+  recorded_at: Tue, 12 Sep 2017 18:56:38 GMT
+recorded_with: VCR 3.0.3

--- a/src/api/spec/cassettes/Webui_Kiwi_ImagesController/POST_update/with_valid_repositories_data/without_use_project_repositories/1_3_2_1_2.yml
+++ b/src/api/spec/cassettes/Webui_Kiwi_ImagesController/POST_update/with_valid_repositories_data/without_use_project_repositories/1_3_2_1_2.yml
@@ -1,0 +1,618 @@
+---
+http_interactions:
+- request:
+    method: put
+    uri: http://localhost:3200/source/home:tom/_meta?user=tom
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:tom">
+          <title/>
+          <description/>
+          <person userid="tom" role="maintainer"/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '129'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:tom">
+          <title></title>
+          <description></description>
+          <person userid="tom" role="maintainer" />
+        </project>
+    http_version: 
+  recorded_at: Tue, 12 Sep 2017 18:56:38 GMT
+- request:
+    method: put
+    uri: http://localhost:3200/source/home:tom/package_with_kiwi_image/_meta?user=tom
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="package_with_kiwi_image" project="home:tom">
+          <title>Surprised by Joy</title>
+          <description>Odit ipsam commodi omnis ut expedita voluptatem.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '183'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="package_with_kiwi_image" project="home:tom">
+          <title>Surprised by Joy</title>
+          <description>Odit ipsam commodi omnis ut expedita voluptatem.</description>
+        </package>
+    http_version: 
+  recorded_at: Tue, 12 Sep 2017 18:56:39 GMT
+- request:
+    method: put
+    uri: http://localhost:3200/source/home:tom/package_with_kiwi_image/_meta
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="package_with_kiwi_image" project="home:tom">
+          <title>Surprised by Joy</title>
+          <description>Odit ipsam commodi omnis ut expedita voluptatem.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '183'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="package_with_kiwi_image" project="home:tom">
+          <title>Surprised by Joy</title>
+          <description>Odit ipsam commodi omnis ut expedita voluptatem.</description>
+        </package>
+    http_version: 
+  recorded_at: Tue, 12 Sep 2017 18:56:39 GMT
+- request:
+    method: put
+    uri: http://localhost:3200/source/home:tom/package_with_kiwi_image/package_with_kiwi_image.kiwi
+    body:
+      encoding: UTF-8
+      string: |
+        <?xml version="1.0" encoding="utf-8"?>
+        <image schemaversion="6.2" name="suse-13.2-live">
+          <description type="system">
+          </description>
+          <preferences>
+            <type image="oem" primary="true" boot="oemboot/suse-13.2"/>
+          </preferences>
+        </image>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '209'
+    body:
+      encoding: UTF-8
+      string: |
+        <revision rev="75" vrev="75">
+          <srcmd5>82f39606fd3c729f7f16de7d227e6dae</srcmd5>
+          <version>unknown</version>
+          <time>1505242599</time>
+          <user>unknown</user>
+          <comment></comment>
+          <requestid/>
+        </revision>
+    http_version: 
+  recorded_at: Tue, 12 Sep 2017 18:56:39 GMT
+- request:
+    method: put
+    uri: http://localhost:3200/source/home:tom/package_with_kiwi_image/_meta?user=tom
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="package_with_kiwi_image" project="home:tom">
+          <title>Surprised by Joy</title>
+          <description>Odit ipsam commodi omnis ut expedita voluptatem.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '183'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="package_with_kiwi_image" project="home:tom">
+          <title>Surprised by Joy</title>
+          <description>Odit ipsam commodi omnis ut expedita voluptatem.</description>
+        </package>
+    http_version: 
+  recorded_at: Tue, 12 Sep 2017 18:56:39 GMT
+- request:
+    method: get
+    uri: http://localhost:3200/source/home:tom/package_with_kiwi_image
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '234'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="package_with_kiwi_image" rev="75" vrev="75" srcmd5="82f39606fd3c729f7f16de7d227e6dae">
+          <entry name="package_with_kiwi_image.kiwi" md5="dda935f455dcd6607d83705328bee9df" size="242" mtime="1505241815" />
+        </directory>
+    http_version: 
+  recorded_at: Tue, 12 Sep 2017 18:56:39 GMT
+- request:
+    method: get
+    uri: http://localhost:3200/source/home:tom/package_with_kiwi_image
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '234'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="package_with_kiwi_image" rev="75" vrev="75" srcmd5="82f39606fd3c729f7f16de7d227e6dae">
+          <entry name="package_with_kiwi_image.kiwi" md5="dda935f455dcd6607d83705328bee9df" size="242" mtime="1505241815" />
+        </directory>
+    http_version: 
+  recorded_at: Tue, 12 Sep 2017 18:56:39 GMT
+- request:
+    method: get
+    uri: http://localhost:3200/source/home:tom/package_with_kiwi_image
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '234'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="package_with_kiwi_image" rev="75" vrev="75" srcmd5="82f39606fd3c729f7f16de7d227e6dae">
+          <entry name="package_with_kiwi_image.kiwi" md5="dda935f455dcd6607d83705328bee9df" size="242" mtime="1505241815" />
+        </directory>
+    http_version: 
+  recorded_at: Tue, 12 Sep 2017 18:56:39 GMT
+- request:
+    method: get
+    uri: http://localhost:3200/source/home:tom/package_with_kiwi_image/package_with_kiwi_image.kiwi
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/octet-stream
+      Content-Length:
+      - '242'
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+    body:
+      encoding: UTF-8
+      string: |
+        <?xml version="1.0" encoding="utf-8"?>
+        <image schemaversion="6.2" name="suse-13.2-live">
+          <description type="system">
+          </description>
+          <preferences>
+            <type image="oem" primary="true" boot="oemboot/suse-13.2"/>
+          </preferences>
+        </image>
+    http_version: 
+  recorded_at: Tue, 12 Sep 2017 18:56:39 GMT
+- request:
+    method: put
+    uri: http://localhost:3200/source/home:tom/package_with_kiwi_image/package_with_kiwi_image.kiwi?user=tom
+    body:
+      encoding: UTF-8
+      string: |
+        <?xml version="1.0" encoding="utf-8"?>
+        <image schemaversion="6.2" name="suse-13.2-live">
+          <description type="system">
+          </description>
+          <repository type="apt-deb">
+            <source path="http://"/>
+          </repository>
+          <preferences>
+            <type image="oem" primary="true" boot="oemboot/suse-13.2"/>
+          </preferences>
+        </image>
+    headers:
+      Content-Type:
+      - text/plain
+      Accept-Encoding:
+      - identity
+      Content-Length:
+      - '317'
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '205'
+    body:
+      encoding: UTF-8
+      string: |
+        <revision rev="76" vrev="76">
+          <srcmd5>991fe64afaa493a2c28cd732651edc5f</srcmd5>
+          <version>unknown</version>
+          <time>1505242599</time>
+          <user>tom</user>
+          <comment></comment>
+          <requestid/>
+        </revision>
+    http_version: 
+  recorded_at: Tue, 12 Sep 2017 18:56:39 GMT
+- request:
+    method: put
+    uri: http://localhost:3200/source/home:tom/package_with_kiwi_image/_meta?user=tom
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="package_with_kiwi_image" project="home:tom">
+          <title>Surprised by Joy</title>
+          <description>Odit ipsam commodi omnis ut expedita voluptatem.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '183'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="package_with_kiwi_image" project="home:tom">
+          <title>Surprised by Joy</title>
+          <description>Odit ipsam commodi omnis ut expedita voluptatem.</description>
+        </package>
+    http_version: 
+  recorded_at: Tue, 12 Sep 2017 18:56:39 GMT
+- request:
+    method: get
+    uri: http://localhost:3200/source/home:tom/package_with_kiwi_image
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '234'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="package_with_kiwi_image" rev="76" vrev="76" srcmd5="991fe64afaa493a2c28cd732651edc5f">
+          <entry name="package_with_kiwi_image.kiwi" md5="488c7ab58e125fd012fb488b9c0adf1b" size="317" mtime="1505241819" />
+        </directory>
+    http_version: 
+  recorded_at: Tue, 12 Sep 2017 18:56:39 GMT
+- request:
+    method: get
+    uri: http://localhost:3200/source/home:tom/package_with_kiwi_image?nofilename=1&view=info&withchangesmd5=1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '199'
+    body:
+      encoding: UTF-8
+      string: |
+        <sourceinfo package="package_with_kiwi_image" rev="76" vrev="76" srcmd5="991fe64afaa493a2c28cd732651edc5f" verifymd5="991fe64afaa493a2c28cd732651edc5f">
+          <revtime>1505242599</revtime>
+        </sourceinfo>
+    http_version: 
+  recorded_at: Tue, 12 Sep 2017 18:56:39 GMT
+- request:
+    method: get
+    uri: http://localhost:3200/source/home:tom/package_with_kiwi_image
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '234'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="package_with_kiwi_image" rev="76" vrev="76" srcmd5="991fe64afaa493a2c28cd732651edc5f">
+          <entry name="package_with_kiwi_image.kiwi" md5="488c7ab58e125fd012fb488b9c0adf1b" size="317" mtime="1505241819" />
+        </directory>
+    http_version: 
+  recorded_at: Tue, 12 Sep 2017 18:56:39 GMT
+- request:
+    method: post
+    uri: http://localhost:3200/source/home:tom/package_with_kiwi_image?cmd=diff&linkrev=base&onlyissues=1&orev=0&view=xml
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Content-Type:
+      - application/octet-stream
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Content-Length:
+      - '328'
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+    body:
+      encoding: UTF-8
+      string: |
+        <sourcediff key="6658dc1e9e4e51e6fb22977508e93347">
+          <old project="home:tom" package="package_with_kiwi_image" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e" />
+          <new project="home:tom" package="package_with_kiwi_image" rev="74" srcmd5="991fe64afaa493a2c28cd732651edc5f" />
+          <files />
+          <issues>
+          </issues>
+        </sourcediff>
+    http_version: 
+  recorded_at: Tue, 12 Sep 2017 18:56:39 GMT
+- request:
+    method: get
+    uri: http://localhost:3200/source/home:tom/package_with_kiwi_image
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '234'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="package_with_kiwi_image" rev="76" vrev="76" srcmd5="991fe64afaa493a2c28cd732651edc5f">
+          <entry name="package_with_kiwi_image.kiwi" md5="488c7ab58e125fd012fb488b9c0adf1b" size="317" mtime="1505241819" />
+        </directory>
+    http_version: 
+  recorded_at: Tue, 12 Sep 2017 18:56:39 GMT
+recorded_with: VCR 3.0.3

--- a/src/api/spec/models/kiwi/image_spec.rb
+++ b/src/api/spec/models/kiwi/image_spec.rb
@@ -116,6 +116,40 @@ RSpec.describe Kiwi::Image, type: :model, vcr: true do
       end
     end
 
+    context 'with source_path' do
+      context 'obsrepositories' do
+        subject { Kiwi::Image.build_from_xml(kiwi_xml_with_obsrepositories, 'some_md5') }
+
+        it { expect(subject.valid?).to be_truthy }
+        it { expect(subject.use_project_repositories?).to be_truthy }
+
+        it { expect(subject.repositories.length).to eq(0) }
+      end
+
+      context 'obsrepositories and others' do
+        subject { Kiwi::Image.build_from_xml(invalid_kiwi_xml_with_obsrepositories, 'some_md5') }
+
+        it { expect(subject.valid?).to be_falsey }
+        it { expect(subject.use_project_repositories?).to be_truthy }
+
+        it { expect(subject.repositories.length).to eq(1) }
+        it 'parses the repository elements of the xml into a KiwiImage model' do
+          expect(subject.repositories[0]).to have_attributes(
+            source_path: 'http://download.opensuse.org/update/13.2/',
+            repo_type: 'apt-deb',
+            priority: 10,
+            order: 1,
+            alias: 'debian',
+            imageinclude: true,
+            password: '123456',
+            prefer_license: true,
+            replaceable: true,
+            username: 'Tom'
+          )
+        end
+      end
+    end
+
     context 'with an invalid Kiwi File' do
       subject { Kiwi::Image.build_from_xml(invalid_kiwi_xml, 'some_md5') }
 

--- a/src/api/spec/support/shared_contexts/a_kiwi_image_xml.rb
+++ b/src/api/spec/support/shared_contexts/a_kiwi_image_xml.rb
@@ -49,4 +49,46 @@ RSpec.shared_context 'a kiwi image xml' do
 </image>
     XML
   end
+
+  let(:kiwi_xml_with_obsrepositories) do
+    <<-XML
+<?xml version="1.0" encoding="UTF-8"?>
+<image name="Christians_openSUSE_13.2_JeOS" displayname="Christians_openSUSE_13.2_JeOS" schemaversion="5.2">
+  <description type="system">
+    <author>Christian Bruckmayer</author>
+    <contact>noemail@example.com</contact>
+    <specification>Tiny, minimalistic appliances</specification>
+  </description>
+  <packages type="image" patternType="onlyRequired">
+    <package name="e2fsprogs"/>
+    <package name="aaa_base"/>
+    <package name="branding-openSUSE"/>
+    <package name="patterns-openSUSE-base"/>
+    <package name="grub2"/>
+    <package name="hwinfo"/>
+    <package name="iputils"/>
+    <package name="kernel-default"/>
+    <package name="netcfg"/>
+    <package name="openSUSE-build-key"/>
+    <package name="openssh"/>
+    <package name="plymouth"/>
+    <package name="polkit-default-privs"/>
+    <package name="rpcbind"/>
+    <package name="syslog-ng"/>
+    <package name="vim"/>
+    <package name="zypper"/>
+    <package name="timezone"/>
+    <package name="openSUSE-release-dvd"/>
+    <package name="gfxboot-devel" bootinclude="true"/>
+  </packages>
+  <packages type="delete">
+    <package name="e2fsprogss"/>
+    <package name="bbb_base"/>
+  </packages>
+  <repository type="rpm-md">
+    <source path="obsrepositories:/"/>
+  </repository>
+</image>
+    XML
+  end
 end

--- a/src/api/spec/support/shared_contexts/an_invalid_kiwi_image_xml.rb
+++ b/src/api/spec/support/shared_contexts/an_invalid_kiwi_image_xml.rb
@@ -45,4 +45,49 @@ RSpec.shared_context 'an invalid kiwi image xml' do
 </image>
     XML
   end
+
+  let(:invalid_kiwi_xml_with_obsrepositories) do
+    <<-XML
+<?xml version="1.0" encoding="UTF-8"?>
+<image name="Christians_openSUSE_13.2_JeOS" displayname="Christians_openSUSE_13.2_JeOS" schemaversion="5.2">
+  <description type="system">
+    <author>Christian Bruckmayer</author>
+    <contact>noemail@example.com</contact>
+    <specification>Tiny, minimalistic appliances</specification>
+  </description>
+  <packages type="image" patternType="onlyRequired">
+    <package name="e2fsprogs"/>
+    <package name="aaa_base"/>
+    <package name="branding-openSUSE"/>
+    <package name="patterns-openSUSE-base"/>
+    <package name="grub2"/>
+    <package name="hwinfo"/>
+    <package name="iputils"/>
+    <package name="kernel-default"/>
+    <package name="netcfg"/>
+    <package name="openSUSE-build-key"/>
+    <package name="openssh"/>
+    <package name="plymouth"/>
+    <package name="polkit-default-privs"/>
+    <package name="rpcbind"/>
+    <package name="syslog-ng"/>
+    <package name="vim"/>
+    <package name="zypper"/>
+    <package name="timezone"/>
+    <package name="openSUSE-release-dvd"/>
+    <package name="gfxboot-devel" bootinclude="true"/>
+  </packages>
+  <packages type="delete">
+    <package name="e2fsprogss"/>
+    <package name="bbb_base"/>
+  </packages>
+  <repository type="apt-deb" priority="10" alias="debian" imageinclude="true" password="123456" prefer-license="true" status="replaceable" username="Tom">
+    <source path="http://download.opensuse.org/update/13.2/"/>
+  </repository>
+  <repository type="rpm-md">
+    <source path="obsrepositories:/"/>
+  </repository>
+</image>
+    XML
+  end
 end


### PR DESCRIPTION
We had a checkbox where the users can check it to use the repositories from the current project.

![screenshot from 2017-09-05 13-04-46](https://user-images.githubusercontent.com/1212806/30112892-29d973d6-9313-11e7-8ce4-3b58a4765593.png)

When this option is checked we hide the others repositories because it's not allowed to use `obsrepositories` with others repositories at the same time. When the whole Kiwi Image is saved, these repositories will be deleted.

![screenshot from 2017-09-05 15-31-19](https://user-images.githubusercontent.com/1212806/30112907-36ef180a-9313-11e7-9e2c-fc59665d2daf.png)

![screenshot from 2017-09-06 12-40-34](https://user-images.githubusercontent.com/1212806/30112920-408d2f6e-9313-11e7-8871-6f236a323129.png)

Also when we try to import a kiwi file with multiple repositories and one of them has as `source_path='obsrepositories:/'`, it will be redirected to the view file to indicated what happen.

![screenshot from 2017-09-06 15-04-11](https://user-images.githubusercontent.com/1212806/30113428-fa11f2d4-9314-11e7-937c-991538bb3fc0.png)
