### PR TITLE
Add alert box for superseded request

### DIFF
--- a/src/api/app/views/webui2/webui/request/_superseded_by_message.html.haml
+++ b/src/api/app/views/webui2/webui/request/_superseded_by_message.html.haml
@@ -1,0 +1,24 @@
+- if superseding.present? && superseded_by.nil? && diff_to_superseded.nil?
+  .alert.alert-secondary{ role: 'alert' }
+    %i.fa.fa-info-circle.text-info
+    This request supersedes:
+    - superseding.each do |bs_request|
+      = link_to("request #{bs_request.number}", request_show_path(number: bs_request.number))
+      = surround('(', ")#{', ' unless bs_request == superseding.last}") do
+        = link_to('Show diff', request_show_path(number: bs_request.superseded_by, diff_to_superseded: bs_request.number))
+- if superseded_by.present?
+  .alert.alert-secondary{ role: 'alert' }
+    %i.fa.fa-info-circle.text-info
+    This request is superseded by
+    = link_to("request #{superseded_by}", request_show_path(number: superseded_by))
+    = surround('(', ')') do
+      = link_to('Show diff', request_show_path(number: superseded_by, diff_to_superseded: number))
+- if diff_to_superseded
+  .alert.alert-secondary{ role: 'alert' }
+    %i.fa.fa-info-circle.text-info
+    You're not reviewing the full diff of
+    = link_to("request #{number}", request_show_path(number: number))
+    , but the diff to the superseded
+    = link_to("request #{diff_to_superseded.number}", request_show_path(number: diff_to_superseded))
+    = surround('(', ')') do
+      = link_to('Show full diff', request_show_path(number: number))

--- a/src/api/app/views/webui2/webui/request/show.html.haml
+++ b/src/api/app/views/webui2/webui/request/show.html.haml
@@ -4,6 +4,10 @@
   = render partial: 'webui2/shared/truncated_diff_hint',
   locals: { path: request_show_path(number: @number, full_diff: true) }
 
+= render partial: 'superseded_by_message', locals: { superseded_by: @bs_request.superseded_by,
+                                                     number: @bs_request.number,
+                                                     diff_to_superseded: @diff_to_superseded,
+                                                     superseding: @bs_request.superseding }
 - @pagetitle = "Request #{@number}"
 .card.mb-3
   .card-header.d-flex.justify-content-between


### PR DESCRIPTION
My only concern with this is that we are repeating the information. As you can see in the screenshot below, we now display twice that the request is superseded. It is once in the alert box and then, once in the side links of the request. I believe this is something we should address when reworking this page more in depth (instead of only migrating and fixing major issues as we agreed upon).

![preview](https://user-images.githubusercontent.com/1102934/52637499-a3a33180-2ecf-11e9-8d64-d8e945d139cd.png)
