### PR TITLE
[doc] Fix outdated reference to :frontend in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -167,7 +167,7 @@ You can access the frontend at [localhost:3000](http://localhost:3000). Whatever
 9. Changed something in the frontend? Test your changes!
 
     ```
-    rake docker:test:frontend
+    rake docker:test:rspec
     rake docker:test:lint
     ```
 


### PR DESCRIPTION
Fixes a documentation regression introduced by 81542e1db.