### PR TITLE
Fix minor issues and improve user tab code

### DIFF
--- a/src/api/app/assets/javascripts/webui2/users_groups.js
+++ b/src/api/app/assets/javascripts/webui2/users_groups.js
@@ -2,7 +2,7 @@
 function changeUserRole(obj) { // jshint ignore:line
     var type = obj.data("type");
     var role = obj.data("role");
-    var spinner = obj.next().children('i:first-child');
+    var spinner = obj.siblings('.fa-spinner');
 
     var url;
     var data = {
@@ -17,14 +17,14 @@ function changeUserRole(obj) { // jshint ignore:line
         url = $('#involved-users').data("remove");
     }
 
-    spinner.removeClass('invisible');
+    spinner.removeClass('d-none');
 
     $.ajax({
         url: url,
         type: 'POST',
         data: data,
         complete: function () {
-            spinner.addClass('invisible');
+            spinner.addClass('d-none');
         }
     });
 }

--- a/src/api/app/assets/javascripts/webui2/users_groups.js
+++ b/src/api/app/assets/javascripts/webui2/users_groups.js
@@ -17,14 +17,15 @@ function changeUserRole(obj) { // jshint ignore:line
         url = $('#involved-users').data("remove");
     }
 
-    spinner.removeClass('d-none');
-
     $.ajax({
         url: url,
         type: 'POST',
         data: data,
-        complete: function () {
-            spinner.addClass('d-none');
+        beforeSend: function() {
+          spinner.removeClass('d-none');
+        },
+        complete: function() {
+          spinner.addClass('d-none');
         }
     });
 }

--- a/src/api/app/helpers/webui/user_or_groups_roles_helper.rb
+++ b/src/api/app/helpers/webui/user_or_groups_roles_helper.rb
@@ -1,4 +1,16 @@
 module Webui::UserOrGroupsRolesHelper
+  def display_name(object)
+    if object.is_a?(User) && object.realname.present?
+      "#{object.name} (#{object.login})"
+    else
+      object.name
+    end
+  end
+
+  def user_or_group_show_path(object)
+    object.is_a?(User) ? user_show_path(object) : group_show_path(object)
+  end
+
   def user_or_groups_roles_delete_path(project, type, object, package)
     if package
       package_remove_role_path(project: project, "#{type}id": object, package: package)

--- a/src/api/app/mixins/webui/manage_relationships.rb
+++ b/src/api/app/mixins/webui/manage_relationships.rb
@@ -18,7 +18,7 @@ module Webui::ManageRelationships
       return
     end
     respond_to do |format|
-      format.js { render json: 'ok' }
+      format.js { render json: {}, status: :ok }
       format.html do
         flash[:notice] = "Added user #{params[:userid]} with role #{params[:role]}"
         redirect_to users_path
@@ -37,7 +37,7 @@ module Webui::ManageRelationships
       return
     end
     respond_to do |format|
-      format.js { render json: 'ok' }
+      format.js { render json: {}, status: :ok }
       format.html do
         flash[:notice] = "Added group #{params[:groupid]} with role #{params[:role]}"
         redirect_to users_path
@@ -53,7 +53,7 @@ module Webui::ManageRelationships
       flash[:error] = e.to_s
     end
     respond_to do |format|
-      format.js { render json: 'ok' }
+      format.js { render json: {}, status: :ok }
       format.html do
         if params[:userid]
           flash[:notice] = "Removed user #{params[:userid]}"

--- a/src/api/app/views/webui2/shared/user_or_groups_roles/_list.html.haml
+++ b/src/api/app/views/webui2/shared/user_or_groups_roles/_list.html.haml
@@ -3,7 +3,7 @@
     mail_subject = "#{home_title} - #{project}"
     mail_subject += "/#{package}" if package
 - records.each do |record|
-  %tr{ id: "#{type}-#{valid_xml_id(record.to_s)}" }
+  %tr
     %td.align-middle
       = image_tag_for(record, size: 20)
       = link_to(display_name(record), user_or_group_show_path(record))

--- a/src/api/app/views/webui2/shared/user_or_groups_roles/_list.html.haml
+++ b/src/api/app/views/webui2/shared/user_or_groups_roles/_list.html.haml
@@ -5,8 +5,8 @@
 - records.each do |record|
   %tr{ id: "#{type}-#{valid_xml_id(record.to_s)}" }
     %td.align-middle
-      = user_with_realname_and_icon(record) if type == 'user'
-      = link_to(record.to_s, controller: 'groups', action: 'show', title: record.to_s) if type == 'group'
+      = image_tag_for(record, size: 20)
+      = link_to(display_name(record), user_or_group_show_path(record))
     - roles.each do |role|
       %td.align-middle
         .custom-control.custom-checkbox

--- a/src/api/app/views/webui2/shared/user_or_groups_roles/_list.html.haml
+++ b/src/api/app/views/webui2/shared/user_or_groups_roles/_list.html.haml
@@ -1,4 +1,4 @@
-- if type == 'user' && !User.current.is_nobody?
+- unless User.current.is_nobody?
   :ruby
     mail_subject = "#{home_title} - #{project}"
     mail_subject += "/#{package}" if package
@@ -21,7 +21,7 @@
     %td.text-nowrap
       - if mail_subject && record.email
         = mail_to(record.email, subject: mail_subject) do
-          %i.far.fa-envelope{ title: 'Send email to user' }
+          %i.far.fa-envelope{ title: "Send email to #{type}" }
       - if user_is_maintainer
         = link_to('#', class: "remove-#{type}",
           data: { toggle: 'modal', target: '#delete-role-modal',

--- a/src/api/app/views/webui2/shared/user_or_groups_roles/_list.html.haml
+++ b/src/api/app/views/webui2/shared/user_or_groups_roles/_list.html.haml
@@ -1,3 +1,7 @@
+- if type == 'user' && !User.current.is_nobody?
+  :ruby
+    mail_subject = "#{home_title} - #{project}"
+    mail_subject += "/#{package}" if package
 - records.each do |record|
   %tr{ id: "#{type}-#{valid_xml_id(record.to_s)}" }
     %td.align-middle
@@ -15,11 +19,7 @@
             = link_to(project_users_path(project: project)) do
               %i.fa.fa-cubes.text-secondary{ title: 'inherited from project' }
     %td.text-nowrap
-      - if type == 'user' && !User.current.is_nobody?
-        :ruby
-          home_title = @configuration ? @configuration['title'] : 'Open Build Service'
-          mail_subject = "#{home_title} - #{project}"
-          mail_subject += "/#{package}" if package
+      - if mail_subject && record.email
         = mail_to(record.email, subject: mail_subject) do
           %i.far.fa-envelope{ title: 'Send email to user' }
       - if user_is_maintainer

--- a/src/api/app/views/webui2/shared/user_or_groups_roles/_list.html.haml
+++ b/src/api/app/views/webui2/shared/user_or_groups_roles/_list.html.haml
@@ -5,16 +5,15 @@
       = link_to(record.to_s, controller: 'groups', action: 'show', title: record.to_s) if type == 'group'
     - roles.each do |role|
       %td.align-middle
-        %label.form-inline.custom-control.custom-checkbox
+        .custom-control.custom-checkbox
           = check_box_tag("#{type}_#{role}_#{record}", '',
             (package || project).send("#{type}_has_role?", record, role), disabled: !user_is_maintainer,
-            data: { "#{type}": record.to_s, role: role.title, type: type }, class: 'trigger custom-control-input',
-            id: nil)
-          %span.custom-control-label
-            %i.fas.fa-spinner.fa-spin.invisible
-            - if package && project.send("#{type}_has_role?", record, role)
-              = link_to(project_users_path(project: project)) do
-                %i.fa.fa-cubes.text-secondary{ title: 'inherited from project' }
+            data: { "#{type}": record.to_s, role: role.title, type: type }, class: 'trigger custom-control-input')
+          %label.custom-control-label{ for: "#{type}_#{role}_#{record}" }
+          %i.fas.fa-spinner.fa-spin.d-none
+          - if package && project.send("#{type}_has_role?", record, role)
+            = link_to(project_users_path(project: project)) do
+              %i.fa.fa-cubes.text-secondary{ title: 'inherited from project' }
     %td.text-nowrap
       - if type == 'user' && !User.current.is_nobody?
         :ruby

--- a/src/api/spec/support/shared_examples/features/bootstrap_user_tab.rb
+++ b/src/api/spec/support/shared_examples/features/bootstrap_user_tab.rb
@@ -6,6 +6,19 @@ RSpec.shared_examples 'bootstrap user tab' do
   let!(:package) { nil }
   let!(:project) { nil }
 
+  def toggle_checkbox(html_id)
+    # Workaround: Bootstrap's custom-control causes the checkbox's input field to be at
+    # a different location than it visually appears. For browsers this is not an issue, but
+    # capybara throws an error because "is not clickable at point (596, 335). Other element
+    # would receive the click".
+    # Thus we have to remove bootstraps custom-control classes.
+    page.execute_script("$('##{html_id}').removeClass('custom-control-input')")
+    page.execute_script("$('label[for=#{html_id}]').removeClass('custom-control-label')")
+    find_field(html_id).click
+    # FIXME: Needed to wait for the Ajax call to perform
+    sleep(1)
+  end
+
   describe 'user roles' do
     let!(:bugowner_user_role) do
       create(:relationship,
@@ -84,11 +97,7 @@ RSpec.shared_examples 'bootstrap user tab' do
     end
 
     scenario 'Remove user from package / project' do
-      expect(page).to have_css('a', text: "#{reader.realname} (reader_user)")
-
-      within('#user-reader_user') do
-        click_on(class: 'remove-user')
-      end
+      find('td', text: "#{reader.realname} (reader_user)").ancestor('tr').find('.remove-user').click
       sleep 1 # FIXME: Needed to avoid a flickering test because the animation of the modal is sometimes faster than capybara
       click_button('Delete')
 
@@ -97,19 +106,15 @@ RSpec.shared_examples 'bootstrap user tab' do
     end
 
     scenario 'Add role to user' do
-      # check checkbox
-      find_field('user_reviewer_user_tab_user', visible: false).sibling('span').click
-      sleep 1 # FIXME: Needed to wait for the Ajax call to perform
+      toggle_checkbox('user_reviewer_user_tab_user')
 
-      visit project_path
+      visit project_path # project_users_path
       click_link('Users')
       expect(find_field('user_reviewer_user_tab_user', visible: false)).to be_checked
     end
 
     scenario 'Remove role from user' do
-      # uncheck checkbox
-      find_field('user_bugowner_user_tab_user', visible: false).sibling('span').click
-      sleep 1 # FIXME: Needed to wait for the Ajax call to perform
+      toggle_checkbox('user_bugowner_user_tab_user')
 
       visit project_path
       click_link('Users')
@@ -190,19 +195,15 @@ RSpec.shared_examples 'bootstrap user tab' do
     end
 
     scenario 'Add role to group' do
-      # check checkbox
-      find_field('group_reviewer_existing_group', visible: false).sibling('span').click
-      sleep 1 # FIXME: Needed to wait for the Ajax call to perform
+      toggle_checkbox('group_reviewer_existing_group')
 
       visit project_path
       click_link('Users')
-      expect(find_field('group_reviewer_existing_group', visible: false)).to be_checked
+      expect(find('#group_reviewer_existing_group', visible: false)).to be_checked
     end
 
     scenario 'Remove role from group' do
-      # uncheck checkbox
-      find_field('group_bugowner_existing_group', visible: false).sibling('span').click
-      sleep 1 # FIXME: Needed to wait for the Ajax call to perform
+      toggle_checkbox('group_bugowner_existing_group')
 
       visit project_path
       click_link('Users')

--- a/src/api/spec/support/shared_examples/features/bootstrap_user_tab.rb
+++ b/src/api/spec/support/shared_examples/features/bootstrap_user_tab.rb
@@ -48,7 +48,7 @@ RSpec.shared_examples 'bootstrap user tab' do
       expect(find_field('user_reviewer_user_tab_user', visible: false)).not_to be_checked
       expect(find_field('user_downloader_user_tab_user', visible: false)).not_to be_checked
       expect(find_field('user_reader_user_tab_user', visible: false)).not_to be_checked
-      expect(page).to have_selector('#user-user_tab_user a.remove-user')
+      expect(page).to have_selector("a.remove-user[data-object='user_tab_user']")
     end
 
     scenario 'Add non existent user' do
@@ -147,7 +147,7 @@ RSpec.shared_examples 'bootstrap user tab' do
       expect(find_field('group_reviewer_existing_group', visible: false)).not_to be_checked
       expect(find_field('group_downloader_existing_group', visible: false)).not_to be_checked
       expect(find_field('group_reader_existing_group', visible: false)).not_to be_checked
-      expect(page).to have_selector('#group-existing_group a.remove-group')
+      expect(page).to have_selector("a.remove-group[data-object='existing_group']")
     end
 
     scenario 'Add non existent group' do


### PR DESCRIPTION
* Add group icons to user & group tab
* Add 'send mail' links to groups table
* Prevent the invisible spinner from being rendered in the DOM. This was causing the table being re-rendered every 200ms. 

Before:

![screenshot-2019-2-15 users of home admin - open build service 1](https://user-images.githubusercontent.com/968949/52850700-654a8400-3114-11e9-816d-9d0676a1e108.png)

After:

![screenshot-2019-2-15 users of home admin - open build service](https://user-images.githubusercontent.com/968949/52850686-5e237600-3114-11e9-9d98-8102f343d93c.png)

