### PR TITLE
Staging workflow managers group

### DIFF
--- a/src/api/app/assets/javascripts/webui2/staging_workflow.js
+++ b/src/api/app/assets/javascripts/webui2/staging_workflow.js
@@ -7,3 +7,21 @@ function setSpinnersForDeletion() { // jshint ignore:line
     $(this).find('.delete-spinner').addClass('d-none');
   });
 }
+
+function autocompleteStagingManagersGroup() { // jshint ignore:line
+  $('#managers_title').autocomplete({
+    appendTo: '#assign-managers-group-modal-input',
+    source: $('#managers_title').data('autocompleteGroupsUrl'),
+    search: function() {
+      var icon = $('#assign-managers-group-search-icon i:first-child');
+      icon.addClass('d-none');
+      icon.next().removeClass('d-none');
+    },
+    response: function() {
+      var icon = $('#assign-managers-group-search-icon i:first-child');
+      icon.removeClass('d-none');
+      icon.next().addClass('d-none');
+    },
+    minLength: 2
+  });
+}

--- a/src/api/app/controllers/webui/staging/projects_controller.rb
+++ b/src/api/app/controllers/webui/staging/projects_controller.rb
@@ -12,6 +12,7 @@ module Webui
 
         staging_project_name = "#{@staging_workflow.project}:Staging:#{params[:staging_project_name]}"
         staging_project = @staging_workflow.staging_projects.build(name: staging_project_name)
+        staging_project.assign_managers_group(@staging_workflow.managers_group)
 
         if staging_project.valid? && staging_project.store
           flash[:success] = "Staging project with name = \"#{staging_project}\" was successfully created"

--- a/src/api/app/controllers/webui/staging/projects_controller.rb
+++ b/src/api/app/controllers/webui/staging/projects_controller.rb
@@ -50,7 +50,7 @@ module Webui
         return if @staging_workflow
 
         redirect_back(fallback_location: root_path)
-        flash[:error] = "StagingWorkflow with id = #{params[:staging_workflow_id]} doesn't exist"
+        flash[:error] = "Staging with id = #{params[:staging_workflow_id]} doesn't exist"
         return
       end
     end

--- a/src/api/app/controllers/webui/staging/projects_controller.rb
+++ b/src/api/app/controllers/webui/staging/projects_controller.rb
@@ -12,7 +12,6 @@ module Webui
 
         staging_project_name = "#{@staging_workflow.project}:Staging:#{params[:staging_project_name]}"
         staging_project = @staging_workflow.staging_projects.build(name: staging_project_name)
-        staging_project.assign_managers_group(@staging_workflow.managers_group)
 
         if staging_project.valid? && staging_project.store
           flash[:success] = "Staging project with name = \"#{staging_project}\" was successfully created"

--- a/src/api/app/controllers/webui/staging/workflows_controller.rb
+++ b/src/api/app/controllers/webui/staging/workflows_controller.rb
@@ -20,6 +20,8 @@ class Webui::Staging::WorkflowsController < Webui::WebuiController
     staging_workflow = @project.build_staging
     authorize staging_workflow
 
+    staging_workflow.managers_group = Group.find_by(title: params[:managers_title])
+
     if staging_workflow.save
       flash[:success] = "Staging Workflow for #{@project.name} was successfully created"
       redirect_to staging_workflow_path(staging_workflow)

--- a/src/api/app/controllers/webui/staging/workflows_controller.rb
+++ b/src/api/app/controllers/webui/staging/workflows_controller.rb
@@ -72,23 +72,11 @@ class Webui::Staging::WorkflowsController < Webui::WebuiController
   def update
     authorize @staging_workflow
 
-    begin
-      Staging::Workflow.transaction do
-        old_managers_group = @staging_workflow.managers_group
-        new_managers_group = Group.find_by(title: params[:managers_title])
-
-        @staging_workflow.staging_projects.each do |staging_project|
-          staging_project.unassign_managers_group(old_managers_group)
-          staging_project.assign_managers_group(new_managers_group)
-          staging_project.store
-        end
-
-        @staging_workflow.managers_group = new_managers_group
-        @staging_workflow.save!
-      end
-      flash[:success] = 'Managers group if staging was successfully assigned'
-    rescue
-      flash[:error] = "Sorry, something unexpected happended and the group couldn't be assigned to this staging"
+    @staging_workflow.managers_group = Group.find_by(title: params[:managers_title])
+    if @staging_workflow.save
+      flash[:success] = 'Managers group was successfully assigned'
+    else
+      flash[:error] = "Managers group couldn't be assigned: #{@staging_workflow.errors.full_messages.to_sentence}."
     end
 
     redirect_to edit_staging_workflow_path(@staging_workflow)

--- a/src/api/app/controllers/webui/staging/workflows_controller.rb
+++ b/src/api/app/controllers/webui/staging/workflows_controller.rb
@@ -23,10 +23,10 @@ class Webui::Staging::WorkflowsController < Webui::WebuiController
     staging_workflow.managers_group = Group.find_by(title: params[:managers_title])
 
     if staging_workflow.save
-      flash[:success] = "Staging Workflow for #{@project.name} was successfully created"
+      flash[:success] = "Staging for #{@project} was successfully created"
       redirect_to staging_workflow_path(staging_workflow)
     else
-      flash[:error] = "Staging Workflow for #{@project.name} couldn't be created"
+      flash[:error] = "Staging for #{@project} couldn't be created"
       render :new
     end
   end
@@ -61,10 +61,10 @@ class Webui::Staging::WorkflowsController < Webui::WebuiController
     @staging_workflow.staging_projects.where(id: params[:staging_project_ids]).destroy_all
 
     if @staging_workflow.destroy
-      flash[:success] = "Staging Workflow for #{@project.name} was successfully deleted."
+      flash[:success] = "Staging for #{@project} was successfully deleted."
       render js: "window.location='#{project_show_path(@project)}'"
     else
-      flash[:error] = "Staging Workflow for #{@project.name} couldn't be deleted: #{@staging_workflow.errors.full_messages.to_sentence}."
+      flash[:error] = "Staging for #{@project} couldn't be deleted: #{@staging_workflow.errors.full_messages.to_sentence}."
       render js: "window.location='#{staging_workflow_path(@staging_workflow)}'"
     end
   end
@@ -105,7 +105,7 @@ class Webui::Staging::WorkflowsController < Webui::WebuiController
     return if @staging_workflow
 
     redirect_back(fallback_location: root_path)
-    flash[:error] = "StagingWorkflow with id = #{params[:id]} doesn't exist"
+    flash[:error] = "Staging with id = #{params[:id]} doesn't exist"
     return
   end
 end

--- a/src/api/app/controllers/webui/staging/workflows_controller.rb
+++ b/src/api/app/controllers/webui/staging/workflows_controller.rb
@@ -66,6 +66,19 @@ class Webui::Staging::WorkflowsController < Webui::WebuiController
     end
   end
 
+  def update
+    authorize @staging_workflow
+
+    @staging_workflow.managers = Group.find_by(title: params[:managers_id])
+
+    if @staging_workflow.save
+      flash[:success] = 'Managers group for Staging Workflow was successfully assigned'
+    else
+      flash[:error] = "Sorry the group couldn't be assigned to this Staging Workflow"
+    end
+    redirect_to edit_staging_workflow_path(@staging_workflow)
+  end
+
   private
 
   def set_bootstrap_views

--- a/src/api/app/controllers/webui/staging/workflows_controller.rb
+++ b/src/api/app/controllers/webui/staging/workflows_controller.rb
@@ -41,6 +41,7 @@ class Webui::Staging::WorkflowsController < Webui::WebuiController
     @ignored_requests = @staging_workflow.ignored_requests.first(5)
     @more_ignored_requests = @staging_workflow.ignored_requests.count - @ignored_requests.size
     @empty_projects = @staging_workflow.staging_projects.without_staged_requests
+    @managers = @staging_workflow.managers_group
   end
 
   def edit

--- a/src/api/app/models/group.rb
+++ b/src/api/app/models/group.rb
@@ -5,6 +5,7 @@ require_dependency 'api_exception'
 # Groups have an arbitrary number of roles and users assigned to them.
 #
 class Group < ApplicationRecord
+  has_one :staging_workflow, class_name: 'Staging::Workflow', foreign_key: :managers_group_id, dependent: :nullify
   has_many :groups_users, inverse_of: :group, dependent: :destroy
   has_many :users, -> { distinct }, through: :groups_users
   has_many :group_maintainers, inverse_of: :group, dependent: :destroy

--- a/src/api/app/models/staging/staging_project.rb
+++ b/src/api/app/models/staging/staging_project.rb
@@ -8,6 +8,7 @@ module Staging
 
     after_save :update_staging_workflow_on_backend
     after_destroy :update_staging_workflow_on_backend
+    before_create :add_managers_group
 
     def staging_identifier
       name[/.*:Staging:(.*)/, 1]
@@ -195,6 +196,10 @@ module Staging
 
       staging_workflow.reload
       staging_workflow.write_to_backend
+    end
+
+    def add_managers_group
+      assign_managers_group(staging_workflow.managers_group)
     end
   end
 end

--- a/src/api/app/models/staging/staging_project.rb
+++ b/src/api/app/models/staging/staging_project.rb
@@ -88,6 +88,17 @@ module Staging
       @problems ||= cache_problems
     end
 
+    def assign_managers_group(managers)
+      role = Role.find_by_title!('maintainer')
+      return if relationships.find_by(group: managers, role: role)
+      Relationship.add_group(self, managers, role, nil, true)
+    end
+
+    def unassign_managers_group(managers)
+      role = Role.find_by_title!('maintainer')
+      relationships.find_by(group: managers, role: role).try(:destroy!)
+    end
+
     private
 
     def cache_problems

--- a/src/api/app/models/staging/workflow.rb
+++ b/src/api/app/models/staging/workflow.rb
@@ -6,6 +6,8 @@ class Staging::Workflow < ApplicationRecord
   include CanRenderModel
 
   belongs_to :project, inverse_of: :staging
+  belongs_to :managers, class_name: 'Group'
+
   has_many :staging_projects, class_name: 'Staging::StagingProject', inverse_of: :staging_workflow, dependent: :nullify,
                               foreign_key: 'staging_workflow_id' do
     def without_staged_requests
@@ -24,6 +26,8 @@ class Staging::Workflow < ApplicationRecord
   end
 
   has_many :staged_requests, class_name: 'BsRequest', through: :staging_projects
+
+  validates :managers, presence: true
 
   after_create :create_staging_projects
 

--- a/src/api/app/models/staging/workflow.rb
+++ b/src/api/app/models/staging/workflow.rb
@@ -6,7 +6,7 @@ class Staging::Workflow < ApplicationRecord
   include CanRenderModel
 
   belongs_to :project, inverse_of: :staging
-  belongs_to :managers, class_name: 'Group'
+  belongs_to :managers_group, class_name: 'Group'
 
   has_many :staging_projects, class_name: 'Staging::StagingProject', inverse_of: :staging_workflow, dependent: :nullify,
                               foreign_key: 'staging_workflow_id' do
@@ -27,7 +27,7 @@ class Staging::Workflow < ApplicationRecord
 
   has_many :staged_requests, class_name: 'BsRequest', through: :staging_projects
 
-  validates :managers, presence: true
+  validates :managers_group, presence: true
 
   after_create :create_staging_projects
 
@@ -57,6 +57,7 @@ class Staging::Workflow < ApplicationRecord
       staging_project = parent.becomes(Staging::StagingProject)
       next if staging_project.staging_workflow # if it belongs to another staging workflow skip it
       staging_project.staging_workflow = self
+      staging_project.assign_managers_group(managers_group)
       staging_project.store
     end
   end

--- a/src/api/app/models/staging/workflow.rb
+++ b/src/api/app/models/staging/workflow.rb
@@ -57,7 +57,6 @@ class Staging::Workflow < ApplicationRecord
       staging_project = parent.becomes(Staging::StagingProject)
       next if staging_project.staging_workflow # if it belongs to another staging workflow skip it
       staging_project.staging_workflow = self
-      staging_project.assign_managers_group(managers_group)
       staging_project.store
     end
   end

--- a/src/api/app/policies/staging/workflow_policy.rb
+++ b/src/api/app/policies/staging/workflow_policy.rb
@@ -13,6 +13,10 @@ class Staging::WorkflowPolicy < ApplicationPolicy
     ProjectPolicy.new(@user, @record.project).update?
   end
 
+  def assign_managers_group?
+    update?
+  end
+
   def edit?
     update?
   end

--- a/src/api/app/views/models/staging/_workflow.xml.builder
+++ b/src/api/app/views/models/staging/_workflow.xml.builder
@@ -1,4 +1,4 @@
-xml.workflow(project: my_model.project.name) do
+xml.workflow(project: my_model.project.name, managers: my_model.managers_group.title) do
   my_model.staging_projects.each do |staging_project|
     xml.staging_project(name: staging_project.name)
   end

--- a/src/api/app/views/webui2/webui/staging/workflows/_breadcrumb_items.html.haml
+++ b/src/api/app/views/webui2/webui/staging/workflows/_breadcrumb_items.html.haml
@@ -1,13 +1,13 @@
 = render partial: 'webui/project/breadcrumb_items'
 - if controller_name == 'workflows' && action_name == 'show'
   %li.breadcrumb-item.active{ 'aria-current' => 'page' }
-    Staging Projects
+    Staging
 - elsif controller_name == 'workflows' && action_name == 'new'
   %li.breadcrumb-item.active{ 'aria-current' => 'page' }
     Create Staging Projects
 - else
   %li.breadcrumb-item
-    = link_to 'Staging Projects', staging_workflow_path(@staging_workflow)
+    = link_to 'Staging', staging_workflow_path(@staging_workflow)
   - if controller_name == 'workflows' && action_name == 'edit'
     %li.breadcrumb-item.active{ 'aria-current' => 'page' }
-      Edit
+      Configure

--- a/src/api/app/views/webui2/webui/staging/workflows/_delete.html.haml
+++ b/src/api/app/views/webui2/webui/staging/workflows/_delete.html.haml
@@ -3,9 +3,9 @@
     .modal-content
       .modal-header
         %h5.modal-title
-          Do you want to delete the staging workflow for #{project.name}?
+          Do you want to delete the staging for #{project.name}?
       .modal-body
-        %p Please confirm deletion of the staging workflow for #{project.name}
+        %p Please confirm deletion of the staging for #{project.name}
         = form_tag staging_workflow_path, method: :delete, remote: true, id: 'staging-workflow-delete' do
           - if @staging_workflow.staging_projects.any?
             %p Check the staging projects you want to be deleted:

--- a/src/api/app/views/webui2/webui/staging/workflows/_infos.html.haml
+++ b/src/api/app/views/webui2/webui/staging/workflows/_infos.html.haml
@@ -2,6 +2,11 @@
   %h5.card-header Infos
   .card-body
     %dl
+      %dt Managers:
+      %dd
+        %ul.pl-2.list-unstyled
+          %li= link_to managers.title, group_show_path(managers)
+
       %dt Empty projects:
       %dd= render 'empty_projects_list', projects: empty_projects
 

--- a/src/api/app/views/webui2/webui/staging/workflows/_staging_managers_group.html.haml
+++ b/src/api/app/views/webui2/webui/staging/workflows/_staging_managers_group.html.haml
@@ -1,0 +1,27 @@
+- actual_group = staging_workflow.managers_group ? staging_workflow.managers_group.title : 'None assigned'
+.modal.fade#staging-managers-group-modal{ tabindex: -1, role: 'dialog', aria: { labelledby: 'staging-managers-group-modal-label', hidden: true } }
+  .modal-dialog.modal-dialog-centered{ role: 'document' }
+    .modal-content
+      = form_tag(staging_workflow_path(staging_workflow), method: :put) do
+        .modal-header
+          %h5.modal-title#staging-managers-group-modal-label Assign other group
+        .modal-body
+          .form-group#assign-managers-group-modal-input
+            .mb-4
+              Assigned group is:
+              %strong= actual_group
+
+            = label_tag(:managers_title, 'Replace the group with:')
+            .input-group
+              .input-group-prepend
+                %span.input-group-text#assign-managers-group-search-icon
+                  %i.fa.fa-search
+                  %i.fas.fa-spinner.fa-spin.d-none
+              = text_field_tag 'managers_title', '', required: true, placeholder: 'Type to autocomplete...', class: 'form-control',
+                               data: { autocomplete_groups_url: url_for(controller: '/webui/groups', action: 'autocomplete') }
+
+        .modal-footer
+          = render partial: 'webui2/shared/dialog_action_buttons'
+
+- content_for :ready_function do
+  autocompleteStagingManagersGroup();

--- a/src/api/app/views/webui2/webui/staging/workflows/_staging_projects_table.html.haml
+++ b/src/api/app/views/webui2/webui/staging/workflows/_staging_projects_table.html.haml
@@ -23,4 +23,4 @@
             = render partial: 'delete_staging_project_modal', locals: { staging_workflow: staging_workflow, staging_project: staging_project }
 
 - content_for :ready_function do
-  $('#staging-projects-datatable').DataTable({ responsive: true });
+  $('#staging-projects-datatable').DataTable({responsive: true, paging: false, ordering: false, searching: false, info: false});

--- a/src/api/app/views/webui2/webui/staging/workflows/edit.html.haml
+++ b/src/api/app/views/webui2/webui/staging/workflows/edit.html.haml
@@ -19,9 +19,5 @@
         = render(partial: 'staging_projects_table',
                  locals: { staging_workflow: @staging_workflow, staging_projects: @staging_projects, display_actions_column: true })
 
-        = link_to('#', class: 'nav-link', data: { toggle: 'modal', target: '#create-staging-projects-modal' }) do
-          %i.fas.fa-plus-circle.text-success
-          Create Staging Project
-
         = render partial: 'create_staging_project', locals: { staging_workflow: @staging_workflow }
         = render partial: 'staging_managers_group', locals: { staging_workflow: @staging_workflow }

--- a/src/api/app/views/webui2/webui/staging/workflows/edit.html.haml
+++ b/src/api/app/views/webui2/webui/staging/workflows/edit.html.haml
@@ -1,4 +1,4 @@
-- @pagetitle = "Edit Staging Projects for #{@project}"
+- @pagetitle = "Configure Staging for #{@project}"
 
 .row
   .col-xl-12
@@ -14,7 +14,7 @@
           %li.list-inline-item
             = link_to('#', class: 'nav-link', data: { toggle: 'modal', target: '#staging-managers-group-modal' }) do
               %i.fas.fa-users.text-warning
-              Select Managers
+              Managers
 
         = render(partial: 'staging_projects_table',
                  locals: { staging_workflow: @staging_workflow, staging_projects: @staging_projects, display_actions_column: true })

--- a/src/api/app/views/webui2/webui/staging/workflows/edit.html.haml
+++ b/src/api/app/views/webui2/webui/staging/workflows/edit.html.haml
@@ -1,4 +1,4 @@
-- @pagetitle = "Edit Staging Workflow for #{@project}"
+- @pagetitle = "Edit Staging Projects for #{@project}"
 
 .row
   .col-xl-12
@@ -6,6 +6,15 @@
       = render(partial: 'webui2/webui/project/tabs', locals: { project: @project })
       .card-body
         %h3= @pagetitle
+        %ul.list-inline.mb-0
+          %li.list-inline-item
+            = link_to('#', class: 'nav-link', data: { toggle: 'modal', target: '#create-staging-projects-modal' }) do
+              %i.fas.fa-plus-circle.text-success
+              Create Project
+          %li.list-inline-item
+            = link_to('#', class: 'nav-link', data: { toggle: 'modal', target: '#staging-managers-group-modal' }) do
+              %i.fas.fa-users.text-warning
+              Select Managers
 
         = render(partial: 'staging_projects_table',
                  locals: { staging_workflow: @staging_workflow, staging_projects: @staging_projects, display_actions_column: true })
@@ -15,3 +24,4 @@
           Create Staging Project
 
         = render partial: 'create_staging_project', locals: { staging_workflow: @staging_workflow }
+        = render partial: 'staging_managers_group', locals: { staging_workflow: @staging_workflow }

--- a/src/api/app/views/webui2/webui/staging/workflows/new.html.haml
+++ b/src/api/app/views/webui2/webui/staging/workflows/new.html.haml
@@ -7,20 +7,20 @@
     .mb-3
       Adding the staging capability to this project will enable you to group
       requests into staging projects and being able to see how they build together.
-    .text-center
+    .mb-3.w-50.m-auto
       = form_for @staging_workflow, method: :post do |f|
         = hidden_field_tag :project_name, @project
         .form-group#assign-managers-group-modal-input
-          = label_tag(:managers_id, "Managers:")
+          = label_tag(:managers_title, 'Managers:')
           .input-group
             .input-group-prepend
               %span.input-group-text#assign-managers-group-search-icon
                 %i.fa.fa-search
                 %i.fas.fa-spinner.fa-spin.d-none
-            = text_field_tag 'managers_id', '', required: true, placeholder: 'Type to autocomplete...', class: 'form-control', 
-                               data: { autocomplete_groups_url: url_for(controller: '/webui/groups', action: 'autocomplete')}
-
-        = f.submit 'Create Staging Projects', class: 'btn btn-primary'
+            = text_field_tag 'managers_title', '', required: true, placeholder: 'Type to autocomplete...', class: 'form-control',
+                              data: { autocomplete_groups_url: url_for(controller: '/webui/groups', action: 'autocomplete') }
+        .text-center
+          = f.submit 'Create Staging Projects', class: 'btn btn-primary'
 
 - content_for :ready_function do
   autocompleteStagingManagersGroup();

--- a/src/api/app/views/webui2/webui/staging/workflows/new.html.haml
+++ b/src/api/app/views/webui2/webui/staging/workflows/new.html.haml
@@ -10,4 +10,17 @@
     .text-center
       = form_for @staging_workflow, method: :post do |f|
         = hidden_field_tag :project_name, @project
+        .form-group#assign-managers-group-modal-input
+          = label_tag(:managers_id, "Managers:")
+          .input-group
+            .input-group-prepend
+              %span.input-group-text#assign-managers-group-search-icon
+                %i.fa.fa-search
+                %i.fas.fa-spinner.fa-spin.d-none
+            = text_field_tag 'managers_id', '', required: true, placeholder: 'Type to autocomplete...', class: 'form-control', 
+                               data: { autocomplete_groups_url: url_for(controller: '/webui/groups', action: 'autocomplete')}
+
         = f.submit 'Create Staging Projects', class: 'btn btn-primary'
+
+- content_for :ready_function do
+  autocompleteStagingManagersGroup();

--- a/src/api/app/views/webui2/webui/staging/workflows/show.html.haml
+++ b/src/api/app/views/webui2/webui/staging/workflows/show.html.haml
@@ -1,4 +1,4 @@
-- @pagetitle = "Staging Projects for #{@project}"
+- @pagetitle = "Staging for #{@project}"
 
 .row
   .col-xl-10
@@ -7,10 +7,11 @@
       .card-body
         %h3= @pagetitle
         %ul.list-inline.mb-0
-          %li.list-inline-item
-            = link_to(edit_staging_workflow_path(@staging_workflow), class: 'nav-link') do
-              %i.fas.fa-edit.text-info
-              Edit
+          - if policy(@staging_workflow).update?
+            %li.list-inline-item
+              = link_to(edit_staging_workflow_path(@staging_workflow), class: 'nav-link') do
+                %i.fas.fa-edit.text-info
+                Configure
           - if policy(@staging_workflow).destroy?
             %li.list-inline-item
               = link_to('#', class: 'nav-link', data: { toggle: 'modal', target: '#delete-staging-workflow' }) do

--- a/src/api/app/views/webui2/webui/staging/workflows/show.html.haml
+++ b/src/api/app/views/webui2/webui/staging/workflows/show.html.haml
@@ -28,4 +28,7 @@
                                          unassigned_requests: @unassigned_requests, more_unassigned_requests: @more_unassigned_requests,
                                          ready_requests: @ready_requests, more_ready_requests: @more_ready_requests,
                                          ignored_requests: @ignored_requests, more_ignored_requests: @more_ignored_requests,
-                                         project: @project }
+                                         project: @project, managers: @managers }
+
+- content_for :ready_function do
+  $('#staging-projects-datatable').DataTable({ responsive: true });

--- a/src/api/app/views/webui2/webui/staging/workflows/show.html.haml
+++ b/src/api/app/views/webui2/webui/staging/workflows/show.html.haml
@@ -6,22 +6,21 @@
       = render(partial: 'webui2/webui/project/tabs', locals: { project: @project })
       .card-body
         %h3= @pagetitle
-
-        %hr
+        %ul.list-inline.mb-0
+          %li.list-inline-item
+            = link_to(edit_staging_workflow_path(@staging_workflow), class: 'nav-link') do
+              %i.fas.fa-edit.text-info
+              Edit
+          - if policy(@staging_workflow).destroy?
+            %li.list-inline-item
+              = link_to('#', class: 'nav-link', data: { toggle: 'modal', target: '#delete-staging-workflow' }) do
+                %i.fas.fa-times-circle.text-danger
+                Delete
+              = render(partial: 'delete', locals: { project: @project })
 
         = render(partial: 'staging_projects_table',
                  locals: { staging_workflow: @staging_workflow, staging_projects: @staging_projects, display_actions_column: false })
 
-        %ul.list-inline
-          %li.list-inline-item
-            = link_to(edit_staging_workflow_path(@staging_workflow)) do
-              %i.fas.fa-edit.text-info
-              Edit
-          - if policy(@staging_workflow).destroy?
-            %a{ data: { toggle: 'modal', target: '#delete-staging-workflow' }, href: '#' }
-              %i.fas.fa-times-circle.text-danger
-              Delete
-            = render(partial: 'webui2/webui/staging/workflows/delete', locals: { project: @project })
   .col-xl-2
     = render partial: 'legend'
     = render partial: 'infos', locals: { staging_workflow: @staging_workflow, empty_projects: @empty_projects,
@@ -31,4 +30,4 @@
                                          project: @project, managers: @managers }
 
 - content_for :ready_function do
-  $('#staging-projects-datatable').DataTable({ responsive: true });
+  $('#staging-projects-datatable').DataTable({responsive: true, paging: false, ordering: false, searching: false, info: false});

--- a/src/api/app/views/webui2/webui/staging/workflows/show.html.haml
+++ b/src/api/app/views/webui2/webui/staging/workflows/show.html.haml
@@ -29,6 +29,3 @@
                                          ready_requests: @ready_requests, more_ready_requests: @more_ready_requests,
                                          ignored_requests: @ignored_requests, more_ignored_requests: @more_ignored_requests,
                                          project: @project, managers: @managers }
-
-- content_for :ready_function do
-  $('#staging-projects-datatable').DataTable({responsive: true, paging: false, ordering: false, searching: false, info: false});

--- a/src/api/config/routes.rb
+++ b/src/api/config/routes.rb
@@ -460,7 +460,7 @@ OBSApi::Application.routes.draw do
   get 'published/:project(/:repository(/:arch(/:binary)))' => 'published#index', constraints: cons
   get 'published/' => 'source#index', via: :get
 
-  resources :staging_workflows, except: [:index, :update], controller: 'webui/staging/workflows', constraints: cons do
+  resources :staging_workflows, except: :index, controller: 'webui/staging/workflows', constraints: cons do
     resources :staging_projects, only: [:create, :destroy], controller: 'webui/staging/projects', param: :project_name, constraints: cons
   end
 

--- a/src/api/db/migrate/20181113095753_add_staging_managers_group.rb
+++ b/src/api/db/migrate/20181113095753_add_staging_managers_group.rb
@@ -1,0 +1,7 @@
+class AddStagingManagersGroup < ActiveRecord::Migration[5.2]
+  def change
+    change_table :staging_workflows do |t|
+      t.references :managers_group, index: true, type: :integer
+    end
+  end
+end

--- a/src/api/db/structure.sql
+++ b/src/api/db/structure.sql
@@ -1147,8 +1147,10 @@ CREATE TABLE `staging_workflows` (
   `project_id` int(11) DEFAULT NULL,
   `created_at` datetime NOT NULL,
   `updated_at` datetime NOT NULL,
+  `managers_group_id` int(11) DEFAULT NULL,
   PRIMARY KEY (`id`),
-  UNIQUE KEY `index_staging_workflows_on_project_id` (`project_id`)
+  UNIQUE KEY `index_staging_workflows_on_project_id` (`project_id`),
+  KEY `index_staging_workflows_on_managers_group_id` (`managers_group_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
 CREATE TABLE `static_permissions` (
@@ -1423,6 +1425,7 @@ INSERT INTO `schema_migrations` (version) VALUES
 ('20180924135535'),
 ('20181008150453'),
 ('20181016103905'),
-('20181025152009');
+('20181025152009'),
+('20181113095753');
 
 

--- a/src/api/spec/controllers/staging/staged_requests_controller_spec.rb
+++ b/src/api/spec/controllers/staging/staged_requests_controller_spec.rb
@@ -39,6 +39,8 @@ RSpec.describe Staging::StagedRequestsController, type: :controller, vcr: true d
   describe 'POST #create' do
     context 'invalid user' do
       before do
+        staging_workflow
+
         login other_user
         post :create, params: { staging_project_name: staging_project.name, format: :xml },
                       body: "<requests><number>#{bs_request.number}</number></requests>"

--- a/src/api/spec/controllers/webui/staging/projects_controller_spec.rb
+++ b/src/api/spec/controllers/webui/staging/projects_controller_spec.rb
@@ -2,8 +2,9 @@ require 'rails_helper'
 
 RSpec.describe Webui::Staging::ProjectsController do
   let(:user) { create(:confirmed_user, login: 'tom') }
+  let(:managers_group) { create(:group) }
   let(:project) { user.home_project }
-  let(:staging_workflow) { project.create_staging }
+  let(:staging_workflow) { project.create_staging(managers: managers_group) }
 
   before do
     login(user)
@@ -24,6 +25,9 @@ RSpec.describe Webui::Staging::ProjectsController do
       end
       it { expect(response).to redirect_to(edit_staging_workflow_path(subject)) }
       it { expect(flash[:success]).not_to be_nil }
+      it 'assigns the managers group' do
+        expect(Staging::StagingProject.find_by_name('home:tom:Staging:C').groups.last).to eq(subject.managers_group)
+      end
     end
 
     context 'an existent staging project' do

--- a/src/api/spec/controllers/webui/staging/projects_controller_spec.rb
+++ b/src/api/spec/controllers/webui/staging/projects_controller_spec.rb
@@ -2,9 +2,8 @@ require 'rails_helper'
 
 RSpec.describe Webui::Staging::ProjectsController do
   let(:user) { create(:confirmed_user, login: 'tom') }
-  let(:managers_group) { create(:group) }
   let(:project) { user.home_project }
-  let(:staging_workflow) { project.create_staging(managers: managers_group) }
+  let(:staging_workflow) { create(:staging_workflow, project: project) }
 
   before do
     login(user)

--- a/src/api/spec/controllers/webui/staging/workflows_controller_spec.rb
+++ b/src/api/spec/controllers/webui/staging/workflows_controller_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe Webui::Staging::WorkflowsController do
   let(:managers_group) { create(:group) }
   let(:other_managers_group) { create(:group) }
   let(:project) { user.home_project }
-  let(:staging_workflow) { project.create_staging(managers: managers_group) }
+  let(:staging_workflow) { create(:staging_workflow, project: project, managers_group: managers_group) }
 
   before do
     login(user)
@@ -24,7 +24,7 @@ RSpec.describe Webui::Staging::WorkflowsController do
 
     context 'with an existent staging_workflow for project' do
       before do
-        project.create_staging(managers_id: managers_group.id)
+        staging_workflow
         get :new, params: { project: project.name }
       end
 
@@ -90,7 +90,7 @@ RSpec.describe Webui::Staging::WorkflowsController do
 
     context 'with an existent staging_workflow for project' do
       before do
-        project.create_staging(managers_id: managers_group.id)
+        staging_workflow
         get :show, params: { id: project.staging }
       end
 
@@ -113,7 +113,7 @@ RSpec.describe Webui::Staging::WorkflowsController do
 
     context 'with an existent staging_workflow for project' do
       before do
-        project.create_staging(managers_id: managers_group.id)
+        staging_workflow
         get :edit, params: { id: project.staging }
       end
 
@@ -124,9 +124,10 @@ RSpec.describe Webui::Staging::WorkflowsController do
   end
 
   describe 'DELETE #destroy' do
+    let!(:staging_workflow) { create(:staging_workflow, project: project) }
+
     context 'a staging workflow and staging projects' do
       before do
-        project.create_staging(managers_id: managers_group.id)
         params = { id: project.staging, staging_project_ids: project.staging.staging_projects.ids, format: :js }
         delete :destroy, params: params
       end
@@ -142,7 +143,6 @@ RSpec.describe Webui::Staging::WorkflowsController do
 
     context 'a staging workflow and one staging project' do
       before do
-        project.create_staging(managers_id: managers_group.id)
         params = { id: project.staging, staging_project_ids: project.staging.staging_projects.ids.first, format: :js }
         delete :destroy, params: params
       end
@@ -158,7 +158,6 @@ RSpec.describe Webui::Staging::WorkflowsController do
 
     context 'a staging workflow unsuccessful' do
       before do
-        project.create_staging(managers_id: managers_group.id)
         allow_any_instance_of(Staging::Workflow).to receive(:destroy).and_return(false)
         params = { id: project.staging, staging_project_ids: project.staging.staging_projects.ids, format: :js }
         delete :destroy, params: params

--- a/src/api/spec/factories/staging_workflow.rb
+++ b/src/api/spec/factories/staging_workflow.rb
@@ -1,5 +1,8 @@
 FactoryBot.define do
   factory :staging_workflow, class: 'Staging::Workflow' do
+    project
+    association :managers_group, factory: :group, title: 'staging-workflow-managers'
+
     factory :staging_workflow_with_staging_projects do
       initialize_with { new(attributes) }
 


### PR DESCRIPTION
Now a Managers group needs to be attached to the staging workflow in order to let them managing the assignation/exclusion of requests in the staging projects.

Now the Managers group assigned is shown in **Infos** sidebox:

![image](https://user-images.githubusercontent.com/11314634/48554439-b319db00-e8de-11e8-8f80-1b3f3c6f5d5d.png)


When configuring the Staging you can assign a new group, only one will be assigned:

![image](https://user-images.githubusercontent.com/11314634/48554450-be6d0680-e8de-11e8-95ac-aa36076fa09d.png)

The field for selecting another group is an autocomplete one:

![image](https://user-images.githubusercontent.com/11314634/48552898-55838f80-e8da-11e8-81b4-fad92f30bb81.png)

BTW, I have adapted some of the literals the user see. Now the **Staging Workflow** is referred as **Staging.** The edit action is to configure the Staging.
 
Co-authored-by: David Kang <dkang@suse.com>