### PR TITLE
[dist] Parallelize docker builds with rake multitask

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -69,25 +69,27 @@ namespace :docker do
     end
 
     desc 'Rebuild all our static containers'
-    task rebuild: ['rebuild:base', 'rebuild:backend', 'rebuild:frontend-base', 'rebuild:mariadb', 'rebuild:memcached', 'rebuild:old-test-suite'] do
+    multitask rebuild: ['rebuild:all'] do
     end
     namespace :rebuild do
+      multitask all: [:base, :backend, 'frontend-base', :mariadb, :memcached, 'old-test-suite'] do
+      end
       task :base do
         sh "docker build docker-files/base/ #{tags_for(:base)} -f docker-files/base/Dockerfile.#{VERSION}"
       end
-      task :mariadb do
+      task mariadb: [:base] do
         sh "docker build docker-files/mariadb/ #{tags_for(:mariadb)} -f docker-files/mariadb/Dockerfile.mariadb"
       end
-      task :memcached do
+      task memcached: [:base] do
         sh "docker build docker-files/memcached/ #{tags_for(:memcached)} -f docker-files/memcached/Dockerfile.memcached"
       end
-      task 'frontend-base' do
+      task 'frontend-base' => [:base] do
         sh "docker build src/api/ #{tags_for('frontend-base')} -f src/api/docker-files/Dockerfile.frontend-base"
       end
-      task :backend do
+      task backend: [:base] do
         sh "docker build src/backend/ #{tags_for(:backend)} -f src/backend/docker-files/Dockerfile.backend"
       end
-      task 'old-test-suite' do
+      task 'old-test-suite' => [:base] do
         sh "docker build src/api/ #{tags_for('old-test-suite')} -f src/api/docker-files/Dockerfile.old-test-suite"
       end
     end

--- a/Rakefile
+++ b/Rakefile
@@ -95,10 +95,11 @@ namespace :docker do
     end
 
     desc 'Rebuild and publish all our static containers'
-    task publish: [:rebuild, 'publish:base', 'publish:mariadb', 'publish:memcached', 'publish:backend', 'publish:frontend-base', \
-                   'publish:old-test-suite'] do
+    task publish: [:rebuild, 'publish:all'] do
     end
     namespace :publish do
+      multitask all: [:base, :mariadb, :memcached, :backend, 'frontend-base', 'old-test-suite'] do
+      end
       task :base do
         sh "docker push openbuildservice/base:#{VERSION}"
         sh 'docker push openbuildservice/base'

--- a/docker-compose.ci.yml
+++ b/docker-compose.ci.yml
@@ -2,6 +2,8 @@ version: "2"
 services:
   rspec:
     image: openbuildservice/frontend
+    environment:
+      - LANG=en_US.UTF-8
     volumes:
       - .:/obs
     depends_on:


### PR DESCRIPTION
Defines dependencies between rake docker:maintainer tasks and run them
as multitask. That way tasks that don't depend on each other can run in
parallel and thus reduce the build time.

This also means that the defined dependencies will also run if a single
image is rebuild, eg. via 'rake docker:maintainer:rebuild:frontend-base'.

My assumption is that we are usually building all images at once and
thus don't mind this change. If the old behaviour is still needed, we
can extend the rake tasks.

Real time of 'rake docker:maintainer:rebuild':

before: 16m34.778s
after:   9m10.307s