### PR TITLE
Add DoD repository to Bootstrap repository page 

### DIFF
--- a/src/api/app/controllers/webui/repositories_controller.rb
+++ b/src/api/app/controllers/webui/repositories_controller.rb
@@ -141,6 +141,15 @@ class Webui::RepositoriesController < Webui::WebuiController
     rescue ::Timeout::Error, ActiveRecord::RecordInvalid => e
       @error = "Couldn't add repository: #{e.message}"
     end
+
+    return unless User.current.try(:in_beta?) && Rails.env.development?
+
+    if @error
+      flash[:error] = @error
+    else
+      flash[:success] = "Repository '#{params[:name]}' was successfully created."
+    end
+    redirect_to action: 'index', project: @project
   end
 
   # POST project/create_image_repository

--- a/src/api/app/views/webui2/webui/repositories/_add_dod_repository_modal.html.haml
+++ b/src/api/app/views/webui2/webui/repositories/_add_dod_repository_modal.html.haml
@@ -1,0 +1,47 @@
+.modal.fade#add-dod-repository-modal{ tabindex: -1, role: 'dialog', aria: { labelledby: 'add-dod-repository-label', hidden: 'true' } }
+  .modal-dialog.modal-dialog-centered{ role: 'document' }
+    .modal-content
+      =# TODO: Convert this to form_for and use dod_source_field partial
+      = form_tag(create_dod_repository_path(project: project), method: 'post') do
+        .modal-header
+          %h5.modal-title#add-dod-repository-label Add DoD repository
+        .modal-body
+          .form-group.row
+            = label_tag :name, 'Repository name', class: 'col-sm-4 col-form-label'
+            .col-sm-8
+              = text_field_tag :name, nil, required: true, class: 'form-control'
+          .form-group
+            %h6 Download on Demand Source
+          .form-group.row
+            = label_tag :arch, 'Architecture', class: 'col-sm-4 col-form-label'
+            .col-sm-8
+              = select_tag :arch, options_for_select(Architecture.available, ''), required: true,
+                                  class: 'custom-select'
+          .form-group.row
+            = label_tag :repotype, 'Type', class: 'col-sm-4 col-form-label'
+            .col-sm-8
+              = select_tag :repotype, options_for_select(DownloadRepository::REPOTYPES, ''),
+                                      class: 'custom-select'
+          .form-group.row
+            = label_tag :url, 'Url', class: 'col-sm-4 col-form-label'
+            .col-sm-8
+              = text_field_tag(:url, nil, required: true, class: 'form-control')
+          .form-group.row
+            = label_tag :archfilter, 'Arch. Filter', class: 'col-sm-4 col-form-label'
+            .col-sm-8
+              = text_field_tag :archfilter, nil, class: 'form-control'
+          .form-group.row
+            = label_tag :masterurl, 'Master Url', class: 'col-sm-4 col-form-label'
+            .col-sm-8
+              = text_field_tag :masterurl, nil, class: 'form-control'
+          .form-group.row
+            = label_tag :mastersslfingerprint, 'SSL Fingerprint', class: 'col-sm-4 col-form-label'
+            .col-sm-8
+              = text_field_tag :mastersslfingerprint, nil, class: 'form-control'
+          .form-group.row
+            = label_tag :pubkey, 'Public Key', class: 'col-sm-4 col-form-label'
+            .col-sm-8
+              = text_area_tag :pubkey, nil, row: 2, class: 'form-control'
+        .modal-footer
+          = render partial: 'webui2/shared/dialog_action_buttons'
+

--- a/src/api/app/views/webui2/webui/repositories/_add_dod_source_modal.html.haml
+++ b/src/api/app/views/webui2/webui/repositories/_add_dod_source_modal.html.haml
@@ -1,0 +1,4 @@
+.modal.fade{ id: "add-dod-source-modal-#{repository.id}", tabindex: -1, role: 'dialog', aria: { labelledby: 'add-dod-source-label', hidden: 'true' } }
+  = render partial: 'dod_source_fields', locals: { download_on_demand: download_on_demand,
+                                                   project: project,
+                                                   title: "Add Download on Demand for #{repository.name}" }

--- a/src/api/app/views/webui2/webui/repositories/_delete_dod_source_modal.html.haml
+++ b/src/api/app/views/webui2/webui/repositories/_delete_dod_source_modal.html.haml
@@ -1,0 +1,14 @@
+.modal.fade{ id: "delete-dod-source-#{download_on_demand.id}", tabindex: -1, role: 'dialog',
+                  aria: { labelledby: 'delete-repository-label', hidden: true } }
+  .modal-dialog.modal-dialog-centered{ role: 'document' }
+    .modal-content
+      .modal-header
+        %h5.modal-title
+          Delete Download on Demand?
+      .modal-body
+        %p Please confirm deletion of '#{download_on_demand.arch}' Download on Demand
+        = form_tag(download_repository_path(download_on_demand, project: project), method: :delete) do
+          .modal-footer
+            %a.btn.btn-sm.btn-outline-secondary.px-4{ data: { dismiss: 'modal' } }
+              Cancel
+            = submit_tag('Delete', class: 'btn btn-sm btn-danger px-4')

--- a/src/api/app/views/webui2/webui/repositories/_dod_repository_card_content.html.haml
+++ b/src/api/app/views/webui2/webui/repositories/_dod_repository_card_content.html.haml
@@ -1,0 +1,31 @@
+.card-body
+  Download on demand sources:
+  %ul.list-unstyled.ml-3
+    - repository.download_repositories.each do |dod_element|
+      %li
+        %small.font-weight-bold
+          = dod_element.arch
+          = link_to("#{dod_element.url}", target: '_blank', title: 'Go to the repository') do
+            = dod_element.url
+          (#{dod_element.repotype})
+        = link_to('#', title: 'Edit DoD Source', data: { toggle: 'modal', target: "#edit-dod-source-modal-#{dod_element.id}" }) do
+          %i.fas.fa-edit.text-secondary
+        = link_to('#', title: 'Delete Downdload on Demand source',
+                       data: { toggle: 'modal', target: "#delete-dod-source-#{dod_element.id}" }) do
+          %i.fas.fa-times-circle.text-danger
+        = render partial: 'edit_dod_source_modal', locals: { repository: repository, project: project, download_on_demand: dod_element }
+        = render partial: 'delete_dod_source_modal', locals: { repository: repository, project: project, download_on_demand: dod_element }
+.card-footer.text-center
+  .row
+    .col
+      = link_to('#', title: 'Add DoD Source', data: { toggle: 'modal', target: "#add-dod-source-modal-#{repository.id}" }) do
+        %i.fas.fa-plus-circle.text-primary
+    - if User.current.can_modify?(project)
+      .col
+        = link_to('#', title: 'Delete Repository', data: { toggle: 'modal', target: "#delete-repository-#{repository.id}" }) do
+          %i.fas.fa-times-circle.text-danger
+
+= render partial: 'add_dod_source_modal', locals: { repository: repository,
+                                                    project: project,
+                                                    download_on_demand: DownloadRepository.new(repository_id: repository.id) }
+= render partial: 'delete_repository_modal', locals: { repository: repository, project: project }

--- a/src/api/app/views/webui2/webui/repositories/_dod_source_fields.html.haml
+++ b/src/api/app/views/webui2/webui/repositories/_dod_source_fields.html.haml
@@ -1,0 +1,41 @@
+.modal-dialog.modal-dialog-centered{ role: 'document' }
+  .modal-content
+    = form_for(download_on_demand) do |f|
+      .modal-header
+        %h5.modal-title#edit-dod-source-label= title
+      .modal-body
+        .form-group.row
+          = f.label :arch, 'Architecture', class: 'col-sm-4 col-form-label'
+          .col-sm-8
+            = f.select :arch, options_for_select(Architecture.available, download_on_demand.try(:arch)), {}, required: true,
+                              class: 'custom-select'
+        .form-group.row
+          = f.label :repotype, 'Type', class: 'col-sm-4 col-form-label'
+          .col-sm-8
+            = f.select :repotype, options_for_select(DownloadRepository::REPOTYPES, download_on_demand.try(:repotype)), {},
+                                  class: 'custom-select'
+        .form-group.row
+          = f.label :url, 'Url', class: 'col-sm-4 col-form-label'
+          .col-sm-8
+            = f.text_field(:url, required: true, class: 'form-control')
+        .form-group.row
+          = f.label :archfilter, 'Arch. Filter', class: 'col-sm-4 col-form-label'
+          .col-sm-8
+            = f.text_field :archfilter, class: 'form-control'
+        .form-group.row
+          = f.label :masterurl, 'Master Url', class: 'col-sm-4 col-form-label'
+          .col-sm-8
+            = f.text_field :masterurl, class: 'form-control'
+        .form-group.row
+          = f.label :mastersslfingerprint, 'SSL Fingerprint', class: 'col-sm-4 col-form-label'
+          .col-sm-8
+            = f.text_field :mastersslfingerprint, class: 'form-control'
+        .form-group.row
+          = f.label :pubkey, 'Public Key', class: 'col-sm-4 col-form-label'
+          .col-sm-8
+            = f.text_area :pubkey, row: 2, class: 'form-control'
+        .form-group.row
+          = f.hidden_field :repository_id
+          = hidden_field_tag :project, project
+      .modal-footer
+        = render partial: 'webui2/shared/dialog_action_buttons'

--- a/src/api/app/views/webui2/webui/repositories/_edit_dod_source_modal.html.haml
+++ b/src/api/app/views/webui2/webui/repositories/_edit_dod_source_modal.html.haml
@@ -1,0 +1,5 @@
+.modal.fade{ id: "edit-dod-source-modal-#{download_on_demand.id}", tabindex: -1, role: 'dialog',
+             aria: { labelledby: 'edit-dod-source-label', hidden: 'true' } }
+  = render partial: 'dod_source_fields', locals: { download_on_demand: download_on_demand,
+                                                   project: project,
+                                                   title: "Edit #{download_on_demand.try(:arch)} Download on demand" }

--- a/src/api/app/views/webui2/webui/repositories/_repository_entry.html.haml
+++ b/src/api/app/views/webui2/webui/repositories/_repository_entry.html.haml
@@ -7,4 +7,8 @@
           No architecture selected
         - else
           #{repository.architectures.pluck(:name).join(', ')}
-    = render partial: 'repository_card_content', locals: { project: project, repository: repository, download_url: download_url }
+    - if repository.is_dod_repository?
+      = render partial: 'dod_repository_card_content', locals: { project: project, repository: repository }
+    - else
+      = render partial: 'repository_card_content', locals: { project: project, repository: repository, download_url: download_url }
+

--- a/src/api/app/views/webui2/webui/repositories/index.html.haml
+++ b/src/api/app/views/webui2/webui/repositories/index.html.haml
@@ -45,7 +45,7 @@
 
   .card.mb-3
     .card-header.d-flex.justify-content-between
-      %h5 My Repositories
+      %h5 Repositories for #{@project}
 
     .card-body
       .row.pt-2

--- a/src/api/app/views/webui2/webui/repositories/index.html.haml
+++ b/src/api/app/views/webui2/webui/repositories/index.html.haml
@@ -41,7 +41,7 @@
             = link_to('#', data: { toggle: 'modal', target: '#add-dod-repository-modal' }, class: 'nav-link') do
               %i.fas.fa-plus-circle.text-success
               Add DoD Repository
-            =# render partial: 'add_dod_repository_modal', locals: { project: @project }
+            = render partial: 'add_dod_repository_modal', locals: { project: @project }
 
   .card.mb-3
     .card-header.d-flex.justify-content-between

--- a/src/api/config/routes.rb
+++ b/src/api/config/routes.rb
@@ -184,7 +184,7 @@ OBSApi::Application.routes.draw do
       post 'project/update_target/:project' => :update, constraints: cons
       get 'project/repository_state/:project/:repository' => :state, constraints: cons, as: 'project_repository_state'
       post 'project/remove_target' => :destroy, as: 'destroy_repository'
-      post 'project/create_dod_repository' => :create_dod_repository
+      post 'project/create_dod_repository' => :create_dod_repository, as: 'create_dod_repository'
       post 'project/create_image_repository' => :create_image_repository
 
       # Flags


### PR DESCRIPTION

![image](https://user-images.githubusercontent.com/16052290/49587002-0a9dea80-f963-11e8-89e9-b7e653e5d524.png)

This part was missed in: #6471.

Also add name of project in repositories page title.

TODO (from Add DoD repository):
- Convert create dod repository to `form_for` and use `dod_source_field` partial.

Co-authored-by: @DavidKang 