### PR TITLE
[api] Fix payload keys in ServiceSuccess

### DIFF
--- a/src/api/app/models/event/service_success.rb
+++ b/src/api/app/models/event/service_success.rb
@@ -1,7 +1,7 @@
 module Event
   class ServiceSuccess < Base
     self.description = 'Package source service has succeeded'
-    payload_keys :project, :package, :sender, :project, :rev, :user, :requestid
+    payload_keys :project, :package, :sender, :comment, :rev, :user, :requestid
     receiver_roles :maintainer, :bugowner
     create_jobs :update_backend_infos_job
     after_create_commit :send_to_bus


### PR DESCRIPTION
I removed the `comment` key from the `payload keys` and added `project` twice instead in `Event::ServiceSucess` when refactoring the `Event` module in https://github.com/openSUSE/open-build-service/pull/4191 🙈 