### PR TITLE
[ci] Solve duplicated shared exampls warning

### DIFF
--- a/src/api/spec/models/bs_request_spec.rb
+++ b/src/api/spec/models/bs_request_spec.rb
@@ -116,7 +116,7 @@ RSpec.describe BsRequest do
   end
 
   describe '#update_cache' do
-    RSpec.shared_examples "the subject's cache is reset" do
+    RSpec.shared_examples "the subject's cache is reset when it's request changes" do
       before do
         Timecop.travel(1.minute)
         @cache_key = user.cache_key
@@ -132,7 +132,7 @@ RSpec.describe BsRequest do
       let!(:request) { create(:bs_request, creator: user.login) }
       let(:user) { create(:admin_user) }
 
-      it_should_behave_like "the subject's cache is reset"
+      it_should_behave_like "the subject's cache is reset when it's request changes"
     end
 
     context 'direct maintainer of a target_project' do
@@ -150,7 +150,7 @@ RSpec.describe BsRequest do
       let!(:relationship_project_user) { create(:relationship_project_user, project: target_project) }
       let(:user) { relationship_project_user.user }
 
-      it_should_behave_like "the subject's cache is reset"
+      it_should_behave_like "the subject's cache is reset when it's request changes"
     end
 
     context 'group maintainer of a target_project' do
@@ -170,10 +170,10 @@ RSpec.describe BsRequest do
       let!(:groups_user) { create(:groups_user, group: group) }
       let(:user) { groups_user.user }
 
-      it_should_behave_like "the subject's cache is reset" do
+      it_should_behave_like "the subject's cache is reset when it's request changes" do
         subject { user }
       end
-      it_should_behave_like "the subject's cache is reset" do
+      it_should_behave_like "the subject's cache is reset when it's request changes" do
         subject { group }
       end
     end
@@ -195,7 +195,7 @@ RSpec.describe BsRequest do
       let!(:relationship_package_user) { create(:relationship_package_user, package: target_package) }
       let(:user) { relationship_package_user.user }
 
-      it_should_behave_like "the subject's cache is reset"
+      it_should_behave_like "the subject's cache is reset when it's request changes"
     end
 
     context 'group maintainer of a target_package' do
@@ -217,10 +217,10 @@ RSpec.describe BsRequest do
       let!(:groups_user) { create(:groups_user, group: group) }
       let(:user) { groups_user.user }
 
-      it_should_behave_like "the subject's cache is reset" do
+      it_should_behave_like "the subject's cache is reset when it's request changes" do
         subject { user }
       end
-      it_should_behave_like "the subject's cache is reset" do
+      it_should_behave_like "the subject's cache is reset when it's request changes" do
         subject { group }
       end
     end

--- a/src/api/spec/models/review_spec.rb
+++ b/src/api/spec/models/review_spec.rb
@@ -318,7 +318,7 @@ RSpec.describe Review do
   end
 
   describe '#update_caches' do
-    RSpec.shared_examples "the subject's cache is reset" do
+    RSpec.shared_examples "the subject's cache is reset when it's review changes" do
       before do
         Timecop.travel(1.minute)
         @cache_key = subject.cache_key
@@ -334,7 +334,7 @@ RSpec.describe Review do
       let!(:review) { create(:user_review) }
       subject { review.user }
 
-      it_should_behave_like "the subject's cache is reset"
+      it_should_behave_like "the subject's cache is reset when it's review changes"
     end
 
     context 'by_group' do
@@ -343,10 +343,10 @@ RSpec.describe Review do
       let(:user) { groups_user.user }
       let!(:review) { create(:review, by_group: group) }
 
-      it_should_behave_like "the subject's cache is reset" do
+      it_should_behave_like "the subject's cache is reset when it's review changes" do
         subject { user }
       end
-      it_should_behave_like "the subject's cache is reset" do
+      it_should_behave_like "the subject's cache is reset when it's review changes" do
         subject { group }
       end
     end
@@ -357,7 +357,7 @@ RSpec.describe Review do
       let!(:review) { create(:review, by_package: package, by_project: package.project) }
       subject { relationship_package_user.user }
 
-      it_should_behave_like "the subject's cache is reset"
+      it_should_behave_like "the subject's cache is reset when it's review changes"
     end
 
     context 'by_package with a group relationship' do
@@ -368,10 +368,10 @@ RSpec.describe Review do
       let!(:user) { groups_user.user }
       let!(:review) { create(:review, by_package: package, by_project: package.project) }
 
-      it_should_behave_like "the subject's cache is reset" do
+      it_should_behave_like "the subject's cache is reset when it's review changes" do
         subject { user }
       end
-      it_should_behave_like "the subject's cache is reset" do
+      it_should_behave_like "the subject's cache is reset when it's review changes" do
         subject { group }
       end
     end
@@ -382,7 +382,7 @@ RSpec.describe Review do
       let!(:review) { create(:review, by_project: project) }
       subject { relationship_project_user.user }
 
-      it_should_behave_like "the subject's cache is reset"
+      it_should_behave_like "the subject's cache is reset when it's review changes"
     end
 
     context 'by_project with a group relationship' do
@@ -393,10 +393,10 @@ RSpec.describe Review do
       let!(:user) { groups_user.user }
       let!(:review) { create(:review, by_project: project) }
 
-      it_should_behave_like "the subject's cache is reset" do
+      it_should_behave_like "the subject's cache is reset when it's review changes" do
         subject { user }
       end
-      it_should_behave_like "the subject's cache is reset" do
+      it_should_behave_like "the subject's cache is reset when it's review changes" do
         subject { group }
       end
     end


### PR DESCRIPTION
It would also be an option to merge both examples. But that would mean
we have to deal with 2 variables that can change (subject and review /
request). This would increase the complexity of the example a lot.
For that reason it's better to just fix the name collision.

====

WARNING: Shared example group 'the subject's cache is reset' has been previously defined at:
  /obs/src/api/spec/models/bs_request_spec.rb:119
...and you are now defining it at:
  /obs/src/api/spec/models/review_spec.rb:321
The new definition will overwrite the original one.