### PR TITLE
Reload apache instead of restarting it

### DIFF
--- a/dist/obs-server.spec
+++ b/dist/obs-server.spec
@@ -601,7 +601,7 @@ fi
 %postun -n obs-api
 %insserv_cleanup
 %service_del_postun %{obs_api_support_scripts}
-%restart_on_update apache2
+%service_del_postun -r apache2
 
 %files
 %defattr(-,root,root)


### PR DESCRIPTION
`restart_on_update` called `systemctl try-restart`, while
`service_del_postun -r` calls `systemctl force-reload`,
that is what it is expected to be done on each update of
the `obs-api` package.

Thanks to @bugfinder for providing the solution.