### PR TITLE
[webui] Fix encodings exception in event mailer

### DIFF
--- a/src/api/app/views/event_mailer/_submit_action.text.erb
+++ b/src/api/app/views/event_mailer/_submit_action.text.erb
@@ -1,4 +1,4 @@
 - <%= a['type'] %> <%= a['sourceproject'] %>/<%= a['sourcepackage'] %> => <%= a['targetproject'] %>/<%= a['targetpackage'] %>
 <% if a['diff'] -%>
-<%= a['diff'] %>
+<%= a['diff'].force_encoding('UTF-8') %>
 <% end -%>

--- a/src/api/spec/cassettes/EventMailer/_event/for_an_event_of_type_Event_Request/using_different_encodings/does_not_throw_an_incompatible_character_encodings_exception.yml
+++ b/src/api/spec/cassettes/EventMailer/_event/for_an_event_of_type_Event_Request/using_different_encodings/does_not_throw_an_incompatible_character_encodings_exception.yml
@@ -1,0 +1,720 @@
+---
+http_interactions:
+- request:
+    method: put
+    uri: http://backend:5352/source/home:user_1/_meta?user=user_1
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:user_1">
+          <title/>
+          <description/>
+          <person userid="user_1" role="maintainer"/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '135'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:user_1">
+          <title></title>
+          <description></description>
+          <person userid="user_1" role="maintainer" />
+        </project>
+    http_version: 
+  recorded_at: Wed, 21 Mar 2018 13:38:24 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/source_project/_meta
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="source_project">
+          <title>Where Angels Fear to Tread</title>
+          <description/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '117'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="source_project">
+          <title>Where Angels Fear to Tread</title>
+          <description></description>
+        </project>
+    http_version: 
+  recorded_at: Wed, 21 Mar 2018 13:38:24 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/source_project/_config
+    body:
+      encoding: UTF-8
+      string: Tempore sit facere. Quo impedit consequatur necessitatibus ut temporibus.
+        Animi assumenda ut quod aut nesciunt sed. Ullam harum at occaecati quod exercitationem.
+        Labore consequuntur ut.
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '21'
+    body:
+      encoding: UTF-8
+      string: '<status code="ok" />
+
+'
+    http_version: 
+  recorded_at: Wed, 21 Mar 2018 13:38:24 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/source_project/source_package/_meta?user=_nobody_
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="source_package" project="source_project">
+          <title>No Highway</title>
+          <description>Nemo alias culpa quibusdam in aut distinctio fugiat esse.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '183'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="source_package" project="source_project">
+          <title>No Highway</title>
+          <description>Nemo alias culpa quibusdam in aut distinctio fugiat esse.</description>
+        </package>
+    http_version: 
+  recorded_at: Wed, 21 Mar 2018 13:38:24 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/source_project/source_package/_meta
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="source_package" project="source_project">
+          <title>No Highway</title>
+          <description>Nemo alias culpa quibusdam in aut distinctio fugiat esse.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '183'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="source_package" project="source_project">
+          <title>No Highway</title>
+          <description>Nemo alias culpa quibusdam in aut distinctio fugiat esse.</description>
+        </package>
+    http_version: 
+  recorded_at: Wed, 21 Mar 2018 13:38:25 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/source_project/source_package/_config
+    body:
+      encoding: UTF-8
+      string: Sit impedit molestiae autem ut. Porro vero voluptatem. Tempore quos
+        libero minima. Numquam odio autem sed.
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '209'
+    body:
+      encoding: UTF-8
+      string: |
+        <revision rev="45" vrev="45">
+          <srcmd5>11a491d1770f24f7d54eb222f7d6ba0b</srcmd5>
+          <version>unknown</version>
+          <time>1521639505</time>
+          <user>unknown</user>
+          <comment></comment>
+          <requestid/>
+        </revision>
+    http_version: 
+  recorded_at: Wed, 21 Mar 2018 13:38:25 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/source_project/source_package/somefile.txt
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        U29tZSBzdHJpbmc6IMOhw6nDrcOzw7o=
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '209'
+    body:
+      encoding: UTF-8
+      string: |
+        <revision rev="46" vrev="46">
+          <srcmd5>11a491d1770f24f7d54eb222f7d6ba0b</srcmd5>
+          <version>unknown</version>
+          <time>1521639505</time>
+          <user>unknown</user>
+          <comment></comment>
+          <requestid/>
+        </revision>
+    http_version: 
+  recorded_at: Wed, 21 Mar 2018 13:38:25 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/target_project/_meta
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="target_project">
+          <title>Many Waters</title>
+          <description/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '102'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="target_project">
+          <title>Many Waters</title>
+          <description></description>
+        </project>
+    http_version: 
+  recorded_at: Wed, 21 Mar 2018 13:38:25 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/target_project/_config
+    body:
+      encoding: UTF-8
+      string: Voluptatibus sunt sit accusamus. Voluptatum non dignissimos aut ut maxime
+        ad nemo. Qui incidunt labore. Odio dolorem reprehenderit sed illo. Ipsa natus
+        officia quibusdam.
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '21'
+    body:
+      encoding: UTF-8
+      string: '<status code="ok" />
+
+'
+    http_version: 
+  recorded_at: Wed, 21 Mar 2018 13:38:25 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/target_project/target_package/_meta?user=_nobody_
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="target_package" project="target_project">
+          <title>A Time to Kill</title>
+          <description>Velit repellat placeat ut.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '156'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="target_package" project="target_project">
+          <title>A Time to Kill</title>
+          <description>Velit repellat placeat ut.</description>
+        </package>
+    http_version: 
+  recorded_at: Wed, 21 Mar 2018 13:38:25 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/target_project/target_package/_meta
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="target_package" project="target_project">
+          <title>A Time to Kill</title>
+          <description>Velit repellat placeat ut.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '156'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="target_package" project="target_project">
+          <title>A Time to Kill</title>
+          <description>Velit repellat placeat ut.</description>
+        </package>
+    http_version: 
+  recorded_at: Wed, 21 Mar 2018 13:38:25 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/target_project/target_package/somefile.txt
+    body:
+      encoding: US-ASCII
+      string: '0'
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '211'
+    body:
+      encoding: UTF-8
+      string: |
+        <revision rev="103" vrev="103">
+          <srcmd5>cabf9a1f9a0b7c19d4f7ff46166f4ee0</srcmd5>
+          <version>unknown</version>
+          <time>1521639505</time>
+          <user>unknown</user>
+          <comment></comment>
+          <requestid/>
+        </revision>
+    http_version: 
+  recorded_at: Wed, 21 Mar 2018 13:38:25 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/target_project/target_package/somefile.txt
+    body:
+      encoding: US-ASCII
+      string: '1'
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '211'
+    body:
+      encoding: UTF-8
+      string: |
+        <revision rev="104" vrev="104">
+          <srcmd5>efbe5f0a5dd48df5129b4319df43aa45</srcmd5>
+          <version>unknown</version>
+          <time>1521639505</time>
+          <user>unknown</user>
+          <comment></comment>
+          <requestid/>
+        </revision>
+    http_version: 
+  recorded_at: Wed, 21 Mar 2018 13:38:25 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:user_2/_meta?user=user_2
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:user_2">
+          <title/>
+          <description/>
+          <person userid="user_2" role="maintainer"/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '135'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:user_2">
+          <title></title>
+          <description></description>
+          <person userid="user_2" role="maintainer" />
+        </project>
+    http_version: 
+  recorded_at: Wed, 21 Mar 2018 13:38:25 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/source_project/source_package
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '304'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="source_package" rev="46" vrev="46" srcmd5="11a491d1770f24f7d54eb222f7d6ba0b">
+          <entry name="_config" md5="08a5567be8cbfa012d3e5db7392dc74f" size="106" mtime="1521639505" />
+          <entry name="somefile.txt" md5="81b002f4ff584fcc28ba75365b6121ce" size="23" mtime="1521638378" />
+        </directory>
+    http_version: 
+  recorded_at: Wed, 21 Mar 2018 13:38:25 GMT
+- request:
+    method: post
+    uri: http://backend:5352/source/source_project/source_package?cmd=diff&expand=1&filelimit=10000&opackage=target_package&oproject=target_project&tarlimit=10000
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Content-Type:
+      - application/octet-stream
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/plain
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '405'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        Cm5ldzoKLS0tLQogIF9jb25maWcKCm90aGVyIGNoYW5nZXM6Ci0tLS0tLS0tLS0tLS0tCgorKysrKysgX2NvbmZpZyAobmV3KQotLS0gX2NvbmZpZworKysgX2NvbmZpZwpAQCAtMCwwICsxLDEgQEAKK1NpdCBpbXBlZGl0IG1vbGVzdGlhZSBhdXRlbSB1dC4gUG9ycm8gdmVybyB2b2x1cHRhdGVtLiBUZW1wb3JlIHF1b3MgbGliZXJvIG1pbmltYS4gTnVtcXVhbSBvZGlvIGF1dGVtIHNlZC4KXCBObyBuZXdsaW5lIGF0IGVuZCBvZiBmaWxlCgorKysrKysgc29tZWZpbGUudHh0Ci0tLSBzb21lZmlsZS50eHQKKysrIHNvbWVmaWxlLnR4dApAQCAtMSwxICsxLDEgQEAKLTEKXCBObyBuZXdsaW5lIGF0IGVuZCBvZiBmaWxlCitTb21lIHN0cmluZzogw6HDqcOtw7PDugpcIE5vIG5ld2xpbmUgYXQgZW5kIG9mIGZpbGUK
+    http_version: 
+  recorded_at: Wed, 21 Mar 2018 13:38:25 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/source_project/source_package?expand=1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '304'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="source_package" rev="46" vrev="46" srcmd5="11a491d1770f24f7d54eb222f7d6ba0b">
+          <entry name="_config" md5="08a5567be8cbfa012d3e5db7392dc74f" size="106" mtime="1521639505" />
+          <entry name="somefile.txt" md5="81b002f4ff584fcc28ba75365b6121ce" size="23" mtime="1521638378" />
+        </directory>
+    http_version: 
+  recorded_at: Wed, 21 Mar 2018 13:38:25 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/source_project/source_package
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '304'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="source_package" rev="46" vrev="46" srcmd5="11a491d1770f24f7d54eb222f7d6ba0b">
+          <entry name="_config" md5="08a5567be8cbfa012d3e5db7392dc74f" size="106" mtime="1521639505" />
+          <entry name="somefile.txt" md5="81b002f4ff584fcc28ba75365b6121ce" size="23" mtime="1521638378" />
+        </directory>
+    http_version: 
+  recorded_at: Wed, 21 Mar 2018 13:38:25 GMT
+- request:
+    method: post
+    uri: http://backend:5352/source/source_project/source_package?cmd=diff&expand=1&filelimit=10000&opackage=target_package&oproject=target_project&tarlimit=10000&withissues=1
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Content-Type:
+      - application/octet-stream
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/plain
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '405'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        Cm5ldzoKLS0tLQogIF9jb25maWcKCm90aGVyIGNoYW5nZXM6Ci0tLS0tLS0tLS0tLS0tCgorKysrKysgX2NvbmZpZyAobmV3KQotLS0gX2NvbmZpZworKysgX2NvbmZpZwpAQCAtMCwwICsxLDEgQEAKK1NpdCBpbXBlZGl0IG1vbGVzdGlhZSBhdXRlbSB1dC4gUG9ycm8gdmVybyB2b2x1cHRhdGVtLiBUZW1wb3JlIHF1b3MgbGliZXJvIG1pbmltYS4gTnVtcXVhbSBvZGlvIGF1dGVtIHNlZC4KXCBObyBuZXdsaW5lIGF0IGVuZCBvZiBmaWxlCgorKysrKysgc29tZWZpbGUudHh0Ci0tLSBzb21lZmlsZS50eHQKKysrIHNvbWVmaWxlLnR4dApAQCAtMSwxICsxLDEgQEAKLTEKXCBObyBuZXdsaW5lIGF0IGVuZCBvZiBmaWxlCitTb21lIHN0cmluZzogw6HDqcOtw7PDugpcIE5vIG5ld2xpbmUgYXQgZW5kIG9mIGZpbGUK
+    http_version: 
+  recorded_at: Wed, 21 Mar 2018 13:38:25 GMT
+recorded_with: VCR 4.0.0

--- a/src/api/spec/mailers/event_mailer_spec.rb
+++ b/src/api/spec/mailers/event_mailer_spec.rb
@@ -52,6 +52,19 @@ RSpec.describe EventMailer, vcr: true do
         expect(mail['From'].value).to eq('OBS Notification <unconfigured@openbuildservice.org>')
       end
 
+      context 'using different encodings' do
+        let(:source_package) do
+          create(:package_with_file, name: 'source_package', project: source_project, file_content: 'Some string: áéíóú'.force_encoding('ASCII-8BIT'))
+        end
+        let(:bs_request) do
+          create(:bs_request, bs_request_actions: [bs_request_action_submit], description: 'Some other string: áéíóú.'.force_encoding('UTF-8'))
+        end
+
+        it 'does not throw an "incompatible character encodings" exception' do
+          expect { EventMailer.event(event.subscribers, event).deliver_now }.not_to raise_error
+        end
+      end
+
       it 'uses display name for FROM if originator exists' do
         expect(mail.from).to include(originator.email)
         expect(mail['From'].value).to eq(originator.display_name)


### PR DESCRIPTION
When creating a mail with a diff between two packages, this diff can be encoded in a different encoding as UTF-8. In this case, mixing this `diff` field in the view used by the mailer with other fields like `description` of the request that are in UTF-8 results in throwing this exception:
"incompatible character encodings".

Making sure that the `diff` field is converted to UTF-8 in the view used by the mailer prevents this exception to occur.

Test added for this case.

Fixes #3415.

Co-authored-by: Ana María Martínez Gómez <ammartinez@suse.de>
Co-authored-by: David Kang <dkang@suse.com>
Co-authored-by: Moisés Déniz Alemán <mdeniz@suse.com>