### PR TITLE
Reorganize card-component css and fix header height

### DIFF
--- a/src/api/app/assets/stylesheets/webui2/card-component.scss
+++ b/src/api/app/assets/stylesheets/webui2/card-component.scss
@@ -1,8 +1,17 @@
-.card-body h1, .card-body h2, .card-body h3, .card-body h4, .card-body h5, .card-body h6 {
-    color: $primary;
-}
+.card {
+  .card-header {
+    &.d-flex.justify-content-between {
+      h5 { @extend .mb-0 }
+    }
+  }
+  .card-body {
+    h1, h2, h3, h4, h5, h6 {
+      color: $primary;
+    }
+  }
 
-.card .nav-tabs .nav-link.active {
+  .nav-tabs .nav-link.active {
     background-color: $card-bg;
     border-bottom-color: $card-bg;
+  }
 }


### PR DESCRIPTION
Some card headers were too big.

### Before

![screenshot_2018-11-30 welcome - open build service 1](https://user-images.githubusercontent.com/1212806/49290463-535b2c80-f4a7-11e8-828b-a46ac7991537.png)



### After
![screenshot_2018-11-30 welcome - open build service](https://user-images.githubusercontent.com/1212806/49290439-41798980-f4a7-11e8-9514-9ec7b02e5180.png)

Should fix #6299