### PR TITLE
bs_worker : support .tar.gz and .squashfs as build-product patterns

### DIFF
--- a/src/backend/bs_worker
+++ b/src/backend/bs_worker
@@ -51,7 +51,7 @@ use BSCando;
 
 use strict;
 
-my @binsufs = qw{rpm deb pkg.tar.gz pkg.tar.xz};
+my @binsufs = qw{rpm deb pkg.tar.gz pkg.tar.xz .tar.gz .squashfs};
 my $binsufsre = join('|', map {"\Q$_\E"} @binsufs);
 
 my $buildroot;


### PR DESCRIPTION
Apparently (from notes), this small patch allowed our workers to better support simpleimage and preinstallimage processing. Don't ask *me* how, though ;) //Jim

Original application (to branch we used) at https://github.com/openSUSE/open-build-service/pull/3977