### PR TITLE
Improve release target ng queries

### DIFF
--- a/src/api/app/models/project.rb
+++ b/src/api/app/models/project.rb
@@ -1397,12 +1397,10 @@ class Project < ApplicationRecord
     # One catch, currently there's only one patchinfo per incident, but things keep changing every
     # other day, so it never hurts to have a look into the future:
     package_count = 0
-    packages.where.not(id: global_patchinfo_package).select(:name, :id).each do |pkg|
+    packages.where.not(id: global_patchinfo_package).where("name like '%.%'").select(:name, :id).each do |pkg|
       # Current ui is only showing the first found package and a symbol for any additional package.
       break if package_count > 2
 
-      rt_name = pkg.name.split('.', 2).last
-      next unless rt_name
       # Here we try hard to find the release target our current package is build for:
       rt_name = guess_release_target_from_package(pkg, release_targets_ng)
 


### PR DESCRIPTION
* Move check for release target extension into SQL 
* Refactored code of guess_release_target_from_package method and moved
  it into `release_target_ng`.
  * Instead of filtering the flag query result afterwards we do
    this as part of the SQL query.
  * The method was using a hash for mapping the queried results.
    This code got mostly removed. The remaining hashing is now part
    of the release target loop. So we spare us one loop.
  * Renamed varialbes: pkg -> package, rt_name -> release_target_name