### PR TITLE
[ci] Remove duplicate db:seed task

### DIFF
--- a/src/api/lib/tasks/dev.rake
+++ b/src/api/lib/tasks/dev.rake
@@ -41,7 +41,6 @@ namespace :dev do
     rescue
       Rake::Task['db:create'].invoke
       Rake::Task['db:setup'].invoke
-      Rake::Task['db:seed'].invoke
       if args.old_test_suite
         puts 'Old test suite. Loading fixtures...'
         Rake::Task['db:fixtures:load'].invoke


### PR DESCRIPTION
as db:setup does already load the seeds so do not need to do it twice.