### PR TITLE
Move check_ajax from sourcediff to a before_action

### DIFF
--- a/src/api/app/controllers/webui/request_controller.rb
+++ b/src/api/app/controllers/webui/request_controller.rb
@@ -11,6 +11,8 @@ class Webui::RequestController < Webui::WebuiController
 
   before_action :set_superseded_request, only: :show
 
+  before_action :check_ajax, only: :sourcediff
+
   def add_reviewer_dialog
     @request_number = params[:number]
     render_dialog('requestAddReviewAutocomplete')
@@ -112,7 +114,6 @@ class Webui::RequestController < Webui::WebuiController
   end
 
   def sourcediff
-    check_ajax
     render partial: 'shared/editor', locals: { text: params[:text],
                                                mode: 'diff', style: { read_only: true },
                                                height: 'auto', width: '750px',


### PR DESCRIPTION
```check_ajax``` should be called in a before_action, since its not direct connected with the action ```sourcediff``` logic
