### PR TITLE
Adjust repositories controller rspec for bootstrap DoD migration

### DIFF
--- a/src/api/spec/controllers/webui/repositories_controller_spec.rb
+++ b/src/api/spec/controllers/webui/repositories_controller_spec.rb
@@ -192,7 +192,8 @@ RSpec.describe Webui::RepositoriesController, vcr: true do
       end
 
       it { expect(assigns(:error)).to start_with('Repository with name') }
-      it { expect(response).to have_http_status(:success) }
+      # FIXME: Remove 'have_http_status(:success)' after old webui got dropped
+      it { expect(response).to have_http_status(:success).or(have_http_status(:redirect)) }
     end
 
     context 'with no valid repository type' do
@@ -204,7 +205,8 @@ RSpec.describe Webui::RepositoriesController, vcr: true do
       end
 
       it { expect(assigns(:error)).to start_with("Couldn't add repository:") }
-      it { expect(response).to have_http_status(:success) }
+      # FIXME: Remove 'have_http_status(:success)' after old webui got dropped
+      it { expect(response).to have_http_status(:success).or(have_http_status(:redirect)) }
     end
 
     context 'with no valid repository Architecture' do
@@ -216,7 +218,8 @@ RSpec.describe Webui::RepositoriesController, vcr: true do
       end
 
       it { expect(assigns(:error)).to start_with("Couldn't add repository:") }
-      it { expect(response).to have_http_status(:success) }
+      # FIXME: Remove 'have_http_status(:success)' after old webui got dropped
+      it { expect(response).to have_http_status(:success).or(have_http_status(:redirect)) }
     end
 
     context 'with valid repository data' do
@@ -228,7 +231,8 @@ RSpec.describe Webui::RepositoriesController, vcr: true do
       end
 
       it { expect(assigns(:error)).to be_nil }
-      it { expect(response).to have_http_status(:success) }
+      # FIXME: Remove 'have_http_status(:success)' after old webui got dropped
+      it { expect(response).to have_http_status(:success).or(have_http_status(:redirect)) }
     end
   end
 


### PR DESCRIPTION
The new bootstrap view redirects the user after a DoD repository
gets created. The test expects a 200 http code instead of a 302.

Related to https://github.com/openSUSE/open-build-service/pull/6489/files

