### PR TITLE
[frontend] Update bunny to 2.9.1

### DIFF
--- a/src/api/Gemfile
+++ b/src/api/Gemfile
@@ -69,7 +69,7 @@ gem 'peek-mysql2'
 # for kerberos authentication
 gem 'gssapi', require: false
 # for sending events to rabbitmq
-gem 'bunny', '= 2.8.0'
+gem 'bunny'
 # for making changes to existing data
 gem 'data_migrate', '= 3.2.2'
 # for URI encoding

--- a/src/api/Gemfile.lock
+++ b/src/api/Gemfile.lock
@@ -63,8 +63,8 @@ GEM
     bullet (5.7.0)
       activesupport (>= 3.0.0)
       uniform_notifier (~> 1.10.0)
-    bunny (2.8.0)
-      amq-protocol (>= 2.2.0)
+    bunny (2.9.1)
+      amq-protocol (~> 2.3.0)
     capybara (2.17.0)
       addressable
       mini_mime (>= 0.1.3)
@@ -427,7 +427,7 @@ DEPENDENCIES
   bcrypt
   bullet
   bundler
-  bunny (= 2.8.0)
+  bunny
   capybara
   capybara_minitest_spec
   chunky_png


### PR DESCRIPTION
because depfu is too slow.

This applies a bugfix for bunny which was causing any connection to
rabbitmq to fail (see PR#4362)-

Related bunny issue / PR:
  https://github.com/ruby-amqp/bunny/issues/539
  https://github.com/ruby-amqp/bunny/pull/540