### PR TITLE
[doc] Use local .gitconfig to set commit template

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,10 +22,9 @@ In particular, this community seeks the following types of contributions:
   * Please make sure to mind what our test suite in [travis](https://travis-ci.org/openSUSE/open-build-service) tells you
   * Please always increase our [code coverage](https://codeclimate.com/github/openSUSE/open-build-service) by your pull request
   * To help to write better commit messages we use a [template](https://github.com/openSUSE/open-build-service/blob/master/.gitmessage).
-    Copy this to your home (`cp .gitmessage ~/.gitmessage`) and add this to your `~/.gitconfig`:
+    Set it up with the following command:
     ```
-    [commit]
-      template = ~/.gitmessage
+    git config commit.template .gitmessage
     ```
 
 * A developer of the [open-build-service team](https://github.com/orgs/openSUSE/teams/open-build-service) will review your pull-request


### PR DESCRIPTION
It won't interfere with the global .gitconfig and have potential side-effects in other projects.

It's a one time setup unlike the previous recommendation. With `cp`, it needs to be copied again whenever the template changes.

Note: This could be automated in the rake task building the development environment (`rake docker:build`). I would do this in a following pull request.