### PR TITLE
[webui] Refactor structure and workflow of cloud upload module

### DIFF
--- a/src/api/app/assets/stylesheets/webui/application.css.erb
+++ b/src/api/app/assets/stylesheets/webui/application.css.erb
@@ -34,4 +34,5 @@
  *= require webui/application/image_templates
  *= require webui/application/flash
  *= require webui/application/box-extensions
+ *= require webui/application/utils
 */

--- a/src/api/app/assets/stylesheets/webui/application/utils.scss
+++ b/src/api/app/assets/stylesheets/webui/application/utils.scss
@@ -1,0 +1,7 @@
+.float-right {
+  float: right;
+}
+
+.clear-both {
+  clear: both;
+}

--- a/src/api/app/controllers/webui/cloud/configurations_controller.rb
+++ b/src/api/app/controllers/webui/cloud/configurations_controller.rb
@@ -1,0 +1,17 @@
+module Webui
+  module Cloud
+    class ConfigurationsController < WebuiController
+      before_action :set_breadcrumb
+
+      def index
+        @crumb_list.push << 'Configuration'
+      end
+
+      private
+
+      def set_breadcrumb
+        @crumb_list = [WebuiController.helpers.link_to('Cloud Upload', cloud_upload_index_path)]
+      end
+    end
+  end
+end

--- a/src/api/app/controllers/webui/cloud/ec2/configurations_controller.rb
+++ b/src/api/app/controllers/webui/cloud/ec2/configurations_controller.rb
@@ -3,10 +3,11 @@ module Webui
     module Ec2
       class ConfigurationsController < WebuiController
         before_action :require_login
+        before_action :set_breadcrumb
         before_action -> { feature_active?(:cloud_upload) }
 
         def show
-          @crumb_list = ['EC2 Configuration']
+          @crumb_list << 'EC2'
           @ec2_configuration = User.current.ec2_configuration || User.current.create_ec2_configuration
           @aws_account_id = CONFIG['aws_account_id']
         end
@@ -23,6 +24,13 @@ module Webui
         end
 
         private
+
+        def set_breadcrumb
+          @crumb_list = [
+            WebuiController.helpers.link_to('Cloud Upload', cloud_upload_index_path),
+            WebuiController.helpers.link_to('Configuration', cloud_configuration_index_path)
+          ]
+        end
 
         def permitted_params
           params.require(:ec2_configuration).permit(:id, :arn)

--- a/src/api/app/models/user.rb
+++ b/src/api/app/models/user.rb
@@ -338,6 +338,10 @@ class User < ApplicationRecord
     end
   end
 
+  def cloud_configurations?
+    ec2_configuration.present?
+  end
+
   def to_axml(_opts = {})
     render_axml
   end

--- a/src/api/app/views/webui/cloud/configurations/index.html.haml
+++ b/src/api/app/views/webui/cloud/configurations/index.html.haml
@@ -1,0 +1,9 @@
+%h1
+  Cloud Upload Configuration
+
+%p
+  You need to configure the cloud service providers you want to upload to.
+
+%ul
+  %li
+    = link_to 'Configure Amazon EC2', cloud_ec2_configuration_path

--- a/src/api/app/views/webui/cloud/upload_jobs/index.html.haml
+++ b/src/api/app/views/webui/cloud/upload_jobs/index.html.haml
@@ -1,6 +1,14 @@
 %h1
   Cloud Upload
 
+.float-right
+  %p
+    = link_to cloud_configuration_index_path do
+      = sprite_tag('cog')
+      Cloud upload configuration
+.clear-both
+%br/
+
 %div
   %table#upload-jobs
     %thead
@@ -26,7 +34,3 @@
             - unless ["succeeded", "failed"].include?(job.state)
               |
               = link_to 'Abort', cloud_upload_path(job.id),  method: :delete, data: { confirm: "Do you really want to abort job #{job.id}?" }
-
-%div
-  %p
-    = link_to 'Update your EC2 Configuration', cloud_ec2_configuration_path

--- a/src/api/config/routes.rb
+++ b/src/api/config/routes.rb
@@ -201,6 +201,8 @@ OBSApi::Application.routes.draw do
     end
 
     resource :cloud, only: [] do
+      resources :configuration, only: [:index], controller: 'webui/cloud/configurations'
+
       resources :upload, only: [:index, :create, :destroy], controller: 'webui/cloud/upload_jobs' do
         new do
           get ':project/:package/:repository/:arch/:filename', to: 'webui/cloud/upload_jobs#new', as: '', constraints: cons

--- a/src/api/spec/controllers/webui/cloud/upload_jobs_controller_spec.rb
+++ b/src/api/spec/controllers/webui/cloud/upload_jobs_controller_spec.rb
@@ -44,7 +44,7 @@ RSpec.describe Webui::Cloud::UploadJobsController, type: :controller, vcr: true 
           end
         end
 
-        it { expect(response).to redirect_to(cloud_ec2_configuration_path) }
+        it { expect(response).to redirect_to(cloud_configuration_index_path) }
       end
 
       context 'with an EC2 configuration' do


### PR DESCRIPTION
This commit refactors the structure and the workflow of the cloud upload
module.

Changes:
  * The link to the configuration page received an icon and was put to
    the top of the `Cloud Upload history` page

  * Added a static configurations page

    When clicking the `configuration` link (described in change 2.) on
    the history page, users get pointed to a static configuration page
    where they can select their cloud service provider.

  * Refactored breadcrumbs

    The breadcrumbs where not really useful as they didn't show any
    concrete structure. This has been changed in that commit in order to
    show a good hierarchy.