### PR TITLE
Drop switch to bootstrap2 on request show page

### DIFF
--- a/src/api/app/controllers/webui/projects/bs_requests_controller.rb
+++ b/src/api/app/controllers/webui/projects/bs_requests_controller.rb
@@ -12,13 +12,8 @@ module Webui
         session[:request_numbers] = requests_query.requests.map(&:number)
 
         respond_to do |format|
-          if switch_to_webui2?
-            format.json { render 'webui2/shared/bs_requests/index' }
-          else
-            format.json
-          end
+          format.json
         end
-        switch_to_webui2
       end
     end
   end


### PR DESCRIPTION
as the project request page is not yet migrated this code is not needed and
is causing to not properly show the icons.

Fix #6129.

This needs clarification with @bgeuken & @DavidKang. @bgeuken you seem to have introduced https://github.com/openSUSE/open-build-service/pull/5760 and I'm wondering what issue this PR fixed. The project request page is not yet migrated so this code should not be necessary. I'm wondering if this accidentally slipped in while migration the package show view?

