### PR TITLE
Fix search box in the main navigation bar

### DIFF
--- a/src/api/app/views/layouts/webui2/_search.html.haml
+++ b/src/api/app/views/layouts/webui2/_search.html.haml
@@ -1,2 +1,2 @@
 = form_tag(search_path(project: 1, package: 1, name: 1), { id: 'global-search-form', class: 'form-inline' }) do
-  %input.form-control.mr-sm-2{"aria-label": "Search", placeholder: "Search", type: "text"}/
+  %input.form-control.mr-sm-2{"aria-label": "Search", name: 'search_text', placeholder: "Search", type: "text"}/


### PR DESCRIPTION
Related to the new framework.

Entering some text in the search box in the main navigation bar and pressing enter din't pass the `search_text` parameter to the search page, an resulted in a search with an empty string.