### PR TITLE
Introduces switch to a new layout

### DIFF
--- a/src/api/Gemfile
+++ b/src/api/Gemfile
@@ -188,11 +188,11 @@ group :assets do
   # assets for jQuery and jQuery-ujs
   gem 'jquery-rails'
   # assets for jQuery-ui
-  gem 'jquery-ui-rails', '~> 4.2.1' # version 5 needs henne's new webui
-  # assets for the bootstrap front-end framework. Used by the bratwurst theme
-  # gem 'bootstrap-sass-rails'
+  gem 'jquery-ui-rails', '~> 4.2.1'
+  # assets for the bootstrap front-end framework
+  gem 'bootstrap'
   # assets for font-awesome vector icons
-  gem 'font-awesome-rails'
+  gem 'font-awesome-sass'
   # assets for formatting dates
   gem 'momentjs-rails'
 end

--- a/src/api/Gemfile.lock
+++ b/src/api/Gemfile.lock
@@ -59,7 +59,13 @@ GEM
     ansi (1.5.0)
     arel (9.0.0)
     ast (2.4.0)
+    autoprefixer-rails (8.6.2)
+      execjs
     bcrypt (3.1.12)
+    bootstrap (4.1.1)
+      autoprefixer-rails (>= 6.0.3)
+      popper_js (>= 1.12.9, < 2)
+      sass (>= 3.5.2)
     builder (3.2.3)
     bullet (5.7.5)
       activesupport (>= 3.0.0)
@@ -129,8 +135,8 @@ GEM
     ffi (1.9.25)
     flot-rails (0.0.7)
       jquery-rails
-    font-awesome-rails (4.7.0.4)
-      railties (>= 3.2, < 6.0)
+    font-awesome-sass (5.0.13)
+      sassc (>= 1.11)
     globalid (0.4.1)
       activesupport (>= 4.2.0)
     gssapi (1.2.0)
@@ -241,6 +247,7 @@ GEM
       capybara (>= 2.1, < 4)
       cliver (~> 0.3.1)
       websocket-driver (>= 0.2.0)
+    popper_js (1.12.9)
     power_assert (1.1.2)
     powerpack (0.1.2)
     pry (0.11.3)
@@ -350,6 +357,10 @@ GEM
       sprockets (>= 2.8, < 4.0)
       sprockets-rails (>= 2.0, < 4.0)
       tilt (>= 1.1, < 3)
+    sassc (1.11.4)
+      bundler
+      ffi (~> 1.9.6)
+      sass (>= 3.3.0)
     shoulda-matchers (3.1.2)
       activesupport (>= 4.0.0)
     simplecov (0.16.1)
@@ -423,6 +434,7 @@ DEPENDENCIES
   airbrake (<= 7.1.0)
   airbrake-ruby (<= 2.5.0)
   bcrypt
+  bootstrap
   bullet
   bunny
   capybara
@@ -445,7 +457,7 @@ DEPENDENCIES
   faker
   feature
   flot-rails
-  font-awesome-rails
+  font-awesome-sass
   gssapi
   haml
   haml_lint

--- a/src/api/app/assets/javascripts/webui2/application.js
+++ b/src/api/app/assets/javascripts/webui2/application.js
@@ -1,0 +1,17 @@
+// This is a manifest file that'll be compiled into application.js, which will include all the files
+// listed below.
+//
+// Any JavaScript/Coffee file within this directory, lib/assets/javascripts, vendor/assets/javascripts,
+// or vendor/assets/javascripts of plugins, if any, can be referenced here using a relative path.
+//
+// It's not advisable to add code directly here, but if you do, it'll appear at the bottom of the
+// the compiled file.
+//
+// WARNING: THE FIRST BLANK LINE MARKS THE END OF WHAT'S TO BE PROCESSED, ANY BLANK LINE SHOULD
+// GO AFTER THE REQUIRES BELOW.
+//
+//= require jquery3
+//= require jquery_ujs
+//= require peek
+//= require popper
+//= require bootstrap

--- a/src/api/app/assets/stylesheets/webui2/sticky-footer.scss
+++ b/src/api/app/assets/stylesheets/webui2/sticky-footer.scss
@@ -5,3 +5,7 @@ body {
 .flex-grow {
   flex: 1;
 }
+
+#footer {
+  background-color: $gray-200;
+}

--- a/src/api/app/assets/stylesheets/webui2/sticky-footer.scss
+++ b/src/api/app/assets/stylesheets/webui2/sticky-footer.scss
@@ -1,0 +1,7 @@
+// Sticky footer
+body {
+  min-height: 100vh;
+}
+.flex-grow {
+  flex: 1;
+}

--- a/src/api/app/assets/stylesheets/webui2/webui2.css.scss
+++ b/src/api/app/assets/stylesheets/webui2/webui2.css.scss
@@ -1,0 +1,24 @@
+/*
+ * This is a manifest file that'll be compiled into application.css, which will include all the files
+ * listed below.
+ *
+ * Any CSS and SCSS file within this directory, lib/assets/stylesheets, vendor/assets/stylesheets,
+ * or vendor/assets/stylesheets of plugins, if any, can be referenced here using a relative path.
+ *
+ * You're free to add application-wide styles to this file and they'll appear at the top of the
+ * compiled file, but it's generally better to create a new file per style scope.
+ *
+ *= require peek
+*/
+
+$link-color: #690;
+$link-hover-color: #39c;
+$headings-color: $link-color;
+$gray-100: #f8f9fa;
+$body-bg: $gray-100;
+$gray-200: #e9ecef;
+
+@import "font-awesome-sprockets";
+@import 'font-awesome';
+@import 'bootstrap';
+@import 'sticky-footer';

--- a/src/api/app/controllers/webui/webui_controller.rb
+++ b/src/api/app/controllers/webui/webui_controller.rb
@@ -4,6 +4,8 @@
 require_dependency 'authenticator'
 
 class Webui::WebuiController < ActionController::Base
+  layout :choose_layout
+
   helper_method :valid_xml_id
 
   Rails.cache.set_domain if Rails.cache.respond_to?('set_domain')
@@ -305,5 +307,24 @@ class Webui::WebuiController < ActionController::Base
     @dialog_html = ActionController::Base.helpers.escape_javascript(render_to_string(partial: action_name))
     @dialog_init = dialog_init
     render partial: 'dialog', content_type: 'application/javascript'
+  end
+
+  def switch_to_webui2?
+    User.current && (User.current.is_admin? || User.current.is_staff?)
+  end
+
+  def choose_layout
+    @switch_to_webui2 ? 'webui2/webui' : 'webui/webui'
+  end
+
+  def switch_to_webui2
+    if switch_to_webui2?
+      @switch_to_webui2 = true
+      prepend_view_path('app/views/webui2')
+      prefixed_action_name = "webui2_#{action_name}"
+      send(prefixed_action_name) if action_methods.include?(prefixed_action_name)
+      return true
+    end
+    @switch_to_webui2 = false
   end
 end

--- a/src/api/app/controllers/webui/webui_controller.rb
+++ b/src/api/app/controllers/webui/webui_controller.rb
@@ -14,6 +14,7 @@ class Webui::WebuiController < ActionController::Base
   protect_from_forgery
 
   before_action :setup_view_path
+  before_action :set_breadcrumbs
   before_action :check_user
   before_action :check_anonymous
   before_action :require_configuration
@@ -326,5 +327,12 @@ class Webui::WebuiController < ActionController::Base
       return true
     end
     @switch_to_webui2 = false
+  end
+
+  def set_breadcrumbs
+    name = @configuration ? @configuration['title'] : 'Open Build Service'
+    @breadcrumbs = [
+      { name: name, path: root_path }
+    ]
   end
 end

--- a/src/api/app/views/layouts/webui2/_breadcrumbs.html.haml
+++ b/src/api/app/views/layouts/webui2/_breadcrumbs.html.haml
@@ -1,0 +1,10 @@
+%nav{"aria-label" => "breadcrumb"}
+  %ol.breadcrumb.bg-light
+    - @breadcrumbs.each do |breadcrumb|
+      %li.breadcrumb-item{class: @breadcrumbs.last == breadcrumb && 'active' , "aria-current" => "page"}
+        - if breadcrumb == @breadcrumbs.first
+          %i.fas.fa-home
+        - if breadcrumb[:path]
+          = link_to breadcrumb[:name], breadcrumb[:path]
+        - else
+          = breadcrumb[:name]

--- a/src/api/app/views/layouts/webui2/_flash.html.haml
+++ b/src/api/app/views/layouts/webui2/_flash.html.haml
@@ -1,0 +1,27 @@
+- [:success, :error, :alert, :notice].each do |flash_type|
+  - if (flash[flash_type] && !flash[flash_type].empty?)
+    - case flash_type
+    - when :error
+      - flash_icon = 'times'
+      - flash_header = 'danger'
+    - when :alert
+      - flash_icon = 'exclamation-triangle'
+      - flash_header = 'warning'
+    - when :success
+      - flash_icon = 'thumbs-up'
+      - flash_header = 'success'
+    - when :notice
+      - flash_icon = 'info-circle'
+      - flash_header = 'info'
+    %div{ class: "alert alert-#{flash_header} alert-dismissible fade show" }
+      %i{ class: "fas fa-#{flash_icon}" }
+      = flash_content(flash[flash_type])
+      = link_to 'more info', '#', class: 'btn-more' if @more_info
+      - if @more_info
+        .more_info.hidden
+          %div{ class: flash_header }
+          .more-info-content
+            = simple_format @more_info.gsub(/\\n/, '<br \>')
+      %button.close{type: "button", "data-dismiss": "alert", "aria-label": "Close"}
+        %span{"aria-hidden": "true"}
+          &times;

--- a/src/api/app/views/layouts/webui2/_footer.html.haml
+++ b/src/api/app/views/layouts/webui2/_footer.html.haml
@@ -1,0 +1,49 @@
+.row
+  - if User.current && !User.current.is_nobody?
+    .col
+      %strong
+        = User.current
+      %ul
+        %li= link_to "Your Profile", user_show_path(User.current)
+        - if User.current.home_project
+          %li= link_to "Home Project", project_show_path(User.current.home_project)
+        - else
+          %li= link_to "Create Home Project", new_project_path(name: User.current.home_project_name)
+        %li= link_to 'Logout', session_destroy_path, method: :delete
+  - if ::Configuration.anonymous
+    .col
+      %strong Locations
+      %ul
+        %li= link_to "Projects", projects_path
+        %li= link_to "Search", search_path, class: 'search-link'
+        - unless @spider_bot
+          %li= link_to "Status Monitor", monitor_path
+  .col
+    %strong Help
+    %ul
+      %li
+        %a{href: 'http://openbuildservice.org/'} Open Build Service
+      %li
+        %a{href: 'http://openbuildservice.org/help/manuals/'} OBS Manuals
+      %li
+        %a{href: 'http://en.opensuse.org/Portal:Build_service'} openSUSEs OBS Portal
+      %li
+        %a{href: 'http://openbuildservice.org/support/'} Reporting a Bug
+  .col
+    %strong Contact
+    %ul
+      %li
+        %a{href: 'http://lists.opensuse.org/opensuse-buildservice/'} Mailing List
+      %li
+        %a{href: 'http://forums.opensuse.org/forumdisplay.php/692-Open-Build-Service-%28OBS%29'} Forums
+      %li
+        %a{href: 'irc://irc.opensuse.org/opensuse-buildservice'} Chat (IRC)
+      %li
+        %a{href: 'http://twitter.com/OBShq'} Twitter
+.row#footer-legal
+  .col
+    %p.text-center
+      %a{href: "http://openbuildservice.org"} Open Build Service (OBS)
+      is an
+      = succeed "." do
+        %a{href: "http://www.opensuse.org"} openSUSE project

--- a/src/api/app/views/layouts/webui2/_navigation.html.haml
+++ b/src/api/app/views/layouts/webui2/_navigation.html.haml
@@ -1,0 +1,14 @@
+%nav.navbar.navbar-expand-lg.navbar-dark.bg-dark
+  = link_to root_path, { class: 'navbar-brand', alt: 'Logo' } do
+    = image_tag('obs-logo_small.png', height: '30' )
+  %button.navbar-toggler{ 'type': "button", 'data-toggle': "collapse", 'data-target': "#global-navigation", 'aria-controls': "global-navigation", 'aria-expanded': "false", 'aria-label': "Toggle navigation"}
+    %span.navbar-toggler-icon
+  .collapse.navbar-collapse#global-navigation
+    %ul.navbar-nav.ml-auto
+      - unless User.current.is_nobody?
+        %li.nav-item.dropdown.d-none.d-sm-block
+          = render partial: 'layouts/webui2/watchlist_dropdown'
+    %ul.navbar-nav.d-block.d-sm-none
+      = render partial: "layouts/webui2/personal_navigation"
+      = render partial: 'layouts/webui2/watchlist'
+    = render partial: 'layouts/webui2/search'

--- a/src/api/app/views/layouts/webui2/_personal_navigation.html.haml
+++ b/src/api/app/views/layouts/webui2/_personal_navigation.html.haml
@@ -5,7 +5,7 @@
   %li.nav-item
     - tasks = User.current.tasks
     = link_to(user_tasks_path, class: 'nav-link') do
-      - if tasks > 0
+      - if tasks.positive?
         %span{title: 'where an action is requested from you' }
           = pluralize(tasks, 'Task')
       - else

--- a/src/api/app/views/layouts/webui2/_personal_navigation.html.haml
+++ b/src/api/app/views/layouts/webui2/_personal_navigation.html.haml
@@ -1,0 +1,61 @@
+- if User.current && !User.current.is_nobody?
+  %li.nav-item
+    = link_to(home_path, id: 'link-to-user-home', class: 'nav-link') do
+      = User.current.login
+  %li.nav-item
+    - tasks = User.current.tasks
+    = link_to(user_tasks_path, class: 'nav-link') do
+      - if tasks > 0
+        %span{title: 'where an action is requested from you' }
+          = pluralize(tasks, 'Task')
+      - else
+        Tasks
+  %li.nav-item
+    - if User.current.home_project
+      = link_to(project_show_path(User.current.home_project), class: 'nav-link') do
+        Home Project
+    - else
+      = link_to(new_project_path(name: User.current.home_project_name), class: 'nav-link') do
+        Create Home
+  %li.nav-item
+    = link_to(session_destroy_path, method: :delete, id: 'logout-link', class: 'nav-link') do
+      Logout
+- elsif CONFIG['kerberos_mode']
+  = link_to 'Log In', session_new_path
+- else
+  - if CONFIG['proxy_auth_mode'] == :on
+    - unless CONFIG['proxy_auth_register_page'].blank?
+      %li
+        = link_to 'Sign Up', "#{CONFIG['proxy_auth_register_page']}?%22"
+    %li
+      = link_to 'Log In', session_new_path, id: 'login-trigger'
+    %li
+    .login-form
+      = form_tag(CONFIG['proxy_auth_login_page'], method: :post, id: 'login_form', enctype: 'application/x-www-form-urlencoded') do
+        %p
+          = hidden_field_tag(:context, 'default')
+          = hidden_field_tag(:proxypath, 'reserve')
+          = hidden_field_tag(:message, 'Please log in')
+          = hidden_field_tag(:url, request.fullpath)
+          = label_tag(:username, 'Username')
+          = text_field_tag(:username, '')
+        %p
+          = label_tag(:password, 'Password')
+          = password_field_tag(:password, '')
+        %p= submit_tag('Log In', onclick: 'fillEmptyFields();')
+        %p.slim-footer= link_to('Cancel', '#', id: 'close-login')
+  - else
+    - if can_register
+      = link_to 'Sign Up', user_register_user_path
+      |
+    = link_to 'Log In', session_new_path, id: 'login-trigger'
+    #login-form
+      = form_tag(session_create_path) do
+        %p
+          = label_tag(:username, 'Username')
+          = text_field_tag(:username, '')
+        %p
+          = label_tag(:password, 'Password')
+          = password_field_tag(:password, '')
+        %p= submit_tag('Log In')
+        %p.slim-footer= link_to('Cancel', '#', id: 'close-login')

--- a/src/api/app/views/layouts/webui2/_search.html.haml
+++ b/src/api/app/views/layouts/webui2/_search.html.haml
@@ -1,0 +1,2 @@
+= form_tag(search_path(project: 1, package: 1, name: 1), { id: 'global-search-form', class: 'form-inline' }) do
+  %input.form-control.mr-sm-2{"aria-label": "Search", placeholder: "Search", type: "text"}/

--- a/src/api/app/views/layouts/webui2/_watchlist.html.haml
+++ b/src/api/app/views/layouts/webui2/_watchlist.html.haml
@@ -11,7 +11,3 @@
     %li
       = link_to project_show_path(project), class: 'nav-link' do
         = raw(project.gsub(':', ':<wbr>'))
-
-
-
-

--- a/src/api/app/views/layouts/webui2/_watchlist.html.haml
+++ b/src/api/app/views/layouts/webui2/_watchlist.html.haml
@@ -1,0 +1,17 @@
+%span.navbar-text.h6
+  Watchlist
+- if @project
+  = link_to(project_toggle_watch_path(@project), class: 'nav-link') do
+    - if User.current.watches?(@project)
+      Remove Project #{@project}
+    - else
+      Add Project
+%ul
+  - User.current.watched_project_names.each do |project|
+    %li
+      = link_to project_show_path(project), class: 'nav-link' do
+        = raw(project.gsub(':', ':<wbr>'))
+
+
+
+

--- a/src/api/app/views/layouts/webui2/_watchlist_dropdown.html.haml
+++ b/src/api/app/views/layouts/webui2/_watchlist_dropdown.html.haml
@@ -1,0 +1,23 @@
+%button.btn.btn-link.nav-link.dropdown-toggle#watchlist{"aria-expanded": "false", "aria-haspopup": "true", "data-toggle": "dropdown", "data-offset": 150}
+  Watchlist
+.dropdown-menu{"aria-labelledby": "watchlist"}
+  .dropdown-header
+    List of projects you are watching
+  .dropdown-divider
+  - if params[:project]
+    %a.dropdown-item{ href: project_toggle_watch_path(params[:project]) }
+      - if User.current.watches? params[:project]
+        %p.mb-0
+          Remove this project from Watchlist
+        %small.text-muted
+          Do not watch this project anymore
+      - else
+        %p.mb-0
+          Add this project to Watchlist
+        %small.text-muted
+          Watch this project
+    .dropdown-divider
+  - User.current.watched_project_names.each do |project|
+    = link_to project_show_path(project), class: 'dropdown-item' do
+      %span.icons-project
+      = raw(project.gsub(':', ':<wbr>'))

--- a/src/api/app/views/layouts/webui2/webui.html.haml
+++ b/src/api/app/views/layouts/webui2/webui.html.haml
@@ -1,0 +1,38 @@
+!!!
+%html{lang: "en"}
+  %head
+    %meta{content: "charset=utf-8"}/
+    %meta{name: "viewport", content: "width=device-width, initial-scale=1, shrink-to-fit=no"}
+    - if @metarobots
+      %meta{:content => "#{@metarobots}", :name => "robots"}/
+    = favicon_link_tag
+    %title
+      = "#{@pagetitle} - " if @pagetitle
+      = @configuration ? @configuration['title'] : 'Open Build Service'
+    = stylesheet_link_tag 'webui2/webui2'
+    = javascript_include_tag 'webui2/application'
+    = auto_discovery_link_tag(:rss, news_feed_path(format: 'rss'), {:title => 'News'})
+    = csrf_meta_tag
+    - if User.current.try(:rss_token)
+      = auto_discovery_link_tag(:rss, user_rss_notifications_url(token: User.current.rss_token.string, format: :rss), { title: 'Notifications' })
+  %body.d-flex.flex-column
+    .container-fluid#peek
+      = render 'peek/bar'
+    #navigation
+      = render partial: 'layouts/webui2/navigation'
+    .w-100.m-2
+    .container.d-none.d-sm-block#personal-navigation
+      .row
+        .col-12
+          %nav.nav.justify-content-end.nav-pills
+            = render partial: "layouts/webui2/personal_navigation"
+    - unless flash.blank?
+      .container#flash
+        .row.justify-content-center
+          .col-12
+            = render partial: "layouts/webui2/flash", object: flash
+    .container.flex-grow#content
+      = yield
+    .container-fluid.bg-light.py-4.mt-4#footer
+      .container
+        = render partial: 'layouts/webui2/footer'

--- a/src/api/app/views/layouts/webui2/webui.html.haml
+++ b/src/api/app/views/layouts/webui2/webui.html.haml
@@ -23,8 +23,10 @@
     .w-100.m-2
     .container.d-none.d-sm-block#personal-navigation
       .row
-        .col-12
-          %nav.nav.justify-content-end.nav-pills
+        .col-6
+          = render partial: "layouts/webui2/breadcrumbs"
+        .col-6
+          %nav.nav.nav-pills.justify-content-end
             = render partial: "layouts/webui2/personal_navigation"
     - unless flash.blank?
       .container#flash
@@ -33,6 +35,6 @@
             = render partial: "layouts/webui2/flash", object: flash
     .container.flex-grow#content
       = yield
-    .container-fluid.bg-light.py-4.mt-4#footer
+    .container-fluid.py-4.mt-4#footer
       .container
         = render partial: 'layouts/webui2/footer'

--- a/src/api/config/initializers/assets.rb
+++ b/src/api/config/initializers/assets.rb
@@ -8,4 +8,4 @@ Rails.application.config.assets.version = '1.0'
 
 # Precompile additional assets.
 # application.js, application.css, and all non-JS/CSS in app/assets folder are already added.
-# Rails.application.config.assets.precompile += %w( search.js )
+Rails.application.config.assets.precompile += ['webui2/webui2.css', 'webui2/application.js']


### PR DESCRIPTION
For certain actions and certain users we want to switch to a new bootstrap
based layout while for everyone else things should stay the same.

Adding the `switch_to_webui2` method to a controllers `index` action will

1. switch the layout to bootstrap
2. switch the view path to files below `app/views/webui2`
3. call the `webui2_index` method of the controller (if it exists)

That means you are flexible to overwrite only how the action is rendered (by
adding `switch_to_webui2` to the end of your controller method) or can also
overwrite what you do in the action (by putting it on the top of your method).

Co-authored-by: Henne Vogelsang <hvogel@opensuse.org>
Co-authored-by: Moises Deniz Aleman <mdeniz@suse.com>
Co-authored-by: Stasiek Michalski <hellcp@opensuse.org>