### PR TITLE
Fix flickering attribute test

### DIFF
--- a/src/api/spec/support/features/features_attribute.rb
+++ b/src/api/spec/support/features/features_attribute.rb
@@ -3,7 +3,7 @@ module FeaturesAttribute
     visit index_attribs_path(project: user.home_project_name, package: package.try(:name))
     click_link('Add a new attribute')
     expect(page).to have_text('Add Attribute')
-    find('select#attrib_attrib_type_id').select("#{attribute_type.attrib_namespace}:#{attribute_type.name}")
+    find('select#attrib_attrib_type_id').select("#{attribute_type.attrib_namespace}:#{attribute_type.name}", match: :first)
     click_button('Add')
     expect(page).to have_content('Attribute was successfully created.')
 


### PR DESCRIPTION
It sometimes happens that we have duplicated attributes available.
In that case we fetch the first one.

Fixes #6837



<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md
-->
