### PR TITLE
Fix icon color of 'Show Patchinfo' link

### DIFF
--- a/src/api/app/views/webui2/webui/project/bottom_actions/_patchinfo.html.haml
+++ b/src/api/app/views/webui2/webui/project/bottom_actions/_patchinfo.html.haml
@@ -1,7 +1,7 @@
 - if has_patchinfo
   %li.list-inline-item
     = link_to(patchinfo_show_path(project, 'patchinfo'), class: 'nav-link') do
-      %span.fa-stack.half-font-size.text-info
+      %span.fa-stack.half-font-size.text-secondary
         %i.far.fa-file.fa-stack-2x
         %i.fas.fa-search.fa-stack-1x
       Show Patchinfo


### PR DESCRIPTION
We switched to use the secondary color for such links. Seems we
forgot this one.



<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md
-->
