### PR TITLE
[api] require builder gem to avoid issues in the development environment

### DIFF
--- a/src/api/Gemfile
+++ b/src/api/Gemfile
@@ -73,6 +73,8 @@ gem 'bunny'
 gem 'data_migrate', '= 4.0.0'
 # for URI encoding
 gem 'addressable'
+# for XML builder
+gem 'builder'
 
 group :development, :production do
   # to have the delayed job daemon


### PR DESCRIPTION
since I moved the XML Builder from controller to the view https://github.com/openSUSE/open-build-service/commit/ae0966968b96378926076e4f88c4a7e48acae9f5#diff-ef87c76ec3b8d2870b8ddcf9fb2389c1L880 and the eager load in the development environment is turned off, if we try to call the action source#global_branch (which calls branch_package#report_dryrun, the frontend server explodes with the following backtrace:


```
frontend_1  | 08:55:54 web.1         | 
frontend_1  | 08:55:54 web.1         | [a6ce1db3-e142-453d-aa95-8468552b51a8] [62:3563.07]   
frontend_1  | 08:55:54 web.1         | [a6ce1db3-e142-453d-aa95-8468552b51a8] [62:3563.07] NameError (uninitialized constant Builder::XmlMarkup):
frontend_1  | 08:55:54 web.1         | [a6ce1db3-e142-453d-aa95-8468552b51a8] [62:3563.07]   
frontend_1  | 08:55:54 web.1         | [a6ce1db3-e142-453d-aa95-8468552b51a8] [62:3563.07] app/models/branch_package.rb:251:in `report_dryrun'
frontend_1  | 08:55:54 web.1         | [a6ce1db3-e142-453d-aa95-8468552b51a8] app/models/branch_package.rb:88:in `branch'
frontend_1  | 08:55:54 web.1         | [a6ce1db3-e142-453d-aa95-8468552b51a8] app/controllers/source_controller.rb:1310:in `private_branch_command'
frontend_1  | 08:55:54 web.1         | [a6ce1db3-e142-453d-aa95-8468552b51a8] app/controllers/source_controller.rb:613:in `global_command_branch'
frontend_1  | 08:55:54 web.1         | [a6ce1db3-e142-453d-aa95-8468552b51a8] config/initializers/wrap_parameters.rb:38:in `call'
```

adding a ```require builder``` on ```source_controller.rb``` or ```branch_package.rb``` or a ```gem 'bundle'``` in the development environment seems to fix it.

### How to reproduce it:

#### local:

having a local development project configured with a maintained project and package:

```
vpereira@kimura:~> osc -A http://127.0.0.1:3000 maintained hello
WARNING: SSL certificate checks disabled. Connection is insecure!

Traceback (most recent call last):
  File "/usr/bin/osc", line 41, in <module>
    r = babysitter.run(osccli)
  File "/usr/lib/python2.7/site-packages/osc/babysitter.py", line 61, in run
    return prg.main(argv)
  File "/usr/lib/python2.7/site-packages/osc/cmdln.py", line 344, in main
    return self.cmd(args)
  File "/usr/lib/python2.7/site-packages/osc/cmdln.py", line 367, in cmd
    retval = self.onecmd(argv)
  File "/usr/lib/python2.7/site-packages/osc/cmdln.py", line 501, in onecmd
    return self._dispatch_cmd(handler, argv)
  File "/usr/lib/python2.7/site-packages/osc/cmdln.py", line 1232, in _dispatch_cmd
    return handler(argv[0], opts, *args)
  File "/usr/lib/python2.7/site-packages/osc/commandline.py", line 3272, in do_mbranch
    package, tproject, noaccess = opts.noaccess, nodevelproject=opts.nodevelproject, dryrun=opts.dryrun)
  File "/usr/lib/python2.7/site-packages/osc/core.py", line 5241, in attribute_branch_pkg
    root = ET.fromstring(e.read())
  File "<string>", line 124, in XML
cElementTree.ParseError: mismatched tag: line 2976, column 616
```

after requiring the ```builder``` gem 

```
vpereira@kimura:~> osc -A http://127.0.0.1:3000 maintained hello
WARNING: SSL certificate checks disabled. Connection is insecure!

openSUSE:Leap:42.3:Update/hello
```

#### production:

```
vpereira@kimura:~> osc maintained hello
openSUSE:Leap:15.0:Update/hello
openSUSE:Leap:42.3:Update/hello
vpereira@kimura:~> 
```
