### PR TITLE
[dist] Provide a way to pass a test as a parameter to the old test suite

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -49,9 +49,13 @@ namespace :docker do
 
     namespace :old do
       desc 'Run our frontend api old test suite in the docker container'
-      task :api do
+      task :api, :test do |_t, args|
         begin
-          sh 'docker-compose -f docker-compose.ci_old.yml up --abort-on-container-exit'
+          if args[:test]
+            sh "docker-compose -f docker-compose.ci_old.yml run --rm --entrypoint '/obs/contrib/start_old_tests #{args[:test]}' old-test-suite"
+          else
+            sh 'docker-compose -f docker-compose.ci_old.yml up --no-recreate --abort-on-container-exit'
+          end
         ensure
           sh 'docker-compose -f docker-compose.ci_old.yml stop'
         end

--- a/contrib/start_old_tests
+++ b/contrib/start_old_tests
@@ -10,6 +10,7 @@ sudo rsync -aq --ignore-missing-args --include-from=- /obs_readonly/ /obs/ <<EOF
 + src/
 + src/api/
 + src/api/app/***
++ src/api/bin/***
 - src/api/config/options.yml
 - src/api/config/database.yml
 + src/api/config/***
@@ -39,4 +40,9 @@ cp config/thinking_sphinx.yml{.example,}
 touch config/test.sphinx.conf
 
 echo "Running api test suite..."
-bundle exec rake test:api
+if [[ -n $1 ]]
+then
+  bin/rails test $1
+else
+  bundle exec rake test:api
+fi


### PR DESCRIPTION
Provide a way to pass a test to the old test suite as a parameter in the rake task. So it will possible to run only the full text search tests with this command:

```
rake docker:test:old:api[test/models/full_text_search_test.rb]
```