### PR TITLE
Add beta flag to Admin user in seeds.rb

### DIFF
--- a/src/api/db/seeds.rb
+++ b/src/api/db/seeds.rb
@@ -53,7 +53,7 @@ Role.where(title: 'Staff').first_or_create(global: true)
 puts 'Seeding users table...'
 admin = User.where(login: 'Admin').first_or_create(login: 'Admin', email: 'root@localhost',
                                                     realname: 'OBS Instance Superuser', state: 'confirmed',
-                                                    password: 'opensuse')
+                                                    password: 'opensuse', in_beta: true)
 User.where(login: '_nobody_').first_or_create(login: '_nobody_', email: 'nobody@localhost',
                                               realname: 'Anonymous User', state: 'locked',
                                               password: '123456')


### PR DESCRIPTION
In #5640 we added a public beta to OBS and
removed Admin / Staff users from showing
disabled features. However, we should enable beta
for Admin users by default. For Admins beta features
should be opt out and not opt in.