### PR TITLE
Clarify request's aim and require description for webui2

### DIFF
--- a/src/api/app/views/webui2/webui/package/_submit_request_dialog.html.haml
+++ b/src/api/app/views/webui2/webui/package/_submit_request_dialog.html.haml
@@ -6,6 +6,9 @@
       .modal-body
         %p
           Do you want to submit #{package_link package, rev: revision}?
+        %p.font-italic
+          You are about to send a request to the owner of the original #{package ? 'package' : 'project'}. Please describe what you have done and
+          why they should apply your changes. The owner will be notified with the following details.
 
           = hidden_field_tag(:project, project)
           = hidden_field_tag(:package, package)
@@ -30,7 +33,7 @@
 
           .form-group
             = label_tag(:description, 'Description:')
-            ~ text_area_tag(:description, description, size: '40x3', class: 'form-control')
+            ~ text_area_tag(:description, description, size: '40x3', class: 'form-control', required: true)
 
           .form-group.d-none#supersede-display
             = label_tag(:supersede_requests, 'Supersede requests:')

--- a/src/api/app/views/webui2/webui/request/_delete_request_dialog.html.haml
+++ b/src/api/app/views/webui2/webui/request/_delete_request_dialog.html.haml
@@ -8,6 +8,9 @@
           %p
             -# FIXME: get rid of this helper
             Do you really want to request the deletion of #{project_or_package_link(project: project.name, package: package.name)}?
+          %p.font-italic
+            You are about to send a request to the owner of the original #{package ? 'package' : 'project'}. Please describe your reasons to
+            request the deletion of this #{package ? 'package' : 'project'}. The owner will be notified with the following details.
           = hidden_field_tag(:package, package) if defined?(package)
           %p
             - if defined?(package)
@@ -16,7 +19,7 @@
                 = text_field_tag(:target_project, project, disabled: true, class: 'form-control')
           .form-group
             = label_tag(:description, 'Please explain why:')
-            = text_area_tag(:description, '', row: 3, class: 'form-control')
+            = text_area_tag(:description, '', row: 3, class: 'form-control', required: true)
         .modal-footer
           = render partial: 'webui2/shared/dialog_action_buttons'
 

--- a/src/api/spec/bootstrap/features/webui/packages_spec.rb
+++ b/src/api/spec/bootstrap/features/webui/packages_spec.rb
@@ -75,7 +75,8 @@ RSpec.feature 'Bootstrap_Packages', type: :feature, js: true, vcr: true do
     click_link('Request deletion')
 
     expect(page).to have_text('Do you really want to request the deletion of package ')
-    within('#delete-request-modal .modal-footer') do
+    within('#delete-request-modal') do
+      fill_in('description', with: 'Hey, why not?')
       click_button('Accept')
     end
 


### PR DESCRIPTION
Avoiding unnecessary requets also from bootstrap views, we add a text
explaining request's aim and make description field compulsory.