### PR TITLE
Show reason and requestor of review requests in the review request field

### DIFF
--- a/src/api/app/helpers/webui/request_helper.rb
+++ b/src/api/app/helpers/webui/request_helper.rb
@@ -194,4 +194,8 @@ module Webui::RequestHelper
     end.html_safe
   end
   # rubocop:enable Style/FormatStringToken, Style/FormatString
+
+  def review_request_reason(bs_request, review)
+    bs_request.request_history_elements.where(description_extension: review[:id]).pluck(:comment).first.presence || 'No reason given'
+  end
 end

--- a/src/api/app/models/review.rb
+++ b/src/api/app/models/review.rb
@@ -189,6 +189,7 @@ class Review < ApplicationRecord
     ret = _get_attributes
     # XML has this perl format, don't use that here
     ret[:when] = created_at
+    ret[:id] = id
     ret
   end
 

--- a/src/api/app/views/webui/request/show.html.erb
+++ b/src/api/app/views/webui/request/show.html.erb
@@ -253,6 +253,8 @@
         <% @my_open_reviews.each_with_index do |review, index| %>
             <div class="review_descision_display <%= 'hidden' if index != 0 %>" id="review_descision_display_<%= index %>">
               <%= form_tag(action: 'modify_review') do %>
+                  <p><%= user_with_realname_and_icon(review[:who], short: true) %> requested:</p>
+                  <p><%= simple_format(review_request_reason(@bs_request, review)) %></p>
                   <p><%= text_area_tag('comment', review[:reason], size: '80x2', style: 'width: 99%', class: 'review_comment', placeholder: 'Please comment on your decision') %></p>
 
                   <p>

--- a/src/api/app/views/webui2/webui/request/_review_tab.html.haml
+++ b/src/api/app/views/webui2/webui/request/_review_tab.html.haml
@@ -1,6 +1,12 @@
 = form_tag(action: 'modify_review') do
-  = hidden_field_tag('request_number', request_number)
+  = hidden_field_tag('request_number', bs_request.number)
   = hidden_review_payload(review)
+  %p
+    = user_name_with_icon(User.find_by(login: review[:who]))
+    requested:
+  .ml-4
+    %p
+      #{simple_format(review_request_reason(bs_request, review))}
   %p
     = text_area_tag('comment', review[:reason], rows: 4, class: 'w-100 form-control', placeholder: 'Please comment on your decision')
   %p

--- a/src/api/app/views/webui2/webui/request/show.html.haml
+++ b/src/api/app/views/webui2/webui/request/show.html.haml
@@ -62,7 +62,7 @@
                          is_author: @is_author, single_action_request: @actions.count == 1, action: @actions.first)
             - @my_open_reviews.each_with_index do |review, index|
               .tab-pane.fade.show{ id: "review-#{index}", class: ('active' unless @can_handle_request) }
-                = render('review_tab', review: review, request_number: @bs_request.number)
+                = render('review_tab', review: review, bs_request: @bs_request)
 
   .col-md-4
     .card

--- a/src/api/spec/bootstrap/features/webui/requests_spec.rb
+++ b/src/api/spec/bootstrap/features/webui/requests_spec.rb
@@ -133,6 +133,7 @@ RSpec.feature 'Bootstrap_Requests', type: :feature, js: true, vcr: true do
         click_link 'Add a Review'
         find(:id, 'review_type').select('User')
         fill_in 'review_user', with: reviewer.login
+        fill_in 'Comment for reviewer:', with: 'Please review'
         click_button('Accept')
         expect(page).to have_text(/Open review for\s+#{reviewer.login}/)
         expect(page).to have_text('Request 1 (review)')
@@ -142,8 +143,12 @@ RSpec.feature 'Bootstrap_Requests', type: :feature, js: true, vcr: true do
         login reviewer
         visit request_show_path(1)
         click_link("Review for #{reviewer}")
-        fill_in 'comment', with: 'Ok for the project'
-        click_button 'Approve'
+        within '#review-0' do
+          expect(page).to have_text("#{submitter.realname} (#{submitter.login}) requested:")
+          expect(page).to have_text('Please review')
+          fill_in 'comment', with: 'Ok for the project'
+          click_button 'Approve'
+        end
         expect(page).to have_text('Ok for the project')
         expect(Review.first.state).to eq(:accepted)
         expect(BsRequest.first.state).to eq(:new)

--- a/src/api/spec/helpers/webui/request_helper_spec.rb
+++ b/src/api/spec/helpers/webui/request_helper_spec.rb
@@ -188,4 +188,40 @@ RSpec.describe Webui::RequestHelper do
       it { is_expected.to match(expected_regex) }
     end
   end
+
+  describe '#review_request_reason' do
+    let(:bs_request) do
+      create(:bs_request_with_submit_action,
+             target_package: target_package,
+             source_package: source_package)
+    end
+    let(:review) { bs_request.reviews.first }
+    let(:user) { create(:confirmed_user) }
+
+    subject { review_request_reason(bs_request, review) }
+
+    context 'when review has no request reason' do
+      before do
+        bs_request.addreview(by_user: user)
+      end
+
+      it { is_expected.to eq('No reason given') }
+    end
+
+    context 'when review has a request reason' do
+      before do
+        bs_request.addreview(by_user: user, comment: 'Please have a look.')
+      end
+
+      it { is_expected.to eq('Please have a look.') }
+    end
+
+    context 'when the request reason is empty' do
+      before do
+        bs_request.addreview(by_user: user, comment: '')
+      end
+
+      it { is_expected.to eq('No reason given') }
+    end
+  end
 end


### PR DESCRIPTION
Reviewers need this information to know what is expected from them, aka
why a review was assigned to them.

Fixes #7088


Old UI:
![2019-03-06_17-05](https://user-images.githubusercontent.com/968949/53897287-19656d80-4036-11e9-995c-665bec8e0a87.png)

New UI:
![2019-03-06_17-00](https://user-images.githubusercontent.com/968949/53897294-1ec2b800-4036-11e9-9409-32a96162c73d.png)
