### PR TITLE
Fix icon sizes and breakpoints of main page

### DIFF
--- a/src/api/app/helpers/webui/main_helper.rb
+++ b/src/api/app/helpers/webui/main_helper.rb
@@ -4,4 +4,17 @@ module Webui::MainHelper
                 link_to(sprite_tag(image, title: text), link_opts) + tag(:br) +
                 content_tag(:span, link_to(text, link_opts), class: 'proceed_text'))
   end
+
+  def icon_for_status(message)
+    case message.severity
+    when 1
+      { class: 'fa-check-circle text-success', title: 'Success' }
+    when 2
+      { class: 'fa-exclamation-triangle text-warning', title: 'Warning' }
+    when 3
+      { class: 'fa-exclamation-circle text-danger', title: 'Alert' }
+    else
+      { class: 'fa-info-circle text-info', title: 'Info' }
+    end
+  end
 end

--- a/src/api/app/views/webui2/status_messages/_item.html.haml
+++ b/src/api/app/views/webui2/status_messages/_item.html.haml
@@ -1,16 +1,16 @@
 .list-group-item.list-group-item-integrated.border-left-0.border-right-0.small
   .row
-    .col-2.pl-2.text-center
+    .col-1
       - case message.severity.to_i
         - when 1
-          %i.fa.fa-check-circle.fa-2x.text-success.pt-3{ title: 'Success' }
+          %i.fa.fa-check-circle.fa-lg.text-success{ title: 'Success' }
         - when 2
-          %i.fa.fa-exclamation-triangle.fa-2x.text-warning.pt-3{ title: 'Warning' }
+          %i.fa.fa-exclamation-triangle.fa-lg.text-warning{ title: 'Warning' }
         - when 3
-          %i.fa.fa-exclamation-circle.fa-2x.text-danger.pt-3{ title: 'Alert' }
+          %i.fa.fa-exclamation-circle.fa-lg.text-danger{ title: 'Alert' }
         - else
-          %i.fa.fa-info-circle.fa-2x.text-info.pt-3{ title: 'Info' }
-    .col-10.pl-0
+          %i.fa.fa-info-circle.fa-lg.text-info{ title: 'Info' }
+    .col
       %small
         = user_with_realname_and_icon(message.user, short: true)
         wrote #{time_ago_in_words(message.created_at)} ago

--- a/src/api/app/views/webui2/status_messages/_item.html.haml
+++ b/src/api/app/views/webui2/status_messages/_item.html.haml
@@ -1,15 +1,7 @@
 .list-group-item.list-group-item-integrated.border-left-0.border-right-0.small
   .row
     .col-1
-      - case message.severity.to_i
-        - when 1
-          %i.fa.fa-check-circle.fa-lg.text-success{ title: 'Success' }
-        - when 2
-          %i.fa.fa-exclamation-triangle.fa-lg.text-warning{ title: 'Warning' }
-        - when 3
-          %i.fa.fa-exclamation-circle.fa-lg.text-danger{ title: 'Alert' }
-        - else
-          %i.fa.fa-info-circle.fa-lg.text-info{ title: 'Info' }
+      %i.fa.fa-lg{ icon_for_status(message) }
     .col
       %small
         = user_with_realname_and_icon(message.user, short: true)

--- a/src/api/app/views/webui2/webui/main/_latest_updates.html.haml
+++ b/src/api/app/views/webui2/webui/main/_latest_updates.html.haml
@@ -14,13 +14,13 @@
               %i.fa.fa-archive.fa-lg.text-warning{ title: 'Package' }
             - else
               %i.fa.fa-cubes.fa-lg.text-secondary{ title: 'Project' }
-          .col
-            %span.d-inline-block.text-truncate
+          .col.text-truncate
+            %span
               - if update[1] == :package
                 = link_to(package_show_path(project: update[3], package: update[2])) do
                   = update[2]
               - else
                 = link_to(project_show_path(update[1])) do
                   = update[1]
-            %p.small.mb-0
+            %p.small.mt-1.mb-0
               = fuzzy_time(update[0])

--- a/src/api/app/views/webui2/webui/main/_latest_updates.html.haml
+++ b/src/api/app/views/webui2/webui/main/_latest_updates.html.haml
@@ -9,13 +9,13 @@
     - @latest_updates.each do |update|
       .list-group-item.list-group-item-integrated.border-left-0.border-right-0.small
         .row
-          .col-2.pl-2
+          .col-1
             - if update[1] == :package
-              %i.fa.fa-archive.fa-2x.text-warning.pt-2{ title: 'Package' }
+              %i.fa.fa-archive.fa-lg.text-warning{ title: 'Package' }
             - else
-              %i.fa.fa-cubes.fa-2x.text-secondary.pt-2{ title: 'Project' }
-          .col-10.pl-0
-            %span.d-inline-block.text-truncate.w-100
+              %i.fa.fa-cubes.fa-lg.text-secondary{ title: 'Project' }
+          .col
+            %span.d-inline-block.text-truncate
               - if update[1] == :package
                 = link_to(package_show_path(project: update[3], package: update[2])) do
                   = update[2]


### PR DESCRIPTION

The icons were to large in proportion to the content they
belonged to. Reducing their size also required to drop some
tweaks done via padding and column length.
As a side effect the icons no longer overlap with other elements
for certain screen sizes.

Before

![screenshot_2018-12-03 welcome - opensuse build service](https://user-images.githubusercontent.com/968949/49346386-d6d87180-f691-11e8-89b4-ec6ff870aa5c.png)


After

![screenshot_2018-12-02 welcome - open build service](https://user-images.githubusercontent.com/968949/49346349-2ff3d580-f691-11e8-912f-eaa44ac8100a.png)