### PR TITLE
[frontend] Fix policy check in token controller

### DIFF
--- a/src/api/app/controllers/person/token_controller.rb
+++ b/src/api/app/controllers/person/token_controller.rb
@@ -36,7 +36,7 @@ module Person
     private
 
     def set_user
-      @user = User.find_by(login: params[:login])
+      @user = User.find_by(login: params[:login]) || User.find_nobody!
     end
   end
 end

--- a/src/api/spec/controllers/person/token_controller_spec.rb
+++ b/src/api/spec/controllers/person/token_controller_spec.rb
@@ -27,6 +27,17 @@ RSpec.describe Person::TokenController, vcr: false do
       it { expect(response).to have_http_status(:forbidden) }
       it { expect(assigns(:list)).to be nil }
     end
+
+    context 'called for a user that does not exist' do
+      before do
+        login user
+        get :index, params: { login: 'non-existant-user' }, format: :xml
+      end
+
+      it { expect(response).not_to render_template(:index) }
+      it { expect(response).to have_http_status(:forbidden) }
+      it { expect(assigns(:list)).to be nil }
+    end
   end
 
   describe '#create' do


### PR DESCRIPTION
Users (eg. admins and in case of bot accounts) can request tokens
of other users. Though if the requested user does not exist we
would check the policy of nil and cause a failure.

Instead we are now setting the nobody user when no valid user
could be found.