### PR TITLE
Change color for the completed live build log hint

### DIFF
--- a/src/api/app/assets/stylesheets/webui/application/package.scss
+++ b/src/api/app/assets/stylesheets/webui/application/package.scss
@@ -122,8 +122,8 @@ table.repostatus td {
     .finished {
       cursor: default;
       padding: 10px 0;
-      background: #bdffbd;
-      border: 1px solid #83bf83;
+      background: #fffa94;
+      border: 1px solid #b9cb13;
      }
    }
  }

--- a/src/api/app/views/webui/package/live_build_log.html.erb
+++ b/src/api/app/views/webui/package/live_build_log.html.erb
@@ -36,8 +36,7 @@
       Paused
     </div/>
     <div class='finished hidden'>
-      <%= sprite_tag 'tick' %>
-      Finished
+      End of log
     </div/>
   </div>
   <pre id="log_space"></pre>


### PR DESCRIPTION
Before when a live build log ended a text with "Finished" over green was shown and
it was misleading when a build failed. Now is showing "End of log" over
yellow without any icon to not mislead.

![imagen](https://user-images.githubusercontent.com/11314634/38817799-7125499c-4199-11e8-9133-de90cd44cfbf.png)


If fixes #4840 
