### PR TITLE
Ask if User.current is nil

### DIFF
--- a/src/api/app/models/bs_request_action.rb
+++ b/src/api/app/models/bs_request_action.rb
@@ -902,7 +902,7 @@ class BsRequestAction < ApplicationRecord
         # the target, the request creator (who must have permissions to read source)
         # wanted the target owner to review it
         tprj = Project.find_by_name(target_project)
-        if tprj.nil? || !User.current.can_modify_project?(tprj)
+        if tprj.nil? || User.current.nil? || !User.current.can_modify_project?(tprj)
           # produce an error for the source
           Package.get_by_project_and_name(source_project, source_package)
         end


### PR DESCRIPTION
When delayed job is checking access permissions, the user is not logged, so User.current will always be `nil`. This is a workaround, we should find a better way to handle this.