### PR TITLE
Add project variable to all *_path calls in our breadcrumb partial

### DIFF
--- a/src/api/app/views/webui2/webui/project/_breadcrumb_items.html.haml
+++ b/src/api/app/views/webui2/webui/project/_breadcrumb_items.html.haml
@@ -10,10 +10,10 @@
   - if current_page?(project_show_path(@project))
     %li.breadcrumb-item.active{ 'aria-current' => 'page' }
       Overview
-  - if current_page?(project_requests_path)
+  - if current_page?(project_requests_path(@project))
     %li.breadcrumb-item.active{ 'aria-current' => 'page' }
       Requests
-  - elsif current_page?(project_users_path)
+  - elsif current_page?(project_users_path(@project))
     %li.breadcrumb-item.active{ 'aria-current' => 'page' }
       Users
   - elsif current_page?(project_config_path(@project))

--- a/src/api/app/views/webui2/webui/project/_tabs.html.haml
+++ b/src/api/app/views/webui2/webui/project/_tabs.html.haml
@@ -10,28 +10,28 @@
           = tab_link('Maintained Projects', project_maintained_projects_path)
       - unless project.defines_remote_instance? || project.is_maintenance?
         %li.nav-item
-          = tab_link('Repositories', repositories_path)
+          = tab_link('Repositories', repositories_path(project))
         %li.nav-item
           = tab_link('Monitor', project_monitor_path(project))
       %li.nav-item
-        = tab_link('Requests', project_requests_path)
+        = tab_link('Requests', project_requests_path(project))
       - unless project.defines_remote_instance?
         %li.nav-item
-          = tab_link('Users', project_users_path)
+          = tab_link('Users', project_users_path(project))
       - unless project.defines_remote_instance? || project.is_maintenance?
         %li.nav-item
           = tab_link('Subprojects', project_subprojects_path(project))
         %li.nav-item
-          = tab_link('Project Config', project_config_path)
+          = tab_link('Project Config', project_config_path(project))
       %li.nav-item
         = tab_link('Attributes', index_attribs_path(project))
       %li.nav-item
-        = tab_link('Meta', project_meta_path)
+        = tab_link('Meta', project_meta_path(project))
       - unless project.defines_remote_instance? || project.is_maintenance?
         %li.nav-item
           = tab_link('Status', project_status_path(project))
       %li.nav-item
-        = tab_link('Pulse', project_pulse_path)
+        = tab_link('Pulse', project_pulse_path(project))
     %li.nav-item.dropdown
       %a.nav-link.dropdown-toggle{ href: '#', 'data-toggle': 'dropdown', 'role': 'button', 'aria-expanded': 'false', 'aria-haspopup': 'true' }
       .dropdown-menu.dropdown-menu-right


### PR DESCRIPTION
While working on the bootstrap migration for the status tab I got
routing issues due to missing 'project' parameters.
The reason for that is that we explicitly set the 'project' for
some path helper calls, but not for all.


```ruby
No route matches {:action=>"index", :controller=>"webui/repositories",
 :format=>"html"}, missing required keys: [:project]

  - unless project.defines_remote_instance? || project.is_maintenance?
    %li.nav-item
      = tab_link('Repositories', repositories_path)
    %li.nav-item
      = tab_link('Monitor', project_monitor_path(project))
  %li.nav-item
```
