### PR TITLE
Fix link for downloading a binary

### DIFF
--- a/src/api/app/views/webui2/webui/package/binary.html.haml
+++ b/src/api/app/views/webui2/webui/package/binary.html.haml
@@ -8,7 +8,7 @@
     %h3
       = @pagetitle
       - if @durl
-        = link_to(link_to(@filename, @durl), title: 'Download file') do
+        = link_to(@durl, title: 'Download') do
           %i.fas.fa-download.text-secondary
 
     %div


### PR DESCRIPTION
Without this patch,
https://build.opensuse.org/package/binary/home:bmwiedemann/git-deps/openSUSE_Leap_15.0/x86_64/git-deps-1-lp150.5.1.noarch.rpm
had

```html
<h3>
Detailed Information About git-deps-1-lp150.5.1.noarch.rpm
<a title="Download file" href="<a href=&quot;https://api.opensuse.org:443/build/home:bmwiedemann/openSUSE_Leap_15.0/x86_64/git-deps/git-deps-1-lp150.5.1.noarch.rpm&quot;>git-deps-1-lp150.5.1.noarch.rpm</a>"><i class='fas fa-download text-secondary'></i>
</a></h3>
```