### PR TITLE
Allow use of accesskey to trigger reload

### DIFF
--- a/src/api/app/views/shared/_buildresult_box.html.haml
+++ b/src/api/app/views/shared/_buildresult_box.html.haml
@@ -7,7 +7,7 @@
   %ul{ id: "result_select_#{index}" }
     %li.selected
       %a{ href: '#', id: "result_select_link_#{index}_0", data: { id: "result_display_#{index}_0" } } Build Results
-      = sprite_tag('reload', title: 'Reload', onclick: "update_build_result_#{index}()", class: "result_reload", id: "result_reload_#{index}_0")
+      = sprite_tag('reload', title: 'Reload', accesskey: 'r', onclick: "update_build_result_#{index}()", class: "result_reload", id: "result_reload_#{index}_0")
       = image_tag('ajax-loader.gif', id: "result_spinner_#{index}_0")
     - if controller == 'package'
       %li

--- a/src/api/app/views/webui/kiwi/images/_build_info.html.haml
+++ b/src/api/app/views/webui/kiwi/images/_build_info.html.haml
@@ -2,7 +2,7 @@
   %ul
     %li.selected
       %a.result-select-link#result-select-link{ href: '#' } Build Results
-      = sprite_tag('reload', title: 'Reload', onclick: 'update_build_result()', class: "result_reload", id: "result_reload")
+      = sprite_tag('reload', title: 'Reload', accesskey: 'r', onclick: 'update_build_result()', class: "result_reload", id: "result_reload")
       = image_tag('ajax-loader.gif', id: "result_spinner")
 
 .result-display#result-display

--- a/src/api/app/views/webui2/shared/_buildresult_box.html.haml
+++ b/src/api/app/views/webui2/shared/_buildresult_box.html.haml
@@ -21,7 +21,7 @@
   .card-body
     .tab-content
       .tab-pane.fade.show.active{ id: "build#{index}", role: 'tabpanel', aria: { labelledby: "build#{index}-tab" } }
-        .btn.btn-sm.btn-outline-primary.mb-2.build-refresh{ onclick: "updateBuildResult('#{index}')", title: 'Refresh Build Results' }
+        .btn.btn-sm.btn-outline-primary.mb-2.build-refresh{ onclick: "updateBuildResult('#{index}')", accesskey: 'r', title: 'Refresh Build Results' }
           Refresh
           %i.fas.fa-sm.fa-sync-alt{ id: "build#{index}-reload" }
         .result


### PR DESCRIPTION
Allow use of accesskey to trigger reload
Because users are often waiting for status to update
and do not want to move their mouse to the tiny reload button

Uses Alt-Shift-R in Linux Firefox to trigger a reload

Only slightly tested with manual firebug patching on project/show and package/show pages (new/Beta style)