### PR TITLE
Drop failed_results cache when repo finished

### DIFF
--- a/src/api/app/models/event/repo_build_finished.rb
+++ b/src/api/app/models/event/repo_build_finished.rb
@@ -15,6 +15,7 @@ module Event
       repository_name = payload[:repo]
       architecture_name = payload[:arch]
       Rails.cache.delete("build_id-#{project_name}-#{repository_name}-#{architecture_name}")
+      Rails.cache.delete("failed_results-#{project_name}")
     end
   end
 end


### PR DESCRIPTION
because then also a unresolvable can be fixed.

Follow up on https://github.com/openSUSE/open-build-service/pull/6817

