### PR TITLE
Refactor backend calls to Backend::Api (part 7)

### DIFF
--- a/src/api/app/controllers/application_controller.rb
+++ b/src/api/app/controllers/application_controller.rb
@@ -353,16 +353,6 @@ class ApplicationController < ActionController::Base
     render template: 'status', status: 200
   end
 
-  def backend
-    Backend::Test.start if Rails.env.test?
-    @backend ||= ActiveXML.backend
-  end
-
-  def backend_get( path )
-    # TODO: check why not using SUSE:Backend::get
-    backend.direct_http( URI(path) )
-  end
-
   # Passes control to subroutines determined by action and a request parameter. By
   # default the parameter assumed to contain the command is ':cmd'. Looks for a method
   # named <action>_<command>

--- a/src/api/app/controllers/source_controller.rb
+++ b/src/api/app/controllers/source_controller.rb
@@ -1107,7 +1107,7 @@ class SourceController < ApplicationController
     # create new project object based on oproject
     Project.transaction do
       if oprj.is_a? String # remote project
-        rdata = Xmlhash.parse(backend_get("/source/#{URI.escape(oprj)}/_meta"))
+        rdata = Xmlhash.parse(Backend::Api.meta_from_project(oprj))
         @project = Project.new name: project_name, title: rdata['title'], description: rdata['description']
       else # local project
         @project = Project.new name: project_name, title: oprj.title, description: oprj.description
@@ -1298,25 +1298,24 @@ class SourceController < ApplicationController
     pass_to_backend path
 
     # read meta data from backend to restore database object
-    path = request.path_info + '/_meta'
     prj = Project.find_by_name!(params[:project])
     pkg = prj.packages.new(name: params[:package])
-    pkg.update_from_xml(Xmlhash.parse(backend_get(path)))
+    pkg.update_from_xml(Xmlhash.parse(Backend::Api.meta_from_package(params[:project], params[:package])))
     pkg.store
   end
 
   # FIXME: obsolete this for 3.0
   # POST /source/<project>/<package>?cmd=createSpecFileTemplate
   def package_command_createSpecFileTemplate
-    specfile_path = "#{request.path_info}/#{params[:package]}.spec"
     begin
-      backend_get( specfile_path )
+      # TODO: No need to read the whole file for knowing if it exists already
+      Backend::Api.source_file(params[:project], params[:package], "#{params[:package]}.spec")
       render_error status: 400, errorcode: 'spec_file_exists',
         message: 'SPEC file already exists.'
       return
     rescue ActiveXML::Transport::NotFoundError
-      specfile = File.read "#{Rails.root}/files/specfiletemplate"
-      Backend::Connection.put( specfile_path, specfile )
+      specfile_content = File.read("#{Rails.root}/files/specfiletemplate")
+      Backend::Api.write_source_file(params[:project], params[:package], "#{params[:package]}.spec", specfile_content)
     end
     render_ok
   end

--- a/src/api/app/controllers/source_controller.rb
+++ b/src/api/app/controllers/source_controller.rb
@@ -1338,20 +1338,18 @@ class SourceController < ApplicationController
       end
     end
 
-    path = "/build/#{@project.name}?cmd=rebuild&package=#{@package.name}"
+    options = {}
     if repo_name
       if @package && @package.repositories.find_by_name(repo_name).nil?
         render_error status: 400, errorcode: 'unknown_repository',
           message: "Unknown repository '#{repo_name}'"
         return
       end
-      path += "&repository=#{repo_name}"
+      options[:repository] = repo_name
     end
-    if arch_name
-      path += "&arch=#{arch_name}"
-    end
+    options[:arch] = arch_name if arch_name
 
-    backend.direct_http( URI(path), method: 'POST', data: '')
+    Backend::Api.rebuild(@project.name, @package.name, options)
 
     render_ok
   end

--- a/src/api/app/controllers/test_controller.rb
+++ b/src/api/app/controllers/test_controller.rb
@@ -31,7 +31,7 @@ class TestController < ApplicationController
     @@started = true
     WebMock.disable_net_connect!(allow_localhost: true)
     CONFIG['global_write_through'] = true
-    backend.direct_http(URI("/"))
+    Backend::Api.root
     render_ok
   end
 end

--- a/src/api/app/controllers/webui/package_controller.rb
+++ b/src/api/app/controllers/webui/package_controller.rb
@@ -954,15 +954,10 @@ class Webui::PackageController < Webui::WebuiController
     end
   end
 
-  def get_rpmlint_log(project, package, repository, architecture)
-    path = URI.escape("/build/#{project}/#{repository}/#{architecture}/#{package}/rpmlint.log")
-    ActiveXML.backend.direct_http(URI(path), timeout: 500)
-  end
-
   def rpmlint_log
     required_parameters :project, :package, :repository, :architecture
     begin
-      @log = get_rpmlint_log(params[:project], params[:package], params[:repository], params[:architecture])
+      @log = Backend::Api.rpmlint_log(params[:project], params[:package], params[:repository], params[:architecture])
       @log.encode!(xml: :text)
       render partial: 'rpmlint_log'
     rescue ActiveXML::Transport::NotFoundError

--- a/src/api/app/mixins/request_source_diff.rb
+++ b/src/api/app/mixins/request_source_diff.rb
@@ -105,7 +105,7 @@ module RequestSourceDiff
       # maintenance_release creates new packages instance, but are changing the source only according to the link
       return if action.target_package && :maintenance_incident == action.action_type
       begin
-        data = Xmlhash.parse(ActiveXML.backend.direct_http(URI("/source/#{URI.escape(action.source_project)}/#{URI.escape(spkg)}")))
+        data = Xmlhash.parse(Backend::Api.file_list(action.source_project, spkg))
       rescue ActiveXML::Transport::Error
         return
       end

--- a/src/api/app/models/bs_request_permission_check.rb
+++ b/src/api/app/models/bs_request_permission_check.rb
@@ -48,9 +48,8 @@ class BsRequestPermissionCheck
     if action.action_type.in?([:submit, :maintenance_incident])
       query = {expand: 1}
       query[:rev] = action.source_rev if action.source_rev
-      url = Package.source_path(action.source_project, action.source_package, nil, query)
       begin
-        ActiveXML.backend.direct_http(url)
+        Backend::Api.file_list(action.source_project, action.source_package, query)
       rescue ActiveXML::Transport::Error
         # rubocop:disable Metrics/LineLength
         raise ExpandError, "The source of package #{action.source_project}/#{action.source_package}#{action.source_rev ? " for revision #{action.source_rev}" : ''} is broken"
@@ -104,8 +103,7 @@ class BsRequestPermissionCheck
   def check_maintenance_release_accept(action)
     if action.source_rev
       # FIXME2.4 we have a directory model
-      url = Package.source_path(action.source_project, action.source_package, nil, expand: 1)
-      c = ActiveXML.backend.direct_http(url)
+      c = Backend::Api.file_list(action.source_project, action.source_package, expand: 1)
       data = REXML::Document.new(c)
       unless action.source_rev == data.elements['directory'].attributes['srcmd5']
         raise SourceChanged, "The current source revision in #{action.source_project}/#{action.source_package}" +

--- a/src/api/app/models/package_build_status.rb
+++ b/src/api/app/models/package_build_status.rb
@@ -92,8 +92,7 @@ class PackageBuildStatus
     @buildcode = "unknown"
     begin
       package = CGI.escape(@multibuild_pkg || @pkg.name)
-      uri = URI("/build/#{CGI.escape(@pkg.project.name)}/_result?package=#{package}&repository=#{CGI.escape(srep['name'])}&arch=#{CGI.escape(arch)}")
-      resultlist = Xmlhash.parse(ActiveXML.backend.direct_http(uri))
+      resultlist = Xmlhash.parse(Backend::Api.build_result(@pkg.project.name, package, srep['name'], arch))
       currentcode = nil
       resultlist.elements('result') do |r|
         r.elements('status') { |s| currentcode = s['code'] }

--- a/src/api/app/models/package_build_status.rb
+++ b/src/api/app/models/package_build_status.rb
@@ -124,11 +124,8 @@ class PackageBuildStatus
     missingdeps = []
     # if
     if @eversucceeded
-      # rubocop:disable Metrics/LineLength
-      uri = URI("/build/#{CGI.escape(@pkg.project.name)}/#{CGI.escape(srep['name'])}/#{CGI.escape(arch)}/_builddepinfo?package=#{CGI.escape(@pkg.name)}&view=pkgnames")
-      # rubocop:enable Metrics/LineLength
       begin
-        buildinfo = Xmlhash.parse(ActiveXML.backend.direct_http(uri))
+        buildinfo = Xmlhash.parse(Backend::Api.build_dependency_info(@pkg.project.name, @pkg.name, srep['name'], arch))
       rescue ActiveXML::Transport::Error => e
         # if there is an error, we ignore
         raise FailedToRetrieveBuildInfo, "Can't get buildinfo: #{e.summary}"

--- a/src/api/app/models/worker_status.rb
+++ b/src/api/app/models/worker_status.rb
@@ -1,7 +1,7 @@
 class WorkerStatus
   def self.hidden
     mydata = Rails.cache.read('workerstatus')
-    ws = ActiveXML::Node.new(mydata || ActiveXML.backend.direct_http('/build/_workerstatus'))
+    ws = ActiveXML::Node.new(mydata || Backend::Api.worker_status)
     prjs = Hash.new
     ws.each('building') do |b|
       prjs[b.value(:project)] = 1
@@ -25,7 +25,7 @@ class WorkerStatus
 
   def update_workerstatus_cache
     # do not add hiding in here - this is purely for statistics
-    ret = ActiveXML.backend.direct_http('/build/_workerstatus')
+    ret = Backend::Api.worker_status
     wdata = Xmlhash.parse(ret)
     @mytime = Time.now.to_i
     @squeues = Hash.new

--- a/src/api/lib/activexml/transport.rb
+++ b/src/api/lib/activexml/transport.rb
@@ -208,16 +208,6 @@ module ActiveXML
       @http_header.delete key if @http_header.has_key? key
     end
 
-    # TODO: get rid of this very thin wrapper
-    def direct_http( url, opt = {} )
-      defaults = {method: "GET"}
-      opt = defaults.merge opt
-
-      logger.debug "--> direct_http url: #{url}"
-
-      http_do opt[:method], URI.encode(url.to_s, /\+/), opt
-    end
-
     # replaces the parameter parts in the uri from the config file with the correct values
     def substitute_uri( uri, params )
       # logger.debug "[REST] reducing args: #{params.inspect}"

--- a/src/api/lib/backend/api.rb
+++ b/src/api/lib/backend/api.rb
@@ -193,5 +193,14 @@ module Backend
     def self.worker_status
       Backend::Connection.get('/build/_workerstatus').body.force_encoding("UTF-8")
     end
+
+    # Returns the source diff
+    def self.source_diff(project, package, options = {})
+      path = "/source/#{CGI.escape(project)}/#{CGI.escape(package)}"
+      query_hash = { cmd: :diff, view: :xml, withissues: 1 }
+      query_hash.merge!(options.slice(:rev, :orev, :opackage, :oproject, :linkrev, :olinkrev, :expand))
+      path += "?#{query_hash.to_query}"
+      Backend::Connection.post(path).body.force_encoding('UTF-8')
+    end
   end
 end

--- a/src/api/lib/backend/api.rb
+++ b/src/api/lib/backend/api.rb
@@ -175,5 +175,11 @@ module Backend
       path = "/build/#{CGI.escape(project)}/_result?view=status&code=failed&code=broken&code=unresolvable"
       Backend::Connection.get(path).body
     end
+
+    # Returns the RPMlint log
+    def self.rpmlint_log(project, package, repository, architecture)
+      path = "/build/#{CGI.escape(project)}/#{CGI.escape(repository)}/#{CGI.escape(architecture)}/#{CGI.escape(package)}/rpmlint.log"
+      Backend::Connection.get(path).body.force_encoding("UTF-8")
+    end
   end
 end

--- a/src/api/lib/backend/api.rb
+++ b/src/api/lib/backend/api.rb
@@ -202,5 +202,10 @@ module Backend
       path += "?#{query_hash.to_query}"
       Backend::Connection.post(path).body.force_encoding('UTF-8')
     end
+
+    # Pings the root of the backend
+    def self.root
+      Backend::Connection.get('/').body.force_encoding("UTF-8")
+    end
   end
 end

--- a/src/api/lib/backend/api.rb
+++ b/src/api/lib/backend/api.rb
@@ -181,5 +181,12 @@ module Backend
       path = "/build/#{CGI.escape(project)}/#{CGI.escape(repository)}/#{CGI.escape(architecture)}/#{CGI.escape(package)}/rpmlint.log"
       Backend::Connection.get(path).body.force_encoding("UTF-8")
     end
+
+    # Returns the build dependency information
+    def self.build_dependency_info(project, package, repository, architecture)
+      path = "/build/#{CGI.escape(project)}/#{CGI.escape(repository)}/#{CGI.escape(architecture)}/_builddepinfo"
+      path += "?package=#{CGI.escape(package)}&view=pkgnames"
+      Backend::Connection.get(path).body.force_encoding("UTF-8")
+    end
   end
 end

--- a/src/api/lib/backend/api.rb
+++ b/src/api/lib/backend/api.rb
@@ -188,5 +188,10 @@ module Backend
       path += "?package=#{CGI.escape(package)}&view=pkgnames"
       Backend::Connection.get(path).body.force_encoding("UTF-8")
     end
+
+    # Returns the worker's status
+    def self.worker_status
+      Backend::Connection.get('/build/_workerstatus').body.force_encoding("UTF-8")
+    end
   end
 end

--- a/src/api/lib/backend/api.rb
+++ b/src/api/lib/backend/api.rb
@@ -207,5 +207,14 @@ module Backend
     def self.root
       Backend::Connection.get('/').body.force_encoding("UTF-8")
     end
+
+    # Runs the command rebuild for that project/package
+    def self.rebuild(project, package, options = {})
+      path = "/build/#{CGI.escape(project)}"
+      query_hash = { cmd: :rebuild, package: package }
+      query_hash.merge!(options.slice(:repository, :arch))
+      path += "?#{query_hash.to_query}"
+      Backend::Connection.post(path)
+    end
   end
 end

--- a/src/api/lib/backend/api.rb
+++ b/src/api/lib/backend/api.rb
@@ -37,6 +37,16 @@ module Backend
       Backend::Connection.get("/source/#{CGI.escape(project)}/_project/_meta?rev=#{CGI.escape(revision)}&deleted=1").body
     end
 
+    # Returns the meta file from a project
+    def self.meta_from_project(project)
+      Backend::Connection.get("/source/#{CGI.escape(project)}/_project/_meta").body.force_encoding('UTF-8')
+    end
+
+    # Returns the meta file from a project/package
+    def self.meta_from_package(project, package)
+      Backend::Connection.get("/source/#{CGI.escape(project)}/#{CGI.escape(package)}/_meta").body.force_encoding('UTF-8')
+    end
+
     # It triggers all the services of a package (from src/api/app/controllers/webui/package_controller.rb)
     def self.trigger_services(project, package, user)
       Backend::Connection.post("/source/#{CGI.escape(project)}/#{CGI.escape(package)}?cmd=runservice&user=#{CGI.escape(user)}")
@@ -215,6 +225,16 @@ module Backend
       query_hash.merge!(options.slice(:repository, :arch))
       path += "?#{query_hash.to_query}"
       Backend::Connection.post(path)
+    end
+
+    # Returns the content of the source file
+    def self.source_file(project, package, filename)
+      Backend::Connection.get("/source/#{CGI.escape(project)}/#{CGI.escape(package)}/#{CGI.escape(filename)}").body.force_encoding('UTF-8')
+    end
+
+    # Writes the content of the source file
+    def self.write_source_file(project, package, filename, content = '')
+      Backend::Connection.put("/source/#{CGI.escape(project)}/#{CGI.escape(package)}/#{CGI.escape(filename)}", content)
     end
   end
 end

--- a/src/api/lib/backend/api.rb
+++ b/src/api/lib/backend/api.rb
@@ -24,7 +24,7 @@ module Backend
     def self.file_list(project, package, options = {})
       path = "/source/#{CGI.escape(project)}/#{CGI.escape(package)}"
       path += "?#{options.to_query}" if options.present?
-      Backend::Connection.get(path).body
+      Backend::Connection.get(path).body.force_encoding("UTF-8")
     end
 
     # Returns the revisions list for a package / project using mrev (from src/api/app/helpers/validation_helper.rb)

--- a/src/api/lib/backend/backend.rb
+++ b/src/api/lib/backend/backend.rb
@@ -1,8 +1,3 @@
 require 'benchmark'
 require 'api_exception'
-require_dependency 'logger'
-require_dependency 'connection'
-require_dependency 'file'
-require_dependency 'api'
-require_dependency 'test'
-require_dependency 'tests/tasks'
+Dir[File.join(__dir__, '**', '*')].each {|file| require_dependency file }

--- a/src/api/lib/backend/test/tasks.rb
+++ b/src/api/lib/backend/test/tasks.rb
@@ -1,5 +1,5 @@
 module Backend
-  module Tests
+  class Test
     module Tasks
       def run_scheduler(arch)
         Rails.logger.debug "RUN_SCHEDULER #{arch}"

--- a/src/api/script/start_test_backend
+++ b/src/api/script/start_test_backend
@@ -5,7 +5,7 @@ ENV['LC_ALL'] = 'C'
 require File.expand_path(File.join(File.dirname(__FILE__), '..', 'config', 'environment'))
 require 'builder'
 
-include Backend::Tests::Tasks
+include Backend::Test::Tasks
 
 port_src_server = 3200
 port_rep_server = 3201
@@ -376,8 +376,8 @@ scheduler_thread = Thread.new do
   #
 
   # run scheduler for i586 and x86_64 once
-  Backend::Tests::Tasks.run_scheduler('i586')
-  Backend::Tests::Tasks.run_scheduler('x86_64')
+  Backend::Test::Tasks.run_scheduler('i586')
+  Backend::Test::Tasks.run_scheduler('x86_64')
 
   # Inject build job results
   inject_build_job('home:Iggy', 'TestPack', '10.2', 'i586')
@@ -395,14 +395,14 @@ scheduler_thread = Thread.new do
                           File.open("#{Rails.root}/test/fixtures/backend/binary/delete_me-1.0-1.i586.rpm").read)
 
   # run scheduler again to handle the build result
-  Backend::Tests::Tasks.run_scheduler('i586')
+  Backend::Test::Tasks.run_scheduler('i586')
 
   # copy build result
   Backend::Connection.post('/build/HiddenProject/nada/i586/packCopy?cmd=copy&opackage=pack')
   Backend::Connection.post('/build/BaseDistro/BaseDistro_repo/i586/pack2?cmd=copy&oproject=home:Iggy&orepository=10.2&opackage=TestPack')
 
   # run scheduler again to handle the copy build event
-  Backend::Tests::Tasks.run_scheduler('i586')
+  Backend::Test::Tasks.run_scheduler('i586')
 
   # update event database, esp. binary_release table
   BinaryRelease.transaction(requires_new: true) do

--- a/src/api/test/test_helper.rb
+++ b/src/api/test/test_helper.rb
@@ -386,7 +386,7 @@ end
 
 module ActionDispatch
   class IntegrationTest
-    include Backend::Tests::Tasks
+    include Backend::Test::Tasks
 
     def teardown
       Rails.cache.clear


### PR DESCRIPTION
Refactor all the calls to ActiveXML.backend.direct_http and introduce methods in Backend::Api that replaces all the uses.