### PR TITLE
Update influxdb-rails to 1.0.0.beta

### DIFF
--- a/src/api/Gemfile
+++ b/src/api/Gemfile
@@ -77,7 +77,7 @@ gem 'addressable'
 # for XML builder
 gem 'builder'
 # to write the rails metrics directly into InfluxDB.
-gem 'influxdb-rails'
+gem 'influxdb-rails', '>=1.0.0.beta1'
 
 group :development, :production do
   # to have the delayed job daemon

--- a/src/api/Gemfile.lock
+++ b/src/api/Gemfile.lock
@@ -177,7 +177,7 @@ GEM
     i18n (1.1.1)
       concurrent-ruby (~> 1.0)
     influxdb (0.5.3)
-    influxdb-rails (0.4.3)
+    influxdb-rails (1.0.0.beta1)
       influxdb (~> 0.5.0)
       railties (> 3)
     innertube (1.1.0)
@@ -488,7 +488,7 @@ DEPENDENCIES
   haml
   haml-rails
   haml_lint
-  influxdb-rails
+  influxdb-rails (>= 1.0.0.beta1)
   jquery-datatables
   jquery-rails
   jquery-ui-rails (~> 4.2.1)


### PR DESCRIPTION
because the beta version adds more data.
As this is not production critical we can safely use a beta version.

