### PR TITLE
Fix Nil exception in staging dashboard

### DIFF
--- a/src/api/app/views/webui/obs_factory/staging_projects/_checks.html.haml
+++ b/src/api/app/views/webui/obs_factory/staging_projects/_checks.html.haml
@@ -3,7 +3,7 @@
   Checks
   = "(#{@build_id})"
 %dd
-  - if @checks.empty? && @missing_checks.empty?
+  - if @checks.blank? && @missing_checks.blank?
     None.
   - else
     %ul


### PR DESCRIPTION
@checks and @missing_checks can be nil so we need to check blank instead of empty.