### PR TITLE
If there is no influxdb config, we don't want the default

### DIFF
--- a/src/api/config/initializers/influxdb_rails.rb
+++ b/src/api/config/initializers/influxdb_rails.rb
@@ -1,5 +1,9 @@
-return if CONFIG['influxdb_hosts'].blank? # defaults to localhost otherwise
-
+if CONFIG['influxdb_hosts'].blank? # defaults to localhost otherwise
+  InfluxDB::Rails.configure do |config|
+    config.instrumentation_enabled = false
+  end
+  return
+end
 InfluxDB::Rails.configure do |config|
   config.influxdb_database   = CONFIG['influxdb_database']
   config.influxdb_username   = CONFIG['influxdb_username']


### PR DESCRIPTION
For whatever reason influxdb-rails keeps flooding localhost:8086
if nothing is configured - for every developer, only test environment
is ignored by default
