### PR TITLE
Improve InfluxDB

### DIFF
--- a/src/api/app/controllers/application_controller.rb
+++ b/src/api/app/controllers/application_controller.rb
@@ -23,10 +23,10 @@ class ApplicationController < ActionController::Base
 
   # skip the filter for the user stuff
   before_action :extract_user
+  before_action :set_influxdb_tags
   before_action :shutup_rails
   before_action :validate_params
   before_action :require_login
-  before_action :set_influxdb_tags
 
   delegate :extract_user,
            :extract_user_public,

--- a/src/api/app/jobs/application_job.rb
+++ b/src/api/app/jobs/application_job.rb
@@ -7,7 +7,8 @@ class ApplicationJob < ActiveJob::Base
     InfluxDB::Rails.current.tags = {
       beta: false,
       anonymous: true,
-      interface: :job
+      interface: :job,
+      location: class_name
     }
   end
 end

--- a/src/api/app/jobs/application_job.rb
+++ b/src/api/app/jobs/application_job.rb
@@ -5,10 +5,8 @@ class ApplicationJob < ActiveJob::Base
 
   def set_influxdb_tags
     InfluxDB::Rails.current.tags = {
-      beta: false,
-      anonymous: true,
       interface: :job,
-      location: class_name
+      location: self.class.name
     }
   end
 end

--- a/src/api/config/clock.rb
+++ b/src/api/config/clock.rb
@@ -6,10 +6,8 @@ require 'clockwork'
 module Clockwork
   on(:before_run) do |event|
     InfluxDB::Rails.current.tags = {
-      beta: false,
-      anonymous: true,
       interface: :clock,
-      location: event
+      location: event.to_s
     }
   end
 

--- a/src/api/config/clock.rb
+++ b/src/api/config/clock.rb
@@ -8,7 +8,8 @@ module Clockwork
     InfluxDB::Rails.current.tags = {
       beta: false,
       anonymous: true,
-      interface: "clock_#{event}"
+      interface: :clock,
+      location: event
     }
   end
 

--- a/src/api/config/initializers/influxdb_rails.rb
+++ b/src/api/config/initializers/influxdb_rails.rb
@@ -15,7 +15,12 @@ InfluxDB::Rails.configure do |config|
   config.time_precision      = CONFIG['influxdb_time_precision']
   config.series_name_for_sql = 'rails.sql'
   config.tags_middleware = lambda do |tags|
-    # set a default location when e.g. using ActiveRecord outside of a request
-    { location: :raw }.merge(tags)
+    result = { beta: false, anonymous: true, interface: :none }.merge!(tags)
+    # TODO: workaround for https://github.com/influxdata/influxdb-rails/pull/64
+    result.reject! { |_, value| value.nil? || value == '' }
+    return result if result.key?(:method)
+
+    # set the default location for e.g. SQL calls outside a request
+    { location: :raw }.merge!(result)
   end
 end

--- a/src/api/config/initializers/influxdb_rails.rb
+++ b/src/api/config/initializers/influxdb_rails.rb
@@ -14,4 +14,8 @@ InfluxDB::Rails.configure do |config|
   config.use_ssl             = CONFIG['influxdb_ssl']
   config.time_precision      = CONFIG['influxdb_time_precision']
   config.series_name_for_sql = 'rails.sql'
+  config.tags_middleware = lambda do |tags|
+    # set a default location when e.g. using ActiveRecord outside of a request
+    { location: :raw }.merge(tags)
+  end
 end

--- a/src/api/lib/backend/instrumentation.rb
+++ b/src/api/lib/backend/instrumentation.rb
@@ -44,7 +44,7 @@ module Backend
       result = [
         Thread.current[:_influxdb_obs_backend_api_module],
         Thread.current[:_influxdb_obs_backend_api_method]
-      ]
+      ].reject(&:blank?)
       result.empty? ? :raw : result.join('#')
     end
 

--- a/src/api/lib/backend/instrumentation.rb
+++ b/src/api/lib/backend/instrumentation.rb
@@ -45,7 +45,7 @@ module Backend
         Thread.current[:_influxdb_obs_backend_api_module],
         Thread.current[:_influxdb_obs_backend_api_method]
       ]
-      result.empty? ? 'RAW' : result.join('#')
+      result.empty? ? :raw : result.join('#')
     end
 
     def reset_backend_location


### PR DESCRIPTION
Several improvements for InfluxDB mostly concerning the (default) tags we sent. We now set default tags in the initializer making sure they're never empty (e.g. for DelayedJob processed in the background).