### PR TITLE
Add style for `pre` tag in comments

### DIFF
--- a/src/api/app/assets/stylesheets/webui2/comments.scss
+++ b/src/api/app/assets/stylesheets/webui2/comments.scss
@@ -1,0 +1,9 @@
+.comments {
+  .media .media-body {
+    pre {
+      @extend .p-2;
+      @extend .bg-light;
+      white-space: pre-wrap;
+    }
+  }
+}

--- a/src/api/app/assets/stylesheets/webui2/webui2.css.scss
+++ b/src/api/app/assets/stylesheets/webui2/webui2.css.scss
@@ -32,3 +32,4 @@
 @import 'autocomplete';
 @import 'package-attributes';
 @import 'modals';
+@import 'comments';


### PR DESCRIPTION
The content with `pre` tag was overflowing the comment box.

### Before
![screenshot_2018-09-24 show apache apache2 - opensuse build service](https://user-images.githubusercontent.com/1212806/45947706-868bc600-bff5-11e8-8475-2d5e72374841.png)


### After
![screenshot_2018-09-24 show home admin test - open build service](https://user-images.githubusercontent.com/1212806/45947710-8ab7e380-bff5-11e8-8d32-ea2ce1ea1e59.png)

kudos to @mdeniz 