### PR TITLE
Move code to service

### DIFF
--- a/src/api/app/controllers/webui/architectures_controller.rb
+++ b/src/api/app/controllers/webui/architectures_controller.rb
@@ -7,17 +7,12 @@ class Webui::ArchitecturesController < Webui::WebuiController
   end
 
   def bulk_update_availability
-    all_valid = true
-    params[:archs].each do |name, value|
-      arch = Architecture.find_by(name: name)
-      arch.available = value
-      all_valid &&= arch.save
-    end
+    result = ::ArchitecturesControllerService::ArchitectureUpdater.new(params[:archs]).call
 
     ::Configuration.write_to_backend
 
     respond_to do |format|
-      if all_valid
+      if result.valid?
         format.html { redirect_to architectures_path, notice: 'Architectures successfully updated.' }
       else
         format.html { redirect_back(fallback_location: root_path, error: 'Not all architectures could be saved') }

--- a/src/api/app/services/architectures_controller_service/architecture_updater.rb
+++ b/src/api/app/services/architectures_controller_service/architecture_updater.rb
@@ -1,0 +1,21 @@
+module ArchitecturesControllerService
+  class ArchitectureUpdater
+    def initialize(archs)
+      @archs = archs
+      @all_valid = true
+    end
+
+    def call
+      @archs.each do |name, value|
+        arch = Architecture.find_by(name: name)
+        arch.available = value
+        @all_valid &&= arch.save
+      end
+      self
+    end
+
+    def valid?
+      @all_valid
+    end
+  end
+end


### PR DESCRIPTION
To reduce logic in the controller, move some update relate code
from action ```bulk_update_availability``` to its own service

