### PR TITLE
[webui] Remove virtualization type for EC2

### DIFF
--- a/dist/clouduploader.rb
+++ b/dist/clouduploader.rb
@@ -61,7 +61,6 @@ def upload_image_to_ec2(image, credentials, filename, data)
     "--ssh-key-pair=#{KEY_NAME}",
     "--private-key-file=#{PRIVATE_KEY}",
     "--session-token=#{credentials.session_token}",
-    "--virt-type=#{data['virtualization_type']}",
     "--target-filename=#{filename}",
     '--verbose',
     image

--- a/src/api/app/controllers/webui/cloud/upload_jobs_controller.rb
+++ b/src/api/app/controllers/webui/cloud/upload_jobs_controller.rb
@@ -16,7 +16,6 @@ module Webui
         xml_object = OpenStruct.new(params.slice(:project, :package, :repository, :arch, :filename))
         @upload_job = ::Cloud::Backend::UploadJob.new(xml_object: xml_object)
         @ec2_regions = ::Cloud::Ec2::Configuration::REGIONS
-        @ec2_virtualization_types = ::Cloud::Ec2::Configuration::VIRTUALIZATION_TYPES
       end
 
       def create
@@ -60,7 +59,7 @@ module Webui
 
       def permitted_params
         params.require(:cloud_backend_upload_job).permit(
-          :project, :package, :repository, :arch, :filename, :region, :virtualization_type, :ami_name, :target
+          :project, :package, :repository, :arch, :filename, :region, :ami_name, :target
         )
       end
 

--- a/src/api/app/models/cloud/ec2/configuration.rb
+++ b/src/api/app/models/cloud/ec2/configuration.rb
@@ -19,11 +19,6 @@ module Cloud
         ['South America (São Paulo)', 'sa-east-1']
       ].freeze
 
-      VIRTUALIZATION_TYPES = [
-        ['HVM', 'hvm'],
-        ['PV', 'pv']
-      ].freeze
-
       has_secure_token :external_id
       belongs_to :user, required: true
 

--- a/src/api/app/models/cloud/params/ec2.rb
+++ b/src/api/app/models/cloud/params/ec2.rb
@@ -4,18 +4,15 @@ module Cloud
       include ActiveModel::Validations
       include ActiveModel::Model
 
-      attr_accessor :region, :virtualization_type, :ami_name
+      attr_accessor :region, :ami_name
       validates :region, presence: true, inclusion: {
         in: ::Cloud::Ec2::Configuration::REGIONS.map(&:second), message: "'%{value}' is not a valid EC2 region"
-      }
-      validates :virtualization_type, inclusion: {
-        in: ::Cloud::Ec2::Configuration::VIRTUALIZATION_TYPES.map(&:second), message: "'%{value}' is not a valid EC2 virtualization type"
       }
       validates :ami_name, presence: true, length: { maximum: 100 }
       validate :valid_ami_name
 
       def self.build(params)
-        new(params.slice(:region, :virtualization_type, :ami_name))
+        new(params.slice(:region, :ami_name))
       end
 
       private

--- a/src/api/app/views/webui/cloud/upload_jobs/new.html.haml
+++ b/src/api/app/views/webui/cloud/upload_jobs/new.html.haml
@@ -23,9 +23,6 @@
     = upload_job_form.label 'cloud_backend_upload_job[region]', "Region:"
     = select_tag('cloud_backend_upload_job[region]', options_for_select(@ec2_regions))
   %p
-    = upload_job_form.label 'cloud_backend_upload_job[virtualization_type]', "Virtualization Type:"
-    = select_tag('cloud_backend_upload_job[virtualization_type]', options_for_select(@ec2_virtualization_types))
-  %p
     = upload_job_form.hidden_field :project
     = upload_job_form.hidden_field :package
     = upload_job_form.hidden_field :arch

--- a/src/api/lib/backend/api/cloud.rb
+++ b/src/api/lib/backend/api/cloud.rb
@@ -5,9 +5,9 @@ module Backend
       # Triggers a cloud upload job
       # @return [String]
       def self.upload(params)
-        data = params.slice(:region, :virtualization_type, :ami_name)
+        data = params.slice(:region, :ami_name)
         user = params[:user]
-        params = params.except(:region, :virtualization_type, :ami_name).merge(user: user.login, target: params[:target])
+        params = params.except(:region, :ami_name).merge(user: user.login, target: params[:target])
         data = user.ec2_configuration.attributes.except('id', 'created_at', 'updated_at').merge(data).to_json
         post('/cloudupload', params: params, data: data)
       end

--- a/src/api/spec/controllers/webui/cloud/upload_jobs_controller_spec.rb
+++ b/src/api/spec/controllers/webui/cloud/upload_jobs_controller_spec.rb
@@ -128,15 +128,14 @@ RSpec.describe Webui::Cloud::UploadJobsController, type: :controller, vcr: true 
   describe 'POST #create' do
     let(:params) do
       {
-        project:             'Cloud',
-        package:             'aws',
-        repository:          'standard',
-        arch:                'x86_64',
-        filename:            'appliance.raw.xz',
-        region:              'us-east-1',
-        virtualization_type: 'hvm',
-        ami_name:            'my-image',
-        target:              'ec2'
+        project:    'Cloud',
+        package:    'aws',
+        repository: 'standard',
+        arch:       'x86_64',
+        filename:   'appliance.raw.xz',
+        region:     'us-east-1',
+        ami_name:   'my-image',
+        target:     'ec2'
       }
     end
 
@@ -174,14 +173,6 @@ RSpec.describe Webui::Cloud::UploadJobsController, type: :controller, vcr: true 
         include_context 'it redirects and assigns flash error'
       end
 
-      context 'with an invalid virtualization type' do
-        subject { 'kvm' }
-        before do
-          params[:virtualization_type] = subject
-        end
-        include_context 'it redirects and assigns flash error'
-      end
-
       context 'with an invalid ami_name' do
         subject { 'lorem ipsum' }
         before do
@@ -202,13 +193,12 @@ RSpec.describe Webui::Cloud::UploadJobsController, type: :controller, vcr: true 
     context 'with a backend response' do
       let(:path) { "#{CONFIG['source_url']}/cloudupload?#{backend_params.to_param}" }
       let(:backend_params) do
-        params.merge(target: 'ec2', user: user_with_ec2_configuration.login).except(:region, :virtualization_type, :ami_name)
+        params.merge(target: 'ec2', user: user_with_ec2_configuration.login).except(:region, :ami_name)
       end
       let(:additional_data) do
         {
-          region:              'us-east-1',
-          virtualization_type: 'hvm',
-          ami_name:            'my-image'
+          region:   'us-east-1',
+          ami_name: 'my-image'
         }
       end
       let(:post_body) do

--- a/src/api/spec/models/cloud/backend/upload_job_spec.rb
+++ b/src/api/spec/models/cloud/backend/upload_job_spec.rb
@@ -8,16 +8,15 @@ RSpec.describe Cloud::Backend::UploadJob, type: :model, vcr: true do
   describe '.create' do
     let(:params) do
       {
-        project:             'Cloud',
-        package:             'aws',
-        repository:          'standard',
-        arch:                'x86_64',
-        filename:            'appliance.raw.gz',
-        region:              'us-east-1',
-        user:                user,
-        target:              'ec2',
-        virtualization_type: 'hvm',
-        ami_name:            'myami'
+        project:    'Cloud',
+        package:    'aws',
+        repository: 'standard',
+        arch:       'x86_64',
+        filename:   'appliance.raw.gz',
+        region:     'us-east-1',
+        user:       user,
+        target:     'ec2',
+        ami_name:   'myami'
       }
     end
     let(:xml_response) do
@@ -38,11 +37,11 @@ RSpec.describe Cloud::Backend::UploadJob, type: :model, vcr: true do
       HEREDOC
     end
     let(:backend_params) do
-      params.except(:region, :virtualization_type, :ami_name)
+      params.except(:region, :ami_name)
     end
     let(:post_body) do
       user.ec2_configuration.attributes.except('id', 'created_at', 'updated_at').
-        merge(region: 'us-east-1', virtualization_type: 'hvm', ami_name: 'myami').to_json
+        merge(region: 'us-east-1', ami_name: 'myami').to_json
     end
     let(:path) { "#{CONFIG['source_url']}/cloudupload?#{backend_params.to_param}" }
 

--- a/src/api/spec/models/cloud/params/ec2.rb
+++ b/src/api/spec/models/cloud/params/ec2.rb
@@ -2,7 +2,6 @@ require 'rails_helper'
 
 RSpec.describe Cloud::Params::Ec2, type: :model, vcr: true do
   describe 'validations' do
-    it { is_expected.to validate_inclusion_of(:virtualization_type).in_array(['hvm', 'pv']) }
     it { is_expected.to validate_presence_of :region }
     it { is_expected.to validate_presence_of :ami_name }
     it { is_expected.to allow_value('foo.raw.xz').for(:ami_name) }

--- a/src/api/spec/models/cloud/upload_job_spec.rb
+++ b/src/api/spec/models/cloud/upload_job_spec.rb
@@ -4,16 +4,15 @@ RSpec.describe Cloud::UploadJob, type: :model, vcr: true do
   let(:user) { create(:confirmed_user, login: 'tom', ec2_configuration: create(:ec2_configuration)) }
   let(:params) do
     {
-      project:             'Cloud',
-      package:             'aws',
-      repository:          'standard',
-      arch:                'x86_64',
-      filename:            'appliance.raw.xz',
-      region:              'us-east-1',
-      virtualization_type: 'hvm',
-      ami_name:            'my-image',
-      user:                user,
-      target:              'ec2'
+      project:    'Cloud',
+      package:    'aws',
+      repository: 'standard',
+      arch:       'x86_64',
+      filename:   'appliance.raw.xz',
+      region:     'us-east-1',
+      ami_name:   'my-image',
+      user:       user,
+      target:     'ec2'
     }
   end
   let(:response) do


### PR DESCRIPTION
because we are not supposed to support PV type, we focus on HVM (after talking with public cloud team).