### PR TITLE
Bugfix CI run

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,13 +38,13 @@ aliases:
     name: Init submodule
     command: git submodule update --init --recursive --remote
 
-  - &create_test_db
-    name: Create database
-    command: cd src/api; bundle exec rake db:create db:setup RAILS_ENV=test
-
   - &bootstrap_old_test_suite
     name: Setup application
     command: cd src/api; bundle exec rake dev:bootstrap[old_test_suite] RAILS_ENV=test FORCE_EXAMPLE_FILES=1
+
+  - &bootstrap_rspec
+    name: Setup application
+    command: cd src/api; bundle exec rake dev:bootstrap RAILS_ENV=test FORCE_EXAMPLE_FILES=1
 
   # keep the prefix for the following aligned
   - &save_repo_cache_key
@@ -111,12 +111,9 @@ jobs:
       - <<: *mariadb
     steps:
       - checkout
-      - run:
-          name: Setup application
-          command: cd src/api; bundle exec rake dev:prepare assets:precompile RAILS_ENV=test FORCE_EXAMPLE_FILES=1
       - run: *install_dependencies
       - run: *wait_for_database
-      - run: *create_test_db
+      - run: *bootstrap_rspec
       - run: mkdir /home/frontend/rspec
       - run:
           name: Run rspec


### PR DESCRIPTION
Before we can run anything in the bundle, we need to "update" it.
Also use our dev:prepare task that copies example files, sets up
the database and assets instead of individual CCI tasks for the
same result.