### PR TITLE
Update Bootstrap styling for user notifications

### DIFF
--- a/src/api/app/controllers/webui/users/subscriptions_controller.rb
+++ b/src/api/app/controllers/webui/users/subscriptions_controller.rb
@@ -21,7 +21,7 @@ class Webui::Users::SubscriptionsController < Webui::WebuiController
     end
 
     subscriptions_form.update!(params[:subscriptions])
-    flash[:notice] = 'Notifications settings updated'
+    flash[:success] = 'Notifications settings updated'
   rescue ActiveRecord::RecordInvalid
     flash[:error] = 'Notifications settings could not be updated due to an error'
   ensure

--- a/src/api/app/views/webui2/webui/subscriptions/_subscriptions_form.html.haml
+++ b/src/api/app/views/webui2/webui/subscriptions/_subscriptions_form.html.haml
@@ -1,16 +1,17 @@
-:ruby
-  i = 0
-
+- i = 0
 - @subscriptions_form.subscriptions_by_event.each do |event_class, subscriptions|
-  %li.list-group-item
-    %h5= event_class.description
-    %p= Event::Base::EXPLANATION_FOR_NOTIFICATIONS[event_class.to_s]
-    - subscriptions.each do |subscription|
-      = fields_for "subscriptions[#{i}]", subscription do |f|
-        .custom-control.custom-checkbox.custom-control-inline
-          = f.check_box :channel, { class: 'custom-control-input', data: { eventtype: subscription.eventtype,
-          receiver_role: subscription.receiver_role } }, EventSubscription.channels.keys[1], EventSubscription.channels.keys[0]
-          = f.label :channel, EventSubscription::RECEIVER_ROLE_TEXTS[subscription.receiver_role], class: 'custom-control-label'
-          = f.hidden_field :eventtype
-          = f.hidden_field :receiver_role
-          - i += 1
+  .card.bg-light.mb-2
+    .card-body
+      %h5.card-title= event_class.description
+      %p.card-text= Event::Base::EXPLANATION_FOR_NOTIFICATIONS[event_class.to_s]
+      .form-inline
+        - subscriptions.each do |subscription|
+          = fields_for "subscriptions[#{i}]", subscription do |f|
+            .form-group.custom-control.custom-checkbox.mr-3
+              = f.check_box :channel, { class: 'custom-control-input',
+                data: { eventtype: subscription.eventtype, receiver_role: subscription.receiver_role } },
+                EventSubscription.channels.keys[1], EventSubscription.channels.keys[0]
+              = f.label :channel, EventSubscription::RECEIVER_ROLE_TEXTS[subscription.receiver_role], class: 'custom-control-label'
+              = f.hidden_field :eventtype
+              = f.hidden_field :receiver_role
+            - i += 1

--- a/src/api/app/views/webui2/webui/users/subscriptions/index.html.haml
+++ b/src/api/app/views/webui2/webui/users/subscriptions/index.html.haml
@@ -1,32 +1,29 @@
 - @pagetitle = 'Notifications'
 
 .card
-  .card-header
+  .card-header.d-flex.justify-content-between
     %h5 Notifications
-  .card-body
-    = form_tag(user_notifications_path, method: :put, id: 'notification_form') do
-      - unless @groups_users.empty?
-        .card-block
-          %h3 Groups
-          %p You will receive emails from the checked groups
-          - @groups_users.each do |group_user|
-            .custom-control.custom-checkbox.custom-control-inline
-              = check_box_tag group_user.group, '1', group_user.email, class: 'custom-control-input', id: "checkbox-#{group_user.group}"
-              = label_tag group_user.group.title, nil, class: 'custom-control-label', for: "checkbox-#{group_user.group}"
-        %br
-      .card-block
-        %h3 Events
-        %p Choose from which events you want to get an email
-        %ul.list-group.list-group-flush
-        #subscriptions-form
-          = render partial: 'webui/subscriptions/subscriptions_form'
-        .card-body
-          = submit_tag 'Update', class: 'btn btn-primary'
-          = link_to('Reset to default', user_notifications_path(default_form: true), remote: true)
+  = form_tag(user_notifications_path, method: :put, id: 'notification_form') do
+    - unless @groups_users.empty?
+      .card-body
+        %h4.card-title Groups
+        %p You will receive emails from the checked groups
+        - @groups_users.each do |group_user|
+          .custom-control.custom-checkbox.custom-control-inline
+            = check_box_tag group_user.group, '1', group_user.email, class: 'custom-control-input', id: "checkbox-#{group_user.group}"
+            = label_tag group_user.group.title, nil, class: 'custom-control-label', for: "checkbox-#{group_user.group}"
+    .card-body
+      %h4.card-title Events
+      %p Choose from which events you want to get an email
+      #subscriptions-form
+        = render partial: 'webui/subscriptions/subscriptions_form'
+    .card-body
+      = submit_tag 'Update', class: 'btn btn-primary'
+      = link_to('Reset to default', user_notifications_path(default_form: true), remote: true)
 
 .card.mt-3
   .card-body
-    %h3 RSS Feed
+    %h4.card-title RSS Feed
     = form_tag(user_rss_token_path, id: 'generate_rss_token_form', method: :post) do
       %p
       - if @user.rss_token


### PR DESCRIPTION
Before:

![screenshot_2019-02-26 user notifications - open build service before](https://user-images.githubusercontent.com/24919/53434225-645c0100-39f6-11e9-9149-35fdcea7edb2.png)

After:

![screenshot_2019-02-27 user notifications - open build service_after_4](https://user-images.githubusercontent.com/24919/53563314-fb8a9b00-3b53-11e9-828e-990915853031.png)
