### PR TITLE
Align breadcrumbs' style with personal navigation

### DIFF
--- a/src/api/app/assets/stylesheets/webui2/breadcrumbs-component.scss
+++ b/src/api/app/assets/stylesheets/webui2/breadcrumbs-component.scss
@@ -1,3 +1,11 @@
-.breadcrumb-item > a {
-    color: $gray-600;
+ol.breadcrumb {
+  padding-top: 0.5rem;
+
+  & li.breadcrumb-item {
+    font-size: 0.9rem;
+
+    & a {
+      color: $gray-600;
+    }
+  }
 }


### PR DESCRIPTION
The font size and the padding top is now the same for both components, making them fit better together. It also gives us more room in the breadcrumbs, thanks to the smaller font.