### PR TITLE
Set 0 as a default value for pulse failed/succeeded builds

### DIFF
--- a/src/api/app/views/webui2/webui/projects/pulse/_pulse_list_builds.html.haml
+++ b/src/api/app/views/webui2/webui/projects/pulse/_pulse_list_builds.html.haml
@@ -12,10 +12,10 @@
     builds in the last 24 hours
   of which
   %b.text-danger
-    = builds['build_fail']
+    = builds.fetch('build_fail', 0)
     failed
   and
   %b.text-success
-    = builds['build_success']
+    = builds.fetch('build_success', 0)
     succeeded
   \.


### PR DESCRIPTION
This is an issue which was reported to us following our announcement to the opensuse-buildservice@opensuse.org mailing list.

Take note that normally, the view doesn't display the builds information when no builds are present. However, to prove that it's an issue and to show the fix, I've forced this to be displayed (it's not included in the changes though, it was just to take the screenshots below...)

Before (missing zeroes):
![missing-zeroes](https://user-images.githubusercontent.com/1102934/49866009-c8fbbc80-fe06-11e8-9e40-8e1809e87d6a.png)

After (with zeroes):
![after](https://user-images.githubusercontent.com/1102934/49866025-d31dbb00-fe06-11e8-98b3-3a91221eb0c0.png)