### PR TITLE
Handle self-referencing repositories when cloning staging projects

### DIFF
--- a/src/api/Gemfile
+++ b/src/api/Gemfile
@@ -80,6 +80,8 @@ gem 'builder'
 gem 'experimental-influxdb-rails', '>=1.0.0.beta5'
 # for client side time ago
 gem 'rails-timeago', '~> 2.0'
+# for copying objects with their relations
+gem 'deep_cloneable', '~> 2.4.0'
 
 group :development, :production do
   # to have the delayed job daemon

--- a/src/api/Gemfile.lock
+++ b/src/api/Gemfile.lock
@@ -125,6 +125,8 @@ GEM
     data_migrate (5.3.0)
       rails (>= 4.2)
     database_cleaner (1.7.0)
+    deep_cloneable (2.4.0)
+      activerecord (>= 3.1.0, < 6)
     delayed_job (4.1.5)
       activesupport (>= 3.0, < 5.3)
     delayed_job_active_record (4.1.3)
@@ -472,6 +474,7 @@ DEPENDENCIES
   dalli
   data_migrate (= 5.3.0)
   database_cleaner (>= 1.0.1)
+  deep_cloneable (~> 2.4.0)
   delayed_job_active_record (>= 4.0.0)
   escape_utils
   experimental-influxdb-rails (>= 1.0.0.beta5)

--- a/src/api/app/models/repository.rb
+++ b/src/api/app/models/repository.rb
@@ -257,6 +257,15 @@ class Repository < ApplicationRecord
   def build_id
     Backend::Api::Published.build_id(project.name, name)
   end
+
+  def copy_to(new_project)
+    new_repository = deep_clone(include: [:path_elements, :repository_architectures], skip_missing_associations: true)
+    # DoD repositories require the architecture references to be stored
+    new_repository.update!(db_project_id: new_project.id)
+    new_repository.download_repositories = download_repositories.map(&:deep_clone)
+
+    new_repository.reload
+  end
 end
 
 # == Schema Information

--- a/src/api/app/models/staging/staging_project.rb
+++ b/src/api/app/models/staging/staging_project.rb
@@ -37,6 +37,10 @@ module Staging
         repository.path_elements.where(repository_id: old_project.repositories).find_each do |path|
           new_linked_repo = repositories.find_by(name: path.link.name)
           path.update!(repository_id: new_linked_repo.id)
+
+          # Update repository name by replacing project related part with new project name.
+          new_link_name = path.link.name.sub(/#{old_project.name.tr(':', '.*')}/, name)
+          new_linked_repo.update!(name: new_link_name.tr(':', '_'))
         end
       end
     end

--- a/src/api/app/models/staging/staging_project.rb
+++ b/src/api/app/models/staging/staging_project.rb
@@ -17,6 +17,7 @@ module Staging
         new_project.save!
 
         repositories.each { |repository| repository.copy_to(new_project) }
+        new_project.update_self_referencing_repositories!(self)
 
         # We can't use deep_clone here because of an exception raised in Relationship#add_group
         relationships.each do |relationship|
@@ -26,6 +27,17 @@ module Staging
         new_project.store
 
         new_project
+      end
+    end
+
+    # Some staging projects contain repositories that refer to themself. In such
+    # cases we create a new self-referencing repository path.
+    def update_self_referencing_repositories!(old_project)
+      repositories.includes(:path_elements).find_each do |repository|
+        repository.path_elements.where(repository_id: old_project.repositories).find_each do |path|
+          new_linked_repo = repositories.find_by(name: path.link.name)
+          path.update!(repository_id: new_linked_repo.id)
+        end
       end
     end
 

--- a/src/api/spec/cassettes/Staging_StagingProject/_copy/1_6_2.yml
+++ b/src/api/spec/cassettes/Staging_StagingProject/_copy/1_6_2.yml
@@ -1,0 +1,38 @@
+---
+http_interactions:
+- request:
+    method: put
+    uri: http://backend:5352/source/home:tom:Staging:G/_config?user=factory%20bot
+    body:
+      encoding: UTF-8
+      string: 'Prefer: foo'
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 404
+      message: project 'home tom Staging G' does not exist
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '164'
+    body:
+      encoding: UTF-8
+      string: |
+        <status code="404">
+          <summary>project 'home:tom:Staging:G' does not exist</summary>
+          <details>404 project 'home:tom:Staging:G' does not exist</details>
+        </status>
+    http_version: 
+  recorded_at: Mon, 14 Jan 2019 09:32:18 GMT
+recorded_with: VCR 4.0.0

--- a/src/api/spec/cassettes/Staging_StagingProject/_copy/copies_flags.yml
+++ b/src/api/spec/cassettes/Staging_StagingProject/_copy/copies_flags.yml
@@ -1,0 +1,38 @@
+---
+http_interactions:
+- request:
+    method: put
+    uri: http://backend:5352/source/home:tom:Staging:D/_config?user=factory%20bot
+    body:
+      encoding: UTF-8
+      string: 'Prefer: foo'
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 404
+      message: project 'home tom Staging D' does not exist
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '164'
+    body:
+      encoding: UTF-8
+      string: |
+        <status code="404">
+          <summary>project 'home:tom:Staging:D' does not exist</summary>
+          <details>404 project 'home:tom:Staging:D' does not exist</details>
+        </status>
+    http_version: 
+  recorded_at: Mon, 14 Jan 2019 09:32:13 GMT
+recorded_with: VCR 4.0.0

--- a/src/api/spec/cassettes/Staging_StagingProject/_copy/copies_the_project_config.yml
+++ b/src/api/spec/cassettes/Staging_StagingProject/_copy/copies_the_project_config.yml
@@ -1,0 +1,38 @@
+---
+http_interactions:
+- request:
+    method: put
+    uri: http://backend:5352/source/home:tom:Staging:H/_config?user=factory%20bot
+    body:
+      encoding: UTF-8
+      string: 'Prefer: foo'
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 404
+      message: project 'home tom Staging H' does not exist
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '164'
+    body:
+      encoding: UTF-8
+      string: |
+        <status code="404">
+          <summary>project 'home:tom:Staging:H' does not exist</summary>
+          <details>404 project 'home:tom:Staging:H' does not exist</details>
+        </status>
+    http_version: 
+  recorded_at: Mon, 14 Jan 2019 09:32:18 GMT
+recorded_with: VCR 4.0.0

--- a/src/api/spec/cassettes/Staging_StagingProject/_copy/copies_the_relationships.yml
+++ b/src/api/spec/cassettes/Staging_StagingProject/_copy/copies_the_relationships.yml
@@ -1,0 +1,38 @@
+---
+http_interactions:
+- request:
+    method: put
+    uri: http://backend:5352/source/home:tom:Staging:F/_config?user=factory%20bot
+    body:
+      encoding: UTF-8
+      string: 'Prefer: foo'
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 404
+      message: project 'home tom Staging F' does not exist
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '164'
+    body:
+      encoding: UTF-8
+      string: |
+        <status code="404">
+          <summary>project 'home:tom:Staging:F' does not exist</summary>
+          <details>404 project 'home:tom:Staging:F' does not exist</details>
+        </status>
+    http_version: 
+  recorded_at: Mon, 14 Jan 2019 09:32:17 GMT
+recorded_with: VCR 4.0.0

--- a/src/api/spec/cassettes/Staging_StagingProject/_copy/copies_the_repositories.yml
+++ b/src/api/spec/cassettes/Staging_StagingProject/_copy/copies_the_repositories.yml
@@ -1,0 +1,38 @@
+---
+http_interactions:
+- request:
+    method: put
+    uri: http://backend:5352/source/home:tom:Staging:E/_config?user=factory%20bot
+    body:
+      encoding: UTF-8
+      string: 'Prefer: foo'
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 404
+      message: project 'home tom Staging E' does not exist
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '164'
+    body:
+      encoding: UTF-8
+      string: |
+        <status code="404">
+          <summary>project 'home:tom:Staging:E' does not exist</summary>
+          <details>404 project 'home:tom:Staging:E' does not exist</details>
+        </status>
+    http_version: 
+  recorded_at: Mon, 14 Jan 2019 09:32:14 GMT
+recorded_with: VCR 4.0.0

--- a/src/api/spec/cassettes/Staging_StagingProject/_copy/copies_the_repositories_and_it_s_relations.yml
+++ b/src/api/spec/cassettes/Staging_StagingProject/_copy/copies_the_repositories_and_it_s_relations.yml
@@ -1,0 +1,38 @@
+---
+http_interactions:
+- request:
+    method: put
+    uri: http://backend:5352/source/home:tom:Staging:C/_config?user=factory%20bot
+    body:
+      encoding: UTF-8
+      string: 'Prefer: foo'
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 404
+      message: project 'home tom Staging C' does not exist
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '164'
+    body:
+      encoding: UTF-8
+      string: |
+        <status code="404">
+          <summary>project 'home:tom:Staging:C' does not exist</summary>
+          <details>404 project 'home:tom:Staging:C' does not exist</details>
+        </status>
+    http_version: 
+  recorded_at: Mon, 14 Jan 2019 10:17:15 GMT
+recorded_with: VCR 4.0.0

--- a/src/api/spec/cassettes/Staging_StagingProject/_copy/creates_a_new_staging_project.yml
+++ b/src/api/spec/cassettes/Staging_StagingProject/_copy/creates_a_new_staging_project.yml
@@ -1,0 +1,38 @@
+---
+http_interactions:
+- request:
+    method: put
+    uri: http://backend:5352/source/home:tom:Staging:C/_config?user=factory%20bot
+    body:
+      encoding: UTF-8
+      string: 'Prefer: foo'
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 404
+      message: project 'home tom Staging C' does not exist
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '164'
+    body:
+      encoding: UTF-8
+      string: |
+        <status code="404">
+          <summary>project 'home:tom:Staging:C' does not exist</summary>
+          <details>404 project 'home:tom:Staging:C' does not exist</details>
+        </status>
+    http_version: 
+  recorded_at: Mon, 14 Jan 2019 09:32:12 GMT
+recorded_with: VCR 4.0.0

--- a/src/api/spec/cassettes/Staging_StagingProject/_copy/when_the_repository_contains_path_elements_that_link_to_repositories_of_the_same_project/ensures_that_the_new_created_path_is_also_self_referencing.yml
+++ b/src/api/spec/cassettes/Staging_StagingProject/_copy/when_the_repository_contains_path_elements_that_link_to_repositories_of_the_same_project/ensures_that_the_new_created_path_is_also_self_referencing.yml
@@ -1,0 +1,38 @@
+---
+http_interactions:
+- request:
+    method: put
+    uri: http://backend:5352/source/home:tom:Staging:C/_config?user=factory%20bot
+    body:
+      encoding: UTF-8
+      string: 'Prefer: foo'
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 404
+      message: project 'home tom Staging C' does not exist
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '164'
+    body:
+      encoding: UTF-8
+      string: |
+        <status code="404">
+          <summary>project 'home:tom:Staging:C' does not exist</summary>
+          <details>404 project 'home:tom:Staging:C' does not exist</details>
+        </status>
+    http_version: 
+  recorded_at: Tue, 15 Jan 2019 16:45:43 GMT
+recorded_with: VCR 4.0.0

--- a/src/api/spec/cassettes/Staging_StagingProject/_copy/when_the_repository_contains_path_elements_that_link_to_repositories_of_the_same_project/renames_the_repository_link_if_it_contains_a_reference_to_the_project.yml
+++ b/src/api/spec/cassettes/Staging_StagingProject/_copy/when_the_repository_contains_path_elements_that_link_to_repositories_of_the_same_project/renames_the_repository_link_if_it_contains_a_reference_to_the_project.yml
@@ -1,0 +1,38 @@
+---
+http_interactions:
+- request:
+    method: put
+    uri: http://backend:5352/source/home:tom:Staging:J/_config?user=factory%20bot
+    body:
+      encoding: UTF-8
+      string: 'Prefer: foo'
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 404
+      message: project 'home tom Staging J' does not exist
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '164'
+    body:
+      encoding: UTF-8
+      string: |
+        <status code="404">
+          <summary>project 'home:tom:Staging:J' does not exist</summary>
+          <details>404 project 'home:tom:Staging:J' does not exist</details>
+        </status>
+    http_version: 
+  recorded_at: Tue, 15 Jan 2019 17:25:07 GMT
+recorded_with: VCR 4.0.0

--- a/src/api/spec/cassettes/Staging_StagingProject/_copy/when_the_repository_contains_path_elements_that_link_to_themself/ensures_that_the_new_created_path_is_also_self_referencing.yml
+++ b/src/api/spec/cassettes/Staging_StagingProject/_copy/when_the_repository_contains_path_elements_that_link_to_themself/ensures_that_the_new_created_path_is_also_self_referencing.yml
@@ -1,0 +1,38 @@
+---
+http_interactions:
+- request:
+    method: put
+    uri: http://backend:5352/source/home:tom:Staging:I/_config?user=factory%20bot
+    body:
+      encoding: UTF-8
+      string: 'Prefer: foo'
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 404
+      message: project 'home tom Staging I' does not exist
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '164'
+    body:
+      encoding: UTF-8
+      string: |
+        <status code="404">
+          <summary>project 'home:tom:Staging:I' does not exist</summary>
+          <details>404 project 'home:tom:Staging:I' does not exist</details>
+        </status>
+    http_version: 
+  recorded_at: Tue, 15 Jan 2019 15:16:39 GMT
+recorded_with: VCR 4.0.0

--- a/src/api/spec/factories/project.rb
+++ b/src/api/spec/factories/project.rb
@@ -3,6 +3,7 @@ FactoryBot.define do
     transient do
       link_to { nil }
       maintainer { nil }
+      project_config { nil }
     end
 
     sequence(:name) { |n| "project_#{n}" }
@@ -11,6 +12,10 @@ FactoryBot.define do
     after(:create) do |project, evaluator|
       if evaluator.link_to
         LinkedProject.create(project: project, linked_db_project: evaluator.link_to)
+      end
+
+      if evaluator.project_config
+        project.config.save({ user: 'factory bot' }, evaluator.project_config)
       end
 
       if evaluator.maintainer

--- a/src/api/spec/factories/staging_projects.rb
+++ b/src/api/spec/factories/staging_projects.rb
@@ -1,5 +1,6 @@
 FactoryBot.define do
   factory :staging_project, class: 'Staging::StagingProject', parent: :project do
-    sequence(:name, [*'A'..'Z'].cycle) { |letter| "#{staging_workflow.project.name}:Staging:#{letter}" }
+    # Staging workflows have 2 staging projects by default, *:Staging:A and *:Staging:B.
+    sequence(:name, [*'C'..'Z'].cycle) { |letter| "#{staging_workflow.project.name}:Staging:#{letter}" }
   end
 end

--- a/src/api/spec/features/webui/projects_spec.rb
+++ b/src/api/spec/features/webui/projects_spec.rb
@@ -260,7 +260,7 @@ RSpec.feature 'Projects', type: :feature, js: true do
 
       scenario 'removing download repositories' do
         create(:repository_architecture, repository: repository, architecture: Architecture.find_by_name('i586'))
-        download_repository_2 = create(:download_repository, repository: repository, arch: 'i586')
+        download_repository_2 = create(:download_repository, repository: repository.reload, arch: 'i586')
 
         visit(project_repositories_path(project: project_with_dod_repo))
         # Delete link

--- a/src/api/spec/models/staging/staging_project_spec.rb
+++ b/src/api/spec/models/staging/staging_project_spec.rb
@@ -185,4 +185,51 @@ RSpec.describe Staging::StagingProject, vcr: true do
 
     it { expect(staging_project.reload.groups).to be_empty }
   end
+
+  describe '#copy' do
+    let(:staging_project) { create(:staging_project, staging_workflow: staging_workflow, project_config: 'Prefer: foo') }
+    let(:new_project_name) { "#{user.home_project}:new_project" }
+    let!(:group_relationship) { create(:relationship_project_group, project: staging_project) }
+    let!(:user_relationship) { create(:relationship_project_user, project: staging_project) }
+    let!(:flag) { create(:sourceaccess_flag, project: staging_project) }
+    # path elements and DoD repository are just needed for smoke testing, e.g. do we have validations or
+    # other custom code that would conflict with what 'deep_cloneable' does
+    let!(:path_elements) { create_list(:path_element, 3, repository: repository) }
+    let!(:dod_repository) { create(:download_repository, repository: repository) }
+
+    before do
+      User.current = user
+    end
+
+    after do
+      User.current = nil
+    end
+
+    subject { staging_project.reload.copy(new_project_name) }
+
+    it 'creates a new staging project' do
+      expect(subject).to be_instance_of(Staging::StagingProject)
+      expect(subject).not_to eq(staging_project)
+      expect(subject).to be_persisted
+    end
+
+    it { is_expected.to have_attributes(name: new_project_name, staging_workflow_id: staging_workflow.id) }
+
+    it 'copies the project config' do
+      expect(subject.config.content).to eq(staging_project.config.content)
+    end
+
+    it "copies the repositories and it's relations" do
+      expect(subject.repositories.pluck(:name)).to eq(staging_project.repositories.pluck(:name))
+    end
+
+    it 'copies flags' do
+      expect(subject.flags.pluck(:status, :flag)).to eq(staging_project.flags.pluck(:status, :flag))
+    end
+
+    it 'copies the relationships' do
+      expect(subject.relationships.where(group_relationship.slice(:role_id, :user_id, :group_id))).to exist
+      expect(subject.relationships.where(user_relationship.slice(:role_id, :user_id, :group_id))).to exist
+    end
+  end
 end

--- a/src/api/spec/models/staging/staging_project_spec.rb
+++ b/src/api/spec/models/staging/staging_project_spec.rb
@@ -231,5 +231,18 @@ RSpec.describe Staging::StagingProject, vcr: true do
       expect(subject.relationships.where(group_relationship.slice(:role_id, :user_id, :group_id))).to exist
       expect(subject.relationships.where(user_relationship.slice(:role_id, :user_id, :group_id))).to exist
     end
+
+    context 'when the repository contains path elements that link to repositories of the same project' do
+      let(:other_repository) { create(:repository, architectures: ['x86_64'], project: staging_project) }
+      let!(:path_element) { create(:path_element, repository: repository, link: other_repository) }
+
+      it 'ensures that the new created path is also self referencing' do
+        path_elements_of_project = PathElement.where(parent_id: subject.repositories)
+
+        expect(path_elements_of_project.count).to eq(4)
+        expect(path_elements_of_project.where(link: staging_project.repositories)).not_to exist
+        expect(path_elements_of_project.where(link: subject.repositories)).to exist
+      end
+    end
   end
 end

--- a/src/api/spec/models/staging/staging_project_spec.rb
+++ b/src/api/spec/models/staging/staging_project_spec.rb
@@ -233,7 +233,9 @@ RSpec.describe Staging::StagingProject, vcr: true do
     end
 
     context 'when the repository contains path elements that link to repositories of the same project' do
-      let(:other_repository) { create(:repository, architectures: ['x86_64'], project: staging_project) }
+      let(:other_repository) do
+        create(:repository, architectures: ['x86_64'], project: staging_project, name: "#{staging_project.name.tr(':', '_')}_sles_12")
+      end
       let!(:path_element) { create(:path_element, repository: repository, link: other_repository) }
 
       it 'ensures that the new created path is also self referencing' do
@@ -242,6 +244,10 @@ RSpec.describe Staging::StagingProject, vcr: true do
         expect(path_elements_of_project.count).to eq(4)
         expect(path_elements_of_project.where(link: staging_project.repositories)).not_to exist
         expect(path_elements_of_project.where(link: subject.repositories)).to exist
+      end
+
+      it 'renames the repository link if it contains a reference to the project' do
+        expect(PathElement.find_by(parent_id: subject.repositories, link: subject.repositories).link.name).to eq('home_tom_new_project_sles_12')
       end
     end
   end


### PR DESCRIPTION
Follow up of #6759 (The first two commits).

This adds some code to handle staging projects that contain repositories that link to repositories of the project they belong to. In such cases we now clone the self-referencing link.
