### PR TITLE
Remove OBS label from breadcrumbs

### DIFF
--- a/src/api/app/assets/stylesheets/webui2/breadcrumbs-component.scss
+++ b/src/api/app/assets/stylesheets/webui2/breadcrumbs-component.scss
@@ -8,4 +8,11 @@ ol.breadcrumb {
       color: $gray-600;
     }
   }
+
+  & li.breadcrumb-anchor {
+    font-size: 0.9rem;
+    & a {
+      color: $gray-600;
+    }
+  }
 }

--- a/src/api/app/views/webui2/webui/main/_breadcrumb_items.html.haml
+++ b/src/api/app/views/webui2/webui/main/_breadcrumb_items.html.haml
@@ -1,9 +1,5 @@
 - home_title = @configuration ? @configuration['title'] : 'Open Build Service'
-- if current_page?(root_path)
-  %li.breadcrumb-item.active{ 'aria-current' => 'page' }
-    %i.fas.fa-home.mr-1
-    = home_title
-- else
-  %li.breadcrumb-item
-    %i.fas.fa-home.mr-1
-    = link_to home_title, root_path
+- unless current_page?(root_path)
+  %li.breadcrumb-anchor
+    = link_to(root_path, title: home_title) do
+      %i.fas.fa-home.mr-2


### PR DESCRIPTION
On each page the breadcrumb starts with 'openSUSE Build Service'.
This text is taking away quite some space from the breadcrumbs and it
is not adding much value. Users already know that they are looking at
the OBS when they reached this page.
In case they don't we still have the OBS logo in the navbar.

The link to the main page is now part of the 'home' icon that is
part of each breadcrumb.

-------------------

Depending on which page you are this looks a bit different. That's why I added a couple of screenshots:

On the main page:

![selection_004](https://user-images.githubusercontent.com/968949/50007859-97bfef80-ffb2-11e8-8a7b-a84af7f35b3e.png)


On the other pages:

![selection_005](https://user-images.githubusercontent.com/968949/50007868-a0b0c100-ffb2-11e8-8a33-73828433c39d.png)

![selection_006](https://user-images.githubusercontent.com/968949/50007876-a5757500-ffb2-11e8-8fe4-bf88d8964407.png)
