### PR TITLE
[ci] Reset the cache before each rspec suite

### DIFF
--- a/src/api/spec/cassettes/Login/in_kerberos_mode/for_a_request_that_requires_authentication/and_Negotiate_header_is_not_set/informs_the_client_tool_browser_that_kerberos_authentication_is_required.yml
+++ b/src/api/spec/cassettes/Login/in_kerberos_mode/for_a_request_that_requires_authentication/and_Negotiate_header_is_not_set/informs_the_client_tool_browser_that_kerberos_authentication_is_required.yml
@@ -1,0 +1,56 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://backend:5352/build/_workerstatus
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '1018'
+    body:
+      encoding: UTF-8
+      string: |
+        <workerstatus clients="0">
+          <waiting arch="i586" jobs="0" />
+          <waiting arch="x86_64" jobs="0" />
+          <blocked arch="i586" jobs="0" />
+          <blocked arch="x86_64" jobs="0" />
+          <buildavg arch="i586" buildavg="1200" />
+          <buildavg arch="x86_64" buildavg="1200" />
+          <partition>
+            <daemon type="srcserver" state="running" starttime="1530246095" />
+            <daemon type="service" state="running" starttime="1530246101" />
+            <daemon type="scheduler" arch="i586" state="running" starttime="1530246101">
+              <queue high="0" med="0" low="0" next="0" />
+            </daemon>
+            <daemon type="scheduler" arch="x86_64" state="running" starttime="1530246101">
+              <queue high="0" med="0" low="0" next="0" />
+            </daemon>
+            <daemon type="repserver" state="running" starttime="1530246099" />
+            <daemon type="dispatcher" state="running" starttime="1530246101" />
+            <daemon type="publisher" state="running" starttime="1530246101" />
+            <daemon type="signer" state="running" starttime="1530246102" />
+          </partition>
+        </workerstatus>
+    http_version: 
+  recorded_at: Fri, 29 Jun 2018 10:55:05 GMT
+recorded_with: VCR 4.0.0

--- a/src/api/spec/cassettes/Login/in_kerberos_mode/for_a_request_that_requires_authentication/and_Negotiate_header_is_not_set/informs_users_about_failed_kerberos_authentication_and_possible_cause.yml
+++ b/src/api/spec/cassettes/Login/in_kerberos_mode/for_a_request_that_requires_authentication/and_Negotiate_header_is_not_set/informs_users_about_failed_kerberos_authentication_and_possible_cause.yml
@@ -1,0 +1,56 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://backend:5352/build/_workerstatus
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '1018'
+    body:
+      encoding: UTF-8
+      string: |
+        <workerstatus clients="0">
+          <waiting arch="i586" jobs="0" />
+          <waiting arch="x86_64" jobs="0" />
+          <blocked arch="i586" jobs="0" />
+          <blocked arch="x86_64" jobs="0" />
+          <buildavg arch="i586" buildavg="1200" />
+          <buildavg arch="x86_64" buildavg="1200" />
+          <partition>
+            <daemon type="srcserver" state="running" starttime="1530246095" />
+            <daemon type="service" state="running" starttime="1530246101" />
+            <daemon type="scheduler" arch="i586" state="running" starttime="1530246101">
+              <queue high="0" med="0" low="0" next="0" />
+            </daemon>
+            <daemon type="scheduler" arch="x86_64" state="running" starttime="1530246101">
+              <queue high="0" med="0" low="0" next="0" />
+            </daemon>
+            <daemon type="repserver" state="running" starttime="1530246099" />
+            <daemon type="dispatcher" state="running" starttime="1530246101" />
+            <daemon type="publisher" state="running" starttime="1530246101" />
+            <daemon type="signer" state="running" starttime="1530246102" />
+          </partition>
+        </workerstatus>
+    http_version: 
+  recorded_at: Fri, 29 Jun 2018 10:55:06 GMT
+recorded_with: VCR 4.0.0

--- a/src/api/spec/cassettes/Login/in_kerberos_mode/for_a_request_with_valid_kerberos_ticket/authenticates_the_user.yml
+++ b/src/api/spec/cassettes/Login/in_kerberos_mode/for_a_request_with_valid_kerberos_ticket/authenticates_the_user.yml
@@ -1,0 +1,56 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://backend:5352/build/_workerstatus
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '1018'
+    body:
+      encoding: UTF-8
+      string: |
+        <workerstatus clients="0">
+          <waiting arch="i586" jobs="0" />
+          <waiting arch="x86_64" jobs="0" />
+          <blocked arch="i586" jobs="0" />
+          <blocked arch="x86_64" jobs="0" />
+          <buildavg arch="i586" buildavg="1200" />
+          <buildavg arch="x86_64" buildavg="1200" />
+          <partition>
+            <daemon type="srcserver" state="running" starttime="1530277773" />
+            <daemon type="service" state="running" starttime="1530277779" />
+            <daemon type="scheduler" arch="i586" state="running" starttime="1530277779">
+              <queue high="0" med="0" low="3" next="0" />
+            </daemon>
+            <daemon type="scheduler" arch="x86_64" state="running" starttime="1530277779">
+              <queue high="0" med="0" low="3" next="0" />
+            </daemon>
+            <daemon type="repserver" state="running" starttime="1530277777" />
+            <daemon type="dispatcher" state="running" starttime="1530277779" />
+            <daemon type="publisher" state="running" starttime="1530277779" />
+            <daemon type="signer" state="running" starttime="1530277779" />
+          </partition>
+        </workerstatus>
+    http_version: 
+  recorded_at: Fri, 29 Jun 2018 13:09:48 GMT
+recorded_with: VCR 4.0.0

--- a/src/api/spec/cassettes/Login/login_via_widget.yml
+++ b/src/api/spec/cassettes/Login/login_via_widget.yml
@@ -50,4 +50,57 @@ http_interactions:
         </workerstatus>
     http_version: 
   recorded_at: Mon, 04 Apr 2016 14:06:08 GMT
-recorded_with: VCR 3.0.1
+- request:
+    method: get
+    uri: http://backend:5352/build/_workerstatus
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '1018'
+    body:
+      encoding: UTF-8
+      string: |
+        <workerstatus clients="0">
+          <waiting arch="i586" jobs="0" />
+          <waiting arch="x86_64" jobs="0" />
+          <blocked arch="i586" jobs="0" />
+          <blocked arch="x86_64" jobs="0" />
+          <buildavg arch="i586" buildavg="1200" />
+          <buildavg arch="x86_64" buildavg="1200" />
+          <partition>
+            <daemon type="srcserver" state="running" starttime="1530275878" />
+            <daemon type="service" state="running" starttime="1530275884" />
+            <daemon type="scheduler" arch="i586" state="running" starttime="1530275884">
+              <queue high="0" med="0" low="3" next="0" />
+            </daemon>
+            <daemon type="scheduler" arch="x86_64" state="running" starttime="1530275884">
+              <queue high="0" med="0" low="3" next="0" />
+            </daemon>
+            <daemon type="repserver" state="running" starttime="1530275882" />
+            <daemon type="dispatcher" state="running" starttime="1530275884" />
+            <daemon type="publisher" state="running" starttime="1530275884" />
+            <daemon type="signer" state="running" starttime="1530275884" />
+          </partition>
+        </workerstatus>
+    http_version: 
+  recorded_at: Fri, 29 Jun 2018 12:39:00 GMT
+recorded_with: VCR 4.0.0

--- a/src/api/spec/rails_helper.rb
+++ b/src/api/spec/rails_helper.rb
@@ -69,3 +69,6 @@ require 'feature/testing'
 
 # support Delayed Jobs
 require 'support/delayed_job'
+
+# Cache reset
+require 'support/cache'

--- a/src/api/spec/support/cache.rb
+++ b/src/api/spec/support/cache.rb
@@ -1,0 +1,6 @@
+# reset the cache before each test
+RSpec.configure do |config|
+  config.before do
+    Rails.cache.clear
+  end
+end


### PR DESCRIPTION
With things like database_cleaner you really want to make sure that
tests don't pollute each other with stale cache items

(rails defaults to null_store in test environment, but that's a
harsher measure)