### PR TITLE
Fix some issues around the request show page for the new UI

### DIFF
--- a/src/api/app/controllers/webui/request_controller.rb
+++ b/src/api/app/controllers/webui/request_controller.rb
@@ -255,7 +255,7 @@ class Webui::RequestController < Webui::WebuiController
     else
       begin
         request.setincident(params[:incident_project])
-        flash[:notice] = "Set target of request #{request.number} to incident #{params[:incident_project]}"
+        flash[:success] = "Set target of request #{request.number} to incident #{params[:incident_project]}"
       rescue Project::UnknownObjectError => e
         flash[:error] = "Incident #{e.message} does not exist"
       rescue APIError => e
@@ -325,7 +325,7 @@ class Webui::RequestController < Webui::WebuiController
       }
       begin
         request.change_state(opts)
-        flash[:notice] = "Request #{newstate}!"
+        flash[:success] = "Request #{newstate}!"
         return true
       rescue APIError => e
         flash[:error] = "Failed to change state: #{e.message}!"
@@ -337,7 +337,7 @@ class Webui::RequestController < Webui::WebuiController
   end
 
   def accept_request
-    flash[:notice] = "Request #{params[:number]} accepted"
+    flash[:success] = "Request #{params[:number]} accepted"
 
     # Check if we have to forward this request to other projects / packages
     params.keys.grep(/^forward.*/).each do |fwd|
@@ -360,7 +360,7 @@ class Webui::RequestController < Webui::WebuiController
 
     target_link = ActionController::Base.helpers.link_to("#{tgt_prj} / #{tgt_pkg}", package_show_url(project: tgt_prj, package: tgt_pkg))
     request_link = ActionController::Base.helpers.link_to("request #{forwarded_request.number}", request_show_path(forwarded_request.number))
-    flash[:notice] += " and forwarded to #{target_link} (#{request_link})"
+    flash[:success] += " and forwarded to #{target_link} (#{request_link})"
   end
 
   def request_action_attributes(type)

--- a/src/api/app/controllers/webui/request_controller.rb
+++ b/src/api/app/controllers/webui/request_controller.rb
@@ -359,8 +359,8 @@ class Webui::RequestController < Webui::WebuiController
     end
 
     target_link = ActionController::Base.helpers.link_to("#{tgt_prj} / #{tgt_pkg}", package_show_url(project: tgt_prj, package: tgt_pkg))
-    request_link = ActionController::Base.helpers.link_to(forwarded_request.number, request_show_path(forwarded_request.number))
-    flash[:notice] += " and forwarded to #{target_link} (request #{request_link})"
+    request_link = ActionController::Base.helpers.link_to("request #{forwarded_request.number}", request_show_path(forwarded_request.number))
+    flash[:notice] += " and forwarded to #{target_link} (#{request_link})"
   end
 
   def request_action_attributes(type)

--- a/src/api/app/views/webui2/webui/request/_decision_tab.html.haml
+++ b/src/api/app/views/webui2/webui/request/_decision_tab.html.haml
@@ -11,7 +11,7 @@
           #{project_or_package_link(project: action[:tprj], package: action[:tpkg], short: true)}
     - (action[:forward] || []).each_with_index do |forward, index|
       .custom-control.custom-checkbox
-        = check_box_tag("forward-#{index}", "#{forward[:project]}_#_#{forward[:package]}", false, class: 'custom-control-input')
+        = check_box_tag("forward-#{index}", "#{forward[:project]}_#_#{forward[:package]}", true, class: 'custom-control-input')
         %label.custom-control-label{ for: "forward-#{index}" }
           Forward submit request to
           #{project_or_package_link(project: forward[:project], package: forward[:package], short: true)}

--- a/src/api/spec/controllers/webui/request_controller_spec.rb
+++ b/src/api/spec/controllers/webui/request_controller_spec.rb
@@ -377,7 +377,7 @@ RSpec.describe Webui::RequestController, vcr: true do
                                          description: 'blah blah blah' }
         end.not_to change(BsRequest, :count)
         expect(bs_request.reload.state).to eq(:accepted)
-        expect(flash[:notice]).to match('Request \\d accepted')
+        expect(flash[:success]).to match('Request \\d accepted')
         expect(flash[:error]).to eq('Unable to forward submit request: some error')
       end
     end


### PR DESCRIPTION
* Show green background for flash message that show success.
* Enable the forward request checkbox by default
* Make the whole 'request $nr' string clickable instead of just '$nr', for example in "... and forwarded to home:Admin (request 7)"