### PR TITLE
[webui] Create comments via ajax requests

### DIFF
--- a/src/api/app/assets/javascripts/webui/application/comment.js
+++ b/src/api/app/assets/javascripts/webui/application/comment.js
@@ -10,7 +10,7 @@ function sz(t) {
     if (b > t.rows) t.rows = b;
 }
 
-$(document).ready(function(){
+function reloadCommentBindings() {
     $('a.delete_link').on('ajax:success', function(event, data, status, xhr){
         $('#flash-messages').remove();
         $(data.flash).filter('#flash-messages').insertAfter('#subheader').fadeIn('slow');
@@ -34,4 +34,15 @@ $(document).ready(function(){
   $('.comment_new').submit(function() {
       $(this).find('input[type="submit"]').prop('disabled', true);
   });
+
+  $('.comment_new').on('ajax:complete', function(event, data, status, xhr) {
+    $('#comments').html(data.responseText);
+
+    // as the comments get loaded again, the jQuery bindings are lost. We need to reload them.
+    reloadCommentBindings();
+  });
+}
+
+$(document).ready(function(){
+  reloadCommentBindings();
 });

--- a/src/api/app/controllers/webui/comments_controller.rb
+++ b/src/api/app/controllers/webui/comments_controller.rb
@@ -6,10 +6,14 @@ class Webui::CommentsController < Webui::WebuiController
     comment = @commented.comments.new(permitted_params)
     User.current.comments << comment
 
+    # required for the form construction
+    @comment = Comment.new
+
     respond_to do |format|
       if comment.save
         format.html { redirect_back(fallback_location: root_path, notice: 'Comment was successfully created.') }
         format.json { render json: 'ok' }
+        format.js { render partial: 'webui/comment/show', locals: { commentable: comment.commentable }, status: :ok }
       else
         format.html { redirect_back(fallback_location: root_path, error: "Comment can't be saved: #{comment.errors.full_messages.to_sentence}.") }
         format.json { render json: comment.errors, status: :unprocessable_entity }

--- a/src/api/app/views/webui/comment/_new.html.haml
+++ b/src/api/app/views/webui/comment/_new.html.haml
@@ -1,5 +1,5 @@
 - unless User.current.is_nobody?
-  = form_for @comment, method: :post do |f|
+  = form_for @comment, method: :post, remote: true do |f|
     = hidden_field_tag :commentable_type, commentable.class
     = hidden_field_tag :commentable_id, commentable.id
     ~ f.text_area :body, size: '80x4', onkeyup: 'sz(this);', onclick: 'sz(this);', placeholder: 'Add a new comment (markdown markup supported)', required: 'required'

--- a/src/api/app/views/webui/comment/_reply.html.haml
+++ b/src/api/app/views/webui/comment/_reply.html.haml
@@ -1,5 +1,5 @@
 .comment_new.hidden{id: "reply_form_of_#{comment.id}"}
-  = form_for @comment, method: :post do |f|
+  = form_for @comment, method: :post, remote: true do |f|
     %p
       = hidden_field_tag :commentable_type, commentable.class
       = hidden_field_tag :commentable_id, commentable.id

--- a/src/api/app/views/webui/package/show.html.erb
+++ b/src/api/app/views/webui/package/show.html.erb
@@ -176,7 +176,9 @@
 
 <div class="grid_16 box box-shadow alpha omega">
   <h2 class="box-header">Comments for <%= @project.name %> (<%= @comments.length %>)</h2>
-  <%= render :partial => 'webui/comment/show', locals: { commentable: @package } %>
+  <div id="comments">
+    <%= render :partial => 'webui/comment/show', locals: { commentable: @package } %>
+  </div>
 </div>
 
 <%= render partial: 'webui/package/branch_dialog' %>

--- a/src/api/app/views/webui/project/show.html.erb
+++ b/src/api/app/views/webui/project/show.html.erb
@@ -182,5 +182,7 @@
 </div>
 <div class="grid_16 box box-shadow alpha omega">
   <h2 class="box-header">Comments for <%= @project.name %> (<%= @comments.length %>)</h2>
-  <%= render partial: 'webui/comment/show', locals: { commentable: @project } %>
+  <div id="comments">
+    <%= render partial: 'webui/comment/show', locals: { commentable: @project } %>
+  </div>
 </div>

--- a/src/api/app/views/webui/request/show.html.erb
+++ b/src/api/app/views/webui/request/show.html.erb
@@ -232,7 +232,9 @@
 
     <div class="grid_10 box box-shadow alpha omega">
       <h2 class="box-header">Comments for request <%= @number %> (<%= @comments.length %>)</h2>
-      <%= render :partial => 'webui/comment/show', locals: { commentable: @bs_request } %>
+      <div id="comments">
+        <%= render :partial => 'webui/comment/show', locals: { commentable: @bs_request } %>
+      </div>
     </div>
 
     <div class="grid_10 alpha">

--- a/src/api/spec/features/webui/comments_spec.rb
+++ b/src/api/spec/features/webui/comments_spec.rb
@@ -9,7 +9,6 @@ RSpec.feature 'Comments', type: :feature, js: true do
     fill_in 'comment_body', with: 'Comment Body'
     find_button('Add comment').click
 
-    expect(page).to have_css('#flash-messages', text: 'Comment was successfully created.')
     expect(page).to have_text('Comment Body')
   end
 
@@ -22,7 +21,6 @@ RSpec.feature 'Comments', type: :feature, js: true do
     fill_in "reply_body_#{comment.id}", with: 'Reply Body'
     click_button("add_reply_#{comment.id}")
 
-    expect(page).to have_css('#flash-messages', text: 'Comment was successfully created.')
     expect(page).to have_text('Reply Body')
   end
 end


### PR DESCRIPTION
Comments will now be created via Ajax requests. The comment section is
reloaded every time, when a new comment has been added by the user.

Affects:
* Requests
* Packages
* Projects