### PR TITLE
[backend] use long gpg keyids instead of the short ones

### DIFF
--- a/src/backend/BSSrcServer/Signkey.pm
+++ b/src/backend/BSSrcServer/Signkey.pm
@@ -140,7 +140,7 @@ sub pubkeyinfo {
   $pubkey->{'keysize'} = $keysize if $keysize;
   $pubkey->{'userid'} = $userid if defined $userid;
   if ($fingerprint) {
-    $pubkey->{'keyid'} = substr($fingerprint, -8, 8);
+    $pubkey->{'keyid'} = substr($fingerprint, -16, 16);
     $fingerprint =~ s/(....)/$1 /g;
     $fingerprint =~ s/ $//;
     $pubkey->{'fingerprint'} = $fingerprint;


### PR DESCRIPTION
The shore ones are deprecated because they are not secure enough.



<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md
-->
