### PR TITLE
[webui] Fix kiwi editor containerconfig behaviour.

### DIFF
--- a/src/api/app/models/kiwi/image/xml_builder.rb
+++ b/src/api/app/models/kiwi/image/xml_builder.rb
@@ -65,7 +65,9 @@ module Kiwi
       end
 
       def add_preference_type_containerconfig(document)
-        document.xpath('image/preferences/type').first.add_child(@image.preference.containerconfig_xml)
+        if @image.preference.type_containerconfig_tag.present? || @image.preference.type_containerconfig_name.present?
+          document.xpath('image/preferences/type').first.add_child(@image.preference.containerconfig_xml)
+        end
         document
       end
 

--- a/src/api/spec/models/kiwi/image_spec.rb
+++ b/src/api/spec/models/kiwi/image_spec.rb
@@ -216,6 +216,28 @@ RSpec.describe Kiwi::Image, type: :model, vcr: true do
           expect(subject.xpath('.//image/preferences/version').first).not_to be_nil
         end
       end
+
+      context 'with preference type_image = "docker" but without containerconfig attributes' do
+        let(:kiwi_preference) do
+          create(
+            :kiwi_preference,
+            type_image: 'docker',
+            type_containerconfig_name: nil,
+            type_containerconfig_tag: nil
+          )
+        end
+
+        before do
+          kiwi_image.preference = kiwi_preference
+          kiwi_image.save
+        end
+
+        subject { kiwi_image.to_xml }
+
+        it 'output the xml without any mention of containerconfig' do
+          expect(subject).not_to include('<containerconfig')
+        end
+      end
     end
 
     context 'without kiwi image file' do


### PR DESCRIPTION
Only add the preferences/containerconfig tag if there are
containerconfig attributes set.

Fixes https://github.com/openSUSE/open-build-service/issues/4207