### PR TITLE
Monkey patch to disable source_changed link in job history

### DIFF
--- a/src/api/app/views/webui/packages/job_history/index.html.haml
+++ b/src/api/app/views/webui/packages/job_history/index.html.haml
@@ -26,10 +26,7 @@
         %td
           = time_tag(Time.at(jobhistory.ready_time))
         %td
-          - if jobhistory.reason == 'source change'
-            = link_to(jobhistory.reason, package_rdiff_path(project: @project.name, package: @package.name, orev: jobhistory.prev_verifymd5, rev: jobhistory.verifymd5))
-          - else
-            = jobhistory.reason
+          = jobhistory.reason
         %td{ class: "status_#{jobhistory.code}" }
           = jobhistory.code
         %td


### PR DESCRIPTION
Monkey patches on production as the source link is currently broken.

@evanrolfe is working on a fix!