### PR TITLE
[dist] Create file if it doesn't exist

### DIFF
--- a/dist/schedule-obs.sh
+++ b/dist/schedule-obs.sh
@@ -7,10 +7,11 @@ function trigger_run {
   OBS_VERSION="$1"
   FULL_URL="http://download.opensuse.org/repositories/OBS:/$2/"
   filename=`curl -s $FULL_URL | grep "obs-server.x86_64-.*qcow2" | head -n1 | sed -e 's,.*href=",,; s,".*,,; s,\.mirrorlist,,'`
-  ofilename=`cat /tmp/.last.obs_$OBS_VERSION`
+  last_obs_filename="/tmp/.last.obs_$OBS_VERSION"
+  ofilename=`cat $last_obs_filename || touch $last_obs_filename`
   if test "x$ofilename" != "x$filename"; then
     /usr/share/openqa/script/client isos post --host https://openqa.opensuse.org HDD_1_URL=$FULL_URL$filename DISTRI=obs ARCH=x86_64 VERSION=$OBS_VERSION BUILD=`echo $filename | sed -e 's,obs-server.x86_64-,,; s,Build,,; s,\.qcow2,,'` FLAVOR=Appliance > /dev/null
-    echo $filename > /tmp/.last.obs_$OBS_VERSION
+    echo $filename > $last_obs_filename
   fi
 }
 


### PR DESCRIPTION
- Prevents the script from exit if the file that contains the last build checked doesn't exist. This happens with the addition of a new version.
- Use a variable to refer to the last.obs_version file.