### PR TITLE
Just admins are allowed to run Repositories#create_flag

### DIFF
--- a/src/api/app/controllers/webui/repositories_controller.rb
+++ b/src/api/app/controllers/webui/repositories_controller.rb
@@ -189,8 +189,8 @@ class Webui::RepositoriesController < Webui::WebuiController
   # POST flag/:project(/:package)
   def create_flag
     authorize @main_object, :update?
-
     @flag = @main_object.flags.new(status: params[:status], flag: params[:flag])
+    authorize @flag, :create?
     @flag.architecture = Architecture.find_by_name(params[:architecture])
     @flag.repo = params[:repository] if params[:repository].present?
 

--- a/src/api/app/policies/flag_policy.rb
+++ b/src/api/app/policies/flag_policy.rb
@@ -1,0 +1,6 @@
+class FlagPolicy < ApplicationPolicy
+  # just admin are able to create sourceaccess and access flags
+  def create?
+    user.is_admin? || ['sourceaccess', 'access'].exclude?(record.flag)
+  end
+end


### PR DESCRIPTION
To keep inline with the api ```SourceController#project_command_set_flag```
just allow admin users to create flags _sourceaccess_ and _access_ (boo#1125782)