### PR TITLE
[dist] Create the links to executables system wide

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,15 +13,16 @@ ADD src/api/Gemfile /obs/src/api/Gemfile
 ADD src/api/Gemfile.lock /obs/src/api/Gemfile.lock
 RUN chown -R frontend /obs/src/api
 
+# foreman, which we only run in docker, needs a different thor version than OBS.
+# Installing the gem directly spares us from having to rpm package two different thor versions.
+RUN gem.ruby2.5 install thor:0.19 foreman
+# Ensure there is a foreman command without ruby suffix
+RUN ln -s /usr/bin/foreman.ruby2.5 /usr/local/bin/foreman
+
 # Now do the rest as the user with the same ID as the user who
 # builds this container
 USER frontend
 WORKDIR /obs/src/api
-# foreman, which we only run in docker, needs a different thor version than OBS.
-# Installing the gem directly spares us from having to rpm package two different thor versions.
-RUN sudo gem.ruby2.5 install thor:0.19 foreman
-# Ensure there is a foreman command without ruby suffix
-RUN sudo ln -s /usr/bin/foreman.ruby2.5 /usr/bin/foreman
 
 # FIXME: Retrying bundler if it fails is a workaround for https://github.com/moby/moby/issues/783
 #        which seems to happen on openSUSE (< Tumbleweed 20171001)...

--- a/Dockerfile.frontend-base
+++ b/Dockerfile.frontend-base
@@ -9,13 +9,13 @@ ADD src/api/Gemfile /obs/src/api/Gemfile
 ADD src/api/Gemfile.lock /obs/src/api/Gemfile.lock
 RUN chown -R frontend /obs/src/api
 
+# Ensure there are ruby, gem and irb commands without ruby suffix
+RUN for i in ruby gem irb; do ln -s /usr/bin/$i.ruby2.5 /usr/local/bin/$i; done
+
 # Now do the rest as the user with the same ID as the user who
 # builds this container
 USER frontend
 WORKDIR /obs/src/api
-
-# Ensure there are ruby, gem and irb commands without ruby suffix
-RUN for i in ruby gem irb; do ln -s /usr/bin/$i.ruby2.5 ~/bin/$i; done
 
 # Install our bundle
 # FIXME: Retrying bundler if it fails is a workaround for https://github.com/moby/moby/issues/783

--- a/Dockerfile.old-test-suite
+++ b/Dockerfile.old-test-suite
@@ -9,11 +9,11 @@ ADD src/api/Gemfile.lock /obs/src/api/Gemfile.lock
 ADD contrib/start_old_tests /obs/contrib/start_old_tests
 RUN chown -R frontend:users /obs/
 
+# Set up some convenience ruby binaries...
+RUN for i in ruby gem irb; do ln -s /usr/bin/$i.ruby2.5 /usr/local/bin/$i; done
+
 USER frontend
 WORKDIR /obs/src/api
-
-# Set up some convenience ruby binaries...
-RUN for i in ruby gem irb; do ln -s /usr/bin/$i.ruby2.5 ~/bin/$i; done
 
 # Install our bundle
 # FIXME: Retrying bundler if it fails is a workaround for https://github.com/moby/moby/issues/783


### PR DESCRIPTION
Create the links to the executable file in `/usr/local/bin/`, where they can be reached.

Previously, even they were created in `~/bin/` they were not used because the `$PATH` variable was not correctly set for the user `frontend`.

Pair-programmed with @bgeuken.