### PR TITLE
[frontend] Fix rubocop offense: Naming/PredicateName

### DIFF
--- a/src/api/app/models/obs_factory/staging_project.rb
+++ b/src/api/app/models/obs_factory/staging_project.rb
@@ -253,7 +253,7 @@ module ObsFactory
       :acceptable
     end
 
-    def is_testing?(openqa_jobs)
+    def testing?(openqa_jobs)
       # empty == the ISOs may still be syncing
       openqa_jobs.empty? || openqa_jobs.any? { |job| job.result == 'none' }
     end
@@ -266,7 +266,7 @@ module ObsFactory
     def openqa_state
       # no openqa result for adi staging project
       return :acceptable if adi_staging?
-      return :testing if is_testing?(openqa_jobs)
+      return :testing if testing?(openqa_jobs)
 
       return :acceptable if all_passed?(openqa_jobs)
       # something failed on openqa side, needs manual check


### PR DESCRIPTION
After updating the initial implementation of RuboCop rake tasks for OBS (#5173)
we switched to using the RuboCop::RakeTask library (#5182).
This change caused that the *:all task was only running one of the two
RuboCop setups in our test suite.
PR#5219 solved that issue and this commit cleans up the remaining
RuboCop offenses.