### PR TITLE
Implement feature test suite for bootstrap theming

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -81,7 +81,7 @@ jobs:
       - run: mkdir /home/frontend/rspec
       - run:
           name: Run rspec
-          command: cd src/api; bundle exec rspec --format progress --format RspecJunitFormatter -o /home/frontend/rspec/rspec.xml
+          command: cd src/api; bundle exec rspec --format progress --format RspecJunitFormatter -o /home/frontend/rspec/rspec.xml --exclude-pattern spec/bootstrap/**/*_spec.rb
       - run:
           name: Format code coverage for code climate
           command: ./cc-test-reporter format-coverage --input-type simplecov --output /tmp/coverage/codeclimate.rspec.json src/api/coverage/.resultset.json
@@ -94,6 +94,26 @@ jobs:
           destination: rspec
       - store_test_results:
           path: /home/frontend/rspec
+  rspec-bootstrap:
+    <<: *frontend_base
+    steps:
+      - checkout
+      - run: *download_test_reporter
+      - restore_cache: *restore_bundle_cache
+      - run: *install_dependencies
+      - save_cache: *save_bundle_cache
+      - run: *wait_for_database
+      - run:
+          name: Setup application
+          command: cd src/api; bundle exec rake dev:bootstrap RAILS_ENV=test
+      - run:
+          name: Run rspec with bootstrap enabled
+          environment:
+            BOOTSTRAP: 1
+          command: cd src/api; bundle exec rspec --format progress --pattern spec/features/**/*_spec.rb --pattern spec/bootstrap/**/*_spec.rb
+      - store_artifacts:
+          path: ./src/api/log
+          destination: rspec
   minitest:
     <<: *minitest
     steps:
@@ -173,6 +193,9 @@ workflows:
     jobs:
       - lint
       - rspec:
+          requires:
+            - lint
+      - rspec-bootstrap:
           requires:
             - lint
       - minitest:

--- a/src/api/app/controllers/webui/webui_controller.rb
+++ b/src/api/app/controllers/webui/webui_controller.rb
@@ -311,7 +311,14 @@ class Webui::WebuiController < ActionController::Base
   end
 
   def switch_to_webui2?
-    Feature.active?(:bootstrap)
+    if Rails.env.test?
+      # In test environment we want to enable the
+      # bootstrap theme independent from the user
+      # The feature switch depends on the user (e.g. Admin or Staff)
+      ENV['BOOTSTRAP'].present
+    else
+      Feature.active?(:bootstrap)
+    end
   end
 
   def choose_layout

--- a/src/api/app/controllers/webui/webui_controller.rb
+++ b/src/api/app/controllers/webui/webui_controller.rb
@@ -311,7 +311,7 @@ class Webui::WebuiController < ActionController::Base
   end
 
   def switch_to_webui2?
-    User.current && (User.current.is_admin? || User.current.is_staff?)
+    Feature.active?(:bootstrap)
   end
 
   def choose_layout

--- a/src/api/config/feature.yml
+++ b/src/api/config/feature.yml
@@ -4,6 +4,7 @@ production:
     kiwi_image_editor: false
     cloud_upload: false
     cloud_upload_azure: false
+    bootstrap: false
 
 development:
   features:
@@ -11,6 +12,7 @@ development:
     kiwi_image_editor: true
     cloud_upload: true
     cloud_upload_azure: true
+    bootstrap: false
 
 test:
   features:
@@ -18,3 +20,4 @@ test:
     kiwi_image_editor: true
     cloud_upload: true
     cloud_upload_azure: true
+    bootstrap: false

--- a/src/api/script/api_test_in_spec.sh
+++ b/src/api/script/api_test_in_spec.sh
@@ -8,6 +8,7 @@ MYSQL_DATADIR=$MYSQL_BASEDIR/data
 MEMCACHED_PID_FILE=$TEMP_DIR/memcached.pid
 MYSQL_SOCKET_DIR=`mktemp -d`
 MYSQL_SOCKET=$MYSQL_SOCKET_DIR/mysql.socket
+RETRY=1
 
 MYSQLD_USER=`whoami`
 if [[ $EUID == 0 ]];then

--- a/src/api/spec/README.md
+++ b/src/api/spec/README.md
@@ -213,6 +213,9 @@ file path of the new one to every test covered.
 When you work on the test suite and you notice a method or part of a feature that
 is not tested please add a test for it.
 
+### Bootstrap theming
+As we are in the progress of migrating our views to a new bootstrap based theming, we currently run our feature tests twice (we do not have view tests). In CircleCI we run the feature tests one time with bootstrap enabled and one time disabled (regardless of the logged in user). Sometimes it can happen that a feature test fails with the bootstrap enabled. The desired solution should be to update the feature test that it works with and without bootstrap. If this is not easily possible, you have the possibility to skip this test for bootstrap by adding ```skip_if_bootstrap``` to the first line of the spec. After that, you should copy over the test to the ```spec/bootstrap/features``` directory and adapt it as necessary.
+
 ## Better Specs
 As a set of "rules" to follow in our specs we use [BetterSpecs.org](http://betterspecs.org/).
 Please read those guidelines before you start coding new specs.

--- a/src/api/spec/browser_helper.rb
+++ b/src/api/spec/browser_helper.rb
@@ -6,6 +6,7 @@ require 'support/capybara'
 
 # helper methods for authentication in features tests
 require 'support/features/features_authentication'
+require 'support/features/features_bootstrap'
 
 # Shared examples. Per recommendation of RSpec,
 # https://www.relishapp.com/rspec/rspec-core/v/2-12/docs/example-groups/shared-examples

--- a/src/api/spec/browser_helper.rb
+++ b/src/api/spec/browser_helper.rb
@@ -11,23 +11,6 @@ require 'support/features/features_authentication'
 # https://www.relishapp.com/rspec/rspec-core/v/2-12/docs/example-groups/shared-examples
 Dir['./spec/support/shared_examples/features/*.rb'].each { |example| require example }
 
-require 'rspec/retry'
-RSpec.configure do |config|
-  # show retry status in spec process
-  config.verbose_retry = true
-  # show exception that triggers a retry if verbose_retry is set to true
-  config.display_try_failure_messages = true
-
-  # run retry only on features
-  config.around :each, :js do |ex|
-    ex.run_with_retry retry: 3
-  end
-
-  # callback to be run between retries
-  config.retry_callback = proc do |ex|
-    # run some additional clean up task - can be filtered by example metadata
-    if ex.metadata[:js]
-      Capybara.reset!
-    end
-  end
+if ENV['RETRY'].present?
+  require 'support/features/features_rspec_retry'
 end

--- a/src/api/spec/support/features/features_bootstrap.rb
+++ b/src/api/spec/support/features/features_bootstrap.rb
@@ -1,0 +1,10 @@
+module FeaturesBootstrap
+  def skip_if_bootstrap
+    msg = 'The feature tests are executed with BOOTSTRAP enabled, therefore we skip this test.'
+    skip(msg) if ENV['BOOTSTRAP'].present?
+  end
+end
+
+RSpec.configure do |c|
+  c.include FeaturesBootstrap, type: :feature
+end

--- a/src/api/spec/support/features/features_rspec_retry.rb
+++ b/src/api/spec/support/features/features_rspec_retry.rb
@@ -1,0 +1,20 @@
+require 'rspec/retry'
+RSpec.configure do |config|
+  # show retry status in spec process
+  config.verbose_retry = true
+  # show exception that triggers a retry if verbose_retry is set to true
+  config.display_try_failure_messages = true
+
+  # run retry only on features
+  config.around :each, :js do |ex|
+    ex.run_with_retry retry: 3
+  end
+
+  # callback to be run between retries
+  config.retry_callback = proc do |ex|
+    # run some additional clean up task - can be filtered by example metadata
+    if ex.metadata[:js]
+      Capybara.reset!
+    end
+  end
+end


### PR DESCRIPTION
During the period of migrating our views to bootstrap, we need to run the feature tests twice.
One time with bootstrap disabled and one time with bootstrap disabled.
This can be triggered by setting the BOOTSTRAP environment variable and
excluding the spec/bootstrap/ directory from rspec (see .circleci/config.yml).
If a test does not run with reasonable effort with bootstrap enabled,
the test can get skipped with skip_if_bootstrap and we can
implement a test in spec/bootstrap/ directory.

I will add more explanation to a dedicated wiki page after this PR is merged.