### PR TITLE
Convert custom validations into Rails validations

### DIFF
--- a/src/api/db/data/20190116105222_sanitize_reviews.rb
+++ b/src/api/db/data/20190116105222_sanitize_reviews.rb
@@ -1,0 +1,36 @@
+class SanitizeReviews < ActiveRecord::Migration[5.2]
+  # Find reviews that have multiple review targets (e.g. by_user and by_group)
+  # and split them up. So that reviews are per review target.
+  def up
+    Review.where.not(by_group: nil, by_user: nil, by_project: nil).find_each do |review|
+      # The package / project review
+      review.dup.update!(by_group: nil, group_id: nil, by_user: nil, user_id: nil)
+      # The group review
+      review.dup.update!(by_user: nil, user_id: nil, by_project: nil, project_id: nil, by_package: nil, package_id: nil)
+      # Te user review
+      review.update!(by_group: nil, group_id: nil, by_project: nil, project_id: nil, by_package: nil, package_id: nil)
+    end
+    Review.where.not(by_group: nil, by_user: nil).find_each do |review|
+      # The group review
+      review.dup.update!(by_user: nil, user_id: nil)
+      # Te user review
+      review.update!(by_group: nil, group_id: nil)
+    end
+    Review.where.not(by_group: nil, by_project: nil).find_each do |review|
+      # The group review
+      review.dup.update!(by_project: nil, project_id: nil, by_package: nil, package_id: nil)
+      # The package / project review
+      review.update!(by_group: nil, group_id: nil)
+    end
+    Review.where.not(by_user: nil, by_project: nil).find_each do |review|
+      # Te user review
+      review.dup.update!(by_project: nil, project_id: nil, by_package: nil, package_id: nil)
+      # The package / project review
+      review.update!(by_user: nil, user_id: nil)
+    end
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/src/api/spec/db/data/sanitize_reviews_spec.rb
+++ b/src/api/spec/db/data/sanitize_reviews_spec.rb
@@ -1,0 +1,54 @@
+require 'rails_helper'
+require Rails.root.join('db/data/20190116105222_sanitize_reviews.rb')
+
+RSpec.describe SanitizeReviews, type: :migration do
+  let(:data_migration) { SanitizeReviews.new }
+
+  describe 'up' do
+    let(:package_a) { create(:package) }
+    let(:package_b) { create(:package) }
+    let(:package_c) { create(:package) }
+    let(:group_a) { create(:group) }
+    let(:group_c) { create(:group) }
+    let(:user_b) { create(:confirmed_user) }
+    let(:user_c) { create(:confirmed_user) }
+    let!(:review_a) do
+      review = build(:review,
+                     by_package: package_a.name, package: package_a,
+                     by_project: package_a.project.name, project: package_a.project,
+                     by_group: group_a.title, group: group_a)
+      review.save(validate: false)
+      review
+    end
+    let!(:review_b) do
+      review = build(:review,
+                     by_package: package_b.name, package: package_b,
+                     by_project: package_b.project.name, project: package_b.project,
+                     by_user: user_b.login, user: user_b)
+      review.save(validate: false)
+      review
+    end
+    let!(:review_c) do
+      review = build(:review,
+                     by_package: package_c.name, package: package_c,
+                     by_project: package_c.project.name, project: package_c.project,
+                     by_group: group_c.title, group: group_c,
+                     by_user: user_c.login, user: user_c)
+      review.save(validate: false)
+      review
+    end
+
+    subject { data_migration.up }
+
+    it 'migrates all data' do
+      expect { subject }.to change(Review, :count).by(4)
+      expect(Review.where(package: package_a, project: package_a.project, group: nil, user: nil)).to exist
+      expect(Review.where(package: nil, project: nil, group: group_a, user: nil)).to exist
+      expect(Review.where(package: package_b, project: package_b.project, group: nil, user: nil)).to exist
+      expect(Review.where(package: nil, project: nil, group: nil, user: user_b)).to exist
+      expect(Review.where(package: package_c, project: package_c.project, group: nil, user: nil)).to exist
+      expect(Review.where(package: nil, project: nil, group: nil, user: user_c)).to exist
+      expect(Review.where(package: nil, project: nil, group: group_c, user: nil)).to exist
+    end
+  end
+end

--- a/src/api/spec/models/bs_request_spec.rb
+++ b/src/api/spec/models/bs_request_spec.rb
@@ -127,7 +127,7 @@ RSpec.describe BsRequest, vcr: true do
     it 'fails with reasonable error' do
       expect { request.addreview(by_user: 'NOEXIST') }.to raise_error do |exception|
         expect(exception).to be_a(BsRequest::InvalidReview)
-        expect(exception.message.to_s).to eq('Review invalid: By user NOEXIST not found')
+        expect(exception.message.to_s).to eq("Review invalid: User can't be blank")
       end
     end
   end


### PR DESCRIPTION
This implements validation of presence of the various possible
review assignees (package, project, group or user).
In addition this ensures that these validations always run and not
only during object creation.


