### PR TITLE
[webui] Clarify what set_bugowner does

### DIFF
--- a/src/api/app/helpers/webui/webui_helper.rb
+++ b/src/api/app/helpers/webui/webui_helper.rb
@@ -366,7 +366,7 @@ module Webui::WebuiHelper
   end
 
   def creator_intentions(role = nil)
-    role.blank? ? 'become bugowner' : "get the role #{role}"
+    role.blank? ? 'become bugowner (previous bugowners will be deleted)' : "get the role #{role}"
   end
 
   # If there is any content add the ul tag

--- a/src/api/spec/helpers/webui/webui_helper_spec.rb
+++ b/src/api/spec/helpers/webui/webui_helper_spec.rb
@@ -391,7 +391,7 @@ RSpec.describe Webui::WebuiHelper do
 
   describe '#creator_intentions' do
     it 'do not show the requester if he is the same as the creator' do
-      expect(creator_intentions(nil)).to eq 'become bugowner'
+      expect(creator_intentions(nil)).to eq 'become bugowner (previous bugowners will be deleted)'
     end
 
     it 'show the requester if he is different as the creator' do


### PR DESCRIPTION
Show in the request that the previous bigowners will be deleted. This makes more clear the difference between `add_role bugowner` and `set_bugowner`. :bowtie: 

![image](https://user-images.githubusercontent.com/16052290/37914815-6733a62c-3118-11e8-81b2-4ffd8c5e0883.png)
