### PR TITLE
Create request exclusion model (for ignored requests)

### DIFF
--- a/src/api/app/controllers/webui/staging/excluded_requests_controller.rb
+++ b/src/api/app/controllers/webui/staging/excluded_requests_controller.rb
@@ -1,0 +1,78 @@
+module Webui
+  module Staging
+    class ExcludedRequestsController < WebuiController
+      layout 'webui2/webui'
+
+      before_action :require_login, except: [:index]
+      before_action :switch_to_webui2
+      before_action :set_staging_workflow
+      before_action :set_project
+      before_action :set_request_exclusion, only: [:destroy]
+      after_action :verify_authorized, except: [:index]
+
+      def index
+        @request_exclusions = @staging_workflow.request_exclusions
+        @requests = @staging_workflow.unassigned_requests
+      end
+
+      def create
+        authorize @staging_workflow
+
+        staging_request_exclusion = params[:staging_request_exclusion]
+
+        request = @staging_workflow.target_of_bs_requests.find_by(number: staging_request_exclusion[:number])
+        unless request
+          redirect_back(fallback_location: root_path, error: "Request #{params[:number]} doesn't exist or it doesn't belong to this project")
+          return
+        end
+
+        request_exclusion = @staging_workflow.request_exclusions.build(bs_request: request, description: staging_request_exclusion[:description])
+
+        if request_exclusion.save
+          flash[:success] = 'The request was successfully excluded'
+        else
+          flash[:error] = request_exclusion.errors.full_messages.to_sentence
+        end
+        redirect_to staging_workflow_excluded_requests_path(@staging_workflow)
+      end
+
+      def destroy
+        authorize @staging_workflow
+
+        if @request_exclusion.destroy
+          flash[:success] = 'The request is not excluded anymore'
+        else
+          flash[:error] = "Request #{@request_exclusion.number} couldn't be unexcluded"
+        end
+        redirect_to staging_workflow_excluded_requests_path(@staging_workflow)
+      end
+
+      private
+
+      def switch_to_webui2
+        prepend_view_path('app/views/webui2')
+      end
+
+      def set_staging_workflow
+        @staging_workflow = ::Staging::Workflow.find_by(id: params[:staging_workflow_id])
+        return if @staging_workflow
+
+        redirect_back(fallback_location: root_path, error: "Staging Workflow #{params[:staging_workflow_id]} does not exist")
+      end
+
+      def set_project
+        @project = @staging_workflow.project
+        return if @project
+
+        redirect_back(fallback_location: root_path, error: "Staging Workflow #{params[:staging_workflow_id]} is not assigned to a project")
+      end
+
+      def set_request_exclusion
+        @request_exclusion = ::Staging::RequestExclusion.find_by(id: params[:id])
+        return if @request_exclusion
+
+        redirect_back(fallback_location: staging_workflow_excluded_requests_path(@staging_workflow), error: "Request doesn't exist")
+      end
+    end
+  end
+end

--- a/src/api/app/controllers/webui/staging/excluded_requests_controller.rb
+++ b/src/api/app/controllers/webui/staging/excluded_requests_controller.rb
@@ -17,7 +17,6 @@ module Webui
 
       def create
         authorize @staging_workflow
-
         staging_request_exclusion = params[:staging_request_exclusion]
 
         request = @staging_workflow.target_of_bs_requests.find_by(number: staging_request_exclusion[:number])

--- a/src/api/app/controllers/webui/staging/workflows_controller.rb
+++ b/src/api/app/controllers/webui/staging/workflows_controller.rb
@@ -38,8 +38,8 @@ class Webui::Staging::WorkflowsController < Webui::WebuiController
     @more_unassigned_requests = @staging_workflow.unassigned_requests.count - @unassigned_requests.size
     @ready_requests = @staging_workflow.ready_requests.first(5)
     @more_ready_requests = @staging_workflow.ready_requests.count - @ready_requests.size
-    @ignored_requests = @staging_workflow.ignored_requests.first(5)
-    @more_ignored_requests = @staging_workflow.ignored_requests.count - @ignored_requests.size
+    @excluded_requests = @staging_workflow.excluded_requests.first(5)
+    @more_excluded_requests = @staging_workflow.excluded_requests.count - @excluded_requests.size
     @empty_projects = @staging_workflow.staging_projects.without_staged_requests
     @managers = @staging_workflow.managers_group
   end

--- a/src/api/app/models/bs_request.rb
+++ b/src/api/app/models/bs_request.rb
@@ -96,6 +96,7 @@ class BsRequest < ApplicationRecord
   has_many :target_project_objects, through: :bs_request_actions
 
   belongs_to :staging_project, class_name: 'Project', foreign_key: 'staging_project_id'
+  has_one :request_exclusion, class_name: 'Staging::RequestExclusion', foreign_key: 'bs_request_id', dependent: :destroy
 
   validates :state, inclusion: { in: VALID_REQUEST_STATES }
   validates :creator, presence: true

--- a/src/api/app/models/staging/request_exclusion.rb
+++ b/src/api/app/models/staging/request_exclusion.rb
@@ -1,0 +1,14 @@
+class Staging::RequestExclusion < ApplicationRecord
+  def self.table_name_prefix
+    'staging_'
+  end
+
+  belongs_to :staging_workflow, class_name: 'Staging::Workflow'
+  belongs_to :bs_request
+
+  validates :staging_workflow, :bs_request, :description, presence: true
+  validates :bs_request_id, numericality: true, uniqueness: { scope: :staging_workflow_id, message: 'is already excluded' }
+  validates :description, length: { maximum: 255 }
+
+  delegate :number, to: :bs_request, allow_nil: true
+end

--- a/src/api/app/models/staging/workflow.rb
+++ b/src/api/app/models/staging/workflow.rb
@@ -42,10 +42,6 @@ class Staging::Workflow < ApplicationRecord
     target_of_bs_requests.ready_to_stage.where.not(id: excluded_requests | staged_requests)
   end
 
-  def ignored_requests
-    BsRequest.none # TODO: define this method
-  end
-
   def write_to_backend
     return unless CONFIG['global_write_through']
 

--- a/src/api/app/models/staging/workflow.rb
+++ b/src/api/app/models/staging/workflow.rb
@@ -26,6 +26,8 @@ class Staging::Workflow < ApplicationRecord
   end
 
   has_many :staged_requests, class_name: 'BsRequest', through: :staging_projects
+  has_many :request_exclusions, class_name: 'Staging::RequestExclusion', foreign_key: 'staging_workflow_id', dependent: :destroy
+  has_many :excluded_requests, through: :request_exclusions, source: :bs_request
 
   validates :managers_group, presence: true
 
@@ -33,11 +35,11 @@ class Staging::Workflow < ApplicationRecord
   before_update :update_staging_projects_managers_group
 
   def unassigned_requests
-    target_of_bs_requests.stageable.where.not(id: ignored_requests | staged_requests)
+    target_of_bs_requests.stageable.where.not(id: excluded_requests | staged_requests)
   end
 
   def ready_requests
-    target_of_bs_requests.ready_to_stage.where.not(id: ignored_requests | staged_requests)
+    target_of_bs_requests.ready_to_stage.where.not(id: excluded_requests | staged_requests)
   end
 
   def ignored_requests

--- a/src/api/app/views/webui2/webui/staging/excluded_requests/_breadcrumb_items.html.haml
+++ b/src/api/app/views/webui2/webui/staging/excluded_requests/_breadcrumb_items.html.haml
@@ -1,0 +1,3 @@
+= render partial: 'webui/project/breadcrumb_items'
+%li.breadcrumb-item.active{ 'aria-current' => 'page' }
+  Staging workflow excluded requests

--- a/src/api/app/views/webui2/webui/staging/excluded_requests/_create_dialog.html.haml
+++ b/src/api/app/views/webui2/webui/staging/excluded_requests/_create_dialog.html.haml
@@ -1,0 +1,18 @@
+.modal.fade#exclude-request-modal{ tabindex: -1, role: 'dialog', aria: { labelledby: 'exclude-request-modal-label', hidden: true } }
+  .modal-dialog.modal-dialog-centered{ role: 'document' }
+    .modal-content
+      .modal-header
+        %h5.modal-title#exclude-request-modal-label Exclude Request
+        %a.close{ type: 'button', data: { dismiss: 'modal' }, aria: { label: 'Close' } }
+          %span{ aria: { hidden: true } } &times;
+      = form_for Staging::RequestExclusion.new, url: staging_workflow_excluded_requests_path do |f|
+        .modal-body
+          .form-group
+            = f.label :number, 'Request'
+            = f.number_field :number, required: true, class: 'form-control'
+          .form-group
+            = f.label :description
+            = f.text_area :description,
+              required: true, placeholder: 'Explain why this request will be excluded', class: 'form-control', maxlength: 255
+        .modal-footer
+          = render partial: 'webui2/shared/dialog_action_buttons'

--- a/src/api/app/views/webui2/webui/staging/excluded_requests/_delete_dialog.html.haml
+++ b/src/api/app/views/webui2/webui/staging/excluded_requests/_delete_dialog.html.haml
@@ -1,0 +1,14 @@
+.modal.fade{ id: "delete-excluded-request-modal-#{request_exclusion.bs_request_id}",
+             tabindex: -1, role: 'dialog', aria: { labelledby: 'delete-modal-label', hidden: true } }
+  .modal-dialog.modal-dialog-centered{ role: 'document' }
+    .modal-content
+      .modal-header
+        %h5.modal-title
+          Stop excluding this request?
+      .modal-body
+        %p Please confirm that you want to stop excluding this request
+        = form_tag staging_workflow_excluded_request_path(staging_workflow, request_exclusion), method: :delete do
+          .modal-footer
+            %a.btn.btn-sm.btn-outline-secondary.px-4{ data: { dismiss: 'modal' } }
+              Cancel
+            = submit_tag('Accept', class: 'btn btn-sm btn-danger px-4')

--- a/src/api/app/views/webui2/webui/staging/excluded_requests/index.html.haml
+++ b/src/api/app/views/webui2/webui/staging/excluded_requests/index.html.haml
@@ -1,0 +1,33 @@
+.row
+  .col-xl-12
+    .card.mb-3
+      .card-body
+        %h3 Excluded Requests
+        %table.responsive.table.table-striped.table-bordered#excluded-requests-datatable
+          %thead
+            %tr.text-center
+              %th Request
+              %th Description
+              %th Actions
+          %tbody
+            - @request_exclusions.each do |request_exclusion|
+              %tr
+                %td= request_exclusion.bs_request.number
+                %td= request_exclusion.description
+                %td
+                  = link_to('#', data: { toggle: 'modal', target: "#delete-excluded-request-modal-#{request_exclusion.bs_request_id}" },
+                            title: 'Stop excluding request') do
+                    %i.fas.fa-times-circle.text-danger
+                  = render(partial: 'delete_dialog',
+                          locals: { staging_workflow: @staging_workflow, request_exclusion: request_exclusion })
+        = link_to('#', data: { toggle: 'modal', target: '#exclude-request-modal' }) do
+          %i.fas.fa-plus-circle.text-primary
+          Exclude request
+
+= render partial: 'create_dialog', locals: { requests: @requests }
+
+= content_for :ready_function do
+  :plain
+    $('#excluded-requests-datatable').DataTable({
+      responsive: true
+    });

--- a/src/api/app/views/webui2/webui/staging/workflows/_infos.html.haml
+++ b/src/api/app/views/webui2/webui/staging/workflows/_infos.html.haml
@@ -18,6 +18,6 @@
       -# TODO: add link to see the full list of ready requests
       %dd= render 'requests_list', requests: ready_requests, more_requests: more_ready_requests
 
-      %dt Ignored:
-      -# TODO: add link when IgnoredRequest model is done
-      %dd= render 'requests_list', requests: ignored_requests, more_requests: more_ignored_requests
+      %dt Excluded:
+      -# TODO: add link when ExcludedRequest model is done
+      %dd= render 'requests_list', requests: excluded_requests, more_requests: more_excluded_requests

--- a/src/api/app/views/webui2/webui/staging/workflows/show.html.haml
+++ b/src/api/app/views/webui2/webui/staging/workflows/show.html.haml
@@ -27,5 +27,5 @@
     = render partial: 'infos', locals: { staging_workflow: @staging_workflow, empty_projects: @empty_projects,
                                          unassigned_requests: @unassigned_requests, more_unassigned_requests: @more_unassigned_requests,
                                          ready_requests: @ready_requests, more_ready_requests: @more_ready_requests,
-                                         ignored_requests: @ignored_requests, more_ignored_requests: @more_ignored_requests,
+                                         excluded_requests: @excluded_requests, more_excluded_requests: @more_excluded_requests,
                                          project: @project, managers: @managers }

--- a/src/api/config/locales/en.yml
+++ b/src/api/config/locales/en.yml
@@ -24,3 +24,7 @@ en:
     formats:
       only_date: '%Y-%m-%d'
       default: '%Y-%m-%d %H:%M UTC'
+  activerecord:
+    attributes:
+      staging/request_exclusion:
+        bs_request_id: 'Request'

--- a/src/api/config/routes.rb
+++ b/src/api/config/routes.rb
@@ -462,6 +462,7 @@ OBSApi::Application.routes.draw do
 
   resources :staging_workflows, except: :index, controller: 'webui/staging/workflows', constraints: cons do
     resources :staging_projects, only: [:create, :destroy], controller: 'webui/staging/projects', param: :project_name, constraints: cons
+    resources :excluded_requests, controller: 'webui/staging/excluded_requests'
   end
 
   constraints(APIMatcher) do

--- a/src/api/db/migrate/20181030114152_create_staging_request_exclusions.rb
+++ b/src/api/db/migrate/20181030114152_create_staging_request_exclusions.rb
@@ -1,0 +1,11 @@
+class CreateStagingRequestExclusions < ActiveRecord::Migration[5.2]
+  def change
+    create_table :staging_request_exclusions, id: :integer, options: 'CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC' do |t|
+      t.references :staging_workflow, index: true, type: :integer, null: false
+      t.references :bs_request, index: true, type: :integer, null: false
+      t.string :description
+
+      t.timestamps
+    end
+  end
+end

--- a/src/api/db/structure.sql
+++ b/src/api/db/structure.sql
@@ -1142,6 +1142,18 @@ CREATE TABLE `sessions` (
   KEY `index_sessions_on_updated_at` (`updated_at`) USING BTREE
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
 
+CREATE TABLE `staging_request_exclusions` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `staging_workflow_id` int(11) NOT NULL,
+  `bs_request_id` int(11) NOT NULL,
+  `description` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `created_at` datetime NOT NULL,
+  `updated_at` datetime NOT NULL,
+  PRIMARY KEY (`id`),
+  KEY `index_staging_request_exclusions_on_staging_workflow_id` (`staging_workflow_id`),
+  KEY `index_staging_request_exclusions_on_bs_request_id` (`bs_request_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
+
 CREATE TABLE `staging_workflows` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `project_id` int(11) DEFAULT NULL,
@@ -1426,6 +1438,7 @@ INSERT INTO `schema_migrations` (version) VALUES
 ('20181008150453'),
 ('20181016103905'),
 ('20181025152009'),
+('20181030114152'),
 ('20181113095753');
 
 

--- a/src/api/spec/controllers/webui/staging/excluded_requests_controller_spec.rb
+++ b/src/api/spec/controllers/webui/staging/excluded_requests_controller_spec.rb
@@ -1,0 +1,71 @@
+require 'rails_helper'
+
+RSpec.describe Webui::Staging::ExcludedRequestsController, type: :controller do
+  let(:user) { create(:confirmed_user, login: 'tom') }
+  let(:project) { user.home_project }
+  let(:managers_group) { create(:group) }
+  let(:staging_workflow) { create(:staging_workflow_with_staging_projects, project: project, managers_group: managers_group) }
+
+  let(:source_package) { create(:package) }
+  let(:target_package) { create(:package, name: 'target_package', project: project) }
+  let(:bs_request) do
+    create(:bs_request_with_submit_action,
+           target_project: project.name,
+           target_package: target_package.name,
+           source_project: source_package.project.name,
+           source_package: source_package.name)
+  end
+
+  before do
+    login(user)
+  end
+
+  describe '#create' do
+    let(:description) { Faker::Lorem.sentence }
+
+    context 'success' do
+      before do
+        post :create, params: { staging_workflow_id: staging_workflow, staging_request_exclusion: { number: bs_request, description: description } }
+      end
+
+      it { expect(Staging::RequestExclusion.count).to eq(1) }
+      it { expect(staging_workflow.request_exclusions.first.description).to eq(description) }
+      it { expect(response).to redirect_to(staging_workflow_excluded_requests_path(staging_workflow)) }
+      it { expect(flash[:success]).not_to be_nil }
+    end
+
+    context "doesn't exist" do
+      before do
+        allow_any_instance_of(Staging::RequestExclusion).to receive(:save).and_return(false)
+        post :create, params: { staging_workflow_id: staging_workflow, staging_request_exclusion: { number: bs_request, description: description } }
+      end
+
+      it { expect(response).to redirect_to(staging_workflow_excluded_requests_path(staging_workflow)) }
+      it { expect(flash[:error]).not_to be_nil }
+    end
+  end
+
+  describe '#destroy' do
+    let(:request_exclusion) { create(:request_exclusion, staging_workflow: staging_workflow, bs_request: bs_request) }
+
+    context 'success' do
+      before do
+        delete :destroy, params: { staging_workflow_id: staging_workflow, id: request_exclusion }
+      end
+
+      it { expect(Staging::RequestExclusion.count).to eq(0) }
+      it { expect(response).to redirect_to(staging_workflow_excluded_requests_path(staging_workflow)) }
+      it { expect(flash[:success]).not_to be_nil }
+    end
+
+    context 'error' do
+      before do
+        allow_any_instance_of(Staging::RequestExclusion).to receive(:destroy).and_return(false)
+        delete :destroy, params: { staging_workflow_id: staging_workflow, id: request_exclusion }
+      end
+
+      it { expect(flash[:error]).not_to be_nil }
+      it { expect(response).to redirect_to(staging_workflow_excluded_requests_path(staging_workflow)) }
+    end
+  end
+end

--- a/src/api/spec/factories/staging_request_exclusions.rb
+++ b/src/api/spec/factories/staging_request_exclusions.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :request_exclusion, class: 'Staging::RequestExclusion' do
+    description { Faker::Lorem.sentence }
+  end
+end


### PR DESCRIPTION
Create request ignoration model, controller and views to create and delete ignored requests.

![2018-11-08-ignored_requests](https://user-images.githubusercontent.com/24919/48193164-24d7af00-e34a-11e8-99d3-c1d634c78eb9.gif)

Things to do (which will be done in following PRs - some of them are not only specific of this feature):

- API
- link to this page
- Improve factories (the managers can for example be created by default in the factory)
- Add validation and index to ensure that a request can not be excluded twice.
- Consider if project is needed as a parameter and if we want to render a staging workflow without project (independent of the decision there would be changes to make)
- Add staging workflow to breadcrumb