### PR TITLE
Refactor removing binaries

### DIFF
--- a/src/api/app/views/webui2/webui/package/_delete_binaries_dialog.html.haml
+++ b/src/api/app/views/webui2/webui/package/_delete_binaries_dialog.html.haml
@@ -6,8 +6,8 @@
           Delete binaries?
       .modal-body
         %p Please confirm deletion of binaries for #{arch}
+      .modal-footer
         = form_tag(package_wipe_binaries_path(arch: arch, project: project, package: package, repository: repository), method: :delete) do
-          .modal-footer
-            %a.btn.btn-sm.btn-outline-secondary.px-4{ data: { dismiss: 'modal' } }
-              Cancel
-            = submit_tag('Delete', class: 'btn btn-sm btn-danger px-4')
+          %a.btn.btn-sm.btn-outline-secondary.px-4{ data: { dismiss: 'modal' } }
+            Cancel
+          = submit_tag('Delete', class: 'btn btn-sm btn-danger px-4')

--- a/src/api/app/views/webui2/webui/package/_delete_binaries_dialog.html.haml
+++ b/src/api/app/views/webui2/webui/package/_delete_binaries_dialog.html.haml
@@ -1,13 +1,22 @@
-.modal.fade{ id: "delete-binaries-modal-#{arch}", tabindex: -1, role: 'dialog', aria: { labelledby: 'delete-modal-label', hidden: true } }
+.modal.fade{ id: 'delete-binaries-modal', tabindex: -1, role: 'dialog', aria: { labelledby: 'delete-modal-label', hidden: true } }
   .modal-dialog.modal-dialog-centered{ role: 'document' }
     .modal-content
       .modal-header
         %h5.modal-title
           Delete binaries?
       .modal-body
-        %p Please confirm deletion of binaries for #{arch}
+        %p
+          Please confirm deletion of binaries for
+          %span.arch
       .modal-footer
-        = form_tag(package_wipe_binaries_path(arch: arch, project: project, package: package, repository: repository), method: :delete) do
+        = form_tag nil, method: :delete do
           %a.btn.btn-sm.btn-outline-secondary.px-4{ data: { dismiss: 'modal' } }
             Cancel
           = submit_tag('Delete', class: 'btn btn-sm btn-danger px-4')
+= content_for :ready_function do
+  :plain
+    $('#delete-binaries-modal').on('show.bs.modal', function (event) {
+      var link = $(event.relatedTarget);
+      $(this).find('.arch').text(link.data('arch'));
+      $(this).find('form').attr('action', link.data('action'));
+    });

--- a/src/api/app/views/webui2/webui/package/binaries.html.haml
+++ b/src/api/app/views/webui2/webui/package/binaries.html.haml
@@ -12,6 +12,7 @@
             %i.fas.fa-times-circle.text-danger
             Delete all built binaries
           = render(partial: 'delete_all_binaries_dialog', locals: { project: @project, package: @package_name, repository: @repository })
+          = render partial: 'delete_binaries_dialog'
 
     - @buildresults.each do |result|
       %h5.bg-light.p-2.mb-0

--- a/src/api/app/views/webui2/webui/package/binaries/_trigger_rebuild_wipe_binaries.html.haml
+++ b/src/api/app/views/webui2/webui/package/binaries/_trigger_rebuild_wipe_binaries.html.haml
@@ -5,7 +5,8 @@
     Trigger rebuild
 %li.list-inline-item
   - unless result[:binaries].empty?
-    = link_to('#', data: { toggle: 'modal', target: "#delete-binaries-modal-#{result[:arch]}" }, title: 'Delete binaries') do
+    = link_to('#', title: 'Delete binaries',
+      data: { toggle: 'modal', target: '#delete-binaries-modal', arch: result[:arch],
+      action: package_wipe_binaries_path(arch: result[:arch], project: project, package: package, repository: repository) }) do
       %i.fas.fa-times-circle.text-danger
       Delete binaries
-    = render(partial: 'delete_binaries_dialog', locals: { arch: result[:arch], project: project, package: package, repository: repository })


### PR DESCRIPTION
Instead of generating html code for each modal that asks for removing the binaries, only one modal is created. Arguments for the modal are passed with "data-*" attributes.

Following work of #6608.

