### PR TITLE
Publish Debian upstream tarball signatures to the repositories

### DIFF
--- a/src/backend/bs_publish
+++ b/src/backend/bs_publish
@@ -1931,6 +1931,9 @@ sub publish {
 	  $p = "$bin";
 	} elsif ($bin =~ /\.dsc(?:\.sha256)?$/) {
 	  $p = "$bin";
+	} elsif ($bin =~ /\.orig\.tar\.(gz|xz|bz2)\.asc$/) {
+	  # Debian upstream tarball signature
+	  $p = "$bin";
         } elsif ($bin =~ /^(.*)\.(?:box|json|ovf|phar|qcow2|vdi|vhdfixed|vmx|vmdk|vhdx)(?:\.xz)?(\.sha256)?$/) {
 	  $p = "$bin";
           $kiwimedium = "$arch/$1" if !$2 && -e "$r/$1.packages";


### PR DESCRIPTION
Since Debian packaging tooling supports checking upstream tarball
signatures, the signature (.asc) files should be published to the
repositories as well.

=========================== end of the commit message ==============================

To check that the current OBS implementation is not publishing the Debian upstream tarball signature to the repositories you can create a test project/package and configure a DoD project targeting Debian stable, and then try to upload for example the `xz-utils` package [1] which contains an upstream tarball signature. If you have a Debian system you can simple run `apt-get source xz-utils` or `dget http://deb.debian.org/debian/pool/main/x/xz-utils/xz-utils_5.2.4-1.dsc`.

After `xz-utils` package builds successfully you'll see the `xz-utils_5.2.4.orig.tar.xz.asc` file available in the `build` directory but the OBS publisher will not publish it into the `repos`.

With the proposed patch I was able to get the asc file (Debian upstream tarball signature) published in `repos`.

Thanks for considering it.

[1] https://tracker.debian.org/pkg/xz-utils
