### PR TITLE
Add a bento_only for project#linking_projects

### DIFF
--- a/src/api/app/controllers/webui/project_controller.rb
+++ b/src/api/app/controllers/webui/project_controller.rb
@@ -203,6 +203,7 @@ class Webui::ProjectController < Webui::WebuiController
 
   def packages_simple; end
 
+  # bento_only
   def linking_projects
     @linking_projects = @project.linked_by_projects.pluck(:name)
     render_dialog


### PR DESCRIPTION
In the new UI we used the @linking_projects variable instead of calling the controller again. For more details check: https://github.com/openSUSE/open-build-service/pull/7071



<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md
-->
