### PR TITLE
Disable some cops

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -26,6 +26,10 @@ Layout/AlignHash:
   # inspected?
   EnforcedLastArgumentHashStyle: ignore_implicit
 
+# We decide disable this cop because we can't reach an agreement
+Layout/DotPosition:
+  Enabled: false
+
 #################### Style ###########################
 
 # Find uses of alias where alias_method would be more appropriate (or is simply preferred due to configuration), and vice versa.
@@ -36,6 +40,9 @@ Style/Alias:
 # Use ` or %x around command literals.
 Style/CommandLiteral:
   EnforcedStyle: percent_x
+
+Style/Documentation:
+  Enabled: false
 
 # We need to allow some variables related to rabbiMQ.
 Style/GlobalVars:
@@ -93,6 +100,9 @@ Rails/DynamicFindBy:
 Rails/Exit:
   Exclude:
     - 'src/api/lib/memory_dumper.rb'
+
+Rails/HasAndBelongsToMany:
+  Enabled: false
 
 # Checks for the use of output calls like puts and print
 Rails/Output:

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -6,13 +6,6 @@
 # Note that changes in the inspected code, or installation of new
 # versions of RuboCop, may require this file to be generated again.
 
-# Offense count: 78
-# Cop supports --auto-correct.
-# Configuration parameters: EnforcedStyle, SupportedStyles.
-# SupportedStyles: leading, trailing
-Layout/DotPosition:
-  Enabled: false
-
 # Offense count: 28
 # Cop supports --auto-correct.
 # Configuration parameters: EnforcedStyle, SupportedStyles, IndentationWidth.
@@ -215,20 +208,6 @@ Performance/HashEachMethods:
 Rails/FilePath:
   Enabled: false
 
-# Offense count: 12
-# Configuration parameters: Include.
-# Include: app/models/**/*.rb
-Rails/HasAndBelongsToMany:
-  Exclude:
-    - 'src/api/app/models/bs_request.rb'
-    - 'src/api/app/models/bs_request_action_group.rb'
-    - 'src/api/app/models/distribution.rb'
-    - 'src/api/app/models/distribution_icon.rb'
-    - 'src/api/app/models/group.rb'
-    - 'src/api/app/models/role.rb'
-    - 'src/api/app/models/static_permission.rb'
-    - 'src/api/app/models/user.rb'
-
 # Offense count: 22
 # Configuration parameters: Include.
 # Include: app/models/**/*.rb
@@ -325,10 +304,6 @@ Style/DateTime:
     - 'src/api/app/models/bs_request.rb'
     - 'src/api/spec/features/webui/requests_spec.rb'
     - 'src/api/test/functional/maintenance_test.rb'
-
-# Offense count: 631
-Style/Documentation:
-  Enabled: false
 
 # Offense count: 11
 # Configuration parameters: EnforcedStyle, SupportedStyles.


### PR DESCRIPTION
We decided disable the next cops:

  * Layout/DotPosition
  * Rails/HasAndBelongsToMany
  * Style/Documentation