### PR TITLE
Disable RuboCop RSpec/MultipleExpectations for feature specs

### DIFF
--- a/src/api/.rubocop.yml
+++ b/src/api/.rubocop.yml
@@ -53,6 +53,12 @@ RSpec/FilePath:
   Exclude:
     - 'spec/models/obs_factory/distribution_strategy_opensuse_leap15_spec.rb'
 
+# We sometimes have a lot of expectations when testing complete workflows
+RSpec/MultipleExpectations:
+  Exclude:
+    - 'spec/features/**/*.rb'
+    - 'spec/bootstrap/features/**/*.rb'
+
 Rails/HasAndBelongsToMany:
   Enabled: false
 


### PR DESCRIPTION
Following a discussion we had here: https://github.com/openSUSE/open-build-service/pull/6502/files#r240317760