### PR TITLE
[webui] Make group request datatables work

### DIFF
--- a/src/api/config/routes.rb
+++ b/src/api/config/routes.rb
@@ -354,7 +354,7 @@ OBSApi::Application.routes.draw do
     end
 
     controller 'webui/groups/bs_requests' do
-      get 'groups/(:title)/requests' => :index, as: 'group_requests'
+      get 'groups/(:title)/requests' => :index, constraints: {:title => /[^\/]*/}, as: 'group_requests'
     end
 
     controller 'webui/users/rss_tokens' do


### PR DESCRIPTION
for groups with a dot in the title.
Fix #4021.