### PR TITLE
Simplify condition in bs_srcserver putfile

### DIFF
--- a/src/backend/bs_srcserver
+++ b/src/backend/bs_srcserver
@@ -2701,7 +2701,7 @@ sub putfile {
       die("unsupported meta operation\n");
     }
     my $rev = BSRevision::addrev_meta_replace($cgi, $projid, $packid, [ "$uploaddir/$$", undef, $filename ]);
-    notify_repservers('package', $projid) if $cgi->{'meta'} && $filename eq '_frozenlinks';
+    notify_repservers('package', $projid) if $filename eq '_frozenlinks';
     delete $rev->{'project'};
     delete $rev->{'package'};
     return ($rev, $BSXML::revision);


### PR DESCRIPTION
$cgi->{'meta'} already holds and the $cgi hash is not modified during
BSRevision::addrev_meta_replace.

If you haven't done so already, please read the CONTRIBUTING.md file to learn how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md

