### PR TITLE
Switch color tabs

### DIFF
--- a/src/api/app/assets/stylesheets/webui2/tabs-component.scss
+++ b/src/api/app/assets/stylesheets/webui2/tabs-component.scss
@@ -1,9 +1,9 @@
 ul.nav.nav-tabs li.nav-item {
   & a {
-    color: $obs_green;
+    color: $obs_blue;
 
     &:hover {
-      color: $obs_blue;
+      color: $obs_green;
     }
 
     &.dropdown-item.active {


### PR DESCRIPTION
@openSUSE/open-build-service, we have an open discussion about the colours of the tabs.

The options are the next:

Current:
![screenshot_2018-08-06 open build service 1](https://user-images.githubusercontent.com/1212806/43723592-4babb4a6-9998-11e8-8f86-f4f1c9988f2a.png)

Proposal:

![screenshot_2018-08-06 open build service](https://user-images.githubusercontent.com/1212806/43723608-5722c4c8-9998-11e8-972f-51351c6cbfca.png)

Please vote :+1:  for the proposal and :-1:  for the current.