### PR TITLE
Fix #7079:  Catch revision not found in _history

### DIFF
--- a/src/api/app/views/webui2/webui/package/_commit_item.html.haml
+++ b/src/api/app/views/webui2/webui/package/_commit_item.html.haml
@@ -1,32 +1,35 @@
-- user = User.find_by_login(commit['user'])
-- if user
-  = user_image_tag(user)
-  = link_to(user_show_path(user)) do
-    = user.realname.present? ? "#{user.realname} (#{user})" : user
+- if commit.nil?
+  No revision found
 - else
-  %i= commit['user'] || '-'
+  - user = User.find_by_login(commit['user'])
+  - if user
+    = user_image_tag(user)
+    = link_to(user_show_path(user)) do
+      = user.realname.present? ? "#{user.realname} (#{user})" : user
+  - else
+    %i= commit['user'] || '-'
 
-- if commit['requestid']
-  accepted
-  = link_to("request #{commit['requestid']}", request_show_path(commit['requestid']))
-- else
-  committed
+  - if commit['requestid']
+    accepted
+    = link_to("request #{commit['requestid']}", request_show_path(commit['requestid']))
+  - else
+    committed
 
-%u= fuzzy_time(Time.at(commit['time'].to_i))
+  %u= fuzzy_time(Time.at(commit['time'].to_i))
 
-(revision #{commit['rev']})
+  (revision #{commit['rev']})
 
-- if commit['comment'].present?
-  %pre.plain.mb-0.text-pre-wrap
-    = commit['comment']
+  - if commit['comment'].present?
+    %pre.plain.mb-0.text-pre-wrap
+      = commit['comment']
 
-%ul.nav.float-right
-  - if commit['rev'] != '1'
+  %ul.nav.float-right
+    - if commit['rev'] != '1'
+      %li.nav-item
+        = link_to(package_rdiff_path(@project, @package, rev: commit['rev'], linkrev: 'base'), class: 'nav-link') do
+          %i.fas.fa-copy.text-gray-500
+          Files Changed
     %li.nav-item
-      = link_to(package_rdiff_path(@project, @package, rev: commit['rev'], linkrev: 'base'), class: 'nav-link') do
-        %i.fas.fa-copy.text-gray-500
-        Files Changed
-  %li.nav-item
-    = link_to(package_show_path(@project, @package, rev: commit['rev']), class: 'nav-link') do
-      %i.fas.fa-folder-open.text-warning
-      Browse Source
+      = link_to(package_show_path(@project, @package, rev: commit['rev']), class: 'nav-link') do
+        %i.fas.fa-folder-open.text-warning
+        Browse Source


### PR DESCRIPTION
This can happen if we pass a disturl of a linked source where there wasn't actually a commit with this revision (but inherited e.g. from Factory).

Support disturl links in package#show :bowtie: 

Co-authored-by: @Ana06 