### PR TITLE
Hide deleted and locked users in autocomplete search

### DIFF
--- a/src/api/app/models/user.rb
+++ b/src/api/app/models/user.rb
@@ -67,6 +67,7 @@ class User < ApplicationRecord
 
   scope :all_without_nobody, -> { where('login != ?', NOBODY_LOGIN) }
   scope :not_deleted, -> { where.not(state: 'deleted') }
+  scope :not_locked, -> { where.not(state: 'locked') }
   scope :with_login_prefix, ->(prefix) { where('login LIKE ?', "#{prefix}%") }
 
   validates :login, :state, presence: { message: 'must be given' }
@@ -142,7 +143,7 @@ class User < ApplicationRecord
   end
 
   def self.autocomplete_login(prefix = '')
-    with_login_prefix(prefix).limit(50).order(:login).pluck(:login)
+    with_login_prefix(prefix).not_deleted.not_locked.limit(50).order(:login).pluck(:login)
   end
 
   # the default state of a user based on the api configuration

--- a/src/api/spec/factories/users.rb
+++ b/src/api/spec/factories/users.rb
@@ -50,6 +50,10 @@ FactoryBot.define do
       state { 'deleted' }
     end
 
+    factory :locked_user do
+      state { 'locked' }
+    end
+
     factory :user_nobody do
       login { '_nobody_' }
     end

--- a/src/api/spec/models/user_spec.rb
+++ b/src/api/spec/models/user_spec.rb
@@ -502,11 +502,15 @@ RSpec.describe User do
   describe 'autocomplete methods' do
     let!(:foobar) { create(:confirmed_user, login: 'foobar') }
     let!(:fobaz) { create(:confirmed_user, login: 'fobaz') }
+    let!(:deleted_user) { create(:deleted_user) }
+    let!(:locked_user) { create(:locked_user) }
 
     context '#autocomplete_login' do
       it { expect(User.autocomplete_login('foo')).to match_array(['foobar']) }
       it { expect(User.autocomplete_login('bar')).to match_array([]) }
-      it { expect(User.autocomplete_login(nil)).to match_array(User.all.pluck(:login)) }
+      it { expect(User.autocomplete_login(nil)).to match_array(['foobar', 'fobaz']) }
+      it { expect(User.autocomplete_login(deleted_user.login)).to match_array([]) }
+      it { expect(User.autocomplete_login(locked_user.login)).to match_array([]) }
     end
 
     context '#autocomplete_token' do


### PR DESCRIPTION
Such users are not allowed to execute any actions. So it doesn't
make sense to offer them in forms, e.g. adding them as maintainer.

Fixes #7022



<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md
-->
