### PR TITLE
[frontend] Downgrade data_migrate to v3.2.2

### DIFF
--- a/src/api/Gemfile
+++ b/src/api/Gemfile
@@ -69,7 +69,7 @@ gem "gssapi", require: false
 # for sending events to rabbitmq
 gem 'bunny'
 # for making changes to existing data
-gem 'data_migrate'
+gem 'data_migrate', '= 3.2.2'
 # for URI encoding
 gem 'addressable'
 

--- a/src/api/Gemfile.lock
+++ b/src/api/Gemfile.lock
@@ -105,7 +105,7 @@ GEM
     cssmin (1.0.3)
     daemons (1.2.5)
     dalli (2.7.6)
-    data_migrate (3.3.0)
+    data_migrate (3.2.2)
       rails (>= 4.0)
     database_cleaner (1.6.2)
     delayed_job (4.1.3)
@@ -439,7 +439,7 @@ DEPENDENCIES
   cssmin (>= 1.0.2)
   daemons
   dalli
-  data_migrate
+  data_migrate (= 3.2.2)
   database_cleaner (>= 1.0.1)
   delayed_job_active_record (>= 4.0.0)
   escape_utils


### PR DESCRIPTION
This currently causes failures when running 'rake db:migrate:with_data'.

  rake aborted!
  only Ruby-based data_schema files are supported at this time
  (unknown schema format sql)