### PR TITLE
Enable consider_all_requests_local in test suite

### DIFF
--- a/src/api/config/environments/test.rb
+++ b/src/api/config/environments/test.rb
@@ -19,8 +19,7 @@ OBSApi::Application.configure do
   config.eager_load = ENV.fetch('EAGER_LOAD', '0') == '1'
 
   # Show full error reports and disable caching
-  # local requests don't trigger the global exception handler -> set to false
-  config.consider_all_requests_local = false
+  config.consider_all_requests_local = true
   config.action_controller.perform_caching = false
 
   # Configure public file server for tests with Cache-Control for performance.


### PR DESCRIPTION
This allows us to see the backtrace in CircleCI when a feature test fails, which makes debugging   feature tests much easier. :bowtie: 

Before (CircleCI artifact):

![screenshot_2018-12-18 packages_triggering_package_rebuild_via_binaries_view png png image 1280 x 1024 pixels - scaled 7](https://user-images.githubusercontent.com/968949/50171787-aa5c6080-02f3-11e9-82e3-26a0e803b328.png)

After:

![screenshot_2018-12-18 packages_triggering_package_rebuild_via_binaries_view png png image 1280 x 1024 pixels - scaled 9](https://user-images.githubusercontent.com/968949/50171804-b7794f80-02f3-11e9-8330-b2a796272e69.png)

