### PR TITLE
webui: Use full author identities in generating changes entries

### DIFF
--- a/src/api/app/assets/javascripts/webui/application/package.js
+++ b/src/api/app/assets/javascripts/webui/application/package.js
@@ -56,7 +56,8 @@ function addChangesEntryTemplate() { // jshint ignore:line
   templ = "-------------------------------------------------------------------\n" +
     DAYS[date.getUTCDay()] + " " + MONTHS[date.getUTCMonth()] + " " + day + " " +
     hours + ":" + minutes + ":" + seconds + " UTC " + date.getUTCFullYear() +
-    " - " + $("a.changes-link").data('email') + "\n\n" + "- \n" + "\n";
+    " - " + $("a.changes-link").data('packagername') +
+    " <" + $("a.changes-link").data('packageremail') + ">" +"\n\n" + "- \n" + "\n";
 
   editors[0].setValue(templ + editors[0].getValue());
   editors[0].focus();

--- a/src/api/app/views/webui/package/view_file.html.erb
+++ b/src/api/app/views/webui/package/view_file.html.erb
@@ -14,7 +14,7 @@
     <% if @filename.ends_with?('.changes') %>
   <p>
       <%# Rather hacky attempt to provide 'osc vc'-like functionality, would benefit of proper 'snippet' support for editor: %>
-      <a href="#" class="changes-link" onclick="addChangesEntryTemplate(); return false;" data-email="<%= User.current.email %>">Insert changes entry template</a>
+      <a href="#" class="changes-link" onclick="addChangesEntryTemplate(); return false;" data-packagername="<%= User.current.realname %>" data-packageremail="<%= User.current.email %>">Insert changes entry template</a>
   </p>
     <% end %>
 


### PR DESCRIPTION
Since obs-build 20180816 and osc 0.163.0, changes entries are generated
using full author identities. This change makes it so the build service
web UI has the same behavior for new changes entries.