### PR TITLE
Drop staging identifier

### DIFF
--- a/src/api/app/models/staging/staging_project.rb
+++ b/src/api/app/models/staging/staging_project.rb
@@ -14,10 +14,6 @@ module Staging
     after_destroy :update_staging_workflow_on_backend
     before_create :add_managers_group
 
-    def staging_identifier
-      name[/.*:Staging:(.*)/, 1]
-    end
-
     def classified_requests
       requests = (requests_to_review | staged_requests.includes(:reviews)).map do |request|
         {

--- a/src/api/app/views/webui2/webui/staging/workflows/_empty_projects_list.html.haml
+++ b/src/api/app/views/webui2/webui/staging/workflows/_empty_projects_list.html.haml
@@ -4,4 +4,4 @@
   %ul.pl-4
     - projects.sort.each do |project|
       %li
-        = link_to(project.staging_identifier, staging_workflow_staging_project_path(staging_workflow, project.name))
+        = link_to(project.name, staging_workflow_staging_project_path(staging_workflow, project.name))

--- a/src/api/app/views/webui2/webui/staging/workflows/_overall_state.html.haml
+++ b/src/api/app/views/webui2/webui/staging/workflows/_overall_state.html.haml
@@ -1,6 +1,6 @@
 %span.badge{ class: "state-#{staging_project.overall_state}" }
   %span.badge.badge-light
-    = link_to(staging_project.staging_identifier, staging_workflow_staging_project_path(staging_workflow, staging_project.name))
+    = link_to(staging_project.name, staging_workflow_staging_project_path(staging_workflow, staging_project.name))
   %span
     %br
     = staging_project.overall_state

--- a/src/api/spec/cassettes/Staging_StagingProject/_overall_state/when_there_are_failed_checks/1_3_5_1.yml
+++ b/src/api/spec/cassettes/Staging_StagingProject/_overall_state/when_there_are_failed_checks/1_3_5_1.yml
@@ -32,5 +32,5 @@ http_interactions:
 
 '
     http_version: 
-  recorded_at: Wed, 14 Nov 2018 10:35:07 GMT
+  recorded_at: Wed, 21 Nov 2018 16:02:18 GMT
 recorded_with: VCR 4.0.0

--- a/src/api/spec/cassettes/Staging_StagingProject/_overall_state/when_there_are_missing_checks/1_3_3_1.yml
+++ b/src/api/spec/cassettes/Staging_StagingProject/_overall_state/when_there_are_missing_checks/1_3_3_1.yml
@@ -1,0 +1,36 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://backend:5352/build/home:tom:Staging:A/_result?code=unresolvable
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '56'
+    body:
+      encoding: UTF-8
+      string: '<resultlist state="00000000000000000000000000000000" />
+
+'
+    http_version: 
+  recorded_at: Wed, 21 Nov 2018 16:00:34 GMT
+recorded_with: VCR 4.0.0

--- a/src/api/spec/cassettes/Staging_StagingProject/_overall_state/when_there_are_pending_checks/1_3_4_1.yml
+++ b/src/api/spec/cassettes/Staging_StagingProject/_overall_state/when_there_are_pending_checks/1_3_4_1.yml
@@ -1,0 +1,36 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://backend:5352/build/home:tom:Staging:A/_result?code=unresolvable
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '56'
+    body:
+      encoding: UTF-8
+      string: '<resultlist state="00000000000000000000000000000000" />
+
+'
+    http_version: 
+  recorded_at: Wed, 21 Nov 2018 16:00:34 GMT
+recorded_with: VCR 4.0.0

--- a/src/api/spec/models/staging/staging_project_spec.rb
+++ b/src/api/spec/models/staging/staging_project_spec.rb
@@ -67,14 +67,6 @@ RSpec.describe Staging::StagingProject, vcr: true do
     end
   end
 
-  describe '#staging_identifier' do
-    before do
-      staging_project.update(name: 'openSUSE_41:Staging:myStagingProject')
-    end
-
-    it { expect(staging_project.staging_identifier).to eq('myStagingProject') }
-  end
-
   describe '#untracked_requests' do
     let!(:request_with_review) do
       create(:review_bs_request_by_project, request_attributes.merge(reviewer: user, review_by_project: staging_project))


### PR DESCRIPTION
As result of a discussion related to #6308 we decided to drop the
identifier, since there is no fixed naming scheme we could rely on.

