### PR TITLE
Revert "Add colorful syntax in md code block"

### DIFF
--- a/src/api/Gemfile
+++ b/src/api/Gemfile
@@ -26,7 +26,6 @@ gem 'haml-rails'
 # to avoid tilt downgrade
 gem 'tilt', '>= 1.4.1'
 # to use markdown in the comment system
-gem 'coderay'
 gem 'redcarpet'
 # for nested attribute forms
 gem 'cocoon'

--- a/src/api/Gemfile.lock
+++ b/src/api/Gemfile.lock
@@ -473,7 +473,6 @@ DEPENDENCIES
   cocoon
   codecov
   codemirror-rails
-  coderay
   coffee-rails
   colorize
   coveralls

--- a/src/api/lib/obsapi/markdown_renderer.rb
+++ b/src/api/lib/obsapi/markdown_renderer.rb
@@ -8,11 +8,6 @@ module OBSApi
       { host: ::Configuration.first.obs_url }
     end
 
-    def block_code(code, language)
-      language ||= :plaintext
-      CodeRay.scan(code, language).div
-    end
-
     def preprocess(fulldoc)
       # request#12345 links
       fulldoc.gsub!(/(sr|req|request)#(\d+)/i) { |s| "[#{s}](#{request_show_url(number: Regexp.last_match(2))})" }

--- a/src/api/spec/helpers/webui/markdown_helper_spec.rb
+++ b/src/api/spec/helpers/webui/markdown_helper_spec.rb
@@ -14,12 +14,6 @@ RSpec.describe Webui::MarkdownHelper do
       )
     end
 
-    it 'applies code syntactical color on defining language' do
-      expect(render_as_markdown("```ruby\n #comment\n ```")).to include(
-        '<span style="color:#777">#comment</span>'
-      )
-    end
-
     it 'does not crash due to invalid URIs' do
       expect(render_as_markdown("anbox[400000+22d000]\r\n(the number)")).to eq(
         "<p>anbox<a href='the number'>400000+22d000</a></p>\n"


### PR DESCRIPTION
This reverts commit 82db63b71432f051ed5acf6c9d9fa3bcaec69d62.

Sadly, we're having issues in production with code blocks due to the
changes introduced in this commit. For details, please refer to this
issue: https://github.com/openSUSE/open-build-service/issues/6960

Fix #6960