### PR TITLE
Refactor render_dialog call in request controller for webui2

### DIFF
--- a/src/api/app/controllers/webui/request_controller.rb
+++ b/src/api/app/controllers/webui/request_controller.rb
@@ -247,6 +247,7 @@ class Webui::RequestController < Webui::WebuiController
     redirect_to controller: :request, action: :show, number: request.number
   end
 
+  # TODO: This action needs to be removed when migrating to Bootstrap, is not needed in the webui2
   def change_devel_request_dialog
     @package = Package.find_by_project_and_name(params[:project], params[:package])
     if @package.develpackage

--- a/src/api/app/controllers/webui/request_controller.rb
+++ b/src/api/app/controllers/webui/request_controller.rb
@@ -1,6 +1,5 @@
 class Webui::RequestController < Webui::WebuiController
   helper 'webui/package'
-  include Webui2::RequestController
 
   before_action :require_login, except: [:show, :sourcediff, :diff]
   # requests do not really add much value for our page rank :)
@@ -254,8 +253,6 @@ class Webui::RequestController < Webui::WebuiController
       @current_devel_package = @package.develpackage.name
       @current_devel_project = @package.develpackage.project.name
     end
-
-    return if switch_to_webui2
 
     render_dialog
   end

--- a/src/api/app/controllers/webui2/request_controller.rb
+++ b/src/api/app/controllers/webui2/request_controller.rb
@@ -1,7 +1,0 @@
-module Webui2::RequestController
-  def webui2_change_devel_request_dialog
-    # FIXME: don't use render_dialog
-    render_dialog(nil, project: @project, package: @package, current_devel_project: @current_devel_project,
-                  current_devel_package: @current_devel_package)
-  end
-end

--- a/src/api/app/views/webui2/webui/package/bottom_actions/_request_devel_project_change.html.haml
+++ b/src/api/app/views/webui2/webui/package/bottom_actions/_request_devel_project_change.html.haml
@@ -1,4 +1,4 @@
 %li.list-inline-item
-  = link_to(request_change_devel_dialog_path(project: project, package: package), remote: true, class: 'nav-link') do
+  = link_to('#', class: 'nav-link', data: { toggle: 'modal', target: '#change-devel-request-modal' }) do
     %i.fas.fa-exchange-alt.text-primary
     Request devel project change

--- a/src/api/app/views/webui2/webui/package/show.html.haml
+++ b/src/api/app/views/webui2/webui/package/show.html.haml
@@ -81,3 +81,5 @@
   - else
     = render partial: 'webui2/webui/request/add_role_request_dialog', locals: { project: @project, package: @package }
     = render partial: 'webui2/webui/request/delete_request_dialog', locals: { project: @project, package: @package }
+  - if @package.develpackage
+    = render partial: 'webui2/webui/request/change_devel_request_dialog', locals: { project: @project, package: @package }

--- a/src/api/app/views/webui2/webui/request/_change_devel_request_dialog.html.haml
+++ b/src/api/app/views/webui2/webui/request/_change_devel_request_dialog.html.haml
@@ -1,29 +1,33 @@
-.modal-dialog.modal-dialog-centered{ role: 'document' }
-  .modal-content
-    = form_tag(change_devel_request_path(project: project, package: package), method: :post) do
-      .modal-header
-        %h5.modal-title Change Devel Project Request
-      .modal-body
-        - if current_devel_project && current_devel_package
-          %p
-            -# FIXME: get rid of this helper
-            Do you want to request to change the devel project for #{package_link(package)} from
-            \#{project_or_package_link(project: current_devel_project)}?
-        - else
-          %p
-            -# FIXME: get rid of this helper
-            Do you want to request to set the devel project for #{package_link(package)}?
-        .form-group
+- current_devel_package = package.develpackage.name
+- current_devel_project = package.develpackage.project.name
+
+.modal.fade#change-devel-request-modal{ tabindex: -1, role: 'dialog', aria: { labelledby: 'change-devel-request-modal-label', hidden: true } }
+  .modal-dialog.modal-dialog-centered{ role: 'document' }
+    .modal-content
+      = form_tag(change_devel_request_path(project: project, package: package), method: :post) do
+        .modal-header
+          %h5.modal-title Change Devel Project Request
+        .modal-body
           - if current_devel_project && current_devel_package
-            = label_tag(:devel_project, 'New Devel project (leave free to delete the current one):')
+            %p
+              -# FIXME: get rid of this helper
+              Do you want to request to change the devel project for #{package_link(package)} from
+              \#{project_or_package_link(project: current_devel_project)}?
           - else
-            = label_tag(:devel_project, 'Devel project:')
-          = text_field_tag(:devel_project, '', required: true, class: 'form-control')
-        .form-group
-          = label_tag(:description, 'Description:')
-          = text_area_tag(:description, '', row: 3, class: 'form-control')
-      .modal-footer
-        = render partial: 'webui2/shared/dialog_action_buttons'
+            %p
+              -# FIXME: get rid of this helper
+              Do you want to request to set the devel project for #{package_link(package)}?
+          .form-group
+            - if current_devel_project && current_devel_package
+              = label_tag(:devel_project, 'New Devel project (leave free to delete the current one):')
+            - else
+              = label_tag(:devel_project, 'Devel project:')
+            = text_field_tag(:devel_project, '', required: true, class: 'form-control')
+          .form-group
+            = label_tag(:description, 'Description:')
+            = text_area_tag(:description, '', row: 3, class: 'form-control')
+        .modal-footer
+          = render partial: 'webui2/shared/dialog_action_buttons'
 
 :javascript
   autocompleteDevelProject('#{autocomplete_projects_path}');

--- a/src/api/app/views/webui2/webui/request/_change_devel_request_dialog.html.haml
+++ b/src/api/app/views/webui2/webui/request/_change_devel_request_dialog.html.haml
@@ -1,6 +1,3 @@
-- current_devel_package = package.develpackage.name
-- current_devel_project = package.develpackage.project.name
-
 .modal.fade#change-devel-request-modal{ tabindex: -1, role: 'dialog', aria: { labelledby: 'change-devel-request-modal-label', hidden: true } }
   .modal-dialog.modal-dialog-centered{ role: 'document' }
     .modal-content
@@ -8,20 +5,12 @@
         .modal-header
           %h5.modal-title Change Devel Project Request
         .modal-body
-          - if current_devel_project && current_devel_package
-            %p
-              -# FIXME: get rid of this helper
-              Do you want to request to change the devel project for #{package_link(package)} from
-              \#{project_or_package_link(project: current_devel_project)}?
-          - else
-            %p
-              -# FIXME: get rid of this helper
-              Do you want to request to set the devel project for #{package_link(package)}?
+          %p
+            -# FIXME: get rid of this helper
+            Do you want to request to change the devel project for #{package_link(package)} from
+            \#{project_or_package_link(project: package.develpackage.project.name)}?
           .form-group
-            - if current_devel_project && current_devel_package
-              = label_tag(:devel_project, 'New Devel project (leave free to delete the current one):')
-            - else
-              = label_tag(:devel_project, 'Devel project:')
+            = label_tag(:devel_project, 'New Devel project (leave free to delete the current one):')
             = text_field_tag(:devel_project, '', required: true, class: 'form-control')
           .form-group
             = label_tag(:description, 'Description:')

--- a/src/api/spec/bootstrap/features/webui/packages_spec.rb
+++ b/src/api/spec/bootstrap/features/webui/packages_spec.rb
@@ -93,7 +93,7 @@ RSpec.feature 'Bootstrap_Packages', type: :feature, js: true, vcr: true do
 
     click_link('Request devel project change')
 
-    within('#modal') do
+    within('#change-devel-request-modal') do
       fill_in('devel_project', with: third_project.name)
       fill_in('description', with: 'Hey, why not?')
       click_button('Accept')

--- a/src/api/spec/features/webui/packages_spec.rb
+++ b/src/api/spec/features/webui/packages_spec.rb
@@ -48,6 +48,7 @@ RSpec.feature 'Packages', type: :feature, js: true do
       visit package_show_path(project: user.home_project, package: package)
       expect(page).to have_text('1 derived package')
       click_link('derived package')
+      sleep 1 # Needed to avoid a flickering test. Sometimes the modal is shown too late and the click doen't work
       expect(page).to have_link('home:package_test_user...ome:package_test_user')
       click_link('home:package_test_user...ome:package_test_user')
       expect(page.current_path).to eq(package_show_path(project: branched_project, package: branched_project.packages.first))


### PR DESCRIPTION
We want to remove this pattern of using render_dialog. Is too generic,
now we answer the ajax call with a JS that creates the modal.

We are not integrating the modal directly in the Package#show because it
will need to load the develpackage and project related to that everytime
we show a package and won't be needed that frecuently.

Co-authored-by: David Kang <dkang@suse.com>