### PR TITLE
Fix linking projects in project page

### DIFF
--- a/src/api/app/views/webui2/webui/project/_linking_projects_dialog.html.haml
+++ b/src/api/app/views/webui2/webui/project/_linking_projects_dialog.html.haml
@@ -1,0 +1,13 @@
+.modal.fade#linking-projects-modal{ tabindex: -1, role: 'dialog', aria: { labelledby: 'linking-projects-modal-label', hidden: true } }
+  .modal-dialog.modal-dialog-centered{ role: 'document' }
+    .modal-content
+      .modal-header
+        %h5.modal-title#linking-projects-modal-label Projects linking to #{project}
+      .modal-body
+        %ul
+          - linking_projects.each do |linking_project|
+            %li
+              = link_to linking_project, project_show_path(linking_project)
+      .modal-footer
+        %button.btn.btn-sm.btn-outline-danger.px-4{ data: { dismiss: 'modal' } }
+          Close

--- a/src/api/app/views/webui2/webui/project/_side_links.html.haml
+++ b/src/api/app/views/webui2/webui/project/_side_links.html.haml
@@ -33,8 +33,8 @@
 
   - if linking_projects.present?
     %li
-      %i.fa.fa-info-circle.text-info
-      = link_to(linking_projects_path(project), remote: true) do
+      = link_to('#', data: { toggle: 'modal', target: '#linking-projects-modal' }) do
+        %i.fa.fa-info-circle.text-info
         = pluralize(linking_projects.size, 'linking project')
 
   - if project_maintenance_project

--- a/src/api/app/views/webui2/webui/project/show.html.haml
+++ b/src/api/app/views/webui2/webui/project/show.html.haml
@@ -67,6 +67,7 @@
         = render partial: 'webui2/webui/comment/show', locals: { commentable: @project,
           comment_counter_id: "#comment-counter-project-#{@project.id}" }
 
+= render partial: 'linking_projects_dialog', locals: { project: @project, linking_projects: @linking_projects }
 - unless User.current.is_nobody?
   - if @project.is_locked? && User.current.can_modify?(@project, true)
     = render partial: 'unlock_project_dialog', locals: { project: @project }


### PR DESCRIPTION
The linking projects dialog hadn't been migrated to the new UI.

Fixes https://github.com/openSUSE/open-build-service/issues/6979

![image](https://user-images.githubusercontent.com/16052290/53558784-0ab81b80-3b49-11e9-98c6-d1759b0b1d71.png)


<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md
-->
