### PR TITLE
[api] Demodulize

### DIFF
--- a/src/api/app/models/project_log_entry.rb
+++ b/src/api/app/models/project_log_entry.rb
@@ -19,7 +19,7 @@ class ProjectLogEntry < ApplicationRecord
                 package_name: event.payload['package'],
                 bs_request_id: bs_request_id,
                 datetime: event.created_at,
-                event_type: event.class.model_name.to_s.split('::').last.underscore)
+                event_type: event.class.name.demodulize.underscore)
     entry.user_name = username_from(event.payload)
     entry.additional_info = event.payload.except(*EXCLUDED_KEYS)
     entry.save

--- a/src/api/lib/activexml/transport.rb
+++ b/src/api/lib/activexml/transport.rb
@@ -105,7 +105,7 @@ module ActiveXML
       @default_servers ||= {}
       @http_header = { 'Content-Type' => 'text/plain', 'Accept-Encoding' => 'identity' }
       # stores mapping information
-      # key: symbolified model name
+      # key: symbolized model name
       # value: hash with keys :target_uri and :opt (arguments to connect method)
       @mapping = {}
     end
@@ -121,9 +121,9 @@ module ActiveXML
       params = {}
       data = nil
       own_mimetype = nil
-      symbolified_model = symbolified_model(model)
-      uri = target_for(symbolified_model)
-      options = options_for(symbolified_model)
+      symbolized_model = symbolize_model(model)
+      uri = target_for(symbolized_model)
+      options = options_for(symbolized_model)
       case args[0]
       when Symbol
         # logger.debug "Transport.find: using symbol"
@@ -262,12 +262,12 @@ module ActiveXML
     end
 
     def substituted_uri_for(object, path_id = nil, opt = {})
-      symbolified_model = symbolified_model(object.class)
-      options = options_for(symbolified_model)
+      symbolized_model = symbolize_model(object.class)
+      options = options_for(symbolized_model)
       if path_id && options.has_key?(path_id)
         uri = options[path_id]
       else
-        uri = target_for(symbolified_model)
+        uri = target_for(symbolized_model)
       end
       substitute_uri(uri, object.instance_variable_get('@init_options').merge(opt))
     end
@@ -440,7 +440,7 @@ module ActiveXML
 
     private
 
-    def symbolified_model(model_class)
+    def symbolize_model(model_class)
       model_class.name.demodulize.downcase.to_sym
     end
   end

--- a/src/api/lib/activexml/transport.rb
+++ b/src/api/lib/activexml/transport.rb
@@ -121,7 +121,7 @@ module ActiveXML
       params = {}
       data = nil
       own_mimetype = nil
-      symbolified_model = model.name.demodulize.downcase.to_sym
+      symbolified_model = symbolified_model(model)
       uri = target_for(symbolified_model)
       options = options_for(symbolified_model)
       case args[0]
@@ -262,7 +262,7 @@ module ActiveXML
     end
 
     def substituted_uri_for(object, path_id = nil, opt = {})
-      symbolified_model = object.class.name.demodulize.downcase.to_sym
+      symbolified_model = symbolified_model(object.class)
       options = options_for(symbolified_model)
       if path_id && options.has_key?(path_id)
         uri = options[path_id]
@@ -436,6 +436,12 @@ module ActiveXML
       message = http_response.read_body
       message = http_response.to_s if message.blank?
       raise Error, message.force_encoding('UTF-8')
+    end
+
+    private
+
+    def symbolified_model(model_class)
+      model_class.name.demodulize.downcase.to_sym
     end
   end
 end

--- a/src/api/lib/activexml/transport.rb
+++ b/src/api/lib/activexml/transport.rb
@@ -121,7 +121,7 @@ module ActiveXML
       params = {}
       data = nil
       own_mimetype = nil
-      symbolified_model = model.name.downcase.split('::').last.to_sym
+      symbolified_model = model.name.demodulize.downcase.to_sym
       uri = target_for(symbolified_model)
       options = options_for(symbolified_model)
       case args[0]
@@ -262,7 +262,7 @@ module ActiveXML
     end
 
     def substituted_uri_for(object, path_id = nil, opt = {})
-      symbolified_model = object.class.name.downcase.split('::').last.to_sym
+      symbolified_model = object.class.name.demodulize.downcase.to_sym
       options = options_for(symbolified_model)
       if path_id && options.has_key?(path_id)
         uri = options[path_id]

--- a/src/api/lib/api_exception.rb
+++ b/src/api/lib/api_exception.rb
@@ -24,7 +24,7 @@ class APIException < RuntimeError
   def errorcode
     err = self.class.instance_variable_get '@errorcode'
     return err if err
-    err = self.class.name.split('::').last.underscore
+    err = self.class.name.demodulize.underscore
     # if the class name stops with Error, strip that
     err.gsub(%r{_error$}, '')
   end


### PR DESCRIPTION
- Use `demodulize` Rails method instead of reimplement it by doing: `split('::').last` :bowtie:
- Use `class.name` instead `class.model_name.to_s`.
- Add `symbolified_model` method in Transport to avoid repeating code.
  