### PR TITLE
Ordinalize the dates on the project pulse page

### DIFF
--- a/src/api/app/helpers/webui/project_helper.rb
+++ b/src/api/app/helpers/webui/project_helper.rb
@@ -4,13 +4,15 @@ module Webui::ProjectHelper
   protected
 
   def pulse_period(range)
-    start = if range == 'month'
-              Time.zone.today.prev_month.strftime('%B, %e')
-            else
-              Time.zone.today.prev_week.strftime('%B, %e')
-            end
+    end_time = Time.zone.today
 
-    "#{Time.zone.today.strftime('%B, %e')} – #{start}"
+    start_time = if range == 'month'
+                   end_time.prev_month
+                 else
+                   end_time.prev_week
+                 end
+
+    "#{start_time.strftime("%B, #{start_time.day.ordinalize} %Y")} – #{end_time.strftime("%B, #{end_time.day.ordinalize} %Y")}"
   end
 
   def show_status_comment(comment, package, firstfail, comments_to_clear)


### PR DESCRIPTION
I discovered this amazing method today: https://guides.rubyonrails.org/active_support_core_extensions.html#ordinalize

Also put the dates in an ascending order and added the year

Before:
![before](https://user-images.githubusercontent.com/1102934/49790582-e198a380-fd2e-11e8-987f-9f1ef3f83d5c.png)

After:
![after](https://user-images.githubusercontent.com/1102934/49791925-c0858200-fd31-11e8-98d2-aa33a4974275.png)