### PR TITLE
[frontend] Fix wrong references to openQA job group

### DIFF
--- a/src/api/app/views/webui/obs_factory/distributions/show.html.haml
+++ b/src/api/app/views/webui/obs_factory/distributions/show.html.haml
@@ -78,7 +78,7 @@
       - if @versions[:totest]
         %li
           Testing:
-          = link_to @versions[:totest], "#{openqa_links_helper}/tests/overview?distri=opensuse&version=#{@distribution.openqa_version}&group=#{@distribution.openqa_group}"
+          = link_to @versions[:totest], "#{openqa_links_helper}/tests/overview?distri=opensuse&version=#{@distribution.openqa_version}"
 
       - if @versions[:published]
         %li
@@ -87,7 +87,7 @@
 
     %h2
       %i.fa.fa-2.fa-wrench
-      = link_to "openQA results for #{@versions[:totest]}", "#{openqa_links_helper}/tests/overview?distri=opensuse&version=#{@distribution.openqa_version}&build=#{@versions[:totest]}&group=#{@distribution.openqa_group}"
+      = link_to "openQA results for #{@versions[:totest]}", "#{openqa_links_helper}/tests/overview?distri=opensuse&version=#{@distribution.openqa_version}&build=#{@versions[:totest]}"
 
     %p
       - unless @openqa_jobs.empty?


### PR DESCRIPTION
Previously the "obs_factory" dashboard was resolving an openQA job group
based on a naming convention about the name, major version and minor
version. As discussed in https://progress.opensuse.org/issues/37105 we
would like to reduce the setup and maintenance for setup of minor
versions. On top, defining *one* job group in openQA could be limiting
too much anyway so it is better to let openQA just resolve all matching
test results by itself.

https://build.opensuse.org/project/dashboard/openSUSE:Leap:15.0/ shows
how links to the openQA tests overview were previously generated.
https://build.opensuse.org/project/dashboard/openSUSE:Leap:15.1/
currently shows an error because there is no job group "openSUSE Leap
15.1" and the plan is to not create it but instead use "openSUSE Leap
15". However, we might want to use sub-groups and specifying the
top-level job group will also not do what is intended therefore it is
better to leave out the job group as part of the URL completely.