### PR TITLE
Display li tag only when needed

### DIFF
--- a/src/api/app/views/webui2/webui/package/_breadcrumb_items.html.haml
+++ b/src/api/app/views/webui2/webui/package/_breadcrumb_items.html.haml
@@ -1,6 +1,6 @@
 = render partial: 'webui/project/breadcrumb_items'
 %li.breadcrumb-item
   = link_to @package, package_show_path(@project, @package)
-%li.breadcrumb-item.active{ 'aria-current' => 'page' }
-  - if current_page?(package_view_revisions_path)
+- if current_page?(package_view_revisions_path)
+  %li.breadcrumb-item.active{ 'aria-current' => 'page' }
     Revisions


### PR DESCRIPTION
When the current page is not package/revisions, the li tag must not be displayed.

I found this while working on the Bootstrap version of package#attributes.