### PR TITLE
Fix rendering requests partial on staging board

### DIFF
--- a/src/api/app/views/webui/obs_factory/requests/_request.html.erb
+++ b/src/api/app/views/webui/obs_factory/requests/_request.html.erb
@@ -1,1 +1,1 @@
-<%= link_to "##{request.number} (#{request.state})", request_show_url(request) %>
+<%= link_to "##{request.number} (#{request.state})", request_show_url(request.number) %>


### PR DESCRIPTION
The request_show_url helper requires a request number as parameter.
Otherwise it fails with an ActionView::Template::Error error:

  "undefined method `empty?' for 1:Integer"

This broke with ccaaef52ec15892fc26914030a62462d632f9800