### PR TITLE
[frontend] Use white background-color to be consistent with pre.

### DIFF
--- a/src/api/app/assets/stylesheets/webui/application/bento/base.scss
+++ b/src/api/app/assets/stylesheets/webui/application/bento/base.scss
@@ -208,7 +208,7 @@ blockquote{border-left:5px solid #690;color:#666;font-style:italic;}
 .ui-oo-content-wrapper .ui-oo-box-shadow > * > h4,.content-wrapper .box > * > h4{margin-top:1em;margin-bottom:0.5em;}
 .ui-oo-content-wrapper .box .ui-oo-box-shadow > * > h5,.content-wrapper .box > * > h5{margin-top:1em;margin-bottom:0.5em;}
 .ui-oo-content-wrapper .box .ui-oo-box-shadow > * > h6,.content-wrapper .box > * > h6{margin-top:1em;margin-bottom:0.5em;}
-.box .ui-oo-box-shadow,.box{border-width:1px;border-style:solid;border-color:#ddd #ccc #bbb;background-color:#fefefe;padding:10px 0 10px 0;}
+.box .ui-oo-box-shadow,.box{border-width:1px;border-style:solid;border-color:#ddd #ccc #bbb;background-color:white;padding:10px 0 10px 0;}
 .box .ui-oo-box-shadow a,.box a{color:#069;}
 .ui-oo-box-shadow a:hover,.box a:hover{color:#693;}
 .box.grey{background-color:#eee;}


### PR DESCRIPTION
Otherwise package/project descriptions color differs slightly.

Subtle and depending on contrast of monitor you may not notice, but annoying when you do and seemingly unintended.

![image](https://user-images.githubusercontent.com/22943929/32090042-fe3ad4b4-bab2-11e7-85cb-ff418cdf1e4b.png)
