### PR TITLE
Migrate project creation page to bootstrap

### DIFF
--- a/src/api/app/views/webui2/webui/project/_add_new_subproject_modal.html.haml
+++ b/src/api/app/views/webui2/webui/project/_add_new_subproject_modal.html.haml
@@ -1,8 +1,0 @@
-.modal.fade#add-new-subproject-modal{ tabindex: -1, role: 'dialog', aria: { labelledby: 'add-new-subproject-modal-label', hidden: true } }
-  .modal-dialog.modal-lg{ role: 'document' }
-    .modal-content
-      .modal-header
-        %h5.modal-title#add-new-subproject-modal-label
-          Create Subproject
-      .modal-body
-        = render partial: 'form', locals: { project: Project.new, namespace: project.name, configuration: configuration }

--- a/src/api/app/views/webui2/webui/project/_form.html.haml
+++ b/src/api/app/views/webui2/webui/project/_form.html.haml
@@ -9,7 +9,7 @@
             #{namespace}:
         = form.text_field(:name, required: true, class: 'form-control')
     - else
-      = form.label(:name, 'Project Name:', class: 'form-control')
+      = form.label(:name, 'Project Name:')
       = form.text_field(:name, required: true, class: 'form-control')
   .form-group
     = form.label(:title, 'Title:')

--- a/src/api/app/views/webui2/webui/project/_new_project_modal.html.haml
+++ b/src/api/app/views/webui2/webui/project/_new_project_modal.html.haml
@@ -1,0 +1,8 @@
+.modal.fade#new-project-modal{ tabindex: '-1', role: 'dialog', aria: { labelledby: 'new-project-modal-label', hidden: true } }
+  .modal-dialog.modal-lg{ role: 'document' }
+    .modal-content
+      .modal-header
+        %h5.modal-title#new-project-modal-label
+          Create New Project
+      .modal-body
+        = render partial: 'form', locals: { project: Project.new, configuration: configuration }

--- a/src/api/app/views/webui2/webui/project/_new_project_modal.html.haml
+++ b/src/api/app/views/webui2/webui/project/_new_project_modal.html.haml
@@ -3,6 +3,8 @@
     .modal-content
       .modal-header
         %h5.modal-title#new-project-modal-label
-          Create New Project
+          = local_assigns.key?(:project) ? 'Create Subproject' : 'Create Project'
       .modal-body
-        = render partial: 'form', locals: { project: Project.new, configuration: configuration }
+        - options = { project: Project.new, configuration: configuration }
+        - options[:namespace] = project.name if local_assigns.key?(:project)
+        = render partial: 'form', locals: options

--- a/src/api/app/views/webui2/webui/project/list.html.haml
+++ b/src/api/app/views/webui2/webui/project/list.html.haml
@@ -32,9 +32,11 @@
             Include #{::Configuration.unlisted_projects_filter_description}
       - unless User.current.is_nobody?
         %li.list-inline-item
-          = link_to(new_project_path) do
+          = link_to('#', data: { toggle: 'modal', target: '#new-project-modal' }) do
             %i.fas.fa-plus-circle.text-primary
             Add New Project
+          = render partial: 'new_project_modal', locals: { configuration: @configuration }
+
     - cachekey = Digest::MD5.hexdigest(@projects.join)
     - projecturl = project_show_path('REPLACEIT')
     #project-list

--- a/src/api/app/views/webui2/webui/project/subprojects.html.haml
+++ b/src/api/app/views/webui2/webui/project/subprojects.html.haml
@@ -16,7 +16,7 @@
           %p
             %i This project has no subprojects
         - if User.current.can_modify?(@project)
-          = link_to('#', data: { toggle: 'modal', target: '#add-new-subproject-modal' }, title: 'Add New Subproject', class: 'nav-link') do
+          = link_to('#', data: { toggle: 'modal', target: '#new-project-modal' }, class: 'nav-link') do
             %i.fas.fa-plus-circle.text-primary
             Add New Subproject
     .row.mt-3
@@ -24,7 +24,7 @@
         - if @siblings.present?
           = render partial: 'projects_table', locals: { table_title: 'Sibling Project', project: @project, projects: @siblings }
 
-= render partial: 'add_new_subproject_modal', locals: { project: @project, configuration: @configuration }
+= render partial: 'new_project_modal', locals: { project: @project, configuration: @configuration }
 
 :javascript
   initializeDataTable('.projects-table');


### PR DESCRIPTION
The project creation form is re-designed using bootstrap and it is shown on a modal instead of a page.

The code for creation modal is unified for both projects and subprojects, they are very similar.

Before:

![create new project open build service](https://user-images.githubusercontent.com/2581944/50165102-7af22780-02e4-11e9-8142-c9991ecaf04c.png)

After:

![public projects open build service 5](https://user-images.githubusercontent.com/2581944/50165116-85acbc80-02e4-11e9-94f2-e7b3cc4df674.png)
