### PR TITLE
[webui] Add horizontal scrolling to sourcediff codemirror

### DIFF
--- a/src/api/app/views/shared/_sourcediff.html.haml
+++ b/src/api/app/views/shared/_sourcediff.html.haml
@@ -8,7 +8,7 @@
 - content_for(:content_for_head, javascript_include_tag('webui/application/cm2/index-diff'))
 = content_tag(:div, div_opts) do
   - if filenames && filenames.length > 0
-    %table
+    %table{ style: "table-layout: fixed; width: 98%;" }
       %tbody
         - last_file_id = nil
         - filenames.each_with_index do |filename, index|
@@ -28,7 +28,7 @@
                     $('#expand_#{file_id}').hide();
                   - else
                     $('#collapse_#{file_id}').hide();
-            %td{ style: 'width: 1%' }= file_state
+            %td{ style: 'width: 10%' }= file_state
             %td
               /
                 Most files don't exist when the package is linked, so keeping in mind the statement below don't even bother to try to show them


### PR DESCRIPTION
to set the table to the fixed width of the parent div.
Before it overflowed over the parent and broke the whole page.
Now:
![diff1](https://user-images.githubusercontent.com/3799140/31498547-7da4f1e6-af62-11e7-8a5f-8f7d74c497ec.png)
![diff2](https://user-images.githubusercontent.com/3799140/31498548-7dbb0742-af62-11e7-99f4-88f079406d62.png)

Before:
![diff3](https://user-images.githubusercontent.com/3799140/31498549-7dd314e0-af62-11e7-9035-8eee919d9a35.png)
