### PR TITLE
[webui] colorize request file_state

### DIFF
--- a/src/api/app/assets/stylesheets/webui/application/request.scss
+++ b/src/api/app/assets/stylesheets/webui/application/request.scss
@@ -13,3 +13,11 @@
 [id^='review_accept_button']{
   margin-right: 1em;
 }
+
+.file_state_added {
+  color: green;
+}
+
+.file_state_deleted {
+  color: red;
+}

--- a/src/api/app/views/shared/_sourcediff.html.haml
+++ b/src/api/app/views/shared/_sourcediff.html.haml
@@ -28,7 +28,7 @@
                     $('#expand_#{file_id}').hide();
                   - else
                     $('#collapse_#{file_id}').hide();
-            %td{ style: 'width: 10%' }= file_state
+            %td{ style: 'width: 10%', class: "file_state_#{file_element['state']}" }= file_state
             %td
               /
                 Most files don't exist when the package is linked, so keeping in mind the statement below don't even bother to try to show them


### PR DESCRIPTION
Add colors to 'Added' and 'Deleted' to make distinction to
'Changed' easier to see.

Fixes #2333 

![imagen](https://user-images.githubusercontent.com/11314634/33379946-caffd41a-d519-11e7-98a3-8b19b39a308b.png)
