### PR TITLE
[frontend] Add an API route to the cloud upload controller

### DIFF
--- a/src/api/app/controllers/application_controller.rb
+++ b/src/api/app/controllers/application_controller.rb
@@ -86,6 +86,11 @@ class ApplicationController < ActionController::Base
 
   protected
 
+  def feature_active?(feature)
+    return if Feature.active?(feature)
+    render file: Rails.root.join('public/404'), status: :not_found, layout: false
+  end
+
   def validate_params
     params.each do |key, value|
       next if value.nil?

--- a/src/api/app/controllers/cloud/upload_jobs_controller.rb
+++ b/src/api/app/controllers/cloud/upload_jobs_controller.rb
@@ -1,0 +1,44 @@
+module Cloud
+  class UploadJobsController < ApplicationController
+    before_action :require_login
+    before_action -> { feature_active?(:cloud_upload) }
+    before_action :validate_configuration_presence
+
+    def index
+      render xml: ::Cloud::Backend::UploadJob.all(::User.current, format: :xml)
+    end
+
+    def create
+      upload_job = ::Cloud::UploadJob.create(upload_data)
+      if upload_job.valid?
+        render xml: ::Cloud::Backend::UploadJob.find(upload_job.user_upload_job.id, format: :xml)
+      else
+        render_error status: 400,
+                     errorcode: 'cloud_upload_job_invalid',
+                     message: "Failed to create upload job: #{upload_job.errors.full_messages.to_sentence}."
+      end
+    end
+
+    private
+
+    def validate_configuration_presence
+      return if ::User.current.cloud_configurations?
+      render_error status: 400,
+                   errorcode: 'cloud_upload_job_no_config',
+                   message: "Couldn't find a cloud configuration for user"
+    end
+
+    def permitted_params
+      params.permit(
+        :project, :package, :repository, :arch, :filename, :region, :ami_name, :target, :vpc_subnet_id, :format, :method, :type
+      )
+    end
+
+    def upload_data
+      permitted_params.
+        slice(:project, :package, :repository, :arch, :filename, :region, :ami_name, :target, :vpc_subnet_id).
+        to_h.
+        merge(user: ::User.current)
+    end
+  end
+end

--- a/src/api/app/controllers/cloud/upload_jobs_controller.rb
+++ b/src/api/app/controllers/cloud/upload_jobs_controller.rb
@@ -2,10 +2,18 @@ module Cloud
   class UploadJobsController < ApplicationController
     before_action :require_login
     before_action -> { feature_active?(:cloud_upload) }
-    before_action :validate_configuration_presence
+    before_action :validate_configuration_presence, only: [:index, :create]
 
     def index
       render xml: ::Cloud::Backend::UploadJob.all(::User.current, format: :xml)
+    end
+
+    def show
+      if ::User.current.upload_jobs.where(job_id: params[:id]).exists?
+        render xml: ::Cloud::Backend::UploadJob.find(params[:id], format: :xml)
+      else
+        render_error status: 404
+      end
     end
 
     def create

--- a/src/api/app/models/cloud/backend/upload_job.rb
+++ b/src/api/app/models/cloud/backend/upload_job.rb
@@ -32,8 +32,19 @@ module Cloud
         new(exception: exception.message)
       end
 
-      def self.all(user)
+      def self.find(job_id, options = {})
+        xml = ::Backend::Api::Cloud.upload_jobs([job_id])
+        return xml if options[:format] == :xml
+        xml_hash = Xmlhash.parse(xml)['clouduploadjob']
+        return if xml_hash.blank?
+        new(xml_object: OpenStruct.new(xml_hash))
+      rescue ActiveXML::Transport::Error, Timeout::Error
+        nil
+      end
+
+      def self.all(user, options = {})
         xml = ::Backend::Api::Cloud.upload_jobs(user.upload_jobs.pluck(:job_id))
+        return xml if options[:format] == :xml
         [Xmlhash.parse(xml)['clouduploadjob']].flatten.compact.map do |xml_hash|
           new(xml_object: OpenStruct.new(xml_hash))
         end

--- a/src/api/config/routes.rb
+++ b/src/api/config/routes.rb
@@ -676,7 +676,7 @@ OBSApi::Application.routes.draw do
     ### /cloud/upload
 
     scope :cloud, as: :cloud do
-      resources :upload, only: [:index, :create], controller: 'cloud/upload_jobs'
+      resources :upload, only: [:index, :show, :create], controller: 'cloud/upload_jobs'
     end
 
     ### /public

--- a/src/api/config/routes.rb
+++ b/src/api/config/routes.rb
@@ -673,6 +673,12 @@ OBSApi::Application.routes.draw do
 
     put '/mail_handler' => 'mail_handler#upload'
 
+    ### /cloud/upload
+
+    scope :cloud, as: :cloud do
+      resources :upload, only: [:index, :create], controller: 'cloud/upload_jobs'
+    end
+
     ### /public
     controller :public do
       get 'public' => :index

--- a/src/api/spec/cassettes/Cloud_Backend_UploadJob/_find/with_Timeout_Error/1_2_3_1.yml
+++ b/src/api/spec/cassettes/Cloud_Backend_UploadJob/_find/with_Timeout_Error/1_2_3_1.yml
@@ -1,0 +1,36 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://backend:5352/cloudupload?name=1000
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '43'
+    body:
+      encoding: UTF-8
+      string: |
+        <clouduploadjoblist>
+        </clouduploadjoblist>
+    http_version: 
+  recorded_at: Wed, 28 Mar 2018 11:31:23 GMT
+recorded_with: VCR 4.0.0

--- a/src/api/spec/cassettes/Cloud_Backend_UploadJob/_find/with_an_invalid_backend_response/1_2_2_1.yml
+++ b/src/api/spec/cassettes/Cloud_Backend_UploadJob/_find/with_an_invalid_backend_response/1_2_2_1.yml
@@ -1,0 +1,36 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://backend:5352/cloudupload?name=1000
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '43'
+    body:
+      encoding: UTF-8
+      string: |
+        <clouduploadjoblist>
+        </clouduploadjoblist>
+    http_version: 
+  recorded_at: Wed, 28 Mar 2018 11:31:23 GMT
+recorded_with: VCR 4.0.0

--- a/src/api/spec/controllers/cloud/upload_jobs_controller_spec.rb
+++ b/src/api/spec/controllers/cloud/upload_jobs_controller_spec.rb
@@ -1,0 +1,130 @@
+require 'rails_helper'
+require 'webmock/rspec'
+
+RSpec.describe Cloud::UploadJobsController, vcr: true do
+  let!(:ec2_configuration) { create(:ec2_configuration) }
+  let!(:user_with_ec2_configuration) { create(:confirmed_user, login: 'tom', ec2_configuration: ec2_configuration) }
+  let(:project) { create(:project, name: 'Apache') }
+  let!(:package) { create(:package, name: 'apache2', project: project) }
+  let(:upload_job) { create(:upload_job, user: user_with_ec2_configuration) }
+  let(:xml_response) do
+    <<-HEREDOC
+    <clouduploadjob name="6">
+      <state>created</state>
+      <details>waiting to receive image</details>
+      <created>1513604055</created>
+      <user>mlschroe</user>
+      <target>ec2</target>
+      <project>Base:System</project>
+      <repository>openSUSE_Factory</repository>
+      <package>rpm</package>
+      <arch>x86_64</arch>
+      <filename>rpm-4.14.0-504.2.x86_64.rpm</filename>
+      <size>1690860</size>
+    </clouduploadjob>
+    HEREDOC
+  end
+  let(:xml_response_list) do
+    <<-HEREDOC
+    <clouduploadjoblist>
+      #{xml_response}
+    </clouduploadjoblist>
+    HEREDOC
+  end
+
+  before do
+    login(user_with_ec2_configuration)
+  end
+
+  describe '#index' do
+    context 'with cloud_upload feature enabled' do
+      let(:path) { "#{CONFIG['source_url']}/cloudupload?name=#{upload_job.job_id}" }
+      context 'without an EC2 configuration' do
+        let(:user) { create(:confirmed_user) }
+
+        before do
+          login(user)
+          Feature.run_with_activated(:cloud_upload) do
+            get :index, format: 'xml'
+          end
+        end
+
+        it { expect(response.header['X-Opensuse-Errorcode']).to eq('cloud_upload_job_no_config') }
+        it { expect(response).to have_http_status(:bad_request) }
+      end
+
+      context 'with an EC2 configuration' do
+        before do
+          stub_request(:get, path).and_return(body: xml_response_list)
+          get :index, format: 'xml'
+        end
+
+        it 'returns an xml response with all cloud upload jobs listed' do
+          expect(Xmlhash.parse(response.body)).to eq(Xmlhash.parse(xml_response_list))
+        end
+        it { expect(response).to be_success }
+      end
+    end
+
+    context 'with cloud_upload feature disabled' do
+      before do
+        Feature.run_with_deactivated(:cloud_upload) do
+          get :index, format: 'xml'
+        end
+      end
+
+      it { expect(response).to be_not_found }
+    end
+  end
+
+  describe 'POST #create' do
+    let(:params) do
+      {
+        project:    'Cloud',
+        package:    'aws',
+        repository: 'standard',
+        arch:       'x86_64',
+        filename:   'appliance.raw.xz',
+        region:     'us-east-1',
+        ami_name:   'my-image',
+        target:     'ec2'
+      }
+    end
+
+    context 'requested with invalid data' do
+      before do
+        post :create, params: { region: 'nuernberg-southside' }, format: 'xml'
+      end
+
+      it { expect(response.header['X-Opensuse-Errorcode']).to eq('cloud_upload_job_invalid') }
+      it { expect(response).to have_http_status(:bad_request) }
+    end
+
+    context 'with a backend response' do
+      let(:path) { "#{CONFIG['source_url']}/cloudupload?#{backend_params.to_param}" }
+      let(:backend_params) do
+        params.merge(target: 'ec2', user: user_with_ec2_configuration.login).except(:region, :ami_name)
+      end
+      let(:additional_data) do
+        {
+          region:   'us-east-1',
+          ami_name: 'my-image'
+        }
+      end
+      let(:post_body) do
+        user_with_ec2_configuration.ec2_configuration.attributes.except('id', 'created_at', 'updated_at').merge(additional_data).to_json
+      end
+
+      before do
+        stub_request(:post, path).with(body: post_body).and_return(body: xml_response)
+        stub_request(:get, /#{CONFIG['source_url']}\/cloudupload\?name=\d+/).and_return(body: xml_response_list)
+        post :create, params: params, format: 'xml'
+      end
+
+      it { expect(Cloud::User::UploadJob.last.job_id).to eq(6) }
+      it { expect(Cloud::User::UploadJob.last.user).to eq(user_with_ec2_configuration) }
+      it { expect(response).to be_success }
+      it { expect(Xmlhash.parse(response.body)).to eq(Xmlhash.parse(xml_response_list)) }
+    end
+  end
+end


### PR DESCRIPTION
This adds API routes (aka xml responses) for:

  * Creation of upload jobs
  * Listing all upload jobs a user has access to