### PR TITLE
Fix flickering backend subscriber test

### DIFF
--- a/src/api/spec/lib/influx_db/obs/middleware/backend_subscriber_spec.rb
+++ b/src/api/spec/lib/influx_db/obs/middleware/backend_subscriber_spec.rb
@@ -21,9 +21,8 @@ RSpec.describe InfluxDB::OBS::Middleware::BackendSubscriber do
 
     let(:result) do
       {
-        values: {
-          value: 2000
-        },
+        # :request might be nil. In that case we have to filter it out.
+        values: InfluxDB::Rails.current.values.reject { |_, v| v.nil? }.update(value: 2000),
         tags: {
           http_status_code: 200,
           http_method: 'GET',


### PR DESCRIPTION
Application and webui controller are both setting a request value
in the InfluxDB::Rails.current.values hash.
This was causing the test to fail randomly when run within our CI
(aka running multiple tests) because the request value got set.



<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md
-->
