### PR TITLE
[webui][api] Fix CleanupEvents job

### DIFF
--- a/src/api/app/jobs/cleanup_events.rb
+++ b/src/api/app/jobs/cleanup_events.rb
@@ -3,5 +3,8 @@ class CleanupEvents < ApplicationJob
     Event::Base.transaction do
       Event::Base.where(project_logged: true, mails_sent: true, undone_jobs: 0).lock(true).delete_all
     end
+
+    event_types = Event::PROJECT_CLASSES | Event::PACKAGE_CLASSES
+    Event::Base.where(project_logged: false, mails_sent: true, undone_jobs: 0).where.not(eventtype: event_types).delete_all
   end
 end


### PR DESCRIPTION
Before PR #4197 was merged we would set project_logged = true for all events older
than 10 days. This no longer happens. So we need to make sure we delete those events
who are not of the type which has a ProjectLogEntry created, regardless of whether
or not event.project_logged is set to true or false.