### PR TITLE
Solve Security/YAMLLoad cop

### DIFF
--- a/src/api/.rubocop_todo.yml
+++ b/src/api/.rubocop_todo.yml
@@ -750,12 +750,6 @@ Security/Open:
   Exclude:
     - 'app/models/obs_factory/distribution_strategy_factory.rb'
 
-# Offense count: 1
-# Cop supports --auto-correct.
-Security/YAMLLoad:
-  Exclude:
-    - 'app/controllers/webui/obs_factory/staging_projects_controller.rb'
-
 # Offense count: 29
 # Configuration parameters: EnforcedStyle.
 # SupportedStyles: inline, group

--- a/src/api/app/controllers/webui/obs_factory/staging_projects_controller.rb
+++ b/src/api/app/controllers/webui/obs_factory/staging_projects_controller.rb
@@ -17,7 +17,7 @@ module Webui::ObsFactory
 
           if dashboard_package && dashboard_package.file_exists?('ignored_requests')
             file = ::Backend::Api::Sources::Package.file(staging_project.name, dashboard_package.name, 'ignored_requests')
-            @ignored_requests = YAML.load(file)
+            @ignored_requests = YAML.safe_load(file)
           end
 
           if @ignored_requests


### PR DESCRIPTION
Prefer using YAML.safe_load over YAML.load.
This restricts the kind of objects that will be deserialized by YAML.load
and avoid exploits.

https://ruby-doc.org/stdlib-2.3.3/libdoc/yaml/rdoc/YAML.html#module-YAML-label-Security
http://www.benjaminfleischer.com/2013/03/20/yaml-and-security-in-ruby/