### PR TITLE
 [backend] Fix perl-DateTime dependency

### DIFF
--- a/dist/obs-server.spec
+++ b/dist/obs-server.spec
@@ -87,7 +87,7 @@ BuildArch:      noarch
 Requires(pre):  obs-common
 Requires:       build >= 20170315
 Requires:       perl-BSSolv >= 0.28
-Requires:       perl(TimeDate)
+Requires:       perl-TimeDate
 # Required by source server
 Requires:       diffutils
 PreReq:         git-core


### PR DESCRIPTION
- bs_mergechanges on source server needs perl-DateTime.
- This should really fix #4176.