### PR TITLE
[frontend] Do not assign associations twice

### DIFF
--- a/src/api/app/controllers/webui/package_controller.rb
+++ b/src/api/app/controllers/webui/package_controller.rb
@@ -283,7 +283,6 @@ class Webui::PackageController < Webui::WebuiController
         opts[:source_rev] = params[:rev] if params[:rev]
         action = BsRequestActionSubmit.new(opts)
         req.bs_request_actions << action
-        action.bs_request = req
 
         req.set_add_revision
         req.save!

--- a/src/api/app/controllers/webui/project_controller.rb
+++ b/src/api/app/controllers/webui/project_controller.rb
@@ -133,7 +133,6 @@ class Webui::ProjectController < Webui::WebuiController
 
         action = BsRequestActionMaintenanceIncident.new(source_project: params[:project])
         req.bs_request_actions << action
-        action.bs_request = req
 
         req.set_add_revision
         req.save!
@@ -164,7 +163,6 @@ class Webui::ProjectController < Webui::WebuiController
 
           action = BsRequestActionMaintenanceRelease.new(source_project: params[:project])
           req.bs_request_actions << action
-          action.bs_request = req
 
           req.save!
         end
@@ -378,7 +376,6 @@ class Webui::ProjectController < Webui::WebuiController
         opts[:target_repository] = params[:repository] if params[:repository]
         action = BsRequestActionDelete.new(opts)
         req.bs_request_actions << action
-        action.bs_request = req
 
         req.save!
       end

--- a/src/api/app/controllers/webui/request_controller.rb
+++ b/src/api/app/controllers/webui/request_controller.rb
@@ -202,7 +202,6 @@ class Webui::RequestController < Webui::WebuiController
         opts[:target_repository] = params[:repository] if params[:repository]
         action = BsRequestActionDelete.new(opts)
         req.bs_request_actions << action
-        action.bs_request = req
 
         req.save!
       end
@@ -243,7 +242,6 @@ class Webui::RequestController < Webui::WebuiController
         opts[:group_name] = params[:group] if params[:group]
         action = BsRequestActionAddRole.new(opts)
         req.bs_request_actions << action
-        action.bs_request = req
 
         req.save!
       end
@@ -274,7 +272,6 @@ class Webui::RequestController < Webui::WebuiController
         opts[:group_name] = params[:group] if params[:group]
         action = BsRequestActionSetBugowner.new(opts)
         req.bs_request_actions << action
-        action.bs_request = req
 
         req.save!
       end
@@ -308,7 +305,6 @@ class Webui::RequestController < Webui::WebuiController
           source_package: params[:devel_package] || params[:package])
 
         req.bs_request_actions << action
-        action.bs_request = req
         req.save!
       end
     rescue BsRequestAction::UnknownProject,
@@ -422,7 +418,6 @@ class Webui::RequestController < Webui::WebuiController
           opts[:sourceupdate] = params[:sourceupdate] if params[:sourceupdate]
           action = BsRequestActionSubmit.new(opts)
           req.bs_request_actions << action
-          action.bs_request = req
 
           req.save!
         end


### PR DESCRIPTION
With `req.bs_request_actions << action` + `req.save!`, `action.bs_request` is already assigned to `req`. Stop doing it extra and :heart: the magic of Active Record Associations.