### PR TITLE
Call check_ajax from before_action

### DIFF
--- a/src/api/app/controllers/webui/kiwi/images_controller.rb
+++ b/src/api/app/controllers/webui/kiwi/images_controller.rb
@@ -4,6 +4,7 @@ module Webui
       before_action -> { feature_active?(:kiwi_image_editor) }
       before_action :set_image, except: [:import_from_package]
       before_action :authorize_update, except: [:import_from_package]
+      before_action :check_ajax, only: :build_result
 
       def import_from_package
         package = Package.find(params[:package_id])
@@ -89,7 +90,6 @@ module Webui
       end
 
       def build_result
-        check_ajax
         if @image.package.project.repositories.any?
           @build_results = @image.build_results
           render partial: 'build_status'

--- a/src/api/app/controllers/webui/monitor_controller.rb
+++ b/src/api/app/controllers/webui/monitor_controller.rb
@@ -2,6 +2,7 @@ class Webui::MonitorController < Webui::WebuiController
   before_action :set_default_architecture
   before_action :require_settings, only: [:old, :index, :filtered_list, :update_building]
   before_action :fetch_workerstatus, only: [:old, :filtered_list, :update_building]
+  before_action :check_ajax, only: [:update_building, :events]
 
   def self.addarrays(arr1, arr2)
     # we assert that both have the same size
@@ -54,7 +55,6 @@ class Webui::MonitorController < Webui::WebuiController
   end
 
   def update_building
-    check_ajax
     workers = {}
     max_time = 4 * 3600
     @workerstatus.elements('idle') do |b|
@@ -77,7 +77,6 @@ class Webui::MonitorController < Webui::WebuiController
   end
 
   def events
-    check_ajax
     data = {}
 
     arch = Architecture.find_by(name: params.fetch(:arch, @default_architecture))

--- a/src/api/app/controllers/webui/project_controller.rb
+++ b/src/api/app/controllers/webui/project_controller.rb
@@ -35,6 +35,7 @@ class Webui::ProjectController < Webui::WebuiController
                                                      :remove_maintained_project]
 
   before_action :set_maintained_project, only: [:remove_maintained_project]
+  before_action :check_ajax, only: [:buildresult, :edit_comment_form]
 
   after_action :verify_authorized, only: [:save_new, :new_incident]
 
@@ -217,7 +218,6 @@ class Webui::ProjectController < Webui::WebuiController
 
   def buildresult
     switch_to_webui2 if params[:switch].present?
-    check_ajax
     render partial: 'buildstatus', locals: { project: @project, buildresults: @project.buildresults }
   end
 
@@ -440,7 +440,6 @@ class Webui::ProjectController < Webui::WebuiController
   end
 
   def edit_comment_form
-    check_ajax
     switch_to_webui2
   end
 

--- a/src/api/app/controllers/webui/repositories_controller.rb
+++ b/src/api/app/controllers/webui/repositories_controller.rb
@@ -3,6 +3,7 @@ class Webui::RepositoriesController < Webui::WebuiController
   before_action :set_repository, only: [:state]
   before_action :set_architectures, only: [:index, :change_flag]
   before_action :find_repository_parent, only: [:index, :create_flag, :remove_flag, :toggle_flag, :change_flag]
+  before_action :check_ajax, only: :change_flag
   after_action :verify_authorized, except: [:index, :distributions, :state]
 
   # GET /repositories/:project(/:package)
@@ -253,7 +254,6 @@ class Webui::RepositoriesController < Webui::WebuiController
   # TODO: when removing bento, remove the extra 'change' from the route, for
   # now we need to avoid the clash with create_flag
   def change_flag
-    check_ajax
     required_parameters :flag, :command
     set_webui2_views
     authorize @main_object, :update?

--- a/src/api/app/controllers/webui/webui_controller.rb
+++ b/src/api/app/controllers/webui/webui_controller.rb
@@ -20,6 +20,7 @@ class Webui::WebuiController < ActionController::Base
   before_action :set_influxdb_additional_tags
   before_action :require_configuration
   before_action :set_pending_announcement
+  before_action :check_ajax, only: :render_dialog
   after_action :clean_cache
 
   # :notice and :alert are default, we add :success and :error
@@ -282,7 +283,6 @@ class Webui::WebuiController < ActionController::Base
 
   # dialog_init is a function name called before dialog is shown
   def render_dialog(dialog_init = nil, locals = {})
-    check_ajax
     @dialog_html = ActionController::Base.helpers.escape_javascript(render_to_string(partial: action_name, locals: locals))
     @dialog_init = dialog_init
     render partial: 'dialog', content_type: 'application/javascript'


### PR DESCRIPTION
Many controller actions begin with a call to "check_ajax". We move it to
a before_action instead.
