### PR TITLE
Add revision in branch package

### DIFF
--- a/src/api/app/controllers/webui/package_controller.rb
+++ b/src/api/app/controllers/webui/package_controller.rb
@@ -553,7 +553,9 @@ class Webui::PackageController < Webui::WebuiController
 
     # Set the branch to the current revision if revision is present
     if params[:current_revision].present?
-      dirhash = Directory.hashed(project: source_project_name, package: source_package_name, expand: 1)
+      options = { project: source_project_name, package: source_package_name, expand: 1 }
+      options[:rev] = params[:revision] if params[:revision].present?
+      dirhash = Directory.hashed(options)
       branch_params[:rev] = dirhash['xsrcmd5'] || dirhash['rev']
 
       unless branch_params[:rev]

--- a/src/api/app/views/shared/_package_branch_form.html.haml
+++ b/src/api/app/views/shared/_package_branch_form.html.haml
@@ -11,9 +11,10 @@
   = text_field_tag 'target_package', @package.try(:name), size: 80, maxlength: 200
 %p
   = check_box_tag 'current_revision', false
-  %label{ for: 'current_revision' } Stay on current revision
+  %label{ for: 'current_revision' } Stay on this revision
   - if @revision
     (##{@revision})
+  = hidden_field_tag(:revision, @revision) if @revision
 - if show_project_field && Configuration.cleanup_after_days
   %p
     %input#disable-autocleanup{ type: "checkbox" }

--- a/src/api/app/views/webui2/shared/_package_branch_form.html.haml
+++ b/src/api/app/views/webui2/shared/_package_branch_form.html.haml
@@ -12,9 +12,10 @@
 .form-group.form-check
   = check_box_tag(:current_revision, false, class: 'form-check-input')
   = label_tag(:current_revision, class: 'form-check-label') do
-    Stay on current revision
+    Stay on this revision
     - if revision
       (##{revision})
+  = hidden_field_tag(:revision, revision) if revision
 - if show_project_field && Configuration.cleanup_after_days
   .form-group.form-check
     %input.form-check-input#disable-autocleanup{ type: 'checkbox' }

--- a/src/api/spec/cassettes/Bootstrap_MaintenanceWorkflow/maintenance_workflow.yml
+++ b/src/api/spec/cassettes/Bootstrap_MaintenanceWorkflow/maintenance_workflow.yml
@@ -40,7 +40,7 @@ http_interactions:
           <person userid="user_1" role="maintainer" />
         </project>
     http_version: 
-  recorded_at: Tue, 21 Aug 2018 14:39:04 GMT
+  recorded_at: Wed, 12 Sep 2018 12:03:52 GMT
 - request:
     method: put
     uri: http://backend:5352/source/ProjectWithRepo/_meta?user=user_1
@@ -48,7 +48,7 @@ http_interactions:
       encoding: UTF-8
       string: |
         <project name="ProjectWithRepo">
-          <title>The Millstone</title>
+          <title>Cabbages and Kings</title>
           <description/>
         </project>
     headers:
@@ -70,16 +70,16 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '105'
+      - '110'
     body:
       encoding: UTF-8
       string: |
         <project name="ProjectWithRepo">
-          <title>The Millstone</title>
+          <title>Cabbages and Kings</title>
           <description></description>
         </project>
     http_version: 
-  recorded_at: Tue, 21 Aug 2018 14:39:04 GMT
+  recorded_at: Wed, 12 Sep 2018 12:03:52 GMT
 - request:
     method: put
     uri: http://backend:5352/source/ProjectWithRepo:Update/_meta?user=user_1
@@ -87,7 +87,7 @@ http_interactions:
       encoding: UTF-8
       string: |
         <project name="ProjectWithRepo:Update" kind="maintenance_release">
-          <title>Infinite Jest</title>
+          <title>I Will Fear No Evil</title>
           <description/>
         </project>
     headers:
@@ -109,16 +109,16 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '139'
+      - '145'
     body:
       encoding: UTF-8
       string: |
         <project name="ProjectWithRepo:Update" kind="maintenance_release">
-          <title>Infinite Jest</title>
+          <title>I Will Fear No Evil</title>
           <description></description>
         </project>
     http_version: 
-  recorded_at: Tue, 21 Aug 2018 14:39:04 GMT
+  recorded_at: Wed, 12 Sep 2018 12:03:52 GMT
 - request:
     method: put
     uri: http://backend:5352/source/project_1/_meta?user=user_1
@@ -126,7 +126,7 @@ http_interactions:
       encoding: UTF-8
       string: |
         <project name="project_1">
-          <title>Brandy of the Damned</title>
+          <title>The World, the Flesh and the Devil</title>
           <description/>
         </project>
     headers:
@@ -148,16 +148,16 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '106'
+      - '120'
     body:
       encoding: UTF-8
       string: |
         <project name="project_1">
-          <title>Brandy of the Damned</title>
+          <title>The World, the Flesh and the Devil</title>
           <description></description>
         </project>
     http_version: 
-  recorded_at: Tue, 21 Aug 2018 14:39:04 GMT
+  recorded_at: Wed, 12 Sep 2018 12:03:53 GMT
 - request:
     method: put
     uri: http://backend:5352/source/project_1/_project/_attribute?meta=1&user=user_1
@@ -165,7 +165,7 @@ http_interactions:
       encoding: UTF-8
       string: |
         <attributes>
-          <attribute name="attribute_factory_1" namespace="aut"/>
+          <attribute name="attribute_factory_1" namespace="eligendi"/>
         </attributes>
     headers:
       Accept-Encoding:
@@ -186,19 +186,19 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '169'
+      - '168'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="48">
-          <srcmd5>41891c4a225a3b8264aa0e5af6e9a17c</srcmd5>
-          <time>1534862344</time>
+        <revision rev="7">
+          <srcmd5>b89b43e3bbc623706e271ce767b9a83c</srcmd5>
+          <time>1536753833</time>
           <user>user_1</user>
           <comment></comment>
           <requestid/>
         </revision>
     http_version: 
-  recorded_at: Tue, 21 Aug 2018 14:39:04 GMT
+  recorded_at: Wed, 12 Sep 2018 12:03:53 GMT
 - request:
     method: put
     uri: http://backend:5352/source/ProjectWithRepo/_project/_attribute?meta=1&user=user_1
@@ -229,19 +229,19 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '169'
+      - '168'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="44">
-          <srcmd5>529969766de3d3cc293e04a0b34b3e25</srcmd5>
-          <time>1534862345</time>
+        <revision rev="7">
+          <srcmd5>26f6a5813b861dff1a302b67927f7ca4</srcmd5>
+          <time>1536753833</time>
           <user>user_1</user>
           <comment></comment>
           <requestid/>
         </revision>
     http_version: 
-  recorded_at: Tue, 21 Aug 2018 14:39:05 GMT
+  recorded_at: Wed, 12 Sep 2018 12:03:53 GMT
 - request:
     method: put
     uri: http://backend:5352/source/ProjectWithRepo:Update/_meta?user=user_1
@@ -249,7 +249,7 @@ http_interactions:
       encoding: UTF-8
       string: |
         <project name="ProjectWithRepo:Update" kind="maintenance_release">
-          <title>Infinite Jest</title>
+          <title>I Will Fear No Evil</title>
           <description/>
           <link project="ProjectWithRepo"/>
         </project>
@@ -272,17 +272,17 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '176'
+      - '182'
     body:
       encoding: UTF-8
       string: |
         <project name="ProjectWithRepo:Update" kind="maintenance_release">
-          <title>Infinite Jest</title>
+          <title>I Will Fear No Evil</title>
           <description></description>
           <link project="ProjectWithRepo" />
         </project>
     http_version: 
-  recorded_at: Tue, 21 Aug 2018 14:39:05 GMT
+  recorded_at: Wed, 12 Sep 2018 12:03:53 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:maintenance_coord/_meta?user=maintenance_coord
@@ -323,7 +323,7 @@ http_interactions:
           <person userid="maintenance_coord" role="maintainer" />
         </project>
     http_version: 
-  recorded_at: Tue, 21 Aug 2018 14:39:05 GMT
+  recorded_at: Wed, 12 Sep 2018 12:03:53 GMT
 - request:
     method: put
     uri: http://backend:5352/source/MaintenanceProject/_meta?user=user_1
@@ -364,7 +364,7 @@ http_interactions:
           <person userid="maintenance_coord" role="maintainer" />
         </project>
     http_version: 
-  recorded_at: Tue, 21 Aug 2018 14:39:05 GMT
+  recorded_at: Wed, 12 Sep 2018 12:03:53 GMT
 - request:
     method: put
     uri: http://backend:5352/source/MaintenanceProject/_project/_attribute?meta=1&user=user_1
@@ -397,15 +397,15 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <revision rev="85">
-          <srcmd5>dcb55f0ff8167dc64f2fb57d4cba44bc</srcmd5>
-          <time>1534862345</time>
+        <revision rev="11">
+          <srcmd5>38123539ba60e1e9bc3bcdbce0226dad</srcmd5>
+          <time>1536753833</time>
           <user>user_1</user>
           <comment></comment>
           <requestid/>
         </revision>
     http_version: 
-  recorded_at: Tue, 21 Aug 2018 14:39:05 GMT
+  recorded_at: Wed, 12 Sep 2018 12:03:53 GMT
 - request:
     method: put
     uri: http://backend:5352/source/MaintenanceProject/_meta?user=user_1
@@ -452,7 +452,7 @@ http_interactions:
           </maintenance>
         </project>
     http_version: 
-  recorded_at: Tue, 21 Aug 2018 14:39:05 GMT
+  recorded_at: Wed, 12 Sep 2018 12:03:53 GMT
 - request:
     method: put
     uri: http://backend:5352/source/MaintenanceProject/patchinfo/_meta?user=maintenance_coord
@@ -509,7 +509,7 @@ http_interactions:
           </useforbuild>
         </package>
     http_version: 
-  recorded_at: Tue, 21 Aug 2018 14:39:05 GMT
+  recorded_at: Wed, 12 Sep 2018 12:03:54 GMT
 - request:
     method: put
     uri: http://backend:5352/source/MaintenanceProject/patchinfo/_patchinfo?comment=generated%20by%20createpatchinfo%20call&user=maintenance_coord
@@ -542,20 +542,20 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '252'
+      - '250'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="21" vrev="21">
+        <revision rev="3" vrev="3">
           <srcmd5>7c79565cf2a5793c8092ebecfe0a912a</srcmd5>
           <version>unknown</version>
-          <time>1534862345</time>
+          <time>1536753834</time>
           <user>maintenance_coord</user>
           <comment>generated by createpatchinfo call</comment>
           <requestid/>
         </revision>
     http_version: 
-  recorded_at: Tue, 21 Aug 2018 14:39:05 GMT
+  recorded_at: Wed, 12 Sep 2018 12:03:54 GMT
 - request:
     method: put
     uri: http://backend:5352/source/MaintenanceProject/patchinfo/_meta?user=maintenance_coord
@@ -612,7 +612,7 @@ http_interactions:
           </useforbuild>
         </package>
     http_version: 
-  recorded_at: Tue, 21 Aug 2018 14:39:05 GMT
+  recorded_at: Wed, 12 Sep 2018 12:03:54 GMT
 - request:
     method: get
     uri: http://backend:5352/source/MaintenanceProject/patchinfo
@@ -638,15 +638,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '202'
+      - '200'
     body:
       encoding: UTF-8
       string: |
-        <directory name="patchinfo" rev="21" vrev="21" srcmd5="7c79565cf2a5793c8092ebecfe0a912a">
-          <entry name="_patchinfo" md5="ea890f2483d4b7e7255d64ef4dbb1d43" size="174" mtime="1534841175" />
+        <directory name="patchinfo" rev="3" vrev="3" srcmd5="7c79565cf2a5793c8092ebecfe0a912a">
+          <entry name="_patchinfo" md5="ea890f2483d4b7e7255d64ef4dbb1d43" size="174" mtime="1536751446" />
         </directory>
     http_version: 
-  recorded_at: Tue, 21 Aug 2018 14:39:05 GMT
+  recorded_at: Wed, 12 Sep 2018 12:03:54 GMT
 - request:
     method: get
     uri: http://backend:5352/source/MaintenanceProject/patchinfo?view=info
@@ -672,15 +672,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '187'
+      - '185'
     body:
       encoding: UTF-8
       string: |
-        <sourceinfo package="patchinfo" rev="21" vrev="21" srcmd5="7c79565cf2a5793c8092ebecfe0a912a" verifymd5="7c79565cf2a5793c8092ebecfe0a912a">
+        <sourceinfo package="patchinfo" rev="3" vrev="3" srcmd5="7c79565cf2a5793c8092ebecfe0a912a" verifymd5="7c79565cf2a5793c8092ebecfe0a912a">
           <filename>_patchinfo</filename>
         </sourceinfo>
     http_version: 
-  recorded_at: Tue, 21 Aug 2018 14:39:05 GMT
+  recorded_at: Wed, 12 Sep 2018 12:03:54 GMT
 - request:
     method: get
     uri: http://backend:5352/source/MaintenanceProject/patchinfo
@@ -706,15 +706,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '202'
+      - '200'
     body:
       encoding: UTF-8
       string: |
-        <directory name="patchinfo" rev="21" vrev="21" srcmd5="7c79565cf2a5793c8092ebecfe0a912a">
-          <entry name="_patchinfo" md5="ea890f2483d4b7e7255d64ef4dbb1d43" size="174" mtime="1534841175" />
+        <directory name="patchinfo" rev="3" vrev="3" srcmd5="7c79565cf2a5793c8092ebecfe0a912a">
+          <entry name="_patchinfo" md5="ea890f2483d4b7e7255d64ef4dbb1d43" size="174" mtime="1536751446" />
         </directory>
     http_version: 
-  recorded_at: Tue, 21 Aug 2018 14:39:05 GMT
+  recorded_at: Wed, 12 Sep 2018 12:03:54 GMT
 - request:
     method: get
     uri: http://backend:5352/source/MaintenanceProject/patchinfo/_patchinfo
@@ -752,7 +752,7 @@ http_interactions:
           <description/>
         </patchinfo>
     http_version: 
-  recorded_at: Tue, 21 Aug 2018 14:39:05 GMT
+  recorded_at: Wed, 12 Sep 2018 12:03:54 GMT
 - request:
     method: put
     uri: http://backend:5352/source/MaintenanceProject/_project/_attribute?meta=1&user=user_1
@@ -785,15 +785,15 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <revision rev="87">
-          <srcmd5>b07ebb51545add07310d5d2ab19449f8</srcmd5>
-          <time>1534862346</time>
+        <revision rev="13">
+          <srcmd5>4203c7be5d5ba49c38d8c69341c6962e</srcmd5>
+          <time>1536753834</time>
           <user>user_1</user>
           <comment></comment>
           <requestid/>
         </revision>
     http_version: 
-  recorded_at: Tue, 21 Aug 2018 14:39:06 GMT
+  recorded_at: Wed, 12 Sep 2018 12:03:54 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom/_meta?user=tom
@@ -834,7 +834,7 @@ http_interactions:
           <person userid="tom" role="maintainer" />
         </project>
     http_version: 
-  recorded_at: Tue, 21 Aug 2018 14:39:06 GMT
+  recorded_at: Wed, 12 Sep 2018 12:03:54 GMT
 - request:
     method: put
     uri: http://backend:5352/source/ProjectWithRepo/ProjectWithRepo_package/_meta?user=tom
@@ -842,8 +842,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="ProjectWithRepo_package" project="ProjectWithRepo">
-          <title>Antic Hay</title>
-          <description>A eaque voluptas optio.</description>
+          <title>The Widening Gyre</title>
+          <description>Cupiditate neque nihil consequatur.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -864,16 +864,16 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '158'
+      - '178'
     body:
       encoding: UTF-8
       string: |
         <package name="ProjectWithRepo_package" project="ProjectWithRepo">
-          <title>Antic Hay</title>
-          <description>A eaque voluptas optio.</description>
+          <title>The Widening Gyre</title>
+          <description>Cupiditate neque nihil consequatur.</description>
         </package>
     http_version: 
-  recorded_at: Tue, 21 Aug 2018 14:39:09 GMT
+  recorded_at: Wed, 12 Sep 2018 12:03:57 GMT
 - request:
     method: put
     uri: http://backend:5352/source/ProjectWithRepo/ProjectWithRepo_package/_meta?user=tom
@@ -881,8 +881,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="ProjectWithRepo_package" project="ProjectWithRepo">
-          <title>Antic Hay</title>
-          <description>A eaque voluptas optio.</description>
+          <title>The Widening Gyre</title>
+          <description>Cupiditate neque nihil consequatur.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -903,22 +903,22 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '158'
+      - '178'
     body:
       encoding: UTF-8
       string: |
         <package name="ProjectWithRepo_package" project="ProjectWithRepo">
-          <title>Antic Hay</title>
-          <description>A eaque voluptas optio.</description>
+          <title>The Widening Gyre</title>
+          <description>Cupiditate neque nihil consequatur.</description>
         </package>
     http_version: 
-  recorded_at: Tue, 21 Aug 2018 14:39:09 GMT
+  recorded_at: Wed, 12 Sep 2018 12:03:57 GMT
 - request:
     method: put
     uri: http://backend:5352/source/ProjectWithRepo/ProjectWithRepo_package/_config
     body:
       encoding: UTF-8
-      string: Ea fugiat sit. Ea nobis quos. Aut commodi repellat.
+      string: Qui excepturi quidem. Sit similique in. Minima qui itaque.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -938,26 +938,26 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '209'
+      - '207'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="39" vrev="39">
-          <srcmd5>6697a7b710fec809184bdc0b7a07695e</srcmd5>
+        <revision rev="5" vrev="5">
+          <srcmd5>75da79e6c615c7425419fd07a1dbffc8</srcmd5>
           <version>unknown</version>
-          <time>1534862349</time>
+          <time>1536753837</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
     http_version: 
-  recorded_at: Tue, 21 Aug 2018 14:39:09 GMT
+  recorded_at: Wed, 12 Sep 2018 12:03:57 GMT
 - request:
     method: put
     uri: http://backend:5352/source/ProjectWithRepo/ProjectWithRepo_package/somefile.txt
     body:
       encoding: UTF-8
-      string: Ut est consequatur. Natus quod dolores. Nam quis dolorem.
+      string: Id laudantium eaque. Culpa adipisci corrupti. Autem minus natus.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -977,20 +977,20 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '209'
+      - '207'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="40" vrev="40">
-          <srcmd5>def3bf67a426e8013de578376d34f554</srcmd5>
+        <revision rev="6" vrev="6">
+          <srcmd5>1fe06d22b38ce06632413dcc7aeee49c</srcmd5>
           <version>unknown</version>
-          <time>1534862349</time>
+          <time>1536753837</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
     http_version: 
-  recorded_at: Tue, 21 Aug 2018 14:39:09 GMT
+  recorded_at: Wed, 12 Sep 2018 12:03:57 GMT
 - request:
     method: get
     uri: http://backend:5352/source/ProjectWithRepo/ProjectWithRepo_package
@@ -1016,19 +1016,19 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '312'
+      - '310'
     body:
       encoding: UTF-8
       string: |
-        <directory name="ProjectWithRepo_package" rev="40" vrev="40" srcmd5="def3bf67a426e8013de578376d34f554">
-          <entry name="_config" md5="1a05ff51cbc0ee790ddd75020dc14e94" size="51" mtime="1534862349" />
-          <entry name="somefile.txt" md5="9044d1ae989e292a5e19128f57de9e21" size="57" mtime="1534862349" />
+        <directory name="ProjectWithRepo_package" rev="6" vrev="6" srcmd5="1fe06d22b38ce06632413dcc7aeee49c">
+          <entry name="_config" md5="e76512ea4577d0a559788f9bed2f9ad8" size="58" mtime="1536753837" />
+          <entry name="somefile.txt" md5="d5ff6c3db27c57b3d9dbc5df28a95a21" size="64" mtime="1536753837" />
         </directory>
     http_version: 
-  recorded_at: Tue, 21 Aug 2018 14:39:09 GMT
+  recorded_at: Wed, 12 Sep 2018 12:03:57 GMT
 - request:
     method: get
-    uri: http://backend:5352/source/ProjectWithRepo/ProjectWithRepo_package?expand=1&rev=40
+    uri: http://backend:5352/source/ProjectWithRepo/ProjectWithRepo_package?expand=1&rev=6
     body:
       encoding: US-ASCII
       string: ''
@@ -1051,16 +1051,16 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '312'
+      - '310'
     body:
       encoding: UTF-8
       string: |
-        <directory name="ProjectWithRepo_package" rev="40" vrev="40" srcmd5="def3bf67a426e8013de578376d34f554">
-          <entry name="_config" md5="1a05ff51cbc0ee790ddd75020dc14e94" size="51" mtime="1534862349" />
-          <entry name="somefile.txt" md5="9044d1ae989e292a5e19128f57de9e21" size="57" mtime="1534862349" />
+        <directory name="ProjectWithRepo_package" rev="6" vrev="6" srcmd5="1fe06d22b38ce06632413dcc7aeee49c">
+          <entry name="_config" md5="e76512ea4577d0a559788f9bed2f9ad8" size="58" mtime="1536753837" />
+          <entry name="somefile.txt" md5="d5ff6c3db27c57b3d9dbc5df28a95a21" size="64" mtime="1536753837" />
         </directory>
     http_version: 
-  recorded_at: Tue, 21 Aug 2018 14:39:09 GMT
+  recorded_at: Wed, 12 Sep 2018 12:03:57 GMT
 - request:
     method: get
     uri: http://backend:5352/source/ProjectWithRepo:Update/ProjectWithRepo_package/_service
@@ -1095,7 +1095,7 @@ http_interactions:
           <details>404 _service: no such file</details>
         </status>
     http_version: 
-  recorded_at: Tue, 21 Aug 2018 14:39:09 GMT
+  recorded_at: Wed, 12 Sep 2018 12:03:58 GMT
 - request:
     method: get
     uri: http://backend:5352/source/ProjectWithRepo/ProjectWithRepo_package/_history
@@ -1121,327 +1121,53 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '7373'
+      - '1123'
     body:
       encoding: UTF-8
       string: |
         <revisionlist>
           <revision rev="1" vrev="1">
-            <srcmd5>ef861a3470b1fa0c95c13c953ccf0f11</srcmd5>
+            <srcmd5>74351374fc9cad5c161e945f0ce0ac74</srcmd5>
             <version>unknown</version>
-            <time>1534841179</time>
+            <time>1536751450</time>
             <user>unknown</user>
           </revision>
           <revision rev="2" vrev="2">
-            <srcmd5>e7f382936d8dbbdfef4c6c735b42d7f4</srcmd5>
+            <srcmd5>ef2ac8ba589a2f50a1a8e8cc3bb90830</srcmd5>
             <version>unknown</version>
-            <time>1534841179</time>
+            <time>1536751450</time>
             <user>unknown</user>
           </revision>
           <revision rev="3" vrev="3">
-            <srcmd5>4393dc41f66705facd2bc3676d9feccd</srcmd5>
+            <srcmd5>7be551173f7a102ab7dbd20b3801b0c2</srcmd5>
             <version>unknown</version>
-            <time>1534841308</time>
+            <time>1536751571</time>
             <user>unknown</user>
           </revision>
           <revision rev="4" vrev="4">
-            <srcmd5>5e3a9335d573e6a76e28e05ef162f7f0</srcmd5>
+            <srcmd5>fa173dbe0aec343cc4073e811d8f24ff</srcmd5>
             <version>unknown</version>
-            <time>1534841308</time>
+            <time>1536751571</time>
             <user>unknown</user>
           </revision>
           <revision rev="5" vrev="5">
-            <srcmd5>66643b564ff96ed081e186cf1d8e97be</srcmd5>
+            <srcmd5>75da79e6c615c7425419fd07a1dbffc8</srcmd5>
             <version>unknown</version>
-            <time>1534853632</time>
+            <time>1536753837</time>
             <user>unknown</user>
           </revision>
           <revision rev="6" vrev="6">
-            <srcmd5>7cc80f5e04d9e17b7975a34928acbce4</srcmd5>
+            <srcmd5>1fe06d22b38ce06632413dcc7aeee49c</srcmd5>
             <version>unknown</version>
-            <time>1534853632</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="7" vrev="7">
-            <srcmd5>cdbe9c7b4493f6d7c3eec60a99cb5b3c</srcmd5>
-            <version>unknown</version>
-            <time>1534855027</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="8" vrev="8">
-            <srcmd5>95f195891b09f9f8dc365226f7643e65</srcmd5>
-            <version>unknown</version>
-            <time>1534855027</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="9" vrev="9">
-            <srcmd5>cf3d3a9e671e7cbe1a253272b587b41c</srcmd5>
-            <version>unknown</version>
-            <time>1534857809</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="10" vrev="10">
-            <srcmd5>be38122efefb1fc42b6cb4bcf119a7a3</srcmd5>
-            <version>unknown</version>
-            <time>1534857809</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="11" vrev="11">
-            <srcmd5>03c95d5f86fb0024e76b38fe850066b3</srcmd5>
-            <version>unknown</version>
-            <time>1534858088</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="12" vrev="12">
-            <srcmd5>f0bbd8e0348a4d7e1873fe79b59a3776</srcmd5>
-            <version>unknown</version>
-            <time>1534858089</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="13" vrev="13">
-            <srcmd5>50e3033532fe568f5f043eff485db1bb</srcmd5>
-            <version>unknown</version>
-            <time>1534858256</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="14" vrev="14">
-            <srcmd5>81612afa4b286c162260191744ba39d1</srcmd5>
-            <version>unknown</version>
-            <time>1534858256</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="15" vrev="15">
-            <srcmd5>1ce0c77b1bad0c8a6f30ff48f83f9a5b</srcmd5>
-            <version>unknown</version>
-            <time>1534858444</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="16" vrev="16">
-            <srcmd5>047878c1721dc894d10232caaabccccd</srcmd5>
-            <version>unknown</version>
-            <time>1534858444</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="17" vrev="17">
-            <srcmd5>91b47a11b57ad61c8a36c9fff85880d7</srcmd5>
-            <version>unknown</version>
-            <time>1534859413</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="18" vrev="18">
-            <srcmd5>a375be216773a9b8d4b4aebf7fc08d93</srcmd5>
-            <version>unknown</version>
-            <time>1534859413</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="19" vrev="19">
-            <srcmd5>c40036865d7f036be745970e661628e6</srcmd5>
-            <version>unknown</version>
-            <time>1534859480</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="20" vrev="20">
-            <srcmd5>f18e36470d8c72b8251ede3906eb5cd5</srcmd5>
-            <version>unknown</version>
-            <time>1534859480</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="21" vrev="21">
-            <srcmd5>652d053a110fcb3fccf4c686b60d76e9</srcmd5>
-            <version>unknown</version>
-            <time>1534860178</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="22" vrev="22">
-            <srcmd5>525151d7f89623d96da936aa373a6f42</srcmd5>
-            <version>unknown</version>
-            <time>1534860178</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="23" vrev="23">
-            <srcmd5>c3747efa422e4ba0969da49ef90dcdad</srcmd5>
-            <version>unknown</version>
-            <time>1534860755</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="24" vrev="24">
-            <srcmd5>f63f8c2a7b594f9c28ccfcb5dd0e6d4c</srcmd5>
-            <version>unknown</version>
-            <time>1534860755</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="25" vrev="25">
-            <srcmd5>cd11471be9bb366baef6f952cfe62a83</srcmd5>
-            <version>unknown</version>
-            <time>1534861137</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="26" vrev="26">
-            <srcmd5>fb14db981b41bebbc372a2774e2ccdba</srcmd5>
-            <version>unknown</version>
-            <time>1534861137</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="27" vrev="27">
-            <srcmd5>7cd6b4b384052cbcba954aa49d46f3ed</srcmd5>
-            <version>unknown</version>
-            <time>1534861206</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="28" vrev="28">
-            <srcmd5>8ee056b201b95755b779a15f9b175c74</srcmd5>
-            <version>unknown</version>
-            <time>1534861206</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="29" vrev="29">
-            <srcmd5>005774739c706fd98e01f2ef8ab7f45f</srcmd5>
-            <version>unknown</version>
-            <time>1534861328</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="30" vrev="30">
-            <srcmd5>2e7573bff4c639de61fbf0647c778d76</srcmd5>
-            <version>unknown</version>
-            <time>1534861328</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="31" vrev="31">
-            <srcmd5>32610bca72b766420098389a7b8b40bc</srcmd5>
-            <version>unknown</version>
-            <time>1534861390</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="32" vrev="32">
-            <srcmd5>85669923f3d5e8c99bd4a3a75835013d</srcmd5>
-            <version>unknown</version>
-            <time>1534861390</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="33" vrev="33">
-            <srcmd5>0de000f823cd5dc5dcfdd50658bb6867</srcmd5>
-            <version>unknown</version>
-            <time>1534861509</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="34" vrev="34">
-            <srcmd5>fa890c41ebb19330a503c83576c5ff10</srcmd5>
-            <version>unknown</version>
-            <time>1534861509</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="35" vrev="35">
-            <srcmd5>9f6b356969d2e85632610934ce86e5d4</srcmd5>
-            <version>unknown</version>
-            <time>1534861682</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="36" vrev="36">
-            <srcmd5>a243201fbe8067ef6a96e9958c7d967e</srcmd5>
-            <version>unknown</version>
-            <time>1534861683</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="37" vrev="37">
-            <srcmd5>1dbaff6c778dceabf0b25228f928fcc3</srcmd5>
-            <version>unknown</version>
-            <time>1534862267</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="38" vrev="38">
-            <srcmd5>089d10af26931ec531113f4f511bd7b8</srcmd5>
-            <version>unknown</version>
-            <time>1534862267</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="39" vrev="39">
-            <srcmd5>6697a7b710fec809184bdc0b7a07695e</srcmd5>
-            <version>unknown</version>
-            <time>1534862349</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="40" vrev="40">
-            <srcmd5>def3bf67a426e8013de578376d34f554</srcmd5>
-            <version>unknown</version>
-            <time>1534862349</time>
+            <time>1536753837</time>
             <user>unknown</user>
           </revision>
         </revisionlist>
     http_version: 
-  recorded_at: Tue, 21 Aug 2018 14:39:09 GMT
-- request:
-    method: get
-    uri: http://backend:5352/build/ProjectWithRepo:Update/_result?package=ProjectWithRepo_package&view=status
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Content-Type:
-      - text/plain
-      Accept-Encoding:
-      - identity
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '56'
-    body:
-      encoding: UTF-8
-      string: '<resultlist state="00000000000000000000000000000000" />
-
-'
-    http_version: 
-  recorded_at: Tue, 21 Aug 2018 14:39:10 GMT
+  recorded_at: Wed, 12 Sep 2018 12:03:58 GMT
 - request:
     method: get
     uri: http://backend:5352/build/ProjectWithRepo:Update/_result?locallink=1&multibuild=1&package=ProjectWithRepo_package&view=status
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Content-Type:
-      - text/plain
-      Accept-Encoding:
-      - identity
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '56'
-    body:
-      encoding: UTF-8
-      string: '<resultlist state="00000000000000000000000000000000" />
-
-'
-    http_version: 
-  recorded_at: Tue, 21 Aug 2018 14:39:10 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/ProjectWithRepo/ProjectWithRepo_package?expand=1
     body:
       encoding: US-ASCII
       string: ''
@@ -1464,16 +1190,82 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '312'
+      - '56'
+    body:
+      encoding: UTF-8
+      string: '<resultlist state="00000000000000000000000000000000" />
+
+'
+    http_version: 
+  recorded_at: Wed, 12 Sep 2018 12:03:58 GMT
+- request:
+    method: get
+    uri: http://backend:5352/build/ProjectWithRepo:Update/_result?package=ProjectWithRepo_package&view=status
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '56'
+    body:
+      encoding: UTF-8
+      string: '<resultlist state="00000000000000000000000000000000" />
+
+'
+    http_version: 
+  recorded_at: Wed, 12 Sep 2018 12:03:58 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/ProjectWithRepo/ProjectWithRepo_package?expand=1&rev=6
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '310'
     body:
       encoding: UTF-8
       string: |
-        <directory name="ProjectWithRepo_package" rev="40" vrev="40" srcmd5="def3bf67a426e8013de578376d34f554">
-          <entry name="_config" md5="1a05ff51cbc0ee790ddd75020dc14e94" size="51" mtime="1534862349" />
-          <entry name="somefile.txt" md5="9044d1ae989e292a5e19128f57de9e21" size="57" mtime="1534862349" />
+        <directory name="ProjectWithRepo_package" rev="6" vrev="6" srcmd5="1fe06d22b38ce06632413dcc7aeee49c">
+          <entry name="_config" md5="e76512ea4577d0a559788f9bed2f9ad8" size="58" mtime="1536753837" />
+          <entry name="somefile.txt" md5="d5ff6c3db27c57b3d9dbc5df28a95a21" size="64" mtime="1536753837" />
         </directory>
     http_version: 
-  recorded_at: Tue, 21 Aug 2018 14:39:10 GMT
+  recorded_at: Wed, 12 Sep 2018 12:03:59 GMT
 - request:
     method: post
     uri: http://backend:5352/search/package/id?match=(linkinfo/@package=%22ProjectWithRepo_package%22%20and%20linkinfo/@project=%22ProjectWithRepo:Update%22%20and%20starts-with(@project,%22MaintenanceProject:%22))
@@ -1509,18 +1301,16 @@ http_interactions:
           <package name="ProjectWithRepo_package.ProjectWithRepo_Update" project="MaintenanceProject:0" />
         </collection>
     http_version: 
-  recorded_at: Tue, 21 Aug 2018 14:39:11 GMT
+  recorded_at: Wed, 12 Sep 2018 12:03:59 GMT
 - request:
     method: get
-    uri: http://backend:5352/source/ProjectWithRepo/ProjectWithRepo_package?rev=40
+    uri: http://backend:5352/source/ProjectWithRepo/ProjectWithRepo_package?rev=6
     body:
       encoding: US-ASCII
       string: ''
     headers:
-      Content-Type:
-      - text/plain
       Accept-Encoding:
-      - identity
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
       - "*/*"
       User-Agent:
@@ -1537,16 +1327,16 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '312'
+      - '310'
     body:
       encoding: UTF-8
       string: |
-        <directory name="ProjectWithRepo_package" rev="40" vrev="40" srcmd5="def3bf67a426e8013de578376d34f554">
-          <entry name="_config" md5="1a05ff51cbc0ee790ddd75020dc14e94" size="51" mtime="1534862349" />
-          <entry name="somefile.txt" md5="9044d1ae989e292a5e19128f57de9e21" size="57" mtime="1534862349" />
+        <directory name="ProjectWithRepo_package" rev="6" vrev="6" srcmd5="1fe06d22b38ce06632413dcc7aeee49c">
+          <entry name="_config" md5="e76512ea4577d0a559788f9bed2f9ad8" size="58" mtime="1536753837" />
+          <entry name="somefile.txt" md5="d5ff6c3db27c57b3d9dbc5df28a95a21" size="64" mtime="1536753837" />
         </directory>
     http_version: 
-  recorded_at: Tue, 21 Aug 2018 14:39:11 GMT
+  recorded_at: Wed, 12 Sep 2018 12:03:59 GMT
 - request:
     method: post
     uri: http://backend:5352/search/package/id?match=(linkinfo/@package=%22ProjectWithRepo_package%22%20and%20linkinfo/@project=%22ProjectWithRepo%22%20and%20@project=%22ProjectWithRepo%22)
@@ -1581,7 +1371,7 @@ http_interactions:
         <collection>
         </collection>
     http_version: 
-  recorded_at: Tue, 21 Aug 2018 14:39:11 GMT
+  recorded_at: Wed, 12 Sep 2018 12:03:59 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom:branches:ProjectWithRepo:Update/_meta?user=tom
@@ -1622,7 +1412,7 @@ http_interactions:
           <person userid="tom" role="maintainer" />
         </project>
     http_version: 
-  recorded_at: Tue, 21 Aug 2018 14:39:11 GMT
+  recorded_at: Wed, 12 Sep 2018 12:03:59 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom:branches:ProjectWithRepo:Update/ProjectWithRepo_package/_meta?user=tom
@@ -1630,8 +1420,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="ProjectWithRepo_package" project="home:tom:branches:ProjectWithRepo:Update">
-          <title>Antic Hay</title>
-          <description>A eaque voluptas optio.</description>
+          <title>The Widening Gyre</title>
+          <description>Cupiditate neque nihil consequatur.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -1652,19 +1442,19 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '183'
+      - '203'
     body:
       encoding: UTF-8
       string: |
         <package name="ProjectWithRepo_package" project="home:tom:branches:ProjectWithRepo:Update">
-          <title>Antic Hay</title>
-          <description>A eaque voluptas optio.</description>
+          <title>The Widening Gyre</title>
+          <description>Cupiditate neque nihil consequatur.</description>
         </package>
     http_version: 
-  recorded_at: Tue, 21 Aug 2018 14:39:11 GMT
+  recorded_at: Wed, 12 Sep 2018 12:03:59 GMT
 - request:
     method: post
-    uri: http://backend:5352/source/home:tom:branches:ProjectWithRepo:Update/ProjectWithRepo_package?cmd=branch&noservice=1&opackage=ProjectWithRepo_package&oproject=ProjectWithRepo:Update&orev=def3bf67a426e8013de578376d34f554&user=tom
+    uri: http://backend:5352/source/home:tom:branches:ProjectWithRepo:Update/ProjectWithRepo_package?cmd=branch&noservice=1&opackage=ProjectWithRepo_package&oproject=ProjectWithRepo:Update&orev=1fe06d22b38ce06632413dcc7aeee49c&user=tom
     body:
       encoding: UTF-8
       string: ''
@@ -1689,20 +1479,20 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '205'
+      - '203'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="11" vrev="11">
-          <srcmd5>06049b35725824938748c73fbaff8a7b</srcmd5>
+        <revision rev="5" vrev="5">
+          <srcmd5>13729421ca17606835a0f3eea8d68e65</srcmd5>
           <version>unknown</version>
-          <time>1534862351</time>
+          <time>1536753839</time>
           <user>tom</user>
           <comment></comment>
           <requestid/>
         </revision>
     http_version: 
-  recorded_at: Tue, 21 Aug 2018 14:39:11 GMT
+  recorded_at: Wed, 12 Sep 2018 12:03:59 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom:branches:ProjectWithRepo:Update/ProjectWithRepo_package/_meta?user=tom
@@ -1710,8 +1500,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="ProjectWithRepo_package" project="home:tom:branches:ProjectWithRepo:Update">
-          <title>Antic Hay</title>
-          <description>A eaque voluptas optio.</description>
+          <title>The Widening Gyre</title>
+          <description>Cupiditate neque nihil consequatur.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -1732,16 +1522,16 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '183'
+      - '203'
     body:
       encoding: UTF-8
       string: |
         <package name="ProjectWithRepo_package" project="home:tom:branches:ProjectWithRepo:Update">
-          <title>Antic Hay</title>
-          <description>A eaque voluptas optio.</description>
+          <title>The Widening Gyre</title>
+          <description>Cupiditate neque nihil consequatur.</description>
         </package>
     http_version: 
-  recorded_at: Tue, 21 Aug 2018 14:39:11 GMT
+  recorded_at: Wed, 12 Sep 2018 12:03:59 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:tom:branches:ProjectWithRepo:Update/ProjectWithRepo_package
@@ -1767,18 +1557,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '698'
+      - '696'
     body:
       encoding: UTF-8
       string: |
-        <directory name="ProjectWithRepo_package" rev="11" vrev="11" srcmd5="06049b35725824938748c73fbaff8a7b">
-          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" rev="def3bf67a426e8013de578376d34f554" srcmd5="def3bf67a426e8013de578376d34f554" baserev="def3bf67a426e8013de578376d34f554" xsrcmd5="fedb570d997c7b62fa258146b8ba1a2a" lsrcmd5="06049b35725824938748c73fbaff8a7b" />
-          <entry name="_config" md5="1a05ff51cbc0ee790ddd75020dc14e94" size="51" mtime="1534862349" />
-          <entry name="_link" md5="54e623c39791ca9f3db24ee0fb436950" size="169" mtime="1534862351" />
-          <entry name="somefile.txt" md5="9044d1ae989e292a5e19128f57de9e21" size="57" mtime="1534862349" />
+        <directory name="ProjectWithRepo_package" rev="5" vrev="5" srcmd5="13729421ca17606835a0f3eea8d68e65">
+          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" rev="1fe06d22b38ce06632413dcc7aeee49c" srcmd5="1fe06d22b38ce06632413dcc7aeee49c" baserev="1fe06d22b38ce06632413dcc7aeee49c" xsrcmd5="51ede1ce1de3911b9c1b2f96c00be142" lsrcmd5="13729421ca17606835a0f3eea8d68e65" />
+          <entry name="_config" md5="e76512ea4577d0a559788f9bed2f9ad8" size="58" mtime="1536753837" />
+          <entry name="_link" md5="90e4f5a99633a426e6ec73e94204889b" size="169" mtime="1536753839" />
+          <entry name="somefile.txt" md5="d5ff6c3db27c57b3d9dbc5df28a95a21" size="64" mtime="1536753837" />
         </directory>
     http_version: 
-  recorded_at: Tue, 21 Aug 2018 14:39:11 GMT
+  recorded_at: Wed, 12 Sep 2018 12:03:59 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:tom:branches:ProjectWithRepo:Update/ProjectWithRepo_package?view=info
@@ -1804,17 +1594,17 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '439'
+      - '437'
     body:
       encoding: UTF-8
       string: |
-        <sourceinfo package="ProjectWithRepo_package" rev="11" vrev="11" srcmd5="fedb570d997c7b62fa258146b8ba1a2a" lsrcmd5="06049b35725824938748c73fbaff8a7b" verifymd5="def3bf67a426e8013de578376d34f554">
+        <sourceinfo package="ProjectWithRepo_package" rev="5" vrev="5" srcmd5="51ede1ce1de3911b9c1b2f96c00be142" lsrcmd5="13729421ca17606835a0f3eea8d68e65" verifymd5="1fe06d22b38ce06632413dcc7aeee49c">
           <error>bad build configuration, no build type defined or detected</error>
           <linked project="ProjectWithRepo:Update" package="ProjectWithRepo_package" />
           <linked project="ProjectWithRepo" package="ProjectWithRepo_package" />
         </sourceinfo>
     http_version: 
-  recorded_at: Tue, 21 Aug 2018 14:39:11 GMT
+  recorded_at: Wed, 12 Sep 2018 12:03:59 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:tom:branches:ProjectWithRepo:Update/ProjectWithRepo_package
@@ -1840,18 +1630,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '698'
+      - '696'
     body:
       encoding: UTF-8
       string: |
-        <directory name="ProjectWithRepo_package" rev="11" vrev="11" srcmd5="06049b35725824938748c73fbaff8a7b">
-          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" rev="def3bf67a426e8013de578376d34f554" srcmd5="def3bf67a426e8013de578376d34f554" baserev="def3bf67a426e8013de578376d34f554" xsrcmd5="fedb570d997c7b62fa258146b8ba1a2a" lsrcmd5="06049b35725824938748c73fbaff8a7b" />
-          <entry name="_config" md5="1a05ff51cbc0ee790ddd75020dc14e94" size="51" mtime="1534862349" />
-          <entry name="_link" md5="54e623c39791ca9f3db24ee0fb436950" size="169" mtime="1534862351" />
-          <entry name="somefile.txt" md5="9044d1ae989e292a5e19128f57de9e21" size="57" mtime="1534862349" />
+        <directory name="ProjectWithRepo_package" rev="5" vrev="5" srcmd5="13729421ca17606835a0f3eea8d68e65">
+          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" rev="1fe06d22b38ce06632413dcc7aeee49c" srcmd5="1fe06d22b38ce06632413dcc7aeee49c" baserev="1fe06d22b38ce06632413dcc7aeee49c" xsrcmd5="51ede1ce1de3911b9c1b2f96c00be142" lsrcmd5="13729421ca17606835a0f3eea8d68e65" />
+          <entry name="_config" md5="e76512ea4577d0a559788f9bed2f9ad8" size="58" mtime="1536753837" />
+          <entry name="_link" md5="90e4f5a99633a426e6ec73e94204889b" size="169" mtime="1536753839" />
+          <entry name="somefile.txt" md5="d5ff6c3db27c57b3d9dbc5df28a95a21" size="64" mtime="1536753837" />
         </directory>
     http_version: 
-  recorded_at: Tue, 21 Aug 2018 14:39:11 GMT
+  recorded_at: Wed, 12 Sep 2018 12:04:00 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:tom:branches:ProjectWithRepo:Update/ProjectWithRepo_package?cmd=diff&linkrev=base&onlyissues=1&orev=0&view=xml
@@ -1879,19 +1669,19 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '392'
+      - '391'
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="296aa3cc59d0f8f6a8e390d129c4050b">
+        <sourcediff key="0c76cd7e26ea807654460b9e6def1f51">
           <old project="home:tom:branches:ProjectWithRepo:Update" package="ProjectWithRepo_package" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e" />
-          <new project="home:tom:branches:ProjectWithRepo:Update" package="ProjectWithRepo_package" rev="11" srcmd5="06049b35725824938748c73fbaff8a7b" />
+          <new project="home:tom:branches:ProjectWithRepo:Update" package="ProjectWithRepo_package" rev="5" srcmd5="13729421ca17606835a0f3eea8d68e65" />
           <files />
           <issues>
           </issues>
         </sourcediff>
     http_version: 
-  recorded_at: Tue, 21 Aug 2018 14:39:11 GMT
+  recorded_at: Wed, 12 Sep 2018 12:04:00 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:tom:branches:ProjectWithRepo:Update/ProjectWithRepo_package?cmd=linkdiff&linkrev=base&onlyissues=1&view=xml
@@ -1923,13 +1713,13 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="dea9d9c1a630ce0a88704b86b63c868f">
-          <old project="ProjectWithRepo:Update" package="ProjectWithRepo_package" rev="def3bf67a426e8013de578376d34f554" srcmd5="def3bf67a426e8013de578376d34f554" />
-          <new project="home:tom:branches:ProjectWithRepo:Update" package="ProjectWithRepo_package" rev="fedb570d997c7b62fa258146b8ba1a2a" srcmd5="fedb570d997c7b62fa258146b8ba1a2a" />
+        <sourcediff key="5973a3bfb5717ac99500863ca20d6f69">
+          <old project="ProjectWithRepo:Update" package="ProjectWithRepo_package" rev="1fe06d22b38ce06632413dcc7aeee49c" srcmd5="1fe06d22b38ce06632413dcc7aeee49c" />
+          <new project="home:tom:branches:ProjectWithRepo:Update" package="ProjectWithRepo_package" rev="51ede1ce1de3911b9c1b2f96c00be142" srcmd5="51ede1ce1de3911b9c1b2f96c00be142" />
           <files />
         </sourcediff>
     http_version: 
-  recorded_at: Tue, 21 Aug 2018 14:39:11 GMT
+  recorded_at: Wed, 12 Sep 2018 12:04:00 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom:branches:ProjectWithRepo:Update/_meta?user=tom
@@ -1986,7 +1776,7 @@ http_interactions:
           </repository>
         </project>
     http_version: 
-  recorded_at: Tue, 21 Aug 2018 14:39:11 GMT
+  recorded_at: Wed, 12 Sep 2018 12:04:00 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:tom:branches:ProjectWithRepo:Update/ProjectWithRepo_package
@@ -2012,18 +1802,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '698'
+      - '696'
     body:
       encoding: UTF-8
       string: |
-        <directory name="ProjectWithRepo_package" rev="11" vrev="11" srcmd5="06049b35725824938748c73fbaff8a7b">
-          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" rev="def3bf67a426e8013de578376d34f554" srcmd5="def3bf67a426e8013de578376d34f554" baserev="def3bf67a426e8013de578376d34f554" xsrcmd5="fedb570d997c7b62fa258146b8ba1a2a" lsrcmd5="06049b35725824938748c73fbaff8a7b" />
-          <entry name="_config" md5="1a05ff51cbc0ee790ddd75020dc14e94" size="51" mtime="1534862349" />
-          <entry name="_link" md5="54e623c39791ca9f3db24ee0fb436950" size="169" mtime="1534862351" />
-          <entry name="somefile.txt" md5="9044d1ae989e292a5e19128f57de9e21" size="57" mtime="1534862349" />
+        <directory name="ProjectWithRepo_package" rev="5" vrev="5" srcmd5="13729421ca17606835a0f3eea8d68e65">
+          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" rev="1fe06d22b38ce06632413dcc7aeee49c" srcmd5="1fe06d22b38ce06632413dcc7aeee49c" baserev="1fe06d22b38ce06632413dcc7aeee49c" xsrcmd5="51ede1ce1de3911b9c1b2f96c00be142" lsrcmd5="13729421ca17606835a0f3eea8d68e65" />
+          <entry name="_config" md5="e76512ea4577d0a559788f9bed2f9ad8" size="58" mtime="1536753837" />
+          <entry name="_link" md5="90e4f5a99633a426e6ec73e94204889b" size="169" mtime="1536753839" />
+          <entry name="somefile.txt" md5="d5ff6c3db27c57b3d9dbc5df28a95a21" size="64" mtime="1536753837" />
         </directory>
     http_version: 
-  recorded_at: Tue, 21 Aug 2018 14:39:12 GMT
+  recorded_at: Wed, 12 Sep 2018 12:04:00 GMT
 - request:
     method: get
     uri: http://backend:5352/source/ProjectWithRepo:Update/ProjectWithRepo_package
@@ -2049,16 +1839,16 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '312'
+      - '310'
     body:
       encoding: UTF-8
       string: |
-        <directory name="ProjectWithRepo_package" rev="40" vrev="40" srcmd5="def3bf67a426e8013de578376d34f554">
-          <entry name="_config" md5="1a05ff51cbc0ee790ddd75020dc14e94" size="51" mtime="1534862349" />
-          <entry name="somefile.txt" md5="9044d1ae989e292a5e19128f57de9e21" size="57" mtime="1534862349" />
+        <directory name="ProjectWithRepo_package" rev="6" vrev="6" srcmd5="1fe06d22b38ce06632413dcc7aeee49c">
+          <entry name="_config" md5="e76512ea4577d0a559788f9bed2f9ad8" size="58" mtime="1536753837" />
+          <entry name="somefile.txt" md5="d5ff6c3db27c57b3d9dbc5df28a95a21" size="64" mtime="1536753837" />
         </directory>
     http_version: 
-  recorded_at: Tue, 21 Aug 2018 14:39:12 GMT
+  recorded_at: Wed, 12 Sep 2018 12:04:00 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:tom:branches:ProjectWithRepo:Update/ProjectWithRepo_package
@@ -2084,21 +1874,21 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '698'
+      - '696'
     body:
       encoding: UTF-8
       string: |
-        <directory name="ProjectWithRepo_package" rev="11" vrev="11" srcmd5="06049b35725824938748c73fbaff8a7b">
-          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" rev="def3bf67a426e8013de578376d34f554" srcmd5="def3bf67a426e8013de578376d34f554" baserev="def3bf67a426e8013de578376d34f554" xsrcmd5="fedb570d997c7b62fa258146b8ba1a2a" lsrcmd5="06049b35725824938748c73fbaff8a7b" />
-          <entry name="_config" md5="1a05ff51cbc0ee790ddd75020dc14e94" size="51" mtime="1534862349" />
-          <entry name="_link" md5="54e623c39791ca9f3db24ee0fb436950" size="169" mtime="1534862351" />
-          <entry name="somefile.txt" md5="9044d1ae989e292a5e19128f57de9e21" size="57" mtime="1534862349" />
+        <directory name="ProjectWithRepo_package" rev="5" vrev="5" srcmd5="13729421ca17606835a0f3eea8d68e65">
+          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" rev="1fe06d22b38ce06632413dcc7aeee49c" srcmd5="1fe06d22b38ce06632413dcc7aeee49c" baserev="1fe06d22b38ce06632413dcc7aeee49c" xsrcmd5="51ede1ce1de3911b9c1b2f96c00be142" lsrcmd5="13729421ca17606835a0f3eea8d68e65" />
+          <entry name="_config" md5="e76512ea4577d0a559788f9bed2f9ad8" size="58" mtime="1536753837" />
+          <entry name="_link" md5="90e4f5a99633a426e6ec73e94204889b" size="169" mtime="1536753839" />
+          <entry name="somefile.txt" md5="d5ff6c3db27c57b3d9dbc5df28a95a21" size="64" mtime="1536753837" />
         </directory>
     http_version: 
-  recorded_at: Tue, 21 Aug 2018 14:39:12 GMT
+  recorded_at: Wed, 12 Sep 2018 12:04:00 GMT
 - request:
     method: get
-    uri: http://backend:5352/source/home:tom:branches:ProjectWithRepo:Update/ProjectWithRepo_package?expand=1&rev=11
+    uri: http://backend:5352/source/home:tom:branches:ProjectWithRepo:Update/ProjectWithRepo_package?expand=1&rev=5
     body:
       encoding: US-ASCII
       string: ''
@@ -2121,17 +1911,17 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '591'
+      - '590'
     body:
       encoding: UTF-8
       string: |
-        <directory name="ProjectWithRepo_package" rev="fedb570d997c7b62fa258146b8ba1a2a" vrev="11" srcmd5="fedb570d997c7b62fa258146b8ba1a2a">
-          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" rev="def3bf67a426e8013de578376d34f554" srcmd5="def3bf67a426e8013de578376d34f554" baserev="def3bf67a426e8013de578376d34f554" lsrcmd5="06049b35725824938748c73fbaff8a7b" />
-          <entry name="_config" md5="1a05ff51cbc0ee790ddd75020dc14e94" size="51" mtime="1534862349" />
-          <entry name="somefile.txt" md5="9044d1ae989e292a5e19128f57de9e21" size="57" mtime="1534862349" />
+        <directory name="ProjectWithRepo_package" rev="51ede1ce1de3911b9c1b2f96c00be142" vrev="5" srcmd5="51ede1ce1de3911b9c1b2f96c00be142">
+          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" rev="1fe06d22b38ce06632413dcc7aeee49c" srcmd5="1fe06d22b38ce06632413dcc7aeee49c" baserev="1fe06d22b38ce06632413dcc7aeee49c" lsrcmd5="13729421ca17606835a0f3eea8d68e65" />
+          <entry name="_config" md5="e76512ea4577d0a559788f9bed2f9ad8" size="58" mtime="1536753837" />
+          <entry name="somefile.txt" md5="d5ff6c3db27c57b3d9dbc5df28a95a21" size="64" mtime="1536753837" />
         </directory>
     http_version: 
-  recorded_at: Tue, 21 Aug 2018 14:39:12 GMT
+  recorded_at: Wed, 12 Sep 2018 12:04:00 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:tom:branches:ProjectWithRepo:Update/ProjectWithRepo_package/_service
@@ -2166,7 +1956,7 @@ http_interactions:
           <details>404 _service: no such file</details>
         </status>
     http_version: 
-  recorded_at: Tue, 21 Aug 2018 14:39:12 GMT
+  recorded_at: Wed, 12 Sep 2018 12:04:00 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:tom:branches:ProjectWithRepo:Update/ProjectWithRepo_package
@@ -2192,18 +1982,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '698'
+      - '696'
     body:
       encoding: UTF-8
       string: |
-        <directory name="ProjectWithRepo_package" rev="11" vrev="11" srcmd5="06049b35725824938748c73fbaff8a7b">
-          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" rev="def3bf67a426e8013de578376d34f554" srcmd5="def3bf67a426e8013de578376d34f554" baserev="def3bf67a426e8013de578376d34f554" xsrcmd5="fedb570d997c7b62fa258146b8ba1a2a" lsrcmd5="06049b35725824938748c73fbaff8a7b" />
-          <entry name="_config" md5="1a05ff51cbc0ee790ddd75020dc14e94" size="51" mtime="1534862349" />
-          <entry name="_link" md5="54e623c39791ca9f3db24ee0fb436950" size="169" mtime="1534862351" />
-          <entry name="somefile.txt" md5="9044d1ae989e292a5e19128f57de9e21" size="57" mtime="1534862349" />
+        <directory name="ProjectWithRepo_package" rev="5" vrev="5" srcmd5="13729421ca17606835a0f3eea8d68e65">
+          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" rev="1fe06d22b38ce06632413dcc7aeee49c" srcmd5="1fe06d22b38ce06632413dcc7aeee49c" baserev="1fe06d22b38ce06632413dcc7aeee49c" xsrcmd5="51ede1ce1de3911b9c1b2f96c00be142" lsrcmd5="13729421ca17606835a0f3eea8d68e65" />
+          <entry name="_config" md5="e76512ea4577d0a559788f9bed2f9ad8" size="58" mtime="1536753837" />
+          <entry name="_link" md5="90e4f5a99633a426e6ec73e94204889b" size="169" mtime="1536753839" />
+          <entry name="somefile.txt" md5="d5ff6c3db27c57b3d9dbc5df28a95a21" size="64" mtime="1536753837" />
         </directory>
     http_version: 
-  recorded_at: Tue, 21 Aug 2018 14:39:12 GMT
+  recorded_at: Wed, 12 Sep 2018 12:04:00 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:tom:branches:ProjectWithRepo:Update/ProjectWithRepo_package
@@ -2229,18 +2019,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '698'
+      - '696'
     body:
       encoding: UTF-8
       string: |
-        <directory name="ProjectWithRepo_package" rev="11" vrev="11" srcmd5="06049b35725824938748c73fbaff8a7b">
-          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" rev="def3bf67a426e8013de578376d34f554" srcmd5="def3bf67a426e8013de578376d34f554" baserev="def3bf67a426e8013de578376d34f554" xsrcmd5="fedb570d997c7b62fa258146b8ba1a2a" lsrcmd5="06049b35725824938748c73fbaff8a7b" />
-          <entry name="_config" md5="1a05ff51cbc0ee790ddd75020dc14e94" size="51" mtime="1534862349" />
-          <entry name="_link" md5="54e623c39791ca9f3db24ee0fb436950" size="169" mtime="1534862351" />
-          <entry name="somefile.txt" md5="9044d1ae989e292a5e19128f57de9e21" size="57" mtime="1534862349" />
+        <directory name="ProjectWithRepo_package" rev="5" vrev="5" srcmd5="13729421ca17606835a0f3eea8d68e65">
+          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" rev="1fe06d22b38ce06632413dcc7aeee49c" srcmd5="1fe06d22b38ce06632413dcc7aeee49c" baserev="1fe06d22b38ce06632413dcc7aeee49c" xsrcmd5="51ede1ce1de3911b9c1b2f96c00be142" lsrcmd5="13729421ca17606835a0f3eea8d68e65" />
+          <entry name="_config" md5="e76512ea4577d0a559788f9bed2f9ad8" size="58" mtime="1536753837" />
+          <entry name="_link" md5="90e4f5a99633a426e6ec73e94204889b" size="169" mtime="1536753839" />
+          <entry name="somefile.txt" md5="d5ff6c3db27c57b3d9dbc5df28a95a21" size="64" mtime="1536753837" />
         </directory>
     http_version: 
-  recorded_at: Tue, 21 Aug 2018 14:39:12 GMT
+  recorded_at: Wed, 12 Sep 2018 12:04:00 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:tom:branches:ProjectWithRepo:Update/ProjectWithRepo_package/_history
@@ -2266,116 +2056,44 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '1997'
+      - '929'
     body:
       encoding: UTF-8
       string: |
         <revisionlist>
           <revision rev="1" vrev="1">
-            <srcmd5>4fedafbc819633941949621921d10033</srcmd5>
+            <srcmd5>11e1f05fb2e8c5314eff565d072493b3</srcmd5>
             <version>unknown</version>
-            <time>1534860703</time>
+            <time>1536751452</time>
             <user>tom</user>
           </revision>
           <revision rev="2" vrev="2">
-            <srcmd5>54b1a2aad3c9b1bf18670372cc19ef06</srcmd5>
+            <srcmd5>d54ef0286c97ce5d1c56801acbf6c335</srcmd5>
             <version>unknown</version>
-            <time>1534860850</time>
-            <user>tom</user>
+            <time>1536751453</time>
+            <user>unknown</user>
           </revision>
           <revision rev="3" vrev="3">
-            <srcmd5>a4d9f21b9abe01776f09213a7f9bd1c6</srcmd5>
+            <srcmd5>b1ef2fafc7b9ba1b9e12f1ebe1ad79f7</srcmd5>
             <version>unknown</version>
-            <time>1534861139</time>
+            <time>1536751573</time>
             <user>tom</user>
           </revision>
           <revision rev="4" vrev="4">
-            <srcmd5>cf0b115f72762efc68e922985f029246</srcmd5>
+            <srcmd5>f2d1d5cc36e0336fdf2576467561b37e</srcmd5>
             <version>unknown</version>
-            <time>1534861208</time>
-            <user>tom</user>
-          </revision>
-          <revision rev="5" vrev="5">
-            <srcmd5>5bf24d5fd22ddede438a2470a46b0f05</srcmd5>
-            <version>unknown</version>
-            <time>1534861330</time>
-            <user>tom</user>
-          </revision>
-          <revision rev="6" vrev="6">
-            <srcmd5>3442c819acb0ae47dd6d92795df5de3c</srcmd5>
-            <version>unknown</version>
-            <time>1534861391</time>
-            <user>tom</user>
-          </revision>
-          <revision rev="7" vrev="7">
-            <srcmd5>27ff2cdbea0c0e8d0a46b869c9ba52fb</srcmd5>
-            <version>unknown</version>
-            <time>1534861520</time>
-            <user>tom</user>
-          </revision>
-          <revision rev="8" vrev="8">
-            <srcmd5>069b7c9639fc430eb3cfa2ecbf668629</srcmd5>
-            <version>unknown</version>
-            <time>1534861688</time>
-            <user>tom</user>
-          </revision>
-          <revision rev="9" vrev="9">
-            <srcmd5>4a31a41df73879ba6135363ad6e162bc</srcmd5>
-            <version>unknown</version>
-            <time>1534862269</time>
-            <user>tom</user>
-          </revision>
-          <revision rev="10" vrev="10">
-            <srcmd5>f380db102d234182d609ca692b2e5ddd</srcmd5>
-            <version>unknown</version>
-            <time>1534862270</time>
+            <time>1536751574</time>
             <user>unknown</user>
           </revision>
-          <revision rev="11" vrev="11">
-            <srcmd5>06049b35725824938748c73fbaff8a7b</srcmd5>
+          <revision rev="5" vrev="5">
+            <srcmd5>13729421ca17606835a0f3eea8d68e65</srcmd5>
             <version>unknown</version>
-            <time>1534862351</time>
+            <time>1536753839</time>
             <user>tom</user>
           </revision>
         </revisionlist>
     http_version: 
-  recorded_at: Tue, 21 Aug 2018 14:39:12 GMT
-- request:
-    method: get
-    uri: http://backend:5352/build/home:tom:branches:ProjectWithRepo:Update/_result?package=ProjectWithRepo_package&view=status
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Content-Type:
-      - text/plain
-      Accept-Encoding:
-      - identity
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '248'
-    body:
-      encoding: UTF-8
-      string: |
-        <resultlist state="d717409be2592c96becbdc11142f1468">
-          <result project="home:tom:branches:ProjectWithRepo:Update" repository="repository_2" arch="i586" code="broken" state="broken" details="no build type (ProjectWithRepo:Update)" />
-        </resultlist>
-    http_version: 
-  recorded_at: Tue, 21 Aug 2018 14:39:12 GMT
+  recorded_at: Wed, 12 Sep 2018 12:04:00 GMT
 - request:
     method: get
     uri: http://backend:5352/build/home:tom:branches:ProjectWithRepo:Update/_result?locallink=1&multibuild=1&package=ProjectWithRepo_package&view=status
@@ -2383,10 +2101,8 @@ http_interactions:
       encoding: US-ASCII
       string: ''
     headers:
-      Content-Type:
-      - text/plain
       Accept-Encoding:
-      - identity
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
       - "*/*"
       User-Agent:
@@ -2411,7 +2127,41 @@ http_interactions:
           <result project="home:tom:branches:ProjectWithRepo:Update" repository="repository_2" arch="i586" code="broken" state="broken" details="no build type (ProjectWithRepo:Update)" />
         </resultlist>
     http_version: 
-  recorded_at: Tue, 21 Aug 2018 14:39:12 GMT
+  recorded_at: Wed, 12 Sep 2018 12:04:00 GMT
+- request:
+    method: get
+    uri: http://backend:5352/build/home:tom:branches:ProjectWithRepo:Update/_result?package=ProjectWithRepo_package&view=status
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '248'
+    body:
+      encoding: UTF-8
+      string: |
+        <resultlist state="d717409be2592c96becbdc11142f1468">
+          <result project="home:tom:branches:ProjectWithRepo:Update" repository="repository_2" arch="i586" code="broken" state="broken" details="no build type (ProjectWithRepo:Update)" />
+        </resultlist>
+    http_version: 
+  recorded_at: Wed, 12 Sep 2018 12:04:00 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom:branches:ProjectWithRepo:Update/ProjectWithRepo_package/DUMMY_FILE
@@ -2437,20 +2187,20 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '209'
+      - '207'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="12" vrev="12">
-          <srcmd5>08d09eda7595c7a4a9225e3e1c5992cf</srcmd5>
+        <revision rev="6" vrev="6">
+          <srcmd5>6f64842b339b86054358d876db6f6823</srcmd5>
           <version>unknown</version>
-          <time>1534862352</time>
+          <time>1536753841</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
     http_version: 
-  recorded_at: Tue, 21 Aug 2018 14:39:12 GMT
+  recorded_at: Wed, 12 Sep 2018 12:04:01 GMT
 - request:
     method: get
     uri: http://backend:5352/build/home:tom:branches:ProjectWithRepo:Update/_result?code=unresolvable&view=status
@@ -2484,7 +2234,7 @@ http_interactions:
           <result project="home:tom:branches:ProjectWithRepo:Update" repository="repository_2" arch="i586" code="broken" state="broken" details="no build type (ProjectWithRepo:Update)" />
         </resultlist>
     http_version: 
-  recorded_at: Tue, 21 Aug 2018 14:39:12 GMT
+  recorded_at: Wed, 12 Sep 2018 12:04:01 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:tom:branches:ProjectWithRepo:Update/_keyinfo?donotcreatecert=1&withsslcert=1
@@ -2515,35 +2265,35 @@ http_interactions:
       encoding: UTF-8
       string: |
         <keyinfo project="home:tom">
-          <pubkey keyid="c9009a14" algo="rsa" keysize="2048" expires="1603961175" fingerprint="2a03 78f6 dbd8 5b73 a0e3 7a3d 824d 5ed5 c900 9a14">-----BEGIN PGP PUBLIC KEY BLOCK-----
+          <pubkey keyid="ebc468fa" algo="rsa" keysize="2048" expires="1605862990" fingerprint="56d0 e36c 0f06 2122 ced1 b09f 3220 2291 ebc4 68fa">-----BEGIN PGP PUBLIC KEY BLOCK-----
         Version: GnuPG v2
 
-        mQENBFt70VcBCAC51VHkrHk8OL6gwzXAbwwcDYm/iSZYPDljvgZo6Go3WUzspaic
-        SYZcEhJIvss8ok3EXn3Sv7TCDOuw3tgZCkVIZzgVf6Sirbk137kJ5crRyc7Datop
-        CEHYHqac/tJ2AZBnyebNjPMkYscn3O6WH0U+K8j0bU88rTSCe7FXTM21uDP1PvQi
-        WgaOqfaFYlN4yNUTgbFwxPJiwb3A+auZbih7M949RCDou94ccZJ9H0ejC7kjf/q4
-        07fbQlQYthu/1QGr3hzLky0j4uoPncS6u2qApOi/9xug9GnNfgmjiME+lqLmOQVV
-        Nj877za6fuSHVLxsnyqRnNsBt1fZJuNeUfOhABEBAAG0J2hvbWU6dG9tIE9CUyBQ
-        cm9qZWN0IDxob21lOnRvbUBwcml2YXRlPokBPwQTAQIAKQUCW3vRVwIbAwUJBB6w
-        AAcLCQgHAwIBBhUIAgkKCwQWAgMBAh4BAheAAAoJEIJNXtXJAJoUSzwH/0ikOrnT
-        5v856C+ZZk+n3UprmPM0NbyEt8Y9+ty/EM/hkn1k0sGf/gMdaEb+5n2wdPc7olsV
-        exWgs1WMlIIfp7Kaw1bnnwAgxUrFwhLOtQlqkM4tNnwWWwEon53s2FRQX+vBCKgP
-        PgAoABofDisczvCgLeOdUIJe4xpETzzH14K9PS4rsdrHSyaXc884aND+Z+9wL/R1
-        9DCoJ1PmsNWJuCsTB/YpLXiZ5W0DqYAWoK6/LZc/O1klQvc3KyAQz/OjtgJ0T/LG
-        mtnRCq0EQOpavzsSG4ZEJIUj38ZzYxCtST0NMuDj/2A8jPV1sRd9PiKjLya9R0GO
-        Co0hfYH8GjxnVByJARwEEwECAAYFAlt70VcACgkQv/X5J7hHHOsAmQgAwV43sgYK
-        pRh80eAH6R7MdTFSlgok8I9qa+IBSps6hJlMudKAWK14YPPhPwWtG0tBQl36HoFX
-        owhaYSd9CcQS3B+FW3rKdBEJIsU/211DJ/9Q4leTyuFyRgEtKbESuzBpq0aF7kzM
-        Nu5PQkLCqgvUChCK1Y4CG9CNp52q3JP+TkmJ5Eh2vg89JU3uhZ724LTJVDioRJ+N
-        H6kgIeLCZRPjoa9upT8OqvLsOo3R3za913TcQDMfZ4Y2G1/bgOfdCCe6+pzjoMsf
-        FBFOGSpXkSnWAWCInmV/9pfC1LghFaZTWNu7Uaqa5hCgS/rj3r/h/kOKV0VIAvRJ
-        hlx7WNu5pKcuoQ==
-        =in60
+        mQENBFuY1k4BCADHDdkf6r43rMoFiG9htoPv8vKFQIlqDs4LXDqf6NIcQqxUJbic
+        0tuQfO84QV+TZzuKG2IMghFbTkJVziiThrIHZx9NdD9wKQZwoIeaNMAQ5mX0i+YX
+        bnTtlZHWgHS9+WPQGOkcNdNFsrT17vEREfhXWUmlcAqWt9TJ07d2M8aBOEVAMrIH
+        vxzq9BdEEp2v9pD4VkGt+0nO57IMUHkDVV4VLblMmf9PqY+GZ8eHV5bFJ0L4Kl4D
+        bPkLfkQkaXbrWwLg++3XUCNYVoHo0FP58OKEhv7CpnnI8COTqemWKq5QNPk/HHvl
+        40mzQye3pieM4M8p8g57sAmSLFWJRXO9wTZNABEBAAG0J2hvbWU6dG9tIE9CUyBQ
+        cm9qZWN0IDxob21lOnRvbUBwcml2YXRlPokBPwQTAQIAKQUCW5jWTgIbAwUJBB6w
+        AAcLCQgHAwIBBhUIAgkKCwQWAgMBAh4BAheAAAoJEDIgIpHrxGj6EVoIAJJAbRKf
+        jjsZ+QRT/1aiWqKSnffiWIR1k6h1mVxJLeHKHk7NQ23hqN5F1LE88Mlu+pXGWguk
+        /S2YZKq29jkXpI9u6UPfx1KbgIwNHBrmANt+f+n8mNr+ec2Ev9u/m6UUQgytiHPP
+        X5VTPolCOamZGZDs056j/XGGlowOiyBJA64f+1jsQwb19Wz1JBRC/VbwdHGt2IR4
+        7zDkenZpJqipfbSkaNl5epJ/eDKjdktWruuC+k2gxzr+SDkyRlUNcRmJ7rvuArST
+        PG5H2UIZEEIboZsviGAdi4gvdNWVDJ2wHrg3wFyOrsKtcmPxEboQb0uxAtyK9wo9
+        dc1GiwORw1dKo0yJARwEEwECAAYFAluY1k4ACgkQv/X5J7hHHOuSIAgAjAjMuhdb
+        y3ufC/24QqPDy+prJRQNehdj2ZSQcDW79AhkZXiTMyQsSG3VqPDWdxTpWfM9wesw
+        4WHbbWOpscBjXhqL8OIabjwBk5n7koUbxBD0yWxP3Hn/eNKEfl+o/6aUj3Kf/s+j
+        gPQ1lbsximA+TqZC4mU8lBkGJhORbrZeY/Dbi0xerz/laQYQqX5daWmSKtweu/GC
+        vwXZGkwTIETPlDfLqzpIY7LmCMofzkpY5izl93+cy6l9RRxeUMdkPFGJvdCCohYw
+        9iC1qkGJ1ghbzOGYTcu3qN8PSGhhF1P3GQY5quFYmwEIVtG0F6IJ56QaSXuMtKzw
+        d4bcxmpC0IWffQ==
+        =/a6Y
         -----END PGP PUBLIC KEY BLOCK-----
         </pubkey>
         </keyinfo>
     http_version: 
-  recorded_at: Tue, 21 Aug 2018 14:39:12 GMT
+  recorded_at: Wed, 12 Sep 2018 12:04:01 GMT
 - request:
     method: get
     uri: http://backend:5352/build/home:tom:branches:ProjectWithRepo:Update/_result?view=summary
@@ -2551,10 +2301,8 @@ http_interactions:
       encoding: US-ASCII
       string: ''
     headers:
-      Content-Type:
-      - text/plain
       Accept-Encoding:
-      - identity
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
       - "*/*"
       User-Agent:
@@ -2581,7 +2329,7 @@ http_interactions:
           </result>
         </resultlist>
     http_version: 
-  recorded_at: Tue, 21 Aug 2018 14:39:13 GMT
+  recorded_at: Wed, 12 Sep 2018 12:04:01 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:tom:branches:ProjectWithRepo:Update/ProjectWithRepo_package
@@ -2607,19 +2355,19 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '795'
+      - '793'
     body:
       encoding: UTF-8
       string: |
-        <directory name="ProjectWithRepo_package" rev="12" vrev="12" srcmd5="08d09eda7595c7a4a9225e3e1c5992cf">
-          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" rev="def3bf67a426e8013de578376d34f554" srcmd5="def3bf67a426e8013de578376d34f554" baserev="def3bf67a426e8013de578376d34f554" xsrcmd5="f5a7bab245bc8b8a4e528b8b441fc607" lsrcmd5="08d09eda7595c7a4a9225e3e1c5992cf" />
-          <entry name="DUMMY_FILE" md5="275876e34cf609db118f3d84b799a790" size="5" mtime="1534862270" />
-          <entry name="_config" md5="1a05ff51cbc0ee790ddd75020dc14e94" size="51" mtime="1534862349" />
-          <entry name="_link" md5="54e623c39791ca9f3db24ee0fb436950" size="169" mtime="1534862351" />
-          <entry name="somefile.txt" md5="9044d1ae989e292a5e19128f57de9e21" size="57" mtime="1534862349" />
+        <directory name="ProjectWithRepo_package" rev="6" vrev="6" srcmd5="6f64842b339b86054358d876db6f6823">
+          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" rev="1fe06d22b38ce06632413dcc7aeee49c" srcmd5="1fe06d22b38ce06632413dcc7aeee49c" baserev="1fe06d22b38ce06632413dcc7aeee49c" xsrcmd5="4c8313d77815d19b1b1dd8af509b8861" lsrcmd5="6f64842b339b86054358d876db6f6823" />
+          <entry name="DUMMY_FILE" md5="275876e34cf609db118f3d84b799a790" size="5" mtime="1536751453" />
+          <entry name="_config" md5="e76512ea4577d0a559788f9bed2f9ad8" size="58" mtime="1536753837" />
+          <entry name="_link" md5="90e4f5a99633a426e6ec73e94204889b" size="169" mtime="1536753839" />
+          <entry name="somefile.txt" md5="d5ff6c3db27c57b3d9dbc5df28a95a21" size="64" mtime="1536753837" />
         </directory>
     http_version: 
-  recorded_at: Tue, 21 Aug 2018 14:39:13 GMT
+  recorded_at: Wed, 12 Sep 2018 12:04:02 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:tom:branches:ProjectWithRepo:Update/ProjectWithRepo_package
@@ -2645,19 +2393,19 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '795'
+      - '793'
     body:
       encoding: UTF-8
       string: |
-        <directory name="ProjectWithRepo_package" rev="12" vrev="12" srcmd5="08d09eda7595c7a4a9225e3e1c5992cf">
-          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" rev="def3bf67a426e8013de578376d34f554" srcmd5="def3bf67a426e8013de578376d34f554" baserev="def3bf67a426e8013de578376d34f554" xsrcmd5="f5a7bab245bc8b8a4e528b8b441fc607" lsrcmd5="08d09eda7595c7a4a9225e3e1c5992cf" />
-          <entry name="DUMMY_FILE" md5="275876e34cf609db118f3d84b799a790" size="5" mtime="1534862270" />
-          <entry name="_config" md5="1a05ff51cbc0ee790ddd75020dc14e94" size="51" mtime="1534862349" />
-          <entry name="_link" md5="54e623c39791ca9f3db24ee0fb436950" size="169" mtime="1534862351" />
-          <entry name="somefile.txt" md5="9044d1ae989e292a5e19128f57de9e21" size="57" mtime="1534862349" />
+        <directory name="ProjectWithRepo_package" rev="6" vrev="6" srcmd5="6f64842b339b86054358d876db6f6823">
+          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" rev="1fe06d22b38ce06632413dcc7aeee49c" srcmd5="1fe06d22b38ce06632413dcc7aeee49c" baserev="1fe06d22b38ce06632413dcc7aeee49c" xsrcmd5="4c8313d77815d19b1b1dd8af509b8861" lsrcmd5="6f64842b339b86054358d876db6f6823" />
+          <entry name="DUMMY_FILE" md5="275876e34cf609db118f3d84b799a790" size="5" mtime="1536751453" />
+          <entry name="_config" md5="e76512ea4577d0a559788f9bed2f9ad8" size="58" mtime="1536753837" />
+          <entry name="_link" md5="90e4f5a99633a426e6ec73e94204889b" size="169" mtime="1536753839" />
+          <entry name="somefile.txt" md5="d5ff6c3db27c57b3d9dbc5df28a95a21" size="64" mtime="1536753837" />
         </directory>
     http_version: 
-  recorded_at: Tue, 21 Aug 2018 14:39:13 GMT
+  recorded_at: Wed, 12 Sep 2018 12:04:02 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:tom:branches:ProjectWithRepo:Update/ProjectWithRepo_package
@@ -2683,19 +2431,19 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '795'
+      - '793'
     body:
       encoding: UTF-8
       string: |
-        <directory name="ProjectWithRepo_package" rev="12" vrev="12" srcmd5="08d09eda7595c7a4a9225e3e1c5992cf">
-          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" rev="def3bf67a426e8013de578376d34f554" srcmd5="def3bf67a426e8013de578376d34f554" baserev="def3bf67a426e8013de578376d34f554" xsrcmd5="f5a7bab245bc8b8a4e528b8b441fc607" lsrcmd5="08d09eda7595c7a4a9225e3e1c5992cf" />
-          <entry name="DUMMY_FILE" md5="275876e34cf609db118f3d84b799a790" size="5" mtime="1534862270" />
-          <entry name="_config" md5="1a05ff51cbc0ee790ddd75020dc14e94" size="51" mtime="1534862349" />
-          <entry name="_link" md5="54e623c39791ca9f3db24ee0fb436950" size="169" mtime="1534862351" />
-          <entry name="somefile.txt" md5="9044d1ae989e292a5e19128f57de9e21" size="57" mtime="1534862349" />
+        <directory name="ProjectWithRepo_package" rev="6" vrev="6" srcmd5="6f64842b339b86054358d876db6f6823">
+          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" rev="1fe06d22b38ce06632413dcc7aeee49c" srcmd5="1fe06d22b38ce06632413dcc7aeee49c" baserev="1fe06d22b38ce06632413dcc7aeee49c" xsrcmd5="4c8313d77815d19b1b1dd8af509b8861" lsrcmd5="6f64842b339b86054358d876db6f6823" />
+          <entry name="DUMMY_FILE" md5="275876e34cf609db118f3d84b799a790" size="5" mtime="1536751453" />
+          <entry name="_config" md5="e76512ea4577d0a559788f9bed2f9ad8" size="58" mtime="1536753837" />
+          <entry name="_link" md5="90e4f5a99633a426e6ec73e94204889b" size="169" mtime="1536753839" />
+          <entry name="somefile.txt" md5="d5ff6c3db27c57b3d9dbc5df28a95a21" size="64" mtime="1536753837" />
         </directory>
     http_version: 
-  recorded_at: Tue, 21 Aug 2018 14:39:14 GMT
+  recorded_at: Wed, 12 Sep 2018 12:04:02 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:tom:branches:ProjectWithRepo:Update/ProjectWithRepo_package?cmd=diff&expand=1&filelimit=10000&opackage=ProjectWithRepo_package&oproject=ProjectWithRepo:Update&tarlimit=10000
@@ -2742,7 +2490,7 @@ http_interactions:
         +dummy
         \ No newline at end of file
     http_version: 
-  recorded_at: Tue, 21 Aug 2018 14:39:14 GMT
+  recorded_at: Wed, 12 Sep 2018 12:04:02 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:tom:branches:ProjectWithRepo:Update/ProjectWithRepo_package?expand=1
@@ -2768,18 +2516,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '688'
+      - '687'
     body:
       encoding: UTF-8
       string: |
-        <directory name="ProjectWithRepo_package" rev="f5a7bab245bc8b8a4e528b8b441fc607" vrev="12" srcmd5="f5a7bab245bc8b8a4e528b8b441fc607">
-          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" rev="def3bf67a426e8013de578376d34f554" srcmd5="def3bf67a426e8013de578376d34f554" baserev="def3bf67a426e8013de578376d34f554" lsrcmd5="08d09eda7595c7a4a9225e3e1c5992cf" />
-          <entry name="DUMMY_FILE" md5="275876e34cf609db118f3d84b799a790" size="5" mtime="1534862270" />
-          <entry name="_config" md5="1a05ff51cbc0ee790ddd75020dc14e94" size="51" mtime="1534862349" />
-          <entry name="somefile.txt" md5="9044d1ae989e292a5e19128f57de9e21" size="57" mtime="1534862349" />
+        <directory name="ProjectWithRepo_package" rev="4c8313d77815d19b1b1dd8af509b8861" vrev="6" srcmd5="4c8313d77815d19b1b1dd8af509b8861">
+          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" rev="1fe06d22b38ce06632413dcc7aeee49c" srcmd5="1fe06d22b38ce06632413dcc7aeee49c" baserev="1fe06d22b38ce06632413dcc7aeee49c" lsrcmd5="6f64842b339b86054358d876db6f6823" />
+          <entry name="DUMMY_FILE" md5="275876e34cf609db118f3d84b799a790" size="5" mtime="1536751453" />
+          <entry name="_config" md5="e76512ea4577d0a559788f9bed2f9ad8" size="58" mtime="1536753837" />
+          <entry name="somefile.txt" md5="d5ff6c3db27c57b3d9dbc5df28a95a21" size="64" mtime="1536753837" />
         </directory>
     http_version: 
-  recorded_at: Tue, 21 Aug 2018 14:39:14 GMT
+  recorded_at: Wed, 12 Sep 2018 12:04:02 GMT
 - request:
     method: get
     uri: http://backend:5352/build/home:tom:branches:ProjectWithRepo:Update/_result?code=unresolvable&view=status
@@ -2813,7 +2561,7 @@ http_interactions:
           <result project="home:tom:branches:ProjectWithRepo:Update" repository="repository_2" arch="i586" code="broken" state="broken" details="no build type (ProjectWithRepo:Update)" />
         </resultlist>
     http_version: 
-  recorded_at: Tue, 21 Aug 2018 14:39:14 GMT
+  recorded_at: Wed, 12 Sep 2018 12:04:02 GMT
 - request:
     method: get
     uri: http://backend:5352/build/home:tom:branches:ProjectWithRepo:Update/_result?view=summary
@@ -2821,10 +2569,8 @@ http_interactions:
       encoding: US-ASCII
       string: ''
     headers:
-      Content-Type:
-      - text/plain
       Accept-Encoding:
-      - identity
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
       - "*/*"
       User-Agent:
@@ -2851,7 +2597,7 @@ http_interactions:
           </result>
         </resultlist>
     http_version: 
-  recorded_at: Tue, 21 Aug 2018 14:39:14 GMT
+  recorded_at: Wed, 12 Sep 2018 12:04:02 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:tom:branches:ProjectWithRepo:Update/ProjectWithRepo_package
@@ -2877,22 +2623,22 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '795'
+      - '793'
     body:
       encoding: UTF-8
       string: |
-        <directory name="ProjectWithRepo_package" rev="12" vrev="12" srcmd5="08d09eda7595c7a4a9225e3e1c5992cf">
-          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" rev="def3bf67a426e8013de578376d34f554" srcmd5="def3bf67a426e8013de578376d34f554" baserev="def3bf67a426e8013de578376d34f554" xsrcmd5="f5a7bab245bc8b8a4e528b8b441fc607" lsrcmd5="08d09eda7595c7a4a9225e3e1c5992cf" />
-          <entry name="DUMMY_FILE" md5="275876e34cf609db118f3d84b799a790" size="5" mtime="1534862270" />
-          <entry name="_config" md5="1a05ff51cbc0ee790ddd75020dc14e94" size="51" mtime="1534862349" />
-          <entry name="_link" md5="54e623c39791ca9f3db24ee0fb436950" size="169" mtime="1534862351" />
-          <entry name="somefile.txt" md5="9044d1ae989e292a5e19128f57de9e21" size="57" mtime="1534862349" />
+        <directory name="ProjectWithRepo_package" rev="6" vrev="6" srcmd5="6f64842b339b86054358d876db6f6823">
+          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" rev="1fe06d22b38ce06632413dcc7aeee49c" srcmd5="1fe06d22b38ce06632413dcc7aeee49c" baserev="1fe06d22b38ce06632413dcc7aeee49c" xsrcmd5="4c8313d77815d19b1b1dd8af509b8861" lsrcmd5="6f64842b339b86054358d876db6f6823" />
+          <entry name="DUMMY_FILE" md5="275876e34cf609db118f3d84b799a790" size="5" mtime="1536751453" />
+          <entry name="_config" md5="e76512ea4577d0a559788f9bed2f9ad8" size="58" mtime="1536753837" />
+          <entry name="_link" md5="90e4f5a99633a426e6ec73e94204889b" size="169" mtime="1536753839" />
+          <entry name="somefile.txt" md5="d5ff6c3db27c57b3d9dbc5df28a95a21" size="64" mtime="1536753837" />
         </directory>
     http_version: 
-  recorded_at: Tue, 21 Aug 2018 14:39:16 GMT
+  recorded_at: Wed, 12 Sep 2018 12:04:04 GMT
 - request:
     method: post
-    uri: http://backend:5352/source/home:tom:branches:ProjectWithRepo:Update/ProjectWithRepo_package?cmd=diff&expand=1&filelimit=10000&opackage=ProjectWithRepo_package&oproject=ProjectWithRepo:Update&rev=f5a7bab245bc8b8a4e528b8b441fc607&tarlimit=10000&view=xml&withissues=1
+    uri: http://backend:5352/source/home:tom:branches:ProjectWithRepo:Update/ProjectWithRepo_package?cmd=diff&expand=1&filelimit=10000&opackage=ProjectWithRepo_package&oproject=ProjectWithRepo:Update&rev=4c8313d77815d19b1b1dd8af509b8861&tarlimit=10000&view=xml&withissues=1
     body:
       encoding: UTF-8
       string: ''
@@ -2917,13 +2663,13 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '612'
+      - '611'
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="429ea8bb29feb3d1a7ae1b1ac67a4a73">
-          <old project="ProjectWithRepo:Update" package="ProjectWithRepo_package" rev="40" srcmd5="def3bf67a426e8013de578376d34f554" />
-          <new project="home:tom:branches:ProjectWithRepo:Update" package="ProjectWithRepo_package" rev="f5a7bab245bc8b8a4e528b8b441fc607" srcmd5="f5a7bab245bc8b8a4e528b8b441fc607" />
+        <sourcediff key="2d56d77774c45560122081162e3937e0">
+          <old project="ProjectWithRepo:Update" package="ProjectWithRepo_package" rev="6" srcmd5="1fe06d22b38ce06632413dcc7aeee49c" />
+          <new project="home:tom:branches:ProjectWithRepo:Update" package="ProjectWithRepo_package" rev="4c8313d77815d19b1b1dd8af509b8861" srcmd5="4c8313d77815d19b1b1dd8af509b8861" />
           <files>
             <file state="added">
               <new name="DUMMY_FILE" md5="275876e34cf609db118f3d84b799a790" size="5" />
@@ -2937,7 +2683,7 @@ http_interactions:
           </issues>
         </sourcediff>
     http_version: 
-  recorded_at: Tue, 21 Aug 2018 14:39:16 GMT
+  recorded_at: Wed, 12 Sep 2018 12:04:04 GMT
 - request:
     method: get
     uri: http://backend:5352/build/home:tom:branches:ProjectWithRepo:Update/_result?package=ProjectWithRepo_package&view=status
@@ -2945,10 +2691,8 @@ http_interactions:
       encoding: US-ASCII
       string: ''
     headers:
-      Content-Type:
-      - text/plain
       Accept-Encoding:
-      - identity
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
       - "*/*"
       User-Agent:
@@ -2973,7 +2717,7 @@ http_interactions:
           <result project="home:tom:branches:ProjectWithRepo:Update" repository="repository_2" arch="i586" code="broken" state="broken" details="no build type (ProjectWithRepo:Update)" />
         </resultlist>
     http_version: 
-  recorded_at: Tue, 21 Aug 2018 14:39:16 GMT
+  recorded_at: Wed, 12 Sep 2018 12:04:04 GMT
 - request:
     method: get
     uri: http://backend:5352/build/home:tom:branches:ProjectWithRepo:Update/_result?locallink=1&multibuild=1&package=ProjectWithRepo_package&view=status
@@ -2981,10 +2725,8 @@ http_interactions:
       encoding: US-ASCII
       string: ''
     headers:
-      Content-Type:
-      - text/plain
       Accept-Encoding:
-      - identity
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
       - "*/*"
       User-Agent:
@@ -3009,7 +2751,7 @@ http_interactions:
           <result project="home:tom:branches:ProjectWithRepo:Update" repository="repository_2" arch="i586" code="broken" state="broken" details="no build type (ProjectWithRepo:Update)" />
         </resultlist>
     http_version: 
-  recorded_at: Tue, 21 Aug 2018 14:39:16 GMT
+  recorded_at: Wed, 12 Sep 2018 12:04:04 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:tom:branches:ProjectWithRepo:Update/ProjectWithRepo_package
@@ -3035,22 +2777,22 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '795'
+      - '793'
     body:
       encoding: UTF-8
       string: |
-        <directory name="ProjectWithRepo_package" rev="12" vrev="12" srcmd5="08d09eda7595c7a4a9225e3e1c5992cf">
-          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" rev="def3bf67a426e8013de578376d34f554" srcmd5="def3bf67a426e8013de578376d34f554" baserev="def3bf67a426e8013de578376d34f554" xsrcmd5="f5a7bab245bc8b8a4e528b8b441fc607" lsrcmd5="08d09eda7595c7a4a9225e3e1c5992cf" />
-          <entry name="DUMMY_FILE" md5="275876e34cf609db118f3d84b799a790" size="5" mtime="1534862270" />
-          <entry name="_config" md5="1a05ff51cbc0ee790ddd75020dc14e94" size="51" mtime="1534862349" />
-          <entry name="_link" md5="54e623c39791ca9f3db24ee0fb436950" size="169" mtime="1534862351" />
-          <entry name="somefile.txt" md5="9044d1ae989e292a5e19128f57de9e21" size="57" mtime="1534862349" />
+        <directory name="ProjectWithRepo_package" rev="6" vrev="6" srcmd5="6f64842b339b86054358d876db6f6823">
+          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" rev="1fe06d22b38ce06632413dcc7aeee49c" srcmd5="1fe06d22b38ce06632413dcc7aeee49c" baserev="1fe06d22b38ce06632413dcc7aeee49c" xsrcmd5="4c8313d77815d19b1b1dd8af509b8861" lsrcmd5="6f64842b339b86054358d876db6f6823" />
+          <entry name="DUMMY_FILE" md5="275876e34cf609db118f3d84b799a790" size="5" mtime="1536751453" />
+          <entry name="_config" md5="e76512ea4577d0a559788f9bed2f9ad8" size="58" mtime="1536753837" />
+          <entry name="_link" md5="90e4f5a99633a426e6ec73e94204889b" size="169" mtime="1536753839" />
+          <entry name="somefile.txt" md5="d5ff6c3db27c57b3d9dbc5df28a95a21" size="64" mtime="1536753837" />
         </directory>
     http_version: 
-  recorded_at: Tue, 21 Aug 2018 14:39:17 GMT
+  recorded_at: Wed, 12 Sep 2018 12:04:05 GMT
 - request:
     method: get
-    uri: http://backend:5352/source/home:tom:branches:ProjectWithRepo:Update/ProjectWithRepo_package?expand=1&rev=f5a7bab245bc8b8a4e528b8b441fc607
+    uri: http://backend:5352/source/home:tom:branches:ProjectWithRepo:Update/ProjectWithRepo_package?expand=1&rev=4c8313d77815d19b1b1dd8af509b8861
     body:
       encoding: US-ASCII
       string: ''
@@ -3077,17 +2819,17 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="ProjectWithRepo_package" rev="f5a7bab245bc8b8a4e528b8b441fc607" srcmd5="f5a7bab245bc8b8a4e528b8b441fc607">
-          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" rev="def3bf67a426e8013de578376d34f554" srcmd5="def3bf67a426e8013de578376d34f554" baserev="def3bf67a426e8013de578376d34f554" lsrcmd5="08d09eda7595c7a4a9225e3e1c5992cf" />
-          <entry name="DUMMY_FILE" md5="275876e34cf609db118f3d84b799a790" size="5" mtime="1534862270" />
-          <entry name="_config" md5="1a05ff51cbc0ee790ddd75020dc14e94" size="51" mtime="1534862349" />
-          <entry name="somefile.txt" md5="9044d1ae989e292a5e19128f57de9e21" size="57" mtime="1534862349" />
+        <directory name="ProjectWithRepo_package" rev="4c8313d77815d19b1b1dd8af509b8861" srcmd5="4c8313d77815d19b1b1dd8af509b8861">
+          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" rev="1fe06d22b38ce06632413dcc7aeee49c" srcmd5="1fe06d22b38ce06632413dcc7aeee49c" baserev="1fe06d22b38ce06632413dcc7aeee49c" lsrcmd5="6f64842b339b86054358d876db6f6823" />
+          <entry name="DUMMY_FILE" md5="275876e34cf609db118f3d84b799a790" size="5" mtime="1536751453" />
+          <entry name="_config" md5="e76512ea4577d0a559788f9bed2f9ad8" size="58" mtime="1536753837" />
+          <entry name="somefile.txt" md5="d5ff6c3db27c57b3d9dbc5df28a95a21" size="64" mtime="1536753837" />
         </directory>
     http_version: 
-  recorded_at: Tue, 21 Aug 2018 14:39:17 GMT
+  recorded_at: Wed, 12 Sep 2018 12:04:05 GMT
 - request:
     method: get
-    uri: http://backend:5352/source/home:tom:branches:ProjectWithRepo:Update/ProjectWithRepo_package?expand=1&rev=f5a7bab245bc8b8a4e528b8b441fc607
+    uri: http://backend:5352/source/home:tom:branches:ProjectWithRepo:Update/ProjectWithRepo_package?expand=1&rev=4c8313d77815d19b1b1dd8af509b8861
     body:
       encoding: US-ASCII
       string: ''
@@ -3114,14 +2856,14 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="ProjectWithRepo_package" rev="f5a7bab245bc8b8a4e528b8b441fc607" srcmd5="f5a7bab245bc8b8a4e528b8b441fc607">
-          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" rev="def3bf67a426e8013de578376d34f554" srcmd5="def3bf67a426e8013de578376d34f554" baserev="def3bf67a426e8013de578376d34f554" lsrcmd5="08d09eda7595c7a4a9225e3e1c5992cf" />
-          <entry name="DUMMY_FILE" md5="275876e34cf609db118f3d84b799a790" size="5" mtime="1534862270" />
-          <entry name="_config" md5="1a05ff51cbc0ee790ddd75020dc14e94" size="51" mtime="1534862349" />
-          <entry name="somefile.txt" md5="9044d1ae989e292a5e19128f57de9e21" size="57" mtime="1534862349" />
+        <directory name="ProjectWithRepo_package" rev="4c8313d77815d19b1b1dd8af509b8861" srcmd5="4c8313d77815d19b1b1dd8af509b8861">
+          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" rev="1fe06d22b38ce06632413dcc7aeee49c" srcmd5="1fe06d22b38ce06632413dcc7aeee49c" baserev="1fe06d22b38ce06632413dcc7aeee49c" lsrcmd5="6f64842b339b86054358d876db6f6823" />
+          <entry name="DUMMY_FILE" md5="275876e34cf609db118f3d84b799a790" size="5" mtime="1536751453" />
+          <entry name="_config" md5="e76512ea4577d0a559788f9bed2f9ad8" size="58" mtime="1536753837" />
+          <entry name="somefile.txt" md5="d5ff6c3db27c57b3d9dbc5df28a95a21" size="64" mtime="1536753837" />
         </directory>
     http_version: 
-  recorded_at: Tue, 21 Aug 2018 14:39:17 GMT
+  recorded_at: Wed, 12 Sep 2018 12:04:05 GMT
 - request:
     method: put
     uri: http://backend:5352/source/MaintenanceProject:0/_meta?requestid=1&user=maintenance_coord
@@ -3176,7 +2918,7 @@ http_interactions:
           </publish>
         </project>
     http_version: 
-  recorded_at: Tue, 21 Aug 2018 14:39:17 GMT
+  recorded_at: Wed, 12 Sep 2018 12:04:05 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:tom:branches:ProjectWithRepo:Update/ProjectWithRepo_package
@@ -3202,19 +2944,19 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '795'
+      - '793'
     body:
       encoding: UTF-8
       string: |
-        <directory name="ProjectWithRepo_package" rev="12" vrev="12" srcmd5="08d09eda7595c7a4a9225e3e1c5992cf">
-          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" rev="def3bf67a426e8013de578376d34f554" srcmd5="def3bf67a426e8013de578376d34f554" baserev="def3bf67a426e8013de578376d34f554" xsrcmd5="f5a7bab245bc8b8a4e528b8b441fc607" lsrcmd5="08d09eda7595c7a4a9225e3e1c5992cf" />
-          <entry name="DUMMY_FILE" md5="275876e34cf609db118f3d84b799a790" size="5" mtime="1534862270" />
-          <entry name="_config" md5="1a05ff51cbc0ee790ddd75020dc14e94" size="51" mtime="1534862349" />
-          <entry name="_link" md5="54e623c39791ca9f3db24ee0fb436950" size="169" mtime="1534862351" />
-          <entry name="somefile.txt" md5="9044d1ae989e292a5e19128f57de9e21" size="57" mtime="1534862349" />
+        <directory name="ProjectWithRepo_package" rev="6" vrev="6" srcmd5="6f64842b339b86054358d876db6f6823">
+          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" rev="1fe06d22b38ce06632413dcc7aeee49c" srcmd5="1fe06d22b38ce06632413dcc7aeee49c" baserev="1fe06d22b38ce06632413dcc7aeee49c" xsrcmd5="4c8313d77815d19b1b1dd8af509b8861" lsrcmd5="6f64842b339b86054358d876db6f6823" />
+          <entry name="DUMMY_FILE" md5="275876e34cf609db118f3d84b799a790" size="5" mtime="1536751453" />
+          <entry name="_config" md5="e76512ea4577d0a559788f9bed2f9ad8" size="58" mtime="1536753837" />
+          <entry name="_link" md5="90e4f5a99633a426e6ec73e94204889b" size="169" mtime="1536753839" />
+          <entry name="somefile.txt" md5="d5ff6c3db27c57b3d9dbc5df28a95a21" size="64" mtime="1536753837" />
         </directory>
     http_version: 
-  recorded_at: Tue, 21 Aug 2018 14:39:17 GMT
+  recorded_at: Wed, 12 Sep 2018 12:04:05 GMT
 - request:
     method: post
     uri: http://backend:5352/search/package/id?match=(linkinfo/@package=%22ProjectWithRepo_package%22%20and%20linkinfo/@project=%22ProjectWithRepo:Update%22%20and%20starts-with(@project,%22MaintenanceProject:%22))
@@ -3250,7 +2992,7 @@ http_interactions:
           <package name="ProjectWithRepo_package.ProjectWithRepo_Update" project="MaintenanceProject:0" />
         </collection>
     http_version: 
-  recorded_at: Tue, 21 Aug 2018 14:39:17 GMT
+  recorded_at: Wed, 12 Sep 2018 12:04:05 GMT
 - request:
     method: post
     uri: http://backend:5352/search/package/id?match=(linkinfo/@package=%22ProjectWithRepo_package%22%20and%20linkinfo/@project=%22ProjectWithRepo%22%20and%20@project=%22ProjectWithRepo%22)
@@ -3285,7 +3027,7 @@ http_interactions:
         <collection>
         </collection>
     http_version: 
-  recorded_at: Tue, 21 Aug 2018 14:39:17 GMT
+  recorded_at: Wed, 12 Sep 2018 12:04:05 GMT
 - request:
     method: put
     uri: http://backend:5352/source/MaintenanceProject:0/ProjectWithRepo_package.ProjectWithRepo_Update/_meta?user=maintenance_coord
@@ -3293,8 +3035,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="ProjectWithRepo_package.ProjectWithRepo_Update" project="MaintenanceProject:0">
-          <title>Antic Hay</title>
-          <description>A eaque voluptas optio.</description>
+          <title>The Widening Gyre</title>
+          <description>Cupiditate neque nihil consequatur.</description>
           <releasename>ProjectWithRepo_package</releasename>
         </package>
     headers:
@@ -3316,17 +3058,17 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '239'
+      - '259'
     body:
       encoding: UTF-8
       string: |
         <package name="ProjectWithRepo_package.ProjectWithRepo_Update" project="MaintenanceProject:0">
-          <title>Antic Hay</title>
-          <description>A eaque voluptas optio.</description>
+          <title>The Widening Gyre</title>
+          <description>Cupiditate neque nihil consequatur.</description>
           <releasename>ProjectWithRepo_package</releasename>
         </package>
     http_version: 
-  recorded_at: Tue, 21 Aug 2018 14:39:17 GMT
+  recorded_at: Wed, 12 Sep 2018 12:04:05 GMT
 - request:
     method: post
     uri: http://backend:5352/source/MaintenanceProject:0/ProjectWithRepo_package.ProjectWithRepo_Update?cmd=branch&extendvrev=1&noservice=1&opackage=ProjectWithRepo_package&oproject=ProjectWithRepo:Update&user=maintenance_coord
@@ -3358,16 +3100,16 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <revision rev="5" vrev="5">
-          <srcmd5>7922ce81d1cafc61978abc010f9e2ba8</srcmd5>
+        <revision rev="9" vrev="9">
+          <srcmd5>478f76e51aa8ad2105d6f2a7c70a71df</srcmd5>
           <version>unknown</version>
-          <time>1534862357</time>
+          <time>1536753845</time>
           <user>maintenance_coord</user>
           <comment></comment>
           <requestid/>
         </revision>
     http_version: 
-  recorded_at: Tue, 21 Aug 2018 14:39:17 GMT
+  recorded_at: Wed, 12 Sep 2018 12:04:05 GMT
 - request:
     method: put
     uri: http://backend:5352/source/MaintenanceProject:0/ProjectWithRepo_package.ProjectWithRepo_Update/_meta?user=maintenance_coord
@@ -3375,8 +3117,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="ProjectWithRepo_package.ProjectWithRepo_Update" project="MaintenanceProject:0">
-          <title>Antic Hay</title>
-          <description>A eaque voluptas optio.</description>
+          <title>The Widening Gyre</title>
+          <description>Cupiditate neque nihil consequatur.</description>
           <releasename>ProjectWithRepo_package</releasename>
         </package>
     headers:
@@ -3398,17 +3140,17 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '239'
+      - '259'
     body:
       encoding: UTF-8
       string: |
         <package name="ProjectWithRepo_package.ProjectWithRepo_Update" project="MaintenanceProject:0">
-          <title>Antic Hay</title>
-          <description>A eaque voluptas optio.</description>
+          <title>The Widening Gyre</title>
+          <description>Cupiditate neque nihil consequatur.</description>
           <releasename>ProjectWithRepo_package</releasename>
         </package>
     http_version: 
-  recorded_at: Tue, 21 Aug 2018 14:39:17 GMT
+  recorded_at: Wed, 12 Sep 2018 12:04:05 GMT
 - request:
     method: get
     uri: http://backend:5352/source/MaintenanceProject:0/ProjectWithRepo_package.ProjectWithRepo_Update
@@ -3438,14 +3180,14 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="ProjectWithRepo_package.ProjectWithRepo_Update" rev="5" vrev="5" srcmd5="7922ce81d1cafc61978abc010f9e2ba8">
-          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" srcmd5="def3bf67a426e8013de578376d34f554" baserev="def3bf67a426e8013de578376d34f554" xsrcmd5="c443e5a2a5dd0f28fd22ff7d8c3527a1" lsrcmd5="7922ce81d1cafc61978abc010f9e2ba8" />
-          <entry name="_config" md5="1a05ff51cbc0ee790ddd75020dc14e94" size="51" mtime="1534862349" />
-          <entry name="_link" md5="fc6315cf4d9e91ed369a097e83d59417" size="176" mtime="1534862357" />
-          <entry name="somefile.txt" md5="9044d1ae989e292a5e19128f57de9e21" size="57" mtime="1534862349" />
+        <directory name="ProjectWithRepo_package.ProjectWithRepo_Update" rev="9" vrev="9" srcmd5="478f76e51aa8ad2105d6f2a7c70a71df">
+          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" srcmd5="1fe06d22b38ce06632413dcc7aeee49c" baserev="1fe06d22b38ce06632413dcc7aeee49c" xsrcmd5="e6ff6888d08544c3b12eed46fcf1310e" lsrcmd5="478f76e51aa8ad2105d6f2a7c70a71df" />
+          <entry name="_config" md5="e76512ea4577d0a559788f9bed2f9ad8" size="58" mtime="1536753837" />
+          <entry name="_link" md5="a1f2d4062a5ea3a9a83bcf0195340932" size="175" mtime="1536753845" />
+          <entry name="somefile.txt" md5="d5ff6c3db27c57b3d9dbc5df28a95a21" size="64" mtime="1536753837" />
         </directory>
     http_version: 
-  recorded_at: Tue, 21 Aug 2018 14:39:17 GMT
+  recorded_at: Wed, 12 Sep 2018 12:04:05 GMT
 - request:
     method: get
     uri: http://backend:5352/source/MaintenanceProject:0/ProjectWithRepo_package.ProjectWithRepo_Update?view=info
@@ -3475,13 +3217,13 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <sourceinfo package="ProjectWithRepo_package.ProjectWithRepo_Update" rev="5" vrev="41.6" srcmd5="c443e5a2a5dd0f28fd22ff7d8c3527a1" lsrcmd5="7922ce81d1cafc61978abc010f9e2ba8" verifymd5="def3bf67a426e8013de578376d34f554">
+        <sourceinfo package="ProjectWithRepo_package.ProjectWithRepo_Update" rev="9" vrev="7.10" srcmd5="e6ff6888d08544c3b12eed46fcf1310e" lsrcmd5="478f76e51aa8ad2105d6f2a7c70a71df" verifymd5="1fe06d22b38ce06632413dcc7aeee49c">
           <error>bad build configuration, no build type defined or detected</error>
           <linked project="ProjectWithRepo:Update" package="ProjectWithRepo_package" />
           <linked project="ProjectWithRepo" package="ProjectWithRepo_package" />
         </sourceinfo>
     http_version: 
-  recorded_at: Tue, 21 Aug 2018 14:39:17 GMT
+  recorded_at: Wed, 12 Sep 2018 12:04:05 GMT
 - request:
     method: get
     uri: http://backend:5352/source/MaintenanceProject:0/ProjectWithRepo_package.ProjectWithRepo_Update
@@ -3511,14 +3253,14 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="ProjectWithRepo_package.ProjectWithRepo_Update" rev="5" vrev="5" srcmd5="7922ce81d1cafc61978abc010f9e2ba8">
-          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" srcmd5="def3bf67a426e8013de578376d34f554" baserev="def3bf67a426e8013de578376d34f554" xsrcmd5="c443e5a2a5dd0f28fd22ff7d8c3527a1" lsrcmd5="7922ce81d1cafc61978abc010f9e2ba8" />
-          <entry name="_config" md5="1a05ff51cbc0ee790ddd75020dc14e94" size="51" mtime="1534862349" />
-          <entry name="_link" md5="fc6315cf4d9e91ed369a097e83d59417" size="176" mtime="1534862357" />
-          <entry name="somefile.txt" md5="9044d1ae989e292a5e19128f57de9e21" size="57" mtime="1534862349" />
+        <directory name="ProjectWithRepo_package.ProjectWithRepo_Update" rev="9" vrev="9" srcmd5="478f76e51aa8ad2105d6f2a7c70a71df">
+          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" srcmd5="1fe06d22b38ce06632413dcc7aeee49c" baserev="1fe06d22b38ce06632413dcc7aeee49c" xsrcmd5="e6ff6888d08544c3b12eed46fcf1310e" lsrcmd5="478f76e51aa8ad2105d6f2a7c70a71df" />
+          <entry name="_config" md5="e76512ea4577d0a559788f9bed2f9ad8" size="58" mtime="1536753837" />
+          <entry name="_link" md5="a1f2d4062a5ea3a9a83bcf0195340932" size="175" mtime="1536753845" />
+          <entry name="somefile.txt" md5="d5ff6c3db27c57b3d9dbc5df28a95a21" size="64" mtime="1536753837" />
         </directory>
     http_version: 
-  recorded_at: Tue, 21 Aug 2018 14:39:17 GMT
+  recorded_at: Wed, 12 Sep 2018 12:04:05 GMT
 - request:
     method: post
     uri: http://backend:5352/source/MaintenanceProject:0/ProjectWithRepo_package.ProjectWithRepo_Update?cmd=diff&linkrev=base&onlyissues=1&orev=0&view=xml
@@ -3550,15 +3292,15 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="22401888f8e8f4aa98b140b40836da89">
+        <sourcediff key="7a33aa03e04e7a187015dd00ca9ccb3d">
           <old project="MaintenanceProject:0" package="ProjectWithRepo_package.ProjectWithRepo_Update" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e" />
-          <new project="MaintenanceProject:0" package="ProjectWithRepo_package.ProjectWithRepo_Update" rev="5" srcmd5="7922ce81d1cafc61978abc010f9e2ba8" />
+          <new project="MaintenanceProject:0" package="ProjectWithRepo_package.ProjectWithRepo_Update" rev="9" srcmd5="478f76e51aa8ad2105d6f2a7c70a71df" />
           <files />
           <issues>
           </issues>
         </sourcediff>
     http_version: 
-  recorded_at: Tue, 21 Aug 2018 14:39:17 GMT
+  recorded_at: Wed, 12 Sep 2018 12:04:06 GMT
 - request:
     method: post
     uri: http://backend:5352/source/MaintenanceProject:0/ProjectWithRepo_package.ProjectWithRepo_Update?cmd=linkdiff&linkrev=base&onlyissues=1&view=xml
@@ -3590,13 +3332,13 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="ca148e9fabc33d3ec7bf00197d908826">
-          <old project="ProjectWithRepo:Update" package="ProjectWithRepo_package" rev="def3bf67a426e8013de578376d34f554" srcmd5="def3bf67a426e8013de578376d34f554" />
-          <new project="MaintenanceProject:0" package="ProjectWithRepo_package.ProjectWithRepo_Update" rev="c443e5a2a5dd0f28fd22ff7d8c3527a1" srcmd5="c443e5a2a5dd0f28fd22ff7d8c3527a1" />
+        <sourcediff key="466e1cb8c8175a72d4e3fb1b7d5173c0">
+          <old project="ProjectWithRepo:Update" package="ProjectWithRepo_package" rev="1fe06d22b38ce06632413dcc7aeee49c" srcmd5="1fe06d22b38ce06632413dcc7aeee49c" />
+          <new project="MaintenanceProject:0" package="ProjectWithRepo_package.ProjectWithRepo_Update" rev="e6ff6888d08544c3b12eed46fcf1310e" srcmd5="e6ff6888d08544c3b12eed46fcf1310e" />
           <files />
         </sourcediff>
     http_version: 
-  recorded_at: Tue, 21 Aug 2018 14:39:17 GMT
+  recorded_at: Wed, 12 Sep 2018 12:04:06 GMT
 - request:
     method: put
     uri: http://backend:5352/source/MaintenanceProject:0/ProjectWithRepo_package.ProjectWithRepo_Update/_meta?user=maintenance_coord
@@ -3604,8 +3346,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="ProjectWithRepo_package.ProjectWithRepo_Update" project="MaintenanceProject:0">
-          <title>Antic Hay</title>
-          <description>A eaque voluptas optio.</description>
+          <title>The Widening Gyre</title>
+          <description>Cupiditate neque nihil consequatur.</description>
           <releasename>ProjectWithRepo_package</releasename>
           <build>
             <enable repository="ProjectWithRepo_Update"/>
@@ -3630,20 +3372,20 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '311'
+      - '331'
     body:
       encoding: UTF-8
       string: |
         <package name="ProjectWithRepo_package.ProjectWithRepo_Update" project="MaintenanceProject:0">
-          <title>Antic Hay</title>
-          <description>A eaque voluptas optio.</description>
+          <title>The Widening Gyre</title>
+          <description>Cupiditate neque nihil consequatur.</description>
           <releasename>ProjectWithRepo_package</releasename>
           <build>
             <enable repository="ProjectWithRepo_Update" />
           </build>
         </package>
     http_version: 
-  recorded_at: Tue, 21 Aug 2018 14:39:17 GMT
+  recorded_at: Wed, 12 Sep 2018 12:04:06 GMT
 - request:
     method: get
     uri: http://backend:5352/source/MaintenanceProject:0/ProjectWithRepo_package.ProjectWithRepo_Update
@@ -3673,14 +3415,14 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="ProjectWithRepo_package.ProjectWithRepo_Update" rev="5" vrev="5" srcmd5="7922ce81d1cafc61978abc010f9e2ba8">
-          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" srcmd5="def3bf67a426e8013de578376d34f554" baserev="def3bf67a426e8013de578376d34f554" xsrcmd5="c443e5a2a5dd0f28fd22ff7d8c3527a1" lsrcmd5="7922ce81d1cafc61978abc010f9e2ba8" />
-          <entry name="_config" md5="1a05ff51cbc0ee790ddd75020dc14e94" size="51" mtime="1534862349" />
-          <entry name="_link" md5="fc6315cf4d9e91ed369a097e83d59417" size="176" mtime="1534862357" />
-          <entry name="somefile.txt" md5="9044d1ae989e292a5e19128f57de9e21" size="57" mtime="1534862349" />
+        <directory name="ProjectWithRepo_package.ProjectWithRepo_Update" rev="9" vrev="9" srcmd5="478f76e51aa8ad2105d6f2a7c70a71df">
+          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" srcmd5="1fe06d22b38ce06632413dcc7aeee49c" baserev="1fe06d22b38ce06632413dcc7aeee49c" xsrcmd5="e6ff6888d08544c3b12eed46fcf1310e" lsrcmd5="478f76e51aa8ad2105d6f2a7c70a71df" />
+          <entry name="_config" md5="e76512ea4577d0a559788f9bed2f9ad8" size="58" mtime="1536753837" />
+          <entry name="_link" md5="a1f2d4062a5ea3a9a83bcf0195340932" size="175" mtime="1536753845" />
+          <entry name="somefile.txt" md5="d5ff6c3db27c57b3d9dbc5df28a95a21" size="64" mtime="1536753837" />
         </directory>
     http_version: 
-  recorded_at: Tue, 21 Aug 2018 14:39:17 GMT
+  recorded_at: Wed, 12 Sep 2018 12:04:06 GMT
 - request:
     method: get
     uri: http://backend:5352/source/MaintenanceProject:0/ProjectWithRepo_package.ProjectWithRepo_Update
@@ -3710,14 +3452,14 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="ProjectWithRepo_package.ProjectWithRepo_Update" rev="5" vrev="5" srcmd5="7922ce81d1cafc61978abc010f9e2ba8">
-          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" srcmd5="def3bf67a426e8013de578376d34f554" baserev="def3bf67a426e8013de578376d34f554" xsrcmd5="c443e5a2a5dd0f28fd22ff7d8c3527a1" lsrcmd5="7922ce81d1cafc61978abc010f9e2ba8" />
-          <entry name="_config" md5="1a05ff51cbc0ee790ddd75020dc14e94" size="51" mtime="1534862349" />
-          <entry name="_link" md5="fc6315cf4d9e91ed369a097e83d59417" size="176" mtime="1534862357" />
-          <entry name="somefile.txt" md5="9044d1ae989e292a5e19128f57de9e21" size="57" mtime="1534862349" />
+        <directory name="ProjectWithRepo_package.ProjectWithRepo_Update" rev="9" vrev="9" srcmd5="478f76e51aa8ad2105d6f2a7c70a71df">
+          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" srcmd5="1fe06d22b38ce06632413dcc7aeee49c" baserev="1fe06d22b38ce06632413dcc7aeee49c" xsrcmd5="e6ff6888d08544c3b12eed46fcf1310e" lsrcmd5="478f76e51aa8ad2105d6f2a7c70a71df" />
+          <entry name="_config" md5="e76512ea4577d0a559788f9bed2f9ad8" size="58" mtime="1536753837" />
+          <entry name="_link" md5="a1f2d4062a5ea3a9a83bcf0195340932" size="175" mtime="1536753845" />
+          <entry name="somefile.txt" md5="d5ff6c3db27c57b3d9dbc5df28a95a21" size="64" mtime="1536753837" />
         </directory>
     http_version: 
-  recorded_at: Tue, 21 Aug 2018 14:39:18 GMT
+  recorded_at: Wed, 12 Sep 2018 12:04:06 GMT
 - request:
     method: get
     uri: http://backend:5352/source/MaintenanceProject:0/ProjectWithRepo_package.ProjectWithRepo_Update
@@ -3747,14 +3489,14 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="ProjectWithRepo_package.ProjectWithRepo_Update" rev="5" vrev="5" srcmd5="7922ce81d1cafc61978abc010f9e2ba8">
-          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" srcmd5="def3bf67a426e8013de578376d34f554" baserev="def3bf67a426e8013de578376d34f554" xsrcmd5="c443e5a2a5dd0f28fd22ff7d8c3527a1" lsrcmd5="7922ce81d1cafc61978abc010f9e2ba8" />
-          <entry name="_config" md5="1a05ff51cbc0ee790ddd75020dc14e94" size="51" mtime="1534862349" />
-          <entry name="_link" md5="fc6315cf4d9e91ed369a097e83d59417" size="176" mtime="1534862357" />
-          <entry name="somefile.txt" md5="9044d1ae989e292a5e19128f57de9e21" size="57" mtime="1534862349" />
+        <directory name="ProjectWithRepo_package.ProjectWithRepo_Update" rev="9" vrev="9" srcmd5="478f76e51aa8ad2105d6f2a7c70a71df">
+          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" srcmd5="1fe06d22b38ce06632413dcc7aeee49c" baserev="1fe06d22b38ce06632413dcc7aeee49c" xsrcmd5="e6ff6888d08544c3b12eed46fcf1310e" lsrcmd5="478f76e51aa8ad2105d6f2a7c70a71df" />
+          <entry name="_config" md5="e76512ea4577d0a559788f9bed2f9ad8" size="58" mtime="1536753837" />
+          <entry name="_link" md5="a1f2d4062a5ea3a9a83bcf0195340932" size="175" mtime="1536753845" />
+          <entry name="somefile.txt" md5="d5ff6c3db27c57b3d9dbc5df28a95a21" size="64" mtime="1536753837" />
         </directory>
     http_version: 
-  recorded_at: Tue, 21 Aug 2018 14:39:18 GMT
+  recorded_at: Wed, 12 Sep 2018 12:04:06 GMT
 - request:
     method: post
     uri: http://backend:5352/search/package/id?match=(linkinfo/@package=%22ProjectWithRepo_package%22%20and%20linkinfo/@project=%22ProjectWithRepo%22%20and%20@project=%22ProjectWithRepo%22)
@@ -3789,7 +3531,7 @@ http_interactions:
         <collection>
         </collection>
     http_version: 
-  recorded_at: Tue, 21 Aug 2018 14:39:18 GMT
+  recorded_at: Wed, 12 Sep 2018 12:04:06 GMT
 - request:
     method: put
     uri: http://backend:5352/source/MaintenanceProject:0/_meta?user=maintenance_coord
@@ -3854,7 +3596,7 @@ http_interactions:
           </repository>
         </project>
     http_version: 
-  recorded_at: Tue, 21 Aug 2018 14:39:18 GMT
+  recorded_at: Wed, 12 Sep 2018 12:04:06 GMT
 - request:
     method: put
     uri: http://backend:5352/source/MaintenanceProject:0/_meta?user=maintenance_coord
@@ -3919,10 +3661,10 @@ http_interactions:
           </repository>
         </project>
     http_version: 
-  recorded_at: Tue, 21 Aug 2018 14:39:18 GMT
+  recorded_at: Wed, 12 Sep 2018 12:04:06 GMT
 - request:
     method: post
-    uri: http://backend:5352/source/MaintenanceProject:0/ProjectWithRepo_package.ProjectWithRepo_Update?cmd=copy&comment=Maintenance%20incident%20copy%20from%20project%20home:tom:branches:ProjectWithRepo:Update&expand=1&keeplink=1&opackage=ProjectWithRepo_package&oproject=home:tom:branches:ProjectWithRepo:Update&orev=f5a7bab245bc8b8a4e528b8b441fc607&requestid=1&user=maintenance_coord&withacceptinfo=1
+    uri: http://backend:5352/source/MaintenanceProject:0/ProjectWithRepo_package.ProjectWithRepo_Update?cmd=copy&comment=Maintenance%20incident%20copy%20from%20project%20home:tom:branches:ProjectWithRepo:Update&expand=1&keeplink=1&opackage=ProjectWithRepo_package&oproject=home:tom:branches:ProjectWithRepo:Update&orev=4c8313d77815d19b1b1dd8af509b8861&requestid=1&user=maintenance_coord&withacceptinfo=1
     body:
       encoding: UTF-8
       string: ''
@@ -3947,21 +3689,21 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '505'
+      - '508'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="6" vrev="6">
-          <srcmd5>e682289d8849655423bc12c13c429a3d</srcmd5>
+        <revision rev="10" vrev="10">
+          <srcmd5>1b7a806c27e72befe7752ec51001d414</srcmd5>
           <version>unknown</version>
-          <time>1534862358</time>
+          <time>1536753846</time>
           <user>maintenance_coord</user>
           <comment>Maintenance incident copy from project home:tom:branches:ProjectWithRepo:Update</comment>
           <requestid>1</requestid>
-          <acceptinfo rev="6" srcmd5="e682289d8849655423bc12c13c429a3d" osrcmd5="7922ce81d1cafc61978abc010f9e2ba8" xsrcmd5="3685604074c501a0c064a83e101cf52e" oxsrcmd5="c443e5a2a5dd0f28fd22ff7d8c3527a1" />
+          <acceptinfo rev="10" srcmd5="1b7a806c27e72befe7752ec51001d414" osrcmd5="478f76e51aa8ad2105d6f2a7c70a71df" xsrcmd5="275fdb6919cc016e94566968c0c4aeb5" oxsrcmd5="e6ff6888d08544c3b12eed46fcf1310e" />
         </revision>
     http_version: 
-  recorded_at: Tue, 21 Aug 2018 14:39:18 GMT
+  recorded_at: Wed, 12 Sep 2018 12:04:06 GMT
 - request:
     method: put
     uri: http://backend:5352/source/MaintenanceProject:0/ProjectWithRepo_package.ProjectWithRepo_Update/_meta?user=maintenance_coord
@@ -3969,8 +3711,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="ProjectWithRepo_package.ProjectWithRepo_Update" project="MaintenanceProject:0">
-          <title>Antic Hay</title>
-          <description>A eaque voluptas optio.</description>
+          <title>The Widening Gyre</title>
+          <description>Cupiditate neque nihil consequatur.</description>
           <releasename>ProjectWithRepo_package</releasename>
           <build>
             <enable repository="ProjectWithRepo_Update"/>
@@ -3995,20 +3737,20 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '311'
+      - '331'
     body:
       encoding: UTF-8
       string: |
         <package name="ProjectWithRepo_package.ProjectWithRepo_Update" project="MaintenanceProject:0">
-          <title>Antic Hay</title>
-          <description>A eaque voluptas optio.</description>
+          <title>The Widening Gyre</title>
+          <description>Cupiditate neque nihil consequatur.</description>
           <releasename>ProjectWithRepo_package</releasename>
           <build>
             <enable repository="ProjectWithRepo_Update" />
           </build>
         </package>
     http_version: 
-  recorded_at: Tue, 21 Aug 2018 14:39:18 GMT
+  recorded_at: Wed, 12 Sep 2018 12:04:06 GMT
 - request:
     method: get
     uri: http://backend:5352/source/MaintenanceProject:0/ProjectWithRepo_package.ProjectWithRepo_Update
@@ -4034,19 +3776,19 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '777'
+      - '779'
     body:
       encoding: UTF-8
       string: |
-        <directory name="ProjectWithRepo_package.ProjectWithRepo_Update" rev="6" vrev="6" srcmd5="e682289d8849655423bc12c13c429a3d">
-          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" srcmd5="def3bf67a426e8013de578376d34f554" baserev="def3bf67a426e8013de578376d34f554" xsrcmd5="3685604074c501a0c064a83e101cf52e" lsrcmd5="e682289d8849655423bc12c13c429a3d" />
-          <entry name="DUMMY_FILE" md5="275876e34cf609db118f3d84b799a790" size="5" mtime="1534862270" />
-          <entry name="_config" md5="1a05ff51cbc0ee790ddd75020dc14e94" size="51" mtime="1534862349" />
-          <entry name="_link" md5="fc6315cf4d9e91ed369a097e83d59417" size="176" mtime="1534862357" />
-          <entry name="somefile.txt" md5="9044d1ae989e292a5e19128f57de9e21" size="57" mtime="1534862349" />
+        <directory name="ProjectWithRepo_package.ProjectWithRepo_Update" rev="10" vrev="10" srcmd5="1b7a806c27e72befe7752ec51001d414">
+          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" srcmd5="1fe06d22b38ce06632413dcc7aeee49c" baserev="1fe06d22b38ce06632413dcc7aeee49c" xsrcmd5="275fdb6919cc016e94566968c0c4aeb5" lsrcmd5="1b7a806c27e72befe7752ec51001d414" />
+          <entry name="DUMMY_FILE" md5="275876e34cf609db118f3d84b799a790" size="5" mtime="1536751453" />
+          <entry name="_config" md5="e76512ea4577d0a559788f9bed2f9ad8" size="58" mtime="1536753837" />
+          <entry name="_link" md5="a1f2d4062a5ea3a9a83bcf0195340932" size="175" mtime="1536753845" />
+          <entry name="somefile.txt" md5="d5ff6c3db27c57b3d9dbc5df28a95a21" size="64" mtime="1536753837" />
         </directory>
     http_version: 
-  recorded_at: Tue, 21 Aug 2018 14:39:18 GMT
+  recorded_at: Wed, 12 Sep 2018 12:04:06 GMT
 - request:
     method: get
     uri: http://backend:5352/source/MaintenanceProject:0/ProjectWithRepo_package.ProjectWithRepo_Update?view=info
@@ -4072,17 +3814,17 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '463'
+      - '464'
     body:
       encoding: UTF-8
       string: |
-        <sourceinfo package="ProjectWithRepo_package.ProjectWithRepo_Update" rev="6" vrev="41.7" srcmd5="3685604074c501a0c064a83e101cf52e" lsrcmd5="e682289d8849655423bc12c13c429a3d" verifymd5="911b8ebdc893292a25313ef6deba0a7d">
+        <sourceinfo package="ProjectWithRepo_package.ProjectWithRepo_Update" rev="10" vrev="7.11" srcmd5="275fdb6919cc016e94566968c0c4aeb5" lsrcmd5="1b7a806c27e72befe7752ec51001d414" verifymd5="06a0eba83b76c7de00de4dad643e32e6">
           <error>bad build configuration, no build type defined or detected</error>
           <linked project="ProjectWithRepo:Update" package="ProjectWithRepo_package" />
           <linked project="ProjectWithRepo" package="ProjectWithRepo_package" />
         </sourceinfo>
     http_version: 
-  recorded_at: Tue, 21 Aug 2018 14:39:18 GMT
+  recorded_at: Wed, 12 Sep 2018 12:04:06 GMT
 - request:
     method: get
     uri: http://backend:5352/source/MaintenanceProject:0/ProjectWithRepo_package.ProjectWithRepo_Update
@@ -4108,19 +3850,19 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '777'
+      - '779'
     body:
       encoding: UTF-8
       string: |
-        <directory name="ProjectWithRepo_package.ProjectWithRepo_Update" rev="6" vrev="6" srcmd5="e682289d8849655423bc12c13c429a3d">
-          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" srcmd5="def3bf67a426e8013de578376d34f554" baserev="def3bf67a426e8013de578376d34f554" xsrcmd5="3685604074c501a0c064a83e101cf52e" lsrcmd5="e682289d8849655423bc12c13c429a3d" />
-          <entry name="DUMMY_FILE" md5="275876e34cf609db118f3d84b799a790" size="5" mtime="1534862270" />
-          <entry name="_config" md5="1a05ff51cbc0ee790ddd75020dc14e94" size="51" mtime="1534862349" />
-          <entry name="_link" md5="fc6315cf4d9e91ed369a097e83d59417" size="176" mtime="1534862357" />
-          <entry name="somefile.txt" md5="9044d1ae989e292a5e19128f57de9e21" size="57" mtime="1534862349" />
+        <directory name="ProjectWithRepo_package.ProjectWithRepo_Update" rev="10" vrev="10" srcmd5="1b7a806c27e72befe7752ec51001d414">
+          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" srcmd5="1fe06d22b38ce06632413dcc7aeee49c" baserev="1fe06d22b38ce06632413dcc7aeee49c" xsrcmd5="275fdb6919cc016e94566968c0c4aeb5" lsrcmd5="1b7a806c27e72befe7752ec51001d414" />
+          <entry name="DUMMY_FILE" md5="275876e34cf609db118f3d84b799a790" size="5" mtime="1536751453" />
+          <entry name="_config" md5="e76512ea4577d0a559788f9bed2f9ad8" size="58" mtime="1536753837" />
+          <entry name="_link" md5="a1f2d4062a5ea3a9a83bcf0195340932" size="175" mtime="1536753845" />
+          <entry name="somefile.txt" md5="d5ff6c3db27c57b3d9dbc5df28a95a21" size="64" mtime="1536753837" />
         </directory>
     http_version: 
-  recorded_at: Tue, 21 Aug 2018 14:39:18 GMT
+  recorded_at: Wed, 12 Sep 2018 12:04:06 GMT
 - request:
     method: post
     uri: http://backend:5352/source/MaintenanceProject:0/ProjectWithRepo_package.ProjectWithRepo_Update?cmd=diff&linkrev=base&onlyissues=1&orev=0&view=xml
@@ -4148,19 +3890,19 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '397'
+      - '398'
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="9f2add890cd5d5b32b6239f029cd64a4">
+        <sourcediff key="7f6a7177bde2284912f672af6c4c8661">
           <old project="MaintenanceProject:0" package="ProjectWithRepo_package.ProjectWithRepo_Update" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e" />
-          <new project="MaintenanceProject:0" package="ProjectWithRepo_package.ProjectWithRepo_Update" rev="6" srcmd5="e682289d8849655423bc12c13c429a3d" />
+          <new project="MaintenanceProject:0" package="ProjectWithRepo_package.ProjectWithRepo_Update" rev="10" srcmd5="1b7a806c27e72befe7752ec51001d414" />
           <files />
           <issues>
           </issues>
         </sourcediff>
     http_version: 
-  recorded_at: Tue, 21 Aug 2018 14:39:18 GMT
+  recorded_at: Wed, 12 Sep 2018 12:04:06 GMT
 - request:
     method: post
     uri: http://backend:5352/source/MaintenanceProject:0/ProjectWithRepo_package.ProjectWithRepo_Update?cmd=linkdiff&linkrev=base&onlyissues=1&view=xml
@@ -4192,15 +3934,15 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="9120b46ac17e3ca442167869e9045bef">
-          <old project="ProjectWithRepo:Update" package="ProjectWithRepo_package" rev="def3bf67a426e8013de578376d34f554" srcmd5="def3bf67a426e8013de578376d34f554" />
-          <new project="MaintenanceProject:0" package="ProjectWithRepo_package.ProjectWithRepo_Update" rev="3685604074c501a0c064a83e101cf52e" srcmd5="3685604074c501a0c064a83e101cf52e" />
+        <sourcediff key="f2891c34d2b4318b130893af853e72f6">
+          <old project="ProjectWithRepo:Update" package="ProjectWithRepo_package" rev="1fe06d22b38ce06632413dcc7aeee49c" srcmd5="1fe06d22b38ce06632413dcc7aeee49c" />
+          <new project="MaintenanceProject:0" package="ProjectWithRepo_package.ProjectWithRepo_Update" rev="275fdb6919cc016e94566968c0c4aeb5" srcmd5="275fdb6919cc016e94566968c0c4aeb5" />
           <files />
           <issues>
           </issues>
         </sourcediff>
     http_version: 
-  recorded_at: Tue, 21 Aug 2018 14:39:18 GMT
+  recorded_at: Wed, 12 Sep 2018 12:04:06 GMT
 - request:
     method: put
     uri: http://backend:5352/source/MaintenanceProject:0/_meta?comment=maintenance_incident%20request%201&requestid=1&user=maintenance_coord
@@ -4265,7 +4007,7 @@ http_interactions:
           </repository>
         </project>
     http_version: 
-  recorded_at: Tue, 21 Aug 2018 14:39:18 GMT
+  recorded_at: Wed, 12 Sep 2018 12:04:06 GMT
 - request:
     method: put
     uri: http://backend:5352/source/MaintenanceProject:0/patchinfo/_meta?user=maintenance_coord
@@ -4322,7 +4064,7 @@ http_interactions:
           </useforbuild>
         </package>
     http_version: 
-  recorded_at: Tue, 21 Aug 2018 14:39:18 GMT
+  recorded_at: Wed, 12 Sep 2018 12:04:06 GMT
 - request:
     method: put
     uri: http://backend:5352/source/MaintenanceProject:0/patchinfo/_patchinfo?comment=generated%20by%20request%20id%201%20accept%20call&user=maintenance_coord
@@ -4359,16 +4101,16 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <revision rev="4" vrev="4">
+        <revision rev="7" vrev="7">
           <srcmd5>53b684c8c2dbc9672bb230d024c87a14</srcmd5>
           <version>unknown</version>
-          <time>1534862358</time>
+          <time>1536753846</time>
           <user>maintenance_coord</user>
           <comment>generated by request id 1 accept call</comment>
           <requestid/>
         </revision>
     http_version: 
-  recorded_at: Tue, 21 Aug 2018 14:39:18 GMT
+  recorded_at: Wed, 12 Sep 2018 12:04:06 GMT
 - request:
     method: put
     uri: http://backend:5352/source/MaintenanceProject:0/patchinfo/_meta?user=maintenance_coord
@@ -4425,7 +4167,7 @@ http_interactions:
           </useforbuild>
         </package>
     http_version: 
-  recorded_at: Tue, 21 Aug 2018 14:39:18 GMT
+  recorded_at: Wed, 12 Sep 2018 12:04:07 GMT
 - request:
     method: get
     uri: http://backend:5352/source/MaintenanceProject:0/patchinfo
@@ -4455,11 +4197,11 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="patchinfo" rev="4" vrev="4" srcmd5="53b684c8c2dbc9672bb230d024c87a14">
-          <entry name="_patchinfo" md5="34e0b04fccfd75faea0577efe7cd9ead" size="208" mtime="1534862276" />
+        <directory name="patchinfo" rev="7" vrev="7" srcmd5="53b684c8c2dbc9672bb230d024c87a14">
+          <entry name="_patchinfo" md5="34e0b04fccfd75faea0577efe7cd9ead" size="208" mtime="1536751459" />
         </directory>
     http_version: 
-  recorded_at: Tue, 21 Aug 2018 14:39:18 GMT
+  recorded_at: Wed, 12 Sep 2018 12:04:07 GMT
 - request:
     method: get
     uri: http://backend:5352/source/MaintenanceProject:0/patchinfo?view=info
@@ -4489,11 +4231,11 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <sourceinfo package="patchinfo" rev="4" vrev="4" srcmd5="53b684c8c2dbc9672bb230d024c87a14" verifymd5="53b684c8c2dbc9672bb230d024c87a14">
+        <sourceinfo package="patchinfo" rev="7" vrev="7" srcmd5="53b684c8c2dbc9672bb230d024c87a14" verifymd5="53b684c8c2dbc9672bb230d024c87a14">
           <filename>_patchinfo</filename>
         </sourceinfo>
     http_version: 
-  recorded_at: Tue, 21 Aug 2018 14:39:18 GMT
+  recorded_at: Wed, 12 Sep 2018 12:04:07 GMT
 - request:
     method: get
     uri: http://backend:5352/source/MaintenanceProject:0/patchinfo
@@ -4523,11 +4265,11 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="patchinfo" rev="4" vrev="4" srcmd5="53b684c8c2dbc9672bb230d024c87a14">
-          <entry name="_patchinfo" md5="34e0b04fccfd75faea0577efe7cd9ead" size="208" mtime="1534862276" />
+        <directory name="patchinfo" rev="7" vrev="7" srcmd5="53b684c8c2dbc9672bb230d024c87a14">
+          <entry name="_patchinfo" md5="34e0b04fccfd75faea0577efe7cd9ead" size="208" mtime="1536751459" />
         </directory>
     http_version: 
-  recorded_at: Tue, 21 Aug 2018 14:39:18 GMT
+  recorded_at: Wed, 12 Sep 2018 12:04:07 GMT
 - request:
     method: get
     uri: http://backend:5352/source/MaintenanceProject:0/patchinfo/_patchinfo
@@ -4565,10 +4307,10 @@ http_interactions:
           <description>I want the update</description>
         </patchinfo>
     http_version: 
-  recorded_at: Tue, 21 Aug 2018 14:39:18 GMT
+  recorded_at: Wed, 12 Sep 2018 12:04:07 GMT
 - request:
     method: post
-    uri: http://backend:5352/source/MaintenanceProject:0/ProjectWithRepo_package.ProjectWithRepo_Update?cmd=diff&filelimit=10000&orev=c443e5a2a5dd0f28fd22ff7d8c3527a1&rev=3685604074c501a0c064a83e101cf52e&tarlimit=10000&view=xml&withissues=1
+    uri: http://backend:5352/source/MaintenanceProject:0/ProjectWithRepo_package.ProjectWithRepo_Update?cmd=diff&filelimit=10000&orev=e6ff6888d08544c3b12eed46fcf1310e&rev=275fdb6919cc016e94566968c0c4aeb5&tarlimit=10000&view=xml&withissues=1
     body:
       encoding: UTF-8
       string: ''
@@ -4597,9 +4339,9 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="481242edec873d502f9cb1d3b40be416">
-          <old project="MaintenanceProject:0" package="ProjectWithRepo_package.ProjectWithRepo_Update" rev="c443e5a2a5dd0f28fd22ff7d8c3527a1" srcmd5="c443e5a2a5dd0f28fd22ff7d8c3527a1" />
-          <new project="MaintenanceProject:0" package="ProjectWithRepo_package.ProjectWithRepo_Update" rev="3685604074c501a0c064a83e101cf52e" srcmd5="3685604074c501a0c064a83e101cf52e" />
+        <sourcediff key="808ee903b18ff36e974bb24d3c196e8a">
+          <old project="MaintenanceProject:0" package="ProjectWithRepo_package.ProjectWithRepo_Update" rev="e6ff6888d08544c3b12eed46fcf1310e" srcmd5="e6ff6888d08544c3b12eed46fcf1310e" />
+          <new project="MaintenanceProject:0" package="ProjectWithRepo_package.ProjectWithRepo_Update" rev="275fdb6919cc016e94566968c0c4aeb5" srcmd5="275fdb6919cc016e94566968c0c4aeb5" />
           <files>
             <file state="added">
               <new name="DUMMY_FILE" md5="275876e34cf609db118f3d84b799a790" size="5" />
@@ -4613,7 +4355,7 @@ http_interactions:
           </issues>
         </sourcediff>
     http_version: 
-  recorded_at: Tue, 21 Aug 2018 14:39:19 GMT
+  recorded_at: Wed, 12 Sep 2018 12:04:07 GMT
 - request:
     method: get
     uri: http://backend:5352/build/home:tom:branches:ProjectWithRepo:Update/_result?package=ProjectWithRepo_package&view=status
@@ -4621,10 +4363,8 @@ http_interactions:
       encoding: US-ASCII
       string: ''
     headers:
-      Content-Type:
-      - text/plain
       Accept-Encoding:
-      - identity
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
       - "*/*"
       User-Agent:
@@ -4649,7 +4389,7 @@ http_interactions:
           <result project="home:tom:branches:ProjectWithRepo:Update" repository="repository_2" arch="i586" code="broken" state="broken" details="no build type (ProjectWithRepo:Update)" />
         </resultlist>
     http_version: 
-  recorded_at: Tue, 21 Aug 2018 14:39:19 GMT
+  recorded_at: Wed, 12 Sep 2018 12:04:07 GMT
 - request:
     method: get
     uri: http://backend:5352/build/home:tom:branches:ProjectWithRepo:Update/_result?locallink=1&multibuild=1&package=ProjectWithRepo_package&view=status
@@ -4657,10 +4397,8 @@ http_interactions:
       encoding: US-ASCII
       string: ''
     headers:
-      Content-Type:
-      - text/plain
       Accept-Encoding:
-      - identity
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
       - "*/*"
       User-Agent:
@@ -4685,7 +4423,7 @@ http_interactions:
           <result project="home:tom:branches:ProjectWithRepo:Update" repository="repository_2" arch="i586" code="broken" state="broken" details="no build type (ProjectWithRepo:Update)" />
         </resultlist>
     http_version: 
-  recorded_at: Tue, 21 Aug 2018 14:39:19 GMT
+  recorded_at: Wed, 12 Sep 2018 12:04:07 GMT
 - request:
     method: get
     uri: http://backend:5352/build/MaintenanceProject:0/_result?view=binarylist
@@ -4693,10 +4431,8 @@ http_interactions:
       encoding: US-ASCII
       string: ''
     headers:
-      Content-Type:
-      - text/plain
       Accept-Encoding:
-      - identity
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
       - "*/*"
       User-Agent:
@@ -4721,7 +4457,7 @@ http_interactions:
           <result project="MaintenanceProject:0" repository="ProjectWithRepo_Update" arch="i586" code="broken" state="broken" details="no build type (ProjectWithRepo:Update)" />
         </resultlist>
     http_version: 
-  recorded_at: Tue, 21 Aug 2018 14:39:19 GMT
+  recorded_at: Wed, 12 Sep 2018 12:04:07 GMT
 - request:
     method: get
     uri: http://backend:5352/source/MaintenanceProject:0/patchinfo/_patchinfo
@@ -4759,7 +4495,7 @@ http_interactions:
           <description>I want the update</description>
         </patchinfo>
     http_version: 
-  recorded_at: Tue, 21 Aug 2018 14:39:19 GMT
+  recorded_at: Wed, 12 Sep 2018 12:04:07 GMT
 - request:
     method: get
     uri: http://backend:5352/source/MaintenanceProject:0/patchinfo/_patchinfo
@@ -4797,7 +4533,7 @@ http_interactions:
           <description>I want the update</description>
         </patchinfo>
     http_version: 
-  recorded_at: Tue, 21 Aug 2018 14:39:19 GMT
+  recorded_at: Wed, 12 Sep 2018 12:04:07 GMT
 - request:
     method: get
     uri: http://backend:5352/build/MaintenanceProject:0/_result?view=binarylist
@@ -4805,10 +4541,8 @@ http_interactions:
       encoding: US-ASCII
       string: ''
     headers:
-      Content-Type:
-      - text/plain
       Accept-Encoding:
-      - identity
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
       - "*/*"
       User-Agent:
@@ -4833,7 +4567,7 @@ http_interactions:
           <result project="MaintenanceProject:0" repository="ProjectWithRepo_Update" arch="i586" code="broken" state="broken" details="no build type (ProjectWithRepo:Update)" />
         </resultlist>
     http_version: 
-  recorded_at: Tue, 21 Aug 2018 14:39:20 GMT
+  recorded_at: Wed, 12 Sep 2018 12:04:09 GMT
 - request:
     method: get
     uri: http://backend:5352/source/MaintenanceProject:0/patchinfo/_patchinfo
@@ -4871,7 +4605,7 @@ http_interactions:
           <description>I want the update</description>
         </patchinfo>
     http_version: 
-  recorded_at: Tue, 21 Aug 2018 14:39:20 GMT
+  recorded_at: Wed, 12 Sep 2018 12:04:09 GMT
 - request:
     method: get
     uri: http://backend:5352/source/MaintenanceProject:0/patchinfo/_patchinfo
@@ -4909,7 +4643,7 @@ http_interactions:
           <description>I want the update</description>
         </patchinfo>
     http_version: 
-  recorded_at: Tue, 21 Aug 2018 14:39:20 GMT
+  recorded_at: Wed, 12 Sep 2018 12:04:09 GMT
 - request:
     method: put
     uri: http://backend:5352/source/MaintenanceProject:0/patchinfo/_patchinfo?user=maintenance_coord
@@ -4947,16 +4681,16 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <revision rev="5" vrev="5">
+        <revision rev="8" vrev="8">
           <srcmd5>d07dfcdc0bb71ab61e7d0c85c4a68c71</srcmd5>
           <version>unknown</version>
-          <time>1534862361</time>
+          <time>1536753849</time>
           <user>maintenance_coord</user>
           <comment></comment>
           <requestid/>
         </revision>
     http_version: 
-  recorded_at: Tue, 21 Aug 2018 14:39:21 GMT
+  recorded_at: Wed, 12 Sep 2018 12:04:09 GMT
 - request:
     method: put
     uri: http://backend:5352/source/MaintenanceProject:0/patchinfo/_meta?user=maintenance_coord
@@ -5013,7 +4747,7 @@ http_interactions:
           </useforbuild>
         </package>
     http_version: 
-  recorded_at: Tue, 21 Aug 2018 14:39:21 GMT
+  recorded_at: Wed, 12 Sep 2018 12:04:09 GMT
 - request:
     method: get
     uri: http://backend:5352/source/MaintenanceProject:0/patchinfo
@@ -5043,11 +4777,11 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="patchinfo" rev="5" vrev="5" srcmd5="d07dfcdc0bb71ab61e7d0c85c4a68c71">
-          <entry name="_patchinfo" md5="7fd692cf9ae54961b5c5a22aa13e29c0" size="347" mtime="1534862278" />
+        <directory name="patchinfo" rev="8" vrev="8" srcmd5="d07dfcdc0bb71ab61e7d0c85c4a68c71">
+          <entry name="_patchinfo" md5="7fd692cf9ae54961b5c5a22aa13e29c0" size="347" mtime="1536751462" />
         </directory>
     http_version: 
-  recorded_at: Tue, 21 Aug 2018 14:39:21 GMT
+  recorded_at: Wed, 12 Sep 2018 12:04:09 GMT
 - request:
     method: get
     uri: http://backend:5352/source/MaintenanceProject:0/patchinfo?view=info
@@ -5077,11 +4811,11 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <sourceinfo package="patchinfo" rev="5" vrev="5" srcmd5="d07dfcdc0bb71ab61e7d0c85c4a68c71" verifymd5="d07dfcdc0bb71ab61e7d0c85c4a68c71">
+        <sourceinfo package="patchinfo" rev="8" vrev="8" srcmd5="d07dfcdc0bb71ab61e7d0c85c4a68c71" verifymd5="d07dfcdc0bb71ab61e7d0c85c4a68c71">
           <filename>_patchinfo</filename>
         </sourceinfo>
     http_version: 
-  recorded_at: Tue, 21 Aug 2018 14:39:21 GMT
+  recorded_at: Wed, 12 Sep 2018 12:04:09 GMT
 - request:
     method: get
     uri: http://backend:5352/source/MaintenanceProject:0/patchinfo
@@ -5111,11 +4845,11 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="patchinfo" rev="5" vrev="5" srcmd5="d07dfcdc0bb71ab61e7d0c85c4a68c71">
-          <entry name="_patchinfo" md5="7fd692cf9ae54961b5c5a22aa13e29c0" size="347" mtime="1534862278" />
+        <directory name="patchinfo" rev="8" vrev="8" srcmd5="d07dfcdc0bb71ab61e7d0c85c4a68c71">
+          <entry name="_patchinfo" md5="7fd692cf9ae54961b5c5a22aa13e29c0" size="347" mtime="1536751462" />
         </directory>
     http_version: 
-  recorded_at: Tue, 21 Aug 2018 14:39:21 GMT
+  recorded_at: Wed, 12 Sep 2018 12:04:09 GMT
 - request:
     method: get
     uri: http://backend:5352/source/MaintenanceProject:0/patchinfo/_patchinfo
@@ -5154,7 +4888,7 @@ http_interactions:
           <stopped>locked!</stopped>
         </patchinfo>
     http_version: 
-  recorded_at: Tue, 21 Aug 2018 14:39:21 GMT
+  recorded_at: Wed, 12 Sep 2018 12:04:09 GMT
 - request:
     method: get
     uri: http://backend:5352/source/MaintenanceProject:0/patchinfo/_patchinfo
@@ -5193,7 +4927,7 @@ http_interactions:
           <stopped>locked!</stopped>
         </patchinfo>
     http_version: 
-  recorded_at: Tue, 21 Aug 2018 14:39:21 GMT
+  recorded_at: Wed, 12 Sep 2018 12:04:09 GMT
 - request:
     method: get
     uri: http://backend:5352/source/MaintenanceProject:0/patchinfo/_patchinfo
@@ -5232,7 +4966,7 @@ http_interactions:
           <stopped>locked!</stopped>
         </patchinfo>
     http_version: 
-  recorded_at: Tue, 21 Aug 2018 14:39:21 GMT
+  recorded_at: Wed, 12 Sep 2018 12:04:09 GMT
 - request:
     method: get
     uri: http://backend:5352/build/MaintenanceProject:0/_result?view=binarylist
@@ -5240,10 +4974,8 @@ http_interactions:
       encoding: US-ASCII
       string: ''
     headers:
-      Content-Type:
-      - text/plain
       Accept-Encoding:
-      - identity
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
       - "*/*"
       User-Agent:
@@ -5268,7 +5000,7 @@ http_interactions:
           <result project="MaintenanceProject:0" repository="ProjectWithRepo_Update" arch="i586" code="broken" state="broken" details="no build type (ProjectWithRepo:Update)" />
         </resultlist>
     http_version: 
-  recorded_at: Tue, 21 Aug 2018 14:39:21 GMT
+  recorded_at: Wed, 12 Sep 2018 12:04:09 GMT
 - request:
     method: get
     uri: http://backend:5352/source/MaintenanceProject:0/patchinfo/_patchinfo
@@ -5307,7 +5039,7 @@ http_interactions:
           <stopped>locked!</stopped>
         </patchinfo>
     http_version: 
-  recorded_at: Tue, 21 Aug 2018 14:39:21 GMT
+  recorded_at: Wed, 12 Sep 2018 12:04:09 GMT
 - request:
     method: get
     uri: http://backend:5352/source/MaintenanceProject:0/patchinfo/_patchinfo
@@ -5346,7 +5078,7 @@ http_interactions:
           <stopped>locked!</stopped>
         </patchinfo>
     http_version: 
-  recorded_at: Tue, 21 Aug 2018 14:39:21 GMT
+  recorded_at: Wed, 12 Sep 2018 12:04:09 GMT
 - request:
     method: get
     uri: http://backend:5352/build/MaintenanceProject:0/_result?view=binarylist
@@ -5354,10 +5086,8 @@ http_interactions:
       encoding: US-ASCII
       string: ''
     headers:
-      Content-Type:
-      - text/plain
       Accept-Encoding:
-      - identity
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
       - "*/*"
       User-Agent:
@@ -5382,7 +5112,7 @@ http_interactions:
           <result project="MaintenanceProject:0" repository="ProjectWithRepo_Update" arch="i586" code="broken" state="broken" details="no build type (ProjectWithRepo:Update)" />
         </resultlist>
     http_version: 
-  recorded_at: Tue, 21 Aug 2018 14:39:22 GMT
+  recorded_at: Wed, 12 Sep 2018 12:04:10 GMT
 - request:
     method: get
     uri: http://backend:5352/source/MaintenanceProject:0/patchinfo/_patchinfo
@@ -5421,7 +5151,7 @@ http_interactions:
           <stopped>locked!</stopped>
         </patchinfo>
     http_version: 
-  recorded_at: Tue, 21 Aug 2018 14:39:22 GMT
+  recorded_at: Wed, 12 Sep 2018 12:04:10 GMT
 - request:
     method: get
     uri: http://backend:5352/source/MaintenanceProject:0/patchinfo/_patchinfo
@@ -5460,7 +5190,7 @@ http_interactions:
           <stopped>locked!</stopped>
         </patchinfo>
     http_version: 
-  recorded_at: Tue, 21 Aug 2018 14:39:22 GMT
+  recorded_at: Wed, 12 Sep 2018 12:04:10 GMT
 - request:
     method: put
     uri: http://backend:5352/source/MaintenanceProject:0/patchinfo/_patchinfo?user=maintenance_coord
@@ -5497,16 +5227,16 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <revision rev="6" vrev="6">
+        <revision rev="9" vrev="9">
           <srcmd5>177d57906eba63ae56a64a367592144a</srcmd5>
           <version>unknown</version>
-          <time>1534862362</time>
+          <time>1536753850</time>
           <user>maintenance_coord</user>
           <comment></comment>
           <requestid/>
         </revision>
     http_version: 
-  recorded_at: Tue, 21 Aug 2018 14:39:22 GMT
+  recorded_at: Wed, 12 Sep 2018 12:04:10 GMT
 - request:
     method: put
     uri: http://backend:5352/source/MaintenanceProject:0/patchinfo/_meta?user=maintenance_coord
@@ -5563,7 +5293,7 @@ http_interactions:
           </useforbuild>
         </package>
     http_version: 
-  recorded_at: Tue, 21 Aug 2018 14:39:22 GMT
+  recorded_at: Wed, 12 Sep 2018 12:04:10 GMT
 - request:
     method: get
     uri: http://backend:5352/source/MaintenanceProject:0/patchinfo
@@ -5593,11 +5323,11 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="patchinfo" rev="6" vrev="6" srcmd5="177d57906eba63ae56a64a367592144a">
-          <entry name="_patchinfo" md5="ac29f7f1abd9ef43afeb43fc7737c007" size="318" mtime="1534862280" />
+        <directory name="patchinfo" rev="9" vrev="9" srcmd5="177d57906eba63ae56a64a367592144a">
+          <entry name="_patchinfo" md5="ac29f7f1abd9ef43afeb43fc7737c007" size="318" mtime="1536751463" />
         </directory>
     http_version: 
-  recorded_at: Tue, 21 Aug 2018 14:39:22 GMT
+  recorded_at: Wed, 12 Sep 2018 12:04:10 GMT
 - request:
     method: get
     uri: http://backend:5352/source/MaintenanceProject:0/patchinfo?view=info
@@ -5627,11 +5357,11 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <sourceinfo package="patchinfo" rev="6" vrev="6" srcmd5="177d57906eba63ae56a64a367592144a" verifymd5="177d57906eba63ae56a64a367592144a">
+        <sourceinfo package="patchinfo" rev="9" vrev="9" srcmd5="177d57906eba63ae56a64a367592144a" verifymd5="177d57906eba63ae56a64a367592144a">
           <filename>_patchinfo</filename>
         </sourceinfo>
     http_version: 
-  recorded_at: Tue, 21 Aug 2018 14:39:22 GMT
+  recorded_at: Wed, 12 Sep 2018 12:04:10 GMT
 - request:
     method: get
     uri: http://backend:5352/source/MaintenanceProject:0/patchinfo
@@ -5661,11 +5391,11 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="patchinfo" rev="6" vrev="6" srcmd5="177d57906eba63ae56a64a367592144a">
-          <entry name="_patchinfo" md5="ac29f7f1abd9ef43afeb43fc7737c007" size="318" mtime="1534862280" />
+        <directory name="patchinfo" rev="9" vrev="9" srcmd5="177d57906eba63ae56a64a367592144a">
+          <entry name="_patchinfo" md5="ac29f7f1abd9ef43afeb43fc7737c007" size="318" mtime="1536751463" />
         </directory>
     http_version: 
-  recorded_at: Tue, 21 Aug 2018 14:39:22 GMT
+  recorded_at: Wed, 12 Sep 2018 12:04:10 GMT
 - request:
     method: get
     uri: http://backend:5352/source/MaintenanceProject:0/patchinfo/_patchinfo
@@ -5703,7 +5433,7 @@ http_interactions:
           <description>Fixes nothing, Fixes nothing, Fixes nothing, Fixes nothing, Fixes nothing, Fixes nothing</description>
         </patchinfo>
     http_version: 
-  recorded_at: Tue, 21 Aug 2018 14:39:22 GMT
+  recorded_at: Wed, 12 Sep 2018 12:04:10 GMT
 - request:
     method: get
     uri: http://backend:5352/source/MaintenanceProject:0/patchinfo/_patchinfo
@@ -5741,7 +5471,7 @@ http_interactions:
           <description>Fixes nothing, Fixes nothing, Fixes nothing, Fixes nothing, Fixes nothing, Fixes nothing</description>
         </patchinfo>
     http_version: 
-  recorded_at: Tue, 21 Aug 2018 14:39:22 GMT
+  recorded_at: Wed, 12 Sep 2018 12:04:10 GMT
 - request:
     method: get
     uri: http://backend:5352/source/MaintenanceProject:0/patchinfo/_patchinfo
@@ -5779,7 +5509,7 @@ http_interactions:
           <description>Fixes nothing, Fixes nothing, Fixes nothing, Fixes nothing, Fixes nothing, Fixes nothing</description>
         </patchinfo>
     http_version: 
-  recorded_at: Tue, 21 Aug 2018 14:39:22 GMT
+  recorded_at: Wed, 12 Sep 2018 12:04:10 GMT
 - request:
     method: get
     uri: http://backend:5352/build/home:tom:branches:ProjectWithRepo:Update/_result?code=unresolvable&view=status
@@ -5813,7 +5543,7 @@ http_interactions:
           <result project="home:tom:branches:ProjectWithRepo:Update" repository="repository_2" arch="i586" code="broken" state="broken" details="no build type (ProjectWithRepo:Update)" />
         </resultlist>
     http_version: 
-  recorded_at: Tue, 21 Aug 2018 14:39:23 GMT
+  recorded_at: Wed, 12 Sep 2018 12:04:11 GMT
 - request:
     method: get
     uri: http://backend:5352/build/home:tom:branches:ProjectWithRepo:Update/_result?view=summary
@@ -5821,10 +5551,8 @@ http_interactions:
       encoding: US-ASCII
       string: ''
     headers:
-      Content-Type:
-      - text/plain
       Accept-Encoding:
-      - identity
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
       - "*/*"
       User-Agent:
@@ -5851,7 +5579,7 @@ http_interactions:
           </result>
         </resultlist>
     http_version: 
-  recorded_at: Tue, 21 Aug 2018 14:39:23 GMT
+  recorded_at: Wed, 12 Sep 2018 12:04:12 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:tom:branches:ProjectWithRepo:Update/ProjectWithRepo_package
@@ -5877,19 +5605,19 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '795'
+      - '793'
     body:
       encoding: UTF-8
       string: |
-        <directory name="ProjectWithRepo_package" rev="12" vrev="12" srcmd5="08d09eda7595c7a4a9225e3e1c5992cf">
-          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" rev="def3bf67a426e8013de578376d34f554" srcmd5="def3bf67a426e8013de578376d34f554" baserev="def3bf67a426e8013de578376d34f554" xsrcmd5="f5a7bab245bc8b8a4e528b8b441fc607" lsrcmd5="08d09eda7595c7a4a9225e3e1c5992cf" />
-          <entry name="DUMMY_FILE" md5="275876e34cf609db118f3d84b799a790" size="5" mtime="1534862270" />
-          <entry name="_config" md5="1a05ff51cbc0ee790ddd75020dc14e94" size="51" mtime="1534862349" />
-          <entry name="_link" md5="54e623c39791ca9f3db24ee0fb436950" size="169" mtime="1534862351" />
-          <entry name="somefile.txt" md5="9044d1ae989e292a5e19128f57de9e21" size="57" mtime="1534862349" />
+        <directory name="ProjectWithRepo_package" rev="6" vrev="6" srcmd5="6f64842b339b86054358d876db6f6823">
+          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" rev="1fe06d22b38ce06632413dcc7aeee49c" srcmd5="1fe06d22b38ce06632413dcc7aeee49c" baserev="1fe06d22b38ce06632413dcc7aeee49c" xsrcmd5="4c8313d77815d19b1b1dd8af509b8861" lsrcmd5="6f64842b339b86054358d876db6f6823" />
+          <entry name="DUMMY_FILE" md5="275876e34cf609db118f3d84b799a790" size="5" mtime="1536751453" />
+          <entry name="_config" md5="e76512ea4577d0a559788f9bed2f9ad8" size="58" mtime="1536753837" />
+          <entry name="_link" md5="90e4f5a99633a426e6ec73e94204889b" size="169" mtime="1536753839" />
+          <entry name="somefile.txt" md5="d5ff6c3db27c57b3d9dbc5df28a95a21" size="64" mtime="1536753837" />
         </directory>
     http_version: 
-  recorded_at: Tue, 21 Aug 2018 14:39:24 GMT
+  recorded_at: Wed, 12 Sep 2018 12:04:12 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:tom:branches:ProjectWithRepo:Update/ProjectWithRepo_package
@@ -5915,19 +5643,19 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '795'
+      - '793'
     body:
       encoding: UTF-8
       string: |
-        <directory name="ProjectWithRepo_package" rev="12" vrev="12" srcmd5="08d09eda7595c7a4a9225e3e1c5992cf">
-          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" rev="def3bf67a426e8013de578376d34f554" srcmd5="def3bf67a426e8013de578376d34f554" baserev="def3bf67a426e8013de578376d34f554" xsrcmd5="f5a7bab245bc8b8a4e528b8b441fc607" lsrcmd5="08d09eda7595c7a4a9225e3e1c5992cf" />
-          <entry name="DUMMY_FILE" md5="275876e34cf609db118f3d84b799a790" size="5" mtime="1534862270" />
-          <entry name="_config" md5="1a05ff51cbc0ee790ddd75020dc14e94" size="51" mtime="1534862349" />
-          <entry name="_link" md5="54e623c39791ca9f3db24ee0fb436950" size="169" mtime="1534862351" />
-          <entry name="somefile.txt" md5="9044d1ae989e292a5e19128f57de9e21" size="57" mtime="1534862349" />
+        <directory name="ProjectWithRepo_package" rev="6" vrev="6" srcmd5="6f64842b339b86054358d876db6f6823">
+          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" rev="1fe06d22b38ce06632413dcc7aeee49c" srcmd5="1fe06d22b38ce06632413dcc7aeee49c" baserev="1fe06d22b38ce06632413dcc7aeee49c" xsrcmd5="4c8313d77815d19b1b1dd8af509b8861" lsrcmd5="6f64842b339b86054358d876db6f6823" />
+          <entry name="DUMMY_FILE" md5="275876e34cf609db118f3d84b799a790" size="5" mtime="1536751453" />
+          <entry name="_config" md5="e76512ea4577d0a559788f9bed2f9ad8" size="58" mtime="1536753837" />
+          <entry name="_link" md5="90e4f5a99633a426e6ec73e94204889b" size="169" mtime="1536753839" />
+          <entry name="somefile.txt" md5="d5ff6c3db27c57b3d9dbc5df28a95a21" size="64" mtime="1536753837" />
         </directory>
     http_version: 
-  recorded_at: Tue, 21 Aug 2018 14:39:24 GMT
+  recorded_at: Wed, 12 Sep 2018 12:04:12 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:tom:branches:ProjectWithRepo:Update/ProjectWithRepo_package
@@ -5953,19 +5681,19 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '795'
+      - '793'
     body:
       encoding: UTF-8
       string: |
-        <directory name="ProjectWithRepo_package" rev="12" vrev="12" srcmd5="08d09eda7595c7a4a9225e3e1c5992cf">
-          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" rev="def3bf67a426e8013de578376d34f554" srcmd5="def3bf67a426e8013de578376d34f554" baserev="def3bf67a426e8013de578376d34f554" xsrcmd5="f5a7bab245bc8b8a4e528b8b441fc607" lsrcmd5="08d09eda7595c7a4a9225e3e1c5992cf" />
-          <entry name="DUMMY_FILE" md5="275876e34cf609db118f3d84b799a790" size="5" mtime="1534862270" />
-          <entry name="_config" md5="1a05ff51cbc0ee790ddd75020dc14e94" size="51" mtime="1534862349" />
-          <entry name="_link" md5="54e623c39791ca9f3db24ee0fb436950" size="169" mtime="1534862351" />
-          <entry name="somefile.txt" md5="9044d1ae989e292a5e19128f57de9e21" size="57" mtime="1534862349" />
+        <directory name="ProjectWithRepo_package" rev="6" vrev="6" srcmd5="6f64842b339b86054358d876db6f6823">
+          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" rev="1fe06d22b38ce06632413dcc7aeee49c" srcmd5="1fe06d22b38ce06632413dcc7aeee49c" baserev="1fe06d22b38ce06632413dcc7aeee49c" xsrcmd5="4c8313d77815d19b1b1dd8af509b8861" lsrcmd5="6f64842b339b86054358d876db6f6823" />
+          <entry name="DUMMY_FILE" md5="275876e34cf609db118f3d84b799a790" size="5" mtime="1536751453" />
+          <entry name="_config" md5="e76512ea4577d0a559788f9bed2f9ad8" size="58" mtime="1536753837" />
+          <entry name="_link" md5="90e4f5a99633a426e6ec73e94204889b" size="169" mtime="1536753839" />
+          <entry name="somefile.txt" md5="d5ff6c3db27c57b3d9dbc5df28a95a21" size="64" mtime="1536753837" />
         </directory>
     http_version: 
-  recorded_at: Tue, 21 Aug 2018 14:39:24 GMT
+  recorded_at: Wed, 12 Sep 2018 12:04:12 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:tom:branches:ProjectWithRepo:Update/ProjectWithRepo_package?cmd=diff&expand=1&filelimit=10000&opackage=ProjectWithRepo_package&oproject=ProjectWithRepo:Update&tarlimit=10000
@@ -6012,7 +5740,7 @@ http_interactions:
         +dummy
         \ No newline at end of file
     http_version: 
-  recorded_at: Tue, 21 Aug 2018 14:39:24 GMT
+  recorded_at: Wed, 12 Sep 2018 12:04:12 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:tom:branches:ProjectWithRepo:Update/ProjectWithRepo_package?expand=1
@@ -6038,18 +5766,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '688'
+      - '687'
     body:
       encoding: UTF-8
       string: |
-        <directory name="ProjectWithRepo_package" rev="f5a7bab245bc8b8a4e528b8b441fc607" vrev="12" srcmd5="f5a7bab245bc8b8a4e528b8b441fc607">
-          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" rev="def3bf67a426e8013de578376d34f554" srcmd5="def3bf67a426e8013de578376d34f554" baserev="def3bf67a426e8013de578376d34f554" lsrcmd5="08d09eda7595c7a4a9225e3e1c5992cf" />
-          <entry name="DUMMY_FILE" md5="275876e34cf609db118f3d84b799a790" size="5" mtime="1534862270" />
-          <entry name="_config" md5="1a05ff51cbc0ee790ddd75020dc14e94" size="51" mtime="1534862349" />
-          <entry name="somefile.txt" md5="9044d1ae989e292a5e19128f57de9e21" size="57" mtime="1534862349" />
+        <directory name="ProjectWithRepo_package" rev="4c8313d77815d19b1b1dd8af509b8861" vrev="6" srcmd5="4c8313d77815d19b1b1dd8af509b8861">
+          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" rev="1fe06d22b38ce06632413dcc7aeee49c" srcmd5="1fe06d22b38ce06632413dcc7aeee49c" baserev="1fe06d22b38ce06632413dcc7aeee49c" lsrcmd5="6f64842b339b86054358d876db6f6823" />
+          <entry name="DUMMY_FILE" md5="275876e34cf609db118f3d84b799a790" size="5" mtime="1536751453" />
+          <entry name="_config" md5="e76512ea4577d0a559788f9bed2f9ad8" size="58" mtime="1536753837" />
+          <entry name="somefile.txt" md5="d5ff6c3db27c57b3d9dbc5df28a95a21" size="64" mtime="1536753837" />
         </directory>
     http_version: 
-  recorded_at: Tue, 21 Aug 2018 14:39:24 GMT
+  recorded_at: Wed, 12 Sep 2018 12:04:12 GMT
 - request:
     method: get
     uri: http://backend:5352/build/home:tom:branches:ProjectWithRepo:Update/_result?code=unresolvable&view=status
@@ -6083,7 +5811,7 @@ http_interactions:
           <result project="home:tom:branches:ProjectWithRepo:Update" repository="repository_2" arch="i586" code="broken" state="broken" details="no build type (ProjectWithRepo:Update)" />
         </resultlist>
     http_version: 
-  recorded_at: Tue, 21 Aug 2018 14:39:24 GMT
+  recorded_at: Wed, 12 Sep 2018 12:04:13 GMT
 - request:
     method: get
     uri: http://backend:5352/build/home:tom:branches:ProjectWithRepo:Update/_result?view=summary
@@ -6091,10 +5819,8 @@ http_interactions:
       encoding: US-ASCII
       string: ''
     headers:
-      Content-Type:
-      - text/plain
       Accept-Encoding:
-      - identity
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
       - "*/*"
       User-Agent:
@@ -6121,7 +5847,7 @@ http_interactions:
           </result>
         </resultlist>
     http_version: 
-  recorded_at: Tue, 21 Aug 2018 14:39:25 GMT
+  recorded_at: Wed, 12 Sep 2018 12:04:13 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:tom:branches:ProjectWithRepo:Update/ProjectWithRepo_package
@@ -6147,22 +5873,22 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '795'
+      - '793'
     body:
       encoding: UTF-8
       string: |
-        <directory name="ProjectWithRepo_package" rev="12" vrev="12" srcmd5="08d09eda7595c7a4a9225e3e1c5992cf">
-          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" rev="def3bf67a426e8013de578376d34f554" srcmd5="def3bf67a426e8013de578376d34f554" baserev="def3bf67a426e8013de578376d34f554" xsrcmd5="f5a7bab245bc8b8a4e528b8b441fc607" lsrcmd5="08d09eda7595c7a4a9225e3e1c5992cf" />
-          <entry name="DUMMY_FILE" md5="275876e34cf609db118f3d84b799a790" size="5" mtime="1534862270" />
-          <entry name="_config" md5="1a05ff51cbc0ee790ddd75020dc14e94" size="51" mtime="1534862349" />
-          <entry name="_link" md5="54e623c39791ca9f3db24ee0fb436950" size="169" mtime="1534862351" />
-          <entry name="somefile.txt" md5="9044d1ae989e292a5e19128f57de9e21" size="57" mtime="1534862349" />
+        <directory name="ProjectWithRepo_package" rev="6" vrev="6" srcmd5="6f64842b339b86054358d876db6f6823">
+          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" rev="1fe06d22b38ce06632413dcc7aeee49c" srcmd5="1fe06d22b38ce06632413dcc7aeee49c" baserev="1fe06d22b38ce06632413dcc7aeee49c" xsrcmd5="4c8313d77815d19b1b1dd8af509b8861" lsrcmd5="6f64842b339b86054358d876db6f6823" />
+          <entry name="DUMMY_FILE" md5="275876e34cf609db118f3d84b799a790" size="5" mtime="1536751453" />
+          <entry name="_config" md5="e76512ea4577d0a559788f9bed2f9ad8" size="58" mtime="1536753837" />
+          <entry name="_link" md5="90e4f5a99633a426e6ec73e94204889b" size="169" mtime="1536753839" />
+          <entry name="somefile.txt" md5="d5ff6c3db27c57b3d9dbc5df28a95a21" size="64" mtime="1536753837" />
         </directory>
     http_version: 
-  recorded_at: Tue, 21 Aug 2018 14:39:26 GMT
+  recorded_at: Wed, 12 Sep 2018 12:04:14 GMT
 - request:
     method: post
-    uri: http://backend:5352/source/home:tom:branches:ProjectWithRepo:Update/ProjectWithRepo_package?cmd=diff&expand=1&filelimit=10000&opackage=ProjectWithRepo_package&oproject=ProjectWithRepo:Update&rev=f5a7bab245bc8b8a4e528b8b441fc607&tarlimit=10000&view=xml&withissues=1
+    uri: http://backend:5352/source/home:tom:branches:ProjectWithRepo:Update/ProjectWithRepo_package?cmd=diff&expand=1&filelimit=10000&opackage=ProjectWithRepo_package&oproject=ProjectWithRepo:Update&rev=4c8313d77815d19b1b1dd8af509b8861&tarlimit=10000&view=xml&withissues=1
     body:
       encoding: UTF-8
       string: ''
@@ -6183,7 +5909,7 @@ http_interactions:
       Content-Type:
       - text/xml
       Content-Length:
-      - '612'
+      - '611'
       Cache-Control:
       - no-cache
       Connection:
@@ -6191,9 +5917,9 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="429ea8bb29feb3d1a7ae1b1ac67a4a73">
-          <old project="ProjectWithRepo:Update" package="ProjectWithRepo_package" rev="40" srcmd5="def3bf67a426e8013de578376d34f554" />
-          <new project="home:tom:branches:ProjectWithRepo:Update" package="ProjectWithRepo_package" rev="f5a7bab245bc8b8a4e528b8b441fc607" srcmd5="f5a7bab245bc8b8a4e528b8b441fc607" />
+        <sourcediff key="2d56d77774c45560122081162e3937e0">
+          <old project="ProjectWithRepo:Update" package="ProjectWithRepo_package" rev="6" srcmd5="1fe06d22b38ce06632413dcc7aeee49c" />
+          <new project="home:tom:branches:ProjectWithRepo:Update" package="ProjectWithRepo_package" rev="4c8313d77815d19b1b1dd8af509b8861" srcmd5="4c8313d77815d19b1b1dd8af509b8861" />
           <files>
             <file state="added">
               <new name="DUMMY_FILE" md5="275876e34cf609db118f3d84b799a790" size="5" />
@@ -6207,7 +5933,7 @@ http_interactions:
           </issues>
         </sourcediff>
     http_version: 
-  recorded_at: Tue, 21 Aug 2018 14:39:26 GMT
+  recorded_at: Wed, 12 Sep 2018 12:04:14 GMT
 - request:
     method: get
     uri: http://backend:5352/build/home:tom:branches:ProjectWithRepo:Update/_result?package=ProjectWithRepo_package&view=status
@@ -6215,10 +5941,8 @@ http_interactions:
       encoding: US-ASCII
       string: ''
     headers:
-      Content-Type:
-      - text/plain
       Accept-Encoding:
-      - identity
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
       - "*/*"
       User-Agent:
@@ -6243,7 +5967,7 @@ http_interactions:
           <result project="home:tom:branches:ProjectWithRepo:Update" repository="repository_2" arch="i586" code="broken" state="broken" details="no build type (ProjectWithRepo:Update)" />
         </resultlist>
     http_version: 
-  recorded_at: Tue, 21 Aug 2018 14:39:26 GMT
+  recorded_at: Wed, 12 Sep 2018 12:04:14 GMT
 - request:
     method: get
     uri: http://backend:5352/build/home:tom:branches:ProjectWithRepo:Update/_result?locallink=1&multibuild=1&package=ProjectWithRepo_package&view=status
@@ -6251,10 +5975,8 @@ http_interactions:
       encoding: US-ASCII
       string: ''
     headers:
-      Content-Type:
-      - text/plain
       Accept-Encoding:
-      - identity
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
       - "*/*"
       User-Agent:
@@ -6279,7 +6001,7 @@ http_interactions:
           <result project="home:tom:branches:ProjectWithRepo:Update" repository="repository_2" arch="i586" code="broken" state="broken" details="no build type (ProjectWithRepo:Update)" />
         </resultlist>
     http_version: 
-  recorded_at: Tue, 21 Aug 2018 14:39:26 GMT
+  recorded_at: Wed, 12 Sep 2018 12:04:14 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:tom:branches:ProjectWithRepo:Update/ProjectWithRepo_package
@@ -6305,19 +6027,19 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '795'
+      - '793'
     body:
       encoding: UTF-8
       string: |
-        <directory name="ProjectWithRepo_package" rev="12" vrev="12" srcmd5="08d09eda7595c7a4a9225e3e1c5992cf">
-          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" rev="def3bf67a426e8013de578376d34f554" srcmd5="def3bf67a426e8013de578376d34f554" baserev="def3bf67a426e8013de578376d34f554" xsrcmd5="f5a7bab245bc8b8a4e528b8b441fc607" lsrcmd5="08d09eda7595c7a4a9225e3e1c5992cf" />
-          <entry name="DUMMY_FILE" md5="275876e34cf609db118f3d84b799a790" size="5" mtime="1534862270" />
-          <entry name="_config" md5="1a05ff51cbc0ee790ddd75020dc14e94" size="51" mtime="1534862349" />
-          <entry name="_link" md5="54e623c39791ca9f3db24ee0fb436950" size="169" mtime="1534862351" />
-          <entry name="somefile.txt" md5="9044d1ae989e292a5e19128f57de9e21" size="57" mtime="1534862349" />
+        <directory name="ProjectWithRepo_package" rev="6" vrev="6" srcmd5="6f64842b339b86054358d876db6f6823">
+          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" rev="1fe06d22b38ce06632413dcc7aeee49c" srcmd5="1fe06d22b38ce06632413dcc7aeee49c" baserev="1fe06d22b38ce06632413dcc7aeee49c" xsrcmd5="4c8313d77815d19b1b1dd8af509b8861" lsrcmd5="6f64842b339b86054358d876db6f6823" />
+          <entry name="DUMMY_FILE" md5="275876e34cf609db118f3d84b799a790" size="5" mtime="1536751453" />
+          <entry name="_config" md5="e76512ea4577d0a559788f9bed2f9ad8" size="58" mtime="1536753837" />
+          <entry name="_link" md5="90e4f5a99633a426e6ec73e94204889b" size="169" mtime="1536753839" />
+          <entry name="somefile.txt" md5="d5ff6c3db27c57b3d9dbc5df28a95a21" size="64" mtime="1536753837" />
         </directory>
     http_version: 
-  recorded_at: Tue, 21 Aug 2018 14:39:27 GMT
+  recorded_at: Wed, 12 Sep 2018 12:04:15 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:tom:branches:ProjectWithRepo:Update/ProjectWithRepo_package
@@ -6343,22 +6065,22 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '795'
+      - '793'
     body:
       encoding: UTF-8
       string: |
-        <directory name="ProjectWithRepo_package" rev="12" vrev="12" srcmd5="08d09eda7595c7a4a9225e3e1c5992cf">
-          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" rev="def3bf67a426e8013de578376d34f554" srcmd5="def3bf67a426e8013de578376d34f554" baserev="def3bf67a426e8013de578376d34f554" xsrcmd5="f5a7bab245bc8b8a4e528b8b441fc607" lsrcmd5="08d09eda7595c7a4a9225e3e1c5992cf" />
-          <entry name="DUMMY_FILE" md5="275876e34cf609db118f3d84b799a790" size="5" mtime="1534862270" />
-          <entry name="_config" md5="1a05ff51cbc0ee790ddd75020dc14e94" size="51" mtime="1534862349" />
-          <entry name="_link" md5="54e623c39791ca9f3db24ee0fb436950" size="169" mtime="1534862351" />
-          <entry name="somefile.txt" md5="9044d1ae989e292a5e19128f57de9e21" size="57" mtime="1534862349" />
+        <directory name="ProjectWithRepo_package" rev="6" vrev="6" srcmd5="6f64842b339b86054358d876db6f6823">
+          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" rev="1fe06d22b38ce06632413dcc7aeee49c" srcmd5="1fe06d22b38ce06632413dcc7aeee49c" baserev="1fe06d22b38ce06632413dcc7aeee49c" xsrcmd5="4c8313d77815d19b1b1dd8af509b8861" lsrcmd5="6f64842b339b86054358d876db6f6823" />
+          <entry name="DUMMY_FILE" md5="275876e34cf609db118f3d84b799a790" size="5" mtime="1536751453" />
+          <entry name="_config" md5="e76512ea4577d0a559788f9bed2f9ad8" size="58" mtime="1536753837" />
+          <entry name="_link" md5="90e4f5a99633a426e6ec73e94204889b" size="169" mtime="1536753839" />
+          <entry name="somefile.txt" md5="d5ff6c3db27c57b3d9dbc5df28a95a21" size="64" mtime="1536753837" />
         </directory>
     http_version: 
-  recorded_at: Tue, 21 Aug 2018 14:39:27 GMT
+  recorded_at: Wed, 12 Sep 2018 12:04:15 GMT
 - request:
     method: post
-    uri: http://backend:5352/source/home:tom:branches:ProjectWithRepo:Update/ProjectWithRepo_package?cmd=diff&expand=1&filelimit=10000&opackage=ProjectWithRepo_package&oproject=ProjectWithRepo:Update&rev=f5a7bab245bc8b8a4e528b8b441fc607&tarlimit=10000&view=xml&withissues=1
+    uri: http://backend:5352/source/home:tom:branches:ProjectWithRepo:Update/ProjectWithRepo_package?cmd=diff&expand=1&filelimit=10000&opackage=ProjectWithRepo_package&oproject=ProjectWithRepo:Update&rev=4c8313d77815d19b1b1dd8af509b8861&tarlimit=10000&view=xml&withissues=1
     body:
       encoding: UTF-8
       string: ''
@@ -6379,7 +6101,7 @@ http_interactions:
       Content-Type:
       - text/xml
       Content-Length:
-      - '612'
+      - '611'
       Cache-Control:
       - no-cache
       Connection:
@@ -6387,9 +6109,9 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="429ea8bb29feb3d1a7ae1b1ac67a4a73">
-          <old project="ProjectWithRepo:Update" package="ProjectWithRepo_package" rev="40" srcmd5="def3bf67a426e8013de578376d34f554" />
-          <new project="home:tom:branches:ProjectWithRepo:Update" package="ProjectWithRepo_package" rev="f5a7bab245bc8b8a4e528b8b441fc607" srcmd5="f5a7bab245bc8b8a4e528b8b441fc607" />
+        <sourcediff key="2d56d77774c45560122081162e3937e0">
+          <old project="ProjectWithRepo:Update" package="ProjectWithRepo_package" rev="6" srcmd5="1fe06d22b38ce06632413dcc7aeee49c" />
+          <new project="home:tom:branches:ProjectWithRepo:Update" package="ProjectWithRepo_package" rev="4c8313d77815d19b1b1dd8af509b8861" srcmd5="4c8313d77815d19b1b1dd8af509b8861" />
           <files>
             <file state="added">
               <new name="DUMMY_FILE" md5="275876e34cf609db118f3d84b799a790" size="5" />
@@ -6403,7 +6125,7 @@ http_interactions:
           </issues>
         </sourcediff>
     http_version: 
-  recorded_at: Tue, 21 Aug 2018 14:39:27 GMT
+  recorded_at: Wed, 12 Sep 2018 12:04:15 GMT
 - request:
     method: get
     uri: http://backend:5352/build/home:tom:branches:ProjectWithRepo:Update/_result?package=ProjectWithRepo_package&view=status
@@ -6411,10 +6133,8 @@ http_interactions:
       encoding: US-ASCII
       string: ''
     headers:
-      Content-Type:
-      - text/plain
       Accept-Encoding:
-      - identity
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
       - "*/*"
       User-Agent:
@@ -6439,7 +6159,7 @@ http_interactions:
           <result project="home:tom:branches:ProjectWithRepo:Update" repository="repository_2" arch="i586" code="broken" state="broken" details="no build type (ProjectWithRepo:Update)" />
         </resultlist>
     http_version: 
-  recorded_at: Tue, 21 Aug 2018 14:39:27 GMT
+  recorded_at: Wed, 12 Sep 2018 12:04:15 GMT
 - request:
     method: get
     uri: http://backend:5352/build/home:tom:branches:ProjectWithRepo:Update/_result?locallink=1&multibuild=1&package=ProjectWithRepo_package&view=status
@@ -6447,10 +6167,8 @@ http_interactions:
       encoding: US-ASCII
       string: ''
     headers:
-      Content-Type:
-      - text/plain
       Accept-Encoding:
-      - identity
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
       - "*/*"
       User-Agent:
@@ -6475,7 +6193,7 @@ http_interactions:
           <result project="home:tom:branches:ProjectWithRepo:Update" repository="repository_2" arch="i586" code="broken" state="broken" details="no build type (ProjectWithRepo:Update)" />
         </resultlist>
     http_version: 
-  recorded_at: Tue, 21 Aug 2018 14:39:27 GMT
+  recorded_at: Wed, 12 Sep 2018 12:04:15 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:tom:branches:ProjectWithRepo:Update/ProjectWithRepo_package
@@ -6501,19 +6219,19 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '795'
+      - '793'
     body:
       encoding: UTF-8
       string: |
-        <directory name="ProjectWithRepo_package" rev="12" vrev="12" srcmd5="08d09eda7595c7a4a9225e3e1c5992cf">
-          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" rev="def3bf67a426e8013de578376d34f554" srcmd5="def3bf67a426e8013de578376d34f554" baserev="def3bf67a426e8013de578376d34f554" xsrcmd5="f5a7bab245bc8b8a4e528b8b441fc607" lsrcmd5="08d09eda7595c7a4a9225e3e1c5992cf" />
-          <entry name="DUMMY_FILE" md5="275876e34cf609db118f3d84b799a790" size="5" mtime="1534862270" />
-          <entry name="_config" md5="1a05ff51cbc0ee790ddd75020dc14e94" size="51" mtime="1534862349" />
-          <entry name="_link" md5="54e623c39791ca9f3db24ee0fb436950" size="169" mtime="1534862351" />
-          <entry name="somefile.txt" md5="9044d1ae989e292a5e19128f57de9e21" size="57" mtime="1534862349" />
+        <directory name="ProjectWithRepo_package" rev="6" vrev="6" srcmd5="6f64842b339b86054358d876db6f6823">
+          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" rev="1fe06d22b38ce06632413dcc7aeee49c" srcmd5="1fe06d22b38ce06632413dcc7aeee49c" baserev="1fe06d22b38ce06632413dcc7aeee49c" xsrcmd5="4c8313d77815d19b1b1dd8af509b8861" lsrcmd5="6f64842b339b86054358d876db6f6823" />
+          <entry name="DUMMY_FILE" md5="275876e34cf609db118f3d84b799a790" size="5" mtime="1536751453" />
+          <entry name="_config" md5="e76512ea4577d0a559788f9bed2f9ad8" size="58" mtime="1536753837" />
+          <entry name="_link" md5="90e4f5a99633a426e6ec73e94204889b" size="169" mtime="1536753839" />
+          <entry name="somefile.txt" md5="d5ff6c3db27c57b3d9dbc5df28a95a21" size="64" mtime="1536753837" />
         </directory>
     http_version: 
-  recorded_at: Tue, 21 Aug 2018 14:39:28 GMT
+  recorded_at: Wed, 12 Sep 2018 12:04:16 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:tom:branches:ProjectWithRepo:Update/ProjectWithRepo_package
@@ -6539,22 +6257,22 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '795'
+      - '793'
     body:
       encoding: UTF-8
       string: |
-        <directory name="ProjectWithRepo_package" rev="12" vrev="12" srcmd5="08d09eda7595c7a4a9225e3e1c5992cf">
-          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" rev="def3bf67a426e8013de578376d34f554" srcmd5="def3bf67a426e8013de578376d34f554" baserev="def3bf67a426e8013de578376d34f554" xsrcmd5="f5a7bab245bc8b8a4e528b8b441fc607" lsrcmd5="08d09eda7595c7a4a9225e3e1c5992cf" />
-          <entry name="DUMMY_FILE" md5="275876e34cf609db118f3d84b799a790" size="5" mtime="1534862270" />
-          <entry name="_config" md5="1a05ff51cbc0ee790ddd75020dc14e94" size="51" mtime="1534862349" />
-          <entry name="_link" md5="54e623c39791ca9f3db24ee0fb436950" size="169" mtime="1534862351" />
-          <entry name="somefile.txt" md5="9044d1ae989e292a5e19128f57de9e21" size="57" mtime="1534862349" />
+        <directory name="ProjectWithRepo_package" rev="6" vrev="6" srcmd5="6f64842b339b86054358d876db6f6823">
+          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" rev="1fe06d22b38ce06632413dcc7aeee49c" srcmd5="1fe06d22b38ce06632413dcc7aeee49c" baserev="1fe06d22b38ce06632413dcc7aeee49c" xsrcmd5="4c8313d77815d19b1b1dd8af509b8861" lsrcmd5="6f64842b339b86054358d876db6f6823" />
+          <entry name="DUMMY_FILE" md5="275876e34cf609db118f3d84b799a790" size="5" mtime="1536751453" />
+          <entry name="_config" md5="e76512ea4577d0a559788f9bed2f9ad8" size="58" mtime="1536753837" />
+          <entry name="_link" md5="90e4f5a99633a426e6ec73e94204889b" size="169" mtime="1536753839" />
+          <entry name="somefile.txt" md5="d5ff6c3db27c57b3d9dbc5df28a95a21" size="64" mtime="1536753837" />
         </directory>
     http_version: 
-  recorded_at: Tue, 21 Aug 2018 14:39:28 GMT
+  recorded_at: Wed, 12 Sep 2018 12:04:16 GMT
 - request:
     method: post
-    uri: http://backend:5352/source/home:tom:branches:ProjectWithRepo:Update/ProjectWithRepo_package?cmd=diff&expand=1&filelimit=10000&opackage=ProjectWithRepo_package&oproject=ProjectWithRepo:Update&rev=f5a7bab245bc8b8a4e528b8b441fc607&tarlimit=10000&view=xml&withissues=1
+    uri: http://backend:5352/source/home:tom:branches:ProjectWithRepo:Update/ProjectWithRepo_package?cmd=diff&expand=1&filelimit=10000&opackage=ProjectWithRepo_package&oproject=ProjectWithRepo:Update&rev=4c8313d77815d19b1b1dd8af509b8861&tarlimit=10000&view=xml&withissues=1
     body:
       encoding: UTF-8
       string: ''
@@ -6575,7 +6293,7 @@ http_interactions:
       Content-Type:
       - text/xml
       Content-Length:
-      - '612'
+      - '611'
       Cache-Control:
       - no-cache
       Connection:
@@ -6583,9 +6301,9 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="429ea8bb29feb3d1a7ae1b1ac67a4a73">
-          <old project="ProjectWithRepo:Update" package="ProjectWithRepo_package" rev="40" srcmd5="def3bf67a426e8013de578376d34f554" />
-          <new project="home:tom:branches:ProjectWithRepo:Update" package="ProjectWithRepo_package" rev="f5a7bab245bc8b8a4e528b8b441fc607" srcmd5="f5a7bab245bc8b8a4e528b8b441fc607" />
+        <sourcediff key="2d56d77774c45560122081162e3937e0">
+          <old project="ProjectWithRepo:Update" package="ProjectWithRepo_package" rev="6" srcmd5="1fe06d22b38ce06632413dcc7aeee49c" />
+          <new project="home:tom:branches:ProjectWithRepo:Update" package="ProjectWithRepo_package" rev="4c8313d77815d19b1b1dd8af509b8861" srcmd5="4c8313d77815d19b1b1dd8af509b8861" />
           <files>
             <file state="added">
               <new name="DUMMY_FILE" md5="275876e34cf609db118f3d84b799a790" size="5" />
@@ -6599,7 +6317,7 @@ http_interactions:
           </issues>
         </sourcediff>
     http_version: 
-  recorded_at: Tue, 21 Aug 2018 14:39:28 GMT
+  recorded_at: Wed, 12 Sep 2018 12:04:16 GMT
 - request:
     method: get
     uri: http://backend:5352/build/home:tom:branches:ProjectWithRepo:Update/_result?package=ProjectWithRepo_package&view=status
@@ -6607,10 +6325,8 @@ http_interactions:
       encoding: US-ASCII
       string: ''
     headers:
-      Content-Type:
-      - text/plain
       Accept-Encoding:
-      - identity
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
       - "*/*"
       User-Agent:
@@ -6635,7 +6351,7 @@ http_interactions:
           <result project="home:tom:branches:ProjectWithRepo:Update" repository="repository_2" arch="i586" code="broken" state="broken" details="no build type (ProjectWithRepo:Update)" />
         </resultlist>
     http_version: 
-  recorded_at: Tue, 21 Aug 2018 14:39:28 GMT
+  recorded_at: Wed, 12 Sep 2018 12:04:16 GMT
 - request:
     method: get
     uri: http://backend:5352/build/home:tom:branches:ProjectWithRepo:Update/_result?locallink=1&multibuild=1&package=ProjectWithRepo_package&view=status
@@ -6643,10 +6359,8 @@ http_interactions:
       encoding: US-ASCII
       string: ''
     headers:
-      Content-Type:
-      - text/plain
       Accept-Encoding:
-      - identity
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
       - "*/*"
       User-Agent:
@@ -6671,7 +6385,7 @@ http_interactions:
           <result project="home:tom:branches:ProjectWithRepo:Update" repository="repository_2" arch="i586" code="broken" state="broken" details="no build type (ProjectWithRepo:Update)" />
         </resultlist>
     http_version: 
-  recorded_at: Tue, 21 Aug 2018 14:39:28 GMT
+  recorded_at: Wed, 12 Sep 2018 12:04:16 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:tom:branches:ProjectWithRepo:Update/ProjectWithRepo_package
@@ -6697,22 +6411,22 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '795'
+      - '793'
     body:
       encoding: UTF-8
       string: |
-        <directory name="ProjectWithRepo_package" rev="12" vrev="12" srcmd5="08d09eda7595c7a4a9225e3e1c5992cf">
-          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" rev="def3bf67a426e8013de578376d34f554" srcmd5="def3bf67a426e8013de578376d34f554" baserev="def3bf67a426e8013de578376d34f554" xsrcmd5="f5a7bab245bc8b8a4e528b8b441fc607" lsrcmd5="08d09eda7595c7a4a9225e3e1c5992cf" />
-          <entry name="DUMMY_FILE" md5="275876e34cf609db118f3d84b799a790" size="5" mtime="1534862270" />
-          <entry name="_config" md5="1a05ff51cbc0ee790ddd75020dc14e94" size="51" mtime="1534862349" />
-          <entry name="_link" md5="54e623c39791ca9f3db24ee0fb436950" size="169" mtime="1534862351" />
-          <entry name="somefile.txt" md5="9044d1ae989e292a5e19128f57de9e21" size="57" mtime="1534862349" />
+        <directory name="ProjectWithRepo_package" rev="6" vrev="6" srcmd5="6f64842b339b86054358d876db6f6823">
+          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" rev="1fe06d22b38ce06632413dcc7aeee49c" srcmd5="1fe06d22b38ce06632413dcc7aeee49c" baserev="1fe06d22b38ce06632413dcc7aeee49c" xsrcmd5="4c8313d77815d19b1b1dd8af509b8861" lsrcmd5="6f64842b339b86054358d876db6f6823" />
+          <entry name="DUMMY_FILE" md5="275876e34cf609db118f3d84b799a790" size="5" mtime="1536751453" />
+          <entry name="_config" md5="e76512ea4577d0a559788f9bed2f9ad8" size="58" mtime="1536753837" />
+          <entry name="_link" md5="90e4f5a99633a426e6ec73e94204889b" size="169" mtime="1536753839" />
+          <entry name="somefile.txt" md5="d5ff6c3db27c57b3d9dbc5df28a95a21" size="64" mtime="1536753837" />
         </directory>
     http_version: 
-  recorded_at: Tue, 21 Aug 2018 14:39:29 GMT
+  recorded_at: Wed, 12 Sep 2018 12:04:17 GMT
 - request:
     method: get
-    uri: http://backend:5352/source/home:tom:branches:ProjectWithRepo:Update/ProjectWithRepo_package?expand=1&rev=f5a7bab245bc8b8a4e528b8b441fc607
+    uri: http://backend:5352/source/home:tom:branches:ProjectWithRepo:Update/ProjectWithRepo_package?expand=1&rev=4c8313d77815d19b1b1dd8af509b8861
     body:
       encoding: US-ASCII
       string: ''
@@ -6739,17 +6453,17 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="ProjectWithRepo_package" rev="f5a7bab245bc8b8a4e528b8b441fc607" srcmd5="f5a7bab245bc8b8a4e528b8b441fc607">
-          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" rev="def3bf67a426e8013de578376d34f554" srcmd5="def3bf67a426e8013de578376d34f554" baserev="def3bf67a426e8013de578376d34f554" lsrcmd5="08d09eda7595c7a4a9225e3e1c5992cf" />
-          <entry name="DUMMY_FILE" md5="275876e34cf609db118f3d84b799a790" size="5" mtime="1534862270" />
-          <entry name="_config" md5="1a05ff51cbc0ee790ddd75020dc14e94" size="51" mtime="1534862349" />
-          <entry name="somefile.txt" md5="9044d1ae989e292a5e19128f57de9e21" size="57" mtime="1534862349" />
+        <directory name="ProjectWithRepo_package" rev="4c8313d77815d19b1b1dd8af509b8861" srcmd5="4c8313d77815d19b1b1dd8af509b8861">
+          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" rev="1fe06d22b38ce06632413dcc7aeee49c" srcmd5="1fe06d22b38ce06632413dcc7aeee49c" baserev="1fe06d22b38ce06632413dcc7aeee49c" lsrcmd5="6f64842b339b86054358d876db6f6823" />
+          <entry name="DUMMY_FILE" md5="275876e34cf609db118f3d84b799a790" size="5" mtime="1536751453" />
+          <entry name="_config" md5="e76512ea4577d0a559788f9bed2f9ad8" size="58" mtime="1536753837" />
+          <entry name="somefile.txt" md5="d5ff6c3db27c57b3d9dbc5df28a95a21" size="64" mtime="1536753837" />
         </directory>
     http_version: 
-  recorded_at: Tue, 21 Aug 2018 14:39:29 GMT
+  recorded_at: Wed, 12 Sep 2018 12:04:17 GMT
 - request:
     method: get
-    uri: http://backend:5352/source/home:tom:branches:ProjectWithRepo:Update/ProjectWithRepo_package?expand=1&rev=f5a7bab245bc8b8a4e528b8b441fc607
+    uri: http://backend:5352/source/home:tom:branches:ProjectWithRepo:Update/ProjectWithRepo_package?expand=1&rev=4c8313d77815d19b1b1dd8af509b8861
     body:
       encoding: US-ASCII
       string: ''
@@ -6776,14 +6490,14 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="ProjectWithRepo_package" rev="f5a7bab245bc8b8a4e528b8b441fc607" srcmd5="f5a7bab245bc8b8a4e528b8b441fc607">
-          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" rev="def3bf67a426e8013de578376d34f554" srcmd5="def3bf67a426e8013de578376d34f554" baserev="def3bf67a426e8013de578376d34f554" lsrcmd5="08d09eda7595c7a4a9225e3e1c5992cf" />
-          <entry name="DUMMY_FILE" md5="275876e34cf609db118f3d84b799a790" size="5" mtime="1534862270" />
-          <entry name="_config" md5="1a05ff51cbc0ee790ddd75020dc14e94" size="51" mtime="1534862349" />
-          <entry name="somefile.txt" md5="9044d1ae989e292a5e19128f57de9e21" size="57" mtime="1534862349" />
+        <directory name="ProjectWithRepo_package" rev="4c8313d77815d19b1b1dd8af509b8861" srcmd5="4c8313d77815d19b1b1dd8af509b8861">
+          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" rev="1fe06d22b38ce06632413dcc7aeee49c" srcmd5="1fe06d22b38ce06632413dcc7aeee49c" baserev="1fe06d22b38ce06632413dcc7aeee49c" lsrcmd5="6f64842b339b86054358d876db6f6823" />
+          <entry name="DUMMY_FILE" md5="275876e34cf609db118f3d84b799a790" size="5" mtime="1536751453" />
+          <entry name="_config" md5="e76512ea4577d0a559788f9bed2f9ad8" size="58" mtime="1536753837" />
+          <entry name="somefile.txt" md5="d5ff6c3db27c57b3d9dbc5df28a95a21" size="64" mtime="1536753837" />
         </directory>
     http_version: 
-  recorded_at: Tue, 21 Aug 2018 14:39:29 GMT
+  recorded_at: Wed, 12 Sep 2018 12:04:17 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:tom:branches:ProjectWithRepo:Update/ProjectWithRepo_package
@@ -6809,19 +6523,19 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '795'
+      - '793'
     body:
       encoding: UTF-8
       string: |
-        <directory name="ProjectWithRepo_package" rev="12" vrev="12" srcmd5="08d09eda7595c7a4a9225e3e1c5992cf">
-          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" rev="def3bf67a426e8013de578376d34f554" srcmd5="def3bf67a426e8013de578376d34f554" baserev="def3bf67a426e8013de578376d34f554" xsrcmd5="f5a7bab245bc8b8a4e528b8b441fc607" lsrcmd5="08d09eda7595c7a4a9225e3e1c5992cf" />
-          <entry name="DUMMY_FILE" md5="275876e34cf609db118f3d84b799a790" size="5" mtime="1534862270" />
-          <entry name="_config" md5="1a05ff51cbc0ee790ddd75020dc14e94" size="51" mtime="1534862349" />
-          <entry name="_link" md5="54e623c39791ca9f3db24ee0fb436950" size="169" mtime="1534862351" />
-          <entry name="somefile.txt" md5="9044d1ae989e292a5e19128f57de9e21" size="57" mtime="1534862349" />
+        <directory name="ProjectWithRepo_package" rev="6" vrev="6" srcmd5="6f64842b339b86054358d876db6f6823">
+          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" rev="1fe06d22b38ce06632413dcc7aeee49c" srcmd5="1fe06d22b38ce06632413dcc7aeee49c" baserev="1fe06d22b38ce06632413dcc7aeee49c" xsrcmd5="4c8313d77815d19b1b1dd8af509b8861" lsrcmd5="6f64842b339b86054358d876db6f6823" />
+          <entry name="DUMMY_FILE" md5="275876e34cf609db118f3d84b799a790" size="5" mtime="1536751453" />
+          <entry name="_config" md5="e76512ea4577d0a559788f9bed2f9ad8" size="58" mtime="1536753837" />
+          <entry name="_link" md5="90e4f5a99633a426e6ec73e94204889b" size="169" mtime="1536753839" />
+          <entry name="somefile.txt" md5="d5ff6c3db27c57b3d9dbc5df28a95a21" size="64" mtime="1536753837" />
         </directory>
     http_version: 
-  recorded_at: Tue, 21 Aug 2018 14:39:29 GMT
+  recorded_at: Wed, 12 Sep 2018 12:04:17 GMT
 - request:
     method: post
     uri: http://backend:5352/search/package/id?match=(linkinfo/@package=%22ProjectWithRepo_package%22%20and%20linkinfo/@project=%22ProjectWithRepo:Update%22%20and%20starts-with(@project,%22MaintenanceProject:%22))
@@ -6857,7 +6571,7 @@ http_interactions:
           <package name="ProjectWithRepo_package.ProjectWithRepo_Update" project="MaintenanceProject:0" />
         </collection>
     http_version: 
-  recorded_at: Tue, 21 Aug 2018 14:39:29 GMT
+  recorded_at: Wed, 12 Sep 2018 12:04:17 GMT
 - request:
     method: post
     uri: http://backend:5352/search/package/id?match=(linkinfo/@package=%22ProjectWithRepo_package%22%20and%20linkinfo/@project=%22ProjectWithRepo%22%20and%20@project=%22ProjectWithRepo%22)
@@ -6892,7 +6606,7 @@ http_interactions:
         <collection>
         </collection>
     http_version: 
-  recorded_at: Tue, 21 Aug 2018 14:39:29 GMT
+  recorded_at: Wed, 12 Sep 2018 12:04:17 GMT
 - request:
     method: put
     uri: http://backend:5352/source/MaintenanceProject:0/ProjectWithRepo_package.ProjectWithRepo_Update/_meta?user=maintenance_coord
@@ -6900,8 +6614,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="ProjectWithRepo_package.ProjectWithRepo_Update" project="MaintenanceProject:0">
-          <title>Antic Hay</title>
-          <description>A eaque voluptas optio.</description>
+          <title>The Widening Gyre</title>
+          <description>Cupiditate neque nihil consequatur.</description>
           <releasename>ProjectWithRepo_package</releasename>
           <build>
             <enable repository="ProjectWithRepo_Update"/>
@@ -6926,20 +6640,20 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '311'
+      - '331'
     body:
       encoding: UTF-8
       string: |
         <package name="ProjectWithRepo_package.ProjectWithRepo_Update" project="MaintenanceProject:0">
-          <title>Antic Hay</title>
-          <description>A eaque voluptas optio.</description>
+          <title>The Widening Gyre</title>
+          <description>Cupiditate neque nihil consequatur.</description>
           <releasename>ProjectWithRepo_package</releasename>
           <build>
             <enable repository="ProjectWithRepo_Update" />
           </build>
         </package>
     http_version: 
-  recorded_at: Tue, 21 Aug 2018 14:39:29 GMT
+  recorded_at: Wed, 12 Sep 2018 12:04:17 GMT
 - request:
     method: post
     uri: http://backend:5352/source/MaintenanceProject:0/ProjectWithRepo_package.ProjectWithRepo_Update?cmd=branch&extendvrev=1&noservice=1&opackage=ProjectWithRepo_package&oproject=ProjectWithRepo:Update&user=maintenance_coord
@@ -6967,20 +6681,20 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '217'
+      - '219'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="7" vrev="7">
-          <srcmd5>7922ce81d1cafc61978abc010f9e2ba8</srcmd5>
+        <revision rev="11" vrev="11">
+          <srcmd5>478f76e51aa8ad2105d6f2a7c70a71df</srcmd5>
           <version>unknown</version>
-          <time>1534862369</time>
+          <time>1536753857</time>
           <user>maintenance_coord</user>
           <comment></comment>
           <requestid/>
         </revision>
     http_version: 
-  recorded_at: Tue, 21 Aug 2018 14:39:29 GMT
+  recorded_at: Wed, 12 Sep 2018 12:04:17 GMT
 - request:
     method: put
     uri: http://backend:5352/source/MaintenanceProject:0/ProjectWithRepo_package.ProjectWithRepo_Update/_meta?user=maintenance_coord
@@ -6988,8 +6702,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="ProjectWithRepo_package.ProjectWithRepo_Update" project="MaintenanceProject:0">
-          <title>Antic Hay</title>
-          <description>A eaque voluptas optio.</description>
+          <title>The Widening Gyre</title>
+          <description>Cupiditate neque nihil consequatur.</description>
           <releasename>ProjectWithRepo_package</releasename>
           <build>
             <enable repository="ProjectWithRepo_Update"/>
@@ -7014,20 +6728,20 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '311'
+      - '331'
     body:
       encoding: UTF-8
       string: |
         <package name="ProjectWithRepo_package.ProjectWithRepo_Update" project="MaintenanceProject:0">
-          <title>Antic Hay</title>
-          <description>A eaque voluptas optio.</description>
+          <title>The Widening Gyre</title>
+          <description>Cupiditate neque nihil consequatur.</description>
           <releasename>ProjectWithRepo_package</releasename>
           <build>
             <enable repository="ProjectWithRepo_Update" />
           </build>
         </package>
     http_version: 
-  recorded_at: Tue, 21 Aug 2018 14:39:29 GMT
+  recorded_at: Wed, 12 Sep 2018 12:04:17 GMT
 - request:
     method: get
     uri: http://backend:5352/source/MaintenanceProject:0/ProjectWithRepo_package.ProjectWithRepo_Update
@@ -7053,18 +6767,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '680'
+      - '682'
     body:
       encoding: UTF-8
       string: |
-        <directory name="ProjectWithRepo_package.ProjectWithRepo_Update" rev="7" vrev="7" srcmd5="7922ce81d1cafc61978abc010f9e2ba8">
-          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" srcmd5="def3bf67a426e8013de578376d34f554" baserev="def3bf67a426e8013de578376d34f554" xsrcmd5="c443e5a2a5dd0f28fd22ff7d8c3527a1" lsrcmd5="7922ce81d1cafc61978abc010f9e2ba8" />
-          <entry name="_config" md5="1a05ff51cbc0ee790ddd75020dc14e94" size="51" mtime="1534862349" />
-          <entry name="_link" md5="fc6315cf4d9e91ed369a097e83d59417" size="176" mtime="1534862357" />
-          <entry name="somefile.txt" md5="9044d1ae989e292a5e19128f57de9e21" size="57" mtime="1534862349" />
+        <directory name="ProjectWithRepo_package.ProjectWithRepo_Update" rev="11" vrev="11" srcmd5="478f76e51aa8ad2105d6f2a7c70a71df">
+          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" srcmd5="1fe06d22b38ce06632413dcc7aeee49c" baserev="1fe06d22b38ce06632413dcc7aeee49c" xsrcmd5="e6ff6888d08544c3b12eed46fcf1310e" lsrcmd5="478f76e51aa8ad2105d6f2a7c70a71df" />
+          <entry name="_config" md5="e76512ea4577d0a559788f9bed2f9ad8" size="58" mtime="1536753837" />
+          <entry name="_link" md5="a1f2d4062a5ea3a9a83bcf0195340932" size="175" mtime="1536753845" />
+          <entry name="somefile.txt" md5="d5ff6c3db27c57b3d9dbc5df28a95a21" size="64" mtime="1536753837" />
         </directory>
     http_version: 
-  recorded_at: Tue, 21 Aug 2018 14:39:29 GMT
+  recorded_at: Wed, 12 Sep 2018 12:04:17 GMT
 - request:
     method: get
     uri: http://backend:5352/source/MaintenanceProject:0/ProjectWithRepo_package.ProjectWithRepo_Update?view=info
@@ -7090,17 +6804,17 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '463'
+      - '464'
     body:
       encoding: UTF-8
       string: |
-        <sourceinfo package="ProjectWithRepo_package.ProjectWithRepo_Update" rev="7" vrev="41.8" srcmd5="c443e5a2a5dd0f28fd22ff7d8c3527a1" lsrcmd5="7922ce81d1cafc61978abc010f9e2ba8" verifymd5="def3bf67a426e8013de578376d34f554">
+        <sourceinfo package="ProjectWithRepo_package.ProjectWithRepo_Update" rev="11" vrev="7.12" srcmd5="e6ff6888d08544c3b12eed46fcf1310e" lsrcmd5="478f76e51aa8ad2105d6f2a7c70a71df" verifymd5="1fe06d22b38ce06632413dcc7aeee49c">
           <error>bad build configuration, no build type defined or detected</error>
           <linked project="ProjectWithRepo:Update" package="ProjectWithRepo_package" />
           <linked project="ProjectWithRepo" package="ProjectWithRepo_package" />
         </sourceinfo>
     http_version: 
-  recorded_at: Tue, 21 Aug 2018 14:39:29 GMT
+  recorded_at: Wed, 12 Sep 2018 12:04:17 GMT
 - request:
     method: get
     uri: http://backend:5352/source/MaintenanceProject:0/ProjectWithRepo_package.ProjectWithRepo_Update
@@ -7126,18 +6840,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '680'
+      - '682'
     body:
       encoding: UTF-8
       string: |
-        <directory name="ProjectWithRepo_package.ProjectWithRepo_Update" rev="7" vrev="7" srcmd5="7922ce81d1cafc61978abc010f9e2ba8">
-          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" srcmd5="def3bf67a426e8013de578376d34f554" baserev="def3bf67a426e8013de578376d34f554" xsrcmd5="c443e5a2a5dd0f28fd22ff7d8c3527a1" lsrcmd5="7922ce81d1cafc61978abc010f9e2ba8" />
-          <entry name="_config" md5="1a05ff51cbc0ee790ddd75020dc14e94" size="51" mtime="1534862349" />
-          <entry name="_link" md5="fc6315cf4d9e91ed369a097e83d59417" size="176" mtime="1534862357" />
-          <entry name="somefile.txt" md5="9044d1ae989e292a5e19128f57de9e21" size="57" mtime="1534862349" />
+        <directory name="ProjectWithRepo_package.ProjectWithRepo_Update" rev="11" vrev="11" srcmd5="478f76e51aa8ad2105d6f2a7c70a71df">
+          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" srcmd5="1fe06d22b38ce06632413dcc7aeee49c" baserev="1fe06d22b38ce06632413dcc7aeee49c" xsrcmd5="e6ff6888d08544c3b12eed46fcf1310e" lsrcmd5="478f76e51aa8ad2105d6f2a7c70a71df" />
+          <entry name="_config" md5="e76512ea4577d0a559788f9bed2f9ad8" size="58" mtime="1536753837" />
+          <entry name="_link" md5="a1f2d4062a5ea3a9a83bcf0195340932" size="175" mtime="1536753845" />
+          <entry name="somefile.txt" md5="d5ff6c3db27c57b3d9dbc5df28a95a21" size="64" mtime="1536753837" />
         </directory>
     http_version: 
-  recorded_at: Tue, 21 Aug 2018 14:39:29 GMT
+  recorded_at: Wed, 12 Sep 2018 12:04:17 GMT
 - request:
     method: post
     uri: http://backend:5352/source/MaintenanceProject:0/ProjectWithRepo_package.ProjectWithRepo_Update?cmd=diff&linkrev=base&onlyissues=1&orev=0&view=xml
@@ -7169,15 +6883,15 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="22401888f8e8f4aa98b140b40836da89">
+        <sourcediff key="7a33aa03e04e7a187015dd00ca9ccb3d">
           <old project="MaintenanceProject:0" package="ProjectWithRepo_package.ProjectWithRepo_Update" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e" />
-          <new project="MaintenanceProject:0" package="ProjectWithRepo_package.ProjectWithRepo_Update" rev="5" srcmd5="7922ce81d1cafc61978abc010f9e2ba8" />
+          <new project="MaintenanceProject:0" package="ProjectWithRepo_package.ProjectWithRepo_Update" rev="9" srcmd5="478f76e51aa8ad2105d6f2a7c70a71df" />
           <files />
           <issues>
           </issues>
         </sourcediff>
     http_version: 
-  recorded_at: Tue, 21 Aug 2018 14:39:29 GMT
+  recorded_at: Wed, 12 Sep 2018 12:04:17 GMT
 - request:
     method: post
     uri: http://backend:5352/source/MaintenanceProject:0/ProjectWithRepo_package.ProjectWithRepo_Update?cmd=linkdiff&linkrev=base&onlyissues=1&view=xml
@@ -7209,13 +6923,13 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="ca148e9fabc33d3ec7bf00197d908826">
-          <old project="ProjectWithRepo:Update" package="ProjectWithRepo_package" rev="def3bf67a426e8013de578376d34f554" srcmd5="def3bf67a426e8013de578376d34f554" />
-          <new project="MaintenanceProject:0" package="ProjectWithRepo_package.ProjectWithRepo_Update" rev="c443e5a2a5dd0f28fd22ff7d8c3527a1" srcmd5="c443e5a2a5dd0f28fd22ff7d8c3527a1" />
+        <sourcediff key="466e1cb8c8175a72d4e3fb1b7d5173c0">
+          <old project="ProjectWithRepo:Update" package="ProjectWithRepo_package" rev="1fe06d22b38ce06632413dcc7aeee49c" srcmd5="1fe06d22b38ce06632413dcc7aeee49c" />
+          <new project="MaintenanceProject:0" package="ProjectWithRepo_package.ProjectWithRepo_Update" rev="e6ff6888d08544c3b12eed46fcf1310e" srcmd5="e6ff6888d08544c3b12eed46fcf1310e" />
           <files />
         </sourcediff>
     http_version: 
-  recorded_at: Tue, 21 Aug 2018 14:39:29 GMT
+  recorded_at: Wed, 12 Sep 2018 12:04:17 GMT
 - request:
     method: put
     uri: http://backend:5352/source/MaintenanceProject:0/ProjectWithRepo_package.ProjectWithRepo_Update/_meta?user=maintenance_coord
@@ -7223,8 +6937,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="ProjectWithRepo_package.ProjectWithRepo_Update" project="MaintenanceProject:0">
-          <title>Antic Hay</title>
-          <description>A eaque voluptas optio.</description>
+          <title>The Widening Gyre</title>
+          <description>Cupiditate neque nihil consequatur.</description>
           <releasename>ProjectWithRepo_package</releasename>
           <build>
             <enable repository="ProjectWithRepo_Update"/>
@@ -7250,13 +6964,13 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '362'
+      - '382'
     body:
       encoding: UTF-8
       string: |
         <package name="ProjectWithRepo_package.ProjectWithRepo_Update" project="MaintenanceProject:0">
-          <title>Antic Hay</title>
-          <description>A eaque voluptas optio.</description>
+          <title>The Widening Gyre</title>
+          <description>Cupiditate neque nihil consequatur.</description>
           <releasename>ProjectWithRepo_package</releasename>
           <build>
             <enable repository="ProjectWithRepo_Update" />
@@ -7264,7 +6978,7 @@ http_interactions:
           </build>
         </package>
     http_version: 
-  recorded_at: Tue, 21 Aug 2018 14:39:29 GMT
+  recorded_at: Wed, 12 Sep 2018 12:04:17 GMT
 - request:
     method: get
     uri: http://backend:5352/source/MaintenanceProject:0/ProjectWithRepo_package.ProjectWithRepo_Update
@@ -7290,18 +7004,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '680'
+      - '682'
     body:
       encoding: UTF-8
       string: |
-        <directory name="ProjectWithRepo_package.ProjectWithRepo_Update" rev="7" vrev="7" srcmd5="7922ce81d1cafc61978abc010f9e2ba8">
-          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" srcmd5="def3bf67a426e8013de578376d34f554" baserev="def3bf67a426e8013de578376d34f554" xsrcmd5="c443e5a2a5dd0f28fd22ff7d8c3527a1" lsrcmd5="7922ce81d1cafc61978abc010f9e2ba8" />
-          <entry name="_config" md5="1a05ff51cbc0ee790ddd75020dc14e94" size="51" mtime="1534862349" />
-          <entry name="_link" md5="fc6315cf4d9e91ed369a097e83d59417" size="176" mtime="1534862357" />
-          <entry name="somefile.txt" md5="9044d1ae989e292a5e19128f57de9e21" size="57" mtime="1534862349" />
+        <directory name="ProjectWithRepo_package.ProjectWithRepo_Update" rev="11" vrev="11" srcmd5="478f76e51aa8ad2105d6f2a7c70a71df">
+          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" srcmd5="1fe06d22b38ce06632413dcc7aeee49c" baserev="1fe06d22b38ce06632413dcc7aeee49c" xsrcmd5="e6ff6888d08544c3b12eed46fcf1310e" lsrcmd5="478f76e51aa8ad2105d6f2a7c70a71df" />
+          <entry name="_config" md5="e76512ea4577d0a559788f9bed2f9ad8" size="58" mtime="1536753837" />
+          <entry name="_link" md5="a1f2d4062a5ea3a9a83bcf0195340932" size="175" mtime="1536753845" />
+          <entry name="somefile.txt" md5="d5ff6c3db27c57b3d9dbc5df28a95a21" size="64" mtime="1536753837" />
         </directory>
     http_version: 
-  recorded_at: Tue, 21 Aug 2018 14:39:29 GMT
+  recorded_at: Wed, 12 Sep 2018 12:04:17 GMT
 - request:
     method: get
     uri: http://backend:5352/source/MaintenanceProject:0/ProjectWithRepo_package.ProjectWithRepo_Update
@@ -7327,18 +7041,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '680'
+      - '682'
     body:
       encoding: UTF-8
       string: |
-        <directory name="ProjectWithRepo_package.ProjectWithRepo_Update" rev="7" vrev="7" srcmd5="7922ce81d1cafc61978abc010f9e2ba8">
-          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" srcmd5="def3bf67a426e8013de578376d34f554" baserev="def3bf67a426e8013de578376d34f554" xsrcmd5="c443e5a2a5dd0f28fd22ff7d8c3527a1" lsrcmd5="7922ce81d1cafc61978abc010f9e2ba8" />
-          <entry name="_config" md5="1a05ff51cbc0ee790ddd75020dc14e94" size="51" mtime="1534862349" />
-          <entry name="_link" md5="fc6315cf4d9e91ed369a097e83d59417" size="176" mtime="1534862357" />
-          <entry name="somefile.txt" md5="9044d1ae989e292a5e19128f57de9e21" size="57" mtime="1534862349" />
+        <directory name="ProjectWithRepo_package.ProjectWithRepo_Update" rev="11" vrev="11" srcmd5="478f76e51aa8ad2105d6f2a7c70a71df">
+          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" srcmd5="1fe06d22b38ce06632413dcc7aeee49c" baserev="1fe06d22b38ce06632413dcc7aeee49c" xsrcmd5="e6ff6888d08544c3b12eed46fcf1310e" lsrcmd5="478f76e51aa8ad2105d6f2a7c70a71df" />
+          <entry name="_config" md5="e76512ea4577d0a559788f9bed2f9ad8" size="58" mtime="1536753837" />
+          <entry name="_link" md5="a1f2d4062a5ea3a9a83bcf0195340932" size="175" mtime="1536753845" />
+          <entry name="somefile.txt" md5="d5ff6c3db27c57b3d9dbc5df28a95a21" size="64" mtime="1536753837" />
         </directory>
     http_version: 
-  recorded_at: Tue, 21 Aug 2018 14:39:29 GMT
+  recorded_at: Wed, 12 Sep 2018 12:04:17 GMT
 - request:
     method: get
     uri: http://backend:5352/source/MaintenanceProject:0/ProjectWithRepo_package.ProjectWithRepo_Update
@@ -7364,18 +7078,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '680'
+      - '682'
     body:
       encoding: UTF-8
       string: |
-        <directory name="ProjectWithRepo_package.ProjectWithRepo_Update" rev="7" vrev="7" srcmd5="7922ce81d1cafc61978abc010f9e2ba8">
-          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" srcmd5="def3bf67a426e8013de578376d34f554" baserev="def3bf67a426e8013de578376d34f554" xsrcmd5="c443e5a2a5dd0f28fd22ff7d8c3527a1" lsrcmd5="7922ce81d1cafc61978abc010f9e2ba8" />
-          <entry name="_config" md5="1a05ff51cbc0ee790ddd75020dc14e94" size="51" mtime="1534862349" />
-          <entry name="_link" md5="fc6315cf4d9e91ed369a097e83d59417" size="176" mtime="1534862357" />
-          <entry name="somefile.txt" md5="9044d1ae989e292a5e19128f57de9e21" size="57" mtime="1534862349" />
+        <directory name="ProjectWithRepo_package.ProjectWithRepo_Update" rev="11" vrev="11" srcmd5="478f76e51aa8ad2105d6f2a7c70a71df">
+          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" srcmd5="1fe06d22b38ce06632413dcc7aeee49c" baserev="1fe06d22b38ce06632413dcc7aeee49c" xsrcmd5="e6ff6888d08544c3b12eed46fcf1310e" lsrcmd5="478f76e51aa8ad2105d6f2a7c70a71df" />
+          <entry name="_config" md5="e76512ea4577d0a559788f9bed2f9ad8" size="58" mtime="1536753837" />
+          <entry name="_link" md5="a1f2d4062a5ea3a9a83bcf0195340932" size="175" mtime="1536753845" />
+          <entry name="somefile.txt" md5="d5ff6c3db27c57b3d9dbc5df28a95a21" size="64" mtime="1536753837" />
         </directory>
     http_version: 
-  recorded_at: Tue, 21 Aug 2018 14:39:29 GMT
+  recorded_at: Wed, 12 Sep 2018 12:04:17 GMT
 - request:
     method: post
     uri: http://backend:5352/search/package/id?match=(linkinfo/@package=%22ProjectWithRepo_package%22%20and%20linkinfo/@project=%22ProjectWithRepo%22%20and%20@project=%22ProjectWithRepo%22)
@@ -7410,7 +7124,7 @@ http_interactions:
         <collection>
         </collection>
     http_version: 
-  recorded_at: Tue, 21 Aug 2018 14:39:29 GMT
+  recorded_at: Wed, 12 Sep 2018 12:04:17 GMT
 - request:
     method: put
     uri: http://backend:5352/source/MaintenanceProject:0/_meta?user=maintenance_coord
@@ -7475,7 +7189,7 @@ http_interactions:
           </repository>
         </project>
     http_version: 
-  recorded_at: Tue, 21 Aug 2018 14:39:30 GMT
+  recorded_at: Wed, 12 Sep 2018 12:04:18 GMT
 - request:
     method: put
     uri: http://backend:5352/source/MaintenanceProject:0/_meta?user=maintenance_coord
@@ -7540,10 +7254,10 @@ http_interactions:
           </repository>
         </project>
     http_version: 
-  recorded_at: Tue, 21 Aug 2018 14:39:30 GMT
+  recorded_at: Wed, 12 Sep 2018 12:04:18 GMT
 - request:
     method: post
-    uri: http://backend:5352/source/MaintenanceProject:0/ProjectWithRepo_package.ProjectWithRepo_Update?cmd=copy&comment=Maintenance%20incident%20copy%20from%20project%20home:tom:branches:ProjectWithRepo:Update&expand=1&keeplink=1&opackage=ProjectWithRepo_package&oproject=home:tom:branches:ProjectWithRepo:Update&orev=f5a7bab245bc8b8a4e528b8b441fc607&requestid=2&user=maintenance_coord&withacceptinfo=1
+    uri: http://backend:5352/source/MaintenanceProject:0/ProjectWithRepo_package.ProjectWithRepo_Update?cmd=copy&comment=Maintenance%20incident%20copy%20from%20project%20home:tom:branches:ProjectWithRepo:Update&expand=1&keeplink=1&opackage=ProjectWithRepo_package&oproject=home:tom:branches:ProjectWithRepo:Update&orev=4c8313d77815d19b1b1dd8af509b8861&requestid=2&user=maintenance_coord&withacceptinfo=1
     body:
       encoding: UTF-8
       string: ''
@@ -7568,21 +7282,21 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '505'
+      - '508'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="8" vrev="8">
-          <srcmd5>e682289d8849655423bc12c13c429a3d</srcmd5>
+        <revision rev="12" vrev="12">
+          <srcmd5>1b7a806c27e72befe7752ec51001d414</srcmd5>
           <version>unknown</version>
-          <time>1534862370</time>
+          <time>1536753858</time>
           <user>maintenance_coord</user>
           <comment>Maintenance incident copy from project home:tom:branches:ProjectWithRepo:Update</comment>
           <requestid>2</requestid>
-          <acceptinfo rev="8" srcmd5="e682289d8849655423bc12c13c429a3d" osrcmd5="7922ce81d1cafc61978abc010f9e2ba8" xsrcmd5="3685604074c501a0c064a83e101cf52e" oxsrcmd5="c443e5a2a5dd0f28fd22ff7d8c3527a1" />
+          <acceptinfo rev="12" srcmd5="1b7a806c27e72befe7752ec51001d414" osrcmd5="478f76e51aa8ad2105d6f2a7c70a71df" xsrcmd5="275fdb6919cc016e94566968c0c4aeb5" oxsrcmd5="e6ff6888d08544c3b12eed46fcf1310e" />
         </revision>
     http_version: 
-  recorded_at: Tue, 21 Aug 2018 14:39:30 GMT
+  recorded_at: Wed, 12 Sep 2018 12:04:18 GMT
 - request:
     method: put
     uri: http://backend:5352/source/MaintenanceProject:0/ProjectWithRepo_package.ProjectWithRepo_Update/_meta?user=maintenance_coord
@@ -7590,8 +7304,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="ProjectWithRepo_package.ProjectWithRepo_Update" project="MaintenanceProject:0">
-          <title>Antic Hay</title>
-          <description>A eaque voluptas optio.</description>
+          <title>The Widening Gyre</title>
+          <description>Cupiditate neque nihil consequatur.</description>
           <releasename>ProjectWithRepo_package</releasename>
           <build>
             <enable repository="ProjectWithRepo_Update"/>
@@ -7617,13 +7331,13 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '362'
+      - '382'
     body:
       encoding: UTF-8
       string: |
         <package name="ProjectWithRepo_package.ProjectWithRepo_Update" project="MaintenanceProject:0">
-          <title>Antic Hay</title>
-          <description>A eaque voluptas optio.</description>
+          <title>The Widening Gyre</title>
+          <description>Cupiditate neque nihil consequatur.</description>
           <releasename>ProjectWithRepo_package</releasename>
           <build>
             <enable repository="ProjectWithRepo_Update" />
@@ -7631,7 +7345,7 @@ http_interactions:
           </build>
         </package>
     http_version: 
-  recorded_at: Tue, 21 Aug 2018 14:39:30 GMT
+  recorded_at: Wed, 12 Sep 2018 12:04:18 GMT
 - request:
     method: get
     uri: http://backend:5352/source/MaintenanceProject:0/ProjectWithRepo_package.ProjectWithRepo_Update
@@ -7657,19 +7371,19 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '777'
+      - '779'
     body:
       encoding: UTF-8
       string: |
-        <directory name="ProjectWithRepo_package.ProjectWithRepo_Update" rev="8" vrev="8" srcmd5="e682289d8849655423bc12c13c429a3d">
-          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" srcmd5="def3bf67a426e8013de578376d34f554" baserev="def3bf67a426e8013de578376d34f554" xsrcmd5="3685604074c501a0c064a83e101cf52e" lsrcmd5="e682289d8849655423bc12c13c429a3d" />
-          <entry name="DUMMY_FILE" md5="275876e34cf609db118f3d84b799a790" size="5" mtime="1534862270" />
-          <entry name="_config" md5="1a05ff51cbc0ee790ddd75020dc14e94" size="51" mtime="1534862349" />
-          <entry name="_link" md5="fc6315cf4d9e91ed369a097e83d59417" size="176" mtime="1534862357" />
-          <entry name="somefile.txt" md5="9044d1ae989e292a5e19128f57de9e21" size="57" mtime="1534862349" />
+        <directory name="ProjectWithRepo_package.ProjectWithRepo_Update" rev="12" vrev="12" srcmd5="1b7a806c27e72befe7752ec51001d414">
+          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" srcmd5="1fe06d22b38ce06632413dcc7aeee49c" baserev="1fe06d22b38ce06632413dcc7aeee49c" xsrcmd5="275fdb6919cc016e94566968c0c4aeb5" lsrcmd5="1b7a806c27e72befe7752ec51001d414" />
+          <entry name="DUMMY_FILE" md5="275876e34cf609db118f3d84b799a790" size="5" mtime="1536751453" />
+          <entry name="_config" md5="e76512ea4577d0a559788f9bed2f9ad8" size="58" mtime="1536753837" />
+          <entry name="_link" md5="a1f2d4062a5ea3a9a83bcf0195340932" size="175" mtime="1536753845" />
+          <entry name="somefile.txt" md5="d5ff6c3db27c57b3d9dbc5df28a95a21" size="64" mtime="1536753837" />
         </directory>
     http_version: 
-  recorded_at: Tue, 21 Aug 2018 14:39:30 GMT
+  recorded_at: Wed, 12 Sep 2018 12:04:18 GMT
 - request:
     method: get
     uri: http://backend:5352/source/MaintenanceProject:0/ProjectWithRepo_package.ProjectWithRepo_Update?view=info
@@ -7695,17 +7409,17 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '463'
+      - '464'
     body:
       encoding: UTF-8
       string: |
-        <sourceinfo package="ProjectWithRepo_package.ProjectWithRepo_Update" rev="8" vrev="41.9" srcmd5="3685604074c501a0c064a83e101cf52e" lsrcmd5="e682289d8849655423bc12c13c429a3d" verifymd5="911b8ebdc893292a25313ef6deba0a7d">
+        <sourceinfo package="ProjectWithRepo_package.ProjectWithRepo_Update" rev="12" vrev="7.13" srcmd5="275fdb6919cc016e94566968c0c4aeb5" lsrcmd5="1b7a806c27e72befe7752ec51001d414" verifymd5="06a0eba83b76c7de00de4dad643e32e6">
           <error>bad build configuration, no build type defined or detected</error>
           <linked project="ProjectWithRepo:Update" package="ProjectWithRepo_package" />
           <linked project="ProjectWithRepo" package="ProjectWithRepo_package" />
         </sourceinfo>
     http_version: 
-  recorded_at: Tue, 21 Aug 2018 14:39:30 GMT
+  recorded_at: Wed, 12 Sep 2018 12:04:18 GMT
 - request:
     method: get
     uri: http://backend:5352/source/MaintenanceProject:0/ProjectWithRepo_package.ProjectWithRepo_Update
@@ -7731,19 +7445,19 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '777'
+      - '779'
     body:
       encoding: UTF-8
       string: |
-        <directory name="ProjectWithRepo_package.ProjectWithRepo_Update" rev="8" vrev="8" srcmd5="e682289d8849655423bc12c13c429a3d">
-          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" srcmd5="def3bf67a426e8013de578376d34f554" baserev="def3bf67a426e8013de578376d34f554" xsrcmd5="3685604074c501a0c064a83e101cf52e" lsrcmd5="e682289d8849655423bc12c13c429a3d" />
-          <entry name="DUMMY_FILE" md5="275876e34cf609db118f3d84b799a790" size="5" mtime="1534862270" />
-          <entry name="_config" md5="1a05ff51cbc0ee790ddd75020dc14e94" size="51" mtime="1534862349" />
-          <entry name="_link" md5="fc6315cf4d9e91ed369a097e83d59417" size="176" mtime="1534862357" />
-          <entry name="somefile.txt" md5="9044d1ae989e292a5e19128f57de9e21" size="57" mtime="1534862349" />
+        <directory name="ProjectWithRepo_package.ProjectWithRepo_Update" rev="12" vrev="12" srcmd5="1b7a806c27e72befe7752ec51001d414">
+          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" srcmd5="1fe06d22b38ce06632413dcc7aeee49c" baserev="1fe06d22b38ce06632413dcc7aeee49c" xsrcmd5="275fdb6919cc016e94566968c0c4aeb5" lsrcmd5="1b7a806c27e72befe7752ec51001d414" />
+          <entry name="DUMMY_FILE" md5="275876e34cf609db118f3d84b799a790" size="5" mtime="1536751453" />
+          <entry name="_config" md5="e76512ea4577d0a559788f9bed2f9ad8" size="58" mtime="1536753837" />
+          <entry name="_link" md5="a1f2d4062a5ea3a9a83bcf0195340932" size="175" mtime="1536753845" />
+          <entry name="somefile.txt" md5="d5ff6c3db27c57b3d9dbc5df28a95a21" size="64" mtime="1536753837" />
         </directory>
     http_version: 
-  recorded_at: Tue, 21 Aug 2018 14:39:30 GMT
+  recorded_at: Wed, 12 Sep 2018 12:04:18 GMT
 - request:
     method: post
     uri: http://backend:5352/source/MaintenanceProject:0/ProjectWithRepo_package.ProjectWithRepo_Update?cmd=diff&linkrev=base&onlyissues=1&orev=0&view=xml
@@ -7767,7 +7481,7 @@ http_interactions:
       Content-Type:
       - text/xml
       Content-Length:
-      - '397'
+      - '398'
       Cache-Control:
       - no-cache
       Connection:
@@ -7775,15 +7489,15 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="9f2add890cd5d5b32b6239f029cd64a4">
+        <sourcediff key="7f6a7177bde2284912f672af6c4c8661">
           <old project="MaintenanceProject:0" package="ProjectWithRepo_package.ProjectWithRepo_Update" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e" />
-          <new project="MaintenanceProject:0" package="ProjectWithRepo_package.ProjectWithRepo_Update" rev="6" srcmd5="e682289d8849655423bc12c13c429a3d" />
+          <new project="MaintenanceProject:0" package="ProjectWithRepo_package.ProjectWithRepo_Update" rev="10" srcmd5="1b7a806c27e72befe7752ec51001d414" />
           <files />
           <issues>
           </issues>
         </sourcediff>
     http_version: 
-  recorded_at: Tue, 21 Aug 2018 14:39:30 GMT
+  recorded_at: Wed, 12 Sep 2018 12:04:18 GMT
 - request:
     method: post
     uri: http://backend:5352/source/MaintenanceProject:0/ProjectWithRepo_package.ProjectWithRepo_Update?cmd=linkdiff&linkrev=base&onlyissues=1&view=xml
@@ -7815,15 +7529,15 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="9120b46ac17e3ca442167869e9045bef">
-          <old project="ProjectWithRepo:Update" package="ProjectWithRepo_package" rev="def3bf67a426e8013de578376d34f554" srcmd5="def3bf67a426e8013de578376d34f554" />
-          <new project="MaintenanceProject:0" package="ProjectWithRepo_package.ProjectWithRepo_Update" rev="3685604074c501a0c064a83e101cf52e" srcmd5="3685604074c501a0c064a83e101cf52e" />
+        <sourcediff key="f2891c34d2b4318b130893af853e72f6">
+          <old project="ProjectWithRepo:Update" package="ProjectWithRepo_package" rev="1fe06d22b38ce06632413dcc7aeee49c" srcmd5="1fe06d22b38ce06632413dcc7aeee49c" />
+          <new project="MaintenanceProject:0" package="ProjectWithRepo_package.ProjectWithRepo_Update" rev="275fdb6919cc016e94566968c0c4aeb5" srcmd5="275fdb6919cc016e94566968c0c4aeb5" />
           <files />
           <issues>
           </issues>
         </sourcediff>
     http_version: 
-  recorded_at: Tue, 21 Aug 2018 14:39:30 GMT
+  recorded_at: Wed, 12 Sep 2018 12:04:18 GMT
 - request:
     method: put
     uri: http://backend:5352/source/MaintenanceProject:0/_meta?comment=maintenance_incident%20request%202&requestid=2&user=maintenance_coord
@@ -7888,10 +7602,10 @@ http_interactions:
           </repository>
         </project>
     http_version: 
-  recorded_at: Tue, 21 Aug 2018 14:39:30 GMT
+  recorded_at: Wed, 12 Sep 2018 12:04:18 GMT
 - request:
     method: post
-    uri: http://backend:5352/source/MaintenanceProject:0/ProjectWithRepo_package.ProjectWithRepo_Update?cmd=diff&filelimit=10000&orev=c443e5a2a5dd0f28fd22ff7d8c3527a1&rev=3685604074c501a0c064a83e101cf52e&tarlimit=10000&view=xml&withissues=1
+    uri: http://backend:5352/source/MaintenanceProject:0/ProjectWithRepo_package.ProjectWithRepo_Update?cmd=diff&filelimit=10000&orev=e6ff6888d08544c3b12eed46fcf1310e&rev=275fdb6919cc016e94566968c0c4aeb5&tarlimit=10000&view=xml&withissues=1
     body:
       encoding: UTF-8
       string: ''
@@ -7920,9 +7634,9 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="481242edec873d502f9cb1d3b40be416">
-          <old project="MaintenanceProject:0" package="ProjectWithRepo_package.ProjectWithRepo_Update" rev="c443e5a2a5dd0f28fd22ff7d8c3527a1" srcmd5="c443e5a2a5dd0f28fd22ff7d8c3527a1" />
-          <new project="MaintenanceProject:0" package="ProjectWithRepo_package.ProjectWithRepo_Update" rev="3685604074c501a0c064a83e101cf52e" srcmd5="3685604074c501a0c064a83e101cf52e" />
+        <sourcediff key="808ee903b18ff36e974bb24d3c196e8a">
+          <old project="MaintenanceProject:0" package="ProjectWithRepo_package.ProjectWithRepo_Update" rev="e6ff6888d08544c3b12eed46fcf1310e" srcmd5="e6ff6888d08544c3b12eed46fcf1310e" />
+          <new project="MaintenanceProject:0" package="ProjectWithRepo_package.ProjectWithRepo_Update" rev="275fdb6919cc016e94566968c0c4aeb5" srcmd5="275fdb6919cc016e94566968c0c4aeb5" />
           <files>
             <file state="added">
               <new name="DUMMY_FILE" md5="275876e34cf609db118f3d84b799a790" size="5" />
@@ -7936,7 +7650,7 @@ http_interactions:
           </issues>
         </sourcediff>
     http_version: 
-  recorded_at: Tue, 21 Aug 2018 14:39:30 GMT
+  recorded_at: Wed, 12 Sep 2018 12:04:18 GMT
 - request:
     method: get
     uri: http://backend:5352/build/home:tom:branches:ProjectWithRepo:Update/_result?package=ProjectWithRepo_package&view=status
@@ -7944,10 +7658,8 @@ http_interactions:
       encoding: US-ASCII
       string: ''
     headers:
-      Content-Type:
-      - text/plain
       Accept-Encoding:
-      - identity
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
       - "*/*"
       User-Agent:
@@ -7972,7 +7684,7 @@ http_interactions:
           <result project="home:tom:branches:ProjectWithRepo:Update" repository="repository_2" arch="i586" code="broken" state="broken" details="no build type (ProjectWithRepo:Update)" />
         </resultlist>
     http_version: 
-  recorded_at: Tue, 21 Aug 2018 14:39:30 GMT
+  recorded_at: Wed, 12 Sep 2018 12:04:18 GMT
 - request:
     method: get
     uri: http://backend:5352/build/home:tom:branches:ProjectWithRepo:Update/_result?locallink=1&multibuild=1&package=ProjectWithRepo_package&view=status
@@ -7980,10 +7692,8 @@ http_interactions:
       encoding: US-ASCII
       string: ''
     headers:
-      Content-Type:
-      - text/plain
       Accept-Encoding:
-      - identity
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
       - "*/*"
       User-Agent:
@@ -8008,7 +7718,7 @@ http_interactions:
           <result project="home:tom:branches:ProjectWithRepo:Update" repository="repository_2" arch="i586" code="broken" state="broken" details="no build type (ProjectWithRepo:Update)" />
         </resultlist>
     http_version: 
-  recorded_at: Tue, 21 Aug 2018 14:39:30 GMT
+  recorded_at: Wed, 12 Sep 2018 12:04:18 GMT
 - request:
     method: get
     uri: http://backend:5352/build/MaintenanceProject:0/_result?code=unresolvable&view=status
@@ -8042,7 +7752,7 @@ http_interactions:
           <result project="MaintenanceProject:0" repository="ProjectWithRepo_Update" arch="i586" code="broken" state="broken" details="no build type (ProjectWithRepo:Update)" />
         </resultlist>
     http_version: 
-  recorded_at: Tue, 21 Aug 2018 14:39:30 GMT
+  recorded_at: Wed, 12 Sep 2018 12:04:18 GMT
 - request:
     method: get
     uri: http://backend:5352/source/MaintenanceProject:0/patchinfo
@@ -8072,11 +7782,11 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="patchinfo" rev="6" vrev="6" srcmd5="177d57906eba63ae56a64a367592144a">
-          <entry name="_patchinfo" md5="ac29f7f1abd9ef43afeb43fc7737c007" size="318" mtime="1534862280" />
+        <directory name="patchinfo" rev="9" vrev="9" srcmd5="177d57906eba63ae56a64a367592144a">
+          <entry name="_patchinfo" md5="ac29f7f1abd9ef43afeb43fc7737c007" size="318" mtime="1536751463" />
         </directory>
     http_version: 
-  recorded_at: Tue, 21 Aug 2018 14:39:30 GMT
+  recorded_at: Wed, 12 Sep 2018 12:04:18 GMT
 - request:
     method: get
     uri: http://backend:5352/build/MaintenanceProject:0/_result?view=summary
@@ -8084,10 +7794,8 @@ http_interactions:
       encoding: US-ASCII
       string: ''
     headers:
-      Content-Type:
-      - text/plain
       Accept-Encoding:
-      - identity
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
       - "*/*"
       User-Agent:
@@ -8114,7 +7822,7 @@ http_interactions:
           </result>
         </resultlist>
     http_version: 
-  recorded_at: Tue, 21 Aug 2018 14:39:31 GMT
+  recorded_at: Wed, 12 Sep 2018 12:04:19 GMT
 - request:
     method: get
     uri: http://backend:5352/source/MaintenanceProject:0/ProjectWithRepo_package.ProjectWithRepo_Update
@@ -8140,19 +7848,19 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '777'
+      - '779'
     body:
       encoding: UTF-8
       string: |
-        <directory name="ProjectWithRepo_package.ProjectWithRepo_Update" rev="8" vrev="8" srcmd5="e682289d8849655423bc12c13c429a3d">
-          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" srcmd5="def3bf67a426e8013de578376d34f554" baserev="def3bf67a426e8013de578376d34f554" xsrcmd5="3685604074c501a0c064a83e101cf52e" lsrcmd5="e682289d8849655423bc12c13c429a3d" />
-          <entry name="DUMMY_FILE" md5="275876e34cf609db118f3d84b799a790" size="5" mtime="1534862270" />
-          <entry name="_config" md5="1a05ff51cbc0ee790ddd75020dc14e94" size="51" mtime="1534862349" />
-          <entry name="_link" md5="fc6315cf4d9e91ed369a097e83d59417" size="176" mtime="1534862357" />
-          <entry name="somefile.txt" md5="9044d1ae989e292a5e19128f57de9e21" size="57" mtime="1534862349" />
+        <directory name="ProjectWithRepo_package.ProjectWithRepo_Update" rev="12" vrev="12" srcmd5="1b7a806c27e72befe7752ec51001d414">
+          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" srcmd5="1fe06d22b38ce06632413dcc7aeee49c" baserev="1fe06d22b38ce06632413dcc7aeee49c" xsrcmd5="275fdb6919cc016e94566968c0c4aeb5" lsrcmd5="1b7a806c27e72befe7752ec51001d414" />
+          <entry name="DUMMY_FILE" md5="275876e34cf609db118f3d84b799a790" size="5" mtime="1536751453" />
+          <entry name="_config" md5="e76512ea4577d0a559788f9bed2f9ad8" size="58" mtime="1536753837" />
+          <entry name="_link" md5="a1f2d4062a5ea3a9a83bcf0195340932" size="175" mtime="1536753845" />
+          <entry name="somefile.txt" md5="d5ff6c3db27c57b3d9dbc5df28a95a21" size="64" mtime="1536753837" />
         </directory>
     http_version: 
-  recorded_at: Tue, 21 Aug 2018 14:39:31 GMT
+  recorded_at: Wed, 12 Sep 2018 12:04:19 GMT
 - request:
     method: get
     uri: http://backend:5352/source/MaintenanceProject:0/patchinfo
@@ -8182,11 +7890,11 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="patchinfo" rev="6" vrev="6" srcmd5="177d57906eba63ae56a64a367592144a">
-          <entry name="_patchinfo" md5="ac29f7f1abd9ef43afeb43fc7737c007" size="318" mtime="1534862280" />
+        <directory name="patchinfo" rev="9" vrev="9" srcmd5="177d57906eba63ae56a64a367592144a">
+          <entry name="_patchinfo" md5="ac29f7f1abd9ef43afeb43fc7737c007" size="318" mtime="1536751463" />
         </directory>
     http_version: 
-  recorded_at: Tue, 21 Aug 2018 14:39:31 GMT
+  recorded_at: Wed, 12 Sep 2018 12:04:19 GMT
 - request:
     method: get
     uri: http://backend:5352/build/MaintenanceProject:0/_result?view=versrel
@@ -8220,7 +7928,7 @@ http_interactions:
           <result project="MaintenanceProject:0" repository="ProjectWithRepo_Update" arch="i586" code="broken" state="broken" details="no build type (ProjectWithRepo:Update)" />
         </resultlist>
     http_version: 
-  recorded_at: Tue, 21 Aug 2018 14:39:31 GMT
+  recorded_at: Wed, 12 Sep 2018 12:04:19 GMT
 - request:
     method: get
     uri: http://backend:5352/build/MaintenanceProject:0/_result?code=unresolvable&view=status
@@ -8254,7 +7962,7 @@ http_interactions:
           <result project="MaintenanceProject:0" repository="ProjectWithRepo_Update" arch="i586" code="broken" state="broken" details="no build type (ProjectWithRepo:Update)" />
         </resultlist>
     http_version: 
-  recorded_at: Tue, 21 Aug 2018 14:39:31 GMT
+  recorded_at: Wed, 12 Sep 2018 12:04:19 GMT
 - request:
     method: get
     uri: http://backend:5352/source/MaintenanceProject:0/patchinfo
@@ -8284,11 +7992,11 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="patchinfo" rev="6" vrev="6" srcmd5="177d57906eba63ae56a64a367592144a">
-          <entry name="_patchinfo" md5="ac29f7f1abd9ef43afeb43fc7737c007" size="318" mtime="1534862280" />
+        <directory name="patchinfo" rev="9" vrev="9" srcmd5="177d57906eba63ae56a64a367592144a">
+          <entry name="_patchinfo" md5="ac29f7f1abd9ef43afeb43fc7737c007" size="318" mtime="1536751463" />
         </directory>
     http_version: 
-  recorded_at: Tue, 21 Aug 2018 14:39:31 GMT
+  recorded_at: Wed, 12 Sep 2018 12:04:19 GMT
 - request:
     method: get
     uri: http://backend:5352/build/MaintenanceProject:0/_result?view=summary
@@ -8296,10 +8004,8 @@ http_interactions:
       encoding: US-ASCII
       string: ''
     headers:
-      Content-Type:
-      - text/plain
       Accept-Encoding:
-      - identity
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
       - "*/*"
       User-Agent:
@@ -8326,5 +8032,5 @@ http_interactions:
           </result>
         </resultlist>
     http_version: 
-  recorded_at: Tue, 21 Aug 2018 14:39:31 GMT
+  recorded_at: Wed, 12 Sep 2018 12:04:19 GMT
 recorded_with: VCR 4.0.0

--- a/src/api/spec/cassettes/Bootstrap_Packages/branching_a_package_from_another_users_project/with_AutoCleanup.yml
+++ b/src/api/spec/cassettes/Bootstrap_Packages/branching_a_package_from_another_users_project/with_AutoCleanup.yml
@@ -40,7 +40,7 @@ http_interactions:
           <person userid="package_test_user" role="maintainer" />
         </project>
     http_version: 
-  recorded_at: Tue, 04 Sep 2018 10:51:03 GMT
+  recorded_at: Wed, 12 Sep 2018 11:43:30 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:package_test_user/test_package/_meta?user=_nobody_
@@ -48,8 +48,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="test_package" project="home:package_test_user">
-          <title>A Darkling Plain</title>
-          <description>Quisquam libero et optio.</description>
+          <title>That Hideous Strength</title>
+          <description>Asperiores sint consectetur delectus.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -70,16 +70,16 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '163'
+      - '180'
     body:
       encoding: UTF-8
       string: |
         <package name="test_package" project="home:package_test_user">
-          <title>A Darkling Plain</title>
-          <description>Quisquam libero et optio.</description>
+          <title>That Hideous Strength</title>
+          <description>Asperiores sint consectetur delectus.</description>
         </package>
     http_version: 
-  recorded_at: Tue, 04 Sep 2018 10:51:03 GMT
+  recorded_at: Wed, 12 Sep 2018 11:43:30 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:package_test_user/test_package/_meta?user=_nobody_
@@ -87,8 +87,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="test_package" project="home:package_test_user">
-          <title>A Darkling Plain</title>
-          <description>Quisquam libero et optio.</description>
+          <title>That Hideous Strength</title>
+          <description>Asperiores sint consectetur delectus.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -109,22 +109,22 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '163'
+      - '180'
     body:
       encoding: UTF-8
       string: |
         <package name="test_package" project="home:package_test_user">
-          <title>A Darkling Plain</title>
-          <description>Quisquam libero et optio.</description>
+          <title>That Hideous Strength</title>
+          <description>Asperiores sint consectetur delectus.</description>
         </package>
     http_version: 
-  recorded_at: Tue, 04 Sep 2018 10:51:03 GMT
+  recorded_at: Wed, 12 Sep 2018 11:43:30 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:package_test_user/test_package/_config
     body:
       encoding: UTF-8
-      string: Ad deserunt modi. Molestiae enim fugiat. Eum asperiores voluptas.
+      string: Culpa et quo. Beatae quibusdam minus. Ea vel placeat.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -144,26 +144,26 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '207'
+      - '209'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="5" vrev="5">
-          <srcmd5>d6997ba6053d9f81c798eba8cd0bcc19</srcmd5>
+        <revision rev="17" vrev="17">
+          <srcmd5>5653c79b73962d2ac04471a5e3eecd70</srcmd5>
           <version>unknown</version>
-          <time>1536058263</time>
+          <time>1536752610</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
     http_version: 
-  recorded_at: Tue, 04 Sep 2018 10:51:03 GMT
+  recorded_at: Wed, 12 Sep 2018 11:43:30 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:package_test_user/test_package/somefile.txt
     body:
       encoding: UTF-8
-      string: Sit voluptates ex. Temporibus labore et. Amet nulla assumenda.
+      string: Omnis debitis quos. Ullam consectetur ipsam. Numquam qui et.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -183,20 +183,20 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '207'
+      - '209'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="6" vrev="6">
-          <srcmd5>e45ad4df126e5b27f321623fce6cf033</srcmd5>
+        <revision rev="18" vrev="18">
+          <srcmd5>36d6d23c58f194f12a6106562f1061b9</srcmd5>
           <version>unknown</version>
-          <time>1536058263</time>
+          <time>1536752610</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
     http_version: 
-  recorded_at: Tue, 04 Sep 2018 10:51:03 GMT
+  recorded_at: Wed, 12 Sep 2018 11:43:30 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:other_package_test_user/_meta?user=other_package_test_user
@@ -237,7 +237,7 @@ http_interactions:
           <person userid="other_package_test_user" role="maintainer" />
         </project>
     http_version: 
-  recorded_at: Tue, 04 Sep 2018 10:51:03 GMT
+  recorded_at: Wed, 12 Sep 2018 11:43:30 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:other_package_test_user/branch_test_package/_meta?user=_nobody_
@@ -245,8 +245,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="branch_test_package" project="home:other_package_test_user">
-          <title>Carrion Comfort</title>
-          <description>Autem voluptatem et et.</description>
+          <title>Have His Carcase</title>
+          <description>Vitae fugiat provident voluptatem.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -267,16 +267,16 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '173'
+      - '185'
     body:
       encoding: UTF-8
       string: |
         <package name="branch_test_package" project="home:other_package_test_user">
-          <title>Carrion Comfort</title>
-          <description>Autem voluptatem et et.</description>
+          <title>Have His Carcase</title>
+          <description>Vitae fugiat provident voluptatem.</description>
         </package>
     http_version: 
-  recorded_at: Tue, 04 Sep 2018 10:51:03 GMT
+  recorded_at: Wed, 12 Sep 2018 11:43:30 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:other_package_test_user/branch_test_package/_meta?user=_nobody_
@@ -284,8 +284,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="branch_test_package" project="home:other_package_test_user">
-          <title>Carrion Comfort</title>
-          <description>Autem voluptatem et et.</description>
+          <title>Have His Carcase</title>
+          <description>Vitae fugiat provident voluptatem.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -306,22 +306,22 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '173'
+      - '185'
     body:
       encoding: UTF-8
       string: |
         <package name="branch_test_package" project="home:other_package_test_user">
-          <title>Carrion Comfort</title>
-          <description>Autem voluptatem et et.</description>
+          <title>Have His Carcase</title>
+          <description>Vitae fugiat provident voluptatem.</description>
         </package>
     http_version: 
-  recorded_at: Tue, 04 Sep 2018 10:51:03 GMT
+  recorded_at: Wed, 12 Sep 2018 11:43:31 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:other_package_test_user/branch_test_package/_config
     body:
       encoding: UTF-8
-      string: Hic et animi. Et voluptatem labore. Quisquam facilis qui.
+      string: Aut sint nobis. Aut tenetur iusto. Illo nihil nostrum.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -345,22 +345,22 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <revision rev="19" vrev="19">
-          <srcmd5>96a3a0815afa04990e8d5e5a49864ec7</srcmd5>
+        <revision rev="17" vrev="17">
+          <srcmd5>ce725bf28e654fdcefd25913aa057697</srcmd5>
           <version>unknown</version>
-          <time>1536058263</time>
+          <time>1536752611</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
     http_version: 
-  recorded_at: Tue, 04 Sep 2018 10:51:03 GMT
+  recorded_at: Wed, 12 Sep 2018 11:43:31 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:other_package_test_user/branch_test_package/somefile.txt
     body:
       encoding: UTF-8
-      string: Expedita dolor est. Amet cupiditate ut. Molestias sed consequuntur.
+      string: Impedit accusamus harum. Maxime blanditiis qui. Illo sit enim.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -384,16 +384,16 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <revision rev="20" vrev="20">
-          <srcmd5>b671ab274f4d94aae3f1fab864aa158a</srcmd5>
+        <revision rev="18" vrev="18">
+          <srcmd5>e2109e61778d2acbf80de1211c3bba56</srcmd5>
           <version>unknown</version>
-          <time>1536058263</time>
+          <time>1536752611</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
     http_version: 
-  recorded_at: Tue, 04 Sep 2018 10:51:03 GMT
+  recorded_at: Wed, 12 Sep 2018 11:43:31 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:other_package_test_user/branch_test_package
@@ -423,15 +423,15 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="branch_test_package" rev="20" vrev="20" srcmd5="b671ab274f4d94aae3f1fab864aa158a">
-          <entry name="_config" md5="4259eb3e75fb62084c59caae5e7189f9" size="57" mtime="1536058263" />
-          <entry name="somefile.txt" md5="0ba57ded349c9b60be53fd1c67627348" size="67" mtime="1536058263" />
+        <directory name="branch_test_package" rev="18" vrev="18" srcmd5="e2109e61778d2acbf80de1211c3bba56">
+          <entry name="_config" md5="2aed3be4644acea58f7dadebf3f1f781" size="54" mtime="1536752611" />
+          <entry name="somefile.txt" md5="07864da4294addac747ca7b5bb3ab61c" size="62" mtime="1536752611" />
         </directory>
     http_version: 
-  recorded_at: Tue, 04 Sep 2018 10:51:05 GMT
+  recorded_at: Wed, 12 Sep 2018 11:43:32 GMT
 - request:
     method: get
-    uri: http://backend:5352/source/home:other_package_test_user/branch_test_package?expand=1&rev=20
+    uri: http://backend:5352/source/home:other_package_test_user/branch_test_package?expand=1&rev=18
     body:
       encoding: US-ASCII
       string: ''
@@ -458,12 +458,12 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="branch_test_package" rev="20" vrev="20" srcmd5="b671ab274f4d94aae3f1fab864aa158a">
-          <entry name="_config" md5="4259eb3e75fb62084c59caae5e7189f9" size="57" mtime="1536058263" />
-          <entry name="somefile.txt" md5="0ba57ded349c9b60be53fd1c67627348" size="67" mtime="1536058263" />
+        <directory name="branch_test_package" rev="18" vrev="18" srcmd5="e2109e61778d2acbf80de1211c3bba56">
+          <entry name="_config" md5="2aed3be4644acea58f7dadebf3f1f781" size="54" mtime="1536752611" />
+          <entry name="somefile.txt" md5="07864da4294addac747ca7b5bb3ab61c" size="62" mtime="1536752611" />
         </directory>
     http_version: 
-  recorded_at: Tue, 04 Sep 2018 10:51:05 GMT
+  recorded_at: Wed, 12 Sep 2018 11:43:32 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:other_package_test_user/branch_test_package/_service
@@ -498,7 +498,7 @@ http_interactions:
           <details>404 _service: no such file</details>
         </status>
     http_version: 
-  recorded_at: Tue, 04 Sep 2018 10:51:05 GMT
+  recorded_at: Wed, 12 Sep 2018 11:43:32 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:other_package_test_user/branch_test_package/_history
@@ -524,134 +524,122 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '3693'
+      - '3325'
     body:
       encoding: UTF-8
       string: |
         <revisionlist>
           <revision rev="1" vrev="1">
-            <srcmd5>df24bbf67148333bf797d4626c3ff4ea</srcmd5>
+            <srcmd5>a4a87294fe69bf281692d176ac11c5ce</srcmd5>
             <version>unknown</version>
-            <time>1536057948</time>
+            <time>1536742158</time>
             <user>unknown</user>
           </revision>
           <revision rev="2" vrev="2">
-            <srcmd5>03e5b185e89ba1a7dc37404ad35cad5a</srcmd5>
+            <srcmd5>56f1266200aa13816ecd90400b4c79bc</srcmd5>
             <version>unknown</version>
-            <time>1536057949</time>
+            <time>1536742158</time>
             <user>unknown</user>
           </revision>
           <revision rev="3" vrev="3">
-            <srcmd5>8d53b1273da0428dfb4050557a803e83</srcmd5>
+            <srcmd5>7937d23e57499c190bc6f72e776c0fd1</srcmd5>
             <version>unknown</version>
-            <time>1536057962</time>
+            <time>1536742172</time>
             <user>unknown</user>
           </revision>
           <revision rev="4" vrev="4">
-            <srcmd5>6e557801b6f414b3bfe3013e49eda41e</srcmd5>
+            <srcmd5>b9c11068d94c45e513924bbf644c12ab</srcmd5>
             <version>unknown</version>
-            <time>1536057962</time>
+            <time>1536742172</time>
             <user>unknown</user>
           </revision>
           <revision rev="5" vrev="5">
-            <srcmd5>cab47c2fde8167497ef7b69278f219bf</srcmd5>
+            <srcmd5>4fbd7695b7369791a1a78aef238f6d1f</srcmd5>
             <version>unknown</version>
-            <time>1536057975</time>
+            <time>1536742211</time>
             <user>unknown</user>
           </revision>
           <revision rev="6" vrev="6">
-            <srcmd5>daf7369fef63e9a7a783d8958a7f9f4b</srcmd5>
+            <srcmd5>f43e6c007cc271581bd3e13853917e3f</srcmd5>
             <version>unknown</version>
-            <time>1536057975</time>
+            <time>1536742211</time>
             <user>unknown</user>
           </revision>
           <revision rev="7" vrev="7">
-            <srcmd5>513380c011c7f3210f76d0b0fbf43c14</srcmd5>
+            <srcmd5>8aa665746e9eb15959955e5327d873c8</srcmd5>
             <version>unknown</version>
-            <time>1536058085</time>
+            <time>1536742225</time>
             <user>unknown</user>
           </revision>
           <revision rev="8" vrev="8">
-            <srcmd5>5365d987371c0475d3d2e56586426f15</srcmd5>
+            <srcmd5>b623e26a8dcd3c6a5047761a666d08c4</srcmd5>
             <version>unknown</version>
-            <time>1536058085</time>
+            <time>1536742225</time>
             <user>unknown</user>
           </revision>
           <revision rev="9" vrev="9">
-            <srcmd5>6c83dbef46f21fea22e7a851d827c969</srcmd5>
+            <srcmd5>1dfa8abdaf56c0dcca99e05a00d1fad6</srcmd5>
             <version>unknown</version>
-            <time>1536058097</time>
+            <time>1536748092</time>
             <user>unknown</user>
           </revision>
           <revision rev="10" vrev="10">
-            <srcmd5>f42cb5a0428e1418f7a74936847b3bfb</srcmd5>
+            <srcmd5>80dfdc9ee1b39432be2bfa59204bd7f9</srcmd5>
             <version>unknown</version>
-            <time>1536058097</time>
+            <time>1536748092</time>
             <user>unknown</user>
           </revision>
           <revision rev="11" vrev="11">
-            <srcmd5>10efdbd02bcf9819f430b89f1921a35a</srcmd5>
+            <srcmd5>e8b976cb18a24d19bea19cf5f6220c00</srcmd5>
             <version>unknown</version>
-            <time>1536058109</time>
+            <time>1536748104</time>
             <user>unknown</user>
           </revision>
           <revision rev="12" vrev="12">
-            <srcmd5>3b2fab6eda5c343871d7c65090db7ad4</srcmd5>
+            <srcmd5>1161ee9424c64864462989f6490c69e7</srcmd5>
             <version>unknown</version>
-            <time>1536058109</time>
+            <time>1536748104</time>
             <user>unknown</user>
           </revision>
           <revision rev="13" vrev="13">
-            <srcmd5>62d0a022ceb0b48715d45810a0153ed0</srcmd5>
+            <srcmd5>2861b90ff002eeb57f591d28be1a8e77</srcmd5>
             <version>unknown</version>
-            <time>1536058227</time>
+            <time>1536752310</time>
             <user>unknown</user>
           </revision>
           <revision rev="14" vrev="14">
-            <srcmd5>6acfb52abc27e5cb149dc1404c4dd17c</srcmd5>
+            <srcmd5>4852e89d276c07a8a0b898528ea9b5f7</srcmd5>
             <version>unknown</version>
-            <time>1536058227</time>
+            <time>1536752310</time>
             <user>unknown</user>
           </revision>
           <revision rev="15" vrev="15">
-            <srcmd5>f031e61b53ccae924e4005240d83081b</srcmd5>
+            <srcmd5>03b250f627df05d8d04a10b13e4fc9fd</srcmd5>
             <version>unknown</version>
-            <time>1536058239</time>
+            <time>1536752322</time>
             <user>unknown</user>
           </revision>
           <revision rev="16" vrev="16">
-            <srcmd5>3fef5db8b64bdfd9394d51f66cb75487</srcmd5>
+            <srcmd5>f244a9f08d9a71a5a33cfa493d85d3aa</srcmd5>
             <version>unknown</version>
-            <time>1536058239</time>
+            <time>1536752322</time>
             <user>unknown</user>
           </revision>
           <revision rev="17" vrev="17">
-            <srcmd5>7d46a73f0c5831de26fc1b9cad5bf477</srcmd5>
+            <srcmd5>ce725bf28e654fdcefd25913aa057697</srcmd5>
             <version>unknown</version>
-            <time>1536058252</time>
+            <time>1536752611</time>
             <user>unknown</user>
           </revision>
           <revision rev="18" vrev="18">
-            <srcmd5>16ee36e1e8199aca4a86338a7c955ce3</srcmd5>
+            <srcmd5>e2109e61778d2acbf80de1211c3bba56</srcmd5>
             <version>unknown</version>
-            <time>1536058252</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="19" vrev="19">
-            <srcmd5>96a3a0815afa04990e8d5e5a49864ec7</srcmd5>
-            <version>unknown</version>
-            <time>1536058263</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="20" vrev="20">
-            <srcmd5>b671ab274f4d94aae3f1fab864aa158a</srcmd5>
-            <version>unknown</version>
-            <time>1536058263</time>
+            <time>1536752611</time>
             <user>unknown</user>
           </revision>
         </revisionlist>
     http_version: 
-  recorded_at: Tue, 04 Sep 2018 10:51:05 GMT
+  recorded_at: Wed, 12 Sep 2018 11:43:32 GMT
 - request:
     method: get
     uri: http://backend:5352/build/home:other_package_test_user/_result?package=branch_test_package&view=status
@@ -659,10 +647,8 @@ http_interactions:
       encoding: US-ASCII
       string: ''
     headers:
-      Content-Type:
-      - text/plain
       Accept-Encoding:
-      - identity
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
       - "*/*"
       User-Agent:
@@ -686,10 +672,10 @@ http_interactions:
 
 '
     http_version: 
-  recorded_at: Tue, 04 Sep 2018 10:51:05 GMT
+  recorded_at: Wed, 12 Sep 2018 11:43:33 GMT
 - request:
     method: get
-    uri: http://backend:5352/source/home:other_package_test_user/branch_test_package?expand=1
+    uri: http://backend:5352/source/home:other_package_test_user/branch_test_package?expand=1&rev=18
     body:
       encoding: US-ASCII
       string: ''
@@ -716,23 +702,21 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="branch_test_package" rev="20" vrev="20" srcmd5="b671ab274f4d94aae3f1fab864aa158a">
-          <entry name="_config" md5="4259eb3e75fb62084c59caae5e7189f9" size="57" mtime="1536058263" />
-          <entry name="somefile.txt" md5="0ba57ded349c9b60be53fd1c67627348" size="67" mtime="1536058263" />
+        <directory name="branch_test_package" rev="18" vrev="18" srcmd5="e2109e61778d2acbf80de1211c3bba56">
+          <entry name="_config" md5="2aed3be4644acea58f7dadebf3f1f781" size="54" mtime="1536752611" />
+          <entry name="somefile.txt" md5="07864da4294addac747ca7b5bb3ab61c" size="62" mtime="1536752611" />
         </directory>
     http_version: 
-  recorded_at: Tue, 04 Sep 2018 10:51:06 GMT
+  recorded_at: Wed, 12 Sep 2018 11:43:33 GMT
 - request:
     method: get
-    uri: http://backend:5352/source/home:other_package_test_user/branch_test_package?rev=20
+    uri: http://backend:5352/source/home:other_package_test_user/branch_test_package?rev=18
     body:
       encoding: US-ASCII
       string: ''
     headers:
-      Content-Type:
-      - text/plain
       Accept-Encoding:
-      - identity
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
       - "*/*"
       User-Agent:
@@ -753,12 +737,12 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="branch_test_package" rev="20" vrev="20" srcmd5="b671ab274f4d94aae3f1fab864aa158a">
-          <entry name="_config" md5="4259eb3e75fb62084c59caae5e7189f9" size="57" mtime="1536058263" />
-          <entry name="somefile.txt" md5="0ba57ded349c9b60be53fd1c67627348" size="67" mtime="1536058263" />
+        <directory name="branch_test_package" rev="18" vrev="18" srcmd5="e2109e61778d2acbf80de1211c3bba56">
+          <entry name="_config" md5="2aed3be4644acea58f7dadebf3f1f781" size="54" mtime="1536752611" />
+          <entry name="somefile.txt" md5="07864da4294addac747ca7b5bb3ab61c" size="62" mtime="1536752611" />
         </directory>
     http_version: 
-  recorded_at: Tue, 04 Sep 2018 10:51:06 GMT
+  recorded_at: Wed, 12 Sep 2018 11:43:33 GMT
 - request:
     method: post
     uri: http://backend:5352/search/package/id?match=(linkinfo/@package=%22branch_test_package%22%20and%20linkinfo/@project=%22home:other_package_test_user%22%20and%20@project=%22home:other_package_test_user%22)
@@ -793,7 +777,7 @@ http_interactions:
         <collection>
         </collection>
     http_version: 
-  recorded_at: Tue, 04 Sep 2018 10:51:06 GMT
+  recorded_at: Wed, 12 Sep 2018 11:43:33 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:package_test_user:branches:home:other_package_test_user/_meta?user=package_test_user
@@ -834,7 +818,7 @@ http_interactions:
           <person userid="package_test_user" role="maintainer" />
         </project>
     http_version: 
-  recorded_at: Tue, 04 Sep 2018 10:51:06 GMT
+  recorded_at: Wed, 12 Sep 2018 11:43:34 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:package_test_user:branches:home:other_package_test_user/_project/_attribute?meta=1&user=package_test_user
@@ -843,7 +827,7 @@ http_interactions:
       string: |
         <attributes>
           <attribute name="AutoCleanup" namespace="OBS">
-            <value>2018-09-18T10:51:06+00:00</value>
+            <value>2018-09-26T11:43:34+00:00</value>
           </attribute>
         </attributes>
     headers:
@@ -869,15 +853,15 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <revision rev="30">
-          <srcmd5>d82ba5797d04e80882f264c0800fdb11</srcmd5>
-          <time>1536058266</time>
+        <revision rev="22">
+          <srcmd5>20cbe79370ec78043f110be3b78c63a2</srcmd5>
+          <time>1536752614</time>
           <user>package_test_user</user>
           <comment></comment>
           <requestid/>
         </revision>
     http_version: 
-  recorded_at: Tue, 04 Sep 2018 10:51:06 GMT
+  recorded_at: Wed, 12 Sep 2018 11:43:34 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:package_test_user:branches:home:other_package_test_user/branch_test_package/_meta?user=package_test_user
@@ -885,8 +869,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="branch_test_package" project="home:package_test_user:branches:home:other_package_test_user">
-          <title>Carrion Comfort</title>
-          <description>Autem voluptatem et et.</description>
+          <title>Have His Carcase</title>
+          <description>Vitae fugiat provident voluptatem.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -907,19 +891,19 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '205'
+      - '217'
     body:
       encoding: UTF-8
       string: |
         <package name="branch_test_package" project="home:package_test_user:branches:home:other_package_test_user">
-          <title>Carrion Comfort</title>
-          <description>Autem voluptatem et et.</description>
+          <title>Have His Carcase</title>
+          <description>Vitae fugiat provident voluptatem.</description>
         </package>
     http_version: 
-  recorded_at: Tue, 04 Sep 2018 10:51:06 GMT
+  recorded_at: Wed, 12 Sep 2018 11:43:34 GMT
 - request:
     method: post
-    uri: http://backend:5352/source/home:package_test_user:branches:home:other_package_test_user/branch_test_package?cmd=branch&noservice=1&opackage=branch_test_package&oproject=home:other_package_test_user&orev=b671ab274f4d94aae3f1fab864aa158a&user=package_test_user
+    uri: http://backend:5352/source/home:package_test_user:branches:home:other_package_test_user/branch_test_package?cmd=branch&noservice=1&opackage=branch_test_package&oproject=home:other_package_test_user&orev=e2109e61778d2acbf80de1211c3bba56&user=package_test_user
     body:
       encoding: UTF-8
       string: ''
@@ -948,16 +932,16 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <revision rev="3" vrev="3">
-          <srcmd5>5729343ed2c09cf63f9ce1a9a7fe888f</srcmd5>
+        <revision rev="9" vrev="9">
+          <srcmd5>5bb1f7e3bfcfd6e3c1876cfe2ff6f007</srcmd5>
           <version>unknown</version>
-          <time>1536058266</time>
+          <time>1536752614</time>
           <user>package_test_user</user>
           <comment></comment>
           <requestid/>
         </revision>
     http_version: 
-  recorded_at: Tue, 04 Sep 2018 10:51:06 GMT
+  recorded_at: Wed, 12 Sep 2018 11:43:34 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:package_test_user:branches:home:other_package_test_user/branch_test_package/_meta?user=package_test_user
@@ -965,8 +949,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="branch_test_package" project="home:package_test_user:branches:home:other_package_test_user">
-          <title>Carrion Comfort</title>
-          <description>Autem voluptatem et et.</description>
+          <title>Have His Carcase</title>
+          <description>Vitae fugiat provident voluptatem.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -987,16 +971,16 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '205'
+      - '217'
     body:
       encoding: UTF-8
       string: |
         <package name="branch_test_package" project="home:package_test_user:branches:home:other_package_test_user">
-          <title>Carrion Comfort</title>
-          <description>Autem voluptatem et et.</description>
+          <title>Have His Carcase</title>
+          <description>Vitae fugiat provident voluptatem.</description>
         </package>
     http_version: 
-  recorded_at: Tue, 04 Sep 2018 10:51:06 GMT
+  recorded_at: Wed, 12 Sep 2018 11:43:34 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:package_test_user:branches:home:other_package_test_user/branch_test_package
@@ -1026,14 +1010,14 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="branch_test_package" rev="3" vrev="3" srcmd5="5729343ed2c09cf63f9ce1a9a7fe888f">
-          <linkinfo project="home:other_package_test_user" package="branch_test_package" rev="b671ab274f4d94aae3f1fab864aa158a" srcmd5="b671ab274f4d94aae3f1fab864aa158a" baserev="b671ab274f4d94aae3f1fab864aa158a" xsrcmd5="12882aac8fc80f94beff6a2dc1c0e1e4" lsrcmd5="5729343ed2c09cf63f9ce1a9a7fe888f" />
-          <entry name="_config" md5="4259eb3e75fb62084c59caae5e7189f9" size="57" mtime="1536058263" />
-          <entry name="_link" md5="f2164ff237818b4153e576888a4bd56f" size="175" mtime="1536058266" />
-          <entry name="somefile.txt" md5="0ba57ded349c9b60be53fd1c67627348" size="67" mtime="1536058263" />
+        <directory name="branch_test_package" rev="9" vrev="9" srcmd5="5bb1f7e3bfcfd6e3c1876cfe2ff6f007">
+          <linkinfo project="home:other_package_test_user" package="branch_test_package" rev="e2109e61778d2acbf80de1211c3bba56" srcmd5="e2109e61778d2acbf80de1211c3bba56" baserev="e2109e61778d2acbf80de1211c3bba56" xsrcmd5="f62a88b7c42145998ac0803b02e47d85" lsrcmd5="5bb1f7e3bfcfd6e3c1876cfe2ff6f007" />
+          <entry name="_config" md5="2aed3be4644acea58f7dadebf3f1f781" size="54" mtime="1536752611" />
+          <entry name="_link" md5="10993492fd4bee564bcee59947fa84ba" size="175" mtime="1536752614" />
+          <entry name="somefile.txt" md5="07864da4294addac747ca7b5bb3ab61c" size="62" mtime="1536752611" />
         </directory>
     http_version: 
-  recorded_at: Tue, 04 Sep 2018 10:51:06 GMT
+  recorded_at: Wed, 12 Sep 2018 11:43:34 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:package_test_user:branches:home:other_package_test_user/branch_test_package?view=info
@@ -1063,12 +1047,12 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <sourceinfo package="branch_test_package" rev="3" vrev="3" srcmd5="12882aac8fc80f94beff6a2dc1c0e1e4" lsrcmd5="5729343ed2c09cf63f9ce1a9a7fe888f" verifymd5="b671ab274f4d94aae3f1fab864aa158a">
+        <sourceinfo package="branch_test_package" rev="9" vrev="9" srcmd5="f62a88b7c42145998ac0803b02e47d85" lsrcmd5="5bb1f7e3bfcfd6e3c1876cfe2ff6f007" verifymd5="e2109e61778d2acbf80de1211c3bba56">
           <error>bad build configuration, no build type defined or detected</error>
           <linked project="home:other_package_test_user" package="branch_test_package" />
         </sourceinfo>
     http_version: 
-  recorded_at: Tue, 04 Sep 2018 10:51:06 GMT
+  recorded_at: Wed, 12 Sep 2018 11:43:34 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:package_test_user:branches:home:other_package_test_user/branch_test_package
@@ -1098,14 +1082,14 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="branch_test_package" rev="3" vrev="3" srcmd5="5729343ed2c09cf63f9ce1a9a7fe888f">
-          <linkinfo project="home:other_package_test_user" package="branch_test_package" rev="b671ab274f4d94aae3f1fab864aa158a" srcmd5="b671ab274f4d94aae3f1fab864aa158a" baserev="b671ab274f4d94aae3f1fab864aa158a" xsrcmd5="12882aac8fc80f94beff6a2dc1c0e1e4" lsrcmd5="5729343ed2c09cf63f9ce1a9a7fe888f" />
-          <entry name="_config" md5="4259eb3e75fb62084c59caae5e7189f9" size="57" mtime="1536058263" />
-          <entry name="_link" md5="f2164ff237818b4153e576888a4bd56f" size="175" mtime="1536058266" />
-          <entry name="somefile.txt" md5="0ba57ded349c9b60be53fd1c67627348" size="67" mtime="1536058263" />
+        <directory name="branch_test_package" rev="9" vrev="9" srcmd5="5bb1f7e3bfcfd6e3c1876cfe2ff6f007">
+          <linkinfo project="home:other_package_test_user" package="branch_test_package" rev="e2109e61778d2acbf80de1211c3bba56" srcmd5="e2109e61778d2acbf80de1211c3bba56" baserev="e2109e61778d2acbf80de1211c3bba56" xsrcmd5="f62a88b7c42145998ac0803b02e47d85" lsrcmd5="5bb1f7e3bfcfd6e3c1876cfe2ff6f007" />
+          <entry name="_config" md5="2aed3be4644acea58f7dadebf3f1f781" size="54" mtime="1536752611" />
+          <entry name="_link" md5="10993492fd4bee564bcee59947fa84ba" size="175" mtime="1536752614" />
+          <entry name="somefile.txt" md5="07864da4294addac747ca7b5bb3ab61c" size="62" mtime="1536752611" />
         </directory>
     http_version: 
-  recorded_at: Tue, 04 Sep 2018 10:51:06 GMT
+  recorded_at: Wed, 12 Sep 2018 11:43:34 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:package_test_user:branches:home:other_package_test_user/branch_test_package?cmd=diff&linkrev=base&onlyissues=1&orev=0&view=xml
@@ -1137,15 +1121,15 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="02009bc873dc96778c90e0dd4ad1de54">
+        <sourcediff key="7379e7434a14987c189ba7dc2f0e4144">
           <old project="home:package_test_user:branches:home:other_package_test_user" package="branch_test_package" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e" />
-          <new project="home:package_test_user:branches:home:other_package_test_user" package="branch_test_package" rev="3" srcmd5="5729343ed2c09cf63f9ce1a9a7fe888f" />
+          <new project="home:package_test_user:branches:home:other_package_test_user" package="branch_test_package" rev="9" srcmd5="5bb1f7e3bfcfd6e3c1876cfe2ff6f007" />
           <files />
           <issues>
           </issues>
         </sourcediff>
     http_version: 
-  recorded_at: Tue, 04 Sep 2018 10:51:06 GMT
+  recorded_at: Wed, 12 Sep 2018 11:43:34 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:package_test_user:branches:home:other_package_test_user/branch_test_package?cmd=linkdiff&linkrev=base&onlyissues=1&view=xml
@@ -1177,13 +1161,13 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="fde6cf648629807b47f05a1f5b3dd993">
-          <old project="home:other_package_test_user" package="branch_test_package" rev="b671ab274f4d94aae3f1fab864aa158a" srcmd5="b671ab274f4d94aae3f1fab864aa158a" />
-          <new project="home:package_test_user:branches:home:other_package_test_user" package="branch_test_package" rev="12882aac8fc80f94beff6a2dc1c0e1e4" srcmd5="12882aac8fc80f94beff6a2dc1c0e1e4" />
+        <sourcediff key="237ec9919f56096364f9fe4da10fcb2e">
+          <old project="home:other_package_test_user" package="branch_test_package" rev="e2109e61778d2acbf80de1211c3bba56" srcmd5="e2109e61778d2acbf80de1211c3bba56" />
+          <new project="home:package_test_user:branches:home:other_package_test_user" package="branch_test_package" rev="f62a88b7c42145998ac0803b02e47d85" srcmd5="f62a88b7c42145998ac0803b02e47d85" />
           <files />
         </sourcediff>
     http_version: 
-  recorded_at: Tue, 04 Sep 2018 10:51:06 GMT
+  recorded_at: Wed, 12 Sep 2018 11:43:34 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:package_test_user:branches:home:other_package_test_user/_meta?user=package_test_user
@@ -1230,7 +1214,7 @@ http_interactions:
           </publish>
         </project>
     http_version: 
-  recorded_at: Tue, 04 Sep 2018 10:51:07 GMT
+  recorded_at: Wed, 12 Sep 2018 11:43:34 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:other_package_test_user/branch_test_package?view=info
@@ -1260,11 +1244,11 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <sourceinfo package="branch_test_package" rev="20" vrev="20" srcmd5="b671ab274f4d94aae3f1fab864aa158a" verifymd5="b671ab274f4d94aae3f1fab864aa158a">
+        <sourceinfo package="branch_test_package" rev="18" vrev="18" srcmd5="e2109e61778d2acbf80de1211c3bba56" verifymd5="e2109e61778d2acbf80de1211c3bba56">
           <error>bad build configuration, no build type defined or detected</error>
         </sourceinfo>
     http_version: 
-  recorded_at: Tue, 04 Sep 2018 10:51:07 GMT
+  recorded_at: Wed, 12 Sep 2018 11:43:34 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:other_package_test_user/branch_test_package
@@ -1294,12 +1278,12 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="branch_test_package" rev="20" vrev="20" srcmd5="b671ab274f4d94aae3f1fab864aa158a">
-          <entry name="_config" md5="4259eb3e75fb62084c59caae5e7189f9" size="57" mtime="1536058263" />
-          <entry name="somefile.txt" md5="0ba57ded349c9b60be53fd1c67627348" size="67" mtime="1536058263" />
+        <directory name="branch_test_package" rev="18" vrev="18" srcmd5="e2109e61778d2acbf80de1211c3bba56">
+          <entry name="_config" md5="2aed3be4644acea58f7dadebf3f1f781" size="54" mtime="1536752611" />
+          <entry name="somefile.txt" md5="07864da4294addac747ca7b5bb3ab61c" size="62" mtime="1536752611" />
         </directory>
     http_version: 
-  recorded_at: Tue, 04 Sep 2018 10:51:07 GMT
+  recorded_at: Wed, 12 Sep 2018 11:43:34 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:other_package_test_user/branch_test_package?cmd=diff&linkrev=base&onlyissues=1&orev=0&view=xml
@@ -1331,15 +1315,15 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="02f3b3090b9e39830d3de7fdae174176">
+        <sourcediff key="aeeddc2fce2dae3c49e9d052c63b0ec3">
           <old project="home:other_package_test_user" package="branch_test_package" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e" />
-          <new project="home:other_package_test_user" package="branch_test_package" rev="20" srcmd5="b671ab274f4d94aae3f1fab864aa158a" />
+          <new project="home:other_package_test_user" package="branch_test_package" rev="18" srcmd5="e2109e61778d2acbf80de1211c3bba56" />
           <files />
           <issues>
           </issues>
         </sourcediff>
     http_version: 
-  recorded_at: Tue, 04 Sep 2018 10:51:07 GMT
+  recorded_at: Wed, 12 Sep 2018 11:43:34 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:package_test_user:branches:home:other_package_test_user/branch_test_package
@@ -1369,17 +1353,17 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="branch_test_package" rev="3" vrev="3" srcmd5="5729343ed2c09cf63f9ce1a9a7fe888f">
-          <linkinfo project="home:other_package_test_user" package="branch_test_package" rev="b671ab274f4d94aae3f1fab864aa158a" srcmd5="b671ab274f4d94aae3f1fab864aa158a" baserev="b671ab274f4d94aae3f1fab864aa158a" xsrcmd5="12882aac8fc80f94beff6a2dc1c0e1e4" lsrcmd5="5729343ed2c09cf63f9ce1a9a7fe888f" />
-          <entry name="_config" md5="4259eb3e75fb62084c59caae5e7189f9" size="57" mtime="1536058263" />
-          <entry name="_link" md5="f2164ff237818b4153e576888a4bd56f" size="175" mtime="1536058266" />
-          <entry name="somefile.txt" md5="0ba57ded349c9b60be53fd1c67627348" size="67" mtime="1536058263" />
+        <directory name="branch_test_package" rev="9" vrev="9" srcmd5="5bb1f7e3bfcfd6e3c1876cfe2ff6f007">
+          <linkinfo project="home:other_package_test_user" package="branch_test_package" rev="e2109e61778d2acbf80de1211c3bba56" srcmd5="e2109e61778d2acbf80de1211c3bba56" baserev="e2109e61778d2acbf80de1211c3bba56" xsrcmd5="f62a88b7c42145998ac0803b02e47d85" lsrcmd5="5bb1f7e3bfcfd6e3c1876cfe2ff6f007" />
+          <entry name="_config" md5="2aed3be4644acea58f7dadebf3f1f781" size="54" mtime="1536752611" />
+          <entry name="_link" md5="10993492fd4bee564bcee59947fa84ba" size="175" mtime="1536752614" />
+          <entry name="somefile.txt" md5="07864da4294addac747ca7b5bb3ab61c" size="62" mtime="1536752611" />
         </directory>
     http_version: 
-  recorded_at: Tue, 04 Sep 2018 10:51:07 GMT
+  recorded_at: Wed, 12 Sep 2018 11:43:35 GMT
 - request:
     method: get
-    uri: http://backend:5352/source/home:package_test_user:branches:home:other_package_test_user/branch_test_package?expand=1&rev=3
+    uri: http://backend:5352/source/home:package_test_user:branches:home:other_package_test_user/branch_test_package?expand=1&rev=9
     body:
       encoding: US-ASCII
       string: ''
@@ -1406,13 +1390,13 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="branch_test_package" rev="12882aac8fc80f94beff6a2dc1c0e1e4" vrev="3" srcmd5="12882aac8fc80f94beff6a2dc1c0e1e4">
-          <linkinfo project="home:other_package_test_user" package="branch_test_package" rev="b671ab274f4d94aae3f1fab864aa158a" srcmd5="b671ab274f4d94aae3f1fab864aa158a" baserev="b671ab274f4d94aae3f1fab864aa158a" lsrcmd5="5729343ed2c09cf63f9ce1a9a7fe888f" />
-          <entry name="_config" md5="4259eb3e75fb62084c59caae5e7189f9" size="57" mtime="1536058263" />
-          <entry name="somefile.txt" md5="0ba57ded349c9b60be53fd1c67627348" size="67" mtime="1536058263" />
+        <directory name="branch_test_package" rev="f62a88b7c42145998ac0803b02e47d85" vrev="9" srcmd5="f62a88b7c42145998ac0803b02e47d85">
+          <linkinfo project="home:other_package_test_user" package="branch_test_package" rev="e2109e61778d2acbf80de1211c3bba56" srcmd5="e2109e61778d2acbf80de1211c3bba56" baserev="e2109e61778d2acbf80de1211c3bba56" lsrcmd5="5bb1f7e3bfcfd6e3c1876cfe2ff6f007" />
+          <entry name="_config" md5="2aed3be4644acea58f7dadebf3f1f781" size="54" mtime="1536752611" />
+          <entry name="somefile.txt" md5="07864da4294addac747ca7b5bb3ab61c" size="62" mtime="1536752611" />
         </directory>
     http_version: 
-  recorded_at: Tue, 04 Sep 2018 10:51:07 GMT
+  recorded_at: Wed, 12 Sep 2018 11:43:35 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:package_test_user:branches:home:other_package_test_user/branch_test_package/_service
@@ -1447,7 +1431,7 @@ http_interactions:
           <details>404 _service: no such file</details>
         </status>
     http_version: 
-  recorded_at: Tue, 04 Sep 2018 10:51:07 GMT
+  recorded_at: Wed, 12 Sep 2018 11:43:35 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:package_test_user:branches:home:other_package_test_user/branch_test_package
@@ -1477,14 +1461,14 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="branch_test_package" rev="3" vrev="3" srcmd5="5729343ed2c09cf63f9ce1a9a7fe888f">
-          <linkinfo project="home:other_package_test_user" package="branch_test_package" rev="b671ab274f4d94aae3f1fab864aa158a" srcmd5="b671ab274f4d94aae3f1fab864aa158a" baserev="b671ab274f4d94aae3f1fab864aa158a" xsrcmd5="12882aac8fc80f94beff6a2dc1c0e1e4" lsrcmd5="5729343ed2c09cf63f9ce1a9a7fe888f" />
-          <entry name="_config" md5="4259eb3e75fb62084c59caae5e7189f9" size="57" mtime="1536058263" />
-          <entry name="_link" md5="f2164ff237818b4153e576888a4bd56f" size="175" mtime="1536058266" />
-          <entry name="somefile.txt" md5="0ba57ded349c9b60be53fd1c67627348" size="67" mtime="1536058263" />
+        <directory name="branch_test_package" rev="9" vrev="9" srcmd5="5bb1f7e3bfcfd6e3c1876cfe2ff6f007">
+          <linkinfo project="home:other_package_test_user" package="branch_test_package" rev="e2109e61778d2acbf80de1211c3bba56" srcmd5="e2109e61778d2acbf80de1211c3bba56" baserev="e2109e61778d2acbf80de1211c3bba56" xsrcmd5="f62a88b7c42145998ac0803b02e47d85" lsrcmd5="5bb1f7e3bfcfd6e3c1876cfe2ff6f007" />
+          <entry name="_config" md5="2aed3be4644acea58f7dadebf3f1f781" size="54" mtime="1536752611" />
+          <entry name="_link" md5="10993492fd4bee564bcee59947fa84ba" size="175" mtime="1536752614" />
+          <entry name="somefile.txt" md5="07864da4294addac747ca7b5bb3ab61c" size="62" mtime="1536752611" />
         </directory>
     http_version: 
-  recorded_at: Tue, 04 Sep 2018 10:51:07 GMT
+  recorded_at: Wed, 12 Sep 2018 11:43:35 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:package_test_user:branches:home:other_package_test_user/branch_test_package
@@ -1514,14 +1498,14 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="branch_test_package" rev="3" vrev="3" srcmd5="5729343ed2c09cf63f9ce1a9a7fe888f">
-          <linkinfo project="home:other_package_test_user" package="branch_test_package" rev="b671ab274f4d94aae3f1fab864aa158a" srcmd5="b671ab274f4d94aae3f1fab864aa158a" baserev="b671ab274f4d94aae3f1fab864aa158a" xsrcmd5="12882aac8fc80f94beff6a2dc1c0e1e4" lsrcmd5="5729343ed2c09cf63f9ce1a9a7fe888f" />
-          <entry name="_config" md5="4259eb3e75fb62084c59caae5e7189f9" size="57" mtime="1536058263" />
-          <entry name="_link" md5="f2164ff237818b4153e576888a4bd56f" size="175" mtime="1536058266" />
-          <entry name="somefile.txt" md5="0ba57ded349c9b60be53fd1c67627348" size="67" mtime="1536058263" />
+        <directory name="branch_test_package" rev="9" vrev="9" srcmd5="5bb1f7e3bfcfd6e3c1876cfe2ff6f007">
+          <linkinfo project="home:other_package_test_user" package="branch_test_package" rev="e2109e61778d2acbf80de1211c3bba56" srcmd5="e2109e61778d2acbf80de1211c3bba56" baserev="e2109e61778d2acbf80de1211c3bba56" xsrcmd5="f62a88b7c42145998ac0803b02e47d85" lsrcmd5="5bb1f7e3bfcfd6e3c1876cfe2ff6f007" />
+          <entry name="_config" md5="2aed3be4644acea58f7dadebf3f1f781" size="54" mtime="1536752611" />
+          <entry name="_link" md5="10993492fd4bee564bcee59947fa84ba" size="175" mtime="1536752614" />
+          <entry name="somefile.txt" md5="07864da4294addac747ca7b5bb3ab61c" size="62" mtime="1536752611" />
         </directory>
     http_version: 
-  recorded_at: Tue, 04 Sep 2018 10:51:07 GMT
+  recorded_at: Wed, 12 Sep 2018 11:43:35 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:package_test_user:branches:home:other_package_test_user/branch_test_package/_history
@@ -1547,32 +1531,68 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '607'
+      - '1759'
     body:
       encoding: UTF-8
       string: |
         <revisionlist>
           <revision rev="1" vrev="1">
-            <srcmd5>4369256fc7026ce9efc535ca4af38c57</srcmd5>
+            <srcmd5>1aca36bfa87765d6cd5ca2721753d45b</srcmd5>
             <version>unknown</version>
-            <time>1536058088</time>
+            <time>1536742163</time>
             <user>package_test_user</user>
           </revision>
           <revision rev="2" vrev="2">
-            <srcmd5>3054c237efb30ad77f7986dd041466d5</srcmd5>
+            <srcmd5>e4396ee5b376d0ac30b7cdb8ccdd4b59</srcmd5>
             <version>unknown</version>
-            <time>1536058100</time>
+            <time>1536742175</time>
             <user>package_test_user</user>
           </revision>
           <revision rev="3" vrev="3">
-            <srcmd5>5729343ed2c09cf63f9ce1a9a7fe888f</srcmd5>
+            <srcmd5>2b32c7e5905e80db6abb01432d2c881d</srcmd5>
             <version>unknown</version>
-            <time>1536058266</time>
+            <time>1536742216</time>
+            <user>package_test_user</user>
+          </revision>
+          <revision rev="4" vrev="4">
+            <srcmd5>d7dc2a21eeb234d4ceec7effa04de994</srcmd5>
+            <version>unknown</version>
+            <time>1536742228</time>
+            <user>package_test_user</user>
+          </revision>
+          <revision rev="5" vrev="5">
+            <srcmd5>460a55998efa7bc8c1e727f7b6c33abe</srcmd5>
+            <version>unknown</version>
+            <time>1536748096</time>
+            <user>package_test_user</user>
+          </revision>
+          <revision rev="6" vrev="6">
+            <srcmd5>9e52ae591ccc2d95f7bac74ab2c7a20d</srcmd5>
+            <version>unknown</version>
+            <time>1536748108</time>
+            <user>package_test_user</user>
+          </revision>
+          <revision rev="7" vrev="7">
+            <srcmd5>a2025e524c9ecf86aacc2ed66f2df49f</srcmd5>
+            <version>unknown</version>
+            <time>1536752314</time>
+            <user>package_test_user</user>
+          </revision>
+          <revision rev="8" vrev="8">
+            <srcmd5>f9f2fdc97ab6a5360c320664a3201e97</srcmd5>
+            <version>unknown</version>
+            <time>1536752326</time>
+            <user>package_test_user</user>
+          </revision>
+          <revision rev="9" vrev="9">
+            <srcmd5>5bb1f7e3bfcfd6e3c1876cfe2ff6f007</srcmd5>
+            <version>unknown</version>
+            <time>1536752614</time>
             <user>package_test_user</user>
           </revision>
         </revisionlist>
     http_version: 
-  recorded_at: Tue, 04 Sep 2018 10:51:07 GMT
+  recorded_at: Wed, 12 Sep 2018 11:43:35 GMT
 - request:
     method: get
     uri: http://backend:5352/build/home:package_test_user:branches:home:other_package_test_user/_result?package=branch_test_package&view=status
@@ -1580,10 +1600,8 @@ http_interactions:
       encoding: US-ASCII
       string: ''
     headers:
-      Content-Type:
-      - text/plain
       Accept-Encoding:
-      - identity
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
       - "*/*"
       User-Agent:
@@ -1607,5 +1625,5 @@ http_interactions:
 
 '
     http_version: 
-  recorded_at: Tue, 04 Sep 2018 10:51:07 GMT
+  recorded_at: Wed, 12 Sep 2018 11:43:35 GMT
 recorded_with: VCR 4.0.0

--- a/src/api/spec/cassettes/Bootstrap_Packages/branching_a_package_from_another_users_project/without_AutoCleanup.yml
+++ b/src/api/spec/cassettes/Bootstrap_Packages/branching_a_package_from_another_users_project/without_AutoCleanup.yml
@@ -40,7 +40,7 @@ http_interactions:
           <person userid="package_test_user" role="maintainer" />
         </project>
     http_version: 
-  recorded_at: Tue, 04 Sep 2018 10:51:14 GMT
+  recorded_at: Wed, 12 Sep 2018 11:43:42 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:package_test_user/test_package/_meta?user=_nobody_
@@ -48,8 +48,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="test_package" project="home:package_test_user">
-          <title>The Golden Bowl</title>
-          <description>Sint et nihil et.</description>
+          <title>Precious Bane</title>
+          <description>Mollitia natus repellat nemo.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -70,16 +70,16 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '154'
+      - '164'
     body:
       encoding: UTF-8
       string: |
         <package name="test_package" project="home:package_test_user">
-          <title>The Golden Bowl</title>
-          <description>Sint et nihil et.</description>
+          <title>Precious Bane</title>
+          <description>Mollitia natus repellat nemo.</description>
         </package>
     http_version: 
-  recorded_at: Tue, 04 Sep 2018 10:51:14 GMT
+  recorded_at: Wed, 12 Sep 2018 11:43:42 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:package_test_user/test_package/_meta?user=_nobody_
@@ -87,8 +87,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="test_package" project="home:package_test_user">
-          <title>The Golden Bowl</title>
-          <description>Sint et nihil et.</description>
+          <title>Precious Bane</title>
+          <description>Mollitia natus repellat nemo.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -109,22 +109,22 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '154'
+      - '164'
     body:
       encoding: UTF-8
       string: |
         <package name="test_package" project="home:package_test_user">
-          <title>The Golden Bowl</title>
-          <description>Sint et nihil et.</description>
+          <title>Precious Bane</title>
+          <description>Mollitia natus repellat nemo.</description>
         </package>
     http_version: 
-  recorded_at: Tue, 04 Sep 2018 10:51:14 GMT
+  recorded_at: Wed, 12 Sep 2018 11:43:42 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:package_test_user/test_package/_config
     body:
       encoding: UTF-8
-      string: Vel est aut. Consequatur debitis omnis. Occaecati sequi non.
+      string: Dolores eius reprehenderit. Possimus qui dignissimos. Et aut eos.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -144,26 +144,26 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '207'
+      - '209'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="7" vrev="7">
-          <srcmd5>b9c7b1510ce939857c74c2a5b5b10141</srcmd5>
+        <revision rev="19" vrev="19">
+          <srcmd5>d4695834106d017601479001fb37af92</srcmd5>
           <version>unknown</version>
-          <time>1536058274</time>
+          <time>1536752622</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
     http_version: 
-  recorded_at: Tue, 04 Sep 2018 10:51:14 GMT
+  recorded_at: Wed, 12 Sep 2018 11:43:42 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:package_test_user/test_package/somefile.txt
     body:
       encoding: UTF-8
-      string: Sed iure ut. Eveniet dignissimos sit. Cum earum error.
+      string: Maxime molestiae omnis. Atque odio adipisci. Minus dolorum ex.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -183,20 +183,20 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '207'
+      - '209'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="8" vrev="8">
-          <srcmd5>c620dc860e8504736743700caa2f79d8</srcmd5>
+        <revision rev="20" vrev="20">
+          <srcmd5>0cd95eecee54d0003f84137f21af0fc6</srcmd5>
           <version>unknown</version>
-          <time>1536058274</time>
+          <time>1536752622</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
     http_version: 
-  recorded_at: Tue, 04 Sep 2018 10:51:14 GMT
+  recorded_at: Wed, 12 Sep 2018 11:43:42 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:other_package_test_user/_meta?user=other_package_test_user
@@ -237,7 +237,7 @@ http_interactions:
           <person userid="other_package_test_user" role="maintainer" />
         </project>
     http_version: 
-  recorded_at: Tue, 04 Sep 2018 10:51:15 GMT
+  recorded_at: Wed, 12 Sep 2018 11:43:42 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:other_package_test_user/branch_test_package/_meta?user=_nobody_
@@ -245,8 +245,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="branch_test_package" project="home:other_package_test_user">
-          <title>The Heart Is a Lonely Hunter</title>
-          <description>Animi atque explicabo fuga.</description>
+          <title>The Man Within</title>
+          <description>Et velit reiciendis natus.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -267,16 +267,16 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '190'
+      - '175'
     body:
       encoding: UTF-8
       string: |
         <package name="branch_test_package" project="home:other_package_test_user">
-          <title>The Heart Is a Lonely Hunter</title>
-          <description>Animi atque explicabo fuga.</description>
+          <title>The Man Within</title>
+          <description>Et velit reiciendis natus.</description>
         </package>
     http_version: 
-  recorded_at: Tue, 04 Sep 2018 10:51:15 GMT
+  recorded_at: Wed, 12 Sep 2018 11:43:42 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:other_package_test_user/branch_test_package/_meta?user=_nobody_
@@ -284,8 +284,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="branch_test_package" project="home:other_package_test_user">
-          <title>The Heart Is a Lonely Hunter</title>
-          <description>Animi atque explicabo fuga.</description>
+          <title>The Man Within</title>
+          <description>Et velit reiciendis natus.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -306,22 +306,22 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '190'
+      - '175'
     body:
       encoding: UTF-8
       string: |
         <package name="branch_test_package" project="home:other_package_test_user">
-          <title>The Heart Is a Lonely Hunter</title>
-          <description>Animi atque explicabo fuga.</description>
+          <title>The Man Within</title>
+          <description>Et velit reiciendis natus.</description>
         </package>
     http_version: 
-  recorded_at: Tue, 04 Sep 2018 10:51:15 GMT
+  recorded_at: Wed, 12 Sep 2018 11:43:42 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:other_package_test_user/branch_test_package/_config
     body:
       encoding: UTF-8
-      string: Enim fuga neque. Magnam culpa nemo. Aliquid autem quia.
+      string: Illum aut eius. Sit id atque. Non minus quia.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -345,22 +345,23 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <revision rev="21" vrev="21">
-          <srcmd5>f3863f7e692b9c5fe13bde6c81cf80c9</srcmd5>
+        <revision rev="19" vrev="19">
+          <srcmd5>a3d3643a21cac0359ce3bfea130247a4</srcmd5>
           <version>unknown</version>
-          <time>1536058275</time>
+          <time>1536752622</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
     http_version: 
-  recorded_at: Tue, 04 Sep 2018 10:51:15 GMT
+  recorded_at: Wed, 12 Sep 2018 11:43:42 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:other_package_test_user/branch_test_package/somefile.txt
     body:
       encoding: UTF-8
-      string: Repellat rerum harum. Saepe voluptas consectetur. Error commodi eos.
+      string: Pariatur omnis expedita. Consequuntur consequatur quos. Illo accusantium
+        recusandae.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -384,16 +385,16 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <revision rev="22" vrev="22">
-          <srcmd5>cc3471dfb2c6ae57b51e3cc0f221f630</srcmd5>
+        <revision rev="20" vrev="20">
+          <srcmd5>35ff979459817987c240811aa862b1fd</srcmd5>
           <version>unknown</version>
-          <time>1536058275</time>
+          <time>1536752622</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
     http_version: 
-  recorded_at: Tue, 04 Sep 2018 10:51:15 GMT
+  recorded_at: Wed, 12 Sep 2018 11:43:42 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:other_package_test_user/branch_test_package
@@ -423,15 +424,15 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="branch_test_package" rev="22" vrev="22" srcmd5="cc3471dfb2c6ae57b51e3cc0f221f630">
-          <entry name="_config" md5="49f457d6ed0136f75c143bc4cca6720a" size="55" mtime="1536058275" />
-          <entry name="somefile.txt" md5="2d1bb45b8f6de40839b44a5ba5643a58" size="68" mtime="1536058275" />
+        <directory name="branch_test_package" rev="20" vrev="20" srcmd5="35ff979459817987c240811aa862b1fd">
+          <entry name="_config" md5="434154ae81f704b328abe31ce6120ccd" size="45" mtime="1536752622" />
+          <entry name="somefile.txt" md5="80d5c02bfa1421bd96298a66b6ca4239" size="84" mtime="1536752622" />
         </directory>
     http_version: 
-  recorded_at: Tue, 04 Sep 2018 10:51:16 GMT
+  recorded_at: Wed, 12 Sep 2018 11:43:44 GMT
 - request:
     method: get
-    uri: http://backend:5352/source/home:other_package_test_user/branch_test_package?expand=1&rev=22
+    uri: http://backend:5352/source/home:other_package_test_user/branch_test_package?expand=1&rev=20
     body:
       encoding: US-ASCII
       string: ''
@@ -458,12 +459,12 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="branch_test_package" rev="22" vrev="22" srcmd5="cc3471dfb2c6ae57b51e3cc0f221f630">
-          <entry name="_config" md5="49f457d6ed0136f75c143bc4cca6720a" size="55" mtime="1536058275" />
-          <entry name="somefile.txt" md5="2d1bb45b8f6de40839b44a5ba5643a58" size="68" mtime="1536058275" />
+        <directory name="branch_test_package" rev="20" vrev="20" srcmd5="35ff979459817987c240811aa862b1fd">
+          <entry name="_config" md5="434154ae81f704b328abe31ce6120ccd" size="45" mtime="1536752622" />
+          <entry name="somefile.txt" md5="80d5c02bfa1421bd96298a66b6ca4239" size="84" mtime="1536752622" />
         </directory>
     http_version: 
-  recorded_at: Tue, 04 Sep 2018 10:51:16 GMT
+  recorded_at: Wed, 12 Sep 2018 11:43:44 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:other_package_test_user/branch_test_package/_service
@@ -498,7 +499,7 @@ http_interactions:
           <details>404 _service: no such file</details>
         </status>
     http_version: 
-  recorded_at: Tue, 04 Sep 2018 10:51:16 GMT
+  recorded_at: Wed, 12 Sep 2018 11:43:44 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:other_package_test_user/branch_test_package/_history
@@ -524,146 +525,134 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '4061'
+      - '3693'
     body:
       encoding: UTF-8
       string: |
         <revisionlist>
           <revision rev="1" vrev="1">
-            <srcmd5>df24bbf67148333bf797d4626c3ff4ea</srcmd5>
+            <srcmd5>a4a87294fe69bf281692d176ac11c5ce</srcmd5>
             <version>unknown</version>
-            <time>1536057948</time>
+            <time>1536742158</time>
             <user>unknown</user>
           </revision>
           <revision rev="2" vrev="2">
-            <srcmd5>03e5b185e89ba1a7dc37404ad35cad5a</srcmd5>
+            <srcmd5>56f1266200aa13816ecd90400b4c79bc</srcmd5>
             <version>unknown</version>
-            <time>1536057949</time>
+            <time>1536742158</time>
             <user>unknown</user>
           </revision>
           <revision rev="3" vrev="3">
-            <srcmd5>8d53b1273da0428dfb4050557a803e83</srcmd5>
+            <srcmd5>7937d23e57499c190bc6f72e776c0fd1</srcmd5>
             <version>unknown</version>
-            <time>1536057962</time>
+            <time>1536742172</time>
             <user>unknown</user>
           </revision>
           <revision rev="4" vrev="4">
-            <srcmd5>6e557801b6f414b3bfe3013e49eda41e</srcmd5>
+            <srcmd5>b9c11068d94c45e513924bbf644c12ab</srcmd5>
             <version>unknown</version>
-            <time>1536057962</time>
+            <time>1536742172</time>
             <user>unknown</user>
           </revision>
           <revision rev="5" vrev="5">
-            <srcmd5>cab47c2fde8167497ef7b69278f219bf</srcmd5>
+            <srcmd5>4fbd7695b7369791a1a78aef238f6d1f</srcmd5>
             <version>unknown</version>
-            <time>1536057975</time>
+            <time>1536742211</time>
             <user>unknown</user>
           </revision>
           <revision rev="6" vrev="6">
-            <srcmd5>daf7369fef63e9a7a783d8958a7f9f4b</srcmd5>
+            <srcmd5>f43e6c007cc271581bd3e13853917e3f</srcmd5>
             <version>unknown</version>
-            <time>1536057975</time>
+            <time>1536742211</time>
             <user>unknown</user>
           </revision>
           <revision rev="7" vrev="7">
-            <srcmd5>513380c011c7f3210f76d0b0fbf43c14</srcmd5>
+            <srcmd5>8aa665746e9eb15959955e5327d873c8</srcmd5>
             <version>unknown</version>
-            <time>1536058085</time>
+            <time>1536742225</time>
             <user>unknown</user>
           </revision>
           <revision rev="8" vrev="8">
-            <srcmd5>5365d987371c0475d3d2e56586426f15</srcmd5>
+            <srcmd5>b623e26a8dcd3c6a5047761a666d08c4</srcmd5>
             <version>unknown</version>
-            <time>1536058085</time>
+            <time>1536742225</time>
             <user>unknown</user>
           </revision>
           <revision rev="9" vrev="9">
-            <srcmd5>6c83dbef46f21fea22e7a851d827c969</srcmd5>
+            <srcmd5>1dfa8abdaf56c0dcca99e05a00d1fad6</srcmd5>
             <version>unknown</version>
-            <time>1536058097</time>
+            <time>1536748092</time>
             <user>unknown</user>
           </revision>
           <revision rev="10" vrev="10">
-            <srcmd5>f42cb5a0428e1418f7a74936847b3bfb</srcmd5>
+            <srcmd5>80dfdc9ee1b39432be2bfa59204bd7f9</srcmd5>
             <version>unknown</version>
-            <time>1536058097</time>
+            <time>1536748092</time>
             <user>unknown</user>
           </revision>
           <revision rev="11" vrev="11">
-            <srcmd5>10efdbd02bcf9819f430b89f1921a35a</srcmd5>
+            <srcmd5>e8b976cb18a24d19bea19cf5f6220c00</srcmd5>
             <version>unknown</version>
-            <time>1536058109</time>
+            <time>1536748104</time>
             <user>unknown</user>
           </revision>
           <revision rev="12" vrev="12">
-            <srcmd5>3b2fab6eda5c343871d7c65090db7ad4</srcmd5>
+            <srcmd5>1161ee9424c64864462989f6490c69e7</srcmd5>
             <version>unknown</version>
-            <time>1536058109</time>
+            <time>1536748104</time>
             <user>unknown</user>
           </revision>
           <revision rev="13" vrev="13">
-            <srcmd5>62d0a022ceb0b48715d45810a0153ed0</srcmd5>
+            <srcmd5>2861b90ff002eeb57f591d28be1a8e77</srcmd5>
             <version>unknown</version>
-            <time>1536058227</time>
+            <time>1536752310</time>
             <user>unknown</user>
           </revision>
           <revision rev="14" vrev="14">
-            <srcmd5>6acfb52abc27e5cb149dc1404c4dd17c</srcmd5>
+            <srcmd5>4852e89d276c07a8a0b898528ea9b5f7</srcmd5>
             <version>unknown</version>
-            <time>1536058227</time>
+            <time>1536752310</time>
             <user>unknown</user>
           </revision>
           <revision rev="15" vrev="15">
-            <srcmd5>f031e61b53ccae924e4005240d83081b</srcmd5>
+            <srcmd5>03b250f627df05d8d04a10b13e4fc9fd</srcmd5>
             <version>unknown</version>
-            <time>1536058239</time>
+            <time>1536752322</time>
             <user>unknown</user>
           </revision>
           <revision rev="16" vrev="16">
-            <srcmd5>3fef5db8b64bdfd9394d51f66cb75487</srcmd5>
+            <srcmd5>f244a9f08d9a71a5a33cfa493d85d3aa</srcmd5>
             <version>unknown</version>
-            <time>1536058239</time>
+            <time>1536752322</time>
             <user>unknown</user>
           </revision>
           <revision rev="17" vrev="17">
-            <srcmd5>7d46a73f0c5831de26fc1b9cad5bf477</srcmd5>
+            <srcmd5>ce725bf28e654fdcefd25913aa057697</srcmd5>
             <version>unknown</version>
-            <time>1536058252</time>
+            <time>1536752611</time>
             <user>unknown</user>
           </revision>
           <revision rev="18" vrev="18">
-            <srcmd5>16ee36e1e8199aca4a86338a7c955ce3</srcmd5>
+            <srcmd5>e2109e61778d2acbf80de1211c3bba56</srcmd5>
             <version>unknown</version>
-            <time>1536058252</time>
+            <time>1536752611</time>
             <user>unknown</user>
           </revision>
           <revision rev="19" vrev="19">
-            <srcmd5>96a3a0815afa04990e8d5e5a49864ec7</srcmd5>
+            <srcmd5>a3d3643a21cac0359ce3bfea130247a4</srcmd5>
             <version>unknown</version>
-            <time>1536058263</time>
+            <time>1536752622</time>
             <user>unknown</user>
           </revision>
           <revision rev="20" vrev="20">
-            <srcmd5>b671ab274f4d94aae3f1fab864aa158a</srcmd5>
+            <srcmd5>35ff979459817987c240811aa862b1fd</srcmd5>
             <version>unknown</version>
-            <time>1536058263</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="21" vrev="21">
-            <srcmd5>f3863f7e692b9c5fe13bde6c81cf80c9</srcmd5>
-            <version>unknown</version>
-            <time>1536058275</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="22" vrev="22">
-            <srcmd5>cc3471dfb2c6ae57b51e3cc0f221f630</srcmd5>
-            <version>unknown</version>
-            <time>1536058275</time>
+            <time>1536752622</time>
             <user>unknown</user>
           </revision>
         </revisionlist>
     http_version: 
-  recorded_at: Tue, 04 Sep 2018 10:51:16 GMT
+  recorded_at: Wed, 12 Sep 2018 11:43:44 GMT
 - request:
     method: get
     uri: http://backend:5352/build/home:other_package_test_user/_result?package=branch_test_package&view=status
@@ -671,10 +660,8 @@ http_interactions:
       encoding: US-ASCII
       string: ''
     headers:
-      Content-Type:
-      - text/plain
       Accept-Encoding:
-      - identity
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
       - "*/*"
       User-Agent:
@@ -698,10 +685,10 @@ http_interactions:
 
 '
     http_version: 
-  recorded_at: Tue, 04 Sep 2018 10:51:17 GMT
+  recorded_at: Wed, 12 Sep 2018 11:43:45 GMT
 - request:
     method: get
-    uri: http://backend:5352/source/home:other_package_test_user/branch_test_package?expand=1
+    uri: http://backend:5352/source/home:other_package_test_user/branch_test_package?expand=1&rev=20
     body:
       encoding: US-ASCII
       string: ''
@@ -728,23 +715,21 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="branch_test_package" rev="22" vrev="22" srcmd5="cc3471dfb2c6ae57b51e3cc0f221f630">
-          <entry name="_config" md5="49f457d6ed0136f75c143bc4cca6720a" size="55" mtime="1536058275" />
-          <entry name="somefile.txt" md5="2d1bb45b8f6de40839b44a5ba5643a58" size="68" mtime="1536058275" />
+        <directory name="branch_test_package" rev="20" vrev="20" srcmd5="35ff979459817987c240811aa862b1fd">
+          <entry name="_config" md5="434154ae81f704b328abe31ce6120ccd" size="45" mtime="1536752622" />
+          <entry name="somefile.txt" md5="80d5c02bfa1421bd96298a66b6ca4239" size="84" mtime="1536752622" />
         </directory>
     http_version: 
-  recorded_at: Tue, 04 Sep 2018 10:51:18 GMT
+  recorded_at: Wed, 12 Sep 2018 11:43:46 GMT
 - request:
     method: get
-    uri: http://backend:5352/source/home:other_package_test_user/branch_test_package?rev=22
+    uri: http://backend:5352/source/home:other_package_test_user/branch_test_package?rev=20
     body:
       encoding: US-ASCII
       string: ''
     headers:
-      Content-Type:
-      - text/plain
       Accept-Encoding:
-      - identity
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
       - "*/*"
       User-Agent:
@@ -765,12 +750,12 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="branch_test_package" rev="22" vrev="22" srcmd5="cc3471dfb2c6ae57b51e3cc0f221f630">
-          <entry name="_config" md5="49f457d6ed0136f75c143bc4cca6720a" size="55" mtime="1536058275" />
-          <entry name="somefile.txt" md5="2d1bb45b8f6de40839b44a5ba5643a58" size="68" mtime="1536058275" />
+        <directory name="branch_test_package" rev="20" vrev="20" srcmd5="35ff979459817987c240811aa862b1fd">
+          <entry name="_config" md5="434154ae81f704b328abe31ce6120ccd" size="45" mtime="1536752622" />
+          <entry name="somefile.txt" md5="80d5c02bfa1421bd96298a66b6ca4239" size="84" mtime="1536752622" />
         </directory>
     http_version: 
-  recorded_at: Tue, 04 Sep 2018 10:51:18 GMT
+  recorded_at: Wed, 12 Sep 2018 11:43:46 GMT
 - request:
     method: post
     uri: http://backend:5352/search/package/id?match=(linkinfo/@package=%22branch_test_package%22%20and%20linkinfo/@project=%22home:other_package_test_user%22%20and%20@project=%22home:other_package_test_user%22)
@@ -805,7 +790,7 @@ http_interactions:
         <collection>
         </collection>
     http_version: 
-  recorded_at: Tue, 04 Sep 2018 10:51:18 GMT
+  recorded_at: Wed, 12 Sep 2018 11:43:46 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:package_test_user:branches:home:other_package_test_user/_meta?user=package_test_user
@@ -846,7 +831,7 @@ http_interactions:
           <person userid="package_test_user" role="maintainer" />
         </project>
     http_version: 
-  recorded_at: Tue, 04 Sep 2018 10:51:18 GMT
+  recorded_at: Wed, 12 Sep 2018 11:43:46 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:package_test_user:branches:home:other_package_test_user/branch_test_package/_meta?user=package_test_user
@@ -854,8 +839,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="branch_test_package" project="home:package_test_user:branches:home:other_package_test_user">
-          <title>The Heart Is a Lonely Hunter</title>
-          <description>Animi atque explicabo fuga.</description>
+          <title>The Man Within</title>
+          <description>Et velit reiciendis natus.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -876,19 +861,19 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '222'
+      - '207'
     body:
       encoding: UTF-8
       string: |
         <package name="branch_test_package" project="home:package_test_user:branches:home:other_package_test_user">
-          <title>The Heart Is a Lonely Hunter</title>
-          <description>Animi atque explicabo fuga.</description>
+          <title>The Man Within</title>
+          <description>Et velit reiciendis natus.</description>
         </package>
     http_version: 
-  recorded_at: Tue, 04 Sep 2018 10:51:18 GMT
+  recorded_at: Wed, 12 Sep 2018 11:43:46 GMT
 - request:
     method: post
-    uri: http://backend:5352/source/home:package_test_user:branches:home:other_package_test_user/branch_test_package?cmd=branch&noservice=1&opackage=branch_test_package&oproject=home:other_package_test_user&orev=cc3471dfb2c6ae57b51e3cc0f221f630&user=package_test_user
+    uri: http://backend:5352/source/home:package_test_user:branches:home:other_package_test_user/branch_test_package?cmd=branch&noservice=1&opackage=branch_test_package&oproject=home:other_package_test_user&orev=35ff979459817987c240811aa862b1fd&user=package_test_user
     body:
       encoding: UTF-8
       string: ''
@@ -913,20 +898,20 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '217'
+      - '219'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="4" vrev="4">
-          <srcmd5>de966217ea3b88f6c6c0046ff651206a</srcmd5>
+        <revision rev="10" vrev="10">
+          <srcmd5>6cc1edbd20a63dfdfd82a1a2b201f13f</srcmd5>
           <version>unknown</version>
-          <time>1536058278</time>
+          <time>1536752626</time>
           <user>package_test_user</user>
           <comment></comment>
           <requestid/>
         </revision>
     http_version: 
-  recorded_at: Tue, 04 Sep 2018 10:51:18 GMT
+  recorded_at: Wed, 12 Sep 2018 11:43:46 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:package_test_user:branches:home:other_package_test_user/branch_test_package/_meta?user=package_test_user
@@ -934,8 +919,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="branch_test_package" project="home:package_test_user:branches:home:other_package_test_user">
-          <title>The Heart Is a Lonely Hunter</title>
-          <description>Animi atque explicabo fuga.</description>
+          <title>The Man Within</title>
+          <description>Et velit reiciendis natus.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -956,16 +941,16 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '222'
+      - '207'
     body:
       encoding: UTF-8
       string: |
         <package name="branch_test_package" project="home:package_test_user:branches:home:other_package_test_user">
-          <title>The Heart Is a Lonely Hunter</title>
-          <description>Animi atque explicabo fuga.</description>
+          <title>The Man Within</title>
+          <description>Et velit reiciendis natus.</description>
         </package>
     http_version: 
-  recorded_at: Tue, 04 Sep 2018 10:51:18 GMT
+  recorded_at: Wed, 12 Sep 2018 11:43:46 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:package_test_user:branches:home:other_package_test_user/branch_test_package
@@ -991,18 +976,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '694'
+      - '696'
     body:
       encoding: UTF-8
       string: |
-        <directory name="branch_test_package" rev="4" vrev="4" srcmd5="de966217ea3b88f6c6c0046ff651206a">
-          <linkinfo project="home:other_package_test_user" package="branch_test_package" rev="cc3471dfb2c6ae57b51e3cc0f221f630" srcmd5="cc3471dfb2c6ae57b51e3cc0f221f630" baserev="cc3471dfb2c6ae57b51e3cc0f221f630" xsrcmd5="d0d1923a6483d53ea7d9b815bc1b93e9" lsrcmd5="de966217ea3b88f6c6c0046ff651206a" />
-          <entry name="_config" md5="49f457d6ed0136f75c143bc4cca6720a" size="55" mtime="1536058275" />
-          <entry name="_link" md5="dc61f4c7c8cbe239593288bb263d193f" size="175" mtime="1536058278" />
-          <entry name="somefile.txt" md5="2d1bb45b8f6de40839b44a5ba5643a58" size="68" mtime="1536058275" />
+        <directory name="branch_test_package" rev="10" vrev="10" srcmd5="6cc1edbd20a63dfdfd82a1a2b201f13f">
+          <linkinfo project="home:other_package_test_user" package="branch_test_package" rev="35ff979459817987c240811aa862b1fd" srcmd5="35ff979459817987c240811aa862b1fd" baserev="35ff979459817987c240811aa862b1fd" xsrcmd5="a1e3912239b30d7d819f1f2b5789ae2b" lsrcmd5="6cc1edbd20a63dfdfd82a1a2b201f13f" />
+          <entry name="_config" md5="434154ae81f704b328abe31ce6120ccd" size="45" mtime="1536752622" />
+          <entry name="_link" md5="d4eeaa358a06d0cd3a703b38ea060012" size="175" mtime="1536752626" />
+          <entry name="somefile.txt" md5="80d5c02bfa1421bd96298a66b6ca4239" size="84" mtime="1536752622" />
         </directory>
     http_version: 
-  recorded_at: Tue, 04 Sep 2018 10:51:18 GMT
+  recorded_at: Wed, 12 Sep 2018 11:43:46 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:package_test_user:branches:home:other_package_test_user/branch_test_package?view=info
@@ -1028,16 +1013,16 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '362'
+      - '364'
     body:
       encoding: UTF-8
       string: |
-        <sourceinfo package="branch_test_package" rev="4" vrev="4" srcmd5="d0d1923a6483d53ea7d9b815bc1b93e9" lsrcmd5="de966217ea3b88f6c6c0046ff651206a" verifymd5="cc3471dfb2c6ae57b51e3cc0f221f630">
+        <sourceinfo package="branch_test_package" rev="10" vrev="10" srcmd5="a1e3912239b30d7d819f1f2b5789ae2b" lsrcmd5="6cc1edbd20a63dfdfd82a1a2b201f13f" verifymd5="35ff979459817987c240811aa862b1fd">
           <error>bad build configuration, no build type defined or detected</error>
           <linked project="home:other_package_test_user" package="branch_test_package" />
         </sourceinfo>
     http_version: 
-  recorded_at: Tue, 04 Sep 2018 10:51:18 GMT
+  recorded_at: Wed, 12 Sep 2018 11:43:46 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:package_test_user:branches:home:other_package_test_user/branch_test_package
@@ -1063,18 +1048,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '694'
+      - '696'
     body:
       encoding: UTF-8
       string: |
-        <directory name="branch_test_package" rev="4" vrev="4" srcmd5="de966217ea3b88f6c6c0046ff651206a">
-          <linkinfo project="home:other_package_test_user" package="branch_test_package" rev="cc3471dfb2c6ae57b51e3cc0f221f630" srcmd5="cc3471dfb2c6ae57b51e3cc0f221f630" baserev="cc3471dfb2c6ae57b51e3cc0f221f630" xsrcmd5="d0d1923a6483d53ea7d9b815bc1b93e9" lsrcmd5="de966217ea3b88f6c6c0046ff651206a" />
-          <entry name="_config" md5="49f457d6ed0136f75c143bc4cca6720a" size="55" mtime="1536058275" />
-          <entry name="_link" md5="dc61f4c7c8cbe239593288bb263d193f" size="175" mtime="1536058278" />
-          <entry name="somefile.txt" md5="2d1bb45b8f6de40839b44a5ba5643a58" size="68" mtime="1536058275" />
+        <directory name="branch_test_package" rev="10" vrev="10" srcmd5="6cc1edbd20a63dfdfd82a1a2b201f13f">
+          <linkinfo project="home:other_package_test_user" package="branch_test_package" rev="35ff979459817987c240811aa862b1fd" srcmd5="35ff979459817987c240811aa862b1fd" baserev="35ff979459817987c240811aa862b1fd" xsrcmd5="a1e3912239b30d7d819f1f2b5789ae2b" lsrcmd5="6cc1edbd20a63dfdfd82a1a2b201f13f" />
+          <entry name="_config" md5="434154ae81f704b328abe31ce6120ccd" size="45" mtime="1536752622" />
+          <entry name="_link" md5="d4eeaa358a06d0cd3a703b38ea060012" size="175" mtime="1536752626" />
+          <entry name="somefile.txt" md5="80d5c02bfa1421bd96298a66b6ca4239" size="84" mtime="1536752622" />
         </directory>
     http_version: 
-  recorded_at: Tue, 04 Sep 2018 10:51:18 GMT
+  recorded_at: Wed, 12 Sep 2018 11:43:46 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:package_test_user:branches:home:other_package_test_user/branch_test_package?cmd=diff&linkrev=base&onlyissues=1&orev=0&view=xml
@@ -1102,19 +1087,19 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '423'
+      - '424'
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="821e1f48a1e183d365a0a2dbf4b84d68">
+        <sourcediff key="05467ab31a0c9167eae0e5f07987730e">
           <old project="home:package_test_user:branches:home:other_package_test_user" package="branch_test_package" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e" />
-          <new project="home:package_test_user:branches:home:other_package_test_user" package="branch_test_package" rev="4" srcmd5="de966217ea3b88f6c6c0046ff651206a" />
+          <new project="home:package_test_user:branches:home:other_package_test_user" package="branch_test_package" rev="10" srcmd5="6cc1edbd20a63dfdfd82a1a2b201f13f" />
           <files />
           <issues>
           </issues>
         </sourcediff>
     http_version: 
-  recorded_at: Tue, 04 Sep 2018 10:51:18 GMT
+  recorded_at: Wed, 12 Sep 2018 11:43:46 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:package_test_user:branches:home:other_package_test_user/branch_test_package?cmd=linkdiff&linkrev=base&onlyissues=1&view=xml
@@ -1146,13 +1131,13 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="4c1244ddaf47d2d38ecc2582a5c37238">
-          <old project="home:other_package_test_user" package="branch_test_package" rev="cc3471dfb2c6ae57b51e3cc0f221f630" srcmd5="cc3471dfb2c6ae57b51e3cc0f221f630" />
-          <new project="home:package_test_user:branches:home:other_package_test_user" package="branch_test_package" rev="d0d1923a6483d53ea7d9b815bc1b93e9" srcmd5="d0d1923a6483d53ea7d9b815bc1b93e9" />
+        <sourcediff key="4cbf922b560e57262e5474e26ddf37ff">
+          <old project="home:other_package_test_user" package="branch_test_package" rev="35ff979459817987c240811aa862b1fd" srcmd5="35ff979459817987c240811aa862b1fd" />
+          <new project="home:package_test_user:branches:home:other_package_test_user" package="branch_test_package" rev="a1e3912239b30d7d819f1f2b5789ae2b" srcmd5="a1e3912239b30d7d819f1f2b5789ae2b" />
           <files />
         </sourcediff>
     http_version: 
-  recorded_at: Tue, 04 Sep 2018 10:51:18 GMT
+  recorded_at: Wed, 12 Sep 2018 11:43:46 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:package_test_user:branches:home:other_package_test_user/_meta?user=package_test_user
@@ -1199,7 +1184,7 @@ http_interactions:
           </publish>
         </project>
     http_version: 
-  recorded_at: Tue, 04 Sep 2018 10:51:18 GMT
+  recorded_at: Wed, 12 Sep 2018 11:43:46 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:other_package_test_user/branch_test_package?view=info
@@ -1229,11 +1214,11 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <sourceinfo package="branch_test_package" rev="22" vrev="22" srcmd5="cc3471dfb2c6ae57b51e3cc0f221f630" verifymd5="cc3471dfb2c6ae57b51e3cc0f221f630">
+        <sourceinfo package="branch_test_package" rev="20" vrev="20" srcmd5="35ff979459817987c240811aa862b1fd" verifymd5="35ff979459817987c240811aa862b1fd">
           <error>bad build configuration, no build type defined or detected</error>
         </sourceinfo>
     http_version: 
-  recorded_at: Tue, 04 Sep 2018 10:51:18 GMT
+  recorded_at: Wed, 12 Sep 2018 11:43:47 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:other_package_test_user/branch_test_package
@@ -1263,12 +1248,12 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="branch_test_package" rev="22" vrev="22" srcmd5="cc3471dfb2c6ae57b51e3cc0f221f630">
-          <entry name="_config" md5="49f457d6ed0136f75c143bc4cca6720a" size="55" mtime="1536058275" />
-          <entry name="somefile.txt" md5="2d1bb45b8f6de40839b44a5ba5643a58" size="68" mtime="1536058275" />
+        <directory name="branch_test_package" rev="20" vrev="20" srcmd5="35ff979459817987c240811aa862b1fd">
+          <entry name="_config" md5="434154ae81f704b328abe31ce6120ccd" size="45" mtime="1536752622" />
+          <entry name="somefile.txt" md5="80d5c02bfa1421bd96298a66b6ca4239" size="84" mtime="1536752622" />
         </directory>
     http_version: 
-  recorded_at: Tue, 04 Sep 2018 10:51:18 GMT
+  recorded_at: Wed, 12 Sep 2018 11:43:47 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:other_package_test_user/branch_test_package?cmd=diff&linkrev=base&onlyissues=1&orev=0&view=xml
@@ -1300,15 +1285,15 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="69571fff68f247be85dad265f5cdda80">
+        <sourcediff key="480f900fe82a5f19d1e54f12999f594e">
           <old project="home:other_package_test_user" package="branch_test_package" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e" />
-          <new project="home:other_package_test_user" package="branch_test_package" rev="22" srcmd5="cc3471dfb2c6ae57b51e3cc0f221f630" />
+          <new project="home:other_package_test_user" package="branch_test_package" rev="20" srcmd5="35ff979459817987c240811aa862b1fd" />
           <files />
           <issues>
           </issues>
         </sourcediff>
     http_version: 
-  recorded_at: Tue, 04 Sep 2018 10:51:18 GMT
+  recorded_at: Wed, 12 Sep 2018 11:43:47 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:package_test_user:branches:home:other_package_test_user/branch_test_package
@@ -1334,21 +1319,21 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '694'
+      - '696'
     body:
       encoding: UTF-8
       string: |
-        <directory name="branch_test_package" rev="4" vrev="4" srcmd5="de966217ea3b88f6c6c0046ff651206a">
-          <linkinfo project="home:other_package_test_user" package="branch_test_package" rev="cc3471dfb2c6ae57b51e3cc0f221f630" srcmd5="cc3471dfb2c6ae57b51e3cc0f221f630" baserev="cc3471dfb2c6ae57b51e3cc0f221f630" xsrcmd5="d0d1923a6483d53ea7d9b815bc1b93e9" lsrcmd5="de966217ea3b88f6c6c0046ff651206a" />
-          <entry name="_config" md5="49f457d6ed0136f75c143bc4cca6720a" size="55" mtime="1536058275" />
-          <entry name="_link" md5="dc61f4c7c8cbe239593288bb263d193f" size="175" mtime="1536058278" />
-          <entry name="somefile.txt" md5="2d1bb45b8f6de40839b44a5ba5643a58" size="68" mtime="1536058275" />
+        <directory name="branch_test_package" rev="10" vrev="10" srcmd5="6cc1edbd20a63dfdfd82a1a2b201f13f">
+          <linkinfo project="home:other_package_test_user" package="branch_test_package" rev="35ff979459817987c240811aa862b1fd" srcmd5="35ff979459817987c240811aa862b1fd" baserev="35ff979459817987c240811aa862b1fd" xsrcmd5="a1e3912239b30d7d819f1f2b5789ae2b" lsrcmd5="6cc1edbd20a63dfdfd82a1a2b201f13f" />
+          <entry name="_config" md5="434154ae81f704b328abe31ce6120ccd" size="45" mtime="1536752622" />
+          <entry name="_link" md5="d4eeaa358a06d0cd3a703b38ea060012" size="175" mtime="1536752626" />
+          <entry name="somefile.txt" md5="80d5c02bfa1421bd96298a66b6ca4239" size="84" mtime="1536752622" />
         </directory>
     http_version: 
-  recorded_at: Tue, 04 Sep 2018 10:51:19 GMT
+  recorded_at: Wed, 12 Sep 2018 11:43:47 GMT
 - request:
     method: get
-    uri: http://backend:5352/source/home:package_test_user:branches:home:other_package_test_user/branch_test_package?expand=1&rev=4
+    uri: http://backend:5352/source/home:package_test_user:branches:home:other_package_test_user/branch_test_package?expand=1&rev=10
     body:
       encoding: US-ASCII
       string: ''
@@ -1371,17 +1356,17 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '588'
+      - '589'
     body:
       encoding: UTF-8
       string: |
-        <directory name="branch_test_package" rev="d0d1923a6483d53ea7d9b815bc1b93e9" vrev="4" srcmd5="d0d1923a6483d53ea7d9b815bc1b93e9">
-          <linkinfo project="home:other_package_test_user" package="branch_test_package" rev="cc3471dfb2c6ae57b51e3cc0f221f630" srcmd5="cc3471dfb2c6ae57b51e3cc0f221f630" baserev="cc3471dfb2c6ae57b51e3cc0f221f630" lsrcmd5="de966217ea3b88f6c6c0046ff651206a" />
-          <entry name="_config" md5="49f457d6ed0136f75c143bc4cca6720a" size="55" mtime="1536058275" />
-          <entry name="somefile.txt" md5="2d1bb45b8f6de40839b44a5ba5643a58" size="68" mtime="1536058275" />
+        <directory name="branch_test_package" rev="a1e3912239b30d7d819f1f2b5789ae2b" vrev="10" srcmd5="a1e3912239b30d7d819f1f2b5789ae2b">
+          <linkinfo project="home:other_package_test_user" package="branch_test_package" rev="35ff979459817987c240811aa862b1fd" srcmd5="35ff979459817987c240811aa862b1fd" baserev="35ff979459817987c240811aa862b1fd" lsrcmd5="6cc1edbd20a63dfdfd82a1a2b201f13f" />
+          <entry name="_config" md5="434154ae81f704b328abe31ce6120ccd" size="45" mtime="1536752622" />
+          <entry name="somefile.txt" md5="80d5c02bfa1421bd96298a66b6ca4239" size="84" mtime="1536752622" />
         </directory>
     http_version: 
-  recorded_at: Tue, 04 Sep 2018 10:51:19 GMT
+  recorded_at: Wed, 12 Sep 2018 11:43:47 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:package_test_user:branches:home:other_package_test_user/branch_test_package/_service
@@ -1416,7 +1401,7 @@ http_interactions:
           <details>404 _service: no such file</details>
         </status>
     http_version: 
-  recorded_at: Tue, 04 Sep 2018 10:51:19 GMT
+  recorded_at: Wed, 12 Sep 2018 11:43:47 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:package_test_user:branches:home:other_package_test_user/branch_test_package
@@ -1442,18 +1427,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '694'
+      - '696'
     body:
       encoding: UTF-8
       string: |
-        <directory name="branch_test_package" rev="4" vrev="4" srcmd5="de966217ea3b88f6c6c0046ff651206a">
-          <linkinfo project="home:other_package_test_user" package="branch_test_package" rev="cc3471dfb2c6ae57b51e3cc0f221f630" srcmd5="cc3471dfb2c6ae57b51e3cc0f221f630" baserev="cc3471dfb2c6ae57b51e3cc0f221f630" xsrcmd5="d0d1923a6483d53ea7d9b815bc1b93e9" lsrcmd5="de966217ea3b88f6c6c0046ff651206a" />
-          <entry name="_config" md5="49f457d6ed0136f75c143bc4cca6720a" size="55" mtime="1536058275" />
-          <entry name="_link" md5="dc61f4c7c8cbe239593288bb263d193f" size="175" mtime="1536058278" />
-          <entry name="somefile.txt" md5="2d1bb45b8f6de40839b44a5ba5643a58" size="68" mtime="1536058275" />
+        <directory name="branch_test_package" rev="10" vrev="10" srcmd5="6cc1edbd20a63dfdfd82a1a2b201f13f">
+          <linkinfo project="home:other_package_test_user" package="branch_test_package" rev="35ff979459817987c240811aa862b1fd" srcmd5="35ff979459817987c240811aa862b1fd" baserev="35ff979459817987c240811aa862b1fd" xsrcmd5="a1e3912239b30d7d819f1f2b5789ae2b" lsrcmd5="6cc1edbd20a63dfdfd82a1a2b201f13f" />
+          <entry name="_config" md5="434154ae81f704b328abe31ce6120ccd" size="45" mtime="1536752622" />
+          <entry name="_link" md5="d4eeaa358a06d0cd3a703b38ea060012" size="175" mtime="1536752626" />
+          <entry name="somefile.txt" md5="80d5c02bfa1421bd96298a66b6ca4239" size="84" mtime="1536752622" />
         </directory>
     http_version: 
-  recorded_at: Tue, 04 Sep 2018 10:51:19 GMT
+  recorded_at: Wed, 12 Sep 2018 11:43:47 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:package_test_user:branches:home:other_package_test_user/branch_test_package
@@ -1479,18 +1464,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '694'
+      - '696'
     body:
       encoding: UTF-8
       string: |
-        <directory name="branch_test_package" rev="4" vrev="4" srcmd5="de966217ea3b88f6c6c0046ff651206a">
-          <linkinfo project="home:other_package_test_user" package="branch_test_package" rev="cc3471dfb2c6ae57b51e3cc0f221f630" srcmd5="cc3471dfb2c6ae57b51e3cc0f221f630" baserev="cc3471dfb2c6ae57b51e3cc0f221f630" xsrcmd5="d0d1923a6483d53ea7d9b815bc1b93e9" lsrcmd5="de966217ea3b88f6c6c0046ff651206a" />
-          <entry name="_config" md5="49f457d6ed0136f75c143bc4cca6720a" size="55" mtime="1536058275" />
-          <entry name="_link" md5="dc61f4c7c8cbe239593288bb263d193f" size="175" mtime="1536058278" />
-          <entry name="somefile.txt" md5="2d1bb45b8f6de40839b44a5ba5643a58" size="68" mtime="1536058275" />
+        <directory name="branch_test_package" rev="10" vrev="10" srcmd5="6cc1edbd20a63dfdfd82a1a2b201f13f">
+          <linkinfo project="home:other_package_test_user" package="branch_test_package" rev="35ff979459817987c240811aa862b1fd" srcmd5="35ff979459817987c240811aa862b1fd" baserev="35ff979459817987c240811aa862b1fd" xsrcmd5="a1e3912239b30d7d819f1f2b5789ae2b" lsrcmd5="6cc1edbd20a63dfdfd82a1a2b201f13f" />
+          <entry name="_config" md5="434154ae81f704b328abe31ce6120ccd" size="45" mtime="1536752622" />
+          <entry name="_link" md5="d4eeaa358a06d0cd3a703b38ea060012" size="175" mtime="1536752626" />
+          <entry name="somefile.txt" md5="80d5c02bfa1421bd96298a66b6ca4239" size="84" mtime="1536752622" />
         </directory>
     http_version: 
-  recorded_at: Tue, 04 Sep 2018 10:51:19 GMT
+  recorded_at: Wed, 12 Sep 2018 11:43:47 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:package_test_user:branches:home:other_package_test_user/branch_test_package/_history
@@ -1516,38 +1501,74 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '799'
+      - '1953'
     body:
       encoding: UTF-8
       string: |
         <revisionlist>
           <revision rev="1" vrev="1">
-            <srcmd5>4369256fc7026ce9efc535ca4af38c57</srcmd5>
+            <srcmd5>1aca36bfa87765d6cd5ca2721753d45b</srcmd5>
             <version>unknown</version>
-            <time>1536058088</time>
+            <time>1536742163</time>
             <user>package_test_user</user>
           </revision>
           <revision rev="2" vrev="2">
-            <srcmd5>3054c237efb30ad77f7986dd041466d5</srcmd5>
+            <srcmd5>e4396ee5b376d0ac30b7cdb8ccdd4b59</srcmd5>
             <version>unknown</version>
-            <time>1536058100</time>
+            <time>1536742175</time>
             <user>package_test_user</user>
           </revision>
           <revision rev="3" vrev="3">
-            <srcmd5>5729343ed2c09cf63f9ce1a9a7fe888f</srcmd5>
+            <srcmd5>2b32c7e5905e80db6abb01432d2c881d</srcmd5>
             <version>unknown</version>
-            <time>1536058266</time>
+            <time>1536742216</time>
             <user>package_test_user</user>
           </revision>
           <revision rev="4" vrev="4">
-            <srcmd5>de966217ea3b88f6c6c0046ff651206a</srcmd5>
+            <srcmd5>d7dc2a21eeb234d4ceec7effa04de994</srcmd5>
             <version>unknown</version>
-            <time>1536058278</time>
+            <time>1536742228</time>
+            <user>package_test_user</user>
+          </revision>
+          <revision rev="5" vrev="5">
+            <srcmd5>460a55998efa7bc8c1e727f7b6c33abe</srcmd5>
+            <version>unknown</version>
+            <time>1536748096</time>
+            <user>package_test_user</user>
+          </revision>
+          <revision rev="6" vrev="6">
+            <srcmd5>9e52ae591ccc2d95f7bac74ab2c7a20d</srcmd5>
+            <version>unknown</version>
+            <time>1536748108</time>
+            <user>package_test_user</user>
+          </revision>
+          <revision rev="7" vrev="7">
+            <srcmd5>a2025e524c9ecf86aacc2ed66f2df49f</srcmd5>
+            <version>unknown</version>
+            <time>1536752314</time>
+            <user>package_test_user</user>
+          </revision>
+          <revision rev="8" vrev="8">
+            <srcmd5>f9f2fdc97ab6a5360c320664a3201e97</srcmd5>
+            <version>unknown</version>
+            <time>1536752326</time>
+            <user>package_test_user</user>
+          </revision>
+          <revision rev="9" vrev="9">
+            <srcmd5>5bb1f7e3bfcfd6e3c1876cfe2ff6f007</srcmd5>
+            <version>unknown</version>
+            <time>1536752614</time>
+            <user>package_test_user</user>
+          </revision>
+          <revision rev="10" vrev="10">
+            <srcmd5>6cc1edbd20a63dfdfd82a1a2b201f13f</srcmd5>
+            <version>unknown</version>
+            <time>1536752626</time>
             <user>package_test_user</user>
           </revision>
         </revisionlist>
     http_version: 
-  recorded_at: Tue, 04 Sep 2018 10:51:19 GMT
+  recorded_at: Wed, 12 Sep 2018 11:43:47 GMT
 - request:
     method: get
     uri: http://backend:5352/build/home:package_test_user:branches:home:other_package_test_user/_result?package=branch_test_package&view=status
@@ -1555,10 +1576,8 @@ http_interactions:
       encoding: US-ASCII
       string: ''
     headers:
-      Content-Type:
-      - text/plain
       Accept-Encoding:
-      - identity
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
       - "*/*"
       User-Agent:
@@ -1582,5 +1601,5 @@ http_interactions:
 
 '
     http_version: 
-  recorded_at: Tue, 04 Sep 2018 10:51:19 GMT
+  recorded_at: Wed, 12 Sep 2018 11:43:47 GMT
 recorded_with: VCR 4.0.0

--- a/src/api/spec/cassettes/Webui_PackageController/POST_branch/shows_an_error_if_current_revision_parameter_is_provided_but_there_wasn_t_any_revision_before.yml
+++ b/src/api/spec/cassettes/Webui_PackageController/POST_branch/shows_an_error_if_current_revision_parameter_is_provided_but_there_wasn_t_any_revision_before.yml
@@ -40,7 +40,7 @@ http_interactions:
           <person userid="tom" role="maintainer" />
         </project>
     http_version: 
-  recorded_at: Tue, 27 Mar 2018 13:51:15 GMT
+  recorded_at: Thu, 13 Sep 2018 08:17:30 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom/my_package/_meta?user=tom
@@ -48,8 +48,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="my_package" project="home:tom">
-          <title>Pale Kings and Princes</title>
-          <description>Corrupti possimus explicabo est.</description>
+          <title>Such, Such Were the Joys</title>
+          <description>Ut dolor soluta est.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -70,25 +70,25 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '160'
+      - '150'
     body:
       encoding: UTF-8
       string: |
         <package name="my_package" project="home:tom">
-          <title>Pale Kings and Princes</title>
-          <description>Corrupti possimus explicabo est.</description>
+          <title>Such, Such Were the Joys</title>
+          <description>Ut dolor soluta est.</description>
         </package>
     http_version: 
-  recorded_at: Tue, 27 Mar 2018 13:51:16 GMT
+  recorded_at: Thu, 13 Sep 2018 08:17:30 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom/my_package/_meta
+    uri: http://backend:5352/source/home:tom/my_package/_meta?user=tom
     body:
       encoding: UTF-8
       string: |
         <package name="my_package" project="home:tom">
-          <title>Pale Kings and Princes</title>
-          <description>Corrupti possimus explicabo est.</description>
+          <title>Such, Such Were the Joys</title>
+          <description>Ut dolor soluta est.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -109,19 +109,19 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '160'
+      - '150'
     body:
       encoding: UTF-8
       string: |
         <package name="my_package" project="home:tom">
-          <title>Pale Kings and Princes</title>
-          <description>Corrupti possimus explicabo est.</description>
+          <title>Such, Such Were the Joys</title>
+          <description>Ut dolor soluta est.</description>
         </package>
     http_version: 
-  recorded_at: Tue, 27 Mar 2018 13:51:16 GMT
+  recorded_at: Thu, 13 Sep 2018 08:17:30 GMT
 - request:
     method: get
-    uri: http://backend:5352/source/home:tom/my_package?expand=1
+    uri: http://backend:5352/source/home:tom/my_package?expand=1&rev=2
     body:
       encoding: US-ASCII
       string: ''
@@ -134,8 +134,8 @@ http_interactions:
       - Ruby
   response:
     status:
-      code: 200
-      message: OK
+      code: 404
+      message: no such revision
     headers:
       Content-Type:
       - text/xml
@@ -144,12 +144,14 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '85'
+      - '110'
     body:
       encoding: UTF-8
       string: |
-        <directory name="my_package" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
-        </directory>
+        <status code="404">
+          <summary>no such revision</summary>
+          <details>404 no such revision</details>
+        </status>
     http_version: 
-  recorded_at: Tue, 27 Mar 2018 13:51:16 GMT
+  recorded_at: Thu, 13 Sep 2018 08:17:30 GMT
 recorded_with: VCR 4.0.0

--- a/src/api/spec/cassettes/Webui_PackageController/POST_branch/shows_an_error_if_source_package_does_not_exist.yml
+++ b/src/api/spec/cassettes/Webui_PackageController/POST_branch/shows_an_error_if_source_package_does_not_exist.yml
@@ -40,5 +40,5 @@ http_interactions:
           <person userid="tom" role="maintainer" />
         </project>
     http_version: 
-  recorded_at: Mon, 09 Jan 2017 12:37:39 GMT
-recorded_with: VCR 3.0.3
+  recorded_at: Thu, 13 Sep 2018 08:17:30 GMT
+recorded_with: VCR 4.0.0

--- a/src/api/spec/cassettes/Webui_PackageController/POST_branch/shows_an_error_if_source_package_parameter_not_provided.yml
+++ b/src/api/spec/cassettes/Webui_PackageController/POST_branch/shows_an_error_if_source_package_parameter_not_provided.yml
@@ -40,5 +40,5 @@ http_interactions:
           <person userid="tom" role="maintainer" />
         </project>
     http_version: 
-  recorded_at: Mon, 09 Jan 2017 12:37:39 GMT
-recorded_with: VCR 3.0.3
+  recorded_at: Thu, 13 Sep 2018 08:17:31 GMT
+recorded_with: VCR 4.0.0

--- a/src/api/spec/cassettes/Webui_PackageController/POST_branch/shows_an_error_if_source_project_does_not_exist.yml
+++ b/src/api/spec/cassettes/Webui_PackageController/POST_branch/shows_an_error_if_source_project_does_not_exist.yml
@@ -40,7 +40,7 @@ http_interactions:
           <person userid="tom" role="maintainer" />
         </project>
     http_version: 
-  recorded_at: Mon, 09 Jan 2017 12:37:39 GMT
+  recorded_at: Thu, 13 Sep 2018 08:17:31 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom/my_package/_meta?user=tom
@@ -48,8 +48,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="my_package" project="home:tom">
-          <title/>
-          <description/>
+          <title>The Man Within</title>
+          <description>Minima sed in enim.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -70,25 +70,25 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '106'
+      - '139'
     body:
       encoding: UTF-8
       string: |
         <package name="my_package" project="home:tom">
-          <title></title>
-          <description></description>
+          <title>The Man Within</title>
+          <description>Minima sed in enim.</description>
         </package>
     http_version: 
-  recorded_at: Mon, 09 Jan 2017 12:37:39 GMT
+  recorded_at: Thu, 13 Sep 2018 08:17:31 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom/my_package/_meta
+    uri: http://backend:5352/source/home:tom/my_package/_meta?user=tom
     body:
       encoding: UTF-8
       string: |
         <package name="my_package" project="home:tom">
-          <title/>
-          <description/>
+          <title>The Man Within</title>
+          <description>Minima sed in enim.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -109,14 +109,14 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '106'
+      - '139'
     body:
       encoding: UTF-8
       string: |
         <package name="my_package" project="home:tom">
-          <title></title>
-          <description></description>
+          <title>The Man Within</title>
+          <description>Minima sed in enim.</description>
         </package>
     http_version: 
-  recorded_at: Mon, 09 Jan 2017 12:37:39 GMT
-recorded_with: VCR 3.0.3
+  recorded_at: Thu, 13 Sep 2018 08:17:31 GMT
+recorded_with: VCR 4.0.0

--- a/src/api/spec/cassettes/Webui_PackageController/POST_branch/shows_an_error_if_source_project_parameter_not_provided.yml
+++ b/src/api/spec/cassettes/Webui_PackageController/POST_branch/shows_an_error_if_source_project_parameter_not_provided.yml
@@ -40,7 +40,7 @@ http_interactions:
           <person userid="tom" role="maintainer" />
         </project>
     http_version: 
-  recorded_at: Mon, 09 Jan 2017 12:37:38 GMT
+  recorded_at: Thu, 13 Sep 2018 08:17:30 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom/my_package/_meta?user=tom
@@ -48,8 +48,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="my_package" project="home:tom">
-          <title/>
-          <description/>
+          <title>A Darkling Plain</title>
+          <description>Deleniti est rem et.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -70,25 +70,25 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '106'
+      - '142'
     body:
       encoding: UTF-8
       string: |
         <package name="my_package" project="home:tom">
-          <title></title>
-          <description></description>
+          <title>A Darkling Plain</title>
+          <description>Deleniti est rem et.</description>
         </package>
     http_version: 
-  recorded_at: Mon, 09 Jan 2017 12:37:38 GMT
+  recorded_at: Thu, 13 Sep 2018 08:17:30 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom/my_package/_meta
+    uri: http://backend:5352/source/home:tom/my_package/_meta?user=tom
     body:
       encoding: UTF-8
       string: |
         <package name="my_package" project="home:tom">
-          <title/>
-          <description/>
+          <title>A Darkling Plain</title>
+          <description>Deleniti est rem et.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -109,14 +109,14 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '106'
+      - '142'
     body:
       encoding: UTF-8
       string: |
         <package name="my_package" project="home:tom">
-          <title></title>
-          <description></description>
+          <title>A Darkling Plain</title>
+          <description>Deleniti est rem et.</description>
         </package>
     http_version: 
-  recorded_at: Mon, 09 Jan 2017 12:37:38 GMT
-recorded_with: VCR 3.0.3
+  recorded_at: Thu, 13 Sep 2018 08:17:30 GMT
+recorded_with: VCR 4.0.0

--- a/src/api/spec/cassettes/Webui_PackageController/POST_branch/shows_an_error_if_user_has_no_permissions_for_source_project.yml
+++ b/src/api/spec/cassettes/Webui_PackageController/POST_branch/shows_an_error_if_user_has_no_permissions_for_source_project.yml
@@ -1,6 +1,125 @@
 ---
 http_interactions:
 - request:
+    method: put
+    uri: http://backend:5352/source/home:tom/_meta?user=tom
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:tom">
+          <title/>
+          <description/>
+          <person userid="tom" role="maintainer"/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '129'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:tom">
+          <title></title>
+          <description></description>
+          <person userid="tom" role="maintainer" />
+        </project>
+    http_version: 
+  recorded_at: Thu, 13 Sep 2018 08:17:31 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:tom/my_package/_meta?user=tom
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="my_package" project="home:tom">
+          <title>Fair Stood the Wind for France</title>
+          <description>Temporibus non est sed.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '159'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="my_package" project="home:tom">
+          <title>Fair Stood the Wind for France</title>
+          <description>Temporibus non est sed.</description>
+        </package>
+    http_version: 
+  recorded_at: Thu, 13 Sep 2018 08:17:31 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:tom/my_package/_meta?user=tom
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="my_package" project="home:tom">
+          <title>Fair Stood the Wind for France</title>
+          <description>Temporibus non est sed.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '159'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="my_package" project="home:tom">
+          <title>Fair Stood the Wind for France</title>
+          <description>Temporibus non est sed.</description>
+        </package>
+    http_version: 
+  recorded_at: Thu, 13 Sep 2018 08:17:31 GMT
+- request:
     method: post
     uri: http://backend:5352/search/package/id?match=(linkinfo/@package=%22my_package%22%20and%20linkinfo/@project=%22home:tom%22%20and%20@project=%22home:tom%22)
     body:
@@ -34,5 +153,5 @@ http_interactions:
         <collection>
         </collection>
     http_version: 
-  recorded_at: Tue, 02 May 2017 08:04:34 GMT
-recorded_with: VCR 3.0.3
+  recorded_at: Thu, 13 Sep 2018 08:17:31 GMT
+recorded_with: VCR 4.0.0

--- a/src/api/spec/cassettes/Webui_PackageController/POST_branch/with_currrent_revision_parameter/1_4_8_1.yml
+++ b/src/api/spec/cassettes/Webui_PackageController/POST_branch/with_currrent_revision_parameter/1_4_8_1.yml
@@ -40,7 +40,7 @@ http_interactions:
           <person userid="tom" role="maintainer" />
         </project>
     http_version: 
-  recorded_at: Wed, 28 Mar 2018 07:08:06 GMT
+  recorded_at: Thu, 13 Sep 2018 08:17:35 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom/package_with_revisions/_meta?user=tom
@@ -48,8 +48,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="package_with_revisions" project="home:tom">
-          <title>Beyond the Mexique Bay</title>
-          <description>Aut non ea reprehenderit doloremque eos nobis rem.</description>
+          <title>I Will Fear No Evil</title>
+          <description>At unde consequatur reiciendis.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -70,25 +70,25 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '190'
+      - '168'
     body:
       encoding: UTF-8
       string: |
         <package name="package_with_revisions" project="home:tom">
-          <title>Beyond the Mexique Bay</title>
-          <description>Aut non ea reprehenderit doloremque eos nobis rem.</description>
+          <title>I Will Fear No Evil</title>
+          <description>At unde consequatur reiciendis.</description>
         </package>
     http_version: 
-  recorded_at: Wed, 28 Mar 2018 07:08:06 GMT
+  recorded_at: Thu, 13 Sep 2018 08:17:35 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom/package_with_revisions/_meta
+    uri: http://backend:5352/source/home:tom/package_with_revisions/_meta?user=tom
     body:
       encoding: UTF-8
       string: |
         <package name="package_with_revisions" project="home:tom">
-          <title>Beyond the Mexique Bay</title>
-          <description>Aut non ea reprehenderit doloremque eos nobis rem.</description>
+          <title>I Will Fear No Evil</title>
+          <description>At unde consequatur reiciendis.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -109,16 +109,16 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '190'
+      - '168'
     body:
       encoding: UTF-8
       string: |
         <package name="package_with_revisions" project="home:tom">
-          <title>Beyond the Mexique Bay</title>
-          <description>Aut non ea reprehenderit doloremque eos nobis rem.</description>
+          <title>I Will Fear No Evil</title>
+          <description>At unde consequatur reiciendis.</description>
         </package>
     http_version: 
-  recorded_at: Wed, 28 Mar 2018 07:08:06 GMT
+  recorded_at: Thu, 13 Sep 2018 08:17:35 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom/package_with_revisions/somefile.txt
@@ -148,16 +148,16 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <revision rev="21" vrev="21">
+        <revision rev="77" vrev="77">
           <srcmd5>cabf9a1f9a0b7c19d4f7ff46166f4ee0</srcmd5>
           <version>unknown</version>
-          <time>1522220886</time>
+          <time>1536826655</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
     http_version: 
-  recorded_at: Wed, 28 Mar 2018 07:08:06 GMT
+  recorded_at: Thu, 13 Sep 2018 08:17:35 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom/package_with_revisions/somefile.txt
@@ -187,19 +187,97 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <revision rev="22" vrev="22">
+        <revision rev="78" vrev="78">
           <srcmd5>efbe5f0a5dd48df5129b4319df43aa45</srcmd5>
           <version>unknown</version>
-          <time>1522220887</time>
+          <time>1536826655</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
     http_version: 
-  recorded_at: Wed, 28 Mar 2018 07:08:07 GMT
+  recorded_at: Thu, 13 Sep 2018 08:17:35 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:tom/package_with_revisions/somefile.txt
+    body:
+      encoding: US-ASCII
+      string: '2'
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '209'
+    body:
+      encoding: UTF-8
+      string: |
+        <revision rev="79" vrev="79">
+          <srcmd5>6ba292a7c75f8b46e4d39ac7cb20ebcd</srcmd5>
+          <version>unknown</version>
+          <time>1536826655</time>
+          <user>unknown</user>
+          <comment></comment>
+          <requestid/>
+        </revision>
+    http_version: 
+  recorded_at: Thu, 13 Sep 2018 08:17:35 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:tom/package_with_revisions/somefile.txt
+    body:
+      encoding: US-ASCII
+      string: '3'
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '209'
+    body:
+      encoding: UTF-8
+      string: |
+        <revision rev="80" vrev="80">
+          <srcmd5>60d83e04e1adc0a7e399a5b10312faf1</srcmd5>
+          <version>unknown</version>
+          <time>1536826655</time>
+          <user>unknown</user>
+          <comment></comment>
+          <requestid/>
+        </revision>
+    http_version: 
+  recorded_at: Thu, 13 Sep 2018 08:17:35 GMT
 - request:
     method: get
-    uri: http://backend:5352/source/home:tom/package_with_revisions?expand=1
+    uri: http://backend:5352/source/home:tom/package_with_revisions?rev=2
     body:
       encoding: US-ASCII
       string: ''
@@ -222,51 +300,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '215'
+      - '213'
     body:
       encoding: UTF-8
       string: |
-        <directory name="package_with_revisions" rev="22" vrev="22" srcmd5="efbe5f0a5dd48df5129b4319df43aa45">
-          <entry name="somefile.txt" md5="c4ca4238a0b923820dcc509a6f75849b" size="1" mtime="1522153904" />
+        <directory name="package_with_revisions" rev="2" vrev="2" srcmd5="efbe5f0a5dd48df5129b4319df43aa45">
+          <entry name="somefile.txt" md5="c4ca4238a0b923820dcc509a6f75849b" size="1" mtime="1536742992" />
         </directory>
     http_version: 
-  recorded_at: Wed, 28 Mar 2018 07:08:07 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/home:tom/package_with_revisions?rev=22
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Content-Type:
-      - text/plain
-      Accept-Encoding:
-      - identity
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '215'
-    body:
-      encoding: UTF-8
-      string: |
-        <directory name="package_with_revisions" rev="22" vrev="22" srcmd5="efbe5f0a5dd48df5129b4319df43aa45">
-          <entry name="somefile.txt" md5="c4ca4238a0b923820dcc509a6f75849b" size="1" mtime="1522153904" />
-        </directory>
-    http_version: 
-  recorded_at: Wed, 28 Mar 2018 07:08:07 GMT
+  recorded_at: Thu, 13 Sep 2018 08:17:35 GMT
 - request:
     method: post
     uri: http://backend:5352/search/package/id?match=(linkinfo/@package=%22package_with_revisions%22%20and%20linkinfo/@project=%22home:tom%22%20and%20@project=%22home:tom%22)
@@ -301,7 +343,7 @@ http_interactions:
         <collection>
         </collection>
     http_version: 
-  recorded_at: Wed, 28 Mar 2018 07:08:07 GMT
+  recorded_at: Thu, 13 Sep 2018 08:17:35 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom:branches:home:tom/_meta?user=tom
@@ -342,7 +384,7 @@ http_interactions:
           <person userid="tom" role="maintainer" />
         </project>
     http_version: 
-  recorded_at: Wed, 28 Mar 2018 07:08:07 GMT
+  recorded_at: Thu, 13 Sep 2018 08:17:35 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom:branches:home:tom/package_with_revisions/_meta?user=tom
@@ -350,8 +392,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="package_with_revisions" project="home:tom:branches:home:tom">
-          <title>Beyond the Mexique Bay</title>
-          <description>Aut non ea reprehenderit doloremque eos nobis rem.</description>
+          <title>I Will Fear No Evil</title>
+          <description>At unde consequatur reiciendis.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -372,16 +414,16 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '208'
+      - '186'
     body:
       encoding: UTF-8
       string: |
         <package name="package_with_revisions" project="home:tom:branches:home:tom">
-          <title>Beyond the Mexique Bay</title>
-          <description>Aut non ea reprehenderit doloremque eos nobis rem.</description>
+          <title>I Will Fear No Evil</title>
+          <description>At unde consequatur reiciendis.</description>
         </package>
     http_version: 
-  recorded_at: Wed, 28 Mar 2018 07:08:07 GMT
+  recorded_at: Thu, 13 Sep 2018 08:17:35 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:tom:branches:home:tom/package_with_revisions?cmd=branch&noservice=1&opackage=package_with_revisions&oproject=home:tom&orev=efbe5f0a5dd48df5129b4319df43aa45&user=tom
@@ -413,16 +455,16 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <revision rev="12" vrev="12">
+        <revision rev="47" vrev="47">
           <srcmd5>b40e9cce84f2c67bd45ff4667726a62f</srcmd5>
           <version>unknown</version>
-          <time>1522220887</time>
+          <time>1536826655</time>
           <user>tom</user>
           <comment></comment>
           <requestid/>
         </revision>
     http_version: 
-  recorded_at: Wed, 28 Mar 2018 07:08:07 GMT
+  recorded_at: Thu, 13 Sep 2018 08:17:35 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom:branches:home:tom/package_with_revisions/_meta?user=tom
@@ -430,8 +472,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="package_with_revisions" project="home:tom:branches:home:tom">
-          <title>Beyond the Mexique Bay</title>
-          <description>Aut non ea reprehenderit doloremque eos nobis rem.</description>
+          <title>I Will Fear No Evil</title>
+          <description>At unde consequatur reiciendis.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -452,16 +494,16 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '208'
+      - '186'
     body:
       encoding: UTF-8
       string: |
         <package name="package_with_revisions" project="home:tom:branches:home:tom">
-          <title>Beyond the Mexique Bay</title>
-          <description>Aut non ea reprehenderit doloremque eos nobis rem.</description>
+          <title>I Will Fear No Evil</title>
+          <description>At unde consequatur reiciendis.</description>
         </package>
     http_version: 
-  recorded_at: Wed, 28 Mar 2018 07:08:07 GMT
+  recorded_at: Thu, 13 Sep 2018 08:17:35 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:tom:branches:home:tom/package_with_revisions
@@ -491,13 +533,13 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="package_with_revisions" rev="12" vrev="12" srcmd5="b40e9cce84f2c67bd45ff4667726a62f">
+        <directory name="package_with_revisions" rev="47" vrev="47" srcmd5="b40e9cce84f2c67bd45ff4667726a62f">
           <linkinfo project="home:tom" package="package_with_revisions" rev="efbe5f0a5dd48df5129b4319df43aa45" srcmd5="efbe5f0a5dd48df5129b4319df43aa45" baserev="efbe5f0a5dd48df5129b4319df43aa45" xsrcmd5="d83b1df8a7dcda9ddd21113b898a835f" lsrcmd5="b40e9cce84f2c67bd45ff4667726a62f" />
-          <entry name="_link" md5="7190e2d17317df95c397ad7f48dac06a" size="155" mtime="1522153907" />
-          <entry name="somefile.txt" md5="c4ca4238a0b923820dcc509a6f75849b" size="1" mtime="1522153904" />
+          <entry name="_link" md5="7190e2d17317df95c397ad7f48dac06a" size="155" mtime="1536742992" />
+          <entry name="somefile.txt" md5="c4ca4238a0b923820dcc509a6f75849b" size="1" mtime="1536742992" />
         </directory>
     http_version: 
-  recorded_at: Wed, 28 Mar 2018 07:08:07 GMT
+  recorded_at: Thu, 13 Sep 2018 08:17:35 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:tom:branches:home:tom/package_with_revisions?view=info
@@ -527,12 +569,12 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <sourceinfo package="package_with_revisions" rev="12" vrev="12" srcmd5="d83b1df8a7dcda9ddd21113b898a835f" lsrcmd5="b40e9cce84f2c67bd45ff4667726a62f" verifymd5="efbe5f0a5dd48df5129b4319df43aa45">
+        <sourceinfo package="package_with_revisions" rev="47" vrev="47" srcmd5="d83b1df8a7dcda9ddd21113b898a835f" lsrcmd5="b40e9cce84f2c67bd45ff4667726a62f" verifymd5="efbe5f0a5dd48df5129b4319df43aa45">
           <error>bad build configuration, no build type defined or detected</error>
           <linked project="home:tom" package="package_with_revisions" />
         </sourceinfo>
     http_version: 
-  recorded_at: Wed, 28 Mar 2018 07:08:07 GMT
+  recorded_at: Thu, 13 Sep 2018 08:17:35 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:tom:branches:home:tom/package_with_revisions
@@ -562,13 +604,13 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="package_with_revisions" rev="12" vrev="12" srcmd5="b40e9cce84f2c67bd45ff4667726a62f">
+        <directory name="package_with_revisions" rev="47" vrev="47" srcmd5="b40e9cce84f2c67bd45ff4667726a62f">
           <linkinfo project="home:tom" package="package_with_revisions" rev="efbe5f0a5dd48df5129b4319df43aa45" srcmd5="efbe5f0a5dd48df5129b4319df43aa45" baserev="efbe5f0a5dd48df5129b4319df43aa45" xsrcmd5="d83b1df8a7dcda9ddd21113b898a835f" lsrcmd5="b40e9cce84f2c67bd45ff4667726a62f" />
-          <entry name="_link" md5="7190e2d17317df95c397ad7f48dac06a" size="155" mtime="1522153907" />
-          <entry name="somefile.txt" md5="c4ca4238a0b923820dcc509a6f75849b" size="1" mtime="1522153904" />
+          <entry name="_link" md5="7190e2d17317df95c397ad7f48dac06a" size="155" mtime="1536742992" />
+          <entry name="somefile.txt" md5="c4ca4238a0b923820dcc509a6f75849b" size="1" mtime="1536742992" />
         </directory>
     http_version: 
-  recorded_at: Wed, 28 Mar 2018 07:08:07 GMT
+  recorded_at: Thu, 13 Sep 2018 08:17:35 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:tom:branches:home:tom/package_with_revisions?cmd=diff&linkrev=base&onlyissues=1&orev=0&view=xml
@@ -600,7 +642,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="9ee74e03fc6370e9eb594c20fdb6e3b4">
+        <sourcediff key="1211f84025ee1e56871023e42d0c4d59">
           <old project="home:tom:branches:home:tom" package="package_with_revisions" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e" />
           <new project="home:tom:branches:home:tom" package="package_with_revisions" rev="1" srcmd5="b40e9cce84f2c67bd45ff4667726a62f" />
           <files />
@@ -608,7 +650,7 @@ http_interactions:
           </issues>
         </sourcediff>
     http_version: 
-  recorded_at: Wed, 28 Mar 2018 07:08:07 GMT
+  recorded_at: Thu, 13 Sep 2018 08:17:36 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:tom:branches:home:tom/package_with_revisions?cmd=linkdiff&linkrev=base&onlyissues=1&view=xml
@@ -640,13 +682,13 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="0d0b88fffab999583b488ddd4b8c7566">
+        <sourcediff key="7b0adc67d5eb7f301e42fe3b27249d86">
           <old project="home:tom" package="package_with_revisions" rev="efbe5f0a5dd48df5129b4319df43aa45" srcmd5="efbe5f0a5dd48df5129b4319df43aa45" />
           <new project="home:tom:branches:home:tom" package="package_with_revisions" rev="d83b1df8a7dcda9ddd21113b898a835f" srcmd5="d83b1df8a7dcda9ddd21113b898a835f" />
           <files />
         </sourcediff>
     http_version: 
-  recorded_at: Wed, 28 Mar 2018 07:08:07 GMT
+  recorded_at: Thu, 13 Sep 2018 08:17:36 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom:branches:home:tom/_meta?user=tom
@@ -693,5 +735,5 @@ http_interactions:
           </publish>
         </project>
     http_version: 
-  recorded_at: Wed, 28 Mar 2018 07:08:07 GMT
+  recorded_at: Thu, 13 Sep 2018 08:17:36 GMT
 recorded_with: VCR 4.0.0

--- a/src/api/spec/cassettes/Webui_PackageController/POST_branch/with_currrent_revision_parameter/1_4_8_3.yml
+++ b/src/api/spec/cassettes/Webui_PackageController/POST_branch/with_currrent_revision_parameter/1_4_8_3.yml
@@ -40,7 +40,7 @@ http_interactions:
           <person userid="tom" role="maintainer" />
         </project>
     http_version: 
-  recorded_at: Thu, 13 Sep 2018 08:17:33 GMT
+  recorded_at: Thu, 13 Sep 2018 08:17:34 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom/package_with_revisions/_meta?user=tom
@@ -48,8 +48,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="package_with_revisions" project="home:tom">
-          <title>Many Waters</title>
-          <description>Magni vel vitae delectus.</description>
+          <title>Nectar in a Sieve</title>
+          <description>Nesciunt et ipsam in.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -70,16 +70,16 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '154'
+      - '156'
     body:
       encoding: UTF-8
       string: |
         <package name="package_with_revisions" project="home:tom">
-          <title>Many Waters</title>
-          <description>Magni vel vitae delectus.</description>
+          <title>Nectar in a Sieve</title>
+          <description>Nesciunt et ipsam in.</description>
         </package>
     http_version: 
-  recorded_at: Thu, 13 Sep 2018 08:17:33 GMT
+  recorded_at: Thu, 13 Sep 2018 08:17:34 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom/package_with_revisions/_meta?user=tom
@@ -87,8 +87,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="package_with_revisions" project="home:tom">
-          <title>Many Waters</title>
-          <description>Magni vel vitae delectus.</description>
+          <title>Nectar in a Sieve</title>
+          <description>Nesciunt et ipsam in.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -109,16 +109,16 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '154'
+      - '156'
     body:
       encoding: UTF-8
       string: |
         <package name="package_with_revisions" project="home:tom">
-          <title>Many Waters</title>
-          <description>Magni vel vitae delectus.</description>
+          <title>Nectar in a Sieve</title>
+          <description>Nesciunt et ipsam in.</description>
         </package>
     http_version: 
-  recorded_at: Thu, 13 Sep 2018 08:17:33 GMT
+  recorded_at: Thu, 13 Sep 2018 08:17:34 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom/package_with_revisions/somefile.txt
@@ -148,16 +148,16 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <revision rev="69" vrev="69">
+        <revision rev="73" vrev="73">
           <srcmd5>cabf9a1f9a0b7c19d4f7ff46166f4ee0</srcmd5>
           <version>unknown</version>
-          <time>1536826653</time>
+          <time>1536826654</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
     http_version: 
-  recorded_at: Thu, 13 Sep 2018 08:17:33 GMT
+  recorded_at: Thu, 13 Sep 2018 08:17:34 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom/package_with_revisions/somefile.txt
@@ -187,16 +187,16 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <revision rev="70" vrev="70">
+        <revision rev="74" vrev="74">
           <srcmd5>efbe5f0a5dd48df5129b4319df43aa45</srcmd5>
           <version>unknown</version>
-          <time>1536826653</time>
+          <time>1536826654</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
     http_version: 
-  recorded_at: Thu, 13 Sep 2018 08:17:33 GMT
+  recorded_at: Thu, 13 Sep 2018 08:17:34 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom/package_with_revisions/somefile.txt
@@ -226,16 +226,16 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <revision rev="71" vrev="71">
+        <revision rev="75" vrev="75">
           <srcmd5>6ba292a7c75f8b46e4d39ac7cb20ebcd</srcmd5>
           <version>unknown</version>
-          <time>1536826653</time>
+          <time>1536826654</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
     http_version: 
-  recorded_at: Thu, 13 Sep 2018 08:17:33 GMT
+  recorded_at: Thu, 13 Sep 2018 08:17:34 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom/package_with_revisions/somefile.txt
@@ -265,16 +265,16 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <revision rev="72" vrev="72">
+        <revision rev="76" vrev="76">
           <srcmd5>60d83e04e1adc0a7e399a5b10312faf1</srcmd5>
           <version>unknown</version>
-          <time>1536826653</time>
+          <time>1536826654</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
     http_version: 
-  recorded_at: Thu, 13 Sep 2018 08:17:33 GMT
+  recorded_at: Thu, 13 Sep 2018 08:17:34 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:tom/package_with_revisions?rev=2
@@ -308,7 +308,7 @@ http_interactions:
           <entry name="somefile.txt" md5="c4ca4238a0b923820dcc509a6f75849b" size="1" mtime="1536742992" />
         </directory>
     http_version: 
-  recorded_at: Thu, 13 Sep 2018 08:17:33 GMT
+  recorded_at: Thu, 13 Sep 2018 08:17:34 GMT
 - request:
     method: post
     uri: http://backend:5352/search/package/id?match=(linkinfo/@package=%22package_with_revisions%22%20and%20linkinfo/@project=%22home:tom%22%20and%20@project=%22home:tom%22)
@@ -343,7 +343,7 @@ http_interactions:
         <collection>
         </collection>
     http_version: 
-  recorded_at: Thu, 13 Sep 2018 08:17:33 GMT
+  recorded_at: Thu, 13 Sep 2018 08:17:34 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom:branches:home:tom/_meta?user=tom
@@ -384,7 +384,7 @@ http_interactions:
           <person userid="tom" role="maintainer" />
         </project>
     http_version: 
-  recorded_at: Thu, 13 Sep 2018 08:17:33 GMT
+  recorded_at: Thu, 13 Sep 2018 08:17:34 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom:branches:home:tom/package_with_revisions/_meta?user=tom
@@ -392,8 +392,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="package_with_revisions" project="home:tom:branches:home:tom">
-          <title>Many Waters</title>
-          <description>Magni vel vitae delectus.</description>
+          <title>Nectar in a Sieve</title>
+          <description>Nesciunt et ipsam in.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -414,16 +414,16 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '172'
+      - '174'
     body:
       encoding: UTF-8
       string: |
         <package name="package_with_revisions" project="home:tom:branches:home:tom">
-          <title>Many Waters</title>
-          <description>Magni vel vitae delectus.</description>
+          <title>Nectar in a Sieve</title>
+          <description>Nesciunt et ipsam in.</description>
         </package>
     http_version: 
-  recorded_at: Thu, 13 Sep 2018 08:17:33 GMT
+  recorded_at: Thu, 13 Sep 2018 08:17:34 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:tom:branches:home:tom/package_with_revisions?cmd=branch&noservice=1&opackage=package_with_revisions&oproject=home:tom&orev=efbe5f0a5dd48df5129b4319df43aa45&user=tom
@@ -455,16 +455,16 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <revision rev="45" vrev="45">
+        <revision rev="46" vrev="46">
           <srcmd5>b40e9cce84f2c67bd45ff4667726a62f</srcmd5>
           <version>unknown</version>
-          <time>1536826653</time>
+          <time>1536826654</time>
           <user>tom</user>
           <comment></comment>
           <requestid/>
         </revision>
     http_version: 
-  recorded_at: Thu, 13 Sep 2018 08:17:33 GMT
+  recorded_at: Thu, 13 Sep 2018 08:17:34 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom:branches:home:tom/package_with_revisions/_meta?user=tom
@@ -472,8 +472,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="package_with_revisions" project="home:tom:branches:home:tom">
-          <title>Many Waters</title>
-          <description>Magni vel vitae delectus.</description>
+          <title>Nectar in a Sieve</title>
+          <description>Nesciunt et ipsam in.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -494,16 +494,16 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '172'
+      - '174'
     body:
       encoding: UTF-8
       string: |
         <package name="package_with_revisions" project="home:tom:branches:home:tom">
-          <title>Many Waters</title>
-          <description>Magni vel vitae delectus.</description>
+          <title>Nectar in a Sieve</title>
+          <description>Nesciunt et ipsam in.</description>
         </package>
     http_version: 
-  recorded_at: Thu, 13 Sep 2018 08:17:33 GMT
+  recorded_at: Thu, 13 Sep 2018 08:17:34 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:tom:branches:home:tom/package_with_revisions
@@ -533,13 +533,13 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="package_with_revisions" rev="45" vrev="45" srcmd5="b40e9cce84f2c67bd45ff4667726a62f">
+        <directory name="package_with_revisions" rev="46" vrev="46" srcmd5="b40e9cce84f2c67bd45ff4667726a62f">
           <linkinfo project="home:tom" package="package_with_revisions" rev="efbe5f0a5dd48df5129b4319df43aa45" srcmd5="efbe5f0a5dd48df5129b4319df43aa45" baserev="efbe5f0a5dd48df5129b4319df43aa45" xsrcmd5="d83b1df8a7dcda9ddd21113b898a835f" lsrcmd5="b40e9cce84f2c67bd45ff4667726a62f" />
           <entry name="_link" md5="7190e2d17317df95c397ad7f48dac06a" size="155" mtime="1536742992" />
           <entry name="somefile.txt" md5="c4ca4238a0b923820dcc509a6f75849b" size="1" mtime="1536742992" />
         </directory>
     http_version: 
-  recorded_at: Thu, 13 Sep 2018 08:17:33 GMT
+  recorded_at: Thu, 13 Sep 2018 08:17:34 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:tom:branches:home:tom/package_with_revisions?view=info
@@ -569,12 +569,12 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <sourceinfo package="package_with_revisions" rev="45" vrev="45" srcmd5="d83b1df8a7dcda9ddd21113b898a835f" lsrcmd5="b40e9cce84f2c67bd45ff4667726a62f" verifymd5="efbe5f0a5dd48df5129b4319df43aa45">
+        <sourceinfo package="package_with_revisions" rev="46" vrev="46" srcmd5="d83b1df8a7dcda9ddd21113b898a835f" lsrcmd5="b40e9cce84f2c67bd45ff4667726a62f" verifymd5="efbe5f0a5dd48df5129b4319df43aa45">
           <error>bad build configuration, no build type defined or detected</error>
           <linked project="home:tom" package="package_with_revisions" />
         </sourceinfo>
     http_version: 
-  recorded_at: Thu, 13 Sep 2018 08:17:33 GMT
+  recorded_at: Thu, 13 Sep 2018 08:17:34 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:tom:branches:home:tom/package_with_revisions
@@ -604,7 +604,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="package_with_revisions" rev="45" vrev="45" srcmd5="b40e9cce84f2c67bd45ff4667726a62f">
+        <directory name="package_with_revisions" rev="46" vrev="46" srcmd5="b40e9cce84f2c67bd45ff4667726a62f">
           <linkinfo project="home:tom" package="package_with_revisions" rev="efbe5f0a5dd48df5129b4319df43aa45" srcmd5="efbe5f0a5dd48df5129b4319df43aa45" baserev="efbe5f0a5dd48df5129b4319df43aa45" xsrcmd5="d83b1df8a7dcda9ddd21113b898a835f" lsrcmd5="b40e9cce84f2c67bd45ff4667726a62f" />
           <entry name="_link" md5="7190e2d17317df95c397ad7f48dac06a" size="155" mtime="1536742992" />
           <entry name="somefile.txt" md5="c4ca4238a0b923820dcc509a6f75849b" size="1" mtime="1536742992" />
@@ -650,7 +650,7 @@ http_interactions:
           </issues>
         </sourcediff>
     http_version: 
-  recorded_at: Thu, 13 Sep 2018 08:17:34 GMT
+  recorded_at: Thu, 13 Sep 2018 08:17:35 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:tom:branches:home:tom/package_with_revisions?cmd=linkdiff&linkrev=base&onlyissues=1&view=xml
@@ -688,7 +688,7 @@ http_interactions:
           <files />
         </sourcediff>
     http_version: 
-  recorded_at: Thu, 13 Sep 2018 08:17:34 GMT
+  recorded_at: Thu, 13 Sep 2018 08:17:35 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom:branches:home:tom/_meta?user=tom
@@ -735,5 +735,41 @@ http_interactions:
           </publish>
         </project>
     http_version: 
-  recorded_at: Thu, 13 Sep 2018 08:17:34 GMT
+  recorded_at: Thu, 13 Sep 2018 08:17:35 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:tom:branches:home:tom/package_with_revisions
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '586'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="package_with_revisions" rev="46" vrev="46" srcmd5="b40e9cce84f2c67bd45ff4667726a62f">
+          <linkinfo project="home:tom" package="package_with_revisions" rev="efbe5f0a5dd48df5129b4319df43aa45" srcmd5="efbe5f0a5dd48df5129b4319df43aa45" baserev="efbe5f0a5dd48df5129b4319df43aa45" xsrcmd5="d83b1df8a7dcda9ddd21113b898a835f" lsrcmd5="b40e9cce84f2c67bd45ff4667726a62f" />
+          <entry name="_link" md5="7190e2d17317df95c397ad7f48dac06a" size="155" mtime="1536742992" />
+          <entry name="somefile.txt" md5="c4ca4238a0b923820dcc509a6f75849b" size="1" mtime="1536742992" />
+        </directory>
+    http_version: 
+  recorded_at: Thu, 13 Sep 2018 08:17:35 GMT
 recorded_with: VCR 4.0.0

--- a/src/api/spec/cassettes/Webui_PackageController/POST_branch/with_target_package_name/1_4_7_1.yml
+++ b/src/api/spec/cassettes/Webui_PackageController/POST_branch/with_target_package_name/1_4_7_1.yml
@@ -40,7 +40,7 @@ http_interactions:
           <person userid="tom" role="maintainer" />
         </project>
     http_version: 
-  recorded_at: Wed, 28 Mar 2018 07:07:41 GMT
+  recorded_at: Thu, 13 Sep 2018 08:17:31 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom/my_package/_meta?user=tom
@@ -48,8 +48,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="my_package" project="home:tom">
-          <title>The House of Mirth</title>
-          <description>Officiis odit aut voluptatum vel est reiciendis.</description>
+          <title>The Monkey's Raincoat</title>
+          <description>Dolores quasi et fugiat.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -70,25 +70,25 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '172'
+      - '151'
     body:
       encoding: UTF-8
       string: |
         <package name="my_package" project="home:tom">
-          <title>The House of Mirth</title>
-          <description>Officiis odit aut voluptatum vel est reiciendis.</description>
+          <title>The Monkey's Raincoat</title>
+          <description>Dolores quasi et fugiat.</description>
         </package>
     http_version: 
-  recorded_at: Wed, 28 Mar 2018 07:07:41 GMT
+  recorded_at: Thu, 13 Sep 2018 08:17:31 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom/my_package/_meta
+    uri: http://backend:5352/source/home:tom/my_package/_meta?user=tom
     body:
       encoding: UTF-8
       string: |
         <package name="my_package" project="home:tom">
-          <title>The House of Mirth</title>
-          <description>Officiis odit aut voluptatum vel est reiciendis.</description>
+          <title>The Monkey's Raincoat</title>
+          <description>Dolores quasi et fugiat.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -109,16 +109,16 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '172'
+      - '151'
     body:
       encoding: UTF-8
       string: |
         <package name="my_package" project="home:tom">
-          <title>The House of Mirth</title>
-          <description>Officiis odit aut voluptatum vel est reiciendis.</description>
+          <title>The Monkey's Raincoat</title>
+          <description>Dolores quasi et fugiat.</description>
         </package>
     http_version: 
-  recorded_at: Wed, 28 Mar 2018 07:07:41 GMT
+  recorded_at: Thu, 13 Sep 2018 08:17:31 GMT
 - request:
     method: post
     uri: http://backend:5352/search/package/id?match=(linkinfo/@package=%22my_package%22%20and%20linkinfo/@project=%22home:tom%22%20and%20@project=%22home:tom%22)
@@ -153,7 +153,7 @@ http_interactions:
         <collection>
         </collection>
     http_version: 
-  recorded_at: Wed, 28 Mar 2018 07:07:41 GMT
+  recorded_at: Thu, 13 Sep 2018 08:17:31 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom:branches:home:tom/_meta?user=tom
@@ -194,7 +194,7 @@ http_interactions:
           <person userid="tom" role="maintainer" />
         </project>
     http_version: 
-  recorded_at: Wed, 28 Mar 2018 07:07:41 GMT
+  recorded_at: Thu, 13 Sep 2018 08:17:31 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom:branches:home:tom/new_package_name/_meta?user=tom
@@ -202,8 +202,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="new_package_name" project="home:tom:branches:home:tom">
-          <title>The House of Mirth</title>
-          <description>Officiis odit aut voluptatum vel est reiciendis.</description>
+          <title>The Monkey's Raincoat</title>
+          <description>Dolores quasi et fugiat.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -224,16 +224,16 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '196'
+      - '175'
     body:
       encoding: UTF-8
       string: |
         <package name="new_package_name" project="home:tom:branches:home:tom">
-          <title>The House of Mirth</title>
-          <description>Officiis odit aut voluptatum vel est reiciendis.</description>
+          <title>The Monkey's Raincoat</title>
+          <description>Dolores quasi et fugiat.</description>
         </package>
     http_version: 
-  recorded_at: Wed, 28 Mar 2018 07:07:41 GMT
+  recorded_at: Thu, 13 Sep 2018 08:17:31 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:tom:branches:home:tom/new_package_name?cmd=branch&noservice=1&opackage=my_package&oproject=home:tom&user=tom
@@ -265,16 +265,16 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <revision rev="20" vrev="20">
+        <revision rev="33" vrev="33">
           <srcmd5>49bd231e56677e1dfd80e906f4f5dbe4</srcmd5>
           <version>unknown</version>
-          <time>1522220861</time>
+          <time>1536826651</time>
           <user>tom</user>
           <comment></comment>
           <requestid/>
         </revision>
     http_version: 
-  recorded_at: Wed, 28 Mar 2018 07:07:41 GMT
+  recorded_at: Thu, 13 Sep 2018 08:17:32 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom:branches:home:tom/new_package_name/_meta?user=tom
@@ -282,8 +282,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="new_package_name" project="home:tom:branches:home:tom">
-          <title>The House of Mirth</title>
-          <description>Officiis odit aut voluptatum vel est reiciendis.</description>
+          <title>The Monkey's Raincoat</title>
+          <description>Dolores quasi et fugiat.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -304,16 +304,16 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '196'
+      - '175'
     body:
       encoding: UTF-8
       string: |
         <package name="new_package_name" project="home:tom:branches:home:tom">
-          <title>The House of Mirth</title>
-          <description>Officiis odit aut voluptatum vel est reiciendis.</description>
+          <title>The Monkey's Raincoat</title>
+          <description>Dolores quasi et fugiat.</description>
         </package>
     http_version: 
-  recorded_at: Wed, 28 Mar 2018 07:07:41 GMT
+  recorded_at: Thu, 13 Sep 2018 08:17:32 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:tom:branches:home:tom/new_package_name
@@ -343,12 +343,12 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="new_package_name" rev="20" vrev="20" srcmd5="49bd231e56677e1dfd80e906f4f5dbe4">
+        <directory name="new_package_name" rev="33" vrev="33" srcmd5="49bd231e56677e1dfd80e906f4f5dbe4">
           <linkinfo project="home:tom" package="my_package" srcmd5="d41d8cd98f00b204e9800998ecf8427e" baserev="d41d8cd98f00b204e9800998ecf8427e" xsrcmd5="0a2e3813e4d7ad4b6b72066efa8587cc" lsrcmd5="49bd231e56677e1dfd80e906f4f5dbe4" />
-          <entry name="_link" md5="324a67e2c9fe0d6cdc38c625b1c416f5" size="137" mtime="1522151960" />
+          <entry name="_link" md5="324a67e2c9fe0d6cdc38c625b1c416f5" size="137" mtime="1536742996" />
         </directory>
     http_version: 
-  recorded_at: Wed, 28 Mar 2018 07:07:41 GMT
+  recorded_at: Thu, 13 Sep 2018 08:17:32 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:tom:branches:home:tom/new_package_name?view=info
@@ -378,12 +378,12 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <sourceinfo package="new_package_name" rev="20" vrev="20" srcmd5="0a2e3813e4d7ad4b6b72066efa8587cc" lsrcmd5="49bd231e56677e1dfd80e906f4f5dbe4" verifymd5="d41d8cd98f00b204e9800998ecf8427e">
+        <sourceinfo package="new_package_name" rev="33" vrev="33" srcmd5="0a2e3813e4d7ad4b6b72066efa8587cc" lsrcmd5="49bd231e56677e1dfd80e906f4f5dbe4" verifymd5="d41d8cd98f00b204e9800998ecf8427e">
           <error>bad build configuration, no build type defined or detected</error>
           <linked project="home:tom" package="my_package" />
         </sourceinfo>
     http_version: 
-  recorded_at: Wed, 28 Mar 2018 07:07:41 GMT
+  recorded_at: Thu, 13 Sep 2018 08:17:32 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:tom:branches:home:tom/new_package_name
@@ -413,12 +413,12 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="new_package_name" rev="20" vrev="20" srcmd5="49bd231e56677e1dfd80e906f4f5dbe4">
+        <directory name="new_package_name" rev="33" vrev="33" srcmd5="49bd231e56677e1dfd80e906f4f5dbe4">
           <linkinfo project="home:tom" package="my_package" srcmd5="d41d8cd98f00b204e9800998ecf8427e" baserev="d41d8cd98f00b204e9800998ecf8427e" xsrcmd5="0a2e3813e4d7ad4b6b72066efa8587cc" lsrcmd5="49bd231e56677e1dfd80e906f4f5dbe4" />
-          <entry name="_link" md5="324a67e2c9fe0d6cdc38c625b1c416f5" size="137" mtime="1522151960" />
+          <entry name="_link" md5="324a67e2c9fe0d6cdc38c625b1c416f5" size="137" mtime="1536742996" />
         </directory>
     http_version: 
-  recorded_at: Wed, 28 Mar 2018 07:07:41 GMT
+  recorded_at: Thu, 13 Sep 2018 08:17:32 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:tom:branches:home:tom/new_package_name?cmd=diff&linkrev=base&onlyissues=1&orev=0&view=xml
@@ -450,7 +450,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="d12586925d02b3c1e65fb60b76b2b943">
+        <sourcediff key="802ba34ce76282d979994fd92526d4d7">
           <old project="home:tom:branches:home:tom" package="new_package_name" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e" />
           <new project="home:tom:branches:home:tom" package="new_package_name" rev="1" srcmd5="49bd231e56677e1dfd80e906f4f5dbe4" />
           <files />
@@ -458,7 +458,7 @@ http_interactions:
           </issues>
         </sourcediff>
     http_version: 
-  recorded_at: Wed, 28 Mar 2018 07:07:41 GMT
+  recorded_at: Thu, 13 Sep 2018 08:17:32 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:tom:branches:home:tom/new_package_name?cmd=linkdiff&linkrev=base&onlyissues=1&view=xml
@@ -490,13 +490,13 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="d0a679bbe9896b24825fb8cdab1894be">
+        <sourcediff key="1c1647a9e3cdf8bf1b4868a5cb4ea4fd">
           <old project="home:tom" package="my_package" rev="d41d8cd98f00b204e9800998ecf8427e" srcmd5="d41d8cd98f00b204e9800998ecf8427e" />
           <new project="home:tom:branches:home:tom" package="new_package_name" rev="0a2e3813e4d7ad4b6b72066efa8587cc" srcmd5="0a2e3813e4d7ad4b6b72066efa8587cc" />
           <files />
         </sourcediff>
     http_version: 
-  recorded_at: Wed, 28 Mar 2018 07:07:42 GMT
+  recorded_at: Thu, 13 Sep 2018 08:17:32 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom:branches:home:tom/_meta?user=tom
@@ -543,5 +543,5 @@ http_interactions:
           </publish>
         </project>
     http_version: 
-  recorded_at: Wed, 28 Mar 2018 07:07:42 GMT
+  recorded_at: Thu, 13 Sep 2018 08:17:32 GMT
 recorded_with: VCR 4.0.0

--- a/src/api/spec/cassettes/Webui_PackageController/POST_branch/with_target_package_name/redirects_to_the_branched_package.yml
+++ b/src/api/spec/cassettes/Webui_PackageController/POST_branch/with_target_package_name/redirects_to_the_branched_package.yml
@@ -40,7 +40,7 @@ http_interactions:
           <person userid="tom" role="maintainer" />
         </project>
     http_version: 
-  recorded_at: Wed, 28 Mar 2018 07:07:40 GMT
+  recorded_at: Thu, 13 Sep 2018 08:17:32 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom/my_package/_meta?user=tom
@@ -48,8 +48,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="my_package" project="home:tom">
-          <title>In a Dry Season</title>
-          <description>Ea mollitia sint accusantium sit at.</description>
+          <title>Edna O'Brien</title>
+          <description>Facere quia adipisci vel.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -70,25 +70,25 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '157'
+      - '143'
     body:
       encoding: UTF-8
       string: |
         <package name="my_package" project="home:tom">
-          <title>In a Dry Season</title>
-          <description>Ea mollitia sint accusantium sit at.</description>
+          <title>Edna O'Brien</title>
+          <description>Facere quia adipisci vel.</description>
         </package>
     http_version: 
-  recorded_at: Wed, 28 Mar 2018 07:07:40 GMT
+  recorded_at: Thu, 13 Sep 2018 08:17:32 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom/my_package/_meta
+    uri: http://backend:5352/source/home:tom/my_package/_meta?user=tom
     body:
       encoding: UTF-8
       string: |
         <package name="my_package" project="home:tom">
-          <title>In a Dry Season</title>
-          <description>Ea mollitia sint accusantium sit at.</description>
+          <title>Edna O'Brien</title>
+          <description>Facere quia adipisci vel.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -109,16 +109,16 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '157'
+      - '143'
     body:
       encoding: UTF-8
       string: |
         <package name="my_package" project="home:tom">
-          <title>In a Dry Season</title>
-          <description>Ea mollitia sint accusantium sit at.</description>
+          <title>Edna O'Brien</title>
+          <description>Facere quia adipisci vel.</description>
         </package>
     http_version: 
-  recorded_at: Wed, 28 Mar 2018 07:07:40 GMT
+  recorded_at: Thu, 13 Sep 2018 08:17:32 GMT
 - request:
     method: post
     uri: http://backend:5352/search/package/id?match=(linkinfo/@package=%22my_package%22%20and%20linkinfo/@project=%22home:tom%22%20and%20@project=%22home:tom%22)
@@ -153,7 +153,7 @@ http_interactions:
         <collection>
         </collection>
     http_version: 
-  recorded_at: Wed, 28 Mar 2018 07:07:40 GMT
+  recorded_at: Thu, 13 Sep 2018 08:17:32 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom:branches:home:tom/_meta?user=tom
@@ -194,7 +194,7 @@ http_interactions:
           <person userid="tom" role="maintainer" />
         </project>
     http_version: 
-  recorded_at: Wed, 28 Mar 2018 07:07:40 GMT
+  recorded_at: Thu, 13 Sep 2018 08:17:32 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom:branches:home:tom/new_package_name/_meta?user=tom
@@ -202,8 +202,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="new_package_name" project="home:tom:branches:home:tom">
-          <title>In a Dry Season</title>
-          <description>Ea mollitia sint accusantium sit at.</description>
+          <title>Edna O'Brien</title>
+          <description>Facere quia adipisci vel.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -224,16 +224,16 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '181'
+      - '167'
     body:
       encoding: UTF-8
       string: |
         <package name="new_package_name" project="home:tom:branches:home:tom">
-          <title>In a Dry Season</title>
-          <description>Ea mollitia sint accusantium sit at.</description>
+          <title>Edna O'Brien</title>
+          <description>Facere quia adipisci vel.</description>
         </package>
     http_version: 
-  recorded_at: Wed, 28 Mar 2018 07:07:40 GMT
+  recorded_at: Thu, 13 Sep 2018 08:17:32 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:tom:branches:home:tom/new_package_name?cmd=branch&noservice=1&opackage=my_package&oproject=home:tom&user=tom
@@ -265,16 +265,16 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <revision rev="19" vrev="19">
+        <revision rev="34" vrev="34">
           <srcmd5>49bd231e56677e1dfd80e906f4f5dbe4</srcmd5>
           <version>unknown</version>
-          <time>1522220860</time>
+          <time>1536826652</time>
           <user>tom</user>
           <comment></comment>
           <requestid/>
         </revision>
     http_version: 
-  recorded_at: Wed, 28 Mar 2018 07:07:40 GMT
+  recorded_at: Thu, 13 Sep 2018 08:17:32 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom:branches:home:tom/new_package_name/_meta?user=tom
@@ -282,8 +282,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="new_package_name" project="home:tom:branches:home:tom">
-          <title>In a Dry Season</title>
-          <description>Ea mollitia sint accusantium sit at.</description>
+          <title>Edna O'Brien</title>
+          <description>Facere quia adipisci vel.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -304,16 +304,16 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '181'
+      - '167'
     body:
       encoding: UTF-8
       string: |
         <package name="new_package_name" project="home:tom:branches:home:tom">
-          <title>In a Dry Season</title>
-          <description>Ea mollitia sint accusantium sit at.</description>
+          <title>Edna O'Brien</title>
+          <description>Facere quia adipisci vel.</description>
         </package>
     http_version: 
-  recorded_at: Wed, 28 Mar 2018 07:07:40 GMT
+  recorded_at: Thu, 13 Sep 2018 08:17:32 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:tom:branches:home:tom/new_package_name
@@ -343,12 +343,12 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="new_package_name" rev="19" vrev="19" srcmd5="49bd231e56677e1dfd80e906f4f5dbe4">
+        <directory name="new_package_name" rev="34" vrev="34" srcmd5="49bd231e56677e1dfd80e906f4f5dbe4">
           <linkinfo project="home:tom" package="my_package" srcmd5="d41d8cd98f00b204e9800998ecf8427e" baserev="d41d8cd98f00b204e9800998ecf8427e" xsrcmd5="0a2e3813e4d7ad4b6b72066efa8587cc" lsrcmd5="49bd231e56677e1dfd80e906f4f5dbe4" />
-          <entry name="_link" md5="324a67e2c9fe0d6cdc38c625b1c416f5" size="137" mtime="1522151960" />
+          <entry name="_link" md5="324a67e2c9fe0d6cdc38c625b1c416f5" size="137" mtime="1536742996" />
         </directory>
     http_version: 
-  recorded_at: Wed, 28 Mar 2018 07:07:40 GMT
+  recorded_at: Thu, 13 Sep 2018 08:17:32 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:tom:branches:home:tom/new_package_name?view=info
@@ -378,12 +378,12 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <sourceinfo package="new_package_name" rev="19" vrev="19" srcmd5="0a2e3813e4d7ad4b6b72066efa8587cc" lsrcmd5="49bd231e56677e1dfd80e906f4f5dbe4" verifymd5="d41d8cd98f00b204e9800998ecf8427e">
+        <sourceinfo package="new_package_name" rev="34" vrev="34" srcmd5="0a2e3813e4d7ad4b6b72066efa8587cc" lsrcmd5="49bd231e56677e1dfd80e906f4f5dbe4" verifymd5="d41d8cd98f00b204e9800998ecf8427e">
           <error>bad build configuration, no build type defined or detected</error>
           <linked project="home:tom" package="my_package" />
         </sourceinfo>
     http_version: 
-  recorded_at: Wed, 28 Mar 2018 07:07:40 GMT
+  recorded_at: Thu, 13 Sep 2018 08:17:32 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:tom:branches:home:tom/new_package_name
@@ -413,12 +413,12 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="new_package_name" rev="19" vrev="19" srcmd5="49bd231e56677e1dfd80e906f4f5dbe4">
+        <directory name="new_package_name" rev="34" vrev="34" srcmd5="49bd231e56677e1dfd80e906f4f5dbe4">
           <linkinfo project="home:tom" package="my_package" srcmd5="d41d8cd98f00b204e9800998ecf8427e" baserev="d41d8cd98f00b204e9800998ecf8427e" xsrcmd5="0a2e3813e4d7ad4b6b72066efa8587cc" lsrcmd5="49bd231e56677e1dfd80e906f4f5dbe4" />
-          <entry name="_link" md5="324a67e2c9fe0d6cdc38c625b1c416f5" size="137" mtime="1522151960" />
+          <entry name="_link" md5="324a67e2c9fe0d6cdc38c625b1c416f5" size="137" mtime="1536742996" />
         </directory>
     http_version: 
-  recorded_at: Wed, 28 Mar 2018 07:07:40 GMT
+  recorded_at: Thu, 13 Sep 2018 08:17:32 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:tom:branches:home:tom/new_package_name?cmd=diff&linkrev=base&onlyissues=1&orev=0&view=xml
@@ -450,7 +450,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="d12586925d02b3c1e65fb60b76b2b943">
+        <sourcediff key="802ba34ce76282d979994fd92526d4d7">
           <old project="home:tom:branches:home:tom" package="new_package_name" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e" />
           <new project="home:tom:branches:home:tom" package="new_package_name" rev="1" srcmd5="49bd231e56677e1dfd80e906f4f5dbe4" />
           <files />
@@ -458,7 +458,7 @@ http_interactions:
           </issues>
         </sourcediff>
     http_version: 
-  recorded_at: Wed, 28 Mar 2018 07:07:40 GMT
+  recorded_at: Thu, 13 Sep 2018 08:17:32 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:tom:branches:home:tom/new_package_name?cmd=linkdiff&linkrev=base&onlyissues=1&view=xml
@@ -490,13 +490,13 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="d0a679bbe9896b24825fb8cdab1894be">
+        <sourcediff key="1c1647a9e3cdf8bf1b4868a5cb4ea4fd">
           <old project="home:tom" package="my_package" rev="d41d8cd98f00b204e9800998ecf8427e" srcmd5="d41d8cd98f00b204e9800998ecf8427e" />
           <new project="home:tom:branches:home:tom" package="new_package_name" rev="0a2e3813e4d7ad4b6b72066efa8587cc" srcmd5="0a2e3813e4d7ad4b6b72066efa8587cc" />
           <files />
         </sourcediff>
     http_version: 
-  recorded_at: Wed, 28 Mar 2018 07:07:40 GMT
+  recorded_at: Thu, 13 Sep 2018 08:17:33 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom:branches:home:tom/_meta?user=tom
@@ -543,5 +543,5 @@ http_interactions:
           </publish>
         </project>
     http_version: 
-  recorded_at: Wed, 28 Mar 2018 07:07:40 GMT
+  recorded_at: Thu, 13 Sep 2018 08:17:33 GMT
 recorded_with: VCR 4.0.0


### PR DESCRIPTION
When we branch a package with a specific revision, it was always
branching the last revision. Now it's having into account the revision shown in the Package#show page.

Fixes #5365 