### PR TITLE
Prevent not selecting binaries

### DIFF
--- a/src/api/app/views/webui/patchinfo/_form.html.haml
+++ b/src/api/app/views/webui/patchinfo/_form.html.haml
@@ -104,7 +104,7 @@
             %strong
               = image_tag('info.png', title: 'Move specific binaries to the right select box by using the arrows', alt: 'Binaryinfo')
               Binaries:
-          - if !@binarylist.blank?
+          - if @binarylist.present? || @binaries.present?
             - available_bin = Array.new
             - @binarylist.each { |d| available_bin << "#{d.to_s}" }
             - selected_bin = Array.new


### PR DESCRIPTION
Prevent not being capable of selecting binaries in a patchinfo edit form when all the binaries are selected.

Having a set of binaries to select from like this one:

![patchinfo_binaries_having](https://user-images.githubusercontent.com/24919/40432174-58ff223e-5ea9-11e8-824b-1a4c8c231e1f.png)

After selecting all of them:

![patchinfo_binaries_right](https://user-images.githubusercontent.com/24919/40432201-6a802350-5ea9-11e8-8b23-a22a86538c10.png)

... and saving, it was not possible to edit them any more. This was the next edit screen:

![patchinfo_binaries_no_binaries_available](https://user-images.githubusercontent.com/24919/40432235-81fe5b96-5ea9-11e8-93a2-969d55d0101a.png)
