### PR TITLE
Add workaround for rss notication events

### DIFF
--- a/src/api/app/models/event/comment_event.rb
+++ b/src/api/app/models/event/comment_event.rb
@@ -10,7 +10,7 @@ module Event
 
     def expanded_payload
       p = payload.dup
-      p['commenter'] = User.find_by(login: p['commenter'])
+      p['commenter'] = User.find_by(login: p['commenter']) || User.find(p['commenter'])
       p
     end
 


### PR DESCRIPTION
With 394769ab1230020cd59c743a970a03ba07a2ce38 we changed the
format of the event payload. While we migrated all comment events
that were relying on them, we overlooked that the rss notifications
create temporary events based on their own event_payload.
Until we migrate them we need to add this workaround to prevent
exceptions when RSS Feeds that contain comment events are requested.



<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md
-->
