### PR TITLE
Force utf8 encoding when updating user realname

### DIFF
--- a/src/api/app/models/user.rb
+++ b/src/api/app/models/user.rb
@@ -373,7 +373,7 @@ class User < ApplicationRecord
       save
     end
     return unless env['HTTP_X_FIRSTNAME'].present? && env['HTTP_X_LASTNAME'].present?
-    realname = env['HTTP_X_FIRSTNAME'] + ' ' + env['HTTP_X_LASTNAME']
+    realname = env['HTTP_X_FIRSTNAME'].force_encoding('UTF-8') + ' ' + env['HTTP_X_LASTNAME'].force_encoding('UTF-8')
     return unless self.realname != realname
 
     self.realname = realname


### PR DESCRIPTION
In proxy mode make sure that the user realname is a proper utf8 string.

Fixes #5872.

Co-authored-by: Henne Vogelsang <hvogel@opensuse.org>