### PR TITLE
[frontend] Fix project_log_rotate_manually task

### DIFF
--- a/src/api/lib/tasks/project_log_rotate_manually.rake
+++ b/src/api/lib/tasks/project_log_rotate_manually.rake
@@ -1,5 +1,5 @@
 desc 'Run project log rotate job manually'
-task :project_log_rotate_manually do
+task(project_log_rotate_manually: :environment) do
   event_types = Event::PROJECT_CLASSES | Event::PACKAGE_CLASSES
   oldest_date = 10.days.ago
 


### PR DESCRIPTION
I had forgotten the environment in the task and because of that `Event` couldn't be found. 🙈 

Thanks @mdeniz.