### PR TITLE
Refactor Webui controller, part 5

### DIFF
--- a/src/api/app/controllers/webui/request_controller.rb
+++ b/src/api/app/controllers/webui/request_controller.rb
@@ -176,7 +176,6 @@ class Webui::RequestController < Webui::WebuiController
   end
 
   def list_small
-    required_parameters :project # the minimum
     redirect_to(user_show_path(User.current)) && return unless request.xhr? # non ajax request
     requests = BsRequest.list(params)
     render partial: 'requests_small', locals: { requests: requests }

--- a/src/api/app/controllers/webui/request_controller.rb
+++ b/src/api/app/controllers/webui/request_controller.rb
@@ -281,7 +281,6 @@ class Webui::RequestController < Webui::WebuiController
   end
 
   def change_devel_request_dialog
-    required_parameters :package, :project
     @package = Package.find_by_project_and_name(params[:project], params[:package])
     if @package.develpackage
       @current_devel_package = @package.develpackage.name

--- a/src/api/app/controllers/webui/request_controller.rb
+++ b/src/api/app/controllers/webui/request_controller.rb
@@ -225,7 +225,6 @@ class Webui::RequestController < Webui::WebuiController
   end
 
   def add_role_request
-    required_parameters :project, :role
     req = nil
     begin
       BsRequest.transaction do

--- a/src/api/app/controllers/webui/request_controller.rb
+++ b/src/api/app/controllers/webui/request_controller.rb
@@ -188,7 +188,6 @@ class Webui::RequestController < Webui::WebuiController
   end
 
   def delete_request
-    required_parameters :project
     req = nil
     begin
       BsRequest.transaction do

--- a/src/api/app/controllers/webui/request_controller.rb
+++ b/src/api/app/controllers/webui/request_controller.rb
@@ -17,7 +17,6 @@ class Webui::RequestController < Webui::WebuiController
   end
 
   def add_reviewer
-    required_parameters :review_type
     begin
       opts = {}
       case params[:review_type]

--- a/src/api/app/controllers/webui/request_controller.rb
+++ b/src/api/app/controllers/webui/request_controller.rb
@@ -290,7 +290,6 @@ class Webui::RequestController < Webui::WebuiController
   end
 
   def change_devel_request
-    required_parameters :devel_project, :package, :project
     req = nil
     begin
       BsRequest.transaction do

--- a/src/api/app/controllers/webui/user_controller.rb
+++ b/src/api/app/controllers/webui/user_controller.rb
@@ -162,12 +162,10 @@ class Webui::UserController < Webui::WebuiController
   end
 
   def autocomplete
-    required_parameters :term
     render json: User.autocomplete_login(params[:term])
   end
 
   def tokens
-    required_parameters :q
     render json: User.autocomplete_token(params[:q])
   end
 

--- a/src/api/app/controllers/webui/user_controller.rb
+++ b/src/api/app/controllers/webui/user_controller.rb
@@ -88,14 +88,7 @@ class Webui::UserController < Webui::WebuiController
     render_dialog
   end
 
-  def user_icon
-    required_parameters :icon
-    params[:user] = params[:icon].gsub(/.png$/, '')
-    icon
-  end
-
   def icon
-    required_parameters :user
     size = params[:size].to_i || '20'
     user = User.find_by_login(params[:user])
     if user.nil? || (content = user.gravatar_image(size)) == :none

--- a/src/api/app/helpers/webui/webui_helper.rb
+++ b/src/api/app/helpers/webui/webui_helper.rb
@@ -34,7 +34,7 @@ module Webui::WebuiHelper
     user = User.find_by_login!(user) unless user.is_a? User
     alt ||= user.realname
     alt = user.login if alt.empty?
-    image_tag(user_icon_path(icon: user.login, size: size), width: size, height: size, alt: alt, class: css_class)
+    image_tag(icon_user_path(user: user.login, size: size), width: size, height: size, alt: alt, class: css_class)
   end
 
   def fuzzy_time(time, with_fulltime = true)

--- a/src/api/app/views/webui/package/show.html.erb
+++ b/src/api/app/views/webui/package/show.html.erb
@@ -142,7 +142,7 @@
             <%# TODO: only users w/o rights should see this, maintainers should get a different dialog: %>
             <% if @package.develpackage %>
                 <li>
-                  <%= link_to(sprited_text('arrow_switch', 'Request devel project change'), { :controller => 'request', :action => 'change_devel_request_dialog', :project => @project, :package => @package }, :remote => true) %>
+                  <%= link_to(sprited_text('arrow_switch', 'Request devel project change'), { controller: :request, action: :change_devel_request_dialog, project: @project, package: @package }, remote: true) %>
                 </li>
             <% end %>
         <% end %>

--- a/src/api/app/views/webui/request/_add_role_request_dialog.html.erb
+++ b/src/api/app/views/webui/request/_add_role_request_dialog.html.erb
@@ -4,8 +4,7 @@
       <div class="dialog-content">
         <p>Do you want to request a role addition to <%= project_or_package_link project: @project, package: @package %>?</p>
 
-        <%= form_tag(:action => 'add_role_request') do %>
-          <%= hidden_field_tag(:project, @project) %>
+        <%= form_tag(action: 'add_role_request', project: @project) do %>
           <%= hidden_field_tag(:package, @package) if defined? @package %>
           <p>
             <%= label_tag(:role, 'Add role:') %><br/>

--- a/src/api/app/views/webui/request/_change_devel_request_dialog.html.erb
+++ b/src/api/app/views/webui/request/_change_devel_request_dialog.html.erb
@@ -9,16 +9,14 @@
         <% else %>
           <p>Do you want to request to set the devel project for <%= package_link @package %>?</p>
         <% end %>
-        <%= form_tag(:action => 'change_devel_request', :method => 'post') do %>
-          <%= hidden_field_tag(:project, @project.name) %>
-          <%= hidden_field_tag(:package, @package.name) %>
+        <%= form_tag({ action: :change_devel_request, project: @project, package: @package }, :method => 'post') do %>
           <p>
             <% if @current_devel_project && @current_devel_package %>
               <%= label_tag(:devel_project, 'New Devel project (leave free to delete the current one):') %><br/>
             <% else %>
               <%= label_tag(:devel_project, 'Devel project:') %><br/>
             <% end %>
-            <%= text_field_tag(:devel_project, '', :size => 40) %><br/>
+            <%= text_field_tag(:devel_project, '', :size => 40, required: true) %><br/>
             <%= label_tag(:description, 'Description:') %><br/>
             <%= text_area_tag(:description, '', :size => '40x3') %>
           </p>

--- a/src/api/app/views/webui/request/_delete_request_dialog.html.erb
+++ b/src/api/app/views/webui/request/_delete_request_dialog.html.erb
@@ -4,8 +4,7 @@
       <div class="dialog-content">
         <p>Do you really want to request the deletion of <%= project_or_package_link project: @project, package: @package %>?</p>
 
-        <%= form_tag(:action => 'delete_request', :method => 'post') do %>
-          <%= hidden_field_tag(:project, @project) %>
+        <%= form_tag({ action: :delete_request, project: @project }, method: :post) do %>
           <%= hidden_field_tag(:package, @package) if defined? @package %>
           <p>
             <% if defined? @package %>

--- a/src/api/config/routes.rb
+++ b/src/api/config/routes.rb
@@ -344,13 +344,12 @@ OBSApi::Application.routes.draw do
       get 'user/edit/:user' => :edit, constraints: cons, as: 'user_edit'
 
       get 'user/show/:user' => :show, constraints: cons, as: 'user_show'
-      get 'user/icon/:icon' => :user_icon, constraints: cons, as: 'user_icon'
       # Only here to make old /home url's work
       get 'home/' => :home, as: 'home'
       get 'home/my_work' => :home
       get 'home/list_my' => :home
       get 'home/home_project' => :home_project
-      get 'user/:user/icon' => :icon, constraints: cons
+      get 'user/:user/icon' => :icon, constraints: cons, as: :icon_user
     end
 
     controller 'webui/session' do

--- a/src/api/config/routes.rb
+++ b/src/api/config/routes.rb
@@ -312,7 +312,7 @@ OBSApi::Application.routes.draw do
       post 'request/add_role_request/:project' => :add_role_request, constraints: cons
       get 'request/set_bugowner_request_dialog' => :set_bugowner_request_dialog
       post 'request/set_bugowner_request' => :set_bugowner_request
-      get 'request/change_devel_request_dialog' => :change_devel_request_dialog
+      get 'request/change_devel_request_dialog/:project/:package' => :change_devel_request_dialog, constraints: cons
       post 'request/change_devel_request' => :change_devel_request
       get 'request/set_incident_dialog' => :set_incident_dialog
       post 'request/set_incident' => :set_incident

--- a/src/api/config/routes.rb
+++ b/src/api/config/routes.rb
@@ -307,7 +307,7 @@ OBSApi::Application.routes.draw do
       get 'request/diff/:number' => :diff
       get 'request/list_small' => :list_small
       get 'request/delete_request_dialog' => :delete_request_dialog
-      post 'request/delete_request' => :delete_request
+      post 'request/delete_request/:project' => :delete_request, constraints: cons
       get 'request/add_role_request_dialog' => :add_role_request_dialog
       post 'request/add_role_request' => :add_role_request
       get 'request/set_bugowner_request_dialog' => :set_bugowner_request_dialog

--- a/src/api/config/routes.rb
+++ b/src/api/config/routes.rb
@@ -313,7 +313,7 @@ OBSApi::Application.routes.draw do
       get 'request/set_bugowner_request_dialog' => :set_bugowner_request_dialog
       post 'request/set_bugowner_request' => :set_bugowner_request
       get 'request/change_devel_request_dialog/:project/:package' => :change_devel_request_dialog, constraints: cons
-      post 'request/change_devel_request' => :change_devel_request
+      post 'request/change_devel_request/:project/:package' => :change_devel_request, constraints: cons
       get 'request/set_incident_dialog' => :set_incident_dialog
       post 'request/set_incident' => :set_incident
     end

--- a/src/api/config/routes.rb
+++ b/src/api/config/routes.rb
@@ -309,7 +309,7 @@ OBSApi::Application.routes.draw do
       get 'request/delete_request_dialog' => :delete_request_dialog
       post 'request/delete_request/:project' => :delete_request, constraints: cons
       get 'request/add_role_request_dialog' => :add_role_request_dialog
-      post 'request/add_role_request' => :add_role_request
+      post 'request/add_role_request/:project' => :add_role_request, constraints: cons
       get 'request/set_bugowner_request_dialog' => :set_bugowner_request_dialog
       post 'request/set_bugowner_request' => :set_bugowner_request
       get 'request/change_devel_request_dialog' => :change_devel_request_dialog

--- a/src/api/spec/controllers/webui/user_controller_spec.rb
+++ b/src/api/spec/controllers/webui/user_controller_spec.rb
@@ -337,10 +337,6 @@ RSpec.describe Webui::UserController do
     skip
   end
 
-  describe 'GET #user_icon' do
-    skip
-  end
-
   describe 'GET #icon' do
     skip
   end

--- a/src/api/spec/features/webui/users/users_icons_spec.rb
+++ b/src/api/spec/features/webui/users/users_icons_spec.rb
@@ -3,10 +3,10 @@ require 'browser_helper'
 RSpec.feature "User's icons", type: :feature, js: true do
   let(:user) { create(:confirmed_user, login: 'moi') }
 
-  scenario 'specifying png format' do
-    visit "/user/icon/#{user.login}.png"
+  scenario 'specifying icon' do
+    visit "/user/#{user.login}/icon"
     expect(page.status_code).to be 200
-    visit "/user/icon/#{user.login}.png?size=20"
+    visit "/user/#{user.login}/icon?size=20"
     expect(page.status_code).to be 200
   end
 

--- a/src/api/spec/helpers/webui/webui_helper_spec.rb
+++ b/src/api/spec/helpers/webui/webui_helper_spec.rb
@@ -341,7 +341,7 @@ RSpec.describe Webui::WebuiHelper do
       it 'does not link to user profiles' do
         expect(user_and_role(user.login)).to eq(
           "<img width=\"20\" height=\"20\" alt=\"#{CGI.escapeHTML(user.realname)}\" " \
-          "src=\"/user/icon/#{user.login}?size=20\" />#{CGI.escapeHTML(user.realname)} (#{user.login})"
+          "src=\"/user/#{user.login}/icon?size=20\" />#{CGI.escapeHTML(user.realname)} (#{user.login})"
         )
       end
     end


### PR DESCRIPTION
Remove  `required_parameters` callbacks from the following controllers: `Webui::RequestController`, `Webui::UserController`.

This will allow us to remove the following class in the future:
``class MissingParameterError < RuntimeError; end``.