### PR TITLE
[frontend] Make baseclass of Factory controllers explicit

### DIFF
--- a/src/api/app/controllers/webui/obs_factory/distributions_controller.rb
+++ b/src/api/app/controllers/webui/obs_factory/distributions_controller.rb
@@ -1,5 +1,5 @@
 module Webui::ObsFactory
-  class DistributionsController < ApplicationController
+  class DistributionsController < Webui::ObsFactory::ApplicationController
     respond_to :html
 
     before_action :require_distribution, :require_dashboard

--- a/src/api/app/controllers/webui/obs_factory/staging_projects_controller.rb
+++ b/src/api/app/controllers/webui/obs_factory/staging_projects_controller.rb
@@ -1,5 +1,5 @@
 module Webui::ObsFactory
-  class StagingProjectsController < ApplicationController
+  class StagingProjectsController < Webui::ObsFactory::ApplicationController
     respond_to :json, :html
 
     before_action :require_distribution


### PR DESCRIPTION
In test environment we don't eagerly load all classes,
so ruby does not know there is a 2nd ApplicationController
class in the module - and takes the one from API.

But this one (for one) requires login - which we don't
want for Staging dashboard.

Fixes #5431
:crossed_fingers: 