### PR TITLE
Fix coloring of build result links in the new webui

### DIFF
--- a/src/api/app/assets/stylesheets/webui2/build-results.scss
+++ b/src/api/app/assets/stylesheets/webui2/build-results.scss
@@ -34,7 +34,7 @@
   color: $dark;
 }
 
-.build-state-unresolvable, .build-state-broken {
+.build-state-unresolvable, .build-state-broken, .build-state-failed {
   color: $red;
 }
 


### PR DESCRIPTION
The 'failed' link for the build results should be red, but it was blue.

This broke when moving the defined result colors to a CSS file (f589a07240b).


