### PR TITLE
Run the proper clockworkd binstub

### DIFF
--- a/dist/obs-bundled-gems.spec
+++ b/dist/obs-bundled-gems.spec
@@ -68,8 +68,9 @@ bundle --local --path %{buildroot}/%_libdir/obs-api/
 # Remove sources of extensions, we don't need them
 rm -rf %{buildroot}/%_libdir/obs-api/ruby/*/gems/*/ext/
 
-# remove bins - the uninstalled # ones contain invalid interpreters
-rm -rf %{buildroot}/%_libdir/obs-api/ruby/*/gems/*/bin
+# remove binaries with invalid interpreters
+rm -rf %{buildroot}%_libdir/obs-api/ruby/*/gems/diff-lcs-*/bin
+
 # remove spec / test files from gems as they shouldn't be shipped in gems anyway
 # and often cause errors / warning in rpmlint
 rm -rf %{buildroot}/%_libdir/obs-api/ruby/*/gems/*/spec/

--- a/dist/obsapidelayed
+++ b/dist/obsapidelayed
@@ -38,7 +38,7 @@
 . /etc/rc.status
 
 API_ROOT=/srv/www/obs/api
-CLOCKWORKD=/usr/lib64/obs-api/bin/clockworkd
+CLOCKWORKD=/usr/lib64/obs-api/ruby/2.5.0/bin/clockworkd
 
 # If you are using newrelic_rpm you need this
 # to fix detection of our delay_job.api daemons


### PR DESCRIPTION
Removing the uninstalled bins was a little too eager,
the clockword binstub calls the other one as daemon,
so just don't remove any

Fixes #5489