### PR TITLE
Replace 2 SQL queries with preloadable code

### DIFF
--- a/src/api/app/views/webui2/webui/repositories/_repository_entry.html.haml
+++ b/src/api/app/views/webui2/webui/repositories/_repository_entry.html.haml
@@ -3,12 +3,11 @@
     .card-header
       = link_to(repository, project_repository_state_path(project: project, repository: repository.name), class: 'font-weight-bold')
       .small
-        - if repository.architectures.size.zero?
+        - if repository.architectures.blank?
           No architecture selected
         - else
-          #{repository.architectures.pluck(:name).join(', ')}
+          #{repository.architectures.map(&:name).join(', ')}
     - if repository.is_dod_repository?
       = render partial: 'dod_repository_card_content', locals: { project: project, repository: repository }
     - else
       = render partial: 'repository_card_content', locals: { project: project, repository: repository, download_url: download_url }
-


### PR DESCRIPTION
Using pluck forces a SQL query - while we already have them preloaded (potentially, see issue #6662). The same with .size - this is an enforced count(*) query, while present? and blank? reuse the preloaded data.