### PR TITLE
Be consistent with icons in package#attributes form

### DIFF
--- a/src/api/app/views/webui2/webui/attribute/_form.html.haml
+++ b/src/api/app/views/webui2/webui/attribute/_form.html.haml
@@ -18,7 +18,7 @@
     - if attribute.values_addable?
       %p
         = link_to_add_association(form, :values, render_options: { locals: value_fields_locals }, title: 'Add a value') do
-          %i.fas.fa-plus-square
+          %i.fas.fa-plus-circle.text-primary
           Add a value
   - if issue_trackers
     #issues
@@ -26,7 +26,7 @@
         = render('issue_fields', { f: issue }.merge(issue_fields_locals))
     %p
       = link_to_add_association(form, :issues, render_options: { locals: issue_fields_locals }, title: 'Add an issue') do
-        %i.fas.fa-plus-square
+        %i.fas.fa-plus-circle.text-primary
         Add an issue
 
   = form.submit('Save', class: 'btn btn-primary')

--- a/src/api/app/views/webui2/webui/attribute/_issue_fields.html.haml
+++ b/src/api/app/views/webui2/webui/attribute/_issue_fields.html.haml
@@ -8,4 +8,4 @@
       = f.text_field(:name, class: 'form-control')
     .col-auto.col-form-label
       = link_to_remove_association(f, title: 'Delete issue') do
-        %i.fas.fa-minus-circle
+        %i.fas.fa-times-circle.text-danger

--- a/src/api/app/views/webui2/webui/attribute/_value_fields.html.haml
+++ b/src/api/app/views/webui2/webui/attribute/_value_fields.html.haml
@@ -16,4 +16,4 @@
     - if attribute.values_removeable?
       .col-auto.col-form-label
         = link_to_remove_association(f, title: 'Delete value') do
-          %i.fas.fa-minus-circle
+          %i.fas.fa-times-circle.text-danger


### PR DESCRIPTION
Follow-up to #5713. I just forgot to do it in #5808. 

Values:
![icons1](https://user-images.githubusercontent.com/1102934/45229057-2989d380-b2c5-11e8-9469-faa6fb50f4bb.png)

Issues:
![icons-issue](https://user-images.githubusercontent.com/1102934/45229060-2bec2d80-b2c5-11e8-97a8-1eb8e13788f8.png)
