### PR TITLE
Kiwi editor: autocomplete binary packages names

### DIFF
--- a/ReleaseNotes-2.9
+++ b/ReleaseNotes-2.9
@@ -38,6 +38,7 @@ UI:
    * A basic and expert mode for adding repositories is available.
    * obsrepositories:/ source_path can be added easily using 'use project repositories' checkbox.
    * Only `apt-deb` and `rpm-md` are allowed as repo_type. Other values will be replaced by `rpm-md`.
+   * Added autocompletion for binary packages names.
  * Job history: 'source change' rows now link to the diff
 
 API:

--- a/src/api/app/assets/javascripts/webui/application/kiwi_editor.js
+++ b/src/api/app/assets/javascripts/webui/application/kiwi_editor.js
@@ -253,7 +253,24 @@ function kiwiPackagesSetupAutocomplete(fields) {
   var package_field = fields.find('[id$=name]');
 
   package_field.autocomplete({
-    source: package_field.data('ajaxurl'),
+    source: function (request, response) {
+      var repositories = $("#kiwi-repositories-list [id$='source_path']").map(function() { return this.value;}).get();
+      var repository_destroy_fields = $("#kiwi-repositories-list [id$='_destroy']");
+      var using_project_repositories =  $('#kiwi_image_use_project_repositories').prop('checked');
+      repository_destroy_fields.each(function(index, input){ // remove destroyed repositories from the payload
+        if ($(input).val() == "1") {
+          repositories.splice(index, 1);
+        }
+      });
+      var payload = { term: request.term, repositories: repositories };
+      if (using_project_repositories) {
+        payload.use_project_repositories = true;
+      }
+      $.getJSON(package_field.data('ajaxurl'), payload,
+        function (data) {
+          response(data);
+        });
+    },
     minLength: 2
   });
 }

--- a/src/api/app/assets/javascripts/webui/application/kiwi_editor.js
+++ b/src/api/app/assets/javascripts/webui/application/kiwi_editor.js
@@ -249,6 +249,15 @@ function kiwiRepositoriesSetupAutocomplete(fields) {
   });
 }
 
+function kiwiPackagesSetupAutocomplete(fields) {
+  var package_field = fields.find('[id$=name]');
+
+  package_field.autocomplete({
+    source: package_field.data('ajaxurl'),
+    minLength: 2
+  });
+}
+
 $(document).ready(function(){
   // Save image
   $('#kiwi-image-update-form-save').click(saveImage);
@@ -274,6 +283,9 @@ $(document).ready(function(){
   $('#kiwi-repositories-list .kiwi_list_item, #kiwi-packages-list .kiwi_list_item').hover(hoverListItem, hoverListItem);
   $('[name=target_project]').each(function() {
     kiwiRepositoriesSetupAutocomplete($(this).parents('.nested-fields'));
+  });
+  $('#kiwi-packages-list .nested-fields').each(function() {
+    kiwiPackagesSetupAutocomplete($(this));
   });
 
   // After inserting new repositories add the Callbacks
@@ -308,6 +320,7 @@ $(document).ready(function(){
     $(addedFields).find('.close-dialog').click(closeDialog);
     $(addedFields).find('.revert-dialog').click(revertDialog);
     $(addedFields).find('.kiwi_list_item').hover(hoverListItem, hoverListItem);
+    kiwiPackagesSetupAutocomplete($(addedFields));
     $('#no-packages').hide();
   });
 

--- a/src/api/app/controllers/webui/kiwi/images_controller.rb
+++ b/src/api/app/controllers/webui/kiwi/images_controller.rb
@@ -49,6 +49,15 @@ module Webui
         redirect_back(fallback_location: root_path)
       end
 
+      def autocomplete_binaries
+        binaries = @image.find_binaries_by_name(params[:term])
+        autocomplete_result = []
+        binaries.each do |package, _|
+          autocomplete_result << {id: package, label: package, value: package}
+        end
+        render json: autocomplete_result
+      end
+
       private
 
       def image_params

--- a/src/api/app/controllers/webui/kiwi/images_controller.rb
+++ b/src/api/app/controllers/webui/kiwi/images_controller.rb
@@ -50,12 +50,9 @@ module Webui
       end
 
       def autocomplete_binaries
-        binaries = @image.find_binaries_by_name(params[:term])
-        autocomplete_result = []
-        binaries.each do |package, _|
-          autocomplete_result << {id: package, label: package, value: package}
-        end
-        render json: autocomplete_result
+        binaries = ::Kiwi::Image.find_binaries_by_name(params[:term], @image.package.project.name,
+                                                       params[:repositories], use_project_repositories: params[:use_project_repositories])
+        render json: binaries.to_a.map { |result| {id: result.first, label: result.first, value: result.first} }
       end
 
       private

--- a/src/api/app/models/kiwi/image.rb
+++ b/src/api/app/models/kiwi/image.rb
@@ -144,7 +144,31 @@ class Kiwi::Image < ApplicationRecord
     package_groups.find_or_create_by(kiwi_type: :image, pattern_type: 'onlyRequired')
   end
 
+  def find_binaries_by_name(query)
+    finder = /\A#{Regexp.quote(query)}/
+    binaries_available.select { |package, _| finder.match(package.to_s) }
+  end
+
+  def binaries_available
+    return {} unless package
+    Rails.cache.fetch("kiwi_image_binaries_available_#{md5_last_revision}", expires_in: 5.minutes) do
+      if use_project_repositories
+        Backend::Api::BuildResults::Binaries.available_in_project(package.project.name)
+      else
+        Backend::Api::BuildResults::Binaries.available_in_repositories(package.project.name, non_obs_repository_urls, obs_repository_paths)
+      end
+    end
+  end
+
   private
+
+  def non_obs_repository_urls
+    repositories.reject(&:obs_source_path?).map(&:source_path)
+  end
+
+  def obs_repository_paths
+    repositories.select(&:obs_source_path?).map { |repository| "#{repository.project_for_type_obs}/#{repository.repository_for_type_obs}" }
+  end
 
   def repositories_for_xml
     if use_project_repositories?

--- a/src/api/app/views/webui/kiwi/images/_package_fields.html.haml
+++ b/src/api/app/views/webui/kiwi/images/_package_fields.html.haml
@@ -15,7 +15,7 @@
       .dialog-content
         %p
           = f.label :name, 'Name:'
-          = f.text_field :name, data: { default: f.object.name }
+          = f.text_field :name, data: { ajaxurl: url_for(controller: '/webui/kiwi/images', action: 'autocomplete_binaries'), default: f.object.name }
         %p
           = f.label :arch, 'Arch:'
           = f.text_field :arch, data: { default: f.object.arch }

--- a/src/api/config/routes.rb
+++ b/src/api/config/routes.rb
@@ -195,7 +195,11 @@ OBSApi::Application.routes.draw do
       get 'package/:package_id/kiwi_images/import_from_package' => :import_from_package, as: 'import_kiwi_image'
     end
 
-    resources :kiwi_images, only: [:show, :update], controller: 'webui/kiwi/images'
+    resources :kiwi_images, only: [:show, :update], controller: 'webui/kiwi/images' do
+      member do
+        get 'autocomplete_binaries'
+      end
+    end
 
     controller 'webui/project' do
       get 'project/' => :index, as: 'projects'

--- a/src/api/spec/cassettes/Kiwi_Image/_binaries_available/with_OBS_and_normal_repositories_set/1_6_3_1.yml
+++ b/src/api/spec/cassettes/Kiwi_Image/_binaries_available/with_OBS_and_normal_repositories_set/1_6_3_1.yml
@@ -1,0 +1,161 @@
+---
+http_interactions:
+- request:
+    method: put
+    uri: http://localhost:3200/source/home:tom/_meta?user=tom
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:tom">
+          <title/>
+          <description/>
+          <person userid="tom" role="maintainer"/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '129'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:tom">
+          <title></title>
+          <description></description>
+          <person userid="tom" role="maintainer" />
+        </project>
+    http_version: 
+  recorded_at: Fri, 22 Sep 2017 08:49:47 GMT
+- request:
+    method: put
+    uri: http://localhost:3200/source/home:tom/package_with_kiwi_image/_meta?user=_nobody_
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="package_with_kiwi_image" project="home:tom">
+          <title>A Scanner Darkly</title>
+          <description>Ut neque voluptas ut eveniet repudiandae qui officia.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '188'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="package_with_kiwi_image" project="home:tom">
+          <title>A Scanner Darkly</title>
+          <description>Ut neque voluptas ut eveniet repudiandae qui officia.</description>
+        </package>
+    http_version: 
+  recorded_at: Fri, 22 Sep 2017 08:49:48 GMT
+- request:
+    method: put
+    uri: http://localhost:3200/source/home:tom/package_with_kiwi_image/_meta
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="package_with_kiwi_image" project="home:tom">
+          <title>A Scanner Darkly</title>
+          <description>Ut neque voluptas ut eveniet repudiandae qui officia.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '188'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="package_with_kiwi_image" project="home:tom">
+          <title>A Scanner Darkly</title>
+          <description>Ut neque voluptas ut eveniet repudiandae qui officia.</description>
+        </package>
+    http_version: 
+  recorded_at: Fri, 22 Sep 2017 08:49:48 GMT
+- request:
+    method: put
+    uri: http://localhost:3200/source/home:tom/package_with_kiwi_image/_meta?user=_nobody_
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="package_with_kiwi_image" project="home:tom">
+          <title>A Scanner Darkly</title>
+          <description>Ut neque voluptas ut eveniet repudiandae qui officia.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '188'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="package_with_kiwi_image" project="home:tom">
+          <title>A Scanner Darkly</title>
+          <description>Ut neque voluptas ut eveniet repudiandae qui officia.</description>
+        </package>
+    http_version: 
+  recorded_at: Fri, 22 Sep 2017 08:49:48 GMT
+recorded_with: VCR 3.0.3

--- a/src/api/spec/cassettes/Kiwi_Image/_binaries_available/with_OBS_and_normal_repositories_set/1_6_3_2.yml
+++ b/src/api/spec/cassettes/Kiwi_Image/_binaries_available/with_OBS_and_normal_repositories_set/1_6_3_2.yml
@@ -1,0 +1,161 @@
+---
+http_interactions:
+- request:
+    method: put
+    uri: http://localhost:3200/source/home:tom/_meta?user=tom
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:tom">
+          <title/>
+          <description/>
+          <person userid="tom" role="maintainer"/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '129'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:tom">
+          <title></title>
+          <description></description>
+          <person userid="tom" role="maintainer" />
+        </project>
+    http_version: 
+  recorded_at: Fri, 22 Sep 2017 08:49:47 GMT
+- request:
+    method: put
+    uri: http://localhost:3200/source/home:tom/package_with_kiwi_image/_meta?user=_nobody_
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="package_with_kiwi_image" project="home:tom">
+          <title>The Grapes of Wrath</title>
+          <description>Deleniti nam repellendus molestiae totam laboriosam quia qui.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '199'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="package_with_kiwi_image" project="home:tom">
+          <title>The Grapes of Wrath</title>
+          <description>Deleniti nam repellendus molestiae totam laboriosam quia qui.</description>
+        </package>
+    http_version: 
+  recorded_at: Fri, 22 Sep 2017 08:49:47 GMT
+- request:
+    method: put
+    uri: http://localhost:3200/source/home:tom/package_with_kiwi_image/_meta
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="package_with_kiwi_image" project="home:tom">
+          <title>The Grapes of Wrath</title>
+          <description>Deleniti nam repellendus molestiae totam laboriosam quia qui.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '199'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="package_with_kiwi_image" project="home:tom">
+          <title>The Grapes of Wrath</title>
+          <description>Deleniti nam repellendus molestiae totam laboriosam quia qui.</description>
+        </package>
+    http_version: 
+  recorded_at: Fri, 22 Sep 2017 08:49:47 GMT
+- request:
+    method: put
+    uri: http://localhost:3200/source/home:tom/package_with_kiwi_image/_meta?user=_nobody_
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="package_with_kiwi_image" project="home:tom">
+          <title>The Grapes of Wrath</title>
+          <description>Deleniti nam repellendus molestiae totam laboriosam quia qui.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '199'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="package_with_kiwi_image" project="home:tom">
+          <title>The Grapes of Wrath</title>
+          <description>Deleniti nam repellendus molestiae totam laboriosam quia qui.</description>
+        </package>
+    http_version: 
+  recorded_at: Fri, 22 Sep 2017 08:49:47 GMT
+recorded_with: VCR 3.0.3

--- a/src/api/spec/cassettes/Kiwi_Image/_binaries_available/with_OBS_and_normal_repositories_set/1_6_3_3.yml
+++ b/src/api/spec/cassettes/Kiwi_Image/_binaries_available/with_OBS_and_normal_repositories_set/1_6_3_3.yml
@@ -1,0 +1,161 @@
+---
+http_interactions:
+- request:
+    method: put
+    uri: http://localhost:3200/source/home:tom/_meta?user=tom
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:tom">
+          <title/>
+          <description/>
+          <person userid="tom" role="maintainer"/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '129'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:tom">
+          <title></title>
+          <description></description>
+          <person userid="tom" role="maintainer" />
+        </project>
+    http_version: 
+  recorded_at: Fri, 22 Sep 2017 08:49:46 GMT
+- request:
+    method: put
+    uri: http://localhost:3200/source/home:tom/package_with_kiwi_image/_meta?user=_nobody_
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="package_with_kiwi_image" project="home:tom">
+          <title>After Many a Summer Dies the Swan</title>
+          <description>Aut et voluptatum amet.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '175'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="package_with_kiwi_image" project="home:tom">
+          <title>After Many a Summer Dies the Swan</title>
+          <description>Aut et voluptatum amet.</description>
+        </package>
+    http_version: 
+  recorded_at: Fri, 22 Sep 2017 08:49:46 GMT
+- request:
+    method: put
+    uri: http://localhost:3200/source/home:tom/package_with_kiwi_image/_meta
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="package_with_kiwi_image" project="home:tom">
+          <title>After Many a Summer Dies the Swan</title>
+          <description>Aut et voluptatum amet.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '175'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="package_with_kiwi_image" project="home:tom">
+          <title>After Many a Summer Dies the Swan</title>
+          <description>Aut et voluptatum amet.</description>
+        </package>
+    http_version: 
+  recorded_at: Fri, 22 Sep 2017 08:49:46 GMT
+- request:
+    method: put
+    uri: http://localhost:3200/source/home:tom/package_with_kiwi_image/_meta?user=_nobody_
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="package_with_kiwi_image" project="home:tom">
+          <title>After Many a Summer Dies the Swan</title>
+          <description>Aut et voluptatum amet.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '175'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="package_with_kiwi_image" project="home:tom">
+          <title>After Many a Summer Dies the Swan</title>
+          <description>Aut et voluptatum amet.</description>
+        </package>
+    http_version: 
+  recorded_at: Fri, 22 Sep 2017 08:49:46 GMT
+recorded_with: VCR 3.0.3

--- a/src/api/spec/cassettes/Kiwi_Image/_binaries_available/with_OBS_and_normal_repositories_set/1_6_3_4.yml
+++ b/src/api/spec/cassettes/Kiwi_Image/_binaries_available/with_OBS_and_normal_repositories_set/1_6_3_4.yml
@@ -1,0 +1,161 @@
+---
+http_interactions:
+- request:
+    method: put
+    uri: http://localhost:3200/source/home:tom/_meta?user=tom
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:tom">
+          <title/>
+          <description/>
+          <person userid="tom" role="maintainer"/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '129'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:tom">
+          <title></title>
+          <description></description>
+          <person userid="tom" role="maintainer" />
+        </project>
+    http_version: 
+  recorded_at: Fri, 22 Sep 2017 08:49:46 GMT
+- request:
+    method: put
+    uri: http://localhost:3200/source/home:tom/package_with_kiwi_image/_meta?user=_nobody_
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="package_with_kiwi_image" project="home:tom">
+          <title>No Longer at Ease</title>
+          <description>Possimus a doloribus itaque ab rerum aut explicabo voluptatem.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '198'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="package_with_kiwi_image" project="home:tom">
+          <title>No Longer at Ease</title>
+          <description>Possimus a doloribus itaque ab rerum aut explicabo voluptatem.</description>
+        </package>
+    http_version: 
+  recorded_at: Fri, 22 Sep 2017 08:49:47 GMT
+- request:
+    method: put
+    uri: http://localhost:3200/source/home:tom/package_with_kiwi_image/_meta
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="package_with_kiwi_image" project="home:tom">
+          <title>No Longer at Ease</title>
+          <description>Possimus a doloribus itaque ab rerum aut explicabo voluptatem.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '198'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="package_with_kiwi_image" project="home:tom">
+          <title>No Longer at Ease</title>
+          <description>Possimus a doloribus itaque ab rerum aut explicabo voluptatem.</description>
+        </package>
+    http_version: 
+  recorded_at: Fri, 22 Sep 2017 08:49:47 GMT
+- request:
+    method: put
+    uri: http://localhost:3200/source/home:tom/package_with_kiwi_image/_meta?user=_nobody_
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="package_with_kiwi_image" project="home:tom">
+          <title>No Longer at Ease</title>
+          <description>Possimus a doloribus itaque ab rerum aut explicabo voluptatem.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '198'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="package_with_kiwi_image" project="home:tom">
+          <title>No Longer at Ease</title>
+          <description>Possimus a doloribus itaque ab rerum aut explicabo voluptatem.</description>
+        </package>
+    http_version: 
+  recorded_at: Fri, 22 Sep 2017 08:49:47 GMT
+recorded_with: VCR 3.0.3

--- a/src/api/spec/cassettes/Kiwi_Image/_binaries_available/with_use_project_repositories_set/1_6_2_1.yml
+++ b/src/api/spec/cassettes/Kiwi_Image/_binaries_available/with_use_project_repositories_set/1_6_2_1.yml
@@ -1,0 +1,161 @@
+---
+http_interactions:
+- request:
+    method: put
+    uri: http://localhost:3200/source/home:tom/_meta?user=tom
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:tom">
+          <title/>
+          <description/>
+          <person userid="tom" role="maintainer"/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '129'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:tom">
+          <title></title>
+          <description></description>
+          <person userid="tom" role="maintainer" />
+        </project>
+    http_version: 
+  recorded_at: Fri, 22 Sep 2017 08:49:49 GMT
+- request:
+    method: put
+    uri: http://localhost:3200/source/home:tom/package_with_kiwi_image/_meta?user=_nobody_
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="package_with_kiwi_image" project="home:tom">
+          <title>Cover Her Face</title>
+          <description>Quia praesentium est sint.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '159'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="package_with_kiwi_image" project="home:tom">
+          <title>Cover Her Face</title>
+          <description>Quia praesentium est sint.</description>
+        </package>
+    http_version: 
+  recorded_at: Fri, 22 Sep 2017 08:49:49 GMT
+- request:
+    method: put
+    uri: http://localhost:3200/source/home:tom/package_with_kiwi_image/_meta
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="package_with_kiwi_image" project="home:tom">
+          <title>Cover Her Face</title>
+          <description>Quia praesentium est sint.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '159'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="package_with_kiwi_image" project="home:tom">
+          <title>Cover Her Face</title>
+          <description>Quia praesentium est sint.</description>
+        </package>
+    http_version: 
+  recorded_at: Fri, 22 Sep 2017 08:49:49 GMT
+- request:
+    method: put
+    uri: http://localhost:3200/source/home:tom/package_with_kiwi_image/_meta?user=_nobody_
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="package_with_kiwi_image" project="home:tom">
+          <title>Cover Her Face</title>
+          <description>Quia praesentium est sint.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '159'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="package_with_kiwi_image" project="home:tom">
+          <title>Cover Her Face</title>
+          <description>Quia praesentium est sint.</description>
+        </package>
+    http_version: 
+  recorded_at: Fri, 22 Sep 2017 08:49:49 GMT
+recorded_with: VCR 3.0.3

--- a/src/api/spec/cassettes/Kiwi_Image/_binaries_available/with_use_project_repositories_set/1_6_2_2.yml
+++ b/src/api/spec/cassettes/Kiwi_Image/_binaries_available/with_use_project_repositories_set/1_6_2_2.yml
@@ -1,0 +1,161 @@
+---
+http_interactions:
+- request:
+    method: put
+    uri: http://localhost:3200/source/home:tom/_meta?user=tom
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:tom">
+          <title/>
+          <description/>
+          <person userid="tom" role="maintainer"/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '129'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:tom">
+          <title></title>
+          <description></description>
+          <person userid="tom" role="maintainer" />
+        </project>
+    http_version: 
+  recorded_at: Fri, 22 Sep 2017 08:49:48 GMT
+- request:
+    method: put
+    uri: http://localhost:3200/source/home:tom/package_with_kiwi_image/_meta?user=_nobody_
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="package_with_kiwi_image" project="home:tom">
+          <title>What's Become of Waring</title>
+          <description>Recusandae assumenda tempora saepe.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '177'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="package_with_kiwi_image" project="home:tom">
+          <title>What's Become of Waring</title>
+          <description>Recusandae assumenda tempora saepe.</description>
+        </package>
+    http_version: 
+  recorded_at: Fri, 22 Sep 2017 08:49:48 GMT
+- request:
+    method: put
+    uri: http://localhost:3200/source/home:tom/package_with_kiwi_image/_meta
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="package_with_kiwi_image" project="home:tom">
+          <title>What's Become of Waring</title>
+          <description>Recusandae assumenda tempora saepe.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '177'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="package_with_kiwi_image" project="home:tom">
+          <title>What's Become of Waring</title>
+          <description>Recusandae assumenda tempora saepe.</description>
+        </package>
+    http_version: 
+  recorded_at: Fri, 22 Sep 2017 08:49:48 GMT
+- request:
+    method: put
+    uri: http://localhost:3200/source/home:tom/package_with_kiwi_image/_meta?user=_nobody_
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="package_with_kiwi_image" project="home:tom">
+          <title>What's Become of Waring</title>
+          <description>Recusandae assumenda tempora saepe.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '177'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="package_with_kiwi_image" project="home:tom">
+          <title>What's Become of Waring</title>
+          <description>Recusandae assumenda tempora saepe.</description>
+        </package>
+    http_version: 
+  recorded_at: Fri, 22 Sep 2017 08:49:49 GMT
+recorded_with: VCR 3.0.3

--- a/src/api/spec/cassettes/Kiwi_Image/_binaries_available/with_use_project_repositories_set/1_6_2_3.yml
+++ b/src/api/spec/cassettes/Kiwi_Image/_binaries_available/with_use_project_repositories_set/1_6_2_3.yml
@@ -1,0 +1,161 @@
+---
+http_interactions:
+- request:
+    method: put
+    uri: http://localhost:3200/source/home:tom/_meta?user=tom
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:tom">
+          <title/>
+          <description/>
+          <person userid="tom" role="maintainer"/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '129'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:tom">
+          <title></title>
+          <description></description>
+          <person userid="tom" role="maintainer" />
+        </project>
+    http_version: 
+  recorded_at: Fri, 22 Sep 2017 08:49:49 GMT
+- request:
+    method: put
+    uri: http://localhost:3200/source/home:tom/package_with_kiwi_image/_meta?user=_nobody_
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="package_with_kiwi_image" project="home:tom">
+          <title>Recalled to Life</title>
+          <description>Qui quis accusantium quis consectetur adipisci dolores inventore neque.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '206'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="package_with_kiwi_image" project="home:tom">
+          <title>Recalled to Life</title>
+          <description>Qui quis accusantium quis consectetur adipisci dolores inventore neque.</description>
+        </package>
+    http_version: 
+  recorded_at: Fri, 22 Sep 2017 08:49:49 GMT
+- request:
+    method: put
+    uri: http://localhost:3200/source/home:tom/package_with_kiwi_image/_meta
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="package_with_kiwi_image" project="home:tom">
+          <title>Recalled to Life</title>
+          <description>Qui quis accusantium quis consectetur adipisci dolores inventore neque.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '206'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="package_with_kiwi_image" project="home:tom">
+          <title>Recalled to Life</title>
+          <description>Qui quis accusantium quis consectetur adipisci dolores inventore neque.</description>
+        </package>
+    http_version: 
+  recorded_at: Fri, 22 Sep 2017 08:49:49 GMT
+- request:
+    method: put
+    uri: http://localhost:3200/source/home:tom/package_with_kiwi_image/_meta?user=_nobody_
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="package_with_kiwi_image" project="home:tom">
+          <title>Recalled to Life</title>
+          <description>Qui quis accusantium quis consectetur adipisci dolores inventore neque.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '206'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="package_with_kiwi_image" project="home:tom">
+          <title>Recalled to Life</title>
+          <description>Qui quis accusantium quis consectetur adipisci dolores inventore neque.</description>
+        </package>
+    http_version: 
+  recorded_at: Fri, 22 Sep 2017 08:49:49 GMT
+recorded_with: VCR 3.0.3

--- a/src/api/spec/cassettes/Kiwi_Image/_binaries_available/with_use_project_repositories_set/1_6_2_4.yml
+++ b/src/api/spec/cassettes/Kiwi_Image/_binaries_available/with_use_project_repositories_set/1_6_2_4.yml
@@ -1,0 +1,161 @@
+---
+http_interactions:
+- request:
+    method: put
+    uri: http://localhost:3200/source/home:tom/_meta?user=tom
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:tom">
+          <title/>
+          <description/>
+          <person userid="tom" role="maintainer"/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '129'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:tom">
+          <title></title>
+          <description></description>
+          <person userid="tom" role="maintainer" />
+        </project>
+    http_version: 
+  recorded_at: Fri, 22 Sep 2017 08:49:48 GMT
+- request:
+    method: put
+    uri: http://localhost:3200/source/home:tom/package_with_kiwi_image/_meta?user=_nobody_
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="package_with_kiwi_image" project="home:tom">
+          <title>The Needle's Eye</title>
+          <description>Recusandae fuga ex quia aut natus.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '169'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="package_with_kiwi_image" project="home:tom">
+          <title>The Needle's Eye</title>
+          <description>Recusandae fuga ex quia aut natus.</description>
+        </package>
+    http_version: 
+  recorded_at: Fri, 22 Sep 2017 08:49:48 GMT
+- request:
+    method: put
+    uri: http://localhost:3200/source/home:tom/package_with_kiwi_image/_meta
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="package_with_kiwi_image" project="home:tom">
+          <title>The Needle's Eye</title>
+          <description>Recusandae fuga ex quia aut natus.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '169'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="package_with_kiwi_image" project="home:tom">
+          <title>The Needle's Eye</title>
+          <description>Recusandae fuga ex quia aut natus.</description>
+        </package>
+    http_version: 
+  recorded_at: Fri, 22 Sep 2017 08:49:48 GMT
+- request:
+    method: put
+    uri: http://localhost:3200/source/home:tom/package_with_kiwi_image/_meta?user=_nobody_
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="package_with_kiwi_image" project="home:tom">
+          <title>The Needle's Eye</title>
+          <description>Recusandae fuga ex quia aut natus.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '169'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="package_with_kiwi_image" project="home:tom">
+          <title>The Needle's Eye</title>
+          <description>Recusandae fuga ex quia aut natus.</description>
+        </package>
+    http_version: 
+  recorded_at: Fri, 22 Sep 2017 08:49:48 GMT
+recorded_with: VCR 3.0.3

--- a/src/api/spec/cassettes/Kiwi_Image/_binaries_available/without_a_package_for_the_image/1_6_1_1.yml
+++ b/src/api/spec/cassettes/Kiwi_Image/_binaries_available/without_a_package_for_the_image/1_6_1_1.yml
@@ -1,0 +1,44 @@
+---
+http_interactions:
+- request:
+    method: put
+    uri: http://localhost:3200/source/home:tom/_meta?user=tom
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:tom">
+          <title/>
+          <description/>
+          <person userid="tom" role="maintainer"/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '129'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:tom">
+          <title></title>
+          <description></description>
+          <person userid="tom" role="maintainer" />
+        </project>
+    http_version: 
+  recorded_at: Fri, 22 Sep 2017 08:49:49 GMT
+recorded_with: VCR 3.0.3

--- a/src/api/spec/cassettes/Webui_Kiwi_ImagesController/GET_autocomplete_binaries/1_4_1.yml
+++ b/src/api/spec/cassettes/Webui_Kiwi_ImagesController/GET_autocomplete_binaries/1_4_1.yml
@@ -1,0 +1,242 @@
+---
+http_interactions:
+- request:
+    method: put
+    uri: http://localhost:3200/source/home:tom/_meta?user=tom
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:tom">
+          <title/>
+          <description/>
+          <person userid="tom" role="maintainer"/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '129'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:tom">
+          <title></title>
+          <description></description>
+          <person userid="tom" role="maintainer" />
+        </project>
+    http_version: 
+  recorded_at: Thu, 21 Sep 2017 11:57:18 GMT
+- request:
+    method: put
+    uri: http://localhost:3200/source/home:tom/package_with_kiwi_image/_meta?user=tom
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="package_with_kiwi_image" project="home:tom">
+          <title>The Needle's Eye</title>
+          <description>Qui sit corrupti odit voluptatem ea aut.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '175'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="package_with_kiwi_image" project="home:tom">
+          <title>The Needle's Eye</title>
+          <description>Qui sit corrupti odit voluptatem ea aut.</description>
+        </package>
+    http_version: 
+  recorded_at: Thu, 21 Sep 2017 11:57:19 GMT
+- request:
+    method: put
+    uri: http://localhost:3200/source/home:tom/package_with_kiwi_image/_meta
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="package_with_kiwi_image" project="home:tom">
+          <title>The Needle's Eye</title>
+          <description>Qui sit corrupti odit voluptatem ea aut.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '175'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="package_with_kiwi_image" project="home:tom">
+          <title>The Needle's Eye</title>
+          <description>Qui sit corrupti odit voluptatem ea aut.</description>
+        </package>
+    http_version: 
+  recorded_at: Thu, 21 Sep 2017 11:57:19 GMT
+- request:
+    method: put
+    uri: http://localhost:3200/source/home:tom/package_with_kiwi_image/package_with_kiwi_image.kiwi
+    body:
+      encoding: UTF-8
+      string: |
+        <?xml version="1.0" encoding="utf-8"?>
+        <image schemaversion="6.2" name="suse-13.2-live">
+          <description type="system">
+          </description>
+          <preferences>
+            <type image="oem" primary="true" boot="oemboot/suse-13.2"/>
+          </preferences>
+        </image>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '209'
+    body:
+      encoding: UTF-8
+      string: |
+        <revision rev="46" vrev="46">
+          <srcmd5>82f39606fd3c729f7f16de7d227e6dae</srcmd5>
+          <version>unknown</version>
+          <time>1505995039</time>
+          <user>unknown</user>
+          <comment></comment>
+          <requestid/>
+        </revision>
+    http_version: 
+  recorded_at: Thu, 21 Sep 2017 11:57:19 GMT
+- request:
+    method: put
+    uri: http://localhost:3200/source/home:tom/package_with_kiwi_image/_meta?user=tom
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="package_with_kiwi_image" project="home:tom">
+          <title>The Needle's Eye</title>
+          <description>Qui sit corrupti odit voluptatem ea aut.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '175'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="package_with_kiwi_image" project="home:tom">
+          <title>The Needle's Eye</title>
+          <description>Qui sit corrupti odit voluptatem ea aut.</description>
+        </package>
+    http_version: 
+  recorded_at: Thu, 21 Sep 2017 11:57:19 GMT
+- request:
+    method: get
+    uri: http://localhost:3200/source/home:tom/package_with_kiwi_image
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '234'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="package_with_kiwi_image" rev="46" vrev="46" srcmd5="82f39606fd3c729f7f16de7d227e6dae">
+          <entry name="package_with_kiwi_image.kiwi" md5="dda935f455dcd6607d83705328bee9df" size="242" mtime="1505991770" />
+        </directory>
+    http_version: 
+  recorded_at: Thu, 21 Sep 2017 11:57:19 GMT
+recorded_with: VCR 3.0.3

--- a/src/api/spec/cassettes/Webui_Kiwi_ImagesController/GET_autocomplete_binaries/1_4_2.yml
+++ b/src/api/spec/cassettes/Webui_Kiwi_ImagesController/GET_autocomplete_binaries/1_4_2.yml
@@ -1,0 +1,242 @@
+---
+http_interactions:
+- request:
+    method: put
+    uri: http://localhost:3200/source/home:tom/_meta?user=tom
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:tom">
+          <title/>
+          <description/>
+          <person userid="tom" role="maintainer"/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '129'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:tom">
+          <title></title>
+          <description></description>
+          <person userid="tom" role="maintainer" />
+        </project>
+    http_version: 
+  recorded_at: Thu, 21 Sep 2017 11:57:19 GMT
+- request:
+    method: put
+    uri: http://localhost:3200/source/home:tom/package_with_kiwi_image/_meta?user=tom
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="package_with_kiwi_image" project="home:tom">
+          <title>This Lime Tree Bower</title>
+          <description>Et inventore repellat perspiciatis velit reiciendis dolor et.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '200'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="package_with_kiwi_image" project="home:tom">
+          <title>This Lime Tree Bower</title>
+          <description>Et inventore repellat perspiciatis velit reiciendis dolor et.</description>
+        </package>
+    http_version: 
+  recorded_at: Thu, 21 Sep 2017 11:57:19 GMT
+- request:
+    method: put
+    uri: http://localhost:3200/source/home:tom/package_with_kiwi_image/_meta
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="package_with_kiwi_image" project="home:tom">
+          <title>This Lime Tree Bower</title>
+          <description>Et inventore repellat perspiciatis velit reiciendis dolor et.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '200'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="package_with_kiwi_image" project="home:tom">
+          <title>This Lime Tree Bower</title>
+          <description>Et inventore repellat perspiciatis velit reiciendis dolor et.</description>
+        </package>
+    http_version: 
+  recorded_at: Thu, 21 Sep 2017 11:57:19 GMT
+- request:
+    method: put
+    uri: http://localhost:3200/source/home:tom/package_with_kiwi_image/package_with_kiwi_image.kiwi
+    body:
+      encoding: UTF-8
+      string: |
+        <?xml version="1.0" encoding="utf-8"?>
+        <image schemaversion="6.2" name="suse-13.2-live">
+          <description type="system">
+          </description>
+          <preferences>
+            <type image="oem" primary="true" boot="oemboot/suse-13.2"/>
+          </preferences>
+        </image>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '209'
+    body:
+      encoding: UTF-8
+      string: |
+        <revision rev="47" vrev="47">
+          <srcmd5>82f39606fd3c729f7f16de7d227e6dae</srcmd5>
+          <version>unknown</version>
+          <time>1505995039</time>
+          <user>unknown</user>
+          <comment></comment>
+          <requestid/>
+        </revision>
+    http_version: 
+  recorded_at: Thu, 21 Sep 2017 11:57:19 GMT
+- request:
+    method: put
+    uri: http://localhost:3200/source/home:tom/package_with_kiwi_image/_meta?user=tom
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="package_with_kiwi_image" project="home:tom">
+          <title>This Lime Tree Bower</title>
+          <description>Et inventore repellat perspiciatis velit reiciendis dolor et.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '200'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="package_with_kiwi_image" project="home:tom">
+          <title>This Lime Tree Bower</title>
+          <description>Et inventore repellat perspiciatis velit reiciendis dolor et.</description>
+        </package>
+    http_version: 
+  recorded_at: Thu, 21 Sep 2017 11:57:20 GMT
+- request:
+    method: get
+    uri: http://localhost:3200/source/home:tom/package_with_kiwi_image
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '234'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="package_with_kiwi_image" rev="47" vrev="47" srcmd5="82f39606fd3c729f7f16de7d227e6dae">
+          <entry name="package_with_kiwi_image.kiwi" md5="dda935f455dcd6607d83705328bee9df" size="242" mtime="1505991770" />
+        </directory>
+    http_version: 
+  recorded_at: Thu, 21 Sep 2017 11:57:20 GMT
+recorded_with: VCR 3.0.3

--- a/src/api/spec/cassettes/Webui_Kiwi_ImagesController/GET_autocomplete_binaries/1_4_3.yml
+++ b/src/api/spec/cassettes/Webui_Kiwi_ImagesController/GET_autocomplete_binaries/1_4_3.yml
@@ -1,0 +1,242 @@
+---
+http_interactions:
+- request:
+    method: put
+    uri: http://localhost:3200/source/home:tom/_meta?user=tom
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:tom">
+          <title/>
+          <description/>
+          <person userid="tom" role="maintainer"/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '129'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:tom">
+          <title></title>
+          <description></description>
+          <person userid="tom" role="maintainer" />
+        </project>
+    http_version: 
+  recorded_at: Thu, 21 Sep 2017 11:57:20 GMT
+- request:
+    method: put
+    uri: http://localhost:3200/source/home:tom/package_with_kiwi_image/_meta?user=tom
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="package_with_kiwi_image" project="home:tom">
+          <title>The Mirror Crack'd from Side to Side</title>
+          <description>Aut aut consequuntur quis incidunt.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '190'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="package_with_kiwi_image" project="home:tom">
+          <title>The Mirror Crack'd from Side to Side</title>
+          <description>Aut aut consequuntur quis incidunt.</description>
+        </package>
+    http_version: 
+  recorded_at: Thu, 21 Sep 2017 11:57:20 GMT
+- request:
+    method: put
+    uri: http://localhost:3200/source/home:tom/package_with_kiwi_image/_meta
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="package_with_kiwi_image" project="home:tom">
+          <title>The Mirror Crack'd from Side to Side</title>
+          <description>Aut aut consequuntur quis incidunt.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '190'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="package_with_kiwi_image" project="home:tom">
+          <title>The Mirror Crack'd from Side to Side</title>
+          <description>Aut aut consequuntur quis incidunt.</description>
+        </package>
+    http_version: 
+  recorded_at: Thu, 21 Sep 2017 11:57:20 GMT
+- request:
+    method: put
+    uri: http://localhost:3200/source/home:tom/package_with_kiwi_image/package_with_kiwi_image.kiwi
+    body:
+      encoding: UTF-8
+      string: |
+        <?xml version="1.0" encoding="utf-8"?>
+        <image schemaversion="6.2" name="suse-13.2-live">
+          <description type="system">
+          </description>
+          <preferences>
+            <type image="oem" primary="true" boot="oemboot/suse-13.2"/>
+          </preferences>
+        </image>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '209'
+    body:
+      encoding: UTF-8
+      string: |
+        <revision rev="48" vrev="48">
+          <srcmd5>82f39606fd3c729f7f16de7d227e6dae</srcmd5>
+          <version>unknown</version>
+          <time>1505995040</time>
+          <user>unknown</user>
+          <comment></comment>
+          <requestid/>
+        </revision>
+    http_version: 
+  recorded_at: Thu, 21 Sep 2017 11:57:20 GMT
+- request:
+    method: put
+    uri: http://localhost:3200/source/home:tom/package_with_kiwi_image/_meta?user=tom
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="package_with_kiwi_image" project="home:tom">
+          <title>The Mirror Crack'd from Side to Side</title>
+          <description>Aut aut consequuntur quis incidunt.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '190'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="package_with_kiwi_image" project="home:tom">
+          <title>The Mirror Crack'd from Side to Side</title>
+          <description>Aut aut consequuntur quis incidunt.</description>
+        </package>
+    http_version: 
+  recorded_at: Thu, 21 Sep 2017 11:57:20 GMT
+- request:
+    method: get
+    uri: http://localhost:3200/source/home:tom/package_with_kiwi_image
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '234'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="package_with_kiwi_image" rev="48" vrev="48" srcmd5="82f39606fd3c729f7f16de7d227e6dae">
+          <entry name="package_with_kiwi_image.kiwi" md5="dda935f455dcd6607d83705328bee9df" size="242" mtime="1505991770" />
+        </directory>
+    http_version: 
+  recorded_at: Thu, 21 Sep 2017 11:57:20 GMT
+recorded_with: VCR 3.0.3

--- a/src/api/spec/cassettes/Webui_Kiwi_ImagesController/GET_autocomplete_binaries/1_4_4/1_4_4_1.yml
+++ b/src/api/spec/cassettes/Webui_Kiwi_ImagesController/GET_autocomplete_binaries/1_4_4/1_4_4_1.yml
@@ -1,0 +1,242 @@
+---
+http_interactions:
+- request:
+    method: put
+    uri: http://localhost:3200/source/home:tom/_meta?user=tom
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:tom">
+          <title/>
+          <description/>
+          <person userid="tom" role="maintainer"/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '129'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:tom">
+          <title></title>
+          <description></description>
+          <person userid="tom" role="maintainer" />
+        </project>
+    http_version: 
+  recorded_at: Thu, 21 Sep 2017 11:57:21 GMT
+- request:
+    method: put
+    uri: http://localhost:3200/source/home:tom/package_with_kiwi_image/_meta?user=tom
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="package_with_kiwi_image" project="home:tom">
+          <title>His Dark Materials</title>
+          <description>Officiis eum non doloribus.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '164'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="package_with_kiwi_image" project="home:tom">
+          <title>His Dark Materials</title>
+          <description>Officiis eum non doloribus.</description>
+        </package>
+    http_version: 
+  recorded_at: Thu, 21 Sep 2017 11:57:21 GMT
+- request:
+    method: put
+    uri: http://localhost:3200/source/home:tom/package_with_kiwi_image/_meta
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="package_with_kiwi_image" project="home:tom">
+          <title>His Dark Materials</title>
+          <description>Officiis eum non doloribus.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '164'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="package_with_kiwi_image" project="home:tom">
+          <title>His Dark Materials</title>
+          <description>Officiis eum non doloribus.</description>
+        </package>
+    http_version: 
+  recorded_at: Thu, 21 Sep 2017 11:57:21 GMT
+- request:
+    method: put
+    uri: http://localhost:3200/source/home:tom/package_with_kiwi_image/package_with_kiwi_image.kiwi
+    body:
+      encoding: UTF-8
+      string: |
+        <?xml version="1.0" encoding="utf-8"?>
+        <image schemaversion="6.2" name="suse-13.2-live">
+          <description type="system">
+          </description>
+          <preferences>
+            <type image="oem" primary="true" boot="oemboot/suse-13.2"/>
+          </preferences>
+        </image>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '209'
+    body:
+      encoding: UTF-8
+      string: |
+        <revision rev="50" vrev="50">
+          <srcmd5>82f39606fd3c729f7f16de7d227e6dae</srcmd5>
+          <version>unknown</version>
+          <time>1505995041</time>
+          <user>unknown</user>
+          <comment></comment>
+          <requestid/>
+        </revision>
+    http_version: 
+  recorded_at: Thu, 21 Sep 2017 11:57:21 GMT
+- request:
+    method: put
+    uri: http://localhost:3200/source/home:tom/package_with_kiwi_image/_meta?user=tom
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="package_with_kiwi_image" project="home:tom">
+          <title>His Dark Materials</title>
+          <description>Officiis eum non doloribus.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '164'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="package_with_kiwi_image" project="home:tom">
+          <title>His Dark Materials</title>
+          <description>Officiis eum non doloribus.</description>
+        </package>
+    http_version: 
+  recorded_at: Thu, 21 Sep 2017 11:57:21 GMT
+- request:
+    method: get
+    uri: http://localhost:3200/source/home:tom/package_with_kiwi_image
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '234'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="package_with_kiwi_image" rev="50" vrev="50" srcmd5="82f39606fd3c729f7f16de7d227e6dae">
+          <entry name="package_with_kiwi_image.kiwi" md5="dda935f455dcd6607d83705328bee9df" size="242" mtime="1505991770" />
+        </directory>
+    http_version: 
+  recorded_at: Thu, 21 Sep 2017 11:57:21 GMT
+recorded_with: VCR 3.0.3

--- a/src/api/spec/cassettes/Webui_Kiwi_ImagesController/GET_autocomplete_binaries/1_4_5/1_4_5_1.yml
+++ b/src/api/spec/cassettes/Webui_Kiwi_ImagesController/GET_autocomplete_binaries/1_4_5/1_4_5_1.yml
@@ -1,0 +1,242 @@
+---
+http_interactions:
+- request:
+    method: put
+    uri: http://localhost:3200/source/home:tom/_meta?user=tom
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:tom">
+          <title/>
+          <description/>
+          <person userid="tom" role="maintainer"/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '129'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:tom">
+          <title></title>
+          <description></description>
+          <person userid="tom" role="maintainer" />
+        </project>
+    http_version: 
+  recorded_at: Thu, 21 Sep 2017 11:57:20 GMT
+- request:
+    method: put
+    uri: http://localhost:3200/source/home:tom/package_with_kiwi_image/_meta?user=tom
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="package_with_kiwi_image" project="home:tom">
+          <title>East of Eden</title>
+          <description>Ea deleniti nostrum nisi minus nihil non voluptate fugit.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '188'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="package_with_kiwi_image" project="home:tom">
+          <title>East of Eden</title>
+          <description>Ea deleniti nostrum nisi minus nihil non voluptate fugit.</description>
+        </package>
+    http_version: 
+  recorded_at: Thu, 21 Sep 2017 11:57:20 GMT
+- request:
+    method: put
+    uri: http://localhost:3200/source/home:tom/package_with_kiwi_image/_meta
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="package_with_kiwi_image" project="home:tom">
+          <title>East of Eden</title>
+          <description>Ea deleniti nostrum nisi minus nihil non voluptate fugit.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '188'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="package_with_kiwi_image" project="home:tom">
+          <title>East of Eden</title>
+          <description>Ea deleniti nostrum nisi minus nihil non voluptate fugit.</description>
+        </package>
+    http_version: 
+  recorded_at: Thu, 21 Sep 2017 11:57:20 GMT
+- request:
+    method: put
+    uri: http://localhost:3200/source/home:tom/package_with_kiwi_image/package_with_kiwi_image.kiwi
+    body:
+      encoding: UTF-8
+      string: |
+        <?xml version="1.0" encoding="utf-8"?>
+        <image schemaversion="6.2" name="suse-13.2-live">
+          <description type="system">
+          </description>
+          <preferences>
+            <type image="oem" primary="true" boot="oemboot/suse-13.2"/>
+          </preferences>
+        </image>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '209'
+    body:
+      encoding: UTF-8
+      string: |
+        <revision rev="49" vrev="49">
+          <srcmd5>82f39606fd3c729f7f16de7d227e6dae</srcmd5>
+          <version>unknown</version>
+          <time>1505995040</time>
+          <user>unknown</user>
+          <comment></comment>
+          <requestid/>
+        </revision>
+    http_version: 
+  recorded_at: Thu, 21 Sep 2017 11:57:20 GMT
+- request:
+    method: put
+    uri: http://localhost:3200/source/home:tom/package_with_kiwi_image/_meta?user=tom
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="package_with_kiwi_image" project="home:tom">
+          <title>East of Eden</title>
+          <description>Ea deleniti nostrum nisi minus nihil non voluptate fugit.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '188'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="package_with_kiwi_image" project="home:tom">
+          <title>East of Eden</title>
+          <description>Ea deleniti nostrum nisi minus nihil non voluptate fugit.</description>
+        </package>
+    http_version: 
+  recorded_at: Thu, 21 Sep 2017 11:57:21 GMT
+- request:
+    method: get
+    uri: http://localhost:3200/source/home:tom/package_with_kiwi_image
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '234'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="package_with_kiwi_image" rev="49" vrev="49" srcmd5="82f39606fd3c729f7f16de7d227e6dae">
+          <entry name="package_with_kiwi_image.kiwi" md5="dda935f455dcd6607d83705328bee9df" size="242" mtime="1505991770" />
+        </directory>
+    http_version: 
+  recorded_at: Thu, 21 Sep 2017 11:57:21 GMT
+recorded_with: VCR 3.0.3

--- a/src/api/spec/cassettes/Webui_Kiwi_ImagesController/GET_autocomplete_binaries/1_4_6/1_4_6_1.yml
+++ b/src/api/spec/cassettes/Webui_Kiwi_ImagesController/GET_autocomplete_binaries/1_4_6/1_4_6_1.yml
@@ -1,0 +1,242 @@
+---
+http_interactions:
+- request:
+    method: put
+    uri: http://localhost:3200/source/home:tom/_meta?user=tom
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:tom">
+          <title/>
+          <description/>
+          <person userid="tom" role="maintainer"/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '129'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:tom">
+          <title></title>
+          <description></description>
+          <person userid="tom" role="maintainer" />
+        </project>
+    http_version: 
+  recorded_at: Thu, 21 Sep 2017 11:57:22 GMT
+- request:
+    method: put
+    uri: http://localhost:3200/source/home:tom/package_with_kiwi_image/_meta?user=tom
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="package_with_kiwi_image" project="home:tom">
+          <title>Fair Stood the Wind for France</title>
+          <description>Illum nisi nemo dolore et.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '175'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="package_with_kiwi_image" project="home:tom">
+          <title>Fair Stood the Wind for France</title>
+          <description>Illum nisi nemo dolore et.</description>
+        </package>
+    http_version: 
+  recorded_at: Thu, 21 Sep 2017 11:57:22 GMT
+- request:
+    method: put
+    uri: http://localhost:3200/source/home:tom/package_with_kiwi_image/_meta
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="package_with_kiwi_image" project="home:tom">
+          <title>Fair Stood the Wind for France</title>
+          <description>Illum nisi nemo dolore et.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '175'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="package_with_kiwi_image" project="home:tom">
+          <title>Fair Stood the Wind for France</title>
+          <description>Illum nisi nemo dolore et.</description>
+        </package>
+    http_version: 
+  recorded_at: Thu, 21 Sep 2017 11:57:22 GMT
+- request:
+    method: put
+    uri: http://localhost:3200/source/home:tom/package_with_kiwi_image/package_with_kiwi_image.kiwi
+    body:
+      encoding: UTF-8
+      string: |
+        <?xml version="1.0" encoding="utf-8"?>
+        <image schemaversion="6.2" name="suse-13.2-live">
+          <description type="system">
+          </description>
+          <preferences>
+            <type image="oem" primary="true" boot="oemboot/suse-13.2"/>
+          </preferences>
+        </image>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '209'
+    body:
+      encoding: UTF-8
+      string: |
+        <revision rev="51" vrev="51">
+          <srcmd5>82f39606fd3c729f7f16de7d227e6dae</srcmd5>
+          <version>unknown</version>
+          <time>1505995042</time>
+          <user>unknown</user>
+          <comment></comment>
+          <requestid/>
+        </revision>
+    http_version: 
+  recorded_at: Thu, 21 Sep 2017 11:57:22 GMT
+- request:
+    method: put
+    uri: http://localhost:3200/source/home:tom/package_with_kiwi_image/_meta?user=tom
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="package_with_kiwi_image" project="home:tom">
+          <title>Fair Stood the Wind for France</title>
+          <description>Illum nisi nemo dolore et.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '175'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="package_with_kiwi_image" project="home:tom">
+          <title>Fair Stood the Wind for France</title>
+          <description>Illum nisi nemo dolore et.</description>
+        </package>
+    http_version: 
+  recorded_at: Thu, 21 Sep 2017 11:57:22 GMT
+- request:
+    method: get
+    uri: http://localhost:3200/source/home:tom/package_with_kiwi_image
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '234'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="package_with_kiwi_image" rev="51" vrev="51" srcmd5="82f39606fd3c729f7f16de7d227e6dae">
+          <entry name="package_with_kiwi_image.kiwi" md5="dda935f455dcd6607d83705328bee9df" size="242" mtime="1505991770" />
+        </directory>
+    http_version: 
+  recorded_at: Thu, 21 Sep 2017 11:57:22 GMT
+recorded_with: VCR 3.0.3

--- a/src/api/spec/cassettes/Webui_Kiwi_ImagesController/GET_autocomplete_binaries/1_4_7/1_4_7_1.yml
+++ b/src/api/spec/cassettes/Webui_Kiwi_ImagesController/GET_autocomplete_binaries/1_4_7/1_4_7_1.yml
@@ -1,0 +1,242 @@
+---
+http_interactions:
+- request:
+    method: put
+    uri: http://localhost:3200/source/home:tom/_meta?user=tom
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:tom">
+          <title/>
+          <description/>
+          <person userid="tom" role="maintainer"/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '129'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:tom">
+          <title></title>
+          <description></description>
+          <person userid="tom" role="maintainer" />
+        </project>
+    http_version: 
+  recorded_at: Thu, 21 Sep 2017 11:57:22 GMT
+- request:
+    method: put
+    uri: http://localhost:3200/source/home:tom/package_with_kiwi_image/_meta?user=tom
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="package_with_kiwi_image" project="home:tom">
+          <title>As I Lay Dying</title>
+          <description>Iste quia molestias repellendus cumque deleniti aut.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '185'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="package_with_kiwi_image" project="home:tom">
+          <title>As I Lay Dying</title>
+          <description>Iste quia molestias repellendus cumque deleniti aut.</description>
+        </package>
+    http_version: 
+  recorded_at: Thu, 21 Sep 2017 11:57:22 GMT
+- request:
+    method: put
+    uri: http://localhost:3200/source/home:tom/package_with_kiwi_image/_meta
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="package_with_kiwi_image" project="home:tom">
+          <title>As I Lay Dying</title>
+          <description>Iste quia molestias repellendus cumque deleniti aut.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '185'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="package_with_kiwi_image" project="home:tom">
+          <title>As I Lay Dying</title>
+          <description>Iste quia molestias repellendus cumque deleniti aut.</description>
+        </package>
+    http_version: 
+  recorded_at: Thu, 21 Sep 2017 11:57:22 GMT
+- request:
+    method: put
+    uri: http://localhost:3200/source/home:tom/package_with_kiwi_image/package_with_kiwi_image.kiwi
+    body:
+      encoding: UTF-8
+      string: |
+        <?xml version="1.0" encoding="utf-8"?>
+        <image schemaversion="6.2" name="suse-13.2-live">
+          <description type="system">
+          </description>
+          <preferences>
+            <type image="oem" primary="true" boot="oemboot/suse-13.2"/>
+          </preferences>
+        </image>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '209'
+    body:
+      encoding: UTF-8
+      string: |
+        <revision rev="52" vrev="52">
+          <srcmd5>82f39606fd3c729f7f16de7d227e6dae</srcmd5>
+          <version>unknown</version>
+          <time>1505995042</time>
+          <user>unknown</user>
+          <comment></comment>
+          <requestid/>
+        </revision>
+    http_version: 
+  recorded_at: Thu, 21 Sep 2017 11:57:22 GMT
+- request:
+    method: put
+    uri: http://localhost:3200/source/home:tom/package_with_kiwi_image/_meta?user=tom
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="package_with_kiwi_image" project="home:tom">
+          <title>As I Lay Dying</title>
+          <description>Iste quia molestias repellendus cumque deleniti aut.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '185'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="package_with_kiwi_image" project="home:tom">
+          <title>As I Lay Dying</title>
+          <description>Iste quia molestias repellendus cumque deleniti aut.</description>
+        </package>
+    http_version: 
+  recorded_at: Thu, 21 Sep 2017 11:57:22 GMT
+- request:
+    method: get
+    uri: http://localhost:3200/source/home:tom/package_with_kiwi_image
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '234'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="package_with_kiwi_image" rev="52" vrev="52" srcmd5="82f39606fd3c729f7f16de7d227e6dae">
+          <entry name="package_with_kiwi_image.kiwi" md5="dda935f455dcd6607d83705328bee9df" size="242" mtime="1505991770" />
+        </directory>
+    http_version: 
+  recorded_at: Thu, 21 Sep 2017 11:57:22 GMT
+recorded_with: VCR 3.0.3

--- a/src/api/spec/controllers/webui/kiwi/images_controller_spec.rb
+++ b/src/api/spec/controllers/webui/kiwi/images_controller_spec.rb
@@ -280,7 +280,7 @@ RSpec.describe Webui::Kiwi::ImagesController, type: :controller, vcr: true do
 
     before do
       login user
-      allow_any_instance_of(Kiwi::Image).to receive(:binaries_available).and_return(binaries_available_sample)
+      allow(Kiwi::Image).to receive(:binaries_available).and_return(binaries_available_sample)
     end
 
     subject do

--- a/src/api/spec/controllers/webui/kiwi/images_controller_spec.rb
+++ b/src/api/spec/controllers/webui/kiwi/images_controller_spec.rb
@@ -269,4 +269,52 @@ RSpec.describe Webui::Kiwi::ImagesController, type: :controller, vcr: true do
       it { expect(kiwi_package.arch).to eq("x86-876") }
     end
   end
+
+  describe 'GET #autocomplete_binaries' do
+    let(:binaries_available_sample) do
+      { 'apache' => ['i586', 'x86_64'], 'apache2' => ['x86_64'],
+        'appArmor' => ['i586', 'x86_64'], 'bcrypt' => ['x86_64'] }
+    end
+
+    let(:term) { '' }
+
+    before do
+      login user
+      allow_any_instance_of(Kiwi::Image).to receive(:binaries_available).and_return(binaries_available_sample)
+    end
+
+    subject do
+      get :autocomplete_binaries, params: { format: :json, id: kiwi_image_with_package_with_kiwi_file.id, term: term }
+    end
+
+    it { expect(subject.content_type).to eq("application/json") }
+    it { expect(subject).to have_http_status(:success) }
+    it do
+      expect(JSON.parse(subject.body)).to eq([{ 'id' => 'apache', 'label' => 'apache', 'value' => 'apache' },
+                                              { 'id' => 'apache2', 'label' => 'apache2', 'value' => 'apache2' },
+                                              { 'id' => 'appArmor', 'label' => 'appArmor', 'value' => 'appArmor' },
+                                              { 'id' => 'bcrypt', 'label' => 'bcrypt', 'value' => 'bcrypt' }])
+    end
+
+    context do
+      let(:term) { 'ap' }
+      it do
+        expect(JSON.parse(subject.body)).to eq([{ 'id' => 'apache', 'label' => 'apache', 'value' => 'apache' },
+                                                { 'id' => 'apache2', 'label' => 'apache2', 'value' => 'apache2' },
+                                                { 'id' => 'appArmor', 'label' => 'appArmor', 'value' => 'appArmor' }])
+      end
+    end
+    context do
+      let(:term) { 'app' }
+      it { expect(JSON.parse(subject.body)).to eq([{ 'id' => 'appArmor', 'label' => 'appArmor', 'value' => 'appArmor' }]) }
+    end
+    context do
+      let(:term) { 'b' }
+      it { expect(JSON.parse(subject.body)).to eq([{ 'id' => 'bcrypt', 'label' => 'bcrypt', 'value' => 'bcrypt' }]) }
+    end
+    context do
+      let(:term) { 'c' }
+      it { expect(JSON.parse(subject.body)).to be_empty }
+    end
+  end
 end

--- a/src/api/spec/models/kiwi/image_spec.rb
+++ b/src/api/spec/models/kiwi/image_spec.rb
@@ -1,4 +1,5 @@
 require 'rails_helper'
+require 'webmock/rspec'
 
 # WARNING: Some tests require real backend answers, so make sure you uncomment
 # this line and start a test backend.
@@ -317,5 +318,92 @@ RSpec.describe Kiwi::Image, type: :model, vcr: true do
         end
       end
     end
+  end
+
+  describe '.binaries_available' do
+    before do
+      Rails.cache.clear
+      path = "#{CONFIG['source_url']}/build/#{CGI.escape(project.name)}/_availablebinaries"
+      stub_request(:get, path).and_return(body:
+      "<availablebinaries>
+          <packages>
+            <arch>i586</arch>
+            <name>package1</name>
+            <name>package2</name>
+          </packages>
+          <packages>
+            <arch>x86_64</arch>
+            <name>package1</name>
+            <name>package3</name>
+          </packages>
+        </availablebinaries>")
+      stub_request(:get, "#{path}?path=#{CGI.escape(project.name)}/standard&url=#{CGI.escape('http://example.com/')}").and_return(body:
+      "<availablebinaries>
+          <packages>
+            <arch>i586</arch>
+            <name>package3</name>
+            <name>package4</name>
+          </packages>
+          <packages>
+            <arch>x86_64</arch>
+            <name>package1</name>
+            <name>package4</name>
+          </packages>
+        </availablebinaries>")
+    end
+
+    context 'without a package for the image' do
+      subject { create(:kiwi_image) }
+
+      it { expect(subject.binaries_available).to be_empty }
+    end
+
+    subject { create(:kiwi_image_with_package, project: project) }
+
+    context 'with use_project_repositories set' do
+      before do
+        subject.use_project_repositories = true
+        subject.save
+      end
+
+      it { expect(subject.binaries_available.keys).to match_array(['package1', 'package2', 'package3']) }
+      it { expect(subject.binaries_available['package1']).to match_array(['i586', 'x86_64']) }
+      it { expect(subject.binaries_available['package2']).to match_array(['i586']) }
+      it { expect(subject.binaries_available['package3']).to match_array(['i586', 'x86_64']) }
+    end
+
+    context 'with OBS and "normal" repositories set' do
+      before do
+        subject.repositories << build(:kiwi_repository, source_path: 'obs://home:tom/standard')
+        subject.repositories << build(:kiwi_repository)
+        subject.save
+      end
+
+      it { expect(subject.binaries_available.keys).to match_array(['package1', 'package3', 'package4']) }
+      it { expect(subject.binaries_available['package1']).to match_array(['x86_64']) }
+      it { expect(subject.binaries_available['package3']).to match_array(['i586']) }
+      it { expect(subject.binaries_available['package4']).to match_array(['i586', 'x86_64']) }
+    end
+  end
+
+  describe '.find_binaries_by_name' do
+    let(:binaries_available_sample) do
+      { 'apache' => ['i586', 'x86_64'], 'apache2' => ['x86_64'],
+        'appArmor' => ['i586', 'x86_64'], 'bcrypt' => ['x86_64'] }
+    end
+
+    before do
+      allow(subject).to receive(:binaries_available).and_return(binaries_available_sample)
+    end
+
+    subject { create(:kiwi_image) }
+
+    it { expect(subject.find_binaries_by_name('')).to eq(binaries_available_sample) }
+    it do
+      expect(subject.find_binaries_by_name('ap')).to eq({ 'apache' => ['i586', 'x86_64'], 'apache2' => ['x86_64'], 'appArmor' => ['i586', 'x86_64'] })
+    end
+    it { expect(subject.find_binaries_by_name('app')).to eq({ 'appArmor' => ['i586', 'x86_64'] }) }
+    it { expect(subject.find_binaries_by_name('b')).to eq({ 'bcrypt' => ['x86_64'] }) }
+    it { expect(subject.find_binaries_by_name('c')).to be_empty }
   end
 end

--- a/src/api/spec/models/kiwi/image_spec.rb
+++ b/src/api/spec/models/kiwi/image_spec.rb
@@ -320,7 +320,7 @@ RSpec.describe Kiwi::Image, type: :model, vcr: true do
     end
   end
 
-  describe '.binaries_available' do
+  describe '#binaries_available' do
     before do
       Rails.cache.clear
       path = "#{CONFIG['source_url']}/build/#{CGI.escape(project.name)}/_availablebinaries"
@@ -352,41 +352,26 @@ RSpec.describe Kiwi::Image, type: :model, vcr: true do
         </availablebinaries>")
     end
 
-    context 'without a package for the image' do
-      subject { create(:kiwi_image) }
-
-      it { expect(subject.binaries_available).to be_empty }
-    end
-
-    subject { create(:kiwi_image_with_package, project: project) }
-
     context 'with use_project_repositories set' do
-      before do
-        subject.use_project_repositories = true
-        subject.save
-      end
+      subject { Kiwi::Image.binaries_available(project.name, true, []) }
 
-      it { expect(subject.binaries_available.keys).to match_array(['package1', 'package2', 'package3']) }
-      it { expect(subject.binaries_available['package1']).to match_array(['i586', 'x86_64']) }
-      it { expect(subject.binaries_available['package2']).to match_array(['i586']) }
-      it { expect(subject.binaries_available['package3']).to match_array(['i586', 'x86_64']) }
+      it { expect(subject.keys).to match_array(['package1', 'package2', 'package3']) }
+      it { expect(subject['package1']).to match_array(['i586', 'x86_64']) }
+      it { expect(subject['package2']).to match_array(['i586']) }
+      it { expect(subject['package3']).to match_array(['i586', 'x86_64']) }
     end
 
     context 'with OBS and "normal" repositories set' do
-      before do
-        subject.repositories << build(:kiwi_repository, source_path: 'obs://home:tom/standard')
-        subject.repositories << build(:kiwi_repository)
-        subject.save
-      end
+      subject { Kiwi::Image.binaries_available(project.name, false, ['obs://home:tom/standard', 'http://example.com/']) }
 
-      it { expect(subject.binaries_available.keys).to match_array(['package1', 'package3', 'package4']) }
-      it { expect(subject.binaries_available['package1']).to match_array(['x86_64']) }
-      it { expect(subject.binaries_available['package3']).to match_array(['i586']) }
-      it { expect(subject.binaries_available['package4']).to match_array(['i586', 'x86_64']) }
+      it { expect(subject.keys).to match_array(['package1', 'package3', 'package4']) }
+      it { expect(subject['package1']).to match_array(['x86_64']) }
+      it { expect(subject['package3']).to match_array(['i586']) }
+      it { expect(subject['package4']).to match_array(['i586', 'x86_64']) }
     end
   end
 
-  describe '.find_binaries_by_name' do
+  describe '#find_binaries_by_name' do
     let(:binaries_available_sample) do
       { 'apache' => ['i586', 'x86_64'], 'apache2' => ['x86_64'],
         'appArmor' => ['i586', 'x86_64'], 'bcrypt' => ['x86_64'] }
@@ -396,14 +381,15 @@ RSpec.describe Kiwi::Image, type: :model, vcr: true do
       allow(subject).to receive(:binaries_available).and_return(binaries_available_sample)
     end
 
-    subject { create(:kiwi_image) }
+    subject { Kiwi::Image }
 
-    it { expect(subject.find_binaries_by_name('')).to eq(binaries_available_sample) }
+    it { expect(subject.find_binaries_by_name('', 'project', [], use_project_repositories: true)).to eq(binaries_available_sample) }
     it do
-      expect(subject.find_binaries_by_name('ap')).to eq({ 'apache' => ['i586', 'x86_64'], 'apache2' => ['x86_64'], 'appArmor' => ['i586', 'x86_64'] })
+      expect(subject.find_binaries_by_name('ap', 'project', [], use_project_repositories: true)).to eq({ 'apache' => ['i586', 'x86_64'],
+        'apache2' => ['x86_64'], 'appArmor' => ['i586', 'x86_64'] })
     end
-    it { expect(subject.find_binaries_by_name('app')).to eq({ 'appArmor' => ['i586', 'x86_64'] }) }
-    it { expect(subject.find_binaries_by_name('b')).to eq({ 'bcrypt' => ['x86_64'] }) }
-    it { expect(subject.find_binaries_by_name('c')).to be_empty }
+    it { expect(subject.find_binaries_by_name('app', 'project', [], use_project_repositories: true)).to eq({ 'appArmor' => ['i586', 'x86_64'] }) }
+    it { expect(subject.find_binaries_by_name('b', 'project', [], use_project_repositories: true)).to eq({ 'bcrypt' => ['x86_64'] }) }
+    it { expect(subject.find_binaries_by_name('c', 'project', [], use_project_repositories: true)).to be_empty }
   end
 end


### PR DESCRIPTION
The backend is offering support for getting a list of available packages for a given set of repositories.
Now the package dialog in the kiwi editor will autocomplete the field for the name based on the backend information for the actual kiwi image.