### PR TITLE
[frontend] Reduce the scope of directories we want to jslint

### DIFF
--- a/src/api/lib/tasks/dev.rake
+++ b/src/api/lib/tasks/dev.rake
@@ -68,7 +68,7 @@ namespace :dev do
     Rake::Task['haml_lint'].invoke
     sh 'rubocop -D -F -S --fail-level convention ../..'
     Rake::Task['git_cop'].invoke
-    sh 'jshint .'
+    sh 'jshint ./app/assets/javascripts/'
   end
 end
 


### PR DESCRIPTION
We were checking all files in our rails root directory. Since all
javascript files we maintain are in app/assets/javascripts we can reduce
the files we check by only checking that directory.

Reduces the execution time from ~2.2s to ~0.7s.