### PR TITLE
Drop unused UpdateInfo

### DIFF
--- a/src/api/app/models/updateinfo.rb
+++ b/src/api/app/models/updateinfo.rb
@@ -1,4 +1,0 @@
-class Updateinfo < ApplicationRecord
-  belongs_to :package, foreign_key: :package_id
-  belongs_to :repository, foreign_key: :repository_id
-end


### PR DESCRIPTION
The table is dropped since 2014 in UpdateinfoTrackingSecondAttempt