### PR TITLE
Bootstrap: modal dialogs instead of confirm boxes to be consistent

### DIFF
--- a/src/api/app/assets/stylesheets/webui2/modals.scss
+++ b/src/api/app/assets/stylesheets/webui2/modals.scss
@@ -1,0 +1,3 @@
+.modal h5 {
+    color: initial;
+}

--- a/src/api/app/assets/stylesheets/webui2/webui2.css.scss
+++ b/src/api/app/assets/stylesheets/webui2/webui2.css.scss
@@ -31,3 +31,4 @@
 @import 'build-results';
 @import 'autocomplete';
 @import 'package-attributes';
+@import 'modals';

--- a/src/api/app/controllers/webui2/comments_controller.rb
+++ b/src/api/app/controllers/webui2/comments_controller.rb
@@ -14,7 +14,7 @@ module Webui2::CommentsController
         flash.now[:error] = "Failed to create comment: #{comment.errors.full_messages.to_sentence}."
         status = :unprocessable_entity
       end
-      format.js { render 'webui2/webui/comment/create_or_destroy', status: status }
+      format.js { render 'webui2/webui/comment/create', status: status }
     end
   end
 
@@ -32,7 +32,7 @@ module Webui2::CommentsController
         flash.now[:error] = "Failed to delete comment: #{comment.errors.full_messages.to_sentence}."
         status = :unprocessable_entity
       end
-      format.js { render 'webui2/webui/comment/create_or_destroy', status: status }
+      format.js { render 'webui2/webui/comment/destroy', status: status }
     end
   end
 end

--- a/src/api/app/views/webui2/webui/attribute/_delete_dialog.html.haml
+++ b/src/api/app/views/webui2/webui/attribute/_delete_dialog.html.haml
@@ -1,0 +1,13 @@
+.modal.fade{ id: "delete-attribute-modal-#{attribute.id}", tabindex: -1, role: 'dialog', aria: { labelledby: 'delete-modal-label', hidden: true } }
+  .modal-dialog.modal-dialog-centered{ role: 'document' }
+    .modal-content
+      .modal-header
+        %h5.modal-title
+          Delete attribute?
+      .modal-body
+        %p Please confirm deletion of attribute #{attribute.fullname}
+        = form_tag(attrib_path(attribute), method: :delete) do
+          .modal-footer
+            %button.btn.btn-sm.btn-outline-secondary.px-4{ data: { dismiss: 'modal' } }
+              Cancel
+            = submit_tag('Delete', class: 'btn btn-sm btn-danger px-4')

--- a/src/api/app/views/webui2/webui/attribute/index.html.haml
+++ b/src/api/app/views/webui2/webui/attribute/index.html.haml
@@ -32,9 +32,8 @@
                     - if attribute.values_editable?
                       = link_to(edit_attribs_path(project: @project.name, package: @package, attribute: attribute.fullname), title: 'Edit values') do
                         %i.fas.fa-edit.text-info
-                    = link_to(attrib_path(attribute),
-                              data: { confirm: "Delete attribute '#{attribute.fullname}'?" },
-                              method: :delete,
+                    = render(partial: 'delete_dialog', locals: { attribute: attribute })
+                    = link_to('#', data: { toggle: 'modal', target: "#delete-attribute-modal-#{attribute.id}" },
                               title: 'Delete attribute') do
                       %i.fas.fa-times-circle.text-danger
     - else

--- a/src/api/app/views/webui2/webui/comment/_delete_dialog.html.haml
+++ b/src/api/app/views/webui2/webui/comment/_delete_dialog.html.haml
@@ -1,0 +1,15 @@
+.modal.fade{ id: "delete-comment-modal-#{comment.id}", tabindex: -1, role: 'dialog',
+             aria: { labelledby: 'delete-comment-modal-label', hidden: true } }
+  .modal-dialog.modal-dialog-centered{ role: 'document' }
+    .modal-content
+      .modal-header
+        %h5.modal-title
+          Delete comment?
+      .modal-body
+        %p Please confirm deletion of comment
+
+        = form_tag(comment_path(comment), method: :delete, remote: true) do
+          .modal-footer
+            %button.btn.btn-sm.btn-outline-secondary.px-4{ data: { dismiss: 'modal' } }
+              Cancel
+            = submit_tag('Delete', class: 'btn btn-sm btn-danger px-4')

--- a/src/api/app/views/webui2/webui/comment/_links.html.haml
+++ b/src/api/app/views/webui2/webui/comment/_links.html.haml
@@ -5,5 +5,7 @@
         Reply
   - if policy(comment).destroy?
     %li.list-inline-item
-      = link_to('Delete', comment, method: :delete, id: "delete_link_id_#{comment.id}", class: 'delete_link btn btn-sm btn-outline-danger',
-        remote: true, 'data-confirm': 'Do you really want delete this comment?')
+      = render(partial: 'webui/comment/delete_dialog', locals: { comment: comment })
+      = link_to('#', data: { toggle: 'modal', target: "#delete-comment-modal-#{comment.id}" },
+                class: 'delete_link btn btn-sm btn-outline-danger', title: 'Delete comment') do
+        Delete

--- a/src/api/app/views/webui2/webui/comment/create.js.haml
+++ b/src/api/app/views/webui2/webui/comment/create.js.haml
@@ -2,4 +2,3 @@
   $('#flash').html("#{escape_javascript(render(layout: false, partial: 'layouts/webui2/flash', object: flash))}");
   $('#comments').html("#{escape_javascript(render(partial: 'webui2/webui/comment/show', locals: { commentable: @commentable }))}");
   reloadCommentBindings();
-

--- a/src/api/app/views/webui2/webui/comment/destroy.js.haml
+++ b/src/api/app/views/webui2/webui/comment/destroy.js.haml
@@ -1,0 +1,8 @@
+:plain
+  $('#flash').html("#{escape_javascript(render(layout: false, partial: 'layouts/webui2/flash', object: flash))}");
+  $('#delete-comment-modal-#{params[:id]}').modal('toggle');
+  $('#delete-comment-modal-#{params[:id]}').on('hidden.bs.modal', function (e) {
+    $('#comments').html("#{escape_javascript(render(partial: 'webui2/webui/comment/show', locals: { commentable: @commentable }))}");
+    reloadCommentBindings();
+  })
+

--- a/src/api/app/views/webui2/webui/main/_add_status_message_modal.html.haml
+++ b/src/api/app/views/webui2/webui/main/_add_status_message_modal.html.haml
@@ -1,5 +1,5 @@
 .modal#status-message-modal{ role: 'dialog', tabindex: '-1' }
-  .modal-dialog{ role: 'document' }
+  .modal-dialog.modal-dialog-centered{ role: 'document' }
     .modal-content
       .modal-header
         %h5.modal-title Add Status Message

--- a/src/api/app/views/webui2/webui/package/_branch_dialog.html.haml
+++ b/src/api/app/views/webui2/webui/package/_branch_dialog.html.haml
@@ -1,5 +1,5 @@
 .modal.fade#branch-modal{ tabindex: -1, role: 'dialog', aria: { labelledby: 'branch-modal-label', hidden: true } }
-  .modal-dialog{ role: 'document' }
+  .modal-dialog.modal-dialog-centered{ role: 'document' }
     .modal-content
       .modal-header
         %h5.modal-title#branch-modal-label Branch Confirmation

--- a/src/api/app/views/webui2/webui/package/_delete_dialog.html.haml
+++ b/src/api/app/views/webui2/webui/package/_delete_dialog.html.haml
@@ -1,5 +1,5 @@
 .modal.fade#delete-modal{ tabindex: -1, role: 'dialog', aria: { labelledby: 'delete-modal-label', hidden: true } }
-  .modal-dialog{ role: 'document' }
+  .modal-dialog.modal-dialog-centered{ role: 'document' }
     .modal-content
       .modal-header
         %h5.modal-title#delete-modal-label Do you really want to delete this package?
@@ -24,4 +24,6 @@
               = label_tag(:force, 'Delete anyway?', class: 'form-check-label')
 
           .modal-footer
-            = render partial: 'webui2/shared/dialog_action_buttons'
+            %button.btn.btn-sm.btn-outline-secondary.px-4{ data: { dismiss: 'modal' } }
+              Cancel
+            = submit_tag('Delete', class: 'btn btn-sm btn-danger px-4')

--- a/src/api/app/views/webui2/webui/package/_delete_file_dialog.html.haml
+++ b/src/api/app/views/webui2/webui/package/_delete_file_dialog.html.haml
@@ -1,0 +1,13 @@
+.modal.fade{ id: "delete-file-modal-#{file_id}", tabindex: -1, role: 'dialog', aria: { labelledby: 'delete-modal-label', hidden: true } }
+  .modal-dialog.modal-dialog-centered{ role: 'document' }
+    .modal-content
+      .modal-header
+        %h5.modal-title
+          Delete file?
+      .modal-body
+        %p Please confirm deletion of file '#{filename}'
+        = form_tag({ action: :remove_file, project: project, package: package, filename: filename }, method: :post) do
+          .modal-footer
+            %button.btn.btn-sm.btn-outline-secondary.px-4{ data: { dismiss: 'modal' } }
+              Cancel
+            = submit_tag('Delete', class: 'btn btn-sm btn-danger px-4')

--- a/src/api/app/views/webui2/webui/package/_files_view.html.haml
+++ b/src/api/app/views/webui2/webui/package/_files_view.html.haml
@@ -8,7 +8,7 @@
           %th Changed
           %th Actions
       %tbody
-        - files.each do |file|
+        - files.each_with_index do |file, index|
           %tr{ id: "file-#{valid_xml_id(file[:name])}" }
             %td
               - link_opts = { action: :view_file, project: project, package: package, filename: file[:name], expand: expand }
@@ -27,8 +27,10 @@
                 = link_to(file_url(project.name, package.name, file[:name], file[:srcmd5]), title: 'Download file') do
                   %i.fas.fa-arrow-circle-down.text-secondary
               - if removable_file?(file_name: file[:name], package: package) && User.current.can_modify?(package)
-                = link_to({ action: :remove_file, project: project.to_param, package: package.to_param, filename: file[:name] },
-                  data: { confirm: "Really remove file '#{file[:name]}'?" }, method: :post, title: 'Remove file') do
+                = render(partial: 'delete_file_dialog',
+                         locals: { project: project.to_param, package: package.to_param, filename: file[:name], file_id: index })
+                = link_to('#', data: { toggle: 'modal', target: "#delete-file-modal-#{index}" },
+                          title: 'Delete file') do
                   %i.fas.fa-times-circle.text-danger
   - else
     %i This package has no files yet

--- a/src/api/app/views/webui2/webui/package/_linking_packages.html.haml
+++ b/src/api/app/views/webui2/webui/package/_linking_packages.html.haml
@@ -1,4 +1,4 @@
-.modal-dialog{ role: 'document' }
+.modal-dialog.modal-dialog-centered{ role: 'document' }
   .modal-content
     .modal-header
       %h5.modal-title Derived Packages

--- a/src/api/app/views/webui2/webui/package/_submit_request_dialog.html.haml
+++ b/src/api/app/views/webui2/webui/package/_submit_request_dialog.html.haml
@@ -1,4 +1,4 @@
-.modal-dialog{ role: 'document' }
+.modal-dialog.modal-dialog-centered{ role: 'document' }
   .modal-content
     = form_tag({ controller: 'package', action: 'submit_request' }, method: 'post') do
       .modal-header

--- a/src/api/app/views/webui2/webui/request/_add_role_request_dialog.html.haml
+++ b/src/api/app/views/webui2/webui/request/_add_role_request_dialog.html.haml
@@ -1,5 +1,5 @@
 .modal.fade#add-role-modal{ tabindex: -1, role: 'dialog', aria: { labelledby: 'add-role-modal-label', hidden: true } }
-  .modal-dialog{ role: 'document' }
+  .modal-dialog.modal-dialog-centered{ role: 'document' }
     .modal-content
       = form_tag(add_role_request_path(project: project)) do
         .modal-header

--- a/src/api/app/views/webui2/webui/request/_change_devel_request_dialog.html.haml
+++ b/src/api/app/views/webui2/webui/request/_change_devel_request_dialog.html.haml
@@ -1,4 +1,4 @@
-.modal-dialog{ role: 'document' }
+.modal-dialog.modal-dialog-centered{ role: 'document' }
   .modal-content
     = form_tag(change_devel_request_path(project: project, package: package), method: :post) do
       .modal-header

--- a/src/api/app/views/webui2/webui/request/_delete_request_dialog.html.haml
+++ b/src/api/app/views/webui2/webui/request/_delete_request_dialog.html.haml
@@ -1,5 +1,5 @@
 .modal.fade#delete-request-modal{ tabindex: -1, role: 'dialog', aria: { labelledby: 'delete-request-modal-label', hidden: true } }
-  .modal-dialog{ role: 'document' }
+  .modal-dialog.modal-dialog-centered{ role: 'document' }
     .modal-content
       = form_tag(delete_request_path(project: project), method: :post) do
         .modal-header

--- a/src/api/spec/bootstrap/features/webui/maintenance_workflow_spec.rb
+++ b/src/api/spec/bootstrap/features/webui/maintenance_workflow_spec.rb
@@ -29,9 +29,12 @@ RSpec.feature 'Bootstrap_MaintenanceWorkflow', type: :feature, js: true, vcr: tr
     visit package_show_path(project: update_project, package: package)
 
     click_link('Branch package')
+    sleep 1 # Needed to avoid a flickering test.
     expect(page).to have_text('Source')
 
-    click_button('Accept')
+    within('#branch-modal .modal-footer') do
+      click_button('Accept')
+    end
     expect(page).to have_text('Successfully branched package')
 
     # change the package sources so we have a difference

--- a/src/api/spec/bootstrap/features/webui/packages_spec.rb
+++ b/src/api/spec/bootstrap/features/webui/packages_spec.rb
@@ -24,6 +24,7 @@ RSpec.feature 'Bootstrap_Packages', type: :feature, js: true, vcr: true do
       login user
       visit package_show_path(project: other_user.home_project, package: other_users_package)
       click_link('Branch package')
+      sleep 1 # Needed to avoid a flickering test. Sometimes the summary is not expanded and its content not visible
     end
 
     scenario 'with AutoCleanup' do
@@ -62,7 +63,7 @@ RSpec.feature 'Bootstrap_Packages', type: :feature, js: true, vcr: true do
 
     expect(find('#delete-modal')).to have_text('Do you really want to delete this package?')
     within('#delete-modal .modal-footer') do
-      click_button('Accept')
+      click_button('Delete')
     end
 
     expect(find('#flash-messages')).to have_text('Package was successfully removed.')


### PR DESCRIPTION
Before we have been using the data-confirm behaviour of the browsers, now to be consistent with the rest of the boostrap style we replace this to use a modal dialog.

It will show something like this:

![image](https://user-images.githubusercontent.com/11314634/45412442-e63db500-b676-11e8-907e-ddd06ce6cf86.png)

instead of:

![image](https://user-images.githubusercontent.com/11314634/45412560-37e63f80-b677-11e8-8f40-2ca0fd1bbd82.png)

BTW, we vertically aligned all of them
