### PR TITLE
Align the old UI with the new Bootstrap UI to pass the specs

### DIFF
--- a/src/api/app/views/webui/project/_packages_table.html.erb
+++ b/src/api/app/views/webui/project/_packages_table.html.erb
@@ -37,10 +37,10 @@
           <% if !@project.defines_remote_instance? && !(@is_incident_project && !@packages.blank? && @has_patchinfo && @open_release_requests.empty?) && !@is_maintenance_project %>
               <ul class="horizontal-list">
                 <li>
-                  <%= link_to(sprited_text('package_add', 'Create package'), controller: 'project', action: 'new_package', project: @project) %>
+                  <%= link_to(sprited_text('package_add', 'Create Package'), controller: 'project', action: 'new_package', project: @project) %>
                 </li>
                 <li>
-                  <%= link_to sprited_text('package_link', 'Branch existing package'), controller: :project, action: :new_package_branch, project: @project %>
+                  <%= link_to sprited_text('package_link', 'Branch Existing Package'), controller: :project, action: :new_package_branch, project: @project %>
                 </li>
               </ul>
           <% end %>

--- a/src/api/app/views/webui/project/edit.html.erb
+++ b/src/api/app/views/webui/project/edit.html.erb
@@ -1,4 +1,4 @@
-<% @pagetitle = "Edit Project Information of #{@project}"
+<% @pagetitle = "Edit Project #{@project}"
    @metarobots = 'noindex'
    project_bread_crumb 'Edit Project'
 -%>

--- a/src/api/app/views/webui/project/new_package.html.erb
+++ b/src/api/app/views/webui/project/new_package.html.erb
@@ -23,5 +23,5 @@
   <%= check_box_tag :disable_publishing %>
   <label for="disable_publishing">Disable build results publishing.</label>
 </p>
-<p><%= submit_tag %></p>
+<p><%= submit_tag 'Accept' %></p>
 <% end %>

--- a/src/api/app/views/webui/project/new_package_branch.html.erb
+++ b/src/api/app/views/webui/project/new_package_branch.html.erb
@@ -33,7 +33,7 @@ package.</p>
     </p>
     <%= hidden_field_tag 'target_project', @project %>
     <%= render partial: 'shared/package_branch_form', locals: {show_project_field: false, target_project: @project} %>
-    <p><%= submit_tag "Create Branch" %></p>
+    <p><%= submit_tag 'Accept' %></p>
   </div>
 <% end %>
 

--- a/src/api/app/views/webui/project/show.html.erb
+++ b/src/api/app/views/webui/project/show.html.erb
@@ -111,53 +111,53 @@
         <ul class="horizontal-list">
           <% if !@bugowners_mail.empty? && !CONFIG['bugzilla_host'].nil? %>
               <li>
-                <%= link_to(sprited_text('tools-report-bug', 'Report bug'), bugzilla_url(@bugowners_mail, "#{@project.name}: Bug")) -%>
+                <%= link_to(sprited_text('tools-report-bug', 'Report Bug'), bugzilla_url(@bugowners_mail, "#{@project.name}: Bug")) -%>
               </li>
           <% end -%>
           <% if @project.is_locked? && User.current.can_modify?(@project, true) %>
                   <li>
-                    <%= link_to(sprited_text('lock_open', 'Unlock project'), { controller: 'project', action: 'unlock_dialog', project: @project.name }, remote: true) %>
+                    <%= link_to(sprited_text('lock_open', 'Unlock Project'), { controller: 'project', action: 'unlock_dialog', project: @project.name }, remote: true) %>
                   </li>
           <% elsif User.current.can_modify?(@project) %>
               <% unless @project.defines_remote_instance? %>
                   <% if @is_incident_project && @packages.present? && @has_patchinfo && @open_release_requests.blank? %>
                       <li>
-                        <%= link_to(sprited_text('brick_go', 'Request to release'), { controller: 'project', action: 'release_request_dialog', project: @project }, remote: true) %>
+                        <%= link_to(sprited_text('brick_go', 'Request to Release'), { controller: 'project', action: 'release_request_dialog', project: @project }, remote: true) %>
                       </li>
                   <% elsif @is_maintenance_project %>
                       <li>
-                        <%= link_to(sprited_text('brick_add', 'Create maintenance incident'), { controller: 'project', action: 'new_incident', ns: @project.name }, method: :post) %>
+                        <%= link_to(sprited_text('brick_add', 'Create Maintenance Incident'), { controller: 'project', action: 'new_incident', ns: @project.name }, method: :post) %>
                       </li>
                   <% else %>
                       <% if @has_patchinfo %>
                           <li>
-                            <%= link_to(sprited_text('information', 'Show patchinfo'), controller: 'patchinfo', action: 'show', project: @project, package: 'patchinfo') %>
+                            <%= link_to(sprited_text('information', 'Show Patchinfo'), controller: 'patchinfo', action: 'show', project: @project, package: 'patchinfo') %>
                           </li>
                       <% else %>
                           <li>
-                            <%= link_to(sprited_text('plugin_add', 'Create patchinfo'), { controller: 'patchinfo', action: :new_patchinfo, project: @project }, method: :post) %>
+                            <%= link_to(sprited_text('plugin_add', 'Create Patchinfo'), { controller: 'patchinfo', action: :new_patchinfo, project: @project }, method: :post) %>
                           </li>
                       <% end %>
                       <% if !@is_incident_project && @releasetargets.length > 0 %>
                           <li>
-                            <%= link_to(sprited_text('brick_go', 'Submit as update'), { controller: 'project', action: 'incident_request_dialog', project: @project }, remote: true) %>
+                            <%= link_to(sprited_text('brick_go', 'Submit as Update'), { controller: 'project', action: 'incident_request_dialog', project: @project }, remote: true) %>
                           </li>
                       <% end %>
                       <%= render partial: 'webui/project/show/encryption_key_download_links' %>
                   <% end %>
               <% end %>
               <li>
-                <%= link_to(sprited_text('brick_edit', 'Edit description'), { action: 'edit', project: @project }, id: 'edit-description') %>
+                <%= link_to(sprited_text('brick_edit', 'Edit Project'), { action: 'edit', project: @project }, id: 'edit-project') %>
               </li>
               <li>
-                <%= link_to(sprited_text('brick_delete', 'Delete project'), { controller: 'project', action: 'delete_dialog', project: @project.name }, remote: true, id: 'delete-project') %>
+                <%= link_to(sprited_text('brick_delete', 'Delete Project'), { controller: 'project', action: 'delete_dialog', project: @project.name }, remote: true, id: 'delete-project') %>
               </li>
           <% elsif !@project.is_locked? %>
               <li>
-                <%= link_to(sprited_text('user_add', 'Request role addition'), { controller: 'request', action: 'add_role_request_dialog', project: @project }, remote: true) %>
+                <%= link_to(sprited_text('user_add', 'Request Role Addition'), { controller: 'request', action: 'add_role_request_dialog', project: @project }, remote: true) %>
               </li>
               <li>
-                <%= link_to(sprited_text('package_delete', 'Request deletion'), { controller: 'request', action: 'delete_request_dialog', project: @project }, remote: true, id: 'request-deletion') %>
+                <%= link_to(sprited_text('package_delete', 'Request Deletion'), { controller: 'request', action: 'delete_request_dialog', project: @project }, remote: true, id: 'request-deletion') %>
               </li>
           <% end %>
         </ul>

--- a/src/api/app/views/webui/shared/_dialog_action_buttons.html.haml
+++ b/src/api/app/views/webui/shared/_dialog_action_buttons.html.haml
@@ -1,3 +1,3 @@
 .dialog-buttons
   = remove_dialog_tag('Cancel')
-  = submit_tag('Ok')
+  = submit_tag('Accept')

--- a/src/api/app/views/webui2/webui/comment/_links.html.haml
+++ b/src/api/app/views/webui2/webui/comment/_links.html.haml
@@ -1,7 +1,7 @@
 %ul.list-inline
   - unless User.current.is_nobody?
     %li.list-inline-item.togglable_comment{ "data-toggle": "reply_form_of_#{comment.id}" }
-      %span.btn.btn-sm.btn-outline-secondary{ id: "reply_link_id_#{comment.id}" }
+      %button.btn.btn-sm.btn-outline-secondary{ id: "reply_link_id_#{comment.id}" }
         Reply
   - if policy(comment).destroy?
     %li.list-inline-item

--- a/src/api/app/views/webui2/webui/project/_add_new_subproject_modal.html.haml
+++ b/src/api/app/views/webui2/webui/project/_add_new_subproject_modal.html.haml
@@ -3,6 +3,6 @@
     .modal-content
       .modal-header
         %h5.modal-title#add-new-subproject-modal-label
-          Create subproject
+          Create Subproject
       .modal-body
         = render partial: 'form', locals: { project: Project.new, namespace: project.name, configuration: configuration }

--- a/src/api/app/views/webui2/webui/project/_new_package_branch_modal.html.haml
+++ b/src/api/app/views/webui2/webui/project/_new_package_branch_modal.html.haml
@@ -3,7 +3,7 @@
     .modal-content
       .modal-header
         %h5.modal-title#new-package-branch-modal-label
-          Add new package branch to #{project.name}
+          Add New Package Branch to #{project.name}
         %button.close{ type: 'button', data: { dismiss: 'modal' }, aria: { label: 'close' } }
           %span{ aria: { hidden: true } }
             &times

--- a/src/api/app/views/webui2/webui/project/_new_package_modal.html.haml
+++ b/src/api/app/views/webui2/webui/project/_new_package_modal.html.haml
@@ -3,7 +3,7 @@
     .modal-content
       .modal-header
         %h5.modal-title#new-package-modal-label
-          Create new package for #{project.name}
+          Create New Package for #{project.name}
         %button.close{ type: 'button', data: { dismiss: 'modal' }, aria: { label: 'close' } }
           %span{ aria: { hidden: true } }
             &times

--- a/src/api/spec/bootstrap/features/webui/maintenance_workflow_spec.rb
+++ b/src/api/spec/bootstrap/features/webui/maintenance_workflow_spec.rb
@@ -32,9 +32,7 @@ RSpec.feature 'Bootstrap_MaintenanceWorkflow', type: :feature, js: true, vcr: tr
     sleep 1 # Needed to avoid a flickering test.
     expect(page).to have_text('Source')
 
-    within('#branch-modal .modal-footer') do
-      click_button('Accept')
-    end
+    click_button('Accept')
     expect(page).to have_text('Successfully branched package')
 
     # change the package sources so we have a difference
@@ -44,12 +42,12 @@ RSpec.feature 'Bootstrap_MaintenanceWorkflow', type: :feature, js: true, vcr: tr
     #####################################
     visit project_show_path(project: 'home:tom:branches:ProjectWithRepo:Update')
 
-    click_link('Submit as update')
+    click_link('Submit as Update')
     # we need this find to wait for the dialog to appear
     expect(find(:css, '.dialog h2')).to have_text('Submit as Update')
     fill_in('description', with: 'I want the update')
 
-    click_button('Ok')
+    click_button('Accept')
     expect(page).to have_css('#flash-messages', text: 'Created maintenance incident request')
 
     # Check that sending maintenance updates adds the source revision
@@ -102,11 +100,11 @@ RSpec.feature 'Bootstrap_MaintenanceWorkflow', type: :feature, js: true, vcr: tr
     login(user)
     visit project_show_path(project: 'home:tom:branches:ProjectWithRepo:Update')
 
-    click_link('Submit as update')
+    click_link('Submit as Update')
 
     expect(find(:css, '.dialog h2')).to have_text('Submit as Update')
     fill_in('description', with: 'I have a additional fix')
-    click_button('Ok')
+    click_button('Accept')
 
     logout
 
@@ -121,7 +119,7 @@ RSpec.feature 'Bootstrap_MaintenanceWorkflow', type: :feature, js: true, vcr: tr
 
     fill_in('incident_project', with: 2)
 
-    click_button('Ok')
+    click_button('Accept')
     expect(page).to have_css('#flash-messages', text: 'Incident MaintenanceProject:2 does not exist')
 
     click_link('Merge with existing incident')
@@ -130,7 +128,7 @@ RSpec.feature 'Bootstrap_MaintenanceWorkflow', type: :feature, js: true, vcr: tr
 
     fill_in('incident_project', with: 0)
 
-    click_button('Ok')
+    click_button('Accept')
     expect(page).to have_css('#flash-messages', text: 'Set target of request 2 to incident 0')
 
     click_button('accept_request_button')
@@ -138,10 +136,10 @@ RSpec.feature 'Bootstrap_MaintenanceWorkflow', type: :feature, js: true, vcr: tr
     # Step 7: The maintenance coordinator releases the request
     ##########################################################
     visit project_show_path('MaintenanceProject:0')
-    click_link('Request to release')
+    click_link('Request to Release')
 
     fill_in('description', with: 'RELEASE!')
-    click_button('Ok')
+    click_button('Accept')
 
     # As we can't release without build results this should fail
     expect(page).to have_css('#flash-messages',

--- a/src/api/spec/bootstrap/features/webui/projects_spec.rb
+++ b/src/api/spec/bootstrap/features/webui/projects_spec.rb
@@ -10,7 +10,7 @@ RSpec.feature 'Bootstrap_Projects', type: :feature, js: true, vcr: true do
     before do
       login user
       visit project_show_path(project: user.home_project)
-      click_link('Create package')
+      click_link('Create Package')
     end
 
     scenario 'with valid data' do
@@ -19,7 +19,7 @@ RSpec.feature 'Bootstrap_Projects', type: :feature, js: true, vcr: true do
       fill_in 'name', with: 'coolstuff'
       fill_in 'title', with: 'cool stuff everyone needs'
       fill_in 'description', with: very_long_description
-      click_button 'Save changes'
+      click_button 'Accept'
 
       expect(page).to have_text("Package 'coolstuff' was created successfully")
       expect(page).to have_current_path(package_show_path(project: user.home_project_name, package: 'coolstuff'))

--- a/src/api/spec/features/webui/comments_spec.rb
+++ b/src/api/spec/features/webui/comments_spec.rb
@@ -13,6 +13,7 @@ RSpec.feature 'Comments', type: :feature, js: true do
   end
 
   scenario 'can be answered' do
+    skip_if_bootstrap
     login user
     comment = create(:comment_project, commentable: Project.first, user: user)
     visit project_show_path(user.home_project)

--- a/src/api/spec/features/webui/maintenance_workflow_spec.rb
+++ b/src/api/spec/features/webui/maintenance_workflow_spec.rb
@@ -43,12 +43,12 @@ RSpec.feature 'MaintenanceWorkflow', type: :feature, js: true do
     #####################################
     visit project_show_path(project: 'home:tom:branches:ProjectWithRepo:Update')
 
-    click_link('Submit as update')
+    click_link('Submit as Update')
     # we need this find to wait for the dialog to appear
     expect(find(:css, '.dialog h2')).to have_text('Submit as Update')
     fill_in('description', with: 'I want the update')
 
-    click_button('Ok')
+    click_button('Accept')
     expect(page).to have_css('#flash-messages', text: 'Created maintenance incident request')
 
     # Check that sending maintenance updates adds the source revision
@@ -101,11 +101,11 @@ RSpec.feature 'MaintenanceWorkflow', type: :feature, js: true do
     login(user)
     visit project_show_path(project: 'home:tom:branches:ProjectWithRepo:Update')
 
-    click_link('Submit as update')
+    click_link('Submit as Update')
 
     expect(find(:css, '.dialog h2')).to have_text('Submit as Update')
     fill_in('description', with: 'I have a additional fix')
-    click_button('Ok')
+    click_button('Accept')
 
     logout
 
@@ -120,7 +120,7 @@ RSpec.feature 'MaintenanceWorkflow', type: :feature, js: true do
 
     fill_in('incident_project', with: 2)
 
-    click_button('Ok')
+    click_button('Accept')
     expect(page).to have_css('#flash-messages', text: 'Incident MaintenanceProject:2 does not exist')
 
     click_link('Merge with existing incident')
@@ -129,7 +129,7 @@ RSpec.feature 'MaintenanceWorkflow', type: :feature, js: true do
 
     fill_in('incident_project', with: 0)
 
-    click_button('Ok')
+    click_button('Accept')
     expect(page).to have_css('#flash-messages', text: 'Set target of request 2 to incident 0')
 
     click_button('accept_request_button')
@@ -137,10 +137,10 @@ RSpec.feature 'MaintenanceWorkflow', type: :feature, js: true do
     # Step 7: The maintenance coordinator releases the request
     ##########################################################
     visit project_show_path('MaintenanceProject:0')
-    click_link('Request to release')
+    click_link('Request to Release')
 
     fill_in('description', with: 'RELEASE!')
-    click_button('Ok')
+    click_button('Accept')
 
     # As we can't release without build results this should fail
     expect(page).to have_css('#flash-messages',

--- a/src/api/spec/features/webui/packages_spec.rb
+++ b/src/api/spec/features/webui/packages_spec.rb
@@ -120,7 +120,7 @@ RSpec.feature 'Packages', type: :feature, js: true do
     visit package_show_path(package: package, project: user.home_project)
     click_link('delete-package')
     expect(find('#del_dialog')).to have_text('Do you really want to delete this package?')
-    click_button('Ok')
+    click_button('Accept')
     expect(find('#flash-messages')).to have_text('Package was successfully removed.')
   end
 
@@ -155,7 +155,7 @@ RSpec.feature 'Packages', type: :feature, js: true do
     click_link('Request deletion')
     expect(page).to have_text('Do you really want to request the deletion of package ')
     fill_in 'description', with: 'Hey, why not?'
-    click_button('Ok')
+    click_button('Accept')
     expect(page).to have_text('Created delete request')
     find('a', text: /delete request \d+/).click
     expect(page.current_path).to match('/request/show/\\d+')
@@ -169,7 +169,7 @@ RSpec.feature 'Packages', type: :feature, js: true do
     click_link('Request devel project change')
     fill_in 'description', with: 'Hey, why not?'
     fill_in 'devel_project', with: third_project.name
-    click_button 'Ok'
+    click_button('Accept')
 
     expect(find('#flash-messages', visible: false)).not_to be_visible
     request = BsRequest.where(description: 'Hey, why not?', creator: user.login, state: 'review')

--- a/src/api/spec/features/webui/patchinfo_spec.rb
+++ b/src/api/spec/features/webui/patchinfo_spec.rb
@@ -10,8 +10,8 @@ RSpec.feature 'Patchinfo', type: :feature, js: true do
     scenario 'form incomplete' do
       login user
       visit project_show_path(user.home_project)
-      expect(page).to have_link('Create patchinfo')
-      click_link('Create patchinfo')
+      expect(page).to have_link('Create Patchinfo')
+      click_link('Create Patchinfo')
       expect(page).to have_current_path(patchinfo_new_patchinfo_path(project: project))
       expect(page).to have_text("Patchinfo-Editor for #{project.name}")
       fill_in 'summary', with: 'A' * 9
@@ -24,8 +24,8 @@ RSpec.feature 'Patchinfo', type: :feature, js: true do
     scenario 'form complete' do
       login user
       visit project_show_path(user.home_project)
-      expect(page).to have_link('Create patchinfo')
-      click_link('Create patchinfo')
+      expect(page).to have_link('Create Patchinfo')
+      click_link('Create Patchinfo')
       expect(page).to have_current_path(patchinfo_new_patchinfo_path(project: project))
       expect(page).to have_text("Patchinfo-Editor for #{project.name}")
       fill_in 'summary', with: 'A' * 15
@@ -49,7 +49,7 @@ RSpec.feature 'Patchinfo', type: :feature, js: true do
       expect(page).to have_link('Delete patchinfo')
       click_link('Delete patchinfo')
       expect(page).to have_text('Do you really want')
-      click_button('Ok')
+      click_button('Accept')
       expect(page).to have_text('Patchinfo was successfully removed.')
     end
   end

--- a/src/api/spec/features/webui/projects_spec.rb
+++ b/src/api/spec/features/webui/projects_spec.rb
@@ -23,8 +23,8 @@ RSpec.feature 'Projects', type: :feature, js: true do
     login user
     visit project_show_path(project: project)
 
-    click_link('Edit description')
-    expect(page).to have_text('Edit Project Information of')
+    click_link('Edit Project')
+    expect(page).to have_text('Edit Project')
 
     fill_in 'project_title', with: 'My Title hopefully got changed'
     fill_in 'project_description', with: 'New description. Not kidding.. Brand new!'
@@ -41,7 +41,7 @@ RSpec.feature 'Projects', type: :feature, js: true do
     before do
       login user
       visit project_show_path(project: user.home_project)
-      click_link('Create package')
+      click_link('Create Package')
       expect(page).to have_text("Create New Package for #{user.home_project_name}")
     end
 
@@ -51,7 +51,7 @@ RSpec.feature 'Projects', type: :feature, js: true do
       fill_in 'name', with: 'coolstuff'
       fill_in 'title', with: 'cool stuff everyone needs'
       fill_in 'description', with: very_long_description
-      click_button 'Save changes'
+      click_button('Accept')
 
       expect(page).to have_text("Package 'coolstuff' was created successfully")
       expect(page.current_path).to eq(package_show_path(project: user.home_project_name, package: 'coolstuff'))
@@ -61,7 +61,7 @@ RSpec.feature 'Projects', type: :feature, js: true do
 
     scenario 'with invalid data (validation fails)' do
       fill_in 'name', with: 'cool stuff'
-      click_button 'Save changes'
+      click_button('Accept')
 
       expect(page).to have_text("Invalid package name: 'cool stuff'")
       expect(page.current_path).to eq("/project/new_package/#{user.home_project_name}")
@@ -71,7 +71,7 @@ RSpec.feature 'Projects', type: :feature, js: true do
       create(:package, name: 'coolstuff', project: user.home_project)
 
       fill_in 'name', with: 'coolstuff'
-      click_button 'Save changes'
+      click_button('Accept')
 
       expect(page).to have_text("Package 'coolstuff' already exists in project '#{user.home_project_name}'")
       expect(page.current_path).to eq("/project/new_package/#{user.home_project_name}")
@@ -91,7 +91,7 @@ RSpec.feature 'Projects', type: :feature, js: true do
       visit "/project/new_package/#{global_project}"
 
       fill_in 'name', with: 'coolstuff'
-      click_button 'Save changes'
+      click_button('Accept')
 
       expect(page).to have_text("You can't create packages in #{global_project}")
       expect(page.current_path).to eq("/project/new_package/#{global_project}")
@@ -100,10 +100,10 @@ RSpec.feature 'Projects', type: :feature, js: true do
     scenario 'as admin' do
       login admin_user
       visit project_show_path(project: global_project)
-      click_link('Create package')
+      click_link('Create Package')
 
       fill_in 'name', with: 'coolstuff'
-      click_button 'Save changes'
+      click_button('Accept')
 
       expect(page).to have_text("Package 'coolstuff' was created successfully")
       expect(page.current_path).to eq(package_show_path(project: global_project.to_s, package: 'coolstuff'))
@@ -153,9 +153,9 @@ RSpec.feature 'Projects', type: :feature, js: true do
     end
 
     scenario 'unlock' do
-      click_link('Unlock project')
+      click_link('Unlock Project')
       fill_in 'comment', with: 'Freedom at last!'
-      click_button('Ok')
+      click_button('Accept')
       expect(page).to have_content('Successfully unlocked project')
 
       visit project_show_path(project: locked_project.name)
@@ -165,9 +165,9 @@ RSpec.feature 'Projects', type: :feature, js: true do
     scenario 'fail to unlock' do
       allow_any_instance_of(Project).to receive(:can_be_unlocked?).and_return(false)
 
-      click_link('Unlock project')
+      click_link('Unlock Project')
       fill_in 'comment', with: 'Freedom at last!'
-      click_button('Ok')
+      click_button('Accept')
       expect(page).to have_content("Project can't be unlocked")
 
       visit project_show_path(project: locked_project.name)
@@ -301,36 +301,36 @@ RSpec.feature 'Projects', type: :feature, js: true do
     before do
       login user
       visit project_show_path(project)
-      click_link('Branch existing package')
+      click_link('Branch Existing Package')
     end
 
     scenario 'an existing package' do
-      fill_in('Original project name', with: other_user.home_project_name)
-      fill_in('Original package name', with: package_of_another_project.name)
+      fill_in('linked_project', with: other_user.home_project_name)
+      fill_in('linked_package', with: package_of_another_project.name)
       # This needs global write through
-      click_button('Create Branch')
+      click_button('Accept')
 
       expect(page).to have_text('Successfully branched package')
       expect(page.current_path).to eq('/package/show/home:Jane/branch_test_package')
     end
 
     scenario 'an existing package, but chose a different target package name' do
-      fill_in('Original project name', with: other_user.home_project_name)
-      fill_in('Original package name', with: package_of_another_project.name)
+      fill_in('linked_project', with: other_user.home_project_name)
+      fill_in('linked_package', with: package_of_another_project.name)
       fill_in('Branch package name', with: 'some_different_name')
       # This needs global write through
-      click_button('Create Branch')
+      click_button('Accept')
 
       expect(page).to have_text('Successfully branched package')
       expect(page.current_path).to eq("/package/show/#{user.home_project_name}/some_different_name")
     end
 
     scenario 'an existing package to an invalid target package or project' do
-      fill_in('Original project name', with: other_user.home_project_name)
-      fill_in('Original package name', with: package_of_another_project.name)
+      fill_in('linked_project', with: other_user.home_project_name)
+      fill_in('linked_package', with: package_of_another_project.name)
       fill_in('Branch package name', with: 'something/illegal')
       # This needs global write through
-      click_button('Create Branch')
+      click_button('Accept')
 
       expect(page).to have_text('Failed to branch: Validation failed: Name is illegal')
       expect(page.current_path).to eq('/project/new_package_branch/home:Jane')
@@ -339,20 +339,20 @@ RSpec.feature 'Projects', type: :feature, js: true do
     scenario 'an existing package were the target package already exists' do
       create(:package_with_file, name: package_of_another_project.name, project: user.home_project)
 
-      fill_in('Original project name', with: other_user.home_project_name)
-      fill_in('Original package name', with: package_of_another_project.name)
+      fill_in('linked_project', with: other_user.home_project_name)
+      fill_in('linked_package', with: package_of_another_project.name)
       # This needs global write through
-      click_button('Create Branch')
+      click_button('Accept')
 
       expect(page).to have_text('You have already branched this package')
       expect(page.current_path).to eq('/package/show/home:Jane/branch_test_package')
     end
 
     scenario 'a non-existing package' do
-      fill_in('Original project name', with: 'non-existing_package')
-      fill_in('Original package name', with: package_of_another_project.name)
+      fill_in('linked_project', with: 'non-existing_package')
+      fill_in('linked_package', with: package_of_another_project.name)
       # This needs global write through
-      click_button('Create Branch')
+      click_button('Accept')
 
       expect(page).to have_text('Failed to branch: Package does not exist.')
       expect(page.current_path).to eq('/project/new_package_branch/home:Jane')
@@ -361,11 +361,11 @@ RSpec.feature 'Projects', type: :feature, js: true do
     scenario 'a package with disabled access flag' do
       create(:access_flag, status: 'disable', project: other_user.home_project)
 
-      fill_in('Original project name', with: other_user.home_project_name)
-      fill_in('Original package name', with: package_of_another_project.name)
+      fill_in('linked_project', with: other_user.home_project_name)
+      fill_in('linked_package', with: package_of_another_project.name)
       fill_in('Branch package name', with: 'some_different_name')
       # This needs global write through
-      click_button('Create Branch')
+      click_button('Accept')
 
       expect(page).to have_text('Failed to branch: Package does not exist.')
       expect(page.current_path).to eq('/project/new_package_branch/home:Jane')
@@ -374,24 +374,24 @@ RSpec.feature 'Projects', type: :feature, js: true do
     scenario 'a package with disabled sourceaccess flag' do
       create(:sourceaccess_flag, status: 'disable', project: other_user.home_project)
 
-      fill_in('Original project name', with: other_user.home_project_name)
-      fill_in('Original package name', with: package_of_another_project.name)
+      fill_in('linked_project', with: other_user.home_project_name)
+      fill_in('linked_package', with: package_of_another_project.name)
       fill_in('Branch package name', with: 'some_different_name')
       # This needs global write through
-      click_button('Create Branch')
+      click_button('Accept')
 
       expect(page).to have_text('Sorry, you are not authorized to branch this Package.')
       expect(page.current_path).to eq('/project/new_package_branch/home:Jane')
     end
 
     scenario 'a package and select current revision' do
-      fill_in('Original project name', with: other_user.home_project_name)
-      fill_in('Original package name', with: package_of_another_project.name)
+      fill_in('linked_project', with: other_user.home_project_name)
+      fill_in('linked_package', with: package_of_another_project.name)
 
       find("input[id='current_revision']").set(true)
 
       # This needs global write through
-      click_button('Create Branch')
+      click_button('Accept')
 
       expect(page).to have_text('Successfully branched package')
       expect(page.current_path).to eq('/package/show/home:Jane/branch_test_package')
@@ -429,7 +429,7 @@ RSpec.feature 'Projects', type: :feature, js: true do
       click_link('Maintained Projects')
       click_link('Add project to maintenance')
       fill_in('Project to maintain:', with: project.name)
-      click_button('Ok')
+      click_button('Accept')
 
       expect(page).to have_text("Added #{project.name} to maintenance")
       expect(find('table#maintained_projects_table td:first-child')).to have_text(project.name)

--- a/src/api/spec/features/webui/requests_spec.rb
+++ b/src/api/spec/features/webui/requests_spec.rb
@@ -57,11 +57,11 @@ RSpec.feature 'Requests', type: :feature, js: true do
       it 'can be submitted' do
         login submitter
         visit project_show_path(project: target_project)
-        click_link 'Request role addition'
+        click_link('Request Role Addition')
         find(:id, 'role').select('Bugowner')
         fill_in 'description', with: 'I can fix bugs too.'
 
-        expect { click_button 'Ok' }.to change(BsRequest, :count).by(1)
+        expect { click_button('Accept') }.to change(BsRequest, :count).by(1)
         expect(page).to have_text("#{submitter.realname} (#{submitter.login}) wants to get the role bugowner for project #{target_project}")
         expect(page).to have_css('#description-text', text: 'I can fix bugs too.')
         expect(page).to have_text('In state new')
@@ -92,7 +92,7 @@ RSpec.feature 'Requests', type: :feature, js: true do
         fill_in 'description', with: 'I can produce bugs too.'
 
         within('#dialog_wrapper .dialog-buttons') do
-          expect { click_button 'Ok' }.to change(BsRequest, :count).by(1)
+          expect { click_button('Accept') }.to change(BsRequest, :count).by(1)
         end
         expect(page).to have_text("#{submitter.realname} (#{submitter.login}) wants to get the role maintainer " \
                                   "for package #{target_project} / #{target_package}")
@@ -126,7 +126,7 @@ RSpec.feature 'Requests', type: :feature, js: true do
         click_link 'Add a review'
         find(:id, 'review_type').select('User')
         fill_in 'review_user', with: reviewer.login
-        click_button 'Ok'
+        click_button('Accept')
         expect(page).to have_text(/Open review for\s+#{reviewer.login}/)
         expect(page).to have_text('Request 1 (review)')
         expect(Review.all.count).to eq(1)
@@ -151,7 +151,7 @@ RSpec.feature 'Requests', type: :feature, js: true do
         click_link 'Add a review'
         find(:id, 'review_type').select('Group')
         fill_in 'review_group', with: review_group.title
-        click_button 'Ok'
+        click_button('Accept')
         expect(page).to have_text("Open review for #{review_group.title}")
       end
     end
@@ -163,7 +163,7 @@ RSpec.feature 'Requests', type: :feature, js: true do
         click_link 'Add a review'
         find(:id, 'review_type').select('Project')
         fill_in 'review_project', with: submitter.home_project
-        click_button 'Ok'
+        click_button('Accept')
         expect(page).to have_text("Review for #{submitter.home_project}")
       end
     end
@@ -177,7 +177,7 @@ RSpec.feature 'Requests', type: :feature, js: true do
         find(:id, 'review_type').select('Package')
         fill_in 'review_project', with: submitter.home_project
         fill_in 'review_package', with: package.name
-        click_button 'Ok'
+        click_button('Accept')
         expect(page).to have_text("Review for #{submitter.home_project} / #{package.name}")
       end
     end
@@ -189,7 +189,7 @@ RSpec.feature 'Requests', type: :feature, js: true do
         click_link 'Add a review'
         find(:id, 'review_type').select('Project')
         fill_in 'review_project', with: 'INVALID/PROJECT'
-        click_button 'Ok'
+        click_button('Accept')
         expect(page).to have_css('#flash-messages', text: 'Unable add review to')
       end
     end


### PR DESCRIPTION
We currently have the bootstrap views behind a feature switch. Some of
these bootstrap views require some adaptations of the existing tests in
order to pass.

Co-authored-by: Dany Marcoux <dmarcoux@suse.com>


