### PR TITLE
Reduce the default number of requests shown on the user tasks page

### DIFF
--- a/src/api/app/assets/javascripts/webui2/requests_table.js.erb
+++ b/src/api/app/assets/javascripts/webui2/requests_table.js.erb
@@ -5,6 +5,7 @@ $(document).ready(function() {
     var typeDropdown = $('select[name=request_type_select][data-table=' + dataTableId + ']');
     var stateDropdown = $('select[name=request_state_select][data-table=' + dataTableId + ']');
     var url = $(this).data('source');
+    var pageLength = $(this).data('page-length') || 25;
 
     $(this).dataTable({
       order: [[0,'desc']],
@@ -15,7 +16,7 @@ $(document).ready(function() {
         { orderable: false, targets: [6] }
       ],
       paging: true,
-      pageLength: 25,
+      pageLength: pageLength,
       pagingType: "full_numbers",
       processing: true,
       language: {

--- a/src/api/app/views/webui2/shared/_patchinfos_table.html.haml
+++ b/src/api/app/views/webui2/shared/_patchinfos_table.html.haml
@@ -23,6 +23,6 @@
 = javascript_tag do
   :plain
     $(function() {
-      $('#open-patchinfos-table').dataTable();
+      $('#open-patchinfos-table').dataTable({ 'iDisplayLength': 10 });
     });
 

--- a/src/api/app/views/webui2/shared/_requests_table.html.haml
+++ b/src/api/app/views/webui2/shared/_requests_table.html.haml
@@ -2,7 +2,8 @@
   Refresh
   %i.fas.fa-sm.fa-sync-alt
 
-%table.responsive.requests-datatable.table.table-striped.table-bordered.w-100{ data: { source: source_url }, id: id }
+%table.responsive.requests-datatable.table.table-striped.table-bordered.w-100{ data: { source: source_url,
+  'page-length': local_assigns[:page_length] }, id: id }
   %thead
     %tr
       %th Created

--- a/src/api/app/views/webui2/webui/users/tasks/index.html.haml
+++ b/src/api/app/views/webui2/webui/users/tasks/index.html.haml
@@ -15,7 +15,8 @@
 
     .card-body
       .tab-content#reviews-in
-        = render(partial: 'webui2/shared/requests_table', locals: { id: 'reviews_in_table', source_url: user_requests_path(User.current) })
+        = render(partial: 'webui2/shared/requests_table', locals: { id: 'reviews_in_table', source_url: user_requests_path(User.current),
+                 page_length: 10 })
 
   .card.mt-3#requests
     .bg-light
@@ -51,13 +52,17 @@
     .card-body
       .tab-content
         .tab-pane.fade.show.active#requests-in{ role: 'tabpanel', 'aria-labelledby': 'requests-in-tab' }
-          = render(partial: 'webui2/shared/requests_table', locals: { id: 'requests_in_table', source_url: user_requests_path(User.current) })
+          = render(partial: 'webui2/shared/requests_table', locals: { id: 'requests_in_table', source_url: user_requests_path(User.current),
+                   page_length: 10 })
         .tab-pane.fade#requests-out{ role: 'tabpanel', 'aria-labelledby': 'requests-out-tab' }
-          = render(partial: 'webui2/shared/requests_table', locals: { id: 'requests_out_table', source_url: user_requests_path(User.current) })
+          = render(partial: 'webui2/shared/requests_table', locals: { id: 'requests_out_table', source_url: user_requests_path(User.current),
+                   page_length: 10 })
         .tab-pane.fade#requests-declined{ role: 'tabpanel', 'aria-labelledby': 'requests-declined-tab' }
-          = render(partial: 'webui2/shared/requests_table', locals: { id: 'requests_declined_table', source_url: user_requests_path(User.current) })
+          = render(partial: 'webui2/shared/requests_table', locals: { id: 'requests_declined_table', source_url: user_requests_path(User.current),
+                   page_length: 10 })
         .tab-pane.fade#all-requests{ role: 'tabpanel', 'aria-labelledby': 'all-requests-tab' }
-          = render(partial: 'webui2/shared/requests_table', locals: { id: 'all_requests_table', source_url: user_requests_path(User.current) })
+          = render(partial: 'webui2/shared/requests_table', locals: { id: 'all_requests_table', source_url: user_requests_path(User.current),
+                   page_length: 10 })
 
   - involved_patchinfos = User.current.involved_patchinfos
   - if involved_patchinfos.present?


### PR DESCRIPTION
In the new bootstrap UI the request table takes more space. Hence it's
better show less requests by default.

Fixes #6464


