### PR TITLE
Set nobody when request is processed

### DIFF
--- a/src/api/app/controllers/application_controller.rb
+++ b/src/api/app/controllers/application_controller.rb
@@ -27,6 +27,7 @@ class ApplicationController < ActionController::Base
   before_action :shutup_rails
   before_action :validate_params
   before_action :require_login
+  after_action :set_nobody
 
   delegate :extract_user,
            :extract_user_public,
@@ -456,6 +457,10 @@ class ApplicationController < ActionController::Base
 
   def shutup_rails
     Rails.cache.silence! unless Rails.env.development?
+  end
+
+  def set_nobody
+    User.current = User.find_nobody!
   end
 
   def set_influxdb_tags

--- a/src/api/test/functional/maintenance_test.rb
+++ b/src/api/test/functional/maintenance_test.rb
@@ -1419,7 +1419,9 @@ class MaintenanceTests < ActionDispatch::IntegrationTest
     assert_difference 'ActionMailer::Base.deliveries.size', +1 do
       post create_request_comment_path(request_number: reqid), params: 'Slave, can you release it? The master is gone'
       assert_response :success
+      User.current = User.find_by_login('king')
       SendEventEmailsJob.new.perform
+      User.current = nil
     end
 
     email = ActionMailer::Base.deliveries.last

--- a/src/api/test/functional/source_controller_test.rb
+++ b/src/api/test/functional/source_controller_test.rb
@@ -3591,7 +3591,9 @@ class SourceControllerTest < ActionDispatch::IntegrationTest
 
     # in future
     Timecop.freeze(10.days) do
+      User.current = User.find_by_login('fredlibs')
       ProjectCreateAutoCleanupRequests.new.perform
+      User.current = nil
     end
     # validate request
     br = BsRequest.all.last

--- a/src/api/test/test_consistency_helper.rb
+++ b/src/api/test/test_consistency_helper.rb
@@ -18,7 +18,9 @@ def resubmit_all_fixtures
     get "/source/#{name}/_meta"
     assert_response :success
     r = @response.body
+    User.current = User.find_by_login('king')
     next if Project.find_by_name(name).is_locked?
+    User.current = nil
     # FIXME: add some more validation checks here
     put "/source/#{name}/_meta", params: r.dup
     assert_response :success


### PR DESCRIPTION
When we authenticate a user, we set User.current = .
Howerver, after the request is processed we never set it to nil.
If the next request does not require authentication and skips the
extract_user before filter, we still have the user from the previous
request set in User.current.
We should clean up what we set in Thread.current.

