### PR TITLE
[frontend] Fix rendering invalid markdown links

### DIFF
--- a/src/api/lib/obsapi/markdown_renderer.rb
+++ b/src/api/lib/obsapi/markdown_renderer.rb
@@ -27,7 +27,10 @@ module OBSApi
     # unfortunately we can't call super (into C) - see vmg/redcarpet#51
     def link(link, title, content)
       title = " title='#{title}'" if title.present?
-      link = URI.join(::Configuration.obs_url, link)
+      begin
+        link = URI.join(::Configuration.obs_url, link)
+      rescue URI::InvalidURIError
+      end
       "<a href='#{link}'#{title}>#{content}</a>"
     end
   end

--- a/src/api/spec/helpers/comment_helper_spec.rb
+++ b/src/api/spec/helpers/comment_helper_spec.rb
@@ -1,0 +1,23 @@
+require 'rails_helper'
+
+RSpec.describe CommentHelper, type: :helper do
+  describe '#comment_body' do
+    it 'renders markdown links to html links' do
+      expect(comment_body('[my link](https://github.com/openSUSE/open-build-service/issues/5091)')).to eq(
+        "<p><a href='https://github.com/openSUSE/open-build-service/issues/5091'>my link</a></p>\n"
+      )
+    end
+
+    it 'adds the OBS domain to relative links' do
+      expect(comment_body('[my link](/here)')).to eq(
+        "<p><a href='#{::Configuration.obs_url}/here'>my link</a></p>\n"
+      )
+    end
+
+    it 'does not crash due to invalid URIs' do
+      expect(comment_body("anbox[400000+22d000]\r\n(the number)")).to eq(
+        "<p>anbox<a href='the number'>400000+22d000</a></p>\n"
+      )
+    end
+  end
+end


### PR DESCRIPTION
Since commit c466c65d67cfd01e877aca224dd6aa3dd5fea06c we overwrite
the redcarpet renderer for links and add the OBS domain to relative
links.
The code that would craft these URIs wasn't expecting invalid links
and would fail with an URI::InvalidURIError exception.
This commit catches such exceptions and renders the invalid markdown
in the same format Redcarpet would do.