### PR TITLE
Bootstrap/fix issue hit enter in input

### DIFF
--- a/src/api/app/views/webui2/shared/_dialog_action_buttons.html.haml
+++ b/src/api/app/views/webui2/shared/_dialog_action_buttons.html.haml
@@ -1,4 +1,4 @@
-%button.btn.btn-sm.btn-outline-danger.px-4{ data: { dismiss: 'modal' } }
+%a.btn.btn-sm.btn-outline-danger.px-4{ data: { dismiss: 'modal' } }
   Cancel
 = submit_tag('Accept', class: 'btn btn-sm btn-primary px-4')
 

--- a/src/api/app/views/webui2/webui/attribute/_delete_dialog.html.haml
+++ b/src/api/app/views/webui2/webui/attribute/_delete_dialog.html.haml
@@ -8,6 +8,6 @@
         %p Please confirm deletion of attribute #{attribute.fullname}
         = form_tag(attrib_path(attribute), method: :delete) do
           .modal-footer
-            %button.btn.btn-sm.btn-outline-secondary.px-4{ data: { dismiss: 'modal' } }
+            %a.btn.btn-sm.btn-outline-secondary.px-4{ data: { dismiss: 'modal' } }
               Cancel
             = submit_tag('Delete', class: 'btn btn-sm btn-danger px-4')

--- a/src/api/app/views/webui2/webui/comment/_delete_dialog.html.haml
+++ b/src/api/app/views/webui2/webui/comment/_delete_dialog.html.haml
@@ -10,6 +10,6 @@
 
         = form_tag(comment_path(comment), method: :delete, remote: true) do
           .modal-footer
-            %button.btn.btn-sm.btn-outline-secondary.px-4{ data: { dismiss: 'modal' } }
+            %a.btn.btn-sm.btn-outline-secondary.px-4{ data: { dismiss: 'modal' } }
               Cancel
             = submit_tag('Delete', class: 'btn btn-sm btn-danger px-4')

--- a/src/api/app/views/webui2/webui/main/_add_status_message_modal.html.haml
+++ b/src/api/app/views/webui2/webui/main/_add_status_message_modal.html.haml
@@ -3,17 +3,13 @@
     .modal-content
       .modal-header
         %h5.modal-title Add Status Message
-        %button.close{ 'aria-label' => 'Close', 'data-dismiss' => 'modal', type: 'button' }
-          %span{ 'aria-hidden' => 'true' } ×
       .modal-body
         = form_tag({ controller: 'status_messages', action: 'create' }, method: 'post') do
-          %p
+          .form-group
             = label_tag(:message, 'Message:')
-            %br/
             = text_area_tag(:message, '', size: '40x3', required: true, class: 'form-control')
-            %br/
+          .form-group
             = label_tag(:severity, 'Severity:')
-            %br/
             = select_tag(:severity, options_for_select([['Information', 0], ['Green', 1], ['Yellow', 2], ['Red', 3]]), class: 'form-control')
           .modal-footer
-            = submit_tag('Save changes', class: 'btn btn-success')
+            = render partial: 'webui2/shared/dialog_action_buttons'

--- a/src/api/app/views/webui2/webui/package/_branch_dialog.html.haml
+++ b/src/api/app/views/webui2/webui/package/_branch_dialog.html.haml
@@ -3,7 +3,7 @@
     .modal-content
       .modal-header
         %h5.modal-title#branch-modal-label Branch Confirmation
-        %button.close{ type: 'button', data: { dismiss: 'modal' }, aria: { label: 'Close' } }
+        %a.close{ type: 'button', data: { dismiss: 'modal' }, aria: { label: 'Close' } }
           %span{ aria: { hidden: true } } &times;
       .modal-body
         - branch_project = User.current.branch_project_name(project.name)

--- a/src/api/app/views/webui2/webui/package/_delete_dialog.html.haml
+++ b/src/api/app/views/webui2/webui/package/_delete_dialog.html.haml
@@ -24,6 +24,6 @@
               = label_tag(:force, 'Delete anyway?', class: 'custom-control-label')
 
           .modal-footer
-            %button.btn.btn-sm.btn-outline-secondary.px-4{ data: { dismiss: 'modal' } }
+            %a.btn.btn-sm.btn-outline-secondary.px-4{ data: { dismiss: 'modal' } }
               Cancel
             = submit_tag('Delete', class: 'btn btn-sm btn-danger px-4')

--- a/src/api/app/views/webui2/webui/package/_delete_file_dialog.html.haml
+++ b/src/api/app/views/webui2/webui/package/_delete_file_dialog.html.haml
@@ -8,6 +8,6 @@
         %p Please confirm deletion of file '#{filename}'
         = form_tag({ action: :remove_file, project: project, package: package, filename: filename }, method: :post) do
           .modal-footer
-            %button.btn.btn-sm.btn-outline-secondary.px-4{ data: { dismiss: 'modal' } }
+            %a.btn.btn-sm.btn-outline-secondary.px-4{ data: { dismiss: 'modal' } }
               Cancel
             = submit_tag('Delete', class: 'btn btn-sm btn-danger px-4')

--- a/src/api/app/views/webui2/webui/package/_linking_packages.html.haml
+++ b/src/api/app/views/webui2/webui/package/_linking_packages.html.haml
@@ -14,5 +14,5 @@
             end
           %li= link_to(name, package_show_path(project: linking_package.project.name, package: linking_package.name))
     .modal-footer
-      %button.btn.btn-sm.btn-outline-danger.px-4{ data: { dismiss: 'modal' } }
+      %a.btn.btn-sm.btn-outline-danger.px-4{ data: { dismiss: 'modal' } }
         Cancel


### PR DESCRIPTION
Before we had buttons for canceling a dialog that converted it in the
default action to take when hitting enter inside an input field.

Now we replaced the buttons with anchors styled properly, that way the
default action is to submit the dialog instead of canceling.

It fixes #5959.
