### PR TITLE
[frontend] Synchronize serialization of comment and event payload

### DIFF
--- a/src/api/app/jobs/send_event_emails_job.rb
+++ b/src/api/app/jobs/send_event_emails_job.rb
@@ -29,7 +29,7 @@ class SendEventEmailsJob < ApplicationJob
       Notification::RssFeedItem.create(
         subscriber: subscription.subscriber,
         event_type: event.eventtype,
-        event_payload: event.payload,
+        event_payload: Yajl::Encoder.encode(event.payload),
         subscription_receiver_role: subscription.receiver_role
       )
     end

--- a/src/api/app/models/notification.rb
+++ b/src/api/app/models/notification.rb
@@ -1,10 +1,12 @@
 class Notification < ApplicationRecord
   belongs_to :subscriber, polymorphic: true
 
-  serialize :event_payload, JSON
-
   def event
     @event ||= event_type.constantize.new(event_payload)
+  end
+
+  def event_payload
+    @event_payload ||= Yajl::Parser.parse(self[:event_payload])
   end
 end
 

--- a/src/api/spec/controllers/webui/feeds_controller_spec.rb
+++ b/src/api/spec/controllers/webui/feeds_controller_spec.rb
@@ -72,7 +72,9 @@ RSpec.describe Webui::FeedsController do
         when: '2017-06-27T10:34:30',
         who: 'heino' }
     end
-    let!(:rss_notification) { create(:rss_notification, event_payload: payload, subscriber: user, event_type: 'Event::RequestCreate') }
+    let!(:rss_notification) do
+      create(:rss_notification, event_payload: Yajl::Encoder.encode(payload), subscriber: user, event_type: 'Event::RequestCreate')
+    end
 
     context 'with a working token' do
       render_views

--- a/src/api/spec/jobs/send_event_emails_job_spec.rb
+++ b/src/api/spec/jobs/send_event_emails_job_spec.rb
@@ -51,6 +51,14 @@ RSpec.describe SendEventEmailsJob, type: :job do
         expect(raw_event_payload).to eq(raw_notification_payload)
       end
 
+      it 'serializes payloads the same way as event payloads are serialized' do
+        notification = Notification.find_by(subscriber: user)
+        event_payload = Event::Base.first.attributes['payload']
+        notification_payload = notification.attributes['event_payload']
+
+        expect(event_payload).to eq(notification_payload)
+      end
+
       it "creates an rss notification for group's email" do
         notification = Notification::RssFeedItem.find_by(subscriber: group)
 

--- a/src/api/spec/models/notification_spec.rb
+++ b/src/api/spec/models/notification_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe Notification do
   let(:delete_package_event) { Event::DeletePackage.new(payload) }
 
   describe '#event' do
-    subject { create(:rss_notification, event_type: 'Event::DeletePackage', event_payload: payload).event }
+    subject { create(:rss_notification, event_type: 'Event::DeletePackage', event_payload: Yajl::Encoder.encode(payload)).event }
 
     it { expect(subject.class).to eq(delete_package_event.class) }
     it { expect(subject.payload).to eq(delete_package_event.payload) }


### PR DESCRIPTION
SendEventEmailsJob is creating notifications from certain events. As part
of this the serialized event payload is copied to the 'event_payload'
attribute.
Both models were using different serialization libraries (Yajl::Encoder
for events, ActiveSupport::JSON.encode for notifications), which could
cause the stored data format to differ, eg. active support encodes
certains chars differently.
In general this was not causing any trouble, because the decoded data
would be the same. But it could happen that the payload of the
notification is bigger than the original event payload and exceeds the
size limit of that field. In such a case the notification creation
failed with a ActiveRecord::ValueTooLong error.

By using the same serialization method in both places, we avoid this
from happening. Since notifications are created from events, and the
event payload length is already sanitized based on that serialization
method used by the event model, we pick the Yajl::Encoder.

Fixes #3638 #4161