### PR TITLE
[frontend] Prevent codecov reports being send outside of travis

### DIFF
--- a/src/api/spec/rails_helper.rb
+++ b/src/api/spec/rails_helper.rb
@@ -1,8 +1,10 @@
 # for generating test coverage
 require 'simplecov'
-# support test coverage
-require 'support/coverage'
-
+# Avoid codecov failures outside of travis
+if ENV['TRAVIS'] == 'true'
+  # support test coverage
+  require 'support/coverage'
+end
 ENV['RAILS_ENV'] ||= 'test'
 require File.expand_path('../../config/environment', __FILE__)
 # Prevent database truncation if the environment is production


### PR DESCRIPTION
We only need this for travis to have codecov reports for every pull
request and the master branch.
On our development instances sending the report always fails due to a
timeout (~30sec).