### PR TITLE
Add byebug history to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,7 @@
 /src/api/spec/examples.txt
 /src/api/last_deploy
 /src/api/test/reports
+/src/api/.byebug_history
 /src/backend/blib
 /src/backend/BSConfig.pm
 /src/backend/BSSolv.bs


### PR DESCRIPTION
The byebug (debugger) history should not be committed.


