### PR TITLE
[backend] XML::Structured: prefer XML::LibXML::SAX as saxparser

### DIFF
--- a/src/backend/XML/Structured.pm
+++ b/src/backend/XML/Structured.pm
@@ -245,6 +245,11 @@ sub _chooseparser {
   my $saxok;
   if (!$@) {
     $saxok = 1;
+    eval { require XML::LibXML::SAX; };
+    if (!$@) {
+      $XML::SAX::ParserPackage = 'XML::LibXML::SAX';
+      return \&_saxparser;
+    }
     my $parsers = XML::SAX->parsers();
     return \&_saxparser if $parsers && @$parsers && (@$parsers > 1 || $parsers->[0]->{'Name'} ne 'XML::SAX::PurePerl');
   }


### PR DESCRIPTION
It currently defaults to using libexpat. We want libxml because:
- it is faster than libexpat
- it does not get 16 random bytes for every parse from the kernel

We also set $XML::SAX::ParserPackage because we do not want the
slow ini file walk that XML::SAX::ParserFactory does for every
parser instantiation.

If you haven't done so already, please read the CONTRIBUTING.md file to learn how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md

