### PR TITLE
Add watchlists specs for Bootstrap

### DIFF
--- a/src/api/app/views/layouts/webui2/_watchlist_dropdown.html.haml
+++ b/src/api/app/views/layouts/webui2/_watchlist_dropdown.html.haml
@@ -5,7 +5,7 @@
     List of projects you are watching
   .dropdown-divider
   - if params[:project]
-    %a.dropdown-item{ href: project_toggle_watch_path(params[:project]) }
+    %a.dropdown-item#toggle-watch{ href: project_toggle_watch_path(params[:project]) }
       - if User.current.watches? params[:project]
         %p.mb-0
           Remove this project from Watchlist
@@ -18,7 +18,7 @@
           Watch this project
     .dropdown-divider
   - User.current.watched_project_names.each_with_index do |project, index|
-    = link_to project_show_path(project), class: "dropdown-item text-wrap text-word-break-all #{'border-top' unless index.zero?}" do
+    = link_to project_show_path(project), class: "dropdown-item project-link text-wrap text-word-break-all #{'border-top' unless index.zero?}" do
       %i.fa.fa-cubes.fa.text-secondary.pt-2
       %span.small
         = project

--- a/src/api/spec/bootstrap/features/webui/watchlists_spec.rb
+++ b/src/api/spec/bootstrap/features/webui/watchlists_spec.rb
@@ -1,0 +1,56 @@
+require 'browser_helper'
+
+RSpec.feature 'Watchlists', type: :feature, js: true do
+  let(:user) { create(:confirmed_user, login: 'kody') }
+  let(:project) { create(:project, name: 'watchlist_test_project') }
+  let(:user_with_watched_project) do
+    other_user = create(:confirmed_user, login: 'brian')
+    other_user.watched_projects << create(:watched_project,
+                                          project: create(:project, name: "#{other_user.login}_s_watched_project"))
+    other_user
+  end
+
+  scenario 'add projects to watchlist' do
+    login user
+    visit project_show_path(user.home_project)
+
+    click_on('Watchlist')
+    expect(page).to have_content('List of projects you are watching')
+    expect(page).to have_css('a.dropdown-item.project-link', count: 0)
+
+    expect(page).to have_css('#toggle-watch', text: 'Add this project to Watchlist')
+    find('#toggle-watch').click
+
+    click_on('Watchlist')
+    expect(page).to have_css('a.dropdown-item.project-link', text: user.home_project_name)
+    expect(page).to have_css('a.dropdown-item.project-link', count: 1)
+
+    visit project_show_path(project: project.name)
+    click_on('Watchlist')
+    expect(page).to have_css('#toggle-watch', text: 'Add this project to Watchlist')
+    find('#toggle-watch').click
+
+    click_on('Watchlist')
+    expect(page).to have_css('a.dropdown-item.project-link', text: user.home_project_name)
+    expect(page).to have_css('a.dropdown-item.project-link', text: project.name)
+    expect(page).to have_css('a.dropdown-item.project-link', count: 2)
+  end
+
+  scenario 'remove projects from watchlist' do
+    login user_with_watched_project
+    visit project_show_path(project: 'brian_s_watched_project')
+
+    click_on('Watchlist')
+    expect(page).to have_content('List of projects you are watching')
+    expect(page).to have_css('a.dropdown-item.project-link', text: 'brian_s_watched_project')
+    expect(page).to have_css('a.dropdown-item.project-link', count: 1)
+    expect(page).to have_css('#toggle-watch', text: 'Remove this project from Watchlist')
+
+    find('#toggle-watch').click
+
+    visit project_show_path(project: 'brian_s_watched_project')
+    click_on('Watchlist')
+    expect(page).to have_css('a.dropdown-item.project-link', count: 0)
+    expect(page).to have_css('#toggle-watch', text: 'Add this project to Watchlist')
+  end
+end

--- a/src/api/spec/features/webui/watchlists_spec.rb
+++ b/src/api/spec/features/webui/watchlists_spec.rb
@@ -11,6 +11,8 @@ RSpec.feature 'Watchlists', type: :feature, js: true do
   end
 
   scenario 'add projects to watchlist' do
+    skip_if_bootstrap
+
     login user
     visit project_show_path(user.home_project)
 
@@ -37,6 +39,8 @@ RSpec.feature 'Watchlists', type: :feature, js: true do
   end
 
   scenario 'remove projects from watchlist' do
+    skip_if_bootstrap
+
     login user_with_watched_project
     visit project_show_path(project: 'brian_s_watched_project')
 


### PR DESCRIPTION
The HTML/CSS is too different to adapt the specs from the old UI