### PR TITLE
[backend] signer: do not write a .bininfo file if it didn't exist yet

### DIFF
--- a/src/backend/bs_signer
+++ b/src/backend/bs_signer
@@ -525,32 +525,34 @@ sub signjob {
     }
 
     # we have changed the file ids, thus we need to re-create
-    # the .bininfo file
-    my $bininfo = {};
-    my $oldbininfo = BSUtil::retrieve("$jobdir/.bininfo", 1) || {};
-    for my $file (@files) {
-      my @s = stat("$jobdir/$file");
-      my $id = "$s[9]/$s[7]/$s[1]";
-      next unless @s;
-      if ($file !~ /\.(?:rpm|deb)$/) {
-	$bininfo->{$file} = $oldbininfo->{$file} if $oldbininfo->{$file};
-	next;
+    # the entries in the .bininfo file
+    my $oldbininfo = BSUtil::retrieve("$jobdir/.bininfo", 1);
+    if ($oldbininfo) {
+      my $bininfo = {};
+      for my $file (@files) {
+	my @s = stat("$jobdir/$file");
+	my $id = "$s[9]/$s[7]/$s[1]";
+	next unless @s;
+	if ($file !~ /\.(?:rpm|deb)$/) {
+	  $bininfo->{$file} = $oldbininfo->{$file} if $oldbininfo->{$file};
+	  next;
+	}
+	my $data = Build::query("$jobdir/$file", 'evra' => 1);
+	die("$jobdir/$file: query failed") unless $data;
+	eval {
+	  BSVerify::verify_nevraquery($data);
+	};
+	die("$jobdir/$file: $@") if $@;
+	my $leadsigmd5;
+	die("$jobdir/$file: queryhdrmd5 failed\n") unless Build::queryhdrmd5("$jobdir/$file", \$leadsigmd5);
+	$data->{'leadsigmd5'} = $leadsigmd5 if $leadsigmd5;
+	$data->{'filename'} = $file;
+	$data->{'id'} = $id;
+	$bininfo->{$file} = $data;
       }
-      my $data = Build::query("$jobdir/$file", 'evra' => 1);
-      die("$jobdir/$file: query failed") unless $data;
-      eval {
-        BSVerify::verify_nevraquery($data);
-      };
-      die("$jobdir/$file: $@") if $@;
-      my $leadsigmd5;
-      die("$jobdir/$file: queryhdrmd5 failed\n") unless Build::queryhdrmd5("$jobdir/$file", \$leadsigmd5);
-      $data->{'leadsigmd5'} = $leadsigmd5 if $leadsigmd5;
-      $data->{'filename'} = $file;
-      $data->{'id'} = $id;
-      $bininfo->{$file} = $data;
+      $bininfo->{'.bininfo'} = {};	# mark new version
+      BSUtil::store("$jobdir/.bininfo", undef, $bininfo);
     }
-    $bininfo->{'.bininfo'} = {};	# mark new version
-    BSUtil::store("$jobdir/.bininfo", undef, $bininfo);
   }
   
   # write finished job status and release lock


### PR DESCRIPTION
The code reuses entries from the old bininfo files for non-rpm packages,
so the entries will be missing if the .bininfo did not exist before.
But the job handling code in the scheduler relies on the bininfo
containing all entries.



<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md
-->
