### PR TITLE
Implement Status::RequiredChecks 

### DIFF
--- a/src/api/app/assets/stylesheets/webui/obs_factory/application.css
+++ b/src/api/app/assets/stylesheets/webui/obs_factory/application.css
@@ -30,7 +30,7 @@ a.openqa-failed, a.check-error, a.check-failure {
     color: red
 }
 
-a.openqa-none, a.check-pending {
+a.openqa-none, span.check-pending {
     color: #006699
 }
 

--- a/src/api/app/controllers/status/checks_controller.rb
+++ b/src/api/app/controllers/status/checks_controller.rb
@@ -8,15 +8,19 @@ class Status::ChecksController < ApplicationController
   skip_before_action :require_login, only: [:show, :index]
   after_action :verify_authorized
 
+  # GET /projects/:project_name/repositories/:repository_name/repository_publishes/:repository_publish_build_id/checks
   def index
     @checks = @checkable.checks
+    @missing_checks = @checkable.missing_checks
     authorize @checks
   end
 
+  # GET /projects/:project_name/repositories/:repository_name/repository_publishes/:repository_publish_build_id/checks/:id
   def show
     authorize @check
   end
 
+  # POST /projects/:project_name/repositories/:repository_name/repository_publishes/:repository_publish_build_id/checks
   def create
     @xml_check[:checkable] = @checkable
     @check = Status::Check.new(@xml_check)
@@ -28,6 +32,7 @@ class Status::ChecksController < ApplicationController
     end
   end
 
+  # PATCH /projects/:project_name/repositories/:repository_name/repository_publishes/:repository_publish_build_id/checks/:id
   def update
     authorize @check
     if @check.update(@xml_check)
@@ -37,6 +42,7 @@ class Status::ChecksController < ApplicationController
     end
   end
 
+  # DELETE /projects/:project_name/repositories/:repository_name/repository_publishes/:repository_publish_build_id/checks/:id
   def destroy
     authorize @check
     if @check.destroy
@@ -49,12 +55,12 @@ class Status::ChecksController < ApplicationController
   private
 
   def require_or_initialize_checkable
-    @checkable = @repository.status_publishes.find_or_initialize_by(build_id: params[:status_repository_publish_build_id])
+    @checkable = @repository.status_publishes.find_or_initialize_by(build_id: params[:repository_publish_build_id])
   end
 
   def require_checkable
-    @checkable = Status::RepositoryPublish.find_by(build_id: params[:status_repository_publish_build_id]) if params[:status_repository_publish_build_id]
-    render_error(status: 404, errorcode: 'not_found', message: "Unable to find status_repository_publish with id '#{params[:status_repository_publish_build_id]}'") unless @checkable
+    @checkable = Status::RepositoryPublish.find_by(build_id: params[:repository_publish_build_id]) if params[:repository_publish_build_id]
+    render_error(status: 404, errorcode: 'not_found', message: "Unable to find status_repository_publish with id '#{params[:repository_publish_build_id]}'") unless @checkable
   end
 
   def require_check

--- a/src/api/app/controllers/status/required_checks_controller.rb
+++ b/src/api/app/controllers/status/required_checks_controller.rb
@@ -1,0 +1,98 @@
+class Status::RequiredChecksController < ApplicationController
+  #### Includes and extends
+
+  #### Constants
+
+  #### Self config
+
+  #### Callbacks macros: before_action, after_action, etc.
+  before_action :set_checkable, only: [:index, :create, :destroy]
+  before_action :set_required_check, only: [:destroy]
+  skip_before_action :require_login, only: [:index]
+  # Pundit authorization policies control
+  after_action :verify_authorized
+
+  #### CRUD actions
+
+  # GET /projects/:project_name/repositories/:repository_name/required_checks
+  def index
+    authorize @checkable
+    @required_checks = @checkable.required_checks
+  end
+
+  # POST /projects/:project_name/repositories/:repository_name/required_checks
+  def create
+    authorize @checkable
+    @required_checks = @checkable.required_checks |= names
+
+    if @checkable.save
+      render action: :index
+    else
+      render_error(
+        status: 422,
+        errorcode: 'invalid_required_check',
+        message: "Could not save required check: #{@checkable.errors.full_messages.to_sentence}"
+      )
+    end
+  end
+
+  # DELETE /projects/:project_name/repositories/:repository_name/required_checks/:name
+  def destroy
+    authorize @checkable
+    @checkable.required_checks -= [params[:name]]
+
+    if @checkable.save
+      render_ok
+    else
+      render_error(
+        status: 422,
+        errorcode: 'invalid_required_check',
+        message: "Could not delete required check: #{@checkable.errors.full_messages.to_sentence}"
+      )
+    end
+  end
+
+  #### Non CRUD actions
+
+  #### Non actions methods
+  # Use hide_action if they are not private
+
+  private
+
+  def set_checkable
+    @project = Project.get_by_name(params[:project_name])
+    if params[:repository_name]
+      @checkable = @project.repositories.find_by(name: params[:repository_name])
+      return if @checkable
+
+      render_error(
+        status: 404,
+        errorcode: 'not_found',
+        message: "Unable to find repository with name '#{params[:project_name]}/#{params[:repository_name]}'"
+      )
+    else
+      render_error(
+        status: 404,
+        errorcode: 'not_found',
+        message: 'No repository name specified.'
+      )
+    end
+  end
+
+  # Use callbacks to share common setup or constraints between actions.
+  def set_required_check
+    @required_check = @checkable.required_checks.find(params[:id])
+    return if @required_check
+
+    render_error(
+      status: 404,
+      errorcode: 'not_found',
+      message: "Unable to find required check with id '#{params[:id]}'"
+    )
+  end
+
+  def names
+    result = (Xmlhash.parse(request.body.read) || {}).with_indifferent_access
+    [result[:name]].flatten.reject(&:blank?)
+  end
+end

--- a/src/api/app/controllers/status/required_checks_controller.rb
+++ b/src/api/app/controllers/status/required_checks_controller.rb
@@ -60,8 +60,8 @@ class Status::RequiredChecksController < ApplicationController
   private
 
   def set_checkable
-    @project = Project.get_by_name(params[:project_name])
     if params[:repository_name]
+      @project = Project.get_by_name(params[:project_name])
       @checkable = @project.repositories.find_by(name: params[:repository_name])
       return if @checkable
 

--- a/src/api/app/controllers/webui/obs_factory/staging_projects_controller.rb
+++ b/src/api/app/controllers/webui/obs_factory/staging_projects_controller.rb
@@ -37,7 +37,7 @@ module Webui::ObsFactory
         format.html do
           # FIXME: For staging repositories only the images repository is relevant atm
           # However, we should make this configurable in the future
-          images_repository = @staging_project.repositories.find_by(name: 'image')
+          images_repository = @staging_project.repositories.find_by(name: 'images')
           @staging_project = ::ObsFactory::StagingProjectPresenter.new(@staging_project)
           # For the breadcrumbs
           @project = @distribution.project

--- a/src/api/app/controllers/webui/obs_factory/staging_projects_controller.rb
+++ b/src/api/app/controllers/webui/obs_factory/staging_projects_controller.rb
@@ -42,8 +42,12 @@ module Webui::ObsFactory
           # For the breadcrumbs
           @project = @distribution.project
           return if images_repository.blank?
+
           @build_id = images_repository.build_id
-          @checks = images_repository.checks.for_build_id(@build_id)
+          status = images_repository.status_publishes.find_by(build_id: @build_id)
+          return if status.nil?
+          @missing_checks = status.missing_checks
+          @checks = status.checks
         end
         format.json { render json: @staging_project }
       end

--- a/src/api/app/helpers/status/required_checks_helper.rb
+++ b/src/api/app/helpers/status/required_checks_helper.rb
@@ -1,0 +1,11 @@
+module Status::RequiredChecksHelper
+  def build_header(project, checkable)
+    if checkable.is_a?(Repository)
+      { project: project.name, repository: checkable.name }
+    elsif checkable.is_a?(Package)
+      { project: project.name, package: checkable.name }
+    else
+      { project: project.name }
+    end
+  end
+end

--- a/src/api/app/models/project.rb
+++ b/src/api/app/models/project.rb
@@ -75,7 +75,6 @@ class Project < ApplicationRecord
 
   has_many :target_of_bs_request_actions, class_name: 'BsRequestAction', foreign_key: 'target_project_id'
   has_many :target_of_bs_requests, through: :target_of_bs_request_actions, source: :bs_request
-  has_many :required_checks, class_name: 'Status::RequiredCheck', as: :checkable
 
   default_scope { where('projects.id not in (?)', Relationship.forbidden_project_ids) }
 

--- a/src/api/app/models/project.rb
+++ b/src/api/app/models/project.rb
@@ -75,6 +75,7 @@ class Project < ApplicationRecord
 
   has_many :target_of_bs_request_actions, class_name: 'BsRequestAction', foreign_key: 'target_project_id'
   has_many :target_of_bs_requests, through: :target_of_bs_request_actions, source: :bs_request
+  has_many :required_checks, class_name: 'Status::RequiredCheck', as: :checkable
 
   default_scope { where('projects.id not in (?)', Relationship.forbidden_project_ids) }
 

--- a/src/api/app/models/repository.rb
+++ b/src/api/app/models/repository.rb
@@ -1,4 +1,5 @@
 class Repository < ApplicationRecord
+  serialize :required_checks, Array
   belongs_to :project, foreign_key: :db_project_id, inverse_of: :repositories
 
   before_destroy :cleanup_before_destroy

--- a/src/api/app/models/status/check.rb
+++ b/src/api/app/models/status/check.rb
@@ -8,7 +8,9 @@ class Status::Check < ApplicationRecord
 
   #### Attributes
   validates :state, :name, :checkable, presence: true
+  # TODO: This should be an ENUM
   validates :state, inclusion: { in: %w[pending error failure success] }
+  validates :name, uniqueness: { scope: :checkable }
 
   #### Associations macros (Belongs to, Has one, Has many)
   belongs_to :checkable, polymorphic: true
@@ -25,6 +27,12 @@ class Status::Check < ApplicationRecord
   #### private
 
   #### Instance methods (public and then protected/private)
+  def required?
+    # TODO: we will remove the checkable polymorphic Association
+    # in a follow up refactoring and this will be then
+    # report.checkable.required_checks.include?(name)
+    checkable.repository.required_checks.include?(name)
+  end
 
   #### Alias of methods
 end

--- a/src/api/app/models/status/repository_publish.rb
+++ b/src/api/app/models/status/repository_publish.rb
@@ -1,4 +1,3 @@
-# TODO: Please overwrite this comment with something explaining the model target
 class Status::RepositoryPublish < ApplicationRecord
   #### Includes and extends
 
@@ -29,6 +28,9 @@ class Status::RepositoryPublish < ApplicationRecord
   #### private
 
   #### Instance methods (public and then protected/private)
+  def missing_checks
+    repository.required_checks - checks.pluck(:name)
+  end
 
   #### Alias of methods
 end

--- a/src/api/app/policies/repository_policy.rb
+++ b/src/api/app/policies/repository_policy.rb
@@ -1,0 +1,27 @@
+class RepositoryPolicy < ApplicationPolicy
+  def initialize(user, record)
+    raise Pundit::NotAuthorizedError, 'record does not exist' unless record
+    @user = user
+    @record = record
+  end
+
+  def create?
+    update?
+  end
+
+  def update?
+    ProjectPolicy.new(@user, @record.project).update?
+  end
+
+  def destroy?
+    create?
+  end
+
+  def index?
+    true
+  end
+
+  def show?
+    index?
+  end
+end

--- a/src/api/app/views/status/checks/_check.xml.builder
+++ b/src/api/app/views/status/checks/_check.xml.builder
@@ -1,6 +1,6 @@
-builder.check(id: object.id) do |check|
-  check.url object.url
+builder.check(id: object.id, required: object.required?) do |check|
+  check.name object.name
   check.state object.state
   check.short_description object.short_description
-  check.name object.name
+  check.url object.url
 end

--- a/src/api/app/views/status/checks/index.xml.builder
+++ b/src/api/app/views/status/checks/index.xml.builder
@@ -2,4 +2,10 @@ xml.checks do
   @checks.each do |check|
     render(partial: 'check', locals: { builder: xml, object: check })
   end
+  @missing_checks.each do |name|
+    xml.check(required: true) do |check|
+      check.name(name)
+      check.state(:pending)
+    end
+  end
 end

--- a/src/api/app/views/status/required_checks/index.xml.builder
+++ b/src/api/app/views/status/required_checks/index.xml.builder
@@ -1,0 +1,5 @@
+xml.required_checks(build_header(@project, @checkable)) do
+  @required_checks.each do |name|
+    xml.name(name)
+  end
+end

--- a/src/api/app/views/webui/obs_factory/staging_projects/_checks.html.haml
+++ b/src/api/app/views/webui/obs_factory/staging_projects/_checks.html.haml
@@ -3,10 +3,13 @@
   Checks
   = "(#{@build_id})"
 %dd
-  - if @checks.empty?
+  - if @checks.empty? && @missing_checks.empty?
     None.
   - else
     %ul
+      - @missing_checks.each do |name|
+        %li
+          %span.check-pending= "#{name} (Expected - Waiting for status to be reported)"
       - @checks.each do |check|
         %li
           = link_to "#{check.name} (#{check.state} - #{time_ago_in_words(check.updated_at)} ago)", check.url, class: "check-#{check.state}", title: "#{check.short_description} (#{check.updated_at})"

--- a/src/api/config/routes.rb
+++ b/src/api/config/routes.rb
@@ -1,4 +1,3 @@
-# we take everything here that is not XML - the default mimetype is xml though
 class WebuiMatcher
   class InvalidRequestFormat < APIError
   end
@@ -776,11 +775,14 @@ OBSApi::Application.routes.draw do
     delete 'source/:project/:package' => :delete_package, constraints: cons
   end
 
-  resources :projects, only: [], param: :name, constraints: cons do
-    resources :repositories, only: [], param: :name, constraints: cons do
-      resources :status_repository_publishes, only: [], param: :build_id, constraints: cons do
-        scope module: 'status' do
-          resources :checks, only: [:index, :show, :destroy, :update, :create]
+  defaults format: 'xml' do
+    resources :projects, only: [], param: :name, constraints: cons do
+      resources :repositories, only: [], param: :name, constraints: cons do
+        scope module: :status do
+          resources :repository_publishes, only: [], param: :build_id, constraints: cons do
+            resources :checks, only: [:index, :show, :destroy, :update, :create]
+          end
+          resources :required_checks, except: [:show, :update, :new, :edit], param: :name
         end
       end
     end

--- a/src/api/db/migrate/20180903135535_add_required_checks_to_repository.rb
+++ b/src/api/db/migrate/20180903135535_add_required_checks_to_repository.rb
@@ -1,0 +1,5 @@
+class AddRequiredChecksToRepository < ActiveRecord::Migration[5.2]
+  def change
+    add_column :repositories, :required_checks, :string
+  end
+end

--- a/src/api/db/structure.sql
+++ b/src/api/db/structure.sql
@@ -1013,6 +1013,7 @@ CREATE TABLE `repositories` (
   `block` enum('all','local','never') CHARACTER SET utf8 DEFAULT NULL,
   `linkedbuild` enum('off','localdep','all') CHARACTER SET utf8 DEFAULT NULL,
   `hostsystem_id` int(11) DEFAULT NULL,
+  `required_checks` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   PRIMARY KEY (`id`),
   UNIQUE KEY `projects_name_index` (`db_project_id`,`name`,`remote_project_name`) USING BTREE,
   KEY `remote_project_name_index` (`remote_project_name`) USING BTREE,
@@ -1379,6 +1380,7 @@ INSERT INTO `schema_migrations` (version) VALUES
 ('20180731124926'),
 ('20180731125103'),
 ('20180807114201'),
-('20180814112739');
+('20180814112739'),
+('20180903135535');
 
 

--- a/src/api/spec/controllers/status/required_checks_controller_spec.rb
+++ b/src/api/spec/controllers/status/required_checks_controller_spec.rb
@@ -1,0 +1,229 @@
+require 'rails_helper'
+
+RSpec.describe Status::RequiredChecksController, type: :controller do
+  let(:user) { create(:confirmed_user) }
+  let(:repository) { create(:repository) }
+  let(:project) { create(:project, repositories: [repository]) }
+
+  describe 'GET index' do
+    shared_context 'it renders index' do
+      context 'with required checks' do
+        before do
+          repository.update!(required_checks: ['first check', 'second check'])
+          get :index, params: { project_name: project.name, repository_name: repository.name }, format: :xml
+        end
+
+        it { expect(assigns(:required_checks)).to include('first check') }
+        it { expect(assigns(:required_checks)).to include('second check') }
+        it { expect(response).to have_http_status(:success) }
+      end
+
+      context 'without required checks' do
+        before do
+          get :index, params: { project_name: project.name, repository_name: repository.name }, format: :xml
+        end
+
+        it { expect(assigns(:required_checks)).to be_empty }
+        it { expect(response).to have_http_status(:success) }
+      end
+    end
+
+    context 'for a logged-in user' do
+      before do
+        login(user)
+      end
+
+      include_context 'it renders index'
+    end
+
+    context 'for an anonymous user' do
+      include_context 'it renders index'
+    end
+  end
+
+  describe 'POST create' do
+    let(:required_check_xml) do
+      file_fixture('required_check.xml').read
+    end
+
+    shared_examples 'does create a required check' do
+      it 'will create a required check' do
+        expect do
+          post :create, body: required_check_xml, params: { project_name: project.name,
+                                                   repository_name: repository.name }, format: :xml
+        end.to change {
+          # we need to to reload because required_checks is a serialized attribute
+          repository.reload
+          repository.required_checks.count
+        }.by(example_count)
+      end
+      it { expect(response).to have_http_status(:success) }
+    end
+
+    shared_examples 'does not create a required check' do
+      it 'will not create a required check' do
+        expect do
+          post :create, body: required_check_xml, params: { project_name: project.name, repository_name: repository.name }, format: :xml
+        end.not_to(
+          change do
+            # we need to to reload because required_checks is a serialized attribute
+            repository.reload
+            repository.required_checks.count
+          end
+        )
+      end
+    end
+
+    shared_examples 'returns correct status' do
+      before do
+        post :create, body: required_check_xml, params: { project_name: project.name, repository_name: repository.name }, format: :xml
+      end
+
+      it 'has correct HTTP status' do
+        expect(response).to have_http_status(status)
+      end
+    end
+
+    context 'for logged in user' do
+      before do
+        login(user)
+      end
+
+      context 'with user permission' do
+        let!(:relationship) { create(:relationship_project_user, user: user, project: project) }
+
+        context 'with one required check' do
+          let(:example_count) { 1 }
+
+          include_context 'does create a required check'
+        end
+
+        context 'with more one required check' do
+          let(:required_check_xml) do
+            file_fixture('required_checks.xml').read
+          end
+          let(:example_count) { 2 }
+
+          include_context 'does create a required check'
+        end
+      end
+
+      context 'with group permission' do
+        let(:example_count) { 1 }
+        let(:group_with_user) { create(:group_with_user) }
+        let(:user) { group_with_user.users.first }
+        let!(:relationship) { create(:relationship_project_group, group: group_with_user, project: project) }
+
+        include_context 'does create a required check'
+      end
+
+      context 'without permission' do
+        let(:status) { :forbidden }
+        include_context 'does not create a required check'
+        include_context 'returns correct status'
+      end
+    end
+
+    context 'with additional elements in body' do
+      let!(:relationship) { create(:relationship_project_user, user: user, project: project) }
+      let(:example_count) { 1 }
+      let(:required_check_xml) do
+        file_fixture('required_check_with_additional_params.xml').read
+      end
+
+      before do
+        login(user)
+      end
+
+      include_context 'does create a required check'
+    end
+
+    context 'for an anonymous user' do
+      let(:status) { :unauthorized }
+      include_context 'does not create a required check'
+      include_context 'returns correct status'
+    end
+  end
+
+  describe 'DELETE destroy' do
+    before do
+      repository.required_checks = ['first check', 'second check']
+      repository.save
+    end
+
+    shared_examples 'does delete the required check' do
+      it 'will delete the required check' do
+        expect do
+          delete :destroy, params: { project_name: project.name,
+                                                   repository_name: repository.name,
+                                                   name: 'first check' }, format: :xml
+        end.to change {
+          # we need to to reload because required_checks is a serialized attribute
+          repository.reload
+          repository.required_checks.count
+        }.by(-1)
+      end
+      it { expect(response).to have_http_status(:success) }
+    end
+
+    shared_examples 'does not delete the required check' do
+      it 'will not delete the required check' do
+        expect do
+          delete :destroy, params: { project_name: project.name,
+                                                   repository_name: repository.name,
+                                                   name: 'first check' }, format: :xml
+        end.not_to(
+          change do
+            # we need to to reload because required_checks is a serialized attribute
+            repository.reload
+            repository.required_checks.count
+          end
+        )
+      end
+    end
+
+    shared_examples 'returns correct status' do
+      before do
+        delete :destroy, params: { project_name: project.name,
+                                                 repository_name: repository.name,
+                                                 name: 'first check' }, format: :xml
+      end
+
+      it 'has correct HTTP status' do
+        expect(response).to have_http_status(status)
+      end
+    end
+
+    context 'for logged in user' do
+      before do
+        login(user)
+      end
+
+      context 'with user permissions' do
+        let!(:relationship) { create(:relationship_project_user, user: user, project: project) }
+
+        include_context 'does delete the required check'
+      end
+
+      context 'with group permissions' do
+        let(:group_with_user) { create(:group_with_user) }
+        let(:user) { group_with_user.users.first }
+        let!(:relationship) { create(:relationship_project_group, group: group_with_user, project: project) }
+
+        include_context 'does delete the required check'
+      end
+
+      context 'without permissions' do
+        let(:status) { :forbidden }
+        include_context 'does not delete the required check'
+        include_context 'returns correct status'
+      end
+    end
+
+    context 'for an anonymous user' do
+      let(:status) { :unauthorized }
+      include_context 'does not delete the required check'
+      include_context 'returns correct status'
+    end
+  end
+end

--- a/src/api/spec/factories/checks.rb
+++ b/src/api/spec/factories/checks.rb
@@ -1,9 +1,9 @@
 FactoryBot.define do
   factory :check, class: Status::Check do
+    sequence(:name) { |n| "check_#{n}" }
     checkable { create(:status_repository_publish) }
     url { Faker::Internet.url }
     state { %w[pending error failure success].sample }
     short_description { Faker::Lorem.sentence }
-    name { Faker::Cat.name }
   end
 end

--- a/src/api/spec/fixtures/files/required_check.xml
+++ b/src/api/spec/fixtures/files/required_check.xml
@@ -1,0 +1,3 @@
+<required_check>
+  <name>ci/example: example test</name>
+</required_check>

--- a/src/api/spec/fixtures/files/required_check_with_additional_params.xml
+++ b/src/api/spec/fixtures/files/required_check_with_additional_params.xml
@@ -1,0 +1,6 @@
+<required_check>
+  <name>ci/example: example test</name>
+  <not-existent>ci/example: example test</not-existent>
+  <checkable_id>1</checkable_id>
+  <checkable_type>repository</checkable_type>
+</required_check>

--- a/src/api/spec/fixtures/files/required_checks.xml
+++ b/src/api/spec/fixtures/files/required_checks.xml
@@ -1,0 +1,4 @@
+<required_check>
+  <name>ci/example: example test</name>
+  <name>ci/example2: example test</name>
+</required_check>


### PR DESCRIPTION
A required check can be defined on a checkable
(e.g. project, package, repository). When a check
does not exist, the required check will be displayed instead.
As soon as a check exists with the same name as the required
check, this check will be displayed instead.

In the WebUI this is implemented on the staging project dashboard.

We implemented the required check as an independent model, however, maybe it would make sense to combine it with the Check model. There are some pending refactoring by @hennevogel we maybe should also wait to land first.