### PR TITLE
[frontend] Manually fix Lint/DuplicateMethods offense

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -143,12 +143,6 @@ Lint/BooleanSymbol:
     - 'src/api/spec/features/webui/projects_spec.rb'
     - 'src/api/spec/spec_helper.rb'
 
-# Offense count: 3
-Lint/DuplicateMethods:
-  Exclude:
-    - 'src/api/app/models/history_element.rb'
-    - 'src/api/lib/activexml/node.rb'
-
 # Offense count: 19
 Lint/EmptyWhen:
   Exclude:

--- a/src/api/app/models/history_element.rb
+++ b/src/api/app/models/history_element.rb
@@ -6,9 +6,7 @@ module HistoryElement
     self.table_name = 'history_elements'
 
     class << self
-      attr_accessor :description, :raw_type
-      attr_accessor :comment, :raw_type
-      attr_accessor :created_at, :raw_type
+      attr_accessor :description, :raw_type, :comment, :created_at
     end
 
     def color

--- a/src/api/lib/activexml/node.rb
+++ b/src/api/lib/activexml/node.rb
@@ -40,10 +40,7 @@ module ActiveXML
         @@xml_time = 0
       end
 
-      # transport object, gets defined according to configuration when Base is subclassed
-      attr_reader :transport
-
-      def inherited( subclass )
+      def inherited(subclass)
         # called when a subclass is defined
         # Rails.logger.debug "Initializing ActiveXML model #{subclass}"
         subclass.instance_variable_set '@default_find_parameter', @default_find_parameter


### PR DESCRIPTION
This fixes offenses caused by duplicated method definitions. In the
node.rb file we drop the 'attr_reader :transport', since this got
overwritten by a later definition of the transport method.

Mob-programming with @DavidKang