### PR TITLE
Experiment: debuging the flickering test

### DIFF
--- a/src/api/spec/features/webui/projects_spec.rb
+++ b/src/api/spec/features/webui/projects_spec.rb
@@ -311,6 +311,7 @@ RSpec.feature 'Projects', type: :feature, js: true do
     scenario 'an existing package' do
       fill_in('linked_project', with: other_user.home_project_name)
       fill_in('linked_package', with: package_of_another_project.name)
+      expect(page).to(have_text('1 result is available')) unless is_bootstrap?
       # This needs global write through
       click_button('Accept')
 
@@ -347,6 +348,7 @@ RSpec.feature 'Projects', type: :feature, js: true do
 
       fill_in('linked_project', with: other_user.home_project_name)
       fill_in('linked_package', with: package_of_another_project.name)
+      expect(page).to(have_text('1 result is available')) unless is_bootstrap?
       # This needs global write through
       click_button('Accept')
 


### PR DESCRIPTION
Check if [the flickering test](https://github.com/openSUSE/open-build-service/issues/6238) is caused by a time problem. As the test only fails in build.opensuse.org and not in circle-ci neither locally, we need to merge this experiment to check if time is the problem.



<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md
-->
