### PR TITLE
[frontend] Fix rendering of staging project rings

### DIFF
--- a/src/api/app/views/webui/obs_factory/staging_projects/_openqa_jobs.html.erb
+++ b/src/api/app/views/webui/obs_factory/staging_projects/_openqa_jobs.html.erb
@@ -6,7 +6,7 @@
 <% else %>
   <ul>
     <% project.openqa_jobs.each do |job| %>
-      <li class="openqa_job"><%= render job %></li>
+      <li class="openqa_job"><%= render(template: 'webui/obs_factory/openqa_jobs/_openqa_job', locals: { openqa_job: job }) %></li>
     <% end %>
   </ul>
 <% end %>


### PR DESCRIPTION
Sub-projects of the staging projects would cause a 500 due to broken
rendering. We already solved a similiar issue in 46838faab49589d4513cc
and overlooked that this page was broken as well.

F, [2018-06-25T08:09:55.491889 #16020] FATAL -- : [c7807bec-311c-4626-a2d3-dc4d84559596] [16020:673.15] ActionView::Template::Error (Missing partial webui/obs_factory/obs_factory/openqa_jobs/_openqa_job with {:locale=>[:en], :formats=>[:html], :variants=>[], :handlers=>[:raw, :erb, :html, :builder, :ruby, :coffee, :haml]}. Searched in:
  * "/srv/www/obs/api/app/views/webui/theme/bento"
  * "/srv/www/obs/api/app/views"
  * "/usr/lib64/ruby/gems/2.5.0/gems/peek-mysql2-1.2.0/app/views"
  * "/usr/lib64/ruby/gems/2.5.0/gems/peek-host-1.0.0/app/views"
  * "/usr/lib64/ruby/gems/2.5.0/gems/peek-dalli-1.2.0/app/views"
  * "/usr/lib64/ruby/gems/2.5.0/gems/peek-1.0.1/app/views"
  * "/usr/lib64/ruby/gems/2.5.0/gems/kaminari-core-1.1.1/app/views"
):

Co-authored-by: Eduardo Navarro <enavarro@suse.com>