### PR TITLE
Add backend response time to lograge output

### DIFF
--- a/src/api/config/environments/production.rb
+++ b/src/api/config/environments/production.rb
@@ -79,6 +79,7 @@ OBSApi::Application.configure do
       params: event.payload[:params].except(*exceptions),
       host:   event.payload[:headers].env['REMOTE_ADDR'],
       time:   event.time,
+      backend: event.payload[:backend_runtime],
       user:   User.current.try(:login)
     }
   end


### PR DESCRIPTION
We already calculate and store the backend runtime.
However, so we only show it in debug mode and store it to a dedicated file: backend_access.log.
This commit includes the total backend response time in the lograge output as
well to get a quick overview.

Example output:
```
method=GET path=/about format=html controller=AboutController action=index status=200 duration=36.84 view=16.92 db=0.00 params={} host=172.18.0.1 time=2018-10-19 12:21:07 +0000 backend=11.93 user=
```
