### PR TITLE
Convert rss notification payload

### DIFF
--- a/src/api/db/data/20190307145633_migrate_rss_notification_payload.rb
+++ b/src/api/db/data/20190307145633_migrate_rss_notification_payload.rb
@@ -1,0 +1,29 @@
+class MigrateRssNotificationPayload < ActiveRecord::Migration[5.2]
+  def up
+    Notification::RssFeedItem.all.find_each { |notification| convert_payload(notification) }
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+
+  private
+
+  def convert_payload(notification)
+    return unless notification.event_type.in?(['Event::CommentForPackage', 'Event::CommentForProject', 'Event::CommentForRequest'])
+
+    payload = notification.event_payload
+    # Find unconverted comment events
+    return unless integer?(payload['commenter'])
+    payload['commenter'] = User.find(notification.event_payload['commenter']).login
+    payload['commenters'] = User.find(notification.event_payload['commenters']).pluck(:login)
+    notification.event_payload = payload
+    notification.save!
+  end
+
+  def integer?(string)
+    # rubocop:disable Style/RescueModifier
+    Integer(string) rescue false
+    # rubocop:enable Style/RescueModifier
+  end
+end


### PR DESCRIPTION
In PR#6879 we converted the commenter and commenters entries of
event payloads. Since the RSS Notification payload is relying
on some of the event views and methods, this broke our RSS feeds.

This commit adds a data migration that converts existing RSS feeds.

Fixes #7134



<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md
-->
