### PR TITLE
[api] fix another add container special case

### DIFF
--- a/src/api/spec/cassettes/Package/_add_containers/1_26_1.yml
+++ b/src/api/spec/cassettes/Package/_add_containers/1_26_1.yml
@@ -1,0 +1,315 @@
+---
+http_interactions:
+- request:
+    method: put
+    uri: http://backend:5352/source/home:tom/_meta?user=tom
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:tom">
+          <title/>
+          <description/>
+          <person userid="tom" role="maintainer"/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '129'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:tom">
+          <title></title>
+          <description></description>
+          <person userid="tom" role="maintainer" />
+        </project>
+    http_version: 
+  recorded_at: Wed, 15 May 2019 11:22:22 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/project_foo/_meta?user=tom
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="project_foo" kind="maintenance">
+          <title>The Line of Beauty</title>
+          <description/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '125'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="project_foo" kind="maintenance">
+          <title>The Line of Beauty</title>
+          <description></description>
+        </project>
+    http_version: 
+  recorded_at: Wed, 15 May 2019 11:22:22 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/project_foo/_project/_attribute?meta=1&user=tom
+    body:
+      encoding: UTF-8
+      string: |
+        <attributes>
+          <attribute name="MaintenanceProject" namespace="OBS"/>
+        </attributes>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '165'
+    body:
+      encoding: UTF-8
+      string: |
+        <revision rev="2">
+          <srcmd5>fc76ef870cc943d1d2c171241cd0d47f</srcmd5>
+          <time>1557919343</time>
+          <user>tom</user>
+          <comment></comment>
+          <requestid/>
+        </revision>
+    http_version: 
+  recorded_at: Wed, 15 May 2019 11:22:23 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/project_foo/package_bar/_meta?user=tom
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="package_bar" project="project_foo">
+          <title>To Your Scattered Bodies Go</title>
+          <description>Molestiae qui voluptas et.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '163'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="package_bar" project="project_foo">
+          <title>To Your Scattered Bodies Go</title>
+          <description>Molestiae qui voluptas et.</description>
+        </package>
+    http_version: 
+  recorded_at: Wed, 15 May 2019 11:22:23 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/project_foo/package_bar/_meta?user=tom
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="package_bar" project="project_foo">
+          <title>To Your Scattered Bodies Go</title>
+          <description>Molestiae qui voluptas et.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '163'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="package_bar" project="project_foo">
+          <title>To Your Scattered Bodies Go</title>
+          <description>Molestiae qui voluptas et.</description>
+        </package>
+    http_version: 
+  recorded_at: Wed, 15 May 2019 11:22:23 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/project_foo/package_bar/_config
+    body:
+      encoding: UTF-8
+      string: Et cumque laudantium. Ut facere blanditiis. Vel quas ipsam.
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '207'
+    body:
+      encoding: UTF-8
+      string: |
+        <revision rev="1" vrev="1">
+          <srcmd5>68791b0ad72ac17f6754c0584f3398bf</srcmd5>
+          <version>unknown</version>
+          <time>1557919343</time>
+          <user>unknown</user>
+          <comment></comment>
+          <requestid/>
+        </revision>
+    http_version: 
+  recorded_at: Wed, 15 May 2019 11:22:23 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/project_foo/package_bar/somefile.txt
+    body:
+      encoding: UTF-8
+      string: Esse iusto cumque. Illum veritatis architecto. Voluptatem sit occaecati.
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '207'
+    body:
+      encoding: UTF-8
+      string: |
+        <revision rev="2" vrev="2">
+          <srcmd5>0f3ec7e492f955fb5c3310843c5a9b05</srcmd5>
+          <version>unknown</version>
+          <time>1557919343</time>
+          <user>unknown</user>
+          <comment></comment>
+          <requestid/>
+        </revision>
+    http_version: 
+  recorded_at: Wed, 15 May 2019 11:22:23 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/project_foo/package_bar
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '298'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="package_bar" rev="2" vrev="2" srcmd5="0f3ec7e492f955fb5c3310843c5a9b05">
+          <entry name="_config" md5="99e8cc136f1e61560d93731750bc7294" size="59" mtime="1557919343" />
+          <entry name="somefile.txt" md5="6505cacd9c0bfeb1e311211de5f33659" size="72" mtime="1557919343" />
+        </directory>
+    http_version: 
+  recorded_at: Wed, 15 May 2019 11:22:23 GMT
+recorded_with: VCR 4.0.0

--- a/src/api/spec/models/package_spec.rb
+++ b/src/api/spec/models/package_spec.rb
@@ -790,4 +790,11 @@ RSpec.describe Package, vcr: true do
       expect(package.render_xml).to eq(corrected_meta_xml)
     end
   end
+
+  describe '#add_containers' do
+    let(:maintenance_update_with_package) { create(:maintenance_project, name: 'project_foo') }
+    let(:first_maintained_package) { create(:package_with_file, name: 'package_bar', project: maintenance_update_with_package) }
+
+    it { expect { first_maintained_package.add_containers({}) }.not_to raise_error }
+  end
 end


### PR DESCRIPTION
When maintnenace updates went out, but container update was left out.
The next maintenancen update canidate will not find the container
candidates still using GA packages.

We come with update project already in that case and need to find the
GA versions via all project links.



<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md
-->
