### PR TITLE
[frontend] Fix rendering of openqa_job template

### DIFF
--- a/src/api/app/views/webui/obs_factory/staging_projects/_problems.html.erb
+++ b/src/api/app/views/webui/obs_factory/staging_projects/_problems.html.erb
@@ -1,6 +1,6 @@
  <% 
    problems = project.failed_openqa_jobs.map do |j|
-     content_tag(:li, "QA: #{render(j)}".html_safe, class: "openqa_job")
+     content_tag(:li, "QA: #{render(template: 'webui/obs_factory/openqa_jobs/_openqa_job', locals: { openqa_job: j })}".html_safe, class: "openqa_job")
    end
 -%>
 


### PR DESCRIPTION
OBS was not specifying the template when rendering openqa_jobs.
This caused that the application did not find the partial and broke the
staging project page. Explicitly setting the template to render
solves this.

Co-authored-by: David Kang <dkang@suse.com>