### PR TITLE
[frontend] Disable feature tests for archs != x86

### DIFF
--- a/dist/obs-server.spec
+++ b/dist/obs-server.spec
@@ -410,6 +410,10 @@ make -C src/backend test
 # start api testing
 #
 %if 0%{?disable_obs_frontend_test_suite:1} < 1
+# UI tests are not needed for non x86 architectures
+%ifnarch %ix86 x86_64
+rm -r src/api/spec/features/
+%endif  
 make -C src/api test
 %endif
 


### PR DESCRIPTION
These tests tend to fail because of capybara timeouts and we don't
need / use the UI for these architectures anyway.