### PR TITLE
Patchinfo fixes and refactoring

### DIFF
--- a/src/api/app/controllers/webui/patchinfo_controller.rb
+++ b/src/api/app/controllers/webui/patchinfo_controller.rb
@@ -98,6 +98,11 @@ class Webui::PatchinfoController < Webui::WebuiController
         @file.each(:package) do |pkg|
           node.package pkg.text
         end
+        @file.each(:releasetarget) do |release_target|
+          attributes = { project: release_target.value(:project) }
+          attributes[:repository] = release_target.value(:repository) if release_target.value(:repository)
+          node.releasetarget(attributes)
+        end
         node.message params[:message].gsub("\r\n", "\n") if params[:message].present?
         node.reboot_needed if params[:reboot]
         node.relogin_needed if params[:relogin]

--- a/src/api/app/controllers/webui/patchinfo_controller.rb
+++ b/src/api/app/controllers/webui/patchinfo_controller.rb
@@ -230,7 +230,6 @@ class Webui::PatchinfoController < Webui::WebuiController
     @file.each(:binary) do |binaries|
       @binaries << binaries.text
     end
-    @binary = []
     @packager = @file.value(:packager)
     @version = @file.value(:version)
 

--- a/src/api/app/controllers/webui/patchinfo_controller.rb
+++ b/src/api/app/controllers/webui/patchinfo_controller.rb
@@ -220,15 +220,6 @@ class Webui::PatchinfoController < Webui::WebuiController
     render_dialog
   end
 
-  def valid_summary?(name)
-    name && name.length > 10
-  end
-
-  def valid_description?(name)
-    name &&
-      name.length > [params[:summary].length, 50].max
-  end
-
   def new_tracker
     # collection with all informations of the new issues
     issue_collection = []
@@ -274,6 +265,17 @@ class Webui::PatchinfoController < Webui::WebuiController
     render json: { error: error, issues: issue_collection }
   end
 
+  private
+
+  def valid_summary?(name)
+    name && name.length > 10
+  end
+
+  def valid_description?(name)
+    name &&
+      name.length > [params[:summary].length, 50].max
+  end
+
   # returns issue summary of an issue
   # returns empty string in case of ActiveXML::Transport::Error exception
   # returns nil in case of error (bug mismatches tracker result regex)
@@ -293,8 +295,6 @@ class Webui::PatchinfoController < Webui::WebuiController
     return issue.summary.gsub(/\\|'/) { '' } if issue.summary
     return ''
   end
-
-  private
 
   def get_binaries
     @binarylist = []

--- a/src/api/app/controllers/webui/patchinfo_controller.rb
+++ b/src/api/app/controllers/webui/patchinfo_controller.rb
@@ -95,6 +95,9 @@ class Webui::PatchinfoController < Webui::WebuiController
         node.rating params[:rating].try(:strip)
         node.summary params[:summary].try(:strip)
         node.description params[:description].gsub("\r\n", "\n")
+        @file.each(:package) do |pkg|
+          node.package pkg.text
+        end
         node.message params[:message].gsub("\r\n", "\n") if params[:message].present?
         node.reboot_needed if params[:reboot]
         node.relogin_needed if params[:relogin]

--- a/src/api/config/routes.rb
+++ b/src/api/config/routes.rb
@@ -168,7 +168,6 @@ OBSApi::Application.routes.draw do
       post 'patchinfo/updatepatchinfo' => :updatepatchinfo
       get 'patchinfo/edit_patchinfo' => :edit_patchinfo
       get 'patchinfo/show/:project/:package' => :show, as: 'patchinfo_show', constraints: cons, defaults: { format: 'html' }
-      get 'patchinfo/read_patchinfo' => :read_patchinfo
       post 'patchinfo/save/:project/:package' => :save, constraints: cons, as: :patchinfo_save
       post 'patchinfo/remove' => :remove
       get 'patchinfo/new_tracker' => :new_tracker


### PR DESCRIPTION
- Fix preserving `package` and `releasetarget` elements after editing a patchinfo.
- Remove `get patchinfo/read_patchinfo` route as it is not used in any place.

This is another approach to a work started in #5019.