### PR TITLE
Support a local build of a local multibuild package

### DIFF
--- a/src/api/app/controllers/build_controller.rb
+++ b/src/api/app/controllers/build_controller.rb
@@ -107,7 +107,7 @@ class BuildController < ApplicationController
   def buildinfo
     required_parameters :project, :repository, :arch, :package
     # just for permission checking
-    if request.post? && params[:package] == '_repository'
+    if request.post? && Package.striping_multibuild_suffix(params[:package]) == '_repository'
       # for osc local package build in this repository
       Project.get_by_name params[:project]
     else

--- a/src/backend/bs_repserver
+++ b/src/backend/bs_repserver
@@ -2888,6 +2888,7 @@ sub getbuildinfo_post {
       $packid =~ /^(.*):(.*?)$/;
       $bconf->{'obspackage'} = $1;
       $bconf->{'buildflavor'} = $2;
+      undef $packid if $1 eq '_repository';
     }
   }
   my $d = Build::parse_typed($bconf, $fn, $bconf->{'type'});


### PR DESCRIPTION
Support a local build of a local multibuild package (untested).
Fixes: https://github.com/openSUSE/osc/issues/376 ("osc build -M something
does not work with --alternative-project")