### PR TITLE
Escape chars from url's path for the backend

### DIFF
--- a/src/api/lib/backend/connection_helper.rb
+++ b/src/api/lib/backend/connection_helper.rb
@@ -112,6 +112,7 @@ module Backend
         url_base = endpoint
       else
         template = endpoint.shift
+        endpoint.map! { |x| URI.encode_www_form_component(x) }
         url_base = template.gsub(/(:\w+)/, '%s') % endpoint
       end
       Addressable::URI.parse(url_base).normalize.to_s

--- a/src/api/spec/lib/backend/connection_helper_spec.rb
+++ b/src/api/spec/lib/backend/connection_helper_spec.rb
@@ -17,12 +17,12 @@ RSpec.describe Backend::ConnectionHelper do
     context 'with a template' do
       it { expect(subject.send(:calculate_endpoint, ['string_in_array'])).to eq('string_in_array') }
       it { expect(subject.send(:calculate_endpoint, ['/build/:param', 'my_param'])).to eq('/build/my_param') }
-      it { expect(subject.send(:calculate_endpoint, ['/build/:param', 'my param'])).to eq('/build/my%20param') }
-      it { expect(subject.send(:calculate_endpoint, ['/build/:param', 'my/param'])).to eq('/build/my/param') }
+      it { expect(subject.send(:calculate_endpoint, ['/build/:param', 'my param'])).to eq('/build/my+param') }
+      it { expect(subject.send(:calculate_endpoint, ['/build/:param', 'my/param'])).to eq('/build/my%2Fparam') }
       it { expect(subject.send(:calculate_endpoint, ['/build/:param', 'my&param'])).to eq('/build/my&param') }
-      it { expect(subject.send(:calculate_endpoint, ['/build/:param', 'my?param'])).to eq('/build/my?param') }
+      it { expect(subject.send(:calculate_endpoint, ['/build/:param', 'my?param'])).to eq('/build/my%3Fparam') }
       it { expect(subject.send(:calculate_endpoint, ['/build/:param', 'my:param'])).to eq('/build/my:param') }
-      it { expect(subject.send(:calculate_endpoint, ['/build/:param', 'my#param'])).to eq('/build/my#param') }
+      it { expect(subject.send(:calculate_endpoint, ['/build/:param', 'my#param'])).to eq('/build/my%23param') }
       it { expect(subject.send(:calculate_endpoint, ['/build/:param1/:param2', 'my_param', 'my_2nd_param'])).to eq('/build/my_param/my_2nd_param') }
       it { expect(subject.send(:calculate_endpoint, ['/build/:param1/:param2', 'my_param', 'my_2nd_param'])).to eq('/build/my_param/my_2nd_param') }
       it { expect(subject.send(:calculate_endpoint, ['/build/:param1/:param2', 'home:param2', 'blah'])).to eq('/build/home:param2/blah') }


### PR DESCRIPTION
Before we just replaced the provided strings into the template of the
endpoint. We now escape special url chars to not break the endpoint if there is any
in the variables passed to the placeholders.