### PR TITLE
[webui] Only allow `apt-deb` and `rpm-md`

### DIFF
--- a/src/api/app/models/kiwi/repository.rb
+++ b/src/api/app/models/kiwi/repository.rb
@@ -3,7 +3,7 @@ class Kiwi::Repository < ApplicationRecord
   #### Includes and extends
 
   #### Constants
-  REPO_TYPES = ['rpm-md', 'rpm-dir', 'yast2', 'apt-deb'].freeze
+  REPO_TYPES = ['rpm-md', 'apt-deb'].freeze
 
   #### Self config
 
@@ -13,6 +13,7 @@ class Kiwi::Repository < ApplicationRecord
   belongs_to :image
 
   #### Callbacks macros: before_save, after_save, etc.
+  before_validation :map_to_allowed_repository_types, on: :create
 
   #### Scopes (first the default_scope macro if is used)
 
@@ -99,7 +100,9 @@ class Kiwi::Repository < ApplicationRecord
     Regexp.last_match(2) =~ /\A[^_:\/\000-\037][^:\/\000-\037]*\Z/
   end
 
-  #### Alias of methods
+  def map_to_allowed_repository_types
+    self.repo_type = 'rpm-md' unless repo_type.in?(REPO_TYPES)
+  end
 end
 
 # == Schema Information

--- a/src/api/spec/models/kiwi/image_spec.rb
+++ b/src/api/spec/models/kiwi/image_spec.rb
@@ -27,6 +27,7 @@ RSpec.describe Kiwi::Image, type: :model, vcr: true do
       it { expect(subject.name).to eq('Christians_openSUSE_13.2_JeOS') }
 
       it 'parses the repository elements of the xml into a KiwiImage model' do
+        subject.valid?
         expect(subject.repositories[0]).to have_attributes(
           source_path: 'http://download.opensuse.org/update/13.2/',
           repo_type: 'apt-deb',
@@ -41,7 +42,7 @@ RSpec.describe Kiwi::Image, type: :model, vcr: true do
         )
         expect(subject.repositories[1]).to have_attributes(
           source_path: 'http://download.opensuse.org/distribution/13.2/repo/oss/',
-          repo_type: 'rpm-dir',
+          repo_type: 'rpm-md',
           priority: 20,
           order: 2,
           alias: nil,

--- a/src/api/spec/models/kiwi/repository_spec.rb
+++ b/src/api/spec/models/kiwi/repository_spec.rb
@@ -109,7 +109,9 @@ RSpec.describe Kiwi::Repository, type: :model do
       end
     end
 
-    it { is_expected.to validate_inclusion_of(:repo_type).in_array(Kiwi::Repository::REPO_TYPES) }
+    # We specific the context of the inclusion validation because of a bug in shoulda_matcher.
+    # Remove `.on(:save)` when it's solved.
+    it { is_expected.to validate_inclusion_of(:repo_type).in_array(Kiwi::Repository::REPO_TYPES).on(:save) }
     it { is_expected.to validate_numericality_of(:priority).is_greater_than_or_equal_to(0).is_less_than(100) }
     it { is_expected.to validate_numericality_of(:order).is_greater_than_or_equal_to(1) }
     it { is_expected.to allow_value(nil).for(:imageinclude) }

--- a/src/api/spec/support/shared_contexts/a_kiwi_image_xml.rb
+++ b/src/api/spec/support/shared_contexts/a_kiwi_image_xml.rb
@@ -40,7 +40,7 @@ RSpec.shared_context 'a kiwi image xml' do
   <repository type="rpm-dir" priority="20" imageinclude="false" prefer-license="false">
     <source path="http://download.opensuse.org/distribution/13.2/repo/oss/"/>
   </repository>
-  <repository type="rpm-md" priority="20">
+  <repository type="yast2" priority="20">
     <source path="http://download.opensuse.org/distribution/13.1/repo/oss/"/>
   </repository>
   <repository type="rpm-md">


### PR DESCRIPTION
At the moment we only allow `apt-deb` and `rpm-md` as repo_type. If a
kiwi file as a invalid repo_type, this will be replaced by `rpm-md`
in the Kiwi Editor.