### PR TITLE
Fix size of columns of the projects list

### DIFF
--- a/src/api/app/assets/javascripts/webui2/project.js
+++ b/src/api/app/assets/javascripts/webui2/project.js
@@ -9,8 +9,7 @@ function renderProjectsTable(length) { // jshint ignore:line
     "columns": [
       {
         "title": "Name",
-        "width": "60%",
-        "className": "text-word-break-all",
+        "className": "text-word-break-all w-75",
         "render": function (obj, type, dataRow) {
           var url = projecturl.replace(/REPLACEIT/, dataRow[0]);
           return '<a href="' + url + '">' + dataRow[0] + '</a>';
@@ -18,8 +17,7 @@ function renderProjectsTable(length) { // jshint ignore:line
       },
       {
         "title": "Title",
-        "width": "40%",
-        "className": "text-nowrap"
+        "className": "text-nowrap w-25"
       }
     ],
     "pageLength": length,


### PR DESCRIPTION
Use bootstrap's w-* class to get correct column sizes.
It seems that since we rendered the table content as part of the
datatable initialization the relative column width (60% / 40%) was
incorrect.
This caused the first column to be way to small (~ 9px).

Before:

![screenshot from 2019-01-02 11-35-55](https://user-images.githubusercontent.com/968949/50588849-3ccc3a80-0e84-11e9-9b56-cab7a6dfc9c6.png)

After:

![screenshot from 2019-01-02 11-38-57](https://user-images.githubusercontent.com/968949/50588843-36d65980-0e84-11e9-80a8-4cf022a1dfa9.png)
