### PR TITLE
Migrate announcement to Bootstrap

### DIFF
--- a/src/api/app/assets/stylesheets/webui/application/announcements.scss
+++ b/src/api/app/assets/stylesheets/webui/application/announcements.scss
@@ -2,6 +2,8 @@
 // They will automatically be included in application.css.
 // You can use Sass (SCSS) here: http://sass-lang.com/
 
+// TODO: bento_only
+
 #announcements {
   .announcement {
     background-color: #fff6ef;

--- a/src/api/app/assets/stylesheets/webui2/flash.scss
+++ b/src/api/app/assets/stylesheets/webui2/flash.scss
@@ -1,4 +1,4 @@
-#flash.sticky-top {
+.flash-and-announcement.sticky-top {
   top: 1rem;
   z-index: 1030;
 }

--- a/src/api/app/controllers/webui/announcements_controller.rb
+++ b/src/api/app/controllers/webui/announcements_controller.rb
@@ -4,5 +4,6 @@ class Webui::AnnouncementsController < Webui::WebuiController
     @announcement = Announcement.find_by(id: params[:id])
 
     redirect_back(fallback_location: root_path, error: "Couldn't find announcement") unless @announcement
+    switch_to_webui2
   end
 end

--- a/src/api/app/controllers/webui/users/announcements_controller.rb
+++ b/src/api/app/controllers/webui/users/announcements_controller.rb
@@ -9,5 +9,6 @@ class Webui::Users::AnnouncementsController < Webui::WebuiController
     else
       flash.now[:error] = "Couldn't find Announcement"
     end
+    switch_to_webui2
   end
 end

--- a/src/api/app/views/layouts/webui2/_announcement.html.haml
+++ b/src/api/app/views/layouts/webui2/_announcement.html.haml
@@ -1,0 +1,12 @@
+- if @pending_announcement.present?
+  .row.justify-content-center
+    .col-12
+      .alert.fade.show.alert-notice
+        .row
+          .col-md-10
+            There has been new announcements!
+            = link_to('Read more', announcement_path(@pending_announcement), class: 'alert-link ')
+          .col-md-2
+            - unless User.current.is_nobody?
+              = form_tag(user_announcements_path(@pending_announcement), remote: true, class: 'text-right' ) do
+                = submit_tag 'Got it', class: 'btn btn-sm btn-secondary'

--- a/src/api/app/views/layouts/webui2/webui.html.haml
+++ b/src/api/app/views/layouts/webui2/webui.html.haml
@@ -37,9 +37,13 @@
           = render partial: "layouts/webui2/breadcrumbs"
         .col-auto.ml-auto#personal-navigation
           = render partial: "layouts/webui2/personal_navigation"
-    .container.sticky-top#flash
-      = render partial: "layouts/webui2/flash", object: flash
+
+    .container.sticky-top.flash-and-announcement
+      - unless @hide_announcement_notification
+        #announcement= render partial: 'layouts/webui2/announcement'
+      #flash= render partial: "layouts/webui2/flash", object: flash
     .modal.fade#modal{ tabindex: '-1', role: 'dialog', aria: { labelledby: 'modalLabel', hidden: true } }
+
     .container.flex-grow#content
       = yield
     .container-fluid.py-4.mt-4.text-dark#footer

--- a/src/api/app/views/webui2/webui/announcements/_breadcrumb_items.html.haml
+++ b/src/api/app/views/webui2/webui/announcements/_breadcrumb_items.html.haml
@@ -1,0 +1,4 @@
+= render partial: 'webui/main/breadcrumb_items'
+- if current_page?(announcement_path)
+  %li.breadcrumb-item.active{ 'aria-current' => 'page' }
+    Announcement

--- a/src/api/app/views/webui2/webui/announcements/show.html.haml
+++ b/src/api/app/views/webui2/webui/announcements/show.html.haml
@@ -1,0 +1,9 @@
+- @pagetitle = 'Announcement'
+
+.card
+  .card-body
+    %h2= @announcement.title
+    %p= render_as_markdown(@announcement.content)
+    - if !User.current.is_nobody? && @announcement == @pending_announcement
+      = form_tag(user_announcements_path(@announcement), remote: true) do
+        = submit_tag 'Got it', class: 'btn btn-primary'

--- a/src/api/app/views/webui2/webui/users/announcements/create.js.haml
+++ b/src/api/app/views/webui2/webui/users/announcements/create.js.haml
@@ -1,0 +1,9 @@
+- if flash[:error]
+  flashContent = '#{escape_javascript(render(layout: false, partial: 'layouts/webui2/flash', object: flash, formats: [:html]))}';
+  $('#flash').html(flashContent);
+- else
+  // At announcement's show view only the button disappears
+  $('form input[type="submit"]').fadeOut()
+  // In the rest of the views, the whole banner disappears
+  $('#announcement').fadeOut()
+


### PR DESCRIPTION
Migrates both announcement show page and flash/banner, which is shown
before any other flash.

Shows text and button in the same line.

**Banner before:**

![screenshot-2019-2-28 home of admin - open build service](https://user-images.githubusercontent.com/2581944/53531051-5ee3e100-3af2-11e9-96a5-a597e35f7a83.png)

**Banner after:**

![screenshot-2019-3-4 home of admin - open build service 1](https://user-images.githubusercontent.com/2581944/53728499-300f9700-3e73-11e9-8004-04958a054f67.png)


**Show view before:**

![screenshot-2019-2-28 announcement new bootstrap views - open build service](https://user-images.githubusercontent.com/2581944/53531216-e7fb1800-3af2-11e9-91a6-303194f413ba.png)

**Show view after:**

![screenshot-2019-2-28 announcement - open build service 1](https://user-images.githubusercontent.com/2581944/53531221-ec273580-3af2-11e9-84ed-6b24ef27a8b4.png)
