### PR TITLE
[ci] allow [contrib] in commit message

### DIFF
--- a/dist/git-cop_configuration.yml
+++ b/dist/git-cop_configuration.yml
@@ -56,6 +56,6 @@
     #   * 'Update' or 'Upgrade' (needed by depfu gem)
     #   * Revert (for revert commits)
     # In both cases they should be followed by the actual commit message subject
-    - \A(?!\s)(?:Merge|Revert|Update|Upgrade|\[api\]|\[backend\]|\[ci\]|\[dist\]|\[doc\]|\[frontend\]|\[webui\])+ \S+
+    - \A(?!\s)(?:Merge|Revert|Update|Upgrade|\[api\]|\[backend\]|\[ci\]|\[contrib\]|\[dist\]|\[doc\]|\[frontend\]|\[webui\])+ \S+
 :commit_subject_suffix:
   :enabled: false


### PR DESCRIPTION
I use [contrib] for the development scripts in contrib/ 
Would be nice to allow that in the commit messages