### PR TITLE
Patchinfo refactor

### DIFF
--- a/src/api/app/assets/javascripts/webui/application/patchinfo.js.erb
+++ b/src/api/app/assets/javascripts/webui/application/patchinfo.js.erb
@@ -27,10 +27,10 @@ $(document).on('click', 'a[data-add-issue]', function() {
             $("#issuelist").append("<div id='issue_" + this[0] + "_" + this[1] + "'>" +
               "<a id='remove_" + this[0] + "_" + this[1] + "' onclick='$(\"#issue_" + this[0] + "_" + this[1] + "\").remove(); return false;' href='#'> " +
               "<img src='<%= asset_path('bug_delete.png') %>' title='Remove Bug' alt='Remove Bug'></a> " +
-              "<input type='hidden' name='issueid[]' id='issueid_" + this[0] + "_" + this[1] + "' value='" + this[1] + "'/>" +
-              "<input type='hidden' name='issuetracker[]' id='issuetracker_" + this[0] + "_" + this[1] + "' value='" + this[0] + "'/>" +
-              "<input type='hidden' name='issueurl[]' id='issueurl_" + this[0] + "_" + this[1] + "' value='" + this[2] + "'/>" +
-              "<input type='hidden' name='issuesum[]' id='issuesum_" + this[0] + "_" + this[1] + "' value='" + this[3] + "'/>" +
+              "<input type='hidden' name='patchinfo[issueid][]' id='issueid_" + this[0] + "_" + this[1] + "' value='" + this[1] + "'/>" +
+              "<input type='hidden' name='patchinfo[issuetracker][]' id='issuetracker_" + this[0] + "_" + this[1] + "' value='" + this[0] + "'/>" +
+              "<input type='hidden' name='patchinfo[issueurl][]' id='issueurl_" + this[0] + "_" + this[1] + "' value='" + this[2] + "'/>" +
+              "<input type='hidden' name='patchinfo[issuesum][]' id='issuesum_" + this[0] + "_" + this[1] + "' value='" + this[3] + "'/>" +
               "<a href=\"" + this[2] + "\" target='_blank'>" + this[0] + "#" + this[1] + "</a>" + ":<br/>" +
               "<div id='issue_desc_" + this[0] + "_" + this[1] + "' onclick='change_issue_desc(\"" + this[0] +
               "_" + this[1] + "\");'>" + this[3] + "</div>" +
@@ -90,10 +90,10 @@ function stopRKey(evt) {
 }
 
 function toggle_blockreason(){
-  if (!$("#block").is(":checked")) {
-    $("#block_reason").prop('disabled', true);
+  if (!$("#patchinfo_block").is(":checked")) {
+    $("#patchinfo_block_reason").prop('disabled', true);
   } else {
-    $("#block_reason").prop('disabled', false);
+    $("#patchinfo_block_reason").prop('disabled', false);
   }
 }
 
@@ -101,25 +101,25 @@ function patchinfoReady() {
   document.onkeypress = stopRKey;
   toggle_blockreason();
   $("form").submit(function () {
-    $('#selected_binaries option').prop('selected', true);
+    $('#patchinfo_binaries option').prop('selected', true);
     $('#available_binaries option').prop('selected', true);
   });
 
   $('#add').click(function () {
-    $("#selected_binaries option[value='']").remove();
-    moveSelectedItems('#available_binaries', '#selected_binaries');
+    $("#patchinfo_binaries option[value='']").remove();
+    moveSelectedItems('#available_binaries', '#patchinfo_binaries');
   });
   $('#add-all').click(function () {
-    $("#selected_binaries option[value='']").remove();
+    $("#patchinfo_binaries option[value='']").remove();
     $('#available_binaries option').prop('selected', 'true');
-    moveSelectedItems('#available_binaries', '#selected_binaries');
+    moveSelectedItems('#available_binaries', '#patchinfo_binaries');
   });
   $('#remove').click(function () {
-    moveSelectedItems('#selected_binaries', '#available_binaries');
+    moveSelectedItems('#patchinfo_binaries', '#available_binaries');
   });
   $('#remove-all').click(function () {
-    $('#selected_binaries option').prop('selected', 'true');
-    moveSelectedItems('#selected_binaries', '#available_binaries');
+    $('#patchinfo_binaries option').prop('selected', 'true');
+    moveSelectedItems('#patchinfo_binaries', '#available_binaries');
   });
 
   $("#summary").keypress(function (event) {
@@ -127,7 +127,7 @@ function patchinfoReady() {
       event.preventDefault();
     }
   });
-  $('#block').change(function(){
+  $('#patchinfo_block').change(function(){
     toggle_blockreason();
   });
 }

--- a/src/api/app/views/webui/patchinfo/_form.html.haml
+++ b/src/api/app/views/webui/patchinfo/_form.html.haml
@@ -1,5 +1,5 @@
 = render partial: 'webui/package/tabs'
-= form_tag(update_patchinfo_path(project: @project, package: @package), method: :put, id: 'patchinfo') do
+= form_for(@patchinfo, url: update_patchinfo_path(project: @project, package: @package), method: :put, html: { id: 'patchinfo' }) do |f|
   .section
     .grid_8.alpha
       .box.show_left.show_right
@@ -9,9 +9,9 @@
         .box.show_left.show_right
           %p
             %strong
-              %label{ for: "packager" } Packager:
+              = f.label(:packager, 'Packager:')
             %br/
-            = text_field_tag 'packager', @packager, required: true
+            = f.text_field :packager, required: true
             :javascript
               $("#packager").autocomplete({source: '#{url_for controller: 'user', action: 'autocomplete'}', search: function(event, ui) {
                 $(this).addClass('loading-spinner');
@@ -22,48 +22,48 @@
           %p
             %strong
               = image_tag('info.png', title: 'Enter a short summary. Mainpackage: shortdescription of the mainfix', alt: 'Summaryinfo')
-              %label{ for: "summary" } Summary:
-            = text_area_tag 'summary', @summary, size: '60x1', required: true, minlength: 10
+              = f.label(:summary, 'Summary:')
+            = f.text_area :summary, size: '60x1', required: true, minlength: 10
           %p
             %strong
               = image_tag('info.png', title: 'Enter a full description what the update fixes', alt: 'Descriptioninfo')
-              %label{ for: "description" } Description:
-            = text_area_tag 'description', @description, size: '65x9', required: true, minlength: 50
+              = f.label(:description, 'Description:')
+            = f.text_area :description, size: '65x9', required: true, minlength: 50
           %p
             %strong
               = image_tag('info.png', title: 'Enter a version of this update', alt: 'Versioninfo')
-              %label{ for: "version" } Version:
+              = f.label(:version, 'Version:')
             %br/
-            = text_field_tag 'version', @version
+            = f.text_field :version
           %p
             %strong
               = image_tag('info.png', title: 'Enter a message', alt: 'Messageinfo')
-              %label{ for: "message" } Message:
-            = text_area_tag 'message', @message, size: '65x5'
+              = f.label(:message, 'Message:')
+            = f.text_area :message, size: '65x5'
           %p
             %strong
               = image_tag('info.png', title: 'Choose the category of your update', alt: 'Categoryinfo')
-              %label{ for: "category" } Category:
-            = select_tag 'category', options_for_select(Patchinfo::CATEGORIES, @category)
+              = f.label(:category, 'Category:')
+            = f.select :category, options_for_select(Patchinfo::CATEGORIES, @patchinfo.category)
           %p
             %strong
               = image_tag('info.png', title: 'Select the rating of this update', alt: 'Ratinginfo')
-              %label{ for: "rating" } Rating:
-            = select_tag 'rating', options_for_select(Patchinfo::RATINGS, @rating)
+              = f.label(:rating, 'Rating:')
+            = f.select :rating, options_for_select(Patchinfo::RATINGS, @patchinfo.rating)
         .box.show_left.show_right
           %p
             %strong
               = image_tag('info.png', title: 'List of issues what the update fixes', alt: 'Issueinfo')
               Issues:
           #issuelist
-            - if @issues
-              - @issues.reject { |issue| issue.blank? }.each do |issue|
+            - if @patchinfo.issues
+              - @patchinfo.issues.reject { |issue| issue.blank? }.each do |issue|
                 %div{ id: "issue_#{issue[0]}_#{issue[1]}" }
                   = link_to image_tag('bug_delete.png', alt: 'Remove Bug', title: 'Remove Bug'), '#', onclick: "$('#issue_#{issue[0]}_#{issue[1]}').remove(); return false;", style: 'clear:both;', id: "remove_#{issue[0]}_#{issue[1]}"
-                  = hidden_field_tag 'issueid[]', "#{issue[1]}", id: "issueid_#{issue[0]}_#{issue[1]}"
-                  = hidden_field_tag 'issuetracker[]', "#{issue[0]}", id: "issuetracker_#{issue[0]}_#{issue[1]}"
-                  = hidden_field_tag 'issueurl[]', "#{issue[2]}", id: "issueurl_#{issue[0]}_#{issue[1]}"
-                  = hidden_field_tag 'issuesum[]', "#{issue[3]}", id: "issuesum_#{issue[0]}_#{issue[1]}"
+                  = f.hidden_field :issueid, value: "#{issue[1]}", id: "issueid_#{issue[0]}_#{issue[1]}", multiple: true
+                  = f.hidden_field :issuetracker, value: "#{issue[0]}", id: "issuetracker_#{issue[0]}_#{issue[1]}", multiple: true
+                  = f.hidden_field :issueurl, value: "#{issue[2]}", id: "issueurl_#{issue[0]}_#{issue[1]}", multiple: true
+                  = f.hidden_field :issuesum, value: "#{issue[3]}", id: "issuesum_#{issue[0]}_#{issue[1]}", multiple: true
                   = link_to "#{issue[0].to_s}##{issue[1].to_s}", issue[2].to_s
                   \: 
                   %div{ id: "issue_desc_#{issue[0]}_#{issue[1]}", onclick: "change_issue_desc('#{issue[0]}_#{issue[1]}');" }
@@ -74,7 +74,7 @@
                     = link_to image_tag('req-decline.png', alt: 'Cancel', title: 'Cancel changes'), '#', onclick: "changeDesc('cancel', '#{issue[0]}_#{issue[1]}'); return false;"
           .box.show_right.show_left{ style: "margin-top:5px;" }
             %p
-              %label{ for: "issue" }
+              = f.label(:issue) do
                 Add an additional bug (single or a comma-separated list e.g.: "boo#123456,
                 bgo#654321,CVE-2012-1234)"
                 %br/
@@ -91,26 +91,22 @@
               = image_tag('info.png', title: 'Set the required flags for this update', alt: 'Flagsinfo')
               Required actions:
           %p
-            = check_box_tag('zypp_restart_needed', true, @zypp_restart_needed)
-            %label{ for: "zypp_restart_needed" } Package-manager restart suggested
+            = f.check_box :zypp_restart_needed
+            = f.label(:zypp_restart_needed, 'Package-manager restart suggested')
           %p
-            = check_box_tag('relogin', true, @relogin)
-            %label{ for: "relogin" } Relogin suggested
+            = f.check_box :relogin_needed
+            = f.label(:relogin_needed, 'Relogin suggested')
           %p
-            = check_box_tag('reboot', true, @reboot)
-            %label{ for: "reboot" } Reboot suggested
+            = f.check_box :reboot_needed
+            = f.label(:reboot_needed, 'Reboot suggested')
         .box.show_left.show_right
           %p
             %strong
               = image_tag('info.png', title: 'Move specific binaries to the right select box by using the arrows', alt: 'Binaryinfo')
               Binaries:
-          - if @binarylist.present? || @binaries.present?
-            - available_bin = Array.new
-            - @binarylist.each { |d| available_bin << "#{d.to_s}" }
-            - selected_bin = Array.new
-            - @binaries.each { |bin| selected_bin << "#{bin.to_s}" }
+          - if @binarylist.present? || @patchinfo.binaries.present?
             #avail-bin{ style: "float:left; width:44%; margin-left:5px;" }
-              = select_tag 'available_binaries', options_for_select(available_bin), multiple: true, size: 6, style: 'width:100%;'
+              = select_tag 'available_binaries', options_for_select(@binarylist.to_a), multiple: true, size: 6, style: 'width:100%;'
             #bin-options{ style: "float:left; width:28px;" }
               %input#add{ style: "width:28px;", type: "button", value: ">" }/
               %br/
@@ -121,22 +117,21 @@
               %input#remove{ style: "width:28px;", type: "button", value: "<" }/
               %br/
             #sele-bin{ style: "width:44%; float:left;" }
-              - if !selected_bin.blank?
-                = select_tag 'selected_binaries', options_for_select(selected_bin), multiple: true, size: 6, style: 'width:100%;'
-              - else
-                = select_tag 'selected_binaries', "<option value=''></option>".html_safe, multiple: true, size: 6, style: 'width:100%;'
+              = f.select :binaries, options_for_select(@patchinfo.binaries.to_a), { include_hidden: false }, { multiple: true, size: 6, style: 'width:100%;' }
             %br{ style: "clear:both;" }/
           - else
             %strong No binaries available!
         .box.ui-state-error.ui-widget-shadow.show_left.show_right{ style: "padding-bottom:5px;" }
           %p
-            %strong Block release?
-            = check_box_tag('block', 'true', @block)
+            = f.label(:block) do
+              %strong Block release?
+            = f.check_box :block
           %p
-            %strong Reason:
-            = text_field_tag('block_reason', @block_reason, style: 'width: 99%', disabled: true)
+            = f.label(:block_reason) do
+              %strong Reason:
+            = f.text_field :block_reason, style: 'width: 99%', disabled: true
         %div{ style: "margin-left:5px;" }
           = submit_tag 'Save Patchinfo'
-        = hidden_field_tag "name", @name
+        = f.hidden_field :name
 - content_for :ready_function do
   patchinfoReady();

--- a/src/api/app/views/webui/patchinfo/new_patchinfo.html.haml
+++ b/src/api/app/views/webui/patchinfo/new_patchinfo.html.haml
@@ -1,3 +1,0 @@
-- @pagetitle = "Create Patchinfo"
-- patchinfo_bread_crumb 'Create Patchinfo'
-= render partial: 'form'

--- a/src/api/app/views/webui/patchinfo/show.html.haml
+++ b/src/api/app/views/webui/patchinfo/show.html.haml
@@ -6,7 +6,7 @@
     .box.show_left.show_right
       .box{ style: "background-color:#DDDDDD; margin-top: 0" }
         %h2{ style: "display: inline" }
-          = @category
+          = @patchinfo.category
           update for #{truncate(@pkg_names.join(', '), length: 20)}
         - if User.current.can_modify?(@package)
           %ul.horizontal-list
@@ -16,39 +16,39 @@
             %li
               = link_to(sprite_tag('package_delete'), { action: :delete_dialog, package: @package, project: @project }, remote: true)
               = link_to('Delete patchinfo', { action: :delete_dialog, package: @package, project: @project }, remote: true, id: 'delete-patchinfo')
-      - if @block
+      - if @patchinfo.block
         .box.ui-state-error.ui-widget-shadow{ style: "min-height:15px;" }
           %b This update is currently blocked:
           %br/
-          - if @block_reason.present?
-            = @block_reason
+          - if @patchinfo.block_reason.present?
+            = @patchinfo.block_reason
           - else
             No reason entered.
-      %strong#summary= @summary
+      %strong#summary= @patchinfo.summary
       %br/
       %label#info
       - if @packager
         This update was submitted from #{user_with_realname_and_icon(@packager)} and rated as
       - else
         This update is rated as
-      %span{ style: "color: #{patchinfo_rating_color(@rating)}" }= @rating
+      %span{ style: "color: #{patchinfo_rating_color(@patchinfo.rating)}" }= @patchinfo.rating
     .box.show_left.show_right
       %b Description:
       %br/
-      = description_wrapper(@description)
-    - if @message.present?
+      = description_wrapper(@patchinfo.description)
+    - if @patchinfo.message.present?
       .box.show_left.show_right
         %strong Message:
-        %pre.plain= @message
-    - if @version
+        %pre.plain= @patchinfo.message
+    - if @patchinfo.version
       .box.show_left.show_right
         %b Version:
-        %span= @version
+        %span= @patchinfo.version
     .box.show_left.show_right
       %b Fixed bugs:
-      - if @issues.present?
+      - if @patchinfo.issues.present?
         %ul
-          - @issues.each do |issue|
+          - @patchinfo.issues.each do |issue|
             - if issue[0] == "CVE"
               %li
                 = link_to((issue[1]).to_s, issue[2]) + ": #{issue[3]}"
@@ -61,26 +61,26 @@
       %ul
         %li
           Relogin suggested:
-          - if @relogin
+          - if @patchinfo.relogin_needed
             = image_tag "ok.png", id: "relogin_true"
           - else
             = image_tag "req-decline.png", id: "relogin_false"
         %li
           Reboot suggested:
-          - if @reboot
+          - if @patchinfo.reboot_needed
             = image_tag "ok.png", id: "reboot_true"
           - else
             = image_tag "req-decline.png", id: "reboot_false"
         %li
           Package-manager restart:
-          - if @zypp_restart_needed
+          - if @patchinfo.zypp_restart_needed
             = image_tag "ok.png", id: "zypp_true"
           - else
             = image_tag "req-decline.png", id: "zypp_false"
-    - unless @binaries.empty?
+    - unless @patchinfo.binaries.empty?
       .box.show_left.show_right
         %b Selected binaries:
         %br/
         %ul
-          - @binaries.each do |bin|
+          - @patchinfo.binaries.each do |bin|
             %li= bin

--- a/src/api/spec/controllers/webui/patchinfo_controller_spec.rb
+++ b/src/api/spec/controllers/webui/patchinfo_controller_spec.rb
@@ -15,9 +15,18 @@ RSpec.describe Webui::PatchinfoController, vcr: true do
 
   def do_proper_post_save
     put :update, params: {
-      project: user.home_project_name, package: patchinfo_package.name, summary: 'long enough summary is ok',
-      description: 'long enough description is also ok' * 5, issueid: [769_484], issuetracker: ['bgo'], issuesum: [nil],
-      issueurl: ['https://bugzilla.gnome.org/show_bug.cgi?id=769484'], category: 'recommended', rating: 'low', packager: user.login
+      project: user.home_project_name, package: patchinfo_package.name,
+      patchinfo: {
+        summary: 'long enough summary is ok',
+        description: 'long enough description is also ok' * 5,
+        issueid: [769_484],
+        issuetracker: ['bgo'],
+        issuesum: [nil],
+        issueurl: ['https://bugzilla.gnome.org/show_bug.cgi?id=769484'],
+        category: 'recommended',
+        rating: 'low',
+        packager: user.login
+      }
     }
   end
 
@@ -97,7 +106,6 @@ RSpec.describe Webui::PatchinfoController, vcr: true do
       end
 
       it { expect(response).to redirect_to(edit_patchinfo_path(project: project, package: 'patchinfo')) }
-      it { expect(assigns(:file)).not_to be_nil }
     end
   end
 
@@ -131,7 +139,7 @@ RSpec.describe Webui::PatchinfoController, vcr: true do
     end
 
     it { expect(response).to have_http_status(:success) }
-    it { expect(assigns(:binaries)).to be_a(Array) }
+    it { expect(assigns(:patchinfo).binaries).to be_a(Array) }
     it { expect(assigns(:tracker)).to eq(::Configuration.default_tracker) }
   end
 
@@ -153,7 +161,7 @@ RSpec.describe Webui::PatchinfoController, vcr: true do
       end
 
       it { expect(response).to have_http_status(:success) }
-      it { expect(assigns(:binaries)).to be_a(Array) }
+      it { expect(assigns(:patchinfo).binaries).to be_a(Array) }
       it { expect(assigns(:pkg_names)).to be_empty }
       it { expect(assigns(:packager)).to eq(user) }
     end
@@ -167,14 +175,17 @@ RSpec.describe Webui::PatchinfoController, vcr: true do
     context 'with an unknown issue tracker' do
       before do
         put :update, params: {
-          project: user.home_project_name, package: patchinfo_package.name, summary: 'long enough summary is ok',
-          description: 'long enough description is also ok' * 5, issueid: [769_484], issuetracker: ['NonExistingTracker'], issuesum: [nil],
-          packager: user.login,
-          issueurl: ['https://bugzilla.gnome.org/show_bug.cgi?id=769484']
+          project: user.home_project_name, package: patchinfo_package.name,
+          patchinfo: {
+            summary: 'long enough summary is ok',
+            description: 'long enough description is also ok' * 5, issueid: [769_484], issuetracker: ['NonExistingTracker'], issuesum: [nil],
+            packager: user.login,
+            issueurl: ['https://bugzilla.gnome.org/show_bug.cgi?id=769484']
+          }
         }
       end
 
-      it { expect(flash[:error]).to eq('Unknown Issue tracker NonExistingTracker') }
+      it { expect(flash[:error]).to eq('Unknown Issue trackers: NonExistingTracker') }
       it { expect(response).to have_http_status(:success) }
     end
 
@@ -182,8 +193,14 @@ RSpec.describe Webui::PatchinfoController, vcr: true do
       before do
         put :update, params: {
           project: user.home_project_name, package: patchinfo_package.name,
-          summary: 'long enough summary is ok', description: 'long enough description is also ok' * 5,
-          issueid: [769_484], issuetracker: ['bgo'], issuesum: [nil], issueurl: ['https://bugzilla.gnome.org/show_bug.cgi?id=769484']
+          patchinfo: {
+            summary: 'long enough summary is ok',
+            description: 'long enough description is also ok' * 5,
+            issueid: [769_484],
+            issuetracker: ['bgo'],
+            issuesum: [nil],
+            issueurl: ['https://bugzilla.gnome.org/show_bug.cgi?id=769484']
+          }
         }
       end
 
@@ -224,7 +241,7 @@ RSpec.describe Webui::PatchinfoController, vcr: true do
       end
 
       it { expect(flash[:error]).to eq('Timeout when saving file. Please try again.') }
-      it { expect(response).to redirect_to(action: 'show', project: user.home_project_name, package: patchinfo_package.name) }
+      it { expect(response).to render_template(:edit) }
     end
   end
 

--- a/src/api/spec/features/webui/maintenance_workflow_spec.rb
+++ b/src/api/spec/features/webui/maintenance_workflow_spec.rb
@@ -80,18 +80,18 @@ RSpec.feature 'MaintenanceWorkflow', type: :feature, js: true do
     visit(edit_patchinfo_path(package: 'patchinfo', project: 'MaintenanceProject:0'))
 
     # needed for patchinfo validation
-    fill_in('summary', with: 'ProjectWithRepo_package is much better than the old one')
-    fill_in('description', with: 'Fixes nothing, Fixes nothing, Fixes nothing, Fixes nothing, Fixes nothing, Fixes nothing')
-    check('block')
-    fill_in('block_reason', with: 'locked!')
+    fill_in('patchinfo[summary]', with: 'ProjectWithRepo_package is much better than the old one')
+    fill_in('patchinfo[description]', with: 'Fixes nothing, Fixes nothing, Fixes nothing, Fixes nothing, Fixes nothing, Fixes nothing')
+    check('patchinfo[block]')
+    fill_in('patchinfo[block_reason]', with: 'locked!')
 
     click_button('Save Patchinfo')
     expect(page).to have_css('#flash-messages', text: 'Successfully edited patchinfo')
     expect(find(:css, '.ui-state-error b')).to have_text('This update is currently blocked:')
 
     click_link('Edit patchinfo')
-    uncheck('block')
-    expect(page).to have_css('input[id=block_reason][disabled]')
+    uncheck('patchinfo[block]')
+    expect(page).to have_css('input[id=patchinfo_block_reason][disabled]')
     click_button 'Save Patchinfo'
 
     logout

--- a/src/api/spec/features/webui/patchinfo_spec.rb
+++ b/src/api/spec/features/webui/patchinfo_spec.rb
@@ -14,14 +14,14 @@ RSpec.feature 'Patchinfo', type: :feature, js: true do
       click_link('Create Patchinfo')
       expect(page).to have_current_path(edit_patchinfo_path(project: project, package: 'patchinfo'))
       expect(page).to have_text("Patchinfo-Editor for #{project.name}")
-      fill_in 'summary', with: 'A' * 9
-      fill_in 'description', with: 'A' * 30
+      fill_in 'patchinfo[summary]', with: 'A' * 9
+      fill_in 'patchinfo[description]', with: 'A' * 30
       click_button 'Save Patchinfo'
       # We check this field using 'minlength' HTML5 control. It opens a tooltip and the error message inside can vary depending on the browser,
       # so we just check its presence and not its content like follows.
-      message = page.find('#summary').native.attribute('validationMessage')
+      message = page.find('#patchinfo_summary').native.attribute('validationMessage')
       expect(message).not_to be_empty
-      message = page.find('#description').native.attribute('validationMessage')
+      message = page.find('#patchinfo_description').native.attribute('validationMessage')
       expect(message).not_to be_empty
     end
 
@@ -32,8 +32,8 @@ RSpec.feature 'Patchinfo', type: :feature, js: true do
       click_link('Create Patchinfo')
       expect(page).to have_current_path(edit_patchinfo_path(project: project, package: 'patchinfo'))
       expect(page).to have_text("Patchinfo-Editor for #{project.name}")
-      fill_in 'summary', with: 'A' * 15
-      fill_in 'description', with: 'A' * 55
+      fill_in 'patchinfo[summary]', with: 'A' * 15
+      fill_in 'patchinfo[description]', with: 'A' * 55
       click_button 'Save Patchinfo'
       expect(page).to have_current_path(patchinfo_show_path(project: project, package: 'patchinfo'))
       expect(page).to have_text('Successfully edited patchinfo')


### PR DESCRIPTION
Refactor Patchinfo controller and consequently model, views, javascript and specs.
    
- Moves patchinfo's XML handling to the model.
- Instantiates patchinfo object instead of using instance variables.
- Refactors update action mainly.
- Adapt webui views and javascript.
- Validates attributes in the model in the rails way.
- Simplifies part of the code.

   
Co-authored-by: David Kang <dkang@suse.com>
Co-authored-by: Eduardo Navarro <enavarro@suse.com>
