### PR TITLE
[webui][api] Update Event classes to publish only once.

### DIFF
--- a/src/api/app/models/event/build.rb
+++ b/src/api/app/models/event/build.rb
@@ -22,7 +22,7 @@ end
 
 class Event::BuildSuccess < Event::Build
   self.description = 'Package has succeeded building'
-  after_commit :send_to_bus
+  after_create_commit :send_to_bus
 
   def self.message_bus_queue
     "#{Configuration.amqp_namespace}.package.build_success"
@@ -34,7 +34,7 @@ class Event::BuildFail < Event::Build
 
   self.description = 'Package has failed to build'
   receiver_roles :maintainer, :bugowner, :reader, :watcher
-  after_commit :send_to_bus
+  after_create_commit :send_to_bus
 
   def self.message_bus_queue
     "#{Configuration.amqp_namespace}.package.build_fail"
@@ -81,7 +81,7 @@ end
 
 class Event::BuildUnchanged < Event::Build
   self.description = 'Package has succeeded building with unchanged result'
-  after_commit :send_to_bus
+  after_create_commit :send_to_bus
 
   def self.message_bus_queue
     "#{Configuration.amqp_namespace}.package.build_unchanged"

--- a/src/api/app/models/event/comment.rb
+++ b/src/api/app/models/event/comment.rb
@@ -32,7 +32,7 @@ end
 class Event::CommentForProject < ::Event::Project
   include CommentEvent
   receiver_roles :maintainer, :watcher
-  after_commit :send_to_bus
+  after_create_commit :send_to_bus
 
   def self.message_bus_queue
     "#{Configuration.amqp_namespace}.project.comment"
@@ -48,7 +48,7 @@ end
 class Event::CommentForPackage < ::Event::Package
   include CommentEvent
   receiver_roles :maintainer, :watcher
-  after_commit :send_to_bus
+  after_create_commit :send_to_bus
 
   def self.message_bus_queue
     "#{Configuration.amqp_namespace}.package.comment"
@@ -66,7 +66,7 @@ class Event::CommentForRequest < ::Event::Request
   self.description = 'New comment for request created'
   payload_keys :request_number
   receiver_roles :source_maintainer, :target_maintainer, :creator, :reviewer, :source_watcher, :target_watcher
-  after_commit :send_to_bus
+  after_create_commit :send_to_bus
 
   def self.message_bus_queue
     "#{Configuration.amqp_namespace}.request.comment"

--- a/src/api/app/models/event/package.rb
+++ b/src/api/app/models/event/package.rb
@@ -6,7 +6,7 @@ module Event
 
   class CreatePackage < Package
     self.description = 'Package was created'
-    after_commit :send_to_bus
+    after_create_commit :send_to_bus
 
     def self.message_bus_queue
       "#{Configuration.amqp_namespace}.package.create"
@@ -19,7 +19,7 @@ module Event
 
   class UpdatePackage < Package
     self.description = 'Package meta data was updated'
-    after_commit :send_to_bus
+    after_create_commit :send_to_bus
 
     def self.message_bus_queue
       "#{Configuration.amqp_namespace}.package.update"
@@ -29,7 +29,7 @@ module Event
   class UndeletePackage < Package
     self.description = 'Package was undeleted'
     payload_keys :comment
-    after_commit :send_to_bus
+    after_create_commit :send_to_bus
 
     def self.message_bus_queue
       "#{Configuration.amqp_namespace}.package.undelete"
@@ -45,7 +45,7 @@ module Event
   class DeletePackage < Package
     self.description = 'Package was deleted'
     payload_keys :comment, :requestid
-    after_commit :send_to_bus
+    after_create_commit :send_to_bus
 
     def self.message_bus_queue
       "#{Configuration.amqp_namespace}.package.delete"
@@ -60,7 +60,7 @@ module Event
   class BranchCommand < Package
     self.description = 'Package was branched'
     payload_keys :targetproject, :targetpackage, :user
-    after_commit :send_to_bus
+    after_create_commit :send_to_bus
 
     def self.message_bus_queue
       "#{Configuration.amqp_namespace}.package.branch"
@@ -74,7 +74,7 @@ module Event
   class VersionChange < Package
     self.description = 'Package has changed its version'
     payload_keys :comment, :requestid, :files, :rev, :newversion, :user, :oldversion
-    after_commit :send_to_bus
+    after_create_commit :send_to_bus
 
     def self.message_bus_queue
       "#{Configuration.amqp_namespace}.package.version_change"
@@ -92,7 +92,7 @@ module Event
     payload_keys :project, :package, :comment, :user, :files, :rev, :requestid
 
     create_jobs :update_backend_infos_job
-    after_commit :send_to_bus
+    after_create_commit :send_to_bus
 
     def self.message_bus_queue
       "#{Configuration.amqp_namespace}.package.commit"
@@ -112,7 +112,7 @@ module Event
   class Upload < Package
     self.description = 'Package sources were uploaded'
     payload_keys :project, :package, :comment, :filename, :requestid, :target, :user
-    after_commit :send_to_bus
+    after_create_commit :send_to_bus
 
     def self.message_bus_queue
       "#{Configuration.amqp_namespace}.package.upload"
@@ -124,7 +124,7 @@ module Event
     payload_keys :comment, :package, :project, :rev, :user, :requestid
     receiver_roles :maintainer, :bugowner
     create_jobs :update_backend_infos_job
-    after_commit :send_to_bus
+    after_create_commit :send_to_bus
 
     def self.message_bus_queue
       "#{Configuration.amqp_namespace}.package.service_success"
@@ -146,7 +146,7 @@ module Event
     payload_keys :comment, :error, :package, :project, :rev, :user, :requestid
     receiver_roles :maintainer, :bugowner
     create_jobs :update_backend_infos_job
-    after_commit :send_to_bus
+    after_create_commit :send_to_bus
 
     def self.message_bus_queue
       "#{Configuration.amqp_namespace}.package.service_fail"

--- a/src/api/app/models/event/packtrack.rb
+++ b/src/api/app/models/event/packtrack.rb
@@ -4,7 +4,7 @@ class Event::Packtrack < Event::Base
 
   # for package tracking in first place
   create_jobs :update_released_binaries_job
-  after_commit :send_to_bus
+  after_create_commit :send_to_bus
 
   def self.message_bus_queue
     "#{Configuration.amqp_namespace}.repo.packtrack"

--- a/src/api/app/models/event/project.rb
+++ b/src/api/app/models/event/project.rb
@@ -7,7 +7,7 @@ module Event
   class CreateProject < Project
     self.description = 'Project is created'
     payload_keys :sender
-    after_commit :send_to_bus
+    after_create_commit :send_to_bus
 
     def self.message_bus_queue
       "#{Configuration.amqp_namespace}.project.create"
@@ -21,7 +21,7 @@ module Event
   class UpdateProjectConfig < Project
     self.description = 'Project _config was updated'
     payload_keys :sender, :files, :comment
-    after_commit :send_to_bus
+    after_create_commit :send_to_bus
 
     def self.message_bus_queue
       "#{Configuration.amqp_namespace}.project.update_project_conf"
@@ -31,7 +31,7 @@ module Event
   class UndeleteProject < Project
     self.description = 'Project was undeleted'
     payload_keys :comment, :sender
-    after_commit :send_to_bus
+    after_create_commit :send_to_bus
 
     def self.message_bus_queue
       "#{Configuration.amqp_namespace}.project.undelete"
@@ -41,7 +41,7 @@ module Event
   class UpdateProject < Project
     self.description = 'Project meta was updated'
     payload_keys :sender
-    after_commit :send_to_bus
+    after_create_commit :send_to_bus
 
     def self.message_bus_queue
       "#{Configuration.amqp_namespace}.project.update"
@@ -51,7 +51,7 @@ module Event
   class DeleteProject < Project
     self.description = 'Project was deleted'
     payload_keys :comment, :requestid, :sender
-    after_commit :send_to_bus
+    after_create_commit :send_to_bus
 
     def self.message_bus_queue
       "#{Configuration.amqp_namespace}.project.delete"

--- a/src/api/app/models/event/repo_publish_state.rb
+++ b/src/api/app/models/event/repo_publish_state.rb
@@ -1,7 +1,7 @@
 class Event::RepoPublishState < Event::Base
   self.description = 'Publish State of Repository has changed'
   payload_keys :project, :repo, :state
-  after_commit :send_to_bus
+  after_create_commit :send_to_bus
 
   def self.message_bus_queue
     "#{Configuration.amqp_namespace}.repo.publish_state"

--- a/src/api/app/models/event/repo_published.rb
+++ b/src/api/app/models/event/repo_published.rb
@@ -1,7 +1,7 @@
 class Event::RepoPublished < Event::Base
   self.description = 'Repository was published'
   payload_keys :project, :repo
-  after_commit :send_to_bus
+  after_create_commit :send_to_bus
 
   def self.message_bus_queue
     "#{Configuration.amqp_namespace}.repo.published"

--- a/src/api/app/models/event/request.rb
+++ b/src/api/app/models/event/request.rb
@@ -139,7 +139,7 @@ end
 
 class Event::RequestChange < Event::Request
   self.description = 'Request XML was updated (admin only)'
-  after_commit :send_to_bus
+  after_create_commit :send_to_bus
 
   def self.message_bus_queue
     "#{Configuration.amqp_namespace}.request.change"
@@ -149,7 +149,7 @@ end
 class Event::RequestCreate < Event::Request
   self.description = 'Request created'
   receiver_roles :source_maintainer, :target_maintainer, :source_watcher, :target_watcher
-  after_commit :send_to_bus
+  after_create_commit :send_to_bus
 
   def self.message_bus_queue
     "#{Configuration.amqp_namespace}.request.create"
@@ -174,7 +174,7 @@ end
 
 class Event::RequestDelete < Event::Request
   self.description = 'Request was deleted (admin only)'
-  after_commit :send_to_bus
+  after_create_commit :send_to_bus
 
   def self.message_bus_queue
     "#{Configuration.amqp_namespace}.request.delete"
@@ -185,7 +185,7 @@ class Event::RequestStatechange < Event::Request
   self.description = 'Request state was changed'
   payload_keys :oldstate
   receiver_roles :source_maintainer, :target_maintainer, :creator, :reviewer, :source_watcher, :target_watcher
-  after_commit :send_to_bus
+  after_create_commit :send_to_bus
 
   def self.message_bus_queue
     "#{Configuration.amqp_namespace}.request.state_change"
@@ -201,7 +201,7 @@ class Event::ReviewWanted < Event::Request
 
   payload_keys :reviewers, :by_user, :by_group, :by_project, :by_package
   receiver_roles :reviewer
-  after_commit :send_to_bus
+  after_create_commit :send_to_bus
 
   def self.message_bus_queue
     "#{Configuration.amqp_namespace}.request.review_wanted"


### PR DESCRIPTION
The Event should only be published to the rabbitmq bus once - after
it is created. Before it was published everytime the Event was
created or updated.

Fixes https://github.com/openSUSE/open-build-service/issues/4028