### PR TITLE
[api] Fix attribute creation

### DIFF
--- a/src/api/app/controllers/attribute_controller.rb
+++ b/src/api/app/controllers/attribute_controller.rb
@@ -235,7 +235,8 @@ class AttributeController < ApplicationController
     # init
     req = ActiveXML::Node.new(request.raw_post)
 
-    # checks
+    # This is necessary for checking the authorization and do not create the attribute
+    # The attribute creation will happen in @attribute_container.store_attribute_axml
     req.each('attribute') do |attr|
       attrib_type = AttribType.find_by_namespace_and_name!(attr.value("namespace"), attr.value("name"))
       attrib = Attrib.new(attrib_type: attrib_type)

--- a/src/api/app/mixins/has_attributes.rb
+++ b/src/api/app/mixins/has_attributes.rb
@@ -52,7 +52,7 @@ module HasAttributes
       a.package = self if is_a? Package
       if a.attrib_type.value_count
         a.attrib_type.value_count.times do |i|
-          a.values.build(position: i, value: "")
+          a.values.build(position: i, value: values[i])
         end
       end
       raise AttributeSaveError, a.errors.full_messages.join(", ") unless a.save

--- a/src/api/test/functional/attributes_test.rb
+++ b/src/api/test/functional/attributes_test.rb
@@ -127,6 +127,32 @@ class AttributeControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
     get "/attribute/TEST/Dummy/_meta"
     assert_response :success
+    # use it
+    attrib_data = "<attributes>
+                     <attribute namespace='TEST' name='Dummy' >
+                       <value>M</value>
+                       <value>A</value>
+                     </attribute>
+                   </attributes>"
+    post "/source/home:adrian/_attribute", params: attrib_data
+    assert_response 400
+    assert_match(/Values Value ('|")M('|") is not allowed./, @response.body)
+    get "/source/home:adrian/_attribute"
+    assert_response :success
+    attrib_data = "<attributes>
+                     <attribute namespace='TEST' name='Dummy' >
+                       <value>A</value>
+                       <value>B</value>
+                     </attribute>
+                   </attributes>"
+    post "/source/home:adrian/_attribute", params: attrib_data
+
+    assert_response :success
+    get "/source/home:adrian/_attribute"
+    assert_response :success
+    assert_xml_tag tag: 'value', content: "A"
+    assert_xml_tag tag: 'value', content: "B"
+    # cleanup
     login_Iggy
     delete "/attribute/TEST/Dummy/_meta"
     assert_response 403


### PR DESCRIPTION
attribute_store always set an empty value which caused validations to fail.

Tests cherry-picked from #4235.
Supersedes #4235 for now.

There are more issues we need to resolve in a later PR:
- Authorization does mostly the same what happens in store_attributes, very obfuscating
- There should be a validation for ``validates :attrib_type, uniqueness: { scope: :package / project }``
