### PR TITLE
[frontend] Refactor parsing of openSUSE Leap version

### DIFF
--- a/src/api/app/models/obs_factory/distribution_strategy_opensuse.rb
+++ b/src/api/app/models/obs_factory/distribution_strategy_opensuse.rb
@@ -2,20 +2,18 @@ module ObsFactory
 
   # this class tracks the differences between Factory and the upcoming release
   class DistributionStrategyOpenSUSE < DistributionStrategyFactory
+    SIGNATURE = /openSUSE:(?<full_name>.+:(?<version>(?<major_version>\d+)\.(?<minor_version>\d+)))/
+
     def opensuse_version
-      # Remove the "openSUSE:" part
-      project.name[9..-1]
+      distribution[:full_name]
     end
 
     def opensuse_leap_version
-      # Remove the "openSUSE:Leap:" part
-      project.name[14..-1]
+      distribution[:version]
     end
 
     def openqa_version
-      # Only use major version to find the openSUSE Leap job group since we use
-      # the same job group for the whole codestream
-      opensuse_leap_version[0..1]
+      distribution[:major_version]
     end
 
     def openqa_group
@@ -64,5 +62,10 @@ module ObsFactory
       return "match=#{opensuse_leap_version}:S:#{project.letter}"
     end
 
+    private
+
+    def distribution
+      SIGNATURE.match(project.name)
+    end
   end
 end

--- a/src/api/spec/models/obs_factory/distribution_strategy_opensuse_spec.rb
+++ b/src/api/spec/models/obs_factory/distribution_strategy_opensuse_spec.rb
@@ -1,11 +1,23 @@
 require 'rails_helper'
 
 RSpec.describe ObsFactory::DistributionStrategyOpenSUSE do
-  describe '#openqa_version' do
-    let(:strategy) { ObsFactory::DistributionStrategyOpenSUSE.new(project: create(:project, name: 'openSUSE:Leap:42.3')) }
+  let(:strategy) { ObsFactory::DistributionStrategyOpenSUSE.new(project: create(:project, name: 'openSUSE:Leap:42.3')) }
 
+  describe '#openqa_version' do
     it 'returns the openqa version of a distribution' do
       expect(strategy.openqa_version).to eq('42')
+    end
+  end
+
+  describe '#opensuse_version' do
+    it 'returns the openqa version of a distribution' do
+      expect(strategy.opensuse_version).to eq('Leap:42.3')
+    end
+  end
+
+  describe '#opensuse_leap_version' do
+    it 'returns the openqa version of a distribution' do
+      expect(strategy.opensuse_leap_version).to eq('42.3')
     end
   end
 end


### PR DESCRIPTION
Use a regex with named captures to make it more visible what we print
out for the various *_version methods.