### PR TITLE
Show request id in browser title

### DIFF
--- a/src/api/app/views/webui2/webui/request/show.html.haml
+++ b/src/api/app/views/webui2/webui/request/show.html.haml
@@ -7,7 +7,7 @@
                                                      number: @bs_request.number,
                                                      diff_to_superseded: @diff_to_superseded,
                                                      superseding: @bs_request.superseding }
-- @pagetitle = "Request #{@number}"
+- @pagetitle = "Request #{@bs_request.number}"
 .card.mb-3
   .card-header.d-flex.justify-content-between
     %h5


### PR DESCRIPTION
This got lost when we cleaned up instance variables in the
request controller 4abca1854f8d8d2a73bd353b7269c93c86c5.

Fixes #7159



<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md
-->
