### PR TITLE
Only allow admins to create sourceaccess/access repositories flags

### DIFF
--- a/src/api/app/controllers/webui/repositories_controller.rb
+++ b/src/api/app/controllers/webui/repositories_controller.rb
@@ -177,6 +177,7 @@ class Webui::RepositoriesController < Webui::WebuiController
     authorize @main_object, :update?
 
     @flag = @main_object.flags.new(status: params[:status], flag: params[:flag])
+    authorize @flag, :create?
     @flag.architecture = Architecture.find_by_name(params[:architecture])
     @flag.repo = params[:repository] if params[:repository].present?
 

--- a/src/api/app/policies/flag_policy.rb
+++ b/src/api/app/policies/flag_policy.rb
@@ -1,0 +1,6 @@
+class FlagPolicy < ApplicationPolicy
+  # just admin are able to create sourceaccess and access flags
+  def create?
+    user.is_admin? || ['sourceaccess', 'access'].exclude?(record.flag)
+  end
+end


### PR DESCRIPTION
Webui::RepositoriesController.create_flag allowed creating the access/sourceaccess flags, while in
SourceController#project_command_set_flag this is only allowed for admins.

This was fixed in master in: https://github.com/openSUSE/open-build-service/pull/7169/commits/5f89387c86be9bcefffe64e78125efa88e3c3c4f



<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md
-->
