### PR TITLE
[ci] Update CI container repository links

### DIFF
--- a/docker-compose.ci.yml
+++ b/docker-compose.ci.yml
@@ -1,14 +1,14 @@
 version: "2"
 services:
   rspec:
-    image:  registry.opensuse.org/obs/server/unstable/ci/images/x86_64/openbuildservice/frontend-base:latest
+    image: registry.opensuse.org/obs/server/unstable/container/sle12/sp3/images/x86_64/openbuildservice/frontend-base:latest
     volumes:
       - .:/obs
     depends_on:
       - db
     command: /obs/contrib/start_rspec
   minitest:
-    image: registry.opensuse.org/obs/server/unstable/ci/images/x86_64/openbuildservice/frontend-backend:latest
+    image: registry.opensuse.org/obs/server/unstable/container/sle12/sp3/images/x86_64/openbuildservice/frontend-backend:latest
     privileged: true
     volumes:
       - .:/obs
@@ -17,9 +17,9 @@ services:
       - cache
     command: /obs/contrib/start_minitest
   cache:
-    image: registry.opensuse.org/obs/server/unstable/ci/images/x86_64/openbuildservice/memcached:latest
+    image: registry.opensuse.org/obs/server/unstable/container/sle12/sp3/images/x86_64/openbuildservice/memcached:latest
   db:
-    image: registry.opensuse.org/obs/server/unstable/ci/images/x86_64/openbuildservice/mariadb:latest
+    image: registry.opensuse.org/obs/server/unstable/container/sle12/sp3/images/x86_64/openbuildservice/mariadb:latest
     volumes:
       - mysql_vol:/var/lib/mysql_tmpfs/
       - .:/obs


### PR DESCRIPTION
because I moved the project to another place so that it is easier to follow a common namespace for new base systems

- https://build.opensuse.org/project/show/OBS:Server:Unstable:container:Leap:42.3
- https://build.opensuse.org/project/show/OBS:Server:Unstable:container:SLE12:SP3
- etc...