### PR TITLE
[ci] fix database tests on installed systems

### DIFF
--- a/dist/t/0090-check_database.ts
+++ b/dist/t/0090-check_database.ts
@@ -14,5 +14,6 @@ TABLES_IN_DB=$(mysql -e "show tables" $DB_NAME)
 [[ $TABLES_IN_DB ]]
 is "$?" 0 "Checking if tables in database $DB_NAME"
 
-[ -f /srv/obs/MySQL/*.pid ]
+D=`ps -ef|grep "mysqld .* --datadir=/srv/obs/MySQL"|wc -l`
+[ $D -gt 1 ]
 is "$?" 0 "Checking if database is started under /srv/obs/MySQL"


### PR DESCRIPTION
Without this patch, the mysqld pid file under /srv/obs/MySQL is checked
This might fail and is not a valid test as we expect the datadir under /srv/obs/MySQL
but not the pid-file etc.

This patch checks if the mysqld is started with the correct --datadir option in the process list