### PR TITLE
Add validation to MaintainedProject

### DIFF
--- a/src/api/app/models/maintained_project.rb
+++ b/src/api/app/models/maintained_project.rb
@@ -1,6 +1,13 @@
 class MaintainedProject < ApplicationRecord
   belongs_to :project, foreign_key: :project_id
   belongs_to :maintenance_project, class_name: 'Project', foreign_key: :maintenance_project_id
+
+  validates :project_id, uniqueness: {
+    scope: :maintenance_project_id,
+    message: lambda do |object, _data|
+      "is already maintained by the maintenance project ##{object.maintenance_project_id}"
+    end
+  }
 end
 
 # == Schema Information


### PR DESCRIPTION
Without validation, it raised an exception whenever trying to create a
non-unique MaintainedProject

Fixes #5639