### PR TITLE
Introduce User.current_or_nobody

### DIFF
--- a/src/api/app/controllers/webui/webui_controller.rb
+++ b/src/api/app/controllers/webui/webui_controller.rb
@@ -84,7 +84,7 @@ class Webui::WebuiController < ActionController::Base
     if CONFIG['kerberos_mode']
       kerberos_auth
     else
-      if User.current.nil? || User.current.is_nobody?
+      if User.current_or_nobody.is_nobody?
         render(text: 'Please login') && (return false) if request.xhr?
 
         flash[:error] = 'Please login to access the requested page.'

--- a/src/api/app/models/bs_request_action.rb
+++ b/src/api/app/models/bs_request_action.rb
@@ -853,7 +853,7 @@ class BsRequestAction < ApplicationRecord
         # the target, the request creator (who must have permissions to read source)
         # wanted the target owner to review it
         tprj = Project.find_by_name(target_project)
-        if tprj.nil? || !User.current.can_modify?(tprj)
+        if tprj.nil? || !User.current_or_nobody.can_modify?(tprj)
           # produce an error for the source
           Package.get_by_project_and_name(source_project, source_package)
         end

--- a/src/api/app/models/comment.rb
+++ b/src/api/app/models/comment.rb
@@ -96,7 +96,7 @@ class Comment < ApplicationRecord
   private
 
   def delete_parent_if_unused
-    parent.destroy if parent && parent.user == User.find_nobody! && parent.children.length.zero?
+    parent.destroy if parent && parent.user.is_nobody? && parent.children.length.zero?
   end
 
   def validate_parent_id

--- a/src/api/app/models/user.rb
+++ b/src/api/app/models/user.rb
@@ -216,8 +216,21 @@ class User < ApplicationRecord
     user
   end
 
+  # The currently logged in user (might be nil). It's reset after
+  # every request and normally set during authentification
   def self.current
     Thread.current[:user]
+  end
+
+  def self.nobody
+    Thread.current[:nobody] ||= find_nobody!
+  end
+
+  # Currently logged in user or nobody user if there is no user logged in.
+  # Use this to check permissions, but don't treat it as logged in user. Check
+  # is_nobody? on the returned object
+  def self.current_or_nobody
+    current || nobody
   end
 
   def self.current=(user)


### PR DESCRIPTION
There are way too many places requiring a user object but have to treat User.current being nil as a special case.

User.current_or_nobody always returns a user object and as such you can writer simpler code. I only changed examples though to validate the idea (including an alternative fix for #5351)
