### PR TITLE
Set empty state for Monitor page with Bootstrap

### DIFF
--- a/src/api/app/controllers/webui/project_controller.rb
+++ b/src/api/app/controllers/webui/project_controller.rb
@@ -383,6 +383,7 @@ class Webui::ProjectController < Webui::WebuiController
   end
 
   def monitor
+    switch_to_webui2
     unless (buildresult = monitor_buildresult)
       @buildresult_unavailable = true
       return
@@ -396,8 +397,6 @@ class Webui::ProjectController < Webui::WebuiController
       repohash[repo] = arch_hash.keys.sort!
     end
     @repoarray = repohash.sort
-
-    switch_to_webui2
   end
 
   def toggle_watch

--- a/src/api/app/views/webui2/webui/project/monitor.html.haml
+++ b/src/api/app/views/webui2/webui/project/monitor.html.haml
@@ -3,36 +3,40 @@
 .card.mb-3
   = render partial: 'tabs', locals: { project: @project }
   .card-body#project-monitor
-    = render partial: 'monitor_control',
-      locals: { project: @project, activate_client_search: @activate_client_search,
-      status: @avail_status_values, repositories: @avail_repo_values, architectures: @avail_arch_values,
-      repository_filter: @repo_filter, architecture_filter: @arch_filter, status_filter: @status_filter }
-    .row.mt-4
-      .col-md-12.obs-dataTable.invisible
-        %table.table.table-sm.table-striped.table-bordered.text-nowrap#project-monitor-table
-          %thead.header
-            %tr
-              %th
-              - @repoarray.each do |repo, archlist|
-                - next if archlist.empty?
-                %th.text-center{ colspan: archlist.length }
-                  = repo
-            %tr
-              %th
-              - @repoarray.each do |repo, archlist|
-                - archlist.each do |arch|
-                  %th.text-center
-                    = webui2_repository_status_icon(status: @repostatushash[repo][arch], html_class: 'fa-xs mr-1')
-                    = arch
-          %tbody
-            - @packagenames.each do |packname|
+
+    - if @buildresult_unavailable
+      %p Unavailable Build Results.
+    - else
+      = render partial: 'monitor_control',
+        locals: { project: @project, activate_client_search: @activate_client_search,
+        status: @avail_status_values, repositories: @avail_repo_values, architectures: @avail_arch_values,
+        repository_filter: @repo_filter, architecture_filter: @arch_filter, status_filter: @status_filter }
+      .row.mt-4
+        .col-md-12.obs-dataTable.invisible
+          %table.table.table-sm.table-striped.table-bordered.text-nowrap#project-monitor-table
+            %thead.header
               %tr
-                %td
-                  = link_to word_break(packname, 40), controller: :package, action: :show, package: packname, project: @project.to_s
+                %th
+                - @repoarray.each do |repo, archlist|
+                  - next if archlist.empty?
+                  %th.text-center{ colspan: archlist.length }
+                    = repo
+              %tr
+                %th
                 - @repoarray.each do |repo, archlist|
                   - archlist.each do |arch|
-                    %td.text-center
-                      = webui2_arch_repo_table_cell(repo, arch, packname, nil, false)
+                    %th.text-center
+                      = webui2_repository_status_icon(status: @repostatushash[repo][arch], html_class: 'fa-xs mr-1')
+                      = arch
+            %tbody
+              - @packagenames.each do |packname|
+                %tr
+                  %td
+                    = link_to word_break(packname, 40), controller: :package, action: :show, package: packname, project: @project.to_s
+                  - @repoarray.each do |repo, archlist|
+                    - archlist.each do |arch|
+                      %td.text-center
+                        = webui2_arch_repo_table_cell(repo, arch, packname, nil, false)
 
-- content_for :ready_function do
-  setupProjectMonitor();
+      - content_for :ready_function do
+        setupProjectMonitor();


### PR DESCRIPTION
The page didn't use Bootstrap when the table was empty. Now it uses
Bootstrap and informs that build results are not available.

Co-authored-by: Ana María Martínez Gómez <anamaria@martinezgomez.name>