### PR TITLE
Add background colour in buildresult for blocked state

### DIFF
--- a/src/api/app/assets/stylesheets/webui2/build-results.scss
+++ b/src/api/app/assets/stylesheets/webui2/build-results.scss
@@ -38,8 +38,13 @@
   color: $red;
 }
 
-.build-state-disabled, .build-state-blocked {
+.build-state-disabled {
   @extend .text-black-50;
+}
+.build-state-blocked {
+  @extend .text-white;
+  @extend .bg-secondary;
+  @extend .px-1;
 }
 
 .build-state-scheduled-warning, .build-state-unknown {


### PR DESCRIPTION
Fix issue #6778

![screenshot_2019-01-23 show home admin perl-citrix - open build service 1](https://user-images.githubusercontent.com/1212806/51614108-48f86480-1f25-11e9-9c90-7c311a932272.png)

