### PR TITLE
Revert "Update power_assert: 1.1.2 → 1.1.3 (patch)"

### DIFF
--- a/src/api/Gemfile.lock
+++ b/src/api/Gemfile.lock
@@ -244,7 +244,7 @@ GEM
       cliver (~> 0.3.1)
       websocket-driver (>= 0.2.0)
     popper_js (1.12.9)
-    power_assert (1.1.3)
+    power_assert (1.1.2)
     powerpack (0.1.2)
     pry (0.11.3)
       coderay (~> 1.1.0)


### PR DESCRIPTION
Reverts openSUSE/open-build-service#5194

This caused our test suite to break:

`  1) Packages changing the package's devel project
     Failure/Error: expect(page).to have_text("Created by #{user.login}")
       expected to find text "Created by package_test_user" in "Watchlist\n \nOpen Build Service > Request 1 package_test_user | Tasks | Home Project | Logout\nOverview\nRequest 1 (review)\nHey, why not?\n Add a review\n Created by  package_test_user now\n In state review\n Open review for home:other_package_test_user / branch_test_package\n Open review for project_1134 / develpackage\nChange Devel\nSet the devel project to package project_1134 / develpackage for package home:package_test_user / develpackage\nComments for request 1 (0)\n \nMy Decision\n  \nRequest History\n package_test_user\tcreated request\t now\nHey, why not?\npackage_test_user:\nYour Profile\nHome Project\nLogout\nLocations\nProjects\nSearch\nStatus Monitor\nHelp\nOpen Build Service\nOBS Manuals\nopenSUSEs OBS Portal\nReporting a Bug\nContact\nMailing List\nForums\nChat (IRC)\nTwitter\nOpen Build Service (OBS) is an openSUSE project.". (However, it was found 1 time including non-visible text.)
     # ./spec/features/webui/packages_spec.rb:155:in `block (2 levels) in <top (required)>'
     # ./spec/support/logging.rb:4:in `block (2 levels) in <top (required)>'`