### PR TITLE
Stub download.opensuse.org and gravatar.com globally

### DIFF
--- a/src/api/spec/support/vcr.rb
+++ b/src/api/spec/support/vcr.rb
@@ -1,4 +1,5 @@
 require 'vcr'
+require 'webmock/rspec'
 
 VCR.configure do |config|
   config.cassette_library_dir = 'spec/cassettes'
@@ -6,6 +7,7 @@ VCR.configure do |config|
   config.default_cassette_options = { record: :once }
   config.allow_http_connections_when_no_cassette = true
   config.configure_rspec_metadata!
+  # config.debug_logger = File.open(Rails.root.join('log', 'vcr.log'), 'w')
 
   config.preserve_exact_body_bytes do |http_message|
     !http_message.body.valid_encoding?
@@ -13,7 +15,6 @@ VCR.configure do |config|
 
   # ignore selenium requests
   config.ignore_localhost = true
-  config.ignore_hosts 'www.gravatar.com' # Ignore gravatar calls
   config.ignore_hosts 'selenium'
 end
 
@@ -21,6 +22,8 @@ RSpec.configure do |config|
   # Usually we use VCR to mock the backend responses. If you want to refresh casettes
   # or record new ones you can enable writing to the backend here.
   config.before do
+    stub_request(:get, %r{download.opensuse.org}).to_return(status: [500, 'Internal Server Error'])
+    stub_request(:get, %r{www.gravatar.com}).to_return(body: File.new(Rails.root.join('app', 'assets', 'images', 'default_face.png')))
     # CONFIG['global_write_through'] = true
   end
   # You can also limit this to the type of test with


### PR DESCRIPTION
We had repeatedly the case that the packages don't build in
OBS due to tests accessing download.opensuse.org

So make download.opensuse.org unavailable by default - unless
the test stubs a more specific URL

WDYT?