### PR TITLE
[frontend] Drop halt_callback_chains_on_return_false

### DIFF
--- a/src/api/app/models/package.rb
+++ b/src/api/app/models/package.rb
@@ -814,7 +814,6 @@ class Package < ApplicationRecord
     else
       logger.tagged('backend_sync') { logger.warn "Not saving Package #{project.name}/#{name}, global_write_through is off" }
     end
-    true
   end
 
   def delete_on_backend
@@ -824,8 +823,8 @@ class Package < ApplicationRecord
 
     # not really packages...
     # everything below _product:
-    return true if name =~ /\A_product:\w[-+\w\.]*\z/ && master_product_object != self
-    return true if name == '_project'
+    return if name =~ /\A_product:\w[-+\w\.]*\z/ && master_product_object != self
+    return if name == '_project'
 
     if CONFIG['global_write_through'] && !@commit_opts[:no_backend_write]
       path = source_path
@@ -847,7 +846,6 @@ class Package < ApplicationRecord
     else
       logger.tagged('backend_sync') { logger.warn "Not deleting Package #{project.name}/#{name}, global_write_through is off" }
     end
-    true
   end
 
   def to_axml_id

--- a/src/api/app/models/project.rb
+++ b/src/api/app/models/project.rb
@@ -645,7 +645,6 @@ class Project < ApplicationRecord
     end
 
     self.commit_opts = {}
-    true
   end
   private :delete_on_backend
 

--- a/src/api/app/models/user.rb
+++ b/src/api/app/models/user.rb
@@ -102,15 +102,14 @@ class User < ApplicationRecord
     return unless can_create_project?(home_project_name)
     # find or create the project
     project = Project.find_by(name: home_project_name)
-    unless project
-      project = Project.create(name: home_project_name)
-      # make the user maintainer
-      project.relationships.create(user: self,
-                                   role: Role.find_by_title('maintainer'))
-      project.store(login: login)
-      @home_project = project
-    end
-    true
+    return if project
+
+    project = Project.create(name: home_project_name)
+    # make the user maintainer
+    project.relationships.create(user: self,
+                                 role: Role.find_by_title('maintainer'))
+    project.store(login: login)
+    @home_project = project
   end
 
   # Inform ActiveModel::Dirty that changes are persistent now

--- a/src/api/config/initializers/new_framework_defaults.rb
+++ b/src/api/config/initializers/new_framework_defaults.rb
@@ -18,6 +18,3 @@ ActiveSupport.to_time_preserves_timezone = false
 
 # Require `belongs_to` associations by default. Previous versions had false.
 Rails.application.config.active_record.belongs_to_required_by_default = false
-
-# Do not halt callback chains when a callback returns false. Previous versions had true.
-ActiveSupport.halt_callback_chains_on_return_false = true


### PR DESCRIPTION
In Rails 5 before_* callbacks that return false do not halt the callback
chain anymore. We were keeping this behaviour alive via Rails's
new_framework_defaults initializer.
But this got deprecated in 5.1. So as preparation for 5.2 we had to
verify that we don't need this anymore and finally drop it.
Which is done with this commit;-)

And because of this change we don't have to explicitly return true
anymore in Package#delete_on_backend.