### PR TITLE
Refactor how we render superseded requests list

### DIFF
--- a/src/api/app/views/webui/request/_superseded_by_message.html.haml
+++ b/src/api/app/views/webui/request/_superseded_by_message.html.haml
@@ -5,9 +5,8 @@
         This request supersedes:
         - superseding.each_with_index do |bs_request, index|
           = link_to "request #{bs_request.number}", request_show_path(number: bs_request.number)
-          = succeed (', ' if index < superseding.length - 1) do
-            = surround '(', ')' do
-              = link_to('Show diff', request_show_path(number: bs_request.superseded_by, diff_to_superseded: bs_request.number))
+          = surround '(', ")#{', ' if index < superseding.length - 1 }" do
+            = link_to('Show diff', request_show_path(number: bs_request.superseded_by, diff_to_superseded: bs_request.number))
 - if superseded_by.present?
   .grid_16.alpha.omega.box-invisible
     .ui-state-info.ui-corner-all.ui-widget-shadow.padding-10pt#request-superseded-by-hint

--- a/src/api/app/views/webui/request/_superseded_by_message.html.haml
+++ b/src/api/app/views/webui/request/_superseded_by_message.html.haml
@@ -3,9 +3,9 @@
     .ui-state-info.ui-corner-all.ui-widget-shadow.padding-10pt#request-supersedes-hint
       %span.ui-icon.ui-icon-info
         This request supersedes:
-        - superseding.each_with_index do |bs_request, index|
+        - superseding.each do |bs_request|
           = link_to "request #{bs_request.number}", request_show_path(number: bs_request.number)
-          = surround '(', ")#{', ' if index < superseding.length - 1 }" do
+          = surround '(', ")#{', ' unless bs_request == superseding.last }" do
             = link_to('Show diff', request_show_path(number: bs_request.superseded_by, diff_to_superseded: bs_request.number))
 - if superseded_by.present?
   .grid_16.alpha.omega.box-invisible


### PR DESCRIPTION
`succeed` appends a string to the end of a Haml block, and `surround` appends strings to the end and the beginning. Because of that, if we already need to use `surround`, it doesn't make sense to use `succeed` as well. It is also more readable, as what we want is just a comma after the closing parenthesis. :nerd_face: 

We want a comma except for the last record, because of that I think that it is more readable to use `superseding.last` than using an index and comparing it with `superseding.length - 1`. This way we also don't need to use `each_with_index`, as we don't really care of what index every record have. This may be a matter of taste, but I find it more elegant. :bowtie: 