### PR TITLE
[webui] Return empty job list if user has no jobs

### DIFF
--- a/src/api/lib/backend/api/cloud.rb
+++ b/src/api/lib/backend/api/cloud.rb
@@ -15,7 +15,9 @@ module Backend
       # Returns the status of the cloud upload jobs of a user
       # @return [String]
       def self.status(user)
-        http_get('/cloudupload', params: { name: user.upload_jobs.pluck(:job_id) }, expand: [:name])
+        jobs = user.upload_jobs.pluck(:job_id)
+        return "<clouduploadjoblist>\n</clouduploadjoblist>\n" if jobs.empty?
+        http_get('/cloudupload', params: { name: jobs }, expand: [:name])
       end
 
       # Returns the log file of the cloud upload job


### PR DESCRIPTION
as the backend returns all jobs if there are no jobs specified in the parameter list.
Fix #4557