### PR TITLE
[webui] Fix checkboxes for supersedeing requests in package view

### DIFF
--- a/src/api/app/views/webui2/webui/package/_submit_request_dialog.html.haml
+++ b/src/api/app/views/webui2/webui/package/_submit_request_dialog.html.haml
@@ -37,7 +37,7 @@
 
           .form-group.d-none#supersede-display
             = label_tag(:supersede_requests, 'Supersede requests:')
-            %p#supersede-requests
+            #supersede-requests
 
           .custom-control.custom-checkbox#sourceupdate-display
             = check_box_tag(:sourceupdate, 'cleanup', cleanup_source, class: 'custom-control-input')

--- a/src/api/app/views/webui2/webui/request/_requests_small.html.haml
+++ b/src/api/app/views/webui2/webui/request/_requests_small.html.haml
@@ -2,12 +2,12 @@
   %p No requests.
 - else
   %ul.list-unstyled
-    - requests.each_with_index do |req, index|
+    - requests.each_with_index do |req, _index|
       %li
         .custom-control.custom-checkbox
           = check_box_tag('supersede_request_numbers[]', req.number, false,
             id: "supersede_request_numbers#{req.number}", class: 'custom-control-input')
-          = label_tag("supersede_request_numbers#{index + 1}", class: 'custom-control-label') do
+          = label_tag("supersede_request_numbers#{req.number}", class: 'custom-control-label') do
             = link_to(req.number, controller: :request, action: :show, number: req.number)
             by
             = user_with_realname_and_icon(req.creator, short: true)


### PR DESCRIPTION
Apparently, the number of supersede didn't work properly, and also apparently checkbox inside p inside modal-content causes weird newlines to appear:
![screenshot from 2018-10-01 00-03-56](https://user-images.githubusercontent.com/30577011/46263493-6174e700-c510-11e8-8f7c-a1a83c004200.png)
![screenshot from 2018-10-01 00-04-15](https://user-images.githubusercontent.com/30577011/46263494-620d7d80-c510-11e8-92ed-620b2c1e5058.png)
