### PR TITLE
Fix performance of group#show 

### DIFF
--- a/src/api/app/models/bs_request/find_for/group.rb
+++ b/src/api/app/models/bs_request/find_for/group.rb
@@ -8,14 +8,14 @@ class BsRequest
         group = ::Group.find_by_title!(group_title)
 
         # find requests where group is maintainer in target project
-        @relation, inner_or = extend_query_for_maintainer(group, @relation, roles, inner_or)
+        inner_or = extend_query_for_maintainer(group, roles, inner_or)
 
         if roles.empty? || roles.include?('reviewer')
           @relation = @relation.includes(:reviews).references(:reviews)
           # requests where the user is reviewer or own requests that are in review by someone else
           or_in_and = ["reviews.by_group=#{quote(group.title)}"]
 
-          @relation, inner_or = extend_query_for_involved_reviews(group, or_in_and, @relation, review_states, inner_or)
+          inner_or = extend_query_for_involved_reviews(group, or_in_and, review_states, inner_or)
         end
         if inner_or.empty?
           @relation.none

--- a/src/api/app/models/bs_request/find_for/group.rb
+++ b/src/api/app/models/bs_request/find_for/group.rb
@@ -4,24 +4,39 @@ class BsRequest
       include UserGroupMixin
 
       def all
-        inner_or = []
-        group = ::Group.find_by_title!(group_title)
+        query = union_query
+        @relation = if query.present?
+                      @relation.where("bs_requests.id IN (#{query})")
+                    else
+                      @relation.none
+                    end
+      end
 
-        # find requests where group is maintainer in target project
-        inner_or = extend_query_for_maintainer(group, roles, inner_or)
+      def all_count
+        ActiveRecord::Base.connection.execute("SELECT COUNT(bs_request_id) FROM (#{union_query}) x").first.first
+      end
 
-        if roles.empty? || roles.include?('reviewer')
-          @relation = @relation.includes(:reviews).references(:reviews)
-          # requests where the user is reviewer or own requests that are in review by someone else
-          or_in_and = ["reviews.by_group=#{quote(group.title)}"]
+      private
 
-          inner_or = extend_query_for_involved_reviews(group, or_in_and, review_states, inner_or)
-        end
-        if inner_or.empty?
-          @relation.none
-        else
-          @relation.where(inner_or.join(' or '))
-        end
+      def group
+        @group ||= ::Group.find_by_title!(group_title)
+      end
+
+      def union_query
+        query_parts = []
+        query_parts << bs_request_actions_query.to_sql if bs_request_actions_query
+        query_parts << reviews_query.to_sql if reviews_query
+        query_parts.join(' UNION ')
+      end
+
+      def bs_request_actions_query
+        return unless roles.empty? || roles.include?('maintainer')
+        @bs_request_actions_query ||= bs_request_actions(group).select(:bs_request_id)
+      end
+
+      def reviews_query
+        return unless roles.empty? || roles.include?('reviewer')
+        @reviews_query ||= reviews(group, review_states).select(:bs_request_id)
       end
     end
   end

--- a/src/api/app/models/bs_request/find_for/user.rb
+++ b/src/api/app/models/bs_request/find_for/user.rb
@@ -12,7 +12,7 @@ class BsRequest
           inner_or << "bs_requests.creator = #{quote(user.login)}"
         end
         # find requests where user is maintainer in target project
-        @relation, inner_or = extend_query_for_maintainer(user, @relation, roles, inner_or)
+        inner_or = extend_query_for_maintainer(user, roles, inner_or)
         if roles.empty? || roles.include?('reviewer')
           @relation = @relation.includes(:reviews).references(:reviews)
 
@@ -23,7 +23,7 @@ class BsRequest
           usergroups = user.groups.map { |group| "'#{group.title}'" }
           or_in_and << "reviews.by_group in (#{usergroups.join(',')})" if usergroups.present?
 
-          @relation, inner_or = extend_query_for_involved_reviews(user, or_in_and, @relation, review_states, inner_or)
+          inner_or = extend_query_for_involved_reviews(user, or_in_and, review_states, inner_or)
         end
         if inner_or.empty?
           @relation.none

--- a/src/api/app/models/bs_request/find_for/user.rb
+++ b/src/api/app/models/bs_request/find_for/user.rb
@@ -4,32 +4,37 @@ class BsRequest
       include UserGroupMixin
 
       def all
-        inner_or = []
-        user = ::User.find_by_login!(user_login)
+        query = union_query
+        @relation = if query.present?
+                      @relation.where("bs_requests.id IN (#{query})")
+                    else
+                      @relation.none
+                    end
+      end
 
-        # user's own submitted requests
-        if roles.empty? || roles.include?('creator')
-          inner_or << "bs_requests.creator = #{quote(user.login)}"
-        end
-        # find requests where user is maintainer in target project
-        inner_or = extend_query_for_maintainer(user, roles, inner_or)
-        if roles.empty? || roles.include?('reviewer')
-          @relation = @relation.includes(:reviews).references(:reviews)
+      private
 
-          # requests where the user is reviewer or own requests that are in review by someone else
-          or_in_and = ["reviews.by_user=#{quote(user.login)}"]
+      def user
+        @user = ::User.find_by_login!(user_login)
+      end
 
-          # include all groups of user
-          usergroups = user.groups.map { |group| "'#{group.title}'" }
-          or_in_and << "reviews.by_group in (#{usergroups.join(',')})" if usergroups.present?
+      def union_query
+        query_parts = []
+        # we're inside a scope, so a BsRequest.where can leak other scopes -> unscoped
+        query_parts << BsRequest.unscoped.where(creator: user.login).select(:id).to_sql if roles.empty? || roles.include?('creator')
+        query_parts << bs_request_actions_query.to_sql if bs_request_actions_query
+        query_parts << reviews_query.to_sql if reviews_query
+        query_parts.join(' UNION ')
+      end
 
-          inner_or = extend_query_for_involved_reviews(user, or_in_and, review_states, inner_or)
-        end
-        if inner_or.empty?
-          @relation.none
-        else
-          @relation.where(inner_or.join(' or '))
-        end
+      def bs_request_actions_query
+        return unless roles.empty? || roles.include?('maintainer')
+        @bs_request_actions_query ||= bs_request_actions(user).select(:bs_request_id)
+      end
+
+      def reviews_query
+        return unless roles.empty? || roles.include?('reviewer')
+        @reviews_query ||= reviews(user, review_states).select(:bs_request_id)
       end
     end
   end

--- a/src/api/app/models/bs_request/find_for/user_group_mixin.rb
+++ b/src/api/app/models/bs_request/find_for/user_group_mixin.rb
@@ -3,32 +3,36 @@ class BsRequest
     module UserGroupMixin
       private
 
-      def extend_query_for_maintainer(obj, roles, inner_or)
-        if roles.empty? || roles.include?('maintainer')
-          names = obj.involved_projects.pluck('name').map! { |p| quote(p) }
-          inner_or << "bs_request_actions.target_project in (#{names.join(',')})" unless names.empty?
-          ## find request where group is maintainer in target package, except we have to project already
-          obj.involved_packages.includes(:project).pluck('packages.name, projects.name').each do |ip|
-            inner_or << "(bs_request_actions.target_project='#{ip.second}' and bs_request_actions.target_package='#{ip.first}')"
-          end
-        end
-        inner_or
+      # BsRequestsActions where obj (group or user) is maintainer in target project
+      def bs_request_actions(obj)
+        query_string = 'target_project IN (?)'
+        query_string += " OR ((target_project, target_package) IN (#{packages_query(obj)}))" if packages_query(obj).present?
+        BsRequestAction.where(query_string, projects(obj))
       end
 
-      def extend_query_for_involved_reviews(obj, or_in_and, review_states, inner_or)
-        review_states.each do |review_state|
-          # find requests where obj is maintainer in target project
-          projects = obj.involved_projects.pluck('projects.name').map! { |project| quote(project) }
-          or_in_and << "reviews.by_project in (#{projects.join(',')})" if projects.present?
+      # Reviews where obj (group or user) is reviewer in tarjet project
+      def reviews(obj, review_states)
+        query_string = "by_#{obj.class.name.downcase} = ? OR by_project IN (?)"
+        query_string += " OR by_group IN (#{usergroups_query(obj)})" if obj.is_a?(::User) && usergroups_query(obj).present?
+        query_string += " OR ((by_project, by_package) IN (#{packages_query(obj)}))" if packages_query(obj).present?
 
-          ## find request where user is maintainer in target package, except we have to project already
-          obj.involved_packages.includes(:project).pluck('packages.name, projects.name').each do |ip|
-            or_in_and << "(reviews.by_project='#{ip.second}' and reviews.by_package='#{ip.first}')"
-          end
+        Review.where(state: review_states)
+              .where(query_string, obj.to_s, projects(obj))
+      end
 
-          inner_or << "(reviews.state=#{quote(review_state)} and (#{or_in_and.join(' or ')}))"
-        end
-        inner_or
+      def projects(obj)
+        @projects ||= obj.involved_projects.pluck('projects.name')
+      end
+
+      def usergroups_query(obj)
+        @usergroups_query ||= obj.groups.pluck(:title).map { |group| quote(group) }.join(',')
+      end
+
+      def packages_query(obj)
+        return @packages_query if @packages_query
+        # Hoping that Rails allows to write this nicer: https://github.com/rails/rails/issues/35925
+        projects_and_packages = obj.involved_packages.includes(:project).pluck('projects.name', 'packages.name')
+        @packages_query = projects_and_packages.map { |project, package| "(#{quote(project)},#{quote(package)})" }.join(',')
       end
     end
   end

--- a/src/api/app/models/bs_request/find_for/user_group_mixin.rb
+++ b/src/api/app/models/bs_request/find_for/user_group_mixin.rb
@@ -3,7 +3,7 @@ class BsRequest
     module UserGroupMixin
       private
 
-      def extend_query_for_maintainer(obj, requests, roles, inner_or)
+      def extend_query_for_maintainer(obj, roles, inner_or)
         if roles.empty? || roles.include?('maintainer')
           names = obj.involved_projects.pluck('name').map! { |p| quote(p) }
           inner_or << "bs_request_actions.target_project in (#{names.join(',')})" unless names.empty?
@@ -12,10 +12,10 @@ class BsRequest
             inner_or << "(bs_request_actions.target_project='#{ip.second}' and bs_request_actions.target_package='#{ip.first}')"
           end
         end
-        [requests, inner_or]
+        inner_or
       end
 
-      def extend_query_for_involved_reviews(obj, or_in_and, requests, review_states, inner_or)
+      def extend_query_for_involved_reviews(obj, or_in_and, review_states, inner_or)
         review_states.each do |review_state|
           # find requests where obj is maintainer in target project
           projects = obj.involved_projects.pluck('projects.name').map! { |project| quote(project) }
@@ -28,7 +28,7 @@ class BsRequest
 
           inner_or << "(reviews.state=#{quote(review_state)} and (#{or_in_and.join(' or ')}))"
         end
-        [requests, inner_or]
+        inner_or
       end
     end
   end

--- a/src/api/app/models/group.rb
+++ b/src/api/app/models/group.rb
@@ -180,6 +180,10 @@ class Group < ApplicationRecord
     BsRequest.find_for(group: title, search: search)
   end
 
+  def all_requests_count
+    BsRequest::FindFor::Group.new(group: title, relation: BsRequest.all).all_count
+  end
+
   def tasks
     Rails.cache.fetch("requests_for_#{cache_key}") do
       incoming_requests.count +

--- a/src/api/app/views/webui2/webui/groups/show.html.haml
+++ b/src/api/app/views/webui2/webui/groups/show.html.haml
@@ -24,7 +24,7 @@
         %a.nav-link.text-nowrap#all-requests-tab{ aria: { controls: 'all-requests' }, data: { toggle: 'tab' }, href: '#all-requests', role: 'tab' }
           All Requests
           %span.badge.badge-primary
-            = @group.requests.size
+            = @group.all_requests_count
       %li.nav-item.dropdown
         %a.nav-link.dropdown-toggle{ href: '#', 'data-toggle': 'dropdown', 'role': 'button', 'aria-expanded': 'false', 'aria-haspopup': 'true' }
         .dropdown-menu.dropdown-menu-right

--- a/src/api/db/migrate/20190412130831_add_state_group_index_to_reviews.rb
+++ b/src/api/db/migrate/20190412130831_add_state_group_index_to_reviews.rb
@@ -1,0 +1,5 @@
+class AddStateGroupIndexToReviews < ActiveRecord::Migration[5.2]
+  def change
+    add_index :reviews, [:state, :by_group]
+  end
+end

--- a/src/api/db/structure.sql
+++ b/src/api/db/structure.sql
@@ -1081,6 +1081,7 @@ CREATE TABLE `reviews` (
   KEY `index_reviews_on_group_id` (`group_id`),
   KEY `index_reviews_on_project_id` (`project_id`),
   KEY `index_reviews_on_package_id` (`package_id`),
+  KEY `index_reviews_on_state_and_by_group` (`state`,`by_group`),
   CONSTRAINT `fk_rails_813a4fb24f` FOREIGN KEY (`review_id`) REFERENCES `reviews` (`id`),
   CONSTRAINT `reviews_ibfk_1` FOREIGN KEY (`bs_request_id`) REFERENCES `bs_requests` (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
@@ -1435,6 +1436,7 @@ INSERT INTO `schema_migrations` (version) VALUES
 ('20181113095753'),
 ('20181201065026'),
 ('20190111130416'),
-('20190115131711');
+('20190115131711'),
+('20190412130831');
 
 

--- a/src/api/spec/models/bs_request/find_for/user_spec.rb
+++ b/src/api/spec/models/bs_request/find_for/user_spec.rb
@@ -123,14 +123,6 @@ RSpec.describe BsRequest::FindFor::User do
           it { expect(subject).to include(request) }
           it { expect(subject).not_to include(another_request) }
         end
-
-        context 'does not include not matching reviews' do
-          let!(:another_review) { create(:review, by_user: another_user, bs_request: request, state: :accepted) }
-          subject { klass.new(user: user.login, review_states: :accepted).all }
-
-          it { expect(subject.first.reviews).to include(review) }
-          it { expect(subject.first.reviews).not_to include(another_review) }
-        end
       end
 
       context 'by user' do


### PR DESCRIPTION
The following call done in the group#show page is extremely slow (> 20 seconds):

```
BsRequest::FindFor::Group.new(params).all
```

because of the complex query that it generates. Refactor how the query is generated, writing in the Rail way improving the performance.

We now use the UNION feature of mysql, which allows to avoid the bottleneck of OR avoiding indices. The UNION joins 2 SELECT calls that are technically a OR of a join, but simplifies the way the query optimizer can use indices.

The same applies to FindFor::User, but this code is only used when calling the API with /request?view=collection&user=X.

benchmarks (on production clone of January, just counting the rails time without javascript):

wicked-maintainers:  7077ms -> 312ms
opensuse-review-team: 834ms -> 552ms
gnome-maintainers: 13885ms -> 1889ms

(gnome-maintainers is still a bit slow as it has a lot of reviews and the reviews trouble mariadb indexes, but we decided to stop here).

Fixes #7139

Co-authored-by: @Ana06
Co-authored-by: @andrii-suse