### PR TITLE
Remove 'close' icon from modal for package branching

### DIFF
--- a/src/api/app/views/webui2/webui/package/_branch_dialog.html.haml
+++ b/src/api/app/views/webui2/webui/package/_branch_dialog.html.haml
@@ -3,8 +3,6 @@
     .modal-content
       .modal-header
         %h5.modal-title#branch-modal-label Branch Confirmation
-        %a.close{ type: 'button', data: { dismiss: 'modal' }, aria: { label: 'Close' } }
-          %span{ aria: { hidden: true } } &times;
       .modal-body
         - branch_project = User.current.branch_project_name(project.name)
         %strong Source

--- a/src/api/app/views/webui2/webui/project/_new_package_branch_modal.html.haml
+++ b/src/api/app/views/webui2/webui/project/_new_package_branch_modal.html.haml
@@ -4,9 +4,6 @@
       .modal-header
         %h5.modal-title#new-package-branch-modal-label
           Add New Package Branch to #{project.name}
-        %button.close{ type: 'button', data: { dismiss: 'modal' }, aria: { label: 'close' } }
-          %span{ aria: { hidden: true } }
-            &times
       .modal-body.ui-front
         %p
           By branching a package from another project you add the package and its files

--- a/src/api/app/views/webui2/webui/project/_new_package_modal.html.haml
+++ b/src/api/app/views/webui2/webui/project/_new_package_modal.html.haml
@@ -4,9 +4,6 @@
       .modal-header
         %h5.modal-title#new-package-modal-label
           Create New Package for #{project.name}
-        %button.close{ type: 'button', data: { dismiss: 'modal' }, aria: { label: 'close' } }
-          %span{ aria: { hidden: true } }
-            &times
       .modal-body
         = form_tag(save_new_package_path(project)) do
           .form-group


### PR DESCRIPTION
This align the package branch modal with the other modals.

Before:

![screenshot from 2018-12-10 13-52-55](https://user-images.githubusercontent.com/968949/49733873-f9b2e900-fc82-11e8-9e97-801e80cee17f.png)

After:

![screenshot from 2018-12-10 13-52-35](https://user-images.githubusercontent.com/968949/49733881-fe779d00-fc82-11e8-98b6-d7adce4816e9.png)



