### PR TITLE
[frontend] Store comments.body as utf8mb4

### DIFF
--- a/ReleaseNotes-2.10
+++ b/ReleaseNotes-2.10
@@ -38,7 +38,8 @@ Frontend:
  * Refactored the view of the binaries page that before was just a list of links that
    pointed to the details page. Now you can download the files and upload images to
    the cloud directly from here.
-
+ * Text fields are stored as 4 byte UTF-8 which allows to use emojis. To use this
+   feature, switch database.yml to utf8mb4 encoding
 
 Backend:
 

--- a/src/api/.rubocop.yml
+++ b/src/api/.rubocop.yml
@@ -76,6 +76,7 @@ Rails/BulkChangeTable:
     - 'db/migrate/20170516140442_add_several_fields_to_kiwi_repositories.rb'
     - 'db/migrate/20170607110443_add_and_remove_some_index_in_bs_request_actions.rb'
     - 'db/migrate/20170630121602_add_index_bs_requests_action.rb'
+    - 'db/migrate/20170619111734_alter_notifications_to_use_polymorphic.rb'
     - 'db/migrate/20170905081525_add_has_secure_password_support.rb'
     - 'db/migrate/20170911142301_change_kiwi_package_groups_columns_from_big_int_to_int.rb'
     - 'db/migrate/20170912140257_change_kiwi_packages_columns_from_big_int_to_int.rb'

--- a/src/api/config/database.yml.example
+++ b/src/api/config/database.yml.example
@@ -11,7 +11,7 @@ production:
   database: api_production
   username: root
   password: opensuse
-  encoding: utf8
+  encoding: utf8mb4
   timeout: 15
   pool: 30
 
@@ -20,7 +20,7 @@ development:
   database: api_development
   username: root
   password: opensuse
-  encoding: utf8
+  encoding: utf8mb4
   timeout: 15
   pool: 30
   
@@ -32,7 +32,7 @@ test:
   database: api_test
   username: root
   password: opensuse
-  encoding: utf8
+  encoding: utf8mb4
   timeout: 15
   pool: 30
 

--- a/src/api/db/migrate/20140624101042_add_package_tracking.rb
+++ b/src/api/db/migrate/20140624101042_add_package_tracking.rb
@@ -7,7 +7,7 @@ class AddPackageTracking < ActiveRecord::Migration[4.2]
 
       t.integer :release_package_id
 
-      t.string :binary_name, null: false
+      t.string :binary_name, null: false, charset: 'utf8'
       t.string :binary_epoch,                    limit: 64
       t.string :binary_version,     null: false, limit: 64
       t.string :binary_release,     null: false, limit: 64

--- a/src/api/db/migrate/20140627071042_product_media_tracking.rb
+++ b/src/api/db/migrate/20140627071042_product_media_tracking.rb
@@ -3,7 +3,7 @@ class ProductMediaTracking < ActiveRecord::Migration[4.2]
     create_table :product_media do |t|
       t.references :product
       t.references :repository
-      t.string :medium
+      t.string :medium, charset: 'utf8'
     end
 
     execute('alter table product_media add foreign key (product_id) references products(id)')

--- a/src/api/db/migrate/20140709071042_product_medium_tracking.rb
+++ b/src/api/db/migrate/20140709071042_product_medium_tracking.rb
@@ -1,6 +1,6 @@
 class ProductMediumTracking < ActiveRecord::Migration[4.2]
   def up
-    add_column :binary_releases, :medium, :string
+    add_column :binary_releases, :medium, :string, charset: 'utf8'
   end
 
   def down

--- a/src/api/db/migrate/20140717101042_add_updateinfo_tracking.rb
+++ b/src/api/db/migrate/20140717101042_add_updateinfo_tracking.rb
@@ -4,7 +4,7 @@ class AddUpdateinfoTracking < ActiveRecord::Migration[4.2]
       t.references :repository, null: false
       t.references :package,    null: false
       t.datetime :created_at, null: false
-      t.string :identifier, null: false
+      t.string :identifier, null: false, charset: 'utf8'
     end
 
     add_index :updateinfos, :identifier

--- a/src/api/db/migrate/20140729101042_updateinfo_tracking_second_attempt.rb
+++ b/src/api/db/migrate/20140729101042_updateinfo_tracking_second_attempt.rb
@@ -1,6 +1,6 @@
 class UpdateinfoTrackingSecondAttempt < ActiveRecord::Migration[4.2]
   def up
-    add_column :binary_releases, :binary_updateinfo, :string
+    add_column :binary_releases, :binary_updateinfo, :string, charset: 'utf8'
     add_column :binary_releases, :binary_updateinfo_version, :string
     add_index :binary_releases, :binary_updateinfo
 

--- a/src/api/db/migrate/20140801071042_product_version_tracking.rb
+++ b/src/api/db/migrate/20140801071042_product_version_tracking.rb
@@ -5,7 +5,7 @@ class ProductVersionTracking < ActiveRecord::Migration[4.2]
     add_column :products, :patchlevel, :string
     add_column :products, :release, :string
 
-    rename_column :product_media, :medium, :name
+    execute 'ALTER TABLE `product_media` CHANGE `medium` `name` varchar(255) CHARSET utf8 DEFAULT NULL'
   end
 
   def down

--- a/src/api/db/migrate/20140903125426_add_generic_operation_history.rb
+++ b/src/api/db/migrate/20140903125426_add_generic_operation_history.rb
@@ -1,7 +1,7 @@
 class AddGenericOperationHistory < ActiveRecord::Migration[4.2]
   def self.up
     create_table :history_elements do |t|
-      t.string :type, null: false
+      t.string :type, charset: 'utf8', null: false
       t.integer :op_object_id, null: false # id of request/project/...
       t.datetime :created_at, null: false
       t.references :user, null: false

--- a/src/api/db/migrate/20141110105426_fix_product_media_uniq_index.rb
+++ b/src/api/db/migrate/20141110105426_fix_product_media_uniq_index.rb
@@ -15,7 +15,7 @@ class FixProductMediaUniqIndex < ActiveRecord::Migration[4.2]
       t.references :product
       t.references :repository
       t.integer :arch_filter_id
-      t.string :name
+      t.string :name, charset: 'utf8'
     end
     add_index :product_media, :product_id
     add_index :product_media, :arch_filter_id

--- a/src/api/db/migrate/20170306084558_change_repositories_remote_project_name_to_not_null.rb
+++ b/src/api/db/migrate/20170306084558_change_repositories_remote_project_name_to_not_null.rb
@@ -4,12 +4,10 @@ class ChangeRepositoriesRemoteProjectNameToNotNull < ActiveRecord::Migration[5.0
     # otherwise we will get duplicate entry exception when we set remote_project_name to an empty string
     msg = 'Pending data migration 20170306084550. Please run rake db:migrate:with_data.'
     raise ActiveRecord::ActiveRecordError, msg unless DataMigrate::DataSchemaMigration.where(version: 20_170_306_084_550).exists?
-    change_column_null :repositories, :remote_project_name, false
-    change_column_default :repositories, :remote_project_name, ''
+    execute "ALTER TABLE `repositories` CHANGE  `remote_project_name` `remote_project_name` varchar(255) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL DEFAULT ''"
   end
 
   def down
-    change_column_null :repositories, :remote_project_name, true
-    change_column_default :repositories, :remote_project_name, nil
+    execute 'ALTER TABLE `repositories` CHANGE  `remote_project_name` `remote_project_name` varchar(255) CHARACTER SET utf8 COLLATE utf8_bin DEFAULT NULL'
   end
 end

--- a/src/api/db/migrate/20170619111734_alter_notifications_to_use_polymorphic.rb
+++ b/src/api/db/migrate/20170619111734_alter_notifications_to_use_polymorphic.rb
@@ -1,6 +1,8 @@
 class AlterNotificationsToUsePolymorphic < ActiveRecord::Migration[5.0]
   def change
-    add_reference :notifications, :subscriber, polymorphic: true
+    add_column(:notifications, 'subscriber_type', :string, charset: 'utf8')
+    add_column(:notifications, 'subscriber_id', :integer)
+    add_index(:notifications, ['subscriber_type', 'subscriber_id'])
 
     # Existing notifications would fail because of incompatible payload.
     # Since this is for a feature that just got introduced we can drop them.

--- a/src/api/db/migrate/20171218160607_create_ec2_configuration.rb
+++ b/src/api/db/migrate/20171218160607_create_ec2_configuration.rb
@@ -2,8 +2,8 @@ class CreateEc2Configuration < ActiveRecord::Migration[5.1]
   def change
     create_table :cloud_ec2_configurations, id: :integer do |t|
       t.belongs_to :user, index: true, type: :integer
-      t.string :external_id
-      t.string :arn
+      t.string :external_id, charset: 'utf8'
+      t.string :arn, charset: 'utf8'
 
       t.timestamps
     end

--- a/src/api/db/migrate/20180720082742_switch_to_utf8mb4.rb
+++ b/src/api/db/migrate/20180720082742_switch_to_utf8mb4.rb
@@ -1,0 +1,33 @@
+class SwitchToUtf8mb4 < ActiveRecord::Migration[5.2]
+  def db
+    ActiveRecord::Base.connection
+  end
+
+  def up
+    execute "ALTER DATABASE `#{db.current_database}` CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;"
+    db.tables.each do |table|
+      execute "ALTER TABLE `#{table}` ROW_FORMAT=DYNAMIC CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;"
+    end
+
+    execute 'ALTER TABLE `attrib_allowed_values` MODIFY `value` TEXT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci'
+    execute 'ALTER TABLE `attrib_default_values` MODIFY `value` TEXT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL;'
+    execute 'ALTER TABLE `attrib_values` MODIFY `value` TEXT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci  NOT NULL;'
+    execute 'ALTER TABLE `backend_packages` MODIFY `error` TEXT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;'
+    execute 'ALTER TABLE `bs_requests` MODIFY `description` TEXT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;'
+    execute 'ALTER TABLE `bs_requests` MODIFY `comment` TEXT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;'
+    execute 'ALTER TABLE `comments` MODIFY `body` TEXT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;'
+    execute 'ALTER TABLE `configurations` MODIFY `description` TEXT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;'
+    execute 'ALTER TABLE `delayed_jobs` MODIFY `last_error` TEXT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;'
+    execute 'ALTER TABLE `events` MODIFY `payload` TEXT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;'
+    execute 'ALTER TABLE `history_elements` MODIFY `comment` TEXT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;'
+    execute 'ALTER TABLE `messages` MODIFY `text` TEXT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;'
+    execute 'ALTER TABLE `notifications` MODIFY `event_payload` TEXT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL;'
+    execute 'ALTER TABLE `packages` MODIFY `description` TEXT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;'
+    execute 'ALTER TABLE `project_log_entries` MODIFY `additional_info` TEXT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;'
+    execute 'ALTER TABLE `projects` MODIFY `description` TEXT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;'
+    execute 'ALTER TABLE `reviews` MODIFY `reason` TEXT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci'
+    execute 'ALTER TABLE `sessions` MODIFY `data` TEXT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci'
+    execute 'ALTER TABLE `status_messages` MODIFY `message` TEXT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;'
+    execute 'ALTER TABLE `users` MODIFY `adminnote` TEXT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;'
+  end
+end

--- a/src/api/db/structure.sql
+++ b/src/api/db/structure.sql
@@ -1,10 +1,10 @@
 CREATE TABLE `ar_internal_metadata` (
-  `key` varchar(255) NOT NULL,
-  `value` varchar(255) DEFAULT NULL,
+  `key` varchar(255) CHARACTER SET utf8 NOT NULL,
+  `value` varchar(255) CHARACTER SET utf8 DEFAULT NULL,
   `created_at` datetime NOT NULL,
   `updated_at` datetime(6) NOT NULL,
   PRIMARY KEY (`key`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `architectures` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
@@ -12,33 +12,33 @@ CREATE TABLE `architectures` (
   `available` tinyint(1) DEFAULT '0',
   PRIMARY KEY (`id`),
   UNIQUE KEY `arch_name_index` (`name`) USING BTREE
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `architectures_distributions` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `distribution_id` int(11) DEFAULT NULL,
   `architecture_id` int(11) DEFAULT NULL,
   PRIMARY KEY (`id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `attrib_allowed_values` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `attrib_type_id` int(11) NOT NULL,
-  `value` text CHARACTER SET utf8,
+  `value` text COLLATE utf8mb4_unicode_ci,
   PRIMARY KEY (`id`),
   KEY `attrib_type_id` (`attrib_type_id`) USING BTREE,
   CONSTRAINT `attrib_allowed_values_ibfk_1` FOREIGN KEY (`attrib_type_id`) REFERENCES `attrib_types` (`id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `attrib_default_values` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `attrib_type_id` int(11) NOT NULL,
-  `value` text CHARACTER SET utf8 NOT NULL,
+  `value` text COLLATE utf8mb4_unicode_ci NOT NULL,
   `position` int(11) NOT NULL,
   PRIMARY KEY (`id`),
   KEY `attrib_type_id` (`attrib_type_id`) USING BTREE,
   CONSTRAINT `attrib_default_values_ibfk_1` FOREIGN KEY (`attrib_type_id`) REFERENCES `attrib_types` (`id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `attrib_issues` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
@@ -49,7 +49,7 @@ CREATE TABLE `attrib_issues` (
   KEY `issue_id` (`issue_id`) USING BTREE,
   CONSTRAINT `attrib_issues_ibfk_1` FOREIGN KEY (`attrib_id`) REFERENCES `attribs` (`id`),
   CONSTRAINT `attrib_issues_ibfk_2` FOREIGN KEY (`issue_id`) REFERENCES `issues` (`id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `attrib_namespace_modifiable_bies` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
@@ -63,14 +63,14 @@ CREATE TABLE `attrib_namespace_modifiable_bies` (
   CONSTRAINT `attrib_namespace_modifiable_bies_ibfk_1` FOREIGN KEY (`attrib_namespace_id`) REFERENCES `attrib_namespaces` (`id`),
   CONSTRAINT `attrib_namespace_modifiable_bies_ibfk_4` FOREIGN KEY (`user_id`) REFERENCES `users` (`id`),
   CONSTRAINT `attrib_namespace_modifiable_bies_ibfk_5` FOREIGN KEY (`group_id`) REFERENCES `groups` (`id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `attrib_namespaces` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `name` varchar(255) CHARACTER SET utf8 DEFAULT NULL,
   PRIMARY KEY (`id`),
   KEY `index_attrib_namespaces_on_name` (`name`) USING BTREE
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `attrib_type_modifiable_bies` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
@@ -86,7 +86,7 @@ CREATE TABLE `attrib_type_modifiable_bies` (
   CONSTRAINT `attrib_type_modifiable_bies_ibfk_1` FOREIGN KEY (`user_id`) REFERENCES `users` (`id`),
   CONSTRAINT `attrib_type_modifiable_bies_ibfk_2` FOREIGN KEY (`group_id`) REFERENCES `groups` (`id`),
   CONSTRAINT `attrib_type_modifiable_bies_ibfk_3` FOREIGN KEY (`role_id`) REFERENCES `roles` (`id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `attrib_types` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
@@ -100,17 +100,17 @@ CREATE TABLE `attrib_types` (
   UNIQUE KEY `index_attrib_types_on_attrib_namespace_id_and_name` (`attrib_namespace_id`,`name`) USING BTREE,
   KEY `index_attrib_types_on_name` (`name`) USING BTREE,
   CONSTRAINT `attrib_types_ibfk_1` FOREIGN KEY (`attrib_namespace_id`) REFERENCES `attrib_namespaces` (`id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `attrib_values` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `attrib_id` int(11) NOT NULL,
-  `value` text CHARACTER SET utf8 NOT NULL,
+  `value` text COLLATE utf8mb4_unicode_ci NOT NULL,
   `position` int(11) NOT NULL,
   PRIMARY KEY (`id`),
   KEY `index_attrib_values_on_attrib_id` (`attrib_id`) USING BTREE,
   CONSTRAINT `attrib_values_ibfk_1` FOREIGN KEY (`attrib_id`) REFERENCES `attribs` (`id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `attribs` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
@@ -126,52 +126,52 @@ CREATE TABLE `attribs` (
   CONSTRAINT `attribs_ibfk_1` FOREIGN KEY (`attrib_type_id`) REFERENCES `attrib_types` (`id`),
   CONSTRAINT `attribs_ibfk_2` FOREIGN KEY (`package_id`) REFERENCES `packages` (`id`),
   CONSTRAINT `attribs_ibfk_3` FOREIGN KEY (`project_id`) REFERENCES `projects` (`id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `backend_infos` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
-  `key` varchar(255) COLLATE utf8_unicode_ci NOT NULL,
-  `value` varchar(255) COLLATE utf8_unicode_ci NOT NULL,
+  `key` varchar(255) CHARACTER SET utf8 COLLATE utf8_unicode_ci NOT NULL,
+  `value` varchar(255) CHARACTER SET utf8 COLLATE utf8_unicode_ci NOT NULL,
   `created_at` datetime DEFAULT NULL,
   `updated_at` datetime(6) DEFAULT NULL,
   PRIMARY KEY (`id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `backend_packages` (
   `package_id` int(11) NOT NULL AUTO_INCREMENT,
   `links_to_id` int(11) DEFAULT NULL,
   `updated_at` datetime(6) DEFAULT NULL,
-  `srcmd5` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
-  `changesmd5` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
-  `verifymd5` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
-  `expandedmd5` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
-  `error` text COLLATE utf8_unicode_ci,
+  `srcmd5` varchar(255) CHARACTER SET utf8 COLLATE utf8_unicode_ci DEFAULT NULL,
+  `changesmd5` varchar(255) CHARACTER SET utf8 COLLATE utf8_unicode_ci DEFAULT NULL,
+  `verifymd5` varchar(255) CHARACTER SET utf8 COLLATE utf8_unicode_ci DEFAULT NULL,
+  `expandedmd5` varchar(255) CHARACTER SET utf8 COLLATE utf8_unicode_ci DEFAULT NULL,
+  `error` text COLLATE utf8mb4_unicode_ci,
   `maxmtime` datetime DEFAULT NULL,
   PRIMARY KEY (`package_id`),
   KEY `index_backend_packages_on_links_to_id` (`links_to_id`) USING BTREE,
   CONSTRAINT `backend_packages_ibfk_1` FOREIGN KEY (`package_id`) REFERENCES `packages` (`id`),
   CONSTRAINT `backend_packages_ibfk_2` FOREIGN KEY (`links_to_id`) REFERENCES `packages` (`id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `binary_releases` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `repository_id` int(11) NOT NULL,
-  `operation` enum('added','removed','modified') DEFAULT 'added',
+  `operation` enum('added','removed','modified') CHARACTER SET utf8 DEFAULT 'added',
   `obsolete_time` datetime DEFAULT NULL,
   `release_package_id` int(11) DEFAULT NULL,
-  `binary_name` varchar(255) NOT NULL,
-  `binary_epoch` varchar(64) DEFAULT NULL,
-  `binary_version` varchar(64) NOT NULL,
-  `binary_release` varchar(64) NOT NULL,
-  `binary_arch` varchar(64) NOT NULL,
-  `binary_disturl` varchar(255) DEFAULT NULL,
+  `binary_name` varchar(255) CHARACTER SET utf8 NOT NULL,
+  `binary_epoch` varchar(64) CHARACTER SET utf8 DEFAULT NULL,
+  `binary_version` varchar(64) CHARACTER SET utf8 NOT NULL,
+  `binary_release` varchar(64) CHARACTER SET utf8 NOT NULL,
+  `binary_arch` varchar(64) CHARACTER SET utf8 NOT NULL,
+  `binary_disturl` varchar(255) CHARACTER SET utf8 DEFAULT NULL,
   `binary_buildtime` datetime DEFAULT NULL,
   `binary_releasetime` datetime NOT NULL,
-  `binary_supportstatus` varchar(255) DEFAULT NULL,
-  `binary_maintainer` varchar(255) DEFAULT NULL,
-  `medium` varchar(255) DEFAULT NULL,
-  `binary_updateinfo` varchar(255) DEFAULT NULL,
-  `binary_updateinfo_version` varchar(255) DEFAULT NULL,
+  `binary_supportstatus` varchar(255) CHARACTER SET utf8 DEFAULT NULL,
+  `binary_maintainer` varchar(255) CHARACTER SET utf8 DEFAULT NULL,
+  `medium` varchar(255) CHARACTER SET utf8 DEFAULT NULL,
+  `binary_updateinfo` varchar(255) CHARACTER SET utf8 DEFAULT NULL,
+  `binary_updateinfo_version` varchar(255) CHARACTER SET utf8 DEFAULT NULL,
   `modify_time` datetime DEFAULT NULL,
   PRIMARY KEY (`id`),
   KEY `ra_name_index` (`repository_id`,`binary_name`),
@@ -182,28 +182,28 @@ CREATE TABLE `binary_releases` (
   KEY `index_binary_releases_on_binary_name_and_binary_arch` (`binary_name`,`binary_arch`),
   CONSTRAINT `binary_releases_ibfk_1` FOREIGN KEY (`repository_id`) REFERENCES `repositories` (`id`),
   CONSTRAINT `binary_releases_ibfk_2` FOREIGN KEY (`release_package_id`) REFERENCES `packages` (`id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `bs_request_action_accept_infos` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `bs_request_action_id` int(11) DEFAULT NULL,
-  `rev` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
-  `srcmd5` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
-  `xsrcmd5` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
-  `osrcmd5` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
-  `oxsrcmd5` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
+  `rev` varchar(255) CHARACTER SET utf8 COLLATE utf8_unicode_ci DEFAULT NULL,
+  `srcmd5` varchar(255) CHARACTER SET utf8 COLLATE utf8_unicode_ci DEFAULT NULL,
+  `xsrcmd5` varchar(255) CHARACTER SET utf8 COLLATE utf8_unicode_ci DEFAULT NULL,
+  `osrcmd5` varchar(255) CHARACTER SET utf8 COLLATE utf8_unicode_ci DEFAULT NULL,
+  `oxsrcmd5` varchar(255) CHARACTER SET utf8 COLLATE utf8_unicode_ci DEFAULT NULL,
   `created_at` datetime DEFAULT NULL,
-  `oproject` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
-  `opackage` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
+  `oproject` varchar(255) CHARACTER SET utf8 COLLATE utf8_unicode_ci DEFAULT NULL,
+  `opackage` varchar(255) CHARACTER SET utf8 COLLATE utf8_unicode_ci DEFAULT NULL,
   PRIMARY KEY (`id`),
   KEY `bs_request_action_id` (`bs_request_action_id`) USING BTREE,
   CONSTRAINT `bs_request_action_accept_infos_ibfk_1` FOREIGN KEY (`bs_request_action_id`) REFERENCES `bs_request_actions` (`id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `bs_request_actions` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `bs_request_id` int(11) DEFAULT NULL,
-  `type` varchar(255) COLLATE utf8_bin DEFAULT NULL,
+  `type` varchar(255) CHARACTER SET utf8 COLLATE utf8_bin DEFAULT NULL,
   `target_project` varchar(255) CHARACTER SET utf8 COLLATE utf8_unicode_ci DEFAULT NULL,
   `target_package` varchar(255) CHARACTER SET utf8 COLLATE utf8_unicode_ci DEFAULT NULL,
   `target_releaseproject` varchar(255) CHARACTER SET utf8 COLLATE utf8_unicode_ci DEFAULT NULL,
@@ -216,7 +216,7 @@ CREATE TABLE `bs_request_actions` (
   `group_name` varchar(255) CHARACTER SET utf8 COLLATE utf8_unicode_ci DEFAULT NULL,
   `role` varchar(255) CHARACTER SET utf8 COLLATE utf8_unicode_ci DEFAULT NULL,
   `created_at` datetime DEFAULT NULL,
-  `target_repository` varchar(255) COLLATE utf8_bin DEFAULT NULL,
+  `target_repository` varchar(255) CHARACTER SET utf8 COLLATE utf8_bin DEFAULT NULL,
   `makeoriginolder` tinyint(1) DEFAULT '0',
   `target_package_id` int(11) DEFAULT NULL,
   `target_project_id` int(11) DEFAULT NULL,
@@ -231,26 +231,26 @@ CREATE TABLE `bs_request_actions` (
   KEY `index_bs_request_actions_on_target_project_id` (`target_project_id`),
   KEY `index_bs_request_actions_on_target_package_id` (`target_package_id`),
   CONSTRAINT `bs_request_actions_ibfk_1` FOREIGN KEY (`bs_request_id`) REFERENCES `bs_requests` (`id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `bs_request_counter` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `counter` int(11) DEFAULT '1',
   PRIMARY KEY (`id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `bs_requests` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
-  `description` text COLLATE utf8_bin,
+  `description` text COLLATE utf8mb4_unicode_ci,
   `creator` varchar(255) CHARACTER SET utf8 COLLATE utf8_unicode_ci DEFAULT NULL,
   `state` varchar(255) CHARACTER SET utf8 COLLATE utf8_unicode_ci DEFAULT NULL,
-  `comment` text COLLATE utf8_bin,
+  `comment` text COLLATE utf8mb4_unicode_ci,
   `commenter` varchar(255) CHARACTER SET utf8 COLLATE utf8_unicode_ci DEFAULT NULL,
   `superseded_by` int(11) DEFAULT NULL,
   `created_at` datetime NOT NULL,
   `updated_at` datetime(6) NOT NULL,
   `accept_at` datetime DEFAULT NULL,
-  `priority` enum('critical','important','moderate','low') COLLATE utf8_bin DEFAULT 'moderate',
+  `priority` enum('critical','important','moderate','low') CHARACTER SET utf8 COLLATE utf8_bin DEFAULT 'moderate',
   `number` int(11) DEFAULT NULL,
   `updated_when` datetime DEFAULT NULL,
   PRIMARY KEY (`id`),
@@ -258,18 +258,18 @@ CREATE TABLE `bs_requests` (
   KEY `index_bs_requests_on_creator` (`creator`) USING BTREE,
   KEY `index_bs_requests_on_state` (`state`) USING BTREE,
   KEY `index_bs_requests_on_superseded_by` (`superseded_by`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `channel_binaries` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
-  `name` varchar(255) COLLATE utf8_unicode_ci NOT NULL,
+  `name` varchar(255) CHARACTER SET utf8 COLLATE utf8_unicode_ci NOT NULL,
   `channel_binary_list_id` int(11) NOT NULL,
   `project_id` int(11) DEFAULT NULL,
   `repository_id` int(11) DEFAULT NULL,
   `architecture_id` int(11) DEFAULT NULL,
-  `package` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
-  `binaryarch` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
-  `supportstatus` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
+  `package` varchar(255) CHARACTER SET utf8 COLLATE utf8_unicode_ci DEFAULT NULL,
+  `binaryarch` varchar(255) CHARACTER SET utf8 COLLATE utf8_unicode_ci DEFAULT NULL,
+  `supportstatus` varchar(255) CHARACTER SET utf8 COLLATE utf8_unicode_ci DEFAULT NULL,
   PRIMARY KEY (`id`),
   KEY `index_channel_binaries_on_project_id_and_package` (`project_id`,`package`) USING BTREE,
   KEY `channel_binary_list_id` (`channel_binary_list_id`) USING BTREE,
@@ -280,7 +280,7 @@ CREATE TABLE `channel_binaries` (
   CONSTRAINT `channel_binaries_ibfk_2` FOREIGN KEY (`project_id`) REFERENCES `projects` (`id`),
   CONSTRAINT `channel_binaries_ibfk_3` FOREIGN KEY (`repository_id`) REFERENCES `repositories` (`id`),
   CONSTRAINT `channel_binaries_ibfk_4` FOREIGN KEY (`architecture_id`) REFERENCES `architectures` (`id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `channel_binary_lists` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
@@ -297,14 +297,14 @@ CREATE TABLE `channel_binary_lists` (
   CONSTRAINT `channel_binary_lists_ibfk_2` FOREIGN KEY (`project_id`) REFERENCES `projects` (`id`),
   CONSTRAINT `channel_binary_lists_ibfk_3` FOREIGN KEY (`repository_id`) REFERENCES `repositories` (`id`),
   CONSTRAINT `channel_binary_lists_ibfk_4` FOREIGN KEY (`architecture_id`) REFERENCES `architectures` (`id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `channel_targets` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `channel_id` int(11) NOT NULL,
   `repository_id` int(11) NOT NULL,
-  `prefix` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
-  `id_template` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
+  `prefix` varchar(255) CHARACTER SET utf8 COLLATE utf8_unicode_ci DEFAULT NULL,
+  `id_template` varchar(255) CHARACTER SET utf8 COLLATE utf8_unicode_ci DEFAULT NULL,
   `disabled` tinyint(1) DEFAULT '0',
   `requires_issue` tinyint(1) DEFAULT NULL,
   PRIMARY KEY (`id`),
@@ -312,7 +312,7 @@ CREATE TABLE `channel_targets` (
   KEY `repository_id` (`repository_id`) USING BTREE,
   CONSTRAINT `channel_targets_ibfk_1` FOREIGN KEY (`channel_id`) REFERENCES `channels` (`id`),
   CONSTRAINT `channel_targets_ibfk_2` FOREIGN KEY (`repository_id`) REFERENCES `repositories` (`id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `channels` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
@@ -320,30 +320,30 @@ CREATE TABLE `channels` (
   PRIMARY KEY (`id`),
   UNIQUE KEY `index_unique` (`package_id`),
   CONSTRAINT `channels_ibfk_1` FOREIGN KEY (`package_id`) REFERENCES `packages` (`id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `cloud_azure_configurations` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `user_id` int(11) DEFAULT NULL,
-  `application_id` text,
-  `application_key` text,
+  `application_id` text CHARACTER SET utf8,
+  `application_key` text CHARACTER SET utf8,
   `created_at` datetime NOT NULL,
   `updated_at` datetime NOT NULL,
   PRIMARY KEY (`id`),
   KEY `index_cloud_azure_configurations_on_user_id` (`user_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `cloud_ec2_configurations` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `user_id` int(11) DEFAULT NULL,
-  `external_id` varchar(255) DEFAULT NULL,
-  `arn` varchar(255) DEFAULT NULL,
+  `external_id` varchar(255) CHARACTER SET utf8 DEFAULT NULL,
+  `arn` varchar(255) CHARACTER SET utf8 DEFAULT NULL,
   `created_at` datetime NOT NULL,
   `updated_at` datetime NOT NULL,
   PRIMARY KEY (`id`),
   UNIQUE KEY `index_cloud_ec2_configurations_on_external_id_and_arn` (`external_id`,`arn`),
   KEY `index_cloud_ec2_configurations_on_user_id` (`user_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `cloud_user_upload_jobs` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
@@ -354,16 +354,16 @@ CREATE TABLE `cloud_user_upload_jobs` (
   PRIMARY KEY (`id`),
   UNIQUE KEY `index_cloud_user_upload_jobs_on_job_id` (`job_id`),
   KEY `index_cloud_user_upload_jobs_on_user_id` (`user_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `comments` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
-  `body` text COLLATE utf8_unicode_ci,
+  `body` text COLLATE utf8mb4_unicode_ci,
   `parent_id` int(11) DEFAULT NULL,
   `created_at` datetime DEFAULT NULL,
   `updated_at` datetime(6) DEFAULT NULL,
   `user_id` int(11) NOT NULL,
-  `commentable_type` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
+  `commentable_type` varchar(255) CHARACTER SET utf8 COLLATE utf8_unicode_ci DEFAULT NULL,
   `commentable_id` int(11) DEFAULT NULL,
   PRIMARY KEY (`id`),
   KEY `user_id` (`user_id`) USING BTREE,
@@ -371,16 +371,16 @@ CREATE TABLE `comments` (
   KEY `index_comments_on_commentable_type_and_commentable_id` (`commentable_type`,`commentable_id`),
   CONSTRAINT `comments_ibfk_1` FOREIGN KEY (`user_id`) REFERENCES `users` (`id`),
   CONSTRAINT `comments_ibfk_4` FOREIGN KEY (`parent_id`) REFERENCES `comments` (`id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `configurations` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
-  `title` varchar(255) COLLATE utf8_bin DEFAULT '',
-  `description` text CHARACTER SET utf8,
+  `title` varchar(255) CHARACTER SET utf8 COLLATE utf8_bin DEFAULT '',
+  `description` text COLLATE utf8mb4_unicode_ci,
   `created_at` datetime DEFAULT NULL,
   `updated_at` datetime(6) DEFAULT NULL,
-  `name` varchar(255) COLLATE utf8_bin DEFAULT '',
-  `registration` enum('allow','confirmation','deny') COLLATE utf8_bin DEFAULT 'allow',
+  `name` varchar(255) CHARACTER SET utf8 COLLATE utf8_bin DEFAULT '',
+  `registration` enum('allow','confirmation','deny') CHARACTER SET utf8 COLLATE utf8_bin DEFAULT 'allow',
   `anonymous` tinyint(1) DEFAULT '1',
   `default_access_disabled` tinyint(1) DEFAULT '0',
   `allow_user_to_create_home_project` tinyint(1) DEFAULT '1',
@@ -390,35 +390,35 @@ CREATE TABLE `configurations` (
   `gravatar` tinyint(1) DEFAULT '1',
   `enforce_project_keys` tinyint(1) DEFAULT '0',
   `download_on_demand` tinyint(1) DEFAULT '1',
-  `download_url` varchar(255) COLLATE utf8_bin DEFAULT NULL,
-  `ymp_url` varchar(255) COLLATE utf8_bin DEFAULT NULL,
-  `bugzilla_url` varchar(255) COLLATE utf8_bin DEFAULT NULL,
-  `http_proxy` varchar(255) COLLATE utf8_bin DEFAULT NULL,
-  `no_proxy` varchar(255) COLLATE utf8_bin DEFAULT NULL,
-  `theme` varchar(255) COLLATE utf8_bin DEFAULT NULL,
-  `obs_url` varchar(255) COLLATE utf8_bin DEFAULT 'https://unconfigured.openbuildservice.org',
+  `download_url` varchar(255) CHARACTER SET utf8 COLLATE utf8_bin DEFAULT NULL,
+  `ymp_url` varchar(255) CHARACTER SET utf8 COLLATE utf8_bin DEFAULT NULL,
+  `bugzilla_url` varchar(255) CHARACTER SET utf8 COLLATE utf8_bin DEFAULT NULL,
+  `http_proxy` varchar(255) CHARACTER SET utf8 COLLATE utf8_bin DEFAULT NULL,
+  `no_proxy` varchar(255) CHARACTER SET utf8 COLLATE utf8_bin DEFAULT NULL,
+  `theme` varchar(255) CHARACTER SET utf8 COLLATE utf8_bin DEFAULT NULL,
+  `obs_url` varchar(255) CHARACTER SET utf8 COLLATE utf8_bin DEFAULT 'https://unconfigured.openbuildservice.org',
   `cleanup_after_days` int(11) DEFAULT NULL,
-  `admin_email` varchar(255) COLLATE utf8_bin DEFAULT 'unconfigured@openbuildservice.org',
+  `admin_email` varchar(255) CHARACTER SET utf8 COLLATE utf8_bin DEFAULT 'unconfigured@openbuildservice.org',
   `cleanup_empty_projects` tinyint(1) DEFAULT '1',
   `disable_publish_for_branches` tinyint(1) DEFAULT '1',
-  `default_tracker` varchar(255) COLLATE utf8_bin DEFAULT 'bnc',
-  `api_url` varchar(255) COLLATE utf8_bin DEFAULT NULL,
-  `unlisted_projects_filter` varchar(255) COLLATE utf8_bin DEFAULT '^home:.+',
-  `unlisted_projects_filter_description` varchar(255) COLLATE utf8_bin DEFAULT 'home projects',
+  `default_tracker` varchar(255) CHARACTER SET utf8 COLLATE utf8_bin DEFAULT 'bnc',
+  `api_url` varchar(255) CHARACTER SET utf8 COLLATE utf8_bin DEFAULT NULL,
+  `unlisted_projects_filter` varchar(255) CHARACTER SET utf8 COLLATE utf8_bin DEFAULT '^home:.+',
+  `unlisted_projects_filter_description` varchar(255) CHARACTER SET utf8 COLLATE utf8_bin DEFAULT 'home projects',
   PRIMARY KEY (`id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `data_migrations` (
-  `version` varchar(255) NOT NULL,
+  `version` varchar(255) CHARACTER SET utf8 NOT NULL,
   PRIMARY KEY (`version`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `delayed_jobs` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `priority` int(11) DEFAULT '0',
   `attempts` int(11) DEFAULT '0',
-  `handler` mediumtext COLLATE utf8_bin,
-  `last_error` text CHARACTER SET utf8,
+  `handler` mediumtext CHARACTER SET utf8 COLLATE utf8_bin,
+  `last_error` text COLLATE utf8mb4_unicode_ci,
   `run_at` datetime DEFAULT NULL,
   `locked_at` datetime DEFAULT NULL,
   `failed_at` datetime DEFAULT NULL,
@@ -426,54 +426,54 @@ CREATE TABLE `delayed_jobs` (
   `queue` varchar(255) CHARACTER SET utf8 DEFAULT NULL,
   PRIMARY KEY (`id`),
   KEY `index_delayed_jobs_on_queue` (`queue`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `distribution_icons` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
-  `url` varchar(255) COLLATE utf8_unicode_ci NOT NULL,
+  `url` varchar(255) CHARACTER SET utf8 COLLATE utf8_unicode_ci NOT NULL,
   `width` int(11) DEFAULT NULL,
   `height` int(11) DEFAULT NULL,
   PRIMARY KEY (`id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `distribution_icons_distributions` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `distribution_id` int(11) DEFAULT NULL,
   `distribution_icon_id` int(11) DEFAULT NULL,
   PRIMARY KEY (`id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `distributions` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
-  `vendor` varchar(255) COLLATE utf8_unicode_ci NOT NULL,
-  `version` varchar(255) COLLATE utf8_unicode_ci NOT NULL,
-  `name` varchar(255) COLLATE utf8_unicode_ci NOT NULL,
-  `project` varchar(255) COLLATE utf8_unicode_ci NOT NULL,
-  `reponame` varchar(255) COLLATE utf8_unicode_ci NOT NULL,
-  `repository` varchar(255) COLLATE utf8_unicode_ci NOT NULL,
-  `link` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
+  `vendor` varchar(255) CHARACTER SET utf8 COLLATE utf8_unicode_ci NOT NULL,
+  `version` varchar(255) CHARACTER SET utf8 COLLATE utf8_unicode_ci NOT NULL,
+  `name` varchar(255) CHARACTER SET utf8 COLLATE utf8_unicode_ci NOT NULL,
+  `project` varchar(255) CHARACTER SET utf8 COLLATE utf8_unicode_ci NOT NULL,
+  `reponame` varchar(255) CHARACTER SET utf8 COLLATE utf8_unicode_ci NOT NULL,
+  `repository` varchar(255) CHARACTER SET utf8 COLLATE utf8_unicode_ci NOT NULL,
+  `link` varchar(255) CHARACTER SET utf8 COLLATE utf8_unicode_ci DEFAULT NULL,
   PRIMARY KEY (`id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `download_repositories` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `repository_id` int(11) NOT NULL,
-  `arch` varchar(255) NOT NULL,
-  `url` varchar(255) NOT NULL,
-  `repotype` varchar(255) DEFAULT NULL,
-  `archfilter` varchar(255) DEFAULT NULL,
-  `masterurl` varchar(255) DEFAULT NULL,
-  `mastersslfingerprint` varchar(255) DEFAULT NULL,
-  `pubkey` text,
+  `arch` varchar(255) CHARACTER SET utf8 NOT NULL,
+  `url` varchar(255) CHARACTER SET utf8 NOT NULL,
+  `repotype` varchar(255) CHARACTER SET utf8 DEFAULT NULL,
+  `archfilter` varchar(255) CHARACTER SET utf8 DEFAULT NULL,
+  `masterurl` varchar(255) CHARACTER SET utf8 DEFAULT NULL,
+  `mastersslfingerprint` varchar(255) CHARACTER SET utf8 DEFAULT NULL,
+  `pubkey` text CHARACTER SET utf8,
   PRIMARY KEY (`id`),
   KEY `repository_id` (`repository_id`),
   CONSTRAINT `download_repositories_ibfk_1` FOREIGN KEY (`repository_id`) REFERENCES `repositories` (`id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `event_subscriptions` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
-  `eventtype` varchar(255) COLLATE utf8_unicode_ci NOT NULL,
-  `receiver_role` varchar(255) COLLATE utf8_unicode_ci NOT NULL,
+  `eventtype` varchar(255) CHARACTER SET utf8 COLLATE utf8_unicode_ci NOT NULL,
+  `receiver_role` varchar(255) CHARACTER SET utf8 COLLATE utf8_unicode_ci NOT NULL,
   `user_id` int(11) DEFAULT NULL,
   `created_at` datetime DEFAULT NULL,
   `updated_at` datetime(6) DEFAULT NULL,
@@ -482,12 +482,12 @@ CREATE TABLE `event_subscriptions` (
   PRIMARY KEY (`id`),
   KEY `index_event_subscriptions_on_user_id` (`user_id`) USING BTREE,
   KEY `index_event_subscriptions_on_group_id` (`group_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `events` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
-  `eventtype` varchar(255) COLLATE utf8_unicode_ci NOT NULL,
-  `payload` text COLLATE utf8_unicode_ci,
+  `eventtype` varchar(255) CHARACTER SET utf8 COLLATE utf8_unicode_ci NOT NULL,
+  `payload` text COLLATE utf8mb4_unicode_ci,
   `created_at` datetime DEFAULT NULL,
   `updated_at` datetime(6) DEFAULT NULL,
   `undone_jobs` int(11) DEFAULT '0',
@@ -496,7 +496,7 @@ CREATE TABLE `events` (
   KEY `index_events_on_eventtype` (`eventtype`) USING BTREE,
   KEY `index_events_on_created_at` (`created_at`) USING BTREE,
   KEY `index_events_on_mails_sent` (`mails_sent`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `flags` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
@@ -515,7 +515,7 @@ CREATE TABLE `flags` (
   CONSTRAINT `flags_ibfk_3` FOREIGN KEY (`architecture_id`) REFERENCES `architectures` (`id`),
   CONSTRAINT `flags_ibfk_4` FOREIGN KEY (`project_id`) REFERENCES `projects` (`id`),
   CONSTRAINT `flags_ibfk_5` FOREIGN KEY (`package_id`) REFERENCES `packages` (`id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `group_maintainers` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
@@ -526,7 +526,7 @@ CREATE TABLE `group_maintainers` (
   KEY `user_id` (`user_id`),
   CONSTRAINT `group_maintainers_ibfk_1` FOREIGN KEY (`group_id`) REFERENCES `groups` (`id`),
   CONSTRAINT `group_maintainers_ibfk_2` FOREIGN KEY (`user_id`) REFERENCES `users` (`id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `group_request_requests` (
   `bs_request_action_group_id` int(11) DEFAULT NULL,
@@ -535,7 +535,7 @@ CREATE TABLE `group_request_requests` (
   PRIMARY KEY (`id`),
   KEY `index_group_request_requests_on_bs_request_id` (`bs_request_id`) USING BTREE,
   KEY `index_group_request_requests_on_bs_request_action_group_id` (`bs_request_action_group_id`) USING BTREE
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `groups` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
@@ -543,11 +543,11 @@ CREATE TABLE `groups` (
   `updated_at` datetime(6) DEFAULT NULL,
   `title` varchar(200) CHARACTER SET utf8 NOT NULL DEFAULT '',
   `parent_id` int(11) DEFAULT NULL,
-  `email` varchar(255) COLLATE utf8_bin DEFAULT NULL,
+  `email` varchar(255) CHARACTER SET utf8 COLLATE utf8_bin DEFAULT NULL,
   PRIMARY KEY (`id`),
   KEY `groups_parent_id_index` (`parent_id`) USING BTREE,
   KEY `index_groups_on_title` (`title`) USING BTREE
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `groups_roles` (
   `group_id` int(11) NOT NULL DEFAULT '0',
@@ -557,7 +557,7 @@ CREATE TABLE `groups_roles` (
   KEY `role_id` (`role_id`) USING BTREE,
   CONSTRAINT `groups_roles_ibfk_1` FOREIGN KEY (`group_id`) REFERENCES `groups` (`id`),
   CONSTRAINT `groups_roles_ibfk_2` FOREIGN KEY (`role_id`) REFERENCES `roles` (`id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `groups_users` (
   `group_id` int(11) NOT NULL DEFAULT '0',
@@ -570,28 +570,28 @@ CREATE TABLE `groups_users` (
   KEY `user_id` (`user_id`) USING BTREE,
   CONSTRAINT `groups_users_ibfk_1` FOREIGN KEY (`group_id`) REFERENCES `groups` (`id`),
   CONSTRAINT `groups_users_ibfk_2` FOREIGN KEY (`user_id`) REFERENCES `users` (`id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `history_elements` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
-  `type` varchar(255) NOT NULL,
+  `type` varchar(255) CHARACTER SET utf8 NOT NULL,
   `op_object_id` int(11) NOT NULL,
   `created_at` datetime NOT NULL,
   `user_id` int(11) NOT NULL,
-  `description_extension` varchar(255) DEFAULT NULL,
-  `comment` text,
+  `description_extension` varchar(255) CHARACTER SET utf8 DEFAULT NULL,
+  `comment` text COLLATE utf8mb4_unicode_ci,
   PRIMARY KEY (`id`),
   KEY `index_history_elements_on_created_at` (`created_at`),
   KEY `index_history_elements_on_type` (`type`),
   KEY `index_search` (`op_object_id`,`type`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `incident_counter` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `maintenance_db_project_id` int(11) DEFAULT NULL,
   `counter` int(11) DEFAULT '0',
   PRIMARY KEY (`id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `incident_updateinfo_counter_values` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
@@ -603,12 +603,12 @@ CREATE TABLE `incident_updateinfo_counter_values` (
   KEY `uniq_id_index` (`updateinfo_counter_id`,`project_id`),
   KEY `project_id` (`project_id`),
   CONSTRAINT `incident_updateinfo_counter_values_ibfk_1` FOREIGN KEY (`project_id`) REFERENCES `projects` (`id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `issue_trackers` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `name` varchar(255) CHARACTER SET utf8 NOT NULL,
-  `kind` enum('other','bugzilla','cve','fate','trac','launchpad','sourceforge','github') COLLATE utf8_bin NOT NULL,
+  `kind` enum('other','bugzilla','cve','fate','trac','launchpad','sourceforge','github') CHARACTER SET utf8 COLLATE utf8_bin NOT NULL,
   `description` varchar(255) CHARACTER SET utf8 DEFAULT NULL,
   `url` varchar(255) CHARACTER SET utf8 NOT NULL,
   `show_url` varchar(255) CHARACTER SET utf8 DEFAULT NULL,
@@ -619,7 +619,7 @@ CREATE TABLE `issue_trackers` (
   `issues_updated` datetime NOT NULL,
   `enable_fetch` tinyint(1) DEFAULT '0',
   PRIMARY KEY (`id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `issues` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
@@ -636,49 +636,49 @@ CREATE TABLE `issues` (
   KEY `index_issues_on_name_and_issue_tracker_id` (`name`,`issue_tracker_id`) USING BTREE,
   CONSTRAINT `issues_ibfk_1` FOREIGN KEY (`owner_id`) REFERENCES `users` (`id`),
   CONSTRAINT `issues_ibfk_2` FOREIGN KEY (`issue_tracker_id`) REFERENCES `issue_trackers` (`id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `kiwi_descriptions` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `image_id` int(11) DEFAULT NULL,
   `description_type` int(11) DEFAULT '0',
-  `author` varchar(255) DEFAULT NULL,
-  `contact` varchar(255) DEFAULT NULL,
-  `specification` varchar(255) DEFAULT NULL,
+  `author` varchar(255) CHARACTER SET utf8 DEFAULT NULL,
+  `contact` varchar(255) CHARACTER SET utf8 DEFAULT NULL,
+  `specification` varchar(255) CHARACTER SET utf8 DEFAULT NULL,
   `created_at` datetime NOT NULL,
   `updated_at` datetime NOT NULL,
   PRIMARY KEY (`id`),
   KEY `index_kiwi_descriptions_on_image_id` (`image_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `kiwi_images` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
-  `name` varchar(255) DEFAULT NULL,
-  `md5_last_revision` varchar(32) DEFAULT NULL,
+  `name` varchar(255) CHARACTER SET utf8 DEFAULT NULL,
+  `md5_last_revision` varchar(32) CHARACTER SET utf8 DEFAULT NULL,
   `created_at` datetime NOT NULL,
   `updated_at` datetime(6) NOT NULL,
   `use_project_repositories` tinyint(1) DEFAULT '0',
   PRIMARY KEY (`id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `kiwi_package_groups` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `kiwi_type` int(11) NOT NULL,
-  `profiles` varchar(255) DEFAULT NULL,
-  `pattern_type` varchar(255) DEFAULT NULL,
+  `profiles` varchar(255) CHARACTER SET utf8 DEFAULT NULL,
+  `pattern_type` varchar(255) CHARACTER SET utf8 DEFAULT NULL,
   `image_id` int(11) DEFAULT NULL,
   `created_at` datetime NOT NULL,
   `updated_at` datetime NOT NULL,
   PRIMARY KEY (`id`),
   KEY `index_kiwi_package_groups_on_image_id` (`image_id`),
   CONSTRAINT `fk_rails_c64a679086` FOREIGN KEY (`image_id`) REFERENCES `kiwi_images` (`id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `kiwi_packages` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
-  `name` varchar(255) NOT NULL,
-  `arch` varchar(255) DEFAULT NULL,
-  `replaces` varchar(255) DEFAULT NULL,
+  `name` varchar(255) CHARACTER SET utf8 NOT NULL,
+  `arch` varchar(255) CHARACTER SET utf8 DEFAULT NULL,
+  `replaces` varchar(255) CHARACTER SET utf8 DEFAULT NULL,
   `bootinclude` tinyint(1) DEFAULT NULL,
   `bootdelete` tinyint(1) DEFAULT NULL,
   `package_group_id` int(11) DEFAULT NULL,
@@ -687,38 +687,38 @@ CREATE TABLE `kiwi_packages` (
   PRIMARY KEY (`id`),
   KEY `index_kiwi_packages_on_package_group_id` (`package_group_id`),
   CONSTRAINT `fk_rails_0ecab3b2cd` FOREIGN KEY (`package_group_id`) REFERENCES `kiwi_package_groups` (`id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `kiwi_preferences` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `image_id` int(11) DEFAULT NULL,
   `type_image` int(11) DEFAULT NULL,
-  `type_containerconfig_name` varchar(255) DEFAULT NULL,
-  `type_containerconfig_tag` varchar(255) DEFAULT NULL,
-  `version` varchar(255) DEFAULT NULL,
+  `type_containerconfig_name` varchar(255) CHARACTER SET utf8 DEFAULT NULL,
+  `type_containerconfig_tag` varchar(255) CHARACTER SET utf8 DEFAULT NULL,
+  `version` varchar(255) CHARACTER SET utf8 DEFAULT NULL,
   PRIMARY KEY (`id`),
   KEY `index_kiwi_preferences_on_image_id` (`image_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `kiwi_repositories` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `image_id` int(11) DEFAULT NULL,
-  `repo_type` varchar(255) DEFAULT NULL,
-  `source_path` varchar(255) DEFAULT NULL,
+  `repo_type` varchar(255) CHARACTER SET utf8 DEFAULT NULL,
+  `source_path` varchar(255) CHARACTER SET utf8 DEFAULT NULL,
   `order` int(11) DEFAULT NULL,
   `priority` int(11) DEFAULT NULL,
   `created_at` datetime NOT NULL,
   `updated_at` datetime(6) NOT NULL,
-  `alias` varchar(255) DEFAULT NULL,
+  `alias` varchar(255) CHARACTER SET utf8 DEFAULT NULL,
   `imageinclude` tinyint(1) DEFAULT NULL,
-  `password` varchar(255) DEFAULT NULL,
+  `password` varchar(255) CHARACTER SET utf8 DEFAULT NULL,
   `prefer_license` tinyint(1) DEFAULT NULL,
   `replaceable` tinyint(1) DEFAULT NULL,
-  `username` varchar(255) DEFAULT NULL,
+  `username` varchar(255) CHARACTER SET utf8 DEFAULT NULL,
   PRIMARY KEY (`id`),
   UNIQUE KEY `index_kiwi_repositories_on_image_id_and_order` (`image_id`,`order`),
   KEY `index_kiwi_repositories_on_image_id` (`image_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `linked_projects` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
@@ -726,10 +726,10 @@ CREATE TABLE `linked_projects` (
   `linked_db_project_id` int(11) DEFAULT NULL,
   `position` int(11) DEFAULT NULL,
   `linked_remote_project_name` varchar(255) CHARACTER SET utf8 DEFAULT NULL,
-  `vrevmode` enum('standard','unextend','extend') COLLATE utf8_bin DEFAULT 'standard',
+  `vrevmode` enum('standard','unextend','extend') CHARACTER SET utf8 COLLATE utf8_bin DEFAULT 'standard',
   PRIMARY KEY (`id`),
   UNIQUE KEY `linked_projects_index` (`db_project_id`,`linked_db_project_id`) USING BTREE
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `maintained_projects` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
@@ -740,7 +740,7 @@ CREATE TABLE `maintained_projects` (
   KEY `maintenance_project_id` (`maintenance_project_id`),
   CONSTRAINT `maintained_projects_ibfk_1` FOREIGN KEY (`project_id`) REFERENCES `projects` (`id`),
   CONSTRAINT `maintained_projects_ibfk_2` FOREIGN KEY (`maintenance_project_id`) REFERENCES `projects` (`id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `maintenance_incidents` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
@@ -752,7 +752,7 @@ CREATE TABLE `maintenance_incidents` (
   PRIMARY KEY (`id`),
   KEY `index_maintenance_incidents_on_db_project_id` (`db_project_id`) USING BTREE,
   KEY `index_maintenance_incidents_on_maintenance_db_project_id` (`maintenance_db_project_id`) USING BTREE
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `messages` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
@@ -764,54 +764,54 @@ CREATE TABLE `messages` (
   `sent_at` datetime DEFAULT NULL,
   `private` tinyint(1) DEFAULT NULL,
   `severity` int(11) DEFAULT NULL,
-  `text` text CHARACTER SET utf8,
+  `text` text COLLATE utf8mb4_unicode_ci,
   PRIMARY KEY (`id`),
   KEY `object` (`db_object_id`) USING BTREE,
   KEY `user` (`user_id`) USING BTREE
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `notifications` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
-  `type` varchar(255) NOT NULL,
-  `event_type` varchar(255) NOT NULL,
-  `event_payload` text NOT NULL,
-  `subscription_receiver_role` varchar(255) NOT NULL,
+  `type` varchar(255) CHARACTER SET utf8 NOT NULL,
+  `event_type` varchar(255) CHARACTER SET utf8 NOT NULL,
+  `event_payload` text COLLATE utf8mb4_unicode_ci NOT NULL,
+  `subscription_receiver_role` varchar(255) CHARACTER SET utf8 NOT NULL,
   `delivered` tinyint(1) DEFAULT '0',
   `created_at` datetime NOT NULL,
   `updated_at` datetime(6) NOT NULL,
-  `subscriber_type` varchar(255) DEFAULT NULL,
+  `subscriber_type` varchar(255) CHARACTER SET utf8 DEFAULT NULL,
   `subscriber_id` int(11) DEFAULT NULL,
   PRIMARY KEY (`id`),
   KEY `index_notifications_on_subscriber_type_and_subscriber_id` (`subscriber_type`,`subscriber_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `package_issues` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `package_id` int(11) NOT NULL,
   `issue_id` int(11) NOT NULL,
-  `change` enum('added','deleted','changed','kept') DEFAULT NULL,
+  `change` enum('added','deleted','changed','kept') CHARACTER SET utf8 DEFAULT NULL,
   PRIMARY KEY (`id`),
   KEY `index_package_issues_on_package_id_and_issue_id` (`package_id`,`issue_id`) USING BTREE,
   KEY `index_package_issues_on_issue_id` (`issue_id`) USING BTREE,
   CONSTRAINT `package_issues_ibfk_1` FOREIGN KEY (`package_id`) REFERENCES `packages` (`id`),
   CONSTRAINT `package_issues_ibfk_2` FOREIGN KEY (`issue_id`) REFERENCES `issues` (`id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `package_kinds` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `package_id` int(11) DEFAULT NULL,
-  `kind` enum('patchinfo','aggregate','link','channel','product') NOT NULL,
+  `kind` enum('patchinfo','aggregate','link','channel','product') CHARACTER SET utf8 NOT NULL,
   PRIMARY KEY (`id`),
   KEY `index_package_kinds_on_package_id` (`package_id`) USING BTREE,
   CONSTRAINT `package_kinds_ibfk_1` FOREIGN KEY (`package_id`) REFERENCES `packages` (`id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `packages` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `project_id` int(11) NOT NULL,
-  `name` varchar(200) COLLATE utf8_bin NOT NULL,
+  `name` varchar(200) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL,
   `title` varchar(255) CHARACTER SET utf8 DEFAULT NULL,
-  `description` text CHARACTER SET utf8,
+  `description` text COLLATE utf8mb4_unicode_ci,
   `created_at` datetime DEFAULT NULL,
   `updated_at` datetime(6) DEFAULT NULL,
   `url` varchar(255) CHARACTER SET utf8 DEFAULT NULL,
@@ -819,7 +819,7 @@ CREATE TABLE `packages` (
   `bcntsynctag` varchar(255) CHARACTER SET utf8 DEFAULT NULL,
   `develpackage_id` int(11) DEFAULT NULL,
   `delta` tinyint(1) NOT NULL DEFAULT '1',
-  `releasename` varchar(255) COLLATE utf8_bin DEFAULT NULL,
+  `releasename` varchar(255) CHARACTER SET utf8 COLLATE utf8_bin DEFAULT NULL,
   `kiwi_image_id` int(11) DEFAULT NULL,
   PRIMARY KEY (`id`),
   UNIQUE KEY `packages_all_index` (`project_id`,`name`) USING BTREE,
@@ -829,7 +829,7 @@ CREATE TABLE `packages` (
   CONSTRAINT `fk_rails_9a47aff19d` FOREIGN KEY (`kiwi_image_id`) REFERENCES `kiwi_images` (`id`),
   CONSTRAINT `packages_ibfk_3` FOREIGN KEY (`develpackage_id`) REFERENCES `packages` (`id`),
   CONSTRAINT `packages_ibfk_4` FOREIGN KEY (`project_id`) REFERENCES `projects` (`id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `path_elements` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
@@ -841,7 +841,7 @@ CREATE TABLE `path_elements` (
   KEY `repository_id` (`repository_id`) USING BTREE,
   CONSTRAINT `path_elements_ibfk_1` FOREIGN KEY (`parent_id`) REFERENCES `repositories` (`id`),
   CONSTRAINT `path_elements_ibfk_2` FOREIGN KEY (`repository_id`) REFERENCES `repositories` (`id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `product_channels` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
@@ -852,14 +852,14 @@ CREATE TABLE `product_channels` (
   KEY `product_id` (`product_id`) USING BTREE,
   CONSTRAINT `product_channels_ibfk_1` FOREIGN KEY (`channel_id`) REFERENCES `channels` (`id`),
   CONSTRAINT `product_channels_ibfk_2` FOREIGN KEY (`product_id`) REFERENCES `products` (`id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `product_media` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `product_id` int(11) DEFAULT NULL,
   `repository_id` int(11) DEFAULT NULL,
   `arch_filter_id` int(11) DEFAULT NULL,
-  `name` varchar(255) DEFAULT NULL,
+  `name` varchar(255) CHARACTER SET utf8 DEFAULT NULL,
   PRIMARY KEY (`id`),
   UNIQUE KEY `index_unique` (`product_id`,`repository_id`,`name`,`arch_filter_id`),
   KEY `index_product_media_on_product_id` (`product_id`),
@@ -869,7 +869,7 @@ CREATE TABLE `product_media` (
   CONSTRAINT `product_media_ibfk_1` FOREIGN KEY (`product_id`) REFERENCES `products` (`id`),
   CONSTRAINT `product_media_ibfk_2` FOREIGN KEY (`repository_id`) REFERENCES `repositories` (`id`),
   CONSTRAINT `product_media_ibfk_3` FOREIGN KEY (`arch_filter_id`) REFERENCES `architectures` (`id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `product_update_repositories` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
@@ -884,32 +884,32 @@ CREATE TABLE `product_update_repositories` (
   CONSTRAINT `product_update_repositories_ibfk_1` FOREIGN KEY (`product_id`) REFERENCES `products` (`id`),
   CONSTRAINT `product_update_repositories_ibfk_2` FOREIGN KEY (`repository_id`) REFERENCES `repositories` (`id`),
   CONSTRAINT `product_update_repositories_ibfk_3` FOREIGN KEY (`arch_filter_id`) REFERENCES `architectures` (`id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `products` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
-  `name` varchar(255) COLLATE utf8_unicode_ci NOT NULL,
+  `name` varchar(255) CHARACTER SET utf8 COLLATE utf8_unicode_ci NOT NULL,
   `package_id` int(11) NOT NULL,
-  `cpe` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
-  `version` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
-  `baseversion` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
-  `patchlevel` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
-  `release` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
+  `cpe` varchar(255) CHARACTER SET utf8 COLLATE utf8_unicode_ci DEFAULT NULL,
+  `version` varchar(255) CHARACTER SET utf8 COLLATE utf8_unicode_ci DEFAULT NULL,
+  `baseversion` varchar(255) CHARACTER SET utf8 COLLATE utf8_unicode_ci DEFAULT NULL,
+  `patchlevel` varchar(255) CHARACTER SET utf8 COLLATE utf8_unicode_ci DEFAULT NULL,
+  `release` varchar(255) CHARACTER SET utf8 COLLATE utf8_unicode_ci DEFAULT NULL,
   PRIMARY KEY (`id`),
   UNIQUE KEY `index_products_on_name_and_package_id` (`name`,`package_id`) USING BTREE,
   KEY `package_id` (`package_id`) USING BTREE,
   CONSTRAINT `products_ibfk_1` FOREIGN KEY (`package_id`) REFERENCES `packages` (`id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `project_log_entries` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `project_id` int(11) DEFAULT NULL,
-  `user_name` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
-  `package_name` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
+  `user_name` varchar(255) CHARACTER SET utf8 COLLATE utf8_unicode_ci DEFAULT NULL,
+  `package_name` varchar(255) CHARACTER SET utf8 COLLATE utf8_unicode_ci DEFAULT NULL,
   `bs_request_id` int(11) DEFAULT NULL,
   `datetime` datetime DEFAULT NULL,
-  `event_type` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
-  `additional_info` text COLLATE utf8_unicode_ci,
+  `event_type` varchar(255) CHARACTER SET utf8 COLLATE utf8_unicode_ci DEFAULT NULL,
+  `additional_info` text COLLATE utf8mb4_unicode_ci,
   PRIMARY KEY (`id`),
   KEY `project_id` (`project_id`) USING BTREE,
   KEY `index_project_log_entries_on_user_name` (`user_name`) USING BTREE,
@@ -918,26 +918,26 @@ CREATE TABLE `project_log_entries` (
   KEY `index_project_log_entries_on_event_type` (`event_type`) USING BTREE,
   KEY `index_project_log_entries_on_datetime` (`datetime`) USING BTREE,
   CONSTRAINT `project_log_entries_ibfk_1` FOREIGN KEY (`project_id`) REFERENCES `projects` (`id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `projects` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
-  `name` varchar(200) COLLATE utf8_bin NOT NULL,
+  `name` varchar(200) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL,
   `title` varchar(255) CHARACTER SET utf8 DEFAULT NULL,
-  `description` text CHARACTER SET utf8,
+  `description` text COLLATE utf8mb4_unicode_ci,
   `created_at` datetime DEFAULT NULL,
   `updated_at` datetime(6) DEFAULT NULL,
   `remoteurl` varchar(255) CHARACTER SET utf8 DEFAULT NULL,
   `remoteproject` varchar(255) CHARACTER SET utf8 DEFAULT NULL,
   `develproject_id` int(11) DEFAULT NULL,
   `delta` tinyint(1) NOT NULL DEFAULT '1',
-  `kind` enum('standard','maintenance','maintenance_incident','maintenance_release') COLLATE utf8_bin DEFAULT 'standard',
-  `url` varchar(255) COLLATE utf8_bin DEFAULT NULL,
+  `kind` enum('standard','maintenance','maintenance_incident','maintenance_release') CHARACTER SET utf8 COLLATE utf8_bin DEFAULT 'standard',
+  `url` varchar(255) CHARACTER SET utf8 COLLATE utf8_bin DEFAULT NULL,
   PRIMARY KEY (`id`),
   UNIQUE KEY `projects_name_index` (`name`) USING BTREE,
   KEY `updated_at_index` (`updated_at`) USING BTREE,
   KEY `devel_project_id_index` (`develproject_id`) USING BTREE
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `ratings` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
@@ -950,7 +950,7 @@ CREATE TABLE `ratings` (
   KEY `object` (`db_object_id`) USING BTREE,
   KEY `user` (`user_id`) USING BTREE,
   CONSTRAINT `ratings_ibfk_1` FOREIGN KEY (`user_id`) REFERENCES `users` (`id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `relationships` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
@@ -972,25 +972,25 @@ CREATE TABLE `relationships` (
   CONSTRAINT `relationships_ibfk_3` FOREIGN KEY (`group_id`) REFERENCES `groups` (`id`),
   CONSTRAINT `relationships_ibfk_4` FOREIGN KEY (`project_id`) REFERENCES `projects` (`id`),
   CONSTRAINT `relationships_ibfk_5` FOREIGN KEY (`package_id`) REFERENCES `packages` (`id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `release_targets` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `repository_id` int(11) NOT NULL,
   `target_repository_id` int(11) NOT NULL,
-  `trigger` enum('manual','allsucceeded','maintenance') DEFAULT NULL,
+  `trigger` enum('manual','allsucceeded','maintenance') CHARACTER SET utf8 DEFAULT NULL,
   PRIMARY KEY (`id`),
   KEY `repository_id_index` (`repository_id`) USING BTREE,
   KEY `index_release_targets_on_target_repository_id` (`target_repository_id`) USING BTREE,
   CONSTRAINT `release_targets_ibfk_1` FOREIGN KEY (`repository_id`) REFERENCES `repositories` (`id`),
   CONSTRAINT `release_targets_ibfk_2` FOREIGN KEY (`target_repository_id`) REFERENCES `repositories` (`id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `repositories` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `db_project_id` int(11) NOT NULL,
-  `name` varchar(255) COLLATE utf8_bin NOT NULL,
-  `remote_project_name` varchar(255) COLLATE utf8_bin NOT NULL DEFAULT '',
+  `name` varchar(255) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL,
+  `remote_project_name` varchar(255) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL DEFAULT '',
   `rebuild` enum('transitive','direct','local') CHARACTER SET utf8 DEFAULT NULL,
   `block` enum('all','local','never') CHARACTER SET utf8 DEFAULT NULL,
   `linkedbuild` enum('off','localdep','all') CHARACTER SET utf8 DEFAULT NULL,
@@ -1001,7 +1001,7 @@ CREATE TABLE `repositories` (
   KEY `hostsystem_id` (`hostsystem_id`) USING BTREE,
   CONSTRAINT `repositories_ibfk_1` FOREIGN KEY (`db_project_id`) REFERENCES `projects` (`id`),
   CONSTRAINT `repositories_ibfk_2` FOREIGN KEY (`hostsystem_id`) REFERENCES `repositories` (`id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `repository_architectures` (
   `repository_id` int(11) NOT NULL,
@@ -1013,15 +1013,15 @@ CREATE TABLE `repository_architectures` (
   KEY `architecture_id` (`architecture_id`) USING BTREE,
   CONSTRAINT `repository_architectures_ibfk_1` FOREIGN KEY (`repository_id`) REFERENCES `repositories` (`id`),
   CONSTRAINT `repository_architectures_ibfk_2` FOREIGN KEY (`architecture_id`) REFERENCES `architectures` (`id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `reviews` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `bs_request_id` int(11) DEFAULT NULL,
-  `creator` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
-  `reviewer` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
-  `reason` text COLLATE utf8_unicode_ci,
-  `state` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
+  `creator` varchar(255) CHARACTER SET utf8 COLLATE utf8_unicode_ci DEFAULT NULL,
+  `reviewer` varchar(255) CHARACTER SET utf8 COLLATE utf8_unicode_ci DEFAULT NULL,
+  `reason` text COLLATE utf8mb4_unicode_ci,
+  `state` varchar(255) CHARACTER SET utf8 COLLATE utf8_unicode_ci DEFAULT NULL,
   `by_user` varchar(255) CHARACTER SET utf8 DEFAULT NULL,
   `by_group` varchar(255) CHARACTER SET utf8 DEFAULT NULL,
   `by_project` varchar(255) CHARACTER SET utf8 DEFAULT NULL,
@@ -1050,7 +1050,7 @@ CREATE TABLE `reviews` (
   KEY `index_reviews_on_package_id` (`package_id`),
   CONSTRAINT `fk_rails_813a4fb24f` FOREIGN KEY (`review_id`) REFERENCES `reviews` (`id`),
   CONSTRAINT `reviews_ibfk_1` FOREIGN KEY (`bs_request_id`) REFERENCES `bs_requests` (`id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `roles` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
@@ -1062,7 +1062,7 @@ CREATE TABLE `roles` (
   PRIMARY KEY (`id`),
   KEY `roles_parent_id_index` (`parent_id`) USING BTREE,
   CONSTRAINT `roles_ibfk_1` FOREIGN KEY (`parent_id`) REFERENCES `roles` (`id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `roles_static_permissions` (
   `role_id` int(11) NOT NULL DEFAULT '0',
@@ -1071,7 +1071,7 @@ CREATE TABLE `roles_static_permissions` (
   KEY `role_id` (`role_id`) USING BTREE,
   CONSTRAINT `roles_static_permissions_ibfk_1` FOREIGN KEY (`role_id`) REFERENCES `roles` (`id`),
   CONSTRAINT `roles_static_permissions_ibfk_2` FOREIGN KEY (`static_permission_id`) REFERENCES `static_permissions` (`id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `roles_users` (
   `user_id` int(11) NOT NULL DEFAULT '0',
@@ -1083,30 +1083,30 @@ CREATE TABLE `roles_users` (
   KEY `role_id` (`role_id`) USING BTREE,
   CONSTRAINT `roles_users_ibfk_1` FOREIGN KEY (`user_id`) REFERENCES `users` (`id`),
   CONSTRAINT `roles_users_ibfk_2` FOREIGN KEY (`role_id`) REFERENCES `roles` (`id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `schema_migrations` (
   `version` varchar(255) CHARACTER SET utf8 NOT NULL,
   UNIQUE KEY `unique_schema_migrations` (`version`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `sessions` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
-  `session_id` varchar(255) COLLATE utf8_unicode_ci NOT NULL,
-  `data` text COLLATE utf8_unicode_ci,
+  `session_id` varchar(255) CHARACTER SET utf8 COLLATE utf8_unicode_ci NOT NULL,
+  `data` text COLLATE utf8mb4_unicode_ci,
   `created_at` datetime DEFAULT NULL,
   `updated_at` datetime(6) DEFAULT NULL,
   PRIMARY KEY (`id`),
   KEY `index_sessions_on_session_id` (`session_id`) USING BTREE,
   KEY `index_sessions_on_updated_at` (`updated_at`) USING BTREE
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `static_permissions` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `title` varchar(200) CHARACTER SET utf8 NOT NULL DEFAULT '',
   PRIMARY KEY (`id`),
   UNIQUE KEY `static_permissions_title_index` (`title`) USING BTREE
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `status_histories` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
@@ -1116,33 +1116,33 @@ CREATE TABLE `status_histories` (
   PRIMARY KEY (`id`),
   KEY `index_status_histories_on_time_and_key` (`time`,`key`) USING BTREE,
   KEY `index_status_histories_on_key` (`key`) USING BTREE
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `status_messages` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `created_at` datetime DEFAULT NULL,
   `deleted_at` datetime DEFAULT NULL,
-  `message` text CHARACTER SET utf8,
+  `message` text COLLATE utf8mb4_unicode_ci,
   `user_id` int(11) DEFAULT NULL,
   `severity` int(11) DEFAULT NULL,
   PRIMARY KEY (`id`),
   KEY `user` (`user_id`) USING BTREE,
   KEY `index_status_messages_on_deleted_at_and_created_at` (`deleted_at`,`created_at`) USING BTREE
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `tokens` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
-  `string` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
+  `string` varchar(255) CHARACTER SET utf8 COLLATE utf8_unicode_ci DEFAULT NULL,
   `user_id` int(11) NOT NULL,
   `package_id` int(11) DEFAULT NULL,
-  `type` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
+  `type` varchar(255) CHARACTER SET utf8 COLLATE utf8_unicode_ci DEFAULT NULL,
   PRIMARY KEY (`id`),
   UNIQUE KEY `index_tokens_on_string` (`string`) USING BTREE,
   KEY `user_id` (`user_id`) USING BTREE,
   KEY `package_id` (`package_id`) USING BTREE,
   CONSTRAINT `tokens_ibfk_1` FOREIGN KEY (`user_id`) REFERENCES `users` (`id`),
   CONSTRAINT `tokens_ibfk_2` FOREIGN KEY (`package_id`) REFERENCES `packages` (`id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `updateinfo_counters` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
@@ -1152,7 +1152,7 @@ CREATE TABLE `updateinfo_counters` (
   `year` int(11) DEFAULT NULL,
   `counter` int(11) DEFAULT '0',
   PRIMARY KEY (`id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `user_registrations` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
@@ -1164,7 +1164,7 @@ CREATE TABLE `user_registrations` (
   UNIQUE KEY `user_registrations_user_id_index` (`user_id`) USING BTREE,
   KEY `user_registrations_expires_at_index` (`expires_at`) USING BTREE,
   CONSTRAINT `user_registrations_ibfk_1` FOREIGN KEY (`user_id`) REFERENCES `users` (`id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `users` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
@@ -1172,21 +1172,21 @@ CREATE TABLE `users` (
   `updated_at` datetime(6) DEFAULT NULL,
   `last_logged_in_at` datetime DEFAULT NULL,
   `login_failure_count` int(11) NOT NULL DEFAULT '0',
-  `login` text COLLATE utf8_bin,
+  `login` text CHARACTER SET utf8 COLLATE utf8_bin,
   `email` varchar(200) CHARACTER SET utf8 NOT NULL DEFAULT '',
   `realname` varchar(200) CHARACTER SET utf8 NOT NULL DEFAULT '',
-  `password_digest` varchar(255) COLLATE utf8_bin DEFAULT NULL,
-  `deprecated_password` varchar(255) COLLATE utf8_bin DEFAULT NULL,
-  `deprecated_password_hash_type` varchar(255) COLLATE utf8_bin DEFAULT NULL,
-  `deprecated_password_salt` varchar(255) COLLATE utf8_bin DEFAULT NULL,
-  `adminnote` text CHARACTER SET utf8,
-  `state` enum('unconfirmed','confirmed','locked','deleted','subaccount') COLLATE utf8_bin DEFAULT 'unconfirmed',
+  `password_digest` varchar(255) CHARACTER SET utf8 COLLATE utf8_bin DEFAULT NULL,
+  `deprecated_password` varchar(255) CHARACTER SET utf8 COLLATE utf8_bin DEFAULT NULL,
+  `deprecated_password_hash_type` varchar(255) CHARACTER SET utf8 COLLATE utf8_bin DEFAULT NULL,
+  `deprecated_password_salt` varchar(255) CHARACTER SET utf8 COLLATE utf8_bin DEFAULT NULL,
+  `adminnote` text COLLATE utf8mb4_unicode_ci,
+  `state` enum('unconfirmed','confirmed','locked','deleted','subaccount') CHARACTER SET utf8 COLLATE utf8_bin DEFAULT 'unconfirmed',
   `owner_id` int(11) DEFAULT NULL,
   `ignore_auth_services` tinyint(1) DEFAULT '0',
   PRIMARY KEY (`id`),
   UNIQUE KEY `users_login_index` (`login`(255)) USING BTREE,
   KEY `users_password_index` (`deprecated_password`) USING BTREE
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `watched_projects` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
@@ -1195,7 +1195,7 @@ CREATE TABLE `watched_projects` (
   PRIMARY KEY (`id`),
   KEY `watched_projects_users_fk_1` (`user_id`) USING BTREE,
   CONSTRAINT `watched_projects_ibfk_1` FOREIGN KEY (`user_id`) REFERENCES `users` (`id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
 
 INSERT INTO `schema_migrations` (version) VALUES
 ('1'),
@@ -1332,6 +1332,7 @@ INSERT INTO `schema_migrations` (version) VALUES
 ('20180221175514'),
 ('20180307074538'),
 ('20180516074538'),
-('20180523123532');
+('20180523123532'),
+('20180720082742');
 
 

--- a/src/api/script/api_test_in_spec.sh
+++ b/src/api/script/api_test_in_spec.sh
@@ -35,14 +35,14 @@ development:
   host:     localhost
   database: api_25
   username: root
-  encoding: utf8
+  encoding: utf8mb4
   socket:   $MYSQL_SOCKET
 test:
   adapter:  mysql2
   host:     localhost
   database: api_test
   username: root
-  encoding: utf8
+  encoding: utf8mb4
   socket:   $MYSQL_SOCKET
   # disable timeout, required on SLES 11 SP3 at least
   connect_timeout:

--- a/src/api/spec/models/comment_spec.rb
+++ b/src/api/spec/models/comment_spec.rb
@@ -10,6 +10,13 @@ RSpec.describe Comment do
     it { expect(comment_package).to be_valid }
   end
 
+  describe 'save' do
+    it 'stores emoji' do
+      comment_package.body = '😁'
+      comment_package.save
+    end
+  end
+
   describe 'associations' do
     it { is_expected.to belong_to(:commentable) }
     it { is_expected.to belong_to(:user).inverse_of(:comments) }


### PR DESCRIPTION
Allows emojis and fixes #3547

This charset change requires mysql 5.5, which was released 2012
but is still not the default. See more details about the problem
on https://railsmachine.com/articles/2017/05/19/converting-a-rails-database-to-utf8mb4.html

I borrowed the migration from there - but limited it to comments,
the charset is backward compatible, but requires changes to database.yml
in production (to store emojis not to apply the migration)