### PR TITLE
 Remove obsapisetup.service call and duplicated obs-clockwork.service

### DIFF
--- a/dist/obs-server.spec
+++ b/dist/obs-server.spec
@@ -83,7 +83,7 @@ fi										\
 }
 %endif
 
-%global obs_api_support_scripts obs-api-support.target obs-clockwork.service obs-clockwork.service obs-delayedjob-queue-consistency_check.service obs-delayedjob-queue-default.service obs-delayedjob-queue-issuetracking.service obs-delayedjob-queue-mailers.service obs-delayedjob-queue-project_log_rotate.service obs-delayedjob-queue-releasetracking.service obs-sphinx.service
+%global obs_api_support_scripts obs-api-support.target obs-clockwork.service obs-delayedjob-queue-consistency_check.service obs-delayedjob-queue-default.service obs-delayedjob-queue-issuetracking.service obs-delayedjob-queue-mailers.service obs-delayedjob-queue-project_log_rotate.service obs-delayedjob-queue-releasetracking.service obs-sphinx.service
 
 Name:           obs-server
 Summary:        The Open Build Service -- Server Component

--- a/dist/obs-server.spec
+++ b/dist/obs-server.spec
@@ -83,7 +83,7 @@ fi										\
 }
 %endif
 
-%global obs_api_support_scripts obs-api-support.target obsapisetup.service obs-clockwork.service obs-clockwork.service obs-delayedjob-queue-consistency_check.service obs-delayedjob-queue-default.service obs-delayedjob-queue-issuetracking.service obs-delayedjob-queue-mailers.service obs-delayedjob-queue-project_log_rotate.service obs-delayedjob-queue-releasetracking.service obs-sphinx.service
+%global obs_api_support_scripts obs-api-support.target obs-clockwork.service obs-clockwork.service obs-delayedjob-queue-consistency_check.service obs-delayedjob-queue-default.service obs-delayedjob-queue-issuetracking.service obs-delayedjob-queue-mailers.service obs-delayedjob-queue-project_log_rotate.service obs-delayedjob-queue-releasetracking.service obs-sphinx.service
 
 Name:           obs-server
 Summary:        The Open Build Service -- Server Component

--- a/dist/systemd/obs-api-support.target
+++ b/dist/systemd/obs-api-support.target
@@ -1,6 +1,6 @@
 [Unit]
 Description = Open Build Service API Support Daemons
-Wants = obsapisetup.service obs-clockwork.service obs-delayedjob-queue-consistency_check.service obs-delayedjob-queue-default.service obs-delayedjob-queue-issuetracking.service obs-delayedjob-queue-mailers.service obs-delayedjob-queue-project_log_rotate.service obs-delayedjob-queue-quick@0.service obs-delayedjob-queue-quick@1.service obs-delayedjob-queue-quick@2.service obs-delayedjob-queue-releasetracking.service obs-sphinx.service
+Wants = obs-clockwork.service obs-delayedjob-queue-consistency_check.service obs-delayedjob-queue-default.service obs-delayedjob-queue-issuetracking.service obs-delayedjob-queue-mailers.service obs-delayedjob-queue-project_log_rotate.service obs-delayedjob-queue-quick@0.service obs-delayedjob-queue-quick@1.service obs-delayedjob-queue-quick@2.service obs-delayedjob-queue-releasetracking.service obs-sphinx.service
 After = network.target
 AllowIsolate = yes
 


### PR DESCRIPTION
We shouldn't be calling `obsapisetup.service` in the rpm as this is only needed in the appliance. This was causing the following error when deploying: `Failed to execute operation: No such file or directory`

Also remove duplicated `obs-clockwork.service`

Fixes #6188

Co-authored-by: @eduardoj 
