### PR TITLE
[webui][api] Make description a shortenable key for events.

### DIFF
--- a/src/api/app/models/event/request.rb
+++ b/src/api/app/models/event/request.rb
@@ -2,6 +2,7 @@ class Event::Request < ::Event::Base
   self.description = 'Request was updated'
   self.abstract_class = true
   payload_keys :author, :comment, :description, :number, :actions, :state, :when, :who
+  shortenable_key :description
 
   DiffLimit = 120
 


### PR DESCRIPTION
We are seeing an error occur when an Event::RequestCreate is attempted
to be created and the description is too long to fit in the database.
So the description will be amde "shortenable" so it will shorten it
if its too long.

Fixes: https://errbit-opensuse.herokuapp.com/apps/5620ca2bdc71fa00b1000000/problems/5a10a20652fc66000670fa4d