### PR TITLE
[backend] enable EFI binaries signing for Debian packages

### DIFF
--- a/src/backend/bs_repserver
+++ b/src/backend/bs_repserver
@@ -2101,7 +2101,7 @@ sub putjob {
 
   my $ev = {'type' => 'built', 'arch' => $arch, 'job' => $job};
 
-  if ($BSConfig::sign && (@{$kiwitree_tosign || []} || grep {$_->{'name'} =~ /\.(?:d?rpm|sha256|iso|pkg\.tar\.gz|pkg\.tar.xz|AppImage)$/} @$uploaded)) {
+  if ($BSConfig::sign && (@{$kiwitree_tosign || []} || grep {$_->{'name'} =~ /\.(?:d?rpm|sha256|iso|pkg\.tar\.gz|pkg\.tar.xz|AppImage|deb)$/} @$uploaded)) {
     # write jobstatus and free lock
     if (@{$kiwitree_tosign || []}) {
       my $c = '';

--- a/src/backend/bs_signer
+++ b/src/backend/bs_signer
@@ -395,7 +395,7 @@ sub signjob {
     # check for followup files
     if (!$info->{'followupfile'} && ($info->{'file'} || '') ne '_aggregate') {
       if (grep {/\.rsasign$/} @signfiles) {
-        $followupfile = (grep {/\.spec$/} @files)[0];
+        $followupfile = (grep {/\.(spec|dsc)$/} @files)[0];
         @signfiles = grep {/\.rsasign$/} @signfiles if $followupfile;
       }
       if (!$followupfile && grep {/\.followup.spec$/} @files) {


### PR DESCRIPTION
Just like for RPMs, if a Debian package build creates $pkg.cpio.rsasign
trigger a signd signature and a rebuild (look for .dsc other than .spec
for the followup build).

The packages to actually do the sign&repack for kernel, shim and grub
can be found:

https://github.com/bluca/linux-signed/tree/obs
https://github.com/bluca/shim-signed/tree/obs
https://github.com/bluca/grub2-signed/tree/obs
https://build.opensuse.org/project/show/home:bluca:debian_secure_boot