### PR TITLE
[frontend] Fix option name for autocompletion widget

### DIFF
--- a/src/api/app/assets/javascripts/webui/application/request.js
+++ b/src/api/app/assets/javascripts/webui/application/request.js
@@ -186,7 +186,7 @@ function requestAddReviewAutocomplete() {
         response: function(event, ui) {
           $(this).removeClass('loading-spinner');
         },
-        min_length: 2,
+        minLength: 2,
         minChars: 0,
         matchCase: true,
         max: 50


### PR DESCRIPTION
The `minLength` option was written incorrectly. This caused that the
autocompletion was using the default, 1 instead of 2 characters before
starting the auto complete.

https://api.jqueryui.com/autocomplete/#option-minLength