### PR TITLE
Migrate interconnect to Bootstrap

### DIFF
--- a/src/api/app/assets/javascripts/webui2/application.js
+++ b/src/api/app/assets/javascripts/webui2/application.js
@@ -46,4 +46,5 @@
 //= require webui2/project.js
 //= require webui2/project_monitor.js
 //= require webui2/collapsible_text
+//= require webui2/interconnect
 //= require rails-timeago

--- a/src/api/app/assets/javascripts/webui2/interconnect.js
+++ b/src/api/app/assets/javascripts/webui2/interconnect.js
@@ -1,0 +1,16 @@
+function projectLink(projectName) {
+ return $('<a>', { href: '/project/show/' + projectName, class: 'small mb-0', text: projectName });
+}
+
+function initInterconnect() {// jshint ignore:line
+  $(document).on('ajax:success', 'button.interconnect', function(){
+    var $parent = $(this).parents('.list-group-item');
+    $parent.find('h5').removeClass('text-muted');
+    $parent.find('.connected').removeClass('d-none');
+    $parent.find('.interconnect-info i').addClass('text-secondary');
+    var linkText = $parent.find('.interconnect-info small').text();
+    $parent.find('.interconnect-info small').replaceWith(projectLink(linkText));
+    $(this).remove();
+  });
+}
+

--- a/src/api/app/controllers/webui2/interconnects_controller.rb
+++ b/src/api/app/controllers/webui2/interconnects_controller.rb
@@ -1,0 +1,5 @@
+module Webui2::InterconnectsController
+  def webui2_index
+    @interconnect = RemoteProject.new
+  end
+end

--- a/src/api/app/helpers/webui/webui_helper.rb
+++ b/src/api/app/helpers/webui/webui_helper.rb
@@ -398,9 +398,9 @@ module Webui::WebuiHelper
     short + long
   end
 
-  def tab_link(label, path, active = false)
+  def tab_link(label, path, active = false, permit = true)
     html_class = 'nav-link text-nowrap'
-    html_class << ' active' if active || request.path.include?(path)
+    html_class << ' active' if active || (request.path.include?(path) && permit)
 
     link_to(label, path, class: html_class)
   end

--- a/src/api/app/views/webui/interconnects/new.html.haml
+++ b/src/api/app/views/webui/interconnects/new.html.haml
@@ -25,7 +25,7 @@
                             data: { name: 'Packman',
                                     remoteurl: 'https://pmbs-api.links2linux.de/public',
                                     title: 'Packman Build Service PMBS',
-                                    description: 'this instance can be used to access resources from packman.' },
+                                    description: 'This instance can be used to access resources from packman.' },
                             disabled: Project.exists?(name: 'Packman'))
   %h3
     Add custom OBS instance

--- a/src/api/app/views/webui2/webui/interconnects/_interconnect_button.html.haml
+++ b/src/api/app/views/webui2/webui/interconnects/_interconnect_button.html.haml
@@ -1,0 +1,23 @@
+.list-group-item
+  .d-flex.w-100.justify-content-between
+    %h5.mb-1{ class: "#{'text-muted' unless exists}" }= title
+    %small.text-primary.connected{ class: "#{'d-none' unless exists}" } Connected
+    - unless exists
+      - params = "project[name]=#{name}&project[remoteurl]=#{remoteurl}&project[title]=#{title}&project[description]=#{description}"
+      = button_tag data: { url: interconnects_path,
+                           params: params,
+                           remote: true,
+                           disable_with: 'Connecting...',
+                           method: :post },
+                   class: 'btn btn-sm btn-primary interconnect' do
+        Connect
+  .interconnect-info.text-muted
+    %i.fa.fa-cubes.fa-xs{ class: "#{'text-secondary' if exists}" }
+    - if exists
+      = link_to(name, project_show_path(project: name), class: 'small m-0')
+    - else
+      %small= name
+
+  %p.text-muted
+    %i.fas.fa-link.fa-xs
+    %small= remoteurl

--- a/src/api/app/views/webui2/webui/interconnects/_interconnect_modal.html.haml
+++ b/src/api/app/views/webui2/webui/interconnects/_interconnect_modal.html.haml
@@ -1,0 +1,26 @@
+.modal.fade#interconnect-modal{ tabindex: -1, role: 'dialog', aria: { labelledby: 'interconnect-modal-label', hidden: true } }
+  .modal-dialog.modal-dialog-centered{ role: 'document' }
+    .modal-content
+      = form_for(RemoteProject.new, as: :project, url: interconnects_path) do |f|
+        .modal-header
+          %h5.modal-title#interconnect-modal-label Add custom OBS instance
+        .modal-body
+          .form-group
+            = f.label :name, 'Local Project Name'
+            %abbr.text-danger{ title: 'required' } *
+            = f.text_field :name, class: 'form-control', required: true, placeholder: 'Add a name for your project'
+          .form-group
+            = f.label :remote_url, 'Remote OBS api url'
+            %abbr.text-danger{ title: 'required' } *
+            = f.text_field :remoteurl, class: 'form-control', required: true, placeholder: 'Add an OBS api url'
+          .form-group
+            = f.label :title
+            %abbr.text-danger{ title: 'required' } *
+            = f.text_field :title, class: 'form-control', required: true, placeholder: 'Remote OBS instance'
+          .form-group
+            = f.label :description
+            %abbr.text-danger{ title: 'required' } *
+            = f.text_field :description, class: 'form-control', required: true,
+                                         placeholder: 'This project is representing a remote build service instance.'
+        .modal-footer
+          = render partial: 'webui2/shared/dialog_action_buttons'

--- a/src/api/app/views/webui2/webui/interconnects/_tabs.html.haml
+++ b/src/api/app/views/webui2/webui/interconnects/_tabs.html.haml
@@ -1,7 +1,7 @@
 .bg-light
   %ul.nav.nav-tabs.pt-2.px-3.flex-nowrap.collapsible{ 'role': 'tablist' }
     %li.nav-item
-      = tab_link('Configuration', configuration_path)
+      = tab_link('Configuration', configuration_path, false, false)
     %li.nav-item
       = tab_link('Architectures', architectures_path)
     %li.nav-item

--- a/src/api/app/views/webui2/webui/interconnects/create.js.haml
+++ b/src/api/app/views/webui2/webui/interconnects/create.js.haml
@@ -1,0 +1,1 @@
+$('#flash').html("#{escape_javascript(render(layout: false, partial: 'layouts/webui2/flash', object: flash))}");

--- a/src/api/app/views/webui2/webui/interconnects/new.html.haml
+++ b/src/api/app/views/webui2/webui/interconnects/new.html.haml
@@ -1,6 +1,36 @@
-:ruby
-  @pagetitle = 'Interconnect'
+- @pagetitle = 'Interconnect'
 
 .card.mb-3
   = render partial: 'tabs'
   .card-body
+    %h3= @pagetitle
+    %p Connect a remote Open Build Service instance
+    .list-group.my-3
+      = render partial: 'interconnect_button', locals: { name: 'openSUSE.org',
+                                                         remoteurl: 'https://api.opensuse.org/public',
+                                                         title: 'Standard OBS instance at build.opensuse.org',
+                                                         description: 'This instance delivers the default build targets for OBS.',
+                                                         type: 'opensuse',
+                                                         exists: Project.exists?(name: 'openSUSE.org') }
+      = render partial: 'interconnect_button', locals: { name: 'tizen.org',
+                                                         remoteurl: 'https://api.tizen.org/public',
+                                                         title: 'Standard OBS instance at build.opensuse.org',
+                                                         description: 'This instance delivers the default build targets for OBS.',
+                                                         type: 'tizen',
+                                                         exists: Project.exists?(name: 'tizen.org') }
+      = render partial: 'interconnect_button', locals: { name: 'Packman',
+                                                         remoteurl: 'https://pmbs-api.links2linux.de/public',
+                                                         title: 'Packman Build Service PMBS',
+                                                         description: 'This instance can be used to access resources from packman.',
+                                                         type: 'packman',
+                                                         exists: Project.exists?(name: 'Packman') }
+      .list-group-item
+        .d-flex.w-100.justify-content-between
+          %h5.mb-1 Custom OBS instance
+          = button_tag 'Add', class: 'btn btn-sm btn-primary', data: { toggle: 'modal', target: '#interconnect-modal' }
+        %small.text-muted This project is representing a remote build service instance.
+
+= render partial: 'interconnect_modal'
+
+:javascript
+  initInterconnect();

--- a/src/api/config/routes.rb
+++ b/src/api/config/routes.rb
@@ -79,9 +79,7 @@ OBSApi::Application.routes.draw do
       get 'configuration' => :index
       patch 'configuration' => :update
     end
-    scope :configuration do
-      resources :interconnects, only: [:new, :create], controller: 'webui/interconnects'
-    end
+    resources :interconnects, only: [:new, :create], controller: 'webui/interconnects'
 
     controller 'webui/subscriptions' do
       get 'notifications' => :index

--- a/src/api/spec/bootstrap/features/webui/interconnects_spec.rb
+++ b/src/api/spec/bootstrap/features/webui/interconnects_spec.rb
@@ -1,0 +1,30 @@
+require 'browser_helper'
+RSpec.feature 'Interconnects', type: :feature, js: true, vcr: true do
+  let(:admin_user) { create(:admin_user) }
+
+  scenario 'creating openSUSE.org interconnect' do
+    login admin_user
+    visit new_interconnect_path
+
+    click_button('Connect', match: :first)
+
+    expect(page).to have_content("Project 'openSUSE.org' was successfully created.")
+    expect(RemoteProject.exists?(name: 'openSUSE.org')).to be true
+  end
+
+  scenario 'creating custom interconnect' do
+    login admin_user
+    visit new_interconnect_path
+
+    click_button('Add')
+
+    fill_in 'project_name', with: 'custom_packman'
+    fill_in 'project_remoteurl', with: 'https://pmbs-api.links2linux.de/public'
+    fill_in 'project_title', with: 'My custom Build Service Packman'
+    fill_in 'project_description', with: 'This instance can be used to access resources from packman.'
+
+    click_button('Accept')
+    expect(page).to have_content("Project 'custom_packman' was successfully created.")
+    expect(page).to have_current_path(project_show_path(project: 'custom_packman'))
+  end
+end

--- a/src/api/spec/bootstrap/features/webui/repositories_spec.rb
+++ b/src/api/spec/bootstrap/features/webui/repositories_spec.rb
@@ -17,12 +17,9 @@ RSpec.feature 'Bootstrap_Repositories', type: :feature, js: true, vcr: true do
     end
 
     scenario 'add/delete repository from distribution' do
-      # TODO: Enable after migration is finished
-      skip_if_bootstrap
-
       # Create interconnect
       visit(repositories_distributions_path(project: admin_user.home_project))
-      click_button('Save changes')
+      click_button('Connect', match: :first)
 
       visit(repositories_distributions_path(project: admin_user.home_project))
       find("label[for='repo_openSUSE_Tumbleweed']").click

--- a/src/api/spec/cassettes/Interconnects/creating_custom_interconnect.yml
+++ b/src/api/spec/cassettes/Interconnects/creating_custom_interconnect.yml
@@ -1,0 +1,69 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://backend:5352/build/custom_packman/_result?code=unresolvable&view=status
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '56'
+    body:
+      encoding: UTF-8
+      string: '<resultlist state="00000000000000000000000000000000" />
+
+'
+    http_version: 
+  recorded_at: Wed, 06 Mar 2019 13:14:48 GMT
+- request:
+    method: get
+    uri: http://backend:5352/build/custom_packman/_result?view=summary
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '56'
+    body:
+      encoding: UTF-8
+      string: '<resultlist state="00000000000000000000000000000000" />
+
+'
+    http_version: 
+  recorded_at: Wed, 06 Mar 2019 13:14:50 GMT
+recorded_with: VCR 4.0.0

--- a/src/api/spec/controllers/webui/interconnects_controller_spec.rb
+++ b/src/api/spec/controllers/webui/interconnects_controller_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe Webui::InterconnectsController do
       end
 
       it { expect(response).to redirect_to(project_show_path('MyRemoteProject')) }
-      it { expect(flash[:notice]).to eq("Project 'MyRemoteProject' was created successfully") }
+      it { expect(flash[:notice]).to eq("Project 'MyRemoteProject' was successfully created.") }
       it { expect(RemoteProject.exists?(name: 'MyRemoteProject')).to be(true) }
     end
   end


### PR DESCRIPTION
Like the other pages, we also migrate the interconnect page to bootstrap.

![screenshot_2019-02-28 interconnect - open build service](https://user-images.githubusercontent.com/1212806/53571006-1a932800-3b68-11e9-80e8-682287d04a1d.png)

<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md
-->
