### PR TITLE
Only show request actions the user has permissions for

### DIFF
--- a/src/api/app/views/webui2/webui/request/_decision_tab.html.haml
+++ b/src/api/app/views/webui2/webui/request/_decision_tab.html.haml
@@ -2,7 +2,7 @@
   = hidden_field_tag(:number, request_number)
   %p
     = text_area_tag(:reason, nil, placeholder: 'Please add a comment', rows: 4, class: 'w-100 form-control')
-  - if single_action_request
+  - if single_action_request && is_target_maintainer && state.in?(['new', 'review'])
     - if state.in?(['new', 'review']) && !action[:creator_is_target_maintainer]
       .custom-control.custom-checkbox
         = check_box_tag('add_submitter_as_maintainer_0', "#{action[:tprj]}_#_#{action[:tpkg]}", false, class: 'custom-control-input')
@@ -15,8 +15,8 @@
         %label.custom-control-label{ for: "forward-#{index}" }
           Forward submit request to
           #{project_or_package_link(project: forward[:project], package: forward[:package], short: true)}
-  %hr
-  - if state.in?(['new', 'review'])
+    %hr
+  - if state.in?(['new', 'review']) && is_target_maintainer
     - confirmation = (state == 'review' ? { confirm: 'Do you really want to approve this request, despite of open review requests?' } : {})
     = submit_tag 'Accept request', name: 'accepted', class: 'btn btn-primary', data: confirmation
     - unless is_author

--- a/src/api/app/views/webui2/webui/request/show.html.haml
+++ b/src/api/app/views/webui2/webui/request/show.html.haml
@@ -66,7 +66,7 @@
     .tab-content
       .tab-pane.fade.show.active{ id: 'decision' }
         - if @can_handle_request
-          = render('decision_tab', request_number: @number, request_creator: @req['creator'],
+          = render('decision_tab', request_number: @number, request_creator: @req['creator'], is_target_maintainer: @is_target_maintainer,
             state: @state, is_author: @is_author, single_action_request: @actions.count == 1, action: @actions.first)
         - else
           %p


### PR DESCRIPTION
When porting this to the new webui I accidentally ignored
the @is_target_maintainer variable.
This adds it to the new view now, which fixes that the
forward request checkbox and accept request box is shown
for users that don't have the required permissions.



<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md
-->
