### PR TITLE
[frontend] Update exception handling in event mailer

### DIFF
--- a/src/api/app/mailers/event_mailer.rb
+++ b/src/api/app/mailers/event_mailer.rb
@@ -55,9 +55,9 @@ class EventMailer < ActionMailer::Base
           format.text { render template_name, locals: locals }
         end
       end
-    rescue ArgumentError
+    rescue ArgumentError => e
       Rails.logger.error "ArgumentError (catched): template: #{template_name}, locals: #{locals.inspect}, tos: #{tos.inspect}, orig: #{orig}"
-      raise
+      raise e
     end
   end
 end


### PR DESCRIPTION
Re-raise exception instead of raising a new one. This ensures that we
don't loose data related to the exception.

This previously changed with 1f259e35d4eb6c866163530de29ae22bb39204b6