### PR TITLE
Enable WordArray Rubocop cop

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -1049,13 +1049,6 @@ Style/VariableNumber:
     - 'src/api/spec/features/webui/projects_spec.rb'
     - 'src/api/test/unit/project_test.rb'
 
-# Offense count: 108
-# Cop supports --auto-correct.
-# Configuration parameters: EnforcedStyle, SupportedStyles, MinSize, WordRegex.
-# SupportedStyles: percent, brackets
-Style/WordArray:
-  Enabled: false
-
 # Offense count: 3
 # Cop supports --auto-correct.
 Style/YodaCondition:

--- a/src/api/app/controllers/request_controller.rb
+++ b/src/api/app/controllers/request_controller.rb
@@ -169,7 +169,7 @@ class RequestController < ApplicationController
     end
 
     req.bs_request_actions.each do |action|
-      withissues = params[:withissues].to_s.in?(["1", "true"])
+      withissues = params[:withissues].to_s.in?(%w[1 true])
       action_diff = action.sourcediff(view: params[:view], withissues: withissues)
 
       if xml_request

--- a/src/api/app/controllers/source_controller.rb
+++ b/src/api/app/controllers/source_controller.rb
@@ -181,7 +181,7 @@ class SourceController < ApplicationController
     project_name = params[:project]
     params[:user] = User.current.login
 
-    if command.in?(["undelete", "release", "copy", "move"])
+    if command.in?(%w[undelete release copy move])
       return dispatch_command(:project_command, command)
     end
 
@@ -289,7 +289,7 @@ class SourceController < ApplicationController
     @deleted_package = params.has_key? :deleted
 
     # FIXME: for OBS 3, api of branch and copy calls have target and source in the opossite place
-    if params[:cmd].in?(['branch', 'release'])
+    if params[:cmd].in?(%w[branch release])
       @target_package_name = params[:package]
       @target_project_name = params[:target_project] # might be nil
       @target_package_name = params[:target_package] if params[:target_package]
@@ -349,7 +349,7 @@ class SourceController < ApplicationController
     # Check for existence/access of origin package when specified
     @spkg = nil
     Project.get_by_name origin_project_name if origin_project_name
-    if origin_package_name && !origin_package_name.in?(["_project", "_pattern"]) && !(params[:missingok] && @command.in?(['branch', 'release']))
+    if origin_package_name && !origin_package_name.in?(%w[_project _pattern]) && !(params[:missingok] && @command.in?(%w[branch release]))
       @spkg = Package.get_by_project_and_name(origin_project_name, origin_package_name)
     end
     unless Package_creating_commands.include?(@command) && !Project.exists_by_name(@target_project_name)
@@ -382,7 +382,7 @@ class SourceController < ApplicationController
 
     follow_project_links = Source_untouched_commands.include?(@command)
 
-    unless @target_package_name.in?(["_project", "_pattern"])
+    unless @target_package_name.in?(%w[_project _pattern])
       use_source = true
       use_source = false if @command == 'showlinked'
       @package = Package.get_by_project_and_name(@target_project_name, @target_package_name,
@@ -792,8 +792,8 @@ class SourceController < ApplicationController
     pass_to_backend @path
 
     # update package timestamp and reindex sources
-    return if params[:rev] == 'repository' || @package_name.in?(["_project", "_pattern"])
-    special_file = params[:filename].in?(["_aggregate", "_constraints", "_link", "_service", "_patchinfo", "_channel"])
+    return if params[:rev] == 'repository' || @package_name.in?(%w[_project _pattern])
+    special_file = params[:filename].in?(%w[_aggregate _constraints _link _service _patchinfo _channel])
     @pack.sources_changed(wait_for_update: special_file) # wait for indexing for special files
   end
 

--- a/src/api/app/controllers/webui/request_controller.rb
+++ b/src/api/app/controllers/webui/request_controller.rb
@@ -46,7 +46,7 @@ class Webui::RequestController < Webui::WebuiController
     state = nil
     req = nil
     params.each do |key, value|
-      state = key if  key.in?(["accepted", "declined", "new"])
+      state = key if  key.in?(%w[accepted declined new])
       req = BsRequest.find_by_number(value) if key.starts_with?('review_request_number_')
 
       # Our views are valid XHTML. So, several forms 'POST'-ing to the same action have different
@@ -91,8 +91,8 @@ class Webui::RequestController < Webui::WebuiController
 
     @my_open_reviews = @req['my_open_reviews']
     @other_open_reviews = @req['other_open_reviews']
-    @can_add_reviews = @state.in?(["new", "review"]) && (@is_author || @is_target_maintainer || @my_open_reviews.present?) && !User.current.is_nobody?
-    @can_handle_request = @state.in?(["new", "review", "declined"]) && (@is_target_maintainer || @is_author) && !User.current.is_nobody?
+    @can_add_reviews = @state.in?(%w[new review]) && (@is_author || @is_target_maintainer || @my_open_reviews.present?) && !User.current.is_nobody?
+    @can_handle_request = @state.in?(%w[new review declined]) && (@is_target_maintainer || @is_author) && !User.current.is_nobody?
 
     @history = @bs_request.history_elements
     @actions = @req['actions']

--- a/src/api/app/helpers/webui/package_helper.rb
+++ b/src/api/app/helpers/webui/package_helper.rb
@@ -21,7 +21,7 @@ module Webui::PackageHelper
   end
 
   def guess_code_class( filename )
-    return 'xml' if filename.in?(["_aggregate", "_link", "_patchinfo", "_service"]) || filename =~ /.*\.service/
+    return 'xml' if filename.in?(%w[_aggregate _link _patchinfo _service]) || filename =~ /.*\.service/
     return 'shell' if filename =~ /^rc[\w-]+$/ # rc-scripts are shell
     return 'python' if filename =~ /^.*rpmlintrc$/
     return 'makefile' if filename == 'debian.rules'

--- a/src/api/app/helpers/webui/webui_helper.rb
+++ b/src/api/app/helpers/webui/webui_helper.rb
@@ -190,7 +190,7 @@ module Webui::WebuiHelper
   end
 
   def is_advanced_tab?
-    @current_action.to_s.in?(["prjconf", "index", "meta", "status"])
+    @current_action.to_s.in?(%w[prjconf index meta status])
   end
 
   def sprite_tag(icon, opts = {})

--- a/src/api/app/mixins/webui/load_buildresults.rb
+++ b/src/api/app/mixins/webui/load_buildresults.rb
@@ -25,7 +25,7 @@ module Webui::LoadBuildresults
 
       result.elements('status') do |status|
         stathash[status['package']] = status
-        if status['code'].in?(["unresolvable", "failed", "broken"])
+        if status['code'].in?(%w[unresolvable failed broken])
           @failures += 1
         end
       end

--- a/src/api/app/models/bs_request.rb
+++ b/src/api/app/models/bs_request.rb
@@ -123,7 +123,7 @@ class BsRequest < ApplicationRecord
     # it's wiser to split the queries
     if opts[:project] && roles.empty? && (states.empty? || states.include?("review"))
       (BsRequest.find_for(opts.merge(roles: ["reviewer"])) +
-        BsRequest.find_for(opts.merge(roles: ["target", "source"]))).uniq
+        BsRequest.find_for(opts.merge(roles: %w[target source]))).uniq
     else
       BsRequest.find_for(opts).uniq
     end
@@ -790,7 +790,7 @@ class BsRequest < ApplicationRecord
   def setpriority(opts)
     permission_check_setpriority!
 
-    unless opts[:priority].in?(['low', 'moderate', 'important', 'critical'])
+    unless opts[:priority].in?(%w[low moderate important critical])
       raise SaveError, "Illegal priority '#{opts[:priority]}'"
     end
 
@@ -808,7 +808,7 @@ class BsRequest < ApplicationRecord
     # rails enums do not support compare and break db constraints :/
     if new == "critical"
       self.priority = new
-    elsif new == "important" && priority.in?(["moderate", "low"])
+    elsif new == "important" && priority.in?(%w[moderate low])
       self.priority = new
     elsif new == "moderate" && "low" == priority
       self.priority = new

--- a/src/api/app/models/bs_request/data_table/params_parser_with_state_and_type.rb
+++ b/src/api/app/models/bs_request/data_table/params_parser_with_state_and_type.rb
@@ -13,7 +13,7 @@ class BsRequest
 
       def states
         if @requested_params[:state] == 'new or review'
-          ['new', 'review']
+          %w[new review]
         elsif @requested_params[:state].present?
           [@requested_params[:state]]
         end

--- a/src/api/app/models/bs_request_action.rb
+++ b/src/api/app/models/bs_request_action.rb
@@ -5,7 +5,7 @@ class BsRequestAction < ApplicationRecord
   include ParsePackageDiff
 
   #### Constants
-  VALID_SOURCEUPDATE_OPTIONS = ['update', 'noupdate', 'cleanup']
+  VALID_SOURCEUPDATE_OPTIONS = %w[update noupdate cleanup]
 
   #### Self config
   class DiffError < APIException; setup 404; end # a diff error can have many reasons, but most likely something within us
@@ -55,7 +55,7 @@ class BsRequestAction < ApplicationRecord
   validate :check_sanity
   validates :type, uniqueness: {
                      scope:      [:target_project, :target_package, :bs_request_id],
-                     conditions: -> { where.not(type: ['add_role', 'maintenance_incident']) }
+                     conditions: -> { where.not(type: %w[add_role maintenance_incident]) }
   }
 
   before_validation :set_target_associations
@@ -589,11 +589,11 @@ class BsRequestAction < ApplicationRecord
             raise BuildNotFinished, "The repository '#{pkg.project.name}' / '#{repo}' / #{arch} " +
                                        "needs recalculation by the schedulers"
           end
-          if result.attributes['state'].in?(["finished", "publishing"])
+          if result.attributes['state'].in?(%w[finished publishing])
             raise BuildNotFinished, "The repository '#{pkg.project.name}' / '#{repo}' / #{arch}" +
                                        "did not finish the publish yet"
           end
-          unless result.attributes['state'].in?(["published", "unpublished"])
+          unless result.attributes['state'].in?(%w[published unpublished])
             raise BuildNotFinished, "The repository '#{pkg.project.name}' / '#{repo}' / #{arch} " +
                                        "did not finish the build yet"
           end
@@ -813,7 +813,7 @@ class BsRequestAction < ApplicationRecord
         raise 'We should have expanded a target_project' unless target_project
         # validate project type
         prj = Project.get_by_name(target_project)
-        unless prj.kind.in?(["maintenance", "maintenance_incident"])
+        unless prj.kind.in?(%w[maintenance maintenance_incident])
           raise IncidentHasNoMaintenanceProject, 'incident projects shall only create below maintenance projects'
         end
       end

--- a/src/api/app/models/bs_request_permission_check.rb
+++ b/src/api/app/models/bs_request_permission_check.rb
@@ -125,7 +125,7 @@ class BsRequestPermissionCheck
   # check if the action can change state - or throw an APIException if not
   def check_newstate_action!(action, opts)
     # relaxed checks for final exit states
-    return if opts[:newstate].in?(["declined", "revoked", "superseded"])
+    return if opts[:newstate].in?(%w[declined revoked superseded])
 
     if opts[:newstate] == 'accepted'
       check_accepted_action(action)
@@ -161,7 +161,7 @@ class BsRequestPermissionCheck
     end
     # maintenance incident target permission checks
     return unless action.is_maintenance_incident?
-    return if @target_project.kind.in?(["maintenance", "maintenance_incident"])
+    return if @target_project.kind.in?(%w[maintenance maintenance_incident])
 
     raise TargetNotMaintenance, "The target project is not of type maintenance or incident but #{@target_project.kind}"
   end
@@ -325,7 +325,7 @@ class BsRequestPermissionCheck
     # do not allow direct switches from a final state to another one to avoid races and double actions.
     # request needs to get reopened first.
     if req.state.in?([:accepted, :superseded, :revoked])
-      if opts[:newstate].in?(["accepted", "declined", "superseded", "revoked"])
+      if opts[:newstate].in?(%w[accepted declined superseded revoked])
         raise PostRequestNoPermission, "set state to #{opts[:newstate]} from a final state is not allowed."
       end
     end
@@ -341,10 +341,10 @@ class BsRequestPermissionCheck
       raise PostRequestNoPermission, 'Deletion of a request is only permitted for administrators. Please revoke the request instead.'
     end
 
-    if opts[:newstate].in?(["new", "review", "revoked", "superseded"]) && req.creator == User.current.login
+    if opts[:newstate].in?(%w[new review revoked superseded]) && req.creator == User.current.login
       # request creator can reopen, revoke or supersede a request which was declined
       permission_granted = true
-    elsif req.state == :declined && opts[:newstate].in?(["new", "review"]) && req.commenter == User.current.login
+    elsif req.state == :declined && opts[:newstate].in?(%w[new review]) && req.commenter == User.current.login
       # people who declined a request shall also be able to reopen it
       permission_granted = true
     end

--- a/src/api/app/models/buildresult.rb
+++ b/src/api/app/models/buildresult.rb
@@ -54,7 +54,7 @@ class Buildresult < ActiveXML::Node
   end
 
   def self.final_status?(status)
-    status.in?(["succeeded", "failed", "unresolvable", "broken", "disabled", "excluded"])
+    status.in?(%w[succeeded failed unresolvable broken disabled excluded])
   end
 
   def self.summary(project_name)

--- a/src/api/app/models/download_repository.rb
+++ b/src/api/app/models/download_repository.rb
@@ -1,5 +1,5 @@
 class DownloadRepository < ApplicationRecord
-  REPOTYPES = ["rpmmd", "susetags", "deb", "arch", "mdk"]
+  REPOTYPES = %w[rpmmd susetags deb arch mdk]
 
   belongs_to :repository
 

--- a/src/api/app/models/kiwi/repository.rb
+++ b/src/api/app/models/kiwi/repository.rb
@@ -44,7 +44,7 @@ class Kiwi::Repository < ApplicationRecord
   def source_path_format
     return if source_path == 'obsrepositories:/'
     return if source_path =~ /^(dir|iso|smb|this):\/\/.+/
-    return if source_path =~ /\A#{URI.regexp(['ftp', 'http', 'https', 'plain'])}\z/
+    return if source_path =~ /\A#{URI.regexp(%w[ftp http https plain])}\z/
     if source_path_for_obs_repository?
       return if repo_type == 'rpm-md'
       errors.add(:repo_type, "should be 'rpm-md' for obs:// repositories")

--- a/src/api/app/models/package.rb
+++ b/src/api/app/models/package.rb
@@ -1399,7 +1399,7 @@ class Package < ApplicationRecord
 
     # update package timestamp and reindex sources
     return if opt[:rev] == 'repository' || %w(_project _pattern).include?(name)
-    sources_changed(wait_for_update: ['_aggregate', '_constraints', '_link', '_service', '_patchinfo', '_channel'].include?(opt[:filename]))
+    sources_changed(wait_for_update: %w[_aggregate _constraints _link _service _patchinfo _channel].include?(opt[:filename]))
   end
 
   def to_param

--- a/src/api/app/models/package_build_status.rb
+++ b/src/api/app/models/package_build_status.rb
@@ -100,10 +100,10 @@ class PackageBuildStatus
     rescue ActiveXML::Transport::Error
       currentcode = nil
     end
-    if currentcode.in?(["unresolvable", "failed", "broken"])
+    if currentcode.in?(%w[unresolvable failed broken])
       @buildcode = 'failed'
     end
-    if currentcode.in?(["building", "scheduled", "finished", "signing", "blocked"])
+    if currentcode.in?(%w[building scheduled finished signing blocked])
       @buildcode = 'building'
     end
     if currentcode == 'excluded'

--- a/src/api/app/models/project.rb
+++ b/src/api/app/models/project.rb
@@ -774,7 +774,7 @@ class Project < ApplicationRecord
       flag_default = FlagHelper.default_for(flag_name)
       archs = Array.new
       flagret = Array.new
-      unless flag_name.in?(["lock", "access", "sourceaccess"])
+      unless flag_name.in?(%w[lock access sourceaccess])
         repos.each do |repo|
           flagret << flag_status(flag_default, repo.name, nil, flaglist, pkg_flags)
           repo.architectures.each do |arch|
@@ -1139,7 +1139,7 @@ class Project < ApplicationRecord
     # - omit 'lock' or we cannot create packages
     disable_publish_for_branches = ::Configuration.disable_publish_for_branches || project.image_template?
     project.flags.each do |f|
-      next if f.flag.in?(["build", "lock"])
+      next if f.flag.in?(%w[build lock])
       next if f.flag == 'publish' && disable_publish_for_branches
       # NOTE: it does not matter if that flag is set to enable or disable, so we do not check fro
       #       for same flag status here explizit
@@ -1446,12 +1446,12 @@ class Project < ApplicationRecord
     if repository && repository_states.has_key?(repository)
       return false if repository_states[repository].empty? # No buildresult is bad
       repository_states[repository].each do |state, _|
-        return false if state.in?(["broken", "failed", "unresolvable"])
+        return false if state.in?(%w[broken failed unresolvable])
       end
     else
       return false unless states.empty? # No buildresult is bad
       states.each do |state, _|
-        return false if state.in?(["broken", "failed", "unresolvable"])
+        return false if state.in?(%w[broken failed unresolvable])
       end
     end
     true

--- a/src/api/app/models/unregistered_user.rb
+++ b/src/api/app/models/unregistered_user.rb
@@ -32,7 +32,7 @@ class UnregisteredUser < User
     end
 
     # Turn on registration if it's enabled
-    if ["allow", "confirmation"].include?(::Configuration.registration)
+    if %w[allow confirmation].include?(::Configuration.registration)
       return true
     end
 

--- a/src/api/app/models/user.rb
+++ b/src/api/app/models/user.rb
@@ -88,7 +88,7 @@ class User < ApplicationRecord
   after_create :create_home_project
   def create_home_project
     # avoid errors during seeding
-    return if login.in?(["_nobody_", "Admin"])
+    return if login.in?(%w[_nobody_ Admin])
     # may be disabled via Configuration setting
     return unless can_create_project?(home_project_name)
     # find or create the project
@@ -325,9 +325,9 @@ class User < ApplicationRecord
     when 'unconfirmed'
       true
     when 'confirmed'
-      to.in?(["locked", "deleted"])
+      to.in?(%w[locked deleted])
     when 'locked'
-      to.in?(["confirmed", "deleted"])
+      to.in?(%w[confirmed deleted])
     when 'deleted'
       to == "confirmed"
     else

--- a/src/api/db/migrate/001_initial_database.rb
+++ b/src/api/db/migrate/001_initial_database.rb
@@ -31,7 +31,7 @@ class InitialDatabase < ActiveRecord::Migration[4.2]
     create_table "attrib_issues", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
       t.integer "attrib_id", null: false
       t.integer "issue_id",  null: false
-      t.index ["attrib_id", "issue_id"], name: "index_attrib_issues_on_attrib_id_and_issue_id", unique: true, using: :btree
+      t.index %w[attrib_id issue_id], name: "index_attrib_issues_on_attrib_id_and_issue_id", unique: true, using: :btree
       t.index ["issue_id"], name: "issue_id", using: :btree
     end
 
@@ -39,7 +39,7 @@ class InitialDatabase < ActiveRecord::Migration[4.2]
       t.integer "attrib_namespace_id", null: false
       t.integer "user_id"
       t.integer "group_id"
-      t.index ["attrib_namespace_id", "user_id", "group_id"], name: "attrib_namespace_user_role_all_index", unique: true, using: :btree
+      t.index %w[attrib_namespace_id user_id group_id], name: "attrib_namespace_user_role_all_index", unique: true, using: :btree
       t.index ["attrib_namespace_id"], name: "index_attrib_namespace_modifiable_bies_on_attrib_namespace_id", using: :btree
       t.index ["user_id"], name: "bs_user_id", using: :btree
       t.index ["group_id"], name: "bs_group_id", using: :btree
@@ -55,7 +55,7 @@ class InitialDatabase < ActiveRecord::Migration[4.2]
       t.integer "user_id"
       t.integer "group_id", options: "AFTER user_id"
       t.integer "role_id"
-      t.index ["attrib_type_id", "user_id", "group_id", "role_id"], name: "attrib_type_user_role_all_index", unique: true, using: :btree
+      t.index %w[attrib_type_id user_id group_id role_id], name: "attrib_type_user_role_all_index", unique: true, using: :btree
       t.index ["user_id"], name: "user_id", using: :btree
       t.index ["group_id"], name: "group_id", using: :btree
       t.index ["role_id"], name: "role_id", using: :btree
@@ -68,7 +68,7 @@ class InitialDatabase < ActiveRecord::Migration[4.2]
       t.integer "value_count"
       t.integer "attrib_namespace_id",                 null: false
       t.boolean "issue_list",          default: false
-      t.index ["attrib_namespace_id", "name"], name: "index_attrib_types_on_attrib_namespace_id_and_name", unique: true, using: :btree
+      t.index %w[attrib_namespace_id name], name: "index_attrib_types_on_attrib_namespace_id_and_name", unique: true, using: :btree
       t.index ["attrib_namespace_id"], name: "attrib_namespace_id", using: :btree
       t.index ["name"], name: "index_attrib_types_on_name", using: :btree
     end
@@ -77,7 +77,7 @@ class InitialDatabase < ActiveRecord::Migration[4.2]
       t.integer "attrib_id",               null: false
       t.text    "value",     limit: 65535, null: false, collation: "utf8_general_ci"
       t.integer "position",                null: false
-      t.index ["attrib_id", "position"], name: "index_attrib_values_on_attrib_id_and_position", unique: true, using: :btree
+      t.index %w[attrib_id position], name: "index_attrib_values_on_attrib_id_and_position", unique: true, using: :btree
       t.index ["attrib_id"], name: "index_attrib_values_on_attrib_id", using: :btree
     end
 
@@ -86,8 +86,8 @@ class InitialDatabase < ActiveRecord::Migration[4.2]
       t.integer "package_id"
       t.string  "binary",                      collation: "utf8_general_ci"
       t.integer "project_id"
-      t.index ["attrib_type_id", "package_id", "project_id", "binary"], name: "attribs_index", unique: true, using: :btree
-      t.index ["attrib_type_id", "project_id", "package_id", "binary"], name: "attribs_on_proj_and_pack", unique: true, using: :btree
+      t.index %w[attrib_type_id package_id project_id binary], name: "attribs_index", unique: true, using: :btree
+      t.index %w[attrib_type_id project_id package_id binary], name: "attribs_on_proj_and_pack", unique: true, using: :btree
       t.index ["package_id"], name: "index_attribs_on_package_id", using: :btree
       t.index ["project_id"], name: "index_attribs_on_project_id", using: :btree
     end
@@ -148,7 +148,7 @@ class InitialDatabase < ActiveRecord::Migration[4.2]
       t.index ["target_package"], name: "index_bs_request_actions_on_target_package", using: :btree
       t.index ["source_project"], name: "index_bs_request_actions_on_source_project", using: :btree
       t.index ["source_package"], name: "index_bs_request_actions_on_source_package", using: :btree
-      t.index ["target_project", "source_project"], name: "index_bs_request_actions_on_target_project_and_source_project", using: :btree
+      t.index %w[target_project source_project], name: "index_bs_request_actions_on_target_project_and_source_project", using: :btree
     end
 
     create_table "bs_request_histories", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin" do |t|
@@ -181,7 +181,7 @@ class InitialDatabase < ActiveRecord::Migration[4.2]
       t.string   "project"
       t.integer  "request"
       t.datetime "created_at"
-      t.index ["project", "package"], name: "index_cache_lines_on_project_and_package", using: :btree
+      t.index %w[project package], name: "index_cache_lines_on_project_and_package", using: :btree
       t.index ["project"], name: "index_cache_lines_on_project", using: :btree
     end
 
@@ -194,11 +194,11 @@ class InitialDatabase < ActiveRecord::Migration[4.2]
       t.string  "package"
       t.string  "binaryarch"
       t.string  "supportstatus"
-      t.index ["project_id", "package"], name: "index_channel_binaries_on_project_id_and_package", using: :btree
+      t.index %w[project_id package], name: "index_channel_binaries_on_project_id_and_package", using: :btree
       t.index ["channel_binary_list_id"], name: "channel_binary_list_id", using: :btree
       t.index ["repository_id"], name: "repository_id", using: :btree
       t.index ["architecture_id"], name: "architecture_id", using: :btree
-      t.index ["name", "channel_binary_list_id"], name: "index_channel_binaries_on_name_and_channel_binary_list_id", using: :btree
+      t.index %w[name channel_binary_list_id], name: "index_channel_binaries_on_name_and_channel_binary_list_id", using: :btree
     end
 
     create_table "channel_binary_lists", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
@@ -217,7 +217,7 @@ class InitialDatabase < ActiveRecord::Migration[4.2]
       t.integer "repository_id", null: false
       t.string  "prefix"
       t.string  "tag"
-      t.index ["channel_id", "repository_id"], name: "index_channel_targets_on_channel_id_and_repository_id", unique: true, using: :btree
+      t.index %w[channel_id repository_id], name: "index_channel_targets_on_channel_id_and_repository_id", unique: true, using: :btree
       t.index ["repository_id"], name: "repository_id", using: :btree
     end
 
@@ -277,7 +277,7 @@ class InitialDatabase < ActiveRecord::Migration[4.2]
     create_table "db_projects_tags", id: false, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
       t.integer "db_project_id", null: false
       t.integer "tag_id",        null: false
-      t.index ["db_project_id", "tag_id"], name: "projects_tags_all_index", unique: true, using: :btree
+      t.index %w[db_project_id tag_id], name: "projects_tags_all_index", unique: true, using: :btree
       t.index ["tag_id"], name: "tag_id", using: :btree
     end
 
@@ -387,7 +387,7 @@ class InitialDatabase < ActiveRecord::Migration[4.2]
       t.integer  "group_id",   default: 0, null: false
       t.integer  "role_id",    default: 0, null: false
       t.datetime "created_at"
-      t.index ["group_id", "role_id"], name: "groups_roles_all_index", unique: true, using: :btree
+      t.index %w[group_id role_id], name: "groups_roles_all_index", unique: true, using: :btree
       t.index ["role_id"], name: "role_id", using: :btree
     end
 
@@ -396,7 +396,7 @@ class InitialDatabase < ActiveRecord::Migration[4.2]
       t.integer  "user_id",    default: 0,    null: false
       t.datetime "created_at"
       t.boolean  "email",      default: true
-      t.index ["group_id", "user_id"], name: "groups_users_all_index", unique: true, using: :btree
+      t.index %w[group_id user_id], name: "groups_users_all_index", unique: true, using: :btree
       t.index ["user_id"], name: "user_id", using: :btree
     end
 
@@ -429,7 +429,7 @@ class InitialDatabase < ActiveRecord::Migration[4.2]
       t.column   "state", "enum('OPEN','CLOSED','UNKNOWN')", limit: 7,              collation: "utf8_general_ci"
       t.index ["owner_id"], name: "owner_id", using: :btree
       t.index ["issue_tracker_id"], name: "issue_tracker_id", using: :btree
-      t.index ["name", "issue_tracker_id"], name: "index_issues_on_name_and_issue_tracker_id", using: :btree
+      t.index %w[name issue_tracker_id], name: "index_issues_on_name_and_issue_tracker_id", using: :btree
     end
 
     create_table "linked_projects", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin" do |t|
@@ -437,7 +437,7 @@ class InitialDatabase < ActiveRecord::Migration[4.2]
       t.integer "linked_db_project_id"
       t.integer "position"
       t.string  "linked_remote_project_name",              collation: "utf8_general_ci"
-      t.index ["db_project_id", "linked_db_project_id"], name: "linked_projects_index", unique: true, using: :btree
+      t.index %w[db_project_id linked_db_project_id], name: "linked_projects_index", unique: true, using: :btree
     end
 
     create_table "maintenance_incidents", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin" do |t|
@@ -468,7 +468,7 @@ class InitialDatabase < ActiveRecord::Migration[4.2]
       t.integer "package_id",           null: false
       t.integer "issue_id",             null: false
       t.column  "change", "enum('added','deleted','changed','kept')", limit: 7
-      t.index ["package_id", "issue_id"], name: "index_package_issues_on_package_id_and_issue_id", using: :btree
+      t.index %w[package_id issue_id], name: "index_package_issues_on_package_id_and_issue_id", using: :btree
       t.index ["issue_id"], name: "index_package_issues_on_issue_id", using: :btree
       t.index ["package_id"], name: "index_package_issues_on_package_id", using: :btree
     end
@@ -493,7 +493,7 @@ class InitialDatabase < ActiveRecord::Migration[4.2]
       t.integer  "develpackage_id"
       t.boolean  "delta",                         default: true,  null: false
       t.index ["develpackage_id"], name: "devel_package_id_index", using: :btree
-      t.index ["project_id", "name"], name: "packages_all_index", unique: true, length: { name: 255 }, using: :btree
+      t.index %w[project_id name], name: "packages_all_index", unique: true, length: { name: 255 }, using: :btree
       t.index ["project_id"], name: "index_packages_on_project_id", using: :btree
       t.index ["updated_at"], name: "updated_at_index", using: :btree
     end
@@ -502,15 +502,15 @@ class InitialDatabase < ActiveRecord::Migration[4.2]
       t.integer "parent_id",     null: false
       t.integer "repository_id", null: false
       t.integer "position",      null: false
-      t.index ["parent_id", "position"], name: "parent_repo_pos_index", unique: true, using: :btree
-      t.index ["parent_id", "repository_id"], name: "parent_repository_index", unique: true, using: :btree
+      t.index %w[parent_id position], name: "parent_repo_pos_index", unique: true, using: :btree
+      t.index %w[parent_id repository_id], name: "parent_repository_index", unique: true, using: :btree
       t.index ["repository_id"], name: "repository_id", using: :btree
     end
 
     create_table "product_channels", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
       t.integer "product_id", null: false
       t.integer "channel_id", null: false
-      t.index ["channel_id", "product_id"], name: "index_product_channels_on_channel_id_and_product_id", unique: true, using: :btree
+      t.index %w[channel_id product_id], name: "index_product_channels_on_channel_id_and_product_id", unique: true, using: :btree
       t.index ["product_id"], name: "product_id", using: :btree
     end
 
@@ -525,7 +525,7 @@ class InitialDatabase < ActiveRecord::Migration[4.2]
       t.string  "name",       null: false
       t.integer "package_id", null: false
       t.string  "cpe"
-      t.index ["name", "package_id"], name: "index_products_on_name_and_package_id", unique: true, using: :btree
+      t.index %w[name package_id], name: "index_products_on_name_and_package_id", unique: true, using: :btree
       t.index ["package_id"], name: "package_id", using: :btree
     end
 
@@ -580,10 +580,10 @@ class InitialDatabase < ActiveRecord::Migration[4.2]
       t.integer "role_id",    null: false
       t.integer "user_id"
       t.integer "group_id"
-      t.index ["project_id", "role_id", "group_id"], name: "index_relationships_on_project_id_and_role_id_and_group_id", unique: true, using: :btree
-      t.index ["project_id", "role_id", "user_id"], name: "index_relationships_on_project_id_and_role_id_and_user_id", unique: true, using: :btree
-      t.index ["package_id", "role_id", "group_id"], name: "index_relationships_on_package_id_and_role_id_and_group_id", unique: true, using: :btree
-      t.index ["package_id", "role_id", "user_id"], name: "index_relationships_on_package_id_and_role_id_and_user_id", unique: true, using: :btree
+      t.index %w[project_id role_id group_id], name: "index_relationships_on_project_id_and_role_id_and_group_id", unique: true, using: :btree
+      t.index %w[project_id role_id user_id], name: "index_relationships_on_project_id_and_role_id_and_user_id", unique: true, using: :btree
+      t.index %w[package_id role_id group_id], name: "index_relationships_on_package_id_and_role_id_and_group_id", unique: true, using: :btree
+      t.index %w[package_id role_id user_id], name: "index_relationships_on_package_id_and_role_id_and_user_id", unique: true, using: :btree
       t.index ["role_id"], name: "role_id", using: :btree
       t.index ["user_id"], name: "user_id", using: :btree
       t.index ["group_id"], name: "group_id", using: :btree
@@ -605,7 +605,7 @@ class InitialDatabase < ActiveRecord::Migration[4.2]
       t.column  "block", "enum('all','local','never')", limit: 5,               collation: "utf8_general_ci"
       t.column  "linkedbuild", "enum('off','localdep','all')", limit: 8,               collation: "utf8_general_ci"
       t.integer "hostsystem_id"
-      t.index ["db_project_id", "name", "remote_project_name"], name: "projects_name_index", unique: true, using: :btree
+      t.index %w[db_project_id name remote_project_name], name: "projects_name_index", unique: true, using: :btree
       t.index ["remote_project_name"], name: "remote_project_name_index", using: :btree
       t.index ["hostsystem_id"], name: "hostsystem_id", using: :btree
     end
@@ -615,7 +615,7 @@ class InitialDatabase < ActiveRecord::Migration[4.2]
       t.integer "architecture_id",             null: false
       t.integer "position",        default: 0, null: false
       t.index ["architecture_id"], name: "architecture_id", using: :btree
-      t.index ["repository_id", "architecture_id"], name: "arch_repo_index", unique: true, using: :btree
+      t.index %w[repository_id architecture_id], name: "arch_repo_index", unique: true, using: :btree
     end
 
     create_table "reviews", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
@@ -635,10 +635,10 @@ class InitialDatabase < ActiveRecord::Migration[4.2]
       t.index ["by_user"], name: "index_reviews_on_by_user", using: :btree
       t.index ["by_group"], name: "index_reviews_on_by_group", using: :btree
       t.index ["by_project"], name: "index_reviews_on_by_project", using: :btree
-      t.index ["by_package", "by_project"], name: "index_reviews_on_by_package_and_by_project", using: :btree
+      t.index %w[by_package by_project], name: "index_reviews_on_by_package_and_by_project", using: :btree
       t.index ["bs_request_id"], name: "bs_request_id", using: :btree
-      t.index ["state", "by_project"], name: "index_reviews_on_state_and_by_project", using: :btree
-      t.index ["state", "by_user"], name: "index_reviews_on_state_and_by_user", using: :btree
+      t.index %w[state by_project], name: "index_reviews_on_state_and_by_project", using: :btree
+      t.index %w[state by_user], name: "index_reviews_on_state_and_by_user", using: :btree
       t.index ["state"], name: "index_reviews_on_state", using: :btree
     end
 
@@ -653,7 +653,7 @@ class InitialDatabase < ActiveRecord::Migration[4.2]
       t.integer "role_id",              default: 0, null: false
       t.integer "static_permission_id", default: 0, null: false
       t.index ["role_id"], name: "role_id", using: :btree
-      t.index ["static_permission_id", "role_id"], name: "roles_static_permissions_all_index", unique: true, using: :btree
+      t.index %w[static_permission_id role_id], name: "roles_static_permissions_all_index", unique: true, using: :btree
     end
 
     create_table "roles_users", id: false, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
@@ -661,7 +661,7 @@ class InitialDatabase < ActiveRecord::Migration[4.2]
       t.integer  "role_id",    default: 0, null: false
       t.datetime "created_at"
       t.index ["role_id"], name: "role_id", using: :btree
-      t.index ["user_id", "role_id"], name: "roles_users_all_index", unique: true, using: :btree
+      t.index %w[user_id role_id], name: "roles_users_all_index", unique: true, using: :btree
     end
 
     create_table "sessions", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
@@ -682,7 +682,7 @@ class InitialDatabase < ActiveRecord::Migration[4.2]
       t.integer "time"
       t.string  "key",                           collation: "utf8_general_ci"
       t.float   "value", limit: 24, null: false
-      t.index ["time", "key"], name: "index_status_histories_on_time_and_key", using: :btree
+      t.index %w[time key], name: "index_status_histories_on_time_and_key", using: :btree
       t.index ["key"], name: "index_status_histories_on_key", using: :btree
     end
 
@@ -693,7 +693,7 @@ class InitialDatabase < ActiveRecord::Migration[4.2]
       t.integer  "user_id"
       t.integer  "severity"
       t.index ["user_id"], name: "user", using: :btree
-      t.index ["deleted_at", "created_at"], name: "index_status_messages_on_deleted_at_and_created_at", using: :btree
+      t.index %w[deleted_at created_at], name: "index_status_messages_on_deleted_at_and_created_at", using: :btree
     end
 
     create_table "taggings", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin" do |t|
@@ -701,7 +701,7 @@ class InitialDatabase < ActiveRecord::Migration[4.2]
       t.string  "taggable_type", collation: "utf8_general_ci"
       t.integer "tag_id"
       t.integer "user_id"
-      t.index ["taggable_id", "taggable_type", "tag_id", "user_id"], name: "taggings_taggable_id_index", unique: true, using: :btree
+      t.index %w[taggable_id taggable_type tag_id user_id], name: "taggings_taggable_id_index", unique: true, using: :btree
       t.index ["taggable_type"], name: "index_taggings_on_taggable_type", using: :btree
       t.index ["tag_id"], name: "tag_id", using: :btree
       t.index ["user_id"], name: "user_id", using: :btree

--- a/src/api/db/migrate/20161122121211_move_comments_data.rb
+++ b/src/api/db/migrate/20161122121211_move_comments_data.rb
@@ -5,7 +5,7 @@ class MoveCommentsData < ActiveRecord::Migration[5.0]
       Comment.find_each(batch_size: 5000) do |comment|
         /\AComment(?<type>.+)/ =~ comment.type
         type = 'BsRequest' if type == 'Request'
-        unless ['Project', 'Package', 'BsRequest'].include? type
+        unless %w[Project Package BsRequest].include? type
           # broken data, luckily only a comment, so forget about it
           comment.destroy
           next

--- a/src/api/db/migrate/20170821110941_remove_taggings.rb
+++ b/src/api/db/migrate/20170821110941_remove_taggings.rb
@@ -5,7 +5,7 @@ class RemoveTaggings < ActiveRecord::Migration[5.1]
       t.string  "taggable_type", collation: "utf8_general_ci"
       t.references :tag, index: { unique: true }, foreign_key: true
       t.references :user, index: { unique: true }, type: :integer, foreign_key: true
-      t.index ["taggable_id", "taggable_type"], name: "taggings_taggable_id_index", unique: true, using: :btree
+      t.index %w[taggable_id taggable_type], name: "taggings_taggable_id_index", unique: true, using: :btree
     end
   end
 end

--- a/src/api/script/import_database.rb
+++ b/src/api/script/import_database.rb
@@ -9,7 +9,7 @@ require 'fileutils'
 require 'optparse'
 require 'pathname'
 
-TABLES_TO_REMOVE = ['cache_lines', 'project_log_entries']
+TABLES_TO_REMOVE = %w[cache_lines project_log_entries]
 @params = {}
 @params[:environment] = 'development'
 @options_path = ::File.expand_path('../../config/options.yml', __FILE__)

--- a/src/api/spec/controllers/status_controller_spec.rb
+++ b/src/api/spec/controllers/status_controller_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe StatusController, vcr: true do
 
     context 'with failures' do
       before do
-        allow_any_instance_of(ProjectStatus::PackInfo).to receive(:fails).and_return([['repo', 'arch', 'time', 'md5']])
+        allow_any_instance_of(ProjectStatus::PackInfo).to receive(:fails).and_return([%w[repo arch time md5]])
         login(admin_user)
         get :project, params: { project: project.name, format: :xml }
       end

--- a/src/api/spec/controllers/webui/kiwi/images_controller_spec.rb
+++ b/src/api/spec/controllers/webui/kiwi/images_controller_spec.rb
@@ -293,8 +293,8 @@ RSpec.describe Webui::Kiwi::ImagesController, type: :controller, vcr: true do
 
   describe 'GET #autocomplete_binaries' do
     let(:binaries_available_sample) do
-      { 'apache' => ['i586', 'x86_64'], 'apache2' => ['x86_64'],
-        'appArmor' => ['i586', 'x86_64'], 'bcrypt' => ['x86_64'] }
+      { 'apache' => %w[i586 x86_64], 'apache2' => ['x86_64'],
+        'appArmor' => %w[i586 x86_64], 'bcrypt' => ['x86_64'] }
     end
 
     let(:term) { '' }

--- a/src/api/spec/controllers/webui/package_controller_spec.rb
+++ b/src/api/spec/controllers/webui/package_controller_spec.rb
@@ -1208,8 +1208,8 @@ EOT
 
     it { expect(response).to have_http_status(:success) }
     it { expect(assigns(:repo_list)).to include(['openSUSE_Leap_42.1', 'openSUSE_Leap_42_1']) }
-    it { expect(assigns(:repo_list)).not_to include(['images', 'images']) }
-    it { expect(assigns(:repo_list)).not_to include(['openSUSE_Tumbleweed', 'openSUSE_Tumbleweed']) }
+    it { expect(assigns(:repo_list)).not_to include(%w[images images]) }
+    it { expect(assigns(:repo_list)).not_to include(%w[openSUSE_Tumbleweed openSUSE_Tumbleweed]) }
     it { expect(assigns(:repo_arch_hash)['openSUSE_Leap_42_1']).to include('x86_64') }
     it { expect(assigns(:repo_arch_hash)['openSUSE_Leap_42_1']).not_to include('armv7l') }
   end

--- a/src/api/spec/controllers/webui/project_controller_spec.rb
+++ b/src/api/spec/controllers/webui/project_controller_spec.rb
@@ -1420,7 +1420,7 @@ RSpec.describe Webui::ProjectController, vcr: true do
           it { expect(assigns(:buildresult_unavailable)).to be_nil }
           it { expect(assigns(:packagenames)).to eq(['c++', 'redis']) }
           it { expect(assigns(:statushash)).to eq(statushash) }
-          it { expect(assigns(:repohash)).to eq({ "openSUSE_Tumbleweed" => ["i586", "x86_64"], "openSUSE_42.2" => ["s390x"] }) }
+          it { expect(assigns(:repohash)).to eq({ "openSUSE_Tumbleweed" => %w[i586 x86_64], "openSUSE_42.2" => ["s390x"] }) }
           it {
             expect(assigns(:repostatushash)).to eq({ "openSUSE_Tumbleweed" => { "i586" => "published", "x86_64" => "building" },
                                                      "openSUSE_42.2"       => { "s390x" => "outdated_published" }})
@@ -1519,7 +1519,7 @@ RSpec.describe Webui::ProjectController, vcr: true do
           )
         end
         let(:repohash) do
-          { "home_coolo_standard" => ["i586", "x86_64"] }
+          { "home_coolo_standard" => %w[i586 x86_64] }
         end
 
         let(:statushash) do
@@ -1560,7 +1560,7 @@ RSpec.describe Webui::ProjectController, vcr: true do
           )
         end
         let(:repohash) do
-          { "home_coolo_standard" => ["i586", "x86_64"] }
+          { "home_coolo_standard" => %w[i586 x86_64] }
         end
 
         let(:statushash) do

--- a/src/api/spec/controllers/webui/repositories_controller_spec.rb
+++ b/src/api/spec/controllers/webui/repositories_controller_spec.rb
@@ -77,8 +77,8 @@ RSpec.describe Webui::RepositoriesController, vcr: true do
         expect(foo.count).to eq(foo.distinct.count)
       end
 
-      it { expect(repo_for_user_home.architectures.pluck(:name)).to match_array(['i586', 'x86_64']) }
-      it { expect(Architecture.available.pluck(:name)).to match_array(["armv7l", "i586", "x86_64"]) }
+      it { expect(repo_for_user_home.architectures.pluck(:name)).to match_array(%w[i586 x86_64]) }
+      it { expect(Architecture.available.pluck(:name)).to match_array(%w[armv7l i586 x86_64]) }
       it { expect(assigns(:repository_arch_hash).to_a).to match_array([["armv7l", false], ['i586', true], ['x86_64', true]])}
       it { is_expected.to redirect_to(action: :index) }
       it { expect(flash[:notice]).to eq("Successfully updated repository") }

--- a/src/api/spec/features/webui/login_spec.rb
+++ b/src/api/spec/features/webui/login_spec.rb
@@ -168,7 +168,7 @@ RSpec.feature "Login", type: :feature, js: true do
     include_context 'setup ldap mock with user mock'
     include_context 'an ldap connection'
 
-    let(:ldap_user) { double(:ldap_user, to_hash: { 'dn' => 'tux', 'sn' => ['John', 'Smith'] }) }
+    let(:ldap_user) { double(:ldap_user, to_hash: { 'dn' => 'tux', 'sn' => %w[John Smith] }) }
 
     before do
       stub_const('CONFIG', CONFIG.merge({

--- a/src/api/spec/helpers/webui/webui_helper_spec.rb
+++ b/src/api/spec/helpers/webui/webui_helper_spec.rb
@@ -211,7 +211,7 @@ RSpec.describe Webui::WebuiHelper do
   end
 
   describe '#is_advanced_tab?' do
-    advanced_tabs = ['prjconf', 'index', 'meta', 'status']
+    advanced_tabs = %w[prjconf index meta status]
     advanced_tabs.each do |action|
       context "@current_action is '#{action}'" do
         before do

--- a/src/api/spec/models/download_repository_spec.rb
+++ b/src/api/spec/models/download_repository_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe DownloadRepository do
     it { is_expected.to validate_presence_of(:repotype) }
     it { is_expected.to validate_presence_of(:repository_id) }
     it { is_expected.to validate_uniqueness_of(:arch).scoped_to(:repository_id) }
-    it { is_expected.to validate_inclusion_of(:repotype).in_array(["rpmmd", "susetags", "deb", "arch", "mdk"]) }
+    it { is_expected.to validate_inclusion_of(:repotype).in_array(%w[rpmmd susetags deb arch mdk]) }
 
     describe "architecture_inclusion validation" do
       subject(:download_repository) { create(:download_repository) }

--- a/src/api/spec/models/kiwi/image_spec.rb
+++ b/src/api/spec/models/kiwi/image_spec.rb
@@ -348,26 +348,26 @@ RSpec.describe Kiwi::Image, type: :model, vcr: true do
     context 'with use_project_repositories set' do
       subject { Kiwi::Image.binaries_available(project.name, true, []) }
 
-      it { expect(subject.keys).to match_array(['package1', 'package2', 'package3']) }
-      it { expect(subject['package1']).to match_array(['i586', 'x86_64']) }
+      it { expect(subject.keys).to match_array(%w[package1 package2 package3]) }
+      it { expect(subject['package1']).to match_array(%w[i586 x86_64]) }
       it { expect(subject['package2']).to match_array(['i586']) }
-      it { expect(subject['package3']).to match_array(['i586', 'x86_64']) }
+      it { expect(subject['package3']).to match_array(%w[i586 x86_64]) }
     end
 
     context 'with OBS and "normal" repositories set' do
       subject { Kiwi::Image.binaries_available(project.name, false, ['obs://home:tom/standard', 'http://example.com/']) }
 
-      it { expect(subject.keys).to match_array(['package1', 'package3', 'package4']) }
+      it { expect(subject.keys).to match_array(%w[package1 package3 package4]) }
       it { expect(subject['package1']).to match_array(['x86_64']) }
       it { expect(subject['package3']).to match_array(['i586']) }
-      it { expect(subject['package4']).to match_array(['i586', 'x86_64']) }
+      it { expect(subject['package4']).to match_array(%w[i586 x86_64]) }
     end
   end
 
   describe '#find_binaries_by_name' do
     let(:binaries_available_sample) do
-      { 'apache' => ['i586', 'x86_64'], 'apache2' => ['x86_64'],
-        'appArmor' => ['i586', 'x86_64'], 'bcrypt' => ['x86_64'] }
+      { 'apache' => %w[i586 x86_64], 'apache2' => ['x86_64'],
+        'appArmor' => %w[i586 x86_64], 'bcrypt' => ['x86_64'] }
     end
 
     before do
@@ -378,10 +378,10 @@ RSpec.describe Kiwi::Image, type: :model, vcr: true do
 
     it { expect(subject.find_binaries_by_name('', 'project', [], use_project_repositories: true)).to eq(binaries_available_sample) }
     it do
-      expect(subject.find_binaries_by_name('ap', 'project', [], use_project_repositories: true)).to eq({ 'apache' => ['i586', 'x86_64'],
-        'apache2' => ['x86_64'], 'appArmor' => ['i586', 'x86_64'] })
+      expect(subject.find_binaries_by_name('ap', 'project', [], use_project_repositories: true)).to eq({ 'apache' => %w[i586 x86_64],
+        'apache2' => ['x86_64'], 'appArmor' => %w[i586 x86_64] })
     end
-    it { expect(subject.find_binaries_by_name('app', 'project', [], use_project_repositories: true)).to eq({ 'appArmor' => ['i586', 'x86_64'] }) }
+    it { expect(subject.find_binaries_by_name('app', 'project', [], use_project_repositories: true)).to eq({ 'appArmor' => %w[i586 x86_64] }) }
     it { expect(subject.find_binaries_by_name('b', 'project', [], use_project_repositories: true)).to eq({ 'bcrypt' => ['x86_64'] }) }
     it { expect(subject.find_binaries_by_name('c', 'project', [], use_project_repositories: true)).to be_empty }
   end

--- a/src/api/spec/models/kiwi/repository_spec.rb
+++ b/src/api/spec/models/kiwi/repository_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe Kiwi::Repository, type: :model do
         is_expected.to allow_value('obsrepositories:/').for(:source_path)
       end
 
-      ['dir', 'iso', 'smb', 'this'].each do |protocol|
+      %w[dir iso smb this].each do |protocol|
         it "valid" do
           property_of {
             protocol + '://' + sized(range(1, 199)) { string(/./) }
@@ -41,7 +41,7 @@ RSpec.describe Kiwi::Repository, type: :model do
         end
       end
 
-      ['ftp', 'http', 'https', 'plain'].each do |protocol|
+      %w[ftp http https plain].each do |protocol|
         it "valid" do
           property_of {
             # TODO: improve regular expression to generate the URI
@@ -86,7 +86,7 @@ RSpec.describe Kiwi::Repository, type: :model do
         }
       end
 
-      ['ftp', 'http', 'https', 'plain', 'obs'].each do |protocol|
+      %w[ftp http https plain obs].each do |protocol|
         it "not valid when has `{`" do
           property_of {
             string = sized(range(1, 199)) { string(/[\w]/) }

--- a/src/api/spec/models/package_spec.rb
+++ b/src/api/spec/models/package_spec.rb
@@ -405,7 +405,7 @@ RSpec.describe Package, vcr: true do
       end
 
       it 'returns an array with the dependencies' do
-        expect(result).to eq(['gcc6', 'xz'])
+        expect(result).to eq(%w[gcc6 xz])
       end
     end
 

--- a/src/api/spec/models/project/update_from_xml_command_spec.rb
+++ b/src/api/spec/models/project/update_from_xml_command_spec.rb
@@ -161,7 +161,7 @@ RSpec.describe Project::UpdateFromXmlCommand do
         )
         Project::UpdateFromXmlCommand.new(project).send(:update_repositories, xml_hash, false)
 
-        expect(repository_1.architectures.map(&:name).sort).to eq ["i586", "x86_64"]
+        expect(repository_1.architectures.map(&:name).sort).to eq %w[i586 x86_64]
         expect(repository_1.repository_architectures.where(position: 1).first.architecture.name).to eq "x86_64"
         expect(repository_1.repository_architectures.where(position: 2).first.architecture.name).to eq "i586"
       end

--- a/src/api/spec/models/project_spec.rb
+++ b/src/api/spec/models/project_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe Project, vcr: true do
   describe "validations" do
     it {
       is_expected.to validate_inclusion_of(:kind).
-        in_array(["standard", "maintenance", "maintenance_incident", "maintenance_release"])
+        in_array(%w[standard maintenance maintenance_incident maintenance_release])
     }
     it { is_expected.to validate_length_of(:name).is_at_most(200) }
     it { is_expected.to validate_length_of(:title).is_at_most(250) }

--- a/src/api/spec/models/role_spec.rb
+++ b/src/api/spec/models/role_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe Role do
 
   describe '::hashed' do
     # created by db/seeds.rb
-    let(:existing_role_titles) { ['Admin', 'maintainer', 'bugowner', 'reviewer', 'downloader', 'reader'] }
+    let(:existing_role_titles) { %w[Admin maintainer bugowner reviewer downloader reader] }
 
     it 'returns a hashed version of Role.all with role titles as key' do
       existing_role_titles.each do |title|
@@ -21,7 +21,7 @@ RSpec.describe Role do
   end
 
   describe '::local_roles' do
-    let(:expected_local_roles) { Role.where(title: ['maintainer', 'bugowner', 'reviewer', 'downloader', 'reader']) }
+    let(:expected_local_roles) { Role.where(title: %w[maintainer bugowner reviewer downloader reader]) }
 
     it 'returns an array with all local role instances' do
       expect(Role.local_roles).to match_array(expected_local_roles)
@@ -29,7 +29,7 @@ RSpec.describe Role do
   end
 
   describe '::global_roles' do
-    let(:expected_global_roles) { ['Admin', 'User'] }
+    let(:expected_global_roles) { %w[Admin User] }
 
     it 'returns an array with all global role titles' do
       expect(Role.global_roles).to match_array(expected_global_roles)

--- a/src/api/spec/models/user_ldap_strategy_spec.rb
+++ b/src/api/spec/models/user_ldap_strategy_spec.rb
@@ -321,13 +321,13 @@ RSpec.describe UserLdapStrategy do
         include_context 'setup ldap mock with user mock'
         include_context 'an ldap connection'
         include_context 'mock searching a user' do
-          let(:ldap_user) { double(:ldap_user, to_hash: { 'dn' => 'tux', 'sn' => ['John', 'Smith'] }) }
+          let(:ldap_user) { double(:ldap_user, to_hash: { 'dn' => 'tux', 'sn' => %w[John Smith] }) }
         end
 
         subject! { UserLdapStrategy.find_with_ldap('tux', 'tux_password') }
 
         it 'returns name and username' do
-          is_expected.to eq(['John', 'tux'])
+          is_expected.to eq(%w[John tux])
         end
       end
 
@@ -335,7 +335,7 @@ RSpec.describe UserLdapStrategy do
         include_context 'setup ldap mock with user mock'
         include_context 'an ldap connection'
         include_context 'mock searching a user' do
-          let(:ldap_user) { double(:ldap_user, to_hash: { 'dn' => 'tux', 'sn' => ['John', 'Smith'] }) }
+          let(:ldap_user) { double(:ldap_user, to_hash: { 'dn' => 'tux', 'sn' => %w[John Smith] }) }
         end
 
         before do
@@ -363,7 +363,7 @@ RSpec.describe UserLdapStrategy do
         include_context 'setup ldap mock with user mock'
         include_context 'an ldap connection'
         include_context 'mock searching a user' do
-          let(:ldap_user) { double(:ldap_user, to_hash: { 'dn' => 'tux', 'sn' => ['John', 'Smith'], 'fn' => 'SJ' }) }
+          let(:ldap_user) { double(:ldap_user, to_hash: { 'dn' => 'tux', 'sn' => %w[John Smith], 'fn' => 'SJ' }) }
         end
 
         before do
@@ -375,7 +375,7 @@ RSpec.describe UserLdapStrategy do
         subject! { UserLdapStrategy.find_with_ldap('tux', 'tux_password') }
 
         it 'returns the users ldap_name_attr and username' do
-          is_expected.to eq(['John', 'S'])
+          is_expected.to eq(%w[John S])
         end
       end
 
@@ -387,7 +387,7 @@ RSpec.describe UserLdapStrategy do
         include_context 'setup ldap mock with user mock'
         include_context 'an ldap connection'
         include_context 'mock searching a user' do
-          let(:ldap_user) { double(:ldap_user, to_hash: { 'dn' => 'tux', 'sn' => ['John', 'Smith'] }) }
+          let(:ldap_user) { double(:ldap_user, to_hash: { 'dn' => 'tux', 'sn' => %w[John Smith] }) }
         end
 
         before do
@@ -409,7 +409,7 @@ RSpec.describe UserLdapStrategy do
           UserLdapStrategy.find_with_ldap('tux', 'tux_password')
         end
 
-        it { is_expected.to eq(['John', 'tux']) }
+        it { is_expected.to eq(%w[John tux]) }
       end
     end
   end

--- a/src/api/spec/spec_helper.rb
+++ b/src/api/spec/spec_helper.rb
@@ -75,7 +75,7 @@ RSpec.configure do |config|
   unless ENV['TRAVIS'] || ENV['RPM_BUILD_ROOT']
     # users who tend to run test cases manually and may need to debug travis issues
     calling_user = %x(id -u -n)
-    unless ['adrian', 'mls', 'frontend'].include? calling_user.chomp
+    unless %w[adrian mls frontend].include? calling_user.chomp
       puts "calling user: #{calling_user}"
       config.formatter = 'NyanUnicornFormatter'
     end

--- a/src/api/spec/support/shared_examples/features/flags_tables.rb
+++ b/src/api/spec/support/shared_examples/features/flags_tables.rb
@@ -92,10 +92,10 @@ end
 
 RSpec.shared_examples "tests for sections with flag tables" do
   describe "flags tables" do
-    let(:architectures) { ["i586", "x86_64"] }
+    let(:architectures) { %w[i586 x86_64] }
     let!(:repository) { create(:repository, project: project, architectures: architectures) }
-    let(:arch_rows) { ["Repository", "All"] + architectures }
-    let(:repo_cols) { ["Repository", "All"] + project.repositories.pluck(:name) }
+    let(:arch_rows) { %w[Repository All] + architectures }
+    let(:repo_cols) { %w[Repository All] + project.repositories.pluck(:name) }
 
     before do
       login(user)

--- a/src/api/test/functional/attributes_test.rb
+++ b/src/api/test/functional/attributes_test.rb
@@ -172,7 +172,7 @@ ription</description>
     assert_response :success
     get "/attribute/TEST/Dummy/_meta"
     assert_response :success
-    for i in ['count', 'description', 'default', 'allowed', 'count', 'modifiable_by'] do
+    for i in %w[count description default allowed count modifiable_by] do
       assert_equal(Xmlhash.parse(data)[i], Xmlhash.parse(@response.body)[i])
     end
     login_Iggy

--- a/src/api/test/functional/webui/patchinfo_controller_test.rb
+++ b/src/api/test/functional/webui/patchinfo_controller_test.rb
@@ -135,14 +135,14 @@ class Webui::PatchinfoControllerTest < Webui::IntegrationTest
     fill_in "summary", with: "This is a test for the patchinfo-editor"
     fill_in "description", with: LONG_DESCRIPTION
 
-    ["package", "delete_me"].each do |bin|
+    %w[package delete_me].each do |bin|
       find('select#available_binaries').select(bin)
       click_button("add")
     end
     click_button("Save Patchinfo")
 
     page.must_have_text "Selected binaries:"
-    ["package", "delete_me"].each do |bin|
+    %w[package delete_me].each do |bin|
       page.must_have_text bin
     end
 

--- a/src/api/test/unit/project_test.rb
+++ b/src/api/test/unit/project_test.rb
@@ -12,11 +12,11 @@ class ProjectTest < ActiveSupport::TestCase
 
   def test_maintained_project_names
     project = Project.create(name: "Z")
-    ["A", "B", "C"].each do |project_name|
+    %w[A B C].each do |project_name|
       project.maintained_projects.create(project: Project.create(name: project_name))
     end
 
-    assert_equal ["A", "B", "C"], project.maintained_project_names
+    assert_equal %w[A B C], project.maintained_project_names
   end
 
   def test_flags_inheritance
@@ -287,7 +287,7 @@ class ProjectTest < ActiveSupport::TestCase
     project2.reload
 
     # test if all project flags are default for a new project
-    allflags = ['build', 'publish', 'useforbuild', 'binarydownload', 'access', 'lock', 'debuginfo']
+    allflags = %w[build publish useforbuild binarydownload access lock debuginfo]
     allflags.each do |flagtype|
       project2.get_flags(flagtype).each do |repo|
         repo[1].each do |flag|

--- a/src/api/test/unit/webui/webui_helper_test.rb
+++ b/src/api/test/unit/webui/webui_helper_test.rb
@@ -30,7 +30,7 @@ class Webui::WebuiHelperTest < ActiveSupport::TestCase
   end
 
   def test_elide_two # spec/helpers/webui/webui_helper_spec.rb
-    assert_equal ["aaa", "bbb"], elide_two('aaa', 'bbb')
+    assert_equal %w[aaa bbb], elide_two('aaa', 'bbb')
   end
 
   def test_next_codemirror_uid


### PR DESCRIPTION
This cop can check for array literals made up of word-like strings, that are not using the `%w()` syntax. :bowtie: 