### PR TITLE
Change `Trigger Rebuild` button colour

### DIFF
--- a/src/api/app/assets/stylesheets/webui2/live_build_log.scss
+++ b/src/api/app/assets/stylesheets/webui2/live_build_log.scss
@@ -9,7 +9,7 @@
 
 .live-link-action {
   @extend .px-2;
-  @extend .mr-2;
+  @extend .mr-3;
   @extend .mb-2;
   @extend .btn;
   @extend .btn-sm;

--- a/src/api/app/views/webui2/webui/package/_live_build_log_controls.html.haml
+++ b/src/api/app/views/webui2/webui/package/_live_build_log_controls.html.haml
@@ -20,7 +20,7 @@
       Download logfile
   - if @can_modify
     = link_to(package_trigger_rebuild_path(project: @project, package: @package, arch: @arch, repository: @repo),
-              class: 'link_trigger_rebuild live-link-action btn-primary d-none',
+              class: 'link_trigger_rebuild live-link-action btn-warning d-none',
               method: :post) do
       %i.fas.fa-redo
       Trigger Rebuild


### PR DESCRIPTION
We changed the colour of `Trigger Rebuild` button from `green` to `yellow` and we also added more margin between buttons 

### Before
![screenshot_2018-11-30 build log for package perl-citrix project home admin - open build service 1](https://user-images.githubusercontent.com/1212806/49295495-2bbf9080-f4b6-11e8-9dc4-da70c98b5e40.png)


### After
![screenshot_2018-11-30 build log for package perl-citrix project home admin - open build service](https://user-images.githubusercontent.com/1212806/49295488-28c4a000-f4b6-11e8-8df9-f80f89fe388a.png)

This should fix #6099