### PR TITLE
[dist] Fix openQA tests

### DIFF
--- a/dist/t/spec/spec_helper.rb
+++ b/dist/t/spec/spec_helper.rb
@@ -36,7 +36,7 @@ def take_screenshot(example)
 end
 
 def login
-    visit "/user/login"
+    visit "/session/new"
     fill_in 'user-login', with: 'Admin'
     fill_in 'user-password', with: 'opensuse'
     click_button('log-in-button')


### PR DESCRIPTION
We were using `/user/login` route that was removed in https://github.com/openSUSE/open-build-service/pull/4731 :bowtie: 