### PR TITLE
Fix huge bottleneck in notification emails

### DIFF
--- a/src/api/app/models/event/request.rb
+++ b/src/api/app/models/event/request.rb
@@ -134,8 +134,8 @@ module Event
 
     def find_watchers(project_key)
       project_names = payload['actions'].map { |action| action[project_key] }.uniq
-      projects = Project.where(name: project_names).joins(watched_projects: :user)
-      projects.flat_map { |project| project.watched_projects.map(&:user) }
+      watched_projects = WatchedProject.where(project: Project.where(name: project_names))
+      User.where(id: watched_projects.select(:user_id))
     end
   end
 end


### PR DESCRIPTION
The way source_watchers and target_watchers were implemented was pretty
suboptimal. It took >20 seconds to dig out 128 users watching
openSUSE:Factory by going through the WatchedProject objects connected
to these 128 users and listed the users for these, which resulted in
128x128 SELECT user ... - but all we want is the list of 128 User
objects (to filter subscriptions for them)

So the new query results in one SQL statement taking the database a
friction of a second