### PR TITLE
[WIP] Add report model

### DIFF
--- a/src/api/app/jobs/staging_project_copy_job.rb
+++ b/src/api/app/jobs/staging_project_copy_job.rb
@@ -1,7 +1,13 @@
 class StagingProjectCopyJob < ApplicationJob
+  queue_as :default
+
+  rescue_from(::ActiveRecord::ActiveRecordError) do |exception|
+    @original_staging_project.reports.create!(failure_message: exception.message)
+  end
+
   def perform(staging_workflow_project_name, original_staging_project_name, staging_project_copy_name)
     staging_workflow_project = Project.find_by!(name: staging_workflow_project_name)
-    original_staging_project = staging_workflow_project.staging.staging_projects.find_by!(name: original_staging_project_name)
-    original_staging_project.copy(staging_project_copy_name)
+    @original_staging_project = staging_workflow_project.staging.staging_projects.find_by!(name: original_staging_project_name)
+    @original_staging_project.copy(staging_project_copy_name)
   end
 end

--- a/src/api/app/models/copy_staging_project_report.rb
+++ b/src/api/app/models/copy_staging_project_report.rb
@@ -1,0 +1,6 @@
+class CopyStagingProjectReport < Report
+
+  def self.sti_name
+    :copy_staging_project
+  end
+end

--- a/src/api/app/models/report.rb
+++ b/src/api/app/models/report.rb
@@ -1,0 +1,3 @@
+class Report < ApplicationRecord
+  belongs_to :reportable
+end

--- a/src/api/app/models/staging/staging_project.rb
+++ b/src/api/app/models/staging/staging_project.rb
@@ -1,6 +1,7 @@
 module Staging
   class StagingProject < Project
     has_many :staged_requests, class_name: 'BsRequest', foreign_key: :staging_project_id, dependent: :nullify
+    has_many :reports
     belongs_to :staging_workflow, class_name: 'Staging::Workflow'
 
     default_scope { where.not(staging_workflow: nil) }

--- a/src/api/db/migrate/20190118134930_create_reports.rb
+++ b/src/api/db/migrate/20190118134930_create_reports.rb
@@ -1,0 +1,12 @@
+class CreateReports < ActiveRecord::Migration[5.2]
+  def change
+    create_table :reports, id: :integer do |t|
+      t.string :type
+      t.boolean :dismissed, default: false
+      t.text :failure_message
+      t.references :staging_project, type: :integer
+
+      t.timestamps
+    end
+  end
+end

--- a/src/api/db/structure.sql
+++ b/src/api/db/structure.sql
@@ -1017,6 +1017,18 @@ CREATE TABLE `release_targets` (
   CONSTRAINT `release_targets_ibfk_2` FOREIGN KEY (`target_repository_id`) REFERENCES `repositories` (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
 
+CREATE TABLE `reports` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `type` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `dismissed` tinyint(1) DEFAULT '0',
+  `failure_message` text COLLATE utf8mb4_unicode_ci,
+  `staging_project_id` int(11) DEFAULT NULL,
+  `created_at` datetime NOT NULL,
+  `updated_at` datetime NOT NULL,
+  PRIMARY KEY (`id`),
+  KEY `index_reports_on_staging_project_id` (`staging_project_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
 CREATE TABLE `repositories` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `db_project_id` int(11) NOT NULL,
@@ -1435,6 +1447,7 @@ INSERT INTO `schema_migrations` (version) VALUES
 ('20181113095753'),
 ('20181201065026'),
 ('20190111130416'),
-('20190115131711');
+('20190115131711'),
+('20190118134930');
 
 

--- a/src/api/spec/cassettes/StagingProjectCopyJob/_perform/when_there_is_an_error/creates_a_report.yml
+++ b/src/api/spec/cassettes/StagingProjectCopyJob/_perform/when_there_is_an_error/creates_a_report.yml
@@ -1,0 +1,38 @@
+---
+http_interactions:
+- request:
+    method: put
+    uri: http://backend:5352/source/my_project:Staging:D/_config?user=factory%20bot
+    body:
+      encoding: UTF-8
+      string: 'Prefer: something'
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 404
+      message: project 'my_project Staging D' does not exist
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '168'
+    body:
+      encoding: UTF-8
+      string: |
+        <status code="404">
+          <summary>project 'my_project:Staging:D' does not exist</summary>
+          <details>404 project 'my_project:Staging:D' does not exist</details>
+        </status>
+    http_version: 
+  recorded_at: Mon, 21 Jan 2019 13:05:25 GMT
+recorded_with: VCR 4.0.0

--- a/src/api/spec/jobs/staging_project_copy_job_spec.rb
+++ b/src/api/spec/jobs/staging_project_copy_job_spec.rb
@@ -12,8 +12,15 @@ RSpec.describe StagingProjectCopyJob, type: :job, vcr: true do
 
     it 'copies the staging project' do
       expect(Project.exists?(name: staging_project_copy_name)).to be false
-      StagingProjectCopyJob.new.perform(staging_workflow.project.name, original_staging_project.name, staging_project_copy_name)
+      StagingProjectCopyJob.perform_now(staging_workflow.project.name, original_staging_project.name, staging_project_copy_name)
       expect(Project.exists?(name: staging_project_copy_name)).to be true
+    end
+
+    context 'when there is an error' do
+      it 'creates a report' do
+        StagingProjectCopyJob.perform_now(staging_workflow.project.name, original_staging_project.name, original_staging_project.name)
+        expect(original_staging_project.reports.where(dismissed: false, failure_message: 'Validation failed: Name has already been taken')).to exist
+      end
     end
   end
 end

--- a/src/api/spec/models/report_spec.rb
+++ b/src/api/spec/models/report_spec.rb
@@ -1,0 +1,9 @@
+require 'rails_helper'
+
+RSpec.describe Report, type: :model do
+  subject { Report.create(failure_message: 'something happened') }
+
+  it "sets 'succeeded' to false when there is a failure message" do
+    expect(subject.succeeded).to be(false)
+  end
+end


### PR DESCRIPTION
This is kind of a proof of concept. At least the payload part is similar to what we have for events, except that events don't have relations right now, eg. belongs to staging_project.
I think it's better to not extend the events in that way. Instead I created a report model to store results of jobs we run asynchronously.

We were talking about giving users an overview of what has been copied. This could be done via the payload in the [CopyStagingReport model](https://github.com/openSUSE/open-build-service/pull/6803/files#diff-1689407cb24a3477a992ee3a3d5e1ab0R12).
IIRC we had a similar issue with staging bs_requests. This could be solved the same way.
