### PR TITLE
[backend] refactor various wipes

### DIFF
--- a/src/backend/BSSched/EventHandler.pm
+++ b/src/backend/BSSched/EventHandler.pm
@@ -384,7 +384,8 @@ sub event_wipe {
   my $reporoot = $gctx->{'reporoot'};
   my $gdst = "$reporoot/$prp/$myarch";
   print "wiping $prp $packid\n";
-  BSSched::BuildResult::wipe($gctx, $prp, $packid, $ectx->{'dstcache'}) if -d "$gdst/$packid";
+  my $prpsearchpath = $gctx->{'prpsearchpath'}->{$prp};
+  BSSched::BuildResult::wipe($gctx, $prp, $packid, $prpsearchpath, $ectx->{'dstcache'}) if -d "$gdst/$packid";
   for $prp (@{$gctx->{'prps'}}) {
     if ((split('/', $prp, 2))[0] eq $projid) {
       $changed_high->{$prp} = 2;


### PR DESCRIPTION
- refactor code that wipes the on-disk data from from
  BSSched::Checker::wipeobsolete to BSSched::BuildResult::wipeobsolete
- move code that wipes an obsolete repo from BSSched::Checker::wipe
  to BSSched::Checker::wipeobsoleterepo()
- add prpsearchpath argument to BSSched::BuildResult::wipe so that
  it matches the other wipe functions



<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md
-->
