### PR TITLE
Fix maintenance incident release when package already exists

### DIFF
--- a/src/api/app/models/package.rb
+++ b/src/api/app/models/package.rb
@@ -1236,12 +1236,12 @@ class Package < ApplicationRecord
     update_needed = nil
     if project.flags.find_by_flag_and_status('build', 'disable')
       # enable package builds if project default is disabled
-      flags.create(position: 1, flag: 'build', status: 'enable', repo: repo_name)
+      flags.find_or_create_by(flag: 'build', status: 'enable', repo: repo_name)
       update_needed = true
     end
     if project.flags.find_by_flag_and_status('debuginfo', 'disable')
       # take over debuginfo config from origin project
-      flags.create(position: 1, flag: 'debuginfo', status: 'enable', repo: repo_name)
+      flags.find_or_create_by(flag: 'debuginfo', status: 'enable', repo: repo_name)
       update_needed = true
     end
     store if update_needed

--- a/src/api/spec/bootstrap/features/webui/maintenance_workflow_spec.rb
+++ b/src/api/spec/bootstrap/features/webui/maintenance_workflow_spec.rb
@@ -142,6 +142,8 @@ RSpec.feature 'Bootstrap_MaintenanceWorkflow', type: :feature, js: true, vcr: tr
 
     click_button('accept_request_button')
 
+    expect(page).to have_css('#flash-messages', text: 'Request 2 accepted')
+
     # Step 7: The maintenance coordinator releases the request
     ##########################################################
     visit project_show_path('MaintenanceProject:0')


### PR DESCRIPTION
When updating a package in a maintenance project which already exists it crashed
because it tried to create the flags again which caused the uniqueness validation to crash.
This was introduced in #6619.
Fix #6766.

