### PR TITLE
Implement checks in StagingDashboard show view

### DIFF
--- a/src/api/app/assets/stylesheets/webui/obs_factory/application.css
+++ b/src/api/app/assets/stylesheets/webui/obs_factory/application.css
@@ -22,15 +22,15 @@
 }
 
 /* openQA */
-a.openqa-passed {
+a.openqa-passed, a.check-success {
     color: #6eb927
 }
 
-a.openqa-failed {
+a.openqa-failed, a.check-error, a.check-failure {
     color: red
 }
 
-a.openqa-none {
+a.openqa-none, a.check-pending {
     color: #006699
 }
 

--- a/src/api/app/controllers/webui/obs_factory/staging_projects_controller.rb
+++ b/src/api/app/controllers/webui/obs_factory/staging_projects_controller.rb
@@ -35,9 +35,15 @@ module Webui::ObsFactory
     def show
       respond_to do |format|
         format.html do
+          # FIXME: For staging repositories only the images repository is relevant atm
+          # However, we should make this configurable in the future
+          images_repository = @staging_project.repositories.find_by(name: 'image')
           @staging_project = ::ObsFactory::StagingProjectPresenter.new(@staging_project)
           # For the breadcrumbs
           @project = @distribution.project
+          return if images_repository.blank?
+          @build_id = images_repository.build_id
+          @checks = images_repository.checks.for_build_id(@build_id)
         end
         format.json { render json: @staging_project }
       end

--- a/src/api/app/helpers/webui/obs_factory/application_helper.rb
+++ b/src/api/app/helpers/webui/obs_factory/application_helper.rb
@@ -8,4 +8,10 @@ module Webui::ObsFactory::ApplicationHelper
     path << "&build=#{version}" if version
     path
   end
+
+  def icon_for_checks(checks)
+    return 'eye' if checks.any? { |check| check.state == 'pending' }
+    return 'accept' if checks.all? { |check| check.state == 'success' }
+    'error'
+  end
 end

--- a/src/api/app/models/obs_factory/staging_project.rb
+++ b/src/api/app/models/obs_factory/staging_project.rb
@@ -9,6 +9,7 @@ module ObsFactory
     include ActiveModel::Serializers::JSON
 
     attr_accessor :project, :distribution, :parent
+    delegate :repositories, to: :project
 
     NAME_PREFIX = ":Staging:".freeze
     ADI_NAME_PREFIX = ":Staging:adi:".freeze

--- a/src/api/app/views/webui/obs_factory/staging_projects/_checks.html.haml
+++ b/src/api/app/views/webui/obs_factory/staging_projects/_checks.html.haml
@@ -1,0 +1,12 @@
+%dt
+  = sprite_tag(icon_for_checks(@checks))
+  Checks
+  = "(#{@build_id})"
+%dd
+  - if @checks.empty?
+    None.
+  - else
+    %ul
+      - @checks.each do |check|
+        %li
+          = link_to "#{check.name} (#{check.state} - #{time_ago_in_words(check.updated_at)} ago)", check.url, class: "check-#{check.state}", title: "#{check.short_description} (#{check.updated_at})"

--- a/src/api/app/views/webui/obs_factory/staging_projects/show.html.erb
+++ b/src/api/app/views/webui/obs_factory/staging_projects/show.html.erb
@@ -47,6 +47,9 @@
         </dd>
         <%= render partial: 'buildinfo', locals: {project: @staging_project} %>
         <%= render partial: 'openqa_jobs', locals: {project: @staging_project} %>
+        <% if @build_id.present? %>
+          <%= render partial: 'checks', locals: {project: @staging_project} %>
+        <% end %>
       </dl>
     </div>
   </div>

--- a/src/api/lib/backend/api/published.rb
+++ b/src/api/lib/backend/api/published.rb
@@ -6,8 +6,16 @@ module Backend
 
       # Returns the download url for a repository
       # @return [String]
-      def self.download_url_for_repository(project_name, repository_name)
-        http_get(['/published/:project/:repository', project_name, repository_name], params: { view: :publishedpath })
+      def self.download_url_for_repository(project_name, repository_name, view = :publishedpath)
+        http_get(['/published/:project/:repository', project_name, repository_name], params: { view: view })
+      end
+
+      # Returns the build id for a repository
+      # @return [String]
+      def self.build_id(project_name, repository_name)
+        response = download_url_for_repository(project_name, repository_name, :status)
+        result = Xmlhash.parse(response).with_indifferent_access
+        result[:buildid]
       end
     end
   end

--- a/src/api/spec/cassettes/Webui_ObsFactory_StagingProjectsController/GET_show/with_a_existent_factory_staging_project/requesting_html/1_2_1_1_1.yml
+++ b/src/api/spec/cassettes/Webui_ObsFactory_StagingProjectsController/GET_show/with_a_existent_factory_staging_project/requesting_html/1_2_1_1_1.yml
@@ -7,7 +7,7 @@ http_interactions:
       encoding: UTF-8
       string: |
         <project name="openSUSE:Factory:Staging">
-          <title>Nine Coaches Waiting</title>
+          <title>Specimen Days</title>
           <description/>
         </project>
     headers:
@@ -29,16 +29,16 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '121'
+      - '114'
     body:
       encoding: UTF-8
       string: |
         <project name="openSUSE:Factory:Staging">
-          <title>Nine Coaches Waiting</title>
+          <title>Specimen Days</title>
           <description></description>
         </project>
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 19:12:15 GMT
+  recorded_at: Tue, 14 Aug 2018 08:01:23 GMT
 - request:
     method: put
     uri: http://backend:5352/source/openSUSE:Factory/_meta?user=_nobody_
@@ -46,7 +46,7 @@ http_interactions:
       encoding: UTF-8
       string: |
         <project name="openSUSE:Factory">
-          <title>Now Sleeps the Crimson Petal</title>
+          <title>Many Waters</title>
           <description/>
         </project>
     headers:
@@ -68,16 +68,16 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '121'
+      - '104'
     body:
       encoding: UTF-8
       string: |
         <project name="openSUSE:Factory">
-          <title>Now Sleeps the Crimson Petal</title>
+          <title>Many Waters</title>
           <description></description>
         </project>
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 19:12:15 GMT
+  recorded_at: Tue, 14 Aug 2018 08:01:23 GMT
 - request:
     method: put
     uri: http://backend:5352/source/openSUSE:Factory/target_package/_meta?user=_nobody_
@@ -85,8 +85,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="target_package" project="openSUSE:Factory">
-          <title>The Wind's Twelve Quarters</title>
-          <description>Exercitationem quae enim doloribus.</description>
+          <title>That Good Night</title>
+          <description>Et eos ex magni.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -107,16 +107,16 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '179'
+      - '149'
     body:
       encoding: UTF-8
       string: |
         <package name="target_package" project="openSUSE:Factory">
-          <title>The Wind's Twelve Quarters</title>
-          <description>Exercitationem quae enim doloribus.</description>
+          <title>That Good Night</title>
+          <description>Et eos ex magni.</description>
         </package>
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 19:12:15 GMT
+  recorded_at: Tue, 14 Aug 2018 08:01:23 GMT
 - request:
     method: put
     uri: http://backend:5352/source/openSUSE:Factory/target_package/_meta?user=_nobody_
@@ -124,8 +124,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="target_package" project="openSUSE:Factory">
-          <title>The Wind's Twelve Quarters</title>
-          <description>Exercitationem quae enim doloribus.</description>
+          <title>That Good Night</title>
+          <description>Et eos ex magni.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -146,24 +146,24 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '179'
+      - '149'
     body:
       encoding: UTF-8
       string: |
         <package name="target_package" project="openSUSE:Factory">
-          <title>The Wind's Twelve Quarters</title>
-          <description>Exercitationem quae enim doloribus.</description>
+          <title>That Good Night</title>
+          <description>Et eos ex magni.</description>
         </package>
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 19:12:16 GMT
+  recorded_at: Tue, 14 Aug 2018 08:01:23 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/project_10/_meta?user=_nobody_
+    uri: http://backend:5352/source/project_11/_meta?user=_nobody_
     body:
       encoding: UTF-8
       string: |
-        <project name="project_10">
-          <title>Have His Carcase</title>
+        <project name="project_11">
+          <title>In a Glass Darkly</title>
           <description/>
         </project>
     headers:
@@ -185,25 +185,25 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '103'
+      - '104'
     body:
       encoding: UTF-8
       string: |
-        <project name="project_10">
-          <title>Have His Carcase</title>
+        <project name="project_11">
+          <title>In a Glass Darkly</title>
           <description></description>
         </project>
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 19:12:16 GMT
+  recorded_at: Tue, 14 Aug 2018 08:01:23 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/project_10/package_10/_meta?user=_nobody_
+    uri: http://backend:5352/source/project_11/package_11/_meta?user=_nobody_
     body:
       encoding: UTF-8
       string: |
-        <package name="package_10" project="project_10">
-          <title>If I Forget Thee Jerusalem</title>
-          <description>Est eligendi atque quasi.</description>
+        <package name="package_11" project="project_11">
+          <title>Clouds of Witness</title>
+          <description>Aut voluptas excepturi aut.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -224,25 +224,25 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '159'
+      - '152'
     body:
       encoding: UTF-8
       string: |
-        <package name="package_10" project="project_10">
-          <title>If I Forget Thee Jerusalem</title>
-          <description>Est eligendi atque quasi.</description>
+        <package name="package_11" project="project_11">
+          <title>Clouds of Witness</title>
+          <description>Aut voluptas excepturi aut.</description>
         </package>
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 19:12:16 GMT
+  recorded_at: Tue, 14 Aug 2018 08:01:23 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/project_10/package_10/_meta?user=_nobody_
+    uri: http://backend:5352/source/project_11/package_11/_meta?user=_nobody_
     body:
       encoding: UTF-8
       string: |
-        <package name="package_10" project="project_10">
-          <title>If I Forget Thee Jerusalem</title>
-          <description>Est eligendi atque quasi.</description>
+        <package name="package_11" project="project_11">
+          <title>Clouds of Witness</title>
+          <description>Aut voluptas excepturi aut.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -263,26 +263,26 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '159'
+      - '152'
     body:
       encoding: UTF-8
       string: |
-        <package name="package_10" project="project_10">
-          <title>If I Forget Thee Jerusalem</title>
-          <description>Est eligendi atque quasi.</description>
+        <package name="package_11" project="project_11">
+          <title>Clouds of Witness</title>
+          <description>Aut voluptas excepturi aut.</description>
         </package>
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 19:12:16 GMT
+  recorded_at: Tue, 14 Aug 2018 08:01:23 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:user_25/_meta?user=user_25
+    uri: http://backend:5352/source/home:user_26/_meta?user=user_26
     body:
       encoding: UTF-8
       string: |
-        <project name="home:user_25">
+        <project name="home:user_26">
           <title/>
           <description/>
-          <person userid="user_25" role="maintainer"/>
+          <person userid="user_26" role="maintainer"/>
         </project>
     headers:
       Accept-Encoding:
@@ -307,13 +307,13 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <project name="home:user_25">
+        <project name="home:user_26">
           <title></title>
           <description></description>
-          <person userid="user_25" role="maintainer" />
+          <person userid="user_26" role="maintainer" />
         </project>
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 19:12:16 GMT
+  recorded_at: Tue, 14 Aug 2018 08:01:23 GMT
 - request:
     method: put
     uri: http://backend:5352/source/openSUSE:Factory:Staging:A/_meta?user=_nobody_
@@ -321,7 +321,7 @@ http_interactions:
       encoding: UTF-8
       string: |
         <project name="openSUSE:Factory:Staging:A">
-          <title>Time of our Darkness</title>
+          <title>The Mirror Crack'd from Side to Side</title>
           <description>      requests:
                 - { id: 1 }
         </description>
@@ -345,18 +345,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '159'
+      - '175'
     body:
       encoding: UTF-8
       string: |
         <project name="openSUSE:Factory:Staging:A">
-          <title>Time of our Darkness</title>
+          <title>The Mirror Crack'd from Side to Side</title>
           <description>      requests:
                 - { id: 1 }
         </description>
         </project>
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 19:12:16 GMT
+  recorded_at: Tue, 14 Aug 2018 08:01:23 GMT
 - request:
     method: put
     uri: http://backend:5352/source/openSUSE:Factory:Staging:B/_meta?user=_nobody_
@@ -364,7 +364,7 @@ http_interactions:
       encoding: UTF-8
       string: |
         <project name="openSUSE:Factory:Staging:B">
-          <title>All the King's Men</title>
+          <title>The Far-Distant Oxus</title>
           <description>Factory staging project B</description>
         </project>
     headers:
@@ -386,16 +386,49 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '146'
+      - '148'
     body:
       encoding: UTF-8
       string: |
         <project name="openSUSE:Factory:Staging:B">
-          <title>All the King's Men</title>
+          <title>The Far-Distant Oxus</title>
           <description>Factory staging project B</description>
         </project>
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 19:12:16 GMT
+  recorded_at: Tue, 14 Aug 2018 08:01:24 GMT
+- request:
+    method: get
+    uri: http://backend:5352/published/openSUSE:Factory:Staging:A/images?view=status
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Content-Length:
+      - '26'
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+    body:
+      encoding: UTF-8
+      string: '<status code="unknown" />
+
+'
+    http_version: 
+  recorded_at: Tue, 14 Aug 2018 08:01:24 GMT
 - request:
     method: get
     uri: http://backend:5352/build/openSUSE:Factory:Staging:A/_result?code=unresolvable
@@ -430,7 +463,7 @@ http_interactions:
 
 '
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 19:12:16 GMT
+  recorded_at: Tue, 14 Aug 2018 08:01:24 GMT
 - request:
     method: get
     uri: http://backend:5352/build/openSUSE:Factory:Staging:A/_result?package=Test-DVD-x86_64&repository=images&view=binarylist
@@ -467,5 +500,5 @@ http_interactions:
           <details>404 unknown repository 'images'</details>
         </status>
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 19:12:16 GMT
+  recorded_at: Tue, 14 Aug 2018 08:01:24 GMT
 recorded_with: VCR 4.0.0

--- a/src/api/spec/cassettes/Webui_ObsFactory_StagingProjectsController/GET_show/with_a_existent_factory_staging_project/requesting_html/1_2_1_1_2.yml
+++ b/src/api/spec/cassettes/Webui_ObsFactory_StagingProjectsController/GET_show/with_a_existent_factory_staging_project/requesting_html/1_2_1_1_2.yml
@@ -7,7 +7,7 @@ http_interactions:
       encoding: UTF-8
       string: |
         <project name="openSUSE:Factory:Staging">
-          <title>An Evil Cradling</title>
+          <title>Bury My Heart at Wounded Knee</title>
           <description/>
         </project>
     headers:
@@ -29,16 +29,16 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '117'
+      - '130'
     body:
       encoding: UTF-8
       string: |
         <project name="openSUSE:Factory:Staging">
-          <title>An Evil Cradling</title>
+          <title>Bury My Heart at Wounded Knee</title>
           <description></description>
         </project>
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 19:12:14 GMT
+  recorded_at: Tue, 14 Aug 2018 08:01:22 GMT
 - request:
     method: put
     uri: http://backend:5352/source/openSUSE:Factory/_meta?user=_nobody_
@@ -46,7 +46,7 @@ http_interactions:
       encoding: UTF-8
       string: |
         <project name="openSUSE:Factory">
-          <title>Beneath the Bleeding</title>
+          <title>Pale Kings and Princes</title>
           <description/>
         </project>
     headers:
@@ -68,16 +68,16 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '113'
+      - '115'
     body:
       encoding: UTF-8
       string: |
         <project name="openSUSE:Factory">
-          <title>Beneath the Bleeding</title>
+          <title>Pale Kings and Princes</title>
           <description></description>
         </project>
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 19:12:14 GMT
+  recorded_at: Tue, 14 Aug 2018 08:01:22 GMT
 - request:
     method: put
     uri: http://backend:5352/source/openSUSE:Factory/target_package/_meta?user=_nobody_
@@ -85,8 +85,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="target_package" project="openSUSE:Factory">
-          <title>This Lime Tree Bower</title>
-          <description>Reprehenderit totam omnis earum.</description>
+          <title>The Violent Bear It Away</title>
+          <description>Enim aut libero enim.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -107,16 +107,16 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '170'
+      - '163'
     body:
       encoding: UTF-8
       string: |
         <package name="target_package" project="openSUSE:Factory">
-          <title>This Lime Tree Bower</title>
-          <description>Reprehenderit totam omnis earum.</description>
+          <title>The Violent Bear It Away</title>
+          <description>Enim aut libero enim.</description>
         </package>
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 19:12:14 GMT
+  recorded_at: Tue, 14 Aug 2018 08:01:22 GMT
 - request:
     method: put
     uri: http://backend:5352/source/openSUSE:Factory/target_package/_meta?user=_nobody_
@@ -124,8 +124,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="target_package" project="openSUSE:Factory">
-          <title>This Lime Tree Bower</title>
-          <description>Reprehenderit totam omnis earum.</description>
+          <title>The Violent Bear It Away</title>
+          <description>Enim aut libero enim.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -146,24 +146,24 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '170'
+      - '163'
     body:
       encoding: UTF-8
       string: |
         <package name="target_package" project="openSUSE:Factory">
-          <title>This Lime Tree Bower</title>
-          <description>Reprehenderit totam omnis earum.</description>
+          <title>The Violent Bear It Away</title>
+          <description>Enim aut libero enim.</description>
         </package>
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 19:12:14 GMT
+  recorded_at: Tue, 14 Aug 2018 08:01:22 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/project_9/_meta?user=_nobody_
+    uri: http://backend:5352/source/project_10/_meta?user=_nobody_
     body:
       encoding: UTF-8
       string: |
-        <project name="project_9">
-          <title>Dance Dance Dance</title>
+        <project name="project_10">
+          <title>Number the Stars</title>
           <description/>
         </project>
     headers:
@@ -189,21 +189,21 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <project name="project_9">
-          <title>Dance Dance Dance</title>
+        <project name="project_10">
+          <title>Number the Stars</title>
           <description></description>
         </project>
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 19:12:14 GMT
+  recorded_at: Tue, 14 Aug 2018 08:01:22 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/project_9/package_9/_meta?user=_nobody_
+    uri: http://backend:5352/source/project_10/package_10/_meta?user=_nobody_
     body:
       encoding: UTF-8
       string: |
-        <package name="package_9" project="project_9">
-          <title>I Sing the Body Electric</title>
-          <description>Reprehenderit aliquid incidunt autem.</description>
+        <package name="package_10" project="project_10">
+          <title>A Glass of Blessings</title>
+          <description>Tempore odio perspiciatis placeat.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -224,25 +224,25 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '167'
+      - '162'
     body:
       encoding: UTF-8
       string: |
-        <package name="package_9" project="project_9">
-          <title>I Sing the Body Electric</title>
-          <description>Reprehenderit aliquid incidunt autem.</description>
+        <package name="package_10" project="project_10">
+          <title>A Glass of Blessings</title>
+          <description>Tempore odio perspiciatis placeat.</description>
         </package>
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 19:12:14 GMT
+  recorded_at: Tue, 14 Aug 2018 08:01:22 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/project_9/package_9/_meta?user=_nobody_
+    uri: http://backend:5352/source/project_10/package_10/_meta?user=_nobody_
     body:
       encoding: UTF-8
       string: |
-        <package name="package_9" project="project_9">
-          <title>I Sing the Body Electric</title>
-          <description>Reprehenderit aliquid incidunt autem.</description>
+        <package name="package_10" project="project_10">
+          <title>A Glass of Blessings</title>
+          <description>Tempore odio perspiciatis placeat.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -263,26 +263,26 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '167'
+      - '162'
     body:
       encoding: UTF-8
       string: |
-        <package name="package_9" project="project_9">
-          <title>I Sing the Body Electric</title>
-          <description>Reprehenderit aliquid incidunt autem.</description>
+        <package name="package_10" project="project_10">
+          <title>A Glass of Blessings</title>
+          <description>Tempore odio perspiciatis placeat.</description>
         </package>
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 19:12:15 GMT
+  recorded_at: Tue, 14 Aug 2018 08:01:22 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:user_24/_meta?user=user_24
+    uri: http://backend:5352/source/home:user_25/_meta?user=user_25
     body:
       encoding: UTF-8
       string: |
-        <project name="home:user_24">
+        <project name="home:user_25">
           <title/>
           <description/>
-          <person userid="user_24" role="maintainer"/>
+          <person userid="user_25" role="maintainer"/>
         </project>
     headers:
       Accept-Encoding:
@@ -307,13 +307,13 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <project name="home:user_24">
+        <project name="home:user_25">
           <title></title>
           <description></description>
-          <person userid="user_24" role="maintainer" />
+          <person userid="user_25" role="maintainer" />
         </project>
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 19:12:15 GMT
+  recorded_at: Tue, 14 Aug 2018 08:01:23 GMT
 - request:
     method: put
     uri: http://backend:5352/source/openSUSE:Factory:Staging:A/_meta?user=_nobody_
@@ -321,7 +321,7 @@ http_interactions:
       encoding: UTF-8
       string: |
         <project name="openSUSE:Factory:Staging:A">
-          <title>That Hideous Strength</title>
+          <title>Mother Night</title>
           <description>      requests:
                 - { id: 1 }
         </description>
@@ -345,18 +345,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '160'
+      - '151'
     body:
       encoding: UTF-8
       string: |
         <project name="openSUSE:Factory:Staging:A">
-          <title>That Hideous Strength</title>
+          <title>Mother Night</title>
           <description>      requests:
                 - { id: 1 }
         </description>
         </project>
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 19:12:15 GMT
+  recorded_at: Tue, 14 Aug 2018 08:01:23 GMT
 - request:
     method: put
     uri: http://backend:5352/source/openSUSE:Factory:Staging:B/_meta?user=_nobody_
@@ -364,7 +364,7 @@ http_interactions:
       encoding: UTF-8
       string: |
         <project name="openSUSE:Factory:Staging:B">
-          <title>An Evil Cradling</title>
+          <title>The Other Side of Silence</title>
           <description>Factory staging project B</description>
         </project>
     headers:
@@ -386,16 +386,49 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '144'
+      - '153'
     body:
       encoding: UTF-8
       string: |
         <project name="openSUSE:Factory:Staging:B">
-          <title>An Evil Cradling</title>
+          <title>The Other Side of Silence</title>
           <description>Factory staging project B</description>
         </project>
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 19:12:15 GMT
+  recorded_at: Tue, 14 Aug 2018 08:01:23 GMT
+- request:
+    method: get
+    uri: http://backend:5352/published/openSUSE:Factory:Staging:A/images?view=status
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Content-Length:
+      - '26'
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+    body:
+      encoding: UTF-8
+      string: '<status code="unknown" />
+
+'
+    http_version: 
+  recorded_at: Tue, 14 Aug 2018 08:01:23 GMT
 - request:
     method: get
     uri: http://backend:5352/build/openSUSE:Factory:Staging:A/_result?code=unresolvable
@@ -430,7 +463,7 @@ http_interactions:
 
 '
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 19:12:15 GMT
+  recorded_at: Tue, 14 Aug 2018 08:01:23 GMT
 - request:
     method: get
     uri: http://backend:5352/build/openSUSE:Factory:Staging:A/_result?package=Test-DVD-x86_64&repository=images&view=binarylist
@@ -467,5 +500,5 @@ http_interactions:
           <details>404 unknown repository 'images'</details>
         </status>
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 19:12:15 GMT
+  recorded_at: Tue, 14 Aug 2018 08:01:23 GMT
 recorded_with: VCR 4.0.0

--- a/src/api/spec/cassettes/Webui_ObsFactory_StagingProjectsController/GET_show/with_a_existent_factory_staging_project/requesting_html/1_2_1_1_3.yml
+++ b/src/api/spec/cassettes/Webui_ObsFactory_StagingProjectsController/GET_show/with_a_existent_factory_staging_project/requesting_html/1_2_1_1_3.yml
@@ -7,7 +7,46 @@ http_interactions:
       encoding: UTF-8
       string: |
         <project name="openSUSE:Factory:Staging">
-          <title>Death Be Not Proud</title>
+          <title>The Moving Finger</title>
+          <description/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '118'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="openSUSE:Factory:Staging">
+          <title>The Moving Finger</title>
+          <description></description>
+        </project>
+    http_version: 
+  recorded_at: Tue, 14 Aug 2018 08:01:21 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/openSUSE:Factory/_meta?user=_nobody_
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="openSUSE:Factory">
+          <title>The Skull Beneath the Skin</title>
           <description/>
         </project>
     headers:
@@ -33,20 +72,98 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <project name="openSUSE:Factory:Staging">
-          <title>Death Be Not Proud</title>
+        <project name="openSUSE:Factory">
+          <title>The Skull Beneath the Skin</title>
           <description></description>
         </project>
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 19:12:16 GMT
+  recorded_at: Tue, 14 Aug 2018 08:01:21 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/openSUSE:Factory/_meta?user=_nobody_
+    uri: http://backend:5352/source/openSUSE:Factory/target_package/_meta?user=_nobody_
     body:
       encoding: UTF-8
       string: |
-        <project name="openSUSE:Factory">
-          <title>The Daffodil Sky</title>
+        <package name="target_package" project="openSUSE:Factory">
+          <title>A Summer Bird-Cage</title>
+          <description>Dolorem reprehenderit ex voluptas.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '170'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="target_package" project="openSUSE:Factory">
+          <title>A Summer Bird-Cage</title>
+          <description>Dolorem reprehenderit ex voluptas.</description>
+        </package>
+    http_version: 
+  recorded_at: Tue, 14 Aug 2018 08:01:22 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/openSUSE:Factory/target_package/_meta?user=_nobody_
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="target_package" project="openSUSE:Factory">
+          <title>A Summer Bird-Cage</title>
+          <description>Dolorem reprehenderit ex voluptas.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '170'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="target_package" project="openSUSE:Factory">
+          <title>A Summer Bird-Cage</title>
+          <description>Dolorem reprehenderit ex voluptas.</description>
+        </package>
+    http_version: 
+  recorded_at: Tue, 14 Aug 2018 08:01:22 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/project_9/_meta?user=_nobody_
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="project_9">
+          <title>Postern of Fate</title>
           <description/>
         </project>
     headers:
@@ -68,25 +185,25 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '109'
+      - '101'
     body:
       encoding: UTF-8
       string: |
-        <project name="openSUSE:Factory">
-          <title>The Daffodil Sky</title>
+        <project name="project_9">
+          <title>Postern of Fate</title>
           <description></description>
         </project>
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 19:12:17 GMT
+  recorded_at: Tue, 14 Aug 2018 08:01:22 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/openSUSE:Factory/target_package/_meta?user=_nobody_
+    uri: http://backend:5352/source/project_9/package_9/_meta?user=_nobody_
     body:
       encoding: UTF-8
       string: |
-        <package name="target_package" project="openSUSE:Factory">
-          <title>His Dark Materials</title>
-          <description>Iusto consectetur tenetur totam.</description>
+        <package name="package_9" project="project_9">
+          <title>The Way Through the Woods</title>
+          <description>Eius quidem perferendis deleniti.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -107,25 +224,25 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '168'
+      - '164'
     body:
       encoding: UTF-8
       string: |
-        <package name="target_package" project="openSUSE:Factory">
-          <title>His Dark Materials</title>
-          <description>Iusto consectetur tenetur totam.</description>
+        <package name="package_9" project="project_9">
+          <title>The Way Through the Woods</title>
+          <description>Eius quidem perferendis deleniti.</description>
         </package>
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 19:12:17 GMT
+  recorded_at: Tue, 14 Aug 2018 08:01:22 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/openSUSE:Factory/target_package/_meta?user=_nobody_
+    uri: http://backend:5352/source/project_9/package_9/_meta?user=_nobody_
     body:
       encoding: UTF-8
       string: |
-        <package name="target_package" project="openSUSE:Factory">
-          <title>His Dark Materials</title>
-          <description>Iusto consectetur tenetur totam.</description>
+        <package name="package_9" project="project_9">
+          <title>The Way Through the Woods</title>
+          <description>Eius quidem perferendis deleniti.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -146,143 +263,26 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '168'
+      - '164'
     body:
       encoding: UTF-8
       string: |
-        <package name="target_package" project="openSUSE:Factory">
-          <title>His Dark Materials</title>
-          <description>Iusto consectetur tenetur totam.</description>
+        <package name="package_9" project="project_9">
+          <title>The Way Through the Woods</title>
+          <description>Eius quidem perferendis deleniti.</description>
         </package>
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 19:12:17 GMT
+  recorded_at: Tue, 14 Aug 2018 08:01:22 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/project_11/_meta?user=_nobody_
+    uri: http://backend:5352/source/home:user_24/_meta?user=user_24
     body:
       encoding: UTF-8
       string: |
-        <project name="project_11">
-          <title>A Handful of Dust</title>
-          <description/>
-        </project>
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '104'
-    body:
-      encoding: UTF-8
-      string: |
-        <project name="project_11">
-          <title>A Handful of Dust</title>
-          <description></description>
-        </project>
-    http_version: 
-  recorded_at: Mon, 30 Jul 2018 19:12:17 GMT
-- request:
-    method: put
-    uri: http://backend:5352/source/project_11/package_11/_meta?user=_nobody_
-    body:
-      encoding: UTF-8
-      string: |
-        <package name="package_11" project="project_11">
-          <title>Jesting Pilate</title>
-          <description>Fugit quas mollitia consectetur.</description>
-        </package>
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '154'
-    body:
-      encoding: UTF-8
-      string: |
-        <package name="package_11" project="project_11">
-          <title>Jesting Pilate</title>
-          <description>Fugit quas mollitia consectetur.</description>
-        </package>
-    http_version: 
-  recorded_at: Mon, 30 Jul 2018 19:12:17 GMT
-- request:
-    method: put
-    uri: http://backend:5352/source/project_11/package_11/_meta?user=_nobody_
-    body:
-      encoding: UTF-8
-      string: |
-        <package name="package_11" project="project_11">
-          <title>Jesting Pilate</title>
-          <description>Fugit quas mollitia consectetur.</description>
-        </package>
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '154'
-    body:
-      encoding: UTF-8
-      string: |
-        <package name="package_11" project="project_11">
-          <title>Jesting Pilate</title>
-          <description>Fugit quas mollitia consectetur.</description>
-        </package>
-    http_version: 
-  recorded_at: Mon, 30 Jul 2018 19:12:17 GMT
-- request:
-    method: put
-    uri: http://backend:5352/source/home:user_26/_meta?user=user_26
-    body:
-      encoding: UTF-8
-      string: |
-        <project name="home:user_26">
+        <project name="home:user_24">
           <title/>
           <description/>
-          <person userid="user_26" role="maintainer"/>
+          <person userid="user_24" role="maintainer"/>
         </project>
     headers:
       Accept-Encoding:
@@ -307,13 +307,13 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <project name="home:user_26">
+        <project name="home:user_24">
           <title></title>
           <description></description>
-          <person userid="user_26" role="maintainer" />
+          <person userid="user_24" role="maintainer" />
         </project>
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 19:12:17 GMT
+  recorded_at: Tue, 14 Aug 2018 08:01:22 GMT
 - request:
     method: put
     uri: http://backend:5352/source/openSUSE:Factory:Staging:A/_meta?user=_nobody_
@@ -321,7 +321,7 @@ http_interactions:
       encoding: UTF-8
       string: |
         <project name="openSUSE:Factory:Staging:A">
-          <title>A Darkling Plain</title>
+          <title>The Daffodil Sky</title>
           <description>      requests:
                 - { id: 1 }
         </description>
@@ -350,13 +350,13 @@ http_interactions:
       encoding: UTF-8
       string: |
         <project name="openSUSE:Factory:Staging:A">
-          <title>A Darkling Plain</title>
+          <title>The Daffodil Sky</title>
           <description>      requests:
                 - { id: 1 }
         </description>
         </project>
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 19:12:17 GMT
+  recorded_at: Tue, 14 Aug 2018 08:01:22 GMT
 - request:
     method: put
     uri: http://backend:5352/source/openSUSE:Factory:Staging:B/_meta?user=_nobody_
@@ -364,7 +364,7 @@ http_interactions:
       encoding: UTF-8
       string: |
         <project name="openSUSE:Factory:Staging:B">
-          <title>The Lathe of Heaven</title>
+          <title>Dulce et Decorum Est</title>
           <description>Factory staging project B</description>
         </project>
     headers:
@@ -386,16 +386,49 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '147'
+      - '148'
     body:
       encoding: UTF-8
       string: |
         <project name="openSUSE:Factory:Staging:B">
-          <title>The Lathe of Heaven</title>
+          <title>Dulce et Decorum Est</title>
           <description>Factory staging project B</description>
         </project>
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 19:12:17 GMT
+  recorded_at: Tue, 14 Aug 2018 08:01:22 GMT
+- request:
+    method: get
+    uri: http://backend:5352/published/openSUSE:Factory:Staging:A/images?view=status
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Content-Length:
+      - '26'
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+    body:
+      encoding: UTF-8
+      string: '<status code="unknown" />
+
+'
+    http_version: 
+  recorded_at: Tue, 14 Aug 2018 08:01:22 GMT
 - request:
     method: get
     uri: http://backend:5352/build/openSUSE:Factory:Staging:A/_result?code=unresolvable
@@ -430,7 +463,7 @@ http_interactions:
 
 '
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 19:12:17 GMT
+  recorded_at: Tue, 14 Aug 2018 08:01:22 GMT
 - request:
     method: get
     uri: http://backend:5352/build/openSUSE:Factory:Staging:A/_result?package=Test-DVD-x86_64&repository=images&view=binarylist
@@ -467,5 +500,5 @@ http_interactions:
           <details>404 unknown repository 'images'</details>
         </status>
     http_version: 
-  recorded_at: Mon, 30 Jul 2018 19:12:17 GMT
+  recorded_at: Tue, 14 Aug 2018 08:01:22 GMT
 recorded_with: VCR 4.0.0


### PR DESCRIPTION
Recently we introduced a checks API to add checks to a published repository. With this commit
we now show these checks on the Staging Dashboard.

![image](https://user-images.githubusercontent.com/3799140/44033649-5c5b09dc-9f0b-11e8-87b5-1103bc368eda.png)
