### PR TITLE
[dist] avoid build and runtime failure when not using obs_scm

### DIFF
--- a/dist/obs-server.spec
+++ b/dist/obs-server.spec
@@ -342,6 +342,8 @@ export OBS_VERSION="%{version}"
 DESTDIR=%{buildroot} make install FILLUPDIR=%{_fillupdir}
 if [ -f %{_sourcedir}/open-build-service.obsinfo ]; then
     sed -n -e 's/commit: \(.\+\)/\1/p' %{_sourcedir}/open-build-service.obsinfo > %{buildroot}/srv/www/obs/api/last_deploy
+else
+    echo "%version" > %{buildroot}/srv/www/obs/api/last_deploy
 fi
 #
 # turn duplicates into hard links
@@ -525,7 +527,6 @@ touch /srv/www/obs/api/log/production.log
 chown %{apache_user}:%{apache_group} /srv/www/obs/api/log/production.log
 
 %restart_on_update memcached
-touch /srv/www/obs/api/last_deploy
 
 %postun -n obs-api
 %insserv_cleanup

--- a/src/api/config/initializers/git.rb
+++ b/src/api/config/initializers/git.rb
@@ -1,6 +1,6 @@
 module Git
   if File.exist?(File.join(Rails.root, 'last_deploy'))
-    COMMIT = File.open(File.join(Rails.root, 'last_deploy'), 'r') { |f| GIT_REVISION = f.gets.chomp }
+    COMMIT = File.open(File.join(Rails.root, 'last_deploy'), 'r') { |f| GIT_REVISION = f.gets.try(:chomp) }
     LAST_DEPLOYMENT = File.new(File.join(Rails.root, 'last_deploy')).atime
   else
     COMMIT = %x(SHA1=$(git rev-parse --short HEAD 2> /dev/null); if [ $SHA1 ]; then echo $SHA1; else echo 'unknown'; fi).chomp


### PR DESCRIPTION
frontend code is just crashing by attempting to chomp and package
builds fail due to hard required last_deployed file in %files