### PR TITLE
Show staging in project tabs list

### DIFF
--- a/src/api/app/views/webui/project/_tabs.html.erb
+++ b/src/api/app/views/webui/project/_tabs.html.erb
@@ -39,6 +39,7 @@
         <%= tab 'meta', "Meta", :controller => '/webui/project', :action => :meta %>
         <%= tab 'status', 'Status', :controller => '/webui/project', :action => :status unless @project.defines_remote_instance? || @is_maintenance_project %>
         <%= tab 'pulse', 'Pulse', :controller => '/webui/project', :action => :pulse %>
+        <%= tab 'staging', 'Staging', controller: '/webui/staging/workflows', action: :new unless @project.defines_remote_instance? || @is_maintenance_project %>
       <% end -%>
     </ul>
   </div>

--- a/src/api/app/views/webui2/webui/project/_tabs.html.haml
+++ b/src/api/app/views/webui2/webui/project/_tabs.html.haml
@@ -16,11 +16,6 @@
       - unless project.defines_remote_instance?
         %li.nav-item
           = tab_link('Users', project_users_path(project))
-      // This link is intentionally hidden, only users that access to the staging workflow show will see it
-      // TODO: show it if the project have a staging_workflow attached when this feature will be released
-      - if controller_name == 'staging_workflows'
-        %li.nav-item
-          = tab_link('Staging', request.url, controller_name == 'staging_workflows')
       - unless project.defines_remote_instance? || project.is_maintenance?
         %li.nav-item
           = tab_link('Subprojects', project_subprojects_path(project))
@@ -35,6 +30,9 @@
           = tab_link('Status', project_status_path(project))
       %li.nav-item
         = tab_link('Pulse', project_pulse_path(project))
+      - unless project.defines_remote_instance? || project.is_maintenance?
+        %li.nav-item
+          = tab_link('Staging', request.url, controller_name == 'staging_workflows')
     %li.nav-item.dropdown
       %a.nav-link.dropdown-toggle{ href: '#', 'data-toggle': 'dropdown', 'role': 'button', 'aria-expanded': 'false', 'aria-haspopup': 'true' }
       .dropdown-menu.dropdown-menu-right


### PR DESCRIPTION
![selection_010](https://user-images.githubusercontent.com/3799140/48421574-111eb500-e75d-11e8-9d24-f80829f20799.png)

As we work now in a feature branch we can get rid of the hack now.

Open question: Do we want to put it into the Advanced tab?