### PR TITLE
Update bundler version

### DIFF
--- a/dist/obs-bundled-gems.spec
+++ b/dist/obs-bundled-gems.spec
@@ -51,7 +51,7 @@ This package bundles all the gems required by the Open Build Service
 to make it easier to deploy the obs-server package.
 
 %define rake_version 12.3.2
-%define rack_version 2.0.6
+%define rack_version 2.0.7
 
 %package -n obs-api-deps
 Summary:        Holding dependencies required to run the OBS frontend

--- a/src/api/Gemfile.lock
+++ b/src/api/Gemfile.lock
@@ -551,4 +551,4 @@ DEPENDENCIES
   yajl-ruby
 
 BUNDLED WITH
-   1.13.6
+   1.17.1


### PR DESCRIPTION
We used a very outdated version that e.g. causes the crash in the rubocop update, so I updated the obs package - but this needs to be aligned with Gemfile.lock (it's soon part of the containers) 

