### PR TITLE
[dist] Add missing release notes entry for bcrypt

### DIFF
--- a/ReleaseNotes-2.9
+++ b/ReleaseNotes-2.9
@@ -70,6 +70,8 @@ Wanted changes:
 
  * dropping of the project/package tag functionality/api
 
+ * password hashing algorithm was changed to bcrypt (blowfish)
+
 Other changes
 =============
 


### PR DESCRIPTION
This adds a release notes entry regarding the bcrypt implementation from
PR #3814

Commit: d0fd0bdb8ec9ffbc7f85faf4050ff2bfb1204263