### PR TITLE
Update influxdb-rails to master branch

### DIFF
--- a/src/api/Gemfile
+++ b/src/api/Gemfile
@@ -77,7 +77,7 @@ gem 'addressable'
 # for XML builder
 gem 'builder'
 # to write the rails metrics directly into InfluxDB.
-gem 'influxdb-rails', '>=1.0.0.beta2'
+gem 'influxdb-rails', source: 'https://github.com/influxdata/influxdb-rails.git', branch: 'master', ref: '96b7eb18ee6b242b8f9cb99089e9b75c02f71bbe'
 # for client side time ago
 gem 'rails-timeago', '~> 2.0'
 

--- a/src/api/Gemfile.lock
+++ b/src/api/Gemfile.lock
@@ -1,5 +1,6 @@
 GEM
   remote: https://rubygems.org/
+  remote: https://github.com/influxdata/influxdb-rails.git/
   specs:
     actioncable (5.2.2)
       actionpack (= 5.2.2)
@@ -491,7 +492,7 @@ DEPENDENCIES
   haml
   haml-rails
   haml_lint
-  influxdb-rails (>= 1.0.0.beta2)
+  influxdb-rails!
   jquery-datatables
   jquery-rails
   jquery-ui-rails (~> 4.2.1)


### PR DESCRIPTION
To not store cache_hits and counts for render_collection series anymore.
These values have a high cardinality and therefore not usable as tags
which causes high load on metrics.o.o due to constantly indexing.

https://github.com/influxdata/influxdb-rails/pull/63

