### PR TITLE
[dist] Don't package our docker files

### DIFF
--- a/dist/obs-server.spec
+++ b/dist/obs-server.spec
@@ -297,6 +297,10 @@ This package contains all the necessary tools for upload images to the cloud.
 
 %setup -q -n open-build-service-%version
 
+# We don't need our docker files in our packages
+rm -r src/{api,backend}/docker-files
+rm src/api/Dockerfile.frontend-base
+
 # drop build script, we require the installed one from own package
 rm -rf src/backend/build
 find . -name .git\* -o -name Capfile -o -name deploy.rb | xargs rm -rf


### PR DESCRIPTION
We recently (8576fe1c41b6d12) moved our docker files to the api
and backend directory. A side effect of this was that our docker files
got included in our rpm packages.
Since we don't want this, we have to remove them in our spec file.