### PR TITLE
Fix Security/Open Rubocop offense

### DIFF
--- a/src/api/.rubocop_todo.yml
+++ b/src/api/.rubocop_todo.yml
@@ -745,11 +745,6 @@ Rails/SkipsModelValidations:
 Rails/TimeZone:
   Enabled: false
 
-# Offense count: 1
-Security/Open:
-  Exclude:
-    - 'app/models/obs_factory/distribution_strategy_factory.rb'
-
 # Offense count: 29
 # Configuration parameters: EnforcedStyle.
 # SupportedStyles: inline, group

--- a/src/api/app/controllers/webui/package_controller.rb
+++ b/src/api/app/controllers/webui/package_controller.rb
@@ -1,4 +1,3 @@
-require 'open-uri'
 require 'project'
 
 class Webui::PackageController < Webui::WebuiController

--- a/src/api/app/models/obs_factory/distribution.rb
+++ b/src/api/app/models/obs_factory/distribution.rb
@@ -1,5 +1,3 @@
-require 'open-uri'
-
 module ObsFactory
   class UnknownDistribution < RuntimeError
   end

--- a/src/api/app/models/obs_factory/distribution_strategy_factory.rb
+++ b/src/api/app/models/obs_factory/distribution_strategy_factory.rb
@@ -1,5 +1,3 @@
-require 'open-uri'
-
 module ObsFactory
   # this is not a Factory pattern, this is for openSUSE:Factory :/
   class DistributionStrategyFactory
@@ -114,11 +112,12 @@ module ObsFactory
     # @return [String] version string
     def published_version
       begin
-        f = open(repo_url)
+        stream = URI(repo_url)
       rescue ::OpenURI::HTTPError
         return 'unknown'
       end
-      matchdata = /openSUSE-(.*)-#{published_arch}-.*/.match(f.read)
+
+      matchdata = /openSUSE-(.*)-#{published_arch}-.*/.match(stream.read)
       matchdata[1]
     end
 

--- a/src/api/app/models/obs_factory/distribution_strategy_factory.rb
+++ b/src/api/app/models/obs_factory/distribution_strategy_factory.rb
@@ -117,8 +117,7 @@ module ObsFactory
         return 'unknown'
       end
 
-      matchdata = /openSUSE-(.*)-#{published_arch}-.*/.match(stream.read)
-      matchdata[1]
+      stream.read[/openSUSE-(.*)-#{published_arch}-.*/, 1]
     end
 
     def openqa_filter(project)

--- a/src/api/app/models/obs_factory/distribution_strategy_opensuse_leap15.rb
+++ b/src/api/app/models/obs_factory/distribution_strategy_opensuse_leap15.rb
@@ -44,12 +44,12 @@ module ObsFactory
     # @return [String] version string
     def published_version
       begin
-        f = URI(repo_url).open
+        stream = URI(repo_url)
       rescue ::OpenURI::HTTPError
         return 'unknown'
       end
-      matchdata = %r{openSUSE-#{opensuse_leap_version}-#{published_arch}-Build(.*)-Media}.match(f.read)
-      matchdata[1]
+
+      stream.read[/openSUSE-#{opensuse_leap_version}-#{published_arch}-Build(.*)-Media/, 1]
     end
 
     # URL parameter for Leap

--- a/src/api/spec/models/obs_factory/distribution_strategy_factory_spec.rb
+++ b/src/api/spec/models/obs_factory/distribution_strategy_factory_spec.rb
@@ -146,10 +146,9 @@ RSpec.describe ObsFactory::DistributionStrategyFactory do
   end
 
   describe '#published_version' do
-    let(:file) { StringIO.new('openSUSE-20180604-i586-Build') }
-
     before do
-      allow_any_instance_of(ObsFactory::DistributionStrategyFactory).to receive(:open).and_return(file)
+      stub_request(:get, 'http://download.opensuse.org/tumbleweed/repo/oss/media.1/media').
+        and_return(body: 'openSUSE-20180604-i586-Build')
     end
 
     it { expect(strategy.published_version).to eq('20180604') }


### PR DESCRIPTION
Using openURI's open method allows access to Kernel#open, which is
a bad idea when the parsed URIs can be provided by users.
This isn't the case for us right now, but since we plan to make the
staging dashboards configurable it makes sense to solve this now.
Otherwise this might become a problem in the future.

https://sakurity.com/blog/2015/02/28/openuri.html
https://twin.github.io/improving-open-uri/