### PR TITLE
[dist] revert commit 12adeaa6c

### DIFF
--- a/dist/obs-api-testsuite-rspec.spec
+++ b/dist/obs-api-testsuite-rspec.spec
@@ -56,6 +56,9 @@ bundle --local --path %_libdir/obs-api/
 
 ./script/prepare_spec_tests.sh
 
+# map to casssettes
+perl -pi -e 's/source_host: localhost/source_host: backend/' config/options.yml
+
 export RAILS_ENV=test
 bin/rake db:create db:setup
 bin/rails assets:precompile

--- a/src/api/config/options.yml.example
+++ b/src/api/config/options.yml.example
@@ -19,7 +19,7 @@ min_votes_for_rating: 3
 response_schema_validation: false
 
 # backend source server
-source_host: backend
+source_host: localhost
 # NOTE: the source_port setting is ignored and hardcoded for "test" and "development" env
 source_port: 5352
 #source_protocol: https


### PR DESCRIPTION
This commit reverts commit 12adeaa6c, because ATM our default
installation is broken. Even it might work in the test suite,
changing source_host to backend breaks real life installations.