### PR TITLE
Fix Monitor page for long package names

### DIFF
--- a/src/api/app/assets/stylesheets/webui2/datatables.scss
+++ b/src/api/app/assets/stylesheets/webui2/datatables.scss
@@ -24,5 +24,8 @@ table.dataTable.table-sm {
     bottom: 0.3em;
   }
 
-  td { white-space: normal !important; }
+  td { 
+    white-space: normal !important;
+    word-break: break-all;
+  }
 }


### PR DESCRIPTION
The previous CSS only broke the names in the `-`. If a package name didn't have any (or not enough of them), it broke the table layout.

Co-authored-by: @hennevogel 

# Before

![image](https://user-images.githubusercontent.com/16052290/52842649-0da21d80-3100-11e9-9367-ae8f2ea0f57f.png)


# After

![image](https://user-images.githubusercontent.com/16052290/52842631-fc591100-30ff-11e9-9a4c-b13ffc7f923a.png)
