### PR TITLE
[frontend] Fix repository autocompletion

### DIFF
--- a/src/api/app/views/webui/repositories/new.html.haml
+++ b/src/api/app/views/webui/repositories/new.html.haml
@@ -3,7 +3,7 @@
 - project_bread_crumb @pagetitle
 = render partial: "webui/project/tabs"
 = content_for :ready_function do
-  repositories_setup_autocomplete();
+  repositoriesSetupAutocomplete();
 %h2
   Add Repository to #{@project}
 = form_tag({ action: :create, project: @project }) do


### PR DESCRIPTION
This was overlooked when renaming js variables from snake case to
camel case (c5e45f9d0ae6ff3841cb35796412d27c1a598cb5).

Fixes #4711