### PR TITLE
Migrate Package revision diff to bootstrap

### DIFF
--- a/src/api/app/assets/javascripts/webui2/packages.js
+++ b/src/api/app/assets/javascripts/webui2/packages.js
@@ -14,5 +14,17 @@ $(function ($) {
       editor.refresh();
     },1);
   });
-});
 
+  $('#expand-diffs').on('click', function () {
+    var details = $('details.card.details-with-codemirror');
+    details.attr('open', 'open');
+    $('.CodeMirror').each(function(){
+      $(this)[0].CodeMirror.refresh();
+    });
+  });
+
+  $('#collapse-diffs').on('click', function () {
+    var details = $('details.card.details-with-codemirror');
+    details.attr('open', null);
+  });
+});

--- a/src/api/app/assets/javascripts/webui2/packages.js
+++ b/src/api/app/assets/javascripts/webui2/packages.js
@@ -7,4 +7,12 @@ $(function ($) {
   $inputs.on('change', function () {
     $inputs.not(this).prop('required', !$(this).val().length);
   });
+
+  $('details.details-with-codemirror').on('click', function () {
+    var editor = $(this).find('.CodeMirror')[0].CodeMirror;
+    window.setTimeout(function() {
+      editor.refresh();
+    },1);
+  });
 });
+

--- a/src/api/app/assets/stylesheets/webui2/cm2.scss
+++ b/src/api/app/assets/stylesheets/webui2/cm2.scss
@@ -1,2 +1,9 @@
 @import "cm2/toolbars";
 @import "cm2/suse";
+
+.diff-menu-buttons {
+  position: absolute;
+  top: 0.55rem;
+  right: 0.55rem;
+  z-index: 4;
+}

--- a/src/api/app/controllers/webui/package_controller.rb
+++ b/src/api/app/controllers/webui/package_controller.rb
@@ -489,6 +489,19 @@ class Webui::PackageController < Webui::WebuiController
     @files = filenames['files']
     @not_full_diff = @files.any? { |file| file[1]['diff'].try(:[], 'shown') }
     @filenames = filenames['filenames']
+
+    # TODO: moved from the old view, needs refactoring
+    @submit_url_opts = { action: 'submit_request_dialog', project: @project, package: @package, revision: @rev }
+    if @oproject && @opackage && !@oproject.find_attribute('OBS', 'RejectRequests') && !@opackage.find_attribute('OBS', 'RejectRequests')
+      @submit_message = "Submit to #{@oproject.name}/#{@opackage.name}"
+      @submit_url_opts[:target_project] = @oproject.name
+      @submit_url_opts[:targetpackage] = @opackage.name
+    elsif @rev != @last_rev
+      @submit_message = "Revert #{@project.name}/#{@package.name} to revision #{@rev}"
+      @submit_url_opts[:target_project] = @project.name
+    end
+
+    switch_to_webui2
   end
 
   def save_new

--- a/src/api/app/helpers/webui/package_helper.rb
+++ b/src/api/app/helpers/webui/package_helper.rb
@@ -88,4 +88,28 @@ module Webui::PackageHelper
   def uploadable?(filename, architecture)
     ::Cloud::UploadJob.new(filename: filename, arch: architecture).uploadable?
   end
+
+  def badge_for_diff_state(state)
+    case state
+    when 'added'
+      'badge-success'
+    when 'deleted'
+      'badge-danger'
+    when 'changed'
+      'badge-warning'
+    else
+      'badge-primary'
+    end
+  end
+
+  def expand_diff?(filename, state)
+    state != 'deleted' &&
+      !filename.include?('/') &&
+      (filename == '_patchinfo' || filename.ends_with?('.spec') || filename.ends_with?('.changes'))
+  end
+
+  def calculate_revision_on_state(revision, state)
+    result = revision.to_i
+    state == 'deleted' && result > 0 ? result - 1 : result
+  end
 end

--- a/src/api/app/helpers/webui/package_helper.rb
+++ b/src/api/app/helpers/webui/package_helper.rb
@@ -110,6 +110,7 @@ module Webui::PackageHelper
 
   def calculate_revision_on_state(revision, state)
     result = revision.to_i
-    state == 'deleted' && result > 0 ? result - 1 : result
+    result -= 1 if state == 'deleted'
+    [result, 0].max
   end
 end

--- a/src/api/app/views/webui2/shared/_truncated_diff_hint.html.haml
+++ b/src/api/app/views/webui2/shared/_truncated_diff_hint.html.haml
@@ -1,0 +1,4 @@
+.alert.alert-warning{ role: :alert }
+  %i.fa.fa-exclamation-triangle.text-warning
+  We truncated the diff of some files because they were too big.
+  If you want to see the full diff for every file, #{link_to 'click here', path}.

--- a/src/api/app/views/webui2/webui/package/_revision_diff_detail.html.haml
+++ b/src/api/app/views/webui2/webui/package/_revision_diff_detail.html.haml
@@ -1,0 +1,14 @@
+%details.card.details-with-codemirror{ open: expand_diff?(filename, file['state']), id: "revision_details_#{index}" }
+  %summary.card-header
+    = filename
+    %span.badge{ class: badge_for_diff_state(file['state']) }= file['state'].capitalize
+    .btn-group.float-right{ role: :group }
+      - unless @linkinfo
+        = link_to_unless(Package.is_binary_file?(filename) || filename.include?('/'),
+        'View file',
+        package_view_file_path(project: project, package: package, filename: filename, rev: calculate_revision_on_state(revision, file['state'])),
+        class: 'btn btn-sm btn-outline-secondary', title: 'View the whole file')
+      - if index.positive?
+        %a.btn.btn-sm.btn-outline-secondary.fas.fa-chevron-up{ style: 'height: 16px, width: 16px', href: "#revision_details_#{index - 1}", title: 'Go up to the previous diff' }
+  %div
+    = render partial: 'shared/editor', locals: { text: file.dig('diff', '_content'), mode: 'diff', style: { read_only: true } }

--- a/src/api/app/views/webui2/webui/package/_revision_diff_detail.html.haml
+++ b/src/api/app/views/webui2/webui/package/_revision_diff_detail.html.haml
@@ -1,16 +1,19 @@
-%details.card.details-with-codemirror{ open: expand_diff?(filename, file['state']), id: "revision_details_#{index}" }
-  %summary.card-header
-    = filename
-    %span.badge{ class: badge_for_diff_state(file['state']) }= file['state'].capitalize
-    .btn-group.float-right{ role: :group }
-      - if index.positive?
-        %a.btn.btn-sm.btn-outline-secondary.fas.fa-chevron-up{ href: "#revision_details_#{index - 1}", title: 'Go up to the previous diff' }
-      - unless last
-        %a.btn.btn-sm.btn-outline-secondary.fas.fa-chevron-down{ href: "#revision_details_#{index + 1}", title: 'Go down to the next diff' }
-      - unless @linkinfo
-        = link_to_unless(Package.is_binary_file?(filename) || filename.include?('/'),
-        'View file',
-        package_view_file_path(project: project, package: package, filename: filename, rev: calculate_revision_on_state(revision, file['state'])),
-        class: 'btn btn-sm btn-outline-secondary', title: 'View the whole file')
-  %div
-    = render partial: 'shared/editor', locals: { text: file.dig('diff', '_content'), mode: 'diff', style: { read_only: true } }
+.position-relative
+  .btn-group.diff-menu-buttons{ role: :group }
+    - if index.positive?
+      %a.btn.btn-sm.btn-outline-secondary{ href: "#revision_details_#{index - 1}", title: 'Go up to the previous diff' }
+        %i.fas.fa-chevron-up
+    - unless last
+      %a.btn.btn-sm.btn-outline-secondary{ href: "#revision_details_#{index + 1}", title: 'Go down to the next diff' }
+        %i.fas.fa-chevron-down
+    - unless @linkinfo
+      = link_to_unless(Package.is_binary_file?(filename) || filename.include?('/'),
+      'View file',
+      package_view_file_path(project: project, package: package, filename: filename, rev: calculate_revision_on_state(revision, file['state'])),
+      class: 'btn btn-sm btn-outline-secondary', title: 'View the whole file')
+  %details.card.details-with-codemirror{ open: expand_diff?(filename, file['state']), id: "revision_details_#{index}" }
+    %summary.card-header
+      = filename
+      %span.badge{ class: badge_for_diff_state(file['state']) }= file['state'].capitalize
+    %div
+      = render partial: 'shared/editor', locals: { text: file.dig('diff', '_content'), mode: 'diff', style: { read_only: true } }

--- a/src/api/app/views/webui2/webui/package/_revision_diff_detail.html.haml
+++ b/src/api/app/views/webui2/webui/package/_revision_diff_detail.html.haml
@@ -3,12 +3,14 @@
     = filename
     %span.badge{ class: badge_for_diff_state(file['state']) }= file['state'].capitalize
     .btn-group.float-right{ role: :group }
+      - if index.positive?
+        %a.btn.btn-sm.btn-outline-secondary.fas.fa-chevron-up{ href: "#revision_details_#{index - 1}", title: 'Go up to the previous diff' }
+      - unless last
+        %a.btn.btn-sm.btn-outline-secondary.fas.fa-chevron-down{ href: "#revision_details_#{index + 1}", title: 'Go down to the next diff' }
       - unless @linkinfo
         = link_to_unless(Package.is_binary_file?(filename) || filename.include?('/'),
         'View file',
         package_view_file_path(project: project, package: package, filename: filename, rev: calculate_revision_on_state(revision, file['state'])),
         class: 'btn btn-sm btn-outline-secondary', title: 'View the whole file')
-      - if index.positive?
-        %a.btn.btn-sm.btn-outline-secondary.fas.fa-chevron-up{ style: 'height: 16px, width: 16px', href: "#revision_details_#{index - 1}", title: 'Go up to the previous diff' }
   %div
     = render partial: 'shared/editor', locals: { text: file.dig('diff', '_content'), mode: 'diff', style: { read_only: true } }

--- a/src/api/app/views/webui2/webui/package/_revision_diff_footer.html.haml
+++ b/src/api/app/views/webui2/webui/package/_revision_diff_footer.html.haml
@@ -6,7 +6,7 @@
     = user_with_realname_and_icon(request['decliner'], short: true)
     with the following message:
     %pre= request['comment']
-- if submit_message
+- if submit_message && show_revert_link
   %p
     = link_to(submit_url_opts, remote: true) do
       %i.fas.fa-share-square.text-warning

--- a/src/api/app/views/webui2/webui/package/_revision_diff_footer.html.haml
+++ b/src/api/app/views/webui2/webui/package/_revision_diff_footer.html.haml
@@ -1,0 +1,13 @@
+- if request.present?
+  %p
+    The previous request
+    = link_to(request['id'], request_show_path(project, package, request['id']))
+    was declined #{fuzzy_time_string(request['when'])} by
+    = user_with_realname_and_icon(request['decliner'], short: true)
+    with the following message:
+    %pre= request['comment']
+- if submit_message
+  %p
+    = link_to(submit_url_opts, remote: true) do
+      %i.fas.fa-share-square.text-warning
+      = submit_message

--- a/src/api/app/views/webui2/webui/package/rdiff.html.haml
+++ b/src/api/app/views/webui2/webui/package/rdiff.html.haml
@@ -41,4 +41,9 @@
           %p No source changes.
           %br
         = render partial: 'revision_diff_footer',
-        locals: { project: @project, package: @package, request: @last_req, submit_message: @submit_message, submit_url_opts: @submit_url_opts }
+        locals: { project: @project,
+          package: @package,
+          request: @last_req,
+          submit_message: @submit_message,
+          submit_url_opts: @submit_url_opts,
+          show_revert_link: !User.current.is_nobody? && @filenames.present? }

--- a/src/api/app/views/webui2/webui/package/rdiff.html.haml
+++ b/src/api/app/views/webui2/webui/package/rdiff.html.haml
@@ -18,7 +18,13 @@
     - if @filenames.present?
       - @filenames.each_with_index do |filename, index|
         = render partial: 'revision_diff_detail',
-        locals: { project: @project, package: @package, filename: filename, file: @files[filename], revision: @rev, index: index }
+        locals: { project: @project,
+          package: @package,
+          filename: filename,
+          file: @files[filename],
+          revision: @rev,
+          index: index,
+          last: @filenames.last == filename }
         %br
     - else
       %p No source changes.

--- a/src/api/app/views/webui2/webui/package/rdiff.html.haml
+++ b/src/api/app/views/webui2/webui/package/rdiff.html.haml
@@ -1,0 +1,27 @@
+- content_for(:content_for_head, javascript_include_tag('webui2/cm2/index-diff'))
+- @pagetitle = "Changes of Revision #{@rev}"
+
+- if @not_full_diff
+  = render partial: 'webui2/shared/truncated_diff_hint',
+  locals: { path: package_rdiff_path(project: @project, package: @package, linkrev: @linkrev, rev: @rev, full_diff: true) }
+
+.card
+  = render partial: 'tabs', locals: { project: @project, package: @package }
+  .card-body
+    - if @opackage
+      %h3
+        Difference Between Revision #{@rev}
+        and #{project_or_package_link project: @oproject.name, package: @opackage.name, short: true}
+    - else
+      %h3
+        Changes of Revision #{@rev}
+    - if @filenames.present?
+      - @filenames.each_with_index do |filename, index|
+        = render partial: 'revision_diff_detail',
+        locals: { project: @project, package: @package, filename: filename, file: @files[filename], revision: @rev, index: index }
+        %br
+    - else
+      %p No source changes.
+      %br
+    = render partial: 'revision_diff_footer',
+    locals: { project: @project, package: @package, request: @last_req, submit_message: @submit_message, submit_url_opts: @submit_url_opts }

--- a/src/api/app/views/webui2/webui/package/rdiff.html.haml
+++ b/src/api/app/views/webui2/webui/package/rdiff.html.haml
@@ -8,26 +8,37 @@
 .card
   = render partial: 'tabs', locals: { project: @project, package: @package }
   .card-body
-    - if @opackage
-      %h3
-        Difference Between Revision #{@rev}
-        and #{project_or_package_link project: @oproject.name, package: @opackage.name, short: true}
-    - else
-      %h3
-        Changes of Revision #{@rev}
-    - if @filenames.present?
-      - @filenames.each_with_index do |filename, index|
-        = render partial: 'revision_diff_detail',
-        locals: { project: @project,
-          package: @package,
-          filename: filename,
-          file: @files[filename],
-          revision: @rev,
-          index: index,
-          last: @filenames.last == filename }
-        %br
-    - else
-      %p No source changes.
-      %br
-    = render partial: 'revision_diff_footer',
-    locals: { project: @project, package: @package, request: @last_req, submit_message: @submit_message, submit_url_opts: @submit_url_opts }
+    .row
+      .col-sm-10
+        - if @opackage
+          %h3
+            Difference Between Revision #{@rev}
+            and #{project_or_package_link project: @oproject.name, package: @opackage.name, short: true}
+        - else
+          %h3
+            Changes of Revision #{@rev}
+      .col-sm-2
+        .btn-group.float-right
+          %button.btn.btn-sm.btn-outline-secondary#expand-diffs
+            Expand all
+          %button.btn.btn-sm.btn-outline-secondary#collapse-diffs
+            Collapse all
+    %br
+    .row
+      .col-sm-12
+        - if @filenames.present?
+          - @filenames.each_with_index do |filename, index|
+            = render partial: 'revision_diff_detail',
+            locals: { project: @project,
+              package: @package,
+              filename: filename,
+              file: @files[filename],
+              revision: @rev,
+              index: index,
+              last: @filenames.last == filename }
+            %br
+        - else
+          %p No source changes.
+          %br
+        = render partial: 'revision_diff_footer',
+        locals: { project: @project, package: @package, request: @last_req, submit_message: @submit_message, submit_url_opts: @submit_url_opts }

--- a/src/api/spec/helpers/webui/package_helper_spec.rb
+++ b/src/api/spec/helpers/webui/package_helper_spec.rb
@@ -253,4 +253,25 @@ RSpec.describe Webui::PackageHelper, type: :helper do
     it { expect(uploadable?('image.vhdfixed.xz', 'i386')).to be_falsy }
     it { expect(uploadable?('apache2.rpm', 'x86_64')).to be_falsy }
   end
+
+  describe '#expand_diff?' do
+    it { expect(expand_diff?('ctris.spec', 'added')).to be true }
+    it { expect(expand_diff?('_patchinfo', 'added')).to be true }
+    it { expect(expand_diff?('ctris.changes', 'added')).to be true }
+    it { expect(expand_diff?('ctris.changes', 'deleted')).to be false }
+    it { expect(expand_diff?('/foo/bar/test.txt', 'added')).to be false }
+  end
+
+  describe '#badge_for_diff_state' do
+    it { expect(badge_for_diff_state('added')).to eq('badge-success') }
+    it { expect(badge_for_diff_state('deleted')).to eq('badge-danger') }
+    it { expect(badge_for_diff_state('changed')).to eq('badge-warning') }
+    it { expect(badge_for_diff_state('other')).to eq('badge-primary') }
+  end
+
+  describe '#calculate_revision_on_state' do
+    it { expect(calculate_revision_on_state('1', 'deleted')).to eq(0) }
+    it { expect(calculate_revision_on_state('0', 'deleted')).to eq(0) }
+    it { expect(calculate_revision_on_state('1', 'added')).to eq(1) }
+  end
 end


### PR DESCRIPTION
To continue our efforts to migrate the whole frontend to bootstrap.
https://github.com/openSUSE/open-build-service/wiki/How-to-work-in-Bootstrap-%28new-UI%29

## Not expanded diffs
![selection_026](https://user-images.githubusercontent.com/3799140/46200148-2d7fa300-c311-11e8-99b2-a242be98935b.png)

## Small expanded diff
![selection_027](https://user-images.githubusercontent.com/3799140/46200158-32dced80-c311-11e8-8e5f-c1689fb7eb8f.png)

## Large expanded diff
![selection_028](https://user-images.githubusercontent.com/3799140/46200172-3a03fb80-c311-11e8-809c-b996604ff072.png)

