### PR TITLE
Swap buttons for copying staging projects

### DIFF
--- a/src/api/app/views/webui2/webui/staging/projects/preview_copy.html.haml
+++ b/src/api/app/views/webui2/webui/staging/projects/preview_copy.html.haml
@@ -17,5 +17,5 @@
             = label_tag(:staging_project_copy_name, 'Name of the Staging Project Copy:')
             = text_field_tag(:staging_project_copy_name, nil, placeholder: "Eg: #{@staging_project}-copy", class: 'form-control')
 
-          = submit_tag('Copy', class: 'btn btn-primary')
           = link_to('Back', edit_staging_workflow_path(@staging_workflow), class: 'btn btn-secondary', role: 'button')
+          = submit_tag('Copy', class: 'btn btn-primary')


### PR DESCRIPTION
In OBS, primary buttons are on the right.




<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md
-->
