### PR TITLE
Preselect group_ids to ease SQL query for involved_packages

### DIFF
--- a/src/api/app/models/user.rb
+++ b/src/api/app/models/user.rb
@@ -639,12 +639,12 @@ class User < ApplicationRecord
   end
 
   def involved_projects
-    Project.for_user(id).or(Project.for_group(groups))
+    Project.for_user(id).or(Project.for_group(group_ids))
   end
 
   # lists packages maintained by this user and are not in maintained projects
   def involved_packages
-    Package.for_user(id).or(Package.for_group(groups)).where.not(project: involved_projects)
+    Package.for_user(id).or(Package.for_group(group_ids)).where.not(project: involved_projects)
   end
 
   # list packages owned by this user.


### PR DESCRIPTION
Possibly there are other ways but this way mariadb is no
longer using the role_id key but merges user_id and group_id
index hits - which are way less than all maintainers checked
by where

Fixes #6548
500ms -> 10ms
