### PR TITLE
Migrate Package#meta to bootstrap

### DIFF
--- a/src/api/app/views/webui2/webui/package/meta.html.haml
+++ b/src/api/app/views/webui2/webui/package/meta.html.haml
@@ -1,0 +1,14 @@
+- content_for(:content_for_head, javascript_include_tag('webui2/cm2/index-xml'))
+- @pagetitle = "Meta Configuration of Package #{@package}"
+
+.card
+  = render(partial: 'webui/package/tabs', locals: { project: @project, package: @package })
+
+  .card-body
+    %h3= @pagetitle
+    - if User.current.can_modify? @package
+      = render partial: 'shared/editor', locals: { text: @meta, mode: 'xml',
+        save: { url: package_save_meta_path, method: :post,
+        data: { project: @project.name, package: @package.name, submit: 'meta', use_webui2: true } } }
+    - else
+      = render partial: 'shared/editor', locals: { text: @meta, mode: 'xml', style: { read_only: true } }

--- a/src/api/config/routes.rb
+++ b/src/api/config/routes.rb
@@ -142,7 +142,7 @@ OBSApi::Application.routes.draw do
         get 'package/rpmlint_result' => :rpmlint_result, constraints: cons, as: 'rpmlint_result'
         get 'package/rpmlint_log' => :rpmlint_log, constraints: cons
         get 'package/meta/:project/:package' => :meta, constraints: cons, as: 'package_meta'
-        post 'package/save_meta/:project/:package' => :save_meta, constraints: cons
+        post 'package/save_meta/:project/:package' => :save_meta, constraints: cons, as: 'package_save_meta'
         # compat route
         get 'package/attributes/:project/:package', to: redirect('/attribs/%{project}/%{package}'), constraints: cons
         get 'package/edit/:project/:package' => :edit, constraints: cons, as: :package_edit

--- a/src/api/spec/bootstrap/features/webui/packages_spec.rb
+++ b/src/api/spec/bootstrap/features/webui/packages_spec.rb
@@ -146,4 +146,36 @@ RSpec.feature 'Bootstrap_Packages', type: :feature, js: true, vcr: true do
       expect(page.source).to have_text('[1] this is my dummy logfile')
     end
   end
+
+  context 'meta configuration' do
+    describe 'as admin' do
+      let!(:admin_user) { create(:admin_user) }
+
+      before do
+        login admin_user
+      end
+
+      scenario 'can edit' do
+        visit package_meta_path(package.project, package)
+        fill_in_editor_field('<!-- Comment for testing -->')
+        click_button('Save')
+        expect(page).to have_text('The Meta file has been successfully saved.')
+        expect(page).to have_css('.CodeMirror-code', text: 'Comment for testing')
+      end
+    end
+
+    describe 'as common user' do
+      let(:other_user) { create(:confirmed_user, login: 'common_user') }
+      before do
+        login other_user
+      end
+
+      scenario 'can not edit' do
+        visit package_meta_path(package.project, package)
+        within('.card-body') do
+          expect(page).not_to have_css('.toolbar')
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
 - Uses CodeMirror.
- Includes tests to check CodeMirror editor functionality.
- Fixs redirection after XML validation to webui2 flash view.
    
Co-authored-by: Björn Geuken <bgeuken@suse.de>
Co-authored-by: David Kang <dkang@suse.com>
