### PR TITLE
[api] move project meta actions to its own controller and make it REST

### DIFF
--- a/src/api/app/controllers/source_project_controller.rb
+++ b/src/api/app/controllers/source_project_controller.rb
@@ -1,7 +1,4 @@
 class SourceProjectController < SourceController
-  validate_action update_project_meta: { request: :project, response: :status }
-  validate_action show_project_meta: { response: :project }
-
   # GET /source/:project
   def show
     project_name = params[:project]
@@ -115,95 +112,5 @@ class SourceProjectController < SourceController
     else
       raise CmdExecutionNoPermission, "no permission to execute command '#{command}'"
     end
-  end
-
-  # GET /source/:project/_meta
-  #---------------------------
-  def show_project_meta
-    if Project.find_remote_project params[:project]
-      # project from remote buildservice, get metadata from backend
-      raise InvalidProjectParameters if params[:view]
-      pass_to_backend
-    else
-      # access check
-      prj = Project.get_by_name params[:project]
-      render xml: prj.to_axml
-    end
-  end
-
-  # PUT /source/:project/_meta
-  def update_project_meta
-    project_name = params[:project]
-    params[:user] = User.current.login
-
-    request_data = Xmlhash.parse(request.raw_post)
-
-    # permission check
-    if request_data['name'] != project_name
-      raise ProjectNameMismatch, "project name in xml data ('#{request_data['name']}) does not match resource path component ('#{project_name}')"
-    end
-
-    begin
-      project = Project.get_by_name(request_data['name'])
-    rescue Project::UnknownObjectError
-      project = nil
-    end
-
-    # Need permission
-    logger.debug 'Checking permission for the put'
-    if project
-      # project exists, change it
-      unless User.current.can_modify_project?(project)
-        if project.is_locked?
-          logger.debug "no permission to modify LOCKED project #{project.name}"
-          raise ChangeProjectNoPermission, "The project #{project.name} is locked"
-        end
-        logger.debug "user #{user.login} has no permission to modify project #{project.name}"
-        raise ChangeProjectNoPermission, 'no permission to change project'
-      end
-    else
-      # project is new
-      unless User.current.can_create_project?(project_name)
-        logger.debug 'Not allowed to create new project'
-        raise CreateProjectNoPermission, "no permission to create project #{project_name}"
-      end
-    end
-
-    # projects using remote resources must be edited by the admin
-    result = Project.validate_remote_permissions(request_data)
-    if result[:error]
-      raise ChangeProjectNoPermission, 'admin rights are required to change projects using remote resources'
-    end
-
-    result = Project.validate_link_xml_attribute(request_data, project_name)
-    raise ProjectReadAccessFailure, result[:error] if result[:error]
-
-    result = Project.validate_maintenance_xml_attribute(request_data)
-    raise ModifyProjectNoPermission, result[:error] if result[:error]
-
-    result = Project.validate_repository_xml_attribute(request_data, project_name)
-    raise RepositoryAccessFailure, result[:error] if result[:error]
-
-    if project
-      remove_repositories = project.get_removed_repositories(request_data)
-      opts = { no_write_to_backend: true,
-               force:               params[:force].present?,
-               recursive_remove:    params[:remove_linking_repositories].present? }
-      check_and_remove_repositories!(remove_repositories, opts)
-    end
-
-    Project.transaction do
-      # exec
-      if project
-        project.update_from_xml!(request_data)
-      else
-        project = Project.new(name: project_name)
-        project.update_from_xml!(request_data)
-        # FIXME3.0: don't modify send data
-        project.relationships.build(user: User.current, role: Role.find_by_title!('maintainer'))
-      end
-      project.store(comment: params[:comment])
-    end
-    render_ok
   end
 end

--- a/src/api/app/controllers/source_project_meta_controller.rb
+++ b/src/api/app/controllers/source_project_meta_controller.rb
@@ -1,0 +1,94 @@
+class SourceProjectMetaController < SourceController
+  validate_action update: { request: :project, response: :status }
+  validate_action show: { response: :project }
+
+  # GET /source/:project/_meta
+  #---------------------------
+  def show
+    if Project.find_remote_project params[:project]
+      # project from remote buildservice, get metadata from backend
+      raise InvalidProjectParameters if params[:view]
+      pass_to_backend
+    else
+      # access check
+      prj = Project.get_by_name params[:project]
+      render xml: prj.to_axml
+    end
+  end
+
+  # PUT /source/:project/_meta
+  def update
+    project_name = params[:project]
+    params[:user] = User.current.login
+
+    request_data = Xmlhash.parse(request.raw_post)
+
+    # permission check
+    if request_data['name'] != project_name
+      raise ProjectNameMismatch, "project name in xml data ('#{request_data['name']}) does not match resource path component ('#{project_name}')"
+    end
+
+    begin
+      project = Project.get_by_name(request_data['name'])
+    rescue Project::UnknownObjectError
+      project = nil
+    end
+
+    # Need permission
+    logger.debug 'Checking permission for the put'
+    if project
+      # project exists, change it
+      unless User.current.can_modify_project?(project)
+        if project.is_locked?
+          logger.debug "no permission to modify LOCKED project #{project.name}"
+          raise ChangeProjectNoPermission, "The project #{project.name} is locked"
+        end
+        logger.debug "user #{user.login} has no permission to modify project #{project.name}"
+        raise ChangeProjectNoPermission, 'no permission to change project'
+      end
+    else
+      # project is new
+      unless User.current.can_create_project?(project_name)
+        logger.debug 'Not allowed to create new project'
+        raise CreateProjectNoPermission, "no permission to create project #{project_name}"
+      end
+    end
+
+    # projects using remote resources must be edited by the admin
+    result = Project.validate_remote_permissions(request_data)
+    if result[:error]
+      raise ChangeProjectNoPermission, 'admin rights are required to change projects using remote resources'
+    end
+
+    result = Project.validate_link_xml_attribute(request_data, project_name)
+    raise ProjectReadAccessFailure, result[:error] if result[:error]
+
+    result = Project.validate_maintenance_xml_attribute(request_data)
+    raise ModifyProjectNoPermission, result[:error] if result[:error]
+
+    result = Project.validate_repository_xml_attribute(request_data, project_name)
+    raise RepositoryAccessFailure, result[:error] if result[:error]
+
+    if project
+      remove_repositories = project.get_removed_repositories(request_data)
+      opts = { no_write_to_backend: true,
+               force:               params[:force].present?,
+               recursive_remove:    params[:remove_linking_repositories].present? }
+      check_and_remove_repositories!(remove_repositories, opts)
+    end
+
+    Project.transaction do
+      # exec
+      if project
+        project.update_from_xml!(request_data)
+      else
+        project = Project.new(name: project_name)
+        project.update_from_xml!(request_data)
+        # FIXME3.0: don't modify send data
+        project.relationships.build(user: User.current, role: Role.find_by_title!('maintainer'))
+      end
+      project.store(comment: params[:comment])
+    end
+    render_ok
+  end
+end

--- a/src/api/config/routes.rb
+++ b/src/api/config/routes.rb
@@ -730,12 +730,15 @@ OBSApi::Application.routes.draw do
   end
 
   # project level
+  controller :source_project_meta do
+    get 'source/:project/_meta' => :show, constraints: cons
+    put 'source/:project/_meta' => :update, constraints: cons
+  end
+
   controller :source_project do
     get 'source/:project' => :show, constraints: cons
     delete 'source/:project' => :delete, constraints: cons
     post 'source/:project' => :project_command, constraints: cons
-    get 'source/:project/_meta' => :show_project_meta, constraints: cons
-    put 'source/:project/_meta' => :update_project_meta, constraints: cons
   end
 
   controller :source do

--- a/src/api/spec/cassettes/SourceProjectMetaController/GET_show/1_1_1.yml
+++ b/src/api/spec/cassettes/SourceProjectMetaController/GET_show/1_1_1.yml
@@ -40,5 +40,5 @@ http_interactions:
           <person userid="tom" role="maintainer" />
         </project>
     http_version: 
-  recorded_at: Fri, 03 Mar 2017 13:00:46 GMT
-recorded_with: VCR 3.0.3
+  recorded_at: Sun, 10 Jun 2018 17:21:41 GMT
+recorded_with: VCR 4.0.0

--- a/src/api/spec/cassettes/SourceProjectMetaController/GET_show/1_1_2.yml
+++ b/src/api/spec/cassettes/SourceProjectMetaController/GET_show/1_1_2.yml
@@ -40,5 +40,5 @@ http_interactions:
           <person userid="tom" role="maintainer" />
         </project>
     http_version: 
-  recorded_at: Fri, 03 Mar 2017 13:00:46 GMT
-recorded_with: VCR 3.0.3
+  recorded_at: Sun, 10 Jun 2018 17:21:41 GMT
+recorded_with: VCR 4.0.0

--- a/src/api/spec/controllers/source_project_meta_controller_spec.rb
+++ b/src/api/spec/controllers/source_project_meta_controller_spec.rb
@@ -1,13 +1,13 @@
 require 'rails_helper'
 
-RSpec.describe SourceProjectController, vcr: true do
+RSpec.describe SourceProjectMetaController, vcr: true do
   let(:user) { create(:confirmed_user, login: 'tom') }
   let(:project) { user.home_project }
 
-  describe 'GET #show_project_meta' do
+  describe 'GET #show' do
     before do
       login user
-      get :show_project_meta, params: { project: project }
+      get :show, params: { project: project }
     end
 
     it { expect(response).to be_success }

--- a/src/api/test/functional/read_permission_test.rb
+++ b/src/api/test/functional/read_permission_test.rb
@@ -485,14 +485,14 @@ class ReadPermissionTest < ActionDispatch::IntegrationTest
   def test_alter_source_access_flags
     # Create public project with protected package
     login_adrian
-    put url_for(controller: :source_project, action: :update_project_meta, project: 'home:adrian:Project'),
+    put url_for(controller: :source_project_meta, action: :update, project: 'home:adrian:Project'),
         params: '<project name="home:adrian:Project"> <title/> <description/> </project>'
     assert_response :success
-    put url_for(controller: :source_project, action: :update_project_meta, project: 'home:adrian:Project'),
+    put url_for(controller: :source_project_meta, action: :update, project: 'home:adrian:Project'),
         params: '<project name="home:adrian:Project"> <title/> <description/> <sourceaccess><disable/></sourceaccess> </project>'
     assert_response 403
     assert_xml_tag tag: 'status', attributes: { code: 'change_project_protection_level' }
-    put url_for(controller: :source_project, action: :update_project_meta, project: 'home:adrian:PublicProject'),
+    put url_for(controller: :source_project_meta, action: :update, project: 'home:adrian:PublicProject'),
         params: '<project name="home:adrian:PublicProject"> <title/> <description/> </project>'
     assert_response :success
     put url_for(controller: :source, action: :update_package_meta, project: 'home:adrian:PublicProject', package: 'pack'),
@@ -516,15 +516,15 @@ class ReadPermissionTest < ActionDispatch::IntegrationTest
   def test_alter_access_flags
     # Create public project with protected package
     login_adrian
-    put url_for(controller: :source_project, action: :update_project_meta, project: 'home:adrian:Project'),
+    put url_for(controller: :source_project_meta, action: :update, project: 'home:adrian:Project'),
         params: '<project name="home:adrian:Project"> <title/> <description/> </project>'
     assert_response :success
-    put url_for(controller: :source_project, action: :update_project_meta, project: 'home:adrian:Project'),
+    put url_for(controller: :source_project_meta, action: :update, project: 'home:adrian:Project'),
         params: '<project name="home:adrian:Project"> <title/> <description/> <access><disable/></access> </project>'
     assert_response 403
     assert_xml_tag tag: 'status', attributes: { code: 'change_project_protection_level' }
     login_king
-    put url_for(controller: :source_project, action: :update_project_meta, project: 'home:adrian:Project'),
+    put url_for(controller: :source_project_meta, action: :update, project: 'home:adrian:Project'),
         params: '<project name="home:adrian:Project"> <title/> <description/> <access><disable/></access> </project>'
     assert_response :success
     delete '/source/home:adrian:Project'
@@ -534,7 +534,7 @@ class ReadPermissionTest < ActionDispatch::IntegrationTest
   def test_project_links_to_sourceaccess_protected_package
     # Create public project with protected package
     login_adrian
-    put url_for(controller: :source_project, action: :update_project_meta, project: 'home:adrian:PublicProject'),
+    put url_for(controller: :source_project_meta, action: :update, project: 'home:adrian:PublicProject'),
         params: '<project name="home:adrian:PublicProject"> <title/> <description/> </project>'
     assert_response :success
     # rubocop:disable Metrics/LineLength
@@ -552,7 +552,7 @@ class ReadPermissionTest < ActionDispatch::IntegrationTest
     assert_response 403
     assert_xml_tag tag: 'status', attributes: { code: 'project_copy_no_permission' }
     # try to access it via own project link
-    put url_for(controller: :source_project, action: :update_project_meta, project: 'home:tom:temp'),
+    put url_for(controller: :source_project_meta, action: :update, project: 'home:tom:temp'),
         params: '<project name="home:tom:temp"> <title/> <description/> <link project="home:adrian:PublicProject"/> </project>'
     assert_response :success
     get '/source/home:tom:temp/ProtectedPackage'
@@ -616,7 +616,7 @@ class ReadPermissionTest < ActionDispatch::IntegrationTest
     login_adrian
     get '/source/home:adrian:ProtectedProject'
     assert_response 404
-    put url_for(controller: :source_project, action: :update_project_meta, project: 'home:adrian:ProtectedProject'),
+    put url_for(controller: :source_project_meta, action: :update, project: 'home:adrian:ProtectedProject'),
         params: '<project name="home:adrian:ProtectedProject"> <title/> <description/> <sourceaccess><disable/></sourceaccess>  </project>'
     assert_response :success
     put url_for(controller: :source, action: :update_package_meta, project: 'home:adrian:ProtectedProject', package: 'Package'),
@@ -628,7 +628,7 @@ class ReadPermissionTest < ActionDispatch::IntegrationTest
     get '/source/home:adrian:ProtectedProject/Package'
     assert_response 403
     # try to access it via own project link
-    put url_for(controller: :source_project, action: :update_project_meta, project: 'home:tom:temp'),
+    put url_for(controller: :source_project_meta, action: :update, project: 'home:tom:temp'),
         params: '<project name="home:tom:temp"> <title/> <description/> <link project="home:adrian:ProtectedProject"/> </project>'
     assert_response :success
     get '/source/home:tom:temp/Package'
@@ -659,53 +659,53 @@ class ReadPermissionTest < ActionDispatch::IntegrationTest
     login_tom
 
     # try to link to an access protected hidden project from sourceaccess project
-    put url_for(controller: :source_project, action: :update_project_meta, project: 'home:tom:ProtectedProject2'),
+    put url_for(controller: :source_project_meta, action: :update, project: 'home:tom:ProtectedProject2'),
         params: '<project name="home:tom:ProtectedProject2"> <title/> <description/> <link project="HiddenProject"/> </project>'
     assert_response 404
-    put url_for(controller: :source_project, action: :update_project_meta, project: 'home:tom:ProtectedProject2'),
+    put url_for(controller: :source_project_meta, action: :update, project: 'home:tom:ProtectedProject2'),
         params: '<project name="home:tom:ProtectedProject2"> <title/> <description/> <link project="HiddenProject"/> </project>'
     assert_response 404
 
     login_adrian
     # try to link to an access protected hidden project from sourceaccess project
-    put url_for(controller: :source_project, action: :update_project_meta, project: 'home:adrian:ProtectedProject2'),
+    put url_for(controller: :source_project_meta, action: :update, project: 'home:adrian:ProtectedProject2'),
         params: '<project name="home:adrian:ProtectedProject2"> <title/> <description/> <link project="HiddenProject"/> </project>'
     assert_response 404
-    put url_for(controller: :source_project, action: :update_project_meta, project: 'home:adrian:ProtectedProject2'),
+    put url_for(controller: :source_project_meta, action: :update, project: 'home:adrian:ProtectedProject2'),
         params: '<project name="home:adrian:ProtectedProject2"> <title/> <description/> <link project="HiddenProject"/> </project>'
     assert_response 404
 
-    put url_for(controller: :source_project, action: :update_project_meta, project: 'home:adrian:ProtectedProject2'),
+    put url_for(controller: :source_project_meta, action: :update, project: 'home:adrian:ProtectedProject2'),
         params: '<project name="home:adrian:ProtectedProject2"> <title/> <description/> <sourceaccess><disable/></sourceaccess> </project>'
     assert_response :success
-    put url_for(controller: :source_project, action: :update_project_meta, project: 'home:adrian:ProtectedProject1'),
+    put url_for(controller: :source_project_meta, action: :update, project: 'home:adrian:ProtectedProject1'),
         params: '<project name="home:adrian:ProtectedProject1"> <title/> <description/> </project>'
     assert_response :success
 
     # Allow linking from not sourceaccess protected project to protected own. src.rpms are not delivered by the backend.
     #
-    put url_for(controller: :source_project, action: :update_project_meta, project: 'home:adrian:ProtectedProject1'),
+    put url_for(controller: :source_project_meta, action: :update, project: 'home:adrian:ProtectedProject1'),
         params: '<project name="home:adrian:ProtectedProject1"> <title/> <description/> <link project="home:adrian:ProtectedProject2"/> </project>'
     assert_response :success
 
     # try to link to an access protected hidden project from access hidden project
-    put url_for(controller: :source_project, action: :update_project_meta, project: 'home:adrian:ProtectedProject3'),
+    put url_for(controller: :source_project_meta, action: :update, project: 'home:adrian:ProtectedProject3'),
         params: '<project name="home:adrian:ProtectedProject3"> <title/> <description/> <link project="HiddenProject"/> </project>'
     assert_response 404
 
-    put url_for(controller: :source_project, action: :update_project_meta, project: 'home:adrian:ProtectedProject3'),
+    put url_for(controller: :source_project_meta, action: :update, project: 'home:adrian:ProtectedProject3'),
         params: '<project name="home:adrian:ProtectedProject3"> <title/> <description/> <access><disable/></access> </project>'
     assert_response :success
 
-    put url_for(controller: :source_project, action: :update_project_meta, project: 'home:adrian:ProtectedProject3'),
+    put url_for(controller: :source_project_meta, action: :update, project: 'home:adrian:ProtectedProject3'),
         params: '<project name="home:adrian:ProtectedProject3"> <title/> <description/> <link project="HiddenProject"/> </project>'
     assert_response 404
 
-    put url_for(controller: :source_project, action: :update_project_meta, project: 'home:adrian:ProtectedProject4'),
+    put url_for(controller: :source_project_meta, action: :update, project: 'home:adrian:ProtectedProject4'),
         params: '<project name="home:adrian:ProtectedProject4"> <title/> <description/> <access><disable/></access> </project>'
     assert_response :success
     # rubocop:disable Metrics/LineLength
-    put url_for(controller: :source_project, action: :update_project_meta, project: 'home:adrian:ProtectedProject4'),
+    put url_for(controller: :source_project_meta, action: :update, project: 'home:adrian:ProtectedProject4'),
         params: '<project name="home:adrian:ProtectedProject4"> <title/> <description/> <access><disable/></access> <link project="home:adrian:ProtectedProject2"/> </project>'
     # rubocop:enable Metrics/LineLength
     assert_response :success
@@ -714,7 +714,7 @@ class ReadPermissionTest < ActionDispatch::IntegrationTest
     login_tom
 
     # try to link to an access protected hidden project
-    put url_for(controller: :source_project, action: :update_project_meta, project: 'home:tom:temp2'),
+    put url_for(controller: :source_project_meta, action: :update, project: 'home:tom:temp2'),
         params: '<project name="home:tom:temp2"> <title/> <description/> <link project="HiddenProject"/> </project>'
     assert_response 404
 
@@ -754,7 +754,7 @@ class ReadPermissionTest < ActionDispatch::IntegrationTest
     login_adrian
     get '/source/home:adrian:ProtectedProject'
     assert_response 404
-    put url_for(controller: :source_project, action: :update_project_meta, project: 'home:adrian:ProtectedProject'),
+    put url_for(controller: :source_project_meta, action: :update, project: 'home:adrian:ProtectedProject'),
         params: '<project name="home:adrian:ProtectedProject"> <title/> <description/> <access><disable/></access> </project>'
     assert_response :success
     get '/source/home:adrian:ProtectedProject'
@@ -789,18 +789,18 @@ class ReadPermissionTest < ActionDispatch::IntegrationTest
     prepare_request_with_user 'binary_homer', 'buildservice'
 
     # check if sufficiently protected projects can access protected projects
-    put url_for(controller: :source_project, action: :update_project_meta, project: 'home:binary_homer:ProtectedProject1'),
+    put url_for(controller: :source_project_meta, action: :update, project: 'home:binary_homer:ProtectedProject1'),
         params: '<project name="home:binary_homer:ProtectedProject1"> <title/> <description/> <binarydownload><disable/></binarydownload> </project>'
     assert_response 200
 
     # rubocop:disable Metrics/LineLength
-    put url_for(controller: :source_project, action: :update_project_meta, project: 'home:binary_homer:ProtectedProject1'),
+    put url_for(controller: :source_project_meta, action: :update, project: 'home:binary_homer:ProtectedProject1'),
         params: '<project name="home:binary_homer:ProtectedProject1"> <title/> <description/> <repository name="BinaryprotectedProjectRepo"> <path repository="nada" project="BinaryprotectedProject"/> <arch>i586</arch> </repository> </project>'
     # rubocop:enable Metrics/LineLength
     assert_response 200
 
     # check if sufficiently protected projects can access protected projects
-    put url_for(controller: :source_project, action: :update_project_meta, project: 'home:binary_homer:ProtectedProject2'),
+    put url_for(controller: :source_project_meta, action: :update, project: 'home:binary_homer:ProtectedProject2'),
         params: '<project name="home:binary_homer:ProtectedProject2"> <title/> <description/> </project>'
     assert_response 200
 
@@ -818,7 +818,7 @@ class ReadPermissionTest < ActionDispatch::IntegrationTest
 
     # check if unsufficiently permitted users tries to access protected projects
     # rubocop:disable Metrics/LineLength
-    put url_for(controller: :source_project, action: :update_project_meta, project: 'home:tom:ProtectedProject2'),
+    put url_for(controller: :source_project_meta, action: :update, project: 'home:tom:ProtectedProject2'),
         params: '<project name="home:tom:ProtectedProject2"> <title/> <description/>  <repository name="HiddenProjectRepo"> <path repository="nada" project="HiddenProject"/> <arch>i586</arch> </repository> </project>'
     # rubocop:enable Metrics/LineLength
     assert_response 404
@@ -826,44 +826,44 @@ class ReadPermissionTest < ActionDispatch::IntegrationTest
     # try to access it with a user permitted for access
     login_adrian
 
-    put url_for(controller: :source_project, action: :update_project_meta, project: 'home:adrian:ProtectedProject1'),
+    put url_for(controller: :source_project_meta, action: :update, project: 'home:adrian:ProtectedProject1'),
         params: '<project name="home:adrian:ProtectedProject1"> <title/> <description/> <access><disable/></access> </project>'
     # STDERR.puts(@response.body)
     assert_response 200
 
     # rubocop:disable Metrics/LineLength
-    put url_for(controller: :source_project, action: :update_project_meta, project: 'home:adrian:ProtectedProject1'),
+    put url_for(controller: :source_project_meta, action: :update, project: 'home:adrian:ProtectedProject1'),
         params: '<project name="home:adrian:ProtectedProject1"> <title/> <description/> <repository name="HiddenProjectRepo"> <path repository="nada" project="HiddenProject"/> <arch>i586</arch> </repository> </project>'
     # rubocop:enable Metrics/LineLength
     assert_response 404
 
     # building against
     # rubocop:disable Metrics/LineLength
-    put url_for(controller: :source_project, action: :update_project_meta, project: 'home:adrian:ProtectedProject2'),
+    put url_for(controller: :source_project_meta, action: :update, project: 'home:adrian:ProtectedProject2'),
         params: '<project name="home:adrian:ProtectedProject2"> <title/> <description/> <repository name="HiddenProjectRepo"> <path repository="nada" project="HiddenProject"/> <arch>i586</arch> </repository> </project>'
     # rubocop:enable Metrics/LineLength
     assert_response 404
 
     # check if download protected project has to access protected project, which reveals Hidden project existence to others and is and error
-    put url_for(controller: :source_project, action: :update_project_meta, project: 'home:adrian:ProtectedProject2'),
+    put url_for(controller: :source_project_meta, action: :update, project: 'home:adrian:ProtectedProject2'),
         params: '<project name="home:adrian:ProtectedProject2"> <title/> <description/> <binarydownload><disable/></binarydownload> </project>'
     assert_response 200
 
     # rubocop:disable Metrics/LineLength
-    put url_for(controller: :source_project, action: :update_project_meta, project: 'home:adrian:ProtectedProject2'),
+    put url_for(controller: :source_project_meta, action: :update, project: 'home:adrian:ProtectedProject2'),
         params: '<project name="home:adrian:ProtectedProject2"> <title/> <description/> <repository name="HiddenProjectRepo"> <path repository="nada" project="HiddenProject"/> <arch>i586</arch> </repository> </project>'
     # rubocop:enable Metrics/LineLength
     assert_response 404
 
     # check if access protected project has access binarydownload protected project
     prepare_request_with_user 'binary_homer', 'buildservice'
-    put url_for(controller: :source_project, action: :update_project_meta, project: 'home:binary_homer:ProtectedProject3'),
+    put url_for(controller: :source_project_meta, action: :update, project: 'home:binary_homer:ProtectedProject3'),
         params: '<project name="home:binary_homer:ProtectedProject3"> <title/> <description/> <access><disable/></access> </project>'
     # STDERR.puts(@response.body)
     assert_response 200
 
     # rubocop:disable Metrics/LineLength
-    put url_for(controller: :source_project, action: :update_project_meta, project: 'home:binary_homer:ProtectedProject3'),
+    put url_for(controller: :source_project_meta, action: :update, project: 'home:binary_homer:ProtectedProject3'),
         params: '<project name="home:binary_homer:ProtectedProject3"> <title/> <description/> <repository name="BinaryprotectedProjectRepo"> <path repository="nada" project="BinaryprotectedProject"/> <arch>i586</arch> </repository> </project>'
     # rubocop:enable Metrics/LineLength
     assert_response 200
@@ -955,7 +955,7 @@ class ReadPermissionTest < ActionDispatch::IntegrationTest
   def test_setup_default_project
     # Create public project
     login_adrian
-    put url_for(controller: :source_project, action: :update_project_meta, project: 'home:adrian:Project'),
+    put url_for(controller: :source_project_meta, action: :update, project: 'home:adrian:Project'),
         params: '<project name="home:adrian:Project"> <title/> <description/> </project>'
     assert_response :success
     get '/source/home:adrian:Project/_meta'
@@ -969,14 +969,14 @@ class ReadPermissionTest < ActionDispatch::IntegrationTest
     orig_value = c.default_access_disabled
     c.default_access_disabled = true
     c.save!
-    put url_for(controller: :source_project, action: :update_project_meta, project: 'home:adrian:Project'),
+    put url_for(controller: :source_project_meta, action: :update, project: 'home:adrian:Project'),
         params: '<project name="home:adrian:Project"> <title/> <description/> </project>'
     assert_response :success
     get '/source/home:adrian:Project/_meta'
     assert_response :success
     assert_xml_tag(tag: 'disable', parent: { tag: 'access' })
     # enabling access is not allowed in this mode
-    put url_for(controller: :source_project, action: :update_project_meta, project: 'home:adrian:Project'),
+    put url_for(controller: :source_project_meta, action: :update, project: 'home:adrian:Project'),
         params: '<project name="home:adrian:Project"> <title/> <description/> </project>'
     assert_response 403
     assert_xml_tag tag: 'status', attributes: { code: 'change_project_protection_level' }
@@ -984,7 +984,7 @@ class ReadPermissionTest < ActionDispatch::IntegrationTest
     # enabling access is allowed
     c.default_access_disabled = orig_value
     c.save!
-    put url_for(controller: :source_project, action: :update_project_meta, project: 'home:adrian:Project'),
+    put url_for(controller: :source_project_meta, action: :update, project: 'home:adrian:Project'),
         params: '<project name="home:adrian:Project"> <title/> <description/> </project>'
     assert_response :success
 

--- a/src/api/test/functional/request_controller_test.rb
+++ b/src/api/test/functional/request_controller_test.rb
@@ -3101,7 +3101,7 @@ class RequestControllerTest < ActionDispatch::IntegrationTest
      </repository>
      </project>"
 
-    put url_for(controller: :source_project, action: :update_project_meta, project: 'home:Iggy:todo'), params: meta
+    put url_for(controller: :source_project_meta, action: :update, project: 'home:Iggy:todo'), params: meta
     assert_response :success
 
     meta = "<package name='realfun' project='home:Iggy:todo'><title/><description/></package>"
@@ -3182,7 +3182,7 @@ class RequestControllerTest < ActionDispatch::IntegrationTest
      </repository>
      </project>"
 
-    put url_for(controller: :source_project, action: :update_project_meta, project: 'home:Iggy:todo'), params: meta
+    put url_for(controller: :source_project_meta, action: :update, project: 'home:Iggy:todo'), params: meta
     assert_response :success
 
     meta = "<package name='realfun' project='home:Iggy:todo'><title/><description/></package>"


### PR DESCRIPTION
third iteration of source_controller refactoring. Now I moved the "project meta" related code from ```source_project_controller``` to its own controller ```source_project_meta_controller```. 
minispec and rspec suites were updated too. 