### PR TITLE
[backend] publish ONIE binary

### DIFF
--- a/src/backend/bs_publish
+++ b/src/backend/bs_publish
@@ -1521,6 +1521,9 @@ sub publish {
 	if ($bin =~ /\.iso(?:\.sha256)?$/) {
 	  $p = "iso/$bin";
 	  $kiwimedium{$p} = $1 if $bin =~ /(.+)\.iso$/;
+	} elsif ($bin =~ /ONIE\.bin$/) {
+	  $p = "onie/$bin";
+	  $kiwimedium{$p} = $1 if $bin =~ /(.+)ONIE\.bin$/;
 	} elsif ($bin =~ /\.raw(?:\.install)?(?:\.(?:gz|bz2|xz))?(?:\.sha256)?$/) {
 	  $p = "$bin";
 	} elsif ($bin =~ /(.*-Build\d.*)\.(?:tbz|tgz|tar|tar\.gz|tar\.bz2|tar\.xz)(\.sha256)?$/) {


### PR DESCRIPTION
Open Network Install Environment is an open image format used by
networking vendor to ship a standardised image for networking white
box switches.

Those images names have a standard suffix, "ONIE.bin", which means
right now they are ignored by the OBS publisher when they are built.
Add a simple match for this new type, and publish into an onie/
subdirectory.

Reference: http://onie.org


Sent of behalf of my colleague at $work, Erik.
@dstape FYI