### PR TITLE
Avoid .required? function in loops

### DIFF
--- a/src/api/app/controllers/status/checks_controller.rb
+++ b/src/api/app/controllers/status/checks_controller.rb
@@ -20,6 +20,7 @@ class Status::ChecksController < ApplicationController
 
     if @check.save
       @event_class.create(check_notify_params)
+      @checkable = @status_report.checkable
       render :show
     else
       render_error(status: 422, errorcode: 'invalid_check', message: "Could not save check: #{@check.errors.full_messages.to_sentence}")

--- a/src/api/app/views/status/checks/_check.xml.builder
+++ b/src/api/app/views/status/checks/_check.xml.builder
@@ -1,4 +1,4 @@
-builder.check(name: object.name, required: object.required?) do |check|
+builder.check(name: object.name, required: checkable.required_checks.include?(object.name)) do |check|
   check.state object.state
   check.short_description object.short_description
   check.url object.url

--- a/src/api/app/views/status/checks/show.xml.builder
+++ b/src/api/app/views/status/checks/show.xml.builder
@@ -1,1 +1,1 @@
-render(partial: 'check', locals: { builder: xml, object: @check })
+render(partial: 'check', locals: { builder: xml, object: @check, checkable: @checkable })

--- a/src/api/app/views/status/reports/show.xml.builder
+++ b/src/api/app/views/status/reports/show.xml.builder
@@ -1,6 +1,7 @@
 xml.status_report(uuid: @status_report.uuid) do |xml|
   @checks.each do |check|
-    render(partial: 'status/checks/check', locals: { builder: xml, object: check })
+    render(partial: 'status/checks/check', locals: { builder: xml, object: check,
+                                                     checkable: @status_report.checkable })
   end
 
   @missing_checks.each do |name|


### PR DESCRIPTION
The check's required function actually checks the checkable
of the status_report, which is rather expensive

```
  SELECT  `status_reports`.* FROM `status_reports` WHERE `status_reports`.`id` = 32 LIMIT 1  [["id", 32], ["LIMIT", 1]]
  SELECT  `repositories`.* FROM `repositories` WHERE `repositories`.`id` = 342446 LIMIT 1  [["id", 342446], ["LIMIT", 1]]
```
And this is done for every check in the report. While we already know
the checkable (the repository), so just pass it to the partial.

