### PR TITLE
Add roles to metrics

### DIFF
--- a/src/api/app/models/event/base.rb
+++ b/src/api/app/models/event/base.rb
@@ -292,6 +292,7 @@ module Event
     def to_metric
       tags = metric_tags.map { |k, v| "#{k}=#{v}" }.join(',')
       tags = ",#{tags}" if tags.present?
+      tags += ",#{User.find(payload['sender']).roles_for_metrics}" if payload['sender']
       fields = metric_fields.map { |k, v| "#{k}=#{v}" }.join(',')
       "#{metric_measurement}#{tags} #{fields}"
     end

--- a/src/api/app/models/user.rb
+++ b/src/api/app/models/user.rb
@@ -106,6 +106,11 @@ class User < ApplicationRecord
     RabbitmqBus.send_to_bus('metrics', 'user.create value=1')
   end
 
+  def roles_for_metrics
+    # We add all the roles because otherwise false won't be equivalent to not true
+    Roles.all.map { |role| "#{role.title}=#{roles.exists?(role.id)}" }.join(',')
+  end
+
   def create_home_project
     # avoid errors during seeding
     return if login.in?([NOBODY_LOGIN, 'Admin'])


### PR DESCRIPTION
- Add roles to sessions metrics tags  (@dmarcoux thinks it is useful. :unamused:)
- Add sender roles to events metrics

To know what kind of users log in/send events. :bowtie: 