### PR TITLE
Fix test suite after recent Circle CI change

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -110,7 +110,10 @@ jobs:
       - <<: *frontend_base
       - <<: *mariadb
     steps:
-      - *restore_repo
+      - checkout
+      - run:
+          name: Setup application
+          command: cd src/api; bundle exec rake dev:prepare assets:precompile RAILS_ENV=test FORCE_EXAMPLE_FILES=1
       - run: *install_dependencies
       - run: *wait_for_database
       - run: *create_test_db
@@ -162,7 +165,7 @@ jobs:
       - <<: *frontend_backend
       - <<: *mariadb
     steps:
-      - *restore_repo
+      - checkout
       - run: *install_dependencies
       - run: *init_git_submodule
       - run: *wait_for_database
@@ -199,7 +202,7 @@ jobs:
       - <<: *frontend_backend
       - <<: *mariadb
     steps:
-      - *restore_repo
+      - checkout
       - run: *install_dependencies
       - run: *init_git_submodule
       - run: *wait_for_database
@@ -214,7 +217,7 @@ jobs:
       - image: *backend
     working_directory: /home/frontend/project
     steps:
-      - *restore_repo
+      - checkout
       - run: *init_git_submodule
       - run:
           name: backend
@@ -225,7 +228,7 @@ jobs:
       - <<: *frontend_base
 
     steps:
-      - *restore_repo
+      - checkout
       - run: *install_dependencies
       - attach_workspace:
          at: .


### PR DESCRIPTION
Due to security concerns Circle CI disabled[*] saving of caches
for PRs from forked repositories.

In our setup the first CI job ("checking code") creates a cache and
every following test job uses the cached sources.
Without having the cached git checkout all these test jobs started to
fail.

For now we check out the git repo for each test job to get a working
test suite again.

=====

cd ./src/api && bundle install --jobs=4 --retry=3

/bin/bash: line 0: cd: ./src/api: No such file or directory
Exited with code 1

=====

[*] https://discuss.circleci.com/t/saving-cache-stopped-working-warning-skipping-this-step-disabled-in-configuration/24423/3