### PR TITLE
[webui] Show superseded comments on request page

### DIFF
--- a/src/api/app/assets/javascripts/webui/application/comment.js
+++ b/src/api/app/assets/javascripts/webui/application/comment.js
@@ -10,19 +10,6 @@ function sz(t) {
     if (b > t.rows) t.rows = b;
 }
 
-function setup_comment_page() {
-    // setup toggle events
-    $('.togglable_comment').click(function () {
-        var toggleid = $(this).data("toggle");
-        $("#" + toggleid).toggle();
-    });
-
-    // prevent duplicate comment submissions
-    $('.comment_new').submit(function() {
-        $(this).find('input[type="submit"]').prop('disabled', true);
-    });
-}
-
 $(document).ready(function(){
     $('a.delete_link').on('ajax:success', function(event, data, status, xhr){
         $('#flash-messages').remove();
@@ -33,4 +20,18 @@ $(document).ready(function(){
         $('#flash-messages').remove();
         $(response.flash).filter('#flash-messages').insertAfter('#subheader').fadeIn('slow');
     });
+  $('a.supersed_comments_link').on('click', function(){
+    var link = $(this).text();
+    $(this).text(link == 'Show outdated comments' ? 'Hide outdated comments' : 'Show outdated comments');
+    $(this).parent().siblings('.superseded_comments').toggle();
+  });
+  $('.togglable_comment').click(function () {
+      var toggleid = $(this).data("toggle");
+      $("#" + toggleid).toggle();
+  });
+
+  // prevent duplicate comment submissions
+  $('.comment_new').submit(function() {
+      $(this).find('input[type="submit"]').prop('disabled', true);
+  });
 });

--- a/src/api/app/views/webui/comment/_show.html.haml
+++ b/src/api/app/views/webui/comment/_show.html.haml
@@ -1,5 +1,5 @@
 .comments
-  - @comments.walk_tree do |comment, level|
+  - commentable.comments.walk_tree do |comment, level|
     %div{class: "comment thread_level_#{level >= 4 ? 4 : level}"}
       = user_with_realname_and_icon(comment.user, no_icon: true, short: true)
       wrote
@@ -10,5 +10,3 @@
       = render partial: 'webui/comment/reply', locals: { comment: comment, level: 0, commentable: commentable }
   .comment_new.alpha.omega
     = render partial: 'webui/comment/new', locals: { commentable: commentable }
-- content_for :ready_function do
-  setup_comment_page();

--- a/src/api/app/views/webui/request/show.html.erb
+++ b/src/api/app/views/webui/request/show.html.erb
@@ -209,6 +209,16 @@
 
 <div class="grid_16 alpha omega">
   <div class="grid_10 alpha">
+    <% if @superseding %>
+      <% @superseding.each do |supersed| %>
+        <div class="grid_10 box box-shadow alpha omega">
+          <h2 class="box-header"><a class="supersed_comments_link">Show outdated comments</a>for superseded <%= link_to "request #{supersed.number}", number: supersed.number %></h2>
+          <div class="superseded_comments hidden">
+            <%= render :partial => 'webui/comment/show', locals: { commentable: supersed } %>
+          </div>
+        </div>
+      <% end %>
+    <% end %>
 
     <div class="grid_10 box box-shadow alpha omega">
       <h2 class="box-header">Comments for request <%= @number %> (<%= @comments.length %>)</h2>


### PR DESCRIPTION
to avoid opening the superseded requests in a separate tab.
Requested by openSUSE review team.
![screenshot from 2017-09-28 15-56-43](https://user-images.githubusercontent.com/3799140/30970524-ab3d7310-a465-11e7-9f5f-ee2fe35e63a1.png)

![screenshot from 2017-09-28 15-56-48](https://user-images.githubusercontent.com/3799140/30970526-aca2417c-a465-11e7-8fcf-ef6e2376ccb8.png)

@lnussel @ismail please have look!