### PR TITLE
[backend] add project wide jobhistory query and add an endtime filter

### DIFF
--- a/src/backend/BSXML.pm
+++ b/src/backend/BSXML.pm
@@ -941,6 +941,8 @@ our $jobhistlay = [
 
 our $jobhist = [
     'jobhist' =>
+	'repository',
+	'arch',
 	@$jobhistlay,
 ];
 

--- a/src/backend/bs_repserver
+++ b/src/backend/bs_repserver
@@ -2999,8 +2999,29 @@ sub getjobhistory {
     my %code = map {$_ => 1} @{$cgi->{'code'}};
     $filter = sub {$code{$_[0]->{'code'}}};
   }
+  if ($cgi->{'endtime_start'} || $cgi->{'endtime_end'} || 1) {
+    my $filter2 = $filter;
+    my $endtime_start = $cgi->{'endtime_start'} || 0;
+    my $endtime_end = $cgi->{'endtime_end'};
+    $filter = sub {$_[0]->{'endtime'} < $endtime_start ? -2 : defined($endtime_end) && $_[0]->{'endtime'} > $endtime_end ? 0 : $filter2 ? $filter2->($_[0]) : 1};
+  }
   my @hist = BSFileDB::fdb_getall_reverse("$reporoot/$projid/$repoid/$arch/:jobhistory", $BSXML::jobhistlay, $cgi->{'limit'} || 100, $filter);
   @hist = reverse @hist;
+  my $ret = {jobhist => \@hist};
+  return ($ret, $BSXML::jobhistlist);
+}
+
+sub getjobhistory_project {
+  my ($cgi, $prpas) = @_;
+  my @hist;
+  for my $prpa (@$prpas) {
+    my ($projid, $repoid, $arch) = split('/', $prpa, 3);
+    my ($r) = getjobhistory($cgi, $projid, $repoid, $arch);
+    ($_->{'repository'}, $_->{'arch'}) = ($repoid, $arch) for @{$r->{'jobhist'} || []};
+    push @hist, @{$r->{'jobhist'} || []};
+  }
+  @hist = sort {$a->{'endtime'} <=> $b->{'endtime'}} @hist;
+  splice(@hist, 0, -$cgi->{'limit'}) if $cgi->{'limit'} && @hist > $cgi->{'limit'};
   my $ret = {jobhist => \@hist};
   return ($ret, $BSXML::jobhistlist);
 }
@@ -4237,7 +4258,7 @@ my $dispatches = [
   'POST:/build/$project/$repository/$arch/_repository match:' => \&postrepo,
   '/build/$project/$repository/$arch package* view:?' => \&getpackagelist_build,
   '/build/$project/$repository/$arch/_builddepinfo package* view:?' => \&getbuilddepinfo,
-  '/build/$project/$repository/$arch/_jobhistory package* code:* limit:num?' => \&getjobhistory,
+  '/build/$project/$repository/$arch/_jobhistory package* code:* limit:num? endtime_start:num? endtime_end:num?' => \&getjobhistory,
   'POST:/build/$project/$repository/$arch/_relsync' => \&postrelsync,
   '/build/$project/$repository/$arch/_relsync' => \&getrelsync,
   'POST:/build/$project/$repository/$arch/$package cmd=copy oproject:project? opackage:package? orepository:repository? setupdateinfoid:? resign:bool? setrelease:?' => \&copybuild,
@@ -4315,6 +4336,7 @@ my $dispatches = [
   '/configuration' => \&getconfiguration,
 
   '/_result $prpa+ oldstate:md5? package* code:* lastbuild:bool? withbinarylist:bool? withstats:bool? summary:bool? withversrel:bool?' => \&getresult,
+  '/_jobhistory $prpa+ package* code:* limit:num? endtime_start:num? endtime_end:num?' => \&getjobhistory_project,
   'POST:/_command $cmd: $prpa+ package* code:* sysrq:?' => \&docommand,
 
   '/serverstatus' => \&BSStdServer::serverstatus,

--- a/src/backend/bs_srcserver
+++ b/src/backend/bs_srcserver
@@ -3956,8 +3956,27 @@ sub getjobhistory {
 
   checkprojrepoarch($projid, $repoid, $arch);
   my $reposerver = $BSConfig::partitioning ? BSSrcServer::Partition::projid2reposerver($projid) : $BSConfig::reposerver;
-  my @args = BSRPC::args($cgi, 'limit', 'package', 'code');
+  my @args = BSRPC::args($cgi, 'limit', 'package', 'code', 'endtime_start', 'endtime_end');
   my $res = BSWatcher::rpc("$reposerver/build/$projid/$repoid/$arch/_jobhistory", $BSXML::jobhistlist, @args);
+  return ($res, $BSXML::jobhistlist);
+}
+
+sub getjobhistory_project {
+  my ($cgi, $projid) = @_;
+  my $proj = checkprojrepoarch($projid, undef, undef, 1);
+  my %repoidfilter = map {$_ => 1} @{$cgi->{'repository'} || []};
+  my %archfilter = map {$_ => 1} @{$cgi->{'arch'} || []};
+  my @prpas;
+  for my $repo (@{$proj->{'repository'} || []}) {
+    next if %repoidfilter && !$repoidfilter{$repo->{'name'}};
+    my @archs = @{$repo->{'arch'} || []};
+    @archs = grep {$archfilter{$_}} @archs if %archfilter;
+    push @prpas, map {"$projid/$repo->{'name'}/$_"} @archs;
+  }
+  return ({}, $BSXML::jobhistlist) unless @prpas;
+  my $reposerver = $BSConfig::partitioning ? BSSrcServer::Partition::projid2reposerver($projid) : $BSConfig::reposerver;
+  my @args = BSRPC::args($cgi, 'limit', 'package', 'code', 'endtime_start', 'endtime_end');
+  my $res = BSWatcher::rpc("$reposerver/_jobhistory", $BSXML::jobhistlist, (map {"prpa=$_"} @prpas), @args);
   return ($res, $BSXML::jobhistlist);
 }
 
@@ -6460,11 +6479,12 @@ my $dispatches = [
   'POST:/build/$project cmd: repository* arch* package* code:* wipe:* comment:? sysrq:?' => \&docommand,
   '/build/$project' => \&getrepositorylist,
   '/build/$project/_result oldstate:md5? view:resultview* lastbuild:bool? repository* arch* package* code:* multibuild:bool? locallink:bool?' => \&getresult,
+  '/build/$project/_jobhistory package* code:* limit:num? endtime_start:num? endtime_end:num?' => \&getjobhistory_project,
   '/build/$project/$repository' => \&getarchlist,
   '/build/$project/$repository/_buildconfig path:prp*' => \&getbuildconfig,
   '/build/$project/$repository/$arch package* view:?' => \&getpackagelist_build,
   '!- /build/$project/$repository/$arch/_builddepinfo package* view:?' => \&getbuilddepinfo,
-  '/build/$project/$repository/$arch/_jobhistory package* code:* limit:num?' => \&getjobhistory,
+  '/build/$project/$repository/$arch/_jobhistory package* code:* limit:num? endtime_start:num? endtime_end:num?' => \&getjobhistory,
   'POST:/build/$project/$repository/$arch/_repository match:' =>  \&postrepo,
   'POST:/build/$project/$repository/$arch/$package cmd=copy oproject:project? opackage:package? orepository:repository? setupdateinfoid:? resign:bool? setrelease:? multibuild:bool?' => \&copybuild,
   'POST:/build/$project/$repository/$arch/$package' => \&uploadbuild,


### PR DESCRIPTION
The endtime can be filtered with the endtime_start and endtime_end
parameters.

If you haven't done so already, please read the CONTRIBUTING.md file to learn how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md

