### PR TITLE
Revert "[frontend] Set environment variable in docker"

### DIFF
--- a/docker-compose.ci.yml
+++ b/docker-compose.ci.yml
@@ -2,8 +2,6 @@ version: "2"
 services:
   rspec:
     image: openbuildservice/frontend
-    environment:
-      - LANG=en_US.UTF-8
     volumes:
       - .:/obs
     depends_on:


### PR DESCRIPTION
This reverts commit 8279faad2897eaf73da47e8cc89e608b79251722.

This has been fixed meanwhile and we just updated to the new git-cop
version: https://github.com/bkuhlmann/git-cop/pull/40