### PR TITLE
Avoid N+1 queries in update policy

### DIFF
--- a/src/api/app/models/project.rb
+++ b/src/api/app/models/project.rb
@@ -1586,7 +1586,7 @@ class Project < ApplicationRecord
   end
 
   def has_remote_repositories?
-    repositories.any? { |r| r.download_repositories.any? }
+    DownloadRepository.where(repository_id: repositories.select(:id)).exists?
   end
 
   def api_obj


### PR DESCRIPTION
has_remote_repositories? is called from project update? policy, which is called in a lot of places. And it's horribly slow as it loops through an array with N+1 queries looking like this in logs:

```
  DownloadRepository Exists (0.1ms)  SELECT  1 AS one FROM `download_repositories` WHERE `download_repositories`.`repository_id` = 357782 LIMIT 1
  DownloadRepository Exists (0.2ms)  SELECT  1 AS one FROM `download_repositories` WHERE `download_repositories`.`repository_id` = 157220 LIMIT 1
  DownloadRepository Exists (0.1ms)  SELECT  1 AS one FROM `download_repositories` WHERE `download_repositories`.`repository_id` = 214402 LIMIT 1
  DownloadRepository Exists (0.1ms)  SELECT  1 AS one FROM `download_repositories` WHERE `download_repositories`.`repository_id` = 289102 LIMIT 1
  DownloadRepository Exists (0.1ms)  SELECT  1 AS one FROM `download_repositories` WHERE `download_repositories`.`repository_id` = 264047 LIMIT 1
  DownloadRepository Exists (0.1ms)  SELECT  1 AS one FROM `download_repositories` WHERE `download_repositories`.`repository_id` = 320882 LIMIT 1
  DownloadRepository Exists (0.1ms)  SELECT  1 AS one FROM `download_repositories` WHERE `download_repositories`.`repository_id` = 408379 LIMIT 1
```

Using one subselect gives you one access into the repositories index.

```
p=Project.find_by_name('openSUSE:Tools')
irb(main):022:0> Benchmark.measure { 100.times { p.has_remote_repositories_old? } }
=> real=2.6102131991647184
irb(main):023:0> Benchmark.measure { 100.times { p.has_remote_repositories? } }
=> real=0.0647597061470151
```
