### PR TITLE
Switch to use selenium with chrome instead of phantomjs for r2.9

### DIFF
--- a/dist/t/Gemfile
+++ b/dist/t/Gemfile
@@ -4,4 +4,4 @@ gem 'capybara'
 gem 'rspec-core'
 gem 'rspec-expectations'
 # as driver for capybara
-gem 'poltergeist', '>= 1.4'
+gem 'selenium-webdriver'

--- a/dist/t/Gemfile.lock
+++ b/dist/t/Gemfile.lock
@@ -10,18 +10,16 @@ GEM
       rack (>= 1.0.0)
       rack-test (>= 0.5.4)
       xpath (~> 2.0)
-    cliver (0.3.2)
+    childprocess (0.9.0)
+      ffi (~> 1.0, >= 1.0.11)
     diff-lcs (1.3)
+    ffi (1.9.25)
     mime-types (3.1)
       mime-types-data (~> 3.2015)
     mime-types-data (3.2016.0521)
     mini_portile2 (2.1.0)
     nokogiri (1.7.1)
       mini_portile2 (~> 2.1.0)
-    poltergeist (1.14.0)
-      capybara (~> 2.1)
-      cliver (~> 0.3.1)
-      websocket-driver (>= 0.2.0)
     public_suffix (2.0.5)
     rack (2.0.1)
     rack-test (0.6.3)
@@ -32,9 +30,10 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.5.0)
     rspec-support (3.5.0)
-    websocket-driver (0.6.5)
-      websocket-extensions (>= 0.1.0)
-    websocket-extensions (0.1.2)
+    rubyzip (1.2.1)
+    selenium-webdriver (3.14.0)
+      childprocess (~> 0.5)
+      rubyzip (~> 1.2)
     xpath (2.0.0)
       nokogiri (~> 1.3)
 
@@ -43,9 +42,9 @@ PLATFORMS
 
 DEPENDENCIES
   capybara
-  poltergeist (>= 1.4)
   rspec-core
   rspec-expectations
+  selenium-webdriver
 
 BUNDLED WITH
    1.13.7

--- a/dist/t/spec/support/capybara.rb
+++ b/dist/t/spec/support/capybara.rb
@@ -1,14 +1,20 @@
 require 'capybara'
 require 'capybara/dsl'
-require 'capybara/poltergeist'
+require 'selenium-webdriver'
 require 'socket'
 
-Capybara.register_driver :poltergeist do |app|
-  Capybara::Poltergeist::Driver.new(app, debug: false, timeout: 60)
+Selenium::WebDriver::Chrome.driver_path = '/usr/lib64/chromium/chromedriver'
+
+Capybara.register_driver :selenium_chrome_headless do |app|
+  browser_options = ::Selenium::WebDriver::Chrome::Options.new
+  browser_options.args << '--headless'
+  browser_options.args << '--no-sandbox'
+  browser_options.args << '--allow-insecure-localhost'
+  Capybara::Selenium::Driver.new(app, browser: :chrome, options: browser_options)
 end
 
-Capybara.default_driver = :poltergeist
-Capybara.javascript_driver = :poltergeist
+Capybara.default_driver = :selenium_chrome_headless
+Capybara.javascript_driver = :selenium_chrome_headless
 Capybara.save_path = '/tmp/rspec_screens'
 
 # Set hostname


### PR DESCRIPTION
Backport #5580 to 2.9.

Since we don't package phantomjs for OBS, and it is not used in the CI test suite, we also switch to selenium and headless chromium in smoke tests.

Co-authored-by: Saray Cabrera Padrón <scabrerapadron@suse.de>
Co-authored-by: Stephan Kulow <coolo@suse.de>