### PR TITLE
Add anchor tag to comments

### DIFF
--- a/src/api/app/views/webui2/webui/comment/_content.html.haml
+++ b/src/api/app/views/webui2/webui/comment/_content.html.haml
@@ -5,7 +5,7 @@
     %p
       = link_to(comment.user, user_show_path(comment.user))
       wrote
-      %u{ title: l(comment.created_at.utc) }
+      = link_to("#comment-#{comment.id}", title: l(comment.created_at.utc), name: "comment-#{comment.id}") do
         #{time_ago_in_words(comment.created_at)} ago
     = render_as_markdown(comment)
     = render partial: 'webui2/webui/comment/links', locals: { comment: comment }


### PR DESCRIPTION
This allows users to reference to comments by linking to them.



<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md
-->
