### PR TITLE
[webui] Bugfix: Validation error on AWS ARN

### DIFF
--- a/src/api/app/models/cloud/ec2/configuration.rb
+++ b/src/api/app/models/cloud/ec2/configuration.rb
@@ -22,7 +22,8 @@ module Cloud
       has_secure_token :external_id
       belongs_to :user, required: true
 
-      validates :external_id, :arn, uniqueness: true
+      validates :external_id, uniqueness: true
+      validates :arn, uniqueness: true, allow_nil: true
       # http://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html
       validates :arn, format: { with: /\Aarn:([\w\-\/:])+\z/, message: 'not a valid format', allow_blank: true }
 


### PR DESCRIPTION
The default for the `arn` column is `NULL`. This would mean if one user gets an ec2 configuration and doesn't set an `arn`, no more users can get an ec2 configuration because the default value `NULL` is treated as an actual value and has to be unique.

```
irb(main):006:0> User.current.create_ec2_configuration.errors
   (0.2ms)  BEGIN
  Cloud::Ec2::Configuration Exists (0.2ms)  SELECT  1 AS one FROM `cloud_ec2_configurations` WHERE `cloud_ec2_configurations`.`external_id` IS NULL LIMIT 1
  Cloud::Ec2::Configuration Exists (0.2ms)  SELECT  1 AS one FROM `cloud_ec2_configurations` WHERE `cloud_ec2_configurations`.`arn` IS NULL LIMIT 1
   (0.1ms)  ROLLBACK
   (0.1ms)  BEGIN
   (0.1ms)  COMMIT
=> #<ActiveModel::Errors:0x0000000006cb9520 @base=#<Cloud::Ec2::Configuration id: nil, user_id: 15, external_id: nil, arn: nil, created_at: nil, updated_at: nil>, @messages={:arn=>["has already been taken"]}, @details={:arn=>[{:error=>:taken, :value=>nil}]}>

```

Fixes #4393