### PR TITLE
Trigger one rspec run without cassettes at night

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -110,6 +110,7 @@ jobs:
           paths:
             - .
 
+  
   rspec:
     parallelism: 4
     docker:
@@ -130,6 +131,11 @@ jobs:
           name: Run rspec
           command: |
             cd src/api
+            # defined in obs-no-cassettes context - see Org settings
+            if test -n "$REMOVE_CASSETTES"; then
+               echo "Removing casssettes"
+               rm -r spec/cassettes
+            fi
             pickfile=log/pick.$CIRCLE_NODE_INDEX.list
             # reserve the latest node for bootstrap
             if test "$CIRCLE_NODE_INDEX" = $((CIRCLE_NODE_TOTAL-1)); then
@@ -263,3 +269,19 @@ workflows:
           requires:
             - rspec
             - minitest
+
+  check_without_cassettes:
+    triggers:
+      - schedule:
+          # random point in the night (UTC)
+          cron: "11 2 * * *"
+          filters:
+            branches:
+              only:
+                - master
+    jobs:
+      - checkout_code
+      - rspec:
+          context: obs-no-cassettes
+          requires:
+            - checkout_code

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,6 +46,12 @@ aliases:
     name: Setup application
     command: cd src/api; bundle exec rake dev:bootstrap[old_test_suite] RAILS_ENV=test
 
+  - &start_remote_backend
+    name: Start Backend
+    command: |
+      sed -e "s,@CIRCLE_REPOSITORY_URL@,$CIRCLE_REPOSITORY_URL,; s,@CIRCLE_SHA1@,$CIRCLE_SHA1," -i contrib/trigger_checkout
+      nc backend 4000 < contrib/trigger_checkout
+
   # keep the prefix for the following aligned
   - &save_repo_cache_key
     key: v3-repo-{{ .Branch }}-{{ .Revision }}
@@ -109,9 +115,14 @@ jobs:
     docker:
       - <<: *frontend_base
       - <<: *mariadb
+      - image: *backend
+        name: backend
+        user: frontend
+        command: /bin/bash /remote_executor.sh
     steps:
       - *restore_repo
       - run: *install_dependencies
+      - run: *start_remote_backend
       - run: *wait_for_database
       - run: *create_test_db
       - run: mkdir /home/frontend/rspec

--- a/contrib/trigger_checkout
+++ b/contrib/trigger_checkout
@@ -1,0 +1,12 @@
+#! /bin/sh
+
+set -e
+
+url=$(echo @CIRCLE_REPOSITORY_URL@ | sed -e 's,git@github.com:,https://github.com/,; s,\.git$,,')
+git clone $url /obs/bs
+cd /obs/bs
+git checkout @CIRCLE_SHA1@
+git submodule update --init
+
+/obs/bs/contrib/start_development_backend -d /obs/bs
+


### PR DESCRIPTION
This way we can keep using cassettes from git and still verify
the code works fine without them - at least relatively close to
the breakage
