### PR TITLE
Change size icon for staging project deletion

### DIFF
--- a/src/api/app/views/webui2/webui/staging/workflows/_problems.html.haml
+++ b/src/api/app/views/webui2/webui/staging/workflows/_problems.html.haml
@@ -5,7 +5,7 @@
 
 - if staging_project.problems.empty?
   .text-center
-    %i.fas.fa-check-circle.fa-2x.text-success
+    %i.fas.fa-check-circle.text-success
 - else
   %ul.list-group.list-group-flush
     = render partial: 'problems_item', locals: { staging_project: staging_project, index: 0...max_problems }


### PR DESCRIPTION
The delete icon was much smaller than the problem icon, which made
the table look a bit strange.
Since project deletion is one of the main actions on the edit view,
we increase it's size to make it more visible.

Before:

![Before](https://screenshotscdn.firefoxusercontent.com/images/f5a760b5-4a6d-4c35-a527-047ff8a7f572.png)

After:

![After](https://screenshotscdn.firefoxusercontent.com/images/b8f7beac-d1f5-49a5-8635-d94814d0e81b.png)

