### PR TITLE
 Unify table styling according to OBS pattern library

### DIFF
--- a/src/api/app/views/webui2/webui/attribute/index.html.haml
+++ b/src/api/app/views/webui2/webui/attribute/index.html.haml
@@ -9,15 +9,15 @@
       %table.responsive.table.table-striped.table-bordered#attributes
         %thead
           %tr
-            %th.col-auto{ scope: 'col' } Attributes
-            %th.col{ scope: 'col' } Values
+            %th.w-50 Attributes
+            %th.w-25 Values
             - if policy(@package).update?
-              %th.col-auto{ scope: 'col' } Actions
+              %th Actions
         %tbody
           - @attributes.each do |attribute|
             %tr
-              %td.col-6.text-word-break-all= attribute.fullname
-              %td.col-4
+              %td.text-word-break-all= attribute.fullname
+              %td
                 %ul
                   - unless attribute.values.empty?
                     - attribute.values.each do |v|
@@ -26,7 +26,7 @@
                   - unless attribute.issues.empty?
                     %li= attribute.issues.map(&:name).to_sentence
               - if policy(@package).update?
-                %td.col-2
+                %td
                   - if attribute.values_editable?
                     = link_to(edit_attribs_path(project: @project.name, package: @package, attribute: attribute.fullname), title: 'Edit values') do
                       %i.fas.fa-edit.text-secondary

--- a/src/api/app/views/webui2/webui/attribute/index.html.haml
+++ b/src/api/app/views/webui2/webui/attribute/index.html.haml
@@ -6,8 +6,8 @@
   .card-body
     %h3= @pagetitle
     - if @attributes.present?
-      %table.responsive.table.table-hover.w-100#attributes
-        %thead.thead-light
+      %table.responsive.table.table-striped.table-bordered#attributes
+        %thead
           %tr
             %th.col-auto{ scope: 'col' } Attributes
             %th.col{ scope: 'col' } Values

--- a/src/api/app/views/webui2/webui/package/_deps.html.haml
+++ b/src/api/app/views/webui2/webui/package/_deps.html.haml
@@ -4,8 +4,8 @@
     %table.table.table-striped.table-bordered.table-sm
       %thead
         %tr
-          %th.col-md-3.col-sm-6{ scope: 'col' } Symbol
-          %th.col-md-2.col-sm-4{ scope: 'col' } Required by
+          %th.w-75 Symbol
+          %th.w-25 Required by
       %tbody
         - fileinfo.elements('provides_ext') do |package_file|
           %tr
@@ -33,8 +33,8 @@
     %table.table.table-striped.table-bordered.table-sm
       %thead
         %tr
-          %th.col-md-3.col-sm-6{ scope: 'col' } Symbol
-          %th.col-md-2.col-sm-4{ scope: 'col' } Provided by
+          %th.w-75 Symbol
+          %th.w-25 Provided by
       %tbody
         - fileinfo.elements('requires_ext') do |package_file|
           %tr
@@ -56,4 +56,3 @@
           %tr
             %td{ colspan: '2' }
               %em No requires
-

--- a/src/api/app/views/webui2/webui/package/_deps.html.haml
+++ b/src/api/app/views/webui2/webui/package/_deps.html.haml
@@ -1,8 +1,8 @@
 .row
   .table-responsive.col-sm-12.col-md-6
     %h3 Provides
-    %table.table.table-hover
-      %thead.thead-light
+    %table.table.table-striped.table-bordered.table-sm
+      %thead
         %tr
           %th.col-md-3.col-sm-6{ scope: 'col' } Symbol
           %th.col-md-2.col-sm-4{ scope: 'col' } Required by
@@ -30,8 +30,8 @@
 
   .table-responsive.col-sm-12.col-md-6
     %h3 Requires
-    %table.table.table-hover
-      %thead.thead-light
+    %table.table.table-striped.table-bordered.table-sm
+      %thead
         %tr
           %th.col-md-3.col-sm-6{ scope: 'col' } Symbol
           %th.col-md-2.col-sm-4{ scope: 'col' } Provided by

--- a/src/api/app/views/webui2/webui/packages/build_reason/index.html.haml
+++ b/src/api/app/views/webui2/webui/packages/build_reason/index.html.haml
@@ -23,8 +23,8 @@
           %strong
             #{@package.name}.
         .table-responsive
-          %table.table.table-hover#changed-packages
-            %thead.thead-light
+          %table.table.table-striped.table-bordered#changed-packages
+            %thead
               %tr
                 %th Package
                 %th Change


### PR DESCRIPTION
See for more context https://github.com/openSUSE/obs-patterns/pull/25

![selection_046](https://user-images.githubusercontent.com/3799140/46471654-d418e780-c7da-11e8-8a33-a0b72544b059.png)

![selection_047](https://user-images.githubusercontent.com/3799140/46471671-e7c44e00-c7da-11e8-96af-637b4f970548.png)



Additionally using bootstraps sizing classes now because the grid system does not work reliable for chrome in tables.