### PR TITLE
Add XML endpoint for StagingProjectsController#show action

### DIFF
--- a/src/api/app/controllers/staging/staging_projects_controller.rb
+++ b/src/api/app/controllers/staging/staging_projects_controller.rb
@@ -1,0 +1,7 @@
+class Staging::StagingProjectsController < ApplicationController
+  skip_before_action :require_login
+
+  def show
+    @staging_project = Staging::StagingProject.find_by!(name: params[:name])
+  end
+end

--- a/src/api/app/views/staging/staging_projects/_broken_packages.xml.builder
+++ b/src/api/app/views/staging/staging_projects/_broken_packages.xml.builder
@@ -1,0 +1,5 @@
+builder.broken_package(count: count) do |broken_package|
+  broken_packages.each do |package|
+    broken_package.entry(package: package[:package], project: package[:project])
+  end
+end

--- a/src/api/app/views/staging/staging_projects/_building_repositories.xml.builder
+++ b/src/api/app/views/staging/staging_projects/_building_repositories.xml.builder
@@ -1,0 +1,6 @@
+xml.building_repositories(count: count) do |building_repository|
+  building_repositories.each do |repo|
+    # missing , tobuild: repo[''], final: repo['']
+    building_repository.entry(name: repo['repository'], arch: repo['arch'], code: repo['code'], state: repo['state'])
+  end
+end

--- a/src/api/app/views/staging/staging_projects/_missing_reviews.xml.builder
+++ b/src/api/app/views/staging/staging_projects/_missing_reviews.xml.builder
@@ -1,0 +1,5 @@
+builder.missing_reviews(count: count) do |missing_review|
+  missing_reviews.each do |bs_request|
+    missing_review.entry(id: bs_request[:id], creator: bs_request[:by], state: bs_request[:state], package: bs_request[:package])
+  end
+end

--- a/src/api/app/views/staging/staging_projects/_requests_to_review.xml.builder
+++ b/src/api/app/views/staging/staging_projects/_requests_to_review.xml.builder
@@ -1,0 +1,5 @@
+builder.requests_to_review(count: count) do
+  requests_to_review.each do |bs_request|
+    builder.entry(id: bs_request.number, creator: bs_request.creator, state: bs_request.state, package: bs_request.first_target_package)
+  end
+end

--- a/src/api/app/views/staging/staging_projects/_staged_requests.xml.builder
+++ b/src/api/app/views/staging/staging_projects/_staged_requests.xml.builder
@@ -1,0 +1,5 @@
+builder.staged_requests(count: count) do |staged_request|
+  staged_requests.each do |bs_request|
+    staged_request.entry(id: bs_request.number, creator: bs_request.creator, state: bs_request.state, package: bs_request.first_target_package)
+  end
+end

--- a/src/api/app/views/staging/staging_projects/_untracked_requests.xml.builder
+++ b/src/api/app/views/staging/staging_projects/_untracked_requests.xml.builder
@@ -1,0 +1,5 @@
+builder.untracked_requests(count: count) do |untracked_request|
+  untracked_requests.each do |bs_request|
+    untracked_request.entry(id: bs_request.number, creator: bs_request.creator, state: bs_request.state, package: bs_request.first_target_package)
+  end
+end

--- a/src/api/app/views/staging/staging_projects/show.xml.builder
+++ b/src/api/app/views/staging/staging_projects/show.xml.builder
@@ -1,0 +1,13 @@
+xml.staging_project(name: @staging_project.name) do
+  render(partial: 'staged_requests', locals: { staged_requests: @staging_project.staged_requests, count: @staging_project.staged_requests.count, builder: xml })
+
+  render(partial: 'untracked_requests', locals: { untracked_requests: @staging_project.untracked_requests, count: @staging_project.untracked_requests.count, builder: xml  })
+
+  render(partial: 'requests_to_review', locals: { requests_to_review: @staging_project.requests_to_review, count: @staging_project.requests_to_review.count, builder: xml  })
+
+  render(partial: 'missing_reviews', locals: { missing_reviews: @staging_project.missing_reviews, count: @staging_project.missing_reviews.count, builder: xml })
+
+  render(partial: 'building_repositories', locals: { building_repositories: @staging_project.building_repositories, count: @staging_project.building_repositories.count, builder: xml })
+
+  render(partial: 'broken_packages', locals: { broken_packages: @staging_project.broken_packages, count: @staging_project.broken_packages.count, builder: xml })
+end

--- a/src/api/config/routes.rb
+++ b/src/api/config/routes.rb
@@ -731,11 +731,12 @@ OBSApi::Application.routes.draw do
   end
 
   # StagingWorkflow API
-  resources :staging_project, only: [], param: :name do
-    get 'staged_requests' => 'staging/staged_requests#index', constraints: cons
-    resource :staged_requests, controller: 'staging/staged_requests', only: [:create, :destroy], constraints: cons
+  scope module: 'staging' do
+    resources :staging_projects, only: [:show], param: :name do
+      get 'staged_requests' => 'staged_requests#index', constraints: cons
+      resource :staged_requests, controller: 'staged_requests', only: [:create, :destroy], constraints: cons
+    end
   end
-
   controller :source_attribute do
     get 'source/:project(/:package(/:binary))/_attribute(/:attribute)' => :show, constraints: cons
     post 'source/:project(/:package(/:binary))/_attribute(/:attribute)' => :update, constraints: cons, as: :change_attribute

--- a/src/api/spec/controllers/staging/staging_projects_controller_spec.rb
+++ b/src/api/spec/controllers/staging/staging_projects_controller_spec.rb
@@ -1,0 +1,93 @@
+require 'rails_helper'
+
+RSpec.describe Staging::StagingProjectsController, type: :controller do
+  render_views
+
+  let(:user) { create(:confirmed_user, login: 'permitted_user') }
+  let(:project) { user.home_project }
+  let(:staging_workflow) { create(:staging_workflow_with_staging_projects, project: project) }
+  let(:staging_project) { staging_workflow.staging_projects.first }
+  let(:source_project) { create(:project, name: 'source_project') }
+  let(:target_package) { create(:package, name: 'target_package', project: project) }
+  let(:source_package) { create(:package, name: 'source_package', project: source_project) }
+
+  describe 'GET #show' do
+    context 'not existing project' do
+      before do
+        get :show, params: { name: 'does-not-exist', format: :xml }
+      end
+
+      it { expect(response).to have_http_status(:not_found) }
+    end
+
+    context 'valid project' do
+      let(:broken_packages_backend) do
+        <<~XML
+          <resultlist state="e9e2a9641ea83ac9c8786c24ca57dc6f">
+            <result project="home:foo:Staging:A" repository="openSUSE_Tumbleweed" arch="i586" code="published" state="published">
+              <status package="barbar" code="failed" />
+            </result>
+            <result project="home:foo:Staging:A" repository="openSUSE_Tumbleweed" arch="x86_64" code="published" state="published">
+              <status package="barbar" code="failed" />
+            </result>
+          </resultlist>
+        XML
+      end
+      let(:broken_packages_path) { "#{CONFIG['source_url']}/build/#{staging_project.name}/_result?code=failed&code=broken&code=unresolvable" }
+
+      let(:request_attributes) do
+        {
+          target_project: project.name,
+          target_package: target_package.name,
+          source_project: source_project.name,
+          source_package: source_package.name
+        }
+      end
+
+      let!(:bs_request) do
+        create(:bs_request_with_submit_action, request_attributes.merge(creator: user, staging_project: staging_project))
+      end
+
+      let(:untracked_review) { create(:review, by_project: staging_project) }
+      let!(:untracked_request) do
+        create(:bs_request_with_submit_action, request_attributes.merge(creator: user, reviews: [untracked_review]))
+      end
+
+      let(:review) { create(:review, by_project: staging_project) }
+      let!(:bs_request_to_review) do
+        create(:bs_request_with_submit_action, request_attributes.merge(creator: user, reviews: [review], staging_project: staging_project))
+      end
+
+      let(:missing_review) { create(:review, by_user: user) }
+      let!(:bs_request_missing_review) do
+        create(:bs_request_with_submit_action, request_attributes.merge(creator: user, reviews: [missing_review], staging_project: staging_project))
+      end
+
+      before do
+        stub_request(:get, broken_packages_path).and_return(body: broken_packages_backend)
+        get :show, params: { name: staging_project.name, format: :xml }
+      end
+
+      it { expect(response).to have_http_status(:success) }
+      it 'returns the staging_project name xml' do
+        assert_select 'staging_project' do
+          assert_select 'staged_requests', 1 do
+            assert_select 'entry', 3
+          end
+          assert_select 'untracked_requests', 1 do
+            assert_select 'entry', 1
+          end
+          assert_select 'requests_to_review', 1 do
+            assert_select 'entry', 2
+          end
+          assert_select 'missing_reviews', 1 do
+            assert_select 'entry', 1
+          end
+          assert_select 'broken_package', 1 do
+            assert_select 'entry', 2
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Add XML endpoint similar with:

https://build.opensuse.org/project/staging_projects/openSUSE:Factory/C?format=json


the output:

```
<staging_project name="home:foo:Staging:A">
  <staged_requests count="1">
    <entry id="3" creator="foo" state="review" package="barbar"/>
  </staged_requests>
  <untracked_requests count="1">
    <entry id="4" creator="bar" state="review" package="barbar"/>
  </untracked_requests>
  <requests_to_review count="1">
    <entry id="4" creator="bar" state="review" package="barbar"/>
  </requests_to_review>
  <missing_reviews count="1">
    <entry id="2" creator="foo" state="new" package="barbar"/>
  </missing_reviews>
  <broken_package count="2">
    <entry package="barbar" project="home:foo:Staging:A"/>
    <entry package="barbar" project="home:foo:Staging:A"/>
  </broken_package>
</staging_project>
```