### PR TITLE
[webui] Fix Show/Hide outdated comments link text

### DIFF
--- a/src/api/app/views/webui/request/show.html.erb
+++ b/src/api/app/views/webui/request/show.html.erb
@@ -227,8 +227,9 @@
       <% @superseding.each do |supersed| %>
         <% if supersed.comments.any? %>
           <div class="grid_10 box box-shadow alpha omega">
-            <h2 class="box-header"><a class="supersed_comments_link">
-              Show outdated comments</a>for superseded <%= link_to "request #{supersed.number}", number: supersed.number %>
+            <h2 class="box-header">
+              <a class="supersed_comments_link">Show outdated comments</a>for superseded
+              <%= link_to "request #{supersed.number}", number: supersed.number %>
             </h2>
             <div class="superseded_comments hidden">
               <%= render :partial => 'webui/comment/show', locals: { commentable: supersed } %>


### PR DESCRIPTION
The line break in the `<a>` tag was causing the Javascript check to fail due to the text having leading whitespaces. It doesn't have these whitespaces anymore

Fixes #4889