### PR TITLE
Fix undefined local variables in package build status

### DIFF
--- a/src/api/app/views/webui2/webui/package/_buildstatus.html.haml
+++ b/src/api/app/views/webui2/webui/package/_buildstatus.html.haml
@@ -13,9 +13,9 @@
       - if results.present?
         - previous_repo = nil
         - results.each do |result|
+          - repository_name = result.repository.tr('.', '_')
+          - expanded = !collapsed_repositories.include?(repository_name)
           - if result.repository != previous_repo
-            - repository_name = result.repository.tr('.', '_')
-            - expanded = !collapsed_repositories.include?(repository_name)
             .row.py-1.bg-light
               .col{ title: result.repository.to_s }
                 = link_to(word_break(result.repository, 22),


### PR DESCRIPTION
The local variables are used outside the scope of the `if` statement in which they were defined.

Fixes #6957