### PR TITLE
[frontend] Document how to handle delayed jobs queue during updates

### DIFF
--- a/dist/README.UPDATERS
+++ b/dist/README.UPDATERS
@@ -3,6 +3,10 @@ For Updaters from OBS 2.9 to OBS 2.10
 
 Note: Update from OBS 2.5 should also work, but is untested.
       A direct update from OBS 2.4 or older will not work.
+      It's recommended to wait for all pending delayed jobs to be processed before
+      creating a DB dump or running the migrations.
+      To see the number of pending delayed jobs run
+      `(cd /srv/www/obs/api; bundle exec rails r -e production "puts Delayed::Job.count")`
 
   1) Remove the OBS 2.9 Repository
 
@@ -54,6 +58,10 @@ For Updaters to OBS 2.9 from OBS 2.8
 
 Note: Update from OBS 2.5 should also work, but is untested.
       A direct update from OBS 2.4 or older will not work.
+      It's recommended to wait for all pending delayed jobs to be processed before
+      creating a DB dump or running the migrations.
+      To see the number of pending delayed jobs run
+      `(cd /srv/www/obs/api; bundle exec rails r -e production "puts Delayed::Job.count")`
 
   1) Remove the OBS 2.8 Repository
 
@@ -106,6 +114,10 @@ For Updaters to OBS 2.8 from OBS 2.7
 
 Note: Update from OBS 2.5 should also work, but is untested.
       A direct update from OBS 2.4 or older will not work.
+      It's recommended to wait for all pending delayed jobs to be processed before
+      creating a DB dump or running the migrations.
+      To see the number of pending delayed jobs run
+      `(cd /srv/www/obs/api; bundle exec rails r -e production "puts Delayed::Job.count")`
 
   1) Remove the OBS 2.7 Repository
 


### PR DESCRIPTION
When updating OBS, it can happen that the delayed jobs table contains
pending jobs. In case that the OBS update includes a code change that
is incompatible with the object stored by delayed jobs, this can cause
breakage when once the delayed job gets executed.

This can either happen when running database migrations (see PR#4969)
or by processing the delayed jobs service.

While this can happen for any deployed OBS instance it is far more
likely this occurs in our Stable releases. This is because of the much
larger delay between creating a migration and running it (= updating the
OBS instance).

Since this can hardly be avoided, we document this limitation and how to
avoid this from happening in the updaters guide.