### PR TITLE
[frontend] Fix live build log when already started

### DIFF
--- a/src/api/app/controllers/webui/package_controller.rb
+++ b/src/api/app/controllers/webui/package_controller.rb
@@ -815,8 +815,9 @@ class Webui::PackageController < Webui::WebuiController
       chunk_start = @offset
       chunk_end = @offset + @maxsize
 
-      if @first_request && @finished
-        chunk_start = [0, @size - @maxsize].max # To not get the full log, just the las 64k
+      # Start at the most recent part to not get the full log from the begining just the last 64k
+      if @first_request && (@finished || @size >= @maxsize)
+        chunk_start = [0, @size - @maxsize].max
         chunk_end = @size
       end
 


### PR DESCRIPTION
The build log was loaded from the begining when it was already started,
now only the last chunk is loaded (up to 64K).

Fixes #4708