### PR TITLE
Remove unneeded instance variables in Bootstrap views

### DIFF
--- a/src/api/app/views/webui2/webui/project/_side_links.html.haml
+++ b/src/api/app/views/webui2/webui/project/_side_links.html.haml
@@ -1,5 +1,5 @@
 %ul.list-unstyled
-  - if is_maintenance_project
+  - if project.is_maintenance?
     = render partial: 'webui2/webui/project/side_links/maintenance_project', locals: { open_maintenance_incidents: open_maintenance_incidents,
                                                                                        project: project,
                                                                                        maintained_projects: maintained_projects }
@@ -11,7 +11,7 @@
     - if has_patchinfo
       = render partial: 'webui2/webui/project/side_links/patchinfo_present', locals: { project: project }
 
-    - if is_incident_project
+    - if project.is_maintenance_incident?
       = render partial: 'webui2/webui/project/side_links/incident_project', locals: { has_patchinfo: has_patchinfo,
                                                                                       project: project,
                                                                                       open_release_requests: open_release_requests }

--- a/src/api/app/views/webui2/webui/project/show.html.haml
+++ b/src/api/app/views/webui2/webui/project/show.html.haml
@@ -17,13 +17,11 @@
           - else
             = simple_format(@project.description)
       .col-md-4
-        = render partial: 'side_links', locals: { is_maintenance_project: @is_maintenance_project,
-                                                  open_maintenance_incidents: @open_maintenance_incidents,
+        = render partial: 'side_links', locals: { open_maintenance_incidents: @open_maintenance_incidents,
                                                   project: @project,
                                                   maintained_projects: @maintained_projects,
                                                   nr_of_problem_packages: @nr_of_problem_packages,
                                                   has_patchinfo: @has_patchinfo,
-                                                  is_incident_project: @is_incident_project,
                                                   open_release_requests: @open_release_requests,
                                                   release_targets: @releasetargets,
                                                   requests: @requests,


### PR DESCRIPTION
As pointed out in #6403 by @bgeuken, the now-removed instance variables are unneeded. The calls are inexpensive and it makes the views more readable. We already have so many instance variables.