### PR TITLE
Fix multiple reviews of the class

### DIFF
--- a/src/api/app/models/bs_request.rb
+++ b/src/api/app/models/bs_request.rb
@@ -707,7 +707,9 @@ class BsRequest < ApplicationRecord
   end
 
   def find_review_for_opts(opts)
-    reviews.reverse.find { |review| review.reviewable_by?(opts) }
+    matching_reviews = reviews.order(id: :desc).select { |review| review.reviewable_by?(opts) }
+    # prefer not yet accepted review
+    matching_reviews.find { |review| review.state != :accepted } || matching_reviews.first
   end
 
   def supersede_request(history_arguments, superseded_opt)

--- a/src/api/app/models/review.rb
+++ b/src/api/app/models/review.rb
@@ -247,7 +247,7 @@ class Review < ApplicationRecord
     arguments = { review: self, comment: comment, user: User.current }
     if new_state == :accepted
       HistoryElement::ReviewAccepted.create(arguments)
-    elsif new_state == :declsined
+    elsif new_state == :declined
       HistoryElement::ReviewDeclined.create(arguments)
     elsif new_state == :new
       HistoryElement::ReviewReopened.create(arguments)

--- a/src/api/spec/models/bs_request_spec.rb
+++ b/src/api/spec/models/bs_request_spec.rb
@@ -177,6 +177,15 @@ RSpec.describe BsRequest, vcr: true do
 
           expect_no_message
         end
+
+        it 'allows multiple reviews by user' do
+          request.addreview(by_user: reviewer, comment: 'does it still look ok?')
+          request.change_review_state(:accepted, by_user: reviewer.login)
+          # one of the reviews is accepted, but the other stays open
+          expect(request.state).to be(:review)
+          request.change_review_state(:accepted, by_user: reviewer.login)
+          expect(request.state).to be(:new)
+        end
       end
     end
   end


### PR DESCRIPTION
If a request contains multiple by_user reviews, they shall be accepted one after the other - but for this we need to ignore accepted reviews
