### PR TITLE
[api][dist] Do not show commit and last_deployment when not present

### DIFF
--- a/dist/obs-server.spec
+++ b/dist/obs-server.spec
@@ -344,7 +344,7 @@ DESTDIR=%{buildroot} make install FILLUPDIR=%{_fillupdir}
 if [ -f %{_sourcedir}/open-build-service.obsinfo ]; then
     sed -n -e 's/commit: \(.\+\)/\1/p' %{_sourcedir}/open-build-service.obsinfo > %{buildroot}/srv/www/obs/api/last_deploy
 else
-    echo "%version" > %{buildroot}/srv/www/obs/api/last_deploy
+    echo "" > %{buildroot}/srv/www/obs/api/last_deploy
 fi
 #
 # turn duplicates into hard links

--- a/src/api/config/initializers/git.rb
+++ b/src/api/config/initializers/git.rb
@@ -3,7 +3,7 @@ module Git
     COMMIT = File.open(File.join(Rails.root, 'last_deploy'), 'r') { |f| GIT_REVISION = f.gets.try(:chomp) }
     LAST_DEPLOYMENT = File.new(File.join(Rails.root, 'last_deploy')).atime
   else
-    COMMIT = %x(SHA1=$(git rev-parse --short HEAD 2> /dev/null); if [ $SHA1 ]; then echo $SHA1; else echo 'unknown'; fi).chomp
-    LAST_DEPLOYMENT = 'unknown'.freeze
+    COMMIT = %x(SHA1=$(git rev-parse --short HEAD 2> /dev/null); if [ $SHA1 ]; then echo $SHA1; else echo ''; fi).chomp
+    LAST_DEPLOYMENT = ''.freeze
   end
 end


### PR DESCRIPTION
* In the spec file we put now an empty string in the last_deploy file in
case we do not have a revision
* In case we do not have the last_deploy file we also use an empty string