### PR TITLE
Enable sql series for influxdb-rails gem

### DIFF
--- a/src/api/config/initializers/influxdb_rails.rb
+++ b/src/api/config/initializers/influxdb_rails.rb
@@ -1,11 +1,11 @@
 InfluxDB::Rails.configure do |config|
-  config.influxdb_database = CONFIG['influxdb_database']
-  config.influxdb_username = CONFIG['influxdb_username']
-  config.influxdb_password = CONFIG['influxdb_password']
-  config.influxdb_hosts    = CONFIG['influxdb_hosts'] || [] # default is otherwise localhost
-  config.influxdb_port     = CONFIG['influxdb_port']
-  config.retry             = CONFIG['influxdb_retry']
-  config.use_ssl           = CONFIG['influxdb_ssl']
-
-  config.time_precision = CONFIG['influxdb_time_precision']
+  config.influxdb_database   = CONFIG['influxdb_database']
+  config.influxdb_username   = CONFIG['influxdb_username']
+  config.influxdb_password   = CONFIG['influxdb_password']
+  config.influxdb_hosts      = CONFIG['influxdb_hosts'] || [] # default is otherwise localhost
+  config.influxdb_port       = CONFIG['influxdb_port']
+  config.retry               = CONFIG['influxdb_retry']
+  config.use_ssl             = CONFIG['influxdb_ssl']
+  config.time_precision      = CONFIG['influxdb_time_precision']
+  config.series_name_for_sql = 'rails.sql'
 end


### PR DESCRIPTION
because it is disabled by default and provides useful information.


