### PR TITLE
[frontend] Forward only submit requests

### DIFF
--- a/src/api/app/models/bs_request.rb
+++ b/src/api/app/models/bs_request.rb
@@ -1162,7 +1162,7 @@ class BsRequest < ApplicationRecord
   def forward_to(project:, package: nil, options: {})
     new_request = BsRequest.new(description: options[:description])
     BsRequest.transaction do
-      bs_request_actions.each do |action|
+      bs_request_actions.where(type: 'submit').find_each do |action|
         rev = Directory.hashed(project: action.target_project, package: action.target_package)['rev']
 
         opts = { source_project: action.target_project,
@@ -1170,7 +1170,7 @@ class BsRequest < ApplicationRecord
                  source_rev:     rev,
                  target_project: project,
                  target_package: package,
-                 type:           'submit' }
+                 type:           action.type }
         opts[:sourceupdate] = options[:sourceupdate] if options[:sourceupdate]
         new_request.bs_request_actions.build(opts)
 

--- a/src/api/spec/cassettes/BsRequest/_forward_to/only_forwards_submit_requests.yml
+++ b/src/api/spec/cassettes/BsRequest/_forward_to/only_forwards_submit_requests.yml
@@ -1,0 +1,388 @@
+---
+http_interactions:
+- request:
+    method: put
+    uri: http://backend:5352/source/target_project/_meta
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="target_project">
+          <title>To Sail Beyond the Sunset</title>
+          <description/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '116'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="target_project">
+          <title>To Sail Beyond the Sunset</title>
+          <description></description>
+        </project>
+    http_version: 
+  recorded_at: Mon, 30 Apr 2018 09:41:40 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/target_project/_config
+    body:
+      encoding: UTF-8
+      string: Optio ullam repellat necessitatibus et animi. Voluptas tempora quo exercitationem.
+        Non nihil voluptates qui repudiandae.
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '21'
+    body:
+      encoding: UTF-8
+      string: '<status code="ok" />
+
+'
+    http_version: 
+  recorded_at: Mon, 30 Apr 2018 09:41:40 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/target_project/target_package/_meta?user=_nobody_
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="target_package" project="target_project">
+          <title>Recalled to Life</title>
+          <description>Aliquam voluptates labore assumenda aut.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '172'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="target_package" project="target_project">
+          <title>Recalled to Life</title>
+          <description>Aliquam voluptates labore assumenda aut.</description>
+        </package>
+    http_version: 
+  recorded_at: Mon, 30 Apr 2018 09:41:40 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/target_project/target_package/_meta
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="target_package" project="target_project">
+          <title>Recalled to Life</title>
+          <description>Aliquam voluptates labore assumenda aut.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '172'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="target_package" project="target_project">
+          <title>Recalled to Life</title>
+          <description>Aliquam voluptates labore assumenda aut.</description>
+        </package>
+    http_version: 
+  recorded_at: Mon, 30 Apr 2018 09:41:40 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/source_project/_meta
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="source_project">
+          <title>Ring of Bright Water</title>
+          <description/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '111'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="source_project">
+          <title>Ring of Bright Water</title>
+          <description></description>
+        </project>
+    http_version: 
+  recorded_at: Mon, 30 Apr 2018 09:41:40 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/source_project/_config
+    body:
+      encoding: UTF-8
+      string: Hic molestiae omnis earum explicabo corporis culpa. Repellat beatae
+        esse expedita veritatis soluta provident. Autem sunt quod amet qui voluptatibus.
+        Sequi quo nam atque minima error sit optio.
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '21'
+    body:
+      encoding: UTF-8
+      string: '<status code="ok" />
+
+'
+    http_version: 
+  recorded_at: Mon, 30 Apr 2018 09:41:40 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/source_project/source_package/_meta?user=_nobody_
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="source_package" project="source_project">
+          <title>Tirra Lirra by the River</title>
+          <description>Culpa cupiditate pariatur et aut maxime.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '180'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="source_package" project="source_project">
+          <title>Tirra Lirra by the River</title>
+          <description>Culpa cupiditate pariatur et aut maxime.</description>
+        </package>
+    http_version: 
+  recorded_at: Mon, 30 Apr 2018 09:41:40 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/source_project/source_package/_meta
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="source_package" project="source_project">
+          <title>Tirra Lirra by the River</title>
+          <description>Culpa cupiditate pariatur et aut maxime.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '180'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="source_package" project="source_project">
+          <title>Tirra Lirra by the River</title>
+          <description>Culpa cupiditate pariatur et aut maxime.</description>
+        </package>
+    http_version: 
+  recorded_at: Mon, 30 Apr 2018 09:41:40 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:user_1/_meta?user=user_1
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:user_1">
+          <title/>
+          <description/>
+          <person userid="user_1" role="maintainer"/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '135'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:user_1">
+          <title></title>
+          <description></description>
+          <person userid="user_1" role="maintainer" />
+        </project>
+    http_version: 
+  recorded_at: Mon, 30 Apr 2018 09:41:40 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:tux/_meta?user=tux
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:tux">
+          <title/>
+          <description/>
+          <person userid="tux" role="maintainer"/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '129'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:tux">
+          <title></title>
+          <description></description>
+          <person userid="tux" role="maintainer" />
+        </project>
+    http_version: 
+  recorded_at: Mon, 30 Apr 2018 09:41:40 GMT
+recorded_with: VCR 4.0.0

--- a/src/api/spec/factories/bs_request_actions.rb
+++ b/src/api/spec/factories/bs_request_actions.rb
@@ -13,6 +13,9 @@ FactoryBot.define do
     factory :bs_request_action_submit, class: BsRequestActionSubmit do
       type 'submit'
     end
+    factory :bs_request_action_delete, class: BsRequestActionDelete do
+      type 'delete'
+    end
     factory :bs_request_action_maintenance_incident, class: BsRequestActionMaintenanceIncident do
       type 'maintenance_incident'
     end

--- a/src/api/spec/factories/bs_requests.rb
+++ b/src/api/spec/factories/bs_requests.rb
@@ -73,6 +73,17 @@ FactoryBot.define do
       end
     end
 
+    factory :delete_bs_request do
+      after(:create) do |request, evaluator|
+        request.bs_request_actions.delete_all
+        request.bs_request_actions << create(
+          :bs_request_action_delete,
+          target_project: evaluator.target_project,
+          target_package: evaluator.target_package
+        )
+      end
+    end
+
     factory :bs_request_with_maintenance_release_action do
       after(:create) do |request, evaluator|
         request.bs_request_actions.delete_all


### PR DESCRIPTION
Previously any bs request action that was forwarded would be converted
into a submit request. This doesn't really make sense and it's better to
skip such request actions for now.