### PR TITLE
Disabling some rubocop cops :(

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -37,6 +37,10 @@ Style/Alias:
 Style/CommandLiteral:
   EnforcedStyle: percent_x
 
+# We need to allow some variables related to rabbiMQ.
+Style/GlobalVars:
+  AllowedVariables: ['$rabbitmq_conn', '$rabbitmq_exchange', '$rabbitmq_channel']
+
 # Checks for chaining of a block after another block that spans multiple lines.
 # We disabled this cop because of Rantly.
 Style/MultilineBlockChain:
@@ -47,8 +51,13 @@ Style/MultilineBlockChain:
 Style/RedundantReturn:
   Enabled: false
 
-Style/GlobalVars:
-  AllowedVariables: ['$rabbitmq_conn', '$rabbitmq_exchange', '$rabbitmq_channel']
+# TODO: Disabled until we reach an agreement
+Style/SymbolArray:
+  Enabled: false
+
+# TODO: Disabled until we reach an agreement
+Style/WordArray:
+  Enabled: false
 
 ##################### Metrics ##################################
 

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -613,13 +613,6 @@ Style/StderrPuts:
   Exclude:
     - 'src/api/test/functional/webui/spider_test.rb'
 
-# Offense count: 272
-# Cop supports --auto-correct.
-# Configuration parameters: EnforcedStyle, MinSize, SupportedStyles.
-# SupportedStyles: percent, brackets
-Style/SymbolArray:
-  Enabled: false
-
 # Offense count: 3
 # Cop supports --auto-correct.
 # Configuration parameters: ExactNameMatch, AllowPredicates, AllowDSLWriters, IgnoreClassMethods, Whitelist.
@@ -628,10 +621,3 @@ Style/TrivialAccessors:
   Exclude:
     - 'src/api/lib/activexml/node.rb'
     - 'src/api/test/test_helper.rb'
-
-# Offense count: 128
-# Cop supports --auto-correct.
-# Configuration parameters: EnforcedStyle, SupportedStyles, MinSize, WordRegex.
-# SupportedStyles: percent, brackets
-Style/WordArray:
-  Enabled: false


### PR DESCRIPTION
@openSUSE/open-build-service Please review

The affected cops are:
  * http://rubocop.readthedocs.io/en/latest/cops_style/#stylewordarray
  * http://rubocop.readthedocs.io/en/latest/cops_style/#stylesymbolarray