### PR TITLE
Add missing exception

### DIFF
--- a/src/api/app/models/event/base.rb
+++ b/src/api/app/models/event/base.rb
@@ -274,7 +274,7 @@ module Event
 
     def send_to_bus
       RabbitmqBus.publish(self.class.message_bus_routing_key, self[:payload])
-    rescue Bunny::Exception => e
+    rescue Bunny::Exception, OpenSSL::SSL::SSLError => e
       logger.error "Publishing to RabbitMQ failed: #{e.message}"
     end
 


### PR DESCRIPTION
Add missing exception to rescue clause when sending messages to RabbitMQ.
This prevents the webui to show the error.

This should fix #4522.

Co-authored-by: David Kang <dkang@suse.com>