### PR TITLE
Use custom file input bootstrap class

### DIFF
--- a/src/api/app/assets/javascripts/webui2/application.js
+++ b/src/api/app/assets/javascripts/webui2/application.js
@@ -27,6 +27,7 @@
 //= require webui2/attributes.js
 //= require webui2/packages.js
 //= require webui2/live_build_log.js
+//= require webui2/forms.js
 // FIXME refactor these files
 //= require webui2/autocomplete.js
 //= require webui2/comment.js

--- a/src/api/app/assets/javascripts/webui2/forms.js
+++ b/src/api/app/assets/javascripts/webui2/forms.js
@@ -3,6 +3,10 @@ $(document).ready(function() {
   $('.custom-file-input').on('change',function() {
       //get the file name
       var fileName = $(this).val();
+      // Most modern browser don't allow JS to access
+      // the full path of the file and show e.g. C:\fakepath
+      // As this is confusing we only show the filename and strip the path
+      fileName = fileName.replace(/^.*[\\\/]/, '');
       //replace the "Choose a file" label
       $(this).next('.custom-file-label').html(fileName);
   });

--- a/src/api/app/assets/javascripts/webui2/forms.js
+++ b/src/api/app/assets/javascripts/webui2/forms.js
@@ -1,0 +1,9 @@
+$(document).ready(function() {
+  // to resolve the filename in the label
+  $('.custom-file-input').on('change',function() {
+      //get the file name
+      var fileName = $(this).val();
+      //replace the "Choose a file" label
+      $(this).next('.custom-file-label').html(fileName);
+  });
+});

--- a/src/api/app/views/webui2/webui/package/add_file.html.haml
+++ b/src/api/app/views/webui2/webui/package/add_file.html.haml
@@ -20,7 +20,7 @@
         %small.form-text.text-muted
           URLs to src.rpm files will get extracted. URLs to git repositories will get stored in a tar ball.
       .form-group
-        %label{ for: :file }
-          %strong or select file:
-        = file_field_tag 'file', class: 'form-control-file', required: true
+        .custom-file
+          = file_field_tag 'file', class: 'custom-file-input', id: 'file', required: true
+          %label.custom-file-label{ for: 'file' } Choose a file
       = submit_tag 'Save', class: 'btn btn-sm btn-primary', id: :submit_button


### PR DESCRIPTION
for add file view.
Because this is what we decided in the pattern library so we need to change it
to follow.

Please note that this requires also that we have now JS for updating the label / what is in the input field.

![selection_031](https://user-images.githubusercontent.com/3799140/46286249-c7985300-c57e-11e8-9d9a-875e10b3f8d3.png)

vs.

![selection_032](https://user-images.githubusercontent.com/3799140/46286254-cb2bda00-c57e-11e8-8b0a-8992d794e3a9.png)


Also note that e.g. chrome does not allow JS to get the whole path to the file and replaces the path e.g. with ``C:\fakepath\...`` for security reasons. From my POV this is fine but I'm also fine if we e.g. drop the path and just show the filename? 