### PR TITLE
Enable build results in request show page, and also show the issue

### DIFF
--- a/src/api/app/views/webui2/webui/request/_issues_table.html.haml
+++ b/src/api/app/views/webui2/webui/request/_issues_table.html.haml
@@ -1,0 +1,23 @@
+%p
+  %b
+    Mentioned Issues (#{issues.length})
+%table
+  %tbody
+    - issues.each do |long_name, issue|
+      - if issue[:owner] && issue[:state]
+        %tr
+          %td
+            = link_to(long_name, issue[:url], target: '_blank', rel: 'noopener')
+          %td.nowrap
+            - if issue[:owner]
+              = user_with_realname_and_icon issue[:owner], short: true
+          %td
+            = issue[:state].capitalize if issue[:state]
+      - else
+        %tr.even
+          %td{ colspan: '3' }
+            = link_to(long_name, issue[:url], target: '_blank', rel: 'noopener')
+      - if issue[:summary]
+        %tr.odd
+          %td{ colspan: '3' }
+            = toggle_sliced_text(issue[:summary])

--- a/src/api/app/views/webui2/webui/request/show.html.haml
+++ b/src/api/app/views/webui2/webui/request/show.html.haml
@@ -9,7 +9,15 @@
     %h5
       Diff
   .card-body
-    -# Diff content and build results
+    - @actions.each_with_index do |action, action_index|
+      - action[:sourcediff].each do |sourcediff|
+        .row
+          .col-md-8
+            Diff content
+          .col-md-4
+            = render partial: 'webui2/shared/buildresult_box', locals: { project: action[:sprj], package: action[:spkg], index: action_index }
+            - if sourcediff['issues'].present?
+              = render partial: 'issues_table', locals: { issues: sourcediff['issues'] }
 .row
   .col-md-8
     .card


### PR DESCRIPTION
This is the first PR of a serie of PRs for enabling build results in the request show page, and refactor the build result section.

TODO:
 - make it work with a request with multiple submits (with tabs).
 - make it collapsible.

Co-authored-by: David Kang <dkang@suse.com>

![peek 2019-01-31 13-18-request-build-results](https://user-images.githubusercontent.com/24919/52053912-0523e180-255b-11e9-90c2-8506911b77ee.gif)