### PR TITLE
Allow users to join the beta, even with a proxy

### DIFF
--- a/src/api/app/views/webui/user/_save_dialog.html.haml
+++ b/src/api/app/views/webui/user/_save_dialog.html.haml
@@ -11,7 +11,4 @@
         %p
           = f.label(:email, "e-Mail:")
           = f.text_field(:email, required: true, email: true)
-        %p
-          = f.label(:in_beta, 'Join the beta?')
-          = f.check_box(:in_beta)
         = render partial: '/webui/shared/dialog_action_buttons'

--- a/src/api/app/views/webui/user/show.html.haml
+++ b/src/api/app/views/webui/user/show.html.haml
@@ -42,6 +42,11 @@
         - else
           = link_to(sprited_text('user_edit', 'Edit your account'), { controller: 'user', action: 'save_dialog', user: User.current }, {id: 'save_dialog', remote: true})
         %br/
+      - if @displayed_user.in_beta?
+        = link_to(sprited_text('user_delete', 'Leave public beta program'), user_save_path(user: { login: @displayed_user.login, in_beta: 0}), method: :post)
+      - else
+        = link_to(sprited_text('user_add', 'Join public beta program'), user_save_path(user: { login: @displayed_user.login, in_beta: 1 }), method: :post)
+      %br/
       - if @configuration.passwords_changable?(User.current)
         = link_to(sprited_text('key', 'Change your password'), { controller: 'user', action: 'password_dialog', user: User.current }, {id: 'password_dialog', remote: true})
         %br/

--- a/src/api/spec/features/webui/users/user_home_page_spec.rb
+++ b/src/api/spec/features/webui/users/user_home_page_spec.rb
@@ -17,7 +17,6 @@ RSpec.feature "User's home project creation", type: :feature, js: true do
     expect(page).to have_css('#home-realname', text: 'Jim Knopf')
     expect(page).to have_css("a[href='mailto:jim.knopf@puppenkiste.com']", text: 'jim.knopf@puppenkiste.com')
 
-    expect(page).not_to have_text('Participates in public beta program')
     expect(page).to have_text('Edit your account')
     expect(page).to have_text('Change your password')
 
@@ -42,12 +41,22 @@ RSpec.feature "User's home project creation", type: :feature, js: true do
 
     fill_in('user_realname', with: 'John Doe')
     fill_in('user_email', with: 'john.doe@opensuse.org')
-    check('user_in_beta')
     click_button('Ok')
 
-    expect(page).to have_text('Participates in public beta program')
     expect(page).to have_text("User data for user 'Jim' successfully updated.")
     expect(page).to have_css('#home-realname', text: 'John Doe')
     expect(page).to have_css("a[href='mailto:john.doe@opensuse.org']", text: 'john.doe@opensuse.org')
+  end
+
+  scenario 'public beta program' do
+    expect(page).not_to have_text('Participates in public beta program')
+
+    click_link('Join public beta program')
+    expect(page).to have_text("User data for user 'Jim' successfully updated.")
+    expect(page).to have_text('Participates in public beta program')
+
+    click_link('Leave public beta program')
+    expect(page).to have_text("User data for user 'Jim' successfully updated.")
+    expect(page).not_to have_text('Participates in public beta program')
   end
 end


### PR DESCRIPTION
Users could not join the beta when a proxy is in place. The page to edit
their account (and join the beta) was not reachable.

Fixes #5667