### PR TITLE
Don't require cloud clients in the backend docker image

### DIFF
--- a/docker-files/base/docker-bootstrap.sh
+++ b/docker-files/base/docker-bootstrap.sh
@@ -29,10 +29,11 @@ do
       obs-service-format_spec_file obs-service-kiwi_import \
       perl-Devel-Cover perl-Diff-LibXDiff \
       osc \
-      python3-setuptools \
-      python3-ec2uploadimg \
-      aws-cli \
       azure-cli
+      # AWS client disabled temporarily till python-botocore 1.10.62 can build for Leap 42.3
+      # python3-setuptools \
+      # python3-ec2uploadimg \
+      # aws-cli \
     ;;
 
   memcached)

--- a/docker-files/base/docker-bootstrap.sh
+++ b/docker-files/base/docker-bootstrap.sh
@@ -28,12 +28,14 @@ do
       obs-service-download_url \
       obs-service-format_spec_file obs-service-kiwi_import \
       perl-Devel-Cover perl-Diff-LibXDiff \
-      osc \
-      azure-cli
+      osc
       # AWS client disabled temporarily till python-botocore 1.10.62 can build for Leap 42.3
       # python3-setuptools \
       # python3-ec2uploadimg \
       # aws-cli \
+      #
+      # Azure client disabled temporarily till python3-pydocumentdb 2.0.1 can build for Leap 42.3
+      # azure-cli
     ;;
 
   memcached)


### PR DESCRIPTION
The Azure and AWS cllent packages can be temporarily not included in the `backend ` dockerfile in order to build the `backend` docker image that is only used in the development environment.

The backend docker image could be created and uploaded to docker hub as soon as this PR is merged. This image is the only one that is not updated in Docker Hub, now since 10 months.