### PR TITLE
Fix autoloading for backend InfluxDB instrumentation

### DIFF
--- a/src/api/lib/backend/backend.rb
+++ b/src/api/lib/backend/backend.rb
@@ -12,6 +12,8 @@ end
 
 require 'benchmark'
 require 'api_exception'
+require_dependency 'remember_location'
+require_dependency 'instrumentation'
 require_dependency 'connection'
 require_dependency 'connection_helper'
 require_dependency 'error'

--- a/src/api/lib/backend/connection_helper.rb
+++ b/src/api/lib/backend/connection_helper.rb
@@ -1,5 +1,3 @@
-require 'remember_location'
-
 module Backend
   # Module that holds the wrapping methods for http requests, are mainly used for simplify the calculation of urls.
   #

--- a/src/api/lib/backend/logger.rb
+++ b/src/api/lib/backend/logger.rb
@@ -1,5 +1,3 @@
-require_relative 'instrumentation'
-
 module Backend
   # Class that implements a logger to write output in the backend logs
   class Logger


### PR DESCRIPTION
we should not mix require & autoload. The backend directory already gets autoloaded
which caused some weird autoloading errors which this PR will fix.

