### PR TITLE
[webui] In /search, remove extra hidden form fields

### DIFF
--- a/src/api/app/controllers/webui/search_controller.rb
+++ b/src/api/app/controllers/webui/search_controller.rb
@@ -111,12 +111,12 @@ class Webui::SearchController < Webui::WebuiController
     @search_text = @search_text.delete("'[]\n")
 
     @search_what = []
-    @search_what << 'package' if params[:package] == '1' || params[:package].nil?
-    @search_what << 'project' if params[:project] == '1' || params[:project].nil? && !@search_issue
+    @search_what << 'package' if params[:package] == '1'
+    @search_what << 'project' if params[:project] == '1' || !@search_issue
     @search_what << 'owner' if params[:owner] == '1' && !@search_issue
 
     @search_where = []
-    @search_where << 'name' if params[:name] == '1' || params[:name].nil?
+    @search_where << 'name' if params[:name] == '1'
     @search_where << 'title' if params[:title] == '1'
     @search_where << 'description' if params[:description] == '1'
 

--- a/src/api/app/views/layouts/webui/_watch_and_search.html.haml
+++ b/src/api/app/views/layouts/webui/_watch_and_search.html.haml
@@ -20,7 +20,7 @@
       %li
         = link_to(content_tag(:span, content_tag(:span, '', class: 'icons-project') + raw(project.gsub(':', ':<wbr>')),
           class: 'project-link'), project_show_path(project))
-= form_tag(search_path, { id: 'global-search-form', class: 'label-overlay' }) do
+= form_tag(search_path(project: 1, package: 1, name: 1), { id: 'global-search-form', class: 'label-overlay' }) do
   %div{ style: 'display: inline' }
     %label.hidden{ for: 'search' } Search
     = text_field_tag 'search_text', '', id: 'search'

--- a/src/api/app/views/webui/search/index.html.haml
+++ b/src/api/app/views/webui/search/index.html.haml
@@ -23,21 +23,16 @@
       #advanced-container{ style: "display: none;" }
         %h4 Search for:
         %p
-          = hidden_field_tag('project', 0)
           = check_box_tag('project', 1, params[:project].nil? || params[:project] == "1")
           %label{for: "project" } Projects
-          = hidden_field_tag('package', 0)
           = check_box_tag('package', 1, params[:package].nil? || params[:package] == "1")
           %label{ for: "package" } Packages
         %h4 Search in:
         %p
-          = hidden_field_tag('name', 0)
           = check_box_tag('name', 1, params[:name].nil? || params[:name] == "1")
           %label{ for: "name" } Name
-          = hidden_field_tag('title', 0)
           = check_box_tag('title', 1, params[:title] == "1")
           %label{ for: "title" } Title
-          = hidden_field_tag('description', 0)
           = check_box_tag('description', 1, params[:description] == "1")
           %label{ for: "description" } Description
         %h4 Require attribute:

--- a/src/api/spec/controllers/webui/search_controller_spec.rb
+++ b/src/api/spec/controllers/webui/search_controller_spec.rb
@@ -80,9 +80,9 @@ RSpec.describe Webui::SearchController, vcr: true do
       end
     end
 
-    context 'with bad search_where' do
+    context 'with no search scope' do
       before do
-        get :index, params: { search_text: 'whatever', name: '0' }
+        get :index, params: { search_text: 'whatever' }
       end
 
       it { expect(flash[:error]).to eq('You have to search for whatever in something. Click the advanced button...') }
@@ -92,7 +92,7 @@ RSpec.describe Webui::SearchController, vcr: true do
     context 'with proper parameters but no results' do
       before do
         allow(ThinkingSphinx).to receive(:search).and_return([])
-        get :index, params: { search_text: 'whatever' }
+        get :index, params: { search_text: 'whatever', project: 1, package: 1, name: 1 }
       end
 
       it { expect(flash[:notice]).to eq('Your search did not return any results.') }
@@ -103,7 +103,7 @@ RSpec.describe Webui::SearchController, vcr: true do
     context 'with proper parameters and some results' do
       before do
         allow(ThinkingSphinx).to receive(:search).and_return(["Fake result with #{package.name}"])
-        get :index, params: { search_text: package.name }
+        get :index, params: { search_text: package.name, project: 1, package: 1, name: 1 }
       end
 
       it { expect(response).to have_http_status(:success) }


### PR DESCRIPTION
In [/search](https://build.opensuse.org/search), remove extra hidden form fields.

This also fixes the association of the labels with the checkboxes.