### PR TITLE
Remove exit 0 as bug in Rubocop is fixed

### DIFF
--- a/src/api/lib/tasks/dev.rake
+++ b/src/api/lib/tasks/dev.rake
@@ -98,13 +98,13 @@ namespace :dev do
 
         desc 'Autogenerate rubocop config in rails'
         task :rails do
-          sh 'rubocop --auto-gen-config --ignore_parent_exclusion || exit 0'
+          sh 'rubocop --auto-gen-config --ignore_parent_exclusion'
         end
 
         desc 'Run the ruby linter in root'
         task :root do
           Dir.chdir('../..') do
-            sh 'rubocop --auto-gen-config || exit 0'
+            sh 'rubocop --auto-gen-config'
           end
         end
       end


### PR DESCRIPTION
[The bug we found when implementing the Rubocop task](https://github.com/rubocop-hq/rubocop/issues/6057) has been solved in Rubocop 0.59.0 and the `exit 0` is not needed anymore, as now `rubocop --auto-gen-config` returns 0 if there are offenses always that the todo file was successfully generated. :bowtie: 

