### PR TITLE
Handle multibuild packages in breadcrumbs

### DIFF
--- a/src/api/app/views/webui2/webui/package/_breadcrumb_items.html.haml
+++ b/src/api/app/views/webui2/webui/package/_breadcrumb_items.html.haml
@@ -1,6 +1,6 @@
 = render partial: 'webui/project/breadcrumb_items'
 %li.breadcrumb-item.text-word-break-all
-  = link_to truncate(@package.name, length: 50), package_show_path(@project, @package)
+  = link_to truncate(@package.to_s, length: 50), package_show_path(@project, @package)
 - if current_page?(package_add_file_path)
   %li.breadcrumb-item.active{ 'aria-current' => 'page' }
     Add File


### PR DESCRIPTION
`@package` is not a Package, but a String when accessing the
live_build_log action for a multibuild package.

https://github.com/openSUSE/open-build-service/blob/93ac2948b9eccc8a9756d2c87329bb229f758beb/src/api/app/controllers/webui/package_controller.rb#L1137-L1138

Fixes #7133