### PR TITLE
[backend] Adding configurable RSYNCD port

### DIFF
--- a/src/backend/BSConfig.pm.template
+++ b/src/backend/BSConfig.pm.template
@@ -150,6 +150,7 @@ our $relsync_pool = {
 #No extra stage server sync
 #our $stageserver = 'rsync://127.0.0.1/put-repos-main';
 #our $stageserver_sync = 'rsync://127.0.0.1/trigger-repos-sync';
+#our $stageport = 873;
 
 #No package signing server
 #our $sign = '/usr/bin/sign';

--- a/src/backend/bs_publish
+++ b/src/backend/bs_publish
@@ -1211,6 +1211,14 @@ sub sync_to_stage {
     }
   }
 
+  # adds the default rsync port
+  my $stageport;
+  if ($BSConfig::stageport) {
+       $stageport = $BSConfig::stageport;
+  } else {
+       $stageport = 873 # default rsync port
+  }
+
   # sync the parent directory for deletes
   my $extdirx = $extdir;
   $extdirx =~ s/\/[^\/]*$// if $isdelete;
@@ -1220,8 +1228,9 @@ sub sync_to_stage {
       print "    running rsync to $1 at ".localtime(time)."\n";
       # rsync with a timeout of 1 hour
       # sync first just the binaries without deletion of the old ones, afterwards the rest(esp. meta data) and cleanup
-      qsystem('echo', "$extdirx\0", 'rsync', '-ar0', '--fuzzy', @binsufsrsync, '--include=*/', '--exclude=*', '--timeout', '7200', '--files-from=-', $extrepodir, "$1::$2") && die("    rsync failed at ".localtime(time).": $?\n");
-      qsystem('echo', "$extdirx\0", 'rsync', '-ar0', '--delete-after', '--exclude=repocache', '--delete-excluded', '--timeout', '7200', '--files-from=-', $extrepodir, "$1::$2") && die("    rsync failed at ".localtime(time).": $?\n");
+      qsystem('echo', "$extdirx\0", 'rsync', '-ar0', @binsufsrsync, '--include=*/', '--exclude=*', '--timeout', '7200', "--port=$stageport", '--files-from=-', $extrepodir, "$1::$2") && die("    rsync failed at ".localtime(time).": $?\n");
+      qsystem('echo', "$extdirx\0", 'rsync', '-ar0', '--delete-after', '--exclude=repocache', '--delete-excluded', '--timeout', '7200', "--port=$stageport", '--files-from=-', $extrepodir, "$1::$2") && die("    rsync failed at ".localtime(time).": $?\n");
+
     }
     if ($stageserver =~ /^script:(\/.*)$/) {
       print "    running sync script $1 at ".localtime(time)."\n";
@@ -1242,7 +1251,7 @@ sub sync_to_stage {
   if ($BSConfig::stageserver_sync && $BSConfig::stageserver_sync =~ /^rsync:\/\/([^\/]+)\/(.*)$/) {
     print "    running trigger rsync to $1 at ".localtime(time)."\n";
     # small sync, timout 1 minute
-    qsystem('rsync', '-a', '--timeout', '120', "$extrepodir_sync/$filename", "$1::$2/$filename") && warn("    trigger rsync failed at ".localtime(time).": $?\n");
+    qsystem('rsync', '-a', '--timeout', '120', "--port=$stageport", "$extrepodir_sync/$filename", "$1::$2/$filename") && warn("    trigger rsync failed at ".localtime(time).": $?\n");
   }
 }
 


### PR DESCRIPTION
[backend] adds a configurable parameter to BSConfig.pm to specify a custom TCP port for RSYNCD. This is necessary because since there are hardcoded "::" in the qsystem() calls, using the regular rsync://server:port format will not work as intended. RSYNCD has a less ambiguous parameter to specify the port.