### PR TITLE
Revert "[webui][api] Increase the number of workers for mailers queue."

### DIFF
--- a/dist/obsapidelayed
+++ b/dist/obsapidelayed
@@ -63,7 +63,7 @@ case "$1" in
         run_in_api script/delayed_job.api.rb --queue=quick start -n $NUM
         run_in_api script/delayed_job.api.rb --queue=releasetracking start -i 1000
         run_in_api script/delayed_job.api.rb --queue=issuetracking start -i 1010
-        run_in_api script/delayed_job.api.rb --queue=mailers start -n 30 -i 1020
+        run_in_api script/delayed_job.api.rb --queue=mailers start -i 1020
         # The default queue used by ActiveJob (jobs scheduled with .perform_later)
         run_in_api script/delayed_job.api.rb --queue=default start -i 1030
         run_in_api script/delayed_job.api.rb --queue=project_log_rotate start -i 1040


### PR DESCRIPTION
This reverts commit b31442ba2d7785732a599491b8bbf15c0adb507e.

This wasn't solving the problem since the mysql connection was the
actual bottleneck.