### PR TITLE
Allow depfu to update Rantly

### DIFF
--- a/src/api/Gemfile
+++ b/src/api/Gemfile
@@ -132,7 +132,7 @@ group :test do
   # assigns has been extracted to a gem
   gem 'rails-controller-testing'
   # To generate random data
-  gem 'rantly', '>= 1.1.0'
+  gem 'rantly'
   # for test analysis in CircleCI
   gem 'coveralls'
   gem 'minitest-ci'


### PR DESCRIPTION
There is no reason to block this gem in version 1.2.0, version 2.0.0 includes great changes and bug fixes :cupid: 
