### PR TITLE
Authorize move_path

### DIFF
--- a/src/api/app/controllers/webui/project_controller.rb
+++ b/src/api/app/controllers/webui/project_controller.rb
@@ -39,7 +39,13 @@ class Webui::ProjectController < Webui::WebuiController
 
   before_action :set_maintained_project, only: [:remove_maintained_project]
 
-  after_action :verify_authorized, only: [:save_new, :new_incident, :save_meta]
+  after_action :verify_authorized, except: [:add_maintained_project_dialog, :autocomplete_incidents, :autocomplete_packages, :autocomplete_projects,
+                                            :autocomplete_repositories, :buildresult, :delete_dialog, :edit_comment, :edit_comment_form,
+                                            :incident_request_dialog, :index, :linking_projects, :maintained_projects, :maintenance_incidents, :meta,
+                                            :monitor, :new, :new_incident, :new_incident_request, :new_release_request, :package_buildresult,
+                                            :packages_simple, :prjconf, :rebuild_time, :rebuild_time_png, :release_request_dialog,
+                                            :release_request_dialog, :remove_target_request, :remove_target_request_dialog, :requests, :show,
+                                            :status, :subprojects, :toggle_watch, :unlock_dialog, :users]
 
   def index
     @show_all = (params[:show_all].to_s == 'true')
@@ -113,9 +119,13 @@ class Webui::ProjectController < Webui::WebuiController
     end
   end
 
-  def new_package; end
+  def new_package
+    authorize @project, :update?
+  end
 
   def new_package_branch
+    authorize @project, :update?
+
     @remote_projects = Project.where.not(remoteurl: nil).pluck(:id, :name, :title)
   end
 
@@ -410,6 +420,8 @@ class Webui::ProjectController < Webui::WebuiController
   end
 
   def move_path
+    authorize @project, :update?
+
     params.require(:direction)
     repository = @project.repositories.find(params[:repository])
     path_element = repository.path_elements.find(params[:path])

--- a/src/api/app/mixins/webui/manage_relationships.rb
+++ b/src/api/app/mixins/webui/manage_relationships.rb
@@ -8,6 +8,7 @@ module Webui::ManageRelationships
   end
 
   def save_person
+    authorize main_object, :update?
     begin
       Relationship.add_user(main_object, load_obj, Role.find_by_title!(params[:role]), nil, true) # report error on duplicate
       main_object.store
@@ -27,6 +28,7 @@ module Webui::ManageRelationships
   end
 
   def save_group
+    authorize main_object, :update?
     begin
       Relationship.add_group(main_object, load_obj, Role.find_by_title!(params[:role]), nil, true) # report error on duplicate
       main_object.store
@@ -46,6 +48,7 @@ module Webui::ManageRelationships
   end
 
   def remove_role
+    authorize main_object, :update?
     begin
       main_object.remove_role(load_obj, Role.find_by_title(params[:role]))
       main_object.store

--- a/src/api/spec/cassettes/Projects/creating_packages_in_projects_not_owned_by_user_eg_global_namespace/as_non-admin_user.yml
+++ b/src/api/spec/cassettes/Projects/creating_packages_in_projects_not_owned_by_user_eg_global_namespace/as_non-admin_user.yml
@@ -1,24 +1,27 @@
 ---
 http_interactions:
 - request:
-    method: get
-    uri: http://backend:5352/build/global_project/_result?code=unresolvable&view=status
+    method: put
+    uri: http://backend:5352/source/home:user_1/_meta?user=user_1
     body:
-      encoding: US-ASCII
-      string: ''
+      encoding: UTF-8
+      string: |
+        <project name="home:user_1">
+          <title/>
+          <description/>
+          <person userid="user_1" role="maintainer"/>
+        </project>
     headers:
-      Content-Type:
-      - text/plain
       Accept-Encoding:
-      - identity
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
       - "*/*"
       User-Agent:
       - Ruby
   response:
     status:
-      code: 404
-      message: project 'global_project' does not exist
+      code: 200
+      message: OK
     headers:
       Content-Type:
       - text/xml
@@ -27,16 +30,205 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '156'
+      - '135'
     body:
       encoding: UTF-8
       string: |
-        <status code="404">
-          <summary>project 'global_project' does not exist</summary>
-          <details>404 project 'global_project' does not exist</details>
-        </status>
+        <project name="home:user_1">
+          <title></title>
+          <description></description>
+          <person userid="user_1" role="maintainer" />
+        </project>
     http_version: 
-  recorded_at: Tue, 24 May 2016 11:41:31 GMT
+  recorded_at: Wed, 27 Mar 2019 13:05:14 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:Jane/_meta?user=Jane
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:Jane">
+          <title/>
+          <description/>
+          <person userid="Jane" role="maintainer"/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '131'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:Jane">
+          <title></title>
+          <description></description>
+          <person userid="Jane" role="maintainer" />
+        </project>
+    http_version: 
+  recorded_at: Wed, 27 Mar 2019 13:05:15 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/global_project/_meta
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="global_project">
+          <title>Death Be Not Proud</title>
+          <description/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '109'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="global_project">
+          <title>Death Be Not Proud</title>
+          <description></description>
+        </project>
+    http_version: 
+  recorded_at: Wed, 27 Mar 2019 13:05:15 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/global_project/_config
+    body:
+      encoding: UTF-8
+      string: "          <project name=\"global_project\">\n            <title/>\n
+        \           <description/>\n            \n          </project>\n"
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '21'
+    body:
+      encoding: UTF-8
+      string: '<status code="ok" />
+
+'
+    http_version: 
+  recorded_at: Wed, 27 Mar 2019 13:05:15 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:other_user/_meta?user=other_user
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:other_user">
+          <title/>
+          <description/>
+          <person userid="other_user" role="maintainer"/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '143'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:other_user">
+          <title></title>
+          <description></description>
+          <person userid="other_user" role="maintainer" />
+        </project>
+    http_version: 
+  recorded_at: Wed, 27 Mar 2019 13:05:15 GMT
+- request:
+    method: get
+    uri: http://backend:5352/build/global_project/_result?code=unresolvable&view=status
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '56'
+    body:
+      encoding: UTF-8
+      string: '<resultlist state="00000000000000000000000000000000" />
+
+'
+    http_version: 
+  recorded_at: Wed, 27 Mar 2019 13:05:18 GMT
 - request:
     method: get
     uri: http://backend:5352/build/global_project/_result?view=summary
@@ -54,8 +246,8 @@ http_interactions:
       - Ruby
   response:
     status:
-      code: 404
-      message: project 'global_project' does not exist
+      code: 200
+      message: OK
     headers:
       Content-Type:
       - text/xml
@@ -64,14 +256,68 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '156'
+      - '56'
+    body:
+      encoding: UTF-8
+      string: '<resultlist state="00000000000000000000000000000000" />
+
+'
+    http_version: 
+  recorded_at: Wed, 27 Mar 2019 13:05:18 GMT
+- request:
+    method: get
+    uri: http://backend:5352/build/_workerstatus
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '1205'
     body:
       encoding: UTF-8
       string: |
-        <status code="404">
-          <summary>project 'global_project' does not exist</summary>
-          <details>404 project 'global_project' does not exist</details>
-        </status>
+        <workerstatus clients="2">
+          <idle workerid="4ce61a595de6:1" hostarch="x86_64" />
+          <idle workerid="4ce61a595de6:2" hostarch="x86_64" />
+          <waiting arch="i586" jobs="0" />
+          <waiting arch="x86_64" jobs="0" />
+          <blocked arch="i586" jobs="0" />
+          <blocked arch="x86_64" jobs="0" />
+          <buildavg arch="i586" buildavg="1200" />
+          <buildavg arch="x86_64" buildavg="1200" />
+          <partition>
+            <daemon type="srcserver" state="running" starttime="1553691872" />
+            <daemon type="servicedispatch" state="running" starttime="1553691878" />
+            <daemon type="service" state="running" starttime="1553691878" />
+            <daemon type="scheduler" arch="i586" state="running" starttime="1553691878">
+              <queue high="0" med="0" low="5" next="0" />
+            </daemon>
+            <daemon type="scheduler" arch="x86_64" state="running" starttime="1553691878">
+              <queue high="0" med="0" low="5" next="0" />
+            </daemon>
+            <daemon type="repserver" state="running" starttime="1553691876" />
+            <daemon type="dispatcher" state="running" starttime="1553691878" />
+            <daemon type="publisher" state="running" starttime="1553691878" />
+            <daemon type="signer" state="running" starttime="1553691878" />
+          </partition>
+        </workerstatus>
     http_version: 
-  recorded_at: Tue, 24 May 2016 11:41:31 GMT
-recorded_with: VCR 3.0.1
+  recorded_at: Wed, 27 Mar 2019 13:05:19 GMT
+recorded_with: VCR 4.0.0

--- a/src/api/spec/controllers/webui/project_controller_spec.rb
+++ b/src/api/spec/controllers/webui/project_controller_spec.rb
@@ -417,7 +417,7 @@ RSpec.describe Webui::ProjectController, vcr: true do
 
   describe 'GET #new_package_branch' do
     it 'branches the package' do
-      login user
+      login(admin_user)
       @remote_projects_created = create_list(:remote_project, 3)
       get :new_package_branch, params: { project: apache_project }
       expect(assigns(:remote_projects)).to match_array(@remote_projects_created.map { |r| [r.id, r.name, r.title] })
@@ -1297,6 +1297,10 @@ RSpec.describe Webui::ProjectController, vcr: true do
       let(:repository) { create(:repository, project: apache_project) }
       let(:path_element) { create(:path_element, repository: repository) }
 
+      before do
+        login(admin_user)
+      end
+
       context 'without direction' do
         it { expect { post :move_path, params: { project: apache_project } }.to raise_error ActionController::ParameterMissing }
       end
@@ -1375,6 +1379,10 @@ RSpec.describe Webui::ProjectController, vcr: true do
     end
 
     context 'with non existing project' do
+      before do
+        login(admin_user)
+      end
+
       it { expect { post :move_path, params: { project: 'non:existent:project' } }.to raise_error ActiveRecord::RecordNotFound }
     end
   end

--- a/src/api/spec/features/webui/projects_spec.rb
+++ b/src/api/spec/features/webui/projects_spec.rb
@@ -78,7 +78,7 @@ RSpec.feature 'Projects', type: :feature, js: true do
 
   describe 'creating packages in projects not owned by user, eg. global namespace' do
     let(:other_user) { create(:confirmed_user, login: 'other_user') }
-    let(:global_project) { create(:project, name: 'global_project') }
+    let!(:global_project) { create(:project, name: 'global_project') }
 
     scenario 'as non-admin user' do
       login other_user
@@ -88,11 +88,8 @@ RSpec.feature 'Projects', type: :feature, js: true do
       # Use direct path instead
       visit "/project/new_package/#{global_project}"
 
-      fill_in 'name', with: 'coolstuff'
-      click_button 'Save changes'
-
-      expect(page).to have_text("You can't create packages in #{global_project}")
-      expect(page.current_path).to eq("/project/new_package/#{global_project}")
+      expect(page).to have_text('Sorry, you are not authorized to update this Project')
+      expect(page.current_path).to eq(root_path)
     end
 
     scenario 'as admin' do


### PR DESCRIPTION
Additionally turn the after_action around and maintain a whitelist instead of a blacklist. This requires new methods authorized by default.

new_package and its dialog are just informal authorizations, so people do not even try to do this.

Co-authored-by: Henne Vogelsang <hvogel@opensuse.org>
Co-authored-by: Saray Cabrera Padrón <scabrerapadron@suse.de>
Co-authored-by: David Kang <dkang@suse.com>