### PR TITLE
[frontend] Add an API route to the cloud upload controller

### DIFF
--- a/src/api/app/models/cloud/backend/upload_job.rb
+++ b/src/api/app/models/cloud/backend/upload_job.rb
@@ -32,8 +32,9 @@ module Cloud
         new(exception: exception.message)
       end
 
-      def self.all(user)
+      def self.all(user, options = {})
         xml = ::Backend::Api::Cloud.status(user)
+        return xml if options[:format] == :xml
         [Xmlhash.parse(xml)['clouduploadjob']].flatten.compact.map do |xml_hash|
           new(xml_object: OpenStruct.new(xml_hash))
         end

--- a/src/api/app/models/cloud/params/ec2.rb
+++ b/src/api/app/models/cloud/params/ec2.rb
@@ -1,3 +1,5 @@
+require 'builder'
+
 module Cloud
   module Params
     class Ec2
@@ -13,6 +15,14 @@ module Cloud
 
       def self.build(params)
         new(params.slice(:region, :ami_name))
+      end
+
+      def to_xml(options = {})
+        builder = options[:builder] || Builder::XmlMarkup.new(options)
+        builder.cloud_upload_params do |xml|
+          xml.ami_name ami_name
+          xml.region region
+        end
       end
 
       private

--- a/src/api/app/models/cloud/upload_job.rb
+++ b/src/api/app/models/cloud/upload_job.rb
@@ -1,3 +1,5 @@
+require 'builder'
+
 module Cloud
   class UploadJob
     include ActiveModel::Validations
@@ -37,6 +39,16 @@ module Cloud
 
     def target_validator_class
       @target_validator_class ||= "::Cloud::Params::#{target.capitalize}".constantize
+    end
+
+    def to_xml(options = {})
+      builder = Builder::XmlMarkup.new(options)
+      builder.cloud_upload_job(id: id) do |xml|
+        xml.target target
+        xml.filename filename
+        xml.vpc_subnet_id vpc_subnet_id
+        target_params.to_xml(options.merge(builder: xml))
+      end
     end
 
     private

--- a/src/api/config/routes.rb
+++ b/src/api/config/routes.rb
@@ -673,6 +673,18 @@ OBSApi::Application.routes.draw do
 
     put '/mail_handler' => 'mail_handler#upload'
 
+    ### /cloud/upload
+
+    scope :cloud, as: :cloud do
+      resources :upload, only: [:index, :create, :destroy], controller: 'webui/cloud/upload_jobs' do
+        new do
+          get ':project/:package/:repository/:arch/:filename', to: redirect('webui/cloud/upload_jobs#new')
+        end
+
+        resource :log, only: :show, controller: 'webui/cloud/upload_job/logs'
+      end
+    end
+
     ### /public
     controller :public do
       get 'public' => :index

--- a/src/api/spec/routing/api_matcher_spec.rb
+++ b/src/api/spec/routing/api_matcher_spec.rb
@@ -3,6 +3,8 @@ require 'rails_helper'
 RSpec.describe 'APIMatcher' do
   it { expect(get('/distributions?format=xml')).to route_to(controller: 'distributions', action: 'index', format: 'xml') }
 
+  it { expect(get('/cloud/upload')).to route_to(controller: 'webui/cloud/upload_jobs', action: 'index') }
+
   context '/public and /about path use API routes with html format' do
     it { expect(get('/distributions?format=html')).not_to route_to(controller: 'distributions', action: 'index', format: 'html') }
     it { expect(get('/distributions/about?format=html')).not_to route_to(controller: 'distributions', action: 'show', id: 'about', format: 'html') }


### PR DESCRIPTION
This adds API routes (aka xml responses) for:

  * Creation of upload jobs
  * Listing all upload jobs a user has access to

We are re-using the existing webui controller, unlike we usually do, to
reduce code duplication.