### PR TITLE
Bs request action maintenance release errors

### DIFF
--- a/src/api/app/models/bs_request_action_maintenance_release.rb
+++ b/src/api/app/models/bs_request_action_maintenance_release.rb
@@ -2,15 +2,10 @@
 class BsRequestActionMaintenanceRelease < BsRequestAction
   #### Includes and extends
   include BsRequestAction::Differ
-
+  include BsRequestActionMaintenanceRelease::Errors
   #### Constants
 
   #### Self config
-  class LackingReleaseMaintainership < APIError; setup 'lacking_maintainership', 403; end
-  class RepositoryWithoutReleaseTarget < APIError; setup 'repository_without_releasetarget'; end
-  class RepositoryWithoutArchitecture < APIError; setup 'repository_without_architecture'; end
-  class ArchitectureOrderMissmatch < APIError; setup 'architecture_order_missmatch'; end
-  class OpenReleaseRequests < APIError; setup 'open_release_requests'; end
 
   #### Attributes
 

--- a/src/api/app/models/bs_request_action_maintenance_release/errors.rb
+++ b/src/api/app/models/bs_request_action_maintenance_release/errors.rb
@@ -1,0 +1,8 @@
+module BsRequestActionMaintenanceRelease::Errors
+  extend ActiveSupport::Concern
+  class LackingReleaseMaintainership < APIError; setup 'lacking_maintainership', 403; end
+  class RepositoryWithoutReleaseTarget < APIError; setup 'repository_without_releasetarget'; end
+  class RepositoryWithoutArchitecture < APIError; setup 'repository_without_architecture'; end
+  class ArchitectureOrderMissmatch < APIError; setup 'architecture_order_missmatch'; end
+  class OpenReleaseRequests < APIError; setup 'open_release_requests'; end
+end


### PR DESCRIPTION
move the exceptions classes to its own errors module to better organize code and reduce clutter