### PR TITLE
Only use md5 and mtime as cache key

### DIFF
--- a/src/api/app/views/webui/package/_file.html.erb
+++ b/src/api/app/views/webui/package/_file.html.erb
@@ -11,7 +11,7 @@
   <td><span class="hidden"><%= file[:mtime] %></span><%= timeago_tag Time.at(file[:mtime].to_i), limit: 1.year.ago %>
   </td>
   <!-- limit download for anonymous user to avoid getting killed by crawlers -->
-  <td><%= if !nobody || file[:size].to_i < (4 * 1024 * 1024)
+  <td><%= if !nobody || file[:size].to_i < 4.megabytes
             link_to sprite_tag('page_white_put', title: 'Download File'),
                     file_url(project.name, package.name, file[:name], file[:srcmd5])
           end %>

--- a/src/api/app/views/webui/package/_file.html.erb
+++ b/src/api/app/views/webui/package/_file.html.erb
@@ -8,7 +8,7 @@
   </td>
   <td><span class="hidden"><%= file[:size].rjust(10, '0') %></span><%= human_readable_fsize(file[:size]) %>
   </td>
-  <td><span class="hidden"><%= file[:mtime] %></span><%= timeago_tag Time.at(file[:mtime].to_i) %>
+  <td><span class="hidden"><%= file[:mtime] %></span><%= timeago_tag Time.at(file[:mtime].to_i), limit: 1.year.ago %>
   </td>
   <!-- limit download for anonymous user to avoid getting killed by crawlers -->
   <td><%= if !nobody || file[:size].to_i < (4 * 1024 * 1024)

--- a/src/api/app/views/webui/package/_files_view.html.erb
+++ b/src/api/app/views/webui/package/_files_view.html.erb
@@ -13,7 +13,7 @@
           project: @project, package: @package, expand: @expand, is_current_rev: @is_current_rev,
           can_modify: User.current.can_modify?(@package), nobody: User.current.is_nobody?
         } %>
-        <%= render partial: 'file', collection: @files, cached: proc { |file| [file, file_locals].hash }, locals: file_locals
+        <%= render partial: 'file', collection: @files, cached: proc { |file| [file[:mtime], file[:md5], file_locals].hash }, locals: file_locals
         %>
       </tbody>
     </table>

--- a/src/api/app/views/webui2/webui/package/_file.html.haml
+++ b/src/api/app/views/webui2/webui/package/_file.html.haml
@@ -9,7 +9,7 @@
     %span.d-none= file[:size].rjust(10, '0')
     = human_readable_fsize(file[:size])
   %td.text-nowrap
-    = timeago_tag Time.at(file[:mtime].to_i)
+    = timeago_tag Time.at(file[:mtime].to_i), limit: 1.year.ago
   / limit download for anonymous user to avoid getting killed by crawlers
   %td.text-center
     - if !nobody || file[:size].to_i < 4.megabytes

--- a/src/api/app/views/webui2/webui/package/_files_view.html.haml
+++ b/src/api/app/views/webui2/webui/package/_files_view.html.haml
@@ -10,7 +10,7 @@
       %tbody
         - file_locals = { package: package, project: project, expand: expand, is_current_rev: is_current_rev,
         can_modify: User.current.can_modify?(package), nobody: User.current.is_nobody? }
-        = render partial: 'file', collection: files, cached: proc { |file| [file, file_locals].hash }, locals: file_locals
+        = render partial: 'file', collection: files, cached: proc { |file| [file[:mtime], file[:md5], file_locals].hash }, locals: file_locals
   - else
     %i This package has no files yet
   - if User.current.can_modify?(package)


### PR DESCRIPTION
Because for instance the srcmd5 does change for all files of a package
when the md5 of one file does change which invalidates all file caches.
However, in this case we only want to invalidate the cache of the single
file and not all.

