### PR TITLE
[api] support releasing into maintenance_release without incident pro…

### DIFF
--- a/src/api/app/controllers/source_controller.rb
+++ b/src/api/app/controllers/source_controller.rb
@@ -996,6 +996,9 @@ class SourceController < ApplicationController
       multibuild_container = params[:package].gsub(/^.*:/, '')
     end
 
+    # uniq timestring for all targets
+    time_string = Time.now.utc.strftime('%Y%m%d%H%M%S')
+
     # specified target
     if params[:target_project]
       # we do not create it ourself
@@ -1013,6 +1016,10 @@ class SourceController < ApplicationController
           if pkg.project.is_maintenance_incident?
             # The maintenance ID is always the sub project name of the maintenance project
             target_package_name += '.' << pkg.project.name.gsub(/.*:/, '')
+          elsif releasetarget.target_repository.project.is_maintenance_release?
+            # Fallback for releasing into a release project outside of maintenance incident
+            # avoid overwriting existing binaries in this case
+            target_package_name += '.' << time_string
           end
 
           # find md5sum and release source and binaries


### PR DESCRIPTION
…ject

Using readable timestamp as fallback.

Used in continous rebuild projects for container releases

If you haven't done so already, please read the CONTRIBUTING.md file to learn how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md

