### PR TITLE
[frontend] Remove User#gravatar_hash

### DIFF
--- a/src/api/app/helpers/webui/user_helper.rb
+++ b/src/api/app/helpers/webui/user_helper.rb
@@ -5,7 +5,7 @@ module Webui::UserHelper
     alt = user.try(:login) if alt.empty?
     size = opt[:size] || 20
     if user && ::Configuration.gravatar
-      url = "http://www.gravatar.com/avatar/#{user.gravatar_hash}?s=#{size}&d=wavatar"
+      url = "http://www.gravatar.com/avatar/#{Digest::MD5.hexdigest(user.email.downcase)}?s=#{size}&d=wavatar"
     else
       url = 'default_face.png'
     end

--- a/src/api/app/models/user.rb
+++ b/src/api/app/models/user.rb
@@ -838,10 +838,6 @@ class User < ApplicationRecord
     update_attributes(last_logged_in_at: Time.now, login_failure_count: 0)
   end
 
-  def gravatar_hash
-    Digest::MD5.hexdigest(email.downcase)
-  end
-
   private
 
   def password_validation


### PR DESCRIPTION
This method is only needed by the view. So it should be in a helper
instead of a model. And since it's only used once and the code is rather
short we can generate the hash on the fly.

Follow up of #5352