### PR TITLE
Allow to modify required_checks for RepositoryArchitecture

### DIFF
--- a/src/api/app/controllers/status/required_checks_controller.rb
+++ b/src/api/app/controllers/status/required_checks_controller.rb
@@ -78,16 +78,15 @@ class Status::RequiredChecksController < ApplicationController
   end
 
   def set_checkable
-    if params[:repository_name]
-      @checkable = @project.repositories.find_by!(name: params[:repository_name])
+    @checkable = checkable
+  end
 
-      if params[:architecture_name]
-        @checkable = @checkable.repository_architectures.find_by!(architecture: Architecture.find_by!(name: params[:architecture_name]))
-      end
-
-      return
-    end
-    @checkable = @project
+  def checkable
+    return @project unless params[:repository_name]
+    repo = @project.repositories.find_by!(name: params[:repository_name])
+    return repo unless params[:architecture_name]
+    architecture = Architecture.find_by!(name: params[:architecture_name])
+    repo.repository_architectures.find_by!(architecture: architecture)
   end
 
   # Use callbacks to share common setup or constraints between actions.

--- a/src/api/app/controllers/status/required_checks_controller.rb
+++ b/src/api/app/controllers/status/required_checks_controller.rb
@@ -17,6 +17,7 @@ class Status::RequiredChecksController < ApplicationController
 
   # GET /status_reports/projects/:project_name/required_checks
   # GET /status_reports/repositories/:project_name/:repository_name/required_checks
+  # GET /status_reports/repositories/:project_name/:repository_name/:architecture_name/required_checks
   def index
     authorize @checkable
     @required_checks = @checkable.required_checks
@@ -24,6 +25,7 @@ class Status::RequiredChecksController < ApplicationController
 
   # POST /status_reports/projects/:project_name/required_checks/:name
   # POST /status_reports/repositories/:project_name/:repository_name/required_checks/:name
+  # POST /status_reports/repositories/:project_name/:repository_name/:architecture_name/required_checks/:name
   def create
     authorize @checkable
     @required_checks = @checkable.required_checks |= names
@@ -41,6 +43,7 @@ class Status::RequiredChecksController < ApplicationController
 
   # DELETE /status_reports/projects/:project_name/required_checks/:name
   # DELETE /status_reports/repositories/:project_name/:repository_name/required_checks/:name
+  # DELETE /status_reports/repositories/:project_name/:repository_name/:architecture_name/required_checks/:name
   def destroy
     authorize @checkable
     @checkable.required_checks -= [params[:name]]
@@ -76,17 +79,15 @@ class Status::RequiredChecksController < ApplicationController
 
   def set_checkable
     if params[:repository_name]
-      @checkable = @project.repositories.find_by(name: params[:repository_name])
-      return if @checkable
+      @checkable = @project.repositories.find_by!(name: params[:repository_name])
 
-      render_error(
-        status: 404,
-        errorcode: 'not_found',
-        message: "Repository '#{params[:repository_name]}/#{params[:project_name]}' not found."
-      )
-    else
-      @checkable = @project
+      if params[:architecture_name]
+        @checkable = @checkable.repository_architectures.find_by!(architecture: Architecture.find_by!(name: params[:architecture_name]))
+      end
+
+      return
     end
+    @checkable = @project
   end
 
   # Use callbacks to share common setup or constraints between actions.

--- a/src/api/app/helpers/status/required_checks_helper.rb
+++ b/src/api/app/helpers/status/required_checks_helper.rb
@@ -1,10 +1,11 @@
 module Status::RequiredChecksHelper
   def build_header(project, checkable)
-    if checkable.is_a?(Repository)
+    case checkable
+    when Repository
       { project: project.name, repository: checkable.name }
-    elsif checkable.is_a?(Package)
+    when Package
       { project: project.name, package: checkable.name }
-    elsif checkable.is_a?(RepositoryArchitecture)
+    when RepositoryArchitecture
       build_header(project, checkable.repository).merge(architecture: checkable.architecture.name)
     else
       { project: checkable.name }

--- a/src/api/app/helpers/status/required_checks_helper.rb
+++ b/src/api/app/helpers/status/required_checks_helper.rb
@@ -4,6 +4,8 @@ module Status::RequiredChecksHelper
       { project: project.name, repository: checkable.name }
     elsif checkable.is_a?(Package)
       { project: project.name, package: checkable.name }
+    elsif checkable.is_a?(RepositoryArchitecture)
+      build_header(project, checkable.repository).merge(architecture: checkable.architecture.name)
     else
       { project: checkable.name }
     end

--- a/src/api/app/policies/repository_architecture_policy.rb
+++ b/src/api/app/policies/repository_architecture_policy.rb
@@ -1,0 +1,25 @@
+class RepositoryArchitecturePolicy < ApplicationPolicy
+  def initialize(user, record)
+    super(user, record, user_optional: true)
+  end
+
+  def create?
+    update?
+  end
+
+  def update?
+    RepositoryPolicy.new(user, record.repository).update?
+  end
+
+  def destroy?
+    create?
+  end
+
+  def index?
+    true
+  end
+
+  def show?
+    index?
+  end
+end

--- a/src/api/config/routes.rb
+++ b/src/api/config/routes.rb
@@ -834,6 +834,16 @@ OBSApi::Application.routes.draw do
       end
     end
 
+    scope :built_repositories do
+      resources :projects, only: [], param: :name, path: '', constraints: cons do
+        resources :repositories, only: [], param: :name, path: '', constraints: cons do
+          resources :architectures, only: [], param: :name, path: '', constraints: cons do
+            resources :required_checks, only: [:index, :create, :destroy], param: :name
+          end
+        end
+      end
+    end
+
     controller :reports do
       scope :published do
         get ':project_name/:repository_name/reports/:report_uuid' => :show, constraints: cons


### PR DESCRIPTION
The model allowed this for a while and the staging dashboard also supported it, but as the Status API sprint never continued this was never implemented - but as it blocks my work on repository checks, henne and me decided to put a bandaid in place

