### PR TITLE
OBS_Factory: Improve database queries

### DIFF
--- a/src/api/app/models/bs_request.rb
+++ b/src/api/app/models/bs_request.rb
@@ -89,7 +89,7 @@ class BsRequest < ApplicationRecord
   }
 
   before_save :assign_number
-  has_many :bs_request_actions, -> { includes([:bs_request_action_accept_info]) }, dependent: :destroy
+  has_many :bs_request_actions, dependent: :destroy
   has_many :reviews, dependent: :delete_all
   has_many :comments, as: :commentable, dependent: :delete_all
   has_many :request_history_elements, -> { order(:created_at) }, class_name: 'HistoryElement::Request', foreign_key: :op_object_id
@@ -399,7 +399,7 @@ class BsRequest < ApplicationRecord
   def render_xml(opts = {})
     builder = Nokogiri::XML::Builder.new
     builder.request(id: number, creator: creator) do |r|
-      bs_request_actions.each do |action|
+      bs_request_actions.includes([:bs_request_action_accept_info]).find_each do |action|
         action.render_xml(r)
       end
 

--- a/src/api/app/models/bs_request.rb
+++ b/src/api/app/models/bs_request.rb
@@ -84,7 +84,7 @@ class BsRequest < ApplicationRecord
     where(state: 'new').where(id: Review.where(review_attributes).select(:bs_request_id)).includes(:reviews)
   }
   scope :with_open_reviews_for, lambda { |review_attributes|
-    where(state: 'review', id: Review.where(review_attributes).where(state: 'new').pluck(:bs_request_id))
+    where(state: 'review', id: Review.where(review_attributes).where(state: 'new').select(:bs_request_id))
       .includes(:reviews)
   }
 

--- a/src/api/app/models/project.rb
+++ b/src/api/app/models/project.rb
@@ -1612,6 +1612,7 @@ class Project < ApplicationRecord
   end
 
   def checks
+    return Status::Check.none if combined_status_reports.empty?
     Status::Check.where(status_report: combined_status_reports)
   end
 
@@ -1675,7 +1676,8 @@ class Project < ApplicationRecord
   end
 
   def status_reports(checkables)
-    checkables = checkables.where.not(required_checks: nil)
+    checkables = checkables.select { |checkable| checkable.required_checks.present? }
+    return [] if checkables.empty?
     status_reports = Status::Report.where(checkable: checkables)
     result = {}
     status_reports.where(uuid: checkables.map(&:build_id)).find_each do |report|

--- a/src/api/app/presenters/obs_factory/staging_project_presenter.rb
+++ b/src/api/app/presenters/obs_factory/staging_project_presenter.rb
@@ -24,7 +24,7 @@ module ObsFactory
     # engine helpers are troublesome, so we avoid them
     def self.review_icon(reviewer)
       case reviewer
-      when 'opensuse-review-team' then
+      when 'opensuse-review-team', 'autobuild-team' then
         'search'
       when 'repo-checker' then
         'cog'

--- a/src/api/app/presenters/obs_factory/staging_project_presenter.rb
+++ b/src/api/app/presenters/obs_factory/staging_project_presenter.rb
@@ -50,7 +50,7 @@ module ObsFactory
       return @classified_requests if @classified_requests
 
       @classified_requests = []
-      requests = selected_requests
+      requests = open_requests + obsolete_requests
       return @classified_requests unless requests
 
       reviews = Hash.new

--- a/src/api/spec/models/obs_factory/staging_project_spec.rb
+++ b/src/api/spec/models/obs_factory/staging_project_spec.rb
@@ -286,16 +286,17 @@ RSpec.describe ObsFactory::StagingProject do
 
     subject { ObsFactory::StagingProject.new(project: staging_h, distribution: factory_distribution) }
 
-    it { expect(subject.selected_requests).to contain_exactly(bs_request_1, bs_request_2) }
+    it { expect(subject.selected_requests).to contain_exactly(bs_request_1.number, bs_request_2.number) }
   end
 
   describe '#missing_reviews' do
     include_context 'a staging project with description'
 
     let(:user) { create(:user, login: 'king') }
-    let(:bs_request_1) { create(:set_bugowner_request, number: 614_459, state: :review) }
+    let(:bs_request_1) { create(:set_bugowner_request, number: 614_459, review_by_project: staging_h) }
     let!(:review_1) { create(:review, state: :accepted, bs_request: bs_request_1, by_user: user.login) }
-    let(:bs_request_2) { create(:set_bugowner_request, number: 614_471, state: :review) }
+    let(:source_package) { create(:package, :as_submission_source) }
+    let(:bs_request_2) { create(:set_bugowner_request, target_project: factory, review_by_project: staging_h, number: 614_471) }
 
     subject { ObsFactory::StagingProject.new(project: staging_h, distribution: factory_distribution) }
 


### PR DESCRIPTION
Take selected_requests as number array and avoid duplicated queries for stagings without
no difference between open_requests and selected_requests

We still load the requests per project, but this is hard to fix without injecting into objects

```
Before: 8461ms (Views: 1742.5ms | ActiveRecord: 3279.2ms | Backend: 3.8ms)
After:  3054ms (Views: 821.8ms  | ActiveRecord: 689.0ms | Backend: 3.6ms)
```

(the backend is of course lobotomized in the dev environment)