### PR TITLE
[frontend] Fix ec2 upload errors

### DIFF
--- a/src/api/lib/backend/api/cloud.rb
+++ b/src/api/lib/backend/api/cloud.rb
@@ -7,7 +7,7 @@ module Backend
       def self.upload(params)
         data = params.slice(:region, :ami_name, :vpc_subnet_id)
         user = params[:user]
-        params = params.except(:region, :ami_name).merge(user: user.login, target: params[:target])
+        params = params.except(:region, :ami_name, :vpc_subnet_id).merge(user: user.login, target: params[:target])
         data = user.ec2_configuration.upload_parameters.merge(data).to_json
         http_post('/cloudupload', params: params, data: data)
       end

--- a/src/api/spec/lib/backend/api/cloud_spec.rb
+++ b/src/api/spec/lib/backend/api/cloud_spec.rb
@@ -1,0 +1,22 @@
+require 'rails_helper'
+
+RSpec.describe Backend::Api::Cloud do
+  context '#upload' do
+    let(:user) { create(:confirmed_user) }
+    let!(:ec2_configuration) { create(:ec2_configuration, user: user) }
+
+    it 'crafts a correct backend request' do
+      # rubocop:disable RSpec/MessageSpies
+      expect(Backend::Api::Cloud).to receive(:http_post).with(
+        '/cloudupload',
+        params: {
+          user:   user.login,
+          target: 'ec2'
+        },
+        data: ec2_configuration.upload_parameters.merge(vpc_subnet_id: 'my_subnet').to_json
+      )
+      # rubocop:enable RSpec/MessageSpies
+      Backend::Api::Cloud.upload(user: user, target: 'ec2', vpc_subnet_id: 'my_subnet')
+    end
+  end
+end


### PR DESCRIPTION
The vpc_subnet_id parameter was not removed from the parameter list
before doing the request to the backend. Because the backend validates
these parameters and doesn't expect / allow a vpc_subnet_id it caused a
failure during the upload.

Disabled rubocop rule, since this test is just about sending the correct
request. Having this rule enabled would mean that we have to configure
the backend for cloud uploads.