### PR TITLE
Be consistent in Manage Groups/Users views

### DIFF
--- a/src/api/app/views/webui2/webui/groups/_breadcrumb_items.html.haml
+++ b/src/api/app/views/webui2/webui/groups/_breadcrumb_items.html.haml
@@ -1,20 +1,22 @@
-- if current_page?(groups_path)
+- case action_name
+- when 'index'
   -# This page is only reachable from the configuration, so it's based on configuration
   = render partial: 'webui/configuration/breadcrumb_items'
   %li.breadcrumb-item.active{ 'aria-current' => 'page' }
     Manage Groups
-- else
-  = render partial: 'webui/main/breadcrumb_items'
+- when 'new'
+  = render partial: 'webui/configuration/breadcrumb_items'
   %li.breadcrumb-item
-    = link_to 'Groups', groups_path
-  - if current_page?(group_new_path)
-    %li.breadcrumb-item.active{ 'aria-current' => 'page' }
-      Create Group
-  - elsif current_page?(group_show_path)
-    %li.breadcrumb-item.active{ 'aria-current' => 'page' }
-      = @group
-  - else
-    %li.breadcrumb-item
-      = link_to @group, group_show_path(@group)
-    %li.breadcrumb-item.active{ 'aria-current' => 'page' }
-      Edit
+    = link_to 'Manage Groups', groups_path
+  %li.breadcrumb-item.active{ 'aria-current' => 'page' }
+    Create Group
+- when 'edit'
+  = render partial: 'webui/configuration/breadcrumb_items'
+  %li.breadcrumb-item
+    = link_to('Manage Groups', groups_path)
+  %li.breadcrumb-item.active{ 'aria-current' => 'page' }
+    = @group
+- when 'show'
+  = render partial: 'webui/main/breadcrumb_items'
+  %li.breadcrumb-item.active{ 'aria-current' => 'page' }
+    = @group

--- a/src/api/app/views/webui2/webui/groups/edit.html.haml
+++ b/src/api/app/views/webui2/webui/groups/edit.html.haml
@@ -1,14 +1,14 @@
 - @pagetitle = "Edit Group #{@group}"
 
 .card.mb-3
-  = render partial: 'webui/configuration/tabs'
   .card-body
     %h3= @pagetitle
-    = form_tag(group_update_path(title: @group)) do
-      .form-group.col-md-6.pl-0
-        = label_tag(:members)
-        = text_field_tag('group[members]', @members, id: 'group-members', class: 'form-control tag-input', data: { source: user_autocomplete_path })
-      = submit_tag('Save', class: 'btn btn-primary')
+    .col-lg-6.pl-0
+      = form_tag(group_update_path(title: @group)) do
+        .form-group
+          = label_tag(:members)
+          = text_field_tag('group[members]', @members, id: 'group-members', class: 'form-control tag-input', data: { source: user_autocomplete_path })
+        = submit_tag('Save', class: 'btn btn-primary')
 
 = content_for(:ready_function) do
   initializeGroupTokenfield();

--- a/src/api/app/views/webui2/webui/groups/index.html.haml
+++ b/src/api/app/views/webui2/webui/groups/index.html.haml
@@ -3,7 +3,7 @@
 .card.mb-3
   = render partial: 'webui/configuration/tabs'
   .card-body
-    %h3 Manage Groups
+    %h3= @pagetitle
     %table.responsive.table.table-sm.table-striped.table-bordered.w-100#manage-groups-table
       %thead
         %tr
@@ -18,7 +18,7 @@
             %td
               = safe_join(group.users.map { |user| link_to(truncate(user.login, length: 20), user_show_path(user), title: user.login) }, ', ')
             %td
-              = link_to(group_edit_title_path(title: group), title: 'Edit') do
+              = link_to(group_edit_title_path(title: group), title: 'Edit Group') do
                 %i.fas.fa-edit.text-secondary
 
     .pt-4

--- a/src/api/app/views/webui2/webui/groups/index.html.haml
+++ b/src/api/app/views/webui2/webui/groups/index.html.haml
@@ -27,4 +27,4 @@
         Create Group
 
 = content_for(:ready_function) do
-  initializeDataTable('#manage-groups-table');
+  initializeDataTable('#manage-groups-table', { columnDefs: [{ orderable: false, searchable: false, targets: -1 }] });

--- a/src/api/app/views/webui2/webui/groups/new.html.haml
+++ b/src/api/app/views/webui2/webui/groups/new.html.haml
@@ -1,18 +1,18 @@
 - @pagetitle = 'Create Group'
 
 .card.mb-3
-  = render partial: 'webui/configuration/tabs'
   .card-body
     %h3= @pagetitle
-    = form_for(Group.new, url: group_create_path, method: :post) do |form|
-      .form-group.col-md-6.pl-0
-        = form.label(:title)
-        %abbr.text-danger{ title: 'required' } *
-        = form.text_field(:title, class: 'form-control', required: true, autofocus: true)
-      .form-group.col-md-6.pl-0
-        = label_tag(:members)
-        = text_field_tag('group[members]', @members, id: 'group-members', class: 'form-control tag-input', data: { source: user_autocomplete_path })
-      = form.submit('Create', class: 'btn btn-primary', data: { disable_with: 'Creating...' })
+    .col-lg-6.pl-0
+      = form_for(Group.new, url: group_create_path, method: :post) do |form|
+        .form-group
+          = form.label(:title)
+          %abbr.text-danger{ title: 'required' } *
+          = form.text_field(:title, class: 'form-control', required: true, autofocus: true)
+        .form-group
+          = label_tag(:members)
+          = text_field_tag('group[members]', @members, id: 'group-members', class: 'form-control tag-input', data: { source: user_autocomplete_path })
+        = form.submit('Create', class: 'btn btn-primary', data: { disable_with: 'Creating...' })
 
 = content_for(:ready_function) do
   initializeGroupTokenfield();

--- a/src/api/app/views/webui2/webui/user/_breadcrumb_items.html.haml
+++ b/src/api/app/views/webui2/webui/user/_breadcrumb_items.html.haml
@@ -12,9 +12,8 @@
     = @displayed_user
 - when 'show'
   = render partial: 'webui/main/breadcrumb_items'
-  - if action_name == 'show'
-    %li.breadcrumb-item.active{ 'aria-current' => 'page' }
-      Home of #{@displayed_user}
+  %li.breadcrumb-item.active{ 'aria-current' => 'page' }
+    Home of #{@displayed_user}
 - when 'register_user'
   = render partial: 'webui/configuration/breadcrumb_items'
   %li.breadcrumb-item

--- a/src/api/app/views/webui2/webui/user/edit.html.haml
+++ b/src/api/app/views/webui2/webui/user/edit.html.haml
@@ -1,35 +1,32 @@
-- @pagetitle = 'Edit User'
+- @pagetitle = "Edit User #{@displayed_user}"
 
-.container
-  .card
-    .card-body
-      %h2
-        Edit User #{@displayed_user.login}
-      .row
-        .col-md-6
-          = form_for(@displayed_user, url: user_save_path, method: 'post') do |form|
-            = form.hidden_field(:login)
-            .form-group
-              = form.label(:realname, 'Name:')
-              = form.text_field(:realname, disabled: user_is_configurable(@configuration, @displayed_user), class: 'form-control')
-            .form-group
-              = form.label(:email, 'Email:')
-              %abbr.text-danger{ title: 'required' } *
-              = form.text_field(:email, required: true, email: true, disabled: user_is_configurable(@configuration, @displayed_user),
-                class: 'form-control')
-            .form-group
-              = form.collection_check_boxes(:role_ids, Role.global, :id, :title, {}) do |checkbox|
-                .custom-control.custom-checkbox
-                  = checkbox.check_box(class: 'custom-control-input')
-                  = checkbox.label(class: 'custom-control-label')
-            .form-group
-              = form.collection_radio_buttons(:state, User::STATES - ['subaccount'], :to_s, :to_s, class: 'custom-control-input') do |radio|
-                .custom-control.custom-radio.custom-control-inline
-                  = radio.radio_button(class: 'custom-control-input')
-                  = radio.label(class: 'custom-control-label')
-            - if Configuration.ldap_enabled? && User.current.is_admin?
-              .form-group
-                .custom-control.custom-checkbox
-                  = form.check_box(:ignore_auth_services, { class: 'custom-control-input' }, true)
-                  = form.label(:ignore_auth_services, 'Local user', class: 'custom-control-label')
-            = form.submit('Update', class: 'btn btn-primary')
+.card.mb-3
+  .card-body
+    %h3= @pagetitle
+    .col-md-6.pl-0
+      = form_for(@displayed_user, url: user_save_path, method: 'post') do |form|
+        = form.hidden_field(:login)
+        .form-group
+          = form.label(:realname, 'Name:')
+          = form.text_field(:realname, disabled: user_is_configurable(@configuration, @displayed_user), class: 'form-control')
+        .form-group
+          = form.label(:email, 'Email:')
+          %abbr.text-danger{ title: 'required' } *
+          = form.text_field(:email, required: true, email: true, disabled: user_is_configurable(@configuration, @displayed_user),
+            class: 'form-control')
+        .form-group
+          = form.collection_check_boxes(:role_ids, Role.global, :id, :title, {}) do |checkbox|
+            .custom-control.custom-checkbox
+              = checkbox.check_box(class: 'custom-control-input')
+              = checkbox.label(class: 'custom-control-label')
+        .form-group
+          = form.collection_radio_buttons(:state, User::STATES - ['subaccount'], :to_s, :to_s, class: 'custom-control-input') do |radio|
+            .custom-control.custom-radio.custom-control-inline
+              = radio.radio_button(class: 'custom-control-input')
+              = radio.label(class: 'custom-control-label')
+        - if Configuration.ldap_enabled? && User.current.is_admin?
+          .form-group
+            .custom-control.custom-checkbox
+              = form.check_box(:ignore_auth_services, { class: 'custom-control-input' }, true)
+              = form.label(:ignore_auth_services, 'Local user', class: 'custom-control-label')
+        = form.submit('Update', class: 'btn btn-primary', data: { disable_with: 'Updating...' })

--- a/src/api/app/views/webui2/webui/user/index.html.haml
+++ b/src/api/app/views/webui2/webui/user/index.html.haml
@@ -44,4 +44,4 @@
                     %i.fas.fa-times-circle.text-danger{ title: 'Delete user' }
 
 - content_for :ready_function do
-  $('#user-table').dataTable({ pageLength: 50 });
+  initializeDataTable('#user-table', { pageLength: 50, columnDefs: [{ orderable: false, searchable: false, targets: -1 }] });

--- a/src/api/app/views/webui2/webui/user/index.html.haml
+++ b/src/api/app/views/webui2/webui/user/index.html.haml
@@ -1,47 +1,45 @@
-:ruby
-  @pagetitle = 'Manage Users'
+- @pagetitle = 'Manage Users'
 
 .card.mb-3
   = render partial: 'webui/configuration/tabs'
   .card-body
-    .row.mb-3
-      .col
-        = link_to(user_register_user_path) do
-          %i.fas.fa-plus-circle.text-primary
-          Create User
-    .row
-      .col
-        %table.responsive.table.table-sm.table-striped.table-bordered#user-table
-          %thead
-            %tr
+    %h3= @pagetitle
+    %table.responsive.table.table-sm.table-striped.table-bordered#user-table
+      %thead
+        %tr
+          %td
+            User
+          - if Configuration.ldap_enabled?
+            %td
+              Local User
+          %td
+            State
+          %td
+            Actions
+      %tbody
+        - @users.each do |user|
+          %tr
+            %td
+              = image_tag_for(user, size: 20)
+              = link_to(display_name(user), user_show_path(user))
+            - if Configuration.ldap_enabled?
               %td
-                User
-              - if Configuration.ldap_enabled?
-                %td
-                  Local user
-              %td
-                State
-              %td
-                Actions
-          %tbody
-            - @users.each do |user|
-              %tr
-                %td
-                  = image_tag_for(user, size: 20)
-                  = link_to(display_name(user), user_show_path(user))
-                - if Configuration.ldap_enabled?
-                  %td
-                    = user.ignore_auth_services?
-                %td
-                  = user.state
-                %td
-                  = link_to(user_edit_path(user.login)) do
-                    %i.fas.fa-edit.text-info{ title: 'Edit User' }
-                  = mail_to(user.email) do
-                    %i.far.fa-envelope{ title: 'Send Email to User' }
-                  = link_to(user_delete_path(user: { login: user.login }),
-                    method: :delete, data: { confirm: 'Are you sure?' }) do
-                    %i.fas.fa-times-circle.text-danger{ title: 'Delete user' }
+                = user.ignore_auth_services?
+            %td
+              = user.state
+            %td
+              = link_to(user_edit_path(user.login)) do
+                %i.fas.fa-edit.text-secondary{ title: 'Edit User' }
+              = mail_to(user.email) do
+                %i.far.fa-envelope.text-secondary{ title: 'Send Email to User' }
+              = link_to(user_delete_path(user: { login: user.login }),
+                method: :delete, data: { confirm: 'Are you sure?' }) do
+                %i.fas.fa-times-circle.text-danger{ title: 'Delete user' }
+
+    .pt-4
+      = link_to(user_register_user_path) do
+        %i.fas.fa-plus-circle.text-primary
+        Create User
 
 - content_for :ready_function do
   initializeDataTable('#user-table', { pageLength: 50, columnDefs: [{ orderable: false, searchable: false, targets: -1 }] });

--- a/src/api/app/views/webui2/webui/user/register_user.html.haml
+++ b/src/api/app/views/webui2/webui/user/register_user.html.haml
@@ -1,12 +1,10 @@
-:ruby
-  @pagetitle = 'Create User'
+- @pagetitle = 'Create User'
 
-.card
+.card.mb-3
   .card-body
-    .row
-      .col-lg-6
-        - if can_register
-          %h5.card-title  Create User
-          = render partial: 'webui2/shared/sign_up', locals: { submit_btn_text: 'Create' }
-        - else
-          %p Sorry, sign up is disabled
+    .col-lg-6.pl-0
+      - if can_register
+        %h3= @pagetitle
+        = render partial: 'webui2/shared/sign_up', locals: { submit_btn_text: 'Create' }
+      - else
+        %p Sorry, sign up is disabled

--- a/src/api/app/views/webui2/webui/user/show.html.haml
+++ b/src/api/app/views/webui2/webui/user/show.html.haml
@@ -1,5 +1,4 @@
-:ruby
-  @pagetitle = "Home of #{@displayed_user}"
+- @pagetitle = "Home of #{@displayed_user}"
 
 .row
   .col-12.col-md-4.col-lg-3

--- a/src/api/app/views/webui2/webui/user/signup.html.haml
+++ b/src/api/app/views/webui2/webui/user/signup.html.haml
@@ -1,12 +1,10 @@
-:ruby
-  @pagetitle = 'Sign Up'
+- @pagetitle = 'Sign Up'
 
-.card
+.card.mb-3
   .card-body
-    .row
-      .col-lg-6
-        - if can_register
-          %h5.card-title  Sign Up for an Open Build Service account
-          = render partial: 'webui2/shared/sign_up', locals: { submit_btn_text: 'Sign Up' }
-        - else
-          %p Sorry, sign up is disabled
+    .col-lg-6.pl-0
+      - if can_register
+        %h3= @pagetitle
+        = render partial: 'webui2/shared/sign_up', locals: { submit_btn_text: 'Sign Up' }
+      - else
+        %p Sorry, sign up is disabled


### PR DESCRIPTION
To compare the two options regarding the new/edit views, the Groups views have tabs and the Users views don't. I prefer with tabs, but I want your opinion on this. Once we decide, I will do it for both sets of pages. We still have one issue to fix for tabs as the `Manage Groups/Users` is not active when we are on the new/edit views.

Refer to the commits for details on what changed exactly. It's already written there.

Links for review:
- http://obs-reviewlab.opensuse.org/dmarcoux-consistent-manage-groups-users/groups
- http://obs-reviewlab.opensuse.org/dmarcoux-consistent-manage-groups-users/group/new
- http://obs-reviewlab.opensuse.org/dmarcoux-consistent-manage-groups-users/group/edit/review-team
- http://obs-reviewlab.opensuse.org/dmarcoux-consistent-manage-groups-users/users
- http://obs-reviewlab.opensuse.org/dmarcoux-consistent-manage-groups-users/user/register_user
- http://obs-reviewlab.opensuse.org/dmarcoux-consistent-manage-groups-users/user/signup
- http://obs-reviewlab.opensuse.org/dmarcoux-consistent-manage-groups-users/user/edit/Iggy