### PR TITLE
Add influxdb-rails

### DIFF
--- a/src/api/Gemfile
+++ b/src/api/Gemfile
@@ -76,6 +76,8 @@ gem 'data_migrate', '= 5.2.0'
 gem 'addressable'
 # for XML builder
 gem 'builder'
+# to write the rails metrics directly into InfluxDB.
+gem 'influxdb-rails'
 
 group :development, :production do
   # to have the delayed job daemon

--- a/src/api/Gemfile.lock
+++ b/src/api/Gemfile.lock
@@ -176,6 +176,10 @@ GEM
       ruby_parser (~> 3.5)
     i18n (1.1.1)
       concurrent-ruby (~> 1.0)
+    influxdb (0.5.3)
+    influxdb-rails (0.4.3)
+      influxdb (~> 0.5.0)
+      railties (> 3)
     innertube (1.1.0)
     jaro_winkler (1.5.1)
     joiner (0.4.2)
@@ -484,6 +488,7 @@ DEPENDENCIES
   haml
   haml-rails
   haml_lint
+  influxdb-rails
   jquery-datatables
   jquery-rails
   jquery-ui-rails (~> 4.2.1)

--- a/src/api/config/initializers/influxdb_rails.rb
+++ b/src/api/config/initializers/influxdb_rails.rb
@@ -1,0 +1,9 @@
+InfluxDB::Rails.configure do |config|
+  config.influxdb_database = CONFIG['influxdb_database']
+  config.influxdb_username = CONFIG['influxdb_username']
+  config.influxdb_password = CONFIG['influxdb_password']
+  config.influxdb_hosts    = CONFIG['influxdb_hosts'] || [] # default is otherwise localhost
+  config.influxdb_port     = CONFIG['influxdb_port']
+  config.retry             = CONFIG['influxdb_retry']
+  config.use_ssl           = CONFIG['influxdb_ssl']
+end

--- a/src/api/config/options.yml.example
+++ b/src/api/config/options.yml.example
@@ -183,6 +183,15 @@ default: &default
   #    persistent: true
   #    passive: true
 
+  # For sending application performance metrics to a influx time series database
+  # influxdb_database: rails
+  # influxdb_username: rails
+  # influxdb_password: 123456
+  # influxdb_hosts:
+  #  - https://domain.tld
+  # influxdb_port: 8086
+  # influxdb_ssl: true
+  # influxdb_retry: 10
 production:
   <<: *default
 


### PR DESCRIPTION
to collect performance metrics of the OBS rails app like
* request time
* view render time
* db query time

This information will be collection on metrics.o.o

The influxdb is already reachable on metrics.o.o so we could deploy it. Let me know so I can give you the credentials.

