### PR TITLE
Fix setting the request number in truncated_diff_hint partial

### DIFF
--- a/src/api/app/views/webui/shared/_truncated_diff_hint.html.erb
+++ b/src/api/app/views/webui/shared/_truncated_diff_hint.html.erb
@@ -3,7 +3,7 @@
     We truncated the diff of some files because they were too big. If you want to see the full diff for
     every file,
     <% if type == :request %>
-      <%= link_to 'click here', request_show_path(number: @number, full_diff: true) %>.
+      <%= link_to 'click here', request_show_path(number: @bs_request.number, full_diff: true) %>.
     <% elsif type == :package %>
       <%= link_to 'click here', package_rdiff_path(project: @project, package: @package, linkrev: @linkrev, rev: @rev, full_diff: true) %>.
     <% end %>


### PR DESCRIPTION
This broke when cleaning up the request webui_info hash
in 4abca1854f8d8d2a73bd353b7269c93c86c560c1.


