### PR TITLE
Fix issue while adding XML for requests diff

### DIFF
--- a/src/api/app/controllers/request_controller.rb
+++ b/src/api/app/controllers/request_controller.rb
@@ -185,7 +185,7 @@ class RequestController < ApplicationController
         # Inject backend-provided XML diff into action XML:
         builder = Nokogiri::XML::Builder.new
         action.render_xml(builder)
-        xml_request.add_child(builder.to_xml)
+        xml_request.add_child(builder.doc.root.to_xml)
         xml_request.at_css('action').add_child(action_diff)
       else
         diff_text += action_diff


### PR DESCRIPTION
We had an issue that was adding the `<?xml version="1.0"??>` after the
first node (`<request...>`), now is fixed and is the first node of the XML

It fixes issue #5843