### PR TITLE
Show package_groups without patternType

### DIFF
--- a/src/api/app/assets/stylesheets/webui/application/kiwi_image.scss
+++ b/src/api/app/assets/stylesheets/webui/application/kiwi_image.scss
@@ -35,6 +35,18 @@
   }
 }
 
+#kiwi-packages-list {
+  .pattern {
+    color: #999;
+    font-size: 1em;
+    border-bottom: 1px solid #999;
+    margin-left: 0;
+    margin-top: 20px;
+    padding-left: 5px;
+    padding-bottom: 5px;
+  }
+}
+
 #kiwi-repositories-list, #kiwi-packages-list {
   padding-left: 10px;
   padding-right: 10px;

--- a/src/api/app/models/kiwi/image.rb
+++ b/src/api/app/models/kiwi/image.rb
@@ -21,7 +21,7 @@ class Kiwi::Image < ApplicationRecord
   has_one :package, foreign_key: 'kiwi_image_id', class_name: '::Package', dependent: :nullify, inverse_of: :kiwi_image
   has_many :repositories, -> { order(order: :asc) }, dependent: :destroy, index_errors: true
   has_many :package_groups, -> { order(:id) }, dependent: :destroy, index_errors: true
-  has_many :kiwi_packages, -> { where(kiwi_package_groups: { kiwi_type: Kiwi::PackageGroup.kiwi_types[:image], pattern_type: 'onlyRequired' }) },
+  has_many :kiwi_packages, -> { where(kiwi_package_groups: { kiwi_type: Kiwi::PackageGroup.kiwi_types[:image] }) },
            through: :package_groups, source: :packages, inverse_of: :kiwi_image
 
   #### Callbacks macros: before_save, after_save, etc.
@@ -133,7 +133,7 @@ class Kiwi::Image < ApplicationRecord
   end
 
   def default_package_group
-    package_groups.find_or_create_by(kiwi_type: :image, pattern_type: 'onlyRequired')
+    package_groups.find_or_create_by(kiwi_type: :image)
   end
 
   def self.find_binaries_by_name(query, project, repositories, options = {})

--- a/src/api/app/models/kiwi/image.rb
+++ b/src/api/app/models/kiwi/image.rb
@@ -133,7 +133,7 @@ class Kiwi::Image < ApplicationRecord
   end
 
   def default_package_group
-    package_groups.find_or_create_by(kiwi_type: :image)
+    package_groups.type_image
   end
 
   def self.find_binaries_by_name(query, project, repositories, options = {})

--- a/src/api/app/models/kiwi/package_group.rb
+++ b/src/api/app/models/kiwi/package_group.rb
@@ -26,6 +26,10 @@ class Kiwi::PackageGroup < ApplicationRecord
 
     builder.to_xml save_with: Nokogiri::XML::Node::SaveOptions::NO_DECLARATION | Nokogiri::XML::Node::SaveOptions::FORMAT
   end
+
+  def kiwi_type_image?
+    kiwi_type == 'image'
+  end
 end
 
 # == Schema Information

--- a/src/api/app/models/kiwi/package_group.rb
+++ b/src/api/app/models/kiwi/package_group.rb
@@ -6,6 +6,8 @@ class Kiwi::PackageGroup < ApplicationRecord
   # exist in Active Record, such as "delete"
   enum kiwi_type: %i[bootstrap delete docker image iso lxc oem pxe split testsuite vmx], _prefix: :type
 
+  scope :type_image, -> { where(kiwi_type: :image) }
+
   validates :kiwi_type, presence: true
 
   accepts_nested_attributes_for :packages, reject_if: :all_blank, allow_destroy: true

--- a/src/api/spec/cassettes/Webui_Kiwi_ImagesController/GET_import_from_package/with_a_kiwi_file/with_multiple_package_groups/with_same_attributes/1_1_2_4_1_2.yml
+++ b/src/api/spec/cassettes/Webui_Kiwi_ImagesController/GET_import_from_package/with_a_kiwi_file/with_multiple_package_groups/with_same_attributes/1_1_2_4_1_2.yml
@@ -1,0 +1,38 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://localhost:3200/source/fake_project/package_with_invalid_kiwi_file
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 404
+      message: project 'fake_project' does not exist
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '152'
+    body:
+      encoding: UTF-8
+      string: |
+        <status code="404">
+          <summary>project 'fake_project' does not exist</summary>
+          <details>404 project 'fake_project' does not exist</details>
+        </status>
+    http_version: 
+  recorded_at: Fri, 22 Sep 2017 14:47:32 GMT
+recorded_with: VCR 3.0.3

--- a/src/api/spec/cassettes/Webui_Kiwi_ImagesController/GET_import_from_package/with_a_kiwi_file/with_multiple_package_groups/with_same_attributes/redirect_to_package_view_file_path.yml
+++ b/src/api/spec/cassettes/Webui_Kiwi_ImagesController/GET_import_from_package/with_a_kiwi_file/with_multiple_package_groups/with_same_attributes/redirect_to_package_view_file_path.yml
@@ -1,0 +1,38 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://localhost:3200/source/fake_project/package_with_invalid_kiwi_file
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 404
+      message: project 'fake_project' does not exist
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '152'
+    body:
+      encoding: UTF-8
+      string: |
+        <status code="404">
+          <summary>project 'fake_project' does not exist</summary>
+          <details>404 project 'fake_project' does not exist</details>
+        </status>
+    http_version: 
+  recorded_at: Fri, 22 Sep 2017 14:47:32 GMT
+recorded_with: VCR 3.0.3

--- a/src/api/spec/cassettes/Webui_Kiwi_ImagesController/GET_import_from_package/with_a_kiwi_file/with_multiple_package_groups/with_the_same_attributes/1_1_2_4_1_2.yml
+++ b/src/api/spec/cassettes/Webui_Kiwi_ImagesController/GET_import_from_package/with_a_kiwi_file/with_multiple_package_groups/with_the_same_attributes/1_1_2_4_1_2.yml
@@ -7,7 +7,7 @@ http_interactions:
       encoding: UTF-8
       string: |
         <project name="fake_project">
-          <title>By Grand Central Station I Sat Down and Wept</title>
+          <title>The Doors of Perception</title>
           <description/>
         </project>
     headers:
@@ -29,23 +29,23 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '133'
+      - '112'
     body:
       encoding: UTF-8
       string: |
         <project name="fake_project">
-          <title>By Grand Central Station I Sat Down and Wept</title>
+          <title>The Doors of Perception</title>
           <description></description>
         </project>
     http_version: 
-  recorded_at: Mon, 11 Sep 2017 21:36:38 GMT
+  recorded_at: Thu, 05 Oct 2017 08:56:46 GMT
 - request:
     method: put
     uri: http://backend:5352/source/fake_project/_config
     body:
       encoding: UTF-8
-      string: Deserunt perspiciatis autem quas facilis molestias sint. Fugiat qui
-        libero. Molestias quo cum ut qui at quia.
+      string: Ut hic molestias esse. Aspernatur accusamus saepe ut rerum error enim
+        officia. Illo veritatis consectetur et quis esse a.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -72,16 +72,16 @@ http_interactions:
 
 '
     http_version: 
-  recorded_at: Mon, 11 Sep 2017 21:36:38 GMT
+  recorded_at: Thu, 05 Oct 2017 08:56:46 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/fake_project/package_with_invalid_kiwi_file/_meta?user=tom
+    uri: http://backend:5352/source/fake_project/package_with_invalid_kiwi_file/_meta?user=_nobody_
     body:
       encoding: UTF-8
       string: |
         <package name="package_with_invalid_kiwi_file" project="fake_project">
-          <title>Absalom, Absalom!</title>
-          <description>Cupiditate repellat et optio ipsa.</description>
+          <title>That Good Night</title>
+          <description>Nisi occaecati expedita nihil veniam beatae voluptatem eos.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -102,16 +102,16 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '181'
+      - '204'
     body:
       encoding: UTF-8
       string: |
         <package name="package_with_invalid_kiwi_file" project="fake_project">
-          <title>Absalom, Absalom!</title>
-          <description>Cupiditate repellat et optio ipsa.</description>
+          <title>That Good Night</title>
+          <description>Nisi occaecati expedita nihil veniam beatae voluptatem eos.</description>
         </package>
     http_version: 
-  recorded_at: Mon, 11 Sep 2017 21:36:38 GMT
+  recorded_at: Thu, 05 Oct 2017 08:56:46 GMT
 - request:
     method: put
     uri: http://backend:5352/source/fake_project/package_with_invalid_kiwi_file/_meta
@@ -119,8 +119,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="package_with_invalid_kiwi_file" project="fake_project">
-          <title>Absalom, Absalom!</title>
-          <description>Cupiditate repellat et optio ipsa.</description>
+          <title>That Good Night</title>
+          <description>Nisi occaecati expedita nihil veniam beatae voluptatem eos.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -141,16 +141,16 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '181'
+      - '204'
     body:
       encoding: UTF-8
       string: |
         <package name="package_with_invalid_kiwi_file" project="fake_project">
-          <title>Absalom, Absalom!</title>
-          <description>Cupiditate repellat et optio ipsa.</description>
+          <title>That Good Night</title>
+          <description>Nisi occaecati expedita nihil veniam beatae voluptatem eos.</description>
         </package>
     http_version: 
-  recorded_at: Mon, 11 Sep 2017 21:36:38 GMT
+  recorded_at: Thu, 05 Oct 2017 08:56:46 GMT
 - request:
     method: put
     uri: http://backend:5352/source/fake_project/package_with_invalid_kiwi_file/package_with_invalid_kiwi_file.kiwi
@@ -169,34 +169,25 @@ http_interactions:
             <package name="aaa_base"/>
             <package name="branding-openSUSE"/>
             <package name="patterns-openSUSE-base"/>
-            <package name="grub2"/>
-            <package name="hwinfo"/>
-            <package name="iputils"/>
-            <package name="kernel-default"/>
-            <package name="netcfg"/>
-            <package name="openSUSE-build-key"/>
-            <package name="openssh"/>
-            <package name="plymouth"/>
-            <package name="polkit-default-privs"/>
-            <package name="rpcbind"/>
-            <package name="syslog-ng"/>
-            <package name="vim"/>
-            <package name="zypper"/>
-            <package name="timezone"/>
-            <package name="openSUSE-release-dvd"/>
-            <package name="gfxboot-devel" bootinclude="true"/>
           </packages>
-          <repository type="wrong" priority="10" alias="debian" imageinclude="true" password="123456" prefer-license="true" status="replaceable" username="Tom">
+          <packages type="image" patternType="onlyRequired">
+            <package name="e2fsprogs"/>
+            <package name="aaa_base"/>
+            <package name="branding-openSUSE"/>
+            <package name="patterns-openSUSE-base"/>
+          </packages>
+          <packages type="image">
+            <package name="e2fsprogs"/>
+            <package name="aaa_base"/>
+            <package name="branding-openSUSE"/>
+            <package name="patterns-openSUSE-base"/>
+          </packages>
+          <packages type="delete">
+            <package name="e2fsprogss"/>
+            <package name="bbb_base"/>
+          </packages>
+          <repository type="apt-deb" priority="10" alias="debian" imageinclude="true" password="123456" prefer-license="true" status="replaceable" username="Tom">
             <source path="http://download.opensuse.org/update/13.2/"/>
-          </repository>
-          <repository type="rpm-dir" priority="wrong" imageinclude="false" prefer-license="false">
-            <source path="http://download.opensuse.org/distribution/13.2/repo/oss/"/>
-          </repository>
-          <repository type="rpm-md" priority="20">
-            <source path="wrong://download.opensuse.org/distribution/13.1/repo/oss/"/>
-          </repository>
-          <repository type="rpm-md">
-            <source path="http://download.opensuse.org/distribution/12.1/repo/oss/"/>
           </repository>
         </image>
     headers:
@@ -218,20 +209,20 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '209'
+      - '207'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="20" vrev="20">
-          <srcmd5>6ccfa0805f62f6fba78db7bc8b4082ba</srcmd5>
+        <revision rev="2" vrev="2">
+          <srcmd5>95d5332d39abd8e345bd458f2bc40b41</srcmd5>
           <version>unknown</version>
-          <time>1505165798</time>
+          <time>1507193806</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
     http_version: 
-  recorded_at: Mon, 11 Sep 2017 21:36:38 GMT
+  recorded_at: Thu, 05 Oct 2017 08:56:47 GMT
 - request:
     method: get
     uri: http://backend:5352/source/fake_project/package_with_invalid_kiwi_file
@@ -257,15 +248,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '249'
+      - '247'
     body:
       encoding: UTF-8
       string: |
-        <directory name="package_with_invalid_kiwi_file" rev="20" vrev="20" srcmd5="6ccfa0805f62f6fba78db7bc8b4082ba">
-          <entry name="package_with_invalid_kiwi_file.kiwi" md5="5a69f457207aa0e7d1cdc633164df54d" size="1791" mtime="1505142565" />
+        <directory name="package_with_invalid_kiwi_file" rev="2" vrev="2" srcmd5="95d5332d39abd8e345bd458f2bc40b41">
+          <entry name="package_with_invalid_kiwi_file.kiwi" md5="886f273630dea2b68a3259d38c1080f7" size="1311" mtime="1507193806" />
         </directory>
     http_version: 
-  recorded_at: Mon, 11 Sep 2017 21:36:38 GMT
+  recorded_at: Thu, 05 Oct 2017 08:56:47 GMT
 - request:
     method: get
     uri: http://backend:5352/source/fake_project/package_with_invalid_kiwi_file/package_with_invalid_kiwi_file.kiwi
@@ -287,7 +278,7 @@ http_interactions:
       Content-Type:
       - application/octet-stream
       Content-Length:
-      - '1791'
+      - '1311'
       Cache-Control:
       - no-cache
       Connection:
@@ -307,38 +298,29 @@ http_interactions:
             <package name="aaa_base"/>
             <package name="branding-openSUSE"/>
             <package name="patterns-openSUSE-base"/>
-            <package name="grub2"/>
-            <package name="hwinfo"/>
-            <package name="iputils"/>
-            <package name="kernel-default"/>
-            <package name="netcfg"/>
-            <package name="openSUSE-build-key"/>
-            <package name="openssh"/>
-            <package name="plymouth"/>
-            <package name="polkit-default-privs"/>
-            <package name="rpcbind"/>
-            <package name="syslog-ng"/>
-            <package name="vim"/>
-            <package name="zypper"/>
-            <package name="timezone"/>
-            <package name="openSUSE-release-dvd"/>
-            <package name="gfxboot-devel" bootinclude="true"/>
           </packages>
-          <repository type="wrong" priority="10" alias="debian" imageinclude="true" password="123456" prefer-license="true" status="replaceable" username="Tom">
+          <packages type="image" patternType="onlyRequired">
+            <package name="e2fsprogs"/>
+            <package name="aaa_base"/>
+            <package name="branding-openSUSE"/>
+            <package name="patterns-openSUSE-base"/>
+          </packages>
+          <packages type="image">
+            <package name="e2fsprogs"/>
+            <package name="aaa_base"/>
+            <package name="branding-openSUSE"/>
+            <package name="patterns-openSUSE-base"/>
+          </packages>
+          <packages type="delete">
+            <package name="e2fsprogss"/>
+            <package name="bbb_base"/>
+          </packages>
+          <repository type="apt-deb" priority="10" alias="debian" imageinclude="true" password="123456" prefer-license="true" status="replaceable" username="Tom">
             <source path="http://download.opensuse.org/update/13.2/"/>
-          </repository>
-          <repository type="rpm-dir" priority="wrong" imageinclude="false" prefer-license="false">
-            <source path="http://download.opensuse.org/distribution/13.2/repo/oss/"/>
-          </repository>
-          <repository type="rpm-md" priority="20">
-            <source path="wrong://download.opensuse.org/distribution/13.1/repo/oss/"/>
-          </repository>
-          <repository type="rpm-md">
-            <source path="http://download.opensuse.org/distribution/12.1/repo/oss/"/>
           </repository>
         </image>
     http_version: 
-  recorded_at: Mon, 11 Sep 2017 21:36:38 GMT
+  recorded_at: Thu, 05 Oct 2017 08:56:47 GMT
 - request:
     method: get
     uri: http://backend:5352/source/fake_project/package_with_invalid_kiwi_file
@@ -364,52 +346,13 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '249'
+      - '247'
     body:
       encoding: UTF-8
       string: |
-        <directory name="package_with_invalid_kiwi_file" rev="20" vrev="20" srcmd5="6ccfa0805f62f6fba78db7bc8b4082ba">
-          <entry name="package_with_invalid_kiwi_file.kiwi" md5="5a69f457207aa0e7d1cdc633164df54d" size="1791" mtime="1505142565" />
+        <directory name="package_with_invalid_kiwi_file" rev="2" vrev="2" srcmd5="95d5332d39abd8e345bd458f2bc40b41">
+          <entry name="package_with_invalid_kiwi_file.kiwi" md5="886f273630dea2b68a3259d38c1080f7" size="1311" mtime="1507193806" />
         </directory>
-    http_version: 
-  recorded_at: Mon, 11 Sep 2017 21:36:38 GMT
-- request:
-    method: put
-    uri: http://backend:5352/source/fake_project/package_with_invalid_kiwi_file/_meta?user=_nobody_
-    body:
-      encoding: UTF-8
-      string: |
-        <package name="package_with_invalid_kiwi_file" project="fake_project">
-          <title>Brandy of the Damned</title>
-          <description>Tempora error doloremque animi praesentium mollitia.</description>
-        </package>
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '202'
-    body:
-      encoding: UTF-8
-      string: |
-        <package name="package_with_invalid_kiwi_file" project="fake_project">
-          <title>Brandy of the Damned</title>
-          <description>Tempora error doloremque animi praesentium mollitia.</description>
-        </package>
     http_version: 
   recorded_at: Thu, 05 Oct 2017 08:56:47 GMT
 recorded_with: VCR 3.0.3

--- a/src/api/spec/cassettes/Webui_Kiwi_ImagesController/GET_import_from_package/with_a_kiwi_file/with_multiple_package_groups/with_the_same_attributes/redirect_to_package_view_file_path.yml
+++ b/src/api/spec/cassettes/Webui_Kiwi_ImagesController/GET_import_from_package/with_a_kiwi_file/with_multiple_package_groups/with_the_same_attributes/redirect_to_package_view_file_path.yml
@@ -7,7 +7,7 @@ http_interactions:
       encoding: UTF-8
       string: |
         <project name="fake_project">
-          <title>By Grand Central Station I Sat Down and Wept</title>
+          <title>Bury My Heart at Wounded Knee</title>
           <description/>
         </project>
     headers:
@@ -29,23 +29,24 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '133'
+      - '118'
     body:
       encoding: UTF-8
       string: |
         <project name="fake_project">
-          <title>By Grand Central Station I Sat Down and Wept</title>
+          <title>Bury My Heart at Wounded Knee</title>
           <description></description>
         </project>
     http_version: 
-  recorded_at: Mon, 11 Sep 2017 21:36:38 GMT
+  recorded_at: Thu, 05 Oct 2017 08:56:46 GMT
 - request:
     method: put
     uri: http://backend:5352/source/fake_project/_config
     body:
       encoding: UTF-8
-      string: Deserunt perspiciatis autem quas facilis molestias sint. Fugiat qui
-        libero. Molestias quo cum ut qui at quia.
+      string: Occaecati eius et incidunt. Quod sunt dolorum omnis dolore et. Enim
+        cum odio ullam maxime eos. Velit eum error voluptatem modi quibusdam. Quas
+        beatae labore deserunt autem sapiente.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -72,16 +73,16 @@ http_interactions:
 
 '
     http_version: 
-  recorded_at: Mon, 11 Sep 2017 21:36:38 GMT
+  recorded_at: Thu, 05 Oct 2017 08:56:46 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/fake_project/package_with_invalid_kiwi_file/_meta?user=tom
+    uri: http://backend:5352/source/fake_project/package_with_invalid_kiwi_file/_meta?user=_nobody_
     body:
       encoding: UTF-8
       string: |
         <package name="package_with_invalid_kiwi_file" project="fake_project">
-          <title>Absalom, Absalom!</title>
-          <description>Cupiditate repellat et optio ipsa.</description>
+          <title>A Glass of Blessings</title>
+          <description>Itaque omnis expedita harum corporis consequuntur necessitatibus.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -102,16 +103,16 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '181'
+      - '215'
     body:
       encoding: UTF-8
       string: |
         <package name="package_with_invalid_kiwi_file" project="fake_project">
-          <title>Absalom, Absalom!</title>
-          <description>Cupiditate repellat et optio ipsa.</description>
+          <title>A Glass of Blessings</title>
+          <description>Itaque omnis expedita harum corporis consequuntur necessitatibus.</description>
         </package>
     http_version: 
-  recorded_at: Mon, 11 Sep 2017 21:36:38 GMT
+  recorded_at: Thu, 05 Oct 2017 08:56:46 GMT
 - request:
     method: put
     uri: http://backend:5352/source/fake_project/package_with_invalid_kiwi_file/_meta
@@ -119,8 +120,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="package_with_invalid_kiwi_file" project="fake_project">
-          <title>Absalom, Absalom!</title>
-          <description>Cupiditate repellat et optio ipsa.</description>
+          <title>A Glass of Blessings</title>
+          <description>Itaque omnis expedita harum corporis consequuntur necessitatibus.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -141,16 +142,16 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '181'
+      - '215'
     body:
       encoding: UTF-8
       string: |
         <package name="package_with_invalid_kiwi_file" project="fake_project">
-          <title>Absalom, Absalom!</title>
-          <description>Cupiditate repellat et optio ipsa.</description>
+          <title>A Glass of Blessings</title>
+          <description>Itaque omnis expedita harum corporis consequuntur necessitatibus.</description>
         </package>
     http_version: 
-  recorded_at: Mon, 11 Sep 2017 21:36:38 GMT
+  recorded_at: Thu, 05 Oct 2017 08:56:46 GMT
 - request:
     method: put
     uri: http://backend:5352/source/fake_project/package_with_invalid_kiwi_file/package_with_invalid_kiwi_file.kiwi
@@ -169,34 +170,25 @@ http_interactions:
             <package name="aaa_base"/>
             <package name="branding-openSUSE"/>
             <package name="patterns-openSUSE-base"/>
-            <package name="grub2"/>
-            <package name="hwinfo"/>
-            <package name="iputils"/>
-            <package name="kernel-default"/>
-            <package name="netcfg"/>
-            <package name="openSUSE-build-key"/>
-            <package name="openssh"/>
-            <package name="plymouth"/>
-            <package name="polkit-default-privs"/>
-            <package name="rpcbind"/>
-            <package name="syslog-ng"/>
-            <package name="vim"/>
-            <package name="zypper"/>
-            <package name="timezone"/>
-            <package name="openSUSE-release-dvd"/>
-            <package name="gfxboot-devel" bootinclude="true"/>
           </packages>
-          <repository type="wrong" priority="10" alias="debian" imageinclude="true" password="123456" prefer-license="true" status="replaceable" username="Tom">
+          <packages type="image" patternType="onlyRequired">
+            <package name="e2fsprogs"/>
+            <package name="aaa_base"/>
+            <package name="branding-openSUSE"/>
+            <package name="patterns-openSUSE-base"/>
+          </packages>
+          <packages type="image">
+            <package name="e2fsprogs"/>
+            <package name="aaa_base"/>
+            <package name="branding-openSUSE"/>
+            <package name="patterns-openSUSE-base"/>
+          </packages>
+          <packages type="delete">
+            <package name="e2fsprogss"/>
+            <package name="bbb_base"/>
+          </packages>
+          <repository type="apt-deb" priority="10" alias="debian" imageinclude="true" password="123456" prefer-license="true" status="replaceable" username="Tom">
             <source path="http://download.opensuse.org/update/13.2/"/>
-          </repository>
-          <repository type="rpm-dir" priority="wrong" imageinclude="false" prefer-license="false">
-            <source path="http://download.opensuse.org/distribution/13.2/repo/oss/"/>
-          </repository>
-          <repository type="rpm-md" priority="20">
-            <source path="wrong://download.opensuse.org/distribution/13.1/repo/oss/"/>
-          </repository>
-          <repository type="rpm-md">
-            <source path="http://download.opensuse.org/distribution/12.1/repo/oss/"/>
           </repository>
         </image>
     headers:
@@ -218,20 +210,20 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '209'
+      - '207'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="20" vrev="20">
-          <srcmd5>6ccfa0805f62f6fba78db7bc8b4082ba</srcmd5>
+        <revision rev="1" vrev="1">
+          <srcmd5>95d5332d39abd8e345bd458f2bc40b41</srcmd5>
           <version>unknown</version>
-          <time>1505165798</time>
+          <time>1507193806</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
     http_version: 
-  recorded_at: Mon, 11 Sep 2017 21:36:38 GMT
+  recorded_at: Thu, 05 Oct 2017 08:56:46 GMT
 - request:
     method: get
     uri: http://backend:5352/source/fake_project/package_with_invalid_kiwi_file
@@ -257,15 +249,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '249'
+      - '247'
     body:
       encoding: UTF-8
       string: |
-        <directory name="package_with_invalid_kiwi_file" rev="20" vrev="20" srcmd5="6ccfa0805f62f6fba78db7bc8b4082ba">
-          <entry name="package_with_invalid_kiwi_file.kiwi" md5="5a69f457207aa0e7d1cdc633164df54d" size="1791" mtime="1505142565" />
+        <directory name="package_with_invalid_kiwi_file" rev="1" vrev="1" srcmd5="95d5332d39abd8e345bd458f2bc40b41">
+          <entry name="package_with_invalid_kiwi_file.kiwi" md5="886f273630dea2b68a3259d38c1080f7" size="1311" mtime="1507193806" />
         </directory>
     http_version: 
-  recorded_at: Mon, 11 Sep 2017 21:36:38 GMT
+  recorded_at: Thu, 05 Oct 2017 08:56:46 GMT
 - request:
     method: get
     uri: http://backend:5352/source/fake_project/package_with_invalid_kiwi_file/package_with_invalid_kiwi_file.kiwi
@@ -287,7 +279,7 @@ http_interactions:
       Content-Type:
       - application/octet-stream
       Content-Length:
-      - '1791'
+      - '1311'
       Cache-Control:
       - no-cache
       Connection:
@@ -307,38 +299,29 @@ http_interactions:
             <package name="aaa_base"/>
             <package name="branding-openSUSE"/>
             <package name="patterns-openSUSE-base"/>
-            <package name="grub2"/>
-            <package name="hwinfo"/>
-            <package name="iputils"/>
-            <package name="kernel-default"/>
-            <package name="netcfg"/>
-            <package name="openSUSE-build-key"/>
-            <package name="openssh"/>
-            <package name="plymouth"/>
-            <package name="polkit-default-privs"/>
-            <package name="rpcbind"/>
-            <package name="syslog-ng"/>
-            <package name="vim"/>
-            <package name="zypper"/>
-            <package name="timezone"/>
-            <package name="openSUSE-release-dvd"/>
-            <package name="gfxboot-devel" bootinclude="true"/>
           </packages>
-          <repository type="wrong" priority="10" alias="debian" imageinclude="true" password="123456" prefer-license="true" status="replaceable" username="Tom">
+          <packages type="image" patternType="onlyRequired">
+            <package name="e2fsprogs"/>
+            <package name="aaa_base"/>
+            <package name="branding-openSUSE"/>
+            <package name="patterns-openSUSE-base"/>
+          </packages>
+          <packages type="image">
+            <package name="e2fsprogs"/>
+            <package name="aaa_base"/>
+            <package name="branding-openSUSE"/>
+            <package name="patterns-openSUSE-base"/>
+          </packages>
+          <packages type="delete">
+            <package name="e2fsprogss"/>
+            <package name="bbb_base"/>
+          </packages>
+          <repository type="apt-deb" priority="10" alias="debian" imageinclude="true" password="123456" prefer-license="true" status="replaceable" username="Tom">
             <source path="http://download.opensuse.org/update/13.2/"/>
-          </repository>
-          <repository type="rpm-dir" priority="wrong" imageinclude="false" prefer-license="false">
-            <source path="http://download.opensuse.org/distribution/13.2/repo/oss/"/>
-          </repository>
-          <repository type="rpm-md" priority="20">
-            <source path="wrong://download.opensuse.org/distribution/13.1/repo/oss/"/>
-          </repository>
-          <repository type="rpm-md">
-            <source path="http://download.opensuse.org/distribution/12.1/repo/oss/"/>
           </repository>
         </image>
     http_version: 
-  recorded_at: Mon, 11 Sep 2017 21:36:38 GMT
+  recorded_at: Thu, 05 Oct 2017 08:56:46 GMT
 - request:
     method: get
     uri: http://backend:5352/source/fake_project/package_with_invalid_kiwi_file
@@ -364,52 +347,13 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '249'
+      - '247'
     body:
       encoding: UTF-8
       string: |
-        <directory name="package_with_invalid_kiwi_file" rev="20" vrev="20" srcmd5="6ccfa0805f62f6fba78db7bc8b4082ba">
-          <entry name="package_with_invalid_kiwi_file.kiwi" md5="5a69f457207aa0e7d1cdc633164df54d" size="1791" mtime="1505142565" />
+        <directory name="package_with_invalid_kiwi_file" rev="1" vrev="1" srcmd5="95d5332d39abd8e345bd458f2bc40b41">
+          <entry name="package_with_invalid_kiwi_file.kiwi" md5="886f273630dea2b68a3259d38c1080f7" size="1311" mtime="1507193806" />
         </directory>
     http_version: 
-  recorded_at: Mon, 11 Sep 2017 21:36:38 GMT
-- request:
-    method: put
-    uri: http://backend:5352/source/fake_project/package_with_invalid_kiwi_file/_meta?user=_nobody_
-    body:
-      encoding: UTF-8
-      string: |
-        <package name="package_with_invalid_kiwi_file" project="fake_project">
-          <title>Brandy of the Damned</title>
-          <description>Tempora error doloremque animi praesentium mollitia.</description>
-        </package>
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '202'
-    body:
-      encoding: UTF-8
-      string: |
-        <package name="package_with_invalid_kiwi_file" project="fake_project">
-          <title>Brandy of the Damned</title>
-          <description>Tempora error doloremque animi praesentium mollitia.</description>
-        </package>
-    http_version: 
-  recorded_at: Thu, 05 Oct 2017 08:56:47 GMT
+  recorded_at: Thu, 05 Oct 2017 08:56:46 GMT
 recorded_with: VCR 3.0.3

--- a/src/api/spec/cassettes/Webui_Kiwi_ImagesController/GET_import_from_package/with_a_kiwi_file/with_multiple_package_groups/with_type_image_/1_1_2_4_2_2.yml
+++ b/src/api/spec/cassettes/Webui_Kiwi_ImagesController/GET_import_from_package/with_a_kiwi_file/with_multiple_package_groups/with_type_image_/1_1_2_4_2_2.yml
@@ -7,7 +7,7 @@ http_interactions:
       encoding: UTF-8
       string: |
         <project name="fake_project">
-          <title>By Grand Central Station I Sat Down and Wept</title>
+          <title>Blue Remembered Earth</title>
           <description/>
         </project>
     headers:
@@ -29,23 +29,23 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '133'
+      - '110'
     body:
       encoding: UTF-8
       string: |
         <project name="fake_project">
-          <title>By Grand Central Station I Sat Down and Wept</title>
+          <title>Blue Remembered Earth</title>
           <description></description>
         </project>
     http_version: 
-  recorded_at: Mon, 11 Sep 2017 21:36:38 GMT
+  recorded_at: Thu, 05 Oct 2017 08:56:47 GMT
 - request:
     method: put
     uri: http://backend:5352/source/fake_project/_config
     body:
       encoding: UTF-8
-      string: Deserunt perspiciatis autem quas facilis molestias sint. Fugiat qui
-        libero. Molestias quo cum ut qui at quia.
+      string: Ut eos et soluta. Dicta error ipsa quis non enim minus. Cumque sunt
+        a ex.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -72,16 +72,16 @@ http_interactions:
 
 '
     http_version: 
-  recorded_at: Mon, 11 Sep 2017 21:36:38 GMT
+  recorded_at: Thu, 05 Oct 2017 08:56:47 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/fake_project/package_with_invalid_kiwi_file/_meta?user=tom
+    uri: http://backend:5352/source/fake_project/package_with_invalid_kiwi_file/_meta?user=_nobody_
     body:
       encoding: UTF-8
       string: |
         <package name="package_with_invalid_kiwi_file" project="fake_project">
-          <title>Absalom, Absalom!</title>
-          <description>Cupiditate repellat et optio ipsa.</description>
+          <title>The Road Less Traveled</title>
+          <description>Autem a itaque vel.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -102,16 +102,16 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '181'
+      - '171'
     body:
       encoding: UTF-8
       string: |
         <package name="package_with_invalid_kiwi_file" project="fake_project">
-          <title>Absalom, Absalom!</title>
-          <description>Cupiditate repellat et optio ipsa.</description>
+          <title>The Road Less Traveled</title>
+          <description>Autem a itaque vel.</description>
         </package>
     http_version: 
-  recorded_at: Mon, 11 Sep 2017 21:36:38 GMT
+  recorded_at: Thu, 05 Oct 2017 08:56:47 GMT
 - request:
     method: put
     uri: http://backend:5352/source/fake_project/package_with_invalid_kiwi_file/_meta
@@ -119,8 +119,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="package_with_invalid_kiwi_file" project="fake_project">
-          <title>Absalom, Absalom!</title>
-          <description>Cupiditate repellat et optio ipsa.</description>
+          <title>The Road Less Traveled</title>
+          <description>Autem a itaque vel.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -141,16 +141,16 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '181'
+      - '171'
     body:
       encoding: UTF-8
       string: |
         <package name="package_with_invalid_kiwi_file" project="fake_project">
-          <title>Absalom, Absalom!</title>
-          <description>Cupiditate repellat et optio ipsa.</description>
+          <title>The Road Less Traveled</title>
+          <description>Autem a itaque vel.</description>
         </package>
     http_version: 
-  recorded_at: Mon, 11 Sep 2017 21:36:38 GMT
+  recorded_at: Thu, 05 Oct 2017 08:56:47 GMT
 - request:
     method: put
     uri: http://backend:5352/source/fake_project/package_with_invalid_kiwi_file/package_with_invalid_kiwi_file.kiwi
@@ -169,34 +169,25 @@ http_interactions:
             <package name="aaa_base"/>
             <package name="branding-openSUSE"/>
             <package name="patterns-openSUSE-base"/>
-            <package name="grub2"/>
-            <package name="hwinfo"/>
-            <package name="iputils"/>
-            <package name="kernel-default"/>
-            <package name="netcfg"/>
-            <package name="openSUSE-build-key"/>
-            <package name="openssh"/>
-            <package name="plymouth"/>
-            <package name="polkit-default-privs"/>
-            <package name="rpcbind"/>
-            <package name="syslog-ng"/>
-            <package name="vim"/>
-            <package name="zypper"/>
-            <package name="timezone"/>
-            <package name="openSUSE-release-dvd"/>
-            <package name="gfxboot-devel" bootinclude="true"/>
           </packages>
-          <repository type="wrong" priority="10" alias="debian" imageinclude="true" password="123456" prefer-license="true" status="replaceable" username="Tom">
+          <packages type="image" patternType="onlyRequired">
+            <package name="e2fsprogs"/>
+            <package name="aaa_base"/>
+            <package name="branding-openSUSE"/>
+            <package name="patterns-openSUSE-base"/>
+          </packages>
+          <packages type="image">
+            <package name="e2fsprogs"/>
+            <package name="aaa_base"/>
+            <package name="branding-openSUSE"/>
+            <package name="patterns-openSUSE-base"/>
+          </packages>
+          <packages type="delete">
+            <package name="e2fsprogss"/>
+            <package name="bbb_base"/>
+          </packages>
+          <repository type="apt-deb" priority="10" alias="debian" imageinclude="true" password="123456" prefer-license="true" status="replaceable" username="Tom">
             <source path="http://download.opensuse.org/update/13.2/"/>
-          </repository>
-          <repository type="rpm-dir" priority="wrong" imageinclude="false" prefer-license="false">
-            <source path="http://download.opensuse.org/distribution/13.2/repo/oss/"/>
-          </repository>
-          <repository type="rpm-md" priority="20">
-            <source path="wrong://download.opensuse.org/distribution/13.1/repo/oss/"/>
-          </repository>
-          <repository type="rpm-md">
-            <source path="http://download.opensuse.org/distribution/12.1/repo/oss/"/>
           </repository>
         </image>
     headers:
@@ -218,20 +209,20 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '209'
+      - '207'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="20" vrev="20">
-          <srcmd5>6ccfa0805f62f6fba78db7bc8b4082ba</srcmd5>
+        <revision rev="3" vrev="3">
+          <srcmd5>95d5332d39abd8e345bd458f2bc40b41</srcmd5>
           <version>unknown</version>
-          <time>1505165798</time>
+          <time>1507193807</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
     http_version: 
-  recorded_at: Mon, 11 Sep 2017 21:36:38 GMT
+  recorded_at: Thu, 05 Oct 2017 08:56:47 GMT
 - request:
     method: get
     uri: http://backend:5352/source/fake_project/package_with_invalid_kiwi_file
@@ -257,15 +248,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '249'
+      - '247'
     body:
       encoding: UTF-8
       string: |
-        <directory name="package_with_invalid_kiwi_file" rev="20" vrev="20" srcmd5="6ccfa0805f62f6fba78db7bc8b4082ba">
-          <entry name="package_with_invalid_kiwi_file.kiwi" md5="5a69f457207aa0e7d1cdc633164df54d" size="1791" mtime="1505142565" />
+        <directory name="package_with_invalid_kiwi_file" rev="3" vrev="3" srcmd5="95d5332d39abd8e345bd458f2bc40b41">
+          <entry name="package_with_invalid_kiwi_file.kiwi" md5="886f273630dea2b68a3259d38c1080f7" size="1311" mtime="1507193806" />
         </directory>
     http_version: 
-  recorded_at: Mon, 11 Sep 2017 21:36:38 GMT
+  recorded_at: Thu, 05 Oct 2017 08:56:47 GMT
 - request:
     method: get
     uri: http://backend:5352/source/fake_project/package_with_invalid_kiwi_file/package_with_invalid_kiwi_file.kiwi
@@ -287,7 +278,7 @@ http_interactions:
       Content-Type:
       - application/octet-stream
       Content-Length:
-      - '1791'
+      - '1311'
       Cache-Control:
       - no-cache
       Connection:
@@ -307,38 +298,29 @@ http_interactions:
             <package name="aaa_base"/>
             <package name="branding-openSUSE"/>
             <package name="patterns-openSUSE-base"/>
-            <package name="grub2"/>
-            <package name="hwinfo"/>
-            <package name="iputils"/>
-            <package name="kernel-default"/>
-            <package name="netcfg"/>
-            <package name="openSUSE-build-key"/>
-            <package name="openssh"/>
-            <package name="plymouth"/>
-            <package name="polkit-default-privs"/>
-            <package name="rpcbind"/>
-            <package name="syslog-ng"/>
-            <package name="vim"/>
-            <package name="zypper"/>
-            <package name="timezone"/>
-            <package name="openSUSE-release-dvd"/>
-            <package name="gfxboot-devel" bootinclude="true"/>
           </packages>
-          <repository type="wrong" priority="10" alias="debian" imageinclude="true" password="123456" prefer-license="true" status="replaceable" username="Tom">
+          <packages type="image" patternType="onlyRequired">
+            <package name="e2fsprogs"/>
+            <package name="aaa_base"/>
+            <package name="branding-openSUSE"/>
+            <package name="patterns-openSUSE-base"/>
+          </packages>
+          <packages type="image">
+            <package name="e2fsprogs"/>
+            <package name="aaa_base"/>
+            <package name="branding-openSUSE"/>
+            <package name="patterns-openSUSE-base"/>
+          </packages>
+          <packages type="delete">
+            <package name="e2fsprogss"/>
+            <package name="bbb_base"/>
+          </packages>
+          <repository type="apt-deb" priority="10" alias="debian" imageinclude="true" password="123456" prefer-license="true" status="replaceable" username="Tom">
             <source path="http://download.opensuse.org/update/13.2/"/>
-          </repository>
-          <repository type="rpm-dir" priority="wrong" imageinclude="false" prefer-license="false">
-            <source path="http://download.opensuse.org/distribution/13.2/repo/oss/"/>
-          </repository>
-          <repository type="rpm-md" priority="20">
-            <source path="wrong://download.opensuse.org/distribution/13.1/repo/oss/"/>
-          </repository>
-          <repository type="rpm-md">
-            <source path="http://download.opensuse.org/distribution/12.1/repo/oss/"/>
           </repository>
         </image>
     http_version: 
-  recorded_at: Mon, 11 Sep 2017 21:36:38 GMT
+  recorded_at: Thu, 05 Oct 2017 08:56:47 GMT
 - request:
     method: get
     uri: http://backend:5352/source/fake_project/package_with_invalid_kiwi_file
@@ -364,52 +346,13 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '249'
+      - '247'
     body:
       encoding: UTF-8
       string: |
-        <directory name="package_with_invalid_kiwi_file" rev="20" vrev="20" srcmd5="6ccfa0805f62f6fba78db7bc8b4082ba">
-          <entry name="package_with_invalid_kiwi_file.kiwi" md5="5a69f457207aa0e7d1cdc633164df54d" size="1791" mtime="1505142565" />
+        <directory name="package_with_invalid_kiwi_file" rev="3" vrev="3" srcmd5="95d5332d39abd8e345bd458f2bc40b41">
+          <entry name="package_with_invalid_kiwi_file.kiwi" md5="886f273630dea2b68a3259d38c1080f7" size="1311" mtime="1507193806" />
         </directory>
-    http_version: 
-  recorded_at: Mon, 11 Sep 2017 21:36:38 GMT
-- request:
-    method: put
-    uri: http://backend:5352/source/fake_project/package_with_invalid_kiwi_file/_meta?user=_nobody_
-    body:
-      encoding: UTF-8
-      string: |
-        <package name="package_with_invalid_kiwi_file" project="fake_project">
-          <title>Brandy of the Damned</title>
-          <description>Tempora error doloremque animi praesentium mollitia.</description>
-        </package>
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '202'
-    body:
-      encoding: UTF-8
-      string: |
-        <package name="package_with_invalid_kiwi_file" project="fake_project">
-          <title>Brandy of the Damned</title>
-          <description>Tempora error doloremque animi praesentium mollitia.</description>
-        </package>
     http_version: 
   recorded_at: Thu, 05 Oct 2017 08:56:47 GMT
 recorded_with: VCR 3.0.3

--- a/src/api/spec/cassettes/Webui_Kiwi_ImagesController/GET_import_from_package/with_a_kiwi_file/with_multiple_package_groups/with_type_image_/redirect_to_package_view_file_path.yml
+++ b/src/api/spec/cassettes/Webui_Kiwi_ImagesController/GET_import_from_package/with_a_kiwi_file/with_multiple_package_groups/with_type_image_/redirect_to_package_view_file_path.yml
@@ -7,7 +7,7 @@ http_interactions:
       encoding: UTF-8
       string: |
         <project name="fake_project">
-          <title>By Grand Central Station I Sat Down and Wept</title>
+          <title>To Your Scattered Bodies Go</title>
           <description/>
         </project>
     headers:
@@ -29,23 +29,23 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '133'
+      - '116'
     body:
       encoding: UTF-8
       string: |
         <project name="fake_project">
-          <title>By Grand Central Station I Sat Down and Wept</title>
+          <title>To Your Scattered Bodies Go</title>
           <description></description>
         </project>
     http_version: 
-  recorded_at: Mon, 11 Sep 2017 21:36:38 GMT
+  recorded_at: Thu, 05 Oct 2017 08:56:47 GMT
 - request:
     method: put
     uri: http://backend:5352/source/fake_project/_config
     body:
       encoding: UTF-8
-      string: Deserunt perspiciatis autem quas facilis molestias sint. Fugiat qui
-        libero. Molestias quo cum ut qui at quia.
+      string: Illo temporibus voluptas. Expedita earum dolor. Rem consequatur et est
+        facilis optio dolor. Repellat beatae voluptas sit sed.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -72,16 +72,16 @@ http_interactions:
 
 '
     http_version: 
-  recorded_at: Mon, 11 Sep 2017 21:36:38 GMT
+  recorded_at: Thu, 05 Oct 2017 08:56:47 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/fake_project/package_with_invalid_kiwi_file/_meta?user=tom
+    uri: http://backend:5352/source/fake_project/package_with_invalid_kiwi_file/_meta?user=_nobody_
     body:
       encoding: UTF-8
       string: |
         <package name="package_with_invalid_kiwi_file" project="fake_project">
-          <title>Absalom, Absalom!</title>
-          <description>Cupiditate repellat et optio ipsa.</description>
+          <title>The Mirror Crack'd from Side to Side</title>
+          <description>Nobis reprehenderit corrupti voluptas.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -102,16 +102,16 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '181'
+      - '204'
     body:
       encoding: UTF-8
       string: |
         <package name="package_with_invalid_kiwi_file" project="fake_project">
-          <title>Absalom, Absalom!</title>
-          <description>Cupiditate repellat et optio ipsa.</description>
+          <title>The Mirror Crack'd from Side to Side</title>
+          <description>Nobis reprehenderit corrupti voluptas.</description>
         </package>
     http_version: 
-  recorded_at: Mon, 11 Sep 2017 21:36:38 GMT
+  recorded_at: Thu, 05 Oct 2017 08:56:47 GMT
 - request:
     method: put
     uri: http://backend:5352/source/fake_project/package_with_invalid_kiwi_file/_meta
@@ -119,8 +119,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="package_with_invalid_kiwi_file" project="fake_project">
-          <title>Absalom, Absalom!</title>
-          <description>Cupiditate repellat et optio ipsa.</description>
+          <title>The Mirror Crack'd from Side to Side</title>
+          <description>Nobis reprehenderit corrupti voluptas.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -141,16 +141,16 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '181'
+      - '204'
     body:
       encoding: UTF-8
       string: |
         <package name="package_with_invalid_kiwi_file" project="fake_project">
-          <title>Absalom, Absalom!</title>
-          <description>Cupiditate repellat et optio ipsa.</description>
+          <title>The Mirror Crack'd from Side to Side</title>
+          <description>Nobis reprehenderit corrupti voluptas.</description>
         </package>
     http_version: 
-  recorded_at: Mon, 11 Sep 2017 21:36:38 GMT
+  recorded_at: Thu, 05 Oct 2017 08:56:47 GMT
 - request:
     method: put
     uri: http://backend:5352/source/fake_project/package_with_invalid_kiwi_file/package_with_invalid_kiwi_file.kiwi
@@ -169,34 +169,25 @@ http_interactions:
             <package name="aaa_base"/>
             <package name="branding-openSUSE"/>
             <package name="patterns-openSUSE-base"/>
-            <package name="grub2"/>
-            <package name="hwinfo"/>
-            <package name="iputils"/>
-            <package name="kernel-default"/>
-            <package name="netcfg"/>
-            <package name="openSUSE-build-key"/>
-            <package name="openssh"/>
-            <package name="plymouth"/>
-            <package name="polkit-default-privs"/>
-            <package name="rpcbind"/>
-            <package name="syslog-ng"/>
-            <package name="vim"/>
-            <package name="zypper"/>
-            <package name="timezone"/>
-            <package name="openSUSE-release-dvd"/>
-            <package name="gfxboot-devel" bootinclude="true"/>
           </packages>
-          <repository type="wrong" priority="10" alias="debian" imageinclude="true" password="123456" prefer-license="true" status="replaceable" username="Tom">
+          <packages type="image" patternType="onlyRequired">
+            <package name="e2fsprogs"/>
+            <package name="aaa_base"/>
+            <package name="branding-openSUSE"/>
+            <package name="patterns-openSUSE-base"/>
+          </packages>
+          <packages type="image">
+            <package name="e2fsprogs"/>
+            <package name="aaa_base"/>
+            <package name="branding-openSUSE"/>
+            <package name="patterns-openSUSE-base"/>
+          </packages>
+          <packages type="delete">
+            <package name="e2fsprogss"/>
+            <package name="bbb_base"/>
+          </packages>
+          <repository type="apt-deb" priority="10" alias="debian" imageinclude="true" password="123456" prefer-license="true" status="replaceable" username="Tom">
             <source path="http://download.opensuse.org/update/13.2/"/>
-          </repository>
-          <repository type="rpm-dir" priority="wrong" imageinclude="false" prefer-license="false">
-            <source path="http://download.opensuse.org/distribution/13.2/repo/oss/"/>
-          </repository>
-          <repository type="rpm-md" priority="20">
-            <source path="wrong://download.opensuse.org/distribution/13.1/repo/oss/"/>
-          </repository>
-          <repository type="rpm-md">
-            <source path="http://download.opensuse.org/distribution/12.1/repo/oss/"/>
           </repository>
         </image>
     headers:
@@ -218,20 +209,20 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '209'
+      - '207'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="20" vrev="20">
-          <srcmd5>6ccfa0805f62f6fba78db7bc8b4082ba</srcmd5>
+        <revision rev="4" vrev="4">
+          <srcmd5>95d5332d39abd8e345bd458f2bc40b41</srcmd5>
           <version>unknown</version>
-          <time>1505165798</time>
+          <time>1507193807</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
     http_version: 
-  recorded_at: Mon, 11 Sep 2017 21:36:38 GMT
+  recorded_at: Thu, 05 Oct 2017 08:56:47 GMT
 - request:
     method: get
     uri: http://backend:5352/source/fake_project/package_with_invalid_kiwi_file
@@ -257,15 +248,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '249'
+      - '247'
     body:
       encoding: UTF-8
       string: |
-        <directory name="package_with_invalid_kiwi_file" rev="20" vrev="20" srcmd5="6ccfa0805f62f6fba78db7bc8b4082ba">
-          <entry name="package_with_invalid_kiwi_file.kiwi" md5="5a69f457207aa0e7d1cdc633164df54d" size="1791" mtime="1505142565" />
+        <directory name="package_with_invalid_kiwi_file" rev="4" vrev="4" srcmd5="95d5332d39abd8e345bd458f2bc40b41">
+          <entry name="package_with_invalid_kiwi_file.kiwi" md5="886f273630dea2b68a3259d38c1080f7" size="1311" mtime="1507193806" />
         </directory>
     http_version: 
-  recorded_at: Mon, 11 Sep 2017 21:36:38 GMT
+  recorded_at: Thu, 05 Oct 2017 08:56:47 GMT
 - request:
     method: get
     uri: http://backend:5352/source/fake_project/package_with_invalid_kiwi_file/package_with_invalid_kiwi_file.kiwi
@@ -287,7 +278,7 @@ http_interactions:
       Content-Type:
       - application/octet-stream
       Content-Length:
-      - '1791'
+      - '1311'
       Cache-Control:
       - no-cache
       Connection:
@@ -307,38 +298,29 @@ http_interactions:
             <package name="aaa_base"/>
             <package name="branding-openSUSE"/>
             <package name="patterns-openSUSE-base"/>
-            <package name="grub2"/>
-            <package name="hwinfo"/>
-            <package name="iputils"/>
-            <package name="kernel-default"/>
-            <package name="netcfg"/>
-            <package name="openSUSE-build-key"/>
-            <package name="openssh"/>
-            <package name="plymouth"/>
-            <package name="polkit-default-privs"/>
-            <package name="rpcbind"/>
-            <package name="syslog-ng"/>
-            <package name="vim"/>
-            <package name="zypper"/>
-            <package name="timezone"/>
-            <package name="openSUSE-release-dvd"/>
-            <package name="gfxboot-devel" bootinclude="true"/>
           </packages>
-          <repository type="wrong" priority="10" alias="debian" imageinclude="true" password="123456" prefer-license="true" status="replaceable" username="Tom">
+          <packages type="image" patternType="onlyRequired">
+            <package name="e2fsprogs"/>
+            <package name="aaa_base"/>
+            <package name="branding-openSUSE"/>
+            <package name="patterns-openSUSE-base"/>
+          </packages>
+          <packages type="image">
+            <package name="e2fsprogs"/>
+            <package name="aaa_base"/>
+            <package name="branding-openSUSE"/>
+            <package name="patterns-openSUSE-base"/>
+          </packages>
+          <packages type="delete">
+            <package name="e2fsprogss"/>
+            <package name="bbb_base"/>
+          </packages>
+          <repository type="apt-deb" priority="10" alias="debian" imageinclude="true" password="123456" prefer-license="true" status="replaceable" username="Tom">
             <source path="http://download.opensuse.org/update/13.2/"/>
-          </repository>
-          <repository type="rpm-dir" priority="wrong" imageinclude="false" prefer-license="false">
-            <source path="http://download.opensuse.org/distribution/13.2/repo/oss/"/>
-          </repository>
-          <repository type="rpm-md" priority="20">
-            <source path="wrong://download.opensuse.org/distribution/13.1/repo/oss/"/>
-          </repository>
-          <repository type="rpm-md">
-            <source path="http://download.opensuse.org/distribution/12.1/repo/oss/"/>
           </repository>
         </image>
     http_version: 
-  recorded_at: Mon, 11 Sep 2017 21:36:38 GMT
+  recorded_at: Thu, 05 Oct 2017 08:56:47 GMT
 - request:
     method: get
     uri: http://backend:5352/source/fake_project/package_with_invalid_kiwi_file
@@ -364,52 +346,13 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '249'
+      - '247'
     body:
       encoding: UTF-8
       string: |
-        <directory name="package_with_invalid_kiwi_file" rev="20" vrev="20" srcmd5="6ccfa0805f62f6fba78db7bc8b4082ba">
-          <entry name="package_with_invalid_kiwi_file.kiwi" md5="5a69f457207aa0e7d1cdc633164df54d" size="1791" mtime="1505142565" />
+        <directory name="package_with_invalid_kiwi_file" rev="4" vrev="4" srcmd5="95d5332d39abd8e345bd458f2bc40b41">
+          <entry name="package_with_invalid_kiwi_file.kiwi" md5="886f273630dea2b68a3259d38c1080f7" size="1311" mtime="1507193806" />
         </directory>
-    http_version: 
-  recorded_at: Mon, 11 Sep 2017 21:36:38 GMT
-- request:
-    method: put
-    uri: http://backend:5352/source/fake_project/package_with_invalid_kiwi_file/_meta?user=_nobody_
-    body:
-      encoding: UTF-8
-      string: |
-        <package name="package_with_invalid_kiwi_file" project="fake_project">
-          <title>Brandy of the Damned</title>
-          <description>Tempora error doloremque animi praesentium mollitia.</description>
-        </package>
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '202'
-    body:
-      encoding: UTF-8
-      string: |
-        <package name="package_with_invalid_kiwi_file" project="fake_project">
-          <title>Brandy of the Damned</title>
-          <description>Tempora error doloremque animi praesentium mollitia.</description>
-        </package>
     http_version: 
   recorded_at: Thu, 05 Oct 2017 08:56:47 GMT
 recorded_with: VCR 3.0.3

--- a/src/api/spec/controllers/webui/kiwi/images_controller_spec.rb
+++ b/src/api/spec/controllers/webui/kiwi/images_controller_spec.rb
@@ -92,6 +92,44 @@ RSpec.describe Webui::Kiwi::ImagesController, type: :controller, vcr: true do
           it { expect(flash[:error]).to end_with('please remove the other repositories.') }
         end
       end
+
+      context 'with multiple package_groups' do
+        context 'with the same attributes' do
+          let(:package_with_kiwi_file) do
+            create(:package_with_kiwi_file, name: 'package_with_invalid_kiwi_file',
+                   project: project, kiwi_file_content: invalid_kiwi_xml_with_multiple_package_groups)
+          end
+
+          before do
+            get :import_from_package, params: { package_id: package_with_kiwi_file.id }
+          end
+
+          it 'redirect to package_view_file_path' do
+            expect(response).to redirect_to(package_view_file_path(project: package_with_kiwi_file.project,
+                                                                   package: package_with_kiwi_file,
+                                                                   filename: "#{package_with_kiwi_file.name}.kiwi"))
+          end
+          it { expect(flash[:error]).to match(/Multiple package groups with same attributes is not allowed/) }
+        end
+
+        context 'with type="image"' do
+          let(:package_with_kiwi_file) do
+            create(:package_with_kiwi_file, name: 'package_with_invalid_kiwi_file',
+                   project: project, kiwi_file_content: invalid_kiwi_xml_with_multiple_package_groups)
+          end
+
+          before do
+            get :import_from_package, params: { package_id: package_with_kiwi_file.id }
+          end
+
+          it 'redirect to package_view_file_path' do
+            expect(response).to redirect_to(package_view_file_path(project: package_with_kiwi_file.project,
+                                                                   package: package_with_kiwi_file,
+                                                                   filename: "#{package_with_kiwi_file.name}.kiwi"))
+          end
+          it { expect(flash[:error]).to match(/Having more than 2 package groups with type='image' is not allowed/) }
+        end
+      end
     end
   end
 

--- a/src/api/spec/support/shared_contexts/a_kiwi_image_xml.rb
+++ b/src/api/spec/support/shared_contexts/a_kiwi_image_xml.rb
@@ -80,6 +80,9 @@ RSpec.shared_context 'a kiwi image xml' do
     <package name="openSUSE-release-dvd"/>
     <package name="gfxboot-devel" bootinclude="true"/>
   </packages>
+  <packages type="image">
+    <package name="citrix"/>
+  </packages>
   <packages type="delete">
     <package name="e2fsprogss"/>
     <package name="bbb_base"/>

--- a/src/api/spec/support/shared_contexts/an_invalid_kiwi_image_xml.rb
+++ b/src/api/spec/support/shared_contexts/an_invalid_kiwi_image_xml.rb
@@ -90,4 +90,42 @@ RSpec.shared_context 'an invalid kiwi image xml' do
 </image>
     XML
   end
+
+  let(:invalid_kiwi_xml_with_multiple_package_groups) do
+    <<-XML
+<?xml version="1.0" encoding="UTF-8"?>
+<image name="Christians_openSUSE_13.2_JeOS" displayname="Christians_openSUSE_13.2_JeOS" schemaversion="5.2">
+  <description type="system">
+    <author>Christian Bruckmayer</author>
+    <contact>noemail@example.com</contact>
+    <specification>Tiny, minimalistic appliances</specification>
+  </description>
+  <packages type="image" patternType="onlyRequired">
+    <package name="e2fsprogs"/>
+    <package name="aaa_base"/>
+    <package name="branding-openSUSE"/>
+    <package name="patterns-openSUSE-base"/>
+  </packages>
+  <packages type="image" patternType="onlyRequired">
+    <package name="e2fsprogs"/>
+    <package name="aaa_base"/>
+    <package name="branding-openSUSE"/>
+    <package name="patterns-openSUSE-base"/>
+  </packages>
+  <packages type="image">
+    <package name="e2fsprogs"/>
+    <package name="aaa_base"/>
+    <package name="branding-openSUSE"/>
+    <package name="patterns-openSUSE-base"/>
+  </packages>
+  <packages type="delete">
+    <package name="e2fsprogss"/>
+    <package name="bbb_base"/>
+  </packages>
+  <repository type="apt-deb" priority="10" alias="debian" imageinclude="true" password="123456" prefer-license="true" status="replaceable" username="Tom">
+    <source path="http://download.opensuse.org/update/13.2/"/>
+  </repository>
+</image>
+    XML
+  end
 end


### PR DESCRIPTION
Now we show all `package_groups` with type 'image' independently of the pattenType.

#### Showing patternType

![screenshot from 2017-09-21 13-41-38](https://user-images.githubusercontent.com/1212806/30694763-d0c679a0-9ed5-11e7-821b-b7cbf4177bed.png)
