### PR TITLE
Move to blowfish hashing algorithm

### DIFF
--- a/src/api/Gemfile
+++ b/src/api/Gemfile
@@ -36,6 +36,8 @@ gem 'escape_utils'
 gem 'sanitize'
 # as authorization system
 gem "pundit"
+# for password hashing
+gem 'bcrypt'
 #
 gem 'responders', '~> 2.0'
 # needed for travis-ci.org, must be global for scripts

--- a/src/api/Gemfile.lock
+++ b/src/api/Gemfile.lock
@@ -58,6 +58,7 @@ GEM
     arel (8.0.0)
     ast (2.3.0)
     atomic (1.1.99)
+    bcrypt (3.1.11)
     builder (3.2.3)
     bullet (5.6.1)
       activesupport (>= 3.0.0)
@@ -412,6 +413,7 @@ DEPENDENCIES
   acts_as_tree
   airbrake
   annotate
+  bcrypt
   bullet
   bundler
   capybara

--- a/src/api/app/controllers/person_controller.rb
+++ b/src/api/app/controllers/person_controller.rb
@@ -258,7 +258,7 @@ class PersonController < ApplicationController
     end
 
     # update password in users db
-    user.update_password( password )
+    user.password = password
     user.save!
   end
   private :change_password

--- a/src/api/app/controllers/webui/user_controller.rb
+++ b/src/api/app/controllers/webui/user_controller.rb
@@ -39,7 +39,7 @@ class Webui::UserController < Webui::WebuiController
       return
     end
 
-    Rails.logger.debug "Authentificated user '#{user.try(:login)}'"
+    Rails.logger.debug "Authenticated as user '#{user.try(:login)}'"
 
     session[:login] = user.login
     User.current = user

--- a/src/api/app/models/unregistered_user.rb
+++ b/src/api/app/models/unregistered_user.rb
@@ -48,9 +48,10 @@ class UnregisteredUser < User
     state = ::Configuration.registration == 'allow' ? "confirmed" : "unconfirmed"
 
     newuser = User.create(
-        login: opts[:login],
-        password: opts[:password],
-        email: opts[:email] )
+        login:                 opts[:login],
+        password:              opts[:password],
+        email:                 opts[:email]
+    )
 
     newuser.realname = opts[:realname] || ""
     newuser.state = state
@@ -73,23 +74,24 @@ end
 #
 # Table name: users
 #
-#  id                  :integer          not null, primary key
-#  created_at          :datetime
-#  updated_at          :datetime
-#  last_logged_in_at   :datetime
-#  login_failure_count :integer          default(0), not null
-#  login               :text(65535)      indexed
-#  email               :string(200)      default(""), not null
-#  realname            :string(200)      default(""), not null
-#  password            :string(100)      default(""), not null, indexed
-#  password_hash_type  :string(20)       default("md5"), not null
-#  password_salt       :string(10)       default("1234512345"), not null
-#  adminnote           :text(65535)
-#  state               :string(11)       default("unconfirmed")
-#  owner_id            :integer
+#  id                            :integer          not null, primary key
+#  created_at                    :datetime
+#  updated_at                    :datetime
+#  last_logged_in_at             :datetime
+#  login_failure_count           :integer          default(0), not null
+#  login                         :text(65535)      indexed
+#  email                         :string(200)      default(""), not null
+#  realname                      :string(200)      default(""), not null
+#  password_digest               :string(255)
+#  deprecated_password           :string(255)      indexed
+#  deprecated_password_hash_type :string(255)
+#  deprecated_password_salt      :string(255)
+#  adminnote                     :text(65535)
+#  state                         :string(11)       default("unconfirmed")
+#  owner_id                      :integer
 #
 # Indexes
 #
 #  users_login_index     (login) UNIQUE
-#  users_password_index  (password)
+#  users_password_index  (deprecated_password)
 #

--- a/src/api/db/migrate/20170905081525_add_has_secure_password_support.rb
+++ b/src/api/db/migrate/20170905081525_add_has_secure_password_support.rb
@@ -1,0 +1,13 @@
+class AddHasSecurePasswordSupport < ActiveRecord::Migration[5.1]
+  def change
+    rename_column :users, :password, :deprecated_password
+    rename_column :users, :password_hash_type, :deprecated_password_hash_type
+    rename_column :users, :password_salt, :deprecated_password_salt
+
+    change_column :users, :deprecated_password, :string, null: true, default: nil, after: :realname
+    change_column :users, :deprecated_password_hash_type, :string, null: true, default: nil, after: :deprecated_password
+    change_column :users, :deprecated_password_salt, :string, null: true, default: nil, after: :deprecated_password_hash_type
+
+    add_column :users, :password_digest, :string, after: :realname
+  end
+end

--- a/src/api/db/structure.sql
+++ b/src/api/db/structure.sql
@@ -1115,15 +1115,16 @@ CREATE TABLE `users` (
   `login` text COLLATE utf8_bin,
   `email` varchar(200) CHARACTER SET utf8 NOT NULL DEFAULT '',
   `realname` varchar(200) CHARACTER SET utf8 NOT NULL DEFAULT '',
-  `password` varchar(100) CHARACTER SET utf8 NOT NULL DEFAULT '',
-  `password_hash_type` varchar(20) COLLATE utf8_bin NOT NULL DEFAULT 'md5',
-  `password_salt` varchar(10) CHARACTER SET utf8 NOT NULL DEFAULT '1234512345',
+  `password_digest` varchar(255) COLLATE utf8_bin DEFAULT NULL,
+  `deprecated_password` varchar(255) COLLATE utf8_bin DEFAULT NULL,
+  `deprecated_password_hash_type` varchar(255) COLLATE utf8_bin DEFAULT NULL,
+  `deprecated_password_salt` varchar(255) COLLATE utf8_bin DEFAULT NULL,
   `adminnote` text CHARACTER SET utf8,
   `state` enum('unconfirmed','confirmed','locked','deleted','subaccount') COLLATE utf8_bin DEFAULT 'unconfirmed',
   `owner_id` int(11) DEFAULT NULL,
   PRIMARY KEY (`id`),
   UNIQUE KEY `users_login_index` (`login`(255)) USING BTREE,
-  KEY `users_password_index` (`password`) USING BTREE
+  KEY `users_password_index` (`deprecated_password`) USING BTREE
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin;
 
 CREATE TABLE `watched_projects` (
@@ -1245,6 +1246,7 @@ INSERT INTO `schema_migrations` (version) VALUES
 ('20170821110918'),
 ('20170821110941'),
 ('20170821110946'),
+('20170905081525'),
 ('20170905101113'),
 ('20170911142301'),
 ('20170912140257'),

--- a/src/api/spec/controllers/person_controller_spec.rb
+++ b/src/api/spec/controllers/person_controller_spec.rb
@@ -24,9 +24,27 @@ RSpec.describe PersonController, vcr: false do
   end
 
   describe 'POST #post_userinfo' do
+    before do
+      login user
+    end
+
+    context 'when using default authentication' do
+      let!(:old_password) { user.password_digest }
+
+      before do
+        request.env["RAW_POST_DATA"] = "password_has_changed"
+        post :post_userinfo, params: { login: user.login, cmd: 'change_password', format: :xml }
+
+        user.reload
+      end
+
+      it 'changes the password' do
+        expect(old_password).to_not eq(user.password_digest)
+      end
+    end
+
     context 'when in LDAP mode' do
       before do
-        login user
         stub_const('CONFIG', CONFIG.merge({ 'ldap_mode' => :on }))
         post :post_userinfo, params: { login: user.login, cmd: 'change_password', format: :xml }
       end

--- a/src/api/spec/controllers/webui/user_controller_spec.rb
+++ b/src/api/spec/controllers/webui/user_controller_spec.rb
@@ -73,7 +73,7 @@ RSpec.describe Webui::UserController do
     it { is_expected.to render_template("webui/user/edit") }
   end
 
-  describe "POST #do_login" do
+  shared_examples "login" do
     before do
       request.env["HTTP_REFERER"] = search_url # Needed for the redirect_to(root_url)
     end
@@ -100,6 +100,18 @@ RSpec.describe Webui::UserController do
       post :do_login, params: { username: user.login, password: 'buildservice' }
       expect(User.current).to eq(user)
       expect(session[:login]).to eq(user.login)
+    end
+  end
+
+  describe "POST #do_login" do
+    context "with deprecated password" do
+      let(:user) { create(:user_deprecated_password, state: :confirmed) }
+
+      it_behaves_like "login"
+    end
+
+    context "with bcrypt password" do
+      it_behaves_like "login"
     end
   end
 

--- a/src/api/spec/factories/users.rb
+++ b/src/api/spec/factories/users.rb
@@ -19,6 +19,18 @@ FactoryGirl.define do
       end
     end
 
+    factory :user_deprecated_password do
+      after(:create) do |user|
+        user.password_digest = nil
+        user.deprecated_password = "b6ead59da72f491dd29f84a6579d6dc4" # password: buildservice
+        user.deprecated_password_hash_type = "md5"
+        user.deprecated_password_salt = "m/YVlu5w0M"
+
+        # ignore validations because `password_digest` can't be nil
+        user.save!(validate: false)
+      end
+    end
+
     factory :deleted_user do
       login 'deleted'
       state 4
@@ -31,7 +43,7 @@ FactoryGirl.define do
     # This is needed because the salt is random
     # in User.after_validation
     after(:create) do |user|
-      user.update_password('buildservice')
+      user.password = 'buildservice'
       user.save!
     end
   end

--- a/src/api/test/fixtures/users.yml
+++ b/src/api/test/fixtures/users.yml
@@ -6,9 +6,7 @@ Admin:
   login: Admin
   email: root@localhost
   realname: OBS Instance Superuser
-  password: f2eb735aacb365155a6d0076434b73e9
-  password_hash_type: md5
-  password_salt: 6H2zF0vSjj
+  password_digest: $2a$10$kvnsKtwOAqKeBYpaDhzQfOTZ7BuSjShOvnwqp4tFRLk1YUwLAH6la
   state: "confirmed"
 Iggy:
   created_at: 2011-07-29 14:00:21.000000000 Z
@@ -17,9 +15,7 @@ Iggy:
   login: Iggy
   email: Iggy@pop.org
   realname: Iggy Pop
-  password: 2852b2024791b850ae30314b1b9f28eb
-  password_hash_type: md5
-  password_salt: ''
+  password_digest: $2a$10$kvnsKtwOAqKeBYpaDhzQfOTZ7BuSjShOvnwqp4tFRLk1YUwLAH6la
   state: "confirmed"
 _nobody_:
   created_at: 2011-07-29 14:00:21.000000000 Z
@@ -28,9 +24,7 @@ _nobody_:
   login: _nobody_
   email: nobody@localhost
   realname: Anonymous User
-  password: 2852b2024791b850ae30314b1b9f28eb
-  password_hash_type: md5
-  password_salt: ''
+  password_digest: $2a$10$Xi1VnoTy352Zj78Qp9Hix.HzKtpGTz9nXq2/6eDF9tRIr4bTwAtkO
   state: "locked"
 adrian:
   created_at: 2011-07-29 14:00:21.000000000 Z
@@ -39,9 +33,7 @@ adrian:
   login: adrian
   email: adrian@example.com
   realname: Johnny Thunders
-  password: 2852b2024791b850ae30314b1b9f28eb
-  password_hash_type: md5
-  password_salt: ''
+  password_digest: $2a$10$kvnsKtwOAqKeBYpaDhzQfOTZ7BuSjShOvnwqp4tFRLk1YUwLAH6la
   state: "confirmed"
 adrian_downloader:
   created_at: 2011-07-29 14:00:21.000000000 Z
@@ -50,9 +42,7 @@ adrian_downloader:
   login: adrian_downloader
   email: adrian@example.com
   realname: user has access to binary files only
-  password: 2852b2024791b850ae30314b1b9f28eb
-  password_hash_type: md5
-  password_salt: ''
+  password_digest: $2a$10$kvnsKtwOAqKeBYpaDhzQfOTZ7BuSjShOvnwqp4tFRLk1YUwLAH6la
   state: "confirmed"
 adrian_nobody:
   created_at: 2011-07-29 14:00:21.000000000 Z
@@ -61,9 +51,7 @@ adrian_nobody:
   login: adrian_nobody
   email: adrian@example.com
   realname: user exists, but has no permissions
-  password: 2852b2024791b850ae30314b1b9f28eb
-  password_hash_type: md5
-  password_salt: ''
+  password_digest: $2a$10$kvnsKtwOAqKeBYpaDhzQfOTZ7BuSjShOvnwqp4tFRLk1YUwLAH6la
   state: "confirmed"
 adrian_reader:
   created_at: 2011-07-29 14:00:21.000000000 Z
@@ -72,9 +60,7 @@ adrian_reader:
   login: adrian_reader
   email: adrian@example.com
   realname: user has access to sources (and binaries ?)
-  password: 2852b2024791b850ae30314b1b9f28eb
-  password_hash_type: md5
-  password_salt: ''
+  password_digest: $2a$10$kvnsKtwOAqKeBYpaDhzQfOTZ7BuSjShOvnwqp4tFRLk1YUwLAH6la
   state: "confirmed"
 binary_homer:
   created_at: 2011-07-29 14:00:21.000000000 Z
@@ -83,9 +69,7 @@ binary_homer:
   login: binary_homer
   email: homer@nospam.net
   realname: user is maintainer in binary protected project (binarydownload)
-  password: 2852b2024791b850ae30314b1b9f28eb
-  password_hash_type: md5
-  password_salt: ''
+  password_digest: $2a$10$kvnsKtwOAqKeBYpaDhzQfOTZ7BuSjShOvnwqp4tFRLk1YUwLAH6la
   state: "confirmed"
 deleted:
   created_at: 2012-01-16 13:36:00.000000000 Z
@@ -95,9 +79,7 @@ deleted:
   login: deleted
   email: test@example.com
   realname: ''
-  password: 8e7a61bc50e5b38543cbb890ce0c0c06
-  password_hash_type: md5
-  password_salt: Vibb8QsN4I
+  password_digest: $2a$10$kvnsKtwOAqKeBYpaDhzQfOTZ7BuSjShOvnwqp4tFRLk1YUwLAH6la
   state: "deleted"
 dmayr:
   created_at: 2012-01-16 13:36:00.000000000 Z
@@ -107,9 +89,7 @@ dmayr:
   login: dmayr
   email: test@example.com
   realname: ''
-  password: 8e7a61bc50e5b38543cbb890ce0c0c06
-  password_hash_type: md5
-  password_salt: Vibb8QsN4I
+  password_digest: $2a$10$kvnsKtwOAqKeBYpaDhzQfOTZ7BuSjShOvnwqp4tFRLk1YUwLAH6la
   state: "confirmed"
 fred:
   created_at: 2011-07-29 14:00:21.000000000 Z
@@ -118,9 +98,7 @@ fred:
   login: fred
   email: fred@feuerstein.de
   realname: Frederic Feuerstone
-  password: 2852b2024791b850ae30314b1b9f28eb
-  password_hash_type: md5
-  password_salt: ''
+  password_digest: $2a$10$kvnsKtwOAqKeBYpaDhzQfOTZ7BuSjShOvnwqp4tFRLk1YUwLAH6la
   state: "confirmed"
 fredlibs:
   created_at: 2011-07-29 14:00:21.000000000 Z
@@ -129,9 +107,7 @@ fredlibs:
   login: fredlibs
   email: fred@feuerstein.de
   realname: Frederic Feuerstone
-  password: 2852b2024791b850ae30314b1b9f28eb
-  password_hash_type: md5
-  password_salt: ''
+  password_digest: $2a$10$kvnsKtwOAqKeBYpaDhzQfOTZ7BuSjShOvnwqp4tFRLk1YUwLAH6la
   state: "confirmed"
 hidden_homer:
   created_at: 2011-07-29 14:00:21.000000000 Z
@@ -140,9 +116,7 @@ hidden_homer:
   login: hidden_homer
   email: homer@nospam.net
   realname: user is maintainer in hidden project
-  password: 2852b2024791b850ae30314b1b9f28eb
-  password_hash_type: md5
-  password_salt: ''
+  password_digest: $2a$10$kvnsKtwOAqKeBYpaDhzQfOTZ7BuSjShOvnwqp4tFRLk1YUwLAH6la
   state: "confirmed"
 king:
   created_at: 2011-07-29 14:00:21.000000000 Z
@@ -151,9 +125,7 @@ king:
   login: king
   email: king@all-the-kings.org
   realname: The King
-  password: e5e7105d5c05d9c0cc5944ff1341b533
-  password_hash_type: md5
-  password_salt: ''
+  password_digest: $2a$10$.cJH/mzFxmng1Z32zqR1juRBcIceF94GN5CynZrwrQgSRTXsqYyZe
   state: "confirmed"
 maintenance_assi:
   created_at: 2014-04-07 06:51:18.000000000 Z
@@ -162,9 +134,7 @@ maintenance_assi:
   login: maintenance_assi
   email: homer@nospam.net
   realname: Maintenance Slave
-  password: f021ce8ca85a51a5eb08d8b6e7cf82b1
-  password_hash_type: md5
-  password_salt: 0hY2gWMfcb
+  password_digest: $2a$10$kvnsKtwOAqKeBYpaDhzQfOTZ7BuSjShOvnwqp4tFRLk1YUwLAH6la
   state: "confirmed"
 maintenance_coord:
   created_at: 2011-07-29 14:00:21.000000000 Z
@@ -173,9 +143,7 @@ maintenance_coord:
   login: maintenance_coord
   email: dirkmueller@example.com
   realname: our hero
-  password: 2852b2024791b850ae30314b1b9f28eb
-  password_hash_type: md5
-  password_salt: ''
+  password_digest: $2a$10$kvnsKtwOAqKeBYpaDhzQfOTZ7BuSjShOvnwqp4tFRLk1YUwLAH6la
   state: "confirmed"
 sourceaccess_homer:
   created_at: 2011-07-29 14:00:21.000000000 Z
@@ -184,9 +152,7 @@ sourceaccess_homer:
   login: sourceaccess_homer
   email: homer@nospam.net
   realname: user is maintainer in sourceaccess protected project (sourceaccess)
-  password: 2852b2024791b850ae30314b1b9f28eb
-  password_hash_type: md5
-  password_salt: ''
+  password_digest: $2a$10$kvnsKtwOAqKeBYpaDhzQfOTZ7BuSjShOvnwqp4tFRLk1YUwLAH6la
   state: "confirmed"
 tom:
   created_at: 2011-07-29 14:00:21.000000000 Z
@@ -195,9 +161,7 @@ tom:
   login: tom
   email: tschmidt@example.com
   realname: Thor
-  password: 2852b2024791b850ae30314b1b9f28eb
-  password_hash_type: md5
-  password_salt: ''
+  password_digest: $2a$10$kvnsKtwOAqKeBYpaDhzQfOTZ7BuSjShOvnwqp4tFRLk1YUwLAH6la
   state: "confirmed"
 user1:
   created_at: 2012-01-16 13:36:00.000000000 Z
@@ -207,9 +171,7 @@ user1:
   login: user1
   email: user1@example.com
   realname: ''
-  password: 8e7a61bc50e5b38543cbb890ce0c0c06
-  password_hash_type: md5
-  password_salt: Vibb8QsN4I
+  password_digest: $2a$10$kvnsKtwOAqKeBYpaDhzQfOTZ7BuSjShOvnwqp4tFRLk1YUwLAH6la
   state: "confirmed"
 user2:
   created_at: 2012-01-16 13:36:00.000000000 Z
@@ -219,9 +181,7 @@ user2:
   login: user2
   email: user2@example.com
   realname: ''
-  password: 8e7a61bc50e5b38543cbb890ce0c0c06
-  password_hash_type: md5
-  password_salt: Vibb8QsN4I
+  password_digest: $2a$10$kvnsKtwOAqKeBYpaDhzQfOTZ7BuSjShOvnwqp4tFRLk1YUwLAH6la
   state: "confirmed"
 user3:
   created_at: 2012-01-16 13:36:00.000000000 Z
@@ -231,9 +191,7 @@ user3:
   login: user3
   email: test@example.com
   realname: ''
-  password: 8e7a61bc50e5b38543cbb890ce0c0c06
-  password_hash_type: md5
-  password_salt: Vibb8QsN4I
+  password_digest: $2a$10$kvnsKtwOAqKeBYpaDhzQfOTZ7BuSjShOvnwqp4tFRLk1YUwLAH6la
   state: "confirmed"
 user4:
   created_at: 2012-01-16 13:36:00.000000000 Z
@@ -243,9 +201,7 @@ user4:
   login: user4
   email: user4@example.com
   realname: ''
-  password: 8e7a61bc50e5b38543cbb890ce0c0c06
-  password_hash_type: md5
-  password_salt: Vibb8QsN4I
+  password_digest: $2a$10$kvnsKtwOAqKeBYpaDhzQfOTZ7BuSjShOvnwqp4tFRLk1YUwLAH6la
   state: "confirmed"
 user5:
   created_at: 2012-01-16 13:36:00.000000000 Z
@@ -255,9 +211,7 @@ user5:
   login: user5
   email: user5@example.com
   realname: ''
-  password: 8e7a61bc50e5b38543cbb890ce0c0c06
-  password_hash_type: md5
-  password_salt: Vibb8QsN4I
+  password_digest: $2a$10$kvnsKtwOAqKeBYpaDhzQfOTZ7BuSjShOvnwqp4tFRLk1YUwLAH6la
   state: "confirmed"
 user6:
   created_at: 2012-01-16 13:36:00.000000000 Z
@@ -267,9 +221,7 @@ user6:
   login: user6
   email: test@example.com
   realname: ''
-  password: 8e7a61bc50e5b38543cbb890ce0c0c06
-  password_hash_type: md5
-  password_salt: Vibb8QsN4I
+  password_digest: $2a$10$kvnsKtwOAqKeBYpaDhzQfOTZ7BuSjShOvnwqp4tFRLk1YUwLAH6la
   state: 2
 unconfirmed_user:
   created_at: 2012-01-16 13:36:00.000000000 Z
@@ -279,7 +231,5 @@ unconfirmed_user:
   login: unconfirmed_user
   email: test@example.com
   realname: ''
-  password: 8e7a61bc50e5b38543cbb890ce0c0c06
-  password_hash_type: md5
-  password_salt: Vibb8QsN4I
+  password_digest: $2a$10$kvnsKtwOAqKeBYpaDhzQfOTZ7BuSjShOvnwqp4tFRLk1YUwLAH6la
   state: "unconfirmed"


### PR DESCRIPTION
We need to move to a better hashing algorithm, since `md5` is really outdated.

Please provide some feedback, the test cases are not written. I just adapted the old one so far (as discussed today).

The package `rubygem-bcrypt` has been linked from `devel:languages:ruby:extensions` to `OBS:Server:Unstable`