### PR TITLE
[frontend] Use mtime to show last deployment time

### DIFF
--- a/src/api/config/initializers/git.rb
+++ b/src/api/config/initializers/git.rb
@@ -1,7 +1,7 @@
 module Git
   if File.exist?(File.join(Rails.root, 'last_deploy'))
     COMMIT = File.open(File.join(Rails.root, 'last_deploy'), 'r') { |f| GIT_REVISION = f.gets.try(:chomp) }
-    LAST_DEPLOYMENT = File.new(File.join(Rails.root, 'last_deploy')).atime
+    LAST_DEPLOYMENT = File.new(File.join(Rails.root, 'last_deploy')).mtime
   else
     COMMIT = %x(SHA1=$(git rev-parse --short HEAD 2> /dev/null); if [ $SHA1 ]; then echo $SHA1; else echo ''; fi).chomp
     LAST_DEPLOYMENT = ''.freeze


### PR DESCRIPTION
instead of the atime (access time).
This caused to show wrong timestamps for the last deployment time.