### PR TITLE
Show cloud upload details in the list

### DIFF
--- a/src/api/app/models/cloud/backend/upload_job.rb
+++ b/src/api/app/models/cloud/backend/upload_job.rb
@@ -19,8 +19,7 @@ module Cloud
                      :arch,
                      :filename,
                      :vpc_subnet_id,
-                     :size,
-                     :backend_response
+                     :size
       alias_method :id, :name
       alias_method :architecture, :arch
       validate :validate_xml

--- a/src/api/app/views/webui/cloud/upload_jobs/index.html.haml
+++ b/src/api/app/views/webui/cloud/upload_jobs/index.html.haml
@@ -7,6 +7,7 @@
       %tr
         %th #
         %th Filename
+        %th Details
         %th Platform
         %th Status
         %th Created
@@ -15,7 +16,8 @@
       - @upload_jobs.each do |job|
         %tr
           %td= job.id
-          %td= job.filename
+          %td= link_to(job.filename, controller: '/webui/package', action: :binaries, project: job.project, package: job.package, repository: job.repository)
+          %td= job.details
           %td= job.target.upcase
           %td= job.state
           %td= time_tag(job.created_at)

--- a/src/api/spec/models/cloud/backend/upload_job_spec.rb
+++ b/src/api/spec/models/cloud/backend/upload_job_spec.rb
@@ -146,7 +146,7 @@ RSpec.describe Cloud::Backend::UploadJob, type: :model, vcr: true do
                 <pid>18788</pid>
               </clouduploadjob>
               <clouduploadjob name="3">
-                <state>uploading</state>
+                <state>succeeded</state>
                 <created>1513603663</created>
                 <user>mlschroe</user>
                 <target>ec2</target>
@@ -155,6 +155,7 @@ RSpec.describe Cloud::Backend::UploadJob, type: :model, vcr: true do
                 <package>rpm</package>
                 <arch>x86_64</arch>
                 <filename>rpm-4.14.0-504.2.x86_64.rpm</filename>
+                <details>ami-09348234</details>
                 <size>1690860</size>
                 <pid>18790</pid>
               </clouduploadjob>


### PR DESCRIPTION
Now the list of cloud uploads shows the `details` field and in case of the succeeded jobs then the resulting image name is shown (AMI for EC2).

See an example (the second succeeded job was before I enabled the result in the uploader script):
![details_cloud_upload](https://user-images.githubusercontent.com/11314634/36545609-92cea7ca-17e9-11e8-829f-607f8e9cdabf.png)
