### PR TITLE
Add status checks for unpublished repositories

### DIFF
--- a/src/api/app/controllers/status/checks_controller.rb
+++ b/src/api/app/controllers/status/checks_controller.rb
@@ -18,7 +18,7 @@ class Status::ChecksController < ApplicationController
     end
 
     if @check.save
-      create_event
+      @event_class.create(check_notify_params)
       render :show
     else
       render_error(status: 422, errorcode: 'invalid_check', message: "Could not save check: #{@check.errors.full_messages.to_sentence}")
@@ -26,18 +26,6 @@ class Status::ChecksController < ApplicationController
   end
 
   private
-
-  def create_event
-    if @project
-      if @architecture
-        Event::StatusCheckForBuild.create(check_notify_params)
-      else
-        Event::StatusCheckForPublished.create(check_notify_params)
-      end
-    else
-      Event::StatusCheckForRequest.create(check_notify_params)
-    end
-  end
 
   def check_notify_params
     params = { who: User.current.login, state: @check.state, name: @check.name }

--- a/src/api/app/controllers/status/checks_controller.rb
+++ b/src/api/app/controllers/status/checks_controller.rb
@@ -29,7 +29,11 @@ class Status::ChecksController < ApplicationController
 
   def create_event
     if @project
-      Event::StatusCheckForPublished.create(check_notify_params)
+      if @architecture
+        Event::StatusCheckForBuild.create(check_notify_params)
+      else
+        Event::StatusCheckForPublished.create(check_notify_params)
+      end
     else
       Event::StatusCheckForRequest.create(check_notify_params)
     end

--- a/src/api/app/controllers/status/checks_controller.rb
+++ b/src/api/app/controllers/status/checks_controller.rb
@@ -6,6 +6,7 @@ class Status::ChecksController < ApplicationController
   after_action :verify_authorized
 
   # PUT /status_reports/published/:project_name/:repository_name/reports/:uuid
+  # PUT /status_reports/build/:project_name/:repository_name/:arch/reports/:uuid
   # PUT /status_reports/requests/:number
   def update
     authorize @status_report

--- a/src/api/app/controllers/status/concerns/set_checkable.rb
+++ b/src/api/app/controllers/status/concerns/set_checkable.rb
@@ -10,15 +10,11 @@ module Status
       private
 
       def set_checkable
-        set_repository_architecture || set_bs_request
+        set_repository_architecture if params[:project_name]
+        set_bs_request if params[:bs_request_number]
         return if @checkable
 
-        @error_message ||= 'Provide at least project_name and repository_name or request number.'
-        render_error(
-          status: 404,
-          errorcode: 'not_found',
-          message: @error_message
-        )
+        raise ActiveRecord::RecordNotFound, @error_message
       end
 
       def set_project

--- a/src/api/app/controllers/status/concerns/set_checkable.rb
+++ b/src/api/app/controllers/status/concerns/set_checkable.rb
@@ -10,7 +10,7 @@ module Status
       private
 
       def set_checkable
-        set_repository || set_bs_request
+        set_repository_architecture || set_bs_request
         return if @checkable
 
         @error_message ||= 'Provide at least project_name and repository_name or request number.'
@@ -36,6 +36,15 @@ module Status
         return @checkable if @checkable
 
         @error_message = "Repository '#{params[:project_name]}/#{params[:repository_name]}' not found."
+      end
+
+      def set_repository_architecture
+        return unless set_repository
+        return @checkable unless params[:arch]
+        @checkable = @checkable.repository_architectures.joins(:architecture).find_by(architectures: { name: params[:arch] })
+        return @checkable if @checkable
+
+        @error_message = "Repository '#{params[:project_name]}/#{params[:repository_name]}/#{params[:arch]}' not found."
       end
 
       def set_bs_request

--- a/src/api/app/controllers/status/concerns/set_checkable.rb
+++ b/src/api/app/controllers/status/concerns/set_checkable.rb
@@ -37,6 +37,7 @@ module Status
       def set_repository_architecture
         return unless set_repository
         return @checkable unless params[:arch]
+        @architecture = params[:arch]
         @checkable = @checkable.repository_architectures.joins(:architecture).find_by(architectures: { name: params[:arch] })
         return @checkable if @checkable
 

--- a/src/api/app/controllers/status/concerns/set_checkable.rb
+++ b/src/api/app/controllers/status/concerns/set_checkable.rb
@@ -29,6 +29,7 @@ module Status
         return unless @project
 
         @checkable = @project.repositories.find_by(name: params[:repository_name])
+        @event_class = Event::StatusCheckForPublished
         return @checkable if @checkable
 
         @error_message = "Repository '#{params[:project_name]}/#{params[:repository_name]}' not found."
@@ -37,8 +38,9 @@ module Status
       def set_repository_architecture
         return unless set_repository
         return @checkable unless params[:arch]
-        @architecture = params[:arch]
+
         @checkable = @checkable.repository_architectures.joins(:architecture).find_by(architectures: { name: params[:arch] })
+        @event_class = Event::StatusCheckForBuild
         return @checkable if @checkable
 
         @error_message = "Repository '#{params[:project_name]}/#{params[:repository_name]}/#{params[:arch]}' not found."
@@ -46,6 +48,7 @@ module Status
 
       def set_bs_request
         @checkable = BsRequest.with_submit_requests.find_by(number: params[:bs_request_number])
+        @event_class = Event::StatusCheckForRequest
         return @checkable if @checkable
 
         @error_message = "Submit request with number '#{params[:bs_request_number]}' not found."

--- a/src/api/app/controllers/status/reports_controller.rb
+++ b/src/api/app/controllers/status/reports_controller.rb
@@ -4,6 +4,7 @@ class Status::ReportsController < ApplicationController
   skip_before_action :require_login, only: [:show]
 
   # GET /status_reports/published/:project_name/:repository_name/reports/:uuid
+  # GET /status_reports/build/:project_name/:repository_name/:arch/reports/:uuid
   def show
     @checks = @status_report.checks
     @missing_checks = @status_report.missing_checks

--- a/src/api/app/models/event/base.rb
+++ b/src/api/app/models/event/base.rb
@@ -76,6 +76,7 @@ module Event
       def inherited(subclass)
         super
 
+        subclass.after_create_commit(:send_to_bus)
         subclass.add_classname(name) unless name == 'Event::Base'
         subclass.payload_keys(*payload_keys)
         subclass.create_jobs(*create_jobs)
@@ -268,7 +269,7 @@ module Event
     end
 
     def send_to_bus
-      RabbitmqBus.send_to_bus(message_bus_routing_key, self[:payload])
+      RabbitmqBus.send_to_bus(message_bus_routing_key, self[:payload]) if message_bus_routing_key
       RabbitmqBus.send_to_bus('metrics', to_metric) if metric_fields.present?
     end
 

--- a/src/api/app/models/event/base.rb
+++ b/src/api/app/models/event/base.rb
@@ -20,6 +20,7 @@ module Event
 
     class << self
       attr_accessor :description
+      attr_accessor :message_bus_routing_key
       @payload_keys = nil
       @create_jobs = nil
       @classnames = nil
@@ -79,10 +80,6 @@ module Event
         subclass.payload_keys(*payload_keys)
         subclass.create_jobs(*create_jobs)
         subclass.receiver_roles(*receiver_roles)
-      end
-
-      def message_bus_routing_key
-        raise NotImplementedError
       end
     end
 
@@ -271,11 +268,15 @@ module Event
     end
 
     def send_to_bus
-      RabbitmqBus.send_to_bus(self.class.message_bus_routing_key, self[:payload])
+      RabbitmqBus.send_to_bus(message_bus_routing_key, self[:payload])
       RabbitmqBus.send_to_bus('metrics', to_metric) if metric_fields.present?
     end
 
     private
+
+    def message_bus_routing_key
+      self.class.message_bus_routing_key
+    end
 
     def metric_tags
       {}
@@ -286,7 +287,7 @@ module Event
     end
 
     def metric_measurement
-      self.class.message_bus_routing_key
+      message_bus_routing_key
     end
 
     def to_metric

--- a/src/api/app/models/event/branch_command.rb
+++ b/src/api/app/models/event/branch_command.rb
@@ -1,12 +1,9 @@
 module Event
   class BranchCommand < Base
     self.description = 'Package was branched'
+    self.message_bus_routing_key = 'package.branch'
     payload_keys :project, :package, :sender, :targetproject, :targetpackage, :user
     after_create_commit :send_to_bus
-
-    def self.message_bus_routing_key
-      'package.branch'
-    end
 
     def subject
       "Package Branched: #{payload['project']}/#{payload['package']} => #{payload['targetproject']}/#{payload['targetpackage']}"

--- a/src/api/app/models/event/branch_command.rb
+++ b/src/api/app/models/event/branch_command.rb
@@ -3,7 +3,6 @@ module Event
     self.description = 'Package was branched'
     self.message_bus_routing_key = 'package.branch'
     payload_keys :project, :package, :sender, :targetproject, :targetpackage, :user
-    after_create_commit :send_to_bus
 
     def subject
       "Package Branched: #{payload['project']}/#{payload['package']} => #{payload['targetproject']}/#{payload['targetpackage']}"

--- a/src/api/app/models/event/build_fail.rb
+++ b/src/api/app/models/event/build_fail.rb
@@ -5,7 +5,6 @@ module Event
     self.message_bus_routing_key = 'package.build_fail'
     self.description = 'Package has failed to build'
     receiver_roles :maintainer, :bugowner, :reader, :watcher
-    after_create_commit :send_to_bus
 
     def subject
       "Build failure of #{payload['project']}/#{payload['package']} in #{payload['repository']}/#{payload['arch']}"

--- a/src/api/app/models/event/build_fail.rb
+++ b/src/api/app/models/event/build_fail.rb
@@ -2,13 +2,10 @@ module Event
   class BuildFail < Build
     include BuildLogSupport
 
+    self.message_bus_routing_key = 'package.build_fail'
     self.description = 'Package has failed to build'
     receiver_roles :maintainer, :bugowner, :reader, :watcher
     after_create_commit :send_to_bus
-
-    def self.message_bus_routing_key
-      'package.build_fail'
-    end
 
     def subject
       "Build failure of #{payload['project']}/#{payload['package']} in #{payload['repository']}/#{payload['arch']}"

--- a/src/api/app/models/event/build_success.rb
+++ b/src/api/app/models/event/build_success.rb
@@ -2,7 +2,6 @@ module Event
   class BuildSuccess < Build
     self.message_bus_routing_key = 'package.build_success'
     self.description = 'Package has succeeded building'
-    after_create_commit :send_to_bus
   end
 end
 

--- a/src/api/app/models/event/build_success.rb
+++ b/src/api/app/models/event/build_success.rb
@@ -1,11 +1,8 @@
 module Event
   class BuildSuccess < Build
+    self.message_bus_routing_key = 'package.build_success'
     self.description = 'Package has succeeded building'
     after_create_commit :send_to_bus
-
-    def self.message_bus_routing_key
-      'package.build_success'
-    end
   end
 end
 

--- a/src/api/app/models/event/build_unchanged.rb
+++ b/src/api/app/models/event/build_unchanged.rb
@@ -1,11 +1,8 @@
 module Event
   class BuildUnchanged < Build
+    self.message_bus_routing_key = 'package.build_unchanged'
     self.description = 'Package has succeeded building with unchanged result'
     after_create_commit :send_to_bus
-
-    def self.message_bus_routing_key
-      'package.build_unchanged'
-    end
   end
 end
 

--- a/src/api/app/models/event/build_unchanged.rb
+++ b/src/api/app/models/event/build_unchanged.rb
@@ -2,7 +2,6 @@ module Event
   class BuildUnchanged < Build
     self.message_bus_routing_key = 'package.build_unchanged'
     self.description = 'Package has succeeded building with unchanged result'
-    after_create_commit :send_to_bus
   end
 end
 

--- a/src/api/app/models/event/comment_for_package.rb
+++ b/src/api/app/models/event/comment_for_package.rb
@@ -4,7 +4,6 @@ module Event
     self.message_bus_routing_key = 'package.comment'
     self.description = 'New comment for package created'
     receiver_roles :maintainer, :bugowner, :watcher
-    after_create_commit :send_to_bus
     payload_keys :project, :package, :sender
 
     def subject

--- a/src/api/app/models/event/comment_for_package.rb
+++ b/src/api/app/models/event/comment_for_package.rb
@@ -1,16 +1,11 @@
 module Event
   class CommentForPackage < Base
     include CommentEvent
-    self.description = 'Package was touched'
+    self.message_bus_routing_key = 'package.comment'
+    self.description = 'New comment for package created'
     receiver_roles :maintainer, :bugowner, :watcher
     after_create_commit :send_to_bus
     payload_keys :project, :package, :sender
-
-    def self.message_bus_routing_key
-      'package.comment'
-    end
-
-    self.description = 'New comment for package created'
 
     def subject
       "New comment in package #{payload['project']}/#{payload['package']} by #{User.find(payload['commenter']).login}"

--- a/src/api/app/models/event/comment_for_project.rb
+++ b/src/api/app/models/event/comment_for_project.rb
@@ -1,16 +1,11 @@
 module Event
   class CommentForProject < Base
     include CommentEvent
-    self.description = 'Project was touched'
+    self.message_bus_routing_key = 'project.comment'
+    self.description = 'New comment for project created'
     payload_keys :project
     receiver_roles :maintainer, :bugowner, :watcher
     after_create_commit :send_to_bus
-
-    def self.message_bus_routing_key
-      'project.comment'
-    end
-
-    self.description = 'New comment for project created'
 
     def subject
       "New comment in project #{payload['project']} by #{User.find(payload['commenter']).login}"

--- a/src/api/app/models/event/comment_for_project.rb
+++ b/src/api/app/models/event/comment_for_project.rb
@@ -5,7 +5,6 @@ module Event
     self.description = 'New comment for project created'
     payload_keys :project
     receiver_roles :maintainer, :bugowner, :watcher
-    after_create_commit :send_to_bus
 
     def subject
       "New comment in project #{payload['project']} by #{User.find(payload['commenter']).login}"

--- a/src/api/app/models/event/comment_for_request.rb
+++ b/src/api/app/models/event/comment_for_request.rb
@@ -5,7 +5,6 @@ module Event
     self.description = 'New comment for request created'
     payload_keys :request_number
     receiver_roles :source_maintainer, :target_maintainer, :creator, :reviewer, :source_watcher, :target_watcher
-    after_create_commit :send_to_bus
 
     def subject
       req = BsRequest.find_by_number(payload['number'])

--- a/src/api/app/models/event/comment_for_request.rb
+++ b/src/api/app/models/event/comment_for_request.rb
@@ -1,14 +1,11 @@
 module Event
   class CommentForRequest < Request
     include CommentEvent
+    self.message_bus_routing_key = 'request.comment'
     self.description = 'New comment for request created'
     payload_keys :request_number
     receiver_roles :source_maintainer, :target_maintainer, :creator, :reviewer, :source_watcher, :target_watcher
     after_create_commit :send_to_bus
-
-    def self.message_bus_routing_key
-      'request.comment'
-    end
 
     def subject
       req = BsRequest.find_by_number(payload['number'])

--- a/src/api/app/models/event/commit.rb
+++ b/src/api/app/models/event/commit.rb
@@ -3,9 +3,7 @@ module Event
     self.message_bus_routing_key = 'package.commit'
     self.description = 'New revision of a package was commited'
     payload_keys :project, :package, :sender, :comment, :user, :files, :rev, :requestid
-
     create_jobs :update_backend_infos_job
-    after_create_commit :send_to_bus
 
     def subject
       "#{payload['project']}/#{payload['package']} r#{payload['rev']} commited"

--- a/src/api/app/models/event/commit.rb
+++ b/src/api/app/models/event/commit.rb
@@ -1,14 +1,11 @@
 module Event
   class Commit < Base
+    self.message_bus_routing_key = 'package.commit'
     self.description = 'New revision of a package was commited'
     payload_keys :project, :package, :sender, :comment, :user, :files, :rev, :requestid
 
     create_jobs :update_backend_infos_job
     after_create_commit :send_to_bus
-
-    def self.message_bus_routing_key
-      'package.commit'
-    end
 
     def subject
       "#{payload['project']}/#{payload['package']} r#{payload['rev']} commited"

--- a/src/api/app/models/event/create_package.rb
+++ b/src/api/app/models/event/create_package.rb
@@ -3,7 +3,6 @@ module Event
     self.message_bus_routing_key = 'package.create'
     self.description = 'Package was created'
     payload_keys :project, :package, :sender
-    after_create_commit :send_to_bus
 
     def subject
       "New Package #{payload['project']}/#{payload['package']}"

--- a/src/api/app/models/event/create_package.rb
+++ b/src/api/app/models/event/create_package.rb
@@ -1,12 +1,9 @@
 module Event
   class CreatePackage < Base
+    self.message_bus_routing_key = 'package.create'
     self.description = 'Package was created'
     payload_keys :project, :package, :sender
     after_create_commit :send_to_bus
-
-    def self.message_bus_routing_key
-      'package.create'
-    end
 
     def subject
       "New Package #{payload['project']}/#{payload['package']}"

--- a/src/api/app/models/event/create_project.rb
+++ b/src/api/app/models/event/create_project.rb
@@ -3,7 +3,6 @@ module Event
     self.message_bus_routing_key = 'project.create'
     self.description = 'Project is created'
     payload_keys :project, :sender
-    after_create_commit :send_to_bus
 
     def subject
       "New Project #{payload['project']}"

--- a/src/api/app/models/event/create_project.rb
+++ b/src/api/app/models/event/create_project.rb
@@ -1,12 +1,9 @@
 module Event
   class CreateProject < Base
+    self.message_bus_routing_key = 'project.create'
     self.description = 'Project is created'
     payload_keys :project, :sender
     after_create_commit :send_to_bus
-
-    def self.message_bus_routing_key
-      'project.create'
-    end
 
     def subject
       "New Project #{payload['project']}"

--- a/src/api/app/models/event/delete_package.rb
+++ b/src/api/app/models/event/delete_package.rb
@@ -1,12 +1,9 @@
 module Event
   class DeletePackage < Base
+    self.message_bus_routing_key = 'package.delete'
     self.description = 'Package was deleted'
     payload_keys :project, :package, :sender, :comment, :requestid
     after_create_commit :send_to_bus
-
-    def self.message_bus_routing_key
-      'package.delete'
-    end
 
     def set_payload(attribs, keys)
       attribs['comment'] = attribs['comment'][0..800] if attribs['comment'].present?

--- a/src/api/app/models/event/delete_package.rb
+++ b/src/api/app/models/event/delete_package.rb
@@ -3,7 +3,6 @@ module Event
     self.message_bus_routing_key = 'package.delete'
     self.description = 'Package was deleted'
     payload_keys :project, :package, :sender, :comment, :requestid
-    after_create_commit :send_to_bus
 
     def set_payload(attribs, keys)
       attribs['comment'] = attribs['comment'][0..800] if attribs['comment'].present?

--- a/src/api/app/models/event/delete_project.rb
+++ b/src/api/app/models/event/delete_project.rb
@@ -3,7 +3,6 @@ module Event
     self.message_bus_routing_key = 'project.delete'
     self.description = 'Project was deleted'
     payload_keys :project, :comment, :requestid, :sender
-    after_create_commit :send_to_bus
 
     private
 

--- a/src/api/app/models/event/delete_project.rb
+++ b/src/api/app/models/event/delete_project.rb
@@ -1,12 +1,9 @@
 module Event
   class DeleteProject < Base
+    self.message_bus_routing_key = 'project.delete'
     self.description = 'Project was deleted'
     payload_keys :project, :comment, :requestid, :sender
     after_create_commit :send_to_bus
-
-    def self.message_bus_routing_key
-      'project.delete'
-    end
 
     private
 

--- a/src/api/app/models/event/packtrack.rb
+++ b/src/api/app/models/event/packtrack.rb
@@ -6,7 +6,6 @@ module Event
 
     # for package tracking in first place
     create_jobs :update_released_binaries_job
-    after_create_commit :send_to_bus
   end
 end
 

--- a/src/api/app/models/event/packtrack.rb
+++ b/src/api/app/models/event/packtrack.rb
@@ -1,15 +1,12 @@
 module Event
   class Packtrack < Base
+    self.message_bus_routing_key = 'repo.packtrack'
     self.description = 'Binary was published'
     payload_keys :project, :repo, :payload
 
     # for package tracking in first place
     create_jobs :update_released_binaries_job
     after_create_commit :send_to_bus
-
-    def self.message_bus_routing_key
-      'repo.packtrack'
-    end
   end
 end
 

--- a/src/api/app/models/event/repo_build_finished.rb
+++ b/src/api/app/models/event/repo_build_finished.rb
@@ -3,7 +3,6 @@ module Event
     self.message_bus_routing_key = 'repo.build_finished'
     self.description = 'Repository finished building'
     payload_keys :project, :repo, :arch, :buildid
-    after_create_commit :send_to_bus
   end
 end
 

--- a/src/api/app/models/event/repo_build_finished.rb
+++ b/src/api/app/models/event/repo_build_finished.rb
@@ -1,12 +1,9 @@
 module Event
   class RepoBuildFinished < Base
+    self.message_bus_routing_key = 'repo.build_finished'
     self.description = 'Repository finished building'
     payload_keys :project, :repo, :arch, :buildid
     after_create_commit :send_to_bus
-
-    def self.message_bus_routing_key
-      'repo.build_finished'
-    end
   end
 end
 

--- a/src/api/app/models/event/repo_build_finished.rb
+++ b/src/api/app/models/event/repo_build_finished.rb
@@ -1,0 +1,30 @@
+module Event
+  class RepoBuildFinished < Base
+    self.description = 'Repository finished building'
+    payload_keys :project, :repo, :arch, :buildid
+    after_create_commit :send_to_bus
+
+    def self.message_bus_routing_key
+      'repo.build_finished'
+    end
+  end
+end
+
+# == Schema Information
+#
+# Table name: events
+#
+#  id          :integer          not null, primary key
+#  eventtype   :string(255)      not null, indexed
+#  payload     :text(65535)
+#  created_at  :datetime         indexed
+#  updated_at  :datetime
+#  undone_jobs :integer          default(0)
+#  mails_sent  :boolean          default(FALSE), indexed
+#
+# Indexes
+#
+#  index_events_on_created_at  (created_at)
+#  index_events_on_eventtype   (eventtype)
+#  index_events_on_mails_sent  (mails_sent)
+#

--- a/src/api/app/models/event/repo_publish_state.rb
+++ b/src/api/app/models/event/repo_publish_state.rb
@@ -1,12 +1,9 @@
 module Event
   class RepoPublishState < Base
+    self.message_bus_routing_key = 'repo.publish_state'
     self.description = 'Publish State of Repository has changed'
     payload_keys :project, :repo, :state
     after_create_commit :send_to_bus
-
-    def self.message_bus_routing_key
-      'repo.publish_state'
-    end
   end
 end
 

--- a/src/api/app/models/event/repo_publish_state.rb
+++ b/src/api/app/models/event/repo_publish_state.rb
@@ -3,7 +3,6 @@ module Event
     self.message_bus_routing_key = 'repo.publish_state'
     self.description = 'Publish State of Repository has changed'
     payload_keys :project, :repo, :state
-    after_create_commit :send_to_bus
   end
 end
 

--- a/src/api/app/models/event/repo_published.rb
+++ b/src/api/app/models/event/repo_published.rb
@@ -1,12 +1,9 @@
 module Event
   class RepoPublished < Base
+    self.message_bus_routing_key = 'repo.published'
     self.description = 'Repository was published'
     payload_keys :project, :repo, :buildid
     after_create_commit :send_to_bus
-
-    def self.message_bus_routing_key
-      'repo.published'
-    end
   end
 end
 

--- a/src/api/app/models/event/repo_published.rb
+++ b/src/api/app/models/event/repo_published.rb
@@ -3,7 +3,6 @@ module Event
     self.message_bus_routing_key = 'repo.published'
     self.description = 'Repository was published'
     payload_keys :project, :repo, :buildid
-    after_create_commit :send_to_bus
   end
 end
 

--- a/src/api/app/models/event/request_change.rb
+++ b/src/api/app/models/event/request_change.rb
@@ -2,7 +2,6 @@ module Event
   class RequestChange < Request
     self.message_bus_routing_key = 'request.change'
     self.description = 'Request XML was updated (admin only)'
-    after_create_commit :send_to_bus
   end
 end
 

--- a/src/api/app/models/event/request_change.rb
+++ b/src/api/app/models/event/request_change.rb
@@ -1,11 +1,8 @@
 module Event
   class RequestChange < Request
+    self.message_bus_routing_key = 'request.change'
     self.description = 'Request XML was updated (admin only)'
     after_create_commit :send_to_bus
-
-    def self.message_bus_routing_key
-      'request.change'
-    end
   end
 end
 

--- a/src/api/app/models/event/request_create.rb
+++ b/src/api/app/models/event/request_create.rb
@@ -3,7 +3,6 @@ module Event
     self.message_bus_routing_key = 'request.create'
     self.description = 'Request created'
     receiver_roles :source_maintainer, :target_maintainer, :source_watcher, :target_watcher
-    after_create_commit :send_to_bus
 
     def custom_headers
       base = super

--- a/src/api/app/models/event/request_create.rb
+++ b/src/api/app/models/event/request_create.rb
@@ -1,12 +1,9 @@
 module Event
   class RequestCreate < Request
+    self.message_bus_routing_key = 'request.create'
     self.description = 'Request created'
     receiver_roles :source_maintainer, :target_maintainer, :source_watcher, :target_watcher
     after_create_commit :send_to_bus
-
-    def self.message_bus_routing_key
-      'request.create'
-    end
 
     def custom_headers
       base = super

--- a/src/api/app/models/event/request_delete.rb
+++ b/src/api/app/models/event/request_delete.rb
@@ -2,7 +2,6 @@ module Event
   class RequestDelete < Request
     self.message_bus_routing_key = 'request.delete'
     self.description = 'Request was deleted (admin only)'
-    after_create_commit :send_to_bus
   end
 end
 

--- a/src/api/app/models/event/request_delete.rb
+++ b/src/api/app/models/event/request_delete.rb
@@ -1,11 +1,8 @@
 module Event
   class RequestDelete < Request
+    self.message_bus_routing_key = 'request.delete'
     self.description = 'Request was deleted (admin only)'
     after_create_commit :send_to_bus
-
-    def self.message_bus_routing_key
-      'request.delete'
-    end
   end
 end
 

--- a/src/api/app/models/event/request_statechange.rb
+++ b/src/api/app/models/event/request_statechange.rb
@@ -1,13 +1,10 @@
 module Event
   class RequestStatechange < Request
+    self.message_bus_routing_key = 'request.state_change'
     self.description = 'Request state was changed'
     payload_keys :oldstate
     receiver_roles :source_maintainer, :target_maintainer, :creator, :reviewer, :source_watcher, :target_watcher
     after_create_commit :send_to_bus
-
-    def self.message_bus_routing_key
-      'request.state_change'
-    end
 
     def subject
       "Request #{payload['number']} changed to #{payload['state']} (#{actions_summary})"

--- a/src/api/app/models/event/request_statechange.rb
+++ b/src/api/app/models/event/request_statechange.rb
@@ -4,7 +4,6 @@ module Event
     self.description = 'Request state was changed'
     payload_keys :oldstate
     receiver_roles :source_maintainer, :target_maintainer, :creator, :reviewer, :source_watcher, :target_watcher
-    after_create_commit :send_to_bus
 
     def subject
       "Request #{payload['number']} changed to #{payload['state']} (#{actions_summary})"

--- a/src/api/app/models/event/review_wanted.rb
+++ b/src/api/app/models/event/review_wanted.rb
@@ -1,14 +1,11 @@
 module Event
   class ReviewWanted < Request
+    self.message_bus_routing_key = 'request.review_wanted'
     self.description = 'Review was created'
 
     payload_keys :reviewers, :by_user, :by_group, :by_project, :by_package
     receiver_roles :reviewer
     after_create_commit :send_to_bus
-
-    def self.message_bus_routing_key
-      'request.review_wanted'
-    end
 
     def subject
       "Request #{payload['number']} requires review (#{actions_summary})"

--- a/src/api/app/models/event/review_wanted.rb
+++ b/src/api/app/models/event/review_wanted.rb
@@ -2,10 +2,8 @@ module Event
   class ReviewWanted < Request
     self.message_bus_routing_key = 'request.review_wanted'
     self.description = 'Review was created'
-
     payload_keys :reviewers, :by_user, :by_group, :by_project, :by_package
     receiver_roles :reviewer
-    after_create_commit :send_to_bus
 
     def subject
       "Request #{payload['number']} requires review (#{actions_summary})"

--- a/src/api/app/models/event/service_fail.rb
+++ b/src/api/app/models/event/service_fail.rb
@@ -1,14 +1,11 @@
 module Event
   class ServiceFail < Base
+    self.message_bus_routing_key = 'package.service_fail'
     self.description = 'Package source service has failed'
     payload_keys :project, :package, :sender, :comment, :error, :rev, :user, :requestid
     receiver_roles :maintainer, :bugowner
     create_jobs :update_backend_infos_job
     after_create_commit :send_to_bus
-
-    def self.message_bus_routing_key
-      'package.service_fail'
-    end
 
     def subject
       "Source service failure of #{payload['project']}/#{payload['package']}"

--- a/src/api/app/models/event/service_fail.rb
+++ b/src/api/app/models/event/service_fail.rb
@@ -5,7 +5,6 @@ module Event
     payload_keys :project, :package, :sender, :comment, :error, :rev, :user, :requestid
     receiver_roles :maintainer, :bugowner
     create_jobs :update_backend_infos_job
-    after_create_commit :send_to_bus
 
     def subject
       "Source service failure of #{payload['project']}/#{payload['package']}"

--- a/src/api/app/models/event/service_success.rb
+++ b/src/api/app/models/event/service_success.rb
@@ -5,7 +5,6 @@ module Event
     payload_keys :project, :package, :sender, :comment, :rev, :user, :requestid
     receiver_roles :maintainer, :bugowner
     create_jobs :update_backend_infos_job
-    after_create_commit :send_to_bus
 
     def subject
       "Source service succeeded of #{payload['project']}/#{payload['package']}"

--- a/src/api/app/models/event/service_success.rb
+++ b/src/api/app/models/event/service_success.rb
@@ -1,14 +1,11 @@
 module Event
   class ServiceSuccess < Base
+    self.message_bus_routing_key = 'package.service_success'
     self.description = 'Package source service has succeeded'
     payload_keys :project, :package, :sender, :comment, :rev, :user, :requestid
     receiver_roles :maintainer, :bugowner
     create_jobs :update_backend_infos_job
     after_create_commit :send_to_bus
-
-    def self.message_bus_routing_key
-      'package.service_success'
-    end
 
     def subject
       "Source service succeeded of #{payload['project']}/#{payload['package']}"

--- a/src/api/app/models/event/status_check.rb
+++ b/src/api/app/models/event/status_check.rb
@@ -1,0 +1,10 @@
+module Event
+  class StatusCheck < Base
+    self.abstract_class = true
+    payload_keys :who, :name, :short_description, :state, :url
+
+    def originator
+      payload_address('who')
+    end
+  end
+end

--- a/src/api/app/models/event/status_check.rb
+++ b/src/api/app/models/event/status_check.rb
@@ -2,9 +2,5 @@ module Event
   class StatusCheck < Base
     self.abstract_class = true
     payload_keys :who, :name, :short_description, :state, :url
-
-    def originator
-      payload_address('who')
-    end
   end
 end

--- a/src/api/app/models/event/status_check_for_build.rb
+++ b/src/api/app/models/event/status_check_for_build.rb
@@ -1,0 +1,10 @@
+module Event
+  class StatusCheckForBuild < StatusCheck
+    self.description = 'Status Check for Finished Repository Created'
+    payload_keys :project, :repo, :arch, :buildid
+
+    def self.message_bus_routing_key
+      'repo.status_report'
+    end
+  end
+end

--- a/src/api/app/models/event/status_check_for_build.rb
+++ b/src/api/app/models/event/status_check_for_build.rb
@@ -1,10 +1,7 @@
 module Event
   class StatusCheckForBuild < StatusCheck
+    self.message_bus_routing_key = 'repo.status_report'
     self.description = 'Status Check for Finished Repository Created'
     payload_keys :project, :repo, :arch, :buildid
-
-    def self.message_bus_routing_key
-      'repo.status_report'
-    end
   end
 end

--- a/src/api/app/models/event/status_check_for_published.rb
+++ b/src/api/app/models/event/status_check_for_published.rb
@@ -1,10 +1,7 @@
 module Event
   class StatusCheckForPublished < StatusCheck
+    self.message_bus_routing_key = 'published.status_report'
     self.description = 'Status Check for Published Repository Created'
     payload_keys :project, :repo, :buildid
-
-    def self.message_bus_routing_key
-      'published.status_report'
-    end
   end
 end

--- a/src/api/app/models/event/status_check_for_published.rb
+++ b/src/api/app/models/event/status_check_for_published.rb
@@ -1,0 +1,6 @@
+module Event
+  class StatusCheckForPublished < StatusCheck
+    self.description = 'Status Check for Published Repository Created'
+    payload_keys :project, :repository, :uuid
+  end
+end

--- a/src/api/app/models/event/status_check_for_published.rb
+++ b/src/api/app/models/event/status_check_for_published.rb
@@ -1,7 +1,7 @@
 module Event
   class StatusCheckForPublished < StatusCheck
     self.description = 'Status Check for Published Repository Created'
-    payload_keys :project, :repository, :uuid
+    payload_keys :project, :repo, :buildid
 
     def self.message_bus_routing_key
       'published.status_report'

--- a/src/api/app/models/event/status_check_for_published.rb
+++ b/src/api/app/models/event/status_check_for_published.rb
@@ -2,5 +2,9 @@ module Event
   class StatusCheckForPublished < StatusCheck
     self.description = 'Status Check for Published Repository Created'
     payload_keys :project, :repository, :uuid
+
+    def self.message_bus_routing_key
+      'published.status_report'
+    end
   end
 end

--- a/src/api/app/models/event/status_check_for_request.rb
+++ b/src/api/app/models/event/status_check_for_request.rb
@@ -1,5 +1,9 @@
 module Event
   class StatusCheckForRequest < StatusCheck
     payload_keys :number
+
+    def self.message_bus_routing_key
+      'request.status_report'
+    end
   end
 end

--- a/src/api/app/models/event/status_check_for_request.rb
+++ b/src/api/app/models/event/status_check_for_request.rb
@@ -1,9 +1,6 @@
 module Event
   class StatusCheckForRequest < StatusCheck
+    self.message_bus_routing_key = 'request.status_report'
     payload_keys :number
-
-    def self.message_bus_routing_key
-      'request.status_report'
-    end
   end
 end

--- a/src/api/app/models/event/status_check_for_request.rb
+++ b/src/api/app/models/event/status_check_for_request.rb
@@ -1,0 +1,5 @@
+module Event
+  class StatusCheckForRequest < StatusCheck
+    payload_keys :number
+  end
+end

--- a/src/api/app/models/event/undelete_package.rb
+++ b/src/api/app/models/event/undelete_package.rb
@@ -1,12 +1,9 @@
 module Event
   class UndeletePackage < Base
+    self.message_bus_routing_key = 'package.undelete'
     self.description = 'Package was undeleted'
     payload_keys :project, :package, :sender, :comment
     after_create_commit :send_to_bus
-
-    def self.message_bus_routing_key
-      'package.undelete'
-    end
 
     def set_payload(attribs, keys)
       attribs['comment'] = attribs['comment'][0..800] if attribs['comment'].present?

--- a/src/api/app/models/event/undelete_package.rb
+++ b/src/api/app/models/event/undelete_package.rb
@@ -3,7 +3,6 @@ module Event
     self.message_bus_routing_key = 'package.undelete'
     self.description = 'Package was undeleted'
     payload_keys :project, :package, :sender, :comment
-    after_create_commit :send_to_bus
 
     def set_payload(attribs, keys)
       attribs['comment'] = attribs['comment'][0..800] if attribs['comment'].present?

--- a/src/api/app/models/event/undelete_project.rb
+++ b/src/api/app/models/event/undelete_project.rb
@@ -3,7 +3,6 @@ module Event
     self.message_bus_routing_key = 'project.undelete'
     self.description = 'Project was undeleted'
     payload_keys :project, :comment, :sender
-    after_create_commit :send_to_bus
   end
 end
 

--- a/src/api/app/models/event/undelete_project.rb
+++ b/src/api/app/models/event/undelete_project.rb
@@ -1,12 +1,9 @@
 module Event
   class UndeleteProject < Base
+    self.message_bus_routing_key = 'project.undelete'
     self.description = 'Project was undeleted'
     payload_keys :project, :comment, :sender
     after_create_commit :send_to_bus
-
-    def self.message_bus_routing_key
-      'project.undelete'
-    end
   end
 end
 

--- a/src/api/app/models/event/update_package.rb
+++ b/src/api/app/models/event/update_package.rb
@@ -1,12 +1,9 @@
 module Event
   class UpdatePackage < Base
+    self.message_bus_routing_key = 'package.update'
     self.description = 'Package meta data was updated'
     payload_keys :project, :package, :sender
     after_create_commit :send_to_bus
-
-    def self.message_bus_routing_key
-      'package.update'
-    end
   end
 end
 

--- a/src/api/app/models/event/update_package.rb
+++ b/src/api/app/models/event/update_package.rb
@@ -3,7 +3,6 @@ module Event
     self.message_bus_routing_key = 'package.update'
     self.description = 'Package meta data was updated'
     payload_keys :project, :package, :sender
-    after_create_commit :send_to_bus
   end
 end
 

--- a/src/api/app/models/event/update_project.rb
+++ b/src/api/app/models/event/update_project.rb
@@ -1,12 +1,9 @@
 module Event
   class UpdateProject < Base
+    self.message_bus_routing_key = 'project.update'
     self.description = 'Project meta was updated'
     payload_keys :project, :sender
     after_create_commit :send_to_bus
-
-    def self.message_bus_routing_key
-      'project.update'
-    end
   end
 end
 

--- a/src/api/app/models/event/update_project.rb
+++ b/src/api/app/models/event/update_project.rb
@@ -3,7 +3,6 @@ module Event
     self.message_bus_routing_key = 'project.update'
     self.description = 'Project meta was updated'
     payload_keys :project, :sender
-    after_create_commit :send_to_bus
   end
 end
 

--- a/src/api/app/models/event/update_project_config.rb
+++ b/src/api/app/models/event/update_project_config.rb
@@ -3,7 +3,6 @@ module Event
     self.message_bus_routing_key = 'project.update_project_conf'
     self.description = 'Project _config was updated'
     payload_keys :project, :sender, :files, :comment
-    after_create_commit :send_to_bus
   end
 end
 

--- a/src/api/app/models/event/update_project_config.rb
+++ b/src/api/app/models/event/update_project_config.rb
@@ -1,12 +1,9 @@
 module Event
   class UpdateProjectConfig < Base
+    self.message_bus_routing_key = 'project.update_project_conf'
     self.description = 'Project _config was updated'
     payload_keys :project, :sender, :files, :comment
     after_create_commit :send_to_bus
-
-    def self.message_bus_routing_key
-      'project.update_project_conf'
-    end
   end
 end
 

--- a/src/api/app/models/event/upload.rb
+++ b/src/api/app/models/event/upload.rb
@@ -3,7 +3,6 @@ module Event
     self.message_bus_routing_key = 'package.upload'
     self.description = 'Package sources were uploaded'
     payload_keys :project, :package, :sender, :comment, :filename, :requestid, :target, :user
-    after_create_commit :send_to_bus
   end
 end
 

--- a/src/api/app/models/event/upload.rb
+++ b/src/api/app/models/event/upload.rb
@@ -1,12 +1,9 @@
 module Event
   class Upload < Base
+    self.message_bus_routing_key = 'package.upload'
     self.description = 'Package sources were uploaded'
     payload_keys :project, :package, :sender, :comment, :filename, :requestid, :target, :user
     after_create_commit :send_to_bus
-
-    def self.message_bus_routing_key
-      'package.upload'
-    end
   end
 end
 

--- a/src/api/app/models/event/version_change.rb
+++ b/src/api/app/models/event/version_change.rb
@@ -3,7 +3,6 @@ module Event
     self.message_bus_routing_key = 'package.version_change'
     self.description = 'Package has changed its version'
     payload_keys :project, :package, :sender, :comment, :requestid, :files, :rev, :newversion, :user, :oldversion
-    after_create_commit :send_to_bus
 
     def set_payload(attribs, keys)
       attribs['comment'] = attribs['comment'][0..800] if attribs['comment'].present?

--- a/src/api/app/models/event/version_change.rb
+++ b/src/api/app/models/event/version_change.rb
@@ -1,12 +1,9 @@
 module Event
   class VersionChange < Base
+    self.message_bus_routing_key = 'package.version_change'
     self.description = 'Package has changed its version'
     payload_keys :project, :package, :sender, :comment, :requestid, :files, :rev, :newversion, :user, :oldversion
     after_create_commit :send_to_bus
-
-    def self.message_bus_routing_key
-      'package.version_change'
-    end
 
     def set_payload(attribs, keys)
       attribs['comment'] = attribs['comment'][0..800] if attribs['comment'].present?

--- a/src/api/app/models/obs_factory/staging_project.rb
+++ b/src/api/app/models/obs_factory/staging_project.rb
@@ -253,13 +253,9 @@ module ObsFactory
     end
 
     def add_status(checkable)
-      status = checkable.status_reports.latest
-      if status
-        @missing_checks += status.missing_checks
-        @checks += status.checks
-      else
-        @missing_checks += checkable.required_checks
-      end
+      status = checkable.current_status_report
+      @missing_checks += status.missing_checks
+      @checks += status.checks
     end
 
     # Used internally to calculate #broken_packages and #building_repositories

--- a/src/api/app/models/obs_factory/staging_project.rb
+++ b/src/api/app/models/obs_factory/staging_project.rb
@@ -245,14 +245,20 @@ module ObsFactory
       @checks = []
       @missing_checks = []
       repositories.each do |repo|
-        build_id = repo.build_id
-        status = repo.status_reports.find_by(uuid: build_id)
-        if status
-          @missing_checks += status.missing_checks
-          @checks += status.checks
-        else
-          @missing_checks += repo.required_checks
+        add_status(repo)
+        repo.repository_architectures.each do |repo_arch|
+          add_status(repo_arch)
         end
+      end
+    end
+
+    def add_status(checkable)
+      status = checkable.status_reports.latest
+      if status
+        @missing_checks += status.missing_checks
+        @checks += status.checks
+      else
+        @missing_checks += repo.required_checks
       end
     end
 

--- a/src/api/app/models/obs_factory/staging_project.rb
+++ b/src/api/app/models/obs_factory/staging_project.rb
@@ -169,7 +169,7 @@ module ObsFactory
     #
     # @return [Hash] Hash with the metadata (currently the list of requests)
     def meta
-      @meta ||= YAML.safe_load(description) || {}
+      @meta ||= YAML.safe_load(description.to_s) || {}
     end
 
     def self.attributes
@@ -258,7 +258,7 @@ module ObsFactory
         @missing_checks += status.missing_checks
         @checks += status.checks
       else
-        @missing_checks += repo.required_checks
+        @missing_checks += checkable.required_checks
       end
     end
 

--- a/src/api/app/models/repository.rb
+++ b/src/api/app/models/repository.rb
@@ -22,7 +22,7 @@ class Repository < ApplicationRecord
     end
 
     def latest
-      for_uuid(proxy_association.owner.build_id)
+      for_uuid(proxy_association.owner.build_id).first
     end
   end
 

--- a/src/api/app/models/repository.rb
+++ b/src/api/app/models/repository.rb
@@ -1,5 +1,6 @@
 class Repository < ApplicationRecord
-  serialize :required_checks, Array
+  include Status::Checkable
+
   belongs_to :project, foreign_key: :db_project_id, inverse_of: :repositories
 
   before_destroy :cleanup_before_destroy
@@ -16,15 +17,6 @@ class Repository < ApplicationRecord
   has_many :product_medium, dependent: :delete_all
   has_many :repository_architectures, -> { order('position') }, dependent: :destroy, inverse_of: :repository
   has_many :architectures, -> { order('position') }, through: :repository_architectures
-  has_many :status_reports, as: :checkable, class_name: 'Status::Report', dependent: :destroy do
-    def for_uuid(uuid)
-      where(status_reports: { uuid: uuid })
-    end
-
-    def latest
-      for_uuid(proxy_association.owner.build_id).first
-    end
-  end
 
   scope :not_remote, -> { where(remote_project_name: '') }
   scope :remote, -> { where.not(remote_project_name: '') }

--- a/src/api/app/models/repository_architecture.rb
+++ b/src/api/app/models/repository_architecture.rb
@@ -1,4 +1,5 @@
 class RepositoryArchitecture < ApplicationRecord
+  serialize :required_checks, Array
   belongs_to :repository,   inverse_of: :repository_architectures
   belongs_to :architecture, inverse_of: :repository_architectures
 
@@ -6,6 +7,16 @@ class RepositoryArchitecture < ApplicationRecord
 
   validates :repository, :architecture, :position, presence: true
   validates :repository, uniqueness: { scope: :architecture }
+
+  has_many :status_reports, as: :checkable, class_name: 'Status::Report', dependent: :destroy do
+    def for_uuid(uuid)
+      where(status_reports: { uuid: uuid })
+    end
+
+    def latest
+      for_uuid(proxy_association.owner.build_id)
+    end
+  end
 end
 
 # == Schema Information

--- a/src/api/app/models/repository_architecture.rb
+++ b/src/api/app/models/repository_architecture.rb
@@ -1,5 +1,6 @@
 class RepositoryArchitecture < ApplicationRecord
-  serialize :required_checks, Array
+  include Status::Checkable
+
   belongs_to :repository,   inverse_of: :repository_architectures
   belongs_to :architecture, inverse_of: :repository_architectures
 
@@ -7,16 +8,6 @@ class RepositoryArchitecture < ApplicationRecord
 
   validates :repository, :architecture, :position, presence: true
   validates :repository, uniqueness: { scope: :architecture }
-
-  has_many :status_reports, as: :checkable, class_name: 'Status::Report', dependent: :destroy do
-    def for_uuid(uuid)
-      where(status_reports: { uuid: uuid })
-    end
-
-    def latest
-      for_uuid(proxy_association.owner.build_id).first
-    end
-  end
 
   def build_id
     Backend::Api::Build::Repository.build_id(repository.project.name, repository.name, architecture.name)

--- a/src/api/app/models/repository_architecture.rb
+++ b/src/api/app/models/repository_architecture.rb
@@ -8,7 +8,15 @@ class RepositoryArchitecture < ApplicationRecord
   validates :repository, :architecture, :position, presence: true
   validates :repository, uniqueness: { scope: :architecture }
 
-  has_many :status_reports, as: :checkable, class_name: 'Status::Report', dependent: :destroy
+  has_many :status_reports, as: :checkable, class_name: 'Status::Report', dependent: :destroy do
+    def for_uuid(uuid)
+      where(status_reports: { uuid: uuid })
+    end
+
+    def latest
+      for_uuid(proxy_association.owner.build_id)
+    end
+  end
 
   def build_id
     Backend::Api::Build::Repository.build_id(repository.project.name, repository.name, architecture.name)

--- a/src/api/app/models/repository_architecture.rb
+++ b/src/api/app/models/repository_architecture.rb
@@ -8,14 +8,10 @@ class RepositoryArchitecture < ApplicationRecord
   validates :repository, :architecture, :position, presence: true
   validates :repository, uniqueness: { scope: :architecture }
 
-  has_many :status_reports, as: :checkable, class_name: 'Status::Report', dependent: :destroy do
-    def for_uuid(uuid)
-      where(status_reports: { uuid: uuid })
-    end
+  has_many :status_reports, as: :checkable, class_name: 'Status::Report', dependent: :destroy
 
-    def latest
-      for_uuid(proxy_association.owner.build_id)
-    end
+  def build_id
+    Backend::Api::Build::Repository.build_id(repository.project.name, repository.name, architecture.name)
   end
 end
 

--- a/src/api/app/models/repository_architecture.rb
+++ b/src/api/app/models/repository_architecture.rb
@@ -14,7 +14,7 @@ class RepositoryArchitecture < ApplicationRecord
     end
 
     def latest
-      for_uuid(proxy_association.owner.build_id)
+      for_uuid(proxy_association.owner.build_id).first
     end
   end
 

--- a/src/api/app/models/status/checkable.rb
+++ b/src/api/app/models/status/checkable.rb
@@ -1,0 +1,12 @@
+module Status::Checkable
+  extend ActiveSupport::Concern
+
+  included do
+    serialize :required_checks, Array
+    has_many :status_reports, as: :checkable, class_name: 'Status::Report', dependent: :destroy
+  end
+
+  def current_status_report
+    status_reports.find_or_initialize_by(uuid: build_id)
+  end
+end

--- a/src/api/app/models/status/report.rb
+++ b/src/api/app/models/status/report.rb
@@ -39,6 +39,8 @@ class Status::Report < ApplicationRecord
       checkable.bs_request_actions.map(&:target_project_object).flatten
     when Repository
       [checkable.project]
+    when RepositoryArchitecture
+      [checkable.repository.project]
     else
       []
     end

--- a/src/api/app/models/status/report.rb
+++ b/src/api/app/models/status/report.rb
@@ -51,7 +51,9 @@ class Status::Report < ApplicationRecord
     when BsRequest
       { number: checkable.number }
     when Repository
-      { project: checkable.project.name, repository: checkable.name, uuid: uuid }
+      { project: checkable.project.name, repo: checkable.name, buildid: uuid }
+    when RepositoryArchitecture
+      { project: checkable.repository.project.name, repo: checkable.repository.name, arch: checkable.architecture.name, buildid: uuid }
     else
       {}
     end

--- a/src/api/app/models/status/report.rb
+++ b/src/api/app/models/status/report.rb
@@ -20,6 +20,10 @@ class Status::Report < ApplicationRecord
   validates :checkable, presence: true
   validates :uuid, presence: true
 
+  validates_each :checkable do |record, attr, value|
+    record.errors.add(attr, "invalid class #{value.class}") unless %w[BsRequest Repository RepositoryArchitecture].include?(value.class.to_s)
+  end
+
   #### Class methods using self. (public and then private)
 
   #### To define class methods as private use private_class_method
@@ -41,11 +45,10 @@ class Status::Report < ApplicationRecord
       [checkable.project]
     when RepositoryArchitecture
       [checkable.repository.project]
-    else
-      []
     end
   end
 
+  # TODO: prefer duck typing - also for above
   def notify_params
     case checkable
     when BsRequest
@@ -54,8 +57,6 @@ class Status::Report < ApplicationRecord
       { project: checkable.project.name, repo: checkable.name, buildid: uuid }
     when RepositoryArchitecture
       { project: checkable.repository.project.name, repo: checkable.repository.name, arch: checkable.architecture.name, buildid: uuid }
-    else
-      {}
     end
   end
 

--- a/src/api/app/models/status/report.rb
+++ b/src/api/app/models/status/report.rb
@@ -46,6 +46,17 @@ class Status::Report < ApplicationRecord
     end
   end
 
+  def notify_params
+    case checkable
+    when BsRequest
+      { number: checkable.number }
+    when Repository
+      { project: checkable.project.name, repository: checkable.name, uuid: uuid }
+    else
+      {}
+    end
+  end
+
   #### Instance methods (public and then protected/private)
 
   #### Alias of methods

--- a/src/api/config/routes.rb
+++ b/src/api/config/routes.rb
@@ -792,6 +792,9 @@ OBSApi::Application.routes.draw do
       scope :published do
         get ':project_name/:repository_name/reports/:report_uuid' => :show, constraints: cons
       end
+      scope :built do
+        get ':project_name/:repository_name/:arch/reports/:report_uuid' => :show, constraints: cons
+      end
       scope :requests do
         get ':bs_request_number/reports' => :show
       end
@@ -799,6 +802,9 @@ OBSApi::Application.routes.draw do
     controller :checks do
       scope :published do
         post ':project_name/:repository_name/reports/:report_uuid' => :update, constraints: cons
+      end
+      scope :built do
+        post ':project_name/:repository_name/:arch/reports/:report_uuid' => :update, constraints: cons
       end
       scope :requests do
         post ':bs_request_number/reports' => :update

--- a/src/api/db/migrate/20181025152009_add_required_checks_to_repository_architecture.rb
+++ b/src/api/db/migrate/20181025152009_add_required_checks_to_repository_architecture.rb
@@ -1,0 +1,5 @@
+class AddRequiredChecksToRepositoryArchitecture < ActiveRecord::Migration[5.2]
+  def change
+    add_column :repository_architectures, :required_checks, :string
+  end
+end

--- a/src/api/db/structure.sql
+++ b/src/api/db/structure.sql
@@ -1044,6 +1044,7 @@ CREATE TABLE `repository_architectures` (
   `architecture_id` int(11) NOT NULL,
   `position` int(11) NOT NULL DEFAULT '0',
   `id` int(11) NOT NULL AUTO_INCREMENT,
+  `required_checks` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   PRIMARY KEY (`id`),
   UNIQUE KEY `arch_repo_index` (`repository_id`,`architecture_id`) USING BTREE,
   KEY `architecture_id` (`architecture_id`) USING BTREE,
@@ -1406,6 +1407,7 @@ INSERT INTO `schema_migrations` (version) VALUES
 ('20180906142702'),
 ('20180906142802'),
 ('20180911123709'),
-('20180924135535');
+('20180924135535'),
+('20181025152009');
 
 

--- a/src/api/lib/backend/api/build/repository.rb
+++ b/src/api/lib/backend/api/build/repository.rb
@@ -1,0 +1,17 @@
+module Backend
+  module Api
+    module Build
+      # Class that connect to endpoints related to projects
+      class Repository
+        extend Backend::ConnectionHelper
+
+        # Returns the build id for a repository
+        # @return [String]
+        def self.build_id(project_name, repository_name, architecture)
+          response = http_get(['/build/:project/:repository/:architecture', project_name, repository_name, architecture], params: { view: 'status' })
+          Xmlhash.parse(response).value('buildid')
+        end
+      end
+    end
+  end
+end

--- a/src/api/spec/cassettes/Webui_ObsFactory_StagingProjectsController/GET_show/with_a_existent_factory_staging_project/with_checks/build_repo_has_failed_check/returns_failed.yml
+++ b/src/api/spec/cassettes/Webui_ObsFactory_StagingProjectsController/GET_show/with_a_existent_factory_staging_project/with_checks/build_repo_has_failed_check/returns_failed.yml
@@ -1,0 +1,551 @@
+---
+http_interactions:
+- request:
+    method: put
+    uri: http://backend:5352/source/openSUSE:Factory:Staging/_meta?user=_nobody_
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="openSUSE:Factory:Staging">
+          <title>The Sun Also Rises</title>
+          <description/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '119'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="openSUSE:Factory:Staging">
+          <title>The Sun Also Rises</title>
+          <description></description>
+        </project>
+    http_version: 
+  recorded_at: Sat, 03 Nov 2018 08:51:30 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/openSUSE:Factory/_meta?user=_nobody_
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="openSUSE:Factory">
+          <title>A Glass of Blessings</title>
+          <description/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '113'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="openSUSE:Factory">
+          <title>A Glass of Blessings</title>
+          <description></description>
+        </project>
+    http_version: 
+  recorded_at: Sat, 03 Nov 2018 08:51:30 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/openSUSE:Factory/target_package/_meta?user=_nobody_
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="target_package" project="openSUSE:Factory">
+          <title>The Lathe of Heaven</title>
+          <description>Possimus omnis perferendis laudantium.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '175'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="target_package" project="openSUSE:Factory">
+          <title>The Lathe of Heaven</title>
+          <description>Possimus omnis perferendis laudantium.</description>
+        </package>
+    http_version: 
+  recorded_at: Sat, 03 Nov 2018 08:51:30 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/openSUSE:Factory/target_package/_meta?user=_nobody_
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="target_package" project="openSUSE:Factory">
+          <title>The Lathe of Heaven</title>
+          <description>Possimus omnis perferendis laudantium.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '175'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="target_package" project="openSUSE:Factory">
+          <title>The Lathe of Heaven</title>
+          <description>Possimus omnis perferendis laudantium.</description>
+        </package>
+    http_version: 
+  recorded_at: Sat, 03 Nov 2018 08:51:30 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/project_17/_meta?user=_nobody_
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="project_17">
+          <title>East of Eden</title>
+          <description/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '99'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="project_17">
+          <title>East of Eden</title>
+          <description></description>
+        </project>
+    http_version: 
+  recorded_at: Sat, 03 Nov 2018 08:51:30 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/project_17/package_9/_meta?user=_nobody_
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="package_9" project="project_17">
+          <title>Postern of Fate</title>
+          <description>Nemo quia sit qui.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '140'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="package_9" project="project_17">
+          <title>Postern of Fate</title>
+          <description>Nemo quia sit qui.</description>
+        </package>
+    http_version: 
+  recorded_at: Sat, 03 Nov 2018 08:51:30 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/project_17/package_9/_meta?user=_nobody_
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="package_9" project="project_17">
+          <title>Postern of Fate</title>
+          <description>Nemo quia sit qui.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '140'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="package_9" project="project_17">
+          <title>Postern of Fate</title>
+          <description>Nemo quia sit qui.</description>
+        </package>
+    http_version: 
+  recorded_at: Sat, 03 Nov 2018 08:51:30 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:user_20/_meta?user=user_20
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:user_20">
+          <title/>
+          <description/>
+          <person userid="user_20" role="maintainer"/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '137'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:user_20">
+          <title></title>
+          <description></description>
+          <person userid="user_20" role="maintainer" />
+        </project>
+    http_version: 
+  recorded_at: Sat, 03 Nov 2018 08:51:30 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/openSUSE:Factory:Staging:A/_meta?user=_nobody_
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="openSUSE:Factory:Staging:A">
+          <title>Some Buried Caesar</title>
+          <description>      requests:
+                - { id: 1 }
+        </description>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '157'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="openSUSE:Factory:Staging:A">
+          <title>Some Buried Caesar</title>
+          <description>      requests:
+                - { id: 1 }
+        </description>
+        </project>
+    http_version: 
+  recorded_at: Sat, 03 Nov 2018 08:51:31 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/openSUSE:Factory:Staging:B/_meta?user=_nobody_
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="openSUSE:Factory:Staging:B">
+          <title>Have His Carcase</title>
+          <description>Factory staging project B</description>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '144'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="openSUSE:Factory:Staging:B">
+          <title>Have His Carcase</title>
+          <description>Factory staging project B</description>
+        </project>
+    http_version: 
+  recorded_at: Sat, 03 Nov 2018 08:51:31 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:user_21/_meta?user=user_21
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:user_21">
+          <title/>
+          <description/>
+          <person userid="user_21" role="maintainer"/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '137'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:user_21">
+          <title></title>
+          <description></description>
+          <person userid="user_21" role="maintainer" />
+        </project>
+    http_version: 
+  recorded_at: Sat, 03 Nov 2018 08:51:31 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/openSUSE:Factory:Staging:D/_meta?user=_nobody_
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="openSUSE:Factory:Staging:D">
+          <title>The Widening Gyre</title>
+          <description>                     requests:
+                               - { id: 2 }
+        </description>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '186'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="openSUSE:Factory:Staging:D">
+          <title>The Widening Gyre</title>
+          <description>                     requests:
+                               - { id: 2 }
+        </description>
+        </project>
+    http_version: 
+  recorded_at: Sat, 03 Nov 2018 08:51:31 GMT
+- request:
+    method: get
+    uri: http://backend:5352/build/openSUSE:Factory:Staging:D/_result?code=unresolvable
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '56'
+    body:
+      encoding: UTF-8
+      string: '<resultlist state="00000000000000000000000000000000" />
+
+'
+    http_version: 
+  recorded_at: Sat, 03 Nov 2018 08:51:31 GMT
+- request:
+    method: get
+    uri: http://backend:5352/build/openSUSE:Factory:Staging:D/images/local?view=status
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 404
+      message: project 'openSUSE Factory Staging D' has no repository 'images'
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '204'
+    body:
+      encoding: UTF-8
+      string: |
+        <status code="404">
+          <summary>project 'openSUSE:Factory:Staging:D' has no repository 'images'</summary>
+          <details>404 project 'openSUSE:Factory:Staging:D' has no repository 'images'</details>
+        </status>
+    http_version: 
+  recorded_at: Sat, 03 Nov 2018 08:51:31 GMT
+recorded_with: VCR 4.0.0

--- a/src/api/spec/cassettes/Webui_ObsFactory_StagingProjectsController/GET_show/with_a_existent_factory_staging_project/with_checks/build_repo_has_pending_check/returns_testing.yml
+++ b/src/api/spec/cassettes/Webui_ObsFactory_StagingProjectsController/GET_show/with_a_existent_factory_staging_project/with_checks/build_repo_has_pending_check/returns_testing.yml
@@ -1,0 +1,551 @@
+---
+http_interactions:
+- request:
+    method: put
+    uri: http://backend:5352/source/openSUSE:Factory:Staging/_meta?user=_nobody_
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="openSUSE:Factory:Staging">
+          <title>Now Sleeps the Crimson Petal</title>
+          <description/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '129'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="openSUSE:Factory:Staging">
+          <title>Now Sleeps the Crimson Petal</title>
+          <description></description>
+        </project>
+    http_version: 
+  recorded_at: Sat, 03 Nov 2018 08:51:32 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/openSUSE:Factory/_meta?user=_nobody_
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="openSUSE:Factory">
+          <title>Postern of Fate</title>
+          <description/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '108'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="openSUSE:Factory">
+          <title>Postern of Fate</title>
+          <description></description>
+        </project>
+    http_version: 
+  recorded_at: Sat, 03 Nov 2018 08:51:32 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/openSUSE:Factory/target_package/_meta?user=_nobody_
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="target_package" project="openSUSE:Factory">
+          <title>The Waste Land</title>
+          <description>Nobis dolorem aut iure.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '155'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="target_package" project="openSUSE:Factory">
+          <title>The Waste Land</title>
+          <description>Nobis dolorem aut iure.</description>
+        </package>
+    http_version: 
+  recorded_at: Sat, 03 Nov 2018 08:51:32 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/openSUSE:Factory/target_package/_meta?user=_nobody_
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="target_package" project="openSUSE:Factory">
+          <title>The Waste Land</title>
+          <description>Nobis dolorem aut iure.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '155'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="target_package" project="openSUSE:Factory">
+          <title>The Waste Land</title>
+          <description>Nobis dolorem aut iure.</description>
+        </package>
+    http_version: 
+  recorded_at: Sat, 03 Nov 2018 08:51:32 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/project_18/_meta?user=_nobody_
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="project_18">
+          <title>The Far-Distant Oxus</title>
+          <description/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '107'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="project_18">
+          <title>The Far-Distant Oxus</title>
+          <description></description>
+        </project>
+    http_version: 
+  recorded_at: Sat, 03 Nov 2018 08:51:32 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/project_18/package_10/_meta?user=_nobody_
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="package_10" project="project_18">
+          <title>Ring of Bright Water</title>
+          <description>Cum officiis beatae quo.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '152'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="package_10" project="project_18">
+          <title>Ring of Bright Water</title>
+          <description>Cum officiis beatae quo.</description>
+        </package>
+    http_version: 
+  recorded_at: Sat, 03 Nov 2018 08:51:32 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/project_18/package_10/_meta?user=_nobody_
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="package_10" project="project_18">
+          <title>Ring of Bright Water</title>
+          <description>Cum officiis beatae quo.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '152'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="package_10" project="project_18">
+          <title>Ring of Bright Water</title>
+          <description>Cum officiis beatae quo.</description>
+        </package>
+    http_version: 
+  recorded_at: Sat, 03 Nov 2018 08:51:32 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:user_22/_meta?user=user_22
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:user_22">
+          <title/>
+          <description/>
+          <person userid="user_22" role="maintainer"/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '137'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:user_22">
+          <title></title>
+          <description></description>
+          <person userid="user_22" role="maintainer" />
+        </project>
+    http_version: 
+  recorded_at: Sat, 03 Nov 2018 08:51:32 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/openSUSE:Factory:Staging:A/_meta?user=_nobody_
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="openSUSE:Factory:Staging:A">
+          <title>Death Be Not Proud</title>
+          <description>      requests:
+                - { id: 1 }
+        </description>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '157'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="openSUSE:Factory:Staging:A">
+          <title>Death Be Not Proud</title>
+          <description>      requests:
+                - { id: 1 }
+        </description>
+        </project>
+    http_version: 
+  recorded_at: Sat, 03 Nov 2018 08:51:33 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/openSUSE:Factory:Staging:B/_meta?user=_nobody_
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="openSUSE:Factory:Staging:B">
+          <title>An Acceptable Time</title>
+          <description>Factory staging project B</description>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '146'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="openSUSE:Factory:Staging:B">
+          <title>An Acceptable Time</title>
+          <description>Factory staging project B</description>
+        </project>
+    http_version: 
+  recorded_at: Sat, 03 Nov 2018 08:51:33 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:user_23/_meta?user=user_23
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:user_23">
+          <title/>
+          <description/>
+          <person userid="user_23" role="maintainer"/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '137'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:user_23">
+          <title></title>
+          <description></description>
+          <person userid="user_23" role="maintainer" />
+        </project>
+    http_version: 
+  recorded_at: Sat, 03 Nov 2018 08:51:33 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/openSUSE:Factory:Staging:D/_meta?user=_nobody_
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="openSUSE:Factory:Staging:D">
+          <title>The Waste Land</title>
+          <description>                     requests:
+                               - { id: 2 }
+        </description>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '183'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="openSUSE:Factory:Staging:D">
+          <title>The Waste Land</title>
+          <description>                     requests:
+                               - { id: 2 }
+        </description>
+        </project>
+    http_version: 
+  recorded_at: Sat, 03 Nov 2018 08:51:33 GMT
+- request:
+    method: get
+    uri: http://backend:5352/build/openSUSE:Factory:Staging:D/_result?code=unresolvable
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '56'
+    body:
+      encoding: UTF-8
+      string: '<resultlist state="00000000000000000000000000000000" />
+
+'
+    http_version: 
+  recorded_at: Sat, 03 Nov 2018 08:51:33 GMT
+- request:
+    method: get
+    uri: http://backend:5352/build/openSUSE:Factory:Staging:D/images/local?view=status
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 404
+      message: project 'openSUSE Factory Staging D' has no repository 'images'
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '204'
+    body:
+      encoding: UTF-8
+      string: |
+        <status code="404">
+          <summary>project 'openSUSE:Factory:Staging:D' has no repository 'images'</summary>
+          <details>404 project 'openSUSE:Factory:Staging:D' has no repository 'images'</details>
+        </status>
+    http_version: 
+  recorded_at: Sat, 03 Nov 2018 08:51:33 GMT
+recorded_with: VCR 4.0.0

--- a/src/api/spec/cassettes/Webui_ObsFactory_StagingProjectsController/GET_show/with_a_existent_factory_staging_project/with_checks/build_repo_has_succeeded_check/returns_acceptable.yml
+++ b/src/api/spec/cassettes/Webui_ObsFactory_StagingProjectsController/GET_show/with_a_existent_factory_staging_project/with_checks/build_repo_has_succeeded_check/returns_acceptable.yml
@@ -1,0 +1,551 @@
+---
+http_interactions:
+- request:
+    method: put
+    uri: http://backend:5352/source/openSUSE:Factory:Staging/_meta?user=_nobody_
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="openSUSE:Factory:Staging">
+          <title>The Way Through the Woods</title>
+          <description/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '126'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="openSUSE:Factory:Staging">
+          <title>The Way Through the Woods</title>
+          <description></description>
+        </project>
+    http_version: 
+  recorded_at: Sat, 03 Nov 2018 08:51:17 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/openSUSE:Factory/_meta?user=_nobody_
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="openSUSE:Factory">
+          <title>Blithe Spirit</title>
+          <description/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '106'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="openSUSE:Factory">
+          <title>Blithe Spirit</title>
+          <description></description>
+        </project>
+    http_version: 
+  recorded_at: Sat, 03 Nov 2018 08:51:17 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/openSUSE:Factory/target_package/_meta?user=_nobody_
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="target_package" project="openSUSE:Factory">
+          <title>Blue Remembered Earth</title>
+          <description>Assumenda illo blanditiis odio.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '170'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="target_package" project="openSUSE:Factory">
+          <title>Blue Remembered Earth</title>
+          <description>Assumenda illo blanditiis odio.</description>
+        </package>
+    http_version: 
+  recorded_at: Sat, 03 Nov 2018 08:51:17 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/openSUSE:Factory/target_package/_meta?user=_nobody_
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="target_package" project="openSUSE:Factory">
+          <title>Blue Remembered Earth</title>
+          <description>Assumenda illo blanditiis odio.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '170'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="target_package" project="openSUSE:Factory">
+          <title>Blue Remembered Earth</title>
+          <description>Assumenda illo blanditiis odio.</description>
+        </package>
+    http_version: 
+  recorded_at: Sat, 03 Nov 2018 08:51:17 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/project_10/_meta?user=_nobody_
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="project_10">
+          <title>An Acceptable Time</title>
+          <description/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '105'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="project_10">
+          <title>An Acceptable Time</title>
+          <description></description>
+        </project>
+    http_version: 
+  recorded_at: Sat, 03 Nov 2018 08:51:17 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/project_10/package_2/_meta?user=_nobody_
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="package_2" project="project_10">
+          <title>The Soldier's Art</title>
+          <description>Corrupti alias facilis molestias.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '157'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="package_2" project="project_10">
+          <title>The Soldier's Art</title>
+          <description>Corrupti alias facilis molestias.</description>
+        </package>
+    http_version: 
+  recorded_at: Sat, 03 Nov 2018 08:51:17 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/project_10/package_2/_meta?user=_nobody_
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="package_2" project="project_10">
+          <title>The Soldier's Art</title>
+          <description>Corrupti alias facilis molestias.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '157'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="package_2" project="project_10">
+          <title>The Soldier's Art</title>
+          <description>Corrupti alias facilis molestias.</description>
+        </package>
+    http_version: 
+  recorded_at: Sat, 03 Nov 2018 08:51:17 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:user_6/_meta?user=user_6
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:user_6">
+          <title/>
+          <description/>
+          <person userid="user_6" role="maintainer"/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '135'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:user_6">
+          <title></title>
+          <description></description>
+          <person userid="user_6" role="maintainer" />
+        </project>
+    http_version: 
+  recorded_at: Sat, 03 Nov 2018 08:51:17 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/openSUSE:Factory:Staging:A/_meta?user=_nobody_
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="openSUSE:Factory:Staging:A">
+          <title>Oh! To be in England</title>
+          <description>      requests:
+                - { id: 1 }
+        </description>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '159'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="openSUSE:Factory:Staging:A">
+          <title>Oh! To be in England</title>
+          <description>      requests:
+                - { id: 1 }
+        </description>
+        </project>
+    http_version: 
+  recorded_at: Sat, 03 Nov 2018 08:51:17 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/openSUSE:Factory:Staging:B/_meta?user=_nobody_
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="openSUSE:Factory:Staging:B">
+          <title>I Will Fear No Evil</title>
+          <description>Factory staging project B</description>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '147'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="openSUSE:Factory:Staging:B">
+          <title>I Will Fear No Evil</title>
+          <description>Factory staging project B</description>
+        </project>
+    http_version: 
+  recorded_at: Sat, 03 Nov 2018 08:51:18 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:user_7/_meta?user=user_7
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:user_7">
+          <title/>
+          <description/>
+          <person userid="user_7" role="maintainer"/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '135'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:user_7">
+          <title></title>
+          <description></description>
+          <person userid="user_7" role="maintainer" />
+        </project>
+    http_version: 
+  recorded_at: Sat, 03 Nov 2018 08:51:18 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/openSUSE:Factory:Staging:D/_meta?user=_nobody_
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="openSUSE:Factory:Staging:D">
+          <title>Paths of Glory</title>
+          <description>                     requests:
+                               - { id: 2 }
+        </description>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '183'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="openSUSE:Factory:Staging:D">
+          <title>Paths of Glory</title>
+          <description>                     requests:
+                               - { id: 2 }
+        </description>
+        </project>
+    http_version: 
+  recorded_at: Sat, 03 Nov 2018 08:51:18 GMT
+- request:
+    method: get
+    uri: http://backend:5352/build/openSUSE:Factory:Staging:D/_result?code=unresolvable
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '56'
+    body:
+      encoding: UTF-8
+      string: '<resultlist state="00000000000000000000000000000000" />
+
+'
+    http_version: 
+  recorded_at: Sat, 03 Nov 2018 08:51:18 GMT
+- request:
+    method: get
+    uri: http://backend:5352/build/openSUSE:Factory:Staging:D/images/local?view=status
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 404
+      message: project 'openSUSE Factory Staging D' has no repository 'images'
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '204'
+    body:
+      encoding: UTF-8
+      string: |
+        <status code="404">
+          <summary>project 'openSUSE:Factory:Staging:D' has no repository 'images'</summary>
+          <details>404 project 'openSUSE:Factory:Staging:D' has no repository 'images'</details>
+        </status>
+    http_version: 
+  recorded_at: Sat, 03 Nov 2018 08:51:18 GMT
+recorded_with: VCR 4.0.0

--- a/src/api/spec/cassettes/Webui_ObsFactory_StagingProjectsController/GET_show/with_a_existent_factory_staging_project/with_checks/has_no_checks_at_all/returns_acceptable.yml
+++ b/src/api/spec/cassettes/Webui_ObsFactory_StagingProjectsController/GET_show/with_a_existent_factory_staging_project/with_checks/has_no_checks_at_all/returns_acceptable.yml
@@ -1,0 +1,551 @@
+---
+http_interactions:
+- request:
+    method: put
+    uri: http://backend:5352/source/openSUSE:Factory:Staging/_meta?user=_nobody_
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="openSUSE:Factory:Staging">
+          <title>Jacob Have I Loved</title>
+          <description/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '119'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="openSUSE:Factory:Staging">
+          <title>Jacob Have I Loved</title>
+          <description></description>
+        </project>
+    http_version: 
+  recorded_at: Sat, 03 Nov 2018 08:51:22 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/openSUSE:Factory/_meta?user=_nobody_
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="openSUSE:Factory">
+          <title>Cabbages and Kings</title>
+          <description/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '111'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="openSUSE:Factory">
+          <title>Cabbages and Kings</title>
+          <description></description>
+        </project>
+    http_version: 
+  recorded_at: Sat, 03 Nov 2018 08:51:22 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/openSUSE:Factory/target_package/_meta?user=_nobody_
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="target_package" project="openSUSE:Factory">
+          <title>I Know Why the Caged Bird Sings</title>
+          <description>Enim dolores eos sapiente.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '175'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="target_package" project="openSUSE:Factory">
+          <title>I Know Why the Caged Bird Sings</title>
+          <description>Enim dolores eos sapiente.</description>
+        </package>
+    http_version: 
+  recorded_at: Sat, 03 Nov 2018 08:51:22 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/openSUSE:Factory/target_package/_meta?user=_nobody_
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="target_package" project="openSUSE:Factory">
+          <title>I Know Why the Caged Bird Sings</title>
+          <description>Enim dolores eos sapiente.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '175'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="target_package" project="openSUSE:Factory">
+          <title>I Know Why the Caged Bird Sings</title>
+          <description>Enim dolores eos sapiente.</description>
+        </package>
+    http_version: 
+  recorded_at: Sat, 03 Nov 2018 08:51:22 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/project_13/_meta?user=_nobody_
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="project_13">
+          <title>Pale Kings and Princes</title>
+          <description/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '109'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="project_13">
+          <title>Pale Kings and Princes</title>
+          <description></description>
+        </project>
+    http_version: 
+  recorded_at: Sat, 03 Nov 2018 08:51:22 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/project_13/package_5/_meta?user=_nobody_
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="package_5" project="project_13">
+          <title>I Sing the Body Electric</title>
+          <description>Reprehenderit sed occaecati quasi.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '165'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="package_5" project="project_13">
+          <title>I Sing the Body Electric</title>
+          <description>Reprehenderit sed occaecati quasi.</description>
+        </package>
+    http_version: 
+  recorded_at: Sat, 03 Nov 2018 08:51:23 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/project_13/package_5/_meta?user=_nobody_
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="package_5" project="project_13">
+          <title>I Sing the Body Electric</title>
+          <description>Reprehenderit sed occaecati quasi.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '165'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="package_5" project="project_13">
+          <title>I Sing the Body Electric</title>
+          <description>Reprehenderit sed occaecati quasi.</description>
+        </package>
+    http_version: 
+  recorded_at: Sat, 03 Nov 2018 08:51:23 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:user_12/_meta?user=user_12
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:user_12">
+          <title/>
+          <description/>
+          <person userid="user_12" role="maintainer"/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '137'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:user_12">
+          <title></title>
+          <description></description>
+          <person userid="user_12" role="maintainer" />
+        </project>
+    http_version: 
+  recorded_at: Sat, 03 Nov 2018 08:51:23 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/openSUSE:Factory:Staging:A/_meta?user=_nobody_
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="openSUSE:Factory:Staging:A">
+          <title>Stranger in a Strange Land</title>
+          <description>      requests:
+                - { id: 1 }
+        </description>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '165'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="openSUSE:Factory:Staging:A">
+          <title>Stranger in a Strange Land</title>
+          <description>      requests:
+                - { id: 1 }
+        </description>
+        </project>
+    http_version: 
+  recorded_at: Sat, 03 Nov 2018 08:51:23 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/openSUSE:Factory:Staging:B/_meta?user=_nobody_
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="openSUSE:Factory:Staging:B">
+          <title>The Mermaids Singing</title>
+          <description>Factory staging project B</description>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '148'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="openSUSE:Factory:Staging:B">
+          <title>The Mermaids Singing</title>
+          <description>Factory staging project B</description>
+        </project>
+    http_version: 
+  recorded_at: Sat, 03 Nov 2018 08:51:23 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:user_13/_meta?user=user_13
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:user_13">
+          <title/>
+          <description/>
+          <person userid="user_13" role="maintainer"/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '137'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:user_13">
+          <title></title>
+          <description></description>
+          <person userid="user_13" role="maintainer" />
+        </project>
+    http_version: 
+  recorded_at: Sat, 03 Nov 2018 08:51:23 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/openSUSE:Factory:Staging:D/_meta?user=_nobody_
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="openSUSE:Factory:Staging:D">
+          <title>Time To Murder And Create</title>
+          <description>                     requests:
+                               - { id: 2 }
+        </description>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '194'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="openSUSE:Factory:Staging:D">
+          <title>Time To Murder And Create</title>
+          <description>                     requests:
+                               - { id: 2 }
+        </description>
+        </project>
+    http_version: 
+  recorded_at: Sat, 03 Nov 2018 08:51:24 GMT
+- request:
+    method: get
+    uri: http://backend:5352/build/openSUSE:Factory:Staging:D/_result?code=unresolvable
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '56'
+    body:
+      encoding: UTF-8
+      string: '<resultlist state="00000000000000000000000000000000" />
+
+'
+    http_version: 
+  recorded_at: Sat, 03 Nov 2018 08:51:24 GMT
+- request:
+    method: get
+    uri: http://backend:5352/build/openSUSE:Factory:Staging:D/images/local?view=status
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 404
+      message: project 'openSUSE Factory Staging D' has no repository 'images'
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '204'
+    body:
+      encoding: UTF-8
+      string: |
+        <status code="404">
+          <summary>project 'openSUSE:Factory:Staging:D' has no repository 'images'</summary>
+          <details>404 project 'openSUSE:Factory:Staging:D' has no repository 'images'</details>
+        </status>
+    http_version: 
+  recorded_at: Sat, 03 Nov 2018 08:51:24 GMT
+recorded_with: VCR 4.0.0

--- a/src/api/spec/cassettes/Webui_ObsFactory_StagingProjectsController/GET_show/with_a_existent_factory_staging_project/with_checks/published_repo_has_failed_check/returns_failed.yml
+++ b/src/api/spec/cassettes/Webui_ObsFactory_StagingProjectsController/GET_show/with_a_existent_factory_staging_project/with_checks/published_repo_has_failed_check/returns_failed.yml
@@ -1,0 +1,551 @@
+---
+http_interactions:
+- request:
+    method: put
+    uri: http://backend:5352/source/openSUSE:Factory:Staging/_meta?user=_nobody_
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="openSUSE:Factory:Staging">
+          <title>A Summer Bird-Cage</title>
+          <description/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '119'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="openSUSE:Factory:Staging">
+          <title>A Summer Bird-Cage</title>
+          <description></description>
+        </project>
+    http_version: 
+  recorded_at: Sat, 03 Nov 2018 08:51:26 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/openSUSE:Factory/_meta?user=_nobody_
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="openSUSE:Factory">
+          <title>Pale Kings and Princes</title>
+          <description/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '115'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="openSUSE:Factory">
+          <title>Pale Kings and Princes</title>
+          <description></description>
+        </project>
+    http_version: 
+  recorded_at: Sat, 03 Nov 2018 08:51:26 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/openSUSE:Factory/target_package/_meta?user=_nobody_
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="target_package" project="openSUSE:Factory">
+          <title>Cover Her Face</title>
+          <description>Reiciendis vero non rerum.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '158'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="target_package" project="openSUSE:Factory">
+          <title>Cover Her Face</title>
+          <description>Reiciendis vero non rerum.</description>
+        </package>
+    http_version: 
+  recorded_at: Sat, 03 Nov 2018 08:51:26 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/openSUSE:Factory/target_package/_meta?user=_nobody_
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="target_package" project="openSUSE:Factory">
+          <title>Cover Her Face</title>
+          <description>Reiciendis vero non rerum.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '158'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="target_package" project="openSUSE:Factory">
+          <title>Cover Her Face</title>
+          <description>Reiciendis vero non rerum.</description>
+        </package>
+    http_version: 
+  recorded_at: Sat, 03 Nov 2018 08:51:26 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/project_15/_meta?user=_nobody_
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="project_15">
+          <title>Tiger! Tiger!</title>
+          <description/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '100'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="project_15">
+          <title>Tiger! Tiger!</title>
+          <description></description>
+        </project>
+    http_version: 
+  recorded_at: Sat, 03 Nov 2018 08:51:26 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/project_15/package_7/_meta?user=_nobody_
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="package_7" project="project_15">
+          <title>Time of our Darkness</title>
+          <description>Possimus amet nam quisquam.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '154'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="package_7" project="project_15">
+          <title>Time of our Darkness</title>
+          <description>Possimus amet nam quisquam.</description>
+        </package>
+    http_version: 
+  recorded_at: Sat, 03 Nov 2018 08:51:26 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/project_15/package_7/_meta?user=_nobody_
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="package_7" project="project_15">
+          <title>Time of our Darkness</title>
+          <description>Possimus amet nam quisquam.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '154'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="package_7" project="project_15">
+          <title>Time of our Darkness</title>
+          <description>Possimus amet nam quisquam.</description>
+        </package>
+    http_version: 
+  recorded_at: Sat, 03 Nov 2018 08:51:26 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:user_16/_meta?user=user_16
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:user_16">
+          <title/>
+          <description/>
+          <person userid="user_16" role="maintainer"/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '137'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:user_16">
+          <title></title>
+          <description></description>
+          <person userid="user_16" role="maintainer" />
+        </project>
+    http_version: 
+  recorded_at: Sat, 03 Nov 2018 08:51:27 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/openSUSE:Factory:Staging:A/_meta?user=_nobody_
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="openSUSE:Factory:Staging:A">
+          <title>An Instant In The Wind</title>
+          <description>      requests:
+                - { id: 1 }
+        </description>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '161'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="openSUSE:Factory:Staging:A">
+          <title>An Instant In The Wind</title>
+          <description>      requests:
+                - { id: 1 }
+        </description>
+        </project>
+    http_version: 
+  recorded_at: Sat, 03 Nov 2018 08:51:27 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/openSUSE:Factory:Staging:B/_meta?user=_nobody_
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="openSUSE:Factory:Staging:B">
+          <title>To Sail Beyond the Sunset</title>
+          <description>Factory staging project B</description>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '153'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="openSUSE:Factory:Staging:B">
+          <title>To Sail Beyond the Sunset</title>
+          <description>Factory staging project B</description>
+        </project>
+    http_version: 
+  recorded_at: Sat, 03 Nov 2018 08:51:27 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:user_17/_meta?user=user_17
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:user_17">
+          <title/>
+          <description/>
+          <person userid="user_17" role="maintainer"/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '137'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:user_17">
+          <title></title>
+          <description></description>
+          <person userid="user_17" role="maintainer" />
+        </project>
+    http_version: 
+  recorded_at: Sat, 03 Nov 2018 08:51:27 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/openSUSE:Factory:Staging:D/_meta?user=_nobody_
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="openSUSE:Factory:Staging:D">
+          <title>Blithe Spirit</title>
+          <description>                     requests:
+                               - { id: 2 }
+        </description>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '182'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="openSUSE:Factory:Staging:D">
+          <title>Blithe Spirit</title>
+          <description>                     requests:
+                               - { id: 2 }
+        </description>
+        </project>
+    http_version: 
+  recorded_at: Sat, 03 Nov 2018 08:51:28 GMT
+- request:
+    method: get
+    uri: http://backend:5352/build/openSUSE:Factory:Staging:D/_result?code=unresolvable
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '56'
+    body:
+      encoding: UTF-8
+      string: '<resultlist state="00000000000000000000000000000000" />
+
+'
+    http_version: 
+  recorded_at: Sat, 03 Nov 2018 08:51:28 GMT
+- request:
+    method: get
+    uri: http://backend:5352/build/openSUSE:Factory:Staging:D/images/local?view=status
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 404
+      message: project 'openSUSE Factory Staging D' has no repository 'images'
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '204'
+    body:
+      encoding: UTF-8
+      string: |
+        <status code="404">
+          <summary>project 'openSUSE:Factory:Staging:D' has no repository 'images'</summary>
+          <details>404 project 'openSUSE:Factory:Staging:D' has no repository 'images'</details>
+        </status>
+    http_version: 
+  recorded_at: Sat, 03 Nov 2018 08:51:28 GMT
+recorded_with: VCR 4.0.0

--- a/src/api/spec/cassettes/Webui_ObsFactory_StagingProjectsController/GET_show/with_a_existent_factory_staging_project/with_checks/published_repo_has_failed_check_but_wrong_buildid/returns_acceptable_without_required_checks.yml
+++ b/src/api/spec/cassettes/Webui_ObsFactory_StagingProjectsController/GET_show/with_a_existent_factory_staging_project/with_checks/published_repo_has_failed_check_but_wrong_buildid/returns_acceptable_without_required_checks.yml
@@ -1,0 +1,516 @@
+---
+http_interactions:
+- request:
+    method: put
+    uri: http://backend:5352/source/openSUSE:Factory:Staging/_meta?user=_nobody_
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="openSUSE:Factory:Staging">
+          <title>Now Sleeps the Crimson Petal</title>
+          <description/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '129'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="openSUSE:Factory:Staging">
+          <title>Now Sleeps the Crimson Petal</title>
+          <description></description>
+        </project>
+    http_version: 
+  recorded_at: Sat, 03 Nov 2018 11:42:38 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/openSUSE:Factory/_meta?user=_nobody_
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="openSUSE:Factory">
+          <title>Of Human Bondage</title>
+          <description/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '109'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="openSUSE:Factory">
+          <title>Of Human Bondage</title>
+          <description></description>
+        </project>
+    http_version: 
+  recorded_at: Sat, 03 Nov 2018 11:42:38 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/openSUSE:Factory/target_package/_meta?user=_nobody_
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="target_package" project="openSUSE:Factory">
+          <title>A Catskill Eagle</title>
+          <description>Dolor sapiente consequatur dolor.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '167'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="target_package" project="openSUSE:Factory">
+          <title>A Catskill Eagle</title>
+          <description>Dolor sapiente consequatur dolor.</description>
+        </package>
+    http_version: 
+  recorded_at: Sat, 03 Nov 2018 11:42:38 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/openSUSE:Factory/target_package/_meta?user=_nobody_
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="target_package" project="openSUSE:Factory">
+          <title>A Catskill Eagle</title>
+          <description>Dolor sapiente consequatur dolor.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '167'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="target_package" project="openSUSE:Factory">
+          <title>A Catskill Eagle</title>
+          <description>Dolor sapiente consequatur dolor.</description>
+        </package>
+    http_version: 
+  recorded_at: Sat, 03 Nov 2018 11:42:38 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/project_8/_meta?user=_nobody_
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="project_8">
+          <title>The Wings of the Dove</title>
+          <description/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '107'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="project_8">
+          <title>The Wings of the Dove</title>
+          <description></description>
+        </project>
+    http_version: 
+  recorded_at: Sat, 03 Nov 2018 11:42:38 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/project_8/package_1/_meta?user=_nobody_
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="package_1" project="project_8">
+          <title>Consider the Lilies</title>
+          <description>Magnam voluptatibus dolorem tempore.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '161'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="package_1" project="project_8">
+          <title>Consider the Lilies</title>
+          <description>Magnam voluptatibus dolorem tempore.</description>
+        </package>
+    http_version: 
+  recorded_at: Sat, 03 Nov 2018 11:42:38 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/project_8/package_1/_meta?user=_nobody_
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="package_1" project="project_8">
+          <title>Consider the Lilies</title>
+          <description>Magnam voluptatibus dolorem tempore.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '161'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="package_1" project="project_8">
+          <title>Consider the Lilies</title>
+          <description>Magnam voluptatibus dolorem tempore.</description>
+        </package>
+    http_version: 
+  recorded_at: Sat, 03 Nov 2018 11:42:38 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:user_1/_meta?user=user_1
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:user_1">
+          <title/>
+          <description/>
+          <person userid="user_1" role="maintainer"/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '135'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:user_1">
+          <title></title>
+          <description></description>
+          <person userid="user_1" role="maintainer" />
+        </project>
+    http_version: 
+  recorded_at: Sat, 03 Nov 2018 11:42:39 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/openSUSE:Factory:Staging:A/_meta?user=_nobody_
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="openSUSE:Factory:Staging:A">
+          <title>Frequent Hearses</title>
+          <description>      requests:
+                - { id: 1 }
+        </description>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '155'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="openSUSE:Factory:Staging:A">
+          <title>Frequent Hearses</title>
+          <description>      requests:
+                - { id: 1 }
+        </description>
+        </project>
+    http_version: 
+  recorded_at: Sat, 03 Nov 2018 11:42:39 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/openSUSE:Factory:Staging:B/_meta?user=_nobody_
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="openSUSE:Factory:Staging:B">
+          <title>I Know Why the Caged Bird Sings</title>
+          <description>Factory staging project B</description>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '159'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="openSUSE:Factory:Staging:B">
+          <title>I Know Why the Caged Bird Sings</title>
+          <description>Factory staging project B</description>
+        </project>
+    http_version: 
+  recorded_at: Sat, 03 Nov 2018 11:42:39 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:user_2/_meta?user=user_2
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:user_2">
+          <title/>
+          <description/>
+          <person userid="user_2" role="maintainer"/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '135'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:user_2">
+          <title></title>
+          <description></description>
+          <person userid="user_2" role="maintainer" />
+        </project>
+    http_version: 
+  recorded_at: Sat, 03 Nov 2018 11:42:40 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/openSUSE:Factory:Staging:D/_meta?user=_nobody_
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="openSUSE:Factory:Staging:D">
+          <title>By Grand Central Station I Sat Down and Wept</title>
+          <description>                     requests:
+                               - { id: 2 }
+        </description>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '213'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="openSUSE:Factory:Staging:D">
+          <title>By Grand Central Station I Sat Down and Wept</title>
+          <description>                     requests:
+                               - { id: 2 }
+        </description>
+        </project>
+    http_version: 
+  recorded_at: Sat, 03 Nov 2018 11:42:40 GMT
+- request:
+    method: get
+    uri: http://backend:5352/build/openSUSE:Factory:Staging:D/_result?code=unresolvable
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '56'
+    body:
+      encoding: UTF-8
+      string: '<resultlist state="00000000000000000000000000000000" />
+
+'
+    http_version: 
+  recorded_at: Sat, 03 Nov 2018 11:42:40 GMT
+recorded_with: VCR 4.0.0

--- a/src/api/spec/cassettes/Webui_ObsFactory_StagingProjectsController/GET_show/with_a_existent_factory_staging_project/with_checks/published_repo_has_failed_check_but_wrong_buildid/returns_testing_with_required_checks.yml
+++ b/src/api/spec/cassettes/Webui_ObsFactory_StagingProjectsController/GET_show/with_a_existent_factory_staging_project/with_checks/published_repo_has_failed_check_but_wrong_buildid/returns_testing_with_required_checks.yml
@@ -1,0 +1,516 @@
+---
+http_interactions:
+- request:
+    method: put
+    uri: http://backend:5352/source/openSUSE:Factory:Staging/_meta?user=_nobody_
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="openSUSE:Factory:Staging">
+          <title>The Violent Bear It Away</title>
+          <description/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '125'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="openSUSE:Factory:Staging">
+          <title>The Violent Bear It Away</title>
+          <description></description>
+        </project>
+    http_version: 
+  recorded_at: Sat, 03 Nov 2018 11:42:40 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/openSUSE:Factory/_meta?user=_nobody_
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="openSUSE:Factory">
+          <title>An Acceptable Time</title>
+          <description/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '111'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="openSUSE:Factory">
+          <title>An Acceptable Time</title>
+          <description></description>
+        </project>
+    http_version: 
+  recorded_at: Sat, 03 Nov 2018 11:42:40 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/openSUSE:Factory/target_package/_meta?user=_nobody_
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="target_package" project="openSUSE:Factory">
+          <title>The Painted Veil</title>
+          <description>Vel nihil nihil quo.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '154'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="target_package" project="openSUSE:Factory">
+          <title>The Painted Veil</title>
+          <description>Vel nihil nihil quo.</description>
+        </package>
+    http_version: 
+  recorded_at: Sat, 03 Nov 2018 11:42:40 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/openSUSE:Factory/target_package/_meta?user=_nobody_
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="target_package" project="openSUSE:Factory">
+          <title>The Painted Veil</title>
+          <description>Vel nihil nihil quo.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '154'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="target_package" project="openSUSE:Factory">
+          <title>The Painted Veil</title>
+          <description>Vel nihil nihil quo.</description>
+        </package>
+    http_version: 
+  recorded_at: Sat, 03 Nov 2018 11:42:40 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/project_9/_meta?user=_nobody_
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="project_9">
+          <title>Surprised by Joy</title>
+          <description/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '102'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="project_9">
+          <title>Surprised by Joy</title>
+          <description></description>
+        </project>
+    http_version: 
+  recorded_at: Sat, 03 Nov 2018 11:42:41 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/project_9/package_2/_meta?user=_nobody_
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="package_2" project="project_9">
+          <title>Of Mice and Men</title>
+          <description>Sit quod quia consequuntur.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '148'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="package_2" project="project_9">
+          <title>Of Mice and Men</title>
+          <description>Sit quod quia consequuntur.</description>
+        </package>
+    http_version: 
+  recorded_at: Sat, 03 Nov 2018 11:42:41 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/project_9/package_2/_meta?user=_nobody_
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="package_2" project="project_9">
+          <title>Of Mice and Men</title>
+          <description>Sit quod quia consequuntur.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '148'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="package_2" project="project_9">
+          <title>Of Mice and Men</title>
+          <description>Sit quod quia consequuntur.</description>
+        </package>
+    http_version: 
+  recorded_at: Sat, 03 Nov 2018 11:42:41 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:user_3/_meta?user=user_3
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:user_3">
+          <title/>
+          <description/>
+          <person userid="user_3" role="maintainer"/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '135'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:user_3">
+          <title></title>
+          <description></description>
+          <person userid="user_3" role="maintainer" />
+        </project>
+    http_version: 
+  recorded_at: Sat, 03 Nov 2018 11:42:41 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/openSUSE:Factory:Staging:A/_meta?user=_nobody_
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="openSUSE:Factory:Staging:A">
+          <title>Rosemary Sutcliff</title>
+          <description>      requests:
+                - { id: 1 }
+        </description>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '156'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="openSUSE:Factory:Staging:A">
+          <title>Rosemary Sutcliff</title>
+          <description>      requests:
+                - { id: 1 }
+        </description>
+        </project>
+    http_version: 
+  recorded_at: Sat, 03 Nov 2018 11:42:41 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/openSUSE:Factory:Staging:B/_meta?user=_nobody_
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="openSUSE:Factory:Staging:B">
+          <title>The Far-Distant Oxus</title>
+          <description>Factory staging project B</description>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '148'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="openSUSE:Factory:Staging:B">
+          <title>The Far-Distant Oxus</title>
+          <description>Factory staging project B</description>
+        </project>
+    http_version: 
+  recorded_at: Sat, 03 Nov 2018 11:42:41 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:user_4/_meta?user=user_4
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:user_4">
+          <title/>
+          <description/>
+          <person userid="user_4" role="maintainer"/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '135'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:user_4">
+          <title></title>
+          <description></description>
+          <person userid="user_4" role="maintainer" />
+        </project>
+    http_version: 
+  recorded_at: Sat, 03 Nov 2018 11:42:41 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/openSUSE:Factory:Staging:D/_meta?user=_nobody_
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="openSUSE:Factory:Staging:D">
+          <title>An Instant In The Wind</title>
+          <description>                     requests:
+                               - { id: 2 }
+        </description>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '191'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="openSUSE:Factory:Staging:D">
+          <title>An Instant In The Wind</title>
+          <description>                     requests:
+                               - { id: 2 }
+        </description>
+        </project>
+    http_version: 
+  recorded_at: Sat, 03 Nov 2018 11:42:42 GMT
+- request:
+    method: get
+    uri: http://backend:5352/build/openSUSE:Factory:Staging:D/_result?code=unresolvable
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '56'
+    body:
+      encoding: UTF-8
+      string: '<resultlist state="00000000000000000000000000000000" />
+
+'
+    http_version: 
+  recorded_at: Sat, 03 Nov 2018 11:42:42 GMT
+recorded_with: VCR 4.0.0

--- a/src/api/spec/cassettes/Webui_ObsFactory_StagingProjectsController/GET_show/with_a_existent_factory_staging_project/with_checks/published_repo_has_pending_check/returns_testing.yml
+++ b/src/api/spec/cassettes/Webui_ObsFactory_StagingProjectsController/GET_show/with_a_existent_factory_staging_project/with_checks/published_repo_has_pending_check/returns_testing.yml
@@ -1,0 +1,551 @@
+---
+http_interactions:
+- request:
+    method: put
+    uri: http://backend:5352/source/openSUSE:Factory:Staging/_meta?user=_nobody_
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="openSUSE:Factory:Staging">
+          <title>The Wives of Bath</title>
+          <description/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '118'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="openSUSE:Factory:Staging">
+          <title>The Wives of Bath</title>
+          <description></description>
+        </project>
+    http_version: 
+  recorded_at: Sat, 03 Nov 2018 08:51:14 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/openSUSE:Factory/_meta?user=_nobody_
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="openSUSE:Factory">
+          <title>Dulce et Decorum Est</title>
+          <description/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '113'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="openSUSE:Factory">
+          <title>Dulce et Decorum Est</title>
+          <description></description>
+        </project>
+    http_version: 
+  recorded_at: Sat, 03 Nov 2018 08:51:14 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/openSUSE:Factory/target_package/_meta?user=_nobody_
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="target_package" project="openSUSE:Factory">
+          <title>When the Green Woods Laugh</title>
+          <description>Suscipit nostrum laboriosam nesciunt.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '181'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="target_package" project="openSUSE:Factory">
+          <title>When the Green Woods Laugh</title>
+          <description>Suscipit nostrum laboriosam nesciunt.</description>
+        </package>
+    http_version: 
+  recorded_at: Sat, 03 Nov 2018 08:51:14 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/openSUSE:Factory/target_package/_meta?user=_nobody_
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="target_package" project="openSUSE:Factory">
+          <title>When the Green Woods Laugh</title>
+          <description>Suscipit nostrum laboriosam nesciunt.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '181'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="target_package" project="openSUSE:Factory">
+          <title>When the Green Woods Laugh</title>
+          <description>Suscipit nostrum laboriosam nesciunt.</description>
+        </package>
+    http_version: 
+  recorded_at: Sat, 03 Nov 2018 08:51:14 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/project_9/_meta?user=_nobody_
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="project_9">
+          <title>Ring of Bright Water</title>
+          <description/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '106'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="project_9">
+          <title>Ring of Bright Water</title>
+          <description></description>
+        </project>
+    http_version: 
+  recorded_at: Sat, 03 Nov 2018 08:51:14 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/project_9/package_1/_meta?user=_nobody_
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="package_1" project="project_9">
+          <title>After Many a Summer Dies the Swan</title>
+          <description>Magni nesciunt corrupti ducimus.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '171'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="package_1" project="project_9">
+          <title>After Many a Summer Dies the Swan</title>
+          <description>Magni nesciunt corrupti ducimus.</description>
+        </package>
+    http_version: 
+  recorded_at: Sat, 03 Nov 2018 08:51:14 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/project_9/package_1/_meta?user=_nobody_
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="package_1" project="project_9">
+          <title>After Many a Summer Dies the Swan</title>
+          <description>Magni nesciunt corrupti ducimus.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '171'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="package_1" project="project_9">
+          <title>After Many a Summer Dies the Swan</title>
+          <description>Magni nesciunt corrupti ducimus.</description>
+        </package>
+    http_version: 
+  recorded_at: Sat, 03 Nov 2018 08:51:15 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:user_4/_meta?user=user_4
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:user_4">
+          <title/>
+          <description/>
+          <person userid="user_4" role="maintainer"/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '135'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:user_4">
+          <title></title>
+          <description></description>
+          <person userid="user_4" role="maintainer" />
+        </project>
+    http_version: 
+  recorded_at: Sat, 03 Nov 2018 08:51:15 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/openSUSE:Factory:Staging:A/_meta?user=_nobody_
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="openSUSE:Factory:Staging:A">
+          <title>The Sun Also Rises</title>
+          <description>      requests:
+                - { id: 1 }
+        </description>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '157'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="openSUSE:Factory:Staging:A">
+          <title>The Sun Also Rises</title>
+          <description>      requests:
+                - { id: 1 }
+        </description>
+        </project>
+    http_version: 
+  recorded_at: Sat, 03 Nov 2018 08:51:15 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/openSUSE:Factory:Staging:B/_meta?user=_nobody_
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="openSUSE:Factory:Staging:B">
+          <title>The Wives of Bath</title>
+          <description>Factory staging project B</description>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '145'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="openSUSE:Factory:Staging:B">
+          <title>The Wives of Bath</title>
+          <description>Factory staging project B</description>
+        </project>
+    http_version: 
+  recorded_at: Sat, 03 Nov 2018 08:51:16 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:user_5/_meta?user=user_5
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:user_5">
+          <title/>
+          <description/>
+          <person userid="user_5" role="maintainer"/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '135'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:user_5">
+          <title></title>
+          <description></description>
+          <person userid="user_5" role="maintainer" />
+        </project>
+    http_version: 
+  recorded_at: Sat, 03 Nov 2018 08:51:16 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/openSUSE:Factory:Staging:D/_meta?user=_nobody_
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="openSUSE:Factory:Staging:D">
+          <title>The Lathe of Heaven</title>
+          <description>                     requests:
+                               - { id: 2 }
+        </description>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '188'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="openSUSE:Factory:Staging:D">
+          <title>The Lathe of Heaven</title>
+          <description>                     requests:
+                               - { id: 2 }
+        </description>
+        </project>
+    http_version: 
+  recorded_at: Sat, 03 Nov 2018 08:51:16 GMT
+- request:
+    method: get
+    uri: http://backend:5352/build/openSUSE:Factory:Staging:D/_result?code=unresolvable
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '56'
+    body:
+      encoding: UTF-8
+      string: '<resultlist state="00000000000000000000000000000000" />
+
+'
+    http_version: 
+  recorded_at: Sat, 03 Nov 2018 08:51:16 GMT
+- request:
+    method: get
+    uri: http://backend:5352/build/openSUSE:Factory:Staging:D/images/local?view=status
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 404
+      message: project 'openSUSE Factory Staging D' has no repository 'images'
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '204'
+    body:
+      encoding: UTF-8
+      string: |
+        <status code="404">
+          <summary>project 'openSUSE:Factory:Staging:D' has no repository 'images'</summary>
+          <details>404 project 'openSUSE:Factory:Staging:D' has no repository 'images'</details>
+        </status>
+    http_version: 
+  recorded_at: Sat, 03 Nov 2018 08:51:16 GMT
+recorded_with: VCR 4.0.0

--- a/src/api/spec/cassettes/Webui_ObsFactory_StagingProjectsController/GET_show/with_a_existent_factory_staging_project/with_checks/published_repo_has_succeeded_check/returns_acceptable.yml
+++ b/src/api/spec/cassettes/Webui_ObsFactory_StagingProjectsController/GET_show/with_a_existent_factory_staging_project/with_checks/published_repo_has_succeeded_check/returns_acceptable.yml
@@ -1,0 +1,551 @@
+---
+http_interactions:
+- request:
+    method: put
+    uri: http://backend:5352/source/openSUSE:Factory:Staging/_meta?user=_nobody_
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="openSUSE:Factory:Staging">
+          <title>Unweaving the Rainbow</title>
+          <description/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '122'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="openSUSE:Factory:Staging">
+          <title>Unweaving the Rainbow</title>
+          <description></description>
+        </project>
+    http_version: 
+  recorded_at: Sat, 03 Nov 2018 08:51:18 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/openSUSE:Factory/_meta?user=_nobody_
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="openSUSE:Factory">
+          <title>The Road Less Traveled</title>
+          <description/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '115'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="openSUSE:Factory">
+          <title>The Road Less Traveled</title>
+          <description></description>
+        </project>
+    http_version: 
+  recorded_at: Sat, 03 Nov 2018 08:51:19 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/openSUSE:Factory/target_package/_meta?user=_nobody_
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="target_package" project="openSUSE:Factory">
+          <title>Dulce et Decorum Est</title>
+          <description>Natus ullam laudantium et.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '164'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="target_package" project="openSUSE:Factory">
+          <title>Dulce et Decorum Est</title>
+          <description>Natus ullam laudantium et.</description>
+        </package>
+    http_version: 
+  recorded_at: Sat, 03 Nov 2018 08:51:19 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/openSUSE:Factory/target_package/_meta?user=_nobody_
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="target_package" project="openSUSE:Factory">
+          <title>Dulce et Decorum Est</title>
+          <description>Natus ullam laudantium et.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '164'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="target_package" project="openSUSE:Factory">
+          <title>Dulce et Decorum Est</title>
+          <description>Natus ullam laudantium et.</description>
+        </package>
+    http_version: 
+  recorded_at: Sat, 03 Nov 2018 08:51:19 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/project_11/_meta?user=_nobody_
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="project_11">
+          <title>An Instant In The Wind</title>
+          <description/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '109'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="project_11">
+          <title>An Instant In The Wind</title>
+          <description></description>
+        </project>
+    http_version: 
+  recorded_at: Sat, 03 Nov 2018 08:51:19 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/project_11/package_3/_meta?user=_nobody_
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="package_3" project="project_11">
+          <title>For a Breath I Tarry</title>
+          <description>Et doloremque quisquam sed.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '154'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="package_3" project="project_11">
+          <title>For a Breath I Tarry</title>
+          <description>Et doloremque quisquam sed.</description>
+        </package>
+    http_version: 
+  recorded_at: Sat, 03 Nov 2018 08:51:19 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/project_11/package_3/_meta?user=_nobody_
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="package_3" project="project_11">
+          <title>For a Breath I Tarry</title>
+          <description>Et doloremque quisquam sed.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '154'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="package_3" project="project_11">
+          <title>For a Breath I Tarry</title>
+          <description>Et doloremque quisquam sed.</description>
+        </package>
+    http_version: 
+  recorded_at: Sat, 03 Nov 2018 08:51:19 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:user_8/_meta?user=user_8
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:user_8">
+          <title/>
+          <description/>
+          <person userid="user_8" role="maintainer"/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '135'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:user_8">
+          <title></title>
+          <description></description>
+          <person userid="user_8" role="maintainer" />
+        </project>
+    http_version: 
+  recorded_at: Sat, 03 Nov 2018 08:51:19 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/openSUSE:Factory:Staging:A/_meta?user=_nobody_
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="openSUSE:Factory:Staging:A">
+          <title>Behold the Man</title>
+          <description>      requests:
+                - { id: 1 }
+        </description>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '153'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="openSUSE:Factory:Staging:A">
+          <title>Behold the Man</title>
+          <description>      requests:
+                - { id: 1 }
+        </description>
+        </project>
+    http_version: 
+  recorded_at: Sat, 03 Nov 2018 08:51:19 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/openSUSE:Factory:Staging:B/_meta?user=_nobody_
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="openSUSE:Factory:Staging:B">
+          <title>Dulce et Decorum Est</title>
+          <description>Factory staging project B</description>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '148'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="openSUSE:Factory:Staging:B">
+          <title>Dulce et Decorum Est</title>
+          <description>Factory staging project B</description>
+        </project>
+    http_version: 
+  recorded_at: Sat, 03 Nov 2018 08:51:19 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:user_9/_meta?user=user_9
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:user_9">
+          <title/>
+          <description/>
+          <person userid="user_9" role="maintainer"/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '135'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:user_9">
+          <title></title>
+          <description></description>
+          <person userid="user_9" role="maintainer" />
+        </project>
+    http_version: 
+  recorded_at: Sat, 03 Nov 2018 08:51:20 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/openSUSE:Factory:Staging:D/_meta?user=_nobody_
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="openSUSE:Factory:Staging:D">
+          <title>Brandy of the Damned</title>
+          <description>                     requests:
+                               - { id: 2 }
+        </description>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '189'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="openSUSE:Factory:Staging:D">
+          <title>Brandy of the Damned</title>
+          <description>                     requests:
+                               - { id: 2 }
+        </description>
+        </project>
+    http_version: 
+  recorded_at: Sat, 03 Nov 2018 08:51:20 GMT
+- request:
+    method: get
+    uri: http://backend:5352/build/openSUSE:Factory:Staging:D/_result?code=unresolvable
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '56'
+    body:
+      encoding: UTF-8
+      string: '<resultlist state="00000000000000000000000000000000" />
+
+'
+    http_version: 
+  recorded_at: Sat, 03 Nov 2018 08:51:20 GMT
+- request:
+    method: get
+    uri: http://backend:5352/build/openSUSE:Factory:Staging:D/images/local?view=status
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 404
+      message: project 'openSUSE Factory Staging D' has no repository 'images'
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '204'
+    body:
+      encoding: UTF-8
+      string: |
+        <status code="404">
+          <summary>project 'openSUSE:Factory:Staging:D' has no repository 'images'</summary>
+          <details>404 project 'openSUSE:Factory:Staging:D' has no repository 'images'</details>
+        </status>
+    http_version: 
+  recorded_at: Sat, 03 Nov 2018 08:51:20 GMT
+recorded_with: VCR 4.0.0

--- a/src/api/spec/cassettes/Webui_ObsFactory_StagingProjectsController/GET_show/with_a_existent_factory_staging_project/with_checks/required_check_on_build_repo/returns_missing_check.yml
+++ b/src/api/spec/cassettes/Webui_ObsFactory_StagingProjectsController/GET_show/with_a_existent_factory_staging_project/with_checks/required_check_on_build_repo/returns_missing_check.yml
@@ -1,0 +1,551 @@
+---
+http_interactions:
+- request:
+    method: put
+    uri: http://backend:5352/source/openSUSE:Factory:Staging/_meta?user=_nobody_
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="openSUSE:Factory:Staging">
+          <title>Let Us Now Praise Famous Men</title>
+          <description/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '129'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="openSUSE:Factory:Staging">
+          <title>Let Us Now Praise Famous Men</title>
+          <description></description>
+        </project>
+    http_version: 
+  recorded_at: Sat, 03 Nov 2018 08:51:24 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/openSUSE:Factory/_meta?user=_nobody_
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="openSUSE:Factory">
+          <title>This Lime Tree Bower</title>
+          <description/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '113'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="openSUSE:Factory">
+          <title>This Lime Tree Bower</title>
+          <description></description>
+        </project>
+    http_version: 
+  recorded_at: Sat, 03 Nov 2018 08:51:24 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/openSUSE:Factory/target_package/_meta?user=_nobody_
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="target_package" project="openSUSE:Factory">
+          <title>Consider the Lilies</title>
+          <description>Dolores corporis perspiciatis voluptate.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '177'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="target_package" project="openSUSE:Factory">
+          <title>Consider the Lilies</title>
+          <description>Dolores corporis perspiciatis voluptate.</description>
+        </package>
+    http_version: 
+  recorded_at: Sat, 03 Nov 2018 08:51:24 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/openSUSE:Factory/target_package/_meta?user=_nobody_
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="target_package" project="openSUSE:Factory">
+          <title>Consider the Lilies</title>
+          <description>Dolores corporis perspiciatis voluptate.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '177'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="target_package" project="openSUSE:Factory">
+          <title>Consider the Lilies</title>
+          <description>Dolores corporis perspiciatis voluptate.</description>
+        </package>
+    http_version: 
+  recorded_at: Sat, 03 Nov 2018 08:51:24 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/project_14/_meta?user=_nobody_
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="project_14">
+          <title>Dance Dance Dance</title>
+          <description/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '104'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="project_14">
+          <title>Dance Dance Dance</title>
+          <description></description>
+        </project>
+    http_version: 
+  recorded_at: Sat, 03 Nov 2018 08:51:24 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/project_14/package_6/_meta?user=_nobody_
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="package_6" project="project_14">
+          <title>Sleep the Brave</title>
+          <description>Dolor dolores distinctio quis.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '152'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="package_6" project="project_14">
+          <title>Sleep the Brave</title>
+          <description>Dolor dolores distinctio quis.</description>
+        </package>
+    http_version: 
+  recorded_at: Sat, 03 Nov 2018 08:51:24 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/project_14/package_6/_meta?user=_nobody_
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="package_6" project="project_14">
+          <title>Sleep the Brave</title>
+          <description>Dolor dolores distinctio quis.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '152'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="package_6" project="project_14">
+          <title>Sleep the Brave</title>
+          <description>Dolor dolores distinctio quis.</description>
+        </package>
+    http_version: 
+  recorded_at: Sat, 03 Nov 2018 08:51:25 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:user_14/_meta?user=user_14
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:user_14">
+          <title/>
+          <description/>
+          <person userid="user_14" role="maintainer"/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '137'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:user_14">
+          <title></title>
+          <description></description>
+          <person userid="user_14" role="maintainer" />
+        </project>
+    http_version: 
+  recorded_at: Sat, 03 Nov 2018 08:51:25 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/openSUSE:Factory:Staging:A/_meta?user=_nobody_
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="openSUSE:Factory:Staging:A">
+          <title>What's Become of Waring</title>
+          <description>      requests:
+                - { id: 1 }
+        </description>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '162'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="openSUSE:Factory:Staging:A">
+          <title>What's Become of Waring</title>
+          <description>      requests:
+                - { id: 1 }
+        </description>
+        </project>
+    http_version: 
+  recorded_at: Sat, 03 Nov 2018 08:51:25 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/openSUSE:Factory:Staging:B/_meta?user=_nobody_
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="openSUSE:Factory:Staging:B">
+          <title>A Many-Splendoured Thing</title>
+          <description>Factory staging project B</description>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '152'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="openSUSE:Factory:Staging:B">
+          <title>A Many-Splendoured Thing</title>
+          <description>Factory staging project B</description>
+        </project>
+    http_version: 
+  recorded_at: Sat, 03 Nov 2018 08:51:25 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:user_15/_meta?user=user_15
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:user_15">
+          <title/>
+          <description/>
+          <person userid="user_15" role="maintainer"/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '137'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:user_15">
+          <title></title>
+          <description></description>
+          <person userid="user_15" role="maintainer" />
+        </project>
+    http_version: 
+  recorded_at: Sat, 03 Nov 2018 08:51:25 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/openSUSE:Factory:Staging:D/_meta?user=_nobody_
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="openSUSE:Factory:Staging:D">
+          <title>The Needle's Eye</title>
+          <description>                     requests:
+                               - { id: 2 }
+        </description>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '185'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="openSUSE:Factory:Staging:D">
+          <title>The Needle's Eye</title>
+          <description>                     requests:
+                               - { id: 2 }
+        </description>
+        </project>
+    http_version: 
+  recorded_at: Sat, 03 Nov 2018 08:51:26 GMT
+- request:
+    method: get
+    uri: http://backend:5352/build/openSUSE:Factory:Staging:D/_result?code=unresolvable
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '56'
+    body:
+      encoding: UTF-8
+      string: '<resultlist state="00000000000000000000000000000000" />
+
+'
+    http_version: 
+  recorded_at: Sat, 03 Nov 2018 08:51:26 GMT
+- request:
+    method: get
+    uri: http://backend:5352/build/openSUSE:Factory:Staging:D/images/local?view=status
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 404
+      message: project 'openSUSE Factory Staging D' has no repository 'images'
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '204'
+    body:
+      encoding: UTF-8
+      string: |
+        <status code="404">
+          <summary>project 'openSUSE:Factory:Staging:D' has no repository 'images'</summary>
+          <details>404 project 'openSUSE:Factory:Staging:D' has no repository 'images'</details>
+        </status>
+    http_version: 
+  recorded_at: Sat, 03 Nov 2018 08:51:26 GMT
+recorded_with: VCR 4.0.0

--- a/src/api/spec/cassettes/Webui_ObsFactory_StagingProjectsController/GET_show/with_a_existent_factory_staging_project/with_checks/required_check_on_published_repo/returns_missing_check.yml
+++ b/src/api/spec/cassettes/Webui_ObsFactory_StagingProjectsController/GET_show/with_a_existent_factory_staging_project/with_checks/required_check_on_published_repo/returns_missing_check.yml
@@ -1,0 +1,551 @@
+---
+http_interactions:
+- request:
+    method: put
+    uri: http://backend:5352/source/openSUSE:Factory:Staging/_meta?user=_nobody_
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="openSUSE:Factory:Staging">
+          <title>In Death Ground</title>
+          <description/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '116'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="openSUSE:Factory:Staging">
+          <title>In Death Ground</title>
+          <description></description>
+        </project>
+    http_version: 
+  recorded_at: Sat, 03 Nov 2018 08:51:20 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/openSUSE:Factory/_meta?user=_nobody_
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="openSUSE:Factory">
+          <title>Bury My Heart at Wounded Knee</title>
+          <description/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '122'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="openSUSE:Factory">
+          <title>Bury My Heart at Wounded Knee</title>
+          <description></description>
+        </project>
+    http_version: 
+  recorded_at: Sat, 03 Nov 2018 08:51:20 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/openSUSE:Factory/target_package/_meta?user=_nobody_
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="target_package" project="openSUSE:Factory">
+          <title>Rosemary Sutcliff</title>
+          <description>Quibusdam molestiae sint minus.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '166'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="target_package" project="openSUSE:Factory">
+          <title>Rosemary Sutcliff</title>
+          <description>Quibusdam molestiae sint minus.</description>
+        </package>
+    http_version: 
+  recorded_at: Sat, 03 Nov 2018 08:51:20 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/openSUSE:Factory/target_package/_meta?user=_nobody_
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="target_package" project="openSUSE:Factory">
+          <title>Rosemary Sutcliff</title>
+          <description>Quibusdam molestiae sint minus.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '166'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="target_package" project="openSUSE:Factory">
+          <title>Rosemary Sutcliff</title>
+          <description>Quibusdam molestiae sint minus.</description>
+        </package>
+    http_version: 
+  recorded_at: Sat, 03 Nov 2018 08:51:21 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/project_12/_meta?user=_nobody_
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="project_12">
+          <title>No Country for Old Men</title>
+          <description/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '109'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="project_12">
+          <title>No Country for Old Men</title>
+          <description></description>
+        </project>
+    http_version: 
+  recorded_at: Sat, 03 Nov 2018 08:51:21 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/project_12/package_4/_meta?user=_nobody_
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="package_4" project="project_12">
+          <title>The Curious Incident of the Dog in the Night-Time</title>
+          <description>Eum aliquam quo adipisci.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '181'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="package_4" project="project_12">
+          <title>The Curious Incident of the Dog in the Night-Time</title>
+          <description>Eum aliquam quo adipisci.</description>
+        </package>
+    http_version: 
+  recorded_at: Sat, 03 Nov 2018 08:51:21 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/project_12/package_4/_meta?user=_nobody_
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="package_4" project="project_12">
+          <title>The Curious Incident of the Dog in the Night-Time</title>
+          <description>Eum aliquam quo adipisci.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '181'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="package_4" project="project_12">
+          <title>The Curious Incident of the Dog in the Night-Time</title>
+          <description>Eum aliquam quo adipisci.</description>
+        </package>
+    http_version: 
+  recorded_at: Sat, 03 Nov 2018 08:51:21 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:user_10/_meta?user=user_10
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:user_10">
+          <title/>
+          <description/>
+          <person userid="user_10" role="maintainer"/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '137'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:user_10">
+          <title></title>
+          <description></description>
+          <person userid="user_10" role="maintainer" />
+        </project>
+    http_version: 
+  recorded_at: Sat, 03 Nov 2018 08:51:21 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/openSUSE:Factory:Staging:A/_meta?user=_nobody_
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="openSUSE:Factory:Staging:A">
+          <title>All the King's Men</title>
+          <description>      requests:
+                - { id: 1 }
+        </description>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '157'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="openSUSE:Factory:Staging:A">
+          <title>All the King's Men</title>
+          <description>      requests:
+                - { id: 1 }
+        </description>
+        </project>
+    http_version: 
+  recorded_at: Sat, 03 Nov 2018 08:51:21 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/openSUSE:Factory:Staging:B/_meta?user=_nobody_
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="openSUSE:Factory:Staging:B">
+          <title>The Painted Veil</title>
+          <description>Factory staging project B</description>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '144'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="openSUSE:Factory:Staging:B">
+          <title>The Painted Veil</title>
+          <description>Factory staging project B</description>
+        </project>
+    http_version: 
+  recorded_at: Sat, 03 Nov 2018 08:51:21 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:user_11/_meta?user=user_11
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:user_11">
+          <title/>
+          <description/>
+          <person userid="user_11" role="maintainer"/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '137'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:user_11">
+          <title></title>
+          <description></description>
+          <person userid="user_11" role="maintainer" />
+        </project>
+    http_version: 
+  recorded_at: Sat, 03 Nov 2018 08:51:22 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/openSUSE:Factory:Staging:D/_meta?user=_nobody_
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="openSUSE:Factory:Staging:D">
+          <title>Clouds of Witness</title>
+          <description>                     requests:
+                               - { id: 2 }
+        </description>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '186'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="openSUSE:Factory:Staging:D">
+          <title>Clouds of Witness</title>
+          <description>                     requests:
+                               - { id: 2 }
+        </description>
+        </project>
+    http_version: 
+  recorded_at: Sat, 03 Nov 2018 08:51:22 GMT
+- request:
+    method: get
+    uri: http://backend:5352/build/openSUSE:Factory:Staging:D/_result?code=unresolvable
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '56'
+    body:
+      encoding: UTF-8
+      string: '<resultlist state="00000000000000000000000000000000" />
+
+'
+    http_version: 
+  recorded_at: Sat, 03 Nov 2018 08:51:22 GMT
+- request:
+    method: get
+    uri: http://backend:5352/build/openSUSE:Factory:Staging:D/images/local?view=status
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 404
+      message: project 'openSUSE Factory Staging D' has no repository 'images'
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '204'
+    body:
+      encoding: UTF-8
+      string: |
+        <status code="404">
+          <summary>project 'openSUSE:Factory:Staging:D' has no repository 'images'</summary>
+          <details>404 project 'openSUSE:Factory:Staging:D' has no repository 'images'</details>
+        </status>
+    http_version: 
+  recorded_at: Sat, 03 Nov 2018 08:51:22 GMT
+recorded_with: VCR 4.0.0

--- a/src/api/spec/cassettes/Webui_ObsFactory_StagingProjectsController/GET_show/with_a_existent_factory_staging_project/with_checks/required_check_on_standard_repo/returns_missing_check.yml
+++ b/src/api/spec/cassettes/Webui_ObsFactory_StagingProjectsController/GET_show/with_a_existent_factory_staging_project/with_checks/required_check_on_standard_repo/returns_missing_check.yml
@@ -1,0 +1,480 @@
+---
+http_interactions:
+- request:
+    method: put
+    uri: http://backend:5352/source/openSUSE:Factory:Staging/_meta?user=_nobody_
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="openSUSE:Factory:Staging">
+          <title>Françoise Sagan</title>
+          <description/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '117'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        PHByb2plY3QgbmFtZT0ib3BlblNVU0U6RmFjdG9yeTpTdGFnaW5nIj4KICA8dGl0bGU+RnJhbsOnb2lzZSBTYWdhbjwvdGl0bGU+CiAgPGRlc2NyaXB0aW9uPjwvZGVzY3JpcHRpb24+CjwvcHJvamVjdD4K
+    http_version: 
+  recorded_at: Sat, 03 Nov 2018 08:51:28 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/openSUSE:Factory/_meta?user=_nobody_
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="openSUSE:Factory">
+          <title>Clouds of Witness</title>
+          <description/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '110'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="openSUSE:Factory">
+          <title>Clouds of Witness</title>
+          <description></description>
+        </project>
+    http_version: 
+  recorded_at: Sat, 03 Nov 2018 08:51:28 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/openSUSE:Factory/target_package/_meta?user=_nobody_
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="target_package" project="openSUSE:Factory">
+          <title>After Many a Summer Dies the Swan</title>
+          <description>Aut accusamus et reiciendis.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '179'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="target_package" project="openSUSE:Factory">
+          <title>After Many a Summer Dies the Swan</title>
+          <description>Aut accusamus et reiciendis.</description>
+        </package>
+    http_version: 
+  recorded_at: Sat, 03 Nov 2018 08:51:28 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/openSUSE:Factory/target_package/_meta?user=_nobody_
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="target_package" project="openSUSE:Factory">
+          <title>After Many a Summer Dies the Swan</title>
+          <description>Aut accusamus et reiciendis.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '179'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="target_package" project="openSUSE:Factory">
+          <title>After Many a Summer Dies the Swan</title>
+          <description>Aut accusamus et reiciendis.</description>
+        </package>
+    http_version: 
+  recorded_at: Sat, 03 Nov 2018 08:51:28 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/project_16/_meta?user=_nobody_
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="project_16">
+          <title>The Green Bay Tree</title>
+          <description/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '105'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="project_16">
+          <title>The Green Bay Tree</title>
+          <description></description>
+        </project>
+    http_version: 
+  recorded_at: Sat, 03 Nov 2018 08:51:28 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/project_16/package_8/_meta?user=_nobody_
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="package_8" project="project_16">
+          <title>As I Lay Dying</title>
+          <description>Maxime et qui aut.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '139'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="package_8" project="project_16">
+          <title>As I Lay Dying</title>
+          <description>Maxime et qui aut.</description>
+        </package>
+    http_version: 
+  recorded_at: Sat, 03 Nov 2018 08:51:28 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/project_16/package_8/_meta?user=_nobody_
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="package_8" project="project_16">
+          <title>As I Lay Dying</title>
+          <description>Maxime et qui aut.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '139'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="package_8" project="project_16">
+          <title>As I Lay Dying</title>
+          <description>Maxime et qui aut.</description>
+        </package>
+    http_version: 
+  recorded_at: Sat, 03 Nov 2018 08:51:28 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:user_18/_meta?user=user_18
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:user_18">
+          <title/>
+          <description/>
+          <person userid="user_18" role="maintainer"/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '137'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:user_18">
+          <title></title>
+          <description></description>
+          <person userid="user_18" role="maintainer" />
+        </project>
+    http_version: 
+  recorded_at: Sat, 03 Nov 2018 08:51:29 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/openSUSE:Factory:Staging:A/_meta?user=_nobody_
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="openSUSE:Factory:Staging:A">
+          <title>An Acceptable Time</title>
+          <description>      requests:
+                - { id: 1 }
+        </description>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '157'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="openSUSE:Factory:Staging:A">
+          <title>An Acceptable Time</title>
+          <description>      requests:
+                - { id: 1 }
+        </description>
+        </project>
+    http_version: 
+  recorded_at: Sat, 03 Nov 2018 08:51:29 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/openSUSE:Factory:Staging:B/_meta?user=_nobody_
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="openSUSE:Factory:Staging:B">
+          <title>Beneath the Bleeding</title>
+          <description>Factory staging project B</description>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '148'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="openSUSE:Factory:Staging:B">
+          <title>Beneath the Bleeding</title>
+          <description>Factory staging project B</description>
+        </project>
+    http_version: 
+  recorded_at: Sat, 03 Nov 2018 08:51:29 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:user_19/_meta?user=user_19
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:user_19">
+          <title/>
+          <description/>
+          <person userid="user_19" role="maintainer"/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '137'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:user_19">
+          <title></title>
+          <description></description>
+          <person userid="user_19" role="maintainer" />
+        </project>
+    http_version: 
+  recorded_at: Sat, 03 Nov 2018 08:51:29 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/openSUSE:Factory:Staging:D/_meta?user=_nobody_
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="openSUSE:Factory:Staging:D">
+          <title>Time To Murder And Create</title>
+          <description>                     requests:
+                               - { id: 2 }
+        </description>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '194'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="openSUSE:Factory:Staging:D">
+          <title>Time To Murder And Create</title>
+          <description>                     requests:
+                               - { id: 2 }
+        </description>
+        </project>
+    http_version: 
+  recorded_at: Sat, 03 Nov 2018 08:51:29 GMT
+recorded_with: VCR 4.0.0

--- a/src/api/spec/cassettes/Webui_ObsFactory_StagingProjectsController/GET_show/with_a_existent_factory_staging_project/with_required_checks_on_published_repo/returns_missing_check.yml
+++ b/src/api/spec/cassettes/Webui_ObsFactory_StagingProjectsController/GET_show/with_a_existent_factory_staging_project/with_required_checks_on_published_repo/returns_missing_check.yml
@@ -1,0 +1,549 @@
+---
+http_interactions:
+- request:
+    method: put
+    uri: http://backend:5352/source/openSUSE:Factory:Staging/_meta?user=_nobody_
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="openSUSE:Factory:Staging">
+          <title>The Last Enemy</title>
+          <description/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '115'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="openSUSE:Factory:Staging">
+          <title>The Last Enemy</title>
+          <description></description>
+        </project>
+    http_version: 
+  recorded_at: Fri, 02 Nov 2018 15:39:42 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/openSUSE:Factory/_meta?user=_nobody_
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="openSUSE:Factory">
+          <title>Of Mice and Men</title>
+          <description/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '108'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="openSUSE:Factory">
+          <title>Of Mice and Men</title>
+          <description></description>
+        </project>
+    http_version: 
+  recorded_at: Fri, 02 Nov 2018 15:39:42 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/openSUSE:Factory/target_package/_meta?user=_nobody_
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="target_package" project="openSUSE:Factory">
+          <title>Look to Windward</title>
+          <description>Dolorum atque consequatur vero.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '165'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="target_package" project="openSUSE:Factory">
+          <title>Look to Windward</title>
+          <description>Dolorum atque consequatur vero.</description>
+        </package>
+    http_version: 
+  recorded_at: Fri, 02 Nov 2018 15:39:42 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/openSUSE:Factory/target_package/_meta?user=_nobody_
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="target_package" project="openSUSE:Factory">
+          <title>Look to Windward</title>
+          <description>Dolorum atque consequatur vero.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '165'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="target_package" project="openSUSE:Factory">
+          <title>Look to Windward</title>
+          <description>Dolorum atque consequatur vero.</description>
+        </package>
+    http_version: 
+  recorded_at: Fri, 02 Nov 2018 15:39:42 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/project_1/_meta?user=_nobody_
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="project_1">
+          <title>An Evil Cradling</title>
+          <description/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '102'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="project_1">
+          <title>An Evil Cradling</title>
+          <description></description>
+        </project>
+    http_version: 
+  recorded_at: Fri, 02 Nov 2018 15:39:42 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/project_1/package_1/_meta?user=_nobody_
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="package_1" project="project_1">
+          <title>Stranger in a Strange Land</title>
+          <description>Voluptatibus ullam maiores tempore.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '167'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="package_1" project="project_1">
+          <title>Stranger in a Strange Land</title>
+          <description>Voluptatibus ullam maiores tempore.</description>
+        </package>
+    http_version: 
+  recorded_at: Fri, 02 Nov 2018 15:39:42 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/project_1/package_1/_meta?user=_nobody_
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="package_1" project="project_1">
+          <title>Stranger in a Strange Land</title>
+          <description>Voluptatibus ullam maiores tempore.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '167'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="package_1" project="project_1">
+          <title>Stranger in a Strange Land</title>
+          <description>Voluptatibus ullam maiores tempore.</description>
+        </package>
+    http_version: 
+  recorded_at: Fri, 02 Nov 2018 15:39:42 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:user_1/_meta?user=user_1
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:user_1">
+          <title/>
+          <description/>
+          <person userid="user_1" role="maintainer"/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '135'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:user_1">
+          <title></title>
+          <description></description>
+          <person userid="user_1" role="maintainer" />
+        </project>
+    http_version: 
+  recorded_at: Fri, 02 Nov 2018 15:39:43 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/openSUSE:Factory:Staging:A/_meta?user=_nobody_
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="openSUSE:Factory:Staging:A">
+          <title>Some Buried Caesar</title>
+          <description>      requests:
+                - { id: 1 }
+        </description>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '157'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="openSUSE:Factory:Staging:A">
+          <title>Some Buried Caesar</title>
+          <description>      requests:
+                - { id: 1 }
+        </description>
+        </project>
+    http_version: 
+  recorded_at: Fri, 02 Nov 2018 15:39:43 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/openSUSE:Factory:Staging:B/_meta?user=_nobody_
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="openSUSE:Factory:Staging:B">
+          <title>The Mirror Crack'd from Side to Side</title>
+          <description>Factory staging project B</description>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '164'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="openSUSE:Factory:Staging:B">
+          <title>The Mirror Crack'd from Side to Side</title>
+          <description>Factory staging project B</description>
+        </project>
+    http_version: 
+  recorded_at: Fri, 02 Nov 2018 15:39:43 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:user_2/_meta?user=user_2
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:user_2">
+          <title/>
+          <description/>
+          <person userid="user_2" role="maintainer"/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '135'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:user_2">
+          <title></title>
+          <description></description>
+          <person userid="user_2" role="maintainer" />
+        </project>
+    http_version: 
+  recorded_at: Fri, 02 Nov 2018 15:39:43 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/openSUSE:Factory:Staging:D/_meta?user=_nobody_
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="openSUSE:Factory:Staging:D">
+          <title>Some Buried Caesar</title>
+          <description>                     requests:
+                               - { id: 2 }
+        </description>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '187'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="openSUSE:Factory:Staging:D">
+          <title>Some Buried Caesar</title>
+          <description>                     requests:
+                               - { id: 2 }
+        </description>
+        </project>
+    http_version: 
+  recorded_at: Fri, 02 Nov 2018 15:39:44 GMT
+- request:
+    method: get
+    uri: http://backend:5352/build/openSUSE:Factory:Staging:D/_result?code=unresolvable
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '56'
+    body:
+      encoding: UTF-8
+      string: '<resultlist state="00000000000000000000000000000000" />
+
+'
+    http_version: 
+  recorded_at: Fri, 02 Nov 2018 15:39:44 GMT
+- request:
+    method: get
+    uri: http://backend:5352/published/openSUSE:Factory:Staging:D/repository_1?view=status
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Content-Length:
+      - '26'
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+    body:
+      encoding: UTF-8
+      string: '<status code="unknown" />
+
+'
+    http_version: 
+  recorded_at: Fri, 02 Nov 2018 15:39:44 GMT
+recorded_with: VCR 4.0.0

--- a/src/api/spec/controllers/status/checks_controller_spec.rb
+++ b/src/api/spec/controllers/status/checks_controller_spec.rb
@@ -106,7 +106,7 @@ RSpec.describe Status::ChecksController, type: :controller do
 
         it 'creates the proper event' do
           post :update, body: xml, params: params, format: :xml
-          expect(Event::StatusCheckForPublished.first.payload).to include('who' => user.login, 'project' => project.name, 'repository' => repository.name, 'state' => 'pending')
+          expect(Event::StatusCheckForPublished.first.payload).to include('who' => user.login, 'project' => project.name, 'repo' => repository.name, 'state' => 'pending')
         end
       end
 

--- a/src/api/spec/controllers/status/checks_controller_spec.rb
+++ b/src/api/spec/controllers/status/checks_controller_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe Status::ChecksController, type: :controller do
   let(:user) { create(:confirmed_user) }
   let(:project) { create(:project) }
   let(:repository) { create(:repository, project: project) }
+  let(:repository_architecture) { create(:repository_architecture, repository: repository) }
   let(:status_report) { create(:status_report, checkable: repository) }
 
   before do
@@ -172,6 +173,16 @@ RSpec.describe Status::ChecksController, type: :controller do
         let!(:check) { create(:check, name: 'openQA', state: 'pending', status_report: status_report) }
         let(:params) do
           { report_uuid: status_report.uuid, repository_name: repository.name, project_name: project.name }
+        end
+
+        include_context 'does update the check'
+      end
+
+      context 'for a repository architecture' do
+        let(:status_report) { create(:status_report, checkable: repository_architecture) }
+        let!(:check) { create(:check, name: 'openQA', state: 'pending', status_report: status_report) }
+        let(:params) do
+          { report_uuid: status_report.uuid, repository_name: repository.name, project_name: project.name, arch: repository_architecture.architecture.name }
         end
 
         include_context 'does update the check'

--- a/src/api/spec/controllers/status/checks_controller_spec.rb
+++ b/src/api/spec/controllers/status/checks_controller_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe Status::ChecksController, type: :controller do
 
       it 'gives 404 for invalid project' do
         expect(post(:update, body: xml, params: { project_name: project.name + '_', report_uuid: 'nada', repository_name: repository.name }, format: :xml)).to have_http_status(:not_found)
-        expect(Xmlhash.parse(response.body)['summary']).to match(/Project.*not found/)
+        expect(Xmlhash.parse(response.body)['summary']).to match(/Couldn't find Project/)
       end
 
       it 'gives 404 for invalid repository' do

--- a/src/api/spec/controllers/status/checks_controller_spec.rb
+++ b/src/api/spec/controllers/status/checks_controller_spec.rb
@@ -117,6 +117,12 @@ RSpec.describe Status::ChecksController, type: :controller do
         end
 
         include_context 'does create the check'
+
+        it 'creates the proper event' do
+          post :update, body: xml, params: params, format: :xml
+          expect(Event::StatusCheckForBuild.first.payload).to include('who' => user.login, 'project' => project.name, 'repo' => repository.name,
+                                                                      'arch' => repository_architecture.architecture.name, 'state' => 'pending')
+        end
       end
 
       context 'for a request' do

--- a/src/api/spec/controllers/webui/obs_factory/staging_projects_controller_spec.rb
+++ b/src/api/spec/controllers/webui/obs_factory/staging_projects_controller_spec.rb
@@ -167,6 +167,200 @@ RSpec.describe Webui::ObsFactory::StagingProjectsController, type: :controller, 
           )
         end
       end
+
+      context 'with checks' do
+        let(:one_request) do
+          create(:bs_request_with_submit_action,
+                 target_project: factory.name,
+                           source_project: source_package.project.name,
+                           source_package: source_package.name)
+        end
+        let(:meta) do
+          <<-DESCRIPTION
+                     requests:
+                       - { id: #{one_request.number} }
+          DESCRIPTION
+        end
+        let(:factory_staging_d) { create(:project, name: 'openSUSE:Factory:Staging:D', description: meta) }
+        let!(:images_repository) { create(:repository, project: factory_staging_d, name: 'images', architectures: ['local']) }
+        let(:images_local_arch) { images_repository.repository_architectures.first }
+        let(:published_report) { create(:status_report, checkable: images_repository) }
+        let(:build_report) { create(:status_report, checkable: images_local_arch) }
+
+        before do
+          path = "#{CONFIG['source_url']}/published/openSUSE:Factory:Staging:D/images?view=status"
+          d_status = "<status code='succeeded'><starttime>1541096739</starttime><endtime>1541096742</endtime><buildid>#{published_report.uuid}</buildid></status>"
+          stub_request(:get, path).and_return(body: d_status)
+
+          path = "#{CONFIG['source_url']}/build/openSUSE:Factory:Staging:D/images/local?view=status"
+          d_status = "<status code='succeeded'><starttime>1541096739</starttime><endtime>1541096742</endtime><buildid>#{build_report.uuid}</buildid></status>"
+          stub_request(:get, path).and_return(body: d_status)
+        end
+
+        context 'has no checks at all' do
+          it 'returns acceptable' do
+            get :show, params: { project: factory, project_name: 'D' }, format: :json
+            expect(response).to have_http_status(:success)
+
+            json_hash = JSON.parse(response.body)
+            expect(json_hash).to include(
+              'missing_checks' => [],
+              'checks' => [],
+              'overall_state' => 'acceptable'
+            )
+          end
+        end
+
+        context 'required check on published repo' do
+          before do
+            images_repository.required_checks = ['openqa']
+            images_repository.save
+          end
+
+          it 'returns missing check' do
+            get :show, params: { project: factory, project_name: 'D' }, format: :json
+            expect(response).to have_http_status(:success)
+
+            expect(JSON.parse(response.body)).to include(
+              'missing_checks' => ['openqa'],
+              'checks' => [],
+              'overall_state' => 'testing'
+            )
+          end
+        end
+
+        context 'required check on build repo' do
+          before do
+            images_local_arch.required_checks = ['openqa']
+            images_local_arch.save
+          end
+
+          it 'returns missing check' do
+            get :show, params: { project: factory, project_name: 'D' }, format: :json
+            expect(response).to have_http_status(:success)
+
+            expect(JSON.parse(response.body)).to include(
+              'missing_checks' => ['openqa'],
+              'checks' => [],
+              'overall_state' => 'testing'
+            )
+          end
+        end
+
+        context 'published repo has pending check' do
+          let!(:check) { create(:check, name: 'openqa', state: 'pending', status_report: published_report) }
+
+          it 'returns testing' do
+            get :show, params: { project: factory, project_name: 'D' }, format: :json
+            expect(response).to have_http_status(:success)
+
+            json_hash = JSON.parse(response.body)
+            expect(json_hash).to include(
+              'missing_checks' => [],
+              'checks' => [check.serializable_hash],
+              'overall_state' => 'testing'
+            )
+          end
+        end
+
+        context 'published repo has failed check' do
+          let!(:check) { create(:check, name: 'openqa', state: 'failure', status_report: published_report) }
+
+          it 'returns failed' do
+            get :show, params: { project: factory, project_name: 'D' }, format: :json
+            expect(response).to have_http_status(:success)
+
+            json_hash = JSON.parse(response.body)
+            expect(json_hash).to include(
+              'missing_checks' => [],
+              'checks' => [check.serializable_hash],
+              'overall_state' => 'failed'
+            )
+          end
+        end
+
+        context 'published repo has succeeded check' do
+          let!(:check) { create(:check, name: 'openqa', state: 'success', status_report: published_report) }
+
+          it 'returns acceptable' do
+            get :show, params: { project: factory, project_name: 'D' }, format: :json
+            expect(response).to have_http_status(:success)
+
+            json_hash = JSON.parse(response.body)
+            expect(json_hash).to include(
+              'missing_checks' => [],
+              'checks' => [check.serializable_hash],
+              'overall_state' => 'acceptable'
+            )
+          end
+        end
+
+        context 'required check on build repo' do
+          before do
+            images_local_arch.required_checks = ['openqa']
+            images_local_arch.save
+          end
+
+          it 'returns missing check' do
+            get :show, params: { project: factory, project_name: 'D' }, format: :json
+            expect(response).to have_http_status(:success)
+
+            expect(JSON.parse(response.body)).to include(
+              'missing_checks' => ['openqa'],
+              'checks' => [],
+              'overall_state' => 'testing'
+            )
+          end
+        end
+
+        context 'build repo has pending check' do
+          let!(:check) { create(:check, name: 'openqa', state: 'pending', status_report: build_report) }
+
+          it 'returns testing' do
+            get :show, params: { project: factory, project_name: 'D' }, format: :json
+            expect(response).to have_http_status(:success)
+
+            json_hash = JSON.parse(response.body)
+            expect(json_hash).to include(
+              'missing_checks' => [],
+              'checks' => [check.serializable_hash],
+              'overall_state' => 'testing'
+            )
+          end
+        end
+
+        context 'build repo has failed check' do
+          let!(:check) { create(:check, name: 'openqa', state: 'failure', status_report: build_report) }
+
+          it 'returns failed' do
+            get :show, params: { project: factory, project_name: 'D' }, format: :json
+            expect(response).to have_http_status(:success)
+
+            json_hash = JSON.parse(response.body)
+            expect(json_hash).to include(
+              'missing_checks' => [],
+              'checks' => [check.serializable_hash],
+              'overall_state' => 'failed'
+            )
+          end
+        end
+
+        context 'build repo has succeeded check' do
+          let!(:check) { create(:check, name: 'openqa', state: 'success', status_report: build_report) }
+
+          it 'returns acceptable' do
+            get :show, params: { project: factory, project_name: 'D' }, format: :json
+            expect(response).to have_http_status(:success)
+
+            json_hash = JSON.parse(response.body)
+            expect(json_hash).to include(
+              'missing_checks' => [],
+              'checks' => [check.serializable_hash],
+              'overall_state' => 'acceptable'
+            )
+          end
+        end
+      end
     end
 
     context 'with a non-existent factory_staging_project' do

--- a/src/api/spec/models/event/repo_build_finished_spec.rb
+++ b/src/api/spec/models/event/repo_build_finished_spec.rb
@@ -1,0 +1,34 @@
+require 'rails_helper'
+
+RSpec.describe Event::RepoBuildFinished do
+  describe 'UpdateNotificationEvents' do
+    let(:path) { "#{CONFIG['source_url']}/lastnotifications?block=1&start=1" }
+    let(:xml_response) do
+      <<-HEREDOC
+         <notifications next="2">
+           <notification type="REPO_BUILD_FINISHED" time="1539445101">
+            <data key="project">home:coolo</data>
+            <data key="repo">standard</data>
+            <data key="arch">x86_64</data>
+            <data key="buildid">67394b7f7d6e15920e8f2096047c0b4a</data>
+          </notification>
+         </notifications>
+      HEREDOC
+    end
+
+    before do
+      create(:admin_user, login: 'Admin')
+      stub_request(:get, path).and_return(body: xml_response)
+      UpdateNotificationEvents.new.perform
+    end
+
+    it 'fetches from backend' do
+      expect(Event::RepoBuildFinished.count).to be(1)
+    end
+
+    it 'gets the payload right' do
+      expect(Event::RepoBuildFinished.first.payload).to include('buildid' => '67394b7f7d6e15920e8f2096047c0b4a',
+                                                                'arch' => 'x86_64', 'project' => 'home:coolo', 'repo' => 'standard')
+    end
+  end
+end

--- a/src/api/spec/models/repository_architecture_spec.rb
+++ b/src/api/spec/models/repository_architecture_spec.rb
@@ -1,0 +1,25 @@
+require 'rails_helper'
+
+RSpec.describe RepositoryArchitecture do
+  describe '.build_id' do
+    let(:repository_architecture) { create(:repository_architecture) }
+    let(:repository) { repository_architecture.repository }
+    let(:project) { repository.project.name }
+    let(:architecture) { repository_architecture.architecture.name }
+
+    let(:good_response) { '<status code="finished"><buildid>1</buildid></status>' }
+    let(:busy_response) { '<status code="building"/>' }
+
+    subject { repository_architecture.build_id }
+
+    it 'fetches from backend' do
+      stub_request(:get, "#{CONFIG['source_url']}/build/#{project}/#{repository.name}/#{architecture}?view=status").and_return(body: good_response)
+      expect(subject).to eq('1')
+    end
+
+    it 'does not crash' do
+      stub_request(:get, "#{CONFIG['source_url']}/build/#{project}/#{repository.name}/#{architecture}?view=status").and_return(body: busy_response)
+      expect(subject).to be_nil
+    end
+  end
+end

--- a/src/backend/BSSched/Checker.pm
+++ b/src/backend/BSSched/Checker.pm
@@ -125,7 +125,7 @@ sub set_repo_state {
     $id = Digest::MD5::md5_hex($id);
     if (($oldstate->{'buildid'} || $oldstate->{'oldbuildid'} || '') ne $id) {
       my $myarch = $ctx->{'gctx'}->{'arch'};
-      #BSNotify::notify('REPO_BUILD_FINISHED', { project => $ctx->{'project'}, 'repo' => $ctx->{'repository'}, 'arch' => $myarch, 'buildid' => $id} );
+      BSNotify::notify('REPO_BUILD_FINISHED', { project => $ctx->{'project'}, 'repo' => $ctx->{'repository'}, 'arch' => $myarch, 'buildid' => $id} );
     }
     $newstate->{'buildid'} = $id;
     delete $newstate->{'oldbuildid'};


### PR DESCRIPTION
Allow status checks to be attached to /build/$PROJECT/$REPOSITORY/$ARCHITECTURE as well - even on unpublished, but per architecture