### PR TITLE
Validate that XML is valid in response

### DIFF
--- a/src/api/test/test_helper.rb
+++ b/src/api/test/test_helper.rb
@@ -355,7 +355,9 @@ class ActiveSupport::TestCase
   set_fixture_class history_elements: HistoryElement::Base
 
   def check_xml_tag(data, conds)
-    NodeMatcher.new(conds).find_matching(Nokogiri::XML(data).root)
+    xml_data = Nokogiri::XML(data)
+    raise MiniTest::Assertion, "Invalid XML: #{xml_data.errors.join(', ')}" unless xml_data.errors.empty?
+    NodeMatcher.new(conds).find_matching(xml_data.root)
   end
 
   def assert_xml_tag(data, conds)


### PR DESCRIPTION
Nokogiri does not complain if xml is invalid in the test:

e.g.

```ruby
require 'nokogiri'

xml = '' + \
'<request id="123" actions="0">' + \
'<?xml version="1.0"??>' + \
'<action type="maintenance_incident"></action>' + \
'</request>'

result = Nokogiri::XML(xml)
puts result.errors # 1:36: FATAL: XML declaration allowed only at the start of the document
```