### PR TITLE
[api] Fix IssueTracker#fetch_bugzilla_issues on connection reset.

### DIFF
--- a/src/api/app/models/issue_tracker.rb
+++ b/src/api/app/models/issue_tracker.rb
@@ -196,11 +196,11 @@ class IssueTracker < ApplicationRecord
     while !ids.blank?
       begin
         result = bugzilla_server.get({ids: ids[0..limit_per_slice], permissive: 1})
-      rescue RuntimeError => e
-        logger.error "Unable to fetch issue #{e.inspect}"
-        return false
       rescue XMLRPC::FaultException => e
         logger.error "Error: #{e.faultCode} #{e.faultString}"
+        return false
+      rescue StandardError => e
+        logger.error "Unable to fetch issue #{e.inspect}"
         return false
       end
       result["bugs"].each { |r| parse_single_bugzilla_issue(r) }


### PR DESCRIPTION
This method was raising an error when the connection resets but we would
rather have this fail silently since it is run from a delayed job.

https://errbit-opensuse.herokuapp.com/apps/5620ca2bdc71fa00b1000000/problems/59b9416038009500069ce522