### PR TITLE
Don't start repository architectures with position 1

### DIFF
--- a/src/api/app/models/project/update_from_xml_command.rb
+++ b/src/api/app/models/project/update_from_xml_command.rb
@@ -294,7 +294,7 @@ class Project
       check_for_duplicated_archs!(xml_archs)
 
       architectures = []
-      xml_archs.each.with_index(1) do |archname, position|
+      xml_archs.each_with_index do |archname, position|
         architecture = Architecture.from_cache!(archname)
         current_repo.repository_architectures.find_or_create_by(architecture: architecture).insert_at(position)
         architectures << architecture

--- a/src/api/spec/models/project/update_from_xml_command_spec.rb
+++ b/src/api/spec/models/project/update_from_xml_command_spec.rb
@@ -161,9 +161,8 @@ RSpec.describe Project::UpdateFromXmlCommand do
         )
         Project::UpdateFromXmlCommand.new(project).send(:update_repositories, xml_hash, false)
 
-        expect(repository_1.architectures.map(&:name).sort).to eq(['i586', 'x86_64'])
-        expect(repository_1.repository_architectures.where(position: 1).first.architecture.name).to eq('x86_64')
-        expect(repository_1.repository_architectures.where(position: 2).first.architecture.name).to eq('i586')
+        expect(repository_1.architectures.map(&:name)).to eq(['x86_64', 'i586'])
+        expect(repository_1.repository_architectures.map { |repoarch| repoarch.architecture.name }).to eq(['x86_64', 'i586'])
       end
 
       it 'should raise an error for unkown architectures' do


### PR DESCRIPTION
Webui starts with 0 and that's also the configured 'top'.
And as we rewrite the positions on update, there is no
migration to worry about either. It's just an offset,
but at least future developers won't have to worry if
the 1 is meaningful
