### PR TITLE
Update influxdb-rails gem

### DIFF
--- a/src/api/Gemfile
+++ b/src/api/Gemfile
@@ -77,7 +77,7 @@ gem 'addressable'
 # for XML builder
 gem 'builder'
 # to write the rails metrics directly into InfluxDB.
-gem 'influxdb-rails', '>=1.0.0.beta1'
+gem 'influxdb-rails', '>=1.0.0.beta2'
 
 group :development, :production do
   # to have the delayed job daemon

--- a/src/api/Gemfile.lock
+++ b/src/api/Gemfile.lock
@@ -176,10 +176,10 @@ GEM
       ruby_parser (~> 3.5)
     i18n (1.1.1)
       concurrent-ruby (~> 1.0)
-    influxdb (0.5.3)
-    influxdb-rails (1.0.0.beta1)
-      influxdb (~> 0.5.0)
-      railties (> 3)
+    influxdb (0.6.4)
+    influxdb-rails (1.0.0.beta2)
+      influxdb (~> 0.6, >= 0.6.4)
+      railties (>= 4.2)
     innertube (1.1.0)
     jaro_winkler (1.5.1)
     joiner (0.4.2)
@@ -488,7 +488,7 @@ DEPENDENCIES
   haml
   haml-rails
   haml_lint
-  influxdb-rails (>= 1.0.0.beta1)
+  influxdb-rails (>= 1.0.0.beta2)
   jquery-datatables
   jquery-rails
   jquery-ui-rails (~> 4.2.1)

--- a/src/api/config/initializers/influxdb_rails.rb
+++ b/src/api/config/initializers/influxdb_rails.rb
@@ -6,4 +6,6 @@ InfluxDB::Rails.configure do |config|
   config.influxdb_port     = CONFIG['influxdb_port']
   config.retry             = CONFIG['influxdb_retry']
   config.use_ssl           = CONFIG['influxdb_ssl']
+
+  config.time_precision = CONFIG['influxdb_time_precision']
 end

--- a/src/api/config/options.yml.example
+++ b/src/api/config/options.yml.example
@@ -192,6 +192,7 @@ default: &default
   # influxdb_port: 8086
   # influxdb_ssl: true
   # influxdb_retry: 10
+  # influxdb_time_precision: ms
 
   # Enable (true) / Disable (false) Ruby on Rails profiling top-bar in the web ui
   peek_enabled: false

--- a/src/api/lib/influxdb_obs/obs/middleware/backend_subscriber.rb
+++ b/src/api/lib/influxdb_obs/obs/middleware/backend_subscriber.rb
@@ -16,7 +16,7 @@ module InfluxDB
             InfluxDB::Rails.client.write_point(series_name,
                                                tags: tags(data),
                                                values: values(data[:runtime]),
-                                               timestamp: InfluxDB::Rails.convert_timestamp(finished.utc))
+                                               timestamp: InfluxDB.convert_timestamp(finished.utc))
           rescue StandardError => e
             logger.info "[InfluxDB Backend Subscriber]: #{e.message}"
           end


### PR DESCRIPTION
We need to use the beta branch because it is fixing an issue which
currently kills our InfluxDB server in production (adding the
path element as tag causes millions of tags which need to get
indexed).