### PR TITLE
[backend] do not simply remove the worker building data

### DIFF
--- a/src/backend/bs_repserver
+++ b/src/backend/bs_repserver
@@ -1576,7 +1576,6 @@ sub workerstate {
 	  close F;
         }
       }
-      unlink("$workersdir/building/$idlename");
     }
     my $worker = {
       'hostarch' => $harch,
@@ -2066,7 +2065,8 @@ sub putjob {
   $idlename =~ s/\//_/g;
   if (!($BSConfig::masterdispatcher && $BSConfig::masterdispatcher ne $BSConfig::reposerver)) {
     print "oops, we are not building ($idlename)?\n" unless -e "$workersdir/building/$idlename";
-    unlink("$workersdir/building/$idlename");
+    mkdir_p("$workersdir/down") unless -d "$workersdir/down";
+    rename("$workersdir/building/$idlename", "$workersdir/down/$idlename");
   }
 
   if ($cgi->{'code'} && $cgi->{'code'} eq 'badhost') {


### PR DESCRIPTION
Removing it can make the dispatcher abort jobs with "no compliant
workers found". Instead, move the worker data to "down" for
a short amount of time. This is not optimal, but introducing a new
"resting" state seems a bit overkill...



<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md
-->
