### PR TITLE
[api] Fix attribute creation

### DIFF
--- a/ReleaseNotes-2.8.5
+++ b/ReleaseNotes-2.8.5
@@ -19,4 +19,4 @@ Changes:
 Bugfixes:
 =========
 
-* 
+* Fix Attribute creation via API

--- a/src/api/app/mixins/has_attributes.rb
+++ b/src/api/app/mixins/has_attributes.rb
@@ -52,7 +52,7 @@ module HasAttributes
       a.package = self if is_a? Package
       if a.attrib_type.value_count
         a.attrib_type.value_count.times do |i|
-          a.values.build(position: i, value: "")
+          a.values.build(position: i, value: values[i])
         end
       end
       if a.save

--- a/src/api/test/functional/attributes_test.rb
+++ b/src/api/test/functional/attributes_test.rb
@@ -131,6 +131,36 @@ class AttributeControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
     get "/attribute/TEST/Dummy/_meta"
     assert_response :success
+    # use it
+    attrib_data = "<attributes>
+                     <attribute namespace='TEST' name='Dummy' >
+                       <value>M</value>
+                       <value>A</value>
+                     </attribute>
+                   </attributes>"
+    post "/source/home:adrian/_attribute", params: attrib_data
+    assert_response 400
+    assert_match(/Values Value ('|")M('|") is not allowed./, @response.body)
+    get "/source/home:adrian/_attribute"
+    assert_response :success
+    attrib_data = "<attributes>
+                     <attribute namespace='TEST' name='Dummy' >
+                       <value>A</value>
+                       <value>B</value>
+                     </attribute>
+                   </attributes>"
+    post "/source/home:adrian/_attribute", params: attrib_data
+
+    assert_response :success
+    get "/source/home:adrian/_attribute"
+    assert_response :success
+    assert_xml_tag tag: 'value', content: "A"
+    assert_xml_tag tag: 'value', content: "B"
+    # cleanup
+    login_Iggy
+    delete "/attribute/TEST/Dummy/_meta"
+    assert_response 403
+    login_adrian
     delete "/attribute/TEST/Dummy"
     assert_response :success
     get "/attribute/TEST/Dummy/_meta"


### PR DESCRIPTION
attribute_store always set an empty value which caused validations to fail.