### PR TITLE
Fix more info in package error flash

### DIFF
--- a/src/api/app/assets/javascripts/webui2/packages.js
+++ b/src/api/app/assets/javascripts/webui2/packages.js
@@ -34,3 +34,11 @@ $(function ($) {
     details.attr('open', null);
   });
 });
+
+$(document).ready(function() {
+  $('.btn-more').click(function() {
+    var moreInfo = $('.more_info');
+    moreInfo.toggleClass('d-none');
+    $(this).text(moreInfo.hasClass('d-none') ? 'more info' : 'less info');
+  });
+});

--- a/src/api/app/views/layouts/webui2/_flash.html.haml
+++ b/src/api/app/views/layouts/webui2/_flash.html.haml
@@ -18,7 +18,7 @@
         .alert.alert-dismissible.fade.show{ class: "alert-#{flash_header}" }
           %i.fas{ class: "fa-#{flash_icon}" }
           = flash_content(flash[flash_type])
-          = link_to('more info', '#', class: 'btn-more') if @more_info
+          = link_to('more info', '#', class: 'btn-more alert-link') if @more_info
           - if @more_info
             .more_info.d-none
               %div{ class: flash_header }

--- a/src/api/app/views/layouts/webui2/_flash.html.haml
+++ b/src/api/app/views/layouts/webui2/_flash.html.haml
@@ -20,7 +20,7 @@
           = flash_content(flash[flash_type])
           = link_to('more info', '#', class: 'btn-more') if @more_info
           - if @more_info
-            .more_info.hidden
+            .more_info.d-none
               %div{ class: flash_header }
               .more-info-content
                 = simple_format @more_info.gsub(/\\n/, '<br \>')


### PR DESCRIPTION
The Javascript for the more info was missing and  `.hidden` was been dropped in Bootrstrap 4: https://getbootstrap.com/docs/4.0/migration. Also, style link in alert using Bootstrap class.  :bowtie: 

Fixes https://github.com/openSUSE/open-build-service/issues/6072

![image](https://user-images.githubusercontent.com/16052290/46743595-b3a0cf80-cca9-11e8-93e1-a2950318291a.png)

![image](https://user-images.githubusercontent.com/16052290/46743572-aaaffe00-cca9-11e8-9725-4a1845b3b794.png)


