### PR TITLE
Just use first names for users

### DIFF
--- a/src/api/spec/factories/kiwi_image.rb
+++ b/src/api/spec/factories/kiwi_image.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :kiwi_image, class: Kiwi::Image do
-    name { Faker::Name.name }
+    name { Faker::Name.first_name }
     md5_last_revision { nil }
 
     before(:create) do |image|

--- a/src/api/spec/factories/users.rb
+++ b/src/api/spec/factories/users.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
   factory :user do
     email { Faker::Internet.email }
-    realname { Faker::Name.name }
+    realname { Faker::Name.first_name }
     sequence(:login) { |n| "user_#{n}" }
     password { 'buildservice' }
 


### PR DESCRIPTION
Avoids last names containing ' - which breaks some tests

Fixes #7196
