### PR TITLE
Migrate configuration page to Bootstrap

### DIFF
--- a/src/api/app/controllers/webui/configuration_controller.rb
+++ b/src/api/app/controllers/webui/configuration_controller.rb
@@ -27,7 +27,7 @@ class Webui::ConfigurationController < Webui::WebuiController
   def update
     respond_to do |format|
       if @configuration.update(configuration_params)
-        format.html { redirect_to configuration_path, notice: 'Configuration was successfully updated.' }
+        format.html { redirect_to configuration_path, success: 'Configuration was successfully updated.' }
       else
         format.html do
           redirect_back(fallback_location: root_path, error: "Configuration can't be saved: #{@configuration.errors.full_messages.to_sentence}")

--- a/src/api/app/views/webui2/webui/configuration/index.html.haml
+++ b/src/api/app/views/webui2/webui/configuration/index.html.haml
@@ -4,3 +4,39 @@
 .card.mb-3
   = render partial: 'tabs'
   .card-body
+    %h3.mb-4 Configure your Open Build Service instance
+    = form_for(@configuration, url: { action: :update }) do |f|
+      .h5 Frontpage Greeting
+      %p.text-muted
+        Change the text that is displayed as greeting on the frontpage
+      .form-group
+        = f.label :title
+        %abbr.text-danger{ title: 'required' } *
+        = f.text_field :title, required: true, autofocus: true, class: 'form-control'
+      .form-group
+        = f.label :description
+        %abbr.text-danger{ title: 'required' } *
+        ~ f.text_area :description, rows: 7, required: true, class: 'form-control'
+
+      .h5.mt-4 Base Configuration
+      %p.text-muted
+        %i.fas.fa-exclamation-triangle.text-warning
+        Backend restart is needed after a change here.
+      .form-group
+        = f.label :name
+        %abbr.text-danger{ title: 'required' } *
+        = f.text_field :name, required: true, class: 'form-control'
+        %small.text-muted
+          The instance name which gets generated into each package. Short string only, no white spaces recommended.
+      .form-group
+        = f.label :unlisted_projects_filter_description
+        = f.text_field :unlisted_projects_filter_description, class: 'form-control'
+        %small.text-muted
+          The description that will appear in projects list for explaining the exclusion filter.
+      .form-group
+        = f.label :unlisted_projects_filter
+        = f.text_field :unlisted_projects_filter, class: 'form-control'
+        %small.text-muted
+          The exclusion filter itself. Is a Regular Expression (eg: ^home:.*)
+
+      = f.submit 'Update', class: 'btn btn-primary'

--- a/src/api/spec/controllers/webui/configuration_controller_spec.rb
+++ b/src/api/spec/controllers/webui/configuration_controller_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe Webui::ConfigurationController do
       end
 
       it { expect(response).to redirect_to(configuration_path) }
-      it { expect(flash[:notice]).to eq('Configuration was successfully updated.') }
+      it { expect(flash[:success]).to eq('Configuration was successfully updated.') }
       it { expect(::Configuration.first.name).to eq('obs') }
       it { expect(::Configuration.first.title).to eq('OBS') }
       it { expect(::Configuration.first.description).to eq('something') }


### PR DESCRIPTION
We migrate the configuration page to Bootstrap.


![screenshot_2019-02-21 configuration - open build service](https://user-images.githubusercontent.com/1212806/53160296-ec41a580-35c7-11e9-97f1-6530b24a5516.png)

