### PR TITLE
Fix build results for multiple actions requests

### DIFF
--- a/src/api/app/assets/javascripts/webui2/buildresult.js
+++ b/src/api/app/assets/javascripts/webui2/buildresult.js
@@ -2,7 +2,7 @@ function updateRpmlintResult(index) { // jshint ignore:line
   $('#rpm'+index+'-reload').addClass('fa-spin');
   $.ajax({
     url: '/package/rpmlint_result',
-    data: $('#buildresult-box').data(),
+    data: $('#buildresult' + index + '-box').data(),
     success: function(data) {
       $('#rpm' + index + ' .result').html(data);
     },
@@ -16,11 +16,11 @@ function updateRpmlintResult(index) { // jshint ignore:line
 }
 
 function updateBuildResult(index) { // jshint ignore:line
-  var ajaxDataShow = $('#buildresult-box').data();
+  var ajaxDataShow = $('#buildresult' + index + '-box').data();
   ajaxDataShow.show_all = $('#show_all_'+index).is(':checked'); // jshint ignore:line
   $('#build'+index+'-reload').addClass('fa-spin');
   $.ajax({
-    url: $('#buildresult-urls').data('buildresultUrl'),
+    url: $('#buildresult' + index + '-urls').data('buildresultUrl'),
     data: ajaxDataShow,
     success: function(data) {
       $('#build' + index + ' .result').html(data);

--- a/src/api/app/views/webui2/shared/_buildresult_box.html.haml
+++ b/src/api/app/views/webui2/shared/_buildresult_box.html.haml
@@ -7,8 +7,8 @@
   ajax_data['index'] = h(index) if defined?(index)
 
 .card
-  .bg-light#buildresult-urls{ data: { buildresult_url: defined?(package) ? package_buildresult_path : project_buildresult_path } }
-    %ul.nav.nav-tabs.pt-2.px-3.flex-nowrap#buildresult-box{ role: 'tablist', data: ajax_data }
+  .bg-light{ id: "buildresult#{index}-urls", data: { buildresult_url: defined?(package) ? package_buildresult_path : project_buildresult_path } }
+    %ul.nav.nav-tabs.pt-2.px-3.flex-nowrap{ id: "buildresult#{index}-box", role: 'tablist', data: ajax_data }
       %li.nav-item
         = link_to("#build#{index}", id: "build#{index}-tab", class: 'nav-link active text-nowrap',
           data: { toggle: 'tab' }, role: 'tab', aria: { controls: "build#{index}", selected: true }) do


### PR DESCRIPTION
Build results box for multiple actions didn't have the needed id to identify the correct subject.

Fix #6896.

Co-authored-by: David Kang <dkang@suse.com>