### PR TITLE
Fix 500 error on attribute edit page

### DIFF
--- a/src/api/app/controllers/webui/attribute_controller.rb
+++ b/src/api/app/controllers/webui/attribute_controller.rb
@@ -23,6 +23,7 @@ class Webui::AttributeController < Webui::WebuiController
 
   def edit
     @attribute = Attrib.find_by_container_and_fullname(@container, params[:attribute])
+    raise ActiveRecord::RecordNotFound unless @attribute
 
     authorize @attribute
 

--- a/src/api/spec/controllers/webui/attribute_controller_spec.rb
+++ b/src/api/spec/controllers/webui/attribute_controller_spec.rb
@@ -104,6 +104,12 @@ RSpec.describe Webui::AttributeController do
       it { expect(assigns(:attribute).attrib_type.value_count).to be_nil }
       it { expect(assigns(:attribute).values.length).to eq(attrib_values_length_before) }
     end
+
+    context 'when attribute is not added to the project' do
+      it 'renders the 404 page (production mode)' do
+        expect { get :edit, params: { project: user.home_project, attribute: 'OBS:Issues' } }.to raise_error(ActiveRecord::RecordNotFound)
+      end
+    end
   end
 
   describe 'POST #create' do


### PR DESCRIPTION
When an attribute got deleted from a project or package, or did not
exist in first place, the @attribute variable would unexpectedly be nil.
With this commit we raise an ActiveRecord::RecordNotFound in such a
case.
The exception will be catched by an exception handler which renders
a generic 404 page, in production mode.