### PR TITLE
[frontend] Remove unused code

### DIFF
--- a/src/api/spec/support/shared_examples/features/flags_tables.rb
+++ b/src/api/spec/support/shared_examples/features/flags_tables.rb
@@ -80,8 +80,6 @@ RSpec.shared_examples 'a flag table' do
   end
 
   scenario 'toggle a single flag' do
-    query_attributes.merge!(repo: repository.name, architecture_id: Architecture.find_by_name('x86_64'))
-
     disable_flag_field_for(repository: repository.name, architecture: 'x86_64')
     expect(project.flags.reload.where(status: 'disable')).to exist
 


### PR DESCRIPTION
The query_attributes varaible is not used in this test. So it doesn't
make sense to have this line around.