### PR TITLE
Align 'Your Home' link title with href attribute

### DIFF
--- a/src/api/app/views/webui2/webui/main/_user_proceed-list.html.haml
+++ b/src/api/app/views/webui2/webui/main/_user_proceed-list.html.haml
@@ -1,6 +1,6 @@
 - unless User.current.is_nobody?
   .col
-    = link_to(user_show_path(User.current), class: 'btn btn-default', title: 'Go to your home project') do
+    = link_to(user_show_path(User.current), class: 'btn btn-default', title: 'Go to your home') do
       %i.fas.fa-home.fa-2x.text-dark
       %br
       Your Home


### PR DESCRIPTION
Fixes #6605
