### PR TITLE
[ci] Enable rspec-retry again when explicit set for a feature test

### DIFF
--- a/src/api/spec/README.md
+++ b/src/api/spec/README.md
@@ -205,6 +205,11 @@ To find out which tests we skip, you can ```grep``` for:
 fillup-templates
 ```
 
+#### Flaky tests
+Sometimes a feature test is flaky and it fails the first run. This is especially a problem in the package build in OBS as the test suite run is significant longer as it is not parallelized. As a workaround we use [rspec-retry](https://github.com/NoRedInk/rspec-retry) which runs a test again if it fails.
+
+However, it should be desired to fix the test that it always succeeds. Therefore you need to flag the test with ``retry: 3``, otherwise rspec-retry will not run the test again. In the package build, we always retry feature tests.
+
 ### Migrating tests
 When migrating tests from the old minitest based suite to rspec, please add the
 file path of the new one to every test covered.

--- a/src/api/spec/browser_helper.rb
+++ b/src/api/spec/browser_helper.rb
@@ -12,6 +12,4 @@ require 'support/features/features_bootstrap'
 # https://www.relishapp.com/rspec/rspec-core/v/2-12/docs/example-groups/shared-examples
 Dir['./spec/support/shared_examples/features/*.rb'].each { |example| require example }
 
-if ENV['RETRY'].present?
-  require 'support/features/features_rspec_retry'
-end
+require 'support/features/features_rspec_retry'

--- a/src/api/spec/features/webui/projects_spec.rb
+++ b/src/api/spec/features/webui/projects_spec.rb
@@ -184,7 +184,7 @@ RSpec.feature 'Projects', type: :feature, js: true do
         login admin_user
       end
 
-      scenario 'adding DoD repositories' do
+      scenario 'adding DoD repositories', retry: 3 do
         visit(project_repositories_path(project: admin_user.home_project_name))
         click_link('Add DoD repository')
         fill_in('Repository name', with: 'My DoD repository')

--- a/src/api/spec/support/features/features_rspec_retry.rb
+++ b/src/api/spec/support/features/features_rspec_retry.rb
@@ -5,9 +5,10 @@ RSpec.configure do |config|
   # show exception that triggers a retry if verbose_retry is set to true
   config.display_try_failure_messages = true
 
-  # run retry only on features
-  config.around :each, :js do |ex|
-    ex.run_with_retry retry: 3
+  if ENV['RETRY'].present?
+    config.around :each, :js do |ex|
+      ex.run_with_retry retry: 3
+    end
   end
 
   # callback to be run between retries


### PR DESCRIPTION
It is now possible to flag a test with retry: 3 to also retry in CI.
Before it was only enabled for package builds in OBS.
However, we had some flaky tests in CI which we now explicit set.
This makes it possible to maintain a list of flaky tests with the advantage
of running these flaky tests nevertheless.