### PR TITLE
Add WebUI/API endpoints, documentation and job to copy a staging project

### DIFF
--- a/docs/api/api/api.txt
+++ b/docs/api/api/api.txt
@@ -1937,6 +1937,7 @@ XmlResult: required_checks
 
 <staging_workflow_project>: The name of the staging workflow project, e.g. openSUSE:Factory
 <staging_project>: The name of the staging project, e.g. openSUSE:Factory:Staging:A
+<staging_project_copy_name>: The name of the staging project's copy, e.g. openSUSE:Factory:Staging:B
 
 GET /staging/<staging_workflow_project>/staging_projects
   Get the overall state of all staging projects belonging to a staging workflow project
@@ -1945,6 +1946,10 @@ XmlResult: staging_projects
 GET /staging/<staging_workflow_project>/staging_projects/<staging_project>
   Get the overall state of a staging project
 XmlResult: staging_project
+
+POST /staging/<staging_workflow_project>/staging_projects/<staging_project>/copy/<staging_project_copy_name>
+  Copy a staging project
+XmlResult: status_ok
 
 === Excluded Requests
 

--- a/src/api/app/controllers/staging/staging_projects_controller.rb
+++ b/src/api/app/controllers/staging/staging_projects_controller.rb
@@ -1,5 +1,5 @@
 class Staging::StagingProjectsController < ApplicationController
-  skip_before_action :require_login
+  before_action :require_login, except: [:index, :show]
 
   before_action :set_main_project
 
@@ -14,6 +14,14 @@ class Staging::StagingProjectsController < ApplicationController
 
   def show
     @staging_project = @main_project.staging.staging_projects.find_by!(name: params[:name])
+  end
+
+  def copy
+    authorize @main_project.staging
+
+    StagingProjectCopyJob.perform_later(params[:staging_main_project_name], params[:staging_project_name], params[:staging_project_copy_name])
+
+    render_ok
   end
 
   private

--- a/src/api/app/controllers/webui/staging/projects_controller.rb
+++ b/src/api/app/controllers/webui/staging/projects_controller.rb
@@ -47,6 +47,23 @@ module Webui
         redirect_to edit_staging_workflow_path(@staging_workflow)
       end
 
+      def preview_copy
+        authorize @staging_workflow
+
+        @staging_project = @staging_workflow.staging_projects.find_by(name: params[:staging_project_project_name])
+        @project = @staging_workflow.project
+      end
+
+      def copy
+        authorize @staging_workflow
+
+        StagingProjectCopyJob.perform_later(@staging_workflow.project.name, params[:staging_project_project_name], params[:staging_project_copy_name])
+
+        flash[:success] = "Job to copy the staging project #{params[:staging_project_project_name]} successfully queued."
+
+        redirect_to edit_staging_workflow_path(@staging_workflow)
+      end
+
       private
 
       def set_staging_workflow

--- a/src/api/app/jobs/staging_project_copy_job.rb
+++ b/src/api/app/jobs/staging_project_copy_job.rb
@@ -1,0 +1,7 @@
+class StagingProjectCopyJob < ApplicationJob
+  def perform(staging_workflow_project_name, original_staging_project_name, staging_project_copy_name)
+    staging_workflow_project = Project.find_by!(name: staging_workflow_project_name)
+    original_staging_project = staging_workflow_project.staging.staging_projects.find_by!(name: original_staging_project_name)
+    original_staging_project.copy(staging_project_copy_name)
+  end
+end

--- a/src/api/app/policies/staging/workflow_policy.rb
+++ b/src/api/app/policies/staging/workflow_policy.rb
@@ -22,4 +22,12 @@ class Staging::WorkflowPolicy < ApplicationPolicy
   def destroy?
     ProjectPolicy.new(user, record.project).destroy?
   end
+
+  def copy?
+    update?
+  end
+
+  def preview_copy?
+    copy?
+  end
 end

--- a/src/api/app/views/webui2/webui/staging/projects/_breadcrumb_items.html.haml
+++ b/src/api/app/views/webui2/webui/staging/projects/_breadcrumb_items.html.haml
@@ -2,3 +2,8 @@
 - if controller_name == 'projects' && action_name == 'show'
   %li.breadcrumb-item.active{ 'aria-current' => 'page' }
     = @staging_project.name
+- elsif controller_name == 'projects' && action_name == 'preview_copy'
+  %li.breadcrumb-item
+    = link_to(@staging_project.name, staging_workflow_staging_project_path(@staging_project.staging_workflow_id, @staging_project))
+  %li.breadcrumb-item.active{ 'aria-current' => 'page' }
+    Copy

--- a/src/api/app/views/webui2/webui/staging/projects/preview_copy.html.haml
+++ b/src/api/app/views/webui2/webui/staging/projects/preview_copy.html.haml
@@ -1,0 +1,21 @@
+- @pagetitle = "Copy #{@staging_project.name}"
+
+.row
+  .col-xl-10
+    .card.mb-3
+      = render(partial: 'webui2/webui/project/tabs', locals: { project: @staging_project })
+      .card-body
+        %h3= @pagetitle
+        %p The following data will be copied:
+        %ul
+          %li Project Configuration
+          %li Repositories
+          %li Users and Groups
+
+        = form_tag(staging_workflow_staging_project_copy_path(@staging_workflow, @staging_project), method: :post) do
+          .form-group
+            = label_tag(:staging_project_copy_name, 'Name of the Staging Project Copy:')
+            = text_field_tag(:staging_project_copy_name, nil, placeholder: "Eg: #{@staging_project}-copy", class: 'form-control')
+
+          = submit_tag('Copy', class: 'btn btn-primary')
+          = link_to('Back', edit_staging_workflow_path(@staging_workflow), class: 'btn btn-secondary', role: 'button')

--- a/src/api/app/views/webui2/webui/staging/workflows/_staging_projects_table.html.haml
+++ b/src/api/app/views/webui2/webui/staging/workflows/_staging_projects_table.html.haml
@@ -17,6 +17,8 @@
           = render partial: 'problems', locals: { staging_project: staging_project }
         - if display_actions_column
           %td.text-center
+            = link_to(staging_workflow_staging_project_preview_copy_path(staging_workflow, staging_project), title: 'Copy Staging Project') do
+              %i.fas.fa-clone.text-secondary
             = link_to('#', data: { toggle: 'modal', target: "#confirm-modal-#{staging_project.id}" }, title: "Delete #{staging_project}") do
               %i.fas.fa-times-circle.text-danger
 

--- a/src/api/config/routes.rb
+++ b/src/api/config/routes.rb
@@ -480,7 +480,10 @@ OBSApi::Application.routes.draw do
   get 'published/' => 'source#index', via: :get
 
   resources :staging_workflows, except: :index, controller: 'webui/staging/workflows', constraints: cons do
-    resources :staging_projects, only: [:create, :destroy, :show], controller: 'webui/staging/projects', param: :project_name, constraints: cons
+    resources :staging_projects, only: [:create, :destroy, :show], controller: 'webui/staging/projects', param: :project_name, constraints: cons do
+      get :preview_copy
+      post :copy
+    end
     resources :excluded_requests, controller: 'webui/staging/excluded_requests'
   end
 
@@ -752,6 +755,8 @@ OBSApi::Application.routes.draw do
   # StagingWorkflow API
   resources :staging, only: [], param: 'main_project_name' do
     resources :staging_projects, only: [:index, :show], controller: 'staging/staging_projects', param: :name do
+      post 'copy/:staging_project_copy_name' => :copy
+
       get 'staged_requests' => 'staging/staged_requests#index', constraints: cons
       resource :staged_requests, controller: 'staging/staged_requests', only: [:create, :destroy], constraints: cons
     end

--- a/src/api/spec/cassettes/StagingProjectCopyJob/_perform/copies_the_staging_project.yml
+++ b/src/api/spec/cassettes/StagingProjectCopyJob/_perform/copies_the_staging_project.yml
@@ -1,0 +1,550 @@
+---
+http_interactions:
+- request:
+    method: put
+    uri: http://backend:5352/source/my_project/_meta?user=_nobody_
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="my_project">
+          <title>The Little Foxes</title>
+          <description/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '103'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="my_project">
+          <title>The Little Foxes</title>
+          <description></description>
+        </project>
+    http_version: 
+  recorded_at: Fri, 18 Jan 2019 13:14:47 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/my_project/_project/_staging_workflow?user=_nobody_
+    body:
+      encoding: UTF-8
+      string: |
+        <workflow project="my_project" managers="staging-workflow-managers-1">
+          <staging_project name="my_project:Staging:A"/>
+        </workflow>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '170'
+    body:
+      encoding: UTF-8
+      string: |
+        <revision rev="5">
+          <srcmd5>55e6dddca7dae9aacbad0d843acbb3d0</srcmd5>
+          <time>1547817287</time>
+          <user>_nobody_</user>
+          <comment></comment>
+          <requestid/>
+        </revision>
+    http_version: 
+  recorded_at: Fri, 18 Jan 2019 13:14:47 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/my_project:Staging:A/_meta?user=_nobody_
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="my_project:Staging:A">
+          <title/>
+          <description/>
+          <group groupid="staging-workflow-managers-1" role="maintainer"/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '165'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="my_project:Staging:A">
+          <title></title>
+          <description></description>
+          <group groupid="staging-workflow-managers-1" role="maintainer" />
+        </project>
+    http_version: 
+  recorded_at: Fri, 18 Jan 2019 13:14:47 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/my_project/_project/_staging_workflow?user=_nobody_
+    body:
+      encoding: UTF-8
+      string: |
+        <workflow project="my_project" managers="staging-workflow-managers-1">
+          <staging_project name="my_project:Staging:A"/>
+          <staging_project name="my_project:Staging:B"/>
+        </workflow>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '170'
+    body:
+      encoding: UTF-8
+      string: |
+        <revision rev="6">
+          <srcmd5>cc139e06c82bb7d36078874e5f20082a</srcmd5>
+          <time>1547817287</time>
+          <user>_nobody_</user>
+          <comment></comment>
+          <requestid/>
+        </revision>
+    http_version: 
+  recorded_at: Fri, 18 Jan 2019 13:14:47 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/my_project:Staging:B/_meta?user=_nobody_
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="my_project:Staging:B">
+          <title/>
+          <description/>
+          <group groupid="staging-workflow-managers-1" role="maintainer"/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '165'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="my_project:Staging:B">
+          <title></title>
+          <description></description>
+          <group groupid="staging-workflow-managers-1" role="maintainer" />
+        </project>
+    http_version: 
+  recorded_at: Fri, 18 Jan 2019 13:14:47 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/my_project/_project/_staging_workflow?user=_nobody_
+    body:
+      encoding: UTF-8
+      string: |
+        <workflow project="my_project" managers="staging-workflow-managers-1">
+          <staging_project name="my_project:Staging:A"/>
+          <staging_project name="my_project:Staging:B"/>
+          <staging_project name="my_project:Staging:C"/>
+        </workflow>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '170'
+    body:
+      encoding: UTF-8
+      string: |
+        <revision rev="7">
+          <srcmd5>713c147aa50131553d2c3b2556d918bf</srcmd5>
+          <time>1547817287</time>
+          <user>_nobody_</user>
+          <comment></comment>
+          <requestid/>
+        </revision>
+    http_version: 
+  recorded_at: Fri, 18 Jan 2019 13:14:47 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/my_project:Staging:C/_config?user=factory%20bot
+    body:
+      encoding: UTF-8
+      string: 'Prefer: something'
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 404
+      message: project 'my_project Staging C' does not exist
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '168'
+    body:
+      encoding: UTF-8
+      string: |
+        <status code="404">
+          <summary>project 'my_project:Staging:C' does not exist</summary>
+          <details>404 project 'my_project:Staging:C' does not exist</details>
+        </status>
+    http_version: 
+  recorded_at: Fri, 18 Jan 2019 13:14:47 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/my_project:Staging:C/_meta?user=_nobody_
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="my_project:Staging:C">
+          <title>O Pioneers!</title>
+          <description/>
+          <group groupid="staging-workflow-managers-1" role="maintainer"/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '176'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="my_project:Staging:C">
+          <title>O Pioneers!</title>
+          <description></description>
+          <group groupid="staging-workflow-managers-1" role="maintainer" />
+        </project>
+    http_version: 
+  recorded_at: Fri, 18 Jan 2019 13:14:47 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/my_project/_project/_staging_workflow?user=_nobody_
+    body:
+      encoding: UTF-8
+      string: |
+        <workflow project="my_project" managers="staging-workflow-managers-1">
+          <staging_project name="my_project:Staging:A"/>
+          <staging_project name="my_project:Staging:B"/>
+          <staging_project name="my_project:Staging:C"/>
+          <staging_project name="my_project:Staging:C-copy"/>
+        </workflow>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '170'
+    body:
+      encoding: UTF-8
+      string: |
+        <revision rev="8">
+          <srcmd5>13bd0a0f14d368cc34f1b9ab5e96f89d</srcmd5>
+          <time>1547817287</time>
+          <user>_nobody_</user>
+          <comment></comment>
+          <requestid/>
+        </revision>
+    http_version: 
+  recorded_at: Fri, 18 Jan 2019 13:14:47 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/my_project/_project/_staging_workflow?user=_nobody_
+    body:
+      encoding: UTF-8
+      string: |
+        <workflow project="my_project" managers="staging-workflow-managers-1">
+          <staging_project name="my_project:Staging:A"/>
+          <staging_project name="my_project:Staging:B"/>
+          <staging_project name="my_project:Staging:C"/>
+          <staging_project name="my_project:Staging:C-copy"/>
+        </workflow>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '170'
+    body:
+      encoding: UTF-8
+      string: |
+        <revision rev="9">
+          <srcmd5>13bd0a0f14d368cc34f1b9ab5e96f89d</srcmd5>
+          <time>1547817287</time>
+          <user>_nobody_</user>
+          <comment></comment>
+          <requestid/>
+        </revision>
+    http_version: 
+  recorded_at: Fri, 18 Jan 2019 13:14:47 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/my_project:Staging:C-copy/_meta?user=_nobody_
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="my_project:Staging:C-copy">
+          <title>O Pioneers!</title>
+          <description/>
+          <group groupid="staging-workflow-managers-1" role="maintainer"/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '181'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="my_project:Staging:C-copy">
+          <title>O Pioneers!</title>
+          <description></description>
+          <group groupid="staging-workflow-managers-1" role="maintainer" />
+        </project>
+    http_version: 
+  recorded_at: Fri, 18 Jan 2019 13:14:47 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/my_project:Staging:C/_config
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/plain
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '0'
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Fri, 18 Jan 2019 13:14:47 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/my_project:Staging:C-copy/_config?comment=Copying%20project%20my_project:Staging:C&user=
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '21'
+    body:
+      encoding: UTF-8
+      string: '<status code="ok" />
+
+'
+    http_version: 
+  recorded_at: Fri, 18 Jan 2019 13:14:47 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/my_project:Staging:C-copy/_config
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/plain
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '0'
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Fri, 18 Jan 2019 13:14:47 GMT
+recorded_with: VCR 4.0.0

--- a/src/api/spec/jobs/staging_project_copy_job_spec.rb
+++ b/src/api/spec/jobs/staging_project_copy_job_spec.rb
@@ -1,0 +1,19 @@
+require 'rails_helper'
+require 'webmock/rspec'
+
+RSpec.describe StagingProjectCopyJob, type: :job, vcr: true do
+  include ActiveJob::TestHelper
+
+  describe '#perform' do
+    let(:project) { create(:project, name: 'my_project') }
+    let(:staging_workflow) { create(:staging_workflow, project: project) }
+    let!(:original_staging_project) { create(:staging_project, staging_workflow: staging_workflow, project_config: 'Prefer: something') }
+    let(:staging_project_copy_name) { "#{original_staging_project.name}-copy" }
+
+    it 'copies the staging project' do
+      expect(Project.exists?(name: staging_project_copy_name)).to be false
+      StagingProjectCopyJob.new.perform(staging_workflow.project.name, original_staging_project.name, staging_project_copy_name)
+      expect(Project.exists?(name: staging_project_copy_name)).to be true
+    end
+  end
+end


### PR DESCRIPTION

![copy](https://user-images.githubusercontent.com/1102934/51307814-e55fca00-1a40-11e9-9623-5c30d640a264.png)
For the WebUI part, I have created a view to preview the copy of a staging project. Right now, it's quite basic and rough, but I prefer to gather feedback before going further (if we decide it's worth it). Anyway, my idea is to provide some information about what is to be copied instead of just copying a staging project without giving any feedback to the user (this would be so if we used a modal for example).

Let me know what you think. Here's how it looks:

Clickable icons to reach the `Copy` page, they are displayed when we are configuring the staging workflow (so after clicking the `Configure` on the staging workflow show page):
![icon](https://user-images.githubusercontent.com/1102934/51257978-286e5e80-19a9-11e9-99d9-e31d132aeb78.png)

The `Copy` page:
![copy](https://user-images.githubusercontent.com/1102934/51307830-f1e42280-1a40-11e9-97cf-a4831712272b.png)