### PR TITLE
[frontend] Fix crash when configuring exchange options for RabbitMQ

### DIFF
--- a/src/api/lib/rabbitmq_bus.rb
+++ b/src/api/lib/rabbitmq_bus.rb
@@ -3,18 +3,18 @@ class RabbitmqBus
     return unless CONFIG['amqp_options']
     start_connection
 
-    queue = $rabbitmq_channel.queue(event_queue_name, CONFIG['amqp_queue_options'].try(:with_indifferent_access) || {})
+    queue = $rabbitmq_channel.queue(event_queue_name, CONFIG['amqp_queue_options'].try(:symbolize_keys) || {})
     $rabbitmq_exchange.publish(event_payload, routing_key: queue.name)
   end
 
   # Start one connection, channel and exchange per rails process
   # and reuse them
   def self.start_connection
-    $rabbitmq_conn ||= Bunny.new(CONFIG['amqp_options'].with_indifferent_access)
+    $rabbitmq_conn ||= Bunny.new(CONFIG['amqp_options'].try(:symbolize_keys))
     $rabbitmq_conn.start
     $rabbitmq_channel ||= $rabbitmq_conn.create_channel
     $rabbitmq_exchange = if CONFIG['amqp_exchange_name']
-      $rabbitmq_channel.exchange(CONFIG['amqp_exchange_name'], CONFIG['amqp_exchange_options'].try(:with_indifferent_access) || {})
+      $rabbitmq_channel.exchange(CONFIG['amqp_exchange_name'], CONFIG['amqp_exchange_options'].try(:symbolize_keys) || {})
     else
       $rabbitmq_channel.default_exchange
     end


### PR DESCRIPTION
Bunny, the library we use for using rabbitmq, only accepts hash keys
that are symbols. Any key that is not a symbol doesn't get applied
by bunny.

OBS was using with_indifferent_access for any hash passed to bunny
to ensure that the bunny recognizes the hash as 'symbolized'.
However with_indifferent_access creates and returns an
ActiveSupport::HashWithIndifferentAccess instance, which isn't something
bunny knows how to deal with. Therefore it still failed to
apply the options.

The solution is to use the symbolize_keys method to ensure that all
hash keys are symbols, before passing them to bunny.

Kudos goes to @coolo for debugging this.