### PR TITLE
Align links with users/groups page with other pages to be consistent

### DIFF
--- a/src/api/app/views/webui2/shared/user_or_groups_roles/_index.html.haml
+++ b/src/api/app/views/webui2/shared/user_or_groups_roles/_index.html.haml
@@ -30,9 +30,9 @@
 
   - if user_is_maintainer
     = render(partial: 'webui2/shared/user_or_groups_roles/add_user_dialog', locals: { project: project.to_param, package: package.to_param })
-    = link_to('#', data: { toggle: 'modal', target: '#add-user-role-modal' }, id: 'add-user') do
+    = link_to('#', data: { toggle: 'modal', target: '#add-user-role-modal' }, id: 'add-user', class: 'nav-link') do
       %i.fas.fa-plus-circle.text-primary
-      Add user
+      Add User
 
   %hr
 
@@ -53,9 +53,9 @@
                            project: project, package: package }
   - if user_is_maintainer
     = render(partial: 'webui2/shared/user_or_groups_roles/add_group_dialog', locals: { project: project.to_param, package: package.to_param })
-    = link_to('#', data: { toggle: 'modal', target: '#add-group-role-modal' }, id: 'add-user') do
+    = link_to('#', data: { toggle: 'modal', target: '#add-group-role-modal' }, id: 'add-group', class: 'nav-link') do
       %i.fas.fa-plus-circle.text-primary
-      Add group
+      Add Group
 :javascript
   setDataTableForUsersAndGroups();
 - if user_is_maintainer

--- a/src/api/spec/support/shared_examples/features/bootstrap_user_tab.rb
+++ b/src/api/spec/support/shared_examples/features/bootstrap_user_tab.rb
@@ -39,7 +39,7 @@ RSpec.shared_examples 'bootstrap user tab' do
     end
 
     scenario 'Add non existent user' do
-      click_link('Add user')
+      click_link('Add User')
       sleep 1 # FIXME: Needed to avoid a flickering test because the animation of the modal is sometimes faster than capybara
 
       within('#add-user-role-modal') do
@@ -51,7 +51,7 @@ RSpec.shared_examples 'bootstrap user tab' do
     end
 
     scenario 'Add an existing user' do
-      click_link('Add user')
+      click_link('Add User')
       sleep 1 # FIXME: Needed to avoid a flickering test because the animation of the modal is sometimes faster than capybara
 
       within('#add-user-role-modal') do
@@ -67,7 +67,7 @@ RSpec.shared_examples 'bootstrap user tab' do
       end
 
       # Adding a user twice...
-      click_link('Add user')
+      click_link('Add User')
       sleep 1 # FIXME: Needed to avoid a flickering test because the animation of the modal is sometimes faster than capybara
 
       within('#add-user-role-modal') do
@@ -146,7 +146,7 @@ RSpec.shared_examples 'bootstrap user tab' do
     end
 
     scenario 'Add non existent group' do
-      click_link('Add group')
+      click_link('Add Group')
       sleep 1 # FIXME: Needed to avoid a flickering test because the animation of the modal is sometimes faster than capybara
 
       within('#add-group-role-modal') do
@@ -158,7 +158,7 @@ RSpec.shared_examples 'bootstrap user tab' do
     end
 
     scenario 'Add an existing group' do
-      click_link('Add group')
+      click_link('Add Group')
       sleep 1 # FIXME: Needed to avoid a flickering test because the animation of the modal is sometimes faster than capybara
 
       within('#add-group-role-modal') do
@@ -173,7 +173,7 @@ RSpec.shared_examples 'bootstrap user tab' do
       end
 
       # Adding a group twice...
-      click_link('Add group')
+      click_link('Add Group')
       sleep 1 # FIXME: Needed to avoid a flickering test because the animation of the modal is sometimes faster than capybara
 
       within('#add-group-role-modal') do


### PR DESCRIPTION
- Use nav-link classes for users/groups page
- Use the correct ID for 'Add Group' link
- Capitalize users/groups links correctly

Before:
![before-links](https://user-images.githubusercontent.com/1102934/49645175-2369d700-fa1b-11e8-93c5-a2c9d654a0c8.png)

After:
![after-links](https://user-images.githubusercontent.com/1102934/49645187-341a4d00-fa1b-11e8-8835-200319ca70e7.png)