### PR TITLE
Allow to store status checks on unpublished repositories

### DIFF
--- a/src/api/app/controllers/status/concerns/set_checkable.rb
+++ b/src/api/app/controllers/status/concerns/set_checkable.rb
@@ -10,7 +10,7 @@ module Status
       private
 
       def set_checkable
-        set_repository || set_bs_request
+        set_repository_architecture || set_bs_request
         return if @checkable
 
         @error_message ||= 'Provide at least project_name and repository_name or request number.'
@@ -36,6 +36,14 @@ module Status
         return @checkable if @checkable
 
         @error_message = "Repository '#{params[:project_name]}/#{params[:repository_name]}' not found."
+      end
+
+      def set_repository_architecture
+        return unless set_repository && params[:arch]
+        @checkable = @checkable.repository_architectures.joins(:architecture).find_by(architectures: { name: params[:arch] })
+        return @checkable if @checkable
+
+        @error_message = "Repository '#{params[:project_name]}/#{params[:repository_name]}/#{params[:arch]}' not found."
       end
 
       def set_bs_request

--- a/src/api/app/models/repository_architecture.rb
+++ b/src/api/app/models/repository_architecture.rb
@@ -1,4 +1,5 @@
 class RepositoryArchitecture < ApplicationRecord
+  serialize :required_checks, Array
   belongs_to :repository,   inverse_of: :repository_architectures
   belongs_to :architecture, inverse_of: :repository_architectures
 
@@ -6,6 +7,16 @@ class RepositoryArchitecture < ApplicationRecord
 
   validates :repository, :architecture, :position, presence: true
   validates :repository, uniqueness: { scope: :architecture }
+
+  has_many :status_reports, as: :checkable, class_name: 'Status::Report', dependent: :destroy do
+    def for_uuid(uuid)
+      where(status_reports: { uuid: uuid })
+    end
+
+    def latest
+      for_uuid(proxy_association.owner.build_id)
+    end
+  end
 end
 
 # == Schema Information

--- a/src/api/app/models/repository_architecture.rb
+++ b/src/api/app/models/repository_architecture.rb
@@ -12,10 +12,10 @@ class RepositoryArchitecture < ApplicationRecord
     def for_uuid(uuid)
       where(status_reports: { uuid: uuid })
     end
+  end
 
-    def latest
-      for_uuid(proxy_association.owner.build_id)
-    end
+  def build_id
+    Backend::Api::Build::Repository.build_id(repository.project.name, repository.name, architecture.name)
   end
 end
 

--- a/src/api/config/routes.rb
+++ b/src/api/config/routes.rb
@@ -792,6 +792,9 @@ OBSApi::Application.routes.draw do
       scope :published do
         get ':project_name/:repository_name/reports/:report_uuid' => :show, constraints: cons
       end
+      scope :built do
+        get ':project_name/:repository_name/:arch/reports/:report_uuid' => :show, constraints: cons
+      end
       scope :requests do
         get ':bs_request_number/reports' => :show
       end
@@ -799,6 +802,9 @@ OBSApi::Application.routes.draw do
     controller :checks do
       scope :published do
         post ':project_name/:repository_name/reports/:report_uuid' => :update, constraints: cons
+      end
+      scope :built do
+        post ':project_name/:repository_name/:arch/reports/:report_uuid' => :update, constraints: cons
       end
       scope :requests do
         post ':bs_request_number/reports' => :update

--- a/src/api/db/migrate/20181025152009_add_required_checks_to_repository_architecture.rb
+++ b/src/api/db/migrate/20181025152009_add_required_checks_to_repository_architecture.rb
@@ -1,0 +1,5 @@
+class AddRequiredChecksToRepositoryArchitecture < ActiveRecord::Migration[5.2]
+  def change
+    add_column :repository_architectures, :required_checks, :string
+  end
+end

--- a/src/api/db/structure.sql
+++ b/src/api/db/structure.sql
@@ -1044,6 +1044,7 @@ CREATE TABLE `repository_architectures` (
   `architecture_id` int(11) NOT NULL,
   `position` int(11) NOT NULL DEFAULT '0',
   `id` int(11) NOT NULL AUTO_INCREMENT,
+  `required_checks` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   PRIMARY KEY (`id`),
   UNIQUE KEY `arch_repo_index` (`repository_id`,`architecture_id`) USING BTREE,
   KEY `architecture_id` (`architecture_id`) USING BTREE,
@@ -1406,6 +1407,7 @@ INSERT INTO `schema_migrations` (version) VALUES
 ('20180906142702'),
 ('20180906142802'),
 ('20180911123709'),
-('20180924135535');
+('20180924135535'),
+('20181025152009');
 
 

--- a/src/api/lib/backend/api/build/repository.rb
+++ b/src/api/lib/backend/api/build/repository.rb
@@ -1,0 +1,18 @@
+module Backend
+  module Api
+    module Build
+      # Class that connect to endpoints related to projects
+      class Repository
+        extend Backend::ConnectionHelper
+
+        # Returns the build id for a repository
+        # @return [String]
+        def self.build_id(project_name, repository_name, architecture)
+          response = http_get(['/build/:project/:repository/:architecture', project_name, repository_name, architecture], params: { view: 'status' })
+          Rails.logger.debug(Xmlhash.parse(response))
+          Xmlhash.parse(response).value('buildid')
+        end
+      end
+    end
+  end
+end

--- a/src/api/spec/controllers/status/checks_controller_spec.rb
+++ b/src/api/spec/controllers/status/checks_controller_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe Status::ChecksController, type: :controller do
   let(:project) { create(:project) }
   let(:repository) { create(:repository, project: project) }
   let(:status_report) { create(:status_report, checkable: repository) }
+  let(:repository_architecture) { create(:repository_architecture, repository: repository) }
 
   before do
     login user
@@ -172,6 +173,15 @@ RSpec.describe Status::ChecksController, type: :controller do
         let!(:check) { create(:check, name: 'openQA', state: 'pending', status_report: status_report) }
         let(:params) do
           { report_uuid: status_report.uuid, repository_name: repository.name, project_name: project.name }
+        end
+
+        include_context 'does update the check'
+      end
+
+      context 'for a repository architecture' do
+        let!(:check) { create(:check, name: 'openQA', state: 'pending', status_report: status_report) }
+        let(:params) do
+          { report_uuid: status_report.uuid, repository_name: repository.name, project_name: project.name, arch: repository_architecture.architecture.name }
         end
 
         include_context 'does update the check'

--- a/src/api/spec/controllers/status/reports_controller_spec.rb
+++ b/src/api/spec/controllers/status/reports_controller_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe Status::ReportsController, type: :controller do
       it { expect(assigns(:missing_checks)).to contain_exactly('openQA') }
     end
 
-    context 'for repository' do
+    context 'for published repository' do
       let(:project) { create(:project_with_repository) }
       let(:repository) { project.repositories.first }
       let(:status_report) { create(:status_report, checkable: repository) }
@@ -38,6 +38,27 @@ RSpec.describe Status::ReportsController, type: :controller do
       end
 
       subject! { get :show, params: { project_name: project.name, repository_name: repository.name, report_uuid: status_report.uuid }, format: :xml }
+
+      it { is_expected.to have_http_status(:success) }
+      it { expect(assigns(:checks)).to contain_exactly(check) }
+      it { expect(assigns(:missing_checks)).to contain_exactly('openQA') }
+    end
+
+    context 'for built repository' do
+      let(:project) { create(:project_with_repository) }
+      let(:repository) { project.repositories.first }
+      let(:repository_architecture) { create(:repository_architecture, repository: repository) }
+      let(:status_report) { create(:status_report, checkable: repository_architecture) }
+      let!(:check) { create(:check, status_report: status_report, name: 'ExampleCI') }
+
+      before do
+        repository_architecture.update_attributes!(required_checks: ['openQA'])
+      end
+
+      subject! do
+        get :show, params: { project_name: project.name, repository_name: repository.name,
+        arch: repository_architecture.architecture.name, report_uuid: status_report.uuid }, format: :xml
+      end
 
       it { is_expected.to have_http_status(:success) }
       it { expect(assigns(:checks)).to contain_exactly(check) }

--- a/src/api/spec/models/repository_architecture_spec.rb
+++ b/src/api/spec/models/repository_architecture_spec.rb
@@ -1,0 +1,25 @@
+require 'rails_helper'
+
+RSpec.describe RepositoryArchitecture do
+  describe '.build_id' do
+    let(:repository_architecture) { create(:repository_architecture) }
+    let(:repository) { repository_architecture.repository }
+    let(:project) { repository.project.name }
+    let(:architecture) { repository_architecture.architecture.name }
+
+    let(:good_response) { '<status code="finished"><buildid>1</buildid></status>' }
+    let(:busy_response) { '<status code="building"/>' }
+
+    subject { repository_architecture.build_id }
+
+    it 'fetches from backend' do
+      stub_request(:get, "#{CONFIG['source_url']}/build/#{project}/#{repository.name}/#{architecture}?view=status").and_return(body: good_response)
+      expect(subject).to eq('1')
+    end
+
+    it 'does not crash' do
+      stub_request(:get, "#{CONFIG['source_url']}/build/#{project}/#{repository.name}/#{architecture}?view=status").and_return(body: busy_response)
+      expect(subject).to be_nil
+    end
+  end
+end


### PR DESCRIPTION
Repo checker and pkglist generation happen on standard repository - and we don't want to wait for the publisher on this one.