### PR TITLE
Cleanup breadcrumb CSS

### DIFF
--- a/src/api/app/assets/stylesheets/webui2/breadcrumbs-component.scss
+++ b/src/api/app/assets/stylesheets/webui2/breadcrumbs-component.scss
@@ -1,16 +1,9 @@
 ol.breadcrumb {
   padding-top: 0.5rem;
 
-  & li.breadcrumb-item {
+  & li {
     font-size: 0.9rem;
 
-    & a {
-      color: $gray-600;
-    }
-  }
-
-  & li.breadcrumb-anchor {
-    font-size: 0.9rem;
     & a {
       color: $gray-600;
     }

--- a/src/api/app/views/webui2/webui/main/_breadcrumb_items.html.haml
+++ b/src/api/app/views/webui2/webui/main/_breadcrumb_items.html.haml
@@ -1,5 +1,5 @@
 - home_title = @configuration ? @configuration['title'] : 'Open Build Service'
 - unless current_page?(root_path)
-  %li.breadcrumb-anchor
+  %li
     = link_to(root_path, title: home_title) do
       %i.fas.fa-home.mr-2


### PR DESCRIPTION
Style any link within the breadcrumbs the same, regardless of having the 'breadcrumb-item' class or not.

This is just a follow up of #6592 which was already merged when I realized that the CSS could be written in a simpler way.