### PR TITLE
Improve InfluxDB backend reportings

### DIFF
--- a/src/api/app/controllers/application_controller.rb
+++ b/src/api/app/controllers/application_controller.rb
@@ -464,8 +464,7 @@ class ApplicationController < ActionController::Base
     InfluxDB::Rails.current.tags = {
       beta: !anonymous && User.current.in_beta?,
       anonymous: anonymous,
-      interface: :api,
-      volley: @skip_validation
+      interface: :api
     }
   end
 end

--- a/src/api/app/controllers/webui/webui_controller.rb
+++ b/src/api/app/controllers/webui/webui_controller.rb
@@ -330,8 +330,7 @@ class Webui::WebuiController < ActionController::Base
     InfluxDB::Rails.current.tags = {
       beta: !anonymous && User.current.in_beta?,
       anonymous: anonymous,
-      interface: :webui,
-      volley: false # only relevant for API,
+      interface: :webui
     }
   end
 

--- a/src/api/app/jobs/application_job.rb
+++ b/src/api/app/jobs/application_job.rb
@@ -7,8 +7,7 @@ class ApplicationJob < ActiveJob::Base
     InfluxDB::Rails.current.tags = {
       beta: false,
       anonymous: true,
-      interface: :job,
-      volley: false
+      interface: :job
     }
   end
 end

--- a/src/api/config/clock.rb
+++ b/src/api/config/clock.rb
@@ -8,8 +8,7 @@ module Clockwork
     InfluxDB::Rails.current.tags = {
       beta: false,
       anonymous: true,
-      interface: "clock_#{event}",
-      volley: false
+      interface: "clock_#{event}"
     }
   end
 

--- a/src/api/lib/backend/instrumentation.rb
+++ b/src/api/lib/backend/instrumentation.rb
@@ -11,6 +11,7 @@ module Backend
       return unless enabled?
 
       ActiveSupport::Notifications.instrument('obs.backend.process_response', data)
+      reset_backend_location
     end
 
     private
@@ -44,6 +45,11 @@ module Backend
         Thread.current[:_influxdb_obs_backend_api_module],
         Thread.current[:_influxdb_obs_backend_api_method]
       ].reject(&:blank?).join('#')
+    end
+
+    def reset_backend_location
+      Thread.current[:_influxdb_obs_backend_api_module] = nil
+      Thread.current[:_influxdb_obs_backend_api_method] = nil
     end
   end
 end

--- a/src/api/lib/backend/instrumentation.rb
+++ b/src/api/lib/backend/instrumentation.rb
@@ -41,10 +41,11 @@ module Backend
     end
 
     def backend_location
-      [
+      result = [
         Thread.current[:_influxdb_obs_backend_api_module],
         Thread.current[:_influxdb_obs_backend_api_method]
-      ].reject(&:blank?).join('#')
+      ]
+      result.empty? ? 'RAW' : result.join('#')
     end
 
     def reset_backend_location


### PR DESCRIPTION
Several improvements:

* Reset the location otherwise RAW calls will be wrongly tagged
* Remove volley tag as it was useless
* Set RAW tag when we directly call the backend