### PR TITLE
Refactor method of BsRequestActionGroup

### DIFF
--- a/src/api/app/models/bs_request_action_group.rb
+++ b/src/api/app/models/bs_request_action_group.rb
@@ -171,11 +171,8 @@ class BsRequestActionGroup < BsRequestAction
   end
 
   def find_review_state_of_group
-    bs_requests.each do |req|
-      req.reviews.each do |rev|
-        return :review if rev.state != :accepted
-      end
-    end
+    return :review if bs_requests.joins(:reviews).where.not('reviews.state': :accepted).exists?
+
     :new
   end
 


### PR DESCRIPTION
By moving all parts of the actual query to the SQL level we make this
method faster and solve some n + 1 issues as well.


