### PR TITLE
Update breadcrumb for group show page

### DIFF
--- a/src/api/app/views/webui2/webui/groups/_breadcrumb_items.html.haml
+++ b/src/api/app/views/webui2/webui/groups/_breadcrumb_items.html.haml
@@ -18,5 +18,10 @@
     = @group
 - when 'show'
   = render partial: 'webui/main/breadcrumb_items'
+  %li.breadcrumb-item
+    - if User.current.is_admin?
+      = link_to 'Manage Groups', groups_path
+    - else
+      Groups
   %li.breadcrumb-item.active{ 'aria-current' => 'page' }
     = @group


### PR DESCRIPTION
Like for the other breadcrumbs we now show a 'Groups' label
for non-admins.
Users with admin rights will see a 'Manage Groups' label which links
to the groups index.


Before:
![Screenshot_2019-03-20 Open Build Service](https://user-images.githubusercontent.com/968949/54679119-d233ae00-4b06-11e9-8b86-33a7edf67db1.png)

After:

For non admin users:
![Screenshot_2019-03-20 Open Build Service(1)](https://user-images.githubusercontent.com/968949/54679056-b5977600-4b06-11e9-8804-d2ecb0db8a36.png)

For admins
![Screenshot_2019-03-20 Open Build Service(2)](https://user-images.githubusercontent.com/968949/54679259-23dc3880-4b07-11e9-8ac3-aaa68c7933b8.png)
