### PR TITLE
Make Package.is_locked? one SQL query instead of 2

### DIFF
--- a/src/api/app/models/package.rb
+++ b/src/api/app/models/package.rb
@@ -312,8 +312,8 @@ class Package < ApplicationRecord
   end
 
   def is_locked?
-    return true if flags.find_by_flag_and_status('lock', 'enable')
-    project.is_locked?
+    is_locked = Flag.where(package: self).or(Flag.where(project: project))
+    is_locked.where(flag: 'lock', status: 'enable').exists?
   end
 
   def kiwi_image?


### PR DESCRIPTION
Before:
```
Flag Load (0.3ms)  SELECT  `flags`.* FROM `flags` WHERE `flags`.`package_id` = 11295 AND `flags`.`flag` = 'lock' AND `flags`.`status` = 'enable' ORDER BY `flags`.`position` ASC LIMIT 1
Flag Exists (0.3ms)  SELECT  1 AS one FROM `flags` WHERE `flags`.`project_id` = 164 AND `flags`.`flag` = 'lock' AND `flags`.`status` = 'enable' LIMIT 1
```
After:
```
Flag Exists (0.5ms)  SELECT  1 AS one FROM `flags` WHERE (`flags`.`package_id` = 11295 OR `flags`.`project_id` = 164) AND `flags`.`flag` = 'lock' AND `flags`.`status` = 'enable' LIMIT 1
```

All 3 queries are of course quick, but less queries are better :)

