### PR TITLE
Drop phantomjs and run against selenium container with chrome

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,12 @@ branches:
     # starting with depfu/
     - /^depfu\/.*/
 
+before_install:
+  - sudo rm /usr/local/bin/docker-compose
+  - curl -L https://github.com/docker/compose/releases/download/1.21.2/docker-compose-`uname -s`-`uname -m` > docker-compose
+  - chmod +x docker-compose
+  - sudo mv docker-compose /usr/local/bin
+
 # Scripts
 after_failure: dist/ci/travis_after_failure.sh
  # we need to chown the build dir to frontend:users (1000:100) to avoid permission errors

--- a/Rakefile
+++ b/Rakefile
@@ -25,7 +25,7 @@ namespace :docker do
     desc 'Run our frontend tests in the docker container'
     task :rspec do
       begin
-        sh 'docker-compose', '-f', 'docker-compose.ci.yml', '-p', 'rspec', 'run', *environment_vars, '--rm', 'rspec'
+        sh 'docker-compose', '-f', 'docker-compose.ci.yml', '-p', 'rspec', 'run', '--use-aliases', *environment_vars, '--rm', 'rspec'
       ensure
         sh 'docker-compose -f docker-compose.ci.yml -p rspec stop'
       end

--- a/dist/obs-server.spec
+++ b/dist/obs-server.spec
@@ -115,6 +115,10 @@ BuildRequires:  fdupes
 PreReq:         %insserv_prereq permissions pwdutils
 %endif
 
+%if 0%{?disable_obs_frontend_test_suite:1} < 1 && 0%{?disable_obs_test_suite} < 1
+BuildRequires:  chromedriver
+%endif
+
 %if 0%{?suse_version:1}
 Recommends:     yum yum-metadata-parser repoview dpkg
 Recommends:     deb >= 1.5
@@ -409,10 +413,6 @@ make -C src/backend test
 # start api testing
 #
 %if 0%{?disable_obs_frontend_test_suite:1} < 1
-# UI tests are not needed for non x86 architectures
-%ifnarch %ix86 x86_64
-rm -r src/api/spec/features/
-%endif  
 make -C src/api test
 %endif
 

--- a/docker-compose.ci.yml
+++ b/docker-compose.ci.yml
@@ -6,7 +6,10 @@ services:
       - .:/obs
     depends_on:
       - db
+      - selenium
     command: /obs/contrib/start_rspec
+    environment:
+      RSPEC_HOST: rspec
   minitest:
     image: registry.opensuse.org/obs/server/unstable/container/leap/42.3/images/openbuildservice/frontend-backend:latest
     privileged: true
@@ -27,3 +30,5 @@ services:
       - .:/obs
     working_dir: /obs
     command: make -C src/backend test
+  selenium:
+    image: selenium/standalone-chrome

--- a/docker-compose.selenium.yml
+++ b/docker-compose.selenium.yml
@@ -1,0 +1,14 @@
+version: "2.1"
+services:
+  frontend:
+    depends_on:
+      - selenium
+    environment:
+      RSPEC_HOST: frontend
+  selenium:
+    image: selenium/standalone-chrome-debug
+    environment:
+      VNC_NO_PASSWORD: 1
+    ports:
+      - 5900:5900
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,18 +35,8 @@ services:
     ports:
       - "3000:3000"
       - "1080:1080"
-    environment:
-      RSPEC_HOST: frontend
     depends_on:
       - db
       - cache
       - backend
       - worker
-      - selenium
-  selenium:
-    image: selenium/standalone-chrome-debug
-    environment:
-      VNC_NO_PASSWORD: 1
-    ports:
-      - 5900:5900
-

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,8 +35,18 @@ services:
     ports:
       - "3000:3000"
       - "1080:1080"
+    environment:
+      RSPEC_HOST: frontend
     depends_on:
       - db
       - cache
       - backend
       - worker
+      - selenium
+  selenium:
+    image: selenium/standalone-chrome-debug
+    environment:
+      VNC_NO_PASSWORD: 1
+    ports:
+      - 5900:5900
+

--- a/docker-files/base/docker-bootstrap.sh
+++ b/docker-files/base/docker-bootstrap.sh
@@ -6,7 +6,6 @@ do
   frontend)
     zypper -n install --no-recommends --replacefiles \
       sphinx \
-      phantomjs \
       nodejs6 npm6 \
       mariadb-client \
       sqlite3-devel \

--- a/src/api/Gemfile
+++ b/src/api/Gemfile
@@ -153,8 +153,6 @@ group :development, :test do
   gem 'haml_lint'
   # to generate random long strings
   gem 'faker'
-  # as driver for capybara
-  gem 'poltergeist'
   # to launch browser in test
   gem 'launchy'
   # for calling single testd
@@ -163,6 +161,8 @@ group :development, :test do
   gem 'bullet'
   # Use Puma as the app server (rails 5 default)
   gem 'puma', '~> 3.11'
+  # to drive headless chrome
+  gem 'selenium-webdriver'
 end
 
 # Gems used only for assets and not required in production environments by default.

--- a/src/api/Gemfile.lock
+++ b/src/api/Gemfile.lock
@@ -82,8 +82,9 @@ GEM
     capybara_minitest_spec (1.0.7)
       capybara (>= 2)
       minitest (>= 4)
+    childprocess (0.9.0)
+      ffi (~> 1.0, >= 1.0.11)
     chunky_png (1.3.10)
-    cliver (0.3.2)
     clockwork (2.0.3)
       tzinfo
     cocoon (1.2.11)
@@ -248,10 +249,6 @@ GEM
       mysql2
       peek
     pkg-config (1.3.1)
-    poltergeist (1.18.1)
-      capybara (>= 2.1, < 4)
-      cliver (~> 0.3.1)
-      websocket-driver (>= 0.2.0)
     popper_js (1.12.9)
     power_assert (1.1.3)
     powerpack (0.1.2)
@@ -346,6 +343,7 @@ GEM
       rubocop (>= 0.56.0)
     ruby-ldap (0.9.20)
     ruby-progressbar (1.9.0)
+    rubyzip (1.2.1)
     safe_yaml (1.0.4)
     sanitize (4.6.5)
       crass (~> 1.0.2)
@@ -365,6 +363,9 @@ GEM
     sassc (1.12.1)
       ffi (~> 1.9.6)
       sass (>= 3.3.0)
+    selenium-webdriver (3.13.0)
+      childprocess (~> 0.5)
+      rubyzip (~> 1.2)
     shoulda-matchers (3.1.2)
       activesupport (>= 4.0.0)
     simplecov (0.16.1)
@@ -483,7 +484,6 @@ DEPENDENCIES
   peek-dalli
   peek-host
   peek-mysql2
-  poltergeist
   pry (>= 0.9.12)
   puma (~> 3.11)
   pundit
@@ -503,6 +503,7 @@ DEPENDENCIES
   ruby-ldap
   sanitize
   sass-rails (~> 5.0.1)
+  selenium-webdriver
   shoulda-matchers (~> 3.1)
   simplecov
   single_test

--- a/src/api/app/assets/javascripts/webui/application/image_templates.js
+++ b/src/api/app/assets/javascripts/webui/application/image_templates.js
@@ -1,7 +1,7 @@
-$(function() {
+function setupImageTemplates() { // jshint ignore:line
   $(".image_template").on("click", function(){
     $('#target_package').val(this.getAttribute('data-package'));
     $('#linked_package').val(this.getAttribute('data-package'));
     $('#linked_project').val(this.getAttribute('data-project'));
   });
-});
+}

--- a/src/api/app/views/webui/image_templates/index.html.haml
+++ b/src/api/app/views/webui/image_templates/index.html.haml
@@ -45,3 +45,5 @@
   - elsif @projects.empty?
     %p
       There are no templates yet, sorry.
+- content_for :ready_function do
+  setupImageTemplates();

--- a/src/api/spec/cassettes/Projects/locked_projects/fail_to_unlock.yml
+++ b/src/api/spec/cassettes/Projects/locked_projects/fail_to_unlock.yml
@@ -1,0 +1,400 @@
+---
+http_interactions:
+- request:
+    method: put
+    uri: http://backend:5352/source/home:user_1/_meta?user=user_1
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:user_1">
+          <title/>
+          <description/>
+          <person userid="user_1" role="maintainer"/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '135'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:user_1">
+          <title></title>
+          <description></description>
+          <person userid="user_1" role="maintainer" />
+        </project>
+    http_version: 
+  recorded_at: Fri, 06 Jul 2018 11:36:09 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:Jane/_meta?user=Jane
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:Jane">
+          <title/>
+          <description/>
+          <person userid="Jane" role="maintainer"/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '131'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:Jane">
+          <title></title>
+          <description></description>
+          <person userid="Jane" role="maintainer" />
+        </project>
+    http_version: 
+  recorded_at: Fri, 06 Jul 2018 11:36:09 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/locked_project/_meta?user=_nobody_
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="locked_project">
+          <title>No Longer at Ease</title>
+          <description/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '108'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="locked_project">
+          <title>No Longer at Ease</title>
+          <description></description>
+        </project>
+    http_version: 
+  recorded_at: Fri, 06 Jul 2018 11:36:09 GMT
+- request:
+    method: get
+    uri: http://backend:5352/build/locked_project/_result?code=unresolvable&view=status
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '56'
+    body:
+      encoding: UTF-8
+      string: '<resultlist state="00000000000000000000000000000000" />
+
+'
+    http_version: 
+  recorded_at: Fri, 06 Jul 2018 11:36:12 GMT
+- request:
+    method: get
+    uri: http://backend:5352/build/locked_project/_result?view=summary
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - text/plain
+      Accept-Encoding:
+      - identity
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '56'
+    body:
+      encoding: UTF-8
+      string: '<resultlist state="00000000000000000000000000000000" />
+
+'
+    http_version: 
+  recorded_at: Fri, 06 Jul 2018 11:36:12 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/locked_project/_meta?user=Jane
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="locked_project">
+          <title>No Longer at Ease</title>
+          <description/>
+          <person userid="Jane" role="maintainer"/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '153'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="locked_project">
+          <title>No Longer at Ease</title>
+          <description></description>
+          <person userid="Jane" role="maintainer" />
+        </project>
+    http_version: 
+  recorded_at: Fri, 06 Jul 2018 11:36:12 GMT
+- request:
+    method: get
+    uri: http://backend:5352/build/locked_project/_result?code=unresolvable&view=status
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '56'
+    body:
+      encoding: UTF-8
+      string: '<resultlist state="00000000000000000000000000000000" />
+
+'
+    http_version: 
+  recorded_at: Fri, 06 Jul 2018 11:36:12 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/locked_project/_keyinfo?donotcreatecert=1&withsslcert=1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '12'
+    body:
+      encoding: UTF-8
+      string: "<keyinfo />\n"
+    http_version: 
+  recorded_at: Fri, 06 Jul 2018 11:36:12 GMT
+- request:
+    method: get
+    uri: http://backend:5352/build/locked_project/_result?view=summary
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - text/plain
+      Accept-Encoding:
+      - identity
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '56'
+    body:
+      encoding: UTF-8
+      string: '<resultlist state="00000000000000000000000000000000" />
+
+'
+    http_version: 
+  recorded_at: Fri, 06 Jul 2018 11:36:13 GMT
+- request:
+    method: get
+    uri: http://backend:5352/build/locked_project/_result?code=unresolvable&view=status
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '56'
+    body:
+      encoding: UTF-8
+      string: '<resultlist state="00000000000000000000000000000000" />
+
+'
+    http_version: 
+  recorded_at: Fri, 06 Jul 2018 11:36:13 GMT
+- request:
+    method: get
+    uri: http://backend:5352/build/locked_project/_result?view=summary
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - text/plain
+      Accept-Encoding:
+      - identity
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '56'
+    body:
+      encoding: UTF-8
+      string: '<resultlist state="00000000000000000000000000000000" />
+
+'
+    http_version: 
+  recorded_at: Fri, 06 Jul 2018 11:36:13 GMT
+recorded_with: VCR 4.0.0

--- a/src/api/spec/cassettes/Projects/locked_projects/unlock.yml
+++ b/src/api/spec/cassettes/Projects/locked_projects/unlock.yml
@@ -1,24 +1,27 @@
 ---
 http_interactions:
 - request:
-    method: get
-    uri: http://backend:5352/build/locked_project/_result?code=unresolvable&view=status
+    method: put
+    uri: http://backend:5352/source/home:user_1/_meta?user=user_1
     body:
-      encoding: US-ASCII
-      string: ''
+      encoding: UTF-8
+      string: |
+        <project name="home:user_1">
+          <title/>
+          <description/>
+          <person userid="user_1" role="maintainer"/>
+        </project>
     headers:
-      Content-Type:
-      - text/plain
       Accept-Encoding:
-      - identity
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
       - "*/*"
       User-Agent:
       - Ruby
   response:
     status:
-      code: 404
-      message: project 'locked_project' does not exist
+      code: 200
+      message: OK
     headers:
       Content-Type:
       - text/xml
@@ -27,16 +30,130 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '156'
+      - '135'
     body:
       encoding: UTF-8
       string: |
-        <status code="404">
-          <summary>project 'locked_project' does not exist</summary>
-          <details>404 project 'locked_project' does not exist</details>
-        </status>
+        <project name="home:user_1">
+          <title></title>
+          <description></description>
+          <person userid="user_1" role="maintainer" />
+        </project>
     http_version: 
-  recorded_at: Wed, 23 Mar 2016 17:11:54 GMT
+  recorded_at: Fri, 06 Jul 2018 11:35:34 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:Jane/_meta?user=Jane
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:Jane">
+          <title/>
+          <description/>
+          <person userid="Jane" role="maintainer"/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '131'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:Jane">
+          <title></title>
+          <description></description>
+          <person userid="Jane" role="maintainer" />
+        </project>
+    http_version: 
+  recorded_at: Fri, 06 Jul 2018 11:35:34 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/locked_project/_meta?user=_nobody_
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="locked_project">
+          <title>The Heart Is a Lonely Hunter</title>
+          <description/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '119'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="locked_project">
+          <title>The Heart Is a Lonely Hunter</title>
+          <description></description>
+        </project>
+    http_version: 
+  recorded_at: Fri, 06 Jul 2018 11:35:34 GMT
+- request:
+    method: get
+    uri: http://backend:5352/build/locked_project/_result?code=unresolvable&view=status
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '56'
+    body:
+      encoding: UTF-8
+      string: '<resultlist state="00000000000000000000000000000000" />
+
+'
+    http_version: 
+  recorded_at: Fri, 06 Jul 2018 11:35:37 GMT
 - request:
     method: get
     uri: http://backend:5352/build/locked_project/_result?view=summary
@@ -54,8 +171,8 @@ http_interactions:
       - Ruby
   response:
     status:
-      code: 404
-      message: project 'locked_project' does not exist
+      code: 200
+      message: OK
     headers:
       Content-Type:
       - text/xml
@@ -64,16 +181,55 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '156'
+      - '56'
+    body:
+      encoding: UTF-8
+      string: '<resultlist state="00000000000000000000000000000000" />
+
+'
+    http_version: 
+  recorded_at: Fri, 06 Jul 2018 11:35:37 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/locked_project/_meta?comment=Freedom%20at%20last!&user=Jane
     body:
       encoding: UTF-8
       string: |
-        <status code="404">
-          <summary>project 'locked_project' does not exist</summary>
-          <details>404 project 'locked_project' does not exist</details>
-        </status>
+        <project name="locked_project">
+          <title>The Heart Is a Lonely Hunter</title>
+          <description/>
+          <person userid="Jane" role="maintainer"/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '164'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="locked_project">
+          <title>The Heart Is a Lonely Hunter</title>
+          <description></description>
+          <person userid="Jane" role="maintainer" />
+        </project>
     http_version: 
-  recorded_at: Wed, 23 Mar 2016 17:11:54 GMT
+  recorded_at: Fri, 06 Jul 2018 11:35:37 GMT
 - request:
     method: get
     uri: http://backend:5352/build/locked_project/_result?code=unresolvable&view=status
@@ -81,154 +237,6 @@ http_interactions:
       encoding: US-ASCII
       string: ''
     headers:
-      Content-Type:
-      - text/plain
-      Accept-Encoding:
-      - identity
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 404
-      message: project 'locked_project' does not exist
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '156'
-    body:
-      encoding: UTF-8
-      string: |
-        <status code="404">
-          <summary>project 'locked_project' does not exist</summary>
-          <details>404 project 'locked_project' does not exist</details>
-        </status>
-    http_version: 
-  recorded_at: Wed, 23 Mar 2016 17:11:55 GMT
-- request:
-    method: get
-    uri: http://backend:5352/build/locked_project/_result?view=summary
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Content-Type:
-      - text/plain
-      Accept-Encoding:
-      - identity
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 404
-      message: project 'locked_project' does not exist
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '156'
-    body:
-      encoding: UTF-8
-      string: |
-        <status code="404">
-          <summary>project 'locked_project' does not exist</summary>
-          <details>404 project 'locked_project' does not exist</details>
-        </status>
-    http_version: 
-  recorded_at: Wed, 23 Mar 2016 17:11:55 GMT
-- request:
-    method: get
-    uri: http://backend:5352/build/locked_project/_result?code=unresolvable&view=status
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Content-Type:
-      - text/plain
-      Accept-Encoding:
-      - identity
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 404
-      message: project 'locked_project' does not exist
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '156'
-    body:
-      encoding: UTF-8
-      string: |
-        <status code="404">
-          <summary>project 'locked_project' does not exist</summary>
-          <details>404 project 'locked_project' does not exist</details>
-        </status>
-    http_version: 
-  recorded_at: Wed, 23 Mar 2016 17:11:55 GMT
-- request:
-    method: get
-    uri: http://backend:5352/build/locked_project/_result?view=summary
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Content-Type:
-      - text/plain
-      Accept-Encoding:
-      - identity
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 404
-      message: project 'locked_project' does not exist
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '156'
-    body:
-      encoding: UTF-8
-      string: |
-        <status code="404">
-          <summary>project 'locked_project' does not exist</summary>
-          <details>404 project 'locked_project' does not exist</details>
-        </status>
-    http_version: 
-  recorded_at: Wed, 23 Mar 2016 17:11:55 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/locked_project/_keyinfo?withsslcert=1
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -247,136 +255,14 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '12'
+      - '56'
     body:
       encoding: UTF-8
-      string: "<keyinfo />\n"
+      string: '<resultlist state="00000000000000000000000000000000" />
+
+'
     http_version: 
-  recorded_at: Mon, 09 Jan 2017 11:21:37 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/locked_project/_keyinfo?withsslcert=1
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '12'
-    body:
-      encoding: UTF-8
-      string: "<keyinfo />\n"
-    http_version: 
-  recorded_at: Mon, 09 Jan 2017 11:21:37 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/locked_project/_keyinfo?withsslcert=1
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '12'
-    body:
-      encoding: UTF-8
-      string: "<keyinfo />\n"
-    http_version: 
-  recorded_at: Mon, 09 Jan 2017 11:21:37 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/locked_project/_keyinfo?withsslcert=1
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '12'
-    body:
-      encoding: UTF-8
-      string: "<keyinfo />\n"
-    http_version: 
-  recorded_at: Mon, 09 Jan 2017 11:21:37 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/locked_project/_keyinfo
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '12'
-    body:
-      encoding: UTF-8
-      string: "<keyinfo />\n"
-    http_version: 
-  recorded_at: Mon, 13 Feb 2017 16:03:28 GMT
+  recorded_at: Fri, 06 Jul 2018 11:35:37 GMT
 - request:
     method: get
     uri: http://backend:5352/source/locked_project/_keyinfo?donotcreatecert=1&withsslcert=1
@@ -407,5 +293,108 @@ http_interactions:
       encoding: UTF-8
       string: "<keyinfo />\n"
     http_version: 
-  recorded_at: Mon, 08 May 2017 21:13:05 GMT
-recorded_with: VCR 3.0.3
+  recorded_at: Fri, 06 Jul 2018 11:35:37 GMT
+- request:
+    method: get
+    uri: http://backend:5352/build/locked_project/_result?view=summary
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - text/plain
+      Accept-Encoding:
+      - identity
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '56'
+    body:
+      encoding: UTF-8
+      string: '<resultlist state="00000000000000000000000000000000" />
+
+'
+    http_version: 
+  recorded_at: Fri, 06 Jul 2018 11:35:37 GMT
+- request:
+    method: get
+    uri: http://backend:5352/build/locked_project/_result?code=unresolvable&view=status
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '56'
+    body:
+      encoding: UTF-8
+      string: '<resultlist state="00000000000000000000000000000000" />
+
+'
+    http_version: 
+  recorded_at: Fri, 06 Jul 2018 11:35:37 GMT
+- request:
+    method: get
+    uri: http://backend:5352/build/locked_project/_result?view=summary
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - text/plain
+      Accept-Encoding:
+      - identity
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '56'
+    body:
+      encoding: UTF-8
+      string: '<resultlist state="00000000000000000000000000000000" />
+
+'
+    http_version: 
+  recorded_at: Fri, 06 Jul 2018 11:35:37 GMT
+recorded_with: VCR 4.0.0

--- a/src/api/spec/cassettes/Sign_up/User.yml
+++ b/src/api/spec/cassettes/Sign_up/User.yml
@@ -7,10 +7,8 @@ http_interactions:
       encoding: US-ASCII
       string: ''
     headers:
-      Content-Type:
-      - text/plain
       Accept-Encoding:
-      - identity
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
       - "*/*"
       User-Agent:
@@ -27,32 +25,108 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '589'
+      - '1363'
     body:
       encoding: UTF-8
       string: |
-        <workerstatus clients="0">
-          <waiting arch="i586" jobs="1" />
+        <workerstatus clients="2">
+          <idle workerid="1adb34fe44af:1" hostarch="x86_64" />
+          <idle workerid="1adb34fe44af:2" hostarch="x86_64" />
+          <waiting arch="i586" jobs="0" />
           <waiting arch="x86_64" jobs="0" />
           <blocked arch="i586" jobs="0" />
           <blocked arch="x86_64" jobs="0" />
           <buildavg arch="i586" buildavg="1200" />
           <buildavg arch="x86_64" buildavg="1200" />
           <partition>
-            <daemon type="scheduler" arch="i586" state="dead">
-              <queue high="0" med="0" low="3" next="0" />
+            <daemon type="srcserver" state="running" starttime="1530715415" />
+            <daemon type="servicedispatch" state="running" starttime="1530715421" />
+            <daemon type="service" state="running" starttime="1530715421" />
+            <daemon type="clouduploadserver" state="running" starttime="1530715421" />
+            <daemon type="clouduploadworker" state="running" starttime="1530715421" />
+            <daemon type="scheduler" arch="i586" state="running" starttime="1530715421">
+              <queue high="0" med="0" low="0" next="0" />
             </daemon>
-            <daemon type="scheduler" arch="x86_64" state="dead">
-              <queue high="0" med="0" low="6" next="0" />
+            <daemon type="scheduler" arch="x86_64" state="running" starttime="1530715421">
+              <queue high="0" med="0" low="0" next="0" />
             </daemon>
-            <daemon type="publisher" state="dead" />
+            <daemon type="repserver" state="running" starttime="1530715419" />
+            <daemon type="dispatcher" state="running" starttime="1530715421" />
+            <daemon type="publisher" state="running" starttime="1530715421" />
+            <daemon type="signer" state="running" starttime="1530715421" />
           </partition>
         </workerstatus>
     http_version: 
-  recorded_at: Wed, 10 Feb 2016 16:04:28 GMT
+  recorded_at: Wed, 04 Jul 2018 15:20:33 GMT
 - request:
     method: get
     uri: http://backend:5352/build/home:eisendieter/_result?code=unresolvable&view=status
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 404
+      message: project 'home eisendieter' does not exist
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '160'
+    body:
+      encoding: UTF-8
+      string: |
+        <status code="404">
+          <summary>project 'home:eisendieter' does not exist</summary>
+          <details>404 project 'home:eisendieter' does not exist</details>
+        </status>
+    http_version: 
+  recorded_at: Wed, 04 Jul 2018 15:20:35 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:eisendieter/_keyinfo?donotcreatecert=1&withsslcert=1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '12'
+    body:
+      encoding: UTF-8
+      string: "<keyinfo />\n"
+    http_version: 
+  recorded_at: Wed, 04 Jul 2018 15:20:35 GMT
+- request:
+    method: get
+    uri: http://backend:5352/build/home:eisendieter/_result?view=summary
     body:
       encoding: US-ASCII
       string: ''
@@ -86,129 +160,5 @@ http_interactions:
           <details>404 project 'home:eisendieter' does not exist</details>
         </status>
     http_version: 
-  recorded_at: Wed, 10 Feb 2016 16:04:28 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/home:eisendieter/_keyinfo?withsslcert=1
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '12'
-    body:
-      encoding: UTF-8
-      string: "<keyinfo />\n"
-    http_version: 
-  recorded_at: Mon, 09 Jan 2017 11:06:01 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/home:eisendieter/_keyinfo?withsslcert=1
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '12'
-    body:
-      encoding: UTF-8
-      string: "<keyinfo />\n"
-    http_version: 
-  recorded_at: Mon, 09 Jan 2017 11:06:01 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/home:eisendieter/_keyinfo
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '12'
-    body:
-      encoding: UTF-8
-      string: "<keyinfo />\n"
-    http_version: 
-  recorded_at: Mon, 13 Feb 2017 15:54:27 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/home:eisendieter/_keyinfo?donotcreatecert=1&withsslcert=1
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '12'
-    body:
-      encoding: UTF-8
-      string: "<keyinfo />\n"
-    http_version: 
-  recorded_at: Mon, 08 May 2017 22:06:27 GMT
-recorded_with: VCR 3.0.3
+  recorded_at: Wed, 04 Jul 2018 15:20:36 GMT
+recorded_with: VCR 4.0.0

--- a/src/api/spec/features/webui/image_templates_spec.rb
+++ b/src/api/spec/features/webui/image_templates_spec.rb
@@ -27,7 +27,9 @@ RSpec.feature 'ImageTemplates', type: :feature, js: true do
       expect(page).to have_selector("input[data-package='#{kiwi_package}']:not(:checked)", visible: false)
 
       expect(page).to have_field('target_package', with: package1)
-      find(:xpath, "//input[@data-package='#{package2}']/../dd/span[@class='group']").click
+      within :xpath, "//input[@data-package='#{package2}']/../dd" do
+        find('.description').click
+      end
       expect(page).to have_field('target_package', with: package2)
       fill_in 'target_package', with: 'custom_name'
 
@@ -52,8 +54,11 @@ RSpec.feature 'ImageTemplates', type: :feature, js: true do
       expect(page).to have_selector("input[data-package='#{kiwi_package}']:not(:checked)", visible: false)
 
       expect(page).to have_field('target_package', with: package1)
-      find(:xpath, "//input[@data-package='#{kiwi_package}']/../dd/span[@class='group']").click
+      within :xpath, "//input[@data-package='#{kiwi_package}']/../dd" do
+        find('.description').click
+      end
       expect(page).to have_field('target_package', with: kiwi_package)
+
       fill_in 'target_package', with: 'package_with_kiwi_image'
 
       click_button('Create appliance')

--- a/src/api/spec/features/webui/packages_spec.rb
+++ b/src/api/spec/features/webui/packages_spec.rb
@@ -135,7 +135,7 @@ RSpec.feature 'Packages', type: :feature, js: true do
     fill_in 'devel_project', with: third_project.name
     click_button 'Ok'
 
-    expect(find('#flash-messages').text).to be_empty
+    expect(find('#flash-messages', visible: false)).not_to be_visible
     request = BsRequest.where(description: 'Hey, why not?', creator: user.login, state: 'review')
     expect(request).to exist
     expect(page.current_path).to match("/request/show/#{request.first.number}")

--- a/src/api/spec/features/webui/projects_spec.rb
+++ b/src/api/spec/features/webui/projects_spec.rb
@@ -149,23 +149,23 @@ RSpec.feature 'Projects', type: :feature, js: true do
       visit project_show_path(project: locked_project.name)
     end
 
-    scenario 'unlock project' do
+    scenario 'unlock' do
       click_link('Unlock project')
       fill_in 'comment', with: 'Freedom at last!'
       click_button('Ok')
-      expect(page).to have_text('Successfully unlocked project')
+      expect(page).to have_content('Successfully unlocked project')
 
       visit project_show_path(project: locked_project.name)
       expect(page).not_to have_text('is locked')
     end
 
-    scenario 'unlock project' do
+    scenario 'fail to unlock' do
       allow_any_instance_of(Project).to receive(:can_be_unlocked?).and_return(false)
 
       click_link('Unlock project')
       fill_in 'comment', with: 'Freedom at last!'
       click_button('Ok')
-      expect(page).to have_text("Project can't be unlocked")
+      expect(page).to have_content("Project can't be unlocked")
 
       visit project_show_path(project: locked_project.name)
       expect(page).to have_text('is locked')

--- a/src/api/spec/features/webui/projects_spec.rb
+++ b/src/api/spec/features/webui/projects_spec.rb
@@ -214,8 +214,11 @@ RSpec.feature 'Projects', type: :feature, js: true do
       scenario 'removing DoD repositories' do
         visit(project_repositories_path(project: project_with_dod_repo))
         within '.repository-container' do
-          click_link('Delete repository')
+          accept_alert do
+            click_link('Delete repository')
+          end
         end
+        expect(page).to have_text 'Successfully removed repository'
         expect(project_with_dod_repo.repositories).to be_empty
       end
 
@@ -256,7 +259,9 @@ RSpec.feature 'Projects', type: :feature, js: true do
         expect(page).to have_text 'Successfully removed Download on Demand'
         expect(repository.download_repositories.count).to eq 1
 
-        find(:xpath, "//a[@href='/download_repositories/#{download_repository_2.id}?project=#{project_with_dod_repo}'][text()='Delete']").click
+        accept_alert do
+          find(:xpath, "//a[@href='/download_repositories/#{download_repository_2.id}?project=#{project_with_dod_repo}'][text()='Delete']").click
+        end
         expect(page).to have_text "Download on Demand can't be removed: DoD Repositories must have at least one repository."
         expect(repository.download_repositories.count).to eq 1
       end

--- a/src/api/spec/features/webui/sign_up_spec.rb
+++ b/src/api/spec/features/webui/sign_up_spec.rb
@@ -1,6 +1,6 @@
 require 'browser_helper'
 
-RSpec.feature 'Sign up', type: :feature do
+RSpec.feature 'Sign up', type: :feature, js: true do
   let!(:user) { build(:user) }
 
   scenario 'User' do

--- a/src/api/spec/support/vcr.rb
+++ b/src/api/spec/support/vcr.rb
@@ -11,11 +11,8 @@ VCR.configure do |config|
     !http_message.body.valid_encoding?
   end
 
-  config.ignore_request do |request|
-    # Ignore capybara identify calls. For more details:
-    #   http://stackoverflow.com/questions/6119669/using-webmock-with-cucumber
-    request.uri =~ /0.0.0.0:\d*\/__identify__/
-  end
+  # ignore selenium requests
+  config.ignore_localhost = true
   config.ignore_hosts 'www.gravatar.com' # Ignore gravatar calls
   config.ignore_hosts 'selenium'
 end

--- a/src/api/spec/support/vcr.rb
+++ b/src/api/spec/support/vcr.rb
@@ -14,9 +14,10 @@ VCR.configure do |config|
   config.ignore_request do |request|
     # Ignore capybara identify calls. For more details:
     #   http://stackoverflow.com/questions/6119669/using-webmock-with-cucumber
-    request.uri =~ /127.0.0.1:\d{5}\/__identify__/
+    request.uri =~ /0.0.0.0:\d*\/__identify__/
   end
   config.ignore_hosts 'www.gravatar.com' # Ignore gravatar calls
+  config.ignore_hosts 'selenium'
 end
 
 RSpec.configure do |config|


### PR DESCRIPTION
chromium is a beast with many dependencies and as such is pretty expensive within the frontend container. As communication with the driver is through tcp, leaving the chromedriver in a container in itself is possible, if not natural.

This makes it possible to use *any* container, there is no need to build it against the SUT's platform. I picked a debian one from github, but we could replace it also with a Tumbleweed or Leap15 one.

And no, it doesn't work as yet and there are some parts left from my attempts to run chromium within container.