### PR TITLE
Fix clickable area of links on project user tab

### DIFF
--- a/src/api/app/views/webui2/shared/user_or_groups_roles/_index.html.haml
+++ b/src/api/app/views/webui2/shared/user_or_groups_roles/_index.html.haml
@@ -29,11 +29,13 @@
                            project: project, package: package }
 
   - if user_is_maintainer
-    = render(partial: 'webui2/shared/user_or_groups_roles/add_user_dialog', locals: { project: project.to_param, package: package.to_param })
-    = link_to('#', data: { toggle: 'modal', target: '#add-user-role-modal' }, id: 'add-user', class: 'nav-link') do
-      %i.fas.fa-plus-circle.text-primary
-      Add User
-    = render(partial: 'webui2/shared/user_or_groups_roles/delete_dialog')
+    %ul.list-inline
+      %li.list-inline-item
+        = render(partial: 'webui2/shared/user_or_groups_roles/add_user_dialog', locals: { project: project.to_param, package: package.to_param })
+        = link_to('#', data: { toggle: 'modal', target: '#add-user-role-modal' }, id: 'add-user', class: 'nav-link') do
+          %i.fas.fa-plus-circle.text-primary
+          Add User
+        = render(partial: 'webui2/shared/user_or_groups_roles/delete_dialog')
 
   %hr
 
@@ -53,10 +55,13 @@
                            user_is_maintainer: user_is_maintainer,
                            project: project, package: package }
   - if user_is_maintainer
-    = render(partial: 'webui2/shared/user_or_groups_roles/add_group_dialog', locals: { project: project.to_param, package: package.to_param })
-    = link_to('#', data: { toggle: 'modal', target: '#add-group-role-modal' }, id: 'add-group', class: 'nav-link') do
-      %i.fas.fa-plus-circle.text-primary
-      Add Group
+    %ul.list-inline
+      %li.list-inline-item
+        = render(partial: 'webui2/shared/user_or_groups_roles/add_group_dialog', locals: { project: project.to_param, package: package.to_param })
+        = link_to('#', data: { toggle: 'modal', target: '#add-group-role-modal' }, id: 'add-group', class: 'nav-link') do
+          %i.fas.fa-plus-circle.text-primary
+          Add Group
+
 :javascript
   setDataTableForUsersAndGroups();
 - if user_is_maintainer


### PR DESCRIPTION
This insures that only the visible link text and icon is clickable.
Before all of the whitespace that followed the link was clickable.



