### PR TITLE
Use normal font-weight for diff content header

### DIFF
--- a/src/api/app/views/webui2/webui/request/_sourcediff_tab.html.haml
+++ b/src/api/app/views/webui2/webui/request/_sourcediff_tab.html.haml
@@ -1,7 +1,6 @@
 .row
   .col
-    %b
-      = request_action_header(action, request_creator)
+    = request_action_header(action, request_creator)
 - if action[:type] == :maintenance_incident && action[:releaseproject]
   %i
     Release in #{action[:releaseproject]}


### PR DESCRIPTION
Before:
![before](https://user-images.githubusercontent.com/1102934/52419739-fd32e700-2af0-11e9-9a55-24544bead296.png)

After:
![after](https://user-images.githubusercontent.com/1102934/52419749-015f0480-2af1-11e9-9786-9faee582f267.png)