### PR TITLE
[dist] Give codecov something to report

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -9,9 +9,7 @@ coverage:
   status:
     project:
       default:
-        target: auto
-        base: auto
-        threshold: 1
+        target: 88.5
 comment:
   layout: "reach, diff, flags"
   require_changes: true


### PR DESCRIPTION
One last theory about the lack of codecov reports is that
it's possibly silent when there is nothing to report.
So give it a target to compare against (88.5)