### PR TITLE
Disable InstanceVariables in haml-lint

### DIFF
--- a/src/api/.haml-lint.yml
+++ b/src/api/.haml-lint.yml
@@ -4,10 +4,7 @@ linters:
 
   # Apply lint in all partials, but exclude 'breadcrumb_items' partials
   InstanceVariables:
-    enabled: true
-    file_types: not_breadcrumb_items
-    matchers:
-      not_breadcrumb_items: \A_(?!breadcrumb_items).*\.haml\z
+    enabled: false
 
   RuboCop:
     enabled: true


### PR DESCRIPTION
I find [the arguments that are made](http://www.carlosramireziii.com/stop-using-instance-variables-in-partials.html) very weak. Instance variables exist for a
reason, to pass data to the higher layers. That is not a weakness to avoid in
the top most layer, that partials are. It's a strength you should embrace all
around.

I set up @user in my action in the controller, pass it to the view, which makes
use of it in the partial. All the arguments that are brought forward against
using them in partials, like coupling with the controller action etc., are also
true for using them in the view. You wouldn't stop using instance variables all
around, would you? So why in partials?

Another argument is that it makes partials reusable. Yes partials _can_ be
reusable, but is that the most important part of partials? I don't think so,
there are other, equally important, features of partials like abstraction. Why
would you make them way harder to use just to potentially make a partial
reusable? Even if it does not neet to be reused?

This is not a question of general style. It's a question of using the right
thing at the right time and shouldn't be linted at all IMHO.

