### PR TITLE
[ci] fix plan in 0200-check_docker_registry.ts

### DIFF
--- a/dist/t/osc/0200-check_docker_registry.ts
+++ b/dist/t/osc/0200-check_docker_registry.ts
@@ -9,7 +9,7 @@ use Test::More tests => 2;
 # skipable
 
 SKIP: {
-  skip "tests disabled by default. To enable set ENABLE_DOCKER_REGISTRY_TESTS=1", 1 unless $ENV{ENABLE_DOCKER_REGISTRY_TESTS};
+  skip "tests disabled by default. To enable set ENABLE_DOCKER_REGISTRY_TESTS=1", 2 unless $ENV{ENABLE_DOCKER_REGISTRY_TESTS};
   `osc rdelete -m "testing deleted it" -rf BaseContainer 2>&1`;
   `rm -rf /tmp/BaseContainer`;
   `osc branch openSUSE.org:openSUSE:Templates:Images:42.3:Base  openSUSE-Leap-Container-Base BaseContainer`;


### PR DESCRIPTION
if checks are not activate, we need to skip 2 tests to
keep the plan valid.

without this patch, you get a false positive like:

1..2
ok 1 # skip tests disabled by default. To enable set ENABLE_DOCKER_REGISTRY_TESTS=1
 # Looks like you planned 2 tests but ran 1.