### PR TITLE
Add excluded request routes into staging namespace

### DIFF
--- a/src/api/config/routes.rb
+++ b/src/api/config/routes.rb
@@ -736,11 +736,11 @@ OBSApi::Application.routes.draw do
       get 'staged_requests' => 'staged_requests#index', constraints: cons
       resource :staged_requests, controller: 'staged_requests', only: [:create, :destroy], constraints: cons
     end
-  end
 
-  controller 'staging/excluded_requests' do
-    post 'staging_excluded_requests/:number/:project_name' => :create, constraints: cons
-    delete 'staging_excluded_requests/:number' => :destroy, constraints: cons
+    controller 'excluded_requests' do
+      post 'staging_excluded_requests/:number/:project_name' => :create, constraints: cons
+      delete 'staging_excluded_requests/:number' => :destroy, constraints: cons
+    end
   end
 
   controller :source_attribute do


### PR DESCRIPTION
It makes sense to the routes into the staging namespace. It was required here: #6336 :confounded: 