### PR TITLE
Add new icon for show request

### DIFF
--- a/src/api/app/views/webui2/shared/bs_requests/index.json.erb
+++ b/src/api/app/views/webui2/shared/bs_requests/index.json.erb
@@ -12,7 +12,7 @@
           "<%= escape_javascript(user_with_realname_and_icon(row.creator, short: true)) %>",
           "<%= escape_javascript(new_or_update_request(row)) %>",
           "<%= escape_javascript(row.priority) %>",
-          "<%= escape_javascript(link_to(icon('fa', 'info-circle'), request_show_path(row.number), { title: "Show request ##{row.number}", class: :request_link })) %>"
+          "<%= escape_javascript(link_to(icon('far', 'eye'), request_show_path(row.number), { title: "Show request ##{row.number}", class: :request_link })) %>"
         <% end %>
       ]
       <% unless index == @requests_data_table.rows.length - 1 %>


### PR DESCRIPTION
We switched the info icon to something more representative.

### Before

![screenshot_2018-08-27 requests for test - open build service 1](https://user-images.githubusercontent.com/1212806/44657278-94e9c080-a9fc-11e8-8c78-7913e6d70077.png)


### After

![screenshot_2018-08-27 requests for test - open build service](https://user-images.githubusercontent.com/1212806/44657270-90250c80-a9fc-11e8-9f89-3491237f7ede.png)
