### PR TITLE
Update indentation of requests in staging workflow info box

### DIFF
--- a/src/api/app/views/webui2/webui/staging/workflows/_requests_list.html.haml
+++ b/src/api/app/views/webui2/webui/staging/workflows/_requests_list.html.haml
@@ -1,7 +1,8 @@
-- if requests.empty?
-  Empty
-- else
-  %ul.pl-2.list-unstyled
+%ul.pl-2.list-unstyled
+  - if requests.empty?
+    %li
+      Empty
+  - else
     - requests.each do |request|
       %li= link_to(elide(request.first_target_package, 19), request_show_path(request.number))
     - unless more_requests.zero?


### PR DESCRIPTION
Use the same level of indentation for 'Empty' requests placeholder as
we use for actual requests.

Before:

![screenshot-2018-11-22 staging for home admin - open build service 1](https://user-images.githubusercontent.com/968949/48904685-6f375080-ee5f-11e8-8e3a-235e0c822032.png)


After:

![screenshot-2018-11-22 staging for home admin - open build service](https://user-images.githubusercontent.com/968949/48904661-62b2f800-ee5f-11e8-8d64-d3a264aab587.png)
