### PR TITLE
[frontend] Downgrade bunny to version 2.8.0

### DIFF
--- a/src/api/Gemfile
+++ b/src/api/Gemfile
@@ -69,7 +69,7 @@ gem 'peek-mysql2'
 # for kerberos authentication
 gem 'gssapi', require: false
 # for sending events to rabbitmq
-gem 'bunny'
+gem 'bunny', '= 2.8.0'
 # for making changes to existing data
 gem 'data_migrate', '= 3.2.2'
 # for URI encoding

--- a/src/api/Gemfile.lock
+++ b/src/api/Gemfile.lock
@@ -63,7 +63,7 @@ GEM
     bullet (5.7.0)
       activesupport (>= 3.0.0)
       uniform_notifier (~> 1.10.0)
-    bunny (2.9.0)
+    bunny (2.8.0)
       amq-protocol (>= 2.2.0)
     capybara (2.17.0)
       addressable
@@ -427,7 +427,7 @@ DEPENDENCIES
   bcrypt
   bullet
   bundler
-  bunny
+  bunny (= 2.8.0)
   capybara
   capybara_minitest_spec
   chunky_png


### PR DESCRIPTION
With the last deployment sending to rabbitmq broke and caused errors
("No CA certificates found, add one with :tls_ca_certificates").

We checked the certificate setup together with Adrian and they seem to
be fine. Given that, and that the issue started with the last
deployment, it seems likely that the recent bunndy update to version
2.9.0 caused the issue.

That's why we downgrade the package for now until we found the root
cause.

Mob-programming with @DavidKang, @mdeniz