### PR TITLE
Use BsRequest instead of Request

### DIFF
--- a/src/api/app/views/webui/obs_factory/requests/_request.html.erb
+++ b/src/api/app/views/webui/obs_factory/requests/_request.html.erb
@@ -1,1 +1,1 @@
-<%= link_to "##{request.number} (#{request.state})", main_app.request_show_url(request.bs_request) %>
+<%= link_to "##{request.number} (#{request.state})", main_app.request_show_url(request) %>


### PR DESCRIPTION
Recently we integrate `Request` model into `BsRequest`, so now we use
`BsRequest` instead of `Request`.