### PR TITLE
Allow branch'ed preinstallimages to customize via topadd (2.6.7 version)

### DIFF
--- a/src/backend/bs_srcserver
+++ b/src/backend/bs_srcserver
@@ -1728,6 +1728,15 @@ sub applylink {
   mkdir_p($tmpdir);
   die("$tmpdir: $!\n") unless -d $tmpdir;
   unlink("$tmpdir/$_") for ls($tmpdir);	# remove old stuff
+
+  {
+	local *F;
+	open(F, '>>', "$tmpdir/.log") || die("$tmpdir/.log: $!\n");
+	print F "Applying link...\n";
+	close F;
+	print STDERR "Applying link...\n";
+  }
+
   my %apply = map {$_->{'name'} => 1} grep {$_->{'type'} eq 'apply'} @patches;
   $apply{$_} = 1 for keys %{$llnk->{'ignore'} || {}};	# also ignore those files, used in keeplink
   my %fl;
@@ -1867,6 +1876,7 @@ sub applylink {
         open(F, '>>', "$tmpdir/.log") || die("$tmpdir/.log: $!\n");
         print F "adding text at top of $spec\n";
         close F;
+        print STDERR "adding text at top of $spec: $p\n";
         topaddspec($p, $tmpdir, $spec);
         delete $fl{$spec};
       }

--- a/src/backend/bs_srcserver
+++ b/src/backend/bs_srcserver
@@ -2697,6 +2697,7 @@ sub findfile {
   }
 
   return @{$files{'_preinstallimage'}} if $ext ne 'kiwi' && keys(%files) == 1 && $files{'_preinstallimage'};
+  return @{$files{'simpleimage'}} if $files{'simpleimage'};
 
   if ($ext eq 'arch') {
     return @{$files{'PKGBUILD'}} if $files{'PKGBUILD'};
@@ -3366,7 +3367,7 @@ sub getprojpack {
             my ($md5, $file) = findfile($rev, $repoid, $type, $files);
 	    if (!$md5) {
 	      # no spec/dsc/kiwi file found
-	      if ($files->{'_preinstallimage'} || grep {/\.(?:spec|dsc|kiwi)$/} keys %$files) {
+	      if ($files->{'_preinstallimage'} || $files->{'simpleimage'}  || grep {/\.(?:spec|dsc|kiwi)$/} keys %$files) {
 		# only different types available
 		$rinfo->{'error'} = 'excluded';
 	      }

--- a/src/backend/bs_srcserver
+++ b/src/backend/bs_srcserver
@@ -1862,11 +1862,11 @@ sub applylink {
       next;
     }
     if ($p->{'type'} eq 'topadd') {
-      for my $spec (grep {/\.spec$/} ls($tmpdir)) {
-	local *F;
-	open(F, '>>', "$tmpdir/.log") || die("$tmpdir/.log: $!\n");
-	print F "adding text at top of $spec\n";
-	close F;
+      for my $spec (grep {/(_preinstallimage|simpleimage|\.spec)$/} ls($tmpdir)) {
+        local *F;
+        open(F, '>>', "$tmpdir/.log") || die("$tmpdir/.log: $!\n");
+        print F "adding text at top of $spec\n";
+        close F;
         topaddspec($p, $tmpdir, $spec);
         delete $fl{$spec};
       }


### PR DESCRIPTION
Another of our customizations for the 2.6.7-based deployment we use; this one allows to define a preinstallimage source "package" for our project once, including some basic dependencies and some more dependencies needed for many (but not all) components of the project, and branch it to spawn many differently customized preinstall images.

Since OBS uses the best-matching preinstall image which uses as many, or less than, the set of packages that the package being built requires, this means we have to define many preinstall image recipes.

It is convenient to manually manage the source `_preinstallimage` recipe once, and hide the optional dependencies in `%if` blocks - and then clone this package into many other preinstallimage recipes that piggyback on the `topadd` feature for specfiles (and the fact that a `_preinstallimage` recipe is a spec file too), and define the different needed sets of optional packages here and there, mixing and matching a large number of near-perfect-fit images to speed up our builds (ARM workers take about 10-15 minutes to prepare a buildroot from scratch, vs. a minute or so to unpack a preinstallimage using our other published patches to OBS).

Also note: one caveat is that currently it seems only possible to branch a package once into the same target project - subsequent branch attempts do not produce manageable packages, even though files are created. However, branches of branches can be made (once too), so you can make at least a chain of recipes e.g. from generic to specific (top-adding more definitions with each layer). I hope this limitation can also get resolved.