### PR TITLE
[webui] update dependency `airbrake-ruby` to version 2.4.2

### DIFF
--- a/src/api/Gemfile.lock
+++ b/src/api/Gemfile.lock
@@ -50,7 +50,7 @@ GEM
       public_suffix (>= 2.0.2, < 4.0)
     airbrake (7.0.3)
       airbrake-ruby (~> 2.4)
-    airbrake-ruby (2.4.1)
+    airbrake-ruby (2.4.2)
     amq-protocol (2.2.0)
     annotate (2.7.2)
       activerecord (>= 3.2, < 6.0)


### PR DESCRIPTION
There is no `airbrake-ruby` 2.4.1 version in `devel:languages:ruby:extensions`. It was directly updated from `2.4.0` to `2.4.2` because `2.4.1` was released on the same day like `2.4.2`. Thus our packages don't build anymore and since `airbrake` requires `airbrake-ruby` to be greater than `2.4`, we can update it manually to `2.4.2` because it's still working. I just verified it.