### PR TITLE
Remove unused release_repository_dialog route

### DIFF
--- a/src/api/config/routes.rb
+++ b/src/api/config/routes.rb
@@ -275,7 +275,6 @@ OBSApi::Application.routes.draw do
       post 'project/remove_target_request' => :remove_target_request, as: 'project_remove_target_request'
       post 'project/remove_path_from_target' => :remove_path_from_target, as: 'remove_repository_path'
       post 'project/release_repository/:project/:repository' => :release_repository, constraints: cons
-      get 'project/release_repository_dialog/:project/:repository' => :release_repository_dialog, constraints: cons
       post 'project/move_path/:project' => :move_path, as: 'move_repository_path'
       post 'project/save_person/:project' => :save_person, constraints: cons, as: 'project_save_person'
       post 'project/save_group/:project' => :save_group, constraints: cons, as: 'project_save_group'


### PR DESCRIPTION
- removes the `release_repository_dialog` routes from routes.rb as it is not
being used

Fixes #6534