### PR TITLE
Fix active review tabs when there is no decision box

### DIFF
--- a/src/api/app/views/webui2/webui/request/show.html.haml
+++ b/src/api/app/views/webui2/webui/request/show.html.haml
@@ -50,7 +50,8 @@
                   My decision
             - @my_open_reviews.each_with_index do |review, index|
               %li.nav-item
-                %a.nav-link.text-nowrap{ href: "#review-#{index}", data: { toggle: 'tab' }, role: 'tab' }
+                %a.nav-link.text-nowrap{ href: "#review-#{index}", data: { toggle: 'tab' }, role: 'tab',
+                  class: ('active' if index.zero? && !@can_handle_request) }
                   Review for #{reviewer(review)}
         .card-body
           - if @can_handle_request && @show_project_maintainer_hint
@@ -65,7 +66,7 @@
                          is_target_maintainer: @is_target_maintainer, state: @bs_request.state.to_s,
                          is_author: @is_author, single_action_request: @actions.count == 1, action: @actions.first)
             - @my_open_reviews.each_with_index do |review, index|
-              .tab-pane.fade.show{ id: "review-#{index}", class: ('active' unless @can_handle_request) }
+              .tab-pane.fade.show{ id: "review-#{index}", class: ('active' if index.zero? && !@can_handle_request) }
                 = render('review_tab', review: review, bs_request: @bs_request)
 
   .col-md-4


### PR DESCRIPTION
When there is no decision box for the request (the user can not
accept or decline it) we have to mark the first review as
active (= visible).
Since we did not consider the index of the review list, all reviews
were visible when no the request decision box is hidden.

Fixes #7229



<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md
-->
