### PR TITLE
Adjust margin-bottom for pre tag in package#revisions

### DIFF
--- a/src/api/app/views/webui2/webui/package/_commit_item.html.haml
+++ b/src/api/app/views/webui2/webui/package/_commit_item.html.haml
@@ -17,7 +17,7 @@
 (revision #{commit['rev']})
 
 - if commit['comment'].present?
-  %pre.plain= commit['comment']
+  %pre.plain.mb-0= commit['comment']
 
 %ul.nav.float-right
   - if commit['rev'] != '1'


### PR DESCRIPTION
I noticed the gap between the comment section and the `Browse Source` link, which is a bit too much.

Before my changes:
![before](https://user-images.githubusercontent.com/1102934/43650292-b16b7f5c-973f-11e8-85e1-e8a118f1284e.png)

After my changes:
![after](https://user-images.githubusercontent.com/1102934/43650313-be5a1868-973f-11e8-8c37-a189dca72c92.png)
