### PR TITLE
Don't crash on default reviews

### DIFF
--- a/src/api/app/helpers/webui/request_helper.rb
+++ b/src/api/app/helpers/webui/request_helper.rb
@@ -195,10 +195,6 @@ module Webui::RequestHelper
   end
   # rubocop:enable Style/FormatStringToken, Style/FormatString
 
-  def review_request_reason(bs_request, review)
-    bs_request.request_history_elements.where(description_extension: review[:id]).pluck(:comment).first.presence || 'No reason given'
-  end
-
   def list_maintainers(maintainers)
     maintainers.pluck(:login).map do |maintainer|
       user_with_realname_and_icon(maintainer, short: true)

--- a/src/api/app/models/review.rb
+++ b/src/api/app/models/review.rb
@@ -189,6 +189,8 @@ class Review < ApplicationRecord
     ret = _get_attributes
     # XML has this perl format, don't use that here
     ret[:when] = created_at
+    ret[:creator] = creator
+    ret[:reason] = reason
     ret[:id] = id
     ret
   end

--- a/src/api/app/views/webui/request/show.html.erb
+++ b/src/api/app/views/webui/request/show.html.erb
@@ -253,9 +253,11 @@
         <% @my_open_reviews.each_with_index do |review, index| %>
             <div class="review_descision_display <%= 'hidden' if index != 0 %>" id="review_descision_display_<%= index %>">
               <%= form_tag(action: 'modify_review') do %>
-                  <p><%= user_with_realname_and_icon(review[:who], short: true) %> requested:</p>
-                  <p><%= simple_format(review_request_reason(@bs_request, review)) %></p>
-                  <p><%= text_area_tag('comment', review[:reason], size: '80x2', style: 'width: 99%', class: 'review_comment', placeholder: 'Please comment on your decision') %></p>
+                  <% if review[:creator] %>
+                    <p><%= user_with_realname_and_icon(review[:creator], short: true) %> requested:</p>
+                    <p><%= simple_format(review[:reason] || 'No reason given') %></p>
+                  <% end %>
+                  <p><%= text_area_tag('comment', '', size: '80x2', style: 'width: 99%', class: 'review_comment', placeholder: 'Please comment on your decision') %></p>
 
                   <p>
                     <%= hidden_field_tag("request_number", @bs_request.number) %>

--- a/src/api/app/views/webui2/webui/request/_review_tab.html.haml
+++ b/src/api/app/views/webui2/webui/request/_review_tab.html.haml
@@ -1,14 +1,14 @@
 = form_tag(action: 'modify_review') do
   = hidden_field_tag('request_number', bs_request.number)
   = hidden_review_payload(review)
-  %p
-    = user_name_with_icon(User.find_by(login: review[:who]))
-    requested:
-  .ml-4
+  - if review[:creator]
     %p
-      #{simple_format(review_request_reason(bs_request, review))}
+      = user_name_with_icon(User.find_by(login: review[:creator]))
+      requested:
+    .ml-4
+      %p= simple_format(review[:reason] || 'No reason given')
   %p
-    = text_area_tag('comment', review[:reason], rows: 4, class: 'w-100 form-control', placeholder: 'Please comment on your decision')
+    = text_area_tag('comment', '', rows: 4, class: 'w-100 form-control', placeholder: 'Please comment on your decision')
   %p
     = submit_tag 'Approve', name: 'new_state', title: 'Give this request your blessing, it will continue.', class: 'btn btn-primary mr-2'
     = submit_tag 'Disregard', name: 'new_state', title: 'Veto this request, it will be declined.', class: 'btn btn-danger'

--- a/src/api/spec/features/webui/requests_spec.rb
+++ b/src/api/spec/features/webui/requests_spec.rb
@@ -188,6 +188,41 @@ RSpec.feature 'Requests', type: :feature, js: true do
         expect(page).to have_css('#flash-messages', text: 'Unable add review to')
       end
     end
+
+    describe 'for reviewer' do
+      let(:review_group) { create(:group) }
+      let(:reviewer) { create(:confirmed_user) }
+
+      before do
+        review_group.users << reviewer
+        review_group.save!
+      end
+
+      context 'for project reviews' do
+        before do
+          create(:review, by_group: review_group, bs_request: bs_request)
+        end
+
+        it 'renders the review tab' do
+          login reviewer
+          visit request_show_path(bs_request)
+          expect(find('#review_descision_display_0')).not_to have_text('requested:')
+        end
+      end
+
+      context 'for manual reviews' do
+        before do
+          create(:review, by_group: review_group, bs_request: bs_request,
+                          creator: receiver, reason: 'Does this make sense?')
+        end
+
+        it 'renders the review tab' do
+          login reviewer
+          visit request_show_path(bs_request)
+          expect(find('#review_descision_display_0')).to have_text("#{receiver.login} requested:\nDoes this make sense?")
+        end
+      end
+    end
   end
 
   describe 'shows the correct auto accepted message' do

--- a/src/api/spec/helpers/webui/request_helper_spec.rb
+++ b/src/api/spec/helpers/webui/request_helper_spec.rb
@@ -188,40 +188,4 @@ RSpec.describe Webui::RequestHelper do
       it { is_expected.to match(expected_regex) }
     end
   end
-
-  describe '#review_request_reason' do
-    let(:bs_request) do
-      create(:bs_request_with_submit_action,
-             target_package: target_package,
-             source_package: source_package)
-    end
-    let(:review) { bs_request.reviews.first }
-    let(:user) { create(:confirmed_user) }
-
-    subject { review_request_reason(bs_request, review) }
-
-    context 'when review has no request reason' do
-      before do
-        bs_request.addreview(by_user: user)
-      end
-
-      it { is_expected.to eq('No reason given') }
-    end
-
-    context 'when review has a request reason' do
-      before do
-        bs_request.addreview(by_user: user, comment: 'Please have a look.')
-      end
-
-      it { is_expected.to eq('Please have a look.') }
-    end
-
-    context 'when the request reason is empty' do
-      before do
-        bs_request.addreview(by_user: user, comment: '')
-      end
-
-      it { is_expected.to eq('No reason given') }
-    end
-  end
 end


### PR DESCRIPTION
Reviews added by users have a creator and a reason - reviews added by project/package 'reviewer' role do not. So don't try to show users if there are none.

This reverts quite big parts of #7128 because you don't need an extra function to check the review reason - it's in the model. Unfortunately we're not using the review model, but a hash from it

Fixes #7164
