### PR TITLE
[ci] Don't reseed the database on every test start

### DIFF
--- a/src/api/spec/support/database_cleaner.rb
+++ b/src/api/spec/support/database_cleaner.rb
@@ -9,13 +9,6 @@ RSpec.configure do |config|
   config.use_transactional_fixtures = false
 
   config.before(:suite) do
-    # Before the test suites runs make sure the database is empty
-    log_level = Rails.logger.level
-    Rails.logger.level = :fatal
-    DatabaseCleaner.clean_with(:truncation)
-    # and is seeded
-    load "#{Rails.root}/db/seeds.rb"
-    Rails.logger.level = log_level
     # Truncate all tables loaded in db/seeds.rb, except the static ones, in the
     # beginning to be consistent.
     DatabaseCleaner.clean_with(:truncation, except: STATIC_TABLES)


### PR DESCRIPTION
As followup on #5327 - reseeding the database on every
test run is super conservative and steals a lot of developer
time for the sake of being safe on very rare test crashes

Truncating the static tables is good enough for normal test
crashes. The model tests run in transactions, so don't
interfere with the database - but are the ones most likely
to break.

And in case the database is busted, recreating it is just
as fast/slow as what we basically did before every test
run.

The reseeding takes on my system ~10 seconds - and according
to dmarcoux's comment in 5327 on his it's a minute. So drop it