### PR TITLE
[dist] Fix path to Gemfile

### DIFF
--- a/src/api/docker-files/Dockerfile.frontend-base
+++ b/src/api/docker-files/Dockerfile.frontend-base
@@ -5,8 +5,8 @@ RUN /root/bin/docker-bootstrap.sh frontend
 # Install other requirements
 RUN npm install -g jshint
 
-ADD Gemfile /obs/src/api/Gemfile
-ADD Gemfile.lock /obs/src/api/Gemfile.lock
+ADD ../Gemfile /obs/src/api/Gemfile
+ADD ../Gemfile.lock /obs/src/api/Gemfile.lock
 RUN chown -R frontend /obs/src/api
 
 # Ensure there are ruby, gem and irb commands without ruby suffix


### PR DESCRIPTION
We recently (8576fe1c41b6d120b5e) moved the dockerfiles to different
locations. This change broke the relative path to the Gemfile in our
Dockerfile.frontend-base recipe.
This commit is fixing it.