### PR TITLE
Use a list for package binaries in binary view

### DIFF
--- a/src/api/app/views/webui2/webui/package/_deps.html.haml
+++ b/src/api/app/views/webui2/webui/package/_deps.html.haml
@@ -13,16 +13,18 @@
               %span.nowrap{ title: package_file['dep'] }
                 = truncate(package_file['dep'], length: 30)
             %td
-              - package_file.elements('requiredby') do |package_binary|
-                = link_to package_binary['name'], action:               :dependency,
-                                                  project:              project,
-                                                  package:              package,
-                                                  repository:           repository.try(:name) || repository,
-                                                  arch:                 architecture.try(:name) || architecture,
-                                                  dependant_project:    package_binary['project'],
-                                                  dependant_repository: package_binary['repository'],
-                                                  dependant_name:       package_binary['name'],
-                                                  filename:             filename
+              %ul.list-unstyled
+                - package_file.elements('requiredby') do |package_binary|
+                  %li
+                    = link_to package_binary['name'], action: :dependency,
+                                                      project: project,
+                                                      package: package,
+                                                      repository: repository.try(:name) || repository,
+                                                      arch: architecture.try(:name) || architecture,
+                                                      dependant_project: package_binary['project'],
+                                                      dependant_repository: package_binary['repository'],
+                                                      dependant_name: package_binary['name'],
+                                                      filename: filename
         - unless fileinfo['provides_ext']
           %tr
             %td{ colspan: '2' }
@@ -42,16 +44,18 @@
               %span.nowrap{ title: package_file['dep'] }
                 = truncate(package_file['dep'], length: 30)
             %td
-              - package_file.elements('providedby') do |package_binary|
-                = link_to package_binary['name'], action:               :dependency,
-                                                  project:              project,
-                                                  package:              package,
-                                                  repository:           repository.try(:name) || repository,
-                                                  arch:                 architecture.try(:name) || architecture,
-                                                  dependant_project:    package_binary['project'],
-                                                  dependant_repository: package_binary['repository'],
-                                                  dependant_name:       package_binary['name'],
-                                                  filename:             filename
+              %ul.list-unstyled
+                - package_file.elements('providedby') do |package_binary|
+                  %li
+                    = link_to package_binary['name'], action: :dependency,
+                                                      project: project,
+                                                      package: package,
+                                                      repository: repository.try(:name) || repository,
+                                                      arch: architecture.try(:name) || architecture,
+                                                      dependant_project: package_binary['project'],
+                                                      dependant_repository: package_binary['repository'],
+                                                      dependant_name: package_binary['name'],
+                                                      filename: filename
         - unless fileinfo['requires_ext']
           %tr
             %td{ colspan: '2' }
@@ -71,16 +75,18 @@
               %span.nowrap{ title: package_file['dep'] }
                 = truncate(package_file['dep'], length: 30)
             %td
-              - package_file.elements('providedby') do |package_binary|
-                = link_to package_binary['name'], action:               :dependency,
-                                                  project:              project,
-                                                  package:              package,
-                                                  repository:           repository.try(:name) || repository,
-                                                  arch:                 architecture.try(:name) || architecture,
-                                                  dependant_project:    package_binary['project'],
-                                                  dependant_repository: package_binary['repository'],
-                                                  dependant_name:       package_binary['name'],
-                                                  filename:             filename
+              %ul.list-unstyled
+                - package_file.elements('providedby') do |package_binary|
+                  %li
+                    = link_to package_binary['name'], action: :dependency,
+                                                      project: project,
+                                                      package: package,
+                                                      repository: repository.try(:name) || repository,
+                                                      arch: architecture.try(:name) || architecture,
+                                                      dependant_project: package_binary['project'],
+                                                      dependant_repository: package_binary['repository'],
+                                                      dependant_name: package_binary['name'],
+                                                      filename: filename
         - unless fileinfo['recommends_ext']
           %tr
             %td{ colspan: '2' }


### PR DESCRIPTION
Otherwise they are hard to read when packages are
overflowing to the next line.

Before:
![screenshot_2019-03-08 detailed information about ctris-0 42-15 1 x86_64 rpm - open build service 2](https://user-images.githubusercontent.com/968949/54036659-7b4fdf80-41bc-11e9-8e47-8080a46edb56.png)

After:
![screenshot_2019-03-08 detailed information about ctris-0 42-15 1 x86_64 rpm - open build service 1](https://user-images.githubusercontent.com/968949/54036723-a0dce900-41bc-11e9-8565-fd1fc8fdcf36.png)

