### PR TITLE
Fix several issues on revision diff page

### DIFF
--- a/src/api/app/assets/stylesheets/webui2/cm2.scss
+++ b/src/api/app/assets/stylesheets/webui2/cm2.scss
@@ -1,13 +1,6 @@
 @import "cm2/toolbars";
 @import "cm2/suse";
 
-.diff-menu-buttons {
-  position: absolute;
-  top: 0.55rem;
-  right: 0.55rem;
-  z-index: 4;
-}
-
 .custom-file-label-with-overflow {
     @extend .custom-file-label;
     overflow: hidden;

--- a/src/api/app/assets/stylesheets/webui2/diff.scss
+++ b/src/api/app/assets/stylesheets/webui2/diff.scss
@@ -2,3 +2,10 @@
   inline-size: 75%;
   display: inline-block
 }
+
+.diff-menu-buttons {
+  position: absolute;
+  top: 0.55rem;
+  right: 0.55rem;
+  z-index: 4;
+}

--- a/src/api/app/assets/stylesheets/webui2/diff.scss
+++ b/src/api/app/assets/stylesheets/webui2/diff.scss
@@ -1,0 +1,4 @@
+.diff-card-header {
+  inline-size: 75%;
+  display: inline-block
+}

--- a/src/api/app/assets/stylesheets/webui2/webui2.css.scss
+++ b/src/api/app/assets/stylesheets/webui2/webui2.css.scss
@@ -37,6 +37,7 @@
 @import 'cm2';
 @import 'live_build_log';
 @import 'borders';
+@import 'diff';
 
 html {
     overflow-y: scroll !important;

--- a/src/api/app/views/webui2/webui/package/_revision_diff_detail.html.haml
+++ b/src/api/app/views/webui2/webui/package/_revision_diff_detail.html.haml
@@ -13,9 +13,15 @@
       title: 'View the whole file' do
         %i.far.fa-file.d-block.d-sm-block.d-md-none
         %span.d-none.d-sm-none.d-md-block View file
-  %details.card.details-with-codemirror{ open: expand_diff?(filename, file['state']), id: "revision_details_#{index}" }
-    %summary.card-header
-      = calculate_filename(filename, file)
-      %span.badge{ class: badge_for_diff_state(file['state']) }= file['state'].capitalize
-    %div
-      = render partial: 'shared/editor', locals: { text: file.dig('diff', '_content'), mode: 'diff', style: { read_only: true } }
+  - if diff_content.present?
+    %details.card.details-with-codemirror{ open: expand_diff?(filename, file['state']), id: "revision_details_#{index}" }
+      %summary.card-header
+        = calculate_filename(filename, file)
+        %span.badge{ class: badge_for_diff_state(file['state']) }= file['state'].capitalize
+      %div
+        = render partial: 'shared/editor', locals: { text: diff_content, mode: 'diff', style: { read_only: true } }
+  - else
+    .card{ id: "revision_details_#{index}" }
+      .card-header
+        = calculate_filename(filename, file)
+        %span.badge{ class: badge_for_diff_state(file['state']) }= file['state'].capitalize

--- a/src/api/app/views/webui2/webui/package/_revision_diff_detail.html.haml
+++ b/src/api/app/views/webui2/webui/package/_revision_diff_detail.html.haml
@@ -4,22 +4,28 @@
       %i.fas.fa-chevron-up
     %a.btn.btn-sm.btn-outline-secondary.d-none.d-sm-none.d-md-block{ class: ('disabled' if last), href: "#revision_details_#{index + 1}", title: 'Go down to the next diff' }
       %i.fas.fa-chevron-down
+    - link_options = { project: project, package: package, filename: filename, rev: calculate_revision_on_state(revision, file['state']) }
     - if !@linkinfo && (diff_content.present? && !Package.is_binary_file?(filename) && !filename.include?('/'))
-      - link_options = { project: project, package: package, filename: filename, rev: calculate_revision_on_state(revision, file['state']) }
       = link_to package_view_file_path(link_options),
-      class: 'btn btn-sm btn-outline-secondary',
-      title: 'View the whole file' do
-        %i.far.fa-file.d-block.d-sm-block.d-md-none
+        class: 'btn btn-sm btn-outline-secondary',
+        title: 'View the whole file' do
         %span.d-none.d-sm-none.d-md-block View file
+        %i.far.fa-file.d-block.d-sm-block.d-md-none
+    - else
+      %a.btn.btn-sm.btn-outline-secondary.disabled{ href: ''}
+        %span.d-none.d-sm-none.d-md-block View file
+        %i.far.fa-file.d-block.d-sm-block.d-md-none
   - if diff_content.present?
     %details.card.details-with-codemirror{ open: expand_diff?(filename, file['state']), id: "revision_details_#{index}" }
       %summary.card-header
-        = calculate_filename(filename, file)
-        %span.badge{ class: badge_for_diff_state(file['state']) }= file['state'].capitalize
+        .diff-card-header
+          = calculate_filename(filename, file)
+          %span.badge{ class: badge_for_diff_state(file['state']) }= file['state'].capitalize
       %div
         = render partial: 'shared/editor', locals: { text: diff_content, mode: 'diff', style: { read_only: true } }
   - else
     .card{ id: "revision_details_#{index}" }
       .card-header
-        = calculate_filename(filename, file)
-        %span.badge{ class: badge_for_diff_state(file['state']) }= file['state'].capitalize
+        .div.w-75
+          = calculate_filename(filename, file)
+          %span.badge{ class: badge_for_diff_state(file['state']) }= file['state'].capitalize

--- a/src/api/app/views/webui2/webui/package/_revision_diff_detail.html.haml
+++ b/src/api/app/views/webui2/webui/package/_revision_diff_detail.html.haml
@@ -1,20 +1,13 @@
 .position-relative
-  .btn-group.diff-menu-buttons{ role: :group }
-    %a.btn.btn-sm.btn-outline-secondary.d-none.d-sm-none.d-md-block{ class: ('disabled' if index.zero?), href: "#revision_details_#{index - 1}", title: 'Go up to the previous diff' }
-      %i.fas.fa-chevron-up
-    %a.btn.btn-sm.btn-outline-secondary.d-none.d-sm-none.d-md-block{ class: ('disabled' if last), href: "#revision_details_#{index + 1}", title: 'Go down to the next diff' }
-      %i.fas.fa-chevron-down
-    - link_options = { project: project, package: package, filename: filename, rev: calculate_revision_on_state(revision, file['state']) }
-    - if !@linkinfo && (diff_content.present? && !Package.is_binary_file?(filename) && !filename.include?('/'))
-      = link_to package_view_file_path(link_options),
-        class: 'btn btn-sm btn-outline-secondary',
-        title: 'View the whole file' do
-        %span.d-none.d-sm-none.d-md-block View file
-        %i.far.fa-file.d-block.d-sm-block.d-md-none
-    - else
-      %a.btn.btn-sm.btn-outline-secondary.disabled{ href: ''}
-        %span.d-none.d-sm-none.d-md-block View file
-        %i.far.fa-file.d-block.d-sm-block.d-md-none
+  = render partial: 'revision_diff_detail_buttons',
+  locals: { project: project,
+    package: package,
+    filename: filename,
+    revision: revision,
+    index: index,
+    last: last,
+    state: file['state'],
+    has_content: diff_content.present? }
   - if diff_content.present?
     %details.card.details-with-codemirror{ open: expand_diff?(filename, file['state']), id: "revision_details_#{index}" }
       %summary.card-header

--- a/src/api/app/views/webui2/webui/package/_revision_diff_detail.html.haml
+++ b/src/api/app/views/webui2/webui/package/_revision_diff_detail.html.haml
@@ -1,11 +1,9 @@
 .position-relative
   .btn-group.diff-menu-buttons{ role: :group }
-    - if index.positive?
-      %a.btn.btn-sm.btn-outline-secondary.d-none.d-sm-none.d-md-block{ href: "#revision_details_#{index - 1}", title: 'Go up to the previous diff' }
-        %i.fas.fa-chevron-up
-    - unless last
-      %a.btn.btn-sm.btn-outline-secondary.d-none.d-sm-none.d-md-block{ href: "#revision_details_#{index + 1}", title: 'Go down to the next diff' }
-        %i.fas.fa-chevron-down
+    %a.btn.btn-sm.btn-outline-secondary.d-none.d-sm-none.d-md-block{ class: ('disabled' unless index.positive?), href: "#revision_details_#{index - 1}", title: 'Go up to the previous diff' }
+      %i.fas.fa-chevron-up
+    %a.btn.btn-sm.btn-outline-secondary.d-none.d-sm-none.d-md-block{ class: ('disabled' if last), href: "#revision_details_#{index + 1}", title: 'Go down to the next diff' }
+      %i.fas.fa-chevron-down
     - if !@linkinfo && (diff_content.present? && !Package.is_binary_file?(filename) && !filename.include?('/'))
       - link_options = { project: project, package: package, filename: filename, rev: calculate_revision_on_state(revision, file['state']) }
       = link_to package_view_file_path(link_options),

--- a/src/api/app/views/webui2/webui/package/_revision_diff_detail.html.haml
+++ b/src/api/app/views/webui2/webui/package/_revision_diff_detail.html.haml
@@ -1,6 +1,6 @@
 .position-relative
   .btn-group.diff-menu-buttons{ role: :group }
-    %a.btn.btn-sm.btn-outline-secondary.d-none.d-sm-none.d-md-block{ class: ('disabled' unless index.positive?), href: "#revision_details_#{index - 1}", title: 'Go up to the previous diff' }
+    %a.btn.btn-sm.btn-outline-secondary.d-none.d-sm-none.d-md-block{ class: ('disabled' if index.zero?), href: "#revision_details_#{index - 1}", title: 'Go up to the previous diff' }
       %i.fas.fa-chevron-up
     %a.btn.btn-sm.btn-outline-secondary.d-none.d-sm-none.d-md-block{ class: ('disabled' if last), href: "#revision_details_#{index + 1}", title: 'Go down to the next diff' }
       %i.fas.fa-chevron-down

--- a/src/api/app/views/webui2/webui/package/_revision_diff_detail.html.haml
+++ b/src/api/app/views/webui2/webui/package/_revision_diff_detail.html.haml
@@ -6,7 +6,7 @@
     - unless last
       %a.btn.btn-sm.btn-outline-secondary.d-none.d-sm-none.d-md-block{ href: "#revision_details_#{index + 1}", title: 'Go down to the next diff' }
         %i.fas.fa-chevron-down
-    - unless @linkinfo || Package.is_binary_file?(filename) || filename.include?('/')
+    - if !@linkinfo && (diff_content.present? && !Package.is_binary_file?(filename) && !filename.include?('/'))
       - link_options = { project: project, package: package, filename: filename, rev: calculate_revision_on_state(revision, file['state']) }
       = link_to package_view_file_path(link_options),
       class: 'btn btn-sm btn-outline-secondary',

--- a/src/api/app/views/webui2/webui/package/_revision_diff_detail_buttons.html.haml
+++ b/src/api/app/views/webui2/webui/package/_revision_diff_detail_buttons.html.haml
@@ -1,0 +1,20 @@
+.btn-group.diff-menu-buttons{ role: :group }
+  %a.btn.btn-sm.btn-outline-secondary.d-none.d-sm-none.d-md-block{ class: ('disabled' if index.zero?),
+  href: "#revision_details_#{index - 1}",
+  title: 'Go up to the previous diff' }
+    %i.fas.fa-chevron-up
+  %a.btn.btn-sm.btn-outline-secondary.d-none.d-sm-none.d-md-block{ class: ('disabled' if last),
+  href: "#revision_details_#{index + 1}",
+  title: 'Go down to the next diff' }
+    %i.fas.fa-chevron-down
+  - link_options = { project: project, package: package, filename: filename, rev: calculate_revision_on_state(revision, state) }
+  - if !@linkinfo && (has_content && !Package.is_binary_file?(filename) && !filename.include?('/'))
+    = link_to package_view_file_path(link_options),
+      class: 'btn btn-sm btn-outline-secondary',
+      title: 'View the whole file' do
+      %span.d-none.d-sm-none.d-md-block View file
+      %i.far.fa-file.d-block.d-sm-block.d-md-none
+  - else
+    %a.btn.btn-sm.btn-outline-secondary.disabled{ href: '' }
+      %span.d-none.d-sm-none.d-md-block View file
+      %i.far.fa-file.d-block.d-sm-block.d-md-none

--- a/src/api/app/views/webui2/webui/package/rdiff.html.haml
+++ b/src/api/app/views/webui2/webui/package/rdiff.html.haml
@@ -39,7 +39,7 @@
               last: @filenames.last == filename }
             %br
         - else
-          %p No source changes.
+          %p.lead No source changes.
           %br
         = render partial: 'revision_diff_footer',
         locals: { project: @project,

--- a/src/api/app/views/webui2/webui/package/rdiff.html.haml
+++ b/src/api/app/views/webui2/webui/package/rdiff.html.haml
@@ -17,12 +17,13 @@
         - else
           %h3
             Changes of Revision #{@rev}
-      .col-sm-2
-        .btn-group.float-right
-          %button.btn.btn-sm.btn-outline-secondary#expand-diffs
-            Expand all
-          %button.btn.btn-sm.btn-outline-secondary#collapse-diffs
-            Collapse all
+      - if @filenames.present?
+        .col-sm-2
+          .btn-group.float-right
+            %button.btn.btn-sm.btn-outline-secondary#expand-diffs
+              Expand all
+            %button.btn.btn-sm.btn-outline-secondary#collapse-diffs
+              Collapse all
     %br
     .row
       .col-sm-12

--- a/src/api/app/views/webui2/webui/package/rdiff.html.haml
+++ b/src/api/app/views/webui2/webui/package/rdiff.html.haml
@@ -33,6 +33,7 @@
               package: @package,
               filename: filename,
               file: @files[filename],
+              diff_content: @files[filename].dig('diff', '_content'),
               revision: @rev,
               index: index,
               last: @filenames.last == filename }


### PR DESCRIPTION

* We always show now the buttons and just disable. This improves usability because the mouse is not suddenly over a different button when using the 'jumping' buttons. Thanks to @hennevogel for suggestion.
![selection_048](https://user-images.githubusercontent.com/3799140/46479805-3203fa00-c7f0-11e8-9bc0-2f7403b0289f.png)

* Filename is now limited to not use the whole size of the summary and therefore sometimes overlapping with the view file button
![selection_049](https://user-images.githubusercontent.com/3799140/46479879-58299a00-c7f0-11e8-967e-bce59f53759b.png)

* Expand link is now hidden when there is no diff (e.g. binary files)
![selection_049](https://user-images.githubusercontent.com/3799140/46480002-99ba4500-c7f0-11e8-9f3d-ea4c49ef76d4.png)

* Additionally moved buttons to a partial

Fixes #6011