### PR TITLE
Replace usage of text-secondary and text-primary for coloring elements that present actions and information

### DIFF
--- a/src/api/app/helpers/webui/buildresult_helper.rb
+++ b/src/api/app/helpers/webui/buildresult_helper.rb
@@ -60,7 +60,7 @@ module Webui::BuildresultHelper
 
     capture_haml do
       if enable_help && status['code']
-        concat(content_tag(:i, nil, class: ['fa', 'fa-question-circle', 'text-secondary', 'mr-1'],
+        concat(content_tag(:i, nil, class: ['fa', 'fa-question-circle', 'text-info', 'mr-1'],
                            data: { content: Buildresult.status_description(status['code']), placement: 'top', toggle: 'popover' }))
       end
       if code.in?(['-', 'unresolvable', 'blocked', 'excluded', 'scheduled'])

--- a/src/api/app/helpers/webui/packages/job_history_helper.rb
+++ b/src/api/app/helpers/webui/packages/job_history_helper.rb
@@ -12,7 +12,7 @@ module Webui::Packages::JobHistoryHelper
   def html_class_for_state(state)
     case state
     when 'succeeded'
-      'text-primary'
+      'text-success'
     when 'failed'
       'text-danger'
     end

--- a/src/api/app/views/webui2/shared/_flag_popover.html.haml
+++ b/src/api/app/views/webui2/shared/_flag_popover.html.haml
@@ -9,7 +9,7 @@
     = link_to(create_repository_flag_path(project: project, package: package, flag: flag.flag,
               status: 'enable', repository: flag.repo, architecture: flag.arch), method: :post, remote: remote,
               class: 'popover_flag_action', data: { flag_id: flag.fullname }) do
-      %i.fas.fa-check.text-primary
+      %i.fas.fa-check.text-success
       Enable
 - else
   %div
@@ -19,10 +19,10 @@
         %i.fas.fa-ban.text-danger
         Disable
       - else
-        %i.fas.fa-check.text-primary
+        %i.fas.fa-check.text-success
         Enable
   .pt-2
     = link_to(remove_repository_flag_path(project: project, package: package, flag: flag),
               method: :delete, remote: remote, class: 'popover_flag_action', data: { flag_id: flag.fullname }) do
-      %i.fas{ class: flag.default_status == 'disable' ? 'fa-ban text-danger' : 'fa-check text-primary' }
+      %i.fas{ class: flag.default_status == 'disable' ? 'fa-ban text-danger' : 'fa-check text-success' }
       Take default (#{flag.default_status})

--- a/src/api/app/views/webui2/shared/_open_requests.html.haml
+++ b/src/api/app/views/webui2/shared/_open_requests.html.haml
@@ -2,5 +2,5 @@
   - path = package ? package_requests_path(project, package) : project_requests_path(project)
   - path = request_show_path(requests[0]) if requests.size == 1
   %li
-    %i.fas.fa-info-circle.text-secondary
+    %i.fas.fa-info-circle.text-info
     = link_to(pluralize(requests.size, 'open request'), path)

--- a/src/api/app/views/webui2/shared/_repositories_flag_table_column.html.haml
+++ b/src/api/app/views/webui2/shared/_repositories_flag_table_column.html.haml
@@ -6,7 +6,7 @@
     content = render(partial: 'shared/flag_popover',
                      locals: { flag: flag, project: project, package: package, remote: !flag.has_children })
   end
-  icon_class = flag.effective_status == 'disable' ? 'fa-ban text-danger' : 'fa-check text-primary'
+  icon_class = flag.effective_status == 'disable' ? 'fa-ban text-danger' : 'fa-check text-success'
   icon_class += ' ml-0_6' if is_flag_set_by_user
 
 %div{ id: flag.fullname }

--- a/src/api/app/views/webui2/status_messages/_item.html.haml
+++ b/src/api/app/views/webui2/status_messages/_item.html.haml
@@ -3,7 +3,7 @@
     .col-2.pl-2.text-center
       - case message.severity.to_i
         - when 1
-          %i.fa.fa-check-circle.fa-2x.text-primary.pt-3{ title: 'Success' }
+          %i.fa.fa-check-circle.fa-2x.text-success.pt-3{ title: 'Success' }
         - when 2
           %i.fa.fa-exclamation-triangle.fa-2x.text-warning.pt-3{ title: 'Warning' }
         - when 3

--- a/src/api/app/views/webui2/status_messages/_item.html.haml
+++ b/src/api/app/views/webui2/status_messages/_item.html.haml
@@ -9,7 +9,7 @@
         - when 3
           %i.fa.fa-exclamation-circle.fa-2x.text-danger.pt-3{ title: 'Alert' }
         - else
-          %i.fa.fa-info-circle.fa-2x.text-secondary.pt-3{ title: 'Info' }
+          %i.fa.fa-info-circle.fa-2x.text-info.pt-3{ title: 'Info' }
     .col-10.pl-0
       %small
         = user_with_realname_and_icon(message.user, short: true)

--- a/src/api/app/views/webui2/webui/attribute/_form.html.haml
+++ b/src/api/app/views/webui2/webui/attribute/_form.html.haml
@@ -18,7 +18,7 @@
     - if attribute.values_addable?
       %p
         = link_to_add_association(form, :values, render_options: { locals: value_fields_locals }, title: 'Add a value') do
-          %i.fas.fa-plus-circle.text-primary
+          %i.fas.fa-plus-circle.text-success
           Add a value
   - if issue_trackers
     #issues
@@ -26,7 +26,7 @@
         = render('issue_fields', { f: issue }.merge(issue_fields_locals))
     %p
       = link_to_add_association(form, :issues, render_options: { locals: issue_fields_locals }, title: 'Add an issue') do
-        %i.fas.fa-plus-circle.text-primary
+        %i.fas.fa-plus-circle.text-success
         Add an issue
 
   = form.submit('Save', class: 'btn btn-primary')

--- a/src/api/app/views/webui2/webui/main/_status_messages.html.haml
+++ b/src/api/app/views/webui2/webui/main/_status_messages.html.haml
@@ -11,6 +11,6 @@
     - if User.current.is_admin?
       .card-footer
         = link_to('#', 'data-toggle': 'modal', 'data-target': '#status-message-modal') do
-          %i.fas.fa-plus-circle.text-primary
+          %i.fas.fa-plus-circle.text-success
           Add new status message
       = render partial: 'add_status_message_modal'

--- a/src/api/app/views/webui2/webui/package/side_links/_show_derived_packages.html.haml
+++ b/src/api/app/views/webui2/webui/package/side_links/_show_derived_packages.html.haml
@@ -1,4 +1,4 @@
 %li
-  %i.fas.fa-info-circle.text-secondary
+  %i.fas.fa-info-circle.text-info
   = package.linking_packages.size
   = link_to('derived packages', linking_packages_path(project: project, package: package), remote: true)

--- a/src/api/app/views/webui2/webui/package/side_links/_show_devel_package.html.haml
+++ b/src/api/app/views/webui2/webui/package/side_links/_show_devel_package.html.haml
@@ -1,4 +1,4 @@
 %li
-  %i.fas.fa-info-circle.text-secondary
+  %i.fas.fa-info-circle.text-info
   Developed at
   = link_to(elide(devel_package.project.name, 44), package_show_path(project: devel_package.project.name, package: devel_package.name))

--- a/src/api/app/views/webui2/webui/package/side_links/_show_developed_packages.html.haml
+++ b/src/api/app/views/webui2/webui/package/side_links/_show_developed_packages.html.haml
@@ -1,5 +1,5 @@
 %li
-  %i.fas.fa-info-circle.text-secondary
+  %i.fas.fa-info-circle.text-info
   Devel package for
   - developed_packages.each_with_index do |pkg, index|
     = ',' if index > 0

--- a/src/api/app/views/webui2/webui/package/side_links/_show_inherited_from_project.html.haml
+++ b/src/api/app/views/webui2/webui/package/side_links/_show_inherited_from_project.html.haml
@@ -1,4 +1,4 @@
 %li
-  %i.fas.fa-info-circle.text-secondary
+  %i.fas.fa-info-circle.text-info
   Sources inherited from project
   = link_to(elide(project_name, 40), package_show_path(project: project_name, package: package_name))

--- a/src/api/app/views/webui2/webui/package/side_links/_show_linkinfo.html.haml
+++ b/src/api/app/views/webui2/webui/package/side_links/_show_linkinfo.html.haml
@@ -17,7 +17,7 @@
     %i= linkinfo[:error]
 - elsif linkinfo[:diff]
   %li
-    %i.fas.fa-info-circle.text-secondary
+    %i.fas.fa-info-circle.text-info
     Has a
     = link_to('link diff', package_rdiff_path(oproject: linked_package.project.name, opackage: linked_package.name,
                                               project: project, package: package, rev: revision))

--- a/src/api/app/views/webui2/webui/package/side_links/_show_patchinfo.html.haml
+++ b/src/api/app/views/webui2/webui/package/side_links/_show_patchinfo.html.haml
@@ -1,5 +1,5 @@
 %li
-  %i.fas.fa-info-circle.text-secondary
+  %i.fas.fa-info-circle.text-info
   Has a
   = link_to 'patchinfo', patchinfo_show_path(package: package, project: project)
   for


### PR DESCRIPTION
This PR replaces usage of
* text-primary by text-success for elements that signaling success, like build state, as well as for the enabled flags icon
* and text-secondary by text-info for elements that provide information

Fixes of the cases of #6091

Screenshot (so you can see the differences in the colors):
- Right side, status messages: `text-success` (green) and `text-info` (blue)
- Bottom, buttons: `text-primary` (green) and `text-secondary` (blue)
![diff-colors](https://user-images.githubusercontent.com/1102934/47906345-50a9ef00-de89-11e8-86ed-9f4d981e9330.png)
