### PR TITLE
Move calculation of download for binaries to a dedicated action

### DIFF
--- a/src/api/config/routes.rb
+++ b/src/api/config/routes.rb
@@ -103,6 +103,8 @@ OBSApi::Application.routes.draw do
         get 'package/show/:project/:package' => :show, as: 'package_show', constraints: cons
         get 'package/dependency/:project/:package' => :dependency, constraints: cons
         get 'package/binary/:project/:package/:repository/:arch/:filename' => :binary, constraints: cons, as: 'package_binary'
+        get 'package/binary/download/:project/:package/:repository/:arch/:filename' => :binary_download,
+            constraints: cons, as: 'package_binary_download'
         get 'package/binaries/:project/:package/:repository' => :binaries, constraints: cons, as: 'package_binaries'
         get 'package/users/:project/:package' => :users, as: 'package_users', constraints: cons
         get 'package/requests/:project/:package' => :requests, as: 'package_requests', constraints: cons

--- a/src/api/test/functional/webui/spider_test.rb
+++ b/src/api/test/functional/webui/spider_test.rb
@@ -53,6 +53,7 @@ class Webui::SpiderTest < Webui::IntegrationTest
   def raiseit(message, url)
     # known issues
     return if url =~ %r{/package/binary/BinaryprotectedProject/.*}
+    return if url =~ %r{/package/binary/download/*}
     return if url =~ %r{/package/statistics/BinaryprotectedProject/.*}
     return if url =~ %r{/package/statistics/SourceprotectedProject/.*}
     return if url.end_with? '/package/binary/SourceprotectedProject/pack?arch=i586&filename=package-1.0-1.src.rpm&repository=repo'


### PR DESCRIPTION
We show a download link per file in the binaries view, but the
calculation of the url is expensive and can end up in performing up to
2 http request to external servers.

Now we use an internal url and there in that action we calculate the url
to redirect the user to the right place.

That way in the lis of binaries we just show simple links

This closes #4736