### PR TITLE
Enable Layout/AlignHash rubocop

### DIFF
--- a/src/api/.haml-lint.yml
+++ b/src/api/.haml-lint.yml
@@ -9,6 +9,30 @@ linters:
     matchers:
       not_breadcrumb_items: \A_(?!breadcrumb_items).*\.haml\z
 
+  RuboCop:
+    enabled: true
+    # These cops are incredibly noisy when it comes to HAML templates, so we
+    # ignore them.
+    ignored_cops:
+      - Lint/BlockAlignment
+      - Lint/EndAlignment
+      - Lint/Void
+      - Layout/AlignParameters
+      - Layout/ElseAlignment
+      - Layout/EndOfLine
+      - Layout/IndentationWidth
+      - Layout/TrailingBlankLines
+      - Layout/TrailingWhitespace
+      - Layout/AlignHash
+      - Metrics/BlockLength
+      - Metrics/BlockNesting
+      - Metrics/LineLength
+      - Naming/FileName
+      - Style/FrozenStringLiteralComment
+      - Style/IfUnlessModifier
+      - Style/Next
+      - Style/WhileUntilModifier
+
 exclude:
 - 'vendor/bundle/**/*'
 # Everything below is the old interface. We only lint the new Bootstrap interface

--- a/src/api/.rubocop_todo.yml
+++ b/src/api/.rubocop_todo.yml
@@ -19,15 +19,6 @@ Capybara/CurrentPathExpectation:
 Capybara/FeatureMethods:
   Enabled: false
 
-# Offense count: 257
-# Cop supports --auto-correct.
-# Configuration parameters: EnforcedHashRocketStyle, EnforcedColonStyle, EnforcedLastArgumentHashStyle.
-# SupportedHashRocketStyles: key, separator, table
-# SupportedColonStyles: key, separator, table
-# SupportedLastArgumentHashStyles: always_inspect, always_ignore, ignore_implicit, ignore_explicit
-Layout/AlignHash:
-  Enabled: false
-
 # Offense count: 3
 # Cop supports --auto-correct.
 Layout/ClosingHeredocIndentation:

--- a/src/api/app/controllers/application_controller.rb
+++ b/src/api/app/controllers/application_controller.rb
@@ -192,7 +192,7 @@ class ApplicationController < ActionController::Base
 
     text = response.body
     send_data(text, type: response.fetch('content-type'),
-      disposition: 'inline')
+                    disposition: 'inline')
     text
   end
   public :pass_to_backend

--- a/src/api/app/controllers/attribute_namespace_controller.rb
+++ b/src/api/app/controllers/attribute_namespace_controller.rb
@@ -32,7 +32,7 @@ class AttributeNamespaceController < ApplicationController
       render template: 'attribute_namespace/show'
     else
       render_error message: "Unknown attribute namespace '#{@namespace}'",
-        status: 404, errorcode: 'unknown_attribute_namespace'
+                   status: 404, errorcode: 'unknown_attribute_namespace'
     end
   end
 
@@ -47,7 +47,7 @@ class AttributeNamespaceController < ApplicationController
 
     unless xml_element['name'] == @namespace
       render_error status: 400, errorcode: 'illegal_request',
-        message: "Illegal request: PUT/POST #{request.path}: path does not match content"
+                   message: "Illegal request: PUT/POST #{request.path}: path does not match content"
       return
     end
 

--- a/src/api/app/controllers/build/file_controller.rb
+++ b/src/api/app/controllers/build/file_controller.rb
@@ -20,7 +20,7 @@ module Build
         unless User.current.is_admin?
           # this route can be used publish binaries without history changes in sources
           render_error status: 403, errorcode: 'upload_binary_no_permission',
-            message: 'No permission to upload binaries.'
+                       message: 'No permission to upload binaries.'
           return
         end
 
@@ -32,7 +32,7 @@ module Build
     def destroy
       unless permissions.project_change?(params[:project])
         render_error status: 403, errorcode: 'delete_binary_no_permission',
-          message: "No permission to delete binaries from project #{params[:project]}"
+                     message: "No permission to delete binaries from project #{params[:project]}"
         return
       end
 
@@ -40,7 +40,7 @@ module Build
         pass_to_backend
       else
         render_error status: 400, errorcode: 'invalid_operation',
-          message: 'Delete operation of build results is not allowed'
+                     message: 'Delete operation of build results is not allowed'
       end
 
       return
@@ -75,7 +75,7 @@ module Build
       return if user_has_permission
 
       render_error status: 403, errorcode: 'download_binary_no_permission',
-        message: "No permission to download binaries from package #{params[:package]}, project #{params[:project]}"
+                   message: "No permission to download binaries from package #{params[:package]}, project #{params[:project]}"
       return
     end
 

--- a/src/api/app/controllers/build_controller.rb
+++ b/src/api/app/controllers/build_controller.rb
@@ -18,7 +18,7 @@ class BuildController < ApplicationController
       pass_to_backend
     else
       render_error status: 403, errorcode: 'execute_cmd_no_permission',
-        message: 'Upload of binaries is only permitted for administrators'
+                   message: 'Upload of binaries is only permitted for administrators'
     end
   end
 
@@ -44,13 +44,13 @@ class BuildController < ApplicationController
 
       unless ['wipe', 'restartbuild', 'killbuild', 'abortbuild', 'rebuild', 'unpublish', 'sendsysrq'].include?(params[:cmd])
         render_error status: 400, errorcode: 'illegal_request',
-          message: "unsupported POST command #{params[:cmd]} to #{request.url}"
+                     message: "unsupported POST command #{params[:cmd]} to #{request.url}"
         return
       end
 
       unless prj.class == Project
         render_error status: 403, errorcode: 'readonly_error',
-          message: "The project #{params[:project]} is a remote project and therefore readonly."
+                     message: "The project #{params[:project]} is a remote project and therefore readonly."
         return
       end
 
@@ -61,14 +61,14 @@ class BuildController < ApplicationController
             allowed = permissions.project_change?(prj)
             unless allowed
               render_error status: 403, errorcode: 'execute_cmd_no_permission',
-                message: "No permission to execute command on package #{pack_name} in project #{prj.name}"
+                           message: "No permission to execute command on package #{pack_name} in project #{prj.name}"
               return
             end
           else
             allowed = permissions.package_change?(pkg)
             unless allowed
               render_error status: 403, errorcode: 'execute_cmd_no_permission',
-                message: "No permission to execute command on package #{pack_name}"
+                           message: "No permission to execute command on package #{pack_name}"
               return
             end
           end
@@ -77,7 +77,7 @@ class BuildController < ApplicationController
 
       unless allowed
         render_error status: 403, errorcode: 'execute_cmd_no_permission',
-          message: "No permission to execute command on project #{params[:project]}"
+                     message: "No permission to execute command on project #{params[:project]}"
         return
       end
 
@@ -88,12 +88,12 @@ class BuildController < ApplicationController
         pass_to_backend
       else
         render_error status: 403, errorcode: 'execute_cmd_no_permission',
-          message: "No permission to execute command on project #{params[:project]}"
+                     message: "No permission to execute command on project #{params[:project]}"
       end
       return
     else
       render_error status: 400, errorcode: 'illegal_request',
-        message: "Illegal request: #{request.method.to_s.upcase} #{request.path}"
+                   message: "Illegal request: #{request.method.to_s.upcase} #{request.path}"
       return
     end
   end

--- a/src/api/app/controllers/person_controller.rb
+++ b/src/api/app/controllers/person_controller.rb
@@ -101,7 +101,7 @@ class PersonController < ApplicationController
       unless user.login == User.current.login || User.current.is_admin?
         logger.debug 'User has no permission to change userinfo'
         render_error(status: 403, errorcode: 'change_userinfo_no_permission',
-          message: "no permission to change userinfo for user #{user.login}") && return
+                     message: "no permission to change userinfo for user #{user.login}") && return
       end
     elsif User.current.is_admin?
       user = User.create(login: login, password: 'notset', email: 'TEMP')
@@ -128,7 +128,7 @@ class PersonController < ApplicationController
         user.owner = User.find_by_login!(xml['owner']['userid'])
         if user.owner.owner
           render_error(status: 400, errorcode: 'subaccount_chaining',
-            message: "A subaccount can not be assigned to subaccount #{user.owner.login}") && return
+                       message: "A subaccount can not be assigned to subaccount #{user.owner.login}") && return
         end
       end
     end
@@ -249,14 +249,14 @@ class PersonController < ApplicationController
 
     if login.blank? || password.blank?
       render_error status: 404, errorcode: 'failed to change password',
-            message: 'Failed to change password: missing parameter'
+                   message: 'Failed to change password: missing parameter'
       return
     end
 
     # change password to LDAP if LDAP is enabled
     unless ::Configuration.passwords_changable?(User.current)
       render_error status: 404, errorcode: 'change_passwd_failure',
-                                message: 'LDAP passwords can not be changed in OBS. Please refer to your LDAP server to change it.'
+                   message: 'LDAP passwords can not be changed in OBS. Please refer to your LDAP server to change it.'
       return
     end
 

--- a/src/api/app/controllers/search_controller.rb
+++ b/src/api/app/controllers/search_controller.rb
@@ -102,7 +102,7 @@ class SearchController < ApplicationController
 
     if owners.nil?
       render_error status: 400, errorcode: 'no_binary',
-                    message: "The search needs at least a 'binary' or 'user' parameter"
+                   message: "The search needs at least a 'binary' or 'user' parameter"
       return
     end
 

--- a/src/api/app/controllers/source_controller.rb
+++ b/src/api/app/controllers/source_controller.rb
@@ -551,7 +551,7 @@ class SourceController < ApplicationController
 
     if @project.is_a?(String) # remote project
       render_error status: 404, errorcode: 'remote_project',
-        message: 'The release from remote projects is currently not supported'
+                   message: 'The release from remote projects is currently not supported'
       return
     end
 
@@ -608,7 +608,7 @@ class SourceController < ApplicationController
       project.packages.each { |package| package.store(commit) }
     rescue
       render_error status: 400, errorcode: 'move_failed',
-        message: 'Move operation failed'
+                   message: 'Move operation failed'
       return
     end
 
@@ -855,7 +855,7 @@ class SourceController < ApplicationController
       # TODO: No need to read the whole file for knowing if it exists already
       Backend::Api::Sources::Package.file(params[:project], params[:package], "#{params[:package]}.spec")
       render_error status: 400, errorcode: 'spec_file_exists',
-        message: 'SPEC file already exists.'
+                   message: 'SPEC file already exists.'
       return
     rescue Backend::NotFoundError
       specfile_content = File.read("#{Rails.root}/files/specfiletemplate")
@@ -876,7 +876,7 @@ class SourceController < ApplicationController
       answer = Backend::Connection.get(request.path_info)
       unless answer
         render_error status: 400, errorcode: 'unknown_package',
-          message: "Unknown package '#{package_name}'"
+                     message: "Unknown package '#{package_name}'"
         return
       end
     end
@@ -885,7 +885,7 @@ class SourceController < ApplicationController
     if repo_name
       if @package && @package.repositories.find_by_name(repo_name).nil?
         render_error status: 400, errorcode: 'unknown_repository',
-          message: "Unknown repository '#{repo_name}'"
+                     message: "Unknown repository '#{repo_name}'"
         return
       end
       options[:repository] = repo_name

--- a/src/api/app/controllers/webui/project_controller.rb
+++ b/src/api/app/controllers/webui/project_controller.rb
@@ -401,7 +401,7 @@ class Webui::ProjectController < Webui::WebuiController
     monitor_set_filter(defaults)
 
     find_opt = { project: @project, view: 'status', code: @status_filter,
-      arch: @arch_filter, repository: @repo_filter }
+                 arch: @arch_filter, repository: @repo_filter }
     find_opt[:lastbuild] = 1 if @lastbuild_switch.present?
 
     @buildresult = Buildresult.find_hashed(find_opt)
@@ -769,9 +769,9 @@ class Webui::ProjectController < Webui::WebuiController
     return unless @is_incident_project
 
     @open_release_requests = BsRequest.find_for(project: @project.name,
-                                  states: ['new', 'review'],
-                                  types: ['maintenance_release'],
-                                  roles: ['source']).pluck(:number)
+                                                states: ['new', 'review'],
+                                                types: ['maintenance_release'],
+                                                roles: ['source']).pluck(:number)
   end
 
   def valid_target_name?(name)

--- a/src/api/app/controllers/webui/request_controller.rb
+++ b/src/api/app/controllers/webui/request_controller.rb
@@ -130,9 +130,9 @@ class Webui::RequestController < Webui::WebuiController
   def sourcediff
     check_ajax
     render partial: 'shared/editor', locals: { text: params[:text],
-                                                    mode: 'diff', style: { read_only: true },
-                                                    height: 'auto', width: '750px',
-                                                    no_border: true, uid: params[:uid] }
+                                               mode: 'diff', style: { read_only: true },
+                                               height: 'auto', width: '750px',
+                                               no_border: true, uid: params[:uid] }
   end
 
   def changerequest

--- a/src/api/app/helpers/webui/buildresult_helper.rb
+++ b/src/api/app/helpers/webui/buildresult_helper.rb
@@ -61,7 +61,7 @@ module Webui::BuildresultHelper
     capture_haml do
       if enable_help && status['code']
         concat(content_tag(:i, nil, class: ['fa', 'fa-question-circle', 'text-info', 'mr-1'],
-                           data: { content: Buildresult.status_description(status['code']), placement: 'top', toggle: 'popover' }))
+                                    data: { content: Buildresult.status_description(status['code']), placement: 'top', toggle: 'popover' }))
       end
       if code.in?(['-', 'unresolvable', 'blocked', 'excluded', 'scheduled'])
         concat(link_to(code, '#', id: status_id, class: theclass, data: { content: link_title, placement: 'top', toggle: 'popover' }))

--- a/src/api/app/helpers/webui/project_helper.rb
+++ b/src/api/app/helpers/webui/project_helper.rb
@@ -12,7 +12,7 @@ module Webui::ProjectHelper
         if User.current.can_modify?(@project.api_obj)
           status_comment_html += ' '.html_safe + link_to(image_tag('comment_delete.png', size: '16x16', alt: 'Clear'),
                                                          { action: :clear_failed_comment, project: @project,
-                                                          package: package, update: valid_xml_id("comment_#{package}") },
+                                                           package: package, update: valid_xml_id("comment_#{package}") },
                                                          remote: true)
           comments_to_clear << package
         end
@@ -20,8 +20,8 @@ module Webui::ProjectHelper
         status_comment_html += ' '.html_safe
         status_comment_html += link_to(image_tag('comment_edit.png', alt: 'Edit'),
                                        { action: 'edit_comment_form', comment: comment,
-                                        package: package, project: @project,
-                                        update: valid_xml_id("comment_edit_#{package}") },
+                                         package: package, project: @project,
+                                         update: valid_xml_id("comment_edit_#{package}") },
                                        remote: true)
       end
     elsif firstfail
@@ -29,7 +29,7 @@ module Webui::ProjectHelper
         status_comment_html += " <span class='unknown_failure'>Unknown build failure ".html_safe +
                                link_to(image_tag('comment_edit.png', size: '16x16', alt: 'Edit'),
                                        { action: 'edit_comment_form', comment: '', package: package,
-                                        project: @project, update: valid_xml_id("comment_edit_#{package}") },
+                                         project: @project, update: valid_xml_id("comment_edit_#{package}") },
                                        remote: true)
         status_comment_html += '</span>'.html_safe
       else

--- a/src/api/app/mixins/has_attributes.rb
+++ b/src/api/app/mixins/has_attributes.rb
@@ -76,7 +76,7 @@ module HasAttributes
       project.render_main_attributes(xml, opts) if opts[:with_project]
     end
     builder.doc.to_xml(indent: 2, encoding: 'UTF-8',
-                              save_with: Nokogiri::XML::Node::SaveOptions::NO_DECLARATION |
+                       save_with: Nokogiri::XML::Node::SaveOptions::NO_DECLARATION |
                                          Nokogiri::XML::Node::SaveOptions::FORMAT)
   end
 

--- a/src/api/app/models/bs_request_action_maintenance_incident.rb
+++ b/src/api/app/models/bs_request_action_maintenance_incident.rb
@@ -90,12 +90,12 @@ class BsRequestActionMaintenanceIncident < BsRequestAction
       package_name = linkinfo['package'] if linkinfo
 
       branch_params = { target_project: incident_project.name,
-                       olinkrev: 'base',
-                       requestid: bs_request.number,
-                       maintenance: 1,
-                       force: 1,
-                       comment: 'Initial new branch from specified release project',
-                       project: target_releaseproject, package: package_name }
+                        olinkrev: 'base',
+                        requestid: bs_request.number,
+                        maintenance: 1,
+                        force: 1,
+                        comment: 'Initial new branch from specified release project',
+                        project: target_releaseproject, package: package_name }
       # accept branching from former update incidents or GM (for kgraft case)
       linkprj = Project.find_by_name(linkinfo['project']) if linkinfo
       if defined?(linkprj) && linkprj
@@ -118,12 +118,12 @@ class BsRequestActionMaintenanceIncident < BsRequestAction
       linked_package = linkinfo['package']
 
       branch_params = { target_project: incident_project.name,
-                       olinkrev: 'base',
-                       requestid: bs_request.number,
-                       maintenance: 1,
-                       force: 1,
-                       comment: 'Initial new branch',
-                       project: linked_project, package: linked_package }
+                        olinkrev: 'base',
+                        requestid: bs_request.number,
+                        maintenance: 1,
+                        force: 1,
+                        comment: 'Initial new branch',
+                        project: linked_project, package: linked_package }
       ret = BranchPackage.new(branch_params).branch
       new_pkg = Package.get_by_project_and_name(ret[:data][:targetproject], ret[:data][:targetpackage])
     elsif linkinfo && linkinfo['package'] # a new package for all targets

--- a/src/api/app/models/bs_request_action_submit.rb
+++ b/src/api/app/models/bs_request_action_submit.rb
@@ -90,7 +90,7 @@ class BsRequestActionSubmit < BsRequestAction
       # source package got used as devel package, link it to the target
       # re-create it via branch , but keep current content...
       options = { comment: "initialized devel package after accepting #{bs_request.number}",
-        requestid: bs_request.number, keepcontent: 1, noservice: 1 }
+                  requestid: bs_request.number, keepcontent: 1, noservice: 1 }
       Backend::Api::Sources::Package.branch(self.target_project, self.target_package, source_project, source_package, User.current.login, options)
     elsif sourceupdate == 'cleanup'
       source_cleanup

--- a/src/api/app/models/cloud/azure/configuration.rb
+++ b/src/api/app/models/cloud/azure/configuration.rb
@@ -3,7 +3,7 @@ module Cloud
     class Configuration < ApplicationRecord
       # maximum length has to be 245 (2048 bit RSA keys cannot encrypt more than 245 characters)
       validates :application_id, presence: { message: 'ID can\'t be blank' },
-        length: { maximum: 245, too_long: 'ID is too long (maximum is 245 characters)' }, on: :update
+                                 length: { maximum: 245, too_long: 'ID is too long (maximum is 245 characters)' }, on: :update
       validates :application_key, presence: true, length: { maximum: 245 }, on: :update
 
       before_save :encrypt_credentials

--- a/src/api/app/models/cloud/azure/params.rb
+++ b/src/api/app/models/cloud/azure/params.rb
@@ -7,14 +7,14 @@ module Cloud
       attr_accessor :image_name, :application_id, :application_key, :subscription, :container, :storage_account, :resource_group
 
       validates :image_name, presence: true, length: { minimum: 2, maximum: 63 },
-                format: { with: /\A[[:alnum:]]([\w\.-]*\w)?\z/, message: 'not a valid format' }
+                             format: { with: /\A[[:alnum:]]([\w\.-]*\w)?\z/, message: 'not a valid format' }
       validates :subscription, presence: true, length: { minimum: 3 }
       validates :container, presence: true, length: { minimum: 3, maximum: 63 },
-                format: { with: /\A[-a-z0-9]+\z/, message: 'not a valid format' }
+                            format: { with: /\A[-a-z0-9]+\z/, message: 'not a valid format' }
       validates :storage_account, presence: true, length: { minimum: 3, maximum: 24 },
-                format: { with: /\A[a-z0-9]+\z/, message: 'not a valid format' }
+                                  format: { with: /\A[a-z0-9]+\z/, message: 'not a valid format' }
       validates :resource_group, presence: true, length: { minimum: 1, maximum: 90 },
-                format: { with: /\A[-\w\.]*[-\w]\z/, message: 'not a valid format' }
+                                 format: { with: /\A[-\w\.]*[-\w]\z/, message: 'not a valid format' }
 
       def self.build(params)
         new(params.slice(:image_name, :application_id, :application_key, :subscription, :container, :storage_account, :resource_group))

--- a/src/api/app/models/distribution.rb
+++ b/src/api/app/models/distribution.rb
@@ -56,8 +56,8 @@ class Distribution < ApplicationRecord
           iconlist << { 'width' => i['width'], 'height' => i['height'], 'url' => i['url'] }
         end
         list << { 'vendor' => d['vendor'], 'version' => d['version'], 'name' => d['name'],
-          'project' => prj.name + ':' + d['project'], 'architectures' => architecturelist, 'icons' => iconlist,
-          'reponame' => d['reponame'], 'repository' => d['repository'], 'link' => d['link'] }
+                  'project' => prj.name + ':' + d['project'], 'architectures' => architecturelist, 'icons' => iconlist,
+                  'reponame' => d['reponame'], 'repository' => d['repository'], 'link' => d['link'] }
       end
     end
     list

--- a/src/api/app/models/issue.rb
+++ b/src/api/app/models/issue.rb
@@ -120,7 +120,7 @@ class Issue < ApplicationRecord
       render_body node
     end
     builder.to_xml(indent: 2, encoding: 'UTF-8',
-                               save_with: Nokogiri::XML::Node::SaveOptions::NO_DECLARATION |
+                   save_with: Nokogiri::XML::Node::SaveOptions::NO_DECLARATION |
                                           Nokogiri::XML::Node::SaveOptions::FORMAT)
   end
 

--- a/src/api/app/models/kiwi/repository.rb
+++ b/src/api/app/models/kiwi/repository.rb
@@ -23,7 +23,7 @@ module Kiwi
     validates :source_path, presence: { message: 'can\'t be nil' }
     validate :source_path_format
     validates :priority, numericality: { only_integer: true, allow_nil: true, greater_than_or_equal_to: 0,
-                                        less_than: 100, message: 'must be between 0 and 99' }
+                                         less_than: 100, message: 'must be between 0 and 99' }
     validates :order, numericality: { only_integer: true, greater_than_or_equal_to: 1 }
     # TODO: repo_type value depends on packagemanager element
     # https://doc.opensuse.org/projects/kiwi/doc/#sec.description.repository

--- a/src/api/app/models/project/update_from_xml_command.rb
+++ b/src/api/app/models/project/update_from_xml_command.rb
@@ -72,9 +72,9 @@ class Project
         if link.nil?
           if Project.find_remote_project(l['project'])
             project.linking_to.create(project: project,
-                                       linked_remote_project_name: l['project'],
-                                       vrevmode: l['vrevmode'],
-                                       position: position)
+                                      linked_remote_project_name: l['project'],
+                                      vrevmode: l['vrevmode'],
+                                      position: position)
           else
             raise SaveError, "unable to link against project '#{l['project']}'"
           end

--- a/src/api/app/models/user.rb
+++ b/src/api/app/models/user.rb
@@ -79,8 +79,8 @@ class User < ApplicationRecord
                       message: 'must not contain invalid characters' }
   validates :login,
             length: { in: 2..100, allow_nil: true,
-            too_long: 'must have less than 100 characters',
-            too_short: 'must have more than two characters' }
+                      too_long: 'must have less than 100 characters',
+                      too_short: 'must have more than two characters' }
 
   validates :state, inclusion: { in: STATES }
 

--- a/src/api/app/views/result/packageresult.xml.builder
+++ b/src/api/app/views/result/packageresult.xml.builder
@@ -1,5 +1,5 @@
 xml.packageresult('project' => @project, 'repository' => @repository,
-                   'package' => @package) do
+                  'package' => @package) do
   xml.date(Time.now)
   xml.status('code' => @status) do
     xml.packagecount(@succeeded, 'state' => 'succeeded')

--- a/src/api/config/routes.rb
+++ b/src/api/config/routes.rb
@@ -609,7 +609,7 @@ OBSApi::Application.routes.draw do
 
       get 'statistics/active_request_creators/:project' => :active_request_creators, constraints: cons
       get 'statistics/maintenance_statistics/:project' => 'statistics/maintenance_statistics#index', constraints: cons,
-        as: 'maintenance_statistics'
+          as: 'maintenance_statistics'
       get 'public/statistics/maintenance_statistics/:project' => 'statistics/maintenance_statistics#index', constraints: cons
     end
 

--- a/src/api/db/seeds.rb
+++ b/src/api/db/seeds.rb
@@ -52,8 +52,8 @@ Role.where(title: 'Staff').first_or_create(global: true)
 
 puts 'Seeding users table...'
 admin = User.where(login: 'Admin').first_or_create(login: 'Admin', email: 'root@localhost',
-                                                    realname: 'OBS Instance Superuser', state: 'confirmed',
-                                                    password: 'opensuse')
+                                                   realname: 'OBS Instance Superuser', state: 'confirmed',
+                                                   password: 'opensuse')
 admin.update!(in_beta: true) if Rails.env.development?
 
 User.where(login: '_nobody_').first_or_create(login: '_nobody_', email: 'nobody@localhost',
@@ -317,7 +317,7 @@ IssueTracker.where(name: 'osc').first_or_create(description: 'OBS CLI Issues',
                                                 url: 'https://api.github.com/repos/openSUSE/osc/issues',
                                                 label: 'osc#@@@', show_url: 'https://github.com/openSUSE/osc/issues/@@@')
 IssueTracker.where(name: 'lf').first_or_create(description: 'Linux Foundation Bugzilla',
-                                                kind: 'bugzilla',
-                                                regex: 'lf#(\d+)',
-                                                url: 'https://developerbugs.linuxfoundation.org',
-                                                label: 'lf#@@@', show_url: 'https://developerbugs.linuxfoundation.org/show_bug.cgi?id=@@@')
+                                               kind: 'bugzilla',
+                                               regex: 'lf#(\d+)',
+                                               url: 'https://developerbugs.linuxfoundation.org',
+                                               label: 'lf#@@@', show_url: 'https://developerbugs.linuxfoundation.org/show_bug.cgi?id=@@@')

--- a/src/api/lib/backend/api/sources/package.rb
+++ b/src/api/lib/backend/api/sources/package.rb
@@ -134,7 +134,7 @@ module Backend
         # @return [String]
         def self.rebuild(project_name, package_name, options = {})
           http_post(['/build/:project', project_name], defaults: { cmd: :rebuild, package: package_name },
-                    params: options, accepted: [:repository, :arch])
+                                                       params: options, accepted: [:repository, :arch])
         end
 
         # Returns the content of the source file

--- a/src/api/lib/backend/api/sources/project.rb
+++ b/src/api/lib/backend/api/sources/project.rb
@@ -90,7 +90,7 @@ module Backend
         # Undeletes the project
         def self.undelete(project_name, options = {})
           http_post(['/source/:project', project_name], defaults: { cmd: :undelete },
-                    params: options, accepted: [:user, :comment])
+                                                        params: options, accepted: [:user, :comment])
         end
 
         # Returns the list of repositories

--- a/src/api/lib/tasks/sprites.rake
+++ b/src/api/lib/tasks/sprites.rake
@@ -10,7 +10,7 @@ namespace :assets do
     # md5=Digest::MD5.hexdigest(File.open('tmp/sprite.tmp.png').read)
     # File.unlink('tmp/sprite.tmp.png')
     SpriteFactory.run!('app/assets/icons', output_style: 'app/assets/stylesheets/webui/application/icons.scss',
-                       output_image: 'app/assets/images/icons_sprite.png', margin: 2, nocomments: true) do |images|
+                                           output_image: 'app/assets/images/icons_sprite.png', margin: 2, nocomments: true) do |images|
       rules = []
       images.each do |icon, hash|
         rules << ".icons-#{icon} { #{hash[:style]}; }"

--- a/src/api/lib/xpath_engine.rb
+++ b/src/api/lib/xpath_engine.rb
@@ -49,15 +49,15 @@ class XpathEngine
         'group/@groupid'               => { cpart: 'groups.title', joins:       ['LEFT JOIN groups ON groups.id = group_relation.group_id'] },
         'group/@role'                  => { cpart: 'gpr.title', joins:          ['LEFT JOIN roles AS gpr ON group_relation.role_id = gpr.id'] },
         'attribute/@name'              => { cpart: 'attrib_namespaces.name = ? AND attrib_types.name', split: ':',
-                                           joins: ['LEFT JOIN attrib_types ON attribs.attrib_type_id = attrib_types.id',
-                                                   'LEFT JOIN attrib_namespaces ON attrib_types.attrib_namespace_id = attrib_namespaces.id',
-                                                   'LEFT JOIN attribs AS attribsprj ON attribsprj.project_id = packages.project_id', # include also, when set in project
-                                                   'LEFT JOIN attrib_types AS attrib_typesprj ON attribsprj.attrib_type_id = attrib_typesprj.id',
-                                                   'LEFT JOIN attrib_namespaces AS attrib_namespacesprj ON attrib_typesprj.attrib_namespace_id = attrib_namespacesprj.id'] },
+                                            joins: ['LEFT JOIN attrib_types ON attribs.attrib_type_id = attrib_types.id',
+                                                    'LEFT JOIN attrib_namespaces ON attrib_types.attrib_namespace_id = attrib_namespaces.id',
+                                                    'LEFT JOIN attribs AS attribsprj ON attribsprj.project_id = packages.project_id', # include also, when set in project
+                                                    'LEFT JOIN attrib_types AS attrib_typesprj ON attribsprj.attrib_type_id = attrib_typesprj.id',
+                                                    'LEFT JOIN attrib_namespaces AS attrib_namespacesprj ON attrib_typesprj.attrib_namespace_id = attrib_namespacesprj.id'] },
         'project/attribute/@name'      => { cpart: 'attrib_namespaces_proj.name = ? AND attrib_types_proj.name', split: ':',
-                                           joins: ['LEFT JOIN attribs AS attribs_proj ON attribs_proj.project_id = packages.project_id',
-                                                   'LEFT JOIN attrib_types AS attrib_types_proj ON attribs_proj.attrib_type_id = attrib_types_proj.id',
-                                                   'LEFT JOIN attrib_namespaces AS attrib_namespaces_proj ON attrib_types_proj.attrib_namespace_id = attrib_namespaces_proj.id'] }
+                                            joins: ['LEFT JOIN attribs AS attribs_proj ON attribs_proj.project_id = packages.project_id',
+                                                    'LEFT JOIN attrib_types AS attrib_types_proj ON attribs_proj.attrib_type_id = attrib_types_proj.id',
+                                                    'LEFT JOIN attrib_namespaces AS attrib_namespaces_proj ON attrib_types_proj.attrib_namespace_id = attrib_namespaces_proj.id'] }
       },
       'projects'          => {
         '@name'                             => { cpart: 'projects.name' },
@@ -86,9 +86,9 @@ class XpathEngine
                                                          'join release_targets rt on rt.repository_id=r.id'] },
         'package/@name'                     => { cpart: 'packs.name', joins: ['LEFT JOIN packages AS packs ON packs.project_id = projects.id'] },
         'attribute/@name'                   => { cpart: 'attrib_namespaces.name = ? AND attrib_types.name', split: ':',
-                                                joins: ['LEFT JOIN attribs ON attribs.project_id = projects.id',
-                                                        'LEFT JOIN attrib_types ON attribs.attrib_type_id = attrib_types.id',
-                                                        'LEFT JOIN attrib_namespaces ON attrib_types.attrib_namespace_id = attrib_namespaces.id'] }
+                                                 joins: ['LEFT JOIN attribs ON attribs.project_id = projects.id',
+                                                         'LEFT JOIN attrib_types ON attribs.attrib_type_id = attrib_types.id',
+                                                         'LEFT JOIN attrib_namespaces ON attrib_types.attrib_namespace_id = attrib_namespaces.id'] }
       },
       'repositories'      => {
         '@project'                   => { cpart: 'pr.name', joins: 'LEFT JOIN projects AS pr ON repositories.db_project_id=pr.id' },

--- a/src/api/spec/bootstrap/features/webui/packages_spec.rb
+++ b/src/api/spec/bootstrap/features/webui/packages_spec.rb
@@ -6,7 +6,7 @@ RSpec.feature 'Bootstrap_Packages', type: :feature, js: true, vcr: true do
   it_behaves_like 'bootstrap user tab' do
     let(:package) do
       create(:package, name: 'group_test_package',
-        project_id: user_tab_user.home_project.id)
+                       project_id: user_tab_user.home_project.id)
     end
     let!(:maintainer_user_role) { create(:relationship, package: package, user: user_tab_user) }
     let(:project_path) { package_show_path(project: user_tab_user.home_project, package: package) }

--- a/src/api/spec/controllers/source_project_config_controller_spec.rb
+++ b/src/api/spec/controllers/source_project_config_controller_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe SourceProjectConfigController, vcr: true do
       before do
         login user
         put :update, params: { project: remote_project.name,
-             comment: 'Updated by test', format: :xml }
+                               comment: 'Updated by test', format: :xml }
       end
 
       it { expect(response).to be_forbidden }

--- a/src/api/spec/controllers/source_project_package_meta_controller_spec.rb
+++ b/src/api/spec/controllers/source_project_package_meta_controller_spec.rb
@@ -51,7 +51,7 @@ RSpec.describe SourceProjectPackageMetaController, vcr: true do
         project_with_package
         put :update, params: { project: project_with_package,
                                package: 'foo' },
-                               body: meta, format: :xml
+                     body: meta, format: :xml
       end
 
       it { expect(response).to be_success }
@@ -65,7 +65,7 @@ RSpec.describe SourceProjectPackageMetaController, vcr: true do
         project_with_package
         put :update, params: { project: project_with_package,
                                package: 'foo' },
-                               body: meta, format: :xml
+                     body: meta, format: :xml
       end
 
       it { expect(response).to have_http_status(400) }

--- a/src/api/spec/controllers/status/required_checks_controller_spec.rb
+++ b/src/api/spec/controllers/status/required_checks_controller_spec.rb
@@ -171,8 +171,8 @@ RSpec.describe Status::RequiredChecksController, type: :controller do
       it 'will not delete the required check' do
         expect do
           delete :destroy, params: { project_name: project.name,
-                                                   repository_name: repository.name,
-                                                   name: 'first check' }, format: :xml
+                                     repository_name: repository.name,
+                                     name: 'first check' }, format: :xml
         end.not_to(
           change do
             # we need to to reload because required_checks is a serialized attribute
@@ -186,8 +186,8 @@ RSpec.describe Status::RequiredChecksController, type: :controller do
     shared_examples 'returns correct status' do
       before do
         delete :destroy, params: { project_name: project.name,
-                                                 repository_name: repository.name,
-                                                 name: 'first check' }, format: :xml
+                                   repository_name: repository.name,
+                                   name: 'first check' }, format: :xml
       end
 
       it 'has correct HTTP status' do

--- a/src/api/spec/controllers/webui/configuration_controller_spec.rb
+++ b/src/api/spec/controllers/webui/configuration_controller_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe Webui::ConfigurationController do
       before do
         login(admin_user)
         patch :update, params: { configuration: { name: 'obs', title: 'OBS', description: 'something',
-          unlisted_projects_filter: '^home:fake_user:.*', unlisted_projects_filter_description: "fake_user's home" } }
+                                                  unlisted_projects_filter: '^home:fake_user:.*', unlisted_projects_filter_description: "fake_user's home" } }
       end
 
       it { expect(response).to redirect_to(configuration_path) }

--- a/src/api/spec/controllers/webui/kiwi/images_controller_spec.rb
+++ b/src/api/spec/controllers/webui/kiwi/images_controller_spec.rb
@@ -50,8 +50,8 @@ RSpec.describe Webui::Kiwi::ImagesController, type: :controller, vcr: true do
 
         it 'redirect to package_view_file_path' do
           expect(response).to redirect_to(package_view_file_path(project: package_with_kiwi_file.project,
-                                                                    package: package_with_kiwi_file,
-                                                                    filename: "#{package_with_kiwi_file.name}.kiwi"))
+                                                                 package: package_with_kiwi_file,
+                                                                 filename: "#{package_with_kiwi_file.name}.kiwi"))
         end
         it { expect(flash[:error]).not_to be_nil }
       end
@@ -60,7 +60,7 @@ RSpec.describe Webui::Kiwi::ImagesController, type: :controller, vcr: true do
         context 'with obsrepository' do
           let(:package_with_kiwi_file) do
             create(:package_with_kiwi_file, name: 'package_with_a_kiwi_file',
-                   project: project, kiwi_file_content: kiwi_xml_with_obsrepositories)
+                                            project: project, kiwi_file_content: kiwi_xml_with_obsrepositories)
           end
 
           before do
@@ -76,7 +76,7 @@ RSpec.describe Webui::Kiwi::ImagesController, type: :controller, vcr: true do
         context 'with obsrepository and others' do
           let(:package_with_kiwi_file) do
             create(:package_with_kiwi_file, name: 'package_with_invalid_kiwi_file',
-                   project: project, kiwi_file_content: invalid_kiwi_xml_with_obsrepositories)
+                                            project: project, kiwi_file_content: invalid_kiwi_xml_with_obsrepositories)
           end
           let(:errors) do
             {
@@ -106,7 +106,7 @@ RSpec.describe Webui::Kiwi::ImagesController, type: :controller, vcr: true do
         context 'with the same type' do
           let(:package_with_kiwi_file) do
             create(:package_with_kiwi_file, name: 'package_with_invalid_kiwi_file',
-                   project: project, kiwi_file_content: invalid_kiwi_xml_with_multiple_package_groups)
+                                            project: project, kiwi_file_content: invalid_kiwi_xml_with_multiple_package_groups)
           end
 
           let(:errors) do

--- a/src/api/spec/controllers/webui/package_controller_spec.rb
+++ b/src/api/spec/controllers/webui/package_controller_spec.rb
@@ -1092,7 +1092,7 @@ RSpec.describe Webui::PackageController, vcr: true do
                </result>
               </resultlist>))
           do_request project: source_project_with_plus, package: package_of_project_with_plus,
-            repository: repo_leap_45_1.name, arch: 'i586', format: 'js'
+                     repository: repo_leap_45_1.name, arch: 'i586', format: 'js'
         end
 
         it { expect(response).to have_http_status(:ok) }
@@ -1650,8 +1650,8 @@ RSpec.describe Webui::PackageController, vcr: true do
     let(:my_user) { user }
     let(:post_params) do
       { project: source_project, name: package_name,
-                              title: 'package foo',
-                              description: 'awesome package foo' }
+        title: 'package foo',
+        description: 'awesome package foo' }
     end
 
     context 'Package#save failed' do
@@ -1680,9 +1680,9 @@ RSpec.describe Webui::PackageController, vcr: true do
       context 'valid package with source_protection enabled' do
         let(:post_params) do
           { project: source_project, name: package_name,
-                                  title: 'package foo',
-                                  description: 'awesome package foo', source_protection: 'foo',
-                                  disable_publishing: 'bar' }
+            title: 'package foo',
+            description: 'awesome package foo', source_protection: 'foo',
+            disable_publishing: 'bar' }
         end
 
         it { expect(Package.find_by(name: package_name).flags).to include(Flag.find_by_flag('sourceaccess')) }

--- a/src/api/spec/controllers/webui/repositories_controller_spec.rb
+++ b/src/api/spec/controllers/webui/repositories_controller_spec.rb
@@ -152,7 +152,7 @@ RSpec.describe Webui::RepositoriesController, vcr: true do
         target_repo = create(:repository, project: another_project)
         post :create, params: {
           project: user.home_project, repository: 'valid_name',
-            target_project: another_project, target_repo: target_repo.name, architectures: ['i586']
+          target_project: another_project, target_repo: target_repo.name, architectures: ['i586']
         }
       end
 
@@ -186,9 +186,9 @@ RSpec.describe Webui::RepositoriesController, vcr: true do
 
       before do
         post :create_dod_repository, xhr: true,
-          params: {
-            project: user.home_project, name: existing_repository.name, arch: Architecture.first.name, url: 'http://whatever.com', repotype: 'rpmmd'
-          }
+                                     params: {
+                                       project: user.home_project, name: existing_repository.name, arch: Architecture.first.name, url: 'http://whatever.com', repotype: 'rpmmd'
+                                     }
       end
 
       it { expect(assigns(:error)).to start_with('Repository with name') }
@@ -198,9 +198,9 @@ RSpec.describe Webui::RepositoriesController, vcr: true do
     context 'with no valid repository type' do
       before do
         post :create_dod_repository, xhr: true,
-          params: {
-            project: user.home_project, name: 'NewRepo', arch: Architecture.first.name, url: 'http://whatever.com', repotype: 'invalid_repo_type'
-          }
+                                     params: {
+                                       project: user.home_project, name: 'NewRepo', arch: Architecture.first.name, url: 'http://whatever.com', repotype: 'invalid_repo_type'
+                                     }
       end
 
       it { expect(assigns(:error)).to start_with("Couldn't add repository:") }
@@ -210,9 +210,9 @@ RSpec.describe Webui::RepositoriesController, vcr: true do
     context 'with no valid repository Architecture' do
       before do
         post :create_dod_repository, xhr: true,
-          params: {
-            project: user.home_project, name: 'NewRepo', arch: 'non_existent_arch', url: 'http://whatever.com', repotype: 'rpmmd'
-          }
+                                     params: {
+                                       project: user.home_project, name: 'NewRepo', arch: 'non_existent_arch', url: 'http://whatever.com', repotype: 'rpmmd'
+                                     }
       end
 
       it { expect(assigns(:error)).to start_with("Couldn't add repository:") }
@@ -222,9 +222,9 @@ RSpec.describe Webui::RepositoriesController, vcr: true do
     context 'with valid repository data' do
       before do
         post :create_dod_repository, xhr: true,
-          params: {
-            project: user.home_project, name: 'NewRepo', arch: Architecture.first.name, url: 'http://whatever.com', repotype: 'rpmmd'
-          }
+                                     params: {
+                                       project: user.home_project, name: 'NewRepo', arch: Architecture.first.name, url: 'http://whatever.com', repotype: 'rpmmd'
+                                     }
       end
 
       it { expect(assigns(:error)).to be_nil }

--- a/src/api/spec/controllers/webui/request_controller_spec.rb
+++ b/src/api/spec/controllers/webui/request_controller_spec.rb
@@ -121,7 +121,7 @@ RSpec.describe Webui::RequestController, vcr: true do
         context 'for ASCII files' do
           let(:target_package) do
             create(:package_with_file, name: 'test-package-ascii',
-                   file_content: "a\n" * (file_size_threshold + 1), project: target_project)
+                                       file_content: "a\n" * (file_size_threshold + 1), project: target_project)
           end
 
           it_behaves_like 'a full diff not requested for', 'somefile.txt'
@@ -133,7 +133,7 @@ RSpec.describe Webui::RequestController, vcr: true do
           end
           let(:source_package) do
             create(:package_with_binary, name: 'test-source-package-binary', project: source_project,
-                   file_name: 'spec/support/files/bigfile_archive_2.tar.gz')
+                                         file_name: 'spec/support/files/bigfile_archive_2.tar.gz')
           end
 
           it_behaves_like 'a full diff not requested for', 'bigfile_archive.tar.gz/bigfile.txt'
@@ -162,7 +162,7 @@ RSpec.describe Webui::RequestController, vcr: true do
           let(:expected_diff_size) { file_size_threshold + 1 + diff_header_size }
           let(:target_package) do
             create(:package_with_file, name: 'test-package-ascii',
-                   file_content: "a\n" * (file_size_threshold + 1), project: target_project)
+                                       file_content: "a\n" * (file_size_threshold + 1), project: target_project)
           end
 
           it_behaves_like 'a full diff requested for', 'somefile.txt'
@@ -173,7 +173,7 @@ RSpec.describe Webui::RequestController, vcr: true do
           let(:target_package) { create(:package_with_binary, name: 'test-package-binary', project: target_project) }
           let(:source_package) do
             create(:package_with_binary, name: 'test-source-package-binary',
-                   project: source_project, file_name: 'spec/support/files/bigfile_archive_2.tar.gz')
+                                         project: source_project, file_name: 'spec/support/files/bigfile_archive_2.tar.gz')
           end
 
           it_behaves_like 'a full diff requested for', 'bigfile_archive.tar.gz/bigfile.txt'
@@ -422,7 +422,7 @@ RSpec.describe Webui::RequestController, vcr: true do
         login(submitter)
         post :change_devel_request, params: {
           project: target_project.name, package: target_package.name,
-            devel_project: source_project.name, devel_package: source_package.name, description: 'change it!'
+          devel_project: source_project.name, devel_package: source_package.name, description: 'change it!'
         }
       end
 
@@ -448,7 +448,7 @@ RSpec.describe Webui::RequestController, vcr: true do
         login(submitter)
         post :change_devel_request, params: {
           project: target_project.name, package: target_package.name,
-            devel_project: source_project.name, devel_package: 'non-existant', description: 'change it!'
+          devel_project: source_project.name, devel_package: 'non-existant', description: 'change it!'
         }
       end
 

--- a/src/api/spec/factories/download_repository_factory.rb
+++ b/src/api/spec/factories/download_repository_factory.rb
@@ -14,7 +14,7 @@ FactoryBot.define do
       # We set the position explicit in the repository_architecture factory
       unless repo_arch
         create(:repository_architecture, repository: download_repository.repository,
-               architecture: Architecture.find_or_create_by!(name: download_repository.arch))
+                                         architecture: Architecture.find_or_create_by!(name: download_repository.arch))
       end
     end
   end

--- a/src/api/spec/factories/kiwi_image.rb
+++ b/src/api/spec/factories/kiwi_image.rb
@@ -20,7 +20,7 @@ FactoryBot.define do
         if evaluator.with_kiwi_file
           image.package =
             create(:package_with_kiwi_file, name: evaluator.package_name, project: evaluator.project,
-                   kiwi_file_content: evaluator.file_content, kiwi_file_name: evaluator.kiwi_file_name)
+                                            kiwi_file_content: evaluator.file_content, kiwi_file_name: evaluator.kiwi_file_name)
           image.md5_last_revision = image.package.kiwi_file_md5
         else
           image.package = create(:package, name: evaluator.package_name, project: evaluator.project)

--- a/src/api/spec/factories/repository.rb
+++ b/src/api/spec/factories/repository.rb
@@ -10,7 +10,7 @@ FactoryBot.define do
     after(:create) do |repository, evaluator|
       evaluator.architectures.each do |arch|
         create(:repository_architecture, repository:   repository,
-               architecture: Architecture.find_or_create_by!(name: arch))
+                                         architecture: Architecture.find_or_create_by!(name: arch))
       end
     end
 

--- a/src/api/spec/features/webui/notifications_spec.rb
+++ b/src/api/spec/features/webui/notifications_spec.rb
@@ -26,7 +26,7 @@ RSpec.feature 'Notifications', type: :feature, js: true do
       expect(EventSubscription.exists?(user_id: user_id, eventtype: 'Event::CommentForPackage',
                                        receiver_role: 'commenter', channel: 'instant_email')).to be(true)
       expect(EventSubscription.exists?(user_id: user_id, eventtype: 'Event::CommentForProject',
-                                      receiver_role: 'maintainer', channel: 'instant_email')).to be(true)
+                                       receiver_role: 'maintainer', channel: 'instant_email')).to be(true)
       expect(EventSubscription.exists?(user_id: user_id, eventtype: 'Event::CommentForRequest',
                                        receiver_role: 'reviewer', channel: 'instant_email')).to be(true)
       expect(EventSubscription.exists?(user_id: user_id, eventtype: 'Event::BuildFail',

--- a/src/api/spec/features/webui/packages_spec.rb
+++ b/src/api/spec/features/webui/packages_spec.rb
@@ -5,7 +5,7 @@ RSpec.feature 'Packages', type: :feature, js: true do
   it_behaves_like 'user tab' do
     let(:package) do
       create(:package, name: 'group_test_package',
-        project_id: user_tab_user.home_project.id)
+                       project_id: user_tab_user.home_project.id)
     end
     let!(:maintainer_user_role) { create(:relationship, package: package, user: user_tab_user) }
     let(:project_path) { package_show_path(project: user_tab_user.home_project, package: package) }
@@ -132,9 +132,9 @@ RSpec.feature 'Packages', type: :feature, js: true do
     let!(:bs_request) do
       create(:bs_request_with_submit_action,
              source_project: source_project,
-                 source_package: source_package,
-                 target_project: target_project,
-                 target_package: package)
+             source_package: source_package,
+             target_project: target_project,
+             target_package: package)
     end
 
     scenario 'see a request' do

--- a/src/api/spec/jobs/update_backend_infos_job_spec.rb
+++ b/src/api/spec/jobs/update_backend_infos_job_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe UpdateBackendInfosJob, vcr: true do
   let(:user) { create(:admin_user, login: 'myself') }
   let(:event) do
     Event::UndeletePackage.create('project' => project.name, 'package' => package.name,
-                               'sender' => user.login, 'comment' => 'fake_payload_comment')
+                                  'sender' => user.login, 'comment' => 'fake_payload_comment')
   end
 
   context 'for an event with a package' do

--- a/src/api/spec/models/bs_request_action_spec.rb
+++ b/src/api/spec/models/bs_request_action_spec.rb
@@ -12,11 +12,11 @@ RSpec.describe BsRequestAction, vcr: true do
     let(:project) { user.home_project }
     let(:target_package) do
       create(:package_with_file, name: 'package_encoding_1',
-             file_content: file_content, project: project)
+                                 file_content: file_content, project: project)
     end
     let(:source_package) do
       create(:package_with_file, name: 'package_encoding_2',
-             file_content: 'test', project: project)
+                                 file_content: 'test', project: project)
     end
     let(:bs_request) { build(:bs_request, creator: user.login) }
     let(:action_attributes) do

--- a/src/api/spec/models/kiwi/image_spec.rb
+++ b/src/api/spec/models/kiwi/image_spec.rb
@@ -303,7 +303,7 @@ RSpec.describe Kiwi::Image, type: :model, vcr: true do
 
       subject do
         create(:kiwi_image_with_package, project: project,
-               with_kiwi_file: true, file_content: 'Invalid content for a kiwi xml file<image></image>')
+                                         with_kiwi_file: true, file_content: 'Invalid content for a kiwi xml file<image></image>')
       end
 
       it { expect(subject.to_xml).to be_nil }
@@ -484,7 +484,7 @@ RSpec.describe Kiwi::Image, type: :model, vcr: true do
     it { expect(subject.find_binaries_by_name('', 'project', [], use_project_repositories: true)).to eq(binaries_available_sample) }
     it do
       expect(subject.find_binaries_by_name('ap', 'project', [], use_project_repositories: true)).to eq('apache' => ['i586', 'x86_64'],
-        'apache2' => ['x86_64'], 'appArmor' => ['i586', 'x86_64'])
+                                                                                                       'apache2' => ['x86_64'], 'appArmor' => ['i586', 'x86_64'])
     end
     it { expect(subject.find_binaries_by_name('app', 'project', [], use_project_repositories: true)).to eq('appArmor' => ['i586', 'x86_64']) }
     it { expect(subject.find_binaries_by_name('b', 'project', [], use_project_repositories: true)).to eq('bcrypt' => ['x86_64']) }

--- a/src/api/spec/models/local_build_statistic/for_package_spec.rb
+++ b/src/api/spec/models/local_build_statistic/for_package_spec.rb
@@ -58,9 +58,9 @@ RSpec.describe LocalBuildStatistic::ForPackage do
       it { expect(results.memory).to have_attributes(size: '106', unit: 'M') }
       it 'related with times (total, install, preinstall, main)' do
         expect(results.times).to have_attributes(total: '107', total_unit: 's',
-                                                   preinstall: '18', preinstall_unit: 's',
-                                                   install: '24', install_unit: 's',
-                                                   main: '4', main_unit: 's')
+                                                 preinstall: '18', preinstall_unit: 's',
+                                                 install: '24', install_unit: 's',
+                                                 main: '4', main_unit: 's')
       end
     end
 

--- a/src/api/spec/models/obs_factory/obs_project_spec.rb
+++ b/src/api/spec/models/obs_factory/obs_project_spec.rb
@@ -48,7 +48,7 @@ RSpec.describe ObsFactory::ObsProject do
               'arch' => 'i586',
               'code' => 'published',
               'state' => 'published',
-             'summary' => { 'statuscount' => { 'code' => 'succeeded', 'count' => '5' } }
+              'summary' => { 'statuscount' => { 'code' => 'succeeded', 'count' => '5' } }
             },
             {
               'project' => 'openSUSE:Factory',
@@ -56,7 +56,7 @@ RSpec.describe ObsFactory::ObsProject do
               'arch' => 'i586',
               'code' => 'published',
               'state' => 'published',
-             'summary' => { 'statuscount' => { 'code' => 'succeeded', 'count' => '5' } }
+              'summary' => { 'statuscount' => { 'code' => 'succeeded', 'count' => '5' } }
             }
           ]
         )

--- a/src/api/spec/models/obs_factory/staging_project_spec.rb
+++ b/src/api/spec/models/obs_factory/staging_project_spec.rb
@@ -196,7 +196,7 @@ RSpec.describe ObsFactory::StagingProject do
       it {
         expect(subject.broken_packages).to eq(
           [{ 'package' => 'firebird', 'project' => 'openSUSE:Factory:Staging:A', 'state' => 'failed',
-              'details' => nil, 'repository' => 'standard', 'arch' => 'x86_64' }]
+             'details' => nil, 'repository' => 'standard', 'arch' => 'x86_64' }]
         )
       }
     end

--- a/src/api/spec/models/project_spec.rb
+++ b/src/api/spec/models/project_spec.rb
@@ -319,35 +319,35 @@ RSpec.describe Project, vcr: true do
 
       let!(:review) do
         create(:review_bs_request, creator: admin_user.login, target_project: project.name, source_project: other_project.name,
-               target_package: package.name, source_package: other_package.name, reviewer: confirmed_user)
+                                   target_package: package.name, source_package: other_package.name, reviewer: confirmed_user)
       end
 
       let!(:target) { create(:bs_request, creator: confirmed_user.login, source_project: project.name) }
       let!(:other_target) do
         create(:bs_request_with_submit_action, creator: admin_user.login, target_project: project.name, source_project: other_project.name,
-                                                                          target_package: package.name, source_package: other_package.name)
+                                               target_package: package.name, source_package: other_package.name)
       end
       let!(:declined_target) do
         create(:declined_bs_request, creator: confirmed_user.login, target_project: other_project.name, source_project: project.name,
-                                                                          target_package: package.name, source_package: other_package.name)
+                                     target_package: package.name, source_package: other_package.name)
       end
 
       let!(:incident) do
         create(:bs_request_with_maintenance_incident_action, creator: admin_user.login, target_project: project.name,
-               source_project: subproject.name, target_package: other_package, source_package: package.name)
+                                                             source_project: subproject.name, target_package: other_package, source_package: package.name)
       end
       let(:accepted_incident) do
         create(:bs_request_with_maintenance_incident_action, creator: admin_user.login, target_project: project.name,
-               source_project: subproject.name, target_package: other_package, source_package: package.name)
+                                                             source_project: subproject.name, target_package: other_package, source_package: package.name)
       end
 
       let!(:release) do
         create(:bs_request_with_maintenance_release_action, creator: admin_user.login, target_project: other_project.name,
-               source_project: subproject.name, target_package: other_package, source_package: package.name)
+                                                            source_project: subproject.name, target_package: other_package, source_package: package.name)
       end
       let!(:other_release) do
         create(:bs_request_with_maintenance_release_action, creator: admin_user.login, target_project: subproject.name,
-               source_project: other_project.name, target_package: package.name, source_package: other_package.name)
+                                                            source_project: other_project.name, target_package: package.name, source_package: other_package.name)
       end
 
       before do
@@ -595,12 +595,12 @@ RSpec.describe Project, vcr: true do
     let!(:maintenance_incident_project) { create(:maintenance_incident_project) }
     it {
       expect(maintenance_incident_project.expand_flags).to eq('lock' => [['disable', {}]],
-      'build' => [['disable', { explicit: '1' }]],
-      'publish' => [['disable', { explicit: '1' }]],
-      'debuginfo' => [['disable', {}]],
-      'useforbuild' => [['enable', {}]],
-      'binarydownload' => [['enable', {}]],
-      'sourceaccess' => [['enable', {}]], 'access' => [['enable', {}]])
+                                                              'build' => [['disable', { explicit: '1' }]],
+                                                              'publish' => [['disable', { explicit: '1' }]],
+                                                              'debuginfo' => [['disable', {}]],
+                                                              'useforbuild' => [['enable', {}]],
+                                                              'binarydownload' => [['enable', {}]],
+                                                              'sourceaccess' => [['enable', {}]], 'access' => [['enable', {}]])
     }
   end
 end

--- a/src/api/spec/support/capybara.rb
+++ b/src/api/spec/support/capybara.rb
@@ -20,7 +20,7 @@ if ENV['RSPEC_HOST'].blank?
     path[':session_id'] = bridge.session_id
 
     bridge.http.call(:post, path, cmd: 'Page.addScriptToEvaluateOnNewDocument',
-                                params: { source: '$.fx.off = true;' })
+                                  params: { source: '$.fx.off = true;' })
     driver
   end
 
@@ -30,7 +30,7 @@ else
     'goog:chromeOptions' => {
       'args' => ['--no-sandbox']
     },
-     browserName: 'chrome'
+    browserName: 'chrome'
   )
 
   Capybara.register_driver :chrome do |app|

--- a/src/api/test/functional/attributes_test.rb
+++ b/src/api/test/functional/attributes_test.rb
@@ -260,7 +260,7 @@ ription</description>
     get '/source/home:adrian/_attribute/TEST:Dummy'
     assert_response :success
     assert_no_xml_tag parent: { tag: 'attribute', attributes: { name: 'Dummy', namespace: 'TEST' } },
-                   tag: 'issue', attributes: { name: '123', tracker: 'bnc' }
+                      tag: 'issue', attributes: { name: '123', tracker: 'bnc' }
     assert_xml_tag parent: { tag: 'attribute', attributes: { name: 'Dummy', namespace: 'TEST' } },
                    tag: 'issue', attributes: { name: '456', tracker: 'bnc' }
 

--- a/src/api/test/functional/channel_maintenance_test.rb
+++ b/src/api/test/functional/channel_maintenance_test.rb
@@ -105,9 +105,9 @@ class ChannelMaintenanceTests < ActionDispatch::IntegrationTest
     assert_xml_tag(tag: 'new', attributes: { project: 'home:tom:branches:OBS_Maintained:pack2', package: 'pack2.BaseDistro3', rev: '33fed2157de2517bc62894b3fdfd485c', srcmd5: '33fed2157de2517bc62894b3fdfd485c' })
     # the diffed files
     assert_xml_tag(tag: 'old', attributes: { name: 'file', md5: '722d122e81cbbe543bd5520bb8678c0e', size: '4' },
-                    parent: { tag: 'file', attributes: { state: 'changed' } })
+                   parent: { tag: 'file', attributes: { state: 'changed' } })
     assert_xml_tag(tag: 'new', attributes: { name: 'file', md5: '6c7c49c0d7106a1198fb8f1b3523c971', size: '16' },
-                    parent: { tag: 'file', attributes: { state: 'changed' } })
+                   parent: { tag: 'file', attributes: { state: 'changed' } })
     # the expected file transfer
     assert_xml_tag(tag: 'source', attributes: { project: 'home:tom:branches:OBS_Maintained:pack2', package: 'pack2.BaseDistro3', rev: '33fed2157de2517bc62894b3fdfd485c' })
     assert_xml_tag(tag: 'target', attributes: { project: 'My:Maintenance', releaseproject: 'BaseDistro3' })
@@ -539,15 +539,15 @@ class ChannelMaintenanceTests < ActionDispatch::IntegrationTest
     get "/search/published/binary/id?match=project='" + incident_project + "'"
     assert_response :success
     assert_xml_tag tag: 'binary', attributes: { name: 'package', project: incident_project, package: 'patchinfo',
-                                                      repository: 'BaseDistro3', version: '1.0', release: '1', arch: 'i586',
-                                                      filename: 'package-1.0-1.i586.rpm',
-                                                      filepath: 'My:/Maintenance:/0/BaseDistro3/i586/package-1.0-1.i586.rpm',
-                                                      baseproject: 'BaseDistro3', type: 'rpm' }
+                                                repository: 'BaseDistro3', version: '1.0', release: '1', arch: 'i586',
+                                                filename: 'package-1.0-1.i586.rpm',
+                                                filepath: 'My:/Maintenance:/0/BaseDistro3/i586/package-1.0-1.i586.rpm',
+                                                baseproject: 'BaseDistro3', type: 'rpm' }
     assert_xml_tag tag: 'binary', attributes: { name: 'package', project: incident_project, package: 'patchinfo',
-                                                      repository: 'BaseDistro3Channel', version: '1.0', release: '1', arch: 'i586',
-                                                      filename: 'package-1.0-1.i586.rpm',
-                                                      filepath: 'My:/Maintenance:/0/BaseDistro3Channel/rpm/i586/package-1.0-1.i586.rpm',
-                                                      baseproject: 'BaseDistro3Channel', type: 'rpm' }
+                                                repository: 'BaseDistro3Channel', version: '1.0', release: '1', arch: 'i586',
+                                                filename: 'package-1.0-1.i586.rpm',
+                                                filepath: 'My:/Maintenance:/0/BaseDistro3Channel/rpm/i586/package-1.0-1.i586.rpm',
+                                                baseproject: 'BaseDistro3Channel', type: 'rpm' }
 
     # create release request
     post '/request?cmd=create', params: '<request>
@@ -627,13 +627,13 @@ class ChannelMaintenanceTests < ActionDispatch::IntegrationTest
                    parent: { tag: 'action', attributes: { type: 'submit' } }
     # channel package is not released
     assert_no_xml_tag tag: 'source', attributes: { project: 'My:Maintenance:0', package: 'BaseDistro3.Channel' },
-                   parent: { tag: 'action', attributes: { type: 'maintenance_release' } }
+                      parent: { tag: 'action', attributes: { type: 'maintenance_release' } }
     # but it has a source change, so submit action
     assert_xml_tag tag: 'source', attributes: { project: 'My:Maintenance:0', package: 'BaseDistro3.Channel' },
                    parent: { tag: 'action', attributes: { type: 'submit' } }
     # no release patchinfo into channel
     assert_no_xml_tag tag: 'target', attributes: { project: 'Channel', package: 'patchinfo.0' },
-                   parent: { tag: 'action', attributes: { type: 'maintenance_release' } }
+                      parent: { tag: 'action', attributes: { type: 'maintenance_release' } }
     # release of patchinfos
     assert_xml_tag tag: 'target', attributes: { project: 'BaseDistro2.0:LinkedUpdateProject', package: 'patchinfo.0' },
                    parent: { tag: 'action', attributes: { type: 'maintenance_release' } }
@@ -758,7 +758,7 @@ class ChannelMaintenanceTests < ActionDispatch::IntegrationTest
     assert_xml_tag parent: { tag: 'binary', attributes: { name: 'package_newweaktags', version: '1.0', release: '1', arch: 'x86_64' } },
                    tag: 'publish', attributes: { package: 'pack2' }
     assert_no_xml_tag parent: { tag: 'binary', attributes: { name: 'package_newweaktags', version: '1.0', release: '1', arch: 'i586' } },
-                   tag: 'obsolete'
+                      tag: 'obsolete'
     assert_xml_tag parent: { tag: 'binary', attributes:                      { name: 'package', version: '1.0', release: '1', arch: 'i586' } },
                    tag: 'build', attributes: { time: '2014-07-03 12:26:54 UTC' }
     assert_xml_tag parent: { tag: 'binary', attributes:                      { name: 'package', version: '1.0', release: '1', arch: 'i586' } },

--- a/src/api/test/functional/configurations_controller_test.rb
+++ b/src/api/test/functional/configurations_controller_test.rb
@@ -41,7 +41,7 @@ class ConfigurationsControllerTest < ActionDispatch::IntegrationTest
     assert_xml_tag parent: { tag: 'schedulers' },
                    tag: 'arch', content: 's390x'
     assert_no_xml_tag parent: { tag: 'schedulers' },
-                   tag: 'arch', content: 'i586'
+                      tag: 'arch', content: 'i586'
 
     # overwriting options.yml is not allowed
     ::Configuration::OPTIONS_YML[:registration] = 'allow'
@@ -65,6 +65,6 @@ class ConfigurationsControllerTest < ActionDispatch::IntegrationTest
     assert_xml_tag parent: { tag: 'schedulers' },
                    tag: 'arch', content: 'i586'
     assert_no_xml_tag parent: { tag: 'schedulers' },
-                   tag: 'arch', content: 's390x'
+                      tag: 'arch', content: 's390x'
   end
 end

--- a/src/api/test/functional/distributions_controller_test.rb
+++ b/src/api/test/functional/distributions_controller_test.rb
@@ -108,15 +108,15 @@ class DistributionsControllerTest < ActionDispatch::IntegrationTest
     assert_xml_tag tag: 'repository', content: 'standard'
     assert_xml_tag tag: 'link', content: 'http://www.opensuse.org/'
     assert_xml_tag tag: 'icon', attributes: { url: 'https://static.opensuse.org/distributions/logos/opensuse-12.2-8.png',
-                                                    width: '8', height: '8' }
+                                              width: '8', height: '8' }
     # local repos
     assert_no_xml_tag parent: { tag: 'distribution', attributes: { vendor: 'openSUSE', version: '1.0' } },
-                   tag: 'architecture'
+                      tag: 'architecture'
     assert_xml_tag parent: { tag: 'distribution', attributes: { vendor: 'OBS', version: 'Base' } },
                    tag: 'architecture', content: 'x86_64'
     # remote repos
     assert_no_xml_tag parent: { tag: 'distribution', attributes: { vendor: 'openSUSE', version: 'Factory' } },
-                   tag: 'architecture'
+                      tag: 'architecture'
     assert_xml_tag parent: { tag: 'distribution', attributes: { vendor: 'openSUSE', version: '12.2' } },
                    tag: 'architecture', content: 'aarch64'
   end

--- a/src/api/test/functional/kgraft_maintenance_test.rb
+++ b/src/api/test/functional/kgraft_maintenance_test.rb
@@ -257,18 +257,18 @@ class MaintenanceTests < ActionDispatch::IntegrationTest
     get "/build/#{incident_project}/_result"
     assert_response :success
     assert_xml_tag parent: { tag: 'result', attributes: { repository: kernel_incident_project.tr(':', '_'), arch: 'i586', code: 'building' } },
-               tag: 'status', attributes: { package: "kgraft-incident-0.#{kernel_incident_project.tr(':', '_')}", code: 'scheduled' }
+                   tag: 'status', attributes: { package: "kgraft-incident-0.#{kernel_incident_project.tr(':', '_')}", code: 'scheduled' }
     assert_xml_tag parent: { tag: 'result', attributes: { repository: kernel_incident_project.tr(':', '_'), arch: 'i586', code: 'building' } },
-               tag: 'status', attributes: { package: 'kgraft-GA.BaseDistro2.0', code: 'disabled' }
+                   tag: 'status', attributes: { package: 'kgraft-GA.BaseDistro2.0', code: 'disabled' }
     assert_xml_tag parent: { tag: 'result', attributes: { repository: kernel_incident_project.tr(':', '_'), arch: 'i586', code: 'building' } },
-               tag: 'status', attributes: { package: 'BaseDistro2.Channel', code: 'disabled' }
+                   tag: 'status', attributes: { package: 'BaseDistro2.Channel', code: 'disabled' }
     assert_xml_tag parent: { tag: 'result', attributes: { repository: kernel_incident_project.tr(':', '_'), arch: 'i586', code: 'building' } },
-               tag: 'status', attributes: { package: 'patchinfo', code: 'blocked' }
+                   tag: 'status', attributes: { package: 'patchinfo', code: 'blocked' }
     assert_xml_tag parent: { tag: 'result', attributes: { repository: 'BaseDistro2Channel', arch: 'i586' } }
     assert_xml_tag parent: { tag: 'result', attributes: { repository: 'BaseDistro2.0', arch: 'i586', code: 'building' } },
-               tag: 'status', attributes: { package: 'kgraft-GA.BaseDistro2.0', code: 'scheduled' }
+                   tag: 'status', attributes: { package: 'kgraft-GA.BaseDistro2.0', code: 'scheduled' }
     assert_xml_tag parent: { tag: 'result', attributes: { repository: 'BaseDistro2.0', arch: 'i586', code: 'building' } },
-               tag: 'status', attributes: { package: 'patchinfo', code: 'blocked' }
+                   tag: 'status', attributes: { package: 'patchinfo', code: 'blocked' }
 
     # upload build result as a worker would do
     # Those binaries will get picked up based on previously made channel configurations
@@ -296,9 +296,9 @@ class MaintenanceTests < ActionDispatch::IntegrationTest
     get "/build/#{incident_project}/_result"
     assert_response :success
     assert_xml_tag parent: { tag: 'result', attributes: { repository: 'BaseDistro2Channel', arch: 'i586', state: 'published' } },
-               tag: 'status', attributes: { package: 'BaseDistro2.Channel', code: 'succeeded' }
+                   tag: 'status', attributes: { package: 'BaseDistro2.Channel', code: 'succeeded' }
     assert_xml_tag parent: { tag: 'result', attributes: { repository: 'BaseDistro2Channel', arch: 'i586', state: 'published' } },
-               tag: 'status', attributes: { package: 'patchinfo', code: 'succeeded' }
+                   tag: 'status', attributes: { package: 'patchinfo', code: 'succeeded' }
     get "/build/#{incident_project}/BaseDistro2Channel/i586/patchinfo/"
     assert_response :success
 
@@ -322,20 +322,20 @@ class MaintenanceTests < ActionDispatch::IntegrationTest
     # GM project may be locked, must not appear
     assert_no_xml_tag(tag: 'target', attributes: { project: 'BaseDistro2.0' })
     assert_xml_tag(parent: { tag: 'action', attributes: { type: 'maintenance_release' } },
-                    tag: 'target', attributes: { project: 'BaseDistro2.0:LinkedUpdateProject', package: 'kgraft-incident-0.1' })
+                   tag: 'target', attributes: { project: 'BaseDistro2.0:LinkedUpdateProject', package: 'kgraft-incident-0.1' })
     # code stream gets the sources of the packages
     assert_xml_tag(parent: { tag: 'action', attributes: { type: 'maintenance_release' } },
-                    tag: 'source', attributes: { project: incident_project, package: 'kgraft-GA.BaseDistro2.0' })
+                   tag: 'source', attributes: { project: incident_project, package: 'kgraft-GA.BaseDistro2.0' })
     assert_xml_tag(parent: { tag: 'action', attributes: { type: 'maintenance_release' } },
-                    tag: 'target', attributes: { project: 'BaseDistro2.0:LinkedUpdateProject', package: 'kgraft-GA.1' })
+                   tag: 'target', attributes: { project: 'BaseDistro2.0:LinkedUpdateProject', package: 'kgraft-GA.1' })
     # update channel file
     assert_xml_tag(parent: { tag: 'action', attributes: { type: 'submit' } },
-                    tag: 'target', attributes: { project: 'Channel', package: 'BaseDistro2' })
+                   tag: 'target', attributes: { project: 'Channel', package: 'BaseDistro2' })
     # release to channels
     assert_xml_tag(parent: { tag: 'action', attributes: { type: 'maintenance_release' } },
-                    tag: 'source', attributes: { project: incident_project, package: 'patchinfo' })
+                   tag: 'source', attributes: { project: incident_project, package: 'patchinfo' })
     assert_xml_tag(parent: { tag: 'action', attributes: { type: 'maintenance_release' } },
-                    tag: 'target', attributes: { project: 'BaseDistro2Channel', package: 'patchinfo.1' })
+                   tag: 'target', attributes: { project: 'BaseDistro2Channel', package: 'patchinfo.1' })
     node = Xmlhash.parse(@response.body)
     assert node['id']
     reqid = node['id']

--- a/src/api/test/functional/maintenance_test.rb
+++ b/src/api/test/functional/maintenance_test.rb
@@ -650,12 +650,12 @@ class MaintenanceTests < ActionDispatch::IntegrationTest
     assert_xml_tag parent: { tag: 'build' }, tag: 'disable'
 
     assert_xml_tag parent: { tag: 'repository', attributes: { name: 'BaseDistro2.0_LinkedUpdateProject' } },
-               tag: 'path', attributes: { repository: 'BaseDistro2LinkedUpdateProject_repo', project: 'BaseDistro2.0:LinkedUpdateProject' }
+                   tag: 'path', attributes: { repository: 'BaseDistro2LinkedUpdateProject_repo', project: 'BaseDistro2.0:LinkedUpdateProject' }
     assert_xml_tag parent: { tag: 'repository', attributes: { name: 'BaseDistro2.0_LinkedUpdateProject' } },
-               tag: 'arch', content: 'i586'
+                   tag: 'arch', content: 'i586'
 
     assert_xml_tag parent: { tag: 'repository', attributes: { name: 'BaseDistro_Update' } },
-               tag: 'path', attributes: { repository: 'BaseDistroUpdateProject_repo', project: 'BaseDistro:Update' }
+                   tag: 'path', attributes: { repository: 'BaseDistroUpdateProject_repo', project: 'BaseDistro:Update' }
 
     assert_xml_tag(tag: 'releasetarget', attributes: { project: 'BaseDistro:Update', repository: 'BaseDistroUpdateProject_repo', trigger: nil })
 
@@ -1119,24 +1119,24 @@ class MaintenanceTests < ActionDispatch::IntegrationTest
     assert_response :success
     # BaseDistro2.0_BaseDistro2LinkedUpdateProject_repo
     assert_xml_tag parent: { tag: 'result', attributes: { repository: 'BaseDistro2.0_LinkedUpdateProject', arch: 'i586', state: 'building' } },
-               tag: 'status', attributes: { package: 'pack2.BaseDistro2.0_LinkedUpdateProject', code: 'scheduled' }
+                   tag: 'status', attributes: { package: 'pack2.BaseDistro2.0_LinkedUpdateProject', code: 'scheduled' }
     assert_xml_tag parent: { tag: 'result', attributes: { repository: 'BaseDistro2.0_LinkedUpdateProject', arch: 'i586' } },
-               tag: 'status', attributes: { package: 'pack2.BaseDistro3', code: 'disabled' }
+                   tag: 'status', attributes: { package: 'pack2.BaseDistro3', code: 'disabled' }
     assert_xml_tag parent: { tag: 'result', attributes: { repository: 'BaseDistro2.0_LinkedUpdateProject', arch: 'i586' } },
-               tag: 'status', attributes: { package: 'pack2.linked.BaseDistro2.0_LinkedUpdateProject', code: 'scheduled' }
+                   tag: 'status', attributes: { package: 'pack2.linked.BaseDistro2.0_LinkedUpdateProject', code: 'scheduled' }
     assert_xml_tag parent: { tag: 'result', attributes: { repository: 'BaseDistro2.0_LinkedUpdateProject', arch: 'i586' } },
-               tag: 'status', attributes: { package: 'packNew.BaseDistro2.0_LinkedUpdateProject', code: 'scheduled' }
+                   tag: 'status', attributes: { package: 'packNew.BaseDistro2.0_LinkedUpdateProject', code: 'scheduled' }
     assert_xml_tag parent: { tag: 'result', attributes: { repository: 'BaseDistro2.0_LinkedUpdateProject', arch: 'i586' } },
-               tag: 'status', attributes: { package: 'patchinfo', code: 'blocked' }
+                   tag: 'status', attributes: { package: 'patchinfo', code: 'blocked' }
     assert_xml_tag parent: { tag: 'result', attributes: { repository: 'BaseDistro2.0_LinkedUpdateProject', arch: 'x86_64', state: 'building' } },
-               tag: 'status', attributes: { package: 'patchinfo', code: 'excluded' }
+                   tag: 'status', attributes: { package: 'patchinfo', code: 'excluded' }
     # BaseDistro3_BaseDistro3_repo
     assert_xml_tag parent: { tag: 'result', attributes: { repository: 'BaseDistro3', arch: 'i586', state: 'building' } },
-               tag: 'status', attributes: { package: 'pack2.BaseDistro2.0_LinkedUpdateProject', code: 'disabled' }
+                   tag: 'status', attributes: { package: 'pack2.BaseDistro2.0_LinkedUpdateProject', code: 'disabled' }
     assert_xml_tag parent: { tag: 'result', attributes: { repository: 'BaseDistro3', arch: 'i586' } },
-               tag: 'status', attributes: { package: 'packNew.BaseDistro2.0_LinkedUpdateProject', code: 'disabled' }
+                   tag: 'status', attributes: { package: 'packNew.BaseDistro2.0_LinkedUpdateProject', code: 'disabled' }
     assert_xml_tag parent: { tag: 'result', attributes: { repository: 'BaseDistro3', arch: 'i586' } },
-               tag: 'status', attributes: { package: 'pack2.BaseDistro3', code: 'scheduled' }
+                   tag: 'status', attributes: { package: 'pack2.BaseDistro3', code: 'scheduled' }
 
     # try to create release request too early
     post '/request?cmd=create', params: '<request>
@@ -1174,7 +1174,7 @@ class MaintenanceTests < ActionDispatch::IntegrationTest
     get "/build/#{incident_project}/_result"
     assert_response :success
     assert_xml_tag parent: { tag: 'result', attributes: { repository: 'BaseDistro2.0_LinkedUpdateProject', arch: 'i586', state: 'unpublished' } },
-               tag: 'status', attributes: { package: 'patchinfo', code: 'broken' }
+                   tag: 'status', attributes: { package: 'patchinfo', code: 'broken' }
     # try to create release request nevertheless
     post '/request?cmd=create&addrevision=1', params: '<request>
                                    <action type="maintenance_release">
@@ -1197,7 +1197,7 @@ class MaintenanceTests < ActionDispatch::IntegrationTest
     get "/build/#{incident_project}/_result"
     assert_response :success
     assert_xml_tag parent: { tag: 'result', attributes: { repository: 'BaseDistro2.0_LinkedUpdateProject', arch: 'i586', state: 'unpublished' } },
-               tag: 'status', attributes: { package: 'patchinfo', code: 'failed' }
+                   tag: 'status', attributes: { package: 'patchinfo', code: 'failed' }
     # fix it again
     pi.css('binary').remove
     put "/source/#{incident_project}/patchinfo/_patchinfo", params: pi.to_xml
@@ -1209,7 +1209,7 @@ class MaintenanceTests < ActionDispatch::IntegrationTest
     get "/build/#{incident_project}/_result"
     assert_response :success
     assert_xml_tag parent: { tag: 'result', attributes: { repository: 'BaseDistro2.0_LinkedUpdateProject', arch: 'i586', state: 'unpublished' } },
-               tag: 'status', attributes: { package: 'patchinfo', code: 'succeeded' }
+                   tag: 'status', attributes: { package: 'patchinfo', code: 'succeeded' }
     get "/build/#{incident_project}/BaseDistro2.0_LinkedUpdateProject/i586/patchinfo/_history"
     assert_response :success
 
@@ -1277,11 +1277,11 @@ class MaintenanceTests < ActionDispatch::IntegrationTest
     post '/source', params: { cmd: 'branch', dryrun: 1, package: 'pack2' }
     assert_response :success
     assert_xml_tag(parent: { tag: 'package', attributes: { project: 'BaseDistro2.0:LinkedUpdateProject', package: 'pack2' } },
-                    tag: 'devel',
-                    attributes: { project: incident_project, package: 'pack2.BaseDistro2.0_LinkedUpdateProject' })
+                   tag: 'devel',
+                   attributes: { project: incident_project, package: 'pack2.BaseDistro2.0_LinkedUpdateProject' })
     assert_xml_tag(parent: { tag: 'package', attributes: { project: 'BaseDistro3', package: 'pack2' } },
-                    tag: 'devel',
-                    attributes: { project: incident_project, package: 'pack2.BaseDistro3' })
+                   tag: 'devel',
+                   attributes: { project: incident_project, package: 'pack2.BaseDistro3' })
 
     # create release request for real
     post '/request?cmd=create&addrevision=1', params: '<request>

--- a/src/api/test/functional/product_test.rb
+++ b/src/api/test/functional/product_test.rb
@@ -18,7 +18,7 @@ class ProductTests < ActionDispatch::IntegrationTest
       tag:        'product',
       attributes: { name: 'simple', originproject: 'home:tom:temporary', originpackage: '_product' }
     },
-      tag: 'cpe', content: 'cpe:/o:obs_fuzzies:simple:13.1'
+                   tag: 'cpe', content: 'cpe:/o:obs_fuzzies:simple:13.1'
     get "#{prefix}/source/home:tom:temporary?view=verboseproductlist&expand=1"
     assert_response :success
     assert_xml_tag parent: { tag:        'product',

--- a/src/api/test/functional/release_management_test.rb
+++ b/src/api/test/functional/release_management_test.rb
@@ -184,9 +184,9 @@ class ReleaseManagementTests < ActionDispatch::IntegrationTest
                     code:       'published',
                     state:      'published' }
     },
-      tag: 'status',
-      attributes: { package: 'TestPack',
-                    code:    'succeeded' }
+                   tag: 'status',
+                   attributes: { package: 'TestPack',
+                                 code:    'succeeded' }
     assert_xml_tag parent: {
       tag:        'result',
       attributes: { project:    'home:Iggy',
@@ -195,8 +195,8 @@ class ReleaseManagementTests < ActionDispatch::IntegrationTest
                     code:       'published',
                     state:      'published' }
     },
-      tag: 'status', attributes: { package: 'TestPack',
-                                   code:    'succeeded' }
+                   tag: 'status', attributes: { package: 'TestPack',
+                                                code:    'succeeded' }
 
     # copy project with binaries
     post '/source/IggyHomeCopy?cmd=copy&oproject=home:Iggy&noservice=1&withbinaries=1&nodelay=1'
@@ -212,16 +212,16 @@ class ReleaseManagementTests < ActionDispatch::IntegrationTest
     assert_response :success
 
     assert_xml_tag parent: { tag: 'project', attributes: { name: 'IggyHomeCopy' } },
-      tag: 'repository', attributes: { name: '10.2' }
+                   tag: 'repository', attributes: { name: '10.2' }
 
     assert_xml_tag parent: { tag: 'repository', attributes: { name: '10.2' } },
-      tag: 'path', attributes: { project: 'BaseDistro', repository: 'BaseDistro_repo' }
+                   tag: 'path', attributes: { project: 'BaseDistro', repository: 'BaseDistro_repo' }
 
     assert_xml_tag parent: { tag: 'repository', attributes: { name: '10.2' } },
-      tag: 'arch', content: 'i586'
+                   tag: 'arch', content: 'i586'
 
     assert_xml_tag parent: { tag: 'repository', attributes: { name: '10.2' } },
-      tag: 'arch', content: 'x86_64'
+                   tag: 'arch', content: 'x86_64'
 
     # check build results are copied correctly
     get '/build/IggyHomeCopy/_result'
@@ -233,8 +233,8 @@ class ReleaseManagementTests < ActionDispatch::IntegrationTest
                     code:       'published',
                     state:      'published' }
     },
-      tag: 'status',
-      attributes: { package: 'TestPack', code: 'succeeded' }
+                   tag: 'status',
+                   attributes: { package: 'TestPack', code: 'succeeded' }
 
     assert_xml_tag parent: {
       tag:        'result',
@@ -244,8 +244,8 @@ class ReleaseManagementTests < ActionDispatch::IntegrationTest
                     code:       'published',
                     state:      'published' }
     },
-      tag: 'status',
-      attributes: { package: 'TestPack', code: 'succeeded' }
+                   tag: 'status',
+                   attributes: { package: 'TestPack', code: 'succeeded' }
 
     # check that the same binaries are copied
     get '/build/home:Iggy/10.2/i586/TestPack'

--- a/src/api/test/functional/request_controller_test.rb
+++ b/src/api/test/functional/request_controller_test.rb
@@ -1012,11 +1012,11 @@ class RequestControllerTest < ActionDispatch::IntegrationTest
                      'by_user' => 'tom',
                      'comment' => 'reopen2',
                      'history' => [{ 'who' => 'tom', 'when' => '2010-07-12T00:00:04',
-                                    'description' => 'Review got accepted',
-                                    'comment' => 'review2' },
+                                     'description' => 'Review got accepted',
+                                     'comment' => 'review2' },
                                    { 'who' => 'tom', 'when' => '2010-07-12T00:00:05',
-                                    'description' => 'Review got reopened',
-                                    'comment' => 'reopen2' }]
+                                     'description' => 'Review got reopened',
+                                     'comment' => 'reopen2' }]
                    }],
                    'history' => [
                      { 'who'         => 'Iggy',
@@ -3379,12 +3379,12 @@ class RequestControllerTest < ActionDispatch::IntegrationTest
                                   'comment' => {} },
                    'history' =>
                                 [{ 'who' => 'Iggy', 'when' => '2010-07-12T00:00:00',
-                         'description' => 'Request created' },
+                                   'description' => 'Request created' },
                                  { 'who' => 'Iggy', 'when' => '2010-07-12T00:00:01',
-                                  'description' => 'Request got declined',
-                                  'comment' => "The target project 'home:Iggy:fordecline' has been removed" },
+                                   'description' => 'Request got declined',
+                                   'comment' => "The target project 'home:Iggy:fordecline' has been removed" },
                                  { 'who' => 'Iggy', 'when' => '2010-07-12T00:00:02',
-                                  'description' => 'Request got revoked' }] }, node)
+                                   'description' => 'Request got revoked' }] }, node)
   end
 
   def test_check_target_maintainer

--- a/src/api/test/functional/search_controller_test.rb
+++ b/src/api/test/functional/search_controller_test.rb
@@ -515,32 +515,32 @@ class SearchControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
     assert_xml_tag tag: 'collection', children: { count: 1 }
     assert_xml_tag parent: { tag: 'owner', children: { count: 2 },
-                                attributes: { rootproject: '', project: 'home:Iggy' } },
+                             attributes: { rootproject: '', project: 'home:Iggy' } },
                    tag: 'person', attributes: { name: 'Iggy', role: 'maintainer' }
 
     get '/search/owner?project=home:Iggy&package=TestPack'
     assert_xml_tag tag: 'collection', children: { count: 2 }
     assert_xml_tag parent: { tag: 'owner', children: { count: 4 },
-                                attributes: { project: 'home:Iggy', package: 'TestPack' } },
+                             attributes: { project: 'home:Iggy', package: 'TestPack' } },
                    tag: 'person', attributes: { name: 'fred', role: 'maintainer' }
     assert_xml_tag parent: { tag: 'owner', children: { count: 4 },
-                                attributes: { project: 'home:Iggy', package: 'TestPack' } },
+                             attributes: { project: 'home:Iggy', package: 'TestPack' } },
                    tag: 'person', attributes: { name: 'Iggy', role: 'bugowner' }
     assert_xml_tag parent: { tag: 'owner', children: { count: 4 },
-                                attributes: { project: 'home:Iggy', package: 'TestPack' } },
+                             attributes: { project: 'home:Iggy', package: 'TestPack' } },
                    tag: 'person', attributes: { name: 'Iggy', role: 'maintainer' }
     assert_xml_tag parent: { tag: 'owner', children: { count: 4 },
-                                attributes: { project: 'home:Iggy', package: 'TestPack' } },
+                             attributes: { project: 'home:Iggy', package: 'TestPack' } },
                    tag: 'group', attributes: { name: 'test_group_b', role: 'maintainer' }
     assert_xml_tag parent: { tag: 'owner', children: { count: 2 },
-                                attributes: { project: 'home:Iggy' } },
+                             attributes: { project: 'home:Iggy' } },
                    tag: 'person', attributes: { name: 'hidden_homer', role: 'maintainer' }
 
     get '/search/owner?project=home:Iggy&package=TestPack&filter=bugowner'
     # no bugowner defined for the project => no owner node for the project
     assert_xml_tag tag: 'collection', children: { count: 1 }
     assert_xml_tag parent: { tag: 'owner', children: { count: 1 },
-                                attributes: { project: 'home:Iggy', package: 'TestPack' } },
+                             attributes: { project: 'home:Iggy', package: 'TestPack' } },
                    tag: 'person', attributes: { name: 'Iggy', role: 'bugowner' }
 
     get '/search/owner?project=home:coolo:test'

--- a/src/api/test/functional/source_controller_test.rb
+++ b/src/api/test/functional/source_controller_test.rb
@@ -3261,7 +3261,7 @@ class SourceControllerTest < ActionDispatch::IntegrationTest
     assert_xml_tag(tag: 'entry', attributes: { name: 'file_in_linked_package' })
     assert_xml_tag(tag: 'entry', attributes: { name: '_link' })
     assert_xml_tag(tag: 'linkinfo', attributes: { project: 'UseRemoteInstance', package: 'pack2',
-                                                        srcmd5: 'd3e3fafcc29140ff418220a649df8070', xsrcmd5: '3481fc5f1445a65a2d463b8adf26d3a9', lsrcmd5: 'e6a8595663acb2095c62824bf457142c' })
+                                                  srcmd5: 'd3e3fafcc29140ff418220a649df8070', xsrcmd5: '3481fc5f1445a65a2d463b8adf26d3a9', lsrcmd5: 'e6a8595663acb2095c62824bf457142c' })
     get '/source/kde4/temporary2?expand=1'
     assert_response :success
     assert_xml_tag(tag: 'entry', attributes: { name: 'package.spec' })

--- a/src/api/test/functional/source_services_test.rb
+++ b/src/api/test/functional/source_services_test.rb
@@ -52,9 +52,9 @@ class SourceServicesTest < ActionDispatch::IntegrationTest
     assert_response :success
     assert_xml_tag(tag: 'service', attributes: { name: 'download_files' })
     assert_xml_tag(parent: { tag: 'service', attributes: { name: 'download_url' } },
-                    tag: 'param', attributes: { name: 'host' }, content: 'blahfasel')
+                   tag: 'param', attributes: { name: 'host' }, content: 'blahfasel')
     assert_xml_tag(parent: { tag: 'service', attributes: { name: 'set_version' } },
-                    tag: 'param', attributes: { name: 'version' }, content: '0815')
+                   tag: 'param', attributes: { name: 'version' }, content: '0815')
 
     # cleanup
     login_king

--- a/src/api/test/unit/binary_release.rb
+++ b/src/api/test/unit/binary_release.rb
@@ -19,7 +19,7 @@ class BinaryReleaseTest < ActiveSupport::TestCase
     xml = br.render_xml
     assert_xml_tag xml, tag: 'binary',
                         attributes: { project: 'BaseDistro3', repository: 'BaseDistro3_repo',
-                                         name: 'package', version: '1.0', release: '1', arch: 'i586' }
+                                      name: 'package', version: '1.0', release: '1', arch: 'i586' }
     assert_xml_tag xml, tag: 'maintainer', content: 'Iggy'
     assert_xml_tag xml, tag: 'operation', content: 'added'
     assert_xml_tag xml, tag: 'supportstatus', content: 'l3'
@@ -55,17 +55,17 @@ class BinaryReleaseTest < ActiveSupport::TestCase
 
   def test_update_from_json_hash
     json = [{ 'arch' => 'i586', 'binaryarch' => 'i586', 'repository' => 'BaseDistro3_repo',
-             'release' => '1', 'name' => 'delete_me', 'project' => 'BaseDistro3', 'version' => '1.0',
-             'package' => 'pack2', 'buildtime' => '1409642056' },
+              'release' => '1', 'name' => 'delete_me', 'project' => 'BaseDistro3', 'version' => '1.0',
+              'package' => 'pack2', 'buildtime' => '1409642056' },
             { 'arch' => 'i586', 'binaryarch' => 'i586', 'name' => 'package', 'repository' => 'BaseDistro3_repo',
-             'release' => '1', 'project' => 'BaseDistro3', 'version' => '1.0',
-             'package' => 'pack2', 'buildtime' => '1409642056' },
+              'release' => '1', 'project' => 'BaseDistro3', 'version' => '1.0',
+              'package' => 'pack2', 'buildtime' => '1409642056' },
             { 'arch' => 'i586', 'binaryarch' => 'src', 'name' => 'package', 'repository' => 'BaseDistro3_repo',
-             'release' => '1', 'project' => 'BaseDistro3', 'version' => '1.0',
-             'package' => 'pack2', 'buildtime' => '1409642056' },
+              'release' => '1', 'project' => 'BaseDistro3', 'version' => '1.0',
+              'package' => 'pack2', 'buildtime' => '1409642056' },
             { 'binaryarch' => 'x86_64', 'arch' => 'i586', 'package' => 'pack2', 'project' => 'BaseDistro3',
-             'version' => '1.0', 'release' => '1', 'repository' => 'BaseDistro3_repo',
-             'name' => 'package_newweaktags', 'buildtime' => '1409642056' }]
+              'version' => '1.0', 'release' => '1', 'repository' => 'BaseDistro3_repo',
+              'name' => 'package_newweaktags', 'buildtime' => '1409642056' }]
 
     r = Repository.find_by_project_and_name('BaseDistro3', 'BaseDistro3_repo')
 
@@ -77,29 +77,29 @@ class BinaryReleaseTest < ActiveSupport::TestCase
 
     # modify just one timestampe
     json = [{ 'arch' => 'i586', 'binaryarch' => 'i586', 'repository' => 'BaseDistro3_repo',
-             'release' => '1', 'name' => 'delete_me', 'project' => 'BaseDistro3', 'version' => '1.0',
-             'package' => 'pack2', 'buildtime' => '1409642056' },
+              'release' => '1', 'name' => 'delete_me', 'project' => 'BaseDistro3', 'version' => '1.0',
+              'package' => 'pack2', 'buildtime' => '1409642056' },
             { 'arch' => 'i586', 'binaryarch' => 'i586', 'name' => 'package', 'repository' => 'BaseDistro3_repo',
-             'release' => '1', 'project' => 'BaseDistro3', 'version' => '1.0',
-             'package' => 'pack2', 'buildtime' => '1409642056' },
+              'release' => '1', 'project' => 'BaseDistro3', 'version' => '1.0',
+              'package' => 'pack2', 'buildtime' => '1409642056' },
             { 'arch' => 'i586', 'binaryarch' => 'src', 'name' => 'package', 'repository' => 'BaseDistro3_repo',
-             'release' => '1', 'project' => 'BaseDistro3', 'version' => '1.0',
-             'package' => 'pack2', 'buildtime' => '1409642056' },
+              'release' => '1', 'project' => 'BaseDistro3', 'version' => '1.0',
+              'package' => 'pack2', 'buildtime' => '1409642056' },
             { 'binaryarch' => 'x86_64', 'arch' => 'i586', 'package' => 'pack2', 'project' => 'BaseDistro3',
-             'version' => '1.0', 'release' => '1', 'repository' => 'BaseDistro3_repo',
-             'name' => 'package_newweaktags', 'buildtime' => '1409642057' }]
+              'version' => '1.0', 'release' => '1', 'repository' => 'BaseDistro3_repo',
+              'name' => 'package_newweaktags', 'buildtime' => '1409642057' }]
     BinaryRelease.update_binary_releases_via_json(r, json)
     assert_equal count, BinaryRelease.all.length - 1 # one entry added
   end
 
   def test_container_handling
     json = [{ 'arch' => 'i586', 'binaryarch' => 'i586', 'repository' => 'BaseDistro3_repo',
-             'release' => '0', 'name' => 'my_container', 'project' => 'BaseDistro3', 'version' => '0',
-             'package' => 'pack2', 'buildtime' => '1409642056',
-             'ismedium' => 'my_container.docker.tar.xz' },
+              'release' => '0', 'name' => 'my_container', 'project' => 'BaseDistro3', 'version' => '0',
+              'package' => 'pack2', 'buildtime' => '1409642056',
+              'ismedium' => 'my_container.docker.tar.xz' },
             { 'arch' => 'i586', 'binaryarch' => 'i586', 'name' => 'package', 'repository' => 'BaseDistro3_repo',
-             'release' => '1', 'project' => 'BaseDistro3', 'version' => '1.0',
-             'package' => 'pack3', 'buildtime' => '1409642056', 'medium' => 'my_container.docker.tar.xz' }]
+              'release' => '1', 'project' => 'BaseDistro3', 'version' => '1.0',
+              'package' => 'pack3', 'buildtime' => '1409642056', 'medium' => 'my_container.docker.tar.xz' }]
     r = Repository.find_by_project_and_name('BaseDistro3', 'BaseDistro3_repo')
 
     BinaryRelease.update_binary_releases_via_json(r, json)

--- a/src/api/test/unit/project_test.rb
+++ b/src/api/test/unit/project_test.rb
@@ -1233,16 +1233,16 @@ class ProjectTest < ActiveSupport::TestCase
       child = projects('Apache')
 
       parent2.linking_to.create(project: parent2,
-                                 linked_db_project_id: projects('home_Iggy').id,
-                                 position: 1)
+                                linked_db_project_id: projects('home_Iggy').id,
+                                position: 1)
 
       child.linking_to.create(project: child,
-                                 linked_db_project_id: parent1.id,
-                                 position: 1)
+                              linked_db_project_id: parent1.id,
+                              position: 1)
 
       child.linking_to.create(project: child,
-                                  linked_db_project_id: parent2.id,
-                                  position: 2)
+                              linked_db_project_id: parent2.id,
+                              position: 2)
 
       result = projects('home_Iggy').packages + child.packages + parent1.packages + parent2.packages
       result.sort! { |a, b| a.name.downcase <=> b.name.downcase }.map! { |package| [package.name, package.project.name] }
@@ -1273,12 +1273,12 @@ class ProjectTest < ActiveSupport::TestCase
       child = projects('Apache')
 
       child.linking_to.create(project: child,
-                                  linked_db_project_id: parent1.id,
-                                  position: 1)
+                              linked_db_project_id: parent1.id,
+                              position: 1)
 
       child.linking_to.create(project: child,
-                                  linked_db_project_id: parent2.id,
-                                  position: 2)
+                              linked_db_project_id: parent2.id,
+                              position: 2)
 
       pack2 = parent2.packages.where(name: 'pack2').first
       child.packages << pack2.dup
@@ -1298,12 +1298,12 @@ class ProjectTest < ActiveSupport::TestCase
       child = projects('Apache')
 
       child.linking_to.create(project: child,
-                                  linked_db_project_id: base_distro_update.id,
-                                  position: 1)
+                              linked_db_project_id: base_distro_update.id,
+                              position: 1)
 
       child.linking_to.create(project: child,
-                                  linked_db_project_id: base_distro.id,
-                                  position: 2)
+                              linked_db_project_id: base_distro.id,
+                              position: 2)
 
       pack2 = base_distro.packages.where(name: 'pack2').first
       base_distro_update.packages << pack2.dup


### PR DESCRIPTION
In a codebase that is otherwise auto aligned, I find the super inconsistent hash indentation pretty annoying. Sometimes it's 2 chars left, sometimes 3 right sometimes even inconsistent in itself.

So @openSUSE/open-build-service - this cop does autocorrect, so it's a simple vote, no extra work required.