### PR TITLE
Serve public assets in tests

### DIFF
--- a/src/api/config/environments/test.rb
+++ b/src/api/config/environments/test.rb
@@ -24,7 +24,7 @@ OBSApi::Application.configure do
   config.action_controller.perform_caching = false
 
   # Configure public file server for tests with Cache-Control for performance.
-  config.public_file_server.enabled = false
+  config.public_file_server.enabled = true
   config.public_file_server.headers = {
     'Cache-Control' => 'public, max-age=3600'
   }


### PR DESCRIPTION
This is rails default - and I actually have no idea why it works for anyone else. Without serving public files, I have no assets in tests :question: 
