### PR TITLE
[ci] Fix travis failure script

### DIFF
--- a/dist/ci/travis_after_failure.sh
+++ b/dist/ci/travis_after_failure.sh
@@ -8,5 +8,5 @@ function upload_files {
   done
 }
 
-pushd src/api/log
+pushd api/log || exit 1
 upload_files


### PR DESCRIPTION
In case of test failures our travis failure script switches to the
log directory and uploads all files it finds there.
With the switch to docker the start directory travis is running from
changed and changing to the log dir failed silently.

Because of that we uploaded all files within our git repo and not only
our frontend log files.

This commit updates the cd command and causes the script to fail if the
log directory can not be found.