### PR TITLE
Update project name validation

### DIFF
--- a/src/api/.rubocop_todo.yml
+++ b/src/api/.rubocop_todo.yml
@@ -449,18 +449,6 @@ RSpec/HookArgument:
     - 'spec/rails_helper.rb'
     - 'spec/support/database_cleaner.rb'
 
-# Offense count: 13
-# Cop supports --auto-correct.
-# Configuration parameters: EnforcedStyle.
-# SupportedStyles: is_expected, should
-RSpec/ImplicitExpect:
-  Exclude:
-    - 'spec/controllers/webui/download_on_demand_controller_spec.rb'
-    - 'spec/models/bs_request_action_spec.rb'
-    - 'spec/models/project_spec.rb'
-    - 'spec/models/repository_spec.rb'
-    - 'spec/models/review_spec.rb'
-
 # Offense count: 64
 # Configuration parameters: AssignmentOnly.
 RSpec/InstanceVariable:

--- a/src/api/app/models/project.rb
+++ b/src/api/app/models/project.rb
@@ -1257,12 +1257,14 @@ class Project < ApplicationRecord
 
   private :bsrequest_repos_map
 
+  # NOTE: This has to cover project name validations in backend/BSVerify.pm (verify_projid)
   def self.valid_name?(name)
     return false unless name.is_a?(String)
     return false if name == '0'
-    return false if name =~ /::/
+    return false if name =~ /:[:\._]/
+    return false if name =~ /\A[:\._]/
     return false if name.end_with?(':')
-    return true if name =~ /\A[a-zA-Z0-9][-+\w\.:]{0,199}\z/
+    return true  if name =~ /\A[-+\w\.:]{1,200}\z/
     false
   end
 

--- a/src/api/spec/controllers/webui/download_on_demand_controller_spec.rb
+++ b/src/api/spec/controllers/webui/download_on_demand_controller_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe Webui::DownloadOnDemandController do
 
   it 'uses strong parameters' do
     login(admin_user)
-    should permit(:arch, :repotype, :url, :repository_id, :archfilter, :masterurl, :mastersslfingerprint, :pubkey).
+    is_expected.to permit(:arch, :repotype, :url, :repository_id, :archfilter, :masterurl, :mastersslfingerprint, :pubkey).
       for(:create, params: { params: dod_parameters }).on(:download_repository)
   end
 

--- a/src/api/spec/models/bs_request_action_spec.rb
+++ b/src/api/spec/models/bs_request_action_spec.rb
@@ -71,7 +71,7 @@ RSpec.describe BsRequestAction, vcr: true do
     it_should_behave_like 'it skips validation for type', 'maintenance_incident'
   end
 
-  it { should belong_to(:bs_request).touch(true) }
+  it { is_expected.to belong_to(:bs_request).touch(true) }
 
   describe '.set_source_and_target_associations' do
     let(:project) { create(:project_with_package, name: 'Apache', package_name: 'apache2') }

--- a/src/api/spec/models/project_spec.rb
+++ b/src/api/spec/models/project_spec.rb
@@ -20,6 +20,7 @@ RSpec.describe Project, vcr: true do
     it { is_expected.to validate_length_of(:title).is_at_most(250) }
     it { is_expected.to validate_presence_of(:name) }
     it { is_expected.to validate_uniqueness_of(:name) }
+    it { is_expected.not_to allow_value('0').for(:name) }
     it { is_expected.not_to allow_value('foo::bar').for(:name) }
     it { is_expected.not_to allow_value('foo:_bar').for(:name) }
     it { is_expected.not_to allow_value('foo:.bar').for(:name) }

--- a/src/api/spec/models/project_spec.rb
+++ b/src/api/spec/models/project_spec.rb
@@ -20,10 +20,14 @@ RSpec.describe Project, vcr: true do
     it { is_expected.to validate_length_of(:title).is_at_most(250) }
     it { is_expected.to validate_presence_of(:name) }
     it { is_expected.to validate_uniqueness_of(:name) }
-    it { should_not allow_value('_foo').for(:name) }
-    it { should_not allow_value('foo::bar').for(:name) }
-    it { should_not allow_value('ends_with_:').for(:name) }
-    it { should allow_value('fOO:+-').for(:name) }
+    it { is_expected.not_to allow_value('foo::bar').for(:name) }
+    it { is_expected.not_to allow_value('foo:_bar').for(:name) }
+    it { is_expected.not_to allow_value('foo:.bar').for(:name) }
+    it { is_expected.not_to allow_value(':foo').for(:name) }
+    it { is_expected.not_to allow_value('_foo').for(:name) }
+    it { is_expected.not_to allow_value('.foo').for(:name) }
+    it { is_expected.not_to allow_value('ends_with_:').for(:name) }
+    it { is_expected.to allow_value('fOO:123:+-_.').for(:name) }
   end
 
   describe '.image_templates' do
@@ -250,7 +254,7 @@ RSpec.describe Project, vcr: true do
 
       it 'has ::' do
         property_of do
-          string = sized(1) { string(/[a-zA-Z0-9]/) } + sized(range(1, 199)) { string(/[-+\w\.]/) }
+          string = sized(1) { string(/[a-zA-Z0-9\-+\.:]/) } + sized(range(1, 199)) { string(/[-+\w\.:]/) }
           index = range(0, (string.length - 2))
           string[index] = string[index + 1] = ':'
           string
@@ -261,8 +265,8 @@ RSpec.describe Project, vcr: true do
 
       it 'end with :' do
         property_of do
-          string = sized(1) { string(/[a-zA-Z0-9]/) } + sized(range(0, 198)) { string(/[-+\w\.:]/) } + ':'
-          guard string !~ /::/
+          string = sized(1) { string(/[a-zA-Z0-9\-+\.:]/) } + sized(range(0, 198)) { string(/[-+\w\.:]/) } + ':'
+          guard string !~ /:[:\._]/
           string
         end.check do |string|
           expect(Project.valid_name?(string)).to be(false)
@@ -271,8 +275,8 @@ RSpec.describe Project, vcr: true do
 
       it 'has an invalid character in first position' do
         property_of do
-          string = sized(1) { string(/[-+\.:_]/) } + sized(range(0, 199)) { string(/[-+\w\.:]/) }
-          guard !(string[-1] == ':' && string.length > 1) && string !~ /::/
+          string = sized(1) { string(/[\.:_]/) } + sized(range(0, 199)) { string(/[-+\w\.:]/) }
+          guard !(string[-1] == ':' && string.length > 1) && string !~ /:[:\._]/
           string
         end.check do |string|
           expect(Project.valid_name?(string)).to be(false)
@@ -281,8 +285,8 @@ RSpec.describe Project, vcr: true do
 
       it 'has more than 200 characters' do
         property_of do
-          string = sized(1) { string(/[a-zA-Z0-9]/) } + sized(200) { string(/[-+\w\.:]/) }
-          guard string[-1] != ':' && string !~ /::/
+          string = sized(1) { string(/[a-zA-Z0-9\-+\.:]/) } + sized(200) { string(/[-+\w\.:]/) }
+          guard string[-1] != ':' && string !~ /:[:\._]/
           string
         end.check(3) do |string|
           expect(Project.valid_name?(string)).to be(false)
@@ -295,8 +299,8 @@ RSpec.describe Project, vcr: true do
 
     it 'valid' do
       property_of do
-        string = sized(1) { string(/[a-zA-Z0-9]/) } + sized(range(0, 199)) { string(/[-+\w\.:]/) }
-        guard string != '0' && string[-1] != ':' && !(/::/ =~ string)
+        string = sized(1) { string(/[a-zA-Z0-9\-+]/) } + sized(range(0, 199)) { string(/[-+\w\.:]/) }
+        guard string != '0' && string[-1] != ':' && !(/:[:\._]/ =~ string)
         string
       end.check do |string|
         expect(Project.valid_name?(string)).to be(true)

--- a/src/api/spec/models/repository_spec.rb
+++ b/src/api/spec/models/repository_spec.rb
@@ -10,12 +10,12 @@ RSpec.describe Repository do
         scoped_to(:db_project_id, :remote_project_name).
         with_message("#{repository.name} is already used by a repository of this project")
     end
-    it { should_not allow_value('_foo').for(:name) }
-    it { should_not allow_value('f:oo').for(:name) }
-    it { should_not allow_value('f/oo').for(:name) }
-    it { should_not allow_value("f\noo").for(:name) }
-    it { should allow_value('fOO_-§$&!#+~()=?\\"').for(:name) }
-    it { should allow_value('f').for(:name) }
+    it { is_expected.not_to(allow_value('_foo').for(:name)) }
+    it { is_expected.not_to(allow_value('f:oo').for(:name)) }
+    it { is_expected.not_to(allow_value('f/oo').for(:name)) }
+    it { is_expected.not_to(allow_value("f\noo").for(:name)) }
+    it { is_expected.to allow_value('fOO_-§$&!#+~()=?\\"').for(:name) }
+    it { is_expected.to allow_value('f').for(:name) }
 
     describe '#remote_project_name_not_nil' do
       subject! { repository.valid? }

--- a/src/api/spec/models/review_spec.rb
+++ b/src/api/spec/models/review_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe Review do
   let(:user) { create(:user, login: 'King') }
   let(:group) { create(:group, title: 'Staff') }
 
-  it { should belong_to(:bs_request).touch(true) }
+  it { is_expected.to belong_to(:bs_request).touch(true) }
 
   describe 'validations' do
     it 'is not allowed to specify by_user and any other reviewable' do


### PR DESCRIPTION
Project names are validated in the frontend and backend. Because of that the frontend validation has to cover at least the backend validations.
This wasn't the case for project names that started with '.', ':' or '_' and and project names that
contain a ':' followed by one of the three characters.