### PR TITLE
Merge test preparation for show and index action

### DIFF
--- a/src/api/spec/cassettes/Webui_ObsFactory_StagingProjectsController/GET_index/requesting_json/1_1_3_1.yml
+++ b/src/api/spec/cassettes/Webui_ObsFactory_StagingProjectsController/GET_index/requesting_json/1_1_3_1.yml
@@ -2,51 +2,12 @@
 http_interactions:
 - request:
     method: put
-    uri: http://backend:5352/source/openSUSE:Factory:Staging:A/_meta?user=_nobody_
-    body:
-      encoding: UTF-8
-      string: |
-        <project name="openSUSE:Factory:Staging:A">
-          <title>Brandy of the Damned</title>
-          <description>Factory staging project A</description>
-        </project>
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '148'
-    body:
-      encoding: UTF-8
-      string: |
-        <project name="openSUSE:Factory:Staging:A">
-          <title>Brandy of the Damned</title>
-          <description>Factory staging project A</description>
-        </project>
-    http_version: 
-  recorded_at: Mon, 30 Jul 2018 09:08:54 GMT
-- request:
-    method: put
     uri: http://backend:5352/source/openSUSE:Factory:Staging/_meta?user=_nobody_
     body:
       encoding: UTF-8
       string: |
         <project name="openSUSE:Factory:Staging">
-          <title>Beneath the Bleeding</title>
+          <title>A Many-Splendoured Thing</title>
           <description/>
         </project>
     headers:
@@ -68,55 +29,16 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '121'
+      - '125'
     body:
       encoding: UTF-8
       string: |
         <project name="openSUSE:Factory:Staging">
-          <title>Beneath the Bleeding</title>
+          <title>A Many-Splendoured Thing</title>
           <description></description>
         </project>
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 09:08:54 GMT
-- request:
-    method: put
-    uri: http://backend:5352/source/openSUSE:Factory:Staging:B/_meta?user=_nobody_
-    body:
-      encoding: UTF-8
-      string: |
-        <project name="openSUSE:Factory:Staging:B">
-          <title>I Sing the Body Electric</title>
-          <description/>
-        </project>
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '127'
-    body:
-      encoding: UTF-8
-      string: |
-        <project name="openSUSE:Factory:Staging:B">
-          <title>I Sing the Body Electric</title>
-          <description></description>
-        </project>
-    http_version: 
-  recorded_at: Mon, 30 Jul 2018 09:08:54 GMT
+  recorded_at: Mon, 30 Jul 2018 19:12:01 GMT
 - request:
     method: put
     uri: http://backend:5352/source/openSUSE:Factory/_meta?user=_nobody_
@@ -124,7 +46,7 @@ http_interactions:
       encoding: UTF-8
       string: |
         <project name="openSUSE:Factory">
-          <title>Death Be Not Proud</title>
+          <title>Time To Murder And Create</title>
           <description/>
         </project>
     headers:
@@ -146,16 +68,334 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '111'
+      - '118'
     body:
       encoding: UTF-8
       string: |
         <project name="openSUSE:Factory">
-          <title>Death Be Not Proud</title>
+          <title>Time To Murder And Create</title>
           <description></description>
         </project>
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 09:08:54 GMT
+  recorded_at: Mon, 30 Jul 2018 19:12:01 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/openSUSE:Factory/target_package/_meta?user=_nobody_
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="target_package" project="openSUSE:Factory">
+          <title>For Whom the Bell Tolls</title>
+          <description>Officia et tenetur eius.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '165'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="target_package" project="openSUSE:Factory">
+          <title>For Whom the Bell Tolls</title>
+          <description>Officia et tenetur eius.</description>
+        </package>
+    http_version: 
+  recorded_at: Mon, 30 Jul 2018 19:12:01 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/openSUSE:Factory/target_package/_meta?user=_nobody_
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="target_package" project="openSUSE:Factory">
+          <title>For Whom the Bell Tolls</title>
+          <description>Officia et tenetur eius.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '165'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="target_package" project="openSUSE:Factory">
+          <title>For Whom the Bell Tolls</title>
+          <description>Officia et tenetur eius.</description>
+        </package>
+    http_version: 
+  recorded_at: Mon, 30 Jul 2018 19:12:01 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/project_4/_meta?user=_nobody_
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="project_4">
+          <title>Consider the Lilies</title>
+          <description/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '105'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="project_4">
+          <title>Consider the Lilies</title>
+          <description></description>
+        </project>
+    http_version: 
+  recorded_at: Mon, 30 Jul 2018 19:12:01 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/project_4/package_4/_meta?user=_nobody_
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="package_4" project="project_4">
+          <title>To Say Nothing of the Dog</title>
+          <description>Nisi modi fugit similique.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '157'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="package_4" project="project_4">
+          <title>To Say Nothing of the Dog</title>
+          <description>Nisi modi fugit similique.</description>
+        </package>
+    http_version: 
+  recorded_at: Mon, 30 Jul 2018 19:12:01 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/project_4/package_4/_meta?user=_nobody_
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="package_4" project="project_4">
+          <title>To Say Nothing of the Dog</title>
+          <description>Nisi modi fugit similique.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '157'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="package_4" project="project_4">
+          <title>To Say Nothing of the Dog</title>
+          <description>Nisi modi fugit similique.</description>
+        </package>
+    http_version: 
+  recorded_at: Mon, 30 Jul 2018 19:12:01 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:user_4/_meta?user=user_4
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:user_4">
+          <title/>
+          <description/>
+          <person userid="user_4" role="maintainer"/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '135'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:user_4">
+          <title></title>
+          <description></description>
+          <person userid="user_4" role="maintainer" />
+        </project>
+    http_version: 
+  recorded_at: Mon, 30 Jul 2018 19:12:01 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/openSUSE:Factory:Staging:A/_meta?user=_nobody_
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="openSUSE:Factory:Staging:A">
+          <title>The Little Foxes</title>
+          <description>      requests:
+                - { id: 1 }
+        </description>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '155'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="openSUSE:Factory:Staging:A">
+          <title>The Little Foxes</title>
+          <description>      requests:
+                - { id: 1 }
+        </description>
+        </project>
+    http_version: 
+  recorded_at: Mon, 30 Jul 2018 19:12:01 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/openSUSE:Factory:Staging:B/_meta?user=_nobody_
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="openSUSE:Factory:Staging:B">
+          <title>A Confederacy of Dunces</title>
+          <description>Factory staging project B</description>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '151'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="openSUSE:Factory:Staging:B">
+          <title>A Confederacy of Dunces</title>
+          <description>Factory staging project B</description>
+        </project>
+    http_version: 
+  recorded_at: Mon, 30 Jul 2018 19:12:01 GMT
 - request:
     method: get
     uri: http://backend:5352/build/openSUSE:Factory:Staging:A/_result?package=Test-DVD-x86_64&repository=images&view=binarylist
@@ -192,7 +432,7 @@ http_interactions:
           <details>404 unknown repository 'images'</details>
         </status>
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 09:08:55 GMT
+  recorded_at: Mon, 30 Jul 2018 19:12:01 GMT
 - request:
     method: get
     uri: http://backend:5352/build/openSUSE:Factory:Staging:A/_result?code=unresolvable
@@ -227,7 +467,7 @@ http_interactions:
 
 '
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 09:08:55 GMT
+  recorded_at: Mon, 30 Jul 2018 19:12:01 GMT
 - request:
     method: get
     uri: http://backend:5352/build/openSUSE:Factory:Staging:B/_result?package=Test-DVD-x86_64&repository=images&view=binarylist
@@ -264,7 +504,7 @@ http_interactions:
           <details>404 unknown repository 'images'</details>
         </status>
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 09:08:55 GMT
+  recorded_at: Mon, 30 Jul 2018 19:12:02 GMT
 - request:
     method: get
     uri: http://backend:5352/build/openSUSE:Factory:Staging:B/_result?code=unresolvable
@@ -299,5 +539,5 @@ http_interactions:
 
 '
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 09:08:55 GMT
+  recorded_at: Mon, 30 Jul 2018 19:12:02 GMT
 recorded_with: VCR 4.0.0

--- a/src/api/spec/cassettes/Webui_ObsFactory_StagingProjectsController/GET_index/requesting_json/responds_with_a_json_representation_of_the_staging_project.yml
+++ b/src/api/spec/cassettes/Webui_ObsFactory_StagingProjectsController/GET_index/requesting_json/responds_with_a_json_representation_of_the_staging_project.yml
@@ -2,14 +2,209 @@
 http_interactions:
 - request:
     method: put
-    uri: http://backend:5352/source/openSUSE:Factory:Staging:A/_meta?user=_nobody_
+    uri: http://backend:5352/source/openSUSE:Factory:Staging/_meta?user=_nobody_
     body:
       encoding: UTF-8
       string: |
-        <project name="openSUSE:Factory:Staging:A">
-          <title>If Not Now, When?</title>
-          <description>Factory staging project A</description>
+        <project name="openSUSE:Factory:Staging">
+          <title>No Highway</title>
+          <description/>
         </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '111'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="openSUSE:Factory:Staging">
+          <title>No Highway</title>
+          <description></description>
+        </project>
+    http_version: 
+  recorded_at: Mon, 30 Jul 2018 19:12:02 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/openSUSE:Factory/_meta?user=_nobody_
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="openSUSE:Factory">
+          <title>Terrible Swift Sword</title>
+          <description/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '113'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="openSUSE:Factory">
+          <title>Terrible Swift Sword</title>
+          <description></description>
+        </project>
+    http_version: 
+  recorded_at: Mon, 30 Jul 2018 19:12:02 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/openSUSE:Factory/target_package/_meta?user=_nobody_
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="target_package" project="openSUSE:Factory">
+          <title>Endless Night</title>
+          <description>Consequatur fuga consectetur sed.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '164'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="target_package" project="openSUSE:Factory">
+          <title>Endless Night</title>
+          <description>Consequatur fuga consectetur sed.</description>
+        </package>
+    http_version: 
+  recorded_at: Mon, 30 Jul 2018 19:12:02 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/openSUSE:Factory/target_package/_meta?user=_nobody_
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="target_package" project="openSUSE:Factory">
+          <title>Endless Night</title>
+          <description>Consequatur fuga consectetur sed.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '164'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="target_package" project="openSUSE:Factory">
+          <title>Endless Night</title>
+          <description>Consequatur fuga consectetur sed.</description>
+        </package>
+    http_version: 
+  recorded_at: Mon, 30 Jul 2018 19:12:02 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/project_5/_meta?user=_nobody_
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="project_5">
+          <title>Down to a Sunless Sea</title>
+          <description/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '107'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="project_5">
+          <title>Down to a Sunless Sea</title>
+          <description></description>
+        </project>
+    http_version: 
+  recorded_at: Mon, 30 Jul 2018 19:12:02 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/project_5/package_5/_meta?user=_nobody_
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="package_5" project="project_5">
+          <title>That Good Night</title>
+          <description>Ea inventore et maiores.</description>
+        </package>
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -33,21 +228,61 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <project name="openSUSE:Factory:Staging:A">
-          <title>If Not Now, When?</title>
-          <description>Factory staging project A</description>
-        </project>
+        <package name="package_5" project="project_5">
+          <title>That Good Night</title>
+          <description>Ea inventore et maiores.</description>
+        </package>
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 09:08:55 GMT
+  recorded_at: Mon, 30 Jul 2018 19:12:02 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/openSUSE:Factory:Staging/_meta?user=_nobody_
+    uri: http://backend:5352/source/project_5/package_5/_meta?user=_nobody_
     body:
       encoding: UTF-8
       string: |
-        <project name="openSUSE:Factory:Staging">
-          <title>In Dubious Battle</title>
+        <package name="package_5" project="project_5">
+          <title>That Good Night</title>
+          <description>Ea inventore et maiores.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '145'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="package_5" project="project_5">
+          <title>That Good Night</title>
+          <description>Ea inventore et maiores.</description>
+        </package>
+    http_version: 
+  recorded_at: Mon, 30 Jul 2018 19:12:02 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:user_5/_meta?user=user_5
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:user_5">
+          <title/>
           <description/>
+          <person userid="user_5" role="maintainer"/>
         </project>
     headers:
       Accept-Encoding:
@@ -68,16 +303,60 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '118'
+      - '135'
     body:
       encoding: UTF-8
       string: |
-        <project name="openSUSE:Factory:Staging">
-          <title>In Dubious Battle</title>
+        <project name="home:user_5">
+          <title></title>
           <description></description>
+          <person userid="user_5" role="maintainer" />
         </project>
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 09:08:55 GMT
+  recorded_at: Mon, 30 Jul 2018 19:12:02 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/openSUSE:Factory:Staging:A/_meta?user=_nobody_
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="openSUSE:Factory:Staging:A">
+          <title>Number the Stars</title>
+          <description>      requests:
+                - { id: 1 }
+        </description>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '155'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="openSUSE:Factory:Staging:A">
+          <title>Number the Stars</title>
+          <description>      requests:
+                - { id: 1 }
+        </description>
+        </project>
+    http_version: 
+  recorded_at: Mon, 30 Jul 2018 19:12:02 GMT
 - request:
     method: put
     uri: http://backend:5352/source/openSUSE:Factory:Staging:B/_meta?user=_nobody_
@@ -85,8 +364,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <project name="openSUSE:Factory:Staging:B">
-          <title>No Longer at Ease</title>
-          <description/>
+          <title>Consider the Lilies</title>
+          <description>Factory staging project B</description>
         </project>
     headers:
       Accept-Encoding:
@@ -107,55 +386,16 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '120'
+      - '147'
     body:
       encoding: UTF-8
       string: |
         <project name="openSUSE:Factory:Staging:B">
-          <title>No Longer at Ease</title>
-          <description></description>
+          <title>Consider the Lilies</title>
+          <description>Factory staging project B</description>
         </project>
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 09:08:55 GMT
-- request:
-    method: put
-    uri: http://backend:5352/source/openSUSE:Factory/_meta?user=_nobody_
-    body:
-      encoding: UTF-8
-      string: |
-        <project name="openSUSE:Factory">
-          <title>Recalled to Life</title>
-          <description/>
-        </project>
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '109'
-    body:
-      encoding: UTF-8
-      string: |
-        <project name="openSUSE:Factory">
-          <title>Recalled to Life</title>
-          <description></description>
-        </project>
-    http_version: 
-  recorded_at: Mon, 30 Jul 2018 09:08:55 GMT
+  recorded_at: Mon, 30 Jul 2018 19:12:02 GMT
 - request:
     method: get
     uri: http://backend:5352/build/openSUSE:Factory:Staging:A/_result?package=Test-DVD-x86_64&repository=images&view=binarylist
@@ -192,7 +432,7 @@ http_interactions:
           <details>404 unknown repository 'images'</details>
         </status>
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 09:08:55 GMT
+  recorded_at: Mon, 30 Jul 2018 19:12:02 GMT
 - request:
     method: get
     uri: http://backend:5352/build/openSUSE:Factory:Staging:A/_result?code=unresolvable
@@ -227,7 +467,7 @@ http_interactions:
 
 '
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 09:08:55 GMT
+  recorded_at: Mon, 30 Jul 2018 19:12:02 GMT
 - request:
     method: get
     uri: http://backend:5352/build/openSUSE:Factory:Staging:B/_result?package=Test-DVD-x86_64&repository=images&view=binarylist
@@ -264,7 +504,7 @@ http_interactions:
           <details>404 unknown repository 'images'</details>
         </status>
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 09:08:55 GMT
+  recorded_at: Mon, 30 Jul 2018 19:12:02 GMT
 - request:
     method: get
     uri: http://backend:5352/build/openSUSE:Factory:Staging:B/_result?code=unresolvable
@@ -299,7 +539,7 @@ http_interactions:
 
 '
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 09:08:55 GMT
+  recorded_at: Mon, 30 Jul 2018 19:12:02 GMT
 - request:
     method: get
     uri: http://backend:5352/build/openSUSE:Factory:Staging:A/_result?package=Test-DVD-x86_64&repository=images&view=binarylist
@@ -336,7 +576,7 @@ http_interactions:
           <details>404 unknown repository 'images'</details>
         </status>
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 09:08:55 GMT
+  recorded_at: Mon, 30 Jul 2018 19:12:03 GMT
 - request:
     method: get
     uri: http://backend:5352/build/openSUSE:Factory:Staging:A/_result?code=unresolvable
@@ -371,7 +611,7 @@ http_interactions:
 
 '
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 09:08:55 GMT
+  recorded_at: Mon, 30 Jul 2018 19:12:03 GMT
 - request:
     method: get
     uri: http://backend:5352/build/openSUSE:Factory:Staging:B/_result?package=Test-DVD-x86_64&repository=images&view=binarylist
@@ -408,7 +648,7 @@ http_interactions:
           <details>404 unknown repository 'images'</details>
         </status>
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 09:08:55 GMT
+  recorded_at: Mon, 30 Jul 2018 19:12:03 GMT
 - request:
     method: get
     uri: http://backend:5352/build/openSUSE:Factory:Staging:B/_result?code=unresolvable
@@ -443,5 +683,5 @@ http_interactions:
 
 '
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 09:08:55 GMT
+  recorded_at: Mon, 30 Jul 2018 19:12:03 GMT
 recorded_with: VCR 4.0.0

--- a/src/api/spec/cassettes/Webui_ObsFactory_StagingProjectsController/GET_index/with_dashboard_package/with_ignored_requests_file/with_content/1_1_2_1_1_1.yml
+++ b/src/api/spec/cassettes/Webui_ObsFactory_StagingProjectsController/GET_index/with_dashboard_package/with_ignored_requests_file/with_content/1_1_2_1_1_1.yml
@@ -2,168 +2,12 @@
 http_interactions:
 - request:
     method: put
-    uri: http://backend:5352/source/openSUSE:Factory:Staging:A/_meta?user=_nobody_
-    body:
-      encoding: UTF-8
-      string: |
-        <project name="openSUSE:Factory:Staging:A">
-          <title>After Many a Summer Dies the Swan</title>
-          <description>Factory staging project A</description>
-        </project>
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '161'
-    body:
-      encoding: UTF-8
-      string: |
-        <project name="openSUSE:Factory:Staging:A">
-          <title>After Many a Summer Dies the Swan</title>
-          <description>Factory staging project A</description>
-        </project>
-    http_version: 
-  recorded_at: Tue, 24 Jul 2018 08:06:15 GMT
-- request:
-    method: put
     uri: http://backend:5352/source/openSUSE:Factory:Staging/_meta?user=_nobody_
     body:
       encoding: UTF-8
       string: |
         <project name="openSUSE:Factory:Staging">
-          <title>Beyond the Mexique Bay</title>
-          <description/>
-        </project>
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '123'
-    body:
-      encoding: UTF-8
-      string: |
-        <project name="openSUSE:Factory:Staging">
-          <title>Beyond the Mexique Bay</title>
-          <description></description>
-        </project>
-    http_version: 
-  recorded_at: Tue, 24 Jul 2018 08:06:15 GMT
-- request:
-    method: put
-    uri: http://backend:5352/source/openSUSE:Factory:Staging/dashboard/_meta?user=_nobody_
-    body:
-      encoding: UTF-8
-      string: |
-        <package name="dashboard" project="openSUSE:Factory:Staging">
-          <title>Cover Her Face</title>
-          <description>Aut suscipit voluptatum laboriosam.</description>
-        </package>
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '170'
-    body:
-      encoding: UTF-8
-      string: |
-        <package name="dashboard" project="openSUSE:Factory:Staging">
-          <title>Cover Her Face</title>
-          <description>Aut suscipit voluptatum laboriosam.</description>
-        </package>
-    http_version: 
-  recorded_at: Tue, 24 Jul 2018 08:06:15 GMT
-- request:
-    method: put
-    uri: http://backend:5352/source/openSUSE:Factory:Staging/dashboard/_meta?user=_nobody_
-    body:
-      encoding: UTF-8
-      string: |
-        <package name="dashboard" project="openSUSE:Factory:Staging">
-          <title>Cover Her Face</title>
-          <description>Aut suscipit voluptatum laboriosam.</description>
-        </package>
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '170'
-    body:
-      encoding: UTF-8
-      string: |
-        <package name="dashboard" project="openSUSE:Factory:Staging">
-          <title>Cover Her Face</title>
-          <description>Aut suscipit voluptatum laboriosam.</description>
-        </package>
-    http_version: 
-  recorded_at: Tue, 24 Jul 2018 08:06:16 GMT
-- request:
-    method: put
-    uri: http://backend:5352/source/openSUSE:Factory/_meta?user=_nobody_
-    body:
-      encoding: UTF-8
-      string: |
-        <project name="openSUSE:Factory">
-          <title>The Line of Beauty</title>
+          <title>No Highway</title>
           <description/>
         </project>
     headers:
@@ -189,12 +33,51 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <project name="openSUSE:Factory">
-          <title>The Line of Beauty</title>
+        <project name="openSUSE:Factory:Staging">
+          <title>No Highway</title>
           <description></description>
         </project>
     http_version: 
-  recorded_at: Tue, 24 Jul 2018 08:06:16 GMT
+  recorded_at: Mon, 30 Jul 2018 19:12:06 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/openSUSE:Factory/_meta?user=_nobody_
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="openSUSE:Factory">
+          <title>An Evil Cradling</title>
+          <description/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '109'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="openSUSE:Factory">
+          <title>An Evil Cradling</title>
+          <description></description>
+        </project>
+    http_version: 
+  recorded_at: Mon, 30 Jul 2018 19:12:06 GMT
 - request:
     method: put
     uri: http://backend:5352/source/openSUSE:Factory/target_package/_meta?user=_nobody_
@@ -202,8 +85,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="target_package" project="openSUSE:Factory">
-          <title>The Stars' Tennis Balls</title>
-          <description>Magni et fuga eveniet.</description>
+          <title>Beneath the Bleeding</title>
+          <description>In voluptatum explicabo esse.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -224,16 +107,16 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '163'
+      - '167'
     body:
       encoding: UTF-8
       string: |
         <package name="target_package" project="openSUSE:Factory">
-          <title>The Stars' Tennis Balls</title>
-          <description>Magni et fuga eveniet.</description>
+          <title>Beneath the Bleeding</title>
+          <description>In voluptatum explicabo esse.</description>
         </package>
     http_version: 
-  recorded_at: Tue, 24 Jul 2018 08:06:16 GMT
+  recorded_at: Mon, 30 Jul 2018 19:12:06 GMT
 - request:
     method: put
     uri: http://backend:5352/source/openSUSE:Factory/target_package/_meta?user=_nobody_
@@ -241,8 +124,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="target_package" project="openSUSE:Factory">
-          <title>The Stars' Tennis Balls</title>
-          <description>Magni et fuga eveniet.</description>
+          <title>Beneath the Bleeding</title>
+          <description>In voluptatum explicabo esse.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -263,16 +146,16 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '163'
+      - '167'
     body:
       encoding: UTF-8
       string: |
         <package name="target_package" project="openSUSE:Factory">
-          <title>The Stars' Tennis Balls</title>
-          <description>Magni et fuga eveniet.</description>
+          <title>Beneath the Bleeding</title>
+          <description>In voluptatum explicabo esse.</description>
         </package>
     http_version: 
-  recorded_at: Tue, 24 Jul 2018 08:06:16 GMT
+  recorded_at: Mon, 30 Jul 2018 19:12:06 GMT
 - request:
     method: put
     uri: http://backend:5352/source/source_project/_meta?user=_nobody_
@@ -311,7 +194,7 @@ http_interactions:
           <description></description>
         </project>
     http_version: 
-  recorded_at: Tue, 24 Jul 2018 08:06:16 GMT
+  recorded_at: Mon, 30 Jul 2018 19:12:07 GMT
 - request:
     method: put
     uri: http://backend:5352/source/source_project/source_package/_meta?user=_nobody_
@@ -319,8 +202,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="source_package" project="source_project">
-          <title>For Whom the Bell Tolls</title>
-          <description>Modi error incidunt perspiciatis.</description>
+          <title>Far From the Madding Crowd</title>
+          <description>Nesciunt optio et consequatur.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -346,11 +229,11 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="source_package" project="source_project">
-          <title>For Whom the Bell Tolls</title>
-          <description>Modi error incidunt perspiciatis.</description>
+          <title>Far From the Madding Crowd</title>
+          <description>Nesciunt optio et consequatur.</description>
         </package>
     http_version: 
-  recorded_at: Tue, 24 Jul 2018 08:06:16 GMT
+  recorded_at: Mon, 30 Jul 2018 19:12:07 GMT
 - request:
     method: put
     uri: http://backend:5352/source/source_project/source_package/_meta?user=_nobody_
@@ -358,8 +241,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="source_package" project="source_project">
-          <title>For Whom the Bell Tolls</title>
-          <description>Modi error incidunt perspiciatis.</description>
+          <title>Far From the Madding Crowd</title>
+          <description>Nesciunt optio et consequatur.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -385,21 +268,21 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="source_package" project="source_project">
-          <title>For Whom the Bell Tolls</title>
-          <description>Modi error incidunt perspiciatis.</description>
+          <title>Far From the Madding Crowd</title>
+          <description>Nesciunt optio et consequatur.</description>
         </package>
     http_version: 
-  recorded_at: Tue, 24 Jul 2018 08:06:16 GMT
+  recorded_at: Mon, 30 Jul 2018 19:12:07 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:user_1/_meta?user=user_1
+    uri: http://backend:5352/source/home:user_9/_meta?user=user_9
     body:
       encoding: UTF-8
       string: |
-        <project name="home:user_1">
+        <project name="home:user_9">
           <title/>
           <description/>
-          <person userid="user_1" role="maintainer"/>
+          <person userid="user_9" role="maintainer"/>
         </project>
     headers:
       Accept-Encoding:
@@ -424,23 +307,24 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <project name="home:user_1">
+        <project name="home:user_9">
           <title></title>
           <description></description>
-          <person userid="user_1" role="maintainer" />
+          <person userid="user_9" role="maintainer" />
         </project>
     http_version: 
-  recorded_at: Tue, 24 Jul 2018 08:06:16 GMT
+  recorded_at: Mon, 30 Jul 2018 19:12:07 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:user_2/_meta?user=user_2
+    uri: http://backend:5352/source/openSUSE:Factory:Staging:A/_meta?user=_nobody_
     body:
       encoding: UTF-8
       string: |
-        <project name="home:user_2">
-          <title/>
-          <description/>
-          <person userid="user_2" role="maintainer"/>
+        <project name="openSUSE:Factory:Staging:A">
+          <title>The Widening Gyre</title>
+          <description>      requests:
+                - { id: 1 }
+        </description>
         </project>
     headers:
       Accept-Encoding:
@@ -461,27 +345,27 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '135'
+      - '156'
     body:
       encoding: UTF-8
       string: |
-        <project name="home:user_2">
-          <title></title>
-          <description></description>
-          <person userid="user_2" role="maintainer" />
+        <project name="openSUSE:Factory:Staging:A">
+          <title>The Widening Gyre</title>
+          <description>      requests:
+                - { id: 1 }
+        </description>
         </project>
     http_version: 
-  recorded_at: Tue, 24 Jul 2018 08:06:16 GMT
+  recorded_at: Mon, 30 Jul 2018 19:12:07 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:user_3/_meta?user=user_3
+    uri: http://backend:5352/source/openSUSE:Factory:Staging:B/_meta?user=_nobody_
     body:
       encoding: UTF-8
       string: |
-        <project name="home:user_3">
-          <title/>
-          <description/>
-          <person userid="user_3" role="maintainer"/>
+        <project name="openSUSE:Factory:Staging:B">
+          <title>Tender Is the Night</title>
+          <description>Factory staging project B</description>
         </project>
     headers:
       Accept-Encoding:
@@ -502,27 +386,104 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '135'
+      - '147'
     body:
       encoding: UTF-8
       string: |
-        <project name="home:user_3">
-          <title></title>
-          <description></description>
-          <person userid="user_3" role="maintainer" />
+        <project name="openSUSE:Factory:Staging:B">
+          <title>Tender Is the Night</title>
+          <description>Factory staging project B</description>
         </project>
     http_version: 
-  recorded_at: Tue, 24 Jul 2018 08:06:17 GMT
+  recorded_at: Mon, 30 Jul 2018 19:12:07 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:user_4/_meta?user=user_4
+    uri: http://backend:5352/source/openSUSE:Factory:Staging/dashboard/_meta?user=_nobody_
     body:
       encoding: UTF-8
       string: |
-        <project name="home:user_4">
+        <package name="dashboard" project="openSUSE:Factory:Staging">
+          <title>Jesting Pilate</title>
+          <description>Qui accusantium sint eaque.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '162'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="dashboard" project="openSUSE:Factory:Staging">
+          <title>Jesting Pilate</title>
+          <description>Qui accusantium sint eaque.</description>
+        </package>
+    http_version: 
+  recorded_at: Mon, 30 Jul 2018 19:12:07 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/openSUSE:Factory:Staging/dashboard/_meta?user=_nobody_
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="dashboard" project="openSUSE:Factory:Staging">
+          <title>Jesting Pilate</title>
+          <description>Qui accusantium sint eaque.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '162'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="dashboard" project="openSUSE:Factory:Staging">
+          <title>Jesting Pilate</title>
+          <description>Qui accusantium sint eaque.</description>
+        </package>
+    http_version: 
+  recorded_at: Mon, 30 Jul 2018 19:12:07 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:user_10/_meta?user=user_10
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:user_10">
           <title/>
           <description/>
-          <person userid="user_4" role="maintainer"/>
+          <person userid="user_10" role="maintainer"/>
         </project>
     headers:
       Accept-Encoding:
@@ -543,15 +504,210 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '135'
+      - '137'
     body:
       encoding: UTF-8
       string: |
-        <project name="home:user_4">
+        <project name="home:user_10">
           <title></title>
           <description></description>
-          <person userid="user_4" role="maintainer" />
+          <person userid="user_10" role="maintainer" />
         </project>
     http_version: 
-  recorded_at: Tue, 24 Jul 2018 08:06:17 GMT
+  recorded_at: Mon, 30 Jul 2018 19:12:07 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:user_11/_meta?user=user_11
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:user_11">
+          <title/>
+          <description/>
+          <person userid="user_11" role="maintainer"/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '137'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:user_11">
+          <title></title>
+          <description></description>
+          <person userid="user_11" role="maintainer" />
+        </project>
+    http_version: 
+  recorded_at: Mon, 30 Jul 2018 19:12:08 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:user_12/_meta?user=user_12
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:user_12">
+          <title/>
+          <description/>
+          <person userid="user_12" role="maintainer"/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '137'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:user_12">
+          <title></title>
+          <description></description>
+          <person userid="user_12" role="maintainer" />
+        </project>
+    http_version: 
+  recorded_at: Mon, 30 Jul 2018 19:12:08 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:user_13/_meta?user=user_13
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:user_13">
+          <title/>
+          <description/>
+          <person userid="user_13" role="maintainer"/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '137'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:user_13">
+          <title></title>
+          <description></description>
+          <person userid="user_13" role="maintainer" />
+        </project>
+    http_version: 
+  recorded_at: Mon, 30 Jul 2018 19:12:08 GMT
+- request:
+    method: get
+    uri: http://backend:5352/build/openSUSE:Factory:Staging:A/_result?package=Test-DVD-x86_64&repository=images&view=binarylist
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - text/plain
+      Accept-Encoding:
+      - identity
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 404
+      message: unknown repository 'images'
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '132'
+    body:
+      encoding: UTF-8
+      string: |
+        <status code="404">
+          <summary>unknown repository 'images'</summary>
+          <details>404 unknown repository 'images'</details>
+        </status>
+    http_version: 
+  recorded_at: Mon, 30 Jul 2018 19:12:09 GMT
+- request:
+    method: get
+    uri: http://backend:5352/build/openSUSE:Factory:Staging:A/_result?code=unresolvable
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - text/plain
+      Accept-Encoding:
+      - identity
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '56'
+    body:
+      encoding: UTF-8
+      string: '<resultlist state="00000000000000000000000000000000" />
+
+'
+    http_version: 
+  recorded_at: Mon, 30 Jul 2018 19:12:09 GMT
 recorded_with: VCR 4.0.0

--- a/src/api/spec/cassettes/Webui_ObsFactory_StagingProjectsController/GET_index/with_dashboard_package/with_ignored_requests_file/with_content/1_1_2_1_1_2.yml
+++ b/src/api/spec/cassettes/Webui_ObsFactory_StagingProjectsController/GET_index/with_dashboard_package/with_ignored_requests_file/with_content/1_1_2_1_1_2.yml
@@ -2,51 +2,12 @@
 http_interactions:
 - request:
     method: put
-    uri: http://backend:5352/source/openSUSE:Factory:Staging:A/_meta?user=_nobody_
-    body:
-      encoding: UTF-8
-      string: |
-        <project name="openSUSE:Factory:Staging:A">
-          <title>In a Glass Darkly</title>
-          <description>Factory staging project A</description>
-        </project>
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '145'
-    body:
-      encoding: UTF-8
-      string: |
-        <project name="openSUSE:Factory:Staging:A">
-          <title>In a Glass Darkly</title>
-          <description>Factory staging project A</description>
-        </project>
-    http_version: 
-  recorded_at: Tue, 24 Jul 2018 08:06:17 GMT
-- request:
-    method: put
     uri: http://backend:5352/source/openSUSE:Factory:Staging/_meta?user=_nobody_
     body:
       encoding: UTF-8
       string: |
         <project name="openSUSE:Factory:Staging">
-          <title>Some Buried Caesar</title>
+          <title>All the King's Men</title>
           <description/>
         </project>
     headers:
@@ -73,89 +34,11 @@ http_interactions:
       encoding: UTF-8
       string: |
         <project name="openSUSE:Factory:Staging">
-          <title>Some Buried Caesar</title>
+          <title>All the King's Men</title>
           <description></description>
         </project>
     http_version: 
-  recorded_at: Tue, 24 Jul 2018 08:06:17 GMT
-- request:
-    method: put
-    uri: http://backend:5352/source/openSUSE:Factory:Staging/dashboard/_meta?user=_nobody_
-    body:
-      encoding: UTF-8
-      string: |
-        <package name="dashboard" project="openSUSE:Factory:Staging">
-          <title>That Good Night</title>
-          <description>Reiciendis possimus aut tenetur.</description>
-        </package>
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '168'
-    body:
-      encoding: UTF-8
-      string: |
-        <package name="dashboard" project="openSUSE:Factory:Staging">
-          <title>That Good Night</title>
-          <description>Reiciendis possimus aut tenetur.</description>
-        </package>
-    http_version: 
-  recorded_at: Tue, 24 Jul 2018 08:06:17 GMT
-- request:
-    method: put
-    uri: http://backend:5352/source/openSUSE:Factory:Staging/dashboard/_meta?user=_nobody_
-    body:
-      encoding: UTF-8
-      string: |
-        <package name="dashboard" project="openSUSE:Factory:Staging">
-          <title>That Good Night</title>
-          <description>Reiciendis possimus aut tenetur.</description>
-        </package>
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '168'
-    body:
-      encoding: UTF-8
-      string: |
-        <package name="dashboard" project="openSUSE:Factory:Staging">
-          <title>That Good Night</title>
-          <description>Reiciendis possimus aut tenetur.</description>
-        </package>
-    http_version: 
-  recorded_at: Tue, 24 Jul 2018 08:06:17 GMT
+  recorded_at: Mon, 30 Jul 2018 19:12:09 GMT
 - request:
     method: put
     uri: http://backend:5352/source/openSUSE:Factory/_meta?user=_nobody_
@@ -163,7 +46,7 @@ http_interactions:
       encoding: UTF-8
       string: |
         <project name="openSUSE:Factory">
-          <title>The Waste Land</title>
+          <title>Ah, Wilderness!</title>
           <description/>
         </project>
     headers:
@@ -185,16 +68,16 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '107'
+      - '108'
     body:
       encoding: UTF-8
       string: |
         <project name="openSUSE:Factory">
-          <title>The Waste Land</title>
+          <title>Ah, Wilderness!</title>
           <description></description>
         </project>
     http_version: 
-  recorded_at: Tue, 24 Jul 2018 08:06:17 GMT
+  recorded_at: Mon, 30 Jul 2018 19:12:09 GMT
 - request:
     method: put
     uri: http://backend:5352/source/openSUSE:Factory/target_package/_meta?user=_nobody_
@@ -202,8 +85,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="target_package" project="openSUSE:Factory">
-          <title>Taming a Sea Horse</title>
-          <description>Libero asperiores qui voluptatem.</description>
+          <title>Time To Murder And Create</title>
+          <description>Laudantium occaecati nesciunt sunt.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -224,16 +107,16 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '169'
+      - '178'
     body:
       encoding: UTF-8
       string: |
         <package name="target_package" project="openSUSE:Factory">
-          <title>Taming a Sea Horse</title>
-          <description>Libero asperiores qui voluptatem.</description>
+          <title>Time To Murder And Create</title>
+          <description>Laudantium occaecati nesciunt sunt.</description>
         </package>
     http_version: 
-  recorded_at: Tue, 24 Jul 2018 08:06:17 GMT
+  recorded_at: Mon, 30 Jul 2018 19:12:09 GMT
 - request:
     method: put
     uri: http://backend:5352/source/openSUSE:Factory/target_package/_meta?user=_nobody_
@@ -241,8 +124,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="target_package" project="openSUSE:Factory">
-          <title>Taming a Sea Horse</title>
-          <description>Libero asperiores qui voluptatem.</description>
+          <title>Time To Murder And Create</title>
+          <description>Laudantium occaecati nesciunt sunt.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -263,16 +146,16 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '169'
+      - '178'
     body:
       encoding: UTF-8
       string: |
         <package name="target_package" project="openSUSE:Factory">
-          <title>Taming a Sea Horse</title>
-          <description>Libero asperiores qui voluptatem.</description>
+          <title>Time To Murder And Create</title>
+          <description>Laudantium occaecati nesciunt sunt.</description>
         </package>
     http_version: 
-  recorded_at: Tue, 24 Jul 2018 08:06:17 GMT
+  recorded_at: Mon, 30 Jul 2018 19:12:09 GMT
 - request:
     method: put
     uri: http://backend:5352/source/source_project/_meta?user=_nobody_
@@ -280,7 +163,7 @@ http_interactions:
       encoding: UTF-8
       string: |
         <project name="source_project">
-          <title>Ah, Wilderness!</title>
+          <title>Vanity Fair</title>
           <description/>
         </project>
     headers:
@@ -302,16 +185,16 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '106'
+      - '102'
     body:
       encoding: UTF-8
       string: |
         <project name="source_project">
-          <title>Ah, Wilderness!</title>
+          <title>Vanity Fair</title>
           <description></description>
         </project>
     http_version: 
-  recorded_at: Tue, 24 Jul 2018 08:06:17 GMT
+  recorded_at: Mon, 30 Jul 2018 19:12:09 GMT
 - request:
     method: put
     uri: http://backend:5352/source/source_project/source_package/_meta?user=_nobody_
@@ -319,8 +202,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="source_package" project="source_project">
-          <title>The Wealth of Nations</title>
-          <description>Eum qui minus quibusdam.</description>
+          <title>The Golden Bowl</title>
+          <description>Ut praesentium nisi est.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -341,16 +224,16 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '161'
+      - '155'
     body:
       encoding: UTF-8
       string: |
         <package name="source_package" project="source_project">
-          <title>The Wealth of Nations</title>
-          <description>Eum qui minus quibusdam.</description>
+          <title>The Golden Bowl</title>
+          <description>Ut praesentium nisi est.</description>
         </package>
     http_version: 
-  recorded_at: Tue, 24 Jul 2018 08:06:17 GMT
+  recorded_at: Mon, 30 Jul 2018 19:12:09 GMT
 - request:
     method: put
     uri: http://backend:5352/source/source_project/source_package/_meta?user=_nobody_
@@ -358,8 +241,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="source_package" project="source_project">
-          <title>The Wealth of Nations</title>
-          <description>Eum qui minus quibusdam.</description>
+          <title>The Golden Bowl</title>
+          <description>Ut praesentium nisi est.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -380,26 +263,26 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '161'
+      - '155'
     body:
       encoding: UTF-8
       string: |
         <package name="source_package" project="source_project">
-          <title>The Wealth of Nations</title>
-          <description>Eum qui minus quibusdam.</description>
+          <title>The Golden Bowl</title>
+          <description>Ut praesentium nisi est.</description>
         </package>
     http_version: 
-  recorded_at: Tue, 24 Jul 2018 08:06:17 GMT
+  recorded_at: Mon, 30 Jul 2018 19:12:09 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:user_5/_meta?user=user_5
+    uri: http://backend:5352/source/home:user_14/_meta?user=user_14
     body:
       encoding: UTF-8
       string: |
-        <project name="home:user_5">
+        <project name="home:user_14">
           <title/>
           <description/>
-          <person userid="user_5" role="maintainer"/>
+          <person userid="user_14" role="maintainer"/>
         </project>
     headers:
       Accept-Encoding:
@@ -420,27 +303,28 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '135'
+      - '137'
     body:
       encoding: UTF-8
       string: |
-        <project name="home:user_5">
+        <project name="home:user_14">
           <title></title>
           <description></description>
-          <person userid="user_5" role="maintainer" />
+          <person userid="user_14" role="maintainer" />
         </project>
     http_version: 
-  recorded_at: Tue, 24 Jul 2018 08:06:18 GMT
+  recorded_at: Mon, 30 Jul 2018 19:12:09 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:user_6/_meta?user=user_6
+    uri: http://backend:5352/source/openSUSE:Factory:Staging:A/_meta?user=_nobody_
     body:
       encoding: UTF-8
       string: |
-        <project name="home:user_6">
-          <title/>
-          <description/>
-          <person userid="user_6" role="maintainer"/>
+        <project name="openSUSE:Factory:Staging:A">
+          <title>This Side of Paradise</title>
+          <description>      requests:
+                - { id: 1 }
+        </description>
         </project>
     headers:
       Accept-Encoding:
@@ -461,27 +345,27 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '135'
+      - '160'
     body:
       encoding: UTF-8
       string: |
-        <project name="home:user_6">
-          <title></title>
-          <description></description>
-          <person userid="user_6" role="maintainer" />
+        <project name="openSUSE:Factory:Staging:A">
+          <title>This Side of Paradise</title>
+          <description>      requests:
+                - { id: 1 }
+        </description>
         </project>
     http_version: 
-  recorded_at: Tue, 24 Jul 2018 08:06:18 GMT
+  recorded_at: Mon, 30 Jul 2018 19:12:10 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:user_7/_meta?user=user_7
+    uri: http://backend:5352/source/openSUSE:Factory:Staging:B/_meta?user=_nobody_
     body:
       encoding: UTF-8
       string: |
-        <project name="home:user_7">
-          <title/>
-          <description/>
-          <person userid="user_7" role="maintainer"/>
+        <project name="openSUSE:Factory:Staging:B">
+          <title>Beyond the Mexique Bay</title>
+          <description>Factory staging project B</description>
         </project>
     headers:
       Accept-Encoding:
@@ -502,27 +386,104 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '135'
+      - '150'
     body:
       encoding: UTF-8
       string: |
-        <project name="home:user_7">
-          <title></title>
-          <description></description>
-          <person userid="user_7" role="maintainer" />
+        <project name="openSUSE:Factory:Staging:B">
+          <title>Beyond the Mexique Bay</title>
+          <description>Factory staging project B</description>
         </project>
     http_version: 
-  recorded_at: Tue, 24 Jul 2018 08:06:18 GMT
+  recorded_at: Mon, 30 Jul 2018 19:12:10 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:user_8/_meta?user=user_8
+    uri: http://backend:5352/source/openSUSE:Factory:Staging/dashboard/_meta?user=_nobody_
     body:
       encoding: UTF-8
       string: |
-        <project name="home:user_8">
+        <package name="dashboard" project="openSUSE:Factory:Staging">
+          <title>To Your Scattered Bodies Go</title>
+          <description>Aperiam quae consequuntur sequi.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '180'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="dashboard" project="openSUSE:Factory:Staging">
+          <title>To Your Scattered Bodies Go</title>
+          <description>Aperiam quae consequuntur sequi.</description>
+        </package>
+    http_version: 
+  recorded_at: Mon, 30 Jul 2018 19:12:10 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/openSUSE:Factory:Staging/dashboard/_meta?user=_nobody_
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="dashboard" project="openSUSE:Factory:Staging">
+          <title>To Your Scattered Bodies Go</title>
+          <description>Aperiam quae consequuntur sequi.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '180'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="dashboard" project="openSUSE:Factory:Staging">
+          <title>To Your Scattered Bodies Go</title>
+          <description>Aperiam quae consequuntur sequi.</description>
+        </package>
+    http_version: 
+  recorded_at: Mon, 30 Jul 2018 19:12:10 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:user_15/_meta?user=user_15
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:user_15">
           <title/>
           <description/>
-          <person userid="user_8" role="maintainer"/>
+          <person userid="user_15" role="maintainer"/>
         </project>
     headers:
       Accept-Encoding:
@@ -543,15 +504,210 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '135'
+      - '137'
     body:
       encoding: UTF-8
       string: |
-        <project name="home:user_8">
+        <project name="home:user_15">
           <title></title>
           <description></description>
-          <person userid="user_8" role="maintainer" />
+          <person userid="user_15" role="maintainer" />
         </project>
     http_version: 
-  recorded_at: Tue, 24 Jul 2018 08:06:18 GMT
+  recorded_at: Mon, 30 Jul 2018 19:12:10 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:user_16/_meta?user=user_16
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:user_16">
+          <title/>
+          <description/>
+          <person userid="user_16" role="maintainer"/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '137'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:user_16">
+          <title></title>
+          <description></description>
+          <person userid="user_16" role="maintainer" />
+        </project>
+    http_version: 
+  recorded_at: Mon, 30 Jul 2018 19:12:10 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:user_17/_meta?user=user_17
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:user_17">
+          <title/>
+          <description/>
+          <person userid="user_17" role="maintainer"/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '137'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:user_17">
+          <title></title>
+          <description></description>
+          <person userid="user_17" role="maintainer" />
+        </project>
+    http_version: 
+  recorded_at: Mon, 30 Jul 2018 19:12:11 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:user_18/_meta?user=user_18
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:user_18">
+          <title/>
+          <description/>
+          <person userid="user_18" role="maintainer"/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '137'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:user_18">
+          <title></title>
+          <description></description>
+          <person userid="user_18" role="maintainer" />
+        </project>
+    http_version: 
+  recorded_at: Mon, 30 Jul 2018 19:12:11 GMT
+- request:
+    method: get
+    uri: http://backend:5352/build/openSUSE:Factory:Staging:A/_result?package=Test-DVD-x86_64&repository=images&view=binarylist
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - text/plain
+      Accept-Encoding:
+      - identity
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 404
+      message: unknown repository 'images'
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '132'
+    body:
+      encoding: UTF-8
+      string: |
+        <status code="404">
+          <summary>unknown repository 'images'</summary>
+          <details>404 unknown repository 'images'</details>
+        </status>
+    http_version: 
+  recorded_at: Mon, 30 Jul 2018 19:12:11 GMT
+- request:
+    method: get
+    uri: http://backend:5352/build/openSUSE:Factory:Staging:A/_result?code=unresolvable
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - text/plain
+      Accept-Encoding:
+      - identity
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '56'
+    body:
+      encoding: UTF-8
+      string: '<resultlist state="00000000000000000000000000000000" />
+
+'
+    http_version: 
+  recorded_at: Mon, 30 Jul 2018 19:12:11 GMT
 recorded_with: VCR 4.0.0

--- a/src/api/spec/cassettes/Webui_ObsFactory_StagingProjectsController/GET_index/with_dashboard_package/with_ignored_requests_file/with_content/sets_up_the_required_variables.yml
+++ b/src/api/spec/cassettes/Webui_ObsFactory_StagingProjectsController/GET_index/with_dashboard_package/with_ignored_requests_file/with_content/sets_up_the_required_variables.yml
@@ -2,51 +2,12 @@
 http_interactions:
 - request:
     method: put
-    uri: http://backend:5352/source/openSUSE:Factory:Staging:A/_meta?user=_nobody_
-    body:
-      encoding: UTF-8
-      string: |
-        <project name="openSUSE:Factory:Staging:A">
-          <title>Terrible Swift Sword</title>
-          <description>Factory staging project A</description>
-        </project>
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '148'
-    body:
-      encoding: UTF-8
-      string: |
-        <project name="openSUSE:Factory:Staging:A">
-          <title>Terrible Swift Sword</title>
-          <description>Factory staging project A</description>
-        </project>
-    http_version: 
-  recorded_at: Tue, 24 Jul 2018 08:06:19 GMT
-- request:
-    method: put
     uri: http://backend:5352/source/openSUSE:Factory:Staging/_meta?user=_nobody_
     body:
       encoding: UTF-8
       string: |
         <project name="openSUSE:Factory:Staging">
-          <title>Consider Phlebas</title>
+          <title>The Stars' Tennis Balls</title>
           <description/>
         </project>
     headers:
@@ -68,94 +29,16 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '117'
+      - '124'
     body:
       encoding: UTF-8
       string: |
         <project name="openSUSE:Factory:Staging">
-          <title>Consider Phlebas</title>
+          <title>The Stars' Tennis Balls</title>
           <description></description>
         </project>
     http_version: 
-  recorded_at: Tue, 24 Jul 2018 08:06:19 GMT
-- request:
-    method: put
-    uri: http://backend:5352/source/openSUSE:Factory:Staging/dashboard/_meta?user=_nobody_
-    body:
-      encoding: UTF-8
-      string: |
-        <package name="dashboard" project="openSUSE:Factory:Staging">
-          <title>Pale Kings and Princes</title>
-          <description>Dolore ut occaecati et.</description>
-        </package>
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '166'
-    body:
-      encoding: UTF-8
-      string: |
-        <package name="dashboard" project="openSUSE:Factory:Staging">
-          <title>Pale Kings and Princes</title>
-          <description>Dolore ut occaecati et.</description>
-        </package>
-    http_version: 
-  recorded_at: Tue, 24 Jul 2018 08:06:19 GMT
-- request:
-    method: put
-    uri: http://backend:5352/source/openSUSE:Factory:Staging/dashboard/_meta?user=_nobody_
-    body:
-      encoding: UTF-8
-      string: |
-        <package name="dashboard" project="openSUSE:Factory:Staging">
-          <title>Pale Kings and Princes</title>
-          <description>Dolore ut occaecati et.</description>
-        </package>
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '166'
-    body:
-      encoding: UTF-8
-      string: |
-        <package name="dashboard" project="openSUSE:Factory:Staging">
-          <title>Pale Kings and Princes</title>
-          <description>Dolore ut occaecati et.</description>
-        </package>
-    http_version: 
-  recorded_at: Tue, 24 Jul 2018 08:06:19 GMT
+  recorded_at: Mon, 30 Jul 2018 19:12:12 GMT
 - request:
     method: put
     uri: http://backend:5352/source/openSUSE:Factory/_meta?user=_nobody_
@@ -163,7 +46,7 @@ http_interactions:
       encoding: UTF-8
       string: |
         <project name="openSUSE:Factory">
-          <title>Precious Bane</title>
+          <title>The Far-Distant Oxus</title>
           <description/>
         </project>
     headers:
@@ -185,16 +68,16 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '106'
+      - '113'
     body:
       encoding: UTF-8
       string: |
         <project name="openSUSE:Factory">
-          <title>Precious Bane</title>
+          <title>The Far-Distant Oxus</title>
           <description></description>
         </project>
     http_version: 
-  recorded_at: Tue, 24 Jul 2018 08:06:19 GMT
+  recorded_at: Mon, 30 Jul 2018 19:12:12 GMT
 - request:
     method: put
     uri: http://backend:5352/source/openSUSE:Factory/target_package/_meta?user=_nobody_
@@ -202,8 +85,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="target_package" project="openSUSE:Factory">
-          <title>The Yellow Meads of Asphodel</title>
-          <description>Architecto porro maxime unde.</description>
+          <title>The Lathe of Heaven</title>
+          <description>Asperiores quis perspiciatis reiciendis.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -224,16 +107,16 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '175'
+      - '177'
     body:
       encoding: UTF-8
       string: |
         <package name="target_package" project="openSUSE:Factory">
-          <title>The Yellow Meads of Asphodel</title>
-          <description>Architecto porro maxime unde.</description>
+          <title>The Lathe of Heaven</title>
+          <description>Asperiores quis perspiciatis reiciendis.</description>
         </package>
     http_version: 
-  recorded_at: Tue, 24 Jul 2018 08:06:19 GMT
+  recorded_at: Mon, 30 Jul 2018 19:12:12 GMT
 - request:
     method: put
     uri: http://backend:5352/source/openSUSE:Factory/target_package/_meta?user=_nobody_
@@ -241,8 +124,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="target_package" project="openSUSE:Factory">
-          <title>The Yellow Meads of Asphodel</title>
-          <description>Architecto porro maxime unde.</description>
+          <title>The Lathe of Heaven</title>
+          <description>Asperiores quis perspiciatis reiciendis.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -263,16 +146,16 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '175'
+      - '177'
     body:
       encoding: UTF-8
       string: |
         <package name="target_package" project="openSUSE:Factory">
-          <title>The Yellow Meads of Asphodel</title>
-          <description>Architecto porro maxime unde.</description>
+          <title>The Lathe of Heaven</title>
+          <description>Asperiores quis perspiciatis reiciendis.</description>
         </package>
     http_version: 
-  recorded_at: Tue, 24 Jul 2018 08:06:19 GMT
+  recorded_at: Mon, 30 Jul 2018 19:12:12 GMT
 - request:
     method: put
     uri: http://backend:5352/source/source_project/_meta?user=_nobody_
@@ -280,7 +163,7 @@ http_interactions:
       encoding: UTF-8
       string: |
         <project name="source_project">
-          <title>Ring of Bright Water</title>
+          <title>Rosemary Sutcliff</title>
           <description/>
         </project>
     headers:
@@ -302,16 +185,16 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '111'
+      - '108'
     body:
       encoding: UTF-8
       string: |
         <project name="source_project">
-          <title>Ring of Bright Water</title>
+          <title>Rosemary Sutcliff</title>
           <description></description>
         </project>
     http_version: 
-  recorded_at: Tue, 24 Jul 2018 08:06:19 GMT
+  recorded_at: Mon, 30 Jul 2018 19:12:12 GMT
 - request:
     method: put
     uri: http://backend:5352/source/source_project/source_package/_meta?user=_nobody_
@@ -319,8 +202,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="source_package" project="source_project">
-          <title>Now Sleeps the Crimson Petal</title>
-          <description>Est cumque iure nihil.</description>
+          <title>The Waste Land</title>
+          <description>Asperiores nostrum aut sit.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -341,16 +224,16 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '166'
+      - '157'
     body:
       encoding: UTF-8
       string: |
         <package name="source_package" project="source_project">
-          <title>Now Sleeps the Crimson Petal</title>
-          <description>Est cumque iure nihil.</description>
+          <title>The Waste Land</title>
+          <description>Asperiores nostrum aut sit.</description>
         </package>
     http_version: 
-  recorded_at: Tue, 24 Jul 2018 08:06:19 GMT
+  recorded_at: Mon, 30 Jul 2018 19:12:12 GMT
 - request:
     method: put
     uri: http://backend:5352/source/source_project/source_package/_meta?user=_nobody_
@@ -358,8 +241,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="source_package" project="source_project">
-          <title>Now Sleeps the Crimson Petal</title>
-          <description>Est cumque iure nihil.</description>
+          <title>The Waste Land</title>
+          <description>Asperiores nostrum aut sit.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -380,67 +263,26 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '166'
+      - '157'
     body:
       encoding: UTF-8
       string: |
         <package name="source_package" project="source_project">
-          <title>Now Sleeps the Crimson Petal</title>
-          <description>Est cumque iure nihil.</description>
+          <title>The Waste Land</title>
+          <description>Asperiores nostrum aut sit.</description>
         </package>
     http_version: 
-  recorded_at: Tue, 24 Jul 2018 08:06:19 GMT
+  recorded_at: Mon, 30 Jul 2018 19:12:12 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:user_9/_meta?user=user_9
+    uri: http://backend:5352/source/home:user_19/_meta?user=user_19
     body:
       encoding: UTF-8
       string: |
-        <project name="home:user_9">
+        <project name="home:user_19">
           <title/>
           <description/>
-          <person userid="user_9" role="maintainer"/>
-        </project>
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '135'
-    body:
-      encoding: UTF-8
-      string: |
-        <project name="home:user_9">
-          <title></title>
-          <description></description>
-          <person userid="user_9" role="maintainer" />
-        </project>
-    http_version: 
-  recorded_at: Tue, 24 Jul 2018 08:06:19 GMT
-- request:
-    method: put
-    uri: http://backend:5352/source/home:user_10/_meta?user=user_10
-    body:
-      encoding: UTF-8
-      string: |
-        <project name="home:user_10">
-          <title/>
-          <description/>
-          <person userid="user_10" role="maintainer"/>
+          <person userid="user_19" role="maintainer"/>
         </project>
     headers:
       Accept-Encoding:
@@ -465,23 +307,183 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <project name="home:user_10">
+        <project name="home:user_19">
           <title></title>
           <description></description>
-          <person userid="user_10" role="maintainer" />
+          <person userid="user_19" role="maintainer" />
         </project>
     http_version: 
-  recorded_at: Tue, 24 Jul 2018 08:06:19 GMT
+  recorded_at: Mon, 30 Jul 2018 19:12:12 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:user_11/_meta?user=user_11
+    uri: http://backend:5352/source/openSUSE:Factory:Staging:A/_meta?user=_nobody_
     body:
       encoding: UTF-8
       string: |
-        <project name="home:user_11">
+        <project name="openSUSE:Factory:Staging:A">
+          <title>The Heart Is a Lonely Hunter</title>
+          <description>      requests:
+                - { id: 1 }
+        </description>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '167'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="openSUSE:Factory:Staging:A">
+          <title>The Heart Is a Lonely Hunter</title>
+          <description>      requests:
+                - { id: 1 }
+        </description>
+        </project>
+    http_version: 
+  recorded_at: Mon, 30 Jul 2018 19:12:12 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/openSUSE:Factory:Staging:B/_meta?user=_nobody_
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="openSUSE:Factory:Staging:B">
+          <title>The Yellow Meads of Asphodel</title>
+          <description>Factory staging project B</description>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '156'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="openSUSE:Factory:Staging:B">
+          <title>The Yellow Meads of Asphodel</title>
+          <description>Factory staging project B</description>
+        </project>
+    http_version: 
+  recorded_at: Mon, 30 Jul 2018 19:12:12 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/openSUSE:Factory:Staging/dashboard/_meta?user=_nobody_
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="dashboard" project="openSUSE:Factory:Staging">
+          <title>Tender Is the Night</title>
+          <description>Iusto esse quidem fugit.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '164'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="dashboard" project="openSUSE:Factory:Staging">
+          <title>Tender Is the Night</title>
+          <description>Iusto esse quidem fugit.</description>
+        </package>
+    http_version: 
+  recorded_at: Mon, 30 Jul 2018 19:12:12 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/openSUSE:Factory:Staging/dashboard/_meta?user=_nobody_
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="dashboard" project="openSUSE:Factory:Staging">
+          <title>Tender Is the Night</title>
+          <description>Iusto esse quidem fugit.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '164'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="dashboard" project="openSUSE:Factory:Staging">
+          <title>Tender Is the Night</title>
+          <description>Iusto esse quidem fugit.</description>
+        </package>
+    http_version: 
+  recorded_at: Mon, 30 Jul 2018 19:12:12 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:user_20/_meta?user=user_20
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:user_20">
           <title/>
           <description/>
-          <person userid="user_11" role="maintainer"/>
+          <person userid="user_20" role="maintainer"/>
         </project>
     headers:
       Accept-Encoding:
@@ -506,23 +508,23 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <project name="home:user_11">
+        <project name="home:user_20">
           <title></title>
           <description></description>
-          <person userid="user_11" role="maintainer" />
+          <person userid="user_20" role="maintainer" />
         </project>
     http_version: 
-  recorded_at: Tue, 24 Jul 2018 08:06:20 GMT
+  recorded_at: Mon, 30 Jul 2018 19:12:13 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:user_12/_meta?user=user_12
+    uri: http://backend:5352/source/home:user_21/_meta?user=user_21
     body:
       encoding: UTF-8
       string: |
-        <project name="home:user_12">
+        <project name="home:user_21">
           <title/>
           <description/>
-          <person userid="user_12" role="maintainer"/>
+          <person userid="user_21" role="maintainer"/>
         </project>
     headers:
       Accept-Encoding:
@@ -547,11 +549,165 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <project name="home:user_12">
+        <project name="home:user_21">
           <title></title>
           <description></description>
-          <person userid="user_12" role="maintainer" />
+          <person userid="user_21" role="maintainer" />
         </project>
     http_version: 
-  recorded_at: Tue, 24 Jul 2018 08:06:20 GMT
+  recorded_at: Mon, 30 Jul 2018 19:12:13 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:user_22/_meta?user=user_22
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:user_22">
+          <title/>
+          <description/>
+          <person userid="user_22" role="maintainer"/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '137'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:user_22">
+          <title></title>
+          <description></description>
+          <person userid="user_22" role="maintainer" />
+        </project>
+    http_version: 
+  recorded_at: Mon, 30 Jul 2018 19:12:13 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:user_23/_meta?user=user_23
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:user_23">
+          <title/>
+          <description/>
+          <person userid="user_23" role="maintainer"/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '137'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:user_23">
+          <title></title>
+          <description></description>
+          <person userid="user_23" role="maintainer" />
+        </project>
+    http_version: 
+  recorded_at: Mon, 30 Jul 2018 19:12:14 GMT
+- request:
+    method: get
+    uri: http://backend:5352/build/openSUSE:Factory:Staging:A/_result?package=Test-DVD-x86_64&repository=images&view=binarylist
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - text/plain
+      Accept-Encoding:
+      - identity
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 404
+      message: unknown repository 'images'
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '132'
+    body:
+      encoding: UTF-8
+      string: |
+        <status code="404">
+          <summary>unknown repository 'images'</summary>
+          <details>404 unknown repository 'images'</details>
+        </status>
+    http_version: 
+  recorded_at: Mon, 30 Jul 2018 19:12:14 GMT
+- request:
+    method: get
+    uri: http://backend:5352/build/openSUSE:Factory:Staging:A/_result?code=unresolvable
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - text/plain
+      Accept-Encoding:
+      - identity
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '56'
+    body:
+      encoding: UTF-8
+      string: '<resultlist state="00000000000000000000000000000000" />
+
+'
+    http_version: 
+  recorded_at: Mon, 30 Jul 2018 19:12:14 GMT
 recorded_with: VCR 4.0.0

--- a/src/api/spec/cassettes/Webui_ObsFactory_StagingProjectsController/GET_index/with_dashboard_package/with_ignored_requests_file/without_content/1_1_2_1_2_1.yml
+++ b/src/api/spec/cassettes/Webui_ObsFactory_StagingProjectsController/GET_index/with_dashboard_package/with_ignored_requests_file/without_content/1_1_2_1_2_1.yml
@@ -2,51 +2,12 @@
 http_interactions:
 - request:
     method: put
-    uri: http://backend:5352/source/openSUSE:Factory:Staging:A/_meta?user=_nobody_
-    body:
-      encoding: UTF-8
-      string: |
-        <project name="openSUSE:Factory:Staging:A">
-          <title>Brandy of the Damned</title>
-          <description>Factory staging project A</description>
-        </project>
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '148'
-    body:
-      encoding: UTF-8
-      string: |
-        <project name="openSUSE:Factory:Staging:A">
-          <title>Brandy of the Damned</title>
-          <description>Factory staging project A</description>
-        </project>
-    http_version: 
-  recorded_at: Tue, 24 Jul 2018 08:06:21 GMT
-- request:
-    method: put
     uri: http://backend:5352/source/openSUSE:Factory:Staging/_meta?user=_nobody_
     body:
       encoding: UTF-8
       string: |
         <project name="openSUSE:Factory:Staging">
-          <title>The Road Less Traveled</title>
+          <title>I Will Fear No Evil</title>
           <description/>
         </project>
     headers:
@@ -68,94 +29,16 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '123'
+      - '120'
     body:
       encoding: UTF-8
       string: |
         <project name="openSUSE:Factory:Staging">
-          <title>The Road Less Traveled</title>
+          <title>I Will Fear No Evil</title>
           <description></description>
         </project>
     http_version: 
-  recorded_at: Tue, 24 Jul 2018 08:06:21 GMT
-- request:
-    method: put
-    uri: http://backend:5352/source/openSUSE:Factory:Staging/dashboard/_meta?user=_nobody_
-    body:
-      encoding: UTF-8
-      string: |
-        <package name="dashboard" project="openSUSE:Factory:Staging">
-          <title>No Longer at Ease</title>
-          <description>Quaerat et explicabo itaque.</description>
-        </package>
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '166'
-    body:
-      encoding: UTF-8
-      string: |
-        <package name="dashboard" project="openSUSE:Factory:Staging">
-          <title>No Longer at Ease</title>
-          <description>Quaerat et explicabo itaque.</description>
-        </package>
-    http_version: 
-  recorded_at: Tue, 24 Jul 2018 08:06:21 GMT
-- request:
-    method: put
-    uri: http://backend:5352/source/openSUSE:Factory:Staging/dashboard/_meta?user=_nobody_
-    body:
-      encoding: UTF-8
-      string: |
-        <package name="dashboard" project="openSUSE:Factory:Staging">
-          <title>No Longer at Ease</title>
-          <description>Quaerat et explicabo itaque.</description>
-        </package>
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '166'
-    body:
-      encoding: UTF-8
-      string: |
-        <package name="dashboard" project="openSUSE:Factory:Staging">
-          <title>No Longer at Ease</title>
-          <description>Quaerat et explicabo itaque.</description>
-        </package>
-    http_version: 
-  recorded_at: Tue, 24 Jul 2018 08:06:21 GMT
+  recorded_at: Mon, 30 Jul 2018 19:12:03 GMT
 - request:
     method: put
     uri: http://backend:5352/source/openSUSE:Factory/_meta?user=_nobody_
@@ -163,7 +46,7 @@ http_interactions:
       encoding: UTF-8
       string: |
         <project name="openSUSE:Factory">
-          <title>Taming a Sea Horse</title>
+          <title>Specimen Days</title>
           <description/>
         </project>
     headers:
@@ -185,14 +68,482 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '111'
+      - '106'
     body:
       encoding: UTF-8
       string: |
         <project name="openSUSE:Factory">
-          <title>Taming a Sea Horse</title>
+          <title>Specimen Days</title>
           <description></description>
         </project>
     http_version: 
-  recorded_at: Tue, 24 Jul 2018 08:06:21 GMT
+  recorded_at: Mon, 30 Jul 2018 19:12:03 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/openSUSE:Factory/target_package/_meta?user=_nobody_
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="target_package" project="openSUSE:Factory">
+          <title>Specimen Days</title>
+          <description>Qui ut adipisci nesciunt.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '156'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="target_package" project="openSUSE:Factory">
+          <title>Specimen Days</title>
+          <description>Qui ut adipisci nesciunt.</description>
+        </package>
+    http_version: 
+  recorded_at: Mon, 30 Jul 2018 19:12:03 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/openSUSE:Factory/target_package/_meta?user=_nobody_
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="target_package" project="openSUSE:Factory">
+          <title>Specimen Days</title>
+          <description>Qui ut adipisci nesciunt.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '156'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="target_package" project="openSUSE:Factory">
+          <title>Specimen Days</title>
+          <description>Qui ut adipisci nesciunt.</description>
+        </package>
+    http_version: 
+  recorded_at: Mon, 30 Jul 2018 19:12:03 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/project_6/_meta?user=_nobody_
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="project_6">
+          <title>Such, Such Were the Joys</title>
+          <description/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '110'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="project_6">
+          <title>Such, Such Were the Joys</title>
+          <description></description>
+        </project>
+    http_version: 
+  recorded_at: Mon, 30 Jul 2018 19:12:03 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/project_6/package_6/_meta?user=_nobody_
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="package_6" project="project_6">
+          <title>The Moving Toyshop</title>
+          <description>Quasi harum veniam et.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '146'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="package_6" project="project_6">
+          <title>The Moving Toyshop</title>
+          <description>Quasi harum veniam et.</description>
+        </package>
+    http_version: 
+  recorded_at: Mon, 30 Jul 2018 19:12:03 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/project_6/package_6/_meta?user=_nobody_
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="package_6" project="project_6">
+          <title>The Moving Toyshop</title>
+          <description>Quasi harum veniam et.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '146'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="package_6" project="project_6">
+          <title>The Moving Toyshop</title>
+          <description>Quasi harum veniam et.</description>
+        </package>
+    http_version: 
+  recorded_at: Mon, 30 Jul 2018 19:12:03 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:user_6/_meta?user=user_6
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:user_6">
+          <title/>
+          <description/>
+          <person userid="user_6" role="maintainer"/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '135'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:user_6">
+          <title></title>
+          <description></description>
+          <person userid="user_6" role="maintainer" />
+        </project>
+    http_version: 
+  recorded_at: Mon, 30 Jul 2018 19:12:03 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/openSUSE:Factory:Staging:A/_meta?user=_nobody_
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="openSUSE:Factory:Staging:A">
+          <title>The Last Enemy</title>
+          <description>      requests:
+                - { id: 1 }
+        </description>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '153'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="openSUSE:Factory:Staging:A">
+          <title>The Last Enemy</title>
+          <description>      requests:
+                - { id: 1 }
+        </description>
+        </project>
+    http_version: 
+  recorded_at: Mon, 30 Jul 2018 19:12:03 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/openSUSE:Factory:Staging:B/_meta?user=_nobody_
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="openSUSE:Factory:Staging:B">
+          <title>Gone with the Wind</title>
+          <description>Factory staging project B</description>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '146'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="openSUSE:Factory:Staging:B">
+          <title>Gone with the Wind</title>
+          <description>Factory staging project B</description>
+        </project>
+    http_version: 
+  recorded_at: Mon, 30 Jul 2018 19:12:03 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/openSUSE:Factory:Staging/dashboard/_meta?user=_nobody_
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="dashboard" project="openSUSE:Factory:Staging">
+          <title>A Swiftly Tilting Planet</title>
+          <description>At molestiae et nam.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '165'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="dashboard" project="openSUSE:Factory:Staging">
+          <title>A Swiftly Tilting Planet</title>
+          <description>At molestiae et nam.</description>
+        </package>
+    http_version: 
+  recorded_at: Mon, 30 Jul 2018 19:12:04 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/openSUSE:Factory:Staging/dashboard/_meta?user=_nobody_
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="dashboard" project="openSUSE:Factory:Staging">
+          <title>A Swiftly Tilting Planet</title>
+          <description>At molestiae et nam.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '165'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="dashboard" project="openSUSE:Factory:Staging">
+          <title>A Swiftly Tilting Planet</title>
+          <description>At molestiae et nam.</description>
+        </package>
+    http_version: 
+  recorded_at: Mon, 30 Jul 2018 19:12:04 GMT
+- request:
+    method: get
+    uri: http://backend:5352/build/openSUSE:Factory:Staging:A/_result?package=Test-DVD-x86_64&repository=images&view=binarylist
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - text/plain
+      Accept-Encoding:
+      - identity
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 404
+      message: unknown repository 'images'
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '132'
+    body:
+      encoding: UTF-8
+      string: |
+        <status code="404">
+          <summary>unknown repository 'images'</summary>
+          <details>404 unknown repository 'images'</details>
+        </status>
+    http_version: 
+  recorded_at: Mon, 30 Jul 2018 19:12:04 GMT
+- request:
+    method: get
+    uri: http://backend:5352/build/openSUSE:Factory:Staging:A/_result?code=unresolvable
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - text/plain
+      Accept-Encoding:
+      - identity
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '56'
+    body:
+      encoding: UTF-8
+      string: '<resultlist state="00000000000000000000000000000000" />
+
+'
+    http_version: 
+  recorded_at: Mon, 30 Jul 2018 19:12:04 GMT
 recorded_with: VCR 4.0.0

--- a/src/api/spec/cassettes/Webui_ObsFactory_StagingProjectsController/GET_index/with_dashboard_package/with_ignored_requests_file/without_content/1_1_2_1_2_2.yml
+++ b/src/api/spec/cassettes/Webui_ObsFactory_StagingProjectsController/GET_index/with_dashboard_package/with_ignored_requests_file/without_content/1_1_2_1_2_2.yml
@@ -2,51 +2,12 @@
 http_interactions:
 - request:
     method: put
-    uri: http://backend:5352/source/openSUSE:Factory:Staging:A/_meta?user=_nobody_
-    body:
-      encoding: UTF-8
-      string: |
-        <project name="openSUSE:Factory:Staging:A">
-          <title>Time To Murder And Create</title>
-          <description>Factory staging project A</description>
-        </project>
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '153'
-    body:
-      encoding: UTF-8
-      string: |
-        <project name="openSUSE:Factory:Staging:A">
-          <title>Time To Murder And Create</title>
-          <description>Factory staging project A</description>
-        </project>
-    http_version: 
-  recorded_at: Tue, 24 Jul 2018 08:06:21 GMT
-- request:
-    method: put
     uri: http://backend:5352/source/openSUSE:Factory:Staging/_meta?user=_nobody_
     body:
       encoding: UTF-8
       string: |
         <project name="openSUSE:Factory:Staging">
-          <title>Great Work of Time</title>
+          <title>That Good Night</title>
           <description/>
         </project>
     headers:
@@ -68,94 +29,16 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '119'
+      - '116'
     body:
       encoding: UTF-8
       string: |
         <project name="openSUSE:Factory:Staging">
-          <title>Great Work of Time</title>
+          <title>That Good Night</title>
           <description></description>
         </project>
     http_version: 
-  recorded_at: Tue, 24 Jul 2018 08:06:21 GMT
-- request:
-    method: put
-    uri: http://backend:5352/source/openSUSE:Factory:Staging/dashboard/_meta?user=_nobody_
-    body:
-      encoding: UTF-8
-      string: |
-        <package name="dashboard" project="openSUSE:Factory:Staging">
-          <title>Jacob Have I Loved</title>
-          <description>Occaecati recusandae repudiandae quibusdam.</description>
-        </package>
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '182'
-    body:
-      encoding: UTF-8
-      string: |
-        <package name="dashboard" project="openSUSE:Factory:Staging">
-          <title>Jacob Have I Loved</title>
-          <description>Occaecati recusandae repudiandae quibusdam.</description>
-        </package>
-    http_version: 
-  recorded_at: Tue, 24 Jul 2018 08:06:21 GMT
-- request:
-    method: put
-    uri: http://backend:5352/source/openSUSE:Factory:Staging/dashboard/_meta?user=_nobody_
-    body:
-      encoding: UTF-8
-      string: |
-        <package name="dashboard" project="openSUSE:Factory:Staging">
-          <title>Jacob Have I Loved</title>
-          <description>Occaecati recusandae repudiandae quibusdam.</description>
-        </package>
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '182'
-    body:
-      encoding: UTF-8
-      string: |
-        <package name="dashboard" project="openSUSE:Factory:Staging">
-          <title>Jacob Have I Loved</title>
-          <description>Occaecati recusandae repudiandae quibusdam.</description>
-        </package>
-    http_version: 
-  recorded_at: Tue, 24 Jul 2018 08:06:21 GMT
+  recorded_at: Mon, 30 Jul 2018 19:12:04 GMT
 - request:
     method: put
     uri: http://backend:5352/source/openSUSE:Factory/_meta?user=_nobody_
@@ -163,7 +46,7 @@ http_interactions:
       encoding: UTF-8
       string: |
         <project name="openSUSE:Factory">
-          <title>Time To Murder And Create</title>
+          <title>Dying of the Light</title>
           <description/>
         </project>
     headers:
@@ -185,14 +68,482 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '118'
+      - '111'
     body:
       encoding: UTF-8
       string: |
         <project name="openSUSE:Factory">
-          <title>Time To Murder And Create</title>
+          <title>Dying of the Light</title>
           <description></description>
         </project>
     http_version: 
-  recorded_at: Tue, 24 Jul 2018 08:06:21 GMT
+  recorded_at: Mon, 30 Jul 2018 19:12:04 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/openSUSE:Factory/target_package/_meta?user=_nobody_
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="target_package" project="openSUSE:Factory">
+          <title>The Proper Study</title>
+          <description>Ea nihil enim et.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '151'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="target_package" project="openSUSE:Factory">
+          <title>The Proper Study</title>
+          <description>Ea nihil enim et.</description>
+        </package>
+    http_version: 
+  recorded_at: Mon, 30 Jul 2018 19:12:04 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/openSUSE:Factory/target_package/_meta?user=_nobody_
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="target_package" project="openSUSE:Factory">
+          <title>The Proper Study</title>
+          <description>Ea nihil enim et.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '151'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="target_package" project="openSUSE:Factory">
+          <title>The Proper Study</title>
+          <description>Ea nihil enim et.</description>
+        </package>
+    http_version: 
+  recorded_at: Mon, 30 Jul 2018 19:12:04 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/project_7/_meta?user=_nobody_
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="project_7">
+          <title>The Skull Beneath the Skin</title>
+          <description/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '112'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="project_7">
+          <title>The Skull Beneath the Skin</title>
+          <description></description>
+        </project>
+    http_version: 
+  recorded_at: Mon, 30 Jul 2018 19:12:04 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/project_7/package_7/_meta?user=_nobody_
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="package_7" project="project_7">
+          <title>An Evil Cradling</title>
+          <description>Modi exercitationem quae enim.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '152'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="package_7" project="project_7">
+          <title>An Evil Cradling</title>
+          <description>Modi exercitationem quae enim.</description>
+        </package>
+    http_version: 
+  recorded_at: Mon, 30 Jul 2018 19:12:04 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/project_7/package_7/_meta?user=_nobody_
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="package_7" project="project_7">
+          <title>An Evil Cradling</title>
+          <description>Modi exercitationem quae enim.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '152'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="package_7" project="project_7">
+          <title>An Evil Cradling</title>
+          <description>Modi exercitationem quae enim.</description>
+        </package>
+    http_version: 
+  recorded_at: Mon, 30 Jul 2018 19:12:04 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:user_7/_meta?user=user_7
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:user_7">
+          <title/>
+          <description/>
+          <person userid="user_7" role="maintainer"/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '135'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:user_7">
+          <title></title>
+          <description></description>
+          <person userid="user_7" role="maintainer" />
+        </project>
+    http_version: 
+  recorded_at: Mon, 30 Jul 2018 19:12:04 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/openSUSE:Factory:Staging:A/_meta?user=_nobody_
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="openSUSE:Factory:Staging:A">
+          <title>A Many-Splendoured Thing</title>
+          <description>      requests:
+                - { id: 1 }
+        </description>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '163'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="openSUSE:Factory:Staging:A">
+          <title>A Many-Splendoured Thing</title>
+          <description>      requests:
+                - { id: 1 }
+        </description>
+        </project>
+    http_version: 
+  recorded_at: Mon, 30 Jul 2018 19:12:05 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/openSUSE:Factory:Staging:B/_meta?user=_nobody_
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="openSUSE:Factory:Staging:B">
+          <title>An Acceptable Time</title>
+          <description>Factory staging project B</description>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '146'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="openSUSE:Factory:Staging:B">
+          <title>An Acceptable Time</title>
+          <description>Factory staging project B</description>
+        </project>
+    http_version: 
+  recorded_at: Mon, 30 Jul 2018 19:12:05 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/openSUSE:Factory:Staging/dashboard/_meta?user=_nobody_
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="dashboard" project="openSUSE:Factory:Staging">
+          <title>The Cricket on the Hearth</title>
+          <description>Assumenda dolorem hic error.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '174'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="dashboard" project="openSUSE:Factory:Staging">
+          <title>The Cricket on the Hearth</title>
+          <description>Assumenda dolorem hic error.</description>
+        </package>
+    http_version: 
+  recorded_at: Mon, 30 Jul 2018 19:12:05 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/openSUSE:Factory:Staging/dashboard/_meta?user=_nobody_
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="dashboard" project="openSUSE:Factory:Staging">
+          <title>The Cricket on the Hearth</title>
+          <description>Assumenda dolorem hic error.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '174'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="dashboard" project="openSUSE:Factory:Staging">
+          <title>The Cricket on the Hearth</title>
+          <description>Assumenda dolorem hic error.</description>
+        </package>
+    http_version: 
+  recorded_at: Mon, 30 Jul 2018 19:12:05 GMT
+- request:
+    method: get
+    uri: http://backend:5352/build/openSUSE:Factory:Staging:A/_result?package=Test-DVD-x86_64&repository=images&view=binarylist
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - text/plain
+      Accept-Encoding:
+      - identity
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 404
+      message: unknown repository 'images'
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '132'
+    body:
+      encoding: UTF-8
+      string: |
+        <status code="404">
+          <summary>unknown repository 'images'</summary>
+          <details>404 unknown repository 'images'</details>
+        </status>
+    http_version: 
+  recorded_at: Mon, 30 Jul 2018 19:12:05 GMT
+- request:
+    method: get
+    uri: http://backend:5352/build/openSUSE:Factory:Staging:A/_result?code=unresolvable
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - text/plain
+      Accept-Encoding:
+      - identity
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '56'
+    body:
+      encoding: UTF-8
+      string: '<resultlist state="00000000000000000000000000000000" />
+
+'
+    http_version: 
+  recorded_at: Mon, 30 Jul 2018 19:12:05 GMT
 recorded_with: VCR 4.0.0

--- a/src/api/spec/cassettes/Webui_ObsFactory_StagingProjectsController/GET_index/with_dashboard_package/with_ignored_requests_file/without_content/sets_up_the_required_variables.yml
+++ b/src/api/spec/cassettes/Webui_ObsFactory_StagingProjectsController/GET_index/with_dashboard_package/with_ignored_requests_file/without_content/sets_up_the_required_variables.yml
@@ -2,51 +2,12 @@
 http_interactions:
 - request:
     method: put
-    uri: http://backend:5352/source/openSUSE:Factory:Staging:A/_meta?user=_nobody_
-    body:
-      encoding: UTF-8
-      string: |
-        <project name="openSUSE:Factory:Staging:A">
-          <title>When the Green Woods Laugh</title>
-          <description>Factory staging project A</description>
-        </project>
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '154'
-    body:
-      encoding: UTF-8
-      string: |
-        <project name="openSUSE:Factory:Staging:A">
-          <title>When the Green Woods Laugh</title>
-          <description>Factory staging project A</description>
-        </project>
-    http_version: 
-  recorded_at: Tue, 24 Jul 2018 08:06:20 GMT
-- request:
-    method: put
     uri: http://backend:5352/source/openSUSE:Factory:Staging/_meta?user=_nobody_
     body:
       encoding: UTF-8
       string: |
         <project name="openSUSE:Factory:Staging">
-          <title>The Golden Apples of the Sun</title>
+          <title>The Stars' Tennis Balls</title>
           <description/>
         </project>
     headers:
@@ -68,94 +29,16 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '129'
+      - '124'
     body:
       encoding: UTF-8
       string: |
         <project name="openSUSE:Factory:Staging">
-          <title>The Golden Apples of the Sun</title>
+          <title>The Stars' Tennis Balls</title>
           <description></description>
         </project>
     http_version: 
-  recorded_at: Tue, 24 Jul 2018 08:06:20 GMT
-- request:
-    method: put
-    uri: http://backend:5352/source/openSUSE:Factory:Staging/dashboard/_meta?user=_nobody_
-    body:
-      encoding: UTF-8
-      string: |
-        <package name="dashboard" project="openSUSE:Factory:Staging">
-          <title>In a Glass Darkly</title>
-          <description>Dignissimos nisi officiis voluptatem.</description>
-        </package>
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '175'
-    body:
-      encoding: UTF-8
-      string: |
-        <package name="dashboard" project="openSUSE:Factory:Staging">
-          <title>In a Glass Darkly</title>
-          <description>Dignissimos nisi officiis voluptatem.</description>
-        </package>
-    http_version: 
-  recorded_at: Tue, 24 Jul 2018 08:06:20 GMT
-- request:
-    method: put
-    uri: http://backend:5352/source/openSUSE:Factory:Staging/dashboard/_meta?user=_nobody_
-    body:
-      encoding: UTF-8
-      string: |
-        <package name="dashboard" project="openSUSE:Factory:Staging">
-          <title>In a Glass Darkly</title>
-          <description>Dignissimos nisi officiis voluptatem.</description>
-        </package>
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '175'
-    body:
-      encoding: UTF-8
-      string: |
-        <package name="dashboard" project="openSUSE:Factory:Staging">
-          <title>In a Glass Darkly</title>
-          <description>Dignissimos nisi officiis voluptatem.</description>
-        </package>
-    http_version: 
-  recorded_at: Tue, 24 Jul 2018 08:06:20 GMT
+  recorded_at: Mon, 30 Jul 2018 19:12:05 GMT
 - request:
     method: put
     uri: http://backend:5352/source/openSUSE:Factory/_meta?user=_nobody_
@@ -163,7 +46,7 @@ http_interactions:
       encoding: UTF-8
       string: |
         <project name="openSUSE:Factory">
-          <title>Surprised by Joy</title>
+          <title>A Summer Bird-Cage</title>
           <description/>
         </project>
     headers:
@@ -185,14 +68,476 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '109'
+      - '111'
     body:
       encoding: UTF-8
       string: |
         <project name="openSUSE:Factory">
-          <title>Surprised by Joy</title>
+          <title>A Summer Bird-Cage</title>
           <description></description>
         </project>
     http_version: 
-  recorded_at: Tue, 24 Jul 2018 08:06:20 GMT
+  recorded_at: Mon, 30 Jul 2018 19:12:05 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/openSUSE:Factory/target_package/_meta?user=_nobody_
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="target_package" project="openSUSE:Factory">
+          <title>Mr Standfast</title>
+          <description>Eum aliquam quia aliquid.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '155'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="target_package" project="openSUSE:Factory">
+          <title>Mr Standfast</title>
+          <description>Eum aliquam quia aliquid.</description>
+        </package>
+    http_version: 
+  recorded_at: Mon, 30 Jul 2018 19:12:05 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/openSUSE:Factory/target_package/_meta?user=_nobody_
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="target_package" project="openSUSE:Factory">
+          <title>Mr Standfast</title>
+          <description>Eum aliquam quia aliquid.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '155'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="target_package" project="openSUSE:Factory">
+          <title>Mr Standfast</title>
+          <description>Eum aliquam quia aliquid.</description>
+        </package>
+    http_version: 
+  recorded_at: Mon, 30 Jul 2018 19:12:05 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/project_8/_meta?user=_nobody_
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="project_8">
+          <title>An Evil Cradling</title>
+          <description/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '102'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="project_8">
+          <title>An Evil Cradling</title>
+          <description></description>
+        </project>
+    http_version: 
+  recorded_at: Mon, 30 Jul 2018 19:12:05 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/project_8/package_8/_meta?user=_nobody_
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="package_8" project="project_8">
+          <title>Françoise Sagan</title>
+          <description>Necessitatibus voluptatem eum saepe.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '158'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        PHBhY2thZ2UgbmFtZT0icGFja2FnZV84IiBwcm9qZWN0PSJwcm9qZWN0XzgiPgogIDx0aXRsZT5GcmFuw6dvaXNlIFNhZ2FuPC90aXRsZT4KICA8ZGVzY3JpcHRpb24+TmVjZXNzaXRhdGlidXMgdm9sdXB0YXRlbSBldW0gc2FlcGUuPC9kZXNjcmlwdGlvbj4KPC9wYWNrYWdlPgo=
+    http_version: 
+  recorded_at: Mon, 30 Jul 2018 19:12:05 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/project_8/package_8/_meta?user=_nobody_
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="package_8" project="project_8">
+          <title>Françoise Sagan</title>
+          <description>Necessitatibus voluptatem eum saepe.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '158'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        PHBhY2thZ2UgbmFtZT0icGFja2FnZV84IiBwcm9qZWN0PSJwcm9qZWN0XzgiPgogIDx0aXRsZT5GcmFuw6dvaXNlIFNhZ2FuPC90aXRsZT4KICA8ZGVzY3JpcHRpb24+TmVjZXNzaXRhdGlidXMgdm9sdXB0YXRlbSBldW0gc2FlcGUuPC9kZXNjcmlwdGlvbj4KPC9wYWNrYWdlPgo=
+    http_version: 
+  recorded_at: Mon, 30 Jul 2018 19:12:05 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:user_8/_meta?user=user_8
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:user_8">
+          <title/>
+          <description/>
+          <person userid="user_8" role="maintainer"/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '135'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:user_8">
+          <title></title>
+          <description></description>
+          <person userid="user_8" role="maintainer" />
+        </project>
+    http_version: 
+  recorded_at: Mon, 30 Jul 2018 19:12:06 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/openSUSE:Factory:Staging:A/_meta?user=_nobody_
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="openSUSE:Factory:Staging:A">
+          <title>The Painted Veil</title>
+          <description>      requests:
+                - { id: 1 }
+        </description>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '155'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="openSUSE:Factory:Staging:A">
+          <title>The Painted Veil</title>
+          <description>      requests:
+                - { id: 1 }
+        </description>
+        </project>
+    http_version: 
+  recorded_at: Mon, 30 Jul 2018 19:12:06 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/openSUSE:Factory:Staging:B/_meta?user=_nobody_
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="openSUSE:Factory:Staging:B">
+          <title>Those Barren Leaves, Thrones, Dominations</title>
+          <description>Factory staging project B</description>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '169'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="openSUSE:Factory:Staging:B">
+          <title>Those Barren Leaves, Thrones, Dominations</title>
+          <description>Factory staging project B</description>
+        </project>
+    http_version: 
+  recorded_at: Mon, 30 Jul 2018 19:12:06 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/openSUSE:Factory:Staging/dashboard/_meta?user=_nobody_
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="dashboard" project="openSUSE:Factory:Staging">
+          <title>An Acceptable Time</title>
+          <description>Vero et dolore et.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '157'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="dashboard" project="openSUSE:Factory:Staging">
+          <title>An Acceptable Time</title>
+          <description>Vero et dolore et.</description>
+        </package>
+    http_version: 
+  recorded_at: Mon, 30 Jul 2018 19:12:06 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/openSUSE:Factory:Staging/dashboard/_meta?user=_nobody_
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="dashboard" project="openSUSE:Factory:Staging">
+          <title>An Acceptable Time</title>
+          <description>Vero et dolore et.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '157'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="dashboard" project="openSUSE:Factory:Staging">
+          <title>An Acceptable Time</title>
+          <description>Vero et dolore et.</description>
+        </package>
+    http_version: 
+  recorded_at: Mon, 30 Jul 2018 19:12:06 GMT
+- request:
+    method: get
+    uri: http://backend:5352/build/openSUSE:Factory:Staging:A/_result?package=Test-DVD-x86_64&repository=images&view=binarylist
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - text/plain
+      Accept-Encoding:
+      - identity
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 404
+      message: unknown repository 'images'
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '132'
+    body:
+      encoding: UTF-8
+      string: |
+        <status code="404">
+          <summary>unknown repository 'images'</summary>
+          <details>404 unknown repository 'images'</details>
+        </status>
+    http_version: 
+  recorded_at: Mon, 30 Jul 2018 19:12:06 GMT
+- request:
+    method: get
+    uri: http://backend:5352/build/openSUSE:Factory:Staging:A/_result?code=unresolvable
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - text/plain
+      Accept-Encoding:
+      - identity
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '56'
+    body:
+      encoding: UTF-8
+      string: '<resultlist state="00000000000000000000000000000000" />
+
+'
+    http_version: 
+  recorded_at: Mon, 30 Jul 2018 19:12:06 GMT
 recorded_with: VCR 4.0.0

--- a/src/api/spec/cassettes/Webui_ObsFactory_StagingProjectsController/GET_index/without_dashboard_package/1_1_1_1.yml
+++ b/src/api/spec/cassettes/Webui_ObsFactory_StagingProjectsController/GET_index/without_dashboard_package/1_1_1_1.yml
@@ -2,51 +2,12 @@
 http_interactions:
 - request:
     method: put
-    uri: http://backend:5352/source/openSUSE:Factory:Staging:A/_meta?user=_nobody_
-    body:
-      encoding: UTF-8
-      string: |
-        <project name="openSUSE:Factory:Staging:A">
-          <title>I Will Fear No Evil</title>
-          <description>Factory staging project A</description>
-        </project>
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '147'
-    body:
-      encoding: UTF-8
-      string: |
-        <project name="openSUSE:Factory:Staging:A">
-          <title>I Will Fear No Evil</title>
-          <description>Factory staging project A</description>
-        </project>
-    http_version: 
-  recorded_at: Tue, 24 Jul 2018 08:06:22 GMT
-- request:
-    method: put
     uri: http://backend:5352/source/openSUSE:Factory:Staging/_meta?user=_nobody_
     body:
       encoding: UTF-8
       string: |
         <project name="openSUSE:Factory:Staging">
-          <title>Consider the Lilies</title>
+          <title>East of Eden</title>
           <description/>
         </project>
     headers:
@@ -68,16 +29,16 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '120'
+      - '113'
     body:
       encoding: UTF-8
       string: |
         <project name="openSUSE:Factory:Staging">
-          <title>Consider the Lilies</title>
+          <title>East of Eden</title>
           <description></description>
         </project>
     http_version: 
-  recorded_at: Tue, 24 Jul 2018 08:06:22 GMT
+  recorded_at: Mon, 30 Jul 2018 19:11:56 GMT
 - request:
     method: put
     uri: http://backend:5352/source/openSUSE:Factory/_meta?user=_nobody_
@@ -85,7 +46,7 @@ http_interactions:
       encoding: UTF-8
       string: |
         <project name="openSUSE:Factory">
-          <title>The Moving Finger</title>
+          <title>Blue Remembered Earth</title>
           <description/>
         </project>
     headers:
@@ -107,14 +68,404 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '110'
+      - '114'
     body:
       encoding: UTF-8
       string: |
         <project name="openSUSE:Factory">
-          <title>The Moving Finger</title>
+          <title>Blue Remembered Earth</title>
           <description></description>
         </project>
     http_version: 
-  recorded_at: Tue, 24 Jul 2018 08:06:22 GMT
+  recorded_at: Mon, 30 Jul 2018 19:11:56 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/openSUSE:Factory/target_package/_meta?user=_nobody_
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="target_package" project="openSUSE:Factory">
+          <title>A Time to Kill</title>
+          <description>Rerum doloribus dolore ea.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '158'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="target_package" project="openSUSE:Factory">
+          <title>A Time to Kill</title>
+          <description>Rerum doloribus dolore ea.</description>
+        </package>
+    http_version: 
+  recorded_at: Mon, 30 Jul 2018 19:11:56 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/openSUSE:Factory/target_package/_meta?user=_nobody_
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="target_package" project="openSUSE:Factory">
+          <title>A Time to Kill</title>
+          <description>Rerum doloribus dolore ea.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '158'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="target_package" project="openSUSE:Factory">
+          <title>A Time to Kill</title>
+          <description>Rerum doloribus dolore ea.</description>
+        </package>
+    http_version: 
+  recorded_at: Mon, 30 Jul 2018 19:11:56 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/project_1/_meta?user=_nobody_
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="project_1">
+          <title>Quo Vadis</title>
+          <description/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '95'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="project_1">
+          <title>Quo Vadis</title>
+          <description></description>
+        </project>
+    http_version: 
+  recorded_at: Mon, 30 Jul 2018 19:11:56 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/project_1/package_1/_meta?user=_nobody_
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="package_1" project="project_1">
+          <title>The Moving Finger</title>
+          <description>Corrupti quis veniam sit.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '148'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="package_1" project="project_1">
+          <title>The Moving Finger</title>
+          <description>Corrupti quis veniam sit.</description>
+        </package>
+    http_version: 
+  recorded_at: Mon, 30 Jul 2018 19:11:56 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/project_1/package_1/_meta?user=_nobody_
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="package_1" project="project_1">
+          <title>The Moving Finger</title>
+          <description>Corrupti quis veniam sit.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '148'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="package_1" project="project_1">
+          <title>The Moving Finger</title>
+          <description>Corrupti quis veniam sit.</description>
+        </package>
+    http_version: 
+  recorded_at: Mon, 30 Jul 2018 19:11:56 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:user_1/_meta?user=user_1
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:user_1">
+          <title/>
+          <description/>
+          <person userid="user_1" role="maintainer"/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '135'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:user_1">
+          <title></title>
+          <description></description>
+          <person userid="user_1" role="maintainer" />
+        </project>
+    http_version: 
+  recorded_at: Mon, 30 Jul 2018 19:11:56 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/openSUSE:Factory:Staging:A/_meta?user=_nobody_
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="openSUSE:Factory:Staging:A">
+          <title>In a Glass Darkly</title>
+          <description>      requests:
+                - { id: 1 }
+        </description>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '156'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="openSUSE:Factory:Staging:A">
+          <title>In a Glass Darkly</title>
+          <description>      requests:
+                - { id: 1 }
+        </description>
+        </project>
+    http_version: 
+  recorded_at: Mon, 30 Jul 2018 19:11:57 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/openSUSE:Factory:Staging:B/_meta?user=_nobody_
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="openSUSE:Factory:Staging:B">
+          <title>The Golden Apples of the Sun</title>
+          <description>Factory staging project B</description>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '156'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="openSUSE:Factory:Staging:B">
+          <title>The Golden Apples of the Sun</title>
+          <description>Factory staging project B</description>
+        </project>
+    http_version: 
+  recorded_at: Mon, 30 Jul 2018 19:11:57 GMT
+- request:
+    method: get
+    uri: http://backend:5352/build/openSUSE:Factory:Staging:A/_result?package=Test-DVD-x86_64&repository=images&view=binarylist
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - text/plain
+      Accept-Encoding:
+      - identity
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 404
+      message: unknown repository 'images'
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '132'
+    body:
+      encoding: UTF-8
+      string: |
+        <status code="404">
+          <summary>unknown repository 'images'</summary>
+          <details>404 unknown repository 'images'</details>
+        </status>
+    http_version: 
+  recorded_at: Mon, 30 Jul 2018 19:11:57 GMT
+- request:
+    method: get
+    uri: http://backend:5352/build/openSUSE:Factory:Staging:A/_result?code=unresolvable
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - text/plain
+      Accept-Encoding:
+      - identity
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '56'
+    body:
+      encoding: UTF-8
+      string: '<resultlist state="00000000000000000000000000000000" />
+
+'
+    http_version: 
+  recorded_at: Mon, 30 Jul 2018 19:11:57 GMT
 recorded_with: VCR 4.0.0

--- a/src/api/spec/cassettes/Webui_ObsFactory_StagingProjectsController/GET_index/without_dashboard_package/sets_up_the_required_variables.yml
+++ b/src/api/spec/cassettes/Webui_ObsFactory_StagingProjectsController/GET_index/without_dashboard_package/sets_up_the_required_variables.yml
@@ -2,51 +2,12 @@
 http_interactions:
 - request:
     method: put
-    uri: http://backend:5352/source/openSUSE:Factory:Staging:A/_meta?user=_nobody_
-    body:
-      encoding: UTF-8
-      string: |
-        <project name="openSUSE:Factory:Staging:A">
-          <title>All the King's Men</title>
-          <description>Factory staging project A</description>
-        </project>
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '146'
-    body:
-      encoding: UTF-8
-      string: |
-        <project name="openSUSE:Factory:Staging:A">
-          <title>All the King's Men</title>
-          <description>Factory staging project A</description>
-        </project>
-    http_version: 
-  recorded_at: Tue, 24 Jul 2018 08:06:21 GMT
-- request:
-    method: put
     uri: http://backend:5352/source/openSUSE:Factory:Staging/_meta?user=_nobody_
     body:
       encoding: UTF-8
       string: |
         <project name="openSUSE:Factory:Staging">
-          <title>The Wealth of Nations</title>
+          <title>The Daffodil Sky</title>
           <description/>
         </project>
     headers:
@@ -68,16 +29,16 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '122'
+      - '117'
     body:
       encoding: UTF-8
       string: |
         <project name="openSUSE:Factory:Staging">
-          <title>The Wealth of Nations</title>
+          <title>The Daffodil Sky</title>
           <description></description>
         </project>
     http_version: 
-  recorded_at: Tue, 24 Jul 2018 08:06:21 GMT
+  recorded_at: Mon, 30 Jul 2018 19:11:58 GMT
 - request:
     method: put
     uri: http://backend:5352/source/openSUSE:Factory/_meta?user=_nobody_
@@ -85,7 +46,7 @@ http_interactions:
       encoding: UTF-8
       string: |
         <project name="openSUSE:Factory">
-          <title>Precious Bane</title>
+          <title>Tirra Lirra by the River</title>
           <description/>
         </project>
     headers:
@@ -107,14 +68,404 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '106'
+      - '117'
     body:
       encoding: UTF-8
       string: |
         <project name="openSUSE:Factory">
-          <title>Precious Bane</title>
+          <title>Tirra Lirra by the River</title>
           <description></description>
         </project>
     http_version: 
-  recorded_at: Tue, 24 Jul 2018 08:06:21 GMT
+  recorded_at: Mon, 30 Jul 2018 19:11:58 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/openSUSE:Factory/target_package/_meta?user=_nobody_
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="target_package" project="openSUSE:Factory">
+          <title>No Longer at Ease</title>
+          <description>Non nobis aspernatur accusamus.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '166'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="target_package" project="openSUSE:Factory">
+          <title>No Longer at Ease</title>
+          <description>Non nobis aspernatur accusamus.</description>
+        </package>
+    http_version: 
+  recorded_at: Mon, 30 Jul 2018 19:11:59 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/openSUSE:Factory/target_package/_meta?user=_nobody_
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="target_package" project="openSUSE:Factory">
+          <title>No Longer at Ease</title>
+          <description>Non nobis aspernatur accusamus.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '166'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="target_package" project="openSUSE:Factory">
+          <title>No Longer at Ease</title>
+          <description>Non nobis aspernatur accusamus.</description>
+        </package>
+    http_version: 
+  recorded_at: Mon, 30 Jul 2018 19:11:59 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/project_2/_meta?user=_nobody_
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="project_2">
+          <title>The World, the Flesh and the Devil</title>
+          <description/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '120'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="project_2">
+          <title>The World, the Flesh and the Devil</title>
+          <description></description>
+        </project>
+    http_version: 
+  recorded_at: Mon, 30 Jul 2018 19:11:59 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/project_2/package_2/_meta?user=_nobody_
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="package_2" project="project_2">
+          <title>The Golden Bowl</title>
+          <description>Distinctio impedit architecto et.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '154'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="package_2" project="project_2">
+          <title>The Golden Bowl</title>
+          <description>Distinctio impedit architecto et.</description>
+        </package>
+    http_version: 
+  recorded_at: Mon, 30 Jul 2018 19:11:59 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/project_2/package_2/_meta?user=_nobody_
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="package_2" project="project_2">
+          <title>The Golden Bowl</title>
+          <description>Distinctio impedit architecto et.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '154'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="package_2" project="project_2">
+          <title>The Golden Bowl</title>
+          <description>Distinctio impedit architecto et.</description>
+        </package>
+    http_version: 
+  recorded_at: Mon, 30 Jul 2018 19:11:59 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:user_2/_meta?user=user_2
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:user_2">
+          <title/>
+          <description/>
+          <person userid="user_2" role="maintainer"/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '135'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:user_2">
+          <title></title>
+          <description></description>
+          <person userid="user_2" role="maintainer" />
+        </project>
+    http_version: 
+  recorded_at: Mon, 30 Jul 2018 19:11:59 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/openSUSE:Factory:Staging:A/_meta?user=_nobody_
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="openSUSE:Factory:Staging:A">
+          <title>To Your Scattered Bodies Go</title>
+          <description>      requests:
+                - { id: 1 }
+        </description>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '166'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="openSUSE:Factory:Staging:A">
+          <title>To Your Scattered Bodies Go</title>
+          <description>      requests:
+                - { id: 1 }
+        </description>
+        </project>
+    http_version: 
+  recorded_at: Mon, 30 Jul 2018 19:11:59 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/openSUSE:Factory:Staging:B/_meta?user=_nobody_
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="openSUSE:Factory:Staging:B">
+          <title>Butter In a Lordly Dish</title>
+          <description>Factory staging project B</description>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '151'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="openSUSE:Factory:Staging:B">
+          <title>Butter In a Lordly Dish</title>
+          <description>Factory staging project B</description>
+        </project>
+    http_version: 
+  recorded_at: Mon, 30 Jul 2018 19:11:59 GMT
+- request:
+    method: get
+    uri: http://backend:5352/build/openSUSE:Factory:Staging:A/_result?package=Test-DVD-x86_64&repository=images&view=binarylist
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - text/plain
+      Accept-Encoding:
+      - identity
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 404
+      message: unknown repository 'images'
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '132'
+    body:
+      encoding: UTF-8
+      string: |
+        <status code="404">
+          <summary>unknown repository 'images'</summary>
+          <details>404 unknown repository 'images'</details>
+        </status>
+    http_version: 
+  recorded_at: Mon, 30 Jul 2018 19:11:59 GMT
+- request:
+    method: get
+    uri: http://backend:5352/build/openSUSE:Factory:Staging:A/_result?code=unresolvable
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - text/plain
+      Accept-Encoding:
+      - identity
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '56'
+    body:
+      encoding: UTF-8
+      string: '<resultlist state="00000000000000000000000000000000" />
+
+'
+    http_version: 
+  recorded_at: Mon, 30 Jul 2018 19:11:59 GMT
 recorded_with: VCR 4.0.0

--- a/src/api/spec/cassettes/Webui_ObsFactory_StagingProjectsController/GET_show/with_a_existent_factory_staging_project/requesting_html/1_2_1_1_1.yml
+++ b/src/api/spec/cassettes/Webui_ObsFactory_StagingProjectsController/GET_show/with_a_existent_factory_staging_project/requesting_html/1_2_1_1_1.yml
@@ -2,13 +2,13 @@
 http_interactions:
 - request:
     method: put
-    uri: http://backend:5352/source/openSUSE:Factory:Staging:A/_meta?user=_nobody_
+    uri: http://backend:5352/source/openSUSE:Factory:Staging/_meta?user=_nobody_
     body:
       encoding: UTF-8
       string: |
-        <project name="openSUSE:Factory:Staging:A">
-          <title>The Stars' Tennis Balls</title>
-          <description>Factory staging project A</description>
+        <project name="openSUSE:Factory:Staging">
+          <title>Nine Coaches Waiting</title>
+          <description/>
         </project>
     headers:
       Accept-Encoding:
@@ -29,16 +29,16 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '151'
+      - '121'
     body:
       encoding: UTF-8
       string: |
-        <project name="openSUSE:Factory:Staging:A">
-          <title>The Stars' Tennis Balls</title>
-          <description>Factory staging project A</description>
+        <project name="openSUSE:Factory:Staging">
+          <title>Nine Coaches Waiting</title>
+          <description></description>
         </project>
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 09:10:12 GMT
+  recorded_at: Mon, 30 Jul 2018 19:12:15 GMT
 - request:
     method: put
     uri: http://backend:5352/source/openSUSE:Factory/_meta?user=_nobody_
@@ -46,7 +46,7 @@ http_interactions:
       encoding: UTF-8
       string: |
         <project name="openSUSE:Factory">
-          <title>A Farewell to Arms</title>
+          <title>Now Sleeps the Crimson Petal</title>
           <description/>
         </project>
     headers:
@@ -68,16 +68,16 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '111'
+      - '121'
     body:
       encoding: UTF-8
       string: |
         <project name="openSUSE:Factory">
-          <title>A Farewell to Arms</title>
+          <title>Now Sleeps the Crimson Petal</title>
           <description></description>
         </project>
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 09:10:13 GMT
+  recorded_at: Mon, 30 Jul 2018 19:12:15 GMT
 - request:
     method: put
     uri: http://backend:5352/source/openSUSE:Factory/target_package/_meta?user=_nobody_
@@ -85,85 +85,85 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="target_package" project="openSUSE:Factory">
-          <title>Blue Remembered Earth</title>
-          <description>Earum quos ut sed.</description>
-        </package>
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '157'
-    body:
-      encoding: UTF-8
-      string: |
-        <package name="target_package" project="openSUSE:Factory">
-          <title>Blue Remembered Earth</title>
-          <description>Earum quos ut sed.</description>
-        </package>
-    http_version: 
-  recorded_at: Mon, 30 Jul 2018 09:10:13 GMT
-- request:
-    method: put
-    uri: http://backend:5352/source/openSUSE:Factory/target_package/_meta?user=_nobody_
-    body:
-      encoding: UTF-8
-      string: |
-        <package name="target_package" project="openSUSE:Factory">
-          <title>Blue Remembered Earth</title>
-          <description>Earum quos ut sed.</description>
-        </package>
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '157'
-    body:
-      encoding: UTF-8
-      string: |
-        <package name="target_package" project="openSUSE:Factory">
-          <title>Blue Remembered Earth</title>
-          <description>Earum quos ut sed.</description>
-        </package>
-    http_version: 
-  recorded_at: Mon, 30 Jul 2018 09:10:13 GMT
-- request:
-    method: put
-    uri: http://backend:5352/source/project_4/_meta?user=_nobody_
-    body:
-      encoding: UTF-8
-      string: |
-        <project name="project_4">
           <title>The Wind's Twelve Quarters</title>
+          <description>Exercitationem quae enim doloribus.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '179'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="target_package" project="openSUSE:Factory">
+          <title>The Wind's Twelve Quarters</title>
+          <description>Exercitationem quae enim doloribus.</description>
+        </package>
+    http_version: 
+  recorded_at: Mon, 30 Jul 2018 19:12:15 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/openSUSE:Factory/target_package/_meta?user=_nobody_
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="target_package" project="openSUSE:Factory">
+          <title>The Wind's Twelve Quarters</title>
+          <description>Exercitationem quae enim doloribus.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '179'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="target_package" project="openSUSE:Factory">
+          <title>The Wind's Twelve Quarters</title>
+          <description>Exercitationem quae enim doloribus.</description>
+        </package>
+    http_version: 
+  recorded_at: Mon, 30 Jul 2018 19:12:16 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/project_10/_meta?user=_nobody_
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="project_10">
+          <title>Have His Carcase</title>
           <description/>
         </project>
     headers:
@@ -185,25 +185,25 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '112'
+      - '103'
     body:
       encoding: UTF-8
       string: |
-        <project name="project_4">
-          <title>The Wind's Twelve Quarters</title>
+        <project name="project_10">
+          <title>Have His Carcase</title>
           <description></description>
         </project>
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 09:10:13 GMT
+  recorded_at: Mon, 30 Jul 2018 19:12:16 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/project_4/package_4/_meta?user=_nobody_
+    uri: http://backend:5352/source/project_10/package_10/_meta?user=_nobody_
     body:
       encoding: UTF-8
       string: |
-        <package name="package_4" project="project_4">
-          <title>The Monkey's Raincoat</title>
-          <description>Eveniet provident qui consectetur.</description>
+        <package name="package_10" project="project_10">
+          <title>If I Forget Thee Jerusalem</title>
+          <description>Est eligendi atque quasi.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -224,25 +224,25 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '161'
+      - '159'
     body:
       encoding: UTF-8
       string: |
-        <package name="package_4" project="project_4">
-          <title>The Monkey's Raincoat</title>
-          <description>Eveniet provident qui consectetur.</description>
+        <package name="package_10" project="project_10">
+          <title>If I Forget Thee Jerusalem</title>
+          <description>Est eligendi atque quasi.</description>
         </package>
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 09:10:13 GMT
+  recorded_at: Mon, 30 Jul 2018 19:12:16 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/project_4/package_4/_meta?user=_nobody_
+    uri: http://backend:5352/source/project_10/package_10/_meta?user=_nobody_
     body:
       encoding: UTF-8
       string: |
-        <package name="package_4" project="project_4">
-          <title>The Monkey's Raincoat</title>
-          <description>Eveniet provident qui consectetur.</description>
+        <package name="package_10" project="project_10">
+          <title>If I Forget Thee Jerusalem</title>
+          <description>Est eligendi atque quasi.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -263,26 +263,26 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '161'
+      - '159'
     body:
       encoding: UTF-8
       string: |
-        <package name="package_4" project="project_4">
-          <title>The Monkey's Raincoat</title>
-          <description>Eveniet provident qui consectetur.</description>
+        <package name="package_10" project="project_10">
+          <title>If I Forget Thee Jerusalem</title>
+          <description>Est eligendi atque quasi.</description>
         </package>
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 09:10:13 GMT
+  recorded_at: Mon, 30 Jul 2018 19:12:16 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:user_4/_meta?user=user_4
+    uri: http://backend:5352/source/home:user_25/_meta?user=user_25
     body:
       encoding: UTF-8
       string: |
-        <project name="home:user_4">
+        <project name="home:user_25">
           <title/>
           <description/>
-          <person userid="user_4" role="maintainer"/>
+          <person userid="user_25" role="maintainer"/>
         </project>
     headers:
       Accept-Encoding:
@@ -303,17 +303,99 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '135'
+      - '137'
     body:
       encoding: UTF-8
       string: |
-        <project name="home:user_4">
+        <project name="home:user_25">
           <title></title>
           <description></description>
-          <person userid="user_4" role="maintainer" />
+          <person userid="user_25" role="maintainer" />
         </project>
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 09:10:13 GMT
+  recorded_at: Mon, 30 Jul 2018 19:12:16 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/openSUSE:Factory:Staging:A/_meta?user=_nobody_
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="openSUSE:Factory:Staging:A">
+          <title>Time of our Darkness</title>
+          <description>      requests:
+                - { id: 1 }
+        </description>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '159'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="openSUSE:Factory:Staging:A">
+          <title>Time of our Darkness</title>
+          <description>      requests:
+                - { id: 1 }
+        </description>
+        </project>
+    http_version: 
+  recorded_at: Mon, 30 Jul 2018 19:12:16 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/openSUSE:Factory:Staging:B/_meta?user=_nobody_
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="openSUSE:Factory:Staging:B">
+          <title>All the King's Men</title>
+          <description>Factory staging project B</description>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '146'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="openSUSE:Factory:Staging:B">
+          <title>All the King's Men</title>
+          <description>Factory staging project B</description>
+        </project>
+    http_version: 
+  recorded_at: Mon, 30 Jul 2018 19:12:16 GMT
 - request:
     method: get
     uri: http://backend:5352/build/openSUSE:Factory:Staging:A/_result?code=unresolvable
@@ -348,7 +430,7 @@ http_interactions:
 
 '
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 09:10:14 GMT
+  recorded_at: Mon, 30 Jul 2018 19:12:16 GMT
 - request:
     method: get
     uri: http://backend:5352/build/openSUSE:Factory:Staging:A/_result?package=Test-DVD-x86_64&repository=images&view=binarylist
@@ -385,5 +467,5 @@ http_interactions:
           <details>404 unknown repository 'images'</details>
         </status>
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 09:10:14 GMT
+  recorded_at: Mon, 30 Jul 2018 19:12:16 GMT
 recorded_with: VCR 4.0.0

--- a/src/api/spec/cassettes/Webui_ObsFactory_StagingProjectsController/GET_show/with_a_existent_factory_staging_project/requesting_html/1_2_1_1_2.yml
+++ b/src/api/spec/cassettes/Webui_ObsFactory_StagingProjectsController/GET_show/with_a_existent_factory_staging_project/requesting_html/1_2_1_1_2.yml
@@ -2,13 +2,13 @@
 http_interactions:
 - request:
     method: put
-    uri: http://backend:5352/source/openSUSE:Factory:Staging:A/_meta?user=_nobody_
+    uri: http://backend:5352/source/openSUSE:Factory:Staging/_meta?user=_nobody_
     body:
       encoding: UTF-8
       string: |
-        <project name="openSUSE:Factory:Staging:A">
-          <title>Tender Is the Night</title>
-          <description>Factory staging project A</description>
+        <project name="openSUSE:Factory:Staging">
+          <title>An Evil Cradling</title>
+          <description/>
         </project>
     headers:
       Accept-Encoding:
@@ -29,16 +29,16 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '147'
+      - '117'
     body:
       encoding: UTF-8
       string: |
-        <project name="openSUSE:Factory:Staging:A">
-          <title>Tender Is the Night</title>
-          <description>Factory staging project A</description>
+        <project name="openSUSE:Factory:Staging">
+          <title>An Evil Cradling</title>
+          <description></description>
         </project>
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 09:10:10 GMT
+  recorded_at: Mon, 30 Jul 2018 19:12:14 GMT
 - request:
     method: put
     uri: http://backend:5352/source/openSUSE:Factory/_meta?user=_nobody_
@@ -46,7 +46,7 @@ http_interactions:
       encoding: UTF-8
       string: |
         <project name="openSUSE:Factory">
-          <title>The Widening Gyre</title>
+          <title>Beneath the Bleeding</title>
           <description/>
         </project>
     headers:
@@ -68,16 +68,16 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '110'
+      - '113'
     body:
       encoding: UTF-8
       string: |
         <project name="openSUSE:Factory">
-          <title>The Widening Gyre</title>
+          <title>Beneath the Bleeding</title>
           <description></description>
         </project>
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 09:10:10 GMT
+  recorded_at: Mon, 30 Jul 2018 19:12:14 GMT
 - request:
     method: put
     uri: http://backend:5352/source/openSUSE:Factory/target_package/_meta?user=_nobody_
@@ -85,8 +85,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="target_package" project="openSUSE:Factory">
-          <title>Pale Kings and Princes</title>
-          <description>Voluptas itaque aut voluptates.</description>
+          <title>This Lime Tree Bower</title>
+          <description>Reprehenderit totam omnis earum.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -107,16 +107,16 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '171'
+      - '170'
     body:
       encoding: UTF-8
       string: |
         <package name="target_package" project="openSUSE:Factory">
-          <title>Pale Kings and Princes</title>
-          <description>Voluptas itaque aut voluptates.</description>
+          <title>This Lime Tree Bower</title>
+          <description>Reprehenderit totam omnis earum.</description>
         </package>
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 09:10:10 GMT
+  recorded_at: Mon, 30 Jul 2018 19:12:14 GMT
 - request:
     method: put
     uri: http://backend:5352/source/openSUSE:Factory/target_package/_meta?user=_nobody_
@@ -124,8 +124,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="target_package" project="openSUSE:Factory">
-          <title>Pale Kings and Princes</title>
-          <description>Voluptas itaque aut voluptates.</description>
+          <title>This Lime Tree Bower</title>
+          <description>Reprehenderit totam omnis earum.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -146,24 +146,24 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '171'
+      - '170'
     body:
       encoding: UTF-8
       string: |
         <package name="target_package" project="openSUSE:Factory">
-          <title>Pale Kings and Princes</title>
-          <description>Voluptas itaque aut voluptates.</description>
+          <title>This Lime Tree Bower</title>
+          <description>Reprehenderit totam omnis earum.</description>
         </package>
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 09:10:10 GMT
+  recorded_at: Mon, 30 Jul 2018 19:12:14 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/project_3/_meta?user=_nobody_
+    uri: http://backend:5352/source/project_9/_meta?user=_nobody_
     body:
       encoding: UTF-8
       string: |
-        <project name="project_3">
-          <title>To a God Unknown</title>
+        <project name="project_9">
+          <title>Dance Dance Dance</title>
           <description/>
         </project>
     headers:
@@ -185,25 +185,25 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '102'
+      - '103'
     body:
       encoding: UTF-8
       string: |
-        <project name="project_3">
-          <title>To a God Unknown</title>
+        <project name="project_9">
+          <title>Dance Dance Dance</title>
           <description></description>
         </project>
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 09:10:11 GMT
+  recorded_at: Mon, 30 Jul 2018 19:12:14 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/project_3/package_3/_meta?user=_nobody_
+    uri: http://backend:5352/source/project_9/package_9/_meta?user=_nobody_
     body:
       encoding: UTF-8
       string: |
-        <package name="package_3" project="project_3">
-          <title>Precious Bane</title>
-          <description>Nihil consequatur ea accusamus.</description>
+        <package name="package_9" project="project_9">
+          <title>I Sing the Body Electric</title>
+          <description>Reprehenderit aliquid incidunt autem.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -224,25 +224,25 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '150'
+      - '167'
     body:
       encoding: UTF-8
       string: |
-        <package name="package_3" project="project_3">
-          <title>Precious Bane</title>
-          <description>Nihil consequatur ea accusamus.</description>
+        <package name="package_9" project="project_9">
+          <title>I Sing the Body Electric</title>
+          <description>Reprehenderit aliquid incidunt autem.</description>
         </package>
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 09:10:11 GMT
+  recorded_at: Mon, 30 Jul 2018 19:12:14 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/project_3/package_3/_meta?user=_nobody_
+    uri: http://backend:5352/source/project_9/package_9/_meta?user=_nobody_
     body:
       encoding: UTF-8
       string: |
-        <package name="package_3" project="project_3">
-          <title>Precious Bane</title>
-          <description>Nihil consequatur ea accusamus.</description>
+        <package name="package_9" project="project_9">
+          <title>I Sing the Body Electric</title>
+          <description>Reprehenderit aliquid incidunt autem.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -263,26 +263,26 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '150'
+      - '167'
     body:
       encoding: UTF-8
       string: |
-        <package name="package_3" project="project_3">
-          <title>Precious Bane</title>
-          <description>Nihil consequatur ea accusamus.</description>
+        <package name="package_9" project="project_9">
+          <title>I Sing the Body Electric</title>
+          <description>Reprehenderit aliquid incidunt autem.</description>
         </package>
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 09:10:11 GMT
+  recorded_at: Mon, 30 Jul 2018 19:12:15 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:user_3/_meta?user=user_3
+    uri: http://backend:5352/source/home:user_24/_meta?user=user_24
     body:
       encoding: UTF-8
       string: |
-        <project name="home:user_3">
+        <project name="home:user_24">
           <title/>
           <description/>
-          <person userid="user_3" role="maintainer"/>
+          <person userid="user_24" role="maintainer"/>
         </project>
     headers:
       Accept-Encoding:
@@ -303,17 +303,99 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '135'
+      - '137'
     body:
       encoding: UTF-8
       string: |
-        <project name="home:user_3">
+        <project name="home:user_24">
           <title></title>
           <description></description>
-          <person userid="user_3" role="maintainer" />
+          <person userid="user_24" role="maintainer" />
         </project>
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 09:10:11 GMT
+  recorded_at: Mon, 30 Jul 2018 19:12:15 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/openSUSE:Factory:Staging:A/_meta?user=_nobody_
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="openSUSE:Factory:Staging:A">
+          <title>That Hideous Strength</title>
+          <description>      requests:
+                - { id: 1 }
+        </description>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '160'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="openSUSE:Factory:Staging:A">
+          <title>That Hideous Strength</title>
+          <description>      requests:
+                - { id: 1 }
+        </description>
+        </project>
+    http_version: 
+  recorded_at: Mon, 30 Jul 2018 19:12:15 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/openSUSE:Factory:Staging:B/_meta?user=_nobody_
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="openSUSE:Factory:Staging:B">
+          <title>An Evil Cradling</title>
+          <description>Factory staging project B</description>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '144'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="openSUSE:Factory:Staging:B">
+          <title>An Evil Cradling</title>
+          <description>Factory staging project B</description>
+        </project>
+    http_version: 
+  recorded_at: Mon, 30 Jul 2018 19:12:15 GMT
 - request:
     method: get
     uri: http://backend:5352/build/openSUSE:Factory:Staging:A/_result?code=unresolvable
@@ -348,7 +430,7 @@ http_interactions:
 
 '
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 09:10:12 GMT
+  recorded_at: Mon, 30 Jul 2018 19:12:15 GMT
 - request:
     method: get
     uri: http://backend:5352/build/openSUSE:Factory:Staging:A/_result?package=Test-DVD-x86_64&repository=images&view=binarylist
@@ -385,5 +467,5 @@ http_interactions:
           <details>404 unknown repository 'images'</details>
         </status>
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 09:10:12 GMT
+  recorded_at: Mon, 30 Jul 2018 19:12:15 GMT
 recorded_with: VCR 4.0.0

--- a/src/api/spec/cassettes/Webui_ObsFactory_StagingProjectsController/GET_show/with_a_existent_factory_staging_project/requesting_html/1_2_1_1_3.yml
+++ b/src/api/spec/cassettes/Webui_ObsFactory_StagingProjectsController/GET_show/with_a_existent_factory_staging_project/requesting_html/1_2_1_1_3.yml
@@ -7,7 +7,7 @@ http_interactions:
       encoding: UTF-8
       string: |
         <project name="openSUSE:Factory:Staging">
-          <title>Antic Hay</title>
+          <title>Death Be Not Proud</title>
           <description/>
         </project>
     headers:
@@ -29,16 +29,16 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '110'
+      - '119'
     body:
       encoding: UTF-8
       string: |
         <project name="openSUSE:Factory:Staging">
-          <title>Antic Hay</title>
+          <title>Death Be Not Proud</title>
           <description></description>
         </project>
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 19:12:00 GMT
+  recorded_at: Mon, 30 Jul 2018 19:12:16 GMT
 - request:
     method: put
     uri: http://backend:5352/source/openSUSE:Factory/_meta?user=_nobody_
@@ -46,7 +46,7 @@ http_interactions:
       encoding: UTF-8
       string: |
         <project name="openSUSE:Factory">
-          <title>The Torment of Others</title>
+          <title>The Daffodil Sky</title>
           <description/>
         </project>
     headers:
@@ -68,16 +68,16 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '114'
+      - '109'
     body:
       encoding: UTF-8
       string: |
         <project name="openSUSE:Factory">
-          <title>The Torment of Others</title>
+          <title>The Daffodil Sky</title>
           <description></description>
         </project>
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 19:12:00 GMT
+  recorded_at: Mon, 30 Jul 2018 19:12:17 GMT
 - request:
     method: put
     uri: http://backend:5352/source/openSUSE:Factory/target_package/_meta?user=_nobody_
@@ -85,8 +85,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="target_package" project="openSUSE:Factory">
-          <title>Little Hands Clapping</title>
-          <description>Quod aliquam perferendis laborum.</description>
+          <title>His Dark Materials</title>
+          <description>Iusto consectetur tenetur totam.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -107,16 +107,16 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '172'
+      - '168'
     body:
       encoding: UTF-8
       string: |
         <package name="target_package" project="openSUSE:Factory">
-          <title>Little Hands Clapping</title>
-          <description>Quod aliquam perferendis laborum.</description>
+          <title>His Dark Materials</title>
+          <description>Iusto consectetur tenetur totam.</description>
         </package>
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 19:12:00 GMT
+  recorded_at: Mon, 30 Jul 2018 19:12:17 GMT
 - request:
     method: put
     uri: http://backend:5352/source/openSUSE:Factory/target_package/_meta?user=_nobody_
@@ -124,8 +124,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="target_package" project="openSUSE:Factory">
-          <title>Little Hands Clapping</title>
-          <description>Quod aliquam perferendis laborum.</description>
+          <title>His Dark Materials</title>
+          <description>Iusto consectetur tenetur totam.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -146,24 +146,24 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '172'
+      - '168'
     body:
       encoding: UTF-8
       string: |
         <package name="target_package" project="openSUSE:Factory">
-          <title>Little Hands Clapping</title>
-          <description>Quod aliquam perferendis laborum.</description>
+          <title>His Dark Materials</title>
+          <description>Iusto consectetur tenetur totam.</description>
         </package>
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 19:12:00 GMT
+  recorded_at: Mon, 30 Jul 2018 19:12:17 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/project_3/_meta?user=_nobody_
+    uri: http://backend:5352/source/project_11/_meta?user=_nobody_
     body:
       encoding: UTF-8
       string: |
-        <project name="project_3">
-          <title>A Scanner Darkly</title>
+        <project name="project_11">
+          <title>A Handful of Dust</title>
           <description/>
         </project>
     headers:
@@ -185,188 +185,26 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '102'
+      - '104'
     body:
       encoding: UTF-8
       string: |
-        <project name="project_3">
-          <title>A Scanner Darkly</title>
+        <project name="project_11">
+          <title>A Handful of Dust</title>
           <description></description>
         </project>
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 19:12:00 GMT
+  recorded_at: Mon, 30 Jul 2018 19:12:17 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/project_3/package_3/_meta?user=_nobody_
+    uri: http://backend:5352/source/project_11/package_11/_meta?user=_nobody_
     body:
       encoding: UTF-8
       string: |
-        <package name="package_3" project="project_3">
-          <title>A Summer Bird-Cage</title>
-          <description>Provident inventore esse non.</description>
+        <package name="package_11" project="project_11">
+          <title>Jesting Pilate</title>
+          <description>Fugit quas mollitia consectetur.</description>
         </package>
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '153'
-    body:
-      encoding: UTF-8
-      string: |
-        <package name="package_3" project="project_3">
-          <title>A Summer Bird-Cage</title>
-          <description>Provident inventore esse non.</description>
-        </package>
-    http_version: 
-  recorded_at: Mon, 30 Jul 2018 19:12:00 GMT
-- request:
-    method: put
-    uri: http://backend:5352/source/project_3/package_3/_meta?user=_nobody_
-    body:
-      encoding: UTF-8
-      string: |
-        <package name="package_3" project="project_3">
-          <title>A Summer Bird-Cage</title>
-          <description>Provident inventore esse non.</description>
-        </package>
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '153'
-    body:
-      encoding: UTF-8
-      string: |
-        <package name="package_3" project="project_3">
-          <title>A Summer Bird-Cage</title>
-          <description>Provident inventore esse non.</description>
-        </package>
-    http_version: 
-  recorded_at: Mon, 30 Jul 2018 19:12:00 GMT
-- request:
-    method: put
-    uri: http://backend:5352/source/home:user_3/_meta?user=user_3
-    body:
-      encoding: UTF-8
-      string: |
-        <project name="home:user_3">
-          <title/>
-          <description/>
-          <person userid="user_3" role="maintainer"/>
-        </project>
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '135'
-    body:
-      encoding: UTF-8
-      string: |
-        <project name="home:user_3">
-          <title></title>
-          <description></description>
-          <person userid="user_3" role="maintainer" />
-        </project>
-    http_version: 
-  recorded_at: Mon, 30 Jul 2018 19:12:00 GMT
-- request:
-    method: put
-    uri: http://backend:5352/source/openSUSE:Factory:Staging:A/_meta?user=_nobody_
-    body:
-      encoding: UTF-8
-      string: |
-        <project name="openSUSE:Factory:Staging:A">
-          <title>A Passage to India</title>
-          <description>      requests:
-                - { id: 1 }
-        </description>
-        </project>
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '157'
-    body:
-      encoding: UTF-8
-      string: |
-        <project name="openSUSE:Factory:Staging:A">
-          <title>A Passage to India</title>
-          <description>      requests:
-                - { id: 1 }
-        </description>
-        </project>
-    http_version: 
-  recorded_at: Mon, 30 Jul 2018 19:12:00 GMT
-- request:
-    method: put
-    uri: http://backend:5352/source/openSUSE:Factory:Staging:B/_meta?user=_nobody_
-    body:
-      encoding: UTF-8
-      string: |
-        <project name="openSUSE:Factory:Staging:B">
-          <title>Far From the Madding Crowd</title>
-          <description>Factory staging project B</description>
-        </project>
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -390,12 +228,209 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
+        <package name="package_11" project="project_11">
+          <title>Jesting Pilate</title>
+          <description>Fugit quas mollitia consectetur.</description>
+        </package>
+    http_version: 
+  recorded_at: Mon, 30 Jul 2018 19:12:17 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/project_11/package_11/_meta?user=_nobody_
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="package_11" project="project_11">
+          <title>Jesting Pilate</title>
+          <description>Fugit quas mollitia consectetur.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '154'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="package_11" project="project_11">
+          <title>Jesting Pilate</title>
+          <description>Fugit quas mollitia consectetur.</description>
+        </package>
+    http_version: 
+  recorded_at: Mon, 30 Jul 2018 19:12:17 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:user_26/_meta?user=user_26
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:user_26">
+          <title/>
+          <description/>
+          <person userid="user_26" role="maintainer"/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '137'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:user_26">
+          <title></title>
+          <description></description>
+          <person userid="user_26" role="maintainer" />
+        </project>
+    http_version: 
+  recorded_at: Mon, 30 Jul 2018 19:12:17 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/openSUSE:Factory:Staging:A/_meta?user=_nobody_
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="openSUSE:Factory:Staging:A">
+          <title>A Darkling Plain</title>
+          <description>      requests:
+                - { id: 1 }
+        </description>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '155'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="openSUSE:Factory:Staging:A">
+          <title>A Darkling Plain</title>
+          <description>      requests:
+                - { id: 1 }
+        </description>
+        </project>
+    http_version: 
+  recorded_at: Mon, 30 Jul 2018 19:12:17 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/openSUSE:Factory:Staging:B/_meta?user=_nobody_
+    body:
+      encoding: UTF-8
+      string: |
         <project name="openSUSE:Factory:Staging:B">
-          <title>Far From the Madding Crowd</title>
+          <title>The Lathe of Heaven</title>
+          <description>Factory staging project B</description>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '147'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="openSUSE:Factory:Staging:B">
+          <title>The Lathe of Heaven</title>
           <description>Factory staging project B</description>
         </project>
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 19:12:00 GMT
+  recorded_at: Mon, 30 Jul 2018 19:12:17 GMT
+- request:
+    method: get
+    uri: http://backend:5352/build/openSUSE:Factory:Staging:A/_result?code=unresolvable
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - text/plain
+      Accept-Encoding:
+      - identity
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '56'
+    body:
+      encoding: UTF-8
+      string: '<resultlist state="00000000000000000000000000000000" />
+
+'
+    http_version: 
+  recorded_at: Mon, 30 Jul 2018 19:12:17 GMT
 - request:
     method: get
     uri: http://backend:5352/build/openSUSE:Factory:Staging:A/_result?package=Test-DVD-x86_64&repository=images&view=binarylist
@@ -432,40 +467,5 @@ http_interactions:
           <details>404 unknown repository 'images'</details>
         </status>
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 19:12:01 GMT
-- request:
-    method: get
-    uri: http://backend:5352/build/openSUSE:Factory:Staging:A/_result?code=unresolvable
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Content-Type:
-      - text/plain
-      Accept-Encoding:
-      - identity
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '56'
-    body:
-      encoding: UTF-8
-      string: '<resultlist state="00000000000000000000000000000000" />
-
-'
-    http_version: 
-  recorded_at: Mon, 30 Jul 2018 19:12:01 GMT
+  recorded_at: Mon, 30 Jul 2018 19:12:17 GMT
 recorded_with: VCR 4.0.0

--- a/src/api/spec/cassettes/Webui_ObsFactory_StagingProjectsController/GET_show/with_a_existent_factory_staging_project/requesting_json/1_2_1_2_1.yml
+++ b/src/api/spec/cassettes/Webui_ObsFactory_StagingProjectsController/GET_show/with_a_existent_factory_staging_project/requesting_json/1_2_1_2_1.yml
@@ -2,13 +2,13 @@
 http_interactions:
 - request:
     method: put
-    uri: http://backend:5352/source/openSUSE:Factory:Staging:A/_meta?user=_nobody_
+    uri: http://backend:5352/source/openSUSE:Factory:Staging/_meta?user=_nobody_
     body:
       encoding: UTF-8
       string: |
-        <project name="openSUSE:Factory:Staging:A">
-          <title>Consider the Lilies</title>
-          <description>Factory staging project A</description>
+        <project name="openSUSE:Factory:Staging">
+          <title>A Darkling Plain</title>
+          <description/>
         </project>
     headers:
       Accept-Encoding:
@@ -29,16 +29,16 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '147'
+      - '117'
     body:
       encoding: UTF-8
       string: |
-        <project name="openSUSE:Factory:Staging:A">
-          <title>Consider the Lilies</title>
-          <description>Factory staging project A</description>
+        <project name="openSUSE:Factory:Staging">
+          <title>A Darkling Plain</title>
+          <description></description>
         </project>
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 09:10:09 GMT
+  recorded_at: Mon, 30 Jul 2018 19:12:19 GMT
 - request:
     method: put
     uri: http://backend:5352/source/openSUSE:Factory/_meta?user=_nobody_
@@ -46,7 +46,7 @@ http_interactions:
       encoding: UTF-8
       string: |
         <project name="openSUSE:Factory">
-          <title>This Side of Paradise</title>
+          <title>For Whom the Bell Tolls</title>
           <description/>
         </project>
     headers:
@@ -68,16 +68,16 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '114'
+      - '116'
     body:
       encoding: UTF-8
       string: |
         <project name="openSUSE:Factory">
-          <title>This Side of Paradise</title>
+          <title>For Whom the Bell Tolls</title>
           <description></description>
         </project>
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 09:10:09 GMT
+  recorded_at: Mon, 30 Jul 2018 19:12:19 GMT
 - request:
     method: put
     uri: http://backend:5352/source/openSUSE:Factory/target_package/_meta?user=_nobody_
@@ -85,8 +85,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="target_package" project="openSUSE:Factory">
-          <title>Time of our Darkness</title>
-          <description>Architecto exercitationem nam voluptate.</description>
+          <title>An Instant In The Wind</title>
+          <description>Suscipit unde aut quia.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -107,16 +107,16 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '178'
+      - '163'
     body:
       encoding: UTF-8
       string: |
         <package name="target_package" project="openSUSE:Factory">
-          <title>Time of our Darkness</title>
-          <description>Architecto exercitationem nam voluptate.</description>
+          <title>An Instant In The Wind</title>
+          <description>Suscipit unde aut quia.</description>
         </package>
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 09:10:09 GMT
+  recorded_at: Mon, 30 Jul 2018 19:12:19 GMT
 - request:
     method: put
     uri: http://backend:5352/source/openSUSE:Factory/target_package/_meta?user=_nobody_
@@ -124,8 +124,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="target_package" project="openSUSE:Factory">
-          <title>Time of our Darkness</title>
-          <description>Architecto exercitationem nam voluptate.</description>
+          <title>An Instant In The Wind</title>
+          <description>Suscipit unde aut quia.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -146,24 +146,24 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '178'
+      - '163'
     body:
       encoding: UTF-8
       string: |
         <package name="target_package" project="openSUSE:Factory">
-          <title>Time of our Darkness</title>
-          <description>Architecto exercitationem nam voluptate.</description>
+          <title>An Instant In The Wind</title>
+          <description>Suscipit unde aut quia.</description>
         </package>
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 09:10:10 GMT
+  recorded_at: Mon, 30 Jul 2018 19:12:19 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/project_2/_meta?user=_nobody_
+    uri: http://backend:5352/source/project_13/_meta?user=_nobody_
     body:
       encoding: UTF-8
       string: |
-        <project name="project_2">
-          <title>In Dubious Battle</title>
+        <project name="project_13">
+          <title>The Heart Is Deceitful Above All Things</title>
           <description/>
         </project>
     headers:
@@ -185,25 +185,25 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '103'
+      - '126'
     body:
       encoding: UTF-8
       string: |
-        <project name="project_2">
-          <title>In Dubious Battle</title>
+        <project name="project_13">
+          <title>The Heart Is Deceitful Above All Things</title>
           <description></description>
         </project>
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 09:10:10 GMT
+  recorded_at: Mon, 30 Jul 2018 19:12:19 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/project_2/package_2/_meta?user=_nobody_
+    uri: http://backend:5352/source/project_13/package_13/_meta?user=_nobody_
     body:
       encoding: UTF-8
       string: |
-        <package name="package_2" project="project_2">
-          <title>A Passage to India</title>
-          <description>Minima nisi et aut.</description>
+        <package name="package_13" project="project_13">
+          <title>An Instant In The Wind</title>
+          <description>Molestiae in qui unde.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -224,25 +224,25 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '143'
+      - '152'
     body:
       encoding: UTF-8
       string: |
-        <package name="package_2" project="project_2">
-          <title>A Passage to India</title>
-          <description>Minima nisi et aut.</description>
+        <package name="package_13" project="project_13">
+          <title>An Instant In The Wind</title>
+          <description>Molestiae in qui unde.</description>
         </package>
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 09:10:10 GMT
+  recorded_at: Mon, 30 Jul 2018 19:12:19 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/project_2/package_2/_meta?user=_nobody_
+    uri: http://backend:5352/source/project_13/package_13/_meta?user=_nobody_
     body:
       encoding: UTF-8
       string: |
-        <package name="package_2" project="project_2">
-          <title>A Passage to India</title>
-          <description>Minima nisi et aut.</description>
+        <package name="package_13" project="project_13">
+          <title>An Instant In The Wind</title>
+          <description>Molestiae in qui unde.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -263,26 +263,26 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '143'
+      - '152'
     body:
       encoding: UTF-8
       string: |
-        <package name="package_2" project="project_2">
-          <title>A Passage to India</title>
-          <description>Minima nisi et aut.</description>
+        <package name="package_13" project="project_13">
+          <title>An Instant In The Wind</title>
+          <description>Molestiae in qui unde.</description>
         </package>
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 09:10:10 GMT
+  recorded_at: Mon, 30 Jul 2018 19:12:19 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:user_2/_meta?user=user_2
+    uri: http://backend:5352/source/home:user_28/_meta?user=user_28
     body:
       encoding: UTF-8
       string: |
-        <project name="home:user_2">
+        <project name="home:user_28">
           <title/>
           <description/>
-          <person userid="user_2" role="maintainer"/>
+          <person userid="user_28" role="maintainer"/>
         </project>
     headers:
       Accept-Encoding:
@@ -303,17 +303,99 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '135'
+      - '137'
     body:
       encoding: UTF-8
       string: |
-        <project name="home:user_2">
+        <project name="home:user_28">
           <title></title>
           <description></description>
-          <person userid="user_2" role="maintainer" />
+          <person userid="user_28" role="maintainer" />
         </project>
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 09:10:10 GMT
+  recorded_at: Mon, 30 Jul 2018 19:12:19 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/openSUSE:Factory:Staging:A/_meta?user=_nobody_
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="openSUSE:Factory:Staging:A">
+          <title>To Your Scattered Bodies Go</title>
+          <description>      requests:
+                - { id: 1 }
+        </description>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '166'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="openSUSE:Factory:Staging:A">
+          <title>To Your Scattered Bodies Go</title>
+          <description>      requests:
+                - { id: 1 }
+        </description>
+        </project>
+    http_version: 
+  recorded_at: Mon, 30 Jul 2018 19:12:20 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/openSUSE:Factory:Staging:B/_meta?user=_nobody_
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="openSUSE:Factory:Staging:B">
+          <title>Little Hands Clapping</title>
+          <description>Factory staging project B</description>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '149'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="openSUSE:Factory:Staging:B">
+          <title>Little Hands Clapping</title>
+          <description>Factory staging project B</description>
+        </project>
+    http_version: 
+  recorded_at: Mon, 30 Jul 2018 19:12:20 GMT
 - request:
     method: get
     uri: http://backend:5352/build/openSUSE:Factory:Staging:A/_result?package=Test-DVD-x86_64&repository=images&view=binarylist
@@ -350,7 +432,7 @@ http_interactions:
           <details>404 unknown repository 'images'</details>
         </status>
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 09:10:10 GMT
+  recorded_at: Mon, 30 Jul 2018 19:12:20 GMT
 - request:
     method: get
     uri: http://backend:5352/build/openSUSE:Factory:Staging:A/_result?code=unresolvable
@@ -385,5 +467,5 @@ http_interactions:
 
 '
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 09:10:10 GMT
+  recorded_at: Mon, 30 Jul 2018 19:12:20 GMT
 recorded_with: VCR 4.0.0

--- a/src/api/spec/cassettes/Webui_ObsFactory_StagingProjectsController/GET_show/with_a_existent_factory_staging_project/requesting_json/responds_with_a_json_representation_of_the_staging_project.yml
+++ b/src/api/spec/cassettes/Webui_ObsFactory_StagingProjectsController/GET_show/with_a_existent_factory_staging_project/requesting_json/responds_with_a_json_representation_of_the_staging_project.yml
@@ -2,13 +2,13 @@
 http_interactions:
 - request:
     method: put
-    uri: http://backend:5352/source/openSUSE:Factory:Staging:A/_meta?user=_nobody_
+    uri: http://backend:5352/source/openSUSE:Factory:Staging/_meta?user=_nobody_
     body:
       encoding: UTF-8
       string: |
-        <project name="openSUSE:Factory:Staging:A">
-          <title>The Wealth of Nations</title>
-          <description>Factory staging project A</description>
+        <project name="openSUSE:Factory:Staging">
+          <title>A Many-Splendoured Thing</title>
+          <description/>
         </project>
     headers:
       Accept-Encoding:
@@ -29,16 +29,16 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '149'
+      - '125'
     body:
       encoding: UTF-8
       string: |
-        <project name="openSUSE:Factory:Staging:A">
-          <title>The Wealth of Nations</title>
-          <description>Factory staging project A</description>
+        <project name="openSUSE:Factory:Staging">
+          <title>A Many-Splendoured Thing</title>
+          <description></description>
         </project>
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 09:10:09 GMT
+  recorded_at: Mon, 30 Jul 2018 19:12:18 GMT
 - request:
     method: put
     uri: http://backend:5352/source/openSUSE:Factory/_meta?user=_nobody_
@@ -46,7 +46,7 @@ http_interactions:
       encoding: UTF-8
       string: |
         <project name="openSUSE:Factory">
-          <title>Fair Stood the Wind for France</title>
+          <title>This Lime Tree Bower</title>
           <description/>
         </project>
     headers:
@@ -68,16 +68,16 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '123'
+      - '113'
     body:
       encoding: UTF-8
       string: |
         <project name="openSUSE:Factory">
-          <title>Fair Stood the Wind for France</title>
+          <title>This Lime Tree Bower</title>
           <description></description>
         </project>
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 09:10:09 GMT
+  recorded_at: Mon, 30 Jul 2018 19:12:18 GMT
 - request:
     method: put
     uri: http://backend:5352/source/openSUSE:Factory/target_package/_meta?user=_nobody_
@@ -85,8 +85,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="target_package" project="openSUSE:Factory">
-          <title>The Line of Beauty</title>
-          <description>Est quod asperiores et.</description>
+          <title>Dance Dance Dance</title>
+          <description>Libero quia nemo perspiciatis.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -107,16 +107,16 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '159'
+      - '165'
     body:
       encoding: UTF-8
       string: |
         <package name="target_package" project="openSUSE:Factory">
-          <title>The Line of Beauty</title>
-          <description>Est quod asperiores et.</description>
+          <title>Dance Dance Dance</title>
+          <description>Libero quia nemo perspiciatis.</description>
         </package>
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 09:10:09 GMT
+  recorded_at: Mon, 30 Jul 2018 19:12:18 GMT
 - request:
     method: put
     uri: http://backend:5352/source/openSUSE:Factory/target_package/_meta?user=_nobody_
@@ -124,8 +124,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="target_package" project="openSUSE:Factory">
-          <title>The Line of Beauty</title>
-          <description>Est quod asperiores et.</description>
+          <title>Dance Dance Dance</title>
+          <description>Libero quia nemo perspiciatis.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -146,24 +146,24 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '159'
+      - '165'
     body:
       encoding: UTF-8
       string: |
         <package name="target_package" project="openSUSE:Factory">
-          <title>The Line of Beauty</title>
-          <description>Est quod asperiores et.</description>
+          <title>Dance Dance Dance</title>
+          <description>Libero quia nemo perspiciatis.</description>
         </package>
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 09:10:09 GMT
+  recorded_at: Mon, 30 Jul 2018 19:12:18 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/project_1/_meta?user=_nobody_
+    uri: http://backend:5352/source/project_12/_meta?user=_nobody_
     body:
       encoding: UTF-8
       string: |
-        <project name="project_1">
-          <title>Waiting for the Barbarians</title>
+        <project name="project_12">
+          <title>To a God Unknown</title>
           <description/>
         </project>
     headers:
@@ -185,25 +185,25 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '112'
+      - '103'
     body:
       encoding: UTF-8
       string: |
-        <project name="project_1">
-          <title>Waiting for the Barbarians</title>
+        <project name="project_12">
+          <title>To a God Unknown</title>
           <description></description>
         </project>
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 09:10:09 GMT
+  recorded_at: Mon, 30 Jul 2018 19:12:18 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/project_1/package_1/_meta?user=_nobody_
+    uri: http://backend:5352/source/project_12/package_12/_meta?user=_nobody_
     body:
       encoding: UTF-8
       string: |
-        <package name="package_1" project="project_1">
-          <title>Taming a Sea Horse</title>
-          <description>Fugiat et sit dicta.</description>
+        <package name="package_12" project="project_12">
+          <title>A Darkling Plain</title>
+          <description>Aperiam quibusdam rerum nam.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -224,25 +224,25 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '144'
+      - '152'
     body:
       encoding: UTF-8
       string: |
-        <package name="package_1" project="project_1">
-          <title>Taming a Sea Horse</title>
-          <description>Fugiat et sit dicta.</description>
+        <package name="package_12" project="project_12">
+          <title>A Darkling Plain</title>
+          <description>Aperiam quibusdam rerum nam.</description>
         </package>
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 09:10:09 GMT
+  recorded_at: Mon, 30 Jul 2018 19:12:18 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/project_1/package_1/_meta?user=_nobody_
+    uri: http://backend:5352/source/project_12/package_12/_meta?user=_nobody_
     body:
       encoding: UTF-8
       string: |
-        <package name="package_1" project="project_1">
-          <title>Taming a Sea Horse</title>
-          <description>Fugiat et sit dicta.</description>
+        <package name="package_12" project="project_12">
+          <title>A Darkling Plain</title>
+          <description>Aperiam quibusdam rerum nam.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -263,26 +263,26 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '144'
+      - '152'
     body:
       encoding: UTF-8
       string: |
-        <package name="package_1" project="project_1">
-          <title>Taming a Sea Horse</title>
-          <description>Fugiat et sit dicta.</description>
+        <package name="package_12" project="project_12">
+          <title>A Darkling Plain</title>
+          <description>Aperiam quibusdam rerum nam.</description>
         </package>
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 09:10:09 GMT
+  recorded_at: Mon, 30 Jul 2018 19:12:18 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:user_1/_meta?user=user_1
+    uri: http://backend:5352/source/home:user_27/_meta?user=user_27
     body:
       encoding: UTF-8
       string: |
-        <project name="home:user_1">
+        <project name="home:user_27">
           <title/>
           <description/>
-          <person userid="user_1" role="maintainer"/>
+          <person userid="user_27" role="maintainer"/>
         </project>
     headers:
       Accept-Encoding:
@@ -303,17 +303,99 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '135'
+      - '137'
     body:
       encoding: UTF-8
       string: |
-        <project name="home:user_1">
+        <project name="home:user_27">
           <title></title>
           <description></description>
-          <person userid="user_1" role="maintainer" />
+          <person userid="user_27" role="maintainer" />
         </project>
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 09:10:09 GMT
+  recorded_at: Mon, 30 Jul 2018 19:12:18 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/openSUSE:Factory:Staging:A/_meta?user=_nobody_
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="openSUSE:Factory:Staging:A">
+          <title>A Time to Kill</title>
+          <description>      requests:
+                - { id: 1 }
+        </description>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '153'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="openSUSE:Factory:Staging:A">
+          <title>A Time to Kill</title>
+          <description>      requests:
+                - { id: 1 }
+        </description>
+        </project>
+    http_version: 
+  recorded_at: Mon, 30 Jul 2018 19:12:18 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/openSUSE:Factory:Staging:B/_meta?user=_nobody_
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="openSUSE:Factory:Staging:B">
+          <title>The Little Foxes</title>
+          <description>Factory staging project B</description>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '144'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="openSUSE:Factory:Staging:B">
+          <title>The Little Foxes</title>
+          <description>Factory staging project B</description>
+        </project>
+    http_version: 
+  recorded_at: Mon, 30 Jul 2018 19:12:18 GMT
 - request:
     method: get
     uri: http://backend:5352/build/openSUSE:Factory:Staging:A/_result?package=Test-DVD-x86_64&repository=images&view=binarylist
@@ -350,7 +432,7 @@ http_interactions:
           <details>404 unknown repository 'images'</details>
         </status>
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 09:10:09 GMT
+  recorded_at: Mon, 30 Jul 2018 19:12:19 GMT
 - request:
     method: get
     uri: http://backend:5352/build/openSUSE:Factory:Staging:A/_result?code=unresolvable
@@ -385,5 +467,5 @@ http_interactions:
 
 '
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 09:10:09 GMT
+  recorded_at: Mon, 30 Jul 2018 19:12:19 GMT
 recorded_with: VCR 4.0.0

--- a/src/api/spec/cassettes/Webui_ObsFactory_StagingProjectsController/GET_show/with_a_non-existent_factory_staging_project/1_2_2_1.yml
+++ b/src/api/spec/cassettes/Webui_ObsFactory_StagingProjectsController/GET_show/with_a_non-existent_factory_staging_project/1_2_2_1.yml
@@ -2,51 +2,12 @@
 http_interactions:
 - request:
     method: put
-    uri: http://backend:5352/source/openSUSE:Factory:Staging:A/_meta?user=_nobody_
+    uri: http://backend:5352/source/openSUSE:Factory:Staging/_meta?user=_nobody_
     body:
       encoding: UTF-8
       string: |
-        <project name="openSUSE:Factory:Staging:A">
-          <title>To Your Scattered Bodies Go</title>
-          <description>Factory staging project A</description>
-        </project>
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '155'
-    body:
-      encoding: UTF-8
-      string: |
-        <project name="openSUSE:Factory:Staging:A">
-          <title>To Your Scattered Bodies Go</title>
-          <description>Factory staging project A</description>
-        </project>
-    http_version: 
-  recorded_at: Mon, 30 Jul 2018 09:10:08 GMT
-- request:
-    method: put
-    uri: http://backend:5352/source/openSUSE:Factory/_meta?user=_nobody_
-    body:
-      encoding: UTF-8
-      string: |
-        <project name="openSUSE:Factory">
-          <title>That Hideous Strength</title>
+        <project name="openSUSE:Factory:Staging">
+          <title>A Scanner Darkly</title>
           <description/>
         </project>
     headers:
@@ -68,14 +29,371 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '114'
+      - '117'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="openSUSE:Factory:Staging">
+          <title>A Scanner Darkly</title>
+          <description></description>
+        </project>
+    http_version: 
+  recorded_at: Mon, 30 Jul 2018 19:12:21 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/openSUSE:Factory/_meta?user=_nobody_
     body:
       encoding: UTF-8
       string: |
         <project name="openSUSE:Factory">
-          <title>That Hideous Strength</title>
+          <title>I Sing the Body Electric</title>
+          <description/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '117'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="openSUSE:Factory">
+          <title>I Sing the Body Electric</title>
           <description></description>
         </project>
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 09:10:08 GMT
+  recorded_at: Mon, 30 Jul 2018 19:12:21 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/openSUSE:Factory/target_package/_meta?user=_nobody_
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="target_package" project="openSUSE:Factory">
+          <title>Arms and the Man</title>
+          <description>Magnam quidem cupiditate sed.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '163'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="target_package" project="openSUSE:Factory">
+          <title>Arms and the Man</title>
+          <description>Magnam quidem cupiditate sed.</description>
+        </package>
+    http_version: 
+  recorded_at: Mon, 30 Jul 2018 19:12:21 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/openSUSE:Factory/target_package/_meta?user=_nobody_
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="target_package" project="openSUSE:Factory">
+          <title>Arms and the Man</title>
+          <description>Magnam quidem cupiditate sed.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '163'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="target_package" project="openSUSE:Factory">
+          <title>Arms and the Man</title>
+          <description>Magnam quidem cupiditate sed.</description>
+        </package>
+    http_version: 
+  recorded_at: Mon, 30 Jul 2018 19:12:21 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/project_15/_meta?user=_nobody_
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="project_15">
+          <title>A Farewell to Arms</title>
+          <description/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '105'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="project_15">
+          <title>A Farewell to Arms</title>
+          <description></description>
+        </project>
+    http_version: 
+  recorded_at: Mon, 30 Jul 2018 19:12:21 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/project_15/package_15/_meta?user=_nobody_
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="package_15" project="project_15">
+          <title>A Monstrous Regiment of Women</title>
+          <description>Provident sint quod nostrum.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '165'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="package_15" project="project_15">
+          <title>A Monstrous Regiment of Women</title>
+          <description>Provident sint quod nostrum.</description>
+        </package>
+    http_version: 
+  recorded_at: Mon, 30 Jul 2018 19:12:21 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/project_15/package_15/_meta?user=_nobody_
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="package_15" project="project_15">
+          <title>A Monstrous Regiment of Women</title>
+          <description>Provident sint quod nostrum.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '165'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="package_15" project="project_15">
+          <title>A Monstrous Regiment of Women</title>
+          <description>Provident sint quod nostrum.</description>
+        </package>
+    http_version: 
+  recorded_at: Mon, 30 Jul 2018 19:12:21 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:user_30/_meta?user=user_30
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:user_30">
+          <title/>
+          <description/>
+          <person userid="user_30" role="maintainer"/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '137'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:user_30">
+          <title></title>
+          <description></description>
+          <person userid="user_30" role="maintainer" />
+        </project>
+    http_version: 
+  recorded_at: Mon, 30 Jul 2018 19:12:21 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/openSUSE:Factory:Staging:A/_meta?user=_nobody_
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="openSUSE:Factory:Staging:A">
+          <title>The Other Side of Silence</title>
+          <description>      requests:
+                - { id: 1 }
+        </description>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '164'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="openSUSE:Factory:Staging:A">
+          <title>The Other Side of Silence</title>
+          <description>      requests:
+                - { id: 1 }
+        </description>
+        </project>
+    http_version: 
+  recorded_at: Mon, 30 Jul 2018 19:12:21 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/openSUSE:Factory:Staging:B/_meta?user=_nobody_
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="openSUSE:Factory:Staging:B">
+          <title>Recalled to Life</title>
+          <description>Factory staging project B</description>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '144'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="openSUSE:Factory:Staging:B">
+          <title>Recalled to Life</title>
+          <description>Factory staging project B</description>
+        </project>
+    http_version: 
+  recorded_at: Mon, 30 Jul 2018 19:12:22 GMT
 recorded_with: VCR 4.0.0

--- a/src/api/spec/cassettes/Webui_ObsFactory_StagingProjectsController/GET_show/with_a_non-existent_factory_staging_project/1_2_2_2.yml
+++ b/src/api/spec/cassettes/Webui_ObsFactory_StagingProjectsController/GET_show/with_a_non-existent_factory_staging_project/1_2_2_2.yml
@@ -2,51 +2,12 @@
 http_interactions:
 - request:
     method: put
-    uri: http://backend:5352/source/openSUSE:Factory:Staging:A/_meta?user=_nobody_
+    uri: http://backend:5352/source/openSUSE:Factory:Staging/_meta?user=_nobody_
     body:
       encoding: UTF-8
       string: |
-        <project name="openSUSE:Factory:Staging:A">
-          <title>The Painted Veil</title>
-          <description>Factory staging project A</description>
-        </project>
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '144'
-    body:
-      encoding: UTF-8
-      string: |
-        <project name="openSUSE:Factory:Staging:A">
-          <title>The Painted Veil</title>
-          <description>Factory staging project A</description>
-        </project>
-    http_version: 
-  recorded_at: Mon, 30 Jul 2018 09:10:08 GMT
-- request:
-    method: put
-    uri: http://backend:5352/source/openSUSE:Factory/_meta?user=_nobody_
-    body:
-      encoding: UTF-8
-      string: |
-        <project name="openSUSE:Factory">
-          <title>Wildfire at Midnight</title>
+        <project name="openSUSE:Factory:Staging">
+          <title>All the King's Men</title>
           <description/>
         </project>
     headers:
@@ -68,14 +29,371 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '113'
+      - '119'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="openSUSE:Factory:Staging">
+          <title>All the King's Men</title>
+          <description></description>
+        </project>
+    http_version: 
+  recorded_at: Mon, 30 Jul 2018 19:12:20 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/openSUSE:Factory/_meta?user=_nobody_
     body:
       encoding: UTF-8
       string: |
         <project name="openSUSE:Factory">
-          <title>Wildfire at Midnight</title>
+          <title>All the King's Men</title>
+          <description/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '111'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="openSUSE:Factory">
+          <title>All the King's Men</title>
           <description></description>
         </project>
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 09:10:08 GMT
+  recorded_at: Mon, 30 Jul 2018 19:12:20 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/openSUSE:Factory/target_package/_meta?user=_nobody_
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="target_package" project="openSUSE:Factory">
+          <title>Little Hands Clapping</title>
+          <description>Sit qui error iure.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '158'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="target_package" project="openSUSE:Factory">
+          <title>Little Hands Clapping</title>
+          <description>Sit qui error iure.</description>
+        </package>
+    http_version: 
+  recorded_at: Mon, 30 Jul 2018 19:12:20 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/openSUSE:Factory/target_package/_meta?user=_nobody_
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="target_package" project="openSUSE:Factory">
+          <title>Little Hands Clapping</title>
+          <description>Sit qui error iure.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '158'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="target_package" project="openSUSE:Factory">
+          <title>Little Hands Clapping</title>
+          <description>Sit qui error iure.</description>
+        </package>
+    http_version: 
+  recorded_at: Mon, 30 Jul 2018 19:12:20 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/project_14/_meta?user=_nobody_
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="project_14">
+          <title>Little Hands Clapping</title>
+          <description/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '108'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="project_14">
+          <title>Little Hands Clapping</title>
+          <description></description>
+        </project>
+    http_version: 
+  recorded_at: Mon, 30 Jul 2018 19:12:20 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/project_14/package_14/_meta?user=_nobody_
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="package_14" project="project_14">
+          <title>Pale Kings and Princes</title>
+          <description>Itaque in consequatur maxime.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '159'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="package_14" project="project_14">
+          <title>Pale Kings and Princes</title>
+          <description>Itaque in consequatur maxime.</description>
+        </package>
+    http_version: 
+  recorded_at: Mon, 30 Jul 2018 19:12:20 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/project_14/package_14/_meta?user=_nobody_
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="package_14" project="project_14">
+          <title>Pale Kings and Princes</title>
+          <description>Itaque in consequatur maxime.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '159'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="package_14" project="project_14">
+          <title>Pale Kings and Princes</title>
+          <description>Itaque in consequatur maxime.</description>
+        </package>
+    http_version: 
+  recorded_at: Mon, 30 Jul 2018 19:12:20 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:user_29/_meta?user=user_29
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:user_29">
+          <title/>
+          <description/>
+          <person userid="user_29" role="maintainer"/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '137'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:user_29">
+          <title></title>
+          <description></description>
+          <person userid="user_29" role="maintainer" />
+        </project>
+    http_version: 
+  recorded_at: Mon, 30 Jul 2018 19:12:20 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/openSUSE:Factory:Staging:A/_meta?user=_nobody_
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="openSUSE:Factory:Staging:A">
+          <title>The Wings of the Dove</title>
+          <description>      requests:
+                - { id: 1 }
+        </description>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '160'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="openSUSE:Factory:Staging:A">
+          <title>The Wings of the Dove</title>
+          <description>      requests:
+                - { id: 1 }
+        </description>
+        </project>
+    http_version: 
+  recorded_at: Mon, 30 Jul 2018 19:12:21 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/openSUSE:Factory:Staging:B/_meta?user=_nobody_
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="openSUSE:Factory:Staging:B">
+          <title>Ring of Bright Water</title>
+          <description>Factory staging project B</description>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '148'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="openSUSE:Factory:Staging:B">
+          <title>Ring of Bright Water</title>
+          <description>Factory staging project B</description>
+        </project>
+    http_version: 
+  recorded_at: Mon, 30 Jul 2018 19:12:21 GMT
 recorded_with: VCR 4.0.0

--- a/src/api/spec/controllers/webui/obs_factory/staging_projects_controller_spec.rb
+++ b/src/api/spec/controllers/webui/obs_factory/staging_projects_controller_spec.rb
@@ -12,8 +12,6 @@ RSpec.describe Webui::ObsFactory::StagingProjectsController, type: :controller, 
   end
   let(:factory) { create(:project, name: 'openSUSE:Factory') }
   let!(:factory_staging) { create(:project, name: 'openSUSE:Factory:Staging') }
-  let!(:factory_staging_a) { create(:project, name: 'openSUSE:Factory:Staging:A', description: description) }
-  let!(:factory_staging_b) { create(:project, name: 'openSUSE:Factory:Staging:B', description: 'Factory staging project B') }
 
   let(:factory_distribution) { ::ObsFactory::Distribution.find(factory.name) }
   let(:staging_projects) { ::ObsFactory::StagingProject.for(factory_distribution) }
@@ -26,6 +24,11 @@ RSpec.describe Webui::ObsFactory::StagingProjectsController, type: :controller, 
            target_package: target_package.name,
            source_project: source_package.project.name,
            source_package: source_package.name)
+  end
+
+  before do
+    create(:project, name: 'openSUSE:Factory:Staging:A', description: description)
+    create(:project, name: 'openSUSE:Factory:Staging:B', description: 'Factory staging project B')
   end
 
   describe 'GET #index' do

--- a/src/api/spec/controllers/webui/obs_factory/staging_projects_controller_spec.rb
+++ b/src/api/spec/controllers/webui/obs_factory/staging_projects_controller_spec.rb
@@ -4,12 +4,31 @@ require 'webmock/rspec'
 RSpec.describe Webui::ObsFactory::StagingProjectsController, type: :controller, vcr: true do
   render_views
 
+  let(:description) do
+    <<-DESCRIPTION
+      requests:
+        - { id: #{declined_bs_request.number} }
+    DESCRIPTION
+  end
   let(:factory) { create(:project, name: 'openSUSE:Factory') }
-  let!(:factory_staging_a) { create(:project, name: 'openSUSE:Factory:Staging:A', description: 'Factory staging project A') }
+  let!(:factory_staging) { create(:project, name: 'openSUSE:Factory:Staging') }
+  let!(:factory_staging_a) { create(:project, name: 'openSUSE:Factory:Staging:A', description: description) }
+  let!(:factory_staging_b) { create(:project, name: 'openSUSE:Factory:Staging:B', description: 'Factory staging project B') }
+
+  let(:factory_distribution) { ::ObsFactory::Distribution.find(factory.name) }
+  let(:staging_projects) { ::ObsFactory::StagingProject.for(factory_distribution) }
+
+  let(:source_package) { create(:package) }
+  let(:target_package) { create(:package, name: 'target_package', project: factory) }
+  let(:declined_bs_request) do
+    create(:declined_bs_request,
+           target_project: factory.name,
+           target_package: target_package.name,
+           source_project: source_package.project.name,
+           source_package: source_package.name)
+  end
 
   describe 'GET #index' do
-    let!(:factory_staging) { create(:project, name: 'openSUSE:Factory:Staging') }
-
     context 'without dashboard package' do
       before do
         get :index, params: { project: factory }
@@ -107,10 +126,6 @@ RSpec.describe Webui::ObsFactory::StagingProjectsController, type: :controller, 
     end
 
     context 'requesting json' do
-      let!(:factory_staging_b) { create(:project, name: 'openSUSE:Factory:Staging:B', description: '') }
-      let(:factory_distribution) { ::ObsFactory::Distribution.find(factory.name) }
-      let(:staging_projects) { ::ObsFactory::StagingProject.for(factory_distribution) }
-
       subject { get :index, params: { project: factory }, format: :json }
 
       it { is_expected.to have_http_status(:success) }
@@ -121,33 +136,13 @@ RSpec.describe Webui::ObsFactory::StagingProjectsController, type: :controller, 
   end
 
   describe 'GET #show' do
-    let(:source_package) { create(:package) }
-    let(:target_package) { create(:package, name: 'target_package', project: factory) }
-    let(:bs_request) do
-      create(:bs_request_with_submit_action,
-             target_project: factory.name,
-             target_package: target_package.name,
-             source_project: source_package.project.name,
-             source_package: source_package.name)
-    end
-    let(:description) do
-      <<-DESCRIPTION
-        requests:
-          - { id: #{bs_request.number} }
-      DESCRIPTION
-    end
-
     context 'with a existent factory_staging_project' do
-      before do
-        bs_request.update(state: 'declined')
-        factory_staging_a.update(description: description)
-      end
-
       context 'requesting html' do
-        subject { get :show, params: { project: factory, project_name: 'A' } }
+        subject! { get :show, params: { project: factory, project_name: 'A' } }
 
         it { is_expected.to have_http_status(:success) }
         it { is_expected.to render_template(:show) }
+        it { expect(assigns(:staging_project).obsolete_requests).to contain_exactly(declined_bs_request) }
       end
 
       context 'requesting json' do
@@ -159,7 +154,7 @@ RSpec.describe Webui::ObsFactory::StagingProjectsController, type: :controller, 
           expect(response).to include(
             'name'              => 'openSUSE:Factory:Staging:A',
             'description'       => description,
-            'obsolete_requests' => [JSON.parse(bs_request.to_json)],
+            'obsolete_requests' => [JSON.parse(declined_bs_request.to_json)],
             'overall_state'     => 'unacceptable'
           )
         end
@@ -167,7 +162,7 @@ RSpec.describe Webui::ObsFactory::StagingProjectsController, type: :controller, 
     end
 
     context 'with a non-existent factory_staging_project' do
-      subject { get :show, params: { project: factory, project_name: 'B' } }
+      subject { get :show, params: { project: factory, project_name: 'C' } }
 
       it { is_expected.to have_http_status(:found) }
       it { is_expected.to redirect_to(root_path) }

--- a/src/api/spec/controllers/webui/obs_factory/staging_projects_controller_spec.rb
+++ b/src/api/spec/controllers/webui/obs_factory/staging_projects_controller_spec.rb
@@ -30,12 +30,12 @@ RSpec.describe Webui::ObsFactory::StagingProjectsController, type: :controller, 
 
   describe 'GET #index' do
     context 'without dashboard package' do
-      before do
+      subject! do
         get :index, params: { project: factory }
       end
 
-      it { expect(response).to have_http_status(:success) }
-      it { expect(response).to render_template(:index) }
+      it { is_expected.to have_http_status(:success) }
+      it { is_expected.to render_template(:index) }
 
       it 'sets up the required variables' do
         expect(assigns(:backlog_requests_ignored)).to be_empty
@@ -89,12 +89,14 @@ RSpec.describe Webui::ObsFactory::StagingProjectsController, type: :controller, 
           before do
             allow_any_instance_of(Package).to receive(:file_exists?).with('ignored_requests').and_return(true)
             stub_request(:get, backend_url).and_return(body: backend_response)
+          end
 
+          subject! do
             get :index, params: { project: factory }
           end
 
-          it { expect(response).to have_http_status(:success) }
-          it { expect(response).to render_template(:index) }
+          it { is_expected.to have_http_status(:success) }
+          it { is_expected.to render_template(:index) }
 
           it 'sets up the required variables' do
             expect(assigns(:backlog_requests_ignored)).to contain_exactly(create_review_requests.first)
@@ -109,11 +111,14 @@ RSpec.describe Webui::ObsFactory::StagingProjectsController, type: :controller, 
             allow_any_instance_of(Package).to receive(:file_exists?).with('ignored_requests').and_return(true)
 
             stub_request(:get, backend_url).and_return(body: '')
+          end
+
+          subject! do
             get :index, params: { project: factory }
           end
 
-          it { expect(response).to have_http_status(:success) }
-          it { expect(response).to render_template(:index) }
+          it { is_expected.to have_http_status(:success) }
+          it { is_expected.to render_template(:index) }
 
           it 'sets up the required variables' do
             expect(assigns(:backlog_requests_ignored)).to be_empty


### PR DESCRIPTION
There is some overlap in what both tests set up.
Therefore it makes sense to define common code on the top level to
keep the test code DRY.

Add a test to ensure that declined requests are shown