### PR TITLE
Fix monitor page pagination in Firefox

### DIFF
--- a/src/api/app/views/webui2/webui/project/monitor.html.haml
+++ b/src/api/app/views/webui2/webui/project/monitor.html.haml
@@ -33,5 +33,6 @@
                   - archlist.each do |arch|
                     %td.text-center
                       = webui2_arch_repo_table_cell(repo, arch, packname, nil, false)
-:javascript
+
+- content_for :ready_function do
   setupProjectMonitor();


### PR DESCRIPTION
We need to initialize the DataTable after the page is ready.

Fixes https://github.com/openSUSE/open-build-service/issues/6561



<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md
-->
