### PR TITLE
Revert "[webui] get a defined order of templates"

### DIFF
--- a/src/api/app/views/webui/image_templates/index.html.haml
+++ b/src/api/app/views/webui/image_templates/index.html.haml
@@ -8,7 +8,7 @@
       %dl.templateslist
         %dt
           = link_to(title_or_name(project), project_show_path(project))
-        - project.packages.order_by_name.each do |template|
+        - project.packages.each do |template|
           %label
             %input{ name: 'image', type: 'radio', class: 'hidden image_template', checked: check_first(first_template), data: { project: project, package: template } }
             - first_template ||= template


### PR DESCRIPTION
This reverts commit 44fa6c153295bc0f14e42bea3d1bfae2fb3536ed.

Because it doesn't work for remote projects as they don't
exists in the database.
The order_by_name scope however performs a database query
which results in an empty collection.