### PR TITLE
[frontend] Add origin-manager as code-fork icon in obs_factory.

### DIFF
--- a/src/api/app/presenters/obs_factory/staging_project_presenter.rb
+++ b/src/api/app/presenters/obs_factory/staging_project_presenter.rb
@@ -36,7 +36,7 @@ module ObsFactory
         'medkit'
       when 'legal-team', 'legal-auto' then
         'graduation-cap'
-      when 'leaper' then
+      when 'leaper', 'origin-manager' then
         'code-fork'
       when 'sle-changelog-checker' then
         'tags'


### PR DESCRIPTION
In preparation for upcoming [Origin Manager](https://github.com/openSUSE/openSUSE-release-tools/issues/1643).