### PR TITLE
[webui][api] Email admins if jobs queue reaches limit.

### DIFF
--- a/ReleaseNotes-2.9
+++ b/ReleaseNotes-2.9
@@ -50,6 +50,7 @@ UI:
 API:
  * Kerberos authentication mode
  * api_relative_url_root option was removed
+ * An error is raised if delayed_jobs is down
 
 Backend:
  * support showing source files in blame view (works also via links)

--- a/dist/Makefile
+++ b/dist/Makefile
@@ -49,6 +49,7 @@ install_obs_bin: system_dirs
 
 install_crontabs:
 	$(INSTALL) -m 644 cleanup_scm_cache.cron $(DESTDIR)/etc/cron.d/cleanup_scm_cache
+	$(INSTALL) -m 644 obs_api_delayed_jobs_monitor.cron $(DESTDIR)/etc/cron.d/obs_api_delayed_jobs_monitor
 
 system_dirs:
 	$(INSTALL) -d -m 755 $(DESTDIR)$(OBS_BACKEND_PREFIX)

--- a/dist/obs-server.spec
+++ b/dist/obs-server.spec
@@ -385,7 +385,7 @@ make -C src/backend test
 make -C src/api test
 %endif
 
-#### 
+####
 # distribution tests
 %if 0%{?disable_obs_dist_test_suite:1} < 1
 make -C dist test
@@ -592,6 +592,7 @@ usermod -a -G docker obsservicerun
 /srv/www/obs/overview
 
 /srv/www/obs/api/config/thinking_sphinx.yml.example
+/etc/cron.d/obs_api_delayed_jobs_monitor
 %config(noreplace) /srv/www/obs/api/config/thinking_sphinx.yml
 %attr(-,%{apache_user},%{apache_group}) %config(noreplace) /srv/www/obs/api/config/production.sphinx.conf
 
@@ -711,10 +712,10 @@ Requires:       docker-distribution-registry
 
 %description -n obs-container-registry
 The OBS Container Registry, based on the docker registry, which allows
-    
+
 * anonymous pulls from anywhere
 * anonymous pushes from localhost.
-    
+
 This is done by proxying access to the registry through
 apache and restricting any other http method than GET and HEAD
 to localhost.

--- a/dist/obs_api_delayed_jobs_monitor.cron
+++ b/dist/obs_api_delayed_jobs_monitor.cron
@@ -1,0 +1,1 @@
+*/10 * * * * /usr/bin/bundle.ruby2.4 exec /srv/www/obs/api/script/delayed_job_monitor.rb > /dev/null

--- a/src/api/script/delayed_job_monitor.rb
+++ b/src/api/script/delayed_job_monitor.rb
@@ -1,0 +1,6 @@
+#!/usr/bin/env ruby.ruby2.4
+require File.expand_path(File.join(File.dirname(__FILE__), '..', 'config', 'environment'))
+
+output = %x(service obsapidelayed status | grep "active")
+
+raise StandardError, 'obsapidelayed service is down!' if output.blank?


### PR DESCRIPTION
Send an email to the admin if the number of jobs in the queue reaches the
limit defined in options.yml. DelayedJob slows down signficantly the more
jobs there are in the queue so its important we dont them pile up if
delayed job workers are not running for some reason.