### PR TITLE
Show recommends in package binary page

### DIFF
--- a/src/api/app/views/webui2/webui/package/_deps.html.haml
+++ b/src/api/app/views/webui2/webui/package/_deps.html.haml
@@ -56,3 +56,32 @@
           %tr
             %td{ colspan: '2' }
               %em No requires
+
+  .table-responsive.col-sm-12.col-md-6
+    %h3 Recommends
+    %table.table.table-striped.table-bordered.table-sm
+      %thead
+        %tr
+          %th.w-75 Symbol
+          %th.w-25 Provided by
+      %tbody
+        - fileinfo.elements('recommends_ext') do |package_file|
+          %tr
+            %td
+              %span.nowrap{ title: package_file['dep'] }
+                = truncate(package_file['dep'], length: 30)
+            %td
+              - package_file.elements('providedby') do |package_binary|
+                = link_to package_binary['name'], action:               :dependency,
+                                                  project:              project,
+                                                  package:              package,
+                                                  repository:           repository.try(:name) || repository,
+                                                  arch:                 architecture.try(:name) || architecture,
+                                                  dependant_project:    package_binary['project'],
+                                                  dependant_repository: package_binary['repository'],
+                                                  dependant_name:       package_binary['name'],
+                                                  filename:             filename
+        - unless fileinfo['recommends_ext']
+          %tr
+            %td{ colspan: '2' }
+              %em No recommends


### PR DESCRIPTION
We already fetch this data as part of the package_file variable. So
rendering it here won't cause any performance regression.
And since this data belongs to the package details it makes sense to
include this here.

Fixes #6443


On larger screens:

![screenshot-2019-3-7 detailed information about ctris-0 42-13 1 x86_64 rpm - open build service](https://user-images.githubusercontent.com/968949/53953291-3dc35780-40d3-11e9-863a-acfce3a8fcd3.png)

On smaller screens:

![screenshot-2019-3-7 detailed information about ctris-0 42-13 1 x86_64 rpm - open build service 2](https://user-images.githubusercontent.com/968949/53953299-4156de80-40d3-11e9-8c0f-6d0f1de7a809.png)
