### PR TITLE
[ci] Use in memory database in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,8 @@ aliases:
           EAGER_LOAD: 1
           <<: *cc_test_reporter_id
       - image: registry.opensuse.org/obs/server/unstable/container/leap/42.3/images/openbuildservice/mariadb:latest
-        command: /usr/lib/mysql/mysql-systemd-helper start
+        command: |
+          /bin/bash -c 'echo -e "[mysqld]\ndatadir = /dev/shm" > /etc/my.cnf.d/obs.cnf && cp -a /var/lib/mysql/* /dev/shm && /usr/lib/mysql/mysql-systemd-helper start'
         name: db
       - image: registry.opensuse.org/obs/server/unstable/container/leap/42.3/images/openbuildservice/memcached:latest
         name: cache
@@ -21,7 +22,8 @@ aliases:
           NOKOGIRI_USE_SYSTEM_LIBRARIES: 1
           <<: *cc_test_reporter_id
       - image: registry.opensuse.org/obs/server/unstable/container/leap/42.3/images/openbuildservice/mariadb:latest
-        command: /usr/lib/mysql/mysql-systemd-helper start
+        command: |
+          /bin/bash -c 'echo -e "[mysqld]\ndatadir = /dev/shm" > /etc/my.cnf.d/obs.cnf && cp -a /var/lib/mysql/* /dev/shm && /usr/lib/mysql/mysql-systemd-helper start'
         name: db
   - &restore_bundle_cache
     keys:

--- a/contrib/start_test_db
+++ b/contrib/start_test_db
@@ -1,8 +1,8 @@
 #!/bin/bash
 # Copy our data dir to the tmpfs mount
-cp -a /var/lib/mysql/* /var/lib/mysql_tmpfs
+cp -a /var/lib/mysql/* /dev/shm
 # Remove all our databases
-rm -rf /var/lib/mysql_tmpfs/api*
+rm -rf /dev/shm/api*
 # Configure the new datadir
-echo -e "[mysqld]\ndatadir = /var/lib/mysql_tmpfs" > /etc/my.cnf.d/obs.cnf
+echo -e "[mysqld]\ndatadir = /dev/shm" > /etc/my.cnf.d/obs.cnf
 /usr/lib/mysql/mysql-systemd-helper start

--- a/docker-compose.ci.yml
+++ b/docker-compose.ci.yml
@@ -21,8 +21,8 @@ services:
   db:
     image: registry.opensuse.org/obs/server/unstable/container/sle12/sp3/images/openbuildservice/mariadb:latest
     volumes:
-      - mysql_vol:/var/lib/mysql_tmpfs/
       - .:/obs
+    shm_size: 512MB
     command: /obs/contrib/start_test_db
   backend:
     image: registry.opensuse.org/obs/server/unstable/container/sle12/sp3/images/openbuildservice/backend:latest
@@ -30,8 +30,3 @@ services:
       - .:/obs
     working_dir: /obs
     command: make -C src/backend test
-volumes:
-  mysql_vol:
-    driver_opts:
-      type: tmpfs
-      device: tmpfs


### PR DESCRIPTION
Before we used a tmpfs in Travis. As this is not possible in CircleCI
we directly mount the data directory into /dev/shm.