### PR TITLE
Fix inherited package link

### DIFF
--- a/src/api/app/views/webui2/webui/project/_project_inherited_packages.html.haml
+++ b/src/api/app/views/webui2/webui/project/_project_inherited_packages.html.haml
@@ -10,6 +10,6 @@
           - inherited_packages.each do |package|
             %tr
               %td
-                = link_to(package.first, package_show_path(package: package.first, project: package.second))
+                = link_to(package.first, package_show_path(package: package.first, project: project))
               %td
                 = package.second

--- a/src/api/app/views/webui2/webui/project/show.html.haml
+++ b/src/api/app/views/webui2/webui/project/show.html.haml
@@ -58,7 +58,7 @@
         .tab-pane.fade.show.active#packages{ role: 'tabpanel', aria: { labelledby: 'packages-tab' } }
           = render partial: 'project_packages', locals: { project: @project, packages: @packages }
         .tab-pane.fade#inherited-packages{ role: 'tabpanel', aria: { labelledby: 'inherited-packages-tab' } }
-          = render partial: 'project_inherited_packages', locals: { inherited_packages: @ipackages }
+          = render partial: 'project_inherited_packages', locals: { project: @project, inherited_packages: @ipackages }
   .comments
     .card
       %h5.card-header


### PR DESCRIPTION
The inherited packages were pointing to the original project and not to
the current one.

Should fix #6621

