### PR TITLE
Add history to staging project show page

### DIFF
--- a/src/api/app/controllers/staging/staged_requests_controller.rb
+++ b/src/api/app/controllers/staging/staged_requests_controller.rb
@@ -13,7 +13,8 @@ class Staging::StagedRequestsController < ApplicationController
     result = ::Staging::StageRequests.new(
       request_numbers: request_numbers,
       staging_workflow: @staging_workflow,
-      staging_project: @staging_project
+      staging_project: @staging_project,
+      user_login: User.current.login
     ).create
 
     if result.valid?
@@ -34,6 +35,7 @@ class Staging::StagedRequestsController < ApplicationController
       request_numbers: request_numbers,
       staging_workflow: @staging_workflow,
       staging_project: @staging_project,
+      user_login: User.current.login
     ).destroy
 
     if result.valid?

--- a/src/api/app/controllers/staging/staged_requests_controller.rb
+++ b/src/api/app/controllers/staging/staged_requests_controller.rb
@@ -14,7 +14,7 @@ class Staging::StagedRequestsController < ApplicationController
       request_numbers: request_numbers,
       staging_workflow: @staging_workflow,
       staging_project: @staging_project
-    ).perform
+    ).create
 
     if result.valid?
       render_ok
@@ -29,25 +29,20 @@ class Staging::StagedRequestsController < ApplicationController
 
   def destroy
     authorize @staging_project, :update?
-    requests = @staging_project.staged_requests.where(number: request_numbers)
-    package_names = requests.joins(:bs_request_actions).pluck('bs_request_actions.target_package')
 
-    @staging_project.staged_requests.delete(requests)
-    not_unassigned_requests = request_numbers - requests.pluck(:number).map(&:to_s)
+    result = ::Staging::StageRequests.new(
+      request_numbers: request_numbers,
+      staging_workflow: @staging_workflow,
+      staging_project: @staging_project,
+    ).destroy
 
-    result = @staging_project.packages.where(name: package_names).destroy_all
-    not_deleted_packages = package_names - result.pluck(:name)
-
-    if not_unassigned_requests.empty? && not_deleted_packages.empty?
+    if result.valid?
       render_ok
     else
-      message = 'Error while unassigning requests: '
-      message << "Requests with number #{not_unassigned_requests.to_sentence} not found. " unless not_unassigned_requests.empty?
-      message << "Could not delete packages #{not_deleted_packages.to_sentence}." unless not_deleted_packages.empty?
       render_error(
         status: 400,
         errorcode: 'invalid_request',
-        message: message
+        message: "Error while unassigning requests: #{result.errors.to_sentence}"
       )
     end
   end

--- a/src/api/app/views/webui2/webui/staging/projects/_history_elements.html.haml
+++ b/src/api/app/views/webui2/webui/staging/projects/_history_elements.html.haml
@@ -1,0 +1,9 @@
+%ul
+  - elements.each do |element|
+    %li
+      = element.event_type.humanize
+      = link_to("##{element.bs_request.number}", request_path(element.bs_request.number))
+      for package
+      %b= element.package_name
+      submitted by
+      %b= element.user_name

--- a/src/api/app/views/webui2/webui/staging/projects/show.html.haml
+++ b/src/api/app/views/webui2/webui/staging/projects/show.html.haml
@@ -32,5 +32,11 @@
             %tr
               = render partial: 'checks',
                        locals: { checks: @staging_project.checks, missing_checks: @staging_project.missing_checks }
+    .card.mb-3
+      %h5.card-header History
+      .card-body
+        = render partial: 'history_elements',
+                       locals: { elements: |
+                       @staging_project.project_log_entries.where(event_type: [:staged_request, :unstaged_request]).includes(:bs_request) } |
   .col-xl-2
     = render partial: 'webui/staging/shared/legend'


### PR DESCRIPTION
![selection_018](https://user-images.githubusercontent.com/3799140/50974160-db8f1180-14ea-11e9-9c50-0450a37f87d6.png)

There is one difference now: The history was before done by comments on the project page. This history is now done with ProjectLogEntries and therefore it is on the staging project page. However, I guess this is an improvement. If it was desired to have it on the project show page, we can move it also there.