### PR TITLE
Add Issue.name validation

### DIFF
--- a/src/api/app/models/issue.rb
+++ b/src/api/app/models/issue.rb
@@ -10,6 +10,8 @@ class Issue < ApplicationRecord
   belongs_to :issue_tracker
   belongs_to :owner, class_name: "User"
 
+  validates :name, format: { with: /\A[\d\-]+\z/, message: 'only digits and hyphens' }
+
   scope :stateless, -> { where(state: nil) }
 
   def self.find_or_create_by_name_and_tracker( name, issue_tracker_name, force_update = nil )


### PR DESCRIPTION
See issue #1215 

This change adds validation to the `Issue.name` column. The name should only be composed of numbers and digits.

(A convenient place to test Ruby regular expressions in http://rubular.com/)