### PR TITLE
Refactor delete of roles

### DIFF
--- a/src/api/app/views/webui2/shared/user_or_groups_roles/_delete_dialog.html.haml
+++ b/src/api/app/views/webui2/shared/user_or_groups_roles/_delete_dialog.html.haml
@@ -1,13 +1,27 @@
-.modal.fade{ id: "delete-role-modal-#{type}-#{object.id}", tabindex: -1, role: 'dialog', aria: { labelledby: 'delete-modal-label', hidden: true } }
+.modal.fade{ id: 'delete-role-modal', tabindex: -1, role: 'dialog', aria: { labelledby: 'delete-modal-label', hidden: true } }
   .modal-dialog.modal-dialog-centered{ role: 'document' }
     .modal-content
       .modal-header
         %h5.modal-title
-          Delete all roles of #{type}?
+          Delete all roles of
+          = succeed '?' do
+            %span.type
       .modal-body
-        %p Please confirm deletion of all roles of the #{type} '#{object}'
-        = form_tag(user_or_groups_roles_delete_path(project, type, object, package), method: :post) do
+        %p
+          Please confirm deletion of all roles of the
+          %span.type
+          = surround "'" do
+            %span.object
+        = form_tag(nil, method: :post) do
           .modal-footer
             %button.btn.btn-sm.btn-outline-secondary.px-4{ data: { dismiss: 'modal' } }
               Cancel
             = submit_tag('Delete', class: 'btn btn-sm btn-danger px-4')
+= content_for :ready_function do
+  :plain
+    $('#delete-role-modal').on('show.bs.modal', function (event) {
+      var link = $(event.relatedTarget);
+      $(this).find('.type').text(link.data('type'));
+      $(this).find('.object').text(link.data('object'));
+      $(this).find('form').attr('action', link.data('action'));
+    });

--- a/src/api/app/views/webui2/shared/user_or_groups_roles/_index.html.haml
+++ b/src/api/app/views/webui2/shared/user_or_groups_roles/_index.html.haml
@@ -33,6 +33,7 @@
     = link_to('#', data: { toggle: 'modal', target: '#add-user-role-modal' }, id: 'add-user', class: 'nav-link') do
       %i.fas.fa-plus-circle.text-primary
       Add User
+    = render(partial: 'webui2/shared/user_or_groups_roles/delete_dialog')
 
   %hr
 

--- a/src/api/app/views/webui2/shared/user_or_groups_roles/_list.html.haml
+++ b/src/api/app/views/webui2/shared/user_or_groups_roles/_list.html.haml
@@ -24,7 +24,7 @@
         = mail_to(record.email, subject: mail_subject) do
           %i.far.fa-envelope{ title: 'Send email to user' }
       - if user_is_maintainer
-        = link_to('#', data: { toggle: 'modal', target: "#delete-role-modal-#{type}-#{record.id}" }, class: "remove-#{type}") do
+        = link_to('#', class: "remove-#{type}",
+          data: { toggle: 'modal', target: '#delete-role-modal',
+          action: user_or_groups_roles_delete_path(project, type, record, package), type: type, object: record.to_s }) do
           %i.fas.fa-times-circle.text-danger{ title: "Delete all roles for #{type}" }
-  = render(partial: 'webui2/shared/user_or_groups_roles/delete_dialog',
-           locals: { project: project.to_param, package: package.to_param, type: type, object: record })


### PR DESCRIPTION
Instead of generating html code for each modal that asks for deleting a role, only one modal is created. Arguments for the modal are passed with "data-*" attributes.

Following work started in #6608.
