### PR TITLE
[ci] Automate gem install version in Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,8 +43,9 @@ jobs:
       before_install:
         - npm install -g jshint
         # These lines are needed to run rubocop in the root directory as we install gems with `bundle install` under `src/api/`
-        - gem install rubocop -v 0.54.0
-        - gem install rubocop-rspec -v 1.25.1
+        # The versions are fetched with bundler and the output is parsed with grep
+        - gem install rubocop -v $(bundle show rubocop | grep -o '[^/rubocop-]*$')
+        - gem install rubocop-rspec -v $(bundle show rubocop-rspec | grep -o '[^/rubocop-rspec-]*$')
     - stage: test
       env: TEST_SUITE=rspec
     - env: TEST_SUITE=api


### PR DESCRIPTION
Whenever depfu is creating PRs to update rubocop, we need to remember to update Travis CI's configuration to use rubocop's new version. We can forget sometimes. This won't happen anymore with these changes