### PR TITLE
Remove some rubygem dependencies not needed

### DIFF
--- a/dist/obs-server.spec
+++ b/dist/obs-server.spec
@@ -210,9 +210,6 @@ Requires:       apache2 apache2-mod_xforward rubygem-passenger-apache2 ruby2.4-r
 Requires:       memcached
 Conflicts:      memcached < 1.4
 
-# For local runs
-BuildRequires:  rubygem(sqlite3)
-
 Requires:       mysql
 
 Requires:       ruby(abi) >= 2.0
@@ -228,7 +225,6 @@ BuildRequires:  curl
 BuildRequires:  memcached >= 1.4
 BuildRequires:  mysql
 BuildRequires:  netcfg
-BuildRequires:  rubygem(ci_reporter)
 BuildRequires:  xorg-x11-Xvnc
 BuildRequires:  xorg-x11-server
 BuildRequires:  xorg-x11-server-extra

--- a/src/api/Gemfile
+++ b/src/api/Gemfile
@@ -42,8 +42,6 @@ gem 'pundit'
 gem 'bcrypt'
 #
 gem 'responders', '~> 2.0'
-# needed for travis-ci.org, must be global for scripts
-gem 'bundler'
 # for threaded comments
 gem 'acts_as_tree'
 # js plotting (OBS monitor)

--- a/src/api/Gemfile.lock
+++ b/src/api/Gemfile.lock
@@ -426,7 +426,6 @@ DEPENDENCIES
   annotate
   bcrypt
   bullet
-  bundler
   bunny
   capybara
   capybara_minitest_spec

--- a/src/api/script/rubygem_package_names.rb
+++ b/src/api/script/rubygem_package_names.rb
@@ -16,7 +16,7 @@ require 'bundler'
 # rubygem-phantomjs
 # rubygem-phantomjs-2_2
 
-Bundler.definition.specs_for([:default, :production, :assets]).any? do |s|
+Bundler.definition.resolve.any? do |s|
   min_version = s.version.to_s.split(/\./)[0..1].join('_')
   print "rubygem-#{s.name} rubygem-#{s.name}-#{min_version} "
 end


### PR DESCRIPTION
- `sqlite3` and `ci_reporter` gems are not needed anymore, so they get removed from the `obs-server.spec` file.
- `bundler` is already required in the `obs-server.spec` file, so is not needed in `Gemfile` anymore.
- Modify the script `rubygem_package_names.rb` to retrieve all the names of the rubygem dependencies, not only those in production mode.
