### PR TITLE
Convert nil to string for links in datatable

### DIFF
--- a/src/api/app/helpers/webui/webui_helper.rb
+++ b/src/api/app/helpers/webui/webui_helper.rb
@@ -148,9 +148,9 @@ module Webui::WebuiHelper
 
   def elide_two(text1, text2, overall_length = 40, mode = :middle)
     half_length = overall_length / 2
-    text1_free = half_length - text1.length
+    text1_free = half_length - text1.to_s.length
     text1_free = 0 if text1_free < 0
-    text2_free = half_length - text2.length
+    text2_free = half_length - text2.to_s.length
     text2_free = 0 if text2_free < 0
     [elide(text1, half_length + text2_free, mode), elide(text2, half_length + text1_free, mode)]
   end


### PR DESCRIPTION
Because in bs_request_actions_delete `source_project` should be `nil'
and the `length` of `nil` raise an exception.

Fix #5472