### PR TITLE
Use badge for group tasks

### DIFF
--- a/src/api/app/views/webui2/webui/user/_info.html.haml
+++ b/src/api/app/views/webui2/webui/user/_info.html.haml
@@ -18,7 +18,11 @@
       Member of the #{'group'.pluralize(groups.size)}
       %ul
         - groups.each do |group|
-          %li= link_to("#{group.title} (#{group.tasks})", group_show_path(group))
+          %li
+            = link_to(group_show_path(group)) do
+              #{group.title}
+              %span.badge.badge-primary
+                #{group.tasks} #{'task'.pluralize(group.tasks)}
 
     - if role_titles.any?
       Has the #{'role'.pluralize(role_titles.size)}


### PR DESCRIPTION
To be consistent with other views

Before:
![before](https://user-images.githubusercontent.com/1102934/49589732-6cae1e00-f96a-11e8-93d8-5d5e03118755.png)

After:
![after](https://user-images.githubusercontent.com/1102934/49589740-70da3b80-f96a-11e8-862a-b96a2454528f.png)



