### PR TITLE
[frontend] Add rpmlintrc

### DIFF
--- a/dist/obs-rpmlintrc
+++ b/dist/obs-rpmlintrc
@@ -1,0 +1,2 @@
+addFilter("description-shorter-than-summary")
+


### PR DESCRIPTION
Disable warnings for rpm package descriptions being shorter than the
summary.
This is only the case for the obs-devel package and not an issue to
worry about.