### PR TITLE
[dist] Add docs/ back to docker images

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,4 +2,3 @@ src/api/tmp/*
 src/api/log/*
 src/backend/t/tmp/*
 src/auth-proxy/
-docs


### PR DESCRIPTION
Files in docs/api are actually needed for tests in the old, minitest based,
test suite.