### PR TITLE
[webui][api] Set always the Nobody instead of Nil

### DIFF
--- a/src/api/app/models/user.rb
+++ b/src/api/app/models/user.rb
@@ -196,11 +196,11 @@ class User < ApplicationRecord
   end
 
   def self.current
-    Thread.current[:user]
+    Thread.current[:user] || find_nobody!
   end
 
   def self.current=(user)
-    Thread.current[:user] = user
+    Thread.current[:user] = user || find_nobody!
   end
 
   def self.current_login


### PR DESCRIPTION
Nobody user is our UserNilObject, we assume in the code that there is always a User object.
However, on some places we still set the User.current to nil.
This should fix it, however, we should get rid of the places were we set User.current = nil.
#4746.