### PR TITLE
[frontend] Drop test for fuzzy time

### DIFF
--- a/src/api/spec/helpers/webui/webui_helper_spec.rb
+++ b/src/api/spec/helpers/webui/webui_helper_spec.rb
@@ -285,33 +285,6 @@ RSpec.describe Webui::WebuiHelper do
     end
   end
 
-  describe '#fuzzy_time' do
-    skip('This test currently fail in our package builds')
-
-    before do
-      Timecop.freeze
-    end
-
-    after do
-      Timecop.return
-    end
-
-    context 'with time less than 1 minute' do
-      it { expect(fuzzy_time(59.seconds.ago)).to eq('now') }
-    end
-
-    context 'with_fulltime' do
-      time = (3.hours - 2.minutes).ago.utc
-      output = "<span title='#{time.strftime('%Y-%m-%d %H:%M UTC')}' class='fuzzy-time'>about 3 hours ago</span>"
-      it { expect(fuzzy_time(time)).to eq(output) }
-    end
-
-    context 'without_fulltime' do
-      time = (3.hours - 2.minutes).ago.utc
-      it { expect(fuzzy_time(time, false)).to eq('about 3 hours ago') }
-    end
-  end
-
   describe '#repo_status_icon' do
     skip('Please add some tests')
   end


### PR DESCRIPTION
This test is not adding much value since it's just ensure that the
result of a rails helper (*.ago) is properly shown.
It's also flickering quite often and causes our test suite to fail.

So let's drop it.