### PR TITLE
[frontend] Add LDAP migration and apply missing migrations

### DIFF
--- a/src/api/app/models/configuration.rb
+++ b/src/api/app/models/configuration.rb
@@ -153,7 +153,7 @@ end
 #  http_proxy                           :string(255)
 #  no_proxy                             :string(255)
 #  theme                                :string(255)
-#  obs_url                              :string(255)
+#  obs_url                              :string(255)      default("https://unconfigured.openbuildservice.org")
 #  cleanup_after_days                   :integer
 #  admin_email                          :string(255)      default("unconfigured@openbuildservice.org")
 #  cleanup_empty_projects               :boolean          default(TRUE)

--- a/src/api/app/models/linked_project.rb
+++ b/src/api/app/models/linked_project.rb
@@ -28,6 +28,7 @@ end
 #  linked_db_project_id       :integer          indexed => [db_project_id]
 #  position                   :integer
 #  linked_remote_project_name :string(255)
+#  vrevmode                   :string(8)        default("standard")
 #
 # Indexes
 #

--- a/src/api/app/models/unregistered_user.rb
+++ b/src/api/app/models/unregistered_user.rb
@@ -86,6 +86,7 @@ end
 #  adminnote                     :text(65535)
 #  state                         :string(11)       default("unconfirmed")
 #  owner_id                      :integer
+#  ignore_auth_services          :boolean          default(FALSE)
 #
 # Indexes
 #

--- a/src/api/app/models/user.rb
+++ b/src/api/app/models/user.rb
@@ -899,6 +899,7 @@ end
 #  adminnote                     :text(65535)
 #  state                         :string(11)       default("unconfirmed")
 #  owner_id                      :integer
+#  ignore_auth_services          :boolean          default(FALSE)
 #
 # Indexes
 #

--- a/src/api/db/structure.sql
+++ b/src/api/db/structure.sql
@@ -385,7 +385,7 @@ CREATE TABLE `configurations` (
   `http_proxy` varchar(255) COLLATE utf8_bin DEFAULT NULL,
   `no_proxy` varchar(255) COLLATE utf8_bin DEFAULT NULL,
   `theme` varchar(255) COLLATE utf8_bin DEFAULT NULL,
-  `obs_url` varchar(255) COLLATE utf8_bin DEFAULT NULL,
+  `obs_url` varchar(255) COLLATE utf8_bin DEFAULT 'https://unconfigured.openbuildservice.org',
   `cleanup_after_days` int(11) DEFAULT NULL,
   `admin_email` varchar(255) COLLATE utf8_bin DEFAULT 'unconfigured@openbuildservice.org',
   `cleanup_empty_projects` tinyint(1) DEFAULT '1',
@@ -715,6 +715,7 @@ CREATE TABLE `linked_projects` (
   `linked_db_project_id` int(11) DEFAULT NULL,
   `position` int(11) DEFAULT NULL,
   `linked_remote_project_name` varchar(255) CHARACTER SET utf8 DEFAULT NULL,
+  `vrevmode` enum('standard','unextend','extend') COLLATE utf8_bin DEFAULT 'standard',
   PRIMARY KEY (`id`),
   UNIQUE KEY `linked_projects_index` (`db_project_id`,`linked_db_project_id`) USING BTREE
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin;
@@ -1170,6 +1171,7 @@ CREATE TABLE `users` (
   `adminnote` text CHARACTER SET utf8,
   `state` enum('unconfirmed','confirmed','locked','deleted','subaccount') COLLATE utf8_bin DEFAULT 'unconfirmed',
   `owner_id` int(11) DEFAULT NULL,
+  `ignore_auth_services` tinyint(1) DEFAULT '0',
   PRIMARY KEY (`id`),
   UNIQUE KEY `users_login_index` (`login`(255)) USING BTREE,
   KEY `users_password_index` (`deprecated_password`) USING BTREE
@@ -1271,6 +1273,7 @@ INSERT INTO `schema_migrations` (version) VALUES
 ('20170323123236'),
 ('20170412121601'),
 ('20170412121957'),
+('20170413212201'),
 ('20170426153510'),
 ('20170509123922'),
 ('20170511120355'),
@@ -1313,6 +1316,8 @@ INSERT INTO `schema_migrations` (version) VALUES
 ('20171218160607'),
 ('20171219122451'),
 ('20180109115548'),
-('20180110074142');
+('20180110074142'),
+('20180221175514'),
+('20180307074538');
 
 


### PR DESCRIPTION
Per discussion in PR #4638 we already include the LDAP migration so that
users won't have to run a db migration when we inttroduce this feature
to 2.9.
There were also some missing migrations that have not been applied yet.
Those are added now as well.