### PR TITLE
Refactor repositories delete modals

### DIFF
--- a/src/api/app/views/webui2/webui/repositories/_delete_repository_modal.html.haml
+++ b/src/api/app/views/webui2/webui/repositories/_delete_repository_modal.html.haml
@@ -1,13 +1,24 @@
-.modal.fade{ id: "delete-repository-#{repository.id}", tabindex: -1, role: 'dialog', aria: { labelledby: 'delete-repository-label', hidden: true } }
+.modal.fade{ id: 'delete-repository', tabindex: -1, role: 'dialog', aria: { labelledby: 'delete-repository-label', hidden: true } }
   .modal-dialog.modal-dialog-centered{ role: 'document' }
     .modal-content
       .modal-header
         %h5.modal-title
           Delete repository?
       .modal-body
-        %p Please confirm deletion of '#{repository}' repository
-        = form_tag(destroy_repository_path(project: project, target: repository.name), method: :post) do
-          .modal-footer
-            %a.btn.btn-sm.btn-outline-secondary.px-4{ data: { dismiss: 'modal' } }
-              Cancel
-            = submit_tag('Delete', class: 'btn btn-sm btn-danger px-4')
+        %p
+          Please confirm deletion of
+          = surround "'" do
+            %span.repository
+          repository
+      .modal-footer
+        = form_tag(nil, method: :post) do
+          %a.btn.btn-sm.btn-outline-secondary.px-4{ data: { dismiss: 'modal' } }
+            Cancel
+          = submit_tag('Delete', class: 'btn btn-sm btn-danger px-4')
+= content_for :ready_function do
+  :plain
+    $('#delete-repository').on('show.bs.modal', function (event) {
+      var link = $(event.relatedTarget);
+      $(this).find('.repository').text(link.data('repository'));
+      $(this).find('form').attr('action', link.data('action'));
+    });

--- a/src/api/app/views/webui2/webui/repositories/_delete_repository_path_modal.html.haml
+++ b/src/api/app/views/webui2/webui/repositories/_delete_repository_path_modal.html.haml
@@ -1,13 +1,26 @@
-.modal.fade{ id: "delete-path-#{path.id}", tabindex: -1, role: 'dialog', aria: { labelledby: 'delete-repository-path-label', hidden: true } }
+.modal.fade{ id: 'delete-path-modal', tabindex: -1, role: 'dialog', aria: { labelledby: 'delete-repository-path-label', hidden: true } }
   .modal-dialog.modal-dialog-centered{ role: 'document' }
     .modal-content
       .modal-header
         %h5.modal-title
           Delete repository path?
       .modal-body
-        %p Please confirm deletion of '#{path.link.project}/#{path.link.name}' repository path from #{repository}
-        = form_tag(remove_repository_path_path(project: project, repository: repository, path: path), method: :post) do
-          .modal-footer
-            %a.btn.btn-sm.btn-outline-secondary.px-4{ data: { dismiss: 'modal' } }
-              Cancel
-            = submit_tag('Delete', class: 'btn btn-sm btn-danger px-4')
+        %p
+          Please confirm deletion of
+          = surround "'" do
+            %span.path-name
+          repository path from
+          %span.repository
+      .modal-footer
+        = form_tag(nil, method: :post) do
+          %a.btn.btn-sm.btn-outline-secondary.px-4{ data: { dismiss: 'modal' } }
+            Cancel
+          = submit_tag('Delete', class: 'btn btn-sm btn-danger px-4')
+= content_for :ready_function do
+  :plain
+    $('#delete-path-modal').on('show.bs.modal', function (event) {
+      var link = $(event.relatedTarget);
+      $(this).find('.path-name').text(link.data('path-name'));
+      $(this).find('.repository').text(link.data('repository'));
+      $(this).find('form').attr('action', link.data('action'));
+    });

--- a/src/api/app/views/webui2/webui/repositories/_dod_repository_card_content.html.haml
+++ b/src/api/app/views/webui2/webui/repositories/_dod_repository_card_content.html.haml
@@ -28,11 +28,10 @@
           %i.fas.fa-times-circle.text-danger
     - elsif !User.current.is_nobody?
       .col
-        = link_to('#', title: 'Request Delete Repository',
-                       data: { toggle: 'modal', target: "#request-delete-repository-#{repository.id}" }) do
+        = link_to('#', title: 'Request Delete Repository', data: { toggle: 'modal', target: '#request-delete-repository',
+          action: project_remove_target_request_path(project: project, target: repository), repository: repository.name }) do
           %i.fas.fa-user-times.text-danger
 
 = render partial: 'add_dod_source_modal', locals: { repository: repository,
                                                     project: project,
                                                     download_on_demand: DownloadRepository.new(repository_id: repository.id) }
-= render partial: 'request_delete_repository_modal', locals: { repository: repository, project: project }

--- a/src/api/app/views/webui2/webui/repositories/_dod_repository_card_content.html.haml
+++ b/src/api/app/views/webui2/webui/repositories/_dod_repository_card_content.html.haml
@@ -23,7 +23,8 @@
         = link_to('#', title: 'Add Download on Demand Source', data: { toggle: 'modal', target: "#add-dod-source-modal-#{repository.id}" }) do
           %i.fas.fa-plus-circle.text-primary
       .col
-        = link_to('#', title: 'Delete Repository', data: { toggle: 'modal', target: "#delete-repository-#{repository.id}" }) do
+        = link_to('#', title: 'Delete Repository', data: { toggle: 'modal', target: '#delete-repository',
+          action: destroy_repository_path(project: project, target: repository.name), repository: repository.name }) do
           %i.fas.fa-times-circle.text-danger
     - elsif !User.current.is_nobody?
       .col
@@ -34,5 +35,4 @@
 = render partial: 'add_dod_source_modal', locals: { repository: repository,
                                                     project: project,
                                                     download_on_demand: DownloadRepository.new(repository_id: repository.id) }
-= render partial: 'delete_repository_modal', locals: { repository: repository, project: project }
 = render partial: 'request_delete_repository_modal', locals: { repository: repository, project: project }

--- a/src/api/app/views/webui2/webui/repositories/_repository_card_content.html.haml
+++ b/src/api/app/views/webui2/webui/repositories/_repository_card_content.html.haml
@@ -39,10 +39,9 @@
           %i.fas.fa-times-circle.text-danger
     - elsif !User.current.is_nobody?
       .col
-        = link_to('#', title: 'Request Delete Repository',
-                       data: { toggle: 'modal', target: "#request-delete-repository-#{repository.id}" }) do
+        = link_to('#', title: 'Request Delete Repository', data: { toggle: 'modal', target: '#request-delete-repository',
+          action: project_remove_target_request_path(project: project, target: repository), repository: repository.name }) do
           %i.fas.fa-user-times.text-danger
 
 = render partial: 'edit_repository_modal', locals: { repository: repository, project: project }
 = render partial: 'add_repository_path_modal', locals: { repository: repository, project: project }
-= render partial: 'request_delete_repository_modal', locals: { repository: repository, project: project }

--- a/src/api/app/views/webui2/webui/repositories/_repository_card_content.html.haml
+++ b/src/api/app/views/webui2/webui/repositories/_repository_card_content.html.haml
@@ -34,8 +34,8 @@
 
     - if user_can_modify_project
       .col
-        = link_to('#', title: 'Delete Repository',
-                       data: { toggle: 'modal', target: "#delete-repository-#{repository.id}" }) do
+        = link_to('#', title: 'Delete Repository', data: { toggle: 'modal', target: '#delete-repository',
+          action: destroy_repository_path(project: project, target: repository.name), repository: repository.name }) do
           %i.fas.fa-times-circle.text-danger
     - elsif !User.current.is_nobody?
       .col
@@ -45,5 +45,4 @@
 
 = render partial: 'edit_repository_modal', locals: { repository: repository, project: project }
 = render partial: 'add_repository_path_modal', locals: { repository: repository, project: project }
-= render partial: 'delete_repository_modal', locals: { repository: repository, project: project }
 = render partial: 'request_delete_repository_modal', locals: { repository: repository, project: project }

--- a/src/api/app/views/webui2/webui/repositories/_repository_path_item.html.haml
+++ b/src/api/app/views/webui2/webui/repositories/_repository_path_item.html.haml
@@ -4,7 +4,7 @@
       %i.fas.fa-exclamation-circle.text-warning
       Target repository has been removed
     - else
-      #{path.link.project}/#{path.link.name}
+      = path_name = "#{path.link.project}/#{path.link.name}"
       - if User.current.can_modify?(project)
         - if repository.path_elements.size > 1
           - unless path == repository.path_elements.first
@@ -15,8 +15,7 @@
             = link_to(move_repository_path_path(project: project, repository: repository, path: path, direction: 'down'), method: :post,
                       title: 'Move Down the Repository Path') do
               %i.fas.fa-arrow-alt-circle-down.fa-lg.text-info
-        = link_to('#', title: "Delete '#{path.link.project}/#{path.link.name}' repository path",
-                   data: { toggle: 'modal', target: "#delete-path-#{path.id}" }) do
+        = link_to('#', title: "Delete '#{path_name}' repository path", data: { toggle: 'modal', target: '#delete-path-modal',
+          action: remove_repository_path_path(project: project, repository: repository, path: path),
+          path_name: path_name, repository: repository.name }) do
           %i.fas.fa-times-circle.fa-lg.text-danger
-
-= render partial: 'delete_repository_path_modal', locals: { repository: repository, project: project, path: path }

--- a/src/api/app/views/webui2/webui/repositories/_request_delete_repository_modal.html.haml
+++ b/src/api/app/views/webui2/webui/repositories/_request_delete_repository_modal.html.haml
@@ -1,4 +1,4 @@
-.modal.fade{ id: "request-delete-repository", tabindex: -1, role: 'dialog', aria: { labelledby: 'request-delete-repository-label', hidden: true } }
+.modal.fade{ id: 'request-delete-repository', tabindex: -1, role: 'dialog', aria: { labelledby: 'request-delete-repository-label', hidden: true } }
   .modal-dialog.modal-dialog-centered{ role: 'document' }
     .modal-content
       .modal-header

--- a/src/api/app/views/webui2/webui/repositories/_request_delete_repository_modal.html.haml
+++ b/src/api/app/views/webui2/webui/repositories/_request_delete_repository_modal.html.haml
@@ -1,17 +1,27 @@
-.modal.fade{ id: "request-delete-repository-#{repository.id}", tabindex: -1, role: 'dialog',
-             aria: { labelledby: 'request-delete-repository-label', hidden: true } }
+.modal.fade{ id: "request-delete-repository", tabindex: -1, role: 'dialog', aria: { labelledby: 'request-delete-repository-label', hidden: true } }
   .modal-dialog.modal-dialog-centered{ role: 'document' }
     .modal-content
       .modal-header
         %h5.modal-title
-          Do you really want to request the deletion of repository #{repository}
+          Do you really want to request the deletion of repository
+          = succeed '?' do
+            %span.repository
       .modal-body
-        %p Please confirm deletion of '#{repository}' repository
-        = form_tag(project_remove_target_request_path(project: project, target: repository), method: :post) do
-          = hidden_field_tag :project, project
-          = hidden_field_tag :repository, repository
+        %p
+          Please confirm deletion of
+          = surround "'" do
+            %span.repository
+          repository
+      .modal-footer
+        = form_tag(nil, method: :post) do
           .form-group
             = label_tag :description
             = text_area_tag :description, '', row: 3, class: 'form-control'
-          .modal-footer
-            = render partial: 'webui2/shared/dialog_action_buttons'
+          = render partial: 'webui2/shared/dialog_action_buttons'
+= content_for :ready_function do
+  :plain
+    $('#request-delete-repository').on('show.bs.modal', function (event) {
+      var link = $(event.relatedTarget);
+      $(this).find('.repository').text(link.data('repository'));
+      $(this).find('form').attr('action', link.data('action'));
+    });

--- a/src/api/app/views/webui2/webui/repositories/index.html.haml
+++ b/src/api/app/views/webui2/webui/repositories/index.html.haml
@@ -1,3 +1,4 @@
+= render partial: 'delete_repository_modal'
 - if @package
   .card.mb-3
     - @pagetitle = "Repositories for #{@package}"

--- a/src/api/app/views/webui2/webui/repositories/index.html.haml
+++ b/src/api/app/views/webui2/webui/repositories/index.html.haml
@@ -1,5 +1,6 @@
 = render partial: 'delete_repository_modal'
 = render partial: 'request_delete_repository_modal'
+= render partial: 'delete_repository_path_modal'
 - if @package
   .card.mb-3
     - @pagetitle = "Repositories for #{@package}"

--- a/src/api/app/views/webui2/webui/repositories/index.html.haml
+++ b/src/api/app/views/webui2/webui/repositories/index.html.haml
@@ -1,4 +1,5 @@
 = render partial: 'delete_repository_modal'
+= render partial: 'request_delete_repository_modal'
 - if @package
   .card.mb-3
     - @pagetitle = "Repositories for #{@package}"

--- a/src/api/spec/bootstrap/features/webui/repositories_spec.rb
+++ b/src/api/spec/bootstrap/features/webui/repositories_spec.rb
@@ -118,10 +118,10 @@ RSpec.feature 'Bootstrap_Repositories', type: :feature, js: true, vcr: true do
         click_link(title: 'Delete Repository')
       end
 
-      expect(find("#delete-repository-#{dod_repository.id}")).
+      expect(find('#delete-repository')).
         to have_text("Please confirm deletion of '#{dod_repository}' repository")
 
-      within("#delete-repository-#{dod_repository.id} .modal-footer") do
+      within('#delete-repository .modal-footer') do
         click_button('Delete')
       end
 


### PR DESCRIPTION
Instead of generating html code for each modal that asks for deleting something in repositories, only one modal is created.

Following work of #6608.

