### PR TITLE
Revert "[webui][api] Change SendEventEmails to 1 event per job."

### DIFF
--- a/src/api/app/jobs/send_event_emails_job.rb
+++ b/src/api/app/jobs/send_event_emails_job.rb
@@ -1,23 +1,25 @@
 class SendEventEmailsJob < ApplicationJob
   queue_as :mailers
 
-  def perform(event_id)
-    event = Event::Base.find(event_id)
-    subscribers = event.subscribers
+  def perform
+    Event::Base.where(mails_sent: false).order(created_at: :asc).limit(1000).each do |event|
+      subscribers = event.subscribers
 
-    if subscribers.empty?
-      event.update_attributes(mails_sent: true)
-      return
-    end
+      if subscribers.empty?
+        event.update_attributes(mails_sent: true)
+        next
+      end
 
-    begin
-      create_rss_notifications(event)
-      EventMailer.event(subscribers, event).deliver_now
-    rescue StandardError => e
-      Airbrake.notify(e, event_id: event.id)
-    ensure
-      event.update_attributes(mails_sent: true)
+      begin
+        create_rss_notifications(event)
+        EventMailer.event(subscribers, event).deliver_now
+      rescue StandardError => e
+        Airbrake.notify(e, event_id: event.id)
+      ensure
+        event.update_attributes(mails_sent: true)
+      end
     end
+    true
   end
 
   private

--- a/src/api/config/clock.rb
+++ b/src/api/config/clock.rb
@@ -16,6 +16,10 @@ module Clockwork
     WorkerStatus.new.update_workerstatus_cache
   end
 
+  every(30.seconds, 'send notifications') do
+    SendEventEmailsJob.perform_later
+  end
+
   every(49.minutes, 'rescale history') do
     StatusHistoryRescalerJob.perform_later
   end

--- a/src/api/test/functional/comments_controller_test.rb
+++ b/src/api/test/functional/comments_controller_test.rb
@@ -87,9 +87,11 @@ class CommentsControllerTest < ActionDispatch::IntegrationTest
     # body can't be empty
     assert_xml_tag tag: 'status', attributes: { code: 'invalid_record' }
 
+    SendEventEmailsJob.new.perform
     assert_difference 'ActionMailer::Base.deliveries.size', +1 do
       post create_request_comment_path(request_number: 2), params: 'Hallo'
       assert_response :success
+      SendEventEmailsJob.new.perform
     end
 
     email = ActionMailer::Base.deliveries.last
@@ -101,9 +103,11 @@ class CommentsControllerTest < ActionDispatch::IntegrationTest
 
     # just check if adrian gets the mail too - he's a commenter now
     login_dmayr
+    SendEventEmailsJob.new.perform
     assert_difference 'ActionMailer::Base.deliveries.size', +1 do
       post create_request_comment_path(request_number: 2), params: 'Hallo'
       assert_response :success
+      SendEventEmailsJob.new.perform
     end
 
     email = ActionMailer::Base.deliveries.last
@@ -113,6 +117,7 @@ class CommentsControllerTest < ActionDispatch::IntegrationTest
     assert_difference 'ActionMailer::Base.deliveries.size', +1 do
       post create_request_comment_path(request_number: 2), params: 'Hallo @fred'
       assert_response :success
+      SendEventEmailsJob.new.perform
     end
 
     email = ActionMailer::Base.deliveries.last
@@ -122,6 +127,7 @@ class CommentsControllerTest < ActionDispatch::IntegrationTest
     assert_difference 'ActionMailer::Base.deliveries.size', +1 do
       post create_request_comment_path(request_number: 2), params: 'Is Fred listening now?'
       assert_response :success
+      SendEventEmailsJob.new.perform
     end
 
     email = ActionMailer::Base.deliveries.last
@@ -138,9 +144,11 @@ class CommentsControllerTest < ActionDispatch::IntegrationTest
     # body can't be empty
     assert_xml_tag tag: 'status', attributes: { code: 'invalid_record' }
 
+    SendEventEmailsJob.new.perform
     assert_difference 'ActionMailer::Base.deliveries.size', +1 do
       post create_project_comment_path(project: 'Apache'), params: 'Beautiful project'
       assert_response :success
+      SendEventEmailsJob.new.perform
     end
 
     email = ActionMailer::Base.deliveries.last
@@ -162,9 +170,11 @@ class CommentsControllerTest < ActionDispatch::IntegrationTest
     # body can't be empty
     assert_xml_tag tag: 'status', attributes: { code: 'invalid_record' }
 
+    SendEventEmailsJob.new.perform
     assert_difference 'ActionMailer::Base.deliveries.size', +1 do
       post create_package_comment_path(project: 'kde4', package: 'kdebase'), params: 'Hola, estoy aprendiendo español'
       assert_response :success
+      SendEventEmailsJob.new.perform
     end
 
     email = ActionMailer::Base.deliveries.last
@@ -177,10 +187,12 @@ class CommentsControllerTest < ActionDispatch::IntegrationTest
 
   def test_create_a_comment_that_only_mentioned_people_will_notice
     login_tom
+    SendEventEmailsJob.new.perform
     assert_difference 'ActionMailer::Base.deliveries.size', +1 do
       # Trolling
       post create_package_comment_path(project: 'BaseDistro', package: 'pack1'), params: "I preffer Apache1, don't you? @fred"
       assert_response :success
+      SendEventEmailsJob.new.perform
     end
 
     email = ActionMailer::Base.deliveries.last

--- a/src/api/test/functional/maintenance_test.rb
+++ b/src/api/test/functional/maintenance_test.rb
@@ -1399,12 +1399,14 @@ class MaintenanceTests < ActionDispatch::IntegrationTest
     assert_response :success
     assert_xml_tag(parent: { tag: 'state' }, tag: 'comment', content: 'blahfasel')
 
+    SendEventEmailsJob.new.perform
     ActionMailer::Base.deliveries.clear
 
     # leave a comment
     assert_difference 'ActionMailer::Base.deliveries.size', +1 do
       post create_request_comment_path(request_number: reqid), params: 'Release it now!'
       assert_response :success
+      SendEventEmailsJob.new.perform
     end
 
     email = ActionMailer::Base.deliveries.last
@@ -1417,6 +1419,7 @@ class MaintenanceTests < ActionDispatch::IntegrationTest
     assert_difference 'ActionMailer::Base.deliveries.size', +1 do
       post create_request_comment_path(request_number: reqid), params: 'Slave, can you release it? The master is gone'
       assert_response :success
+      SendEventEmailsJob.new.perform
     end
 
     email = ActionMailer::Base.deliveries.last

--- a/src/api/test/functional/request_events_test.rb
+++ b/src/api/test/functional/request_events_test.rb
@@ -22,11 +22,13 @@ class RequestEventsTest < ActionDispatch::IntegrationTest
 
     Timecop.travel(2013, 8, 20, 12, 0, 0)
     myid = 0
+    SendEventEmailsJob.new.perform
     assert_difference 'ActionMailer::Base.deliveries.size', +1 do
       post '/request?cmd=create',
            params: "<request><action type='add_role'><target project='home:tom'/><person name='Iggy' role='reviewer'/></action></request>"
       assert_response :success
       myid = Xmlhash.parse(@response.body)['id']
+      SendEventEmailsJob.new.perform
     end
 
     email = ActionMailer::Base.deliveries.last
@@ -41,6 +43,7 @@ class RequestEventsTest < ActionDispatch::IntegrationTest
 
     Timecop.travel(2013, 8, 20, 12, 0, 0)
     myid = 0
+    SendEventEmailsJob.new.perform
     assert_difference 'ActionMailer::Base.deliveries.size', +1 do
       body = "<request>\n"
       actions = 1000
@@ -53,6 +56,7 @@ class RequestEventsTest < ActionDispatch::IntegrationTest
       req = Xmlhash.parse(@response.body)
       assert_equal actions, req['action'].count
       myid = req['id']
+      SendEventEmailsJob.new.perform
     end
 
     email = ActionMailer::Base.deliveries.last
@@ -66,10 +70,12 @@ class RequestEventsTest < ActionDispatch::IntegrationTest
 
     Timecop.travel(2013, 8, 20, 12, 0, 0)
     myid = 0
+    SendEventEmailsJob.new.perform
     assert_difference 'ActionMailer::Base.deliveries.size', +1 do
       post '/request?cmd=create', params: "<request><action type='set_bugowner'><target project='home:tom'/><person name='Iggy'/></action></request>"
       assert_response :success
       myid = Xmlhash.parse(@response.body)['id']
+      SendEventEmailsJob.new.perform
     end
 
     email = ActionMailer::Base.deliveries.last
@@ -86,6 +92,7 @@ class RequestEventsTest < ActionDispatch::IntegrationTest
     assert_difference 'ActionMailer::Base.deliveries.size', +1 do
       post "/request/#{myid}?cmd=changestate&newstate=declined", params: ''
       assert_response :success
+      SendEventEmailsJob.new.perform
     end
     email = nil
     ActionMailer::Base.deliveries.each do |m|
@@ -105,12 +112,14 @@ class RequestEventsTest < ActionDispatch::IntegrationTest
 
     Timecop.travel(2013, 8, 20, 12, 0, 0)
     myid = ''
+    SendEventEmailsJob.new.perform
     assert_difference 'ActionMailer::Base.deliveries.size', +1 do
       post '/request?cmd=create',
            params: "<request><action type='add_role'><target project='kde4' package='kdelibs'/><person name='Iggy' role='reviewer'/></action>"\
                    '</request>'
       assert_response :success
       myid = Xmlhash.parse(@response.body)['id']
+      SendEventEmailsJob.new.perform
     end
 
     email = ActionMailer::Base.deliveries.last
@@ -123,10 +132,12 @@ class RequestEventsTest < ActionDispatch::IntegrationTest
 
     Timecop.travel(2013, 8, 20, 12, 0, 0)
     myid = ''
+    SendEventEmailsJob.new.perform
     assert_difference 'ActionMailer::Base.deliveries.size', +1 do
       post '/request?cmd=create', params: "<request><action type='delete'><target project='home:coolo' repository='standard'/></action></request>"
       assert_response :success
       myid = Xmlhash.parse(@response.body)['id']
+      SendEventEmailsJob.new.perform
     end
 
     email = ActionMailer::Base.deliveries.last

--- a/src/api/test/models/event_test.rb
+++ b/src/api/test/models/event_test.rb
@@ -72,8 +72,10 @@ class EventTest < ActionDispatch::IntegrationTest
     User.current = users(:Iggy)
     req = bs_requests(:submit_from_home_project)
     myid = req.number
+    SendEventEmailsJob.new.perform # empty queue
     assert_difference 'ActionMailer::Base.deliveries.size', +1 do
       req.addreview by_user: 'tom', comment: 'Can you check that?'
+      SendEventEmailsJob.new.perform
     end
     email = ActionMailer::Base.deliveries.last
 
@@ -85,6 +87,17 @@ class EventTest < ActionDispatch::IntegrationTest
       should.gsub!(/\n@@ -0,0 \+1,1 @@\n/, "\n@@ -0,0 +1 @@\n")
     end
     assert_equal should, email.encoded.lines.map(&:chomp).reject { |l| l =~ %r{^Date:} }.join("\n")
+  end
+
+  test 'cleanup job' do
+    firstcount = Event::Base.count
+    CleanupEvents.new.perform
+    assert Event::Base.count == firstcount, 'all our fixtures are fresh, mail must be sent first'
+    f = Event::Base.first
+    f.mails_sent = true
+    f.save
+    CleanupEvents.new.perform
+    assert Event::Base.count != firstcount, 'now its gone'
   end
 
   test 'maintainer mails for build failure' do
@@ -122,8 +135,10 @@ class EventTest < ActionDispatch::IntegrationTest
     User.current = users(:Iggy)
     req = bs_requests(:submit_from_home_project)
     myid = req.number
+    SendEventEmailsJob.new.perform # empty queue
     assert_difference 'ActionMailer::Base.deliveries.size', +1 do
       req.addreview by_project: 'home:Iggy', by_package: 'TestPack', comment: 'Can you check that?'
+      SendEventEmailsJob.new.perform
     end
     email = ActionMailer::Base.deliveries.last
 
@@ -136,6 +151,7 @@ class EventTest < ActionDispatch::IntegrationTest
     ActionMailer::Base.deliveries.clear
     assert_difference 'ActionMailer::Base.deliveries.size', +1 do
       req.addreview by_project: 'Apache', by_package: 'apache2', comment: 'Can you check that?'
+      SendEventEmailsJob.new.perform
     end
     email = ActionMailer::Base.deliveries.last
 

--- a/src/api/test/unit/event_mailer_test.rb
+++ b/src/api/test/unit/event_mailer_test.rb
@@ -57,10 +57,11 @@ class EventMailerTest < ActionMailer::TestCase
     req = bs_requests(:submit_from_home_project)
     Timecop.travel(2013, 8, 20, 12, 0, 0)
     myid = req.number
-
+    SendEventEmailsJob.new.perform # empty queue
     assert_difference 'ActionMailer::Base.deliveries.size', +1 do
-      event = req.addreview(by_group: 'test_group', comment: 'does it look ok?')
-      SendEventEmailsJob.perform_now(event.id)
+      req.addreview(by_group: 'test_group', comment: 'does it look ok?')
+      # trigger the send job
+      SendEventEmailsJob.new.perform
     end
 
     email = ActionMailer::Base.deliveries.last


### PR DESCRIPTION
This reverts commit df92a8fb9ae35a8ffda6db536d7e9d85357d65a7.

Moving to 1 event per job is not a good idea while we are still using delayed job since delayed job cannot handle large number of jobs in the queue. We should first move to an async system which can scale, and then move to 1 event / job.