### PR TITLE
Swap accept review / request buttons on request show page

### DIFF
--- a/src/api/app/views/webui2/webui/request/_decision_tab.html.haml
+++ b/src/api/app/views/webui2/webui/request/_decision_tab.html.haml
@@ -16,12 +16,12 @@
           Forward submit request to
           #{project_or_package_link(project: forward[:project], package: forward[:package], short: true)}
     %hr
-  - if state.in?(['new', 'review']) && is_target_maintainer
-    - confirmation = (state == 'review' ? { confirm: 'Do you really want to approve this request, despite of open review requests?' } : {})
-    = submit_tag 'Accept request', name: 'accepted', class: 'btn btn-primary mr-2', data: confirmation
-    - unless is_author
-      = submit_tag 'Decline request', name: 'declined', class: 'btn btn-danger mr-2'
   - if is_author && state.in?(['new', 'review', 'declined'])
     = submit_tag 'Revoke request', name: 'revoked', class: 'btn btn-danger mr-2'
   - if state == 'declined'
-    = submit_tag 'Reopen request', name: 'new', class: 'btn btn-warning'
+    = submit_tag 'Reopen request', name: 'new', class: 'btn btn-warning mr-2'
+  - if state.in?(['new', 'review']) && is_target_maintainer
+    - unless is_author
+      = submit_tag 'Decline request', name: 'declined', class: 'btn btn-danger mr-2'
+    - confirmation = (state == 'review' ? { confirm: 'Do you really want to approve this request, despite of open review requests?' } : {})
+    = submit_tag 'Accept request', name: 'accepted', class: 'btn btn-primary', data: confirmation

--- a/src/api/app/views/webui2/webui/request/_review_tab.html.haml
+++ b/src/api/app/views/webui2/webui/request/_review_tab.html.haml
@@ -10,5 +10,5 @@
   %p
     = text_area_tag('comment', '', rows: 4, class: 'w-100 form-control', placeholder: 'Please comment on your decision')
   %p
-    = submit_tag 'Approve', name: 'new_state', title: 'Give this request your blessing, it will continue.', class: 'btn btn-primary mr-2'
-    = submit_tag 'Disregard', name: 'new_state', title: 'Veto this request, it will be declined.', class: 'btn btn-danger'
+    = submit_tag 'Disregard', name: 'new_state', title: 'Veto this request, it will be declined.', class: 'btn btn-danger mr-2'
+    = submit_tag 'Approve', name: 'new_state', title: 'Give this request your blessing, it will continue.', class: 'btn btn-primary'


### PR DESCRIPTION
In OBS, primary buttons are on the right and since accepting
a request or review is the default action it makes sense to place
it on the right.



<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md
-->
