### PR TITLE
Cleanup classes that create ProjectLogEntries

### DIFF
--- a/src/api/app/models/event.rb
+++ b/src/api/app/models/event.rb
@@ -1,8 +1,5 @@
 module Event
   PROJECT_CLASSES = ['Event::CommentForProject',
-                     'Event::CreateProject',
-                     'Event::DeleteProject',
-                     'Event::UndeleteProject',
                      'Event::UpdateProjectConfig',
                      'Event::UpdateProject'].freeze
   PACKAGE_CLASSES = ['Event::BranchCommand',
@@ -16,6 +13,5 @@ module Event
                      'Event::ServiceSuccess',
                      'Event::UndeletePackage',
                      'Event::UpdatePackage',
-                     'Event::Upload',
                      'Event::VersionChange'].freeze
 end


### PR DESCRIPTION
PLEs belong to a project so it makes not much sense to track
creation/deletion of Projects with PLEs.

Don't know what Event::Upload is. No events or PLEs like
that in production, we also show this nowhere.

