### PR TITLE
Refactor removing excluded request

### DIFF
--- a/src/api/app/views/webui2/webui/staging/excluded_requests/_delete_dialog.html.haml
+++ b/src/api/app/views/webui2/webui/staging/excluded_requests/_delete_dialog.html.haml
@@ -1,4 +1,4 @@
-.modal.fade{ id: "delete-excluded-request-modal-#{request_exclusion.bs_request_id}",
+.modal.fade{ id: 'delete-excluded-request-modal',
              tabindex: -1, role: 'dialog', aria: { labelledby: 'delete-modal-label', hidden: true } }
   .modal-dialog.modal-dialog-centered{ role: 'document' }
     .modal-content
@@ -7,8 +7,14 @@
           Stop excluding this request?
       .modal-body
         %p Please confirm that you want to stop excluding this request
-        = form_tag staging_workflow_excluded_request_path(staging_workflow, request_exclusion), method: :delete do
+        = form_tag nil, method: :delete do
           .modal-footer
             %a.btn.btn-sm.btn-outline-secondary.px-4{ data: { dismiss: 'modal' } }
               Cancel
             = submit_tag('Accept', class: 'btn btn-sm btn-danger px-4')
+= content_for :ready_function do
+  :plain
+    $('#delete-excluded-request-modal').on('show.bs.modal', function (event) {
+      var link = $(event.relatedTarget);
+      $(this).find('form').attr('action', link.data('action'));
+    });

--- a/src/api/app/views/webui2/webui/staging/excluded_requests/index.html.haml
+++ b/src/api/app/views/webui2/webui/staging/excluded_requests/index.html.haml
@@ -15,16 +15,14 @@
                 %td= request_exclusion.bs_request.number
                 %td= request_exclusion.description
                 %td
-                  = link_to('#', data: { toggle: 'modal', target: "#delete-excluded-request-modal-#{request_exclusion.bs_request_id}" },
-                            title: 'Stop excluding request') do
+                  = link_to('#', title: 'Stop excluding request', data: { toggle: 'modal', target: '#delete-excluded-request-modal',
+                    action: staging_workflow_excluded_request_path(@staging_workflow, request_exclusion) }) do
                     %i.fas.fa-times-circle.text-danger
-                  = render(partial: 'delete_dialog',
-                          locals: { staging_workflow: @staging_workflow, request_exclusion: request_exclusion })
         = link_to('#', data: { toggle: 'modal', target: '#exclude-request-modal' }) do
           %i.fas.fa-plus-circle.text-primary
           Exclude request
-
 = render partial: 'create_dialog'
+= render partial: 'delete_dialog'
 
 = content_for :ready_function do
   :plain


### PR DESCRIPTION
Instead of generating html code for each modal that asks for removing a excluded reques,t only one modal is created. Arguments for the modal are passed with "data-*" attributes.

Following work of #6608.