### PR TITLE
Partially re-write modify_review action

### DIFF
--- a/src/api/app/assets/stylesheets/webui/application/request.scss
+++ b/src/api/app/assets/stylesheets/webui/application/request.scss
@@ -10,7 +10,7 @@
   color: #d80000;
 }
 
-[id^='review_accept_button']{
+.review_accept_button {
   margin-right: 1em;
 }
 

--- a/src/api/app/controllers/webui/request_controller.rb
+++ b/src/api/app/controllers/webui/request_controller.rb
@@ -43,32 +43,19 @@ class Webui::RequestController < Webui::WebuiController
   end
 
   def modify_review
-    opts = {}
-    state = nil
-    request = nil
-    params.each do |key, value|
-      state = key if  key.in?(['accepted', 'declined', 'new'])
-      request = BsRequest.find_by_number(value) if key.starts_with?('review_request_number_')
-
-      # Our views are valid XHTML. So, several forms 'POST'-ing to the same action have different
-      # HTML ids. Thus we have to parse 'params' a bit:
-      opts[:comment] = value if key.starts_with?('review_comment_')
-      opts[:by_user] = value if key.starts_with?('review_by_user_')
-      opts[:by_group] = value if key.starts_with?('review_by_group_')
-      opts[:by_project] = value if key.starts_with?('review_by_project_')
-      opts[:by_package] = value if key.starts_with?('review_by_package_')
-    end
+    review_params = params.slice(:comment, :by_user, :by_group, :by_project, :by_package)
+    request = BsRequest.find_by_number(params[:request_number])
 
     if request.nil?
       flash[:error] = 'Unable to load request'
       redirect_back(fallback_location: user_show_path(User.current))
       return
-    elsif state.nil?
+    elsif !new_state.in?(['accepted', 'declined'])
       flash[:error] = 'Unknown state to set'
     else
       begin
-        request.permission_check_change_review!(opts)
-        request.change_review_state(state, opts)
+        request.permission_check_change_review!(review_params)
+        request.change_review_state(new_state, review_params)
       rescue BsRequestPermissionCheck::ReviewChangeStateNoPermission => e
         flash[:error] = "Not permitted to change review state: #{e.message}"
       rescue APIError => e
@@ -311,6 +298,15 @@ class Webui::RequestController < Webui::WebuiController
   end
 
   private
+
+  def new_state
+    case params[:new_state]
+    when 'Approve'
+      'accepted'
+    when 'Disregard'
+      'declined'
+    end
+  end
 
   def set_superseded_request
     return unless params[:diff_to_superseded]

--- a/src/api/app/helpers/webui/request_helper.rb
+++ b/src/api/app/helpers/webui/request_helper.rb
@@ -139,4 +139,12 @@ module Webui::RequestHelper
   def diff_label(diff)
     "#{diff['project']} / #{diff['package']} (rev #{diff['rev']})"
   end
+
+  def hidden_review_payload(review)
+    capture do
+      [:by_user, :by_group, :by_project, :by_package].each do |key|
+        concat(hidden_field_tag(key, review[key])) if review[key]
+      end
+    end
+  end
 end

--- a/src/api/app/views/webui/request/show.html.erb
+++ b/src/api/app/views/webui/request/show.html.erb
@@ -309,17 +309,14 @@
         </div>
         <% @my_open_reviews.each_with_index do |review, index| %>
             <div class="review_descision_display <%= 'hidden' if index != 0 %>" id="review_descision_display_<%= index %>">
-              <%= form_tag(:action => 'modify_review') do %>
-                  <p><%= text_area_tag("review_comment_#{index}", review[:reason], :size => '80x2', :style => 'width: 99%', :class => 'review_comment', :placeholder => 'Please comment on your decision') %></p>
+              <%= form_tag(action: 'modify_review') do %>
+                  <p><%= text_area_tag('comment', review[:reason], size: '80x2', style: 'width: 99%', class: 'review_comment', placeholder: 'Please comment on your decision') %></p>
 
                   <p>
-                    <%= hidden_field_tag("review_request_number_#{index}", @number) %>
-                    <%= hidden_field_tag("review_by_user_#{index}", review[:by_user]) if review[:by_user] %>
-                    <%= hidden_field_tag("review_by_group_#{index}", review[:by_group]) if review[:by_group] %>
-                    <%= hidden_field_tag("review_by_project_#{index}", review[:by_project]) if review[:by_project] %>
-                    <%= hidden_field_tag("review_by_package_#{index}", review[:by_package]) if review[:by_package] %>
-                    <%= submit_tag 'Approve', name: 'accepted', id: "review_accept_button_#{index}", title: 'Give this request your blessing, it will continue.' %>
-                    <%= submit_tag 'Disregard', name: 'declined', id: "review_decline_button_#{index}", title: 'Veto this request, it will be declined.' %>
+                    <%= hidden_field_tag("request_number", @number) %>
+                    <%= hidden_review_payload(review) %>
+                    <%= submit_tag 'Approve', name: 'new_state', class: 'review_accept_button', title: 'Give this request your blessing, it will continue.' %>
+                    <%= submit_tag 'Disregard', name: 'new_state', title: 'Veto this request, it will be declined.' %>
                   </p>
               <% end %>
             </div>

--- a/src/api/spec/features/webui/requests_spec.rb
+++ b/src/api/spec/features/webui/requests_spec.rb
@@ -132,8 +132,8 @@ RSpec.feature 'Requests', type: :feature, js: true do
         login reviewer
         visit request_show_path(1)
         click_link('review_descision_link_0')
-        fill_in 'review_comment_0', with: 'Ok for the project'
-        click_button 'review_accept_button_0'
+        fill_in 'comment', with: 'Ok for the project'
+        click_button 'Approve'
         expect(page).to have_text('Ok for the project')
         expect(Review.first.state).to eq(:accepted)
         expect(BsRequest.first.state).to eq(:new)


### PR DESCRIPTION
* Remove index from parameters. This action always processes one
  review at a time. There was no need to add an index to the parameters.
* Move setting of hidden field tags to a helper to dry the code.
* Directly access parameters we need instead of looping over all of
  them.



<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md
-->
