### PR TITLE
Put user provided id in apostrophes

### DIFF
--- a/src/api/app/controllers/staging/staged_requests_controller.rb
+++ b/src/api/app/controllers/staging/staged_requests_controller.rb
@@ -21,7 +21,7 @@ class Staging::StagedRequestsController < ApplicationController
       render_error(
         status: 400,
         errorcode: 'invalid_request',
-        message: "Could not assign requests #{unassigned_requests.to_sentence} to #{@staging_project}."
+        message: "Could not assign requests '#{unassigned_requests.to_sentence}' to #{@staging_project}."
       )
     end
   end


### PR DESCRIPTION
It's a tiny change, but it makes it much clearer that OBS wasn't able to
fetch the id.

Before:

<status code="invalid_request">
  <summary>Could not assign requests  to home:Admin:Staging:A.</summary>
</status>

After:

<status code="invalid_request">
  <summary>Could not assign requests '' to home:Admin:Staging:A.</summary>
</status>

If you haven't done so already, please read the CONTRIBUTING.md file to learn how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md

