### PR TITLE
[backend] add support for cpio.tar.bz2 with staticlinks

### DIFF
--- a/src/backend/bs_publish
+++ b/src/backend/bs_publish
@@ -995,7 +995,7 @@ sub createrepo_staticlinks {
       } elsif (/^(.*)-Build\d\d\d\d(-Media\d)(\.iso?(\.sha256)?)$/s) {
         # product builds
         $link = "$1$2$3"; # no support for versioned links
-      } elsif (/^(.*)-(\d+\.\d+\.\d+)?(-\w+)?(\.(?:libvirt|virtualbox))?-Build\d+\..*(\.(raw.install.raw.xz|raw.xz|tar.xz|box|json|install.iso|tbz|tgz|vmx|vmdk|vhdx|vdi|vhdfixed.xz|iso|qcow2|qcow2.xz|ova)?(?:\.sha256)?)$/s) {
+      } elsif (/^(.*)-(\d+\.\d+\.\d+)?(-\w+)?(\.(?:libvirt|virtualbox))?-Build\d+\..*((?:\.|-)(raw.install.raw.xz|raw.xz|tar.xz|box|json|install.iso|tbz|tgz|vmx|vmdk|vhdx|vdi|vhdfixed.xz|iso|qcow2|qcow2.xz|ova|cpio.tar.bz2)?(?:\.sha256)?)$/s) {
         # kiwi appliance
         my $profile = $3 || "";
         my $box_type = $4 || "";


### PR DESCRIPTION
Kiwi images with `image="cpio"` will produce files called `...Build4.17-cpio.tar.bz2`, this is not captured currently with "staticlinks"