### PR TITLE
Disable backend callbacks while creating seeds

### DIFF
--- a/src/api/db/seeds.rb
+++ b/src/api/db/seeds.rb
@@ -18,6 +18,7 @@ end
 end
 
 # set default configuration settings if no settings exist
+Configuration.skip_callback(:save, :after, :delayed_write_to_backend)
 Configuration.first_or_create(name: 'private', title: 'Open Build Service') do |conf|
   conf.description = <<-EOT
   <p class="description">
@@ -160,6 +161,7 @@ at.allowed_values << AttribAllowedValue.new(value: 'BugownerOnly')
 update_all_attrib_type_descriptions
 
 puts 'Seeding issue trackers ...'
+IssueTracker.skip_callback(:save, :after, :delayed_write_to_backend)
 IssueTracker.where(name: 'boost').first_or_create(description: 'Boost Trac',
                                                   kind: 'trac',
                                                   regex: 'boost#(\d+)',


### PR DESCRIPTION
Performing backend actions during db:seed is problematic as the backend is not part of the docker network.

We update the configuration later - which will trigger a background job to write it once the full stack is up

Fixes #7303



<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md
-->
