### PR TITLE
Use confirmed_user in Groups factory

### DIFF
--- a/src/api/spec/factories/groups.rb
+++ b/src/api/spec/factories/groups.rb
@@ -5,7 +5,7 @@ FactoryBot.define do
 
     factory :group_with_user do
       after(:create) do |group|
-        group.groups_users.create(user: create(:user))
+        group.groups_users.create(user: create(:confirmed_user))
       end
     end
   end


### PR DESCRIPTION
because it is expected when creating a Group with a User
that the user is fully functional and it is not necessary
to set the state to confirmed first.

This can cause quite some debugging and frustration.