### PR TITLE
Add create new user modal to manage user page

### DIFF
--- a/src/api/app/controllers/webui/user_controller.rb
+++ b/src/api/app/controllers/webui/user_controller.rb
@@ -120,7 +120,9 @@ class Webui::UserController < Webui::WebuiController
     end
   end
 
-  def register_user; end
+  def register_user
+    switch_to_webui2 if Rails.env.development? || Rails.env.test?
+  end
 
   def password_dialog
     render_dialog

--- a/src/api/app/views/webui2/shared/_sign_up.html.haml
+++ b/src/api/app/views/webui2/shared/_sign_up.html.haml
@@ -5,15 +5,4 @@
     %p= link_to 'Use this link to Sign Up', CONFIG['proxy_auth_register_page']
 - else
   = form_tag({ controller: 'user', action: 'register', method: :post }, class: 'sign-up', autocomplete: 'off') do
-    .form-group
-      = text_field_tag 'login', nil, placeholder: 'Username', autocomplete: 'off', class: 'form-control'
-    .form-group
-      = text_field_tag 'email', nil, placeholder: 'Email address', autocomplete: 'off', class: 'form-control'
-    .form-group
-      = password_field_tag :password, nil, id: 'pwd', placeholder: 'Enter a password', autocomplete: 'off', class: 'form-control'
-    .form-group
-      = password_field_tag(:password_confirmation, nil, id: 'pwd_confirmation', placeholder: 'Password confirmation', autocomplete: 'off',
-        class: 'form-control')
-    = hidden_field_tag 'register', 'true'
-    .text-center
-      = submit_tag 'Sign Up', class: 'btn btn-primary'
+    = yield

--- a/src/api/app/views/webui2/shared/_sign_up_form_input.html.haml
+++ b/src/api/app/views/webui2/shared/_sign_up_form_input.html.haml
@@ -1,0 +1,14 @@
+.form-group
+  = label_tag 'login', 'Username:'
+  = text_field_tag 'login', nil, placeholder: 'Username', autocomplete: 'off', class: 'form-control'
+.form-group
+  = label_tag 'email', 'Email:'
+  = text_field_tag 'email', nil, placeholder: 'Email address', autocomplete: 'off', class: 'form-control'
+.form-group
+  = label_tag 'password', 'Password:'
+  = password_field_tag :password, nil, id: 'pwd', placeholder: 'Enter a password', autocomplete: 'off', class: 'form-control'
+.form-group
+  = label_tag 'password_confirmation', 'Password confirmation:'
+  = password_field_tag(:password_confirmation, nil, id: 'pwd_confirmation', placeholder: 'Password confirmation', autocomplete: 'off',
+                        class: 'form-control')
+= hidden_field_tag 'register', 'true'

--- a/src/api/app/views/webui2/webui/main/index.html.haml
+++ b/src/api/app/views/webui2/webui/main/index.html.haml
@@ -22,7 +22,11 @@
       .card.mb-3
         %h5.card-header New here? Sign up!
         .card-body
-          = render partial: 'webui2/shared/sign_up'
+          = render 'webui2/shared/sign_up' do
+            = render partial: 'webui2/shared/sign_up_form_input'
+            .text-center
+              = submit_tag 'Sign Up', class: 'btn btn-primary'
+
     = render partial: 'sponsors'
     - if @status_messages.present? || User.current.is_admin?
       = render partial: 'status_messages'

--- a/src/api/app/views/webui2/webui/user/_register_user.html.haml
+++ b/src/api/app/views/webui2/webui/user/_register_user.html.haml
@@ -1,0 +1,11 @@
+.modal.fade#signup-modal{ tabindex: -1, role: 'dialog', aria: { labelledby: 'signup-modal-label', hidden: true } }
+  .modal-dialog.modal-dialog-centered{ role: 'document' }
+    .modal-content
+      .modal-header
+        %h5.modal-title#signup-modal-label
+          Sign Up for an Open Build Service account
+      = render 'webui2/shared/sign_up' do
+        .modal-body
+          = render partial: 'webui2/shared/sign_up_form_input'
+        .modal-footer
+          = render partial: 'webui2/shared/dialog_action_buttons'

--- a/src/api/app/views/webui2/webui/user/index.html.haml
+++ b/src/api/app/views/webui2/webui/user/index.html.haml
@@ -4,3 +4,8 @@
 .card.mb-3
   = render partial: 'webui/configuration/tabs'
   .card-body
+    = link_to('#', data: { toggle: 'modal', target: '#signup-modal' }, title: 'Create new user') do
+      %i.fas.fa-user-plus
+      Create new user
+
+= render partial: 'register_user'


### PR DESCRIPTION
User creation through the manage user page is part of the configuration area, which gets migrated to bootstrap. To be consistent with the other bootstrap views, i moved the signup form to a modal instead of having a seperate view.

![screenshot-2019-2-26 manage users - open build service](https://user-images.githubusercontent.com/22001671/53406743-dca4d100-39ba-11e9-8bed-225c2acb1d33.png)

