### PR TITLE
[frontend] Always present notification icon

### DIFF
--- a/src/api/app/views/layouts/webui/_personal_navigation.html.haml
+++ b/src/api/app/views/layouts/webui/_personal_navigation.html.haml
@@ -2,11 +2,14 @@
   - if User.current && !User.current.is_nobody?
     = link_to(home_path, id: 'link-to-user-home') do
       = User.current.login
+    |
     - tasks = User.current.tasks
     - if tasks > 0
-      |
-      = link_to(user_tasks_path, title: 'where an action is requested from you') do
-        = pluralize(tasks, 'Task')
+      = link_to(user_tasks_path) do
+        %span{title: 'where an action is requested from you' }
+          = pluralize(tasks, 'Task')
+    - else
+      Tasks
     |
     - if User.current.home_project
       = link_to 'Home Project', project_show_path(User.current.home_project)

--- a/src/api/spec/features/webui/login_spec.rb
+++ b/src/api/spec/features/webui/login_spec.rb
@@ -39,13 +39,17 @@ RSpec.feature 'Login', type: :feature, js: true do
 
   scenario 'login with home project shows a link to it' do
     login user
-    expect(page).to have_content "#{user.login} | Home Project | Logout"
+    within('#subheader') do
+      expect(page).to have_link('Home Project')
+    end
   end
 
   scenario 'login without home project shows a link to create it' do
     user.home_project.destroy
     login user
-    expect(page).to have_content "#{user.login} | Create Home | Logout"
+    within('#subheader') do
+      expect(page).to have_link('Create Home')
+    end
   end
 
   scenario 'login via login page' do
@@ -133,7 +137,9 @@ RSpec.feature 'Login', type: :feature, js: true do
         page.driver.add_header('AUTHORIZATION', "Negotiate #{Base64.strict_encode64(ticket)}")
 
         click_link('Log In')
-        expect(page).to have_content "#{login} | Home Project | Logout"
+        within('#subheader') do
+          expect(page).to have_link('Home Project')
+        end
       end
     end
 
@@ -155,7 +161,9 @@ RSpec.feature 'Login', type: :feature, js: true do
         page.driver.add_header('AUTHORIZATION', "Negotiate #{Base64.strict_encode64('ticket')}")
 
         click_link('Log In')
-        expect(page).not_to have_content '| Home Project | Logout'
+        within('#subheader') do
+          expect(page).not_to have_link('Home Project')
+        end
         expect(find('.flash-content')).to have_text "Authentication failed: 'Received a GSSAPI exception"
         expect(find('.flash-content')).to have_text "couldn't validate ticket"
       end

--- a/src/api/spec/features/webui/users/users_home_project_spec.rb
+++ b/src/api/spec/features/webui/users/users_home_project_spec.rb
@@ -10,7 +10,6 @@ RSpec.feature "User's home project creation", type: :feature, js: true do
 
     click_button('Create Project')
     expect(page).to have_content("Project '#{user.home_project_name}' was created successfully")
-    expect(page).to have_content "#{user.login} | Home Project | Logout"
     expect(user.home_project).not_to be_nil
   end
 end


### PR DESCRIPTION
There is no other way to get to user_tasks_path, so always show this.
Switch to an icon because this is easier to grasp as text and for most
people the number of tasks is not important, but that there are tasks.

![screenshot from 2018-03-19 16-18-30](https://user-images.githubusercontent.com/514785/37604746-fb8993c2-2b91-11e8-9e25-e30bfe716a93.png)
![screenshot from 2018-03-19 16-18-22](https://user-images.githubusercontent.com/514785/37604749-fc2b3a7e-2b91-11e8-989f-4c6c87f1664e.png)
