### PR TITLE
[webui][api] Implement diffs for superseded requests

### DIFF
--- a/src/api/app/models/bs_request_action.rb
+++ b/src/api/app/models/bs_request_action.rb
@@ -315,6 +315,14 @@ class BsRequestAction < ApplicationRecord
     end
   end
 
+  def find_action_with_same_target(other_bs_request)
+    return nil if other_bs_request.blank?
+    other_bs_request.bs_request_actions.find do |other_bs_request_action|
+      target_project == other_bs_request_action.target_project &&
+        target_package == other_bs_request_action.target_package
+    end
+  end
+
   def default_reviewers
     reviews = []
     return reviews unless target_project

--- a/src/api/app/models/bs_request_action/differ/for_source.rb
+++ b/src/api/app/models/bs_request_action/differ/for_source.rb
@@ -14,7 +14,14 @@ class BsRequestAction
       private
 
       def diff(source_package_name)
-        if accepted?
+        if superseded_bs_request_action.present?
+          query_builder = QueryBuilderForSuperseded.new(
+            superseded_bs_request_action: superseded_bs_request_action,
+            bs_request_action: bs_request_action,
+            source_package_name: source_package_name
+          )
+          source_diff(query_builder.project_name, query_builder.package_name, query.merge(query_builder.build))
+        elsif accepted?
           query_builder = QueryBuilderForAccepted.new(
             bs_request_action_accept_info: bs_request_action.bs_request_action_accept_info
           )
@@ -45,6 +52,10 @@ class BsRequestAction
         raise DiffError, "Timeout while diffing #{project_name}/#{package_name}"
       rescue ActiveXML::Transport::Error => e
         raise DiffError, "The diff call for #{project_name}/#{package_name} failed: #{e.summary}"
+      end
+
+      def superseded_bs_request_action
+        options[:superseded_bs_request_action]
       end
 
       def accepted?

--- a/src/api/app/models/bs_request_action/differ/query_builder_for_superseded.rb
+++ b/src/api/app/models/bs_request_action/differ/query_builder_for_superseded.rb
@@ -1,0 +1,57 @@
+class BsRequestAction
+  module Differ
+    class QueryBuilderForSuperseded
+      include ActiveModel::Model
+      attr_accessor :superseded_bs_request_action, :bs_request_action, :source_package_name
+
+      def build
+        query = {}
+        if accepted?
+          query[:rev] = bs_request_action_accept_info.oxsrcmd5 || bs_request_action_accept_info.osrcmd5 || '0'
+          query[:orev] = superseded_bs_request_action.source_rev
+          query[:oproject] = superseded_bs_request_action.source_project
+          query[:opackage] = superseded_bs_request_action.source_package
+        else
+          query[:rev] = bs_request_action.source_rev
+          query[:orev] = superseded_bs_request_action.source_rev
+          unless same_source_package?
+            query[:oproject] = superseded_bs_request_action.source_project
+            query[:opackage] = superseded_bs_request_action.source_package
+          end
+        end
+        query
+      end
+
+      def project_name
+        if accepted?
+          bs_request_action_accept_info.oproject.presence || bs_request_action.target_project
+        else
+          bs_request_action.source_project
+        end
+      end
+
+      def package_name
+        if accepted?
+          bs_request_action_accept_info.opackage.presence || bs_request_action.target_package
+        else
+          bs_request_action.source_package
+        end
+      end
+
+      private
+
+      def bs_request_action_accept_info
+        bs_request_action.bs_request_action_accept_info
+      end
+
+      def accepted?
+        bs_request_action_accept_info.present?
+      end
+
+      def same_source_package?
+        superseded_bs_request_action.source_project == bs_request_action.source_project &&
+          superseded_bs_request_action.source_package == source_package_name
+      end
+    end
+  end
+end

--- a/src/api/app/views/webui/request/_superseded_by_message.html.erb
+++ b/src/api/app/views/webui/request/_superseded_by_message.html.erb
@@ -1,0 +1,24 @@
+<% if superseded_by.present?  %>
+  <div class="grid_16 alpha omega box-invisible">
+    <div id="truncated_diff_hint" class="ui-state-info ui-corner-all ui-widget-shadow padding-10pt">
+      <span class="ui-icon ui-icon-info">
+        This request is superseded by
+        <%= link_to "request #{superseded_by}", request_show_path(number: superseded_by) %>
+        (<%= link_to 'Show diff', request_show_path(number: superseded_by, diff_to_superseded: number) %>)
+      </span>
+    </div>
+  </div>
+<% end %>
+<% if diff_to_superseded.present?  %>
+  <div class="grid_16 alpha omega box-invisible">
+    <div id="truncated_diff_hint" class="ui-state-info ui-corner-all ui-widget-shadow padding-10pt">
+      <span class="ui-icon ui-icon-info">
+        You're not reviewing the full diff of
+        <%= link_to "request #{number}", request_show_path(number: number) %>
+        but the diff to the superseded
+        <%= link_to "request #{diff_to_superseded.number}", request_show_path(number: diff_to_superseded) %>
+        (<%= link_to 'Show full diff', request_show_path(number: number) %>)
+      </span>
+    </div>
+  </div>
+<% end %>

--- a/src/api/app/views/webui/request/show.html.erb
+++ b/src/api/app/views/webui/request/show.html.erb
@@ -78,6 +78,10 @@
   </div>
 <% end %>
 
+<div class="grid_16 alpha omega box-invisible">
+  <%= render partial: 'superseded_by_message', locals: { superseded_by: @superseded_by, number: @number, diff_to_superseded: @diff_to_superseded } %>
+</div>
+
 <div class="grid_16 alpha omega box box-shadow">
 
   <div class="box-header header-tabs">

--- a/src/api/spec/cassettes/Webui_RequestController/GET_show/with_diff_to_superseded_set/and_the_superseded_request_is_not_superseded/1_3_7_2_1.yml
+++ b/src/api/spec/cassettes/Webui_RequestController/GET_show/with_diff_to_superseded_set/and_the_superseded_request_is_not_superseded/1_3_7_2_1.yml
@@ -1,0 +1,110 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://backend:5352/source/home:kugelblitz/ball
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 404
+      message: project 'home kugelblitz' does not exist
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '158'
+    body:
+      encoding: UTF-8
+      string: |
+        <status code="404">
+          <summary>project 'home:kugelblitz' does not exist</summary>
+          <details>404 project 'home:kugelblitz' does not exist</details>
+        </status>
+    http_version: 
+  recorded_at: Tue, 27 Mar 2018 07:51:07 GMT
+- request:
+    method: post
+    uri: http://backend:5352/source/home:kugelblitz/ball?cmd=diff&expand=1&filelimit=10000&opackage=goal&oproject=home:titan&tarlimit=10000&view=xml&withissues=1
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Content-Type:
+      - application/octet-stream
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 404
+      message: project 'home kugelblitz' does not exist
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '158'
+    body:
+      encoding: UTF-8
+      string: |
+        <status code="404">
+          <summary>project 'home:kugelblitz' does not exist</summary>
+          <details>404 project 'home:kugelblitz' does not exist</details>
+        </status>
+    http_version: 
+  recorded_at: Tue, 27 Mar 2018 07:51:07 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:titan/goal
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 404
+      message: project 'home titan' does not exist
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '148'
+    body:
+      encoding: UTF-8
+      string: |
+        <status code="404">
+          <summary>project 'home:titan' does not exist</summary>
+          <details>404 project 'home:titan' does not exist</details>
+        </status>
+    http_version: 
+  recorded_at: Tue, 27 Mar 2018 07:51:07 GMT
+recorded_with: VCR 4.0.0

--- a/src/api/spec/cassettes/Webui_RequestController/GET_show/with_diff_to_superseded_set/and_the_superseded_request_is_not_superseded/1_3_7_2_2.yml
+++ b/src/api/spec/cassettes/Webui_RequestController/GET_show/with_diff_to_superseded_set/and_the_superseded_request_is_not_superseded/1_3_7_2_2.yml
@@ -1,0 +1,110 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://backend:5352/source/home:kugelblitz/ball
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 404
+      message: project 'home kugelblitz' does not exist
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '158'
+    body:
+      encoding: UTF-8
+      string: |
+        <status code="404">
+          <summary>project 'home:kugelblitz' does not exist</summary>
+          <details>404 project 'home:kugelblitz' does not exist</details>
+        </status>
+    http_version: 
+  recorded_at: Tue, 27 Mar 2018 07:51:06 GMT
+- request:
+    method: post
+    uri: http://backend:5352/source/home:kugelblitz/ball?cmd=diff&expand=1&filelimit=10000&opackage=goal&oproject=home:titan&tarlimit=10000&view=xml&withissues=1
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Content-Type:
+      - application/octet-stream
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 404
+      message: project 'home kugelblitz' does not exist
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '158'
+    body:
+      encoding: UTF-8
+      string: |
+        <status code="404">
+          <summary>project 'home:kugelblitz' does not exist</summary>
+          <details>404 project 'home:kugelblitz' does not exist</details>
+        </status>
+    http_version: 
+  recorded_at: Tue, 27 Mar 2018 07:51:06 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:titan/goal
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 404
+      message: project 'home titan' does not exist
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '148'
+    body:
+      encoding: UTF-8
+      string: |
+        <status code="404">
+          <summary>project 'home:titan' does not exist</summary>
+          <details>404 project 'home:titan' does not exist</details>
+        </status>
+    http_version: 
+  recorded_at: Tue, 27 Mar 2018 07:51:06 GMT
+recorded_with: VCR 4.0.0

--- a/src/api/spec/cassettes/Webui_RequestController/GET_show/with_diff_to_superseded_set/and_the_superseded_request_is_superseded/1_3_7_1_1.yml
+++ b/src/api/spec/cassettes/Webui_RequestController/GET_show/with_diff_to_superseded_set/and_the_superseded_request_is_superseded/1_3_7_1_1.yml
@@ -1,0 +1,110 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://backend:5352/source/home:kugelblitz/ball
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 404
+      message: project 'home kugelblitz' does not exist
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '158'
+    body:
+      encoding: UTF-8
+      string: |
+        <status code="404">
+          <summary>project 'home:kugelblitz' does not exist</summary>
+          <details>404 project 'home:kugelblitz' does not exist</details>
+        </status>
+    http_version: 
+  recorded_at: Tue, 27 Mar 2018 07:51:08 GMT
+- request:
+    method: post
+    uri: http://backend:5352/source/home:kugelblitz/ball?cmd=diff&expand=1&filelimit=10000&opackage=goal&oproject=home:titan&tarlimit=10000&view=xml&withissues=1
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Content-Type:
+      - application/octet-stream
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 404
+      message: project 'home kugelblitz' does not exist
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '158'
+    body:
+      encoding: UTF-8
+      string: |
+        <status code="404">
+          <summary>project 'home:kugelblitz' does not exist</summary>
+          <details>404 project 'home:kugelblitz' does not exist</details>
+        </status>
+    http_version: 
+  recorded_at: Tue, 27 Mar 2018 07:51:08 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:titan/goal
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 404
+      message: project 'home titan' does not exist
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '148'
+    body:
+      encoding: UTF-8
+      string: |
+        <status code="404">
+          <summary>project 'home:titan' does not exist</summary>
+          <details>404 project 'home:titan' does not exist</details>
+        </status>
+    http_version: 
+  recorded_at: Tue, 27 Mar 2018 07:51:08 GMT
+recorded_with: VCR 4.0.0

--- a/src/api/spec/controllers/request_controller_spec.rb
+++ b/src/api/spec/controllers/request_controller_spec.rb
@@ -1,0 +1,42 @@
+require 'rails_helper'
+require 'webmock/rspec'
+
+RSpec.describe RequestController, type: :controller do
+  render_views # NOTE: This is required otherwise Suse::Validator.validate will fail
+
+  describe '#request_command' do
+    let(:user) { create(:confirmed_user) }
+    let(:bs_request) { create(:bs_request) }
+    before do
+      login user
+    end
+
+    context 'successful' do
+      before do
+        post :request_command, params: { id: bs_request.number, cmd: :diff, format: :xml }
+      end
+
+      it { expect(response).to have_http_status(:success) }
+    end
+
+    context 'with diff_to_superseded parameter' do
+      let(:another_bs_request) { create(:bs_request) }
+      context 'of a not superseded request' do
+        before do
+          post :request_command, params: { id: bs_request.number, cmd: :diff, format: :xml, diff_to_superseded: another_bs_request }
+        end
+
+        it { expect(response).to have_http_status(:not_found) }
+      end
+
+      context 'of a superseded request' do
+        before do
+          another_bs_request.update(state: :superseded, superseded_by: bs_request.number)
+          post :request_command, params: { id: bs_request.number, cmd: :diff, format: :xml, diff_to_superseded: another_bs_request }
+        end
+
+        it { expect(response).to have_http_status(:success) }
+      end
+    end
+  end
+end

--- a/src/api/spec/controllers/webui/request_controller_spec.rb
+++ b/src/api/spec/controllers/webui/request_controller_spec.rb
@@ -175,6 +175,27 @@ RSpec.describe Webui::RequestController, vcr: true do
         it_behaves_like 'a full diff requested for', 'bigfile_archive.tar.gz/bigfile.txt'
       end
     end
+
+    context 'with :diff_to_superseded set' do
+      let(:superseded_bs_request) { create(:bs_request) }
+      context 'and the superseded request is superseded' do
+        before do
+          superseded_bs_request.update(state: :superseded, superseded_by: bs_request.number)
+          get :show, params: { number: bs_request.number, diff_to_superseded: superseded_bs_request.number }
+        end
+
+        it { expect(assigns(:diff_to_superseded)).to eq(superseded_bs_request) }
+      end
+
+      context 'and the superseded request is not superseded' do
+        before do
+          get :show, params: { number: bs_request.number, diff_to_superseded: superseded_bs_request.number }
+        end
+
+        it { expect(assigns(:diff_to_superseded)).to be_nil }
+        it { expect(flash[:error]).not_to be_nil }
+      end
+    end
   end
 
   describe 'POST #delete_request' do

--- a/src/api/spec/models/bs_request_action/differ/query_builder_for_superseded_spec.rb
+++ b/src/api/spec/models/bs_request_action/differ/query_builder_for_superseded_spec.rb
@@ -1,0 +1,194 @@
+require 'rails_helper'
+
+RSpec.describe BsRequestAction::Differ::QueryBuilderForSuperseded do
+  let(:user) { create(:confirmed_user, login: 'moi') }
+  let(:source_project) { create(:project, name: 'source_project', maintainer: user) }
+  let(:source_package) { create(:package, name: 'source_package', project: source_project) }
+  let(:target_project) { create(:project, name: 'target_project') }
+  let(:target_package) { create(:package, name: 'target_package', project: target_project) }
+  let(:bs_request) do
+    create(:bs_request_with_submit_action,
+           source_project: source_project,
+           source_package: source_package,
+           target_project: target_project,
+           target_package: target_package)
+  end
+  let(:bs_request_action) { bs_request.bs_request_actions.first }
+  let(:superseded_bs_request) do
+    create(:bs_request_with_submit_action,
+           source_project: source_project,
+           source_package: source_package,
+           target_project: target_project,
+           target_package: target_package)
+  end
+  let(:superseded_bs_request_action) { superseded_bs_request.bs_request_actions.first }
+  let(:query_builder) do
+    BsRequestAction::Differ::QueryBuilderForSuperseded.new(
+      superseded_bs_request_action: superseded_bs_request_action,
+      bs_request_action: bs_request_action,
+      source_package_name: source_package.name
+    )
+  end
+
+  describe '#build' do
+    subject { query_builder.build }
+
+    context 'for accepted bs_request_actions' do
+      before do
+        superseded_bs_request_action.update(source_rev: 42)
+      end
+
+      subject do
+        BsRequestAction::Differ::QueryBuilderForSuperseded.new(
+          superseded_bs_request_action: superseded_bs_request_action,
+          bs_request_action: bs_request_action,
+          source_package_name: source_package.name
+        ).build
+      end
+
+      context 'with a oxsrcmd5' do
+        let!(:accept_info) do
+          create(:bs_request_action_accept_info,
+                 bs_request_action: bs_request_action,
+                 opackage: 'opackage',
+                 oproject: 'oproject',
+                 xsrcmd5: 'xsrcmd5',
+                 oxsrcmd5: 'oxsrcmd5')
+        end
+
+        it { expect(subject[:rev]).to eq(accept_info.oxsrcmd5) }
+        it { expect(subject[:orev]).to eq(superseded_bs_request_action.source_rev) }
+        it { expect(subject[:opackage]).to eq(superseded_bs_request_action.source_package) }
+        it { expect(subject[:oproject]).to eq(superseded_bs_request_action.source_project) }
+        it { expect(subject.keys.length).to eq(4) }
+      end
+
+      context 'with an osrcmd5' do
+        let!(:accept_info) do
+          create(:bs_request_action_accept_info,
+                 bs_request_action: bs_request_action,
+                 opackage: 'opackage',
+                 oproject: 'oproject',
+                 srcmd5: 'xrcmd5',
+                 osrcmd5: 'osrcmd5')
+        end
+
+        it { expect(subject[:rev]).to eq(accept_info.osrcmd5) }
+      end
+
+      context 'without an osrcmd5 and oxsrcmd5' do
+        let!(:accept_info) do
+          create(:bs_request_action_accept_info,
+                 bs_request_action: bs_request_action,
+                 opackage: 'opackage',
+                 oproject: 'oproject')
+        end
+
+        it { expect(subject[:rev]).to eq('0') }
+      end
+    end
+
+    context 'for not accepted bs_request_actions' do
+      context 'from the same source' do
+        subject do
+          BsRequestAction::Differ::QueryBuilderForSuperseded.new(
+            superseded_bs_request_action: superseded_bs_request_action,
+            bs_request_action: bs_request_action,
+            source_package_name: source_package.name
+          ).build
+        end
+
+        it { expect(subject[:orev]).to eq(superseded_bs_request_action.source_rev) }
+        it { expect(subject[:rev]).to eq(bs_request_action.source_rev) }
+        it { expect(subject.keys.length).to eq(2) }
+      end
+
+      context 'from different sources' do
+        let!(:another_source_project) { create(:project, name: 'another_source_project', maintainer: user) }
+        let!(:another_source_package) { create(:package, name: 'another_source_package', project: source_project) }
+        let!(:superseded_bs_request) do
+          create(:bs_request_with_submit_action,
+                 source_project: another_source_project,
+                 source_package: another_source_package,
+                 target_project: target_project,
+                 target_package: target_package)
+        end
+        let!(:superseded_bs_request_action) { superseded_bs_request.bs_request_actions.first }
+
+        it { expect(subject[:orev]).to eq(superseded_bs_request_action.source_rev) }
+        it { expect(subject[:oproject]).to eq(superseded_bs_request_action.source_project) }
+        it { expect(subject[:opackage]).to eq(superseded_bs_request_action.source_package) }
+        it { expect(subject[:rev]).to eq(bs_request_action.source_rev) }
+        it { expect(subject.keys.length).to eq(4) }
+      end
+    end
+  end
+
+  describe '#project_name' do
+    subject { query_builder }
+
+    context 'of accepted bs_request_actions' do
+      context 'with an oproject' do
+        let!(:accept_info) do
+          create(:bs_request_action_accept_info,
+                 bs_request_action: bs_request_action,
+                 opackage: 'opackage',
+                 oproject: 'oproject',
+                 srcmd5: 'xrcmd5',
+                 osrcmd5: 'osrcmd5')
+        end
+
+        it { expect(subject.project_name).to eq(accept_info.oproject) }
+      end
+
+      context 'without an oproject' do
+        let!(:accept_info) do
+          create(:bs_request_action_accept_info,
+                 bs_request_action: bs_request_action,
+                 srcmd5: 'xrcmd5',
+                 osrcmd5: 'osrcmd5')
+        end
+
+        it { expect(subject.project_name).to eq(bs_request_action.target_project) }
+      end
+    end
+
+    context 'of not accepted bs_request_actions' do
+      it { expect(subject.project_name).to eq(bs_request_action.source_project) }
+    end
+  end
+
+  describe '#package_name' do
+    subject { query_builder }
+
+    context 'of accepted bs_request_actions' do
+      context 'with an opackage' do
+        let!(:accept_info) do
+          create(:bs_request_action_accept_info,
+                 bs_request_action: bs_request_action,
+                 opackage: 'opackage',
+                 oproject: 'oproject',
+                 srcmd5: 'xrcmd5',
+                 osrcmd5: 'osrcmd5')
+        end
+
+        it { expect(subject.package_name).to eq(accept_info.opackage) }
+      end
+
+      context 'without an opackage' do
+        let!(:accept_info) do
+          create(:bs_request_action_accept_info,
+                 bs_request_action: bs_request_action,
+                 srcmd5: 'xrcmd5',
+                 osrcmd5: 'osrcmd5')
+        end
+
+        it { expect(subject.package_name).to eq(bs_request_action.target_package) }
+      end
+    end
+
+    context 'of not accepted bs_request_actions' do
+      it { expect(subject.package_name).to eq(bs_request_action.source_package) }
+    end
+  end
+end


### PR DESCRIPTION
If a request (submit, maintenance incident or maintenance release) is superseded, it is now possible to
view a diff between the superseded and superseding requests.

In the superseded request, you get a message that this request is superseded and a link to the diff between the superseded and the superseding request:

![image](https://user-images.githubusercontent.com/3799140/37972390-8839357e-31d8-11e8-9775-93aa0daa9245.png)

On the diff page between the superseded and superseding request, you get a message that you're not reviewing the full diff:
![image](https://user-images.githubusercontent.com/3799140/37972450-afc980a8-31d8-11e8-85fa-419dc1cf9a87.png)

I changed the URL to add the parameter ``?diff_to_superseded=:number``. If the supplied number is not superseded by the request, a flash error is rendered in webui and an APIException is raised in the API.
