### PR TITLE
Require rubocop/rake_task gem only when needed

### DIFF
--- a/src/api/lib/tasks/dev.rake
+++ b/src/api/lib/tasks/dev.rake
@@ -2,7 +2,6 @@
 
 require 'fileutils'
 require 'yaml'
-require 'rubocop/rake_task'
 
 namespace :dev do
   task :prepare, [:old_test_suite] do |_t, args|
@@ -80,6 +79,8 @@ namespace :dev do
   end
   namespace :lint do
     namespace :rubocop do
+      require 'rubocop/rake_task'
+
       task all: [:root, :rails] do
       end
       desc 'Run the ruby linter in rails'


### PR DESCRIPTION
Prevent loading `rubocop/rake_task` gem in such tasks as `dev:boostrap`, needed when creating the `obs-api` package.

Co-authored-by: Björn Geuken <bgeuken@suse.de>