### PR TITLE
Fix bug in transform binary packages response && Refactor

### DIFF
--- a/src/api/lib/backend/api/build_results/binaries.rb
+++ b/src/api/lib/backend/api/build_results/binaries.rb
@@ -71,8 +71,9 @@ module Backend
             architectures = [build["arch"]].flatten
             packages = [build["name"]].flatten
             packages.each do |package|
-              architectures = architectures.concat(list[package]) if list[package]
-              list[package] = architectures.uniq
+              architectures_copy = architectures.dup
+              architectures_copy = architectures_copy.concat(list[package]) if list[package]
+              list[package] = architectures_copy.uniq
             end
           end
           list

--- a/src/api/lib/backend/api/build_results/binaries.rb
+++ b/src/api/lib/backend/api/build_results/binaries.rb
@@ -63,18 +63,14 @@ module Backend
         # Transforms the output of the available_in_repositories, available_in_urls and available_in_project methods to a hash containing
         # the name of the binary as keys and the architectures as the value
         def self.transform_binary_packages_response(response)
-          list = {}
+          list = Hash.new([])
           parsed_response = Xmlhash.parse(response)
           return list if parsed_response.blank?
           packages = [parsed_response["packages"]].flatten
           packages.each do |build|
-            architectures = [build["arch"]].flatten
-            packages = [build["name"]].flatten
-            packages.each do |package|
-              architectures_copy = architectures.dup
-              architectures_copy = architectures_copy.concat(list[package]) if list[package]
-              list[package] = architectures_copy.uniq
-            end
+            architectures_names = [build["arch"]].flatten
+            package_names = [build["name"]].flatten
+            package_names.each { |package| list[package] = architectures_names.dup.concat(list[package]).uniq }
           end
           list
         end

--- a/src/api/spec/models/kiwi/image_spec.rb
+++ b/src/api/spec/models/kiwi/image_spec.rb
@@ -417,7 +417,7 @@ RSpec.describe Kiwi::Image, type: :model, vcr: true do
       it { expect(subject.keys).to match_array(['package1', 'package2', 'package3']) }
       it { expect(subject['package1']).to match_array(['i586', 'x86_64']) }
       it { expect(subject['package2']).to match_array(['i586']) }
-      it { expect(subject['package3']).to match_array(['i586', 'x86_64']) }
+      it { expect(subject['package3']).to match_array(['x86_64']) }
     end
 
     context 'with OBS and "normal" repositories set' do


### PR DESCRIPTION
I would say that there is a bug in `Backend::Api::BuildResults::Binaries#transform_binary_packages_response`, as we modified the architectures variable in the each we are adding the architectures of every package in the following ones as well.

I also did some refactoring :bowtie: 