### PR TITLE
[ci] Invalidate CircleCI caches

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,9 +12,9 @@ jobs:
       - checkout
       - restore_cache:
           keys:
-          - v1-dependencies-{{ checksum "./src/api/Gemfile.lock" }}
+          - v2-dependencies-{{ checksum "./src/api/Gemfile.lock" }}
           # fallback to using the latest cache if no exact match is found
-          - v1-dependencies-
+          - v2-dependencies-
       - run:
           name: install dependencies
           command: |
@@ -22,7 +22,7 @@ jobs:
       - save_cache:
           paths:
             - ./src/api/vendor/bundle
-          key: v1-dependencies-{{ checksum "./src/api/Gemfile.lock" }}
+          key: v2-dependencies-{{ checksum "./src/api/Gemfile.lock" }}
       - run:
           name: Wait for DB
           command: mysqladmin ping -h db
@@ -56,9 +56,9 @@ jobs:
           command: git submodule update --init --recursive --remote
       - restore_cache:
           keys:
-          - v1-dependencies-{{ checksum "./src/api/Gemfile.lock" }}
+          - v2-dependencies-{{ checksum "./src/api/Gemfile.lock" }}
           # fallback to using the latest cache if no exact match is found
-          - v1-dependencies-
+          - v2-dependencies-
       - run:
           name: install dependencies
           command: |
@@ -66,7 +66,7 @@ jobs:
       - save_cache:
           paths:
             - ./src/api/vendor/bundle
-          key: v1-dependencies-{{ checksum "./src/api/Gemfile.lock" }}
+          key: v2-dependencies-{{ checksum "./src/api/Gemfile.lock" }}
       - run:
           name: Wait for DB
           command: mysqladmin ping -h db


### PR DESCRIPTION
because we changed the user inside the container which resulted
in wrong user permission errors.
To invalidate the cache in CircleCI we need to change the cache key.

Supersedes https://github.com/openSUSE/open-build-service/pull/5101