### PR TITLE
[frontend] Fix rubocop offense: RSpec/NotToNot

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -381,23 +381,6 @@ RSpec/NamedSubject:
 RSpec/NestedGroups:
   Enabled: false
 
-# Offense count: 18
-# Configuration parameters: EnforcedStyle, SupportedStyles.
-# SupportedStyles: not_to, to_not
-RSpec/NotToNot:
-  Exclude:
-    - 'src/api/spec/controllers/person_controller_spec.rb'
-    - 'src/api/spec/controllers/public_controller_spec.rb'
-    - 'src/api/spec/controllers/webui/main_controller_spec.rb'
-    - 'src/api/spec/controllers/webui/repositories_controller_spec.rb'
-    - 'src/api/spec/controllers/webui/user_controller_spec.rb'
-    - 'src/api/spec/helpers/validation_helper_spec.rb'
-    - 'src/api/spec/helpers/webui/webui_helper_spec.rb'
-    - 'src/api/spec/models/comment_spec.rb'
-    - 'src/api/spec/models/package_spec.rb'
-    - 'src/api/spec/models/user_spec.rb'
-    - 'src/api/spec/routing/api_matcher_spec.rb'
-
 # Offense count: 44
 # Configuration parameters: Strict, EnforcedStyle, SupportedStyles.
 # SupportedStyles: inflected, explicit

--- a/src/api/spec/controllers/person_controller_spec.rb
+++ b/src/api/spec/controllers/person_controller_spec.rb
@@ -83,7 +83,7 @@ RSpec.describe PersonController, vcr: false do
       end
 
       it 'changes the password' do
-        expect(old_password_digest).to_not eq(user.reload.password_digest)
+        expect(old_password_digest).not_to eq(user.reload.password_digest)
       end
     end
 
@@ -108,7 +108,7 @@ RSpec.describe PersonController, vcr: false do
           post :post_userinfo, params: { login: user.login, cmd: 'change_password', format: :xml }
         end
 
-        it { expect(old_password_digest).to_not eq(user.reload.password_digest) }
+        it { expect(old_password_digest).not_to eq(user.reload.password_digest) }
       end
     end
   end

--- a/src/api/spec/controllers/public_controller_spec.rb
+++ b/src/api/spec/controllers/public_controller_spec.rb
@@ -84,7 +84,7 @@ RSpec.describe PublicController, vcr: true do
         end
 
         it { is_expected.to respond_with(400) }
-        it { expect(a_request(:get, /.*\/source\/public_controller_project\?nofilename=1&view=info/)).to_not have_been_made }
+        it { expect(a_request(:get, /.*\/source\/public_controller_project\?nofilename=1&view=info/)).not_to have_been_made }
       end
 
       context "and nofilename is equal '1'" do

--- a/src/api/spec/controllers/webui/main_controller_spec.rb
+++ b/src/api/spec/controllers/webui/main_controller_spec.rb
@@ -19,13 +19,13 @@ RSpec.describe Webui::MainController do
 
       expect do
         post :add_news, params: { message: 'Some message' }
-      end.to_not change(StatusMessage, :count)
+      end.not_to change(StatusMessage, :count)
       expect(response).to redirect_to(root_path)
       expect(flash[:error]).to eq('Please provide a message and severity')
 
       expect do
         post :add_news, params: { severity: 'Green' }
-      end.to_not change(StatusMessage, :count)
+      end.not_to change(StatusMessage, :count)
       expect(response).to redirect_to(root_path)
       expect(flash[:error]).to eq('Please provide a message and severity')
     end

--- a/src/api/spec/controllers/webui/repositories_controller_spec.rb
+++ b/src/api/spec/controllers/webui/repositories_controller_spec.rb
@@ -125,7 +125,7 @@ RSpec.describe Webui::RepositoriesController, vcr: true do
       end
 
       it { expect(action).to redirect_to(root_url) }
-      it { expect { action }.to_not change(Repository, :count) }
+      it { expect { action }.not_to change(Repository, :count) }
     end
 
     context 'with a non valid target repository' do

--- a/src/api/spec/controllers/webui/user_controller_spec.rb
+++ b/src/api/spec/controllers/webui/user_controller_spec.rb
@@ -333,7 +333,7 @@ RSpec.describe Webui::UserController do
 
       it 'applies the Admin role properly' do
         patch :update, params: { user: { login: user.login, make_admin: true } }
-        expect(user.roles.find_by(title: 'Admin')).to_not be_nil
+        expect(user.roles.find_by(title: 'Admin')).not_to be_nil
       end
     end
 

--- a/src/api/spec/helpers/validation_helper_spec.rb
+++ b/src/api/spec/helpers/validation_helper_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe ValidationHelper do
     end
 
     it 'does not raise an exception on valid project names' do
-      expect { valid_project_name!('home:mschnitzer') }.to_not raise_error
+      expect { valid_project_name!('home:mschnitzer') }.not_to raise_error
     end
   end
 end

--- a/src/api/spec/helpers/webui/webui_helper_spec.rb
+++ b/src/api/spec/helpers/webui/webui_helper_spec.rb
@@ -375,7 +375,7 @@ RSpec.describe Webui::WebuiHelper do
   describe '#codemirror_style' do
     context 'option height' do
       it 'uses auto as default value' do
-        expect(codemirror_style).to_not include('height')
+        expect(codemirror_style).not_to include('height')
       end
 
       it 'get set properly' do
@@ -385,7 +385,7 @@ RSpec.describe Webui::WebuiHelper do
 
     context 'option width' do
       it 'uses auto as default value' do
-        expect(codemirror_style).to_not include('width')
+        expect(codemirror_style).not_to include('width')
       end
 
       it 'get set properly' do

--- a/src/api/spec/models/comment_spec.rb
+++ b/src/api/spec/models/comment_spec.rb
@@ -103,7 +103,7 @@ RSpec.describe Comment do
       end
 
       it "shouldn't be destroyed" do
-        expect { comment_package.blank_or_destroy }.to_not(change { Comment.count })
+        expect { comment_package.blank_or_destroy }.not_to(change { Comment.count })
         expect(comment_package.body).to eq 'This comment has been deleted'
         expect(comment_package.user.login).to eq '_nobody_'
       end

--- a/src/api/spec/models/package_spec.rb
+++ b/src/api/spec/models/package_spec.rb
@@ -133,7 +133,7 @@ RSpec.describe Package, vcr: true do
       it 'does not delete file' do
         expect do
           package_with_file.source_file('somefile.txt')
-        end.to_not raise_error
+        end.not_to raise_error
       end
     end
 

--- a/src/api/spec/models/user_spec.rb
+++ b/src/api/spec/models/user_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe User do
     it { is_expected.to validate_inclusion_of(:state).in_array(User::STATES) }
 
     it { is_expected.to allow_value('king@opensuse.org').for(:email) }
-    it { is_expected.to_not allow_values('king.opensuse.org', 'opensuse.org', 'opensuse').for(:email) }
+    it { is_expected.not_to allow_values('king.opensuse.org', 'opensuse.org', 'opensuse').for(:email) }
 
     it { expect(user.state).to eq('unconfirmed') }
 
@@ -632,7 +632,7 @@ RSpec.describe User do
         let!(:review_of_another_subject) { create(:review, by_group: other_group.title, bs_request: request_of_another_subject) }
 
         it 'not include reviews where the user is the creator of the request' do
-          expect(subject).to_not include(request_of_another_subject)
+          expect(subject).not_to include(request_of_another_subject)
         end
       end
     end
@@ -653,7 +653,7 @@ RSpec.describe User do
         let!(:review_of_another_subject) { create(:review, by_project: other_project.name, bs_request: request_of_another_subject) }
 
         it 'not include reviews where the user is the creator of the request' do
-          expect(subject).to_not include(request_of_another_subject)
+          expect(subject).not_to include(request_of_another_subject)
         end
       end
     end
@@ -678,7 +678,7 @@ RSpec.describe User do
         end
 
         it 'not include reviews where the user is the creator of the request' do
-          expect(subject).to_not include(request_of_another_subject)
+          expect(subject).not_to include(request_of_another_subject)
         end
       end
     end

--- a/src/api/spec/routing/api_matcher_spec.rb
+++ b/src/api/spec/routing/api_matcher_spec.rb
@@ -4,9 +4,9 @@ RSpec.describe 'APIMatcher' do
   it { expect(get('/distributions?format=xml')).to route_to(controller: 'distributions', action: 'index', format: 'xml') }
 
   context '/public and /about path use API routes with html format' do
-    it { expect(get('/distributions?format=html')).to_not route_to(controller: 'distributions', action: 'index', format: 'html') }
-    it { expect(get('/distributions/about?format=html')).to_not route_to(controller: 'distributions', action: 'show', id: 'about', format: 'html') }
-    it { expect(get('/distributions/public?format=html')).to_not route_to(controller: 'distributions', action: 'show', id: 'public', format: 'html') }
+    it { expect(get('/distributions?format=html')).not_to route_to(controller: 'distributions', action: 'index', format: 'html') }
+    it { expect(get('/distributions/about?format=html')).not_to route_to(controller: 'distributions', action: 'show', id: 'about', format: 'html') }
+    it { expect(get('/distributions/public?format=html')).not_to route_to(controller: 'distributions', action: 'show', id: 'public', format: 'html') }
   end
 
   RSpec.shared_examples '/public routes to PublicController independent of format' do |format|


### PR DESCRIPTION
We prefer not_to over to_not.