### PR TITLE
[webui] Use a concern to handle nested errors.

### DIFF
--- a/src/api/app/controllers/webui/kiwi/images_controller.rb
+++ b/src/api/app/controllers/webui/kiwi/images_controller.rb
@@ -20,8 +20,8 @@ module Webui
         if package.kiwi_image.blank? || package.kiwi_image.destroyed?
           package.kiwi_image = ::Kiwi::Image.build_from_xml(package.source_file(kiwi_file), package.kiwi_file_md5)
           unless package.save
-            errors = package.kiwi_image.parsed_errors("Kiwi File '#{kiwi_file}' has errors:",
-                                                      [package.kiwi_image.package_groups.map(&:packages)].flatten.compact)
+            errors = package.kiwi_image.nested_error_messages.merge(title: "Kiwi File '#{kiwi_file}' has errors:")
+
             redirect_to package_view_file_path(project: package.project, package: package, filename: kiwi_file), error: errors
             return
           end
@@ -52,7 +52,7 @@ module Webui
         redirect_to action: :show
       rescue ActiveRecord::RecordInvalid, Timeout::Error
         @package_groups = @image.package_groups.select(&:kiwi_type_image?).first
-        flash.now[:error] = @image.parsed_errors('Cannot update KIWI Image:', @package_groups.packages)
+        flash.now[:error] = @image.nested_error_messages.merge(title: 'Cannot update KIWI Image:')
         render action: :show
       end
 

--- a/src/api/app/models/kiwi/package.rb
+++ b/src/api/app/models/kiwi/package.rb
@@ -3,7 +3,7 @@ module Kiwi
     belongs_to :package_group
     has_one :kiwi_image, through: :package_groups
 
-    validates :name, presence: { message: 'Package name can\'t be blank'}
+    validates :name, presence: { message: 'can\'t be blank'}
 
     def to_h
       hash = { name: name }

--- a/src/api/app/models/kiwi/package_group.rb
+++ b/src/api/app/models/kiwi/package_group.rb
@@ -1,6 +1,6 @@
 module Kiwi
   class PackageGroup < ApplicationRecord
-    has_many :packages, dependent: :destroy
+    has_many :packages, dependent: :destroy, index_errors: true
     belongs_to :image
 
     # we need to add a prefix, to avoid generating class methods that already

--- a/src/api/app/models/kiwi/repository.rb
+++ b/src/api/app/models/kiwi/repository.rb
@@ -19,17 +19,17 @@ module Kiwi
     #### Scopes (first the default_scope macro if is used)
 
     #### Validations macros
-    validates :alias, :source_path, uniqueness: { scope: :image, message: "%{attribute} '%{value}' has already been taken."}, allow_blank: true
-    validates :source_path, presence: { message: '%{attribute} can\'t be nil.'}
+    validates :alias, :source_path, uniqueness: { scope: :image, message: "'%{value}' has already been taken."}, allow_blank: true
+    validates :source_path, presence: { message: 'can\'t be nil.'}
     validate :source_path_format
     validates :priority, numericality: { only_integer: true, allow_nil: true, greater_than_or_equal_to: 0,
-                                        less_than: 100, message: '%{attribute} must be between 0 and 99.' }
+                                        less_than: 100, message: 'must be between 0 and 99.' }
     validates :order, numericality: { only_integer: true, greater_than_or_equal_to: 1 }
     # TODO: repo_type value depends on packagemanager element
     # https://doc.opensuse.org/projects/kiwi/doc/#sec.description.repository
-    validates :repo_type, inclusion: { in: REPO_TYPES, message: "%{attribute} '%{value}' is not included in the list." }
-    validates :replaceable, inclusion: { in: [true, false], message: "%{attribute} has to be a boolean" }
-    validates :imageinclude, :prefer_license, inclusion: { in: [true, false], message: "%{attribute} has to be a boolean" }, allow_nil: true
+    validates :repo_type, inclusion: { in: REPO_TYPES, message: "'%{value}' is not included in the list." }
+    validates :replaceable, inclusion: { in: [true, false], message: "has to be a boolean" }
+    validates :imageinclude, :prefer_license, inclusion: { in: [true, false], message: "has to be a boolean" }, allow_nil: true
     validates_associated :image, on: :update
 
     #### Class methods using self. (public and then private)
@@ -49,10 +49,10 @@ module Kiwi
       return if source_path =~ /\A#{URI.regexp(['ftp', 'http', 'https', 'plain'])}\z/
       if source_path_for_obs_repository?
         return if repo_type == 'rpm-md'
-        errors.add(:repo_type, "Repo type should be 'rpm-md' for obs:// repositories.")
+        errors.add(:repo_type, "should be 'rpm-md' for obs:// repositories.")
       end
       return if source_path_for_opensuse_repository?
-      errors.add(:source_path, "Source path has an invalid format.")
+      errors.add(:source_path, "has an invalid format.")
     end
 
     def to_xml

--- a/src/api/lib/pretty_nested_errors.rb
+++ b/src/api/lib/pretty_nested_errors.rb
@@ -1,0 +1,91 @@
+require 'pretty_nested_errors/key_and_messages_parser'
+#  PrettyNestedErrors
+#
+#  Groups errors for nested resources on a model by a lambda for each nested resource.
+#  Example:
+#
+#    class Kiwi::Image < ApplicationRecord
+#      include PrettyNestedErrors
+#
+#      has_many :repositories, index_errors: true
+#      has_many :package_groups, index_errors: true
+#
+#      accepts_nested_attributes_for :repositories
+#      accepts_nested_attributes_for :package_groups
+#
+#      validates_presence_of :name
+#
+#      nest_errors_for :package_groups_packages, by: lambda { |kiwi_package| "Package: #{kiwi_package.name}" }
+#      nest_errors_for :repositories, by: lambda { |repository| "Repository: #{repository.source_path}" }
+#    end
+#
+#    class Kiwi::Repository < ApplicationRecord
+#      belongs_to :image
+#
+#      validates_presence_of :source_path
+#      validates_numericality_of :priority
+#    end
+#
+#    class Kiwi::PackageGroup < ApplicationRecord
+#      belongs_to :image
+#      has_many :packages, index_errors: true
+
+#      accepts_nested_attributes_for :packages
+#    end
+#
+#    class Kiwi::Package < ApplicationRecord
+#      belongs_to :package_group
+#      has_many :packages, index_errors: true
+#
+#      validates_presence_of :name
+#      validates_inclusion_of :name, in: %(valid list of names)
+#    end
+#
+#  So saving a Kiwi::Image with invalid data, might result in a kiwi image with these errors:
+#    kiwi_image.errors.messages =>
+#      {
+#        :"package_groups[0].packages[0].name" => ["can't be blank", "must be in list of valid names"],
+#        :"repositories[0].source_path" => ["can't be blank"],
+#        :"repositories[0].priority" => ["must be between a number"],
+#        :"name" => ["can't be blank"],
+#      }
+#
+#  Those errors are not easy to read, but if we call kiwi_image.nested_error_messages we get something better:
+#    kiwi_image.nested_error_messages =>
+#      {
+#        "Package: " => [
+#          "Name can't be blank",
+#          "Name must be in list of valid names"
+#        ],
+#        "Repository: obs://SUSE:SLE-1x2-SP3:Update/WE" => [
+#          "Source path can't be blank",
+#          "Priority must be between a number"
+#        ],
+#        "Image:" => [
+#          "Name can't be blank"
+#        ]
+#      }
+module PrettyNestedErrors
+  extend ActiveSupport::Concern
+
+  included do
+    attr_reader :nested_error_messages
+    class_attribute :nested_error_groupings
+
+    def self.nest_errors_for(association_name, options = {})
+      self.nested_error_groupings ||= {}
+      self.nested_error_groupings[association_name] = options[:by]
+    end
+
+    after_validation :generate_nested_error_messages
+  end
+
+  def generate_nested_error_messages
+    @nested_error_messages = {}
+    errors.messages.each do |key, messages|
+      @nested_error_messages =
+        KeyAndMessagesParser.new(self, key, messages, @nested_error_messages, self.nested_error_groupings).parse
+    end
+    @nested_error_messages
+  end
+end

--- a/src/api/lib/pretty_nested_errors/key_and_messages_parser.rb
+++ b/src/api/lib/pretty_nested_errors/key_and_messages_parser.rb
@@ -1,0 +1,114 @@
+module PrettyNestedErrors
+  class KeyAndMessagesParser
+    DOUBLE_NESTED_ERROR_REGEX = /(\w+)\[(\d+)\]\.(\w+)\[(\d+)\]\.(\w+)/
+    NESTED_ERROR_REGEX = /(\w+)\[(\d+)\]\.(\w+)/
+    HAS_ONE_ERROR_REGEX = /(\w+)\.(\w+)/
+
+    def initialize(base_model, key, messages, nested_error_messages, nested_error_groupings)
+      @base_model = base_model
+      @key = key
+      @messages = messages
+      @nested_error_messages = nested_error_messages
+      @nested_error_groupings = nested_error_groupings
+    end
+
+    # This method hard codes the behaviour for validations errors on 4 different types of associations:
+    # 1. errors on a double nested has_many association
+    # 2. errors on a nested has_many association
+    # 3. errors on a has_one associations
+    # 4. errors on the base model
+    # TODO: Make it so that the method uses regex to recursivley parse the validation key (i.e.
+    # "package_groups[0].packages[0].name") so that it can handle n-level nested assoications
+    def parse
+      # Matches an error on a has_many nested resource of a has_many nested resource
+      # like: {:"package_groups[0].packages[0].name"=>["can't be blank"]}
+      if @key.match(DOUBLE_NESTED_ERROR_REGEX)
+        parse_error_message_for_double_nested
+
+      # Matches an error on a has_many nested resource
+      # like {:"repositories[0].source_path"=>["can't be blank"]}
+      elsif @key.match(NESTED_ERROR_REGEX)
+        parse_error_message_for_nested
+
+      # Matches an error on a has_one nested resource like: {:"preference.type_containerconfig_tag"=>["can't be blank"]}
+      elsif @key.match(HAS_ONE_ERROR_REGEX)
+        parse_error_message_for_has_one
+
+      # Matches an error on the base resource like: {:"name"=>["can't be blank"]}
+      else
+        parse_error_message_for_base
+      end
+
+      @nested_error_messages
+    end
+
+    private
+
+    def parse_error_message_for_double_nested
+      parsed_key = @key.match(DOUBLE_NESTED_ERROR_REGEX)
+
+      association_name = parsed_key[1].to_sym
+      association_index = parsed_key[2].to_i
+      sub_association_name = parsed_key[3].to_sym
+      sub_association_index = parsed_key[4].to_i
+      association_invalid_column = parsed_key[5]
+
+      # Find the association record
+      record = @base_model.send(association_name)[association_index].send(sub_association_name)[sub_association_index]
+
+      # Call the lambda method to determine the grouping
+      group_by = @nested_error_groupings["#{association_name}_#{sub_association_name}".to_sym].call(record)
+
+      @nested_error_messages[group_by] ||= []
+      @nested_error_messages[group_by] +=
+        @messages.map { |message| @base_model.errors.full_message(association_invalid_column, message) }
+    end
+
+    def parse_error_message_for_nested
+      parsed_key = @key.match(NESTED_ERROR_REGEX)
+
+      association_name = parsed_key[1].to_sym
+      association_index = parsed_key[2].to_i
+      association_invalid_column = parsed_key[3]
+
+      # Find the association record
+      record = @base_model.send(association_name)[association_index]
+
+      # Call the lambda method to determine the grouping
+      group_by = @nested_error_groupings[association_name].call(record)
+
+      @nested_error_messages[group_by] ||= []
+      @nested_error_messages[group_by] +=
+        @messages.map { |message| @base_model.errors.full_message(association_invalid_column, message) }
+    end
+
+    def parse_error_message_for_has_one
+      parsed_key = @key.match(HAS_ONE_ERROR_REGEX)
+
+      association_name = parsed_key[1].to_sym
+      association_invalid_column = parsed_key[2].to_sym
+
+      # Call the lambda method to determine the grouping
+      group_by = @nested_error_groupings[association_name].call
+
+      @nested_error_messages[group_by] ||= []
+      @nested_error_messages[group_by] +=
+        @messages.map { |message| @base_model.errors.full_message(association_invalid_column, message) }
+    end
+
+    def parse_error_message_for_base
+      base_model_grouping = @nested_error_groupings[@base_model.class.name.demodulize.underscore.to_sym]
+
+      group_by =
+        if base_model_grouping.present?
+          base_model_grouping.call
+        else
+          @base_model.class.name.humanize
+        end
+
+      @nested_error_messages[group_by] ||= []
+      @nested_error_messages[group_by] +=
+        @messages.map { |message| @base_model.errors.full_message(@key, message) }
+    end
+  end
+end

--- a/src/api/spec/controllers/webui/kiwi/images_controller_spec.rb
+++ b/src/api/spec/controllers/webui/kiwi/images_controller_spec.rb
@@ -79,13 +79,13 @@ RSpec.describe Webui::Kiwi::ImagesController, type: :controller, vcr: true do
                    project: project, kiwi_file_content: invalid_kiwi_xml_with_obsrepositories)
           end
           let(:errors) do
-            [
-              [:title, "Kiwi File 'package_with_invalid_kiwi_file.kiwi' has errors:"],
-              [
-                "Image Errors:",
-                ["A repository with source_path \"obsrepositories:/\" has been set. If you want to use it, please remove the other repositories."]
-              ]
-            ]
+            {
+              "Image Errors:" => [
+                "A repository with source_path \"obsrepositories:/\" has been set. If you want to use it, please remove the other repositories.",
+                "Preference can't be blank"
+              ],
+              title: "Kiwi File 'package_with_invalid_kiwi_file.kiwi' has errors:"
+            }
           end
 
           before do
@@ -98,7 +98,7 @@ RSpec.describe Webui::Kiwi::ImagesController, type: :controller, vcr: true do
                                                                    filename: "#{package_with_kiwi_file.name}.kiwi"))
           end
 
-          it { expect(flash[:error]).to match_array(errors) }
+          it { expect(flash[:error]).to eq(errors) }
         end
       end
 
@@ -112,7 +112,13 @@ RSpec.describe Webui::Kiwi::ImagesController, type: :controller, vcr: true do
           let(:errors) do
             [
               [:title, "Kiwi File 'package_with_invalid_kiwi_file.kiwi' has errors:"],
-              ["Image Errors:", ["Multiple package groups with same type are not allowed."]]
+              [
+                "Image Errors:",
+                [
+                  "Multiple package groups with same type are not allowed.",
+                  "Preference can't be blank"
+                ]
+              ]
             ]
           end
 
@@ -177,18 +183,18 @@ RSpec.describe Webui::Kiwi::ImagesController, type: :controller, vcr: true do
         }
       end
       let(:errors) do
-        [
-          [:title, "Cannot update KIWI Image:"],
-          [
-            "Repository: htt:__example.com",
-            ["Source path has an invalid format.", "Repo type 'apt2-deb' is not included in the list."]
-          ]
-        ]
+        {
+          "Repository: htt://example.com" => [
+            "Source path has an invalid format.",
+            "Repo type 'apt2-deb' is not included in the list."
+          ],
+          title: "Cannot update KIWI Image:"
+        }
       end
 
-      subject { post :update, params: invalid_repositories_update_params }
+      subject! { post :update, params: invalid_repositories_update_params }
 
-      it { expect(subject.request.flash[:error]).to match_array(errors) }
+      it { expect(subject.request.flash[:error]).to eq(errors) }
       it { expect(subject).to have_http_status(:success) }
       it { expect(subject).to render_template(:show) }
     end
@@ -273,15 +279,15 @@ RSpec.describe Webui::Kiwi::ImagesController, type: :controller, vcr: true do
       end
 
       let(:errors) do
-        [
-          [:title, "Cannot update KIWI Image:"],
-          ["Package: ", ["Package name can't be blank"]]
-        ]
+        {
+          "Package: " => ["Name can't be blank"],
+          title: "Cannot update KIWI Image:"
+        }
       end
 
       subject { post :update, params: invalid_packages_update_params }
 
-      it { expect(subject.request.flash[:error]).to match_array(errors) }
+      it { expect(subject.request.flash[:error]).to eq(errors) }
       it { expect(subject).to have_http_status(:success) }
       it { expect(subject).to render_template(:show) }
     end

--- a/src/api/spec/models/kiwi/image_spec.rb
+++ b/src/api/spec/models/kiwi/image_spec.rb
@@ -464,21 +464,18 @@ RSpec.describe Kiwi::Image, type: :model, vcr: true do
     it { expect(subject.find_binaries_by_name('c', 'project', [], use_project_repositories: true)).to be_empty }
   end
 
-  describe '#parsed_errors' do
+  describe '#nested_error_messages' do
     let!(:kiwi_repository) { create(:kiwi_repository, image: kiwi_image) }
     let(:result) do
       {
-        title: "title",
-        "Image Errors:" =>
-        [
-          "Multiple package groups with same type are not allowed."
-        ],
-        "Repository: example" =>
-        [
+        "Repository: http://example.com/" => [
           "Source path can't be nil.",
           "Source path has an invalid format.",
-          "is not a number",
+          "Order is not a number",
           "Replaceable has to be a boolean"
+        ],
+        "Image Errors:"                   => [
+          "Multiple package groups with same type are not allowed."
         ]
       }
     end
@@ -490,8 +487,8 @@ RSpec.describe Kiwi::Image, type: :model, vcr: true do
       kiwi_image.valid?
     end
 
-    subject { kiwi_image.parsed_errors('title', []) }
+    subject { kiwi_image.nested_error_messages }
 
-    it { expect(subject).to eq(result) }
+    it { is_expected.to eq(result) }
   end
 end

--- a/src/api/spec/models/kiwi/repository_spec.rb
+++ b/src/api/spec/models/kiwi/repository_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe Kiwi::Repository, type: :model do
     subject { create(:kiwi_repository) }
 
     context 'for source_path' do
-      it { is_expected.to validate_presence_of(:source_path).with_message(/Source path can't be nil/) }
+      it { is_expected.to validate_presence_of(:source_path).with_message(/can't be nil/) }
 
       it "obsrepositories should be valid" do
         is_expected.to allow_value('obsrepositories:/').for(:source_path)
@@ -114,7 +114,7 @@ RSpec.describe Kiwi::Repository, type: :model do
     it { is_expected.to validate_inclusion_of(:repo_type).in_array(Kiwi::Repository::REPO_TYPES).on(:save) }
     it do
       is_expected.to validate_numericality_of(:priority).is_greater_than_or_equal_to(0).is_less_than(100)
-                                                        .with_message(/Priority must be between 0 and 99/)
+                                                        .with_message(/must be between 0 and 99/)
     end
     it { is_expected.to validate_numericality_of(:order).is_greater_than_or_equal_to(1) }
     it { is_expected.to allow_value(nil).for(:imageinclude) }


### PR DESCRIPTION
Move the logic which generates nice validation error messages for nested resources to a generic concern so we can re-use this in other ActiveRecord models which have nested resources.

Also makes the preferences and descriptions validation messages appear in a nice format too:
![screenshot from 2017-11-08 08-59-47](https://user-images.githubusercontent.com/9274/32540409-8f0af37e-c464-11e7-8d42-32f8656b3f09.png)
![screenshot from 2017-11-08 09-00-31](https://user-images.githubusercontent.com/9274/32540415-92a916dc-c464-11e7-97cd-08422ef8459d.png)
