### PR TITLE
Nodoc

### DIFF
--- a/src/api/lib/activexml/node.rb
+++ b/src/api/lib/activexml/node.rb
@@ -220,7 +220,7 @@ module ActiveXML
       _data.name = name
     end
 
-    def _data # nodoc
+    def _data
       if !@data && @raw_data
         parse(@raw_data)
         # save memory

--- a/src/api/lib/activexml/node.rb
+++ b/src/api/lib/activexml/node.rb
@@ -480,10 +480,10 @@ module ActiveXML
       return
     end
 
-    # stay away from this
-    def internal_data # nodoc
+    def internal_data
       _data
     end
+    protected :internal_data
 
     def marshal_dump
       raise "you don't want to put it in cache - never!"


### PR DESCRIPTION
I shouldn't have called [this](https://github.com/openSUSE/open-build-service/pull/2503) best comment ever, you can always find something "better".

- I make the method private instead of using the  _`stay away from this`_ scaring message.
- Do not use :nodoc: for private methods as it shouldn't have any impact.