### PR TITLE
 Add API to create Staging Workflows & refactor staging routes

### DIFF
--- a/docs/api/api/api.txt
+++ b/docs/api/api/api.txt
@@ -1933,11 +1933,16 @@ XmlResult: required_checks
 == Staging
   WARNING: This API is currently in beta and unstable
 
-=== Staging Projects
+=== Staging Workflow
 
 <staging_workflow_project>: The name of the staging workflow project, e.g. openSUSE:Factory
 <staging_project>: The name of the staging project, e.g. openSUSE:Factory:Staging:A
 <staging_project_copy_name>: The name of the staging project's copy, e.g. openSUSE:Factory:Staging:B
+
+POST /staging/<staging_workflow_project>/workflow
+  Create a staging workflow for a given project.
+XmlBody: create_staging_workflow
+XmlResult: status_ok
 
 GET /staging/<staging_workflow_project>/staging_projects
   Get the overall state of all staging projects belonging to a staging workflow project

--- a/docs/api/api/create_staging_workflow.xml
+++ b/docs/api/api/create_staging_workflow.xml
@@ -1,0 +1,1 @@
+<workflow managers='group_title'/>

--- a/src/api/app/controllers/staging/excluded_requests_controller.rb
+++ b/src/api/app/controllers/staging/excluded_requests_controller.rb
@@ -46,13 +46,13 @@ class Staging::ExcludedRequestsController < ApplicationController
   end
 
   def set_project
-    @project = Project.get_by_name(params[:staging_main_project_name])
+    @project = Project.get_by_name(params[:staging_workflow_project])
   end
 
   def set_staging_workflow
     @staging_workflow = @project.staging
     return if @staging_workflow
 
-    raise InvalidParameterError, "Project #{params[:staging_main_project_name]} doesn't have an asociated Staging Workflow"
+    raise InvalidParameterError, "Project #{params[:staging_workflow_project]} doesn't have an asociated Staging Workflow"
   end
 end

--- a/src/api/app/controllers/staging/staging_projects_controller.rb
+++ b/src/api/app/controllers/staging/staging_projects_controller.rb
@@ -19,7 +19,7 @@ class Staging::StagingProjectsController < ApplicationController
   def copy
     authorize @main_project.staging
 
-    StagingProjectCopyJob.perform_later(params[:staging_main_project_name], params[:staging_project_name], params[:staging_project_copy_name], User.current.id)
+    StagingProjectCopyJob.perform_later(params[:staging_workflow_project], params[:staging_project_name], params[:staging_project_copy_name], User.current.id)
 
     render_ok
   end
@@ -27,6 +27,6 @@ class Staging::StagingProjectsController < ApplicationController
   private
 
   def set_main_project
-    @main_project = Project.find_by!(name: params[:staging_main_project_name])
+    @main_project = Project.find_by!(name: params[:staging_workflow_project])
   end
 end

--- a/src/api/app/controllers/staging/workflows_controller.rb
+++ b/src/api/app/controllers/staging/workflows_controller.rb
@@ -1,0 +1,38 @@
+class Staging::WorkflowsController < ApplicationController
+  before_action :require_login
+  before_action :set_project
+
+  def create
+    staging_workflow = @project.build_staging
+    authorize staging_workflow
+
+    staging_workflow.managers_group = Group.find_by!(title: xml_hash['managers'])
+
+    if staging_workflow.save
+      render_ok
+    else
+      render_error(
+        status: 400,
+        errorcode: 'invalid_request',
+        message: "Staging for #{@project} couldn't be created: #{staging_workflow.errors.to_sentence}"
+      )
+    end
+  end
+
+  private
+
+  def set_project
+    @project = Project.get_by_name(params[:staging_main_project_name])
+
+    return if @project
+    render_error(
+      status: 404,
+      errorcode: 'not_found',
+      message: "Project '#{params[:staging_workflow_project]}' not found."
+    )
+  end
+
+  def xml_hash
+    Xmlhash.parse(request.body.read) || {}
+  end
+end

--- a/src/api/app/controllers/staging/workflows_controller.rb
+++ b/src/api/app/controllers/staging/workflows_controller.rb
@@ -22,7 +22,7 @@ class Staging::WorkflowsController < ApplicationController
   private
 
   def set_project
-    @project = Project.get_by_name(params[:staging_main_project_name])
+    @project = Project.get_by_name(params[:staging_workflow_project])
 
     return if @project
     render_error(

--- a/src/api/config/routes.rb
+++ b/src/api/config/routes.rb
@@ -761,17 +761,17 @@ OBSApi::Application.routes.draw do
   end
 
   # StagingWorkflow API
-  resources :staging, only: [], param: 'main_project_name' do
-    resource :workflow, only: :create, controller: 'staging/workflows', constraints: cons
-    resources :staging_projects, only: [:index, :show], controller: 'staging/staging_projects', param: :name do
+  resources :staging, only: [], param: 'main_project_name', module: 'staging' do
+    resource :workflow, only: :create, constraints: cons
+    resources :staging_projects, only: [:index, :show], param: :name do
       post 'copy/:staging_project_copy_name' => :copy
 
-      get 'staged_requests' => 'staging/staged_requests#index', constraints: cons
-      resource :staged_requests, controller: 'staging/staged_requests', only: [:create, :destroy], constraints: cons
+      get 'staged_requests' => 'staged_requests#index', constraints: cons
+      resource :staged_requests, only: [:create, :destroy], constraints: cons
     end
 
-    resources :excluded_requests, controller: 'staging/excluded_requests', only: [:index], constraints: cons
-    resource :excluded_requests, controller: 'staging/excluded_requests', only: [:create, :destroy], constraints: cons
+    resources :excluded_requests, only: [:index], constraints: cons
+    resource :excluded_requests, only: [:create, :destroy], constraints: cons
   end
 
   controller :source_attribute do

--- a/src/api/config/routes.rb
+++ b/src/api/config/routes.rb
@@ -762,6 +762,7 @@ OBSApi::Application.routes.draw do
 
   # StagingWorkflow API
   resources :staging, only: [], param: 'main_project_name' do
+    resource :workflow, only: :create, controller: 'staging/workflows', constraints: cons
     resources :staging_projects, only: [:index, :show], controller: 'staging/staging_projects', param: :name do
       post 'copy/:staging_project_copy_name' => :copy
 

--- a/src/api/config/routes.rb
+++ b/src/api/config/routes.rb
@@ -761,7 +761,7 @@ OBSApi::Application.routes.draw do
   end
 
   # StagingWorkflow API
-  resources :staging, only: [], param: 'main_project_name', module: 'staging' do
+  resources :staging, only: [], param: 'workflow_project', module: 'staging' do
     resource :workflow, only: :create, constraints: cons
     resources :staging_projects, only: [:index, :show], param: :name do
       post 'copy/:staging_project_copy_name' => :copy

--- a/src/api/spec/controllers/staging/excluded_requests_controller_spec.rb
+++ b/src/api/spec/controllers/staging/excluded_requests_controller_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe Staging::ExcludedRequestsController, type: :controller, vcr: true
     let!(:request_exclusion_2) { create(:request_exclusion, bs_request: bs_request_2, staging_workflow: staging_workflow, description: 'Request 2') }
 
     before do
-      get :index, params: { staging_main_project_name: staging_workflow.project.name, format: :xml }
+      get :index, params: { staging_workflow_project: staging_workflow.project.name, format: :xml }
     end
 
     it { expect(response).to have_http_status(:success) }
@@ -52,7 +52,7 @@ RSpec.describe Staging::ExcludedRequestsController, type: :controller, vcr: true
 
     context 'succeeds' do
       before do
-        post :create, params: { staging_main_project_name: staging_workflow.project.name, format: :xml },
+        post :create, params: { staging_workflow_project: staging_workflow.project.name, format: :xml },
                       body: "<excluded_requests><request number='#{bs_request.number}' description='hey'/></excluded_requests>"
       end
 
@@ -65,7 +65,7 @@ RSpec.describe Staging::ExcludedRequestsController, type: :controller, vcr: true
 
     context 'fails: project does not exist' do
       before do
-        post :create, params: { staging_main_project_name: 'i_do_not_exist', format: :xml },
+        post :create, params: { staging_workflow_project: 'i_do_not_exist', format: :xml },
                       body: "<excluded_requests><request number='#{bs_request.number}' description='hey'/></excluded_requests>"
       end
 
@@ -75,7 +75,7 @@ RSpec.describe Staging::ExcludedRequestsController, type: :controller, vcr: true
     context 'fails: project without staging_workflow' do
       let(:project_without_staging) { create(:project, name: 'no_staging') }
       before do
-        post :create, params: { staging_main_project_name: project_without_staging, format: :xml },
+        post :create, params: { staging_workflow_project: project_without_staging, format: :xml },
                       body: "<excluded_requests><request number='#{bs_request.number}' description='hey'/></excluded_requests>"
       end
 
@@ -84,7 +84,7 @@ RSpec.describe Staging::ExcludedRequestsController, type: :controller, vcr: true
 
     context 'fails: no description, invalid request exclusion' do
       before do
-        post :create, params: { staging_main_project_name: staging_workflow.project.name, format: :xml },
+        post :create, params: { staging_workflow_project: staging_workflow.project.name, format: :xml },
                       body: "<excluded_requests><request number='#{bs_request.number}'/></excluded_requests>"
       end
 
@@ -93,7 +93,7 @@ RSpec.describe Staging::ExcludedRequestsController, type: :controller, vcr: true
 
     context 'fails: non-existant bs_request number, invalid request exclusion' do
       before do
-        post :create, params: { staging_main_project_name: staging_workflow.project.name, format: :xml },
+        post :create, params: { staging_workflow_project: staging_workflow.project.name, format: :xml },
                       body: "<excluded_requests><request number='43_543'/></excluded_requests>"
       end
 
@@ -110,7 +110,7 @@ RSpec.describe Staging::ExcludedRequestsController, type: :controller, vcr: true
       before { request_exclusion }
 
       subject do
-        delete :destroy, params: { staging_main_project_name: staging_workflow.project.name, format: :xml },
+        delete :destroy, params: { staging_workflow_project: staging_workflow.project.name, format: :xml },
                          body: "<requests><number>#{bs_request.number}</number></requests>"
       end
 
@@ -125,7 +125,7 @@ RSpec.describe Staging::ExcludedRequestsController, type: :controller, vcr: true
 
     context 'fails: request not excluded' do
       before do
-        delete :destroy, params: { staging_main_project_name: staging_workflow.project.name, format: :xml },
+        delete :destroy, params: { staging_workflow_project: staging_workflow.project.name, format: :xml },
                          body: "<requests><number>#{bs_request.number}</number></requests>"
       end
 
@@ -136,7 +136,7 @@ RSpec.describe Staging::ExcludedRequestsController, type: :controller, vcr: true
       before do
         request_exclusion
         allow_any_instance_of(ActiveRecord::Relation).to receive(:destroy_all).and_return([])
-        delete :destroy, params: { staging_main_project_name: staging_workflow.project.name, format: :xml },
+        delete :destroy, params: { staging_workflow_project: staging_workflow.project.name, format: :xml },
                          body: "<requests><number>#{bs_request.number}</number></requests>"
       end
 

--- a/src/api/spec/controllers/staging/staged_requests_controller_spec.rb
+++ b/src/api/spec/controllers/staging/staged_requests_controller_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe Staging::StagedRequestsController, type: :controller, vcr: true d
     before do
       bs_request.staging_project = staging_project
       bs_request.save
-      get :index, params: { staging_main_project_name: staging_workflow.project.name, staging_project_name: staging_project.name, format: :xml }
+      get :index, params: { staging_workflow_project: staging_workflow.project.name, staging_project_name: staging_project.name, format: :xml }
     end
 
     it { expect(response).to have_http_status(:success) }
@@ -43,7 +43,7 @@ RSpec.describe Staging::StagedRequestsController, type: :controller, vcr: true d
         staging_workflow
 
         login other_user
-        post :create, params: { staging_main_project_name: staging_workflow.project.name, staging_project_name: staging_project.name, format: :xml },
+        post :create, params: { staging_workflow_project: staging_workflow.project.name, staging_project_name: staging_project.name, format: :xml },
                       body: "<requests><number>#{bs_request.number}</number></requests>"
       end
 
@@ -53,7 +53,7 @@ RSpec.describe Staging::StagedRequestsController, type: :controller, vcr: true d
     context 'non-existent staging project' do
       before do
         login user
-        post :create, params: { staging_main_project_name: staging_workflow.project.name, staging_project_name: 'does-not-exist', format: :xml },
+        post :create, params: { staging_workflow_project: staging_workflow.project.name, staging_project_name: 'does-not-exist', format: :xml },
                       body: "<requests><number>#{bs_request.number}</number></requests>"
       end
 
@@ -63,7 +63,7 @@ RSpec.describe Staging::StagedRequestsController, type: :controller, vcr: true d
     context 'with valid and invalid request number' do
       before do
         login user
-        post :create, params: { staging_main_project_name: staging_workflow.project.name, staging_project_name: staging_project.name, format: :xml },
+        post :create, params: { staging_workflow_project: staging_workflow.project.name, staging_project_name: staging_project.name, format: :xml },
                       body: "<requests><number>-1</number><number>#{bs_request.number}</number></requests>"
       end
 
@@ -74,7 +74,7 @@ RSpec.describe Staging::StagedRequestsController, type: :controller, vcr: true d
     context 'with valid staging_project' do
       before do
         login user
-        post :create, params: { staging_main_project_name: staging_workflow.project.name, staging_project_name: staging_project.name, format: :xml },
+        post :create, params: { staging_workflow_project: staging_workflow.project.name, staging_project_name: staging_project.name, format: :xml },
                       body: "<requests><number>#{bs_request.number}</number></requests>"
       end
 
@@ -96,7 +96,7 @@ RSpec.describe Staging::StagedRequestsController, type: :controller, vcr: true d
     context 'invalid user' do
       before do
         login other_user
-        delete :destroy, params: { staging_main_project_name: staging_workflow.project.name, staging_project_name: staging_project.name, format: :xml },
+        delete :destroy, params: { staging_workflow_project: staging_workflow.project.name, staging_project_name: staging_project.name, format: :xml },
                          body: "<requests><number>#{bs_request.number}</number></requests>"
       end
 
@@ -106,7 +106,7 @@ RSpec.describe Staging::StagedRequestsController, type: :controller, vcr: true d
     context 'with invalid staging project' do
       before do
         login user
-        delete :destroy, params: { staging_main_project_name: staging_workflow.project.name, staging_project_name: 'does-not-exist', format: :xml },
+        delete :destroy, params: { staging_workflow_project: staging_workflow.project.name, staging_project_name: 'does-not-exist', format: :xml },
                          body: "<requests><number>#{bs_request.number}</number></requests>"
       end
 
@@ -117,7 +117,7 @@ RSpec.describe Staging::StagedRequestsController, type: :controller, vcr: true d
       context 'with valid request number' do
         before do
           login user
-          delete :destroy, params: { staging_main_project_name: staging_workflow.project.name, staging_project_name: staging_project.name, format: :xml },
+          delete :destroy, params: { staging_workflow_project: staging_workflow.project.name, staging_project_name: staging_project.name, format: :xml },
                            body: "<requests><number>#{bs_request.number}</number></requests>"
         end
 
@@ -129,7 +129,7 @@ RSpec.describe Staging::StagedRequestsController, type: :controller, vcr: true d
       context 'with valid and invalid request number' do
         before do
           login user
-          delete :destroy, params: { staging_main_project_name: staging_workflow.project.name, staging_project_name: staging_project.name, format: :xml },
+          delete :destroy, params: { staging_workflow_project: staging_workflow.project.name, staging_project_name: staging_project.name, format: :xml },
                            body: "<requests><number>-1</number><number>#{bs_request.number}</number></requests>"
         end
 

--- a/src/api/spec/controllers/staging/staging_projects_controller_spec.rb
+++ b/src/api/spec/controllers/staging/staging_projects_controller_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe Staging::StagingProjectsController, type: :controller, vcr: true 
   describe 'GET #index' do
     context 'existing staging_workflow' do
       before do
-        get :index, params: { staging_main_project_name: staging_workflow.project.name, format: :xml }
+        get :index, params: { staging_workflow_project: staging_workflow.project.name, format: :xml }
       end
 
       it { expect(response).to have_http_status(:success) }
@@ -23,7 +23,7 @@ RSpec.describe Staging::StagingProjectsController, type: :controller, vcr: true 
 
     context 'not existing staging_workflow' do
       before do
-        get :index, params: { staging_main_project_name: project_without_staging.name, format: :xml }
+        get :index, params: { staging_workflow_project: project_without_staging.name, format: :xml }
       end
 
       it { expect(response).to have_http_status(:bad_request) }
@@ -33,7 +33,7 @@ RSpec.describe Staging::StagingProjectsController, type: :controller, vcr: true 
   describe 'GET #show' do
     context 'not existing project' do
       before do
-        get :show, params: { staging_main_project_name: staging_workflow.project.name, name: 'does-not-exist', format: :xml }
+        get :show, params: { staging_workflow_project: staging_workflow.project.name, name: 'does-not-exist', format: :xml }
       end
 
       it { expect(response).to have_http_status(:not_found) }
@@ -84,7 +84,7 @@ RSpec.describe Staging::StagingProjectsController, type: :controller, vcr: true 
         bs_request_missing_review.change_review_state(:accepted, by_group: staging_workflow.managers_group.title)
         untracked_request.change_review_state(:accepted, by_group: staging_workflow.managers_group.title)
         bs_request.change_review_state(:accepted, by_group: staging_workflow.managers_group.title)
-        get :show, params: { staging_main_project_name: staging_workflow.project.name, name: staging_project.name, format: :xml }
+        get :show, params: { staging_workflow_project: staging_workflow.project.name, name: staging_project.name, format: :xml }
       end
 
       it { expect(response).to have_http_status(:success) }
@@ -111,12 +111,12 @@ RSpec.describe Staging::StagingProjectsController, type: :controller, vcr: true 
   end
 
   describe 'POST #copy' do
-    let(:staging_main_project_name) { staging_workflow.project.name }
+    let(:staging_workflow_project) { staging_workflow.project.name }
     let(:original_staging_project_name) { staging_workflow.staging_projects.first.name }
     let(:staging_project_copy_name) { "#{original_staging_project_name}-copy" }
     let(:params) do
       {
-        staging_main_project_name: staging_main_project_name,
+        staging_workflow_project: staging_workflow_project,
         staging_project_name: original_staging_project_name,
         staging_project_copy_name: staging_project_copy_name
       }
@@ -132,7 +132,7 @@ RSpec.describe Staging::StagingProjectsController, type: :controller, vcr: true 
     end
 
     it 'queues a StagingProjectCopyJob job' do
-      expect { post :copy, format: :xml, params: params }.to have_enqueued_job(StagingProjectCopyJob).with(staging_main_project_name,
+      expect { post :copy, format: :xml, params: params }.to have_enqueued_job(StagingProjectCopyJob).with(staging_workflow_project,
                                                                                                            original_staging_project_name,
                                                                                                            staging_project_copy_name,
                                                                                                            user.id)

--- a/src/api/spec/controllers/staging/workflows_controller_spec.rb
+++ b/src/api/spec/controllers/staging/workflows_controller_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe Staging::WorkflowsController, type: :controller, vcr: true do
     context 'with valid staging_project' do
       before do
         login user
-        post :create, params: { staging_main_project_name: project, format: :xml },
+        post :create, params: { staging_workflow_project: project, format: :xml },
                       body: "<workflow managers='#{group}'/>"
       end
 
@@ -22,7 +22,7 @@ RSpec.describe Staging::WorkflowsController, type: :controller, vcr: true do
     context 'invalid user' do
       before do
         login other_user
-        post :create, params: { staging_main_project_name: project, format: :xml },
+        post :create, params: { staging_workflow_project: project, format: :xml },
                       body: "<workflow managers='#{group}'/>"
       end
 
@@ -33,7 +33,7 @@ RSpec.describe Staging::WorkflowsController, type: :controller, vcr: true do
     context 'non-existent project' do
       before do
         login user
-        post :create, params: { staging_main_project_name: 'imaginary_project', format: :xml },
+        post :create, params: { staging_workflow_project: 'imaginary_project', format: :xml },
                       body: "<workflow managers='#{group}'/>"
       end
 
@@ -43,7 +43,7 @@ RSpec.describe Staging::WorkflowsController, type: :controller, vcr: true do
     context 'without group' do
       before do
         login user
-        post :create, params: { staging_main_project_name: project, format: :xml }
+        post :create, params: { staging_workflow_project: project, format: :xml }
       end
 
       it { expect(response).to have_http_status(:not_found) }

--- a/src/api/spec/controllers/staging/workflows_controller_spec.rb
+++ b/src/api/spec/controllers/staging/workflows_controller_spec.rb
@@ -1,0 +1,53 @@
+require 'rails_helper'
+
+RSpec.describe Staging::WorkflowsController, type: :controller, vcr: true do
+  let(:other_user) { create(:confirmed_user, login: 'unpermitted_user') }
+  let(:user) { create(:confirmed_user, login: 'permitted_user') }
+  let(:project) { user.home_project }
+  let(:group) { create(:group) }
+  let(:staging_workflow) { create(:staging_workflow_with_staging_projects, project: project) }
+
+  describe 'POST #create' do
+    context 'with valid staging_project' do
+      before do
+        login user
+        post :create, params: { staging_main_project_name: project, format: :xml },
+                      body: "<workflow managers='#{group}'/>"
+      end
+
+      it { expect(response).to have_http_status(:success) }
+      it { expect(project.staging).not_to be_nil }
+    end
+
+    context 'invalid user' do
+      before do
+        login other_user
+        post :create, params: { staging_main_project_name: project, format: :xml },
+                      body: "<workflow managers='#{group}'/>"
+      end
+
+      it { expect(response).to have_http_status(:forbidden) }
+      it { expect(project.staging).to be_nil }
+    end
+
+    context 'non-existent project' do
+      before do
+        login user
+        post :create, params: { staging_main_project_name: 'imaginary_project', format: :xml },
+                      body: "<workflow managers='#{group}'/>"
+      end
+
+      it { expect(response).to have_http_status(:not_found) }
+    end
+
+    context 'without group' do
+      before do
+        login user
+        post :create, params: { staging_main_project_name: project, format: :xml }
+      end
+
+      it { expect(response).to have_http_status(:not_found) }
+      it { expect(project.staging).to be_nil }
+    end
+  end
+end

--- a/src/api/test/functional/backend_test.rb
+++ b/src/api/test/functional/backend_test.rb
@@ -20,7 +20,7 @@ class BackendTests < ActionDispatch::IntegrationTest
           'status_messages', 'tagcloud', 'taglist', 'tags', 'updated_timestamp', 'distributions',
           'productlist', 'binary_released', 'check', 'required_checks', 'status_report',
           'staged_requests', 'remove_staged_requests', 'status_ok', 'staging_project',
-          'staging_projects'].include?(schema)
+          'staging_projects', 'create_staging_workflow'].include?(schema)
         # no backend schema exists
         next
       elsif schema == 'aggregate'


### PR DESCRIPTION
- Add API to create Staging Workflows, which was only possible to do in the WebUI before. :bowtie: 

- Refactor routes to simplify their definition the routes file and follow Rails defaults.

<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md
-->
