### PR TITLE
Add default_scope to StagingProject

### DIFF
--- a/src/api/app/models/staging/staging_project.rb
+++ b/src/api/app/models/staging/staging_project.rb
@@ -4,6 +4,8 @@ module Staging
     has_many :status_reports, through: :repositories, inverse_of: :checkable
     belongs_to :staging_workflow, class_name: 'Staging::Workflow'
 
+    default_scope { where.not(staging_workflow: nil) }
+
     def staging_identifier
       name[/.*:Staging:(.*)/, 1]
     end

--- a/src/api/app/models/staging/workflow.rb
+++ b/src/api/app/models/staging/workflow.rb
@@ -41,7 +41,8 @@ class Staging::Workflow < ApplicationRecord
 
   def create_staging_projects
     ['A', 'B'].each do |letter|
-      staging_project = Staging::StagingProject.find_or_initialize_by(name: "#{project.name}:Staging:#{letter}")
+      parent = Project.find_or_initialize_by(name: "#{project.name}:Staging:#{letter}")
+      staging_project = parent.becomes(Staging::StagingProject)
       next if staging_project.staging_workflow # if it belongs to another staging workflow skip it
       staging_project.staging_workflow = self
       staging_project.store


### PR DESCRIPTION
because otherwise using ActiveRecord query methods will consider
all Projects and not only StagingProjects.
This causes some weird issues like returning Projects without
a Staging::Workflow associated.

