### PR TITLE
Fix rendering of fontawesome icon on request tab in webui2 mode

### DIFF
--- a/src/api/app/views/webui2/shared/bs_requests/index.json.erb
+++ b/src/api/app/views/webui2/shared/bs_requests/index.json.erb
@@ -12,7 +12,7 @@
           "<%= escape_javascript(user_with_realname_and_icon(row.creator, short: true)) %>",
           "<%= escape_javascript(new_or_update_request(row)) %>",
           "<%= escape_javascript(row.priority) %>",
-          "<%= escape_javascript(link_to(icon('far', 'eye'), request_show_path(row.number), { title: "Show request ##{row.number}", class: :request_link })) %>"
+          "<%= escape_javascript(link_to('<i class="far fa-eye"></i>'.html_safe, request_show_path(row.number), { title: "Show request ##{row.number}", class: :request_link })) %>"
         <% end %>
       ]
       <% unless index == @requests_data_table.rows.length - 1 %>


### PR DESCRIPTION
Calling the 'icon' helper of font-awesome-sass gem recently started to
fail. Since the partial that contains the method call is cached, it's
not fully clear when this started to happen and what was causing this.

Fixes #5756 again

Co-authored-by: Saray Cabrera Padrón <scabrerapadron@suse.de>