### PR TITLE
[dist] Remove old git cop config option

### DIFF
--- a/dist/git-cop_configuration.yml
+++ b/dist/git-cop_configuration.yml
@@ -18,8 +18,6 @@
 :commit_body_leading_line:
   :enabled: true
   :severity: :error
-:commit_body_leading_space:
-  :enabled: false
 :commit_body_line_length:
   :enabled: true
   :severity: :warn


### PR DESCRIPTION
got removed in https://github.com/bkuhlmann/git-cop/commit/d092bb05edb1ddd048025bc092ccf2275af4facd.
Fixes PR#4534.