### PR TITLE
[api] fix package owner search when defined in maintenance release pr…

### DIFF
--- a/src/api/app/models/owner.rb
+++ b/src/api/app/models/owner.rb
@@ -101,8 +101,10 @@ class Owner
       data.elements('binary').each do |b| # no order
         next unless b['project'] == prj.name
 
-        pkg = prj.packages.find_by_name(b['package'])
-        next if pkg.nil?
+        package_name = b['package']
+        package_name.gsub!(/\.[^\.]*$/, '') if prj.is_maintenance_release?
+        pkg = prj.packages.find_by_name(package_name)
+        next if pkg.nil? || pkg.is_patchinfo?
 
         # the "" means any matching relationships will get taken
         m, limit, already_checked = lookup_package_owner(rootproject, pkg, '', limit, devel, filter, deepest, already_checked)


### PR DESCRIPTION
…oject (bsc#1046062)

Not sure when this broke, but it shows we need a test case with a realistic
maintenance setup. An :Update project with kind="maintenance_release" and
following packages:

 patchinfo.42
   contains an package.rpm
 package
   contains a _link pointing to package.42
 package.42
   contains the same package.rpm

package container must get found, if it has a role="bugowner".