### PR TITLE
[frontend] Fix sorting of image templates

### DIFF
--- a/src/api/app/models/project.rb
+++ b/src/api/app/models/project.rb
@@ -109,7 +109,8 @@ class Project < ApplicationRecord
   # will return all projects with attribute 'OBS:ImageTemplates'
   scope :local_image_templates, lambda {
     includes(:packages).joins(attribs: { attrib_type: :attrib_namespace }).
-      where(attrib_types: { name: 'ImageTemplates' }, attrib_namespaces: { name: 'OBS' })
+      where(attrib_types: { name: 'ImageTemplates' }, attrib_namespaces: { name: 'OBS' }).
+      order(:title)
   }
 
   scope :for_user, ->(user_id) { joins(:relationships).where(relationships: { user_id: user_id, role_id: Role.hashed['maintainer'] }) }
@@ -159,7 +160,7 @@ class Project < ApplicationRecord
   end
 
   def self.image_templates
-    (local_image_templates + remote_image_templates).sort_by(&:name)
+    local_image_templates + remote_image_templates
   end
 
   def self.remote_image_templates

--- a/src/api/spec/cassettes/ImageTemplates/branching/branch_image_template.yml
+++ b/src/api/spec/cassettes/ImageTemplates/branching/branch_image_template.yml
@@ -1800,4 +1800,74 @@ http_interactions:
         </workerstatus>
     http_version: 
   recorded_at: Thu, 10 Aug 2017 05:56:27 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/my_project/third_package
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 404
+      message: project 'my_project' does not exist
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '148'
+    body:
+      encoding: UTF-8
+      string: |
+        <status code="404">
+          <summary>project 'my_project' does not exist</summary>
+          <details>404 project 'my_project' does not exist</details>
+        </status>
+    http_version: 
+  recorded_at: Tue, 10 Oct 2017 12:36:05 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/my_project/third_package
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 404
+      message: project 'my_project' does not exist
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '148'
+    body:
+      encoding: UTF-8
+      string: |
+        <status code="404">
+          <summary>project 'my_project' does not exist</summary>
+          <details>404 project 'my_project' does not exist</details>
+        </status>
+    http_version: 
+  recorded_at: Tue, 10 Oct 2017 12:36:11 GMT
 recorded_with: VCR 3.0.3

--- a/src/api/spec/features/webui/image_templates_spec.rb
+++ b/src/api/spec/features/webui/image_templates_spec.rb
@@ -8,8 +8,9 @@ RSpec.feature "ImageTemplates", type: :feature, js: true do
 
   context "branching" do
     let!(:project) { create(:project, name: "my_project") }
-    let!(:package1) { create(:package_with_file, project: project, name: "first_package") }
-    let!(:package2) { create(:package_with_file, project: project, name: "second_package") }
+    let!(:package1) { create(:package_with_file, project: project, name: "first_package",  title: "a") }
+    let!(:package2) { create(:package_with_file, project: project, name: "second_package", title: "c") }
+    let!(:package3) { create(:package_with_file, project: project, name: "third_package",  title: "b") }
     let!(:attrib) { create(:template_attrib, project: project) }
 
     scenario "branch image template" do
@@ -22,6 +23,7 @@ RSpec.feature "ImageTemplates", type: :feature, js: true do
 
       expect(page).to have_text(package1.title)
       expect(find("input[data-package='#{package1}']", visible: false)['checked']).to be true
+      expect(find("input[data-package='#{package3}']", visible: false)['checked']).to be false
       expect(find("input[data-package='#{package2}']", visible: false)['checked']).to be false
 
       expect(page).to have_field('target_package', with: package1)


### PR DESCRIPTION
* Shows templates from local projects first, and remotes afterwards.
  This broke with 89d7fc5.
* Sorts each template within a project by it's title. The title is what
  is visible by the user.