### PR TITLE
Add method for retrieving free staging projects

### DIFF
--- a/src/api/app/models/staging_workflow.rb
+++ b/src/api/app/models/staging_workflow.rb
@@ -1,6 +1,10 @@
 class StagingWorkflow < ApplicationRecord
   belongs_to :project, inverse_of: :staging
-  has_many :staging_projects, class_name: 'Project', inverse_of: :staging_workflow, dependent: :nullify
+  has_many :staging_projects, class_name: 'Project', inverse_of: :staging_workflow, dependent: :nullify do
+    def without_staged_requests
+      includes(:staged_requests).where(bs_requests: { id: nil })
+    end
+  end
 
   has_many :target_of_bs_requests, through: :project
   has_many :staged_requests, class_name: 'BsRequest', through: :staging_projects


### PR DESCRIPTION
This method retrieves the staging projects of a workflow project that don't have any requests assigned.

Co-authored-by: Saray Cabrera Padrón <scabrerapadron@suse.de>