### PR TITLE
Fix DataTable problems in monitor page

### DIFF
--- a/src/api/app/assets/stylesheets/webui2/datatables.scss
+++ b/src/api/app/assets/stylesheets/webui2/datatables.scss
@@ -11,3 +11,15 @@ table.table-fixed {
   width: 100% !important;
   margin-left: 0 !important;
 }
+
+// TODO: Delete when bug is fixed: https://github.com/mkhairi/jquery-datatables/issues/17
+table.dataTable.table-sm .sorting:before,
+table.dataTable.table-sm .sorting_asc:before,
+table.dataTable.table-sm .sorting_desc:before {
+  top: initial;
+  right: 1em;
+  bottom: 0.3em;
+}
+.DTFC_LeftBodyLiner{
+  overflow-y: hidden !important;
+}


### PR DESCRIPTION
The problems are caused by a bug:https://github.com/mkhairi/jquery-datatables/issues/17

This solution is still not perfect, but it looks less broken than before. Hopefully the bug get fixed upstream fast.

![image](https://user-images.githubusercontent.com/16052290/52480033-db963600-2baa-11e9-835b-d64f024c28b1.png)

We have anyway to think about this page a bit. Using datatable setting a column has performance consequences.... there may be a better approach.



<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md
-->
