### PR TITLE
Be consistent in modal buttons

### DIFF
--- a/src/api/app/views/webui2/webui/project/_new_package_branch_modal.html.haml
+++ b/src/api/app/views/webui2/webui/project/_new_package_branch_modal.html.haml
@@ -44,7 +44,7 @@
           = render partial: 'shared/package_branch_form', locals: { show_project_field: false, target_project: project,
                                                                     package: nil, revision: nil }
           .modal-footer
-            = submit_tag 'Create Branch', class: 'btn btn-primary'
+            = render partial: 'webui2/shared/dialog_action_buttons'
 
 :javascript
   autocomleteBranchPackageName('#{autocomplete_packages_path}');

--- a/src/api/app/views/webui2/webui/project/_new_package_modal.html.haml
+++ b/src/api/app/views/webui2/webui/project/_new_package_modal.html.haml
@@ -26,4 +26,4 @@
             = check_box_tag :disable_publishing, 1, false, class: 'custom-control-input', type: 'checkbox'
             %label.custom-control-label{ for: 'disable_publishing' } Disable build results publishing
           .modal-footer
-            = submit_tag 'Create package', class: 'btn btn-primary'
+            = render partial: 'webui2/shared/dialog_action_buttons'


### PR DESCRIPTION
Use the same modal buttons as the other forms in which we create records

I realized that we missed that in the review of #6458. I found this while working on the subprojects page and comparing the modals...

So it's now like this:
![modal-buttons-1](https://user-images.githubusercontent.com/1102934/49585009-6bc2bf80-f95d-11e8-81bd-70ac32df6fee.png)

![modal-buttons-2](https://user-images.githubusercontent.com/1102934/49585054-93198c80-f95d-11e8-94ed-d746425ee058.png)


