### PR TITLE
Rubocop - Disabling Rails/DynamicFindBy cop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -76,6 +76,10 @@ Lint/EndAlignment:
 Rails:
   Enabled: true
 
+# Actually is not possible to enable this cop because we have several overwritten methods.
+Rails/DynamicFindBy:
+  Enabled: false
+
 # Enforces that 'exit' calls are not used.
 Rails/Exit:
   Exclude:

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -228,13 +228,6 @@ Naming/VariableNumber:
 Performance/HashEachMethods:
   Enabled: false
 
-# Offense count: 538
-# Cop supports --auto-correct.
-# Configuration parameters: Whitelist.
-# Whitelist: find_by_sql
-Rails/DynamicFindBy:
-  Enabled: false
-
 # Offense count: 83
 Rails/FilePath:
   Enabled: false


### PR DESCRIPTION
Actually is not possible to enable this cop because we have several
overwritten methods.