### PR TITLE
Fix testdata rake task

### DIFF
--- a/src/api/lib/tasks/dev.rake
+++ b/src/api/lib/tasks/dev.rake
@@ -195,10 +195,10 @@ namespace :dev do
       )
 
       # Create factory dashboard projects
-      create(:project, name: 'openSUSE:Factory', description: 'requests:')
+      create(:project, name: 'openSUSE:Factory')
       create(:project, name: 'openSUSE:Factory:Rings:0-Bootstrap')
       create(:project, name: 'openSUSE:Factory:Rings:1-MinimalX')
-      create(:project, name: 'openSUSE:Factory:Staging:A')
+      create(:project, name: 'openSUSE:Factory:Staging:A', description: 'requests:')
     end
   end
 end


### PR DESCRIPTION
and add the YAML magic comment to the Staging project instead of the parent.
Otherwise the staging dashboard will crash because of a YAML load error
while parsing the empty description of the Staging project.