### PR TITLE
 Show confirmation modal before deleting binaries

### DIFF
--- a/src/api/app/views/webui2/webui/package/_delete_all_binaries_dialog.html.haml
+++ b/src/api/app/views/webui2/webui/package/_delete_all_binaries_dialog.html.haml
@@ -1,0 +1,13 @@
+.modal.fade{ id: 'delete-all-binaries-modal', tabindex: -1, role: 'dialog', aria: { labelledby: 'delete-modal-label', hidden: true } }
+  .modal-dialog.modal-dialog-centered{ role: 'document' }
+    .modal-content
+      .modal-header
+        %h5.modal-title
+          Delete all built binaries?
+      .modal-body
+        %p Please confirm deletion of all built binaries
+        = form_tag(package_wipe_binaries_path(project: project, package: package, repository: repository), method: :delete) do
+          .modal-footer
+            %a.btn.btn-sm.btn-outline-secondary.px-4{ data: { dismiss: 'modal' } }
+              Cancel
+            = submit_tag('Delete all', class: 'btn btn-sm btn-danger px-4')

--- a/src/api/app/views/webui2/webui/package/_delete_binaries_dialog.html.haml
+++ b/src/api/app/views/webui2/webui/package/_delete_binaries_dialog.html.haml
@@ -1,0 +1,13 @@
+.modal.fade{ id: "delete-binaries-modal-#{arch}", tabindex: -1, role: 'dialog', aria: { labelledby: 'delete-modal-label', hidden: true } }
+  .modal-dialog.modal-dialog-centered{ role: 'document' }
+    .modal-content
+      .modal-header
+        %h5.modal-title
+          Delete binaries?
+      .modal-body
+        %p Please confirm deletion of binaries for #{arch}
+        = form_tag(package_wipe_binaries_path(arch: arch, project: project, package: package, repository: repository), method: :delete) do
+          .modal-footer
+            %a.btn.btn-sm.btn-outline-secondary.px-4{ data: { dismiss: 'modal' } }
+              Cancel
+            = submit_tag('Delete', class: 'btn btn-sm btn-danger px-4')

--- a/src/api/app/views/webui2/webui/package/binaries.html.haml
+++ b/src/api/app/views/webui2/webui/package/binaries.html.haml
@@ -8,10 +8,10 @@
                                                                        download_url: @configuration['download_url'] }
       - unless @buildresults.empty?
         %li.list-inline-item
-          = link_to(package_wipe_binaries_path(project: @project, package: @package_name, repository: @repository),
-            method: :delete, class: 'nav-link') do
+          = link_to('#', data: { toggle: 'modal', target: '#delete-all-binaries-modal' }, title: 'Delete all built binaries') do
             %i.fas.fa-times-circle.text-danger
             Delete all built binaries
+          = render(partial: 'delete_all_binaries_dialog', locals: { project: @project, package: @package_name, repository: @repository })
 
     - @buildresults.each do |result|
       %h5.bg-light.p-2.mb-0

--- a/src/api/app/views/webui2/webui/package/binaries/_trigger_rebuild_wipe_binaries.html.haml
+++ b/src/api/app/views/webui2/webui/package/binaries/_trigger_rebuild_wipe_binaries.html.haml
@@ -5,7 +5,7 @@
     Trigger rebuild
 %li.list-inline-item
   - unless result[:binaries].empty?
-    = link_to(package_wipe_binaries_path(arch: result[:arch], project: project, package: package, repository: repository), method: :delete,
-    title: 'Wipe all binaries', class: 'nav-link') do
+    = link_to('#', data: { toggle: 'modal', target: "#delete-binaries-modal-#{result[:arch]}" }, title: 'Delete binaries') do
       %i.fas.fa-times-circle.text-danger
       Delete binaries
+    = render(partial: 'delete_binaries_dialog', locals: { arch: result[:arch], project: project, package: package, repository: repository })


### PR DESCRIPTION
Shows our customized modal dialog in both `Delete binaries` (per architecture) and `Delete all build binaries` actions.

Fixes #6002