### PR TITLE
Migrate user home info to Boostrap

### DIFF
--- a/src/api/app/assets/stylesheets/webui2/user.scss
+++ b/src/api/app/assets/stylesheets/webui2/user.scss
@@ -1,0 +1,8 @@
+.home-usertitle {
+  margin: 25px 0 15px;
+}
+
+.home-login {
+  margin-top: 5px;
+  color: $gray-500;
+}

--- a/src/api/app/assets/stylesheets/webui2/webui2.css.scss
+++ b/src/api/app/assets/stylesheets/webui2/webui2.css.scss
@@ -40,6 +40,7 @@
 @import 'diff';
 @import 'repositories';
 @import 'project-package-show-grid';
+@import 'user';
 
 html {
     overflow-y: scroll !important;

--- a/src/api/app/controllers/webui/user_controller.rb
+++ b/src/api/app/controllers/webui/user_controller.rb
@@ -15,6 +15,12 @@ class Webui::UserController < Webui::WebuiController
     @groups = @displayed_user.groups
     @role_titles = @displayed_user.roles.global.pluck(:title)
     @account_edit_link = CONFIG['proxy_auth_account_page']
+
+    # # TODO: Remove the `return unless` and the flash once this should be available to all beta users on production
+    return unless User.current.try(:in_beta?) && Rails.env.development?
+
+    flash[:notice] = 'We are currently migrating the project pages to Bootstrap. This page is only seen on the development and test environments'
+    switch_to_webui2
   end
 
   def home

--- a/src/api/app/helpers/webui/user_helper.rb
+++ b/src/api/app/helpers/webui/user_helper.rb
@@ -12,6 +12,16 @@ module Webui::UserHelper
     image_tag(url, width: size, height: size, alt: alt, class: opt[:css_class])
   end
 
+  def webui2_user_image_tag(user, css_class = nil, alt = nil)
+    alt ||= (user ? "#{user.name}'s avatar" : 'Avatar')
+    url = if user.try(:email) && ::Configuration.gravatar
+            "https://www.gravatar.com/avatar/#{Digest::MD5.hexdigest(user.email.downcase)}?s=500&d=wavatar"
+          else
+            'default_face.png'
+          end
+    image_tag(url, alt: alt, class: css_class, width: '100%')
+  end
+
   def _optional_icon(user, opt)
     if opt[:no_icon]
       ''

--- a/src/api/app/models/user.rb
+++ b/src/api/app/models/user.rb
@@ -831,6 +831,10 @@ class User < ApplicationRecord
     address.format
   end
 
+  def name
+    realname.presence || login
+  end
+
   def combined_rss_feed_items
     Notification::RssFeedItem.where(subscriber: self).or(
       Notification::RssFeedItem.where(subscriber: groups)

--- a/src/api/app/views/webui2/webui/user/_breadcrumb_items.html.haml
+++ b/src/api/app/views/webui2/webui/user/_breadcrumb_items.html.haml
@@ -1,0 +1,3 @@
+= render partial: 'webui/main/breadcrumb_items'
+%li.breadcrumb-item.active{ 'aria-current' => 'page' }
+  Home of #{@displayed_user}

--- a/src/api/app/views/webui2/webui/user/_edit_dialog.html.haml
+++ b/src/api/app/views/webui2/webui/user/_edit_dialog.html.haml
@@ -1,0 +1,16 @@
+.modal.fade#edit-modal{ tabindex: -1, role: 'dialog', aria: { labelledby: 'branch-modal-label', hidden: true } }
+  .modal-dialog.modal-dialog-centered{ role: 'document' }
+    .modal-content
+      .modal-header
+        %h5.modal-title#branch-modal-label Edit your account
+      = form_for(user, url: user_save_path, method: 'post') do |f|
+        .modal-body
+          = f.hidden_field(:login, id: 'user')
+          .form-group
+            = f.label(:realname, 'Name:')
+            = f.text_field(:realname, class: 'form-control')
+          .form-group
+            = f.label(:email, 'Email:')
+            = f.text_field(:email, required: true, email: true, class: 'form-control')
+        .modal-footer
+          = render partial: 'webui2/shared/dialog_action_buttons'

--- a/src/api/app/views/webui2/webui/user/_info.html.haml
+++ b/src/api/app/views/webui2/webui/user/_info.html.haml
@@ -1,0 +1,63 @@
+= webui2_user_image_tag(user, 'home-avatar')
+
+%h4.home-usertitle
+  .home-username
+    = user.realname
+  .home-login
+    = user.login
+
+- unless user.is_nobody?
+  %p
+    = mail_to user.email, title: "Send mail to #{user.name}" do
+      %i.fas.fa-envelope
+      = user.email
+
+- if groups.any?
+  Member of the #{'group'.pluralize(groups.size)}
+  %ul
+    - groups.each do |group|
+      %li= link_to("#{group.title} (#{group.tasks})", group_show_path(group))
+
+- if role_titles.any?
+  Has the #{'role'.pluralize(role_titles.size)}
+  %ul
+    - role_titles.each do |title|
+      %li= title
+
+- if is_user
+  - if user.in_beta?
+    %p
+      .badge.badge-info
+        In public beta program
+    = link_to(user_save_path(user: { login: user.login, in_beta: 0 }), method: :post) do
+      %i.fas.fa-sign-out-alt
+      Leave public beta program
+  - else
+    = link_to(user_save_path(user: { login: user.login, in_beta: 1 }), method: :post) do
+      %i.fas.fa-sign-in-alt
+      Join public beta program
+  %br
+  - if configuration.accounts_editable?(user)
+    - if account_edit_link.present?
+      = link_to account_edit_link do
+        %i.fas.fa-user-edit
+        Edit your account
+    - else
+      = link_to('#', data: { toggle: 'modal', target: '#edit-modal' }) do
+        %i.fas.fa-user-edit
+        Edit your account
+    %br
+  - if configuration.passwords_changable?(user)
+    = link_to('#', data: { toggle: 'modal', target: '#password-modal' }) do
+      %i.fas.fa-key
+      Change your password
+    %br
+  = link_to user_notifications_path do
+    %i.fas.fa-bell
+    Change your notifications
+  %br
+  - if user.rss_token
+    = link_to(user_rss_notifications_path(token: user.rss_token.string, format: 'rss'), title: 'RSS Feed for Notifications') do
+      %i.fas.fa-rss-square
+      RSS for notifications
+

--- a/src/api/app/views/webui2/webui/user/_involvement.html.haml
+++ b/src/api/app/views/webui2/webui/user/_involvement.html.haml
@@ -1,0 +1,1 @@
+Placeholder for things the user is involved in

--- a/src/api/app/views/webui2/webui/user/_password_dialog.html.haml
+++ b/src/api/app/views/webui2/webui/user/_password_dialog.html.haml
@@ -1,0 +1,18 @@
+.modal.fade#password-modal{ tabindex: -1, role: 'dialog', aria: { labelledby: 'branch-modal-label', hidden: true } }
+  .modal-dialog.modal-dialog-centered{ role: 'document' }
+    .modal-content
+      .modal-header
+        %h5.modal-title#branch-modal-label Change Your Password
+      = form_tag(action: 'change_password') do
+        .modal-body
+          .form-group
+            = label_tag :password, 'Current Password:'
+            = text_field_tag :password, nil, type: 'password', required: 'true', class: 'form-control'
+          .form-group
+            = label_tag :new_password, 'New Password:'
+            = text_field_tag :new_password, nil, type: 'password', autocomplete: 'off', required: 'true', class: 'form-control'
+          .form-group
+            = label_tag :repeat_password, 'Repeat Password:'
+            = text_field_tag :repeat_password, nil, type: 'password', autocomplete: 'off', required: 'true', class: 'form-control'
+        .modal-footer
+          = render partial: 'webui2/shared/dialog_action_buttons'

--- a/src/api/app/views/webui2/webui/user/show.html.haml
+++ b/src/api/app/views/webui2/webui/user/show.html.haml
@@ -1,0 +1,24 @@
+:ruby
+  @pagetitle = "Home of #{@displayed_user}"
+
+.row
+  .col-12.col-md-3
+    .card
+      .card-body
+        = render partial: 'webui2/webui/user/info', locals: { user: @displayed_user,
+                                                              is_user: @is_displayed_user,
+                                                              groups: @groups,
+                                                              role_titles: @role_titles,
+                                                              configuration: @configuration,
+                                                              account_edit_link: @account_edit_link }
+  .col-12.col-md
+    .card
+      .card-body
+        = render partial: 'webui2/webui/user/involvement', locals: { user: @displayed_user,
+                                                                     owned_packages: @owned,
+                                                                     involved_projects: @iprojects,
+                                                                     involved_packages: @ipackages }
+
+= render partial: 'password_dialog', locals: { user: @displayed_user }
+= render partial: 'edit_dialog', locals: { user: @displayed_user }
+

--- a/src/api/spec/models/user_spec.rb
+++ b/src/api/spec/models/user_spec.rb
@@ -64,6 +64,22 @@ RSpec.describe User do
     it { expect(user.can_modify_user?(user)).to be(true) }
   end
 
+  describe '#name' do
+    context 'user with empty name' do
+      before { user.update(realname: '') }
+
+      it { expect(user.name).to eq(user.login) }
+    end
+
+    context 'user with present name' do
+      let(:realname) { 'Beautiful Name' }
+
+      before { user.update(realname: realname) }
+
+      it { expect(user.name).to eq(realname) }
+    end
+  end
+
   describe 'user creation' do
     it "sets the 'last_logged_in_at' attribute" do
       user = User.new


### PR DESCRIPTION
Create the layout for the user home page and implement the info partial. :bowtie: The involvement partial will be implemented in a separated PR. Until that is done only show this view in development environment.

![image](https://user-images.githubusercontent.com/16052290/49083761-d8e3a000-f24d-11e8-9254-d37db76fff81.png)

![image](https://user-images.githubusercontent.com/16052290/49138118-b05fb280-f2ee-11e8-92fd-980a212f95f6.png)

