### PR TITLE
[dist] Recommend cron in spec file

### DIFF
--- a/dist/obs-server.spec
+++ b/dist/obs-server.spec
@@ -103,6 +103,7 @@ Requires:       %(/bin/bash -c 'rpm -q --qf "%%{name} = %%{version}-%%{release}"
 %else
 Requires:       /usr/bin/createrepo
 %endif
+Recommends:     cron
 
 BuildRequires:  xz
 


### PR DESCRIPTION
The obs-server package includes a cron script, but does not require
the cron package.
Rpmlint recommends to either require or recommend the cron package
in such a case. Since the cron script is optional we just recommend to
install cron.