### PR TITLE
[webui] Implement more EC2 upload options and add validations

### DIFF
--- a/src/api/app/helpers/webui/package_helper.rb
+++ b/src/api/app/helpers/webui/package_helper.rb
@@ -87,7 +87,7 @@ module Webui::PackageHelper
     [repository.repo_type, repository.priority].compact.join(', Priority: ')
   end
 
-  def cloud_image_file?(filename)
-    filename.end_with?('.raw.xz', '.vhdfixed.xz')
+  def uploadable?(filename, architecture)
+    ::Cloud::UploadJob.new(filename: filename, arch: architecture).uploadable?
   end
 end

--- a/src/api/app/models/cloud/backend/upload_job.rb
+++ b/src/api/app/models/cloud/backend/upload_job.rb
@@ -21,12 +21,11 @@ module Cloud
                      :size,
                      :backend_response
       alias_method :id, :name
-      alias_method :platform, :target
       alias_method :architecture, :arch
       validate :validate_xml
 
-      def self.create(user, params)
-        xml = ::Backend::Api::Cloud.upload(user, params)
+      def self.create(params)
+        xml = ::Backend::Api::Cloud.upload(params)
 
         new(xml: xml)
       rescue ActiveXML::Transport::Error, Timeout::Error => exception

--- a/src/api/app/models/cloud/ec2/configuration.rb
+++ b/src/api/app/models/cloud/ec2/configuration.rb
@@ -19,6 +19,11 @@ module Cloud
         ['South America (São Paulo)', 'sa-east-1']
       ].freeze
 
+      VIRTUALIZATION_TYPES = [
+        ['HVM', 'hvm'],
+        ['PV', 'pv']
+      ].freeze
+
       has_secure_token :external_id
       belongs_to :user, required: true
 

--- a/src/api/app/models/cloud/params/ec2.rb
+++ b/src/api/app/models/cloud/params/ec2.rb
@@ -1,0 +1,29 @@
+module Cloud
+  module Params
+    class Ec2
+      include ActiveModel::Validations
+      include ActiveModel::Model
+
+      attr_accessor :region, :virtualization_type, :ami_name
+      validates :region, presence: true, inclusion: {
+        in: ::Cloud::Ec2::Configuration::REGIONS.map(&:second), message: "'%{value}' is not a valid EC2 region"
+      }
+      validates :virtualization_type, inclusion: {
+        in: ::Cloud::Ec2::Configuration::VIRTUALIZATION_TYPES.map(&:second), message: "'%{value}' is not a valid EC2 virtualization type"
+      }
+      validates :ami_name, presence: true, length: { maximum: 100 }
+      validate :valid_ami_name
+
+      def self.build(params)
+        new(params.slice(:region, :virtualization_type, :ami_name))
+      end
+
+      private
+
+      def valid_ami_name
+        return if Project.valid_name?(ami_name)
+        errors.add(:ami_name, "'#{ami_name}' is not a valid ami name (only letters, numbers, dots and hyphens)")
+      end
+    end
+  end
+end

--- a/src/api/app/models/cloud/upload_job.rb
+++ b/src/api/app/models/cloud/upload_job.rb
@@ -4,31 +4,48 @@ module Cloud
     include ActiveModel::Model
     extend Forwardable
 
-    attr_accessor :user_upload_job, :backend_upload_job
-    validate :validate_jobs
+    attr_accessor :user_upload_job, :backend_upload_job, :target_params, :filename, :arch, :target, :user
+    validate :validate_dependencies
+    validates :user, presence: true
+    validates :filename, presence: true, format: {
+      with: /\A.+(.raw.xz|.vhdfixed.xz)\z/, message: "'%{value}' is not a valid cloud image (needs to be a raw.xz or vhdfixed.xz file)"
+    }
+    validates :arch, inclusion: { in: ['x86_64'], message: "'%{value}' is not a valid cloud architecture" }
+    validates :target, inclusion: { in: ['ec2'] }
+
     def_delegator :backend_upload_job, :id
 
-    def self.create(user, params)
-      upload_job = new
-      upload_job.backend_upload_job = Cloud::Backend::UploadJob.create(user, params)
-      return upload_job unless upload_job.backend_upload_job.valid?
+    def self.create(params)
+      upload_job = new(params.slice(:filename, :arch, :user, :target))
+      return upload_job if upload_job.invalid?
 
-      upload_job.user_upload_job = user.upload_jobs.create(job_id: upload_job.id)
+      upload_job.target_params = upload_job.target_validator_class.build(params)
+      return upload_job if upload_job.target_params.invalid?
+
+      upload_job.backend_upload_job = Cloud::Backend::UploadJob.create(params.merge(target: upload_job.target))
+      return upload_job if upload_job.backend_upload_job.invalid?
+
+      upload_job.user_upload_job = upload_job.user.upload_jobs.create(job_id: upload_job.id)
       upload_job
+    end
+
+    def uploadable?
+      valid?
+      errors[:filename].blank? && errors[:arch].blank?
+    end
+
+    def target_validator_class
+      @target_validator_class ||= "::Cloud::Params::#{target.capitalize}".constantize
     end
 
     private
 
-    def validate_jobs
-      if backend_upload_job.present? && backend_upload_job.invalid?
-        backend_upload_job.errors.full_messages.each do |msg|
-          errors.add(:backend_upload_job, msg)
+    def validate_dependencies
+      [target_params, backend_upload_job, user_upload_job].each do |dependency|
+        next if dependency.blank? || dependency.valid?
+        dependency.errors.full_messages.each do |msg|
+          errors.add(:base, msg)
         end
-      end
-
-      return if user_upload_job.blank? || user_upload_job.valid?
-      user_upload_job.errors.full_messages.each do |msg|
-        errors.add(:user_upload_job, msg)
       end
     end
   end

--- a/src/api/app/views/webui/cloud/upload_jobs/new.html.haml
+++ b/src/api/app/views/webui/cloud/upload_jobs/new.html.haml
@@ -8,19 +8,32 @@
   = link_to "Amazon EC2 configuration", cloud_ec2_configuration_path
   for more information.
 
+%h3
+  Upload image
+
 = form_for @upload_job, url: cloud_upload_index_path, method: :post do |upload_job_form|
   %p
-    Upload image
+    Filename:
     %b
       = @upload_job.filename
-    to region
+  %p
+    = upload_job_form.label 'cloud_backend_upload_job[ami_name]', "AMI Name:"
+    = upload_job_form.text_field :filename, size: 35, name: 'cloud_backend_upload_job[ami_name]'
+  %p
+    = upload_job_form.label 'cloud_backend_upload_job[region]', "Region:"
     = select_tag('cloud_backend_upload_job[region]', options_for_select(@ec2_regions))
+  %p
+    = upload_job_form.label 'cloud_backend_upload_job[virtualization_type]', "Virtualization Type:"
+    = select_tag('cloud_backend_upload_job[virtualization_type]', options_for_select(@ec2_virtualization_types))
+  %p
     = upload_job_form.hidden_field :project
     = upload_job_form.hidden_field :package
     = upload_job_form.hidden_field :arch
     = upload_job_form.hidden_field :repository
     = upload_job_form.hidden_field :filename
-    = submit_tag 'Upload'
+    = upload_job_form.hidden_field :target, value: 'ec2'
+  %p
+    = submit_tag 'Upload Image'
 
 %p
   = link_to "All Cloud Uploads", cloud_upload_index_path

--- a/src/api/app/views/webui/package/binary.html.erb
+++ b/src/api/app/views/webui/package/binary.html.erb
@@ -33,7 +33,7 @@
   <p><strong>Size:</strong> <%= human_readable_fsize(@fileinfo.value(:size).to_i) %></p>
   <p><strong>Build Time:</strong> <%= btime = Time.at(@fileinfo.value(:mtime).to_i)
   btime.to_s + " (" + fuzzy_time_string(btime.ctime) + ")" %></p>
-  <% if Feature.active?(:cloud_upload) && !User.current.is_nobody? && cloud_image_file?(@filename) %>
+  <% if Feature.active?(:cloud_upload) && !User.current.is_nobody? && uploadable?(@filename, @architecture) %>
     <p><strong>Cloud Upload</strong></p>
     <p>
       The Open Build Service can upload appliances to Cloud providers like Amazon EC2 or Microsoft Azure.

--- a/src/api/lib/backend/api/cloud.rb
+++ b/src/api/lib/backend/api/cloud.rb
@@ -4,10 +4,12 @@ module Backend
       extend Backend::ConnectionHelper
       # Triggers a cloud upload job
       # @return [String]
-      def self.upload(user, params, target_name = 'ec2')
-        region = params.delete(:region)
-        data = user.ec2_configuration.attributes.except('id', 'created_at', 'updated_at').merge(region: region).to_json
-        post('/cloudupload', params: params.merge(user: user.login, target: target_name), data: data)
+      def self.upload(params)
+        data = params.slice(:region, :virtualization_type, :ami_name)
+        user = params[:user]
+        params = params.except(:region, :virtualization_type, :ami_name).merge(user: user.login, target: params[:target])
+        data = user.ec2_configuration.attributes.except('id', 'created_at', 'updated_at').merge(data).to_json
+        post('/cloudupload', params: params, data: data)
       end
 
       # Returns the status of the cloud upload jobs of a user

--- a/src/api/spec/cassettes/Cloud_Backend_UploadJob/_create/with_a_valid_backend_response/1_1_1_1.yml
+++ b/src/api/spec/cassettes/Cloud_Backend_UploadJob/_create/with_a_valid_backend_response/1_1_1_1.yml
@@ -1,0 +1,39 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: http://backend:5352/cloudupload?arch=x86_64&filename=appliance.raw.gz&package=aws&project=Cloud&repository=standard&target=ec2&user=tom
+    body:
+      encoding: UTF-8
+      string: '{"user_id":38,"external_id":"iynipfokybcxu95lmxvouhcv","arn":"arn:2j5ymojadd","region":"us-east-1","virtualization_type":"hvm","ami_name":"myami"}'
+    headers:
+      Content-Type:
+      - application/octet-stream
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 400
+      message: no cloud upload server configurated
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '87'
+    body:
+      encoding: UTF-8
+      string: |
+        <status code="400">
+          <summary>no cloud upload server configurated</summary>
+        </status>
+    http_version: 
+  recorded_at: Mon, 15 Jan 2018 11:01:50 GMT
+recorded_with: VCR 4.0.0

--- a/src/api/spec/cassettes/Cloud_Backend_UploadJob/_create/with_a_valid_backend_response/1_1_1_10.yml
+++ b/src/api/spec/cassettes/Cloud_Backend_UploadJob/_create/with_a_valid_backend_response/1_1_1_10.yml
@@ -1,0 +1,39 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: http://backend:5352/cloudupload?arch=x86_64&filename=appliance.raw.gz&package=aws&project=Cloud&repository=standard&target=ec2&user=tom
+    body:
+      encoding: UTF-8
+      string: '{"user_id":28,"external_id":"3p6mds97cdrtdgeehjnipmxf","arn":"arn:uc378qg3ls","region":"us-east-1","virtualization_type":"hvm","ami_name":"myami"}'
+    headers:
+      Content-Type:
+      - application/octet-stream
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 400
+      message: no cloud upload server configurated
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '87'
+    body:
+      encoding: UTF-8
+      string: |
+        <status code="400">
+          <summary>no cloud upload server configurated</summary>
+        </status>
+    http_version: 
+  recorded_at: Mon, 15 Jan 2018 11:01:49 GMT
+recorded_with: VCR 4.0.0

--- a/src/api/spec/cassettes/Cloud_Backend_UploadJob/_create/with_a_valid_backend_response/1_1_1_11.yml
+++ b/src/api/spec/cassettes/Cloud_Backend_UploadJob/_create/with_a_valid_backend_response/1_1_1_11.yml
@@ -1,0 +1,39 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: http://backend:5352/cloudupload?arch=x86_64&filename=appliance.raw.gz&package=aws&project=Cloud&repository=standard&target=ec2&user=tom
+    body:
+      encoding: UTF-8
+      string: '{"user_id":20,"external_id":"wxji9idumiyddafpln29ks8n","arn":"arn:g7xi48x7zg","region":"us-east-1","virtualization_type":"hvm","ami_name":"myami"}'
+    headers:
+      Content-Type:
+      - application/octet-stream
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 400
+      message: no cloud upload server configurated
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '87'
+    body:
+      encoding: UTF-8
+      string: |
+        <status code="400">
+          <summary>no cloud upload server configurated</summary>
+        </status>
+    http_version: 
+  recorded_at: Mon, 15 Jan 2018 11:01:49 GMT
+recorded_with: VCR 4.0.0

--- a/src/api/spec/cassettes/Cloud_Backend_UploadJob/_create/with_a_valid_backend_response/1_1_1_12.yml
+++ b/src/api/spec/cassettes/Cloud_Backend_UploadJob/_create/with_a_valid_backend_response/1_1_1_12.yml
@@ -1,0 +1,39 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: http://backend:5352/cloudupload?arch=x86_64&filename=appliance.raw.gz&package=aws&project=Cloud&repository=standard&target=ec2&user=tom
+    body:
+      encoding: UTF-8
+      string: '{"user_id":36,"external_id":"j8vcwjc0errkok8ic0iijkwc","arn":"arn:tk0uxpqgyc","region":"us-east-1","virtualization_type":"hvm","ami_name":"myami"}'
+    headers:
+      Content-Type:
+      - application/octet-stream
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 400
+      message: no cloud upload server configurated
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '87'
+    body:
+      encoding: UTF-8
+      string: |
+        <status code="400">
+          <summary>no cloud upload server configurated</summary>
+        </status>
+    http_version: 
+  recorded_at: Mon, 15 Jan 2018 11:01:50 GMT
+recorded_with: VCR 4.0.0

--- a/src/api/spec/cassettes/Cloud_Backend_UploadJob/_create/with_a_valid_backend_response/1_1_1_13.yml
+++ b/src/api/spec/cassettes/Cloud_Backend_UploadJob/_create/with_a_valid_backend_response/1_1_1_13.yml
@@ -1,0 +1,39 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: http://backend:5352/cloudupload?arch=x86_64&filename=appliance.raw.gz&package=aws&project=Cloud&repository=standard&target=ec2&user=tom
+    body:
+      encoding: UTF-8
+      string: '{"user_id":22,"external_id":"inydu5rf9i2tmjyrcoh9bsj2","arn":"arn:y8vzsuec06","region":"us-east-1","virtualization_type":"hvm","ami_name":"myami"}'
+    headers:
+      Content-Type:
+      - application/octet-stream
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 400
+      message: no cloud upload server configurated
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '87'
+    body:
+      encoding: UTF-8
+      string: |
+        <status code="400">
+          <summary>no cloud upload server configurated</summary>
+        </status>
+    http_version: 
+  recorded_at: Mon, 15 Jan 2018 11:01:49 GMT
+recorded_with: VCR 4.0.0

--- a/src/api/spec/cassettes/Cloud_Backend_UploadJob/_create/with_a_valid_backend_response/1_1_1_14.yml
+++ b/src/api/spec/cassettes/Cloud_Backend_UploadJob/_create/with_a_valid_backend_response/1_1_1_14.yml
@@ -1,0 +1,39 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: http://backend:5352/cloudupload?arch=x86_64&filename=appliance.raw.gz&package=aws&project=Cloud&repository=standard&target=ec2&user=tom
+    body:
+      encoding: UTF-8
+      string: '{"user_id":34,"external_id":"iywwnuy58rxq5henyxm5k4vf","arn":"arn:b0h276udhu","region":"us-east-1","virtualization_type":"hvm","ami_name":"myami"}'
+    headers:
+      Content-Type:
+      - application/octet-stream
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 400
+      message: no cloud upload server configurated
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '87'
+    body:
+      encoding: UTF-8
+      string: |
+        <status code="400">
+          <summary>no cloud upload server configurated</summary>
+        </status>
+    http_version: 
+  recorded_at: Mon, 15 Jan 2018 11:01:50 GMT
+recorded_with: VCR 4.0.0

--- a/src/api/spec/cassettes/Cloud_Backend_UploadJob/_create/with_a_valid_backend_response/1_1_1_2.yml
+++ b/src/api/spec/cassettes/Cloud_Backend_UploadJob/_create/with_a_valid_backend_response/1_1_1_2.yml
@@ -1,0 +1,39 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: http://backend:5352/cloudupload?arch=x86_64&filename=appliance.raw.gz&package=aws&project=Cloud&repository=standard&target=ec2&user=tom
+    body:
+      encoding: UTF-8
+      string: '{"user_id":44,"external_id":"zlk6ifvzeamk8p6ltakd0qta","arn":"arn:mdzcxgwb6t","region":"us-east-1","virtualization_type":"hvm","ami_name":"myami"}'
+    headers:
+      Content-Type:
+      - application/octet-stream
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 400
+      message: no cloud upload server configurated
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '87'
+    body:
+      encoding: UTF-8
+      string: |
+        <status code="400">
+          <summary>no cloud upload server configurated</summary>
+        </status>
+    http_version: 
+  recorded_at: Mon, 15 Jan 2018 11:01:50 GMT
+recorded_with: VCR 4.0.0

--- a/src/api/spec/cassettes/Cloud_Backend_UploadJob/_create/with_a_valid_backend_response/1_1_1_3.yml
+++ b/src/api/spec/cassettes/Cloud_Backend_UploadJob/_create/with_a_valid_backend_response/1_1_1_3.yml
@@ -1,0 +1,39 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: http://backend:5352/cloudupload?arch=x86_64&filename=appliance.raw.gz&package=aws&project=Cloud&repository=standard&target=ec2&user=tom
+    body:
+      encoding: UTF-8
+      string: '{"user_id":32,"external_id":"vx0esmm1uepaazuibqhdkycz","arn":"arn:xzz651b8jt","region":"us-east-1","virtualization_type":"hvm","ami_name":"myami"}'
+    headers:
+      Content-Type:
+      - application/octet-stream
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 400
+      message: no cloud upload server configurated
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '87'
+    body:
+      encoding: UTF-8
+      string: |
+        <status code="400">
+          <summary>no cloud upload server configurated</summary>
+        </status>
+    http_version: 
+  recorded_at: Mon, 15 Jan 2018 11:01:49 GMT
+recorded_with: VCR 4.0.0

--- a/src/api/spec/cassettes/Cloud_Backend_UploadJob/_create/with_a_valid_backend_response/1_1_1_4.yml
+++ b/src/api/spec/cassettes/Cloud_Backend_UploadJob/_create/with_a_valid_backend_response/1_1_1_4.yml
@@ -1,0 +1,39 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: http://backend:5352/cloudupload?arch=x86_64&filename=appliance.raw.gz&package=aws&project=Cloud&repository=standard&target=ec2&user=tom
+    body:
+      encoding: UTF-8
+      string: '{"user_id":24,"external_id":"gemocdb2g0m7epfwkvtlx4vo","arn":"arn:qf4s0h2a0q","region":"us-east-1","virtualization_type":"hvm","ami_name":"myami"}'
+    headers:
+      Content-Type:
+      - application/octet-stream
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 400
+      message: no cloud upload server configurated
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '87'
+    body:
+      encoding: UTF-8
+      string: |
+        <status code="400">
+          <summary>no cloud upload server configurated</summary>
+        </status>
+    http_version: 
+  recorded_at: Mon, 15 Jan 2018 11:01:49 GMT
+recorded_with: VCR 4.0.0

--- a/src/api/spec/cassettes/Cloud_Backend_UploadJob/_create/with_a_valid_backend_response/1_1_1_5.yml
+++ b/src/api/spec/cassettes/Cloud_Backend_UploadJob/_create/with_a_valid_backend_response/1_1_1_5.yml
@@ -1,0 +1,39 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: http://backend:5352/cloudupload?arch=x86_64&filename=appliance.raw.gz&package=aws&project=Cloud&repository=standard&target=ec2&user=tom
+    body:
+      encoding: UTF-8
+      string: '{"user_id":40,"external_id":"n96c21pzt9mt3da9voarrj4v","arn":"arn:dji1goqtmw","region":"us-east-1","virtualization_type":"hvm","ami_name":"myami"}'
+    headers:
+      Content-Type:
+      - application/octet-stream
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 400
+      message: no cloud upload server configurated
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '87'
+    body:
+      encoding: UTF-8
+      string: |
+        <status code="400">
+          <summary>no cloud upload server configurated</summary>
+        </status>
+    http_version: 
+  recorded_at: Mon, 15 Jan 2018 11:01:50 GMT
+recorded_with: VCR 4.0.0

--- a/src/api/spec/cassettes/Cloud_Backend_UploadJob/_create/with_a_valid_backend_response/1_1_1_6.yml
+++ b/src/api/spec/cassettes/Cloud_Backend_UploadJob/_create/with_a_valid_backend_response/1_1_1_6.yml
@@ -1,0 +1,39 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: http://backend:5352/cloudupload?arch=x86_64&filename=appliance.raw.gz&package=aws&project=Cloud&repository=standard&target=ec2&user=tom
+    body:
+      encoding: UTF-8
+      string: '{"user_id":42,"external_id":"2rdu3w8nagcpru53sa9pi6gz","arn":"arn:a8dfaevcip","region":"us-east-1","virtualization_type":"hvm","ami_name":"myami"}'
+    headers:
+      Content-Type:
+      - application/octet-stream
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 400
+      message: no cloud upload server configurated
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '87'
+    body:
+      encoding: UTF-8
+      string: |
+        <status code="400">
+          <summary>no cloud upload server configurated</summary>
+        </status>
+    http_version: 
+  recorded_at: Mon, 15 Jan 2018 11:01:50 GMT
+recorded_with: VCR 4.0.0

--- a/src/api/spec/cassettes/Cloud_Backend_UploadJob/_create/with_a_valid_backend_response/1_1_1_7.yml
+++ b/src/api/spec/cassettes/Cloud_Backend_UploadJob/_create/with_a_valid_backend_response/1_1_1_7.yml
@@ -1,0 +1,39 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: http://backend:5352/cloudupload?arch=x86_64&filename=appliance.raw.gz&package=aws&project=Cloud&repository=standard&target=ec2&user=tom
+    body:
+      encoding: UTF-8
+      string: '{"user_id":30,"external_id":"jfnysudxhp2c7bpxi8z3osca","arn":"arn:qe9ux4be9b","region":"us-east-1","virtualization_type":"hvm","ami_name":"myami"}'
+    headers:
+      Content-Type:
+      - application/octet-stream
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 400
+      message: no cloud upload server configurated
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '87'
+    body:
+      encoding: UTF-8
+      string: |
+        <status code="400">
+          <summary>no cloud upload server configurated</summary>
+        </status>
+    http_version: 
+  recorded_at: Mon, 15 Jan 2018 11:01:49 GMT
+recorded_with: VCR 4.0.0

--- a/src/api/spec/cassettes/Cloud_Backend_UploadJob/_create/with_a_valid_backend_response/1_1_1_8.yml
+++ b/src/api/spec/cassettes/Cloud_Backend_UploadJob/_create/with_a_valid_backend_response/1_1_1_8.yml
@@ -1,0 +1,39 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: http://backend:5352/cloudupload?arch=x86_64&filename=appliance.raw.gz&package=aws&project=Cloud&repository=standard&target=ec2&user=tom
+    body:
+      encoding: UTF-8
+      string: '{"user_id":18,"external_id":"l61g8k0yadqqk388bxzxvm1j","arn":"arn:rr60iuetzt","region":"us-east-1","virtualization_type":"hvm","ami_name":"myami"}'
+    headers:
+      Content-Type:
+      - application/octet-stream
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 400
+      message: no cloud upload server configurated
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '87'
+    body:
+      encoding: UTF-8
+      string: |
+        <status code="400">
+          <summary>no cloud upload server configurated</summary>
+        </status>
+    http_version: 
+  recorded_at: Mon, 15 Jan 2018 11:01:49 GMT
+recorded_with: VCR 4.0.0

--- a/src/api/spec/cassettes/Cloud_Backend_UploadJob/_create/with_a_valid_backend_response/1_1_1_9.yml
+++ b/src/api/spec/cassettes/Cloud_Backend_UploadJob/_create/with_a_valid_backend_response/1_1_1_9.yml
@@ -1,0 +1,39 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: http://backend:5352/cloudupload?arch=x86_64&filename=appliance.raw.gz&package=aws&project=Cloud&repository=standard&target=ec2&user=tom
+    body:
+      encoding: UTF-8
+      string: '{"user_id":26,"external_id":"di45zi0bpt3t0m8gitro2905","arn":"arn:hcffcdyuwp","region":"us-east-1","virtualization_type":"hvm","ami_name":"myami"}'
+    headers:
+      Content-Type:
+      - application/octet-stream
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 400
+      message: no cloud upload server configurated
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '87'
+    body:
+      encoding: UTF-8
+      string: |
+        <status code="400">
+          <summary>no cloud upload server configurated</summary>
+        </status>
+    http_version: 
+  recorded_at: Mon, 15 Jan 2018 11:01:49 GMT
+recorded_with: VCR 4.0.0

--- a/src/api/spec/cassettes/Cloud_UploadJob/_create/with_an_invalid_Backend_UploadJob/1_1_2_1.yml
+++ b/src/api/spec/cassettes/Cloud_UploadJob/_create/with_an_invalid_Backend_UploadJob/1_1_2_1.yml
@@ -36,4 +36,40 @@ http_interactions:
         </status>
     http_version: 
   recorded_at: Fri, 22 Dec 2017 13:42:37 GMT
+- request:
+    method: post
+    uri: http://backend:5352/cloudupload?arch=x86_64&filename=appliance.raw.xz&package=aws&project=Cloud&repository=standard&target=ec2&user=tom
+    body:
+      encoding: UTF-8
+      string: '{"user_id":2,"external_id":"pnxhnnnpijfqmcyflacepw5g","arn":"arn:1wvkoxv9jd","region":"us-east-1","virtualization_type":"hvm","ami_name":"my-image"}'
+    headers:
+      Content-Type:
+      - application/octet-stream
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 400
+      message: no cloud upload server configurated
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '87'
+    body:
+      encoding: UTF-8
+      string: |
+        <status code="400">
+          <summary>no cloud upload server configurated</summary>
+        </status>
+    http_version: 
+  recorded_at: Thu, 11 Jan 2018 15:28:18 GMT
 recorded_with: VCR 4.0.0

--- a/src/api/spec/cassettes/Cloud_UploadJob/_create/with_an_invalid_Backend_UploadJob/1_2_2_1.yml
+++ b/src/api/spec/cassettes/Cloud_UploadJob/_create/with_an_invalid_Backend_UploadJob/1_2_2_1.yml
@@ -1,0 +1,39 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: http://backend:5352/cloudupload?arch=x86_64&filename=appliance.raw.xz&package=aws&project=Cloud&repository=standard&target=ec2&user=tom
+    body:
+      encoding: UTF-8
+      string: '{"user_id":4,"external_id":"i5hj51cw5qz0y540jqj8o27a","arn":"arn:vv51n8vivo","region":"us-east-1","virtualization_type":"hvm","ami_name":"my-image"}'
+    headers:
+      Content-Type:
+      - application/octet-stream
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 400
+      message: no cloud upload server configurated
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '87'
+    body:
+      encoding: UTF-8
+      string: |
+        <status code="400">
+          <summary>no cloud upload server configurated</summary>
+        </status>
+    http_version: 
+  recorded_at: Thu, 11 Jan 2018 15:43:29 GMT
+recorded_with: VCR 4.0.0

--- a/src/api/spec/cassettes/Cloud_UploadJob/_create/with_an_invalid_Backend_UploadJob/has_the_correct_error_message.yml
+++ b/src/api/spec/cassettes/Cloud_UploadJob/_create/with_an_invalid_Backend_UploadJob/has_the_correct_error_message.yml
@@ -36,4 +36,40 @@ http_interactions:
         </status>
     http_version: 
   recorded_at: Fri, 22 Dec 2017 13:42:38 GMT
+- request:
+    method: post
+    uri: http://backend:5352/cloudupload?arch=x86_64&filename=appliance.raw.xz&package=aws&project=Cloud&repository=standard&target=ec2&user=tom
+    body:
+      encoding: UTF-8
+      string: '{"user_id":4,"external_id":"wilxk6lwbg931y4pg3nevzfn","arn":"arn:6ti9dpb2ml","region":"us-east-1","virtualization_type":"hvm","ami_name":"my-image"}'
+    headers:
+      Content-Type:
+      - application/octet-stream
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 400
+      message: no cloud upload server configurated
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '87'
+    body:
+      encoding: UTF-8
+      string: |
+        <status code="400">
+          <summary>no cloud upload server configurated</summary>
+        </status>
+    http_version: 
+  recorded_at: Thu, 11 Jan 2018 15:28:18 GMT
 recorded_with: VCR 4.0.0

--- a/src/api/spec/cassettes/Webui_Cloud_UploadJobsController/POST_create/with_a_backend_response/1_3_2_2.yml
+++ b/src/api/spec/cassettes/Webui_Cloud_UploadJobsController/POST_create/with_a_backend_response/1_3_2_2.yml
@@ -36,4 +36,40 @@ http_interactions:
         </status>
     http_version: 
   recorded_at: Thu, 04 Jan 2018 14:12:59 GMT
+- request:
+    method: post
+    uri: http://backend:5352/cloudupload?arch=x86_64&filename=appliance.raw.xz&package=aws&project=Cloud&repository=standard&target=ec2&user=tom
+    body:
+      encoding: UTF-8
+      string: '{"user_id":6,"external_id":"dxbikque9wij898g8wrjsx04","arn":"arn:a6l555frzo","region":"us-east-1","virtualization_type":"hvm","ami_name":"my-image"}'
+    headers:
+      Content-Type:
+      - application/octet-stream
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 400
+      message: no cloud upload server configurated
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '87'
+    body:
+      encoding: UTF-8
+      string: |
+        <status code="400">
+          <summary>no cloud upload server configurated</summary>
+        </status>
+    http_version: 
+  recorded_at: Thu, 11 Jan 2018 14:40:10 GMT
 recorded_with: VCR 4.0.0

--- a/src/api/spec/cassettes/Webui_Cloud_UploadJobsController/POST_create/with_a_backend_response/1_3_2_3.yml
+++ b/src/api/spec/cassettes/Webui_Cloud_UploadJobsController/POST_create/with_a_backend_response/1_3_2_3.yml
@@ -36,4 +36,40 @@ http_interactions:
         </status>
     http_version: 
   recorded_at: Thu, 04 Jan 2018 14:12:59 GMT
+- request:
+    method: post
+    uri: http://backend:5352/cloudupload?arch=x86_64&filename=appliance.raw.xz&package=aws&project=Cloud&repository=standard&target=ec2&user=tom
+    body:
+      encoding: UTF-8
+      string: '{"user_id":8,"external_id":"jj54vb3fe6tre05jcfudse2i","arn":"arn:wt1dbjjahp","region":"us-east-1","virtualization_type":"hvm","ami_name":"my-image"}'
+    headers:
+      Content-Type:
+      - application/octet-stream
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 400
+      message: no cloud upload server configurated
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '87'
+    body:
+      encoding: UTF-8
+      string: |
+        <status code="400">
+          <summary>no cloud upload server configurated</summary>
+        </status>
+    http_version: 
+  recorded_at: Thu, 11 Jan 2018 14:40:10 GMT
 recorded_with: VCR 4.0.0

--- a/src/api/spec/cassettes/Webui_Cloud_UploadJobsController/POST_create/with_a_backend_response/1_3_2_4.yml
+++ b/src/api/spec/cassettes/Webui_Cloud_UploadJobsController/POST_create/with_a_backend_response/1_3_2_4.yml
@@ -36,4 +36,40 @@ http_interactions:
         </status>
     http_version: 
   recorded_at: Thu, 04 Jan 2018 14:12:59 GMT
+- request:
+    method: post
+    uri: http://backend:5352/cloudupload?arch=x86_64&filename=appliance.raw.xz&package=aws&project=Cloud&repository=standard&target=ec2&user=tom
+    body:
+      encoding: UTF-8
+      string: '{"user_id":2,"external_id":"tsu484qz57ldr9b6v3vtpzbc","arn":"arn:tg699pwv7f","region":"us-east-1","virtualization_type":"hvm","ami_name":"my-image"}'
+    headers:
+      Content-Type:
+      - application/octet-stream
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 400
+      message: no cloud upload server configurated
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '87'
+    body:
+      encoding: UTF-8
+      string: |
+        <status code="400">
+          <summary>no cloud upload server configurated</summary>
+        </status>
+    http_version: 
+  recorded_at: Thu, 11 Jan 2018 14:40:10 GMT
 recorded_with: VCR 4.0.0

--- a/src/api/spec/cassettes/Webui_Cloud_UploadJobsController/POST_create/with_a_backend_response/1_3_2_5.yml
+++ b/src/api/spec/cassettes/Webui_Cloud_UploadJobsController/POST_create/with_a_backend_response/1_3_2_5.yml
@@ -36,4 +36,40 @@ http_interactions:
         </status>
     http_version: 
   recorded_at: Thu, 04 Jan 2018 14:12:59 GMT
+- request:
+    method: post
+    uri: http://backend:5352/cloudupload?arch=x86_64&filename=appliance.raw.xz&package=aws&project=Cloud&repository=standard&target=ec2&user=tom
+    body:
+      encoding: UTF-8
+      string: '{"user_id":4,"external_id":"6bx7wc0snezyrp1ktyqj40vs","arn":"arn:kse3p8cp5y","region":"us-east-1","virtualization_type":"hvm","ami_name":"my-image"}'
+    headers:
+      Content-Type:
+      - application/octet-stream
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 400
+      message: no cloud upload server configurated
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '87'
+    body:
+      encoding: UTF-8
+      string: |
+        <status code="400">
+          <summary>no cloud upload server configurated</summary>
+        </status>
+    http_version: 
+  recorded_at: Thu, 11 Jan 2018 14:40:10 GMT
 recorded_with: VCR 4.0.0

--- a/src/api/spec/cassettes/Webui_Cloud_UploadJobsController/POST_create/with_a_backend_response/1_3_3_1.yml
+++ b/src/api/spec/cassettes/Webui_Cloud_UploadJobsController/POST_create/with_a_backend_response/1_3_3_1.yml
@@ -1,0 +1,39 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: http://backend:5352/cloudupload?arch=x86_64&filename=appliance.raw.xz&package=aws&project=Cloud&repository=standard&target=&user=tom
+    body:
+      encoding: UTF-8
+      string: '{"user_id":18,"external_id":"bf18u7rkuozsrrg9bdh2f313","arn":"arn:s3wx5w1704","region":"us-east-1","virtualization_type":"hvm","ami_name":"my-image"}'
+    headers:
+      Content-Type:
+      - application/octet-stream
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 400
+      message: no cloud upload server configurated
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '87'
+    body:
+      encoding: UTF-8
+      string: |
+        <status code="400">
+          <summary>no cloud upload server configurated</summary>
+        </status>
+    http_version: 
+  recorded_at: Fri, 12 Jan 2018 13:07:21 GMT
+recorded_with: VCR 4.0.0

--- a/src/api/spec/cassettes/Webui_Cloud_UploadJobsController/POST_create/with_a_backend_response/1_3_3_2.yml
+++ b/src/api/spec/cassettes/Webui_Cloud_UploadJobsController/POST_create/with_a_backend_response/1_3_3_2.yml
@@ -1,0 +1,39 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: http://backend:5352/cloudupload?arch=x86_64&filename=appliance.raw.xz&package=aws&project=Cloud&repository=standard&target=&user=tom
+    body:
+      encoding: UTF-8
+      string: '{"user_id":16,"external_id":"r3eu3u7pmz25fccnjc050kou","arn":"arn:g5lnq821ye","region":"us-east-1","virtualization_type":"hvm","ami_name":"my-image"}'
+    headers:
+      Content-Type:
+      - application/octet-stream
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 400
+      message: no cloud upload server configurated
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '87'
+    body:
+      encoding: UTF-8
+      string: |
+        <status code="400">
+          <summary>no cloud upload server configurated</summary>
+        </status>
+    http_version: 
+  recorded_at: Fri, 12 Jan 2018 13:07:21 GMT
+recorded_with: VCR 4.0.0

--- a/src/api/spec/cassettes/Webui_Cloud_UploadJobsController/POST_create/with_a_backend_response/1_3_3_3.yml
+++ b/src/api/spec/cassettes/Webui_Cloud_UploadJobsController/POST_create/with_a_backend_response/1_3_3_3.yml
@@ -1,0 +1,39 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: http://backend:5352/cloudupload?arch=x86_64&filename=appliance.raw.xz&package=aws&project=Cloud&repository=standard&target=&user=tom
+    body:
+      encoding: UTF-8
+      string: '{"user_id":20,"external_id":"5f9tf3m286mpdbqkvdv6sxc4","arn":"arn:j0j7ocl6vk","region":"us-east-1","virtualization_type":"hvm","ami_name":"my-image"}'
+    headers:
+      Content-Type:
+      - application/octet-stream
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 400
+      message: no cloud upload server configurated
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '87'
+    body:
+      encoding: UTF-8
+      string: |
+        <status code="400">
+          <summary>no cloud upload server configurated</summary>
+        </status>
+    http_version: 
+  recorded_at: Fri, 12 Jan 2018 13:07:22 GMT
+recorded_with: VCR 4.0.0

--- a/src/api/spec/cassettes/Webui_Cloud_UploadJobsController/POST_create/with_a_backend_response/1_3_3_4.yml
+++ b/src/api/spec/cassettes/Webui_Cloud_UploadJobsController/POST_create/with_a_backend_response/1_3_3_4.yml
@@ -1,0 +1,39 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: http://backend:5352/cloudupload?arch=x86_64&filename=appliance.raw.xz&package=aws&project=Cloud&repository=standard&target=&user=tom
+    body:
+      encoding: UTF-8
+      string: '{"user_id":22,"external_id":"op5vor9vvfzr7hnq57g3au3c","arn":"arn:j6uq5tfmkv","region":"us-east-1","virtualization_type":"hvm","ami_name":"my-image"}'
+    headers:
+      Content-Type:
+      - application/octet-stream
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 400
+      message: no cloud upload server configurated
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '87'
+    body:
+      encoding: UTF-8
+      string: |
+        <status code="400">
+          <summary>no cloud upload server configurated</summary>
+        </status>
+    http_version: 
+  recorded_at: Fri, 12 Jan 2018 13:07:22 GMT
+recorded_with: VCR 4.0.0

--- a/src/api/spec/cassettes/Webui_Cloud_UploadJobsController/POST_create/with_a_backend_response/1_3_3_5.yml
+++ b/src/api/spec/cassettes/Webui_Cloud_UploadJobsController/POST_create/with_a_backend_response/1_3_3_5.yml
@@ -1,0 +1,39 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: http://backend:5352/cloudupload?arch=x86_64&filename=appliance.raw.xz&package=aws&project=Cloud&repository=standard&target=&user=tom
+    body:
+      encoding: UTF-8
+      string: '{"user_id":14,"external_id":"v006x3zwopsehuvml9d8rulm","arn":"arn:n67hajgc2d","region":"us-east-1","virtualization_type":"hvm","ami_name":"my-image"}'
+    headers:
+      Content-Type:
+      - application/octet-stream
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 400
+      message: no cloud upload server configurated
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '87'
+    body:
+      encoding: UTF-8
+      string: |
+        <status code="400">
+          <summary>no cloud upload server configurated</summary>
+        </status>
+    http_version: 
+  recorded_at: Fri, 12 Jan 2018 13:07:21 GMT
+recorded_with: VCR 4.0.0

--- a/src/api/spec/cassettes/Webui_Cloud_UploadJobsController/POST_create/without_backend_configured/1_3_1_1.yml
+++ b/src/api/spec/cassettes/Webui_Cloud_UploadJobsController/POST_create/without_backend_configured/1_3_1_1.yml
@@ -2,46 +2,10 @@
 http_interactions:
 - request:
     method: post
-    uri: http://backend:5352/cloudupload?arch=x86_64&filename=appliance.raw.gz&package=aws&project=Cloud&repository=standard&target=ec2&user=tom
-    body:
-      encoding: UTF-8
-      string: '{"user_id":5,"external_id":"gwbrg58pwxywbo06u00zlq14","arn":"arn:hndj62cwoo","region":"us-east-1"}'
-    headers:
-      Content-Type:
-      - application/octet-stream
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 400
-      message: no cloud upload server configurated
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '87'
-    body:
-      encoding: UTF-8
-      string: |
-        <status code="400">
-          <summary>no cloud upload server configurated</summary>
-        </status>
-    http_version: 
-  recorded_at: Thu, 04 Jan 2018 14:13:00 GMT
-- request:
-    method: post
     uri: http://backend:5352/cloudupload?arch=x86_64&filename=appliance.raw.xz&package=aws&project=Cloud&repository=standard&target=ec2&user=tom
     body:
       encoding: UTF-8
-      string: '{"user_id":10,"external_id":"i14c9nxejtgdm33lwuwex0r8","arn":"arn:p3fs3ojirl","region":"us-east-1","virtualization_type":"hvm","ami_name":"my-image"}'
+      string: '{"user_id":30,"external_id":"pz6aeza8hf8fjl6fnxj22z7l","arn":"arn:eqgfi5hr6x","region":"us-east-1","virtualization_type":"hvm","ami_name":"my-image"}'
     headers:
       Content-Type:
       - application/octet-stream
@@ -71,5 +35,41 @@ http_interactions:
           <summary>no cloud upload server configurated</summary>
         </status>
     http_version: 
-  recorded_at: Thu, 11 Jan 2018 14:40:11 GMT
+  recorded_at: Thu, 11 Jan 2018 15:08:56 GMT
+- request:
+    method: post
+    uri: http://backend:5352/cloudupload?arch=x86_64&filename=appliance.raw.xz&package=aws&project=Cloud&repository=standard&target=&user=tom
+    body:
+      encoding: UTF-8
+      string: '{"user_id":26,"external_id":"et5mm4a7w46nyk383c9nyqwe","arn":"arn:1hqc7b10o1","region":"us-east-1","virtualization_type":"hvm","ami_name":"my-image"}'
+    headers:
+      Content-Type:
+      - application/octet-stream
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 400
+      message: no cloud upload server configurated
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '87'
+    body:
+      encoding: UTF-8
+      string: |
+        <status code="400">
+          <summary>no cloud upload server configurated</summary>
+        </status>
+    http_version: 
+  recorded_at: Fri, 12 Jan 2018 13:07:22 GMT
 recorded_with: VCR 4.0.0

--- a/src/api/spec/cassettes/Webui_Cloud_UploadJobsController/POST_create/without_backend_configured/1_3_1_2.yml
+++ b/src/api/spec/cassettes/Webui_Cloud_UploadJobsController/POST_create/without_backend_configured/1_3_1_2.yml
@@ -2,46 +2,10 @@
 http_interactions:
 - request:
     method: post
-    uri: http://backend:5352/cloudupload?arch=x86_64&filename=appliance.raw.gz&package=aws&project=Cloud&repository=standard&target=ec2&user=tom
-    body:
-      encoding: UTF-8
-      string: '{"user_id":5,"external_id":"gwbrg58pwxywbo06u00zlq14","arn":"arn:hndj62cwoo","region":"us-east-1"}'
-    headers:
-      Content-Type:
-      - application/octet-stream
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 400
-      message: no cloud upload server configurated
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '87'
-    body:
-      encoding: UTF-8
-      string: |
-        <status code="400">
-          <summary>no cloud upload server configurated</summary>
-        </status>
-    http_version: 
-  recorded_at: Thu, 04 Jan 2018 14:13:00 GMT
-- request:
-    method: post
     uri: http://backend:5352/cloudupload?arch=x86_64&filename=appliance.raw.xz&package=aws&project=Cloud&repository=standard&target=ec2&user=tom
     body:
       encoding: UTF-8
-      string: '{"user_id":10,"external_id":"i14c9nxejtgdm33lwuwex0r8","arn":"arn:p3fs3ojirl","region":"us-east-1","virtualization_type":"hvm","ami_name":"my-image"}'
+      string: '{"user_id":32,"external_id":"c5nbgvapimomxb5yh8twjxz9","arn":"arn:34rbua64dg","region":"us-east-1","virtualization_type":"hvm","ami_name":"my-image"}'
     headers:
       Content-Type:
       - application/octet-stream
@@ -71,5 +35,41 @@ http_interactions:
           <summary>no cloud upload server configurated</summary>
         </status>
     http_version: 
-  recorded_at: Thu, 11 Jan 2018 14:40:11 GMT
+  recorded_at: Thu, 11 Jan 2018 15:08:56 GMT
+- request:
+    method: post
+    uri: http://backend:5352/cloudupload?arch=x86_64&filename=appliance.raw.xz&package=aws&project=Cloud&repository=standard&target=&user=tom
+    body:
+      encoding: UTF-8
+      string: '{"user_id":24,"external_id":"vnnjnq4lcmb5fpyzfomgymts","arn":"arn:9br3l94z8t","region":"us-east-1","virtualization_type":"hvm","ami_name":"my-image"}'
+    headers:
+      Content-Type:
+      - application/octet-stream
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 400
+      message: no cloud upload server configurated
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '87'
+    body:
+      encoding: UTF-8
+      string: |
+        <status code="400">
+          <summary>no cloud upload server configurated</summary>
+        </status>
+    http_version: 
+  recorded_at: Fri, 12 Jan 2018 13:07:22 GMT
 recorded_with: VCR 4.0.0

--- a/src/api/spec/helpers/webui/package_helper_spec.rb
+++ b/src/api/spec/helpers/webui/package_helper_spec.rb
@@ -273,9 +273,10 @@ RSpec.describe Webui::PackageHelper, type: :helper do
     end
   end
 
-  describe 'cloud_image_file?' do
-    it { expect(cloud_image_file?('image.raw.xz')).to be_truthy }
-    it { expect(cloud_image_file?('image.vhdfixed.xz')).to be_truthy }
-    it { expect(cloud_image_file?('apache2.rpm')).to be_falsy }
+  describe '#uploadable?' do
+    it { expect(uploadable?('image.raw.xz', 'x86_64')).to be_truthy }
+    it { expect(uploadable?('image.vhdfixed.xz', 'x86_64')).to be_truthy }
+    it { expect(uploadable?('image.vhdfixed.xz', 'i386')).to be_falsy }
+    it { expect(uploadable?('apache2.rpm', 'x86_64')).to be_falsy }
   end
 end

--- a/src/api/spec/models/cloud/params/ec2.rb
+++ b/src/api/spec/models/cloud/params/ec2.rb
@@ -1,0 +1,19 @@
+require 'rails_helper'
+
+RSpec.describe Cloud::Params::Ec2, type: :model, vcr: true do
+  describe 'validations' do
+    it { is_expected.to validate_inclusion_of(:virtualization_type).in_array(['hvm', 'pv']) }
+    it { is_expected.to validate_presence_of :region }
+    it { is_expected.to validate_presence_of :ami_name }
+    it { is_expected.to allow_value('foo.raw.xz').for(:ami_name) }
+    it { is_expected.not_to allow_value('lorem ipsum').for(:ami_name) }
+    it { is_expected.to allow_value('us-east-1').for(:region) }
+    it { is_expected.not_to allow_value('nuernberg-soutside').for(:region) }
+  end
+
+  describe '.build' do
+    it 'ignores not necessary values' do
+      expect(Cloud::Params::Ec2.build(not: :necessary, region: 'us-east-1').region).to eq('us-east-1')
+    end
+  end
+end


### PR DESCRIPTION
It is now possible to configure the ami name, and virtualization type.
Furthermore this commit adds before filter to the UploadJobs Controller to only allow uploads for cloud images
as well as model validations for all parameters.
To support all new parameters the backend clouduploader was also adapted.