### PR TITLE
Fix revision diff for small devices

### DIFF
--- a/src/api/app/views/webui2/webui/package/_revision_diff_detail.html.haml
+++ b/src/api/app/views/webui2/webui/package/_revision_diff_detail.html.haml
@@ -7,7 +7,8 @@
       %a.btn.btn-sm.btn-outline-secondary.d-none.d-sm-none.d-md-block{ href: "#revision_details_#{index + 1}", title: 'Go down to the next diff' }
         %i.fas.fa-chevron-down
     - unless @linkinfo || Package.is_binary_file?(filename) || filename.include?('/')
-      = link_to package_view_file_path(project: project, package: package, filename: filename, rev: calculate_revision_on_state(revision, file['state'])),
+      - link_options = { project: project, package: package, filename: filename, rev: calculate_revision_on_state(revision, file['state']) }
+      = link_to package_view_file_path(link_options),
       class: 'btn btn-sm btn-outline-secondary',
       title: 'View the whole file' do
         %i.far.fa-file.d-block.d-sm-block.d-md-none

--- a/src/api/app/views/webui2/webui/package/_revision_diff_detail.html.haml
+++ b/src/api/app/views/webui2/webui/package/_revision_diff_detail.html.haml
@@ -1,16 +1,17 @@
 .position-relative
   .btn-group.diff-menu-buttons{ role: :group }
     - if index.positive?
-      %a.btn.btn-sm.btn-outline-secondary{ href: "#revision_details_#{index - 1}", title: 'Go up to the previous diff' }
+      %a.btn.btn-sm.btn-outline-secondary.d-none.d-sm-none.d-md-block{ href: "#revision_details_#{index - 1}", title: 'Go up to the previous diff' }
         %i.fas.fa-chevron-up
     - unless last
-      %a.btn.btn-sm.btn-outline-secondary{ href: "#revision_details_#{index + 1}", title: 'Go down to the next diff' }
+      %a.btn.btn-sm.btn-outline-secondary.d-none.d-sm-none.d-md-block{ href: "#revision_details_#{index + 1}", title: 'Go down to the next diff' }
         %i.fas.fa-chevron-down
     - unless @linkinfo || Package.is_binary_file?(filename) || filename.include?('/')
-      = link_to 'View file',
-      package_view_file_path(project: project, package: package, filename: filename, rev: calculate_revision_on_state(revision, file['state'])),
+      = link_to package_view_file_path(project: project, package: package, filename: filename, rev: calculate_revision_on_state(revision, file['state'])),
       class: 'btn btn-sm btn-outline-secondary',
-      title: 'View the whole file'
+      title: 'View the whole file' do
+        %i.far.fa-file.d-block.d-sm-block.d-md-none
+        %span.d-none.d-sm-none.d-md-block View file
   %details.card.details-with-codemirror{ open: expand_diff?(filename, file['state']), id: "revision_details_#{index}" }
     %summary.card-header
       = calculate_filename(filename, file)


### PR DESCRIPTION
On small devices we hide now the the 'jump' buttons (for jumping from diff to diff)
because it does not provide much value on a small device.
Additionally we show an icon for view file on small devices to save space.

Large screen:
![selection_037](https://user-images.githubusercontent.com/3799140/46353641-013f8b80-c65d-11e8-96eb-4ad8d0c0f6e1.png)

Small screen:
![selection_038](https://user-images.githubusercontent.com/3799140/46353664-0ac8f380-c65d-11e8-9f45-b4e0c11d8175.png)

(Note that the first view file link is hidden because it is a binary file, I just mocked the filename to make it really long :blush: )