### PR TITLE
Remove required version for data_migrate gem

### DIFF
--- a/src/api/Gemfile
+++ b/src/api/Gemfile
@@ -71,7 +71,7 @@ gem 'gssapi', require: false
 # for sending events to rabbitmq
 gem 'bunny'
 # for making changes to existing data
-gem 'data_migrate', '= 5.3.1'
+gem 'data_migrate'
 # for URI encoding
 gem 'addressable'
 # for XML builder

--- a/src/api/Gemfile.lock
+++ b/src/api/Gemfile.lock
@@ -472,7 +472,7 @@ DEPENDENCIES
   cssmin (>= 1.0.2)
   daemons
   dalli
-  data_migrate (= 5.3.1)
+  data_migrate
   database_cleaner (>= 1.0.1)
   deep_cloneable (~> 2.4.0)
   delayed_job_active_record (>= 4.0.0)


### PR DESCRIPTION
According to our git history we a couple of gem updates
regardless of the fixed version requirement. There is also
no known reason to lock this gem to an older version.


