### PR TITLE
Fix Statistics for multibuild

### DIFF
--- a/src/api/app/controllers/webui2/package_controller.rb
+++ b/src/api/app/controllers/webui2/package_controller.rb
@@ -26,6 +26,9 @@ module Webui2::PackageController
     @repository = params[:repository]
     @package_name = params[:package]
 
-    @statistics = @package.statistics(@project.name, @repository, params[:arch]).results
+    @statistics = LocalBuildStatistic::ForPackage.new(package: @package_name,
+                                                      project: @project.name,
+                                                      repository: @repository,
+                                                      architecture: params[:arch]).results
   end
 end

--- a/src/api/app/models/package.rb
+++ b/src/api/app/models/package.rb
@@ -1451,10 +1451,6 @@ class Package < ApplicationRecord
     PackageBuildReason.new(data)
   end
 
-  def statistics(project_name, repository_name, architecture_name)
-    LocalBuildStatistic::ForPackage.new(package: self, project: project_name, repository: repository_name, architecture: architecture_name)
-  end
-
   private
 
   def _add_channel(mode, channel_binary, message)

--- a/src/api/spec/models/package_spec.rb
+++ b/src/api/spec/models/package_spec.rb
@@ -756,56 +756,5 @@ RSpec.describe Package, vcr: true do
       end
     end
   end
-
-  describe '#statistics' do
-    let(:fake_statistics_result) do
-      <<-HEREDOC
-        <buildstatistics>
-          <disk>
-            <usage>
-              <size unit="M">491</size>
-              <io_requests>4900</io_requests>
-              <io_sectors>826498</io_sectors>
-            </usage>
-          </disk>
-          <memory>
-            <usage>
-              <size unit="M">106</size>
-            </usage>
-          </memory>
-          <times>
-            <total>
-              <time unit="s">107</time>
-            </total>
-            <preinstall>
-              <time unit="s">18</time>
-            </preinstall>
-            <install>
-              <time unit="s">24</time>
-            </install>
-            <main>
-              <time unit="s">4</time>
-            </main>
-            <download>
-              <time unit="s">4</time>
-            </download>
-          </times>
-          <download>
-            <size unit="k">7548</size>
-            <binaries>4</binaries>
-            <cachehits>103</cachehits>
-          </download>
-        </buildstatistics>
-      HEREDOC
-    end
-
-    before do
-      allow(Backend::Api::BuildResults::Status).to receive(:statistics).and_return(fake_statistics_result)
-    end
-
-    it 'returns an object with class LocalBuildStatistic::ForPackage' do
-      expect(package.statistics(home_project, 'SLE_12_SP2', 'x68_64').class).to eq(LocalBuildStatistic::ForPackage)
-    end
-  end
 end
 # rubocop:enable Metrics/BlockLength


### PR DESCRIPTION
We always passed to the backend the main package. Now we send the
correct package.

Should fix #6606

