### PR TITLE
Fix scaling of breadcrumbs on low width screens

### DIFF
--- a/src/api/app/views/layouts/webui2/webui.html.haml
+++ b/src/api/app/views/layouts/webui2/webui.html.haml
@@ -23,9 +23,9 @@
     .w-100.m-2
     .container.d-none.d-sm-block#personal-navigation
       .row
-        .col-8
+        .col
           = render partial: "layouts/webui2/breadcrumbs"
-        .col-4
+        .col-auto.ml-auto
           = render partial: "layouts/webui2/personal_navigation"
     .container#flash
       = render partial: "layouts/webui2/flash", object: flash

--- a/src/api/app/views/webui2/webui/main/_breadcrumb_items.html.haml
+++ b/src/api/app/views/webui2/webui/main/_breadcrumb_items.html.haml
@@ -5,5 +5,5 @@
     = home_title
 - else
   %li.breadcrumb-item
-    %i.fas.fa-home
+    %i.fas.fa-home.mr-1
     = link_to home_title, root_path

--- a/src/api/app/views/webui2/webui/main/_breadcrumb_items.html.haml
+++ b/src/api/app/views/webui2/webui/main/_breadcrumb_items.html.haml
@@ -1,7 +1,7 @@
 - home_title = @configuration ? @configuration['title'] : 'Open Build Service'
 - if current_page?(root_path)
   %li.breadcrumb-item.active{ 'aria-current' => 'page' }
-    %i.fas.fa-home
+    %i.fas.fa-home.mr-1
     = home_title
 - else
   %li.breadcrumb-item


### PR DESCRIPTION
![screenshot from 2018-09-21 20-57-40](https://user-images.githubusercontent.com/30577011/45900802-14429800-bde1-11e8-9bcf-7661527db193.png)
![screenshot from 2018-09-21 20-57-25](https://user-images.githubusercontent.com/30577011/45900801-14429800-bde1-11e8-8d40-b4fa89649955.png)
So it will use the full width of available space, will also kick out personal navigation to row if there is not enough space for it at the top.

Would also be beneficial to consider changing scheme in there to display ":house: Home" instead of ":house: Name of the instance of Open Build Service" because it can get veeeery long and take up way too much space, and conveys message of it coming back to homepage more than name of the instance.