### PR TITLE
[webui] Add hint in live build log

### DIFF
--- a/src/api/app/assets/javascripts/webui/application/live_build_log.js
+++ b/src/api/app/assets/javascripts/webui/application/live_build_log.js
@@ -1,4 +1,4 @@
-var LiveLog = function(wrapperId, startButton, stopButton, status, finished) {
+var LiveLog = function(wrapperId, startButton, stopButton, status, finished, info) {
   this.wrapper = $(wrapperId);
   this.startButton = $(startButton);
   this.stopButton = $(stopButton);
@@ -8,12 +8,14 @@ var LiveLog = function(wrapperId, startButton, stopButton, status, finished) {
   this.ajaxRequest = 0;
   this.offset = 0;
   this.finished = finished;
+  this.logInfo = $(info);
 };
 
 $.extend(LiveLog.prototype, {
   initialize: function() {
     this.startButton.click($.proxy(this.start, this));
     this.stopButton.click($.proxy(this.stop, this));
+    this.checkScroll();
     this.start();
     this.initial = false;
     return this;
@@ -24,6 +26,7 @@ $.extend(LiveLog.prototype, {
       this.autoRefresh = true;
       this.lastScroll = 0;
       this.loadContent();
+      this.indicatorStatus('running');
       this.startButton.hide();
       this.stopButton.show();
     }
@@ -32,6 +35,7 @@ $.extend(LiveLog.prototype, {
 
   stop: function() {
     this.autoRefresh = false;
+    this.indicatorStatus('paused');
     this.stopAjaxRequest();
     this.stopButton.hide();
     this.startButton.show();
@@ -41,6 +45,7 @@ $.extend(LiveLog.prototype, {
   loadContent: function() {
     if (this.autoRefresh) {
       var url = this.wrapper.data('url') + '&offset=' + this.offset + ';&' + 'initial=' + (this.initial ? '1' : '0');
+
       this.ajaxRequest = $.ajax({
         type: 'GET',
         url: url,
@@ -65,6 +70,7 @@ $.extend(LiveLog.prototype, {
     this.finished = true;
     this.stop();
     this.status.html('Build finished');
+    this.indicatorStatus('finished');
     this.hideAbort();
   },
 
@@ -82,5 +88,19 @@ $.extend(LiveLog.prototype, {
   hideAbort: function() { // jshint ignore:line
     $(".link_abort_build").hide();
     $(".link_trigger_rebuild").show();
+  },
+
+  indicatorStatus: function(status) { // jshint ignore:line
+    this.logInfo.children().hide();
+    this.logInfo.children('.' + status).show();
+  },
+
+  checkScroll: function() {
+    var element = this;
+    $(window).scroll(function() {
+      var cssStyle = $(document).scrollTop() > element.wrapper.offset().top ? 'fixed' : 'initial';
+      element.logInfo.css('position', cssStyle);
+    });
   }
 });
+

--- a/src/api/app/assets/stylesheets/webui/application/package.scss
+++ b/src/api/app/assets/stylesheets/webui/application/package.scss
@@ -91,3 +91,39 @@ table.repostatus td {
   border-bottom: 1px solid #eee;
   padding: 3px 5px;
 }
+
+#log_space_wrapper {
+  #log-info {
+    width: 920px;
+    top: 0;
+    display: block;
+    margin: 0 10px;
+    text-align: center;
+    cursor: pointer;
+
+    .running {
+      padding: 10px 0;
+      background: #b0e0e6;
+      border: 1px solid #749ca1;
+      &:hover {
+        background: #92ced5;
+      }
+     }
+
+    .paused {
+      padding: 10px 0;
+      background: #dedede;
+      border: 1px solid #a7a7a7;
+      &:hover {
+        background: #d4d2d2;
+      }
+     }
+
+    .finished {
+      cursor: default;
+      padding: 10px 0;
+      background: #bdffbd;
+      border: 1px solid #83bf83;
+     }
+   }
+ }

--- a/src/api/app/views/webui/package/live_build_log.html.erb
+++ b/src/api/app/views/webui/package/live_build_log.html.erb
@@ -23,9 +23,23 @@
 
 <div id="log_space_wrapper"
      data-url="<%= url_for(action: :update_build_log,
-		   package: @package, project: @project,
-                   status: @status,
-                   arch: @arch, repository: @repo) %>">
+                           package: @package, project: @project,
+                           status: @status,
+                           arch: @arch, repository: @repo) %>">
+  <div id='log-info'>
+    <div class='running stop_refresh hidden'>
+      <%= image_tag 'ajax-loader.gif' %>
+      Running...
+    </div/>
+    <div class='paused start_refresh hidden'>
+      <%= sprite_tag 'time_error' %>
+      Paused
+    </div/>
+    <div class='finished hidden'>
+      <%= sprite_tag 'tick' %>
+      Finished
+    </div/>
+  </div>
   <pre id="log_space"></pre>
 </div>
 
@@ -34,5 +48,5 @@
 <% end %>
 
 <%= content_for :ready_function do %>
-  liveLog = new LiveLog('#log_space_wrapper', '.start_refresh', '.stop_refresh', '#status', <%= @finished %>).initialize();
+  liveLog = new LiveLog('#log_space_wrapper', '.start_refresh', '.stop_refresh', '#status', <%= @finished %>, '#log-info').initialize();
 <% end -%>


### PR DESCRIPTION
We added a hint to the live build log to know what is doing: `running`,
`paused` or `finished`. This hint also starts and pause the auto-refresh.

### Running, Paused and Finished

![3-states](https://user-images.githubusercontent.com/1212806/38421285-eab3e688-39a6-11e8-8612-5c02dd0c83be.png)


This hint will always follow you

![screenshot from 2018-04-06 13-57-55](https://user-images.githubusercontent.com/1212806/38420751-2211f4a0-39a5-11e8-8838-b35adfb6597a.png)

Fixes #4713 
