### PR TITLE
Remove symlink to foreman in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,8 +21,6 @@ WORKDIR /obs/src/api
 # foreman, which we only run in docker, needs a different thor version than OBS.
 # Installing the gem directly spares us from having to rpm package two different thor versions.
 RUN sudo gem.ruby2.5 install thor:0.19 foreman
-# Ensure there is a foreman command without ruby suffix
-RUN sudo ln -s /usr/bin/foreman.ruby2.5 /usr/bin/foreman
 
 # FIXME: Retrying bundler if it fails is a workaround for https://github.com/moby/moby/issues/783
 #        which seems to happen on openSUSE (< Tumbleweed 20171001)...


### PR DESCRIPTION
This isn't needed anymore as it produces the following error:
```
ln: failed to create symbolic link '/usr/bin/foreman': File exists
```
