### PR TITLE
Implement simple prototype for EC2 upload feature

### DIFF
--- a/src/api/app/assets/javascripts/webui/application.js.erb
+++ b/src/api/app/assets/javascripts/webui/application.js.erb
@@ -44,6 +44,7 @@
 //= require webui/application/image_templates
 //= require webui/application/kiwi_editor
 //= require webui/application/groups
+//= require webui/application/upload_jobs
 
 function remove_dialog() {
     $(this).parents('.dialog:visible').remove();

--- a/src/api/app/assets/javascripts/webui/application/upload_jobs.js
+++ b/src/api/app/assets/javascripts/webui/application/upload_jobs.js
@@ -1,0 +1,3 @@
+$(document).ready(function(){
+  $('#upload-jobs').DataTable();
+});

--- a/src/api/app/controllers/webui/cloud/ec2/configurations_controller.rb
+++ b/src/api/app/controllers/webui/cloud/ec2/configurations_controller.rb
@@ -1,0 +1,33 @@
+module Webui
+  module Cloud
+    module Ec2
+      class ConfigurationsController < WebuiController
+        before_action :require_login
+        before_action -> { feature_active?(:cloud_upload) }
+
+        def show
+          @crumb_list = ['EC2 Configuration']
+          @ec2_configuration = User.current.ec2_configuration || User.current.create_ec2_configuration
+          @aws_account_id = CONFIG['aws_account_id']
+        end
+
+        def update
+          @ec2_configuration = User.current.ec2_configuration
+          if @ec2_configuration.update(permitted_params)
+            flash[:success] = 'Successfully updated your EC2 configuration.'
+            redirect_to cloud_upload_index_path
+          else
+            flash[:error] = "Failed to updated your EC2 configuration: #{@ec2_configuration.errors.full_messages.to_sentence}."
+            redirect_back(fallback_location: root_path)
+          end
+        end
+
+        private
+
+        def permitted_params
+          params.require(:ec2_configuration).permit(:id, :arn)
+        end
+      end
+    end
+  end
+end

--- a/src/api/app/controllers/webui/cloud/upload_jobs_controller.rb
+++ b/src/api/app/controllers/webui/cloud/upload_jobs_controller.rb
@@ -1,0 +1,51 @@
+module Webui
+  module Cloud
+    class UploadJobsController < WebuiController
+      before_action :require_login
+      before_action -> { feature_active?(:cloud_upload) }
+      before_action :validate_configuration_presence, :set_breadcrump
+      before_action :set_package, only: :new
+
+      def index
+        @upload_jobs = User.current.upload_jobs
+      end
+
+      def new
+        xml_object = OpenStruct.new(params.slice(:project, :package, :repository, :arch, :filename))
+        @upload_job = ::Cloud::Backend::UploadJob.new(xml_object: xml_object)
+      end
+
+      def create
+        @upload_job = ::Cloud::UploadJob.create(User.current, permitted_params)
+        if @upload_job.valid?
+          flash[:success] = "Successfully created upload job #{@upload_job.id}."
+          redirect_to cloud_upload_index_path
+        else
+          flash[:error] = "Failed to create upload job: #{@upload_job.errors.full_messages.to_sentence}."
+          redirect_back(fallback_location: root_path)
+        end
+      end
+
+      private
+
+      def set_breadcrump
+        @crumb_list = ['Cloud Upload']
+      end
+
+      def validate_configuration_presence
+        redirect_to cloud_ec2_configuration_path if User.current.ec2_configuration.blank?
+      end
+
+      def permitted_params
+        params.require(:cloud_backend_upload_job).permit(:project, :package, :repository, :arch, :filename, :region)
+      end
+
+      def set_package
+        @package = Package.find_by_project_and_name(params[:project], params[:package])
+        return if @package.present?
+        flash[:error] = "Package #{params[:project]}/#{params[:package]} does not exist."
+        redirect_to cloud_upload_index_path
+      end
+    end
+  end
+end

--- a/src/api/app/helpers/webui/package_helper.rb
+++ b/src/api/app/helpers/webui/package_helper.rb
@@ -88,4 +88,8 @@ module Webui::PackageHelper
   def repo_type_and_priority(repository)
     [repository.repo_type, repository.priority].compact.join(', Priority: ')
   end
+
+  def cloud_image_file?(filename)
+    filename.end_with?('.raw.xz', '.vhdfixed.xz')
+  end
 end

--- a/src/api/app/models/cloud/backend/upload_job.rb
+++ b/src/api/app/models/cloud/backend/upload_job.rb
@@ -1,0 +1,53 @@
+module Cloud
+  module Backend
+    class UploadJob
+      include ActiveModel::Model
+      include ActiveModel::Validations
+      extend Forwardable
+
+      attr_accessor :xml, :exception
+      attr_writer :xml_object
+      def_delegators :xml_object,
+                     :name,
+                     :state,
+                     :details,
+                     :target,
+                     :user,
+                     :project,
+                     :package,
+                     :repository,
+                     :arch,
+                     :filename,
+                     :size,
+                     :backend_response
+      alias_method :id, :name
+      alias_method :platform, :target
+      alias_method :architecture, :arch
+      validate :validate_xml
+
+      def self.create(user, params)
+        xml = ::Backend::Api::Cloud.upload(user, params)
+
+        new(xml: xml)
+      rescue ActiveXML::Transport::Error, Timeout::Error => exception
+        new(exception: exception.message)
+      end
+
+      private
+
+      def xml_object
+        @xml_object ||= OpenStruct.new(xml_hash)
+      end
+
+      def xml_hash
+        @xml_hash ||= Xmlhash.parse(xml) if xml
+      end
+
+      def validate_xml
+        return if exception.blank?
+        message = Xmlhash.parse(exception).try(:fetch, 'summary', nil) || exception
+        errors.add(:base, message)
+      end
+    end
+  end
+end

--- a/src/api/app/models/cloud/ec2/configuration.rb
+++ b/src/api/app/models/cloud/ec2/configuration.rb
@@ -1,0 +1,33 @@
+module Cloud
+  module Ec2
+    class Configuration < ApplicationRecord
+      has_secure_token :external_id
+      belongs_to :user, required: true
+
+      validates :external_id, :arn, uniqueness: true
+      # http://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html
+      validates :arn, format: { with: /\Aarn:([\w\-\/:])+\z/, message: 'not a valid format', allow_blank: true }
+
+      def self.table_name_prefix
+        'cloud_ec2_'
+      end
+    end
+  end
+end
+
+# == Schema Information
+#
+# Table name: cloud_ec2_configurations
+#
+#  id          :integer          not null, primary key
+#  user_id     :integer          indexed
+#  external_id :string(255)      indexed => [arn]
+#  arn         :string(255)      indexed => [external_id]
+#  created_at  :datetime         not null
+#  updated_at  :datetime         not null
+#
+# Indexes
+#
+#  index_cloud_ec2_configurations_on_external_id_and_arn  (external_id,arn) UNIQUE
+#  index_cloud_ec2_configurations_on_user_id              (user_id)
+#

--- a/src/api/app/models/cloud/upload_job.rb
+++ b/src/api/app/models/cloud/upload_job.rb
@@ -1,0 +1,35 @@
+module Cloud
+  class UploadJob
+    include ActiveModel::Validations
+    include ActiveModel::Model
+    extend Forwardable
+
+    attr_accessor :user_upload_job, :backend_upload_job
+    validate :validate_jobs
+    def_delegator :backend_upload_job, :id
+
+    def self.create(user, params)
+      upload_job = new
+      upload_job.backend_upload_job = Cloud::Backend::UploadJob.create(user, params)
+      return upload_job unless upload_job.backend_upload_job.valid?
+
+      upload_job.user_upload_job = user.upload_jobs.create(job_id: upload_job.id)
+      upload_job
+    end
+
+    private
+
+    def validate_jobs
+      if backend_upload_job.present? && backend_upload_job.invalid?
+        backend_upload_job.errors.full_messages.each do |msg|
+          errors.add(:backend_upload_job, msg)
+        end
+      end
+
+      return if user_upload_job.blank? || user_upload_job.valid?
+      user_upload_job.errors.full_messages.each do |msg|
+        errors.add(:user_upload_job, msg)
+      end
+    end
+  end
+end

--- a/src/api/app/models/cloud/user/upload_job.rb
+++ b/src/api/app/models/cloud/user/upload_job.rb
@@ -1,0 +1,31 @@
+module Cloud
+  module User
+    class UploadJob < ApplicationRecord
+      belongs_to :user, required: true, class_name: '::User'
+
+      scope :ec2, -> { where(type: :ec2) }
+
+      validates :job_id, presence: true, uniqueness: true
+
+      def self.table_name_prefix
+        'cloud_user_'
+      end
+    end
+  end
+end
+
+# == Schema Information
+#
+# Table name: cloud_user_upload_jobs
+#
+#  id         :integer          not null, primary key
+#  user_id    :integer          indexed
+#  job_id     :integer          indexed
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#
+# Indexes
+#
+#  index_cloud_user_upload_jobs_on_job_id   (job_id) UNIQUE
+#  index_cloud_user_upload_jobs_on_user_id  (user_id)
+#

--- a/src/api/app/models/user.rb
+++ b/src/api/app/models/user.rb
@@ -53,6 +53,9 @@ class User < ApplicationRecord
   # users have 0..1 user_registration records assigned to them
   has_one :user_registration
 
+  has_one :ec2_configuration, class_name: 'Cloud::Ec2::Configuration', dependent: :destroy
+  has_many :upload_jobs, class_name: 'Cloud::User::UploadJob', dependent: :destroy
+
   has_many :rss_feed_items, -> { order(created_at: :desc) }, class_name: 'Notification::RssFeedItem', as: :subscriber, dependent: :destroy
 
   scope :all_without_nobody, -> { where('login != ?', nobody_login) }

--- a/src/api/app/views/webui/cloud/ec2/configurations/show.html.haml
+++ b/src/api/app/views/webui/cloud/ec2/configurations/show.html.haml
@@ -1,0 +1,57 @@
+%h1
+  Amazon EC2 Configuration
+
+%p
+  Before the Open Build Service can upload appliances to Amazon EC2, you need to enable some configuration in your AWS Account.
+
+%h2 SSH Key
+%p
+  %ul
+    %li Select the Region you want to upload the image.
+    %li
+      Go to
+      %i
+        Network & Security -> Key Pairs -> Import Key Pair
+      and paste the OBS public key:
+      %pre
+        ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQConqL/iFLOoV5Ts7dXMQ4hGTnv9Cn+Dvalh/JDaQ9lU2TBfdoYIjqkcw1ARiKLbynmZ9ktCX2Nmxi2HCsUYP0S2z+2KbQn2WRWF1Gel5tgwNqaed85bnySg3oPLqI2fVEUdQdCA2P73P/c4/nXkunlZc6PVPQX4Q28xaYvXRfcZS8cNW5Uhxc357uPuNXSsbUIXwRZGwfHi7jBoXOincj+YBdx86+NTAlltIRqXrn3l+Paq2JDm1gLmw9pThhfpzm/eX6BKaODG7sIGVGgOeulgxVimAxsXJDVJtNC20ITU0HrPJjqfQ0pNQj86LKm+2y20JplMw0aEXWVnSD+4ixX
+    %li Make sure that default security group has the permission to SSH into the machine.
+
+%h2 Roles and permissions
+%p
+  %ul
+    %li
+      Go to
+      %i
+        IAM -> Roles -> Create role
+      and select
+      %i
+        Another AWS Account.
+    %li
+      Enter
+      %b
+        = @aws_account_id
+      as
+      %i
+        Account ID.
+    %li
+      Select option
+      %i
+        Require external ID
+      and enter
+      %b
+        = @ec2_configuration.external_id
+      as External ID.
+    %li
+      Attach
+      %i
+        AmazonEC2FullAccess
+      permission policy and create the role.
+
+= form_for @ec2_configuration, url: cloud_ec2_configuration_path, method: :put do
+  %p
+    Please enter now the obtained
+    %b
+      Amazon Resouce Name (ARN):
+    = text_field :ec2_configuration, :arn, value: @ec2_configuration.arn
+    = submit_tag "Submit"

--- a/src/api/app/views/webui/cloud/upload_jobs/index.html.haml
+++ b/src/api/app/views/webui/cloud/upload_jobs/index.html.haml
@@ -1,0 +1,18 @@
+%h1
+  Cloud Upload
+
+%div
+  %table#upload-jobs
+    %thead
+      %tr
+        %th #
+        %th Platform
+    %tbody
+      - @upload_jobs.each do |job|
+        %tr
+          %td= job.job_id
+          %td EC2
+
+%div
+  %p
+    = link_to 'Update your EC2 Configuration', cloud_ec2_configuration_path

--- a/src/api/app/views/webui/cloud/upload_jobs/new.html.haml
+++ b/src/api/app/views/webui/cloud/upload_jobs/new.html.haml
@@ -1,0 +1,26 @@
+%h1
+  EC2 Uploader
+
+%p
+  Select the Amazon EC2 region to which you want to upload your cloud image.
+  Please note that it is necessary to have the OBS public key available in this region before starting the upload job.
+  Please have a lookt at your
+  = link_to "Amazon EC2 configuration", cloud_ec2_configuration_path
+  for more information.
+
+= form_for @upload_job, url: cloud_upload_index_path, method: :post do |person_form|
+  %p
+    Upload image
+    %b
+      = @upload_job.filename
+    to region
+    = select_tag('cloud_backend_upload_job[region]', options_for_select([['us-east-1', 'us-east-1'], ['us-east-2', 'us-east-2']], 'us-east-2'))
+    = person_form.hidden_field :project
+    = person_form.hidden_field :package
+    = person_form.hidden_field :arch
+    = person_form.hidden_field :repository
+    = person_form.hidden_field :filename
+    = submit_tag 'Upload'
+
+%p
+  = link_to "All Cloud Uploads", cloud_upload_index_path

--- a/src/api/app/views/webui/kiwi/images/_base_info.html.haml
+++ b/src/api/app/views/webui/kiwi/images/_base_info.html.haml
@@ -15,5 +15,7 @@
     %p
       = link_to(sprited_text('package', 'View Package'), package_show_path(@package.project, @package))
       = link_to(sprited_text('package_edit', 'Edit details'), '#', class: "description_edit detailed-info #{'hidden' unless @is_edit_details_action}")
+      - if Feature.active?(:cloud_upload) && !User.current.is_nobody?
+        = link_to(sprited_text('drive_web', 'Cloud Upload'), cloud_upload_index_path, id: 'cloud-upload')
     - if action_name == 'edit'
       = render partial: 'description_form', locals: { f: f }

--- a/src/api/app/views/webui/package/binary.html.erb
+++ b/src/api/app/views/webui/package/binary.html.erb
@@ -33,6 +33,19 @@
   <p><strong>Size:</strong> <%= human_readable_fsize(@fileinfo.value(:size).to_i) %></p>
   <p><strong>Build Time:</strong> <%= btime = Time.at(@fileinfo.value(:mtime).to_i)
   btime.to_s + " (" + fuzzy_time_string(btime.ctime) + ")" %></p>
+  <% if Feature.active?(:cloud_upload) && !User.current.is_nobody? && cloud_image_file?(@filename) %>
+    <p><strong>Cloud Upload</strong></p>
+    <p>
+      The Open Build Service can upload appliances to Cloud providers like Amazon EC2 or Microsoft Azure.
+    </p>
+    <p>
+      <%= button_tag(type: 'button') do
+        link_to "Upload to EC2", new_cloud_upload_path(project: @project, package: @package, repository: @repository, arch: @arch, filename: @filename)
+      end
+      %>
+    </p>
+  <% end %>
+
 </div>
 
 <%= render :partial => "deps" %>

--- a/src/api/app/views/webui/package/show.html.erb
+++ b/src/api/app/views/webui/package/show.html.erb
@@ -119,6 +119,13 @@
                     </li>
                   <% end %>
                 <% end %>
+                <% if Feature.active?(:cloud_upload) && !User.current.is_nobody? %>
+                  <% if @package.kiwi_image? %>
+                    <li>
+                      <%= link_to(sprited_text('drive_web', 'Cloud Upload'), cloud_upload_index_path, id: 'cloud-upload') %>
+                    </li>
+                  <% end %>
+                <% end %>
                 <% if @services.present? %>
                   <li>
                     <%= link_to(sprited_text('package_link', 'Trigger services'), { action: :trigger_services, package: @package, project: @project }, method: :post) %>

--- a/src/api/config/feature.yml
+++ b/src/api/config/feature.yml
@@ -2,13 +2,16 @@ production:
   features: &default
     image_templates: true
     kiwi_image_editor: false
+    cloud_upload: false
 
 development:
   features:
     <<: *default
     kiwi_image_editor: true
+    cloud_upload: true
 
 test:
   features:
     <<: *default
     kiwi_image_editor: true
+    cloud_upload: true

--- a/src/api/config/routes.rb
+++ b/src/api/config/routes.rb
@@ -202,6 +202,17 @@ OBSApi::Application.routes.draw do
       end
     end
 
+    resource :cloud, only: [] do
+      resources :upload, only: [:index, :create], controller: 'webui/cloud/upload_jobs' do
+        new do
+          get ':project/:package/:repository/:arch/:filename', to: 'webui/cloud/upload_jobs#new', as: '', constraints: cons
+        end
+      end
+      resource :ec2, only: [] do
+        resource :configuration, only: [:show, :update], controller: 'webui/cloud/ec2/configurations'
+      end
+    end
+
     controller 'webui/project' do
       get 'project/' => :index, as: 'projects'
       get 'project/list_public' => :index

--- a/src/api/db/migrate/20171218160607_create_ec2_configuration.rb
+++ b/src/api/db/migrate/20171218160607_create_ec2_configuration.rb
@@ -1,0 +1,12 @@
+class CreateEc2Configuration < ActiveRecord::Migration[5.1]
+  def change
+    create_table :cloud_ec2_configurations, id: :integer do |t|
+      t.belongs_to :user, index: true, type: :integer
+      t.string :external_id
+      t.string :arn
+
+      t.timestamps
+    end
+    add_index :cloud_ec2_configurations, [:external_id, :arn], unique: true
+  end
+end

--- a/src/api/db/migrate/20171219122451_create_upload_job.rb
+++ b/src/api/db/migrate/20171219122451_create_upload_job.rb
@@ -1,0 +1,11 @@
+class CreateUploadJob < ActiveRecord::Migration[5.1]
+  def change
+    create_table :cloud_user_upload_jobs, id: :integer do |t|
+      t.belongs_to :user, index: true, type: :integer
+      t.integer :job_id
+
+      t.timestamps
+    end
+    add_index :cloud_user_upload_jobs, :job_id, unique: true
+  end
+end

--- a/src/api/db/structure.sql
+++ b/src/api/db/structure.sql
@@ -322,6 +322,29 @@ CREATE TABLE `channels` (
   CONSTRAINT `channels_ibfk_1` FOREIGN KEY (`package_id`) REFERENCES `packages` (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
 
+CREATE TABLE `cloud_ec2_configurations` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `user_id` int(11) DEFAULT NULL,
+  `external_id` varchar(255) DEFAULT NULL,
+  `arn` varchar(255) DEFAULT NULL,
+  `created_at` datetime NOT NULL,
+  `updated_at` datetime NOT NULL,
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `index_cloud_ec2_configurations_on_external_id_and_arn` (`external_id`,`arn`),
+  KEY `index_cloud_ec2_configurations_on_user_id` (`user_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+CREATE TABLE `cloud_user_upload_jobs` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `user_id` int(11) DEFAULT NULL,
+  `job_id` int(11) DEFAULT NULL,
+  `created_at` datetime NOT NULL,
+  `updated_at` datetime NOT NULL,
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `index_cloud_user_upload_jobs_on_job_id` (`job_id`),
+  KEY `index_cloud_user_upload_jobs_on_user_id` (`user_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
 CREATE TABLE `comments` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `body` text COLLATE utf8_unicode_ci,
@@ -1288,6 +1311,8 @@ INSERT INTO `schema_migrations` (version) VALUES
 ('20171102110929'),
 ('20171107125828'),
 ('20171109095756'),
-('20171212083426');
+('20171212083426'),
+('20171218160607'),
+('20171219122451');
 
 

--- a/src/api/lib/backend/api/cloud.rb
+++ b/src/api/lib/backend/api/cloud.rb
@@ -1,0 +1,20 @@
+module Backend
+  module Api
+    module Cloud
+      extend Backend::ConnectionHelper
+      # Triggers a cloud upload job
+      # @return [String]
+      def self.upload(user, params, target_name = 'ec2')
+        region = params.delete(:region)
+        data = user.ec2_configuration.attributes.except('id', 'created_at', 'updated_at').merge(region: region).to_json
+        post(['/cloudupload'], params: params.merge(user: user.login, target: target_name), data: data)
+      end
+
+      # Returns the status of a cloud upload job
+      # @return [String]
+      def self.status(job_id)
+        get(['/cloudupload', job_id])
+      end
+    end
+  end
+end

--- a/src/api/lib/feature_switch/obs_repository.rb
+++ b/src/api/lib/feature_switch/obs_repository.rb
@@ -4,7 +4,8 @@ module Feature
     #
     class ObsRepository < YamlRepository
       DEFAULTS = {
-        image_templates: true
+        image_templates: true,
+        cloud_upload:    false
       }.freeze
 
       # Returns list of active features

--- a/src/api/spec/cassettes/Cloud_Backend_UploadJob/_create/with_an_invalid_backend_response/1_1_2_1.yml
+++ b/src/api/spec/cassettes/Cloud_Backend_UploadJob/_create/with_an_invalid_backend_response/1_1_2_1.yml
@@ -1,0 +1,183 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: http://backend:5352/cloudupload?arch=x86_64&filename=appliance.raw.gz&package=aws&project=Cloud&repository=standard&target=ec2&user=user_2
+    body:
+      encoding: UTF-8
+      string: '{"user_id":2,"external_id":"yl1pkw2ts0cba6gcrfqtpp3r","arn":"arn:bo504d032p","region":"us-east-1"}'
+    headers:
+      Content-Type:
+      - application/octet-stream
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 400
+      message: no cloud upload server configurated
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '87'
+    body:
+      encoding: UTF-8
+      string: |
+        <status code="400">
+          <summary>no cloud upload server configurated</summary>
+        </status>
+    http_version: 
+  recorded_at: Fri, 22 Dec 2017 12:56:55 GMT
+- request:
+    method: post
+    uri: http://backend:5352/cloudupload?arch=x86_64&filename=appliance.raw.gz&package=aws&project=Cloud&repository=standard&target=ec2&user=user_4
+    body:
+      encoding: UTF-8
+      string: '{"user_id":4,"external_id":"6qur2ui4lmfbrn5qgjped3kp","arn":"arn:wjjaceyg90","region":"us-east-1"}'
+    headers:
+      Content-Type:
+      - application/octet-stream
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 400
+      message: no cloud upload server configurated
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '87'
+    body:
+      encoding: UTF-8
+      string: |
+        <status code="400">
+          <summary>no cloud upload server configurated</summary>
+        </status>
+    http_version: 
+  recorded_at: Fri, 22 Dec 2017 13:00:59 GMT
+- request:
+    method: post
+    uri: http://backend:5352/cloudupload?arch=x86_64&filename=appliance.raw.gz&package=aws&project=Cloud&repository=standard&target=ec2&user=user_30
+    body:
+      encoding: UTF-8
+      string: '{"user_id":30,"external_id":"yuflomjn33sp45qjmo55xd4c","arn":"arn:4w1wcjcvgr","region":"us-east-1"}'
+    headers:
+      Content-Type:
+      - application/octet-stream
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 400
+      message: no cloud upload server configurated
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '87'
+    body:
+      encoding: UTF-8
+      string: |
+        <status code="400">
+          <summary>no cloud upload server configurated</summary>
+        </status>
+    http_version: 
+  recorded_at: Fri, 22 Dec 2017 13:02:05 GMT
+- request:
+    method: post
+    uri: http://backend:5352/cloudupload?arch=x86_64&filename=appliance.raw.gz&package=aws&project=Cloud&repository=standard&target=ec2&user=user_28
+    body:
+      encoding: UTF-8
+      string: '{"user_id":28,"external_id":"o4nokpfn7z0wys19x15331i9","arn":"arn:bg9vkjxerl","region":"us-east-1"}'
+    headers:
+      Content-Type:
+      - application/octet-stream
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 400
+      message: no cloud upload server configurated
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '87'
+    body:
+      encoding: UTF-8
+      string: |
+        <status code="400">
+          <summary>no cloud upload server configurated</summary>
+        </status>
+    http_version: 
+  recorded_at: Fri, 22 Dec 2017 13:02:57 GMT
+- request:
+    method: post
+    uri: http://backend:5352/cloudupload?arch=x86_64&filename=appliance.raw.gz&package=aws&project=Cloud&repository=standard&target=ec2&user=tom
+    body:
+      encoding: UTF-8
+      string: '{"user_id":4,"external_id":"k2nhwdfrx2kayrqvqfdd77x8","arn":"arn:ani6sgtour","region":"us-east-1"}'
+    headers:
+      Content-Type:
+      - application/octet-stream
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 400
+      message: no cloud upload server configurated
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '87'
+    body:
+      encoding: UTF-8
+      string: |
+        <status code="400">
+          <summary>no cloud upload server configurated</summary>
+        </status>
+    http_version: 
+  recorded_at: Fri, 22 Dec 2017 13:44:50 GMT
+recorded_with: VCR 4.0.0

--- a/src/api/spec/cassettes/Cloud_Backend_UploadJob/_create/with_an_invalid_backend_response/1_1_2_2.yml
+++ b/src/api/spec/cassettes/Cloud_Backend_UploadJob/_create/with_an_invalid_backend_response/1_1_2_2.yml
@@ -1,0 +1,147 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: http://backend:5352/cloudupload?arch=x86_64&filename=appliance.raw.gz&package=aws&project=Cloud&repository=standard&target=ec2&user=user_4
+    body:
+      encoding: UTF-8
+      string: '{"user_id":4,"external_id":"0ak2mwcnyn8oupsswto51z8v","arn":"arn:gyljmqxjp7","region":"us-east-1"}'
+    headers:
+      Content-Type:
+      - application/octet-stream
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 400
+      message: no cloud upload server configurated
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '87'
+    body:
+      encoding: UTF-8
+      string: |
+        <status code="400">
+          <summary>no cloud upload server configurated</summary>
+        </status>
+    http_version: 
+  recorded_at: Fri, 22 Dec 2017 12:59:57 GMT
+- request:
+    method: post
+    uri: http://backend:5352/cloudupload?arch=x86_64&filename=appliance.raw.gz&package=aws&project=Cloud&repository=standard&target=ec2&user=user_2
+    body:
+      encoding: UTF-8
+      string: '{"user_id":2,"external_id":"zn340ha0knl0gq8nb9wnxevi","arn":"arn:an8kd10ayr","region":"us-east-1"}'
+    headers:
+      Content-Type:
+      - application/octet-stream
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 400
+      message: no cloud upload server configurated
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '87'
+    body:
+      encoding: UTF-8
+      string: |
+        <status code="400">
+          <summary>no cloud upload server configurated</summary>
+        </status>
+    http_version: 
+  recorded_at: Fri, 22 Dec 2017 13:00:59 GMT
+- request:
+    method: post
+    uri: http://backend:5352/cloudupload?arch=x86_64&filename=appliance.raw.gz&package=aws&project=Cloud&repository=standard&target=ec2&user=user_32
+    body:
+      encoding: UTF-8
+      string: '{"user_id":32,"external_id":"33z9nqih0bxfxtt0k6ar0pj3","arn":"arn:4dr7ffnyf2","region":"us-east-1"}'
+    headers:
+      Content-Type:
+      - application/octet-stream
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 400
+      message: no cloud upload server configurated
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '87'
+    body:
+      encoding: UTF-8
+      string: |
+        <status code="400">
+          <summary>no cloud upload server configurated</summary>
+        </status>
+    http_version: 
+  recorded_at: Fri, 22 Dec 2017 13:02:05 GMT
+- request:
+    method: post
+    uri: http://backend:5352/cloudupload?arch=x86_64&filename=appliance.raw.gz&package=aws&project=Cloud&repository=standard&target=ec2&user=user_26
+    body:
+      encoding: UTF-8
+      string: '{"user_id":26,"external_id":"ejsogl23r8mjz7nmegaz01va","arn":"arn:3xx6bf7h1l","region":"us-east-1"}'
+    headers:
+      Content-Type:
+      - application/octet-stream
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 400
+      message: no cloud upload server configurated
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '87'
+    body:
+      encoding: UTF-8
+      string: |
+        <status code="400">
+          <summary>no cloud upload server configurated</summary>
+        </status>
+    http_version: 
+  recorded_at: Fri, 22 Dec 2017 13:02:57 GMT
+recorded_with: VCR 4.0.0

--- a/src/api/spec/cassettes/Cloud_Backend_UploadJob/_create/with_an_invalid_backend_response/has_the_correct_error_message.yml
+++ b/src/api/spec/cassettes/Cloud_Backend_UploadJob/_create/with_an_invalid_backend_response/has_the_correct_error_message.yml
@@ -1,0 +1,75 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: http://backend:5352/cloudupload?arch=x86_64&filename=appliance.raw.gz&package=aws&project=Cloud&repository=standard&target=ec2&user=user_2
+    body:
+      encoding: UTF-8
+      string: '{"user_id":2,"external_id":"25g6n136gxfmlwkmg4c9t4fw","arn":"arn:z8mmuzjwyz","region":"us-east-1"}'
+    headers:
+      Content-Type:
+      - application/octet-stream
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 400
+      message: no cloud upload server configurated
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '87'
+    body:
+      encoding: UTF-8
+      string: |
+        <status code="400">
+          <summary>no cloud upload server configurated</summary>
+        </status>
+    http_version: 
+  recorded_at: Fri, 22 Dec 2017 13:05:23 GMT
+- request:
+    method: post
+    uri: http://backend:5352/cloudupload?arch=x86_64&filename=appliance.raw.gz&package=aws&project=Cloud&repository=standard&target=ec2&user=tom
+    body:
+      encoding: UTF-8
+      string: '{"user_id":2,"external_id":"mh3lr0by0j0ln21ic0cqo45g","arn":"arn:gdum5fc6qc","region":"us-east-1"}'
+    headers:
+      Content-Type:
+      - application/octet-stream
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 400
+      message: no cloud upload server configurated
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '87'
+    body:
+      encoding: UTF-8
+      string: |
+        <status code="400">
+          <summary>no cloud upload server configurated</summary>
+        </status>
+    http_version: 
+  recorded_at: Fri, 22 Dec 2017 13:44:50 GMT
+recorded_with: VCR 4.0.0

--- a/src/api/spec/cassettes/Cloud_UploadJob/_create/with_an_invalid_Backend_UploadJob/1_1_2_1.yml
+++ b/src/api/spec/cassettes/Cloud_UploadJob/_create/with_an_invalid_Backend_UploadJob/1_1_2_1.yml
@@ -1,0 +1,39 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: http://backend:5352/cloudupload?arch=x86_64&filename=appliance.raw.gz&package=aws&project=Cloud&repository=standard&target=ec2&user=tom
+    body:
+      encoding: UTF-8
+      string: '{"user_id":10,"external_id":"xu849ofp983ujuv0bb0x54zz","arn":"arn:vd7jjmiecs","region":"us-east-1"}'
+    headers:
+      Content-Type:
+      - application/octet-stream
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 400
+      message: no cloud upload server configurated
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '87'
+    body:
+      encoding: UTF-8
+      string: |
+        <status code="400">
+          <summary>no cloud upload server configurated</summary>
+        </status>
+    http_version: 
+  recorded_at: Fri, 22 Dec 2017 13:42:37 GMT
+recorded_with: VCR 4.0.0

--- a/src/api/spec/cassettes/Cloud_UploadJob/_create/with_an_invalid_Backend_UploadJob/has_the_correct_error_message.yml
+++ b/src/api/spec/cassettes/Cloud_UploadJob/_create/with_an_invalid_Backend_UploadJob/has_the_correct_error_message.yml
@@ -1,0 +1,39 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: http://backend:5352/cloudupload?arch=x86_64&filename=appliance.raw.gz&package=aws&project=Cloud&repository=standard&target=ec2&user=tom
+    body:
+      encoding: UTF-8
+      string: '{"user_id":12,"external_id":"p7t0qevxiznqkrvo8kupj7go","arn":"arn:teed9shvxc","region":"us-east-1"}'
+    headers:
+      Content-Type:
+      - application/octet-stream
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 400
+      message: no cloud upload server configurated
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '87'
+    body:
+      encoding: UTF-8
+      string: |
+        <status code="400">
+          <summary>no cloud upload server configurated</summary>
+        </status>
+    http_version: 
+  recorded_at: Fri, 22 Dec 2017 13:42:38 GMT
+recorded_with: VCR 4.0.0

--- a/src/api/spec/cassettes/ImageTemplates/branching/branch_image_template.yml
+++ b/src/api/spec/cassettes/ImageTemplates/branching/branch_image_template.yml
@@ -2398,4 +2398,39 @@ http_interactions:
         </directory>
     http_version: 
   recorded_at: Thu, 19 Oct 2017 10:56:39 GMT
-recorded_with: VCR 3.0.3
+- request:
+    method: get
+    uri: http://backend:5352/source/home:tom:branches:my_project/custom_name
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 404
+      message: project 'home tom branches my_project' does not exist
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '184'
+    body:
+      encoding: UTF-8
+      string: |
+        <status code="404">
+          <summary>project 'home:tom:branches:my_project' does not exist</summary>
+          <details>404 project 'home:tom:branches:my_project' does not exist</details>
+        </status>
+    http_version: 
+  recorded_at: Wed, 03 Jan 2018 14:29:21 GMT
+recorded_with: VCR 4.0.0

--- a/src/api/spec/cassettes/Packages/Viewing_a_package_that/has_a_mime_like_suffix_in_it_s_name.yml
+++ b/src/api/spec/cassettes/Packages/Viewing_a_package_that/has_a_mime_like_suffix_in_it_s_name.yml
@@ -325,4 +325,474 @@ http_interactions:
         </status>
     http_version: 
   recorded_at: Tue, 16 May 2017 15:09:26 GMT
-recorded_with: VCR 3.0.3
+- request:
+    method: put
+    uri: http://backend:5352/source/home:package_test_user/_meta?user=package_test_user
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:package_test_user">
+          <title/>
+          <description/>
+          <person userid="package_test_user" role="maintainer"/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '157'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:package_test_user">
+          <title></title>
+          <description></description>
+          <person userid="package_test_user" role="maintainer" />
+        </project>
+    http_version: 
+  recorded_at: Wed, 03 Jan 2018 13:13:53 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:package_test_user/test_package/_meta?user=package_test_user
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="test_package" project="home:package_test_user">
+          <title>Ego Dominus Tuus</title>
+          <description>Odio odit ratione commodi debitis non cumque molestias vero.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '198'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="test_package" project="home:package_test_user">
+          <title>Ego Dominus Tuus</title>
+          <description>Odio odit ratione commodi debitis non cumque molestias vero.</description>
+        </package>
+    http_version: 
+  recorded_at: Wed, 03 Jan 2018 13:13:53 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:package_test_user/test_package/_meta
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="test_package" project="home:package_test_user">
+          <title>Ego Dominus Tuus</title>
+          <description>Odio odit ratione commodi debitis non cumque molestias vero.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '198'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="test_package" project="home:package_test_user">
+          <title>Ego Dominus Tuus</title>
+          <description>Odio odit ratione commodi debitis non cumque molestias vero.</description>
+        </package>
+    http_version: 
+  recorded_at: Wed, 03 Jan 2018 13:13:53 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:package_test_user/test_package/_config
+    body:
+      encoding: UTF-8
+      string: Dicta odio et nihil nostrum totam nihil. Quia minima ab molestiae. In
+        suscipit distinctio error ad labore est.
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '207'
+    body:
+      encoding: UTF-8
+      string: |
+        <revision rev="2" vrev="2">
+          <srcmd5>c849a1d9be425bd3c83769b5f2ca7c9f</srcmd5>
+          <version>unknown</version>
+          <time>1514985233</time>
+          <user>unknown</user>
+          <comment></comment>
+          <requestid/>
+        </revision>
+    http_version: 
+  recorded_at: Wed, 03 Jan 2018 13:13:53 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:package_test_user/test_package/somefile.txt
+    body:
+      encoding: UTF-8
+      string: Consequatur ab nostrum. Blanditiis rerum eaque voluptates officiis sint
+        architecto. Quam consequuntur autem. Ut delectus omnis.
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '207'
+    body:
+      encoding: UTF-8
+      string: |
+        <revision rev="3" vrev="3">
+          <srcmd5>f69d66eae19594b626fe6cc073afcde5</srcmd5>
+          <version>unknown</version>
+          <time>1514985233</time>
+          <user>unknown</user>
+          <comment></comment>
+          <requestid/>
+        </revision>
+    http_version: 
+  recorded_at: Wed, 03 Jan 2018 13:13:53 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:other_package_test_user/_meta?user=other_package_test_user
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:other_package_test_user">
+          <title/>
+          <description/>
+          <person userid="other_package_test_user" role="maintainer"/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '169'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:other_package_test_user">
+          <title></title>
+          <description></description>
+          <person userid="other_package_test_user" role="maintainer" />
+        </project>
+    http_version: 
+  recorded_at: Wed, 03 Jan 2018 13:13:53 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:other_package_test_user/branch_test_package/_meta?user=package_test_user
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="branch_test_package" project="home:other_package_test_user">
+          <title>To Your Scattered Bodies Go</title>
+          <description>Unde qui id aut sint ex.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '186'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="branch_test_package" project="home:other_package_test_user">
+          <title>To Your Scattered Bodies Go</title>
+          <description>Unde qui id aut sint ex.</description>
+        </package>
+    http_version: 
+  recorded_at: Wed, 03 Jan 2018 13:13:53 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:other_package_test_user/branch_test_package/_meta
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="branch_test_package" project="home:other_package_test_user">
+          <title>To Your Scattered Bodies Go</title>
+          <description>Unde qui id aut sint ex.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '186'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="branch_test_package" project="home:other_package_test_user">
+          <title>To Your Scattered Bodies Go</title>
+          <description>Unde qui id aut sint ex.</description>
+        </package>
+    http_version: 
+  recorded_at: Wed, 03 Jan 2018 13:13:53 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:other_package_test_user/branch_test_package/_config
+    body:
+      encoding: UTF-8
+      string: Magnam qui commodi est nam fuga. Omnis voluptas praesentium excepturi
+        alias magnam omnis. Tenetur accusamus placeat autem sint autem.
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '207'
+    body:
+      encoding: UTF-8
+      string: |
+        <revision rev="4" vrev="4">
+          <srcmd5>61e2ab4eb2fa044c631926c905a877f3</srcmd5>
+          <version>unknown</version>
+          <time>1514985233</time>
+          <user>unknown</user>
+          <comment></comment>
+          <requestid/>
+        </revision>
+    http_version: 
+  recorded_at: Wed, 03 Jan 2018 13:13:53 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:other_package_test_user/branch_test_package/somefile.txt
+    body:
+      encoding: UTF-8
+      string: Consequatur ab nostrum. Blanditiis rerum eaque voluptates officiis sint
+        architecto. Quam consequuntur autem. Ut delectus omnis.
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '207'
+    body:
+      encoding: UTF-8
+      string: |
+        <revision rev="5" vrev="5">
+          <srcmd5>6e2fdcf66f8c0db09adf9aa631781ab7</srcmd5>
+          <version>unknown</version>
+          <time>1514985233</time>
+          <user>unknown</user>
+          <comment></comment>
+          <requestid/>
+        </revision>
+    http_version: 
+  recorded_at: Wed, 03 Jan 2018 13:13:53 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:package_test_user/test.json/_meta?user=package_test_user
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="test.json" project="home:package_test_user">
+          <title>Françoise Sagan</title>
+          <description>A package with a mime type suffix</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '168'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        PHBhY2thZ2UgbmFtZT0idGVzdC5qc29uIiBwcm9qZWN0PSJob21lOnBhY2thZ2VfdGVzdF91c2VyIj4KICA8dGl0bGU+RnJhbsOnb2lzZSBTYWdhbjwvdGl0bGU+CiAgPGRlc2NyaXB0aW9uPkEgcGFja2FnZSB3aXRoIGEgbWltZSB0eXBlIHN1ZmZpeDwvZGVzY3JpcHRpb24+CjwvcGFja2FnZT4K
+    http_version: 
+  recorded_at: Wed, 03 Jan 2018 13:13:54 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:package_test_user/test.json/_meta
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="test.json" project="home:package_test_user">
+          <title>Françoise Sagan</title>
+          <description>A package with a mime type suffix</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '168'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        PHBhY2thZ2UgbmFtZT0idGVzdC5qc29uIiBwcm9qZWN0PSJob21lOnBhY2thZ2VfdGVzdF91c2VyIj4KICA8dGl0bGU+RnJhbsOnb2lzZSBTYWdhbjwvdGl0bGU+CiAgPGRlc2NyaXB0aW9uPkEgcGFja2FnZSB3aXRoIGEgbWltZSB0eXBlIHN1ZmZpeDwvZGVzY3JpcHRpb24+CjwvcGFja2FnZT4K
+    http_version: 
+  recorded_at: Wed, 03 Jan 2018 13:13:54 GMT
+recorded_with: VCR 4.0.0

--- a/src/api/spec/cassettes/Packages/Viewing_a_package_that/was_branched.yml
+++ b/src/api/spec/cassettes/Packages/Viewing_a_package_that/was_branched.yml
@@ -1161,4 +1161,82 @@ http_interactions:
 '
     http_version: 
   recorded_at: Fri, 28 Apr 2017 11:53:31 GMT
-recorded_with: VCR 3.0.3
+- request:
+    method: put
+    uri: http://backend:5352/source/home:package_test_user/test_package/_meta?user=package_test_user
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="test_package" project="home:package_test_user">
+          <title>The Way Through the Woods</title>
+          <description>Voluptas ut aperiam sit id ea quidem amet.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '189'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="test_package" project="home:package_test_user">
+          <title>The Way Through the Woods</title>
+          <description>Voluptas ut aperiam sit id ea quidem amet.</description>
+        </package>
+    http_version: 
+  recorded_at: Wed, 03 Jan 2018 13:14:14 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:other_package_test_user/branch_test_package/_meta?user=package_test_user
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="branch_test_package" project="home:other_package_test_user">
+          <title>Many Waters</title>
+          <description>Voluptatum ut ea doloremque consectetur minima.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '193'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="branch_test_package" project="home:other_package_test_user">
+          <title>Many Waters</title>
+          <description>Voluptatum ut ea doloremque consectetur minima.</description>
+        </package>
+    http_version: 
+  recorded_at: Wed, 03 Jan 2018 13:14:14 GMT
+recorded_with: VCR 4.0.0

--- a/src/api/spec/cassettes/Packages/adding_a_valid_file.yml
+++ b/src/api/spec/cassettes/Packages/adding_a_valid_file.yml
@@ -1491,4 +1491,150 @@ http_interactions:
         </status>
     http_version: 
   recorded_at: Fri, 16 Jun 2017 14:23:11 GMT
-recorded_with: VCR 3.0.3
+- request:
+    method: put
+    uri: http://backend:5352/source/home:other_package_test_user/branch_test_package/_meta?user=package_test_user
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="branch_test_package" project="home:other_package_test_user">
+          <title>This Side of Paradise</title>
+          <description>Minus est iste sit voluptas deleniti.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '193'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="branch_test_package" project="home:other_package_test_user">
+          <title>This Side of Paradise</title>
+          <description>Minus est iste sit voluptas deleniti.</description>
+        </package>
+    http_version: 
+  recorded_at: Wed, 03 Jan 2018 13:13:18 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:package_test_user/test_package?rev=6
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 404
+      message: package 'test_package' does not exist
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '152'
+    body:
+      encoding: UTF-8
+      string: |
+        <status code="404">
+          <summary>package 'test_package' does not exist</summary>
+          <details>404 package 'test_package' does not exist</details>
+        </status>
+    http_version: 
+  recorded_at: Wed, 03 Jan 2018 13:13:20 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:package_test_user/test_package/_meta?user=package_test_user
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="test_package" project="home:package_test_user">
+          <title>Butter In a Lordly Dish</title>
+          <description>Tempore corporis odit dolorem.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '175'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="test_package" project="home:package_test_user">
+          <title>Butter In a Lordly Dish</title>
+          <description>Tempore corporis odit dolorem.</description>
+        </package>
+    http_version: 
+  recorded_at: Wed, 03 Jan 2018 13:13:21 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:package_test_user/test_package
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '87'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="test_package" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
+        </directory>
+    http_version: 
+  recorded_at: Wed, 03 Jan 2018 13:13:21 GMT
+recorded_with: VCR 4.0.0

--- a/src/api/spec/cassettes/Packages/adding_an_invalid_file.yml
+++ b/src/api/spec/cassettes/Packages/adding_an_invalid_file.yml
@@ -1357,4 +1357,150 @@ http_interactions:
         </status>
     http_version: 
   recorded_at: Fri, 16 Jun 2017 14:23:08 GMT
-recorded_with: VCR 3.0.3
+- request:
+    method: put
+    uri: http://backend:5352/source/home:package_test_user/test_package/_meta?user=package_test_user
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="test_package" project="home:package_test_user">
+          <title>Surprised by Joy</title>
+          <description>Corrupti numquam placeat suscipit ipsum quia sed rerum.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '193'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="test_package" project="home:package_test_user">
+          <title>Surprised by Joy</title>
+          <description>Corrupti numquam placeat suscipit ipsum quia sed rerum.</description>
+        </package>
+    http_version: 
+  recorded_at: Wed, 03 Jan 2018 13:13:41 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:other_package_test_user/branch_test_package/_meta?user=package_test_user
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="branch_test_package" project="home:other_package_test_user">
+          <title>The Lathe of Heaven</title>
+          <description>Ea deleniti nisi ut qui ut ut qui repellat.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '197'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="branch_test_package" project="home:other_package_test_user">
+          <title>The Lathe of Heaven</title>
+          <description>Ea deleniti nisi ut qui ut ut qui repellat.</description>
+        </package>
+    http_version: 
+  recorded_at: Wed, 03 Jan 2018 13:13:42 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:package_test_user/test_package
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '200'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="test_package" rev="1" vrev="1" srcmd5="76f14d7f71d84f62e33056b3e088d941">
+          <entry name="_config" md5="59b46c46338e845890c00a2811779a58" size="102" mtime="1514985210" />
+        </directory>
+    http_version: 
+  recorded_at: Wed, 03 Jan 2018 13:13:44 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:package_test_user/test_package
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '200'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="test_package" rev="1" vrev="1" srcmd5="76f14d7f71d84f62e33056b3e088d941">
+          <entry name="_config" md5="59b46c46338e845890c00a2811779a58" size="102" mtime="1514985210" />
+        </directory>
+    http_version: 
+  recorded_at: Wed, 03 Jan 2018 13:13:44 GMT
+recorded_with: VCR 4.0.0

--- a/src/api/spec/cassettes/Packages/behaves_like_user_tab/group_roles/Add_group_to_package_/_project.yml
+++ b/src/api/spec/cassettes/Packages/behaves_like_user_tab/group_roles/Add_group_to_package_/_project.yml
@@ -591,4 +591,365 @@ http_interactions:
         </status>
     http_version: 
   recorded_at: Fri, 16 Jun 2017 14:23:39 GMT
-recorded_with: VCR 3.0.3
+- request:
+    method: put
+    uri: http://backend:5352/source/home:package_test_user/_meta?user=package_test_user
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:package_test_user">
+          <title/>
+          <description/>
+          <person userid="package_test_user" role="maintainer"/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '157'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:package_test_user">
+          <title></title>
+          <description></description>
+          <person userid="package_test_user" role="maintainer" />
+        </project>
+    http_version: 
+  recorded_at: Wed, 03 Jan 2018 13:15:06 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:user_tab_user/_meta?user=user_tab_user
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:user_tab_user">
+          <title/>
+          <description/>
+          <person userid="user_tab_user" role="maintainer"/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '149'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:user_tab_user">
+          <title></title>
+          <description></description>
+          <person userid="user_tab_user" role="maintainer" />
+        </project>
+    http_version: 
+  recorded_at: Wed, 03 Jan 2018 13:15:06 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:user_tab_user/group_test_package/_meta?user=package_test_user
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="group_test_package" project="home:user_tab_user">
+          <title>Mr Standfast</title>
+          <description>Quis dolores veniam velit sit.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '166'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="group_test_package" project="home:user_tab_user">
+          <title>Mr Standfast</title>
+          <description>Quis dolores veniam velit sit.</description>
+        </package>
+    http_version: 
+  recorded_at: Wed, 03 Jan 2018 13:15:06 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:user_tab_user/group_test_package/_meta
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="group_test_package" project="home:user_tab_user">
+          <title>Mr Standfast</title>
+          <description>Quis dolores veniam velit sit.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '166'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="group_test_package" project="home:user_tab_user">
+          <title>Mr Standfast</title>
+          <description>Quis dolores veniam velit sit.</description>
+        </package>
+    http_version: 
+  recorded_at: Wed, 03 Jan 2018 13:15:06 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:other_user/_meta?user=other_user
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:other_user">
+          <title/>
+          <description/>
+          <person userid="other_user" role="maintainer"/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '143'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:other_user">
+          <title></title>
+          <description></description>
+          <person userid="other_user" role="maintainer" />
+        </project>
+    http_version: 
+  recorded_at: Wed, 03 Jan 2018 13:15:07 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:other_user/branch_test_package/_meta?user=package_test_user
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="branch_test_package" project="home:other_user">
+          <title>A Confederacy of Dunces</title>
+          <description>Numquam velit aut non qui.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '171'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="branch_test_package" project="home:other_user">
+          <title>A Confederacy of Dunces</title>
+          <description>Numquam velit aut non qui.</description>
+        </package>
+    http_version: 
+  recorded_at: Wed, 03 Jan 2018 13:15:07 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:other_user/branch_test_package/_config
+    body:
+      encoding: UTF-8
+      string: Dicta nobis sit laborum possimus fugit voluptas. Sint dolor dolores
+        qui eligendi assumenda. Quas quod assumenda voluptatem dolorum hic eos quasi.
+        Minus ipsam sunt et.
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '207'
+    body:
+      encoding: UTF-8
+      string: |
+        <revision rev="1" vrev="1">
+          <srcmd5>f81f412cfa23a3de75150944af0d8ca4</srcmd5>
+          <version>unknown</version>
+          <time>1514985307</time>
+          <user>unknown</user>
+          <comment></comment>
+          <requestid/>
+        </revision>
+    http_version: 
+  recorded_at: Wed, 03 Jan 2018 13:15:07 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:user_tab_user/group_test_package
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '93'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="group_test_package" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
+        </directory>
+    http_version: 
+  recorded_at: Wed, 03 Jan 2018 13:15:09 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:user_tab_user/group_test_package/_meta?user=user_tab_user
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="group_test_package" project="home:user_tab_user">
+          <title>Mr Standfast</title>
+          <description>Quis dolores veniam velit sit.</description>
+          <person userid="user_tab_user" role="maintainer"/>
+          <group groupid="existing_group" role="bugowner"/>
+          <group groupid="existing_group" role="maintainer"/>
+          <group groupid="other_group" role="maintainer"/>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '380'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="group_test_package" project="home:user_tab_user">
+          <title>Mr Standfast</title>
+          <description>Quis dolores veniam velit sit.</description>
+          <person userid="user_tab_user" role="maintainer" />
+          <group groupid="existing_group" role="bugowner" />
+          <group groupid="existing_group" role="maintainer" />
+          <group groupid="other_group" role="maintainer" />
+        </package>
+    http_version: 
+  recorded_at: Wed, 03 Jan 2018 13:15:10 GMT
+recorded_with: VCR 4.0.0

--- a/src/api/spec/cassettes/Packages/behaves_like_user_tab/group_roles/Add_role_to_group.yml
+++ b/src/api/spec/cassettes/Packages/behaves_like_user_tab/group_roles/Add_role_to_group.yml
@@ -955,4 +955,398 @@ http_interactions:
         </status>
     http_version: 
   recorded_at: Fri, 16 Jun 2017 14:23:36 GMT
-recorded_with: VCR 3.0.3
+- request:
+    method: put
+    uri: http://backend:5352/source/home:package_test_user/_meta?user=package_test_user
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:package_test_user">
+          <title/>
+          <description/>
+          <person userid="package_test_user" role="maintainer"/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '157'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:package_test_user">
+          <title></title>
+          <description></description>
+          <person userid="package_test_user" role="maintainer" />
+        </project>
+    http_version: 
+  recorded_at: Wed, 03 Jan 2018 13:15:50 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:user_tab_user/_meta?user=user_tab_user
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:user_tab_user">
+          <title/>
+          <description/>
+          <person userid="user_tab_user" role="maintainer"/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '149'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:user_tab_user">
+          <title></title>
+          <description></description>
+          <person userid="user_tab_user" role="maintainer" />
+        </project>
+    http_version: 
+  recorded_at: Wed, 03 Jan 2018 13:15:50 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:user_tab_user/group_test_package/_meta?user=user_tab_user
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="group_test_package" project="home:user_tab_user">
+          <title>Dulce et Decorum Est</title>
+          <description>Natus est dolor qui illo rerum autem ex.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '184'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="group_test_package" project="home:user_tab_user">
+          <title>Dulce et Decorum Est</title>
+          <description>Natus est dolor qui illo rerum autem ex.</description>
+        </package>
+    http_version: 
+  recorded_at: Wed, 03 Jan 2018 13:15:50 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:user_tab_user/group_test_package/_meta
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="group_test_package" project="home:user_tab_user">
+          <title>Dulce et Decorum Est</title>
+          <description>Natus est dolor qui illo rerum autem ex.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '184'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="group_test_package" project="home:user_tab_user">
+          <title>Dulce et Decorum Est</title>
+          <description>Natus est dolor qui illo rerum autem ex.</description>
+        </package>
+    http_version: 
+  recorded_at: Wed, 03 Jan 2018 13:15:50 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:other_user/_meta?user=other_user
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:other_user">
+          <title/>
+          <description/>
+          <person userid="other_user" role="maintainer"/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '143'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:other_user">
+          <title></title>
+          <description></description>
+          <person userid="other_user" role="maintainer" />
+        </project>
+    http_version: 
+  recorded_at: Wed, 03 Jan 2018 13:15:50 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:other_user/branch_test_package/_meta?user=user_tab_user
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="branch_test_package" project="home:other_user">
+          <title>Paths of Glory</title>
+          <description>Eius est sed ex qui.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '156'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="branch_test_package" project="home:other_user">
+          <title>Paths of Glory</title>
+          <description>Eius est sed ex qui.</description>
+        </package>
+    http_version: 
+  recorded_at: Wed, 03 Jan 2018 13:15:50 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:other_user/branch_test_package/_config
+    body:
+      encoding: UTF-8
+      string: Placeat et reiciendis officia enim dolorum. Ducimus alias consequuntur.
+        Dolorem quas quasi beatae commodi. Magnam cupiditate minima sunt. Est eaque
+        eveniet.
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '207'
+    body:
+      encoding: UTF-8
+      string: |
+        <revision rev="4" vrev="4">
+          <srcmd5>2fe9cd2c9f3861154d92e8a8b97629a4</srcmd5>
+          <version>unknown</version>
+          <time>1514985350</time>
+          <user>unknown</user>
+          <comment></comment>
+          <requestid/>
+        </revision>
+    http_version: 
+  recorded_at: Wed, 03 Jan 2018 13:15:50 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:user_tab_user/group_test_package/_meta?user=user_tab_user
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="group_test_package" project="home:user_tab_user">
+          <title>Dulce et Decorum Est</title>
+          <description>Natus est dolor qui illo rerum autem ex.</description>
+          <person userid="user_tab_user" role="maintainer"/>
+          <group groupid="existing_group" role="bugowner"/>
+          <group groupid="existing_group" role="maintainer"/>
+          <group groupid="existing_group" role="reviewer"/>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '399'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="group_test_package" project="home:user_tab_user">
+          <title>Dulce et Decorum Est</title>
+          <description>Natus est dolor qui illo rerum autem ex.</description>
+          <person userid="user_tab_user" role="maintainer" />
+          <group groupid="existing_group" role="bugowner" />
+          <group groupid="existing_group" role="maintainer" />
+          <group groupid="existing_group" role="reviewer" />
+        </package>
+    http_version: 
+  recorded_at: Wed, 03 Jan 2018 13:15:52 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:user_tab_user/group_test_package
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '93'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="group_test_package" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
+        </directory>
+    http_version: 
+  recorded_at: Wed, 03 Jan 2018 13:15:52 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:user_tab_user/group_test_package
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '93'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="group_test_package" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
+        </directory>
+    http_version: 
+  recorded_at: Wed, 03 Jan 2018 13:15:52 GMT
+recorded_with: VCR 4.0.0

--- a/src/api/spec/cassettes/Packages/behaves_like_user_tab/group_roles/Remove_role_from_group.yml
+++ b/src/api/spec/cassettes/Packages/behaves_like_user_tab/group_roles/Remove_role_from_group.yml
@@ -956,4 +956,436 @@ http_interactions:
         </status>
     http_version: 
   recorded_at: Fri, 16 Jun 2017 14:23:44 GMT
-recorded_with: VCR 3.0.3
+- request:
+    method: put
+    uri: http://backend:5352/source/home:package_test_user/_meta?user=package_test_user
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:package_test_user">
+          <title/>
+          <description/>
+          <person userid="package_test_user" role="maintainer"/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '157'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:package_test_user">
+          <title></title>
+          <description></description>
+          <person userid="package_test_user" role="maintainer" />
+        </project>
+    http_version: 
+  recorded_at: Wed, 03 Jan 2018 13:15:21 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:user_tab_user/_meta?user=user_tab_user
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:user_tab_user">
+          <title/>
+          <description/>
+          <person userid="user_tab_user" role="maintainer"/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '149'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:user_tab_user">
+          <title></title>
+          <description></description>
+          <person userid="user_tab_user" role="maintainer" />
+        </project>
+    http_version: 
+  recorded_at: Wed, 03 Jan 2018 13:15:21 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:user_tab_user/group_test_package/_meta?user=user_tab_user
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="group_test_package" project="home:user_tab_user">
+          <title>If Not Now, When?</title>
+          <description>Eius illum provident omnis perspiciatis voluptate.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '191'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="group_test_package" project="home:user_tab_user">
+          <title>If Not Now, When?</title>
+          <description>Eius illum provident omnis perspiciatis voluptate.</description>
+        </package>
+    http_version: 
+  recorded_at: Wed, 03 Jan 2018 13:15:21 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:user_tab_user/group_test_package/_meta
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="group_test_package" project="home:user_tab_user">
+          <title>If Not Now, When?</title>
+          <description>Eius illum provident omnis perspiciatis voluptate.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '191'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="group_test_package" project="home:user_tab_user">
+          <title>If Not Now, When?</title>
+          <description>Eius illum provident omnis perspiciatis voluptate.</description>
+        </package>
+    http_version: 
+  recorded_at: Wed, 03 Jan 2018 13:15:21 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:other_user/_meta?user=other_user
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:other_user">
+          <title/>
+          <description/>
+          <person userid="other_user" role="maintainer"/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '143'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:other_user">
+          <title></title>
+          <description></description>
+          <person userid="other_user" role="maintainer" />
+        </project>
+    http_version: 
+  recorded_at: Wed, 03 Jan 2018 13:15:21 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:other_user/branch_test_package/_meta?user=user_tab_user
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="branch_test_package" project="home:other_user">
+          <title>The Violent Bear It Away</title>
+          <description>Sint dolores asperiores ea esse atque.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '184'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="branch_test_package" project="home:other_user">
+          <title>The Violent Bear It Away</title>
+          <description>Sint dolores asperiores ea esse atque.</description>
+        </package>
+    http_version: 
+  recorded_at: Wed, 03 Jan 2018 13:15:22 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:other_user/branch_test_package/_config
+    body:
+      encoding: UTF-8
+      string: In occaecati debitis ut. Ut error reprehenderit qui cupiditate excepturi
+        autem velit. Cumque porro repellendus quam possimus assumenda.
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '207'
+    body:
+      encoding: UTF-8
+      string: |
+        <revision rev="2" vrev="2">
+          <srcmd5>1bcb8f5d71287384f62055cb0e354363</srcmd5>
+          <version>unknown</version>
+          <time>1514985322</time>
+          <user>unknown</user>
+          <comment></comment>
+          <requestid/>
+        </revision>
+    http_version: 
+  recorded_at: Wed, 03 Jan 2018 13:15:22 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:user_tab_user/group_test_package/_meta?user=user_tab_user
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="group_test_package" project="home:user_tab_user">
+          <title>If Not Now, When?</title>
+          <description>Eius illum provident omnis perspiciatis voluptate.</description>
+          <person userid="user_tab_user" role="maintainer"/>
+          <group groupid="existing_group" role="maintainer"/>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '300'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="group_test_package" project="home:user_tab_user">
+          <title>If Not Now, When?</title>
+          <description>Eius illum provident omnis perspiciatis voluptate.</description>
+          <person userid="user_tab_user" role="maintainer" />
+          <group groupid="existing_group" role="maintainer" />
+        </package>
+    http_version: 
+  recorded_at: Wed, 03 Jan 2018 13:15:24 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:user_tab_user/group_test_package/_meta?user=user_tab_user
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="group_test_package" project="home:user_tab_user">
+          <title>If Not Now, When?</title>
+          <description>Eius illum provident omnis perspiciatis voluptate.</description>
+          <person userid="user_tab_user" role="maintainer"/>
+          <group groupid="existing_group" role="maintainer"/>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '300'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="group_test_package" project="home:user_tab_user">
+          <title>If Not Now, When?</title>
+          <description>Eius illum provident omnis perspiciatis voluptate.</description>
+          <person userid="user_tab_user" role="maintainer" />
+          <group groupid="existing_group" role="maintainer" />
+        </package>
+    http_version: 
+  recorded_at: Wed, 03 Jan 2018 13:15:24 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:user_tab_user/group_test_package
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '93'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="group_test_package" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
+        </directory>
+    http_version: 
+  recorded_at: Wed, 03 Jan 2018 13:15:24 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:user_tab_user/group_test_package
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '93'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="group_test_package" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
+        </directory>
+    http_version: 
+  recorded_at: Wed, 03 Jan 2018 13:15:24 GMT
+recorded_with: VCR 4.0.0

--- a/src/api/spec/cassettes/Packages/behaves_like_user_tab/group_roles/Viewing_group_roles.yml
+++ b/src/api/spec/cassettes/Packages/behaves_like_user_tab/group_roles/Viewing_group_roles.yml
@@ -591,4 +591,317 @@ http_interactions:
         </status>
     http_version: 
   recorded_at: Fri, 16 Jun 2017 14:23:32 GMT
-recorded_with: VCR 3.0.3
+- request:
+    method: put
+    uri: http://backend:5352/source/home:package_test_user/_meta?user=package_test_user
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:package_test_user">
+          <title/>
+          <description/>
+          <person userid="package_test_user" role="maintainer"/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '157'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:package_test_user">
+          <title></title>
+          <description></description>
+          <person userid="package_test_user" role="maintainer" />
+        </project>
+    http_version: 
+  recorded_at: Wed, 03 Jan 2018 13:15:36 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:user_tab_user/_meta?user=user_tab_user
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:user_tab_user">
+          <title/>
+          <description/>
+          <person userid="user_tab_user" role="maintainer"/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '149'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:user_tab_user">
+          <title></title>
+          <description></description>
+          <person userid="user_tab_user" role="maintainer" />
+        </project>
+    http_version: 
+  recorded_at: Wed, 03 Jan 2018 13:15:36 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:user_tab_user/group_test_package/_meta?user=user_tab_user
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="group_test_package" project="home:user_tab_user">
+          <title>The Cricket on the Hearth</title>
+          <description>Blanditiis autem similique ut eaque.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '185'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="group_test_package" project="home:user_tab_user">
+          <title>The Cricket on the Hearth</title>
+          <description>Blanditiis autem similique ut eaque.</description>
+        </package>
+    http_version: 
+  recorded_at: Wed, 03 Jan 2018 13:15:37 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:user_tab_user/group_test_package/_meta
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="group_test_package" project="home:user_tab_user">
+          <title>The Cricket on the Hearth</title>
+          <description>Blanditiis autem similique ut eaque.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '185'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="group_test_package" project="home:user_tab_user">
+          <title>The Cricket on the Hearth</title>
+          <description>Blanditiis autem similique ut eaque.</description>
+        </package>
+    http_version: 
+  recorded_at: Wed, 03 Jan 2018 13:15:37 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:other_user/_meta?user=other_user
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:other_user">
+          <title/>
+          <description/>
+          <person userid="other_user" role="maintainer"/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '143'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:other_user">
+          <title></title>
+          <description></description>
+          <person userid="other_user" role="maintainer" />
+        </project>
+    http_version: 
+  recorded_at: Wed, 03 Jan 2018 13:15:37 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:other_user/branch_test_package/_meta?user=user_tab_user
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="branch_test_package" project="home:other_user">
+          <title>Look Homeward, Angel</title>
+          <description>Eveniet sit possimus maiores ea quisquam aut maxime.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '194'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="branch_test_package" project="home:other_user">
+          <title>Look Homeward, Angel</title>
+          <description>Eveniet sit possimus maiores ea quisquam aut maxime.</description>
+        </package>
+    http_version: 
+  recorded_at: Wed, 03 Jan 2018 13:15:37 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:other_user/branch_test_package/_config
+    body:
+      encoding: UTF-8
+      string: Est est tempora omnis sapiente eius. In et praesentium. At quis aut
+        inventore. Hic quidem ratione debitis quibusdam amet numquam ex.
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '207'
+    body:
+      encoding: UTF-8
+      string: |
+        <revision rev="3" vrev="3">
+          <srcmd5>c649e8ed3c30e5f01941986fd2e4ec83</srcmd5>
+          <version>unknown</version>
+          <time>1514985338</time>
+          <user>unknown</user>
+          <comment></comment>
+          <requestid/>
+        </revision>
+    http_version: 
+  recorded_at: Wed, 03 Jan 2018 13:15:38 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:user_tab_user/group_test_package
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '93'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="group_test_package" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
+        </directory>
+    http_version: 
+  recorded_at: Wed, 03 Jan 2018 13:15:39 GMT
+recorded_with: VCR 4.0.0

--- a/src/api/spec/cassettes/Packages/behaves_like_user_tab/user_roles/Add_role_to_user.yml
+++ b/src/api/spec/cassettes/Packages/behaves_like_user_tab/user_roles/Add_role_to_user.yml
@@ -955,4 +955,438 @@ http_interactions:
         </status>
     http_version: 
   recorded_at: Fri, 16 Jun 2017 14:23:47 GMT
-recorded_with: VCR 3.0.3
+- request:
+    method: put
+    uri: http://backend:5352/source/home:package_test_user/_meta?user=package_test_user
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:package_test_user">
+          <title/>
+          <description/>
+          <person userid="package_test_user" role="maintainer"/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '157'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:package_test_user">
+          <title></title>
+          <description></description>
+          <person userid="package_test_user" role="maintainer" />
+        </project>
+    http_version: 
+  recorded_at: Wed, 03 Jan 2018 13:16:40 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:user_tab_user/_meta?user=user_tab_user
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:user_tab_user">
+          <title/>
+          <description/>
+          <person userid="user_tab_user" role="maintainer"/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '149'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:user_tab_user">
+          <title></title>
+          <description></description>
+          <person userid="user_tab_user" role="maintainer" />
+        </project>
+    http_version: 
+  recorded_at: Wed, 03 Jan 2018 13:16:40 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:user_tab_user/group_test_package/_meta?user=user_tab_user
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="group_test_package" project="home:user_tab_user">
+          <title>Shall not Perish</title>
+          <description>Qui possimus omnis accusantium.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '171'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="group_test_package" project="home:user_tab_user">
+          <title>Shall not Perish</title>
+          <description>Qui possimus omnis accusantium.</description>
+        </package>
+    http_version: 
+  recorded_at: Wed, 03 Jan 2018 13:16:40 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:user_tab_user/group_test_package/_meta
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="group_test_package" project="home:user_tab_user">
+          <title>Shall not Perish</title>
+          <description>Qui possimus omnis accusantium.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '171'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="group_test_package" project="home:user_tab_user">
+          <title>Shall not Perish</title>
+          <description>Qui possimus omnis accusantium.</description>
+        </package>
+    http_version: 
+  recorded_at: Wed, 03 Jan 2018 13:16:40 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:other_user/_meta?user=other_user
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:other_user">
+          <title/>
+          <description/>
+          <person userid="other_user" role="maintainer"/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '143'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:other_user">
+          <title></title>
+          <description></description>
+          <person userid="other_user" role="maintainer" />
+        </project>
+    http_version: 
+  recorded_at: Wed, 03 Jan 2018 13:16:40 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:other_user/branch_test_package/_meta?user=user_tab_user
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="branch_test_package" project="home:other_user">
+          <title>Butter In a Lordly Dish</title>
+          <description>Omnis eum earum et culpa cumque sint.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '182'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="branch_test_package" project="home:other_user">
+          <title>Butter In a Lordly Dish</title>
+          <description>Omnis eum earum et culpa cumque sint.</description>
+        </package>
+    http_version: 
+  recorded_at: Wed, 03 Jan 2018 13:16:40 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:other_user/branch_test_package/_config
+    body:
+      encoding: UTF-8
+      string: Ut sed voluptas dicta id vitae ipsum repellat. Natus voluptas doloribus
+        distinctio. Quo ex eum dolor debitis. Fuga molestias dolorem.
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '207'
+    body:
+      encoding: UTF-8
+      string: |
+        <revision rev="8" vrev="8">
+          <srcmd5>d837c43b42a66704b978a58bb82003ca</srcmd5>
+          <version>unknown</version>
+          <time>1514985400</time>
+          <user>unknown</user>
+          <comment></comment>
+          <requestid/>
+        </revision>
+    http_version: 
+  recorded_at: Wed, 03 Jan 2018 13:16:40 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:reader_user/_meta?user=reader_user
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:reader_user">
+          <title/>
+          <description/>
+          <person userid="reader_user" role="maintainer"/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '145'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:reader_user">
+          <title></title>
+          <description></description>
+          <person userid="reader_user" role="maintainer" />
+        </project>
+    http_version: 
+  recorded_at: Wed, 03 Jan 2018 13:16:40 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:user_tab_user/group_test_package/_meta?user=user_tab_user
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="group_test_package" project="home:user_tab_user">
+          <title>Shall not Perish</title>
+          <description>Qui possimus omnis accusantium.</description>
+          <person userid="user_tab_user" role="bugowner"/>
+          <person userid="user_tab_user" role="maintainer"/>
+          <person userid="reader_user" role="reader"/>
+          <person userid="user_tab_user" role="reviewer"/>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '377'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="group_test_package" project="home:user_tab_user">
+          <title>Shall not Perish</title>
+          <description>Qui possimus omnis accusantium.</description>
+          <person userid="user_tab_user" role="bugowner" />
+          <person userid="user_tab_user" role="maintainer" />
+          <person userid="reader_user" role="reader" />
+          <person userid="user_tab_user" role="reviewer" />
+        </package>
+    http_version: 
+  recorded_at: Wed, 03 Jan 2018 13:16:42 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:user_tab_user/group_test_package
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '93'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="group_test_package" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
+        </directory>
+    http_version: 
+  recorded_at: Wed, 03 Jan 2018 13:16:43 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:user_tab_user/group_test_package
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '93'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="group_test_package" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
+        </directory>
+    http_version: 
+  recorded_at: Wed, 03 Jan 2018 13:16:43 GMT
+recorded_with: VCR 4.0.0

--- a/src/api/spec/cassettes/Packages/behaves_like_user_tab/user_roles/Add_user_to_package_/_project.yml
+++ b/src/api/spec/cassettes/Packages/behaves_like_user_tab/user_roles/Add_user_to_package_/_project.yml
@@ -592,4 +592,406 @@ http_interactions:
         </status>
     http_version: 
   recorded_at: Fri, 16 Jun 2017 14:23:50 GMT
-recorded_with: VCR 3.0.3
+- request:
+    method: put
+    uri: http://backend:5352/source/home:package_test_user/_meta?user=package_test_user
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:package_test_user">
+          <title/>
+          <description/>
+          <person userid="package_test_user" role="maintainer"/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '157'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:package_test_user">
+          <title></title>
+          <description></description>
+          <person userid="package_test_user" role="maintainer" />
+        </project>
+    http_version: 
+  recorded_at: Wed, 03 Jan 2018 13:16:14 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:user_tab_user/_meta?user=user_tab_user
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:user_tab_user">
+          <title/>
+          <description/>
+          <person userid="user_tab_user" role="maintainer"/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '149'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:user_tab_user">
+          <title></title>
+          <description></description>
+          <person userid="user_tab_user" role="maintainer" />
+        </project>
+    http_version: 
+  recorded_at: Wed, 03 Jan 2018 13:16:14 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:user_tab_user/group_test_package/_meta?user=user_tab_user
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="group_test_package" project="home:user_tab_user">
+          <title>The Needle's Eye</title>
+          <description>Consequatur ex deserunt qui.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '168'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="group_test_package" project="home:user_tab_user">
+          <title>The Needle's Eye</title>
+          <description>Consequatur ex deserunt qui.</description>
+        </package>
+    http_version: 
+  recorded_at: Wed, 03 Jan 2018 13:16:14 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:user_tab_user/group_test_package/_meta
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="group_test_package" project="home:user_tab_user">
+          <title>The Needle's Eye</title>
+          <description>Consequatur ex deserunt qui.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '168'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="group_test_package" project="home:user_tab_user">
+          <title>The Needle's Eye</title>
+          <description>Consequatur ex deserunt qui.</description>
+        </package>
+    http_version: 
+  recorded_at: Wed, 03 Jan 2018 13:16:14 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:other_user/_meta?user=other_user
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:other_user">
+          <title/>
+          <description/>
+          <person userid="other_user" role="maintainer"/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '143'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:other_user">
+          <title></title>
+          <description></description>
+          <person userid="other_user" role="maintainer" />
+        </project>
+    http_version: 
+  recorded_at: Wed, 03 Jan 2018 13:16:14 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:other_user/branch_test_package/_meta?user=user_tab_user
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="branch_test_package" project="home:other_user">
+          <title>From Here to Eternity</title>
+          <description>Reiciendis est ut in voluptate rerum corporis porro.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '195'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="branch_test_package" project="home:other_user">
+          <title>From Here to Eternity</title>
+          <description>Reiciendis est ut in voluptate rerum corporis porro.</description>
+        </package>
+    http_version: 
+  recorded_at: Wed, 03 Jan 2018 13:16:14 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:other_user/branch_test_package/_config
+    body:
+      encoding: UTF-8
+      string: Dolores minus quia dolor qui aliquid ex. Quas ab dolores non libero.
+        Iste animi necessitatibus itaque. Qui veritatis rerum sed et ut fuga. Eos
+        possimus nulla eveniet amet.
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '207'
+    body:
+      encoding: UTF-8
+      string: |
+        <revision rev="6" vrev="6">
+          <srcmd5>9ea52f1dc5b29976cfc9f14d1e1828a3</srcmd5>
+          <version>unknown</version>
+          <time>1514985374</time>
+          <user>unknown</user>
+          <comment></comment>
+          <requestid/>
+        </revision>
+    http_version: 
+  recorded_at: Wed, 03 Jan 2018 13:16:14 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:reader_user/_meta?user=reader_user
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:reader_user">
+          <title/>
+          <description/>
+          <person userid="reader_user" role="maintainer"/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '145'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:reader_user">
+          <title></title>
+          <description></description>
+          <person userid="reader_user" role="maintainer" />
+        </project>
+    http_version: 
+  recorded_at: Wed, 03 Jan 2018 13:16:15 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:user_tab_user/group_test_package
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '93'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="group_test_package" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
+        </directory>
+    http_version: 
+  recorded_at: Wed, 03 Jan 2018 13:16:16 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:user_tab_user/group_test_package/_meta?user=user_tab_user
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="group_test_package" project="home:user_tab_user">
+          <title>The Needle's Eye</title>
+          <description>Consequatur ex deserunt qui.</description>
+          <person userid="user_tab_user" role="bugowner"/>
+          <person userid="other_user" role="maintainer"/>
+          <person userid="user_tab_user" role="maintainer"/>
+          <person userid="reader_user" role="reader"/>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '373'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="group_test_package" project="home:user_tab_user">
+          <title>The Needle's Eye</title>
+          <description>Consequatur ex deserunt qui.</description>
+          <person userid="user_tab_user" role="bugowner" />
+          <person userid="other_user" role="maintainer" />
+          <person userid="user_tab_user" role="maintainer" />
+          <person userid="reader_user" role="reader" />
+        </package>
+    http_version: 
+  recorded_at: Wed, 03 Jan 2018 13:16:17 GMT
+recorded_with: VCR 4.0.0

--- a/src/api/spec/cassettes/Packages/behaves_like_user_tab/user_roles/Remove_role_from_user.yml
+++ b/src/api/spec/cassettes/Packages/behaves_like_user_tab/user_roles/Remove_role_from_user.yml
@@ -956,4 +956,478 @@ http_interactions:
         </status>
     http_version: 
   recorded_at: Fri, 16 Jun 2017 14:23:55 GMT
-recorded_with: VCR 3.0.3
+- request:
+    method: put
+    uri: http://backend:5352/source/home:package_test_user/_meta?user=package_test_user
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:package_test_user">
+          <title/>
+          <description/>
+          <person userid="package_test_user" role="maintainer"/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '157'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:package_test_user">
+          <title></title>
+          <description></description>
+          <person userid="package_test_user" role="maintainer" />
+        </project>
+    http_version: 
+  recorded_at: Wed, 03 Jan 2018 13:16:02 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:user_tab_user/_meta?user=user_tab_user
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:user_tab_user">
+          <title/>
+          <description/>
+          <person userid="user_tab_user" role="maintainer"/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '149'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:user_tab_user">
+          <title></title>
+          <description></description>
+          <person userid="user_tab_user" role="maintainer" />
+        </project>
+    http_version: 
+  recorded_at: Wed, 03 Jan 2018 13:16:02 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:user_tab_user/group_test_package/_meta?user=user_tab_user
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="group_test_package" project="home:user_tab_user">
+          <title>Unweaving the Rainbow</title>
+          <description>Incidunt veniam repudiandae architecto autem deserunt qui accusamus.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '213'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="group_test_package" project="home:user_tab_user">
+          <title>Unweaving the Rainbow</title>
+          <description>Incidunt veniam repudiandae architecto autem deserunt qui accusamus.</description>
+        </package>
+    http_version: 
+  recorded_at: Wed, 03 Jan 2018 13:16:02 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:user_tab_user/group_test_package/_meta
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="group_test_package" project="home:user_tab_user">
+          <title>Unweaving the Rainbow</title>
+          <description>Incidunt veniam repudiandae architecto autem deserunt qui accusamus.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '213'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="group_test_package" project="home:user_tab_user">
+          <title>Unweaving the Rainbow</title>
+          <description>Incidunt veniam repudiandae architecto autem deserunt qui accusamus.</description>
+        </package>
+    http_version: 
+  recorded_at: Wed, 03 Jan 2018 13:16:02 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:other_user/_meta?user=other_user
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:other_user">
+          <title/>
+          <description/>
+          <person userid="other_user" role="maintainer"/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '143'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:other_user">
+          <title></title>
+          <description></description>
+          <person userid="other_user" role="maintainer" />
+        </project>
+    http_version: 
+  recorded_at: Wed, 03 Jan 2018 13:16:02 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:other_user/branch_test_package/_meta?user=user_tab_user
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="branch_test_package" project="home:other_user">
+          <title>Paths of Glory</title>
+          <description>Et necessitatibus voluptatum voluptatem voluptas quas voluptatibus.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '203'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="branch_test_package" project="home:other_user">
+          <title>Paths of Glory</title>
+          <description>Et necessitatibus voluptatum voluptatem voluptas quas voluptatibus.</description>
+        </package>
+    http_version: 
+  recorded_at: Wed, 03 Jan 2018 13:16:02 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:other_user/branch_test_package/_config
+    body:
+      encoding: UTF-8
+      string: Nulla praesentium quia eum omnis cupiditate voluptatibus qui. Sed asperiores
+        eum ratione sunt dolorum deleniti enim. Iusto deserunt quia accusamus voluptate
+        voluptas dolores ab. Quos sed omnis nemo alias non.
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '207'
+    body:
+      encoding: UTF-8
+      string: |
+        <revision rev="5" vrev="5">
+          <srcmd5>c5fafe128b9ddaf0f3776a22fbb1cd98</srcmd5>
+          <version>unknown</version>
+          <time>1514985362</time>
+          <user>unknown</user>
+          <comment></comment>
+          <requestid/>
+        </revision>
+    http_version: 
+  recorded_at: Wed, 03 Jan 2018 13:16:02 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:reader_user/_meta?user=reader_user
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:reader_user">
+          <title/>
+          <description/>
+          <person userid="reader_user" role="maintainer"/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '145'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:reader_user">
+          <title></title>
+          <description></description>
+          <person userid="reader_user" role="maintainer" />
+        </project>
+    http_version: 
+  recorded_at: Wed, 03 Jan 2018 13:16:02 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:user_tab_user/group_test_package/_meta?user=user_tab_user
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="group_test_package" project="home:user_tab_user">
+          <title>Unweaving the Rainbow</title>
+          <description>Incidunt veniam repudiandae architecto autem deserunt qui accusamus.</description>
+          <person userid="user_tab_user" role="maintainer"/>
+          <person userid="reader_user" role="reader"/>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '315'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="group_test_package" project="home:user_tab_user">
+          <title>Unweaving the Rainbow</title>
+          <description>Incidunt veniam repudiandae architecto autem deserunt qui accusamus.</description>
+          <person userid="user_tab_user" role="maintainer" />
+          <person userid="reader_user" role="reader" />
+        </package>
+    http_version: 
+  recorded_at: Wed, 03 Jan 2018 13:16:04 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:user_tab_user/group_test_package/_meta?user=user_tab_user
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="group_test_package" project="home:user_tab_user">
+          <title>Unweaving the Rainbow</title>
+          <description>Incidunt veniam repudiandae architecto autem deserunt qui accusamus.</description>
+          <person userid="user_tab_user" role="maintainer"/>
+          <person userid="reader_user" role="reader"/>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '315'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="group_test_package" project="home:user_tab_user">
+          <title>Unweaving the Rainbow</title>
+          <description>Incidunt veniam repudiandae architecto autem deserunt qui accusamus.</description>
+          <person userid="user_tab_user" role="maintainer" />
+          <person userid="reader_user" role="reader" />
+        </package>
+    http_version: 
+  recorded_at: Wed, 03 Jan 2018 13:16:04 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:user_tab_user/group_test_package
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '93'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="group_test_package" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
+        </directory>
+    http_version: 
+  recorded_at: Wed, 03 Jan 2018 13:16:04 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:user_tab_user/group_test_package
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '93'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="group_test_package" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
+        </directory>
+    http_version: 
+  recorded_at: Wed, 03 Jan 2018 13:16:04 GMT
+recorded_with: VCR 4.0.0

--- a/src/api/spec/cassettes/Packages/behaves_like_user_tab/user_roles/Remove_user_from_package_/_project.yml
+++ b/src/api/spec/cassettes/Packages/behaves_like_user_tab/user_roles/Remove_user_from_package_/_project.yml
@@ -356,4 +356,524 @@ http_interactions:
         </status>
     http_version: 
   recorded_at: Fri, 11 Aug 2017 08:26:47 GMT
-recorded_with: VCR 3.0.3
+- request:
+    method: put
+    uri: http://backend:5352/source/home:package_test_user/_meta?user=package_test_user
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:package_test_user">
+          <title/>
+          <description/>
+          <person userid="package_test_user" role="maintainer"/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '157'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:package_test_user">
+          <title></title>
+          <description></description>
+          <person userid="package_test_user" role="maintainer" />
+        </project>
+    http_version: 
+  recorded_at: Wed, 03 Jan 2018 13:16:51 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:user_tab_user/_meta?user=user_tab_user
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:user_tab_user">
+          <title/>
+          <description/>
+          <person userid="user_tab_user" role="maintainer"/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '149'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:user_tab_user">
+          <title></title>
+          <description></description>
+          <person userid="user_tab_user" role="maintainer" />
+        </project>
+    http_version: 
+  recorded_at: Wed, 03 Jan 2018 13:16:51 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:user_tab_user/group_test_package/_meta?user=user_tab_user
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="group_test_package" project="home:user_tab_user">
+          <title>The Heart Is a Lonely Hunter</title>
+          <description>Hic sequi voluptatibus esse reprehenderit et.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '197'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="group_test_package" project="home:user_tab_user">
+          <title>The Heart Is a Lonely Hunter</title>
+          <description>Hic sequi voluptatibus esse reprehenderit et.</description>
+        </package>
+    http_version: 
+  recorded_at: Wed, 03 Jan 2018 13:16:51 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:user_tab_user/group_test_package/_meta
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="group_test_package" project="home:user_tab_user">
+          <title>The Heart Is a Lonely Hunter</title>
+          <description>Hic sequi voluptatibus esse reprehenderit et.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '197'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="group_test_package" project="home:user_tab_user">
+          <title>The Heart Is a Lonely Hunter</title>
+          <description>Hic sequi voluptatibus esse reprehenderit et.</description>
+        </package>
+    http_version: 
+  recorded_at: Wed, 03 Jan 2018 13:16:51 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:other_user/_meta?user=other_user
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:other_user">
+          <title/>
+          <description/>
+          <person userid="other_user" role="maintainer"/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '143'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:other_user">
+          <title></title>
+          <description></description>
+          <person userid="other_user" role="maintainer" />
+        </project>
+    http_version: 
+  recorded_at: Wed, 03 Jan 2018 13:16:51 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:other_user/branch_test_package/_meta?user=user_tab_user
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="branch_test_package" project="home:other_user">
+          <title>No Highway</title>
+          <description>Similique odio omnis provident id et suscipit eum.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '182'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="branch_test_package" project="home:other_user">
+          <title>No Highway</title>
+          <description>Similique odio omnis provident id et suscipit eum.</description>
+        </package>
+    http_version: 
+  recorded_at: Wed, 03 Jan 2018 13:16:51 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:other_user/branch_test_package/_meta
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="branch_test_package" project="home:other_user">
+          <title>No Highway</title>
+          <description>Similique odio omnis provident id et suscipit eum.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '182'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="branch_test_package" project="home:other_user">
+          <title>No Highway</title>
+          <description>Similique odio omnis provident id et suscipit eum.</description>
+        </package>
+    http_version: 
+  recorded_at: Wed, 03 Jan 2018 13:16:51 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:other_user/branch_test_package/_config
+    body:
+      encoding: UTF-8
+      string: Et delectus dolorem nobis nemo. Velit voluptatem corrupti. Optio autem
+        eos accusantium. Exercitationem et dolor dolores sint. Nihil delectus dolore
+        ipsam aut iure similique consequatur.
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '207'
+    body:
+      encoding: UTF-8
+      string: |
+        <revision rev="9" vrev="9">
+          <srcmd5>425f0f10015c9ff36f3e52d84898ba64</srcmd5>
+          <version>unknown</version>
+          <time>1514985411</time>
+          <user>unknown</user>
+          <comment></comment>
+          <requestid/>
+        </revision>
+    http_version: 
+  recorded_at: Wed, 03 Jan 2018 13:16:51 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:other_user/branch_test_package/somefile.txt
+    body:
+      encoding: UTF-8
+      string: Consequatur ab nostrum. Blanditiis rerum eaque voluptates officiis sint
+        architecto. Quam consequuntur autem. Ut delectus omnis.
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '209'
+    body:
+      encoding: UTF-8
+      string: |
+        <revision rev="10" vrev="10">
+          <srcmd5>4c0ac11b3d615b74d6d623d0d006f0e1</srcmd5>
+          <version>unknown</version>
+          <time>1514985411</time>
+          <user>unknown</user>
+          <comment></comment>
+          <requestid/>
+        </revision>
+    http_version: 
+  recorded_at: Wed, 03 Jan 2018 13:16:51 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:reader_user/_meta?user=reader_user
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:reader_user">
+          <title/>
+          <description/>
+          <person userid="reader_user" role="maintainer"/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '145'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:reader_user">
+          <title></title>
+          <description></description>
+          <person userid="reader_user" role="maintainer" />
+        </project>
+    http_version: 
+  recorded_at: Wed, 03 Jan 2018 13:16:51 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:user_tab_user/group_test_package
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '93'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="group_test_package" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
+        </directory>
+    http_version: 
+  recorded_at: Wed, 03 Jan 2018 13:16:52 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:user_tab_user/group_test_package/_meta?user=user_tab_user
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="group_test_package" project="home:user_tab_user">
+          <title>The Heart Is a Lonely Hunter</title>
+          <description>Hic sequi voluptatibus esse reprehenderit et.</description>
+          <person userid="user_tab_user" role="bugowner"/>
+          <person userid="user_tab_user" role="maintainer"/>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '303'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="group_test_package" project="home:user_tab_user">
+          <title>The Heart Is a Lonely Hunter</title>
+          <description>Hic sequi voluptatibus esse reprehenderit et.</description>
+          <person userid="user_tab_user" role="bugowner" />
+          <person userid="user_tab_user" role="maintainer" />
+        </package>
+    http_version: 
+  recorded_at: Wed, 03 Jan 2018 13:16:53 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:user_tab_user/group_test_package/_meta?user=user_tab_user
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="group_test_package" project="home:user_tab_user">
+          <title>The Heart Is a Lonely Hunter</title>
+          <description>Hic sequi voluptatibus esse reprehenderit et.</description>
+          <person userid="user_tab_user" role="bugowner"/>
+          <person userid="user_tab_user" role="maintainer"/>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '303'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="group_test_package" project="home:user_tab_user">
+          <title>The Heart Is a Lonely Hunter</title>
+          <description>Hic sequi voluptatibus esse reprehenderit et.</description>
+          <person userid="user_tab_user" role="bugowner" />
+          <person userid="user_tab_user" role="maintainer" />
+        </package>
+    http_version: 
+  recorded_at: Wed, 03 Jan 2018 13:16:53 GMT
+recorded_with: VCR 4.0.0

--- a/src/api/spec/cassettes/Packages/behaves_like_user_tab/user_roles/Viewing_user_roles.yml
+++ b/src/api/spec/cassettes/Packages/behaves_like_user_tab/user_roles/Viewing_user_roles.yml
@@ -592,4 +592,358 @@ http_interactions:
         </status>
     http_version: 
   recorded_at: Fri, 16 Jun 2017 14:23:58 GMT
-recorded_with: VCR 3.0.3
+- request:
+    method: put
+    uri: http://backend:5352/source/home:package_test_user/_meta?user=package_test_user
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:package_test_user">
+          <title/>
+          <description/>
+          <person userid="package_test_user" role="maintainer"/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '157'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:package_test_user">
+          <title></title>
+          <description></description>
+          <person userid="package_test_user" role="maintainer" />
+        </project>
+    http_version: 
+  recorded_at: Wed, 03 Jan 2018 13:16:29 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:user_tab_user/_meta?user=user_tab_user
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:user_tab_user">
+          <title/>
+          <description/>
+          <person userid="user_tab_user" role="maintainer"/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '149'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:user_tab_user">
+          <title></title>
+          <description></description>
+          <person userid="user_tab_user" role="maintainer" />
+        </project>
+    http_version: 
+  recorded_at: Wed, 03 Jan 2018 13:16:29 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:user_tab_user/group_test_package/_meta?user=user_tab_user
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="group_test_package" project="home:user_tab_user">
+          <title>For Whom the Bell Tolls</title>
+          <description>Et necessitatibus vel quo repudiandae quia tempore.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '198'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="group_test_package" project="home:user_tab_user">
+          <title>For Whom the Bell Tolls</title>
+          <description>Et necessitatibus vel quo repudiandae quia tempore.</description>
+        </package>
+    http_version: 
+  recorded_at: Wed, 03 Jan 2018 13:16:29 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:user_tab_user/group_test_package/_meta
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="group_test_package" project="home:user_tab_user">
+          <title>For Whom the Bell Tolls</title>
+          <description>Et necessitatibus vel quo repudiandae quia tempore.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '198'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="group_test_package" project="home:user_tab_user">
+          <title>For Whom the Bell Tolls</title>
+          <description>Et necessitatibus vel quo repudiandae quia tempore.</description>
+        </package>
+    http_version: 
+  recorded_at: Wed, 03 Jan 2018 13:16:29 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:other_user/_meta?user=other_user
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:other_user">
+          <title/>
+          <description/>
+          <person userid="other_user" role="maintainer"/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '143'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:other_user">
+          <title></title>
+          <description></description>
+          <person userid="other_user" role="maintainer" />
+        </project>
+    http_version: 
+  recorded_at: Wed, 03 Jan 2018 13:16:29 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:other_user/branch_test_package/_meta?user=user_tab_user
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="branch_test_package" project="home:other_user">
+          <title>Everything is Illuminated</title>
+          <description>Voluptas magni doloribus sint impedit pariatur itaque ut cupiditate.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '215'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="branch_test_package" project="home:other_user">
+          <title>Everything is Illuminated</title>
+          <description>Voluptas magni doloribus sint impedit pariatur itaque ut cupiditate.</description>
+        </package>
+    http_version: 
+  recorded_at: Wed, 03 Jan 2018 13:16:29 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:other_user/branch_test_package/_config
+    body:
+      encoding: UTF-8
+      string: Repellat quo eligendi qui. Porro esse in aliquid et quis facere. Provident
+        ad voluptates eaque adipisci voluptatum alias quibusdam.
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '207'
+    body:
+      encoding: UTF-8
+      string: |
+        <revision rev="7" vrev="7">
+          <srcmd5>077287b9cd573f8f18998eb5db37be30</srcmd5>
+          <version>unknown</version>
+          <time>1514985389</time>
+          <user>unknown</user>
+          <comment></comment>
+          <requestid/>
+        </revision>
+    http_version: 
+  recorded_at: Wed, 03 Jan 2018 13:16:29 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:reader_user/_meta?user=reader_user
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:reader_user">
+          <title/>
+          <description/>
+          <person userid="reader_user" role="maintainer"/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '145'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:reader_user">
+          <title></title>
+          <description></description>
+          <person userid="reader_user" role="maintainer" />
+        </project>
+    http_version: 
+  recorded_at: Wed, 03 Jan 2018 13:16:30 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:user_tab_user/group_test_package
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '93'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="group_test_package" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
+        </directory>
+    http_version: 
+  recorded_at: Wed, 03 Jan 2018 13:16:31 GMT
+recorded_with: VCR 4.0.0

--- a/src/api/spec/cassettes/Packages/branching_a_package/from_another_user_s_project.yml
+++ b/src/api/spec/cassettes/Packages/branching_a_package/from_another_user_s_project.yml
@@ -40,7 +40,7 @@ http_interactions:
           <person userid="package_test_user" role="maintainer" />
         </project>
     http_version: 
-  recorded_at: Fri, 28 Apr 2017 10:52:29 GMT
+  recorded_at: Wed, 03 Jan 2018 13:11:11 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:package_test_user/test_package/_meta?user=_nobody_
@@ -48,8 +48,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="test_package" project="home:package_test_user">
-          <title>Now Sleeps the Crimson Petal</title>
-          <description>A mollitia debitis numquam qui itaque iure est.</description>
+          <title>The Sun Also Rises</title>
+          <description>Ut in est ea omnis incidunt sunt consequatur.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -70,16 +70,16 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '197'
+      - '185'
     body:
       encoding: UTF-8
       string: |
         <package name="test_package" project="home:package_test_user">
-          <title>Now Sleeps the Crimson Petal</title>
-          <description>A mollitia debitis numquam qui itaque iure est.</description>
+          <title>The Sun Also Rises</title>
+          <description>Ut in est ea omnis incidunt sunt consequatur.</description>
         </package>
     http_version: 
-  recorded_at: Fri, 28 Apr 2017 10:52:29 GMT
+  recorded_at: Wed, 03 Jan 2018 13:11:12 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:package_test_user/test_package/_meta
@@ -87,8 +87,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="test_package" project="home:package_test_user">
-          <title>Now Sleeps the Crimson Petal</title>
-          <description>A mollitia debitis numquam qui itaque iure est.</description>
+          <title>The Sun Also Rises</title>
+          <description>Ut in est ea omnis incidunt sunt consequatur.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -109,24 +109,24 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '197'
+      - '185'
     body:
       encoding: UTF-8
       string: |
         <package name="test_package" project="home:package_test_user">
-          <title>Now Sleeps the Crimson Petal</title>
-          <description>A mollitia debitis numquam qui itaque iure est.</description>
+          <title>The Sun Also Rises</title>
+          <description>Ut in est ea omnis incidunt sunt consequatur.</description>
         </package>
     http_version: 
-  recorded_at: Fri, 28 Apr 2017 10:52:29 GMT
+  recorded_at: Wed, 03 Jan 2018 13:11:12 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:package_test_user/test_package/_config
     body:
       encoding: UTF-8
-      string: Ducimus quas autem est consequatur rem enim. Ex atque omnis aut ipsa.
-        Repellat ad nemo recusandae laudantium cum. Soluta quos cumque nostrum. Et
-        quaerat cumque.
+      string: Necessitatibus vitae quasi distinctio iusto facilis perferendis. Ipsum
+        velit impedit expedita. Consequatur ullam amet doloremque et dolores eos.
+        Ut consectetur nemo. Unde hic itaque voluptate aliquid molestias est enim.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -150,24 +150,23 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <revision rev="3" vrev="3">
-          <srcmd5>eb8947f386da9c7bd903343d065e7ea4</srcmd5>
+        <revision rev="1" vrev="1">
+          <srcmd5>ee6e743dcc7a95ae0cd84ca0290032cf</srcmd5>
           <version>unknown</version>
-          <time>1493376749</time>
+          <time>1514985072</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
     http_version: 
-  recorded_at: Fri, 28 Apr 2017 10:52:29 GMT
+  recorded_at: Wed, 03 Jan 2018 13:11:12 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:package_test_user/test_package/somefile.txt
     body:
       encoding: UTF-8
-      string: Ipsum iste cum. Et officiis est earum veritatis perspiciatis. Ut consectetur
-        amet. Voluptatibus voluptatem provident necessitatibus excepturi saepe molestiae
-        voluptas.
+      string: Similique fugit ex accusamus et impedit. Non non neque quo saepe quaerat.
+        Sit aut minus vitae ut enim. Eum corrupti rerum.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -191,16 +190,16 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <revision rev="4" vrev="4">
-          <srcmd5>ae6893022d2c1f8d5670a6a61ecc8582</srcmd5>
+        <revision rev="2" vrev="2">
+          <srcmd5>540199cabe28ebba68e0846c0083a396</srcmd5>
           <version>unknown</version>
-          <time>1493376749</time>
+          <time>1514985072</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
     http_version: 
-  recorded_at: Fri, 28 Apr 2017 10:52:29 GMT
+  recorded_at: Wed, 03 Jan 2018 13:11:12 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:other_package_test_user/_meta?user=other_package_test_user
@@ -241,7 +240,7 @@ http_interactions:
           <person userid="other_package_test_user" role="maintainer" />
         </project>
     http_version: 
-  recorded_at: Fri, 28 Apr 2017 10:52:29 GMT
+  recorded_at: Wed, 03 Jan 2018 13:11:12 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:other_package_test_user/branch_test_package/_meta?user=_nobody_
@@ -249,8 +248,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="branch_test_package" project="home:other_package_test_user">
-          <title>Ah, Wilderness!</title>
-          <description>Vel provident ratione sit deleniti quia qui nulla.</description>
+          <title>A Passage to India</title>
+          <description>Sit iure qui illo.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -271,16 +270,16 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '200'
+      - '171'
     body:
       encoding: UTF-8
       string: |
         <package name="branch_test_package" project="home:other_package_test_user">
-          <title>Ah, Wilderness!</title>
-          <description>Vel provident ratione sit deleniti quia qui nulla.</description>
+          <title>A Passage to India</title>
+          <description>Sit iure qui illo.</description>
         </package>
     http_version: 
-  recorded_at: Fri, 28 Apr 2017 10:52:29 GMT
+  recorded_at: Wed, 03 Jan 2018 13:11:13 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:other_package_test_user/branch_test_package/_meta
@@ -288,8 +287,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="branch_test_package" project="home:other_package_test_user">
-          <title>Ah, Wilderness!</title>
-          <description>Vel provident ratione sit deleniti quia qui nulla.</description>
+          <title>A Passage to India</title>
+          <description>Sit iure qui illo.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -310,24 +309,24 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '200'
+      - '171'
     body:
       encoding: UTF-8
       string: |
         <package name="branch_test_package" project="home:other_package_test_user">
-          <title>Ah, Wilderness!</title>
-          <description>Vel provident ratione sit deleniti quia qui nulla.</description>
+          <title>A Passage to India</title>
+          <description>Sit iure qui illo.</description>
         </package>
     http_version: 
-  recorded_at: Fri, 28 Apr 2017 10:52:29 GMT
+  recorded_at: Wed, 03 Jan 2018 13:11:13 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:other_package_test_user/branch_test_package/_config
     body:
       encoding: UTF-8
-      string: Nam voluptatibus sit ab architecto distinctio consequatur. Architecto
-        suscipit sit corrupti deleniti. Quos numquam ut. Aliquam maiores veniam nihil
-        quia consequatur in. Qui consequatur et.
+      string: Assumenda error laborum dicta modi sint. Eligendi velit soluta minima
+        aperiam consequatur praesentium. Nesciunt voluptas et. Qui quia assumenda
+        ea.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -352,22 +351,22 @@ http_interactions:
       encoding: UTF-8
       string: |
         <revision rev="1" vrev="1">
-          <srcmd5>8aff1e13ae04a0579d091dcb6f2d801e</srcmd5>
+          <srcmd5>b161c441e2cf81edb19709342225248b</srcmd5>
           <version>unknown</version>
-          <time>1493376749</time>
+          <time>1514985073</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
     http_version: 
-  recorded_at: Fri, 28 Apr 2017 10:52:29 GMT
+  recorded_at: Wed, 03 Jan 2018 13:11:13 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:other_package_test_user/branch_test_package/somefile.txt
     body:
       encoding: UTF-8
-      string: Dolores sed voluptas veniam officiis amet mollitia. Aut quas neque.
-        Quia natus quia. Hic officiis animi.
+      string: Similique fugit ex accusamus et impedit. Non non neque quo saepe quaerat.
+        Sit aut minus vitae ut enim. Eum corrupti rerum.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -392,15 +391,15 @@ http_interactions:
       encoding: UTF-8
       string: |
         <revision rev="2" vrev="2">
-          <srcmd5>b2e8584e27fe5d51f298d47858f6c157</srcmd5>
+          <srcmd5>ce797e25ce29c7f947fb59950d437fb5</srcmd5>
           <version>unknown</version>
-          <time>1493376749</time>
+          <time>1514985073</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
     http_version: 
-  recorded_at: Fri, 28 Apr 2017 10:52:29 GMT
+  recorded_at: Wed, 03 Jan 2018 13:11:13 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:other_package_test_user/branch_test_package?nofilename=1&view=info&withchangesmd5=1
@@ -430,11 +429,11 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <sourceinfo package="branch_test_package" rev="2" vrev="2" srcmd5="b2e8584e27fe5d51f298d47858f6c157" verifymd5="b2e8584e27fe5d51f298d47858f6c157">
-          <revtime>1493376749</revtime>
+        <sourceinfo package="branch_test_package" rev="2" vrev="2" srcmd5="ce797e25ce29c7f947fb59950d437fb5" verifymd5="ce797e25ce29c7f947fb59950d437fb5">
+          <revtime>1514985073</revtime>
         </sourceinfo>
     http_version: 
-  recorded_at: Fri, 28 Apr 2017 10:52:35 GMT
+  recorded_at: Wed, 03 Jan 2018 13:11:16 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:other_package_test_user/branch_test_package
@@ -464,12 +463,12 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="branch_test_package" rev="2" vrev="2" srcmd5="b2e8584e27fe5d51f298d47858f6c157">
-          <entry name="_config" md5="7701892124ce996d1273e7ab8c6d521b" size="188" mtime="1493376749" />
-          <entry name="somefile.txt" md5="3d61950f3bc89795f487f2df389522c0" size="104" mtime="1493376749" />
+        <directory name="branch_test_package" rev="2" vrev="2" srcmd5="ce797e25ce29c7f947fb59950d437fb5">
+          <entry name="_config" md5="6e88f0a236426e4194060bebe6777b79" size="147" mtime="1514985073" />
+          <entry name="somefile.txt" md5="a50059593b79508e188300cd51ee2155" size="122" mtime="1514985073" />
         </directory>
     http_version: 
-  recorded_at: Fri, 28 Apr 2017 10:52:35 GMT
+  recorded_at: Wed, 03 Jan 2018 13:11:16 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:other_package_test_user/branch_test_package?cmd=diff&linkrev=base&onlyissues=1&orev=0&view=xml
@@ -501,15 +500,15 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="d948ecf71a3012048dd0dfe24de12d04">
+        <sourcediff key="894bf3862a20c9c387c128b3dccaa5a5">
           <old project="home:other_package_test_user" package="branch_test_package" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e" />
-          <new project="home:other_package_test_user" package="branch_test_package" rev="2" srcmd5="b2e8584e27fe5d51f298d47858f6c157" />
+          <new project="home:other_package_test_user" package="branch_test_package" rev="2" srcmd5="ce797e25ce29c7f947fb59950d437fb5" />
           <files />
           <issues>
           </issues>
         </sourcediff>
     http_version: 
-  recorded_at: Fri, 28 Apr 2017 10:52:35 GMT
+  recorded_at: Wed, 03 Jan 2018 13:11:16 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:other_package_test_user/branch_test_package
@@ -539,12 +538,12 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="branch_test_package" rev="2" vrev="2" srcmd5="b2e8584e27fe5d51f298d47858f6c157">
-          <entry name="_config" md5="7701892124ce996d1273e7ab8c6d521b" size="188" mtime="1493376749" />
-          <entry name="somefile.txt" md5="3d61950f3bc89795f487f2df389522c0" size="104" mtime="1493376749" />
+        <directory name="branch_test_package" rev="2" vrev="2" srcmd5="ce797e25ce29c7f947fb59950d437fb5">
+          <entry name="_config" md5="6e88f0a236426e4194060bebe6777b79" size="147" mtime="1514985073" />
+          <entry name="somefile.txt" md5="a50059593b79508e188300cd51ee2155" size="122" mtime="1514985073" />
         </directory>
     http_version: 
-  recorded_at: Fri, 28 Apr 2017 10:52:35 GMT
+  recorded_at: Wed, 03 Jan 2018 13:11:16 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:other_package_test_user/branch_test_package?expand=1&rev=2
@@ -552,10 +551,8 @@ http_interactions:
       encoding: US-ASCII
       string: ''
     headers:
-      Content-Type:
-      - text/plain
       Accept-Encoding:
-      - identity
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
       - "*/*"
       User-Agent:
@@ -576,12 +573,12 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="branch_test_package" rev="2" vrev="2" srcmd5="b2e8584e27fe5d51f298d47858f6c157">
-          <entry name="_config" md5="7701892124ce996d1273e7ab8c6d521b" size="188" mtime="1493376749" />
-          <entry name="somefile.txt" md5="3d61950f3bc89795f487f2df389522c0" size="104" mtime="1493376749" />
+        <directory name="branch_test_package" rev="2" vrev="2" srcmd5="ce797e25ce29c7f947fb59950d437fb5">
+          <entry name="_config" md5="6e88f0a236426e4194060bebe6777b79" size="147" mtime="1514985073" />
+          <entry name="somefile.txt" md5="a50059593b79508e188300cd51ee2155" size="122" mtime="1514985073" />
         </directory>
     http_version: 
-  recorded_at: Fri, 28 Apr 2017 10:52:35 GMT
+  recorded_at: Wed, 03 Jan 2018 13:11:16 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:other_package_test_user/branch_test_package
@@ -613,12 +610,12 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="branch_test_package" rev="2" vrev="2" srcmd5="b2e8584e27fe5d51f298d47858f6c157">
-          <entry name="_config" md5="7701892124ce996d1273e7ab8c6d521b" size="188" mtime="1493376749" />
-          <entry name="somefile.txt" md5="3d61950f3bc89795f487f2df389522c0" size="104" mtime="1493376749" />
+        <directory name="branch_test_package" rev="2" vrev="2" srcmd5="ce797e25ce29c7f947fb59950d437fb5">
+          <entry name="_config" md5="6e88f0a236426e4194060bebe6777b79" size="147" mtime="1514985073" />
+          <entry name="somefile.txt" md5="a50059593b79508e188300cd51ee2155" size="122" mtime="1514985073" />
         </directory>
     http_version: 
-  recorded_at: Fri, 28 Apr 2017 10:52:35 GMT
+  recorded_at: Wed, 03 Jan 2018 13:11:16 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:other_package_test_user/branch_test_package/_service
@@ -655,7 +652,7 @@ http_interactions:
           <details>404 _service: no such file</details>
         </status>
     http_version: 
-  recorded_at: Fri, 28 Apr 2017 10:52:35 GMT
+  recorded_at: Wed, 03 Jan 2018 13:11:17 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:other_package_test_user/branch_test_package/_history
@@ -687,20 +684,20 @@ http_interactions:
       string: |
         <revisionlist>
           <revision rev="1" vrev="1">
-            <srcmd5>8aff1e13ae04a0579d091dcb6f2d801e</srcmd5>
+            <srcmd5>b161c441e2cf81edb19709342225248b</srcmd5>
             <version>unknown</version>
-            <time>1493376749</time>
+            <time>1514985073</time>
             <user>unknown</user>
           </revision>
           <revision rev="2" vrev="2">
-            <srcmd5>b2e8584e27fe5d51f298d47858f6c157</srcmd5>
+            <srcmd5>ce797e25ce29c7f947fb59950d437fb5</srcmd5>
             <version>unknown</version>
-            <time>1493376749</time>
+            <time>1514985073</time>
             <user>unknown</user>
           </revision>
         </revisionlist>
     http_version: 
-  recorded_at: Fri, 28 Apr 2017 10:52:35 GMT
+  recorded_at: Wed, 03 Jan 2018 13:11:17 GMT
 - request:
     method: get
     uri: http://backend:5352/build/home:other_package_test_user/_result?package=branch_test_package&view=status
@@ -735,7 +732,7 @@ http_interactions:
 
 '
     http_version: 
-  recorded_at: Fri, 28 Apr 2017 10:52:36 GMT
+  recorded_at: Wed, 03 Jan 2018 13:11:17 GMT
 - request:
     method: post
     uri: http://backend:5352/search/package/id?match=(linkinfo/@package=%22branch_test_package%22%20and%20linkinfo/@project=%22home:other_package_test_user%22%20and%20@project=%22home:other_package_test_user%22)
@@ -770,7 +767,7 @@ http_interactions:
         <collection>
         </collection>
     http_version: 
-  recorded_at: Fri, 28 Apr 2017 10:52:36 GMT
+  recorded_at: Wed, 03 Jan 2018 13:11:17 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:package_test_user:branches:home:other_package_test_user/_meta?user=package_test_user
@@ -811,7 +808,7 @@ http_interactions:
           <person userid="package_test_user" role="maintainer" />
         </project>
     http_version: 
-  recorded_at: Fri, 28 Apr 2017 10:52:36 GMT
+  recorded_at: Wed, 03 Jan 2018 13:11:18 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:package_test_user:branches:home:other_package_test_user/branch_test_package/_meta?user=package_test_user
@@ -819,8 +816,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="branch_test_package" project="home:package_test_user:branches:home:other_package_test_user">
-          <title>Ah, Wilderness!</title>
-          <description>Vel provident ratione sit deleniti quia qui nulla.</description>
+          <title>A Passage to India</title>
+          <description>Sit iure qui illo.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -841,16 +838,16 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '232'
+      - '203'
     body:
       encoding: UTF-8
       string: |
         <package name="branch_test_package" project="home:package_test_user:branches:home:other_package_test_user">
-          <title>Ah, Wilderness!</title>
-          <description>Vel provident ratione sit deleniti quia qui nulla.</description>
+          <title>A Passage to India</title>
+          <description>Sit iure qui illo.</description>
         </package>
     http_version: 
-  recorded_at: Fri, 28 Apr 2017 10:52:36 GMT
+  recorded_at: Wed, 03 Jan 2018 13:11:18 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:package_test_user:branches:home:other_package_test_user/branch_test_package?cmd=branch&opackage=branch_test_package&oproject=home:other_package_test_user&user=package_test_user
@@ -883,15 +880,15 @@ http_interactions:
       encoding: UTF-8
       string: |
         <revision rev="1" vrev="1">
-          <srcmd5>189114e06ad1cce5d0fd29a436999b54</srcmd5>
+          <srcmd5>9fc49634e40649e5b47462f2937ad5c7</srcmd5>
           <version>unknown</version>
-          <time>1493376756</time>
+          <time>1514985078</time>
           <user>package_test_user</user>
           <comment></comment>
           <requestid/>
         </revision>
     http_version: 
-  recorded_at: Fri, 28 Apr 2017 10:52:36 GMT
+  recorded_at: Wed, 03 Jan 2018 13:11:18 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:package_test_user:branches:home:other_package_test_user/branch_test_package/_meta?user=package_test_user
@@ -899,8 +896,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="branch_test_package" project="home:package_test_user:branches:home:other_package_test_user">
-          <title>Ah, Wilderness!</title>
-          <description>Vel provident ratione sit deleniti quia qui nulla.</description>
+          <title>A Passage to India</title>
+          <description>Sit iure qui illo.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -921,16 +918,16 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '232'
+      - '203'
     body:
       encoding: UTF-8
       string: |
         <package name="branch_test_package" project="home:package_test_user:branches:home:other_package_test_user">
-          <title>Ah, Wilderness!</title>
-          <description>Vel provident ratione sit deleniti quia qui nulla.</description>
+          <title>A Passage to India</title>
+          <description>Sit iure qui illo.</description>
         </package>
     http_version: 
-  recorded_at: Fri, 28 Apr 2017 10:52:36 GMT
+  recorded_at: Wed, 03 Jan 2018 13:11:18 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:package_test_user:branches:home:other_package_test_user/branch_test_package
@@ -960,14 +957,14 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="branch_test_package" rev="1" vrev="1" srcmd5="189114e06ad1cce5d0fd29a436999b54">
-          <linkinfo project="home:other_package_test_user" package="branch_test_package" srcmd5="b2e8584e27fe5d51f298d47858f6c157" baserev="b2e8584e27fe5d51f298d47858f6c157" xsrcmd5="1644b76cba46cc700c1a5e689fb25574" lsrcmd5="189114e06ad1cce5d0fd29a436999b54" />
-          <entry name="_config" md5="7701892124ce996d1273e7ab8c6d521b" size="188" mtime="1493376749" />
-          <entry name="_link" md5="3db228aac83556055f4faf854db84f72" size="136" mtime="1493376756" />
-          <entry name="somefile.txt" md5="3d61950f3bc89795f487f2df389522c0" size="104" mtime="1493376749" />
+        <directory name="branch_test_package" rev="1" vrev="1" srcmd5="9fc49634e40649e5b47462f2937ad5c7">
+          <linkinfo project="home:other_package_test_user" package="branch_test_package" srcmd5="ce797e25ce29c7f947fb59950d437fb5" baserev="ce797e25ce29c7f947fb59950d437fb5" xsrcmd5="d54f71d2c6d8bf1c69d24a66a887c979" lsrcmd5="9fc49634e40649e5b47462f2937ad5c7" />
+          <entry name="_config" md5="6e88f0a236426e4194060bebe6777b79" size="147" mtime="1514985073" />
+          <entry name="_link" md5="61f413f7278da621038ecba3f505fb1c" size="136" mtime="1514985078" />
+          <entry name="somefile.txt" md5="a50059593b79508e188300cd51ee2155" size="122" mtime="1514985073" />
         </directory>
     http_version: 
-  recorded_at: Fri, 28 Apr 2017 10:52:36 GMT
+  recorded_at: Wed, 03 Jan 2018 13:11:18 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:package_test_user:branches:home:other_package_test_user/branch_test_package?nofilename=1&view=info&withchangesmd5=1
@@ -997,12 +994,12 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <sourceinfo package="branch_test_package" rev="1" vrev="3" srcmd5="1644b76cba46cc700c1a5e689fb25574" lsrcmd5="189114e06ad1cce5d0fd29a436999b54" verifymd5="b2e8584e27fe5d51f298d47858f6c157">
+        <sourceinfo package="branch_test_package" rev="1" vrev="3" srcmd5="d54f71d2c6d8bf1c69d24a66a887c979" lsrcmd5="9fc49634e40649e5b47462f2937ad5c7" verifymd5="ce797e25ce29c7f947fb59950d437fb5">
           <linked project="home:other_package_test_user" package="branch_test_package" />
-          <revtime>1493376756</revtime>
+          <revtime>1514985078</revtime>
         </sourceinfo>
     http_version: 
-  recorded_at: Fri, 28 Apr 2017 10:52:36 GMT
+  recorded_at: Wed, 03 Jan 2018 13:11:18 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:package_test_user:branches:home:other_package_test_user/branch_test_package
@@ -1032,14 +1029,14 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="branch_test_package" rev="1" vrev="1" srcmd5="189114e06ad1cce5d0fd29a436999b54">
-          <linkinfo project="home:other_package_test_user" package="branch_test_package" srcmd5="b2e8584e27fe5d51f298d47858f6c157" baserev="b2e8584e27fe5d51f298d47858f6c157" xsrcmd5="1644b76cba46cc700c1a5e689fb25574" lsrcmd5="189114e06ad1cce5d0fd29a436999b54" />
-          <entry name="_config" md5="7701892124ce996d1273e7ab8c6d521b" size="188" mtime="1493376749" />
-          <entry name="_link" md5="3db228aac83556055f4faf854db84f72" size="136" mtime="1493376756" />
-          <entry name="somefile.txt" md5="3d61950f3bc89795f487f2df389522c0" size="104" mtime="1493376749" />
+        <directory name="branch_test_package" rev="1" vrev="1" srcmd5="9fc49634e40649e5b47462f2937ad5c7">
+          <linkinfo project="home:other_package_test_user" package="branch_test_package" srcmd5="ce797e25ce29c7f947fb59950d437fb5" baserev="ce797e25ce29c7f947fb59950d437fb5" xsrcmd5="d54f71d2c6d8bf1c69d24a66a887c979" lsrcmd5="9fc49634e40649e5b47462f2937ad5c7" />
+          <entry name="_config" md5="6e88f0a236426e4194060bebe6777b79" size="147" mtime="1514985073" />
+          <entry name="_link" md5="61f413f7278da621038ecba3f505fb1c" size="136" mtime="1514985078" />
+          <entry name="somefile.txt" md5="a50059593b79508e188300cd51ee2155" size="122" mtime="1514985073" />
         </directory>
     http_version: 
-  recorded_at: Fri, 28 Apr 2017 10:52:36 GMT
+  recorded_at: Wed, 03 Jan 2018 13:11:18 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:package_test_user:branches:home:other_package_test_user/branch_test_package?cmd=diff&linkrev=base&onlyissues=1&orev=0&view=xml
@@ -1071,15 +1068,15 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="9be3e511a92e1ddd98e29ca7c1d2b443">
+        <sourcediff key="c98305b452f986945d4b5de0fe630e11">
           <old project="home:package_test_user:branches:home:other_package_test_user" package="branch_test_package" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e" />
-          <new project="home:package_test_user:branches:home:other_package_test_user" package="branch_test_package" rev="1" srcmd5="189114e06ad1cce5d0fd29a436999b54" />
+          <new project="home:package_test_user:branches:home:other_package_test_user" package="branch_test_package" rev="1" srcmd5="9fc49634e40649e5b47462f2937ad5c7" />
           <files />
           <issues>
           </issues>
         </sourcediff>
     http_version: 
-  recorded_at: Fri, 28 Apr 2017 10:52:36 GMT
+  recorded_at: Wed, 03 Jan 2018 13:11:18 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:package_test_user:branches:home:other_package_test_user/branch_test_package?cmd=linkdiff&linkrev=base&onlyissues=1&view=xml
@@ -1111,13 +1108,13 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="954401b562d07a3212a3395c9b47bc87">
-          <old project="home:other_package_test_user" package="branch_test_package" rev="b2e8584e27fe5d51f298d47858f6c157" srcmd5="b2e8584e27fe5d51f298d47858f6c157" />
-          <new project="home:package_test_user:branches:home:other_package_test_user" package="branch_test_package" rev="1644b76cba46cc700c1a5e689fb25574" srcmd5="1644b76cba46cc700c1a5e689fb25574" />
+        <sourcediff key="e7b8da93ecf9a4aefb32990f70e37965">
+          <old project="home:other_package_test_user" package="branch_test_package" rev="ce797e25ce29c7f947fb59950d437fb5" srcmd5="ce797e25ce29c7f947fb59950d437fb5" />
+          <new project="home:package_test_user:branches:home:other_package_test_user" package="branch_test_package" rev="d54f71d2c6d8bf1c69d24a66a887c979" srcmd5="d54f71d2c6d8bf1c69d24a66a887c979" />
           <files />
         </sourcediff>
     http_version: 
-  recorded_at: Fri, 28 Apr 2017 10:52:36 GMT
+  recorded_at: Wed, 03 Jan 2018 13:11:18 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:package_test_user:branches:home:other_package_test_user/_meta?user=package_test_user
@@ -1164,7 +1161,7 @@ http_interactions:
           </publish>
         </project>
     http_version: 
-  recorded_at: Fri, 28 Apr 2017 10:52:36 GMT
+  recorded_at: Wed, 03 Jan 2018 13:11:18 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:package_test_user:branches:home:other_package_test_user/branch_test_package
@@ -1194,14 +1191,14 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="branch_test_package" rev="1" vrev="1" srcmd5="189114e06ad1cce5d0fd29a436999b54">
-          <linkinfo project="home:other_package_test_user" package="branch_test_package" srcmd5="b2e8584e27fe5d51f298d47858f6c157" baserev="b2e8584e27fe5d51f298d47858f6c157" xsrcmd5="1644b76cba46cc700c1a5e689fb25574" lsrcmd5="189114e06ad1cce5d0fd29a436999b54" />
-          <entry name="_config" md5="7701892124ce996d1273e7ab8c6d521b" size="188" mtime="1493376749" />
-          <entry name="_link" md5="3db228aac83556055f4faf854db84f72" size="136" mtime="1493376756" />
-          <entry name="somefile.txt" md5="3d61950f3bc89795f487f2df389522c0" size="104" mtime="1493376749" />
+        <directory name="branch_test_package" rev="1" vrev="1" srcmd5="9fc49634e40649e5b47462f2937ad5c7">
+          <linkinfo project="home:other_package_test_user" package="branch_test_package" srcmd5="ce797e25ce29c7f947fb59950d437fb5" baserev="ce797e25ce29c7f947fb59950d437fb5" xsrcmd5="d54f71d2c6d8bf1c69d24a66a887c979" lsrcmd5="9fc49634e40649e5b47462f2937ad5c7" />
+          <entry name="_config" md5="6e88f0a236426e4194060bebe6777b79" size="147" mtime="1514985073" />
+          <entry name="_link" md5="61f413f7278da621038ecba3f505fb1c" size="136" mtime="1514985078" />
+          <entry name="somefile.txt" md5="a50059593b79508e188300cd51ee2155" size="122" mtime="1514985073" />
         </directory>
     http_version: 
-  recorded_at: Fri, 28 Apr 2017 10:52:37 GMT
+  recorded_at: Wed, 03 Jan 2018 13:11:18 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:package_test_user:branches:home:other_package_test_user/branch_test_package?expand=1&rev=1
@@ -1209,10 +1206,8 @@ http_interactions:
       encoding: US-ASCII
       string: ''
     headers:
-      Content-Type:
-      - text/plain
       Accept-Encoding:
-      - identity
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
       - "*/*"
       User-Agent:
@@ -1233,13 +1228,13 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="branch_test_package" rev="1644b76cba46cc700c1a5e689fb25574" vrev="3" srcmd5="1644b76cba46cc700c1a5e689fb25574">
-          <linkinfo project="home:other_package_test_user" package="branch_test_package" srcmd5="b2e8584e27fe5d51f298d47858f6c157" baserev="b2e8584e27fe5d51f298d47858f6c157" lsrcmd5="189114e06ad1cce5d0fd29a436999b54" />
-          <entry name="_config" md5="7701892124ce996d1273e7ab8c6d521b" size="188" mtime="1493376749" />
-          <entry name="somefile.txt" md5="3d61950f3bc89795f487f2df389522c0" size="104" mtime="1493376749" />
+        <directory name="branch_test_package" rev="d54f71d2c6d8bf1c69d24a66a887c979" vrev="3" srcmd5="d54f71d2c6d8bf1c69d24a66a887c979">
+          <linkinfo project="home:other_package_test_user" package="branch_test_package" srcmd5="ce797e25ce29c7f947fb59950d437fb5" baserev="ce797e25ce29c7f947fb59950d437fb5" lsrcmd5="9fc49634e40649e5b47462f2937ad5c7" />
+          <entry name="_config" md5="6e88f0a236426e4194060bebe6777b79" size="147" mtime="1514985073" />
+          <entry name="somefile.txt" md5="a50059593b79508e188300cd51ee2155" size="122" mtime="1514985073" />
         </directory>
     http_version: 
-  recorded_at: Fri, 28 Apr 2017 10:52:37 GMT
+  recorded_at: Wed, 03 Jan 2018 13:11:18 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:package_test_user:branches:home:other_package_test_user/branch_test_package
@@ -1271,14 +1266,14 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="branch_test_package" rev="1" vrev="1" srcmd5="189114e06ad1cce5d0fd29a436999b54">
-          <linkinfo project="home:other_package_test_user" package="branch_test_package" srcmd5="b2e8584e27fe5d51f298d47858f6c157" baserev="b2e8584e27fe5d51f298d47858f6c157" xsrcmd5="1644b76cba46cc700c1a5e689fb25574" lsrcmd5="189114e06ad1cce5d0fd29a436999b54" />
-          <entry name="_config" md5="7701892124ce996d1273e7ab8c6d521b" size="188" mtime="1493376749" />
-          <entry name="_link" md5="3db228aac83556055f4faf854db84f72" size="136" mtime="1493376756" />
-          <entry name="somefile.txt" md5="3d61950f3bc89795f487f2df389522c0" size="104" mtime="1493376749" />
+        <directory name="branch_test_package" rev="1" vrev="1" srcmd5="9fc49634e40649e5b47462f2937ad5c7">
+          <linkinfo project="home:other_package_test_user" package="branch_test_package" srcmd5="ce797e25ce29c7f947fb59950d437fb5" baserev="ce797e25ce29c7f947fb59950d437fb5" xsrcmd5="d54f71d2c6d8bf1c69d24a66a887c979" lsrcmd5="9fc49634e40649e5b47462f2937ad5c7" />
+          <entry name="_config" md5="6e88f0a236426e4194060bebe6777b79" size="147" mtime="1514985073" />
+          <entry name="_link" md5="61f413f7278da621038ecba3f505fb1c" size="136" mtime="1514985078" />
+          <entry name="somefile.txt" md5="a50059593b79508e188300cd51ee2155" size="122" mtime="1514985073" />
         </directory>
     http_version: 
-  recorded_at: Fri, 28 Apr 2017 10:52:37 GMT
+  recorded_at: Wed, 03 Jan 2018 13:11:18 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:package_test_user:branches:home:other_package_test_user/branch_test_package/_service
@@ -1315,7 +1310,81 @@ http_interactions:
           <details>404 _service: no such file</details>
         </status>
     http_version: 
-  recorded_at: Fri, 28 Apr 2017 10:52:37 GMT
+  recorded_at: Wed, 03 Jan 2018 13:11:18 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:package_test_user:branches:home:other_package_test_user/branch_test_package
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '657'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="branch_test_package" rev="1" vrev="1" srcmd5="9fc49634e40649e5b47462f2937ad5c7">
+          <linkinfo project="home:other_package_test_user" package="branch_test_package" srcmd5="ce797e25ce29c7f947fb59950d437fb5" baserev="ce797e25ce29c7f947fb59950d437fb5" xsrcmd5="d54f71d2c6d8bf1c69d24a66a887c979" lsrcmd5="9fc49634e40649e5b47462f2937ad5c7" />
+          <entry name="_config" md5="6e88f0a236426e4194060bebe6777b79" size="147" mtime="1514985073" />
+          <entry name="_link" md5="61f413f7278da621038ecba3f505fb1c" size="136" mtime="1514985078" />
+          <entry name="somefile.txt" md5="a50059593b79508e188300cd51ee2155" size="122" mtime="1514985073" />
+        </directory>
+    http_version: 
+  recorded_at: Wed, 03 Jan 2018 13:11:19 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:package_test_user:branches:home:other_package_test_user/branch_test_package
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '657'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="branch_test_package" rev="1" vrev="1" srcmd5="9fc49634e40649e5b47462f2937ad5c7">
+          <linkinfo project="home:other_package_test_user" package="branch_test_package" srcmd5="ce797e25ce29c7f947fb59950d437fb5" baserev="ce797e25ce29c7f947fb59950d437fb5" xsrcmd5="d54f71d2c6d8bf1c69d24a66a887c979" lsrcmd5="9fc49634e40649e5b47462f2937ad5c7" />
+          <entry name="_config" md5="6e88f0a236426e4194060bebe6777b79" size="147" mtime="1514985073" />
+          <entry name="_link" md5="61f413f7278da621038ecba3f505fb1c" size="136" mtime="1514985078" />
+          <entry name="somefile.txt" md5="a50059593b79508e188300cd51ee2155" size="122" mtime="1514985073" />
+        </directory>
+    http_version: 
+  recorded_at: Wed, 03 Jan 2018 13:11:19 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:package_test_user:branches:home:other_package_test_user/branch_test_package/_history
@@ -1347,14 +1416,14 @@ http_interactions:
       string: |
         <revisionlist>
           <revision rev="1" vrev="1">
-            <srcmd5>189114e06ad1cce5d0fd29a436999b54</srcmd5>
+            <srcmd5>9fc49634e40649e5b47462f2937ad5c7</srcmd5>
             <version>unknown</version>
-            <time>1493376756</time>
+            <time>1514985078</time>
             <user>package_test_user</user>
           </revision>
         </revisionlist>
     http_version: 
-  recorded_at: Fri, 28 Apr 2017 10:52:37 GMT
+  recorded_at: Wed, 03 Jan 2018 13:11:19 GMT
 - request:
     method: get
     uri: http://backend:5352/build/home:package_test_user:branches:home:other_package_test_user/_result?package=branch_test_package&view=status
@@ -1389,7 +1458,7 @@ http_interactions:
 
 '
     http_version: 
-  recorded_at: Fri, 28 Apr 2017 10:52:37 GMT
+  recorded_at: Wed, 03 Jan 2018 13:11:19 GMT
 - request:
     method: delete
     uri: http://backend:5352/source/home:other_package_test_user
@@ -1420,7 +1489,7 @@ http_interactions:
 
 '
     http_version: 
-  recorded_at: Fri, 28 Apr 2017 10:52:37 GMT
+  recorded_at: Wed, 03 Jan 2018 13:11:20 GMT
 - request:
     method: delete
     uri: http://backend:5352/source/home:package_test_user:branches:home:other_package_test_user
@@ -1451,13 +1520,17 @@ http_interactions:
 
 '
     http_version: 
-  recorded_at: Fri, 28 Apr 2017 10:52:37 GMT
+  recorded_at: Wed, 03 Jan 2018 13:11:20 GMT
 - request:
-    method: get
-    uri: http://backend:5352/source/home:package_test_user:branches:home:other_package_test_user/branch_test_package
+    method: put
+    uri: http://backend:5352/source/home:package_test_user/test_package/_meta?user=package_test_user
     body:
-      encoding: US-ASCII
-      string: ''
+      encoding: UTF-8
+      string: |
+        <package name="test_package" project="home:package_test_user">
+          <title>That Hideous Strength</title>
+          <description>Quas praesentium accusantium unde.</description>
+        </package>
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -1467,9 +1540,8 @@ http_interactions:
       - Ruby
   response:
     status:
-      code: 404
-      message: project 'home package_test_user branches home other_package_test_user'
-        does not exist
+      code: 200
+      message: OK
     headers:
       Content-Type:
       - text/xml
@@ -1478,14 +1550,53 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '248'
+      - '177'
     body:
       encoding: UTF-8
       string: |
-        <status code="404">
-          <summary>project 'home:package_test_user:branches:home:other_package_test_user' does not exist</summary>
-          <details>404 project 'home:package_test_user:branches:home:other_package_test_user' does not exist</details>
-        </status>
+        <package name="test_package" project="home:package_test_user">
+          <title>That Hideous Strength</title>
+          <description>Quas praesentium accusantium unde.</description>
+        </package>
     http_version: 
-  recorded_at: Fri, 16 Jun 2017 14:23:29 GMT
-recorded_with: VCR 3.0.3
+  recorded_at: Wed, 03 Jan 2018 13:14:45 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:other_package_test_user/branch_test_package/_meta?user=package_test_user
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="branch_test_package" project="home:other_package_test_user">
+          <title>The Skull Beneath the Skin</title>
+          <description>Vero qui consequatur optio repellendus commodi et.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '211'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="branch_test_package" project="home:other_package_test_user">
+          <title>The Skull Beneath the Skin</title>
+          <description>Vero qui consequatur optio repellendus commodi et.</description>
+        </package>
+    http_version: 
+  recorded_at: Wed, 03 Jan 2018 13:14:45 GMT
+recorded_with: VCR 4.0.0

--- a/src/api/spec/cassettes/Packages/changing_the_package_s_devel_project.yml
+++ b/src/api/spec/cassettes/Packages/changing_the_package_s_devel_project.yml
@@ -712,4 +712,550 @@ http_interactions:
         </status>
     http_version: 
   recorded_at: Fri, 16 Jun 2017 14:23:14 GMT
-recorded_with: VCR 3.0.3
+- request:
+    method: put
+    uri: http://backend:5352/source/home:package_test_user/_meta?user=package_test_user
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:package_test_user">
+          <title/>
+          <description/>
+          <person userid="package_test_user" role="maintainer"/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '157'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:package_test_user">
+          <title></title>
+          <description></description>
+          <person userid="package_test_user" role="maintainer" />
+        </project>
+    http_version: 
+  recorded_at: Wed, 03 Jan 2018 13:13:30 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:package_test_user/test_package/_meta?user=package_test_user
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="test_package" project="home:package_test_user">
+          <title>The Painted Veil</title>
+          <description>Ipsum provident omnis sunt nihil.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '171'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="test_package" project="home:package_test_user">
+          <title>The Painted Veil</title>
+          <description>Ipsum provident omnis sunt nihil.</description>
+        </package>
+    http_version: 
+  recorded_at: Wed, 03 Jan 2018 13:13:30 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:package_test_user/test_package/_config
+    body:
+      encoding: UTF-8
+      string: Voluptatum ut fugiat dignissimos qui et. Sapiente accusamus iusto magnam
+        architecto iste. Id odio nam.
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '207'
+    body:
+      encoding: UTF-8
+      string: |
+        <revision rev="1" vrev="1">
+          <srcmd5>76f14d7f71d84f62e33056b3e088d941</srcmd5>
+          <version>unknown</version>
+          <time>1514985210</time>
+          <user>unknown</user>
+          <comment></comment>
+          <requestid/>
+        </revision>
+    http_version: 
+  recorded_at: Wed, 03 Jan 2018 13:13:30 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:other_package_test_user/_meta?user=other_package_test_user
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:other_package_test_user">
+          <title/>
+          <description/>
+          <person userid="other_package_test_user" role="maintainer"/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '169'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:other_package_test_user">
+          <title></title>
+          <description></description>
+          <person userid="other_package_test_user" role="maintainer" />
+        </project>
+    http_version: 
+  recorded_at: Wed, 03 Jan 2018 13:13:30 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:other_package_test_user/branch_test_package/_meta?user=package_test_user
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="branch_test_package" project="home:other_package_test_user">
+          <title>The Golden Bowl</title>
+          <description>Repudiandae id soluta eum ratione distinctio.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '195'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="branch_test_package" project="home:other_package_test_user">
+          <title>The Golden Bowl</title>
+          <description>Repudiandae id soluta eum ratione distinctio.</description>
+        </package>
+    http_version: 
+  recorded_at: Wed, 03 Jan 2018 13:13:30 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:other_package_test_user/branch_test_package/_config
+    body:
+      encoding: UTF-8
+      string: Quo et exercitationem et qui. Ratione est assumenda. Rem ipsa iste.
+        Minus ea delectus.
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '207'
+    body:
+      encoding: UTF-8
+      string: |
+        <revision rev="3" vrev="3">
+          <srcmd5>c2bcf70eebb202a5a1b7c6f5d94f9298</srcmd5>
+          <version>unknown</version>
+          <time>1514985210</time>
+          <user>unknown</user>
+          <comment></comment>
+          <requestid/>
+        </revision>
+    http_version: 
+  recorded_at: Wed, 03 Jan 2018 13:13:30 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:package_test_user/develpackage/_meta?user=package_test_user
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="develpackage" project="home:package_test_user">
+          <title>The Cricket on the Hearth</title>
+          <description>Labore totam iusto numquam quis ea.</description>
+          <devel project="home:other_package_test_user" package="branch_test_package"/>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '263'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="develpackage" project="home:package_test_user">
+          <title>The Cricket on the Hearth</title>
+          <description>Labore totam iusto numquam quis ea.</description>
+          <devel project="home:other_package_test_user" package="branch_test_package" />
+        </package>
+    http_version: 
+  recorded_at: Wed, 03 Jan 2018 13:13:31 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:package_test_user/develpackage/_meta
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="develpackage" project="home:package_test_user">
+          <title>The Cricket on the Hearth</title>
+          <description>Labore totam iusto numquam quis ea.</description>
+          <devel project="home:other_package_test_user" package="branch_test_package"/>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '263'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="develpackage" project="home:package_test_user">
+          <title>The Cricket on the Hearth</title>
+          <description>Labore totam iusto numquam quis ea.</description>
+          <devel project="home:other_package_test_user" package="branch_test_package" />
+        </package>
+    http_version: 
+  recorded_at: Wed, 03 Jan 2018 13:13:31 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:package_test_user/develpackage
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '87'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="develpackage" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
+        </directory>
+    http_version: 
+  recorded_at: Wed, 03 Jan 2018 13:13:31 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/project_1/_meta
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="project_1">
+          <title>Recalled to Life</title>
+          <description/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '102'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="project_1">
+          <title>Recalled to Life</title>
+          <description></description>
+        </project>
+    http_version: 
+  recorded_at: Wed, 03 Jan 2018 13:13:32 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/project_1/_config
+    body:
+      encoding: UTF-8
+      string: Voluptas et quae maxime nobis corrupti illo. Blanditiis possimus reiciendis
+        corrupti. Dicta qui qui dolorem incidunt. Aperiam omnis qui totam atque animi
+        accusantium excepturi.
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '21'
+    body:
+      encoding: UTF-8
+      string: '<status code="ok" />
+
+'
+    http_version: 
+  recorded_at: Wed, 03 Jan 2018 13:13:32 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/project_1/develpackage/_meta?user=package_test_user
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="develpackage" project="project_1">
+          <title>Specimen Days</title>
+          <description>Velit qui qui nemo sunt doloremque.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '157'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="develpackage" project="project_1">
+          <title>Specimen Days</title>
+          <description>Velit qui qui nemo sunt doloremque.</description>
+        </package>
+    http_version: 
+  recorded_at: Wed, 03 Jan 2018 13:13:32 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/project_1/develpackage/_meta
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="develpackage" project="project_1">
+          <title>Specimen Days</title>
+          <description>Velit qui qui nemo sunt doloremque.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '157'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="develpackage" project="project_1">
+          <title>Specimen Days</title>
+          <description>Velit qui qui nemo sunt doloremque.</description>
+        </package>
+    http_version: 
+  recorded_at: Wed, 03 Jan 2018 13:13:32 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/project_1/develpackage/_meta?user=package_test_user
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="develpackage" project="project_1">
+          <title>Specimen Days</title>
+          <description>Velit qui qui nemo sunt doloremque.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '157'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="develpackage" project="project_1">
+          <title>Specimen Days</title>
+          <description>Velit qui qui nemo sunt doloremque.</description>
+        </package>
+    http_version: 
+  recorded_at: Wed, 03 Jan 2018 13:13:32 GMT
+recorded_with: VCR 4.0.0

--- a/src/api/spec/cassettes/Packages/deleting_a_package.yml
+++ b/src/api/spec/cassettes/Packages/deleting_a_package.yml
@@ -903,4 +903,313 @@ http_interactions:
         </status>
     http_version: 
   recorded_at: Fri, 16 Jun 2017 14:23:22 GMT
-recorded_with: VCR 3.0.3
+- request:
+    method: put
+    uri: http://backend:5352/source/home:package_test_user/_meta?user=package_test_user
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:package_test_user">
+          <title/>
+          <description/>
+          <person userid="package_test_user" role="maintainer"/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '157'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:package_test_user">
+          <title></title>
+          <description></description>
+          <person userid="package_test_user" role="maintainer" />
+        </project>
+    http_version: 
+  recorded_at: Wed, 03 Jan 2018 13:13:06 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:package_test_user/test_package/_meta?user=package_test_user
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="test_package" project="home:package_test_user">
+          <title>The Green Bay Tree</title>
+          <description>Est qui fugit error et.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '163'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="test_package" project="home:package_test_user">
+          <title>The Green Bay Tree</title>
+          <description>Est qui fugit error et.</description>
+        </package>
+    http_version: 
+  recorded_at: Wed, 03 Jan 2018 13:13:06 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:package_test_user/test_package/_config
+    body:
+      encoding: UTF-8
+      string: Accusantium iure accusamus sed provident delectus. Non doloremque eaque
+        beatae excepturi. Aperiam cupiditate ut. Qui sed eius ut distinctio excepturi
+        libero ut.
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '207'
+    body:
+      encoding: UTF-8
+      string: |
+        <revision rev="4" vrev="4">
+          <srcmd5>384e270dbbc35a76c084a2a52fd779a7</srcmd5>
+          <version>unknown</version>
+          <time>1514985186</time>
+          <user>unknown</user>
+          <comment></comment>
+          <requestid/>
+        </revision>
+    http_version: 
+  recorded_at: Wed, 03 Jan 2018 13:13:06 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:other_package_test_user/_meta?user=other_package_test_user
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:other_package_test_user">
+          <title/>
+          <description/>
+          <person userid="other_package_test_user" role="maintainer"/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '169'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:other_package_test_user">
+          <title></title>
+          <description></description>
+          <person userid="other_package_test_user" role="maintainer" />
+        </project>
+    http_version: 
+  recorded_at: Wed, 03 Jan 2018 13:13:06 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:other_package_test_user/branch_test_package/_meta?user=package_test_user
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="branch_test_package" project="home:other_package_test_user">
+          <title>The Far-Distant Oxus</title>
+          <description>Deleniti est architecto soluta recusandae maxime sint sed.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '213'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="branch_test_package" project="home:other_package_test_user">
+          <title>The Far-Distant Oxus</title>
+          <description>Deleniti est architecto soluta recusandae maxime sint sed.</description>
+        </package>
+    http_version: 
+  recorded_at: Wed, 03 Jan 2018 13:13:06 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:other_package_test_user/branch_test_package/_config
+    body:
+      encoding: UTF-8
+      string: Incidunt et sed cum consectetur. Velit voluptatum explicabo veritatis
+        qui quibusdam ut. Id iure repudiandae quibusdam minus.
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '207'
+    body:
+      encoding: UTF-8
+      string: |
+        <revision rev="2" vrev="2">
+          <srcmd5>69a6cfdaa399a261a38394f90bdb0453</srcmd5>
+          <version>unknown</version>
+          <time>1514985186</time>
+          <user>unknown</user>
+          <comment></comment>
+          <requestid/>
+        </revision>
+    http_version: 
+  recorded_at: Wed, 03 Jan 2018 13:13:06 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:package_test_user/test_package
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '301'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="test_package" rev="4" vrev="4" srcmd5="384e270dbbc35a76c084a2a52fd779a7">
+          <entry name="_config" md5="b1babe1f9cd77ea581172e345d1ee1af" size="160" mtime="1514985186" />
+          <entry name="somefile.txt" md5="a50059593b79508e188300cd51ee2155" size="122" mtime="1514985072" />
+        </directory>
+    http_version: 
+  recorded_at: Wed, 03 Jan 2018 13:13:07 GMT
+- request:
+    method: delete
+    uri: http://backend:5352/source/home:package_test_user/test_package?comment&user=package_test_user
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '21'
+    body:
+      encoding: UTF-8
+      string: '<status code="ok" />
+
+'
+    http_version: 
+  recorded_at: Wed, 03 Jan 2018 13:13:08 GMT
+recorded_with: VCR 4.0.0

--- a/src/api/spec/cassettes/Packages/editing_package_files/editing_an_existing_file.yml
+++ b/src/api/spec/cassettes/Packages/editing_package_files/editing_an_existing_file.yml
@@ -1076,4 +1076,324 @@ http_interactions:
         </status>
     http_version: 
   recorded_at: Fri, 20 Jan 2017 02:54:54 GMT
-recorded_with: VCR 3.0.3
+- request:
+    method: put
+    uri: http://backend:5352/source/home:package_test_user/_meta?user=package_test_user
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:package_test_user">
+          <title/>
+          <description/>
+          <person userid="package_test_user" role="maintainer"/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '157'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:package_test_user">
+          <title></title>
+          <description></description>
+          <person userid="package_test_user" role="maintainer" />
+        </project>
+    http_version: 
+  recorded_at: Wed, 03 Jan 2018 13:14:56 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:package_test_user/test_package/_meta?user=package_test_user
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="test_package" project="home:package_test_user">
+          <title>The Wings of the Dove</title>
+          <description>Et culpa non totam dolores fugiat.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '177'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="test_package" project="home:package_test_user">
+          <title>The Wings of the Dove</title>
+          <description>Et culpa non totam dolores fugiat.</description>
+        </package>
+    http_version: 
+  recorded_at: Wed, 03 Jan 2018 13:14:56 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:package_test_user/test_package/_config
+    body:
+      encoding: UTF-8
+      string: Necessitatibus veritatis debitis vel ab ut et commodi. Quia odio quae
+        non. Autem voluptatem ut ut.
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '207'
+    body:
+      encoding: UTF-8
+      string: |
+        <revision rev="4" vrev="4">
+          <srcmd5>8ec47b05aea6b87554e460f6f6ac5cff</srcmd5>
+          <version>unknown</version>
+          <time>1514985296</time>
+          <user>unknown</user>
+          <comment></comment>
+          <requestid/>
+        </revision>
+    http_version: 
+  recorded_at: Wed, 03 Jan 2018 13:14:56 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:other_package_test_user/_meta?user=other_package_test_user
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:other_package_test_user">
+          <title/>
+          <description/>
+          <person userid="other_package_test_user" role="maintainer"/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '169'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:other_package_test_user">
+          <title></title>
+          <description></description>
+          <person userid="other_package_test_user" role="maintainer" />
+        </project>
+    http_version: 
+  recorded_at: Wed, 03 Jan 2018 13:14:56 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:other_package_test_user/branch_test_package/_meta?user=package_test_user
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="branch_test_package" project="home:other_package_test_user">
+          <title>Vanity Fair</title>
+          <description>Sapiente quibusdam ipsum qui officia.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '183'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="branch_test_package" project="home:other_package_test_user">
+          <title>Vanity Fair</title>
+          <description>Sapiente quibusdam ipsum qui officia.</description>
+        </package>
+    http_version: 
+  recorded_at: Wed, 03 Jan 2018 13:14:56 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:other_package_test_user/branch_test_package/_config
+    body:
+      encoding: UTF-8
+      string: Similique laborum facilis. Nesciunt deleniti voluptatem maxime aut.
+        Deleniti animi vero quia et itaque velit. Cumque aut repudiandae laudantium.
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '207'
+    body:
+      encoding: UTF-8
+      string: |
+        <revision rev="6" vrev="6">
+          <srcmd5>5f04707a9e2df4510f9dc515196b12c6</srcmd5>
+          <version>unknown</version>
+          <time>1514985296</time>
+          <user>unknown</user>
+          <comment></comment>
+          <requestid/>
+        </revision>
+    http_version: 
+  recorded_at: Wed, 03 Jan 2018 13:14:56 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:package_test_user/file_edit_test_package/_meta?user=package_test_user
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="file_edit_test_package" project="home:package_test_user">
+          <title>Oh! To be in England</title>
+          <description>Modi exercitationem atque veniam eum quos.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '194'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="file_edit_test_package" project="home:package_test_user">
+          <title>Oh! To be in England</title>
+          <description>Modi exercitationem atque veniam eum quos.</description>
+        </package>
+    http_version: 
+  recorded_at: Wed, 03 Jan 2018 13:14:57 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:package_test_user/file_edit_test_package/_config
+    body:
+      encoding: UTF-8
+      string: Earum enim quo exercitationem. Porro eum voluptatem in maxime pariatur
+        rem quidem. Voluptatum eaque dolor reiciendis dolor. Quo ad velit accusantium
+        voluptatem et.
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '207'
+    body:
+      encoding: UTF-8
+      string: |
+        <revision rev="1" vrev="1">
+          <srcmd5>e8d06b2187e8e6b899130db5be14ba4b</srcmd5>
+          <version>unknown</version>
+          <time>1514985297</time>
+          <user>unknown</user>
+          <comment></comment>
+          <requestid/>
+        </revision>
+    http_version: 
+  recorded_at: Wed, 03 Jan 2018 13:14:57 GMT
+recorded_with: VCR 4.0.0

--- a/src/api/spec/cassettes/Packages/log/download_logfile_succesfully.yml
+++ b/src/api/spec/cassettes/Packages/log/download_logfile_succesfully.yml
@@ -805,4 +805,117 @@ http_interactions:
         </status>
     http_version: 
   recorded_at: Tue, 29 Aug 2017 15:43:05 GMT
-recorded_with: VCR 3.0.3
+- request:
+    method: put
+    uri: http://backend:5352/source/home:package_test_user/test_package/_meta?user=package_test_user
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="test_package" project="home:package_test_user">
+          <title>The Curious Incident of the Dog in the Night-Time</title>
+          <description>Et nostrum est officiis.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '195'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="test_package" project="home:package_test_user">
+          <title>The Curious Incident of the Dog in the Night-Time</title>
+          <description>Et nostrum est officiis.</description>
+        </package>
+    http_version: 
+  recorded_at: Wed, 03 Jan 2018 13:14:23 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:other_package_test_user/branch_test_package/_meta?user=package_test_user
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="branch_test_package" project="home:other_package_test_user">
+          <title>The Wings of the Dove</title>
+          <description>Aut autem magnam veniam possimus.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '189'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="branch_test_package" project="home:other_package_test_user">
+          <title>The Wings of the Dove</title>
+          <description>Aut autem magnam veniam possimus.</description>
+        </package>
+    http_version: 
+  recorded_at: Wed, 03 Jan 2018 13:14:23 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:package_test_user/test_package
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '301'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="test_package" rev="3" vrev="3" srcmd5="f69d66eae19594b626fe6cc073afcde5">
+          <entry name="_config" md5="e5e404e767c22acb2e9c342d06c0a2f2" size="110" mtime="1514985233" />
+          <entry name="somefile.txt" md5="5d88a7ec3d8b87d9b380ad5046e4eb5a" size="127" mtime="1514985233" />
+        </directory>
+    http_version: 
+  recorded_at: Wed, 03 Jan 2018 13:14:24 GMT
+recorded_with: VCR 4.0.0

--- a/src/api/spec/cassettes/Packages/log/live_build_finishes_succesfully.yml
+++ b/src/api/spec/cassettes/Packages/log/live_build_finishes_succesfully.yml
@@ -436,4 +436,82 @@ http_interactions:
         </status>
     http_version: 
   recorded_at: Tue, 29 Aug 2017 12:36:18 GMT
-recorded_with: VCR 3.0.3
+- request:
+    method: put
+    uri: http://backend:5352/source/home:package_test_user/test_package/_meta?user=package_test_user
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="test_package" project="home:package_test_user">
+          <title>A Passage to India</title>
+          <description>Id iure et nesciunt placeat.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '168'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="test_package" project="home:package_test_user">
+          <title>A Passage to India</title>
+          <description>Id iure et nesciunt placeat.</description>
+        </package>
+    http_version: 
+  recorded_at: Wed, 03 Jan 2018 13:14:35 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:other_package_test_user/branch_test_package/_meta?user=package_test_user
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="branch_test_package" project="home:other_package_test_user">
+          <title>A Scanner Darkly</title>
+          <description>Quis consequatur impedit itaque est.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '187'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="branch_test_package" project="home:other_package_test_user">
+          <title>A Scanner Darkly</title>
+          <description>Quis consequatur impedit itaque est.</description>
+        </package>
+    http_version: 
+  recorded_at: Wed, 03 Jan 2018 13:14:35 GMT
+recorded_with: VCR 4.0.0

--- a/src/api/spec/cassettes/Packages/requesting_package_deletion.yml
+++ b/src/api/spec/cassettes/Packages/requesting_package_deletion.yml
@@ -771,4 +771,245 @@ http_interactions:
         </status>
     http_version: 
   recorded_at: Fri, 20 Jan 2017 02:54:42 GMT
-recorded_with: VCR 3.0.3
+- request:
+    method: put
+    uri: http://backend:5352/source/home:package_test_user/_meta?user=package_test_user
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:package_test_user">
+          <title/>
+          <description/>
+          <person userid="package_test_user" role="maintainer"/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '157'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:package_test_user">
+          <title></title>
+          <description></description>
+          <person userid="package_test_user" role="maintainer" />
+        </project>
+    http_version: 
+  recorded_at: Wed, 03 Jan 2018 13:12:51 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:package_test_user/test_package/_meta?user=_nobody_
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="test_package" project="home:package_test_user">
+          <title>Infinite Jest</title>
+          <description>Exercitationem distinctio consectetur sed qui in aut dolores.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '196'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="test_package" project="home:package_test_user">
+          <title>Infinite Jest</title>
+          <description>Exercitationem distinctio consectetur sed qui in aut dolores.</description>
+        </package>
+    http_version: 
+  recorded_at: Wed, 03 Jan 2018 13:12:51 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:package_test_user/test_package/_config
+    body:
+      encoding: UTF-8
+      string: Natus maxime ab. Voluptas sint nostrum ad sit. Dolore fugiat deleniti
+        iste quod odio voluptatibus.
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '207'
+    body:
+      encoding: UTF-8
+      string: |
+        <revision rev="3" vrev="3">
+          <srcmd5>b3b13d2a351c137961818c7a1eefc3e3</srcmd5>
+          <version>unknown</version>
+          <time>1514985171</time>
+          <user>unknown</user>
+          <comment></comment>
+          <requestid/>
+        </revision>
+    http_version: 
+  recorded_at: Wed, 03 Jan 2018 13:12:51 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:other_package_test_user/_meta?user=other_package_test_user
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:other_package_test_user">
+          <title/>
+          <description/>
+          <person userid="other_package_test_user" role="maintainer"/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '169'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:other_package_test_user">
+          <title></title>
+          <description></description>
+          <person userid="other_package_test_user" role="maintainer" />
+        </project>
+    http_version: 
+  recorded_at: Wed, 03 Jan 2018 13:12:51 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:other_package_test_user/branch_test_package/_meta?user=_nobody_
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="branch_test_package" project="home:other_package_test_user">
+          <title>The Lathe of Heaven</title>
+          <description>Ratione repudiandae incidunt eos saepe.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '193'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="branch_test_package" project="home:other_package_test_user">
+          <title>The Lathe of Heaven</title>
+          <description>Ratione repudiandae incidunt eos saepe.</description>
+        </package>
+    http_version: 
+  recorded_at: Wed, 03 Jan 2018 13:12:51 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:other_package_test_user/branch_test_package/_config
+    body:
+      encoding: UTF-8
+      string: Sint et laborum velit nihil sed. Fugit dolorem quia officia temporibus
+        corporis tempore similique. Optio molestias quaerat. Quis tempora quisquam.
+        Saepe itaque iste.
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '207'
+    body:
+      encoding: UTF-8
+      string: |
+        <revision rev="1" vrev="1">
+          <srcmd5>810b8f35e166c37edd7bb74e78f83876</srcmd5>
+          <version>unknown</version>
+          <time>1514985171</time>
+          <user>unknown</user>
+          <comment></comment>
+          <requestid/>
+        </revision>
+    http_version: 
+  recorded_at: Wed, 03 Jan 2018 13:12:51 GMT
+recorded_with: VCR 4.0.0

--- a/src/api/spec/cassettes/Packages/triggering_package_rebuild/via_binaries_view.yml
+++ b/src/api/spec/cassettes/Packages/triggering_package_rebuild/via_binaries_view.yml
@@ -437,4 +437,82 @@ http_interactions:
         </status>
     http_version: 
   recorded_at: Tue, 29 Aug 2017 12:41:42 GMT
-recorded_with: VCR 3.0.3
+- request:
+    method: put
+    uri: http://backend:5352/source/home:package_test_user/test_package/_meta?user=package_test_user
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="test_package" project="home:package_test_user">
+          <title>The Other Side of Silence</title>
+          <description>Magnam et laudantium recusandae.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '179'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="test_package" project="home:package_test_user">
+          <title>The Other Side of Silence</title>
+          <description>Magnam et laudantium recusandae.</description>
+        </package>
+    http_version: 
+  recorded_at: Wed, 03 Jan 2018 13:17:12 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:other_package_test_user/branch_test_package/_meta?user=package_test_user
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="branch_test_package" project="home:other_package_test_user">
+          <title>The Monkey's Raincoat</title>
+          <description>Eligendi animi explicabo et nemo in ut.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '195'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="branch_test_package" project="home:other_package_test_user">
+          <title>The Monkey's Raincoat</title>
+          <description>Eligendi animi explicabo et nemo in ut.</description>
+        </package>
+    http_version: 
+  recorded_at: Wed, 03 Jan 2018 13:17:13 GMT
+recorded_with: VCR 4.0.0

--- a/src/api/spec/cassettes/Packages/triggering_package_rebuild/via_live_build_log.yml
+++ b/src/api/spec/cassettes/Packages/triggering_package_rebuild/via_live_build_log.yml
@@ -583,4 +583,82 @@ http_interactions:
         </status>
     http_version: 
   recorded_at: Tue, 29 Aug 2017 12:41:45 GMT
-recorded_with: VCR 3.0.3
+- request:
+    method: put
+    uri: http://backend:5352/source/home:package_test_user/test_package/_meta?user=user_tab_user
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="test_package" project="home:package_test_user">
+          <title>Brandy of the Damned</title>
+          <description>Voluptas vel nihil error.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '167'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="test_package" project="home:package_test_user">
+          <title>Brandy of the Damned</title>
+          <description>Voluptas vel nihil error.</description>
+        </package>
+    http_version: 
+  recorded_at: Wed, 03 Jan 2018 13:17:01 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:other_package_test_user/branch_test_package/_meta?user=user_tab_user
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="branch_test_package" project="home:other_package_test_user">
+          <title>Paths of Glory</title>
+          <description>Qui soluta reiciendis ex fuga.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '179'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="branch_test_package" project="home:other_package_test_user">
+          <title>Paths of Glory</title>
+          <description>Qui soluta reiciendis ex fuga.</description>
+        </package>
+    http_version: 
+  recorded_at: Wed, 03 Jan 2018 13:17:01 GMT
+recorded_with: VCR 4.0.0

--- a/src/api/spec/cassettes/Projects/branching/a_package_and_select_current_revision.yml
+++ b/src/api/spec/cassettes/Projects/branching/a_package_and_select_current_revision.yml
@@ -1846,4 +1846,109 @@ http_interactions:
         </status>
     http_version: 
   recorded_at: Fri, 16 Jun 2017 14:26:54 GMT
-recorded_with: VCR 3.0.3
+- request:
+    method: get
+    uri: http://backend:5352/source/home:Jane/branch_test_package
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 404
+      message: package 'branch_test_package' does not exist
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '166'
+    body:
+      encoding: UTF-8
+      string: |
+        <status code="404">
+          <summary>package 'branch_test_package' does not exist</summary>
+          <details>404 package 'branch_test_package' does not exist</details>
+        </status>
+    http_version: 
+  recorded_at: Wed, 03 Jan 2018 14:25:42 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:Jane/branch_test_package
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 404
+      message: package 'branch_test_package' does not exist
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '166'
+    body:
+      encoding: UTF-8
+      string: |
+        <status code="404">
+          <summary>package 'branch_test_package' does not exist</summary>
+          <details>404 package 'branch_test_package' does not exist</details>
+        </status>
+    http_version: 
+  recorded_at: Wed, 03 Jan 2018 14:25:42 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:Jane/branch_test_package?expand=0
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 404
+      message: package 'branch_test_package' does not exist
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '166'
+    body:
+      encoding: UTF-8
+      string: |
+        <status code="404">
+          <summary>package 'branch_test_package' does not exist</summary>
+          <details>404 package 'branch_test_package' does not exist</details>
+        </status>
+    http_version: 
+  recorded_at: Wed, 03 Jan 2018 14:25:42 GMT
+recorded_with: VCR 4.0.0

--- a/src/api/spec/cassettes/Projects/branching/an_existing_package.yml
+++ b/src/api/spec/cassettes/Projects/branching/an_existing_package.yml
@@ -1274,4 +1274,39 @@ http_interactions:
         </status>
     http_version: 
   recorded_at: Fri, 16 Jun 2017 14:27:01 GMT
-recorded_with: VCR 3.0.3
+- request:
+    method: get
+    uri: http://backend:5352/source/home:Jane/branch_test_package
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 404
+      message: package 'branch_test_package' does not exist
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '166'
+    body:
+      encoding: UTF-8
+      string: |
+        <status code="404">
+          <summary>package 'branch_test_package' does not exist</summary>
+          <details>404 package 'branch_test_package' does not exist</details>
+        </status>
+    http_version: 
+  recorded_at: Wed, 03 Jan 2018 14:23:53 GMT
+recorded_with: VCR 4.0.0

--- a/src/api/spec/cassettes/Projects/branching/an_existing_package_but_chose_a_different_target_package_name.yml
+++ b/src/api/spec/cassettes/Projects/branching/an_existing_package_but_chose_a_different_target_package_name.yml
@@ -1273,4 +1273,39 @@ http_interactions:
         </status>
     http_version: 
   recorded_at: Fri, 16 Jun 2017 14:27:04 GMT
-recorded_with: VCR 3.0.3
+- request:
+    method: get
+    uri: http://backend:5352/source/home:Jane/some_different_name
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 404
+      message: package 'some_different_name' does not exist
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '166'
+    body:
+      encoding: UTF-8
+      string: |
+        <status code="404">
+          <summary>package 'some_different_name' does not exist</summary>
+          <details>404 package 'some_different_name' does not exist</details>
+        </status>
+    http_version: 
+  recorded_at: Wed, 03 Jan 2018 14:24:43 GMT
+recorded_with: VCR 4.0.0

--- a/src/api/spec/cassettes/Projects/branching/an_existing_package_were_the_target_package_already_exists.yml
+++ b/src/api/spec/cassettes/Projects/branching/an_existing_package_were_the_target_package_already_exists.yml
@@ -947,4 +947,39 @@ http_interactions:
         </status>
     http_version: 
   recorded_at: Fri, 16 Jun 2017 14:26:57 GMT
-recorded_with: VCR 3.0.3
+- request:
+    method: get
+    uri: http://backend:5352/source/home:Jane/branch_test_package
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 404
+      message: package 'branch_test_package' does not exist
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '166'
+    body:
+      encoding: UTF-8
+      string: |
+        <status code="404">
+          <summary>package 'branch_test_package' does not exist</summary>
+          <details>404 package 'branch_test_package' does not exist</details>
+        </status>
+    http_version: 
+  recorded_at: Wed, 03 Jan 2018 14:26:41 GMT
+recorded_with: VCR 4.0.0

--- a/src/api/spec/cassettes/Projects/creating_packages_in_projects_not_owned_by_user_eg_global_namespace/as_admin.yml
+++ b/src/api/spec/cassettes/Projects/creating_packages_in_projects_not_owned_by_user_eg_global_namespace/as_admin.yml
@@ -632,4 +632,39 @@ http_interactions:
         </status>
     http_version: 
   recorded_at: Fri, 16 Jun 2017 14:26:33 GMT
-recorded_with: VCR 3.0.3
+- request:
+    method: get
+    uri: http://backend:5352/source/global_project/coolstuff
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 404
+      message: package 'coolstuff' does not exist
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '146'
+    body:
+      encoding: UTF-8
+      string: |
+        <status code="404">
+          <summary>package 'coolstuff' does not exist</summary>
+          <details>404 package 'coolstuff' does not exist</details>
+        </status>
+    http_version: 
+  recorded_at: Wed, 03 Jan 2018 14:21:38 GMT
+recorded_with: VCR 4.0.0

--- a/src/api/spec/cassettes/Projects/creating_packages_in_projects_owned_by_user_eg_home_projects/with_valid_data.yml
+++ b/src/api/spec/cassettes/Projects/creating_packages_in_projects_owned_by_user_eg_home_projects/with_valid_data.yml
@@ -632,4 +632,39 @@ http_interactions:
         </status>
     http_version: 
   recorded_at: Fri, 16 Jun 2017 14:26:46 GMT
-recorded_with: VCR 3.0.3
+- request:
+    method: get
+    uri: http://backend:5352/source/home:Jane/coolstuff
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 404
+      message: package 'coolstuff' does not exist
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '146'
+    body:
+      encoding: UTF-8
+      string: |
+        <status code="404">
+          <summary>package 'coolstuff' does not exist</summary>
+          <details>404 package 'coolstuff' does not exist</details>
+        </status>
+    http_version: 
+  recorded_at: Wed, 03 Jan 2018 14:23:01 GMT
+recorded_with: VCR 4.0.0

--- a/src/api/spec/cassettes/Webui_Cloud_UploadJobsController/POST_create/without_backend_response/1_3_1_1.yml
+++ b/src/api/spec/cassettes/Webui_Cloud_UploadJobsController/POST_create/without_backend_response/1_3_1_1.yml
@@ -1,0 +1,39 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: http://backend:5352/cloudupload?arch=x86_64&filename=appliance.raw.xz&package=apache2&project=Apache&repository=standard&target=ec2&user=tom
+    body:
+      encoding: UTF-8
+      string: '{"user_id":1,"external_id":"tae861t1cj4wk8robexz3xsq","arn":"arn:tio6znmxtt","region":"us-east-1"}'
+    headers:
+      Content-Type:
+      - application/octet-stream
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 400
+      message: no cloud upload server configurated
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '87'
+    body:
+      encoding: UTF-8
+      string: |
+        <status code="400">
+          <summary>no cloud upload server configurated</summary>
+        </status>
+    http_version: 
+  recorded_at: Fri, 22 Dec 2017 14:14:34 GMT
+recorded_with: VCR 4.0.0

--- a/src/api/spec/cassettes/Webui_Cloud_UploadJobsController/POST_create/without_backend_response/1_3_1_2.yml
+++ b/src/api/spec/cassettes/Webui_Cloud_UploadJobsController/POST_create/without_backend_response/1_3_1_2.yml
@@ -1,0 +1,39 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: http://backend:5352/cloudupload?arch=x86_64&filename=appliance.raw.xz&package=apache2&project=Apache&repository=standard&target=ec2&user=tom
+    body:
+      encoding: UTF-8
+      string: '{"user_id":2,"external_id":"yn13tsaa5nllcx0xovsf8u5j","arn":"arn:ziiv5zwgaj","region":"us-east-1"}'
+    headers:
+      Content-Type:
+      - application/octet-stream
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 400
+      message: no cloud upload server configurated
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '87'
+    body:
+      encoding: UTF-8
+      string: |
+        <status code="400">
+          <summary>no cloud upload server configurated</summary>
+        </status>
+    http_version: 
+  recorded_at: Fri, 22 Dec 2017 14:14:34 GMT
+recorded_with: VCR 4.0.0

--- a/src/api/spec/controllers/webui/cloud/ec2/configurations_controller_spec.rb
+++ b/src/api/spec/controllers/webui/cloud/ec2/configurations_controller_spec.rb
@@ -1,0 +1,61 @@
+require 'rails_helper'
+
+RSpec.describe Webui::Cloud::Ec2::ConfigurationsController, type: :controller do
+  let(:user) { create(:confirmed_user, login: 'tom') }
+  before do
+    login(user)
+  end
+
+  describe 'GET #show' do
+    context 'without EC2 configuration' do
+      before do
+        Feature.run_with_activated(:cloud_upload) do
+          get :show
+        end
+      end
+
+      it 'creates an EC2 configuration' do
+        expect(user.ec2_configuration).not_to be_nil
+      end
+    end
+
+    context 'with EC2 configuration' do
+      let!(:ec2_configuration) { create(:ec2_configuration, user: user) }
+
+      before do
+        Feature.run_with_activated(:cloud_upload) do
+          get :show
+        end
+      end
+
+      it { expect(user.ec2_configuration).to eq(ec2_configuration) }
+    end
+  end
+
+  describe 'GET #update' do
+    let!(:ec2_configuration) { create(:ec2_configuration, user: user) }
+
+    context 'with valid parameters' do
+      before do
+        Feature.run_with_activated(:cloud_upload) do
+          put :update, params: { ec2_configuration: { arn: 'arn:123:456' } }
+        end
+        ec2_configuration.reload
+      end
+
+      it { expect(ec2_configuration.arn).to eq('arn:123:456') }
+      it { expect(flash[:success]).not_to be_nil }
+    end
+
+    context 'with invalid parameters' do
+      before do
+        Feature.run_with_activated(:cloud_upload) do
+          put :update, params: { ec2_configuration: { arn: '123' } }
+        end
+      end
+
+      it { expect(ec2_configuration.arn).not_to eq('123') }
+      it { expect(flash[:error]).not_to be_nil }
+    end
+  end
+end

--- a/src/api/spec/controllers/webui/cloud/upload_jobs_controller_spec.rb
+++ b/src/api/spec/controllers/webui/cloud/upload_jobs_controller_spec.rb
@@ -1,0 +1,122 @@
+require 'rails_helper'
+
+RSpec.describe Webui::Cloud::UploadJobsController, type: :controller, vcr: true do
+  let!(:user) { create(:confirmed_user, login: 'tom') }
+  let!(:ec2_configuration) { create(:ec2_configuration, user: user) }
+  let!(:upload_job) { create(:upload_job, user: user) }
+  let(:project) { create(:project, name: 'Apache') }
+  let!(:package) { create(:package, name: 'apache2', project: project) }
+
+  before do
+    login(user)
+  end
+
+  describe 'src/api/spec/ #index' do
+    context 'with cloud_upload feature enabled' do
+      context 'without an EC2 configuration' do
+        before do
+          user.ec2_configuration = nil
+          user.save
+
+          Feature.run_with_activated(:cloud_upload) do
+            get :index
+          end
+        end
+
+        it { expect(response).to redirect_to(cloud_ec2_configuration_path) }
+      end
+
+      context 'with an EC2 configuration' do
+        before do
+          Feature.run_with_activated(:cloud_upload) do
+            get :index
+          end
+        end
+
+        it { expect(assigns(:upload_jobs)).to match_array([upload_job]) }
+        it { expect(response).to have_http_status(:success) }
+      end
+    end
+
+    context 'with cloud_upload feature disabled' do
+      before do
+        Feature.run_with_deactivated(:cloud_upload) do
+          get :index
+        end
+      end
+
+      it { expect(response).to have_http_status(:not_found) }
+    end
+  end
+
+  describe 'GET #new' do
+    before do
+      Feature.run_with_activated(:cloud_upload) do
+        get :new, params: { project: 'Apache', package: 'apache2', repository: 'standard', arch: 'x86_64', filename: 'appliance.raw.xz' }
+      end
+    end
+
+    it { expect(response).to have_http_status(:success) }
+    it {
+      expect(assigns(:upload_job)).
+        to have_attributes(project: 'Apache', package: 'apache2', repository: 'standard', arch: 'x86_64', filename: 'appliance.raw.xz')
+    }
+  end
+
+  describe 'POST #create' do
+    context 'without backend response' do
+      before do
+        Feature.run_with_activated(:cloud_upload) do
+          post :create, params: { cloud_backend_upload_job: {
+            project: 'Apache', package: 'apache2', repository: 'standard', arch: 'x86_64', filename: 'appliance.raw.xz', region: 'us-east-1'
+          } }
+        end
+      end
+
+      it { expect(flash[:error]).not_to be_nil }
+      it { expect(response).to have_http_status(302) }
+    end
+
+    context 'with a backend response' do
+      let(:response) do
+        <<-HEREDOC
+        <clouduploadjob name="6">
+          <state>created</state>
+          <details>waiting to receive image</details>
+          <created>1513604055</created>
+          <user>mlschroe</user>
+          <target>ec2</target>
+          <project>Base:System</project>
+          <repository>openSUSE_Factory</repository>
+          <package>rpm</package>
+          <arch>x86_64</arch>
+          <filename>rpm-4.14.0-504.2.x86_64.rpm</filename>
+          <size>1690860</size>
+        </clouduploadjob>
+        HEREDOC
+      end
+      let(:params) do
+        ActionController::Parameters.new(
+          project:    'Cloud',
+          package:    'aws',
+          repository: 'standard',
+          arch:       'x86_64',
+          filename:   'appliance.raw.gz',
+          region:     'us-east-1'
+        ).permit!
+      end
+      before do
+        allow(Backend::Api::Cloud).to receive(:upload).with(user, params).and_return(response)
+
+        Feature.run_with_activated(:cloud_upload) do
+          post :create, params: { cloud_backend_upload_job: params }
+        end
+      end
+
+      it { expect(flash[:success]).not_to be_nil }
+      it { expect(Cloud::User::UploadJob.last.job_id).to eq(6) }
+      it { expect(Cloud::User::UploadJob.last.user).to eq(user) }
+      it { expect(response).to redirect_to(cloud_upload_index_path) }
+    end
+  end
+end

--- a/src/api/spec/factories/ec2_configuration.rb
+++ b/src/api/spec/factories/ec2_configuration.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :ec2_configuration, class: Cloud::Ec2::Configuration do
+    user
+    arn { "arn:#{Faker::Lorem.characters(10)}" }
+    external_id { Faker::Lorem.characters(24) }
+  end
+end

--- a/src/api/spec/factories/upload_job.rb
+++ b/src/api/spec/factories/upload_job.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :upload_job, class: Cloud::User::UploadJob do
+    user
+    job_id { Faker::Number.between(100, 1000) }
+  end
+end

--- a/src/api/spec/helpers/webui/package_helper_spec.rb
+++ b/src/api/spec/helpers/webui/package_helper_spec.rb
@@ -272,4 +272,10 @@ RSpec.describe Webui::PackageHelper, type: :helper do
       end
     end
   end
+
+  describe 'cloud_image_file?' do
+    it { expect(cloud_image_file?('image.raw.xz')).to be_truthy }
+    it { expect(cloud_image_file?('image.vhdfixed.xz')).to be_truthy }
+    it { expect(cloud_image_file?('apache2.rpm')).to be_falsy }
+  end
 end

--- a/src/api/spec/models/cloud/backend/upload_job_spec.rb
+++ b/src/api/spec/models/cloud/backend/upload_job_spec.rb
@@ -1,0 +1,78 @@
+require 'rails_helper'
+
+RSpec.describe Cloud::Backend::UploadJob, type: :model, vcr: true do
+  describe '.create' do
+    let(:user) { create(:confirmed_user, login: 'tom', ec2_configuration: create(:ec2_configuration)) }
+    let(:params) do
+      {
+        project:    'Cloud',
+        package:    'aws',
+        repository: 'standard',
+        arch:       'x86_64',
+        filename:   'appliance.raw.gz',
+        region:     'us-east-1'
+      }
+    end
+    let(:response) do
+      <<-HEREDOC
+      <clouduploadjob name="6">
+        <state>created</state>
+        <details>waiting to receive image</details>
+        <created>1513604055</created>
+        <user>mlschroe</user>
+        <target>ec2</target>
+        <project>Base:System</project>
+        <repository>openSUSE_Factory</repository>
+        <package>rpm</package>
+        <arch>x86_64</arch>
+        <filename>rpm-4.14.0-504.2.x86_64.rpm</filename>
+        <size>1690860</size>
+      </clouduploadjob>
+      HEREDOC
+    end
+
+    context 'with a valid backend response' do
+      before do
+        allow(Backend::Api::Cloud).to receive(:upload).with(user, params).and_return(response)
+      end
+
+      subject { Cloud::Backend::UploadJob.create(user, params) }
+
+      it { expect(subject.valid?).to be_truthy }
+      it { expect(subject.id).to eq('6') }
+      it { expect(subject.state).to eq('created') }
+      it { expect(subject.details).to eq('waiting to receive image') }
+      it { expect(subject.user).to eq('mlschroe') }
+      it { expect(subject.platform).to eq('ec2') }
+      it { expect(subject.project).to eq('Base:System') }
+      it { expect(subject.package).to eq('rpm') }
+      it { expect(subject.repository).to eq('openSUSE_Factory') }
+      it { expect(subject.architecture).to eq('x86_64') }
+      it { expect(subject.filename).to eq('rpm-4.14.0-504.2.x86_64.rpm') }
+      it { expect(subject.size).to eq('1690860') }
+    end
+
+    context 'with an invalid backend response' do
+      subject { Cloud::Backend::UploadJob.create(user, params) }
+
+      it { expect(subject.valid?).to be_falsy }
+      it 'has the correct error message' do
+        subject.valid?
+        expect(subject.errors.full_messages.to_sentence).to eq('no cloud upload server configurated')
+      end
+    end
+
+    context 'with Timeout::Error' do
+      before do
+        allow(Backend::Api::Cloud).to receive(:upload).with(user, params).and_raise(Timeout::Error, 'boom')
+      end
+      subject { Cloud::Backend::UploadJob.create(user, params) }
+
+      it { expect(subject.valid?).to be_falsy }
+      it 'has the correct error message' do
+        subject.valid?
+        expect(subject.errors.full_messages.to_sentence).to eq('boom')
+      end
+    end
+  end
+end

--- a/src/api/spec/models/cloud/ec2/configuration_spec.rb
+++ b/src/api/spec/models/cloud/ec2/configuration_spec.rb
@@ -1,0 +1,11 @@
+require 'rails_helper'
+
+RSpec.describe Cloud::Ec2::Configuration, type: :model, vcr: true do
+  describe 'validations' do
+    it { is_expected.to belong_to(:user) }
+    it { is_expected.to validate_uniqueness_of(:external_id) }
+    it { is_expected.to validate_uniqueness_of(:arn) }
+    it { is_expected.to allow_value('arn:123:456/tom').for(:arn) }
+    it { is_expected.not_to allow_value('123:456/tom').for(:arn) }
+  end
+end

--- a/src/api/spec/models/cloud/upload_job_spec.rb
+++ b/src/api/spec/models/cloud/upload_job_spec.rb
@@ -1,0 +1,69 @@
+require 'rails_helper'
+
+RSpec.describe Cloud::UploadJob, type: :model, vcr: true do
+  let(:user) { create(:confirmed_user, login: 'tom', ec2_configuration: create(:ec2_configuration)) }
+  let(:params) do
+    {
+      project:    'Cloud',
+      package:    'aws',
+      repository: 'standard',
+      arch:       'x86_64',
+      filename:   'appliance.raw.gz',
+      region:     'us-east-1'
+    }
+  end
+  let(:response) do
+    <<-HEREDOC
+    <clouduploadjob name="6">
+      <state>created</state>
+      <details>waiting to receive image</details>
+      <created>1513604055</created>
+      <user>#{user.login}</user>
+      <target>ec2</target>
+      <project>Base:System</project>
+      <repository>openSUSE_Factory</repository>
+      <package>rpm</package>
+      <arch>x86_64</arch>
+      <filename>rpm-4.14.0-504.2.x86_64.rpm</filename>
+      <size>1690860</size>
+    </clouduploadjob>
+    HEREDOC
+  end
+
+  describe '.create' do
+    context 'with a valid backend response' do
+      before do
+        allow(Backend::Api::Cloud).to receive(:upload).with(user, params).and_return(response)
+      end
+
+      subject { Cloud::UploadJob.create(user, params) }
+
+      it { expect(subject.valid?).to be_truthy }
+    end
+
+    context 'with an invalid Backend::UploadJob' do
+      subject { Cloud::UploadJob.create(user, params) }
+
+      it { expect(subject.valid?).to be_falsy }
+      it 'has the correct error message' do
+        subject.valid?
+        expect(subject.errors.full_messages.to_sentence).to eq('Backend upload job no cloud upload server configurated')
+      end
+    end
+
+    context 'with an invalid User::UploadJob' do
+      let!(:job) { create(:upload_job, job_id: 6) }
+      before do
+        allow(Backend::Api::Cloud).to receive(:upload).with(user, params).and_return(response)
+      end
+
+      subject { Cloud::UploadJob.create(user, params) }
+
+      it { expect(subject.valid?).to be_falsy }
+      it 'has the correct error message' do
+        subject.valid?
+        expect(subject.errors.full_messages.to_sentence).to eq('User upload job Job has already been taken')
+      end
+    end
+  end
+end

--- a/src/api/spec/models/cloud/user/upload_job_spec.rb
+++ b/src/api/spec/models/cloud/user/upload_job_spec.rb
@@ -1,0 +1,9 @@
+require 'rails_helper'
+
+RSpec.describe Cloud::User::UploadJob, type: :model, vcr: true do
+  describe 'validations' do
+    it { is_expected.to validate_presence_of(:job_id) }
+    it { is_expected.to belong_to(:user) }
+    it { is_expected.to validate_uniqueness_of(:job_id) }
+  end
+end


### PR DESCRIPTION
- Implement upload job index page
- Implement EC2 configuration page
- Implement Backend API calls to trigger upload

Not implemented yet:
- Validation of uploaded file, for now it is possible to upload any binary
- Status of the UploadJob  (already implemented in the backend)
- Log of the UploadJob (already implemented in the backend)
- Cancel of the UploadJob (not yet implemented in the backend)
- Hard coded public key in the view. Depending on how we will go forward we will replace the public key completely and create a temporary key in the backend
- EC2 regions is limited to us-east-1 and us-east-2
- Workflow needs to be revised
- and probably many more things

This is intended to be a prototype and is hidden behind the cloud_upload feature flag.

## Configuration
![image](https://user-images.githubusercontent.com/3799140/34218925-e83309e8-e5af-11e7-9ff0-8e91a27b6b1c.png)

## UploadJob list
![image](https://user-images.githubusercontent.com/3799140/34218906-d5430a7c-e5af-11e7-8e4f-bb2e5183114b.png)

## Upload
![image](https://user-images.githubusercontent.com/3799140/34218988-19cd5256-e5b0-11e7-920e-5f3ab7afbdc7.png)


