### PR TITLE
Add pry-byebug gem

### DIFF
--- a/src/api/Gemfile
+++ b/src/api/Gemfile
@@ -147,6 +147,8 @@ group :development, :test do
   gem 'vcr'
   # as alternative to the standard IRB shell
   gem 'pry', '>= 0.9.12'
+  # add step-by-step debugging and stack navigation capabilities to pry
+  gem 'pry-byebug'
   # for style checks
   gem 'rubocop', require: false
   # for rspec style checks

--- a/src/api/Gemfile.lock
+++ b/src/api/Gemfile.lock
@@ -72,6 +72,7 @@ GEM
       uniform_notifier (~> 1.11.0)
     bunny (2.11.0)
       amq-protocol (~> 2.3.0)
+    byebug (10.0.2)
     capybara (3.5.1)
       addressable
       mini_mime (>= 0.1.3)
@@ -265,6 +266,9 @@ GEM
     pry (0.11.3)
       coderay (~> 1.1.0)
       method_source (~> 0.9.0)
+    pry-byebug (3.6.0)
+      byebug (~> 10.0)
+      pry (~> 0.10)
     public_suffix (3.0.2)
     puma (3.12.0)
     pundit (2.0.0)
@@ -499,6 +503,7 @@ DEPENDENCIES
   peek-host
   peek-mysql2
   pry (>= 0.9.12)
+  pry-byebug
   puma (~> 3.11)
   pundit
   rails (~> 5.2.0)


### PR DESCRIPTION
I would like to add the `pry-byebug` gem to improve the debugging experience. I don't know for you all, but when debugging, I set a breakpoint somewhere then move through the code to understand/debug what is going on. With `pry-byebug`, this is possible. This gem adds only one dependency for a lot of value in my opinion.

The gem's source/documentation is at https://github.com/deivid-rodriguez/pry-byebug