### PR TITLE
Fix 404 error on project dashboard

### DIFF
--- a/src/api/app/models/obs_factory/distribution_strategy_factory.rb
+++ b/src/api/app/models/obs_factory/distribution_strategy_factory.rb
@@ -112,7 +112,7 @@ module ObsFactory
     # @return [String] version string
     def published_version
       begin
-        stream = URI(repo_url)
+        stream = URI.open(repo_url)
       rescue ::OpenURI::HTTPError
         return 'unknown'
       end

--- a/src/api/app/models/obs_factory/distribution_strategy_opensuse_leap15.rb
+++ b/src/api/app/models/obs_factory/distribution_strategy_opensuse_leap15.rb
@@ -44,7 +44,7 @@ module ObsFactory
     # @return [String] version string
     def published_version
       begin
-        stream = URI(repo_url)
+        stream = URI.open(repo_url)
       rescue ::OpenURI::HTTPError
         return 'unknown'
       end


### PR DESCRIPTION
Calling URI($url) lead to a 404 error. For unknown reason this only
would happen in production mode. Hence we did not notice this in
development and test.

Fixes #5599