### PR TITLE
Fix long names in modal's heading

### DIFF
--- a/src/api/app/assets/stylesheets/webui2/modals.scss
+++ b/src/api/app/assets/stylesheets/webui2/modals.scss
@@ -1,5 +1,7 @@
 .modal h5 {
     color: $body-color;
+    overflow-x: hidden;
+    overflow-wrap: break-word;
 }
 
 .modal-body p {


### PR DESCRIPTION
Fixes #6255

Before:
![overflow1](https://user-images.githubusercontent.com/1102934/48763023-9c8fcd00-ecac-11e8-8c0e-797c054f44fc.png)

After:
![overflow](https://user-images.githubusercontent.com/1102934/48765880-728dd900-ecb3-11e8-9152-e7dce4c0b45f.png)

