### PR TITLE
Fix comment in review tab

### DIFF
--- a/src/api/app/views/webui2/webui/request/_review_tab.html.haml
+++ b/src/api/app/views/webui2/webui/request/_review_tab.html.haml
@@ -2,7 +2,7 @@
   = hidden_field_tag('request_number', request_number)
   = hidden_review_payload(review)
   %p
-    = text_area_tag('review_comment', review[:reason], rows: 4, class: 'w-100 form-control', placeholder: 'Please comment on your decision')
+    = text_area_tag('comment', review[:reason], rows: 4, class: 'w-100 form-control', placeholder: 'Please comment on your decision')
   %p
     = submit_tag 'Approve', name: 'new_state', title: 'Give this request your blessing, it will continue.', class: 'btn btn-primary'
     = submit_tag 'Disregard', name: 'new_state', title: 'Veto this request, it will be declined.', class: 'btn btn-danger'


### PR DESCRIPTION
The comment wasn't save because we slice the params `comment` in
`modify_review` action.



<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md
-->
