### PR TITLE
Migrate Package#build_reason to bootstrap

### DIFF
--- a/src/api/app/controllers/webui/packages/build_reason_controller.rb
+++ b/src/api/app/controllers/webui/packages/build_reason_controller.rb
@@ -8,6 +8,7 @@ module Webui
 
       def index
         @details = @package.last_build_reason(@repository, @architecture.name, @package_name)
+        switch_to_webui2
         return if @details.explain.present?
 
         redirect_back(fallback_location: package_binaries_path(package: @package, project: @project, repository: @repository.name),

--- a/src/api/app/models/package_build_reason.rb
+++ b/src/api/app/models/package_build_reason.rb
@@ -2,5 +2,10 @@ class PackageBuildReason
   include ActiveModel::Model
 
   validates :explain, :time, presence: true
-  attr_accessor :explain, :time, :oldsource, :packagechange
+  attr_accessor :explain, :oldsource, :packagechange
+  attr_writer :time
+
+  def time
+    Time.at(@time.to_i)
+  end
 end

--- a/src/api/app/views/webui2/webui/package/_tabs.html.haml
+++ b/src/api/app/views/webui2/webui/package/_tabs.html.haml
@@ -1,7 +1,7 @@
 .bg-light
   %ul.nav.nav-tabs.pt-2.px-3.flex-nowrap.collapsible{ 'role': 'tablist' }
     %li.nav-item
-      = tab_link('Overview', package_show_path)
+      = tab_link('Overview', package_show_path(project, package))
     - if package.name == 'patchinfo'
       %li.nav-item
         = tab_link('Details', patchinfo_show_path)
@@ -9,15 +9,15 @@
       %li.nav-item
         = tab_link('Repositories', repositories_path)
       %li.nav-item
-        = tab_link('Revisions', package_view_revisions_path)
+        = tab_link('Revisions', package_view_revisions_path(project, package))
       %li.nav-item
-        = tab_link('Requests', package_requests_path)
+        = tab_link('Requests', package_requests_path(project, package))
       %li.nav-item
-        = tab_link('Users', package_users_path)
+        = tab_link('Users', package_users_path(project, package))
       %li.nav-item
         = tab_link('Attributes', index_attribs_path(project, package))
       %li.nav-item
-        = tab_link('Meta', package_meta_path)
+        = tab_link('Meta', package_meta_path(project, package))
     %li.nav-item.dropdown
       %a.nav-link.dropdown-toggle{ href: '#', 'data-toggle': 'dropdown', 'role': 'button', 'aria-expanded': 'false', 'aria-haspopup': 'true' }
       .dropdown-menu.dropdown-menu-right

--- a/src/api/app/views/webui2/webui/packages/build_reason/_breadcrumb_items.html.haml
+++ b/src/api/app/views/webui2/webui/packages/build_reason/_breadcrumb_items.html.haml
@@ -1,0 +1,7 @@
+= render partial: 'webui/project/breadcrumb_items'
+%li.breadcrumb-item
+  = link_to @package, package_show_path(@project, @package)
+%li.breadcrumb-item
+  = link_to 'Repositoy state', package_binaries_path(@project, @package, @repository.name)
+%li.breadcrumb-item.active{ 'aria-current' => 'page' }
+  Build Reason

--- a/src/api/app/views/webui2/webui/packages/build_reason/index.html.haml
+++ b/src/api/app/views/webui2/webui/packages/build_reason/index.html.haml
@@ -14,7 +14,7 @@
       %br
       %strong
         Build scheduled at:
-      = Time.at(@details.time.to_i)
+      = @details.time
       - if @details.packagechange
         %p
           %strong

--- a/src/api/app/views/webui2/webui/packages/build_reason/index.html.haml
+++ b/src/api/app/views/webui2/webui/packages/build_reason/index.html.haml
@@ -1,0 +1,35 @@
+- @pagetitle = "Build Reason for #{@project} / #{@package_name}"
+
+.card
+  = render partial: 'webui2/webui/package/tabs', locals: { project: @project, package: @package }
+  .card-body
+    %h3
+      = @pagetitle
+    %h6.subtitle
+      Repository / Architecture: #{@repository.name} / #{@architecture}}
+    %p
+      %strong
+        Build reason:
+      = @details.explain
+      %br
+      %strong
+        Build scheduled at:
+      = Time.at(@details.time.to_i)
+      - if @details.packagechange
+        %p
+          %strong
+            = pluralize(@details.packagechange.size, 'package')
+          that got changed and scheduled a build for package
+          %strong
+            #{@package.name}.
+        .table-responsive
+          %table.table.table-hover#changed-packages
+            %thead.thead-light
+              %tr
+                %th Package
+                %th Change
+            %tbody
+              - @details.packagechange.each do |packagechange|
+                %tr
+                  %td= packagechange['key']
+                  %td= packagechange['change']

--- a/src/api/app/views/webui2/webui/packages/build_reason/index.html.haml
+++ b/src/api/app/views/webui2/webui/packages/build_reason/index.html.haml
@@ -14,7 +14,7 @@
       %br
       %strong
         Build scheduled at:
-      = @details.time
+      = @details.time.strftime('%Y-%m-%d %H:%M')
       - if @details.packagechange
         %p
           %strong

--- a/src/api/spec/models/package_spec.rb
+++ b/src/api/spec/models/package_spec.rb
@@ -515,10 +515,11 @@ RSpec.describe Package, vcr: true do
 
   describe '#last_build_reason' do
     let(:path) { "#{CONFIG['source_url']}/build/#{package.project.name}/openSUSE_Leap_42.3/x86_64/#{package.name}/_reason" }
+    let(:time) { 1_496_387_771 }
 
     before do
       stub_request(:get, path).and_return(body:
-        %(<reason>\n  <explain>source change</explain>  <time>1496387771</time>  <oldsource>1de56fdc419ea4282e35bd388285d370</oldsource></reason>))
+        %(<reason>\n  <explain>source change</explain>  <time>#{time}</time>  <oldsource>1de56fdc419ea4282e35bd388285d370</oldsource></reason>))
     end
 
     let(:result) { package.last_build_reason('openSUSE_Leap_42.3', 'x86_64') }
@@ -533,7 +534,7 @@ RSpec.describe Package, vcr: true do
       end
 
       it 'for: time' do
-        expect(result.time).to eq('1496387771')
+        expect(result.time).to eq(Time.at(time))
       end
 
       it 'for: oldsource' do


### PR DESCRIPTION

![selection_020](https://user-images.githubusercontent.com/3799140/46135014-859ca380-c244-11e8-9660-b64094a72cf6.png)

![selection_018](https://user-images.githubusercontent.com/3799140/46090453-0611c480-c1b1-11e8-89ac-c34af7add351.png)

Getting the table locally can be tricky because you need a package with a dependency on another package, trigger the dependency and then you would get a table. However, you can just mock this by adding this:
```
  def packagechange
    [
      { 'key' => 'package1', 'change' => 'changed' },
      { 'key' => 'package2', 'change' => 'changed' },
      { 'key' => 'package3', 'change' => 'changed' },
      { 'key' => 'package1', 'change' => 'changed' }
    ]
  end
```

to ``src/api/app/models/package_build_reason.rb``.