### PR TITLE
Order the autocomplete projects by length of match

### DIFF
--- a/src/api/app/models/project.rb
+++ b/src/api/app/models/project.rb
@@ -31,7 +31,7 @@ class Project < ApplicationRecord
   has_many :relationships, dependent: :destroy, inverse_of: :project
   has_many :packages, inverse_of: :project do
     def autocomplete(search)
-      where(['lower(packages.name) like lower(?)', "%#{search}%"]).order(:name).limit(50)
+      where(['lower(packages.name) like lower(?)', "%#{search}%"]).order('length(name)', :name).limit(50)
     end
   end
 
@@ -88,7 +88,7 @@ class Project < ApplicationRecord
     where.not('name rlike ?', ::Configuration.unlisted_projects_filter) if ::Configuration.unlisted_projects_filter.present?
   }
   scope :remote, -> { where('NOT ISNULL(projects.remoteurl)') }
-  scope :autocomplete, ->(search) { where('lower(name) like lower(?)', "%#{search}%").order(:name).limit(50) }
+  scope :autocomplete, ->(search) { where('lower(name) like lower(?)', "%#{search}%").order('length(name)', :name).limit(50) }
 
   # will return all projects with attribute 'OBS:ImageTemplates'
   scope :local_image_templates, lambda {


### PR DESCRIPTION
Fixes https://github.com/openSUSE/open-build-service/issues/6753

before
```
puts Project.autocomplete('openSUSE:Factory')
devel:openSUSE:Factory
devel:openSUSE:Factory:Apps
devel:openSUSE:Factory:for-legal-lhf
devel:openSUSE:Factory:kernel
devel:openSUSE:Factory:legal-queue
devel:openSUSE:Factory:rpmlint
home:1enn0:branches:openSUSE:Factory
home:Guillaume_G:branches:openSUSE:Factory:ARM
home:JERiveraMoya:branches:devel:openSUSE:Factory
home:JRivrain:branches:devel:openSUSE:Factory
home:Jeffreycheung:branches:openSUSE:Factory
home:JonathanKang:branches:openSUSE:Factory
home:MartinMohring:playground:openSUSE:Factory:Base:build:armv5el
home:MartinMohring:playground:openSUSE:Factory:Base:build:stage1
home:SebD:branches:openSUSE:Factory
home:StefanBruens:branches:devel:openSUSE:Factory:rpmlint
home:StefanBruens:branches:devel:openSUSE:Factory:rpmlint_2
home:StefanBruens:branches:devel:openSUSE:Factory:rpmlint_submit
home:StefanBruens:branches:openSUSE:Factory:ARM
home:TheBlackCat:branches:devel:openSUSE:Factory:rpmlint
home:Vogtinator:branches:openSUSE:Factory
home:a_faerber:branches:openSUSE:Factory:ARM
home:a_faerber:openSUSE:Factory:bootstrap
home:acho:branches:openSUSE:Factory
home:adrianSuSE:branches:openSUSE:Factory
home:adrianSuSE:branches:openSUSE:Factory:Containers
home:aginies:branches:devel:openSUSE:Factory:rpmlint
home:aginies:branches:openSUSE:Factory
home:amosery:branches:openSUSE:Factory
home:apappas:branches:devel:openSUSE:Factory
home:bigironman:branches:openSUSE:Factory:zSystems
home:bigironman:branches:openSUSE:Factory:zSystems:ToTest
home:birefringence:branches:openSUSE:Factory
home:bmwiedemann:branches:openSUSE:Factory
home:ccret:branches:devel:openSUSE:Factory
home:cfeck:branches:openSUSE:Factory
home:colyli:branches:openSUSE:Factory
home:coolo:branches:openSUSE:Factory
home:dirkmueller:branches:openSUSE:Factory
home:dmulder:branches:openSUSE:Factory
home:dorf:branches:openSUSE:Factory
home:eeich:branches:devel:openSUSE:Factory:rpmlint
home:elvigia:branches:devel:openSUSE:Factory
home:favogt:branches:openSUSE:Factory:Live
home:forwardbackwards:branches:openSUSE:Factory:ARM:Live
home:frank_kunz:branches:openSUSE:Factory:ARM
home:ganghe:branches:openSUSE:Factory
home:gary_lin:branches:devel:openSUSE:Factory
home:harish2704:branches:openSUSE:Factory
home:hellcp:branches:openSUSE:Factory
```

after:
```
puts Project.autocomplete('openSUSE:Factory')
openSUSE:Factory
openSUSE:Factory:ARM
openSUSE:Factory:Live
devel:openSUSE:Factory
openSUSE:Factory:Build
openSUSE:Factory:RISCV
openSUSE:Factory:Rings
openSUSE:Factory:Images
openSUSE:Factory:ToTest
openSUSE:Factory:Update
openSUSE:Factory:NonFree
openSUSE:Factory:PowerPC
openSUSE:Factory:Rebuild
openSUSE:Factory:Staging
openSUSE:Factory:ARM:Live
openSUSE:Factory:zSystems
openSUSE:Factory:Staging:A
openSUSE:Factory:Staging:B
openSUSE:Factory:Staging:C
openSUSE:Factory:Staging:D
openSUSE:Factory:Staging:E
openSUSE:Factory:Staging:F
openSUSE:Factory:Staging:G
openSUSE:Factory:Staging:H
openSUSE:Factory:Staging:I
openSUSE:Factory:Staging:J
openSUSE:Factory:Staging:K
openSUSE:Factory:Staging:L
openSUSE:Factory:Staging:M
openSUSE:Factory:Staging:N
openSUSE:Factory:Staging:O
devel:openSUSE:Factory:Apps
openSUSE:Factory:ARM:ToTest
openSUSE:Factory:Containers
openSUSE:Factory:RISCV:qemu
home:swella:openSUSE:Factory
openSUSE:Factory:ARM:Staging
devel:openSUSE:Factory:kernel
openSUSE:Factory:Staging:Gcc7
devel:openSUSE:Factory:rpmlint
openSUSE:Factory:PowerPC:Rings
openSUSE:Factory:Staging:adi:1
openSUSE:Factory:Staging:adi:2
openSUSE:Factory:Staging:adi:3
openSUSE:Factory:Staging:adi:4
openSUSE:Factory:Staging:adi:5
openSUSE:Factory:Staging:adi:6
openSUSE:Factory:Staging:adi:7
openSUSE:Factory:Staging:adi:8
openSUSE:Factory:Staging:adi:9
```

Sorting this array by name (after the limit applied), gives us (I looked at it, but as it doens't have the exact match at start I discarded it):

```
devel:openSUSE:Factory
devel:openSUSE:Factory:Apps
devel:openSUSE:Factory:kernel
devel:openSUSE:Factory:rpmlint
home:swella:openSUSE:Factory
openSUSE:Factory
openSUSE:Factory:ARM
openSUSE:Factory:ARM:Live
openSUSE:Factory:ARM:Staging
openSUSE:Factory:ARM:ToTest
openSUSE:Factory:Build
openSUSE:Factory:Containers
openSUSE:Factory:Images
openSUSE:Factory:Live
openSUSE:Factory:NonFree
openSUSE:Factory:PowerPC
openSUSE:Factory:PowerPC:Rings
openSUSE:Factory:RISCV
openSUSE:Factory:RISCV:qemu
openSUSE:Factory:Rebuild
openSUSE:Factory:Rings
openSUSE:Factory:Staging
openSUSE:Factory:Staging:A
openSUSE:Factory:Staging:B
openSUSE:Factory:Staging:C
openSUSE:Factory:Staging:D
openSUSE:Factory:Staging:E
openSUSE:Factory:Staging:F
openSUSE:Factory:Staging:G
openSUSE:Factory:Staging:Gcc7
openSUSE:Factory:Staging:H
openSUSE:Factory:Staging:I
openSUSE:Factory:Staging:J
openSUSE:Factory:Staging:K
openSUSE:Factory:Staging:L
openSUSE:Factory:Staging:M
openSUSE:Factory:Staging:N
openSUSE:Factory:Staging:O
openSUSE:Factory:Staging:adi:1
openSUSE:Factory:Staging:adi:2
openSUSE:Factory:Staging:adi:3
openSUSE:Factory:Staging:adi:4
openSUSE:Factory:Staging:adi:5
openSUSE:Factory:Staging:adi:6
openSUSE:Factory:Staging:adi:7
openSUSE:Factory:Staging:adi:8
openSUSE:Factory:Staging:adi:9
openSUSE:Factory:ToTest
openSUSE:Factory:Update
openSUSE:Factory:zSystems
```