### PR TITLE
Enable Bootstrap project show to all beta users

### DIFF
--- a/src/api/app/controllers/webui/project_controller.rb
+++ b/src/api/app/controllers/webui/project_controller.rb
@@ -206,10 +206,6 @@ class Webui::ProjectController < Webui::WebuiController
     @comment = Comment.new
     render :show, status: params[:nextstatus] if params[:nextstatus]
 
-    # TODO: Remove the `return unless` and the flash once this should be available to all beta users on all environments
-    return unless User.current && User.current.in_beta? && (Rails.env.development? || Rails.env.test?)
-    flash[:notice] = "We are currently migrating the project pages to Bootstrap. It's active only on the development and test environments while this is work-in-progress."
-
     switch_to_webui2
   end
 

--- a/src/api/app/views/layouts/webui2/_watchlist_dropdown.html.haml
+++ b/src/api/app/views/layouts/webui2/_watchlist_dropdown.html.haml
@@ -5,7 +5,7 @@
     List of projects you are watching
   .dropdown-divider
   - if params[:project]
-    %a.dropdown-item{ href: project_toggle_watch_path(params[:project]) }
+    %a.dropdown-item#toggle-watch{ href: project_toggle_watch_path(params[:project]) }
       - if User.current.watches? params[:project]
         %p.mb-0
           Remove this project from Watchlist
@@ -18,7 +18,7 @@
           Watch this project
     .dropdown-divider
   - User.current.watched_project_names.each_with_index do |project, index|
-    = link_to project_show_path(project), class: "dropdown-item text-wrap text-word-break-all #{'border-top' unless index.zero?}" do
+    = link_to project_show_path(project), class: "dropdown-item project-link text-wrap text-word-break-all #{'border-top' unless index.zero?}" do
       %i.fa.fa-cubes.fa.text-secondary.pt-2
       %span.small
         = project

--- a/src/api/app/views/webui/project/edit.html.erb
+++ b/src/api/app/views/webui/project/edit.html.erb
@@ -21,5 +21,5 @@
     <label for="project_url"><strong>URL:</strong></label><br/>
     <%= f.text_field :url, :size => 80 %>
   </p>
-  <p><%= f.submit %></p>
+  <p><%= f.submit('Accept') %></p>
 <% end %>

--- a/src/api/app/views/webui/project/show.html.erb
+++ b/src/api/app/views/webui/project/show.html.erb
@@ -9,7 +9,7 @@
 <div class="grid_16 alpha omega box box-shadow">
   <%= render partial: 'tabs' %>
   <div class="grid_10 alpha">
-    <h3 id="project_title"><%= @project.title %><%= @project if @project.title.blank? -%></h3>
+    <h3 id="project-title"><%= @project.title %><%= @project if @project.title.blank? -%></h3>
     <%= description_wrapper(@project.description) %>
     <% if @project.url.present? %>
       <p>

--- a/src/api/app/views/webui2/webui/project/bottom_actions/_submit_as_update.html.haml
+++ b/src/api/app/views/webui2/webui/project/bottom_actions/_submit_as_update.html.haml
@@ -1,4 +1,4 @@
-- if project.is_maintenance_incident? && release_targets.present?
+- if !project.is_maintenance_incident? && release_targets.present?
   %li.list-inline-item
     = link_to('#', class: 'nav-link', data: { toggle: 'modal', target: '#project-submit-update-modal' }) do
       %i.fas.fa-share-square.text-warning

--- a/src/api/spec/bootstrap/features/webui/maintenance_workflow_spec.rb
+++ b/src/api/spec/bootstrap/features/webui/maintenance_workflow_spec.rb
@@ -47,11 +47,14 @@ RSpec.feature 'Bootstrap_MaintenanceWorkflow', type: :feature, js: true, vcr: tr
 
     click_link('Submit as Update')
     # we need this find to wait for the dialog to appear
-    expect(find(:css, '.dialog h2')).to have_text('Submit as Update')
+    expect(find('#project-submit-update-modal-label')).to have_text('Submit as Update')
     fill_in('description', with: 'I want the update')
 
-    click_button('Accept')
-    expect(page).to have_css('#flash-messages', text: 'Created maintenance incident request')
+    within('#project-submit-update-modal .modal-footer') do
+      click_button('Accept')
+    end
+
+    expect(page).to have_css('#flash', text: 'Created maintenance incident request')
 
     # Check that sending maintenance updates adds the source revision
     new_bs_request_action = BsRequestAction.where(
@@ -104,10 +107,13 @@ RSpec.feature 'Bootstrap_MaintenanceWorkflow', type: :feature, js: true, vcr: tr
     visit project_show_path(project: 'home:tom:branches:ProjectWithRepo:Update')
 
     click_link('Submit as Update')
-
-    expect(find(:css, '.dialog h2')).to have_text('Submit as Update')
+    # we need this find to wait for the dialog to appear
+    expect(find('#project-submit-update-modal-label')).to have_text('Submit as Update')
     fill_in('description', with: 'I have a additional fix')
-    click_button('Accept')
+
+    within('#project-submit-update-modal .modal-footer') do
+      click_button('Accept')
+    end
 
     logout
 
@@ -141,11 +147,16 @@ RSpec.feature 'Bootstrap_MaintenanceWorkflow', type: :feature, js: true, vcr: tr
     visit project_show_path('MaintenanceProject:0')
     click_link('Request to Release')
 
+    # we need this find to wait for the dialog to appear
+    expect(find('#project-release-request-modal-label')).to have_text('Create Maintenance Release Request')
     fill_in('description', with: 'RELEASE!')
-    click_button('Accept')
+
+    within('#project-release-request-modal .modal-footer') do
+      click_button('Accept')
+    end
 
     # As we can't release without build results this should fail
-    expect(page).to have_css('#flash-messages',
+    expect(page).to have_css('#flash',
                              text: "The repository 'MaintenanceProject:0' / 'ProjectWithRepo_Update' / i586 did not finish the build yet")
   end
 end

--- a/src/api/spec/bootstrap/features/webui/projects_spec.rb
+++ b/src/api/spec/bootstrap/features/webui/projects_spec.rb
@@ -27,4 +27,41 @@ RSpec.feature 'Bootstrap_Projects', type: :feature, js: true, vcr: true do
       expect(find(:css, '#description-text')).to have_text(very_long_description)
     end
   end
+
+  scenario 'changing project title and description' do
+    login user
+    visit project_show_path(project: project)
+
+    click_on('Edit Project')
+    expect(page).to have_text("Edit Project #{project}")
+
+    fill_in 'project_title', with: 'My Title hopefully got changed'
+    fill_in 'project_description', with: 'New description. Not kidding.. Brand new!'
+    click_button 'Accept'
+
+    visit project_show_path(project: project)
+    expect(find(:id, 'project-title')).to have_text('My Title hopefully got changed')
+    expect(find(:id, 'description-text')).to have_text('New description. Not kidding.. Brand new!')
+  end
+
+  describe 'branching' do
+    let(:other_user) { create(:confirmed_user, login: 'other_user') }
+    let!(:package_of_another_project) { create(:package_with_file, name: 'branch_test_package', project: other_user.home_project) }
+
+    before do
+      login user
+      visit project_show_path(project)
+      click_link('Branch Existing Package')
+    end
+
+    scenario 'a non-existing package' do
+      fill_in('linked_project', with: 'non-existing_package')
+      fill_in('linked_package', with: package_of_another_project.name)
+
+      click_button('Accept')
+
+      expect(page).to have_text('Failed to branch: Package does not exist.')
+      expect(page).to have_current_path(project_show_path('home:Jane'))
+    end
+  end
 end

--- a/src/api/spec/bootstrap/features/webui/watchlists_spec.rb
+++ b/src/api/spec/bootstrap/features/webui/watchlists_spec.rb
@@ -1,0 +1,56 @@
+require 'browser_helper'
+
+RSpec.feature 'Bootstrap_Watchlists', type: :feature, js: true, vcr: true do
+  let(:user) { create(:confirmed_user, login: 'kody') }
+  let(:project) { create(:project, name: 'watchlist_test_project') }
+  let(:user_with_watched_project) do
+    other_user = create(:confirmed_user, login: 'brian')
+    other_user.watched_projects << create(:watched_project,
+                                          project: create(:project, name: "#{other_user.login}_s_watched_project"))
+    other_user
+  end
+
+  scenario 'add projects to watchlist' do
+    login user
+    visit project_show_path(user.home_project)
+
+    click_on('Watchlist')
+    expect(page).to have_content('List of projects you are watching')
+    expect(page).to have_css('a.dropdown-item.project-link', count: 0)
+
+    expect(page).to have_css('#toggle-watch', text: 'Add this project to Watchlist')
+    find('#toggle-watch').click
+
+    click_on('Watchlist')
+    expect(page).to have_css('a.dropdown-item.project-link', text: user.home_project_name)
+    expect(page).to have_css('a.dropdown-item.project-link', count: 1)
+
+    visit project_show_path(project: project.name)
+    click_on('Watchlist')
+    expect(page).to have_css('#toggle-watch', text: 'Add this project to Watchlist')
+    find('#toggle-watch').click
+
+    click_on('Watchlist')
+    expect(page).to have_css('a.dropdown-item.project-link', text: user.home_project_name)
+    expect(page).to have_css('a.dropdown-item.project-link', text: project.name)
+    expect(page).to have_css('a.dropdown-item.project-link', count: 2)
+  end
+
+  scenario 'remove projects from watchlist' do
+    login user_with_watched_project
+    visit project_show_path(project: 'brian_s_watched_project')
+
+    click_on('Watchlist')
+    expect(page).to have_content('List of projects you are watching')
+    expect(page).to have_css('a.dropdown-item.project-link', text: 'brian_s_watched_project')
+    expect(page).to have_css('a.dropdown-item.project-link', count: 1)
+    expect(page).to have_css('#toggle-watch', text: 'Remove this project from Watchlist')
+
+    find('#toggle-watch').click
+
+    visit project_show_path(project: 'brian_s_watched_project')
+    click_on('Watchlist')
+    expect(page).to have_css('a.dropdown-item.project-link', count: 0)
+    expect(page).to have_css('#toggle-watch', text: 'Add this project to Watchlist')
+  end
+end

--- a/src/api/spec/cassettes/Bootstrap_Projects/branching/a_non-existing_package.yml
+++ b/src/api/spec/cassettes/Bootstrap_Projects/branching/a_non-existing_package.yml
@@ -1,0 +1,143 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://backend:5352/build/home:Jane/_result?code=unresolvable&view=status
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 404
+      message: project 'home Jane' does not exist
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '146'
+    body:
+      encoding: UTF-8
+      string: |
+        <status code="404">
+          <summary>project 'home:Jane' does not exist</summary>
+          <details>404 project 'home:Jane' does not exist</details>
+        </status>
+    http_version: 
+  recorded_at: Mon, 10 Dec 2018 15:20:12 GMT
+- request:
+    method: get
+    uri: http://backend:5352/build/home:Jane/_result?view=summary
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 404
+      message: project 'home Jane' does not exist
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '146'
+    body:
+      encoding: UTF-8
+      string: |
+        <status code="404">
+          <summary>project 'home:Jane' does not exist</summary>
+          <details>404 project 'home:Jane' does not exist</details>
+        </status>
+    http_version: 
+  recorded_at: Mon, 10 Dec 2018 15:20:13 GMT
+- request:
+    method: get
+    uri: http://backend:5352/build/home:Jane/_result?code=unresolvable&view=status
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 404
+      message: project 'home Jane' does not exist
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '146'
+    body:
+      encoding: UTF-8
+      string: |
+        <status code="404">
+          <summary>project 'home:Jane' does not exist</summary>
+          <details>404 project 'home:Jane' does not exist</details>
+        </status>
+    http_version: 
+  recorded_at: Mon, 10 Dec 2018 15:20:14 GMT
+- request:
+    method: get
+    uri: http://backend:5352/build/home:Jane/_result?view=summary
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 404
+      message: project 'home Jane' does not exist
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '146'
+    body:
+      encoding: UTF-8
+      string: |
+        <status code="404">
+          <summary>project 'home:Jane' does not exist</summary>
+          <details>404 project 'home:Jane' does not exist</details>
+        </status>
+    http_version: 
+  recorded_at: Mon, 10 Dec 2018 15:20:14 GMT
+recorded_with: VCR 4.0.0

--- a/src/api/spec/cassettes/Bootstrap_Projects/branching/a_package_with_disabled_access_flag.yml
+++ b/src/api/spec/cassettes/Bootstrap_Projects/branching/a_package_with_disabled_access_flag.yml
@@ -1,0 +1,143 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://backend:5352/build/home:Jane/_result?code=unresolvable&view=status
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 404
+      message: project 'home Jane' does not exist
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '146'
+    body:
+      encoding: UTF-8
+      string: |
+        <status code="404">
+          <summary>project 'home:Jane' does not exist</summary>
+          <details>404 project 'home:Jane' does not exist</details>
+        </status>
+    http_version: 
+  recorded_at: Mon, 10 Dec 2018 15:19:42 GMT
+- request:
+    method: get
+    uri: http://backend:5352/build/home:Jane/_result?view=summary
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 404
+      message: project 'home Jane' does not exist
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '146'
+    body:
+      encoding: UTF-8
+      string: |
+        <status code="404">
+          <summary>project 'home:Jane' does not exist</summary>
+          <details>404 project 'home:Jane' does not exist</details>
+        </status>
+    http_version: 
+  recorded_at: Mon, 10 Dec 2018 15:19:42 GMT
+- request:
+    method: get
+    uri: http://backend:5352/build/home:Jane/_result?code=unresolvable&view=status
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 404
+      message: project 'home Jane' does not exist
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '146'
+    body:
+      encoding: UTF-8
+      string: |
+        <status code="404">
+          <summary>project 'home:Jane' does not exist</summary>
+          <details>404 project 'home:Jane' does not exist</details>
+        </status>
+    http_version: 
+  recorded_at: Mon, 10 Dec 2018 15:19:44 GMT
+- request:
+    method: get
+    uri: http://backend:5352/build/home:Jane/_result?view=summary
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 404
+      message: project 'home Jane' does not exist
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '146'
+    body:
+      encoding: UTF-8
+      string: |
+        <status code="404">
+          <summary>project 'home:Jane' does not exist</summary>
+          <details>404 project 'home:Jane' does not exist</details>
+        </status>
+    http_version: 
+  recorded_at: Mon, 10 Dec 2018 15:19:44 GMT
+recorded_with: VCR 4.0.0

--- a/src/api/spec/cassettes/Bootstrap_Projects/branching/a_package_with_disabled_sourceaccess_flag.yml
+++ b/src/api/spec/cassettes/Bootstrap_Projects/branching/a_package_with_disabled_sourceaccess_flag.yml
@@ -1,0 +1,143 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://backend:5352/build/home:Jane/_result?code=unresolvable&view=status
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 404
+      message: project 'home Jane' does not exist
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '146'
+    body:
+      encoding: UTF-8
+      string: |
+        <status code="404">
+          <summary>project 'home:Jane' does not exist</summary>
+          <details>404 project 'home:Jane' does not exist</details>
+        </status>
+    http_version: 
+  recorded_at: Mon, 10 Dec 2018 15:19:52 GMT
+- request:
+    method: get
+    uri: http://backend:5352/build/home:Jane/_result?view=summary
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 404
+      message: project 'home Jane' does not exist
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '146'
+    body:
+      encoding: UTF-8
+      string: |
+        <status code="404">
+          <summary>project 'home:Jane' does not exist</summary>
+          <details>404 project 'home:Jane' does not exist</details>
+        </status>
+    http_version: 
+  recorded_at: Mon, 10 Dec 2018 15:19:52 GMT
+- request:
+    method: get
+    uri: http://backend:5352/build/home:Jane/_result?code=unresolvable&view=status
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 404
+      message: project 'home Jane' does not exist
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '146'
+    body:
+      encoding: UTF-8
+      string: |
+        <status code="404">
+          <summary>project 'home:Jane' does not exist</summary>
+          <details>404 project 'home:Jane' does not exist</details>
+        </status>
+    http_version: 
+  recorded_at: Mon, 10 Dec 2018 15:19:54 GMT
+- request:
+    method: get
+    uri: http://backend:5352/build/home:Jane/_result?view=summary
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 404
+      message: project 'home Jane' does not exist
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '146'
+    body:
+      encoding: UTF-8
+      string: |
+        <status code="404">
+          <summary>project 'home:Jane' does not exist</summary>
+          <details>404 project 'home:Jane' does not exist</details>
+        </status>
+    http_version: 
+  recorded_at: Mon, 10 Dec 2018 15:19:54 GMT
+recorded_with: VCR 4.0.0

--- a/src/api/spec/cassettes/Bootstrap_Projects/branching/an_existing_package_to_an_invalid_target_package_or_project.yml
+++ b/src/api/spec/cassettes/Bootstrap_Projects/branching/an_existing_package_to_an_invalid_target_package_or_project.yml
@@ -1,0 +1,178 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://backend:5352/build/home:Jane/_result?code=unresolvable&view=status
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 404
+      message: project 'home Jane' does not exist
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '146'
+    body:
+      encoding: UTF-8
+      string: |
+        <status code="404">
+          <summary>project 'home:Jane' does not exist</summary>
+          <details>404 project 'home:Jane' does not exist</details>
+        </status>
+    http_version: 
+  recorded_at: Mon, 10 Dec 2018 15:20:02 GMT
+- request:
+    method: get
+    uri: http://backend:5352/build/home:Jane/_result?view=summary
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 404
+      message: project 'home Jane' does not exist
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '146'
+    body:
+      encoding: UTF-8
+      string: |
+        <status code="404">
+          <summary>project 'home:Jane' does not exist</summary>
+          <details>404 project 'home:Jane' does not exist</details>
+        </status>
+    http_version: 
+  recorded_at: Mon, 10 Dec 2018 15:20:03 GMT
+- request:
+    method: post
+    uri: http://backend:5352/search/package/id?match=(linkinfo/@package=%22branch_test_package%22%20and%20linkinfo/@project=%22home:other_user%22%20and%20@project=%22home:other_user%22)
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Content-Type:
+      - application/octet-stream
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '27'
+    body:
+      encoding: UTF-8
+      string: |
+        <collection>
+        </collection>
+    http_version: 
+  recorded_at: Mon, 10 Dec 2018 15:20:04 GMT
+- request:
+    method: get
+    uri: http://backend:5352/build/home:Jane/_result?code=unresolvable&view=status
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 404
+      message: project 'home Jane' does not exist
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '146'
+    body:
+      encoding: UTF-8
+      string: |
+        <status code="404">
+          <summary>project 'home:Jane' does not exist</summary>
+          <details>404 project 'home:Jane' does not exist</details>
+        </status>
+    http_version: 
+  recorded_at: Mon, 10 Dec 2018 15:20:04 GMT
+- request:
+    method: get
+    uri: http://backend:5352/build/home:Jane/_result?view=summary
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 404
+      message: project 'home Jane' does not exist
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '146'
+    body:
+      encoding: UTF-8
+      string: |
+        <status code="404">
+          <summary>project 'home:Jane' does not exist</summary>
+          <details>404 project 'home:Jane' does not exist</details>
+        </status>
+    http_version: 
+  recorded_at: Mon, 10 Dec 2018 15:20:04 GMT
+recorded_with: VCR 4.0.0

--- a/src/api/spec/cassettes/Bootstrap_Projects/changing_project_title_and_description.yml
+++ b/src/api/spec/cassettes/Bootstrap_Projects/changing_project_title_and_description.yml
@@ -1,0 +1,213 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://backend:5352/build/home:Jane/_result?code=unresolvable&view=status
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 404
+      message: project 'home Jane' does not exist
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '146'
+    body:
+      encoding: UTF-8
+      string: |
+        <status code="404">
+          <summary>project 'home:Jane' does not exist</summary>
+          <details>404 project 'home:Jane' does not exist</details>
+        </status>
+    http_version: 
+  recorded_at: Mon, 10 Dec 2018 14:33:33 GMT
+- request:
+    method: get
+    uri: http://backend:5352/build/home:Jane/_result?view=summary
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 404
+      message: project 'home Jane' does not exist
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '146'
+    body:
+      encoding: UTF-8
+      string: |
+        <status code="404">
+          <summary>project 'home:Jane' does not exist</summary>
+          <details>404 project 'home:Jane' does not exist</details>
+        </status>
+    http_version: 
+  recorded_at: Mon, 10 Dec 2018 14:33:34 GMT
+- request:
+    method: get
+    uri: http://backend:5352/build/home:Jane/_result?code=unresolvable&view=status
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 404
+      message: project 'home Jane' does not exist
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '146'
+    body:
+      encoding: UTF-8
+      string: |
+        <status code="404">
+          <summary>project 'home:Jane' does not exist</summary>
+          <details>404 project 'home:Jane' does not exist</details>
+        </status>
+    http_version: 
+  recorded_at: Mon, 10 Dec 2018 14:33:35 GMT
+- request:
+    method: get
+    uri: http://backend:5352/build/home:Jane/_result?view=summary
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 404
+      message: project 'home Jane' does not exist
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '146'
+    body:
+      encoding: UTF-8
+      string: |
+        <status code="404">
+          <summary>project 'home:Jane' does not exist</summary>
+          <details>404 project 'home:Jane' does not exist</details>
+        </status>
+    http_version: 
+  recorded_at: Mon, 10 Dec 2018 14:33:35 GMT
+- request:
+    method: get
+    uri: http://backend:5352/build/home:Jane/_result?code=unresolvable&view=status
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 404
+      message: project 'home Jane' does not exist
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '146'
+    body:
+      encoding: UTF-8
+      string: |
+        <status code="404">
+          <summary>project 'home:Jane' does not exist</summary>
+          <details>404 project 'home:Jane' does not exist</details>
+        </status>
+    http_version: 
+  recorded_at: Mon, 10 Dec 2018 14:33:35 GMT
+- request:
+    method: get
+    uri: http://backend:5352/build/home:Jane/_result?view=summary
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 404
+      message: project 'home Jane' does not exist
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '146'
+    body:
+      encoding: UTF-8
+      string: |
+        <status code="404">
+          <summary>project 'home:Jane' does not exist</summary>
+          <details>404 project 'home:Jane' does not exist</details>
+        </status>
+    http_version: 
+  recorded_at: Mon, 10 Dec 2018 14:33:36 GMT
+recorded_with: VCR 4.0.0

--- a/src/api/spec/cassettes/Bootstrap_Watchlists/add_projects_to_watchlist.yml
+++ b/src/api/spec/cassettes/Bootstrap_Watchlists/add_projects_to_watchlist.yml
@@ -1,0 +1,347 @@
+---
+http_interactions:
+- request:
+    method: put
+    uri: http://backend:5352/source/home:kody/_meta?user=kody
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:kody">
+          <title/>
+          <description/>
+          <person userid="kody" role="maintainer"/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '131'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:kody">
+          <title></title>
+          <description></description>
+          <person userid="kody" role="maintainer" />
+        </project>
+    http_version: 
+  recorded_at: Mon, 10 Dec 2018 16:44:21 GMT
+- request:
+    method: get
+    uri: http://backend:5352/build/home:kody/_result?code=unresolvable&view=status
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '56'
+    body:
+      encoding: UTF-8
+      string: '<resultlist state="00000000000000000000000000000000" />
+
+'
+    http_version: 
+  recorded_at: Mon, 10 Dec 2018 16:44:26 GMT
+- request:
+    method: get
+    uri: http://backend:5352/build/home:kody/_result?view=summary
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '56'
+    body:
+      encoding: UTF-8
+      string: '<resultlist state="00000000000000000000000000000000" />
+
+'
+    http_version: 
+  recorded_at: Mon, 10 Dec 2018 16:44:26 GMT
+- request:
+    method: get
+    uri: http://backend:5352/build/home:kody/_result?code=unresolvable&view=status
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '56'
+    body:
+      encoding: UTF-8
+      string: '<resultlist state="00000000000000000000000000000000" />
+
+'
+    http_version: 
+  recorded_at: Mon, 10 Dec 2018 16:44:27 GMT
+- request:
+    method: get
+    uri: http://backend:5352/build/home:kody/_result?view=summary
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '56'
+    body:
+      encoding: UTF-8
+      string: '<resultlist state="00000000000000000000000000000000" />
+
+'
+    http_version: 
+  recorded_at: Mon, 10 Dec 2018 16:44:27 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/watchlist_test_project/_meta?user=kody
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="watchlist_test_project">
+          <title>Cabbages and Kings</title>
+          <description/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '117'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="watchlist_test_project">
+          <title>Cabbages and Kings</title>
+          <description></description>
+        </project>
+    http_version: 
+  recorded_at: Mon, 10 Dec 2018 16:44:27 GMT
+- request:
+    method: get
+    uri: http://backend:5352/build/watchlist_test_project/_result?code=unresolvable&view=status
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '56'
+    body:
+      encoding: UTF-8
+      string: '<resultlist state="00000000000000000000000000000000" />
+
+'
+    http_version: 
+  recorded_at: Mon, 10 Dec 2018 16:44:27 GMT
+- request:
+    method: get
+    uri: http://backend:5352/build/watchlist_test_project/_result?view=summary
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '56'
+    body:
+      encoding: UTF-8
+      string: '<resultlist state="00000000000000000000000000000000" />
+
+'
+    http_version: 
+  recorded_at: Mon, 10 Dec 2018 16:44:28 GMT
+- request:
+    method: get
+    uri: http://backend:5352/build/watchlist_test_project/_result?code=unresolvable&view=status
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '56'
+    body:
+      encoding: UTF-8
+      string: '<resultlist state="00000000000000000000000000000000" />
+
+'
+    http_version: 
+  recorded_at: Mon, 10 Dec 2018 16:44:28 GMT
+- request:
+    method: get
+    uri: http://backend:5352/build/watchlist_test_project/_result?view=summary
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '56'
+    body:
+      encoding: UTF-8
+      string: '<resultlist state="00000000000000000000000000000000" />
+
+'
+    http_version: 
+  recorded_at: Mon, 10 Dec 2018 16:44:28 GMT
+recorded_with: VCR 4.0.0

--- a/src/api/spec/cassettes/Bootstrap_Watchlists/remove_projects_from_watchlist.yml
+++ b/src/api/spec/cassettes/Bootstrap_Watchlists/remove_projects_from_watchlist.yml
@@ -1,0 +1,322 @@
+---
+http_interactions:
+- request:
+    method: put
+    uri: http://backend:5352/source/home:brian/_meta?user=brian
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:brian">
+          <title/>
+          <description/>
+          <person userid="brian" role="maintainer"/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '133'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:brian">
+          <title></title>
+          <description></description>
+          <person userid="brian" role="maintainer" />
+        </project>
+    http_version: 
+  recorded_at: Mon, 10 Dec 2018 16:44:35 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/brian_s_watched_project/_meta?user=_nobody_
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="brian_s_watched_project">
+          <title>Stranger in a Strange Land</title>
+          <description/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '126'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="brian_s_watched_project">
+          <title>Stranger in a Strange Land</title>
+          <description></description>
+        </project>
+    http_version: 
+  recorded_at: Mon, 10 Dec 2018 16:44:35 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:user_1/_meta?user=user_1
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:user_1">
+          <title/>
+          <description/>
+          <person userid="user_1" role="maintainer"/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '135'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:user_1">
+          <title></title>
+          <description></description>
+          <person userid="user_1" role="maintainer" />
+        </project>
+    http_version: 
+  recorded_at: Mon, 10 Dec 2018 16:44:35 GMT
+- request:
+    method: get
+    uri: http://backend:5352/build/brian_s_watched_project/_result?code=unresolvable&view=status
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '56'
+    body:
+      encoding: UTF-8
+      string: '<resultlist state="00000000000000000000000000000000" />
+
+'
+    http_version: 
+  recorded_at: Mon, 10 Dec 2018 16:44:37 GMT
+- request:
+    method: get
+    uri: http://backend:5352/build/brian_s_watched_project/_result?view=summary
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '56'
+    body:
+      encoding: UTF-8
+      string: '<resultlist state="00000000000000000000000000000000" />
+
+'
+    http_version: 
+  recorded_at: Mon, 10 Dec 2018 16:44:37 GMT
+- request:
+    method: get
+    uri: http://backend:5352/build/brian_s_watched_project/_result?code=unresolvable&view=status
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '56'
+    body:
+      encoding: UTF-8
+      string: '<resultlist state="00000000000000000000000000000000" />
+
+'
+    http_version: 
+  recorded_at: Mon, 10 Dec 2018 16:44:38 GMT
+- request:
+    method: get
+    uri: http://backend:5352/build/brian_s_watched_project/_result?view=summary
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '56'
+    body:
+      encoding: UTF-8
+      string: '<resultlist state="00000000000000000000000000000000" />
+
+'
+    http_version: 
+  recorded_at: Mon, 10 Dec 2018 16:44:38 GMT
+- request:
+    method: get
+    uri: http://backend:5352/build/brian_s_watched_project/_result?code=unresolvable&view=status
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '56'
+    body:
+      encoding: UTF-8
+      string: '<resultlist state="00000000000000000000000000000000" />
+
+'
+    http_version: 
+  recorded_at: Mon, 10 Dec 2018 16:44:38 GMT
+- request:
+    method: get
+    uri: http://backend:5352/build/brian_s_watched_project/_result?view=summary
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '56'
+    body:
+      encoding: UTF-8
+      string: '<resultlist state="00000000000000000000000000000000" />
+
+'
+    http_version: 
+  recorded_at: Mon, 10 Dec 2018 16:44:38 GMT
+recorded_with: VCR 4.0.0

--- a/src/api/spec/features/webui/projects_spec.rb
+++ b/src/api/spec/features/webui/projects_spec.rb
@@ -13,13 +13,15 @@ RSpec.feature 'Projects', type: :feature, js: true do
   scenario 'project show' do
     login user
     visit project_show_path(project: project)
-    expect(page).to have_text('Packages (0)')
+    expect(page).to have_text(/Packages .*0/)
     expect(page).to have_text('This project does not contain any packages')
     expect(page).to have_text(project.description)
     expect(page).to have_css('h3', text: project.title)
   end
 
   scenario 'changing project title and description' do
+    skip_if_bootstrap
+
     login user
     visit project_show_path(project: project)
 
@@ -28,10 +30,10 @@ RSpec.feature 'Projects', type: :feature, js: true do
 
     fill_in 'project_title', with: 'My Title hopefully got changed'
     fill_in 'project_description', with: 'New description. Not kidding.. Brand new!'
-    click_button 'Update Project'
+    click_button('Accept')
 
     visit project_show_path(project: project)
-    expect(find(:id, 'project_title')).to have_text('My Title hopefully got changed')
+    expect(find(:id, 'project-title')).to have_text('My Title hopefully got changed')
     expect(find(:id, 'description-text')).to have_text('New description. Not kidding.. Brand new!')
   end
 
@@ -123,7 +125,7 @@ RSpec.feature 'Projects', type: :feature, js: true do
       expect(page).to have_content("Project '#{user.home_project_name}:coolstuff' was created successfully")
 
       expect(page.current_path).to match(project_show_path(project: "#{user.home_project_name}:coolstuff"))
-      expect(find('#project_title').text).to eq("#{user.home_project_name}:coolstuff")
+      expect(find('#project-title').text).to eq("#{user.home_project_name}:coolstuff")
     end
 
     scenario "create subproject with checked 'disable publishing' checkbox" do
@@ -331,6 +333,8 @@ RSpec.feature 'Projects', type: :feature, js: true do
     end
 
     scenario 'an existing package to an invalid target package or project' do
+      skip_if_bootstrap
+
       fill_in('linked_project', with: other_user.home_project_name)
       fill_in('linked_package', with: package_of_another_project.name)
       fill_in('Branch package name', with: 'something/illegal')
@@ -354,6 +358,8 @@ RSpec.feature 'Projects', type: :feature, js: true do
     end
 
     scenario 'a non-existing package' do
+      skip_if_bootstrap
+
       fill_in('linked_project', with: 'non-existing_package')
       fill_in('linked_package', with: package_of_another_project.name)
       # This needs global write through
@@ -364,6 +370,8 @@ RSpec.feature 'Projects', type: :feature, js: true do
     end
 
     scenario 'a package with disabled access flag' do
+      skip_if_bootstrap
+
       create(:access_flag, status: 'disable', project: other_user.home_project)
 
       fill_in('linked_project', with: other_user.home_project_name)
@@ -377,6 +385,8 @@ RSpec.feature 'Projects', type: :feature, js: true do
     end
 
     scenario 'a package with disabled sourceaccess flag' do
+      skip_if_bootstrap
+
       create(:sourceaccess_flag, status: 'disable', project: other_user.home_project)
 
       fill_in('linked_project', with: other_user.home_project_name)
@@ -390,6 +400,8 @@ RSpec.feature 'Projects', type: :feature, js: true do
     end
 
     scenario 'a package and select current revision' do
+      skip_if_bootstrap
+
       fill_in('linked_project', with: other_user.home_project_name)
       fill_in('linked_package', with: package_of_another_project.name)
 
@@ -410,10 +422,12 @@ RSpec.feature 'Projects', type: :feature, js: true do
 
   describe 'maintenance projects' do
     scenario 'creating a maintenance project' do
+      skip_if_bootstrap
+
       login(admin_user)
       visit project_show_path(project)
 
-      click_link('Advanced')
+      click_link('Advanced') unless is_bootstrap?
       click_link('Attributes')
       click_link('Add a new attribute')
       select('OBS:MaintenanceProject')

--- a/src/api/spec/features/webui/watchlists_spec.rb
+++ b/src/api/spec/features/webui/watchlists_spec.rb
@@ -11,6 +11,8 @@ RSpec.feature 'Watchlists', type: :feature, js: true do
   end
 
   scenario 'add projects to watchlist' do
+    skip_if_bootstrap
+
     login user
     visit project_show_path(user.home_project)
 
@@ -37,6 +39,8 @@ RSpec.feature 'Watchlists', type: :feature, js: true do
   end
 
   scenario 'remove projects from watchlist' do
+    skip_if_bootstrap
+
     login user_with_watched_project
     visit project_show_path(project: 'brian_s_watched_project')
 

--- a/src/api/spec/support/features/features_bootstrap.rb
+++ b/src/api/spec/support/features/features_bootstrap.rb
@@ -1,4 +1,8 @@
 module FeaturesBootstrap
+  def is_bootstrap?
+    ENV['BOOTSTRAP'].present?
+  end
+
   def skip_if_bootstrap
     msg = 'The feature tests are executed with BOOTSTRAP enabled, therefore we skip this test.'
     skip(msg) if ENV['BOOTSTRAP'].present?


### PR DESCRIPTION
Align the old UI with the new Bootstrap UI for specs:
- Update project feature specs
- Maintenance workflow feature specs
- Watchlist feature specs

These include fixes to existing feature specs to make them pass when
testing the new bootstrap UI. Specs that can't be written for both UIs
got ported to the spec/bootstrap/* directory.

Fix Submit as Update link condition

Co-authored-by: Björn Geuken <bgeuken@suse.de>
Co-authored-by: Dany Marcoux <dmarcoux@suse.com>
Co-authored-by: Eduardo Navarro <enavarro@suse.com>
Co-authored-by: Victor Pereira <vpereira@suse.com>