### PR TITLE
Only copy the project config when it has any content

### DIFF
--- a/src/api/app/models/staging/staging_project.rb
+++ b/src/api/app/models/staging/staging_project.rb
@@ -24,7 +24,8 @@ module Staging
         end
 
         new_project.store
-        new_project.config.save!({ user: User.current, comment: "Copying project #{name}" }, config.content)
+        project_config = config.content
+        new_project.config.save!({ user: User.current, comment: "Copying project #{name}" }, project_config) if project_config.present?
 
         new_project
       end


### PR DESCRIPTION
Since we store the project config in the backend, we should only
copy this content if necessary.

Kudos to @dmarcoux for the idea


