### PR TITLE
Configure Rails generator to use integer as primary and foreign keys

### DIFF
--- a/src/api/.rubocop.yml
+++ b/src/api/.rubocop.yml
@@ -166,6 +166,7 @@ Style/MethodCallWithArgsParentheses:
     - mkdir
     - must_be
     - not_to
+    - orm
     - parse
     - post
     - print

--- a/src/api/config/application.rb
+++ b/src/api/config/application.rb
@@ -113,6 +113,7 @@ module OBSApi
     config.generators do |g|
       g.factory_bot(false)
       g.test_framework :rspec
+      g.orm :active_record, primary_key_type: :integer
     end
 
     unless Rails.env.test?

--- a/src/api/config/database.yml.example
+++ b/src/api/config/database.yml.example
@@ -12,6 +12,7 @@ production:
   username: root
   password: opensuse
   encoding: utf8mb4
+  collation: utf8mb4_unicode_ci
   timeout: 15
   pool: 30
 
@@ -21,6 +22,7 @@ development:
   username: root
   password: opensuse
   encoding: utf8mb4
+  collation: utf8mb4_unicode_ci
   timeout: 15
   pool: 30
   
@@ -33,6 +35,7 @@ test:
   username: root
   password: opensuse
   encoding: utf8mb4
+  collation: utf8mb4_unicode_ci
   timeout: 15
   pool: 30
 


### PR DESCRIPTION
All our existing tables use integers as primary key. Using the "new"
default in Rails (bigint) would cause breakage in MySQL.