### PR TITLE
[dist] enable empty passphrase for autogenerated gpg keys

### DIFF
--- a/dist/setup-appliance.sh
+++ b/dist/setup-appliance.sh
@@ -542,6 +542,7 @@ function prepare_obssigner {
            Name-Comment: key without passphrase
            Name-Email: defaultkey@localobs
            Expire-Date: 0
+           %no-protection
            %pubring $backenddir/gnupg/pubring.gpg
            %secring $backenddir/gnupg/secring.gpg
            %commit


### PR DESCRIPTION
Without this change, the following errors are raise while
generating a gpg key in setup-appliance.sh:

gpg: Generating a default OBS instance key
gpg: agent_genkey failed: End of file
gpg: key generation failed: End of file

later on this will result in hanging publishing/signing process
when containers should be signed:

gpg: skipped "defaultkey@localobs": No secret key
gpg: signing failed: No secret key
sign failed: sign /srv/obs/jobs/x86_64/BaseContainer::images::openSUSE-Leap-Container-Base