### PR TITLE
Fix several issues on the revision diff

### DIFF
--- a/src/api/app/views/webui2/webui/package/_revision_diff_detail.html.haml
+++ b/src/api/app/views/webui2/webui/package/_revision_diff_detail.html.haml
@@ -6,11 +6,11 @@
     - unless last
       %a.btn.btn-sm.btn-outline-secondary{ href: "#revision_details_#{index + 1}", title: 'Go down to the next diff' }
         %i.fas.fa-chevron-down
-    - unless @linkinfo
-      = link_to_unless(Package.is_binary_file?(filename) || filename.include?('/'),
-      'View file',
+    - unless @linkinfo || Package.is_binary_file?(filename) || filename.include?('/')
+      = link_to 'View file',
       package_view_file_path(project: project, package: package, filename: filename, rev: calculate_revision_on_state(revision, file['state'])),
-      class: 'btn btn-sm btn-outline-secondary', title: 'View the whole file')
+      class: 'btn btn-sm btn-outline-secondary',
+      title: 'View the whole file'
   %details.card.details-with-codemirror{ open: expand_diff?(filename, file['state']), id: "revision_details_#{index}" }
     %summary.card-header
       = filename

--- a/src/api/app/views/webui2/webui/package/_revision_diff_detail.html.haml
+++ b/src/api/app/views/webui2/webui/package/_revision_diff_detail.html.haml
@@ -13,7 +13,7 @@
       title: 'View the whole file'
   %details.card.details-with-codemirror{ open: expand_diff?(filename, file['state']), id: "revision_details_#{index}" }
     %summary.card-header
-      = filename
+      = calculate_filename(filename, file)
       %span.badge{ class: badge_for_diff_state(file['state']) }= file['state'].capitalize
     %div
       = render partial: 'shared/editor', locals: { text: file.dig('diff', '_content'), mode: 'diff', style: { read_only: true } }


### PR DESCRIPTION
* Do not show 'View file' link for special files (e.g. binaries, path and without a linkinfo)
* Calculate the filename (not relevant for this view but for the request diff in the future)