### PR TITLE
Await autocomplete on review users

### DIFF
--- a/src/api/spec/features/webui/projects_spec.rb
+++ b/src/api/spec/features/webui/projects_spec.rb
@@ -445,6 +445,7 @@ RSpec.feature 'Projects', type: :feature, js: true do
       click_link('Maintained Projects')
       click_link('Add project to maintenance')
       fill_in('Project to maintain:', with: project.name)
+      expect(page).to have_text('1 result is available')
       click_button('Accept')
 
       expect(page).to have_text("Added #{project.name} to maintenance")

--- a/src/api/spec/features/webui/requests_spec.rb
+++ b/src/api/spec/features/webui/requests_spec.rb
@@ -121,6 +121,7 @@ RSpec.feature 'Requests', type: :feature, js: true do
         click_link 'Add a review'
         find(:id, 'review_type').select('User')
         fill_in 'review_user', with: reviewer.login
+        expect(page).to have_text('1 result is available')
         click_button('Accept')
         expect(page).to have_text(/Open review for\s+#{reviewer.login}/)
         expect(page).to have_text('Request 1 (review)')
@@ -146,6 +147,7 @@ RSpec.feature 'Requests', type: :feature, js: true do
         click_link 'Add a review'
         find(:id, 'review_type').select('Group')
         fill_in 'review_group', with: review_group.title
+        expect(page).to have_text('1 result is available')
         click_button('Accept')
         expect(page).to have_text("Open review for #{review_group.title}")
       end
@@ -158,6 +160,7 @@ RSpec.feature 'Requests', type: :feature, js: true do
         click_link 'Add a review'
         find(:id, 'review_type').select('Project')
         fill_in 'review_project', with: submitter.home_project
+        expect(page).to have_text('1 result is available')
         click_button('Accept')
         expect(page).to have_text("Review for #{submitter.home_project}")
       end
@@ -172,6 +175,7 @@ RSpec.feature 'Requests', type: :feature, js: true do
         find(:id, 'review_type').select('Package')
         fill_in 'review_project', with: submitter.home_project
         fill_in 'review_package', with: package.name
+        expect(page).to have_text('1 result is available')
         click_button('Accept')
         expect(page).to have_text("Review for #{submitter.home_project} / #{package.name}")
       end


### PR DESCRIPTION
We had fun trying to replicate the error condition, but it's basically that selenium looks for the 'Accept' button and before it can click it, autocomplete moves the button down by adding a '1 result available' text box into the layout. As such actually awaiting it, avoids suprises and makes the test stable

Fixes #6238

Co-authored-by: @Ana06
