### PR TITLE
Migrate user creation page to bootstrap

### DIFF
--- a/src/api/app/controllers/webui/user_controller.rb
+++ b/src/api/app/controllers/webui/user_controller.rb
@@ -122,7 +122,13 @@ class Webui::UserController < Webui::WebuiController
     end
   end
 
-  def register_user; end
+  def register_user
+    switch_to_webui2 if Rails.env.development? || Rails.env.test?
+  end
+
+  def signup
+    switch_to_webui2 if Rails.env.development? || Rails.env.test?
+  end
 
   def password_dialog
     render_dialog

--- a/src/api/app/views/layouts/webui2/_personal_navigation.html.haml
+++ b/src/api/app/views/layouts/webui2/_personal_navigation.html.haml
@@ -8,7 +8,7 @@
   - else
     - if can_register
       %li.nav-item
-        = link_to('Sign Up', user_register_user_path, class: 'nav-link')
+        = link_to('Sign Up', user_signup_path, class: 'nav-link')
       %li.nav-item.dropdown
         = link_to('#', id: 'login-trigger', class: 'nav-link dropdown-toggle', "data-toggle": "dropdown") do
           Log In

--- a/src/api/app/views/webui2/shared/_sign_up.html.haml
+++ b/src/api/app/views/webui2/shared/_sign_up.html.haml
@@ -6,14 +6,21 @@
 - else
   = form_tag({ controller: 'user', action: 'register', method: :post }, class: 'sign-up', autocomplete: 'off') do
     .form-group
-      = text_field_tag 'login', nil, placeholder: 'Username', autocomplete: 'off', class: 'form-control'
+      = label_tag 'login', 'Username:'
+      %abbr.text-danger{ title: 'required' } *
+      = text_field_tag 'login', nil, placeholder: 'Username', autocomplete: 'off', class: 'form-control', required: true
     .form-group
-      = text_field_tag 'email', nil, placeholder: 'Email address', autocomplete: 'off', class: 'form-control'
+      = label_tag 'email', 'Email:'
+      %abbr.text-danger{ title: 'required' } *
+      = text_field_tag 'email', nil, placeholder: 'Email address', autocomplete: 'off', class: 'form-control', type: 'email', required: true
     .form-group
-      = password_field_tag :password, nil, id: 'pwd', placeholder: 'Enter a password', autocomplete: 'off', class: 'form-control'
+      = label_tag 'password', 'Password:'
+      %abbr.text-danger{ title: 'required' } *
+      = password_field_tag :password, nil, id: 'pwd', placeholder: 'Enter a password', autocomplete: 'off', class: 'form-control', required: true
     .form-group
+      = label_tag 'password_confirmation', 'Password confirmation:'
+      %abbr.text-danger{ title: 'required' } *
       = password_field_tag(:password_confirmation, nil, id: 'pwd_confirmation', placeholder: 'Password confirmation', autocomplete: 'off',
-        class: 'form-control')
+        class: 'form-control', required: true)
     = hidden_field_tag 'register', 'true'
-    .text-center
-      = submit_tag 'Sign Up', class: 'btn btn-primary'
+    = submit_tag submit_btn_text, class: 'btn btn-primary'

--- a/src/api/app/views/webui2/webui/main/index.html.haml
+++ b/src/api/app/views/webui2/webui/main/index.html.haml
@@ -22,7 +22,7 @@
       .card.mb-3
         %h5.card-header New here? Sign up!
         .card-body
-          = render partial: 'webui2/shared/sign_up'
+          = render partial: 'webui2/shared/sign_up', locals: { submit_btn_text: 'Sign Up' }
     = render partial: 'sponsors'
     - if @status_messages.present? || User.current.is_admin?
       = render partial: 'status_messages'

--- a/src/api/app/views/webui2/webui/user/_breadcrumb_items.html.haml
+++ b/src/api/app/views/webui2/webui/user/_breadcrumb_items.html.haml
@@ -7,7 +7,7 @@
 - when 'edit'
   = render partial: 'webui/configuration/breadcrumb_items'
   %li.breadcrumb-item
-    = link_to('Manage users', users_path)
+    = link_to('Manage Users', users_path)
   %li.breadcrumb-item.active{ 'aria-current' => 'page' }
     = @displayed_user
 - when 'show'
@@ -15,3 +15,13 @@
   - if action_name == 'show'
     %li.breadcrumb-item.active{ 'aria-current' => 'page' }
       Home of #{@displayed_user}
+- when 'register_user'
+  = render partial: 'webui/configuration/breadcrumb_items'
+  %li.breadcrumb-item
+    = link_to('Manage Users', users_path)
+  %li.breadcrumb-item.active{ 'aria-current' => 'page' }
+    Create User
+- when 'signup'
+  = render partial: 'webui/main/breadcrumb_items'
+  %li.breadcrumb-item.active{ 'aria-current' => 'page' }
+    Sign Up

--- a/src/api/app/views/webui2/webui/user/index.html.haml
+++ b/src/api/app/views/webui2/webui/user/index.html.haml
@@ -4,3 +4,6 @@
 .card.mb-3
   = render partial: 'webui/configuration/tabs'
   .card-body
+    = link_to(user_register_user_path) do
+      %i.fas.fa-plus-circle.text-primary
+      Create User

--- a/src/api/app/views/webui2/webui/user/register_user.html.haml
+++ b/src/api/app/views/webui2/webui/user/register_user.html.haml
@@ -1,0 +1,12 @@
+:ruby
+  @pagetitle = 'Create User'
+
+.card
+  .card-body
+    .row
+      .col-lg-6
+        - if can_register
+          %h5.card-title  Create User
+          = render partial: 'webui2/shared/sign_up', locals: { submit_btn_text: 'Create' }
+        - else
+          %p Sorry, sign up is disabled

--- a/src/api/app/views/webui2/webui/user/signup.html.haml
+++ b/src/api/app/views/webui2/webui/user/signup.html.haml
@@ -1,0 +1,12 @@
+:ruby
+  @pagetitle = 'Sign Up'
+
+.card
+  .card-body
+    .row
+      .col-lg-6
+        - if can_register
+          %h5.card-title  Sign Up for an Open Build Service account
+          = render partial: 'webui2/shared/sign_up', locals: { submit_btn_text: 'Sign Up' }
+        - else
+          %p Sorry, sign up is disabled

--- a/src/api/config/routes.rb
+++ b/src/api/config/routes.rb
@@ -374,6 +374,7 @@ OBSApi::Application.routes.draw do
 
       post 'user/register' => :register
       get 'user/register_user' => :register_user
+      get 'user/signup' => :signup
 
       post 'user/save' => :save, constraints: cons
       get 'user/save_dialog' => :save_dialog


### PR DESCRIPTION
We are migrating the configuration section to bootstrap. The
manage user page belongs to this area and includes the user creation.

![screenshot-2019-2-27 sign up - open build service](https://user-images.githubusercontent.com/22001671/53507417-245d5280-3ab8-11e9-9b30-aeb1a5db03dd.png)

