### PR TITLE
Update grid for build results

### DIFF
--- a/src/api/app/views/webui2/webui/package/_buildstatus.html.haml
+++ b/src/api/app/views/webui2/webui/package/_buildstatus.html.haml
@@ -21,8 +21,7 @@
                   package_binaries_path(project: project, package: package, repository: result.repository),
                   data: { content: "Binaries for #{result.repository}", placement: 'top', toggle: 'popover' })
           .row.py-1
-            .col.col-sm-2.col-md
-            .col-4.col-sm-3.text-nowrap
+            .col-4.col-sm-3.offset-2.offset-sm-4.text-nowrap
               - if !(repository && repository.architectures.pluck(:name).include?(result.architecture))
                 %i.fas.fa-clock.text-warning{ title: 'This result is outdated' }
               - else

--- a/src/api/app/views/webui2/webui/project/_buildstatus.html.haml
+++ b/src/api/app/views/webui2/webui/project/_buildstatus.html.haml
@@ -23,8 +23,7 @@
         %div
           - build_results.sort_by(&:architecture).each do |build_result|
             .row.py-1
-              .col.col-sm-2.col-md
-              .col-4.col-sm-3.text-nowrap{ title: "#{repository} summary" }
+              .col-4.col-sm-3.offset-2.offset-sm-4.text-nowrap{ title: "#{repository} summary" }
                 :ruby
                   icon = webui2_repo_status_icon(build_result.state)
                   description = webui2_repo_status_description(build_result.state, build_result.details)


### PR DESCRIPTION
The build results for each repository are indented to
visually distinguish them from the repository they belong to.
Before we were doing this by adding an empty column. Instead we
now use bootstrap's grid column offset.


