### PR TITLE
[frontend] Ignore db migration failure when dropping indexes

### DIFF
--- a/src/api/db/migrate/20170123115500_remove_duplicate_indexes.rb
+++ b/src/api/db/migrate/20170123115500_remove_duplicate_indexes.rb
@@ -144,6 +144,8 @@ class RemoveDuplicateIndexes < ActiveRecord::Migration[5.0]
     #	  `by_user` varchar(255) collate utf8_unicode_ci default null
     # To remove this duplicate index, execute:
     execute 'ALTER TABLE `reviews` DROP INDEX `index_reviews_on_state`;'
+  rescue
+    # Ignore failures based on https://github.com/openSUSE/open-build-service/issues/2949#issuecomment-292870618
   end
 
   def self.down


### PR DESCRIPTION
Addresses #2949

As recommended in issue #2949, we can ignore indexes in case of failure.
Instead of commenting individual ALTER TABLE lines, I've added an empty
`rescue` block to ignore any exceptions.