### PR TITLE
[dist] added obsapisetup to "After" of obsscheduler.service

### DIFF
--- a/dist/systemd/obsscheduler.service
+++ b/dist/systemd/obsscheduler.service
@@ -1,8 +1,8 @@
 [Unit]
 Description=OBS job scheduler
 Requires=obsrepserver.service
-After=network.target obssrcserver.service obsrepserver.service
 Wants=obsapisetup.service
+After=network.target obssrcserver.service obsrepserver.service obsapisetup.service
 
 [Service]
 Type=oneshot


### PR DESCRIPTION
In https://github.com/openSUSE/open-build-service/commit/c682bcd6dcad57b63cd3b0e1020e4349e6b35265#diff-dab5349d410c1037e0345c2a211eb284R5

we ensured that obsapisetup is started before obsscheduler.
As obsapisetup is a long running oneshot service, we`d like to ensure
that obsscheduler is starting "After=" finishing obsapisetup.
"After=" is not relevant if obsapisetup is not enabled.

Further info about Before/After:
https://www.freedesktop.org/software/systemd/man/systemd.unit.html#Before=