### PR TITLE
[webui] Remove public key from EC2 configuration

### DIFF
--- a/src/api/app/views/webui/cloud/ec2/configurations/show.html.haml
+++ b/src/api/app/views/webui/cloud/ec2/configurations/show.html.haml
@@ -2,22 +2,15 @@
   Amazon EC2 Configuration
 
 %p
-  Before the Open Build Service can upload appliances to Amazon EC2, you need to enable some configuration in your AWS Account.
-
-%h2 SSH Key
-%p
-  %ul
-    %li Select the Region you want to upload the image.
-    %li
-      Go to
-      %i
-        Network & Security -> Key Pairs -> Import Key Pair
-      and paste the OBS public key:
-      %pre
-        ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQConqL/iFLOoV5Ts7dXMQ4hGTnv9Cn+Dvalh/JDaQ9lU2TBfdoYIjqkcw1ARiKLbynmZ9ktCX2Nmxi2HCsUYP0S2z+2KbQn2WRWF1Gel5tgwNqaed85bnySg3oPLqI2fVEUdQdCA2P73P/c4/nXkunlZc6PVPQX4Q28xaYvXRfcZS8cNW5Uhxc357uPuNXSsbUIXwRZGwfHi7jBoXOincj+YBdx86+NTAlltIRqXrn3l+Paq2JDm1gLmw9pThhfpzm/eX6BKaODG7sIGVGgOeulgxVimAxsXJDVJtNC20ITU0HrPJjqfQ0pNQj86LKm+2y20JplMw0aEXWVnSD+4ixX
-    %li Make sure that default security group has the permission to SSH into the machine.
+  Amazon EC2 allows you to easily run instances of your appliance on Amazon's webservers.
 
 %h2 Roles and permissions
+%p
+  To upload your appliances to Amazon EC2, the Open Build Service requires permissions to run EC2 instances.
+  This may incur costs,
+  %a{ href: 'https://aws.amazon.com/partners/suse/' }
+    read Amazon's price list
+  for details.
 %p
   %ul
     %li
@@ -53,5 +46,5 @@
     Please enter now the obtained
     %b
       Amazon Resouce Name (ARN):
-    = text_field :ec2_configuration, :arn, value: @ec2_configuration.arn
+    = text_field :ec2_configuration, :arn, value: @ec2_configuration.arn, size: 40
     = submit_tag "Submit"


### PR DESCRIPTION
because ec2uploadimg creates now a temporary key and we do not need require to c&p the key manually anymore.