### PR TITLE
[api] Never return nil as current user, but nobody

### DIFF
--- a/src/api/app/controllers/application_controller.rb
+++ b/src/api/app/controllers/application_controller.rb
@@ -43,7 +43,7 @@ class ApplicationController < ActionController::Base
 
   # Don't show performance of database queries to users
   def peek_enabled?
-    User.current && (User.current.is_admin? || User.current.is_staff?)
+    User.current.is_admin? || User.current.is_staff?
   end
 
   def permissions

--- a/src/api/app/controllers/webui/webui_controller.rb
+++ b/src/api/app/controllers/webui/webui_controller.rb
@@ -99,7 +99,7 @@ class Webui::WebuiController < ActionController::Base
     if CONFIG['kerberos_mode']
       kerberos_auth
     else
-      if User.current.nil? || User.current.is_nobody?
+      if User.current.is_nobody?
         render(text: 'Please login') && (return false) if request.xhr?
 
         flash[:error] = 'Please login to access the requested page.'
@@ -133,7 +133,7 @@ class Webui::WebuiController < ActionController::Base
   end
 
   def kerberos_auth
-    return true unless CONFIG['kerberos_mode'] && (User.current.nil? || User.current.is_nobody?)
+    return true unless CONFIG['kerberos_mode'] && User.current.is_nobody?
 
     authorization = authenticator.authorization_infos || []
     if authorization[0].to_s != 'Negotiate'
@@ -200,7 +200,7 @@ class Webui::WebuiController < ActionController::Base
         @displayed_user = User.find_by_login!(params['user'])
       rescue NotFoundError
         # admins can see deleted users
-        @displayed_user = User.find_by_login(params['user']) if User.current && User.current.is_admin?
+        @displayed_user = User.find_by_login(params['user']) if User.current.is_admin?
         redirect_back(fallback_location: root_path, error: "User not found #{params['user']}") unless @displayed_user
       end
     else
@@ -221,7 +221,7 @@ class Webui::WebuiController < ActionController::Base
 
   # Don't show performance of database queries to users
   def peek_enabled?
-    User.current && (User.current.is_admin? || User.current.is_staff?)
+    User.current.is_admin? || User.current.is_staff?
   end
 
   def require_package
@@ -263,14 +263,14 @@ class Webui::WebuiController < ActionController::Base
 
   # Before filter to check if current user is administrator
   def require_admin
-    return unless User.current.nil? || !User.current.is_admin?
+    return if User.current.is_admin?
     flash[:error] = 'Requires admin privileges'
     redirect_back(fallback_location: { controller: 'main', action: 'index' })
   end
 
   # before filter to only show the frontpage to anonymous users
   def check_anonymous
-    if User.current && User.current.is_nobody?
+    if User.current.is_nobody?
       unless ::Configuration.anonymous
         flash[:error] = 'No anonymous access. Please log in!'
         redirect_back(fallback_location: root_path)

--- a/src/api/app/models/package.rb
+++ b/src/api/app/models/package.rb
@@ -313,7 +313,7 @@ class Package < ApplicationRecord
 
   def check_source_access?
     if disabled_for?('sourceaccess', nil, nil) || project.disabled_for?('sourceaccess', nil, nil)
-      return false unless User.current && User.current.can_source_access?(self)
+      return false unless User.current.can_source_access?(self)
     end
     true
   end

--- a/src/api/app/models/relationship.rb
+++ b/src/api/app/models/relationship.rb
@@ -108,7 +108,7 @@ class Relationship < ApplicationRecord
   # calculate and cache forbidden_project_ids for users
   def self.forbidden_project_ids
     # Admins don't have forbidden projects
-    return [0] if User.current && User.current.is_admin?
+    return [0] if User.current.is_admin?
 
     # This will cache and return a hash like this:
     # {projecs: [p1,p2], whitelist: { u1: [p1], u2: [p1,p2], u3: [p2] } }
@@ -128,7 +128,7 @@ class Relationship < ApplicationRecord
       forbidden_projects_hash
     end
     # We don't need to check the relationships if we don't have a User
-    return forbidden_projects[:projects] if User.current.nil? || User.current.is_nobody?
+    return forbidden_projects[:projects] if User.current.is_nobody?
     # The cache sequence is for invalidating user centric cache entries for all users
     cache_sequence = Rails.cache.read('cache_sequence_for_forbidden_projects') || 0
     Rails.cache.fetch("users/#{User.current.id}-forbidden_projects-#{cache_sequence}") do

--- a/src/api/app/models/unregistered_user.rb
+++ b/src/api/app/models/unregistered_user.rb
@@ -44,7 +44,7 @@ class UnregisteredUser < User
   def self.register(opts)
     can_register?
 
-    opts[:note] = nil unless User.current && User.current.is_admin?
+    opts[:note] = nil unless User.current.is_admin?
     state = ::Configuration.registration == 'allow' ? 'confirmed' : 'unconfirmed'
 
     newuser = User.new(

--- a/src/api/app/models/user.rb
+++ b/src/api/app/models/user.rb
@@ -209,7 +209,7 @@ class User < ApplicationRecord
   end
 
   def self.current
-    Thread.current[:user]
+    Thread.current[:user] || Thread.current[:user] = find_nobody!
   end
 
   def self.current=(user)

--- a/src/api/app/views/layouts/webui/_header.html.haml
+++ b/src/api/app/views/layouts/webui/_header.html.haml
@@ -4,7 +4,7 @@
     = link_to image_tag('obs-logo_small.png', height: 26), root_path, { id: 'header-logo' }
     %ul#global-navigation
       %li
-      - if User.current && !User.current.is_nobody?
+      - unless User.current.is_nobody?
         %li#item-favorites{ style: 'float: right;' }
           %a{ href: '#' } Watchlist
     = render partial: 'layouts/webui/watch_and_search'

--- a/src/api/app/views/layouts/webui/_personal_navigation.html.haml
+++ b/src/api/app/views/layouts/webui/_personal_navigation.html.haml
@@ -1,5 +1,5 @@
 .grid_6.omega{ style: 'text-align: right' }
-  - if User.current && !User.current.is_nobody?
+  - unless User.current.is_nobody?
     = link_to(home_path, id: 'link-to-user-home') do
       = User.current.login
     |

--- a/src/api/app/views/layouts/webui/_watch_and_search.html.haml
+++ b/src/api/app/views/layouts/webui/_watch_and_search.html.haml
@@ -1,4 +1,4 @@
-- if User.current && !User.current.is_nobody?
+- unless User.current.is_nobody?
   %ul.global-navigation-menu.global-navigation-menu-favorites#menu-favorites
     %li
       %span.desc

--- a/src/api/app/views/layouts/webui/webui.html.erb
+++ b/src/api/app/views/layouts/webui/webui.html.erb
@@ -86,7 +86,7 @@
     <div style="clear: both;"></div>
 
     <div id="footer" class="container_12">
-    <% if User.current && !User.current.is_nobody? -%>
+    <% unless User.current.is_nobody? -%>
       <div class="grid_3">
         <strong class="grey-medium spacer1"><%= link_to(user_show_path(User.current)) do %><%= User.current %><% end %>:</strong>
         <ul>

--- a/src/api/app/views/webui/repositories/state.html.haml
+++ b/src/api/app/views/webui/repositories/state.html.haml
@@ -23,5 +23,5 @@
         %i
           There are no cycles for #{arch}
     %p
-      - if User.current && !User.current.is_nobody?
+      - unless User.current.is_nobody?
         Check the rebuild time for #{link_to arch, project_rebuild_time_path(project: @project, arch: arch.name, repository: @repository.name), { rel: 'nofollow' }}

--- a/src/api/lib/feature_switch/feature.rb
+++ b/src/api/lib/feature_switch/feature.rb
@@ -2,7 +2,7 @@ module Feature
   @perform_initial_refresh_for_user = true
 
   def self.active?(feature)
-    if User.current && (User.current.is_admin? || User.current.is_staff?)
+    if User.current.is_admin? || User.current.is_staff?
       # caching the feature.yml file, this is basically taken from Feature.active_features
       if @auto_refresh || @perform_initial_refresh_for_user || (@next_refresh_after && Time.now > @next_refresh_after)
         @data = YAML.load_file("#{Rails.root}/config/feature.yml").with_indifferent_access


### PR DESCRIPTION
Return the `nobody` user instead of nil if there is not current user, similarly as it is done with `current_login`. :bowtie: 

With this we could actually always set the current user to nil in the code, and then everything related to the `nobody user` could be inside the User model. We could even make the `find_nobody!` method private.

Fixes https://github.com/openSUSE/open-build-service/issues/4746