### PR TITLE
[webui][api] Skip events which have already had their emails sent.

### DIFF
--- a/src/api/app/jobs/send_event_emails_job.rb
+++ b/src/api/app/jobs/send_event_emails_job.rb
@@ -3,6 +3,7 @@ class SendEventEmailsJob < ApplicationJob
 
   def perform(event_id)
     event = Event::Base.find(event_id)
+    return if event.mails_sent
     subscribers = event.subscribers
 
     if subscribers.empty?


### PR DESCRIPTION
Do not bother finding subscribers for an event if the emails have
already been sent for it.