### PR TITLE
Revert "Update capybara to version 2.15.4"

### DIFF
--- a/src/api/Gemfile.lock
+++ b/src/api/Gemfile.lock
@@ -66,7 +66,7 @@ GEM
       uniform_notifier (~> 1.10.0)
     bunny (2.7.1)
       amq-protocol (>= 2.2.0)
-    capybara (2.15.4)
+    capybara (2.15.3)
       addressable
       mini_mime (>= 0.1.3)
       nokogiri (>= 1.3.3)


### PR DESCRIPTION
This reverts commit 0fd0afff56395554a2702e31685d6225017ac2c0.

This reason being is that this merge decreased the coverage down to 61%.
It needs to be investigated first.

It was merged by accident.