### PR TITLE
Collapse/Expand the build results

### DIFF
--- a/src/api/app/assets/javascripts/webui2/buildresult.js
+++ b/src/api/app/assets/javascripts/webui2/buildresult.js
@@ -18,6 +18,7 @@ function updateRpmlintResult(index) { // jshint ignore:line
 function updateBuildResult(index) { // jshint ignore:line
   var ajaxDataShow = $('#buildresult' + index + '-box').data();
   ajaxDataShow.show_all = $('#show_all_'+index).is(':checked'); // jshint ignore:line
+  ajaxDataShow.collapsedRepositories = $('.result div.collapse:not(.show)').map(function(_index, domElement) { return $(domElement).data('repository'); }).get();
   $('#build'+index+'-reload').addClass('fa-spin');
   $.ajax({
     url: $('#buildresult' + index + '-urls').data('buildresultUrl'),

--- a/src/api/app/controllers/webui/package_controller.rb
+++ b/src/api/app/controllers/webui/package_controller.rb
@@ -951,7 +951,10 @@ class Webui::PackageController < Webui::WebuiController
       @index = params[:index]
       @buildresults = @package.buildresult(@project, show_all)
       switch_to_webui2 if params[:switch].present?
-      render partial: 'buildstatus', locals: { buildresults: @buildresults, index: @index, project: @project }
+      render partial: 'buildstatus', locals: { buildresults: @buildresults,
+                                               index: @index,
+                                               project: @project,
+                                               collapsed_repositories: params.fetch(:collapsedRepositories, []) }
     else
       switch_to_webui2 if params[:switch].present?
       render partial: 'no_repositories', locals: { project: @project }

--- a/src/api/app/controllers/webui/project_controller.rb
+++ b/src/api/app/controllers/webui/project_controller.rb
@@ -218,7 +218,9 @@ class Webui::ProjectController < Webui::WebuiController
 
   def buildresult
     switch_to_webui2 if params[:switch].present?
-    render partial: 'buildstatus', locals: { project: @project, buildresults: @project.buildresults }
+    render partial: 'buildstatus', locals: { project: @project,
+                                             buildresults: @project.buildresults,
+                                             collapsed_repositories: params.fetch(:collapsedRepositories, []) }
   end
 
   def delete_dialog

--- a/src/api/app/views/webui2/webui/package/_buildstatus.html.haml
+++ b/src/api/app/views/webui2/webui/package/_buildstatus.html.haml
@@ -14,21 +14,29 @@
         - previous_repo = nil
         - results.each do |result|
           - if result.repository != previous_repo
+            - repository_name = result.repository.tr('.', '_')
+            - expanded = !collapsed_repositories.include?(repository_name)
             .row.py-1.bg-light
               .col{ title: result.repository.to_s }
                 = link_to(word_break(result.repository, 22),
                   package_binaries_path(project: project, package: package, repository: result.repository),
                   data: { content: "Binaries for #{result.repository}", placement: 'top', toggle: 'popover' })
-          .row.py-1
-            .col-4.col-sm-3.offset-2.offset-sm-4.text-nowrap
-              - if !result.is_repository_in_db
-                %i.fas.fa-clock.text-warning{ title: 'This result is outdated' }
-              - else
-                = webui2_repository_status_icon(status: result.state, details: result.details)
-              %span.ml-1
-                = result.architecture
-            .col-6.col-sm-5.buildstatus.text-nowrap
-              = webui2_arch_repo_table_cell(result.repository, result.architecture, package, 'code' => result.code, 'details' => result.details)
+                = link_to('#', aria: { controls: "collapse-#{repository_name}", expanded: expanded }, class: 'ml-1',
+                          data: { toggle: 'collapse' }, href: ".collapse-#{repository_name}", role: 'button') do
+                  %i.fas.fa-chevron-left.expander{ title: 'Show build results for this repository' }
+                  %i.fas.fa-chevron-down.collapser{ title: 'Hide build results for this repository' }
+
+          .collapse{ class: "collapse-#{repository_name}#{expanded ? ' show' : ''}", data: { repository: repository_name } }
+            .row.py-1
+              .col-4.col-sm-3.offset-2.offset-sm-4.text-nowrap
+                - if !result.is_repository_in_db
+                  %i.fas.fa-clock.text-warning{ title: 'This result is outdated' }
+                - else
+                  = webui2_repository_status_icon(status: result.state, details: result.details)
+                %span.ml-1
+                  = result.architecture
+              .col-6.col-sm-5.buildstatus.text-nowrap
+                = webui2_arch_repo_table_cell(result.repository, result.architecture, package, 'code' => result.code, 'details' => result.details)
           - previous_repo = result.repository
       - else
         All the results have state

--- a/src/api/app/views/webui2/webui/project/_buildstatus.html.haml
+++ b/src/api/app/views/webui2/webui/project/_buildstatus.html.haml
@@ -14,13 +14,19 @@
         %i No build result available
   - else
     - buildresults.each do |repository, build_results|
+      - repository_name = repository.tr('.', '_')
+      - expanded = !collapsed_repositories.include?(repository_name)
       .d-flex.flex-column
         .d-flex.flex-row.py-1.bg-light.pl-3
           = link_to(word_break(repository, 12),
             project_repository_state_path(project: project.name, repository: repository),
             title: "Repository #{repository}")
+          = link_to('#', aria: { controls: "collapse-#{repository_name}", expanded: expanded }, class: 'ml-1',
+                    data: { toggle: 'collapse' }, href: ".collapse-#{repository_name}", role: 'button') do
+            %i.fas.fa-chevron-left.expander{ title: 'Show build results for this repository' }
+            %i.fas.fa-chevron-down.collapser{ title: 'Hide build results for this repository' }
 
-        %div
+        .collapse{ class: "collapse-#{repository_name}#{expanded ? ' show' : ''}", data: { repository: repository_name } }
           - build_results.sort_by(&:architecture).each do |build_result|
             .row.py-1
               .col-4.col-sm-3.offset-2.offset-sm-4.text-nowrap{ title: "#{repository} summary" }


### PR DESCRIPTION
Co-authored-by: Eduardo Navarro <enavarro@suse.com>

After our discussions today on what is left for the current deliverable, we agreed to ship this as a first step. From there, we will move to using UJS in an upcoming PR to improve the code. The end result won't be much different for our users, so they already benefit from the changes included in this PR.

Here's a preview of the changes. Be aware that just before recording the GIF, I added the repository `openSUSE Leap 15.0`. I then collapse a repository and refresh the build results. The collapsed/expanded state is kept for all repositories and the build results are refreshed.

![preview](https://user-images.githubusercontent.com/1102934/52414900-d6bb7e80-2ae5-11e9-821c-f070a685b50c.gif)