### PR TITLE
[api] avoid multiple hits of same package on maintenance branch

### DIFF
--- a/src/api/app/models/branch_package.rb
+++ b/src/api/app/models/branch_package.rb
@@ -72,6 +72,10 @@ class BranchPackage
     # Just requests should be nearly the same
     find_package_targets unless params[:request]
 
+    # it is okay to branch the same package multiple times when having
+    # different link_target_projects
+    @packages.uniq! { |x| x[:target_package] }
+
     @target_project ||= User.current.branch_project_name(params[:project])
 
     #


### PR DESCRIPTION
happens when you get the same package instance via multiple OBS:Maintained
entry points via project linking

The target_package strings takes also the possible different link_target_project into account.