### PR TITLE
Show white text when clicking on dropdown menu link

### DIFF
--- a/src/api/app/assets/stylesheets/webui2/tabs-component.scss
+++ b/src/api/app/assets/stylesheets/webui2/tabs-component.scss
@@ -6,8 +6,14 @@ ul.nav.nav-tabs li.nav-item {
       color: $link-hover-color;
     }
 
-    &.dropdown-item.active {
+    &.dropdown-item.active,
+    &.dropdown-item:active {
       color: $white;
+
+      span.badge {
+        color: $link-hover-color;
+        background-color: $white;
+      }
     }
   }
 }


### PR DESCRIPTION
When a dropdown menu link was clicked, the text became green on top of a
green background. Now text is set to white in that case (:active).

Fixes: #6526

Before:
![home of admin open build service 2](https://user-images.githubusercontent.com/2581944/49730832-dfc0d880-fc79-11e8-86e6-b3c657658873.png)

After:
![home of admin open build service 4](https://user-images.githubusercontent.com/2581944/49731036-59f15d00-fc7a-11e8-907e-fcc574d67bf9.png)


