### PR TITLE
[dist] Use multiple arguments in our Rakefile

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -25,7 +25,7 @@ namespace :docker do
     desc 'Run our frontend tests in the docker container'
     task :rspec do
       begin
-        sh "docker-compose -f docker-compose.ci.yml -p rspec run #{environment_vars} --rm rspec"
+        sh 'docker-compose', '-f', 'docker-compose.ci.yml', '-p', 'rspec', 'run', *environment_vars, '--rm', 'rspec'
       ensure
         sh 'docker-compose -f docker-compose.ci.yml -p rspec stop'
       end
@@ -43,7 +43,8 @@ namespace :docker do
     desc 'Scan the code base for syntax/code problems'
     task :lint do
       begin
-        sh "docker-compose -f docker-compose.ci.yml -p lint run #{environment_vars(false)} --rm rspec ../../contrib/start_lint"
+        sh 'docker-compose', '-f', 'docker-compose.ci.yml', '-p', 'lint', 'run', *environment_vars(false),
+           '--rm', 'rspec', '../../contrib/start_lint'
       ensure
         sh 'docker-compose -f docker-compose.ci.yml -p lint stop'
       end
@@ -52,7 +53,7 @@ namespace :docker do
     desc 'Run our old api minitest test suite in the docker container'
     task :minitest do
       begin
-        sh "docker-compose -f docker-compose.ci.yml -p minitest run #{environment_vars} --rm minitest"
+        sh 'docker-compose', '-f', 'docker-compose.ci.yml', '-p', 'minitest', 'run', *environment_vars, '--rm', 'minitest'
       ensure
         sh 'docker-compose -f docker-compose.ci.yml -p minitest stop'
       end
@@ -61,7 +62,8 @@ namespace :docker do
     desc 'Run the spider test to crawl all pages and fail for exceptions'
     task :spider do
       begin
-        sh "docker-compose -f docker-compose.ci.yml -p spider run #{environment_vars(false)} --rm minitest /bin/bash -c ../../contrib/start_spider"
+        sh 'docker-compose', '-f', 'docker-compose.ci.yml', '-p', 'spider', 'run', *environment_vars(false), '--rm',
+           'minitest', '/bin/bash', '-c', '../../contrib/start_spider'
       ensure
         sh 'docker-compose -f docker-compose.ci.yml -p spider stop'
       end
@@ -144,14 +146,15 @@ end
 
 def environment_vars(with_coverage = true)
   environment = travis_environment_variables
-  environment << '-e DO_COVERAGE=1 ' if with_coverage && ENV['TRAVIS']
-  environment << '-e EAGER_LOAD=1 '
-  environment << "-e TEST_SUITE='#{ENV['TEST_SUITE']}'"
+  environment.concat(['-e', 'DO_COVERAGE=1']) if with_coverage && ENV['TRAVIS']
+  environment.concat(['-e', 'EAGER_LOAD=1'])
+  environment.concat(['-e', "TEST_SUITE='#{ENV['TEST_SUITE']}'"])
   environment
 end
 
 def travis_environment_variables
-  return '' unless ENV['TRAVIS']
-  result = ENV.to_h.keep_if { |key, _value| key.start_with?('TRAVIS') }.map { |key, value| "-e #{key}='#{value}'" }.join(' ')
-  "#{result} -e CI='#{ENV['CI']}' "
+  return [] unless ENV['TRAVIS']
+  result = ENV.to_h.keep_if { |key, _| key.start_with?('TRAVIS') }.map { |key, value| ['-e', "#{key}='#{value}'"] }.flatten
+
+  result.concat(['-e', "CI='#{ENV['CI']}'"])
 end


### PR DESCRIPTION
This prevents us from interpolating user input.

Our rakefile is passing certain environment variables to the
docker-compose command. Since we were not escaping these parameters
it was possible to manipulate or break the command, eg. by having
a ' character in a commit message.

Found due to a failure in travis:
  rake docker:test:lint
  ...
  sh: 7: Syntax error: Unterminated quoted string