### PR TITLE
Symlink assets to a common name

### DIFF
--- a/dist/obs-server.spec
+++ b/dist/obs-server.spec
@@ -321,6 +321,12 @@ install -m 644 $RPM_BUILD_DIR/open-build-service-%version/dist/ec2utils.conf.exa
 mkdir -p $RPM_BUILD_ROOT/etc/obs/cloudupload/.aws
 install -m 644 $RPM_BUILD_DIR/open-build-service-%version/dist/aws_credentials.example $RPM_BUILD_ROOT/etc/obs/cloudupload/.aws/credentials
 
+# Link the assets without hash to make them accessible for third party tools like the pattern library
+pushd $RPM_BUILD_ROOT/srv/www/obs/api/public/assets/webui2/
+ln -sf application-*.js application.js
+ln -sf webui2-*.css webui2.css
+popd
+
 %check
 %if 0%{?disable_obs_test_suite}
 echo "WARNING:"


### PR DESCRIPTION
In rails assets get add a hash sum to make caching in browser work.
However, to access the assets from a third party (like obs-patterns) we
need a stable link to access it.