### PR TITLE
Fix smoke tests, after some literals got modified

### DIFF
--- a/dist/t/spec/features/0030_project_spec.rb
+++ b/dist/t/spec/features/0030_project_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe "Project" do
     within("div#subheader") do
       click_link('Create Home')
     end
-    first('input[type=submit]').click # 'Create Project' for 2.8 and 2.9. 'Accept' for master
+    page.has_button?('Create Project') ? click_button('Create Project') : click_button('Accept')
     expect(page).to have_content("Project 'home:Admin' was created successfully")
   end
 

--- a/dist/t/spec/features/0040_package_spec.rb
+++ b/dist/t/spec/features/0040_package_spec.rb
@@ -13,11 +13,11 @@ RSpec.describe "Package" do
     within("div#subheader") do
       click_link('Home Project')
     end
-    click_link('Create package')
+    page.has_link?('Create package') ? click_link('Create package') : click_link('Create Package')
     fill_in 'name', with: 'ctris'
     fill_in 'title', with: 'ctris'
     fill_in 'description', with: 'ctris'
-    click_button('Save changes')
+    page.has_button?('Save changes') ? click_button('Save changes') : click_button('Accept')
     expect(page).to have_content("Package 'ctris' was created successfully")
   end
 
@@ -42,19 +42,19 @@ RSpec.describe "Package" do
     within("div#subheader") do
       click_link('Home Project')
     end
-    click_link('Branch existing package')
+    page.has_link?('Branch existing package') ? click_link('Branch existing package') : click_link('Branch Existing Package')
     fill_in 'linked_project', with: 'openSUSE.org:openSUSE:Tools'
     fill_in 'linked_package', with: 'build'
     # Do not wait for autocomplete
     page.execute_script("$('input[type=\"submit\"]').prop('disabled', false)")
-    click_button('Create Branch')
+    page.has_button?('Create Branch') ? click_button('Create Branch') : click_button('Accept')
     expect(page).to have_content('build.spec')
   end
 
   it 'should be able to delete' do
     click_link('Delete package')
     expect(page).to have_content('Do you really want to delete this package?')
-    click_button('Ok')
+    page.has_button?('Ok') ? click_button('Ok') : click_button('Accept')
     expect(page).to have_content('Package was successfully removed.')
   end
 


### PR DESCRIPTION
Smoke test, those run in [openQA](https://openqa.opensuse.org/group_overview/17), are adapted to be run in versions 2.8 and 2.9 of OBS, with old literals, and in master branch, with new literals.
