### PR TITLE
Allow acceptance of requests when they are in 'accepting' state

### DIFF
--- a/src/api/app/models/concerns/staging_project.rb
+++ b/src/api/app/models/concerns/staging_project.rb
@@ -144,7 +144,7 @@ module StagingProject
 
   def accept_staged_requests
     clear_memoized_data
-    return unless overall_state == :acceptable
+    return unless overall_state.in?([:acceptable, :accepting])
 
     accepted_packages = []
     staged_requests.each do |staged_request|
@@ -182,6 +182,7 @@ module StagingProject
   end
 
   def state
+    # FIXME: We should use a better way to check if we are in :accepting state. Could be a state machine or storing the state locally.
     return :accepting if Delayed::Job.where("handler LIKE '%job_class: StagingProjectAcceptJob% project_id: #{id}%'").exists?
     return :empty if staged_requests.blank?
     return :unacceptable if untracked_requests.present? || staged_requests.obsolete.exists?


### PR DESCRIPTION
Because the overall_state method queries delayed jobs we need to
consider the 'accepting' state as one of the "mergable" states.

Co-authored-by: Saray Cabrera Padrón <scabrerapadron@suse.de>



<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md
-->
