### PR TITLE
Ignore running CircleCI in old branches

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -246,20 +246,38 @@ workflows:
   version: 2
   test_all:
     jobs:
-      - checkout_code
+      - checkout_code:
+          filters:
+            branches:
+              ignore: /^2\.[8-9]/
       - backend_test:
           requires:
             - checkout_code
+          filters:
+            branches:
+              ignore: /^2\.[8-9]/
       - rspec:
           requires:
             - checkout_code
+          filters:
+            branches:
+              ignore: /^2\.[8-9]/
       - minitest:
           requires:
             - checkout_code
+          filters:
+            branches:
+              ignore: /^2\.[8-9]/
       - spider:
           requires:
             - checkout_code
+          filters:
+            branches:
+              ignore: /^2\.[8-9]/
       - coverage:
           requires:
             - rspec
             - minitest
+          filters:
+            branches:
+              ignore: /^2\.[8-9]/


### PR DESCRIPTION
This prevents the tests on a pull request for an old branch (2.8 or 2.9) to fail on a not configured CircleCI environment. We can rely for that on TravisCI.

An entry on each job has been created. The workflow level filtering feature is not yet implemented.