### PR TITLE
[webui][api] Change SendEventEmails to 1 event per job.

### DIFF
--- a/src/api/app/models/event/base.rb
+++ b/src/api/app/models/event/base.rb
@@ -8,6 +8,8 @@ module Event
     self.table_name = 'events'
 
     after_create :create_project_log_entry_job, if: -> { (PROJECT_CLASSES | PACKAGE_CLASSES).include?(self.class.name) }
+    after_create :perform_create_jobs
+    after_create :send_event_emails_job
 
     EXPLANATION_FOR_NOTIFICATIONS =  {
       'Event::BuildFail'          => 'Receive notifications of build failures for packages for which you are...',
@@ -151,8 +153,6 @@ module Event
       CreateProjectLogEntryJob.perform_later(payload, created_at.to_s, self.class.name)
     end
 
-    after_create :perform_create_jobs
-
     def perform_create_jobs
       self.undone_jobs = 0
       save
@@ -168,6 +168,10 @@ module Event
         self.undone_jobs += 1
       end
       save if self.undone_jobs > 0
+    end
+
+    def send_event_emails_job
+      SendEventEmailsJob.perform_later(id)
     end
 
     # to be overwritten in subclasses

--- a/src/api/config/clock.rb
+++ b/src/api/config/clock.rb
@@ -16,10 +16,6 @@ module Clockwork
     WorkerStatus.new.update_workerstatus_cache
   end
 
-  every(30.seconds, 'send notifications') do
-    SendEventEmailsJob.perform_later
-  end
-
   every(49.minutes, 'rescale history') do
     StatusHistoryRescalerJob.perform_later
   end

--- a/src/api/spec/jobs/send_event_emails_job_spec.rb
+++ b/src/api/spec/jobs/send_event_emails_job_spec.rb
@@ -1,8 +1,6 @@
 require 'rails_helper'
 
 RSpec.describe SendEventEmailsJob, type: :job do
-  include ActiveJob::TestHelper
-
   describe '#perform' do
     before do
       ActionMailer::Base.deliveries = []
@@ -15,16 +13,18 @@ RSpec.describe SendEventEmailsJob, type: :job do
     let!(:project) { create(:project, name: 'comment_project', maintainer: [user, group]) }
 
     let!(:comment_author) { create(:confirmed_user) }
-
-    let!(:comment) { create(:comment_project, commentable: project, body: "Hey @#{user.login} how are things?", user: comment_author) }
     let!(:user_maintainer) { create(:group) }
+
+    let(:comment) do
+      create(:comment_project, commentable: project, body: "Hey @#{user.login} how are things?", user: comment_author)
+    end
 
     context 'with no errors being raised' do
       let!(:subscription1) { create(:event_subscription_comment_for_project, receiver_role: 'maintainer', user: user) }
       let!(:subscription2) { create(:event_subscription_comment_for_project, receiver_role: 'maintainer', user: nil, group: group) }
       let!(:subscription3) { create(:event_subscription_comment_for_project, receiver_role: 'commenter', user: comment_author) }
 
-      subject! { SendEventEmailsJob.new.perform }
+      subject! { comment }
 
       it 'sends an email to the subscribers' do
         email = ActionMailer::Base.deliveries.first
@@ -76,7 +76,7 @@ RSpec.describe SendEventEmailsJob, type: :job do
         allow(Airbrake).to receive(:notify)
       end
 
-      subject! { SendEventEmailsJob.new.perform }
+      subject! { comment }
 
       it 'updates the event mails_sent = true' do
         event = Event::CommentForProject.first
@@ -89,7 +89,7 @@ RSpec.describe SendEventEmailsJob, type: :job do
     end
 
     context 'with no subscriptions for the event' do
-      subject! { SendEventEmailsJob.new.perform }
+      subject! { comment }
 
       it 'updates the event mails_sent = true' do
         event = Event::CommentForProject.first

--- a/src/api/test/functional/comments_controller_test.rb
+++ b/src/api/test/functional/comments_controller_test.rb
@@ -87,11 +87,9 @@ class CommentsControllerTest < ActionDispatch::IntegrationTest
     # body can't be empty
     assert_xml_tag tag: 'status', attributes: { code: 'invalid_record' }
 
-    SendEventEmailsJob.new.perform
     assert_difference 'ActionMailer::Base.deliveries.size', +1 do
       post create_request_comment_path(request_number: 2), params: 'Hallo'
       assert_response :success
-      SendEventEmailsJob.new.perform
     end
 
     email = ActionMailer::Base.deliveries.last
@@ -103,11 +101,9 @@ class CommentsControllerTest < ActionDispatch::IntegrationTest
 
     # just check if adrian gets the mail too - he's a commenter now
     login_dmayr
-    SendEventEmailsJob.new.perform
     assert_difference 'ActionMailer::Base.deliveries.size', +1 do
       post create_request_comment_path(request_number: 2), params: 'Hallo'
       assert_response :success
-      SendEventEmailsJob.new.perform
     end
 
     email = ActionMailer::Base.deliveries.last
@@ -117,7 +113,6 @@ class CommentsControllerTest < ActionDispatch::IntegrationTest
     assert_difference 'ActionMailer::Base.deliveries.size', +1 do
       post create_request_comment_path(request_number: 2), params: 'Hallo @fred'
       assert_response :success
-      SendEventEmailsJob.new.perform
     end
 
     email = ActionMailer::Base.deliveries.last
@@ -127,7 +122,6 @@ class CommentsControllerTest < ActionDispatch::IntegrationTest
     assert_difference 'ActionMailer::Base.deliveries.size', +1 do
       post create_request_comment_path(request_number: 2), params: 'Is Fred listening now?'
       assert_response :success
-      SendEventEmailsJob.new.perform
     end
 
     email = ActionMailer::Base.deliveries.last
@@ -144,11 +138,9 @@ class CommentsControllerTest < ActionDispatch::IntegrationTest
     # body can't be empty
     assert_xml_tag tag: 'status', attributes: { code: 'invalid_record' }
 
-    SendEventEmailsJob.new.perform
     assert_difference 'ActionMailer::Base.deliveries.size', +1 do
       post create_project_comment_path(project: 'Apache'), params: 'Beautiful project'
       assert_response :success
-      SendEventEmailsJob.new.perform
     end
 
     email = ActionMailer::Base.deliveries.last
@@ -170,11 +162,9 @@ class CommentsControllerTest < ActionDispatch::IntegrationTest
     # body can't be empty
     assert_xml_tag tag: 'status', attributes: { code: 'invalid_record' }
 
-    SendEventEmailsJob.new.perform
     assert_difference 'ActionMailer::Base.deliveries.size', +1 do
       post create_package_comment_path(project: 'kde4', package: 'kdebase'), params: 'Hola, estoy aprendiendo español'
       assert_response :success
-      SendEventEmailsJob.new.perform
     end
 
     email = ActionMailer::Base.deliveries.last
@@ -187,12 +177,10 @@ class CommentsControllerTest < ActionDispatch::IntegrationTest
 
   def test_create_a_comment_that_only_mentioned_people_will_notice
     login_tom
-    SendEventEmailsJob.new.perform
     assert_difference 'ActionMailer::Base.deliveries.size', +1 do
       # Trolling
       post create_package_comment_path(project: 'BaseDistro', package: 'pack1'), params: "I preffer Apache1, don't you? @fred"
       assert_response :success
-      SendEventEmailsJob.new.perform
     end
 
     email = ActionMailer::Base.deliveries.last

--- a/src/api/test/functional/maintenance_test.rb
+++ b/src/api/test/functional/maintenance_test.rb
@@ -1380,14 +1380,12 @@ class MaintenanceTests < ActionDispatch::IntegrationTest
     assert_response :success
     assert_xml_tag(parent: { tag: 'state' }, tag: 'comment', content: 'blahfasel')
 
-    SendEventEmailsJob.new.perform
     ActionMailer::Base.deliveries.clear
 
     # leave a comment
     assert_difference 'ActionMailer::Base.deliveries.size', +1 do
       post create_request_comment_path(request_number: reqid), params: 'Release it now!'
       assert_response :success
-      SendEventEmailsJob.new.perform
     end
 
     email = ActionMailer::Base.deliveries.last
@@ -1400,7 +1398,6 @@ class MaintenanceTests < ActionDispatch::IntegrationTest
     assert_difference 'ActionMailer::Base.deliveries.size', +1 do
       post create_request_comment_path(request_number: reqid), params: 'Slave, can you release it? The master is gone'
       assert_response :success
-      SendEventEmailsJob.new.perform
     end
 
     email = ActionMailer::Base.deliveries.last

--- a/src/api/test/functional/request_events_test.rb
+++ b/src/api/test/functional/request_events_test.rb
@@ -22,13 +22,11 @@ class RequestEventsTest < ActionDispatch::IntegrationTest
 
     Timecop.travel(2013, 8, 20, 12, 0, 0)
     myid = 0
-    SendEventEmailsJob.new.perform
     assert_difference 'ActionMailer::Base.deliveries.size', +1 do
       post '/request?cmd=create',
            params: "<request><action type='add_role'><target project='home:tom'/><person name='Iggy' role='reviewer'/></action></request>"
       assert_response :success
       myid = Xmlhash.parse(@response.body)['id']
-      SendEventEmailsJob.new.perform
     end
 
     email = ActionMailer::Base.deliveries.last
@@ -43,7 +41,6 @@ class RequestEventsTest < ActionDispatch::IntegrationTest
 
     Timecop.travel(2013, 8, 20, 12, 0, 0)
     myid = 0
-    SendEventEmailsJob.new.perform
     assert_difference 'ActionMailer::Base.deliveries.size', +1 do
       body = "<request>\n"
       actions = 1000
@@ -56,7 +53,6 @@ class RequestEventsTest < ActionDispatch::IntegrationTest
       req = Xmlhash.parse(@response.body)
       assert_equal actions, req['action'].count
       myid = req['id']
-      SendEventEmailsJob.new.perform
     end
 
     email = ActionMailer::Base.deliveries.last
@@ -70,12 +66,10 @@ class RequestEventsTest < ActionDispatch::IntegrationTest
 
     Timecop.travel(2013, 8, 20, 12, 0, 0)
     myid = 0
-    SendEventEmailsJob.new.perform
     assert_difference 'ActionMailer::Base.deliveries.size', +1 do
       post '/request?cmd=create', params: "<request><action type='set_bugowner'><target project='home:tom'/><person name='Iggy'/></action></request>"
       assert_response :success
       myid = Xmlhash.parse(@response.body)['id']
-      SendEventEmailsJob.new.perform
     end
 
     email = ActionMailer::Base.deliveries.last
@@ -92,7 +86,6 @@ class RequestEventsTest < ActionDispatch::IntegrationTest
     assert_difference 'ActionMailer::Base.deliveries.size', +1 do
       post "/request/#{myid}?cmd=changestate&newstate=declined", params: ''
       assert_response :success
-      SendEventEmailsJob.new.perform
     end
     email = nil
     ActionMailer::Base.deliveries.each do |m|
@@ -112,14 +105,12 @@ class RequestEventsTest < ActionDispatch::IntegrationTest
 
     Timecop.travel(2013, 8, 20, 12, 0, 0)
     myid = ''
-    SendEventEmailsJob.new.perform
     assert_difference 'ActionMailer::Base.deliveries.size', +1 do
       post '/request?cmd=create',
            params: "<request><action type='add_role'><target project='kde4' package='kdelibs'/><person name='Iggy' role='reviewer'/></action>"\
                    '</request>'
       assert_response :success
       myid = Xmlhash.parse(@response.body)['id']
-      SendEventEmailsJob.new.perform
     end
 
     email = ActionMailer::Base.deliveries.last
@@ -132,12 +123,10 @@ class RequestEventsTest < ActionDispatch::IntegrationTest
 
     Timecop.travel(2013, 8, 20, 12, 0, 0)
     myid = ''
-    SendEventEmailsJob.new.perform
     assert_difference 'ActionMailer::Base.deliveries.size', +1 do
       post '/request?cmd=create', params: "<request><action type='delete'><target project='home:coolo' repository='standard'/></action></request>"
       assert_response :success
       myid = Xmlhash.parse(@response.body)['id']
-      SendEventEmailsJob.new.perform
     end
 
     email = ActionMailer::Base.deliveries.last

--- a/src/api/test/unit/event_mailer_test.rb
+++ b/src/api/test/unit/event_mailer_test.rb
@@ -57,11 +57,10 @@ class EventMailerTest < ActionMailer::TestCase
     req = bs_requests(:submit_from_home_project)
     Timecop.travel(2013, 8, 20, 12, 0, 0)
     myid = req.number
-    SendEventEmailsJob.new.perform # empty queue
+
     assert_difference 'ActionMailer::Base.deliveries.size', +1 do
-      req.addreview(by_group: 'test_group', comment: 'does it look ok?')
-      # trigger the send job
-      SendEventEmailsJob.new.perform
+      event = req.addreview(by_group: 'test_group', comment: 'does it look ok?')
+      SendEventEmailsJob.perform_now(event.id)
     end
 
     email = ActionMailer::Base.deliveries.last


### PR DESCRIPTION
To move the tracking of jobs (if they have been performed yet, or if they have been failed) from the events table to the delayed_jobs gem since that what is already designed for.