### PR TITLE
Use unique fake words for attribute namespaces

### DIFF
--- a/src/api/spec/factories/attrib_namespaces.rb
+++ b/src/api/spec/factories/attrib_namespaces.rb
@@ -1,5 +1,5 @@
 FactoryBot.define do
   factory :attrib_namespace do
-    name { Faker::Lorem.word }
+    name { Faker::Lorem.unique.word }
   end
 end

--- a/src/api/spec/rails_helper.rb
+++ b/src/api/spec/rails_helper.rb
@@ -83,3 +83,6 @@ require 'support/migration'
 
 # support rabbitmq
 require 'support/rabbitmq'
+
+# avoid duplicated attribute namespaces
+require 'support/faker'

--- a/src/api/spec/support/faker.rb
+++ b/src/api/spec/support/faker.rb
@@ -1,0 +1,7 @@
+RSpec.configure do |config|
+  config.before do
+    # avoid names already used as attrib namespace as tests rely on them
+    # being unique (issue #7204)
+    Faker::Lorem.unique.exclude(:word, [], AttribNamespace.pluck(:name))
+  end
+end


### PR DESCRIPTION
Fixes #7204
