### PR TITLE
Include the commentable for user comment API

### DIFF
--- a/src/api/app/models/comment.rb
+++ b/src/api/app/models/comment.rb
@@ -62,8 +62,12 @@ class Comment < ApplicationRecord
     users.to_a
   end
 
-  def to_xml(builder)
+  def to_xml(builder, include_commentable = false)
     attrs = { who: user, when: created_at, id: id }
+    if include_commentable
+      attrs[commentable.class.name.downcase] = commentable.to_param
+      attrs['project'] = commentable.project if commentable.is_a?(Package)
+    end
     attrs[:parent] = parent_id if parent_id
 
     builder.comment_(attrs) do

--- a/src/api/app/views/comments/_comments.xml.builder
+++ b/src/api/app/views/comments/_comments.xml.builder
@@ -1,3 +1,3 @@
-comments.each do |c|
-  c.to_xml(builder)
+comments.each do |comment|
+  comment.to_xml(builder, @obj.is_a?(User))
 end

--- a/src/api/spec/controllers/comments_controller_spec.rb
+++ b/src/api/spec/controllers/comments_controller_spec.rb
@@ -62,7 +62,12 @@ RSpec.describe CommentsController, type: :controller do
         get :index, format: :xml
       end
 
-      include_examples 'request comment index'
+      it { expect(response).to have_http_status(:success) }
+      it { expect(assigns(:obj)).to eq(object) }
+      it {
+        expect(response.body).
+          to include("<comment who=\"#{comment.user}\" when=\"#{comment.created_at}\" id=\"#{comment.id}\" bsrequest=\"#{comment.commentable.number}\">#{comment.body}</comment>")
+      }
       it { expect(response.body).to include("<comments user=\"#{user.login}\">") }
     end
   end


### PR DESCRIPTION
Asking the user returned comments without including what commentable they are
for which made this API rather hard to use...

```xml
<comments user="Admin">
  <comment who="Admin" when="2018-09-07 21:43:02 UTC" id="1" project="home:Admin">
    shalala
  </comment>
  <comment who="Admin" when="2018-09-07 21:58:39 UTC" id="2" package="ctris" project="home:Admin">
    YOYOYO
  </comment>
  <comment who="Admin" when="2018-09-07 22:04:51 UTC" id="3" bsrequest="1">
    yo yo yo
  </comment>
  <comment who="Admin" when="2018-09-07 22:08:16 UTC" id="4" bsrequest="1" parent="3">
    hmmmmm
  </comment>
</comments>
```