### PR TITLE
[webui][api] Do not call SendEventEmailsJob if id not present.

### DIFF
--- a/src/api/app/models/event/base.rb
+++ b/src/api/app/models/event/base.rb
@@ -171,7 +171,7 @@ module Event
     end
 
     def send_event_emails_job
-      SendEventEmailsJob.perform_later(id)
+      SendEventEmailsJob.perform_later(id) if id.present?
     end
 
     # to be overwritten in subclasses


### PR DESCRIPTION
Because we are getting occasional errors from SendEventEmailsJob
being called with no arguments, so I think this will fix it.

https://errbit-opensuse.herokuapp.com/apps/5620ca2bdc71fa00b1000000/problems/5a6741b6c5e14a000e61a8d9