### PR TITLE
[api][webui] Fix Event#watchers when the project is not found.

### DIFF
--- a/src/api/app/models/event/base.rb
+++ b/src/api/app/models/event/base.rb
@@ -253,6 +253,8 @@ module Event
 
     def watchers
       project = ::Project.find_by_name(payload['project'])
+      return [] if project.blank?
+
       project.watched_projects.map(&:user)
     end
 


### PR DESCRIPTION
If the project in the events payload doesnt exist then this method raises
an error. This changes the method to fail silently so SendEventEmails
can continue.