### PR TITLE
[dist] Setting RAILS_ENV for delayed_job_monitor

### DIFF
--- a/dist/obs_api_delayed_jobs_monitor.cron
+++ b/dist/obs_api_delayed_jobs_monitor.cron
@@ -1,1 +1,1 @@
-*/10 * * * * RAILS_ENV=production /usr/bin/bundle.ruby2.5 exec /srv/www/obs/api/script/delayed_job_monitor.rb > /dev/null
+*/10 * * * * root RAILS_ENV=production /usr/bin/bundle.ruby2.5 exec /srv/www/obs/api/script/delayed_job_monitor.rb > /dev/null

--- a/dist/obs_api_delayed_jobs_monitor.cron
+++ b/dist/obs_api_delayed_jobs_monitor.cron
@@ -1,1 +1,1 @@
-*/10 * * * * /usr/bin/bundle.ruby2.5 exec /srv/www/obs/api/script/delayed_job_monitor.rb > /dev/null
+*/10 * * * * RAILS_ENV=production /usr/bin/bundle.ruby2.5 exec /srv/www/obs/api/script/delayed_job_monitor.rb > /dev/null


### PR DESCRIPTION
RAILS_ENV defaults to development and running the command without
RAILS_ENV set to production, results in a backtrace.

```
$ sudo /usr/bin/bundle.ruby2.5 exec /srv/www/obs/api/script/delayed_job_monitor.rb
Traceback (most recent call last):
        26: from /srv/www/obs/api/script/delayed_job_monitor.rb:2:in `<main>'
        25: from /srv/www/obs/api/script/delayed_job_monitor.rb:2:in `require'
        24: from /srv/www/obs/api/config/environment.rb:24:in `<top (required)>'
        23: from /usr/lib64/ruby/gems/2.5.0/gems/railties-5.1.4/lib/rails/railtie.rb:185:in `method_missing'
        22: from /usr/lib64/ruby/gems/2.5.0/gems/railties-5.1.4/lib/rails/railtie.rb:185:in `public_send'
        21: from /usr/lib64/ruby/gems/2.5.0/gems/railties-5.1.4/lib/rails/application.rb:353:in `initialize!'
        20: from /usr/lib64/ruby/gems/2.5.0/gems/railties-5.1.4/lib/rails/initializable.rb:58:in `run_initializers'
        19: from /usr/lib64/ruby/2.5.0/tsort.rb:205:in `tsort_each'
        18: from /usr/lib64/ruby/2.5.0/tsort.rb:226:in `tsort_each'
        17: from /usr/lib64/ruby/2.5.0/tsort.rb:347:in `each_strongly_connected_component'
        16: from /usr/lib64/ruby/2.5.0/tsort.rb:347:in `call'
        15: from /usr/lib64/ruby/2.5.0/tsort.rb:347:in `each'
        14: from /usr/lib64/ruby/2.5.0/tsort.rb:349:in `block in each_strongly_connected_component'
        13: from /usr/lib64/ruby/2.5.0/tsort.rb:431:in `each_strongly_connected_component_from'
        12: from /usr/lib64/ruby/2.5.0/tsort.rb:350:in `block (2 levels) in each_strongly_connected_component'
        11: from /usr/lib64/ruby/2.5.0/tsort.rb:228:in `block in tsort_each'
        10: from /usr/lib64/ruby/gems/2.5.0/gems/railties-5.1.4/lib/rails/initializable.rb:59:in `block in run_initializers'
         9: from /usr/lib64/ruby/gems/2.5.0/gems/railties-5.1.4/lib/rails/initializable.rb:30:in `run'
         8: from /usr/lib64/ruby/gems/2.5.0/gems/railties-5.1.4/lib/rails/initializable.rb:30:in `instance_exec'
         7: from /usr/lib64/ruby/gems/2.5.0/gems/railties-5.1.4/lib/rails/application/finisher.rb:73:in `block in <module:Finisher>'
         6: from /usr/lib64/ruby/gems/2.5.0/gems/activesupport-5.1.4/lib/active_support/lazy_load_hooks.rb:49:in `run_load_hooks'
         5: from /usr/lib64/ruby/gems/2.5.0/gems/activesupport-5.1.4/lib/active_support/lazy_load_hooks.rb:49:in `each'
         4: from /usr/lib64/ruby/gems/2.5.0/gems/activesupport-5.1.4/lib/active_support/lazy_load_hooks.rb:50:in `block in run_load_hooks'
         3: from /usr/lib64/ruby/gems/2.5.0/gems/activesupport-5.1.4/lib/active_support/lazy_load_hooks.rb:65:in `execute_hook'
         2: from /usr/lib64/ruby/gems/2.5.0/gems/activesupport-5.1.4/lib/active_support/lazy_load_hooks.rb:60:in `with_execution_control'
         1: from /usr/lib64/ruby/gems/2.5.0/gems/activesupport-5.1.4/lib/active_support/lazy_load_hooks.rb:67:in `block in execute_hook'
/srv/www/obs/api/config/environments/development.rb:72:in `block (2 levels) in <top (required)>': uninitialized constant Bullet (NameError)
```

The last line confirms that `config/environments/development.rb` is being read. When `RAILS_ENV=production` is passed, the command runs without any errors:

```
$ sudo RAILS_ENV=production /usr/bin/bundle.ruby2.5 exec /srv/www/obs/api/script/delayed_job_monitor.rb
$ echo $?
0
```