### PR TITLE
Improve Package#show performance

### DIFF
--- a/src/api/Gemfile
+++ b/src/api/Gemfile
@@ -78,6 +78,8 @@ gem 'addressable'
 gem 'builder'
 # to write the rails metrics directly into InfluxDB.
 gem 'influxdb-rails', '>=1.0.0.beta2'
+# for client side time ago
+gem 'rails-timeago', '~> 2.0'
 
 group :development, :production do
   # to have the delayed job daemon

--- a/src/api/Gemfile.lock
+++ b/src/api/Gemfile.lock
@@ -303,6 +303,9 @@ GEM
       nokogiri (>= 1.6)
     rails-html-sanitizer (1.0.4)
       loofah (~> 2.2, >= 2.2.2)
+    rails-timeago (2.16.0)
+      actionpack (>= 3.1)
+      activesupport (>= 3.1)
     rails_tokeninput (1.7.0)
       railties (>= 3.1.0)
     railties (5.2.2)
@@ -514,6 +517,7 @@ DEPENDENCIES
   pundit
   rails (~> 5.2.0)
   rails-controller-testing
+  rails-timeago (~> 2.0)
   rails_tokeninput (>= 1.6.1.rc1)
   rantly (>= 1.1.0)
   rdoc

--- a/src/api/app/assets/javascripts/webui/application.js.erb
+++ b/src/api/app/assets/javascripts/webui/application.js.erb
@@ -26,6 +26,7 @@
 //= require moment
 //= require mousetrap
 //= require peek
+//= require rails-timeago
 //
 //= require webui/keybindings.js.coffee
 //= require webui/application/bento/script.js

--- a/src/api/app/assets/javascripts/webui2/application.js
+++ b/src/api/app/assets/javascripts/webui2/application.js
@@ -43,3 +43,4 @@
 //= require webui2/package-view_file.js
 //= require webui2/staging_workflow.js
 //= require webui2/project_monitor.js
+//= require rails-timeago

--- a/src/api/app/controllers/webui/package_controller.rb
+++ b/src/api/app/controllers/webui/package_controller.rb
@@ -86,7 +86,7 @@ class Webui::PackageController < Webui::WebuiController
 
     @comments = @package.comments.includes(:user)
     @comment = Comment.new
-    @services = Backend::Api::Sources::Package.service(@project.name, @package.name)
+    @services = @files.any? { |file| file[:name] == '_service' }
 
     switch_to_webui2
   end

--- a/src/api/app/views/webui/package/_file.html.erb
+++ b/src/api/app/views/webui/package/_file.html.erb
@@ -1,0 +1,26 @@
+<tr id="file-<%= valid_xml_id(file[:name]) %>">
+  <td>
+    <% link_opts = { action: :view_file, project: project, package: package, filename: file[:name], expand: expand }
+        unless @is_current_rev
+          link_opts[:rev] = file[:srcmd5]
+        end %>
+    <%= link_to_if(file[:viewable], nbsp(file[:name]), link_opts) %>
+  </td>
+  <td><span class="hidden"><%= file[:size].rjust(10, '0') %></span><%= human_readable_fsize(file[:size]) %>
+  </td>
+  <td><span class="hidden"><%= file[:mtime] %></span><%= timeago_tag Time.at(file[:mtime].to_i) %>
+  </td>
+  <!-- limit download for anonymous user to avoid getting killed by crawlers -->
+  <td><%= if !User.current.is_nobody? || file[:size].to_i < (4 * 1024 * 1024)
+            link_to sprite_tag('page_white_put', title: 'Download File'),
+                    file_url(project.name, package.name, file[:name], file[:srcmd5])
+          end %>
+    <% if removable_file?(file_name: file[:name], package: package) %>
+        <% if User.current.can_modify? package %>
+            <%= link_to sprite_tag('page_white_delete', title: 'Remove File'), {:action => :remove_file, :project => project.to_param,
+                                                                                :package => package.to_param, :filename => file[:name]},
+                        {data: {confirm: "Really remove file '#{file[:name]}'?"}, :method => :post} %>
+        <% end %>
+    <% end %>
+  </td>
+</tr>

--- a/src/api/app/views/webui/package/_files_view.html.erb
+++ b/src/api/app/views/webui/package/_files_view.html.erb
@@ -9,34 +9,7 @@
       </tr>
       </thead>
       <tbody>
-      <% @files.each do |file| %>
-          <tr id="file-<%= valid_xml_id(file[:name]) %>">
-            <td>
-              <% link_opts = {action: :view_file, project: @project, package: @package, filename: file[:name], expand: @expand}
-                 unless @is_current_rev
-                   link_opts[:rev] = file[:srcmd5]
-                 end %>
-              <%= link_to_if(file[:viewable], nbsp(file[:name]), link_opts) %>
-            </td>
-            <td><span class="hidden"><%= file[:size].rjust(10, '0') %></span><%= human_readable_fsize(file[:size]) %>
-            </td>
-            <td><span class="hidden"><%= file[:mtime] %></span><%= fuzzy_time_string(Time.at(file[:mtime].to_i).to_s) %>
-            </td>
-            <!-- limit download for anonymous user to avoid getting killed by crawlers -->
-            <td><%= if !User.current.is_nobody? || file[:size].to_i < (4 * 1024 * 1024)
-                      link_to sprite_tag('page_white_put', title: 'Download File'),
-                              file_url(@project.name, @package.name, file[:name], file[:srcmd5])
-                    end %>
-              <% if removable_file?(file_name: file[:name], package: @package) %>
-                  <% if User.current.can_modify? @package %>
-                      <%= link_to sprite_tag('page_white_delete', title: 'Remove File'), {:action => :remove_file, :project => @project.to_param,
-                                                                                          :package => @package.to_param, :filename => file[:name]},
-                                  {data: {confirm: "Really remove file '#{file[:name]}'?"}, :method => :post} %>
-                  <% end %>
-              <% end %>
-            </td>
-          </tr>
-      <% end %>
+        <%= render partial: 'file', collection: @files, cached: true, locals: { project: @project, package: @package, expand: @expand } %>
       </tbody>
     </table>
     <% content_for :ready_function do %>

--- a/src/api/app/views/webui2/webui/package/_file.html.haml
+++ b/src/api/app/views/webui2/webui/package/_file.html.haml
@@ -1,0 +1,24 @@
+- can_be_removed = removable_file?(file_name: file[:name], package: package) && User.current.can_modify?(package)
+%tr{ id: "file-#{valid_xml_id(file[:name])}" }
+  %td.text-word-break-all
+    - link_opts = { action: :view_file, project: project, package: package, filename: file[:name], expand: expand }
+    - unless is_current_rev
+      - link_opts[:rev] = file[:srcmd5]
+    = link_to_if(file[:viewable], nbsp(file[:name]), link_opts)
+  %td.text-nowrap
+    %span.d-none= file[:size].rjust(10, '0')
+    = human_readable_fsize(file[:size])
+  %td.text-nowrap
+    = timeago_tag Time.at(file[:mtime].to_i)
+  / limit download for anonymous user to avoid getting killed by crawlers
+  %td.text-center
+    - if !User.current.is_nobody? || file[:size].to_i < 4.megabytes
+      = link_to(file_url(project.name, package.name, file[:name], file[:srcmd5]), title: 'Download file') do
+        %i.fas.fa-download.text-secondary
+    - if can_be_removed
+      = link_to('#', data: { toggle: 'modal', target: "#delete-file-modal-#{file_counter}" },
+                title: 'Delete file') do
+        %i.fas.fa-times-circle.text-danger
+- if can_be_removed
+  = render(partial: 'delete_file_dialog',
+            locals: { project: project.to_param, package: package.to_param, filename: file[:name], file_id: file_counter })

--- a/src/api/app/views/webui2/webui/package/_files_view.html.haml
+++ b/src/api/app/views/webui2/webui/package/_files_view.html.haml
@@ -8,32 +8,8 @@
           %th Changed
           %th Actions
       %tbody
-        - files.each_with_index do |file, index|
-          - can_be_removed = removable_file?(file_name: file[:name], package: package) && User.current.can_modify?(package)
-          %tr{ id: "file-#{valid_xml_id(file[:name])}" }
-            %td.text-word-break-all
-              - link_opts = { action: :view_file, project: project, package: package, filename: file[:name], expand: expand }
-              - unless is_current_rev
-                - link_opts[:rev] = file[:srcmd5]
-              = link_to_if(file[:viewable], nbsp(file[:name]), link_opts)
-            %td.text-nowrap
-              %span.d-none= file[:size].rjust(10, '0')
-              = human_readable_fsize(file[:size])
-            %td.text-nowrap
-              %span.d-none= file[:mtime]
-              = fuzzy_time_string(Time.at(file[:mtime].to_i).to_s)
-            / limit download for anonymous user to avoid getting killed by crawlers
-            %td.text-center
-              - if !User.current.is_nobody? || file[:size].to_i < 4.megabytes
-                = link_to(file_url(project.name, package.name, file[:name], file[:srcmd5]), title: 'Download file') do
-                  %i.fas.fa-download.text-secondary
-              - if can_be_removed
-                = link_to('#', data: { toggle: 'modal', target: "#delete-file-modal-#{index}" },
-                          title: 'Delete file') do
-                  %i.fas.fa-times-circle.text-danger
-          - if can_be_removed
-            = render(partial: 'delete_file_dialog',
-                      locals: { project: project.to_param, package: package.to_param, filename: file[:name], file_id: index })
+        = render partial: 'file', collection: files, cached: true,
+        locals: { package: package, project: project, expand: expand, is_current_rev: is_current_rev }
   - else
     %i This package has no files yet
   - if User.current.can_modify?(package)


### PR DESCRIPTION
InfluxDB performance measuring showed that this view is a bottleneck on Package#show with
a mean render time of ~ 280 ms (bootstrap) and 160 ms (bentoo). Therefore we
introduce now collection caching.

We also need to introduce timeago_tag jquery gem to be able to cache the table
otherwise the timeago would be cached as well causing wrong results.

![selection_011](https://user-images.githubusercontent.com/3799140/49875547-8eebe400-fe21-11e8-8121-687efb17eec2.png)

https://metrics.opensuse.org/d/Gpp3B1Pik/package-show-dashboard

