### PR TITLE
[ci] Start test backend in docker-compose file

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,6 +15,7 @@ services:
       - ./dist/aws_credentials:/etc/obs/cloudupload/.aws/config
       - ./dist/ec2utils.conf:/etc/obs/cloudupload/.ec2utils.conf
       - ./dist/clouduploader.rb:/usr/bin/clouduploader
+    command: /obs/contrib/start_development_backend -d /obs
   worker:
     image: registry.opensuse.org/obs/server/unstable/container/leap/42.3/images/openbuildservice/backend:latest
     volumes:


### PR DESCRIPTION
as we switched to OBS built docker images in #5041 we need now to specify the
command in the docker-compose file.
The reason is that we do not specify a CMD in the image built in OBS anymore
because this image is used for CI, worker and backend and every use case has a different
CMD.