### PR TITLE
[ci] Disable git-cop for 2.9 branch

### DIFF
--- a/dist/ci/travis_script.sh
+++ b/dist/ci/travis_script.sh
@@ -28,7 +28,6 @@ if test -z "$SUBTEST"; then
       make -C ../../ rubocop
       bundle exec rake haml_lint
       jshint .
-      bundle exec git-cop --police
       ;;
     rspec)
       perl -pi -e 's/source_host: localhost/source_host: backend/' config/options.yml


### PR DESCRIPTION
Git cop is always comparing with master instead of the branch we want to
merge. Right now for 2.9 we only do cherry-picks from master that has
passed git-cop checks.