### PR TITLE
Autocomplete binaries

### DIFF
--- a/src/api/app/controllers/webui/kiwi/images_controller.rb
+++ b/src/api/app/controllers/webui/kiwi/images_controller.rb
@@ -84,7 +84,7 @@ module Webui
       def autocomplete_binaries
         binaries = ::Kiwi::Image.find_binaries_by_name(params[:term], @image.package.project.name,
                                                        params[:repositories], use_project_repositories: params[:use_project_repositories])
-        render json: binaries.to_a.map { |result| {id: result.first, label: result.first, value: result.first} }
+        render json: binaries.map { |result| {id: result.first, label: result.first, value: result.first} }
       end
 
       def build_result

--- a/src/api/app/controllers/webui/kiwi/images_controller.rb
+++ b/src/api/app/controllers/webui/kiwi/images_controller.rb
@@ -84,7 +84,7 @@ module Webui
       def autocomplete_binaries
         binaries = ::Kiwi::Image.find_binaries_by_name(params[:term], @image.package.project.name,
                                                        params[:repositories], use_project_repositories: params[:use_project_repositories])
-        render json: binaries.map { |result| {id: result.first, label: result.first, value: result.first} }
+        render json: binaries.keys.map { |package_name| { id: package_name, label: package_name, value: package_name } }
       end
 
       def build_result


### PR DESCRIPTION
`binaries` return a `hash` and `map` over a `hash` has the same result as converting the `hash` to `array` and then applying `map`. Moreover, we were applying `map` over a `hash` to afterwards only using the fist element of every pair, what are the `hash` keys. Instead we can retrieve the `keys` first. I also rename the block variable to make the code more readable. :bowtie: