### PR TITLE
Require `belongs_to` associations by default.

### DIFF
--- a/src/api/config/initializers/new_framework_defaults.rb
+++ b/src/api/config/initializers/new_framework_defaults.rb
@@ -17,4 +17,4 @@ Rails.application.config.action_controller.forgery_protection_origin_check = fal
 ActiveSupport.to_time_preserves_timezone = false
 
 # Require `belongs_to` associations by default. Previous versions had false.
-Rails.application.config.active_record.belongs_to_required_by_default = false
+Rails.application.config.active_record.belongs_to_required_by_default = true


### PR DESCRIPTION
In Rails 5, whenever we define a belongs_to association, it is required to have the associated record present by default after this change.

It triggers validation error if associated record is not present. We disabled it after the migration to Rails 5. That's a try to enable it back.
