### PR TITLE
Fix autocomplete in group members' Add User modal

### DIFF
--- a/src/api/app/views/webui2/webui/groups/_add_user_modal.html.haml
+++ b/src/api/app/views/webui2/webui/groups/_add_user_modal.html.haml
@@ -11,7 +11,7 @@
                 %span.input-group-text#add-user-search-icon
                   %i.fa.fa-search
                   %i.fas.fa-spinner.fa-spin.d-none
-                = text_field_tag 'group[userid]', '', required: true, placeholder: 'Type to autocomplete...', class: 'form-control'
+              = text_field_tag 'group[userid]', '', required: true, placeholder: 'Type to autocomplete...', class: 'form-control'
         .modal-footer
           = render partial: 'webui2/shared/dialog_action_buttons'
 


### PR DESCRIPTION
Before:
![before-modal](https://user-images.githubusercontent.com/1102934/49646154-8e68dd00-fa1e-11e8-9cd1-a19ef8bf267e.png)

After:
![after-modal](https://user-images.githubusercontent.com/1102934/49646165-91fc6400-fa1e-11e8-8924-e1a6513e8885.png)