### PR TITLE
[frontend] Remove redundant assignment

### DIFF
--- a/src/api/lib/opensuse/permission.rb
+++ b/src/api/lib/opensuse/permission.rb
@@ -53,8 +53,6 @@ module Suse
           raise 'autofetch of project only works with objects of class Package'
         end
 
-        project = project if project.is_a? String
-
         pkg = Package.find_by_project_and_name(project, package)
         if pkg.nil?
           raise ArgumentError, "unable to find package object for #{project} / #{package}"


### PR DESCRIPTION
If the "package_change?" method is called and a project parameter is
passed, it seems to be a String (I only checked the "obvious" callers
by grepping for "package_change?"). Hence, there is no need to do
any "conversion" etc. Originally, it was introduced in commit
f2b734be14 ("backward compatibility to handle also string arguments").