### PR TITLE
[frontend] Change events.payload to mediumtext

### DIFF
--- a/src/api/app/models/event/base.rb
+++ b/src/api/app/models/event/base.rb
@@ -312,7 +312,7 @@ end
 #
 #  id             :integer          not null, primary key
 #  eventtype      :string(255)      not null, indexed
-#  payload        :text(65535)
+#  payload        :text(16777215)
 #  created_at     :datetime         indexed
 #  updated_at     :datetime
 #  project_logged :boolean          default(FALSE), indexed

--- a/src/api/app/models/event/branch_command.rb
+++ b/src/api/app/models/event/branch_command.rb
@@ -20,7 +20,7 @@ end
 #
 #  id             :integer          not null, primary key
 #  eventtype      :string(255)      not null, indexed
-#  payload        :text(65535)
+#  payload        :text(16777215)
 #  created_at     :datetime         indexed
 #  updated_at     :datetime
 #  project_logged :boolean          default(FALSE), indexed

--- a/src/api/app/models/event/build_fail.rb
+++ b/src/api/app/models/event/build_fail.rb
@@ -54,7 +54,7 @@ end
 #
 #  id             :integer          not null, primary key
 #  eventtype      :string(255)      not null, indexed
-#  payload        :text(65535)
+#  payload        :text(16777215)
 #  created_at     :datetime         indexed
 #  updated_at     :datetime
 #  project_logged :boolean          default(FALSE), indexed

--- a/src/api/app/models/event/build_success.rb
+++ b/src/api/app/models/event/build_success.rb
@@ -15,7 +15,7 @@ end
 #
 #  id             :integer          not null, primary key
 #  eventtype      :string(255)      not null, indexed
-#  payload        :text(65535)
+#  payload        :text(16777215)
 #  created_at     :datetime         indexed
 #  updated_at     :datetime
 #  project_logged :boolean          default(FALSE), indexed

--- a/src/api/app/models/event/build_unchanged.rb
+++ b/src/api/app/models/event/build_unchanged.rb
@@ -15,7 +15,7 @@ end
 #
 #  id             :integer          not null, primary key
 #  eventtype      :string(255)      not null, indexed
-#  payload        :text(65535)
+#  payload        :text(16777215)
 #  created_at     :datetime         indexed
 #  updated_at     :datetime
 #  project_logged :boolean          default(FALSE), indexed

--- a/src/api/app/models/event/comment_for_package.rb
+++ b/src/api/app/models/event/comment_for_package.rb
@@ -24,7 +24,7 @@ end
 #
 #  id             :integer          not null, primary key
 #  eventtype      :string(255)      not null, indexed
-#  payload        :text(65535)
+#  payload        :text(16777215)
 #  created_at     :datetime         indexed
 #  updated_at     :datetime
 #  project_logged :boolean          default(FALSE), indexed

--- a/src/api/app/models/event/comment_for_project.rb
+++ b/src/api/app/models/event/comment_for_project.rb
@@ -24,7 +24,7 @@ end
 #
 #  id             :integer          not null, primary key
 #  eventtype      :string(255)      not null, indexed
-#  payload        :text(65535)
+#  payload        :text(16777215)
 #  created_at     :datetime         indexed
 #  updated_at     :datetime
 #  project_logged :boolean          default(FALSE), indexed

--- a/src/api/app/models/event/comment_for_request.rb
+++ b/src/api/app/models/event/comment_for_request.rb
@@ -31,7 +31,7 @@ end
 #
 #  id             :integer          not null, primary key
 #  eventtype      :string(255)      not null, indexed
-#  payload        :text(65535)
+#  payload        :text(16777215)
 #  created_at     :datetime         indexed
 #  updated_at     :datetime
 #  project_logged :boolean          default(FALSE), indexed

--- a/src/api/app/models/event/commit.rb
+++ b/src/api/app/models/event/commit.rb
@@ -28,7 +28,7 @@ end
 #
 #  id             :integer          not null, primary key
 #  eventtype      :string(255)      not null, indexed
-#  payload        :text(65535)
+#  payload        :text(16777215)
 #  created_at     :datetime         indexed
 #  updated_at     :datetime
 #  project_logged :boolean          default(FALSE), indexed

--- a/src/api/app/models/event/create_package.rb
+++ b/src/api/app/models/event/create_package.rb
@@ -20,7 +20,7 @@ end
 #
 #  id             :integer          not null, primary key
 #  eventtype      :string(255)      not null, indexed
-#  payload        :text(65535)
+#  payload        :text(16777215)
 #  created_at     :datetime         indexed
 #  updated_at     :datetime
 #  project_logged :boolean          default(FALSE), indexed

--- a/src/api/app/models/event/create_project.rb
+++ b/src/api/app/models/event/create_project.rb
@@ -20,7 +20,7 @@ end
 #
 #  id             :integer          not null, primary key
 #  eventtype      :string(255)      not null, indexed
-#  payload        :text(65535)
+#  payload        :text(16777215)
 #  created_at     :datetime         indexed
 #  updated_at     :datetime
 #  project_logged :boolean          default(FALSE), indexed

--- a/src/api/app/models/event/delete_package.rb
+++ b/src/api/app/models/event/delete_package.rb
@@ -21,7 +21,7 @@ end
 #
 #  id             :integer          not null, primary key
 #  eventtype      :string(255)      not null, indexed
-#  payload        :text(65535)
+#  payload        :text(16777215)
 #  created_at     :datetime         indexed
 #  updated_at     :datetime
 #  project_logged :boolean          default(FALSE), indexed

--- a/src/api/app/models/event/delete_project.rb
+++ b/src/api/app/models/event/delete_project.rb
@@ -16,7 +16,7 @@ end
 #
 #  id             :integer          not null, primary key
 #  eventtype      :string(255)      not null, indexed
-#  payload        :text(65535)
+#  payload        :text(16777215)
 #  created_at     :datetime         indexed
 #  updated_at     :datetime
 #  project_logged :boolean          default(FALSE), indexed

--- a/src/api/app/models/event/packtrack.rb
+++ b/src/api/app/models/event/packtrack.rb
@@ -19,7 +19,7 @@ end
 #
 #  id             :integer          not null, primary key
 #  eventtype      :string(255)      not null, indexed
-#  payload        :text(65535)
+#  payload        :text(16777215)
 #  created_at     :datetime         indexed
 #  updated_at     :datetime
 #  project_logged :boolean          default(FALSE), indexed

--- a/src/api/app/models/event/repo_publish_state.rb
+++ b/src/api/app/models/event/repo_publish_state.rb
@@ -16,7 +16,7 @@ end
 #
 #  id             :integer          not null, primary key
 #  eventtype      :string(255)      not null, indexed
-#  payload        :text(65535)
+#  payload        :text(16777215)
 #  created_at     :datetime         indexed
 #  updated_at     :datetime
 #  project_logged :boolean          default(FALSE), indexed

--- a/src/api/app/models/event/repo_published.rb
+++ b/src/api/app/models/event/repo_published.rb
@@ -16,7 +16,7 @@ end
 #
 #  id             :integer          not null, primary key
 #  eventtype      :string(255)      not null, indexed
-#  payload        :text(65535)
+#  payload        :text(16777215)
 #  created_at     :datetime         indexed
 #  updated_at     :datetime
 #  project_logged :boolean          default(FALSE), indexed

--- a/src/api/app/models/event/request_change.rb
+++ b/src/api/app/models/event/request_change.rb
@@ -15,7 +15,7 @@ end
 #
 #  id             :integer          not null, primary key
 #  eventtype      :string(255)      not null, indexed
-#  payload        :text(65535)
+#  payload        :text(16777215)
 #  created_at     :datetime         indexed
 #  updated_at     :datetime
 #  project_logged :boolean          default(FALSE), indexed

--- a/src/api/app/models/event/request_create.rb
+++ b/src/api/app/models/event/request_create.rb
@@ -32,7 +32,7 @@ end
 #
 #  id             :integer          not null, primary key
 #  eventtype      :string(255)      not null, indexed
-#  payload        :text(65535)
+#  payload        :text(16777215)
 #  created_at     :datetime         indexed
 #  updated_at     :datetime
 #  project_logged :boolean          default(FALSE), indexed

--- a/src/api/app/models/event/request_delete.rb
+++ b/src/api/app/models/event/request_delete.rb
@@ -15,7 +15,7 @@ end
 #
 #  id             :integer          not null, primary key
 #  eventtype      :string(255)      not null, indexed
-#  payload        :text(65535)
+#  payload        :text(16777215)
 #  created_at     :datetime         indexed
 #  updated_at     :datetime
 #  project_logged :boolean          default(FALSE), indexed

--- a/src/api/app/models/event/request_statechange.rb
+++ b/src/api/app/models/event/request_statechange.rb
@@ -21,7 +21,7 @@ end
 #
 #  id             :integer          not null, primary key
 #  eventtype      :string(255)      not null, indexed
-#  payload        :text(65535)
+#  payload        :text(16777215)
 #  created_at     :datetime         indexed
 #  updated_at     :datetime
 #  project_logged :boolean          default(FALSE), indexed

--- a/src/api/app/models/event/review_wanted.rb
+++ b/src/api/app/models/event/review_wanted.rb
@@ -46,7 +46,7 @@ end
 #
 #  id             :integer          not null, primary key
 #  eventtype      :string(255)      not null, indexed
-#  payload        :text(65535)
+#  payload        :text(16777215)
 #  created_at     :datetime         indexed
 #  updated_at     :datetime
 #  project_logged :boolean          default(FALSE), indexed

--- a/src/api/app/models/event/service_fail.rb
+++ b/src/api/app/models/event/service_fail.rb
@@ -34,7 +34,7 @@ end
 #
 #  id             :integer          not null, primary key
 #  eventtype      :string(255)      not null, indexed
-#  payload        :text(65535)
+#  payload        :text(16777215)
 #  created_at     :datetime         indexed
 #  updated_at     :datetime
 #  project_logged :boolean          default(FALSE), indexed

--- a/src/api/app/models/event/service_success.rb
+++ b/src/api/app/models/event/service_success.rb
@@ -28,7 +28,7 @@ end
 #
 #  id             :integer          not null, primary key
 #  eventtype      :string(255)      not null, indexed
-#  payload        :text(65535)
+#  payload        :text(16777215)
 #  created_at     :datetime         indexed
 #  updated_at     :datetime
 #  project_logged :boolean          default(FALSE), indexed

--- a/src/api/app/models/event/undelete_package.rb
+++ b/src/api/app/models/event/undelete_package.rb
@@ -22,7 +22,7 @@ end
 #
 #  id             :integer          not null, primary key
 #  eventtype      :string(255)      not null, indexed
-#  payload        :text(65535)
+#  payload        :text(16777215)
 #  created_at     :datetime         indexed
 #  updated_at     :datetime
 #  project_logged :boolean          default(FALSE), indexed

--- a/src/api/app/models/event/undelete_project.rb
+++ b/src/api/app/models/event/undelete_project.rb
@@ -16,7 +16,7 @@ end
 #
 #  id             :integer          not null, primary key
 #  eventtype      :string(255)      not null, indexed
-#  payload        :text(65535)
+#  payload        :text(16777215)
 #  created_at     :datetime         indexed
 #  updated_at     :datetime
 #  project_logged :boolean          default(FALSE), indexed

--- a/src/api/app/models/event/update_package.rb
+++ b/src/api/app/models/event/update_package.rb
@@ -16,7 +16,7 @@ end
 #
 #  id             :integer          not null, primary key
 #  eventtype      :string(255)      not null, indexed
-#  payload        :text(65535)
+#  payload        :text(16777215)
 #  created_at     :datetime         indexed
 #  updated_at     :datetime
 #  project_logged :boolean          default(FALSE), indexed

--- a/src/api/app/models/event/update_project.rb
+++ b/src/api/app/models/event/update_project.rb
@@ -16,7 +16,7 @@ end
 #
 #  id             :integer          not null, primary key
 #  eventtype      :string(255)      not null, indexed
-#  payload        :text(65535)
+#  payload        :text(16777215)
 #  created_at     :datetime         indexed
 #  updated_at     :datetime
 #  project_logged :boolean          default(FALSE), indexed

--- a/src/api/app/models/event/update_project_config.rb
+++ b/src/api/app/models/event/update_project_config.rb
@@ -16,7 +16,7 @@ end
 #
 #  id             :integer          not null, primary key
 #  eventtype      :string(255)      not null, indexed
-#  payload        :text(65535)
+#  payload        :text(16777215)
 #  created_at     :datetime         indexed
 #  updated_at     :datetime
 #  project_logged :boolean          default(FALSE), indexed

--- a/src/api/app/models/event/upload.rb
+++ b/src/api/app/models/event/upload.rb
@@ -16,7 +16,7 @@ end
 #
 #  id             :integer          not null, primary key
 #  eventtype      :string(255)      not null, indexed
-#  payload        :text(65535)
+#  payload        :text(16777215)
 #  created_at     :datetime         indexed
 #  updated_at     :datetime
 #  project_logged :boolean          default(FALSE), indexed

--- a/src/api/app/models/event/version_change.rb
+++ b/src/api/app/models/event/version_change.rb
@@ -22,7 +22,7 @@ end
 #
 #  id             :integer          not null, primary key
 #  eventtype      :string(255)      not null, indexed
-#  payload        :text(65535)
+#  payload        :text(16777215)
 #  created_at     :datetime         indexed
 #  updated_at     :datetime
 #  project_logged :boolean          default(FALSE), indexed

--- a/src/api/db/migrate/20180110081109_change_payload_to_mediumtext_in_events.rb
+++ b/src/api/db/migrate/20180110081109_change_payload_to_mediumtext_in_events.rb
@@ -1,0 +1,5 @@
+class ChangePayloadToMediumtextInEvents < ActiveRecord::Migration[5.1]
+  def change
+    change_column :events, :payload, :mediumtext
+  end
+end

--- a/src/api/db/structure.sql
+++ b/src/api/db/structure.sql
@@ -476,7 +476,7 @@ CREATE TABLE `event_subscriptions` (
 CREATE TABLE `events` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `eventtype` varchar(255) COLLATE utf8_unicode_ci NOT NULL,
-  `payload` text COLLATE utf8_unicode_ci,
+  `payload` mediumtext COLLATE utf8_unicode_ci,
   `created_at` datetime DEFAULT NULL,
   `updated_at` datetime(6) DEFAULT NULL,
   `project_logged` tinyint(1) DEFAULT '0',
@@ -1313,6 +1313,7 @@ INSERT INTO `schema_migrations` (version) VALUES
 ('20171109095756'),
 ('20171212083426'),
 ('20171218160607'),
-('20171219122451');
+('20171219122451'),
+('20180110081109');
 
 


### PR DESCRIPTION
We need to make this column bigger as `comment.body` is `text` as well and it many cases it is too big that we get the following error:

_Mysql2::Error: Data too long for column 'event_payload'_

Fixes https://github.com/openSUSE/open-build-service/issues/4319