### PR TITLE
[webui][api] Fix CreateProjectLogEntryJob when the entry was not persisted

### DIFF
--- a/src/api/app/jobs/create_project_log_entry_job.rb
+++ b/src/api/app/jobs/create_project_log_entry_job.rb
@@ -3,7 +3,9 @@ class CreateProjectLogEntryJob < ApplicationJob
 
   def perform(event_id)
     event = Event::Base.find(event_id)
-    entry = ProjectLogEntry.create_from(event)
-    event.update_attributes(project_logged: true) if entry.persisted?
+    # If the ProjectLogEntry was invalid then we still mark the event as logged
+    event.update_attributes(project_logged: true)
+
+    ProjectLogEntry.create_from(event)
   end
 end


### PR DESCRIPTION
We have ~2300 events in the db which cannot have a ProjectLogEntry created
for them because the project they relate to no longer exists and project_id
is a required field on ProjectLogEntry. In the past these events would have
been left there and deleted after 10 days but this commit makes it so they get
deleted at the end of the day.