### PR TITLE
[api] make package release atomic

### DIFF
--- a/src/api/app/helpers/maintenance_helper.rb
+++ b/src/api/app/helpers/maintenance_helper.rb
@@ -50,6 +50,8 @@ module MaintenanceHelper
       target_project = target
     end
     target_project.check_write_access!
+    # lock the scheduler
+    target_project.suspend_scheduler
 
     if source_package.name.starts_with?("_product:") && target_project.packages.where(name: "_product").count > 0
       # a master _product container exists, so we need to copy all sources
@@ -79,6 +81,9 @@ module MaintenanceHelper
         # patchinfos stay unpublished, it is anyway too late to test them now ...
       end
     end
+
+    # release the scheduler lock
+    target_project.resume_scheduler
 
     u_ids
   end

--- a/src/api/app/models/project.rb
+++ b/src/api/app/models/project.rb
@@ -1417,6 +1417,15 @@ class Project < ApplicationRecord
     Backend::Connection.post "/build/#{URI.escape(name)}?cmd=wipe"
   end
 
+  # lock the project for the scheduler for atomic change when using multiple operations
+  def suspend_scheduler
+    Backend::Connection.post "/build/#{URI.escape(name)}?cmd=suspendproject"
+  end
+
+  def resume_scheduler
+    Backend::Connection.post "/build/#{URI.escape(name)}?cmd=resumeproject"
+  end
+
   def build_succeeded?(repository = nil)
     states = {}
     repository_states = {}

--- a/src/api/app/models/project.rb
+++ b/src/api/app/models/project.rb
@@ -1403,6 +1403,15 @@ class Project < ApplicationRecord
     store(comment: "Request got revoked", request: request, lowprio: 1)
   end
 
+  # lock the project for the scheduler for atomic change when using multiple operations
+  def suspend_scheduler
+    Backend::Api::Build::Project.suspend_scheduler(name)
+  end
+
+  def resume_scheduler
+    Backend::Api::Build::Project.resume_scheduler(name)
+  end
+
   def reopen_release_targets
     repositories.each do |repo|
       repo.release_targets.each do |releasetarget|
@@ -1414,16 +1423,7 @@ class Project < ApplicationRecord
 
     return unless repositories.count > 0
     # ensure higher build numbers for re-release
-    Backend::Connection.post "/build/#{URI.escape(name)}?cmd=wipe"
-  end
-
-  # lock the project for the scheduler for atomic change when using multiple operations
-  def suspend_scheduler
-    Backend::Connection.post "/build/#{URI.escape(name)}?cmd=suspendproject"
-  end
-
-  def resume_scheduler
-    Backend::Connection.post "/build/#{URI.escape(name)}?cmd=resumeproject"
+    Backend::Api::Build::Project.wipe_binaries(name)
   end
 
   def build_succeeded?(repository = nil)

--- a/src/api/lib/backend/api/build/project.rb
+++ b/src/api/lib/backend/api/build/project.rb
@@ -1,0 +1,23 @@
+module Backend
+  module Api
+    module Build
+      # Class that connect to endpoints related to projects
+      class Project
+        extend Backend::ConnectionHelper
+
+        # lock the project for the scheduler for atomic change when using multiple operations
+        def self.suspend_scheduler(project_name)
+          post(["/build/:project", project_name], params: { cmd: :suspendproject })
+        end
+
+        def self.resume_scheduler(project_name)
+          post(["/build/:project", project_name], params: { cmd: :resumeproject })
+        end
+
+        def self.wipe_binaries(project_name)
+          post(["/build/:project", project_name], params: { cmd: :wipe })
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
The real problem behinds coolos publisher penalty issue ....

No test case here, since the behaviour could be only tested in backend. The basic release test is enough as does-not-crash test.