### PR TITLE
[contrib] start service dispatcher in dev backend

### DIFF
--- a/contrib/start_development_backend
+++ b/contrib/start_development_backend
@@ -67,6 +67,7 @@ if [ -n "$REDIR_LOG" ]; then
   APPEND_ARR[6]=">$REDIR_LOG/bs_service.log 2>&1"
   APPEND_ARR[7]=">$REDIR_LOG/bs_signer.log 2>&1"
   APPEND_ARR[8]=">$REDIR_LOG/signd.log 2>&1"
+  APPEND_ARR[9]=">$REDIR_LOG/bs_servicedispatch.log 2>&1"
 fi
 
 #check if GIT_HOME exists. If not it does not make any sense to continue.
@@ -117,6 +118,9 @@ eval $COMMAND_STRING
 echo "Starting signd"
 COMMAND_STRING="sudo /usr/sbin/signd ${APPEND_ARR[8]} &"
 eval $COMMAND_STRING
+echo "Starting bs_servicedispatch"
+COMMAND_STRING="sudo $GIT_HOME/src/backend/bs_servicedispatch ${APPEND_ARR[9]} &"
+eval $COMMAND_STRING
 
 #Cleanup function to terminate all backend services
 function clean_up {
@@ -136,6 +140,8 @@ function clean_up {
   echo -e "Terminated Publisher"
   sudo killall bs_signer
   echo -e "Terminated Signer"
+  sudo killall bs_servicedispatch
+  echo -e "Terminated service dispatcher"
   exit;
 }
 


### PR DESCRIPTION
The service dispatcher `bs_servicedispatch` needs to be started to 
be able to work with service runs and `_service` files.

@hennevogel: please review