### PR TITLE
[ci] Update airbrake-ruby gem

### DIFF
--- a/src/api/Gemfile
+++ b/src/api/Gemfile
@@ -11,9 +11,8 @@ gem 'nokogiri'
 # for delayed tasks
 gem 'delayed_job_active_record', '>= 4.0.0'
 # to fill errbit
-gem 'airbrake', '<= 7.1.0'
-# Due to a bug in Errbit we need to use 2.5.0 -> https://github.com/errbit/errbit/pull/1237
-gem 'airbrake-ruby', '<= 2.5.0'
+gem 'airbrake'
+gem 'airbrake-ruby'
 # as JSON library - the default json conflicts with activerecord (by means of vice-versa monkey patching)
 gem 'yajl-ruby', require: 'yajl/json_gem'
 # to search the database

--- a/src/api/Gemfile.lock
+++ b/src/api/Gemfile.lock
@@ -54,7 +54,7 @@ GEM
       public_suffix (>= 2.0.2, < 4.0)
     airbrake (7.1.0)
       airbrake-ruby (~> 2.5)
-    airbrake-ruby (2.5.0)
+    airbrake-ruby (2.10.0)
     amq-protocol (2.3.0)
     ansi (1.5.0)
     arel (9.0.0)
@@ -420,8 +420,8 @@ DEPENDENCIES
   acts_as_list
   acts_as_tree
   addressable
-  airbrake (<= 7.1.0)
-  airbrake-ruby (<= 2.5.0)
+  airbrake
+  airbrake-ruby
   bcrypt
   bullet
   bunny


### PR DESCRIPTION
Now that errbit have been released (it only took some months :rofl:) we should be able to update airbrake-ruby to last version:

https://github.com/errbit/errbit/issues/1247

:tada: :tada: 

There is already a package: https://build.opensuse.org/package/show/devel:languages:ruby:extensions/rubygem-airbrake-ruby