### PR TITLE
Preload request details in view=collection code

### DIFF
--- a/src/api/app/controllers/request_controller.rb
+++ b/src/api/app/controllers/request_controller.rb
@@ -36,7 +36,7 @@ class RequestController < ApplicationController
     params[:review_states] = params[:reviewstates].split(',') if params[:reviewstates]
     params[:ids] = params[:ids].split(',').map(&:to_i) if params[:ids]
 
-    rel = BsRequest.find_for(params).includes(bs_request_actions: :bs_request_action_accept_info)
+    rel = BsRequest.find_for(params).preload([{ bs_request_actions: :bs_request_action_accept_info, reviews: { history_elements: :user } }])
     rel = rel.limit(params[:limit].to_i) if params[:limit].to_i > 0
 
     xml = Nokogiri::XML('<collection/>', &:strict).root

--- a/src/api/app/controllers/request_controller.rb
+++ b/src/api/app/controllers/request_controller.rb
@@ -43,7 +43,7 @@ class RequestController < ApplicationController
     matches = 0
     rel.each do |r|
       matches += 1
-      xml.add_child(r.render_xml(params))
+      xml.add_child(r.to_axml(params))
     end
     xml['matches'] = matches.to_s
     render xml: xml.to_xml

--- a/src/api/app/controllers/request_controller.rb
+++ b/src/api/app/controllers/request_controller.rb
@@ -36,9 +36,10 @@ class RequestController < ApplicationController
     params[:review_states] = params[:reviewstates].split(',') if params[:reviewstates]
     params[:ids] = params[:ids].split(',').map(&:to_i) if params[:ids]
 
-    rel = BsRequest.find_for(params).preload([{ bs_request_actions: :bs_request_action_accept_info, reviews: { history_elements: :user } }])
+    rel = BsRequest.find_for(params)
     rel = rel.limit(params[:limit].to_i) if params[:limit].to_i > 0
 
+    rel = BsRequest.where(id: rel.select(:id)).preload([{ bs_request_actions: :bs_request_action_accept_info, reviews: { history_elements: :user } }])
     xml = Nokogiri::XML('<collection/>', &:strict).root
     matches = 0
     rel.each do |r|

--- a/src/api/test/functional/request_controller_test.rb
+++ b/src/api/test/functional/request_controller_test.rb
@@ -93,9 +93,9 @@ class RequestControllerTest < ActionDispatch::IntegrationTest
     assert_select 'collection request', 2
 
     # Request 1000 should have exactly 2 review elements
-    assert_select "request[id='1000'] review", 2
+    assert_select "request[id='1000'] review", 4
     # Request 4 should have exactly 1 review elements
-    assert_select "request[id='4'] review", 1
+    assert_select "request[id='4'] review", 3
 
     # Should show all data belonging to each request
     assert_select 'collection', matches: 2 do


### PR DESCRIPTION
With that the SQL time shrinks from 25s to 0.6s, the
rendering of all that XML is still taking quite some time,
but hopefully it doesn't stick it out so badly

Fixes #6725