### PR TITLE
Collapse/Expand the build results

### DIFF
--- a/src/api/app/assets/javascripts/webui2/buildresult.js
+++ b/src/api/app/assets/javascripts/webui2/buildresult.js
@@ -18,6 +18,7 @@ function updateRpmlintResult(index) { // jshint ignore:line
 function updateBuildResult(index) { // jshint ignore:line
   var ajaxDataShow = $('#buildresult' + index + '-box').data();
   ajaxDataShow.show_all = $('#show_all_'+index).is(':checked'); // jshint ignore:line
+  ajaxDataShow.collapsedRepositories = $('.result div.collapse:not(.show)').map(function(_index, domElement) { return $(domElement).data('repository'); }).get();
   $('#build'+index+'-reload').addClass('fa-spin');
   $.ajax({
     url: $('#buildresult' + index + '-urls').data('buildresultUrl'),

--- a/src/api/app/assets/javascripts/webui2/buildresult.js
+++ b/src/api/app/assets/javascripts/webui2/buildresult.js
@@ -36,6 +36,15 @@ function updateBuildResult(index) { // jshint ignore:line
   });
 }
 
+function subscribeAjaxEvents(index) {
+  // TODO: Handle 'ajax:error'
+  $('#show_all_' + index).on('ajax:success', function(_event, data, _status, _xhr) {
+    $('#build' + index + ' .result').html(data);
+    // Since the element on which we bind the 'ajax:success' is rendered again on the line just above, it needs to be bound again...
+    subscribeAjaxEvents(index);
+  });
+}
+
 function updateArchDisplay(index) { // jshint ignore:line
   $('.rpmlint_arch_select_' + index).hide();
   $('#rpmlint_arch_select_' + index + '_' + $('#rpmlint_repo_select_' + index + ' option:selected').attr('value')).show();

--- a/src/api/app/assets/javascripts/webui2/buildresult.js
+++ b/src/api/app/assets/javascripts/webui2/buildresult.js
@@ -36,11 +36,35 @@ function updateBuildResult(index) { // jshint ignore:line
   });
 }
 
+// TODO: Handle 'ajax:error', 'ajax:complete' and DRY binding code
 function subscribeAjaxEvents(index) {
-  // TODO: Handle 'ajax:error'
   $('#show_all_' + index).on('ajax:success', function(_event, data, _status, _xhr) {
     $('#build' + index + ' .result').html(data);
-    // Since the element on which we bind the 'ajax:success' is rendered again on the line just above, it needs to be bound again...
+    // Since the element on which we bind this event is rendered again on the line just above, it needs to be bound again...
+    subscribeAjaxEvents(index);
+  });
+
+  $('button.build-refresh').on('ajax:before', function(_event) {
+    var button = $(this);
+    var buttonParams = button.data('params');
+    console.log(buttonParams);
+    // var serializedCollapsedRepositories = $('.result div.collapse:not(.show)').map(function(_index, domElement) { return $.param((({ repository }) => ({ repository }))($(domElement).data())); }).get().join('&');
+    // button.data('params', buttonParams + '&' + serializedCollapsedRepositories);
+    console.log(button.data);
+  });
+
+  // $('button.build-refresh').on('ajax:beforeSend', function(_event, _xhr, settings) {
+  //   var button = $(this);
+  //   console.log(_event);
+  //   console.log(_xhr);
+  //   console.log(settings);
+  //   button.data('collapsedRepositories', $('.result div.collapse:not(.show)').map(function(_index, domElement) { return $(domElement).data('repository'); }).get());
+  //   console.log(button.data());
+  // });
+
+  $('button.build-refresh').on('ajax:success', function(_event, data, _status, _xhr) {
+    $('#build' + index + ' .result').html(data);
+    // Since the element on which we bind this event is rendered again on the line just above, it needs to be bound again...
     subscribeAjaxEvents(index);
   });
 }

--- a/src/api/app/controllers/webui/package_controller.rb
+++ b/src/api/app/controllers/webui/package_controller.rb
@@ -946,6 +946,7 @@ class Webui::PackageController < Webui::WebuiController
   end
 
   def buildresult
+    # TODO: Check if webui is still working
     if @project.repositories.any?
       @index = params[:index]
       show_all = params["show_all_#{@index}"] == 'true'

--- a/src/api/app/controllers/webui/package_controller.rb
+++ b/src/api/app/controllers/webui/package_controller.rb
@@ -947,13 +947,14 @@ class Webui::PackageController < Webui::WebuiController
 
   def buildresult
     if @project.repositories.any?
-      show_all = params[:show_all] == 'true'
       @index = params[:index]
+      show_all = params["show_all_#{@index}"] == 'true'
       @buildresults = @package.buildresult(@project, show_all)
       switch_to_webui2 if params[:switch].present?
       render partial: 'buildstatus', locals: { buildresults: @buildresults,
                                                index: @index,
                                                project: @project,
+                                               package: @package,
                                                collapsed_repositories: params.fetch(:collapsedRepositories, []) }
     else
       switch_to_webui2 if params[:switch].present?

--- a/src/api/app/controllers/webui/package_controller.rb
+++ b/src/api/app/controllers/webui/package_controller.rb
@@ -951,7 +951,10 @@ class Webui::PackageController < Webui::WebuiController
       @index = params[:index]
       @buildresults = @package.buildresult(@project, show_all)
       switch_to_webui2 if params[:switch].present?
-      render partial: 'buildstatus', locals: { buildresults: @buildresults, index: @index, project: @project }
+      render partial: 'buildstatus', locals: { buildresults: @buildresults,
+                                               index: @index,
+                                               project: @project,
+                                               collapsed_repositories: params.fetch(:collapsedRepositories, []) }
     else
       switch_to_webui2 if params[:switch].present?
       render partial: 'no_repositories', locals: { project: @project }

--- a/src/api/app/controllers/webui/project_controller.rb
+++ b/src/api/app/controllers/webui/project_controller.rb
@@ -218,7 +218,9 @@ class Webui::ProjectController < Webui::WebuiController
   def buildresult
     switch_to_webui2 if params[:switch].present?
     check_ajax
-    render partial: 'buildstatus', locals: { project: @project, buildresults: @project.buildresults }
+    render partial: 'buildstatus', locals: { project: @project,
+                                             buildresults: @project.buildresults,
+                                             collapsed_repositories: params.fetch(:collapsedRepositories, []) }
   end
 
   def delete_dialog

--- a/src/api/app/views/webui2/shared/_buildresult_box.html.haml
+++ b/src/api/app/views/webui2/shared/_buildresult_box.html.haml
@@ -1,5 +1,5 @@
 :ruby
-  index ||= ''
+  index ||= '0'
   ajax_data = {}
   ajax_data['switch'] = 'true' # FIXME: Remove this when request show is available in bootstrap
   ajax_data['project'] = h(project) if defined?(project)
@@ -35,3 +35,6 @@
 :javascript
   updateBuildResult('#{index}');
   if ($('#rpm#{index}').length === 1) updateRpmlintResult('#{index}');
+
+- content_for(:ready_function) do
+  subscribeAjaxEvents("#{index}");

--- a/src/api/app/views/webui2/shared/_buildresult_box.html.haml
+++ b/src/api/app/views/webui2/shared/_buildresult_box.html.haml
@@ -21,7 +21,9 @@
   .card-body
     .tab-content
       .tab-pane.fade.show.active{ id: "build#{index}", role: 'tabpanel', aria: { labelledby: "build#{index}-tab" } }
-        .btn.btn-sm.btn-outline-primary.mb-2.build-refresh{ onclick: "updateBuildResult('#{index}')", accesskey: 'r', title: 'Refresh Build Results' }
+        - ajax_url = defined?(package) ? package_buildresult_path : project_buildresult_path
+        %button.btn.btn-sm.btn-outline-primary.mb-2.build-refresh{ accesskey: 'r', title: 'Refresh Build Results',
+                                                                   data: { remote: true, url: ajax_url, params: ajax_data.to_param } }
           Refresh
           %i.fas.fa-sm.fa-sync-alt{ id: "build#{index}-reload" }
         .result

--- a/src/api/app/views/webui2/webui/package/_buildstatus.html.haml
+++ b/src/api/app/views/webui2/webui/package/_buildstatus.html.haml
@@ -14,21 +14,29 @@
         - previous_repo = nil
         - results.each do |result|
           - if result.repository != previous_repo
+            - repository_name = result.repository.tr('.', '_')
+            - expanded = !collapsed_repositories.include?(repository_name)
             .row.py-1.bg-light
               .col{ title: result.repository.to_s }
                 = link_to(word_break(result.repository, 22),
                   package_binaries_path(project: project, package: package, repository: result.repository),
                   data: { content: "Binaries for #{result.repository}", placement: 'top', toggle: 'popover' })
-          .row.py-1
-            .col-4.col-sm-3.offset-2.offset-sm-4.text-nowrap
-              - if !result.is_repository_in_db
-                %i.fas.fa-clock.text-warning{ title: 'This result is outdated' }
-              - else
-                = webui2_repository_status_icon(status: result.state, details: result.details)
-              %span.ml-1
-                = result.architecture
-            .col-6.col-sm-5.buildstatus.text-nowrap
-              = webui2_arch_repo_table_cell(result.repository, result.architecture, package, 'code' => result.code, 'details' => result.details)
+                = link_to('#', aria: { controls: "collapse-#{repository_name}", expanded: expanded }, class: 'ml-1',
+                          data: { toggle: 'collapse' }, href: ".collapse-#{repository_name}", role: 'button') do
+                  %i.fas.fa-chevron-left.expander{ title: 'Show build results for this repository' }
+                  %i.fas.fa-chevron-down.collapser{ title: 'Hide build results for this repository' }
+
+          .collapse{ class: "collapse-#{repository_name}#{expanded ? ' show' : ''}", data: { repository: repository_name } }
+            .row.py-1
+              .col-4.col-sm-3.offset-2.offset-sm-4.text-nowrap
+                - if !result.is_repository_in_db
+                  %i.fas.fa-clock.text-warning{ title: 'This result is outdated' }
+                - else
+                  = webui2_repository_status_icon(status: result.state, details: result.details)
+                %span.ml-1
+                  = result.architecture
+              .col-6.col-sm-5.buildstatus.text-nowrap
+                = webui2_arch_repo_table_cell(result.repository, result.architecture, package, 'code' => result.code, 'details' => result.details)
           - previous_repo = result.repository
       - else
         All the results have state

--- a/src/api/app/views/webui2/webui/package/_buildstatus.html.haml
+++ b/src/api/app/views/webui2/webui/package/_buildstatus.html.haml
@@ -1,7 +1,11 @@
 - unless buildresults.excluded_counter.zero? && !buildresults.show_all
+
   .mt-3.small.custom-control-checkbox
+    -# FIXME: Remove `switch: true` under `data-params` when request show is available in Bootstrap
     = check_box_tag("show_all_#{index}", true, buildresults.show_all, class: 'custom-control-input d-none',
-                    onchange: "updateBuildResult('#{index}')")
+                    data: { remote: true,
+                            url: package_buildresult_path,
+                            params: { index: 0, switch: true, project: project, package: package }.to_param })
     - label_message = buildresults.excluded_counter.zero? ? 'Hide' : "Show #{buildresults.excluded_counter}"
     = label_tag "show_all_#{index}" do
       %u.custom-label #{label_message} excluded/disabled results

--- a/src/api/app/views/webui2/webui/project/_buildstatus.html.haml
+++ b/src/api/app/views/webui2/webui/project/_buildstatus.html.haml
@@ -14,13 +14,19 @@
         %i No build result available
   - else
     - buildresults.each do |repository, build_results|
+      - repository_name = repository.tr('.', '_')
+      - expanded = !collapsed_repositories.include?(repository_name)
       .d-flex.flex-column
         .d-flex.flex-row.py-1.bg-light.pl-3
           = link_to(word_break(repository, 12),
             project_repository_state_path(project: project.name, repository: repository),
             title: "Repository #{repository}")
+          = link_to('#', aria: { controls: "collapse-#{repository_name}", expanded: expanded }, class: 'ml-1',
+                    data: { toggle: 'collapse' }, href: ".collapse-#{repository_name}", role: 'button') do
+            %i.fas.fa-chevron-left.expander{ title: 'Show build results for this repository' }
+            %i.fas.fa-chevron-down.collapser{ title: 'Hide build results for this repository' }
 
-        %div
+        .collapse{ class: "collapse-#{repository_name}#{expanded ? ' show' : ''}", data: { repository: repository_name } }
           - build_results.sort_by(&:architecture).each do |build_result|
             .row.py-1
               .col-4.col-sm-3.offset-2.offset-sm-4.text-nowrap{ title: "#{repository} summary" }


### PR DESCRIPTION
@eduardoj and I tried two ways to achieve this.

We wanted to avoid rendering the partial on the server, then sending it to the client when a user refreshes the build results. This is the current state. We looked at multiple options and opted for [Mustache](https://mustache.github.io/) and gave it a fair try. However, it is simply so much changes/code to make this work and maintainable (especially this). It quickly became a mess and even though we would have liked for this to work, we decided to go with the second option.

So we are now with this solution as you can see in this PR. Instead of only sending the needed data to the client for it to be parsed/rendered with JavaScript, we still render the partial on the server and send it to the client. The changes are minimal, but the best would be to achieve what we aim for at first. It's something which we need to think about for `webui2`.

Anyway, here's a preview of how this works. Just before recording the GIF, I added the repository `openSUSE Leap 15.0`. I then collapse a repository and refresh the build results. The collapsed/expanded state is kept for all repositories and the build results are refreshed.

![preview](https://user-images.githubusercontent.com/1102934/52285508-c29d4300-2966-11e9-9e21-e65c32951956.gif) 

Co-authored-by: Eduardo Navarro <enavarro@suse.com>