### PR TITLE
[api] Fix deletion of groups with users

### DIFF
--- a/ReleaseNotes-2.9
+++ b/ReleaseNotes-2.9
@@ -51,6 +51,9 @@ Backend:
 Shipment:
  *
 
+Bugfixes:
+ * Deletion of groups with users was not working
+
 Wanted changes:
 ===============
 

--- a/src/api/db/migrate/20170925060940_allow_null_for_group_id_in_groups_users.rb
+++ b/src/api/db/migrate/20170925060940_allow_null_for_group_id_in_groups_users.rb
@@ -1,0 +1,9 @@
+class AllowNullForGroupIdInGroupsUsers < ActiveRecord::Migration[5.1]
+  def up
+    change_column :groups_users, :group_id, :integer, null: true, default: 0, before: :user_id
+  end
+
+  def down
+    change_column :groups_users, :group_id, :integer, null: false, default: 0, before: :user_id
+  end
+end

--- a/src/api/db/structure.sql
+++ b/src/api/db/structure.sql
@@ -525,7 +525,7 @@ CREATE TABLE `groups_roles` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 CREATE TABLE `groups_users` (
-  `group_id` int(11) NOT NULL DEFAULT '0',
+  `group_id` int(11) DEFAULT '0',
   `user_id` int(11) NOT NULL DEFAULT '0',
   `created_at` datetime DEFAULT NULL,
   `email` tinyint(1) DEFAULT '1',
@@ -1251,6 +1251,7 @@ INSERT INTO `schema_migrations` (version) VALUES
 ('20170911142301'),
 ('20170912140257'),
 ('20170912140713'),
-('20170921100521');
+('20170921100521'),
+('20170925060940');
 
 

--- a/src/api/spec/controllers/group_controller_spec.rb
+++ b/src/api/spec/controllers/group_controller_spec.rb
@@ -1,0 +1,40 @@
+require 'rails_helper'
+# WARNING: If you change tests make sure you uncomment this line
+# and start a test backend. Some of the actions
+# require real backend answers for projects/packages.
+# CONFIG['global_write_through'] = true
+
+RSpec.describe GroupController, vcr: false do
+  let(:admin_user) { create(:admin_user) }
+  let(:group) { create(:group) }
+
+  before do
+    login admin_user
+  end
+
+  describe 'DELETE #delete' do
+    before do
+      delete :delete, params: { title: group.title, format: :xml }
+    end
+
+    shared_examples 'successful group deletion' do
+      it 'responds with 200 OK' do
+        expect(response.code).to eq("200")
+      end
+
+      it 'deletes the record' do
+        expect(Group.find_by(id: group.id)).to be_nil
+      end
+    end
+
+    context 'group without users' do
+      it_behaves_like 'successful group deletion'
+    end
+
+    context 'group with users' do
+      let(:group) { create(:group_with_user) }
+
+      it_behaves_like 'successful group deletion'
+    end
+  end
+end

--- a/src/api/spec/factories/groups.rb
+++ b/src/api/spec/factories/groups.rb
@@ -2,5 +2,11 @@ FactoryGirl.define do
   factory :group do
     sequence(:title){ |n| "group_#{n}" }
     email { Faker::Internet.email }
+
+    factory :group_with_user do
+      after(:create) do |group|
+        group.groups_users.create(user: create(:user))
+      end
+    end
   end
 end


### PR DESCRIPTION
When using `dependent: :destroy`, rails first sets all foreign keys to `NULL` and delete them afterwards. Since we prohibit `group_id` to be `NULL` in our database structure, it fails with an `Mysql2::Error`.

```
  SQL (0.7ms)  UPDATE `groups_users` SET `groups_users`.`group_id` =
  NULL WHERE `groups_users`.`group_id` = 1
     (0.3ms)  ROLLBACK
     ActiveRecord::NotNullViolation: Mysql2::Error: Column 'group_id'
     cannot be null: UPDATE `groups_users` SET `groups_users`.`group_id`
     = NULL WHERE `groups_users`.`group_id` = 1
        from (irb):3
```

Closes #3393 