### PR TITLE
Remove unreachable code

### DIFF
--- a/src/api/app/controllers/webui/user_controller.rb
+++ b/src/api/app/controllers/webui/user_controller.rb
@@ -88,7 +88,7 @@ class Webui::UserController < Webui::WebuiController
   end
 
   def icon
-    size = params[:size].to_i || '20'
+    size = params[:size].to_i
     user = User.find_by_login(params[:user])
     if user.nil? || (content = user.gravatar_image(size)) == :none
       redirect_to ActionController::Base.helpers.asset_path('default_face.png')


### PR DESCRIPTION
`params[:size].to_i` will always return a truthy value, so whatever comes after is never reached.

Co-authored-by: Dany Marcoux <dmarcoux@suse.com>