### PR TITLE
Use Project#get_by_name instead of #find_by in Staging

### DIFF
--- a/src/api/app/controllers/staging/staged_requests_controller.rb
+++ b/src/api/app/controllers/staging/staged_requests_controller.rb
@@ -62,7 +62,7 @@ class Staging::StagedRequestsController < ApplicationController
   end
 
   def set_staging_project
-    @staging_project = Staging::StagingProject.find_by!(name: params[:staging_project_name])
+    @staging_project = Staging::StagingProject.get_by_name(params[:staging_project_name])
   end
 
   def set_staging_workflow

--- a/src/api/app/controllers/staging/staging_projects_controller.rb
+++ b/src/api/app/controllers/staging/staging_projects_controller.rb
@@ -2,6 +2,6 @@ class Staging::StagingProjectsController < ApplicationController
   skip_before_action :require_login
 
   def show
-    @staging_project = Staging::StagingProject.find_by!(name: params[:name])
+    @staging_project = Staging::StagingProject.get_by_name(params[:name])
   end
 end


### PR DESCRIPTION
Staging::StagingProject is a subclass of Project. [`get_by_name`](https://github.com/openSUSE/open-build-service/blob/staging-workflow/src/api/app/models/project.rb#L391) should be used always that a project is required instead of `find_by!` as it considers more cases where an exception should be raised. :bowtie: 

