### PR TITLE
Set a download_url in the testdata rake job

### DIFF
--- a/src/api/lib/tasks/dev.rake
+++ b/src/api/lib/tasks/dev.rake
@@ -199,6 +199,9 @@ namespace :dev do
       create(:project, name: 'openSUSE:Factory:Rings:0-Bootstrap')
       create(:project, name: 'openSUSE:Factory:Rings:1-MinimalX')
       create(:project, name: 'openSUSE:Factory:Staging:A', description: 'requests:')
+
+      Configuration.download_url = 'https://download.opensuse.org'
+      Configuration.save
     end
   end
 end


### PR DESCRIPTION
because otherwise we need to always set it e.g. in a review app if we want to review
the download / binary pages.