### PR TITLE
[frontend] Never raise an exception in RabbitmqBus

### DIFF
--- a/src/api/lib/rabbitmq_bus.rb
+++ b/src/api/lib/rabbitmq_bus.rb
@@ -1,8 +1,9 @@
 class RabbitmqBus
   def self.send_to_bus(channel, data)
     publish("#{Configuration.amqp_namespace}.#{channel}", data)
-  rescue Bunny::Exception, OpenSSL::SSL::SSLError => e
+  rescue => e
     Rails.logger.error "Publishing to RabbitMQ failed: #{e.message}"
+    Airbrake.notify(e)
   end
 
   def self.publish(event_routing_key, event_payload)


### PR DESCRIPTION
There is no need to catch only a subset of exceptions. If the connection
to rabbitmq somehow goes wrong it should never populate to the user.
Log and notify everything instead.