### PR TITLE
Add Policy validation to Add/Remove actions before show create/destroy

### DIFF
--- a/src/api/app/views/webui2/webui/staging/excluded_requests/index.html.haml
+++ b/src/api/app/views/webui2/webui/staging/excluded_requests/index.html.haml
@@ -15,14 +15,18 @@
                 %td= request_exclusion.bs_request.number
                 %td= request_exclusion.description
                 %td
-                  = link_to('#', title: 'Stop excluding request', data: { toggle: 'modal', target: '#delete-excluded-request-modal',
-                    action: staging_workflow_excluded_request_path(@staging_workflow, request_exclusion) }) do
-                    %i.fas.fa-times-circle.text-danger
-        = link_to('#', data: { toggle: 'modal', target: '#exclude-request-modal' }) do
-          %i.fas.fa-plus-circle.text-primary
-          Exclude request
-= render partial: 'create_dialog'
-= render partial: 'delete_dialog'
+                  - if Staging::RequestExclusionPolicy.new(User.current, @staging_workflow).create?
+                    = link_to('#', title: 'Stop excluding request', data: { toggle: 'modal', target: '#delete-excluded-request-modal',
+                      action: staging_workflow_excluded_request_path(@staging_workflow, request_exclusion) }) do
+                      %i.fas.fa-times-circle.text-danger
+        - if Staging::RequestExclusionPolicy.new(User.current, @staging_workflow).create?
+          = link_to('#', data: { toggle: 'modal', target: '#exclude-request-modal' }) do
+            %i.fas.fa-plus-circle.text-primary
+            Exclude request
+
+- if Staging::RequestExclusionPolicy.new(User.current, @staging_workflow).create?
+  = render partial: 'create_dialog'
+  = render partial: 'delete_dialog'
 
 = content_for :ready_function do
   :plain


### PR DESCRIPTION
How the views look like with/without permissions

![Screenshot_2019-04-09_12-06-48](https://user-images.githubusercontent.com/37418/55792156-5226b580-5ac0-11e9-8032-bd7651df441b.png)

![Screenshot_2019-04-09_12-06-24](https://user-images.githubusercontent.com/37418/55792175-5e127780-5ac0-11e9-910e-ef3512571332.png)


I'm not sure if it's better to show a disabled link (to make the user aware that this option exists) or hide it (simplifying the view to the user). Independently I just followed the approach being done until now: 
"Hide options from the user if he/she has no rights to execute it"  