### PR TITLE
[frontend] Fix deprecation warnings for raw sql

### DIFF
--- a/src/api/app/mixins/has_relationships.rb
+++ b/src/api/app/mixins/has_relationships.rb
@@ -77,8 +77,8 @@ module HasRelationships
   end
 
   def maintainers
-    direct_users = relationships.with_users_and_roles_query.maintainers.pluck('users.login as login').map { |user| User.find_by_login!(user) }
-    users_in_groups = relationships.with_groups_and_roles_query.maintainers.pluck('groups.title as title'). \
+    direct_users = relationships.with_users_and_roles_query.maintainers.pluck('users.login').map { |user| User.find_by_login!(user) }
+    users_in_groups = relationships.with_groups_and_roles_query.maintainers.pluck('groups.title'). \
                       map { |title| Group.find_by_title!(title).users }.flatten
     (direct_users + users_in_groups).uniq
   end

--- a/src/api/app/models/relationship.rb
+++ b/src/api/app/models/relationship.rb
@@ -148,11 +148,11 @@ class Relationship < ApplicationRecord
   end
 
   def self.with_users_and_roles
-    with_users_and_roles_query.pluck('users.login as login, roles.title AS role_name')
+    with_users_and_roles_query.pluck('users.login', 'roles.title')
   end
 
   def self.with_groups_and_roles
-    with_groups_and_roles_query.pluck('groups.title as title', 'roles.title as role_name')
+    with_groups_and_roles_query.pluck('groups.title', 'roles.title')
   end
 
   private


### PR DESCRIPTION
"Dangerous query method (method whose arguments are used as raw SQL) called
with non-attribute argument(s): "groups.title as title", "roles.title as
role_name". Non-attribute arguments will be disallowed in Rails 6.0."

Fixes #5133