### PR TITLE
[backend] added 'new' hash string for sha256 check

### DIFF
--- a/src/backend/bs_srcserver
+++ b/src/backend/bs_srcserver
@@ -2976,6 +2976,7 @@ sub sourcecommitfilelist {
     BSVerify::verify_filename($entry->{'name'});
     BSVerify::verify_md5($entry->{'md5'});
     if (! -e BSRevision::revfilename($orev, $entry->{'name'}, $entry->{'md5'})) {
+      $entry->{'hash'} = 'new' if $cgi->{'withvalidate'};
       push @missing, $entry;
     } else {
       die("duplicate file: $entry->{'name'}\n") if exists $files->{$entry->{'name'}};


### PR DESCRIPTION
`$entry->{'hash'} = new` is set if withvalidate is true and
the file is new. This will tell the client (osc) to send the
file with sha256sum generated