### PR TITLE
Align behavior of popovers throughout all views

### DIFF
--- a/src/api/app/assets/javascripts/webui2/buildresult.js
+++ b/src/api/app/assets/javascripts/webui2/buildresult.js
@@ -38,7 +38,7 @@ function updateBuildResult(index) { // jshint ignore:line
     },
     complete: function() {
       $('#build' + index + '-reload').removeClass('fa-spin');
-      $('[data-toggle="popover"]').popover({ trigger: 'hover click' });
+      initializePopovers('[data-toggle="popover"]'); // jshint ignore:line
     }
   });
 }

--- a/src/api/app/assets/javascripts/webui2/popover.js
+++ b/src/api/app/assets/javascripts/webui2/popover.js
@@ -1,3 +1,16 @@
 $(function () {
-  $('[data-toggle="popover"]').popover();
+  initializePopovers('[data-toggle="popover"]');
 });
+
+function initializePopovers(cssSelector, params) {
+  var defaultParams = { trigger: 'hover click' };
+  var newParams = $.extend(defaultParams, params);
+
+  // Remove all popovers as they might be stagnant due to a partial page reload
+  $('div.popover').remove();
+
+  $(cssSelector).popover(newParams).on('show.bs.popover', function() {
+    // Hide all popovers, so only the one triggering this event will be shown
+    $(cssSelector).popover('hide');
+  });
+}

--- a/src/api/app/assets/javascripts/webui2/project_monitor.js
+++ b/src/api/app/assets/javascripts/webui2/project_monitor.js
@@ -1,7 +1,3 @@
-function setupPopover() {
-  $('[data-toggle="popover"]').popover({ trigger: 'hover click' });
-}
-
 function setAllLinks(event) {
   $(this).closest('.dropdown-menu').find('input').prop('checked', event.data.checked);
 }
@@ -83,10 +79,10 @@ function setupProjectMonitor() { // jshint ignore:line
   });
 
   $('#project-monitor-table').on('draw.dt', function () {
-    setupPopover();
+    initializePopovers('[data-toggle="popover"]'); // jshint ignore:line
   });
 
-  setupPopover();
+  initializePopovers('[data-toggle="popover"]'); // jshint ignore:line
 
   $('.monitor-no-filter-link').on('click', { checked: false }, setAllLinks);
 

--- a/src/api/app/assets/javascripts/webui2/repositories.js
+++ b/src/api/app/assets/javascripts/webui2/repositories.js
@@ -46,24 +46,20 @@ function prepareFlagPopover() {
   return clone;
 }
 
-function setupFlagPopupType(flagType) {
-  $('#flag_table_' + flagType + ' .flag-popup').popover({
-    trigger: 'click',
-    html: true,
-    content: prepareFlagPopover
-  });
+function initializeFlagPopovers(cssSelector) {
+  initializePopovers(cssSelector, { trigger: 'click', html: true, content: prepareFlagPopover }); // jshint ignore:line
 }
 
 function replaceFlagTable(data, flagType) {
   $('#flag_table_' + flagType).html(data);
-  setupFlagPopupType(flagType);
+  initializeFlagPopovers('#flag_table_' + flagType + ' .flag-popup');
 }
 
 function setupFlagPopup() { // jshint ignore:line
-  setupFlagPopupType('build');
-  setupFlagPopupType('useforbuild');
-  setupFlagPopupType('debuginfo');
-  setupFlagPopupType('publish');
+  ['build', 'useforbuild', 'debuginfo', 'publish'].forEach(function(flagType) {
+    initializeFlagPopovers('#flag_table_' + flagType + ' .flag-popup');
+  });
+
   $(document).on('click', '.popover_flag_action', function(e) {
     var flagType = $(this).parent().data('flag');
     var data = {


### PR DESCRIPTION
Refactor initialization of popovers to remove duplication and align
behavior of all popovers. In a group of popovers, which is initialized
with a CSS selector, only one popover at a time can be shown. All shown
popovers are removed when a popover group is initialized.

Ignore JSHint errors regarding 'initializePopovers' is not defined.

Fixes #6950

Links for review:
- Build Results: https://obs-reviewlab.opensuse.org/dmarcoux-issue-6950/project/show/home:Admin
- Project Repositories (all flags: https://obs-reviewlab.opensuse.org/dmarcoux-issue-6950/repositories/home:Admin
- Project Monitor: https://obs-reviewlab.opensuse.org/dmarcoux-issue-6950/project/monitor/home:Admin