### PR TITLE
Avoid overlapping UI elements in revision diff

### DIFF
--- a/src/api/app/views/webui2/webui/package/rdiff.html.haml
+++ b/src/api/app/views/webui2/webui/package/rdiff.html.haml
@@ -9,7 +9,13 @@
   = render partial: 'tabs', locals: { project: @project, package: @package }
   .card-body
     .row
-      .col-sm-10
+      .col-12
+        - if @filenames.present?
+          .btn-group.float-right
+            %button.btn.btn-sm.btn-outline-secondary#expand-diffs
+              Expand all
+            %button.btn.btn-sm.btn-outline-secondary#collapse-diffs
+              Collapse all
         - if @opackage
           %h3
             Difference Between Revision #{@rev}
@@ -17,13 +23,6 @@
         - else
           %h3
             Changes of Revision #{@rev}
-      - if @filenames.present?
-        .col-sm-2
-          .btn-group.float-right
-            %button.btn.btn-sm.btn-outline-secondary#expand-diffs
-              Expand all
-            %button.btn.btn-sm.btn-outline-secondary#collapse-diffs
-              Collapse all
     %br
     .row
       .col-sm-12


### PR DESCRIPTION
Avoid overlapping UI elements in revision diff
by dropping btn-group class that prevents wrapping of individual buttons

Fixes #6330