### PR TITLE
Render project_packages modals in the right location

### DIFF
--- a/src/api/app/views/webui2/webui/project/_project_packages.html.haml
+++ b/src/api/app/views/webui2/webui/project/_project_packages.html.haml
@@ -28,6 +28,3 @@
             = link_to('#', class: 'nav-link', data: { toggle: 'modal', target: '#new-package-branch-modal' }) do
               %i.fas.fa-code-branch.text-primary
               Branch Existing Package
-
-      = render partial: 'new_package_modal', locals: { project: project }
-      = render partial: 'new_package_branch_modal', locals: { project: project, remote_projects: remote_projects }

--- a/src/api/app/views/webui2/webui/project/show.html.haml
+++ b/src/api/app/views/webui2/webui/project/show.html.haml
@@ -56,7 +56,7 @@
                   = @ipackages.length
       .tab-content#packages-tabs-content
         .tab-pane.fade.show.active#packages{ role: 'tabpanel', aria: { labelledby: 'packages-tab' } }
-          = render partial: 'project_packages', locals: { project: @project, packages: @packages, remote_projects: @remote_projects }
+          = render partial: 'project_packages', locals: { project: @project, packages: @packages }
         .tab-pane.fade#inherited-packages{ role: 'tabpanel', aria: { labelledby: 'inherited-packages-tab' } }
           = render partial: 'project_inherited_packages', locals: { inherited_packages: @ipackages }
   .comments
@@ -72,6 +72,10 @@
   - elsif User.current.can_modify?(@project)
     = render partial: 'edit_project_dialog', locals: { project: @project }
     = render partial: 'delete_project_dialog', locals: { project: @project }
+
+    - if show_package_actions?
+      = render partial: 'new_package_modal', locals: { project: @project }
+      = render partial: 'new_package_branch_modal', locals: { project: @project, remote_projects: @remote_projects }
 
     - if !@project.defines_remote_instance? && @project.is_maintenance_incident? && @packages.present? && @has_patchinfo
       && @open_release_requests.blank?


### PR DESCRIPTION
This fixes the color of the headers from green to black, so it's now consistent with other modals

Before:
![before-1](https://user-images.githubusercontent.com/1102934/49644225-24e5d000-fa18-11e8-93e2-80a9a5b170ee.png)
![before-2](https://user-images.githubusercontent.com/1102934/49644234-2911ed80-fa18-11e8-8a06-d3f92bec5e95.png)

After:
![after-1](https://user-images.githubusercontent.com/1102934/49644238-2dd6a180-fa18-11e8-97d9-517d5551088d.png)
![after-2](https://user-images.githubusercontent.com/1102934/49644242-2fa06500-fa18-11e8-9def-d2ddcff0482d.png)



