### PR TITLE
[ci] Set eager-load explicit

### DIFF
--- a/dist/ci/travis_script.sh
+++ b/dist/ci/travis_script.sh
@@ -9,6 +9,7 @@ pushd src/api
 
 if test -z "$SUBTEST"; then
   export DO_COVERAGE=1
+  export EAGER_LOAD=1
   export TESTOPTS="-v"
   case $TEST_SUITE in
     api)

--- a/src/api/config/environments/test.rb
+++ b/src/api/config/environments/test.rb
@@ -14,6 +14,10 @@ OBSApi::Application.configure do
   # and recreated between test runs. Don't rely on the data there!
   config.cache_classes = true
 
+  # We set eager loading to true in Travis CI
+  # to run with the same configuration as in production
+  config.eager_load = ENV.fetch('EAGER_LOAD', '0') == '1'
+
   # Show full error reports and disable caching
   # local requests don't trigger the global exception handler -> set to false
   config.consider_all_requests_local = false


### PR DESCRIPTION
because otherwise it will print a warning.

In the previous PR is just dropped the setting. However, this will cause a warning to be printed.
So I set it now explicit.
https://github.com/openSUSE/open-build-service/pull/4722

We should also think about
https://github.com/rails/rails/issues/28736#issuecomment-293822999

Because now eager load will load the whole application even if you run only one test, not a problem in Travis but for local development indeed.
