### PR TITLE
Make all of the request history "small"

### DIFF
--- a/src/api/app/views/webui2/webui/request/_request_history.html.haml
+++ b/src/api/app/views/webui2/webui/request/_request_history.html.haml
@@ -5,7 +5,7 @@
     %h6.mt-0.mb-1
       #{bs_request.creator} (#{fuzzy_time(bs_request.created_at)})
 
-    %p.m-0.p-0.small created request
+    %p.m-0.p-0 created request
 
     = render partial: 'webui/webui/collapsible_text', locals: { text: bs_request.description, threshold: 100 }
 

--- a/src/api/app/views/webui2/webui/request/show.html.haml
+++ b/src/api/app/views/webui2/webui/request/show.html.haml
@@ -70,7 +70,7 @@
       .card-header.d-flex.justify-content-between
         %h5
           Request History
-      .card-body
+      .card-body.small
         = render partial: 'request_history', locals: { bs_request: @bs_request, history: @history }
 
 - unless User.current.is_nobody?


### PR DESCRIPTION
Commit 0c791a7499eb4ea964ca828 removed the 'small' class from the
collapsible text so that it uses the default size. Though in the
request history tab we want to have a smaller text size to give it
less emphasize.



<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md
-->
![2019-02-19_10-19](https://user-images.githubusercontent.com/968949/53003696-d6997800-342f-11e9-8e93-74732d101968.png)
