### PR TITLE
Fix comments in old webui

### DIFF
--- a/src/api/app/controllers/webui/comments_controller.rb
+++ b/src/api/app/controllers/webui/comments_controller.rb
@@ -5,7 +5,7 @@ class Webui::CommentsController < Webui::WebuiController
   before_action :find_commentable, only: :create
 
   def create
-    return if switch_to_webui2
+    return if params[:no_switch].nil? && switch_to_webui2
     comment = @commented.comments.new(permitted_params)
     User.current.comments << comment
 
@@ -25,7 +25,7 @@ class Webui::CommentsController < Webui::WebuiController
   end
 
   def destroy
-    return if switch_to_webui2
+    return if params[:no_switch].nil? && switch_to_webui2
 
     comment = Comment.find(params[:id])
     authorize comment, :destroy?

--- a/src/api/app/views/webui/comment/_links.html.haml
+++ b/src/api/app/views/webui/comment/_links.html.haml
@@ -5,5 +5,5 @@
         = sprited_text('comment_add', 'Reply')
   - if policy(comment).destroy?
     %li
-      = link_to(sprited_text('comment_delete', 'Delete'), comment, method: :delete, id: "delete_link_id_#{comment.id}", class: 'delete_link', remote: true,
+      = link_to(sprited_text('comment_delete', 'Delete'), comment_path(comment, no_switch: true), method: :delete, id: "delete_link_id_#{comment.id}", class: 'delete_link', remote: true,
         'data-confirm': 'Do you really want delete this comment?')

--- a/src/api/app/views/webui/comment/_new.html.haml
+++ b/src/api/app/views/webui/comment/_new.html.haml
@@ -9,5 +9,6 @@
   = form_for @comment, method: :post, remote: true do |f|
     = hidden_field_tag :commentable_type, commentable.class
     = hidden_field_tag :commentable_id, commentable.id
+    = hidden_field_tag :no_switch, true
     ~ f.text_area :body, size: '80x4', onkeyup: 'sz(this);', onclick: 'sz(this);', placeholder: 'Add a new comment (markdown markup supported)', required: 'required'
     = f.submit 'Add comment'

--- a/src/api/app/views/webui/comment/_reply.html.haml
+++ b/src/api/app/views/webui/comment/_reply.html.haml
@@ -3,6 +3,7 @@
     %p
       = hidden_field_tag :commentable_type, commentable.class
       = hidden_field_tag :commentable_id, commentable.id
+      = hidden_field_tag :no_switch, true
       ~ f.text_area :body, size: '80x1', onkeyup: 'sz(this);', onclick: 'sz(this);', class: 'comment_reply_body', id: "reply_body_#{comment.id}", placeholder: 'Comment Text', required: true
       = f.hidden_field :parent_id, value: comment.id, id: "reply_parent_id_#{comment.id}"
     %p


### PR DESCRIPTION
If you are a beta user, the comments section are rendering the views
from `webui2` in sections that are not migrated like `project#show`.

The `no_switch` parameter was added in `webui` comment views because they  will be
deleted as soon as we migrate everything to Bootstrap,

Co-authored-by: Moisés Déniz Alemán <mdeniz@suse.com>

Fixes #5874 