### PR TITLE
[ci] Only use rspec-retry when environment variable is set

### DIFF
--- a/src/api/script/api_test_in_spec.sh
+++ b/src/api/script/api_test_in_spec.sh
@@ -8,6 +8,7 @@ MYSQL_DATADIR=$MYSQL_BASEDIR/data
 MEMCACHED_PID_FILE=$TEMP_DIR/memcached.pid
 MYSQL_SOCKET_DIR=`mktemp -d`
 MYSQL_SOCKET=$MYSQL_SOCKET_DIR/mysql.socket
+RETRY=1
 
 MYSQLD_USER=`whoami`
 if [[ $EUID == 0 ]];then

--- a/src/api/spec/browser_helper.rb
+++ b/src/api/spec/browser_helper.rb
@@ -11,23 +11,6 @@ require 'support/features/features_authentication'
 # https://www.relishapp.com/rspec/rspec-core/v/2-12/docs/example-groups/shared-examples
 Dir['./spec/support/shared_examples/features/*.rb'].each { |example| require example }
 
-require 'rspec/retry'
-RSpec.configure do |config|
-  # show retry status in spec process
-  config.verbose_retry = true
-  # show exception that triggers a retry if verbose_retry is set to true
-  config.display_try_failure_messages = true
-
-  # run retry only on features
-  config.around :each, :js do |ex|
-    ex.run_with_retry retry: 3
-  end
-
-  # callback to be run between retries
-  config.retry_callback = proc do |ex|
-    # run some additional clean up task - can be filtered by example metadata
-    if ex.metadata[:js]
-      Capybara.reset!
-    end
-  end
+if ENV['RETRY'].present?
+  require 'support/features/features_rspec_retry'
 end

--- a/src/api/spec/support/features/features_rspec_retry.rb
+++ b/src/api/spec/support/features/features_rspec_retry.rb
@@ -1,0 +1,20 @@
+require 'rspec/retry'
+RSpec.configure do |config|
+  # show retry status in spec process
+  config.verbose_retry = true
+  # show exception that triggers a retry if verbose_retry is set to true
+  config.display_try_failure_messages = true
+
+  # run retry only on features
+  config.around :each, :js do |ex|
+    ex.run_with_retry retry: 3
+  end
+
+  # callback to be run between retries
+  config.retry_callback = proc do |ex|
+    # run some additional clean up task - can be filtered by example metadata
+    if ex.metadata[:js]
+      Capybara.reset!
+    end
+  end
+end


### PR DESCRIPTION
So that we can disable it in our CI (CircleCI & Travis) but keep it enabled in our package builds.
This way we can sport flaky tests but does not interrupt the package builds.