### PR TITLE
Fix numbers are no longer quoted

### DIFF
--- a/src/api/script/compare_structure_sql.sh
+++ b/src/api/script/compare_structure_sql.sh
@@ -15,6 +15,10 @@ for file in "$git_file" "$migrate_file"; do
   sed -i -e '/^(.21.),$/,/^(.9.);/d' "${file}.normalized" || exit 1
   # we have a different last migration, therefore ; => ,
   sed -i -e 's/\(^(.20.............)\);$/\1,/' "${file}.normalized" || exit 1
+  # From MariaDB 10.2.2, numbers are no longer quoted in the DEFAULT clause in SHOW CREATE statement.
+  # https://mariadb.com/kb/en/library/show-create-table/
+  # TODO: drop this line when we drop support for Mariadb < 10.2.2 (SLE12 & Leap 42.3)
+  sed -i -r "s/DEFAULT '([[:digit:]]+)'/DEFAULT \1/g" "${file}.normalized" || exit 1
 done
 
 if ! diff "${git_file}.normalized" "${migrate_file}.normalized"; then


### PR DESCRIPTION
in DEFAULT from MariaDB 10.2.2 on.
This is needed to make the migration test pass
for MariaDB > and < 10.2.2.
See https://mariadb.com/kb/en/library/show-create-table/