### PR TITLE
[dist] fix osc checks for upload docker images

### DIFF
--- a/dist/t/osc/0200-check_docker_registry.ts
+++ b/dist/t/osc/0200-check_docker_registry.ts
@@ -62,8 +62,9 @@ SKIP: {
     last if $timeout < 1;
     sleep 1;
   }
+  my $expected = qr{basecontainer/images/(?:x86_64/)?opensuse};
 
-  is($repo, "basecontainer/images/opensuse", "Found repository 'basecontainer/images/opensuse' in registry");
+  like($repo, $expected, "Checking upload to registry");
 }
 
 exit 0;


### PR DESCRIPTION
Whithout this patch, integration tests in 2.9 fail, because the old repo schema in 2.9 included the architecture, which is obsolete with "fat manifests"

This patch ensures that both repos

basecontainer/images/opensuse
basecontainer/images/x86_64/opensuse

are accepted in the test case