### PR TITLE
Prevent Faker deprecation warnings from happening

### DIFF
--- a/src/api/spec/factories/kiwi_package.rb
+++ b/src/api/spec/factories/kiwi_package.rb
@@ -6,9 +6,9 @@ FactoryBot.define do
 
     package_group { create(:kiwi_package_group, image: image) }
 
-    name        { Faker::Cat.name }
-    arch        { Faker::Cat.name }
-    replaces    { Faker::Cat.name }
+    name        { Faker::Creature::Cat.name }
+    arch        { Faker::Creature::Cat.name }
+    replaces    { Faker::Creature::Cat.name }
     bootinclude { Faker::Boolean.boolean(0.4) }
     bootdelete  { Faker::Boolean.boolean(0.2) }
   end

--- a/src/api/spec/factories/kiwi_package_group.rb
+++ b/src/api/spec/factories/kiwi_package_group.rb
@@ -3,8 +3,8 @@ FactoryBot.define do
     association :image, factory: :kiwi_image
 
     kiwi_type { Kiwi::PackageGroup.kiwi_types.keys[Faker::Number.between(0, Kiwi::PackageGroup.kiwi_types.keys.length - 1)] }
-    profiles { Faker::Cat.name }
-    pattern_type { Faker::Cat.name }
+    profiles { Faker::Creature::Cat.name }
+    pattern_type { Faker::Creature::Cat.name }
 
     factory :kiwi_package_group_non_empty do
       after(:create) do |group|


### PR DESCRIPTION
These messages are thrown when the rspec test suite is run:

`Faker::Cat.name is deprecated; use Faker::Creature::Cat.name instead. It will be removed on or after 2019-01-01.`