### PR TITLE
Set callbacks for staging project on project model

### DIFF
--- a/docs/api/api/api.txt
+++ b/docs/api/api/api.txt
@@ -283,7 +283,8 @@ XmlResult: status
 DELETE /source/<project>
 
   Deletes specified project. All packages of this project are deleted as if a
-  DELETE request were issued for each package.
+  DELETE request were issued for each package. If it is a staging project, its
+  associated staging workflow will be also updated in the backend.
 
 Parameters:
   force: If force = 1, the project is deleted even if repositories of other

--- a/src/api/app/models/project.rb
+++ b/src/api/app/models/project.rb
@@ -16,6 +16,8 @@ class Project < ApplicationRecord
 
   before_destroy :cleanup_before_destroy
   after_destroy_commit :delete_on_backend
+  after_save :update_staging_workflow_on_backend
+  after_destroy :update_staging_workflow_on_backend
 
   after_save :discard_cache
   after_rollback :reset_cache
@@ -1704,6 +1706,13 @@ class Project < ApplicationRecord
 
   def calculate_missing_checks
     combined_status_reports.map(&:missing_checks).flatten
+  end
+
+  def update_staging_workflow_on_backend
+    return unless staging_workflow_id
+
+    staging_workflow = Staging::Workflow.find(staging_workflow_id)
+    staging_workflow.write_to_backend
   end
 end
 # rubocop:enable Metrics/ClassLength

--- a/src/api/app/models/staging/staging_project.rb
+++ b/src/api/app/models/staging/staging_project.rb
@@ -5,8 +5,6 @@ module Staging
 
     default_scope { where.not(staging_workflow: nil) }
 
-    after_save :update_staging_workflow_on_backend
-    after_destroy :update_staging_workflow_on_backend
     before_create :add_managers_group
 
     def copy(new_project_name)
@@ -213,13 +211,6 @@ module Staging
       end
 
       @broken_packages.reject! { |package| package['state'] == 'unresolvable' } if @building_repositories.present?
-    end
-
-    def update_staging_workflow_on_backend
-      return unless staging_workflow_id
-
-      staging_workflow.reload
-      staging_workflow.write_to_backend
     end
 
     def add_managers_group


### PR DESCRIPTION
There where some callbacks specifically defined for staging projects
that have been moved to the project model. So they can be called even
if we perform some actions treating a staging project as regular
project.

For example, we can now delete a staging project via API using the same
endpoint that we use for any other kind of project `/source/<project>` and 
the right callbacks will be triggered.

Also updates apidocs.
