### PR TITLE
Stop duplicating ApplicationPolicy#initialize in the Staging subclasses

### DIFF
--- a/src/api/app/policies/staging/staging_project_policy.rb
+++ b/src/api/app/policies/staging/staging_project_policy.rb
@@ -1,10 +1,4 @@
 class Staging::StagingProjectPolicy < ApplicationPolicy
-  def initialize(user, record)
-    raise Pundit::NotAuthorizedError, 'staging workflow does not exist' unless record
-    @user = user
-    @record = record
-  end
-
   def create?
     ProjectPolicy.new(@user, @record).create?
   end

--- a/src/api/app/policies/staging/workflow_policy.rb
+++ b/src/api/app/policies/staging/workflow_policy.rb
@@ -1,10 +1,4 @@
 class Staging::WorkflowPolicy < ApplicationPolicy
-  def initialize(user, record)
-    raise Pundit::NotAuthorizedError, 'staging workflow does not exist' unless record
-    @user = user
-    @record = record
-  end
-
   def create?
     ProjectPolicy.new(@user, @record.project).create?
   end


### PR DESCRIPTION
Use the parent method instead of override it with the same code. :bowtie: 

