### PR TITLE
Prevent text in modals to overlap

### DIFF
--- a/src/api/app/assets/stylesheets/webui2/modals.scss
+++ b/src/api/app/assets/stylesheets/webui2/modals.scss
@@ -1,3 +1,7 @@
 .modal h5 {
     color: initial;
 }
+
+.modal-body p {
+    white-space: pre-wrap;
+}


### PR DESCRIPTION
The text was rendered outside the modal. Fixes https://github.com/openSUSE/open-build-service/issues/5921. :bowtie: 

![image](https://user-images.githubusercontent.com/16052290/46151446-14beb100-c26f-11e8-9842-cc97fd5af081.png)
