### PR TITLE
Split rspec test suite into its own spec file

### DIFF
--- a/dist/obs-api-testsuite-rspec.spec
+++ b/dist/obs-api-testsuite-rspec.spec
@@ -29,7 +29,12 @@ BuildRequires:  obs-api-testsuite-deps
 BuildRequires:  chromedriver
 BuildRequires:  xorg-x11-fonts
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build
+%if 0%{?disable_obs_frontend_test_suite} || 0%{?disable_obs_test_suite}
+ExclusiveArch:  nothere
+%else
 ExclusiveArch:  x86_64
+%endif
+
 
 %description
 Running the RSpec test suite of the OBS frontend independently
@@ -63,6 +68,7 @@ bin/rspec -f d
 
 %install
 
+# no result
 %files
 
 %changelog

--- a/dist/obs-api-testsuite-rspec.spec
+++ b/dist/obs-api-testsuite-rspec.spec
@@ -1,0 +1,81 @@
+#
+# spec file for package obs-api-testsuite-rspec
+#
+# Copyright (c) 2018 SUSE LINUX GmbH, Nuernberg, Germany.
+#
+# All modifications and additions to the file contributed by third parties
+# remain the property of their copyright owners, unless otherwise agreed
+# upon. The license for this file, and modifications and additions to the
+# file, is the same license as for the pristine package itself (unless the
+# license for the pristine package is not an Open Source License, in which
+# case the license is the MIT License). An "Open Source License" is a
+# license that conforms to the Open Source Definition (Version 1.9)
+# published by the Open Source Initiative.
+
+# Please submit bugfixes or comments via http://bugs.opensuse.org/
+#
+
+
+Name:           obs-api-testsuite-rspec
+Version:        2.10~alpha.20180726T073243.bd007edee
+Release:        0
+Summary:        The Open Build Service -- RSpec test suite
+License:        GPL-2.0-only
+Group:          Productivity/Networking/Web/Utilities
+Url:            http://www.openbuildservice.org
+Source0:        open-build-service-%version.tar.xz
+# rspec specific dependencies
+BuildRequires:  chromedriver
+BuildRequires:  xorg-x11-fonts
+
+# shared dependencies
+BuildRequires:  perl(GD)
+BuildRequires:  rubygem(ruby:2.5.0:bundler)
+# TODO: move to bundled gems
+BuildRequires:  build >= 20170315
+BuildRequires:  inst-source-utils
+BuildRequires:  memcached >= 1.4
+BuildRequires:  mysql
+BuildRequires:  nodejs
+BuildRequires:  obs-bundled-gems
+BuildRequires:  sphinx >= 2.1.8
+BuildRequires:  rubygem(ruby:2.5.0:rake:12.3.1)
+
+BuildRoot:      %{_tmppath}/%{name}-%{version}-build
+ExclusiveArch:  x86_64
+
+%description
+Running the RSpec test suite of the OBS frontend independently
+of packaging the application
+
+%prep
+%setup -q -n open-build-service-%{version}
+
+%build
+# run in build environment
+pushd src/backend/
+rm -rf build
+ln -sf /usr/lib/build build
+popd
+
+pushd src/api
+# configure to the bundled gems
+bundle --local --path %_libdir/obs-api/
+
+./script/prepare_spec_tests.sh
+
+# map to casssettes
+perl -pi -e 's/source_host: localhost/source_host: backend/' config/options.yml
+perl -pi -e 's/source_port: 3200/source_port: 5352/' config/options.yml
+
+export RAILS_ENV=test
+bin/rake db:create db:setup
+bin/rails assets:precompile
+
+bin/rspec -f d
+
+%install
+
+%files
+
+%changelog

--- a/dist/obs-api-testsuite-rspec.spec
+++ b/dist/obs-api-testsuite-rspec.spec
@@ -17,30 +17,17 @@
 
 
 Name:           obs-api-testsuite-rspec
-Version:        2.10~alpha.20180726T073243.bd007edee
+Version:        2.10~pre
 Release:        0
 Summary:        The Open Build Service -- RSpec test suite
 License:        GPL-2.0-only
 Group:          Productivity/Networking/Web/Utilities
 Url:            http://www.openbuildservice.org
 Source0:        open-build-service-%version.tar.xz
+BuildRequires:  obs-api-testsuite-deps
 # rspec specific dependencies
 BuildRequires:  chromedriver
 BuildRequires:  xorg-x11-fonts
-
-# shared dependencies
-BuildRequires:  perl(GD)
-BuildRequires:  rubygem(ruby:2.5.0:bundler)
-# TODO: move to bundled gems
-BuildRequires:  build >= 20170315
-BuildRequires:  inst-source-utils
-BuildRequires:  memcached >= 1.4
-BuildRequires:  mysql
-BuildRequires:  nodejs
-BuildRequires:  obs-bundled-gems
-BuildRequires:  sphinx >= 2.1.8
-BuildRequires:  rubygem(ruby:2.5.0:rake:12.3.1)
-
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build
 ExclusiveArch:  x86_64
 

--- a/dist/obs-bundled-gems.spec
+++ b/dist/obs-bundled-gems.spec
@@ -43,13 +43,53 @@ BuildRequires:  openldap2-devel
 BuildRequires:  python-devel
 BuildRequires:  ruby2.5-devel
 BuildRequires:  rubygem(ruby:2.5.0:bundler)
+
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build
 
 %description
 This package bundles all the gems required by the Open Build Service
 to make it easier to deploy the obs-server package.
 
+%define rake_version 12.3.1
+
+%package -n obs-api-deps
+Summary:        Holding dependencies required to run the OBS frontend
+Group:          Productivity/Networking/Web/Utilities
+Requires:       build >= 20170315
+Requires:       memcached >= 1.4
+Requires:       mysql
+Requires:       obs-bundled-gems = %{version}
+Requires:       sphinx >= 2.1.8
+Requires:       perl(GD)
+Requires:       rubygem(ruby:2.5.0:bundler)
+Requires:       rubygem(ruby:2.5.0:rake:%{rake_version})
+
+%description -n obs-api-deps
+To simplify splitting the test suite packages off the main package,
+this package is just a meta package used to run and build obs-api
+
+%files -n obs-api-deps
+%doc README
+
+%package -n obs-api-testsuite-deps
+Summary:        Holding dependencies required to run frontend test suites
+Group:          Productivity/Networking/Web/Utilities
+Requires:       inst-source-utils
+Requires:       nodejs
+Requires:       obs-api-deps = %{version}
+
+%description -n obs-api-testsuite-deps
+To simplify splitting the test suite packages off the main package,
+this package is just a meta package used to build obs-api testsuite
+
+%files -n obs-api-testsuite-deps
+%doc README
+
 %prep
+echo > README <<EOF
+This package is just a meta package containing requires
+EOF
+
 cp %{S:0} %{S:1} .
 
 %build
@@ -60,32 +100,35 @@ export GEM_HOME=~/.gems
 bundle config build.nokogiri --use-system-libraries
 
 %install
-bundle --local --path %{buildroot}/%_libdir/obs-api/
+bundle --local --path %{buildroot}%_libdir/obs-api/
+
+# test that the rake_version macro is still matching our Gemfile
+test -f %{buildroot}%_libdir/obs-api/ruby/2.5.0/gems/rake-%{rake_version}/rake.gemspec
 
 # run gem clean up script
-/usr/lib/rpm/gem_build_cleanup.sh %{buildroot}/%_libdir/obs-api/ruby/*/
+/usr/lib/rpm/gem_build_cleanup.sh %{buildroot}%_libdir/obs-api/ruby/*/
 
 # Remove sources of extensions, we don't need them
-rm -rf %{buildroot}/%_libdir/obs-api/ruby/*/gems/*/ext/
+rm -rf %{buildroot}%_libdir/obs-api/ruby/*/gems/*/ext/
 
 # remove binaries with invalid interpreters
 rm -rf %{buildroot}%_libdir/obs-api/ruby/*/gems/diff-lcs-*/bin
 
 # remove spec / test files from gems as they shouldn't be shipped in gems anyway
 # and often cause errors / warning in rpmlint
-rm -rf %{buildroot}/%_libdir/obs-api/ruby/*/gems/*/spec/
-rm -rf %{buildroot}/%_libdir/obs-api/ruby/*/gems/*/test/
+rm -rf %{buildroot}%_libdir/obs-api/ruby/*/gems/*/spec/
+rm -rf %{buildroot}%_libdir/obs-api/ruby/*/gems/*/test/
 # we do not verify signing of the gem
-rm -rf %{buildroot}/%_libdir/obs-api/ruby/*/gems/mousetrap-rails-*/gem-public_cert.pem
+rm -rf %{buildroot}%_libdir/obs-api/ruby/*/gems/mousetrap-rails-*/gem-public_cert.pem
 
 # remove prebuilt binaries causing broken dependencies
-rm -rf %{buildroot}/%_libdir/obs-api/ruby/*/gems/selenium-webdriver-*/lib/selenium/webdriver/firefox/native
+rm -rf %{buildroot}%_libdir/obs-api/ruby/*/gems/selenium-webdriver-*/lib/selenium/webdriver/firefox/native
 
 # remove all gitignore files to fix rpmlint version-control-internal-file
-find %{buildroot}/%_libdir/obs-api -name .gitignore | xargs rm -rf
+find %{buildroot}%_libdir/obs-api -name .gitignore | xargs rm -rf
 
 # fix interpreter in installed binaries
-for bin in %{buildroot}/%_libdir/obs-api/ruby/*/bin/*; do
+for bin in %{buildroot}%_libdir/obs-api/ruby/*/bin/*; do
   sed -i -e 's,/usr/bin/env ruby.ruby2.5,/usr/bin/ruby.ruby2.5,' $bin
 done
 

--- a/dist/obs-server.spec
+++ b/dist/obs-server.spec
@@ -32,8 +32,6 @@
 
 %define secret_key_file /srv/www/obs/api/config/secret.key
 
-%define rake_version 12.3.1
-
 %if ! %{defined _fillupdir}
   %define _fillupdir %{_localstatedir}/adm/fillup-templates
 %endif
@@ -68,8 +66,7 @@ BuildRequires:  python-devel
 # config/environment.rb of the various applications.
 # atm the obs rails version patch above unifies that setting among the applications
 # also see requires in the obs-server-api sub package
-BuildRequires:  build >= 20170315
-BuildRequires:  inst-source-utils
+BuildRequires:  /usr/bin/xmllint
 BuildRequires:  openssl
 BuildRequires:  perl-BSSolv >= 0.28
 BuildRequires:  perl-Compress-Zlib
@@ -82,7 +79,7 @@ BuildRequires:  perl-TimeDate
 BuildRequires:  perl-XML-Parser
 BuildRequires:  perl-XML-Simple
 BuildRequires:  procps
-BuildRequires:  timezone /usr/bin/xmllint
+BuildRequires:  timezone
 BuildRequires:  perl(Devel::Cover)
 BuildRequires:  perl(Test::Simple) > 1
 PreReq:         /usr/sbin/useradd /usr/sbin/groupadd
@@ -204,37 +201,18 @@ Requires:       apache2
 Requires:       apache2-mod_xforward
 Requires:       ruby2.5-rubygem-passenger
 Requires:       rubygem-passenger-apache2
-
-# memcache is required for session data
-Requires:       memcached
 Conflicts:      memcached < 1.4
 
-Requires:       mysql
-
 Requires:       ruby(abi) = 2.5.0
-# needed for fulltext searching
-Requires:       sphinx >= 2.1.8
-BuildRequires:  sphinx >= 2.1.8
 # for test suite:
 BuildRequires:  createrepo
 BuildRequires:  curl
-BuildRequires:  memcached >= 1.4
-BuildRequires:  mysql
 BuildRequires:  netcfg
 # write down dependencies for production
-BuildRequires:  obs-bundled-gems
-BuildRequires:  rubygem(ruby:2.5.0:bundler)
-Requires:       rubygem(ruby:2.5.0:bundler)
-# for compiling assets
-BuildRequires:  nodejs
-Requires:       obs-bundled-gems = %{version}
-BuildRequires:  rubygem(ruby:2.5.0:rake:%{rake_version})
-Requires:       rubygem(ruby:2.5.0:rake:%{rake_version})
-# for rebuild_time
-BuildRequires:  perl(GD)
-Requires:       perl(GD)
-
+BuildRequires:  obs-api-testsuite-deps
 Requires:       ghostscript-fonts-std
+Requires:       obs-api-deps = %{version}
+Requires:       obs-bundled-gems = %{version}
 
 %description -n obs-api
 This is the API server instance, and the web client for the
@@ -281,9 +259,6 @@ This package contains all the necessary tools for upload images to the cloud.
 #--------------------------------------------------------------------------------
 %prep
 %setup -q -n open-build-service-%version
-
-# test that the rake_version macro is still matching our Gemfile
-test -f %_libdir/obs-api/ruby/2.5.0/gems/rake-%{rake_version}/rake.gemspec
 
 # We don't need our docker files in our packages
 rm -r src/{api,backend}/docker-files

--- a/dist/obs-server.spec
+++ b/dist/obs-server.spec
@@ -114,12 +114,6 @@ BuildRequires:  fdupes
 PreReq:         %insserv_prereq permissions pwdutils
 %endif
 
-%if 0%{?disable_obs_frontend_test_suite:1} < 1 && 0%{?disable_obs_test_suite} < 1
-# Required by the test suite
-BuildRequires:  chromedriver
-BuildRequires:  xorg-x11-fonts
-%endif
-
 %if 0%{?suse_version:1}
 Recommends:     yum yum-metadata-parser repoview dpkg
 Recommends:     deb >= 1.5

--- a/src/api/Makefile
+++ b/src/api/Makefile
@@ -64,7 +64,9 @@ build: config
 test_unit:
 	[ -d log ] || mkdir log
 	echo > log/test.log
-	./script/api_test_in_spec.sh
+	sh -x ./script/prepare_spec_tests.sh
+	sh -x ./script/api_minitest.sh
+	# rspec runs independently
 clean:
 	rm -rf ../../docs/api/html
 

--- a/src/api/script/api_minitest.sh
+++ b/src/api/script/api_minitest.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+set -e
+
+source ./mysql_environment
+
+# migration test
+export RAILS_ENV=development
+bin/rake db:create || exit 1
+mv db/structure.sql db/structure.sql.git
+xzcat test/dump_2.5.sql.xz | mysql  -u root --socket=$MYSQL_SOCKET
+bin/rake db:migrate:with_data db:structure:dump db:drop
+./script/compare_structure_sql.sh db/structure.sql.git db/structure.sql
+
+# entire test suite
+export RAILS_ENV=test
+bin/rake db:create db:setup
+
+bin/rails assets:precompile
+
+perl -pi -e 's/source_host: backend/source_host: localhost/' config/options.yml
+perl -pi -e 's/source_port: 5352/source_port: 3200/' config/options.yml
+
+rm -f log/test.log
+bin/rake test:api test:spider
+
+#cleanup
+/usr/bin/mysqladmin -u root --socket=$MYSQL_SOCKET shutdown || true
+rm -rf $MYSQL_DATADIR $MYSQL_SOCKET_DIR
+
+exit 0

--- a/src/api/script/prepare_spec_tests.sh
+++ b/src/api/script/prepare_spec_tests.sh
@@ -49,36 +49,7 @@ test:
 
 EOF
 
-# migration test
-export RAILS_ENV=development
-bin/rake db:create || exit 1
-mv db/structure.sql db/structure.sql.git
-xzcat test/dump_2.5.sql.xz | mysql  -u root --socket=$MYSQL_SOCKET || exit 1
-bin/rake db:migrate:with_data db:structure:dump db:drop || exit 1
-./script/compare_structure_sql.sh db/structure.sql.git db/structure.sql || exit 1
+echo "MYSQL_BASEDIR=$MYSQL_BASEDIR" > mysql_environment
+echo "MYSQL_SOCKET_DIR=$MYSQL_SOCKET_DIR" >> mysql_environment
+echo "MYSQL_SOCKET=$MYSQL_SOCKET" >> mysql_environment
 
-# entire test suite
-export RAILS_ENV=test
-bin/rake db:create db:setup || exit 1
-
-bin/rails assets:precompile
-
-for suite in "rake test:api" "rake test:spider" "rspec"; do
-  rm -f log/test.log
-
-  # Configure the frontend<->backend connection settings
-  if [ "$suite" = "rspec" ]; then
-    perl -pi -e 's/source_host: localhost/source_host: backend/' config/options.yml
-    perl -pi -e 's/source_port: 3200/source_port: 5352/' config/options.yml
-  else
-    perl -pi -e 's/source_host: backend/source_host: localhost/' config/options.yml
-    perl -pi -e 's/source_port: 5352/source_port: 3200/' config/options.yml
-  fi
-  bin/$suite
-done
-
-#cleanup
-/usr/bin/mysqladmin -u root --socket=$MYSQL_SOCKET shutdown || true
-rm -rf $MYSQL_DATADIR $MYSQL_SOCKET_DIR
-
-exit 0


### PR DESCRIPTION
This allows to accelerate the build time and build disable
the rspec test suite on platforms where we don't want to run
them instead of hiding this in prj config