### PR TITLE
Align variable usage in tabs view

### DIFF
--- a/src/api/app/views/webui2/webui/package/_tabs.html.haml
+++ b/src/api/app/views/webui2/webui/package/_tabs.html.haml
@@ -3,7 +3,7 @@
     %li.nav-item
       %a.nav-link{ href: package_show_path, class: [current_page?(package_show_path) && 'active'] }
         Overview
-    - if @package.name == 'patchinfo'
+    - if package.name == 'patchinfo'
       %li.nav-item
         %a.nav-link{ href: patchinfo_show_path, class: [current_page?(patchinfo_show_path) && 'active'] }
           Details


### PR DESCRIPTION
All other project and package variables are expected to be
local variables, except one occasion of @project.