### PR TITLE
Move exceptions classes from bs_request_action to its own module

### DIFF
--- a/src/api/app/controllers/webui/package_controller.rb
+++ b/src/api/app/controllers/webui/package_controller.rb
@@ -295,7 +295,7 @@ class Webui::PackageController < Webui::WebuiController
         req.set_add_revision
         req.save!
       end
-    rescue BsRequestAction::DiffError => e
+    rescue BsRequestAction::Errors::DiffError => e
       flash[:error] = "Unable to diff sources: #{e.message}"
     rescue BsRequestAction::MissingAction => e
       flash[:error] = 'Unable to submit, sources are unchanged'

--- a/src/api/app/controllers/webui/project_controller.rb
+++ b/src/api/app/controllers/webui/project_controller.rb
@@ -180,7 +180,7 @@ class Webui::ProjectController < Webui::WebuiController
              BsRequestAction::BuildNotFinished,
              BsRequestAction::VersionReleaseDiffers,
              BsRequestAction::UnknownProject,
-             BsRequestAction::UnknownTargetProject,
+             BsRequestAction::Errors::UnknownTargetProject,
              BsRequestAction::UnknownTargetPackage => e
         flash[:error] = e.message
         redirect_back(fallback_location: { action: 'show', project: params[:project] }) && return
@@ -343,7 +343,7 @@ class Webui::ProjectController < Webui::WebuiController
       flash[:success] = "Created <a href='#{url_for(controller: 'request',
                                                     action: 'show',
                                                     number: req.number)}'>repository delete request #{req.number}</a>"
-    rescue BsRequestAction::UnknownTargetProject,
+    rescue BsRequestAction::Errors::UnknownTargetProject,
            BsRequestAction::UnknownTargetPackage => e
       flash[:error] = e.message
       redirect_to(action: :index, controller: :repositories, project: params[:project]) && return

--- a/src/api/app/jobs/bs_request_action_webui_infos_job.rb
+++ b/src/api/app/jobs/bs_request_action_webui_infos_job.rb
@@ -22,7 +22,7 @@ class BsRequestActionWebuiInfosJob < ApplicationJob
 
   def silent
     yield
-  rescue BsRequestAction::DiffError, Project::UnknownObjectError, Package::UnknownObjectError
+  rescue BsRequestAction::Errors::DiffError, Project::UnknownObjectError, Package::UnknownObjectError
     # as this is only for caching, we can ignore these errors
   end
 

--- a/src/api/app/models/bs_request_action.rb
+++ b/src/api/app/models/bs_request_action.rb
@@ -3,33 +3,11 @@ require 'api_exception'
 class BsRequestAction < ApplicationRecord
   #### Includes and extends
   include ParsePackageDiff
-
+  include BsRequestAction::Errors
   #### Constants
   VALID_SOURCEUPDATE_OPTIONS = ['update', 'noupdate', 'cleanup'].freeze
 
   #### Self config
-  class DiffError < APIError; setup 404; end # a diff error can have many reasons, but most likely something within us
-  class RemoteSource < APIError; end
-  class RemoteTarget < APIError; end
-  class InvalidReleaseTarget < APIError; end
-  class LackingMaintainership < APIError
-    setup 'lacking_maintainership', 403, 'Creating a submit request action with options requires maintainership in source package'
-  end
-  class NoMaintenanceProject < APIError; end
-  class UnknownAttribute < APIError; setup 404; end
-  class IncidentHasNoMaintenanceProject < APIError; end
-  class NotSupported < APIError; end
-  class SubmitRequestRejected < APIError; end
-  class RequestRejected < APIError; setup 403; end
-  class UnknownProject < APIError; setup 404; end
-  class UnknownRole < APIError; setup 404; end
-  class IllegalRequest < APIError; end
-  class BuildNotFinished < APIError; end
-  class UnknownTargetProject < APIError; end
-  class UnknownTargetPackage < APIError; end
-  class WrongLinkedPackageSource < APIError; end
-  class MissingPatchinfo < APIError; end
-  class VersionReleaseDiffers < APIError; end
 
   #### Attributes
 
@@ -276,7 +254,7 @@ class BsRequestAction < ApplicationRecord
 
   def contains_change?
     return sourcediff.present?
-  rescue BsRequestAction::DiffError
+  rescue BsRequestAction::Errors::DiffError
     # if the diff can'be created we can't say
     # but let's assume the reason for the problem lies in the change
     return true

--- a/src/api/app/models/bs_request_action/differ/for_source.rb
+++ b/src/api/app/models/bs_request_action/differ/for_source.rb
@@ -52,9 +52,9 @@ class BsRequestAction
       def source_diff(project_name, package_name, query)
         Backend::Api::Sources::Package.source_diff(project_name, package_name, query)
       rescue Timeout::Error
-        raise DiffError, "Timeout while diffing #{project_name}/#{package_name}"
+        raise BsRequestAction::Errors::DiffError, "Timeout while diffing #{project_name}/#{package_name}"
       rescue ActiveXML::Transport::Error => e
-        raise DiffError, "The diff call for #{project_name}/#{package_name} failed: #{e.summary}"
+        raise BsRequestAction::Errors::DiffError, "The diff call for #{project_name}/#{package_name} failed: #{e.summary}"
       end
 
       def superseded_bs_request_action

--- a/src/api/app/models/bs_request_action/errors.rb
+++ b/src/api/app/models/bs_request_action/errors.rb
@@ -1,0 +1,32 @@
+module BsRequestAction::Errors
+  extend ActiveSupport::Concern
+
+  # a diff error can have many reasons, but most likely something within us
+  class DiffError < APIError; setup 404; end
+  class RemoteSource < APIError; end
+  class RemoteTarget < APIError; end
+  class InvalidReleaseTarget < APIError; end
+  class LackingMaintainership < APIError
+    setup 'lacking_maintainership', 403, 'Creating a submit request action with options requires maintainership in source package'
+  end
+  class NoMaintenanceProject < APIError; end
+  class UnknownAttribute < APIError; setup 404; end
+  class IncidentHasNoMaintenanceProject < APIError; end
+  class NotSupported < APIError; end
+  class SubmitRequestRejected < APIError; end
+  class RequestRejected < APIError; setup 403; end
+  class UnknownProject < APIError; setup 404; end
+  class UnknownRole < APIError; setup 404; end
+  class IllegalRequest < APIError; end
+  class BuildNotFinished < APIError; end
+  class UnknownTargetProject < APIError; end
+  class UnknownTargetPackage < APIError; end
+  class WrongLinkedPackageSource < APIError; end
+  class MissingPatchinfo < APIError; end
+  class VersionReleaseDiffers < APIError; end
+  class LackingReleaseMaintainership < APIError; setup 'lacking_maintainership', 403; end
+  class RepositoryWithoutReleaseTarget < APIError; setup 'repository_without_releasetarget'; end
+  class RepositoryWithoutArchitecture < APIError; setup 'repository_without_architecture'; end
+  class ArchitectureOrderMissmatch < APIError; setup 'architecture_order_missmatch'; end
+  class OpenReleaseRequests < APIError; setup 'open_release_requests'; end
+end

--- a/src/api/app/models/bs_request_action_maintenance_release.rb
+++ b/src/api/app/models/bs_request_action_maintenance_release.rb
@@ -2,7 +2,6 @@
 class BsRequestActionMaintenanceRelease < BsRequestAction
   #### Includes and extends
   include BsRequestAction::Differ
-  include BsRequestActionMaintenanceRelease::Errors
   #### Constants
 
   #### Self config

--- a/src/api/app/models/event/request.rb
+++ b/src/api/app/models/event/request.rb
@@ -67,7 +67,7 @@ module Event
       action = BsRequestAction.find(a['action_id'])
       begin
         action.sourcediff(view: nil, withissues: 0)
-      rescue BsRequestAction::DiffError
+      rescue BsRequestAction::Errors::DiffError
         return # can't help
       end
     end

--- a/src/api/spec/controllers/webui/project_controller_spec.rb
+++ b/src/api/spec/controllers/webui/project_controller_spec.rb
@@ -658,21 +658,21 @@ RSpec.describe Webui::ProjectController, vcr: true do
 
     context 'without target project' do
       before do
-        expect(BsRequestActionDelete).to receive(:new).and_raise(BsRequestAction::UnknownTargetProject)
+        expect(BsRequestActionDelete).to receive(:new).and_raise(BsRequestAction::Errors::UnknownTargetProject)
         post :remove_target_request, params: { project: apache_project, description: 'Fake description' }
       end
 
-      it { expect(flash[:error]).to eq('BsRequestAction::UnknownTargetProject') }
+      it { expect(flash[:error]).to eq('BsRequestAction::Errors::UnknownTargetProject') }
       it { is_expected.to redirect_to(action: :index, controller: :repositories, project: apache_project) }
     end
 
     context 'without target package' do
       before do
-        expect(BsRequestActionDelete).to receive(:new).and_raise(BsRequestAction::UnknownTargetPackage)
+        expect(BsRequestActionDelete).to receive(:new).and_raise(BsRequestAction::Errors::UnknownTargetPackage)
         post :remove_target_request, params: { project: apache_project, description: 'Fake description' }
       end
 
-      it { expect(flash[:error]).to eq('BsRequestAction::UnknownTargetPackage') }
+      it { expect(flash[:error]).to eq('BsRequestAction::Errors::UnknownTargetPackage') }
       it { is_expected.to redirect_to(action: :index, project: apache_project, controller: :repositories) }
     end
 
@@ -1154,8 +1154,8 @@ RSpec.describe Webui::ProjectController, vcr: true do
        BsRequestActionMaintenanceRelease::RepositoryWithoutArchitecture,
        BsRequestActionMaintenanceRelease::ArchitectureOrderMissmatch,
        BsRequestAction::VersionReleaseDiffers,
-       BsRequestAction::UnknownTargetProject,
-       BsRequestAction::UnknownTargetPackage].each do |error_class|
+       BsRequestAction::Errors::UnknownTargetProject,
+       BsRequestAction::Errors::UnknownTargetPackage].each do |error_class|
         it_behaves_like 'a non APIError', error_class
       end
     end

--- a/src/api/spec/models/bs_request_action/differ/for_source_spec.rb
+++ b/src/api/spec/models/bs_request_action/differ/for_source_spec.rb
@@ -77,7 +77,7 @@ RSpec.describe BsRequestAction::Differ::ForSource, vcr: true do
         stub_request(:post, path).with(query: hash_including('cmd' => 'diff', 'opackage' => target_package.name)).and_return(body: no_such_revision, status: 404)
       end
 
-      it { expect { subject.perform }.to raise_error(BsRequestAction::DiffError, %r{The diff call for source_project/source_package failed: no such revision}) }
+      it { expect { subject.perform }.to raise_error(BsRequestAction::Errors::DiffError, %r{The diff call for source_project/source_package failed: no such revision}) }
     end
 
     context 'with superseded request' do

--- a/src/api/spec/models/bs_request_action_delete_spec.rb
+++ b/src/api/spec/models/bs_request_action_delete_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe BsRequestActionDelete, vcr: true do
       let(:delete_request) { create(:delete_bs_request, target_project: target_project) }
       subject { delete_request.bs_request_actions.first }
 
-      it { expect { subject.sourcediff }.to raise_error(BsRequestAction::DiffError) }
+      it { expect { subject.sourcediff }.to raise_error(BsRequestAction::Errors::DiffError) }
     end
 
     context 'for package' do


### PR DESCRIPTION
To reduce code clutter, following the pattern already used in
other models like ```project.rb``` or ```package.rb```
move the exception classes to its own errors.rb file