### PR TITLE
Use backend as default source_host to fix package build

### DIFF
--- a/src/api/config/options.yml.example
+++ b/src/api/config/options.yml.example
@@ -19,7 +19,7 @@ min_votes_for_rating: 3
 response_schema_validation: false
 
 # backend source server
-source_host: localhost
+source_host: backend
 # NOTE: the source_port setting is ignored and hardcoded for "test" and "development" env
 source_port: 5352
 #source_protocol: https


### PR DESCRIPTION
As long as use cassettes we need to stick to 'backend'
in package builds - minitest hardcodes localhost and
is not affected by this