### PR TITLE
[webui] Fix request review view for set bugowner

### DIFF
--- a/src/api/app/models/bs_request.rb
+++ b/src/api/app/models/bs_request.rb
@@ -1111,6 +1111,8 @@ class BsRequest < ApplicationRecord
         action[:name] = 'Change Devel'
       when :set_bugowner then
         action[:name] = 'Set Bugowner'
+        action[:user] = xml.person_name
+        action[:group] = xml.group_name
       when :maintenance_incident then
         action[:name] = "Incident #{action[:spkg]}"
         action[:sourcediff] = xml.webui_infos if with_diff

--- a/src/api/app/views/webui/request/show.html.erb
+++ b/src/api/app/views/webui/request/show.html.erb
@@ -145,6 +145,23 @@
                 wants the role <b><%= action[:role] %></b> for
                 <%= project_or_package_link project: action[:tprj], package: action[:tpkg] %>
               </b>
+          <% elsif action[:type] == :set_bugowner %>
+              <b>
+                <%= user_with_realname_and_icon @bs_request.creator %>
+                <% if @bs_request.creator == action[:user] %>
+                  wants to
+                <% else %>
+                  wants that the
+                  <% if action[:user] %>
+                    user
+                    <%= user_with_realname_and_icon(action[:user], { no_icon: true }) %>
+                  <% else %>
+                    "group #{action[:group]}"
+                  <% end %>
+                <% end %>
+                become bugowner for
+                <%= project_or_package_link project: action[:tprj], package: action[:tpkg] %>
+              </b>
           <% elsif action[:type] == :change_devel %>
               <b>
                 Set the devel project to


### PR DESCRIPTION
Set bugowner of person of group is shown including the person/group and role. :bowtie: 

![image](https://user-images.githubusercontent.com/16052290/37761777-e2b114ee-2dba-11e8-8b1a-6d2243f33df1.png)

When the user who creates the request is the same who wants to become bugowner:

![image](https://user-images.githubusercontent.com/16052290/37761824-00390e36-2dbb-11e8-88b8-e570c1c3fcc7.png)

This is similar to add role bugowner:

![image](https://user-images.githubusercontent.com/16052290/37761856-119ee808-2dbb-11e8-8ad4-8253c9b95fb8.png)



As it is modifying the view, I do not think that we need tests for this.