### PR TITLE
[ci] Fix failure caused by factory bot change

### DIFF
--- a/src/api/spec/factories/kiwi_preference.rb
+++ b/src/api/spec/factories/kiwi_preference.rb
@@ -1,4 +1,4 @@
-FactoryGirl.define do
+FactoryBot.define do
   factory :kiwi_preference, class: Kiwi::Preference do
     version '2.0'
     type_image 'docker'


### PR DESCRIPTION
PR#4190 was made before that factory got added. So when the PR got
merged this new factory started to break the test suite, because it was
still using the old name.