### PR TITLE
[api][webui] Include again direct_http

### DIFF
--- a/src/api/lib/activexml/transport.rb
+++ b/src/api/lib/activexml/transport.rb
@@ -208,6 +208,16 @@ module ActiveXML
       @http_header.delete key if @http_header.has_key? key
     end
 
+    # TODO: get rid of this very thin wrapper
+    def direct_http( url, opt = {} )
+      defaults = {method: "GET"}
+      opt = defaults.merge opt
+
+      logger.debug "--> direct_http url: #{url}"
+
+      http_do opt[:method], URI.encode(url.to_s, /\+/), opt
+    end
+
     # replaces the parameter parts in the uri from the config file with the correct values
     def substitute_uri( uri, params )
       # logger.debug "[REST] reducing args: #{params.inspect}"


### PR DESCRIPTION
Because obs_factory still using `direct_http` method. 
This method was removed in the commit [14f99b](https://github.com/openSUSE/open-build-service/commit/a14f99bb14ea6731fe978acb6bad3037e35542dd).

resolve #3845