### PR TITLE
Add validation to Kiwi::Repository for image_id and order

### DIFF
--- a/src/api/app/models/kiwi/repository.rb
+++ b/src/api/app/models/kiwi/repository.rb
@@ -31,6 +31,12 @@ module Kiwi
     validates :replaceable, inclusion: { in: [true, false], message: 'has to be a boolean' }
     validates :imageinclude, :prefer_license, inclusion: { in: [true, false], message: 'has to be a boolean' }, allow_nil: true
     validates_associated :image, on: :update
+    validates :order, uniqueness: {
+      scope: :image_id,
+      message: lambda do |object, data|
+        "##{data[:value]} has already been taken for the Image ##{object.image_id}"
+      end
+    }
 
     #### Class methods using self. (public and then private)
 


### PR DESCRIPTION
Without validation, it raised an exception whenever trying to create a non-unique `image_id` + `order` combination for `Kiwi::Repository`

Fixes #5638