### PR TITLE
Revert "Change field name for backend influx subscriber"

### DIFF
--- a/src/api/lib/influxdb_obs/obs/middleware/backend_subscriber.rb
+++ b/src/api/lib/influxdb_obs/obs/middleware/backend_subscriber.rb
@@ -33,7 +33,7 @@ module InfluxDB
         end
 
         def values(runtime)
-          values = { runtime: ((runtime || 0) * 1000).ceil }
+          values = { value: ((runtime || 0) * 1000).ceil }
           values.merge(InfluxDB::Rails.current.values).reject do |_, value|
             value.nil? || value == ''
           end

--- a/src/api/spec/lib/influx_db/obs/middleware/backend_subscriber_spec.rb
+++ b/src/api/spec/lib/influx_db/obs/middleware/backend_subscriber_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe InfluxDB::OBS::Middleware::BackendSubscriber do
     let(:result) do
       {
         values: {
-          runtime: 2000
+          value: 2000
         },
         tags: {
           http_status_code: 200,


### PR DESCRIPTION
This reverts commit a0b183ea52e48bb36898701f17525c0d9bf1dd5b.

Because this was just a workaround to not drop the entire series.
We needed to do this anyway so it makes sense to use value as
field name again to be par with the other series.

