### PR TITLE
[api] fix regression of f57b660f49f830006766a8d4abc3b4af6e178063

### DIFF
--- a/src/api/app/models/bs_request_action_submit.rb
+++ b/src/api/app/models/bs_request_action_submit.rb
@@ -119,7 +119,8 @@ class BsRequestActionSubmit < BsRequestAction
     source_package = Package.get_by_project_and_name!(source_project,
                                                       self.source_package,
                                                       opts)
-    return if User.current.can_modify?(source_package)
+    creator_user = User.find_by_login(bs_request.creator)
+    return if creator_user && creator_user.can_modify?(source_package)
     msg = 'No permission to initialize the source package as a devel package'
     raise PostRequestNoPermission, msg
   end


### PR DESCRIPTION
permission check used the current user, instead the user who created
the request on accepting time.

The creator gave permission to set his packge as devel instance by creating
it

This needs a test case, but this blocks factory people so submission first. Feel free to create a test case yourself.