### PR TITLE
[api] support request pre-approval

### DIFF
--- a/docs/api/api/api.txt
+++ b/docs/api/api/api.txt
@@ -954,6 +954,8 @@ XmlResult: request
   setpriority: Modifies the priority of a requst
   setincident: Change the target incident for maintenance_incident actions
   setacceptat: Set or modify the accept_at time. Either specified by time parameter or now.
+  approve: pre-approve a request in review state. Will turn into accepted after last review
+  cancelapproval: reset the approval
 
 Parameters: 
   newstate: Define the new state

--- a/docs/api/api/request.rng
+++ b/docs/api/api/request.rng
@@ -44,6 +44,11 @@
           <text/>
         </element>
       </optional>
+      <optional>
+	<attribute name="approver">
+          <data type="string" />
+	</attribute>
+      </optional>
       <empty/>
     </element>
   </define>

--- a/src/api/app/controllers/request_controller.rb
+++ b/src/api/app/controllers/request_controller.rb
@@ -86,7 +86,7 @@ class RequestController < ApplicationController
     # FIXME: this should be moved into the model functions, doing
     #        these actions
     case params[:cmd]
-    when 'create', 'changestate', 'addreview', 'setpriority', 'setincident', 'setacceptat'
+    when 'create', 'changestate', 'addreview', 'setpriority', 'setincident', 'setacceptat', 'approve', 'cancelapproval'
       # create -> noop
       # permissions are checked by the model
       nil
@@ -250,6 +250,16 @@ class RequestController < ApplicationController
 
   def request_command_assignreview
     @req.assignreview(params)
+    render_ok
+  end
+
+  def request_command_approve
+    @req.approve(params)
+    render_ok
+  end
+
+  def request_command_cancelapproval
+    @req.cancelapproval(params)
     render_ok
   end
 

--- a/src/api/app/jobs/accept_requests.rb
+++ b/src/api/app/jobs/accept_requests.rb
@@ -1,17 +1,5 @@
 class AcceptRequestsJob < ApplicationJob
   def perform
-    User.current = User.find_by_login('Admin')
-    BsRequest.to_accept.each do |r|
-      begin
-        r.change_state('accepted', comment: 'Auto accept')
-      rescue BsRequestAction::UnknownProject,
-             Package::UnknownObjectError,
-             Package::ReadAccessError,
-             BsRequestAction::UnknownTargetPackage,
-             BsRequestPermissionCheck::NotExistingTarget,
-             Project::UnknownObjectError => e
-        r.change_state('revoked', comment: "Accept failed with: #{e.message}")
-      end
-    end
+    BsRequest.to_accept_by_time.each(&:auto_accept)
   end
 end

--- a/src/api/db/migrate/20180924135535_request_approved.rb
+++ b/src/api/db/migrate/20180924135535_request_approved.rb
@@ -1,0 +1,5 @@
+class RequestApproved < ActiveRecord::Migration[5.2]
+  def change
+    add_column :bs_requests, :approver, :string
+  end
+end

--- a/src/api/db/structure.sql
+++ b/src/api/db/structure.sql
@@ -272,6 +272,7 @@ CREATE TABLE `bs_requests` (
   `priority` enum('critical','important','moderate','low') CHARACTER SET utf8 COLLATE utf8_bin DEFAULT 'moderate',
   `number` int(11) DEFAULT NULL,
   `updated_when` datetime DEFAULT NULL,
+  `approver` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   PRIMARY KEY (`id`),
   UNIQUE KEY `index_bs_requests_on_number` (`number`),
   KEY `index_bs_requests_on_creator` (`creator`) USING BTREE,
@@ -1404,6 +1405,7 @@ INSERT INTO `schema_migrations` (version) VALUES
 ('20180906115417'),
 ('20180906142702'),
 ('20180906142802'),
-('20180911123709');
+('20180911123709'),
+('20180924135535');
 
 


### PR DESCRIPTION
add option to pre-approve a request in review state. It will be accepted
when last review gets accepted.

former way could not work since requests in review state already get
accepted by time.

Also fixed inconsistent behaviour of autoaccept depending on which of the duplicate
autoaccept handling was used.

belongs to Fate 316775