### PR TITLE
[frontend] Add an optional vpc subnet field to cloud upload page

### DIFF
--- a/dist/clouduploader.rb
+++ b/dist/clouduploader.rb
@@ -24,8 +24,7 @@ data = JSON.parse(File.read(data_path))
 FileUtils.ln_s(image_path, File.join(Dir.pwd, filename))
 
 def get_ec2_credentials(data)
-  # Credentials are stored in  ~/.aws/credentials
-  out, err, status = Open3.capture3(
+  command = [
     'aws',
     'sts',
     'assume-role',
@@ -33,7 +32,14 @@ def get_ec2_credentials(data)
     "--external-id=#{data['external_id']}",
     '--role-session-name=obs',
     "--duration-seconds=#{THIRTY_MINUTES}"
-  )
+  ]
+
+  if data['vpc_subnet_id']
+    command << "--vpc-subnet-id=#{data['vpc_subnet_id']}"
+  end
+
+  # Credentials are stored in  ~/.aws/credentials
+  out, err, status = Open3.capture3(command)
 
   if status.success?
     STDOUT.write("Successfully authenticated.\n")

--- a/src/api/Gemfile.lock
+++ b/src/api/Gemfile.lock
@@ -249,7 +249,7 @@ GEM
     pry (0.11.3)
       coderay (~> 1.1.0)
       method_source (~> 0.9.0)
-    public_suffix (3.0.1)
+    public_suffix (3.0.2)
     pundit (1.1.0)
       activesupport (>= 3.0.0)
     rack (2.0.3)

--- a/src/api/app/controllers/webui/cloud/upload_jobs_controller.rb
+++ b/src/api/app/controllers/webui/cloud/upload_jobs_controller.rb
@@ -13,7 +13,7 @@ module Webui
       end
 
       def new
-        xml_object = OpenStruct.new(params.slice(:project, :package, :repository, :arch, :filename))
+        xml_object = OpenStruct.new(params.slice(:project, :package, :repository, :arch, :filename, :vpc_subnet_id))
         @upload_job = ::Cloud::Backend::UploadJob.new(xml_object: xml_object)
         @ec2_regions = ::Cloud::Ec2::Configuration::REGIONS
       end
@@ -59,7 +59,7 @@ module Webui
 
       def permitted_params
         params.require(:cloud_backend_upload_job).permit(
-          :project, :package, :repository, :arch, :filename, :region, :ami_name, :target
+          :project, :package, :repository, :arch, :filename, :region, :ami_name, :target, :vpc_subnet_id
         )
       end
 

--- a/src/api/app/models/cloud/backend/upload_job.rb
+++ b/src/api/app/models/cloud/backend/upload_job.rb
@@ -18,6 +18,7 @@ module Cloud
                      :repository,
                      :arch,
                      :filename,
+                     :vpc_subnet_id,
                      :size,
                      :backend_response
       alias_method :id, :name

--- a/src/api/app/models/cloud/ec2/configuration.rb
+++ b/src/api/app/models/cloud/ec2/configuration.rb
@@ -30,6 +30,10 @@ module Cloud
       def self.table_name_prefix
         'cloud_ec2_'
       end
+
+      def upload_parameters
+        attributes.except('id', 'created_at', 'updated_at')
+      end
     end
   end
 end

--- a/src/api/app/models/cloud/upload_job.rb
+++ b/src/api/app/models/cloud/upload_job.rb
@@ -4,7 +4,7 @@ module Cloud
     include ActiveModel::Model
     extend Forwardable
 
-    attr_accessor :user_upload_job, :backend_upload_job, :target_params, :filename, :arch, :target, :user
+    attr_accessor :user_upload_job, :backend_upload_job, :target_params, :filename, :arch, :target, :user, :vpc_subnet_id
     validate :validate_dependencies
     validates :user, presence: true
     validates :filename, presence: true, format: {
@@ -12,11 +12,12 @@ module Cloud
     }
     validates :arch, inclusion: { in: ['x86_64'], message: "'%{value}' is not a valid cloud architecture" }
     validates :target, inclusion: { in: ['ec2'] }
+    validates :vpc_subnet_id, format: { with: /\Avpc-[-\w]+\z/, message: 'not a valid format', allow_blank: true }
 
     def_delegator :backend_upload_job, :id
 
     def self.create(params)
-      upload_job = new(params.slice(:filename, :arch, :user, :target))
+      upload_job = new(params.slice(:filename, :arch, :user, :target, :vpc_subnet_id))
       return upload_job if upload_job.invalid?
 
       upload_job.target_params = upload_job.target_validator_class.build(params)

--- a/src/api/app/views/webui/cloud/upload_jobs/new.html.haml
+++ b/src/api/app/views/webui/cloud/upload_jobs/new.html.haml
@@ -22,6 +22,9 @@
     = upload_job_form.label 'cloud_backend_upload_job[region]', "Region:"
     = select_tag('cloud_backend_upload_job[region]', options_for_select(@ec2_regions))
   %p
+    = upload_job_form.label 'cloud_backend_upload_job[vpc_subnet_id]', 'VPC Subnet ID (optional):'
+    = upload_job_form.text_field(:vpc_subnet_id, size: 35, name: 'cloud_backend_upload_job[vpc_subnet_id]')
+  %p
     = upload_job_form.hidden_field :project
     = upload_job_form.hidden_field :package
     = upload_job_form.hidden_field :arch

--- a/src/api/lib/backend/api/cloud.rb
+++ b/src/api/lib/backend/api/cloud.rb
@@ -5,10 +5,10 @@ module Backend
       # Triggers a cloud upload job
       # @return [String]
       def self.upload(params)
-        data = params.slice(:region, :ami_name)
+        data = params.slice(:region, :ami_name, :vpc_subnet_id)
         user = params[:user]
         params = params.except(:region, :ami_name).merge(user: user.login, target: params[:target])
-        data = user.ec2_configuration.attributes.except('id', 'created_at', 'updated_at').merge(data).to_json
+        data = user.ec2_configuration.upload_parameters.merge(data).to_json
         http_post('/cloudupload', params: params, data: data)
       end
 

--- a/src/api/spec/models/cloud/ec2/configuration_spec.rb
+++ b/src/api/spec/models/cloud/ec2/configuration_spec.rb
@@ -8,4 +8,15 @@ RSpec.describe Cloud::Ec2::Configuration, type: :model, vcr: true do
     it { is_expected.to allow_value('arn:123:456/tom').for(:arn) }
     it { is_expected.not_to allow_value('123:456/tom').for(:arn) }
   end
+
+  describe 'upload_parameters' do
+    let(:ec2_config) { create(:ec2_configuration) }
+
+    subject { ec2_config.upload_parameters }
+
+    it { expect(subject.keys.count).to be 3 }
+    it { expect(subject['arn']).to eq ec2_config.arn }
+    it { expect(subject['user_id']).to eq ec2_config.user_id }
+    it { expect(subject['external_id']).to eq ec2_config.external_id }
+  end
 end

--- a/src/api/spec/models/cloud/upload_job_spec.rb
+++ b/src/api/spec/models/cloud/upload_job_spec.rb
@@ -42,6 +42,8 @@ RSpec.describe Cloud::UploadJob, type: :model, vcr: true do
     it { is_expected.not_to allow_value('foo.rpm').for(:filename) }
     it { is_expected.not_to allow_value('foo.vhdfixed').for(:filename) }
     it { is_expected.not_to allow_value('foo.raw').for(:filename) }
+    it { is_expected.to allow_value('vpc-23sdfg54').for(:vpc_subnet_id) }
+    it { is_expected.not_to allow_value('vpc-2$sdfg54').for(:vpc_subnet_id) }
   end
 
   describe '.create' do


### PR DESCRIPTION
Provides an optional subnet field to that allows to provide a distinct
subnet to be used for the upload to AWS.
If no vpc subnet id was provided, the upload script generates a
temporary one.