### PR TITLE
[ci] fix @INC in testcase 0100-check_webserver_and_api

### DIFF
--- a/dist/t/0100-check_webserver_and_api.ts
+++ b/dist/t/0100-check_webserver_and_api.ts
@@ -5,6 +5,12 @@ use warnings;
 use Test::More tests => 4;
 use Sys::Hostname;
 use Data::Dumper;
+use FindBin;
+
+BEGIN {
+  unshift @INC, "/usr/lib/obs/server/";
+}
+
 use XML::Structured;
 
 


### PR DESCRIPTION
test case fail ATM with

```
1..3
ok 1 - Checking if database exists
ok 2 - Checking if tables in database api_production
ok 3 - Checking if database is started under /srv/obs/MySQL
ok
Can't locate XML/Structured.pm in @INC (you may need to install the XML::Structured module) (@INC contains: /usr/lib/perl5/site_perl/5.18.2/x86_64-linux-thread-multi /usr/lib/perl5/site_perl/5.18.2 /usr/lib/perl5/vendor_perl/5.18.2/x86_64-linux-thread-multi /usr/lib/perl5/vendor_perl/5.18.2 /usr/lib/perl5/5.18.2/x86_64-linux-thread-multi /usr/lib/perl5/5.18.2 /usr/lib/perl5/site_perl .) at t/0100-check_webserver_and_api.ts line 8.
BEGIN failed--compilation aborted at t/0100-check_webserver_and_api.ts line 8.
# Looks like your test exited with 2 before it could output anything.
t/0100-check_webserver_and_api.ts ..... 
1..4
Dubious, test returned 2 (wstat 512, 0x200)
Failed 4/4 subtests 

Test Summary Report
-------------------
t/0100-check_webserver_and_api.ts   (Wstat: 512 Tests: 0 Failed: 0)
  Non-zero exit status: 2
  Parse errors: Bad plan.  You planned 4 tests but ran 0.
Files=6, Tests=33,  2 wallclock secs ( 0.07 usr  0.03 sys +  0.90 cusr  0.37 csys =  1.37 CPU)
Result: FAIL
Makefile:85: recipe for target 'test_system' failed
make: *** [test_system] Error 1
make: Leaving directory '/tmp/open-build-service/dist'
```