### PR TITLE
[webui] Remove unused exception handling

### DIFF
--- a/src/api/app/controllers/webui/project_controller.rb
+++ b/src/api/app/controllers/webui/project_controller.rb
@@ -568,8 +568,6 @@ class Webui::ProjectController < Webui::WebuiController
 
     rescue Suse::ValidationError => exception
       errors << exception.message
-    rescue Project::UnknownObjectError => exception
-      errors << "Project with name '#{exception.message}' not found"
     end
 
     if errors.empty?

--- a/src/api/app/models/project/update_from_xml_command.rb
+++ b/src/api/app/models/project/update_from_xml_command.rb
@@ -96,7 +96,11 @@ class Project
       if devel
         prj_name = devel['project']
         if prj_name
-          develprj = Project.get_by_name(prj_name)
+          begin
+            develprj = Project.get_by_name(prj_name)
+          rescue UnknownObjectError => e
+            raise UnknownObjectError, "Project with name '#{e.message}' not found"
+          end
           unless develprj
             raise SaveError, "value of develproject has to be a existing project (project '#{prj_name}' does not exist)"
           end

--- a/src/api/spec/controllers/webui/project_controller_spec.rb
+++ b/src/api/spec/controllers/webui/project_controller_spec.rb
@@ -868,6 +868,16 @@ RSpec.describe Webui::ProjectController, vcr: true do
         it { expect(response).to have_http_status(400) }
       end
 
+      context 'with an invalid devel project' do
+        before do
+          post :save_meta, params: { project: user.home_project,
+                                     meta:    '<project name="home:tom"><title/><description/><devel project="non-existant"/></project>' }, xhr: true
+        end
+
+        it { expect(flash.now[:error]).to eq("Project with name 'non-existant' not found") }
+        it { expect(response).to have_http_status(400) }
+      end
+
       context 'with a valid meta' do
         before do
           post :save_meta, params: { project: user.home_project, meta: '<project name="home:tom"><title/><description/></project>' }, xhr: true


### PR DESCRIPTION
UnknownObjectError is not raised by any of the methods called in the
controller. This exception can occure only when calling update_from_xml.
But this method is wrapped within a transaction, which will catch the
exception.

This commit removes the unused rescue and adds a test for calling
save_meta with invalid devel projects.
We also update the xml parser code to throw a more explicit error
message.