### PR TITLE
Empty project link to staging project instead of project

### DIFF
--- a/src/api/app/views/webui2/webui/staging/workflows/_empty_projects_list.html.haml
+++ b/src/api/app/views/webui2/webui/staging/workflows/_empty_projects_list.html.haml
@@ -4,4 +4,4 @@
   %ul.pl-4
     - projects.sort.each do |project|
       %li
-        = link_to(project.staging_identifier, project_show_path(project.name))
+        = link_to(project.staging_identifier, staging_workflow_staging_project_path(staging_workflow, project.name))

--- a/src/api/app/views/webui2/webui/staging/workflows/_infos.html.haml
+++ b/src/api/app/views/webui2/webui/staging/workflows/_infos.html.haml
@@ -8,7 +8,7 @@
           %li= link_to managers.title, group_show_path(managers)
 
       %dt Empty projects:
-      %dd= render 'empty_projects_list', projects: empty_projects
+      %dd= render 'empty_projects_list', projects: empty_projects, staging_workflow: staging_workflow
 
       %dt= link_to('Backlog:', group_show_path(staging_workflow.managers_group))
       %dd= render 'requests_list', requests: unassigned_requests, more_requests: more_unassigned_requests


### PR DESCRIPTION
Talking with @bgeuken we realized that inside Infos box there is a list of Empty Projects and in the old UI they pointed to the project show page. We consider they should point to the staging project instead.