### PR TITLE
[frontend] Move constants to the classes they belong to

### DIFF
--- a/src/api/app/models/bs_request.rb
+++ b/src/api/app/models/bs_request.rb
@@ -32,6 +32,8 @@ class BsRequest < ApplicationRecord
 
   FINAL_REQUEST_STATES = %w(accepted declined superseded revoked)
 
+  VALID_REQUEST_STATES = [:new, :deleted, :declined, :accepted, :review, :revoked, :superseded].freeze
+
   ACTION_NOTIFY_LIMIT = 50
 
   scope :to_accept, -> { where(state: 'new').where('accept_at < ?', DateTime.now) }

--- a/src/api/app/models/review.rb
+++ b/src/api/app/models/review.rb
@@ -5,6 +5,8 @@ class Review < ApplicationRecord
     setup 'review_not_found', 404, 'Review not found'
   end
 
+  VALID_REVIEW_STATES = [:new, :declined, :accepted, :superseded, :obsoleted].freeze
+
   belongs_to :bs_request, touch: true
   has_many :history_elements, -> { order(:created_at) }, class_name: 'HistoryElement::Review', foreign_key: :op_object_id
   has_many :history_elements_assigned, class_name: 'HistoryElement::ReviewAssigned', foreign_key: :op_object_id

--- a/src/api/config/initializers/valid_states.rb
+++ b/src/api/config/initializers/valid_states.rb
@@ -1,2 +1,0 @@
-VALID_REQUEST_STATES = [:new, :deleted, :declined, :accepted, :review, :revoked, :superseded]
-VALID_REVIEW_STATES = [:new, :declined, :accepted, :superseded, :obsoleted]

--- a/src/api/spec/models/user_spec.rb
+++ b/src/api/spec/models/user_spec.rb
@@ -556,7 +556,7 @@ RSpec.describe User do
         # Setting state in create will be overwritten by BsRequest#sanitize!
         # so we need to set it to review afterwards
         [subject_request, request_with_same_creator_and_reviewer, request_of_another_subject].each do |request|
-          request.state = VALID_REQUEST_STATES.sample
+          request.state = BsRequest::VALID_REQUEST_STATES.sample
           request.save
         end
       end


### PR DESCRIPTION
We just shouldn't define constants via initializers. What else could I
say?;-)