### PR TITLE
Prevent failure due to missing link to remote info

### DIFF
--- a/src/api/app/controllers/webui/package_controller.rb
+++ b/src/api/app/controllers/webui/package_controller.rb
@@ -360,7 +360,7 @@ class Webui::PackageController < Webui::WebuiController
   def set_remote_linkinfo
     linkinfo = @package.linkinfo
 
-    return unless linkinfo['package'] && linkinfo['project']
+    return unless linkinfo && linkinfo['package'] && linkinfo['project']
     return unless Package.exists_on_backend?(linkinfo['package'], linkinfo['project'])
 
     @linkinfo = { remote_project: linkinfo['project'], package: linkinfo['package'] }


### PR DESCRIPTION
It is necessary to check if 'linkinfo' exists, not only if its
key-value pairs exit.

Fixes #5718