### PR TITLE
Create unassigned requests scope

### DIFF
--- a/src/api/app/models/bs_request.rb
+++ b/src/api/app/models/bs_request.rb
@@ -87,6 +87,7 @@ class BsRequest < ApplicationRecord
   has_many :review_history_elements, through: :reviews, source: :history_elements
   has_many :status_reports, as: :checkable, class_name: 'Status::Report', dependent: :destroy
   has_many :target_project_objects, through: :bs_request_actions
+  has_one :staged_request, dependent: :destroy
 
   validates :state, inclusion: { in: VALID_REQUEST_STATES }
   validates :creator, presence: true

--- a/src/api/app/models/project.rb
+++ b/src/api/app/models/project.rb
@@ -79,6 +79,7 @@ class Project < ApplicationRecord
 
   has_one :staging, class_name: 'StagingWorkflow', inverse_of: :project
   belongs_to :staging_workflow, inverse_of: :staging_projects
+  has_many :staged_requests
 
   default_scope { where('projects.id not in (?)', Relationship.forbidden_project_ids) }
 

--- a/src/api/app/models/staged_request.rb
+++ b/src/api/app/models/staged_request.rb
@@ -1,0 +1,6 @@
+class StagedRequest < ApplicationRecord
+  belongs_to :project
+  belongs_to :bs_request
+
+  validates :project_id, :bs_request_id, presence: true
+end

--- a/src/api/app/models/staging_workflow.rb
+++ b/src/api/app/models/staging_workflow.rb
@@ -1,4 +1,25 @@
 class StagingWorkflow < ApplicationRecord
   belongs_to :project, inverse_of: :staging
   has_many :staging_projects, class_name: 'Project', inverse_of: :staging_workflow, dependent: :nullify
+
+  validates :project_id, presence: true
+
+  def unassigned_requests
+    project_requests - staging_projects_requests - ignored_requests
+  end
+
+  private
+
+  def project_requests
+    BsRequest.where(id: BsRequestAction.bs_request_ids_of_involved_projects(project_id))
+  end
+
+  def staging_projects_requests
+    BsRequest.where(id: StagedRequest.where(project: staging_projects).pluck(:bs_request_id))
+  end
+
+  def ignored_requests
+    # TODO: define this method
+    []
+  end
 end

--- a/src/api/db/migrate/20181015083927_create_staged_request.rb
+++ b/src/api/db/migrate/20181015083927_create_staged_request.rb
@@ -1,0 +1,11 @@
+class CreateStagedRequest < ActiveRecord::Migration[5.2]
+  def change
+    # rubocop:disable Rails/CreateTableWithTimestamps
+    create_table :staged_requests, id: false do |t|
+      t.belongs_to :bs_request, index: true, type: :integer
+      t.belongs_to :project, index: true, type: :integer
+      t.index [:bs_request_id, :project_id], unique: true
+    end
+    # rubocop:enable Rails/CreateTableWithTimestamps
+  end
+end

--- a/src/api/db/structure.sql
+++ b/src/api/db/structure.sql
@@ -1123,6 +1123,14 @@ CREATE TABLE `sessions` (
   KEY `index_sessions_on_updated_at` (`updated_at`) USING BTREE
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
 
+CREATE TABLE `staged_requests` (
+  `bs_request_id` int(11) DEFAULT NULL,
+  `project_id` int(11) DEFAULT NULL,
+  UNIQUE KEY `index_staged_requests_on_bs_request_id_and_project_id` (`bs_request_id`,`project_id`),
+  KEY `index_staged_requests_on_bs_request_id` (`bs_request_id`),
+  KEY `index_staged_requests_on_project_id` (`project_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
 CREATE TABLE `staging_workflows` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `project_id` int(11) DEFAULT NULL,
@@ -1399,6 +1407,7 @@ INSERT INTO `schema_migrations` (version) VALUES
 ('20180906115417'),
 ('20180906142702'),
 ('20180906142802'),
-('20181008150453');
+('20181008150453'),
+('20181015083927');
 
 

--- a/src/api/spec/factories/project.rb
+++ b/src/api/spec/factories/project.rb
@@ -171,5 +171,9 @@ FactoryBot.define do
         end
       end
     end
+
+    factory :staging_project do
+      sequence(:name, [*'A'..'Z'].cycle) { |n| n }
+    end
   end
 end

--- a/src/api/spec/factories/staged_request.rb
+++ b/src/api/spec/factories/staged_request.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :staged_request do
+    bs_request { nil }
+    project { nil }
+  end
+end

--- a/src/api/spec/factories/staging_workflow.rb
+++ b/src/api/spec/factories/staging_workflow.rb
@@ -1,0 +1,18 @@
+FactoryBot.define do
+  factory :staging_workflow do
+    project { nil }
+
+    factory :staging_workflow_with_staging_projects do
+      transient do
+        staging_project_count { 2 }
+      end
+
+      after(:create) do |staging_workflow, evaluator|
+        evaluator.staging_project_count.times do
+          new_staging_project = create(:staging_project)
+          staging_workflow.staging_projects << new_staging_project
+        end
+      end
+    end
+  end
+end

--- a/src/api/spec/models/staging_workflow_spec.rb
+++ b/src/api/spec/models/staging_workflow_spec.rb
@@ -1,0 +1,60 @@
+require 'rails_helper'
+
+RSpec.describe StagingWorkflow, type: :model do
+  let(:project) { create(:project_with_package) }
+  let!(:staging_workflow) { create(:staging_workflow_with_staging_projects, project: project) }
+  let(:source_project) { create(:project, name: 'source_project') }
+  let(:target_package) { create(:package, name: 'target_package', project: project) }
+  let(:source_package) { create(:package, name: 'source_package', project: source_project) }
+  let(:bs_request) do
+    create(:bs_request_with_submit_action,
+           target_project: project.name,
+           target_package: target_package.name,
+           source_project: source_project.name,
+           source_package: source_package.name)
+  end
+  let(:staging_project) { staging_workflow.staging_projects.first }
+  let(:staged_request) { create(:staged_request, bs_request: bs_request, project: staging_project) }
+
+  it { is_expected.to validate_presence_of :project_id }
+
+  describe '#unassigned_request' do
+    subject { staging_workflow.unassigned_requests }
+
+    context 'without requests in the main project' do
+      it { expect(subject).to be_empty }
+    end
+
+    context 'with requests but not in staging projects' do
+      before do
+        bs_request
+      end
+
+      it { expect(subject).not_to be_empty }
+    end
+
+    context 'with requests but all of them are in staging projects' do
+      before do
+        staged_request
+      end
+
+      it { expect(subject).to be_empty }
+    end
+
+    context 'with requests and some are in staging projects and some not' do
+      let!(:bs_request_2) do
+        create(:bs_request_with_submit_action,
+               target_project: project.name,
+               target_package: target_package.name,
+               source_project: source_project.name,
+               source_package: source_package.name)
+      end
+
+      before do
+        staged_request
+      end
+
+      it { expect(subject).not_to be_empty }
+    end
+  end
+end


### PR DESCRIPTION
Create scope for the unassigned (not in any staging project) requests.

Supersedes #6089.

Co-authored-by: Dany Marcoux dmarcoux@suse.com
Co-authored-by: Saray Cabrera Padrón scabrerapadron@suse.de
Co-authored-by: Victor Pereira vpereira@suse.com
