### PR TITLE
Fix lookup issue due to conflicting namespaces

### DIFF
--- a/src/api/app/controllers/webui/package_controller.rb
+++ b/src/api/app/controllers/webui/package_controller.rb
@@ -314,7 +314,7 @@ class Webui::PackageController < Webui::WebuiController
       flash[:error] = "Unable to diff sources: #{e.message}"
     rescue BsRequestAction::MissingAction => e
       flash[:error] = 'Unable to submit, sources are unchanged'
-    rescue Project::UnknownObjectError,
+    rescue ::Project::UnknownObjectError,
            BsRequestAction::UnknownProject,
            BsRequestAction::UnknownTargetPackage => e
       redirect_back(fallback_location: root_path, error: "Unable to submit (missing target): #{e.message}")
@@ -465,7 +465,7 @@ class Webui::PackageController < Webui::WebuiController
     @last_rev = @package.dir_hash['rev']
     @linkinfo = @package.linkinfo
     if params[:oproject]
-      @oproject = Project.find_by_name(params[:oproject])
+      @oproject = ::Project.find_by_name(params[:oproject])
       @opackage = @oproject.find_package(params[:opackage]) if @oproject && params[:opackage]
     end
 
@@ -1128,8 +1128,8 @@ class Webui::PackageController < Webui::WebuiController
   #
   # If the check succeeds it sets @project and @package variables.
   def check_build_log_access
-    if Project.exists_by_name(params[:project])
-      @project = Project.get_by_name(params[:project])
+    if ::Project.exists_by_name(params[:project])
+      @project = ::Project.get_by_name(params[:project])
     else
       redirect_to root_path, error: "Couldn't find project '#{params[:project]}'. Are you sure it still exists?"
       return false

--- a/src/api/app/controllers/webui/webui_controller.rb
+++ b/src/api/app/controllers/webui/webui_controller.rb
@@ -73,7 +73,7 @@ class Webui::WebuiController < ActionController::Base
 
   def set_project
     # We've started to use project_name for new routes...
-    @project = Project.find_by(name: params[:project_name] || params[:project])
+    @project = ::Project.find_by(name: params[:project_name] || params[:project])
     raise ActiveRecord::RecordNotFound unless @project
   end
 


### PR DESCRIPTION
The Rails lookup code otherwise has trouble to identify which
'Project' class or module is meant.

I started to get this error when accessing one of the project
pages (in development mode):

  "undefined method `find_by' for Webui::Project:Module"

