### PR TITLE
[api][webui] Set default format of comments route to xml

### DIFF
--- a/src/api/config/routes.rb
+++ b/src/api/config/routes.rb
@@ -723,16 +723,18 @@ OBSApi::Application.routes.draw do
     delete 'source/:project/:package' => :delete_package, constraints: cons
   end
 
-  controller :comments do
-    get 'comments/request/:request_number' => :index, constraints: cons, as: :comments_request
-    post 'comments/request/:request_number' => :create, constraints: cons, as: :create_request_comment
-    get 'comments/package/:project/:package' => :index, constraints: cons, as: :comments_package
-    post 'comments/package/:project/:package' => :create, constraints: cons, as: :create_package_comment
-    get 'comments/project/:project' => :index, constraints: cons, as: :comments_project
-    post 'comments/project/:project' => :create, constraints: cons, as: :create_project_comment
-    get 'comments/user' => :index, constraints: cons, as: :comments_user
+  defaults format: "xml" do
+    controller :comments do
+      get 'comments/request/:request_number' => :index, constraints: cons, as: :comments_request
+      post 'comments/request/:request_number' => :create, constraints: cons, as: :create_request_comment
+      get 'comments/package/:project/:package' => :index, constraints: cons, as: :comments_package
+      post 'comments/package/:project/:package' => :create, constraints: cons, as: :create_package_comment
+      get 'comments/project/:project' => :index, constraints: cons, as: :comments_project
+      post 'comments/project/:project' => :create, constraints: cons, as: :create_project_comment
+      get 'comments/user' => :index, constraints: cons, as: :comments_user
 
-    delete 'comment/:id' => :destroy, constraints: cons, as: :comment_delete
+      delete 'comment/:id' => :destroy, constraints: cons, as: :comment_delete
+    end
   end
 
   # this can be requested by non browsers (like HA proxies :)


### PR DESCRIPTION
The /comments/ route is also accessible via the webui. Since we don't
have a html representation for that resource, we would end with an empty
page.

This commits sets the default format of that route to xml. So that users
see the xml representation instead of a blank page.

Fixes #3180