### PR TITLE
Fix backend/file_spec with global_write_through

### DIFF
--- a/src/api/spec/models/backend/file_spec.rb
+++ b/src/api/spec/models/backend/file_spec.rb
@@ -200,6 +200,7 @@ RSpec.describe Backend::File, vcr: true do
   describe '#save' do
     context 'with a backend error' do
       before do
+        somefile_txt_url # create the package before we break put
         allow(Backend::Connection).to receive(:put).and_raise(StandardError, 'message')
       end
 


### PR DESCRIPTION
Creating the package and file needs put, so instanciate
it in the backend before breaking/stubing put

#global_write_through_must_die