### PR TITLE
Remember number of shown entries for project monitor datatable

### DIFF
--- a/src/api/app/assets/javascripts/webui2/project_monitor.js
+++ b/src/api/app/assets/javascripts/webui2/project_monitor.js
@@ -42,7 +42,7 @@ function initializeMonitorDataTable() {
   initializeDataTable('#project-monitor-table', { // jshint ignore:line
     scrollX: true,
     fixedColumns: true,
-    pageLength: 50,
+    pageLength: $('#shown-entries').val(),
     lengthMenu: [[10, 25, 50, 100, -1], [10, 25, 50, 100, "All"]],
     data: packageNames,
     search: {
@@ -74,6 +74,10 @@ function initializeMonitorDataTable() {
 
 function setupProjectMonitor() { // jshint ignore:line
   initializeMonitorDataTable();
+
+  $('select[name="project-monitor-table_length"]').change(function(){
+    $('#shown-entries').val($(this).val());
+  });
 
   $('#table-spinner').addClass('d-none');
   $('#project-monitor .obs-dataTable').removeClass('invisible');

--- a/src/api/app/controllers/webui/project_controller.rb
+++ b/src/api/app/controllers/webui/project_controller.rb
@@ -390,6 +390,7 @@ class Webui::ProjectController < Webui::WebuiController
     end
 
     monitor_parse_buildresult(buildresult)
+    @shown_entries = params.fetch('shown-entries', 50)
 
     # extract repos
     repohash = {}

--- a/src/api/app/views/webui2/webui/project/_monitor_control.html.haml
+++ b/src/api/app/views/webui2/webui/project/_monitor_control.html.haml
@@ -2,6 +2,7 @@
   .col-md-12
     = form_tag(project_monitor_path, project: project, method: :get) do
       = hidden_field_tag :defaults, 0
+      = hidden_field_tag 'shown-entries', shown_entries
       %span.dropdown#project-monitor-status-dropdown
         %button.btn.btn-outline-secondary.dropdown-toggle{ data: { toggle: :dropdown }, type: :button }
           %span.caret

--- a/src/api/app/views/webui2/webui/project/monitor.html.haml
+++ b/src/api/app/views/webui2/webui/project/monitor.html.haml
@@ -8,7 +8,7 @@
       %p Unavailable Build Results.
     - else
       = render partial: 'monitor_control',
-        locals: { project: @project, activate_client_search: @activate_client_search,
+        locals: { project: @project, activate_client_search: @activate_client_search, shown_entries: @shown_entries,
         status: @avail_status_values, repositories: @avail_repo_values, architectures: @avail_arch_values,
         repository_filter: @repo_filter, architecture_filter: @arch_filter, status_filter: @status_filter }
       - tableinfo = []


### PR DESCRIPTION
The complete page is refreshed when applying filters, so this explains
the solution.

Fixes #6883
