### PR TITLE
Fix error in StagingProjectCopyJob

### DIFF
--- a/src/api/app/controllers/staging/staging_projects_controller.rb
+++ b/src/api/app/controllers/staging/staging_projects_controller.rb
@@ -19,7 +19,7 @@ class Staging::StagingProjectsController < ApplicationController
   def copy
     authorize @main_project.staging
 
-    StagingProjectCopyJob.perform_later(params[:staging_main_project_name], params[:staging_project_name], params[:staging_project_copy_name])
+    StagingProjectCopyJob.perform_later(params[:staging_main_project_name], params[:staging_project_name], params[:staging_project_copy_name], User.current.id)
 
     render_ok
   end

--- a/src/api/app/controllers/webui/staging/projects_controller.rb
+++ b/src/api/app/controllers/webui/staging/projects_controller.rb
@@ -57,7 +57,7 @@ module Webui
       def copy
         authorize @staging_workflow
 
-        StagingProjectCopyJob.perform_later(@staging_workflow.project.name, params[:staging_project_project_name], params[:staging_project_copy_name])
+        StagingProjectCopyJob.perform_later(@staging_workflow.project.name, params[:staging_project_project_name], params[:staging_project_copy_name], User.current.id)
 
         flash[:success] = "Job to copy the staging project #{params[:staging_project_project_name]} successfully queued."
 

--- a/src/api/app/jobs/staging_project_copy_job.rb
+++ b/src/api/app/jobs/staging_project_copy_job.rb
@@ -1,5 +1,8 @@
 class StagingProjectCopyJob < ApplicationJob
-  def perform(staging_workflow_project_name, original_staging_project_name, staging_project_copy_name)
+  def perform(staging_workflow_project_name, original_staging_project_name, staging_project_copy_name, user_id)
+    # This is needed as the job depends on the current user and without it, it will failed when performed later
+    User.current ||= User.find(user_id)
+
     staging_workflow_project = Project.find_by!(name: staging_workflow_project_name)
     original_staging_project = staging_workflow_project.staging.staging_projects.find_by!(name: original_staging_project_name)
     original_staging_project.copy(staging_project_copy_name)

--- a/src/api/spec/controllers/staging/staging_projects_controller_spec.rb
+++ b/src/api/spec/controllers/staging/staging_projects_controller_spec.rb
@@ -129,7 +129,8 @@ RSpec.describe Staging::StagingProjectsController, type: :controller, vcr: true 
     it 'queues a StagingProjectCopyJob job' do
       expect { post :copy, format: :xml, params: params }.to have_enqueued_job(StagingProjectCopyJob).with(staging_main_project_name,
                                                                                                            original_staging_project_name,
-                                                                                                           staging_project_copy_name)
+                                                                                                           staging_project_copy_name,
+                                                                                                           user.id)
     end
   end
 end

--- a/src/api/spec/controllers/webui/staging/projects_controller_spec.rb
+++ b/src/api/spec/controllers/webui/staging/projects_controller_spec.rb
@@ -118,7 +118,8 @@ RSpec.describe Webui::Staging::ProjectsController do
     it 'queues a StagingProjectCopyJob job' do
       expect { post :copy, params: params }.to have_enqueued_job(StagingProjectCopyJob).with(staging_workflow.project.name,
                                                                                              original_staging_project_name,
-                                                                                             staging_project_copy_name)
+                                                                                             staging_project_copy_name,
+                                                                                             user.id)
     end
   end
 end

--- a/src/api/spec/jobs/staging_project_copy_job_spec.rb
+++ b/src/api/spec/jobs/staging_project_copy_job_spec.rb
@@ -5,14 +5,14 @@ RSpec.describe StagingProjectCopyJob, type: :job, vcr: true do
   include ActiveJob::TestHelper
 
   describe '#perform' do
-    let(:project) { create(:project, name: 'my_project') }
-    let(:staging_workflow) { create(:staging_workflow, project: project) }
+    let(:user) { create(:confirmed_user) }
+    let(:staging_workflow) { create(:staging_workflow, project: user.home_project) }
     let!(:original_staging_project) { create(:staging_project, staging_workflow: staging_workflow, project_config: 'Prefer: something') }
     let(:staging_project_copy_name) { "#{original_staging_project.name}-copy" }
 
     it 'copies the staging project' do
       expect(Project.exists?(name: staging_project_copy_name)).to be false
-      StagingProjectCopyJob.new.perform(staging_workflow.project.name, original_staging_project.name, staging_project_copy_name)
+      StagingProjectCopyJob.perform_now(staging_workflow.project.name, original_staging_project.name, staging_project_copy_name, user.id)
       expect(Project.exists?(name: staging_project_copy_name)).to be true
     end
   end


### PR DESCRIPTION
Setting the current user is needed in the job as it is performed asynchronously. Therefore, we now pass the current user id to the job to use it later.

