### PR TITLE
Show name when there is no title on package edit

### DIFF
--- a/src/api/app/views/webui2/webui/package/_edit_dialog.html.haml
+++ b/src/api/app/views/webui2/webui/package/_edit_dialog.html.haml
@@ -7,7 +7,7 @@
         .modal-body
           .form-group
             = label_tag(:title, 'Title:')
-            = text_field_tag('title', package.title, class: 'form-control')
+            = text_field_tag('title', package.title.presence || package.name, class: 'form-control')
           .form-group
             = label_tag(:description, 'Description:')
             = text_area_tag(:description, package.description, rows: 8, class: 'form-control')


### PR DESCRIPTION
Because this is similar behavior to what we do on the package show page.

Fix https://github.com/openSUSE/open-build-service/issues/5975

The problem here is that people don't expect that a package has a name and a title (similar to what is in a spec file). On the package show we show the title and if there is no title we show the name because name is presence validated. I think this behaviour makes sense and we should think about to maybe overwrite the title accessor with something like:

```ruby
def title
  self[:title].presence || name
end
```

But I don't know the side effects yet and if we want to have it always like this so for now I only change the edit view.