### PR TITLE
Add link to the API documentation to our footer

### DIFF
--- a/src/api/app/views/layouts/webui2/_footer.html.haml
+++ b/src/api/app/views/layouts/webui2/_footer.html.haml
@@ -23,6 +23,7 @@
     %ul
       %li= link_to('Open Build Service', 'http://openbuildservice.org/')
       %li= link_to('OBS Manuals', 'http://openbuildservice.org/help/manuals/')
+      %li= link_to('API Documentation', 'https://build.opensuse.org/apidocs/')
       %li= link_to('OBS Portal', 'http://en.opensuse.org/Portal:Build_service')
       %li= link_to('Reporting a Bug', 'http://openbuildservice.org/support/')
       - if Announcement.last.present?


### PR DESCRIPTION
We currently don't have any reference to our API documentation
in OBS. This will add one.
