### PR TITLE
[backend] prevent bs_regpush from crashing if no tags in registry

### DIFF
--- a/src/backend/bs_regpush
+++ b/src/backend/bs_regpush
@@ -230,7 +230,7 @@ sub get_all_tags {
   while (1) {
     undef $replyheaders;
     my $r = BSRPC::rpc($param, \&JSON::XS::decode_json);
-    push @regtags, @{$r->{'tags'}};
+    push @regtags, @{$r->{'tags'} || []};
     last unless $replyheaders->{'link'};
     die unless $replyheaders->{'link'} =~ /^<(\/v2\/.*)>/;
     $param->{'uri'} = "$registryserver$1";


### PR DESCRIPTION
This patch prevents bs_regpush from crashing if no tags are available
in the registry.

The registry could return a json like the following:

{"name":"home/m0ses/mycontainer","tags":null}

which results in an error message like

Can't use an undefined value as an ARRAY reference at /usr/lib/obs/server/bs_regpush line 233.

and bs_regpush die's

With this patch we set an empty ARRAY reference if $r->{tags} is empty.