### PR TITLE
Update breadcrumb for excluded requests

### DIFF
--- a/src/api/app/views/webui2/webui/staging/excluded_requests/_breadcrumb_items.html.haml
+++ b/src/api/app/views/webui2/webui/staging/excluded_requests/_breadcrumb_items.html.haml
@@ -1,3 +1,5 @@
 = render partial: 'webui/project/breadcrumb_items'
+%li.breadcrumb-item
+  = link_to 'Staging', staging_workflow_path(@staging_workflow)
 %li.breadcrumb-item.active{ 'aria-current' => 'page' }
-  Staging workflow excluded requests
+  Excluded requests


### PR DESCRIPTION
This aligns the breadcrumb for excluded requests with the other
staging workflow breadcrumbs.

![screenshot-2018-11-20 open build service](https://user-images.githubusercontent.com/968949/48777947-420a6700-ecd4-11e8-888c-b2cf59cbf687.png)