### PR TITLE
Fix flash message for create delete requests

### DIFF
--- a/src/api/app/controllers/webui/request_controller.rb
+++ b/src/api/app/controllers/webui/request_controller.rb
@@ -193,7 +193,7 @@ class Webui::RequestController < Webui::WebuiController
       request = BsRequest.create!(
         description: params[:description], bs_request_actions: [BsRequestAction.new(request_action_attributes(:delete))]
       )
-      request_link = ActionController::Base.helpers.link_to("repository delete request #{request.number}", request_show_path(request.number))
+      request_link = ActionController::Base.helpers.link_to("delete request #{request.number}", request_show_path(request.number))
       flash[:success] = "Created #{request_link}"
     rescue APIError => e
       flash[:error] = e.message

--- a/src/api/spec/controllers/webui/request_controller_spec.rb
+++ b/src/api/spec/controllers/webui/request_controller_spec.rb
@@ -220,7 +220,7 @@ RSpec.describe Webui::RequestController, vcr: true do
       end
 
       it { expect(response).to redirect_to(request_show_path(number: subject)) }
-      it { expect(flash[:success]).to match("Created .+repository delete request #{subject.number}") }
+      it { expect(flash[:success]).to match("Created .+delete request #{subject.number}") }
       it { expect(subject.description).to eq('delete it!') }
     end
 

--- a/src/api/spec/features/webui/packages_spec.rb
+++ b/src/api/spec/features/webui/packages_spec.rb
@@ -121,8 +121,8 @@ RSpec.feature 'Packages', type: :feature, js: true do
     click_link('Request deletion')
     expect(page).to have_text('Do you really want to request the deletion of package ')
     click_button('Ok')
-    expect(page).to have_text('Created repository delete request')
-    find('a', text: /repository delete request \d+/).click
+    expect(page).to have_text('Created delete request')
+    find('a', text: /delete request \d+/).click
     expect(page.current_path).to match('/request/show/\\d+')
   end
 


### PR DESCRIPTION
Delete requests are used for deletion of different objects. Hence we
have to make the flash message generic.

Fixes #4897