### PR TITLE
Style the request count on the user's tasks page with a badge

### DIFF
--- a/src/api/app/views/webui2/webui/users/tasks/index.html.haml
+++ b/src/api/app/views/webui2/webui/users/tasks/index.html.haml
@@ -9,7 +9,9 @@
         %li.nav-item
           - cache "#{User.current.cache_key}-reviews-in" do
             %a.nav-link.text-nowrap.active{ href: '#reviews-in', title: "Requests that #{User.current} has to review" }
-              Incoming Reviews (#{User.current.involved_reviews.count})
+              Incoming Reviews
+              %span.badge.badge-primary
+                = User.current.involved_reviews.count
 
     .card-body
       .tab-content#reviews-in
@@ -22,19 +24,27 @@
           - cache "#{User.current.cache_key}-requests-in" do
             %a.nav-link.text-nowrap.active#requests-in-tab{ href: '#requests-in', title: "Requests that #{User.current} has to merge",
               'data-toggle': 'tab', 'aria-controls': 'requests-in-tab', 'aria-selected': 'true', role: 'tab' }
-              Incoming Requests (#{User.current.incoming_requests.count})
+              Incoming Requests
+              %span.badge.badge-primary
+                = User.current.incoming_requests.count
         %li.nav-item
           %a.nav-link.text-nowrap#requests-out-tab{ href: '#requests-out', title: "Requests that #{User.current} has sent",
             'data-toggle': 'tab', 'aria-controls': 'requests-out-tab', 'aria-selected': 'false', role: 'tab' }
-            Outgoing Requests (#{User.current.outgoing_requests.count})
+            Outgoing Requests
+            %span.badge.badge-primary
+              = User.current.outgoing_requests.count
         %li.nav-item
           %a.nav-link.text-nowrap#requests-declined-tab{ href: '#requests-declined', title: "Requests from #{User.current} that are declined",
             'data-toggle': 'tab', 'aria-controls': 'requests-declined-tab', 'aria-selected': 'false', role: 'tab' }
-            Declined Requests (#{User.current.declined_requests.count})
+            Declined Requests
+            %span.badge.badge-primary
+              = User.current.declined_requests.count
         %li.nav-item
           %a.nav-link.text-nowrap#all-requests-tab{ href: '#all-requests', title: "All Requests from #{User.current}",
             'data-toggle': 'tab', 'aria-controls': 'all-requests-tab', 'aria-selected': 'false', role: 'tab' }
-            All Requests (#{User.current.requests.count})
+            All Requests
+            %span.badge.badge-primary
+              = User.current.requests.count
         %li.nav-item.dropdown
           %a.nav-link.dropdown-toggle{ href: '#', 'data-toggle': 'dropdown', 'role': 'button', 'aria-expanded': 'false', 'aria-haspopup': 'true' }
           .dropdown-menu.dropdown-menu-right


### PR DESCRIPTION
This makes the page look nicer and makes the counter more visible for
users.

Part of #6464

Before

![screenshot_2018-12-04 tasks for bgeuken - opensuse build service](https://user-images.githubusercontent.com/968949/49468167-7289ef00-f804-11e8-90df-28392b9fe21c.png)

After

![screenshot_2018-12-04 tasks for admin - open build service](https://user-images.githubusercontent.com/968949/49468161-6bfb7780-f804-11e8-9a09-dbcf949b1486.png)

