### PR TITLE
[ci] Downgrade Airbrake ruby to solve Errbit bug

### DIFF
--- a/src/api/Gemfile
+++ b/src/api/Gemfile
@@ -11,7 +11,9 @@ gem 'nokogiri'
 # for delayed tasks
 gem 'delayed_job_active_record', '>= 4.0.0'
 # to fill errbit
-gem 'airbrake'
+gem 'airbrake', '<= 7.1.0'
+# Due to a bug in Errbit we need to use 2.5.0 -> https://github.com/errbit/errbit/pull/1237
+gem 'airbrake-ruby', '<= 2.5.0'
 # as JSON library - the default json conflicts with activerecord (by means of vice-versa monkey patching)
 gem 'yajl-ruby'
 # to search the database

--- a/src/api/Gemfile.lock
+++ b/src/api/Gemfile.lock
@@ -48,9 +48,9 @@ GEM
       activerecord (>= 3.0.0)
     addressable (2.5.2)
       public_suffix (>= 2.0.2, < 4.0)
-    airbrake (7.1.1)
+    airbrake (7.1.0)
       airbrake-ruby (~> 2.5)
-    airbrake-ruby (2.7.0)
+    airbrake-ruby (2.5.0)
     amq-protocol (2.2.0)
     annotate (2.7.2)
       activerecord (>= 3.2, < 6.0)
@@ -421,7 +421,8 @@ DEPENDENCIES
   acts_as_list
   acts_as_tree
   addressable
-  airbrake
+  airbrake (<= 7.1.0)
+  airbrake-ruby (<= 2.5.0)
   annotate
   bcrypt
   bullet


### PR DESCRIPTION
There is a bug in Errbit caused my Airbrake Ruby, which is already solved in Github but not applied yet:

https://github.com/errbit/errbit/pull/1237

When we updated Airbrake to 7.1.1, Airbrake-Ruby was also updated from 2.5 to 2.7:

https://github.com/openSUSE/open-build-service/pull/4231

Since this was deployed, we have not tracked any error in Errbit.