### PR TITLE
rubocop: Change AlignHash option to table

### DIFF
--- a/src/api/.rubocop.yml
+++ b/src/api/.rubocop.yml
@@ -224,3 +224,9 @@ Style/MethodCallWithArgsParentheses:
     - write
     - yield
     - ymp
+
+Layout/AlignHash:
+  EnforcedLastArgumentHashStyle: ignore_implicit
+  EnforcedHashRocketStyle: table
+  EnforcedColonStyle: table
+

--- a/src/api/app/controllers/cloud/upload_jobs_controller.rb
+++ b/src/api/app/controllers/cloud/upload_jobs_controller.rb
@@ -30,7 +30,7 @@ module Cloud
     rescue ::Backend::Error => exception
       render_error status: 500,
                    errorcode: 'cloud_upload_job_error',
-                   message:  exception.message
+                   message: exception.message
     end
 
     private

--- a/src/api/app/controllers/trigger_controller.rb
+++ b/src/api/app/controllers/trigger_controller.rb
@@ -30,8 +30,8 @@ class TriggerController < ApplicationController
     if pkg
       # check if user has still access
       unless token.user.is_active? && token.user.can_modify?(pkg)
-        render_error message:   "no permission for package #{pkg.name} in project #{pkg.project.name}",
-                     status:    403,
+        render_error message: "no permission for package #{pkg.name} in project #{pkg.project.name}",
+                     status: 403,
                      errorcode: 'no_permission'
         return
       end

--- a/src/api/app/controllers/webui/download_on_demand_controller.rb
+++ b/src/api/app/controllers/webui/download_on_demand_controller.rb
@@ -8,7 +8,7 @@ class Webui::DownloadOnDemandController < Webui::WebuiController
     begin
       ActiveRecord::Base.transaction do
         @download_on_demand.repository.repository_architectures.where(
-          repository:   @download_on_demand.repository,
+          repository: @download_on_demand.repository,
           architecture: Architecture.find_by_name(permitted_params[:arch])
         ).first_or_create!
         @download_on_demand.save!
@@ -29,7 +29,7 @@ class Webui::DownloadOnDemandController < Webui::WebuiController
     begin
       ActiveRecord::Base.transaction do
         @download_on_demand.repository.repository_architectures.where(
-          repository:   @download_on_demand.repository,
+          repository: @download_on_demand.repository,
           architecture: Architecture.find_by_name(permitted_params[:arch])
         ).first_or_create!
         @download_on_demand.update_attributes!(permitted_params)

--- a/src/api/app/controllers/webui/main_controller.rb
+++ b/src/api/app/controllers/webui/main_controller.rb
@@ -36,10 +36,10 @@ class Webui::MainController < Webui::WebuiController
 
     @system_stats = Rails.cache.fetch('system_stats_hash', expires_in: 30.minutes) do
       {
-        projects: Project.count,
-        packages: Package.count,
+        projects:     Project.count,
+        packages:     Package.count,
         repositories: Repository.count,
-        users: User.count
+        users:        User.count
       }
     end
 

--- a/src/api/app/controllers/webui/obs_factory/distributions_controller.rb
+++ b/src/api/app/controllers/webui/obs_factory/distributions_controller.rb
@@ -6,8 +6,8 @@ module Webui::ObsFactory
 
     def show
       @staging_projects = ::ObsFactory::StagingProjectPresenter.sort(@distribution.staging_projects)
-      @versions = { source: @distribution.source_version,
-                    totest: @distribution.totest_version,
+      @versions = { source:    @distribution.source_version,
+                    totest:    @distribution.totest_version,
                     published: @distribution.published_version }
       @ring_prjs = ::ObsFactory::ObsProjectPresenter.wrap(@distribution.ring_projects)
       @standard = ::ObsFactory::ObsProjectPresenter.new(@distribution.standard_project)

--- a/src/api/app/controllers/webui/package_controller.rb
+++ b/src/api/app/controllers/webui/package_controller.rb
@@ -1136,8 +1136,8 @@ class Webui::PackageController < Webui::WebuiController
     end
 
     begin
-      @package = Package.get_by_project_and_name(@project, params[:package], use_source:           false,
-                                                                             follow_multibuild:    true,
+      @package = Package.get_by_project_and_name(@project, params[:package], use_source: false,
+                                                                             follow_multibuild: true,
                                                                              follow_project_links: true)
     rescue Package::UnknownObjectError
       redirect_to project_show_path(@project.to_param),

--- a/src/api/app/helpers/webui/buildresult_helper.rb
+++ b/src/api/app/helpers/webui/buildresult_helper.rb
@@ -1,17 +1,17 @@
 module Webui::BuildresultHelper
   STATUS_COLOR_HASH = {
-    'succeeded' => 'primary',
-    'building' => 'secondary',
-    'scheduled' => 'info',
-    'signing' => 'dark',
-    'finished' => 'dark',
-    'unresolvable' => 'danger',
-    'broken' => 'danger',
-    'failed' => 'danger',
-    'disabled' => 'black-50',
-    'blocked' => 'black-50',
+    'succeeded'         => 'primary',
+    'building'          => 'secondary',
+    'scheduled'         => 'info',
+    'signing'           => 'dark',
+    'finished'          => 'dark',
+    'unresolvable'      => 'danger',
+    'broken'            => 'danger',
+    'failed'            => 'danger',
+    'disabled'          => 'black-50',
+    'blocked'           => 'black-50',
     'scheduled_warning' => 'warning',
-    'unknown' => 'warning'
+    'unknown'           => 'warning'
   }.freeze
 
   def arch_repo_table_cell(repo, arch, package_name, status = nil, enable_help = true)

--- a/src/api/app/models/bs_request.rb
+++ b/src/api/app/models/bs_request.rb
@@ -842,13 +842,13 @@ class BsRequest < ApplicationRecord
 
   def create_new_review(opts)
     newreview = reviews.create(
-      reason:     opts[:comment],
-      by_user:    opts[:by_user],
-      by_group:   opts[:by_group],
+      reason: opts[:comment],
+      by_user: opts[:by_user],
+      by_group: opts[:by_group],
       by_project: opts[:by_project],
       by_package: opts[:by_package],
-      creator:    User.current.try(:login),
-      reviewer:   User.current.try(:login)
+      creator: User.current.try(:login),
+      reviewer: User.current.try(:login)
     )
     return newreview if newreview.valid?
     raise InvalidReview, 'Review invalid: ' + newreview.errors.full_messages.join("\n")
@@ -1308,11 +1308,11 @@ class BsRequest < ApplicationRecord
     return unless persisted? && priority_changed?
 
     HistoryElement::RequestPriorityChange.create(
-      request:               self,
+      request: self,
       # We need to have a user here
-      user:                  User.find_nobody!,
+      user: User.find_nobody!,
       description_extension: "#{priority_was} => #{priority}",
-      comment:               'Automatic priority bump: Priority of related action increased.'
+      comment: 'Automatic priority bump: Priority of related action increased.'
     )
   end
 

--- a/src/api/app/models/kiwi/image/xml_parser.rb
+++ b/src/api/app/models/kiwi/image/xml_parser.rb
@@ -67,8 +67,8 @@ module Kiwi
         @xml_document.xpath('image/packages').each do |package_group_xml|
           # FIXME: profiles should be Kiwi::Profile, not a string. It makes this easier to validate
           package_group = Kiwi::PackageGroup.new(
-            kiwi_type:    package_group_xml.attribute('type').value,
-            profiles:     package_group_xml.attribute('profiles')&.value,
+            kiwi_type: package_group_xml.attribute('type').value,
+            profiles: package_group_xml.attribute('profiles')&.value,
             pattern_type: package_group_xml.attribute('patternType')&.value
           )
 
@@ -100,9 +100,9 @@ module Kiwi
 
         Kiwi::Description.new(
           description_type: description_element.attribute('type')&.value.to_s,
-          author:           description_element.xpath('author')&.text,
-          contact:          description_element.xpath('contact')&.text,
-          specification:    description_element.xpath('specification')&.text
+          author: description_element.xpath('author')&.text,
+          contact: description_element.xpath('contact')&.text,
+          specification: description_element.xpath('specification')&.text
         )
       end
 
@@ -112,12 +112,12 @@ module Kiwi
 
         preference_elements.map do |preference_element|
           Kiwi::Preference.new(
-            type_image:                preference_type_image(preference_element),
-            version:                   preference_element.xpath('version')&.text,
+            type_image: preference_type_image(preference_element),
+            version: preference_element.xpath('version')&.text,
             type_containerconfig_name: preference_type_containerconfig(preference_element, 'name'),
-            type_containerconfig_tag:  preference_type_containerconfig(preference_element, 'tag'),
+            type_containerconfig_tag: preference_type_containerconfig(preference_element, 'tag'),
             # The profile is a string since creating association between new preferences/profiles is not possible
-            profile:                   preference_element.attribute('profiles')&.value
+            profile: preference_element.attribute('profiles')&.value
           )
         end
       end

--- a/src/api/app/models/kiwi/profile.rb
+++ b/src/api/app/models/kiwi/profile.rb
@@ -22,7 +22,7 @@ module Kiwi
     validates :image, presence: true
     validates :selected, inclusion: { in: [true, false] }
     validates :name, uniqueness: {
-      scope: :image,
+      scope:   :image,
       message: lambda do |object, data|
         "#{data[:value]} has already been taken for the Image ##{object.image_id}"
       end

--- a/src/api/app/models/kiwi/repository.rb
+++ b/src/api/app/models/kiwi/repository.rb
@@ -32,7 +32,7 @@ module Kiwi
     validates :imageinclude, :prefer_license, inclusion: { in: [true, false], message: 'has to be a boolean' }, allow_nil: true
     validates_associated :image, on: :update
     validates :order, uniqueness: {
-      scope: :image_id,
+      scope:   :image_id,
       message: lambda do |object, data|
         "##{data[:value]} has already been taken for the Image ##{object.image_id}"
       end

--- a/src/api/app/models/maintained_project.rb
+++ b/src/api/app/models/maintained_project.rb
@@ -3,7 +3,7 @@ class MaintainedProject < ApplicationRecord
   belongs_to :maintenance_project, class_name: 'Project', foreign_key: :maintenance_project_id
 
   validates :project_id, uniqueness: {
-    scope: :maintenance_project_id,
+    scope:   :maintenance_project_id,
     message: lambda do |object, _data|
       "is already maintained by the maintenance project ##{object.maintenance_project_id}"
     end

--- a/src/api/app/models/package.rb
+++ b/src/api/app/models/package.rb
@@ -99,7 +99,7 @@ class Package < ApplicationRecord
   validates :title, length: { maximum: 250 }
   validates :description, length: { maximum: 65_535 }
   validates :project_id, uniqueness: {
-    scope: :name,
+    scope:   :name,
     message: lambda do |object, _data|
       "##{object.project_id} already has a package with the name `#{object.name}`"
     end

--- a/src/api/app/models/status/check.rb
+++ b/src/api/app/models/status/check.rb
@@ -11,7 +11,7 @@ class Status::Check < ApplicationRecord
   # TODO: This should be an ENUM
   VALID_STATES = %w[pending error failure success].freeze
   validates :state, inclusion: {
-    in: VALID_STATES,
+    in:      VALID_STATES,
     message: "State '%{value}' is not a valid. Valid states are: #{VALID_STATES.join(', ')}"
   }
 

--- a/src/api/app/models/unregistered_user.rb
+++ b/src/api/app/models/unregistered_user.rb
@@ -48,14 +48,14 @@ class UnregisteredUser < User
     state = ::Configuration.registration == 'allow' ? 'confirmed' : 'unconfirmed'
 
     newuser = User.new(
-      realname:              (opts[:realname] || ''),
-      login:                 opts[:login],
-      password:              opts[:password],
+      realname: (opts[:realname] || ''),
+      login: opts[:login],
+      password: opts[:password],
       password_confirmation: opts[:password_confirmation],
-      email:                 opts[:email],
-      state:                 state,
-      adminnote:             opts[:note],
-      ignore_auth_services:  Configuration.ldap_enabled?
+      email: opts[:email],
+      state: state,
+      adminnote: opts[:note],
+      ignore_auth_services: Configuration.ldap_enabled?
     )
 
     unless newuser.save

--- a/src/api/config/environments/production.rb
+++ b/src/api/config/environments/production.rb
@@ -76,11 +76,11 @@ OBSApi::Application.configure do
   config.lograge.custom_options = lambda do |event|
     exceptions = ['controller', 'action', 'format', 'id']
     {
-      params: event.payload[:params].except(*exceptions),
-      host:   event.payload[:headers].env['REMOTE_ADDR'],
-      time:   event.time,
+      params:  event.payload[:params].except(*exceptions),
+      host:    event.payload[:headers].env['REMOTE_ADDR'],
+      time:    event.time,
       backend: event.payload[:backend_runtime],
-      user:   User.current.try(:login)
+      user:    User.current.try(:login)
     }
   end
 

--- a/src/api/config/routes.rb
+++ b/src/api/config/routes.rb
@@ -25,20 +25,20 @@ OBSApi::Application.routes.draw do
   mount Peek::Railtie => '/peek'
 
   cons = {
-    arch:         %r{[^\/]*},
-    binary:       %r{[^\/]*},
-    filename:     %r{[^\/]*},
-    id:           %r{\d*},
-    login:        %r{[^\/]*},
-    package:      %r{[^\/]*},
-    package_name: %r{[^\/]*},
-    project:      %r{[^\/]*},
-    project_name: %r{[^\/]*},
-    repository:   %r{[^\/]*},
-    repository_name:   %r{[^\/]*},
-    service:      %r{\w[^\/]*},
-    title:        %r{[^\/]*},
-    user:         %r{[^\/]*},
+    arch:                        %r{[^\/]*},
+    binary:                      %r{[^\/]*},
+    filename:                    %r{[^\/]*},
+    id:                          %r{\d*},
+    login:                       %r{[^\/]*},
+    package:                     %r{[^\/]*},
+    package_name:                %r{[^\/]*},
+    project:                     %r{[^\/]*},
+    project_name:                %r{[^\/]*},
+    repository:                  %r{[^\/]*},
+    repository_name:             %r{[^\/]*},
+    service:                     %r{\w[^\/]*},
+    title:                       %r{[^\/]*},
+    user:                        %r{[^\/]*},
     repository_publish_build_id: %r{[^\/]*}
   }
 

--- a/src/api/lib/xpath_engine.rb
+++ b/src/api/lib/xpath_engine.rb
@@ -45,19 +45,19 @@ class XpathEngine
         'attribute_issue/owner/@email' => { cpart: 'users.email', joins:        ['LEFT JOIN users ON users.id = attribissues.owner_id'] },
         'attribute_issue/owner/@login' => { cpart: 'users.login', joins:        ['LEFT JOIN users ON users.id = attribissues.owner_id'] },
         'person/@userid'               => { cpart: 'users.login', joins:        ['LEFT JOIN users ON users.id = user_relation.user_id'] },
-        'person/@role'                 => { cpart: 'ppr.title', joins:          ['LEFT JOIN roles AS ppr ON user_relation.role_id = ppr.id'] },
-        'group/@groupid'               => { cpart: 'groups.title', joins:       ['LEFT JOIN groups ON groups.id = group_relation.group_id'] },
-        'group/@role'                  => { cpart: 'gpr.title', joins:          ['LEFT JOIN roles AS gpr ON group_relation.role_id = gpr.id'] },
+        'person/@role'                 => { cpart: 'ppr.title', joins: ['LEFT JOIN roles AS ppr ON user_relation.role_id = ppr.id'] },
+        'group/@groupid'               => { cpart: 'groups.title', joins: ['LEFT JOIN groups ON groups.id = group_relation.group_id'] },
+        'group/@role'                  => { cpart: 'gpr.title', joins: ['LEFT JOIN roles AS gpr ON group_relation.role_id = gpr.id'] },
         'attribute/@name'              => { cpart: 'attrib_namespaces.name = ? AND attrib_types.name', split: ':',
-                                            joins: ['LEFT JOIN attrib_types ON attribs.attrib_type_id = attrib_types.id',
-                                                    'LEFT JOIN attrib_namespaces ON attrib_types.attrib_namespace_id = attrib_namespaces.id',
-                                                    'LEFT JOIN attribs AS attribsprj ON attribsprj.project_id = packages.project_id', # include also, when set in project
-                                                    'LEFT JOIN attrib_types AS attrib_typesprj ON attribsprj.attrib_type_id = attrib_typesprj.id',
-                                                    'LEFT JOIN attrib_namespaces AS attrib_namespacesprj ON attrib_typesprj.attrib_namespace_id = attrib_namespacesprj.id'] },
+                               joins: ['LEFT JOIN attrib_types ON attribs.attrib_type_id = attrib_types.id',
+                                       'LEFT JOIN attrib_namespaces ON attrib_types.attrib_namespace_id = attrib_namespaces.id',
+                                       'LEFT JOIN attribs AS attribsprj ON attribsprj.project_id = packages.project_id', # include also, when set in project
+                                       'LEFT JOIN attrib_types AS attrib_typesprj ON attribsprj.attrib_type_id = attrib_typesprj.id',
+                                       'LEFT JOIN attrib_namespaces AS attrib_namespacesprj ON attrib_typesprj.attrib_namespace_id = attrib_namespacesprj.id'] },
         'project/attribute/@name'      => { cpart: 'attrib_namespaces_proj.name = ? AND attrib_types_proj.name', split: ':',
-                                            joins: ['LEFT JOIN attribs AS attribs_proj ON attribs_proj.project_id = packages.project_id',
-                                                    'LEFT JOIN attrib_types AS attrib_types_proj ON attribs_proj.attrib_type_id = attrib_types_proj.id',
-                                                    'LEFT JOIN attrib_namespaces AS attrib_namespaces_proj ON attrib_types_proj.attrib_namespace_id = attrib_namespaces_proj.id'] }
+                                       joins: ['LEFT JOIN attribs AS attribs_proj ON attribs_proj.project_id = packages.project_id',
+                                               'LEFT JOIN attrib_types AS attrib_types_proj ON attribs_proj.attrib_type_id = attrib_types_proj.id',
+                                               'LEFT JOIN attrib_namespaces AS attrib_namespaces_proj ON attrib_types_proj.attrib_namespace_id = attrib_namespaces_proj.id'] }
       },
       'projects'          => {
         '@name'                             => { cpart: 'projects.name' },
@@ -70,10 +70,10 @@ class XpathEngine
           'LEFT JOIN maintained_projects AS maintained_prj ON projects.id = maintained_prj.maintenance_project_id',
           'LEFT JOIN projects AS maintains_prj ON maintained_prj.project_id = maintains_prj.id'
         ] },
-        'person/@userid'                    => { cpart: 'users.login', joins:  ['LEFT JOIN users ON users.id = user_relation.user_id'] },
-        'person/@role'                      => { cpart: 'ppr.title', joins:    ['LEFT JOIN roles AS ppr ON user_relation.role_id = ppr.id'] },
+        'person/@userid'                    => { cpart: 'users.login', joins: ['LEFT JOIN users ON users.id = user_relation.user_id'] },
+        'person/@role'                      => { cpart: 'ppr.title', joins: ['LEFT JOIN roles AS ppr ON user_relation.role_id = ppr.id'] },
         'group/@groupid'                    => { cpart: 'groups.title', joins: ['LEFT JOIN groups ON groups.id = group_relation.group_id'] },
-        'group/@role'                       => { cpart: 'gpr.title', joins:    ['LEFT JOIN roles AS gpr ON group_relation.role_id = gpr.id'] },
+        'group/@role'                       => { cpart: 'gpr.title', joins: ['LEFT JOIN roles AS gpr ON group_relation.role_id = gpr.id'] },
         'repository/@name'                  => { cpart: 'repositories.name',
                                                  joins: ['join repositories on repositories.db_project_id=projects.id'] },
         'repository/path/@project'          => { cpart: 'childs.name',
@@ -86,9 +86,9 @@ class XpathEngine
                                                          'join release_targets rt on rt.repository_id=r.id'] },
         'package/@name'                     => { cpart: 'packs.name', joins: ['LEFT JOIN packages AS packs ON packs.project_id = projects.id'] },
         'attribute/@name'                   => { cpart: 'attrib_namespaces.name = ? AND attrib_types.name', split: ':',
-                                                 joins: ['LEFT JOIN attribs ON attribs.project_id = projects.id',
-                                                         'LEFT JOIN attrib_types ON attribs.attrib_type_id = attrib_types.id',
-                                                         'LEFT JOIN attrib_namespaces ON attrib_types.attrib_namespace_id = attrib_namespaces.id'] }
+                               joins: ['LEFT JOIN attribs ON attribs.project_id = projects.id',
+                                       'LEFT JOIN attrib_types ON attribs.attrib_type_id = attrib_types.id',
+                                       'LEFT JOIN attrib_namespaces ON attrib_types.attrib_namespace_id = attrib_namespaces.id'] }
       },
       'repositories'      => {
         '@project'                   => { cpart: 'pr.name', joins: 'LEFT JOIN projects AS pr ON repositories.db_project_id=pr.id' },
@@ -158,7 +158,7 @@ class XpathEngine
         'repository/@project'    => { cpart: 'release_projects.name' },
         'repository/@name'       => { cpart: 'release_repositories.name' },
         'publish/@time'          => { cpart: 'binary_releasetime' },
-        'publish/@package'       => { cpart: 'ppkg.name', joins:  ['LEFT join packages ppkg on ppkg.id=release_package_id'] },
+        'publish/@package'       => { cpart: 'ppkg.name', joins: ['LEFT join packages ppkg on ppkg.id=release_package_id'] },
         'updatefor/@project'     => { cpart: 'puprj.name', joins: ['LEFT join packages pupkg on pupkg.id=product_update.package_id ',
                                                                    'LEFT join projects puprj on puprj.id=pupkg.project_id '] },
         'updatefor/@arch'        => { cpart: 'pupa.name',

--- a/src/api/spec/bootstrap/features/webui/maintenance_workflow_spec.rb
+++ b/src/api/spec/bootstrap/features/webui/maintenance_workflow_spec.rb
@@ -54,11 +54,11 @@ RSpec.feature 'Bootstrap_MaintenanceWorkflow', type: :feature, js: true, vcr: tr
 
     # Check that sending maintenance updates adds the source revision
     new_bs_request_action = BsRequestAction.where(
-      type:                  'maintenance_incident',
-      target_project:        maintenance_project.name,
+      type: 'maintenance_incident',
+      target_project: maintenance_project.name,
       target_releaseproject: update_project.name,
-      source_project:        "#{user.home_project}:branches:#{update_project.name}",
-      source_package:        package.name
+      source_project: "#{user.home_project}:branches:#{update_project.name}",
+      source_package: package.name
     )
     expect(new_bs_request_action.pluck(:source_rev).first).not_to be(nil)
 

--- a/src/api/spec/controllers/source_attribute_controller_spec.rb
+++ b/src/api/spec/controllers/source_attribute_controller_spec.rb
@@ -49,9 +49,9 @@ RSpec.describe SourceAttributeController, vcr: true do
       before do
         login user
         update_project_attrib
-        put :update, params: { project: project,
+        put :update, params: { project:   project,
                                attribute: update_project_attrib.fullname,
-                               format: :xml },
+                               format:    :xml },
                      body: xml_attrib
       end
 
@@ -72,9 +72,9 @@ RSpec.describe SourceAttributeController, vcr: true do
       before do
         login user
         update_project_attrib
-        put :update, params: { project: project,
+        put :update, params: { project:   project,
                                attribute: update_project_attrib.fullname,
-                               format: :xml },
+                               format:    :xml },
                      body: wrong_xml_attrib
       end
 
@@ -91,9 +91,9 @@ RSpec.describe SourceAttributeController, vcr: true do
       before do
         login user
         main_attribute
-        delete :delete, params: { project: project,
+        delete :delete, params: { project:   project,
                                   attribute: main_attribute.fullname,
-                                  format: :xml }
+                                  format:    :xml }
       end
 
       it { expect(response).to be_success }
@@ -105,9 +105,9 @@ RSpec.describe SourceAttributeController, vcr: true do
       before do
         login wrong_user
         main_attribute
-        delete :delete, params: { project: project,
+        delete :delete, params: { project:   project,
                                   attribute: main_attribute.fullname,
-                                  format: :xml }
+                                  format:    :xml }
       end
 
       it { expect(response).not_to be_success }

--- a/src/api/spec/controllers/status/required_checks_controller_spec.rb
+++ b/src/api/spec/controllers/status/required_checks_controller_spec.rb
@@ -152,9 +152,9 @@ RSpec.describe Status::RequiredChecksController, type: :controller do
 
     shared_examples 'does delete the required check' do
       subject do
-        delete :destroy, params: { project_name: project.name,
+        delete :destroy, params: { project_name:    project.name,
                                    repository_name: repository.name,
-                                   name: 'first check' }, format: :xml
+                                   name:            'first check' }, format: :xml
       end
 
       it 'will delete the required check' do
@@ -170,9 +170,9 @@ RSpec.describe Status::RequiredChecksController, type: :controller do
     shared_examples 'does not delete the required check' do
       it 'will not delete the required check' do
         expect do
-          delete :destroy, params: { project_name: project.name,
+          delete :destroy, params: { project_name:    project.name,
                                      repository_name: repository.name,
-                                     name: 'first check' }, format: :xml
+                                     name:            'first check' }, format: :xml
         end.not_to(
           change do
             # we need to to reload because required_checks is a serialized attribute
@@ -185,9 +185,9 @@ RSpec.describe Status::RequiredChecksController, type: :controller do
 
     shared_examples 'returns correct status' do
       before do
-        delete :destroy, params: { project_name: project.name,
+        delete :destroy, params: { project_name:    project.name,
                                    repository_name: repository.name,
-                                   name: 'first check' }, format: :xml
+                                   name:            'first check' }, format: :xml
       end
 
       it 'has correct HTTP status' do

--- a/src/api/spec/controllers/webui/obs_factory/staging_projects_controller_spec.rb
+++ b/src/api/spec/controllers/webui/obs_factory/staging_projects_controller_spec.rb
@@ -160,10 +160,10 @@ RSpec.describe Webui::ObsFactory::StagingProjectsController, type: :controller, 
         it 'responds with a json representation of the staging project' do
           response = JSON.parse(subject.body)
           expect(response).to include(
-            'name'              => 'openSUSE:Factory:Staging:A',
-            'description'       => description,
+            'name' => 'openSUSE:Factory:Staging:A',
+            'description' => description,
             'obsolete_requests' => [JSON.parse(declined_bs_request.to_json)],
-            'overall_state'     => 'unacceptable'
+            'overall_state' => 'unacceptable'
           )
         end
       end

--- a/src/api/spec/controllers/webui/package_controller_spec.rb
+++ b/src/api/spec/controllers/webui/package_controller_spec.rb
@@ -118,8 +118,8 @@ RSpec.describe Webui::PackageController, vcr: true do
                  source_package: package.name,
                  target_project: target_project.name,
                  target_package: package.name,
-                 type:           'submit',
-                 source_rev:     2
+                 type: 'submit',
+                 source_rev: 2
         )).to exist
       end
     end
@@ -476,9 +476,9 @@ RSpec.describe Webui::PackageController, vcr: true do
 
       context "adding a file that doesn't exist yet" do
         before do
-          do_request(project:   source_project,
-                     package:   source_package,
-                     filename:  'newly_created_file',
+          do_request(project: source_project,
+                     package: source_package,
+                     filename: 'newly_created_file',
                      file_type: 'local',
                      file: 'some_content')
         end
@@ -1544,9 +1544,9 @@ RSpec.describe Webui::PackageController, vcr: true do
     context 'when passing params referring to valid project/architecture/repository and an invalid repository' do
       let(:params) do
         {
-          dependant_project: source_project.name,
-          arch: 'i586',
-          repository: repo_for_source_project.name,
+          dependant_project:    source_project.name,
+          arch:                 'i586',
+          repository:           repo_for_source_project.name,
           dependant_repository: 'something'
         }
       end
@@ -1562,11 +1562,11 @@ RSpec.describe Webui::PackageController, vcr: true do
 
       let(:params) do
         {
-          dependant_project: source_project.name,
-          arch: 'i586',
-          repository: repo_for_source_project.name,
+          dependant_project:    source_project.name,
+          arch:                 'i586',
+          repository:           repo_for_source_project.name,
           dependant_repository: another_repo_for_source_project.name,
-          filename: 'test.rpm'
+          filename:             'test.rpm'
         }
       end
 

--- a/src/api/spec/controllers/webui/patchinfo_controller_spec.rb
+++ b/src/api/spec/controllers/webui/patchinfo_controller_spec.rb
@@ -289,7 +289,7 @@ RSpec.describe Webui::PatchinfoController, vcr: true do
         let(:my_issues) { ['bgo#132412'] }
 
         it do
-          expect(JSON.parse(response.body)).to eq('error'  => '',
+          expect(JSON.parse(response.body)).to eq('error' => '',
                                                   'issues' => [['bgo', '132412', 'https://bugzilla.gnome.org/show_bug.cgi?id=132412', '']])
         end
         it { expect(response).to have_http_status(:success) }
@@ -299,7 +299,7 @@ RSpec.describe Webui::PatchinfoController, vcr: true do
         let(:my_issues) { ['CVE-2010-31337'] }
 
         it do
-          expect(JSON.parse(response.body)).to eq('error'  => '',
+          expect(JSON.parse(response.body)).to eq('error' => '',
                                                   'issues' => [['cve', 'CVE-2010-31337', 'http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2010-31337', '']])
         end
         it { expect(response).to have_http_status(:success) }

--- a/src/api/spec/controllers/webui/project_controller_spec.rb
+++ b/src/api/spec/controllers/webui/project_controller_spec.rb
@@ -485,10 +485,10 @@ RSpec.describe Webui::ProjectController, vcr: true do
       {
         'result' => Xmlhash::XMLHash.new(
           'repository' => 'openSUSE',
-          'arch'       => 'x86_64',
-          'code'       => 'published',
-          'state'      => 'published',
-          'summary'    => summary
+          'arch' => 'x86_64',
+          'code' => 'published',
+          'state' => 'published',
+          'summary' => summary
         )
       }
     end
@@ -1327,17 +1327,17 @@ RSpec.describe Webui::ProjectController, vcr: true do
           let(:statushash) do
             { 'openSUSE_Tumbleweed' => {
               'i586'   => {
-                'c++'   => { 'package' => 'c++',   'code' => 'succeeded' },
+                'c++'   => { 'package' => 'c++', 'code' => 'succeeded' },
                 'redis' => { 'package' => 'redis', 'code' => 'failed' }
               },
               'x86_64' => {
-                'c++'   => { 'package' => 'c++',   'code' => 'unresolvable', 'details' => 'nothing provides foo' },
+                'c++'   => { 'package' => 'c++', 'code' => 'unresolvable', 'details' => 'nothing provides foo' },
                 'redis' => { 'package' => 'redis', 'code' => 'building', 'details' => 'building on obs-node-3' }
               }
             },
               'openSUSE_42.2'       => {
                 's390x' => {
-                  'c++'   => { 'package' => 'c++',   'code' => 'succeeded' },
+                  'c++'   => { 'package' => 'c++', 'code' => 'succeeded' },
                   'redis' => { 'package' => 'redis', 'code' => 'succeeded' }
                 }
               } }
@@ -1354,11 +1354,11 @@ RSpec.describe Webui::ProjectController, vcr: true do
           it { expect(assigns(:repohash)).to eq('openSUSE_Tumbleweed' => ['i586', 'x86_64'], 'openSUSE_42.2' => ['s390x']) }
           it {
             expect(assigns(:repostatushash)).to eq('openSUSE_Tumbleweed' => { 'i586' => 'published', 'x86_64' => 'building' },
-                                                   'openSUSE_42.2'       => { 's390x' => 'outdated_published' })
+                                                   'openSUSE_42.2' => { 's390x' => 'outdated_published' })
           }
           it {
             expect(assigns(:repostatusdetailshash)).to eq('openSUSE_Tumbleweed' => { 'x86_64' => 'This repo is broken' },
-                                                          'openSUSE_42.2'       => {})
+                                                          'openSUSE_42.2' => {})
           }
           it { expect(response).to have_http_status(:ok) }
         end

--- a/src/api/spec/controllers/webui/request_controller_spec.rb
+++ b/src/api/spec/controllers/webui/request_controller_spec.rb
@@ -402,9 +402,9 @@ RSpec.describe Webui::RequestController, vcr: true do
       before do
         login(submitter_with_group)
         post :set_bugowner_request, params: {
-          project: source_project_fluffy.name,
-          user: submitter_with_group.login,
-          group: submitter_with_group.groups.first.title,
+          project:     source_project_fluffy.name,
+          user:        submitter_with_group.login,
+          group:       submitter_with_group.groups.first.title,
           description: 'blah blah blash'
         }
       end

--- a/src/api/spec/controllers/webui/session_controller_spec.rb
+++ b/src/api/spec/controllers/webui/session_controller_spec.rb
@@ -59,8 +59,8 @@ RSpec.describe Webui::SessionController do
   context 'in kerberos mode' do
     before do
       stub_const('CONFIG', CONFIG.merge('kerberos_service_principal' => 'HTTP/obs.test.com@test_realm.com',
-                                        'kerberos_realm'             => 'test_realm.com',
-                                        'kerberos_mode'              => true))
+                                        'kerberos_realm' => 'test_realm.com',
+                                        'kerberos_mode' => true))
     end
 
     context 'for a request that requires authentication' do

--- a/src/api/spec/factories/download_repository_factory.rb
+++ b/src/api/spec/factories/download_repository_factory.rb
@@ -7,7 +7,7 @@ FactoryBot.define do
 
     before(:create) do |download_repository|
       repo_arch = RepositoryArchitecture.find_by(
-        repository:   download_repository.repository,
+        repository: download_repository.repository,
         architecture: Architecture.find_by_name(download_repository.arch)
       )
       # We need to find and create in two separate steps because for finding the position irrelevant but not for creating

--- a/src/api/spec/factories/repository.rb
+++ b/src/api/spec/factories/repository.rb
@@ -9,7 +9,7 @@ FactoryBot.define do
 
     after(:create) do |repository, evaluator|
       evaluator.architectures.each do |arch|
-        create(:repository_architecture, repository:   repository,
+        create(:repository_architecture, repository: repository,
                                          architecture: Architecture.find_or_create_by!(name: arch))
       end
     end

--- a/src/api/spec/features/webui/login_spec.rb
+++ b/src/api/spec/features/webui/login_spec.rb
@@ -72,10 +72,10 @@ RSpec.feature 'Login', type: :feature, js: true do
     let(:ldap_user) { double(:ldap_user, to_hash: { 'dn' => 'tux', 'sn' => ['John', 'Smith'] }) }
 
     before do
-      stub_const('CONFIG', CONFIG.merge('ldap_mode'         => :on,
-                                        'ldap_search_user'  => 'tux',
-                                        'ldap_search_auth'  => 'tux_password',
-                                        'ldap_ssl'          => :off,
+      stub_const('CONFIG', CONFIG.merge('ldap_mode' => :on,
+                                        'ldap_search_user' => 'tux',
+                                        'ldap_search_auth' => 'tux_password',
+                                        'ldap_ssl' => :off,
                                         'ldap_authenticate' => :ldap))
 
       allow(ldap_mock).to receive(:search).and_yield(ldap_user)

--- a/src/api/spec/features/webui/maintenance_workflow_spec.rb
+++ b/src/api/spec/features/webui/maintenance_workflow_spec.rb
@@ -53,11 +53,11 @@ RSpec.feature 'MaintenanceWorkflow', type: :feature, js: true do
 
     # Check that sending maintenance updates adds the source revision
     new_bs_request_action = BsRequestAction.where(
-      type:                  'maintenance_incident',
-      target_project:        maintenance_project.name,
+      type: 'maintenance_incident',
+      target_project: maintenance_project.name,
       target_releaseproject: update_project.name,
-      source_project:        "#{user.home_project}:branches:#{update_project.name}",
-      source_package:        package.name
+      source_project: "#{user.home_project}:branches:#{update_project.name}",
+      source_package: package.name
     )
     expect(new_bs_request_action.pluck(:source_rev).first).not_to be(nil)
 

--- a/src/api/spec/features/webui/users/user_home_page_spec.rb
+++ b/src/api/spec/features/webui/users/user_home_page_spec.rb
@@ -3,9 +3,9 @@ require 'browser_helper'
 RSpec.feature "User's home project creation", type: :feature, js: true do
   let!(:user) do
     create(:confirmed_user,
-           login:    'Jim',
+           login: 'Jim',
            realname: 'Jim Knopf',
-           email:    'jim.knopf@puppenkiste.com')
+           email: 'jim.knopf@puppenkiste.com')
   end
 
   before do

--- a/src/api/spec/lib/authenticator_spec.rb
+++ b/src/api/spec/lib/authenticator_spec.rb
@@ -63,9 +63,9 @@ RSpec.describe Authenticator do
 
       before do
         stub_const('CONFIG', CONFIG.merge('kerberos_service_principal' => 'HTTP/obs.test.com@test_realm.com',
-                                          'kerberos_realm'             => 'test_realm.com',
-                                          'kerberos_mode'              => true,
-                                          'kerberos_keytab'            => '/etc/krb5.keytab'))
+                                          'kerberos_realm' => 'test_realm.com',
+                                          'kerberos_mode' => true,
+                                          'kerberos_keytab' => '/etc/krb5.keytab'))
       end
 
       context 'with an invalid ticket' do

--- a/src/api/spec/models/bs_request_spec.rb
+++ b/src/api/spec/models/bs_request_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe BsRequest, vcr: true do
   let(:delete_request) do
     create(:delete_bs_request,
            reviewer: user.login,
-           creator:  user.login,
+           creator: user.login,
            target_project: target_project.name,
            target_package: target_package.name)
   end
@@ -363,8 +363,8 @@ RSpec.describe BsRequest, vcr: true do
              target_package: target_package.name,
              source_project: source_package.project.name,
              source_package: source_package.name,
-             description:    'Update package to newest version',
-             creator:        user.login)
+             description: 'Update package to newest version',
+             creator: user.login)
     end
 
     before do
@@ -444,7 +444,7 @@ RSpec.describe BsRequest, vcr: true do
 
       it 'creates a history element for the priority raise' do
         history_element = HistoryElement::RequestPriorityChange.where(
-          comment:               'Automatic priority bump: Priority of related action increased.',
+          comment: 'Automatic priority bump: Priority of related action increased.',
           description_extension: 'moderate => critical'
         )
         expect(history_element).to exist
@@ -473,7 +473,7 @@ RSpec.describe BsRequest, vcr: true do
       it 'creates a submit request action with the correct target' do
         expect(subject.bs_request_actions.count).to eq(1)
         expect(subject.bs_request_actions.where(
-                 type:           'submit',
+                 type: 'submit',
                  target_project: user.home_project.name,
                  target_package: target_package.name,
                  source_project: target_package.project.name,

--- a/src/api/spec/models/obs_factory/obs_project_spec.rb
+++ b/src/api/spec/models/obs_factory/obs_project_spec.rb
@@ -43,20 +43,20 @@ RSpec.describe ObsFactory::ObsProject do
         expect(subject.build_summary['result']).to eq(
           [
             {
-              'project' => 'openSUSE:Factory',
+              'project'    => 'openSUSE:Factory',
               'repository' => 'openSUSE',
-              'arch' => 'i586',
-              'code' => 'published',
-              'state' => 'published',
-              'summary' => { 'statuscount' => { 'code' => 'succeeded', 'count' => '5' } }
+              'arch'       => 'i586',
+              'code'       => 'published',
+              'state'      => 'published',
+              'summary'    => { 'statuscount' => { 'code' => 'succeeded', 'count' => '5' } }
             },
             {
-              'project' => 'openSUSE:Factory',
+              'project'    => 'openSUSE:Factory',
               'repository' => 'SLES',
-              'arch' => 'i586',
-              'code' => 'published',
-              'state' => 'published',
-              'summary' => { 'statuscount' => { 'code' => 'succeeded', 'count' => '5' } }
+              'arch'       => 'i586',
+              'code'       => 'published',
+              'state'      => 'published',
+              'summary'    => { 'statuscount' => { 'code' => 'succeeded', 'count' => '5' } }
             }
           ]
         )

--- a/src/api/spec/models/obs_factory/staging_project_spec.rb
+++ b/src/api/spec/models/obs_factory/staging_project_spec.rb
@@ -318,7 +318,7 @@ RSpec.describe ObsFactory::StagingProject do
     include_context 'a staging project with description'
 
     let(:meta_result) do
-      { 'requests' =>
+      { 'requests'         =>
                               [
                                 {
                                   'author'  => 'iznogood',

--- a/src/api/spec/models/project_spec.rb
+++ b/src/api/spec/models/project_spec.rb
@@ -421,11 +421,11 @@ RSpec.describe Project, vcr: true do
     let(:admin_user) { create(:admin_user, login: 'Admin') }
     let(:deleted_project) do
       create(:project_with_packages,
-             name:                'project_used_for_restoration',
-             title:               'restoration_project_title',
-             package_title:       'restoration_title',
+             name: 'project_used_for_restoration',
+             title: 'restoration_project_title',
+             package_title: 'restoration_title',
              package_description: 'restoration_desc',
-             package_name:        'restoration_package')
+             package_name: 'restoration_package')
     end
 
     # make sure it's gone even if some previous test failed

--- a/src/api/spec/models/user_ldap_strategy_spec.rb
+++ b/src/api/spec/models/user_ldap_strategy_spec.rb
@@ -133,8 +133,8 @@ RSpec.describe UserLdapStrategy do
       include_context 'setup ldap mock', for_ssl: true
 
       before do
-        stub_const('CONFIG', CONFIG.merge('ldap_search_user'      => 'tux',
-                                          'ldap_search_auth'      => 'tux_password',
+        stub_const('CONFIG', CONFIG.merge('ldap_search_user' => 'tux',
+                                          'ldap_search_auth' => 'tux_password',
                                           'ldap_group_title_attr' => 'ldap_group'))
 
         allow(ldap_mock).to receive(:bind).with('tux', 'tux_password')
@@ -183,9 +183,9 @@ RSpec.describe UserLdapStrategy do
 
   describe '#find_with_ldap' do
     before do
-      stub_const('CONFIG', CONFIG.merge('ldap_search_user'  => 'tux',
-                                        'ldap_search_auth'  => 'tux_password',
-                                        'ldap_ssl'          => :off,
+      stub_const('CONFIG', CONFIG.merge('ldap_search_user' => 'tux',
+                                        'ldap_search_auth' => 'tux_password',
+                                        'ldap_ssl' => :off,
                                         'ldap_authenticate' => :ldap))
     end
 

--- a/src/api/spec/models/user_spec.rb
+++ b/src/api/spec/models/user_spec.rb
@@ -470,7 +470,7 @@ RSpec.describe User do
       end
 
       before do
-        stub_const('CONFIG', CONFIG.merge('ldap_mode'        => :on,
+        stub_const('CONFIG', CONFIG.merge('ldap_mode' => :on,
                                           'ldap_search_user' => 'tux',
                                           'ldap_search_auth' => 'tux_password'))
       end

--- a/src/api/spec/requests/kerberos_login_spec.rb
+++ b/src/api/spec/requests/kerberos_login_spec.rb
@@ -7,8 +7,8 @@ RSpec.describe 'Kerberos login', vcr: false, type: :request do
 
     before do
       stub_const('CONFIG', CONFIG.merge('kerberos_service_principal' => 'HTTP/obs.test.com@test_realm.com',
-                                        'kerberos_realm'             => 'test_realm.com',
-                                        'kerberos_mode'              => true))
+                                        'kerberos_realm' => 'test_realm.com',
+                                        'kerberos_mode' => true))
     end
 
     context "calling a controller with 'extract_user' before filter" do

--- a/src/api/spec/routing/api_matcher_spec.rb
+++ b/src/api/spec/routing/api_matcher_spec.rb
@@ -63,20 +63,20 @@ RSpec.describe 'APIMatcher' do
   it 'routes requests to global_command_* correctly' do
     expect(post('/source?cmd=orderkiwirepos')).to route_to(
       controller: 'source',
-      action:     'global_command_orderkiwirepos',
-      cmd:        'orderkiwirepos'
+      action: 'global_command_orderkiwirepos',
+      cmd: 'orderkiwirepos'
     )
 
     expect(post('/source?cmd=branch')).to route_to(
       controller: 'source',
-      action:     'global_command_branch',
-      cmd:        'branch'
+      action: 'global_command_branch',
+      cmd: 'branch'
     )
 
     expect(post('/source?cmd=createmaintenanceincident')).to route_to(
       controller: 'source',
-      action:     'global_command_createmaintenanceincident',
-      cmd:        'createmaintenanceincident'
+      action: 'global_command_createmaintenanceincident',
+      cmd: 'createmaintenanceincident'
     )
   end
 end

--- a/src/api/spec/support/shared_examples/features/bootstrap_user_tab.rb
+++ b/src/api/spec/support/shared_examples/features/bootstrap_user_tab.rb
@@ -11,15 +11,15 @@ RSpec.shared_examples 'bootstrap user tab' do
       create(:relationship,
              project: project,
              package: package,
-             user:    user_tab_user,
-             role:    Role.find_by_title('bugowner'))
+             user: user_tab_user,
+             role: Role.find_by_title('bugowner'))
     end
     let!(:reader_user_role) do
       create(:relationship,
              project: project,
              package: package,
-             user:    reader,
-             role:    Role.find_by_title('reader'))
+             user: reader,
+             role: Role.find_by_title('reader'))
     end
 
     before do
@@ -125,8 +125,8 @@ RSpec.shared_examples 'bootstrap user tab' do
       create(:relationship,
              project: project,
              package: package,
-             group:   group,
-             role:    Role.find_by_title('bugowner'))
+             group: group,
+             role: Role.find_by_title('bugowner'))
     end
 
     before do

--- a/src/api/spec/support/shared_examples/features/user_tab.rb
+++ b/src/api/spec/support/shared_examples/features/user_tab.rb
@@ -11,15 +11,15 @@ RSpec.shared_examples 'user tab' do
       create(:relationship,
              project: project,
              package: package,
-             user:    user_tab_user,
-             role:    Role.find_by_title('bugowner'))
+             user: user_tab_user,
+             role: Role.find_by_title('bugowner'))
     end
     let!(:reader_user_role) do
       create(:relationship,
              project: project,
              package: package,
-             user:    reader,
-             role:    Role.find_by_title('reader'))
+             user: reader,
+             role: Role.find_by_title('reader'))
     end
 
     before do
@@ -109,8 +109,8 @@ RSpec.shared_examples 'user tab' do
       create(:relationship,
              project: project,
              package: package,
-             group:   group,
-             role:    Role.find_by_title('bugowner'))
+             group: group,
+             role: Role.find_by_title('bugowner'))
     end
 
     before do

--- a/src/api/test/models/event_test.rb
+++ b/src/api/test/models/event_test.rb
@@ -20,7 +20,7 @@ class EventTest < ActionDispatch::IntegrationTest
     e = Event::Factory.new_from_type('SRCSRV_CREATE_PACKAGE',
                                      'project' => 'kde4',
                                      'package' => 'kdelibs',
-                                     'sender'  => 'tom')
+                                     'sender' => 'tom')
     assert_equal 'Event::CreatePackage', e.class.name
     assert_equal 'kdelibs', e.payload['package']
     assert_equal [], e.receiver_roles


### PR DESCRIPTION
the default is key, which gives you:

```
  :foo => bar,
  :ba => baz
```

So far a lot of our code uses

```
  :foo => bar,
  :ba  => baz
```

(which is table)

And there is a lot of mixed code, so we need to choose
