### PR TITLE
Fix build_succeeded? method

### DIFF
--- a/src/api/app/models/project.rb
+++ b/src/api/app/models/project.rb
@@ -1404,7 +1404,7 @@ class Project < ApplicationRecord
     br.elements('result') do |result|
       if repository && result['repository'] == repository
         repository_states[repository] ||= {}
-        result['summary'] do |summary|
+        result.elements('summary') do |summary|
           summary.elements('statuscount') do |statuscount|
             repository_states[repository][statuscount['code']] ||= 0
             repository_states[repository][statuscount['code']] += statuscount['count'].to_i


### PR DESCRIPTION
The method returned false even when the state was fine.

Fixes #5791
Co-authored-by: Ana María Martínez Gómez <ammartinez@suse.de>
