### PR TITLE
Remove unneeded call to set_buildinfo

### DIFF
--- a/src/api/app/models/staging/staging_project.rb
+++ b/src/api/app/models/staging/staging_project.rb
@@ -95,8 +95,6 @@ module Staging
     end
 
     def build_state
-      set_buildinfo
-
       return :building if building_repositories.present?
       return :failed if broken_packages.present?
 


### PR DESCRIPTION
It is a consuming call and it is being already done. :bowtie: 

