### PR TITLE
Do not collapse request history when selecting

### DIFF
--- a/src/api/app/assets/javascripts/webui2/collapsible_text.js
+++ b/src/api/app/assets/javascripts/webui2/collapsible_text.js
@@ -1,9 +1,12 @@
 $(document).ready(function() {
   $('.obs-collapsible-textbox').on('click', function() {
-    var collapsibleLink = $(this).find('.obs-collapsible-link');
-    var showText = (collapsibleLink.attr('title') === 'Show more' ) ? 'Show less' : 'Show more';
+    var selectedText = document.getSelection().toString();
+    if(!selectedText) {
+      var collapsibleLink = $(this).find('.obs-collapsible-link');
+      var showText = (collapsibleLink.attr('title') === 'Show more' ) ? 'Show less' : 'Show more';
 
-    $(this).find('.obs-collapsible-text, .obs-collapsible-link').toggleClass('obs-collapsed obs-uncollapsed');
-    collapsibleLink.attr('title', showText);
+      $(this).find('.obs-collapsible-text, .obs-collapsible-link').toggleClass('obs-collapsed obs-uncollapsed');
+      collapsibleLink.attr('title', showText);
+    }
   });
 });


### PR DESCRIPTION
In the request show page, the history elements which a long description used to collapse when selecting the text. The user needed most likely to open it again.

![image](https://user-images.githubusercontent.com/16052290/53727323-381a0780-3e70-11e9-968b-cdbd91f35d62.png)

Fixes https://github.com/openSUSE/open-build-service/issues/6994

<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md
-->
