### PR TITLE
Fix package repositories breadcrumb

### DIFF
--- a/src/api/app/views/webui2/webui/repositories/_breadcrumb_items.html.haml
+++ b/src/api/app/views/webui2/webui/repositories/_breadcrumb_items.html.haml
@@ -1,4 +1,4 @@
-- if defined?(package)
+- if defined?(@package)
   = render partial: 'webui/package/breadcrumb_items'
 - else
   = render partial: 'webui/project/breadcrumb_items'


### PR DESCRIPTION
Use instance variable as the local one is never defined. :bowtie: 

Co-authored-by: @DavidKang 

