### PR TITLE
Use a Docker volume to cache gems

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,6 +20,7 @@ services:
     image: openbuildservice/backend
     volumes:
       - .:/obs
+      - gems:/gems # Cache gems from 'bundler' commands (install, update, etc...) in gems volume
     privileged: true
     depends_on:
       - backend
@@ -32,6 +33,7 @@ services:
       context: src/api
     volumes:
       - .:/obs
+      - gems:/gems # Cache gems from 'bundler' commands (install, update, etc...) in gems volume
     ports:
       - "3000:3000"
       - "1080:1080"
@@ -40,3 +42,7 @@ services:
       - cache
       - backend
       - worker
+
+volumes:
+  # Cache gems from 'bundler' commands (install, update, etc...)
+  gems:

--- a/src/api/Dockerfile.frontend-base
+++ b/src/api/Dockerfile.frontend-base
@@ -8,6 +8,9 @@ RUN npm install -g jshint
 # Ensure there are ruby, gem and irb commands without ruby suffix
 RUN for i in ruby gem irb; do ln -s /usr/bin/$i.ruby2.5 /usr/local/bin/$i; done
 
+# Path where gems will be installed. It can be cached with volumes
+ENV BUNDLE_PATH /gems
+
 # foreman, which we only run in docker, needs a different thor version than OBS.
 # Installing the gem directly spares us from having to rpm package two different thor versions.
 RUN gem.ruby2.5 install --no-format-executable thor:0.19 foreman mailcatcher

--- a/src/api/Procfile
+++ b/src/api/Procfile
@@ -1,5 +1,5 @@
-web: bundle exec rails server -b 0.0.0.0
-delayed: bundle exec script/delayed_job.api.rb run
-clock: bundle exec clockworkd --log-dir=log -l -c config/clock.rb run 
-search: bundle exec rake ts:rebuild NODETACH=true
+web: (bundle check || bundle install) && bundle exec rails server -b 0.0.0.0
+delayed: (bundle check || bundle install) && bundle exec script/delayed_job.api.rb run
+clock: (bundle check || bundle install) && bundle exec clockworkd --log-dir=log -l -c config/clock.rb run
+search: (bundle check || bundle install) && bundle exec rake ts:rebuild NODETACH=true
 mailcatcher: mailcatcher --ip 0.0.0.0 -f --no-quit -v


### PR DESCRIPTION
When gems are updated in our current Docker setup, we need to rebuild the Docker image since `bundle install` is one of the steps in the build. With this approach, the installation of gems happens in the command executed by the Docker container when we run them. The gems are installed in a directory which is mapped to a volume, therefore caching them. Whenever running containers, we check if bundle needs to install new dependencies (with `bundle check`), if so, `bundle install` is run.

Note: I've done it in other projects, but I still need to test this more. 