### PR TITLE
Filter out duplicated flags from user provided XML

### DIFF
--- a/src/api/app/models/flag/validations.rb
+++ b/src/api/app/models/flag/validations.rb
@@ -1,0 +1,12 @@
+module Flag::Validations
+  extend ActiveSupport::Concern
+
+  included do
+    validate :validate_no_overlapping_flags
+  end
+
+  def validate_no_overlapping_flags
+    flags = self.flags.map { |flag| "#{flag.flag}-#{flag.architecture_id}-#{flag.repo}" }
+    errors.add(:flags, 'Duplicated flags') if flags.size != flags.uniq.size
+  end
+end

--- a/src/api/app/models/package.rb
+++ b/src/api/app/models/package.rb
@@ -7,6 +7,7 @@ require_dependency 'authenticator'
 
 class Package < ApplicationRecord
   include FlagHelper
+  include Flag::Validations
   include CanRenderModel
   include HasRelationships
   include Package::Errors

--- a/src/api/app/models/project.rb
+++ b/src/api/app/models/project.rb
@@ -3,6 +3,7 @@ require_dependency 'has_relationships'
 # rubocop:disable Metrics/ClassLength
 class Project < ApplicationRecord
   include FlagHelper
+  include Flag::Validations
   include CanRenderModel
   include HasRelationships
   include HasRatings

--- a/src/api/spec/db/data/remove_duplicated_flags_spec.rb
+++ b/src/api/spec/db/data/remove_duplicated_flags_spec.rb
@@ -23,6 +23,6 @@ RSpec.describe RemoveDuplicatedFlags, type: :migration do
       RemoveDuplicatedFlags.new.up
     end
 
-    it { expect(project.flags).to contain_exactly(flag_3, flag_2) }
+    it { expect(project.reload.flags).to contain_exactly(flag_3, flag_2) }
   end
 end

--- a/src/api/spec/models/package_spec.rb
+++ b/src/api/spec/models/package_spec.rb
@@ -756,5 +756,41 @@ RSpec.describe Package, vcr: true do
       end
     end
   end
+
+  describe '#update_from_xml' do
+    let(:invalid_meta_xml) do
+      <<-XML_DATA
+      <package>
+        <title/>
+        <description/>
+        <build>
+          <enable/>
+          <disable/>
+          <enable arch="i586"/>
+          <disable arch="x86_64"/>
+          <enable arch="x86_64"/>
+        </build>
+      </package>
+      XML_DATA
+    end
+    let(:corrected_meta_xml) do
+      <<~XML_DATA2
+        <package name="test_package" project="home:tom">
+          <title/>
+          <description/>
+          <build>
+            <disable/>
+            <enable arch="i586"/>
+            <disable arch="x86_64"/>
+          </build>
+        </package>
+      XML_DATA2
+    end
+
+    it "doesn't crash on duplicated flags" do
+      package.update_from_xml(Xmlhash.parse(invalid_meta_xml))
+      expect(package.render_xml).to eq(corrected_meta_xml)
+    end
+  end
 end
 # rubocop:enable Metrics/BlockLength


### PR DESCRIPTION
This can happen either when posting a _meta (in this case an error could be good enough, but isn't really helpful) or when receiving _meta from local or remote backend. In this case we can't error out, but need to recover the situation

Fixes #6823

