### PR TITLE
[frontend] Fix default subscription switch

### DIFF
--- a/src/api/app/assets/javascripts/webui/application.js.erb
+++ b/src/api/app/assets/javascripts/webui/application.js.erb
@@ -272,11 +272,6 @@ $(document).on('click','.close-dialog', function() {
   }
 });
 
-$(document).on('click', 'a[data-clear-checkboxes]', function(event) {
-  event.preventDefault();
-  $('input:checkbox').prop('checked', false);
-});
-
 // show/hide functionality for text
 $(function() {
   $('.show-hide').on('click', function() {

--- a/src/api/app/controllers/webui/subscriptions_controller.rb
+++ b/src/api/app/controllers/webui/subscriptions_controller.rb
@@ -17,6 +17,6 @@ class Webui::SubscriptionsController < Webui::WebuiController
   private
 
   def subscriptions_form
-    EventSubscription::Form.new(nil)
+    EventSubscription::Form.new
   end
 end

--- a/src/api/app/controllers/webui/users/subscriptions_controller.rb
+++ b/src/api/app/controllers/webui/users/subscriptions_controller.rb
@@ -5,7 +5,12 @@ class Webui::Users::SubscriptionsController < Webui::WebuiController
     @user = User.current
     @groups_users = User.current.groups_users
 
-    @subscriptions_form = subscriptions_form
+    @subscriptions_form = subscriptions_form(default_form: params[:default_form])
+
+    respond_to do |format|
+      format.html
+      format.js
+    end
   end
 
   def update
@@ -24,7 +29,11 @@ class Webui::Users::SubscriptionsController < Webui::WebuiController
 
   private
 
-  def subscriptions_form
-    EventSubscription::Form.new(User.current)
+  def subscriptions_form(options = {})
+    if options[:default_form]
+      EventSubscription::Form.new
+    else
+      EventSubscription::Form.new(User.current)
+    end
   end
 end

--- a/src/api/app/models/event_subscription/form.rb
+++ b/src/api/app/models/event_subscription/form.rb
@@ -2,7 +2,7 @@ class EventSubscription
   class Form
     attr_reader :subscriber
 
-    def initialize(subscriber)
+    def initialize(subscriber = nil)
       @subscriber = subscriber
     end
 

--- a/src/api/app/views/webui/users/subscriptions/index.html.haml
+++ b/src/api/app/views/webui/users/subscriptions/index.html.haml
@@ -18,10 +18,11 @@
 
     %h3 Events
     %p.description Choose from which events you want to get an email
-    = render partial: 'webui/subscriptions/subscriptions_form'
+    #subscriptions-form
+      = render partial: 'webui/subscriptions/subscriptions_form'
     %p
       = submit_tag 'Update'
-      = link_to('Reset to default', '#', data: { 'clear-checkboxes': true })
+      = link_to('Reset to default', user_notifications_path(default_form: true), remote: true)
 .grid_16.alpha.omega.box.box-shadow
   %h2 RSS Feed
   = form_tag(user_rss_token_path, id: 'generate_rss_token_form', method: :post) do

--- a/src/api/app/views/webui/users/subscriptions/index.js.erb
+++ b/src/api/app/views/webui/users/subscriptions/index.js.erb
@@ -1,0 +1,2 @@
+$('#subscriptions-form').replaceWith('<%= escape_javascript(render(partial: 'webui/subscriptions/subscriptions_form')) %>');
+


### PR DESCRIPTION
PR#4336 added a switch that allows users to reset their notification
subscription to default. This was hardcoded to clear all subscriptions.

With this commit the default subscription settings are retrieved from
the server via ajax and properly set in the ui.
The user can then decide to save the new settings or cancel it by
reloading the page.