### PR TITLE
Revert "Notify Errbit for extra payload keys in events"

### DIFF
--- a/src/api/app/models/event/base.rb
+++ b/src/api/app/models/event/base.rb
@@ -123,9 +123,8 @@ module Event
 
       na = []
       attribs.keys.each { |k| na << k.to_s }
-      message = "LEFT #{self.class.name} payload_keys :#{na.sort.join(', :')}"
-      logger.debug(message)
-      Airbrake.notify("#{message} # #{attribs.inspect}")
+      logger.debug "LEFT #{self.class.name} payload_keys :#{na.sort.join(', :')}"
+      raise "LEFT #{self.class.name} payload_keys :#{na.sort.join(', :')} # #{attribs.inspect}"
     end
 
     def set_payload(attribs, keys)


### PR DESCRIPTION
This reverts commit ab5196b6ad9a4f9b0d0572b14054e29de4fc9190.

As discussed in the review meeting.