### PR TITLE
Change icons for flash messages in bootstrap

### DIFF
--- a/src/api/app/views/layouts/webui2/_flash.html.haml
+++ b/src/api/app/views/layouts/webui2/_flash.html.haml
@@ -4,13 +4,13 @@
       - if (flash[flash_type] && !flash[flash_type].empty?)
         - case flash_type
         - when :error
-          - flash_icon = 'times'
+          - flash_icon = 'exclamation-circle'
           - flash_header = 'danger'
         - when :alert
           - flash_icon = 'exclamation-triangle'
           - flash_header = 'warning'
         - when :success
-          - flash_icon = 'thumbs-up'
+          - flash_icon = 'check-circle'
           - flash_header = 'success'
         - when :notice
           - flash_icon = 'info-circle'


### PR DESCRIPTION
Some of the flash icons where confusing, for example the 'x' icon. So
they have been replaced by other icons used in our bootstrap design.

Fixes #6080

Before:

![flash_before](https://user-images.githubusercontent.com/2581944/46980656-8010db80-d0d5-11e8-8902-3b80fef621d2.png)


After:

![flash_after](https://user-images.githubusercontent.com/2581944/46980658-82733580-d0d5-11e8-82e5-691a7c1a7e97.png)
