### PR TITLE
[api] Fix branch_remote_repositories not to rely on cache

### DIFF
--- a/src/api/app/models/project.rb
+++ b/src/api/app/models/project.rb
@@ -1034,7 +1034,7 @@ class Project < ApplicationRecord
   def branch_remote_repositories(project)
     remote_project = Project.new(name: project)
     remote_project_meta = Nokogiri::XML(remote_project.meta.content)
-    local_project_meta = Nokogiri::XML(to_axml)
+    local_project_meta = Nokogiri::XML(render_xml)
 
     remote_repositories = remote_project.repositories_from_meta
     remote_repositories -= repositories.where(name: remote_repositories).pluck(:name)

--- a/src/api/spec/cassettes/Project/_branch_remote_repositories/kiwi_project/1_6_2_2.yml
+++ b/src/api/spec/cassettes/Project/_branch_remote_repositories/kiwi_project/1_6_2_2.yml
@@ -2,12 +2,12 @@
 http_interactions:
 - request:
     method: put
-    uri: http://backend:5352/source/openSUSE_41/_meta
+    uri: http://backend:5352/source/openSUSE_41/_meta?user=_nobody_
     body:
       encoding: UTF-8
       string: |
         <project name="openSUSE_41">
-          <title>A Confederacy of Dunces</title>
+          <title>Those Barren Leaves, Thrones, Dominations</title>
           <description/>
         </project>
     headers:
@@ -29,60 +29,26 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '111'
+      - '129'
     body:
       encoding: UTF-8
       string: |
         <project name="openSUSE_41">
-          <title>A Confederacy of Dunces</title>
+          <title>Those Barren Leaves, Thrones, Dominations</title>
           <description></description>
         </project>
     http_version: 
-  recorded_at: Wed, 19 Apr 2017 13:27:33 GMT
+  recorded_at: Wed, 18 Jul 2018 13:42:47 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/openSUSE_41/_config
-    body:
-      encoding: UTF-8
-      string: Temporibus iusto accusantium nesciunt atque quisquam. Et qui praesentium
-        libero. Ut quis ut et vero. Aut saepe officiis neque inventore.
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '21'
-    body:
-      encoding: UTF-8
-      string: '<status code="ok" />
-
-'
-    http_version: 
-  recorded_at: Wed, 19 Apr 2017 13:27:33 GMT
-- request:
-    method: put
-    uri: http://backend:5352/source/openSUSE.org/_meta
+    uri: http://backend:5352/source/openSUSE.org/_meta?user=_nobody_
     body:
       encoding: UTF-8
       string: |
         <project name="openSUSE.org">
-          <title>Bury My Heart at Wounded Knee</title>
-          <description>Voluptatem ut neque ipsum sed qui deserunt aut.</description>
-          <remoteurl>http://wisoky.co/dangelo</remoteurl>
+          <title>Sleep the Brave</title>
+          <description>Et fugit unde ex.</description>
+          <remoteurl>http://rempel.io/valorie</remoteurl>
         </project>
     headers:
       Accept-Encoding:
@@ -103,51 +69,17 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '215'
+      - '171'
     body:
       encoding: UTF-8
       string: |
         <project name="openSUSE.org">
-          <title>Bury My Heart at Wounded Knee</title>
-          <description>Voluptatem ut neque ipsum sed qui deserunt aut.</description>
-          <remoteurl>http://wisoky.co/dangelo</remoteurl>
+          <title>Sleep the Brave</title>
+          <description>Et fugit unde ex.</description>
+          <remoteurl>http://rempel.io/valorie</remoteurl>
         </project>
     http_version: 
-  recorded_at: Wed, 19 Apr 2017 13:27:33 GMT
-- request:
-    method: put
-    uri: http://backend:5352/source/openSUSE.org/_config
-    body:
-      encoding: UTF-8
-      string: Nihil impedit iusto debitis voluptas sed rerum. Ut non aperiam. Ratione
-        sit reiciendis sed et.
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '21'
-    body:
-      encoding: UTF-8
-      string: '<status code="ok" />
-
-'
-    http_version: 
-  recorded_at: Wed, 19 Apr 2017 13:27:33 GMT
+  recorded_at: Wed, 18 Jul 2018 13:42:47 GMT
 - request:
     method: get
     uri: http://backend:5352/source/openSUSE_41/_config
@@ -173,50 +105,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '136'
+      - '82'
     body:
       encoding: UTF-8
-      string: Temporibus iusto accusantium nesciunt atque quisquam. Et qui praesentium
-        libero. Ut quis ut et vero. Aut saepe officiis neque inventore.
-    http_version: 
-  recorded_at: Wed, 19 Apr 2017 13:27:34 GMT
-- request:
-    method: put
-    uri: http://backend:5352/source/openSUSE_41/_config
-    body:
-      encoding: UTF-8
-      string: |-
+      string: |
         %if "%_repository" == "images"
         Type: kiwi
         Repotype: none
         Patterntype: none
         %endif
-        Temporibus iusto accusantium nesciunt atque quisquam. Et qui praesentium libero. Ut quis ut et vero. Aut saepe officiis neque inventore.
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '21'
-    body:
-      encoding: UTF-8
-      string: '<status code="ok" />
-
-'
     http_version: 
-  recorded_at: Wed, 19 Apr 2017 13:27:34 GMT
-recorded_with: VCR 3.0.3
+  recorded_at: Wed, 18 Jul 2018 13:42:47 GMT
+recorded_with: VCR 4.0.0

--- a/src/api/spec/cassettes/Project/_branch_remote_repositories/kiwi_project/1_6_2_3.yml
+++ b/src/api/spec/cassettes/Project/_branch_remote_repositories/kiwi_project/1_6_2_3.yml
@@ -7,7 +7,7 @@ http_interactions:
       encoding: UTF-8
       string: |
         <project name="openSUSE_41">
-          <title>Pale Kings and Princes</title>
+          <title>Lilies of the Field</title>
           <description/>
         </project>
     headers:
@@ -29,16 +29,16 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '110'
+      - '107'
     body:
       encoding: UTF-8
       string: |
         <project name="openSUSE_41">
-          <title>Pale Kings and Princes</title>
+          <title>Lilies of the Field</title>
           <description></description>
         </project>
     http_version: 
-  recorded_at: Wed, 18 Jul 2018 13:43:04 GMT
+  recorded_at: Wed, 18 Jul 2018 13:42:29 GMT
 - request:
     method: put
     uri: http://backend:5352/source/openSUSE.org/_meta?user=_nobody_
@@ -46,9 +46,9 @@ http_interactions:
       encoding: UTF-8
       string: |
         <project name="openSUSE.org">
-          <title>Vile Bodies</title>
-          <description>Minima saepe ipsam sint.</description>
-          <remoteurl>http://wymanhowe.com/jake.turcotte</remoteurl>
+          <title>The Grapes of Wrath</title>
+          <description>Mollitia maxime nemo minima.</description>
+          <remoteurl>http://toywisozk.info/delmer</remoteurl>
         </project>
     headers:
       Accept-Encoding:
@@ -69,17 +69,17 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '184'
+      - '190'
     body:
       encoding: UTF-8
       string: |
         <project name="openSUSE.org">
-          <title>Vile Bodies</title>
-          <description>Minima saepe ipsam sint.</description>
-          <remoteurl>http://wymanhowe.com/jake.turcotte</remoteurl>
+          <title>The Grapes of Wrath</title>
+          <description>Mollitia maxime nemo minima.</description>
+          <remoteurl>http://toywisozk.info/delmer</remoteurl>
         </project>
     http_version: 
-  recorded_at: Wed, 18 Jul 2018 13:43:04 GMT
+  recorded_at: Wed, 18 Jul 2018 13:42:29 GMT
 - request:
     method: get
     uri: http://backend:5352/source/openSUSE_41/_config
@@ -115,5 +115,5 @@ http_interactions:
         Patterntype: none
         %endif
     http_version: 
-  recorded_at: Wed, 18 Jul 2018 13:43:04 GMT
+  recorded_at: Wed, 18 Jul 2018 13:42:29 GMT
 recorded_with: VCR 4.0.0

--- a/src/api/spec/cassettes/Project/_branch_remote_repositories/kiwi_project/has_proper_project_xml.yml
+++ b/src/api/spec/cassettes/Project/_branch_remote_repositories/kiwi_project/has_proper_project_xml.yml
@@ -7,7 +7,7 @@ http_interactions:
       encoding: UTF-8
       string: |
         <project name="openSUSE_41">
-          <title>Pale Kings and Princes</title>
+          <title>The Far-Distant Oxus</title>
           <description/>
         </project>
     headers:
@@ -29,16 +29,16 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '110'
+      - '108'
     body:
       encoding: UTF-8
       string: |
         <project name="openSUSE_41">
-          <title>Pale Kings and Princes</title>
+          <title>The Far-Distant Oxus</title>
           <description></description>
         </project>
     http_version: 
-  recorded_at: Wed, 18 Jul 2018 13:43:04 GMT
+  recorded_at: Wed, 18 Jul 2018 13:42:28 GMT
 - request:
     method: put
     uri: http://backend:5352/source/openSUSE.org/_meta?user=_nobody_
@@ -46,9 +46,9 @@ http_interactions:
       encoding: UTF-8
       string: |
         <project name="openSUSE.org">
-          <title>Vile Bodies</title>
-          <description>Minima saepe ipsam sint.</description>
-          <remoteurl>http://wymanhowe.com/jake.turcotte</remoteurl>
+          <title>Gone with the Wind</title>
+          <description>Dolor nihil laboriosam ea.</description>
+          <remoteurl>http://olson.co/leone</remoteurl>
         </project>
     headers:
       Accept-Encoding:
@@ -69,17 +69,17 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '184'
+      - '180'
     body:
       encoding: UTF-8
       string: |
         <project name="openSUSE.org">
-          <title>Vile Bodies</title>
-          <description>Minima saepe ipsam sint.</description>
-          <remoteurl>http://wymanhowe.com/jake.turcotte</remoteurl>
+          <title>Gone with the Wind</title>
+          <description>Dolor nihil laboriosam ea.</description>
+          <remoteurl>http://olson.co/leone</remoteurl>
         </project>
     http_version: 
-  recorded_at: Wed, 18 Jul 2018 13:43:04 GMT
+  recorded_at: Wed, 18 Jul 2018 13:42:28 GMT
 - request:
     method: get
     uri: http://backend:5352/source/openSUSE_41/_config
@@ -115,5 +115,5 @@ http_interactions:
         Patterntype: none
         %endif
     http_version: 
-  recorded_at: Wed, 18 Jul 2018 13:43:04 GMT
+  recorded_at: Wed, 18 Jul 2018 13:42:28 GMT
 recorded_with: VCR 4.0.0

--- a/src/api/spec/models/project_spec.rb
+++ b/src/api/spec/models/project_spec.rb
@@ -139,7 +139,7 @@ RSpec.describe Project, vcr: true do
           </project>
         XML_DATA
       end
-      let(:local_xml_meta) do
+      let(:expected_xml_meta) do
         <<-XML_DATA
           <project name="#{project}">
             <title>#{project.title}</title>
@@ -153,11 +153,14 @@ RSpec.describe Project, vcr: true do
           </project>
         XML_DATA
       end
-      let(:expected_xml) { Nokogiri::XML(local_xml_meta) }
 
       before do
         branch_remote_repositories
         project.reload
+      end
+
+      it 'has proper project xml' do
+        expect(Xmlhash.parse(project.render_xml)).to eq(Xmlhash.parse(expected_xml_meta))
       end
 
       context 'keeps original repository' do
@@ -199,7 +202,7 @@ RSpec.describe Project, vcr: true do
         </project>
         XML_DATA
       end
-      let(:local_xml_meta) do
+      let(:expected_xml_meta) do
         <<-XML_DATA
         <project name="#{project}">
           <title>#{project.title}</title>
@@ -216,16 +219,18 @@ RSpec.describe Project, vcr: true do
         </project>
       XML_DATA
       end
-      let(:expected_xml) { Nokogiri::XML(local_xml_meta) }
 
       before do
         branch_remote_repositories
         project.reload
       end
 
-      let(:new_repository) { project.repositories.second }
-      let(:path_elements) { new_repository.path_elements.first.link }
       let(:path_elements2) { new_repository.path_elements.second.link }
+      let(:path_elements) { new_repository.path_elements.first.link }
+      let(:new_repository) { project.repositories.second }
+      it 'has proper project xml' do
+        expect(Xmlhash.parse(project.render_xml)).to eq(Xmlhash.parse(expected_xml_meta))
+      end
 
       it { expect(new_repository.name).to eq('images') }
       it { expect(new_repository.architectures.first.name).to eq('x86_64') }


### PR DESCRIPTION
to_axml reads from Rails.cache but as the function mungles
the XML on a raw base, better use the direct XML not the
cached one.

This avoids races a little better - and fixes #5319