### PR TITLE
Use a default icon for avatar loading error

### DIFF
--- a/src/api/app/views/webui2/webui/comment/_content.html.haml
+++ b/src/api/app/views/webui2/webui/comment/_content.html.haml
@@ -17,3 +17,9 @@
 - if level > 3
   - comment.children.each do |children|
     = render partial: 'webui2/webui/comment/content', locals: { comment: children, commentable: commentable, level: level + 1 }
+
+:javascript
+  $('#comments img').one('error', function(){
+    $(this).after('<i class="fas fa-user-circle fa-2x ' + $(this).attr('class') + '"></i>');
+    $(this).remove();
+  });


### PR DESCRIPTION
Fixes #6183

Whenever an avatar is not loading somehow, we replace its `img` tag by a default icon. We keep the same classes as the avatar to be consistent.

I'm not entirely sure if this is the best approach, but I don't really have another in mind. If you validate this approach, I will move the Javascript to the assets and use it in the other pages where we also have avatars. This would be all done in this PR.

Example:
![preview](https://user-images.githubusercontent.com/1102934/49880744-17bc4d00-fe2d-11e8-929b-44b6549b1326.png)