### PR TITLE
[ci] Force the copying of example config files on dev:prepare

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,7 +44,7 @@ aliases:
 
   - &bootstrap_old_test_suite
     name: Setup application
-    command: cd src/api; bundle exec rake dev:bootstrap[old_test_suite] RAILS_ENV=test
+    command: cd src/api; bundle exec rake dev:bootstrap[old_test_suite] RAILS_ENV=test FORCE_EXAMPLE_FILES=1
 
   # keep the prefix for the following aligned
   - &save_repo_cache_key
@@ -98,7 +98,7 @@ jobs:
       - run: rm -rf src/api/tmp/rubocop*
       - run:
           name: Setup application
-          command: cd src/api; bundle exec rake dev:prepare assets:precompile RAILS_ENV=test
+          command: cd src/api; bundle exec rake dev:prepare assets:precompile RAILS_ENV=test FORCE_EXAMPLE_FILES=1
       - save_cache:
           <<: *save_repo_cache_key
           paths:

--- a/src/api/lib/tasks/dev.rake
+++ b/src/api/lib/tasks/dev.rake
@@ -207,7 +207,7 @@ namespace :dev do
 end
 
 def copy_example_file(example_file)
-  if File.exist?(example_file)
+  if File.exist?(example_file) && !ENV['FORCE_EXAMPLE_FILES']
     example_file = File.join(File.expand_path(File.dirname(__FILE__) + '/../..'), example_file)
     puts "WARNING: You already have the config file #{example_file}, make sure it works with docker"
   else


### PR DESCRIPTION
circleci has the repo in cache and if we change the example
files, they should be used - not the cached ones