### PR TITLE
[ci] Add rspec-retry

### DIFF
--- a/src/api/Gemfile
+++ b/src/api/Gemfile
@@ -140,6 +140,8 @@ end
 group :development, :test do
   # as testing framework
   gem 'rspec-rails', '~> 3.5.0'
+  # to make tests not fail in package test suite
+  gem 'rspec-retry'
   # for fixtures
   gem 'factory_bot_rails'
   # for mocking the backend

--- a/src/api/Gemfile.lock
+++ b/src/api/Gemfile.lock
@@ -312,6 +312,8 @@ GEM
       rspec-expectations (~> 3.5.0)
       rspec-mocks (~> 3.5.0)
       rspec-support (~> 3.5.0)
+    rspec-retry (0.5.7)
+      rspec-core (> 3.3)
     rspec-support (3.5.0)
     rubocop (0.54.0)
       parallel (~> 1.10)
@@ -472,6 +474,7 @@ DEPENDENCIES
   redcarpet
   responders (~> 2.0)
   rspec-rails (~> 3.5.0)
+  rspec-retry
   rubocop
   rubocop-rspec
   ruby-ldap

--- a/src/api/spec/browser_helper.rb
+++ b/src/api/spec/browser_helper.rb
@@ -10,3 +10,24 @@ require 'support/features/features_authentication'
 # Shared examples. Per recommendation of RSpec,
 # https://www.relishapp.com/rspec/rspec-core/v/2-12/docs/example-groups/shared-examples
 Dir['./spec/support/shared_examples/features/*.rb'].each { |example| require example }
+
+require 'rspec/retry'
+RSpec.configure do |config|
+  # show retry status in spec process
+  config.verbose_retry = true
+  # show exception that triggers a retry if verbose_retry is set to true
+  config.display_try_failure_messages = true
+
+  # run retry only on features
+  config.around :each, :js do |ex|
+    ex.run_with_retry retry: 3
+  end
+
+  # callback to be run between retries
+  config.retry_callback = proc do |ex|
+    # run some additional clean up task - can be filtered by example metadata
+    if ex.metadata[:js]
+      Capybara.reset!
+    end
+  end
+end


### PR DESCRIPTION
and enable it for feature tests.
Some feature tests fail randomly in the package build in OBS with timeouts.
Hopefully retrying the same test three times will solve this problem.