### PR TITLE
Migrate and re-design architectures view for bootstrap UI

### DIFF
--- a/src/api/app/assets/stylesheets/webui2/architectures.scss
+++ b/src/api/app/assets/stylesheets/webui2/architectures.scss
@@ -1,0 +1,5 @@
+#architectures {
+  .custom-control-inline {
+    width: 10rem;
+  }
+}

--- a/src/api/app/assets/stylesheets/webui2/webui2.css.scss
+++ b/src/api/app/assets/stylesheets/webui2/webui2.css.scss
@@ -49,6 +49,7 @@
 @import 'collapse-text';
 @import 'requests';
 @import 'collapsible-text';
+@import 'architectures';
 
 html {
     overflow-y: scroll !important;

--- a/src/api/app/controllers/webui/architectures_controller.rb
+++ b/src/api/app/controllers/webui/architectures_controller.rb
@@ -9,6 +9,24 @@ class Webui::ArchitecturesController < Webui::WebuiController
     switch_to_webui2 if Rails.env.development? || Rails.env.test?
   end
 
+  def update
+    architecture = Architecture.find(params[:id])
+
+    if architecture.update(available: params[:available] == 'true')
+      flash.now[:success] = "Updated architecture '#{architecture.name}'"
+      ::Configuration.write_to_backend
+      status = :ok
+    else
+      flash.now[:error] = "Updating architecture '#{architecture.name}' failed: " \
+        "#{architecture.errors.full_messages.to_sentence}"
+      status = :unprocessable_entity
+    end
+
+    respond_to do |format|
+      format.js { render 'webui2/webui/architectures/update', status: status }
+    end
+  end
+
   def bulk_update_availability
     result = ::ArchitecturesControllerService::ArchitectureUpdater.new(params).call
 
@@ -16,8 +34,16 @@ class Webui::ArchitecturesController < Webui::WebuiController
 
     respond_to do |format|
       if result.valid?
+        format.js do
+          flash.now[:success] = 'Updated availability for all architectures.'
+          render 'webui2/webui/architectures/bulk_update_availability'
+        end
         format.html { redirect_to architectures_path, notice: 'Architectures successfully updated.' }
       else
+        format.js do
+          flash.now[:error] = 'Updating architecture availability failed.'
+          render 'webui2/webui/architectures/bulk_update_availability', status: :unprocessable_entity
+        end
         format.html { redirect_back(fallback_location: root_path, error: 'Not all architectures could be saved') }
       end
     end

--- a/src/api/app/controllers/webui/architectures_controller.rb
+++ b/src/api/app/controllers/webui/architectures_controller.rb
@@ -30,10 +30,9 @@ class Webui::ArchitecturesController < Webui::WebuiController
   def bulk_update_availability
     result = ::ArchitecturesControllerService::ArchitectureUpdater.new(params).call
 
-    ::Configuration.write_to_backend
-
     respond_to do |format|
       if result.valid?
+        ::Configuration.write_to_backend
         format.js do
           flash.now[:success] = 'Updated availability for all architectures.'
           render 'webui2/webui/architectures/bulk_update_availability'

--- a/src/api/app/services/architectures_controller_service/architecture_updater.rb
+++ b/src/api/app/services/architectures_controller_service/architecture_updater.rb
@@ -2,10 +2,14 @@ module ArchitecturesControllerService
   class ArchitectureUpdater
     def initialize(params)
       @archs = params.require(:archs).permit!
-      @all_valid = false
+      @all_valid = []
     end
 
     def call
+      if @archs[:all]
+        @all_valid << Architecture.all.update(available: @archs[:all])
+        return self
+      end
       @all_valid = @archs.to_h.map do |name, value|
         arch = Architecture.find_by(name: name)
         arch.available = value

--- a/src/api/app/views/webui2/webui/architectures/bulk_update_availability.js.erb
+++ b/src/api/app/views/webui2/webui/architectures/bulk_update_availability.js.erb
@@ -1,0 +1,1 @@
+$('#flash').html("<%= escape_javascript(render(layout: false, partial: 'layouts/webui2/flash', object: flash)) %>");

--- a/src/api/app/views/webui2/webui/architectures/index.html.haml
+++ b/src/api/app/views/webui2/webui/architectures/index.html.haml
@@ -3,4 +3,31 @@
 
 .card.mb-3
   = render partial: 'webui/configuration/tabs'
-  .card-body
+  .card-body#architectures
+    %h3
+      Architecture Availability
+    %p
+      Toggle the availability of architectures.
+    .form-group
+      = button_tag('All', type: 'submit', class: 'btn btn-sm btn-outline-primary filter-button mr-1', value: true,
+        data: { remote: true, url: bulk_update_availability_path(archs: { all: true }), method: :patch })
+      = button_tag('None', type: 'submit', class: 'btn btn-sm btn-outline-primary filter-button mr-1', value: false,
+        data: { remote: true, url: bulk_update_availability_path(archs: { all: false }), method: :patch })
+      %i.fas.fa-spinner.invisible
+    .form-group.d-flex.flex-wrap
+      - @architectures.each do |arch|
+        .custom-control.custom-checkbox.custom-control-inline
+          = check_box_tag('available', true, arch.available, class: 'custom-control-input', id: "arch-#{arch}",
+            data: { remote: true, url: architecture_path(arch), method: :patch })
+          %label.custom-control-label.pr-2{ for: "arch-#{arch}" }
+            = arch.name
+          %i.fas.fa-spinner.invisible
+
+- content_for :ready_function do
+  :plain
+    $('#architectures').on('ajax:before ajax:complete', '.custom-control-input, .filter-button', function() {
+      $(this).siblings('i.fa-spinner').toggleClass('fa-spin invisible');
+    });
+    $('.filter-button').on('ajax:success', function() {
+      $('#architectures').find('input').prop('checked', $(this).val() === 'true');
+    });

--- a/src/api/app/views/webui2/webui/architectures/update.js.erb
+++ b/src/api/app/views/webui2/webui/architectures/update.js.erb
@@ -1,0 +1,1 @@
+$('#flash').html("<%= escape_javascript(render(layout: false, partial: 'layouts/webui2/flash', object: flash)) %>");

--- a/src/api/config/routes.rb
+++ b/src/api/config/routes.rb
@@ -88,9 +88,10 @@ OBSApi::Application.routes.draw do
     end
 
     controller 'webui/architectures' do
-      get 'architectures' => :index
-      patch 'architectures/bulk_update_availability' => :bulk_update_availability, as: 'bulk_update_availability'
+      patch 'architectures/bulk_update_availability' => :bulk_update_availability, as: :bulk_update_availability
     end
+
+    resources :architectures, only: [:index, :update], controller: 'webui/architectures'
 
     controller 'webui/monitor' do
       get 'monitor/' => :index

--- a/src/api/spec/controllers/webui/architectures_controller_spec.rb
+++ b/src/api/spec/controllers/webui/architectures_controller_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe Webui::ArchitecturesController do
+RSpec.describe Webui::ArchitecturesController, js: true do
   let(:admin_user) { create(:admin_user) }
 
   before do
@@ -15,6 +15,34 @@ RSpec.describe Webui::ArchitecturesController do
     end
 
     it { expect(assigns(:architectures)).to match_array(Architecture.all) }
+  end
+
+  describe 'PATCH #update' do
+    let(:arch) { Architecture.find_by(name: 'x86_64') }
+
+    context 'enabling availability' do
+      before do
+        arch.update!(available: false)
+      end
+
+      subject! { patch :update, params: { id: arch.id, available: 'true', format: :js } }
+
+      it { is_expected.to have_http_status(:success) }
+      it { expect(flash[:success]).to eq("Updated architecture 'x86_64'") }
+      it { expect(arch.reload).to have_attributes(available: true) }
+    end
+
+    context 'disabling availability' do
+      before do
+        arch.update!(available: true)
+      end
+
+      subject! { patch :update, params: { id: arch.id, available: 'false', format: :js } }
+
+      it { is_expected.to have_http_status(:success) }
+      it { expect(flash[:success]).to eq("Updated architecture 'x86_64'") }
+      it { expect(arch.reload).to have_attributes(available: false) }
+    end
   end
 
   describe 'POST #bulk_update_availability' do


### PR DESCRIPTION
Now:

![2019-02-22_16-39](https://user-images.githubusercontent.com/968949/53252945-65bcbf00-36c0-11e9-98cb-b01f1fc6bffc.png)


Before:

![screenshot-2019-2-22 architecture configuration - open build service](https://user-images.githubusercontent.com/968949/53252648-aff17080-36bf-11e9-883f-309a7e1d30f1.png)




Co-authored-by: Eduardo Navarro <enavarro@suse.com>