### PR TITLE
[webui] Only show kiwi preferences under Details tab.

### DIFF
--- a/src/api/app/views/webui/kiwi/_tabs.html.erb
+++ b/src/api/app/views/webui/kiwi/_tabs.html.erb
@@ -1,6 +1,7 @@
 <%= content_for :ready_function do %>
   $("#kiwi_details_trigger").click(function() {
     $("#kiwi-image-details-section").show();
+    $("#kiwi-preferences").show();
     $(".detailed-info").show();
     $("#kiwi-image-repositories-section").hide();
     $("#kiwi-image-packages-section").hide();
@@ -9,6 +10,7 @@
   $("#kiwi_software_trigger").click(function() {
     $("#kiwi-image-repositories-section").show();
     $("#kiwi-image-packages-section").show();
+    $("#kiwi-preferences").hide();
     $(".detailed-info").hide();
     $("#kiwi-image-details-section").hide();
   });

--- a/src/api/app/views/webui/kiwi/images/_preferences.html.haml
+++ b/src/api/app/views/webui/kiwi/images/_preferences.html.haml
@@ -1,46 +1,45 @@
-#kiwi-preferences
-  .nested-fields
-    %h2#image-name
-      Preferences
-    %ul.inline
+.nested-fields
+  %h2#image-name
+    Preferences
+  %ul.inline
+    %li
+      %strong Image type:
+      %span.fill{ data: { tag: 'type_image' }}= @image.preference.type_image
+    %li
+      %strong Version:
+      %span.fill{ data: { tag: 'version' }}= @image.preference.version
+    - if @image.preference.containerconfig_fields_editable?
       %li
-        %strong Image type:
-        %span.fill{ data: { tag: 'type_image' }}= @image.preference.type_image
+        %strong Container config name:
+        %span.fill{ data: { tag: 'type_containerconfig_name' }}= @image.preference.type_containerconfig_name
       %li
-        %strong Version:
-        %span.fill{ data: { tag: 'version' }}= @image.preference.version
-      - if @image.preference.containerconfig_fields_editable?
-        %li
-          %strong Container config name:
-          %span.fill{ data: { tag: 'type_containerconfig_name' }}= @image.preference.type_containerconfig_name
-        %li
-          %strong Container config tag:
-          %span.fill{ data: { tag: 'type_containerconfig_tag' }}= @image.preference.type_containerconfig_tag
-    %p
-      = link_to sprited_text('package_edit', 'Edit preferences'), '#', class: 'preferences_edit'
+        %strong Container config tag:
+        %span.fill{ data: { tag: 'type_containerconfig_tag' }}= @image.preference.type_containerconfig_tag
+  %p
+    = link_to sprited_text('package_edit', 'Edit preferences'), '#', class: 'preferences_edit'
 
-    .dialog.darkgrey_box.hidden{ style: "width: 500px; left: 45%;" }
-      .box.box-shadow
-        %h2.box-header Edit Kiwi Preferences
+  .dialog.darkgrey_box.hidden{ style: "width: 500px; left: 45%;" }
+    .box.box-shadow
+      %h2.box-header Edit Kiwi Preferences
 
-        .dialog-content
-          %p
-            = f.fields_for :preference, f.object.preference do |preference_fields|
+      .dialog-content
+        %p
+          = f.fields_for :preference, f.object.preference do |preference_fields|
+            %p
+              = preference_fields.label :version, 'Version (must be in form Major.Minor.Release)'
+              = preference_fields.text_field :version, data: { default: preference_fields.object.version }
+            - if @image.preference.containerconfig_fields_editable?
               %p
-                = preference_fields.label :version, 'Version (must be in form Major.Minor.Release)'
-                = preference_fields.text_field :version, data: { default: preference_fields.object.version }
-              - if @image.preference.containerconfig_fields_editable?
-                %p
-                  = preference_fields.label :type_containerconfig_name, 'Container Config Name'
-                  = preference_fields.text_field :type_containerconfig_name, data: { default: preference_fields.object.type_containerconfig_name }
-                %p
-                  = preference_fields.label :type_containerconfig_tag, 'Container Config Tag'
-                  = preference_fields.text_field :type_containerconfig_tag, data: { default: preference_fields.object.type_containerconfig_tag }
+                = preference_fields.label :type_containerconfig_name, 'Container Config Name'
+                = preference_fields.text_field :type_containerconfig_name, data: { default: preference_fields.object.type_containerconfig_name }
+              %p
+                = preference_fields.label :type_containerconfig_tag, 'Container Config Tag'
+                = preference_fields.text_field :type_containerconfig_tag, data: { default: preference_fields.object.type_containerconfig_tag }
 
-        %p#flash-messages
-          %p.ui-state-error.ui-widget-shadow.hidden
-            Kiwi Image name can not be empty!
+      %p#flash-messages
+        %p.ui-state-error.ui-widget-shadow.hidden
+          Kiwi Image name can not be empty!
 
-        .dialog-buttons
-          = link_to('Cancel', '#', title: 'Cancel', class: 'revert-dialog')
-          = link_to('Continue', '#', title: 'Continue', class: 'close-preferences-dialog')
+      .dialog-buttons
+        = link_to('Cancel', '#', title: 'Cancel', class: 'revert-dialog')
+        = link_to('Continue', '#', title: 'Continue', class: 'close-preferences-dialog')

--- a/src/api/app/views/webui/kiwi/images/edit.html.haml
+++ b/src/api/app/views/webui/kiwi/images/edit.html.haml
@@ -7,7 +7,7 @@
     = render partial: 'webui/kiwi/tabs'
     = render partial: 'base_info', locals: { f: f }
 
-  .grid_16.alpha.omega.box.box-shadow
+  .grid_16.alpha.omega.box.box-shadow#kiwi-preferences{ class: "#{'hidden' if @is_edit_software_action}" }
     = render partial: 'webui/kiwi/images/preferences', locals: { f: f }
 
   .grid_16.alpha.omega.box.box-shadow#kiwi-image-repositories-section{ class: "#{'hidden' unless @is_edit_software_action}" }


### PR DESCRIPTION
Before this change the preferences box was being shown under both the Details and Software tabs which of course makes no sense.