### PR TITLE
[webui] Reflect renaming of files in submit requests

### DIFF
--- a/src/api/app/helpers/webui/request_helper.rb
+++ b/src/api/app/helpers/webui/request_helper.rb
@@ -102,4 +102,10 @@ module Webui::RequestHelper
     end
     result
   end
+
+  def calculate_filename(filename, file_element)
+    return filename unless file_element['state'] == 'changed'
+    return filename if file_element['old']['name'] == filename
+    return "#{file_element['old']['name']} -> #{filename}"
+  end
 end

--- a/src/api/app/views/shared/_sourcediff.html.haml
+++ b/src/api/app/views/shared/_sourcediff.html.haml
@@ -35,7 +35,7 @@
               - unless @linkinfo
                 - rev = source[:rev]
                 - rev = (rev.to_i - 1).to_s if file_element['state'] == 'deleted'
-                = link_to_unless(Package.is_binary_file?(filename) || filename.include?('/'), filename, controller: 'package', action: 'view_file', project: source[:project], package: source[:package], filename: filename, rev: rev )
+                = link_to_unless(Package.is_binary_file?(filename) || filename.include?('/'), calculate_filename(filename, file_element), controller: 'package', action: 'view_file', project: source[:project], package: source[:package], filename: filename, rev: rev )
               - else
                 = filename
               - if index > 0

--- a/src/api/spec/helpers/webui/request_helper_spec.rb
+++ b/src/api/spec/helpers/webui/request_helper_spec.rb
@@ -47,4 +47,34 @@ RSpec.describe Webui::RequestHelper do
       it { expect(new_or_update_request(row)).to eq('submit') }
     end
   end
+
+  describe '#calculate_filename' do
+    let(:filename) { 'apache2' }
+
+    context 'for deleted files' do
+      let(:file_element) do
+        { state: 'deleted' }.with_indifferent_access
+      end
+
+      it { expect(calculate_filename(filename, file_element)).to eq(filename) }
+    end
+
+    context 'for added files' do
+      let(:file_element) do
+        { state: 'added' }.with_indifferent_access
+      end
+
+      it { expect(calculate_filename(filename, file_element)).to eq(filename) }
+    end
+
+    context 'for changed files' do
+      let(:file_element) do
+        { state: 'changed', old: { name: filename } }.with_indifferent_access
+      end
+      let(:new_filename) { 'apache3' }
+
+      it { expect(calculate_filename(filename, file_element)).to eq(filename) }
+      it { expect(calculate_filename(new_filename, file_element)).to eq("#{filename} -> #{new_filename}") }
+    end
+  end
 end


### PR DESCRIPTION
We just displayed the new name with changed which was confusing
because it is expected that we show the removed / renamed files.
Fix #4971.

![image](https://user-images.githubusercontent.com/3799140/42287196-c371388c-7fb5-11e8-99e7-caf27ff11a1d.png)
