### PR TITLE
Fix clockwork systemd service

### DIFF
--- a/dist/systemd/obs-clockwork.service
+++ b/dist/systemd/obs-clockwork.service
@@ -7,8 +7,8 @@ Environment = "RAILS_ENV=production"
 User = wwwrun
 Group = www
 WorkingDirectory = /srv/www/obs/api
-ExecStart = /usr/lib64/obs-api/ruby/2.5.0/bin/clockworkd --log-dir=log -l -c config/clock.rb start
-ExecStop = /usr/lib64/obs-api/ruby/2.5.0/bin/clockworkd -l -c config/clock.rb stop
+ExecStart = /usr/bin/bundle.ruby2.5 exec /usr/lib64/obs-api/ruby/2.5.0/bin/clockworkd --log-dir=log -l -c config/clock.rb start
+ExecStop = /usr/bin/bundle.ruby2.5 exec /usr/lib64/obs-api/ruby/2.5.0/bin/clockworkd -l -c config/clock.rb stop
 Type = forking
 PIDFile = /srv/www/obs/api/tmp/clockworkd.clock.pid
 


### PR DESCRIPTION
Add missing "bundle exec" command. Without it the clockwork binary cannot find the other executables it depends on.

Co-authored-by: David Kang <dkang@suse.com>