### PR TITLE
Make it possible to preload architectures

### DIFF
--- a/src/api/app/models/repository.rb
+++ b/src/api/app/models/repository.rb
@@ -16,7 +16,7 @@ class Repository < ApplicationRecord
   has_many :product_update_repositories, dependent: :delete_all
   has_many :product_medium, dependent: :delete_all
   has_many :repository_architectures, -> { order('position') }, dependent: :destroy, inverse_of: :repository
-  has_many :architectures, -> { order('position') }, through: :repository_architectures
+  has_many :architectures, through: :repository_architectures
 
   scope :not_remote, -> { where(remote_project_name: '') }
   scope :remote, -> { where.not(remote_project_name: '') }


### PR DESCRIPTION
Architectures don't have a position, so I assume the
relation is pretty much unused, because it would crash
every time - not just in preloads

Fixes #6662
