### PR TITLE
[frontend] Adapt openQA job group version resolution for openSUSE Leap 15

### DIFF
--- a/src/api/.rubocop_todo.yml
+++ b/src/api/.rubocop_todo.yml
@@ -593,6 +593,7 @@ RSpec/FilePath:
     - 'spec/helpers/webui/build_result_helper.rb'
     - 'spec/jobs/bs_request_action_webui_infos_job.rb'
     - 'spec/jobs/project_log_rotate_job_spec.rb'
+    - 'spec/models/obs_factory/distribution_strategy_opensuse_spec.rb'
     - 'spec/models/event/comment_spec.rb'
     - 'spec/models/image_template_spec.rb'
     - 'spec/script/db_checker.rb'

--- a/src/api/app/helpers/webui/obs_factory/application_helper.rb
+++ b/src/api/app/helpers/webui/obs_factory/application_helper.rb
@@ -1,5 +1,11 @@
 module Webui::ObsFactory::ApplicationHelper
-    def openqa_links_helper
-      ObsFactory::OpenqaJob.openqa_links_url
-    end
+  def openqa_links_helper
+    ObsFactory::OpenqaJob.openqa_links_url
+  end
+
+  def distribution_tests_url(distribution, version = nil)
+    path = "#{openqa_links_helper}/tests/overview?distri=opensuse&version=#{distribution.openqa_version}"
+    path << "&build=#{version}" if version
+    path
+  end
 end

--- a/src/api/app/models/obs_factory/distribution_strategy_opensuse.rb
+++ b/src/api/app/models/obs_factory/distribution_strategy_opensuse.rb
@@ -13,7 +13,9 @@ module ObsFactory
     end
 
     def openqa_version
-      opensuse_leap_version
+      # Only use major version to find the openSUSE Leap job group since we use
+      # the same job group for the whole codestream
+      opensuse_leap_version[0..1]
     end
 
     def openqa_group

--- a/src/api/app/views/webui/obs_factory/distributions/show.html.haml
+++ b/src/api/app/views/webui/obs_factory/distributions/show.html.haml
@@ -78,7 +78,7 @@
       - if @versions[:totest]
         %li
           Testing:
-          = link_to @versions[:totest], "#{openqa_links_helper}/tests/overview?distri=opensuse&version=#{@distribution.openqa_version}"
+          = link_to @versions[:totest], distribution_tests_url(@distribution)
 
       - if @versions[:published]
         %li
@@ -87,7 +87,7 @@
 
     %h2
       %i.fa.fa-2.fa-wrench
-      = link_to "openQA results for #{@versions[:totest]}", "#{openqa_links_helper}/tests/overview?distri=opensuse&version=#{@distribution.openqa_version}&build=#{@versions[:totest]}"
+      = link_to "openQA results for #{@versions[:totest]}", distribution_tests_url(@distribution, @versions[:totest])
 
     %p
       - unless @openqa_jobs.empty?

--- a/src/api/app/views/webui/obs_factory/distributions/show.html.haml
+++ b/src/api/app/views/webui/obs_factory/distributions/show.html.haml
@@ -78,7 +78,7 @@
       - if @versions[:totest]
         %li
           Testing:
-          = link_to @versions[:totest], "#{openqa_links_helper}/tests/overview?distri=opensuse&version=#{@distribution.openqa_version}&group=#{@distribution.openqa_group}"
+          = link_to @versions[:totest], "#{openqa_links_helper}/tests/overview?distri=opensuse&version=#{@distribution.openqa_version}"
 
       - if @versions[:published]
         %li
@@ -87,7 +87,7 @@
 
     %h2
       %i.fa.fa-2.fa-wrench
-      = link_to "openQA results for #{@versions[:totest]}", "#{openqa_links_helper}/tests/overview?distri=opensuse&version=#{@distribution.openqa_version}&build=#{@versions[:totest]}&group=#{@distribution.openqa_group}"
+      = link_to "openQA results for #{@versions[:totest]}", "#{openqa_links_helper}/tests/overview?distri=opensuse&version=#{@distribution.openqa_version}&build=#{@versions[:totest]}"
 
     %p
       - unless @openqa_jobs.empty?

--- a/src/api/spec/helpers/webui/obs_factory/application_helper_spec.rb
+++ b/src/api/spec/helpers/webui/obs_factory/application_helper_spec.rb
@@ -1,0 +1,21 @@
+require 'rails_helper'
+
+RSpec.describe Webui::ObsFactory::ApplicationHelper, type: :helper do
+  describe '#distribution_tests_link' do
+    let(:distribution) { ObsFactory::Distribution.new(create(:project, name: 'openSUSE:Leap:42.3')) }
+
+    it 'creates a url to the openqa distribution tests' do
+      expect(distribution_tests_url(distribution)).to eq(
+        'https://openqa.opensuse.org/tests/overview?distri=opensuse&version=42'
+      )
+    end
+
+    context 'when a version is provided' do
+      it 'adds the version to the version to the url' do
+        expect(distribution_tests_url(distribution, 'my_version')).to eq(
+          'https://openqa.opensuse.org/tests/overview?distri=opensuse&version=42&build=my_version'
+        )
+      end
+    end
+  end
+end

--- a/src/api/spec/models/obs_factory/distribution_strategy_opensuse_spec.rb
+++ b/src/api/spec/models/obs_factory/distribution_strategy_opensuse_spec.rb
@@ -1,0 +1,11 @@
+require 'rails_helper'
+
+RSpec.describe ObsFactory::DistributionStrategyOpenSUSE do
+  describe '#openqa_version' do
+    let(:strategy) { ObsFactory::DistributionStrategyOpenSUSE.new(project: create(:project, name: 'openSUSE:Leap:42.3')) }
+
+    it 'returns the openqa version of a distribution' do
+      expect(strategy.openqa_version).to eq('42')
+    end
+  end
+end


### PR DESCRIPTION
For openSUSE Leap 15.1 we want to switch the openQA workflow to mention
the major number or the "codestream" only for openQA job groups to save
the setup effort.

Related progress issue: https://progress.opensuse.org/issues/37105