### PR TITLE
Fix StagingWorkflow#backlog

### DIFF
--- a/src/api/app/models/staging/workflow.rb
+++ b/src/api/app/models/staging/workflow.rb
@@ -36,7 +36,7 @@ class Staging::Workflow < ApplicationRecord
   before_update :update_staging_projects_managers_group
 
   def unassigned_requests
-    target_of_bs_requests.stageable.where.not(id: excluded_requests | staged_requests)
+    target_of_bs_requests.stageable.where.not(id: excluded_requests)
   end
 
   def ready_requests

--- a/src/api/app/models/staging/workflow.rb
+++ b/src/api/app/models/staging/workflow.rb
@@ -40,7 +40,7 @@ class Staging::Workflow < ApplicationRecord
   end
 
   def ready_requests
-    target_of_bs_requests.ready_to_stage.where.not(id: excluded_requests | staged_requests)
+    target_of_bs_requests.ready_to_stage.where.not(id: excluded_requests)
   end
 
   def write_to_backend

--- a/src/api/app/models/staging/workflow.rb
+++ b/src/api/app/models/staging/workflow.rb
@@ -17,7 +17,8 @@ class Staging::Workflow < ApplicationRecord
 
   has_many :target_of_bs_requests, through: :project, foreign_key: 'staging_workflow_id' do
     def stageable
-      in_states(['new', 'review'])
+      managers_group_title = proxy_association.owner.managers_group.try(:title)
+      includes(:reviews).where(state: :review, reviews: { state: :new, by_group: managers_group_title })
     end
 
     def ready_to_stage

--- a/src/api/app/views/webui2/webui/staging/workflows/_infos.html.haml
+++ b/src/api/app/views/webui2/webui/staging/workflows/_infos.html.haml
@@ -13,8 +13,7 @@
       %dt= link_to('Backlog:', group_show_path(staging_workflow.managers_group))
       %dd= render 'requests_list', requests: unassigned_requests, more_requests: more_unassigned_requests
 
-      %dt Ready:
-      -# TODO: add link to see the full list of ready requests
+      %dt= link_to('Ready:', project_requests_path(staging_workflow.project, state: :new))
       %dd= render 'requests_list', requests: ready_requests, more_requests: more_ready_requests
 
       %dt Excluded:

--- a/src/api/app/views/webui2/webui/staging/workflows/_infos.html.haml
+++ b/src/api/app/views/webui2/webui/staging/workflows/_infos.html.haml
@@ -10,8 +10,7 @@
       %dt Empty projects:
       %dd= render 'empty_projects_list', projects: empty_projects
 
-      %dt Backlog:
-      -# TODO: add link to see the full list of the backlog of requests
+      %dt= link_to('Backlog:', group_show_path(staging_workflow.managers_group))
       %dd= render 'requests_list', requests: unassigned_requests, more_requests: more_unassigned_requests
 
       %dt Ready:

--- a/src/api/spec/controllers/staging/staged_requests_controller_spec.rb
+++ b/src/api/spec/controllers/staging/staged_requests_controller_spec.rb
@@ -7,18 +7,22 @@ RSpec.describe Staging::StagedRequestsController, type: :controller, vcr: true d
   let(:user) { create(:confirmed_user, login: 'permitted_user') }
   let(:project) { user.home_project }
   let(:staging_workflow) { create(:staging_workflow_with_staging_projects, project: project) }
+  let(:group) { staging_workflow.managers_group }
   let(:staging_project) { staging_workflow.staging_projects.first }
   let(:source_project) { create(:project, name: 'source_project') }
   let(:target_package) { create(:package, name: 'target_package', project: project) }
   let(:source_package) { create(:package, name: 'source_package', project: source_project) }
+  let(:review) { create(:review, by_group: group.title) }
   let(:bs_request) do
     create(:bs_request_with_submit_action,
+           state: :review,
            creator: other_user,
            target_project: project.name,
            target_package: target_package.name,
            source_project: source_project.name,
            source_package: source_package.name,
-           description: 'BsRequest 1')
+           description: 'BsRequest 1',
+           reviews: [review])
   end
 
   describe 'GET #index' do

--- a/src/api/spec/models/staging/workflow_spec.rb
+++ b/src/api/spec/models/staging/workflow_spec.rb
@@ -3,13 +3,14 @@ require 'rails_helper'
 RSpec.describe Staging::Workflow, type: :model do
   let(:project) { create(:project_with_package, name: 'MyProject') }
   let(:staging_workflow) { create(:staging_workflow_with_staging_projects, project: project) }
+  let(:group) { staging_workflow.managers_group }
   let(:staging_project) { staging_workflow.staging_projects.first }
   let(:source_project) { create(:project, name: 'source_project') }
   let(:target_package) { create(:package, name: 'target_package', project: project) }
   let(:source_package) { create(:package, name: 'source_package', project: source_project) }
   let(:bs_request) do
     create(:bs_request_with_submit_action,
-           request_state: 'review',
+           request_state: :review,
            target_project: project.name,
            target_package: target_package.name,
            source_project: source_project.name,
@@ -23,13 +24,19 @@ RSpec.describe Staging::Workflow, type: :model do
       it { expect(subject).to be_empty }
     end
 
-    context 'with requests but not in staging projects' do
+    context 'with requests without reviews by the staging managers group' do
       before { bs_request }
+
+      it { expect(subject).to be_empty }
+    end
+
+    context 'with requests with reviews by the staging managers group' do
+      let!(:review) { create(:review, by_group: group.title, bs_request: bs_request) }
 
       it { expect(subject).to contain_exactly(bs_request) }
     end
 
-    context 'with requests but all of them are in staging projects' do
+    context 'with requests but all of them are already assigned' do
       before do
         bs_request.staging_project = staging_project
         bs_request.save
@@ -39,12 +46,15 @@ RSpec.describe Staging::Workflow, type: :model do
     end
 
     context 'with requests and some are in staging projects and some not' do
+      let(:review2) { create(:review, by_group: group.title) }
       let!(:bs_request_2) do
         create(:bs_request_with_submit_action,
                target_project: project.name,
                target_package: target_package.name,
                source_project: source_project.name,
-               source_package: source_package.name)
+               source_package: source_package.name,
+               reviews: [review2],
+               state: :review)
       end
 
       before do


### PR DESCRIPTION
The assocation was wrong as it should only consider
* Requests in state :review
* with reviews in state :new and by_group of the staging managers
* with the target project of the distribution

Furthermore it changes the ``unassigned_reqeuests`` method to return an ActiveRecordCollection to be more efficient and make it easier to work with.

Additionally added a link to the GroupShow page which is currently used as Backlog.