### PR TITLE
Just fetch the flags and check if they are empty afterwards

### DIFF
--- a/src/api/app/helpers/flag_helper.rb
+++ b/src/api/app/helpers/flag_helper.rb
@@ -164,4 +164,16 @@ module FlagHelper
     end
     disabled
   end
+
+  def self.render(my_model, xml)
+    flags_sorted = my_model.flags.includes(:architecture).group_by(&:flag)
+
+    # the defined order is by type
+    FlagHelper.flag_types.each do |flag_name|
+      next unless flags_sorted.key?(flag_name)
+      xml.send(flag_name) do
+        flags_sorted[flag_name].each { |flag| flag.to_xml(xml) }
+      end
+    end
+  end
 end

--- a/src/api/app/views/models/_package.xml.builder
+++ b/src/api/app/views/models/_package.xml.builder
@@ -9,15 +9,7 @@ xml.package(name: my_model.name, project: my_model.project.name) do
 
   my_model.render_relationships(xml)
 
-  FlagHelper.flag_types.each do |flag_name|
-    flaglist = my_model.flags.of_type(flag_name)
-    next if flaglist.empty?
-    xml.send(flag_name) do
-      flaglist.each do |flag|
-        flag.to_xml(xml)
-      end
-    end
-  end
+  FlagHelper.render(my_model, xml)
 
   xml.url(my_model.url) if my_model.url.present?
   xml.bcntsynctag(my_model.bcntsynctag) if my_model.bcntsynctag.present?

--- a/src/api/app/views/models/_project.xml.builder
+++ b/src/api/app/views/models/_project.xml.builder
@@ -20,15 +20,7 @@ xml.project(project_attributes) do
   my_model.render_relationships(xml)
 
   repos = my_model.repositories.not_remote.sort { |a, b| b.name <=> a.name }
-  FlagHelper.flag_types.each do |flag_name|
-    flaglist = my_model.flags.of_type(flag_name)
-    next if flaglist.empty?
-    xml.send(flag_name) do
-      flaglist.each do |flag|
-        flag.to_xml(xml)
-      end
-    end
-  end
+  FlagHelper.render(my_model, xml)
 
   repos.each do |repo|
     params = {}


### PR DESCRIPTION
Using .empty? on a relation is a SQL query - but as we want
the flags anyway, querying them into an array and asking ruby
afterwards if the array is empty saves us one trip to the DB
for those flags that exist

```
  Flag Exists (0.7ms)  SELECT  1 AS one FROM `flags` WHERE `flags`.`package_id` = 3958965 AND `flags`.`flag` = 'lock' LIMIT 1
  Flag Exists (0.6ms)  SELECT  1 AS one FROM `flags` WHERE `flags`.`package_id` = 3958965 AND `flags`.`flag` = 'build' LIMIT 1
  Flag Load (0.2ms)  SELECT `flags`.* FROM `flags` WHERE `flags`.`package_id` = 3958965 AND `flags`.`flag` = 'build' ORDER BY `flags`.`position` ASC
  Flag Exists (0.6ms)  SELECT  1 AS one FROM `flags` WHERE `flags`.`package_id` = 3958965 AND `flags`.`flag` = 'publish' LIMIT 1
  Flag Load (0.2ms)  SELECT `flags`.* FROM `flags` WHERE `flags`.`package_id` = 3958965 AND `flags`.`flag` = 'publish' ORDER BY `flags`.`position` ASC
  Flag Exists (0.5ms)  SELECT  1 AS one FROM `flags` WHERE `flags`.`package_id` = 3958965 AND `flags`.`flag` = 'debuginfo' LIMIT 1
  Flag Exists (0.5ms)  SELECT  1 AS one FROM `flags` WHERE `flags`.`package_id` = 3958965 AND `flags`.`flag` = 'useforbuild' LIMIT 1
```

vs

```
  Flag Load (0.3ms)  SELECT `flags`.* FROM `flags` WHERE `flags`.`package_id` = 3958965 AND `flags`.`flag` = 'lock' ORDER BY `flags`.`position` ASC
  Flag Load (0.2ms)  SELECT `flags`.* FROM `flags` WHERE `flags`.`package_id` = 3958965 AND `flags`.`flag` = 'build' ORDER BY `flags`.`position` ASC
  Flag Load (0.3ms)  SELECT `flags`.* FROM `flags` WHERE `flags`.`package_id` = 3958965 AND `flags`.`flag` = 'publish' ORDER BY `flags`.`position` ASC
  Flag Load (0.2ms)  SELECT `flags`.* FROM `flags` WHERE `flags`.`package_id` = 3958965 AND `flags`.`flag` = 'debuginfo' ORDER BY `flags`.`position` ASC
  Flag Load (0.2ms)  SELECT `flags`.* FROM `flags` WHERE `flags`.`package_id` = 3958965 AND `flags`.`flag` = 'useforbuild' ORDER BY `flags`.`position` ASC
```
Note that we don't have an index on package_id *and* flag. So actually querying for just package_id and then doing the grep for flag within memory might even be faster. But as we normally don't have that many flags on a package, measuing the difference would be academical :)

