### PR TITLE
Fix wrong ranges in Rantly tests

### DIFF
--- a/src/api/spec/models/kiwi/repository_spec.rb
+++ b/src/api/spec/models/kiwi/repository_spec.rb
@@ -76,7 +76,7 @@ RSpec.describe Kiwi::Repository, type: :model do
       it 'not valid when protocol is not valid' do
         property_of do
           string = sized(range(3, 199)) { string(/[\w]/) }
-          index = range(0, (string.length - 4))
+          index = range(0, (string.length - 3))
           string[index] = ':'
           string[index + 1] = string[index + 2] = '/'
           guard !['ftp', 'http', 'https', 'plain', 'dir', 'iso', 'smb', 'this', 'obs'].include?(string[0..index - 1])
@@ -90,7 +90,7 @@ RSpec.describe Kiwi::Repository, type: :model do
         it 'not valid when has `{`' do
           property_of do
             string = sized(range(1, 199)) { string(/[\w]/) }
-            index = range(0, (string.length - 2))
+            index = range(0, (string.length - 1))
             uri_character = sized(1) { string(/[{]/) }
             string[index] = uri_character
             protocol + '://' + string


### PR DESCRIPTION
Since last Rantly released wrong ranges return `nil` instead of a wrong value inverting the range (as mentioned in the release notes).

Fixes https://github.com/openSUSE/open-build-service/issues/6773

@dmarcoux  this should fix the flickering tests.

@coolo Rantly was correctly released. The current maintainer did a great job. :stuck_out_tongue_winking_eye: 
