### PR TITLE
[api] ensure right user when doing auto_accept in a loop

### DIFF
--- a/src/api/app/models/bs_request.rb
+++ b/src/api/app/models/bs_request.rb
@@ -969,8 +969,12 @@ class BsRequest < ApplicationRecord
     return if approver && state == :review
 
     with_lock do
-      User.current ||= User.find_by_login(creator) if accept_at
-      User.current = User.find_by_login(approver) if approver
+      if accept_at
+        User.current = User.find_by_login(creator)
+      elsif approver
+        User.current = User.find_by_login(approver)
+      end
+      raise 'Request lacks definition of owner for auto accept' unless User.current
 
       begin
         change_state(newstate: 'accepted', comment: 'Auto accept')


### PR DESCRIPTION
Ensure that we have a valid user for auto_accept (should not be
possible)

Enforce the correct user when running via multiple requests in a loop

This is fixing the new revoke error exceptions in production.

If you haven't done so already, please read the CONTRIBUTING.md file to learn how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md

