### PR TITLE
OpenQA takes the correct qcow2 filename

### DIFF
--- a/dist/schedule-obs.sh
+++ b/dist/schedule-obs.sh
@@ -6,7 +6,7 @@ unset OPENQA_CONFIG
 function trigger_run {
   OBS_VERSION="$1"
   FULL_URL="http://download.opensuse.org/repositories/OBS:/$2/"
-  filename=`curl -s $FULL_URL | grep "obs-server.*.x86_64-.*qcow2" | head -n1 | sed -e 's,.*href=",,; s,".*,,; s,\.mirrorlist,,'`
+  filename=`curl -s $FULL_URL | grep "obs-server.*.x86_64-.*\.qcow2\"" | head -n1 | sed -e 's,.*href=",,; s,".*,,; s,\.mirrorlist,,'`
   last_obs_filename="/tmp/.last.obs_$OBS_VERSION"
   ofilename=`cat $last_obs_filename || touch $last_obs_filename`
   if test "x$ofilename" != "x$filename"; then


### PR DESCRIPTION
OpenQA was failing because it was taken the wrong image name. It was taking
files ending in "*.packages" instead of "*.qcow2".

Now we ensure that it takes only those files ending in ".qcow2" extracting from href attribute which looks like:

```
<a href="obs-server.x86_64-2.9.51-qcow2-Buildlp150.20.34.qcow2">
```

Co-authored-by: David Kang <dkang@suse.com>

