### PR TITLE
Add unique index to staging_requests_exclusions

### DIFF
--- a/src/api/db/migrate/20181121144645_add_index_to_staging_request_exclusions.rb
+++ b/src/api/db/migrate/20181121144645_add_index_to_staging_request_exclusions.rb
@@ -1,0 +1,5 @@
+class AddIndexToStagingRequestExclusions < ActiveRecord::Migration[5.2]
+  def change
+    add_index :staging_request_exclusions, [:staging_workflow_id, :bs_request_id], unique: true, name: 'index_staging_request_exclusions_unique'
+  end
+end

--- a/src/api/db/structure.sql
+++ b/src/api/db/structure.sql
@@ -1150,6 +1150,7 @@ CREATE TABLE `staging_request_exclusions` (
   `created_at` datetime NOT NULL,
   `updated_at` datetime NOT NULL,
   PRIMARY KEY (`id`),
+  UNIQUE KEY `index_staging_request_exclusions_unique` (`staging_workflow_id`,`bs_request_id`),
   KEY `index_staging_request_exclusions_on_staging_workflow_id` (`staging_workflow_id`),
   KEY `index_staging_request_exclusions_on_bs_request_id` (`bs_request_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
@@ -1439,6 +1440,7 @@ INSERT INTO `schema_migrations` (version) VALUES
 ('20181016103905'),
 ('20181025152009'),
 ('20181030114152'),
-('20181113095753');
+('20181113095753'),
+('20181121144645');
 
 


### PR DESCRIPTION
Ensures that a request can not be excluded twice for the same staging workflow in the database.
