### PR TITLE
Minor Kiwi Editor workflow improvements

### DIFF
--- a/src/api/app/controllers/webui/package_controller.rb
+++ b/src/api/app/controllers/webui/package_controller.rb
@@ -557,8 +557,14 @@ class Webui::PackageController < Webui::WebuiController
                                 targetproject: created_project_name, targetpackage: created_package_name,
                                 user: User.current.login)
 
-    flash[:notice] = 'Successfully branched package'
-    redirect_to(package_show_path(project: created_project_name, package: created_package_name))
+    branched_package_object = Package.find_by_project_and_name(created_project_name, created_package_name)
+
+    if request.env["HTTP_REFERER"] == image_templates_url && branched_package_object.kiwi_image?
+      redirect_to(import_kiwi_image_path(branched_package_object.id))
+    else
+      flash[:notice] = 'Successfully branched package'
+      redirect_to(package_show_path(project: created_project_name, package: created_package_name))
+    end
 
   rescue BranchPackage::DoubleBranchPackageError => exception
     flash[:notice] = 'You have already branched this package'

--- a/src/api/app/helpers/webui/kiwi/image_helper.rb
+++ b/src/api/app/helpers/webui/kiwi/image_helper.rb
@@ -3,10 +3,10 @@ module Webui::Kiwi::ImageHelper
 
   def kiwi_image_breadcrumb(kiwi_image, *args)
     @project = kiwi_image.package.try(:project)
+    @package = kiwi_image.package
     return unless @project
 
-    args.insert(0, link_to_if(params['action'] != 'show', 'Image',
-                              kiwi_image_path(id: kiwi_image)))
+    args.insert(0, link_to(@package, package_show_path(project: @project, package: @package)))
     project_bread_crumb( *args )
   end
 end

--- a/src/api/app/views/webui/kiwi/_tabs.html.erb
+++ b/src/api/app/views/webui/kiwi/_tabs.html.erb
@@ -10,17 +10,7 @@
 
 <div class="box-header header-tabs" id="package_tabs">
   <ul>
-    <%= tab 'kiwi', 'Kiwi', controller: 'kiwi/images', action: 'show', selected: true %>
-    <% if @image.package.name == "patchinfo" %>
-      <%= tab 'details', 'Details', controller: '/webui/patchinfo', action: 'show' %>
-    <% end %>
-    <%= tab 'overview', 'Overview', controller: '/webui/package', action: 'show', package: @image.package %>
-    <% unless @spider_bot %>
-      <%= tab 'repositories', 'Repositories', controller: '/webui/repositories', action: 'index' %>
-      <%= tab 'revisions', 'Revisions', :controller => '/webui/package', :action => 'revisions', package: @image.package %>
-      <%= tab 'requests', "Requests", :controller => '/webui/package', :action => 'requests', package: @image.package %>
-      <%= tab 'users', 'Users', :controller => '/webui/package', :action => 'users', package: @image.package %>
-    <% end %>
+    <%= tab 'kiwi', 'Image Editor', controller: 'kiwi/images', action: 'show', selected: true %>
     <% if is_advanced_tab? %>
       <%= content_for :ready_function do %>
         $("#advanced_tabs").show();
@@ -32,6 +22,16 @@
   <% unless @spider_bot %>
     <div id="advanced_tabs" class="hidden">
       <ul>
+        <%= tab 'overview', 'Overview', controller: '/webui/package', action: 'show', package: @image.package %>
+        <% if @image.package.name == "patchinfo" %>
+          <%= tab 'details', 'Details', controller: '/webui/patchinfo', action: 'show' %>
+        <% end %>
+        <% unless @spider_bot %>
+          <%= tab 'repositories', 'Repositories', controller: '/webui/repositories', action: 'index' %>
+          <%= tab 'revisions', 'Revisions', :controller => '/webui/package', :action => 'revisions', package: @image.package %>
+          <%= tab 'requests', "Requests", :controller => '/webui/package', :action => 'requests', package: @image.package %>
+          <%= tab 'users', 'Users', :controller => '/webui/package', :action => 'users', package: @image.package %>
+        <% end %>
         <%= tab 'attributes', 'Attributes', controller: '/webui/attribute', :package => @image.package, :project => @image.package.project , :action => 'index' %>
         <%= tab 'meta', 'Meta', :controller => '/webui/package', :action => 'meta', package: @image.package %>
       </ul>

--- a/src/api/spec/cassettes/ImageTemplates/branching/branch_image_template.yml
+++ b/src/api/spec/cassettes/ImageTemplates/branching/branch_image_template.yml
@@ -1870,4 +1870,39 @@ http_interactions:
         </status>
     http_version: 
   recorded_at: Tue, 10 Oct 2017 12:36:11 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:tom:branches:my_project/custom_name
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 404
+      message: project 'home tom branches my_project' does not exist
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '184'
+    body:
+      encoding: UTF-8
+      string: |
+        <status code="404">
+          <summary>project 'home:tom:branches:my_project' does not exist</summary>
+          <details>404 project 'home:tom:branches:my_project' does not exist</details>
+        </status>
+    http_version: 
+  recorded_at: Thu, 19 Oct 2017 08:13:54 GMT
 recorded_with: VCR 3.0.3

--- a/src/api/spec/features/webui/image_templates_spec.rb
+++ b/src/api/spec/features/webui/image_templates_spec.rb
@@ -32,6 +32,7 @@ RSpec.feature "ImageTemplates", type: :feature, js: true do
       fill_in 'target_package', with: "custom_name"
 
       click_button("Create appliance")
+      find('#package_tabs')
       expect(page).to have_text("Successfully branched package")
       expect(page).to have_text("home:tom:branches:my_project > custom_name")
     end


### PR DESCRIPTION
After selecting an image at the templates page, redirect to the kiwi editor, only if we are dealing with a kiwi image.

In tabs, keep "Kiwi" as first option in tabs, as "Image Editor", and put the other tabs in "Advanced".

Fixed breadcrumbs, now it shows the Package link