### PR TITLE
[backend] Remove key options from ec2uploadimg call

### DIFF
--- a/dist/clouduploader.rb
+++ b/dist/clouduploader.rb
@@ -4,7 +4,7 @@ require 'ostruct'
 require 'open3'
 
 start = Time.now
-ONE_HOUR = 3600
+THIRTY_MINUTES = 1800
 HOME = '/etc/obs/cloudupload'.freeze
 ENV['HOME'] = HOME
 ENV['PYTHONUNBUFFERED'] = '1'
@@ -29,7 +29,7 @@ def get_ec2_credentials(data)
     "--role-arn=#{data['arn']}",
     "--external-id=#{data['external_id']}",
     '--role-session-name=obs',
-    "--duration-seconds=#{ONE_HOUR}"
+    "--duration-seconds=#{THIRTY_MINUTES}"
   )
 
   if status.success?

--- a/dist/clouduploader.rb
+++ b/dist/clouduploader.rb
@@ -65,6 +65,8 @@ def upload_image_to_ec2(image, credentials, filename, data)
     while line = stdout_stderr.gets
       STDOUT.write(line)
     end
+    status = wait_thr.value
+    abort unless status.success?
   end
 end
 

--- a/dist/clouduploader.rb
+++ b/dist/clouduploader.rb
@@ -5,8 +5,6 @@ require 'open3'
 
 start = Time.now
 ONE_HOUR = 3600
-KEY_NAME = 'obs'.freeze
-PRIVATE_KEY = '/etc/clouduploader.pem'.freeze
 HOME = '/etc/obs/cloudupload'.freeze
 ENV['HOME'] = HOME
 ENV['PYTHONUNBUFFERED'] = '1'
@@ -58,8 +56,6 @@ def upload_image_to_ec2(image, credentials, filename, data)
     "--region=#{data['region']}",
     "--secret-key=#{credentials.secret_access_key}",
     "--access-id=#{credentials.access_key_id}",
-    "--ssh-key-pair=#{KEY_NAME}",
-    "--private-key-file=#{PRIVATE_KEY}",
     "--session-token=#{credentials.session_token}",
     "--virt-type=#{data['virtualization_type']}",
     "--target-filename=#{filename}",


### PR DESCRIPTION
because we use now a temporary SSH key.