### PR TITLE
[webui] Split main_controller

### DIFF
--- a/src/api/app/controllers/webui/main_controller.rb
+++ b/src/api/app/controllers/webui/main_controller.rb
@@ -21,7 +21,7 @@ class Webui::MainController < Webui::WebuiController
   end
 
   def index
-    @news = StatusMessage.alive.limit(4).to_a
+    @status_messages = StatusMessage.alive.limit(4).to_a
     @workerstatus = Rails.cache.fetch('workerstatus_hash', expires_in: 10.minutes) do
       WorkerStatus.hidden.to_hash
     end

--- a/src/api/app/controllers/webui/main_controller.rb
+++ b/src/api/app/controllers/webui/main_controller.rb
@@ -1,8 +1,6 @@
 require 'statistics_calculations'
 
 class Webui::MainController < Webui::WebuiController
-  # permissions.status_message_create
-  before_action :require_admin, only: [:delete_message, :add_news]
   skip_before_action :check_anonymous, only: [:index]
 
   def gather_busy
@@ -83,33 +81,5 @@ class Webui::MainController < Webui::WebuiController
     render template: 'webui/main/sitemap_packages',
            layout: false, locals: { action: params[:listaction] },
            content_type: 'application/xml'
-  end
-
-  def add_news_dialog
-    render_dialog
-  end
-
-  def add_news
-    if params[:message].nil? || params[:severity].blank?
-      flash[:error] = 'Please provide a message and severity'
-      redirect_to(action: 'index') && return
-    end
-    # TODO: make use of permissions.status_message_create
-    status_message = StatusMessage.new(message: params[:message], severity: params[:severity], user: User.current)
-    if status_message.save
-      flash[:notice] = 'Status message was successfully created.'
-    else
-      flash[:error] = "Could not create status message: #{status_message.errors.full_messages.to_sentence}"
-    end
-    redirect_to(action: 'index')
-  end
-
-  def delete_message_dialog
-    render_dialog
-  end
-
-  def delete_message
-    StatusMessage.find(params[:message_id]).delete
-    redirect_to(action: 'index')
   end
 end

--- a/src/api/app/controllers/webui/status_messages_controller.rb
+++ b/src/api/app/controllers/webui/status_messages_controller.rb
@@ -1,0 +1,37 @@
+class Webui::StatusMessagesController < Webui::WebuiController
+  # permissions.status_message_create
+  before_action :require_admin, only: [:destroy, :create]
+
+  def create_status_message_dialog
+    render_dialog
+  end
+
+  def create
+    # TODO: make use of permissions.status_message_create
+    status_message = StatusMessage.new(message: params[:message], severity: params[:severity], user: User.current)
+
+    if status_message.save
+      flash[:notice] = 'Status message was successfully created.'
+    else
+      flash[:error] = "Could not create status message: #{status_message.errors.full_messages.to_sentence}"
+    end
+
+    redirect_to(controller: 'main', action: 'index')
+  end
+
+  def destroy_status_message_dialog
+    render_dialog
+  end
+
+  def destroy
+    status_message = StatusMessage.find(params[:id])
+
+    if status_message.delete
+      flash[:notice] = 'Status message was successfully deleted.'
+    else
+      flash[:error] = "Could not delete status message: #{status_message.errors.full_messages.to_sentence}"
+    end
+
+    redirect_to(controller: 'main', action: 'index')
+  end
+end

--- a/src/api/app/views/webui/main/_status_messages.html.haml
+++ b/src/api/app/views/webui/main/_status_messages.html.haml
@@ -10,8 +10,8 @@
       .clear
       .grid_4.box.news-message
         - if User.current.is_admin?
-          = link_to(sprite_tag('comment_delete', title: 'Remove message'),
-            { controller: 'main', action: 'delete_message_dialog', message_id: msg.id },
+          = link_to(sprite_tag('comment_delete', title: 'Remove status message'),
+            { controller: 'status_messages', action: 'destroy_status_message_dialog', id: msg.id },
             { remote: true, class: 'delete-message' })
         - case msg.severity.to_i
         - when 3
@@ -26,4 +26,4 @@
       .clear
     - if User.current.is_admin?
       %p
-        = link_to(sprite_tag('comment_add') + content_tag(:span, 'Add new status', id: "add-new-message"), { controller: 'main', action: 'add_news_dialog' }, { remote: true })
+        = link_to(sprite_tag('comment_add') + content_tag(:span, 'Add new status message', id: "add-new-message"), { controller: 'status_messages', action: 'create_status_message_dialog' }, { remote: true })

--- a/src/api/app/views/webui/main/_status_messages.html.haml
+++ b/src/api/app/views/webui/main/_status_messages.html.haml
@@ -1,9 +1,9 @@
-- if @news.present? || User.current.is_admin?
+- if @status_messages.present? || User.current.is_admin?
   .box.box-shadow#messages
     %h2.box-header
       Announcements
       \#{link_to('', news_feed_path(format: 'rss'), { class: 'alignright icons-feeds', title: 'RSS Feed' })}
-    - @news.each do |msg|
+    - @status_messages.each do |msg|
       .grid_4.news-sender
         = user_with_realname_and_icon msg.user, short: true
         wrote #{time_ago_in_words(msg.created_at)} ago

--- a/src/api/app/views/webui/main/index.html.haml
+++ b/src/api/app/views/webui/main/index.html.haml
@@ -26,5 +26,5 @@
       %h2.box-header New here? Sign up!
       = render partial: 'shared/sign_up'
   = render partial: 'sponsors'
-  = render partial: 'news'
+  = render partial: 'status_messages'
   = render partial: 'latest_updates' if (@latest_updates and ::Configuration.anonymous)

--- a/src/api/app/views/webui/status_messages/_create_status_message_dialog.html.haml
+++ b/src/api/app/views/webui/status_messages/_create_status_message_dialog.html.haml
@@ -1,8 +1,8 @@
 .dialog.darkgrey_box
   .box.box-shadow
-    %h2.box-header Add New Message
+    %h2.box-header Add New Status Message
     .dialog-content
-      = form_tag({ controller: 'main', action: 'add_news' }, method: 'post') do
+      = form_tag({ controller: 'status_messages', action: 'create' }, method: 'post') do
         %p
           = label_tag(:message, 'Message:')
           %br/

--- a/src/api/app/views/webui/status_messages/_destroy_status_message_dialog.html.haml
+++ b/src/api/app/views/webui/status_messages/_destroy_status_message_dialog.html.haml
@@ -2,6 +2,6 @@
   .box.box-shadow
     %h2.box-header Delete Confirmation
     .dialog-content
-      %p Really delete this message?
-    = form_tag(main_delete_message_path(message_id: params[:message_id]), method: :delete) do
+      %p Really delete this status message?
+    = form_tag(status_message_path(id: params[:id]), method: :delete) do
       = render partial: '/webui/shared/dialog_action_buttons'

--- a/src/api/config/routes.rb
+++ b/src/api/config/routes.rb
@@ -46,10 +46,13 @@ OBSApi::Application.routes.draw do
 
     controller 'webui/main' do
       get 'main/systemstatus' => :systemstatus
-      get 'main/add_news_dialog' => :add_news_dialog
-      post 'main/add_news' => :add_news
-      get 'main/delete_message_dialog' => :delete_message_dialog
-      delete 'main/delete_message/:message_id' => :delete_message, as: :main_delete_message
+    end
+
+    resources :status_messages, only: [:create, :destroy], controller: 'webui/status_messages' do
+      collection do
+        get 'create_status_message_dialog' => :create_status_message_dialog
+        get 'destroy_status_message_dialog' => :destroy_status_message_dialog
+      end
     end
 
     controller 'webui/feeds' do

--- a/src/api/spec/controllers/webui/main_controller_spec.rb
+++ b/src/api/spec/controllers/webui/main_controller_spec.rb
@@ -4,99 +4,6 @@ RSpec.describe Webui::MainController do
   let(:user) { create(:confirmed_user) }
   let(:admin_user) { create(:admin_user) }
 
-  describe 'POST add_news' do
-    it 'create a status message' do
-      login(admin_user)
-
-      post :add_news, params: { message: 'Some message', severity: 'Green' }
-      expect(response).to redirect_to(root_path)
-      message = StatusMessage.where(user: admin_user, message: 'Some message', severity: 'Green')
-      expect(message).to exist
-    end
-
-    it 'requires message and severity parameters' do
-      login(admin_user)
-
-      expect do
-        post :add_news, params: { message: 'Some message' }
-      end.not_to change(StatusMessage, :count)
-      expect(response).to redirect_to(root_path)
-      expect(flash[:error]).to eq('Please provide a message and severity')
-
-      expect do
-        post :add_news, params: { severity: 'Green' }
-      end.not_to change(StatusMessage, :count)
-      expect(response).to redirect_to(root_path)
-      expect(flash[:error]).to eq('Please provide a message and severity')
-    end
-
-    context 'non-admin users' do
-      before do
-        login(user)
-
-        post :add_news, params: { message: 'Some message', severity: 'Green' }
-      end
-
-      it 'does not create a status message' do
-        expect(response).to redirect_to(root_path)
-        message = StatusMessage.where(user: admin_user, message: 'Some message', severity: 'Green')
-        expect(message).not_to exist
-      end
-    end
-
-    context 'empty message' do
-      before do
-        login(admin_user)
-        post :add_news, params: { severity: 'Green' }
-      end
-
-      it { expect(flash[:error]).to eq('Please provide a message and severity') }
-    end
-
-    context 'empty severity' do
-      before do
-        login(admin_user)
-        post :add_news, params: { message: 'Some message' }
-      end
-
-      it { expect(flash[:error]).to eq('Please provide a message and severity') }
-    end
-
-    context 'that fails at saving the message' do
-      before do
-        login(admin_user)
-        allow_any_instance_of(StatusMessage).to receive(:save).and_return(false)
-        post :add_news, params: { message: 'Some message', severity: 'Green' }
-      end
-
-      it { expect(flash[:error]).not_to be nil }
-    end
-  end
-
-  describe 'POST delete_message' do
-    let(:message) { create(:status_message, user: admin_user) }
-
-    it 'marks a message as deleted' do
-      login(admin_user)
-
-      post :delete_message, params: { message_id: message.id }
-      expect(response).to redirect_to(root_path)
-      expect(message.reload.deleted_at).to be_a_kind_of(ActiveSupport::TimeWithZone)
-    end
-
-    context 'non-admin users' do
-      before do
-        login(user)
-        post :delete_message, params: { message_id: message.id }
-      end
-
-      it "can't delete messages" do
-        expect(response).to redirect_to(root_path)
-        expect(message.reload.deleted_at).to be nil
-      end
-    end
-  end
-
   describe 'GET #sitemap' do
     render_views
 
@@ -201,21 +108,5 @@ RSpec.describe Webui::MainController do
         end
       end
     end
-  end
-
-  describe 'GET #add_news_dialog' do
-    before do
-      get :add_news_dialog, xhr: true
-    end
-
-    it { is_expected.to respond_with(:success) }
-  end
-
-  describe 'GET #delete_message_dialog' do
-    before do
-      get :delete_message_dialog, xhr: true
-    end
-
-    it { is_expected.to respond_with(:success) }
   end
 end

--- a/src/api/spec/controllers/webui/status_messages_controller_spec.rb
+++ b/src/api/spec/controllers/webui/status_messages_controller_spec.rb
@@ -1,0 +1,115 @@
+require 'rails_helper'
+
+RSpec.describe Webui::StatusMessagesController do
+  let(:user) { create(:confirmed_user) }
+  let(:admin_user) { create(:admin_user) }
+
+  describe 'POST create' do
+    it 'create a status message' do
+      login(admin_user)
+
+      post :create, params: { message: 'Some message', severity: 'Green' }
+      expect(response).to redirect_to(root_path)
+      message = StatusMessage.where(user: admin_user, message: 'Some message', severity: 'Green')
+      expect(message).to exist
+    end
+
+    it 'requires message and severity parameters' do
+      login(admin_user)
+
+      expect do
+        post :create, params: { message: 'Some message' }
+      end.not_to change(StatusMessage, :count)
+      expect(response).to redirect_to(root_path)
+      expect(flash[:error]).to eq("Could not create status message: Severity can't be blank")
+
+      expect do
+        post :create, params: { severity: 'Green' }
+      end.not_to change(StatusMessage, :count)
+      expect(response).to redirect_to(root_path)
+      expect(flash[:error]).to eq("Could not create status message: Message can't be blank")
+    end
+
+    context 'non-admin users' do
+      before do
+        login(user)
+
+        post :create, params: { message: 'Some message', severity: 'Green' }
+      end
+
+      it 'does not create a status message' do
+        expect(response).to redirect_to(root_path)
+        message = StatusMessage.where(user: admin_user, message: 'Some message', severity: 'Green')
+        expect(message).not_to exist
+      end
+    end
+
+    context 'empty message' do
+      before do
+        login(admin_user)
+        post :create, params: { severity: 'Green' }
+      end
+
+      it { expect(flash[:error]).to eq("Could not create status message: Message can't be blank") }
+    end
+
+    context 'empty severity' do
+      before do
+        login(admin_user)
+        post :create, params: { message: 'Some message' }
+      end
+
+      it { expect(flash[:error]).to eq("Could not create status message: Severity can't be blank") }
+    end
+
+    context 'that fails at saving the message' do
+      before do
+        login(admin_user)
+        allow_any_instance_of(StatusMessage).to receive(:save).and_return(false)
+        post :create, params: { message: 'Some message', severity: 'Green' }
+      end
+
+      it { expect(flash[:error]).not_to be nil }
+    end
+  end
+
+  describe 'DELETE destroy' do
+    let(:message) { create(:status_message, user: admin_user) }
+
+    it 'marks a message as deleted' do
+      login(admin_user)
+
+      delete :destroy, params: { id: message.id }
+      expect(response).to redirect_to(root_path)
+      expect(message.reload.deleted_at).to be_a_kind_of(ActiveSupport::TimeWithZone)
+    end
+
+    context 'non-admin users' do
+      before do
+        login(user)
+        delete :destroy, params: { id: message.id }
+      end
+
+      it "can't delete messages" do
+        expect(response).to redirect_to(root_path)
+        expect(message.reload.deleted_at).to be nil
+      end
+    end
+  end
+
+  describe 'GET #create_status_message_dialog' do
+    before do
+      get :create_status_message_dialog, xhr: true
+    end
+
+    it { is_expected.to respond_with(:success) }
+  end
+
+  describe 'GET #destroy_status_message_dialog' do
+    before do
+      get :destroy_status_message_dialog, xhr: true
+    end
+
+    it { is_expected.to respond_with(:success) }
+  end
+end


### PR DESCRIPTION
Status messages don't belong in `webui/main_controller`, so they are now in their own controller. The views and specs were moved too.

Minor changes in the UI for the links to be consistent. It is now always referring to *Status messages*. It was a mix of *message* and *status*.

@hennevogel and @mdeniz, please have a look.