### PR TITLE
Add validation to BsRequest for number

### DIFF
--- a/src/api/app/models/bs_request.rb
+++ b/src/api/app/models/bs_request.rb
@@ -91,6 +91,7 @@ class BsRequest < ApplicationRecord
   validate :check_creator, on: [:create, :save!]
   validates :comment, length: { maximum: 65_535 }
   validates :description, length: { maximum: 65_535 }
+  validates :number, uniqueness: true
   validates_associated :bs_request_actions, message: ->(_, record) { record[:value].map { |r| r.errors.full_messages }.flatten.to_sentence }
 
   before_update :send_state_change


### PR DESCRIPTION
Without validation, it raised an exception whenever trying to create a `BsRequest` with a non-unique number

Fixes #5731