### PR TITLE
Align dropdown menu to the right

### DIFF
--- a/src/api/app/views/layouts/webui2/_watchlist_dropdown.html.haml
+++ b/src/api/app/views/layouts/webui2/_watchlist_dropdown.html.haml
@@ -1,6 +1,6 @@
 %button.btn.btn-link.nav-link.dropdown-toggle#watchlist{ aria: { expanded: false, haspopup: true }, data: { toggle: 'dropdown', offset: 150 } }
   Watchlist
-.dropdown-menu{ aria: { labelledby: 'watchlist' } }
+.dropdown-menu.dropdown-menu-right{ aria: { labelledby: 'watchlist' } }
   .dropdown-header
     List of projects you are watching
   .dropdown-divider


### PR DESCRIPTION
Small aesthetics fix, aligns dropdown to the right side of the dropdown button
![screenshot from 2018-09-28 23-38-02](https://user-images.githubusercontent.com/30577011/46234663-a87ba480-c377-11e8-805c-68df626c5cff.png)
![screenshot from 2018-09-28 23-37-48](https://user-images.githubusercontent.com/30577011/46234661-a87ba480-c377-11e8-9224-10bfad4dd38f.png)

