### PR TITLE
[webui] Fix request review view for add role

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -97,7 +97,7 @@ Metrics/MethodLength:
 # Offense count: 7
 # Configuration parameters: CountComments.
 Metrics/ModuleLength:
-  Max: 341
+  Max: 352
 
 # Offense count: 20
 # Configuration parameters: CountKeywordArgs.

--- a/src/api/app/helpers/webui/webui_helper.rb
+++ b/src/api/app/helpers/webui/webui_helper.rb
@@ -355,6 +355,20 @@ module Webui::WebuiHelper
     end
   end
 
+  def requester_str(creator, requester_user, requester_group)
+    # we don't need to show the requester if he is the same as the creator
+    return if creator == requester_user
+    if requester_user
+      "the user #{user_with_realname_and_icon(requester_user, no_icon: true)}".html_safe
+    elsif requester_group
+      "the group #{requester_group}"
+    end
+  end
+
+  def creator_intentions(role = nil)
+    role.blank? ? 'become bugowner' : "get the role #{role}"
+  end
+
   # If there is any content add the ul tag
   def possibly_empty_ul(html_opts, &block)
     content = capture(&block)

--- a/src/api/app/models/bs_request.rb
+++ b/src/api/app/models/bs_request.rb
@@ -1107,6 +1107,7 @@ class BsRequest < ApplicationRecord
         action[:name] = 'Add Role'
         action[:role] = xml.role
         action[:user] = xml.person_name
+        action[:group] = xml.group_name
       when :change_devel then
         action[:name] = 'Change Devel'
       when :set_bugowner then

--- a/src/api/app/views/webui/request/show.html.erb
+++ b/src/api/app/views/webui/request/show.html.erb
@@ -139,27 +139,14 @@
                 <% end %>
                 <%= project_or_package_link project: action[:tprj], package: action[:tpkg] %>
               </b>
-          <% elsif action[:type] == :add_role %>
-              <b>
-                <%= user_with_realname_and_icon action[:user] %>
-                wants the role <b><%= action[:role] %></b> for
-                <%= project_or_package_link project: action[:tprj], package: action[:tpkg] %>
-              </b>
-          <% elsif action[:type] == :set_bugowner %>
+          <% elsif [:add_role, :set_bugowner].include? action[:type]  %>
               <b>
                 <%= user_with_realname_and_icon @bs_request.creator %>
-                <% if @bs_request.creator == action[:user] %>
-                  wants to
-                <% else %>
-                  wants that the
-                  <% if action[:user] %>
-                    user
-                    <%= user_with_realname_and_icon(action[:user], { no_icon: true }) %>
-                  <% else %>
-                    "group #{action[:group]}"
-                  <% end %>
-                <% end %>
-                become bugowner for
+                wants
+                <%= requester_str(@bs_request.creator, action[:user], action[:group]) %>
+                to
+                <%= creator_intentions(action[:role]) %>
+                for
                 <%= project_or_package_link project: action[:tprj], package: action[:tpkg] %>
               </b>
           <% elsif action[:type] == :change_devel %>

--- a/src/api/spec/features/webui/requests_spec.rb
+++ b/src/api/spec/features/webui/requests_spec.rb
@@ -66,7 +66,7 @@ RSpec.feature 'Requests', type: :feature, js: true do
         fill_in 'description', with: 'I can fix bugs too.'
 
         expect { click_button 'Ok' }.to change { BsRequest.count }.by 1
-        expect(page).to have_text("#{submitter.realname} (#{submitter.login}) wants the role bugowner for project #{target_project}")
+        expect(page).to have_text("#{submitter.realname} (#{submitter.login}) wants to get the role bugowner for project #{target_project}")
         expect(page).to have_css('#description-text', text: 'I can fix bugs too.')
         expect(page).to have_text('In state new')
       end
@@ -94,7 +94,7 @@ RSpec.feature 'Requests', type: :feature, js: true do
         fill_in 'description', with: 'I can produce bugs too.'
 
         expect { click_button 'Ok' }.to change { BsRequest.count }.by 1
-        expect(page).to have_text("#{submitter.realname} (#{submitter.login}) wants the role maintainer \
+        expect(page).to have_text("#{submitter.realname} (#{submitter.login}) wants to get the role maintainer \
                                    for package #{target_project} / #{target_package}")
         expect(page).to have_css('#description-text', text: 'I can produce bugs too.')
         expect(page).to have_text('In state new')

--- a/src/api/spec/helpers/webui/webui_helper_spec.rb
+++ b/src/api/spec/helpers/webui/webui_helper_spec.rb
@@ -372,6 +372,33 @@ RSpec.describe Webui::WebuiHelper do
     skip('Please add some tests')
   end
 
+  describe '#requester_str' do
+    let!(:creator) { create(:user, login: 'Adrian') }
+    let(:requester) { create(:user, login: 'Ana') }
+
+    it 'do not show the requester if he is the same as the creator' do
+      expect(requester_str(creator.login, creator.login, nil)).to be nil
+    end
+
+    it 'show the requester if he is different as the creator' do
+      expect(requester_str(creator.login, requester.login, nil)).to include('user', requester.login)
+    end
+
+    it 'show the group' do
+      expect(requester_str(creator.login, nil, 'ana-team')).to include('group', 'ana-team')
+    end
+  end
+
+  describe '#creator_intentions' do
+    it 'do not show the requester if he is the same as the creator' do
+      expect(creator_intentions(nil)).to eq 'become bugowner'
+    end
+
+    it 'show the requester if he is different as the creator' do
+      expect(creator_intentions('bugowner')).to eq 'get the role bugowner'
+    end
+  end
+
   describe '#codemirror_style' do
     context 'option height' do
       it 'uses auto as default value' do


### PR DESCRIPTION
Add role of person or group is shown including the person/group and role.

This include some refactoring to merge in the view `add_role` and `set_bugowner` code, as they are really similar. :bowtie: (this PR will be follow by more refactoring in this models :smiling_imp:)

![image](https://user-images.githubusercontent.com/16052290/37785856-7e84c75e-2dfb-11e8-8c12-2a493f6f18c5.png)
