### PR TITLE
Bootstrap/request history migration02

### DIFF
--- a/src/api/app/assets/javascripts/webui2/request.js
+++ b/src/api/app/assets/javascripts/webui2/request.js
@@ -122,21 +122,6 @@ function requestAddReviewAutocomplete() { // jshint ignore:line
   });
 }
 
-function setupActionLink() { // jshint ignore:line
-  var index;
-  $('.action_select_link').click(function (event) {
-    $('#action_select li.selected').attr('class', '');
-    $(event.target).parent().attr('class', 'selected');
-    $('.action_display').hide();
-    index = event.target.id.split('action_select_link_')[1];
-    $('#action_display_' + index).show();
-    // It is necessary to refresh the CodeMirror editors after switching tabs to initialise the dimensions again.
-    // Otherwise the editors are empty after calling show().
-    editors.forEach( function(editor) { editor.refresh(); });
-    return false;
-  });
-}
-
 function collapseHistory(parent) { //jshint ignore:line
   var fullReqDescription = parent.find('#show-full-req-description');
   parent.find('#req-description').toggleClass('collapsed-history uncollapsed-history');

--- a/src/api/app/assets/javascripts/webui2/request.js
+++ b/src/api/app/assets/javascripts/webui2/request.js
@@ -121,3 +121,33 @@ function requestAddReviewAutocomplete() { // jshint ignore:line
     max: 50
   });
 }
+
+function setupActionLink() { // jshint ignore:line
+  var index;
+  $('.action_select_link').click(function (event) {
+    $('#action_select li.selected').attr('class', '');
+    $(event.target).parent().attr('class', 'selected');
+    $('.action_display').hide();
+    index = event.target.id.split('action_select_link_')[1];
+    $('#action_display_' + index).show();
+    // It is necessary to refresh the CodeMirror editors after switching tabs to initialise the dimensions again.
+    // Otherwise the editors are empty after calling show().
+    editors.forEach( function(editor) { editor.refresh(); });
+    return false;
+  });
+}
+
+function collapseHistory(parent) { //jshint ignore:line
+  var fullReqDescription = parent.find('#show-full-req-description');
+  parent.find('#req-description').toggleClass('collapsed-history uncollapsed-history');
+  fullReqDescription.toggleClass("collapsed-link uncollapsed-link");
+
+  var showText = (fullReqDescription.attr('title') === 'show more' ) ?  'show less': 'show more';
+  fullReqDescription.attr('title', showText);
+}
+
+function handleCollapseForHistory(origin) {  //jshint ignore:line
+  $('.req-description-box').on('click', origin, function() {
+    collapseHistory($(this).parents('.req-description-box'));
+  });
+}

--- a/src/api/app/assets/stylesheets/webui2/collapse-text.scss
+++ b/src/api/app/assets/stylesheets/webui2/collapse-text.scss
@@ -1,0 +1,37 @@
+/*
+Copyright (c) 2019 by Natalia (https://codepen.io/natonischuk/pen/QbGWBa)
+Fork of an original work by Natalia (https://codepen.io/natonischuk/pen/mJOdmJ)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in the
+Software without restriction, including without limitation the rights to use, copy,
+modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+and to permit persons to whom the Software is furnished to do so, subject to the
+following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies
+or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR
+PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE
+FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+@mixin collapsedText($lineHeight: 1.2em, $lineCount: 1) {
+  overflow: hidden;
+  position: relative;
+  line-height: $lineHeight;
+  max-height: $lineHeight * $lineCount;
+  text-align: justify;
+  margin-right: -1em;
+  padding-right: 1em;
+  &:before {
+    content: ' ...';
+    position: absolute;
+    right: 0;
+    bottom: 0;
+  }
+}

--- a/src/api/app/assets/stylesheets/webui2/requests.scss
+++ b/src/api/app/assets/stylesheets/webui2/requests.scss
@@ -13,3 +13,27 @@
   background-color: $cyan;
 }
 
+.req-description-box {
+  word-break: break-all;
+  white-space: pre-line;
+  font-size: 14px;
+  padding-right: 1em;
+}
+
+.collapsed-history {
+  @include collapsedText($lineHeight: 1.2em, $lineCount: 3);
+}
+
+.uncollapsed-history {
+  @include uncollapsedText($lineHeight: 1.2em);
+}
+
+.collapsed-link:after {
+  @extend .fa;
+  content: '\f078';
+}
+
+.uncollapsed-link:after {
+  @extend .fa;
+  content: '\f077';
+}

--- a/src/api/app/assets/stylesheets/webui2/texts.scss
+++ b/src/api/app/assets/stylesheets/webui2/texts.scss
@@ -27,3 +27,7 @@
 .ml-0_6 {
   margin-left: 0.6rem !important;
 }
+
+@mixin uncollapsedText($lineHeight: 1.2em) {
+  line-height: $lineHeight;
+}

--- a/src/api/app/assets/stylesheets/webui2/webui2.css.scss
+++ b/src/api/app/assets/stylesheets/webui2/webui2.css.scss
@@ -46,6 +46,7 @@
 @import 'user';
 @import 'watchlist';
 @import 'pulse';
+@import 'collapse-text';
 @import 'requests';
 
 html {

--- a/src/api/app/helpers/webui/webui_helper.rb
+++ b/src/api/app/helpers/webui/webui_helper.rb
@@ -405,10 +405,10 @@ module Webui::WebuiHelper
     link_to(label, path, class: html_class)
   end
 
-  def image_tag_for(object, size: 500)
+  def image_tag_for(object, size: 500, custom_class: 'img-fluid')
     return unless object
     alt = "#{object.name}'s avatar"
-    image_tag(gravatar_icon(object.email, size), alt: alt, title: object.name, size: size, class: 'img-fluid')
+    image_tag(gravatar_icon(object.email, size), alt: alt, size: size, title: object.name, class: custom_class)
   end
 
   def gravatar_icon(email, size)

--- a/src/api/app/views/webui2/webui/request/_request_history.html.haml
+++ b/src/api/app/views/webui2/webui/request/_request_history.html.haml
@@ -1,0 +1,16 @@
+.media
+  - user = User.find_by_login(bs_request.creator)
+  = image_tag_for(user, size: 32, custom_class: 'mr-3')
+  .media-body
+    %h6.mt-0.mb-1
+      #{bs_request.creator} (#{fuzzy_time(bs_request.created_at)})
+
+    %p.m-0.p-0.small created request
+
+    = render partial: 'request_history_description', locals: { text: bs_request.description }
+
+= render partial: 'request_history_element', collection: history, as: :element
+
+= content_for :ready_function do
+  handleCollapseForHistory('#req-description');
+  handleCollapseForHistory('#show-full-req-description');

--- a/src/api/app/views/webui2/webui/request/_request_history_description.html.haml
+++ b/src/api/app/views/webui2/webui/request/_request_history_description.html.haml
@@ -1,0 +1,8 @@
+- if text.present?
+  .req-description-box
+    - if text.length > 100
+      .collapsed-history#req-description
+        = simple_format(text, class: 'm-0 p-0 small')
+      %a.collapsed-link.text-center.d-block#show-full-req-description{ title: 'show more' }
+    - else
+      = simple_format(text, class: 'm-0 p-0 small')

--- a/src/api/app/views/webui2/webui/request/_request_history_element.html.haml
+++ b/src/api/app/views/webui2/webui/request/_request_history_element.html.haml
@@ -1,0 +1,11 @@
+.media.mt-2
+  = image_tag_for(element.user, size: 32, custom_class: 'mr-3')
+  .media-body
+    %h6.mt-0.mb-1
+      #{element.user.login} (#{fuzzy_time(element.created_at)})
+
+    - if element.class == HistoryElement::RequestSuperseded
+      = link_to(element.description, request_show_path(element.description_extension))
+    - else
+      = simple_format(element.description, class: 'm-0 p-0 small')
+    = render partial: 'request_history_description', locals: { text: element.comment }

--- a/src/api/app/views/webui2/webui/request/show.html.haml
+++ b/src/api/app/views/webui2/webui/request/show.html.haml
@@ -40,40 +40,42 @@
           Comments for request #{@number} (#{@comments.size})
       .card-body#comments
         = render partial: 'webui2/webui/comment/show', locals: { commentable: @bs_request }
+    .card.mb-3
+      .bg-light
+        %ul.nav.nav-tabs{ role: 'tablist' }
+          %li.nav-item
+            %a.nav-link.text-nowrap.active{ href: '#decision', data: { toggle: 'tab' }, role: 'tab' }
+              My decision
+          - @my_open_reviews.each_with_index do |review, index|
+            %li.nav-item
+              %a.nav-link.text-nowrap{ href: "#review-#{index}", data: { toggle: 'tab' }, role: 'tab' }
+                Review for #{review[:who]}
+      .card-body
+        - if @can_handle_request && @show_project_maintainer_hint
+          .alert.alert-warning
+            You are a <strong>project maintainer</strong> but not a <strong>package maintainer</strong>. This package
+            has <strong>#{pluralize(@package_maintainers.size, 'package maintainer')}</strong> assigned. Please keep
+            in mind that also package maintainers would like to review this request.
+        .tab-content
+          .tab-pane.fade.show.active{ id: 'decision' }
+            - if @can_handle_request
+              = render('decision_tab', request_number: @number, request_creator: @req['creator'],
+                       is_target_maintainer: @is_target_maintainer, state: @state,
+                       is_author: @is_author, single_action_request: @actions.count == 1, action: @actions.first)
+            - else
+              %p
+                There's nothing to be done right now
+          - @my_open_reviews.each_with_index do |review, index|
+            .tab-pane.fade.show{ id: "review-#{index}" }
+              = render('review_tab', review: review, request_number: @number)
+
   .col-md-4
     .card
       .card-header.d-flex.justify-content-between
         %h5
           Request History
       .card-body
-        -# History content
-.card
-  .bg-light
-    %ul.nav.nav-tabs{ role: 'tablist' }
-      %li.nav-item
-        %a.nav-link.text-nowrap.active{ href: '#decision', data: { toggle: 'tab' }, role: 'tab' }
-          My decision
-      - @my_open_reviews.each_with_index do |review, index|
-        %li.nav-item
-          %a.nav-link.text-nowrap{ href: "#review-#{index}", data: { toggle: 'tab' }, role: 'tab' }
-            Review for #{review[:who]}
-  .card-body
-    - if @can_handle_request && @show_project_maintainer_hint
-      .alert.alert-warning
-        You are a <strong>project maintainer</strong> but not a <strong>package maintainer</strong>. This package
-        has <strong>#{pluralize(@package_maintainers.size, 'package maintainer')}</strong> assigned. Please keep
-        in mind that also package maintainers would like to review this request.
-    .tab-content
-      .tab-pane.fade.show.active{ id: 'decision' }
-        - if @can_handle_request
-          = render('decision_tab', request_number: @number, request_creator: @req['creator'], is_target_maintainer: @is_target_maintainer,
-            state: @state, is_author: @is_author, single_action_request: @actions.count == 1, action: @actions.first)
-        - else
-          %p
-            There's nothing to be done right now
-      - @my_open_reviews.each_with_index do |review, index|
-        .tab-pane.fade.show{ id: "review-#{index}" }
-          = render('review_tab', review: review, request_number: @number)
+        = render partial: 'request_history', locals: { bs_request: @bs_request, history: @history }
 
 - unless User.current.is_nobody?
   = render partial: 'webui2/webui/request/add_reviewer_dialog'


### PR DESCRIPTION
Working on the request history, moving it to bootstrap and implementing a generic way to collapse and 
collapse text. It supersedes #6893  

![collapsed](https://user-images.githubusercontent.com/37418/52407251-02336e80-2ad0-11e9-9e48-fb33709058db.png)

![uncollapsed](https://user-images.githubusercontent.com/37418/52407257-06f82280-2ad0-11e9-91b3-e2b1cad9b3e8.png)
