### PR TITLE
Add title field in search results

### DIFF
--- a/src/api/app/views/webui/search/_results.html.haml
+++ b/src/api/app/views/webui/search/_results.html.haml
@@ -13,6 +13,7 @@
         = sprite_tag(rtype, class: rtype, title: rtype.humanize)
         = project_or_package_link project: project, package: package, short: false, trim_to: nil
         = content_tag :span, result.sphinx_attributes, style: 'display:none'
+        = ": #{result.title}" if result.title.present?
       - if result.description.blank?
         %p.data-description ...
       - else


### PR DESCRIPTION
After fixing the indexes and make it possible to search by title and/or description (see #5385) it is usefull to see in the results of the search the title of a project or a package.

Now ": Foo" is shown as the title, next to "test".

![search_foo](https://user-images.githubusercontent.com/24919/42880664-532f9a56-8a95-11e8-986b-632e2a769af4.png)
