### PR TITLE
[frontend] Fix validation for ec2 ARN

### DIFF
--- a/src/api/app/models/cloud/ec2/configuration.rb
+++ b/src/api/app/models/cloud/ec2/configuration.rb
@@ -25,7 +25,7 @@ module Cloud
       validates :external_id, uniqueness: true
       validates :arn, uniqueness: true, allow_nil: true
       # http://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html
-      validates :arn, format: { with: /\Aarn:([\w\-\/:])+\z/, message: 'not a valid format', allow_blank: true }
+      validates :arn, format: { with: /\Aarn:([\w\/:* +=,\.@\-_])+\z/, message: 'not a valid format', allow_blank: true }
 
       def self.table_name_prefix
         'cloud_ec2_'

--- a/src/api/spec/models/cloud/ec2/configuration_spec.rb
+++ b/src/api/spec/models/cloud/ec2/configuration_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe Cloud::Ec2::Configuration, type: :model, vcr: true do
     it { is_expected.to belong_to(:user) }
     it { is_expected.to validate_uniqueness_of(:external_id) }
     it { is_expected.to validate_uniqueness_of(:arn) }
-    it { is_expected.to allow_value('arn:123:456/tom').for(:arn) }
+    it { is_expected.to allow_value('arn:123:45.6/*/tom tom/test-role+=,.@-_').for(:arn) }
     it { is_expected.not_to allow_value('123:456/tom').for(:arn) }
   end
 


### PR DESCRIPTION
ARNs can have dots and whitespaces. They can also include a wildcards
and the @ char and the role name, which is added to the ARN, can have
"alphanumeric and '+=,.@-_' characters".

Details can be found here:
  https://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html