### PR TITLE
Suppress additional rpm output on package update

### DIFF
--- a/dist/obs-server.spec
+++ b/dist/obs-server.spec
@@ -481,7 +481,7 @@ touch /srv/www/obs/api/last_deploy || true
 
 # Upgrading from SysV obsapidelayed.service to systemd obs-api-support.target
 if [ "$1" -gt 1 ]; then
-  if systemctl --quiet is-enabled obsapidelayed.service; then
+  if systemctl --quiet is-enabled obsapidelayed.service 2> /dev/null; then
     systemctl enable obs-api-support.target
   fi
   if systemctl --quiet is-active obsapidelayed.service; then


### PR DESCRIPTION
We recently changed to use systemd instead of SysV for starting delayed
jobs services. Part of this was adding a script that ensures that the new systemd
service would be added when updating packages (710cd0fe48bb4a63212dee17a3fcb8b2bcdf6cbe).

This was working fine for the initial switch from SysV to systemd, but
once the SysV service is removed any following package update would
cause some additional stdout output due to the way we check if the
service still exists.

This commit adapts the rpm scriptlet to solve the issue.

Tested with current master and latest 2.9 release.

=====

  Additional rpm output:
    Failed to get unit file state for obsapidelayed.service: No such file or directory

