### PR TITLE
Indicate inheritance of repositories

### DIFF
--- a/src/api/.rubocop.yml
+++ b/src/api/.rubocop.yml
@@ -25,6 +25,11 @@ Style/MultilineBlockChain:
   Exclude:
     - 'spec/**/*'
 
+# We disabled this cop because HAML doesn't work well with ActiveSupport::SafeBuffer and the to_s method of it is always returning the same object class
+Style/UnneededInterpolation:
+  Exclude:
+    - 'app/views/webui2/**/*'
+
 ##################### Metrics ##################################
 
 Metrics/BlockLength:

--- a/src/api/app/assets/stylesheets/webui2/texts.scss
+++ b/src/api/app/assets/stylesheets/webui2/texts.scss
@@ -19,3 +19,11 @@
 }
 
 .half-font-size { font-size: 0.5rem; }
+
+.text-40p-size {
+  font-size: 40%;
+}
+
+.ml-0_6 {
+  margin-left: 0.6rem !important;
+}

--- a/src/api/app/controllers/webui/repositories_controller.rb
+++ b/src/api/app/controllers/webui/repositories_controller.rb
@@ -15,6 +15,8 @@ class Webui::RepositoriesController < Webui::WebuiController
     @useforbuild = @main_object.get_flags('useforbuild')
     @architectures = @main_object.architectures.reorder('name').distinct
 
+    @user_can_set_flags = policy(@project).update?
+
     switch_to_webui2 if @package
   end
 
@@ -164,6 +166,7 @@ class Webui::RepositoriesController < Webui::WebuiController
     @flag = @main_object.flags.new(status: params[:status], flag: params[:flag])
     @flag.architecture = Architecture.find_by_name(params[:architecture])
     @flag.repo = params[:repository] if params[:repository].present?
+    @user_can_set_flags = policy(@project).update?
 
     respond_to do |format|
       if @flag.save
@@ -186,6 +189,7 @@ class Webui::RepositoriesController < Webui::WebuiController
 
     @flag = Flag.find(params[:flag])
     @flag.status = @flag.status == 'enable' ? 'disable' : 'enable'
+    @user_can_set_flags = policy(@project).update?
 
     respond_to do |format|
       if @flag.save
@@ -210,6 +214,7 @@ class Webui::RepositoriesController < Webui::WebuiController
     @main_object.flags.destroy(@flag)
     @flag = @flag.dup
     @flag.status = @flag.default_status
+    @user_can_set_flags = policy(@project).update?
 
     respond_to do |format|
       # FIXME: This should happen in Flag or even better in Project

--- a/src/api/app/views/webui2/shared/_repositories.html.haml
+++ b/src/api/app/views/webui2/shared/_repositories.html.haml
@@ -4,26 +4,26 @@
       Build Flag
       %span.flagerror
     = render partial: 'shared/repositories_flag_table',
-             locals: { flags: build, project: project, package: package, architectures: architectures }
+             locals: { flags: build, project: project, package: package, architectures: architectures, user_can_set_flags: user_can_set_flags }
   .col
     %h5
       Publish Flag
       %span.flagerror
     = render partial: 'shared/repositories_flag_table',
-             locals: { flags: publish, project: project, package: package, architectures: architectures }
+             locals: { flags: publish, project: project, package: package, architectures: architectures, user_can_set_flags: user_can_set_flags }
 .row
   .col
     %h5
       Debuginfo Flag
       %span.flagerror
     = render partial: 'shared/repositories_flag_table',
-             locals: { flags: debuginfo, project: project, package: package, architectures: architectures }
+             locals: { flags: debuginfo, project: project, package: package, architectures: architectures, user_can_set_flags: user_can_set_flags }
   .col
     %h5
       Use for Build Flag
       %span.flagerror
     = render partial: 'shared/repositories_flag_table',
-             locals: { flags: useforbuild, project: project, package: package, architectures: architectures }
+             locals: { flags: useforbuild, project: project, package: package, architectures: architectures, user_can_set_flags: user_can_set_flags }
 :javascript
   $(document).ready(function() {
     setSpinnersForFlags();

--- a/src/api/app/views/webui2/shared/_repositories_flag_table.html.haml
+++ b/src/api/app/views/webui2/shared/_repositories_flag_table.html.haml
@@ -12,7 +12,8 @@
           %strong All
         - flags['all'].each do |flag|
           %td.all_flag.text-center
-            = render partial: 'shared/repositories_flag_table_column', locals: { flag: flag, project: project, package: package }
+            = render partial: 'shared/repositories_flag_table_column',
+                     locals: { flag: flag, project: project, package: package, user_can_set_flags: user_can_set_flags }
       - project.repositories.each do |repository|
         %tr
           %td.reponame.text-word-break-all
@@ -23,4 +24,5 @@
                 = link_to(repository.name, action: :state, project: project, repository: repository.name)
           - flags[repository.name].each_with_index do |flag, index|
             %td.text-center{ class: index == 0 ? 'all_flag' : nil }
-              = render partial: 'shared/repositories_flag_table_column', locals: { flag: flag, project: project, package: package }
+              = render partial: 'shared/repositories_flag_table_column',
+                       locals: { flag: flag, project: project, package: package, user_can_set_flags: user_can_set_flags }

--- a/src/api/app/views/webui2/shared/_repositories_flag_table_column.html.haml
+++ b/src/api/app/views/webui2/shared/_repositories_flag_table_column.html.haml
@@ -2,13 +2,16 @@
   is_flag_set_by_user = !flag.new_record?
   title = flag.effective_status == 'disable' ? 'Disabled' : 'Enabled'
   title += is_flag_set_by_user ? ' (set by user)' : ' (calculated)'
-  content = render(partial: 'shared/flag_popover', locals: { flag: flag, project: project, package: package, remote: !flag.has_children })
+  if user_can_set_flags
+    content = render(partial: 'shared/flag_popover',
+                     locals: { flag: flag, project: project, package: package, remote: !flag.has_children })
+  end
   icon_class = flag.effective_status == 'disable' ? 'fa-ban text-danger' : 'fa-check text-primary'
   icon_class += ' ml-0_6' if is_flag_set_by_user
 
 %div{ id: flag.fullname }
   %a{ href: 'javascript:void(0)', title: title,
-      data: { html: 'true', toggle: 'popover', placement: 'left', trigger: 'focus', content: "#{content}" } }
+      data: { html: 'true', toggle: user_can_set_flags ? 'popover' : '', placement: 'left', trigger: 'focus', content: "#{content}" } }
     %span.text-nowrap
       %i.fas{ class: icon_class }
       - if is_flag_set_by_user

--- a/src/api/app/views/webui2/shared/_repositories_flag_table_column.html.haml
+++ b/src/api/app/views/webui2/shared/_repositories_flag_table_column.html.haml
@@ -1,9 +1,16 @@
 :ruby
+  is_flag_set_by_user = !flag.new_record?
   title = flag.effective_status == 'disable' ? 'Disabled' : 'Enabled'
-  title += ' (default)' if flag.new_record?
-  content = String.new(render(partial: 'shared/flag_popover', locals: { flag: flag, project: project, package: package, remote: !flag.has_children }))
+  title += is_flag_set_by_user ? ' (set by user)' : ' (calculated)'
+  content = render(partial: 'shared/flag_popover', locals: { flag: flag, project: project, package: package, remote: !flag.has_children })
+  icon_class = flag.effective_status == 'disable' ? 'fa-ban text-danger' : 'fa-check text-primary'
+  icon_class += ' ml-0_6' if is_flag_set_by_user
 
 %div{ id: flag.fullname }
-  %a{ href: 'javascript:void(0)', title: title, data: { html: 'true', toggle: 'popover', placement: 'left', trigger: 'focus', content: content } }
-    %i.fas{ class: flag.effective_status == 'disable' ? 'fa-ban text-danger' : 'fa-check text-primary' }
+  %a{ href: 'javascript:void(0)', title: title,
+      data: { html: 'true', toggle: 'popover', placement: 'left', trigger: 'focus', content: "#{content}" } }
+    %span.text-nowrap
+      %i.fas{ class: icon_class }
+      - if is_flag_set_by_user
+        %i.fas.fa-circle.text-gray-550.text-40p-size
   %i.fas.fa-spinner.fa-spin.d-none

--- a/src/api/app/views/webui2/webui/package/binaries.html.haml
+++ b/src/api/app/views/webui2/webui/package/binaries.html.haml
@@ -38,9 +38,7 @@
                   .d-none.d-sm-block
                     = render_partial
                   .d-sm-none
-                    -# rubocop:disable Style/UnneededInterpolation
                     %i.fas.fa-ellipsis-h.text-secondary{ data: { toggle: 'popover', html: 'true', content: "#{render_partial}" } }
-                    -# rubocop:enable Style/UnneededInterpolation
       %ul.list-inline
         - if User.current.can_modify?(@package)
           = render partial: 'webui2/webui/package/binaries/trigger_rebuild_wipe_binaries', locals: { result: result, project: @project,

--- a/src/api/app/views/webui2/webui/repositories/change_flag.js.haml
+++ b/src/api/app/views/webui2/webui/repositories/change_flag.js.haml
@@ -1,5 +1,5 @@
 - partial = escape_javascript(render(partial: 'webui2/shared/repositories_flag_table_column',
-                                     locals: { flag: @flag, project: @project, package: @package }))
+                                     locals: { flag: @flag, project: @project, package: @package, user_can_set_flags: @user_can_set_flags }))
 :plain
     $( "##{@flag.fullname}".replace(/\./g, '\\.') ).replaceWith("#{partial}");
     $('[data-toggle="popover"]').popover();

--- a/src/api/app/views/webui2/webui/repositories/index.html.haml
+++ b/src/api/app/views/webui2/webui/repositories/index.html.haml
@@ -10,7 +10,7 @@
           = link_to @project, controller: :repositories, action: :index, project: @project
         = render partial: 'shared/repositories',
                  locals: { project: @project, package: @package, build: @build, publish: @publish, debuginfo: @debuginfo,
-                           useforbuild: @useforbuild, architectures: @architectures }
+                           useforbuild: @useforbuild, architectures: @architectures, user_can_set_flags: @user_can_set_flags }
       - else
         %p
           This package is inherited from the project
@@ -39,4 +39,4 @@
 
       = render partial: 'shared/repositories',
                locals: { project: @project, package: @package, build: @build, publish: @publish, debuginfo: @debuginfo,
-                         useforbuild: @useforbuild, architectures: @architectures }
+                         useforbuild: @useforbuild, architectures: @architectures, user_can_set_flags: @user_can_set_flags }


### PR DESCRIPTION
We have added a little gray dot in case the flag value is set by user and nothing if it is calculated. That way the user can see an overview of which flags are inherited/calculated and which are not.

![image](https://user-images.githubusercontent.com/11314634/46536788-d8fb9b00-c8af-11e8-8153-27194e1e2198.png)

This is a flag set by the user:
![image](https://user-images.githubusercontent.com/11314634/46536813-ef095b80-c8af-11e8-851e-9f488c49569f.png)

This is a flag calculated:
![image](https://user-images.githubusercontent.com/11314634/46536840-fd577780-c8af-11e8-8443-c79ed92a8bc9.png)

![repositories_flags_values](https://user-images.githubusercontent.com/11314634/46538256-c1beac80-c8b3-11e8-9dfe-45b3b16be235.gif)


We had the issue of letting any user try to change a flag. Now we use the policy to know if the user can change the repository flags then the popover of the actions appear.

