### PR TITLE
[backend] Define an api_url in BSConfig.pm

### DIFF
--- a/contrib/start_development_backend
+++ b/contrib/start_development_backend
@@ -89,6 +89,7 @@ perl -pi -e 's/my \$hostname.*/my \$hostname=\"$ENV{'DEVHOST'}\";/' $GIT_HOME/sr
 perl -pi -e 's/\$ipaccess/\$removed_by_start_development_backend /' $GIT_HOME/src/backend/BSConfig.pm
 perl -pi -e 's/.*our \$gpg_standard_key.*/our \$gpg_standard_key="\/etc\/ourkeyfile.asc";/' $GIT_HOME/src/backend/BSConfig.pm
 perl -pi -e 's/.*our \$sign .*/our \$sign="\/usr\/bin\/sign";/' $GIT_HOME/src/backend/BSConfig.pm
+perl -pi -e 's/.*our \$api_url.*/our \$api_url="https://api.example.com";/' $GIT_HOME/src/backend/BSConfig.pm
 
 #start backend services (the minimum needed) with two arch(i586/x86_64) schedulers and one worker
 echo "Starting bs_srcserver"

--- a/src/backend/BSConfig.pm.template
+++ b/src/backend/BSConfig.pm.template
@@ -30,6 +30,7 @@ my $hostname = Net::Domain::hostfqdn() || 'localhost';
 my $ip = quotemeta inet_ntoa(inet_aton($hostname) || inet_aton("localhost"));
 
 my $frontend = undef; # FQDN of the WebUI/API server if it's not $hostname
+my $api_url; # _external_ https URL of the API - exported for source services
 
 # If defined, restrict access to the backend servers (bs_repserver, bs_srcserver, bs_service)
 our $ipaccess = {


### PR DESCRIPTION
This is exported as OBS_SERVICE_APIURL in the source service
server - if present.