### PR TITLE
[frontend] Fix typo in BinaryRelease model

### DIFF
--- a/src/api/app/models/binary_release.rb
+++ b/src/api/app/models/binary_release.rb
@@ -187,7 +187,7 @@ class BinaryRelease < ApplicationRecord
     binary_disturl == binary_hash['disturl'] &&
       binary_supportstatus == binary_hash['supportstatus'] &&
       binary_buildtime &&
-      binary_buildtime.to_datetime.utc == DateTime.strptime(binary['buildtime'].to_s, '%s').utc
+      binary_buildtime.to_datetime.utc == DateTime.strptime(binary_hash['buildtime'].to_s, '%s').utc
   end
   # rubocop:enable Style/DateTime
   #### Alias of methods


### PR DESCRIPTION
Caused by 536e6dc161d14f34404f17749e38dac8560cf136