### PR TITLE
Make flash messages stick at the top of the viewpoint

### DIFF
--- a/src/api/app/assets/stylesheets/webui2/flash.scss
+++ b/src/api/app/assets/stylesheets/webui2/flash.scss
@@ -1,0 +1,4 @@
+#flash.sticky-top {
+  top: 1rem;
+  z-index: 1030;
+}

--- a/src/api/app/assets/stylesheets/webui2/flash.scss
+++ b/src/api/app/assets/stylesheets/webui2/flash.scss
@@ -2,3 +2,35 @@
   top: 1rem;
   z-index: 1030;
 }
+
+.alert-success {
+  @extend .alert-success;
+
+  i.fas {
+    @extend .fa-check-circle;
+  }
+}
+
+.alert-error {
+  @extend .alert-danger;
+
+  i.fas {
+    @extend .fa-exclamation-circle;
+  }
+}
+
+.alert-alert {
+  @extend .alert-warning;
+
+  i.fas {
+    @extend .fa-exclamation-triangle;
+  }
+}
+
+.alert-notice {
+  @extend .alert-info;
+
+  i.fas {
+    @extend .fa-info-circle;
+  }
+}

--- a/src/api/app/assets/stylesheets/webui2/tabs-component.scss
+++ b/src/api/app/assets/stylesheets/webui2/tabs-component.scss
@@ -18,6 +18,6 @@ ul.nav.nav-tabs li.nav-item {
   }
 
   .dropdown-menu {
-    z-index: 1021;
+    z-index: 1050;
   }
 }

--- a/src/api/app/assets/stylesheets/webui2/watchlist.scss
+++ b/src/api/app/assets/stylesheets/webui2/watchlist.scss
@@ -1,7 +1,7 @@
 #global-navigation {
   ul {
     .dropdown-menu.dropdown-menu-right {
-      z-index: 1021;
+      z-index: 1050;
     }
   }
 }

--- a/src/api/app/assets/stylesheets/webui2/webui2.css.scss
+++ b/src/api/app/assets/stylesheets/webui2/webui2.css.scss
@@ -50,6 +50,7 @@
 @import 'requests';
 @import 'collapsible-text';
 @import 'architectures';
+@import 'flash';
 
 html {
     overflow-y: scroll !important;

--- a/src/api/app/views/layouts/webui2/_flash.html.haml
+++ b/src/api/app/views/layouts/webui2/_flash.html.haml
@@ -18,7 +18,7 @@
         .alert.alert-dismissible.fade.show{ class: "alert-#{flash_header}" }
           %i.fas{ class: "fa-#{flash_icon}" }
           = flash_content(flash[flash_type])
-          = link_to('more info', '#', class: 'btn-more alert-link') if @more_info
+          = link_to('more info', 'javascript:void(0)', class: 'btn-more alert-link') if @more_info
           - if @more_info
             .more_info.d-none
               %div{ class: flash_header }

--- a/src/api/app/views/layouts/webui2/_flash.html.haml
+++ b/src/api/app/views/layouts/webui2/_flash.html.haml
@@ -1,29 +1,14 @@
 .row.justify-content-center
   .col-12
-    - [:success, :error, :alert, :notice].each do |flash_type|
-      - if (flash[flash_type] && !flash[flash_type].empty?)
-        - case flash_type
-        - when :error
-          - flash_icon = 'exclamation-circle'
-          - flash_header = 'danger'
-        - when :alert
-          - flash_icon = 'exclamation-triangle'
-          - flash_header = 'warning'
-        - when :success
-          - flash_icon = 'check-circle'
-          - flash_header = 'success'
-        - when :notice
-          - flash_icon = 'info-circle'
-          - flash_header = 'info'
-        .alert.alert-dismissible.fade.show{ class: "alert-#{flash_header}" }
-          %i.fas{ class: "fa-#{flash_icon}" }
-          = flash_content(flash[flash_type])
-          = link_to('more info', 'javascript:void(0)', class: 'btn-more alert-link') if @more_info
-          - if @more_info
-            .more_info.d-none
-              %div{ class: flash_header }
-              .more-info-content
-                = simple_format @more_info.gsub(/\\n/, '<br \>')
-          %button.close{ type: "button", "data-dismiss": "alert", "aria-label": "Close" }
-            %span{ "aria-hidden": "true" }
-              &times;
+    - flash.each do |type, message|
+      .alert.alert-dismissible.fade.show{ class: "alert-#{type}" }
+        %i.fas
+        = flash_content(message)
+        - if @more_info
+          = link_to('more info', 'javascript:void(0)', class: 'btn-more alert-link')
+          .more_info.d-none
+            .more-info-content
+              = simple_format(@more_info)
+        %button.close{ type: 'button', 'data-dismiss': 'alert', 'aria-label': 'Close' }
+          %span{ 'aria-hidden': 'true' }
+            &times;

--- a/src/api/app/views/layouts/webui2/webui.html.haml
+++ b/src/api/app/views/layouts/webui2/webui.html.haml
@@ -37,7 +37,7 @@
           = render partial: "layouts/webui2/breadcrumbs"
         .col-auto.ml-auto#personal-navigation
           = render partial: "layouts/webui2/personal_navigation"
-    .container#flash
+    .container.sticky-top#flash
       = render partial: "layouts/webui2/flash", object: flash
     .modal.fade#modal{ tabindex: '-1', role: 'dialog', aria: { labelledby: 'modalLabel', hidden: true } }
     .container.flex-grow#content


### PR DESCRIPTION
... and cleanup the flash partial a bit.

When the scrollbar is at the top of the page:
![2019-02-22_10-58](https://user-images.githubusercontent.com/968949/53331549-756f1a00-38f1-11e9-9519-42f7dc91f3f7.png)

After scrolling down:
![2019-02-22_10-59](https://user-images.githubusercontent.com/968949/53236603-fda4b380-3694-11e9-9dea-460e53ebd238.png)

I increased the z-index of the flash. So all elements except the watchlist are currently in the back of the flash, when they overlap.

