### PR TITLE
Fix payload access in clear_caches

### DIFF
--- a/src/api/app/models/event/build.rb
+++ b/src/api/app/models/event/build.rb
@@ -23,7 +23,7 @@ module Event
     private
 
     def clear_caches
-      Rails.cache.delete("failed_results-#{payload[:project]}")
+      Rails.cache.delete("failed_results-#{payload['project']}")
     end
   end
 end

--- a/src/api/app/models/event/repo_build_finished.rb
+++ b/src/api/app/models/event/repo_build_finished.rb
@@ -10,9 +10,9 @@ module Event
       # TODO: We should touch the repository instead of deleting the key
       # to invalidate the cache. However, repository currently does not have
       # an updated_at column so we can not use Rails' cache_key method.
-      project_name = payload[:project]
-      repository_name = payload[:repo]
-      architecture_name = payload[:arch]
+      project_name = payload['project']
+      repository_name = payload['repo']
+      architecture_name = payload['arch']
       Rails.cache.delete("build_id-#{project_name}-#{repository_name}-#{architecture_name}")
       Rails.cache.delete("failed_results-#{project_name}")
     end

--- a/src/api/app/models/event/repo_build_started.rb
+++ b/src/api/app/models/event/repo_build_started.rb
@@ -10,9 +10,9 @@ module Event
       # TODO: We should touch the repository instead of deleting the key
       # to invalidate the cache. However, repository currently does not have
       # an updated_at column so we can not use Rails' cache_key method.
-      project_name = payload[:project]
-      repository_name = payload[:repo]
-      architecture_name = payload[:arch]
+      project_name = payload['project']
+      repository_name = payload['repo']
+      architecture_name = payload['arch']
       Rails.cache.delete("build_id-#{project_name}-#{repository_name}-#{architecture_name}")
     end
   end

--- a/src/api/app/models/event/repo_published.rb
+++ b/src/api/app/models/event/repo_published.rb
@@ -10,8 +10,8 @@ module Event
       # TODO: We should touch the repository instead of deleting the key
       # to invalidate the cache. However, repository currently does not have
       # an updated_at column so we can not use Rails' cache_key method.
-      project_name = payload[:project]
-      repository_name = payload[:repo]
+      project_name = payload['project']
+      repository_name = payload['repo']
       Rails.cache.delete("build_id-#{project_name}-#{repository_name}")
     end
   end


### PR DESCRIPTION
Payload is actually a string hash not symbols, even though the payload_keys are listed as symbols. No suprise this went unnoticed :(

