### PR TITLE
Avoid a cassette trick in worker status

### DIFF
--- a/src/api/spec/controllers/worker/status_controller_spec.rb
+++ b/src/api/spec/controllers/worker/status_controller_spec.rb
@@ -10,9 +10,17 @@ RSpec.describe Worker::StatusController, vcr: true do
   end
 
   describe 'GET /index' do
+    let(:response) { file_fixture('worker_status_response.xml') }
+
+    before do
+      stub_request(:get, CONFIG['source_url'] + '/build/_workerstatus').and_return(body: response)
+    end
+
     subject! { get :index, params: { format: :xml } }
 
     it { is_expected.to have_http_status(:success) }
-    it { assert_select 'workerstatus[clients=2]' }
+    it 'finds 2 workers' do
+      assert_select 'workerstatus[clients=2]'
+    end
   end
 end

--- a/src/api/spec/fixtures/files/worker_status_response.xml
+++ b/src/api/spec/fixtures/files/worker_status_response.xml
@@ -1,0 +1,27 @@
+<workerstatus clients="2">
+  <idle workerid="7de14aea3d12:1" hostarch="x86_64" />
+  <idle workerid="7de14aea3d12:2" hostarch="x86_64" />
+  <waiting arch="i586" jobs="0" />
+  <waiting arch="x86_64" jobs="0" />
+  <blocked arch="i586" jobs="0" />
+  <blocked arch="x86_64" jobs="0" />
+  <buildavg arch="i586" buildavg="1200" />
+  <buildavg arch="x86_64" buildavg="1200" />
+  <partition>
+    <daemon type="srcserver" state="running" starttime="1535957126" />
+    <daemon type="servicedispatch" state="running" starttime="1535957132" />
+    <daemon type="service" state="running" starttime="1535957132" />
+    <daemon type="clouduploadserver" state="running" starttime="1535957132" />
+    <daemon type="clouduploadworker" state="running" starttime="1535957132" />
+    <daemon type="scheduler" arch="i586" state="running" starttime="1535957132">
+      <queue high="0" med="0" low="2" next="0" />
+    </daemon>
+    <daemon type="scheduler" arch="x86_64" state="running" starttime="1535957132">
+      <queue high="0" med="0" low="2" next="0" />
+    </daemon>
+    <daemon type="repserver" state="running" starttime="1535957130" />
+    <daemon type="dispatcher" state="running" starttime="1535957132" />
+    <daemon type="publisher" state="running" starttime="1535957132" />
+    <daemon type="signer" state="running" starttime="1535957132" />
+  </partition>
+</workerstatus>


### PR DESCRIPTION
Missed that one while reviewing https://github.com/openSUSE/open-build-service/pull/5779
