### PR TITLE
[backend] Require file utils module in cloud uploader script

### DIFF
--- a/dist/clouduploader.rb
+++ b/dist/clouduploader.rb
@@ -1,4 +1,6 @@
 #!/usr/bin/ruby
+
+require 'fileutils'
 require 'json'
 require 'ostruct'
 require 'open3'


### PR DESCRIPTION
Fixes uninitialized constant issue caused by recent changes
(e023f17f199602abb637f4107).

/usr/lib/obs/server/clouduploader:25:in `<main>': uninitialized constant FileUtils (NameError)