### PR TITLE
Fix undefined method '[]' in kiwi import

### DIFF
--- a/src/api/app/models/kiwi/image/xml_parser.rb
+++ b/src/api/app/models/kiwi/image/xml_parser.rb
@@ -36,7 +36,7 @@ module Kiwi
 
       def use_project_repositories?
         repositories_from_xml.any? do |repository|
-          repository['source']['path'] == 'obsrepositories:/'
+          repository.dig('source', 'path') == 'obsrepositories:/'
         end
       end
 


### PR DESCRIPTION
Use dig instead of accessing the values with the key.
This way it can not happen that source is nil and throws
an undefined method error.

Fix #5738.