### PR TITLE
Request create with pundit

### DIFF
--- a/src/api/app/policies/bs_request_policy.rb
+++ b/src/api/app/policies/bs_request_policy.rb
@@ -1,0 +1,14 @@
+class BsRequestPolicy < ApplicationPolicy
+  def initialize(user, record)
+    raise Pundit::NotAuthorizedError, 'record does not exist' unless record
+    @user = user
+    @record = record
+  end
+
+  def create?
+    # new request should not have an id (BsRequest#number)
+    return false if @record.number
+    # dont let user set approver other than himself unless he is admin
+    ![nil, @user.login].include?(@record.approver) && !@user.is_admin? ? false : true
+  end
+end

--- a/src/api/test/functional/request_controller_test.rb
+++ b/src/api/test/functional/request_controller_test.rb
@@ -831,6 +831,36 @@ class RequestControllerTest < ActionDispatch::IntegrationTest
     assert_equal id, first_node['requestid']
   end
 
+  def test_create_request_with_approver
+    req_template = <<~XML_REQUEST
+      <request>
+        <action type="submit">
+          <source project="home:Iggy" package="TestPack" rev="1"/>
+          <target project="home:fred" package="foopkg"/>
+        </action>
+        <review by_group="test_group"/>
+        <state approver="%<approver>s"/>
+      </request>
+    XML_REQUEST
+
+    login_Iggy
+    # request creation fails because we are not admin
+    post '/request?cmd=create', params: format(req_template, approver: 'fred')
+    assert_response 403
+    assert_xml_tag(tag: 'status', attributes: { code: 'create_bs_request_not_authorized' })
+    assert_xml_tag(tag: 'summary', content: 'You are not authorized to create this Bs request.')
+
+    # request creation succeeds because we are "Iggy"
+    post '/request?cmd=create', params: format(req_template, approver: 'Iggy')
+    assert_response :success
+
+    # as admin it should work
+    login_king
+    # request creation succeeds because we are "Iggy"
+    post '/request?cmd=create', params: format(req_template, approver: 'Iggy')
+    assert_response :success
+  end
+
   def test_create_request_and_supersede
     login_Iggy
     req = load_backend_file('request/works')


### PR DESCRIPTION
Add pundit policy to the ```RequestController#create``` API endpoint. Move authorization logic to the ```BsRequestPolicy#create?``` method
