### PR TITLE
[webui] Add focus to reply comment textarea

### DIFF
--- a/src/api/app/assets/javascripts/webui/application/comment.js
+++ b/src/api/app/assets/javascripts/webui/application/comment.js
@@ -28,6 +28,7 @@ function reloadCommentBindings() {
   $('.togglable_comment').click(function () {
       var toggleid = $(this).data("toggle");
       $("#" + toggleid).toggle();
+      $("#" + toggleid + ' .comment_reply_body').focus();
   });
 
   // prevent duplicate comment submissions

--- a/src/api/app/views/webui/comment/_reply.html.haml
+++ b/src/api/app/views/webui/comment/_reply.html.haml
@@ -3,7 +3,7 @@
     %p
       = hidden_field_tag :commentable_type, commentable.class
       = hidden_field_tag :commentable_id, commentable.id
-      ~ f.text_area :body, size: '80x1', onkeyup: 'sz(this);', onclick: 'sz(this);', id: "reply_body_#{comment.id}", placeholder: 'Comment Text', required: true
+      ~ f.text_area :body, size: '80x1', onkeyup: 'sz(this);', onclick: 'sz(this);', class: 'comment_reply_body', id: "reply_body_#{comment.id}", placeholder: 'Comment Text', required: true
       = f.hidden_field :parent_id, value: comment.id, id: "reply_parent_id_#{comment.id}"
     %p
       = f.submit 'Add reply', id: "add_reply_#{comment.id}"


### PR DESCRIPTION
because otherwise the user needs to do two clicks before he can write a comment.
Fix #5055.