### PR TITLE
Add missing optional version field

### DIFF
--- a/src/api/app/controllers/webui/patchinfo_controller.rb
+++ b/src/api/app/controllers/webui/patchinfo_controller.rb
@@ -57,6 +57,7 @@ class Webui::PatchinfoController < Webui::WebuiController
     end
     @binary = []
     @packager = @file.value(:packager)
+    @version = @file.value(:version)
 
     if params[:issueid]
       @issues = params[:issue].to_a << params[:issueid]
@@ -123,6 +124,7 @@ class Webui::PatchinfoController < Webui::WebuiController
       attrs = {
         incident: @package.project.name.gsub(/.*:/, '')
       }
+      attrs[:version] = params[:version] if params[:version].present?
       xml = node.patchinfo(attrs) do
         params[:selected_binaries].to_a.each do |binary|
           node.binary(binary) if binary.present?
@@ -173,6 +175,7 @@ class Webui::PatchinfoController < Webui::WebuiController
                   project: @project.name, package: @package
     else
       @tracker = params[:tracker]
+      @version = params[:version]
       @packager = params[:packager]
       @binaries = params[:selected_binaries]
       @binarylist = params[:available_binaries]

--- a/src/api/app/views/webui/patchinfo/_form.html.haml
+++ b/src/api/app/views/webui/patchinfo/_form.html.haml
@@ -31,6 +31,12 @@
             = text_area_tag 'description', @description, size: '65x9', required: true, min: 10
           %p
             %strong
+              = image_tag('info.png', title: 'Enter a version of this update', alt: 'Versioninfo')
+              %label{for: "version"} Version:
+            %br/
+            = text_field_tag 'version', @version
+          %p
+            %strong
               = image_tag('info.png', title: 'Enter a message', alt: 'Messageinfo')
               %label{for: "message"} Message:
             = text_area_tag 'message', @message, size: '65x5'

--- a/src/api/app/views/webui/patchinfo/show.html.haml
+++ b/src/api/app/views/webui/patchinfo/show.html.haml
@@ -40,6 +40,10 @@
       .box.show_left.show_right
         %strong Message:
         %pre.plain= @message
+    - if @version
+      .box.show_left.show_right
+        %b Version:
+        %span= @version
     .box.show_left.show_right
       %b Fixed bugs:
       - if @issues.present?


### PR DESCRIPTION
Add missing **version** optional field to show and edit views in patchinfo.

The show patchinfo screen looks like this, with the version field added:

![patchinfo_version_show](https://user-images.githubusercontent.com/24919/40419996-383d4ce6-5e87-11e8-998c-e8529d44bfa6.png)

The edit patchinfo screen looks like this:

![patchinfo_version_edit](https://user-images.githubusercontent.com/24919/40420020-456c57c2-5e87-11e8-83d5-c15363caf3b3.png)
