### PR TITLE
[api] support releasing into maintenance_release without incident pro…

### DIFF
--- a/src/api/app/controllers/source_controller.rb
+++ b/src/api/app/controllers/source_controller.rb
@@ -997,7 +997,7 @@ class SourceController < ApplicationController
     end
 
     # uniq timestring for all targets
-    time_string = Time.now.utc.strftime('%Y%m%d%H%M%S')
+    time_now = Time.now.utc
 
     # specified target
     if params[:target_project]
@@ -1011,19 +1011,9 @@ class SourceController < ApplicationController
       pkg.project.repositories.each do |repo|
         next if params[:repository] && params[:repository] != repo.name
         repo.release_targets.each do |releasetarget|
-          target_package_name = pkg.release_target_name
-          # emulate a maintenance release request action here in case
-          if pkg.project.is_maintenance_incident?
-            # The maintenance ID is always the sub project name of the maintenance project
-            target_package_name += '.' << pkg.project.name.gsub(/.*:/, '')
-          elsif releasetarget.target_repository.project.is_maintenance_release?
-            # Fallback for releasing into a release project outside of maintenance incident
-            # avoid overwriting existing binaries in this case
-            target_package_name += '.' << time_string
-          end
-
           # find md5sum and release source and binaries
-          release_package(pkg, releasetarget.target_repository, target_package_name, repo, multibuild_container, nil, params[:setrelease], true)
+          release_package(pkg, releasetarget.target_repository, pkg.release_target_name(releasetarget.target_repository, time_now), repo,
+                          multibuild_container, nil, params[:setrelease], true)
         end
       end
     end

--- a/src/api/app/models/project.rb
+++ b/src/api/app/models/project.rb
@@ -1120,6 +1120,9 @@ class Project < ApplicationRecord
   def do_project_release(params)
     User.current ||= User.find_by_login(params[:user])
 
+    # uniq timestring for all targets
+    time_now = Time.now.utc
+
     packages.each do |pkg|
       next if pkg.name == '_product' # will be handled via _product:*
       pkg.project.repositories.each do |repo|
@@ -1129,7 +1132,7 @@ class Project < ApplicationRecord
           next if params[:targetreposiory] && params[:targetreposiory] != releasetarget.target_repository.name
           # release source and binaries
           # permission checking happens inside this function
-          release_package(pkg, releasetarget.target_repository, pkg.target_name, repo, nil, nil, params[:setrelease], true)
+          release_package(pkg, releasetarget.target_repository, pkg.release_target_name(releasetarget.target_repository, time_now), repo, nil, nil, params[:setrelease], true)
         end
       end
     end

--- a/src/api/spec/cassettes/Package/_release_target_name/when_package_belongs_to_a_maintenance_incident/adds_the_project_basename_as_suffix.yml
+++ b/src/api/spec/cassettes/Package/_release_target_name/when_package_belongs_to_a_maintenance_incident/adds_the_project_basename_as_suffix.yml
@@ -1,0 +1,286 @@
+---
+http_interactions:
+- request:
+    method: put
+    uri: http://backend:5352/source/home:tom/_meta?user=tom
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:tom">
+          <title/>
+          <description/>
+          <person userid="tom" role="maintainer"/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '129'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:tom">
+          <title></title>
+          <description></description>
+          <person userid="tom" role="maintainer" />
+        </project>
+    http_version: 
+  recorded_at: Fri, 01 Mar 2019 15:04:19 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/project_1/_meta?user=tom
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="project_1" kind="maintenance">
+          <title>Nine Coaches Waiting</title>
+          <description/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '125'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="project_1" kind="maintenance">
+          <title>Nine Coaches Waiting</title>
+          <description></description>
+        </project>
+    http_version: 
+  recorded_at: Fri, 01 Mar 2019 15:04:19 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/project_1/_project/_attribute?meta=1&user=tom
+    body:
+      encoding: UTF-8
+      string: |
+        <attributes>
+          <attribute name="MaintenanceProject" namespace="OBS"/>
+        </attributes>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '165'
+    body:
+      encoding: UTF-8
+      string: |
+        <revision rev="6">
+          <srcmd5>1043307eb379cf76de04c634b79b1fd8</srcmd5>
+          <time>1551452660</time>
+          <user>tom</user>
+          <comment></comment>
+          <requestid/>
+        </revision>
+    http_version: 
+  recorded_at: Fri, 01 Mar 2019 15:04:20 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/hello_world_project/_meta?user=tom
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="hello_world_project" kind="maintenance_incident">
+          <title>Frequent Hearses</title>
+          <description/>
+          <build>
+            <disable/>
+          </build>
+          <publish>
+            <disable/>
+          </publish>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '218'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="hello_world_project" kind="maintenance_incident">
+          <title>Frequent Hearses</title>
+          <description></description>
+          <build>
+            <disable />
+          </build>
+          <publish>
+            <disable />
+          </publish>
+        </project>
+    http_version: 
+  recorded_at: Fri, 01 Mar 2019 15:04:20 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/hello_world_project/hello_world/_meta?user=tom
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="hello_world" project="hello_world_project">
+          <title>In Death Ground</title>
+          <description>Autem nam et et.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '149'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="hello_world" project="hello_world_project">
+          <title>In Death Ground</title>
+          <description>Autem nam et et.</description>
+        </package>
+    http_version: 
+  recorded_at: Fri, 01 Mar 2019 15:04:20 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/hello_world_project/hello_world/_meta?user=tom
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="hello_world" project="hello_world_project">
+          <title>In Death Ground</title>
+          <description>Autem nam et et.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '149'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="hello_world" project="hello_world_project">
+          <title>In Death Ground</title>
+          <description>Autem nam et et.</description>
+        </package>
+    http_version: 
+  recorded_at: Fri, 01 Mar 2019 15:04:20 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/hello_world_project/hello_world
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '86'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="hello_world" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
+        </directory>
+    http_version: 
+  recorded_at: Fri, 01 Mar 2019 15:04:20 GMT
+recorded_with: VCR 4.0.0

--- a/src/api/spec/cassettes/Project/_do_project_release/uses_the_package_s_release_target_name_when_releasing_the_package.yml
+++ b/src/api/spec/cassettes/Project/_do_project_release/uses_the_package_s_release_target_name_when_releasing_the_package.yml
@@ -40,7 +40,7 @@ http_interactions:
           <person userid="tux" role="maintainer" />
         </project>
     http_version: 
-  recorded_at: Mon, 18 Jun 2018 11:24:13 GMT
+  recorded_at: Fri, 01 Mar 2019 14:08:34 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tux/my_package_release/_meta?user=_nobody_
@@ -48,8 +48,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="my_package_release" project="home:tux">
-          <title>The Monkey's Raincoat</title>
-          <description>Qui et alias eos vel.</description>
+          <title>His Dark Materials</title>
+          <description>Vitae explicabo deserunt vel.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -70,25 +70,25 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '156'
+      - '161'
     body:
       encoding: UTF-8
       string: |
         <package name="my_package_release" project="home:tux">
-          <title>The Monkey's Raincoat</title>
-          <description>Qui et alias eos vel.</description>
+          <title>His Dark Materials</title>
+          <description>Vitae explicabo deserunt vel.</description>
         </package>
     http_version: 
-  recorded_at: Mon, 18 Jun 2018 11:24:13 GMT
+  recorded_at: Fri, 01 Mar 2019 14:08:34 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tux/my_package_release/_meta
+    uri: http://backend:5352/source/home:tux/my_package_release/_meta?user=_nobody_
     body:
       encoding: UTF-8
       string: |
         <package name="my_package_release" project="home:tux">
-          <title>The Monkey's Raincoat</title>
-          <description>Qui et alias eos vel.</description>
+          <title>His Dark Materials</title>
+          <description>Vitae explicabo deserunt vel.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -109,16 +109,16 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '156'
+      - '161'
     body:
       encoding: UTF-8
       string: |
         <package name="my_package_release" project="home:tux">
-          <title>The Monkey's Raincoat</title>
-          <description>Qui et alias eos vel.</description>
+          <title>His Dark Materials</title>
+          <description>Vitae explicabo deserunt vel.</description>
         </package>
     http_version: 
-  recorded_at: Mon, 18 Jun 2018 11:24:13 GMT
+  recorded_at: Fri, 01 Mar 2019 14:08:34 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tux/my_package_release/somefile.txt
@@ -148,16 +148,16 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <revision rev="1" vrev="1">
+        <revision rev="5" vrev="5">
           <srcmd5>cabf9a1f9a0b7c19d4f7ff46166f4ee0</srcmd5>
           <version>unknown</version>
-          <time>1529321053</time>
+          <time>1551449314</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
     http_version: 
-  recorded_at: Mon, 18 Jun 2018 11:24:13 GMT
+  recorded_at: Fri, 01 Mar 2019 14:08:34 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tux/my_package_release/somefile.txt
@@ -187,24 +187,24 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <revision rev="2" vrev="2">
+        <revision rev="6" vrev="6">
           <srcmd5>efbe5f0a5dd48df5129b4319df43aa45</srcmd5>
           <version>unknown</version>
-          <time>1529321053</time>
+          <time>1551449314</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
     http_version: 
-  recorded_at: Mon, 18 Jun 2018 11:24:13 GMT
+  recorded_at: Fri, 01 Mar 2019 14:08:34 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tux:staging/_meta
+    uri: http://backend:5352/source/home:tux:staging/_meta?user=_nobody_
     body:
       encoding: UTF-8
       string: |
         <project name="home:tux:staging">
-          <title>The Glory and the Dream</title>
+          <title>A Summer Bird-Cage</title>
           <description/>
         </project>
     headers:
@@ -226,52 +226,16 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '116'
+      - '111'
     body:
       encoding: UTF-8
       string: |
         <project name="home:tux:staging">
-          <title>The Glory and the Dream</title>
+          <title>A Summer Bird-Cage</title>
           <description></description>
         </project>
     http_version: 
-  recorded_at: Mon, 18 Jun 2018 11:24:13 GMT
-- request:
-    method: put
-    uri: http://backend:5352/source/home:tux:staging/_config
-    body:
-      encoding: UTF-8
-      string: Corrupti nesciunt ut dolorum qui incidunt architecto labore. Eveniet
-        autem et est ut quam. Consequatur officia voluptatem in ea vitae occaecati
-        error. Autem distinctio porro id est nihil nulla est. Ducimus quos ut est
-        possimus earum in.
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '21'
-    body:
-      encoding: UTF-8
-      string: '<status code="ok" />
-
-'
-    http_version: 
-  recorded_at: Mon, 18 Jun 2018 11:24:13 GMT
+  recorded_at: Fri, 01 Mar 2019 14:08:34 GMT
 - request:
     method: post
     uri: http://backend:5352/build/home:tux:staging?cmd=suspendproject
@@ -306,7 +270,7 @@ http_interactions:
 
 '
     http_version: 
-  recorded_at: Mon, 18 Jun 2018 11:24:14 GMT
+  recorded_at: Fri, 01 Mar 2019 14:08:35 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tux:staging/my_release_target/_meta?user=tux
@@ -314,8 +278,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="my_release_target" project="home:tux:staging">
-          <title>The Monkey's Raincoat</title>
-          <description>Qui et alias eos vel.</description>
+          <title>His Dark Materials</title>
+          <description>Vitae explicabo deserunt vel.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -336,16 +300,16 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '163'
+      - '168'
     body:
       encoding: UTF-8
       string: |
         <package name="my_release_target" project="home:tux:staging">
-          <title>The Monkey's Raincoat</title>
-          <description>Qui et alias eos vel.</description>
+          <title>His Dark Materials</title>
+          <description>Vitae explicabo deserunt vel.</description>
         </package>
     http_version: 
-  recorded_at: Mon, 18 Jun 2018 11:24:14 GMT
+  recorded_at: Fri, 01 Mar 2019 14:08:35 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tux:staging/my_release_target/_meta?user=tux
@@ -353,8 +317,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="my_release_target" project="home:tux:staging">
-          <title>The Monkey's Raincoat</title>
-          <description>Qui et alias eos vel.</description>
+          <title>His Dark Materials</title>
+          <description>Vitae explicabo deserunt vel.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -375,16 +339,16 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '163'
+      - '168'
     body:
       encoding: UTF-8
       string: |
         <package name="my_release_target" project="home:tux:staging">
-          <title>The Monkey's Raincoat</title>
-          <description>Qui et alias eos vel.</description>
+          <title>His Dark Materials</title>
+          <description>Vitae explicabo deserunt vel.</description>
         </package>
     http_version: 
-  recorded_at: Mon, 18 Jun 2018 11:24:14 GMT
+  recorded_at: Fri, 01 Mar 2019 14:08:35 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:tux:staging/my_release_target?cmd=copy&comment=Release%20from%20home:tux%20/%20my_package_release&expand=1&noservice=1&opackage=my_package_release&oproject=home:tux&user=tux&withacceptinfo=1&withvrev=1
@@ -416,16 +380,16 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <revision rev="1" vrev="3">
+        <revision rev="1" vrev="7">
           <srcmd5>efbe5f0a5dd48df5129b4319df43aa45</srcmd5>
           <version>unknown</version>
-          <time>1529321054</time>
+          <time>1551449315</time>
           <user>tux</user>
           <comment>Release from home:tux / my_package_release</comment>
           <requestid/>
         </revision>
     http_version: 
-  recorded_at: Mon, 18 Jun 2018 11:24:14 GMT
+  recorded_at: Fri, 01 Mar 2019 14:08:35 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tux:staging/my_release_target/_meta?user=tux
@@ -433,8 +397,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="my_release_target" project="home:tux:staging">
-          <title>The Monkey's Raincoat</title>
-          <description>Qui et alias eos vel.</description>
+          <title>His Dark Materials</title>
+          <description>Vitae explicabo deserunt vel.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -455,16 +419,16 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '163'
+      - '168'
     body:
       encoding: UTF-8
       string: |
         <package name="my_release_target" project="home:tux:staging">
-          <title>The Monkey's Raincoat</title>
-          <description>Qui et alias eos vel.</description>
+          <title>His Dark Materials</title>
+          <description>Vitae explicabo deserunt vel.</description>
         </package>
     http_version: 
-  recorded_at: Mon, 18 Jun 2018 11:24:14 GMT
+  recorded_at: Fri, 01 Mar 2019 14:08:35 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:tux:staging/my_release_target
@@ -494,11 +458,11 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="my_release_target" rev="1" vrev="3" srcmd5="efbe5f0a5dd48df5129b4319df43aa45">
-          <entry name="somefile.txt" md5="c4ca4238a0b923820dcc509a6f75849b" size="1" mtime="1529224252" />
+        <directory name="my_release_target" rev="1" vrev="7" srcmd5="efbe5f0a5dd48df5129b4319df43aa45">
+          <entry name="somefile.txt" md5="c4ca4238a0b923820dcc509a6f75849b" size="1" mtime="1551444109" />
         </directory>
     http_version: 
-  recorded_at: Mon, 18 Jun 2018 11:24:14 GMT
+  recorded_at: Fri, 01 Mar 2019 14:08:35 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:tux:staging/my_release_target?view=info
@@ -528,11 +492,11 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <sourceinfo package="my_release_target" rev="1" vrev="3" srcmd5="efbe5f0a5dd48df5129b4319df43aa45" verifymd5="efbe5f0a5dd48df5129b4319df43aa45">
+        <sourceinfo package="my_release_target" rev="1" vrev="7" srcmd5="efbe5f0a5dd48df5129b4319df43aa45" verifymd5="efbe5f0a5dd48df5129b4319df43aa45">
           <error>bad build configuration, no build type defined or detected</error>
         </sourceinfo>
     http_version: 
-  recorded_at: Mon, 18 Jun 2018 11:24:14 GMT
+  recorded_at: Fri, 01 Mar 2019 14:08:35 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:tux:staging/my_release_target
@@ -562,11 +526,11 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="my_release_target" rev="1" vrev="3" srcmd5="efbe5f0a5dd48df5129b4319df43aa45">
-          <entry name="somefile.txt" md5="c4ca4238a0b923820dcc509a6f75849b" size="1" mtime="1529224252" />
+        <directory name="my_release_target" rev="1" vrev="7" srcmd5="efbe5f0a5dd48df5129b4319df43aa45">
+          <entry name="somefile.txt" md5="c4ca4238a0b923820dcc509a6f75849b" size="1" mtime="1551444109" />
         </directory>
     http_version: 
-  recorded_at: Mon, 18 Jun 2018 11:24:14 GMT
+  recorded_at: Fri, 01 Mar 2019 14:08:35 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:tux:staging/my_release_target?cmd=diff&linkrev=base&onlyissues=1&orev=0&view=xml
@@ -589,24 +553,24 @@ http_interactions:
     headers:
       Content-Type:
       - text/xml
+      Content-Length:
+      - '333'
       Cache-Control:
       - no-cache
       Connection:
       - close
-      Content-Length:
-      - '331'
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="cfc6a784fe5b44542f5241922b377239">
-          <old project="home:tux:staging" package="my_release_target" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e" />
-          <new project="home:tux:staging" package="my_release_target" rev="1" srcmd5="efbe5f0a5dd48df5129b4319df43aa45" />
+        <sourcediff key="fe1ee31568c3b1d86d5b5c0a5221db2d">
+          <old project="home:tux:staging" package="my_package_release" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e" />
+          <new project="home:tux:staging" package="my_package_release" rev="1" srcmd5="efbe5f0a5dd48df5129b4319df43aa45" />
           <files />
           <issues>
           </issues>
         </sourcediff>
     http_version: 
-  recorded_at: Mon, 18 Jun 2018 11:24:14 GMT
+  recorded_at: Fri, 01 Mar 2019 14:08:35 GMT
 - request:
     method: post
     uri: http://backend:5352/build/home:tux:staging?cmd=resumeproject
@@ -641,5 +605,5 @@ http_interactions:
 
 '
     http_version: 
-  recorded_at: Mon, 18 Jun 2018 11:24:14 GMT
+  recorded_at: Fri, 01 Mar 2019 14:08:35 GMT
 recorded_with: VCR 4.0.0

--- a/src/api/spec/models/package_spec.rb
+++ b/src/api/spec/models/package_spec.rb
@@ -660,17 +660,17 @@ RSpec.describe Package, vcr: true do
     it_behaves_like 'makes a user a maintainer of the subject'
   end
 
-  describe '#target_name' do
+  describe '#release_target_name' do
     it "returns the package name for 'normal' projects" do
-      expect(package.target_name).to eq(package.name)
+      expect(package.release_target_name).to eq(package.name)
     end
 
     context 'when package belongs to a maintenance incident' do
-      let(:maintenance_incident_project) { create(:maintenance_incident_project) }
-      let(:package) { create(:package, project: maintenance_incident_project) }
+      let(:maintenance_incident_project) { create(:maintenance_incident_project, name: 'hello_world_project') }
+      let(:package) { create(:package, name: 'hello_world', project: maintenance_incident_project) }
 
       it 'adds the project basename as suffix' do
-        expect(package.target_name).to eq("#{package.name}.#{package.project.basename}")
+        expect(package.release_target_name).to eq("#{package.name}.#{package.project.basename}")
       end
     end
   end

--- a/src/api/spec/models/project_spec.rb
+++ b/src/api/spec/models/project_spec.rb
@@ -583,7 +583,7 @@ RSpec.describe Project, vcr: true do
 
     before do
       login user
-      allow_any_instance_of(Package).to receive(:target_name).and_return('my_release_target')
+      allow_any_instance_of(Package).to receive(:release_target_name).and_return('my_release_target')
     end
 
     it "uses the package's release target name when releasing the package" do


### PR DESCRIPTION
…ject

Using readable timestamp as fallback.

Used in continous rebuild projects for container releases

consolidate mechanics of entire project and single package release
handling, fixing small unwanted differences



<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md
-->
