### PR TITLE
Have circleci check unintended cassette updates

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,6 +46,12 @@ aliases:
     name: Setup application
     command: cd src/api; bundle exec rake dev:bootstrap[old_test_suite] RAILS_ENV=test
 
+  - &start_remote_backend
+    name: Start Backend
+    command: |
+      sed -e "s,@CIRCLE_REPOSITORY_URL@,$CIRCLE_REPOSITORY_URL,; s,@CIRCLE_SHA1@,$CIRCLE_SHA1," -i contrib/trigger_checkout
+      nc backend 4000 < contrib/trigger_checkout
+
   # keep the prefix for the following aligned
   - &save_repo_cache_key
     key: v3-repo-{{ .Branch }}-{{ .Revision }}
@@ -109,9 +115,14 @@ jobs:
     docker:
       - <<: *frontend_base
       - <<: *mariadb
+      - image: *backend
+        name: backend
+        user: frontend
+        command: /bin/bash /remote_executor.sh
     steps:
       - *restore_repo
       - run: *install_dependencies
+      - run: *start_remote_backend
       - run: *wait_for_database
       - run: *create_test_db
       - run: mkdir /home/frontend/rspec

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -141,6 +141,8 @@ jobs:
               circleci tests split --total $((CIRCLE_NODE_TOTAL-1)) --split-by=timings < spec.list > $pickfile
             fi
             bundle exec rspec --format progress --format RspecJunitFormatter -o /home/frontend/rspec/rspec.xml $(cat $pickfile)
+            # checking if tests updated cassettes - they shouldn't
+            git diff --exit-code spec/cassettes
       - store_artifacts:
           path: ./src/api/log
           destination: rspec

--- a/contrib/trigger_checkout
+++ b/contrib/trigger_checkout
@@ -1,0 +1,12 @@
+#! /bin/sh
+
+set -e
+
+url=$(echo @CIRCLE_REPOSITORY_URL@ | sed -e 's,git@github.com:,https://github.com/,; s,\.git$,,')
+git clone $url /obs/bs
+cd /obs/bs
+git checkout @CIRCLE_SHA1@
+git submodule update --init
+
+/obs/bs/contrib/start_development_backend -d /obs/bs
+

--- a/docker-compose.ci.yml
+++ b/docker-compose.ci.yml
@@ -6,6 +6,7 @@ services:
       - .:/obs
     depends_on:
       - db
+      - backend
     command: /obs/contrib/start_rspec
   minitest:
     image: registry.opensuse.org/obs/server/unstable/container/leap/42.3/images/openbuildservice/frontend-backend:latest
@@ -27,3 +28,11 @@ services:
       - .:/obs
     working_dir: /obs
     command: make -C src/backend test
+  backend:
+    image: registry.opensuse.org/obs/server/unstable/container/leap/42.3/images/openbuildservice/backend:latest
+    volumes:
+      - .:/obs
+      - ./dist/aws_credentials:/etc/obs/cloudupload/.aws/config
+      - ./dist/ec2utils.conf:/etc/obs/cloudupload/.ec2utils.conf
+      - ./dist/clouduploader.rb:/usr/bin/clouduploader
+    command: /obs/contrib/start_development_backend -d /obs


### PR DESCRIPTION
Yet another way to sell the idea :)

I'm having a hard time debugging https://circleci.com/gh/coolo/open-build-service/1227#tests/containers/2 as the test behaves different with write_through and different on circleci than on dev containers

If we had a running backend, the test would pass but we would fail in cassette update checks and I could extract the diff into my checkout to fix it.
