### PR TITLE
Stop mixing years and hours in monitor tests

### DIFF
--- a/src/api/spec/controllers/webui/monitor_controller_spec.rb
+++ b/src/api/spec/controllers/webui/monitor_controller_spec.rb
@@ -68,7 +68,8 @@ RSpec.describe Webui::MonitorController do
       create_list(:status_history, 10, source: 'waiting', range: 10_000..42_000)
       # i586
       create_list(:status_history, 5, source: 'squeue_high', architecture: 'i586')
-      get :events, params: { arch: 'x86_64', range: 8761 }, xhr: true
+      # the factory creates the events 0..8000 hours ago
+      get :events, params: { arch: 'x86_64', range: 8100 }, xhr: true
       @json_response = JSON.parse(response.body)
     end
 

--- a/src/api/spec/factories/status_history.rb
+++ b/src/api/spec/factories/status_history.rb
@@ -7,7 +7,7 @@ FactoryBot.define do
     end
 
     key { "#{source}_#{architecture}" }
-    time { Random.rand(0..365).days.ago.to_i }
+    time { Random.rand(0..8000).hours.ago.to_i }
     value { Random.rand(range) }
   end
 end


### PR DESCRIPTION
If the hour switches between creating the test data and querying it (as it happens every 60 minutes, imagine!), the test may skip one data point. So creating it 8000 hours ago and checking 8100 hours should give us some head room for slow hardware

Fixes #7200
