### PR TITLE
Rename exeption objects to e

### DIFF
--- a/dist/openQA_mail_notification.rb
+++ b/dist/openQA_mail_notification.rb
@@ -25,8 +25,8 @@ def get_build_information(version)
     request = Net::HTTP::Get.new(uri.request_uri)
     response = http.request(request)
     JSON.parse(response.body)['jobs'].last
-  rescue Exception => ex
-    $stderr.puts "Error while fetching openQA data: #{ex.inspect}"
+  rescue Exception => e
+    $stderr.puts "Error while fetching openQA data: #{e.inspect}"
     abort
   end
 end

--- a/src/api/app/controllers/cloud/upload_jobs_controller.rb
+++ b/src/api/app/controllers/cloud/upload_jobs_controller.rb
@@ -27,10 +27,10 @@ module Cloud
     def destroy
       ::Backend::Api::Cloud.destroy(@upload_job.job_id)
       render_ok
-    rescue ::Backend::Error => exception
+    rescue ::Backend::Error => e
       render_error status: 500,
                    errorcode: 'cloud_upload_job_error',
-                   message: exception.message
+                   message: e
     end
 
     private

--- a/src/api/app/controllers/source_controller.rb
+++ b/src/api/app/controllers/source_controller.rb
@@ -105,8 +105,8 @@ class SourceController < ApplicationController
 
     begin
       tpkg.destroy
-    rescue ActiveRecord::RecordNotDestroyed => invalid
-      exception_message = "Destroying Package #{tpkg.project.name}/#{tpkg.name} failed: #{invalid.record.errors.full_messages.to_sentence}"
+    rescue ActiveRecord::RecordNotDestroyed => e
+      exception_message = "Destroying Package #{tpkg.project.name}/#{tpkg.name} failed: #{e.record.errors.full_messages.to_sentence}"
       logger.debug exception_message
       raise ActiveRecord::RecordNotDestroyed, exception_message
     end

--- a/src/api/app/controllers/source_project_controller.rb
+++ b/src/api/app/controllers/source_project_controller.rb
@@ -71,8 +71,8 @@ class SourceProjectController < SourceController
     project.commit_opts = { comment: params[:comment] }
     begin
       project.destroy
-    rescue ActiveRecord::RecordNotDestroyed => invalid
-      exception_message = "Destroying Project #{project.name} failed: #{invalid.record.errors.full_messages.to_sentence}"
+    rescue ActiveRecord::RecordNotDestroyed => e
+      exception_message = "Destroying Project #{project.name} failed: #{e.record.errors.full_messages.to_sentence}"
       logger.debug exception_message
       raise ActiveRecord::RecordNotDestroyed, exception_message
     end

--- a/src/api/app/controllers/webui/cloud/upload_jobs_controller.rb
+++ b/src/api/app/controllers/webui/cloud/upload_jobs_controller.rb
@@ -38,8 +38,8 @@ module Webui
           authorize @upload_job, :destroy?
           Backend::Api::Cloud.destroy(@upload_job.job_id)
           flash[:success] = "Successfully aborted upload job with id #{params[:id]}."
-        rescue Backend::Error => exception
-          flash[:error] = exception.message
+        rescue Backend::Error => e
+          flash[:error] = e.message
         end
 
         redirect_to cloud_upload_index_path

--- a/src/api/app/controllers/webui/download_on_demand_controller.rb
+++ b/src/api/app/controllers/webui/download_on_demand_controller.rb
@@ -14,8 +14,8 @@ class Webui::DownloadOnDemandController < Webui::WebuiController
         @download_on_demand.save!
         @project.store
       end
-    rescue ActiveRecord::RecordInvalid, Backend::Error => exception
-      redirect_back(fallback_location: root_path, error: "Download on Demand can't be created: #{exception.message}")
+    rescue ActiveRecord::RecordInvalid, Backend::Error => e
+      redirect_back(fallback_location: root_path, error: "Download on Demand can't be created: #{e.message}")
       return
     end
 

--- a/src/api/app/models/cloud/backend/upload_job.rb
+++ b/src/api/app/models/cloud/backend/upload_job.rb
@@ -27,8 +27,8 @@ module Cloud
         xml = ::Backend::Api::Cloud.upload(params)
 
         new(xml: xml)
-      rescue ::Backend::Error, Timeout::Error => exception
-        new(exception: exception.message)
+      rescue ::Backend::Error, Timeout::Error => e
+        new(exception: e.message)
       end
 
       def self.find(job_id, options = {})

--- a/src/api/app/models/group.rb
+++ b/src/api/app/models/group.rb
@@ -102,8 +102,8 @@ class Group < ApplicationRecord
       end
       save!
     end
-  rescue ActiveRecord::RecordInvalid, NotFoundError => exception
-    errors.add(:base, exception.message)
+  rescue ActiveRecord::RecordInvalid, NotFoundError => e
+    errors.add(:base, e.message)
   end
 
   def remove_user(user)

--- a/src/api/app/models/project/remote_url.rb
+++ b/src/api/app/models/project/remote_url.rb
@@ -11,8 +11,8 @@ class Project::RemoteURL
     begin
       uri.open.read
     rescue OpenURI::HTTPError, SocketError, Errno::EINTR, Errno::EPIPE, EOFError, Net::HTTPBadResponse, IOError, Errno::ENETUNREACH,
-           Errno::ETIMEDOUT, Errno::ECONNREFUSED, Timeout::Error, OpenSSL::SSL::SSLError => err
-      Rails.logger.debug "#{err} when fetching #{path} from #{remote_project.remoteurl}"
+           Errno::ETIMEDOUT, Errno::ECONNREFUSED, Timeout::Error, OpenSSL::SSL::SSLError => e
+      Rails.logger.debug "#{e} when fetching #{path} from #{remote_project.remoteurl}"
       nil
     end
   end

--- a/src/api/app/services/meta_controller_service/meta_xml_validator.rb
+++ b/src/api/app/services/meta_controller_service/meta_xml_validator.rb
@@ -11,8 +11,8 @@ module MetaControllerService
     def call
       Suse::Validator.validate('project', @meta)
       @request_data = Xmlhash.parse(@meta)
-    rescue Suse::ValidationError => exception
-      @errors = exception.message
+    rescue Suse::ValidationError => e
+      @errors = e.message
     end
 
     def errors?

--- a/src/api/lib/authenticator.rb
+++ b/src/api/lib/authenticator.rb
@@ -153,8 +153,8 @@ class Authenticator
         Rails.logger.debug "Creating account for user '#{@login}'"
         @http_user = User.create_user_with_fake_pw!(login: @login, state: User.default_user_state)
       end
-    rescue GSSAPI::GssApiError => error
-      raise AuthenticationRequiredError, "Received a GSSAPI exception; #{error.message}."
+    rescue GSSAPI::GssApiError => e
+      raise AuthenticationRequiredError, "Received a GSSAPI exception; #{e.message}."
     end
   end
 

--- a/src/api/lib/opensuse/validator.rb
+++ b/src/api/lib/opensuse/validator.rb
@@ -104,8 +104,8 @@ module Suse
             # Only raise an exception for user-input validation!
             raise ValidationError, "#{schema_file} validation error: #{error}"
           end
-        rescue Nokogiri::XML::SyntaxError => error
-          raise ValidationError, "#{schema_file} validation error: #{error}"
+        rescue Nokogiri::XML::SyntaxError => e
+          raise ValidationError, "#{schema_file} validation error: #{e}"
         end
         true
       end

--- a/src/api/lib/tasks/delayed_job.rake
+++ b/src/api/lib/tasks/delayed_job.rake
@@ -10,8 +10,8 @@ task(importrequests: :environment) do
   while lastrq > 0
     begin
       xml = Backend::Api::Request.info(lastrq)
-    rescue Backend::Error => err
-      Rails.logger.error "Request ##{lastrq} could not be retrieved:\n#{err}"
+    rescue Backend::Error => e
+      Rails.logger.error "Request ##{lastrq} could not be retrieved:\n#{e}"
       lastrq -= 1
       next
     end


### PR DESCRIPTION
This is a new default rubocop introduced with 0.67.2 and I agree with it

You can find details at https://rubocop.readthedocs.io/en/latest/cops_naming/#namingrescuedexceptionsvariablename

Please vote @openSUSE/obs-frontend 