### PR TITLE
Fix decision box tabs header for reviews

### DIFF
--- a/src/api/app/views/webui2/webui/request/show.html.haml
+++ b/src/api/app/views/webui2/webui/request/show.html.haml
@@ -49,7 +49,7 @@
           - @my_open_reviews.each_with_index do |review, index|
             %li.nav-item
               %a.nav-link.text-nowrap{ href: "#review-#{index}", data: { toggle: 'tab' }, role: 'tab' }
-                Review for #{review[:who]}
+                Review for #{reviewer(review)}
       .card-body
         - if @can_handle_request && @show_project_maintainer_hint
           .alert.alert-warning

--- a/src/api/spec/bootstrap/features/webui/requests_spec.rb
+++ b/src/api/spec/bootstrap/features/webui/requests_spec.rb
@@ -142,7 +142,7 @@ RSpec.feature 'Bootstrap_Requests', type: :feature, js: true, vcr: true do
 
         login reviewer
         visit request_show_path(1)
-        click_link("Review for #{submitter}")
+        click_link("Review for #{reviewer}")
         fill_in 'comment', with: 'Ok for the project'
         click_button 'Approve'
         expect(page).to have_text('Ok for the project')


### PR DESCRIPTION
The reviewer could still submit reviews, but it was misleading due to the wrong tab header. About the code changes, we use the same helper as the old UI.

Before:
![before-fix](https://user-images.githubusercontent.com/1102934/52862859-8d4adf00-3136-11e9-97c3-7ccd4c42303c.gif)

After:
![after-fix](https://user-images.githubusercontent.com/1102934/52862867-9045cf80-3136-11e9-8d31-4190d36837a0.gif)