### PR TITLE
Move 'unmerged sources' link to next line

### DIFF
--- a/src/api/app/views/webui2/webui/package/show.html.haml
+++ b/src/api/app/views/webui2/webui/package/show.html.haml
@@ -49,12 +49,14 @@
               = link_to('(show merged sources derived from linked package)', package_show_path(project: @project.name, package: @package.name,
                                                                                                rev: @revision_parameter, expand: '1'))
       - if @forced_unexpand.present?
-        %p.card-body
-          %i
-            Sources could not be expanded:
-            = @forced_unexpand
-          = link_to('Show unmerged sources', package_show_path(project: @project.name, package: @package.name,
-                                                               rev: @revision_parameter, expand: '0'))
+        .card-body
+          %p
+            %i
+              Sources could not be expanded:
+              = @forced_unexpand
+          %p
+            = link_to('Show unmerged sources', package_show_path(project: @project.name, package: @package.name,
+                                                                rev: @revision_parameter, expand: '0'))
       - else
         = render partial: 'files_view', locals: { project: @project,
                                                   package: @package,


### PR DESCRIPTION
because it was hard to see on the same line as the information.

New: 

![selection_013](https://user-images.githubusercontent.com/3799140/49880859-4afedc00-fe2d-11e8-959f-fc27ce6af838.png)

Old: 

![selection_014](https://user-images.githubusercontent.com/3799140/49880870-4e926300-fe2d-11e8-98a7-4482cd8fc2c4.png)
