### PR TITLE
Improve efficiency of review_progress

### DIFF
--- a/src/api/app/helpers/webui/staging/workflow_helper.rb
+++ b/src/api/app/helpers/webui/staging/workflow_helper.rb
@@ -15,9 +15,8 @@ module Webui::Staging::WorkflowHelper
   end
 
   def review_progress(staging_project)
-    staged_requests_numbers = staging_project.staged_requests.pluck(:number)
     total = Review.where(bs_request: staging_project.staged_requests).size
-    missing = staging_project.missing_reviews.count { |missing_review| staged_requests_numbers.include?(missing_review[:request]) }
+    missing = staging_project.missing_reviews.size
 
     100 - missing * 100 / total
   end


### PR DESCRIPTION
missing_review use staged_requests when being calculated, so there is no need
to check it again, which has an impact in performance.

Co-authored-by: @Ana06 

