### PR TITLE
Cache user_can_modify_project in repository page

### DIFF
--- a/src/api/app/views/webui2/webui/repositories/_repository_card_content.html.haml
+++ b/src/api/app/views/webui2/webui/repositories/_repository_card_content.html.haml
@@ -18,7 +18,7 @@
 
 .card-footer.text-center
   .row
-    - if User.current.can_modify?(project)
+    - if user_can_modify_project
       .col
         = link_to('#', title: 'Edit Repository',
                        data: { toggle: 'modal', target: "#edit-repository-#{repository.id}" }) do
@@ -32,7 +32,7 @@
       = link_to(url, title: 'Download Repository') do
         %i.fas.fa-download.text-secondary
 
-    - if User.current.can_modify?(project)
+    - if user_can_modify_project
       .col
         = link_to('#', title: 'Delete Repository',
                        data: { toggle: 'modal', target: "#delete-repository-#{repository.id}" }) do

--- a/src/api/app/views/webui2/webui/repositories/_repository_entry.html.haml
+++ b/src/api/app/views/webui2/webui/repositories/_repository_entry.html.haml
@@ -10,5 +10,5 @@
     - if repository.is_dod_repository?
       = render partial: 'dod_repository_card_content', locals: { project: project, repository: repository }
     - else
-      = render partial: 'repository_card_content', locals: { project: project, repository: repository, download_url: download_url }
-
+      = render partial: 'repository_card_content', locals: { project: project, repository: repository,
+                 download_url: download_url, user_can_modify_project: user_can_modify_project }

--- a/src/api/app/views/webui2/webui/repositories/index.html.haml
+++ b/src/api/app/views/webui2/webui/repositories/index.html.haml
@@ -49,8 +49,11 @@
 
     .card-body
       .row.pt-2
+        - user_can_modify_project = User.current.can_modify?(@project)
         - @repositories.each do |repository|
-          = render partial: 'repository_entry', locals: { repository: repository, project: @project, download_url: @configuration['download_url'] }
+          = render partial: 'repository_entry', locals: { repository: repository,
+                      project: @project, download_url: @configuration['download_url'],
+                      user_can_modify_project: user_can_modify_project }
 
   .card.mb-3
     .card-header.d-flex.justify-content-between


### PR DESCRIPTION
This function was called *twice* per repository and is not
exactly cheap:

```
  CACHE Flag Exists (0.0ms)  SELECT  1 AS one FROM `flags` WHERE `flags`.`project_id` = 2 AND `flags`.`flag` = 'lock' AND `flags`.`status` = 'enable' LIMIT 1
has_global_permission? change_project
  CACHE  (0.0ms)  SELECT `roles_static_permissions`.`role_id` FROM `roles_static_permissions` INNER JOIN `static_permissions` ON `static_permissions`.`id` = `roles_static_permissions`.`s tatic_permission_id` WHERE `static_permissions`.`title` = 'change_project'
running local permission check: user coolo, project home:Admin, permission 'change_project'
  CACHE Project Load (0.0ms)  SELECT  `projects`.* FROM `projects` WHERE (projects.id not in (0)) AND `projects`.`name` = 'home' ORDER BY `projects`.`name` DESC LIMIT 1
  CACHE Relationship Exists (0.0ms)  SELECT  1 AS one FROM `relationships` WHERE `relationships`.`project_id` = 2 AND `relationships`.`user_id` = 3 AND (role_id in (1,2)) LIMIT 1
  CACHE Relationship Exists (0.0ms)  SELECT  1 AS one FROM `relationships` INNER JOIN `groups` ON `groups`.`id` = `relationships`.`group_id` INNER JOIN `groups_users` ON `groups_users`.` group_id` = `groups`.`id` WHERE `relationships`.`project_id` = 2 AND `groups_users`.`user_id` = 3 AND (role_id in (1,2)) LIMIT 1


