### PR TITLE
[api] Use Hash#dig

### DIFF
--- a/src/api/app/controllers/configurations_controller.rb
+++ b/src/api/app/controllers/configurations_controller.rb
@@ -30,7 +30,7 @@ class ConfigurationsController < ApplicationController
     attribs = {}
     # scheduler architecture list
     archs = nil
-    archs = Hash[xml['schedulers']['arch'].map { |a| [a, 1] }] if xml['schedulers'] && xml['schedulers']['arch'].class == Array
+    archs = Hash[xml['schedulers']['arch'].map { |a| [a, 1] }] if xml.dig('schedulers', 'arch').class == Array
     archs = Hash[params['arch'].map { |a| [a, 1] }] if params['arch'].class == Array
     if archs
       Architecture.all.each do |arch|


### PR DESCRIPTION
`Hash#dig` was introduced in Ruby 2.3. It retrieves the value object corresponding to the each key objects repeatedly. :bowtie: 