### PR TITLE
[backend] bs_publish: re-fetch repoinfo before updating the state

### DIFF
--- a/src/backend/bs_publish
+++ b/src/backend/bs_publish
@@ -2584,6 +2584,7 @@ publishprog_done:
 
   # update repoinfo with status
   if (!$dbgsplit && $state ne '') {
+    $repoinfo = BSUtil::retrieve("$reporoot/$prp/:repoinfo", 1) || {};
     $repoinfo->{'code'} = 'succeeded';
     $repoinfo->{'starttime'} = $starttime;
     $repoinfo->{'endtime'} = time();


### PR DESCRIPTION
The packtrack sending code clears it, so we need to fetch it
again.



<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md
-->
