### PR TITLE
[api] Make Package#activity use ruby instead of SQL.

### DIFF
--- a/src/api/app/models/package.rb
+++ b/src/api/app/models/package.rb
@@ -876,9 +876,7 @@ class Package < ApplicationRecord
   end
 
   def activity
-    package = Package.find_by_sql("SELECT packages.*, #{Package.activity_algorithm} " \
-                                      "FROM `packages` WHERE id = #{id} LIMIT 1")
-    package.shift.activity_value.to_f
+    activity_index * 2.3276**((updated_at_was.to_f - Time.now.to_f) / 10_000_000)
   end
 
   def expand_flags


### PR DESCRIPTION
We are getting some deadlock errors when updating packages
and it seems that its because when you update the package it
also makes a second mysql query to calculate the activity
value so this commit fixes that by doing the calculation in
ruby.

Doing this as an alternative to https://github.com/openSUSE/open-build-service/pull/4171/files