### PR TITLE
Fix rendering of project tabs for maintenance projects

### DIFF
--- a/src/api/app/views/webui2/webui/project/_tabs.html.haml
+++ b/src/api/app/views/webui2/webui/project/_tabs.html.haml
@@ -5,9 +5,9 @@
     - unless @spider_bot
       - if project.is_maintenance?
         %li.nav-item
-          = tab_link('Incidents', project_maintenance_incidents_path)
+          = tab_link('Incidents', project_maintenance_incidents_path(project))
         %li.nav-item
-          = tab_link('Maintained Projects', project_maintained_projects_path)
+          = tab_link('Maintained Projects', project_maintained_projects_path(project))
       - unless project.defines_remote_instance? || project.is_maintenance?
         %li.nav-item
           = tab_link('Repositories', repositories_path(project))


### PR DESCRIPTION
Clicking on some of the sub tabs of a maintenance project, like 'meta',
was causing an exception. This happened because we generated urls for
maintenance sub tabs without the necessary parameters.

Fixed #7325



<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md
-->
