### PR TITLE
Include aws-cli again for building backend docker image

### DIFF
--- a/docker-files/base/docker-bootstrap.sh
+++ b/docker-files/base/docker-bootstrap.sh
@@ -28,11 +28,10 @@ do
       obs-service-download_url \
       obs-service-format_spec_file obs-service-kiwi_import \
       perl-Devel-Cover perl-Diff-LibXDiff \
+      python3-setuptools \
+      python3-ec2uploadimg \
+      aws-cli \
       osc
-      # AWS client disabled temporarily till python-botocore 1.10.62 can build for Leap 42.3
-      # python3-setuptools \
-      # python3-ec2uploadimg \
-      # aws-cli \
       #
       # Azure client disabled temporarily till python3-pydocumentdb 2.0.1 can build for Leap 42.3
       # azure-cli


### PR DESCRIPTION
Include the `aws-cli` package for building the backend docker image as installing it on a Leap 42.3 was fixed.