### PR TITLE
[frontend] Fix slow hash performance (rubocop)

### DIFF
--- a/src/api/.rubocop_todo.yml
+++ b/src/api/.rubocop_todo.yml
@@ -517,12 +517,6 @@ Naming/VariableNumber:
     - 'spec/features/webui/projects_spec.rb'
     - 'test/unit/project_test.rb'
 
-# Offense count: 1
-# Cop supports --auto-correct.
-Performance/InefficientHashSearch:
-  Exclude:
-    - 'app/models/user.rb'
-
 # Offense count: 2
 # Cop supports --auto-correct.
 Performance/RegexpMatch:

--- a/src/api/app/models/user.rb
+++ b/src/api/app/models/user.rb
@@ -882,7 +882,7 @@ class User < ApplicationRecord
                     'sha256crypt' => 5 }
     if deprecated_password_hash_type == 'md5'
       Digest::MD5.hexdigest(value + deprecated_password_salt)
-    elsif crypt2index.keys.include?(deprecated_password_hash_type)
+    elsif crypt2index.key?(deprecated_password_hash_type)
       value.crypt("$#{crypt2index[deprecated_password_hash_type]}$#{deprecated_password_salt}$").split('$')[3]
     end
   end


### PR DESCRIPTION
`Hash#keys.include?` is less efficient than `Hash#key?`
because the former allocates a new array and then performs
an O(n) search through that array, while `Hash#key?` does
not allocate any array and performs a faster O(1) search
for the key.