### PR TITLE
Hide monitor table while loading it

### DIFF
--- a/src/api/app/assets/javascripts/webui2/project_monitor.js
+++ b/src/api/app/assets/javascripts/webui2/project_monitor.js
@@ -18,6 +18,13 @@ function setupProjectMonitor() { // jshint ignore:line
     }
   });
 
+  $('#table-spinner').addClass('d-none');
+  $('#project-monitor .obs-dataTable').removeClass('invisible');
+
+  $('#filter-button').on('click', function () {
+    $('#table-spinner').removeClass('d-none');
+  });
+
   $('#project-monitor-table').on('draw.dt', function () {
     setupPopover();
   });

--- a/src/api/app/views/webui2/webui/project/_monitor_control.html.haml
+++ b/src/api/app/views/webui2/webui/project/_monitor_control.html.haml
@@ -45,8 +45,10 @@
                 = check_box_tag valid_xml_id('repo_' + repository), 1, repository_filter.include?(repository), class: 'custom-control-input'
                 %label.custom-control-label{ for: valid_xml_id('repo_' + repository) }
                   = repository
-      %button.btn.btn-primary{ type: :submit }
+      %button.btn.btn-primary#filter-button{ type: :submit }
         Apply Filter
+      %i.fas.fa-lg.fa-sync-alt.fa-spin.ml-3#table-spinner
+
       %button.btn.btn-outline-secondary.float-right{ type: :button,
       data: { toggle: 'modal', target: '#build-monitor-legend' }, title: 'Build status legend' }
         Legend

--- a/src/api/app/views/webui2/webui/project/monitor.html.haml
+++ b/src/api/app/views/webui2/webui/project/monitor.html.haml
@@ -8,7 +8,7 @@
       status: @avail_status_values, repositories: @avail_repo_values, architectures: @avail_arch_values,
       repository_filter: @repo_filter, architecture_filter: @arch_filter, status_filter: @status_filter }
     .row.mt-4
-      .col-md-12.obs-dataTable
+      .col-md-12.obs-dataTable.invisible
         %table.table.table-sm.table-striped.table-bordered.text-nowrap.w-100#project-monitor-table
           %thead.header
             %tr


### PR DESCRIPTION
To avoid the overflow until the DataTable with the scroll is loaded.

# Now:

![image](https://user-images.githubusercontent.com/16052290/52220750-e5185900-289f-11e9-8c29-ca98bc293829.png)

# Before:

![image](https://user-images.githubusercontent.com/16052290/52220787-fcefdd00-289f-11e9-9668-61fc098d24c9.png)


This is needed because loading the DataTable is slow, as it is creating two
tables and moving the content around. Another alternative could be to stop
using the scroll from DataTables and just add it to the table, but then the
package column would move as well when scrolling what makes the table unusable.
In this case, and taking into account that the page is only big (= slow) in few
cases, makes sense to prioritize ease of use over performance. The user waits a
bit, but at least he gets a nice table.

The double table that DataTable renders is also causing a bug (which disappears
when not using the scroll from DataTable). :bowtie: 



<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md
-->
