### PR TITLE
[dist] Add Gemfile for docker frontend container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,9 @@ RUN chown -R frontend /obs/src/api
 # builds this container
 USER frontend
 WORKDIR /obs/src/api
+# foreman, which we only run in docker, needs a different thor version than OBS.
+# Installing the gem directly spares us from having to rpm package two different thor versions.
+RUN gem install thor:0.19 foreman
 
 # FIXME: Retrying bundler if it fails is a workaround for https://github.com/moby/moby/issues/783
 #        which seems to happen on openSUSE (< Tumbleweed 20171001)...

--- a/contrib/docker-bootstrap.sh
+++ b/contrib/docker-bootstrap.sh
@@ -12,8 +12,9 @@ do
       git-core \
       ruby2.4-devel cyrus-sasl-devel openldap2-devel libxml2-devel zlib-devel libxslt-devel \
       perl-XML-Parser \
+      libffi48-devel autoconf \
       ruby2.4-rubygem-mysql2 \
-      ruby2.4-rubygem-bundler ruby2.4-rubygem-thor ruby2.4-rubygem-foreman
+      ruby2.4-rubygem-bundler
     ;;
 
   backend)


### PR DESCRIPTION
There are a few gems that we need in our frontened container, but not
elsewhere (aka our rails app).

By adding a gemfile we can fetch the gems directly from rubygems.org
instead of having to package them. That way we also avoid that we have
to package multiple versions of a gem rpm package, eg. foreman
requires thoth v0.19, while OBS requires thoth v0.20.

Only disadvantage is that we have to pre-install packages that are
needed to build the gems.