### PR TITLE
[webui] Add values of variables to exception

### DIFF
--- a/src/api/app/controllers/webui/request_controller.rb
+++ b/src/api/app/controllers/webui/request_controller.rb
@@ -423,7 +423,10 @@ class Webui::RequestController < Webui::WebuiController
         end
       end
     rescue APIException, ActiveRecord::RecordInvalid => e
-      Airbrake.notify("Failed to forward BsRequest: #{@bs_request.number}: #{req} #{e}")
+      error_string = "Failed to forward BsRequest: #{@bs_request.number}, error: #{e}, request: #{req.inspect}, params: #{params.inspect}"
+      error_string << ", action: #{action.inspect}" if defined?(action)
+      error_string << ", Record errors: #{e.record.errors}" if e.respond_to?(:record)
+      Airbrake.notify(error_string)
       flash[:error] = "Unable to forward submit request: #{e.message}"
       return
     end


### PR DESCRIPTION
Add the values of variables to the message sent to Errbit that may cause a "Validation failed: Bs request actions is invalid" exception in the Webui::RequestController.

This will help to know why #3730 happens.