### PR TITLE
Change the way we do logging in production

### DIFF
--- a/src/api/Gemfile
+++ b/src/api/Gemfile
@@ -84,6 +84,8 @@ group :development, :production do
   gem 'clockwork', '>= 0.7'
   # as interface to LDAP
   gem 'ruby-ldap', require: false
+  # to have better logs
+  gem 'lograge'
 end
 
 group :production do

--- a/src/api/Gemfile.lock
+++ b/src/api/Gemfile.lock
@@ -182,6 +182,11 @@ GEM
     kgio (2.11.0)
     launchy (2.4.3)
       addressable (~> 2.3)
+    lograge (0.10.0)
+      actionpack (>= 4)
+      activesupport (>= 4)
+      railties (>= 4)
+      request_store (~> 1.0)
     loofah (2.2.2)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
@@ -286,6 +291,8 @@ GEM
     rdoc (6.0.4)
     redcarpet (3.4.0)
     refinements (5.2.0)
+    request_store (1.4.1)
+      rack (>= 1.4)
     responders (2.4.0)
       actionpack (>= 4.2.0, < 5.3)
       railties (>= 4.2.0, < 5.3)
@@ -449,6 +456,7 @@ DEPENDENCIES
   jquery-ui-rails (~> 4.2.1)
   kaminari
   launchy
+  lograge
   minitest
   minitest-fail-fast
   minitest-reporters

--- a/src/api/config/environments/production.rb
+++ b/src/api/config/environments/production.rb
@@ -71,6 +71,18 @@ OBSApi::Application.configure do
     config.logger = ActiveSupport::TaggedLogging.new(logger)
   end
 
+  # Use lograge to show the logs in one line
+  config.lograge.enabled = true
+  config.lograge.custom_options = lambda do |event|
+    exceptions = ['controller', 'action', 'format', 'id']
+    {
+      params: event.payload[:params].except(*exceptions),
+      host:   event.payload[:headers].env['REMOTE_ADDR'],
+      time:   event.time,
+      user:   User.current.try(:login)
+    }
+  end
+
   # Do not dump schema after migrations.
   config.active_record.dump_schema_after_migration = false
 


### PR DESCRIPTION
We wan to have in the logs at least:

* Timestamp
* Request: Method + Controller + Action + Path + Params
* Response status
* Duration: Overall / View / DB
* Remote IP
* User login

Using https://github.com/roidrage/lograge and adding some extra configurations like the following we can have a one liner log with all we need:

```ruby
  config.lograge.enabled = true
  config.lograge.custom_options = lambda do |event|
    exceptions = %w(controller action format id)
    {
      params: event.payload[:params].except(*exceptions),
      host: event.payload[:headers].env['REMOTE_ADDR'],
      time: event.time,
      user: User.current.try(:login)
    }
  end
```

Example of output:

```
method=POST path=/comments format=js controller=Webui::CommentsController action=create status=200 duration=1436.57 view=77.25 db=13.92 params={"utf8"=>"✓", "commentable_type"=>"Project", "commentable_id"=>"1", "comment"=>{"body"=>"hola que tal"}, "commit"=>"Add comment"} host=127.0.0.1 time=2018-05-14 15:59:03 +0000 user=Admin
```

instead of something like:

```
Started POST "/" for 127.0.0.1 at 2012-03-10 14:28:14 +0100
Processing by HomeController#index as HTML
  Rendered text template within layouts/application (0.0ms)
  Rendered layouts/_assets.html.erb (2.0ms)
  Rendered layouts/_top.html.erb (2.6ms)
  Rendered layouts/_about.html.erb (0.3ms)
  Rendered layouts/_google_analytics.html.erb (0.4ms)
Completed 200 OK in 79ms (Views: 78.8ms | ActiveRecord: 0.0ms)
```