### PR TITLE
Create tests for gravatar_image in User model

### DIFF
--- a/src/api/app/models/user.rb
+++ b/src/api/app/models/user.rb
@@ -829,7 +829,6 @@ class User < ApplicationRecord
         hash = Digest::MD5.hexdigest(email.downcase)
         begin
           content = ActiveXML.backend.load_external_url("http://www.gravatar.com/avatar/#{hash}?s=#{size}&d=wavatar")
-          content.force_encoding('ASCII-8BIT') if content
         rescue ActiveXML::Transport::Error
           # ignored
         end

--- a/src/api/spec/models/user_spec.rb
+++ b/src/api/spec/models/user_spec.rb
@@ -551,4 +551,30 @@ RSpec.describe User do
       expect(user.can_create_project?('foo:bar')).to be true
     end
   end
+
+  describe '#gravatar_image' do
+    context 'gravatar configuration disabled' do
+      before do
+        allow(Configuration).to receive(:gravatar).and_return(false)
+      end
+
+      it { expect(user.gravatar_image(0)).to eq(:none) }
+    end
+
+    context 'gravatar configuration enabled' do
+      context 'problems loading the image' do
+        before do
+          allow(ActiveXML.backend).to receive(:load_external_url).and_raise(ActiveXML::Transport::Error)
+        end
+
+        it { expect(user.gravatar_image(0)).to eq(:none) }
+      end
+
+      before do
+        allow(ActiveXML.backend).to receive(:load_external_url).with(anything).and_return('some_content')
+      end
+
+      it { expect(user.gravatar_image(0)).to eq('some_content') }
+    end
+  end
 end


### PR DESCRIPTION
Also remove unnecessary ASCII-8BIT encoding.

Co-authored-by: Dany Marcoux <dmarcoux@suse.com>