### PR TITLE
Send requests creation to rabbitmq bus

### DIFF
--- a/src/api/app/models/event/request_create.rb
+++ b/src/api/app/models/event/request_create.rb
@@ -23,6 +23,12 @@ module Event
     def expanded_payload
       payload_with_diff
     end
+
+    private
+
+    def metric_fields
+      payload.slice('number')
+    end
   end
 end
 


### PR DESCRIPTION
This allows us to track creation of new requests in grafana.

Co-authored-by: Ana María Martínez Gómez <ammartinez@suse.de>
Co-authored-by: Dany Marcoux <dmarcoux@suse.com>


