### PR TITLE
[webui] Preserve form data for Kiwi Image

### DIFF
--- a/src/api/app/assets/javascripts/webui/application/kiwi_editor.js
+++ b/src/api/app/assets/javascripts/webui/application/kiwi_editor.js
@@ -259,7 +259,12 @@ $(document).ready(function(){
 
   // Revert image
   $('#kiwi-image-update-form-revert').click(function(){
-    location.reload();
+    if ($(this).hasClass('enabled')) {
+      if (confirm('Attention! All unsaved data will be lost! Continue?')) {
+        window.location = window.location.href;
+        return false;
+      }
+    }
   });
 
   // Enable save button

--- a/src/api/app/controllers/webui/kiwi/images_controller.rb
+++ b/src/api/app/controllers/webui/kiwi/images_controller.rb
@@ -45,8 +45,8 @@ module Webui
         end
         redirect_to action: :show
       rescue ActiveRecord::RecordInvalid, Timeout::Error => e
-        flash[:error] = "Cannot update kiwi image: #{@image.errors.full_messages.to_sentence} #{e.message}"
-        redirect_back(fallback_location: root_path)
+        flash.now[:error] = "Cannot update kiwi image: #{@image.errors.full_messages.to_sentence} #{e.message}"
+        render action: :show
       end
 
       private

--- a/src/api/app/views/webui/kiwi/images/show.html.haml
+++ b/src/api/app/views/webui/kiwi/images/show.html.haml
@@ -29,15 +29,16 @@
     #kiwi-packages-list
       %p#no-packages{ class: "#{'hidden' if @image.kiwi_packages.present?}" }= 'There are no packages.'
 
-      = f.fields_for :package_groups, @image.default_package_group do |package_group_fields|
-        = package_group_fields.fields_for :packages do |kiwi_package_fields|
-          = render 'package_fields', f: kiwi_package_fields
-        %p
-          = link_to_add_association(sprite_tag("package_add", title: 'Add package') + ' Add package', package_group_fields, :packages)
+      = f.fields_for :package_groups do |package_group_fields|
+        - if package_group_fields.object.kiwi_type == 'image'
+          = package_group_fields.fields_for :packages do |kiwi_package_fields|
+            = render 'package_fields', f: kiwi_package_fields
+          %p
+            = link_to_add_association(sprite_tag("package_add", title: 'Add package') + ' Add package', package_group_fields, :packages)
 
   .grid_2.alpha.omega.box.box-shadow.kiwi-button
     %h3
       #kiwi-image-update-form-save= sprite_tag("page_save", title: 'Save') + ' Save'
   .grid_2.alpha.omega.box.box-shadow.kiwi-button
     %h3
-      #kiwi-image-update-form-revert= sprite_tag("page_refresh", title: 'Revert') + ' Revert'
+      #kiwi-image-update-form-revert{ class: "#{'enabled' if flash[:error]}" }= sprite_tag("page_save", title: 'Revert') + ' Revert'

--- a/src/api/app/views/webui/patchinfo/_form.html.haml
+++ b/src/api/app/views/webui/patchinfo/_form.html.haml
@@ -68,7 +68,7 @@
               = link_to image_tag('bug_add.png', alt: 'Add Bug', title: "Add additional issues e.g.: \"bnc#123456, bgo#654321\""), '#', onclick: 'append_bug($("#issue").val()); return false;', id: 'add_bug'
               = image_tag('ajax-loader.gif', id: 'issue_spinner', class: 'hidden')
           .box.show_left.show_right
-            = link_to 'Update issues from sources', { action: 'updatepatchinfo', project: @project, package: @package }, { data: { confirm: 'Attention! All unsaved data getting lost! Continue?' }, method: :post }
+            = link_to 'Update issues from sources', { action: 'updatepatchinfo', project: @project, package: @package }, { data: { confirm: 'Attention! All unsaved data will be lost! Continue?' }, method: :post }
         .box.show_left.show_right
           %p
             %strong

--- a/src/api/spec/cassettes/Webui_Kiwi_ImagesController/POST_update/with_invalid_package_empty_name/1_3_3_3.yml
+++ b/src/api/spec/cassettes/Webui_Kiwi_ImagesController/POST_update/with_invalid_package_empty_name/1_3_3_3.yml
@@ -1,0 +1,242 @@
+---
+http_interactions:
+- request:
+    method: put
+    uri: http://localhost:3200/source/home:tom/_meta?user=tom
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:tom">
+          <title/>
+          <description/>
+          <person userid="tom" role="maintainer"/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '129'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:tom">
+          <title></title>
+          <description></description>
+          <person userid="tom" role="maintainer" />
+        </project>
+    http_version: 
+  recorded_at: Fri, 22 Sep 2017 07:37:30 GMT
+- request:
+    method: put
+    uri: http://localhost:3200/source/home:tom/package_with_kiwi_image/_meta?user=tom
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="package_with_kiwi_image" project="home:tom">
+          <title>In Death Ground</title>
+          <description>Illo odit ea dignissimos aut aperiam consequatur voluptatem.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '194'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="package_with_kiwi_image" project="home:tom">
+          <title>In Death Ground</title>
+          <description>Illo odit ea dignissimos aut aperiam consequatur voluptatem.</description>
+        </package>
+    http_version: 
+  recorded_at: Fri, 22 Sep 2017 07:37:30 GMT
+- request:
+    method: put
+    uri: http://localhost:3200/source/home:tom/package_with_kiwi_image/_meta
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="package_with_kiwi_image" project="home:tom">
+          <title>In Death Ground</title>
+          <description>Illo odit ea dignissimos aut aperiam consequatur voluptatem.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '194'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="package_with_kiwi_image" project="home:tom">
+          <title>In Death Ground</title>
+          <description>Illo odit ea dignissimos aut aperiam consequatur voluptatem.</description>
+        </package>
+    http_version: 
+  recorded_at: Fri, 22 Sep 2017 07:37:30 GMT
+- request:
+    method: put
+    uri: http://localhost:3200/source/home:tom/package_with_kiwi_image/package_with_kiwi_image.kiwi
+    body:
+      encoding: UTF-8
+      string: |
+        <?xml version="1.0" encoding="utf-8"?>
+        <image schemaversion="6.2" name="suse-13.2-live">
+          <description type="system">
+          </description>
+          <preferences>
+            <type image="oem" primary="true" boot="oemboot/suse-13.2"/>
+          </preferences>
+        </image>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '209'
+    body:
+      encoding: UTF-8
+      string: |
+        <revision rev="28" vrev="28">
+          <srcmd5>82f39606fd3c729f7f16de7d227e6dae</srcmd5>
+          <version>unknown</version>
+          <time>1506065850</time>
+          <user>unknown</user>
+          <comment></comment>
+          <requestid/>
+        </revision>
+    http_version: 
+  recorded_at: Fri, 22 Sep 2017 07:37:30 GMT
+- request:
+    method: put
+    uri: http://localhost:3200/source/home:tom/package_with_kiwi_image/_meta?user=tom
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="package_with_kiwi_image" project="home:tom">
+          <title>In Death Ground</title>
+          <description>Illo odit ea dignissimos aut aperiam consequatur voluptatem.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '194'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="package_with_kiwi_image" project="home:tom">
+          <title>In Death Ground</title>
+          <description>Illo odit ea dignissimos aut aperiam consequatur voluptatem.</description>
+        </package>
+    http_version: 
+  recorded_at: Fri, 22 Sep 2017 07:37:30 GMT
+- request:
+    method: get
+    uri: http://localhost:3200/source/home:tom/package_with_kiwi_image
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '234'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="package_with_kiwi_image" rev="28" vrev="28" srcmd5="82f39606fd3c729f7f16de7d227e6dae">
+          <entry name="package_with_kiwi_image.kiwi" md5="dda935f455dcd6607d83705328bee9df" size="242" mtime="1506065625" />
+        </directory>
+    http_version: 
+  recorded_at: Fri, 22 Sep 2017 07:37:30 GMT
+recorded_with: VCR 3.0.3

--- a/src/api/spec/cassettes/Webui_Kiwi_ImagesController/POST_update/with_invalid_repositories_data/1_3_1_3.yml
+++ b/src/api/spec/cassettes/Webui_Kiwi_ImagesController/POST_update/with_invalid_repositories_data/1_3_1_3.yml
@@ -1,0 +1,242 @@
+---
+http_interactions:
+- request:
+    method: put
+    uri: http://localhost:3200/source/home:tom/_meta?user=tom
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:tom">
+          <title/>
+          <description/>
+          <person userid="tom" role="maintainer"/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '129'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:tom">
+          <title></title>
+          <description></description>
+          <person userid="tom" role="maintainer" />
+        </project>
+    http_version: 
+  recorded_at: Fri, 22 Sep 2017 07:37:27 GMT
+- request:
+    method: put
+    uri: http://localhost:3200/source/home:tom/package_with_kiwi_image/_meta?user=tom
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="package_with_kiwi_image" project="home:tom">
+          <title>Of Human Bondage</title>
+          <description>Corporis tempore est sed et sit rerum nihil.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '179'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="package_with_kiwi_image" project="home:tom">
+          <title>Of Human Bondage</title>
+          <description>Corporis tempore est sed et sit rerum nihil.</description>
+        </package>
+    http_version: 
+  recorded_at: Fri, 22 Sep 2017 07:37:27 GMT
+- request:
+    method: put
+    uri: http://localhost:3200/source/home:tom/package_with_kiwi_image/_meta
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="package_with_kiwi_image" project="home:tom">
+          <title>Of Human Bondage</title>
+          <description>Corporis tempore est sed et sit rerum nihil.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '179'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="package_with_kiwi_image" project="home:tom">
+          <title>Of Human Bondage</title>
+          <description>Corporis tempore est sed et sit rerum nihil.</description>
+        </package>
+    http_version: 
+  recorded_at: Fri, 22 Sep 2017 07:37:27 GMT
+- request:
+    method: put
+    uri: http://localhost:3200/source/home:tom/package_with_kiwi_image/package_with_kiwi_image.kiwi
+    body:
+      encoding: UTF-8
+      string: |
+        <?xml version="1.0" encoding="utf-8"?>
+        <image schemaversion="6.2" name="suse-13.2-live">
+          <description type="system">
+          </description>
+          <preferences>
+            <type image="oem" primary="true" boot="oemboot/suse-13.2"/>
+          </preferences>
+        </image>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '209'
+    body:
+      encoding: UTF-8
+      string: |
+        <revision rev="27" vrev="27">
+          <srcmd5>82f39606fd3c729f7f16de7d227e6dae</srcmd5>
+          <version>unknown</version>
+          <time>1506065847</time>
+          <user>unknown</user>
+          <comment></comment>
+          <requestid/>
+        </revision>
+    http_version: 
+  recorded_at: Fri, 22 Sep 2017 07:37:27 GMT
+- request:
+    method: put
+    uri: http://localhost:3200/source/home:tom/package_with_kiwi_image/_meta?user=tom
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="package_with_kiwi_image" project="home:tom">
+          <title>Of Human Bondage</title>
+          <description>Corporis tempore est sed et sit rerum nihil.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '179'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="package_with_kiwi_image" project="home:tom">
+          <title>Of Human Bondage</title>
+          <description>Corporis tempore est sed et sit rerum nihil.</description>
+        </package>
+    http_version: 
+  recorded_at: Fri, 22 Sep 2017 07:37:27 GMT
+- request:
+    method: get
+    uri: http://localhost:3200/source/home:tom/package_with_kiwi_image
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '234'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="package_with_kiwi_image" rev="27" vrev="27" srcmd5="82f39606fd3c729f7f16de7d227e6dae">
+          <entry name="package_with_kiwi_image.kiwi" md5="dda935f455dcd6607d83705328bee9df" size="242" mtime="1506065625" />
+        </directory>
+    http_version: 
+  recorded_at: Fri, 22 Sep 2017 07:37:27 GMT
+recorded_with: VCR 3.0.3

--- a/src/api/spec/controllers/webui/kiwi/images_controller_spec.rb
+++ b/src/api/spec/controllers/webui/kiwi/images_controller_spec.rb
@@ -145,7 +145,8 @@ RSpec.describe Webui::Kiwi::ImagesController, type: :controller, vcr: true do
           start_with('Cannot update kiwi image: Repositories[0] repo type is not included in the list')
         )
       end
-      it { expect(subject).to redirect_to(root_path) }
+      it { expect(subject).to have_http_status(:success) }
+      it { expect(subject).to render_template(:show) }
     end
 
     context 'with valid repositories data' do
@@ -234,8 +235,8 @@ RSpec.describe Webui::Kiwi::ImagesController, type: :controller, vcr: true do
           start_with("Cannot update kiwi image: Package groups[0] packages name can't be blank")
         )
       end
-
-      it { expect(subject).to redirect_to(root_path) }
+      it { expect(subject).to have_http_status(:success) }
+      it { expect(subject).to render_template(:show) }
     end
 
     context 'with valid packages data' do


### PR DESCRIPTION
- Preserve data in Kiwi Image edit form.
- Enable revert button in case there is an error after saving.
- Add a confirm dialog before reverting changes.
- Update the tests and cassettes accordingly.

Pair-programmed by @DavidKang and @eduardoj.