### PR TITLE
[dist] fix compression in osc test cases

### DIFF
--- a/dist/t/osc/fixtures/obs-testpackage-2.8._service
+++ b/dist/t/osc/fixtures/obs-testpackage-2.8._service
@@ -6,7 +6,7 @@
     <param name="extract">dist/obs-testpackage.spec</param>
   </service>
   <service name="recompress">
-    <param name="compression">xz</param>
+    <param name="compression">gz</param>
     <param name="file">*.tar</param>
   </service>
   <service name="set_version"/>

--- a/dist/t/osc/fixtures/obs-testpackage._service
+++ b/dist/t/osc/fixtures/obs-testpackage._service
@@ -7,7 +7,7 @@
   </service>
   <service name="tar" mode="buildtime"/>
   <service name="recompress" mode="buildtime">
-    <param name="compression">xz</param>
+    <param name="compression">gz</param>
     <param name="file">*.tar</param>
   </service>
   <service name="set_version" mode="buildtime"/>


### PR DESCRIPTION
Changed to be consistent with

https://github.com/M0ses/obs-testpackage/commit/f43d00d49ffefe2cd3296070e371120041e9d6b2