### PR TITLE
Ready requests take reviews into account

### DIFF
--- a/src/api/app/models/staging/workflow.rb
+++ b/src/api/app/models/staging/workflow.rb
@@ -22,7 +22,7 @@ class Staging::Workflow < ApplicationRecord
     end
 
     def ready_to_stage
-      in_states('new')
+      in_states(:new)
     end
   end
 

--- a/src/api/app/models/staging/workflow.rb
+++ b/src/api/app/models/staging/workflow.rb
@@ -18,7 +18,7 @@ class Staging::Workflow < ApplicationRecord
   has_many :target_of_bs_requests, through: :project, foreign_key: 'staging_workflow_id' do
     def stageable
       managers_group_title = proxy_association.owner.managers_group.try(:title)
-      includes(:reviews).where(state: :review, reviews: { state: :new, by_group: managers_group_title })
+      includes(:reviews).where(state: :review, staging_project_id: nil, reviews: { state: :new, by_group: managers_group_title })
     end
 
     def ready_to_stage

--- a/src/api/app/models/staging/workflow.rb
+++ b/src/api/app/models/staging/workflow.rb
@@ -33,6 +33,7 @@ class Staging::Workflow < ApplicationRecord
   validates :managers_group, presence: true
 
   after_create :create_staging_projects
+  after_create :add_reviewer_group
   before_update :update_staging_projects_managers_group
 
   def unassigned_requests
@@ -76,5 +77,11 @@ class Staging::Workflow < ApplicationRecord
     # FIXME: This assignation is need because after store a staging_project
     # the object is reloaded and we lost the changes.
     self.managers_group = new_managers_group
+  end
+
+  def add_reviewer_group
+    role = Role.find_by_title('reviewer')
+    project.relationships.find_or_create_by(group: managers_group, role: role)
+    project.store
   end
 end

--- a/src/api/spec/models/staging/workflow_spec.rb
+++ b/src/api/spec/models/staging/workflow_spec.rb
@@ -33,15 +33,7 @@ RSpec.describe Staging::Workflow, type: :model do
       it { expect(subject).to be_empty }
     end
 
-    context 'with requests without reviews by the staging managers group' do
-      before { bs_request }
-
-      it { expect(subject).to be_empty }
-    end
-
     context 'with requests with reviews by the staging managers group' do
-      let!(:review) { create(:review, by_group: group.title, bs_request: bs_request) }
-
       it { expect(subject).to contain_exactly(bs_request) }
     end
 

--- a/src/api/spec/models/staging/workflow_spec.rb
+++ b/src/api/spec/models/staging/workflow_spec.rb
@@ -21,6 +21,11 @@ RSpec.describe Staging::Workflow, type: :model do
     staging_workflow
   end
 
+  context 'when created' do
+    let(:role) { Role.find_by_title('reviewer') }
+    it { expect(project.relationships.where(group: group, role: role)).to exist }
+  end
+
   describe '#unassigned_requests' do
     subject { staging_workflow.unassigned_requests }
 


### PR DESCRIPTION
A request is «ready» when its state is «new» and it has some reviews and
at least one of them is in state «accepted».

Co-authored-by: Eduardo Navarro <enavarro@suse.com>


