### PR TITLE
[ci] Run backend tests in SLES12 SP3 container

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -34,7 +34,7 @@ namespace :docker do
     desc 'Run our backend tests in the docker container'
     task :backend do
       begin
-        sh 'docker-compose run --rm -w /obs backend make -C src/backend test'
+        sh 'docker-compose -f docker-compose.ci.yml run --rm backend'
       ensure
         sh 'docker-compose stop'
       end

--- a/docker-compose.ci.yml
+++ b/docker-compose.ci.yml
@@ -24,6 +24,12 @@ services:
       - mysql_vol:/var/lib/mysql_tmpfs/
       - .:/obs
     command: /obs/contrib/start_test_db
+  backend:
+    image: registry.opensuse.org/obs/server/unstable/container/sle12/sp3/images/x86_64/openbuildservice/backend:latest
+    volumes:
+      - .:/obs
+    working_dir: /obs
+    command: make -C src/backend test
 volumes:
   mysql_vol:
     driver_opts:


### PR DESCRIPTION
with all the docker Travis changes, it slipped in that we still run the backend tests on the dev tests :man_facepalming: 