### PR TITLE
[frontend] Refactor encoding of buil log file

### DIFF
--- a/src/api/app/mixins/build_log_support.rb
+++ b/src/api/app/mixins/build_log_support.rb
@@ -6,11 +6,7 @@ module BuildLogSupport
 
   def get_log_chunk(project, package, repo, arch, start, theend)
     log = raw_log_chunk(project, package, repo, arch, start, theend)
-    begin
-      log.encode!(invalid: :replace, undef: :replace, cr_newline: true)
-    rescue Encoding::UndefinedConversionError
-      # encode is documented not to throw it if undef: is :replace, but at least we tried - and ruby 1.9.3 is buggy
-    end
+    log.encode!(invalid: :replace, undef: :replace, cr_newline: true)
     log.gsub(/([^a-zA-Z0-9&;<>\/\n\r \t()])/) do |c|
       begin
         if c.ord < 32

--- a/src/api/app/models/event/build_fail.rb
+++ b/src/api/app/models/event/build_fail.rb
@@ -19,11 +19,7 @@ module Event
       offset = size - 18 * 1024
       offset = 0 if offset < 0
       log = raw_log_chunk(payload['project'], payload['package'], payload['repository'], payload['arch'], offset, size)
-      begin
-        log.encode!(invalid: :replace, undef: :replace, universal_newline: true)
-      rescue Encoding::UndefinedConversionError
-        # encode is documented not to throw it if undef: is :replace, but at least we tried - and ruby 1.9.3 is buggy
-      end
+      log.encode!(invalid: :replace, undef: :replace, universal_newline: true)
       log = log.chomp.lines
       log = log.slice(-29, log.length) if log.length > 30
       log.join


### PR DESCRIPTION
When :undef is configured to ':replace' it's not throwing an exception
but replaces the udnefined char with the configured replacement
character.