### PR TITLE
[frontend] Always link to users tasks view

### DIFF
--- a/src/api/app/views/layouts/webui/_personal_navigation.html.haml
+++ b/src/api/app/views/layouts/webui/_personal_navigation.html.haml
@@ -4,12 +4,12 @@
       = User.current.login
     |
     - tasks = User.current.tasks
-    - if tasks > 0
-      = link_to(user_tasks_path) do
+    = link_to(user_tasks_path) do
+      - if tasks > 0
         %span{title: 'where an action is requested from you' }
           = pluralize(tasks, 'Task')
-    - else
-      Tasks
+      - else
+        Tasks
     |
     - if User.current.home_project
       = link_to 'Home Project', project_show_path(User.current.home_project)


### PR DESCRIPTION
When a user does not have any open requests / reviews, the tasks label
was not a link. Since there is no other way to access the page (except
adding the direct url into the browser) users were basically locked out
from seeing their tasks, eg. closed requests.

Fixes #4674