### PR TITLE
[backend] backport Debian fixes to 2.9 - publish ONIE binary and hashsum, enable Secure Boot EFI signing for Debian packages

### DIFF
--- a/src/backend/bs_publish
+++ b/src/backend/bs_publish
@@ -1521,7 +1521,7 @@ sub publish {
 	if ($bin =~ /\.iso(?:\.sha256)?$/) {
 	  $p = "iso/$bin";
 	  $kiwimedium{$p} = $1 if $bin =~ /(.+)\.iso$/;
-	} elsif ($bin =~ /ONIE\.bin$/) {
+	} elsif ($bin =~ /ONIE\.bin(?:\.sha256)?$/) {
 	  $p = "onie/$bin";
 	  $kiwimedium{$p} = $1 if $bin =~ /(.+)ONIE\.bin$/;
 	} elsif ($bin =~ /\.raw(?:\.install)?(?:\.(?:gz|bz2|xz))?(?:\.sha256)?$/) {

--- a/src/backend/bs_publish
+++ b/src/backend/bs_publish
@@ -1521,6 +1521,9 @@ sub publish {
 	if ($bin =~ /\.iso(?:\.sha256)?$/) {
 	  $p = "iso/$bin";
 	  $kiwimedium{$p} = $1 if $bin =~ /(.+)\.iso$/;
+	} elsif ($bin =~ /ONIE\.bin$/) {
+	  $p = "onie/$bin";
+	  $kiwimedium{$p} = $1 if $bin =~ /(.+)ONIE\.bin$/;
 	} elsif ($bin =~ /\.raw(?:\.install)?(?:\.(?:gz|bz2|xz))?(?:\.sha256)?$/) {
 	  $p = "$bin";
 	} elsif ($bin =~ /(.*-Build\d.*)\.(?:tbz|tgz|tar|tar\.gz|tar\.bz2|tar\.xz)(\.sha256)?$/) {

--- a/src/backend/bs_repserver
+++ b/src/backend/bs_repserver
@@ -2100,7 +2100,7 @@ sub putjob {
 
   my $ev = {'type' => 'built', 'arch' => $arch, 'job' => $job};
 
-  if ($BSConfig::sign && (@{$kiwitree_tosign || []} || grep {$_->{'name'} =~ /\.(?:d?rpm|sha256|iso|pkg\.tar\.gz|pkg\.tar.xz|AppImage)$/} @$uploaded)) {
+  if ($BSConfig::sign && (@{$kiwitree_tosign || []} || grep {$_->{'name'} =~ /\.(?:d?rpm|sha256|iso|pkg\.tar\.gz|pkg\.tar.xz|AppImage|deb)$/} @$uploaded)) {
     # write jobstatus and free lock
     if (@{$kiwitree_tosign || []}) {
       my $c = '';

--- a/src/backend/bs_signer
+++ b/src/backend/bs_signer
@@ -395,7 +395,7 @@ sub signjob {
     # check for followup files
     if (!$info->{'followupfile'} && ($info->{'file'} || '') ne '_aggregate') {
       if (grep {/\.rsasign$/} @signfiles) {
-        $followupfile = (grep {/\.spec$/} @files)[0];
+        $followupfile = (grep {/\.(spec|dsc)$/} @files)[0];
         @signfiles = grep {/\.rsasign$/} @signfiles if $followupfile;
       }
       if (!$followupfile && grep {/\.followup.spec$/} @files) {


### PR DESCRIPTION
Backported from https://github.com/openSUSE/open-build-service/pull/4526 and https://github.com/openSUSE/open-build-service/pull/4639 and https://github.com/openSUSE/open-build-service/pull/4790