### PR TITLE
Fix my fix for BsRequestAction_Differ_ForSource

### DIFF
--- a/src/api/spec/cassettes/BsRequestAction_Differ_ForSource/_perform/with_error/1_1_2_1.yml
+++ b/src/api/spec/cassettes/BsRequestAction_Differ_ForSource/_perform/with_error/1_1_2_1.yml
@@ -33,41 +33,4 @@ http_interactions:
         </directory>
     http_version: 
   recorded_at: Wed, 01 Aug 2018 17:28:03 GMT
-- request:
-    method: post
-    uri: http://backend:5352/source/source_project/source_package?cmd=diff&expand=1&filelimit=42&opackage=target_package&oproject=target_project&rev=2&tarlimit=43&view=xml&withissues=1
-    body:
-      encoding: UTF-8
-      string: ''
-    headers:
-      Content-Type:
-      - application/octet-stream
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 404
-      message: no such revision
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '110'
-    body:
-      encoding: UTF-8
-      string: |
-        <status code="404">
-          <summary>no such revision</summary>
-          <details>404 no such revision</details>
-        </status>
-    http_version: 
-  recorded_at: Wed, 01 Aug 2018 17:28:03 GMT
 recorded_with: VCR 4.0.0

--- a/src/api/spec/models/bs_request_action/differ/for_source_spec.rb
+++ b/src/api/spec/models/bs_request_action/differ/for_source_spec.rb
@@ -74,7 +74,7 @@ RSpec.describe BsRequestAction::Differ::ForSource, vcr: true do
       let(:path) { "#{CONFIG['source_url']}/source/#{source_project}/#{source_package}" }
       let(:no_such_revision) { '<status code="404"><summary>no such revision</summary><details>404 no such revision</details></status>' }
       before do
-        stub_request(:post, path).with(query: hash_including('cmd' => 'diff', 'opackage' => target_package)).and_return(body: no_such_revision, status: 404)
+        stub_request(:post, path).with(query: hash_including('cmd' => 'diff', 'opackage' => target_package.name)).and_return(body: no_such_revision, status: 404)
       end
 
       it { expect { subject.perform }.to raise_error(BsRequestAction::DiffError, %r{The diff call for source_project/source_package failed: no such revision}) }


### PR DESCRIPTION
The stub_request was using the project not its name,
which lead to the request appearing in cassettes - which
should have been a warning sign :(

#globalwritethroughmustdie