### PR TITLE
Remove unused requests variable

### DIFF
--- a/src/api/app/controllers/webui/staging/excluded_requests_controller.rb
+++ b/src/api/app/controllers/webui/staging/excluded_requests_controller.rb
@@ -12,7 +12,6 @@ module Webui
 
       def index
         @request_exclusions = @staging_workflow.request_exclusions
-        @requests = @staging_workflow.unassigned_requests
       end
 
       def create

--- a/src/api/app/views/webui2/webui/staging/excluded_requests/index.html.haml
+++ b/src/api/app/views/webui2/webui/staging/excluded_requests/index.html.haml
@@ -24,7 +24,7 @@
           %i.fas.fa-plus-circle.text-primary
           Exclude request
 
-= render partial: 'create_dialog', locals: { requests: @requests }
+= render partial: 'create_dialog'
 
 = content_for :ready_function do
   :plain


### PR DESCRIPTION
As `@requests` is not used in the create_dialog partial it can be removed.