### PR TITLE
[frontend] Move adding maintainer to model

### DIFF
--- a/src/api/app/controllers/webui/request_controller.rb
+++ b/src/api/app/controllers/webui/request_controller.rb
@@ -154,9 +154,7 @@ class Webui::RequestController < Webui::WebuiController
           if target.can_be_modified_by?(User.current)
             # the request action type might be permitted in future, but that doesn't mean we
             # are allowed to modify the object
-            target.add_user(@bs_request.creator, 'maintainer')
-            target.save
-            target.store if target.kind_of? Project
+            target.add_maintainer(@bs_request.creator)
           end
         end
       end

--- a/src/api/app/models/package.rb
+++ b/src/api/app/models/package.rb
@@ -305,6 +305,11 @@ class Package < ApplicationRecord
     PackageMetaFile.new(project_name: project.name, package_name: name)
   end
 
+  def add_maintainer(user)
+    add_user(user, 'maintainer')
+    save
+  end
+
   def check_source_access?
     if disabled_for?('sourceaccess', nil, nil) || project.disabled_for?('sourceaccess', nil, nil)
       unless User.current && User.current.can_source_access?(self)

--- a/src/api/app/models/project.rb
+++ b/src/api/app/models/project.rb
@@ -273,6 +273,11 @@ class Project < ApplicationRecord
     maintained_projects.includes(:project).pluck("projects.name")
   end
 
+  def add_maintainer(user)
+    add_user(user, 'maintainer')
+    store
+  end
+
   # Check if the project has a path_element matching project and repository
   def has_distribution(project_name, repository)
     has_local_distribution(project_name, repository) || has_remote_distribution(project_name, repository)

--- a/src/api/spec/models/package_spec.rb
+++ b/src/api/spec/models/package_spec.rb
@@ -688,4 +688,10 @@ Wed Aug  2 14:59:15 UTC 2017 - iggy@opensuse.org
       it { expect(package.commit_message(nil, nil)).to include('Lorem ipsum dolorem') }
     end
   end
+
+  describe '#add_maintainer' do
+    subject { package }
+
+    it_behaves_like "makes a user a maintainer of the subject"
+  end
 end

--- a/src/api/spec/models/project_spec.rb
+++ b/src/api/spec/models/project_spec.rb
@@ -530,4 +530,10 @@ RSpec.describe Project, vcr: true do
       expect(Relationship.exists?(relationship.id)).to be_falsey
     end
   end
+
+  describe '#add_maintainer' do
+    subject { project }
+
+    it_behaves_like "makes a user a maintainer of the subject"
+  end
 end

--- a/src/api/spec/support/shared_examples/relationships.rb
+++ b/src/api/spec/support/shared_examples/relationships.rb
@@ -1,0 +1,14 @@
+RSpec.shared_examples 'makes a user a maintainer of the subject' do
+  let(:other_user) { create(:confirmed_user, login: 'bob') }
+  let(:maintainer_role) { Role.where(title: 'maintainer')}
+
+  before do
+    subject.add_maintainer(other_user)
+  end
+
+  it 'makes a user a maintainer of the package' do
+    expect(
+      subject.relationships.where(user: other_user, role: maintainer_role)
+    ).to exist
+  end
+end


### PR DESCRIPTION
This commit implements add_maintainer methods for the package and
project model and moves the code from the controller to the model.