### PR TITLE
[webui] Rename openSUSE strategy to openSUSE Leap 15

### DIFF
--- a/src/api/.rubocop.yml
+++ b/src/api/.rubocop.yml
@@ -46,7 +46,7 @@ Rails/Exit:
 
 RSpec/FilePath:
   Exclude:
-    - 'spec/models/obs_factory/distribution_strategy_opensuse_spec.rb'
+    - 'spec/models/obs_factory/distribution_strategy_opensuse_leap15_spec.rb'
 
 Rails/HasAndBelongsToMany:
   Enabled: false

--- a/src/api/app/models/obs_factory/distribution.rb
+++ b/src/api/app/models/obs_factory/distribution.rb
@@ -211,7 +211,7 @@ module ObsFactory
       s = case project.name
         when 'openSUSE:Factory' then DistributionStrategyFactory.new
         when 'openSUSE:Factory:PowerPC' then DistributionStrategyFactoryPPC.new
-        when /^openSUSE:Leap:15\.*/ then DistributionStrategyOpenSUSE.new
+        when /^openSUSE:Leap:15\.*/ then DistributionStrategyOpenSUSELeap15.new
         when /^SUSE:SLE-12-SP\d:GA/ then DistributionStrategySLE12SP1.new
         when 'SUSE:SLE-15:GA' then DistributionStrategySLE15.new
         when /^SUSE:SLE-15-SP\d:GA/ then DistributionStrategySLE15.new

--- a/src/api/app/models/obs_factory/distribution.rb
+++ b/src/api/app/models/obs_factory/distribution.rb
@@ -211,7 +211,7 @@ module ObsFactory
       s = case project.name
         when 'openSUSE:Factory' then DistributionStrategyFactory.new
         when 'openSUSE:Factory:PowerPC' then DistributionStrategyFactoryPPC.new
-        when /^openSUSE:.*/ then DistributionStrategyOpenSUSE.new
+        when /^openSUSE:Leap:15\.*/ then DistributionStrategyOpenSUSE.new
         when /^SUSE:SLE-12-SP\d:GA/ then DistributionStrategySLE12SP1.new
         when 'SUSE:SLE-15:GA' then DistributionStrategySLE15.new
         when /^SUSE:SLE-15-SP\d:GA/ then DistributionStrategySLE15.new

--- a/src/api/app/models/obs_factory/distribution_strategy_opensuse_leap15.rb
+++ b/src/api/app/models/obs_factory/distribution_strategy_opensuse_leap15.rb
@@ -1,22 +1,18 @@
 module ObsFactory
   # this class tracks the differences between Factory and the upcoming release
-  class DistributionStrategyOpenSUSE < DistributionStrategyFactory
+  class DistributionStrategyOpenSUSELeap15 < DistributionStrategyFactory
     SIGNATURE = /openSUSE:(?<full_name>.+:(?<version>(?<major_version>\d+)\.(?<minor_version>\d+)))/
-
-    def opensuse_version
-      distribution[:full_name]
-    end
 
     def opensuse_leap_version
       distribution[:version]
     end
 
     def openqa_version
-      distribution[:major_version]
+      opensuse_leap_version
     end
 
     def openqa_group
-      "openSUSE Leap #{opensuse_leap_version}"
+      "openSUSE Leap #{distribution[:major_version]}"
     end
 
     def repo_url
@@ -28,7 +24,7 @@ module ObsFactory
     end
 
     def openqa_iso_prefix
-      "openSUSE-#{opensuse_version}-Staging"
+      "openSUSE-Leap-#{opensuse_leap_version}-Staging"
     end
 
     def published_arch
@@ -48,11 +44,11 @@ module ObsFactory
     # @return [String] version string
     def published_version
       begin
-        f = open(repo_url)
-      rescue ::OpenURI::HTTPError => e
+        f = URI(repo_url).open
+      rescue ::OpenURI::HTTPError
         return 'unknown'
       end
-      matchdata = %r{openSUSE-#{opensuse_leap_version}-#{published_arch}-Build(.*)}.match(f.read)
+      matchdata = %r{openSUSE-#{opensuse_leap_version}-#{published_arch}-Build(.*)-Media}.match(f.read)
       matchdata[1]
     end
 

--- a/src/api/spec/helpers/webui/obs_factory/application_helper_spec.rb
+++ b/src/api/spec/helpers/webui/obs_factory/application_helper_spec.rb
@@ -2,18 +2,18 @@ require 'rails_helper'
 
 RSpec.describe Webui::ObsFactory::ApplicationHelper, type: :helper do
   describe '#distribution_tests_link' do
-    let(:distribution) { ObsFactory::Distribution.new(create(:project, name: 'openSUSE:Leap:42.3')) }
+    let(:distribution) { ObsFactory::Distribution.new(create(:project, name: 'openSUSE:Leap:15.1')) }
 
     it 'creates a url to the openqa distribution tests' do
       expect(distribution_tests_url(distribution)).to eq(
-        'https://openqa.opensuse.org/tests/overview?distri=opensuse&version=42'
+        'https://openqa.opensuse.org/tests/overview?distri=opensuse&version=15'
       )
     end
 
     context 'when a version is provided' do
       it 'adds the version to the version to the url' do
         expect(distribution_tests_url(distribution, 'my_version')).to eq(
-          'https://openqa.opensuse.org/tests/overview?distri=opensuse&version=42&build=my_version'
+          'https://openqa.opensuse.org/tests/overview?distri=opensuse&version=15&build=my_version'
         )
       end
     end

--- a/src/api/spec/helpers/webui/obs_factory/application_helper_spec.rb
+++ b/src/api/spec/helpers/webui/obs_factory/application_helper_spec.rb
@@ -6,14 +6,14 @@ RSpec.describe Webui::ObsFactory::ApplicationHelper, type: :helper do
 
     it 'creates a url to the openqa distribution tests' do
       expect(distribution_tests_url(distribution)).to eq(
-        'https://openqa.opensuse.org/tests/overview?distri=opensuse&version=15'
+        'https://openqa.opensuse.org/tests/overview?distri=opensuse&version=15.1'
       )
     end
 
     context 'when a version is provided' do
       it 'adds the version to the version to the url' do
         expect(distribution_tests_url(distribution, 'my_version')).to eq(
-          'https://openqa.opensuse.org/tests/overview?distri=opensuse&version=15&build=my_version'
+          'https://openqa.opensuse.org/tests/overview?distri=opensuse&version=15.1&build=my_version'
         )
       end
     end

--- a/src/api/spec/models/obs_factory/distribution_spec.rb
+++ b/src/api/spec/models/obs_factory/distribution_spec.rb
@@ -13,11 +13,14 @@ RSpec.describe ObsFactory::Distribution do
 
     it { expect(distribution.strategy).to                    be_kind_of ObsFactory::DistributionStrategyFactory }
     it { expect(strategy_for('openSUSE:Factory:PowerPC')).to be_kind_of ObsFactory::DistributionStrategyFactoryPPC }
-    it { expect(strategy_for('openSUSE:42.3')).to            be_kind_of ObsFactory::DistributionStrategyOpenSUSE }
+    it { expect(strategy_for('openSUSE:Leap:15.1')).to            be_kind_of ObsFactory::DistributionStrategyOpenSUSE }
     it { expect(strategy_for('SUSE:SLE-12-SP1:GA')).to       be_kind_of ObsFactory::DistributionStrategySLE12SP1 }
     it { expect(strategy_for('SUSE:SLE-15:GA')).to           be_kind_of ObsFactory::DistributionStrategySLE15 }
     it { expect(strategy_for('SUSE:SLE-15-SP1:GA')).to       be_kind_of ObsFactory::DistributionStrategySLE15 }
     it { expect(strategy_for('SUSE:SLE-12-SP3:Update:Products:CASP20')).to be_kind_of ObsFactory::DistributionStrategyCasp }
+
+    it { expect { strategy_for('openSUSE:42.3') }.to raise_error(ObsFactory::UnknownDistribution) }
+    it { expect { strategy_for('openSUSE:Leap:42.3') }.to raise_error(ObsFactory::UnknownDistribution) }
   end
 
   describe 'self.attributes' do

--- a/src/api/spec/models/obs_factory/distribution_spec.rb
+++ b/src/api/spec/models/obs_factory/distribution_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe ObsFactory::Distribution do
 
     it { expect(distribution.strategy).to                    be_kind_of ObsFactory::DistributionStrategyFactory }
     it { expect(strategy_for('openSUSE:Factory:PowerPC')).to be_kind_of ObsFactory::DistributionStrategyFactoryPPC }
-    it { expect(strategy_for('openSUSE:Leap:15.1')).to            be_kind_of ObsFactory::DistributionStrategyOpenSUSE }
+    it { expect(strategy_for('openSUSE:Leap:15.1')).to be_kind_of ObsFactory::DistributionStrategyOpenSUSELeap15 }
     it { expect(strategy_for('SUSE:SLE-12-SP1:GA')).to       be_kind_of ObsFactory::DistributionStrategySLE12SP1 }
     it { expect(strategy_for('SUSE:SLE-15:GA')).to           be_kind_of ObsFactory::DistributionStrategySLE15 }
     it { expect(strategy_for('SUSE:SLE-15-SP1:GA')).to       be_kind_of ObsFactory::DistributionStrategySLE15 }

--- a/src/api/spec/models/obs_factory/distribution_strategy_opensuse_leap15_spec.rb
+++ b/src/api/spec/models/obs_factory/distribution_strategy_opensuse_leap15_spec.rb
@@ -1,16 +1,13 @@
 require 'rails_helper'
+require 'webmock/rspec'
 
-RSpec.describe ObsFactory::DistributionStrategyOpenSUSE do
+RSpec.describe ObsFactory::DistributionStrategyOpenSUSELeap15 do
   let(:project) { create(:project, name: 'openSUSE:Leap:15.1') }
   let(:distribution) { ObsFactory::Distribution.new(project) }
   let(:strategy) { distribution.strategy }
 
   describe '#openqa_version' do
-    it { expect(strategy.openqa_version).to eq('15') }
-  end
-
-  describe '#opensuse_version' do
-    it { expect(strategy.opensuse_version).to eq('Leap:15.1') }
+    it { expect(strategy.openqa_version).to eq('15.1') }
   end
 
   describe '#opensuse_leap_version' do
@@ -30,7 +27,7 @@ RSpec.describe ObsFactory::DistributionStrategyOpenSUSE do
   end
 
   describe '#openqa_iso_prefix' do
-    it { expect(strategy.openqa_iso_prefix).to eq('openSUSE-Leap:15.1-Staging') }
+    it { expect(strategy.openqa_iso_prefix).to eq('openSUSE-Leap-15.1-Staging') }
   end
 
   describe '#published_arch' do
@@ -46,10 +43,10 @@ RSpec.describe ObsFactory::DistributionStrategyOpenSUSE do
   end
 
   describe '#published_version' do
-    let(:file) { StringIO.new('openSUSE-15.1-x86_64-Build317.2') }
+    let(:file) { "openSUSE - openSUSE-15.1-x86_64-Build317.2-Media\nopenSUSE-15.1-x86_64-Build317.2\n1" }
 
     before do
-      allow_any_instance_of(ObsFactory::DistributionStrategyOpenSUSE).to receive(:open).and_return(file)
+      stub_request(:get, strategy.repo_url).and_return(body: file)
     end
 
     it { expect(strategy.published_version).to eq('317.2') }

--- a/src/api/spec/models/obs_factory/distribution_strategy_opensuse_spec.rb
+++ b/src/api/spec/models/obs_factory/distribution_strategy_opensuse_spec.rb
@@ -1,36 +1,36 @@
 require 'rails_helper'
 
 RSpec.describe ObsFactory::DistributionStrategyOpenSUSE do
-  let(:project) { create(:project, name: 'openSUSE:Leap:42.3') }
+  let(:project) { create(:project, name: 'openSUSE:Leap:15.1') }
   let(:distribution) { ObsFactory::Distribution.new(project) }
   let(:strategy) { distribution.strategy }
 
   describe '#openqa_version' do
-    it { expect(strategy.openqa_version).to eq('42') }
+    it { expect(strategy.openqa_version).to eq('15') }
   end
 
   describe '#opensuse_version' do
-    it { expect(strategy.opensuse_version).to eq('Leap:42.3') }
+    it { expect(strategy.opensuse_version).to eq('Leap:15.1') }
   end
 
   describe '#opensuse_leap_version' do
-    it { expect(strategy.opensuse_leap_version).to eq('42.3') }
+    it { expect(strategy.opensuse_leap_version).to eq('15.1') }
   end
 
   describe '#openqa_group' do
-    it { expect(strategy.openqa_group).to eq('openSUSE Leap 42.3') }
+    it { expect(strategy.openqa_group).to eq('openSUSE Leap 15') }
   end
 
   describe '#repo_url' do
-    it { expect(strategy.repo_url).to eq('http://download.opensuse.org/distribution/leap/42.3/repo/oss/media.1/media') }
+    it { expect(strategy.repo_url).to eq('http://download.opensuse.org/distribution/leap/15.1/repo/oss/media.1/media') }
   end
 
   describe '#url_suffix' do
-    it { expect(strategy.url_suffix).to eq('distribution/leap/42.3/iso') }
+    it { expect(strategy.url_suffix).to eq('distribution/leap/15.1/iso') }
   end
 
   describe '#openqa_iso_prefix' do
-    it { expect(strategy.openqa_iso_prefix).to eq('openSUSE-Leap:42.3-Staging') }
+    it { expect(strategy.openqa_iso_prefix).to eq('openSUSE-Leap:15.1-Staging') }
   end
 
   describe '#published_arch' do
@@ -46,7 +46,7 @@ RSpec.describe ObsFactory::DistributionStrategyOpenSUSE do
   end
 
   describe '#published_version' do
-    let(:file) { StringIO.new('openSUSE-42.3-x86_64-Build317.2') }
+    let(:file) { StringIO.new('openSUSE-15.1-x86_64-Build317.2') }
 
     before do
       allow_any_instance_of(ObsFactory::DistributionStrategyOpenSUSE).to receive(:open).and_return(file)
@@ -56,9 +56,9 @@ RSpec.describe ObsFactory::DistributionStrategyOpenSUSE do
   end
 
   describe '#openqa_filter' do
-    let(:project_staging_a) { create(:project, name: 'openSUSE:Leap:42.3:Staging:A') }
+    let(:project_staging_a) { create(:project, name: 'openSUSE:Leap:15.1:Staging:A') }
     let(:staging_project) { ObsFactory::StagingProject.new(project: project_staging_a, distribution: distribution) }
 
-    it { expect(strategy.openqa_filter(staging_project)).to eq('match=42.3:S:A') }
+    it { expect(strategy.openqa_filter(staging_project)).to eq('match=15.1:S:A') }
   end
 end

--- a/src/api/spec/models/obs_factory/staging_project_spec.rb
+++ b/src/api/spec/models/obs_factory/staging_project_spec.rb
@@ -10,9 +10,9 @@ RSpec.describe ObsFactory::StagingProject do
   let!(:staging_b_dvd) { create(:project, name: 'openSUSE:Factory:Staging:B:DVD') }
   let!(:staging_c) { create(:project, name: 'openSUSE:Factory:Staging:C') }
   let!(:staging_c_dvd) { create(:project, name: 'openSUSE:Factory:Staging:C:DVD') }
-  let(:opensuse_132) { create(:project, name: 'openSUSE:13.2') }
-  let!(:opensuse_staging_a) { create(:project, name: 'openSUSE:13.2:Staging:A') }
-  let!(:opensuse_staging_b) { create(:project, name: 'openSUSE:13.2:Staging:B') }
+  let(:opensuse_leap) { create(:project, name: 'openSUSE:Leap:15.1') }
+  let!(:opensuse_staging_a) { create(:project, name: 'openSUSE:Leap:15.1:Staging:A') }
+  let!(:opensuse_staging_b) { create(:project, name: 'openSUSE:Leap:15.1:Staging:B') }
   let(:factory_distribution) { ObsFactory::Distribution.find(factory.name) }
   let(:staging_project_a) { ObsFactory::StagingProject.new(project: staging_a, distribution: factory_distribution) }
   let(:staging_project_adi) { ObsFactory::StagingProject.new(project: staging_adi, distribution: factory_distribution) }
@@ -31,9 +31,9 @@ RSpec.describe ObsFactory::StagingProject do
       it { expect(subject.map(&:project)).to eq([staging_a, staging_b, staging_c]) }
     end
 
-    context 'openSUSE:13.2' do
-      let(:opensuse_132_distribution) { ObsFactory::Distribution.find(opensuse_132.name) }
-      subject { ObsFactory::StagingProject.for(opensuse_132_distribution) }
+    context 'openSUSE:Leap:15.1' do
+      let(:opensuse_distribution) { ObsFactory::Distribution.find(opensuse_leap.name) }
+      subject { ObsFactory::StagingProject.for(opensuse_distribution) }
 
       it { expect(subject.map(&:project)).to eq([opensuse_staging_a, opensuse_staging_b]) }
     end


### PR DESCRIPTION
The dashboard code was adopted for the product converter
used in Leap 15. As 42.X is no longer in development,
there is no point in maintaining it

Fixes #5410