### PR TITLE
Remove Refresh button from requests page in bootstrap

### DIFF
--- a/src/api/app/views/webui2/shared/_requests_table.html.haml
+++ b/src/api/app/views/webui2/shared/_requests_table.html.haml
@@ -1,7 +1,3 @@
-.btn.btn-sm.btn-outline-primary.mb-2.result_reload{ title: 'Refresh', 'data-table': id }
-  Refresh
-  %i.fas.fa-sm.fa-sync-alt
-
 %table.responsive.requests-datatable.table.table-sm.table-striped.table-bordered.w-100{ data: { source: source_url,
   'page-length': local_assigns[:page_length] }, id: id }
   %thead


### PR DESCRIPTION
When we set some filters in requests' page and then click on Refresh,
all the filters get reset (back to default values). We also realized
that the Refresh functionality is not really needed. Therefore, we
decide to remove the button.

![requests for pro1 open build service](https://user-images.githubusercontent.com/2581944/50098642-9db90900-021c-11e9-9dd3-18be9f4d0352.png)
