### PR TITLE
Change field name for backend influx subscriber

### DIFF
--- a/src/api/lib/influxdb_obs/obs/middleware/backend_subscriber.rb
+++ b/src/api/lib/influxdb_obs/obs/middleware/backend_subscriber.rb
@@ -33,7 +33,7 @@ module InfluxDB
         end
 
         def values(runtime)
-          { value: ((runtime || 0) * 1000).ceil }
+          { runtime: ((runtime || 0) * 1000).ceil }
         end
 
         def tags(data)

--- a/src/api/spec/lib/influx_db/obs/middleware/backend_subscriber_spec.rb
+++ b/src/api/spec/lib/influx_db/obs/middleware/backend_subscriber_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe InfluxDB::OBS::Middleware::BackendSubscriber do
     let(:result) do
       {
         values: {
-          value: 2000
+          runtime: 2000
         },
         tags: {
           http_status_code: 200,


### PR DESCRIPTION
In 3473cb722e07b3e9235b538777fb1f80e373bb97 we changed from float to int datatype.
In InfluxDB it is not possible to change the field type easily. The easiest approach
is to just use a different field name which we just do now.

