### PR TITLE
[webui] Disable links for remote image templates

### DIFF
--- a/src/api/app/views/webui/image_templates/index.html.haml
+++ b/src/api/app/views/webui/image_templates/index.html.haml
@@ -5,9 +5,10 @@
   %fieldset.templateslist
     - first_template = nil
     - @projects.each do |project|
+      - remote = Project.is_remote_project?(project.name)
       %dl.templateslist
         %dt
-          = link_to(title_or_name(project), project_show_path(project))
+          = link_to_if(!remote, title_or_name(project), project_show_path(project))
         - project.packages.each do |template|
           %label
             %input{ name: 'image', type: 'radio', class: 'hidden image_template', checked: check_first(first_template), data: { project: project, package: template } }
@@ -20,7 +21,7 @@
                 = sprite_tag('drive-optical-48')
               %span.group
                 %span.name.break-words
-                  = link_to(title_or_name(template), package_show_path(project: project, package: template))
+                  = link_to_if(!remote, title_or_name(template), package_show_path(project: project, package: template))
                 %span.description.grey.break-words
                   = template.description
         - if project.packages.empty?


### PR DESCRIPTION
We were linking to projects and packages of remote instances. In such a
case we don't have a valid url to point at. So users would end up with
an error when clicking this link.

To fix that we only show a link for local projects and packages on the
image template page.

This is how it looks like now:
![screenshot from 2017-10-10 14-21-27](https://user-images.githubusercontent.com/968949/31386422-101a4d84-adc7-11e7-9f36-fc2a7013b985.png)
