### PR TITLE
[api][webui] Fix BsRequest max char length for columns.

### DIFF
--- a/src/api/app/models/bs_request.rb
+++ b/src/api/app/models/bs_request.rb
@@ -83,8 +83,8 @@ class BsRequest < ApplicationRecord
   validates :creator, presence: true
   validate :check_supersede_state
   validate :check_creator, on: [:create, :save!]
-  validates :comment, length: { maximum: 300000 }
-  validates :description, length: { maximum: 300000 }
+  validates :comment, length: { maximum: 65535 }
+  validates :description, length: { maximum: 65535 }
 
   after_update :send_state_change
   after_commit :update_cache


### PR DESCRIPTION
The max char length for description and comment columns validation was
too long so it would cause a mysql error when too many characters were
attempted to be inserted.

Fixes this error: https://errbit-opensuse.herokuapp.com/apps/5620ca2bdc71fa00b1000000/problems/59bb22d2263b4500066a9558