### PR TITLE
Drop "show who" for maintainers in request page

### DIFF
--- a/src/api/app/helpers/webui/request_helper.rb
+++ b/src/api/app/helpers/webui/request_helper.rb
@@ -198,4 +198,10 @@ module Webui::RequestHelper
   def review_request_reason(bs_request, review)
     bs_request.request_history_elements.where(description_extension: review[:id]).pluck(:comment).first.presence || 'No reason given'
   end
+
+  def list_maintainers(maintainers)
+    maintainers.pluck(:login).map do |maintainer|
+      user_with_realname_and_icon(maintainer, short: true)
+    end.to_sentence.html_safe
+  end
 end

--- a/src/api/app/views/webui2/webui/request/_maintainer_link.html.haml
+++ b/src/api/app/views/webui2/webui/request/_maintainer_link.html.haml
@@ -1,0 +1,5 @@
+- if maintainers.size <= 3
+  #{'Package maintainer'.pluralize(maintainers.size)}:
+  = list_maintainers(maintainers)
+- else
+  #{maintainers.size} package #{link_to('maintainers', '#', class: 'show_dialog', data: { toggle: 'modal', target: '#show-maintainers-modal' })}

--- a/src/api/app/views/webui2/webui/request/_show_package_maintainers.html.haml
+++ b/src/api/app/views/webui2/webui/request/_show_package_maintainers.html.haml
@@ -7,7 +7,7 @@
       .modal-body
         - package_maintainers.pluck(:login).each do |package_maintainer|
           %p
-            = package_maintainer
+            = user_with_realname_and_icon(package_maintainer, short: true)
         .modal-footer
           %button.btn.btn-sm.btn-outline-secondary.px-4{ data: { dismiss: 'modal' } }
             OK

--- a/src/api/app/views/webui2/webui/request/_show_side_links.html.haml
+++ b/src/api/app/views/webui2/webui/request/_show_side_links.html.haml
@@ -11,8 +11,7 @@
   - unless package_maintainers.empty?
     %li
       %i.fas.fa-info-circle.text-info
-      = pluralize(package_maintainers.size, 'package maintainer')
-      (#{link_to('show who', '#', class: 'show_dialog', data: { toggle: 'modal', target: '#show-maintainers-modal' })})
+      = render partial: 'maintainer_link', locals: { maintainers: package_maintainers }
   - if bs_request.superseding.present?
     %li
       %i.fas.fa-plus-circle.text-primary


### PR DESCRIPTION
Allows viewing a request's maintainers without having to open a modal. When more than three maintainers exist, a link to the modal is shown.

In the modal view, links to maintainer's profiles are provided. User icons were added, consistent with the old UI layout.

Fixes #7086

![screenshot from 2019-03-07 21-47-28](https://user-images.githubusercontent.com/22715037/54008175-c74e4600-4122-11e9-826b-fa0dcdccb1e6.png)

![screenshot from 2019-03-07 21-48-12](https://user-images.githubusercontent.com/22715037/54008179-c9b0a000-4122-11e9-99c4-889232bb3689.png)

![screenshot from 2019-03-07 21-45-32](https://user-images.githubusercontent.com/22715037/54008305-66733d80-4123-11e9-9d6d-54d38c881c5c.png) 

 
<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md
-->
