### PR TITLE
[doc] Document current limitations of OBS Cloud uploader setups

### DIFF
--- a/ReleaseNotes-2.9
+++ b/ReleaseNotes-2.9
@@ -49,7 +49,7 @@ Frontend:
    - manual maintenance release support (avoiding requests)
    - operation happen atomic for entire project now
    - support release of single multibuild container
- * Ec2 cloud upload support for ec2 images
+ * Ec2 cloud upload support for ec2 images (currently only available for OBS installations based on openSUSE 42.3)
 
 Backend:
  * support showing source files in blame view (works also via links)
@@ -79,7 +79,6 @@ Backend:
 
 Shipment:
  * To make use of the ec2 cloud upload feature you need to:
-   - Enable the Public Cloud module (only needed for SLE12 systems).
    - Install the obs-cloud-uploader package.
 
 Major bugfixes:


### PR DESCRIPTION
The patches needed for ec2 cloud uploads are not yet available for the
SLE 12 - Public Cloud Module.