### PR TITLE
Fix unknown view 'status' error

### DIFF
--- a/src/api/app/models/repository_architecture.rb
+++ b/src/api/app/models/repository_architecture.rb
@@ -10,7 +10,8 @@ class RepositoryArchitecture < ApplicationRecord
   validates :repository, uniqueness: { scope: :architecture }
 
   def build_id
-    Backend::Api::Build::Repository.build_id(repository.project.name, repository.name, architecture.name)
+    #Backend::Api::Build::Repository.build_id(repository.project.name, repository.name, architecture.name)
+    ''
   end
 end
 


### PR DESCRIPTION
as Backend is not deployed yet we need to comment this code for now.

Kudos to @coolo for quickly fixing.

We can revert this patch when Backend deployed build_id for unpublished repositories.

