### PR TITLE
Unassigned requests for StagingWorkflow

### DIFF
--- a/src/api/app/models/bs_request.rb
+++ b/src/api/app/models/bs_request.rb
@@ -88,6 +88,8 @@ class BsRequest < ApplicationRecord
   has_many :status_reports, as: :checkable, class_name: 'Status::Report', dependent: :destroy
   has_many :target_project_objects, through: :bs_request_actions
 
+  belongs_to :staging_project, class_name: 'Project', foreign_key: 'staging_project_id'
+
   validates :state, inclusion: { in: VALID_REQUEST_STATES }
   validates :creator, presence: true
   validate :check_supersede_state

--- a/src/api/app/models/project.rb
+++ b/src/api/app/models/project.rb
@@ -79,6 +79,7 @@ class Project < ApplicationRecord
 
   has_one :staging, class_name: 'StagingWorkflow', inverse_of: :project
   belongs_to :staging_workflow, inverse_of: :staging_projects
+  has_many :staged_requests, class_name: 'BsRequest', foreign_key: 'staging_project_id'
 
   default_scope { where('projects.id not in (?)', Relationship.forbidden_project_ids) }
 

--- a/src/api/app/models/staging_workflow.rb
+++ b/src/api/app/models/staging_workflow.rb
@@ -1,4 +1,15 @@
 class StagingWorkflow < ApplicationRecord
   belongs_to :project, inverse_of: :staging
   has_many :staging_projects, class_name: 'Project', inverse_of: :staging_workflow, dependent: :nullify
+
+  has_many :target_of_bs_requests, through: :project
+  has_many :staged_requests, class_name: 'BsRequest', through: :staging_projects
+
+  def unassigned_requests
+    target_of_bs_requests.in_states(['new', 'review']) - staged_requests - ignored_requests
+  end
+
+  def ignored_requests
+    BsRequest.none # TODO: define this method
+  end
 end

--- a/src/api/db/migrate/20181016103905_add_staged_request_id_to_bs_requests.rb
+++ b/src/api/db/migrate/20181016103905_add_staged_request_id_to_bs_requests.rb
@@ -1,0 +1,8 @@
+class AddStagedRequestIdToBsRequests < ActiveRecord::Migration[5.2]
+  def change
+    change_table :bs_requests, bulk: true do |t|
+      t.integer :staging_project_id
+      t.index :staging_project_id
+    end
+  end
+end

--- a/src/api/db/structure.sql
+++ b/src/api/db/structure.sql
@@ -271,11 +271,13 @@ CREATE TABLE `bs_requests` (
   `priority` enum('critical','important','moderate','low') CHARACTER SET utf8 COLLATE utf8_bin DEFAULT 'moderate',
   `number` int(11) DEFAULT NULL,
   `updated_when` datetime DEFAULT NULL,
+  `staging_project_id` int(11) DEFAULT NULL,
   PRIMARY KEY (`id`),
   UNIQUE KEY `index_bs_requests_on_number` (`number`),
   KEY `index_bs_requests_on_creator` (`creator`) USING BTREE,
   KEY `index_bs_requests_on_state` (`state`) USING BTREE,
-  KEY `index_bs_requests_on_superseded_by` (`superseded_by`)
+  KEY `index_bs_requests_on_superseded_by` (`superseded_by`),
+  KEY `index_bs_requests_on_staging_project_id` (`staging_project_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `channel_binaries` (
@@ -1399,6 +1401,7 @@ INSERT INTO `schema_migrations` (version) VALUES
 ('20180906115417'),
 ('20180906142702'),
 ('20180906142802'),
-('20181008150453');
+('20181008150453'),
+('20181016103905');
 
 

--- a/src/api/spec/factories/project.rb
+++ b/src/api/spec/factories/project.rb
@@ -171,5 +171,13 @@ FactoryBot.define do
         end
       end
     end
+
+    factory :staging_project do
+      transient do
+        sequence(:workflow_project_name) { |n| "workflow_project_#{n}" }
+      end
+
+      sequence(:name, [*'A'..'Z'].cycle) { |letter| "#{workflow_project_name}:Staging:#{letter}" }
+    end
   end
 end

--- a/src/api/spec/factories/staging_workflow.rb
+++ b/src/api/spec/factories/staging_workflow.rb
@@ -1,0 +1,15 @@
+FactoryBot.define do
+  factory :staging_workflow do
+    factory :staging_workflow_with_staging_projects do
+      transient do
+        staging_project_count { 2 }
+      end
+
+      after(:create) do |staging_workflow, evaluator|
+        evaluator.staging_project_count.times do
+          staging_workflow.staging_projects << create(:staging_project, workflow_project_name: staging_workflow.project.name)
+        end
+      end
+    end
+  end
+end

--- a/src/api/spec/models/staging_workflow_spec.rb
+++ b/src/api/spec/models/staging_workflow_spec.rb
@@ -1,0 +1,57 @@
+require 'rails_helper'
+
+RSpec.describe StagingWorkflow, type: :model do
+  let(:project) { create(:project_with_package) }
+  let(:staging_workflow) { create(:staging_workflow_with_staging_projects, project: project) }
+  let(:staging_project) { staging_workflow.staging_projects.first }
+  let(:source_project) { create(:project, name: 'source_project') }
+  let(:target_package) { create(:package, name: 'target_package', project: project) }
+  let(:source_package) { create(:package, name: 'source_package', project: source_project) }
+  let(:bs_request) do
+    create(:bs_request_with_submit_action,
+           target_project: project.name,
+           target_package: target_package.name,
+           source_project: source_project.name,
+           source_package: source_package.name)
+  end
+
+  describe '#unassigned_request' do
+    subject { staging_workflow.unassigned_requests }
+
+    context 'without requests in the main project' do
+      it { expect(subject).to be_empty }
+    end
+
+    context 'with requests but not in staging projects' do
+      before { bs_request }
+
+      it { expect(subject).to contain_exactly(bs_request) }
+    end
+
+    context 'with requests but all of them are in staging projects' do
+      before do
+        bs_request.staging_project = staging_project
+        bs_request.save
+      end
+
+      it { expect(subject).to be_empty }
+    end
+
+    context 'with requests and some are in staging projects and some not' do
+      let!(:bs_request_2) do
+        create(:bs_request_with_submit_action,
+               target_project: project.name,
+               target_package: target_package.name,
+               source_project: source_project.name,
+               source_package: source_package.name)
+      end
+
+      before do
+        bs_request.staging_project = staging_project
+        bs_request.save
+      end
+
+      it { expect(subject).to contain_exactly(bs_request_2) }
+    end
+  end
+end


### PR DESCRIPTION
We have created the association between StagingWorkflow, StagingProject
and BsRequest.

Unassigned requests are all the requests related to the StagingWorkflow's main
project that are not associated to any of the staging projects.

Supersedes #6097

Co-authored-by: Eduardo Navarro <enavarro@suse.com>
Co-authored-by: Victor Pereira <vpereira@suse.com>


