### PR TITLE
Normalize default values for text types for MariaDB > 10.2.1 (SLE15)

### DIFF
--- a/src/api/lib/tasks/databases.rake
+++ b/src/api/lib/tasks/databases.rake
@@ -136,7 +136,7 @@ namespace :db do
     # https://mariadb.com/kb/en/library/show-create-table/
     # TODO: drop this line when we drop support for Mariadb < 10.2.2 (SLE12 & Leap 42.3)
     structure = File.read("#{Rails.root}/db/structure.sql")
-    structure.gsub!(/DEFAULT (\d)/, "DEFAULT '\\1'")
+    structure.gsub!(/DEFAULT (\d+)/, "DEFAULT '\\1'")
     # MariaDB 10.2.1 permits TEXT and BLOB data types to be assigned a DEFAULT value.
     # As a result, from MariaDB 10.2.1, SHOW CREATE TABLE will append a DEFAULT NULL
     # to nullable TEXT or BLOB fields if no specific default is provided.

--- a/src/api/lib/tasks/databases.rake
+++ b/src/api/lib/tasks/databases.rake
@@ -137,6 +137,12 @@ namespace :db do
     # TODO: drop this line when we drop support for Mariadb < 10.2.2 (SLE12 & Leap 42.3)
     structure = File.read("#{Rails.root}/db/structure.sql")
     structure.gsub!(/DEFAULT (\d)/, "DEFAULT '\\1'")
+    # MariaDB 10.2.1 permits TEXT and BLOB data types to be assigned a DEFAULT value.
+    # As a result, from MariaDB 10.2.1, SHOW CREATE TABLE will append a DEFAULT NULL
+    # to nullable TEXT or BLOB fields if no specific default is provided.
+    # https://mariadb.com/kb/en/library/show-create-table/
+    # TODO: drop this line when we drop support for Mariadb < 10.2.2 (SLE12 & Leap 42.3)
+    structure.gsub!(/(`\w*` (medium)*text [\w* ]*) DEFAULT NULL,/, '\1,')
     File.open("#{Rails.root}/db/structure.sql", 'w+') { |f| f << structure }
   end
 end

--- a/src/api/script/compare_structure_sql.sh
+++ b/src/api/script/compare_structure_sql.sh
@@ -19,6 +19,12 @@ for file in "$git_file" "$migrate_file"; do
   # https://mariadb.com/kb/en/library/show-create-table/
   # TODO: drop this line when we drop support for Mariadb < 10.2.2 (SLE12 & Leap 42.3)
   sed -i -r "s/DEFAULT '([[:digit:]]+)'/DEFAULT \1/g" "${file}.normalized" || exit 1
+  # MariaDB 10.2.1 permits TEXT and BLOB data types to be assigned a DEFAULT value.
+  # As a result, from MariaDB 10.2.1, SHOW CREATE TABLE will append a DEFAULT NULL
+  # to nullable TEXT or BLOB fields if no specific default is provided.
+  # https://mariadb.com/kb/en/library/show-create-table/
+  # TODO: drop this line when we drop support for Mariadb < 10.2.2 (SLE12 & Leap 42.3)
+  sed -r "s/(\`[a-zA-Z0-9]*\` (medium)*text [a-zA-Z0-9 ]*) DEFAULT NULL,/\1,/g"
 done
 
 if ! diff "${git_file}.normalized" "${migrate_file}.normalized"; then


### PR DESCRIPTION
This PR will normalize the structure.sql for MariaDB > 10.2.1 (SLE15).

From MariaDB 10.2.1 on TEXT and BLOB data types can have a DEFAULT value.
As a result, from MariaDB 10.2.1, SHOW CREATE TABLE will append a DEFAULT NULL to nullable TEXT or BLOB
fields if no specific default is provided.
Therefore We normalize the structure.sql dump for the structure verify test as
long as we support SLE12/Leap 42.3 and SLE15.

https://mariadb.com/kb/en/library/show-create-table/