### PR TITLE
[backend] keyinfo: do not die when checking for a default cert if don…

### DIFF
--- a/src/backend/bs_srcserver
+++ b/src/backend/bs_srcserver
@@ -5192,7 +5192,11 @@ sub getkeyinfo {
     $cert = projid2sslcert($skprojid, $sk, $projid, $cgi->{'donotcreatecert'});
   }
   if ($cgi->{'withsslcert'} && !$skprojid && $BSConfig::sign_project && $BSConfig::sign) {
-    $cert = BSSrcServer::Signkey::getdefaultcert($projid);
+    if ($cgi->{'donotcreatecert'}) {
+      eval { $cert = BSSrcServer::Signkey::getdefaultcert($projid) };
+    } else {
+      $cert = BSSrcServer::Signkey::getdefaultcert($projid);
+    }
   }
   if (!$pk && $BSConfig::sign_project && $BSConfig::sign) {
     $pk = BSSrcServer::Signkey::getdefaultpubkey($projid);


### PR DESCRIPTION
…otcreatecert is set

If you haven't done so already, please read the CONTRIBUTING.md file to learn how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md

