### PR TITLE
[api] fix crash on request creation with enabled notification

### DIFF
--- a/src/api/app/models/bs_request.rb
+++ b/src/api/app/models/bs_request.rb
@@ -295,7 +295,12 @@ class BsRequest < ApplicationRecord
     new = created_at ? nil : 1
     sanitize! if new && !@skip_sanitize
     super
-    notify if new
+    if new
+      reviews.each do |review|
+        review.save!
+      end
+      notify
+    end
   end
 
   def history_elements


### PR DESCRIPTION
requests getting default reviewers need to store the review first
before being able to access created_at in notification code.



<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md
-->
