### PR TITLE
[api] support generic github issues

### DIFF
--- a/src/api/app/models/issue.rb
+++ b/src/api/app/models/issue.rb
@@ -83,6 +83,7 @@ class Issue < ApplicationRecord
   end
 
   def url
+    return issue_tracker.show_url_for(label) if issue_tracker.kind == 'github'
     issue_tracker.show_url.gsub('@@@', name)
   end
 

--- a/src/api/app/models/issue_tracker.rb
+++ b/src/api/app/models/issue_tracker.rb
@@ -32,6 +32,7 @@ class IssueTracker < ApplicationRecord
   def show_url_for(issue, html = nil)
     return unless issue
     url = show_url.gsub('@@@', issue)
+    url.gsub!(/(github#|gh#)/, '').gsub!('#', '/issues/') if kind == 'github'
     return "<a href=\"#{url}\">#{CGI.escapeHTML(show_label_for(issue))}</a>" if html
     url
   end

--- a/src/api/db/data/20190130115727_add_github_issue_tracker.rb
+++ b/src/api/db/data/20190130115727_add_github_issue_tracker.rb
@@ -1,0 +1,13 @@
+class AddGithubIssueTracker < ActiveRecord::Migration[5.1]
+  def up
+    IssueTracker.where(name: 'gh').first_or_create(description: 'Generic github tracker',
+                                                   kind: 'github',
+                                                   regex: '(?:gh|github)#(\w+\/\w+#\d+)',
+                                                   url: 'https://www.github.com',
+                                                   label: 'gh#@@@', show_url: 'https://github.com/@@@')
+  end
+
+  def down
+    IssueTracker.find_by(name: 'gh').destroy
+  end
+end

--- a/src/api/db/seeds.rb
+++ b/src/api/db/seeds.rb
@@ -321,3 +321,8 @@ IssueTracker.where(name: 'lf').first_or_create(description: 'Linux Foundation Bu
                                                regex: 'lf#(\d+)',
                                                url: 'https://developerbugs.linuxfoundation.org',
                                                label: 'lf#@@@', show_url: 'https://developerbugs.linuxfoundation.org/show_bug.cgi?id=@@@')
+IssueTracker.where(name: 'gh').first_or_create(description: 'Generic Github Tracker',
+                                               kind: 'github',
+                                               regex: '(?:gh|github)#(\w+\/\w+#\d+)',
+                                               url: 'https://www.github.com',
+                                               label: 'gh#@@@', show_url: 'https://github.com/@@@')

--- a/src/api/spec/factories/issue_tracker.rb
+++ b/src/api/spec/factories/issue_tracker.rb
@@ -1,12 +1,12 @@
 FactoryBot.define do
   factory :issue_tracker do
-    name { 'gh' }
+    name { 'example' }
     description { Faker::Lorem.paragraph }
     kind { 'github' }
     url { Faker::Internet.url(host: 'example.com') }
     show_url { Faker::Internet.url(host: 'example.com') }
-    regex { 'gh#(\d+)' }
-    label { 'gh#@@@' }
+    regex { 'example#(\d+)' }
+    label { 'example#@@@' }
     issues_updated { Time.now }
   end
 end

--- a/src/api/test/fixtures/issue_trackers.yml
+++ b/src/api/test/fixtures/issue_trackers.yml
@@ -261,3 +261,13 @@ obs_github:
   label: obs#@@@
   issues_updated: 2011-07-29 14:00:21.000000000 Z
   enable_fetch: 0
+generic_github:
+  name: gh
+  kind: github
+  description: Generic Github Tracker
+  url: https://www.github.com
+  show_url: https://github.com/@@@
+  regex: (?:gh|github)#(\w+\/\w+#\d+)
+  label: gh#@@@
+  issues_updated: 2011-07-29 14:00:21.000000000 Z
+  enable_fetch: 0

--- a/src/api/test/functional/issue_controller_test.rb
+++ b/src/api/test/functional/issue_controller_test.rb
@@ -255,7 +255,7 @@ Blubber bnc#15\n
          params: { cmd: 'branch', target_project: 'home:Iggy:branches:BaseDistro', target_package: 'pack_new' }
     assert_response :success
     changes += "-------------------------------------------------------------------\n
-Aha bnc#123456\n
+Aha bnc#123456 github#openSUSE/build#123\n
 "
     changes.gsub!(/Blubber/, 'Blabber') # leads to changed
     changes.gsub!(/bnc#14/, '') # leads to removed
@@ -273,6 +273,9 @@ Aha bnc#123456\n
     assert_xml_tag parent: { tag: 'issue', attributes: { change: 'deleted' } }, tag: 'name', content: '14'
     assert_xml_tag parent: { tag: 'issue', attributes: { change: 'changed' } }, tag: 'name', content: '15'
     assert_xml_tag parent: { tag: 'issue', attributes: { change: 'added' } }, tag: 'name', content: '123456'
+    # test github special case, needs the # -> /issues/ replacement
+    assert_xml_tag parent: { tag: 'issue', attributes: { change: 'added' } }, tag: 'name', content: 'openSUSE/build#123'
+    assert_xml_tag parent: { tag: 'issue', attributes: { change: 'added' } }, tag: 'url', content: 'https://github.com/openSUSE/build/issues/123'
 
     # cleanup
     delete '/source/home:Iggy:branches:BaseDistro'

--- a/src/api/test/functional/issue_trackers_controller_test.rb
+++ b/src/api/test/functional/issue_trackers_controller_test.rb
@@ -10,7 +10,7 @@ class IssueTrackersControllerTest < ActionDispatch::IntegrationTest
     login_king
     get '/issue_trackers'
     assert_response :success
-    assert_select 'issue-tracker', 24
+    assert_select 'issue-tracker', 25
   end
 
   def test_create_and_update_new_trackers


### PR DESCRIPTION
write as

 gh#$project/$repo#$issue

eg

 gh#openSUSE/build#123

needs unfortunality a special hack, since github URLs expect /issues/
inside.



<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md
-->
