### PR TITLE
Fix missing groups and users hash on staging

### DIFF
--- a/src/api/app/controllers/webui/staging/projects_controller.rb
+++ b/src/api/app/controllers/webui/staging/projects_controller.rb
@@ -25,6 +25,9 @@ module Webui
       def show
         @staging_project = @staging_workflow.staging_projects.find_by(name: params[:project_name])
         @project = @staging_workflow.project
+
+        @groups_hash = ::Staging::Workflow.load_groups
+        @users_hash = ::Staging::Workflow.load_users(@staging_project)
       end
 
       def destroy

--- a/src/api/app/controllers/webui/staging/workflows_controller.rb
+++ b/src/api/app/controllers/webui/staging/workflows_controller.rb
@@ -49,22 +49,8 @@ class Webui::Staging::WorkflowsController < Webui::WebuiController
     @empty_projects = @staging_workflow.staging_projects.without_staged_requests
     @managers = @staging_workflow.managers_group
 
-    # as it is not expected that there are many groups (~30) we catch all of them. Otherwise use this instead:
-    # group_ids = Review.where(bs_request: BsRequest.where(staging_project: @staging_projects)).select('group_id').distinct
-    # Group.where(id: group_ids).each do |group|
-
-    # TODO: Refactor this code using to_h when updating to Ruby 2.6 (performance improvement)
-    @groups_hash = {}
-    Group.find_each do |group|
-      @groups_hash[group.title] = group
-    end
-
-    # TODO: Refactor this code using to_h when updating to Ruby 2.6 (performance improvement)
-    @users_hash = {}
-    user_ids = Review.where(bs_request: BsRequest.where(staging_project: @staging_projects)).select('user_id').distinct
-    User.where(id: user_ids).each do |user|
-      @users_hash[user.login] = user
-    end
+    @groups_hash = ::Staging::Workflow.load_groups
+    @users_hash = ::Staging::Workflow.load_users(@staging_projects)
   end
 
   def edit
@@ -72,6 +58,9 @@ class Webui::Staging::WorkflowsController < Webui::WebuiController
 
     @project = @staging_workflow.project
     @staging_projects = @staging_workflow.staging_projects.includes(:staged_requests)
+
+    @groups_hash = ::Staging::Workflow.load_groups
+    @users_hash = ::Staging::Workflow.load_users(@staging_projects)
   end
 
   def destroy


### PR DESCRIPTION
Issue introduced when improving the performance of the workflow
show page, which uses the same partials as the broken pages:
#6760

Co-authored-by: David Kang <dkang@suse.com>
Co-authored-by: Ana María Martínez Gómez <ammartinez@suse.de>

