### PR TITLE
Remove duplicated has_many staging_projects

### DIFF
--- a/src/api/app/models/staging_workflow.rb
+++ b/src/api/app/models/staging_workflow.rb
@@ -1,11 +1,10 @@
 class StagingWorkflow < ApplicationRecord
   belongs_to :project, inverse_of: :staging
-  has_many :staging_projects, class_name: 'Project', inverse_of: :staging_workflow, dependent: :nullify do
+  has_many :staging_projects, class_name: 'Project', inverse_of: :staging_workflow, dependent: :nullify, autosave: true do
     def without_staged_requests
       includes(:staged_requests).where(bs_requests: { id: nil })
     end
   end
-  has_many :staging_projects, class_name: 'Project', inverse_of: :staging_workflow, dependent: :nullify, autosave: true
   has_many :target_of_bs_requests, through: :project
   has_many :staged_requests, class_name: 'BsRequest', through: :staging_projects
 


### PR DESCRIPTION
The later staging_projects association was overwriting the correct one.
We also added `autosave: true` missing attribute in the first
association.

Co-authored-by: Eduardo Navarro <enavarro@suse.com>

