### PR TITLE
Migrate project index page to bootstrap

### DIFF
--- a/src/api/app/assets/javascripts/webui2/application.js
+++ b/src/api/app/assets/javascripts/webui2/application.js
@@ -42,5 +42,6 @@
 //= require webui2/cm2/use-codemirror.js
 //= require webui2/package-view_file.js
 //= require webui2/staging_workflow.js
+//= require webui2/project.js
 //= require webui2/project_monitor.js
 //= require rails-timeago

--- a/src/api/app/assets/javascripts/webui2/project.js
+++ b/src/api/app/assets/javascripts/webui2/project.js
@@ -1,0 +1,29 @@
+function renderProjectsTable(length) { // jshint ignore:line
+  length = length || 25;
+  var projects = mainProjects;
+  if (!$('#excludefilter').is(":checked"))
+    projects = projects.concat(exclProjects);
+  var projecturl = $("#projects-table-wrapper").data("url");
+  $("#projects-table").DataTable({
+    "data": projects,
+    "columns": [
+      {
+        "title": "Name",
+        "width": "60%",
+        "className": "text-word-break-all",
+        "render": function (obj, type, dataRow) {
+          var url = projecturl.replace(/REPLACEIT/, dataRow[0]);
+          return '<a href="' + url + '">' + dataRow[0] + '</a>';
+        }
+      },
+      {
+        "title": "Title",
+        "width": "40%",
+        "className": "text-nowrap"
+      }
+    ],
+    "pageLength": length,
+    "stateSave": true,
+    "language": { "search": '', "searchPlaceholder": "Search..." }
+  });
+}

--- a/src/api/app/controllers/webui/project_controller.rb
+++ b/src/api/app/controllers/webui/project_controller.rb
@@ -51,6 +51,7 @@ class Webui::ProjectController < Webui::WebuiController
     if @spider_bot
       render :list_simple, status: params[:nextstatus]
     else
+      switch_to_webui2
       render :list, status: params[:nextstatus]
     end
   end

--- a/src/api/app/views/layouts/webui2/webui.html.haml
+++ b/src/api/app/views/layouts/webui2/webui.html.haml
@@ -17,6 +17,7 @@
       %style{ type: 'text/css' }
         = yield :head_style
     = javascript_tag do
+      = yield :head_javascript
       var _paq = _paq || [];
       $(function() { #{yield :ready_function} });
 

--- a/src/api/app/views/webui2/webui/project/list.html.haml
+++ b/src/api/app/views/webui2/webui/project/list.html.haml
@@ -1,0 +1,52 @@
+:ruby
+  @pagetitle = 'Public Projects'
+.card
+  - if @important_projects.present?
+    .card-body
+      %h3 Main Projects
+      .table-responsive
+        %table.table.table-sm.table-striped.table-bordered
+          %thead
+            %tr
+              %th Name
+              %th Title
+          %tbody
+            - @important_projects.each do |project|
+              %tr
+                %td
+                  = link_to(project.first, action: :show, project: project.first)
+                %td
+                  #{project.second}
+  .card-body
+    %h3= @pagetitle
+    %ul.list-inline
+      - if @show_all
+        %li.list-inline-item.mr-3
+          = link_to(projects_path) do
+            %i.fas.fa-toggle-on.text-primary
+            Exclude #{::Configuration.unlisted_projects_filter_description}
+      - else
+        %li.list-inline-item.mr-3
+          = link_to(projects_path(show_all: true)) do
+            %i.fas.fa-toggle-off.text-primary
+            Include #{::Configuration.unlisted_projects_filter_description}
+      - unless User.current.is_nobody?
+        %li.list-inline-item
+          = link_to(new_project_path) do
+            %i.fas.fa-plus-circle.text-primary
+            Add New Project
+    - cachekey = Digest::MD5.hexdigest(@projects.join)
+    - projecturl = project_show_path('REPLACEIT')
+    #project-list
+      - if @projects.blank?
+        %p
+          %i No projects found
+      - else
+        #projects-table-wrapper{ 'data-url' => projecturl }
+          %table.responsive.table.table-sm.table-striped.table-bordered.w-100#projects-table
+          - content_for :head_javascript do
+            - cache ['list_public_arrays', cachekey] do
+              var mainProjects = [ #{escape_nested_list(@projects)} ];
+              var exclProjects = [];
+          - content_for :ready_function do
+            renderProjectsTable();


### PR DESCRIPTION
The content of the public projects' table is added by javascript. We keep it like
it was with small changes only: the table itself is written by the view not by JS,
we add "Search" placeholder and remove some unnecessary params.

Co-authored-by: David Kang <dkang@suse.com>

Before:

![public projects open build service 2](https://user-images.githubusercontent.com/2581944/50096307-b541c300-0217-11e9-8bd7-c94cca9a4333.png)


After:

![public projects open build service](https://user-images.githubusercontent.com/2581944/50096068-292f9b80-0217-11e9-8f9d-9fb2329c0e4e.png)

