### PR TITLE
[frontend] Manually add ~/bin to PATH environment variable

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@ WORKDIR /obs/src/api
 # Installing the gem directly spares us from having to rpm package two different thor versions.
 RUN sudo gem.ruby2.5 install thor:0.19 foreman
 # Ensure there is a foreman command without ruby suffix
-RUN sudo ln -s /usr/bin/foreman.ruby2.5 /usr/bin/foreman
+RUN ln -s /usr/bin/foreman.ruby2.5 ~/bin/foreman
 
 # FIXME: Retrying bundler if it fails is a workaround for https://github.com/moby/moby/issues/783
 #        which seems to happen on openSUSE (< Tumbleweed 20171001)...

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,6 +24,9 @@ services:
     image: openbuildservice/frontend
     build:
       context: .
+    # Workaround to be able to use our shorthand links to ruby, gem & Co
+    environment:
+      - PATH=/home/frontend/bin/:$PATH
     volumes:
       - .:/obs
     ports:


### PR DESCRIPTION
This stopped working with the current Leap 42.3 docker image. It used to
work before (~ 4 month ago).