### PR TITLE
Show staging workflow tab in project tablist

### DIFF
--- a/src/api/app/views/webui2/webui/project/_tabs.html.haml
+++ b/src/api/app/views/webui2/webui/project/_tabs.html.haml
@@ -18,11 +18,6 @@
       - unless project.defines_remote_instance?
         %li.nav-item
           = tab_link('Users', project_users_path(project))
-      // This link is intentionally hidden, only users that access to the staging workflow show will see it
-      // TODO: show it if the project have a staging_workflow attached when this feature will be released
-      - if controller_path.starts_with?('webui/staging/')
-        %li.nav-item
-          = tab_link('Staging', request.url, true)
       - unless project.defines_remote_instance? || project.is_maintenance?
         %li.nav-item
           = tab_link('Subprojects', project_subprojects_path(project))
@@ -37,6 +32,10 @@
           = tab_link('Status', project_status_path(project))
       %li.nav-item
         = tab_link('Pulse', project_pulse_path(project))
+      - active = controller_path.starts_with?('webui/staging')
+      - if !project.staging_project? || active
+        %li.nav-item
+          = tab_link('Staging', new_staging_workflow_path(project: project), active)
     %li.nav-item.dropdown
       %a.nav-link.dropdown-toggle{ href: '#', 'data-toggle': 'dropdown', 'role': 'button', 'aria-expanded': 'false', 'aria-haspopup': 'true' }
       .dropdown-menu.dropdown-menu-right


### PR DESCRIPTION
The tab Staging is shown when we are in any kind on project unless
the project is already a staging project.

The tab also keeps showing while we are moving through the staging
workflow: creating a staging workflow, showing it, copying staging
projects or showing staging projects inside the workflow.

![staging_workflow:tab](https://user-images.githubusercontent.com/2581944/54597185-6aae2d80-4a36-11e9-9015-fa4815bfd006.gif)


