### PR TITLE
Fix flag validation catching duplicates

### DIFF
--- a/src/api/app/models/flag.rb
+++ b/src/api/app/models/flag.rb
@@ -24,19 +24,12 @@ class Flag < ApplicationRecord
     errors.add(:status, 'Status needs to be enable or disable') unless status && (status.to_sym == :enable || status.to_sym == :disable)
   end
 
-  validate :validate_duplicates, on: :create
+  validate :validate_duplicates
   def validate_duplicates
-    flag_exists = Flag.where(
-      'status = ? AND repo = ? AND project_id = ? AND package_id = ? AND architecture_id = ? AND flag = ?',
-      status,
-      repo,
-      project_id,
-      package_id,
-      architecture_id,
-      flag
-    ).exists?
-
-    errors.add(:flag, 'Flag already exists') if flag_exists
+    flags = Flag.where(repo: repo, project_id: project_id, flag: flag,
+                       package_id: package_id, architecture_id: architecture_id)
+    flags = flags.where.not(id: id) unless new_record?
+    errors.add(:flag, 'Flag already exists') if flags.exists?
   end
 
   def self.default_status(flag_name)

--- a/src/api/app/models/flag.rb
+++ b/src/api/app/models/flag.rb
@@ -24,13 +24,7 @@ class Flag < ApplicationRecord
     errors.add(:status, 'Status needs to be enable or disable') unless status && (status.to_sym == :enable || status.to_sym == :disable)
   end
 
-  validate :validate_duplicates
-  def validate_duplicates
-    flags = Flag.where(repo: repo, project_id: project_id, flag: flag,
-                       package_id: package_id, architecture_id: architecture_id)
-    flags = flags.where.not(id: id) unless new_record?
-    errors.add(:flag, 'Flag already exists') if flags.exists?
-  end
+  validates :flag, uniqueness: { scope: [:project_id, :package_id, :architecture_id, :repo] }
 
   def self.default_status(flag_name)
     FlagHelper.default_for(flag_name)

--- a/src/api/db/data/20181214100207_remove_duplicated_flags.rb
+++ b/src/api/db/data/20181214100207_remove_duplicated_flags.rb
@@ -1,0 +1,22 @@
+class RemoveDuplicatedFlags < ActiveRecord::Migration[5.2]
+  def up
+    attributes = [:flag, :repo, :architecture_id, :package_id, :project_id]
+    # whenever 2 flags are for the same 'thing' (in _meta), we remove all but one
+    last_flags = Flag.group([:status] + attributes).select('MAX(id) as id')
+    # we need to pluck the ids (even though it's a lot) as you can't delete
+    # from within group queries
+    Flag.where.not(id: last_flags).in_batches(&:delete_all)
+
+    # now comes the ugly part - we need to delete conflicting flags. If both
+    # 'enable' and 'disable' are set, the backend prefers disable - so we can
+    # safely remove the 'enable' for those where we have 2
+    Flag.group(attributes).select(attributes).having('count(id) > 1').each do |f|
+      Flag.where(flag: f.flag, repo: f.repo, architecture_id: f.architecture_id,
+                 package_id: f.package_id, project_id: f.project_id, status: 'enable').delete_all
+    end
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/src/api/db/data/20181214100207_remove_duplicated_flags.rb
+++ b/src/api/db/data/20181214100207_remove_duplicated_flags.rb
@@ -5,7 +5,9 @@ class RemoveDuplicatedFlags < ActiveRecord::Migration[5.2]
     last_flags = Flag.group([:status] + attributes).select('MAX(id) as id')
     # we need to pluck the ids (even though it's a lot) as you can't delete
     # from within group queries
-    Flag.where.not(id: last_flags).in_batches(&:delete_all)
+    Flag.where.not(id: last_flags).in_batches do |batch|
+      Flag.where(id: batch.pluck(:id)).delete_all
+    end
 
     # now comes the ugly part - we need to delete conflicting flags. If both
     # 'enable' and 'disable' are set, the backend prefers disable - so we can

--- a/src/api/db/data_schema.rb
+++ b/src/api/db/data_schema.rb
@@ -1,2 +1,2 @@
 # encoding: UTF-8
-DataMigrate::Data.define(version: 20180214132015)
+DataMigrate::Data.define(version: 20181214100207)

--- a/src/api/spec/db/data/remove_duplicated_flags_spec.rb
+++ b/src/api/spec/db/data/remove_duplicated_flags_spec.rb
@@ -1,0 +1,28 @@
+require 'rails_helper'
+require Rails.root.join('db/data/20181214100207_remove_duplicated_flags.rb')
+
+RSpec.describe RemoveDuplicatedFlags, type: :migration do
+  let(:data_migration) { RemoveDuplicateRepositories.new }
+
+  describe 'up' do
+    let(:project) { create(:project) }
+    let!(:flag_1) { create(:build_flag, status: 'disable', project: project) }
+    let!(:flag_2) { create(:publish_flag, status: 'disable', project: project) }
+    let!(:flag_3) do
+      flag = build(:build_flag, status: 'disable', project: project)
+      flag.save(validate: false)
+      flag
+    end
+    let!(:flag_4) do
+      flag = build(:build_flag, status: 'enable', project: project)
+      flag.save(validate: false)
+      flag
+    end
+
+    before do
+      RemoveDuplicatedFlags.new.up
+    end
+
+    it { expect(project.flags).to contain_exactly(flag_3, flag_2) }
+  end
+end

--- a/src/api/test/unit/build_flag_test.rb
+++ b/src/api/test/unit/build_flag_test.rb
@@ -19,7 +19,7 @@ class BuildFlagTest < ActiveSupport::TestCase
 
     # create two new flags and save it.
     for i in 1..2 do
-      f = Flag.new(repo: "10.#{i}", status: 'enable', flag: 'build')
+      f = Flag.new(repo: "9.#{i}", status: 'enable', flag: 'build')
       f.architecture = @arch
       @project.flags << f
     end
@@ -31,7 +31,7 @@ class BuildFlagTest < ActiveSupport::TestCase
 
     f = @project.flags.of_type('build')[2]
 
-    assert_equal '10.1', f.repo
+    assert_equal '9.1', f.repo
     assert_equal @arch.id, f.architecture_id
     assert_equal 'enable', f.status
     assert_equal @project.id, f.project_id
@@ -40,7 +40,7 @@ class BuildFlagTest < ActiveSupport::TestCase
 
     f = @project.flags.of_type('build')[3]
 
-    assert_equal '10.2', f.repo
+    assert_equal '9.2', f.repo
     assert_equal @arch.id, f.architecture_id
     assert_equal 'enable', f.status
     assert_equal @project.id, f.project_id

--- a/src/api/test/unit/debug_flag_test.rb
+++ b/src/api/test/unit/debug_flag_test.rb
@@ -19,7 +19,7 @@ class DebuginfoFlagTest < ActiveSupport::TestCase
 
     # create two new flags and save it.
     for i in 1..2 do
-      f = Flag.new(repo: "10.#{i}", status: 'enable', position: i + 2, flag: 'debuginfo')
+      f = Flag.new(repo: "9.#{i}", status: 'enable', position: i + 2, flag: 'debuginfo')
       f.architecture = @arch
       @project.flags << f
     end
@@ -32,7 +32,7 @@ class DebuginfoFlagTest < ActiveSupport::TestCase
     f = @project.flags.of_type('debuginfo')[2]
     assert_kind_of Flag, f
 
-    assert_equal '10.1', f.repo
+    assert_equal '9.1', f.repo
     assert_equal @arch.id, f.architecture_id
     assert_equal 'enable', f.status
     assert_equal @project.id, f.project_id
@@ -42,7 +42,7 @@ class DebuginfoFlagTest < ActiveSupport::TestCase
     f = @project.flags.of_type('debuginfo')[3]
     assert_kind_of Flag, f
 
-    assert_equal '10.2', f.repo
+    assert_equal '9.2', f.repo
     assert_equal @arch.id, f.architecture_id
     assert_equal 'enable', f.status
     assert_equal @project.id, f.project_id
@@ -157,7 +157,7 @@ class DebuginfoFlagTest < ActiveSupport::TestCase
 
     # create new flag and save it, but set the references in different order as above.
     # The result should be the same.
-    f = Flag.new(repo: '10.2', status: 'enable', position: 4, flag: 'debuginfo')
+    f = Flag.new(repo: '9.2', status: 'enable', position: 4, flag: 'debuginfo')
     f.architecture = @arch
     @project.flags << f
 

--- a/src/api/test/unit/publish_flag_test.rb
+++ b/src/api/test/unit/publish_flag_test.rb
@@ -18,7 +18,7 @@ class PublishFlagTest < ActiveSupport::TestCase
 
     # create two new flags and save it.
     for i in 1..2 do
-      @project.flags.create(repo: "10.#{i}", status: 'enable', position: i + 2, flag: 'publish', architecture: @arch)
+      @project.flags.create(repo: "9.#{i}", status: 'enable', position: i + 2, flag: 'publish', architecture: @arch)
     end
 
     @project.reload
@@ -29,7 +29,7 @@ class PublishFlagTest < ActiveSupport::TestCase
     f = @project.flags.of_type('publish')[2]
     assert_kind_of Flag, f
 
-    assert_equal '10.1', f.repo
+    assert_equal '9.1', f.repo
     assert_equal @arch.id, f.architecture_id
     assert_equal 'enable', f.status
     assert_equal @project.id, f.project_id
@@ -39,7 +39,7 @@ class PublishFlagTest < ActiveSupport::TestCase
     f = @project.flags.of_type('publish')[3]
     assert_kind_of Flag, f
 
-    assert_equal '10.2', f.repo
+    assert_equal '9.2', f.repo
     assert_equal @arch.id, f.architecture_id
     assert_equal 'enable', f.status
     assert_equal @project.id, f.project_id


### PR DESCRIPTION
This has been broken since the introduction as
where('repo = ?', repo) for nil values compares with NULL,
which never exists. On top of that this also checked if
status was duplicated, which means you could have an
enabled and disabled status for the same field, which doesn't
make much sense :bowtie: 

We have a lot of duplicated flags by now, so we need
a data migration :eyes: 

Co-authored-by: @Ana06 

Fixes #6615
