### PR TITLE
Fix rendering of webui2 view in project request tab

### DIFF
--- a/src/api/app/controllers/webui/projects/bs_requests_controller.rb
+++ b/src/api/app/controllers/webui/projects/bs_requests_controller.rb
@@ -12,7 +12,11 @@ module Webui
         session[:request_numbers] = requests_query.requests.map(&:number)
 
         respond_to do |format|
-          format.json
+          if switch_to_webui2?
+            format.json { render 'webui2/shared/bs_requests/index' }
+          else
+            format.json
+          end
         end
         switch_to_webui2
       end


### PR DESCRIPTION
Within respond_to blocks prepending the webui2 path doesn't work.
Therefore we have to explicitly name the partial.