### PR TITLE
[api] Implement webhooks

### DIFF
--- a/src/api/app/controllers/services/webhooks_controller.rb
+++ b/src/api/app/controllers/services/webhooks_controller.rb
@@ -1,0 +1,49 @@
+class Services::WebhooksController < ApplicationController
+  skip_before_action :extract_user
+  skip_before_action :require_login
+  skip_before_action :validate_params
+  before_action :validate_token, :set_package, :set_user
+
+  def create
+    if !@user.is_active? || !@user.can_modify?(@package)
+      render_error message: 'Token not found or not valid.', status: 404
+      return
+    end
+
+    Backend::Api::Sources::Package.trigger_services(@package.project.name, @package.name, @user.login)
+    render_ok
+  end
+
+  private
+
+  def set_package
+    @package = @token.package || Package.get_by_project_and_name(params[:project], params[:package], use_source: true)
+  end
+
+  def validate_token
+    @token = Token::Service.find_by(id: params[:id])
+    return if @token && @token.valid_signature?(signature, request.body.read)
+    render_error message: 'Token not found or not valid.', status: 403
+    return false
+  end
+
+  def set_user
+    @user = @token.user
+  end
+
+  # To trigger the webhook, the sender needs to
+  # generate a signature with a secret token.
+  # The signature needs to be generated over the
+  # payload of the HTTP request and stored
+  # in a HTTP header.
+  # GitHub: HTTP_X_HUB_SIGNATURE
+  # https://developer.github.com/webhooks/securing/
+  # Pagure: HTTP_X-Pagure-Signature-256
+  # https://docs.pagure.org/pagure/usage/using_webhooks.html
+  # Custom signature: HTTP_X_OBS_SIGNATURE
+  def signature
+    request.env['HTTP_X_OBS_SIGNATURE'] ||
+      request.env['HTTP_X_HUB_SIGNATURE'] ||
+      request.env['HTTP_X-Pagure-Signature-256']
+  end
+end

--- a/src/api/app/models/token/service.rb
+++ b/src/api/app/models/token/service.rb
@@ -1,4 +1,14 @@
 class Token::Service < Token
+  def valid_signature?(signature, body)
+    return false unless signature
+    ActiveSupport::SecurityUtils.secure_compare(signature_of(body), signature)
+  end
+
+  private
+
+  def signature_of(body)
+    'sha1=' + OpenSSL::HMAC.hexdigest(OpenSSL::Digest.new('sha1'), string, body)
+  end
 end
 
 # == Schema Information

--- a/src/api/app/views/person/token/create.xml.builder
+++ b/src/api/app/views/person/token/create.xml.builder
@@ -1,4 +1,5 @@
 xml.status(code: 'ok') do |status|
   status.summary 'Ok'
   status.data(@token.string, name: 'token')
+  status.data(@token.id, name: 'id')
 end

--- a/src/api/config/routes.rb
+++ b/src/api/config/routes.rb
@@ -509,6 +509,7 @@ OBSApi::Application.routes.draw do
 
     ### /trigger
     post 'trigger/runservice' => 'trigger#runservice'
+    post 'trigger/webhook' => 'services/webhooks#create'
 
     ### /issue_trackers
     get 'issue_trackers/issues_in' => 'issue_trackers#issues_in'

--- a/src/api/spec/cassettes/Services_WebhooksController/_create/with_HTTP_X-Pagure-Signature-256_http_header/behaves_like_it_verifies_the_signature/when_signature_is_valid/1_1_3_1_1_1.yml
+++ b/src/api/spec/cassettes/Services_WebhooksController/_create/with_HTTP_X-Pagure-Signature-256_http_header/behaves_like_it_verifies_the_signature/when_signature_is_valid/1_1_3_1_1_1.yml
@@ -1,0 +1,38 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: http://backend:5352/source/home:tom/apache2?cmd=runservice&user=tom
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Content-Type:
+      - application/octet-stream
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '21'
+    body:
+      encoding: UTF-8
+      string: '<status code="ok" />
+
+'
+    http_version: 
+  recorded_at: Mon, 16 Jul 2018 11:12:55 GMT
+recorded_with: VCR 4.0.0

--- a/src/api/spec/cassettes/Services_WebhooksController/_create/with_HTTP_X_HUB_SIGNATURE_http_header/behaves_like_it_verifies_the_signature/when_signature_is_valid/1_1_2_1_1_1.yml
+++ b/src/api/spec/cassettes/Services_WebhooksController/_create/with_HTTP_X_HUB_SIGNATURE_http_header/behaves_like_it_verifies_the_signature/when_signature_is_valid/1_1_2_1_1_1.yml
@@ -1,0 +1,38 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: http://backend:5352/source/home:tom/apache2?cmd=runservice&user=tom
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Content-Type:
+      - application/octet-stream
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '21'
+    body:
+      encoding: UTF-8
+      string: '<status code="ok" />
+
+'
+    http_version: 
+  recorded_at: Mon, 16 Jul 2018 11:12:56 GMT
+recorded_with: VCR 4.0.0

--- a/src/api/spec/cassettes/Services_WebhooksController/_create/with_HTTP_X_OBS_SIGNATURE_http_header/behaves_like_it_verifies_the_signature/when_signature_is_valid/1_1_1_1_1_1.yml
+++ b/src/api/spec/cassettes/Services_WebhooksController/_create/with_HTTP_X_OBS_SIGNATURE_http_header/behaves_like_it_verifies_the_signature/when_signature_is_valid/1_1_1_1_1_1.yml
@@ -1,0 +1,38 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: http://backend:5352/source/home:tom/apache2?cmd=runservice&user=tom
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Content-Type:
+      - application/octet-stream
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '21'
+    body:
+      encoding: UTF-8
+      string: '<status code="ok" />
+
+'
+    http_version: 
+  recorded_at: Mon, 16 Jul 2018 11:12:55 GMT
+recorded_with: VCR 4.0.0

--- a/src/api/spec/controllers/services/webhooks_controller_spec.rb
+++ b/src/api/spec/controllers/services/webhooks_controller_spec.rb
@@ -1,0 +1,97 @@
+require 'rails_helper'
+require 'webmock/rspec'
+
+RSpec.describe Services::WebhooksController, type: :controller, vcr: true do
+  describe '#create' do
+    let(:user) { create(:confirmed_user, login: 'tom') }
+    let(:service_token) { create(:service_token, user: user) }
+    let(:body) { { hello: :world }.to_json }
+    let(:project) { user.home_project }
+    let(:package) { create(:package_with_service, name: 'apache2', project: project) }
+    let(:signature) { 'sha1=' + OpenSSL::HMAC.hexdigest(OpenSSL::Digest.new('sha1'), service_token.string, body) }
+
+    shared_examples 'it verifies the signature' do
+      before do
+        request.headers[signature_header_name] = signature
+      end
+
+      context 'when signature is valid' do
+        let(:path) { "#{CONFIG['source_url']}/source/#{project.name}/#{package.name}?cmd=runservice&user=#{user.login}" }
+
+        before do
+          stub_request(:get, path).and_return(body: 'does not matter')
+          post :create, body: body, params: { id: service_token.id, project: project.name, package: package.name, format: :xml }
+        end
+
+        it { expect(response).to be_success }
+      end
+
+      context 'when token is invalid' do
+        it 'renders an error with an invalid signature' do
+          request.headers[signature_header_name] = 'sha1=invalid'
+          post :create, body: body, params: { id: service_token.id, project: project.name, package: package.name, format: :xml }
+          expect(response).to be_forbidden
+        end
+
+        it 'renders an error with an invalid token' do
+          invalid_token_id = 42
+          post :create, body: body, params: { id: invalid_token_id, project: project.name, package: package.name, format: :xml }
+          expect(response).to be_forbidden
+        end
+      end
+
+      context 'when user has no permissions' do
+        let(:project_without_permissions) { create(:project, name: 'Apache') }
+        let(:package_without_permissions) { create(:package_with_service, name: 'apache2', project: project_without_permissions) }
+        let(:inactive_user) { create(:user) }
+        let(:invalid_service_token) { create(:service_token, user: inactive_user) }
+
+        it 'renders an error for missing package permissions' do
+          params = { id: service_token.id, project: project_without_permissions.name, package: package_without_permissions.name, format: :xml }
+          post :create, body: body, params: params
+          expect(response).to be_not_found
+        end
+
+        it 'renders an error for an inactive user' do
+          signature = 'sha1=' + OpenSSL::HMAC.hexdigest(OpenSSL::Digest.new('sha1'), invalid_service_token.string, body)
+          request.headers[signature_header_name] = signature
+          params = { id: invalid_service_token.id, project: project.name, package: package.name, format: :xml }
+          post :create, body: body, params: params
+          expect(response).to be_not_found
+        end
+      end
+
+      context 'when entity does not exist' do
+        it 'renders an error for package' do
+          params = { id: service_token.id, project: project.name, package: 'does-not-exist', format: :xml }
+          post :create, body: body, params: params
+          expect(response).to be_not_found
+        end
+
+        it 'renders an error for project' do
+          params = { id: service_token.id, project: 'does-not-exist', package: package.name, format: :xml }
+          post :create, body: body, params: params
+          expect(response).to be_not_found
+        end
+      end
+    end
+
+    context 'with HTTP_X_OBS_SIGNATURE http header' do
+      let(:signature_header_name) { 'HTTP_X_OBS_SIGNATURE' }
+
+      it_behaves_like 'it verifies the signature'
+    end
+
+    context 'with HTTP_X_HUB_SIGNATURE http header' do
+      let(:signature_header_name) { 'HTTP_X_HUB_SIGNATURE' }
+
+      it_behaves_like 'it verifies the signature'
+    end
+
+    context 'with HTTP_X-Pagure-Signature-256 http header' do
+      let(:signature_header_name) { 'HTTP_X-Pagure-Signature-256' }
+
+      it_behaves_like 'it verifies the signature'
+    end
+  end
+end

--- a/src/api/spec/factories/tokens.rb
+++ b/src/api/spec/factories/tokens.rb
@@ -2,10 +2,10 @@ FactoryBot.define do
   factory :token do
     string { Faker::Lorem.characters(32) }
 
-    factory :service_token do
+    factory :service_token, class: Token::Service do
       type 'Token::Service'
     end
-    factory :rss_token do
+    factory :rss_token, class: Token::Rss do
       type 'Token::Rss'
     end
   end

--- a/src/api/spec/models/token/service_spec.rb
+++ b/src/api/spec/models/token/service_spec.rb
@@ -1,0 +1,22 @@
+require 'rails_helper'
+
+RSpec.describe Token::Service do
+  let(:user) { create(:user) }
+  let(:token) { create(:service_token, user: user) }
+  let(:body) { { hello: :world }.to_s }
+
+  describe '#valid_request?' do
+    context 'for a valid request' do
+      let(:signature) { 'sha1=' + OpenSSL::HMAC.hexdigest(OpenSSL::Digest.new('sha1'), token.string, body) }
+
+      it { expect(token).to be_valid_signature(signature, body) }
+    end
+
+    context 'for an invalid request' do
+      let(:signature) { 'sha1=just-not-valid' }
+
+      it { expect(token).not_to be_valid_signature(signature, body) }
+      it { expect(token).not_to be_valid_signature(nil, body) }
+    end
+  end
+end


### PR DESCRIPTION
GitHub announced the deprecation of GitHub services in favor of
    webhooks (on January 31, 2019 GitHub will stop
    delivering services events).
    WebHooks are designed different than services, therefore it was necessary to
    implement a dedicated controller.
    Unlike the OBS GitHub service, webhooks do not deliver the token anymore
    in the HTTP Header. Because of that it is not possible to compare
    the tokens anymore as part of the authentication process.
    
We used this opportunity to implement generic webhooks which support
for now GitHub, Pagure and a generic webhook.
To trigger a webhook, it is now necessary to generate a signature
    over the payload body with the secret token.
    To authorize, OBS verifies this signature.
    OBS supports for now three different HTTP header to submit this signature:
    * HTTP_X_OBS_SIGNATURE (generic OBS header)
    * HTTP_X_HUB_SIGNATURE (GitHub)
    * HTTP_X-Pagure-Signature-256 (Pagure)
    
It is now also necessary to send the token id with the webhook request.
    This PR introduces the new route:
    'trigger/service/github?id=42'
    
See these URLs for more details:
    https://developer.github.com/changes/2018-04-25-github-services-deprecation/
    https://developer.github.com/webhooks/securing/
    https://docs.pagure.org/pagure/usage/using_webhooks.html
