### PR TITLE
[backend] publish ONIE binary hashsum

### DIFF
--- a/src/backend/bs_publish
+++ b/src/backend/bs_publish
@@ -1575,7 +1575,7 @@ sub publish {
 	if ($bin =~ /\.iso(?:\.sha256)?$/) {
 	  $p = "iso/$bin";
 	  $kiwimedium{$p} = $1 if $bin =~ /(.+)\.iso$/;
-	} elsif ($bin =~ /ONIE\.bin$/) {
+	} elsif ($bin =~ /ONIE\.bin(?:\.sha256)?$/) {
 	  $p = "onie/$bin";
 	  $kiwimedium{$p} = $1 if $bin =~ /(.+)ONIE\.bin$/;
 	} elsif ($bin =~ /\.raw(?:\.install)?(?:\.(?:gz|bz2|xz))?(?:\.sha256)?$/) {


### PR DESCRIPTION
Commit faac8b3d9d20 enabled publishing ONIE image binaries. Now that
obs-build creates hashsums as well, publish them too.

The sha files are added by the following obs-build PR: https://github.com/openSUSE/obs-build/pull/433