### PR TITLE
Move CodeMirror to webui2

### DIFF
--- a/src/api/.jshintignore
+++ b/src/api/.jshintignore
@@ -1,3 +1,4 @@
 app/assets/javascripts/webui/application/bento
 app/assets/javascripts/webui/application/cm2
+app/assets/javascripts/webui2/cm2
 app/assets/javascripts/webui2/*.min.js

--- a/src/api/app/assets/javascripts/webui2/application.js
+++ b/src/api/app/assets/javascripts/webui2/application.js
@@ -32,3 +32,4 @@
 //= require webui2/buildresult.js
 // FIXME remove jquery-ui file when we upgrade jquery-ui gem
 //= require webui2/jquery-ui.min.js
+//= require webui2/cm2/use-codemirror.js

--- a/src/api/app/assets/javascripts/webui2/cm2/index-diff.js
+++ b/src/api/app/assets/javascripts/webui2/cm2/index-diff.js
@@ -1,0 +1,16 @@
+// This is a manifest file that'll be compiled into codemirror, which will include all the files
+// listed below.
+//
+// Any JavaScript/Coffee file within this directory, lib/assets/javascripts, vendor/assets/javascripts,
+// or vendor/assets/javascripts of plugins, if any, can be referenced here using a relative path.
+//
+// It's not advisable to add code directly here, but if you do, it'll appear at the bottom of the
+// the compiled file.
+//
+// WARNING: THE FIRST BLANK LINE MARKS THE END OF WHAT'S TO BE PROCESSED, ANY BLANK LINE SHOULD
+// GO AFTER THE REQUIRES BELOW.
+//
+//= require codemirror
+//= require webui2/cm2/toolbars
+//= require codemirror/modes/diff.js
+//= require webui2/cm2/use-codemirror

--- a/src/api/app/assets/javascripts/webui2/cm2/index-prjconf.js
+++ b/src/api/app/assets/javascripts/webui2/cm2/index-prjconf.js
@@ -1,0 +1,16 @@
+// This is a manifest file that'll be compiled into codemirror, which will include all the files
+// listed below.
+//
+// Any JavaScript/Coffee file within this directory, lib/assets/javascripts, vendor/assets/javascripts,
+// or vendor/assets/javascripts of plugins, if any, can be referenced here using a relative path.
+//
+// It's not advisable to add code directly here, but if you do, it'll appear at the bottom of the
+// the compiled file.
+//
+// WARNING: THE FIRST BLANK LINE MARKS THE END OF WHAT'S TO BE PROCESSED, ANY BLANK LINE SHOULD
+// GO AFTER THE REQUIRES BELOW.
+//
+//= require codemirror
+//= require webui2/cm2/toolbars
+//= require webui2/cm2/mode/prjconf
+//= require webui2/cm2/use-codemirror

--- a/src/api/app/assets/javascripts/webui2/cm2/index-xml.js
+++ b/src/api/app/assets/javascripts/webui2/cm2/index-xml.js
@@ -1,0 +1,16 @@
+// This is a manifest file that'll be compiled into codemirror, which will include all the files
+// listed below.
+//
+// Any JavaScript/Coffee file within this directory, lib/assets/javascripts, vendor/assets/javascripts,
+// or vendor/assets/javascripts of plugins, if any, can be referenced here using a relative path.
+//
+// It's not advisable to add code directly here, but if you do, it'll appear at the bottom of the
+// the compiled file.
+//
+// WARNING: THE FIRST BLANK LINE MARKS THE END OF WHAT'S TO BE PROCESSED, ANY BLANK LINE SHOULD
+// GO AFTER THE REQUIRES BELOW.
+//
+//= require codemirror
+//= require webui2/cm2/toolbars
+//= require codemirror/modes/xml.js
+//= require webui2/cm2/use-codemirror

--- a/src/api/app/assets/javascripts/webui2/cm2/index.js
+++ b/src/api/app/assets/javascripts/webui2/cm2/index.js
@@ -1,0 +1,66 @@
+// This is a manifest file that'll be compiled into codemirror, which will include all the files
+// listed below.
+//
+// Any JavaScript/Coffee file within this directory, lib/assets/javascripts, vendor/assets/javascripts,
+// or vendor/assets/javascripts of plugins, if any, can be referenced here using a relative path.
+//
+// It's not advisable to add code directly here, but if you do, it'll appear at the bottom of the
+// the compiled file.
+//
+// WARNING: THE FIRST BLANK LINE MARKS THE END OF WHAT'S TO BE PROCESSED, ANY BLANK LINE SHOULD
+// GO AFTER THE REQUIRES BELOW.
+//
+//= require codemirror
+//= require webui2/cm2/toolbars
+//= require webui2/cm2/mode/baselibsconf
+//= require webui2/cm2/mode/prjconf
+//= require codemirror/modes/clike.js
+//= require codemirror/modes/clojure.js
+//= require codemirror/modes/coffeescript.js
+//= require codemirror/modes/commonlisp.js
+//= require codemirror/modes/css.js
+//= require codemirror/modes/diff.js
+//= require codemirror/modes/ecl.js
+//= require codemirror/modes/erlang.js
+//= require codemirror/modes/gfm.js
+//= require codemirror/modes/go.js
+//= require codemirror/modes/groovy.js
+//= require codemirror/modes/haskell.js
+//= require codemirror/modes/haxe.js
+//= require codemirror/modes/htmlembedded.js
+//= require codemirror/modes/htmlmixed.js
+//= require codemirror/modes/javascript.js
+//= require codemirror/modes/jinja2.js
+//= require codemirror/modes/lua.js
+//= require codemirror/modes/markdown.js
+//= require codemirror/modes/ntriples.js
+//= require codemirror/modes/pascal.js
+//= require codemirror/modes/perl.js
+//= require codemirror/modes/php.js
+//= require codemirror/modes/pig.js
+//= require codemirror/modes/properties.js
+//= require codemirror/modes/python.js
+//= require codemirror/modes/r.js
+//= require codemirror/modes/rpm
+//= require codemirror/modes/rst.js
+//= require codemirror/modes/ruby.js
+//= require codemirror/modes/scheme.js
+//= require codemirror/modes/shell.js
+//= require codemirror/modes/sieve.js
+//= require codemirror/modes/smalltalk.js
+//= require codemirror/modes/smarty.js
+//= require codemirror/modes/sparql.js
+//= require codemirror/modes/stex.js
+//= require codemirror/modes/tiddlywiki.js
+//= require codemirror/modes/tiki.js
+//= require codemirror/modes/vb.js
+//= require codemirror/modes/vbscript.js
+//= require codemirror/modes/velocity.js
+//= require codemirror/modes/verilog.js
+//= require codemirror/modes/xml.js
+//= require codemirror/modes/xquery.js
+//= require codemirror/modes/yaml.js
+//= require codemirror/modes/yaml.js
+//= require webui2/cm2/use-codemirror
+//= require webui2/cm2/mode/simple.js
+//= require webui2/cm2/mode/dockerfile.js

--- a/src/api/app/assets/javascripts/webui2/cm2/mode/baselibsconf.js
+++ b/src/api/app/assets/javascripts/webui2/cm2/mode/baselibsconf.js
@@ -1,0 +1,70 @@
+// Quick and dirty baselibs.conf file highlighting
+//
+// reuses "spec" and "diff" mode styles
+
+CodeMirror.defineMode("baselibsconf", function(config, modeConfig) {
+  var directive = /^\s+(arch|targettype|targetarch|prefix|legacyversion|extension|configdir|targetname|requires|prereq|provides|conflicts|recommends|suggests|supplements|obsoletes|autoreqprov|pre\(in\)|preun|pre|post\(in\)|postun|post|baselib|config)/;
+  var file_inclusion = /^\s+\+.*/;
+  var control_flow_complex = /^%(ifnarch|ifarch|if)/; // rpm control flow macros
+  var control_flow_simple = /^%(else|endif)/; // rpm control flow macros
+  var operators = /^(\!|\?|\<\=|\<|\>\=|\>|\=\=|\&\&|\|\|)/; // operators in control flow macros
+  var macro = /^\<(extension|name|version|targettype|prefix)\>/;
+
+  return {
+    startState: function () {
+        return {
+          controlFlow: false,
+          macroParameters: false,
+          directive: false
+        };
+    },
+    token: function (stream, state) {
+      var ch = stream.peek();
+      if (stream.sol()) {
+        if (ch == "#") { stream.skipToEnd(); return "comment"; }
+        if (stream.match(/^\w+[\w\-\._]+/)) {
+          state.directive = false;
+          return "preamble";
+        }
+        if (stream.match(file_inclusion)) { return "plus"; }
+        if (stream.match(directive)) {
+          // TODO: Custom handling for various directives, e.g. red color for "requires -gtk2-<targettype>"
+          state.directive = true;
+          return "section";
+        }
+      }
+
+      if (stream.match(macro)) { return "macro"; } // Stuff like '<targettype>'
+
+      if (stream.match(/^\$\w+/)) { return "def"; } // Variables like '$RPM_BUILD_ROOT'
+      if (stream.match(/^\$\{\w+\}/)) { return "def"; } // Variables like '${RPM_BUILD_ROOT}'
+
+      if (state.controlFlow) {
+        if (stream.match(operators)) { return "operator"; }
+        if (stream.match(/^(\d+)/)) { return "number"; }
+        if (stream.eol()) { state.controlFlow = false; }
+      }
+
+      // Macros like '%make_install' or '%attr(0775,root,root)'
+      if (stream.match(/^%[\w]+/)) {
+        if (stream.match(/^\(/)) { state.macroParameters = true; }
+        return "macro";
+      }
+      if (state.macroParameters) {
+        if (stream.match(/^\d+/)) { return "number";}
+        if (stream.match(/^\)/)) {
+          state.macroParameters = false;
+          return "macro";
+        }
+      }
+      if (stream.match(/^%\{\??[\w \-]+\}/)) { return "macro"; } // Macros like '%{defined fedora}'
+
+      //TODO: Include bash script sub-parser (CodeMirror supports that)
+      stream.next();
+      return null;
+    }
+  };
+});
+
+CodeMirror.defineMIME("text/vnd.openbuildservice.baselibsconf", "baselibsconf");
+

--- a/src/api/app/assets/javascripts/webui2/cm2/mode/dockerfile.js
+++ b/src/api/app/assets/javascripts/webui2/cm2/mode/dockerfile.js
@@ -1,0 +1,79 @@
+// CodeMirror, copyright (c) by Marijn Haverbeke and others
+// Distributed under an MIT license: http://codemirror.net/LICENSE
+
+(function(mod) {
+  if (typeof exports == "object" && typeof module == "object") // CommonJS
+    mod(require("../../lib/codemirror"), require("../../addon/mode/simple"));
+  else if (typeof define == "function" && define.amd) // AMD
+    define(["../../lib/codemirror", "../../addon/mode/simple"], mod);
+  else // Plain browser env
+    mod(CodeMirror);
+})(function(CodeMirror) {
+  "use strict";
+
+  // Collect all Dockerfile directives
+  var instructions = ["from", "maintainer", "run", "cmd", "expose", "env",
+                      "add", "copy", "entrypoint", "volume", "user",
+                      "workdir", "onbuild"],
+      instructionRegex = "(" + instructions.join('|') + ")",
+      instructionOnlyLine = new RegExp(instructionRegex + "\\s*$", "i"),
+      instructionWithArguments = new RegExp(instructionRegex + "(\\s+)", "i");
+
+  CodeMirror.defineSimpleMode("dockerfile", {
+    start: [
+      // Block comment: This is a line starting with a comment
+      {
+        regex: /#.*$/,
+        token: "comment"
+      },
+      // Highlight an instruction without any arguments (for convenience)
+      {
+        regex: instructionOnlyLine,
+        token: "variable-2"
+      },
+      // Highlight an instruction followed by arguments
+      {
+        regex: instructionWithArguments,
+        token: ["variable-2", null],
+        next: "arguments"
+      },
+      {
+        regex: /./,
+        token: null
+      }
+    ],
+    arguments: [
+      {
+        // Line comment without instruction arguments is an error
+        regex: /#.*$/,
+        token: "error",
+        next: "start"
+      },
+      {
+        regex: /[^#]+\\$/,
+        token: null
+      },
+      {
+        // Match everything except for the inline comment
+        regex: /[^#]+/,
+        token: null,
+        next: "start"
+      },
+      {
+        regex: /$/,
+        token: null,
+        next: "start"
+      },
+      // Fail safe return to start
+      {
+        token: null,
+        next: "start"
+      }
+    ],
+      meta: {
+          lineComment: "#"
+      }
+  });
+
+  CodeMirror.defineMIME("text/x-dockerfile", "dockerfile");
+});

--- a/src/api/app/assets/javascripts/webui2/cm2/mode/prjconf.js
+++ b/src/api/app/assets/javascripts/webui2/cm2/mode/prjconf.js
@@ -1,0 +1,76 @@
+// Quick and dirty prjconf file highlighting
+
+CodeMirror.defineMode("prjconf", function(config, modeConfig) {
+  var arch = /^(i386|i586|i686|x86_64|ppc64|ppc|ia64|s390x|s390|sparc64|sparcv9|sparc|noarch|alphaev6|alpha|hppa|mipsel)/;
+  var prjconf = /^(Conflict|Ignore|Keep|Macros|Optflags|Order|Prefer|ExportFilter|Type|Patterntype|Preinstall|Repotype|Required|Runscripts|Substitute|Support|VMinstall):/;
+  var control_flow_complex = /^%(ifnarch|ifarch|if)/; // rpm control flow macros
+  var control_flow_simple = /^%(else|endif)/; // rpm control flow macros
+  var operators = /^(\!|\?|\<\=|\<|\>\=|\>|\=\=|\&\&|\|\|)/; // operators in control flow macros
+
+  return {
+    startState: function () {
+        return {
+          controlFlow: false,
+          exportFilter: false,
+          macroParameters: false,
+        };
+    },
+    token: function (stream, state) {
+      var ch = stream.peek();
+      if (ch == "#") { stream.skipToEnd(); return "comment"; }
+
+      if (state.exportFilter) {
+        state.exportFilter = false;
+        if (stream.match(/^.*\$/)) {
+          return "string";
+        }
+      }
+
+      if (stream.sol()) {
+        var match = stream.match(prjconf);
+        if (match) {
+          if (match[0] == "ExportFilter:") {
+            state.exportFilter = true;
+          }
+          return "builtin";
+        }
+      }
+
+      if (stream.match(/^\$\w+/)) { return "def"; } // Variables like '$RPM_BUILD_ROOT'
+      if (stream.match(/^\$\{\w+\}/)) { return "def"; } // Variables like '${RPM_BUILD_ROOT}'
+
+      if (stream.match(control_flow_simple)) { return "keyword"; }
+      if (stream.match(control_flow_complex)) {
+        state.controlFlow = true;
+        return "keyword";
+      }
+      if (state.controlFlow) {
+        if (stream.match(operators)) { return "operator"; }
+        if (stream.match(/^(\d+)/)) { return "number"; }
+        if (stream.eol()) { state.controlFlow = false; }
+      }
+
+      if (stream.match(arch)) { return "number"; }
+
+      // Macros like '%make_install' or '%attr(0775,root,root)'
+      if (stream.match(/^%[\w]+/)) {
+        if (stream.match(/^\(/)) { state.macroParameters = true; }
+        return "macro";
+      }
+      if (state.macroParameters) {
+        if (stream.match(/^\d+/)) { return "number";}
+        if (stream.match(/^\)/)) {
+          state.macroParameters = false;
+          return "macro";
+        }
+      }
+      if (stream.match(/^%\{\??[\w \-]+\}/)) { return "macro"; } // Macros like '%{defined fedora}'
+
+      //TODO: Include bash script sub-parser (CodeMirror supports that)
+      stream.next();
+      return null;
+    }
+  };
+});
+
+CodeMirror.defineMIME("text/vnd.openbuildservice.prjconf", "prjconf");

--- a/src/api/app/assets/javascripts/webui2/cm2/mode/simple.js
+++ b/src/api/app/assets/javascripts/webui2/cm2/mode/simple.js
@@ -1,0 +1,216 @@
+// CodeMirror, copyright (c) by Marijn Haverbeke and others
+// Distributed under an MIT license: http://codemirror.net/LICENSE
+
+(function(mod) {
+  if (typeof exports == "object" && typeof module == "object") // CommonJS
+    mod(require("../../lib/codemirror"));
+  else if (typeof define == "function" && define.amd) // AMD
+    define(["../../lib/codemirror"], mod);
+  else // Plain browser env
+    mod(CodeMirror);
+})(function(CodeMirror) {
+  "use strict";
+
+  CodeMirror.defineSimpleMode = function(name, states) {
+    CodeMirror.defineMode(name, function(config) {
+      return CodeMirror.simpleMode(config, states);
+    });
+  };
+
+  CodeMirror.simpleMode = function(config, states) {
+    ensureState(states, "start");
+    var states_ = {}, meta = states.meta || {}, hasIndentation = false;
+    for (var state in states) if (state != meta && states.hasOwnProperty(state)) {
+      var list = states_[state] = [], orig = states[state];
+      for (var i = 0; i < orig.length; i++) {
+        var data = orig[i];
+        list.push(new Rule(data, states));
+        if (data.indent || data.dedent) hasIndentation = true;
+      }
+    }
+    var mode = {
+      startState: function() {
+        return {state: "start", pending: null,
+                local: null, localState: null,
+                indent: hasIndentation ? [] : null};
+      },
+      copyState: function(state) {
+        var s = {state: state.state, pending: state.pending,
+                 local: state.local, localState: null,
+                 indent: state.indent && state.indent.slice(0)};
+        if (state.localState)
+          s.localState = CodeMirror.copyState(state.local.mode, state.localState);
+        if (state.stack)
+          s.stack = state.stack.slice(0);
+        for (var pers = state.persistentStates; pers; pers = pers.next)
+          s.persistentStates = {mode: pers.mode,
+                                spec: pers.spec,
+                                state: pers.state == state.localState ? s.localState : CodeMirror.copyState(pers.mode, pers.state),
+                                next: s.persistentStates};
+        return s;
+      },
+      token: tokenFunction(states_, config),
+      innerMode: function(state) { return state.local && {mode: state.local.mode, state: state.localState}; },
+      indent: indentFunction(states_, meta)
+    };
+    if (meta) for (var prop in meta) if (meta.hasOwnProperty(prop))
+      mode[prop] = meta[prop];
+    return mode;
+  };
+
+  function ensureState(states, name) {
+    if (!states.hasOwnProperty(name))
+      throw new Error("Undefined state " + name + " in simple mode");
+  }
+
+  function toRegex(val, caret) {
+    if (!val) return /(?:)/;
+    var flags = "";
+    if (val instanceof RegExp) {
+      if (val.ignoreCase) flags = "i";
+      val = val.source;
+    } else {
+      val = String(val);
+    }
+    return new RegExp((caret === false ? "" : "^") + "(?:" + val + ")", flags);
+  }
+
+  function asToken(val) {
+    if (!val) return null;
+    if (val.apply) return val
+    if (typeof val == "string") return val.replace(/\./g, " ");
+    var result = [];
+    for (var i = 0; i < val.length; i++)
+      result.push(val[i] && val[i].replace(/\./g, " "));
+    return result;
+  }
+
+  function Rule(data, states) {
+    if (data.next || data.push) ensureState(states, data.next || data.push);
+    this.regex = toRegex(data.regex);
+    this.token = asToken(data.token);
+    this.data = data;
+  }
+
+  function tokenFunction(states, config) {
+    return function(stream, state) {
+      if (state.pending) {
+        var pend = state.pending.shift();
+        if (state.pending.length == 0) state.pending = null;
+        stream.pos += pend.text.length;
+        return pend.token;
+      }
+
+      if (state.local) {
+        if (state.local.end && stream.match(state.local.end)) {
+          var tok = state.local.endToken || null;
+          state.local = state.localState = null;
+          return tok;
+        } else {
+          var tok = state.local.mode.token(stream, state.localState), m;
+          if (state.local.endScan && (m = state.local.endScan.exec(stream.current())))
+            stream.pos = stream.start + m.index;
+          return tok;
+        }
+      }
+
+      var curState = states[state.state];
+      for (var i = 0; i < curState.length; i++) {
+        var rule = curState[i];
+        var matches = (!rule.data.sol || stream.sol()) && stream.match(rule.regex);
+        if (matches) {
+          if (rule.data.next) {
+            state.state = rule.data.next;
+          } else if (rule.data.push) {
+            (state.stack || (state.stack = [])).push(state.state);
+            state.state = rule.data.push;
+          } else if (rule.data.pop && state.stack && state.stack.length) {
+            state.state = state.stack.pop();
+          }
+
+          if (rule.data.mode)
+            enterLocalMode(config, state, rule.data.mode, rule.token);
+          if (rule.data.indent)
+            state.indent.push(stream.indentation() + config.indentUnit);
+          if (rule.data.dedent)
+            state.indent.pop();
+          var token = rule.token
+          if (token && token.apply) token = token(matches)
+          if (matches.length > 2 && rule.token && typeof rule.token != "string") {
+            state.pending = [];
+            for (var j = 2; j < matches.length; j++)
+              if (matches[j])
+                state.pending.push({text: matches[j], token: rule.token[j - 1]});
+            stream.backUp(matches[0].length - (matches[1] ? matches[1].length : 0));
+            return token[0];
+          } else if (token && token.join) {
+            return token[0];
+          } else {
+            return token;
+          }
+        }
+      }
+      stream.next();
+      return null;
+    };
+  }
+
+  function cmp(a, b) {
+    if (a === b) return true;
+    if (!a || typeof a != "object" || !b || typeof b != "object") return false;
+    var props = 0;
+    for (var prop in a) if (a.hasOwnProperty(prop)) {
+      if (!b.hasOwnProperty(prop) || !cmp(a[prop], b[prop])) return false;
+      props++;
+    }
+    for (var prop in b) if (b.hasOwnProperty(prop)) props--;
+    return props == 0;
+  }
+
+  function enterLocalMode(config, state, spec, token) {
+    var pers;
+    if (spec.persistent) for (var p = state.persistentStates; p && !pers; p = p.next)
+      if (spec.spec ? cmp(spec.spec, p.spec) : spec.mode == p.mode) pers = p;
+    var mode = pers ? pers.mode : spec.mode || CodeMirror.getMode(config, spec.spec);
+    var lState = pers ? pers.state : CodeMirror.startState(mode);
+    if (spec.persistent && !pers)
+      state.persistentStates = {mode: mode, spec: spec.spec, state: lState, next: state.persistentStates};
+
+    state.localState = lState;
+    state.local = {mode: mode,
+                   end: spec.end && toRegex(spec.end),
+                   endScan: spec.end && spec.forceEnd !== false && toRegex(spec.end, false),
+                   endToken: token && token.join ? token[token.length - 1] : token};
+  }
+
+  function indexOf(val, arr) {
+    for (var i = 0; i < arr.length; i++) if (arr[i] === val) return true;
+  }
+
+  function indentFunction(states, meta) {
+    return function(state, textAfter, line) {
+      if (state.local && state.local.mode.indent)
+        return state.local.mode.indent(state.localState, textAfter, line);
+      if (state.indent == null || state.local || meta.dontIndentStates && indexOf(state.state, meta.dontIndentStates) > -1)
+        return CodeMirror.Pass;
+
+      var pos = state.indent.length - 1, rules = states[state.state];
+      scan: for (;;) {
+        for (var i = 0; i < rules.length; i++) {
+          var rule = rules[i];
+          if (rule.data.dedent && rule.data.dedentIfLineStart !== false) {
+            var m = rule.regex.exec(textAfter);
+            if (m && m[0]) {
+              pos--;
+              if (rule.next || rule.push) rules = states[rule.next || rule.push];
+              textAfter = textAfter.slice(m[0].length);
+              continue scan;
+            }
+          }
+        }
+        break;
+      }
+      return pos < 0 ? 0 : state.indent[pos];
+    };
+  }
+});

--- a/src/api/app/assets/javascripts/webui2/cm2/toolbars.js
+++ b/src/api/app/assets/javascripts/webui2/cm2/toolbars.js
@@ -1,0 +1,596 @@
+(function(mod) {
+	  if (typeof exports == "object" && typeof module == "object") // CommonJS
+	    mod(require("../../lib/codemirror"));
+  else if (typeof define == "function" && define.amd) // AMD
+	    define(["../../lib/codemirror"], mod);
+  else // Plain browser env
+	    mod(CodeMirror);
+})(function(CodeMirror) {
+    var cm_instance;
+    CodeMirror.defaults.addToolBars 	= 0;
+    CodeMirror.defaults.supportedTypes 	= [];
+    CodeMirror.defaults.fileType 		= null;
+    CodeMirror.defaults.allowedFontSizes 	= [];
+    CodeMirror.defaults.fontSize 		= '9pt';
+    CodeMirror.defineInitHook(function(cm) {
+	this.cm = cm;
+	var bartype = this.cm.getOption("addToolBars");
+        this.cm.on('cursorActivity', function(cm) { update_toolbar_position(cm)});
+	if(bartype > 0) this.cm.buildToolBars(bartype);
+    });
+
+    function buildToolBars(cm, bartype) {
+	if(bartype == 0) return;
+	this.cm = cm;
+	if(typeof(cm_instance) == 'undefined') {
+	    cm_instance = new Array();
+	    var cm_counter = 0;
+	}
+	else {
+	    cm_counter++;
+	}
+	cm_instance[cm_counter] = this.cm;
+	this.cm.id = cm_counter;
+	var onUpdateValue = this.cm.getOption('onUpdate');
+	this.cm.setOption('onUpdate', '');
+	var slot1 = bartype == 1 ? '' : searchSpan(this.cm.id) ;
+	var slot2 = bartype == 1 ? sizeSpan(this.cm.id) : positionSpan(this.cm.id) ;
+	var wrapper = this.cm.getWrapperElement();
+	var container = wrapper.parentNode;
+	this.cm.topBar = document.createElement("DIV");
+	this.cm.topBar.setAttribute("id", "top_"+this.cm.id);
+	container.insertBefore(this.cm.topBar, wrapper);
+	this.cm.topBar.innerHTML = buildtop(slot1, this.cm.id);
+	this.cm.bottomBar = document.createElement("DIV");
+	this.cm.bottomBar.setAttribute("id", "bottom_"+this.cm.id);
+	container.insertBefore(this.cm.bottomBar, wrapper.nextSibling);
+	this.cm.bottomBar.innerHTML = buildbottom(slot2, this.cm.id);
+	this.cm.width = this.cm.getWrapperElement().offsetWidth;
+	this.cm.bottomBar.style.width = '' + String(this.cm.width) + 'px';
+	this.cm.topBar.style.width =    '' + String(this.cm.width) + 'px';
+	//this.cm.setOption('onUpdate', onUpdateValue);
+	//this.cm.prependOption('onUpdate', setWidth);
+	this.cm.prependOption('onChange', updateHistory);
+	//this.cm.prependOption('onCursorActivity', getPosition);
+	this.cm.setSelections();
+    }
+
+    CodeMirror.defineExtension("buildToolBars", function(bartype) {
+	return new buildToolBars(this, bartype);
+    });
+
+    function prependOption(cm, name, value) {
+	this.cm = cm;
+	return;
+    }
+
+    CodeMirror.defineExtension("prependOption", function(name,value) {
+	return new prependOption(this, name, value);
+    });
+
+    function setWidth(cm) {
+	this.cm = cm;
+	if(typeof(this.cm.id) == 'undefined') return;
+	var width = '' + String(this.cm.getWrapperElement().offsetWidth) + 'px';
+	document.getElementById('top_'+this.cm.id).style.width = width;
+	document.getElementById('bottom_'+this.cm.id).style.width = width;
+    }
+
+    CodeMirror.defineExtension("setWidth", function() {
+	return new setWidth(this);
+    });
+
+    function updateHistory(cm) {
+	this.cm = cm;
+	document.getElementById('undo_'+this.cm.id).style.backgroundColor = this.cm.historySize().undo>0 ? '' : 'transparent' ;
+	document.getElementById('redo_'+this.cm.id).style.backgroundColor = this.cm.historySize().redo>0 ? '' : 'transparent' ;
+    }
+
+    CodeMirror.defineExtension("updateHistory", function() {
+	return new updateHistory(this);
+    });
+
+    function update_toolbar_position(cm) {
+	this.cm = cm;
+	var position = this.cm.getCursor(true);
+	var line = position.line + this.cm.getOption('firstLineNumber');
+	if(document.getElementById('ln_'+this.cm.id) != null) document.getElementById('ln_'+this.cm.id).innerHTML = line;
+	if(document.getElementById('ch_'+this.cm.id) != null) document.getElementById('ch_'+this.cm.id).innerHTML = position.ch;
+	if(document.getElementById('match_'+this.cm.id).value == 'on') {
+	    this.cm.matchHighlight("CodeMirror-matchhighlight");
+	}
+    }
+
+    CodeMirror.defineExtension("getPosition", function() {
+	return new getPosition(this);
+    });
+
+    function setSelections(cm) {
+	this.cm = cm;
+	var options = this.cm.getOption('supportedTypes');
+	var modeSelector = document.getElementById('mode_'+this.cm.id);
+	if(typeof this.cm.getOption('supportedTypes')[0] != 'undefined') {
+	    modeSelector.innerHTML = '';
+	    for(var i=0;i<options.length;i++) {
+		var option = document.createElement('OPTION');
+		option.setAttribute('id', options[i].fileType+'_'+this.cm.id);
+		option.setAttribute('value', options[i].mode);
+		option.innerHTML = options[i].fileType;
+		modeSelector.appendChild(option);
+	    }
+	}
+	var selectedType = this.cm.getOption('fileType');
+	if(selectedType != null) {
+	    modeSelector.value = document.getElementById(selectedType+'_'+this.cm.id).value;
+	    this.cm.setOption('mode', modeSelector.value);
+	}
+	options = this.cm.getOption('allowedFontSizes');
+	var fontSelector = document.getElementById('fontsize_'+this.cm.id);
+	if(typeof this.cm.getOption('allowedFontSizes')[0] != 'undefined') {
+	    fontSelector.innerHTML = '';
+	    for(i=0;i<options.length;i++) {
+		var option = document.createElement('OPTION');
+		option.setAttribute('value', options[i]);
+		option.innerHTML = options[i];
+		fontSelector.appendChild(option);
+	    }
+	}
+	fontSelector.value = this.cm.getOption('fontSize');
+	this.cm.getWrapperElement().style.fontSize = fontSelector.value;
+	var tabSelector = document.getElementById('tabsize_'+this.cm.id);
+	if(tabSelector != null) tabSelector.value = this.cm.getOption('tabSize');
+	var smartOnoff = document.getElementById('smart_'+this.cm.id);
+	if(smartOnoff != null) smartOnoff.value = this.cm.getOption('smartIndent') ? 'on' : 'off' ;
+    }
+
+    CodeMirror.defineExtension("setSelections", function() {
+	return new setSelections(this);
+    });
+
+    var cursor;
+    var marked = Array();
+    var search;
+    var replace;
+    function Search(cm, elt) {
+        var query, begin;
+
+	this.cm = cm;
+	elt.value = elt.value == 'on' ? 'off' : 'on' ;
+	document.getElementById('find_'+this.cm.id).style.display = 'inline';
+	document.getElementById('prenex_'+this.cm.id).style.display = 'none';
+	var S = document.getElementById('search_'+this.cm.id);
+	var R = document.getElementById('replace_'+this.cm.id);
+	if(elt.value == 'on') {
+	    S.removeAttribute('disabled');
+	    S.style.backgroundColor = '';
+	    R.removeAttribute('disabled');
+	    R.style.backgroundColor = '';
+
+	    if(this.cm.somethingSelected()) {
+		query = this.cm.getSelection();
+		S.value = query;
+		begin = this.cm.getCursor(true);
+	    }
+	    else {
+		begin = getBegin(cm);
+	    }
+	}
+	else if(elt.value == 'off') {
+	    S.setAttribute('disabled', true);
+	    S.style.backgroundColor = 'transparent';
+	    R.setAttribute('disabled', true);
+	    R.style.backgroundColor = 'transparent';
+	    S.value = '';
+	    R.value = '';
+	    for(var i=0; i<marked.length; i++) {
+		marked[i].clear();
+	    }
+	    cursor= null;
+	    if(typeof(mark) != 'undefined') mark.clear();
+	    marked = [];
+	    begin = null;
+	}
+	elt.blur();
+    }
+
+    CodeMirror.defineExtension("Search", function(elt) {
+	return new Search(this, elt);
+    });
+
+    function Find(cm, elt) {
+        var found, mark;
+
+	this.cm = cm;
+	var S = document.getElementById('search_'+this.cm.id);
+	if(S.disabled) return;
+	if(S.value == '') {
+	    document.getElementById('search_'+this.cm.id).style.background = '#ffffcc';
+	    return;
+	}
+	this.cm.focus();
+	elt.style.display = 'none';
+	document.getElementById('prenex_'+this.cm.id).style.display = 'inline';
+	query = S.value;
+	cursor = this.cm.getSearchCursor(query, begin);
+	console.log(cursor);
+	found = cursor.findNext();
+	var firstFound = cursor;
+	begin = null;
+	begin = {line:cursor.from().line, ch:cursor.from().ch};
+	cursor = this.cm.getSearchCursor(query, {line:0, ch:0});
+
+	for(;;) {
+	    found = cursor.findNext();
+	    if(found == false) {
+		cursor = null;
+		break;
+	    }
+	    if(typeof(cursor.from()) != 'undefined' && typeof(begin) != 'undefined') {
+		if(cursor.from().line == begin.line && cursor.from().ch == begin.ch) {
+		    mark = this.cm.markText(cursor.from(), cursor.to(), 'CodeMirror-markSelected');
+		    marked.push(mark);
+		}
+		else {
+		    mark = this.cm.markText(cursor.from(), cursor.to(), 'CodeMirror-markFound');
+		    marked.push(mark);
+		}
+	    }
+	    this.cm.setSelection(firstFound.from(), firstFound.to());
+	}
+    }
+
+    CodeMirror.defineExtension("Find", function(elt) {
+	return new Find(this, elt);
+    });
+
+    function Next(cm, elt) {
+	this.cm = cm;
+	if(cursor == null) {
+	    cursor = this.cm.getSearchCursor(query, begin);
+	    cursor.findNext();
+	}
+	if(typeof(mark) != 'undefined') mark.clear();
+	var found = cursor.findNext();
+	if(found == true) {
+	    mark = this.cm.markText(cursor.from(), cursor.to(), 'CodeMirror-markNextPrev');
+	    marked.push(mark);
+	    this.cm.setSelection(cursor.from(), cursor.to());
+	}
+	else {
+	    cursor = this.cm.getSearchCursor(query, {line:0,ch:0});
+	}
+	return;
+    }
+
+    CodeMirror.defineExtension("Next", function(elt) {
+	return new Next(this, elt);
+    });
+
+    function Prev(cm, elt) {
+	this.cm = cm;
+	if(cursor == null) {
+	    cursor = this.cm.getSearchCursor(query, begin);
+	}
+	if(typeof(mark) != 'undefined') mark.clear();
+	var found = cursor.findPrevious();
+	if(found != false){
+	    mark = this.cm.markText(cursor.from(), cursor.to(), 'CodeMirror-markNextPrev');
+	    marked.push(mark);
+	    this.cm.setSelection(cursor.from(), cursor.to());
+	}
+	return;
+    }
+
+    CodeMirror.defineExtension("Prev", function(elt) {
+	return new Prev(this, elt);
+    });
+
+    function Replace(cm, elt) {
+	this.cm = cm;
+	if(cursor == null) {
+	    cursor = this.cm.getSearchCursor(query, begin);
+	    cursor.findNext();
+	}
+	var replace = document.getElementById('replace_'+this.cm.id).value;
+	cursor.replace(replace);
+	if(typeof(mark) != 'undefined') mark.clear();
+	found = cursor.findNext();
+	mark = this.cm.markText(cursor.from(), cursor.to(), 'CodeMirror-markNextPrev');
+	marked.push(mark);
+	this.cm.setSelection(cursor.from(), cursor.to());
+    }
+
+    CodeMirror.defineExtension("Replace", function(elt) {
+	return new Replace(this, elt);
+    });
+
+    function ReplaceAll(cm, elt) {
+	this.cm = cm;
+	cursor = this.cm.getSearchCursor(query, {line:0, ch:0});
+	var replace = document.getElementById('replace_'+this.cm.id).value;
+	for(;;) {
+	    found = cursor.findNext();
+	    if(found == false) {
+		cursor = null;
+		break;
+	    }
+	    cursor.replace(replace);
+	}
+    }
+
+    CodeMirror.defineExtension("ReplaceAll", function(elt) {
+	return new ReplaceAll(this, elt);
+    });
+
+    function Match(cm, elt) {
+	this.cm = cm;
+	if(elt.value == 'on') {
+	    var position = this.cm.getCursor(false);
+	    this.cm.setCursor(position);
+	}
+	elt.value  = elt.value == 'on' ? 'off'   : 'on' ;
+    }
+
+    CodeMirror.defineExtension("Match", function(elt) {
+	return new Match(this, elt);
+    });
+
+    function Undo(cm, elt) {
+	this.cm = cm;
+	this.cm.undo();
+	elt.blur();
+    }
+
+    CodeMirror.defineExtension("Undo", function(elt) {
+	return new Undo(this, elt);
+    });
+
+    function Redo(cm, elt) {
+	this.cm = cm;
+	this.cm.redo();
+	elt.blur();
+    }
+
+    CodeMirror.defineExtension("Redo", function(elt) {
+	return new Redo(this, elt);
+    });
+
+    function updateFontsize(cm, elt) {
+	this.cm = cm;
+	this.cm.getWrapperElement().style.fontSize = elt.value;
+	this.cm.refresh();
+	elt.blur();
+    }
+
+    CodeMirror.defineExtension("updateFontsize", function(elt) {
+	return new updateFontsize(this, elt);
+    });
+
+    function updateMode(cm, elt) {
+	this.cm = cm;
+	this.cm.setOption("mode", elt.value);
+	elt.blur();
+    }
+
+    CodeMirror.defineExtension("updateMode", function(elt) {
+	return new updateMode(this, elt);
+    });
+
+    function SmartIndent(cm, elt) {
+	this.cm = cm;
+	elt.value  = elt.value == 'on' ? 'off'   : 'on' ;
+	if(elt.value == 'on') {
+	    this.cm.setOption('smartIndent', true);
+	    this.cm.setOption('electricChars', true);
+	    this.cm.setOption('extraKeys', {"Shift-Tab": "indentLess"});
+	}
+	else {
+	    this.cm.setOption('smartIndent', false);
+	    this.cm.setOption('electricChars', false);
+	    this.cm.setOption('extraKeys', {"Tab": "defaultTab", "Shift-Tab": "indentLess"});
+	}
+    }
+
+
+    CodeMirror.defineExtension("SmartIndent", function(elt) {
+	return new SmartIndent(this, elt);
+    });
+
+    function autoFormat(cm, elt) {
+	this.cm = cm;
+	if(this.cm.somethingSelected()) {
+	    this.cm.autoFormatRange(this.cm.getCursor(true), this.cm.getCursor(false));
+	}
+	else {
+	    var totalLines = this.cm.lineCount();
+	    var totalChars = this.cm.getValue().length;
+	    this.cm.autoFormatRange(
+		{line: 0, ch: 0},
+		{line: totalLines - 1, ch: this.cm.getLine(totalLines - 1).length}
+	    );
+	}
+	elt.blur();
+    }
+
+    CodeMirror.defineExtension("autoFormat", function(elt) {
+	return new autoFormat(this, elt);
+    });
+
+    function updateTabsize(cm, elt) {
+	this.cm = cm;
+	this.cm.setOption("tabSize", Number(elt.value));
+	this.cm.setOption("indentUnit", Number(elt.value));
+	elt.blur();
+    }
+
+    CodeMirror.defineExtension("updateTabsize", function(elt) {
+	return new updateTabsize(this, elt);
+    });
+
+
+    function gotoLine(cm, elt) {
+	this.cm = cm;
+	this.ln = document.getElementById('line_'+this.cm.id).value - this.cm.getOption('firstLineNumber');
+	this.cm.focus();
+	this.cm.setCursor(this.ln, 0);
+	this.cm.scrollIntoView(null);
+	document.getElementById('line_'+this.cm.id).blur();
+    }
+
+    CodeMirror.defineExtension("gotoLine", function(elt) {
+	return new gotoLine(this, elt);
+    });
+
+    function Wrap(cm, elt) {
+	this.cm = cm;
+	elt.value = elt.value == 'on' ? 'off' : 'on' ;
+	this.value = elt.value == 'on' ;
+	this.cm.setOption('lineWrapping', this.value);
+    }
+
+    CodeMirror.defineExtension("Wrap", function(elt) {
+	return new Wrap(this, elt);
+    });
+
+    function increase(cm, elt) {
+	this.cm = cm;
+	this.height = this.cm.getScrollerElement().offsetHeight + 40;
+	this.width  = this.cm.getWrapperElement().offsetWidth + 65;
+	this.cm.setSize(this.width, this.height);
+	document.body.scrollTop += 40;
+	elt.blur();
+    }
+
+    CodeMirror.defineExtension("increase", function(elt) {
+	return new increase(this, elt);
+    });
+
+    function decrease(cm, elt) {
+	this.cm = cm;
+	this.height = this.cm.getScrollerElement().offsetHeight - 40;
+	this.width  = this.cm.getWrapperElement().offsetWidth - 69;
+	this.cm.setSize(this.width, this.height);
+	document.body.scrollTop -= 40;
+	elt.blur();
+    }
+
+    CodeMirror.defineExtension("decrease", function(elt) {
+	return new decrease(this, elt);
+    });
+
+    function getBegin(cm) {
+	this.cm = cm;
+	var info = this.cm.getScrollInfo();
+	var lineHeight= Math.round((info.height - 10)/this.cm.lineCount());
+	var lineNumber = Math.round((info.y-3)/lineHeight);
+	return {line:lineNumber, ch:0};
+    }
+
+    function buildtop(slot, id) {
+	var topbar = ''+
+	    '<div class="toolbar">'+
+	    slot+
+	    '<span style="float:left;">'+
+	    '<span class="text">matching:</span>'+
+	    '<input type="button" id="match_'+id+'" class="tools buttons small" value="off" onclick="cm_instance['+id+'].Match(this);"/>'+
+	    '</span>'+
+	    '<span style="float:right;">'+
+	    '<input type="button" id="undo_'+id+'" value="undo" class="tools buttons undo" style="background:transparent;" onclick="cm_instance['+id+'].Undo(this);"/>'+
+	    '<input type="button" id="redo_'+id+'" value="redo" class="tools buttons redo" style="background:transparent;" onclick="cm_instance['+id+'].Redo(this);"/>'+
+	    '<select class="tools select" id="fontsize_'+id+'" onchange="cm_instance['+id+'].updateFontsize(this)">'+
+	    '<option value="8pt" >	8pt </option>'+
+	    '<option value="9pt" >	9pt </option>'+
+	    '<option value="10pt" >	10pt</option>'+
+	    '<option value="11pt" >	11pt</option>'+
+	    '<option value="12pt" >	12pt</option>'+
+	    '<option value="14pt" >	14pt</option>'+
+	    '</select>'+
+	    '<select class="tools select" id="mode_'+id+'" onchange="cm_instance['+id+'].updateMode(this)">'+
+	    '<option id="css_'+id+'"  value="css" >				css </option>'+
+	    '<option id="html_'+id+'" value="htmlmixed">			html</option>'+
+	    '<option id="js_'+id+'"   value="javascript">			js  </option>'+
+	    '<option id="php_'+id+'"  value="application/x-httpd-php-open">	php </option>'+
+	    '<option id="mysql_'+id+'"value="mysql" >			mysql </option>'+
+	    '<option id="xml_'+id+'"  value="xml" >				xml </option>'+
+	    '<option id="x_'+id+'"    value="" >				--- </option>'+
+	    '</select>'+
+	    '</span>'+
+	    '</div>';
+	return topbar;
+    }
+
+    function buildbottom(slot, id) {
+	var bottombar = ''+
+	    '<div class="toolbar">'+
+	    slot +
+	    '<span style="float:right;">'+
+	    '<span class="text">line:</span>'+
+	    '<input type="text" id="line_'+id+'" class="tools inputs" autocomplete="off" style="width:30px;"onkeydown="if(event.keyCode==13){cm_instance['+id+'].gotoLine(this);}" />'+
+	    '<input type="button" class="tools buttons small" value="go" onclick="cm_instance['+id+'].gotoLine(this);" />'+
+	    '&nbsp;&nbsp;'+
+	    '<span class="text">line wrapping:</span>'+
+	    '<input type="button" class="tools buttons small" value="off" onclick="cm_instance['+id+'].Wrap(this)" />'+
+	    '</span>'+
+	    '</div>';
+	return bottombar;
+    }
+
+    function searchSpan(id) {
+	var searchHTML = ''+
+	    '<span style="float:left;">'+
+	    '<span class="text">search:</span>'+
+	    '<input type="button" class="tools buttons small" value="off" onclick="cm_instance['+id+'].Search(this)" />'+
+	    '<input disabled type="text"  class="tools inputs" style="background:transparent" id="search_'+id+'" autocomplete="off" placeholder="type or select" onkeydown="this.removeAttribute(\'style\');" />'+
+
+	'<span class="prenex" id="prenex_'+id+'" style="display:none;">'+
+	    '<input type="button" class="tools buttons prev" value="&#9668" id="prev_'+id+'" onclick="cm_instance['+id+'].Prev(this)" />'+
+	    '<input type="button" class="tools buttons next" value="&#9658;" id="next_'+id+'" onclick="cm_instance['+id+'].Next(this)" />'+
+	    '</span>'+
+
+	'<input type="button" class="tools buttons small" style="width:36px;" value="find" id="find_'+id+'" onclick="cm_instance['+id+'].Find(this)" />'+
+	    '&nbsp;&nbsp;'+
+	    '<span class="text">replace:</span>'+
+	    '<input disabled type="text" class="tools inputs" style="background:transparent" id="replace_'+id+'"  autocomplete="off" />'+
+	    '<input type="button" class="tools buttons medium" value="replace" onclick="cm_instance['+id+'].Replace(this);" />'+
+	    '<input type="button" class="tools buttons medium" value="replace all" onclick="cm_instance['+id+'].ReplaceAll(this);" />'+
+	    '&nbsp;&nbsp;&nbsp;'+
+	    '</span>';
+	return searchHTML;
+    }
+
+    function sizeSpan(id) {
+	var sizeHTML = ''+
+	    '<span style="float:left;">'+
+	    '<input type="button" class="tools buttons large" value="increase size" onclick="cm_instance['+id+'].increase(this);" />'+
+	    '<input type="button" class="tools buttons large" value="decrease size" onclick="cm_instance['+id+'].decrease(this);" />'+
+	    '</span>';
+	return sizeHTML;
+    }
+
+    function positionSpan(id) {
+	var positionHTML = ''+
+	    '<span style="float:left;">'+
+	    '<span class="text">position</span>'+
+	    '&nbsp;&nbsp;'+
+	    '<span class="text">line:</span>'+
+	    '<span id="ln_'+id+'" class="text" style="display:inline-block;width:30px;">0</span>'+
+	    '<span class="text">char:</span>'+
+	    '<span id="ch_'+id+'" class="text" style="display:inline-block;width:30px;">0</span>'+
+	    '<span class="text">auto-indent:</span>'+
+	    '<input type="button" class="tools buttons small" value="off" onclick="cm_instance['+id+'].SmartIndent(this)" />'+
+	    '<input type="button" class="tools buttons" style="width:75px;" value="auto-format" onclick="cm_instance['+id+'].autoFormat(this)" />'+
+	    '&nbsp;&nbsp;'+
+	    '<span class="text">tab size:</span>'+
+	    '<select class="tools select" style="min-width:30px;" id="tabsize_'+id+'" onchange="cm_instance['+id+'].updateTabsize(this)">'+
+	    '<option value="2"> 2 </option>'+
+	    '<option value="3"> 3 </option>'+
+	    '<option value="4"> 4 </option>'+
+	    '<option value="5"> 5 </option>'+
+	    '<option value="6"> 6 </option>'+
+	    '<option value="7"> 7 </option>'+
+	    '<option value="8"> 8 </option>'+
+	    '</select>'+
+	    '</span>';
+	return positionHTML;
+    }
+});

--- a/src/api/app/assets/javascripts/webui2/cm2/use-codemirror.js
+++ b/src/api/app/assets/javascripts/webui2/cm2/use-codemirror.js
@@ -1,0 +1,63 @@
+var editors = new Array();
+
+function use_codemirror(id, read_only, mode) {
+  var codeMirrorOptions = {
+    lineNumbers: true,
+    matchBrackets: false,
+    fontSize: '9pt',
+    mode: mode
+  };
+  if (read_only) {
+    codeMirrorOptions['readOnly'] = true;
+  }
+  else {
+    codeMirrorOptions['addToolBars'] = 0;
+    if (mode.length)
+      codeMirrorOptions['mode'] = mode;
+    codeMirrorOptions['extraKeys'] = {"Tab": "defaultTab", "Shift-Tab": "indentLess"};
+  }
+
+  var textarea = $('#editor_' + id);
+  var editor = CodeMirror.fromTextArea(document.getElementById("editor_" + id), codeMirrorOptions);
+  editor.id = id;
+  if (!read_only) {
+    editor.setSelections(editor);
+
+    editor.on('change', function (cm) {
+      var changed = true;
+      cm.updateHistory(cm);
+      if (cm.historySize().undo > 0)
+        $("#save_" + id).removeClass('inactive');
+      else
+        $("#save_" + id).addClass('inactive');
+    });
+    CodeMirror.signal(editor, 'cursorActivity', editor);
+
+  }
+
+  if (textarea.data('save-url')) {
+    $('#save_' + id).click(function () {
+      var data = textarea.data('data');
+      data[data['submit']] = editors[id].getValue();
+      $("#save_" + id).addClass("inactive").addClass("working");
+      $.ajax({
+        url: textarea.data('save-url'),
+        type: (textarea.data('save-method') || 'put'),
+        data: data,
+        success: function (data, textStatus, xhdr) {
+          $("#save_" + id).removeClass("working");
+          // The filter is necessary because we don't return a flash everywhere atm
+          $("#flash").show().html(data);
+        },
+        error: function (xhdr, textStatus, errorThrown) {
+          $("#save_" + id).removeClass("inactive").removeClass("working");
+          // The filter is necessary because we don't return a flash everywhere atm
+          $("#flash").show().html(xhdr.responseText);
+        }
+      });
+    });
+  } else {
+    $("#save_" + id).hide();
+  }
+  editors[id] = editor;
+}

--- a/src/api/app/assets/stylesheets/webui2/cm2.scss
+++ b/src/api/app/assets/stylesheets/webui2/cm2.scss
@@ -1,0 +1,2 @@
+@import "cm2/toolbars";
+@import "cm2/suse";

--- a/src/api/app/assets/stylesheets/webui2/cm2/suse.scss
+++ b/src/api/app/assets/stylesheets/webui2/cm2/suse.scss
@@ -1,0 +1,62 @@
+.CodeMirror {
+  font-family: "Liberation Mono", monospace;
+  font-size: 9pt;
+  height: auto;
+}
+
+.action_display .CodeMirror-scroll {
+  max-height: 800px;
+}
+
+.CodeMirror-scroll {
+  overflow-y: hidden;
+  overflow-x: auto;
+}
+
+.CodeMirror pre {
+  /* We inherit 'overflow: auto;' from the Bento CSS theme.
+  Both v8 and webkit engines thus
+  render garbage scrollbars.
+  Setting to hidden is ok here, the '.CodeMirror pre' elements
+  aren't supposed to be scrollable... */
+  overflow: hidden;
+  line-height: 1.1;
+}
+
+div[id^=top_] .toolbar { border-radius: 4px 4px 0 0; }
+div[id^=bottom_] .toolbar { border-radius: 0 0 4px 4px; }
+
+.toolbar {
+  background: #f0f0f0;
+  padding: 6px 10px;
+
+  & > span:first-child { margin-right: 10px; }
+  span {
+    .left-margin { margin-left: 10px; }
+    .counter { width: 40px; }
+  }
+
+  .buttons { background-color: #dee2e6; }
+  .inputs, select { background: #f8f9fa; }
+  .inputs {
+    /* toolbars default is 130, but we need a little more space */
+    width: 120px;
+  }
+
+  .tools {margin:2px 1px;}
+  .prev {margin-right:-1px;}
+  .next {margin-left:-1px;}
+  .undo {margin-right:-1px;}
+  .redo {margin-left:-1px;}
+
+  .save { background-color: red; }
+  .save.inactive { background-color: transparent; color: #555;  }
+  .save.working { display: none; }
+}
+
+/* RPM spec styles */
+.cm-s-default span.cm-preamble {color: #b26818; font-weight: bold;}
+.cm-s-default span.cm-macro {color: #b218b2;}
+.cm-s-default span.cm-section {color: green; font-weight: bold;}
+.cm-s-default span.cm-script {color: red;}
+.cm-s-default span.cm-issue {color: yellow;}

--- a/src/api/app/assets/stylesheets/webui2/cm2/toolbars.css
+++ b/src/api/app/assets/stylesheets/webui2/cm2/toolbars.css
@@ -1,0 +1,104 @@
+.CodeMirror {
+  border-left:1px solid #b0b0b0;
+  border-right:1px solid #b0b0b0;
+  background-color:#fafcff;
+
+  font-size:10pt;
+}
+.CodeMirror-matchingbracket {
+  background-color:red;
+  color:white;
+}
+.CodeMirror-gutter {
+  border-right:1px solid #b0b0b0;
+  background-color:#F0F0EE;
+}
+span.CodeMirror-matchhighlight {
+  background: #bbeeee;
+}
+.CodeMirror-focused span.CodeMirror-matchhighlight {
+  background:#aaffff !important
+}
+.CodeMirror-markSelected {
+  background:#66ccff;
+  padding:0px;
+}
+.CodeMirror-markFound	 {
+  background:#ffcccc;
+  padding:0px;
+}
+.CodeMirror-markNextPrev {
+  background:#ffffaa;
+  padding: 0px;
+}
+.tools {
+  border:1px solid #b0b0b0;
+  margin:2px 3px;
+  -moz-border-radius:2px;
+  -webkit-border-radius:2px;
+  border-radius:2px;
+  font-family:Tahoma, Calibri, Verdana, Geneva, sans-serif;
+  font: 8pt verdana, geneva, lucida, 'lucida grande', arial, helvetica, sans-serif;
+}
+.toolbar {
+  background-color:#ede9d8;
+  border:1px solid #b0b0b0;
+  padding:1px 6px;
+  overflow-y:hidden;
+
+  font-family:Tahoma, Calibri, Verdana, Geneva, sans-serif;
+  font: 8pt verdana, geneva, lucida, 'lucida grande', arial, helvetica, sans-serif;
+  .buttons {
+    height:18px;
+    padding:0px;
+    text-align:center;
+    background-color:#ddd7c5;
+  }
+  .inputs{
+    padding:1px 4px 2px;
+    background-color:#f0f0ee;
+    width:130px;
+  }
+  .text {
+    display:inline-block;
+    padding:2px 0px 3px;
+  }
+  .prenex {
+    height:18px;
+    padding:0px;
+    margin:0px;
+  }
+  .prev {
+    width:17px;
+    margin-right:1px;
+  }
+  .next {
+    width:17px;
+    margin-left:1px;
+  }
+  .small {
+    width: 30px;
+  }
+  .medium {
+    width:70px;
+  }
+  .large {
+    width:90px;
+  }
+  .undo {
+    width:40px;
+    margin-right:1px;
+  }
+  .redo {
+    width:40px;
+    margin-left:1px;
+  }
+  .select {
+    min-width:40px;
+    height:18px;
+    margin-top:1px;
+    margin-left:6px;
+    background:#f0f0ee;
+    border:1px solid #b0b0b0;
+  }
+}

--- a/src/api/app/assets/stylesheets/webui2/webui2.css.scss
+++ b/src/api/app/assets/stylesheets/webui2/webui2.css.scss
@@ -8,6 +8,7 @@
  * You're free to add application-wide styles to this file and they'll appear at the top of the
  * compiled file, but it's generally better to create a new file per style scope.
  *
+ *= require codemirror
  *= require peek
 */
 
@@ -33,3 +34,4 @@
 @import 'package-attributes';
 @import 'modals';
 @import 'comments';
+@import 'cm2';

--- a/src/api/app/views/layouts/webui2/webui.html.haml
+++ b/src/api/app/views/layouts/webui2/webui.html.haml
@@ -10,7 +10,21 @@
       = "#{@pagetitle} - " if @pagetitle
       = @configuration ? @configuration['title'] : 'Open Build Service'
     = stylesheet_link_tag 'webui2/webui2'
+    - if content_for?(:head_style)
+      %style{ type: 'text/css' }
+        = yield :head_style
+    = yield :content_for_head
+
     = javascript_include_tag 'webui2/application'
+
+    = yield :content_for_head
+    - if content_for?(:head_style)
+      %style{ type: 'text/css' }
+        = yield :head_style
+    = javascript_tag do
+      var _paq = _paq || [];
+      $(function() { #{yield :ready_function} });
+
     = auto_discovery_link_tag(:rss, news_feed_path(format: 'rss'), {:title => 'News'})
     = csrf_meta_tag
     - if User.current.try(:rss_token)

--- a/src/api/app/views/webui2/shared/_editor.html.haml
+++ b/src/api/app/views/webui2/shared/_editor.html.haml
@@ -1,0 +1,70 @@
+:ruby
+  save ||= {}
+  style ||= { read_only: false }
+  uid ||= next_codemirror_uid
+  content_for(:head_style, codemirror_style(style))
+
+- unless style[:read_only]
+  %div{ id: "top_#{uid}" }
+    .toolbar
+      %span.float-left
+        %input.tools.buttons.small.save.inactive{ id: "save_#{uid}", type: 'button', value: 'Save' }
+        %input.tools.buttons.undo.bg-transparent{ id: "undo_#{uid}", onclick: "editors[#{uid}].Undo(this);", type: 'button', value: 'undo' }
+        %input.tools.buttons.redo.bg-transparent{ id: "redo_#{uid}", onclick: "editors[#{uid}].Redo(this);", type: 'button', value: 'redo' }
+      %span.float-right
+        = select_tag("fontsize_#{uid}", options_for_select(%w[8pt 9pt 10pt 11pt 12pt 14pt]),
+          onchange: "editors[#{uid}].updateFontsize(this)", class: 'tools select')
+
+        :ruby
+          modes = [
+            ['changes', 'rpm-changes', { id: "rpm-changes_#{uid}" }],
+            ['spec', 'rpm-spec', { id: "rpm-spec-#{uid}" }],
+            ['diff', { id: "diff_#{uid}" }],
+            ['shell', 'text/x-sh', { id: "shell_#{uid}" }],
+            ['projconf', { id: "projconf_#{uid}" }],
+            ['baselibs', 'baselibsconf', { id: "baselibs_#{uid}" }],
+            ['perl', { id: "perl_#{uid}" }],
+            ['css', 'css', { id: "css_#{uid}" }],
+            ['html', 'htmlmixed', { id: "html_#{uid}" }],
+            ['js', 'javascript', { id: "js_#{uid}" }],
+            ['php', 'application/x-httpd-php-open', { id: "php_#{uid}" }],
+            ['xml', { id: "xml_#{uid}" }],
+            ['---', '', { id: "x_#{uid}", selected: true }]
+          ]
+        = select_tag("mode_#{uid}", options_for_select(modes),
+          onchange: "editors[#{uid}].updateMode(this)", class: 'tools select')
+
+:ruby
+  data = {}
+  data['save-url'] = save[:url] if save[:url]
+  data['save-method'] = save[:method] if save[:method]
+  data['data'] = save[:data] if save[:data]
+  text = force_utf8_and_transform_nonprintables(text)
+
+= text_area_tag("editor_#{uid}", text, cols: '0', rows: '0', data: data, class: 'editor')
+
+- unless style[:read_only]
+  %div{ id: "bottom_#{uid}" }
+    .toolbar
+      %span.float-left
+        %span position
+        %span.left-margin line:
+        %span.d-inline-block.counter{ id: "ln_#{uid}" } 0
+        %span char:
+        %span.d-inline-block.counter{ id: "ch_#{uid}" } 0
+        %span.left-margin tab size:
+        = select_tag("tabsize_#{uid}", options_for_select(2..8),
+          onchange: "editors[#{uid}].updateTabsize(this)", class: 'tools select', style: 'min-width: 30px')
+
+      %span.float-left
+        %span matching:
+        %input.tools.buttons.small{ id: "match_#{uid}", onclick: "editors[#{uid}].Match(this);", type: 'button', value: 'off' }/
+      %span.float-right
+        %span line:
+        %input.tools.inputs.counter{ autocomplete: 'off', id: "line_#{uid}", type: 'text' }/
+        %input.tools.buttons.small{ onclick: "editors[#{uid}].gotoLine(this);", type: 'button', value: 'go' }/
+        %span.left-margin line wrapping:
+        %input.tools.buttons.small{ onclick: "editors[#{uid}].Wrap(this)", type: 'button', value: 'off' }/
+
+- content_for :ready_function do
+  use_codemirror(#{uid}, #{style[:read_only]}, '#{mode}');

--- a/src/api/config/initializers/assets.rb
+++ b/src/api/config/initializers/assets.rb
@@ -8,4 +8,4 @@ Rails.application.config.assets.version = '1.0'
 
 # Precompile additional assets.
 # application.js, application.css, and all non-JS/CSS in app/assets folder are already added.
-Rails.application.config.assets.precompile += ['webui2/webui2.css', 'webui2/application.js', 'webui/obs_factory/application.css']
+Rails.application.config.assets.precompile += ['webui2/webui2.css', 'webui2/application.js', 'webui/obs_factory/application.css', 'webui2/cm2/*']

--- a/src/api/spec/bootstrap/features/webui/packages_spec.rb
+++ b/src/api/spec/bootstrap/features/webui/packages_spec.rb
@@ -1,5 +1,6 @@
 require 'browser_helper'
 require 'webmock/rspec'
+require 'code_mirror_helper'
 
 RSpec.feature 'Bootstrap_Packages', type: :feature, js: true, vcr: true do
   it_behaves_like 'user tab' do

--- a/src/api/spec/code_mirror_helper.rb
+++ b/src/api/spec/code_mirror_helper.rb
@@ -1,0 +1,1 @@
+require 'support/code_mirror'

--- a/src/api/spec/support/code_mirror.rb
+++ b/src/api/spec/support/code_mirror.rb
@@ -1,0 +1,17 @@
+# Reference: https://www.eliotsykes.com/testing-codemirror-editor
+module CodeMirrorHelpers
+  def fill_in_editor_field(text)
+    within '.CodeMirror' do
+      # Click makes CodeMirror element active:
+      current_scope.click
+      # Find the hidden textarea:
+      field = current_scope.find('textarea', visible: false)
+      # Mimic user typing the text:
+      field.send_keys(text)
+    end
+  end
+end
+
+RSpec.configure do |config|
+  config.include CodeMirrorHelpers, type: :feature
+end


### PR DESCRIPTION
- Changes slightly the CSS of the editor's toolbar.
- Refactors the editor code.
- Creates a test helper, `fill_in_editor_field`, to easily write text
  inside CodeMirror editor from feature tests.

Co-authored-by: Björn Geuken <bgeuken@suse.de>