### PR TITLE
Do not allow user to have a login with invalid characters

### DIFF
--- a/src/api/app/models/user.rb
+++ b/src/api/app/models/user.rb
@@ -76,7 +76,7 @@ class User < ApplicationRecord
 
   validates :login,
             format: { with: Regexp.new("\\A(#{NOBODY_LOGIN}|[-+a-zA-Z0-9][-+\\w\\.]*)\\z"),
-                      message: 'must not contain invalid characters' }
+                      message: 'only allows letters, numbers and the following characters: _ - + . (. and _ not at the beginning)' }
   validates :login,
             length: { in: 2..100, allow_nil: true,
                       too_long: 'must have less than 100 characters',

--- a/src/api/app/models/user.rb
+++ b/src/api/app/models/user.rb
@@ -74,9 +74,14 @@ class User < ApplicationRecord
   validates :login,
             uniqueness: { message: 'is the name of an already existing user' }
 
+  # returns the login validation patern and the errors message
+  def self.login_pattern
+    ['[-+a-zA-Z0-9][-+\w\.]*', 'only allows letters, numbers and the following characters: _ - + . (. and _ not at the beginning)']
+  end
+
   validates :login,
-            format: { with: Regexp.new("\\A(#{NOBODY_LOGIN}|[-+a-zA-Z0-9][-+\\w\\.]*)\\z"),
-                      message: 'only allows letters, numbers and the following characters: _ - + . (. and _ not at the beginning)' }
+            format: { with: Regexp.new("\\A(#{NOBODY_LOGIN}|#{User.login_pattern.first})\\z"),
+                      message: User.login_pattern.second }
   validates :login,
             length: { in: 2..100, allow_nil: true,
                       too_long: 'must have less than 100 characters',

--- a/src/api/app/models/user.rb
+++ b/src/api/app/models/user.rb
@@ -75,7 +75,7 @@ class User < ApplicationRecord
             uniqueness: { message: 'is the name of an already existing user' }
 
   validates :login,
-            format: { with: %r{\A[\w \$\^\-\.#\*\+&'"]*\z},
+            format: { with: Regexp.new("\\A(#{NOBODY_LOGIN}|[-+a-zA-Z0-9][-+\\w\\.]*)\\z"),
                       message: 'must not contain invalid characters' }
   validates :login,
             length: { in: 2..100, allow_nil: true,

--- a/src/api/app/views/webui2/shared/_sign_up.html.haml
+++ b/src/api/app/views/webui2/shared/_sign_up.html.haml
@@ -6,14 +6,15 @@
 - else
   = form_tag({ controller: 'user', action: 'register', method: :post }, class: 'sign-up', autocomplete: 'off') do
     .form-group
-      = text_field_tag 'login', nil, placeholder: 'Username', autocomplete: 'off', class: 'form-control', pattern: User.login_pattern.first, title: User.login_pattern.second
+      = text_field_tag 'login', nil, placeholder: 'Username', autocomplete: 'off', class: 'form-control',
+                       pattern: User.login_pattern.first, title: User.login_pattern.second, required: true
     .form-group
-      = text_field_tag 'email', nil, placeholder: 'Email address', autocomplete: 'off', class: 'form-control'
+      = email_field_tag 'email', nil, placeholder: 'Email address', autocomplete: 'off', class: 'form-control', required: true
     .form-group
-      = password_field_tag :password, nil, id: 'pwd', placeholder: 'Enter a password', autocomplete: 'off', class: 'form-control'
+      = password_field_tag :password, nil, id: 'pwd', placeholder: 'Enter a password', autocomplete: 'off', class: 'form-control', required: true
     .form-group
-      = password_field_tag(:password_confirmation, nil, id: 'pwd_confirmation', placeholder: 'Password confirmation', autocomplete: 'off',
-        class: 'form-control')
+      = password_field_tag(:password_confirmation, nil, id: 'pwd_confirmation', placeholder: 'Password confirmation',
+                           autocomplete: 'off', class: 'form-control', required: true)
     = hidden_field_tag 'register', 'true'
     .text-center
       = submit_tag 'Sign Up', class: 'btn btn-primary'

--- a/src/api/app/views/webui2/shared/_sign_up.html.haml
+++ b/src/api/app/views/webui2/shared/_sign_up.html.haml
@@ -6,7 +6,7 @@
 - else
   = form_tag({ controller: 'user', action: 'register', method: :post }, class: 'sign-up', autocomplete: 'off') do
     .form-group
-      = text_field_tag 'login', nil, placeholder: 'Username', autocomplete: 'off', class: 'form-control'
+      = text_field_tag 'login', nil, placeholder: 'Username', autocomplete: 'off', class: 'form-control', pattern: User.login_pattern.first, title: User.login_pattern.second
     .form-group
       = text_field_tag 'email', nil, placeholder: 'Email address', autocomplete: 'off', class: 'form-control'
     .form-group


### PR DESCRIPTION
At the moment creating a user whose login has certain characters fails with a
500 because the home project (created after saving the user) is invalid as the
validation is stricter there.

![image](https://user-images.githubusercontent.com/16052290/51033995-79471700-15a5-11e9-9037-94f66e4ee5ad.png)

![image](https://user-images.githubusercontent.com/16052290/51043184-60972b00-15be-11e9-9e39-3065213a7823.png)

Fixes https://github.com/openSUSE/open-build-service/issues/1771

