### PR TITLE
[frontend] Fix deletion of groups_users

### DIFF
--- a/src/api/app/models/group.rb
+++ b/src/api/app/models/group.rb
@@ -6,6 +6,7 @@ require_dependency 'api_exception'
 #
 class Group < ApplicationRecord
   has_many :groups_users, inverse_of: :group, dependent: :destroy
+  has_many :users, -> { distinct }, through: :groups_users
   has_many :group_maintainers, inverse_of: :group, dependent: :destroy
   has_many :relationships, dependent: :destroy, inverse_of: :group
   has_many :event_subscriptions, dependent: :destroy, inverse_of: :group
@@ -25,8 +26,6 @@ class Group < ApplicationRecord
   validates :title,
             uniqueness: { message: 'is the name of an already existing group.' }
 
-  # groups have a n:m relation to user
-  has_and_belongs_to_many :users, -> { distinct }
   # groups have a n:m relation to groups
   has_and_belongs_to_many :roles, -> { distinct }
 

--- a/src/api/app/models/groups_user.rb
+++ b/src/api/app/models/groups_user.rb
@@ -19,7 +19,7 @@ end
 #
 # Table name: groups_users
 #
-#  group_id   :integer          default(0), indexed => [user_id]
+#  group_id   :integer          default(0), not null, indexed => [user_id]
 #  user_id    :integer          default(0), not null, indexed => [group_id], indexed
 #  created_at :datetime
 #  email      :boolean          default(TRUE)

--- a/src/api/db/migrate/20171102110929_disallow_null_for_group_id_in_groups_users.rb
+++ b/src/api/db/migrate/20171102110929_disallow_null_for_group_id_in_groups_users.rb
@@ -1,0 +1,11 @@
+class DisallowNullForGroupIdInGroupsUsers < ActiveRecord::Migration[5.1]
+  def up
+    # Remove all dangling groups users that got created since 18680d611347d312
+    GroupsUser.where(group_id: nil).destroy_all
+    change_column :groups_users, :group_id, :integer, null: false, default: 0, before: :user_id
+  end
+
+  def down
+    change_column :groups_users, :group_id, :integer, null: true, default: 0, before: :user_id
+  end
+end

--- a/src/api/db/structure.sql
+++ b/src/api/db/structure.sql
@@ -374,11 +374,6 @@ CREATE TABLE `configurations` (
   PRIMARY KEY (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin;
 
-CREATE TABLE `data_migrations` (
-  `version` varchar(255) NOT NULL,
-  UNIQUE KEY `unique_data_migrations` (`version`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
-
 CREATE TABLE `delayed_jobs` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `priority` int(11) DEFAULT '0',
@@ -528,7 +523,7 @@ CREATE TABLE `groups_roles` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 CREATE TABLE `groups_users` (
-  `group_id` int(11) DEFAULT '0',
+  `group_id` int(11) NOT NULL DEFAULT '0',
   `user_id` int(11) NOT NULL DEFAULT '0',
   `created_at` datetime DEFAULT NULL,
   `email` tinyint(1) DEFAULT '1',
@@ -1271,6 +1266,7 @@ INSERT INTO `schema_migrations` (version) VALUES
 ('20170925060940'),
 ('20171011125520'),
 ('20171013103921'),
-('20171019151800');
+('20171019151800'),
+('20171102110929');
 
 

--- a/src/api/spec/controllers/group_controller_spec.rb
+++ b/src/api/spec/controllers/group_controller_spec.rb
@@ -6,7 +6,6 @@ require 'rails_helper'
 
 RSpec.describe GroupController, vcr: false do
   let(:admin_user) { create(:admin_user) }
-  let(:group) { create(:group) }
 
   before do
     login admin_user
@@ -24,10 +23,13 @@ RSpec.describe GroupController, vcr: false do
 
       it 'deletes the record' do
         expect(Group.find_by(id: group.id)).to be_nil
+        expect(GroupsUser.where(group_id: group.id)).not_to exist
       end
     end
 
     context 'group without users' do
+      let(:group) { create(:group) }
+
       it_behaves_like 'successful group deletion'
     end
 


### PR DESCRIPTION
When deleting a group, we also want the related groups_user to be destroyed.
That's reflected with a 'dependent: :destroy'.

In PR #3393 it was already reported that this was not working and destroying a
group that has associated users (and groups_users), would cause a 500.

With 18680d611347d312142 the 500 error was solved, but the underlying
problem (not properly deleting groups users) persisted.

The cause of this issue was that the group model defined the n-to-m
relation to groups_users twice. Once via a has_many relation and once
via a has_and_belongs_to_many.

This doesn't seem to be valid, nor does it make any sense, and it caused
rails to create following SQL calls when a_group.destroy was called:
  SQL (0.6ms)  UPDATE `groups_users` SET `groups_users`.`group_id` = NULL WHERE `groups_users`.`group_id` = 1
  SQL (0.4ms)  DELETE FROM `groups_users` WHERE `groups_users`.`group_id` = 1

As you can see the second SQL query, that would delete the groups user, is
ineffective due to the first one.

By dropping one of the two n-to-m relations, we prevent Rails from
creating bogus SQL queries and thus fix the issue.