### PR TITLE
[api] Update _multibuild syntax

### DIFF
--- a/ReleaseNotes-2.9
+++ b/ReleaseNotes-2.9
@@ -90,6 +90,9 @@ Wanted changes:
    The RabbitMQ plugin is replaced with a RabbitMQ message bus implementation in the frontend, you can find details about this in the admin manual.
    The Hermes plugin is dropped without replacement as it was only used for notifications which the OBS is doing on it's own since quite some time.
 
+ * _multibuild files have a changed syntax, but OBS stays backward compatible.
+   Use <flavor> instead of <package> elements in future.
+
 Other changes
 =============
 

--- a/docs/api/api/multibuild.rng
+++ b/docs/api/api/multibuild.rng
@@ -9,12 +9,20 @@
     <element>
       <name ns="">multibuild</name>
 
-      <oneOrMore>
-        <element>
-          <name ns="">package</name>
-          <text/>
-        </element>
-      </oneOrMore>
+      <choice>
+        <oneOrMore>
+          <element>
+            <name ns="">flavor</name>
+            <text/>
+          </element>
+        </oneOrMore>
+        <oneOrMore> <!-- obsolete, but needs to stay for compability -->
+          <element>
+            <name ns="">package</name>
+            <text/>
+          </element>
+        </oneOrMore>
+      </choice>
 
     </element>
   </define>

--- a/docs/api/api/multibuild.xml
+++ b/docs/api/api/multibuild.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <multibuild>
-    <package>gcc</package>
-    <package>gcc-testsuite</package>
+    <flavor>gcc</flavor>
+    <flavor>gcc-testsuite</flavor>
 </multibuild>

--- a/src/api/app/models/package.rb
+++ b/src/api/app/models/package.rb
@@ -1321,7 +1321,7 @@ class Package < ApplicationRecord
     content = File.open(content.path).read if content.is_a?(ActionDispatch::Http::UploadedFile)
 
     # schema validation, if possible
-    ['aggregate', 'constraints', 'link', 'service', 'patchinfo', 'channel'].each do |schema|
+    ['aggregate', 'constraints', 'link', 'service', 'patchinfo', 'channel', 'multibuild'].each do |schema|
       Suse::Validator.validate(schema, content) if name == '_' + schema
     end
 

--- a/src/api/script/start_test_backend
+++ b/src/api/script/start_test_backend
@@ -253,7 +253,7 @@ Backend::Connection.put('/source/BaseDistro2.0/pack2.linked/_link?user=king', "<
 Backend::Connection.put('/source/BaseDistro2.0:LinkedUpdateProject/_config?user=king', 'cicntstart: 42.1')
 Backend::Connection.put('/source/BaseDistro3/_config?user=king', "Type: spec\nRepotype: rpm-md suse")
 Backend::Connection.put('/source/BaseDistro3/pack2/pack2.spec?user=king', File.open("#{Rails.root}/test/fixtures/backend/binary/package.spec").read)
-Backend::Connection.put('/source/BaseDistro3/pack2/_multibuild?user=king', '<multibuild><package>package_multibuild</package></multibuild>')
+Backend::Connection.put('/source/BaseDistro3/pack2/_multibuild?user=king', '<multibuild><flavor>package_multibuild</flavor></multibuild>')
 Backend::Connection.put('/source/BaseDistro3/pack2/package_multibuild.spec?user=king',
                         File.open("#{Rails.root}/test/fixtures/backend/binary/package.spec").read)
 Backend::Connection.put('/source/BaseDistro:Update/pack2/_link?user=king', '<link project="BaseDistro" package="pack2" />')

--- a/src/api/test/functional/channel_maintenance_test.rb
+++ b/src/api/test/functional/channel_maintenance_test.rb
@@ -101,15 +101,15 @@ class ChannelMaintenanceTests < ActionDispatch::IntegrationTest
     post "/request/#{id1}?cmd=diff&view=xml"
     assert_response :success
     # the diffed packages
-    assert_xml_tag(tag: 'old', attributes: { project: 'BaseDistro3', package: 'pack2', srcmd5: 'eb6705ddf47af932b8332e16ab2ed8b3' })
-    assert_xml_tag(tag: 'new', attributes: { project: 'home:tom:branches:OBS_Maintained:pack2', package: 'pack2.BaseDistro3', rev: '7da33eb2a263a2f91d019a42eb28dae9', srcmd5: '7da33eb2a263a2f91d019a42eb28dae9' })
+    assert_xml_tag(tag: 'old', attributes: { project: 'BaseDistro3', package: 'pack2', srcmd5: 'c3f6b2ae46cbc4cfb495774733c842f0' })
+    assert_xml_tag(tag: 'new', attributes: { project: 'home:tom:branches:OBS_Maintained:pack2', package: 'pack2.BaseDistro3', rev: '33fed2157de2517bc62894b3fdfd485c', srcmd5: '33fed2157de2517bc62894b3fdfd485c' })
     # the diffed files
     assert_xml_tag(tag: 'old', attributes: { name: 'file', md5: '722d122e81cbbe543bd5520bb8678c0e', size: '4' },
                     parent: { tag: 'file', attributes: { state: 'changed' } })
     assert_xml_tag(tag: 'new', attributes: { name: 'file', md5: '6c7c49c0d7106a1198fb8f1b3523c971', size: '16' },
                     parent: { tag: 'file', attributes: { state: 'changed' } })
     # the expected file transfer
-    assert_xml_tag(tag: 'source', attributes: { project: 'home:tom:branches:OBS_Maintained:pack2', package: 'pack2.BaseDistro3', rev: '7da33eb2a263a2f91d019a42eb28dae9' })
+    assert_xml_tag(tag: 'source', attributes: { project: 'home:tom:branches:OBS_Maintained:pack2', package: 'pack2.BaseDistro3', rev: '33fed2157de2517bc62894b3fdfd485c' })
     assert_xml_tag(tag: 'target', attributes: { project: 'My:Maintenance', releaseproject: 'BaseDistro3' })
     # diff contains the critical lines
     assert_match(/^\-NOOP/, @response.body)
@@ -656,7 +656,7 @@ class ChannelMaintenanceTests < ActionDispatch::IntegrationTest
     assert_xml_tag parent: { tag: 'action', attributes: { type: 'maintenance_release' } },
                    tag: 'target', attributes: { project: 'BaseDistro3', package: 'pack2.0' }
     assert_xml_tag parent: { tag: 'action', attributes: { type: 'maintenance_release' } },
-                   tag: 'acceptinfo', attributes: { rev: '1', oproject: 'BaseDistro3', opackage: 'pack2', oxsrcmd5: 'eb6705ddf47af932b8332e16ab2ed8b3', osrcmd5: 'eb6705ddf47af932b8332e16ab2ed8b3' }
+                   tag: 'acceptinfo', attributes: { rev: '1', oproject: 'BaseDistro3', opackage: 'pack2', oxsrcmd5: 'c3f6b2ae46cbc4cfb495774733c842f0', osrcmd5: 'c3f6b2ae46cbc4cfb495774733c842f0' }
 
     # diffing works
     post "/request/#{reqid}?cmd=diff&view=xml"


### PR DESCRIPTION
(this request had a wrong description first due to some github caching problem)

The backend has deprecated `<package>` in multibuild some time ago
but the schema and example got not updated.

Also the validation did not happen yet.
