### PR TITLE
Add Haml-rails gem

### DIFF
--- a/src/api/Gemfile
+++ b/src/api/Gemfile
@@ -21,6 +21,8 @@ gem 'thinking-sphinx', '> 3.1'
 gem 'kaminari'
 # for abstract HTML
 gem 'haml'
+# streamline HAML's integration in Rails
+gem 'haml-rails'
 # to avoid tilt downgrade
 gem 'tilt', '>= 1.4.1'
 # to use markdown in the comment system

--- a/src/api/Gemfile.lock
+++ b/src/api/Gemfile.lock
@@ -129,6 +129,7 @@ GEM
     diff-lcs (1.3)
     docile (1.3.1)
     erubi (1.7.1)
+    erubis (2.7.0)
     escape_utils (1.2.1)
     execjs (2.7.0)
     factory_bot (4.10.0)
@@ -151,6 +152,12 @@ GEM
     haml (5.0.4)
       temple (>= 0.8.0)
       tilt
+    haml-rails (1.0.0)
+      actionpack (>= 4.0.1)
+      activesupport (>= 4.0.1)
+      haml (>= 4.0.6, < 6.0)
+      html2haml (>= 1.0.1)
+      railties (>= 4.0.1)
     haml_lint (0.28.0)
       haml (>= 4.0, < 5.1)
       rainbow
@@ -158,6 +165,11 @@ GEM
       rubocop (>= 0.50.0)
       sysexits (~> 1.1)
     hashdiff (0.3.7)
+    html2haml (2.2.0)
+      erubis (~> 2.7.0)
+      haml (>= 4.0, < 6)
+      nokogiri (>= 1.6.0)
+      ruby_parser (~> 3.5)
     i18n (1.1.0)
       concurrent-ruby (~> 1.0)
     innertube (1.1.0)
@@ -341,6 +353,8 @@ GEM
       rubocop (>= 0.56.0)
     ruby-ldap (0.9.20)
     ruby-progressbar (1.10.0)
+    ruby_parser (3.11.0)
+      sexp_processor (~> 4.9)
     rubyzip (1.2.1)
     safe_yaml (1.0.4)
     sanitize (4.6.6)
@@ -364,6 +378,7 @@ GEM
     selenium-webdriver (3.14.0)
       childprocess (~> 0.5)
       rubyzip (~> 1.2)
+    sexp_processor (4.11.0)
     shoulda-matchers (3.1.2)
       activesupport (>= 4.0.0)
     simplecov (0.16.1)
@@ -462,6 +477,7 @@ DEPENDENCIES
   font-awesome-sass
   gssapi
   haml
+  haml-rails
   haml_lint
   jquery-datatables
   jquery-rails


### PR DESCRIPTION
To generate views in `.haml` format instead of `.erb` by default.