### PR TITLE
Create smaller drpm files

### DIFF
--- a/src/backend/worker-deltagen.spec
+++ b/src/backend/worker-deltagen.spec
@@ -16,7 +16,7 @@ mkdir -p "$odir"
 mopt=
 case `makedeltarpm -m 512 /dev/null /dev/null /dev/null 2>&1` in
   *invalid\ option*) ;;
-  *) mopt="-m 512" ;;
+  *) mopt="-m 1536" ;;
 esac
 
 for i in *.old ; do


### PR DESCRIPTION
I tested with
http://download.opensuse.org/update/leap/15.0/oss/noarch/tftpboot-installation-openSUSE-Leap-15.0-x86_64-14.373-lp150.2.3.2.noarch.rpm http://download.opensuse.org/distribution/leap/15.0/repo/oss/noarch/tftpboot-installation-openSUSE-Leap-15.0-x86_64-14.372-lp150.1.2.noarch.rpm
and
http://download.opensuse.org/update/leap/15.0/oss/noarch/nextcloud-13.0.5-lp150.2.6.1.noarch.rpm http://download.opensuse.org/update/leap/15.0/oss/noarch/nextcloud-13.0.4-lp150.2.3.1.noarch.rpm
and found that running makedeltarpm with -m 1500
improved the output size by a factor of 3.2 and 4.6

Given that b4be43757b68eb47498b53e379f4867b16bab2e7 is from 2012,
Moore's Law should allow for this increase in memory usage.