### PR TITLE
Hide decision box when there is nothing to do for the logged in user

### DIFF
--- a/src/api/app/views/webui2/webui/request/show.html.haml
+++ b/src/api/app/views/webui2/webui/request/show.html.haml
@@ -39,9 +39,10 @@
     .card.mb-3
       .bg-light
         %ul.nav.nav-tabs{ role: 'tablist' }
-          %li.nav-item
-            %a.nav-link.text-nowrap.active{ href: '#decision', data: { toggle: 'tab' }, role: 'tab' }
-              My decision
+          - if @can_handle_request
+            %li.nav-item
+              %a.nav-link.text-nowrap.active{ href: '#decision', data: { toggle: 'tab' }, role: 'tab' }
+                My decision
           - @my_open_reviews.each_with_index do |review, index|
             %li.nav-item
               %a.nav-link.text-nowrap{ href: "#review-#{index}", data: { toggle: 'tab' }, role: 'tab' }
@@ -53,16 +54,13 @@
             has <strong>#{pluralize(@package_maintainers.size, 'package maintainer')}</strong> assigned. Please keep
             in mind that also package maintainers would like to review this request.
         .tab-content
-          .tab-pane.fade.show.active{ id: 'decision' }
-            - if @can_handle_request
+          - if @can_handle_request
+            .tab-pane.fade.show.active{ id: 'decision' }
               = render('decision_tab', request_number: @bs_request.number, request_creator: @bs_request.creator,
                        is_target_maintainer: @is_target_maintainer, state: @bs_request.state.to_s,
                        is_author: @is_author, single_action_request: @actions.count == 1, action: @actions.first)
-            - else
-              %p
-                There's nothing to be done right now
           - @my_open_reviews.each_with_index do |review, index|
-            .tab-pane.fade.show{ id: "review-#{index}" }
+            .tab-pane.fade.show{ id: "review-#{index}", class: ('active' unless @can_handle_request) }
               = render('review_tab', review: review, request_number: @bs_request.number)
 
   .col-md-4


### PR DESCRIPTION
Instead of showing a message that 'there's nothing to be done right now'
we hide the decision box.
This prevents reviewers with open reviews from making detours by having
to click on the "reviews" tab. The request decision can still be viewed
in the request history, like it was before.

Fixes #7026



<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md
-->
