### PR TITLE
[ci] plan tests only once

### DIFF
--- a/dist/t/0070-check_recommended_services.ts
+++ b/dist/t/0070-check_recommended_services.ts
@@ -5,17 +5,20 @@ use warnings;
 use FindBin;
 use lib "$FindBin::Bin/lib";
 use OBS::Test::Utils;
-use Test::More 'tests' => 6;
+use Test::More;
 
+my $test_count = 6;
 my $max_wait = 300;
 
 my @daemons = qw/obsdodup obssigner obsdeltastore/;
 my $pkg_ver = OBS::Test::Utils::get_package_version('obs-server', 2);
 
 if ( $pkg_ver > 2.8) {
-  plan tests => 8;
-  push (@daemons, 'obsservicedispatcher');
+  $test_count = 8;
+  push (@daemons, 'obsservicedispatch');
 }
+
+plan tests => $test_count;
 
 foreach my $srv (@daemons) {
 	my @state=`systemctl is-enabled $srv\.service 2>/dev/null`;


### PR DESCRIPTION
without this fix you get an error message in the tests like

```
You tried to plan twice at t/0070-check_recommended_services.ts line 16.
 # Looks like your test exited with 255 before it could output anything.
t/0070-check_recommended_services.ts ..
```
if the version is higher then 2.8

This patch takes care that the plan is only printed once with the right
number of test