### PR TITLE
Fix excess padding on card titles

### DIFF
--- a/src/api/app/views/webui2/webui/main/_latest_updates.html.haml
+++ b/src/api/app/views/webui2/webui/main/_latest_updates.html.haml
@@ -1,6 +1,6 @@
 .card
   .card-header.d-flex.justify-content-between.align-items-center
-    %h5
+    %h5.mb-0
       Latest Updates
     .float-right
       = link_to(latest_updates_feed_path(format: 'rss'), title: 'RSS Feed') do

--- a/src/api/app/views/webui2/webui/main/_status_messages.html.haml
+++ b/src/api/app/views/webui2/webui/main/_status_messages.html.haml
@@ -1,6 +1,6 @@
 .card.mb-3
   .card-header.d-flex.justify-content-between
-    %h5
+    %h5.mb-0
       News
     .float-right
       = link_to(news_feed_path(format: 'rss'), title: 'RSS Feed') do

--- a/src/api/app/views/webui2/webui/users/subscriptions/index.html.haml
+++ b/src/api/app/views/webui2/webui/users/subscriptions/index.html.haml
@@ -3,8 +3,8 @@
   @pagetitle = 'Notifications'
 
 .card
-  .card-header
-    %h5 Notifications
+  %h5.card-header
+    Notifications
   .card-body
     = form_tag(user_notifications_path, method: :put, id: 'notification_form') do
       - unless @groups_users.empty?


### PR DESCRIPTION
When placing a header within an element with 'card-header' class, we
need to overwrite the bottom margin of that header. Otherwise it bloads
the size of the card header.

Fixes #6299

