### PR TITLE
Pass the package name as a parameter instead of the package object

### DIFF
--- a/src/api/app/controllers/webui/package_controller.rb
+++ b/src/api/app/controllers/webui/package_controller.rb
@@ -1040,11 +1040,12 @@ class Webui::PackageController < Webui::WebuiController
   def edit; end
 
   def binary_download
+    package_name = params[:package]
     architecture = Architecture.find_by_name(params[:arch]).name
     filename = File.basename(params[:filename]) # Ensure it really is just a file name, no '/..', etc.
     repository = Repository.find_by_project_and_name(@project.to_s, params[:repository].to_s)
 
-    url_generator = ::PackageControllerService::URLGenerator.new(project: @project, package: @package,
+    url_generator = ::PackageControllerService::URLGenerator.new(project: @project, package: package_name,
                                                                  user: User.current, arch: architecture,
                                                                  repository: repository, filename: filename)
 


### PR DESCRIPTION
This way, in the case of multibuild, the url for downloading the binary contains the package and the build section, as needed.

Fix #6847.

Co-authored-by: David Kang <dkang@suse.com>