### PR TITLE
Don't display the application's title in the breadcrumbs

### DIFF
--- a/src/api/app/views/webui2/webui/main/_breadcrumb_items.html.haml
+++ b/src/api/app/views/webui2/webui/main/_breadcrumb_items.html.haml
@@ -1,9 +1,8 @@
 - home_title = @configuration ? @configuration['title'] : 'Open Build Service'
 - if current_page?(root_path)
   %li.breadcrumb-item.active{ 'aria-current' => 'page' }
-    %i.fas.fa-home
-    = home_title
+    %i.fas.fa-home{ title: home_title }
 - else
   %li.breadcrumb-item
-    %i.fas.fa-home
-    = link_to home_title, root_path
+    = link_to(root_path) do
+      %i.fas.fa-home{ title: home_title }


### PR DESCRIPTION
We discuss about this in the review meeting on 24.08.2018. We didn't take the decision to not display the application's title in the breadcrumbs, however we were not sure whether we should keep it or not. So you we know how it would look like without it.