### PR TITLE
[webui] "source change" rdiff link uses srcmd5.

### DIFF
--- a/src/api/app/models/local_job_history.rb
+++ b/src/api/app/models/local_job_history.rb
@@ -12,5 +12,5 @@ class LocalJobHistory
                 :code,
                 :srcmd5,
                 :verifymd5,
-                :prev_verifymd5
+                :prev_srcmd5
 end

--- a/src/api/app/models/package.rb
+++ b/src/api/app/models/package.rb
@@ -957,12 +957,12 @@ class Package < ApplicationRecord
 
     local_jobs_history = []
     results.elements('jobhist').each_with_index do |result, index|
-      prev_verifymd5 = results.elements('jobhist')[index - 1].try(:fetch, 'verifymd5', nil)
+      prev_srcmd5 = results.elements('jobhist')[index - 1].try(:fetch, 'srcmd5', nil)
 
       local_jobs_history << LocalJobHistory.new(revision: result['rev'],
                                                 srcmd5: result['srcmd5'],
                                                 verifymd5: result['verifymd5'],
-                                                prev_verifymd5: prev_verifymd5,
+                                                prev_srcmd5: prev_srcmd5,
                                                 build_counter: result['bcnt'],
                                                 worker_id: result['workerid'],
                                                 host_arch: result['hostarch'],

--- a/src/api/app/views/webui/packages/job_history/index.html.haml
+++ b/src/api/app/views/webui/packages/job_history/index.html.haml
@@ -27,7 +27,7 @@
           = time_tag(Time.at(jobhistory.ready_time))
         %td
           - if jobhistory.reason == 'source change'
-            = link_to(jobhistory.reason, package_rdiff_path(project: @project.name, package: @package.name, orev: jobhistory.prev_verifymd5, rev: jobhistory.verifymd5))
+            = link_to(jobhistory.reason, package_rdiff_path(project: @project.name, package: @package.name, orev: jobhistory.prev_srcmd5, rev: jobhistory.srcmd5))
           - else
             = jobhistory.reason
         %td{ class: "status_#{jobhistory.code}" }

--- a/src/api/spec/models/package_spec.rb
+++ b/src/api/spec/models/package_spec.rb
@@ -508,9 +508,9 @@ RSpec.describe Package, vcr: true do
         expect(subject[1].revision).to eq('1')
       end
 
-      it 'contains the previous verifymd5 value on the job with rev=2' do
-        expect(subject[0].verifymd5).to eq('597d297d19621de7db926d36d27d4331')
-        expect(subject[0].prev_verifymd5).to eq('2ac8bd685591b40e412ee99b182f94c2')
+      it 'contains the previous srcmd5 value on the job with rev=2' do
+        expect(subject[0].srcmd5).to eq('597d297d19621de7db926d36d27d4331')
+        expect(subject[0].prev_srcmd5).to eq('2ac8bd685591b40e412ee99b182f94c2')
       end
     end
 


### PR DESCRIPTION
This link mistakenly used verifymd5 in the rdiff link which caused an
error on production. The correct value to use is srcmd5.

Fixes https://github.com/openSUSE/open-build-service/issues/3800