### PR TITLE
[frontend] Add 'reset to default' functionality to notifcations page

### DIFF
--- a/src/api/app/assets/javascripts/webui/application.js.erb
+++ b/src/api/app/assets/javascripts/webui/application.js.erb
@@ -272,6 +272,11 @@ $(document).on('click','.close-dialog', function() {
   }
 });
 
+$(document).on('click', 'a[data-clear-checkboxes]', function(event) {
+  event.preventDefault();
+  $('input:checkbox').prop('checked', false);
+});
+
 // show/hide functionality for text
 $(function() {
   $('.show-hide').on('click', function() {

--- a/src/api/app/views/webui/users/subscriptions/index.html.haml
+++ b/src/api/app/views/webui/users/subscriptions/index.html.haml
@@ -19,7 +19,9 @@
     %h3 Events
     %p.description Choose from which events you want to get an email
     = render partial: 'webui/subscriptions/subscriptions_form'
-    %p= submit_tag 'Update'
+    %p
+      = submit_tag 'Update'
+      = link_to('Reset to default', '#', data: { 'clear-checkboxes': true })
 .grid_16.alpha.omega.box.box-shadow
   %h2 RSS Feed
   = form_tag(user_rss_token_path, id: 'generate_rss_token_form', method: :post) do


### PR DESCRIPTION
This provides a convenient way to clear all notification checkboxes,
which is the default setup for notifications.

Fixes #4186 

![screenshot from 2018-01-12 15-00-29](https://user-images.githubusercontent.com/968949/34878159-75b4510e-f7a9-11e7-8bd5-6bcf2444aa49.png)
