### PR TITLE
Remove unneeded word and align filename to modal context

### DIFF
--- a/src/api/app/views/webui/project/new_package.html.erb
+++ b/src/api/app/views/webui/project/new_package.html.erb
@@ -1,4 +1,4 @@
-<% @pagetitle = "Create New Package"
+<% @pagetitle = "Create Package"
    @metarobots = 'noindex'
    project_bread_crumb @pagetitle
 -%>

--- a/src/api/app/views/webui2/webui/project/_create_package_modal.html.haml
+++ b/src/api/app/views/webui2/webui/project/_create_package_modal.html.haml
@@ -3,7 +3,7 @@
     .modal-content
       .modal-header
         %h5.modal-title#new-package-modal-label
-          Create New Package for #{project.name}
+          Create Package for #{project.name}
       .modal-body
         = form_tag(save_new_package_path(project)) do
           .form-group

--- a/src/api/app/views/webui2/webui/project/show.html.haml
+++ b/src/api/app/views/webui2/webui/project/show.html.haml
@@ -76,7 +76,7 @@
     = render partial: 'delete_project_dialog', locals: { project: @project }
 
     - if show_package_actions?
-      = render partial: 'new_package_modal', locals: { project: @project }
+      = render partial: 'create_package_modal', locals: { project: @project }
       = render partial: 'new_package_branch_modal', locals: { project: @project, remote_projects: @remote_projects }
 
     - if can_be_released?(@project, @packages, @open_release_requests, @has_patchinfo)

--- a/src/api/spec/bootstrap/features/webui/projects_spec.rb
+++ b/src/api/spec/bootstrap/features/webui/projects_spec.rb
@@ -14,7 +14,7 @@ RSpec.feature 'Bootstrap_Projects', type: :feature, js: true, vcr: true do
     end
 
     scenario 'with valid data' do
-      expect(page).to have_text("Create New Package for #{user.home_project_name}")
+      expect(page).to have_text("Create Package for #{user.home_project_name}")
 
       fill_in 'name', with: 'coolstuff'
       fill_in 'title', with: 'cool stuff everyone needs'

--- a/src/api/spec/features/webui/projects_spec.rb
+++ b/src/api/spec/features/webui/projects_spec.rb
@@ -44,7 +44,7 @@ RSpec.feature 'Projects', type: :feature, js: true do
       login user
       visit project_show_path(project: user.home_project)
       click_link('Create Package')
-      expect(page).to have_text("Create New Package for #{user.home_project_name}")
+      expect(page).to have_text("Create Package for #{user.home_project_name}")
     end
 
     scenario 'with valid data' do


### PR DESCRIPTION
A small thing which I noticed... It's a bit redundant to have `New` in the modal's title.

![createpackagemodal](https://user-images.githubusercontent.com/1102934/53968150-cef7f580-40f6-11e9-96a9-1c608f7975a1.png)
