### PR TITLE
[frontend] Turn class attributes into Constants

### DIFF
--- a/src/api/app/models/full_text_search.rb
+++ b/src/api/app/models/full_text_search.rb
@@ -1,19 +1,15 @@
 class FullTextSearch
   include ActiveModel::Serializers::JSON
 
-  cattr_accessor :ranker, :field_weights, :per_page, :star,
-                 :linked_count_weight, :activity_index_weight, :links_to_other_weight,
-                 :is_devel_weight, :max_matches
-
-  self.linked_count_weight = 100
-  self.activity_index_weight = 500
-  self.links_to_other_weight = -1000
-  self.is_devel_weight = 1000
-  self.field_weights = { name: 10, title: 2, description: 1 }
-  self.ranker = :sph04
-  self.per_page = 50
-  self.star = false
-  self.max_matches = 15000
+  LINKED_COUNT_WEIGHT = 100
+  ACTIVITY_INDEX_WEIGHT = 500
+  LINKS_TO_OTHER_WEIGHT = -1000
+  IS_DEVEL_WEIGHT = 1000
+  FIELD_WEIGHTS = { name: 10, title: 2, description: 1 }.freeze
+  RANKER = :sph04
+  PER_PAGE = 50
+  STAR = false
+  MAX_MATCHES = 15000
 
   attr_accessor :text, :classes, :fields, :attrib_type_id, :issue_tracker_name, :issue_name
   attr_reader :result
@@ -28,20 +24,20 @@ class FullTextSearch
   end
 
   def search(options = {})
-    args = { ranker:        FullTextSearch.ranker,
-             star:          FullTextSearch.star,
-             max_matches:   FullTextSearch.max_matches,
+    args = { ranker:        RANKER,
+             star:          STAR,
+             max_matches:   MAX_MATCHES,
              order:         'adjusted_weight DESC',
-             field_weights: FullTextSearch.field_weights,
+             field_weights: FIELD_WEIGHTS,
              page:          options[:page],
-             per_page:      options[:per_page] || FullTextSearch.per_page,
+             per_page:      options[:per_page] || PER_PAGE,
              without:       { project_id: Relationship.forbidden_project_ids } }
 
     args[:select] = '*, (weight() + '\
-                    "#{FullTextSearch.linked_count_weight} * linked_count + "\
-                    "#{FullTextSearch.links_to_other_weight} * links_to_other + "\
-                    "#{FullTextSearch.is_devel_weight} * is_devel + "\
-                    "#{FullTextSearch.activity_index_weight} * (activity_index * POW( 2.3276, (updated_at - #{Time.now.to_i}) / 10000000))) "\
+                    "#{LINKED_COUNT_WEIGHT} * linked_count + "\
+                    "#{LINKS_TO_OTHER_WEIGHT} * links_to_other + "\
+                    "#{IS_DEVEL_WEIGHT} * is_devel + "\
+                    "#{ACTIVITY_INDEX_WEIGHT} * (activity_index * POW( 2.3276, (updated_at - #{Time.now.to_i}) / 10000000))) "\
                     'as adjusted_weight'
 
     issue_id = find_issue_id

--- a/src/api/spec/support/thinking_sphinx.rb
+++ b/src/api/spec/support/thinking_sphinx.rb
@@ -13,8 +13,6 @@ end
 RSpec.configure do |config|
   config.include SphinxHelpers, type: :feature
 
-  FullTextSearch.max_matches = 1000
-
   config.before(:suite) do
     # Ensure sphinx directories exist for the test environment
     ThinkingSphinx::Test.init


### PR DESCRIPTION
These variables are used as constants, eg. we don't have any code that
would add or change them. So it makes sense to handle them as constants.