### PR TITLE
Make the location of the staging project flexible

### DIFF
--- a/src/api/app/controllers/webui/staging/projects_controller.rb
+++ b/src/api/app/controllers/webui/staging/projects_controller.rb
@@ -10,9 +10,8 @@ module Webui
 
       def create
         authorize @staging_workflow
-
-        staging_project_name = "#{@staging_workflow.project}:Staging:#{params[:staging_project_name]}"
-        staging_project = @staging_workflow.staging_projects.build(name: staging_project_name)
+        staging_project = @staging_workflow.staging_projects.build(name: params[:staging_project_name])
+        authorize(staging_project, :create?)
 
         if staging_project.valid? && staging_project.store
           flash[:success] = "Staging project with name = \"#{staging_project}\" was successfully created"

--- a/src/api/app/views/webui2/webui/staging/workflows/_create_staging_project.html.haml
+++ b/src/api/app/views/webui2/webui/staging/workflows/_create_staging_project.html.haml
@@ -6,8 +6,8 @@
           %h5.modal-title#create-staging-projects-modal-label Create Staging Project
         .modal-body
           .form-group
-            = label_tag(:staging_project_name, "#{staging_workflow.project}:Staging:")
-            = text_field_tag(:staging_project_name, nil, placeholder: 'Eg: A', class: 'form-control')
+            = label_tag(:staging_project_name, 'Please enter a project you have permissions to')
+            = text_field_tag(:staging_project_name, nil, placeholder: "Eg: #{staging_workflow.project}:Staging:A", class: 'form-control')
 
         .modal-footer
           = render partial: 'webui2/shared/dialog_action_buttons'

--- a/src/api/spec/controllers/webui/staging/projects_controller_spec.rb
+++ b/src/api/spec/controllers/webui/staging/projects_controller_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe Webui::Staging::ProjectsController do
   describe 'POST #create' do
     context 'a staging_project' do
       before do
-        post :create, params: { staging_workflow_id: staging_workflow.id, staging_project_name: 'C' }
+        post :create, params: { staging_workflow_id: staging_workflow.id, staging_project_name: 'home:tom:My:Projects' }
       end
 
       subject { staging_workflow }
@@ -20,18 +20,18 @@ RSpec.describe Webui::Staging::ProjectsController do
       it { expect(Project.count).to eq(4) }
       it 'create a new staging project' do
         subject.reload
-        expect(subject.staging_projects.map(&:name)).to match_array(['home:tom:Staging:A', 'home:tom:Staging:B', 'home:tom:Staging:C'])
+        expect(subject.staging_projects.map(&:name)).to match_array(['home:tom:Staging:A', 'home:tom:Staging:B', 'home:tom:My:Projects'])
       end
       it { expect(response).to redirect_to(edit_staging_workflow_path(subject)) }
       it { expect(flash[:success]).not_to be_nil }
       it 'assigns the managers group' do
-        expect(Staging::StagingProject.find_by_name('home:tom:Staging:C').groups).to contain_exactly(subject.managers_group)
+        expect(Staging::StagingProject.find_by_name('home:tom:My:Projects').groups).to contain_exactly(subject.managers_group)
       end
     end
 
     context 'an existent staging project' do
       before do
-        post :create, params: { staging_workflow_id: staging_workflow.id, staging_project_name: 'A' }
+        post :create, params: { staging_workflow_id: staging_workflow.id, staging_project_name: 'home:tom:Staging:A' }
       end
 
       subject { staging_workflow }
@@ -42,11 +42,20 @@ RSpec.describe Webui::Staging::ProjectsController do
       it { expect(flash[:error]).not_to be_nil }
     end
 
+    context 'when the user does not have permissions to create that project' do
+      before do
+        post :create, params: { staging_workflow_id: staging_workflow.id, staging_project_name: 'Apache' }
+      end
+
+      it { expect(Project.where(name: 'Apache')).not_to exist }
+      it { expect(flash[:error]).to eq('Sorry, you are not authorized to create this Staging::StagingProject.') }
+    end
+
     context 'when it fails to save' do
       before do
         staging_workflow
         allow_any_instance_of(Project).to receive(:valid?).and_return(false)
-        post :create, params: { staging_workflow_id: staging_workflow.id, staging_project_name: 'C' }
+        post :create, params: { staging_workflow_id: staging_workflow.id, staging_project_name: 'home:tom:My:Projects' }
       end
 
       subject { staging_workflow }

--- a/src/api/spec/controllers/webui/staging/projects_controller_spec.rb
+++ b/src/api/spec/controllers/webui/staging/projects_controller_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe Webui::Staging::ProjectsController do
       it { expect(response).to redirect_to(edit_staging_workflow_path(subject)) }
       it { expect(flash[:success]).not_to be_nil }
       it 'assigns the managers group' do
-        expect(Staging::StagingProject.find_by_name('home:tom:Staging:C').groups.last).to eq(subject.managers_group)
+        expect(Staging::StagingProject.find_by_name('home:tom:Staging:C').groups).to contain_exactly(subject.managers_group)
       end
     end
 


### PR DESCRIPTION
Previously we required the location of the staging projects to be
under the 'Staging' namespace of the staging workflow project
(eg. my_workflow_project:Staging:A).
With this commit it will be possible to create the staging project
anywhere as long as the user has permissions to it's location.


