### PR TITLE
[dist] fix for missing /etc/SUSE-release in setup-appliance.sh

### DIFF
--- a/dist/obsscheduler
+++ b/dist/obsscheduler
@@ -2,22 +2,6 @@
 # Copyright (c) 2007, Novell Inc.
 #
 # Author: adrian@suse.de
-#
-# /etc/init.d/obsscheduler
-#   and its symbolic  link
-# /usr/sbin/rcobsscheduler
-#
-### BEGIN INIT INFO
-# Provides:          obsscheduler
-# Required-Start:    $time $syslog obsrepserver
-# Should-Start:      obssrcserver $network $remote_fs obsapisetup
-# Should-Stop:       $none
-# Required-Stop:     $null
-# Default-Start:     3 5
-# Default-Stop:      0 1 2 4 6
-# Short-Description: OBS job scheduler
-# Description:       open build service job scheduler
-### END INIT INFO
 
 . /etc/rc.status
 

--- a/dist/setup-appliance.sh
+++ b/dist/setup-appliance.sh
@@ -675,7 +675,15 @@ if [[ ! $BOOTSTRAP_TEST_MODE == 1 && $0 != "-bash" ]];then
   echo "$FQHOSTNAME" > $backenddir/.oldfqhostname
 
   OBSVERSION=`rpm -q --qf '%{VERSION}' obs-server`
-  OS=`head -n 1 /etc/SuSE-release`
+  if [ -e /etc/os-release ];then
+    # execute in subshell to preserve the values of the variables
+    # $NAME and $VERSION as these are very generic
+    OS_NAME=`. /etc/os-release;echo $NAME`
+    OS_VERSION=`. /etc/os-release;echo $VERSION`
+    OS="$OS_NAME $OS_VERSION"
+  else
+    OS="UNKNOWN"
+  fi
   RUN_INITIAL_SETUP=""
 
   prepare_database_setup

--- a/dist/systemd/obsscheduler.service
+++ b/dist/systemd/obsscheduler.service
@@ -2,6 +2,7 @@
 Description=OBS job scheduler
 Requires=obsrepserver.service
 After=network.target obssrcserver.service obsrepserver.service
+Wants=obsapisetup.service
 
 [Service]
 Type=oneshot


### PR DESCRIPTION
/etc/SUSE-release is no longer on our appliances.
Thats why we see the following error message on freshly installed systems:

head: cannot open '/etc/SuSE-release' for reading: No such file or directory

This patch uses /etc/os-release if /etc/SuSE-release is not present or
sets it to "UNKNOWN" if /etc/os-release isn`t present either


