### PR TITLE
Refactor delete of attribute

### DIFF
--- a/src/api/app/views/webui2/webui/attribute/_delete_dialog.html.haml
+++ b/src/api/app/views/webui2/webui/attribute/_delete_dialog.html.haml
@@ -1,13 +1,22 @@
-.modal.fade{ id: "delete-attribute-modal-#{attribute.id}", tabindex: -1, role: 'dialog', aria: { labelledby: 'delete-modal-label', hidden: true } }
+.modal.fade{ id: 'delete-attribute-modal', tabindex: -1, role: 'dialog', aria: { labelledby: 'delete-modal-label', hidden: true } }
   .modal-dialog.modal-dialog-centered{ role: 'document' }
     .modal-content
       .modal-header
         %h5.modal-title
           Delete attribute?
       .modal-body
-        %p Please confirm deletion of attribute #{attribute.fullname}
-        = form_tag(attrib_path(attribute), method: :delete) do
+        %p
+          Please confirm deletion of attribute
+          %span#fullname
+        = form_tag(nil, method: :delete) do
           .modal-footer
             %a.btn.btn-sm.btn-outline-secondary.px-4{ data: { dismiss: 'modal' } }
               Cancel
             = submit_tag('Delete', class: 'btn btn-sm btn-danger px-4')
+= content_for :ready_function do
+  :plain
+    $('#delete-attribute-modal').on('show.bs.modal', function (event) {
+      var link = $(event.relatedTarget);
+      $(this).find('#fullname').text(link.data('fullname'));
+      $(this).find('form').attr('action', link.data('action'));
+    });

--- a/src/api/app/views/webui2/webui/attribute/index.html.haml
+++ b/src/api/app/views/webui2/webui/attribute/index.html.haml
@@ -30,11 +30,9 @@
                   - if attribute.values_editable?
                     = link_to(edit_attribs_path(project: @project.name, package: @package, attribute: attribute.fullname), title: 'Edit values') do
                       %i.fas.fa-edit.text-secondary
-                  = link_to('#', data: { toggle: 'modal', target: "#delete-attribute-modal-#{attribute.id}" },
-                            title: 'Delete attribute') do
+                  = link_to('#', title: 'Delete attribute',
+                    data: { toggle: 'modal', target: '#delete-attribute-modal', action: attrib_path(attribute), fullname: attribute.fullname }) do
                     %i.fas.fa-times-circle.text-danger
-            - if policy(@container).update?
-              = render(partial: 'delete_dialog', locals: { attribute: attribute })
     - else
       %p
         %em No attributes set
@@ -44,3 +42,4 @@
         = link_to(new_attribs_path(project: @project.name, package: @package), title: 'Add a new attribute') do
           %i.fas.fa-plus-circle.text-primary
           Add a new attribute
+      = render(partial: 'delete_dialog')

--- a/src/api/app/views/webui2/webui/attribute/index.html.haml
+++ b/src/api/app/views/webui2/webui/attribute/index.html.haml
@@ -1,4 +1,5 @@
 - @pagetitle = "Attributes of #{@package ? "#{@package} (Project #{@project})" : "Project #{@project}"}"
+- can_update_container = policy(@container).update?
 
 .card
   = render(partial: "webui/#{@container.model_name.singular}/tabs", locals: { project: @project, package: @package })
@@ -11,7 +12,7 @@
           %tr
             %th.w-50 Attributes
             %th.w-25 Values
-            - if policy(@container).update?
+            - if can_update_container
               %th Actions
         %tbody
           - @attributes.each do |attribute|
@@ -25,7 +26,7 @@
                         %pre.d-inline= v.value
                   - unless attribute.issues.empty?
                     %li= attribute.issues.map(&:name).to_sentence
-              - if policy(@container).update?
+              - if can_update_container
                 %td
                   - if attribute.values_editable?
                     = link_to(edit_attribs_path(project: @project.name, package: @package, attribute: attribute.fullname), title: 'Edit values') do
@@ -37,7 +38,7 @@
       %p
         %em No attributes set
 
-    - if policy(@container).update?
+    - if can_update_container
       %p
         = link_to(new_attribs_path(project: @project.name, package: @package), title: 'Add a new attribute') do
           %i.fas.fa-plus-circle.text-primary

--- a/src/api/spec/bootstrap/features/webui/attributes_spec.rb
+++ b/src/api/spec/bootstrap/features/webui/attributes_spec.rb
@@ -31,8 +31,8 @@ RSpec.feature 'Bootstrap_Attributes', type: :feature, js: true do
 
           visit index_attribs_path(project: user.home_project_name)
           click_link 'Delete attribute'
-          expect(find("#delete-attribute-modal-#{attribute.id}")).to have_text('Delete attribute?')
-          within("#delete-attribute-modal-#{attribute.id} .modal-footer") do
+          expect(find('#delete-attribute-modal')).to have_text('Delete attribute?')
+          within('#delete-attribute-modal .modal-footer') do
             expect(page).to have_button('Delete')
             click_button('Delete')
           end


### PR DESCRIPTION
Instead of generating html code for each modal that asks for removing an attribute, only one modal is created. Arguments for the modal are passed with "data-*" attributes.

Following work started in #6608.

