### PR TITLE
Use correct exception when a record can not be found

### DIFF
--- a/src/api/app/controllers/webui/package_controller.rb
+++ b/src/api/app/controllers/webui/package_controller.rb
@@ -154,7 +154,7 @@ class Webui::PackageController < Webui::WebuiController
     rescue Backend::Error
     end
 
-    raise ActionController::RoutingError, 'Not Found'
+    raise ActiveRecord::RecordNotFound, 'Not Found'
   end
 
   def binary
@@ -165,10 +165,10 @@ class Webui::PackageController < Webui::WebuiController
     begin
       @fileinfo = Backend::Api::BuildResults::Binaries.fileinfo_ext(@project, @package_name, @repository.name, @arch.name, @filename)
     rescue Backend::Error
-      raise ActionController::RoutingError, 'Not Found'
+      raise ActiveRecord::RecordNotFound, 'Not Found'
     end
     unless @fileinfo
-      raise ActionController::RoutingError, 'Not Found'
+      raise ActiveRecord::RecordNotFound, 'Not Found'
     end
 
     url_generator = ::PackageControllerService::URLGenerator.new(project: @project, package: @package_name,
@@ -189,7 +189,7 @@ class Webui::PackageController < Webui::WebuiController
 
     results_from_backend = Buildresult.find_hashed(project: @project, package: @package_name, repository: @repository, view: ['binarylist', 'status'])
     if results_from_backend.empty?
-      raise ActionController::RoutingError, 'Not Found'
+      raise ActiveRecord::RecordNotFound, 'Not Found'
     end
 
     @buildresults = []

--- a/src/api/app/controllers/webui/packages/build_reason_controller.rb
+++ b/src/api/app/controllers/webui/packages/build_reason_controller.rb
@@ -24,7 +24,7 @@ module Webui
                                                      use_source: false, follow_project_links: true, follow_multibuild: true)
         @is_link = @package.is_link? || @package.is_local_link?
       rescue APIError
-        raise ActionController::RoutingError, 'Not Found'
+        raise ActiveRecord::RecordNotFound, 'Not Found'
       end
 
       def set_repository

--- a/src/api/app/controllers/webui/packages/job_history_controller.rb
+++ b/src/api/app/controllers/webui/packages/job_history_controller.rb
@@ -20,7 +20,7 @@ module Webui
                                                      use_source: false, follow_project_links: true, follow_multibuild: true)
         @is_link = @package.is_link? || @package.is_local_link?
       rescue APIError
-        raise ActionController::RoutingError, 'Not Found'
+        raise ActiveRecord::RecordNotFound, 'Not Found'
       end
 
       def set_repository

--- a/src/api/app/controllers/webui/projects/project_configuration_controller.rb
+++ b/src/api/app/controllers/webui/projects/project_configuration_controller.rb
@@ -10,7 +10,7 @@ module Webui
 
         switch_to_webui2
         return if @content
-        raise ActionController::RoutingError, 'Not Found'
+        raise ActiveRecord::RecordNotFound, 'Not Found'
       end
 
       def update

--- a/src/api/app/controllers/webui/webui_controller.rb
+++ b/src/api/app/controllers/webui/webui_controller.rb
@@ -220,7 +220,7 @@ class Webui::WebuiController < ActionController::Base
 
     return if @package
 
-    raise(ActionController::RoutingError, 'Not Found') unless request.xhr?
+    raise(ActiveRecord::RecordNotFound, 'Not Found') unless request.xhr?
 
     render nothing: true, status: :not_found
   end

--- a/src/api/spec/controllers/webui/package_controller_spec.rb
+++ b/src/api/spec/controllers/webui/package_controller_spec.rb
@@ -394,7 +394,7 @@ RSpec.describe Webui::PackageController, vcr: true do
 
       let(:get_binaries) { get :binaries, params: { package: source_package, project: source_project, repository: repo_for_source_project.name } }
 
-      it { expect { get_binaries }.to raise_error(ActionController::RoutingError) }
+      it { expect { get_binaries }.to raise_error(ActiveRecord::RecordNotFound) }
     end
 
     context 'with build results and no binaries' do
@@ -562,7 +562,7 @@ RSpec.describe Webui::PackageController, vcr: true do
   describe 'GET #show' do
     context 'require_package before_action' do
       context 'with an invalid package' do
-        it { expect { get :show, params: { project: user.home_project, package: 'no_package' } }.to raise_error(ActionController::RoutingError) }
+        it { expect { get :show, params: { project: user.home_project, package: 'no_package' } }.to raise_error(ActiveRecord::RecordNotFound) }
       end
     end
 
@@ -908,7 +908,7 @@ RSpec.describe Webui::PackageController, vcr: true do
     context 'with an unexistent package' do
       let(:post_save_meta) { post :save_meta, params: { project: source_project, package: 'blah', meta: valid_meta } }
 
-      it { expect { post_save_meta }.to raise_error(ActionController::RoutingError) }
+      it { expect { post_save_meta }.to raise_error(ActiveRecord::RecordNotFound) }
     end
 
     context 'when connection with the backend fails' do
@@ -1368,7 +1368,7 @@ RSpec.describe Webui::PackageController, vcr: true do
     context 'when backend does not return statistics' do
       let(:get_statistics) { get :statistics, params: { project: source_project, package: source_package, arch: 'i586', repository: repository.name } }
 
-      it { expect { get_statistics }.to raise_error(ActionController::RoutingError) }
+      it { expect { get_statistics }.to raise_error(ActiveRecord::RecordNotFound) }
     end
 
     context 'when backend raises an exception' do
@@ -1380,7 +1380,7 @@ RSpec.describe Webui::PackageController, vcr: true do
 
       let(:get_statistics) { get :statistics, params: { project: source_project, package: source_package, arch: 'i586', repository: repository.name } }
 
-      it { expect { get_statistics }.to raise_error(ActionController::RoutingError) }
+      it { expect { get_statistics }.to raise_error(ActiveRecord::RecordNotFound) }
     end
   end
 
@@ -1454,7 +1454,7 @@ RSpec.describe Webui::PackageController, vcr: true do
                                filename: 'filename.txt' }
       end
 
-      it { expect { get_binary }.to raise_error(ActionController::RoutingError) }
+      it { expect { get_binary }.to raise_error(ActiveRecord::RecordNotFound) }
     end
 
     context 'without file info' do
@@ -1470,7 +1470,7 @@ RSpec.describe Webui::PackageController, vcr: true do
                                filename: 'filename.txt' }
       end
 
-      it { expect { get_binary }.to raise_error(ActionController::RoutingError) }
+      it { expect { get_binary }.to raise_error(ActiveRecord::RecordNotFound) }
     end
 
     context 'without a valid architecture' do

--- a/src/api/spec/controllers/webui/projects/project_configuration_controller_spec.rb
+++ b/src/api/spec/controllers/webui/projects/project_configuration_controller_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe Webui::Projects::ProjectConfigurationController, vcr: true do
         }
       end
 
-      it { expect { get :show, params: { project: apache_project } }.not_to raise_error(ActionController::RoutingError) }
+      it { expect { get :show, params: { project: apache_project } }.not_to raise_error }
     end
 
     context 'Can not load project config' do
@@ -27,7 +27,7 @@ RSpec.describe Webui::Projects::ProjectConfigurationController, vcr: true do
         }
       end
 
-      it { expect { get :show, params: { project: apache_project } }.to raise_error(ActionController::RoutingError) }
+      it { expect { get :show, params: { project: apache_project } }.to raise_error(ActiveRecord::RecordNotFound) }
     end
   end
 


### PR DESCRIPTION
In 4a505f1b34f37350159b782563eacbc4fd0700a1 the "nextstatus"
code was replaced by raising an exception which is handled by OBS
and causes a 404 view to be rendered.
But since ActionController::RoutingError exceptions also indicate
a bug in OBS we also notify errbit, our exception tracker, about
such errors.
This was causing our exception tracker to be spammed.

Instead we now send ActiveRecord::RecordNotFound exceptions, which
renders a 404 without notifying errbit.

Fixes #7080



<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md
-->
