### PR TITLE
Remove table info from Package datatable

### DIFF
--- a/src/api/app/views/webui2/webui/project/show.html.haml
+++ b/src/api/app/views/webui2/webui/project/show.html.haml
@@ -87,4 +87,4 @@
     = render partial: 'webui2/webui/request/delete_request_dialog', locals: { project: @project }
 
 = content_for :ready_function do
-  initializeDataTable('#packages-table, #inherited-packages-table');
+  initializeDataTable('#packages-table, #inherited-packages-table', { info: false });

--- a/src/api/app/views/webui2/webui/user/_involvement.html.haml
+++ b/src/api/app/views/webui2/webui/user/_involvement.html.haml
@@ -81,5 +81,5 @@
                     = link_to(project_name, project_show_path(project: project_name))
 
 = content_for :ready_function do
-  initializeDataTable('#involved-packages-table, #involved-projects-table, #owned-table');
+  initializeDataTable('#involved-packages-table, #involved-projects-table, #owned-table', { info: false });
 


### PR DESCRIPTION
because the number of packages is already included in the tab
and this removes some noise from the view.

![selection_015](https://user-images.githubusercontent.com/3799140/49881241-25be9d80-fe2e-11e8-8999-4cb945187788.png)

Old:

![selection_016](https://user-images.githubusercontent.com/3799140/49881245-29eabb00-fe2e-11e8-80d2-06deecd47c68.png)


