### PR TITLE
[webui] add branch destination information

### DIFF
--- a/src/api/app/views/webui/package/_branch_dialog.html.erb
+++ b/src/api/app/views/webui/package/_branch_dialog.html.erb
@@ -3,7 +3,10 @@
       <h2 class="box-header">Branch Confirmation</h2>
       <div class="dialog-content">
         <p>
-         Do you really want to branch <%= package_link(@package) %>?<br /><br />
+        Do you want to branch <%= package_link(@package) %> into
+        <%= project_or_package_link(
+              project: User.current.branch_project_name(@package.project.name),
+              short: true) %>?<br /><br />
          <a data-target="#branching-options" data-hidetext="[-] Hide options" data-showtext="[+] More options" class="show-hide">[+] More options</a>
         </p>
       </div>

--- a/src/api/spec/features/webui/maintenance_workflow_spec.rb
+++ b/src/api/spec/features/webui/maintenance_workflow_spec.rb
@@ -34,7 +34,7 @@ RSpec.feature 'MaintenanceWorkflow', type: :feature, js: true do
     visit package_show_path(project: update_project, package: package)
 
     click_link('Branch package')
-    expect(page).to have_text('Do you really want to branch package')
+    expect(page).to have_text('Do you want to branch package')
 
     click_button('Ok')
     expect(page).to have_text('Successfully branched package')


### PR DESCRIPTION
Show (and link to if it already exists) resulting project on the
"Branch Confirmation" dialog.

Fixes #2171

![branch-confirm-one](https://user-images.githubusercontent.com/19352524/33436729-1ca3725a-d5e6-11e7-8234-8ab8f4c38775.png)
![branch-confirm-two](https://user-images.githubusercontent.com/19352524/33436734-1f872f98-d5e6-11e7-89da-1a5a1c74c220.png)
