### PR TITLE
[webui] Show all open reviews at top of request page

### DIFF
--- a/src/api/app/helpers/webui/request_helper.rb
+++ b/src/api/app/helpers/webui/request_helper.rb
@@ -108,4 +108,9 @@ module Webui::RequestHelper
     return filename if file_element['old']['name'] == filename
     return "#{file_element['old']['name']} -> #{filename}"
   end
+
+  def reviewer(review)
+    return "#{review[:by_project]} / #{review[:by_package]}" if review[:by_package]
+    review[:by_user] || review[:by_group] || review[:by_project]
+  end
 end

--- a/src/api/app/views/webui/request/show.html.erb
+++ b/src/api/app/views/webui/request/show.html.erb
@@ -67,6 +67,11 @@
               <%= sprite_tag('exclamation') %> Open review for <%= render :partial => 'reviewer', :locals => { :review => review } %>
             </li>
         <% end %>
+        <% @my_open_reviews.each do |review| %>
+            <li>
+              <%= sprite_tag('exclamation') %> Open review for <%= render partial: 'reviewer', locals: { review: review } %>
+            </li>
+        <% end %>
     <% end %>
   </div>
 </div>
@@ -257,8 +262,9 @@
               <% if @my_open_reviews.length > 0 %>
                   <% @my_open_reviews.each_with_index do |open_review, index| %>
                       <li class="<%= 'selected' if @my_open_reviews.length > 0 && index == 0 %>">
-                        <a class="review_descision_link" id="review_descision_link_<%= index %>" href="#">Review
-                          for <%= render :partial => 'reviewer', :locals => { :review => open_review, :no_icon => true } %></a>
+                        <a class="review_descision_link" id="review_descision_link_<%= index %>" href="#">
+                          Review for <%= reviewer(open_review) %>
+                        </a>
                       </li>
                   <% end %>
               <% end %>


### PR DESCRIPTION
and remove the links from the decision comment tabs.

Because this 'broke' the tabs as half of the tab was a link
to the user/group/package/project show page and
the other half was the actual tab change.
For user reviews it also included the user icon which looked broke the CSS.
The links are now at the top of the page so no need to add it to the tab.

Fix #4679 

Top of the page
![image](https://user-images.githubusercontent.com/3799140/42332889-7f5a0470-8079-11e8-8d91-55ae43709c12.png)

Decision comments tab
![image](https://user-images.githubusercontent.com/3799140/42332896-84c03dbc-8079-11e8-9a50-f3cfede38bb3.png)

