### PR TITLE
[frontend] Switch from unicorn to puma as app server

### DIFF
--- a/dist/obs-server.spec
+++ b/dist/obs-server.spec
@@ -690,7 +690,6 @@ usermod -a -G docker obsservicerun
 /srv/www/obs/api/config/boot.rb
 /srv/www/obs/api/config/routes.rb
 /srv/www/obs/api/config/environments/development.rb
-/srv/www/obs/api/config/unicorn
 %attr(0640,root,%apache_group) %config(noreplace) %verify(md5) /srv/www/obs/api/config/database.yml
 %attr(0640,root,%apache_group) /srv/www/obs/api/config/database.yml.example
 %attr(0644,root,root) %config(noreplace) %verify(md5) /srv/www/obs/api/config/options.yml

--- a/src/api/Gemfile
+++ b/src/api/Gemfile
@@ -131,12 +131,6 @@ group :test do
   gem 'rspec_junit_formatter'
 end
 
-# Gems used only during development not required in production environments by default.
-group :development do
-  # as alternative to the standard IRB shell
-  gem 'unicorn-rails' # webrick won't work
-end
-
 group :development, :test do
   gem 'rspec'
   # as testing framework
@@ -165,6 +159,8 @@ group :development, :test do
   gem 'single_test'
   # to find n+1 queries
   gem 'bullet'
+  # Use Puma as the app server (rails 5 default)
+  gem 'puma', '~> 3.11'
 end
 
 # Gems used only for assets and not required in production environments by default.

--- a/src/api/Gemfile.lock
+++ b/src/api/Gemfile.lock
@@ -177,7 +177,6 @@ GEM
       activerecord
       kaminari-core (= 1.1.1)
     kaminari-core (1.1.1)
-    kgio (2.11.0)
     launchy (2.4.3)
       addressable (~> 2.3)
     lograge (0.10.0)
@@ -250,6 +249,7 @@ GEM
       coderay (~> 1.1.0)
       method_source (~> 0.9.0)
     public_suffix (3.0.2)
+    puma (3.11.4)
     pundit (1.1.0)
       activesupport (>= 3.0.0)
     rack (2.0.5)
@@ -286,7 +286,6 @@ GEM
       rake (>= 0.8.7)
       thor (>= 0.18.1, < 2.0)
     rainbow (3.0.0)
-    raindrops (0.18.0)
     rake (12.3.1)
     rantly (1.1.0)
     rb-fsevent (0.10.3)
@@ -393,12 +392,6 @@ GEM
     uglifier (4.1.14)
       execjs (>= 0.3.0, < 3)
     unicode-display_width (1.4.0)
-    unicorn (5.3.0)
-      kgio (~> 2.6)
-      raindrops (~> 0.7)
-    unicorn-rails (2.2.1)
-      rack
-      unicorn
     uniform_notifier (1.11.0)
     vcr (4.0.0)
     voight_kampff (1.1.2)
@@ -476,6 +469,7 @@ DEPENDENCIES
   peek-mysql2
   poltergeist
   pry (>= 0.9.12)
+  puma (~> 3.11)
   pundit
   rails (~> 5.2.0)
   rails-controller-testing
@@ -502,7 +496,6 @@ DEPENDENCIES
   tilt (>= 1.4.1)
   timecop
   uglifier (>= 1.2.2)
-  unicorn-rails
   vcr
   voight_kampff
   webmock (>= 2.3.0)

--- a/src/api/config/unicorn/development.rb
+++ b/src/api/config/unicorn/development.rb
@@ -1,9 +1,0 @@
-worker_processes 4
-listen 3000
-
-after_fork do |server, _|
-  listener = server.listener_opts.first[0]
-  port = Integer(listener.split(':')[1])
-  ActiveXML.api.port = port
-  CONFIG['frontend_port'] = port
-end


### PR DESCRIPTION
Unicorn was needed in 2012 to merge app and webui as we had
multiple requests on one page and webrick is not multithreaded

But unicorn is pretty much dead by now and puma the default
app server if you start a new rails app

![](https://media.giphy.com/media/d4bnkJDjdFrMGEq4/giphy-tumblr.gif)