### PR TITLE
[ci] Skip broken addKiwiImport service test

### DIFF
--- a/src/api/spec/models/service_spec.rb
+++ b/src/api/spec/models/service_spec.rb
@@ -19,6 +19,7 @@ RSpec.describe Service, vcr: true do
     end
 
     it 'posts mergeservice' do
+      skip('broken because KiwiImport service expects a tar archive, we should move this in Package#save_file.')
       expect(a_request(:post, "#{url}?cmd=mergeservice&user=#{user}")).to have_been_made.once
     end
 


### PR DESCRIPTION
as this service expects a tar archive. We need to transfer this test
to a more integration like test e.g. in Package#save_file.