### PR TITLE
Make collapsible text generic and use it for request description

### DIFF
--- a/src/api/app/assets/javascripts/webui2/application.js
+++ b/src/api/app/assets/javascripts/webui2/application.js
@@ -44,4 +44,5 @@
 //= require webui2/staging_workflow.js
 //= require webui2/project.js
 //= require webui2/project_monitor.js
+//= require webui2/collapsible_text
 //= require rails-timeago

--- a/src/api/app/assets/javascripts/webui2/collapsible_text.js
+++ b/src/api/app/assets/javascripts/webui2/collapsible_text.js
@@ -1,0 +1,9 @@
+$(document).ready(function() {
+  $('.obs-collapsible-textbox').on('click', function() {
+    var collapsibleLink = $(this).find('.obs-collapsible-link');
+    var showText = (collapsibleLink.attr('title') === 'Show more' ) ? 'Show less' : 'Show more';
+
+    $(this).find('.obs-collapsible-text, .obs-collapsible-link').toggleClass('obs-collapsed obs-uncollapsed');
+    collapsibleLink.attr('title', showText);
+  });
+});

--- a/src/api/app/assets/javascripts/webui2/request.js
+++ b/src/api/app/assets/javascripts/webui2/request.js
@@ -121,18 +121,3 @@ function requestAddReviewAutocomplete() { // jshint ignore:line
     max: 50
   });
 }
-
-function collapseHistory(parent) { //jshint ignore:line
-  var fullReqDescription = parent.find('#show-full-req-description');
-  parent.find('#req-description').toggleClass('collapsed-history uncollapsed-history');
-  fullReqDescription.toggleClass("collapsed-link uncollapsed-link");
-
-  var showText = (fullReqDescription.attr('title') === 'show more' ) ?  'show less': 'show more';
-  fullReqDescription.attr('title', showText);
-}
-
-function handleCollapseForHistory(origin) {  //jshint ignore:line
-  $('.req-description-box').on('click', origin, function() {
-    collapseHistory($(this).parents('.req-description-box'));
-  });
-}

--- a/src/api/app/assets/stylesheets/webui2/collapsible-text.scss
+++ b/src/api/app/assets/stylesheets/webui2/collapsible-text.scss
@@ -1,7 +1,6 @@
 .obs-collapsible-textbox {
   word-break: break-all;
   white-space: pre-line;
-  font-size: 14px;
   padding-right: 1em;
 
   .obs-collapsible-text {

--- a/src/api/app/assets/stylesheets/webui2/collapsible-text.scss
+++ b/src/api/app/assets/stylesheets/webui2/collapsible-text.scss
@@ -1,0 +1,28 @@
+.obs-collapsible-textbox {
+  word-break: break-all;
+  white-space: pre-line;
+  font-size: 14px;
+  padding-right: 1em;
+
+  .obs-collapsible-text {
+    &.obs-collapsed {
+      @include collapsedText($lineHeight: 1.2em, $lineCount: 3);
+    }
+
+    &.obs-uncollapsed {
+      @include uncollapsedText($lineHeight: 1.2em);
+    }
+  }
+
+  .obs-collapsible-link {
+    @extend .fa;
+
+    &.obs-collapsed:after {
+      content: '\f078';
+    }
+
+    &.obs-uncollapsed:after {
+      content: '\f077';
+    }
+  }
+}

--- a/src/api/app/assets/stylesheets/webui2/requests.scss
+++ b/src/api/app/assets/stylesheets/webui2/requests.scss
@@ -19,21 +19,3 @@
   font-size: 14px;
   padding-right: 1em;
 }
-
-.collapsed-history {
-  @include collapsedText($lineHeight: 1.2em, $lineCount: 3);
-}
-
-.uncollapsed-history {
-  @include uncollapsedText($lineHeight: 1.2em);
-}
-
-.collapsed-link:after {
-  @extend .fa;
-  content: '\f078';
-}
-
-.uncollapsed-link:after {
-  @extend .fa;
-  content: '\f077';
-}

--- a/src/api/app/assets/stylesheets/webui2/webui2.css.scss
+++ b/src/api/app/assets/stylesheets/webui2/webui2.css.scss
@@ -48,6 +48,7 @@
 @import 'pulse';
 @import 'collapse-text';
 @import 'requests';
+@import 'collapsible-text';
 
 html {
     overflow-y: scroll !important;

--- a/src/api/app/views/webui2/webui/request/_request_history.html.haml
+++ b/src/api/app/views/webui2/webui/request/_request_history.html.haml
@@ -7,10 +7,6 @@
 
     %p.m-0.p-0.small created request
 
-    = render partial: 'request_history_description', locals: { text: bs_request.description }
+    = render partial: 'webui/webui/collapsible_text', locals: { text: bs_request.description, threshold: 100 }
 
 = render partial: 'request_history_element', collection: history, as: :element
-
-= content_for :ready_function do
-  handleCollapseForHistory('#req-description');
-  handleCollapseForHistory('#show-full-req-description');

--- a/src/api/app/views/webui2/webui/request/_request_history_description.html.haml
+++ b/src/api/app/views/webui2/webui/request/_request_history_description.html.haml
@@ -1,8 +1,0 @@
-- if text.present?
-  .req-description-box
-    - if text.length > 100
-      .collapsed-history#req-description
-        = simple_format(text, class: 'm-0 p-0 small')
-      %a.collapsed-link.text-center.d-block#show-full-req-description{ title: 'show more' }
-    - else
-      = simple_format(text, class: 'm-0 p-0 small')

--- a/src/api/app/views/webui2/webui/request/_request_history_element.html.haml
+++ b/src/api/app/views/webui2/webui/request/_request_history_element.html.haml
@@ -8,4 +8,4 @@
       = link_to(element.description, request_show_path(element.description_extension))
     - else
       = simple_format(element.description, class: 'm-0 p-0 small')
-    = render partial: 'request_history_description', locals: { text: element.comment }
+    = render partial: 'webui/webui/collapsible_text', locals: { text: element.comment, threshold: 100 }

--- a/src/api/app/views/webui2/webui/request/_show_overview.html.haml
+++ b/src/api/app/views/webui2/webui/request/_show_overview.html.haml
@@ -2,10 +2,10 @@
   %p Request #{bs_request.number} (#{bs_request.state})
 
 #description-text
-  - if bs_request.description.blank?
-    %i No description set
+  - if bs_request.description.present?
+    = render partial: 'webui/webui/collapsible_text', locals: { text: bs_request.description, threshold: 500 }
   - else
-    = description_wrapper(toggle_sliced_text(bs_request.description))
+    %i No description set
 - if can_add_reviews
   %p
     = link_to(add_reviewer_dialog_path(number: bs_request.number),

--- a/src/api/app/views/webui2/webui/webui/_collapsible_text.html.haml
+++ b/src/api/app/views/webui2/webui/webui/_collapsible_text.html.haml
@@ -2,7 +2,7 @@
   .obs-collapsible-textbox
     - if text.length > threshold
       .obs-collapsible-text.obs-collapsed
-        = simple_format(text, class: 'm-0 p-0 small')
+        = simple_format(text, class: 'm-0 p-0')
       %a.obs-collapsible-link.obs-collapsed.text-center.d-block{ title: 'Show more' }
     - else
-      = simple_format(text, class: 'm-0 p-0 small')
+      = simple_format(text, class: 'm-0 p-0')

--- a/src/api/app/views/webui2/webui/webui/_collapsible_text.html.haml
+++ b/src/api/app/views/webui2/webui/webui/_collapsible_text.html.haml
@@ -1,0 +1,8 @@
+- if text.present?
+  .obs-collapsible-textbox
+    - if text.length > threshold
+      .obs-collapsible-text.obs-collapsed
+        = simple_format(text, class: 'm-0 p-0 small')
+      %a.obs-collapsible-link.obs-collapsed.text-center.d-block{ title: 'Show more' }
+    - else
+      = simple_format(text, class: 'm-0 p-0 small')

--- a/src/api/spec/bootstrap/features/webui/requests_spec.rb
+++ b/src/api/spec/bootstrap/features/webui/requests_spec.rb
@@ -13,11 +13,10 @@ RSpec.feature 'Bootstrap_Requests', type: :feature, js: true, vcr: true do
     scenario 'expanding a text field' do
       visit request_show_path(bs_request)
       within(element) do
-        # FIXME: find a better way to check if the content is collapsed or not
-        find(id: 'show-full-req-description').click
-        expect(find(id: 'req-description').native.css_value('max-height')).to eq('none')
-        find(id: 'show-full-req-description').click
-        expect(find(id: 'req-description').native.css_value('max-height')).not_to eq('none')
+        find('a[title="Show more"]').click
+        expect(page).to have_css('div.obs-uncollapsed')
+        find('a[title="Show less"]').click
+        expect(page).to have_css('div.obs-collapsed')
       end
     end
   end
@@ -57,7 +56,7 @@ RSpec.feature 'Bootstrap_Requests', type: :feature, js: true, vcr: true do
 
     describe 'request history entries' do
       it_behaves_like 'expandable element' do
-        let(:element) { '.req-description-box' }
+        let(:element) { '.media-body > .obs-collapsible-textbox' }
       end
     end
   end


### PR DESCRIPTION
* Make collapsible text generic so we can use it elsewhere.
* Make request description collapsible.
* Update font size of collapsed text. It's was to small (much smaller than the rest of the page).