### PR TITLE
Add separator between personal navigation items

### DIFF
--- a/src/api/app/assets/stylesheets/webui2/main.scss
+++ b/src/api/app/assets/stylesheets/webui2/main.scss
@@ -1,0 +1,9 @@
+#personal-navigation ul.nav >li.nav-item > a {
+  padding-left: 0;
+  padding-right: 0;
+}
+
+#personal-navigation ul.nav > li.nav-item:not(:last-child) > a::after {
+  color: initial;
+  content: "|";
+}

--- a/src/api/app/assets/stylesheets/webui2/webui2.css.scss
+++ b/src/api/app/assets/stylesheets/webui2/webui2.css.scss
@@ -21,4 +21,5 @@ $gray-200: #e9ecef;
 @import "font-awesome-sprockets";
 @import 'font-awesome';
 @import 'bootstrap';
+@import 'main';
 @import 'sticky-footer';


### PR DESCRIPTION
I had a flash after the stand-up when we talked about this issue.

I don't consider this done as this needs to be fixed:
- [x] Separators are in the default text color (so they aren't like the links they separate)
- [ ] The padding between separators and links has to be consistent

I open this PR to get your suggestions on how to fix these remaining issues