### PR TITLE
Add try to serviceinfo to avoid Nil crash

### DIFF
--- a/src/api/app/models/package.rb
+++ b/src/api/app/models/package.rb
@@ -947,7 +947,7 @@ class Package < ApplicationRecord
   end
 
   def service_error(revision = nil)
-    revision ||= serviceinfo['xsrcmd5']
+    revision ||= serviceinfo.try { to_hash['xsrcmd5'] }
     return nil unless revision
     PackageServiceErrorFile.new(project_name: project.name, package_name: name).content(rev: revision)
   end


### PR DESCRIPTION
Partially revert 0a36736e04123fdbf70f0864fff7ea0b4d103ea2.
Fix #5786.