### PR TITLE
[frontend] Merge SetBugowner und AddRole requests

### DIFF
--- a/src/api/app/models/bs_request_action_add_role.rb
+++ b/src/api/app/models/bs_request_action_add_role.rb
@@ -1,53 +1,46 @@
 #
 class BsRequestActionAddRole < BsRequestAction
-  #### Includes and extends
-  #### Constants
-  #### Self config
-  #### Attributes
-  #### Associations macros (Belongs to, Has one, Has many)
-  #### Callbacks macros: before_save, after_save, etc.
-  #### Scopes (first the default_scope macro if is used)
-  #### Validations macros
-
-  #### Class methods using self. (public and then private)
   def self.sti_name
     :add_role
   end
 
-  #### To define class methods as private use private_class_method
-  #### private
-
-  #### Instance methods (public and then protected/private)
   def check_sanity
     super
     errors.add(:role, 'should not be empty for add_role') if role.blank?
-    return unless person_name.blank? && group_name.blank?
-    errors.add(:person_name, 'Either person or group needs to be set')
+    person_or_group_present
   end
 
-  def execute_accept(_opts)
-    object = Project.find_by_name(target_project)
-    object = object.packages.find_by_name(target_package) if target_package
-    if person_name
-      role = Role.find_by_title!(self.role)
-      object.add_user(person_name, role)
-    end
-    if group_name
-      role = Role.find_by_title!(self.role)
-      object.add_group(group_name, role)
-    end
-    object.store(comment: "add_role request #{bs_request.number}", request: bs_request)
+  def execute_accept(opts)
+    object.add_user(person_name, role_object, opts[:ignore_lock]) if person_name
+    object.add_group(group_name, role_object, opts[:ignore_lock]) if group_name
+
+    object.store(comment: "#{type} request #{bs_request.number}", request: bs_request)
   end
 
   def render_xml_attributes(node)
     render_xml_target(node)
     node.person(name: person_name, role: role) if person_name
-    return unless group_name
-
-    node.group(name: group_name, role: role)
+    node.group(name: group_name, role: role) if group_name
   end
 
-  #### Alias of methods
+  protected
+
+  def person_or_group_present
+    return unless person_name.blank? && group_name.blank?
+    errors.add(:person_name, 'Either person or group needs to be set')
+  end
+
+  def object
+    unless @object
+      @object = Project.find_by_name!(target_project)
+      @object.packages.find_by_name(target_package) if target_package
+    end
+    @object
+  end
+
+  def role_object
+    @role_object ||= Role.find_by_title!(role)
+  end
 end
 
 # == Schema Information

--- a/src/api/app/models/bs_request_action_set_bugowner.rb
+++ b/src/api/app/models/bs_request_action_set_bugowner.rb
@@ -1,47 +1,30 @@
 #
-class BsRequestActionSetBugowner < BsRequestAction
-  #### Includes and extends
-  #### Constants
-
-  #### Self config
+class BsRequestActionSetBugowner < BsRequestActionAddRole
   def self.sti_name
     :set_bugowner
   end
 
-  #### Attributes
-  #### Associations macros (Belongs to, Has one, Has many)
-  #### Callbacks macros: before_save, after_save, etc.
-  #### Scopes (first the default_scope macro if is used)
-  #### Validations macros
-  #### Class methods using self. (public and then private)
-  #### To define class methods as private use private_class_method
-  #### private
-
-  #### Instance methods (public and then protected/private)
   def check_sanity
     super
-    return unless person_name.blank? && group_name.blank?
-
-    errors.add(:person_name, 'Either person or group needs to be set')
+    person_or_group_present
   end
 
   def execute_accept(_opts)
-    object = Project.find_by_name!(target_project)
-    bugowner = Role.find_by_title!('bugowner')
-    object = object.packages.find_by_name!(target_package) if target_package
-    object.relationships.where('role_id = ?', bugowner).find_each(&:destroy)
-    object.add_user(person_name, bugowner, true) if person_name # runs with ignoreLock
-    object.add_group(group_name, bugowner, true) if group_name  # runs with ignoreLock
-    object.store(comment: "set_bugowner request #{bs_request.number}", request: bs_request)
+    object.relationships.where('role_id = ?', role_object).find_each(&:destroy)
+    super({ ignore_lock: true })
   end
 
   def render_xml_attributes(node)
     render_xml_target(node)
-    node.person name: person_name if person_name
-    node.group name: group_name   if group_name
+    node.person(name: person_name) if person_name
+    node.group(name: group_name) if group_name
   end
 
-  #### Alias of methods
+  protected
+
+  def role_object
+    @role_object ||= Role.find_by_title!('bugowner')
+  end
 end
 
 # == Schema Information


### PR DESCRIPTION
`BsRequestActionSetBugowner` is just the same as `BsRequestActionAddRole`, with the diference that in the first one previous bugowners are removed. For this small difference we are
duplicating plenty of code.

I would even suggest to get rid of `BsRequestActionSetBugowner`, but let's start with an small change.

Apart from the main difference already mentioned, there were some others between the code of these two classes:

- `Project.find_by_name!(target_project)` in SetBugowner vs `Project.find_by_name(target_project)` in AddRole. But I guess we want it to always fail if project is not found. So this can be unified.

- We set `ignore_lock` to add the role in SetBugowner. This come from: https://github.com/openSUSE/open-build-service/commit/cb15ab2b4dd981e23da922327a77cd53aca41402

I also removed all the sections comments. They were not really followed and they are also not needed for such short classes. :unamused: 