### PR TITLE
[webui] Only show 'new package' hint for submit requests

### DIFF
--- a/src/api/app/helpers/webui/request_helper.rb
+++ b/src/api/app/helpers/webui/request_helper.rb
@@ -10,7 +10,7 @@ module Webui::RequestHelper
   end
 
   def new_or_update_request(row)
-    if row.target_package_id
+    if row.target_package_id || row.request_type != 'submit'
       row.request_type
     else
       "#{row.request_type} <small>(new package)</small>".html_safe

--- a/src/api/spec/helpers/webui/request_helper_spec.rb
+++ b/src/api/spec/helpers/webui/request_helper_spec.rb
@@ -1,21 +1,42 @@
 require 'rails_helper'
 
 RSpec.describe Webui::RequestHelper do
+  let(:target_package) { create(:package) }
+  let(:target_project) { target_package.project }
+  let(:source_package) { create(:package) }
+  let(:source_project) { source_package.project }
 
   describe '#new_or_update' do
-    context 'for a new package' do
-      let(:request) { create(:bs_request) }
-      let(:row) { BsRequest::DataTable::Row .new(request) }
+    context 'for submitting a new package' do
+      let(:bs_request_with_submit_action) do
+        create(:bs_request_with_submit_action,
+               target_project: target_project,
+               target_package: 'does-not-exist-yet',
+               source_project: source_project,
+               source_package: source_package
+              )
+      end
+      let(:row) { BsRequest::DataTable::Row .new(bs_request_with_submit_action) }
 
-      it { expect(new_or_update_request(row)).to eq("BsRequestAction <small>(new package)</small>") }
+      it { expect(new_or_update_request(row)).to eq("submit <small>(new package)</small>") }
       it { expect(new_or_update_request(row)).to be_a(ActiveSupport::SafeBuffer) }
     end
 
-    context 'for an existing package' do
-      let(:target_package) { create(:package) }
-      let(:target_project) { target_package.project }
-      let(:source_package) { create(:package) }
-      let(:source_project) { source_package.project }
+    context 'for releasing a package' do
+      let(:bs_request_with_maintenance_release_action) do
+        create(:bs_request_with_maintenance_release_action,
+               target_project: target_project,
+               target_package: target_package,
+               source_project: source_project,
+               source_package: source_package
+              )
+      end
+      let(:row) { BsRequest::DataTable::Row .new(bs_request_with_maintenance_release_action) }
+
+      it { expect(new_or_update_request(row)).to eq("release") }
+    end
+
+    context 'for submitting an existing package' do
       let(:bs_request_with_submit_action) do
         create(:bs_request_with_submit_action,
                target_project: target_project,


### PR DESCRIPTION
Because e.g. maintenance release requests are always new packages.

This was requested by @Ismail in https://github.com/openSUSE/open-build-service/pull/3960