### PR TITLE
[docu] Introduces a commit message template

### DIFF
--- a/.gitmessage
+++ b/.gitmessage
@@ -1,0 +1,31 @@
+[label] A title that summarizes **what** has been done
+
+# If you can't explain **what** you have done only in the title
+# then elaborate on it in the body 
+# * ...
+
+# Explain **why** you have changed this instead of the *how*.
+# This is the most important content of the message.
+
+* ...
+
+# Explain potential side-effects of this change, if there are any
+# * ...
+
+# If this commit fixes an issue you need to mention it like
+# Fixes #1234
+
+# If this commit has more than one author tag them with:
+# Co-authored-by: Ana María Martínez Gómez <ammartinez@suse.de>
+# Co-authored-by: Björn Geuken <bgeuken@suse.de>
+# Co-authored-by: Christian Bruckmayer <cbruckmayer@suse.com>
+# Co-authored-by: David Kang <dkang@suse.com>
+# Co-authored-by: Eduardo Navarro <enavarro@suse.com> 
+# Co-authored-by: Evan Rolfe <esrolfe@suse.de>
+# Co-authored-by: Henne Vogelsang <hvogel@opensuse.org>
+# Co-authored-by: Moises Deniz Aleman <mdeniz@suse.com>
+# Co-authored-by: Manuel Schnitzer <github@mschnitzer.de>
+# Co-authored-by: Adrian Schröter <adrian@suse.de>
+# Co-authored-by: Marco Strigl <mstrigl@suse.com>
+# Co-authored-by: Michael Schroeder <mls@suse.de>
+# Co-authored-by: Frank Schreiner <schreiner@suse.de>

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,6 +21,12 @@ In particular, this community seeks the following types of contributions:
 * Fork the repository and make a pull-request with your changes
   * Please make sure to mind what our test suite in [travis](https://travis-ci.org/openSUSE/open-build-service) tells you
   * Please always increase our [code coverage](https://codeclimate.com/github/openSUSE/open-build-service) by your pull request
+  * To help to write better commit messages we use a [template](https://github.com/openSUSE/open-build-service/blob/master/.gitmessage).
+    Copy this to your home (`cp .gitmessage ~/.gitmessage`) and add this to your `~/.gitconfig`:
+    ```
+    [commit]
+      template = ~/.gitmessage
+    ```
 
 * A developer of the [open-build-service team](https://github.com/orgs/openSUSE/teams/open-build-service) will review your pull-request
   * If the pull request gets a positive review the reviewer will merge it


### PR DESCRIPTION
A bunch of us have talked about what the content of good commit meesages should
look like and came up with this template. Here is how you can make use of it:

cp .gitmessage ~/.gitmessage

Add this to your ~/.gitconfig

[commit]
  template = ~/.gitmessage

Everyboy following this template will help people to understand the changes in
the future. Addtionally it will make it easier for us to use commit messages in
documentation like our Changelog, books or our blog.

Co-authored-by: Manuel Schnitzer <github@mschnitzer.de>
Co-authored-by: Björn Geuken <bgeuken@suse.de>
Co-authored-by: Henne Vogelsang <hvogel@opensuse.org>
Co-authored-by: Moises Deniz Aleman <mdeniz@suse.com>
Co-authored-by: Eduardo Navarro <enavarro@suse.com>