### PR TITLE
Add extra parameter in build result to switch to webui2

### DIFF
--- a/src/api/app/controllers/webui/package_controller.rb
+++ b/src/api/app/controllers/webui/package_controller.rb
@@ -921,10 +921,10 @@ class Webui::PackageController < Webui::WebuiController
       show_all = params[:show_all] == 'true'
       @index = params[:index]
       @buildresults = @package.buildresult(@project, show_all)
-      switch_to_webui2
+      switch_to_webui2 if params[:switch].present?
       render partial: 'buildstatus', locals: { buildresults: @buildresults, index: @index, project: @project }
     else
-      switch_to_webui2
+      switch_to_webui2 if params[:switch].present?
       render partial: 'no_repositories', locals: { project: @project }
     end
   end
@@ -950,7 +950,7 @@ class Webui::PackageController < Webui::WebuiController
       @repo_list << [repo_name, valid_xml_id(elide(repo_name, 30))]
     end
 
-    return if switch_to_webui2
+    return if params[:switch].present? && switch_to_webui2
 
     if @repo_list.empty?
       render partial: 'no_repositories', locals: { project: @project }

--- a/src/api/app/views/webui2/shared/_buildresult_box.html.haml
+++ b/src/api/app/views/webui2/shared/_buildresult_box.html.haml
@@ -1,6 +1,7 @@
 :ruby
   index ||= ''
   ajax_data = {}
+  ajax_data['switch'] = 'true' # FIXME: Remove this when request show is available in bootstrap
   ajax_data['project'] = h(project) if defined?(project)
   ajax_data['package'] = h(package) if defined?(package)
   ajax_data['index'] = h(index) if defined?(index)


### PR DESCRIPTION
Buildresult box is used in request#show and package#show, because
request#show is not available in bootstrap the buildresult box looks
broken if the user is a beta user.

Fixes: #5834 

Co-authored-by: Moisés Déniz Alemán <mdeniz@suse.com>