### PR TITLE
Make easy to add OBS repositories in kiwi editor

### DIFF
--- a/src/api/app/assets/javascripts/webui/application/kiwi_editor.js
+++ b/src/api/app/assets/javascripts/webui/application/kiwi_editor.js
@@ -29,7 +29,14 @@ function enableSave(){
 function editDialog(){
   var fields = $(this).parents('.nested-fields');
   var dialog = fields.find('.dialog');
+  var normal_mode = fields.find('.normal-mode');
+  var expert_mode = fields.find('.expert-mode');
+
   dialog.removeClass('hidden');
+  normal_mode.show();
+  expert_mode.hide();
+  updateModeButton(fields);
+
   $('.overlay').show();
 }
 
@@ -122,6 +129,23 @@ function addDefault(dialog) {
   });
 }
 
+function repositoryModeToggle() {
+  var fields = $(this).parents('.nested-fields');
+
+  var normal_mode = fields.find('.normal-mode');
+  var expert_mode = fields.find('.expert-mode');
+  normal_mode.toggle();
+  expert_mode.toggle();
+
+  updateModeButton(fields);
+}
+
+function updateModeButton(fields) {
+  var toggle_mode_button = fields.find('.kiwi-repository-mode-toggle');
+  var expert_mode = fields.find('.expert-mode');
+  toggle_mode_button.text(expert_mode.is(":visible") ? "Basic Mode" : "Expert Mode");
+}
+
 function hoverListItem() {
   $(this).find('.kiwi_actions').toggle();
 }
@@ -142,6 +166,7 @@ $(document).ready(function(){
   $('.repository_edit, .package_edit').click(editDialog);
   $('#kiwi-repositories-list .close-dialog, #kiwi-packages-list .close-dialog').click(closeDialog);
   $('.revert-dialog').click(revertDialog);
+  $('.kiwi-repository-mode-toggle').click(repositoryModeToggle);
   $('#kiwi-repositories-list .kiwi_list_item, #kiwi-packages-list .kiwi_list_item').hover(hoverListItem, hoverListItem);
 
   // After inserting new repositories add the Callbacks
@@ -157,6 +182,7 @@ $(document).ready(function(){
     $(addedFields).find('.repository_edit').click(editDialog);
     $(addedFields).find('.close-dialog').click(closeDialog);
     $(addedFields).find('.revert-dialog').click(revertDialog);
+    $(addedFields).find('.kiwi-repository-mode-toggle').click(repositoryModeToggle);
     $(addedFields).find('.kiwi_list_item').hover(hoverListItem, hoverListItem);
   });
 

--- a/src/api/app/assets/stylesheets/webui/application/dialog.scss
+++ b/src/api/app/assets/stylesheets/webui/application/dialog.scss
@@ -16,7 +16,7 @@
   .dialog-content {
     overflow: auto;
     max-height: 400px;
-    input:not([type=submit]):not([type=file]) {
+    input:not([type=submit]):not([type=file]):not([type=checkbox]) {
       width: 95%;
     }
   }
@@ -42,7 +42,7 @@
       }
     }
 
-    .close-dialog, .revert-dialog {
+    a {
       border-radius: 5px;
       border: 1px solid #eee;
     }

--- a/src/api/app/assets/stylesheets/webui/application/our-own-jquery-ui.scss
+++ b/src/api/app/assets/stylesheets/webui/application/our-own-jquery-ui.scss
@@ -60,6 +60,9 @@
   float: left;
   clear: left;
   width: 100%;
+  &:hover {
+    background-color: #eee;
+  }
 }
 
 .ui-menu .ui-menu-item a.ui-state-hover,
@@ -82,3 +85,15 @@ body .ui-tooltip {
         border-width: 2px;
 }
 
+.ui-front {
+  z-index: 100;
+}
+
+.ui-widget-content {
+  border: 1px solid #aaaaaa;
+  background: #ffffff;
+  color: #222222;
+}
+.ui-widget-content a {
+  color: #222222;
+}

--- a/src/api/app/models/kiwi/repository.rb
+++ b/src/api/app/models/kiwi/repository.rb
@@ -74,6 +74,20 @@ class Kiwi::Repository < ApplicationRecord
     builder.to_xml save_with: Nokogiri::XML::Node::SaveOptions::NO_DECLARATION | Nokogiri::XML::Node::SaveOptions::FORMAT
   end
 
+  def obs_source_path?
+    source_path && source_path.match(/^obs:\/\/([^\/]+)\/([^\/]+)$/).present?
+  end
+
+  def project_for_type_obs
+    return '' unless source_path
+    source_path.match(/^obs:\/\/([^\/]+)\/([^\/]+)$/).try(:[], 1)
+  end
+
+  def repository_for_type_obs
+    return '' unless source_path
+    source_path.match(/^obs:\/\/([^\/]+)\/([^\/]+)$/).try(:[], 2)
+  end
+
   #### Alias of methods
 end
 

--- a/src/api/app/views/webui/kiwi/images/_repository_fields.html.haml
+++ b/src/api/app/views/webui/kiwi/images/_repository_fields.html.haml
@@ -13,7 +13,7 @@
         %p
           = f.hidden_field :order
           = f.label :repo_type, 'Type:'
-          = f.select :repo_type, options_for_select(Kiwi::Repository::REPO_TYPES), {}, { data: {default: f.object.repo_type }}
+          = f.select :repo_type, Kiwi::Repository::REPO_TYPES, {}, { data: {default: f.object.repo_type }}
           = f.label :priority, 'Priority:'
           = f.number_field :priority, maxlength: 4, style: "width: 50px", in: 0...99, data: { default: f.object.priority }
           = f.label :alias, 'Alias:'

--- a/src/api/app/views/webui/kiwi/images/_repository_fields.html.haml
+++ b/src/api/app/views/webui/kiwi/images/_repository_fields.html.haml
@@ -10,38 +10,43 @@
       %h2.box-header #{f.object.source_path.present? ? 'Edit' : 'Add'} repository
 
       .dialog-content
-        %p
-          = f.hidden_field :order
-          = f.label :repo_type, 'Type:'
-          = f.select :repo_type, Kiwi::Repository::REPO_TYPES, {}, { data: {default: f.object.repo_type }}
-          = f.label :priority, 'Priority:'
-          = f.number_field :priority, maxlength: 4, style: "width: 50px", in: 0...99, data: { default: f.object.priority }
-          = f.label :alias, 'Alias:'
-          = f.text_field :alias,  style: "width: 170px", data: { default: f.object.alias }
-        %p
-          = f.label :source_path, 'Source:'
-          = f.text_field :source_path, data: { default: f.object.source_path }
-          %span.small-text
-            Write a valid source path
+        .normal-mode
+          %p
+            This is the normal mode!
+        .expert-mode.hidden
+          %p
+            = f.hidden_field :order
+            = f.label :repo_type, 'Type:'
+            = f.select :repo_type, Kiwi::Repository::REPO_TYPES, {}, { data: {default: f.object.repo_type }}
+            = f.label :priority, 'Priority:'
+            = f.number_field :priority, maxlength: 4, style: "width: 50px", in: 0...99, data: { default: f.object.priority }
+            = f.label :alias, 'Alias:'
+            = f.text_field :alias,  style: "width: 170px", data: { default: f.object.alias }
+          %p
+            = f.label :source_path, 'Source:'
+            = f.text_field :source_path, data: { default: f.object.source_path }
+            %span.small-text
+              Write a valid source path
 
-        %p
-          = f.label :username, 'User:'
-          = f.text_field :username,  style: "width: 170px", data: { default: f.object.username }
-          = f.label :password, 'Password:'
-          = f.text_field :password,  style: "width: 170px", data: { default: f.object.password }
+          %p
+            = f.label :username, 'User:'
+            = f.text_field :username,  style: "width: 170px", data: { default: f.object.username }
+            = f.label :password, 'Password:'
+            = f.text_field :password,  style: "width: 170px", data: { default: f.object.password }
 
-      %p
-        = f.check_box :prefer_license, data: { default: f.object.prefer_license }
-        = f.label :prefer_license
-        = f.check_box :imageinclude, data: { default: f.object.imageinclude }
-        = f.label :imageinclude, 'Image include'
-        = f.check_box :replaceable, data: { default: f.object.replaceable }
-        = f.label :replaceable
+          %p
+            = f.check_box :prefer_license, data: { default: f.object.prefer_license }
+            = f.label :prefer_license
+            = f.check_box :imageinclude, data: { default: f.object.imageinclude }
+            = f.label :imageinclude, 'Image include'
+            = f.check_box :replaceable, data: { default: f.object.replaceable }
+            = f.label :replaceable
 
       %p#flash-messages
         %p.ui-state-error.ui-widget-shadow.hidden
           The source path can not be empty!
 
       .dialog-buttons
+        = link_to('Expert Mode', '#', title: 'Mode Toggle', class: 'kiwi-repository-mode-toggle')
         = link_to('Cancel', '#', title: 'Cancel', class: 'revert-dialog')
         = link_to('Continue', '#', title: 'Continue', class: 'close-dialog')

--- a/src/api/app/views/webui/kiwi/images/_repository_fields.html.haml
+++ b/src/api/app/views/webui/kiwi/images/_repository_fields.html.haml
@@ -12,10 +12,22 @@
       .dialog-content
         .normal-mode
           %p
-            This is the normal mode!
+            = label_tag 'Project:'
+            = text_field_tag 'target_project', f.object.project_for_type_obs,
+              data: { ajaxurl: url_for(controller: '/webui/project', action: 'autocomplete_projects'), default: f.object.project_for_type_obs }
+          %p
+            = label_tag 'Repository:'
+            %br/
+            = select_tag "target_repo", options_for_select([f.object.repository_for_type_obs]), disabled: !f.object.obs_source_path?,
+              data: { ajaxurl: url_for(controller: '/webui/project', action: :autocomplete_repositories), default: f.object.repository_for_type_obs }
+            %span.ui-autocomplete-loading.hidden
+              = image_tag('ajax-loader.gif')
+          %p
+            = label_tag 'Alias:'
+            = text_field_tag 'alias_for_repo', f.object.alias, data: { default: f.object.alias }
         .expert-mode.hidden
           %p
-            = f.hidden_field :order
+            = f.hidden_field :order, data: { default: f.object.order }
             = f.label :repo_type, 'Type:'
             = f.select :repo_type, Kiwi::Repository::REPO_TYPES, {}, { data: {default: f.object.repo_type }}
             = f.label :priority, 'Priority:'

--- a/src/api/spec/models/kiwi/repository_spec.rb
+++ b/src/api/spec/models/kiwi/repository_spec.rb
@@ -3,6 +3,9 @@ require 'rantly/rspec_extensions'
 
 RSpec.describe Kiwi::Repository, type: :model do
   let(:kiwi_repository) { create(:kiwi_repository) }
+  let(:non_obs_kiwi_repository) { create(:kiwi_repository, source_path: 'http://example.com/my_repo') }
+  let(:obs_kiwi_repository) { create(:kiwi_repository, source_path: 'obs://home:project/my_obs_repo') }
+  let(:kiwi_repository_without_sourcepath) { build(:kiwi_repository, source_path: nil) }
 
   describe '#name' do
     context 'with an alias' do
@@ -127,6 +130,66 @@ RSpec.describe Kiwi::Repository, type: :model do
         expect(subject).to eq("<repository type=\"apt-deb\" alias=\"example\">\n  " +
                               "<source path=\"http://example.com/\"/>\n</repository>\n")
       end
+    end
+  end
+
+  describe '#obs_source_path?' do
+    context 'with non OBS repository' do
+      subject { non_obs_kiwi_repository.obs_source_path? }
+
+      it { is_expected.to be_falsey }
+    end
+
+    context 'with a repository without source_path' do
+      subject { kiwi_repository_without_sourcepath.obs_source_path? }
+
+      it { is_expected.to be_falsey }
+    end
+
+    context 'with an OBS repository' do
+      subject { obs_kiwi_repository.obs_source_path? }
+
+      it { is_expected.to be_truthy }
+    end
+  end
+
+  describe '#project_for_type_obs' do
+    context 'with non OBS repository' do
+      subject { non_obs_kiwi_repository.project_for_type_obs }
+
+      it { is_expected.to be_nil }
+    end
+
+    context 'with a repository without source_path' do
+      subject { kiwi_repository_without_sourcepath.project_for_type_obs }
+
+      it { is_expected.to eq('') }
+    end
+
+    context 'with an OBS repository' do
+      subject { obs_kiwi_repository.project_for_type_obs }
+
+      it { is_expected.to eq('home:project') }
+    end
+  end
+
+  describe '#repository_for_type_obs' do
+    context 'with non OBS repository' do
+      subject { non_obs_kiwi_repository.repository_for_type_obs }
+
+      it { is_expected.to be_nil }
+    end
+
+    context 'with a repository without source_path' do
+      subject { kiwi_repository_without_sourcepath.repository_for_type_obs }
+
+      it { is_expected.to eq('') }
+    end
+
+    context 'with an OBS repository' do
+      subject { obs_kiwi_repository.repository_for_type_obs }
+
+      it { is_expected.to eq('my_obs_repo') }
     end
   end
 end


### PR DESCRIPTION
Now when adding a new repository to the Kiwi image the user will land in "basic" mode with autocompletion for OBS projects/repositories, something like that:

![image](https://user-images.githubusercontent.com/11314634/30122132-d115c130-932d-11e7-9615-15fa0f02e5ae.png)

And the old interface remains as the "expert" mode:
![image](https://user-images.githubusercontent.com/11314634/30122150-e2c83638-932d-11e7-9766-2e4c588a64c5.png)
