### PR TITLE
Touch last_deploy file in %post to have correct deploy time

### DIFF
--- a/dist/obs-server.spec
+++ b/dist/obs-server.spec
@@ -523,6 +523,10 @@ touch /srv/www/obs/api/log/production.log
 chown %{apache_user}:%{apache_group} /srv/www/obs/api/log/production.log
 
 %restart_on_update memcached
+# We need to touch the last_deploy file in the post hook 
+# to update the timestamp which we use to display the 
+# last deployment time in the API
+touch /srv/www/obs/api/last_deploy || true
 
 %postun -n obs-api
 %insserv_cleanup


### PR DESCRIPTION
This reverts commit 95b9342defb17ee0939a759a108c4475b61e217d.

The mtime is the buildtime of the RPM package so we can not use it.
The atime is the installation time, so we stick with it.
Seems like sth messed with the atime back then but it general this is what we want.