### PR TITLE
Sort changed column by time and not alphabetically

### DIFF
--- a/src/api/app/views/webui2/webui/package/_file.html.haml
+++ b/src/api/app/views/webui2/webui/package/_file.html.haml
@@ -8,7 +8,7 @@
   %td.text-nowrap
     %span.d-none= file[:size].rjust(10, '0')
     = human_readable_fsize(file[:size])
-  %td.text-nowrap
+  %td.text-nowrap{ data: { order: "-#{file[:mtime]}" } }
     = timeago_tag Time.at(file[:mtime].to_i), limit: 1.year.ago
   / limit download for anonymous user to avoid getting killed by crawlers
   %td.text-center

--- a/src/api/app/views/webui2/webui/project/_project_packages.html.haml
+++ b/src/api/app/views/webui2/webui/project/_project_packages.html.haml
@@ -11,7 +11,7 @@
             %tr
               %td
                 = link_to(package.first, package_show_path(package: package.first, project: project))
-              %td
+              %td{ data: { order: "-#{package.second}" } }
                 = time_ago_in_words(Time.at(package.second.to_i))
   - else
     %p This project does not contain any packages


### PR DESCRIPTION
Use the timestamp instead of the generated string in the `Changed` column of
the packages table in the project page and in the files table in the package
page. It is ordered in inverse order in contrast as what it used to be
(incorrectly) done in the old UI. :bowtie: 

![image](https://user-images.githubusercontent.com/16052290/50968725-3f5e0e00-14dc-11e9-9ef6-9037ac250383.png)


Fixes https://github.com/openSUSE/open-build-service/issues/6640

