### PR TITLE
Migrate user notifications view to bootstrap

### DIFF
--- a/src/api/app/controllers/webui/users/subscriptions_controller.rb
+++ b/src/api/app/controllers/webui/users/subscriptions_controller.rb
@@ -2,6 +2,7 @@ class Webui::Users::SubscriptionsController < Webui::WebuiController
   before_action :require_login
 
   def index
+    switch_to_webui2 if User.current.try(:in_beta?) && Rails.env.development?
     @user = User.current
     @groups_users = User.current.groups_users
 

--- a/src/api/app/views/webui2/webui/subscriptions/_subscriptions_form.html.haml
+++ b/src/api/app/views/webui2/webui/subscriptions/_subscriptions_form.html.haml
@@ -1,0 +1,17 @@
+:ruby
+  i = 0
+
+- @subscriptions_form.subscriptions_by_event.each do |event_class, subscriptions|
+  %li.list-group-item
+    %h5= event_class.description
+    %p= Event::Base::EXPLANATION_FOR_NOTIFICATIONS[event_class.to_s]
+    - subscriptions.each do |subscription|
+      = fields_for "subscriptions[#{i}]", subscription do |f|
+        .custom-control.custom-checkbox.custom-control-inline
+          = f.check_box :channel, { id: "#{i}", class: 'custom-control-input', data: { eventtype: subscription.eventtype,
+          receiver_role: subscription.receiver_role } }, EventSubscription.channels.keys[1], EventSubscription.channels.keys[0]
+          = f.label :receive, EventSubscription::RECEIVER_ROLE_TEXTS[subscription.receiver_role], class: 'custom-control-label',
+          for: "#{i}"
+          = f.hidden_field :eventtype
+          = f.hidden_field :receiver_role
+          - i += 1

--- a/src/api/app/views/webui2/webui/users/subscriptions/_breadcrumb_items.html.haml
+++ b/src/api/app/views/webui2/webui/users/subscriptions/_breadcrumb_items.html.haml
@@ -1,0 +1,4 @@
+= render partial: 'webui/main/breadcrumb_items'
+- if current_page?(user_notifications_path)
+  %li.breadcrumb-item.active{ 'aria-current' => 'page' }
+    Notifications

--- a/src/api/app/views/webui2/webui/users/subscriptions/index.html.haml
+++ b/src/api/app/views/webui2/webui/users/subscriptions/index.html.haml
@@ -1,0 +1,41 @@
+:ruby
+  @layouttype = 'custom'
+  @pagetitle = 'Notifications'
+
+.card
+  .card-header
+    %h5 Notifications
+  .card-body
+    = form_tag(user_notifications_path, method: :put, id: 'notification_form') do
+      - unless @groups_users.empty?
+        .card-block
+          %h3 Groups
+          %p You will receive emails from the checked groups
+          - @groups_users.each do |group_user|
+            .custom-control.custom-checkbox.custom-control-inline
+              = check_box_tag group_user.group, '1', group_user.email, class: 'custom-control-input', id: "checkbox-#{group_user.group}"
+              = label_tag group_user.group.title, nil, class: 'custom-control-label', for: "checkbox-#{group_user.group}"
+        %br
+      .card-block
+        %h3 Events
+        %p Choose from which events you want to get an email
+        %ul.list-group.list-group-flush
+        #subscriptions-form
+          = render partial: 'webui/subscriptions/subscriptions_form'
+        .card-body
+          = submit_tag 'Update', class: 'btn btn-primary'
+          = link_to('Reset to default', user_notifications_path(default_form: true), remote: true)
+
+.card
+  .card-body
+    %h3 RSS Feed
+    = form_tag(user_rss_token_path, id: 'generate_rss_token_form', method: :post) do
+      %p
+      - if @user.rss_token
+        To access your RSS feeds, use the following url:
+        = link_to(user_rss_notifications_url(token: @user.rss_token.string, format: 'rss'),
+        user_rss_notifications_url(token: @user.rss_token.string, format: 'rss'), target: '_blank')
+      - else
+        No feed url exists for your notifications.
+      .card-body
+        = submit_tag "#{@user.rss_token ? 'Regenerate Url' : 'Generate Url'}", class: 'btn btn-primary'

--- a/src/api/app/views/webui2/webui/users/subscriptions/index.js.erb
+++ b/src/api/app/views/webui2/webui/users/subscriptions/index.js.erb
@@ -1,0 +1,1 @@
+$('#subscriptions-form').replaceWith('<%= escape_javascript(render(partial: 'webui/subscriptions/subscriptions_form')) %>');


### PR DESCRIPTION
The notifications are part of the user infos which gets
migrated to bootstrap

![screenshot-2018-11-27 notifications - open build service](https://user-images.githubusercontent.com/22001671/49090486-1e0fce00-f25e-11e8-8692-c919caf709ee.png)


