### PR TITLE
Catch exception in meta validator

### DIFF
--- a/src/api/app/services/meta_controller_service/meta_validator.rb
+++ b/src/api/app/services/meta_controller_service/meta_validator.rb
@@ -13,7 +13,11 @@ module MetaControllerService
       @errors << Project.check_repositories(remove_repositories)[:error]
       @errors << Project.validate_remote_permissions(@request_data)[:error]
       @errors << Project.validate_link_xml_attribute(@request_data, @project.name)[:error]
-      @errors << Project.validate_maintenance_xml_attribute(@request_data)[:error]
+      begin
+        @errors << Project.validate_maintenance_xml_attribute(@request_data)[:error]
+      rescue Project::Errors::UnknownObjectError => e
+        @errors << "Maintained project not found: '#{e.message}'"
+      end
       @errors << Project.validate_repository_xml_attribute(@request_data, @project.name)[:error]
       @errors.compact!
     end


### PR DESCRIPTION
When adding a maintenance project that does not exist, saving the
meta would cause a broken UI because we were not catching the
Project::Errors::UnknownObjectError exception.



<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md
-->
