### PR TITLE
[webui][ci] Fix openQA test. Leap 42.2 -> 42.3

### DIFF
--- a/dist/t/spec/features/0030_project_spec.rb
+++ b/dist/t/spec/features/0030_project_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe "Project" do
     end
     click_link('Repositories')
     click_link('Add repositories')
-    check('repo_openSUSE_Leap_42_2')
-    expect(page).to have_content("Successfully added repository 'openSUSE_Leap_42.2'")
+    check('repo_openSUSE_Leap_42_3')
+    expect(page).to have_content("Successfully added repository 'openSUSE_Leap_42.3'")
   end
 end


### PR DESCRIPTION
openQA test was failing. It seems Leap 42.2 is not in the list of available repositories to be added. Changed to 42.3.