### PR TITLE
[Cloud upload] Properly abort an upload job

### DIFF
--- a/dist/clouduploader.rb
+++ b/dist/clouduploader.rb
@@ -73,6 +73,10 @@ def upload_image_to_ec2(image, data, jobid)
   command << image
 
   Open3.popen2e(command) do |_stdin, stdout_stderr, _wait_thr|
+    Signal.trap("TERM") {
+      # We just omit the SIGTERM because otherwise we would not get logs from ec2uploadimg
+      STDOUT.write("Received abort signal, waiting for ec2uploadimg to properly clean up.\n")
+    }
     while line = stdout_stderr.gets
       STDOUT.write(line)
       write_result($1, jobid) if line =~ /^Created\simage:\s(ami-[\w]+)$/

--- a/src/api/app/views/webui/cloud/upload_jobs/index.html.haml
+++ b/src/api/app/views/webui/cloud/upload_jobs/index.html.haml
@@ -25,7 +25,7 @@
             = link_to "Log", cloud_upload_log_path(job.id)
             - unless ["succeeded", "failed"].include?(job.state)
               |
-              = link_to 'Abort', cloud_upload_path(job.id),  method: :delete, data: { confirm: "Do you really want to abort job #{job.id}? Please note that we do NOT clean up AWS (e.g. removing the helper instance)!" }
+              = link_to 'Abort', cloud_upload_path(job.id),  method: :delete, data: { confirm: "Do you really want to abort job #{job.id}?" }
 
 %div
   %p


### PR DESCRIPTION
Two smaller issues on the way to implement proper abortion of an upload job:
- Update the abort hint 
- Send TERM signal properly to children process