### PR TITLE
[webui] Redirect  to Kiwi Overview

### DIFF
--- a/src/api/app/controllers/webui/kiwi/images_controller.rb
+++ b/src/api/app/controllers/webui/kiwi/images_controller.rb
@@ -27,7 +27,7 @@ module Webui
           end
         end
 
-        redirect_to edit_kiwi_image_path(package.kiwi_image, section: 'software')
+        redirect_to kiwi_image_path(package.kiwi_image)
       end
 
       def show

--- a/src/api/app/views/webui/package/show.html.erb
+++ b/src/api/app/views/webui/package/show.html.erb
@@ -115,7 +115,7 @@
                 <% Feature.with(:kiwi_image_editor) do %>
                   <% if @package.kiwi_image? && policy(@package).update? %>
                     <li>
-                      <%= link_to(sprited_text('package_edit', 'Edit KIWI'), import_kiwi_image_path(@package.id), id: 'edit-kiwi') %>
+                      <%= link_to(sprited_text('package_edit', 'View Image'), import_kiwi_image_path(@package.id), id: 'edit-kiwi') %>
                     </li>
                   <% end %>
                 <% end %>

--- a/src/api/spec/controllers/webui/kiwi/images_controller_spec.rb
+++ b/src/api/spec/controllers/webui/kiwi/images_controller_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe Webui::Kiwi::ImagesController, type: :controller, vcr: true do
           get :import_from_package, params: { package_id: kiwi_image.package.id }
         end
 
-        it { expect(response).to redirect_to(edit_kiwi_image_path(kiwi_image, section: 'software')) }
+        it { expect(response).to redirect_to(kiwi_image_path(kiwi_image)) }
       end
 
       context 'that is an invalid kiwi file' do
@@ -69,7 +69,7 @@ RSpec.describe Webui::Kiwi::ImagesController, type: :controller, vcr: true do
 
           it 'redirect to kiwi image show' do
             package_with_kiwi_file.reload
-            expect(response).to redirect_to(edit_kiwi_image_path(package_with_kiwi_file.kiwi_image, section: 'software'))
+            expect(response).to redirect_to(kiwi_image_path(package_with_kiwi_file.kiwi_image))
           end
         end
 


### PR DESCRIPTION
When we branch a template or import a kiwi file we will be redirected to
the Kiwi overview instead of software section.