### PR TITLE
Convert database columns with type bigint => int.

### DIFF
--- a/dist/ci/travis_script.sh
+++ b/dist/ci/travis_script.sh
@@ -26,6 +26,7 @@ if test -z "$SUBTEST"; then
       ;;
     linter)
       bundle exec rake db:structure:verify
+      bundle exec rake db:structure:verify_no_bigint
       make -C ../../ rubocop
       bundle exec rake haml_lint
       jshint .

--- a/src/api/app/models/kiwi/package.rb
+++ b/src/api/app/models/kiwi/package.rb
@@ -32,3 +32,7 @@ end
 #
 #  index_kiwi_packages_on_package_group_id  (package_group_id)
 #
+# Foreign Keys
+#
+#  fk_rails_...  (package_group_id => kiwi_package_groups.id)
+#

--- a/src/api/app/models/kiwi/package_group.rb
+++ b/src/api/app/models/kiwi/package_group.rb
@@ -42,3 +42,7 @@ end
 #
 #  index_kiwi_package_groups_on_image_id  (image_id)
 #
+# Foreign Keys
+#
+#  fk_rails_...  (image_id => kiwi_images.id)
+#

--- a/src/api/db/migrate/20170911142301_change_kiwi_package_groups_columns_from_big_int_to_int.rb
+++ b/src/api/db/migrate/20170911142301_change_kiwi_package_groups_columns_from_big_int_to_int.rb
@@ -1,11 +1,11 @@
 class ChangeKiwiPackageGroupsColumnsFromBigIntToInt < ActiveRecord::Migration[5.1]
   def up
-    change_column :kiwi_package_groups, :id, :integer
+    change_column :kiwi_package_groups, :id, :integer, auto_increment: true
     change_column :kiwi_package_groups, :image_id, :integer
   end
 
   def down
-    change_column :kiwi_package_groups, :id, :bigint
+    change_column :kiwi_package_groups, :id, :bigint, auto_increment: true
     change_column :kiwi_package_groups, :image_id, :bigint
   end
 end

--- a/src/api/db/migrate/20170911142301_change_kiwi_package_groups_columns_from_big_int_to_int.rb
+++ b/src/api/db/migrate/20170911142301_change_kiwi_package_groups_columns_from_big_int_to_int.rb
@@ -1,0 +1,11 @@
+class ChangeKiwiPackageGroupsColumnsFromBigIntToInt < ActiveRecord::Migration[5.1]
+  def up
+    change_column :kiwi_package_groups, :id, :integer
+    change_column :kiwi_package_groups, :image_id, :integer
+  end
+
+  def down
+    change_column :kiwi_package_groups, :id, :bigint
+    change_column :kiwi_package_groups, :image_id, :bigint
+  end
+end

--- a/src/api/db/migrate/20170912140257_change_kiwi_packages_columns_from_big_int_to_int.rb
+++ b/src/api/db/migrate/20170912140257_change_kiwi_packages_columns_from_big_int_to_int.rb
@@ -1,0 +1,11 @@
+class ChangeKiwiPackagesColumnsFromBigIntToInt < ActiveRecord::Migration[5.1]
+  def up
+    change_column :kiwi_packages, :id, :integer
+    change_column :kiwi_packages, :package_group_id, :integer
+  end
+
+  def down
+    change_column :kiwi_packages, :id, :bigint
+    change_column :kiwi_packages, :package_group_id, :bigint
+  end
+end

--- a/src/api/db/migrate/20170912140257_change_kiwi_packages_columns_from_big_int_to_int.rb
+++ b/src/api/db/migrate/20170912140257_change_kiwi_packages_columns_from_big_int_to_int.rb
@@ -1,11 +1,11 @@
 class ChangeKiwiPackagesColumnsFromBigIntToInt < ActiveRecord::Migration[5.1]
   def up
-    change_column :kiwi_packages, :id, :integer
+    change_column :kiwi_packages, :id, :integer, auto_increment: true
     change_column :kiwi_packages, :package_group_id, :integer
   end
 
   def down
-    change_column :kiwi_packages, :id, :bigint
+    change_column :kiwi_packages, :id, :bigint, auto_increment: true
     change_column :kiwi_packages, :package_group_id, :bigint
   end
 end

--- a/src/api/db/migrate/20170912140713_add_foreign_key_constraints_to_kiwi_tables.rb
+++ b/src/api/db/migrate/20170912140713_add_foreign_key_constraints_to_kiwi_tables.rb
@@ -1,0 +1,6 @@
+class AddForeignKeyConstraintsToKiwiTables < ActiveRecord::Migration[5.1]
+  def change
+    add_foreign_key :kiwi_package_groups, :kiwi_images, column: :image_id
+    add_foreign_key :kiwi_packages, :kiwi_package_groups, column: :package_group_id
+  end
+end

--- a/src/api/db/structure.sql
+++ b/src/api/db/structure.sql
@@ -613,7 +613,7 @@ CREATE TABLE `kiwi_images` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 CREATE TABLE `kiwi_package_groups` (
-  `id` int(11) NOT NULL,
+  `id` int(11) NOT NULL AUTO_INCREMENT,
   `kiwi_type` int(11) NOT NULL,
   `profiles` varchar(255) DEFAULT NULL,
   `pattern_type` varchar(255) DEFAULT NULL,
@@ -626,7 +626,7 @@ CREATE TABLE `kiwi_package_groups` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 CREATE TABLE `kiwi_packages` (
-  `id` int(11) NOT NULL,
+  `id` int(11) NOT NULL AUTO_INCREMENT,
   `name` varchar(255) NOT NULL,
   `arch` varchar(255) DEFAULT NULL,
   `replaces` varchar(255) DEFAULT NULL,

--- a/src/api/db/structure.sql
+++ b/src/api/db/structure.sql
@@ -613,29 +613,31 @@ CREATE TABLE `kiwi_images` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 CREATE TABLE `kiwi_package_groups` (
-  `id` bigint(20) NOT NULL AUTO_INCREMENT,
+  `id` int(11) NOT NULL,
   `kiwi_type` int(11) NOT NULL,
   `profiles` varchar(255) DEFAULT NULL,
   `pattern_type` varchar(255) DEFAULT NULL,
-  `image_id` bigint(20) DEFAULT NULL,
+  `image_id` int(11) DEFAULT NULL,
   `created_at` datetime NOT NULL,
   `updated_at` datetime NOT NULL,
   PRIMARY KEY (`id`),
-  KEY `index_kiwi_package_groups_on_image_id` (`image_id`)
+  KEY `index_kiwi_package_groups_on_image_id` (`image_id`),
+  CONSTRAINT `fk_rails_c64a679086` FOREIGN KEY (`image_id`) REFERENCES `kiwi_images` (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 CREATE TABLE `kiwi_packages` (
-  `id` bigint(20) NOT NULL AUTO_INCREMENT,
+  `id` int(11) NOT NULL,
   `name` varchar(255) NOT NULL,
   `arch` varchar(255) DEFAULT NULL,
   `replaces` varchar(255) DEFAULT NULL,
   `bootinclude` tinyint(1) DEFAULT NULL,
   `bootdelete` tinyint(1) DEFAULT NULL,
-  `package_group_id` bigint(20) DEFAULT NULL,
+  `package_group_id` int(11) DEFAULT NULL,
   `created_at` datetime NOT NULL,
   `updated_at` datetime NOT NULL,
   PRIMARY KEY (`id`),
-  KEY `index_kiwi_packages_on_package_group_id` (`package_group_id`)
+  KEY `index_kiwi_packages_on_package_group_id` (`package_group_id`),
+  CONSTRAINT `fk_rails_0ecab3b2cd` FOREIGN KEY (`package_group_id`) REFERENCES `kiwi_package_groups` (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 CREATE TABLE `kiwi_repositories` (
@@ -1241,6 +1243,9 @@ INSERT INTO `schema_migrations` (version) VALUES
 ('20170821110838'),
 ('20170821110918'),
 ('20170821110941'),
-('20170821110946');
+('20170821110946'),
+('20170911142301'),
+('20170912140257'),
+('20170912140713');
 
 

--- a/src/api/lib/tasks/databases.rake
+++ b/src/api/lib/tasks/databases.rake
@@ -97,6 +97,22 @@ namespace :db do
       end
       puts "Everything looks fine!"
     end
+
+    desc "Verify that structure.sql does not use any columns with type = bigint"
+    task verify_no_bigint: :environment do
+      puts 'Checking db/structure.sql for bigint'
+
+      bigint_lines = %x{grep "bigint" #{Rails.root}/db/structure.sql}
+
+      unless bigint_lines.blank?
+        abort <<-STR
+          Please do not use bigint column type in db/structure.sql.
+          You may need to call create_table with `id: :integer` to avoid the id column using bigint.
+        STR
+      end
+
+      puts 'Ok'
+    end
   end
 
   desc 'Create the database, load the structure, and initialize with the seed data'


### PR DESCRIPTION
https://trello.com/c/My00k8q2/532-3-p6-evaluate-change-of-table-id-int-type-made-by-rails-51

Since [rails PR 26266](https://github.com/rails/rails/pull/26266) any new tables created will have the primary key type set to bigint by default. However that will cause problems because we will not be able to create foreign keys between bigint and int columns. If we want to use bigint then we will need to convert all primary and foreign keys from int to bigint and this will take a considerable amount of work to get these migrations to run without causing too much interuption. So for the meantime I propose that we stick with int for the meantime and then evaluate if switching to bigint is worth the cost.

Further reading:
http://ridingtheclutch.com/post/160099545985/rails-51-new-default-bigint-primary-key-sort-of