### PR TITLE
Drop with_packages scope from Relationship model

### DIFF
--- a/src/api/app/controllers/status_project_controller.rb
+++ b/src/api/app/controllers/status_project_controller.rb
@@ -43,8 +43,8 @@ class StatusProjectController < ApplicationController
     @package_hash
   end
 
-  def relationships_for_package(keys)
-    Relationship.with_packages(keys).pluck(:package_id, :user_id, :group_id, :role_id)
+  def relationships_for_package(package_ids)
+    Relationship.where(package: package_ids).pluck(:package_id, :user_id, :group_id, :role_id)
   end
 
   def add_person(user_id, role_id, package_id)

--- a/src/api/app/models/relationship.rb
+++ b/src/api/app/models/relationship.rb
@@ -52,7 +52,6 @@ class Relationship < ApplicationRecord
   scope :maintainers, lambda {
     where(role_id: Role.hashed['maintainer'])
   }
-  scope :with_packages, ->(packages) { where(package_id: packages) }
 
   # we only care for project<->user relationships, but the cache is not *that* expensive
   # to recalculate


### PR DESCRIPTION
This scope is already covered by Rails's where method.

Follow up of f5fee17c3fc04b194e919650efd059d0b2e2b5c1