### PR TITLE
[dist] Introduces real health check for the rabbitmq service

### DIFF
--- a/docker-compose.ahm.yml
+++ b/docker-compose.ahm.yml
@@ -16,10 +16,10 @@ services:
     # to get up and running. Otherwise grafana tries to
     # connect too soon and crashes.
     healthcheck:
-      test: sleep 10
-      interval: 12s
-      timeout: 11s
-      retries: 1
+      test: rabbitmqctl list_queues
+      interval: 10s
+      timeout: 15s
+      retries: 5
   telegraf:
     image: telegraf
     depends_on:

--- a/src/api/app/models/event/base.rb
+++ b/src/api/app/models/event/base.rb
@@ -274,6 +274,8 @@ module Event
 
     def send_to_bus
       RabbitmqBus.publish(self.class.message_bus_routing_key, self[:payload])
+      # FIXME: For application health monitoring we would need some more meaningful data like...
+      # RabbitmqBus.publish('opensuse.obs.metrics', "meaning_of_life, value=#{rand(42).to_i}")
     rescue Bunny::Exception, OpenSSL::SSL::SSLError => e
       logger.error "Publishing to RabbitMQ failed: #{e.message}"
     end


### PR DESCRIPTION
The simple time based health check depends too much on what else is going
on in the system. If you have a weak system or a high load it would fail.
Switching to a real health check makes this more robust.