### PR TITLE
Improve group administration view

### DIFF
--- a/src/api/app/controllers/webui/groups_controller.rb
+++ b/src/api/app/controllers/webui/groups_controller.rb
@@ -41,7 +41,7 @@ class Webui::GroupsController < Webui::WebuiController
 
     if @group.replace_members(group_params[:members])
       flash[:success] = "Group '#{@group.title}' successfully updated."
-      redirect_to controller: :groups, action: :index
+      redirect_to group_edit_title_path(title: @group.title)
     else
       redirect_back(fallback_location: root_path, error: "Group can't be saved: #{@group.errors.full_messages.to_sentence}")
     end

--- a/src/api/app/controllers/webui/groups_controller.rb
+++ b/src/api/app/controllers/webui/groups_controller.rb
@@ -17,11 +17,7 @@ class Webui::GroupsController < Webui::WebuiController
   def edit
     authorize @group, :update?
     @roles = Role.global_roles
-    @members = []
-    @group.users.each do |person|
-      user = { 'name' => person.login }
-      @members << user
-    end
+    @members = @group.users.pluck(:login).map { |login| { 'name' => login } }
   end
 
   def create

--- a/src/api/app/controllers/webui/groups_controller.rb
+++ b/src/api/app/controllers/webui/groups_controller.rb
@@ -5,7 +5,7 @@ class Webui::GroupsController < Webui::WebuiController
 
   def index
     authorize Group, :index?
-    @groups = Group.all.includes(:groups_users)
+    @groups = Group.all.includes(:groups_users, :users)
   end
 
   def show; end

--- a/src/api/app/helpers/webui/group_helper.rb
+++ b/src/api/app/helpers/webui/group_helper.rb
@@ -1,0 +1,9 @@
+module Webui::GroupHelper
+  def group_management_label
+    if User.current.is_admin?
+      link_to('Group Management', groups_path)
+    else
+      'Group Management'
+    end
+  end
+end

--- a/src/api/app/views/webui/groups/edit.html.haml
+++ b/src/api/app/views/webui/groups/edit.html.haml
@@ -1,4 +1,5 @@
 - @pagetitle = "Edit User Data"
+- @crumb_list = [group_management_label, link_to(@group.title, group_show_path(@group.title,))]
 %h2
   Edit Group #{@group.title}
 = form_tag({ action: 'update' }, { id: 'group_add_form' }) do

--- a/src/api/app/views/webui/groups/show.html.haml
+++ b/src/api/app/views/webui/groups/show.html.haml
@@ -35,6 +35,9 @@
       = render(partial: 'webui/shared/requests_table', locals: { id: 'all_requests_table', source_url: group_requests_path(@group) })
     .table-container.hidden#group-members
       %h3 Group Members
+      - if User.current.is_admin? || @group.group_maintainers.where(user: User.current).exists?
+        .grid_16{ style: "margin-bottom: 10px;" }
+          = link_to(sprited_text('brick_edit', 'Update group members'), group_edit_title_path(title: @group.title))
       %table#group-members-table
         %thead
           %tr

--- a/src/api/spec/controllers/webui/groups_controller_spec.rb
+++ b/src/api/spec/controllers/webui/groups_controller_spec.rb
@@ -164,7 +164,7 @@ RSpec.describe Webui::GroupsController do
       end
 
       it { expect(flash[:success]).to eq("Group '#{group.title}' successfully updated.") }
-      it { expect(response).to redirect_to(groups_path) }
+      it { expect(response).to redirect_to(group_edit_title_path(title: group.title)) }
     end
 
     context 'as an admin' do
@@ -177,7 +177,7 @@ RSpec.describe Webui::GroupsController do
       end
 
       it { expect(flash[:success]).to eq("Group '#{group.title}' successfully updated.") }
-      it { expect(response).to redirect_to(groups_path) }
+      it { expect(response).to redirect_to(group_edit_title_path(title: group.title)) }
     end
   end
 end

--- a/src/api/spec/controllers/webui/groups_controller_spec.rb
+++ b/src/api/spec/controllers/webui/groups_controller_spec.rb
@@ -140,4 +140,44 @@ RSpec.describe Webui::GroupsController do
       end
     end
   end
+
+  describe 'POST update' do
+    let(:user_to_add) { create(:user) }
+    let(:group_maintainer) { create(:group_maintainer, group: group) }
+
+    context 'as a normal user' do
+      before do
+        login(user)
+
+        post :update, params: { title: group.title, group: { members: user_to_add.login } }
+      end
+
+      it { expect(flash[:error]).to eq('Sorry, you are not authorized to update this Group.') }
+      it { expect(response).to redirect_to(root_path) }
+    end
+
+    context 'as a maintainer of the group' do
+      before do
+        login(group_maintainer.user)
+
+        post :update, params: { title: group.title, group: { members: user_to_add.login } }
+      end
+
+      it { expect(flash[:success]).to eq("Group '#{group.title}' successfully updated.") }
+      it { expect(response).to redirect_to(groups_path) }
+    end
+
+    context 'as an admin' do
+      let(:admin) { create(:admin_user) }
+
+      before do
+        login(admin)
+
+        post :update, params: { title: group.title, group: { members: user_to_add.login } }
+      end
+
+      it { expect(flash[:success]).to eq("Group '#{group.title}' successfully updated.") }
+      it { expect(response).to redirect_to(groups_path) }
+    end
+  end
 end

--- a/src/api/spec/features/webui/groups_spec.rb
+++ b/src/api/spec/features/webui/groups_spec.rb
@@ -36,7 +36,7 @@ RSpec.feature 'Groups', type: :feature, js: true do
     page.find('input#members', visible: false).set 'eisendieter'
     click_button 'Save'
 
-    within :xpath, "//tr[@id='group-test_group_b']" do
+    within 'form', text: 'Members:' do
       expect(page).to have_content('eisendieter')
     end
   end

--- a/src/api/spec/features/webui/groups_spec.rb
+++ b/src/api/spec/features/webui/groups_spec.rb
@@ -15,6 +15,7 @@ RSpec.feature 'Groups', type: :feature, js: true do
     expect(page).to have_content('Incoming Reviews')
     find('#group-members-tab').click
     expect(page).to have_content('This group does not contain users.')
+    expect(page).to have_link('Update group members')
 
     visit groups_path
     expect(page).to have_content('Showing 1 to 2 of 2 entries')


### PR DESCRIPTION
* Add breadcrumbs to group edit view
* Add a link to the group show view that refers to the group edit page

The breadcrumbs:
![screenshot from 2018-01-04 09-32-19](https://user-images.githubusercontent.com/968949/34555539-8c9d61c6-f132-11e7-9cca-26f3e008c6c1.png)

The group show page:
![screenshot from 2018-01-04 09-32-28](https://user-images.githubusercontent.com/968949/34555546-934dc722-f132-11e7-8c7b-4be3608e17a7.png)

  