### PR TITLE
[ci] Use transaction strategy for database_cleaner

### DIFF
--- a/src/api/spec/support/database_cleaner.rb
+++ b/src/api/spec/support/database_cleaner.rb
@@ -12,7 +12,7 @@ RSpec.configure do |config|
     # Before the test suites runs make sure the database is empty
     log_level = Rails.logger.level
     Rails.logger.level = :fatal
-    DatabaseCleaner.clean_with(:truncation)
+    DatabaseCleaner.clean_with(:transaction)
     # and is seeded
     load "#{Rails.root}/db/seeds.rb"
     Rails.logger.level = log_level


### PR DESCRIPTION
This is an attempt to use a faster strategy for database_cleaner. Refer to the [database_cleaner's README](https://github.com/DatabaseCleaner/database_cleaner#what-strategy-is-fastest) for details.

Locally, I had a big speed improvement when running a single spec (**transaction - 38.7s, truncation - 1min 50s**). However, I don't know if the whole test suite will still be green with this change.