### PR TITLE
[ci] Do not report indivual coverage reports but merge manually

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -130,6 +130,12 @@ jobs:
               circleci tests split --total $((CIRCLE_NODE_TOTAL-1)) --split-by=timings < spec.list > $pickfile
             fi
             bundle exec rspec --format progress --format RspecJunitFormatter -o /home/frontend/rspec/rspec.xml $(cat $pickfile)
+            mkdir coverage_results
+            cp -R coverage/.resultset.json coverage_results/resultset-rspec-${CIRCLE_NODE_INDEX}.json
+      - persist_to_workspace:
+          root: .
+          paths:
+            - src/api/coverage_results
       - store_artifacts:
           path: ./src/api/log
           destination: rspec
@@ -171,6 +177,12 @@ jobs:
                 bundle exec rake test:api:functional
                 ;;
             esac
+            mkdir coverage_results
+            cp -R coverage/.resultset.json coverage_results/resultset-minitest-${CIRCLE_NODE_INDEX}.json
+      - persist_to_workspace:
+          root: .
+          paths:
+            - src/api/coverage_results
       - store_test_results:
           path: /home/frontend/minitest
       - <<: *store_minitest_artefacts
@@ -201,6 +213,28 @@ jobs:
           name: backend
           command: make -C src/backend test
 
+  coverage:
+    docker:
+      - <<: *frontend_base
+
+    steps:
+      - *restore_repo
+      - run: *install_dependencies
+      - attach_workspace:
+         at: .
+      - run:
+          name: Merge and check coverage
+          command: |
+            cd src/api
+            export COVERALLS_REPO_TOKEN=HWLJwfiFsKPGEOzfgllO3pP3rqV540Qt3
+            bundle exec rake ci:simplecov_ci_merge
+      - store_artifacts:
+          path: src/api/coverage
+          destination: coverage
+      - store_artifacts:
+          path: src/api/coverage_results
+          destination: raw_coverage
+
 workflows:
   version: 2
   test_all:
@@ -218,3 +252,7 @@ workflows:
       - spider:
           requires:
             - checkout_code
+      - coverage:
+          requires:
+            - rspec
+            - minitest

--- a/codecov.yml
+++ b/codecov.yml
@@ -3,8 +3,6 @@ fixes:
 codecov:
   ci:
     - !travis-ci.org
-  notify:
-    require_ci_to_pass: yes
 coverage:
   status:
     project:

--- a/src/api/Gemfile
+++ b/src/api/Gemfile
@@ -128,6 +128,7 @@ group :test do
   # To generate random data
   gem 'rantly', '>= 1.1.0'
   # for test analysis in CircleCI
+  gem 'coveralls'
   gem 'minitest-ci'
   gem 'rspec_junit_formatter'
 end

--- a/src/api/Gemfile.lock
+++ b/src/api/Gemfile.lock
@@ -105,6 +105,12 @@ GEM
     concurrent-ruby (1.0.5)
     concurrent-ruby-ext (1.0.5)
       concurrent-ruby (= 1.0.5)
+    coveralls (0.8.22)
+      json (>= 1.8, < 3)
+      simplecov (~> 0.16.1)
+      term-ansicolor (~> 1.3)
+      thor (~> 0.19.4)
+      tins (~> 1.6)
     crack (0.4.3)
       safe_yaml (~> 1.0.0)
     crass (1.0.4)
@@ -378,6 +384,8 @@ GEM
       sprockets (>= 3.0.0)
     sysexits (1.2.0)
     temple (0.8.0)
+    term-ansicolor (1.6.0)
+      tins (~> 1.0)
     test-unit (3.2.8)
       power_assert
     thinking-sphinx (4.0.0)
@@ -387,10 +395,11 @@ GEM
       joiner (>= 0.2.0)
       middleware (>= 0.1.0)
       riddle (~> 2.3)
-    thor (0.20.0)
+    thor (0.19.4)
     thread_safe (0.3.6)
     tilt (2.0.8)
     timecop (0.9.1)
+    tins (1.16.3)
     tzinfo (1.2.5)
       thread_safe (~> 0.1)
     uglifier (4.1.14)
@@ -439,6 +448,7 @@ DEPENDENCIES
   codemirror-rails
   coffee-rails
   colorize
+  coveralls
   cssmin (>= 1.0.2)
   daemons
   dalli

--- a/src/api/lib/tasks/coverage.rake
+++ b/src/api/lib/tasks/coverage.rake
@@ -1,26 +1,8 @@
 namespace :ci do
-  desc 'Generate merged coverage report'
-  task :simplecov_ci_merge do
-    require 'simplecov'
-    require 'codecov'
-    require 'coveralls'
-
-    # initialize data members
-    # and configure simplecov
+  def merged_results(glob)
     coverage_results = []
-    SimpleCov.filters.clear
-    SimpleCov.merge_timeout 100_000
-
-    SimpleCov.configure do
-      add_group('WebUI') { |file| file.filename =~ %r{webui} && file.filename !~ %r{obs_factory} }
-      add_group('Jobs') { |file| file.filename =~ %r{jobs/} }
-      add_group('Models') { |file| file.filename =~ %r{models/} && file.filename !~ %r{obs_factory} }
-      add_group('Helpers') { |file| file.filename =~ %r{helpers/} && file.filename !~ %r{webui} }
-      add_group('API Controllers') { |file| file.filename =~ %r{controllers/} && file.filename !~ %r{webui} }
-      add_group('Factory Dashboard') { |file| file.filename =~ %r{obs_factory} }
-    end
     base_dir = Rails.root.join('coverage_results')
-    Dir["#{base_dir}/resultset*.json"].each do |file|
+    Dir["#{base_dir}/" + glob].each do |file|
       # load json results from coverage folder
       file_results = JSON.parse(File.read(file))
 
@@ -32,13 +14,44 @@ namespace :ci do
     end
 
     # merge results from array to results object
-    merged_results = SimpleCov::ResultMerger.merge_results(*coverage_results)
+    SimpleCov::ResultMerger.merge_results(*coverage_results)
+  end
 
+  desc 'Generate merged coverage report'
+  task :simplecov_ci_merge do
+    require 'simplecov'
+    require 'codecov'
+    require 'coveralls'
+
+    # initialize data members
+    # and configure simplecov
+    SimpleCov.filters.clear
+    SimpleCov.merge_timeout 100_000
+
+    SimpleCov.configure do
+      add_group('WebUI') { |file| file.filename =~ %r{webui} && file.filename !~ %r{obs_factory} }
+      add_group('Jobs') { |file| file.filename =~ %r{jobs/} }
+      add_group('Models') { |file| file.filename =~ %r{models/} && file.filename !~ %r{obs_factory} }
+      add_group('Helpers') { |file| file.filename =~ %r{helpers/} && file.filename !~ %r{webui} }
+      add_group('API Controllers') { |file| file.filename =~ %r{controllers/} && file.filename !~ %r{webui} }
+      add_group('Factory Dashboard') { |file| file.filename =~ %r{obs_factory} }
+    end
+
+    # upload the result for all
     SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter.new [
       Coveralls::SimpleCov::Formatter,
       SimpleCov::Formatter::HTMLFormatter,
       SimpleCov::Formatter::Codecov
     ]
-    merged_results.format!
+    merged_results('resultset*.json').format!
+
+    # render subsets
+    SimpleCov.coverage_dir('coverage/rspec')
+    SimpleCov.formatter = SimpleCov::Formatter::HTMLFormatter
+    merged_results('resultset-rspec*.json').format!
+
+    SimpleCov.coverage_dir('coverage/minitest')
+    SimpleCov.formatter = SimpleCov::Formatter::HTMLFormatter
+    merged_results('resultset-minitest*.json').format!
   end
 end

--- a/src/api/lib/tasks/coverage.rake
+++ b/src/api/lib/tasks/coverage.rake
@@ -9,7 +9,16 @@ namespace :ci do
     # and configure simplecov
     coverage_results = []
     SimpleCov.filters.clear
+    SimpleCov.merge_timeout 100_000
 
+    SimpleCov.configure do
+      add_group('WebUI') { |file| file.filename =~ %r{webui} && file.filename !~ %r{obs_factory} }
+      add_group('Jobs') { |file| file.filename =~ %r{jobs/} }
+      add_group('Models') { |file| file.filename =~ %r{models/} && file.filename !~ %r{obs_factory} }
+      add_group('Helpers') { |file| file.filename =~ %r{helpers/} && file.filename !~ %r{webui} }
+      add_group('API Controllers') { |file| file.filename =~ %r{controllers/} && file.filename !~ %r{webui} }
+      add_group('Factory Dashboard') { |file| file.filename =~ %r{obs_factory} }
+    end
     base_dir = Rails.root.join('coverage_results')
     Dir["#{base_dir}/resultset*.json"].each do |file|
       # load json results from coverage folder

--- a/src/api/lib/tasks/coverage.rake
+++ b/src/api/lib/tasks/coverage.rake
@@ -1,20 +1,35 @@
-namespace :test do
-  desc 'Measures test coverage'
-  task :coverage do
-    rm_f 'coverage'
-    rm_f 'coverage.data'
-    rcov = 'rcov -Itest --rails --aggregate coverage.data -x " rubygems/*,/Library/Ruby/Site/*,gems/*,rcov*,active_rbac*,rbac_helper.rb"'
-    system("#{rcov} --no-html test/unit/*_test.rb")
-    system("#{rcov} --html -t test/functional/*_test.rb")
-    puts 'xdg-open coverage/index.html'
-  end
+namespace :ci do
+  desc 'Generate merged coverage report'
+  task :simplecov_ci_merge do
+    require 'simplecov'
+    require 'codecov'
+    require 'coveralls'
 
-  desc 'Measures test coverage but don\'t display it'
-  task :rcov do
-    rm_rf 'coverage'
-    mkdir 'coverage'
-    rcov = 'rcov -Itest --rails --aggregate coverage/aggregate.data -x " rubygems/*,/Library/Ruby/Site/*,gems/*,rcov*,active_rbac*,rbac_helper.rb"'
-    system("#{rcov} --html -t test/unit/*_test.rb")
-    system("#{rcov} --html -t test/functional/*_test.rb")
+    # initialize data members
+    # and configure simplecov
+    coverage_results = []
+    SimpleCov.filters.clear
+
+    base_dir = Rails.root.join('coverage_results')
+    Dir["#{base_dir}/resultset*.json"].each do |file|
+      # load json results from coverage folder
+      file_results = JSON.parse(File.read(file))
+
+      # parse results from coverage file to array
+      file_results.each do |command, data|
+        result = SimpleCov::Result.from_hash(command => data)
+        coverage_results << result
+      end
+    end
+
+    # merge results from array to results object
+    merged_results = SimpleCov::ResultMerger.merge_results(*coverage_results)
+
+    SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter.new [
+      Coveralls::SimpleCov::Formatter,
+      SimpleCov::Formatter::HTMLFormatter,
+      SimpleCov::Formatter::Codecov
+    ]
+    merged_results.format!
   end
 end

--- a/src/api/spec/support/coverage.rb
+++ b/src/api/spec/support/coverage.rb
@@ -1,6 +1,4 @@
 # for tracking test coverage
-require 'codecov'
-
 if ENV['CIRCLE_ARTIFACTS']
   dir = File.join(ENV['CIRCLE_ARTIFACTS'], 'coverage')
   SimpleCov.coverage_dir(dir)
@@ -8,7 +6,6 @@ end
 
 # SimpleCov configuration
 SimpleCov.start 'rails' do
-  ENV['CODECOV_FLAG'] = ENV['CIRCLE_STAGE']
   # NOTE: Keep filters in sync with test/test_helper.rb
   add_filter '/app/indices/'
   add_filter '/lib/templates/'
@@ -16,5 +13,3 @@ SimpleCov.start 'rails' do
   add_filter '/lib/memory_dumper.rb'
   merge_timeout 3600
 end
-
-SimpleCov.formatter = SimpleCov::Formatter::Codecov

--- a/src/api/test/test_helper.rb
+++ b/src/api/test/test_helper.rb
@@ -3,7 +3,6 @@ ENV['origin_RAILS_ENV'] = ENV['RAILS_ENV']
 ENV['RAILS_ENV'] = 'test'
 
 require 'simplecov'
-require 'codecov'
 require 'builder'
 require 'minitest/reporters'
 
@@ -18,7 +17,6 @@ if ENV['DO_COVERAGE']
     add_filter '/lib/memory_debugger.rb'
     add_filter '/lib/memory_dumper.rb'
     merge_timeout 3600
-    formatter SimpleCov::Formatter::Codecov
   end
 
   SimpleCov.at_exit do


### PR DESCRIPTION
This allows several benefits:
 - we always have HTML reports within circleci artefacts
 - we avoid bugs in merges on coverage services
 - the coverage services don't have to wait - if we upload,
   we're done
 - the coverage can be grouped as wildly as we need it,
   it can be done within the merge task

Codecov still does not report status back reliable, but coveralls
seems to have no problem with it. It doesn't hurt to report into
both though - if we let coveralls not comment but only report
status we can have codecov comments as optional. It will be 100%
the same coverage we calculated ourselves on circleci

Reused the existing lib/tasks/coverage.rake that wasn't in used
since 2012 (when travis+coveralls became a valid option)
