### PR TITLE
Display the select without overflowing its container on mobile

### DIFF
--- a/src/api/app/views/webui2/webui/attribute/new.html.haml
+++ b/src/api/app/views/webui2/webui/attribute/new.html.haml
@@ -6,13 +6,13 @@
   .card-body
     %h3= @pagetitle
     = form_for(@attribute) do |form|
-      .form-row.form-group
+      .form-row
         = form.hidden_field(:project_id)
         - if @attribute.package_id
           = form.hidden_field(:package_id)
-        .col-auto
-          = form.collection_select(:attrib_type_id, @attribute_types, :id, :fullname, {}, class: 'form-control')
-        .col.col-form-label
+        .col-12.col-md-auto
+          = form.collection_select(:attrib_type_id, @attribute_types, :id, :fullname, {}, class: 'form-control custom-select')
+        .col-form-label.col-12.col-md
           - @attribute_types.each do |attribute_type|
             %p.d-none{ id: "attribute_type-description-#{attribute_type.id}" }
               = attribute_type.description.presence || 'Sorry, this attribute has no description'


### PR DESCRIPTION
On top of this, the select is now a custom select from Bootstrap custom
forms.

Fixes #5982

Desktop is still fine:
![desktop](https://user-images.githubusercontent.com/1102934/46473394-493aeb80-c7e0-11e8-80be-f0d8158cdc9f.png)

Mobile is fixed:
![mobile](https://user-images.githubusercontent.com/1102934/46473398-4d670900-c7e0-11e8-9088-4ed9e09422f6.png)
