### PR TITLE
Consider newlines for collapsible partial

### DIFF
--- a/src/api/app/views/webui2/webui/request/_request_history.html.haml
+++ b/src/api/app/views/webui2/webui/request/_request_history.html.haml
@@ -7,6 +7,6 @@
 
     %p.m-0.p-0 created request
 
-    = render partial: 'webui/webui/collapsible_text', locals: { text: bs_request.description, threshold: 100 }
+    = render partial: 'webui/webui/collapsible_text', locals: { text: bs_request.description, threshold: { text_length: 100, line_count: 3 } }
 
 = render partial: 'request_history_element', collection: history, as: :element

--- a/src/api/app/views/webui2/webui/request/_request_history_element.html.haml
+++ b/src/api/app/views/webui2/webui/request/_request_history_element.html.haml
@@ -8,4 +8,4 @@
       = link_to(element.description, request_show_path(element.description_extension))
     - else
       = simple_format(element.description, class: 'm-0 p-0 small')
-    = render partial: 'webui/webui/collapsible_text', locals: { text: element.comment, threshold: 100 }
+    = render partial: 'webui/webui/collapsible_text', locals: { text: element.comment, threshold: { text_length: 100, line_count: 3 } }

--- a/src/api/app/views/webui2/webui/request/_show_overview.html.haml
+++ b/src/api/app/views/webui2/webui/request/_show_overview.html.haml
@@ -3,7 +3,7 @@
 
 #description-text
   - if bs_request.description.present?
-    = render partial: 'webui/webui/collapsible_text', locals: { text: bs_request.description, threshold: 500 }
+    = render partial: 'webui/webui/collapsible_text', locals: { text: bs_request.description, threshold: { text_length: 1000, line_count: 10 } }
   - else
     %i No description set
 - if can_add_reviews

--- a/src/api/app/views/webui2/webui/webui/_collapsible_text.html.haml
+++ b/src/api/app/views/webui2/webui/webui/_collapsible_text.html.haml
@@ -1,6 +1,6 @@
 - if text.present?
   .obs-collapsible-textbox
-    - if text.length > threshold
+    - if text.length > threshold[:text_length] || text.lines.count > threshold[:line_count]
       .obs-collapsible-text.obs-collapsed
         = simple_format(text, class: 'm-0 p-0')
       %a.obs-collapsible-link.obs-collapsed.text-center.d-block{ title: 'Show more' }


### PR DESCRIPTION
Using only the text length was making the collapsible to inflexible.
This was causing the request description box being collapsed in many
cases where it didn't have to.
By also considering the number of newlines this becomes more flexible.

Part of #7056



<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md
-->
