### PR TITLE
[dist] add %verify(not mode group) for /srv/www/obs/api/config/secret.key

### DIFF
--- a/dist/obs-server.spec
+++ b/dist/obs-server.spec
@@ -719,7 +719,7 @@ usermod -a -G docker obsservicerun
 %ghost /srv/www/obs/api/log/error.log
 %ghost /srv/www/obs/api/log/lastevents.access.log
 %ghost /srv/www/obs/api/log/production.log
-%ghost %attr(0640,root,www) %secret_key_file
+%ghost %attr(0640,root,www) %verify(not mode group) %secret_key_file
 
 %files -n obs-common
 %defattr(-,root,root)


### PR DESCRIPTION
to make rpm happy for openSUSE Leap 15.0 and SLE 15