### PR TITLE
Avoid to create records referencing nonexistent objects

### DIFF
--- a/src/api/app/models/download_repository.rb
+++ b/src/api/app/models/download_repository.rb
@@ -3,7 +3,7 @@ class DownloadRepository < ApplicationRecord
 
   belongs_to :repository
 
-  validates :repository_id, presence: true
+  validates :repository, presence: true
   validates :arch, uniqueness: { scope: :repository_id }, presence: true
   validate :architecture_inclusion
   validates :url, presence: true, format: { with: /\A[a-zA-Z]+:.*\Z/ } # from backend/BSVerify.pm

--- a/src/api/app/models/repository.rb
+++ b/src/api/app/models/repository.rb
@@ -32,7 +32,7 @@ class Repository < ApplicationRecord
   validates :name, uniqueness: { scope: [:db_project_id, :remote_project_name],
                                  message: '%{value} is already used by a repository of this project' }
 
-  validates :db_project_id, presence: true
+  validates :project, presence: true
   # NOTE: remote_project_name cannot be NULL because mysql UNIQUE KEY constraint does considers
   #       two NULL's to be distinct. (See mysql bug #8173)
   validate :remote_project_name_not_nill

--- a/src/api/app/models/token.rb
+++ b/src/api/app/models/token.rb
@@ -4,7 +4,7 @@ class Token < ApplicationRecord
 
   has_secure_token :string
 
-  validates :user_id, presence: true
+  validates :user, presence: true
 end
 
 # == Schema Information

--- a/src/api/spec/models/download_repository_spec.rb
+++ b/src/api/spec/models/download_repository_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe DownloadRepository do
     it { is_expected.to validate_presence_of(:url) }
     it { is_expected.to validate_presence_of(:arch) }
     it { is_expected.to validate_presence_of(:repotype) }
-    it { is_expected.to validate_presence_of(:repository_id) }
+    it { is_expected.to validate_presence_of(:repository) }
     it { is_expected.to validate_uniqueness_of(:arch).scoped_to(:repository_id) }
     it { is_expected.to validate_inclusion_of(:repotype).in_array(['rpmmd', 'susetags', 'deb', 'arch', 'mdk']) }
 

--- a/src/api/spec/models/repository_spec.rb
+++ b/src/api/spec/models/repository_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.describe Repository do
   describe 'validations' do
     it { is_expected.to validate_length_of(:name).is_at_least(1).is_at_most(200) }
-    it { is_expected.to validate_presence_of(:db_project_id) }
+    it { is_expected.to validate_presence_of(:project) }
     it 'validates uniqueness of name' do
       repository = create(:repository)
       expect(repository).to validate_uniqueness_of(:name).


### PR DESCRIPTION
Make it fail in the application level instead of in the database. :bowtie: 