### PR TITLE
Drop package controller action: import_spec

### DIFF
--- a/src/api/app/controllers/webui/package_controller.rb
+++ b/src/api/app/controllers/webui/package_controller.rb
@@ -16,7 +16,7 @@ class Webui::PackageController < Webui::WebuiController
                                      :save_group, :remove_role, :view_file,
                                      :abort_build, :trigger_rebuild, :trigger_services,
                                      :wipe_binaries, :buildresult, :rpmlint_result, :rpmlint_log, :meta,
-                                     :save_meta, :attributes, :edit, :import_spec, :files, :binary_download]
+                                     :save_meta, :attributes, :edit, :files, :binary_download]
 
   before_action :require_package, only: [:show, :linking_packages, :dependency, :binary, :binaries,
                                          :requests, :statistics, :commit, :revisions, :submit_request_dialog,
@@ -26,7 +26,7 @@ class Webui::PackageController < Webui::WebuiController
                                          :save_group, :remove_role, :view_file,
                                          :abort_build, :trigger_rebuild, :trigger_services,
                                          :wipe_binaries, :buildresult, :rpmlint_result, :rpmlint_log, :meta,
-                                         :attributes, :edit, :import_spec, :files, :users, :binary_download]
+                                         :attributes, :edit, :files, :users, :binary_download]
 
   before_action :require_repository, only: :binary
   before_action :require_architecture, only: :binary
@@ -392,11 +392,6 @@ class Webui::PackageController < Webui::WebuiController
       end
       @files = []
       return false
-    end
-
-    @spec_count = 0
-    @files.each do |file|
-      @spec_count += 1 if file[:ext] == 'spec'
     end
 
     true
@@ -909,28 +904,6 @@ class Webui::PackageController < Webui::WebuiController
     tgt_pkg = Package.find_by_project_and_name(params[:project], params[:package])
 
     render plain: tgt_pkg.try(:develpackage).try(:project).to_s
-  end
-
-  def import_spec
-    all_files = package_files
-    all_files.each do |file|
-      @specfile_name = file[:name] if file[:name].end_with?('.spec')
-    end
-    if @specfile_name.blank?
-      render json: {}
-      return
-    end
-    specfile_content = @package.source_file(@specfile_name)
-
-    description = []
-    lines = specfile_content.split(/\n/)
-    line = lines.shift until line =~ /^%description\s*$/
-    description << lines.shift until description.last =~ /^%/
-    # maybe the above end-detection of the description-section could be improved like this:
-    # description << lines.shift until description.last =~ /^%\{?(debug_package|prep|pre|preun|....)/
-    description.pop
-
-    render json: { description: description }
   end
 
   def buildresult

--- a/src/api/app/views/webui/package/edit.html.erb
+++ b/src/api/app/views/webui/package/edit.html.erb
@@ -11,23 +11,9 @@
     <label for="title"><strong>Title:</strong></label><br/>
     <%= text_field_tag( 'title', @package.title, :size => 80 ) %><br/>
     <label for="description"><strong>Description:</strong></label>
-    <% if params[:spec_count] == "1" %>
-      <%= link_to('Import from specfile', {:action => 'import_spec', :project => @project, :package => @package, :import => 'description'}, {:id => 'import-spec-link', :remote => true}) %>
-      <%= image_tag('ajax-loader.gif', :id => "spinner", :class => "hidden") %>
-    <% end %><br/>
     <%= text_area_tag( "description", @package.description, :cols => "80", :rows => "20" ) %><br/>
     <%= hidden_field_tag( "project", @project.name ) %>
     <%= hidden_field_tag( "package", @package.name ) %>
   </p>
   <p><%= submit_tag %></p>
-<% end %>
-
-<%= javascript_tag do %>
-  $(function() {
-    var toggleLoading = function () { $('#spinner').toggle(); };
-    $('#import-spec-link')
-      .bind('ajax:loading', toggleLoading)
-      .bind('ajax:complete', toggleLoading)
-      .bind('ajax:success', function (event, data, status, xhr) { $("#description").html(data); });
-  });
 <% end %>

--- a/src/api/app/views/webui/package/show.html.erb
+++ b/src/api/app/views/webui/package/show.html.erb
@@ -111,7 +111,7 @@
             <% end %>
             <% if User.current.can_modify? @package %>
                 <li>
-                  <%= link_to sprited_text('package_edit', 'Edit description'), :action => 'edit', :project => @project, :package => @package, :spec_count => @spec_count -%>
+                  <%= link_to sprited_text('package_edit', 'Edit description'), :action => 'edit', :project => @project, :package => @package %>
                 </li>
                 <li>
                   <%= link_to(sprited_text('package_delete', 'Delete package'), { :action => :delete_dialog, :package => @package, :project => @project }, :remote => true, id: 'delete-package') %>

--- a/src/api/app/views/webui/patchinfo/show.html.haml
+++ b/src/api/app/views/webui/patchinfo/show.html.haml
@@ -11,8 +11,8 @@
         - if User.current.can_modify?(@package)
           %ul.horizontal-list
             %li
-              = link_to sprite_tag('package_edit'), { action: 'edit_patchinfo', project: @project, package: @package, spec_count: @spec_count }
-              = link_to "Edit patchinfo", { action: 'edit_patchinfo', project: @project, package: @package, spec_count: @spec_count }, id: 'edit-patchinfo'
+              = link_to sprite_tag('package_edit'), { action: 'edit_patchinfo', project: @project, package: @package }
+              = link_to "Edit patchinfo", { action: 'edit_patchinfo', project: @project, package: @package }, id: 'edit-patchinfo'
             %li
               = link_to(sprite_tag('package_delete'), { action: :delete_dialog, package: @package, project: @project }, remote: true)
               = link_to('Delete patchinfo', { action: :delete_dialog, package: @package, project: @project }, remote: true, id: 'delete-patchinfo')


### PR DESCRIPTION
This feature isn't is currently hidden via a action parameter and
thus is hidden from users.
Moreover it isn't working anymore (if it ever was).

Let's drop it for now. We would have to re-implement this anyway, if
we decide later on to revive this.