### PR TITLE
[frontend] Add data schema file

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -14,6 +14,7 @@ AllCops:
     - 'src/api/test/fixtures/backend/**/*'
     - 'src/api/files/*'
     - 'src/backend/**/*'
+    - 'src/api/db/data_schema.rb'
     # These files are RPM spec files
     - 'dist/obs-api-deps.spec'
     - 'dist/obs-server.spec'

--- a/dist/obs-server.spec
+++ b/dist/obs-server.spec
@@ -664,6 +664,7 @@ usermod -a -G docker obsservicerun
 /usr/sbin/rcobsapidelayed
 /srv/www/obs/api/app
 %attr(-,%{apache_user},%{apache_group})  /srv/www/obs/api/db/structure.sql
+%attr(-,%{apache_user},%{apache_group})  /srv/www/obs/api/db/data_schema.rb
 /srv/www/obs/api/db/attribute_descriptions.rb
 /srv/www/obs/api/db/data
 /srv/www/obs/api/db/migrate

--- a/src/api/db/data_schema.rb
+++ b/src/api/db/data_schema.rb
@@ -1,0 +1,2 @@
+# encoding: UTF-8
+DataMigrate::Data.define(version: 20180214132015)


### PR DESCRIPTION
With the recent data-migrate gem update (300232b08f61112535f7001ef384d3b211ee8b2f)
data-migrate is also dumping a schema when Rails is configured that way.
This commit will adapt the OBS code to pass our test suite and rpm
package builds.