### PR TITLE
Replace `.` by `::` in rspec for class methods

### DIFF
--- a/src/api/spec/models/backend_info_spec.rb
+++ b/src/api/spec/models/backend_info_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe BackendInfo, type: :model do
-  describe '.getter' do
+  describe '::getter' do
     context 'key does not exist' do
       it { expect(BackendInfo.lastnotification_nr).to eq(0) }
     end
@@ -15,7 +15,7 @@ RSpec.describe BackendInfo, type: :model do
     end
   end
 
-  describe '.setter' do
+  describe '::setter' do
     subject { BackendInfo.where(key: :lastnotification_nr).first.value.to_i }
     it 'will set the assigned value' do
       BackendInfo.lastnotification_nr = 100

--- a/src/api/spec/models/backend_package_spec.rb
+++ b/src/api/spec/models/backend_package_spec.rb
@@ -6,7 +6,7 @@ require 'rails_helper'
 # CONFIG['global_write_through'] = true
 
 RSpec.describe BackendPackage, vcr: true do
-  describe '.refresh_dirty' do
+  describe '::refresh_dirty' do
     let!(:project) { create(:project, name: 'apache') }
     let!(:package) { create(:package_with_file, project: project, name: 'mod_ssl') }
 

--- a/src/api/spec/models/bs_request_action_spec.rb
+++ b/src/api/spec/models/bs_request_action_spec.rb
@@ -73,7 +73,7 @@ RSpec.describe BsRequestAction, vcr: true do
 
   it { is_expected.to belong_to(:bs_request).touch(true) }
 
-  describe '.set_source_and_target_associations' do
+  describe '::set_source_and_target_associations' do
     let(:project) { create(:project_with_package, name: 'Apache', package_name: 'apache2') }
     let(:package) { project.packages.first }
 

--- a/src/api/spec/models/bs_request_spec.rb
+++ b/src/api/spec/models/bs_request_spec.rb
@@ -353,7 +353,7 @@ RSpec.describe BsRequest, vcr: true do
     end
   end
 
-  describe '.delayed_auto_accept' do
+  describe '::delayed_auto_accept' do
     let!(:project) { create(:project) }
     let!(:admin) { create(:admin_user) }
     let!(:request) do

--- a/src/api/spec/models/issue_tracker_spec.rb
+++ b/src/api/spec/models/issue_tracker_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 require 'webmock/rspec'
 
 RSpec.describe IssueTracker do
-  describe '.update_all_issues' do
+  describe '::update_all_issues' do
     let!(:issue_tracker) { create(:issue_tracker, enable_fetch: true) }
 
     before do

--- a/src/api/spec/models/package_spec.rb
+++ b/src/api/spec/models/package_spec.rb
@@ -314,7 +314,7 @@ RSpec.describe Package, vcr: true do
     end
   end
 
-  describe '.what_depends_on' do
+  describe '::what_depends_on' do
     let(:repository) { 'openSUSE_Leap_42.1' }
     let(:architecture) { 'x86_64' }
     let(:parameter) { "package=#{package.name}&view=revpkgnames" }
@@ -564,7 +564,7 @@ RSpec.describe Package, vcr: true do
     end
   end
 
-  describe '.kiwi_image_outdated?' do
+  describe '::kiwi_image_outdated?' do
     context 'without a kiwi_image' do
       it { expect(package.kiwi_image_outdated?).to be(true) }
     end
@@ -674,7 +674,7 @@ Wed Aug  2 14:59:15 UTC 2017 - iggy@opensuse.org
     end
   end
 
-  describe '.exists_by_project_and_name' do
+  describe '::exists_by_project_and_name' do
     subject { package.name }
 
     let(:project_name) { package.project.name }

--- a/src/api/spec/models/project_spec.rb
+++ b/src/api/spec/models/project_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe Project, vcr: true do
     it { is_expected.to allow_value('fOO:123:+-_.').for(:name) }
   end
 
-  describe '.image_templates' do
+  describe '::image_templates' do
     let(:attrib) { create(:attrib, attrib_type: attribute_type, project: leap_project) }
 
     it 'has leap template' do
@@ -391,7 +391,7 @@ RSpec.describe Project, vcr: true do
     end
   end
 
-  describe '.deleted?' do
+  describe '::deleted?' do
     it 'returns false if the project exists in the app' do
       expect(Project.deleted?(project.name)).to be_falsey
     end
@@ -417,7 +417,7 @@ RSpec.describe Project, vcr: true do
     end
   end
 
-  describe '.restore' do
+  describe '::restore' do
     let(:admin_user) { create(:admin_user, login: 'Admin') }
     let(:deleted_project) do
       create(:project_with_packages,

--- a/src/api/spec/models/relationship_spec.rb
+++ b/src/api/spec/models/relationship_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe Relationship do
     ActionController::Base.perform_caching = @caching_state
   end
 
-  describe '.add_user' do
+  describe '::add_user' do
     let(:role) { normal_role }
     let(:user) { create(:confirmed_user, login: 'other_user') }
     let(:project) { user.home_project }
@@ -52,7 +52,7 @@ RSpec.describe Relationship do
     end
   end
 
-  describe '.add_group' do
+  describe '::add_group' do
     let(:role) { normal_role }
     let(:user) { admin_user }
     let(:project) { user.home_project }
@@ -91,7 +91,7 @@ RSpec.describe Relationship do
     end
   end
 
-  describe '.forbidden_project_ids' do
+  describe '::forbidden_project_ids' do
     let(:confirmed_user) { create(:confirmed_user) }
     let(:project) { create(:forbidden_project) }
 

--- a/src/api/spec/models/repository_spec.rb
+++ b/src/api/spec/models/repository_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe Repository do
       end
     end
 
-    describe '.cycles' do
+    describe '::cycles' do
       let(:repository) { create(:repository) }
       subject { repository.cycles('x64_64') }
 

--- a/src/api/spec/models/review_spec.rb
+++ b/src/api/spec/models/review_spec.rb
@@ -48,21 +48,21 @@ RSpec.describe Review do
     end
   end
 
-  describe '.assigned' do
+  describe '::assigned' do
     include_context 'some assigned reviews and some unassigned reviews'
 
     subject { Review.assigned }
     it { is_expected.to match_array([review_assigned1, review_assigned2]) }
   end
 
-  describe '.unassigned' do
+  describe '::unassigned' do
     include_context 'some assigned reviews and some unassigned reviews'
 
     subject { Review.unassigned }
     it { is_expected.to match_array([review_unassigned1, review_unassigned2]) }
   end
 
-  describe '.set_associations' do
+  describe '::set_associations' do
     context 'with valid attributes' do
       it 'sets user association when by_user object exists' do
         review = create(:review, by_user: user.login)
@@ -428,7 +428,7 @@ RSpec.describe Review do
     end
   end
 
-  describe '.new_from_xml_hash' do
+  describe '::new_from_xml_hash' do
     let(:request_xml) do
       "<request>
         <review state='accepted' by_user='#{user}'/>

--- a/src/api/spec/models/user_ldap_strategy_spec.rb
+++ b/src/api/spec/models/user_ldap_strategy_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe UserLdapStrategy do
   let(:dn_string_no_dc)    { 'cn=jsmith,ou=Promotions,uid=dister' }
   let(:dn_string_complete) { 'cn=jsmith,ou=Promotions,dc=noam,dc=com,uid=dister' }
 
-  describe '.dn2user_principal_name' do
+  describe '::dn2user_principal_name' do
     context 'when no user id is provided' do
       it 'returns an empty string' do
         expect(UserLdapStrategy.dn2user_principal_name(dn_string_no_uid)).to eq('')
@@ -28,7 +28,7 @@ RSpec.describe UserLdapStrategy do
     end
   end
 
-  describe '.authenticate_with_local' do
+  describe '::authenticate_with_local' do
     context "with ldap auth method ':cleartext'" do
       before do
         stub_const('CONFIG', CONFIG.merge('ldap_auth_mech' => :cleartext,
@@ -82,7 +82,7 @@ RSpec.describe UserLdapStrategy do
     end
   end
 
-  describe '.initialize_ldap_con' do
+  describe '::initialize_ldap_con' do
     context 'when no ldap_servers are configured' do
       it { expect(UserLdapStrategy.initialize_ldap_con('tux', 'tux_password')).to be(nil) }
     end
@@ -124,7 +124,7 @@ RSpec.describe UserLdapStrategy do
     end
   end
 
-  describe '.find_group_with_ldap' do
+  describe '::find_group_with_ldap' do
     context 'when there is no connection' do
       it { expect(UserLdapStrategy.find_group_with_ldap('any_group')).to be(false) }
     end

--- a/src/api/spec/models/user_spec.rb
+++ b/src/api/spec/models/user_spec.rb
@@ -421,7 +421,7 @@ RSpec.describe User do
     end
   end
 
-  describe '.mark_login!' do
+  describe '::mark_login!' do
     before do
       user.update_attributes!(login_failure_count: 7, last_logged_in_at: 3.hours.ago)
       user.mark_login!
@@ -521,7 +521,7 @@ RSpec.describe User do
     end
   end
 
-  describe '.can_create_project' do
+  describe '::can_create_project' do
     let(:user) { create(:confirmed_user, login: 'toni') }
     let(:admin_user) { create(:admin_user, login: 'bierhoff') }
     let(:maintainer) do


### PR DESCRIPTION
The correct notation is `::`, the one used in Ruby documentation.

Replacement done using:

```
sed -i 's/\(describe ['\''|"]\)\./\1::/g' src/api/spec/models/*.rb
```

:bowtie: 