### PR TITLE
[frontend] Make it possible to run OBS in a subdirectory

### DIFF
--- a/src/api/config.ru
+++ b/src/api/config.ru
@@ -1,4 +1,6 @@
 # This file is used by Rack-based servers to start the application.
 
 require ::File.expand_path('../config/environment', __FILE__)
-run OBSApi::Application
+map Rails.application.config.relative_url_root || '/' do
+  run OBSApi::Application
+end


### PR DESCRIPTION
if the relative_url_root configuration (or env variable) is set,
the routes will be prefixed into this namespace.
This is necessary because this configuration only covers
the assets paths by default.

This is a "hack" I needed for deploying review apps and pushing now upstream back.