### PR TITLE
[ci] No need to start memcached for tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,15 +6,12 @@ aliases:
       - image: registry.opensuse.org/obs/server/unstable/container/sle12/sp3/images/openbuildservice/frontend-backend:latest
         environment:
           NOKOGIRI_USE_SYSTEM_LIBRARIES: 1
-          NO_MEMCACHED: 1
           EAGER_LOAD: 1
           <<: *cc_test_reporter_id
       - image: registry.opensuse.org/obs/server/unstable/container/sle12/sp3/images/openbuildservice/mariadb:latest
         command: |
           /bin/bash -c 'echo -e "[mysqld]\ndatadir = /dev/shm" > /etc/my.cnf.d/obs.cnf && cp -a /var/lib/mysql/* /dev/shm && /usr/lib/mysql/mysql-systemd-helper start'
         name: db
-      - image: registry.opensuse.org/obs/server/unstable/container/sle12/sp3/images/openbuildservice/memcached:latest
-        name: cache
   - &frontend_base
     docker:
       - image: registry.opensuse.org/obs/server/unstable/container/sle12/sp3/images/openbuildservice/frontend-base:latest

--- a/contrib/start_minitest
+++ b/contrib/start_minitest
@@ -4,7 +4,6 @@ export NOKOGIRI_USE_SYSTEM_LIBRARIES=1; bundle install --jobs=3 --retry=3 --path
 echo "Preparing application..."
 bundle exec rake dev:bootstrap[old_test_suite] RAILS_ENV=test
 echo "Running api test suite..."
-export NO_MEMCACHED=1
 bundle exec rake test:api
 tmp_exit=$?
 rm -rf .bundle vendor/bundle

--- a/contrib/start_spider
+++ b/contrib/start_spider
@@ -4,7 +4,6 @@ export NOKOGIRI_USE_SYSTEM_LIBRARIES=1; bundle install --jobs=3 --retry=3 --path
 echo "Preparing application..."
 bundle exec rake dev:bootstrap[old_test_suite] RAILS_ENV=test
 echo "Running spider test..."
-export NO_MEMCACHED=1
 bundle exec rake test:spider
 tmp_exit=$?
 rm -rf .bundle vendor/bundle

--- a/docker-compose.ci.yml
+++ b/docker-compose.ci.yml
@@ -14,10 +14,7 @@ services:
       - .:/obs
     depends_on:
       - db
-      - cache
     command: /obs/contrib/start_minitest
-  cache:
-    image: registry.opensuse.org/obs/server/unstable/container/leap/42.3/images/openbuildservice/memcached:latest
   db:
     image: registry.opensuse.org/obs/server/unstable/container/leap/42.3/images/openbuildservice/mariadb:latest
     volumes:

--- a/src/api/script/start_test_backend
+++ b/src/api/script/start_test_backend
@@ -2,7 +2,6 @@
 ENV['RAILS_ENV'] ||= 'test'
 ENV['origin_RAILS_ENV'] ||= ENV['RAILS_ENV']
 ENV['LC_ALL'] = 'C'
-no_memcached = ENV['NO_MEMCACHED']
 require File.expand_path(File.join(File.dirname(__FILE__), '..', 'config', 'environment'))
 require 'builder'
 
@@ -32,29 +31,6 @@ if File.exist?(backend_config)
   puts 'Old backend data is there. checking if we can stop it'
   ['bs_srcserver', 'bs_repserver', 'bs_servicedispatch', 'bs_service', 'bs_sched', 'bs_publish'].each do |srv|
     system("cd #{backend_config} && exec ./#{srv} --stop 2>&1 && sleep 2")
-  end
-end
-
-# if we run the testsuite in a container, we run memcached in a dedicated container
-unless no_memcached
-  memcached_pid = %x(ps -C memcached -o pid=).strip
-  if memcached_pid.to_i > 0
-    memcached_npid = 0
-    puts "memcached already started (pid=#{memcached_pid})\."
-  else
-    puts "memcached not started.\nTrying to start it ..."
-    if Etc.getpwuid(Process::Sys.geteuid).name == 'root'
-      success = system('/usr/sbin/memcached', '-d', '-u', 'wwwrun')
-    else
-      success = system('/usr/sbin/memcached', '-d')
-    end
-    if success
-      memcached_npid = %x(ps -C memcached -o pid=).strip
-      puts "memcached started (pid=#{memcached_npid})\."
-    else
-      puts "memcached couldn't become started. Abort."
-      exit 1
-    end
   end
 end
 
@@ -353,8 +329,6 @@ at_exit do
   Process.kill 'TERM', reposrv_out.pid
   Process.kill 'TERM', servicedispatchsrv_out.pid
   Process.kill 'TERM', servicesrv_out.pid
-
-  Process.kill 'TERM', memcached_npid if memcached_npid.to_i > 0
 
   srcsrv_out.close
   srcsrv_out = nil


### PR DESCRIPTION
The rails cache store used is mem_store, which is purely
in process. Dalli is only used in product and development