### PR TITLE
[dist] Termporarily disable annotate gem

### DIFF
--- a/src/api/Gemfile
+++ b/src/api/Gemfile
@@ -134,8 +134,11 @@ end
 group :development do
   # as alternative to the standard IRB shell
   gem 'unicorn-rails' # webrick won't work
+  # FIXME: Temporarily disabled until we either switch to bundle-gems service
+  #        or our gem packaging scripts have a way to deal with conflicting
+  #        executeables.
   # for annotating models with schema info
-  gem 'annotate'
+  # gem 'annotate'
 end
 
 group :development, :test do


### PR DESCRIPTION
Until we switch to bundle-gems service or our gem packaging scripts have a way
to deal with conflicting executeables.