### PR TITLE
Prevent exception in repositories breadcrumb

### DIFF
--- a/src/api/app/views/webui2/webui/repositories/_breadcrumb_items.html.haml
+++ b/src/api/app/views/webui2/webui/repositories/_breadcrumb_items.html.haml
@@ -5,7 +5,7 @@
 - if current_page?(repositories_path)
   %li.breadcrumb-item.active{ 'aria-current' => 'page' }
     Repositories
-- elsif current_page?(project_repository_state_path)
+- elsif defined?(@repository) && current_page?(project_repository_state_path)
   %li.breadcrumb-item
     = link_to 'Repositories', repositories_path
   %li.breadcrumb-item.active{ 'aria-current' => 'page' }


### PR DESCRIPTION
project_repository_state_path needs a repository defined in order to find
the right route. When the breadcrumb is used in an view where
no repository is set, it will throw an exception. For example in
the add repository view, which will be added soonish.

