### PR TITLE
[ci] Return test exit status from Travis start scripts

### DIFF
--- a/contrib/start_lint
+++ b/contrib/start_lint
@@ -6,6 +6,6 @@ echo "Preparing application..."
 bundle exec rake dev:prepare RAILS_ENV=test
 echo "Running linter..."
 bundle exec rake dev:lint RAILS_ENV=test
-if ! [ -z "$CI" ]; then
-  rm -rf .bundle vendor/bundle
-fi
+tmp_exit=$?
+rm -rf .bundle vendor/bundle
+exit $tmp_exit

--- a/contrib/start_minitest
+++ b/contrib/start_minitest
@@ -6,6 +6,6 @@ bundle exec rake dev:bootstrap[old_test_suite] RAILS_ENV=test
 echo "Running api test suite..."
 export NO_MEMCACHED=1
 bundle exec rake test:api
-if ! [ -z "$CI" ]; then
-  rm -rf .bundle vendor/bundle
-fi
+tmp_exit=$?
+rm -rf .bundle vendor/bundle
+exit $tmp_exit

--- a/contrib/start_rspec
+++ b/contrib/start_rspec
@@ -5,6 +5,6 @@ echo "Preparing application..."
 bundle exec rake dev:bootstrap RAILS_ENV=test
 echo "Running rspec..."
 bundle exec rspec
-if ! [ -z "$CI" ]; then
-  rm -rf .bundle vendor/bundle
-fi
+tmp_exit=$?
+rm -rf .bundle vendor/bundle
+exit $tmp_exit

--- a/contrib/start_spider
+++ b/contrib/start_spider
@@ -6,6 +6,6 @@ bundle exec rake dev:bootstrap[old_test_suite] RAILS_ENV=test
 echo "Running spider test..."
 export NO_MEMCACHED=1
 bundle exec rake test:spider
-if ! [ -z "$CI" ]; then
-  rm -rf .bundle vendor/bundle
-fi
+tmp_exit=$?
+rm -rf .bundle vendor/bundle
+exit $tmp_exit

--- a/src/api/spec/controllers/source_project_config_controller_spec.rb
+++ b/src/api/spec/controllers/source_project_config_controller_spec.rb
@@ -13,6 +13,7 @@ RSpec.describe SourceProjectConfigController, vcr: true do
 
       it { expect(response).to be_success }
     end
+
     context 'when the project doesnt exist' do
       before do
         login user
@@ -30,6 +31,7 @@ RSpec.describe SourceProjectConfigController, vcr: true do
         put :update, params: { project: remote_project.name,
              comment: 'Updated by test', format: :xml }
       end
+
       it { expect(response).to be_forbidden }
     end
 


### PR DESCRIPTION
otherwise the container exits successfully. This makes it work in Travis and locally.

Co-authored-by: Victor Pereira <vpereirabr@gmail.com>