### PR TITLE
[dist] Change default worker run directory

### DIFF
--- a/dist/obsworker
+++ b/dist/obsworker
@@ -58,7 +58,7 @@ fi
 mkdir -p "$OBS_WORKER_DIRECTORY"
 
 if [ -z "$OBS_RUN_DIR" ]; then
-    OBS_RUN_DIR="/var/run/obs"
+    OBS_RUN_DIR="/tmp/obs-rundir"
 fi
 if [ -z "$OBS_LOG_DIR" ]; then
     OBS_LOG_DIR="/var/log/obs"


### PR DESCRIPTION
Current default run directory for OBS workers is under /var/run. While
in most modern distros Systemd is the responsible for mounting /run and
does so with executable permissions, Debian (and Debian downstream)
distributions delegate this task to their initramfs package, which
mounts /run with the noexec flag on. Note that /var/run is a symlink to
/run on such distributions. This commit changes the default run
directory to a path under /tmp to solve the described issue while
keeping the volatile properties of the directory under /run.

See https://freedesktop.org/wiki/Software/systemd/APIFileSystems and
https://www.freedesktop.org/wiki/Software/systemd/InitrdInterface/ for
further reference.

I Also have a more complete description og the symptoms is a [blog post](https://athoscr.me/blog/gsoc2018-3/) 