### PR TITLE
Prevent creation of a request with an ID attribute

### DIFF
--- a/src/api/app/controllers/request_controller.rb
+++ b/src/api/app/controllers/request_controller.rb
@@ -21,6 +21,10 @@ class RequestController < ApplicationController
     setup 404, 'This call requires at least one filter, either by user, project or package or states or types or reviewstates'
   end
 
+  class SaveError < APIError
+    setup 'request_save_error'
+  end
+
   def render_request_collection
     # if all params areblank, something is wrong
     raise RequireFilter if [:project, :user, :states, :types, :reviewstates, :ids].all? { |f| params[f].blank? }
@@ -145,6 +149,7 @@ class RequestController < ApplicationController
       parsed_xml = Xmlhash.parse(request.raw_post.to_s)
 
       raise SaveError, 'Failed parsing the request xml' unless parsed_xml
+      raise SaveError, 'Request ID attribute not allowed when creating a request' if parsed_xml['id']
 
       @req = BsRequest.new_from_hash(parsed_xml)
       @req.set_add_revision       if params[:addrevision].present?

--- a/src/api/app/controllers/request_controller.rb
+++ b/src/api/app/controllers/request_controller.rb
@@ -142,7 +142,11 @@ class RequestController < ApplicationController
   def request_create
     xml = nil
     BsRequest.transaction do
-      @req = BsRequest.new_from_xml(request.raw_post.to_s)
+      parsed_xml = Xmlhash.parse(request.raw_post.to_s)
+
+      raise SaveError, 'Failed parsing the request xml' unless parsed_xml
+
+      @req = BsRequest.new_from_hash(parsed_xml)
       @req.set_add_revision       if params[:addrevision].present?
       @req.set_ignore_build_state if params[:ignore_build_state].present?
       @req.save!

--- a/src/api/app/models/bs_request.rb
+++ b/src/api/app/models/bs_request.rb
@@ -157,7 +157,10 @@ class BsRequest < ApplicationRecord
     hashed = Xmlhash.parse(xml)
 
     raise SaveError, 'Failed parsing the request xml' unless hashed
+    new_from_hash(hashed)
+  end
 
+  def self.new_from_hash(hashed)
     if hashed['id']
       theid = hashed.delete('id') { raise 'not found' }
       theid = Integer(theid)


### PR DESCRIPTION
New requests should not include the `id` attribute. If a `<state>` element is provided it will be ignored.

Co-authored-by: David Kang <dkang@suse.com>