### PR TITLE
Reset backend location in RememberLocation module

### DIFF
--- a/src/api/app/models/event/build.rb
+++ b/src/api/app/models/event/build.rb
@@ -4,6 +4,7 @@ module Event
     self.abstract_class = true
     payload_keys :project, :package, :sender, :repository, :arch, :release, :readytime, :srcmd5,
                  :rev, :reason, :bcnt, :verifymd5, :hostarch, :starttime, :endtime, :workerid, :versrel, :previouslyfailed
+    after_save :clear_cache
 
     def my_message_id
       # we put the verifymd5 sum in the message id, so new checkins get new thread, but it doesn't have to be very correct
@@ -18,6 +19,12 @@ module Event
       h['In-Reply-To'] = mid
       h['References'] = mid
       h
+    end
+
+    private
+
+    def clear_cache
+      Rails.cache.delete("failed_results-#{payload[:project]}")
     end
   end
 end

--- a/src/api/app/models/obs_factory/obs_project.rb
+++ b/src/api/app/models/obs_factory/obs_project.rb
@@ -42,7 +42,7 @@ module ObsFactory
     #
     # @return [Integer] failures count
     def build_failures_count
-      buildresult = Xmlhash.parse(Backend::Api::BuildResults::Status.failed_results(name))
+      buildresult = Backend::Api::BuildResults::Status.failed_results(name)
       bp = {}
       buildresult.elements('result') do |result|
         result.elements('status') do |s|

--- a/src/api/app/models/obs_factory/staging_project.rb
+++ b/src/api/app/models/obs_factory/staging_project.rb
@@ -235,7 +235,7 @@ module ObsFactory
 
     # Used internally to calculate #broken_packages and #building_repositories
     def set_buildinfo
-      buildresult = Xmlhash.parse(Backend::Api::BuildResults::Status.failed_results(name))
+      buildresult = Backend::Api::BuildResults::Status.failed_results(name)
       @broken_packages = []
       @building_repositories = []
       buildresult.elements('result') do |result|

--- a/src/api/app/models/staging/staging_project.rb
+++ b/src/api/app/models/staging/staging_project.rb
@@ -169,7 +169,7 @@ module Staging
     end
 
     def set_buildinfo
-      buildresult = Xmlhash.parse(Backend::Api::BuildResults::Status.failed_results(name))
+      buildresult = Backend::Api::BuildResults::Status.failed_results(name)
 
       @broken_packages = []
       @building_repositories = []

--- a/src/api/lib/backend/api/build_results/status.rb
+++ b/src/api/lib/backend/api/build_results/status.rb
@@ -48,7 +48,8 @@ module Backend
         # Lists failed package builds in a project
         # @return [String]
         def self.failed_results(project_name)
-          http_get(['/build/:project/_result', project_name], params: { code: %w[failed broken unresolvable] }, expand: [:code])
+          response = http_get(['/build/:project/_result', project_name], params: { code: %w[failed broken unresolvable] }, expand: [:code])
+          Xmlhash.parse(response)
         end
 
         # Returns the log's size for a build

--- a/src/api/lib/backend/api/build_results/status.rb
+++ b/src/api/lib/backend/api/build_results/status.rb
@@ -48,8 +48,10 @@ module Backend
         # Lists failed package builds in a project
         # @return [String]
         def self.failed_results(project_name)
-          response = http_get(['/build/:project/_result', project_name], params: { code: %w[failed broken unresolvable] }, expand: [:code])
-          Xmlhash.parse(response)
+          Rails.cache.fetch("failed_results-#{project_name}") do
+            response = http_get(['/build/:project/_result', project_name], params: { code: %w[failed broken unresolvable] }, expand: [:code])
+            Xmlhash.parse(response)
+          end
         end
 
         # Returns the log's size for a build

--- a/src/api/lib/backend/instrumentation.rb
+++ b/src/api/lib/backend/instrumentation.rb
@@ -11,7 +11,6 @@ module Backend
       return unless enabled?
 
       ActiveSupport::Notifications.instrument('obs.backend.process_response', data)
-      reset_backend_location
     end
 
     private
@@ -46,11 +45,6 @@ module Backend
         Thread.current[:_influxdb_obs_backend_api_method]
       ].reject(&:blank?)
       result.empty? ? :raw : result.join('#')
-    end
-
-    def reset_backend_location
-      Thread.current[:_influxdb_obs_backend_api_module] = nil
-      Thread.current[:_influxdb_obs_backend_api_method] = nil
     end
   end
 end

--- a/src/api/lib/backend/remember_location.rb
+++ b/src/api/lib/backend/remember_location.rb
@@ -13,6 +13,9 @@ module Backend
         Thread.current[:_influxdb_obs_backend_api_method] = method_name.to_s
         Thread.current[:_influxdb_obs_backend_api_module] = name
         original_method.call(*args, &block)
+      ensure
+        Thread.current[:_influxdb_obs_backend_api_method] = nil
+        Thread.current[:_influxdb_obs_backend_api_module] = nil
       end
     end
 

--- a/src/api/spec/lib/backend/remember_location_spec.rb
+++ b/src/api/spec/lib/backend/remember_location_spec.rb
@@ -6,15 +6,22 @@ RSpec.describe Backend::RememberLocation do
   class WithRememberLocation
     extend Backend::RememberLocation
 
-    def self.run_after; end
+    def self.run
+      raise 'Backend module missing' unless Thread.current[:_influxdb_obs_backend_api_module] == 'WithRememberLocation'
+      raise 'Backend method missing' unless Thread.current[:_influxdb_obs_backend_api_method] == 'run'
+    end
   end
 
-  describe 'it remembers the location' do
+  describe 'remembers the location while executing' do
+    it { expect { mod.run }.not_to raise_exception }
+  end
+
+  describe 'resets the cache after executing' do
     before do
-      mod.run_after
+      mod.run
     end
 
-    it { expect(Thread.current[:_influxdb_obs_backend_api_module]).to eq(mod.to_s) }
-    it { expect(Thread.current[:_influxdb_obs_backend_api_method]).to eq('run_after') }
+    it { expect(Thread.current[:_influxdb_obs_backend_api_module]).to be_nil }
+    it { expect(Thread.current[:_influxdb_obs_backend_api_method]).to be_nil }
   end
 end


### PR DESCRIPTION
because we now started to cache in the Backend API which means when
the backend is not called but fetched from cache, we never reset the
backend location. Now we always reset it after calling the method
which also is the right location to do so.

