### PR TITLE
Fix prjconf highlight

### DIFF
--- a/src/api/app/views/webui2/shared/_editor_modal.html.haml
+++ b/src/api/app/views/webui2/shared/_editor_modal.html.haml
@@ -24,7 +24,7 @@
               ['spec', 'rpm-spec', { id: "rpm-spec-#{uid}" }],
               ['diff', { id: "diff_#{uid}" }],
               ['shell', 'text/x-sh', { id: "shell_#{uid}" }],
-              ['projconf', { id: "projconf_#{uid}" }],
+              ['prjconf', 'prjconf', { id: "prjconf_#{uid}" }],
               ['baselibs', 'baselibsconf', { id: "baselibs_#{uid}" }],
               ['perl', { id: "perl_#{uid}" }],
               ['css', 'css', { id: "css_#{uid}" }],


### PR DESCRIPTION
`prjconf` highlighting was using `projconf` instead of `prjconf`.

Related to #6394
