### PR TITLE
Use our fork of the influxdb-rails gem

### DIFF
--- a/src/api/Gemfile
+++ b/src/api/Gemfile
@@ -77,7 +77,7 @@ gem 'addressable'
 # for XML builder
 gem 'builder'
 # to write the rails metrics directly into InfluxDB.
-gem 'influxdb-rails', '>=1.0.0.beta3'
+gem 'experimental-influxdb-rails', '>=1.0.0.beta5'
 # for client side time ago
 gem 'rails-timeago', '~> 2.0'
 

--- a/src/api/Gemfile.lock
+++ b/src/api/Gemfile.lock
@@ -136,6 +136,9 @@ GEM
     erubis (2.7.0)
     escape_utils (1.2.1)
     execjs (2.7.0)
+    experimental-influxdb-rails (1.0.0.beta5)
+      influxdb (~> 0.6, >= 0.6.4)
+      railties (>= 4.2)
     factory_bot (4.11.1)
       activesupport (>= 3.0.0)
     factory_bot_rails (4.11.1)
@@ -176,10 +179,7 @@ GEM
       ruby_parser (~> 3.5)
     i18n (1.5.1)
       concurrent-ruby (~> 1.0)
-    influxdb (0.6.4)
-    influxdb-rails (1.0.0.beta3)
-      influxdb (~> 0.6, >= 0.6.4)
-      railties (>= 4.2)
+    influxdb (0.7.0)
     innertube (1.1.0)
     jaro_winkler (1.5.2)
     joiner (0.4.2)
@@ -474,6 +474,7 @@ DEPENDENCIES
   database_cleaner (>= 1.0.1)
   delayed_job_active_record (>= 4.0.0)
   escape_utils
+  experimental-influxdb-rails (>= 1.0.0.beta5)
   factory_bot_rails
   faker
   feature
@@ -483,7 +484,6 @@ DEPENDENCIES
   haml
   haml-rails
   haml_lint
-  influxdb-rails (>= 1.0.0.beta3)
   jquery-datatables
   jquery-rails
   jquery-ui-rails (~> 4.2.1)

--- a/src/api/app/controllers/application_controller.rb
+++ b/src/api/app/controllers/application_controller.rb
@@ -23,7 +23,7 @@ class ApplicationController < ActionController::Base
 
   # skip the filter for the user stuff
   before_action :extract_user
-  before_action :set_influxdb_tags
+  before_action :set_influxdb_data
   before_action :shutup_rails
   before_action :validate_params
   before_action :require_login
@@ -463,7 +463,7 @@ class ApplicationController < ActionController::Base
     User.current = User.find_nobody!
   end
 
-  def set_influxdb_tags
+  def set_influxdb_data
     anonymous = User.current_login == User::NOBODY_LOGIN
 
     InfluxDB::Rails.current.tags = {
@@ -471,5 +471,6 @@ class ApplicationController < ActionController::Base
       anonymous: anonymous,
       interface: :api
     }
+    InfluxDB::Rails.current.values = { request: request.request_id }
   end
 end

--- a/src/api/app/controllers/webui/webui_controller.rb
+++ b/src/api/app/controllers/webui/webui_controller.rb
@@ -13,11 +13,11 @@ class Webui::WebuiController < ActionController::Base
   include Pundit
   protect_from_forgery
 
-  before_action :set_influxdb_interface_tag
+  before_action :set_influxdb_data
   before_action :setup_view_path
   before_action :check_user
   before_action :check_anonymous
-  before_action :set_influxdb_tags
+  before_action :set_influxdb_additional_tags
   before_action :require_configuration
   before_action :set_pending_announcement
   after_action :clean_cache
@@ -325,13 +325,15 @@ class Webui::WebuiController < ActionController::Base
     @pending_announcement = Announcement.last
   end
 
-  def set_influxdb_interface_tag
+  def set_influxdb_data
     InfluxDB::Rails.current.tags = {
       interface: :webui
     }
+
+    InfluxDB::Rails.current.values = { request: request.request_id }
   end
 
-  def set_influxdb_tags
+  def set_influxdb_additional_tags
     anonymous = User.current_login == User::NOBODY_LOGIN
     tags = {
       beta: !anonymous && User.current.in_beta?,

--- a/src/api/lib/influxdb_obs/obs/middleware/backend_subscriber.rb
+++ b/src/api/lib/influxdb_obs/obs/middleware/backend_subscriber.rb
@@ -33,7 +33,10 @@ module InfluxDB
         end
 
         def values(runtime)
-          { runtime: ((runtime || 0) * 1000).ceil }
+          values = { runtime: ((runtime || 0) * 1000).ceil }
+          values.merge(InfluxDB::Rails.current.values).reject do |_, value|
+            value.nil? || value == ''
+          end
         end
 
         def tags(data)


### PR DESCRIPTION
To move forward with InfluxDB we use now our fork of the influxdb-rails gem. Our focus is still "upstream first" but often enough in the past some of our improvements on the gem turned out to be not practical in production (cardinality of tags, empty tags etc etc). As the bundle gems service currently does not support anything other than rubygems, we created an experimental gem to try out some of our improvements. As long as bundle gems does not support downloads from other services than rubygems.org this is the easiest solution. All other solutions have other trade offs like e.g. not working in CI or development. 

The main feature we would like to try out with production data is adding the request start time and request id. This will enable us to show e.g. the slowest requests of a certain time span and draw metrics for this request (e.g. all backend requests, SQL queries and renderings of this request).

cc @coolo 