### PR TITLE
[webui][ci] Add shorten payload in notifications

### DIFF
--- a/src/api/app/models/event/base.rb
+++ b/src/api/app/models/event/base.rb
@@ -7,7 +7,6 @@ module Event
     self.inheritance_column = 'eventtype'
     self.table_name = 'events'
 
-    before_save :shorten_payload_if_necessary
     after_create :create_project_log_entry_job, if: -> { (PROJECT_CLASSES | PACKAGE_CLASSES).include?(self.class.name) }
 
     EXPLANATION_FOR_NOTIFICATIONS =  {
@@ -150,7 +149,8 @@ module Event
         v = attribs.delete k unless v
         values[k] = v unless v.nil?
       end
-      self.payload = Yajl::Encoder.encode(values)
+      self.payload = Yajl::Encoder.encode(calculate_payload(values))
+
       # now check if anything but the default rails params are left
       check_left_attribs(attribs)
     end
@@ -294,20 +294,19 @@ module Event
 
     private
 
-    def shorten_payload_if_necessary
-      return if shortenable_key.nil? # If no shortenable_key is set then we cannot shorten the payload
+    def calculate_payload(values)
+      return values if shortenable_key.nil? # If no shortenable_key is set then we cannot shorten the payload
 
-      max_length = 65535
-      payload_length = attributes_before_type_cast['payload'].length
+      overflow_bytes = Yajl::Encoder.encode(values).bytesize - 65535
 
-      return if payload_length <= max_length
+      return values if overflow_bytes <= 0
 
       # Shorten the payload so it will fit into the database column
-      char_limit = (payload_length - max_length) + 1
-      payload[shortenable_key.to_s] = payload[shortenable_key.to_s][0..-char_limit]
+      shortenable_content = values[shortenable_key.to_s]
+      new_size = shortenable_content.bytesize - overflow_bytes
+      values[shortenable_key.to_s] = shortenable_content.mb_chars.limit(new_size)
 
-      # Re-serialize the payload now that its been shortened
-      set_payload(payload, payload_keys)
+      values
     end
   end
 end

--- a/src/api/app/models/notification.rb
+++ b/src/api/app/models/notification.rb
@@ -3,8 +3,29 @@ class Notification < ApplicationRecord
 
   serialize :event_payload, JSON
 
+  def initialize(params = {})
+    super
+    shorten_payload_if_necessary
+  end
+
   def event
     @event ||= event_type.constantize.new(event_payload)
+  end
+
+  private
+
+  def shorten_payload_if_necessary
+    return if event.shortenable_key.nil? # If no shortenable_key is set then we cannot shorten the payload
+
+    # NOTE: ActiveSupport::JSON is used for serializing ActiveRecord models attributes
+    overflow_bytes = ActiveSupport::JSON.encode(event_payload).bytesize - 65535
+
+    return if overflow_bytes <= 0
+
+    # Shorten the payload so it will fit into the database column
+    shortenable_content = event_payload[event.shortenable_key.to_s]
+    new_size = shortenable_content.bytesize - overflow_bytes
+    event_payload[event.shortenable_key.to_s] = shortenable_content.mb_chars.limit(new_size)
   end
 end
 

--- a/src/api/spec/factories/notification.rb
+++ b/src/api/spec/factories/notification.rb
@@ -1,8 +1,10 @@
 FactoryBot.define do
   factory :notification do
-    event_type 'FakeEventType'
-    event_payload { { fake: 'payload' } }
+    event_type 'Event::CommentForProject'
+    event_payload { {} }
     subscription_receiver_role 'owner'
+
+    initialize_with { new(attributes) }
   end
 
   factory :rss_notification, parent: :notification, class: 'Notification::RssFeedItem' do

--- a/src/api/spec/models/notification_spec.rb
+++ b/src/api/spec/models/notification_spec.rb
@@ -10,4 +10,42 @@ RSpec.describe Notification do
     it { expect(subject.class).to eq(delete_package_event.class) }
     it { expect(subject.payload).to eq(delete_package_event.payload) }
   end
+
+  describe 'payload is shortened' do
+    let(:user) { create(:confirmed_user, id: 1, login: 'tom') }
+    let(:comment_author) { create(:confirmed_user, id: 2, login: 'jerry') }
+    let(:event) do
+      Event::CommentForProject.new(
+        project: user.home_project_name,
+        commenters: [comment_author.id, user.id],
+        commenter: comment_author.id,
+        comment_body: comment_body
+      )
+    end
+    let(:serialised_payload) { ActiveSupport::JSON.encode(subject.event_payload) }
+    let(:serialised_comment_body) { ActiveSupport::JSON.encode(subject.event_payload['comment_body']) }
+
+    subject { create(:rss_notification, event_type: event.class, event_payload: event.payload) }
+
+    context 'with the payload small enough to fit into the payload column' do
+      let(:comment_body) { '<a>aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa' }
+
+      it { expect(serialised_payload.bytesize).to eq(119) }
+      # Serializing the payload expands special chars to hexadecimal format
+      it { expect(serialised_comment_body).to eq('"\u003ca\u003eaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"') }
+      it { expect(serialised_comment_body.bytesize).to eq(48) }
+    end
+
+    context 'with the comment body too long for the payload column' do
+      # The events.payload column has a max char limit of 65535 so this comment cannot fit
+      # in the payload unless it is shortened
+      let(:comment_body) { '<a>' + 'a' * 65532 }
+
+      it { expect(serialised_payload.bytesize).to eq(65535) }
+      # Serializing the payload expands special chars to hexadecimal format
+      it { expect(serialised_comment_body).to eq('"\u003ca\u003e' + ('a' * 65449) + '"') }
+      # The comment body is shortened to acommodate the payload length into the column
+      it { expect(serialised_comment_body.bytesize).to eq(65464) }
+    end
+  end
 end


### PR DESCRIPTION
Add shorten payload in notifications. This should fix #4161:

- Add shorten_payload_if_necessary method in Notification model to ensure that a payload is not bigger than the field size in database.
- Modify the notification factory to allow passing parameters to initialize.
- Add tests for dealing with the payload in the Notification model.
- Refactor the calculation of payload in Event::Base model.
- Remove the before_save callback and include that code in initialize.
- Add context where payload is short enough to fit into the payload column to Event model tests.

Mobprogrammed with @mdeniz and @DavidKang.