### PR TITLE
[frontend] Update Gemfile.lock

### DIFF
--- a/src/api/Gemfile.lock
+++ b/src/api/Gemfile.lock
@@ -430,6 +430,7 @@ DEPENDENCIES
   airbrake-ruby (<= 2.5.0)
   bcrypt
   bootstrap
+  builder
   bullet
   bunny
   capybara


### PR DESCRIPTION
We updated the Gemfile by explicitly adding builder there. Since we've
already been using builder and thus having it in Gemfile.lock, we
didn't update our bundle.
But apperently we should have^^

Follow up of 518225f4b3e6c91ed121097af225706164034f52.