### PR TITLE
Add new RepoBuildFinished event to be sent through amqp

### DIFF
--- a/src/api/app/models/event/repo_build_finished.rb
+++ b/src/api/app/models/event/repo_build_finished.rb
@@ -1,0 +1,30 @@
+module Event
+  class RepoBuildFinished < Base
+    self.description = 'Repository finished building'
+    payload_keys :project, :repo, :arch, :buildid
+    after_create_commit :send_to_bus
+
+    def self.message_bus_routing_key
+      'repo.build_finished'
+    end
+  end
+end
+
+# == Schema Information
+#
+# Table name: events
+#
+#  id          :integer          not null, primary key
+#  eventtype   :string(255)      not null, indexed
+#  payload     :text(65535)
+#  created_at  :datetime         indexed
+#  updated_at  :datetime
+#  undone_jobs :integer          default(0)
+#  mails_sent  :boolean          default(FALSE), indexed
+#
+# Indexes
+#
+#  index_events_on_created_at  (created_at)
+#  index_events_on_eventtype   (eventtype)
+#  index_events_on_mails_sent  (mails_sent)
+#

--- a/src/api/spec/models/event/repo_build_finished_spec.rb
+++ b/src/api/spec/models/event/repo_build_finished_spec.rb
@@ -1,0 +1,34 @@
+require 'rails_helper'
+
+RSpec.describe Event::RepoBuildFinished do
+  describe 'UpdateNotificationEvents' do
+    let(:path) { "#{CONFIG['source_url']}/lastnotifications?block=1&start=1" }
+    let(:xml_response) do
+      <<-HEREDOC
+         <notifications next="2">
+           <notification type="REPO_BUILD_FINISHED" time="1539445101">
+            <data key="project">home:coolo</data>
+            <data key="repo">standard</data>
+            <data key="arch">x86_64</data>
+            <data key="buildid">67394b7f7d6e15920e8f2096047c0b4a</data>
+          </notification>
+         </notifications>
+      HEREDOC
+    end
+
+    before do
+      create(:admin_user, login: 'Admin')
+      stub_request(:get, path).and_return(body: xml_response)
+      UpdateNotificationEvents.new.perform
+    end
+
+    it 'fetches from backend' do
+      expect(Event::RepoBuildFinished.count).to be(1)
+    end
+
+    it 'gets the payload right' do
+      expect(Event::RepoBuildFinished.first.payload).to include('buildid' => '67394b7f7d6e15920e8f2096047c0b4a',
+            'arch' => 'x86_64', 'project' => 'home:coolo', 'repo' => 'standard')
+    end
+  end
+end

--- a/src/backend/BSSched/Checker.pm
+++ b/src/backend/BSSched/Checker.pm
@@ -125,7 +125,7 @@ sub set_repo_state {
     $id = Digest::MD5::md5_hex($id);
     if (($oldstate->{'buildid'} || $oldstate->{'oldbuildid'} || '') ne $id) {
       my $myarch = $ctx->{'gctx'}->{'arch'};
-      #BSNotify::notify('REPO_BUILD_FINISHED', { project => $ctx->{'project'}, 'repo' => $ctx->{'repository'}, 'arch' => $myarch, 'buildid' => $id} );
+      BSNotify::notify('REPO_BUILD_FINISHED', { project => $ctx->{'project'}, 'repo' => $ctx->{'repository'}, 'arch' => $myarch, 'buildid' => $id} );
     }
     $newstate->{'buildid'} = $id;
     delete $newstate->{'oldbuildid'};


### PR DESCRIPTION
We need a status check on unpublished repos, so we need a repo state when it's done building. This is just a boilerplate.