### PR TITLE
Add Bootstrap breadcrumbs for main, projects and packages

### DIFF
--- a/src/api/.haml-lint.yml
+++ b/src/api/.haml-lint.yml
@@ -2,6 +2,13 @@ linters:
   LineLength:
     max: 150
 
+  # Apply lint in all partials, but exclude 'breadcrumb_items' partials
+  InstanceVariables:
+    enabled: true
+    file_types: not_breadcrumb_items
+    matchers:
+      not_breadcrumb_items: \A_(?!breadcrumb_items).*\.haml\z
+
 exclude:
 - 'vendor/bundle/**/*'
 # Everything below is the old interface. We only lint the new Bootstrap interface

--- a/src/api/app/controllers/webui/webui_controller.rb
+++ b/src/api/app/controllers/webui/webui_controller.rb
@@ -14,7 +14,6 @@ class Webui::WebuiController < ActionController::Base
   protect_from_forgery
 
   before_action :setup_view_path
-  before_action :set_breadcrumbs
   before_action :check_user
   before_action :check_anonymous
   before_action :require_configuration
@@ -334,12 +333,5 @@ class Webui::WebuiController < ActionController::Base
       return true
     end
     @switch_to_webui2 = false
-  end
-
-  def set_breadcrumbs
-    name = @configuration ? @configuration['title'] : 'Open Build Service'
-    @breadcrumbs = [
-      { name: name, path: root_path }
-    ]
   end
 end

--- a/src/api/app/views/layouts/webui2/_breadcrumbs.html.haml
+++ b/src/api/app/views/layouts/webui2/_breadcrumbs.html.haml
@@ -1,10 +1,2 @@
 %nav{ "aria-label" => "breadcrumb" }
   %ol.breadcrumb.bg-transparent
-    - @breadcrumbs.each do |breadcrumb|
-      %li.breadcrumb-item{ class: @breadcrumbs.last == breadcrumb && 'active' , "aria-current" => "page" }
-        - if breadcrumb == @breadcrumbs.first
-          %i.fas.fa-home
-        - if breadcrumb[:path]
-          = link_to breadcrumb[:name], breadcrumb[:path]
-        - else
-          = breadcrumb[:name]

--- a/src/api/app/views/layouts/webui2/_breadcrumbs.html.haml
+++ b/src/api/app/views/layouts/webui2/_breadcrumbs.html.haml
@@ -1,2 +1,3 @@
 %nav{ "aria-label" => "breadcrumb" }
   %ol.breadcrumb.bg-transparent
+    = render partial: 'breadcrumb_items'

--- a/src/api/app/views/webui2/webui/main/_breadcrumb_items.html.haml
+++ b/src/api/app/views/webui2/webui/main/_breadcrumb_items.html.haml
@@ -1,0 +1,9 @@
+- home_title = @configuration ? @configuration['title'] : 'Open Build Service'
+- if current_page?(root_path)
+  %li.breadcrumb-item.active{ 'aria-current' => 'page' }
+    %i.fas.fa-home
+    = home_title
+- else
+  %li.breadcrumb-item
+    %i.fas.fa-home
+    = link_to home_title, root_path

--- a/src/api/app/views/webui2/webui/package/_breadcrumb_items.html.haml
+++ b/src/api/app/views/webui2/webui/package/_breadcrumb_items.html.haml
@@ -1,0 +1,6 @@
+= render partial: 'webui/project/breadcrumb_items'
+%li.breadcrumb-item
+  = link_to @package, package_show_path(@project, @package)
+%li.breadcrumb-item.active{ 'aria-current' => 'page' }
+  - if current_page?(package_view_revisions_path)
+    Revisions

--- a/src/api/app/views/webui2/webui/project/_breadcrumb_items.html.haml
+++ b/src/api/app/views/webui2/webui/project/_breadcrumb_items.html.haml
@@ -1,0 +1,9 @@
+= render partial: 'webui/main/breadcrumb_items'
+- if current_page?(projects_path)
+  %li.breadcrumb-item.active{ 'aria-current' => 'page' }
+    Projects
+- else
+  %li.breadcrumb-item
+    = link_to 'Projects', projects_path
+  %li.breadcrumb-item
+    = link_to @project, project_show_path(@project)


### PR DESCRIPTION
Co-authored-by: Moisés Déniz Alemán <mdeniz@suse.com>

Screenshot of a package page:
![package_breadcrumbs](https://user-images.githubusercontent.com/24919/44353965-d6ccb100-a4a8-11e8-8f4b-da6132590ccc.png)
