### PR TITLE
Add initial SECURITY.md file

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,40 @@
+# Security Policies and Procedures
+
+This document outlines security procedures and general policies for the `Open Build Service`
+project.
+
+  * [Reporting a Bug](#reporting-a-bug)
+  * [Disclosure Policy](#disclosure-policy)
+  * [Comments on this Policy](#comments-on-this-policy)
+
+## Reporting a Bug
+
+The `Open Build Service` team and community take all security bugs in `Open Build Service` seriously.
+Thank you for improving the security of `Open Build Service`. We appreciate your efforts and
+responsible disclosure and will make every effort to acknowledge your
+contributions.
+
+Report security bugs by emailing the [Security Team](https://www.suse.com/support/security/contact/) at security@suse.com.
+
+The security team will acknowledge your email as soon as possible, and will send a
+more detailed response indicating the next steps in handling
+your report. After the initial reply to your report, the security team will
+endeavor to keep you informed of the progress towards a fix and full
+announcement, and may ask for additional information or guidance.
+
+## Disclosure Policy
+
+When the security team receives a security bug report, they will assign it to a
+primary handler. This person will coordinate the fix and release process,
+involving the following steps:
+
+  * Confirm the problem and determine the affected versions.
+  * Audit code to find any potential similar problems.
+  * Prepare fixes for all releases still under maintenance. These fixes will be
+    deployed in production and released as fast as possible to all maintained
+    versions of `Open Build Service`.
+
+## Comments on this Policy
+
+If you have suggestions on how this process could be improved, please contact the `Open Build Service` team at
+the [obs-devel mailinglist](https://lists.opensuse.org/obs-devel/)


### PR DESCRIPTION
To better describe our security issues handling, use a standard
way to define it via SECURITY.md