### PR TITLE
[dist] Add missing libxdiff package

### DIFF
--- a/contrib/docker-bootstrap.sh
+++ b/contrib/docker-bootstrap.sh
@@ -23,7 +23,7 @@ do
       obs-service-download_src_package obs-service-download_files \
       obs-service-download_url \
       obs-service-format_spec_file obs-service-kiwi_import \
-      perl-Devel-Cover \
+      perl-Devel-Cover perl-Diff-LibXDiff \
       osc
     ;;
 

--- a/src/api/test/fixtures/event_mailer/review_wanted
+++ b/src/api/test/fixtures/event_mailer/review_wanted
@@ -45,7 +45,7 @@ other changes:
 ++++++ myfile (new)
 --- myfile
 +++ myfile
-@@ -0,0 +1 @@
+@@ -0,0 +1,1 @@
 +DummyContent
 \ No newline at end of file
 


### PR DESCRIPTION
This should fix tests errors with diffs in the old test suite.

Pairprogrammed with @DavidKang.