### PR TITLE
webui: use system monospace font for patch box again

### DIFF
--- a/src/api/app/assets/stylesheets/webui/application/cm2/suse.scss
+++ b/src/api/app/assets/stylesheets/webui/application/cm2/suse.scss
@@ -1,5 +1,5 @@
 .CodeMirror {
-  font-family: "Liberation Mono", monospace;
+  font-family: monospace;
   font-size: 9pt;
   height: auto;
 }
@@ -20,7 +20,6 @@
      Setting to hidden is ok here, the '.CodeMirror pre' elements
      aren't supposed to be scrollable... */
     overflow: hidden;
-    line-height: 1.1;
 }
 
 .toolbar {


### PR DESCRIPTION
Undo commit e31f2ca36b ("Use 'Liberation Mono' font for code
blocks"). I want my system's preference to be used again. Using
Liberation only there is also weird, because other places with
preformatted text, like the request review comment box, or the
package build log, still use the default monospace.

The "disappearing underscore" problem is caused by the line-height
directive, and *also* manifests in Chromium(!), starting with a
line-height of 105%. It turns out browsers have this weird idea that
the default line-height is "120%" and, as a result, any value less
than that shrinks the box. Throw out line-height for good.

If you haven't done so already, please read the CONTRIBUTING.md file to learn how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md

