### PR TITLE
Center text in project monitor table

### DIFF
--- a/src/api/app/views/webui2/webui/project/monitor.html.haml
+++ b/src/api/app/views/webui2/webui/project/monitor.html.haml
@@ -23,7 +23,7 @@
               %th
               - @repohash.sort.each do |_repo, archlist|
                 - archlist.sort.each do |arch|
-                  %th
+                  %th.text-center
                     = arch
           %tbody
             - @packagenames.each do |packname|
@@ -32,7 +32,7 @@
                   = link_to word_break(packname, 40), controller: :package, action: :show, package: packname, project: @project.to_s
                 - @repohash.sort.each do |repo, archlist|
                   - archlist.sort.each do |arch|
-                    %td
+                    %td.text-center
                       = webui2_arch_repo_table_cell(repo, arch, packname, nil, false)
 :javascript
   setupProjectMonitor();


### PR DESCRIPTION
Fixes #6580

Before:
![before](https://user-images.githubusercontent.com/1102934/49865227-af597580-fe04-11e8-9273-fb07f2a0cb96.png)

After:
![after](https://user-images.githubusercontent.com/1102934/49865235-b2ecfc80-fe04-11e8-98f5-078f9fbf2e5d.png)