### PR TITLE
Fix flickering views in webui2

### DIFF
--- a/src/api/app/assets/stylesheets/webui2/webui2.css.scss
+++ b/src/api/app/assets/stylesheets/webui2/webui2.css.scss
@@ -36,3 +36,8 @@
 @import 'comments';
 @import 'cm2';
 @import 'live_build_log';
+
+html {
+    overflow-y: scroll !important;
+}
+


### PR DESCRIPTION
There was a strange effect between long and short pages, as the second ones were hiding the scrollbar. Showing always the scrollbar fixes that issue. :bowtie: 

This worked in last version of Firefox because there (at least by default) the scrollbar is always present and it is just disabled when not needed.

Fixes https://github.com/openSUSE/open-build-service/issues/5939