### PR TITLE
Staging workflow creation

### DIFF
--- a/src/api/app/controllers/webui/staging_workflows_controller.rb
+++ b/src/api/app/controllers/webui/staging_workflows_controller.rb
@@ -1,25 +1,42 @@
 class Webui::StagingWorkflowsController < Webui::WebuiController
   layout 'webui2/webui'
 
+  before_action :require_login, except: [:show]
   before_action :set_bootstrap_views
-
   before_action :set_project, only: [:new, :create]
+  after_action :verify_authorized, except: [:show, :new]
 
-  def new; end
+  def new
+    if @project.staging
+      redirect_to staging_workflow_path(@project.staging)
+      return
+    end
+
+    @staging_workflow = @project.build_staging
+  end
 
   def create
-    staging_workflow = @project.staging.new
+    staging_workflow = @project.build_staging
+
+    authorize staging_workflow
+
     if staging_workflow.save
       flash[:success] = "Staging Workflow for #{@project.name} was successfully created"
-      redirect_to :show
+      redirect_to staging_workflow_path(staging_workflow)
     else
       flash[:error] = "Staging Workflow for #{@project.name} couldn't be created"
-      redirect_to :new
+      render :new
     end
   end
 
   def show
     @staging_workflow = StagingWorkflow.find_by(id: params[:id])
+    unless @staging_workflow
+      redirect_back(fallback_location: root_path)
+      flash[:error] = "StagingWorkflow with id = #{params[:id]} doesn't exist"
+      return
+    end
+
     @project = @staging_workflow.project
   end
 

--- a/src/api/app/helpers/webui/webui_helper.rb
+++ b/src/api/app/helpers/webui/webui_helper.rb
@@ -400,9 +400,9 @@ module Webui::WebuiHelper
     short + long
   end
 
-  def tab_link(label, path)
+  def tab_link(label, path, active = false)
     html_class = 'nav-link text-nowrap'
-    html_class << ' active' if request.path.include?(path)
+    html_class << ' active' if active || request.path.include?(path)
 
     link_to(label, path, class: html_class)
   end

--- a/src/api/app/policies/staging_workflow_policy.rb
+++ b/src/api/app/policies/staging_workflow_policy.rb
@@ -1,0 +1,11 @@
+class StagingWorkflowPolicy < ApplicationPolicy
+  def initialize(user, record)
+    raise Pundit::NotAuthorizedError, 'staging workflow does not exist' unless record
+    @user = user
+    @record = record
+  end
+
+  def create?
+    ProjectPolicy.new(@user, @record.project).create?
+  end
+end

--- a/src/api/app/views/webui2/webui/project/_tabs.html.haml
+++ b/src/api/app/views/webui2/webui/project/_tabs.html.haml
@@ -20,7 +20,7 @@
       // TODO: show it if the project have a staging_workflow attached when this feature will be released
       - if controller_name == 'staging_workflows'
         %li.nav-item
-          = tab_link('Staging', staging_workflow_path(project.staging))
+          = tab_link('Staging', request.url, controller_name == 'staging_workflows')
       - unless project.defines_remote_instance? || project.is_maintenance?
         %li.nav-item
           = tab_link('Subprojects', project_subprojects_path(project))

--- a/src/api/app/views/webui2/webui/staging_workflows/new.html.haml
+++ b/src/api/app/views/webui2/webui/staging_workflows/new.html.haml
@@ -1,0 +1,13 @@
+- @pagetitle = "Staging Projects for #{@project}"
+
+.card.mb-3
+  = render(partial: 'webui2/webui/project/tabs', locals: { project: @project })
+  .card-body
+    %h3= @pagetitle
+    .mb-3
+      Adding the staging capability to this project will enable you to group
+      requests into staging projects and being able to see how they build together.
+    .text-center
+      = form_for @staging_workflow, method: :post do |f|
+        = hidden_field_tag :project_name, @project
+        = f.submit 'Create Staging Projects', class: 'btn btn-primary'

--- a/src/api/config/routes.rb
+++ b/src/api/config/routes.rb
@@ -304,8 +304,6 @@ OBSApi::Application.routes.draw do
     get 'project/staging_projects/:project' => 'webui/obs_factory/staging_projects#index', as: 'staging_projects', constraints: cons
     get 'project/staging_projects/:project/:project_name' => 'webui/obs_factory/staging_projects#show', as: 'staging_project', constraints: cons
 
-    resources :staging_workflows, controller: 'webui/staging_workflows'
-
     controller 'webui/projects/rebuild_times' do
       get 'project/rebuild_time/:project/:repository/:arch' => :show, constraints: cons, as: 'project_rebuild_time'
       get 'project/rebuild_time_png/:project/:key' => :rebuild_time_png, constraints: cons
@@ -461,6 +459,8 @@ OBSApi::Application.routes.draw do
   # :arch can be also a ymp for a pattern :/
   get 'published/:project(/:repository(/:arch(/:binary)))' => 'published#index', constraints: cons
   get 'published/' => 'source#index', via: :get
+
+  resources :staging_workflows, except: [:index, :edit, :update, :destroy], controller: 'webui/staging_workflows', constraints: cons
 
   constraints(APIMatcher) do
     get '/' => 'main#index'

--- a/src/api/spec/controllers/webui/staging_workflows_controller_spec.rb
+++ b/src/api/spec/controllers/webui/staging_workflows_controller_spec.rb
@@ -1,0 +1,97 @@
+require 'rails_helper'
+
+RSpec.describe Webui::StagingWorkflowsController do
+  let(:user) { create(:confirmed_user, login: 'tom') }
+  let(:project) { user.home_project }
+
+  before do
+    login(user)
+  end
+
+  describe 'GET #new' do
+    context 'non existent staging_workflow for project' do
+      before do
+        get :new, params: { project: project.name }
+      end
+
+      it { expect(StagingWorkflow.count).to eq(0) }
+      it { expect(assigns[:staging_workflow].class).to be(StagingWorkflow) }
+      it { expect(response).to render_template(:new) }
+    end
+
+    context 'with an existent staging_workflow for project' do
+      before do
+        project.create_staging
+        get :new, params: { project: project.name }
+      end
+
+      it { expect(StagingWorkflow.count).to eq(1) }
+      it { expect(response).to redirect_to(staging_workflow_path(project.staging)) }
+    end
+  end
+
+  describe 'POST #create' do
+    context 'a staging_workflow and staging_projects' do
+      before do
+        post :create, params: { project: project.name }
+      end
+
+      subject { project.staging }
+
+      it { expect(StagingWorkflow.count).to eq(1) }
+      it { expect(subject.staging_projects.map(&:name)).to match_array(['home:tom:Staging:A', 'home:tom:Staging:B']) }
+      it { expect(response).to redirect_to(staging_workflow_path(project.staging)) }
+      it { expect(flash[:success]).not_to be_nil }
+    end
+
+    context 'with existent stagings projects' do
+      let!(:staging_a) { create(:project, name: "#{project}:Staging:A") }
+      let!(:staging_b) { create(:project, name: "#{project}:Staging:B") }
+
+      before do
+        post :create, params: { project: project.name }
+      end
+
+      subject { project.staging }
+
+      it { expect(StagingWorkflow.count).to eq(1) }
+      it { expect(subject.staging_projects.map(&:name)).to match_array(['home:tom:Staging:A', 'home:tom:Staging:B']) }
+      it { expect(response).to redirect_to(staging_workflow_path(project.staging)) }
+      it { expect(flash[:success]).not_to be_nil }
+    end
+
+    context 'when it fails to save' do
+      before do
+        allow_any_instance_of(StagingWorkflow).to receive(:save).and_return(false)
+        post :create, params: { project: project.name }
+      end
+
+      it { expect(StagingWorkflow.count).to eq(0) }
+      it { expect(response).to render_template(:new) }
+      it { expect(flash[:error]).not_to be_nil }
+    end
+  end
+
+  describe 'GET #show' do
+    context 'non existent staging_workflow for project' do
+      before do
+        get :show, params: { id: 5 }
+      end
+
+      it { expect(assigns[:staging_workflow]).to be_nil }
+      it { expect(response).to redirect_to(root_path) }
+      it { expect(flash[:error]).not_to be_nil }
+    end
+
+    context 'with an existent staging_workflow for project' do
+      before do
+        project.create_staging
+        get :show, params: { id: project.staging }
+      end
+
+      it { expect(assigns[:staging_workflow]).to eq(project.staging) }
+      it { expect(assigns[:project]).to eq(project) }
+      it { expect(response).to render_template(:show) }
+    end
+  end
+end

--- a/src/api/spec/factories/staging_workflow.rb
+++ b/src/api/spec/factories/staging_workflow.rb
@@ -1,13 +1,19 @@
 FactoryBot.define do
   factory :staging_workflow do
     factory :staging_workflow_with_staging_projects do
+      initialize_with { new(attributes) }
+
       transient do
         staging_project_count { 2 }
       end
 
       after(:create) do |staging_workflow, evaluator|
-        evaluator.staging_project_count.times do
-          staging_workflow.staging_projects << create(:staging_project, workflow_project_name: staging_workflow.project.name)
+        # StagingWorkflow have some staging projects already after initialize
+        new_staging_projects_count = evaluator.staging_project_count - staging_workflow.staging_projects.count
+        letters = [*'A'..'Z']
+        new_staging_projects_count.times do |index|
+          letter = letters[index + staging_workflow.staging_projects.count]
+          staging_workflow.staging_projects << create(:staging_project, name: "#{project.name}:Staging:#{letter}")
         end
       end
     end


### PR DESCRIPTION
Now the user will be able to create a StagingWorkflow. By default it creates/uses two subprojects of the main project (*:Staging:A and *:Staging:B)

This is how the new action will look like:
![image](https://user-images.githubusercontent.com/11314634/47075440-daf12280-d1fc-11e8-9adf-b13aaf49cc11.png)

Do you feel that the text here is self explanatory?