### PR TITLE
Display table information when the pagination is also displayed

### DIFF
--- a/src/api/app/views/webui2/webui/project/show.html.haml
+++ b/src/api/app/views/webui2/webui/project/show.html.haml
@@ -87,4 +87,4 @@
     = render partial: 'webui2/webui/request/delete_request_dialog', locals: { project: @project }
 
 = content_for :ready_function do
-  initializeDataTable('#packages-table, #inherited-packages-table', { info: false });
+  initializeDataTable('#packages-table, #inherited-packages-table');

--- a/src/api/app/views/webui2/webui/user/_involvement.html.haml
+++ b/src/api/app/views/webui2/webui/user/_involvement.html.haml
@@ -81,5 +81,4 @@
                     = link_to(project_name, project_show_path(project: project_name))
 
 = content_for :ready_function do
-  initializeDataTable('#involved-packages-table, #involved-projects-table, #owned-table', { info: false });
-
+  initializeDataTable('#involved-packages-table, #involved-projects-table, #owned-table');


### PR DESCRIPTION
To be consistent in all tables. We have some pages where tables don't have any control (pagination, search), we don't display the information in such cases. When only the search is present, we don't either. In these cases, the tables contain only a few rows (examples: users/groups, attributes).