### PR TITLE
[backend] fix implementation of genmetaalgo 1 in BSBuild

### DIFF
--- a/src/backend/BSBuild.pm
+++ b/src/backend/BSBuild.pm
@@ -73,6 +73,10 @@ sub gen_meta {
   # sort
   @deps = sort {$helper1{$a} <=> $helper1{$b} || $helper2{$a} cmp $helper2{$b} || $a cmp $b} @deps;
 
+  # ignore self-cycles
+  if (%cycle) {
+    delete $cycle{$_} for @subp;
+  }
   # handle cycles
   my %cycdepseen;
   if (%cycle) {


### PR DESCRIPTION
It was different to the implementation in perl-BSSolv, leading
to endless rebuilds in some rare cases.