### PR TITLE
Never consider the _nobody_ user as the displayed user

### DIFF
--- a/src/api/app/controllers/webui/webui_controller.rb
+++ b/src/api/app/controllers/webui/webui_controller.rb
@@ -210,7 +210,7 @@ class Webui::WebuiController < ActionController::Base
       @displayed_user = User.current
       @displayed_user ||= User.find_nobody!
     end
-    @is_displayed_user = User.current == @displayed_user
+    @is_displayed_user = (!User.current.is_nobody? && User.current == @displayed_user)
   end
 
   def map_to_workers(arch)


### PR DESCRIPTION
Without this, the links on the _nobody_ user's page are displayed. It doesn't make sense since nobody should be able to edit the _nobody_ user.

Before:
![nobody-before](https://user-images.githubusercontent.com/1102934/44915649-cb447a00-ad33-11e8-8dbb-be04f08b001e.png)

After:
![nobody-after](https://user-images.githubusercontent.com/1102934/44915661-cf709780-ad33-11e8-9a82-ef0a4a0a1340.png)