### PR TITLE
[api] Make bcrypt migration reversible

### DIFF
--- a/src/api/db/migrate/20170905081525_add_has_secure_password_support.rb
+++ b/src/api/db/migrate/20170905081525_add_has_secure_password_support.rb
@@ -4,9 +4,18 @@ class AddHasSecurePasswordSupport < ActiveRecord::Migration[5.1]
     rename_column :users, :password_hash_type, :deprecated_password_hash_type
     rename_column :users, :password_salt, :deprecated_password_salt
 
-    change_column :users, :deprecated_password, :string, null: true, default: nil, after: :realname
-    change_column :users, :deprecated_password_hash_type, :string, null: true, default: nil, after: :deprecated_password
-    change_column :users, :deprecated_password_salt, :string, null: true, default: nil, after: :deprecated_password_hash_type
+    reversible do |dir|
+      dir.up do
+        change_column :users, :deprecated_password,           :string, null: true, default: nil, after: :realname
+        change_column :users, :deprecated_password_hash_type, :string, null: true, default: nil, after: :deprecated_password
+        change_column :users, :deprecated_password_salt,      :string, null: true, default: nil, after: :deprecated_password_hash_type
+      end
+      dir.down do
+        change_column :users, :deprecated_password,           :string, null: false, default: '', after: :realname, limit: 100
+        change_column :users, :deprecated_password_hash_type, :string, null: false, default: '', after: :deprecated_password, limit: 20
+        change_column :users, :deprecated_password_salt,      :string, null: false, default: '', after: :deprecated_password_hash_type, limit: 10
+      end
+    end
 
     add_column :users, :password_digest, :string, after: :realname
   end


### PR DESCRIPTION
The migration is using change_column, which isn't reversible. Thus we
have to provide a 'down' part for the migration.