### PR TITLE
Provide compat monitor route

### DIFF
--- a/src/api/app/views/webui2/webui/project/_monitor_control.html.haml
+++ b/src/api/app/views/webui2/webui/project/_monitor_control.html.haml
@@ -1,7 +1,6 @@
 .row
   .col-md-12
-    = form_tag(project_monitor_path, method: :get) do
-      = hidden_field_tag :project, project
+    = form_tag(project_monitor_path, project: project, method: :get) do
       = hidden_field_tag :defaults, 0
       %span.dropdown#project-monitor-status-dropdown
         %button.btn.btn-outline-secondary.dropdown-toggle{ data: { toggle: :dropdown }, type: :button }

--- a/src/api/config/routes.rb
+++ b/src/api/config/routes.rb
@@ -143,13 +143,13 @@ OBSApi::Application.routes.draw do
         get 'package/rpmlint_log' => :rpmlint_log, constraints: cons
         get 'package/meta/:project/:package' => :meta, constraints: cons, as: 'package_meta'
         post 'package/save_meta/:project/:package' => :save_meta, constraints: cons, as: 'package_save_meta'
-        # compat route
+        # For backward compatibility
         get 'package/attributes/:project/:package', to: redirect('/attribs/%{project}/%{package}'), constraints: cons
         get 'package/edit/:project/:package' => :edit, constraints: cons, as: :package_edit
-        # compat routes
+        # For backward compatibility
         get 'package/repositories/:project/:package', to: redirect('/repositories/%{project}/%{package}'), constraints: cons
         get 'package/import_spec/:project/:package' => :import_spec, constraints: cons
-        # compat route
+        # For backward compatibility
         get 'package/files/:project/:package' => :show, constraints: cons
       end
     end
@@ -452,7 +452,7 @@ OBSApi::Application.routes.draw do
 
   ### /worker
   get 'worker/_status' => 'worker/status#index', as: :worker_status
-  get 'build/_workerstatus' => 'worker/status#index', as: :build_workerstatus # FIXME3.0: drop this compat route
+  get 'build/_workerstatus' => 'worker/status#index', as: :build_workerstatus # For backward compatibility
   get 'worker/:worker' => 'worker/capability#show'
   post 'worker' => 'worker/command#run'
 

--- a/src/api/config/routes.rb
+++ b/src/api/config/routes.rb
@@ -287,6 +287,12 @@ OBSApi::Application.routes.draw do
       post 'project/remove_person/:project' => :remove_person, constraints: cons
       post 'project/remove_group/:project' => :remove_group, constraints: cons
       get 'project/monitor/:project' => :monitor, constraints: cons, as: 'project_monitor'
+      # For backward compatibility
+      get 'project/monitor', to: redirect { |_path_parameters, request|
+        url_string = request.query_parameters.except(:project).to_param
+        url_string = '?' << url_string unless url_string.empty?
+        "/project/monitor/#{request.query_parameters[:project]}#{url_string}"
+      }, constraints: ->(request) { request.query_parameters['project'].present? }
       # TODO: this should be POST (and the link AJAX)
       get 'project/toggle_watch/:project' => :toggle_watch, constraints: cons, as: 'project_toggle_watch'
       get 'project/clear_failed_comment/:project' => :clear_failed_comment, constraints: cons, as: :clear_failed_comment


### PR DESCRIPTION
The mandatory 'project' parameter for the project monitor page was introduced in f795712.

Routes like `/project/monitor?project=my_project` will now be redirected to `/project/monitor/my_project`, so users can keep the same monitor routes they already had, and will not get an 404 error.

Thanks to @darix for reporting it.

