### PR TITLE
Staging workflow managers group improvements

### DIFF
--- a/src/api/app/controllers/webui/staging/workflows_controller.rb
+++ b/src/api/app/controllers/webui/staging/workflows_controller.rb
@@ -22,12 +22,18 @@ class Webui::Staging::WorkflowsController < Webui::WebuiController
 
     staging_workflow.managers_group = Group.find_by(title: params[:managers_title])
 
+    unless staging_workflow.managers_group
+      flash[:error] = "Managers Group #{params[:managers_title]} couldn't be found"
+      redirect_to new_staging_workflow_path(project_name: @project)
+      return
+    end
+
     if staging_workflow.save
       flash[:success] = "Staging for #{@project} was successfully created"
       redirect_to staging_workflow_path(staging_workflow)
     else
       flash[:error] = "Staging for #{@project} couldn't be created"
-      render :new
+      redirect_to new_staging_workflow_path(project_name: @project)
     end
   end
 

--- a/src/api/app/views/webui2/webui/staging/workflows/new.html.haml
+++ b/src/api/app/views/webui2/webui/staging/workflows/new.html.haml
@@ -4,21 +4,21 @@
   = render(partial: 'webui2/webui/project/tabs', locals: { project: @project })
   .card-body
     %h3= @pagetitle
-    .mb-3
+    %p
       Adding the staging capability to this project will enable you to group
       requests into staging projects and being able to see how they build together.
     .mb-3.w-50.m-auto
       = form_for @staging_workflow, method: :post do |f|
         = hidden_field_tag :project_name, @project
         .form-group#assign-managers-group-modal-input
-          = label_tag(:managers_title, 'Managers:')
+          = label_tag(:managers_title, 'Managers Group:')
           .input-group
             .input-group-prepend
               %span.input-group-text#assign-managers-group-search-icon
                 %i.fa.fa-search
                 %i.fas.fa-spinner.fa-spin.d-none
-            = text_field_tag 'managers_title', '', required: true, placeholder: 'Type to autocomplete...', class: 'form-control',
-                              data: { autocomplete_groups_url: url_for(controller: '/webui/groups', action: 'autocomplete') }
+            = text_field_tag 'managers_title', '', required: true, placeholder: 'Type the name of an existent group to autocomplete...',
+                              class: 'form-control', data: { autocomplete_groups_url: url_for(controller: '/webui/groups', action: 'autocomplete') }
         .text-center
           = f.submit 'Create Staging Projects', class: 'btn btn-primary'
 

--- a/src/api/app/views/webui2/webui/staging/workflows/new.html.haml
+++ b/src/api/app/views/webui2/webui/staging/workflows/new.html.haml
@@ -7,6 +7,10 @@
     %p
       Adding the staging capability to this project will enable you to group
       requests into staging projects and being able to see how they build together.
+    %p
+      Managers groups can only be created by an admin. Please contact an
+      = Configuration[:admin_email] == 'unconfigured@openbuildservice.org' ? 'admin' : mail_to(Configuration[:admin_email], 'admin')
+      if don't have a group yet.
     .mb-3.w-50.m-auto
       = form_for @staging_workflow, method: :post do |f|
         = hidden_field_tag :project_name, @project


### PR DESCRIPTION
We need to use `redirect_to` instead of `render` as otherwise, the value of `action_name` is `create` instead of `new`. This would bring a lot of issues in the rendering of the breadcrumbs.

Before:
![before](https://user-images.githubusercontent.com/1102934/48838836-dbe01b80-ed89-11e8-89bc-d67d1bd0d0e8.png)

After (with an error example in the flash):
![managers-group](https://user-images.githubusercontent.com/1102934/48839119-b43d8300-ed8a-11e8-8b4d-3f1d620a718c.png)

