### PR TITLE
[ci] Update migration test to use with_data option.

### DIFF
--- a/src/api/script/api_test_in_spec.sh
+++ b/src/api/script/api_test_in_spec.sh
@@ -67,7 +67,7 @@ export RAILS_ENV=development
 bundle.ruby2.4 exec rake.ruby2.4 db:create || exit 1
 mv db/structure.sql db/structure.sql.git
 xzcat test/dump_2.5.sql.xz | mysql  -u root --socket=$MYSQL_SOCKET
-bundle.ruby2.4 exec rake.ruby2.4 db:migrate db:structure:dump db:drop || exit 1
+bundle.ruby2.4 exec rake.ruby2.4 db:migrate:with_data db:structure:dump db:drop || exit 1
 ./script/compare_structure_sql.sh db/structure.sql.git db/structure.sql || exit 1
 
 # entire test suite


### PR DESCRIPTION
The migration test needs to run `rake db:migrate:with_data` so that it also creates a data_migrations table.