### PR TITLE
[webui] Move kiwi_body method from XmlBuilder to Image class.

### DIFF
--- a/src/api/app/models/kiwi/image.rb
+++ b/src/api/app/models/kiwi/image.rb
@@ -111,6 +111,16 @@ module Kiwi
       message
     end
 
+    def kiwi_body
+      if package
+        kiwi_file = package.kiwi_image_file
+        return nil unless kiwi_file
+        package.source_file(kiwi_file)
+      else
+        Kiwi::Image::DEFAULT_KIWI_BODY
+      end
+    end
+
     private
 
     def check_use_project_repositories

--- a/src/api/app/models/kiwi/image/xml_builder.rb
+++ b/src/api/app/models/kiwi/image/xml_builder.rb
@@ -6,7 +6,7 @@ module Kiwi
       end
 
       def build
-        doc = Nokogiri::XML::DocumentFragment.parse(kiwi_body)
+        doc = Nokogiri::XML::DocumentFragment.parse(@image.kiwi_body)
         image = doc.at_css('image')
 
         return nil unless image && image.first_element_child
@@ -68,16 +68,6 @@ module Kiwi
           [Kiwi::Repository.new(source_path: 'obsrepositories:/', repo_type: 'rpm-md')]
         else
           @image.repositories
-        end
-      end
-
-      def kiwi_body
-        if @image.package
-          kiwi_file = @image.package.kiwi_image_file
-          return nil unless kiwi_file
-          @image.package.source_file(kiwi_file)
-        else
-          Kiwi::Image::DEFAULT_KIWI_BODY
         end
       end
 


### PR DESCRIPTION
The `XmlBuilder` class takes an image and returns the xml for that image, so having the `kiwi_body` method inside `XmlBuilder` violates the single responsibility principle for that class IMO. I am also refactoring the specs for the `XmlBuilder` class and this change will make the specs more simple.