### PR TITLE
Add Addressable for encoding Backend URIs

### DIFF
--- a/src/api/Gemfile
+++ b/src/api/Gemfile
@@ -70,6 +70,8 @@ gem "gssapi", require: false
 gem 'bunny'
 # for making changes to existing data
 gem 'data_migrate'
+# for URI encoding
+gem 'addressable'
 
 group :development, :production do
   # to have the delayed job daemon

--- a/src/api/Gemfile.lock
+++ b/src/api/Gemfile.lock
@@ -414,6 +414,7 @@ DEPENDENCIES
   activemodel-serializers-xml
   acts_as_list
   acts_as_tree
+  addressable
   airbrake
   annotate
   bcrypt

--- a/src/api/lib/backend/connection_helper.rb
+++ b/src/api/lib/backend/connection_helper.rb
@@ -108,15 +108,13 @@ module Backend
     end
 
     def calculate_endpoint(endpoint)
-      return endpoint if endpoint.is_a?(String)
-      template = endpoint.shift
-      values = endpoint.map { |x| CGI.escape(x.to_s) }
-      placeholders = template.scan(/(:\w+)/).flatten
-      raise "Endpoit not valid: different number of placeholders and values" if values.size != placeholders.size
-      placeholders.each_with_index do |placeholder, index|
-        template.gsub!(placeholder, values[index])
+      if endpoint.is_a?(String)
+        url_base = endpoint
+      else
+        template = endpoint.shift
+        url_base = template.gsub(/(:\w+)/, '%s') % endpoint
       end
-      template
+      Addressable::URI.parse(url_base).normalize.to_s
     end
   end
 end

--- a/src/api/spec/lib/backend/connection_helper_spec.rb
+++ b/src/api/spec/lib/backend/connection_helper_spec.rb
@@ -1,0 +1,35 @@
+require 'rails_helper'
+
+RSpec.describe Backend::ConnectionHelper do
+  let(:backend_api_fake_class) do
+    extended_class = double("Fake Class with ParsePackageDiff")
+    extended_class.extend(Backend::ConnectionHelper)
+    extended_class
+  end
+
+  context '#calculate_endpoint' do
+    subject { backend_api_fake_class }
+
+    context 'with a single string' do
+      it { expect(subject.send(:calculate_endpoint, 'single_string')).to eq('single_string')}
+    end
+
+    context 'with a template' do
+      it { expect(subject.send(:calculate_endpoint, ['string_in_array'])).to eq('string_in_array')}
+      it { expect(subject.send(:calculate_endpoint, ['/build/:param', 'my_param'])).to eq('/build/my_param')}
+      it { expect(subject.send(:calculate_endpoint, ['/build/:param', 'my param'])).to eq('/build/my%20param')}
+      it { expect(subject.send(:calculate_endpoint, ['/build/:param', 'my/param'])).to eq('/build/my/param')}
+      it { expect(subject.send(:calculate_endpoint, ['/build/:param', 'my&param'])).to eq('/build/my&param')}
+      it { expect(subject.send(:calculate_endpoint, ['/build/:param', 'my?param'])).to eq('/build/my?param')}
+      it { expect(subject.send(:calculate_endpoint, ['/build/:param', 'my:param'])).to eq('/build/my:param')}
+      it { expect(subject.send(:calculate_endpoint, ['/build/:param', 'my#param'])).to eq('/build/my#param')}
+      it { expect(subject.send(:calculate_endpoint, ['/build/:param1/:param2', 'my_param', 'my_2nd_param'])).to eq('/build/my_param/my_2nd_param')}
+      it { expect(subject.send(:calculate_endpoint, ['/build/:param1/:param2', 'my_param', 'my_2nd_param'])).to eq('/build/my_param/my_2nd_param')}
+      it { expect(subject.send(:calculate_endpoint, ['/build/:param1/:param2', 'home:param2', 'blah'])).to eq('/build/home:param2/blah')}
+    end
+
+    context 'with a wrong formed template' do
+      it { expect{subject.send(:calculate_endpoint, ['/build/:param'])}.to raise_error(ArgumentError, 'too few arguments')}
+    end
+  end
+end


### PR DESCRIPTION
Use the Addressable gem for encoding properly the URI base (not the query part). 

Before it was encoded using `CGI.encode` that created some issues with repositoriy names that have blank spaces inside.