### PR TITLE
Add missing message field to patchinfo

### DIFF
--- a/src/api/app/controllers/webui/patchinfo_controller.rb
+++ b/src/api/app/controllers/webui/patchinfo_controller.rb
@@ -90,6 +90,7 @@ class Webui::PatchinfoController < Webui::WebuiController
     @name = @file.value(:name)
 
     @description = @file.value(:description)
+    @message = @file.value(:message)
     @relogin = @file.has_element?('relogin_needed')
     @reboot = @file.has_element?('reboot_needed')
     @zypp_restart_needed = @file.has_element?('zypp_restart_needed')
@@ -142,6 +143,7 @@ class Webui::PatchinfoController < Webui::WebuiController
         node.rating params[:rating].try(:strip)
         node.summary params[:summary].try(:strip)
         node.description params[:description].gsub("\r\n", "\n")
+        node.message params[:message].gsub("\r\n", "\n") if params[:message].present?
         node.reboot_needed if params[:reboot]
         node.relogin_needed if params[:relogin]
         node.zypp_restart_needed if params[:zypp_restart_needed]
@@ -187,6 +189,7 @@ class Webui::PatchinfoController < Webui::WebuiController
       @rating = params[:rating]
       @summary = params[:summary]
       @description = params[:description]
+      @message = params[:message]
       @relogin = params[:relogin]
       @reboot = params[:reboot]
       @zypp_restart_needed = params[:zypp_restart_needed]

--- a/src/api/app/views/webui/patchinfo/_form.html.haml
+++ b/src/api/app/views/webui/patchinfo/_form.html.haml
@@ -31,6 +31,11 @@
             = text_area_tag 'description', @description, size: '65x9', required: true, min: 10
           %p
             %strong
+              = image_tag('info.png', title: 'Enter a message', alt: 'Messageinfo')
+              %label{for: "message"} Message:
+            = text_area_tag 'message', @message, size: '65x5'
+          %p
+            %strong
               = image_tag('info.png', title: 'Choose the category of your update', alt: 'Categoryinfo')
               %label{for: "category"} Category:
             = select_tag 'category', options_for_select(Patchinfo::CATEGORIES, @category)

--- a/src/api/app/views/webui/patchinfo/show.html.haml
+++ b/src/api/app/views/webui/patchinfo/show.html.haml
@@ -36,6 +36,10 @@
       %b Description:
       %br/
       = description_wrapper(@description)
+    - if @message.present?
+      .box.show_left.show_right
+        %strong Message:
+        %pre.plain= @message
     .box.show_left.show_right
       %b Fixed bugs:
       - if @issues.present?


### PR DESCRIPTION
Add missing **message** optional field to show and edit views in patchinfo.

Fixes #4895.

Co-authored-by: David Kang <dkang@suse.com>

The show patchinfo screen looks like this:

![patchinfo_show](https://user-images.githubusercontent.com/24919/40368228-95b726aa-5ddb-11e8-99bb-ba5550f3a094.png)

The edit patchinfo screen looks like this:

![patchinfo_edit](https://user-images.githubusercontent.com/24919/40368244-9dfb50c0-5ddb-11e8-808f-37a11eaa23ac.png)
