### PR TITLE
[webui] Make dialog buttons more visible

### DIFF
--- a/src/api/app/assets/stylesheets/webui/application/dialog.scss
+++ b/src/api/app/assets/stylesheets/webui/application/dialog.scss
@@ -31,11 +31,14 @@
       padding: 3px 1ex;
       background: #FFF;
       background-color: #fff;
-      border-color: #EEE;
-      color: #999;
       &:visited {
         text-decoration: none;
       }
+    }
+
+    input {
+      border-color: #EEE;
+      color: #999;
       &:hover {
         text-decoration: none;
         color: #666;
@@ -44,7 +47,12 @@
 
     a {
       border-radius: 5px;
-      border: 1px solid #eee;
+      border: 1px solid #adadad;
+      color: #323232;
+      &:hover {
+        text-decoration: none;
+        background-color: #eee;
+      }
     }
   }
 }


### PR DESCRIPTION
Make dialog buttons **darker** to avoid that users think that they are disable

### Before
![screenshot from 2017-11-24 10-27-19](https://user-images.githubusercontent.com/1212806/33203947-20914fa6-d102-11e7-9701-49bc518c3baf.png)


### After
![screenshot from 2017-11-24 10-21-12](https://user-images.githubusercontent.com/1212806/33203906-f9af23e0-d101-11e7-84e8-547199d24bd1.png)
