### PR TITLE
[dist] should make base /etc/obs dir part of the package

### DIFF
--- a/dist/obs-server.spec
+++ b/dist/obs-server.spec
@@ -726,7 +726,8 @@ usermod -a -G docker obsservicerun
 /usr/lib/obs/server/bs_clouduploadserver
 /usr/lib/obs/server/bs_clouduploadworker
 %{_bindir}/clouduploader.rb
-%dir /etc/obs/cloudupload/
+%dir /etc/obs
+%dir /etc/obs/cloudupload
 %config(noreplace) /etc/obs/cloudupload/ec2utils.conf
 
 %package -n obs-container-registry


### PR DESCRIPTION
If the base dir /etc/obs is not packaged, rpmlint will complain that the basedir is nowhere packaged.