### PR TITLE
Staging Workflow Configure UX

### DIFF
--- a/src/api/app/controllers/webui/staging/workflows_controller.rb
+++ b/src/api/app/controllers/webui/staging/workflows_controller.rb
@@ -57,10 +57,7 @@ class Webui::Staging::WorkflowsController < Webui::WebuiController
     authorize @staging_workflow
 
     @project = @staging_workflow.project
-    @staging_projects = @staging_workflow.staging_projects.includes(:staged_requests)
-
-    @groups_hash = ::Staging::Workflow.load_groups
-    @users_hash = ::Staging::Workflow.load_users(@staging_projects)
+    @staging_projects = @staging_workflow.staging_projects.includes(:staged_requests).order(:name)
   end
 
   def destroy

--- a/src/api/app/views/webui2/webui/staging/workflows/_breadcrumb_items.html.haml
+++ b/src/api/app/views/webui2/webui/staging/workflows/_breadcrumb_items.html.haml
@@ -10,4 +10,4 @@
     = link_to 'Staging', staging_workflow_path(@staging_workflow)
   - if controller_name == 'workflows' && action_name == 'edit'
     %li.breadcrumb-item.active{ 'aria-current' => 'page' }
-      Configure
+      Manage Staging Projects

--- a/src/api/app/views/webui2/webui/staging/workflows/_create_staging_project.html.haml
+++ b/src/api/app/views/webui2/webui/staging/workflows/_create_staging_project.html.haml
@@ -5,9 +5,8 @@
         .modal-header
           %h5.modal-title#create-staging-projects-modal-label Create Staging Project
         .modal-body
-          .form-group
-            = label_tag(:staging_project_name, 'Please enter a project you have permissions to')
-            = text_field_tag(:staging_project_name, nil, placeholder: "Eg: #{staging_workflow.project}:Staging:A", class: 'form-control')
-
+          = render partial: 'webui/autocomplete', locals: { html_id: 'staging_project_name',
+                                                            label: 'Please enter a project you have permissions to',
+                                                            source: url_for(controller: '/webui/project', action: 'autocomplete_projects') }
         .modal-footer
           = render partial: 'webui2/shared/dialog_action_buttons', locals: { submit_tag_text: 'Create' }

--- a/src/api/app/views/webui2/webui/staging/workflows/_staging_project.html.haml
+++ b/src/api/app/views/webui2/webui/staging/workflows/_staging_project.html.haml
@@ -1,0 +1,18 @@
+.col-12.col-md-6.col-lg-4
+  .card.mb-3
+    .card-header.bg-light.p-2
+      .d-flex.w-100.justify-content-between
+        = link_to(staging_project.name, staging_workflow_staging_project_path(staging_workflow, staging_project.name))
+        %span.mr-1
+          = link_to(staging_workflow_staging_project_preview_copy_path(staging_workflow, staging_project), title: 'Copy Staging Project') do
+            %i.fas.fa-clone.text-secondary
+          = link_to('#', data: { toggle: 'modal', target: "#confirm-modal-#{staging_project.id}" }, title: "Delete #{staging_project}") do
+            %i.fas.fa-times-circle.text-danger
+    .card-body.p-2.text-muted
+      %small.d-block
+        state:
+        %strong= staging_project.overall_state
+      %small.d-block
+        requests:
+        %strong= staging_project.staged_requests.size
+      = render partial: 'delete_staging_project_modal', locals: { staging_workflow: staging_workflow, staging_project: staging_project }

--- a/src/api/app/views/webui2/webui/staging/workflows/_staging_projects_table.html.haml
+++ b/src/api/app/views/webui2/webui/staging/workflows/_staging_projects_table.html.haml
@@ -3,7 +3,8 @@
     %tr.text-center
       %th Staging Project
       %th Requests
-      %th Problems
+      - unless display_actions_column
+        %th Problems
       - if display_actions_column
         %th Actions
   %tbody
@@ -14,8 +15,9 @@
         %td.requests
           = render partial: 'webui/staging/shared/packages_list', locals: { staging_project: staging_project,
                                                                             users_hash: users_hash, groups_hash: groups_hash }
-        %td
-          = render partial: 'problems', locals: { staging_project: staging_project }
+        - unless display_actions_column
+          %td
+            = render partial: 'problems', locals: { staging_project: staging_project }
         - if display_actions_column
           %td.text-center
             = link_to(staging_workflow_staging_project_preview_copy_path(staging_workflow, staging_project), title: 'Copy Staging Project') do

--- a/src/api/app/views/webui2/webui/staging/workflows/_staging_projects_table.html.haml
+++ b/src/api/app/views/webui2/webui/staging/workflows/_staging_projects_table.html.haml
@@ -3,10 +3,7 @@
     %tr.text-center
       %th Staging Project
       %th Requests
-      - unless display_actions_column
-        %th Problems
-      - if display_actions_column
-        %th Actions
+      %th Problems
   %tbody
     - staging_projects.each do |staging_project|
       %tr
@@ -15,17 +12,8 @@
         %td.requests
           = render partial: 'webui/staging/shared/packages_list', locals: { staging_project: staging_project,
                                                                             users_hash: users_hash, groups_hash: groups_hash }
-        - unless display_actions_column
-          %td
-            = render partial: 'problems', locals: { staging_project: staging_project }
-        - if display_actions_column
-          %td.text-center
-            = link_to(staging_workflow_staging_project_preview_copy_path(staging_workflow, staging_project), title: 'Copy Staging Project') do
-              %i.fas.fa-clone.text-secondary
-            = link_to('#', data: { toggle: 'modal', target: "#confirm-modal-#{staging_project.id}" }, title: "Delete #{staging_project}") do
-              %i.fas.fa-times-circle.text-danger
-
-            = render partial: 'delete_staging_project_modal', locals: { staging_workflow: staging_workflow, staging_project: staging_project }
+        %td
+          = render partial: 'problems', locals: { staging_project: staging_project }
 
 - content_for :ready_function do
   $('#staging-projects-datatable').DataTable({responsive: true, paging: false, ordering: false, searching: false, info: false});

--- a/src/api/app/views/webui2/webui/staging/workflows/edit.html.haml
+++ b/src/api/app/views/webui2/webui/staging/workflows/edit.html.haml
@@ -6,14 +6,13 @@
       = render(partial: 'webui2/webui/project/tabs', locals: { project: @project })
       .card-body
         %h3= @pagetitle
-        %ul.list-inline.mb-0
+        %ul.list-inline
           %li.list-inline-item
             = link_to('#', class: 'nav-link', data: { toggle: 'modal', target: '#create-staging-projects-modal' }) do
               %i.fas.fa-plus-circle.text-success
               Create Staging Project
+            = render partial: 'create_staging_project', locals: { staging_workflow: @staging_workflow }
+        .row
+          = render(partial: 'staging_project', collection: @staging_projects,
+                                               locals: { staging_workflow: @staging_workflow })
 
-        = render(partial: 'staging_projects_table',
-                 locals: { staging_workflow: @staging_workflow, staging_projects: @staging_projects, display_actions_column: true,
-                           users_hash: @users_hash, groups_hash: @groups_hash })
-
-        = render partial: 'create_staging_project', locals: { staging_workflow: @staging_workflow }

--- a/src/api/app/views/webui2/webui/staging/workflows/edit.html.haml
+++ b/src/api/app/views/webui2/webui/staging/workflows/edit.html.haml
@@ -1,4 +1,4 @@
-- @pagetitle = "Configure Staging for #{@project}"
+- @pagetitle = "Manage Staging Projects for #{@project}"
 
 .row
   .col-xl-12
@@ -10,15 +10,10 @@
           %li.list-inline-item
             = link_to('#', class: 'nav-link', data: { toggle: 'modal', target: '#create-staging-projects-modal' }) do
               %i.fas.fa-plus-circle.text-success
-              Create Project
-          %li.list-inline-item
-            = link_to('#', class: 'nav-link', data: { toggle: 'modal', target: '#staging-managers-group-modal' }) do
-              %i.fas.fa-users.text-warning
-              Managers
+              Create Staging Project
 
         = render(partial: 'staging_projects_table',
                  locals: { staging_workflow: @staging_workflow, staging_projects: @staging_projects, display_actions_column: true,
                            users_hash: @users_hash, groups_hash: @groups_hash })
 
         = render partial: 'create_staging_project', locals: { staging_workflow: @staging_workflow }
-        = render partial: 'staging_managers_group', locals: { staging_workflow: @staging_workflow }

--- a/src/api/app/views/webui2/webui/staging/workflows/show.html.haml
+++ b/src/api/app/views/webui2/webui/staging/workflows/show.html.haml
@@ -25,7 +25,7 @@
               = render(partial: 'delete', locals: { project: @project })
 
         = render(partial: 'staging_projects_table',
-                 locals: { staging_workflow: @staging_workflow, staging_projects: @staging_projects, display_actions_column: false,
+                 locals: { staging_workflow: @staging_workflow, staging_projects: @staging_projects,
                            users_hash: @users_hash, groups_hash: @groups_hash })
 
   .col-xl-2

--- a/src/api/app/views/webui2/webui/staging/workflows/show.html.haml
+++ b/src/api/app/views/webui2/webui/staging/workflows/show.html.haml
@@ -11,12 +11,17 @@
             %li.list-inline-item
               = link_to(edit_staging_workflow_path(@staging_workflow), class: 'nav-link') do
                 %i.fas.fa-edit.text-info
-                Configure
+                Manage Projects
+            %li.list-inline-item
+              = link_to('#', class: 'nav-link', data: { toggle: 'modal', target: '#staging-managers-group-modal' }) do
+                %i.fas.fa-users.text-warning
+                Change Managers
+              = render partial: 'staging_managers_group', locals: { staging_workflow: @staging_workflow }
           - if policy(@staging_workflow).destroy?
             %li.list-inline-item
               = link_to('#', class: 'nav-link', data: { toggle: 'modal', target: '#delete-staging-workflow' }) do
                 %i.fas.fa-times-circle.text-danger
-                Delete
+                Delete Staging
               = render(partial: 'delete', locals: { project: @project })
 
         = render(partial: 'staging_projects_table',


### PR DESCRIPTION
We changed a little bit the interface of the `Configuration` page.

Staging page:

![Screenshot-2019-3-29 Open Build Service](https://user-images.githubusercontent.com/2581944/55224785-858c5900-5211-11e9-8244-3607aae6b449.png)

Manage Staging:

![Screenshot_2019-03-26 Open Build Service(1)](https://user-images.githubusercontent.com/1212806/55012097-2e0aa500-4fe7-11e9-9253-135d40b04396.png)

<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md
-->
