### PR TITLE
[ci] Fix flickering test - do not modify Configuration in test

### DIFF
--- a/src/api/spec/features/webui/packages_spec.rb
+++ b/src/api/spec/features/webui/packages_spec.rb
@@ -61,7 +61,7 @@ RSpec.feature 'Packages', type: :feature, js: true do
 
   describe 'branching a package from another users project' do
     before do
-      Configuration.update_attributes(cleanup_after_days: 14)
+      allow(Configuration).to receive(:cleanup_after_days).and_return(14)
       login user
       visit package_show_path(project: other_user.home_project, package: other_users_package)
       click_link('Branch package')


### PR DESCRIPTION
This can make other tests failing, for example _project without ImageTemplates attribute auto cleanup attribute is not set_ in `src/api/spec/models/branch_package_spec.rb`. :bowtie: 

It should fix https://github.com/openSUSE/open-build-service/issues/4618