### PR TITLE
Show infos section on Staging Workflow layout

### DIFF
--- a/src/api/app/assets/stylesheets/webui2/dashed-list.scss
+++ b/src/api/app/assets/stylesheets/webui2/dashed-list.scss
@@ -1,0 +1,14 @@
+.dashed-list {
+    display: flex;
+    flex-wrap: wrap;
+    list-style: none;
+  }
+
+  .dashed-list-item + .dashed-list-item::before {
+    display: inline-block;
+    content: "-";
+  }
+
+  .dashed-list-item + .dashed-list-item {
+    padding-left: 0.25rem;
+  }

--- a/src/api/app/assets/stylesheets/webui2/webui2.css.scss
+++ b/src/api/app/assets/stylesheets/webui2/webui2.css.scss
@@ -24,6 +24,7 @@
 @import 'breadcrumbs-component';
 @import 'tabs-component';
 @import 'personal-navigation';
+@import 'dashed-list';
 @import 'list-group-item-integrated';
 @import 'icons';
 @import 'kaminari';

--- a/src/api/app/controllers/webui/staging_workflows_controller.rb
+++ b/src/api/app/controllers/webui/staging_workflows_controller.rb
@@ -38,6 +38,13 @@ class Webui::StagingWorkflowsController < Webui::WebuiController
     authorize @staging_workflow
 
     @project = @staging_workflow.project
+    @unassigned_requests = @staging_workflow.unassigned_requests.first(5)
+    @more_unassigned_requests = @staging_workflow.unassigned_requests.count - @unassigned_requests.size
+    @ready_requests = @staging_workflow.ready_requests.first(5)
+    @more_ready_requests = @staging_workflow.ready_requests.count - @ready_requests.size
+    @ignored_requests = @staging_workflow.ignored_requests.first(5)
+    @more_ignored_requests = @staging_workflow.ignored_requests.count - @ignored_requests.size
+    @empty_projects = @staging_workflow.staging_projects.without_staged_requests
   end
 
   private

--- a/src/api/app/models/project.rb
+++ b/src/api/app/models/project.rb
@@ -1692,6 +1692,10 @@ class Project < ApplicationRecord
     packages.find_by(name: 'dashboard')
   end
 
+  def staging_identifier
+    name[/.*:Staging:(.*)/, 1]
+  end
+
   private
 
   def discard_cache

--- a/src/api/app/views/webui2/webui/staging_workflows/_empty_projects_list.haml
+++ b/src/api/app/views/webui2/webui/staging_workflows/_empty_projects_list.haml
@@ -1,0 +1,7 @@
+- if projects.empty?
+  None
+- else
+  %ol.dashed-list.pl-2
+    - projects.sort.each do |project|
+      %li.dashed-list-item
+        = link_to(project.staging_identifier, project_show_path(project.name))

--- a/src/api/app/views/webui2/webui/staging_workflows/_infos.html.haml
+++ b/src/api/app/views/webui2/webui/staging_workflows/_infos.html.haml
@@ -1,4 +1,18 @@
 .card.mb-3
   %h5.card-header Infos
   .card-body
-    Placeholder for the content
+    %dl
+      %dt Empty projects:
+      %dd= render 'empty_projects_list', projects: empty_projects
+
+      %dt Backlog:
+      -# TODO: add link to see the full list of the backlog of requests
+      %dd= render 'requests_list', requests: unassigned_requests, more_requests: more_unassigned_requests
+
+      %dt Ready:
+      -# TODO: add link to see the full list of ready requests
+      %dd= render 'requests_list', requests: ready_requests, more_requests: more_ready_requests
+
+      %dt Ignored:
+      -# TODO: add link when IgnoredRequest model is done
+      %dd= render 'requests_list', requests: ignored_requests, more_requests: more_ignored_requests

--- a/src/api/app/views/webui2/webui/staging_workflows/_requests_list.haml
+++ b/src/api/app/views/webui2/webui/staging_workflows/_requests_list.haml
@@ -1,0 +1,8 @@
+- if requests.empty?
+  Empty
+- else
+  %ul.pl-2.list-unstyled
+    - requests.each do |request|
+      %li= link_to(elide(request.first_target_package, 19), request_show_path(request.number))
+    - unless more_requests.zero?
+      %li ... #{more_requests} more

--- a/src/api/app/views/webui2/webui/staging_workflows/show.html.haml
+++ b/src/api/app/views/webui2/webui/staging_workflows/show.html.haml
@@ -32,7 +32,11 @@
                   = render partial: 'problems', locals: { project: staging_project }
   .col-xl-2
     = render partial: 'legend'
-    = render partial: 'infos'
+    = render partial: 'infos', locals: { staging_workflow: @staging_workflow, empty_projects: @empty_projects,
+                                         unassigned_requests: @unassigned_requests, more_unassigned_requests: @more_unassigned_requests,
+                                         ready_requests: @ready_requests, more_ready_requests: @more_ready_requests,
+                                         ignored_requests: @ignored_requests, more_ignored_requests: @more_ignored_requests,
+                                         project: @project }
 
 - content_for :ready_function do
   $('#staging-projects-datatable').DataTable({ responsive: true });

--- a/src/api/spec/factories/bs_requests.rb
+++ b/src/api/spec/factories/bs_requests.rb
@@ -11,7 +11,7 @@ FactoryBot.define do
       target_package { nil }
       target_repository { nil }
       reviewer { nil }
-      request_state { 'review' }
+      request_state { nil }
     end
 
     before(:create) do |request, evaluator|
@@ -41,6 +41,10 @@ FactoryBot.define do
           source_project: evaluator.source_project,
           source_package: evaluator.source_package
         )
+        if evaluator.request_state
+          request.state = evaluator.request_state
+          request.save!
+        end
       end
     end
 
@@ -86,7 +90,7 @@ FactoryBot.define do
           source_package: evaluator.source_package
         )
         request.reviews << Review.new(by_group: evaluator.reviewer)
-        request.state = evaluator.request_state
+        request.state = evaluator.request_state || 'review'
         request.save!
       end
     end

--- a/src/api/spec/models/project_spec.rb
+++ b/src/api/spec/models/project_spec.rb
@@ -603,4 +603,10 @@ RSpec.describe Project, vcr: true do
       'sourceaccess' => [['enable', {}]], 'access' => [['enable', {}]])
     }
   end
+
+  describe '#staging_identifier' do
+    let(:staging_project) { create(:project, name: 'openSUSE_41:Staging:myStagingProject') }
+
+    it { expect(staging_project.staging_identifier).to eq('myStagingProject') }
+  end
 end

--- a/src/api/spec/models/staging_workflow_spec.rb
+++ b/src/api/spec/models/staging_workflow_spec.rb
@@ -9,13 +9,14 @@ RSpec.describe StagingWorkflow, type: :model do
   let(:source_package) { create(:package, name: 'source_package', project: source_project) }
   let(:bs_request) do
     create(:bs_request_with_submit_action,
+           request_state: 'review',
            target_project: project.name,
            target_package: target_package.name,
            source_project: source_project.name,
            source_package: source_package.name)
   end
 
-  describe '#unassigned_request' do
+  describe '#unassigned_requests' do
     subject { staging_workflow.unassigned_requests }
 
     context 'without requests in the main project' do
@@ -33,6 +34,37 @@ RSpec.describe StagingWorkflow, type: :model do
         bs_request.staging_project = staging_project
         bs_request.save
       end
+
+      it { expect(subject).to be_empty }
+    end
+
+    context 'with requests and some are in staging projects and some not' do
+      let!(:bs_request_2) do
+        create(:bs_request_with_submit_action,
+               target_project: project.name,
+               target_package: target_package.name,
+               source_project: source_project.name,
+               source_package: source_package.name)
+      end
+
+      before do
+        bs_request.staging_project = staging_project
+        bs_request.save
+      end
+
+      it { expect(subject).to contain_exactly(bs_request_2) }
+    end
+  end
+
+  describe '#ready_requests' do
+    subject { staging_workflow.ready_requests }
+
+    context 'without requests in the main project' do
+      it { expect(subject).to be_empty }
+    end
+
+    context 'with requests but not in state new' do
+      before { bs_request }
 
       it { expect(subject).to be_empty }
     end


### PR DESCRIPTION
The Infos section, on the right side, contains the lists of empty projects and requests available to be associated to the Staging Workflow.

![image](https://user-images.githubusercontent.com/11314634/48147331-5a7f8800-e2b7-11e8-95d9-49fcdf0f95af.png)

This supersedes #6186