### PR TITLE
[webui] Show error on invalid usernames in package meta

### DIFF
--- a/src/api/app/controllers/webui/package_controller.rb
+++ b/src/api/app/controllers/webui/package_controller.rb
@@ -1009,7 +1009,7 @@ class Webui::PackageController < Webui::WebuiController
         @package.update_from_xml(meta_xml)
         flash.now[:success] = 'The Meta file has been successfully saved.'
         render layout: false, partial: 'layouts/webui/flash', object: flash
-      rescue ActiveXML::Transport::Error => e
+      rescue ActiveXML::Transport::Error, NotFoundError => e
         flash.now[:error] = "Error while saving the Meta file: #{e}."
         render layout: false, status: 400, partial: 'layouts/webui/flash', object: flash
       end


### PR DESCRIPTION
This otherwise raises an exception that doesn't get caught. The user will not see any info what went wrong. The ui just does nothing.

This is related to: https://errbit-opensuse.herokuapp.com/apps/5620ca2bdc71fa00b1000000/problems/5a6cd49b71626e0006636025