### PR TITLE
[webui] Rescue mail callbacks in EventMailer

### DIFF
--- a/src/api/app/mailers/event_mailer.rb
+++ b/src/api/app/mailers/event_mailer.rb
@@ -41,18 +41,23 @@ class EventMailer < ActionMailer::Base
       orig = mail_sender
     end
 
-    mail(to: tos.sort,
-         subject: e.subject,
-         from: orig,
-         date: e.created_at) do |format|
+    begin
+      mail(to: tos.sort,
+           subject: e.subject,
+           from: orig,
+           date: e.created_at) do |format|
 
-      if template_exists?("event_mailer/#{template_name}", formats: [:html])
-        format.html { render template_name, locals: locals }
-      end
+        if template_exists?("event_mailer/#{template_name}", formats: [:html])
+          format.html { render template_name, locals: locals }
+        end
 
-      if template_exists?("event_mailer/#{template_name}", formats: [:text])
-        format.text { render template_name, locals: locals }
+        if template_exists?("event_mailer/#{template_name}", formats: [:text])
+          format.text { render template_name, locals: locals }
+        end
       end
+    rescue ArgumentError
+      Rails.logger.error "ArgumentError (catched): template: #{template_name}, locals: #{locals.inspect}, tos: #{tos.inspect}, orig: #{orig}"
+      raise
     end
   end
 end


### PR DESCRIPTION
As there is no information regarding the parameters that cause an `ArgumentError` exception in the `mail` callback in `EventMailer`, this exception is catched. It will only log the parameters to the error log, and then will re-raise the exception.

This will help to know the reasons `ArgumentError` exception is thrown and therefore help to fix #4052.