### PR TITLE
Fix project_destroy_path usage

### DIFF
--- a/src/api/app/views/webui2/webui/project/_delete_project_dialog.html.haml
+++ b/src/api/app/views/webui2/webui/project/_delete_project_dialog.html.haml
@@ -6,7 +6,7 @@
       .modal-body
         %p Please confirm deletion of #{link_to(project, project_show_path(project))}
 
-        = form_tag(project_destroy_path(project), method: :delete) do
+        = form_tag(project_destroy_path, method: :delete) do
           = hidden_field_tag(:project, project)
 
           .modal-footer


### PR DESCRIPTION
The project_destroy_path doesn't have parameters, so passing the `project` variable isn't needed. This issue prevented the deletion of remote projects.

Fixes #6449