### PR TITLE
Set stricter CSS rule for modal header

### DIFF
--- a/src/api/app/assets/stylesheets/webui2/modals.scss
+++ b/src/api/app/assets/stylesheets/webui2/modals.scss
@@ -1,4 +1,4 @@
-.modal h5 {
+.modal .modal-header h5 {
     color: $body-color;
     overflow-x: hidden;
     overflow-wrap: break-word;


### PR DESCRIPTION
It was in some cases overridden by another rule `.card .card-body h5` which then turned the modal header from black to green. This happened when the modal is rendered inside a `div` with the `card` class

