### PR TITLE
[dist] Recommend logrotate during package installation

### DIFF
--- a/dist/obs-server.spec
+++ b/dist/obs-server.spec
@@ -103,7 +103,7 @@ Requires:       %(/bin/bash -c 'rpm -q --qf "%%{name} = %%{version}-%%{release}"
 %else
 Requires:       /usr/bin/createrepo
 %endif
-Recommends:     cron
+Recommends:     cron logrotate
 
 BuildRequires:  xz
 


### PR DESCRIPTION
The obs-server package installs files to /etc/logrotate.d/.
Rpmlint recommends to either require or recommend the logrotate package
in such a case. Since logrotate is optional we just recommend to
install the package.