### PR TITLE
Do not use expensive hash keys for cheap queries

### DIFF
--- a/src/api/app/models/role.rb
+++ b/src/api/app/models/role.rb
@@ -40,13 +40,20 @@ class Role < ApplicationRecord
 
   scope :global, -> { where(global: true) }
 
+  after_save :delete_hashed_cache
+  after_destroy :delete_hashed_cache
+
   # Fetches all roles and stores them as a hash. Uses title attribute as hash key.
   #
   # {"Admin" => #<Role id:1>, "downloader" => #<Role id:2>, ... }
   def self.hashed
-    Rails.cache.fetch(Role.all.cache_key) do
+    Rails.cache.fetch('hashed_roles') do
       Hash[Role.all.map { |role| [role.title, role] }]
     end
+  end
+
+  def delete_hashed_cache
+    Rails.cache.delete('hashed_roles')
   end
 
   def self.find_by_title!(title)


### PR DESCRIPTION
Role.hashed uses Rails.all.cache_key - which is rather expensive

SELECT COUNT(*) AS `size`, MAX(`roles`.`updated_at`) AS timestamp FROM `roles`

to avoid querying 8 role titles. The problem is that all the
other code expects Role.hashed to be cheaper than querying the
database directly - which is no longer true with this approach.

E.g.

```
irb(main):001:0> Role.local_roles
   (0.2ms)  SELECT COUNT(*) AS `size`, MAX(`roles`.`updated_at`) AS timestamp FROM `roles`
   (0.3ms)  SELECT COUNT(*) AS `size`, MAX(`roles`.`updated_at`) AS timestamp FROM `roles`
   (0.2ms)  SELECT COUNT(*) AS `size`, MAX(`roles`.`updated_at`) AS timestamp FROM `roles`
   (0.2ms)  SELECT COUNT(*) AS `size`, MAX(`roles`.`updated_at`) AS timestamp FROM `roles`
   (0.2ms)  SELECT COUNT(*) AS `size`, MAX(`roles`.`updated_at`) AS timestamp FROM `roles`
```
I noticed these repeated queries when working on involved_packages
and wondered since then what is going on.
