### PR TITLE
Migrate user configuration view to bootstrap

### DIFF
--- a/src/api/app/views/webui2/webui/user/index.html.haml
+++ b/src/api/app/views/webui2/webui/user/index.html.haml
@@ -4,6 +4,44 @@
 .card.mb-3
   = render partial: 'webui/configuration/tabs'
   .card-body
-    = link_to(user_register_user_path) do
-      %i.fas.fa-plus-circle.text-primary
-      Create User
+    .row.mb-3
+      .col
+        = link_to(user_register_user_path) do
+          %i.fas.fa-plus-circle.text-primary
+          Create User
+    .row
+      .col
+        %table.responsive.table.table-sm.table-striped.table-bordered#user-table
+          %thead
+            %tr
+              %td
+                User
+              - if Configuration.ldap_enabled?
+                %td
+                  Local user
+              %td
+                State
+              %td
+                Actions
+          %tbody
+            - @users.each do |user|
+              %tr
+                %td
+                  = image_tag_for(user, size: 20)
+                  = link_to(display_name(user), user_show_path(user))
+                - if Configuration.ldap_enabled?
+                  %td
+                    = user.ignore_auth_services?
+                %td
+                  = user.state
+                %td
+                  = link_to(user_edit_path(user.login)) do
+                    %i.fas.fa-edit.text-info{ title: 'Edit User' }
+                  = mail_to(user.email) do
+                    %i.far.fa-envelope{ title: 'Send Email to User' }
+                  = link_to(user_delete_path(user: { login: user.login }),
+                    method: :delete, data: { confirm: 'Are you sure?' }) do
+                    %i.fas.fa-times-circle.text-danger{ title: 'Delete user' }
+
+- content_for :ready_function do
+  $('#user-table').dataTable({ pageLength: 50 });


### PR DESCRIPTION
The user actions dropdown got replaced with linked icons like we
usually do in the new UI.
Some of the actions, like confirming and locking users, got removed
since this is already covered by the user edit page which is linked
from within in this table.



<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md
-->
