### PR TITLE
[webui] Fix wrong openqa_iso_prefix for Leap 15

### DIFF
--- a/src/api/app/models/obs_factory/distribution_strategy_opensuse_leap15.rb
+++ b/src/api/app/models/obs_factory/distribution_strategy_opensuse_leap15.rb
@@ -24,7 +24,7 @@ module ObsFactory
     end
 
     def openqa_iso_prefix
-      "openSUSE-Leap-#{opensuse_leap_version}-Staging"
+      "openSUSE-Leap:#{opensuse_leap_version}-Staging"
     end
 
     def published_arch

--- a/src/api/spec/models/obs_factory/distribution_strategy_opensuse_leap15_spec.rb
+++ b/src/api/spec/models/obs_factory/distribution_strategy_opensuse_leap15_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe ObsFactory::DistributionStrategyOpenSUSELeap15 do
   end
 
   describe '#openqa_iso_prefix' do
-    it { expect(strategy.openqa_iso_prefix).to eq('openSUSE-Leap-15.1-Staging') }
+    it { expect(strategy.openqa_iso_prefix).to eq('openSUSE-Leap:15.1-Staging') }
   end
 
   describe '#published_arch' do


### PR DESCRIPTION
Leap's iso has a prefix openSUSE-Leap:15.1-Staging on openQA, da8aa358 changed it to the wrong path, therefore Leap Staging Dashboard unable to find relevant openQA jobs result.