### PR TITLE
Remove space before commas

### DIFF
--- a/src/api/app/views/webui/request/_superseded_by_message.html.haml
+++ b/src/api/app/views/webui/request/_superseded_by_message.html.haml
@@ -5,9 +5,9 @@
         This request supersedes:
         - superseding.each_with_index do |bs_request, index|
           = link_to "request #{bs_request.number}", request_show_path(number: bs_request.number)
-          = surround '(', ')' do
-            = link_to 'Show diff', request_show_path(number: bs_request.superseded_by, diff_to_superseded: bs_request.number)
-          = ', ' if index < superseding.length - 1
+          = succeed (', ' if index < superseding.length - 1) do
+            = surround '(', ')' do
+              = link_to('Show diff', request_show_path(number: bs_request.superseded_by, diff_to_superseded: bs_request.number))
 - if superseded_by.present?
   .grid_16.alpha.omega.box-invisible
     .ui-state-info.ui-corner-all.ui-widget-shadow.padding-10pt#request-superseded-by-hint


### PR DESCRIPTION
In case of having several superseded requests it was added an unneeded space before commas. This way these spaces are removed.

For example:

![requests_without_spaces_before_commas](https://user-images.githubusercontent.com/24919/41650588-b75eda6e-747e-11e8-9680-ebf9a28345c5.png)
