### PR TITLE
Remove Statistic 'model'

### DIFF
--- a/src/api/app/models/statistic.rb
+++ b/src/api/app/models/statistic.rb
@@ -1,2 +1,0 @@
-class Statistic < ActiveXML::Node
-end

--- a/src/api/config/initializers/activexml.rb
+++ b/src/api/config/initializers/activexml.rb
@@ -14,6 +14,4 @@ map.connect :collection, 'rest:///search/:what?:match',
 
 map.connect :buildresult, 'rest:///build/:project/_result?:view&:package&:code&:lastbuild&:arch&:repository&:multibuild&:locallink'
 
-map.connect :statistic, 'rest:///build/:project/:repository/:arch/:package/_statistics'
-
 map.connect :service, 'rest:///source/:project/:package/_service?:user'

--- a/src/api/lib/backend/api/build_results/status.rb
+++ b/src/api/lib/backend/api/build_results/status.rb
@@ -22,6 +22,12 @@ module Backend
           http_get(['/build/:project/:repository/:architecture/:package/_reason', project_name, repository_name, architecture_name, package_name])
         end
 
+        # Return the collected statistics (disk usage, mem usage, ...) of a package
+        # @return [String]
+        def self.statistics(project_name, package_name, repository_name, architecture_name)
+          http_get(['/build/:project/:repository/:arch/:package/_statistics', project_name, repository_name, architecture_name, package_name])
+        end
+
         # Returns the result view for a build
         # @return [String]
         def self.build_result(project_name, package_name, repository_name, architecture_name)


### PR DESCRIPTION
This is just used in one route and only used to fetch
one XML file. This is a good fit for the backend lib