### PR TITLE
[backend] bs_dodup: support | delimited debian URLs

### DIFF
--- a/src/backend/bs_dodup
+++ b/src/backend/bs_dodup
@@ -207,6 +207,8 @@ sub dod_rpmmd {
 
 # same parser as in build package:
 #   distribution:   <baseurl>/<dist>/[components]
+#                   or
+#                   <baseurl|dist[|component[|component]]>
 #   flat repo:      <baseurl>/.[/subdir]
 #     components:   comp1,comp2... (main if empty)
 sub dod_deb {
@@ -221,6 +223,15 @@ sub dod_deb {
     @components = ('.');
     $url = defined($2) ? "$1$2" : $1;
     $url .= '/' unless $url =~ /\/$/;
+  } elsif ($url =~ /\|/) {
+    # Dist and components split by |
+    my @parts = split(/\|/, $url);
+    $baseurl = shift @parts;
+    my $dist = shift @parts;
+    @components = @parts;
+    push @components, 'main' unless @components;
+    $baseurl .= '/' unless $baseurl =~ /\/$/;
+    $url = "${baseurl}dists/${dist}/";
   } else {
     if ($url =~ /([^\/]+)$/) {
       @components = split(/[,+]/, $1);


### PR DESCRIPTION
The debian distro and components are currently parsed by taking trailing
parts of the URL path split with /. This means that the distro and
components cannot contain /s, but both are legal characters in debian
repository specifiers. For instance, the debian security repository uses
distro names of <release>/updates as described in
https://www.debian.org/security/#keeping-secure.

To support this, allow a URL syntax where the distro and components are
delimited by |. For example, a URL for the above security repo would be
http://security.debian.org/debian-security/|stable/updates|main.

https://github.com/openSUSE/open-build-service/issues/5217