### PR TITLE
Fix typo in bootstrap class in buildresult box

### DIFF
--- a/src/api/app/views/webui2/shared/_buildresult_box.html.haml
+++ b/src/api/app/views/webui2/shared/_buildresult_box.html.haml
@@ -18,7 +18,7 @@
           = link_to("#rpm#{index}", id: "rpm#{index}-tab", class: 'nav-link text-nowrap', data: { toggle: 'tab' },
             role: 'tab', aria: { controls: "rpm#{index}", selected: false }) do
             RPM Lint
-  .card-boby
+  .card-body
     .col-12
       .tab-content
         .tab-pane.fade.show.active{ id: "build#{index}", role: 'tabpanel', aria: { labelledby: "build#{index}-tab" } }


### PR DESCRIPTION
Since there was a typo in the bootstrap class it didn't had any effect