### PR TITLE
Send emails as user nobody

### DIFF
--- a/src/api/app/jobs/send_event_emails_job.rb
+++ b/src/api/app/jobs/send_event_emails_job.rb
@@ -2,7 +2,8 @@ class SendEventEmailsJob < ApplicationJob
   queue_as :mailers
 
   def perform
-    User.current = User.find_nobody!
+    # previous_user = User.current
+    # User.current = User.find_nobody!
     Event::Base.where(mails_sent: false).order(created_at: :asc).limit(1000).each do |event|
       subscribers = event.subscribers
 
@@ -20,6 +21,7 @@ class SendEventEmailsJob < ApplicationJob
         event.update_attributes(mails_sent: true)
       end
     end
+    # User.current = previous_user
     true
   end
 

--- a/src/api/app/jobs/send_event_emails_job.rb
+++ b/src/api/app/jobs/send_event_emails_job.rb
@@ -2,6 +2,7 @@ class SendEventEmailsJob < ApplicationJob
   queue_as :mailers
 
   def perform
+    User.current = User.find_nobody!
     Event::Base.where(mails_sent: false).order(created_at: :asc).limit(1000).each do |event|
       subscribers = event.subscribers
 

--- a/src/api/app/models/event_subscription/find_for_event.rb
+++ b/src/api/app/models/event_subscription/find_for_event.rb
@@ -7,6 +7,7 @@ class EventSubscription
     end
 
     def subscriptions
+      # binding.pry
       receivers_and_subscriptions = {}
 
       event.class.receiver_roles.flat_map do |receiver_role|

--- a/src/api/test/functional/maintenance_test.rb
+++ b/src/api/test/functional/maintenance_test.rb
@@ -1400,6 +1400,7 @@ class MaintenanceTests < ActionDispatch::IntegrationTest
     assert_xml_tag(parent: { tag: 'state' }, tag: 'comment', content: 'All reviewers accepted request')
 
     SendEventEmailsJob.new.perform
+    login_king
     ActionMailer::Base.deliveries.clear
 
     # leave a comment
@@ -1412,6 +1413,7 @@ class MaintenanceTests < ActionDispatch::IntegrationTest
     email = ActionMailer::Base.deliveries.last
     assert_equal ['dirkmueller@example.com', 'fred@feuerstein.de', 'test_group@testsuite.org'], email.to.sort
 
+    login_king
     EventSubscription.create(eventtype: 'Event::CommentForRequest', receiver_role: :source_maintainer,
                              user: users(:maintenance_assi), channel: :instant_email)
 
@@ -1420,10 +1422,12 @@ class MaintenanceTests < ActionDispatch::IntegrationTest
       post create_request_comment_path(request_number: reqid), params: 'Slave, can you release it? The master is gone'
       assert_response :success
       User.current = User.find_by_login('king')
+      binding.pry
       SendEventEmailsJob.new.perform
       User.current = nil
     end
 
+    login_king
     email = ActionMailer::Base.deliveries.last
     assert_equal ['dirkmueller@example.com', 'fred@feuerstein.de', 'homer@nospam.net', 'test_group@testsuite.org'], email.to.sort
 

--- a/src/api/test/models/event_test.rb
+++ b/src/api/test/models/event_test.rb
@@ -69,10 +69,10 @@ class EventTest < ActionDispatch::IntegrationTest
   end
 
   test 'create request' do
-    User.current = users(:Iggy)
     req = bs_requests(:submit_from_home_project)
     myid = req.number
     SendEventEmailsJob.new.perform # empty queue
+    User.current = users(:Iggy)
     assert_difference 'ActionMailer::Base.deliveries.size', +1 do
       req.addreview(by_user: 'tom', comment: 'Can you check that?')
       SendEventEmailsJob.new.perform
@@ -128,10 +128,10 @@ class EventTest < ActionDispatch::IntegrationTest
 
   test 'package maintainer mail' do
     ActionMailer::Base.deliveries.clear
-    User.current = users(:Iggy)
     req = bs_requests(:submit_from_home_project)
     myid = req.number
     SendEventEmailsJob.new.perform # empty queue
+    User.current = users(:Iggy)
     assert_difference 'ActionMailer::Base.deliveries.size', +1 do
       req.addreview(by_project: 'home:Iggy', by_package: 'TestPack', comment: 'Can you check that?')
       SendEventEmailsJob.new.perform
@@ -145,6 +145,7 @@ class EventTest < ActionDispatch::IntegrationTest
 
     # now verify another review sends other emails
     ActionMailer::Base.deliveries.clear
+    User.current = users(:Iggy)
     assert_difference 'ActionMailer::Base.deliveries.size', +1 do
       req.addreview(by_project: 'Apache', by_package: 'apache2', comment: 'Can you check that?')
       SendEventEmailsJob.new.perform

--- a/src/api/test/unit/event_mailer_test.rb
+++ b/src/api/test/unit/event_mailer_test.rb
@@ -51,22 +51,19 @@ class EventMailerTest < ActionMailer::TestCase
   end
 
   test 'group emails' do
-    User.current = users(:Iggy)
-
-    # the default is reviewer groups get email, so check that adrian gets an email
     req = bs_requests(:submit_from_home_project)
     Timecop.travel(2013, 8, 20, 12, 0, 0)
-    myid = req.number
     SendEventEmailsJob.new.perform # empty queue
+
+    User.current = users(:Iggy)
     assert_difference 'ActionMailer::Base.deliveries.size', +1 do
       req.addreview(by_group: 'test_group', comment: 'does it look ok?')
-      # trigger the send job
       SendEventEmailsJob.new.perform
     end
 
     email = ActionMailer::Base.deliveries.last
 
-    assert_equal "Request #{myid} requires review (submit Apache/BranchPack)", email.subject
+    assert_equal "Request #{req.number} requires review (submit Apache/BranchPack)", email.subject
     assert_equal ['test_group@testsuite.org'], email.to
   end
 


### PR DESCRIPTION
In `source_access_check!` method in `BsRequestAction` a user is required to know if he has access to the source.

Fix #5351.

Co-authored-by: David Kang <dkang@suse.com>