### PR TITLE
Skip before_destroy of repository when we destroy a project

### DIFF
--- a/src/api/app/models/path_element.rb
+++ b/src/api/app/models/path_element.rb
@@ -1,7 +1,9 @@
 class PathElement < ApplicationRecord
+  # FIXME: This should be called parent
   belongs_to :repository, foreign_key: 'parent_id', inverse_of: :path_elements
   acts_as_list scope: [:parent_id]
 
+  # FIXME: This should be called repository
   belongs_to :link, class_name: 'Repository', foreign_key: 'repository_id', inverse_of: :links
 
   validates :link, :repository, presence: true

--- a/src/api/app/models/repository.rb
+++ b/src/api/app/models/repository.rb
@@ -86,7 +86,7 @@ class Repository < ApplicationRecord
           pe.save
         end
       end
-      lrep.project.store(lowprio: true)
+      lrep.project.store(lowprio: true) unless marked_for_destruction?
     end
     # target repos
     logger.debug "remove target repositories from repository #{project.name}/#{name}"
@@ -103,7 +103,7 @@ class Repository < ApplicationRecord
           rt.target_repository = Repository.deleted_instance
           rt.save
         end
-        repo.project.store(lowprio: true)
+        repo.project.store(lowprio: true) unless marked_for_destruction?
       end
     end
   end
@@ -150,6 +150,7 @@ class Repository < ApplicationRecord
   # or empty list
   def linking_repositories
     return [] if links.size.zero?
+    # FIXME: This is the same as using a `has_many through:` association
     links.map(&:repository)
   end
 
@@ -164,6 +165,7 @@ class Repository < ApplicationRecord
 
   def linking_target_repositories
     return [] if targetlinks.size.zero?
+    # FIXME: This is the same as using a `has_many through:` association
     targetlinks.map(&:target_repository)
   end
 

--- a/src/api/spec/cassettes/Project/_restore/on_a_project_with_packages/creates_package_records_in_the_database.yml
+++ b/src/api/spec/cassettes/Project/_restore/on_a_project_with_packages/creates_package_records_in_the_database.yml
@@ -2,12 +2,12 @@
 http_interactions:
 - request:
     method: put
-    uri: http://backend:5352/source/openSUSE_41/_meta
+    uri: http://backend:5352/source/openSUSE_41/_meta?user=_nobody_
     body:
       encoding: UTF-8
       string: |
         <project name="openSUSE_41">
-          <title>The Little Foxes</title>
+          <title>What's Become of Waring</title>
           <description/>
         </project>
     headers:
@@ -29,362 +29,19 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '104'
+      - '111'
     body:
       encoding: UTF-8
       string: |
         <project name="openSUSE_41">
-          <title>The Little Foxes</title>
+          <title>What's Become of Waring</title>
           <description></description>
         </project>
     http_version: 
-  recorded_at: Thu, 06 Jul 2017 06:48:49 GMT
-- request:
-    method: put
-    uri: http://backend:5352/source/openSUSE_41/_config
-    body:
-      encoding: UTF-8
-      string: Molestiae reiciendis ad et fuga. Aut rerum maxime qui a ut debitis.
-        Tempore corrupti fugit occaecati voluptate dignissimos quas nihil. Corrupti
-        quia minima aut sint aut amet eos. Saepe est qui praesentium hic.
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '21'
-    body:
-      encoding: UTF-8
-      string: '<status code="ok" />
-
-'
-    http_version: 
-  recorded_at: Thu, 06 Jul 2017 06:48:49 GMT
-- request:
-    method: put
-    uri: http://backend:5352/source/project_used_for_restoration/_meta
-    body:
-      encoding: UTF-8
-      string: |
-        <project name="project_used_for_restoration">
-          <title>restoration_project_title</title>
-          <description/>
-        </project>
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '130'
-    body:
-      encoding: UTF-8
-      string: |
-        <project name="project_used_for_restoration">
-          <title>restoration_project_title</title>
-          <description></description>
-        </project>
-    http_version: 
-  recorded_at: Thu, 06 Jul 2017 06:48:49 GMT
-- request:
-    method: put
-    uri: http://backend:5352/source/project_used_for_restoration/_config
-    body:
-      encoding: UTF-8
-      string: Quo quibusdam totam rerum aliquid. Dolor architecto cum maiores atque.
-        Et dignissimos rerum repudiandae non. Perspiciatis aut aspernatur voluptatem
-        minus est eos. Aperiam at aut.
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '21'
-    body:
-      encoding: UTF-8
-      string: '<status code="ok" />
-
-'
-    http_version: 
-  recorded_at: Thu, 06 Jul 2017 06:48:49 GMT
-- request:
-    method: put
-    uri: http://backend:5352/source/project_used_for_restoration/restoration_package_0/_meta?user=Admin
-    body:
-      encoding: UTF-8
-      string: |
-        <package name="restoration_package_0" project="project_used_for_restoration">
-          <title>restoration_title_0</title>
-          <description>restoration_desc_0</description>
-        </package>
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '174'
-    body:
-      encoding: UTF-8
-      string: |
-        <package name="restoration_package_0" project="project_used_for_restoration">
-          <title>restoration_title_0</title>
-          <description>restoration_desc_0</description>
-        </package>
-    http_version: 
-  recorded_at: Thu, 06 Jul 2017 06:48:49 GMT
-- request:
-    method: put
-    uri: http://backend:5352/source/project_used_for_restoration/restoration_package_0/_meta
-    body:
-      encoding: UTF-8
-      string: |
-        <package name="restoration_package_0" project="project_used_for_restoration">
-          <title>restoration_title_0</title>
-          <description>restoration_desc_0</description>
-        </package>
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '174'
-    body:
-      encoding: UTF-8
-      string: |
-        <package name="restoration_package_0" project="project_used_for_restoration">
-          <title>restoration_title_0</title>
-          <description>restoration_desc_0</description>
-        </package>
-    http_version: 
-  recorded_at: Thu, 06 Jul 2017 06:48:49 GMT
-- request:
-    method: put
-    uri: http://backend:5352/source/project_used_for_restoration/restoration_package_0/_meta?user=Admin
-    body:
-      encoding: UTF-8
-      string: |
-        <package name="restoration_package_0" project="project_used_for_restoration">
-          <title>restoration_title_0</title>
-          <description>restoration_desc_0</description>
-        </package>
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '174'
-    body:
-      encoding: UTF-8
-      string: |
-        <package name="restoration_package_0" project="project_used_for_restoration">
-          <title>restoration_title_0</title>
-          <description>restoration_desc_0</description>
-        </package>
-    http_version: 
-  recorded_at: Thu, 06 Jul 2017 06:48:49 GMT
-- request:
-    method: put
-    uri: http://backend:5352/source/project_used_for_restoration/restoration_package_1/_meta?user=Admin
-    body:
-      encoding: UTF-8
-      string: |
-        <package name="restoration_package_1" project="project_used_for_restoration">
-          <title>restoration_title_1</title>
-          <description>restoration_desc_1</description>
-        </package>
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '174'
-    body:
-      encoding: UTF-8
-      string: |
-        <package name="restoration_package_1" project="project_used_for_restoration">
-          <title>restoration_title_1</title>
-          <description>restoration_desc_1</description>
-        </package>
-    http_version: 
-  recorded_at: Thu, 06 Jul 2017 06:48:49 GMT
-- request:
-    method: put
-    uri: http://backend:5352/source/project_used_for_restoration/restoration_package_1/_meta
-    body:
-      encoding: UTF-8
-      string: |
-        <package name="restoration_package_1" project="project_used_for_restoration">
-          <title>restoration_title_1</title>
-          <description>restoration_desc_1</description>
-        </package>
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '174'
-    body:
-      encoding: UTF-8
-      string: |
-        <package name="restoration_package_1" project="project_used_for_restoration">
-          <title>restoration_title_1</title>
-          <description>restoration_desc_1</description>
-        </package>
-    http_version: 
-  recorded_at: Thu, 06 Jul 2017 06:48:49 GMT
-- request:
-    method: put
-    uri: http://backend:5352/source/project_used_for_restoration/restoration_package_1/_meta?user=Admin
-    body:
-      encoding: UTF-8
-      string: |
-        <package name="restoration_package_1" project="project_used_for_restoration">
-          <title>restoration_title_1</title>
-          <description>restoration_desc_1</description>
-        </package>
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '174'
-    body:
-      encoding: UTF-8
-      string: |
-        <package name="restoration_package_1" project="project_used_for_restoration">
-          <title>restoration_title_1</title>
-          <description>restoration_desc_1</description>
-        </package>
-    http_version: 
-  recorded_at: Thu, 06 Jul 2017 06:48:49 GMT
+  recorded_at: Wed, 06 Feb 2019 11:21:38 GMT
 - request:
     method: delete
-    uri: http://backend:5352/source/project_used_for_restoration?comment&user=Admin
+    uri: http://backend:5352/source/project_used_for_restoration
     body:
       encoding: US-ASCII
       string: ''
@@ -412,77 +69,7 @@ http_interactions:
 
 '
     http_version: 
-  recorded_at: Thu, 06 Jul 2017 06:48:49 GMT
-- request:
-    method: post
-    uri: http://backend:5352/source/project_used_for_restoration?cmd=undelete
-    body:
-      encoding: UTF-8
-      string: ''
-    headers:
-      Content-Type:
-      - application/octet-stream
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '21'
-    body:
-      encoding: UTF-8
-      string: '<status code="ok" />
-
-'
-    http_version: 
-  recorded_at: Thu, 06 Jul 2017 06:48:49 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/project_used_for_restoration/_meta
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '130'
-    body:
-      encoding: UTF-8
-      string: |
-        <project name="project_used_for_restoration">
-          <title>restoration_project_title</title>
-          <description></description>
-        </project>
-    http_version: 
-  recorded_at: Thu, 06 Jul 2017 06:48:49 GMT
+  recorded_at: Wed, 06 Feb 2019 11:21:38 GMT
 - request:
     method: put
     uri: http://backend:5352/source/project_used_for_restoration/_meta?user=Admin
@@ -521,7 +108,381 @@ http_interactions:
           <description></description>
         </project>
     http_version: 
-  recorded_at: Thu, 06 Jul 2017 06:48:49 GMT
+  recorded_at: Wed, 06 Feb 2019 11:21:38 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/project_used_for_restoration/restoration_package_0/_meta?user=Admin
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="restoration_package_0" project="project_used_for_restoration">
+          <title>restoration_title_0</title>
+          <description>restoration_desc_0</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '174'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="restoration_package_0" project="project_used_for_restoration">
+          <title>restoration_title_0</title>
+          <description>restoration_desc_0</description>
+        </package>
+    http_version: 
+  recorded_at: Wed, 06 Feb 2019 11:21:38 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/project_used_for_restoration/restoration_package_0/_meta?user=Admin
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="restoration_package_0" project="project_used_for_restoration">
+          <title>restoration_title_0</title>
+          <description>restoration_desc_0</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '174'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="restoration_package_0" project="project_used_for_restoration">
+          <title>restoration_title_0</title>
+          <description>restoration_desc_0</description>
+        </package>
+    http_version: 
+  recorded_at: Wed, 06 Feb 2019 11:21:38 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/project_used_for_restoration/restoration_package_0/_meta?user=Admin
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="restoration_package_0" project="project_used_for_restoration">
+          <title>restoration_title_0</title>
+          <description>restoration_desc_0</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '174'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="restoration_package_0" project="project_used_for_restoration">
+          <title>restoration_title_0</title>
+          <description>restoration_desc_0</description>
+        </package>
+    http_version: 
+  recorded_at: Wed, 06 Feb 2019 11:21:38 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/project_used_for_restoration/restoration_package_1/_meta?user=Admin
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="restoration_package_1" project="project_used_for_restoration">
+          <title>restoration_title_1</title>
+          <description>restoration_desc_1</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '174'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="restoration_package_1" project="project_used_for_restoration">
+          <title>restoration_title_1</title>
+          <description>restoration_desc_1</description>
+        </package>
+    http_version: 
+  recorded_at: Wed, 06 Feb 2019 11:21:38 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/project_used_for_restoration/restoration_package_1/_meta?user=Admin
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="restoration_package_1" project="project_used_for_restoration">
+          <title>restoration_title_1</title>
+          <description>restoration_desc_1</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '174'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="restoration_package_1" project="project_used_for_restoration">
+          <title>restoration_title_1</title>
+          <description>restoration_desc_1</description>
+        </package>
+    http_version: 
+  recorded_at: Wed, 06 Feb 2019 11:21:38 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/project_used_for_restoration/restoration_package_1/_meta?user=Admin
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="restoration_package_1" project="project_used_for_restoration">
+          <title>restoration_title_1</title>
+          <description>restoration_desc_1</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '174'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="restoration_package_1" project="project_used_for_restoration">
+          <title>restoration_title_1</title>
+          <description>restoration_desc_1</description>
+        </package>
+    http_version: 
+  recorded_at: Wed, 06 Feb 2019 11:21:38 GMT
+- request:
+    method: delete
+    uri: http://backend:5352/source/project_used_for_restoration?comment=&user=Admin
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '21'
+    body:
+      encoding: UTF-8
+      string: '<status code="ok" />
+
+'
+    http_version: 
+  recorded_at: Wed, 06 Feb 2019 11:21:39 GMT
+- request:
+    method: post
+    uri: http://backend:5352/source/project_used_for_restoration?cmd=undelete&user=Admin
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Content-Type:
+      - application/octet-stream
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '21'
+    body:
+      encoding: UTF-8
+      string: '<status code="ok" />
+
+'
+    http_version: 
+  recorded_at: Wed, 06 Feb 2019 11:21:39 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/project_used_for_restoration/_meta
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '130'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="project_used_for_restoration">
+          <title>restoration_project_title</title>
+          <description></description>
+        </project>
+    http_version: 
+  recorded_at: Wed, 06 Feb 2019 11:21:39 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/project_used_for_restoration/_meta?user=Admin
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="project_used_for_restoration">
+          <title>restoration_project_title</title>
+          <description/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '130'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="project_used_for_restoration">
+          <title>restoration_project_title</title>
+          <description></description>
+        </project>
+    http_version: 
+  recorded_at: Wed, 06 Feb 2019 11:21:39 GMT
 - request:
     method: get
     uri: http://backend:5352/search/package?match=@project='project_used_for_restoration'
@@ -529,10 +490,8 @@ http_interactions:
       encoding: US-ASCII
       string: ''
     headers:
-      Content-Type:
-      - text/plain
       Accept-Encoding:
-      - identity
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
       - "*/*"
       User-Agent:
@@ -564,7 +523,7 @@ http_interactions:
           </package>
         </collection>
     http_version: 
-  recorded_at: Thu, 06 Jul 2017 06:48:49 GMT
+  recorded_at: Wed, 06 Feb 2019 11:21:39 GMT
 - request:
     method: get
     uri: http://backend:5352/source/project_used_for_restoration/restoration_package_0/_meta
@@ -599,7 +558,7 @@ http_interactions:
           <description>restoration_desc_0</description>
         </package>
     http_version: 
-  recorded_at: Thu, 06 Jul 2017 06:48:49 GMT
+  recorded_at: Wed, 06 Feb 2019 11:21:39 GMT
 - request:
     method: put
     uri: http://backend:5352/source/project_used_for_restoration/restoration_package_0/_meta?user=Admin
@@ -638,7 +597,7 @@ http_interactions:
           <description>restoration_desc_0</description>
         </package>
     http_version: 
-  recorded_at: Thu, 06 Jul 2017 06:48:50 GMT
+  recorded_at: Wed, 06 Feb 2019 11:21:39 GMT
 - request:
     method: put
     uri: http://backend:5352/source/project_used_for_restoration/restoration_package_0/_meta?user=Admin
@@ -677,7 +636,7 @@ http_interactions:
           <description>restoration_desc_0</description>
         </package>
     http_version: 
-  recorded_at: Thu, 06 Jul 2017 06:48:50 GMT
+  recorded_at: Wed, 06 Feb 2019 11:21:39 GMT
 - request:
     method: get
     uri: http://backend:5352/source/project_used_for_restoration/restoration_package_1/_meta
@@ -712,7 +671,7 @@ http_interactions:
           <description>restoration_desc_1</description>
         </package>
     http_version: 
-  recorded_at: Thu, 06 Jul 2017 06:48:50 GMT
+  recorded_at: Wed, 06 Feb 2019 11:21:39 GMT
 - request:
     method: put
     uri: http://backend:5352/source/project_used_for_restoration/restoration_package_1/_meta?user=Admin
@@ -751,7 +710,7 @@ http_interactions:
           <description>restoration_desc_1</description>
         </package>
     http_version: 
-  recorded_at: Thu, 06 Jul 2017 06:48:50 GMT
+  recorded_at: Wed, 06 Feb 2019 11:21:39 GMT
 - request:
     method: put
     uri: http://backend:5352/source/project_used_for_restoration/restoration_package_1/_meta?user=Admin
@@ -790,5 +749,5 @@ http_interactions:
           <description>restoration_desc_1</description>
         </package>
     http_version: 
-  recorded_at: Thu, 06 Jul 2017 06:48:50 GMT
-recorded_with: VCR 3.0.3
+  recorded_at: Wed, 06 Feb 2019 11:21:39 GMT
+recorded_with: VCR 4.0.0

--- a/src/api/spec/cassettes/Project/_restore/on_a_project_with_packages/verifies_the_meta_of_restored_packages/1_10_3_2_1.yml
+++ b/src/api/spec/cassettes/Project/_restore/on_a_project_with_packages/verifies_the_meta_of_restored_packages/1_10_3_2_1.yml
@@ -2,12 +2,12 @@
 http_interactions:
 - request:
     method: put
-    uri: http://backend:5352/source/openSUSE_41/_meta
+    uri: http://backend:5352/source/openSUSE_41/_meta?user=_nobody_
     body:
       encoding: UTF-8
       string: |
         <project name="openSUSE_41">
-          <title>Brandy of the Damned</title>
+          <title>The Torment of Others</title>
           <description/>
         </project>
     headers:
@@ -29,361 +29,19 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '108'
+      - '109'
     body:
       encoding: UTF-8
       string: |
         <project name="openSUSE_41">
-          <title>Brandy of the Damned</title>
+          <title>The Torment of Others</title>
           <description></description>
         </project>
     http_version: 
-  recorded_at: Thu, 06 Jul 2017 06:48:51 GMT
-- request:
-    method: put
-    uri: http://backend:5352/source/openSUSE_41/_config
-    body:
-      encoding: UTF-8
-      string: Dolorem facilis impedit suscipit. Amet repellendus nihil porro. Nemo
-        asperiores dolore deserunt quas unde consequatur. Ipsam aut reiciendis. Maiores
-        neque aliquid non ullam velit officiis.
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '21'
-    body:
-      encoding: UTF-8
-      string: '<status code="ok" />
-
-'
-    http_version: 
-  recorded_at: Thu, 06 Jul 2017 06:48:51 GMT
-- request:
-    method: put
-    uri: http://backend:5352/source/project_used_for_restoration/_meta
-    body:
-      encoding: UTF-8
-      string: |
-        <project name="project_used_for_restoration">
-          <title>restoration_project_title</title>
-          <description/>
-        </project>
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '130'
-    body:
-      encoding: UTF-8
-      string: |
-        <project name="project_used_for_restoration">
-          <title>restoration_project_title</title>
-          <description></description>
-        </project>
-    http_version: 
-  recorded_at: Thu, 06 Jul 2017 06:48:51 GMT
-- request:
-    method: put
-    uri: http://backend:5352/source/project_used_for_restoration/_config
-    body:
-      encoding: UTF-8
-      string: Odit maiores porro voluptatem. Officiis numquam sed. Quibusdam iusto
-        et distinctio expedita consectetur et. Id dolore aliquid.
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '21'
-    body:
-      encoding: UTF-8
-      string: '<status code="ok" />
-
-'
-    http_version: 
-  recorded_at: Thu, 06 Jul 2017 06:48:51 GMT
-- request:
-    method: put
-    uri: http://backend:5352/source/project_used_for_restoration/restoration_package_0/_meta?user=Admin
-    body:
-      encoding: UTF-8
-      string: |
-        <package name="restoration_package_0" project="project_used_for_restoration">
-          <title>restoration_title_0</title>
-          <description>restoration_desc_0</description>
-        </package>
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '174'
-    body:
-      encoding: UTF-8
-      string: |
-        <package name="restoration_package_0" project="project_used_for_restoration">
-          <title>restoration_title_0</title>
-          <description>restoration_desc_0</description>
-        </package>
-    http_version: 
-  recorded_at: Thu, 06 Jul 2017 06:48:51 GMT
-- request:
-    method: put
-    uri: http://backend:5352/source/project_used_for_restoration/restoration_package_0/_meta
-    body:
-      encoding: UTF-8
-      string: |
-        <package name="restoration_package_0" project="project_used_for_restoration">
-          <title>restoration_title_0</title>
-          <description>restoration_desc_0</description>
-        </package>
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '174'
-    body:
-      encoding: UTF-8
-      string: |
-        <package name="restoration_package_0" project="project_used_for_restoration">
-          <title>restoration_title_0</title>
-          <description>restoration_desc_0</description>
-        </package>
-    http_version: 
-  recorded_at: Thu, 06 Jul 2017 06:48:51 GMT
-- request:
-    method: put
-    uri: http://backend:5352/source/project_used_for_restoration/restoration_package_0/_meta?user=Admin
-    body:
-      encoding: UTF-8
-      string: |
-        <package name="restoration_package_0" project="project_used_for_restoration">
-          <title>restoration_title_0</title>
-          <description>restoration_desc_0</description>
-        </package>
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '174'
-    body:
-      encoding: UTF-8
-      string: |
-        <package name="restoration_package_0" project="project_used_for_restoration">
-          <title>restoration_title_0</title>
-          <description>restoration_desc_0</description>
-        </package>
-    http_version: 
-  recorded_at: Thu, 06 Jul 2017 06:48:51 GMT
-- request:
-    method: put
-    uri: http://backend:5352/source/project_used_for_restoration/restoration_package_1/_meta?user=Admin
-    body:
-      encoding: UTF-8
-      string: |
-        <package name="restoration_package_1" project="project_used_for_restoration">
-          <title>restoration_title_1</title>
-          <description>restoration_desc_1</description>
-        </package>
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '174'
-    body:
-      encoding: UTF-8
-      string: |
-        <package name="restoration_package_1" project="project_used_for_restoration">
-          <title>restoration_title_1</title>
-          <description>restoration_desc_1</description>
-        </package>
-    http_version: 
-  recorded_at: Thu, 06 Jul 2017 06:48:51 GMT
-- request:
-    method: put
-    uri: http://backend:5352/source/project_used_for_restoration/restoration_package_1/_meta
-    body:
-      encoding: UTF-8
-      string: |
-        <package name="restoration_package_1" project="project_used_for_restoration">
-          <title>restoration_title_1</title>
-          <description>restoration_desc_1</description>
-        </package>
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '174'
-    body:
-      encoding: UTF-8
-      string: |
-        <package name="restoration_package_1" project="project_used_for_restoration">
-          <title>restoration_title_1</title>
-          <description>restoration_desc_1</description>
-        </package>
-    http_version: 
-  recorded_at: Thu, 06 Jul 2017 06:48:51 GMT
-- request:
-    method: put
-    uri: http://backend:5352/source/project_used_for_restoration/restoration_package_1/_meta?user=Admin
-    body:
-      encoding: UTF-8
-      string: |
-        <package name="restoration_package_1" project="project_used_for_restoration">
-          <title>restoration_title_1</title>
-          <description>restoration_desc_1</description>
-        </package>
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '174'
-    body:
-      encoding: UTF-8
-      string: |
-        <package name="restoration_package_1" project="project_used_for_restoration">
-          <title>restoration_title_1</title>
-          <description>restoration_desc_1</description>
-        </package>
-    http_version: 
-  recorded_at: Thu, 06 Jul 2017 06:48:51 GMT
+  recorded_at: Wed, 06 Feb 2019 11:21:39 GMT
 - request:
     method: delete
-    uri: http://backend:5352/source/project_used_for_restoration?comment&user=Admin
+    uri: http://backend:5352/source/project_used_for_restoration
     body:
       encoding: US-ASCII
       string: ''
@@ -411,77 +69,7 @@ http_interactions:
 
 '
     http_version: 
-  recorded_at: Thu, 06 Jul 2017 06:48:51 GMT
-- request:
-    method: post
-    uri: http://backend:5352/source/project_used_for_restoration?cmd=undelete
-    body:
-      encoding: UTF-8
-      string: ''
-    headers:
-      Content-Type:
-      - application/octet-stream
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '21'
-    body:
-      encoding: UTF-8
-      string: '<status code="ok" />
-
-'
-    http_version: 
-  recorded_at: Thu, 06 Jul 2017 06:48:51 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/project_used_for_restoration/_meta
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '130'
-    body:
-      encoding: UTF-8
-      string: |
-        <project name="project_used_for_restoration">
-          <title>restoration_project_title</title>
-          <description></description>
-        </project>
-    http_version: 
-  recorded_at: Thu, 06 Jul 2017 06:48:51 GMT
+  recorded_at: Wed, 06 Feb 2019 11:21:39 GMT
 - request:
     method: put
     uri: http://backend:5352/source/project_used_for_restoration/_meta?user=Admin
@@ -520,7 +108,381 @@ http_interactions:
           <description></description>
         </project>
     http_version: 
-  recorded_at: Thu, 06 Jul 2017 06:48:51 GMT
+  recorded_at: Wed, 06 Feb 2019 11:21:39 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/project_used_for_restoration/restoration_package_0/_meta?user=Admin
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="restoration_package_0" project="project_used_for_restoration">
+          <title>restoration_title_0</title>
+          <description>restoration_desc_0</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '174'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="restoration_package_0" project="project_used_for_restoration">
+          <title>restoration_title_0</title>
+          <description>restoration_desc_0</description>
+        </package>
+    http_version: 
+  recorded_at: Wed, 06 Feb 2019 11:21:39 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/project_used_for_restoration/restoration_package_0/_meta?user=Admin
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="restoration_package_0" project="project_used_for_restoration">
+          <title>restoration_title_0</title>
+          <description>restoration_desc_0</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '174'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="restoration_package_0" project="project_used_for_restoration">
+          <title>restoration_title_0</title>
+          <description>restoration_desc_0</description>
+        </package>
+    http_version: 
+  recorded_at: Wed, 06 Feb 2019 11:21:39 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/project_used_for_restoration/restoration_package_0/_meta?user=Admin
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="restoration_package_0" project="project_used_for_restoration">
+          <title>restoration_title_0</title>
+          <description>restoration_desc_0</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '174'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="restoration_package_0" project="project_used_for_restoration">
+          <title>restoration_title_0</title>
+          <description>restoration_desc_0</description>
+        </package>
+    http_version: 
+  recorded_at: Wed, 06 Feb 2019 11:21:39 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/project_used_for_restoration/restoration_package_1/_meta?user=Admin
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="restoration_package_1" project="project_used_for_restoration">
+          <title>restoration_title_1</title>
+          <description>restoration_desc_1</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '174'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="restoration_package_1" project="project_used_for_restoration">
+          <title>restoration_title_1</title>
+          <description>restoration_desc_1</description>
+        </package>
+    http_version: 
+  recorded_at: Wed, 06 Feb 2019 11:21:39 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/project_used_for_restoration/restoration_package_1/_meta?user=Admin
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="restoration_package_1" project="project_used_for_restoration">
+          <title>restoration_title_1</title>
+          <description>restoration_desc_1</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '174'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="restoration_package_1" project="project_used_for_restoration">
+          <title>restoration_title_1</title>
+          <description>restoration_desc_1</description>
+        </package>
+    http_version: 
+  recorded_at: Wed, 06 Feb 2019 11:21:39 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/project_used_for_restoration/restoration_package_1/_meta?user=Admin
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="restoration_package_1" project="project_used_for_restoration">
+          <title>restoration_title_1</title>
+          <description>restoration_desc_1</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '174'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="restoration_package_1" project="project_used_for_restoration">
+          <title>restoration_title_1</title>
+          <description>restoration_desc_1</description>
+        </package>
+    http_version: 
+  recorded_at: Wed, 06 Feb 2019 11:21:39 GMT
+- request:
+    method: delete
+    uri: http://backend:5352/source/project_used_for_restoration?comment=&user=Admin
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '21'
+    body:
+      encoding: UTF-8
+      string: '<status code="ok" />
+
+'
+    http_version: 
+  recorded_at: Wed, 06 Feb 2019 11:21:39 GMT
+- request:
+    method: post
+    uri: http://backend:5352/source/project_used_for_restoration?cmd=undelete&user=Admin
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Content-Type:
+      - application/octet-stream
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '21'
+    body:
+      encoding: UTF-8
+      string: '<status code="ok" />
+
+'
+    http_version: 
+  recorded_at: Wed, 06 Feb 2019 11:21:39 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/project_used_for_restoration/_meta
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '130'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="project_used_for_restoration">
+          <title>restoration_project_title</title>
+          <description></description>
+        </project>
+    http_version: 
+  recorded_at: Wed, 06 Feb 2019 11:21:39 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/project_used_for_restoration/_meta?user=Admin
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="project_used_for_restoration">
+          <title>restoration_project_title</title>
+          <description/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '130'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="project_used_for_restoration">
+          <title>restoration_project_title</title>
+          <description></description>
+        </project>
+    http_version: 
+  recorded_at: Wed, 06 Feb 2019 11:21:39 GMT
 - request:
     method: get
     uri: http://backend:5352/search/package?match=@project='project_used_for_restoration'
@@ -528,10 +490,8 @@ http_interactions:
       encoding: US-ASCII
       string: ''
     headers:
-      Content-Type:
-      - text/plain
       Accept-Encoding:
-      - identity
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
       - "*/*"
       User-Agent:
@@ -563,7 +523,7 @@ http_interactions:
           </package>
         </collection>
     http_version: 
-  recorded_at: Thu, 06 Jul 2017 06:48:51 GMT
+  recorded_at: Wed, 06 Feb 2019 11:21:39 GMT
 - request:
     method: get
     uri: http://backend:5352/source/project_used_for_restoration/restoration_package_0/_meta
@@ -598,7 +558,7 @@ http_interactions:
           <description>restoration_desc_0</description>
         </package>
     http_version: 
-  recorded_at: Thu, 06 Jul 2017 06:48:51 GMT
+  recorded_at: Wed, 06 Feb 2019 11:21:39 GMT
 - request:
     method: put
     uri: http://backend:5352/source/project_used_for_restoration/restoration_package_0/_meta?user=Admin
@@ -637,7 +597,7 @@ http_interactions:
           <description>restoration_desc_0</description>
         </package>
     http_version: 
-  recorded_at: Thu, 06 Jul 2017 06:48:51 GMT
+  recorded_at: Wed, 06 Feb 2019 11:21:40 GMT
 - request:
     method: put
     uri: http://backend:5352/source/project_used_for_restoration/restoration_package_0/_meta?user=Admin
@@ -676,7 +636,7 @@ http_interactions:
           <description>restoration_desc_0</description>
         </package>
     http_version: 
-  recorded_at: Thu, 06 Jul 2017 06:48:51 GMT
+  recorded_at: Wed, 06 Feb 2019 11:21:40 GMT
 - request:
     method: get
     uri: http://backend:5352/source/project_used_for_restoration/restoration_package_1/_meta
@@ -711,7 +671,7 @@ http_interactions:
           <description>restoration_desc_1</description>
         </package>
     http_version: 
-  recorded_at: Thu, 06 Jul 2017 06:48:51 GMT
+  recorded_at: Wed, 06 Feb 2019 11:21:40 GMT
 - request:
     method: put
     uri: http://backend:5352/source/project_used_for_restoration/restoration_package_1/_meta?user=Admin
@@ -750,7 +710,7 @@ http_interactions:
           <description>restoration_desc_1</description>
         </package>
     http_version: 
-  recorded_at: Thu, 06 Jul 2017 06:48:51 GMT
+  recorded_at: Wed, 06 Feb 2019 11:21:40 GMT
 - request:
     method: put
     uri: http://backend:5352/source/project_used_for_restoration/restoration_package_1/_meta?user=Admin
@@ -789,5 +749,5 @@ http_interactions:
           <description>restoration_desc_1</description>
         </package>
     http_version: 
-  recorded_at: Thu, 06 Jul 2017 06:48:51 GMT
-recorded_with: VCR 3.0.3
+  recorded_at: Wed, 06 Feb 2019 11:21:40 GMT
+recorded_with: VCR 4.0.0

--- a/src/api/spec/cassettes/Project/_restore/on_a_project_with_packages/verifies_the_meta_of_restored_packages/1_10_3_2_2.yml
+++ b/src/api/spec/cassettes/Project/_restore/on_a_project_with_packages/verifies_the_meta_of_restored_packages/1_10_3_2_2.yml
@@ -2,12 +2,12 @@
 http_interactions:
 - request:
     method: put
-    uri: http://backend:5352/source/openSUSE_41/_meta
+    uri: http://backend:5352/source/openSUSE_41/_meta?user=_nobody_
     body:
       encoding: UTF-8
       string: |
         <project name="openSUSE_41">
-          <title>The World, the Flesh and the Devil</title>
+          <title>I Will Fear No Evil</title>
           <description/>
         </project>
     headers:
@@ -29,361 +29,19 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '122'
+      - '107'
     body:
       encoding: UTF-8
       string: |
         <project name="openSUSE_41">
-          <title>The World, the Flesh and the Devil</title>
+          <title>I Will Fear No Evil</title>
           <description></description>
         </project>
     http_version: 
-  recorded_at: Thu, 06 Jul 2017 06:48:50 GMT
-- request:
-    method: put
-    uri: http://backend:5352/source/openSUSE_41/_config
-    body:
-      encoding: UTF-8
-      string: Dolorem quaerat aut aut libero. Voluptas dolores tenetur qui illo. Quasi
-        ut provident nobis vero iusto nihil sed.
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '21'
-    body:
-      encoding: UTF-8
-      string: '<status code="ok" />
-
-'
-    http_version: 
-  recorded_at: Thu, 06 Jul 2017 06:48:50 GMT
-- request:
-    method: put
-    uri: http://backend:5352/source/project_used_for_restoration/_meta
-    body:
-      encoding: UTF-8
-      string: |
-        <project name="project_used_for_restoration">
-          <title>restoration_project_title</title>
-          <description/>
-        </project>
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '130'
-    body:
-      encoding: UTF-8
-      string: |
-        <project name="project_used_for_restoration">
-          <title>restoration_project_title</title>
-          <description></description>
-        </project>
-    http_version: 
-  recorded_at: Thu, 06 Jul 2017 06:48:50 GMT
-- request:
-    method: put
-    uri: http://backend:5352/source/project_used_for_restoration/_config
-    body:
-      encoding: UTF-8
-      string: Perspiciatis suscipit quis temporibus vitae et dolores aut. Aliquam
-        expedita illo deleniti ut laborum in numquam. Minus qui quaerat dolorem vel
-        et sit corporis.
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '21'
-    body:
-      encoding: UTF-8
-      string: '<status code="ok" />
-
-'
-    http_version: 
-  recorded_at: Thu, 06 Jul 2017 06:48:50 GMT
-- request:
-    method: put
-    uri: http://backend:5352/source/project_used_for_restoration/restoration_package_0/_meta?user=Admin
-    body:
-      encoding: UTF-8
-      string: |
-        <package name="restoration_package_0" project="project_used_for_restoration">
-          <title>restoration_title_0</title>
-          <description>restoration_desc_0</description>
-        </package>
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '174'
-    body:
-      encoding: UTF-8
-      string: |
-        <package name="restoration_package_0" project="project_used_for_restoration">
-          <title>restoration_title_0</title>
-          <description>restoration_desc_0</description>
-        </package>
-    http_version: 
-  recorded_at: Thu, 06 Jul 2017 06:48:50 GMT
-- request:
-    method: put
-    uri: http://backend:5352/source/project_used_for_restoration/restoration_package_0/_meta
-    body:
-      encoding: UTF-8
-      string: |
-        <package name="restoration_package_0" project="project_used_for_restoration">
-          <title>restoration_title_0</title>
-          <description>restoration_desc_0</description>
-        </package>
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '174'
-    body:
-      encoding: UTF-8
-      string: |
-        <package name="restoration_package_0" project="project_used_for_restoration">
-          <title>restoration_title_0</title>
-          <description>restoration_desc_0</description>
-        </package>
-    http_version: 
-  recorded_at: Thu, 06 Jul 2017 06:48:50 GMT
-- request:
-    method: put
-    uri: http://backend:5352/source/project_used_for_restoration/restoration_package_0/_meta?user=Admin
-    body:
-      encoding: UTF-8
-      string: |
-        <package name="restoration_package_0" project="project_used_for_restoration">
-          <title>restoration_title_0</title>
-          <description>restoration_desc_0</description>
-        </package>
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '174'
-    body:
-      encoding: UTF-8
-      string: |
-        <package name="restoration_package_0" project="project_used_for_restoration">
-          <title>restoration_title_0</title>
-          <description>restoration_desc_0</description>
-        </package>
-    http_version: 
-  recorded_at: Thu, 06 Jul 2017 06:48:50 GMT
-- request:
-    method: put
-    uri: http://backend:5352/source/project_used_for_restoration/restoration_package_1/_meta?user=Admin
-    body:
-      encoding: UTF-8
-      string: |
-        <package name="restoration_package_1" project="project_used_for_restoration">
-          <title>restoration_title_1</title>
-          <description>restoration_desc_1</description>
-        </package>
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '174'
-    body:
-      encoding: UTF-8
-      string: |
-        <package name="restoration_package_1" project="project_used_for_restoration">
-          <title>restoration_title_1</title>
-          <description>restoration_desc_1</description>
-        </package>
-    http_version: 
-  recorded_at: Thu, 06 Jul 2017 06:48:50 GMT
-- request:
-    method: put
-    uri: http://backend:5352/source/project_used_for_restoration/restoration_package_1/_meta
-    body:
-      encoding: UTF-8
-      string: |
-        <package name="restoration_package_1" project="project_used_for_restoration">
-          <title>restoration_title_1</title>
-          <description>restoration_desc_1</description>
-        </package>
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '174'
-    body:
-      encoding: UTF-8
-      string: |
-        <package name="restoration_package_1" project="project_used_for_restoration">
-          <title>restoration_title_1</title>
-          <description>restoration_desc_1</description>
-        </package>
-    http_version: 
-  recorded_at: Thu, 06 Jul 2017 06:48:50 GMT
-- request:
-    method: put
-    uri: http://backend:5352/source/project_used_for_restoration/restoration_package_1/_meta?user=Admin
-    body:
-      encoding: UTF-8
-      string: |
-        <package name="restoration_package_1" project="project_used_for_restoration">
-          <title>restoration_title_1</title>
-          <description>restoration_desc_1</description>
-        </package>
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '174'
-    body:
-      encoding: UTF-8
-      string: |
-        <package name="restoration_package_1" project="project_used_for_restoration">
-          <title>restoration_title_1</title>
-          <description>restoration_desc_1</description>
-        </package>
-    http_version: 
-  recorded_at: Thu, 06 Jul 2017 06:48:50 GMT
+  recorded_at: Wed, 06 Feb 2019 11:21:40 GMT
 - request:
     method: delete
-    uri: http://backend:5352/source/project_used_for_restoration?comment&user=Admin
+    uri: http://backend:5352/source/project_used_for_restoration
     body:
       encoding: US-ASCII
       string: ''
@@ -411,77 +69,7 @@ http_interactions:
 
 '
     http_version: 
-  recorded_at: Thu, 06 Jul 2017 06:48:50 GMT
-- request:
-    method: post
-    uri: http://backend:5352/source/project_used_for_restoration?cmd=undelete
-    body:
-      encoding: UTF-8
-      string: ''
-    headers:
-      Content-Type:
-      - application/octet-stream
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '21'
-    body:
-      encoding: UTF-8
-      string: '<status code="ok" />
-
-'
-    http_version: 
-  recorded_at: Thu, 06 Jul 2017 06:48:50 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/project_used_for_restoration/_meta
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '130'
-    body:
-      encoding: UTF-8
-      string: |
-        <project name="project_used_for_restoration">
-          <title>restoration_project_title</title>
-          <description></description>
-        </project>
-    http_version: 
-  recorded_at: Thu, 06 Jul 2017 06:48:50 GMT
+  recorded_at: Wed, 06 Feb 2019 11:21:40 GMT
 - request:
     method: put
     uri: http://backend:5352/source/project_used_for_restoration/_meta?user=Admin
@@ -520,7 +108,381 @@ http_interactions:
           <description></description>
         </project>
     http_version: 
-  recorded_at: Thu, 06 Jul 2017 06:48:50 GMT
+  recorded_at: Wed, 06 Feb 2019 11:21:40 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/project_used_for_restoration/restoration_package_0/_meta?user=Admin
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="restoration_package_0" project="project_used_for_restoration">
+          <title>restoration_title_0</title>
+          <description>restoration_desc_0</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '174'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="restoration_package_0" project="project_used_for_restoration">
+          <title>restoration_title_0</title>
+          <description>restoration_desc_0</description>
+        </package>
+    http_version: 
+  recorded_at: Wed, 06 Feb 2019 11:21:40 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/project_used_for_restoration/restoration_package_0/_meta?user=Admin
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="restoration_package_0" project="project_used_for_restoration">
+          <title>restoration_title_0</title>
+          <description>restoration_desc_0</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '174'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="restoration_package_0" project="project_used_for_restoration">
+          <title>restoration_title_0</title>
+          <description>restoration_desc_0</description>
+        </package>
+    http_version: 
+  recorded_at: Wed, 06 Feb 2019 11:21:40 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/project_used_for_restoration/restoration_package_0/_meta?user=Admin
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="restoration_package_0" project="project_used_for_restoration">
+          <title>restoration_title_0</title>
+          <description>restoration_desc_0</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '174'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="restoration_package_0" project="project_used_for_restoration">
+          <title>restoration_title_0</title>
+          <description>restoration_desc_0</description>
+        </package>
+    http_version: 
+  recorded_at: Wed, 06 Feb 2019 11:21:40 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/project_used_for_restoration/restoration_package_1/_meta?user=Admin
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="restoration_package_1" project="project_used_for_restoration">
+          <title>restoration_title_1</title>
+          <description>restoration_desc_1</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '174'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="restoration_package_1" project="project_used_for_restoration">
+          <title>restoration_title_1</title>
+          <description>restoration_desc_1</description>
+        </package>
+    http_version: 
+  recorded_at: Wed, 06 Feb 2019 11:21:40 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/project_used_for_restoration/restoration_package_1/_meta?user=Admin
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="restoration_package_1" project="project_used_for_restoration">
+          <title>restoration_title_1</title>
+          <description>restoration_desc_1</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '174'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="restoration_package_1" project="project_used_for_restoration">
+          <title>restoration_title_1</title>
+          <description>restoration_desc_1</description>
+        </package>
+    http_version: 
+  recorded_at: Wed, 06 Feb 2019 11:21:40 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/project_used_for_restoration/restoration_package_1/_meta?user=Admin
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="restoration_package_1" project="project_used_for_restoration">
+          <title>restoration_title_1</title>
+          <description>restoration_desc_1</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '174'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="restoration_package_1" project="project_used_for_restoration">
+          <title>restoration_title_1</title>
+          <description>restoration_desc_1</description>
+        </package>
+    http_version: 
+  recorded_at: Wed, 06 Feb 2019 11:21:40 GMT
+- request:
+    method: delete
+    uri: http://backend:5352/source/project_used_for_restoration?comment=&user=Admin
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '21'
+    body:
+      encoding: UTF-8
+      string: '<status code="ok" />
+
+'
+    http_version: 
+  recorded_at: Wed, 06 Feb 2019 11:21:40 GMT
+- request:
+    method: post
+    uri: http://backend:5352/source/project_used_for_restoration?cmd=undelete&user=Admin
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Content-Type:
+      - application/octet-stream
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '21'
+    body:
+      encoding: UTF-8
+      string: '<status code="ok" />
+
+'
+    http_version: 
+  recorded_at: Wed, 06 Feb 2019 11:21:40 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/project_used_for_restoration/_meta
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '130'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="project_used_for_restoration">
+          <title>restoration_project_title</title>
+          <description></description>
+        </project>
+    http_version: 
+  recorded_at: Wed, 06 Feb 2019 11:21:40 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/project_used_for_restoration/_meta?user=Admin
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="project_used_for_restoration">
+          <title>restoration_project_title</title>
+          <description/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '130'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="project_used_for_restoration">
+          <title>restoration_project_title</title>
+          <description></description>
+        </project>
+    http_version: 
+  recorded_at: Wed, 06 Feb 2019 11:21:40 GMT
 - request:
     method: get
     uri: http://backend:5352/search/package?match=@project='project_used_for_restoration'
@@ -528,10 +490,8 @@ http_interactions:
       encoding: US-ASCII
       string: ''
     headers:
-      Content-Type:
-      - text/plain
       Accept-Encoding:
-      - identity
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
       - "*/*"
       User-Agent:
@@ -563,7 +523,7 @@ http_interactions:
           </package>
         </collection>
     http_version: 
-  recorded_at: Thu, 06 Jul 2017 06:48:50 GMT
+  recorded_at: Wed, 06 Feb 2019 11:21:40 GMT
 - request:
     method: get
     uri: http://backend:5352/source/project_used_for_restoration/restoration_package_0/_meta
@@ -598,7 +558,7 @@ http_interactions:
           <description>restoration_desc_0</description>
         </package>
     http_version: 
-  recorded_at: Thu, 06 Jul 2017 06:48:50 GMT
+  recorded_at: Wed, 06 Feb 2019 11:21:40 GMT
 - request:
     method: put
     uri: http://backend:5352/source/project_used_for_restoration/restoration_package_0/_meta?user=Admin
@@ -637,7 +597,7 @@ http_interactions:
           <description>restoration_desc_0</description>
         </package>
     http_version: 
-  recorded_at: Thu, 06 Jul 2017 06:48:50 GMT
+  recorded_at: Wed, 06 Feb 2019 11:21:40 GMT
 - request:
     method: put
     uri: http://backend:5352/source/project_used_for_restoration/restoration_package_0/_meta?user=Admin
@@ -676,7 +636,7 @@ http_interactions:
           <description>restoration_desc_0</description>
         </package>
     http_version: 
-  recorded_at: Thu, 06 Jul 2017 06:48:50 GMT
+  recorded_at: Wed, 06 Feb 2019 11:21:40 GMT
 - request:
     method: get
     uri: http://backend:5352/source/project_used_for_restoration/restoration_package_1/_meta
@@ -711,7 +671,7 @@ http_interactions:
           <description>restoration_desc_1</description>
         </package>
     http_version: 
-  recorded_at: Thu, 06 Jul 2017 06:48:50 GMT
+  recorded_at: Wed, 06 Feb 2019 11:21:40 GMT
 - request:
     method: put
     uri: http://backend:5352/source/project_used_for_restoration/restoration_package_1/_meta?user=Admin
@@ -750,7 +710,7 @@ http_interactions:
           <description>restoration_desc_1</description>
         </package>
     http_version: 
-  recorded_at: Thu, 06 Jul 2017 06:48:51 GMT
+  recorded_at: Wed, 06 Feb 2019 11:21:40 GMT
 - request:
     method: put
     uri: http://backend:5352/source/project_used_for_restoration/restoration_package_1/_meta?user=Admin
@@ -789,5 +749,5 @@ http_interactions:
           <description>restoration_desc_1</description>
         </package>
     http_version: 
-  recorded_at: Thu, 06 Jul 2017 06:48:51 GMT
-recorded_with: VCR 3.0.3
+  recorded_at: Wed, 06 Feb 2019 11:21:40 GMT
+recorded_with: VCR 4.0.0

--- a/src/api/spec/cassettes/Project/_restore/sets_the_user_that_restored_the_project_in_the_history_element.yml
+++ b/src/api/spec/cassettes/Project/_restore/sets_the_user_that_restored_the_project_in_the_history_element.yml
@@ -7,7 +7,7 @@ http_interactions:
       encoding: UTF-8
       string: |
         <project name="openSUSE_41">
-          <title>Blue Remembered Earth</title>
+          <title>Beyond the Mexique Bay</title>
           <description/>
         </project>
     headers:
@@ -29,16 +29,47 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '109'
+      - '110'
     body:
       encoding: UTF-8
       string: |
         <project name="openSUSE_41">
-          <title>Blue Remembered Earth</title>
+          <title>Beyond the Mexique Bay</title>
           <description></description>
         </project>
     http_version: 
-  recorded_at: Fri, 06 Jul 2018 04:03:31 GMT
+  recorded_at: Wed, 06 Feb 2019 11:21:36 GMT
+- request:
+    method: delete
+    uri: http://backend:5352/source/project_used_for_restoration
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '21'
+    body:
+      encoding: UTF-8
+      string: '<status code="ok" />
+
+'
+    http_version: 
+  recorded_at: Wed, 06 Feb 2019 11:21:36 GMT
 - request:
     method: put
     uri: http://backend:5352/source/project_used_for_restoration/_meta?user=Admin
@@ -77,7 +108,7 @@ http_interactions:
           <description></description>
         </project>
     http_version: 
-  recorded_at: Fri, 06 Jul 2018 04:03:31 GMT
+  recorded_at: Wed, 06 Feb 2019 11:21:36 GMT
 - request:
     method: put
     uri: http://backend:5352/source/project_used_for_restoration/restoration_package_0/_meta?user=Admin
@@ -116,7 +147,7 @@ http_interactions:
           <description>restoration_desc_0</description>
         </package>
     http_version: 
-  recorded_at: Fri, 06 Jul 2018 04:03:31 GMT
+  recorded_at: Wed, 06 Feb 2019 11:21:36 GMT
 - request:
     method: put
     uri: http://backend:5352/source/project_used_for_restoration/restoration_package_0/_meta?user=Admin
@@ -155,7 +186,7 @@ http_interactions:
           <description>restoration_desc_0</description>
         </package>
     http_version: 
-  recorded_at: Fri, 06 Jul 2018 04:03:31 GMT
+  recorded_at: Wed, 06 Feb 2019 11:21:36 GMT
 - request:
     method: put
     uri: http://backend:5352/source/project_used_for_restoration/restoration_package_0/_meta?user=Admin
@@ -194,7 +225,7 @@ http_interactions:
           <description>restoration_desc_0</description>
         </package>
     http_version: 
-  recorded_at: Fri, 06 Jul 2018 04:03:31 GMT
+  recorded_at: Wed, 06 Feb 2019 11:21:36 GMT
 - request:
     method: put
     uri: http://backend:5352/source/project_used_for_restoration/restoration_package_1/_meta?user=Admin
@@ -233,7 +264,7 @@ http_interactions:
           <description>restoration_desc_1</description>
         </package>
     http_version: 
-  recorded_at: Fri, 06 Jul 2018 04:03:31 GMT
+  recorded_at: Wed, 06 Feb 2019 11:21:36 GMT
 - request:
     method: put
     uri: http://backend:5352/source/project_used_for_restoration/restoration_package_1/_meta?user=Admin
@@ -272,7 +303,7 @@ http_interactions:
           <description>restoration_desc_1</description>
         </package>
     http_version: 
-  recorded_at: Fri, 06 Jul 2018 04:03:31 GMT
+  recorded_at: Wed, 06 Feb 2019 11:21:36 GMT
 - request:
     method: put
     uri: http://backend:5352/source/project_used_for_restoration/restoration_package_1/_meta?user=Admin
@@ -311,7 +342,7 @@ http_interactions:
           <description>restoration_desc_1</description>
         </package>
     http_version: 
-  recorded_at: Fri, 06 Jul 2018 04:03:31 GMT
+  recorded_at: Wed, 06 Feb 2019 11:21:36 GMT
 - request:
     method: delete
     uri: http://backend:5352/source/project_used_for_restoration?comment=&user=Admin
@@ -342,7 +373,7 @@ http_interactions:
 
 '
     http_version: 
-  recorded_at: Fri, 06 Jul 2018 04:03:31 GMT
+  recorded_at: Wed, 06 Feb 2019 11:21:37 GMT
 - request:
     method: post
     uri: http://backend:5352/source/project_used_for_restoration?cmd=undelete&user=Admin
@@ -377,7 +408,7 @@ http_interactions:
 
 '
     http_version: 
-  recorded_at: Fri, 06 Jul 2018 04:03:32 GMT
+  recorded_at: Wed, 06 Feb 2019 11:21:37 GMT
 - request:
     method: get
     uri: http://backend:5352/source/project_used_for_restoration/_meta
@@ -412,7 +443,7 @@ http_interactions:
           <description></description>
         </project>
     http_version: 
-  recorded_at: Fri, 06 Jul 2018 04:03:32 GMT
+  recorded_at: Wed, 06 Feb 2019 11:21:37 GMT
 - request:
     method: put
     uri: http://backend:5352/source/project_used_for_restoration/_meta?user=Admin
@@ -451,7 +482,7 @@ http_interactions:
           <description></description>
         </project>
     http_version: 
-  recorded_at: Fri, 06 Jul 2018 04:03:32 GMT
+  recorded_at: Wed, 06 Feb 2019 11:21:37 GMT
 - request:
     method: get
     uri: http://backend:5352/search/package?match=@project='project_used_for_restoration'
@@ -459,10 +490,8 @@ http_interactions:
       encoding: US-ASCII
       string: ''
     headers:
-      Content-Type:
-      - text/plain
       Accept-Encoding:
-      - identity
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
       - "*/*"
       User-Agent:
@@ -494,7 +523,7 @@ http_interactions:
           </package>
         </collection>
     http_version: 
-  recorded_at: Fri, 06 Jul 2018 04:03:32 GMT
+  recorded_at: Wed, 06 Feb 2019 11:21:37 GMT
 - request:
     method: get
     uri: http://backend:5352/source/project_used_for_restoration/restoration_package_0/_meta
@@ -529,7 +558,7 @@ http_interactions:
           <description>restoration_desc_0</description>
         </package>
     http_version: 
-  recorded_at: Fri, 06 Jul 2018 04:03:32 GMT
+  recorded_at: Wed, 06 Feb 2019 11:21:37 GMT
 - request:
     method: put
     uri: http://backend:5352/source/project_used_for_restoration/restoration_package_0/_meta?user=Admin
@@ -568,7 +597,7 @@ http_interactions:
           <description>restoration_desc_0</description>
         </package>
     http_version: 
-  recorded_at: Fri, 06 Jul 2018 04:03:32 GMT
+  recorded_at: Wed, 06 Feb 2019 11:21:37 GMT
 - request:
     method: put
     uri: http://backend:5352/source/project_used_for_restoration/restoration_package_0/_meta?user=Admin
@@ -607,7 +636,7 @@ http_interactions:
           <description>restoration_desc_0</description>
         </package>
     http_version: 
-  recorded_at: Fri, 06 Jul 2018 04:03:32 GMT
+  recorded_at: Wed, 06 Feb 2019 11:21:37 GMT
 - request:
     method: get
     uri: http://backend:5352/source/project_used_for_restoration/restoration_package_1/_meta
@@ -642,7 +671,7 @@ http_interactions:
           <description>restoration_desc_1</description>
         </package>
     http_version: 
-  recorded_at: Fri, 06 Jul 2018 04:03:32 GMT
+  recorded_at: Wed, 06 Feb 2019 11:21:37 GMT
 - request:
     method: put
     uri: http://backend:5352/source/project_used_for_restoration/restoration_package_1/_meta?user=Admin
@@ -681,7 +710,7 @@ http_interactions:
           <description>restoration_desc_1</description>
         </package>
     http_version: 
-  recorded_at: Fri, 06 Jul 2018 04:03:32 GMT
+  recorded_at: Wed, 06 Feb 2019 11:21:37 GMT
 - request:
     method: put
     uri: http://backend:5352/source/project_used_for_restoration/restoration_package_1/_meta?user=Admin
@@ -720,7 +749,7 @@ http_interactions:
           <description>restoration_desc_1</description>
         </package>
     http_version: 
-  recorded_at: Fri, 06 Jul 2018 04:03:32 GMT
+  recorded_at: Wed, 06 Feb 2019 11:21:37 GMT
 - request:
     method: get
     uri: http://backend:5352/source/project_used_for_restoration/_project/_history?deleted=1
@@ -754,11 +783,11 @@ http_interactions:
           <revision rev="1" vrev="">
             <srcmd5>d41d8cd98f00b204e9800998ecf8427e</srcmd5>
             <version></version>
-            <time>1530849811</time>
+            <time>1549452097</time>
             <user>Admin</user>
             <comment>project was deleted</comment>
           </revision>
         </revisionlist>
     http_version: 
-  recorded_at: Fri, 06 Jul 2018 04:03:32 GMT
+  recorded_at: Wed, 06 Feb 2019 11:21:37 GMT
 recorded_with: VCR 4.0.0

--- a/src/api/spec/cassettes/Project/_restore/with_linked_repositories/project_meta_is_properly_restored.yml
+++ b/src/api/spec/cassettes/Project/_restore/with_linked_repositories/project_meta_is_properly_restored.yml
@@ -2,12 +2,12 @@
 http_interactions:
 - request:
     method: put
-    uri: http://backend:5352/source/openSUSE_41/_meta
+    uri: http://backend:5352/source/openSUSE_41/_meta?user=_nobody_
     body:
       encoding: UTF-8
       string: |
         <project name="openSUSE_41">
-          <title>The Proper Study</title>
+          <title>In a Dry Season</title>
           <description/>
         </project>
     headers:
@@ -29,494 +29,16 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '104'
+      - '103'
     body:
       encoding: UTF-8
       string: |
         <project name="openSUSE_41">
-          <title>The Proper Study</title>
+          <title>In a Dry Season</title>
           <description></description>
         </project>
     http_version: 
-  recorded_at: Thu, 06 Jul 2017 06:48:46 GMT
-- request:
-    method: put
-    uri: http://backend:5352/source/openSUSE_41/_config
-    body:
-      encoding: UTF-8
-      string: Ut qui blanditiis. Cupiditate perspiciatis eligendi ratione qui provident
-        consequatur. Laboriosam quaerat sed vitae praesentium et dolores dignissimos.
-        Aut sapiente sed.
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '21'
-    body:
-      encoding: UTF-8
-      string: '<status code="ok" />
-
-'
-    http_version: 
-  recorded_at: Thu, 06 Jul 2017 06:48:46 GMT
-- request:
-    method: put
-    uri: http://backend:5352/source/project_used_for_restoration/_meta
-    body:
-      encoding: UTF-8
-      string: |
-        <project name="project_used_for_restoration">
-          <title>restoration_project_title</title>
-          <description/>
-        </project>
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '130'
-    body:
-      encoding: UTF-8
-      string: |
-        <project name="project_used_for_restoration">
-          <title>restoration_project_title</title>
-          <description></description>
-        </project>
-    http_version: 
-  recorded_at: Thu, 06 Jul 2017 06:48:46 GMT
-- request:
-    method: put
-    uri: http://backend:5352/source/project_used_for_restoration/_config
-    body:
-      encoding: UTF-8
-      string: Alias et impedit in sed praesentium. Nobis earum sed. Nobis officia
-        officiis est suscipit. Illum quae cum sit.
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '21'
-    body:
-      encoding: UTF-8
-      string: '<status code="ok" />
-
-'
-    http_version: 
-  recorded_at: Thu, 06 Jul 2017 06:48:46 GMT
-- request:
-    method: put
-    uri: http://backend:5352/source/project_used_for_restoration/restoration_package_0/_meta?user=Admin
-    body:
-      encoding: UTF-8
-      string: |
-        <package name="restoration_package_0" project="project_used_for_restoration">
-          <title>restoration_title_0</title>
-          <description>restoration_desc_0</description>
-        </package>
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '174'
-    body:
-      encoding: UTF-8
-      string: |
-        <package name="restoration_package_0" project="project_used_for_restoration">
-          <title>restoration_title_0</title>
-          <description>restoration_desc_0</description>
-        </package>
-    http_version: 
-  recorded_at: Thu, 06 Jul 2017 06:48:46 GMT
-- request:
-    method: put
-    uri: http://backend:5352/source/project_used_for_restoration/restoration_package_0/_meta
-    body:
-      encoding: UTF-8
-      string: |
-        <package name="restoration_package_0" project="project_used_for_restoration">
-          <title>restoration_title_0</title>
-          <description>restoration_desc_0</description>
-        </package>
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '174'
-    body:
-      encoding: UTF-8
-      string: |
-        <package name="restoration_package_0" project="project_used_for_restoration">
-          <title>restoration_title_0</title>
-          <description>restoration_desc_0</description>
-        </package>
-    http_version: 
-  recorded_at: Thu, 06 Jul 2017 06:48:46 GMT
-- request:
-    method: put
-    uri: http://backend:5352/source/project_used_for_restoration/restoration_package_0/_meta?user=Admin
-    body:
-      encoding: UTF-8
-      string: |
-        <package name="restoration_package_0" project="project_used_for_restoration">
-          <title>restoration_title_0</title>
-          <description>restoration_desc_0</description>
-        </package>
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '174'
-    body:
-      encoding: UTF-8
-      string: |
-        <package name="restoration_package_0" project="project_used_for_restoration">
-          <title>restoration_title_0</title>
-          <description>restoration_desc_0</description>
-        </package>
-    http_version: 
-  recorded_at: Thu, 06 Jul 2017 06:48:46 GMT
-- request:
-    method: put
-    uri: http://backend:5352/source/project_used_for_restoration/restoration_package_1/_meta?user=Admin
-    body:
-      encoding: UTF-8
-      string: |
-        <package name="restoration_package_1" project="project_used_for_restoration">
-          <title>restoration_title_1</title>
-          <description>restoration_desc_1</description>
-        </package>
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '174'
-    body:
-      encoding: UTF-8
-      string: |
-        <package name="restoration_package_1" project="project_used_for_restoration">
-          <title>restoration_title_1</title>
-          <description>restoration_desc_1</description>
-        </package>
-    http_version: 
-  recorded_at: Thu, 06 Jul 2017 06:48:46 GMT
-- request:
-    method: put
-    uri: http://backend:5352/source/project_used_for_restoration/restoration_package_1/_meta
-    body:
-      encoding: UTF-8
-      string: |
-        <package name="restoration_package_1" project="project_used_for_restoration">
-          <title>restoration_title_1</title>
-          <description>restoration_desc_1</description>
-        </package>
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '174'
-    body:
-      encoding: UTF-8
-      string: |
-        <package name="restoration_package_1" project="project_used_for_restoration">
-          <title>restoration_title_1</title>
-          <description>restoration_desc_1</description>
-        </package>
-    http_version: 
-  recorded_at: Thu, 06 Jul 2017 06:48:46 GMT
-- request:
-    method: put
-    uri: http://backend:5352/source/project_used_for_restoration/restoration_package_1/_meta?user=Admin
-    body:
-      encoding: UTF-8
-      string: |
-        <package name="restoration_package_1" project="project_used_for_restoration">
-          <title>restoration_title_1</title>
-          <description>restoration_desc_1</description>
-        </package>
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '174'
-    body:
-      encoding: UTF-8
-      string: |
-        <package name="restoration_package_1" project="project_used_for_restoration">
-          <title>restoration_title_1</title>
-          <description>restoration_desc_1</description>
-        </package>
-    http_version: 
-  recorded_at: Thu, 06 Jul 2017 06:48:47 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/project_used_for_restoration/_meta
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '130'
-    body:
-      encoding: UTF-8
-      string: |
-        <project name="project_used_for_restoration">
-          <title>restoration_project_title</title>
-          <description></description>
-        </project>
-    http_version: 
-  recorded_at: Thu, 06 Jul 2017 06:48:47 GMT
-- request:
-    method: delete
-    uri: http://backend:5352/source/project_used_for_restoration?comment&user=Admin
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '21'
-    body:
-      encoding: UTF-8
-      string: '<status code="ok" />
-
-'
-    http_version: 
-  recorded_at: Thu, 06 Jul 2017 06:48:47 GMT
-- request:
-    method: post
-    uri: http://backend:5352/source/project_used_for_restoration?cmd=undelete
-    body:
-      encoding: UTF-8
-      string: ''
-    headers:
-      Content-Type:
-      - application/octet-stream
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '21'
-    body:
-      encoding: UTF-8
-      string: '<status code="ok" />
-
-'
-    http_version: 
-  recorded_at: Thu, 06 Jul 2017 06:48:47 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/project_used_for_restoration/_meta
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '130'
-    body:
-      encoding: UTF-8
-      string: |
-        <project name="project_used_for_restoration">
-          <title>restoration_project_title</title>
-          <description></description>
-        </project>
-    http_version: 
-  recorded_at: Thu, 06 Jul 2017 06:48:47 GMT
+  recorded_at: Wed, 06 Feb 2019 11:21:37 GMT
 - request:
     method: put
     uri: http://backend:5352/source/project_used_for_restoration/_meta?user=Admin
@@ -555,85 +77,7 @@ http_interactions:
           <description></description>
         </project>
     http_version: 
-  recorded_at: Thu, 06 Jul 2017 06:48:47 GMT
-- request:
-    method: get
-    uri: http://backend:5352/search/package?match=@project='project_used_for_restoration'
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Content-Type:
-      - text/plain
-      Accept-Encoding:
-      - identity
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '391'
-    body:
-      encoding: UTF-8
-      string: |
-        <collection>
-          <package name="restoration_package_0" project="project_used_for_restoration">
-            <title>restoration_title_0</title>
-            <description>restoration_desc_0</description>
-          </package>
-          <package name="restoration_package_1" project="project_used_for_restoration">
-            <title>restoration_title_1</title>
-            <description>restoration_desc_1</description>
-          </package>
-        </collection>
-    http_version: 
-  recorded_at: Thu, 06 Jul 2017 06:48:47 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/project_used_for_restoration/restoration_package_0/_meta
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '174'
-    body:
-      encoding: UTF-8
-      string: |
-        <package name="restoration_package_0" project="project_used_for_restoration">
-          <title>restoration_title_0</title>
-          <description>restoration_desc_0</description>
-        </package>
-    http_version: 
-  recorded_at: Thu, 06 Jul 2017 06:48:47 GMT
+  recorded_at: Wed, 06 Feb 2019 11:21:37 GMT
 - request:
     method: put
     uri: http://backend:5352/source/project_used_for_restoration/restoration_package_0/_meta?user=Admin
@@ -672,7 +116,7 @@ http_interactions:
           <description>restoration_desc_0</description>
         </package>
     http_version: 
-  recorded_at: Thu, 06 Jul 2017 06:48:47 GMT
+  recorded_at: Wed, 06 Feb 2019 11:21:37 GMT
 - request:
     method: put
     uri: http://backend:5352/source/project_used_for_restoration/restoration_package_0/_meta?user=Admin
@@ -711,10 +155,166 @@ http_interactions:
           <description>restoration_desc_0</description>
         </package>
     http_version: 
-  recorded_at: Thu, 06 Jul 2017 06:48:47 GMT
+  recorded_at: Wed, 06 Feb 2019 11:21:37 GMT
 - request:
-    method: get
-    uri: http://backend:5352/source/project_used_for_restoration/restoration_package_1/_meta
+    method: put
+    uri: http://backend:5352/source/project_used_for_restoration/restoration_package_0/_meta?user=Admin
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="restoration_package_0" project="project_used_for_restoration">
+          <title>restoration_title_0</title>
+          <description>restoration_desc_0</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '174'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="restoration_package_0" project="project_used_for_restoration">
+          <title>restoration_title_0</title>
+          <description>restoration_desc_0</description>
+        </package>
+    http_version: 
+  recorded_at: Wed, 06 Feb 2019 11:21:37 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/project_used_for_restoration/restoration_package_1/_meta?user=Admin
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="restoration_package_1" project="project_used_for_restoration">
+          <title>restoration_title_1</title>
+          <description>restoration_desc_1</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '174'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="restoration_package_1" project="project_used_for_restoration">
+          <title>restoration_title_1</title>
+          <description>restoration_desc_1</description>
+        </package>
+    http_version: 
+  recorded_at: Wed, 06 Feb 2019 11:21:37 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/project_used_for_restoration/restoration_package_1/_meta?user=Admin
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="restoration_package_1" project="project_used_for_restoration">
+          <title>restoration_title_1</title>
+          <description>restoration_desc_1</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '174'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="restoration_package_1" project="project_used_for_restoration">
+          <title>restoration_title_1</title>
+          <description>restoration_desc_1</description>
+        </package>
+    http_version: 
+  recorded_at: Wed, 06 Feb 2019 11:21:37 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/project_used_for_restoration/restoration_package_1/_meta?user=Admin
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="restoration_package_1" project="project_used_for_restoration">
+          <title>restoration_title_1</title>
+          <description>restoration_desc_1</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '174'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="restoration_package_1" project="project_used_for_restoration">
+          <title>restoration_title_1</title>
+          <description>restoration_desc_1</description>
+        </package>
+    http_version: 
+  recorded_at: Wed, 06 Feb 2019 11:21:37 GMT
+- request:
+    method: delete
+    uri: http://backend:5352/source/project_used_for_restoration
     body:
       encoding: US-ASCII
       string: ''
@@ -730,33 +330,38 @@ http_interactions:
       code: 200
       message: OK
     headers:
-      Content-Type:
-      - text/xml
       Cache-Control:
       - no-cache
       Connection:
       - close
       Content-Length:
-      - '174'
+      - '21'
     body:
       encoding: UTF-8
-      string: |
-        <package name="restoration_package_1" project="project_used_for_restoration">
-          <title>restoration_title_1</title>
-          <description>restoration_desc_1</description>
-        </package>
+      string: '<status code="ok" />
+
+'
     http_version: 
-  recorded_at: Thu, 06 Jul 2017 06:48:47 GMT
+  recorded_at: Wed, 06 Feb 2019 11:21:37 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/project_used_for_restoration/restoration_package_1/_meta?user=Admin
+    uri: http://backend:5352/source/project_used_for_restoration/_meta?user=Admin
     body:
       encoding: UTF-8
       string: |
-        <package name="restoration_package_1" project="project_used_for_restoration">
-          <title>restoration_title_1</title>
-          <description>restoration_desc_1</description>
-        </package>
+        <project name="project_used_for_restoration">
+          <title>restoration_project_title</title>
+          <description/>
+          <repository name="Tumbleweed">
+            <arch>i586</arch>
+            <arch>x86_64</arch>
+          </repository>
+          <repository name="RepoWithLink">
+            <path project="project_used_for_restoration" repository="Tumbleweed"/>
+            <arch>i586</arch>
+            <arch>x86_64</arch>
+          </repository>
+        </project>
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -776,55 +381,25 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '174'
+      - '398'
     body:
       encoding: UTF-8
       string: |
-        <package name="restoration_package_1" project="project_used_for_restoration">
-          <title>restoration_title_1</title>
-          <description>restoration_desc_1</description>
-        </package>
+        <project name="project_used_for_restoration">
+          <title>restoration_project_title</title>
+          <description></description>
+          <repository name="Tumbleweed">
+            <arch>i586</arch>
+            <arch>x86_64</arch>
+          </repository>
+          <repository name="RepoWithLink">
+            <path project="project_used_for_restoration" repository="Tumbleweed" />
+            <arch>i586</arch>
+            <arch>x86_64</arch>
+          </repository>
+        </project>
     http_version: 
-  recorded_at: Thu, 06 Jul 2017 06:48:47 GMT
-- request:
-    method: put
-    uri: http://backend:5352/source/project_used_for_restoration/restoration_package_1/_meta?user=Admin
-    body:
-      encoding: UTF-8
-      string: |
-        <package name="restoration_package_1" project="project_used_for_restoration">
-          <title>restoration_title_1</title>
-          <description>restoration_desc_1</description>
-        </package>
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '174'
-    body:
-      encoding: UTF-8
-      string: |
-        <package name="restoration_package_1" project="project_used_for_restoration">
-          <title>restoration_title_1</title>
-          <description>restoration_desc_1</description>
-        </package>
-    http_version: 
-  recorded_at: Thu, 06 Jul 2017 06:48:47 GMT
+  recorded_at: Wed, 06 Feb 2019 11:21:37 GMT
 - request:
     method: get
     uri: http://backend:5352/source/project_used_for_restoration/_meta
@@ -850,14 +425,267 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '130'
+      - '398'
     body:
       encoding: UTF-8
       string: |
         <project name="project_used_for_restoration">
           <title>restoration_project_title</title>
           <description></description>
+          <repository name="Tumbleweed">
+            <arch>i586</arch>
+            <arch>x86_64</arch>
+          </repository>
+          <repository name="RepoWithLink">
+            <path project="project_used_for_restoration" repository="Tumbleweed" />
+            <arch>i586</arch>
+            <arch>x86_64</arch>
+          </repository>
         </project>
     http_version: 
-  recorded_at: Thu, 06 Jul 2017 06:48:47 GMT
-recorded_with: VCR 3.0.3
+  recorded_at: Wed, 06 Feb 2019 11:21:38 GMT
+- request:
+    method: delete
+    uri: http://backend:5352/source/project_used_for_restoration?comment=&user=Admin
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '21'
+    body:
+      encoding: UTF-8
+      string: '<status code="ok" />
+
+'
+    http_version: 
+  recorded_at: Wed, 06 Feb 2019 11:21:38 GMT
+- request:
+    method: post
+    uri: http://backend:5352/source/project_used_for_restoration?cmd=undelete&user=Admin
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Content-Type:
+      - application/octet-stream
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '21'
+    body:
+      encoding: UTF-8
+      string: '<status code="ok" />
+
+'
+    http_version: 
+  recorded_at: Wed, 06 Feb 2019 11:21:38 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/project_used_for_restoration/_meta
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '398'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="project_used_for_restoration">
+          <title>restoration_project_title</title>
+          <description></description>
+          <repository name="Tumbleweed">
+            <arch>i586</arch>
+            <arch>x86_64</arch>
+          </repository>
+          <repository name="RepoWithLink">
+            <path project="project_used_for_restoration" repository="Tumbleweed" />
+            <arch>i586</arch>
+            <arch>x86_64</arch>
+          </repository>
+        </project>
+    http_version: 
+  recorded_at: Wed, 06 Feb 2019 11:21:38 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/project_used_for_restoration/_meta?user=Admin
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="project_used_for_restoration">
+          <title>restoration_project_title</title>
+          <description/>
+          <repository name="Tumbleweed">
+            <arch>i586</arch>
+            <arch>x86_64</arch>
+          </repository>
+          <repository name="RepoWithLink">
+            <path project="project_used_for_restoration" repository="Tumbleweed"/>
+            <arch>i586</arch>
+            <arch>x86_64</arch>
+          </repository>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '398'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="project_used_for_restoration">
+          <title>restoration_project_title</title>
+          <description></description>
+          <repository name="Tumbleweed">
+            <arch>i586</arch>
+            <arch>x86_64</arch>
+          </repository>
+          <repository name="RepoWithLink">
+            <path project="project_used_for_restoration" repository="Tumbleweed" />
+            <arch>i586</arch>
+            <arch>x86_64</arch>
+          </repository>
+        </project>
+    http_version: 
+  recorded_at: Wed, 06 Feb 2019 11:21:38 GMT
+- request:
+    method: get
+    uri: http://backend:5352/search/package?match=@project='project_used_for_restoration'
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '27'
+    body:
+      encoding: UTF-8
+      string: |
+        <collection>
+        </collection>
+    http_version: 
+  recorded_at: Wed, 06 Feb 2019 11:21:38 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/project_used_for_restoration/_meta
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '398'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="project_used_for_restoration">
+          <title>restoration_project_title</title>
+          <description></description>
+          <repository name="Tumbleweed">
+            <arch>i586</arch>
+            <arch>x86_64</arch>
+          </repository>
+          <repository name="RepoWithLink">
+            <path project="project_used_for_restoration" repository="Tumbleweed" />
+            <arch>i586</arch>
+            <arch>x86_64</arch>
+          </repository>
+        </project>
+    http_version: 
+  recorded_at: Wed, 06 Feb 2019 11:21:38 GMT
+recorded_with: VCR 4.0.0


### PR DESCRIPTION
When we destroy a project we run the `before_action`
`cleanup_before_destroy`  from the project and also from the
repositories. Now when we destroy a project we skip the `before_action`
of the repositories.

Fix #3735