### PR TITLE
[webui] Fix worst JS ever

### DIFF
--- a/src/api/app/controllers/webui/package_controller.rb
+++ b/src/api/app/controllers/webui/package_controller.rb
@@ -919,6 +919,7 @@ class Webui::PackageController < Webui::WebuiController
     check_ajax
     if @project.repositories.any?
       show_all = params[:show_all] == 'true'
+      @index = params[:index]
       @buildresults = @package.buildresult(@project, show_all)
       render partial: 'buildstatus'
     else

--- a/src/api/app/views/shared/_buildresult_box.html.haml
+++ b/src/api/app/views/shared/_buildresult_box.html.haml
@@ -7,12 +7,12 @@
   %ul{id: "result_select_#{index}"}
     %li.selected
       %a{ href: '#', id: "result_select_link_#{index}_0", data: { id: "result_display_#{index}_0" } } Build Results
-      = sprite_tag('reload', title: 'Reload', onclick: 'update_build_result()', class: "result_reload", id: "result_reload_#{index}_0")
+      = sprite_tag('reload', title: 'Reload', onclick: "update_build_result_#{index}()", class: "result_reload", id: "result_reload_#{index}_0")
       = image_tag('ajax-loader.gif', id: "result_spinner_#{index}_0")
     - if controller == 'package'
       %li
         %a{ href: '#', id: "result_select_link_#{index}_1", data: { id: "result_display_#{index}_1" } } Rpmlint Results
-        = sprite_tag('reload', title: 'Reload', onclick: 'update_rpmlint_result()', class: "result_reload", id: "result_reload_#{index}_1", style: 'display: none')
+        = sprite_tag('reload', title: 'Reload', onclick: "update_rpmlint_result_#{index}()", class: "result_reload", id: "result_reload_#{index}_1", style: 'display: none')
         = image_tag('ajax-loader.gif', id: "result_spinner_#{index}_1", class: 'hidden')
 .content-tabs
   .content-tab{ id: "result_display_#{index}_0" }
@@ -28,7 +28,7 @@
 = javascript_tag do
   - if controller == 'package'
     :plain
-      function update_rpmlint_result() {
+      function update_rpmlint_result_#{index}() {
         $('#result_spinner_#{index}_1').show();
         $('#result_reload_#{index}_1').hide();
         $.ajax({
@@ -49,16 +49,16 @@
         });
       }
 
-      update_rpmlint_result();
+      update_rpmlint_result_#{index}();
 
   :plain
-    function update_build_result() {
+    function update_build_result_#{index}() {
       $('#result_spinner_#{index}_0').show();
       $('#result_reload_#{index}_0').hide();
       $.ajax({
         url: '#{ url_for(controller: controller, action: 'buildresult') }',
         data: {
-          'show_all': $('#show_all').is(':checked'),
+          'show_all': $('#show_all_#{index}').is(':checked'),
           #{ajax_data}
         },
         success: function(data) {
@@ -76,4 +76,4 @@
       });
     }
 
-    update_build_result();
+    update_build_result_#{index}();

--- a/src/api/app/views/webui/package/_buildstatus.html.haml
+++ b/src/api/app/views/webui/package/_buildstatus.html.haml
@@ -1,8 +1,8 @@
 - unless @buildresults.excluded_counter.zero? && !@buildresults.show_all
   .show_all_box
-    = check_box_tag :show_all, true, @buildresults.show_all
+    = check_box_tag "show_all_#{@index}", true, @buildresults.show_all
     - label_message = @buildresults.excluded_counter.zero? ? 'Hide' :  "Show #{@buildresults.excluded_counter}"
-    = label_tag :show_all, "#{label_message} excluded results"
+    = label_tag "show_all_#{@index}", "#{label_message} excluded results"
 
 - @buildresults.results.each_pair do |package, results|
   %h3= package
@@ -38,5 +38,5 @@
     alert(title);
   });
 
-  $('#show_all').change(function(){ update_build_result(); })
+  $("#show_all_#{h @index}").change(function(){ update_build_result_#{h @index}(); })
 


### PR DESCRIPTION
`function update_rpmlint_result` and `function update_build_result`where defined more than once for multiple request.

This fixes the broken "Selecting build / rpmlint result" in request show page, reported in https://github.com/openSUSE/open-build-service/issues/4720 :bowtie: 