### PR TITLE
Fix template_path in staging_project show view

### DIFF
--- a/src/api/app/views/webui/obs_factory/staging_projects/show.html.erb
+++ b/src/api/app/views/webui/obs_factory/staging_projects/show.html.erb
@@ -21,7 +21,7 @@
         <% if ok %>
           None.
         <% else %>
-          <%= render @staging_project.untracked_requests %>
+          <%= render partial: 'webui/obs_factory/requests/request', collection: @staging_project.untracked_requests %>
         <% end %>
         </dd>
         <% ok = @staging_project.obsolete_requests.size.zero? -%>
@@ -30,7 +30,7 @@
         <% if ok %>
           None.
         <% else %>
-          <%= render @staging_project.obsolete_requests %>
+          <%= render partial: 'webui/obs_factory/requests/request', collection: @staging_project.obsolete_requests %>
         <% end %>
         </dd>
         <% ok = @staging_project.missing_reviews.size.zero? -%>


### PR DESCRIPTION
The `show` view of staging project was unable to found the correct
template for the `requests`, it was taking
`webui/obs_factory/obs_factory/requests/_request` instead of
`webui/obs_factory/requests/_request`.