### PR TITLE
[frontend] Do not assign associations twice (2)

### DIFF
--- a/src/api/test/unit/package_remove_test.rb
+++ b/src/api/test/unit/package_remove_test.rb
@@ -86,7 +86,6 @@ class PackageRemoveTest < ActiveSupport::TestCase
                                        target_package: package,
                                        sourceupdate: 'update')
     request.bs_request_actions << action
-    action.bs_request = request
     request.set_add_revision
     request.save!
     @request = request.reload

--- a/src/api/test/unit/project_remove_test.rb
+++ b/src/api/test/unit/project_remove_test.rb
@@ -123,7 +123,6 @@ class ProjectRemoveTest < ActiveSupport::TestCase
                                        target_package: package,
                                        sourceupdate: 'update')
     request.bs_request_actions << action
-    action.bs_request = request
     request.set_add_revision
     request.save!
     @request = request.reload


### PR DESCRIPTION
With `request.bs_request_actions << action` + `request.save!`, `action.bs_request` is already assigned to `request`. Stop doing it extra and use the magic of Active Record Associations.