### PR TITLE
Fix wrong variable names used in staging dashboard

### DIFF
--- a/src/api/app/controllers/webui/obs_factory/staging_projects_controller.rb
+++ b/src/api/app/controllers/webui/obs_factory/staging_projects_controller.rb
@@ -24,12 +24,12 @@ module Webui::ObsFactory
             @backlog_requests_ignored = @backlog_requests.select { |req| @ignored_requests.key?(req.number) }
             @backlog_requests = @backlog_requests.select { |req| !@ignored_requests.key?(req.number) }
             @requests_state_new = @requests_state_new.select { |req| !@ignored_requests.key?(req.number) }
-            @backlog_requests_ignored.sort! { |x,y| x.package <=> y.package }
+            @backlog_requests_ignored.sort! { |x,y| x.first_target_package <=> y.first_target_package }
           else
             @backlog_requests_ignored = []
           end
-          @backlog_requests.sort! { |x,y| x.package <=> y.package }
-          @requests_state_new.sort! { |x,y| x.package <=> y.package }
+          @backlog_requests.sort! { |x,y| x.first_target_package <=> y.first_target_package }
+          @requests_state_new.sort! { |x,y| x.first_target_package <=> y.first_target_package }
           # For the breadcrumbs
           @project = @distribution.project
         end

--- a/src/api/app/views/webui/obs_factory/staging_projects/_infos.html.haml
+++ b/src/api/app/views/webui/obs_factory/staging_projects/_infos.html.haml
@@ -19,7 +19,7 @@
     %ul.staging_backlog
       - @backlog_requests.each_with_index do |req,counter|
         %li
-          = link_to elide(req.package, length = 19), main_app.request_show_path(req.number)
+          = link_to elide(req.first_target_package, length = 19), main_app.request_show_path(req.number)
         - if counter > 5 && @backlog_requests.size > counter + 1
           %li ... #{@backlog_requests.size - counter} more
           - break
@@ -32,7 +32,7 @@
     %ul.staging_backlog
       - @requests_state_new.each_with_index do |req,counter|
         %li
-          = link_to elide(req.package, length = 19), main_app.request_show_path(req.number)
+          = link_to elide(req.first_target_package, length = 19), main_app.request_show_path(req.number)
         - if counter > 5 && @requests_state_new.size > counter + 1
           %li ... #{@requests_state_new.size - counter} more
           - break
@@ -42,7 +42,7 @@
     %ul.staging_backlog_ignored
       - @backlog_requests_ignored.each_with_index do |req,counter|
         %li
-          = link_to elide(req.package, length = 19), main_app.request_show_path(req.number), title: @ignored_requests[req.number]
+          = link_to elide(req.first_target_package, length = 19), main_app.request_show_path(req.number), title: @ignored_requests[req.number]
         - if counter > 5 && @backlog_requests_ignored.size > counter + 1
           %li ... #{@backlog_requests_ignored.size - counter} more
           - break


### PR DESCRIPTION
Commit 515fafba5d0055058b406ff8e00c24e8cec3975f was merging the obs
factory request model into the bs request model. This required some
variable renaming.
Since package and project are very common in OBS some variables got
overlooked and caused breakage.