### PR TITLE
[rspec] Make it fatal to add to a cassette

### DIFF
--- a/src/api/spec/support/vcr.rb
+++ b/src/api/spec/support/vcr.rb
@@ -3,7 +3,7 @@ require 'vcr'
 VCR.configure do |config|
   config.cassette_library_dir = 'spec/cassettes'
   config.hook_into :webmock
-  config.default_cassette_options = { record: :new_episodes }
+  config.default_cassette_options = { record: :once }
   config.allow_http_connections_when_no_cassette = true
   config.configure_rspec_metadata!
 


### PR DESCRIPTION
If a test case requires new routes, the cassette has to be
recreated from scratch. Only this way you can guarantee that
the test case still works without cassette