### PR TITLE
Migrate live build log to Bootstrap

### DIFF
--- a/src/api/app/assets/javascripts/webui2/application.js
+++ b/src/api/app/assets/javascripts/webui2/application.js
@@ -26,6 +26,7 @@
 //= require webui2/requests_table.js
 //= require webui2/attributes.js
 //= require webui2/packages.js
+//= require webui2/live_build_log.js
 // FIXME refactor these files
 //= require webui2/autocomplete.js
 //= require webui2/comment.js

--- a/src/api/app/assets/javascripts/webui2/live_build_log.js
+++ b/src/api/app/assets/javascripts/webui2/live_build_log.js
@@ -1,0 +1,117 @@
+var LiveLog = function(wrapperId, startButton, stopButton, status, finished, info) {
+  this.wrapper = $(wrapperId);
+  this.startButton = $(startButton);
+  this.stopButton = $(stopButton);
+  this.status = $(status);
+  this.initial = true;
+  this.lastScroll = 0;
+  this.ajaxRequest = 0;
+  this.offset = 0;
+  this.finished = finished;
+  this.logInfo = $(info);
+};
+
+$.extend(LiveLog.prototype, {
+  initialize: function() {
+    this.startButton.click($.proxy(this.start, this));
+    this.stopButton.click($.proxy(this.stop, this));
+    this.checkScroll();
+    this.checkResize();
+    this.logInfo.css('width', this.wrapper.width());
+    this.start();
+    this.initial = false;
+    return this;
+  },
+
+  start: function() {
+    if (!this.finished) {
+      this.autoRefresh = true;
+      this.lastScroll = 0;
+      this.loadContent();
+      this.indicatorStatus('running');
+      this.startButton.addClass('d-none');
+      this.stopButton.removeClass('d-none');
+    }
+    return false;
+  },
+
+  stop: function() {
+    this.autoRefresh = false;
+    this.indicatorStatus('paused');
+    this.stopAjaxRequest();
+    this.stopButton.addClass('d-none');
+    this.startButton.removeClass('d-none');
+    return false;
+  },
+
+  loadContent: function() {
+    if (this.autoRefresh) {
+      var url = this.wrapper.data('url') + '&offset=' + this.offset + ';&' + 'initial=' + (this.initial ? '1' : '0');
+
+      this.ajaxRequest = $.ajax({
+        type: 'GET',
+        url: url,
+        data: null,
+        error: $.proxy(this.stop, this),
+        cache: false
+      });
+    }
+  },
+
+  autoScroll: function() {
+    // just return in case the user scrolled up
+    if (this.lastScroll > window.pageYOffset) { return; }
+    // stop loadContent if the user scrolled down
+    if (this.lastScroll < window.pageYOffset && this.lastScroll) { this.stop(); return; }
+    var targetOffset = $('#footer').offset().top - window.innerHeight;
+    window.scrollTo(0, targetOffset);
+    this.lastScroll = window.pageYOffset;
+  },
+
+  finish: function() { // jshint ignore:line
+    this.finished = true;
+    this.stop();
+    this.status.html('Build finished');
+    this.indicatorStatus('finished');
+    this.hideAbort();
+    this.stopButton.addClass('d-none');
+    this.startButton.addClass('d-none');
+  },
+
+  stopAjaxRequest: function() { // jshint ignore:line
+    if (this.ajaxRequest !== 0)
+      this.ajaxRequest.abort();
+    this.ajaxRequest = 0;
+  },
+
+  showAbort: function() { // jshint ignore:line
+    $(".link_abort_build").removeClass('d-none');
+    $(".link_trigger_rebuild").addClass('d-none');
+  },
+
+  hideAbort: function() { // jshint ignore:line
+    $(".link_abort_build").addClass('d-none');
+    $(".link_trigger_rebuild").removeClass('d-none');
+  },
+
+  indicatorStatus: function(status) { // jshint ignore:line
+    this.logInfo.children().hide();
+    this.logInfo.children('.' + status).show();
+  },
+
+  checkScroll: function() {
+    var element = this;
+    $(window).scroll(function() {
+      var cssStyle = $(document).scrollTop() > element.wrapper.offset().top ? 'fixed' : 'initial';
+      element.logInfo.css('position', cssStyle);
+    });
+  },
+
+  checkResize: function() {
+    var element = this;
+    $(window).resize(function() {
+      element.logInfo.css('width', element.wrapper.width());
+    });
+  }
+});
+

--- a/src/api/app/assets/stylesheets/webui2/live_build_log.scss
+++ b/src/api/app/assets/stylesheets/webui2/live_build_log.scss
@@ -1,0 +1,52 @@
+#log-space-wrapper {
+  #log-info {
+    top: 0;
+    cursor: pointer;
+
+    .finished { cursor: default; }
+   }
+
+  pre {
+    white-space: pre-wrap;
+  }
+}
+
+.live-link-action {
+  @extend .px-2;
+  @extend .mr-2;
+  @extend .mb-2;
+  @extend .btn;
+  @extend .btn-sm;
+}
+
+@include media-breakpoint-down(sm) {
+  #log-space-wrapper {
+    pre {
+      font-size: 40%;
+    }
+  }
+}
+
+@include media-breakpoint-up(sm) {
+  #log-space-wrapper {
+    pre {
+      font-size: 50%;
+    }
+  }
+}
+
+@include media-breakpoint-up(md) {
+  #log-space-wrapper {
+    pre {
+      font-size: 60%;
+    }
+  }
+}
+
+@include media-breakpoint-up(lg) {
+  #log-space-wrapper {
+    pre {
+      font-size: 70%;
+    }
+  }
+}

--- a/src/api/app/assets/stylesheets/webui2/webui2.css.scss
+++ b/src/api/app/assets/stylesheets/webui2/webui2.css.scss
@@ -35,3 +35,4 @@
 @import 'modals';
 @import 'comments';
 @import 'cm2';
+@import 'live_build_log';

--- a/src/api/app/controllers/webui/package_controller.rb
+++ b/src/api/app/controllers/webui/package_controller.rb
@@ -816,6 +816,8 @@ class Webui::PackageController < Webui::WebuiController
     @finished = Buildresult.final_status?(status)
 
     set_job_status
+
+    switch_to_webui2
   end
 
   def update_build_log
@@ -876,6 +878,8 @@ class Webui::PackageController < Webui::WebuiController
     end
 
     logger.debug 'finished ' + @finished.to_s
+
+    switch_to_webui2
   end
 
   def abort_build

--- a/src/api/app/views/webui2/webui/package/_breadcrumb_items.html.haml
+++ b/src/api/app/views/webui2/webui/package/_breadcrumb_items.html.haml
@@ -16,3 +16,6 @@
 - if current_page?(package_show_path)
   %li.breadcrumb-item.active{ 'aria-current' => 'page' }
     Overview
+- if @repo && @arch && current_page?(package_live_build_log_path(@project, @package, repository: @repo, arch: @arch))
+  %li.breadcrumb-item.active{ 'aria-current' => 'page' }
+    Build Log

--- a/src/api/app/views/webui2/webui/package/_job_status.html.haml
+++ b/src/api/app/views/webui2/webui/package/_job_status.html.haml
@@ -1,0 +1,12 @@
+%p
+  %strong Repository:
+  = repository
+  %strong Architecture:
+  = architecture
+%p
+  %strong Worker:
+  = worker_id
+  %strong Buildtime:
+  = distance_of_time_in_words(build_time || 0)
+  = "(#{percent}%)" if percent
+

--- a/src/api/app/views/webui2/webui/package/_live_build_log_controls.html.haml
+++ b/src/api/app/views/webui2/webui/package/_live_build_log_controls.html.haml
@@ -1,0 +1,32 @@
+%p
+  = link_to('#', class: 'start_refresh d-none live-link-action btn-info') do
+    %i.far.fa-play-circle
+    Start refresh
+  = link_to('#', class: 'stop_refresh live-link-action btn-dark') do
+    %i.far.fa-pause-circle
+    Stop refresh
+
+  - if User.current.is_nobody?
+    = link_to(public_build_path(package: @package, project: @project, arch: @arch, repository: @repo, filename: '_log'),
+              target: :_blank,
+              class: 'live-link-action btn-secondary') do
+      %i.far.fa-arrow-alt-circle-down
+      Download logfile
+  - else
+    = link_to(raw_logfile_path(package: @package, project: @project, arch: @arch, repository: @repo),
+              target: :_blank,
+              class: 'live-link-action btn-secondary') do
+      %i.far.fa-arrow-alt-circle-down
+      Download logfile
+  - if @can_modify
+    = link_to(package_trigger_rebuild_path(project: @project, package: @package, arch: @arch, repository: @repo),
+              class: 'link_trigger_rebuild live-link-action btn-primary d-none',
+              method: :post) do
+      %i.fas.fa-redo
+      Trigger Rebuild
+    = link_to(package_abort_build_path(project: @project, package: @package, arch: @arch, repository: @repo),
+              class: 'link_abort_build live-link-action btn-danger d-none') do
+      %i.far.fa-times-circle
+      Abort Build
+
+

--- a/src/api/app/views/webui2/webui/package/live_build_log.html.haml
+++ b/src/api/app/views/webui2/webui/package/live_build_log.html.haml
@@ -1,0 +1,39 @@
+- @pagetitle = "Build Log for Package #{@package} (Project #{@project})"
+- @metarobots = 'noindex,nofollow'
+
+.card.mb-3
+  - if @package.is_a?(Package)
+    = render partial: 'tabs', locals: { project: @project, package: @package }
+  .card-body
+    %h3= @pagetitle
+    - if @workerid
+      = render partial: 'job_status', locals: { repository: @repo, architecture: @arch,
+                                                worker_id: @workerid, build_time: @buildtime,
+                                                percent: @percent }
+    %p
+      %strong Status:
+      %span#status Updating...
+    - if @what_depends_on.present?
+      %details.pb-3
+        %summary #{@what_depends_on.length} #{'package'.pluralize(@what_depends_on.length)} with a direct dependency to this package.
+        %strong Packages:
+        = @what_depends_on.join(', ')
+    = render partial: 'live_build_log_controls'
+    #log-space-wrapper{ data: { url: package_update_build_log_path(package: @package, project: @project,
+                                                                   status: @status, arch: @arch, repository: @repo) } }
+      .d-block.text-center.shadow-sm#log-info
+        .running.stop_refresh.py-2.bg-info.text-light
+          %i.fas.fa-spinner.fa-pulse
+          Running...
+        .paused.start_refresh.py-2.bg-dark.text-light
+          %i.far.fa-pause-circle
+          Paused
+        .finished.py-2.bg-warning
+          End of log
+      %pre.p-4.bg-light#log-space
+    - unless @workerid
+      = render partial: 'live_build_log_controls'
+
+:javascript
+  liveLog = new LiveLog('#log-space-wrapper', '.start_refresh', '.stop_refresh', '#status', #{@finished}, '#log-info').initialize();
+

--- a/src/api/app/views/webui2/webui/package/update_build_log.js.haml
+++ b/src/api/app/views/webui2/webui/package/update_build_log.js.haml
@@ -1,0 +1,15 @@
+- if @errors
+  $('#flash').html("#{escape_javascript(render(partial: 'layouts/webui2/flash', locals: { flash: { error: @errors } }))}");
+  $("html, body").scrollTop(0);
+  liveLog.finish();
+- else
+  - if @finished
+    - if @first_request
+      $('#log-space').html('#{escape_javascript(@log_chunk)}');
+    liveLog.finish();
+  - else
+    $('#log-space').append('#{escape_javascript(@log_chunk)}');
+    liveLog.showAbort();
+    liveLog.offset = #{@offset};
+    setTimeout($.proxy(liveLog.loadContent, liveLog), 2000);
+  liveLog.autoScroll();

--- a/src/api/config/routes.rb
+++ b/src/api/config/routes.rb
@@ -129,11 +129,11 @@ OBSApi::Application.routes.draw do
         get 'package/live_build_log/:project/:package/:repository/:arch' => :live_build_log, constraints: cons, as: 'package_live_build_log'
         defaults format: 'js' do
           get 'package/linking_packages/:project/:package' => :linking_packages, constraints: cons, as: 'linking_packages'
-          get 'package/update_build_log/:project/:package/:repository/:arch' => :update_build_log, constraints: cons
+          get 'package/update_build_log/:project/:package/:repository/:arch' => :update_build_log, constraints: cons, as: 'package_update_build_log'
           get 'package/submit_request_dialog/:project/:package' => :submit_request_dialog, constraints: cons, as: 'package_submit_request_dialog'
           get 'package/delete_dialog/:project/:package' => :delete_dialog, constraints: cons, as: 'package_delete_dialog'
-          post 'package/trigger_rebuild/:project/:package' => :trigger_rebuild, constraints: cons
-          get 'package/abort_build/:project/:package' => :abort_build, constraints: cons
+          post 'package/trigger_rebuild/:project/:package' => :trigger_rebuild, constraints: cons, as: 'package_trigger_rebuild'
+          get 'package/abort_build/:project/:package' => :abort_build, constraints: cons, as: 'package_abort_build'
           post 'package/trigger_services/:project/:package' => :trigger_services, constraints: cons, as: 'package_trigger_services'
           delete 'package/wipe_binaries/:project/:package' => :wipe_binaries, constraints: cons
         end


### PR DESCRIPTION
We migrate package#live_build_log to bootstrap.

### Without dependencies

![screenshot_2018-09-25 build log for package perl-citrix project home admin - open build service 4](https://user-images.githubusercontent.com/1212806/46021469-0773bc00-c0e1-11e8-95cd-048068d16e7b.png)

### With Dependencies

![screenshot_2018-09-25 build log for package perl-citrix project home admin - open build service 7](https://user-images.githubusercontent.com/1212806/46021492-18bcc880-c0e1-11e8-82a4-799f2ec7e5a5.png)


### Small Screen
![untitled](https://user-images.githubusercontent.com/1212806/46151606-6ebf7680-c26f-11e8-8243-8ebe84921729.png)

The original screenshot is [here](http://paste.opensuse.org/15277277)

