### PR TITLE
Adapt smoke tests to Bootstrap migration

### DIFF
--- a/dist/t/spec/features/0030_project_spec.rb
+++ b/dist/t/spec/features/0030_project_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe "Project" do
     within("div#subheader") do
       click_link('Create Home')
     end
-    click_button('Create Project')
+    first('input[type=submit]').click # 'Create Project' for 2.8 and 2.9. 'Accept' for master
     expect(page).to have_content("Project 'home:Admin' was created successfully")
   end
 


### PR DESCRIPTION
Adapt smoke tests after subprojects page was migrated to Bootstrap. This should fix openQA tests run for OBS.