### PR TITLE
[webui] Fix Hyperlink colors

### DIFF
--- a/src/api/app/assets/stylesheets/webui/application/our-own-jquery-ui.scss
+++ b/src/api/app/assets/stylesheets/webui/application/our-own-jquery-ui.scss
@@ -88,11 +88,3 @@ body .ui-tooltip {
 .ui-front {
   z-index: 100;
 }
-
-.ui-widget-content {
-  background: #ffffff;
-  color: #222222;
-}
-.ui-widget-content a {
-  color: #222222;
-}


### PR DESCRIPTION
We made some changes in the css that accidentally affect other sections. Now it's reverted.

#### Before
![screenshot from 2017-09-14 10-01-06](https://user-images.githubusercontent.com/1212806/30418720-4084c636-9934-11e7-87c8-94806adf3924.png)


#### After
![screenshot from 2017-09-14 10-00-42](https://user-images.githubusercontent.com/1212806/30418725-4635ed76-9934-11e7-823f-07f2d269d7c5.png)

close #3824 and #3820