### PR TITLE
Implement package binary job history in bootstrap

### DIFF
--- a/src/api/app/assets/javascripts/webui2/application.js
+++ b/src/api/app/assets/javascripts/webui2/application.js
@@ -30,5 +30,6 @@
 //= require webui2/comment.js
 //= require webui2/request.js
 //= require webui2/buildresult.js
+//= require webui2/job_history.js
 // FIXME remove jquery-ui file when we upgrade jquery-ui gem
 //= require webui2/jquery-ui.min.js

--- a/src/api/app/assets/javascripts/webui2/job_history.js
+++ b/src/api/app/assets/javascripts/webui2/job_history.js
@@ -1,0 +1,12 @@
+$(document).ready(function() {
+  $('#jobhistory-table').dataTable({
+    responsive: true,
+    columnDefs: [
+      { orderable: false, targets: [0, 8] },
+      { visible: false, searchable: false, targets: [1, 5] },
+      { orderData: 1, targets: 2 },
+      { orderData: 5, targets: 6 },
+    ],
+    order: [[2, 'desc']]
+  });
+});

--- a/src/api/app/controllers/webui/packages/job_history_controller.rb
+++ b/src/api/app/controllers/webui/packages/job_history_controller.rb
@@ -8,6 +8,7 @@ module Webui
 
       def index
         @jobshistory = Package.jobhistory_list(@project.name, @repository.name, @architecture.name, @package_name)
+        switch_to_webui2
       end
 
       private

--- a/src/api/app/views/webui2/webui/package/_tabs.html.haml
+++ b/src/api/app/views/webui2/webui/package/_tabs.html.haml
@@ -1,7 +1,7 @@
 .bg-light
   %ul.nav.nav-tabs.pt-2.px-3.flex-nowrap.collapsible{ 'role': 'tablist' }
     %li.nav-item
-      = tab_link('Overview', package_show_path)
+      = tab_link('Overview', package_show_path(package: package))
     - if package.name == 'patchinfo'
       %li.nav-item
         = tab_link('Details', patchinfo_show_path)
@@ -9,15 +9,15 @@
       %li.nav-item
         = tab_link('Repositories', repositories_path)
       %li.nav-item
-        = tab_link('Revisions', package_view_revisions_path)
+        = tab_link('Revisions', package_view_revisions_path(package: package))
       %li.nav-item
-        = tab_link('Requests', package_requests_path)
+        = tab_link('Requests', package_requests_path(package: package))
       %li.nav-item
-        = tab_link('Users', package_users_path)
+        = tab_link('Users', package_users_path(package: package))
       %li.nav-item
         = tab_link('Attributes', index_attribs_path(project, package))
       %li.nav-item
-        = tab_link('Meta', package_meta_path)
+        = tab_link('Meta', package_meta_path(package: package))
     %li.nav-item.dropdown
       %a.nav-link.dropdown-toggle{ href: '#', 'data-toggle': 'dropdown', 'role': 'button', 'aria-expanded': 'false', 'aria-haspopup': 'true' }
       .dropdown-menu.dropdown-menu-right

--- a/src/api/app/views/webui2/webui/packages/job_history/_breadcrumb_items.html.haml
+++ b/src/api/app/views/webui2/webui/packages/job_history/_breadcrumb_items.html.haml
@@ -1,0 +1,7 @@
+= render partial: 'webui/project/breadcrumb_items'
+%li.breadcrumb-item
+  = link_to @package, package_show_path(@project, @package)
+%li.breadcrumb-item
+  = link_to 'Repository State', package_binaries_path(package: @package)
+%li.breadcrumb-item.active{ 'aria-current' => 'page' }
+  Job History

--- a/src/api/app/views/webui2/webui/packages/job_history/index.html.haml
+++ b/src/api/app/views/webui2/webui/packages/job_history/index.html.haml
@@ -1,0 +1,52 @@
+- @pagetitle = "Job history of #{@project} / #{@package_name}"
+- @metarobots = 'index,nofollow'
+
+.card
+  = render partial: 'webui/package/tabs', locals: { project: @project, package: @package }
+
+  .card-body
+    %h3= @pagetitle
+    %h6.subtitle
+      Repository / Architecture: #{params[:repository]} / #{params[:arch]}
+
+    %table.responsive.table.table-striped.table-bordered.w-100#jobhistory-table
+      %thead
+        %th Revision
+        %th Time (not formatted)
+        %th Time
+        %th Reason
+        %th Status Code
+        %th Build Time (not formatted)
+        %th Build Time
+        %th Worker
+        %th
+      %tbody
+        - @jobshistory.each do |jobhistory|
+          %tr
+            %td
+              = jobhistory.revision
+            %td
+              = jobhistory.ready_time
+            %td
+              = time_tag(Time.at(jobhistory.ready_time))
+            %td
+              - if jobhistory.reason == 'source change'
+                = link_to(jobhistory.reason, package_rdiff_path(project: @project.name,
+                  package: @package, orev: jobhistory.prev_srcmd5, rev: jobhistory.srcmd5))
+              - else
+                = jobhistory.reason
+            %td{ class: "status_#{jobhistory.code}" }
+              = jobhistory.code
+            %td
+              = jobhistory.total_time
+            %td
+              = humanize_time(jobhistory.total_time)
+            %td
+              = jobhistory.worker_id
+            %td
+              - revision = (@is_link ? { srcmd5: jobhistory.srcmd5 } : { rev: jobhistory.revision })
+              - url = package_show_path(revision.merge(project: @project, package: @package))
+              = link_to(url, title: "Package:#{@package} | revision:#{jobhistory.revision}") do
+                %span.fa-stack.fa-xs.half-font-size
+                  %i.far.fa-file.fa-stack-2x
+                  %i.fas.fa-search.fa-stack-0.5x.pl-2.pt-2


### PR DESCRIPTION
We had to explicitly define the package variable in the breadcrumbs to avoid a breakage when rendering the job history page. This is because the job history page does not define all variables we require for the tabs partial.

Co-authored-by: Saray Cabrera Padrón <scabrerapadron@suse.de>


![data_table_1](https://user-images.githubusercontent.com/968949/46093650-2db85b00-c1b8-11e8-9c75-535af45c0d0f.png)
![data_table_2](https://user-images.githubusercontent.com/968949/46093657-31e47880-c1b8-11e8-8216-cfb71d24c25e.png)