### PR TITLE
[ci] Fix flaky test

### DIFF
--- a/src/api/spec/models/project_spec.rb
+++ b/src/api/spec/models/project_spec.rb
@@ -532,7 +532,7 @@ RSpec.describe Project, vcr: true do
   end
 
   describe '#add_maintainer' do
-    subject { project }
+    subject { create(:user).home_project }
 
     it_behaves_like "makes a user a maintainer of the subject"
   end

--- a/src/api/spec/support/shared_examples/relationships.rb
+++ b/src/api/spec/support/shared_examples/relationships.rb
@@ -3,6 +3,9 @@ RSpec.shared_examples 'makes a user a maintainer of the subject' do
   let(:maintainer_role) { Role.where(title: 'maintainer')}
 
   before do
+    object = (subject.kind_of?(Project) ? subject : subject.project)
+    login(object.relationships.maintainers.first.user)
+
     subject.add_maintainer(other_user)
   end
 


### PR DESCRIPTION
This makes sure that the subject maintainer is logged in when calling
add_maintainer.
This wasn't the case before and could fail occasionally.