### PR TITLE
Improve style of overall state icon

### DIFF
--- a/src/api/app/assets/stylesheets/webui2/staging-workflow.scss
+++ b/src/api/app/assets/stylesheets/webui2/staging-workflow.scss
@@ -29,6 +29,10 @@ ul .table-list-group-item {
     &.project {
       > span.badge {
         @extend .w-100;
+
+        > span.badge {
+          @extend .m-1;
+        }
       }
 
       span.badge {


### PR DESCRIPTION
Add a margin to the staging project identifier to have a
clear seperation from the state type and the border of the outer
part of the "icon".

Before:
![screenshot-2018-11-21 staging for home admin - open build service 1](https://user-images.githubusercontent.com/968949/48830320-99601400-ed74-11e8-9415-cffa38b08a83.png)

After:
![screenshot-2018-11-21 staging for home admin - open build service](https://user-images.githubusercontent.com/968949/48830334-9e24c800-ed74-11e8-927c-bca71ad84ad0.png)
