### PR TITLE
Fix PublicControllTest to work reliably without VCR

### DIFF
--- a/src/api/spec/cassettes/PublicController/GET_project_index/without_view_specified/1_6_1_1.yml
+++ b/src/api/spec/cassettes/PublicController/GET_project_index/without_view_specified/1_6_1_1.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: put
-    uri: http://backend:5352/source/public_controller_project/_meta
+    uri: http://backend:5352/source/public_controller_project/_meta?user=_nobody_
     body:
       encoding: UTF-8
       string: |
@@ -38,14 +38,17 @@ http_interactions:
           <description></description>
         </project>
     http_version: 
-  recorded_at: Thu, 13 Oct 2016 08:34:33 GMT
+  recorded_at: Tue, 31 Jul 2018 20:34:59 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/public_controller_project/_config
+    uri: http://backend:5352/source/public_controller_project/public_controller_package/_meta?user=_nobody_
     body:
       encoding: UTF-8
-      string: Ducimus laudantium voluptates ullam aspernatur at quo sit. Laborum laudantium
-        consequatur ipsa quaerat. Quis enim sed eum modi sit perferendis.
+      string: |
+        <package name="public_controller_package" project="public_controller_project">
+          <title>Consider the Lilies</title>
+          <description>Eaque blanditiis eum est.</description>
+        </package>
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -65,14 +68,133 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '21'
+      - '182'
     body:
       encoding: UTF-8
-      string: '<status code="ok" />
-
-'
+      string: |
+        <package name="public_controller_package" project="public_controller_project">
+          <title>Consider the Lilies</title>
+          <description>Eaque blanditiis eum est.</description>
+        </package>
     http_version: 
-  recorded_at: Thu, 13 Oct 2016 08:34:33 GMT
+  recorded_at: Tue, 31 Jul 2018 20:35:00 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/public_controller_project/public_controller_package/_meta?user=_nobody_
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="public_controller_package" project="public_controller_project">
+          <title>Consider the Lilies</title>
+          <description>Eaque blanditiis eum est.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '182'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="public_controller_package" project="public_controller_project">
+          <title>Consider the Lilies</title>
+          <description>Eaque blanditiis eum est.</description>
+        </package>
+    http_version: 
+  recorded_at: Tue, 31 Jul 2018 20:35:00 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/public_controller_project/public_controller_package/_config
+    body:
+      encoding: UTF-8
+      string: Ratione laudantium qui. Sed nemo ut. Modi perspiciatis sed.
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '207'
+    body:
+      encoding: UTF-8
+      string: |
+        <revision rev="1" vrev="1">
+          <srcmd5>414e844bbaa6fa81a859f64ffe1d73d9</srcmd5>
+          <version>unknown</version>
+          <time>1533069300</time>
+          <user>unknown</user>
+          <comment></comment>
+          <requestid/>
+        </revision>
+    http_version: 
+  recorded_at: Tue, 31 Jul 2018 20:35:00 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/public_controller_project/public_controller_package/somefile.txt
+    body:
+      encoding: UTF-8
+      string: Placeat velit ea. Ea fuga culpa. Quas aut et.
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '207'
+    body:
+      encoding: UTF-8
+      string: |
+        <revision rev="2" vrev="2">
+          <srcmd5>793d3ab8d5a4977471010e49d698f6a6</srcmd5>
+          <version>unknown</version>
+          <time>1533069300</time>
+          <user>unknown</user>
+          <comment></comment>
+          <requestid/>
+        </revision>
+    http_version: 
+  recorded_at: Tue, 31 Jul 2018 20:35:00 GMT
 - request:
     method: get
     uri: http://backend:5352/source/public_controller_project?expand=1&noorigins=1
@@ -106,5 +228,5 @@ http_interactions:
           <entry name="public_controller_package" />
         </directory>
     http_version: 
-  recorded_at: Thu, 13 Oct 2016 08:34:33 GMT
-recorded_with: VCR 3.0.3
+  recorded_at: Tue, 31 Jul 2018 20:35:00 GMT
+recorded_with: VCR 4.0.0

--- a/src/api/spec/cassettes/PublicController/GET_project_index/without_view_specified/1_6_1_2.yml
+++ b/src/api/spec/cassettes/PublicController/GET_project_index/without_view_specified/1_6_1_2.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: put
-    uri: http://backend:5352/source/public_controller_project/_meta
+    uri: http://backend:5352/source/public_controller_project/_meta?user=_nobody_
     body:
       encoding: UTF-8
       string: |
@@ -38,14 +38,17 @@ http_interactions:
           <description></description>
         </project>
     http_version: 
-  recorded_at: Thu, 13 Oct 2016 08:34:33 GMT
+  recorded_at: Tue, 31 Jul 2018 20:35:00 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/public_controller_project/_config
+    uri: http://backend:5352/source/public_controller_project/public_controller_package/_meta?user=_nobody_
     body:
       encoding: UTF-8
-      string: Est sed dolorem. Error sunt pariatur qui dolore. Similique autem neque
-        repellat.
+      string: |
+        <package name="public_controller_package" project="public_controller_project">
+          <title>The Green Bay Tree</title>
+          <description>Minima mollitia dolorem tempore.</description>
+        </package>
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -65,14 +68,133 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '21'
+      - '188'
     body:
       encoding: UTF-8
-      string: '<status code="ok" />
-
-'
+      string: |
+        <package name="public_controller_package" project="public_controller_project">
+          <title>The Green Bay Tree</title>
+          <description>Minima mollitia dolorem tempore.</description>
+        </package>
     http_version: 
-  recorded_at: Thu, 13 Oct 2016 08:34:33 GMT
+  recorded_at: Tue, 31 Jul 2018 20:35:00 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/public_controller_project/public_controller_package/_meta?user=_nobody_
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="public_controller_package" project="public_controller_project">
+          <title>The Green Bay Tree</title>
+          <description>Minima mollitia dolorem tempore.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '188'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="public_controller_package" project="public_controller_project">
+          <title>The Green Bay Tree</title>
+          <description>Minima mollitia dolorem tempore.</description>
+        </package>
+    http_version: 
+  recorded_at: Tue, 31 Jul 2018 20:35:00 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/public_controller_project/public_controller_package/_config
+    body:
+      encoding: UTF-8
+      string: Et fuga omnis. Et hic quod. Consequatur aspernatur eum.
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '207'
+    body:
+      encoding: UTF-8
+      string: |
+        <revision rev="3" vrev="3">
+          <srcmd5>b7a64c4a4bf0e1662a84c3e28547f72e</srcmd5>
+          <version>unknown</version>
+          <time>1533069300</time>
+          <user>unknown</user>
+          <comment></comment>
+          <requestid/>
+        </revision>
+    http_version: 
+  recorded_at: Tue, 31 Jul 2018 20:35:00 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/public_controller_project/public_controller_package/somefile.txt
+    body:
+      encoding: UTF-8
+      string: Placeat velit ea. Ea fuga culpa. Quas aut et.
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '207'
+    body:
+      encoding: UTF-8
+      string: |
+        <revision rev="4" vrev="4">
+          <srcmd5>b7a64c4a4bf0e1662a84c3e28547f72e</srcmd5>
+          <version>unknown</version>
+          <time>1533069300</time>
+          <user>unknown</user>
+          <comment></comment>
+          <requestid/>
+        </revision>
+    http_version: 
+  recorded_at: Tue, 31 Jul 2018 20:35:00 GMT
 - request:
     method: get
     uri: http://backend:5352/source/public_controller_project?expand=1&noorigins=1
@@ -106,5 +228,5 @@ http_interactions:
           <entry name="public_controller_package" />
         </directory>
     http_version: 
-  recorded_at: Thu, 13 Oct 2016 08:34:33 GMT
-recorded_with: VCR 3.0.3
+  recorded_at: Tue, 31 Jul 2018 20:35:01 GMT
+recorded_with: VCR 4.0.0

--- a/src/api/spec/cassettes/PublicController/GET_project_index/without_view_specified/1_6_1_3.yml
+++ b/src/api/spec/cassettes/PublicController/GET_project_index/without_view_specified/1_6_1_3.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: put
-    uri: http://backend:5352/source/public_controller_project/_meta
+    uri: http://backend:5352/source/public_controller_project/_meta?user=_nobody_
     body:
       encoding: UTF-8
       string: |
@@ -38,14 +38,17 @@ http_interactions:
           <description></description>
         </project>
     http_version: 
-  recorded_at: Thu, 13 Oct 2016 08:34:33 GMT
+  recorded_at: Tue, 31 Jul 2018 20:35:01 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/public_controller_project/_config
+    uri: http://backend:5352/source/public_controller_project/public_controller_package/_meta?user=_nobody_
     body:
       encoding: UTF-8
-      string: Sunt adipisci ex cumque qui accusantium voluptates. Autem a sequi odio
-        non. Et ratione quis. Et quidem officiis perferendis qui vel vitae magni.
+      string: |
+        <package name="public_controller_package" project="public_controller_project">
+          <title>Oh! To be in England</title>
+          <description>Neque doloribus consequatur nihil.</description>
+        </package>
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -65,14 +68,133 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '21'
+      - '192'
     body:
       encoding: UTF-8
-      string: '<status code="ok" />
-
-'
+      string: |
+        <package name="public_controller_package" project="public_controller_project">
+          <title>Oh! To be in England</title>
+          <description>Neque doloribus consequatur nihil.</description>
+        </package>
     http_version: 
-  recorded_at: Thu, 13 Oct 2016 08:34:33 GMT
+  recorded_at: Tue, 31 Jul 2018 20:35:01 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/public_controller_project/public_controller_package/_meta?user=_nobody_
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="public_controller_package" project="public_controller_project">
+          <title>Oh! To be in England</title>
+          <description>Neque doloribus consequatur nihil.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '192'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="public_controller_package" project="public_controller_project">
+          <title>Oh! To be in England</title>
+          <description>Neque doloribus consequatur nihil.</description>
+        </package>
+    http_version: 
+  recorded_at: Tue, 31 Jul 2018 20:35:01 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/public_controller_project/public_controller_package/_config
+    body:
+      encoding: UTF-8
+      string: Inventore amet voluptas. Sit ut quia. Libero aliquam voluptas.
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '207'
+    body:
+      encoding: UTF-8
+      string: |
+        <revision rev="7" vrev="7">
+          <srcmd5>bf6e8c61263836a233ed86f872a86169</srcmd5>
+          <version>unknown</version>
+          <time>1533069301</time>
+          <user>unknown</user>
+          <comment></comment>
+          <requestid/>
+        </revision>
+    http_version: 
+  recorded_at: Tue, 31 Jul 2018 20:35:01 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/public_controller_project/public_controller_package/somefile.txt
+    body:
+      encoding: UTF-8
+      string: Placeat velit ea. Ea fuga culpa. Quas aut et.
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '207'
+    body:
+      encoding: UTF-8
+      string: |
+        <revision rev="8" vrev="8">
+          <srcmd5>bf6e8c61263836a233ed86f872a86169</srcmd5>
+          <version>unknown</version>
+          <time>1533069301</time>
+          <user>unknown</user>
+          <comment></comment>
+          <requestid/>
+        </revision>
+    http_version: 
+  recorded_at: Tue, 31 Jul 2018 20:35:01 GMT
 - request:
     method: get
     uri: http://backend:5352/source/public_controller_project?expand=1&noorigins=1
@@ -106,5 +228,5 @@ http_interactions:
           <entry name="public_controller_package" />
         </directory>
     http_version: 
-  recorded_at: Thu, 13 Oct 2016 08:34:33 GMT
-recorded_with: VCR 3.0.3
+  recorded_at: Tue, 31 Jul 2018 20:35:02 GMT
+recorded_with: VCR 4.0.0

--- a/src/api/spec/cassettes/PublicController/GET_project_index/without_view_specified/1_6_1_4.yml
+++ b/src/api/spec/cassettes/PublicController/GET_project_index/without_view_specified/1_6_1_4.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: put
-    uri: http://backend:5352/source/public_controller_project/_meta
+    uri: http://backend:5352/source/public_controller_project/_meta?user=_nobody_
     body:
       encoding: UTF-8
       string: |
@@ -38,14 +38,17 @@ http_interactions:
           <description></description>
         </project>
     http_version: 
-  recorded_at: Thu, 13 Oct 2016 08:34:33 GMT
+  recorded_at: Tue, 31 Jul 2018 20:35:01 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/public_controller_project/_config
+    uri: http://backend:5352/source/public_controller_project/public_controller_package/_meta?user=_nobody_
     body:
       encoding: UTF-8
-      string: Sint fugit quia fuga est voluptate sed perspiciatis. Magni expedita
-        et natus aperiam a. Architecto quia voluptas et.
+      string: |
+        <package name="public_controller_package" project="public_controller_project">
+          <title>Beyond the Mexique Bay</title>
+          <description>Et molestias repellat qui.</description>
+        </package>
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -65,14 +68,133 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '21'
+      - '186'
     body:
       encoding: UTF-8
-      string: '<status code="ok" />
-
-'
+      string: |
+        <package name="public_controller_package" project="public_controller_project">
+          <title>Beyond the Mexique Bay</title>
+          <description>Et molestias repellat qui.</description>
+        </package>
     http_version: 
-  recorded_at: Thu, 13 Oct 2016 08:34:33 GMT
+  recorded_at: Tue, 31 Jul 2018 20:35:01 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/public_controller_project/public_controller_package/_meta?user=_nobody_
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="public_controller_package" project="public_controller_project">
+          <title>Beyond the Mexique Bay</title>
+          <description>Et molestias repellat qui.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '186'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="public_controller_package" project="public_controller_project">
+          <title>Beyond the Mexique Bay</title>
+          <description>Et molestias repellat qui.</description>
+        </package>
+    http_version: 
+  recorded_at: Tue, 31 Jul 2018 20:35:01 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/public_controller_project/public_controller_package/_config
+    body:
+      encoding: UTF-8
+      string: Sit incidunt aut. Neque dolorem corporis. Ipsa explicabo ab.
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '207'
+    body:
+      encoding: UTF-8
+      string: |
+        <revision rev="5" vrev="5">
+          <srcmd5>116f29d820f91d2870e8d9e0b978d8ca</srcmd5>
+          <version>unknown</version>
+          <time>1533069301</time>
+          <user>unknown</user>
+          <comment></comment>
+          <requestid/>
+        </revision>
+    http_version: 
+  recorded_at: Tue, 31 Jul 2018 20:35:01 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/public_controller_project/public_controller_package/somefile.txt
+    body:
+      encoding: UTF-8
+      string: Placeat velit ea. Ea fuga culpa. Quas aut et.
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '207'
+    body:
+      encoding: UTF-8
+      string: |
+        <revision rev="6" vrev="6">
+          <srcmd5>116f29d820f91d2870e8d9e0b978d8ca</srcmd5>
+          <version>unknown</version>
+          <time>1533069301</time>
+          <user>unknown</user>
+          <comment></comment>
+          <requestid/>
+        </revision>
+    http_version: 
+  recorded_at: Tue, 31 Jul 2018 20:35:01 GMT
 - request:
     method: get
     uri: http://backend:5352/source/public_controller_project?expand=1&noorigins=1
@@ -106,5 +228,5 @@ http_interactions:
           <entry name="public_controller_package" />
         </directory>
     http_version: 
-  recorded_at: Thu, 13 Oct 2016 08:34:33 GMT
-recorded_with: VCR 3.0.3
+  recorded_at: Tue, 31 Jul 2018 20:35:01 GMT
+recorded_with: VCR 4.0.0

--- a/src/api/spec/controllers/public_controller_spec.rb
+++ b/src/api/spec/controllers/public_controller_spec.rb
@@ -68,6 +68,7 @@ RSpec.describe PublicController, vcr: true do
   describe 'GET #project_index' do
     context 'without view specified' do
       before do
+        package
         get :project_index, params: { project: project.name }
       end
 


### PR DESCRIPTION
The cassette contains a package that the test never
actually generates - blindly assuming another test
creates it, depending on the order