### PR TITLE
Fix route for configurations in backend Dockerfile

### DIFF
--- a/src/backend/docker-files/Dockerfile.backend
+++ b/src/backend/docker-files/Dockerfile.backend
@@ -3,7 +3,7 @@ FROM openbuildservice/base
 RUN /root/bin/docker-bootstrap.sh backend
 
 # Add our configurations
-ADD docker-files/configurations.tar.bz2 /
+ADD src/backend/docker-files/configurations.tar.bz2 /
 
 # Run our command
 WORKDIR /obs


### PR DESCRIPTION
Creation of backend docker image is failing. The route to copy the `configurations.tar.bz2` file is wrong. This allows to create the backend docker image.