### PR TITLE
Fix api-test to run spec with bootstrap

### DIFF
--- a/dist/obs-api-testsuite-rspec.spec
+++ b/dist/obs-api-testsuite-rspec.spec
@@ -60,7 +60,11 @@ export RAILS_ENV=test
 bin/rake db:create db:setup
 bin/rails assets:precompile
 
-bin/rspec -f d
+#without boostrap
+bin/rspec -f d --exclude-pattern "spec/bootstrap/**/*_spec.rb"
+
+#only bootstrap
+BOOTSTRAP=1 bin/rspec -f d spec/bootstrap/
 
 %install
 


### PR DESCRIPTION
The test was running all the spec including `spec/bootstrap`.
That cause the failures in `obs-api-testsuite-rspec` check.
Now we run twice one without bootstrap and another one only with bootstrap.

Co-authored-by: Moisés Déniz Alemán <mdeniz@suse.com>