### PR TITLE
[ci] Running Lint in parallel with the rest

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -200,22 +200,13 @@ workflows:
   test_all:
     jobs:
       - lint
-      - rspec:
-          requires:
-            - lint
-      - rspec-bootstrap:
-          requires:
-            - lint
-      - minitest:
-          requires:
-            - lint
-      - spider:
-          requires:
-            - lint
-      - backend_test:
-          requires:
-            - lint
+      - rspec
+      - rspec-bootstrap
+      - minitest
+      - spider
+      - backend_test
       - upload_result:
           requires:
             - minitest
             - rspec
+            - lint


### PR DESCRIPTION
It's taking around 6 minutes and to test drive a change,
being thrown back because of a trailing whitespace can
be super annoying

A lint failure is a problem like any other test suite failure,
so run it in parallel