### PR TITLE
Adapt staging workflow's breadcrumb to new namespace

### DIFF
--- a/src/api/app/views/webui2/webui/staging/workflows/_breadcrumb_items.html.haml
+++ b/src/api/app/views/webui2/webui/staging/workflows/_breadcrumb_items.html.haml
@@ -1,13 +1,13 @@
 = render partial: 'webui/project/breadcrumb_items'
-- if controller_name == 'staging_workflows' && action_name == 'show'
+- if controller_name == 'workflows' && action_name == 'show'
   %li.breadcrumb-item.active{ 'aria-current' => 'page' }
     Staging Projects
-- elsif controller_name == 'staging_workflows' && action_name == 'new'
+- elsif controller_name == 'workflows' && action_name == 'new'
   %li.breadcrumb-item.active{ 'aria-current' => 'page' }
     Create Staging Projects
 - else
   %li.breadcrumb-item
-    = link_to 'Staging Projects', staging_workflows_path(@staging_workflow)
-  - if controller_name == 'staging_workflows' && action_name == 'edit'
+    = link_to 'Staging Projects', staging_workflow_path(@staging_workflow)
+  - if controller_name == 'workflows' && action_name == 'edit'
     %li.breadcrumb-item.active{ 'aria-current' => 'page' }
       Edit


### PR DESCRIPTION
Adapt breadcrumb to the new namespace and also fix the path to staging workflow show action 
Co-authored-by: David Kang <dkang@suse.com>

