### PR TITLE
Support search for multibuild packages

### DIFF
--- a/src/api/app/controllers/webui/search_controller.rb
+++ b/src/api/app/controllers/webui/search_controller.rb
@@ -56,7 +56,7 @@ class Webui::SearchController < Webui::WebuiController
       unless disturl_pkgrev.nil?
         disturl_rev, disturl_package = disturl_pkgrev.split('-', 2)
       end
-      if Package.exists_by_project_and_name(disturl_project, disturl_package)
+      if Package.exists_by_project_and_name(disturl_project, disturl_package, follow_multibuild: true)
         redirect_to controller: 'package', action: 'show', project: disturl_project, package: disturl_package, rev: disturl_rev
         return
       else

--- a/src/api/app/models/package.rb
+++ b/src/api/app/models/package.rb
@@ -223,7 +223,8 @@ class Package < ApplicationRecord
 
   # to check existens of a project (local or remote)
   def self.exists_by_project_and_name(project, package, opts = {})
-    opts = { follow_project_links: true, allow_remote_packages: false }.merge(opts)
+    opts = { follow_project_links: true, allow_remote_packages: false, follow_multibuild: false }.merge(opts)
+    package = striping_multibuild_suffix(package) if opts[:follow_multibuild]
     begin
       prj = Project.get_by_name(project)
     rescue Project::UnknownObjectError

--- a/src/api/spec/models/package_spec.rb
+++ b/src/api/spec/models/package_spec.rb
@@ -675,5 +675,43 @@ Wed Aug  2 14:59:15 UTC 2017 - iggy@opensuse.org
       end
     end
   end
+
+  describe '.exists_by_project_and_name' do
+    subject { package.name }
+
+    let(:project_name) { package.project.name }
+
+    context 'for local package' do
+      it 'returns true for an existing package' do
+        expect(Package.exists_by_project_and_name(project_name, subject)).to be_truthy
+      end
+
+      it 'returns false for a not existing package' do
+        expect(Package.exists_by_project_and_name(project_name, 'does-not-exist:hello-world')).to be_falsey
+      end
+
+      it 'returns false for a not existing project' do
+        expect(Package.exists_by_project_and_name('does-not-exist', subject)).to be_falsey
+      end
+    end
+
+    context 'for multibuild package' do
+      it 'returns true for an existing local package' do
+        expect(Package.exists_by_project_and_name(project_name, subject, follow_multibuild: true)).to be_truthy
+      end
+
+      it 'returns true for an existing multibuild package' do
+        expect(Package.exists_by_project_and_name(project_name, "#{subject}:hello-world", follow_multibuild: true)).to be_truthy
+      end
+
+      it 'returns false for a not existing multibuild package' do
+        expect(Package.exists_by_project_and_name(project_name, 'does-not-exist:hello-world', follow_multibuild: true)).to be_falsey
+      end
+
+      it 'returns false for an existing multibuild package without follow_multibuild option' do
+        expect(Package.exists_by_project_and_name(project_name, "#{subject}:hello-world")).to be_falsey
+      end
+    end
+  end
 end
 # rubocop:enable Metrics/BlockLength


### PR DESCRIPTION
before we ignored multibuild packages when searching with a distribution URL.
Fix #5232.