### PR TITLE
[ci][frontend] Remove .bundle & vendor/bundle dirs after CI run

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -71,7 +71,5 @@ nbproject
 *.iws
 .idea/
 .kanku/
-src/api/.bundle/
-src/api/vendor/bundle
 dist/aws_credentials
 dist/ec2utils.conf

--- a/contrib/start_lint
+++ b/contrib/start_lint
@@ -6,3 +6,4 @@ echo "Preparing application..."
 bundle exec rake dev:prepare RAILS_ENV=test
 echo "Running linter..."
 bundle exec rake dev:lint RAILS_ENV=test
+rm -rf .bundle vendor/bundle

--- a/contrib/start_minitest
+++ b/contrib/start_minitest
@@ -6,3 +6,4 @@ bundle exec rake dev:bootstrap[old_test_suite] RAILS_ENV=test
 echo "Running api test suite..."
 export NO_MEMCACHED=1
 bundle exec rake test:api
+rm -rf .bundle vendor/bundle

--- a/contrib/start_rspec
+++ b/contrib/start_rspec
@@ -5,3 +5,4 @@ echo "Preparing application..."
 bundle exec rake dev:bootstrap RAILS_ENV=test
 echo "Running rspec..."
 bundle exec rspec
+rm -rf .bundle vendor/bundle

--- a/contrib/start_spider
+++ b/contrib/start_spider
@@ -6,3 +6,4 @@ bundle exec rake dev:bootstrap[old_test_suite] RAILS_ENV=test
 echo "Running spider test..."
 export NO_MEMCACHED=1
 bundle exec rake test:spider
+rm -rf .bundle vendor/bundle


### PR DESCRIPTION
because the CI containers install into vendor/bundle and create a bundle config.
This causes gem installation failures in the development container.

We also remove this directories from the .gitignore so that we recognize if something is
odd with the development setup.