### PR TITLE
Replace user_name_with_icon by user_with_realname_and_icon

### DIFF
--- a/src/api/app/datatables/user_configuration_datatable.rb
+++ b/src/api/app/datatables/user_configuration_datatable.rb
@@ -1,6 +1,6 @@
 class UserConfigurationDatatable < Datatable
   def_delegator :@view, :user_actions
-  def_delegator :@view, :user_name_with_icon
+  def_delegator :@view, :user_with_realname_and_icon
 
   def view_columns
     @view_columns ||= {
@@ -19,7 +19,7 @@ class UserConfigurationDatatable < Datatable
   def data
     records.map do |record|
       {
-        name: user_name_with_icon(record),
+        name: user_with_realname_and_icon(record),
         local_user: record.ignore_auth_services,
         state: record.state,
         actions: user_actions(record)

--- a/src/api/app/helpers/webui/user_helper.rb
+++ b/src/api/app/helpers/webui/user_helper.rb
@@ -15,13 +15,6 @@ module Webui::UserHelper
     )
   end
 
-  def user_name_with_icon(user)
-    capture do
-      concat(image_tag_for(user, size: 20))
-      concat(link_to(display_name(user), user_show_path(user), class: 'pl-1'))
-    end
-  end
-
   # This method is migrated to Webui2 (and refactored) with the name: image_tag_for
   # @param [User] user object
   def user_image_tag(user, opt = {})

--- a/src/api/app/views/webui2/webui/request/_review_tab.html.haml
+++ b/src/api/app/views/webui2/webui/request/_review_tab.html.haml
@@ -3,7 +3,7 @@
   = hidden_review_payload(review)
   - if review[:creator]
     %p
-      = user_name_with_icon(User.find_by(login: review[:creator]))
+      = user_with_realname_and_icon(User.find_by(login: review[:creator]))
       requested:
     .ml-4
       %p= simple_format(review[:reason] || 'No reason given')


### PR DESCRIPTION
`user_name_with_icon` was introduced in f246132 when we should have instead used `user_with_realname_and_icon` since they both achieve the same result.

They really do the same thing...
![same-result](https://user-images.githubusercontent.com/1102934/54277039-064f2200-458f-11e9-8284-8efc821fd209.png)

