### PR TITLE
Update breadcrumb

### DIFF
--- a/src/api/app/helpers/webui/webui_helper.rb
+++ b/src/api/app/helpers/webui/webui_helper.rb
@@ -159,6 +159,14 @@ module Webui::WebuiHelper
     content_tag('li', link_to(h(text), opts), link_opts)
   end
 
+  def active_breadcrumb_label
+    if controller_name == 'project'
+      project_breadcrumb_label
+    elsif controller_name == 'package'
+      package_breadcrumb_label
+    end
+  end
+
   # Shortens a text if it longer than 'length'.
   def elide(text, length = 20, mode = :middle)
     shortened_text = text.to_s # make sure it's a String
@@ -405,6 +413,32 @@ module Webui::WebuiHelper
     html_class << ' active' if request.path.include?(path)
 
     link_to(label, path, class: html_class)
+  end
+
+  private
+
+  def project_breadcrumb_label
+    case action_name
+    when 'prjconf'
+      'Project Config'
+    when 'show'
+      'Overview'
+    else
+      action_name.humanize
+    end
+  end
+
+  def package_breadcrumb_label
+    case action_name
+    when 'show'
+      'Overview'
+    when 'binaries'
+      'Repository State'
+    when 'live_build_log'
+      'Build Log'
+    else
+      action_name.humanize
+    end
   end
 end
 # rubocop:enable Metrics/ModuleLength

--- a/src/api/app/views/webui2/webui/attribute/_breadcrumb_items.html.haml
+++ b/src/api/app/views/webui2/webui/attribute/_breadcrumb_items.html.haml
@@ -1,6 +1,6 @@
 = render partial: "webui/#{@container.model_name.singular}/breadcrumb_items"
 
-- if current_page?(index_attribs_path)
+- if action_name == 'index'
   %li.breadcrumb-item.active{ 'aria-current' => 'page' }
     Attributes
 - else

--- a/src/api/app/views/webui2/webui/groups/_breadcrumb_items.html.haml
+++ b/src/api/app/views/webui2/webui/groups/_breadcrumb_items.html.haml
@@ -1,7 +1,7 @@
 = render partial: 'webui/main/breadcrumb_items'
 %li.breadcrumb-item
   = link_to 'Groups', groups_path
-- if current_page?(group_show_path)
+- if action_name == 'show'
   %li.breadcrumb-item.active{ 'aria-current' => 'page' }
     = @group
 - else

--- a/src/api/app/views/webui2/webui/main/_breadcrumb_items.html.haml
+++ b/src/api/app/views/webui2/webui/main/_breadcrumb_items.html.haml
@@ -1,5 +1,5 @@
 - home_title = @configuration ? @configuration['title'] : 'Open Build Service'
-- if current_page?(root_path)
+- if controller_name == 'main'
   %li.breadcrumb-item.active{ 'aria-current' => 'page' }
     %i.fas.fa-home.mr-1
     = home_title

--- a/src/api/app/views/webui2/webui/package/_breadcrumb_items.html.haml
+++ b/src/api/app/views/webui2/webui/package/_breadcrumb_items.html.haml
@@ -1,35 +1,14 @@
 = render partial: 'webui/project/breadcrumb_items'
 %li.breadcrumb-item
   = link_to @package, package_show_path(@project, @package)
-- if current_page?(package_add_file_path)
+- if action_name == 'view_file'
   %li.breadcrumb-item.active{ 'aria-current' => 'page' }
-    Add File
-- if current_page?(package_view_revisions_path)
-  %li.breadcrumb-item.active{ 'aria-current' => 'page' }
-    Revisions
-- if current_page?(package_requests_path)
-  %li.breadcrumb-item.active{ 'aria-current' => 'page' }
-    Requests
-- if current_page?(package_users_path)
-  %li.breadcrumb-item.active{ 'aria-current' => 'page' }
-    Users
-- if controller_name == 'package' && action_name == 'binaries'
-  %li.breadcrumb-item.active{ 'aria-current' => 'page' }
-    Repository State
-- if controller_name == 'package' && action_name == 'binary'
-  %li.breadcrumb-item.active{ 'aria-current' => 'page' }
-    Binary
-- if current_page?(package_show_path)
-  %li.breadcrumb-item.active{ 'aria-current' => 'page' }
-    Overview
-- if controller_name == 'package' && action_name == 'live_build_log'
-  %li.breadcrumb-item.active{ 'aria-current' => 'page' }
-    Build Log
-- if controller_name == 'package' && action_name == 'statistics'
+    = @filename
+- elsif controller_name == 'package' && action_name == 'statistics'
   %li.breadcrumb-item
     = link_to 'Repository State', package_binaries_path(@project, @package_name, @repository)
   %li.breadcrumb-item.active{ 'aria-current' => 'page' }
     Statistics
-- if current_page?(package_view_file_path)
+- else
   %li.breadcrumb-item.active{ 'aria-current' => 'page' }
-    = @filename
+    = active_breadcrumb_label

--- a/src/api/app/views/webui2/webui/project/_breadcrumb_items.html.haml
+++ b/src/api/app/views/webui2/webui/project/_breadcrumb_items.html.haml
@@ -1,5 +1,5 @@
 = render partial: 'webui/main/breadcrumb_items'
-- if current_page?(projects_path)
+- if controller_name == 'project' && action_name == 'index'
   %li.breadcrumb-item.active{ 'aria-current' => 'page' }
     Projects
 - else

--- a/src/api/app/views/webui2/webui/project/_breadcrumb_items.html.haml
+++ b/src/api/app/views/webui2/webui/project/_breadcrumb_items.html.haml
@@ -7,21 +7,7 @@
     = link_to 'Projects', projects_path
   %li.breadcrumb-item
     = link_to @project, project_show_path(@project)
-  - if current_page?(project_show_path(@project))
+  // This partial is re-used by breadcrumb partials of other controllers
+  - if controller_name == 'project'
     %li.breadcrumb-item.active{ 'aria-current' => 'page' }
-      Overview
-  - elsif current_page?(project_monitor_path(@project))
-    %li.breadcrumb-item.active{ 'aria-current' => 'page' }
-      Monitor
-  - elsif current_page?(project_requests_path(@project))
-    %li.breadcrumb-item.active{ 'aria-current' => 'page' }
-      Requests
-  - elsif current_page?(project_users_path(@project))
-    %li.breadcrumb-item.active{ 'aria-current' => 'page' }
-      Users
-  - elsif current_page?(project_config_path(@project))
-    %li.breadcrumb-item.active{ 'aria-current' => 'page' }
-      Configuration
-  - elsif current_page?(project_status_path(@project))
-    %li.breadcrumb-item.active{ 'aria-current' => 'page' }
-      Status
+      = active_breadcrumb_label

--- a/src/api/app/views/webui2/webui/repositories/_breadcrumb_items.html.haml
+++ b/src/api/app/views/webui2/webui/repositories/_breadcrumb_items.html.haml
@@ -3,15 +3,15 @@
 - else
   = render partial: 'webui/project/breadcrumb_items'
 
-- if current_page?(repositories_path)
+- if action_name == 'index'
   %li.breadcrumb-item.active{ 'aria-current' => 'page' }
     Repositories
 - else
   %li.breadcrumb-item
     = link_to 'Repositories', repositories_path
   %li.breadcrumb-item.active{ 'aria-current' => 'page' }
-    - if defined?(@repository) && current_page?(project_repository_state_path)
+    - if action_name == 'state'
       Repository State
-    - elsif current_page?(repositories_distributions_path)
+    - elsif action_name == 'distributions'
       Add from a Distribution
 

--- a/src/api/app/views/webui2/webui/users/subscriptions/_breadcrumb_items.html.haml
+++ b/src/api/app/views/webui2/webui/users/subscriptions/_breadcrumb_items.html.haml
@@ -1,4 +1,4 @@
 = render partial: 'webui/main/breadcrumb_items'
-- if current_page?(user_notifications_path)
+- if action_name == 'index'
   %li.breadcrumb-item.active{ 'aria-current' => 'page' }
     Notifications


### PR DESCRIPTION
Evaluate the label for the active breadcrumb in a helper to reduce
repetitive view code.

Advantages

  * No more overhead by using Rails path helpers
  * One place where we set the label for the active breadcrumb
  * More generic code, which means we only have to explicitly set the
    breadcrumb label for some edge cases.


