### PR TITLE
Raise exception if TS guard file exists while running FullTextIndexJob

### DIFF
--- a/src/api/app/jobs/full_text_index_job.rb
+++ b/src/api/app/jobs/full_text_index_job.rb
@@ -1,9 +1,17 @@
+class ThinkingSphinx::GuardfileExistsError < StandardError
+  def message
+    "Guardfile #{File.join(ThinkingSphinx::Configuration.instance.indices_location, 'ts---all.tmp')} exists already"
+  end
+end
+
 class FullTextIndexJob < ApplicationJob
   queue_as :quick
 
   def perform
     return unless Rails.env.production?
-
+    # From time to time, ThinkingSphinx aborts keeping the guard file there
+    # making impossible to rebuild the index. We want to have the exception on errbit
+    raise ThinkingSphinx::GuardfileExistsError if ThinkingSphinx::Guard::File.new('--all').locked?
     # Ensure the connection
     ApplicationRecord.connection_pool.with_connection do |_|
       # Use the RakeInterface provided by ThinkingSphinx


### PR DESCRIPTION
From time to time, ThinkingSphinx aborts keeping the guard file there
making impossible to rebuild the index. We want to have the exception on errbit to be able to track this issue

Co-authored-by: Henne Vogelsang <hvogel@opensuse.org>