### PR TITLE
[dist] Require group www

### DIFF
--- a/dist/obs-server.spec
+++ b/dist/obs-server.spec
@@ -200,6 +200,9 @@ Group:          Productivity/Networking/Web/Utilities
 PreReq:         %insserv_prereq
 Requires(pre):  obs-common
 %endif
+%if 0%{?suse_version} >= 1330
+Requires(pre):  group(www)
+%endif
 
 #For apache
 Requires:       apache2 apache2-mod_xforward rubygem-passenger-apache2 ruby2.4-rubygem-passenger


### PR DESCRIPTION
We use it in a scriptlet and it's not provided by default anymore on openSUSE.