### PR TITLE
[frontend][api] Handle exception when changing column type

### DIFF
--- a/src/api/db/migrate/20170103132257_change_project_package_name_to_string.rb
+++ b/src/api/db/migrate/20170103132257_change_project_package_name_to_string.rb
@@ -4,7 +4,17 @@ class ChangeProjectPackageNameToString < ActiveRecord::Migration[5.0]
     execute 'UPDATE projects SET name = "" WHERE name is null'
     execute 'UPDATE packages SET name = SUBSTR(name, 1, 200)'
     execute 'UPDATE packages SET name = "" WHERE name is null'
-    change_column :projects, :name, :string, limit: 200, null: false
-    change_column :packages, :name, :string, limit: 200, null: false
+    begin
+      change_column :projects, :name, :string, limit: 200, null: false
+    rescue StandardError
+      execute 'ALTER TABLE projects DEFAULT CHARACTER SET utf8 COLLATE utf8_bin'
+      change_column :projects, :name, :string, limit: 200, null: false
+    end
+    begin
+      change_column :packages, :name, :string, limit: 200, null: false
+    rescue StandardError
+      execute 'ALTER TABLE packages DEFAULT CHARACTER SET utf8 COLLATE utf8_bin'
+      change_column :packages, :name, :string, limit: 200, null: false
+    end
   end
 end


### PR DESCRIPTION
Fixes #2574

Altering column type fails when collation is not set. When database is
initialized for the first time, character set and collation options are
set correctly. But in case a database has been upgraded since multiple
versions, then these options are sometimes not set.

This change will set character set and collation option for the column
if `change_column` raises a `StandardError` exception.