### PR TITLE
Fix missing attribute error in statistics controller

### DIFF
--- a/src/api/app/models/bs_request.rb
+++ b/src/api/app/models/bs_request.rb
@@ -284,8 +284,8 @@ class BsRequest < ApplicationRecord
   # customized for that.
   def as_json(*)
     super(except: [:state, :comment, :commenter]).tap do |request_hash|
-      request_hash['superseded_by_id'] = superseded_by
-      request_hash['state'] =            state.to_s
+      request_hash['superseded_by_id'] = superseded_by if has_attribute?(:superseded_by)
+      request_hash['state'] =            state.to_s if has_attribute?(:state)
       request_hash['request_type'] =     bs_request_actions.first.type
       request_hash['package'] =          bs_request_actions.first.target_package
       request_hash['project'] =          bs_request_actions.first.target_project

--- a/src/api/spec/models/bs_request_spec.rb
+++ b/src/api/spec/models/bs_request_spec.rb
@@ -627,5 +627,9 @@ RSpec.describe BsRequest, vcr: true do
         'superseded_by_id' => delete_request.id
       )
     end
+
+    context 'when called for a request with a subset of attributes' do
+      it { expect { BsRequest.all.select(:id).as_json }.not_to raise_error }
+    end
   end
 end


### PR DESCRIPTION
In 429c1b2 we include some additional data to the json representation of
bs requests. This was needed by the staging controller / openSUSE release tools.
Though when the superseded_by attribute is not defined, eg. by fetching
a subset of attributes from the database, this would cause a 'missing
attribute' error.

Checking whether superseded_by is defined before calling it fixes the
issue.

Fixes #5761