### PR TITLE
Hide webui 2 version of project request tab

### DIFF
--- a/src/api/app/controllers/webui/project_controller.rb
+++ b/src/api/app/controllers/webui/project_controller.rb
@@ -252,8 +252,6 @@ class Webui::ProjectController < Webui::WebuiController
     @requests = @project.open_requests
     @default_request_type = params[:type] if params[:type]
     @default_request_state = params[:state] if params[:state]
-
-    switch_to_webui2
   end
 
   def create


### PR DESCRIPTION
We are about to announce the bootstrap version of the package show
and package tabs views. Since the other project views are not done
yet, we hide bootstrap version of the project request tab for now.