### PR TITLE
Use '--link' option in call-service-in-container.sh only for bundle_gems service

### DIFF
--- a/src/backend/BSConfig.pm.template
+++ b/src/backend/BSConfig.pm.template
@@ -266,9 +266,12 @@ our $servicedispatch = 1;
 # special options to use for starting containers in call-service-in-docker.sh
 # our $docker_custom_opt = '';
 
-# server where mirrored gems could be found - used in services like obs-service-bundle_gems
+## Server where mirrored gems could be found - used in services like obs-service-bundle_gems
 # our $gems_mirror = '';
-
+#
+## Container which should be 'linked' when running "bundle_gems" service
+# our $geminabox_container = '';
+#
 
 # public cloud uploader configuration
 # our $cloudupload_pubkey = "/etc/obs/cloudupload/_pubkey"; # default setting

--- a/src/backend/bs_admin
+++ b/src/backend/bs_admin
@@ -1140,9 +1140,9 @@ while (@ARGV) {
     }
   } elsif ( $arg eq "--query-config" ) {
     my $var=shift @ARGV;
-    my $val;
-    eval "\$val = \$BSConfig::$var";
-    print "$val\n";
+    no strict "refs";
+    my $val = ${"BSConfig::$var"};
+    print "$val\n" if defined $val;
   } elsif ( $arg eq "--drop-badhosts" ) {
     BSUtil::touch("$rundir/bs_dispatch.dropbadhosts");
   } elsif ( $arg eq "--list-badhosts" ) {

--- a/src/backend/call-service-in-docker.sh
+++ b/src/backend/call-service-in-docker.sh
@@ -40,7 +40,14 @@ create_dir "$LOGDIR"
 
 shift
 case "$COMMAND" in
-  */download_url|*/download_src_package|*/update_source|*/download_files|*/generator_pom|*/snapcraft|*/kiwi_import|*/appimage|*/bundle_gems)
+  */download_url|*/download_src_package|*/update_source|*/download_files|*/generator_pom|*/snapcraft|*/kiwi_import|*/appimage)
+    WITH_NET="1"
+    ;;
+  */bundle_gems)
+    GEMINABOX=`obs_admin --query-config geminabox_container`
+    if  [ -n "$GEMINABOX" ];then
+      LINK="--link $GEMINABOX:$GEMINABOX"
+    fi
     WITH_NET="1"
     ;;
   */tar_scm|*/obs_scm)
@@ -159,7 +166,7 @@ fi
 
 find $MOUNTDIR
 # run jailed process
-DOCKER_RUN_CMD="docker run -u 2:2 $DOCKER_OPTS_NET --rm --name $CONTAINER_ID $DOCKER_CUSTOM_OPT $DOCKER_VOLUMES $DEBUG_OPTIONS $DOCKER_IMAGE $INNERSCRIPT"
+DOCKER_RUN_CMD="docker run -u 2:2 $DOCKER_OPTS_NET $LINK --rm --name $CONTAINER_ID $DOCKER_CUSTOM_OPT $DOCKER_VOLUMES $DEBUG_OPTIONS $DOCKER_IMAGE $INNERSCRIPT"
 printlog "DOCKER_RUN_CMD: '$DOCKER_RUN_CMD'"
 CMD_OUT=$(${DOCKER_RUN_CMD} 2>&1)
 RET_ERR=$?


### PR DESCRIPTION
The Problem:
ATM we have the problem, that we use docker_custom_opt's which is then added to every service call, 
even if only needed with the 'bundle_gems'. If the geminabox container doesn`t work correctly
it affects all service. 

This tries to reduce dependencies for the other service to the geminabox container by introducing a new option/variable

```$geminabox_container``` in BSConfig.pm

which is only used in bundle_gems case.