### PR TITLE
Refactor source controller (second interaction) 

### DIFF
--- a/src/api/app/controllers/source_controller.rb
+++ b/src/api/app/controllers/source_controller.rb
@@ -12,10 +12,7 @@ class SourceController < ApplicationController
   validate_action projectlist: { method: :get, response: :directory }
   validate_action packagelist: { method: :get, response: :directory }
   validate_action filelist: { method: :get, response: :directory }
-  validate_action show_project_meta: { response: :project }
   validate_action package_meta: { method: :get, response: :package }
-
-  validate_action update_project_meta: { request: :project, response: :status }
   validate_action update_package_meta: { request: :package, response: :status }
 
   skip_before_action :extract_user, only: [:lastevents_public, :global_command_orderkiwirepos]
@@ -59,122 +56,8 @@ class SourceController < ApplicationController
     @login = params[:login]
   end
 
-  def render_project_issues
-    set_issues_default
-    render partial: 'project_issues'
-  end
-
-  # GET /source/:project
-  def show_project
-    project_name = params[:project]
-    if params.key? :deleted
-      unless Project.find_by_name project_name
-        # project is deleted or not accessable
-        validate_visibility_of_deleted_project(project_name)
-      end
-      pass_to_backend
-      return
-    end
-
-    if Project.is_remote_project?(project_name)
-      # not a local project, hand over to backend
-      pass_to_backend
-      return
-    end
-
-    @project = Project.find_by_name(project_name)
-    raise Project::UnknownObjectError, project_name unless @project
-    # we let the backend list the packages after we verified the project is visible
-    if params.key? :view
-      if params[:view] == 'verboseproductlist'
-        @products = Product.all_products(@project, params[:expand])
-        render 'source/verboseproductlist'
-        return
-      elsif params[:view] == 'productlist'
-        @products = Product.all_products(@project, params[:expand])
-        render 'source/productlist'
-        return
-      elsif params[:view] == 'issues'
-        render_project_issues
-      else
-        pass_to_backend
-      end
-      return
-    end
-
-    render_project_packages
-  end
-
-  def render_project_packages
-    @packages = params.key?(:expand) ? @project.expand_all_packages : @project.packages.pluck(:name)
-    render locals: { expand: params.key?(:expand) }, formats: [:xml]
-  end
-
-  # DELETE /source/:project
-  def delete_project
-    project = Project.get_by_name(params[:project])
-
-    # checks
-    unless project.is_a?(Project) && User.current.can_modify_project?(project)
-      logger.debug "No permission to delete project #{project}"
-      render_error status: 403, errorcode: 'delete_project_no_permission',
-                   message: "Permission denied (delete project #{project})"
-      return
-    end
-    project.check_weak_dependencies!
-    opts = { no_write_to_backend: true,
-             force:               params[:force].present?,
-             recursive_remove:    params[:remove_linking_repositories].present? }
-    check_and_remove_repositories!(project.repositories, opts)
-
-    logger.info "destroying project object #{project.name}"
-    project.commit_opts = { comment: params[:comment] }
-    begin
-      project.destroy
-    rescue ActiveRecord::RecordNotDestroyed => invalid
-      exception_message = "Destroying Project #{project.name} failed: #{invalid.record.errors.full_messages.to_sentence}"
-      logger.debug exception_message
-      raise ActiveRecord::RecordNotDestroyed, exception_message
-    end
-
-    render_ok
-  end
-
-  # POST /source/:project?cmd
-  #-----------------
-  def project_command
-    # init and validation
-    #--------------------
-    valid_commands = ['undelete', 'showlinked', 'remove_flag', 'set_flag', 'createpatchinfo',
-                      'createkey', 'extendkey', 'copy', 'createmaintenanceincident', 'lock',
-                      'unlock', 'release', 'addchannels', 'modifychannels', 'move', 'freezelink']
-
-    if params[:cmd] && !params[:cmd].in?(valid_commands)
-      raise IllegalRequest, 'invalid_command'
-    end
-
-    command = params[:cmd]
-    project_name = params[:project]
-    params[:user] = User.current.login
-
-    if command.in?(['undelete', 'release', 'copy', 'move'])
-      return dispatch_command(:project_command, command)
-    end
-
-    @project = Project.get_by_name(project_name)
-
-    # unlock
-    if command == 'unlock' && User.current.can_modify_project?(@project, true)
-      dispatch_command(:project_command, command)
-    elsif command == 'showlinked' || User.current.can_modify_project?(@project)
-      # command: showlinked, set_flag, remove_flag, ...?
-      dispatch_command(:project_command, command)
-    else
-      raise CmdExecutionNoPermission, "no permission to execute command '#{command}'"
-    end
-  end
-
   class NoLocalPackage < APIException; end
+
   class CmdExecutionNoPermission < APIException
     setup 403
   end
@@ -387,20 +270,6 @@ class SourceController < ApplicationController
     setup 404
   end
 
-  # GET /source/:project/_meta
-  #---------------------------
-  def show_project_meta
-    if Project.find_remote_project params[:project]
-      # project from remote buildservice, get metadata from backend
-      raise InvalidProjectParameters if params[:view]
-      pass_to_backend
-    else
-      # access check
-      prj = Project.get_by_name params[:project]
-      render xml: prj.to_axml
-    end
-  end
-
   class ProjectNameMismatch < APIException
   end
 
@@ -410,82 +279,6 @@ class SourceController < ApplicationController
 
   class ProjectReadAccessFailure < APIException
     setup 404
-  end
-
-  # PUT /source/:project/_meta
-  def update_project_meta
-    project_name = params[:project]
-    params[:user] = User.current.login
-
-    request_data = Xmlhash.parse(request.raw_post)
-
-    # permission check
-    if request_data['name'] != project_name
-      raise ProjectNameMismatch, "project name in xml data ('#{request_data['name']}) does not match resource path component ('#{project_name}')"
-    end
-
-    begin
-      project = Project.get_by_name(request_data['name'])
-    rescue Project::UnknownObjectError
-      project = nil
-    end
-
-    # Need permission
-    logger.debug 'Checking permission for the put'
-    if project
-      # project exists, change it
-      unless User.current.can_modify_project?(project)
-        if project.is_locked?
-          logger.debug "no permission to modify LOCKED project #{project.name}"
-          raise ChangeProjectNoPermission, "The project #{project.name} is locked"
-        end
-        logger.debug "user #{user.login} has no permission to modify project #{project.name}"
-        raise ChangeProjectNoPermission, 'no permission to change project'
-      end
-    else
-      # project is new
-      unless User.current.can_create_project?(project_name)
-        logger.debug 'Not allowed to create new project'
-        raise CreateProjectNoPermission, "no permission to create project #{project_name}"
-      end
-    end
-
-    # projects using remote resources must be edited by the admin
-    result = Project.validate_remote_permissions(request_data)
-    if result[:error]
-      raise ChangeProjectNoPermission, 'admin rights are required to change projects using remote resources'
-    end
-
-    result = Project.validate_link_xml_attribute(request_data, project_name)
-    raise ProjectReadAccessFailure, result[:error] if result[:error]
-
-    result = Project.validate_maintenance_xml_attribute(request_data)
-    raise ModifyProjectNoPermission, result[:error] if result[:error]
-
-    result = Project.validate_repository_xml_attribute(request_data, project_name)
-    raise RepositoryAccessFailure, result[:error] if result[:error]
-
-    if project
-      remove_repositories = project.get_removed_repositories(request_data)
-      opts = { no_write_to_backend: true,
-               force:               params[:force].present?,
-               recursive_remove:    params[:remove_linking_repositories].present? }
-      check_and_remove_repositories!(remove_repositories, opts)
-    end
-
-    Project.transaction do
-      # exec
-      if project
-        project.update_from_xml!(request_data)
-      else
-        project = Project.new(name: project_name)
-        project.update_from_xml!(request_data)
-        # FIXME3.0: don't modify send data
-        project.relationships.build(user: User.current, role: Role.find_by_title!('maintainer'))
-      end
-      project.store(comment: params[:comment])
-    end
-    render_ok
   end
 
   def check_and_remove_repositories!(repositories, opts)

--- a/src/api/app/controllers/source_project_controller.rb
+++ b/src/api/app/controllers/source_project_controller.rb
@@ -1,0 +1,209 @@
+class SourceProjectController < SourceController
+  validate_action update_project_meta: { request: :project, response: :status }
+  validate_action show_project_meta: { response: :project }
+
+  # GET /source/:project
+  def show
+    project_name = params[:project]
+    if params.key? :deleted
+      unless Project.find_by_name project_name
+        # project is deleted or not accessable
+        validate_visibility_of_deleted_project(project_name)
+      end
+      pass_to_backend
+      return
+    end
+
+    if Project.is_remote_project?(project_name)
+      # not a local project, hand over to backend
+      pass_to_backend
+      return
+    end
+
+    @project = Project.find_by_name(project_name)
+    raise Project::UnknownObjectError, project_name unless @project
+    # we let the backend list the packages after we verified the project is visible
+    if params.key? :view
+      if params[:view] == 'verboseproductlist'
+        @products = Product.all_products(@project, params[:expand])
+        render 'source/verboseproductlist'
+        return
+      elsif params[:view] == 'productlist'
+        @products = Product.all_products(@project, params[:expand])
+        render 'source/productlist'
+        return
+      elsif params[:view] == 'issues'
+        render_project_issues
+      else
+        pass_to_backend
+      end
+      return
+    end
+
+    render_project_packages
+  end
+
+  def render_project_issues
+    set_issues_default
+    render partial: 'source/project_issues'
+  end
+
+  def render_project_packages
+    @packages = params.key?(:expand) ? @project.expand_all_packages : @project.packages.pluck(:name)
+    render locals: { expand: params.key?(:expand) }, formats: [:xml]
+  end
+
+  # DELETE /source/:project
+  def delete
+    project = Project.get_by_name(params[:project])
+
+    # checks
+    unless project.is_a?(Project) && User.current.can_modify_project?(project)
+      logger.debug "No permission to delete project #{project}"
+      render_error status: 403, errorcode: 'delete_project_no_permission',
+                   message: "Permission denied (delete project #{project})"
+      return
+    end
+    project.check_weak_dependencies!
+    opts = { no_write_to_backend: true,
+             force:               params[:force].present?,
+             recursive_remove:    params[:remove_linking_repositories].present? }
+    check_and_remove_repositories!(project.repositories, opts)
+
+    logger.info "destroying project object #{project.name}"
+    project.commit_opts = { comment: params[:comment] }
+    begin
+      project.destroy
+    rescue ActiveRecord::RecordNotDestroyed => invalid
+      exception_message = "Destroying Project #{project.name} failed: #{invalid.record.errors.full_messages.to_sentence}"
+      logger.debug exception_message
+      raise ActiveRecord::RecordNotDestroyed, exception_message
+    end
+
+    render_ok
+  end
+
+  # POST /source/:project?cmd
+  #-----------------
+  def project_command
+    # init and validation
+    #--------------------
+    valid_commands = ['undelete', 'showlinked', 'remove_flag', 'set_flag', 'createpatchinfo',
+                      'createkey', 'extendkey', 'copy', 'createmaintenanceincident', 'lock',
+                      'unlock', 'release', 'addchannels', 'modifychannels', 'move', 'freezelink']
+
+    if params[:cmd] && !params[:cmd].in?(valid_commands)
+      raise IllegalRequest, 'invalid_command'
+    end
+
+    command = params[:cmd]
+    project_name = params[:project]
+    params[:user] = User.current.login
+
+    if command.in?(['undelete', 'release', 'copy', 'move'])
+      return dispatch_command(:project_command, command)
+    end
+
+    @project = Project.get_by_name(project_name)
+
+    # unlock
+    if command == 'unlock' && User.current.can_modify_project?(@project, true)
+      dispatch_command(:project_command, command)
+    elsif command == 'showlinked' || User.current.can_modify_project?(@project)
+      # command: showlinked, set_flag, remove_flag, ...?
+      dispatch_command(:project_command, command)
+    else
+      raise CmdExecutionNoPermission, "no permission to execute command '#{command}'"
+    end
+  end
+
+  # GET /source/:project/_meta
+  #---------------------------
+  def show_project_meta
+    if Project.find_remote_project params[:project]
+      # project from remote buildservice, get metadata from backend
+      raise InvalidProjectParameters if params[:view]
+      pass_to_backend
+    else
+      # access check
+      prj = Project.get_by_name params[:project]
+      render xml: prj.to_axml
+    end
+  end
+
+  # PUT /source/:project/_meta
+  def update_project_meta
+    project_name = params[:project]
+    params[:user] = User.current.login
+
+    request_data = Xmlhash.parse(request.raw_post)
+
+    # permission check
+    if request_data['name'] != project_name
+      raise ProjectNameMismatch, "project name in xml data ('#{request_data['name']}) does not match resource path component ('#{project_name}')"
+    end
+
+    begin
+      project = Project.get_by_name(request_data['name'])
+    rescue Project::UnknownObjectError
+      project = nil
+    end
+
+    # Need permission
+    logger.debug 'Checking permission for the put'
+    if project
+      # project exists, change it
+      unless User.current.can_modify_project?(project)
+        if project.is_locked?
+          logger.debug "no permission to modify LOCKED project #{project.name}"
+          raise ChangeProjectNoPermission, "The project #{project.name} is locked"
+        end
+        logger.debug "user #{user.login} has no permission to modify project #{project.name}"
+        raise ChangeProjectNoPermission, 'no permission to change project'
+      end
+    else
+      # project is new
+      unless User.current.can_create_project?(project_name)
+        logger.debug 'Not allowed to create new project'
+        raise CreateProjectNoPermission, "no permission to create project #{project_name}"
+      end
+    end
+
+    # projects using remote resources must be edited by the admin
+    result = Project.validate_remote_permissions(request_data)
+    if result[:error]
+      raise ChangeProjectNoPermission, 'admin rights are required to change projects using remote resources'
+    end
+
+    result = Project.validate_link_xml_attribute(request_data, project_name)
+    raise ProjectReadAccessFailure, result[:error] if result[:error]
+
+    result = Project.validate_maintenance_xml_attribute(request_data)
+    raise ModifyProjectNoPermission, result[:error] if result[:error]
+
+    result = Project.validate_repository_xml_attribute(request_data, project_name)
+    raise RepositoryAccessFailure, result[:error] if result[:error]
+
+    if project
+      remove_repositories = project.get_removed_repositories(request_data)
+      opts = { no_write_to_backend: true,
+               force:               params[:force].present?,
+               recursive_remove:    params[:remove_linking_repositories].present? }
+      check_and_remove_repositories!(remove_repositories, opts)
+    end
+
+    Project.transaction do
+      # exec
+      if project
+        project.update_from_xml!(request_data)
+      else
+        project = Project.new(name: project_name)
+        project.update_from_xml!(request_data)
+        # FIXME3.0: don't modify send data
+        project.relationships.build(user: User.current, role: Role.find_by_title!('maintainer'))
+      end
+      project.store(comment: params[:comment])
+    end
+    render_ok
+  end
+end

--- a/src/api/app/views/source_project/show.xml.builder
+++ b/src/api/app/views/source_project/show.xml.builder
@@ -1,0 +1,9 @@
+xml.directory(count: @packages.count) do
+  @packages.map do |name, project|
+    if expand
+      xml.entry(name: name, originproject: project)
+    else
+      xml.entry(name: name)
+    end
+  end
+end

--- a/src/api/config/routes.rb
+++ b/src/api/config/routes.rb
@@ -730,18 +730,20 @@ OBSApi::Application.routes.draw do
     get 'projects/:project/packages/:package/requests' => 'webui/packages/bs_requests#index', constraints: cons, as: 'packages_requests'
   end
 
+  # project level
+  controller :source_project do
+    get 'source/:project' => :show, constraints: cons
+    delete 'source/:project' => :delete, constraints: cons
+    post 'source/:project' => :project_command, constraints: cons
+    get 'source/:project/_meta' => :show_project_meta, constraints: cons
+    put 'source/:project/_meta' => :update_project_meta, constraints: cons
+  end
+
   controller :source do
     get 'source' => :index
     post 'source' => :global_command_createmaintenanceincident, constraints: ->(req) { req.params[:cmd] == 'createmaintenanceincident' }
     post 'source' => :global_command_branch,                    constraints: ->(req) { req.params[:cmd] == 'branch' }
     post 'source' => :global_command_orderkiwirepos,            constraints: ->(req) { req.params[:cmd] == 'orderkiwirepos' }
-
-    # project level
-    get 'source/:project' => :show_project, constraints: cons
-    delete 'source/:project' => :delete_project, constraints: cons
-    post 'source/:project' => :project_command, constraints: cons
-    get 'source/:project/_meta' => :show_project_meta, constraints: cons
-    put 'source/:project/_meta' => :update_project_meta, constraints: cons
 
     get 'source/:project/_config' => :show_project_config, constraints: cons
     put 'source/:project/_config' => :update_project_config, constraints: cons

--- a/src/api/spec/cassettes/SourceController/PUT_update_project_config/1_4_1.yml
+++ b/src/api/spec/cassettes/SourceController/PUT_update_project_config/1_4_1.yml
@@ -1,0 +1,104 @@
+---
+http_interactions:
+- request:
+    method: put
+    uri: http://backend:5352/source/home:tom/_config?comment=Updated%20by%20test&user=tom
+    body:
+      encoding: ASCII-8BIT
+      string: comment=Updated+by+test
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Content-Length:
+      - '23'
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '21'
+    body:
+      encoding: UTF-8
+      string: '<status code="ok" />
+
+'
+    http_version: 
+  recorded_at: Tue, 05 Jun 2018 12:22:51 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:tom/_config?comment=Updated%20by%20test&user=tom
+    body:
+      encoding: ASCII-8BIT
+      string: comment=Updated+by+test
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Content-Length:
+      - '23'
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '21'
+    body:
+      encoding: UTF-8
+      string: '<status code="ok" />
+
+'
+    http_version: 
+  recorded_at: Tue, 05 Jun 2018 12:23:38 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:tom/_config
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/plain
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '23'
+    body:
+      encoding: UTF-8
+      string: comment=Updated+by+test
+    http_version: 
+  recorded_at: Tue, 05 Jun 2018 12:25:13 GMT
+recorded_with: VCR 4.0.0

--- a/src/api/spec/cassettes/SourceController/PUT_update_project_config/1_4_2.yml
+++ b/src/api/spec/cassettes/SourceController/PUT_update_project_config/1_4_2.yml
@@ -1,0 +1,69 @@
+---
+http_interactions:
+- request:
+    method: put
+    uri: http://backend:5352/source/home:tom/_config?comment=Updated%20by%20test&user=tom
+    body:
+      encoding: ASCII-8BIT
+      string: comment=Updated+by+test
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Content-Length:
+      - '23'
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '21'
+    body:
+      encoding: UTF-8
+      string: '<status code="ok" />
+
+'
+    http_version: 
+  recorded_at: Tue, 05 Jun 2018 12:25:22 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:tom/_config
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/plain
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '23'
+    body:
+      encoding: UTF-8
+      string: comment=Updated+by+test
+    http_version: 
+  recorded_at: Tue, 05 Jun 2018 12:25:22 GMT
+recorded_with: VCR 4.0.0

--- a/src/api/spec/controllers/source_controller_spec.rb
+++ b/src/api/spec/controllers/source_controller_spec.rb
@@ -31,16 +31,6 @@ RSpec.describe SourceController, vcr: true do
     end
   end
 
-  describe 'GET #show_project_meta' do
-    before do
-      login user
-      get :show_project_meta, params: { project: project }
-    end
-
-    it { expect(response).to be_success }
-    it { expect(Xmlhash.parse(response.body)['name']).to eq(project.name) }
-  end
-
   describe 'PUT #update_project_config' do
     before do
       login user

--- a/src/api/spec/controllers/source_project_controller_spec.rb
+++ b/src/api/spec/controllers/source_project_controller_spec.rb
@@ -1,0 +1,16 @@
+require 'rails_helper'
+
+RSpec.describe SourceProjectController, vcr: true do
+  let(:user) { create(:confirmed_user, login: 'tom') }
+  let(:project) { user.home_project }
+
+  describe 'GET #show_project_meta' do
+    before do
+      login user
+      get :show_project_meta, params: { project: project }
+    end
+
+    it { expect(response).to be_success }
+    it { expect(Xmlhash.parse(response.body)['name']).to eq(project.name) }
+  end
+end

--- a/src/api/test/functional/read_permission_test.rb
+++ b/src/api/test/functional/read_permission_test.rb
@@ -485,14 +485,14 @@ class ReadPermissionTest < ActionDispatch::IntegrationTest
   def test_alter_source_access_flags
     # Create public project with protected package
     login_adrian
-    put url_for(controller: :source, action: :update_project_meta, project: 'home:adrian:Project'),
+    put url_for(controller: :source_project, action: :update_project_meta, project: 'home:adrian:Project'),
         params: '<project name="home:adrian:Project"> <title/> <description/> </project>'
     assert_response :success
-    put url_for(controller: :source, action: :update_project_meta, project: 'home:adrian:Project'),
+    put url_for(controller: :source_project, action: :update_project_meta, project: 'home:adrian:Project'),
         params: '<project name="home:adrian:Project"> <title/> <description/> <sourceaccess><disable/></sourceaccess> </project>'
     assert_response 403
     assert_xml_tag tag: 'status', attributes: { code: 'change_project_protection_level' }
-    put url_for(controller: :source, action: :update_project_meta, project: 'home:adrian:PublicProject'),
+    put url_for(controller: :source_project, action: :update_project_meta, project: 'home:adrian:PublicProject'),
         params: '<project name="home:adrian:PublicProject"> <title/> <description/> </project>'
     assert_response :success
     put url_for(controller: :source, action: :update_package_meta, project: 'home:adrian:PublicProject', package: 'pack'),
@@ -516,15 +516,15 @@ class ReadPermissionTest < ActionDispatch::IntegrationTest
   def test_alter_access_flags
     # Create public project with protected package
     login_adrian
-    put url_for(controller: :source, action: :update_project_meta, project: 'home:adrian:Project'),
+    put url_for(controller: :source_project, action: :update_project_meta, project: 'home:adrian:Project'),
         params: '<project name="home:adrian:Project"> <title/> <description/> </project>'
     assert_response :success
-    put url_for(controller: :source, action: :update_project_meta, project: 'home:adrian:Project'),
+    put url_for(controller: :source_project, action: :update_project_meta, project: 'home:adrian:Project'),
         params: '<project name="home:adrian:Project"> <title/> <description/> <access><disable/></access> </project>'
     assert_response 403
     assert_xml_tag tag: 'status', attributes: { code: 'change_project_protection_level' }
     login_king
-    put url_for(controller: :source, action: :update_project_meta, project: 'home:adrian:Project'),
+    put url_for(controller: :source_project, action: :update_project_meta, project: 'home:adrian:Project'),
         params: '<project name="home:adrian:Project"> <title/> <description/> <access><disable/></access> </project>'
     assert_response :success
     delete '/source/home:adrian:Project'
@@ -534,7 +534,7 @@ class ReadPermissionTest < ActionDispatch::IntegrationTest
   def test_project_links_to_sourceaccess_protected_package
     # Create public project with protected package
     login_adrian
-    put url_for(controller: :source, action: :update_project_meta, project: 'home:adrian:PublicProject'),
+    put url_for(controller: :source_project, action: :update_project_meta, project: 'home:adrian:PublicProject'),
         params: '<project name="home:adrian:PublicProject"> <title/> <description/> </project>'
     assert_response :success
     # rubocop:disable Metrics/LineLength
@@ -552,7 +552,7 @@ class ReadPermissionTest < ActionDispatch::IntegrationTest
     assert_response 403
     assert_xml_tag tag: 'status', attributes: { code: 'project_copy_no_permission' }
     # try to access it via own project link
-    put url_for(controller: :source, action: :update_project_meta, project: 'home:tom:temp'),
+    put url_for(controller: :source_project, action: :update_project_meta, project: 'home:tom:temp'),
         params: '<project name="home:tom:temp"> <title/> <description/> <link project="home:adrian:PublicProject"/> </project>'
     assert_response :success
     get '/source/home:tom:temp/ProtectedPackage'
@@ -616,7 +616,7 @@ class ReadPermissionTest < ActionDispatch::IntegrationTest
     login_adrian
     get '/source/home:adrian:ProtectedProject'
     assert_response 404
-    put url_for(controller: :source, action: :update_project_meta, project: 'home:adrian:ProtectedProject'),
+    put url_for(controller: :source_project, action: :update_project_meta, project: 'home:adrian:ProtectedProject'),
         params: '<project name="home:adrian:ProtectedProject"> <title/> <description/> <sourceaccess><disable/></sourceaccess>  </project>'
     assert_response :success
     put url_for(controller: :source, action: :update_package_meta, project: 'home:adrian:ProtectedProject', package: 'Package'),
@@ -628,7 +628,7 @@ class ReadPermissionTest < ActionDispatch::IntegrationTest
     get '/source/home:adrian:ProtectedProject/Package'
     assert_response 403
     # try to access it via own project link
-    put url_for(controller: :source, action: :update_project_meta, project: 'home:tom:temp'),
+    put url_for(controller: :source_project, action: :update_project_meta, project: 'home:tom:temp'),
         params: '<project name="home:tom:temp"> <title/> <description/> <link project="home:adrian:ProtectedProject"/> </project>'
     assert_response :success
     get '/source/home:tom:temp/Package'
@@ -659,53 +659,53 @@ class ReadPermissionTest < ActionDispatch::IntegrationTest
     login_tom
 
     # try to link to an access protected hidden project from sourceaccess project
-    put url_for(controller: :source, action: :update_project_meta, project: 'home:tom:ProtectedProject2'),
+    put url_for(controller: :source_project, action: :update_project_meta, project: 'home:tom:ProtectedProject2'),
         params: '<project name="home:tom:ProtectedProject2"> <title/> <description/> <link project="HiddenProject"/> </project>'
     assert_response 404
-    put url_for(controller: :source, action: :update_project_meta, project: 'home:tom:ProtectedProject2'),
+    put url_for(controller: :source_project, action: :update_project_meta, project: 'home:tom:ProtectedProject2'),
         params: '<project name="home:tom:ProtectedProject2"> <title/> <description/> <link project="HiddenProject"/> </project>'
     assert_response 404
 
     login_adrian
     # try to link to an access protected hidden project from sourceaccess project
-    put url_for(controller: :source, action: :update_project_meta, project: 'home:adrian:ProtectedProject2'),
+    put url_for(controller: :source_project, action: :update_project_meta, project: 'home:adrian:ProtectedProject2'),
         params: '<project name="home:adrian:ProtectedProject2"> <title/> <description/> <link project="HiddenProject"/> </project>'
     assert_response 404
-    put url_for(controller: :source, action: :update_project_meta, project: 'home:adrian:ProtectedProject2'),
+    put url_for(controller: :source_project, action: :update_project_meta, project: 'home:adrian:ProtectedProject2'),
         params: '<project name="home:adrian:ProtectedProject2"> <title/> <description/> <link project="HiddenProject"/> </project>'
     assert_response 404
 
-    put url_for(controller: :source, action: :update_project_meta, project: 'home:adrian:ProtectedProject2'),
+    put url_for(controller: :source_project, action: :update_project_meta, project: 'home:adrian:ProtectedProject2'),
         params: '<project name="home:adrian:ProtectedProject2"> <title/> <description/> <sourceaccess><disable/></sourceaccess> </project>'
     assert_response :success
-    put url_for(controller: :source, action: :update_project_meta, project: 'home:adrian:ProtectedProject1'),
+    put url_for(controller: :source_project, action: :update_project_meta, project: 'home:adrian:ProtectedProject1'),
         params: '<project name="home:adrian:ProtectedProject1"> <title/> <description/> </project>'
     assert_response :success
 
     # Allow linking from not sourceaccess protected project to protected own. src.rpms are not delivered by the backend.
     #
-    put url_for(controller: :source, action: :update_project_meta, project: 'home:adrian:ProtectedProject1'),
+    put url_for(controller: :source_project, action: :update_project_meta, project: 'home:adrian:ProtectedProject1'),
         params: '<project name="home:adrian:ProtectedProject1"> <title/> <description/> <link project="home:adrian:ProtectedProject2"/> </project>'
     assert_response :success
 
     # try to link to an access protected hidden project from access hidden project
-    put url_for(controller: :source, action: :update_project_meta, project: 'home:adrian:ProtectedProject3'),
+    put url_for(controller: :source_project, action: :update_project_meta, project: 'home:adrian:ProtectedProject3'),
         params: '<project name="home:adrian:ProtectedProject3"> <title/> <description/> <link project="HiddenProject"/> </project>'
     assert_response 404
 
-    put url_for(controller: :source, action: :update_project_meta, project: 'home:adrian:ProtectedProject3'),
+    put url_for(controller: :source_project, action: :update_project_meta, project: 'home:adrian:ProtectedProject3'),
         params: '<project name="home:adrian:ProtectedProject3"> <title/> <description/> <access><disable/></access> </project>'
     assert_response :success
 
-    put url_for(controller: :source, action: :update_project_meta, project: 'home:adrian:ProtectedProject3'),
+    put url_for(controller: :source_project, action: :update_project_meta, project: 'home:adrian:ProtectedProject3'),
         params: '<project name="home:adrian:ProtectedProject3"> <title/> <description/> <link project="HiddenProject"/> </project>'
     assert_response 404
 
-    put url_for(controller: :source, action: :update_project_meta, project: 'home:adrian:ProtectedProject4'),
+    put url_for(controller: :source_project, action: :update_project_meta, project: 'home:adrian:ProtectedProject4'),
         params: '<project name="home:adrian:ProtectedProject4"> <title/> <description/> <access><disable/></access> </project>'
     assert_response :success
     # rubocop:disable Metrics/LineLength
-    put url_for(controller: :source, action: :update_project_meta, project: 'home:adrian:ProtectedProject4'),
+    put url_for(controller: :source_project, action: :update_project_meta, project: 'home:adrian:ProtectedProject4'),
         params: '<project name="home:adrian:ProtectedProject4"> <title/> <description/> <access><disable/></access> <link project="home:adrian:ProtectedProject2"/> </project>'
     # rubocop:enable Metrics/LineLength
     assert_response :success
@@ -714,7 +714,7 @@ class ReadPermissionTest < ActionDispatch::IntegrationTest
     login_tom
 
     # try to link to an access protected hidden project
-    put url_for(controller: :source, action: :update_project_meta, project: 'home:tom:temp2'),
+    put url_for(controller: :source_project, action: :update_project_meta, project: 'home:tom:temp2'),
         params: '<project name="home:tom:temp2"> <title/> <description/> <link project="HiddenProject"/> </project>'
     assert_response 404
 
@@ -754,7 +754,7 @@ class ReadPermissionTest < ActionDispatch::IntegrationTest
     login_adrian
     get '/source/home:adrian:ProtectedProject'
     assert_response 404
-    put url_for(controller: :source, action: :update_project_meta, project: 'home:adrian:ProtectedProject'),
+    put url_for(controller: :source_project, action: :update_project_meta, project: 'home:adrian:ProtectedProject'),
         params: '<project name="home:adrian:ProtectedProject"> <title/> <description/> <access><disable/></access> </project>'
     assert_response :success
     get '/source/home:adrian:ProtectedProject'
@@ -789,18 +789,18 @@ class ReadPermissionTest < ActionDispatch::IntegrationTest
     prepare_request_with_user 'binary_homer', 'buildservice'
 
     # check if sufficiently protected projects can access protected projects
-    put url_for(controller: :source, action: :update_project_meta, project: 'home:binary_homer:ProtectedProject1'),
+    put url_for(controller: :source_project, action: :update_project_meta, project: 'home:binary_homer:ProtectedProject1'),
         params: '<project name="home:binary_homer:ProtectedProject1"> <title/> <description/> <binarydownload><disable/></binarydownload> </project>'
     assert_response 200
 
     # rubocop:disable Metrics/LineLength
-    put url_for(controller: :source, action: :update_project_meta, project: 'home:binary_homer:ProtectedProject1'),
+    put url_for(controller: :source_project, action: :update_project_meta, project: 'home:binary_homer:ProtectedProject1'),
         params: '<project name="home:binary_homer:ProtectedProject1"> <title/> <description/> <repository name="BinaryprotectedProjectRepo"> <path repository="nada" project="BinaryprotectedProject"/> <arch>i586</arch> </repository> </project>'
     # rubocop:enable Metrics/LineLength
     assert_response 200
 
     # check if sufficiently protected projects can access protected projects
-    put url_for(controller: :source, action: :update_project_meta, project: 'home:binary_homer:ProtectedProject2'),
+    put url_for(controller: :source_project, action: :update_project_meta, project: 'home:binary_homer:ProtectedProject2'),
         params: '<project name="home:binary_homer:ProtectedProject2"> <title/> <description/> </project>'
     assert_response 200
 
@@ -818,7 +818,7 @@ class ReadPermissionTest < ActionDispatch::IntegrationTest
 
     # check if unsufficiently permitted users tries to access protected projects
     # rubocop:disable Metrics/LineLength
-    put url_for(controller: :source, action: :update_project_meta, project: 'home:tom:ProtectedProject2'),
+    put url_for(controller: :source_project, action: :update_project_meta, project: 'home:tom:ProtectedProject2'),
         params: '<project name="home:tom:ProtectedProject2"> <title/> <description/>  <repository name="HiddenProjectRepo"> <path repository="nada" project="HiddenProject"/> <arch>i586</arch> </repository> </project>'
     # rubocop:enable Metrics/LineLength
     assert_response 404
@@ -826,44 +826,44 @@ class ReadPermissionTest < ActionDispatch::IntegrationTest
     # try to access it with a user permitted for access
     login_adrian
 
-    put url_for(controller: :source, action: :update_project_meta, project: 'home:adrian:ProtectedProject1'),
+    put url_for(controller: :source_project, action: :update_project_meta, project: 'home:adrian:ProtectedProject1'),
         params: '<project name="home:adrian:ProtectedProject1"> <title/> <description/> <access><disable/></access> </project>'
     # STDERR.puts(@response.body)
     assert_response 200
 
     # rubocop:disable Metrics/LineLength
-    put url_for(controller: :source, action: :update_project_meta, project: 'home:adrian:ProtectedProject1'),
+    put url_for(controller: :source_project, action: :update_project_meta, project: 'home:adrian:ProtectedProject1'),
         params: '<project name="home:adrian:ProtectedProject1"> <title/> <description/> <repository name="HiddenProjectRepo"> <path repository="nada" project="HiddenProject"/> <arch>i586</arch> </repository> </project>'
     # rubocop:enable Metrics/LineLength
     assert_response 404
 
     # building against
     # rubocop:disable Metrics/LineLength
-    put url_for(controller: :source, action: :update_project_meta, project: 'home:adrian:ProtectedProject2'),
+    put url_for(controller: :source_project, action: :update_project_meta, project: 'home:adrian:ProtectedProject2'),
         params: '<project name="home:adrian:ProtectedProject2"> <title/> <description/> <repository name="HiddenProjectRepo"> <path repository="nada" project="HiddenProject"/> <arch>i586</arch> </repository> </project>'
     # rubocop:enable Metrics/LineLength
     assert_response 404
 
     # check if download protected project has to access protected project, which reveals Hidden project existence to others and is and error
-    put url_for(controller: :source, action: :update_project_meta, project: 'home:adrian:ProtectedProject2'),
+    put url_for(controller: :source_project, action: :update_project_meta, project: 'home:adrian:ProtectedProject2'),
         params: '<project name="home:adrian:ProtectedProject2"> <title/> <description/> <binarydownload><disable/></binarydownload> </project>'
     assert_response 200
 
     # rubocop:disable Metrics/LineLength
-    put url_for(controller: :source, action: :update_project_meta, project: 'home:adrian:ProtectedProject2'),
+    put url_for(controller: :source_project, action: :update_project_meta, project: 'home:adrian:ProtectedProject2'),
         params: '<project name="home:adrian:ProtectedProject2"> <title/> <description/> <repository name="HiddenProjectRepo"> <path repository="nada" project="HiddenProject"/> <arch>i586</arch> </repository> </project>'
     # rubocop:enable Metrics/LineLength
     assert_response 404
 
     # check if access protected project has access binarydownload protected project
     prepare_request_with_user 'binary_homer', 'buildservice'
-    put url_for(controller: :source, action: :update_project_meta, project: 'home:binary_homer:ProtectedProject3'),
+    put url_for(controller: :source_project, action: :update_project_meta, project: 'home:binary_homer:ProtectedProject3'),
         params: '<project name="home:binary_homer:ProtectedProject3"> <title/> <description/> <access><disable/></access> </project>'
     # STDERR.puts(@response.body)
     assert_response 200
 
     # rubocop:disable Metrics/LineLength
-    put url_for(controller: :source, action: :update_project_meta, project: 'home:binary_homer:ProtectedProject3'),
+    put url_for(controller: :source_project, action: :update_project_meta, project: 'home:binary_homer:ProtectedProject3'),
         params: '<project name="home:binary_homer:ProtectedProject3"> <title/> <description/> <repository name="BinaryprotectedProjectRepo"> <path repository="nada" project="BinaryprotectedProject"/> <arch>i586</arch> </repository> </project>'
     # rubocop:enable Metrics/LineLength
     assert_response 200
@@ -955,7 +955,7 @@ class ReadPermissionTest < ActionDispatch::IntegrationTest
   def test_setup_default_project
     # Create public project
     login_adrian
-    put url_for(controller: :source, action: :update_project_meta, project: 'home:adrian:Project'),
+    put url_for(controller: :source_project, action: :update_project_meta, project: 'home:adrian:Project'),
         params: '<project name="home:adrian:Project"> <title/> <description/> </project>'
     assert_response :success
     get '/source/home:adrian:Project/_meta'
@@ -969,14 +969,14 @@ class ReadPermissionTest < ActionDispatch::IntegrationTest
     orig_value = c.default_access_disabled
     c.default_access_disabled = true
     c.save!
-    put url_for(controller: :source, action: :update_project_meta, project: 'home:adrian:Project'),
+    put url_for(controller: :source_project, action: :update_project_meta, project: 'home:adrian:Project'),
         params: '<project name="home:adrian:Project"> <title/> <description/> </project>'
     assert_response :success
     get '/source/home:adrian:Project/_meta'
     assert_response :success
     assert_xml_tag(tag: 'disable', parent: { tag: 'access' })
     # enabling access is not allowed in this mode
-    put url_for(controller: :source, action: :update_project_meta, project: 'home:adrian:Project'),
+    put url_for(controller: :source_project, action: :update_project_meta, project: 'home:adrian:Project'),
         params: '<project name="home:adrian:Project"> <title/> <description/> </project>'
     assert_response 403
     assert_xml_tag tag: 'status', attributes: { code: 'change_project_protection_level' }
@@ -984,7 +984,7 @@ class ReadPermissionTest < ActionDispatch::IntegrationTest
     # enabling access is allowed
     c.default_access_disabled = orig_value
     c.save!
-    put url_for(controller: :source, action: :update_project_meta, project: 'home:adrian:Project'),
+    put url_for(controller: :source_project, action: :update_project_meta, project: 'home:adrian:Project'),
         params: '<project name="home:adrian:Project"> <title/> <description/> </project>'
     assert_response :success
 

--- a/src/api/test/functional/request_controller_test.rb
+++ b/src/api/test/functional/request_controller_test.rb
@@ -3101,7 +3101,7 @@ class RequestControllerTest < ActionDispatch::IntegrationTest
      </repository>
      </project>"
 
-    put url_for(controller: :source, action: :update_project_meta, project: 'home:Iggy:todo'), params: meta
+    put url_for(controller: :source_project, action: :update_project_meta, project: 'home:Iggy:todo'), params: meta
     assert_response :success
 
     meta = "<package name='realfun' project='home:Iggy:todo'><title/><description/></package>"
@@ -3182,7 +3182,7 @@ class RequestControllerTest < ActionDispatch::IntegrationTest
      </repository>
      </project>"
 
-    put url_for(controller: :source, action: :update_project_meta, project: 'home:Iggy:todo'), params: meta
+    put url_for(controller: :source_project, action: :update_project_meta, project: 'home:Iggy:todo'), params: meta
     assert_response :success
 
     meta = "<package name='realfun' project='home:Iggy:todo'><title/><description/></package>"

--- a/src/api/test/functional/source_controller_test.rb
+++ b/src/api/test/functional/source_controller_test.rb
@@ -298,7 +298,7 @@ class SourceControllerTest < ActionDispatch::IntegrationTest
   def test_invalid_project_and_package_name
     login_king
     ['_invalid', '..'].each do |n|
-      put url_for(controller: :source, action: :update_project_meta, project: n), params: "<project name='#{n}'> <title /> <description /> </project>"
+      put url_for(controller: :source_project, action: :update_project_meta, project: n), params: "<project name='#{n}'> <title /> <description /> </project>"
       assert_response 400
       assert_xml_tag tag: 'status', attributes: { code: 'invalid_project_name' }
 
@@ -396,7 +396,7 @@ class SourceControllerTest < ActionDispatch::IntegrationTest
     d.text = new_desc
 
     # Write changed data back
-    put url_for(controller: :source, action: :update_project_meta, project: 'kde4'), params: doc.dump_xml
+    put url_for(controller: :source_project, action: :update_project_meta, project: 'kde4'), params: doc.dump_xml
     assert_response 403
 
     ### admin only tag
@@ -404,29 +404,29 @@ class SourceControllerTest < ActionDispatch::IntegrationTest
     login_fred
     d = doc.add_element 'remoteurl'
     d.text = 'http://localhost:5352'
-    put url_for(controller: :source, action: :update_project_meta, project: 'kde4'), params: doc.dump_xml
+    put url_for(controller: :source_project, action: :update_project_meta, project: 'kde4'), params: doc.dump_xml
     assert_response 403
     assert_match(/admin rights are required to change projects using remote resources/, @response.body)
     # DoD remote repository
     doc = ActiveXML::Node.new(xml)
     r = doc.add_element 'repository', name: 'download_on_demand'
     r.add_element 'download', arch: 'i586', url: 'http://somewhere', repotype: 'rpmmd'
-    put url_for(controller: :source, action: :update_project_meta, project: 'kde4'), params: doc.dump_xml
+    put url_for(controller: :source_project, action: :update_project_meta, project: 'kde4'), params: doc.dump_xml
     assert_response 403
     assert_match(/admin rights are required to change projects using remote resources/, @response.body)
 
     # invalid xml
-    put url_for(controller: :source, action: :update_project_meta, project: 'NewProject'), params: '<asd/>'
+    put url_for(controller: :source_project, action: :update_project_meta, project: 'NewProject'), params: '<asd/>'
     assert_response 400
     assert_match(/validation error/, @response.body)
 
     # new project
-    put url_for(controller: :source, action: :update_project_meta, project: 'NewProject'), params: "<project name='NewProject'><title>blub</title><description/></project>"
+    put url_for(controller: :source_project, action: :update_project_meta, project: 'NewProject'), params: "<project name='NewProject'><title>blub</title><description/></project>"
     assert_response 403
     assert_xml_tag tag: 'status', attributes: { code: 'create_project_no_permission' }
 
     login_king
-    put url_for(controller: :source, action: :update_project_meta, project: '_NewProject'), params: "<project name='_NewProject'><title>blub</title><description/></project>"
+    put url_for(controller: :source_project, action: :update_project_meta, project: '_NewProject'), params: "<project name='_NewProject'><title>blub</title><description/></project>"
     assert_response 400
     assert_match(/invalid project name/, @response.body)
   end
@@ -458,27 +458,27 @@ class SourceControllerTest < ActionDispatch::IntegrationTest
     subprojectmeta = "<project name='kde4:subproject'><title></title><description/></project>"
 
     # nobody
-    put url_for(controller: :source, action: :update_project_meta, project: 'kde4:subproject'), params: subprojectmeta
+    put url_for(controller: :source_project, action: :update_project_meta, project: 'kde4:subproject'), params: subprojectmeta
     assert_response 401
     assert_xml_tag tag: 'status', attributes: { code: 'authentication_required' }
     login_tom
-    put url_for(controller: :source, action: :update_project_meta, project: 'kde4:subproject'), params: subprojectmeta
+    put url_for(controller: :source_project, action: :update_project_meta, project: 'kde4:subproject'), params: subprojectmeta
     assert_response 403
     # admin
     login_king
-    put url_for(controller: :source, action: :update_project_meta, project: 'kde4:subproject'), params: subprojectmeta
+    put url_for(controller: :source_project, action: :update_project_meta, project: 'kde4:subproject'), params: subprojectmeta
     assert_response :success
     delete '/source/kde4:subproject'
     assert_response :success
     # maintainer
     login_fred
-    put url_for(controller: :source, action: :update_project_meta, project: 'kde4:subproject'), params: subprojectmeta
+    put url_for(controller: :source_project, action: :update_project_meta, project: 'kde4:subproject'), params: subprojectmeta
     assert_response :success
     delete '/source/kde4:subproject'
     assert_response :success
     # maintainer via group
     login_adrian
-    put url_for(controller: :source, action: :update_project_meta, project: 'kde4:subproject'), params: subprojectmeta
+    put url_for(controller: :source_project, action: :update_project_meta, project: 'kde4:subproject'), params: subprojectmeta
     assert_response :success
     delete '/source/kde4:subproject'
     assert_response :success
@@ -486,7 +486,7 @@ class SourceControllerTest < ActionDispatch::IntegrationTest
     # create illegal project
     login_fred
     subprojectmeta = "<project name='kde4_subproject'><title></title><description/></project>"
-    put url_for(controller: :source, action: :update_project_meta, project: 'kde4:subproject'), params: subprojectmeta
+    put url_for(controller: :source_project, action: :update_project_meta, project: 'kde4:subproject'), params: subprojectmeta
     assert_response 400
     assert_xml_tag tag: 'status', attributes: { code: 'project_name_mismatch' }
 
@@ -570,11 +570,11 @@ class SourceControllerTest < ActionDispatch::IntegrationTest
 
     # create them
     login_king
-    put url_for(controller: :source, action: :update_project_meta, project: 'TEMPORARY:rel_target'), params: rel_target_meta
+    put url_for(controller: :source_project, action: :update_project_meta, project: 'TEMPORARY:rel_target'), params: rel_target_meta
     assert_response :success
     get '/source/TEMPORARY:rel_target/_meta'
     assert_response :success
-    put url_for(controller: :source, action: :update_project_meta, project: 'TEMPORARY:build'), params: build_meta
+    put url_for(controller: :source_project, action: :update_project_meta, project: 'TEMPORARY:build'), params: build_meta
     assert_response :success
     get '/source/TEMPORARY:build/_meta'
     assert_response :success
@@ -627,11 +627,11 @@ class SourceControllerTest < ActionDispatch::IntegrationTest
 
   def do_change_project_meta_test(project, response1, response2, tag2, doesmatch)
     # Get meta file
-    get url_for(controller: :source, action: :show_project_meta, project: project)
+    get url_for(controller: :source_project, action: :show_project_meta, project: project)
     assert_response response1
     unless response2 && tag2
       # dummy write to check blocking
-      put url_for(controller: :source, action: :update_project_meta, project: project), params: "<project name=\"#{project}\"><title></title><description></description></project>"
+      put url_for(controller: :source_project, action: :update_project_meta, project: project), params: "<project name=\"#{project}\"><title></title><description></description></project>"
       assert_response 403 # 4
       #      assert_match(/unknown_project/, @response.body)
       assert_match(/create_project_no_permission/, @response.body)
@@ -646,12 +646,12 @@ class SourceControllerTest < ActionDispatch::IntegrationTest
     d.text = new_desc
 
     # Write changed data back
-    put url_for(controller: :source, action: :update_project_meta, project: project), params: doc.to_s
+    put url_for(controller: :source_project, action: :update_project_meta, project: project), params: doc.to_s
     assert_response response2
     assert_xml_tag(tag2)
 
     # Get data again and check that it is the changed data
-    get url_for(controller: :source, action: :show_project_meta, project: project)
+    get url_for(controller: :source_project, action: :show_project_meta, project: project)
     assert_response :success
     assert_equal new_desc, Xmlhash.parse(@response.body)['description'] if doesmatch
   end
@@ -661,7 +661,7 @@ class SourceControllerTest < ActionDispatch::IntegrationTest
   def test_create_and_delete_project
     prepare_request_with_user('king', 'sunflower')
     # Get meta file
-    get url_for(controller: :source, action: :show_project_meta, project: 'kde4')
+    get url_for(controller: :source_project, action: :show_project_meta, project: 'kde4')
     assert_response :success
 
     xml = @response.body
@@ -670,12 +670,12 @@ class SourceControllerTest < ActionDispatch::IntegrationTest
     d = doc.elements['/project']
     d.delete_attribute('name')
     d.add_attribute('name', 'kde5')
-    put url_for(controller: :source, action: :update_project_meta, project: 'kde5'), params: doc.to_s
+    put url_for(controller: :source_project, action: :update_project_meta, project: 'kde5'), params: doc.to_s
     assert_response(:success, '--> king was not allowed to create a project')
     assert_xml_tag(tag: 'status', attributes: { code: 'ok' })
 
     # Get data again and check that the maintainer was added
-    get url_for(controller: :source, action: :show_project_meta, project: 'kde5')
+    get url_for(controller: :source_project, action: :show_project_meta, project: 'kde5')
     assert_response :success
     assert_select 'project[name=kde5]'
     assert_select 'person[userid=king][role=maintainer]', {}, 'Creator was not added as project maintainer'
@@ -692,31 +692,31 @@ class SourceControllerTest < ActionDispatch::IntegrationTest
     login_fred
 
     # Get meta file
-    get url_for(controller: :source, action: :show_project_meta, project: 'kde4')
+    get url_for(controller: :source_project, action: :show_project_meta, project: 'kde4')
     assert_response :success
 
     xml = @response.body
     olddoc = REXML::Document.new(xml)
     doc = REXML::Document.new(xml)
     # Write corrupt data back
-    put url_for(controller: :source, action: :update_project_meta, project: 'kde4'), params: doc.to_s + '</xml>'
+    put url_for(controller: :source_project, action: :update_project_meta, project: 'kde4'), params: doc.to_s + '</xml>'
     assert_response 400
     assert_xml_tag tag: 'status', attributes: { code: 'validation_failed' }
 
     login_king
     # write to illegal location:
-    put url_for(controller: :source, action: :update_project_meta, project: '$hash'), params: doc.to_s
+    put url_for(controller: :source_project, action: :update_project_meta, project: '$hash'), params: doc.to_s
     assert_response 400
     assert_xml_tag tag: 'status', attributes: { code: 'invalid_project_name' }
 
     # must not create a project with different pathname and name in _meta.xml:
-    put url_for(controller: :source, action: :update_project_meta, project: 'kde5'), params: doc.to_s
+    put url_for(controller: :source_project, action: :update_project_meta, project: 'kde5'), params: doc.to_s
     assert_response 400
     assert_xml_tag tag: 'status', attributes: { code: 'project_name_mismatch' }
     # TODO: referenced repository names must exist
 
     # verify data is unchanged:
-    get url_for(controller: :source, action: :show_project_meta, project: 'kde4')
+    get url_for(controller: :source_project, action: :show_project_meta, project: 'kde4')
     assert_response :success
     assert_equal(olddoc.to_s, REXML::Document.new(@response.body).to_s)
   end
@@ -725,23 +725,23 @@ class SourceControllerTest < ActionDispatch::IntegrationTest
     login_fred
 
     # Get meta file
-    get url_for(controller: :source, action: :show_project_meta, project: 'home:fred')
+    get url_for(controller: :source_project, action: :show_project_meta, project: 'home:fred')
     assert_response :success
     xml = @response.body
     doc = REXML::Document.new(xml)
 
     # drop myself (fred)
     doc.elements['/project'].delete_element 'person'
-    put url_for(controller: :source, action: :update_project_meta, project: 'home:fred'), params: doc.to_s
+    put url_for(controller: :source_project, action: :update_project_meta, project: 'home:fred'), params: doc.to_s
     assert_response :success
 
     # no person inside anymore
-    get url_for(controller: :source, action: :show_project_meta, project: 'home:fred')
+    get url_for(controller: :source_project, action: :show_project_meta, project: 'home:fred')
     assert_response :success
     assert_no_xml_tag tag: 'person'
 
     # but we are still allowed to modify our home meta, for example to re-add ourself
-    put url_for(controller: :source, action: :update_project_meta, project: 'home:fred'), params: xml
+    put url_for(controller: :source_project, action: :update_project_meta, project: 'home:fred'), params: xml
     assert_response :success
   end
 
@@ -2243,7 +2243,7 @@ class SourceControllerTest < ActionDispatch::IntegrationTest
 
     login_king
     subprojectmeta = "<project name='DoesNotExist:subproject'><title></title><description/></project>"
-    put url_for(controller: :source, action: :update_project_meta, project: 'DoesNotExist:subproject'), params: subprojectmeta
+    put url_for(controller: :source_project, action: :update_project_meta, project: 'DoesNotExist:subproject'), params: subprojectmeta
     assert_response :success
 
     delete '/source/DoesNotExist:subproject/_pubkey'
@@ -3195,7 +3195,7 @@ class SourceControllerTest < ActionDispatch::IntegrationTest
 
   def test_create_links
     login_king
-    put url_for(controller: :source, action: :update_project_meta, project: 'TEMPORARY'), params: '<project name="TEMPORARY"> <title/> <description/> <person role="maintainer" userid="fred"/> </project>'
+    put url_for(controller: :source_project, action: :update_project_meta, project: 'TEMPORARY'), params: '<project name="TEMPORARY"> <title/> <description/> <person role="maintainer" userid="fred"/> </project>'
     assert_response 200
     # create packages via user without any special roles
     login_fred
@@ -3400,12 +3400,12 @@ class SourceControllerTest < ActionDispatch::IntegrationTest
 
   def test_create_project_with_invalid_repository_reference
     login_tom
-    put url_for(controller: :source, action: :update_project_meta, project: 'home:tom:temporary'), params: '<project name="home:tom:temporary"> <title/> <description/>
+    put url_for(controller: :source_project, action: :update_project_meta, project: 'home:tom:temporary'), params: '<project name="home:tom:temporary"> <title/> <description/>
            <repository name="me" />
          </project>'
     assert_response :success
     # self reference
-    put url_for(controller: :source, action: :update_project_meta, project: 'home:tom:temporary'), params: '<project name="home:tom:temporary"> <title/> <description/>
+    put url_for(controller: :source_project, action: :update_project_meta, project: 'home:tom:temporary'), params: '<project name="home:tom:temporary"> <title/> <description/>
            <repository name="me">
              <path project="home:tom:temporary" repository="me" />
            </repository>
@@ -3413,7 +3413,7 @@ class SourceControllerTest < ActionDispatch::IntegrationTest
     assert_response 400
     assert_xml_tag tag: 'status', attributes: { code: 'project_save_error' }
     assert_match(/Using same repository as path element is not allowed/, @response.body)
-    put url_for(controller: :source, action: :update_project_meta, project: 'home:tom:temporary'), params: '<project name="home:tom:temporary"> <title/> <description/>
+    put url_for(controller: :source_project, action: :update_project_meta, project: 'home:tom:temporary'), params: '<project name="home:tom:temporary"> <title/> <description/>
            <repository name="me">
              <hostsystem project="home:tom:temporary" repository="me" />
            </repository>
@@ -3422,7 +3422,7 @@ class SourceControllerTest < ActionDispatch::IntegrationTest
     assert_xml_tag tag: 'status', attributes: { code: 'project_save_error' }
     assert_match(/Using same repository as hostsystem element is not allowed/, @response.body)
     # not existing repo
-    put url_for(controller: :source, action: :update_project_meta, project: 'home:tom:temporary'), params: '<project name="home:tom:temporary"> <title/> <description/>
+    put url_for(controller: :source_project, action: :update_project_meta, project: 'home:tom:temporary'), params: '<project name="home:tom:temporary"> <title/> <description/>
            <repository name="me">
              <path project="home:tom:temporary" repository="DOESNOTEXIST" />
            </repository>
@@ -3430,7 +3430,7 @@ class SourceControllerTest < ActionDispatch::IntegrationTest
     assert_response 400
     assert_xml_tag tag: 'status', attributes: { code: 'project_save_error' }
     assert_match(/unable to walk on path/, @response.body)
-    put url_for(controller: :source, action: :update_project_meta, project: 'home:tom:temporary'), params: '<project name="home:tom:temporary"> <title/> <description/>
+    put url_for(controller: :source_project, action: :update_project_meta, project: 'home:tom:temporary'), params: '<project name="home:tom:temporary"> <title/> <description/>
            <repository name="me">
              <hostsystem project="home:tom:temporary" repository="DOESNOTEXIST" />
            </repository>
@@ -3445,7 +3445,7 @@ class SourceControllerTest < ActionDispatch::IntegrationTest
 
   def test_use_project_link_as_non_maintainer
     login_tom
-    put url_for(controller: :source, action: :update_project_meta, project: 'home:tom:temporary'), params: '<project name="home:tom:temporary"> <title/> <description/> <link project="kde4" /> </project>'
+    put url_for(controller: :source_project, action: :update_project_meta, project: 'home:tom:temporary'), params: '<project name="home:tom:temporary"> <title/> <description/> <link project="kde4" /> </project>'
     assert_response :success
     get '/source/home:tom:temporary'
     assert_response :success
@@ -4085,7 +4085,7 @@ class SourceControllerTest < ActionDispatch::IntegrationTest
   def test_store_invalid_project
     login_tom
     name = "home:tom:#{Faker::Lorem.characters(255)}"
-    url = url_for(controller: :source, action: :update_project_meta, project: name)
+    url = url_for(controller: :source_project, action: :update_project_meta, project: name)
     put url, params: "<project name='#{name}'> <title/> <description/></project>"
     assert_response 400
     assert_select 'status[code] > summary', %r{invalid project name}


### PR DESCRIPTION
break the huge souce_controller in sub controllers

- [x] move /source/:project routes to new controller
- [x] move /source/:project/_meta routes to new controller
- [x] adapt tests and make everything green
- [x] rename the actions to something more REST
