### PR TITLE
[webui] Get rid of error when flags are nil

### DIFF
--- a/src/api/app/views/shared/_repositories_flag_table.html.haml
+++ b/src/api/app/views/shared/_repositories_flag_table.html.haml
@@ -12,16 +12,17 @@
       %td{ class: index == 0 ? 'allrow' : 'allcolum' }
         = render partial: 'shared/repositories_flag_table_column', locals: { flag: flag }
   - @project.repositories.each do |repository|
-    %tr
-      %td.reponame
-        %strong{ title: repository.name }
-          - if @package
-            = link_to(elide(repository.name, 18), action: 'binaries', controller: :package, project: @project, package: @package, repository: repository.name)
-          - else
-            = link_to(elide(repository.name, 18), action: :state, project: @project, repository: repository.name)
-      - flags[repository.name].each_with_index do |flag, index|
-        %td{ class: index == 0 ? 'allrow' : nil }
-          = render partial: 'shared/repositories_flag_table_column', locals: { flag: flag }
+    - if flags[repository.name]
+      %tr
+        %td.reponame
+          %strong{ title: repository.name }
+            - if @package
+              = link_to(elide(repository.name, 18), action: 'binaries', controller: :package, project: @project, package: @package, repository: repository.name)
+            - else
+              = link_to(elide(repository.name, 18), action: :state, project: @project, repository: repository.name)
+        - flags[repository.name].each_with_index do |flag, index|
+          %td{ class: index == 0 ? 'allrow' : nil }
+            = render partial: 'shared/repositories_flag_table_column', locals: { flag: flag }
 - content_for :ready_function do
   :plain
     $( '.flag_spinner_trigger_#{h(first_flag)}' ).click(function() {


### PR DESCRIPTION
Get rid of `undefined method 'each_with_index' for nil:NilClass` error.
"project" or "package" flags could be nil for a certain repository.

This should fix #2200

Mob-programmed with @DavidKang 