### PR TITLE
[dist] Change name of docker container to `frontend-base`

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,7 +21,7 @@ services:
       - backend
     command: /obs/contrib/start_development_worker
   frontend:
-    image: openbuildservice/frontend
+    image: openbuildservice/frontend-base
     build:
       context: .
     volumes:


### PR DESCRIPTION
The name was changed for some reason. This change is required in order to pull the image again.

@hennevogel please have a look.