### PR TITLE
Check if package revisions are present

### DIFF
--- a/src/api/app/views/webui2/webui/package/revisions.html.haml
+++ b/src/api/app/views/webui2/webui/package/revisions.html.haml
@@ -5,8 +5,8 @@
   = render(partial: 'tabs', locals: { project: @project, package: @package })
 
   .card-body
-    - if @revisions
-      %h3 #{@pagetitle} (#{@revisions.count})
+    %h3 #{@pagetitle} (#{@revisions.count})
+    - if @revisions.present?
       .list-group
         - @revisions.each do |revision|
           .list-group-item{ id: "commit_item_#{revision}" }
@@ -19,6 +19,5 @@
         = paginate @revisions
         = link_to('Show all', action: 'revisions', project: @project, package: @package, show_all: 1)
     - else
-      %h3= page_title
       %p
         %i No commits exists yet.


### PR DESCRIPTION
When checking an array with `if my_array`, it will always be true (no matter if the array is empty or not)

I found this while working on the Bootstrap version of package#attributes.