### PR TITLE
[frontend] Refactor Package#last_build_reason

### DIFF
--- a/src/api/app/controllers/webui/packages/build_reason_controller.rb
+++ b/src/api/app/controllers/webui/packages/build_reason_controller.rb
@@ -8,7 +8,7 @@ module Webui
 
       def index
         @details = @package.last_build_reason(@repository, @architecture.name, @package_name)
-        return if @details.explain
+        return if @details.explain.present?
 
         redirect_back(fallback_location: package_binaries_path(package: @package, project: @project, repository: @repository.name),
                       notice: "No build reason found for #{@repository.name}:#{@architecture.name}")

--- a/src/api/app/models/package.rb
+++ b/src/api/app/models/package.rb
@@ -1442,15 +1442,14 @@ class Package < ApplicationRecord
   def last_build_reason(repo, arch, package_name = nil)
     repo = repo.name if repo.is_a? Repository
 
-    xml_data = Nokogiri::XML(BuildReasonFile.new(
+    xml_data = BuildReasonFile.new(
       project_name: project.name,
       package_name: package_name || name,
       repo: repo,
       arch: arch
-    ).to_s).xpath('reason')
+    )
 
-    data = Hash.from_xml(xml_data.to_s)['reason']
-
+    data = Xmlhash.parse(xml_data.to_s)
     # ensure that if 'packagechange' exists, it is an Array and not a Hash
     # Bugreport: https://github.com/openSUSE/open-build-service/issues/3230
     data['packagechange'] = [data['packagechange']] if data && data['packagechange'].is_a?(Hash)

--- a/src/api/spec/controllers/webui/packages/build_reason_controller_spec.rb
+++ b/src/api/spec/controllers/webui/packages/build_reason_controller_spec.rb
@@ -57,7 +57,7 @@ RSpec.describe Webui::Packages::BuildReasonController, type: :controller, vcr: t
         get :index, params: valid_request_params
       end
 
-      it { expect(flash[:notice]).not_to be_empty }
+      it { expect(flash[:notice]).not_to be_blank }
       it 'should redirect to package_binaries_path' do
         expect(response).to redirect_to(package_binaries_path(package: package,
                                                               project: source_project, repository: repo_for_source_project.name))


### PR DESCRIPTION
We've been temporarely converting the xml string, eg. '<a></b>' to
a Nokogiri::XML object before creating a hash from it.
By using Xmlhash#parse we can skip the intermediate step and directly
create a hash.
This reduces the code and slightly improves the performance of that
method.