### PR TITLE
Truncate long package names

### DIFF
--- a/src/api/app/controllers/webui/package_controller.rb
+++ b/src/api/app/controllers/webui/package_controller.rb
@@ -356,7 +356,7 @@ class Webui::PackageController < Webui::WebuiController
       supersede_notice = 'Superseding failed: '
       supersede_notice += supersede_errors.join('. ')
     end
-    flash[:notice] = "Created <a href='#{request_show_path(req.number)}'>submit request #{req.number}</a>\
+    flash[:success] = "Created <a href='#{request_show_path(req.number)}'>submit request #{req.number}</a>\
                       to <a href='#{project_show_path(target_project_name)}'>#{target_project_name}</a>
                       #{supersede_notice}"
     redirect_to(action: 'show', project: project_name, package: package_name)
@@ -512,7 +512,7 @@ class Webui::PackageController < Webui::WebuiController
       @package.flags.build(flag: :publish, status: :disable)
     end
     if @package.save
-      flash[:notice] = "Package '#{@package.name}' was created successfully"
+      flash[:success] = "Package '#{@package.name}' was created successfully"
       redirect_to action: :show, project: params[:project], package: @package_name
     else
       flash[:notice] = "Failed to create package '#{@package}'"
@@ -601,7 +601,7 @@ class Webui::PackageController < Webui::WebuiController
     if request.env['HTTP_REFERER'] == image_templates_url && branched_package_object.kiwi_image?
       redirect_to(import_kiwi_image_path(branched_package_object.id))
     else
-      flash[:notice] = 'Successfully branched package'
+      flash[:success] = 'Successfully branched package'
       redirect_to(package_show_path(project: created_project_name, package: created_package_name))
     end
   rescue BranchPackage::DoubleBranchPackageError => exception
@@ -626,7 +626,7 @@ class Webui::PackageController < Webui::WebuiController
     @package.title = params[:title]
     @package.description = params[:description]
     if @package.save
-      flash[:notice] = "Package data for '#{@package.name}' was saved successfully"
+      flash[:success] = "Package data for '#{@package.name}' was saved successfully"
       redirect_to action: :show, project: params[:project], package: params[:package]
     else
       flash[:error] = "Failed to save package '#{@package.name}': #{@package.errors.full_messages.to_sentence}"
@@ -646,7 +646,7 @@ class Webui::PackageController < Webui::WebuiController
     @package.check_weak_dependencies? unless params[:force]
     if @package.errors.empty?
       @package.destroy
-      redirect_to(project_show_path(@project), notice: 'Package was successfully removed.')
+      redirect_to(project_show_path(@project), success: 'Package was successfully removed.')
     else
       redirect_to(package_show_path(project: @project, package: @package),
                   notice: "Package can't be removed: #{@package.errors.full_messages.to_sentence}")
@@ -658,7 +658,7 @@ class Webui::PackageController < Webui::WebuiController
 
     begin
       Backend::Api::Sources::Package.trigger_services(@project.name, @package.name, User.current.to_s)
-      flash[:notice] = 'Services successfully triggered'
+      flash[:success] = 'Services successfully triggered'
     rescue Timeout::Error => e
       flash[:error] = "Services couldn't be triggered: " + e.message
     rescue Backend::Error => e
@@ -741,7 +741,7 @@ class Webui::PackageController < Webui::WebuiController
     filename = params[:filename]
     begin
       @package.delete_file(filename)
-      flash[:notice] = "File '#{filename}' removed successfully"
+      flash[:success] = "File '#{filename}' removed successfully"
     rescue Backend::NotFoundError
       flash[:notice] = "Failed to remove file '#{filename}'"
     end
@@ -903,7 +903,7 @@ class Webui::PackageController < Webui::WebuiController
     authorize @package, :update?
 
     if @package.abort_build(params)
-      flash[:notice] = "Triggered abort build for #{@project.name}/#{@package.name} successfully."
+      flash[:success] = "Triggered abort build for #{@project.name}/#{@package.name} successfully."
       redirect_to package_show_path(project: @project, package: @package)
     else
       flash[:error] = "Error while triggering abort build for #{@project.name}/#{@package.name}: #{@package.errors.full_messages.to_sentence}."
@@ -915,7 +915,7 @@ class Webui::PackageController < Webui::WebuiController
     authorize @package, :update?
 
     if @package.rebuild(params)
-      flash[:notice] = "Triggered rebuild for #{@project.name}/#{@package.name} successfully."
+      flash[:success] = "Triggered rebuild for #{@project.name}/#{@package.name} successfully."
       redirect_to package_show_path(project: @project, package: @package)
     else
       flash[:error] = "Error while triggering rebuild for #{@project.name}/#{@package.name}: #{@package.errors.full_messages.to_sentence}."
@@ -927,7 +927,7 @@ class Webui::PackageController < Webui::WebuiController
     authorize @package, :update?
 
     if @package.wipe_binaries(params)
-      flash[:notice] = "Triggered wipe binaries for #{@project.name}/#{@package.name} successfully."
+      flash[:success] = "Triggered wipe binaries for #{@project.name}/#{@package.name} successfully."
     else
       flash[:error] = "Error while triggering wipe binaries for #{@project.name}/#{@package.name}: #{@package.errors.full_messages.to_sentence}."
     end

--- a/src/api/app/controllers/webui/patchinfo_controller.rb
+++ b/src/api/app/controllers/webui/patchinfo_controller.rb
@@ -121,7 +121,7 @@ class Webui::PatchinfoController < Webui::WebuiController
 
         @package.sources_changed(wait_for_update: true) # wait for indexing for special files
 
-        flash[:notice] = "Successfully edited #{@package}"
+        flash[:success] = "Successfully edited #{@package}"
       rescue Timeout::Error
         flash[:error] = 'Timeout when saving file. Please try again.'
       end
@@ -164,7 +164,7 @@ class Webui::PatchinfoController < Webui::WebuiController
     authorize @package, :destroy?
 
     if @package.check_weak_dependencies? && @package.destroy
-      redirect_to(project_show_path(@project), notice: 'Patchinfo was successfully removed.')
+      redirect_to(project_show_path(@project), success: 'Patchinfo was successfully removed.')
     else
       redirect_to(patchinfo_show_path(package: @package, project: @project),
                   notice: "Patchinfo can't be removed: #{@package.errors.full_messages.to_sentence}")

--- a/src/api/app/views/layouts/webui2/webui.html.haml
+++ b/src/api/app/views/layouts/webui2/webui.html.haml
@@ -38,7 +38,7 @@
         .col-auto.ml-auto#personal-navigation
           = render partial: "layouts/webui2/personal_navigation"
 
-    .container.sticky-top.flash-and-announcement
+    .container.sticky-top.flash-and-announcement.text-word-break-all
       - unless @hide_announcement_notification
         #announcement= render partial: 'layouts/webui2/announcement'
       #flash= render partial: "layouts/webui2/flash", object: flash

--- a/src/api/app/views/webui2/webui/package/_breadcrumb_items.html.haml
+++ b/src/api/app/views/webui2/webui/package/_breadcrumb_items.html.haml
@@ -1,6 +1,6 @@
 = render partial: 'webui/project/breadcrumb_items'
-%li.breadcrumb-item
-  = link_to @package, package_show_path(@project, @package)
+%li.breadcrumb-item.text-word-break-all
+  = link_to truncate(@package.name, length: 50), package_show_path(@project, @package)
 - if current_page?(package_add_file_path)
   %li.breadcrumb-item.active{ 'aria-current' => 'page' }
     Add File
@@ -31,5 +31,5 @@
   %li.breadcrumb-item.active{ 'aria-current' => 'page' }
     Statistics
 - if current_page?(package_view_file_path)
-  %li.breadcrumb-item.active{ 'aria-current' => 'page' }
-    = @filename
+  %li.breadcrumb-item.active.text-word-break-all{ 'aria-current' => 'page' }
+    = truncate(@filename, length: 50)

--- a/src/api/app/views/webui2/webui/package/add_file.html.haml
+++ b/src/api/app/views/webui2/webui/package/add_file.html.haml
@@ -1,10 +1,10 @@
-- @pagetitle = "Upload file to #{@project.name}/#{@package.name}"
+- @pagetitle = "Upload file to #{truncate(@package.name, length: 50)}/#{truncate(@package.name, length: 50)}"
 
 .card
   = render partial: 'tabs', locals: { project: @project, package: @package }
   .card-body
     %h3
-      = @pagetitle
+      Upload file to #{@project.name}/#{@package.name}
     = form_tag({ action: :save_file, project: @project, package: @package }, multipart: true) do
       .form-group.package-add-file
         %label{ for: :filename }

--- a/src/api/app/views/webui2/webui/package/show.html.haml
+++ b/src/api/app/views/webui2/webui/package/show.html.haml
@@ -1,5 +1,5 @@
 :ruby
-  @pagetitle = "Show #{@project} / #{@package}"
+  @pagetitle = "Show #{@project} / #{truncate(@package.name, length: 50)}"
   devel_package = @package.develpackage
 
 .card.mb-3
@@ -69,7 +69,7 @@
                                                   spider_bot: @spider_bot }
   .comments
     .card
-      %h5.card-header
+      %h5.card-header.text-word-break-all
         Comments for
         = @package.name
         %span.badge.badge-primary{ id: "comment-counter-package-#{@package.id}" }

--- a/src/api/app/views/webui2/webui/package/view_file.html.haml
+++ b/src/api/app/views/webui2/webui/package/view_file.html.haml
@@ -1,11 +1,11 @@
-- @pagetitle = "File #{@filename} of Package #{@package}"
+- @pagetitle = "File #{truncate(@filename, length: 50)} of Package #{truncate(@package.name, length: 50)}"
 - content_for(:content_for_head, javascript_include_tag('webui2/cm2/default'))
 
 .card.mb-3
   = render partial: 'tabs', locals: { project: @project, package: @package }
   .card-body
-    %h3
-      = @pagetitle
+    %h3.text-word-break-all
+      File #{@filename} of Package #{@package}
       - if @rev
         (Revision #{@rev})
     - if @rev

--- a/src/api/app/views/webui2/webui/project/show.html.haml
+++ b/src/api/app/views/webui2/webui/project/show.html.haml
@@ -59,7 +59,7 @@
           = render partial: 'project_inherited_packages', locals: { project: @project, inherited_packages: @ipackages }
   .comments
     .card
-      %h5.card-header
+      %h5.card-header.text-word-break-all
         Comments for #{@project}
         %span.badge.badge-primary{ id: "comment-counter-project-#{@project.id}" }
           = @comments.length

--- a/src/api/spec/controllers/webui/package_controller_spec.rb
+++ b/src/api/spec/controllers/webui/package_controller_spec.rb
@@ -47,7 +47,7 @@ RSpec.describe Webui::PackageController, vcr: true do
     let(:target_package) { package.name }
 
     RSpec.shared_examples 'a response of a successful submit request' do
-      it { expect(flash[:notice]).to match("Created .+submit request \\d.+to .+#{target_project}") }
+      it { expect(flash[:success]).to match("Created .+submit request \\d.+to .+#{target_project}") }
       it { expect(response).to redirect_to(package_show_path(project: source_project, package: package)) }
       it { expect(BsRequestActionSubmit.where(target_project: target_project.name, target_package: target_package)).to exist }
     end
@@ -92,7 +92,7 @@ RSpec.describe Webui::PackageController, vcr: true do
         post :submit_request, params: { project: source_project, package: package, targetproject: target_project, supersede_request_numbers: [42] }
       end
 
-      it { expect(flash[:notice]).to match(" Superseding failed: Couldn't find request with id '42'") }
+      it { expect(flash[:success]).to match(" Superseding failed: Couldn't find request with id '42'") }
       it_should_behave_like 'a response of a successful submit request'
     end
 
@@ -195,7 +195,7 @@ RSpec.describe Webui::PackageController, vcr: true do
         }
       end
 
-      it { expect(flash[:notice]).to eq("Package data for '#{source_package.name}' was saved successfully") }
+      it { expect(flash[:success]).to eq("Package data for '#{source_package.name}' was saved successfully") }
       it { expect(source_package.reload.title).to eq('New title for package') }
       it { expect(source_package.reload.description).to eq('New description for package') }
       it { expect(response).to redirect_to(package_show_path(project: source_project, package: source_package)) }
@@ -271,7 +271,7 @@ RSpec.describe Webui::PackageController, vcr: true do
         post :branch, params: { linked_project: source_project, linked_package: source_package, target_package: 'new_package_name' }
       end
 
-      it { expect(flash[:notice]).to eq('Successfully branched package') }
+      it { expect(flash[:success]).to eq('Successfully branched package') }
       it 'redirects to the branched package' do
         expect(response).to redirect_to(package_show_path(project: "#{source_project.name}:branches:#{source_project.name}",
                                                           package: 'new_package_name'))
@@ -295,7 +295,7 @@ RSpec.describe Webui::PackageController, vcr: true do
         post :branch, params: { linked_project: source_project, linked_package: source_package, current_revision: true, revision: 2 }
       end
 
-      it { expect(flash[:notice]).to eq('Successfully branched package') }
+      it { expect(flash[:success]).to eq('Successfully branched package') }
       it 'redirects to the branched package' do
         expect(response).to redirect_to(package_show_path(project: "#{source_project.name}:branches:#{source_project.name}",
                                                           package: source_package.name))
@@ -323,7 +323,7 @@ RSpec.describe Webui::PackageController, vcr: true do
         login(admin)
         post :remove, params: { project: target_project, package: target_package }
 
-        expect(flash[:notice]).to eq('Package was successfully removed.')
+        expect(flash[:success]).to eq('Package was successfully removed.')
         expect(target_project.packages).to be_empty
       end
     end
@@ -334,7 +334,7 @@ RSpec.describe Webui::PackageController, vcr: true do
       end
 
       it { expect(response).to have_http_status(:found) }
-      it { expect(flash[:notice]).to eq('Package was successfully removed.') }
+      it { expect(flash[:success]).to eq('Package was successfully removed.') }
       it 'deletes the package' do
         expect(user.home_project.packages).to be_empty
       end
@@ -360,7 +360,7 @@ RSpec.describe Webui::PackageController, vcr: true do
         end
 
         it 'deletes the package' do
-          expect(flash[:notice]).to eq('Package was successfully removed.')
+          expect(flash[:success]).to eq('Package was successfully removed.')
           expect(user.home_project.packages).to be_empty
         end
       end
@@ -643,7 +643,7 @@ RSpec.describe Webui::PackageController, vcr: true do
         remove_file_post
       end
 
-      it { expect(flash[:notice]).to eq("File 'the_file' removed successfully") }
+      it { expect(flash[:success]).to eq("File 'the_file' removed successfully") }
       it { expect(assigns(:package)).to eq(source_package) }
       it { expect(assigns(:project)).to eq(user.home_project) }
       it { expect(response).to redirect_to(package_show_path(project: user.home_project, package: source_package)) }
@@ -797,7 +797,7 @@ RSpec.describe Webui::PackageController, vcr: true do
       end
 
       it { expect(a_request(:post, post_url)).to have_been_made.once }
-      it { expect(flash[:notice]).to eq('Services successfully triggered') }
+      it { expect(flash[:success]).to eq('Services successfully triggered') }
       it { is_expected.to redirect_to(action: :show, project: source_project, package: service_package) }
     end
 
@@ -1267,7 +1267,7 @@ RSpec.describe Webui::PackageController, vcr: true do
         post :trigger_rebuild, params: { project: source_project, package: source_package }
       end
 
-      it { expect(flash[:notice]).to eq("Triggered rebuild for #{source_project.name}/#{source_package.name} successfully.") }
+      it { expect(flash[:success]).to eq("Triggered rebuild for #{source_project.name}/#{source_package.name} successfully.") }
       it { expect(response).to redirect_to(package_show_path(project: source_project, package: source_package)) }
     end
   end
@@ -1301,7 +1301,7 @@ RSpec.describe Webui::PackageController, vcr: true do
         post :wipe_binaries, params: { project: source_project, package: source_package, repository: repository.name }
       end
 
-      it { expect(flash[:notice]).to eq("Triggered wipe binaries for #{source_project.name}/#{source_package.name} successfully.") }
+      it { expect(flash[:success]).to eq("Triggered wipe binaries for #{source_project.name}/#{source_package.name} successfully.") }
       it { expect(response).to redirect_to(package_binaries_path(project: source_project, package: source_package, repository: repository.name)) }
     end
   end
@@ -1335,7 +1335,7 @@ RSpec.describe Webui::PackageController, vcr: true do
         post :abort_build, params: { project: source_project, package: source_package }
       end
 
-      it { expect(flash[:notice]).to eq("Triggered abort build for #{source_project.name}/#{source_package.name} successfully.") }
+      it { expect(flash[:success]).to eq("Triggered abort build for #{source_project.name}/#{source_package.name} successfully.") }
       it { expect(response).to redirect_to(package_show_path(project: source_project, package: source_package)) }
     end
   end
@@ -1669,7 +1669,7 @@ RSpec.describe Webui::PackageController, vcr: true do
 
       context 'valid package name' do
         it { expect(response).to redirect_to(package_show_path(source_project, package_name)) }
-        it { expect(flash[:notice]).to eq("Package 'new-package' was created successfully") }
+        it { expect(flash[:success]).to eq("Package 'new-package' was created successfully") }
         it { expect(Package.find_by(name: package_name).flags).to be_empty }
       end
 

--- a/src/api/spec/controllers/webui/patchinfo_controller_spec.rb
+++ b/src/api/spec/controllers/webui/patchinfo_controller_spec.rb
@@ -225,7 +225,7 @@ RSpec.describe Webui::PatchinfoController, vcr: true do
 
       it { expect(@patchinfo['summary']).to eq('long enough summary is ok') }
       it { expect(@patchinfo['description']).to eq('long enough description is also ok' * 5) }
-      it { expect(flash[:notice]).to eq("Successfully edited #{patchinfo_package.name}") }
+      it { expect(flash[:success]).to eq("Successfully edited #{patchinfo_package.name}") }
       it { expect(response).to redirect_to(action: 'show', project: user.home_project_name, package: patchinfo_package.name) }
     end
 
@@ -263,7 +263,7 @@ RSpec.describe Webui::PatchinfoController, vcr: true do
         post :remove, params: { project: user.home_project_name, package: patchinfo_package.name }
       end
 
-      it { expect(flash[:notice]).to eq('Patchinfo was successfully removed.') }
+      it { expect(flash[:success]).to eq('Patchinfo was successfully removed.') }
       it { expect(response).to redirect_to(project_show_path(user.home_project)) }
     end
 


### PR DESCRIPTION
Shorten long package names.

Fixes #6436

Before:
![screenshot_2019-03-06 show home admin aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa](https://user-images.githubusercontent.com/968949/53868591-ad174980-3ff6-11e9-99f4-49466660a1f6.png)


After
![screenshot_2019-03-06 file bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb of package aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa](https://user-images.githubusercontent.com/968949/53868430-56aa0b00-3ff6-11e9-82f7-9a4928df323a.png)
![screenshot_2019-03-06 show home admin aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa - open build service](https://user-images.githubusercontent.com/968949/53868442-5c075580-3ff6-11e9-8f69-36c3ef0065a9.png)
![screenshot_2019-03-06 show home admin aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa - open build service 1](https://user-images.githubusercontent.com/968949/53868452-5f9adc80-3ff6-11e9-8159-8be5ba888407.png)
![screenshot_2019-03-06 upload file to aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa](https://user-images.githubusercontent.com/968949/53868459-63c6fa00-3ff6-11e9-9274-087417c29008.png)

