### PR TITLE
Fix flickering cloud upload job

### DIFF
--- a/src/api/spec/factories/upload_job.rb
+++ b/src/api/spec/factories/upload_job.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :upload_job, class: Cloud::User::UploadJob do
     user
-    job_id { Faker::Number.between(100, 1000) }
+    job_id { rand(1_000_000_000) }
   end
 end


### PR DESCRIPTION
Use a number generator with higher "randomness" to avoid
cloud jobs with duplicated job_id entries.
The job_id comes from the backend. So we can not use another
factory for this.

Fixes #4958



<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md
-->
