### PR TITLE
Fix 500 error when a user owns a project, but not a package

### DIFF
--- a/src/api/app/views/webui2/webui/user/_involvement.html.haml
+++ b/src/api/app/views/webui2/webui/user/_involvement.html.haml
@@ -66,7 +66,8 @@
               - owned.each do |package_name, project_name|
                 %tr
                   %td
-                    = link_to(package_name, package_show_path(package: package_name, project: project_name))
+                    - if package_name
+                      = link_to(package_name, package_show_path(package: package_name, project: project_name))
                   %td
                     = link_to(project_name, project_show_path(project: project_name))
 


### PR DESCRIPTION
When a user owns a project the owner search would return a touple of
[nil, 'some_project']. Our code was not checking for non-existant
packages and thus caused an error.


