### PR TITLE
Fix colors for links that emulate outline buttons

### DIFF
--- a/src/api/app/assets/stylesheets/webui2/links.scss
+++ b/src/api/app/assets/stylesheets/webui2/links.scss
@@ -2,9 +2,16 @@ $link-hover-color: $obs_green;
 $link-color: $obs_blue;
 
 a {
-    &:hover {
-        i.fa, i.fas, i.fal {            
-            filter: brightness(0.7);
-        }
+  &:hover {
+    i.fa, i.fas, i.fal {
+      filter: brightness(0.7);
     }
+  }
+}
+
+a.btn {
+  &.btn-outline-danger { @extend .btn-outline-danger; }
+  &.btn-outline-warning { @extend .btn-outline-warning; }
+  &.btn-outline-primary { @extend .btn-outline-primary; }
+  &.btn-outline-secondary { @extend .btn-outline-secondary; }
 }


### PR DESCRIPTION
In modal dialogs, the color of the text inside the cancel button should be the
same as its boder's color or white when hover.

Fixes: #5992

Co-authored-by: David Kang <dkang@suse.com>

**Before (with hover):**
![screenshot-2018-10-2 show devel languages python python-abimap - open build service 2](https://user-images.githubusercontent.com/2581944/46350037-fa604b00-c653-11e8-8d7e-4d3bc52bc954.png)

**After (without hover):**
![screenshot-2018-10-2 show devel languages python python-abimap - open build service 3](https://user-images.githubusercontent.com/2581944/46350133-3bf0f600-c654-11e8-83fb-04c72dfc6b54.png)

**After (with hover):**
![screenshot-2018-10-2 show devel languages python python-abimap - open build service 1](https://user-images.githubusercontent.com/2581944/46350071-106e0b80-c654-11e8-8b21-0fb2e89ab7ac.png)
