### PR TITLE
Fix undefined method 'repository_index_path' in request_action_header

### DIFF
--- a/src/api/app/helpers/webui/request_helper.rb
+++ b/src/api/app/helpers/webui/request_helper.rb
@@ -162,7 +162,8 @@ module Webui::RequestHelper
         target_container: project_or_package_link(project: action[:tprj], package: action[:tpkg])
       }
     when :delete
-      target_repository = link_to(action[:trepo], repository_index_path(project: action[:tprj], repository: action[:trepo])) if action[:trepo]
+      target_repository = "repository #{link_to(action[:trepo], repositories_path(project: action[:tprj], repository: action[:trepo]))} for " if action[:trepo]
+
       'Delete %{target_repository}%{target_container}' % {
         target_repository: target_repository,
         target_container: project_or_package_link(project: action[:tprj], package: action[:tpkg])

--- a/src/api/spec/helpers/webui/request_helper_spec.rb
+++ b/src/api/spec/helpers/webui/request_helper_spec.rb
@@ -114,7 +114,6 @@ RSpec.describe Webui::RequestHelper do
     let(:source_package) { create(:package) }
     let(:action) do
       {
-        type: :delete,
         tprj: target_package.project.name,
         tpkg: target_package.name,
         sprj: source_package.project.name,
@@ -128,9 +127,21 @@ RSpec.describe Webui::RequestHelper do
                    package_show_path(target_package.project, target_package).to_s)
       end
 
-      subject { request_action_header(action, creator.login) }
+      subject { request_action_header(action.merge(type: :delete), creator.login) }
 
       it { is_expected.to match(expected_regex) }
+
+      context 'with a target repository' do
+        let(:target_repository) { create(:repository, project: target_package.project) }
+        let(:expected_regex) do
+          Regexp.new("Delete repository .*#{Regexp.escape(repositories_path(project: target_repository.project, repository: target_repository.name))}.* for package .*" \
+                     "#{project_show_path(target_package.project)}.* \/ .*#{package_show_path(target_package.project, target_package)}")
+        end
+
+        subject { request_action_header(action.merge(type: :delete, trepo: target_repository.name), creator.login) }
+
+        it { is_expected.to match(expected_regex) }
+      end
     end
 
     context 'when action is :add_role' do


### PR DESCRIPTION
Also make it clearer that it's about deleting a repository.

There was a missing test case for request_action_header when
action[:type] == :delete and action[:trepo] is defined.

Fixes #6936