### PR TITLE
Add a factory for staging workflow manager groups

### DIFF
--- a/src/api/spec/factories/groups.rb
+++ b/src/api/spec/factories/groups.rb
@@ -12,5 +12,9 @@ FactoryBot.define do
         group.groups_users.create(user: evaluator.user)
       end
     end
+
+    factory :staging_workflow_group do
+      sequence(:title) { |n| "staging-workflow-managers-#{n}" }
+    end
   end
 end

--- a/src/api/spec/factories/staging_workflow.rb
+++ b/src/api/spec/factories/staging_workflow.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
   factory :staging_workflow, class: 'Staging::Workflow' do
     project
-    association :managers_group, factory: :group, title: 'staging-workflow-managers'
+    association :managers_group, factory: :staging_workflow_group
 
     factory :staging_workflow_with_staging_projects do
       initialize_with { new(attributes) }


### PR DESCRIPTION
We need to ensure that there are no conflicts between the
generated group titles, to be able to create multiple staging
workflow factories.



