### PR TITLE
[frontend] Adopt migration after renaming class

### DIFF
--- a/src/api/db/migrate/20151030130011_mark_events.rb
+++ b/src/api/db/migrate/20151030130011_mark_events.rb
@@ -1,4 +1,6 @@
 class MarkEvents < ActiveRecord::Migration[4.2]
+  class SendEventEmails < SendEventEmailsJob; end
+
   def up
     add_column :events, :mails_sent, :boolean, default: false
     # all events in existance should have the mail sent out


### PR DESCRIPTION
With f558fb2974dab157eada5acb291918a224668ed0 the SendEventEmails class
got renamed.
This happened in quite some time ago (August 2017). Since we don't
backport migrations to our stable release this now caused issues for
users that updated their OBS stable release, eg. 2.8 -> 2.9.

Kudos to @DStape debugging this and pointing us to the root cause.

Fixes #4969