### PR TITLE
Fix the attributes table in mobile size

### DIFF
--- a/src/api/app/assets/javascripts/webui2/attributes.js
+++ b/src/api/app/assets/javascripts/webui2/attributes.js
@@ -6,4 +6,12 @@ $(document).ready(function() {
     $("[id^='attribute_type-description-']:visible").addClass('d-none');
     $('#attribute_type-description-' + $(this).val()).removeClass('d-none');
   });
+
+  $('#attributes').dataTable({
+    responsive: true,
+    info: false,
+    searching: false,
+    paging: false,
+    ordering: false
+  });
 });

--- a/src/api/app/views/webui2/webui/attribute/index.html.haml
+++ b/src/api/app/views/webui2/webui/attribute/index.html.haml
@@ -6,35 +6,35 @@
   .card-body
     %h3= @pagetitle
     - if @attributes.present?
-      .table-responsive
-        %table.table.table-hover#attributes
-          %thead.thead-light
+      %table.responsive.table.table-hover.w-100#attributes
+        %thead.thead-light
+          %tr
+            %th.col-auto{ scope: 'col' } Attributes
+            %th.col{ scope: 'col' } Values
+            - if policy(@package).update?
+              %th.col-auto{ scope: 'col' } Actions
+        %tbody
+          - @attributes.each do |attribute|
             %tr
-              %th.col-auto{ scope: 'col' } Attributes
-              %th.col{ scope: 'col' } Values
+              %td.col-6.text-word-break-all= attribute.fullname
+              %td.col-4
+                %ul
+                  - unless attribute.values.empty?
+                    - attribute.values.each do |v|
+                      %li.value
+                        %pre.d-inline= v.value
+                  - unless attribute.issues.empty?
+                    %li= attribute.issues.map(&:name).to_sentence
               - if policy(@package).update?
-                %th.col-auto{ scope: 'col' } Actions
-          %tbody
-            - @attributes.each do |attribute|
-              %tr
-                %td= attribute.fullname
-                %td
-                  %ul
-                    - unless attribute.values.empty?
-                      - attribute.values.each do |v|
-                        %li.value
-                          %pre.d-inline= v.value
-                    - unless attribute.issues.empty?
-                      %li= attribute.issues.map(&:name).to_sentence
-                - if policy(@package).update?
-                  %td
-                    - if attribute.values_editable?
-                      = link_to(edit_attribs_path(project: @project.name, package: @package, attribute: attribute.fullname), title: 'Edit values') do
-                        %i.fas.fa-edit.text-info
-                    = render(partial: 'delete_dialog', locals: { attribute: attribute })
-                    = link_to('#', data: { toggle: 'modal', target: "#delete-attribute-modal-#{attribute.id}" },
-                              title: 'Delete attribute') do
-                      %i.fas.fa-times-circle.text-danger
+                %td.col-2
+                  - if attribute.values_editable?
+                    = link_to(edit_attribs_path(project: @project.name, package: @package, attribute: attribute.fullname), title: 'Edit values') do
+                      %i.fas.fa-edit.text-info
+                  = link_to('#', data: { toggle: 'modal', target: "#delete-attribute-modal-#{attribute.id}" },
+                            title: 'Delete attribute') do
+                    %i.fas.fa-times-circle.text-danger
+            - if policy(@package).update?
+              = render(partial: 'delete_dialog', locals: { attribute: attribute })
     - else
       %p
         %em No attributes set


### PR DESCRIPTION
Before the table was using basic responsive style adding
horizontal scrolls and now is using datatables to hide the
columns.

![image](https://user-images.githubusercontent.com/11314634/46344065-38537400-c640-11e8-8477-8d3ada5ba34d.png)

This fixes #5984