### PR TITLE
Adapt package#statistics to Bootstrap

### DIFF
--- a/src/api/app/controllers/webui/package_controller.rb
+++ b/src/api/app/controllers/webui/package_controller.rb
@@ -139,6 +139,7 @@ class Webui::PackageController < Webui::WebuiController
   # rubocop:enable Lint/NonLocalExitFromIterator
 
   def statistics
+    return if switch_to_webui2
     @arch = params[:arch]
     @repository = params[:repository]
     @package_name = params[:package]

--- a/src/api/app/controllers/webui2/package_controller.rb
+++ b/src/api/app/controllers/webui2/package_controller.rb
@@ -21,4 +21,10 @@ module Webui2::PackageController
                                                   repository_list: @repo_list, repo_arch_hash: @repo_arch_hash }
     end
   end
+
+  def webui2_statistics
+    @package_name = params[:package]
+
+    @statistics = @package.statistics(@project.name, @repository, params[:arch]).results
+  end
 end

--- a/src/api/app/controllers/webui2/package_controller.rb
+++ b/src/api/app/controllers/webui2/package_controller.rb
@@ -23,6 +23,7 @@ module Webui2::PackageController
   end
 
   def webui2_statistics
+    @repository = params[:repository]
     @package_name = params[:package]
 
     @statistics = @package.statistics(@project.name, @repository, params[:arch]).results

--- a/src/api/app/models/local_build_statistic/for_package.rb
+++ b/src/api/app/models/local_build_statistic/for_package.rb
@@ -1,0 +1,55 @@
+module LocalBuildStatistic
+  class ForPackage
+    include ActiveModel::Model
+    attr_accessor :package, :project, :repository, :architecture
+    attr_reader :results
+
+    def initialize(attributes = {})
+      super
+      statistic
+    end
+
+    private
+
+    attr_writer :results
+
+    def statistic
+      result = backend_statistics
+      return if result.empty?
+
+      disk = result.dig('disk', 'usage')
+      memory = result.dig('memory', 'usage')
+      times = result.get('times')
+      local_statistics = LocalStatistic.new
+
+      if disk
+        local_statistics.disk = LocalBuildStatistic::Package::Disk.new(size: disk.dig('size', '_content'),
+                                                                       unit: disk.dig('size', 'unit'),
+                                                                       io_requests: disk['io_requests'],
+                                                                       io_sectors: disk['io_sectors'])
+      end
+      if memory
+        local_statistics.memory = LocalBuildStatistic::Package::Memory.new(size: memory.dig('size', '_content'),
+                                                                           unit: memory.dig('size', 'unit'))
+      end
+      if times
+        local_statistics.times = LocalBuildStatistic::Package::Time.new(total: times.dig('total', 'time', '_content'),
+                                                                        total_unit: times.dig('total', 'time', 'unit'),
+                                                                        install: times.dig('install', 'time', '_content'),
+                                                                        install_unit: times.dig('install', 'time', 'unit'),
+                                                                        preinstall: times.dig('preinstall', 'time', '_content'),
+                                                                        preinstall_unit: times.dig('preinstall', 'time', 'unit'),
+                                                                        main: times.dig('main', 'time', '_content'),
+                                                                        main_unit: times.dig('main', 'time', 'unit'))
+      end
+
+      self.results = local_statistics
+    end
+
+    def backend_statistics
+      Xmlhash.parse(Backend::Api::BuildResults::Status.statistics(project, package, repository, architecture))
+    rescue Backend::Error
+      return []
+    end
+  end
+end

--- a/src/api/app/models/local_build_statistic/package/disk.rb
+++ b/src/api/app/models/local_build_statistic/package/disk.rb
@@ -1,0 +1,8 @@
+module LocalBuildStatistic
+  module Package
+    class Disk
+      include ActiveModel::Model
+      attr_accessor :size, :unit, :io_requests, :io_sectors
+    end
+  end
+end

--- a/src/api/app/models/local_build_statistic/package/memory.rb
+++ b/src/api/app/models/local_build_statistic/package/memory.rb
@@ -1,0 +1,8 @@
+module LocalBuildStatistic
+  module Package
+    class Memory
+      include ActiveModel::Model
+      attr_accessor :size, :unit
+    end
+  end
+end

--- a/src/api/app/models/local_build_statistic/package/time.rb
+++ b/src/api/app/models/local_build_statistic/package/time.rb
@@ -1,0 +1,8 @@
+module LocalBuildStatistic
+  module Package
+    class Time
+      include ActiveModel::Model
+      attr_accessor :total, :total_unit, :install, :install_unit, :preinstall, :preinstall_unit, :main, :main_unit
+    end
+  end
+end

--- a/src/api/app/models/local_statistic.rb
+++ b/src/api/app/models/local_statistic.rb
@@ -1,0 +1,4 @@
+class LocalStatistic
+  include ActiveModel::Model
+  attr_accessor :disk, :memory, :times
+end

--- a/src/api/app/models/package.rb
+++ b/src/api/app/models/package.rb
@@ -1445,6 +1445,10 @@ class Package < ApplicationRecord
     PackageBuildReason.new(data)
   end
 
+  def statistics(project_name, repository_name, architecture_name)
+    LocalBuildStatistic::ForPackage.new(package: self, project: project_name, repository: repository_name, architecture: architecture_name)
+  end
+
   private
 
   def _add_channel(mode, channel_binary, message)

--- a/src/api/app/views/webui2/webui/package/_breadcrumb_items.html.haml
+++ b/src/api/app/views/webui2/webui/package/_breadcrumb_items.html.haml
@@ -16,6 +16,11 @@
 - if current_page?(package_show_path)
   %li.breadcrumb-item.active{ 'aria-current' => 'page' }
     Overview
-- if @repo && @arch && current_page?(package_live_build_log_path(@project, @package, repository: @repo, arch: @arch))
+- if controller_name == 'package' && action_name == 'live_build_log'
   %li.breadcrumb-item.active{ 'aria-current' => 'page' }
     Build Log
+- if controller_name == 'package' && action_name == 'statistics'
+  %li.breadcrumb-item
+    = link_to 'Repository State', package_binaries_path(@project, @package_name, @repository)
+  %li.breadcrumb-item.active{ 'aria-current' => 'page' }
+    Statistics

--- a/src/api/app/views/webui2/webui/package/statistics.html.haml
+++ b/src/api/app/views/webui2/webui/package/statistics.html.haml
@@ -1,52 +1,56 @@
-- @pagetitle = "Resource Information"
+- @pagetitle = 'Resource Information'
 - @metarobots = 'noindex' # files change too often
 
 .card.mb-3
   = render partial: 'tabs', locals: { project: @project, package: @package }
   .card-body
     - if @statistics
-      - disk = @statistics.get('disk').get('usage')
-      - if disk
-        %h1 Disk Statistics
-        - if disk['size']
-          %p
-            %strong Maximal used disk space:
-            = disk['size']['_content']
-            = disk['size']['unit']
-            byte
-        - if disk['io_requests']
-          %p
-            %strong Number of IO requests:
-            = disk['io_requests']
-        - if disk['io_sectors']
-          %p
-            %strong Sectors read or written:
-            = disk['io_sectors']
-      - memory = @statistics.get('memory').get('usage')
-      - if memory && memory['size']
-        %h1 Memory Statistics
-        %p
-          %strong Maximal used memory:
-          = memory['size']['_content']
-          = memory['size']['unit']
-          byte
-      - times = @statistics['times']
-      - if times
-        %h1 Times
-        - if times['preinstall']
-          %p
-            Package
-            Preinstall: #{times['preinstall']['time']['_content']} #{times['preinstall']['time']['unit']}
-        - if times['install']
-          %p
-            Package
-            Install: #{times['install']['time']['_content']} #{times['install']['time']['unit']}
-        - if times['main']
-          %p
-            Main build task: #{times['main']['time']['_content']} #{times['main']['time']['unit']}
-        - if times['total']
-          %p
-            Total build: #{times['total']['time']['_content']} #{times['total']['time']['unit']}
+      .row
+        - disk = @statistics.disk
+        - if disk
+          .col-md-4
+            %h3 Disk Statistics
+            - if disk.size
+              %p
+                %strong Maximal used disk space:
+                = disk.size
+                #{disk.unit}byte
+            - if disk.io_requests
+              %p
+                %strong Number of IO requests:
+                = disk.io_requests
+            - if disk.io_sectors
+              %p
+                %strong Sectors read or written:
+                = disk.io_sectors
+        - memory = @statistics.memory
+        - if memory && memory.size
+          .col-md-4
+            %h3 Memory Statistics
+            %p
+              %strong Maximal used memory:
+              = memory.size
+              #{memory.unit}byte
+        - times = @statistics.times
+        - if times
+          .col-md-4
+            %h3 Times
+            - if times.preinstall
+              %p
+                %strong Package Preinstall:
+                #{times.preinstall} #{times.preinstall_unit}
+            - if times.install
+              %p
+                %strong Package Install:
+                #{times.install} #{times.install_unit}
+            - if times.main
+              %p
+                %strong Main build task:
+                #{times.main} #{times.main_unit}
+            - if times.total
+              %p
+                %strong Total build:
+                #{times.total} #{times.total_unit}
     - else
       %strong No statistics exist for this build
 

--- a/src/api/app/views/webui2/webui/package/statistics.html.haml
+++ b/src/api/app/views/webui2/webui/package/statistics.html.haml
@@ -1,0 +1,52 @@
+- @pagetitle = "Resource Information"
+- @metarobots = 'noindex' # files change too often
+
+.card.mb-3
+  = render partial: 'tabs', locals: { project: @project, package: @package }
+  .card-body
+    - if @statistics
+      - disk = @statistics.get('disk').get('usage')
+      - if disk
+        %h1 Disk Statistics
+        - if disk['size']
+          %p
+            %strong Maximal used disk space:
+            = disk['size']['_content']
+            = disk['size']['unit']
+            byte
+        - if disk['io_requests']
+          %p
+            %strong Number of IO requests:
+            = disk['io_requests']
+        - if disk['io_sectors']
+          %p
+            %strong Sectors read or written:
+            = disk['io_sectors']
+      - memory = @statistics.get('memory').get('usage')
+      - if memory && memory['size']
+        %h1 Memory Statistics
+        %p
+          %strong Maximal used memory:
+          = memory['size']['_content']
+          = memory['size']['unit']
+          byte
+      - times = @statistics['times']
+      - if times
+        %h1 Times
+        - if times['preinstall']
+          %p
+            Package
+            Preinstall: #{times['preinstall']['time']['_content']} #{times['preinstall']['time']['unit']}
+        - if times['install']
+          %p
+            Package
+            Install: #{times['install']['time']['_content']} #{times['install']['time']['unit']}
+        - if times['main']
+          %p
+            Main build task: #{times['main']['time']['_content']} #{times['main']['time']['unit']}
+        - if times['total']
+          %p
+            Total build: #{times['total']['time']['_content']} #{times['total']['time']['unit']}
+    - else
+      %strong No statistics exist for this build
+

--- a/src/api/spec/models/local_build_statistic/for_package_spec.rb
+++ b/src/api/spec/models/local_build_statistic/for_package_spec.rb
@@ -1,0 +1,83 @@
+require 'rails_helper'
+require 'webmock/rspec'
+
+RSpec.describe LocalBuildStatistic::ForPackage do
+  let(:fake_statistics_result) do
+    <<-HEREDOC
+      <buildstatistics>
+        <disk>
+          <usage>
+            <size unit="M">491</size>
+            <io_requests>4900</io_requests>
+            <io_sectors>826498</io_sectors>
+          </usage>
+        </disk>
+        <memory>
+          <usage>
+            <size unit="M">106</size>
+          </usage>
+        </memory>
+        <times>
+          <total>
+            <time unit="s">107</time>
+          </total>
+          <preinstall>
+            <time unit="s">18</time>
+          </preinstall>
+          <install>
+            <time unit="s">24</time>
+          </install>
+          <main>
+            <time unit="s">4</time>
+          </main>
+          <download>
+            <time unit="s">4</time>
+          </download>
+        </times>
+        <download>
+          <size unit="k">7548</size>
+          <binaries>4</binaries>
+          <cachehits>103</cachehits>
+        </download>
+      </buildstatistics>
+    HEREDOC
+  end
+
+  describe '#statistic' do
+    let(:results) { local_statistics.results }
+    let(:local_statistics) do
+      LocalBuildStatistic::ForPackage.new(package: 'fake_package', project: 'fake_project', repository: 'SLE_12_SP2', architecture: 'x86_64')
+    end
+
+    context 'with results' do
+      before do
+        allow(Backend::Api::BuildResults::Status).to receive(:statistics).and_return(fake_statistics_result)
+      end
+
+      it { expect(results.disk).to have_attributes(size: '491', unit: 'M', io_requests: '4900', io_sectors: '826498') }
+      it { expect(results.memory).to have_attributes(size: '106', unit: 'M') }
+      it 'related with times (total, install, preinstall, main)' do
+        expect(results.times).to have_attributes(total: '107', total_unit: 's',
+                                                   preinstall: '18', preinstall_unit: 's',
+                                                   install: '24', install_unit: 's',
+                                                   main: '4', main_unit: 's')
+      end
+    end
+
+    context 'without results' do
+      before do
+        allow(Backend::Api::BuildResults::Status).to receive(:statistics).and_return('<buildstatistics></buildstatistics>')
+      end
+
+      it { expect(results).to be_nil }
+    end
+
+    context 'with backend error' do
+      before do
+        allow(Backend::Api::BuildResults::Status).to receive(:statistics).and_raise(Backend::Error)
+      end
+
+      it { expect(results).to be_nil }
+    end
+  end
+end

--- a/src/api/spec/models/package_spec.rb
+++ b/src/api/spec/models/package_spec.rb
@@ -770,5 +770,56 @@ RSpec.describe Package, vcr: true do
       end
     end
   end
+
+  describe '#statistics' do
+    let(:fake_statistics_result) do
+      <<-HEREDOC
+        <buildstatistics>
+          <disk>
+            <usage>
+              <size unit="M">491</size>
+              <io_requests>4900</io_requests>
+              <io_sectors>826498</io_sectors>
+            </usage>
+          </disk>
+          <memory>
+            <usage>
+              <size unit="M">106</size>
+            </usage>
+          </memory>
+          <times>
+            <total>
+              <time unit="s">107</time>
+            </total>
+            <preinstall>
+              <time unit="s">18</time>
+            </preinstall>
+            <install>
+              <time unit="s">24</time>
+            </install>
+            <main>
+              <time unit="s">4</time>
+            </main>
+            <download>
+              <time unit="s">4</time>
+            </download>
+          </times>
+          <download>
+            <size unit="k">7548</size>
+            <binaries>4</binaries>
+            <cachehits>103</cachehits>
+          </download>
+        </buildstatistics>
+      HEREDOC
+    end
+
+    before do
+      allow(Backend::Api::BuildResults::Status).to receive(:statistics).and_return(fake_statistics_result)
+    end
+
+    it 'returns an object with class LocalBuildStatistic::ForPackage' do
+      expect(package.statistics(home_project, 'SLE_12_SP2', 'x68_64').class).to eq(LocalBuildStatistic::ForPackage)
+    end
+  end
 end
 # rubocop:enable Metrics/BlockLength


### PR DESCRIPTION
We adapt package statistics view to Bootstrap

### With Statistics
![screenshot_2018-09-26 resource information - open build service 1](https://user-images.githubusercontent.com/1212806/46086257-022d7480-c1a8-11e8-81d4-c4182dcec2af.png)

### Without Statistics
![screenshot_2018-09-26 resource information - open build service 2](https://user-images.githubusercontent.com/1212806/46086286-0fe2fa00-c1a8-11e8-8fd3-a9e94abaff09.png)

