### PR TITLE
[frontend] Binary automplete returns now empty hash

### DIFF
--- a/src/api/app/models/kiwi/image.rb
+++ b/src/api/app/models/kiwi/image.rb
@@ -97,7 +97,7 @@ module Kiwi
         if use_project_repositories
           Backend::Api::BuildResults::Binaries.available_in_project(project)
         else
-          return [] if repositories.blank?
+          return {} if repositories.blank?
           obs_repository_paths = repositories.select { |url| url.starts_with?('obs://') }.map { |url| url[6..-1] }
           non_obs_repository_urls = repositories.reject { |url| url.starts_with?('obs://') }
           Backend::Api::BuildResults::Binaries.available_in_repositories(project, non_obs_repository_urls, obs_repository_paths)


### PR DESCRIPTION
if there is no repository specified.
As controller assumes it is a hash and uses #keys method which caused an NotMethodError.
#4243.