### PR TITLE
Add a way to run minitest in a container

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -25,6 +25,8 @@ services:
 EOF"
       # Build the frontend container and pull newer version of the image if available
       sh 'docker-compose build --pull frontend'
+      # Build the minitest container on top of that
+      sh 'docker-compose -f docker-compose.yml -f docker-compose.minitest.yml build minitest'
       # Bootstrap the app
       sh 'docker-compose up -d db'
       sh 'docker-compose run --no-deps --rm frontend bundle exec rake dev:bootstrap RAILS_ENV=development'
@@ -55,6 +57,9 @@ EOF"
       end
       task 'frontend-base' => [:base] do
         sh "docker build src/api/ #{tags_for('frontend-base')} -f src/api/docker-files/Dockerfile.frontend-base"
+      end
+      task 'frontend-backend' => [:base] do
+        sh "docker build src/api/ #{tags_for('frontend-backend')} -f src/api/docker-files/Dockerfile.frontend-backend"
       end
       task backend: [:base] do
         sh "docker build src/backend/ #{tags_for(:backend)} -f src/backend/docker-files/Dockerfile.backend"

--- a/dist/obs-api-testsuite-rspec.spec
+++ b/dist/obs-api-testsuite-rspec.spec
@@ -56,10 +56,6 @@ bundle --local --path %_libdir/obs-api/
 
 ./script/prepare_spec_tests.sh
 
-# map to casssettes
-perl -pi -e 's/source_host: localhost/source_host: backend/' config/options.yml
-perl -pi -e 's/source_port: 3200/source_port: 5352/' config/options.yml
-
 export RAILS_ENV=test
 bin/rake db:create db:setup
 bin/rails assets:precompile

--- a/docker-compose.minitest.yml
+++ b/docker-compose.minitest.yml
@@ -1,0 +1,13 @@
+version: "2.1"
+services:
+  minitest:
+    image: openbuildservice/frontend-backend
+    build:
+      dockerfile: docker-files/Dockerfile.frontend-backend
+      context: src/api
+    volumes:
+      - .:/obs
+    depends_on:
+      - db
+      - cache
+

--- a/src/api/config/environments/test.rb
+++ b/src/api/config/environments/test.rb
@@ -79,5 +79,10 @@ CONFIG['frontend_port'] = 3203
 CONFIG['frontend_protocol'] = 'http'
 CONFIG['frontend_ldap_mode'] = :off
 
+if ENV['RUNNING_MINITEST']
+  CONFIG['source_host'] = 'localhost'
+  CONFIG['source_port'] = '3200'
+end
+
 # some defaults enforced
 CONFIG['apidocs_location'] = File.expand_path('../../docs/api/html/')

--- a/src/api/docker-files/Dockerfile.frontend-backend
+++ b/src/api/docker-files/Dockerfile.frontend-backend
@@ -1,0 +1,13 @@
+# layer on top to include backend for minitest
+
+FROM openbuildservice/frontend
+
+# fix file conflict
+RUN sudo zypper -n remove hostname
+RUN sudo zypper -n install net-tools inst-source-utils obs-server obs-signd obs-service-download_src_package obs-service-download_files \
+    obs-service-download_url obs-service-format_spec_file obs-service-kiwi_import perl-Devel-Cover perl-Diff-LibXDiff osc
+
+WORKDIR /obs/src/api
+CMD ["/bin/bash", "-l"]
+
+

--- a/src/api/lib/tasks/dev.rake
+++ b/src/api/lib/tasks/dev.rake
@@ -4,9 +4,7 @@ require 'fileutils'
 require 'yaml'
 
 namespace :dev do
-  task :prepare, [:old_test_suite] do |_t, args|
-    args.with_defaults(old_test_suite: false)
-
+  task :prepare do |_t, args|
     puts 'Setting up the database configuration...'
     copy_example_file('config/database.yml')
     database_yml = YAML.load_file('config/database.yml') || {}
@@ -19,9 +17,9 @@ namespace :dev do
     puts 'Setting up the application configuration...'
     copy_example_file('config/options.yml')
     options_yml = YAML.load_file('config/options.yml') || {}
-    options_yml['source_host'] = args.old_test_suite ? 'localhost' : 'backend'
+    options_yml['source_host'] = 'backend'
     options_yml['memcached_host'] = 'cache'
-    options_yml['source_port'] = args.old_test_suite ? '3200' : '5352'
+    options_yml['source_port'] = '5352'
     File.open('config/options.yml', 'w') do |f|
       f.write(YAML.dump(options_yml))
     end

--- a/src/api/script/api_minitest.sh
+++ b/src/api/script/api_minitest.sh
@@ -18,9 +18,6 @@ bin/rake db:create db:setup
 
 bin/rails assets:precompile
 
-perl -pi -e 's/source_host: backend/source_host: localhost/' config/options.yml
-perl -pi -e 's/source_port: 5352/source_port: 3200/' config/options.yml
-
 rm -f log/test.log
 bin/rake test:api test:spider
 

--- a/src/api/test/test_helper.rb
+++ b/src/api/test/test_helper.rb
@@ -1,6 +1,7 @@
 ENV['origin_RAILS_ENV'] = ENV['RAILS_ENV']
 
 ENV['RAILS_ENV'] = 'test'
+ENV['RUNNING_MINITEST'] = '1'
 
 require 'simplecov'
 require 'builder'


### PR DESCRIPTION
To avoid having to patch options.yml forth and back, I moved
the CONFIG patching into the test environment for minitest, so
you can leave the options.yml shared between development and rspec

Fixes #5553