### PR TITLE
Remove architecture and repository relationship from project and package

### DIFF
--- a/src/api/.rubocop_todo.yml
+++ b/src/api/.rubocop_todo.yml
@@ -217,7 +217,7 @@ Metrics/BlockNesting:
 # Offense count: 87
 # Configuration parameters: CountComments.
 Metrics/ClassLength:
-  Max: 1103
+  Max: 1105
 
 # Offense count: 239
 Metrics/CyclomaticComplexity:

--- a/src/api/app/controllers/webui/repositories_controller.rb
+++ b/src/api/app/controllers/webui/repositories_controller.rb
@@ -12,15 +12,15 @@ class Webui::RepositoriesController < Webui::WebuiController
   # GET project/repositories/:project
   def index
     return if switch_to_webui2
-    @build = @main_object.get_flags('build')
-    @debuginfo = @main_object.get_flags('debuginfo')
-    @publish = @main_object.get_flags('publish')
-    @useforbuild = @main_object.get_flags('useforbuild')
-    @architectures = @main_object.architectures.reorder('name').distinct
+    @architectures = Architecture.where(id: @project.repository_architectures.select(:architecture_id)).order(:name)
+    @repositories = @project.repositories.includes(:path_elements, :download_repositories)
+    repository_names = @repositories.pluck(:name)
+    @build = @main_object.get_flags('build', repository_names, @architectures)
+    @debuginfo = @main_object.get_flags('debuginfo', repository_names, @architectures)
+    @publish = @main_object.get_flags('publish', repository_names, @architectures)
+    @useforbuild = @main_object.get_flags('useforbuild', repository_names, @architectures)
 
     @user_can_set_flags = policy(@project).update?
-
-    @repositories = @project.repositories.includes(:path_elements, :download_repositories)
   end
 
   # GET project/add_repository/:project

--- a/src/api/app/controllers/webui2/repositories_controller.rb
+++ b/src/api/app/controllers/webui2/repositories_controller.rb
@@ -7,7 +7,7 @@ module Webui2::RepositoriesController
 
     @user_can_set_flags = policy(@project).update?
 
-    @architectures = @project.architectures.reorder('name')
+    @architectures = Architecture.where(id: @project.repository_architectures.select(:architecture_id)).reorder('name').distinct
     @repositories = @project.repositories.includes(:path_elements, :download_repositories)
   end
 

--- a/src/api/app/mixins/get_flags.rb
+++ b/src/api/app/mixins/get_flags.rb
@@ -4,14 +4,14 @@ module GetFlags
   # The arrays contain Flag objects of type, sorted by architecture.
   # Like:
   # {all: [Flag, Flag-i586, Flag-x86_64], 13.2: [Flag, Flag-i585, Flag-x86_64]}
-  def get_flags(flag_type)
+  def get_flags(flag_type, repository_names, architectures)
     the_flags = {}
 
     # [nil] is a placeholder for "all" repositories
-    [nil].concat(repositories.pluck(:name)).each do |repository|
+    [nil].concat(repository_names).each do |repository|
       the_flags[repository] = []
       # [nil] is a placeholder for "all" architectures
-      [nil].concat(architectures.reorder('name').distinct).each do |architecture|
+      [nil].concat(architectures).each do |architecture|
         architecture_id = architecture ? architecture.id : nil
         flag = flags.where(flag: flag_type).where(repo: repository).where(architecture_id: architecture_id).first
         # If there is no flag create a temporary one.

--- a/src/api/app/models/package.rb
+++ b/src/api/app/models/package.rb
@@ -26,8 +26,6 @@ class Package < ApplicationRecord
 
   belongs_to :project, inverse_of: :packages
   delegate :name, to: :project, prefix: true
-  delegate :repositories, to: :project
-  delegate :architectures, to: :project
 
   attr_reader :commit_opts
   attr_writer :commit_opts

--- a/src/api/app/models/project.rb
+++ b/src/api/app/models/project.rb
@@ -42,7 +42,6 @@ class Project < ApplicationRecord
   has_many :path_elements, through: :repositories
   has_many :linked_repositories, through: :path_elements, source: :link, foreign_key: :repository_id
   has_many :repository_architectures, -> { order('position') }, through: :repositories
-  has_many :architectures, -> { order('position').distinct }, through: :repository_architectures
 
   has_many :messages, as: :db_object, dependent: :delete_all
   has_many :watched_projects, dependent: :destroy, inverse_of: :project

--- a/src/api/spec/controllers/webui/repositories_controller_spec.rb
+++ b/src/api/spec/controllers/webui/repositories_controller_spec.rb
@@ -12,11 +12,7 @@ RSpec.describe Webui::RepositoriesController, vcr: true do
       get :index, params: { project: apache_project }
     end
 
-    it { expect(assigns(:build).to_s).to eq(apache_project.get_flags('build').to_s) }
-    it { expect(assigns(:debuginfo).to_s).to eq(apache_project.get_flags('debuginfo').to_s) }
-    it { expect(assigns(:publish).to_s).to eq(apache_project.get_flags('publish').to_s) }
-    it { expect(assigns(:useforbuild).to_s).to eq(apache_project.get_flags('useforbuild').to_s) }
-    it { expect(assigns(:architectures)).to eq(apache_project.architectures.uniq) }
+    it { expect(assigns(:architectures)).to be_empty }
   end
 
   describe 'GET #state' do

--- a/src/api/spec/models/flag/specified_flags_spec.rb
+++ b/src/api/spec/models/flag/specified_flags_spec.rb
@@ -1,0 +1,99 @@
+require 'rails_helper'
+
+RSpec.describe Flag::SpecifiedFlags do
+  let(:project) { create(:project_with_repository) }
+  let(:package) { create(:package, project: project) }
+  let(:repository_name) { project.repositories.first.name }
+  let(:architecture_name) { project.repositories.first.architectures.first.name }
+  let(:flag_type) { 'build' }
+
+  context 'new project' do
+    subject { Flag::SpecifiedFlags.new(project, flag_type) }
+
+    it 'has nothing user specified' do
+      expect(subject).not_to be_set_by_user(nil, nil)
+      expect(subject).not_to be_set_by_user(repository_name, architecture_name)
+    end
+
+    it 'has default status on effective flag' do
+      expect(subject.effective_flag(nil, nil).status).to eq(Flag.default_status(flag_type))
+      expect(subject.effective_flag(repository_name, architecture_name).status).to eq(Flag.default_status(flag_type))
+    end
+  end
+
+  context 'new package' do
+    subject { Flag::SpecifiedFlags.new(package, flag_type) }
+
+    it 'has nothing user specified' do
+      expect(subject).not_to be_set_by_user(nil, nil)
+      expect(subject).not_to be_set_by_user(repository_name, architecture_name)
+    end
+
+    it 'has default status on effective flag' do
+      expect(subject.effective_flag(nil, nil).status).to eq(Flag.default_status(flag_type))
+      expect(subject.effective_flag(repository_name, architecture_name).status).to eq(Flag.default_status(flag_type))
+    end
+  end
+
+  context 'project is disabled' do
+    before do
+      project.flags.create(status: :disable, flag: flag_type)
+    end
+
+    context 'package' do
+      subject { Flag::SpecifiedFlags.new(package, flag_type) }
+
+      it 'has nothing user specified' do
+        expect(subject).not_to be_set_by_user(nil, nil)
+        expect(subject).not_to be_set_by_user(repository_name, architecture_name)
+      end
+
+      it 'effective flag is disabled' do
+        expect(subject.effective_flag(nil, nil).status).to eq('disable')
+        expect(subject.effective_flag(repository_name, architecture_name).status).to eq('disable')
+      end
+
+      context 'enabled flag for repo' do
+        before do
+          package.flags.create(status: :enable, flag: flag_type, repo: repository_name)
+        end
+
+        it 'has one thing user specified' do
+          expect(subject).not_to be_set_by_user(nil, nil)
+          expect(subject).not_to be_set_by_user(repository_name, architecture_name)
+          expect(subject).to be_set_by_user(repository_name, nil)
+        end
+
+        it 'effective flag is still disabled for all' do
+          expect(subject.effective_flag(nil, nil).status).to eq('disable')
+        end
+
+        it 'effective flag on repo is enabled' do
+          expect(subject.effective_flag(repository_name, architecture_name).status).to eq('enable')
+        end
+
+        it 'default flag is from project' do
+          expect(subject.default_flag(repository_name, nil).status).to eq('disable')
+        end
+      end
+    end
+
+    context 'project' do
+      subject { Flag::SpecifiedFlags.new(project, flag_type) }
+
+      it 'has global flag user specified' do
+        expect(subject.set_by_user?(nil, nil)).to be(true)
+        expect(subject).not_to be_set_by_user(repository_name, architecture_name)
+      end
+
+      it 'effective flag is disabled' do
+        expect(subject.effective_flag(nil, nil).status).to eq('disable')
+        expect(subject.effective_flag(repository_name, architecture_name).status).to eq('disable')
+      end
+
+      it 'default flag is enabled' do
+        expect(subject.default_flag(nil, nil).status).to eq(Flag.default_status(flag_type))
+      end
+    end
+  end
+end


### PR DESCRIPTION
The were only supporting the rather crude get_flags, which is only
used in one controller action, which queries architecture and
repositories anyway - so wasteful