### PR TITLE
Fix property test for project name validations

### DIFF
--- a/src/api/spec/models/project_spec.rb
+++ b/src/api/spec/models/project_spec.rb
@@ -255,7 +255,7 @@ RSpec.describe Project, vcr: true do
 
       it 'has ::' do
         property_of do
-          string = sized(1) { string(/[a-zA-Z0-9\-+\.:]/) } + sized(range(1, 199)) { string(/[-+\w\.:]/) }
+          string = sized(1) { string(/[a-zA-Z0-9\-+]/) } + sized(range(1, 199)) { string(/[-+\w\.:]/) }
           index = range(0, (string.length - 2))
           string[index] = string[index + 1] = ':'
           string
@@ -266,7 +266,7 @@ RSpec.describe Project, vcr: true do
 
       it 'end with :' do
         property_of do
-          string = sized(1) { string(/[a-zA-Z0-9\-+\.:]/) } + sized(range(0, 198)) { string(/[-+\w\.:]/) } + ':'
+          string = sized(1) { string(/[a-zA-Z0-9\-+]/) } + sized(range(0, 198)) { string(/[-+\w\.:]/) } + ':'
           guard string !~ /:[:\._]/
           string
         end.check do |string|
@@ -286,7 +286,7 @@ RSpec.describe Project, vcr: true do
 
       it 'has more than 200 characters' do
         property_of do
-          string = sized(1) { string(/[a-zA-Z0-9\-+\.:]/) } + sized(200) { string(/[-+\w\.:]/) }
+          string = sized(1) { string(/[a-zA-Z0-9\-+]/) } + sized(200) { string(/[-+\w\.:]/) }
           guard string[-1] != ':' && string !~ /:[:\._]/
           string
         end.check(3) do |string|


### PR DESCRIPTION
In 155eb7c181664668363a20cf9f I changed the regex for the first character
of the generated project name and added some chars that would create an
invalid project name.
This commit fixes it.

Kudos to @eduardoj for catching this.