### PR TITLE
Update bunny to 2.9.1

### DIFF
--- a/src/api/Gemfile.lock
+++ b/src/api/Gemfile.lock
@@ -63,8 +63,8 @@ GEM
     bullet (5.7.0)
       activesupport (>= 3.0.0)
       uniform_notifier (~> 1.10.0)
-    bunny (2.9.0)
-      amq-protocol (>= 2.2.0)
+    bunny (2.9.1)
+      amq-protocol (~> 2.3.0)
     capybara (2.17.0)
       addressable
       mini_mime (>= 0.1.3)


### PR DESCRIPTION
because depfu is too slow and we already updated it in O:S:U