### PR TITLE
Fix repository URL for running TravisCI

### DIFF
--- a/dist/ci/travis_before_install.sh
+++ b/dist/ci/travis_before_install.sh
@@ -8,7 +8,7 @@ sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys C5C219E7
 
 # Install updates from our own repository
 sudo chmod a+w /etc/apt/sources.list.d
-echo 'deb http://download.opensuse.org/repositories/OBS:/Server:/Unstable/xUbuntu_14.04 /' > /etc/apt/sources.list.d/opensuse.list
+echo 'deb http://download.opensuse.org/repositories/OBS:/Server:/2.9:/Staging/xUbuntu_14.04 /' > /etc/apt/sources.list.d/opensuse.list
 
 # We could use this to only update the package list from the OBS,
 # but apprently this is not possible anymore. So we update all package lists.


### PR DESCRIPTION
On 2.9 branch this was pointing to Unstable. This caused not to find packages already deleted in Unstable, and TravisCI to fail.