### PR TITLE
[backend] new env var OBS_SERVICE_DAEMON in bs_service

### DIFF
--- a/src/backend/bs_service
+++ b/src/backend/bs_service
@@ -139,6 +139,7 @@ sub run_source_update {
   $::ENV{'OBS_SERVICE_PACKAGE'} = $packid;
   $::ENV{'OBS_SERVICE_APIURL'} = $BSConfig::api_url if $BSConfig::api_url;
   $::ENV{'OBS_NAME'} = $BSConfig::obsname if $BSConfig::obsname;
+  $::ENV{'OBS_SERVICE_DAEMON'} = 1;
   $::ENV{'no_proxy'} = $noproxy if $noproxy;
 
   # run all services

--- a/src/backend/call-service-in-docker.sh
+++ b/src/backend/call-service-in-docker.sh
@@ -111,6 +111,7 @@ printlog "Creating INNERSCRIPT '$MOUNTDIR/$INNERSCRIPT'"
 echo "#!/bin/bash"                                                                          > "$MOUNTDIR/$INNERSCRIPT"
 echo "export OBS_SERVICE_APIURL=\"$OBS_SERVICE_APIURL\""                                   >> "$MOUNTDIR/$INNERSCRIPT"
 echo "export OBS_SERVICE_BUNDLE_GEMS_MIRROR_URL=\"$OBS_SERVICE_BUNDLE_GEMS_MIRROR_URL\""   >> "$MOUNTDIR/$INNERSCRIPT"
+echo "export OBS_SERVICE_DAEMON=\"$OBS_SERVICE_DAEMON\""                                   >> "$MOUNTDIR/$INNERSCRIPT"
 echo "cd $INNERSRCDIR"                                                                     >> "$MOUNTDIR/$INNERSCRIPT"
 echo -n "${INNERSCRIPT}.command"                                                           >> "$MOUNTDIR/$INNERSCRIPT"
 


### PR DESCRIPTION
This is required in to ensure in service, that they were started
by OBS. Services can then try to fix problems like broken caches
automatically.