### PR TITLE
[frontend] Freeze mutable constants

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -834,11 +834,6 @@ Style/MultipleComparison:
     - 'src/api/lib/tasks/extract.rake'
     - 'src/api/script/reformat_memprof'
 
-# Offense count: 46
-# Cop supports --auto-correct.
-Style/MutableConstant:
-  Enabled: false
-
 # Offense count: 7
 # Cop supports --auto-correct.
 Style/NegatedWhile:

--- a/Rakefile
+++ b/Rakefile
@@ -1,4 +1,4 @@
-CONTAINER_USERID = %x(id -u)
+CONTAINER_USERID = %x(id -u).freeze
 
 namespace :docker do
   desc 'Build our development environment'

--- a/docs/dev/controller_template_example.rb
+++ b/docs/dev/controller_template_example.rb
@@ -4,7 +4,7 @@ class Webui::DogsController < ApplicationController
   include AnimalControl
 
   #### Constants
-  BASIC_DOG_NAMES = %w(Tobby Thor Rambo Dog Blacky)
+  BASIC_DOG_NAMES = %w(Tobby Thor Rambo Dog Blacky).freeze
 
   #### Self config
 

--- a/docs/dev/model_template_example.rb
+++ b/docs/dev/model_template_example.rb
@@ -9,7 +9,7 @@ class Dog < ActiveRecord::Base
   NUMBER_OF_LEGS = 4
   NUMBER_OF_QUEUES = 1
   NUMBER_OF_EYES = 2
-  POSSIBLE_COLORS = %w(white black brown vanilla chocolate dotted)
+  POSSIBLE_COLORS = %w(white black brown vanilla chocolate dotted).freeze
 
   #### Self config
   self.table_name = "OBS_dogs"

--- a/src/api/app/controllers/source_controller.rb
+++ b/src/api/app/controllers/source_controller.rb
@@ -352,15 +352,15 @@ class SourceController < ApplicationController
     if origin_package_name && !origin_package_name.in?(["_project", "_pattern"]) && !(params[:missingok] && @command.in?(['branch', 'release']))
       @spkg = Package.get_by_project_and_name(origin_project_name, origin_package_name)
     end
-    unless Package_creating_commands.include?(@command) && !Project.exists_by_name(@target_project_name)
+    unless PACKAGE_CREATING_COMMANDS.include?(@command) && !Project.exists_by_name(@target_project_name)
       valid_project_name! params[:project]
       valid_package_name! params[:package]
       # even when we can create the package, an existing instance must be checked if permissions are right
       @project = Project.get_by_name @target_project_name
       # rubocop:disable Metrics/LineLength
-      if !Package_creating_commands.include?(@command) || Package.exists_by_project_and_name( @target_project_name,
+      if !PACKAGE_CREATING_COMMANDS.include?(@command) || Package.exists_by_project_and_name( @target_project_name,
                                                                                               @target_package_name,
-                                                                                              follow_project_links: Source_untouched_commands.include?(@command) )
+                                                                                              follow_project_links: SOURCE_UNTOUCHED_COMMANDS.include?(@command) )
         validate_target_for_package_command_exists!
       end
       # rubocop:enable Metrics/LineLength
@@ -369,18 +369,18 @@ class SourceController < ApplicationController
     dispatch_command(:package_command, @command)
   end
 
-  Source_untouched_commands = %w(branch diff linkdiff servicediff showlinked rebuild wipe
+  SOURCE_UNTOUCHED_COMMANDS = %w(branch diff linkdiff servicediff showlinked rebuild wipe
                                  waitservice remove_flag set_flag getprojectservices).freeze
   # list of cammands which create the target package
-  Package_creating_commands = %w(branch release copy undelete instantiate).freeze
+  PACKAGE_CREATING_COMMANDS = %w(branch release copy undelete instantiate).freeze
   # list of commands which are allowed even when the project has the package only via a project link
-  Read_commands = %w(branch diff linkdiff servicediff showlinked getprojectservices release).freeze
+  READ_COMMANDS = %w(branch diff linkdiff servicediff showlinked getprojectservices release).freeze
 
   def validate_target_for_package_command_exists!
     @project = nil
     @package = nil
 
-    follow_project_links = Source_untouched_commands.include?(@command)
+    follow_project_links = SOURCE_UNTOUCHED_COMMANDS.include?(@command)
 
     unless @target_package_name.in?(["_project", "_pattern"])
       use_source = true
@@ -390,7 +390,7 @@ class SourceController < ApplicationController
       if @package # for remote package case it's nil
         @project = @package.project
         ignore_lock = @command == 'unlock'
-        unless Read_commands.include?(@command) || User.current.can_modify_package?(@package, ignore_lock)
+        unless READ_COMMANDS.include?(@command) || User.current.can_modify_package?(@package, ignore_lock)
           raise CmdExecutionNoPermission, "no permission to modify package #{@package.name} in project #{@project.name}"
         end
       end

--- a/src/api/app/controllers/source_controller.rb
+++ b/src/api/app/controllers/source_controller.rb
@@ -370,11 +370,11 @@ class SourceController < ApplicationController
   end
 
   Source_untouched_commands = %w(branch diff linkdiff servicediff showlinked rebuild wipe
-                                 waitservice remove_flag set_flag getprojectservices)
+                                 waitservice remove_flag set_flag getprojectservices).freeze
   # list of cammands which create the target package
-  Package_creating_commands = %w(branch release copy undelete instantiate)
+  Package_creating_commands = %w(branch release copy undelete instantiate).freeze
   # list of commands which are allowed even when the project has the package only via a project link
-  Read_commands = %w(branch diff linkdiff servicediff showlinked getprojectservices release)
+  Read_commands = %w(branch diff linkdiff servicediff showlinked getprojectservices release).freeze
 
   def validate_target_for_package_command_exists!
     @project = nil

--- a/src/api/app/controllers/webui/groups/bs_requests_controller.rb
+++ b/src/api/app/controllers/webui/groups/bs_requests_controller.rb
@@ -8,7 +8,7 @@ module Webui
         'all_requests_table' => :requests,
         'requests_in_table'  => :incoming_requests,
         'reviews_in_table'   => :involved_reviews
-      }
+      }.freeze
 
       private
 

--- a/src/api/app/controllers/webui/users/bs_requests_controller.rb
+++ b/src/api/app/controllers/webui/users/bs_requests_controller.rb
@@ -11,7 +11,7 @@ module Webui
         'requests_declined_table' => :declined_requests,
         'requests_in_table'       => :incoming_requests,
         'reviews_in_table'        => :involved_reviews
-      }
+      }.freeze
 
       private
 

--- a/src/api/app/helpers/flag_helper.rb
+++ b/src/api/app/helpers/flag_helper.rb
@@ -12,7 +12,8 @@ module FlagHelper
     'binarydownload' => :enable,
     'sourceaccess'   => :enable,
     'access'         => :enable
-  }
+  }.freeze
+
   def self.default_for(flag_type)
     TYPES[flag_type.to_s].to_s
   end

--- a/src/api/app/helpers/webui/project_helper.rb
+++ b/src/api/app/helpers/webui/project_helper.rb
@@ -107,7 +107,7 @@ module Webui::ProjectHelper
       'new'      => 'flag_green',
       'review'   => 'flag_yellow',
       'declined' => 'flag_red'
-  }
+  }.freeze
 
   def map_request_state_to_flag(state)
     STATE_ICONS[state.to_s] || ''

--- a/src/api/app/helpers/webui/request_helper.rb
+++ b/src/api/app/helpers/webui/request_helper.rb
@@ -3,7 +3,7 @@ module Webui::RequestHelper
     'new'        => 'green',
     'declined'   => 'red',
     'superseded' => 'red'
-  }
+  }.freeze
 
   def request_state_color(state)
     STATE_COLORS[state.to_s] || ''

--- a/src/api/app/helpers/webui/webui_helper.rb
+++ b/src/api/app/helpers/webui/webui_helper.rb
@@ -87,7 +87,7 @@ module Webui::WebuiHelper
     'outdated_broken'      => 'exclamation',
     'scheduling'           => 'cog',
     'outdated_scheduling'  => 'cog_error'
-  }
+  }.freeze
 
   REPO_STATUS_DESCRIPTIONS = {
     'published'   => 'Repository has been published',
@@ -98,7 +98,7 @@ module Webui::WebuiHelper
     'blocked'     => 'No build possible atm, waiting for jobs in other repositories',
     'broken'      => 'The repository setup is broken, build or publish not possible',
     'scheduling'  => 'The repository state is being calculated right now'
-  }
+  }.freeze
 
   def check_first(first)
     first.nil? ? true : nil

--- a/src/api/app/jobs/project_create_auto_cleanup_requests.rb
+++ b/src/api/app/jobs/project_create_auto_cleanup_requests.rb
@@ -1,9 +1,9 @@
 class ProjectCreateAutoCleanupRequests < ApplicationJob
-  Description = "This is a humble request to remove this project.
+  DESCRIPTION = "This is a humble request to remove this project.
 Accepting this request will free resources on our always crowded server.
 Please decline this request if you want to keep this repository nevertheless. Otherwise this request
 will get accepted automatically in near future.
-Such requests get not created for projects with open requests or if you remove the OBS:AutoCleanup attribute."
+Such requests get not created for projects with open requests or if you remove the OBS:AutoCleanup attribute.".freeze
 
   def perform
     # disabled ?
@@ -52,7 +52,7 @@ Such requests get not created for projects with open requests or if you remove t
                                        <action type="delete">
                                           <target project="' + prj.name + '" />
                                        </action>
-                                       <description>' + Description + '</description>
+                                       <description>' + DESCRIPTION + '</description>
                                        <state />
                                        <accept_at>' + @cleanup_time.to_s + '</accept_at>
                                      </request>')

--- a/src/api/app/models/bs_request.rb
+++ b/src/api/app/models/bs_request.rb
@@ -28,9 +28,9 @@ class BsRequest < ApplicationRecord
     'bs_request_actions.source_project',
     'bs_request_actions.source_package',
     'bs_request_actions.type'
-  ]
+  ].freeze
 
-  FINAL_REQUEST_STATES = %w(accepted declined superseded revoked)
+  FINAL_REQUEST_STATES = %w(accepted declined superseded revoked).freeze
 
   VALID_REQUEST_STATES = [:new, :deleted, :declined, :accepted, :review, :revoked, :superseded].freeze
 

--- a/src/api/app/models/bs_request_action.rb
+++ b/src/api/app/models/bs_request_action.rb
@@ -5,7 +5,7 @@ class BsRequestAction < ApplicationRecord
   include ParsePackageDiff
 
   #### Constants
-  VALID_SOURCEUPDATE_OPTIONS = ['update', 'noupdate', 'cleanup']
+  VALID_SOURCEUPDATE_OPTIONS = ['update', 'noupdate', 'cleanup'].freeze
 
   #### Self config
   class DiffError < APIException; setup 404; end # a diff error can have many reasons, but most likely something within us

--- a/src/api/app/models/buildresult.rb
+++ b/src/api/app/models/buildresult.rb
@@ -15,7 +15,7 @@ class Buildresult < ActiveXML::Node
     locked:       12,
     deleting:     13,
     unknown:      14
-  }
+  }.freeze
 
   STATUS_DESCRIPTION = {
       succeeded:    "Package has built successfully and can be used to build further packages.",
@@ -37,7 +37,7 @@ class Buildresult < ActiveXML::Node
                     "does not provide a matching build description for the target.",
       locked:       "The package is frozen",
       unknown:      "The scheduler has not yet evaluated this package. Should be a short intermediate state for new packages."
-  }.with_indifferent_access
+  }.with_indifferent_access.freeze
 
   def self.status_description(status)
     STATUS_DESCRIPTION[status] || "status explanation not found"

--- a/src/api/app/models/configuration.rb
+++ b/src/api/app/models/configuration.rb
@@ -7,6 +7,7 @@ class Configuration < ApplicationRecord
   validates :name, :title, :description, presence: true
 
   # note: do not add defaults here. It must be either the options.yml content or nil
+  # rubocop:disable Style/MutableConstant
   OPTIONS_YML = {
     title:                                nil,
     description:                          nil,
@@ -36,11 +37,13 @@ class Configuration < ApplicationRecord
     unlisted_projects_filter:             nil,
     unlisted_projects_filter_description: nil
   }
+  # rubocop:enable Style/MutableConstant
+
   ON_OFF_OPTIONS = [:anonymous, :default_access_disabled,
                     :allow_user_to_create_home_project, :disallow_group_creation,
                     :change_password, :hide_private_options, :gravatar,
                     :download_on_demand, :enforce_project_keys,
-                    :cleanup_empty_projects, :disable_publish_for_branches]
+                    :cleanup_empty_projects, :disable_publish_for_branches].freeze
 
   class << self
     def map_value(key, value)

--- a/src/api/app/models/download_repository.rb
+++ b/src/api/app/models/download_repository.rb
@@ -1,5 +1,5 @@
 class DownloadRepository < ApplicationRecord
-  REPOTYPES = ["rpmmd", "susetags", "deb", "arch", "mdk"]
+  REPOTYPES = ["rpmmd", "susetags", "deb", "arch", "mdk"].freeze
 
   belongs_to :repository
 

--- a/src/api/app/models/issue_tracker.rb
+++ b/src/api/app/models/issue_tracker.rb
@@ -18,7 +18,7 @@ class IssueTracker < ApplicationRecord
   end
 
   # FIXME: issues_updated should not be hidden, but it should also not break our api
-  DEFAULT_RENDER_PARAMS = {except: [:id, :password, :user, :issues_updated], dasherize: true, skip_types: true, skip_instruct: true}
+  DEFAULT_RENDER_PARAMS = { except: [:id, :password, :user, :issues_updated], dasherize: true, skip_types: true, skip_instruct: true }.freeze
 
   def delayed_write_to_backend
     IssueTrackerWriteToBackendJob.perform_later

--- a/src/api/app/models/kiwi/image.rb
+++ b/src/api/app/models/kiwi/image.rb
@@ -11,7 +11,7 @@ class Kiwi::Image < ApplicationRecord
     <type image="oem" primary="true" boot="oemboot/suse-13.2"/>
   </preferences>
 </image>
-'
+'.freeze
 
   #### Self config
 

--- a/src/api/app/models/package.rb
+++ b/src/api/app/models/package.rb
@@ -42,10 +42,10 @@ class Package < ApplicationRecord
   class IllegalFileName < APIException; setup 'invalid_file_name_error'; end
   class PutFileNoPermission < APIException; setup 403; end
 
-  BINARY_EXTENSIONS ||= %w{.0 .bin .bin_mid .bz .bz2 .ccf .cert .chk .der .dll .exe .fw
-                           .gem .gif .gz .jar .jpeg .jpg .lzma .ogg .otf .oxt .pdf .pk3
-                           .png .ps .rpm .sig .svgz .tar .taz .tb2 .tbz .tbz2 .tgz .tlz
-                           .txz .ucode .xpm .xz .z .zip .ttf}
+  BINARY_EXTENSIONS = %w{.0 .bin .bin_mid .bz .bz2 .ccf .cert .chk .der .dll .exe .fw
+                         .gem .gif .gz .jar .jpeg .jpg .lzma .ogg .otf .oxt .pdf .pk3
+                         .png .ps .rpm .sig .svgz .tar .taz .tb2 .tbz .tbz2 .tgz .tlz
+                         .txz .ucode .xpm .xz .z .zip .ttf}.freeze
 
   belongs_to :project, inverse_of: :packages
   delegate :name, to: :project, prefix: true

--- a/src/api/app/models/patchinfo.rb
+++ b/src/api/app/models/patchinfo.rb
@@ -22,19 +22,19 @@ class Patchinfo < ActiveXML::Node
     'moderate'  => 'olive',
     'important' => 'red',
     'critical'  => 'maroon'
-  }
+  }.freeze
 
-  RATINGS = RATING_COLORS.keys
+  RATINGS = RATING_COLORS.keys.freeze
 
   CATEGORY_COLORS = {
     'recommended' => 'green',
     'security'    => 'maroon',
     'optional'    => 'olive',
     'feature'     => ''
-  }
+  }.freeze
 
   # '' is a valid category
-  CATEGORIES = CATEGORY_COLORS.keys << ""
+  CATEGORIES = (CATEGORY_COLORS.keys << "").freeze
 
   def self.make_stub( _opt )
     '<patchinfo/>'

--- a/src/api/app/models/project_log_entry.rb
+++ b/src/api/app/models/project_log_entry.rb
@@ -7,8 +7,8 @@ class ProjectLogEntry < ApplicationRecord
 
   validates :event_type, :datetime, :project_id, presence: true
 
-  USERNAME_KEYS = %w(sender user who author commenter)
-  EXCLUDED_KEYS = USERNAME_KEYS + %w(project package requestid)
+  USERNAME_KEYS = %w(sender user who author commenter).freeze
+  EXCLUDED_KEYS = (USERNAME_KEYS + %w(project package requestid)).freeze
 
   # Creates a new LogEntry record from the information contained in an Event
   def self.create_from(event)

--- a/src/api/lib/feature_switch/obs_repository.rb
+++ b/src/api/lib/feature_switch/obs_repository.rb
@@ -5,7 +5,7 @@ module Feature
     class ObsRepository < YamlRepository
       DEFAULTS = {
         image_templates: true
-      }
+      }.freeze
 
       # Returns list of active features
       #

--- a/src/api/lib/tasks/statistics/github/issues.rake
+++ b/src/api/lib/tasks/statistics/github/issues.rake
@@ -3,8 +3,8 @@ namespace :statistics do
     desc 'Export the number of issues merged per week to a file'
     task issues: :environment do
       # GITHUB login required in order to avoid rate limiting on http requests
-      GITHUB_USERNAME = ''
-      GITHUB_PASSWORD = ''
+      GITHUB_USERNAME = ''.freeze
+      GITHUB_PASSWORD = ''.freeze
 
       if GITHUB_USERNAME.empty? || GITHUB_PASSWORD.empty?
         raise StandardError, "Please set your github username/password in lines 8&9 of this file:\nlib/tasks/statistics/github/issues.rake"

--- a/src/api/lib/tasks/statistics/github/pull_requests.rake
+++ b/src/api/lib/tasks/statistics/github/pull_requests.rake
@@ -3,8 +3,8 @@ namespace :statistics do
     desc 'Export the number of pull requests merged per week to a file'
     task pull_requests: :environment do
       # GITHUB login required in order to avoid rate limiting on http requests
-      GITHUB_USERNAME = ''
-      GITHUB_PASSWORD = ''
+      GITHUB_USERNAME = ''.freeze
+      GITHUB_PASSWORD = ''.freeze
 
       if GITHUB_USERNAME.empty? || GITHUB_PASSWORD.empty?
         raise StandardError, "Please set your github username/password in lines 8&9 of this file:\nlib/tasks/statistics/github/pull_requests.rake"

--- a/src/api/script/import
+++ b/src/api/script/import
@@ -8,7 +8,7 @@ require File.dirname(__FILE__) + '/../config/boot'
 CREATE_MISSING_USERS = true
 
 # all users created in the above mentioned way will have those attributes
-DUMMY_USER_ATTR = { password: "asdfasdf", email: "noone@localhost" }
+DUMMY_USER_ATTR = { password: "asdfasdf", email: "noone@localhost" }.freeze
 
 require "activexml/activexml"
 

--- a/src/api/script/import_database.rb
+++ b/src/api/script/import_database.rb
@@ -9,7 +9,7 @@ require 'fileutils'
 require 'optparse'
 require 'pathname'
 
-TABLES_TO_REMOVE = ['cache_lines', 'project_log_entries']
+TABLES_TO_REMOVE = ['cache_lines', 'project_log_entries'].freeze
 @params = {}
 @params[:environment] = 'development'
 @options_path = ::File.expand_path('../../config/options.yml', __FILE__)

--- a/src/api/spec/support/database_cleaner.rb
+++ b/src/api/spec/support/database_cleaner.rb
@@ -4,7 +4,7 @@ RSpec.configure do |config|
   STATIC_TABLES = %w(roles roles_static_permissions
                      static_permissions configurations
                      architectures attrib_types
-                     attrib_namespaces issue_trackers)
+                     attrib_namespaces issue_trackers).freeze
 
   # We are using factory_girl to set up everything the test needs up front,
   # instead of loading a set of fixtures in the beginning of the suite

--- a/src/api/test/functional/webui/package_controller_test.rb
+++ b/src/api/test/functional/webui/package_controller_test.rb
@@ -5,22 +5,22 @@ class Webui::PackageControllerTest < Webui::IntegrationTest
   NEW_META_XML_FOR_TEST_PACK = '<package name="TestPack" project="home:Iggy">
   <title>My Test package Updated via Webui</title>
   <description/>
-</package>'
+</package>'.freeze
 
   INVALID_META_XML_BECAUSE_PACKAGE_NAME = '<package name="TestPackOOO" project="home:Iggy">
   <title>Invalid meta PACKAGE NAME</title>
   <description/>
-</package>'
+</package>'.freeze
 
   INVALID_META_XML_BECAUSE_PROJECT_NAME = '<package name="TestPack" project="home:IggyOOO">
   <title>Invalid meta PROJECT NAME</title>
   <description/>
-</package>'
+</package>'.freeze
 
   INVALID_META_XML_BECAUSE_XML = '<package name="TestPack" project="home:Iggy">
   <title>Invalid meta WRONG XML</title>
   <description/>
-</paaaaackage>'
+</paaaaackage>'.freeze
 
   def delete_and_recreate_kdelibs
     delete_package 'kde4', 'kdelibs'

--- a/src/api/test/unit/ichain_notifier_test.rb
+++ b/src/api/test/unit/ichain_notifier_test.rb
@@ -2,7 +2,7 @@ require File.expand_path(File.dirname(__FILE__) + "/..") + "/test_helper"
 require 'ichain_notifier'
 
 class IchainNotifierTest < ActiveSupport::TestCase
-  CHARSET = "utf-8"
+  CHARSET = "utf-8".freeze
 
   fixtures :users
 

--- a/src/api/test/unit/issue_test.rb
+++ b/src/api/test/unit/issue_test.rb
@@ -36,11 +36,11 @@ class IssueTest < ActiveSupport::TestCase
     issue.destroy
   end
 
-  BugSearch = "<?xml version=\"1.0\" ?><methodCall><methodName>Bug.search</methodName>
+  BUG_SEARCH = "<?xml version=\"1.0\" ?><methodCall><methodName>Bug.search</methodName>
                <params><param><value><struct><member><name>last_change_time</name><value>
                <dateTime.iso8601>20110729T14:00:21</dateTime.iso8601></value></member></struct>
                </value></param></params></methodCall>\n".freeze
-  BugGet = "<?xml version=\"1.0\" ?><methodCall><methodName>Bug.get</methodName><params><param>
+  BUG_GET = "<?xml version=\"1.0\" ?><methodCall><methodName>Bug.get</methodName><params><param>
             <value><struct><member><name>ids</name><value><array><data><value><i4>838932</i4></value>
             <value><i4>838933</i4></value><value><i4>838970</i4></value></data></array></value></member>
             <member><name>permissive</name><value><i4>1</i4></value></member>
@@ -48,13 +48,13 @@ class IssueTest < ActiveSupport::TestCase
 
   test "fetch issues" do
     stub_request(:post, "http://bugzilla.novell.com/xmlrpc.cgi").
-        with(body: BugSearch).
+        with(body: BUG_SEARCH).
         to_return(status: 200,
                   body: load_backend_file("bugzilla_response_search.xml"),
                   headers: {})
 
     stub_request(:post, "http://bugzilla.novell.com/xmlrpc.cgi").
-        with(body: BugGet).
+        with(body: BUG_GET).
         to_return(status: 200,
                   body: load_backend_file("bugzilla_get_response.xml"),
                   headers: {})

--- a/src/api/test/unit/issue_test.rb
+++ b/src/api/test/unit/issue_test.rb
@@ -4,7 +4,7 @@ class IssueTest < ActiveSupport::TestCase
   fixtures :all
 
   # rubocop:disable Metrics/LineLength
-  BugGet0815 = "<?xml version=\"1.0\" ?><methodCall><methodName>Bug.get</methodName><params><param><value><struct><member><name>ids</name><value><array><data><value><string>1234</string></value><value><string>0815</string></value></data></array></value></member><member><name>permissive</name><value><i4>1</i4></value></member></struct></value></param></params></methodCall>\n"
+  BugGet0815 = "<?xml version=\"1.0\" ?><methodCall><methodName>Bug.get</methodName><params><param><value><struct><member><name>ids</name><value><array><data><value><string>1234</string></value><value><string>0815</string></value></data></array></value></member><member><name>permissive</name><value><i4>1</i4></value></member></struct></value></param></params></methodCall>\n".freeze
   # rubocop:enable Metrics/LineLength
 
   def test_parse
@@ -39,12 +39,12 @@ class IssueTest < ActiveSupport::TestCase
   BugSearch = "<?xml version=\"1.0\" ?><methodCall><methodName>Bug.search</methodName>
                <params><param><value><struct><member><name>last_change_time</name><value>
                <dateTime.iso8601>20110729T14:00:21</dateTime.iso8601></value></member></struct>
-               </value></param></params></methodCall>\n"
+               </value></param></params></methodCall>\n".freeze
   BugGet = "<?xml version=\"1.0\" ?><methodCall><methodName>Bug.get</methodName><params><param>
             <value><struct><member><name>ids</name><value><array><data><value><i4>838932</i4></value>
             <value><i4>838933</i4></value><value><i4>838970</i4></value></data></array></value></member>
             <member><name>permissive</name><value><i4>1</i4></value></member>
-            </struct></value></param></params></methodCall>\n"
+            </struct></value></param></params></methodCall>\n".freeze
 
   test "fetch issues" do
     stub_request(:post, "http://bugzilla.novell.com/xmlrpc.cgi").

--- a/src/api/test/unit/public_helper_test.rb
+++ b/src/api/test/unit/public_helper_test.rb
@@ -1,7 +1,7 @@
 require File.expand_path(File.dirname(__FILE__) + '/..') + '/test_helper'
 
 class PublicHelperTest < ActiveSupport::TestCase
-  YMP_URL = 'http://example.com/ymp'
+  YMP_URL = 'http://example.com/ymp'.freeze
   include PublicHelper
 
   def test_ymp_url


### PR DESCRIPTION
Freezing these constants prevents them from being changed after
intialization and also reduces object allocation. In case of frozen
objects, ruby caches and re-uses them.