### PR TITLE
[backend] publisher: do not call bs_regpush twice

### DIFF
--- a/src/backend/BSPublisher/Container.pm
+++ b/src/backend/BSPublisher/Container.pm
@@ -386,7 +386,6 @@ sub upload_to_registry {
   push @opts, '-B', $blobdir if $blobdir;
   my @cmd = ("$INC[0]/bs_regpush", '--dest-creds', '-', @opts, '-F', $containerdigestfile, $registryserver, $repository, @uploadfiles);
   print "Uploading to registry: @cmd\n";
-  BSUtil::xsystem("$registry->{user}:$registry->{password}\n", @cmd);
   my $result = BSPublisher::Util::qsystem('echo', "$registry->{user}:$registry->{password}\n", 'stdout', '', @cmd);
   my $containerdigests = readstr($containerdigestfile, 1);
   unlink($containerdigestfile);


### PR DESCRIPTION
Oops. This should make container publishing a bit faster...



<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md
-->
