### PR TITLE
 Avoid calling strptime with an empty string

### DIFF
--- a/src/api/app/models/binary_release.rb
+++ b/src/api/app/models/binary_release.rb
@@ -202,9 +202,11 @@ class BinaryRelease < ApplicationRecord
   end
 
   def indentical_to?(binary_hash)
+    time = Time.strptime(binary_hash['buildtime'].to_s, '%s') if binary_hash['buildtime'].present?
+
     binary_disturl == binary_hash['disturl'] &&
       binary_supportstatus == binary_hash['supportstatus'] &&
-      binary_buildtime == Time.strptime(binary_hash['buildtime'].to_s, '%s')
+      binary_buildtime == time
   end
   #### Alias of methods
 end


### PR DESCRIPTION
This was caused by https://github.com/openSUSE/open-build-service/commit/e9f6f907bc6af777fe244745baf3d5067c17ca4d#diff-49563098f1992cafd3f7c8195f53a383. Although the code was wrong at that point, because it didn't return `false` if both build times were nil.

Fixes #6240 :bowtie: 