### PR TITLE
[backend] fix regexp in aggregate-container-add-tag handling

### DIFF
--- a/src/backend/BSSched/BuildJob/Aggregate.pm
+++ b/src/backend/BSSched/BuildJob/Aggregate.pm
@@ -402,9 +402,9 @@ sub build {
 	    if ($bconf->{'substitute'}->{"aggregate-container-add-tag:$packid"}) {
 	      my @regtags = @{$bconf->{'substitute'}->{"aggregate-container-add-tag:$packid"}};
 	      for my $tag (@regtags) {
-		$tag = "$tag:latest" unless $tag =~ /^[^\/]+:[^\/]+$/s;
-		push @{$r->{'provides'}}, "container:$tag";
-		push @{$containerinfo->{'tags'}}, $tag;
+		$tag = "$tag:latest" unless $tag =~ /^:[^:\/]+$/s;
+		push @{$r->{'provides'}}, "container:$tag" unless grep {$_ eq "container:$tag"} @{$r->{'provides'} || []};
+		push @{$containerinfo->{'tags'}}, $tag unless grep {$_ eq $tag} @{$containerinfo->{'tags'} || []};
 	      }
 	    }
 	    writecontainerinfo("$jobdatadir/$containerinfofile", undef, $containerinfo);


### PR DESCRIPTION
The old code did not work if the added tag contained a '/'.
Also changed the code to not duplicate tags anymore.



<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md
-->
