### PR TITLE
Remove logging.rb from all backtraces

### DIFF
--- a/src/api/spec/support/logging.rb
+++ b/src/api/spec/support/logging.rb
@@ -1,6 +1,5 @@
 RSpec.configure do |config|
-  config.around do |example|
+  config.before do |example|
     Rails.logger.debug("\n\n\n===== #{example.full_description} =====\n\n")
-    example.run
   end
 end


### PR DESCRIPTION
Instead of using .around we use .before - this way
we don't have the logging.rb in every spec backtrace
and the actual spec is the first entry in the trace