### PR TITLE
Make peek configurable

### DIFF
--- a/src/api/app/controllers/application_controller.rb
+++ b/src/api/app/controllers/application_controller.rb
@@ -43,6 +43,7 @@ class ApplicationController < ActionController::Base
 
   # Don't show performance of database queries to users
   def peek_enabled?
+    return false if CONFIG['peek_enabled'] != 'true'
     User.current && (User.current.is_admin? || User.current.is_staff?)
   end
 

--- a/src/api/app/controllers/webui/webui_controller.rb
+++ b/src/api/app/controllers/webui/webui_controller.rb
@@ -199,6 +199,7 @@ class Webui::WebuiController < ActionController::Base
 
   # Don't show performance of database queries to users
   def peek_enabled?
+    return false if CONFIG['peek_enabled'] != 'true'
     User.current && (User.current.is_admin? || User.current.is_staff?)
   end
 

--- a/src/api/config/options.yml.example
+++ b/src/api/config/options.yml.example
@@ -192,6 +192,10 @@ default: &default
   # influxdb_port: 8086
   # influxdb_ssl: true
   # influxdb_retry: 10
+
+  # Enable (true) / Disable (false) Ruby on Rails profiling top-bar in the web ui
+  peek_enabled: false
+
 production:
   <<: *default
 


### PR DESCRIPTION
Peek is helpful for OBS developers, that can do something about
performance. Not so much for OBS admins, so disable it by default.