### PR TITLE
[dist] docker registry on appliance

### DIFF
--- a/Makefile.include
+++ b/Makefile.include
@@ -11,6 +11,7 @@ APACHE_GROUP=www
 APACHE_CONIFGDIR=/etc/apache2
 APACHE_CONIFGDIR_VHOST=$(APACHE_CONIFGDIR)/vhosts.d
 APACHE_VHOST_CONF=obs-apache24.conf
+APACHE_VHOST_CONTAINER_REGISTRY_CONF=obs-container-registry.conf
 
 # some sortcuts
 test: test_unit

--- a/dist/Makefile
+++ b/dist/Makefile
@@ -8,7 +8,7 @@ SYSTEMD_SERVICE_FILES := obsdeltastore
 
 UNITDIR=/usr/lib/systemd/system/
 
-install: install_obsapisetup install_apache install_initscripts install_project_update install_logrotate install_fillups install_slp install_obs_bin install_devel_docs install_overview install_tests_appliance install_crontabs install_systemd_services
+install: install_obsapisetup install_apache install_initscripts install_project_update install_logrotate install_fillups install_slp install_obs_bin install_devel_docs install_overview install_tests_appliance install_crontabs install_systemd_services install_registry_dirs
 
 #install_overview
 
@@ -19,6 +19,7 @@ install_obsapisetup: system_dirs
 install_apache:
 	$(INSTALL) -d -m 755  $(DESTDIR)$(APACHE_CONIFGDIR_VHOST)
 	$(INSTALL) -m 644 $(APACHE_VHOST_CONF) $(DESTDIR)$(APACHE_CONIFGDIR_VHOST)/obs.conf
+	$(INSTALL) -m 644 $(APACHE_VHOST_CONTAINER_REGISTRY_CONF) $(DESTDIR)$(APACHE_CONIFGDIR_VHOST)/$(APACHE_VHOST_CONTAINER_REGISTRY_CONF)
 
 install_initscripts: system_dirs
 	$(foreach script,$(INIT_SCRIPTS),$(shell $(INSTALL) -m 755 $(script) $(DESTDIR)/etc/init.d/$(script)) )
@@ -68,6 +69,9 @@ install_devel_docs:
 install_overview:
 	$(INSTALL) -d -m 755 $(DESTDIR)$(OBS_DOCUMENT_ROOT)/overview
 	$(INSTALL) -m 644 overview.html.TEMPLATE $(DESTDIR)$(OBS_DOCUMENT_ROOT)/overview
+
+install_registry_dirs:
+	mkdir -p $(DESTDIR)/srv/www/obs/container-registry{,/log,/htdocs}
 
 install_tests_appliance:
 	cp -r ./t/*	$(DESTDIR)/usr/lib/obs/tests/appliance/

--- a/dist/obs-apache24.conf
+++ b/dist/obs-apache24.conf
@@ -110,6 +110,4 @@ LimitRequestFieldsize 20000
 
         ## Older firefox versions needs this, otherwise it wont cache anything over SSL.
         Header append Cache-Control "public"
-
 </VirtualHost>
-

--- a/dist/obs-container-registry.conf
+++ b/dist/obs-container-registry.conf
@@ -1,0 +1,66 @@
+# Forwarding vhost for docker-distribution-registry
+Listen 444
+<VirtualHost *:444>
+        ServerName registry
+
+	#  General setup for the virtual host
+        DocumentRoot  "/srv/www/obs/container-registry/htdocs"
+	ErrorLog /srv/www/obs/container-registry/log/apache_error.log
+	TransferLog /srv/www/obs/container-registry/log/apache_access.log
+
+        # Enable maintenance mode. All requests will be redirected
+        # to the maintenance page and return 503 as http status.
+        # Start your apache with -D MAINTENANCE to enable this.
+        # On (open)SUSE you can do this by setting
+        # APACHE_SERVER_FLAGS="MAINTENANCE" in /etc/sysconfig/apache
+        <IfDefine MAINTENANCE>
+          ErrorDocument 503 /503.html
+          RewriteEngine on
+          RewriteCond %{REQUEST_URI} !=/503.html
+          RewriteRule ^ - [R=503,L]
+        </IfDefine>
+
+	SSLEngine on
+
+	#  SSL protocols
+	#  Supporting TLS only is adequate nowadays
+	SSLProtocol all -SSLv2 -SSLv3
+
+	#   SSL Cipher Suite:
+	#   List the ciphers that the client is permitted to negotiate.
+	#   We disable weak ciphers by default.
+	#   See the mod_ssl documentation or "openssl ciphers -v" for a
+	#   complete list.
+	SSLCipherSuite ALL:!aNULL:!eNULL:!SSLv2:!LOW:!EXP:!MD5:@STRENGTH
+
+	SSLCertificateFile /srv/obs/certs/server.crt
+	SSLCertificateKeyFile /srv/obs/certs/server.key
+
+        <Directory /srv/www/obs/container-registry/htdocs>
+           AllowOverride all
+           Options -MultiViews
+
+           # This requires mod_xforward loaded in apache 
+           # Enable the usage via options.yml
+           # This will decrease the load due to long running requests a lot (unloading from rails stack)
+           XForward on
+
+           Require all granted
+        </Directory>
+
+	SetEnvIf User-Agent ".*MSIE [1-5].*" \
+		 nokeepalive ssl-unclean-shutdown \
+		 downgrade-1.0 force-response-1.0
+
+	CustomLog /var/log/apache2/ssl_request_log   ssl_combined
+
+        RequestHeader set X-Forwarded-Proto "https"
+        ProxyPass "/" "http://localhost:5000/"
+        ProxyPassReverse "/" "http://localhost:5000/"
+
+        <Location "/">
+          <LimitExcept GET HEAD>
+            Require host localhost
+          </LimitExcept>
+        </Location>
+</VirtualHost>

--- a/dist/obs-server.spec
+++ b/dist/obs-server.spec
@@ -692,4 +692,29 @@ usermod -a -G docker obsservicerun
 /usr/lib/obs/tests/appliance/*
 
 
+%package -n obs-container-registry
+Summary:        The Open Build Service -- container registry
+%if 0%{?suse_version} < 1210 && 0%{?suse_version:1}
+Group:          Productivity/Networking/Web/Utilities
+%endif
+Requires:       docker-distribution-registry
+
+%description -n obs-container-registry
+The OBS Container Registry, based on the docker registry, which allows
+    
+* anonymous pulls from anywhere
+* anonymous pushes from localhost.
+    
+This is done by proxying access to the registry through
+apache and restricting any other http method than GET and HEAD
+to localhost.
+
+
+%files -n obs-container-registry
+%defattr(-,root,root)
+%dir /srv/www/obs/container-registry
+%dir /srv/www/obs/container-registry/log
+%dir /srv/www/obs/container-registry/htdocs
+%config /etc/apache2/vhosts.d/obs-container-registry.conf
+
 %changelog

--- a/dist/t/osc/0200-check_docker_registry.ts
+++ b/dist/t/osc/0200-check_docker_registry.ts
@@ -1,0 +1,38 @@
+#!/usr/bin/perl
+
+use strict;
+use warnings;
+
+use Test::More tests => 1;
+
+# These test need a lot of resources, so they should be
+# skipable
+
+exit 0 unless $ENV{ENABLE_DOCKER_REGISTRY_TESTS};
+
+`osc branch openSUSE.org:openSUSE:Templates:Images:42.3:Base  openSUSE-Leap-Container-Base BaseContainer`;
+
+chdir("/tmp");
+
+`osc co BaseContainer/openSUSE-Leap-Container-Base`;
+chdir("/tmp/BaseContainer/openSUSE-Leap-Container-Base");
+
+`osc meta prjconf openSUSE.org:openSUSE:Templates:Images:42.3:Base |osc meta prjconf -F -`;
+open(my $fh, "<", "/tmp/BaseContainer/openSUSE-Leap-Container-Base/config.kiwi")||die $!;
+my $result;
+while (<$fh>) {
+  s#obs://#obs://openSUSE.org:#;
+  $result .= $_;
+}
+close($fh);
+open(my $of, ">", "/tmp/BaseContainer/openSUSE-Leap-Container-Base/config.kiwi")||die $!;
+print $of $result;
+close($of);
+
+`osc ci -m "reconfigured 'source path' elements to use 'openSUSE.org:' as prefix in config.kiwi"`;
+
+`osc r -w`;
+
+ok($? == 0,"Checking result code");
+
+exit 0;

--- a/src/backend/BSConfig.pm.template
+++ b/src/backend/BSConfig.pm.template
@@ -229,13 +229,14 @@ our $servicedispatch = 1;
 # print all messages with a lower level than $debuglevel in addition to the normal log messages
 #our $debuglevel = 1;
 
-# our $container_registries = {
-#   'registry.example.com' => {
-#     host => '',
-#     port => '',
-#     user => '',
-#     password => '',
-#     repository_base => '',
+#our $container_registries = {
+#   'localhost' => {
+#     host => 'localhost',
+#     port => 444,
+#     user => 'ignored',
+#     password => 'ignored',
+#     # Please be aware of the trailing slash
+#     repository_base => '/',
 #   },
 #   'staging-registry.example.com' => {
 #     host => '',
@@ -252,13 +253,13 @@ our $servicedispatch = 1;
 #     repository_base => '',
 #   },
 #};
-#
-# our $publish_containers = [
+
+#our $publish_containers = [
 #   # key:   regex to match projid
 #   # value: ArrayRef with identifiers for registries configured in $container_registries
 #   'SUSE:.*' => [ 'registry.example.com', 'hub.docker.com' ],
 #   '.*:branches:.*' => [ 'staging-registry.example.com' ],
-# ];
-
+#    '.*' => ['localhost'],
+#];
 
 1;


### PR DESCRIPTION
This commit ships

* configuration files
* test cases
* patches for
 * setup-appliance.sh
 * Makefile
 * spec file

a container registry which allow

* anonymous pulls from anywhere
* anonymous pushes from localhost.

This is done by proxying access to the registry through
apache and restricting any other http method than GET and HEAD
to localhost.

This commit includes the following changes

* new vhost config including a proxy forward on port 444 to the local registry
* new pathes under /srv/www/registry in install routines and spec file
* setup-appliance.sh now checks
 * if docker-distribution-registry is installed
 * config variables are untouched in BSConfig
 * then it configures
   * /etc/registry/config.yml
   * BSConfig
 * restarts daemons if needed
 * enables and starts required services