### PR TITLE
Avoid codemirror toolbar to overlap dropdown menu

### DIFF
--- a/src/api/app/assets/stylesheets/webui2/tabs-component.scss
+++ b/src/api/app/assets/stylesheets/webui2/tabs-component.scss
@@ -10,4 +10,8 @@ ul.nav.nav-tabs li.nav-item {
       color: $white;
     }
   }
+
+  .dropdown-menu {
+    z-index: 1021;
+  }
 }


### PR DESCRIPTION
Fixes: #6525 

In small screens, codemirror toolbar was overlapping dropdown menu.
Toolbar's z-index is set to auto but it seems its value is 1020, so 1021
is enough to show the menu above.

This Bootstrap configuration can be the explanation:
```$zindex-sticky:            1020 !default;```
https://getbootstrap.com/docs/4.1/layout/overview/#z-index

Before:
![screenshot-2018-12-7 meta configuration of pro1 - open build service](https://user-images.githubusercontent.com/2581944/49729212-206a2300-fc75-11e8-8d8e-e5db31bf9fb2.png)

After:
![screenshot-2018-12-10 meta configuration of pro1 - open build service](https://user-images.githubusercontent.com/2581944/49729219-252ed700-fc75-11e8-8280-966749d1a6e9.png)

