### PR TITLE
[webui] Run puma on port 3000 in dev

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,6 +26,7 @@ services:
     command: /obs/contrib/start_development_worker
   frontend:
     image: openbuildservice/frontend
+    command: foreman start -p 3000
     build:
       dockerfile: docker-files/Dockerfile
       context: src/api

--- a/src/api/Procfile
+++ b/src/api/Procfile
@@ -1,4 +1,4 @@
-web: bundle exec rails server
+web: bundle exec rails server -b 0.0.0.0
 delayed: bundle exec script/delayed_job.api.rb run
 clock: bundle exec clockworkd --log-dir=log -l -c config/clock.rb run 
 search: bundle exec rake ts:rebuild NODETACH=true


### PR DESCRIPTION
After we switched from unicorn to puma in #5284, the rails development server
started to run on port 5000.
This is caused by foreman as it sets the PORT environment variable to 5000.
There is also a bug in puma which does not respect the puma.rb configuration
when the  environment variable is set.
https://github.com/puma/puma/issues/939

Furthermore we need to bind now to 0.0.0.0 as puma binds by default to localhost
which is not exposed by docker.