### PR TITLE
[webui] Don't fail if no HTTP referrer was provided on login

### DIFF
--- a/src/api/app/controllers/webui/user_controller.rb
+++ b/src/api/app/controllers/webui/user_controller.rb
@@ -44,7 +44,7 @@ class Webui::UserController < Webui::WebuiController
     session[:login] = user.login
     User.current = user
 
-    if request.referer.end_with?("/user/login")
+    if request.referer && request.referer.end_with?("/user/login")
       redirect_to user_show_path(User.current)
     else
       redirect_back(fallback_location: root_path)

--- a/src/api/spec/controllers/webui/user_controller_spec.rb
+++ b/src/api/spec/controllers/webui/user_controller_spec.rb
@@ -104,6 +104,16 @@ RSpec.describe Webui::UserController do
   end
 
   describe "POST #do_login" do
+    context "without referrer" do
+      before do
+        post :do_login, params: { username: user.login, password: 'buildservice' }
+      end
+
+      it 'redirects to root path' do
+        expect(response).to redirect_to root_path
+      end
+    end
+
     context "with deprecated password" do
       let(:user) { create(:user_deprecated_password, state: :confirmed) }
 


### PR DESCRIPTION
Otherwise the app crashes when no referrer was provided. This can harm us especially users forbid their browsers to set that header field.