### PR TITLE
Don't let disabled projects/repos pass stagings as acceptable

### DIFF
--- a/src/api/app/models/obs_factory/staging_project.rb
+++ b/src/api/app/models/obs_factory/staging_project.rb
@@ -117,6 +117,13 @@ module ObsFactory
       @building_repositories
     end
 
+    # Repositories referenced in the staging project that are disabled (as a whole)
+    #
+    # @return [Array] Array of repositories
+    def disabled_repositories
+      project.repositories.select { |repository| project.disabled_for?('build', repository.name, nil) }
+    end
+
     # Requests with open reviews but that are not selected into the staging
     # project
     #
@@ -200,7 +207,7 @@ module ObsFactory
     end
 
     def build_state
-      return :building if building_repositories.present?
+      return :building if building_repositories.present? || disabled_repositories.present?
       return :failed if broken_packages.present?
       :acceptable
     end
@@ -283,6 +290,7 @@ module ObsFactory
           @building_repositories << current_repo
         end
       end
+      # filter out unresolvables while there is work going on
       if @building_repositories.present?
         @broken_packages = @broken_packages.reject { |p| p['state'] == 'unresolvable' }
       end

--- a/src/api/app/models/staging/staging_project.rb
+++ b/src/api/app/models/staging/staging_project.rb
@@ -72,6 +72,10 @@ module Staging
       @requests_to_review ||= BsRequest.with_open_reviews_for(by_project: name)
     end
 
+    def disabled_repositories
+      repositories.select { |repository| disabled_for?('build', repository.name, nil) }
+    end
+
     def building_repositories
       set_buildinfo unless @building_repositories
       @building_repositories
@@ -156,7 +160,7 @@ module Staging
     end
 
     def build_state
-      return :building if building_repositories.present?
+      return :building if building_repositories.present? || disabled_repositories.present?
       return :failed if broken_packages.present?
 
       :acceptable

--- a/src/api/spec/cassettes/Staging_StagingProject/_overall_state/with_disabled_repository/1_3_10_1.yml
+++ b/src/api/spec/cassettes/Staging_StagingProject/_overall_state/with_disabled_repository/1_3_10_1.yml
@@ -1,0 +1,719 @@
+---
+http_interactions:
+- request:
+    method: put
+    uri: http://backend:5352/source/home:tom/_meta?user=tom
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:tom">
+          <title/>
+          <description/>
+          <person userid="tom" role="maintainer"/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '129'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:tom">
+          <title></title>
+          <description></description>
+          <person userid="tom" role="maintainer" />
+        </project>
+    http_version: 
+  recorded_at: Thu, 28 Feb 2019 08:59:55 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:tom/_project/_staging_workflow?user=_nobody_
+    body:
+      encoding: UTF-8
+      string: |
+        <workflow project="home:tom" managers="group_2">
+          <staging_project name="home:tom:Staging:A"/>
+        </workflow>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '171'
+    body:
+      encoding: UTF-8
+      string: |
+        <revision rev="13">
+          <srcmd5>7b2493cbf69cbaf2db433b7573c6f9ba</srcmd5>
+          <time>1551344395</time>
+          <user>_nobody_</user>
+          <comment></comment>
+          <requestid/>
+        </revision>
+    http_version: 
+  recorded_at: Thu, 28 Feb 2019 08:59:55 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:tom:Staging:A/_meta?user=_nobody_
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:tom:Staging:A">
+          <title/>
+          <description/>
+          <group groupid="group_2" role="maintainer"/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '143'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:tom:Staging:A">
+          <title></title>
+          <description></description>
+          <group groupid="group_2" role="maintainer" />
+        </project>
+    http_version: 
+  recorded_at: Thu, 28 Feb 2019 08:59:55 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:tom/_project/_staging_workflow?user=_nobody_
+    body:
+      encoding: UTF-8
+      string: |
+        <workflow project="home:tom" managers="group_2">
+          <staging_project name="home:tom:Staging:A"/>
+          <staging_project name="home:tom:Staging:B"/>
+        </workflow>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '171'
+    body:
+      encoding: UTF-8
+      string: |
+        <revision rev="14">
+          <srcmd5>8634a186b5a256cc97a4519875b4d59b</srcmd5>
+          <time>1551344396</time>
+          <user>_nobody_</user>
+          <comment></comment>
+          <requestid/>
+        </revision>
+    http_version: 
+  recorded_at: Thu, 28 Feb 2019 08:59:56 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:tom:Staging:B/_meta?user=_nobody_
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:tom:Staging:B">
+          <title/>
+          <description/>
+          <group groupid="group_2" role="maintainer"/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '143'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:tom:Staging:B">
+          <title></title>
+          <description></description>
+          <group groupid="group_2" role="maintainer" />
+        </project>
+    http_version: 
+  recorded_at: Thu, 28 Feb 2019 08:59:56 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:tom/_meta?user=_nobody_
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:tom">
+          <title/>
+          <description/>
+          <person userid="tom" role="maintainer"/>
+          <group groupid="group_2" role="reviewer"/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '175'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:tom">
+          <title></title>
+          <description></description>
+          <person userid="tom" role="maintainer" />
+          <group groupid="group_2" role="reviewer" />
+        </project>
+    http_version: 
+  recorded_at: Thu, 28 Feb 2019 08:59:56 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:tom:Staging:A/package_2/_meta?user=_nobody_
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="package_2" project="home:tom:Staging:A">
+          <title>Françoise Sagan</title>
+          <description>Occaecati libero sequi error.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '160'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        PHBhY2thZ2UgbmFtZT0icGFja2FnZV8yIiBwcm9qZWN0PSJob21lOnRvbTpTdGFnaW5nOkEiPgogIDx0aXRsZT5GcmFuw6dvaXNlIFNhZ2FuPC90aXRsZT4KICA8ZGVzY3JpcHRpb24+T2NjYWVjYXRpIGxpYmVybyBzZXF1aSBlcnJvci48L2Rlc2NyaXB0aW9uPgo8L3BhY2thZ2U+Cg==
+    http_version: 
+  recorded_at: Thu, 28 Feb 2019 08:59:56 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:tom:Staging:A/package_2/_meta?user=_nobody_
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="package_2" project="home:tom:Staging:A">
+          <title>Françoise Sagan</title>
+          <description>Occaecati libero sequi error.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '160'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        PHBhY2thZ2UgbmFtZT0icGFja2FnZV8yIiBwcm9qZWN0PSJob21lOnRvbTpTdGFnaW5nOkEiPgogIDx0aXRsZT5GcmFuw6dvaXNlIFNhZ2FuPC90aXRsZT4KICA8ZGVzY3JpcHRpb24+T2NjYWVjYXRpIGxpYmVybyBzZXF1aSBlcnJvci48L2Rlc2NyaXB0aW9uPgo8L3BhY2thZ2U+Cg==
+    http_version: 
+  recorded_at: Thu, 28 Feb 2019 08:59:56 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:tom:Staging:A/package_2/_config
+    body:
+      encoding: UTF-8
+      string: Numquam eius aliquid. Est omnis et. Iusto et dolores.
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '207'
+    body:
+      encoding: UTF-8
+      string: |
+        <revision rev="5" vrev="5">
+          <srcmd5>0725dcbbe08862715978c3c9e6335f20</srcmd5>
+          <version>unknown</version>
+          <time>1551344396</time>
+          <user>unknown</user>
+          <comment></comment>
+          <requestid/>
+        </revision>
+    http_version: 
+  recorded_at: Thu, 28 Feb 2019 08:59:56 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:tom:Staging:A/package_2/somefile.txt
+    body:
+      encoding: UTF-8
+      string: Culpa rem quibusdam. Veritatis consequatur qui. Praesentium doloremque
+        harum.
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '207'
+    body:
+      encoding: UTF-8
+      string: |
+        <revision rev="6" vrev="6">
+          <srcmd5>cdf073c0d1ea0d8dcc4c0503902bbb14</srcmd5>
+          <version>unknown</version>
+          <time>1551344396</time>
+          <user>unknown</user>
+          <comment></comment>
+          <requestid/>
+        </revision>
+    http_version: 
+  recorded_at: Thu, 28 Feb 2019 08:59:56 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/target_project/_meta?user=tom
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="target_project">
+          <title>Postern of Fate</title>
+          <description/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '106'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="target_project">
+          <title>Postern of Fate</title>
+          <description></description>
+        </project>
+    http_version: 
+  recorded_at: Thu, 28 Feb 2019 08:59:56 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/target_project/target_package/_meta?user=tom
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="target_package" project="target_project">
+          <title>Sleep the Brave</title>
+          <description>Illum molestiae explicabo dignissimos.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '169'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="target_package" project="target_project">
+          <title>Sleep the Brave</title>
+          <description>Illum molestiae explicabo dignissimos.</description>
+        </package>
+    http_version: 
+  recorded_at: Thu, 28 Feb 2019 08:59:56 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/target_project/target_package/_meta?user=tom
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="target_package" project="target_project">
+          <title>Sleep the Brave</title>
+          <description>Illum molestiae explicabo dignissimos.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '169'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="target_package" project="target_project">
+          <title>Sleep the Brave</title>
+          <description>Illum molestiae explicabo dignissimos.</description>
+        </package>
+    http_version: 
+  recorded_at: Thu, 28 Feb 2019 08:59:56 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/source_project/_meta?user=tom
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="source_project">
+          <title>The Needle's Eye</title>
+          <description/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '107'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="source_project">
+          <title>The Needle's Eye</title>
+          <description></description>
+        </project>
+    http_version: 
+  recorded_at: Thu, 28 Feb 2019 08:59:56 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/source_project/_project/_attribute?meta=1&user=tom
+    body:
+      encoding: UTF-8
+      string: |
+        <attributes>
+          <attribute name="ApprovedRequestSource" namespace="OBS"/>
+        </attributes>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '166'
+    body:
+      encoding: UTF-8
+      string: |
+        <revision rev="14">
+          <srcmd5>9fc886d6e41159bd263f63f35184e5d7</srcmd5>
+          <time>1551344396</time>
+          <user>tom</user>
+          <comment></comment>
+          <requestid/>
+        </revision>
+    http_version: 
+  recorded_at: Thu, 28 Feb 2019 08:59:56 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/source_project/source_package/_meta?user=tom
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="source_package" project="source_project">
+          <title>Fear and Trembling</title>
+          <description>Ea voluptas tenetur molestias.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '164'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="source_package" project="source_project">
+          <title>Fear and Trembling</title>
+          <description>Ea voluptas tenetur molestias.</description>
+        </package>
+    http_version: 
+  recorded_at: Thu, 28 Feb 2019 08:59:56 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/source_project/source_package/_meta?user=tom
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="source_package" project="source_project">
+          <title>Fear and Trembling</title>
+          <description>Ea voluptas tenetur molestias.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '164'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="source_package" project="source_project">
+          <title>Fear and Trembling</title>
+          <description>Ea voluptas tenetur molestias.</description>
+        </package>
+    http_version: 
+  recorded_at: Thu, 28 Feb 2019 08:59:56 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:user_2/_meta?user=user_2
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:user_2">
+          <title/>
+          <description/>
+          <person userid="user_2" role="maintainer"/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '135'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:user_2">
+          <title></title>
+          <description></description>
+          <person userid="user_2" role="maintainer" />
+        </project>
+    http_version: 
+  recorded_at: Thu, 28 Feb 2019 08:59:56 GMT
+recorded_with: VCR 4.0.0

--- a/src/api/spec/cassettes/Staging_StagingProject/_overall_state/with_disabled_repository/1_3_10_2.yml
+++ b/src/api/spec/cassettes/Staging_StagingProject/_overall_state/with_disabled_repository/1_3_10_2.yml
@@ -1,0 +1,757 @@
+---
+http_interactions:
+- request:
+    method: put
+    uri: http://backend:5352/source/home:tom/_meta?user=tom
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:tom">
+          <title/>
+          <description/>
+          <person userid="tom" role="maintainer"/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '129'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:tom">
+          <title></title>
+          <description></description>
+          <person userid="tom" role="maintainer" />
+        </project>
+    http_version: 
+  recorded_at: Thu, 28 Feb 2019 08:59:53 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:tom/_project/_staging_workflow?user=_nobody_
+    body:
+      encoding: UTF-8
+      string: |
+        <workflow project="home:tom" managers="group_1">
+          <staging_project name="home:tom:Staging:A"/>
+        </workflow>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '171'
+    body:
+      encoding: UTF-8
+      string: |
+        <revision rev="11">
+          <srcmd5>e5041e116aada333f093a54cd9eb647e</srcmd5>
+          <time>1551344393</time>
+          <user>_nobody_</user>
+          <comment></comment>
+          <requestid/>
+        </revision>
+    http_version: 
+  recorded_at: Thu, 28 Feb 2019 08:59:53 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:tom:Staging:A/_meta?user=_nobody_
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:tom:Staging:A">
+          <title/>
+          <description/>
+          <group groupid="group_1" role="maintainer"/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '143'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:tom:Staging:A">
+          <title></title>
+          <description></description>
+          <group groupid="group_1" role="maintainer" />
+        </project>
+    http_version: 
+  recorded_at: Thu, 28 Feb 2019 08:59:53 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:tom/_project/_staging_workflow?user=_nobody_
+    body:
+      encoding: UTF-8
+      string: |
+        <workflow project="home:tom" managers="group_1">
+          <staging_project name="home:tom:Staging:A"/>
+          <staging_project name="home:tom:Staging:B"/>
+        </workflow>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '171'
+    body:
+      encoding: UTF-8
+      string: |
+        <revision rev="12">
+          <srcmd5>24931ffd0c813a8a478aa1e474921c59</srcmd5>
+          <time>1551344393</time>
+          <user>_nobody_</user>
+          <comment></comment>
+          <requestid/>
+        </revision>
+    http_version: 
+  recorded_at: Thu, 28 Feb 2019 08:59:54 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:tom:Staging:B/_meta?user=_nobody_
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:tom:Staging:B">
+          <title/>
+          <description/>
+          <group groupid="group_1" role="maintainer"/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '143'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:tom:Staging:B">
+          <title></title>
+          <description></description>
+          <group groupid="group_1" role="maintainer" />
+        </project>
+    http_version: 
+  recorded_at: Thu, 28 Feb 2019 08:59:54 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:tom/_meta?user=_nobody_
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:tom">
+          <title/>
+          <description/>
+          <person userid="tom" role="maintainer"/>
+          <group groupid="group_1" role="reviewer"/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '175'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:tom">
+          <title></title>
+          <description></description>
+          <person userid="tom" role="maintainer" />
+          <group groupid="group_1" role="reviewer" />
+        </project>
+    http_version: 
+  recorded_at: Thu, 28 Feb 2019 08:59:54 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:tom:Staging:A/package_1/_meta?user=_nobody_
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="package_1" project="home:tom:Staging:A">
+          <title>The Cricket on the Hearth</title>
+          <description>Blanditiis consectetur velit corrupti.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '178'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="package_1" project="home:tom:Staging:A">
+          <title>The Cricket on the Hearth</title>
+          <description>Blanditiis consectetur velit corrupti.</description>
+        </package>
+    http_version: 
+  recorded_at: Thu, 28 Feb 2019 08:59:54 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:tom:Staging:A/package_1/_meta?user=_nobody_
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="package_1" project="home:tom:Staging:A">
+          <title>The Cricket on the Hearth</title>
+          <description>Blanditiis consectetur velit corrupti.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '178'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="package_1" project="home:tom:Staging:A">
+          <title>The Cricket on the Hearth</title>
+          <description>Blanditiis consectetur velit corrupti.</description>
+        </package>
+    http_version: 
+  recorded_at: Thu, 28 Feb 2019 08:59:54 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:tom:Staging:A/package_1/_config
+    body:
+      encoding: UTF-8
+      string: Aut dolores quae. Excepturi ea exercitationem. Sunt beatae quia.
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '207'
+    body:
+      encoding: UTF-8
+      string: |
+        <revision rev="5" vrev="5">
+          <srcmd5>3ae5c78ffbd3de6def41253b6d1c2bb4</srcmd5>
+          <version>unknown</version>
+          <time>1551344394</time>
+          <user>unknown</user>
+          <comment></comment>
+          <requestid/>
+        </revision>
+    http_version: 
+  recorded_at: Thu, 28 Feb 2019 08:59:54 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:tom:Staging:A/package_1/somefile.txt
+    body:
+      encoding: UTF-8
+      string: Vitae molestias laudantium. Est et totam. Quae aliquid consequatur.
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '207'
+    body:
+      encoding: UTF-8
+      string: |
+        <revision rev="6" vrev="6">
+          <srcmd5>67a4785ddf36857c4802701c55392259</srcmd5>
+          <version>unknown</version>
+          <time>1551344394</time>
+          <user>unknown</user>
+          <comment></comment>
+          <requestid/>
+        </revision>
+    http_version: 
+  recorded_at: Thu, 28 Feb 2019 08:59:54 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/target_project/_meta?user=tom
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="target_project">
+          <title>Death Be Not Proud</title>
+          <description/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '109'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="target_project">
+          <title>Death Be Not Proud</title>
+          <description></description>
+        </project>
+    http_version: 
+  recorded_at: Thu, 28 Feb 2019 08:59:54 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/target_project/target_package/_meta?user=tom
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="target_package" project="target_project">
+          <title>Where Angels Fear to Tread</title>
+          <description>Aliquam molestiae cumque maxime.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '174'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="target_package" project="target_project">
+          <title>Where Angels Fear to Tread</title>
+          <description>Aliquam molestiae cumque maxime.</description>
+        </package>
+    http_version: 
+  recorded_at: Thu, 28 Feb 2019 08:59:54 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/target_project/target_package/_meta?user=tom
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="target_package" project="target_project">
+          <title>Where Angels Fear to Tread</title>
+          <description>Aliquam molestiae cumque maxime.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '174'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="target_package" project="target_project">
+          <title>Where Angels Fear to Tread</title>
+          <description>Aliquam molestiae cumque maxime.</description>
+        </package>
+    http_version: 
+  recorded_at: Thu, 28 Feb 2019 08:59:54 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/source_project/_meta?user=tom
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="source_project">
+          <title>For Whom the Bell Tolls</title>
+          <description/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '114'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="source_project">
+          <title>For Whom the Bell Tolls</title>
+          <description></description>
+        </project>
+    http_version: 
+  recorded_at: Thu, 28 Feb 2019 08:59:54 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/source_project/_project/_attribute?meta=1&user=tom
+    body:
+      encoding: UTF-8
+      string: |
+        <attributes>
+          <attribute name="ApprovedRequestSource" namespace="OBS"/>
+        </attributes>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '166'
+    body:
+      encoding: UTF-8
+      string: |
+        <revision rev="12">
+          <srcmd5>22f67b0dd73a34ca5425a792a07818e4</srcmd5>
+          <time>1551344395</time>
+          <user>tom</user>
+          <comment></comment>
+          <requestid/>
+        </revision>
+    http_version: 
+  recorded_at: Thu, 28 Feb 2019 08:59:55 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/source_project/source_package/_meta?user=tom
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="source_package" project="source_project">
+          <title>Unweaving the Rainbow</title>
+          <description>Eius corporis molestias nemo.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '166'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="source_package" project="source_project">
+          <title>Unweaving the Rainbow</title>
+          <description>Eius corporis molestias nemo.</description>
+        </package>
+    http_version: 
+  recorded_at: Thu, 28 Feb 2019 08:59:55 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/source_project/source_package/_meta?user=tom
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="source_package" project="source_project">
+          <title>Unweaving the Rainbow</title>
+          <description>Eius corporis molestias nemo.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '166'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="source_package" project="source_project">
+          <title>Unweaving the Rainbow</title>
+          <description>Eius corporis molestias nemo.</description>
+        </package>
+    http_version: 
+  recorded_at: Thu, 28 Feb 2019 08:59:55 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:user_1/_meta?user=user_1
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:user_1">
+          <title/>
+          <description/>
+          <person userid="user_1" role="maintainer"/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '135'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:user_1">
+          <title></title>
+          <description></description>
+          <person userid="user_1" role="maintainer" />
+        </project>
+    http_version: 
+  recorded_at: Thu, 28 Feb 2019 08:59:55 GMT
+- request:
+    method: get
+    uri: http://backend:5352/build/home:tom:Staging:A/_result?code=unresolvable
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '56'
+    body:
+      encoding: UTF-8
+      string: '<resultlist state="00000000000000000000000000000000" />
+
+'
+    http_version: 
+  recorded_at: Thu, 28 Feb 2019 08:59:55 GMT
+recorded_with: VCR 4.0.0

--- a/src/api/spec/models/obs_factory/staging_project_spec.rb
+++ b/src/api/spec/models/obs_factory/staging_project_spec.rb
@@ -379,6 +379,26 @@ RSpec.describe ObsFactory::StagingProject do
 
       it { expect(subject.build_state).to eq(:acceptable) }
     end
+
+    context 'with repositories' do
+      let!(:standard_repo) { create(:repository, project: staging_a) }
+
+      before do
+        allow_any_instance_of(ObsFactory::StagingProject).to receive(:building_repositories).and_return([])
+      end
+
+      context 'with disabled project' do
+        let!(:flag) { create(:build_flag, status: 'disable', project: staging_a) }
+        it { expect(staging_project_a.disabled_repositories).to contain_exactly(standard_repo) }
+        it { expect(staging_project_a.build_state).to eq(:building) }
+      end
+
+      context 'with disabled repo' do
+        let!(:flag) { create(:build_flag, status: 'disable', project: staging_a, repo: standard_repo.name) }
+        it { expect(staging_project_a.disabled_repositories).to contain_exactly(standard_repo) }
+        it { expect(staging_project_a.build_state).to eq(:building) }
+      end
+    end
   end
 
   describe '#overall_state' do

--- a/src/api/spec/models/staging/staging_project_spec.rb
+++ b/src/api/spec/models/staging/staging_project_spec.rb
@@ -176,6 +176,12 @@ RSpec.describe Staging::StagingProject, vcr: true do
       it { expect(staging_project.missing_checks).to contain_exactly('check_1') }
       it { expect(staging_project.checks).to be_empty }
     end
+
+    context 'with disabled repository' do
+      let!(:flag) { create(:build_flag, status: 'disable', project: staging_project, repo: repository.name) }
+      it { expect(staging_project.disabled_repositories).to contain_exactly(repository) }
+      it { expect(staging_project.overall_state).to eq(:building) }
+    end
   end
 
   describe '#assign_managers_group' do


### PR DESCRIPTION
When osc crashes while selecting, sometimes we don't reenable the staging project and then it becomes acceptable - which is an error.

We discussed this in the release manager round and there is no valid use case of having disabled repositories *and* wanting it to be acceptable. Mapping this to 'building' is obviously a little fake, but unacceptable sounds too harsh too. So in building stagings the RM will look from time to time to see what's taking so long and she would notice then.

