### PR TITLE
Manual release support

### DIFF
--- a/src/api/app/controllers/source_controller.rb
+++ b/src/api/app/controllers/source_controller.rb
@@ -1465,7 +1465,7 @@ class SourceController < ApplicationController
       pkg.project.repositories.each do |repo|
         next if params[:repository] && params[:repository] != repo.name
         repo.release_targets.each do |releasetarget|
-          target_package_name = pkg.name
+          target_package_name = pkg.release_target_name
           # emulate a maintenance release request action here in case
           if pkg.project.is_maintenance_incident?
             # The maintenance ID is always the sub project name of the maintenance project

--- a/src/api/app/controllers/source_controller.rb
+++ b/src/api/app/controllers/source_controller.rb
@@ -1465,8 +1465,15 @@ class SourceController < ApplicationController
       pkg.project.repositories.each do |repo|
         next if params[:repository] && params[:repository] != repo.name
         repo.release_targets.each do |releasetarget|
+          target_package_name = pkg.name
+          # emulate a maintenance release request action here in case
+          if pkg.project.is_maintenance_incident?
+            # The maintenance ID is always the sub project name of the maintenance project
+            target_package_name += '.' << pkg.project.name.gsub(/.*:/, '')
+          end
+
           # find md5sum and release source and binaries
-          release_package(pkg, releasetarget.target_repository, pkg.name, repo, multibuild_container, nil, params[:setrelease], true)
+          release_package(pkg, releasetarget.target_repository, target_package_name, repo, multibuild_container, nil, params[:setrelease], true)
         end
       end
     end

--- a/src/api/app/models/bs_request_action.rb
+++ b/src/api/app/models/bs_request_action.rb
@@ -552,7 +552,10 @@ class BsRequestAction < ApplicationRecord
         end
       end
 
-      if pkg.releasename && is_maintenance_release?
+      if target_package
+        # manual specified
+        tpkg = target_package
+      elsif pkg.releasename && is_maintenance_release?
         # incidents created since OBS 2.8 should have this information already.
         tpkg = pkg.releasename
       elsif tprj.try(:is_maintenance_incident?) && is_maintenance_release?
@@ -564,7 +567,6 @@ class BsRequestAction < ApplicationRecord
         # we need to get rid of it again ...
         tpkg = tpkg.gsub(/#{Regexp.escape(suffix)}$/, '') # strip distro specific extension
       end
-      tpkg = target_package if target_package # already given
 
       # maintenance incident actions need a releasetarget
       releaseproject = get_releaseproject(pkg, tprj)

--- a/src/api/app/models/package.rb
+++ b/src/api/app/models/package.rb
@@ -1437,6 +1437,15 @@ class Package < ApplicationRecord
     backend_build_command(:abortbuild, params[:project], params.slice(:package, :arch, :repository))
   end
 
+  def release_target_name
+    # usually used in maintenance incidents
+    return releasename if releasename
+    # old incidents
+    return linkinfo['package'] if project.is_maintenance_incident? && linkinfo && linkinfo['package']
+    # no incident
+    name
+  end
+
   def backend_build_command(command, build_project, params)
     begin
       Project.find_by(name: build_project).check_write_access!

--- a/src/backend/bs_publish
+++ b/src/backend/bs_publish
@@ -2191,7 +2191,7 @@ publishprog_done:
     my $hook = $BSConfig::publishedhook->{$publish_prp};
     $hook = [ $hook ] unless ref $hook;
     print "    calling published hook @$hook\n";
-    qsystem(@$hook, $prp, $extrep, @changed) && warn("    @$hook failed: $?\n");
+    qsystem(@$hook, $prp, $extrep, @changed) && die("    @$hook failed: $?\n");
   }
 
   BSNotify::notify('REPO_PUBLISHED', { project => $projid , 'repo' => $repoid });


### PR DESCRIPTION
Needed for a special group, but may make sense also for maintenance teams. 
You can (re)-release single packages without the need of a request using this.
