### PR TITLE
Migrate Package#dependency view to Bootstrap

### DIFF
--- a/src/api/app/controllers/webui/package_controller.rb
+++ b/src/api/app/controllers/webui/package_controller.rb
@@ -109,6 +109,7 @@ class Webui::PackageController < Webui::WebuiController
 
   # rubocop:disable Lint/NonLocalExitFromIterator
   def dependency
+    switch_to_webui2
     dependant_project = Project.find_by_name(params[:dependant_project]) || Project.find_remote_project(params[:dependant_project]).try(:first)
     unless dependant_project
       flash[:error] = "Project '#{params[:dependant_project]}' is invalid."
@@ -135,6 +136,7 @@ class Webui::PackageController < Webui::WebuiController
     @repository = params[:repository]
     @dependant_repository = params[:dependant_repository]
     @dependant_project = params[:dependant_project]
+    @package_name = "#{params[:package]}:#{params[:dependant_name]}"
     # Ensure it really is just a file name, no '/..', etc.
     @filename = File.basename(params[:filename])
     @fileinfo = Backend::Api::BuildResults::Binaries.fileinfo_ext(params[:dependant_project], '_repository', params[:dependant_repository],

--- a/src/api/app/views/webui2/webui/package/_breadcrumb_items.html.haml
+++ b/src/api/app/views/webui2/webui/package/_breadcrumb_items.html.haml
@@ -19,6 +19,12 @@
 - if controller_name == 'package' && action_name == 'binary'
   %li.breadcrumb-item.active{ 'aria-current' => 'page' }
     Binary
+- if current_page?(package_dependency_path)
+  %li.breadcrumb-item
+    = link_to('Binary', package_binary_path(project: @dependant_project, package: @package_name, repository: @dependant_repository,
+                                            arch: @arch, filename: @filename))
+  %li.breadcrumb-item.active{ 'aria-current' => 'page' }
+    Dependency
 - if current_page?(package_show_path)
   %li.breadcrumb-item.active{ 'aria-current' => 'page' }
     Overview

--- a/src/api/app/views/webui2/webui/package/_deps.html.haml
+++ b/src/api/app/views/webui2/webui/package/_deps.html.haml
@@ -1,6 +1,6 @@
 .row
-  .table-responsive.col-sm-12.col-md-6
-    %h3 Provides
+  .table-responsive.col-sm-12.col-md-6.mt-4
+    %h4 Provides
     %table.table.table-striped.table-bordered.table-sm
       %thead
         %tr
@@ -9,9 +9,7 @@
       %tbody
         - fileinfo.elements('provides_ext') do |package_file|
           %tr
-            %td
-              %span.nowrap{ title: package_file['dep'] }
-                = truncate(package_file['dep'], length: 30)
+            %td.text-word-break-all= package_file['dep']
             %td
               %ul.list-unstyled
                 - package_file.elements('requiredby') do |package_binary|
@@ -30,8 +28,8 @@
             %td{ colspan: '2' }
               %em No provides
 
-  .table-responsive.col-sm-12.col-md-6
-    %h3 Requires
+  .table-responsive.col-sm-12.col-md-6.mt-4
+    %h4 Requires
     %table.table.table-striped.table-bordered.table-sm
       %thead
         %tr
@@ -40,9 +38,7 @@
       %tbody
         - fileinfo.elements('requires_ext') do |package_file|
           %tr
-            %td
-              %span.nowrap{ title: package_file['dep'] }
-                = truncate(package_file['dep'], length: 30)
+            %td.text-word-break-all= package_file['dep']
             %td
               %ul.list-unstyled
                 - package_file.elements('providedby') do |package_binary|
@@ -61,8 +57,8 @@
             %td{ colspan: '2' }
               %em No requires
 
-  .table-responsive.col-sm-12.col-md-6
-    %h3 Recommends
+  .table-responsive.col-sm-12.col-md-6.mt-4
+    %h4 Recommends
     %table.table.table-striped.table-bordered.table-sm
       %thead
         %tr
@@ -71,9 +67,7 @@
       %tbody
         - fileinfo.elements('recommends_ext') do |package_file|
           %tr
-            %td
-              %span.nowrap{ title: package_file['dep'] }
-                = truncate(package_file['dep'], length: 30)
+            %td.text-word-break-all= package_file['dep']
             %td
               %ul.list-unstyled
                 - package_file.elements('providedby') do |package_binary|

--- a/src/api/app/views/webui2/webui/package/_fileinfo.html.haml
+++ b/src/api/app/views/webui2/webui/package/_fileinfo.html.haml
@@ -1,0 +1,37 @@
+%p
+  %strong Title:
+  = fileinfo.value(:summary)
+%p
+  %strong Description:
+  %br
+  - description = fileinfo.value(:description)
+  - if description
+    - description.split(/\n/).each do |line|
+      = line
+      %br
+  - else
+    %i No description set
+%p
+  %strong Version:
+  = fileinfo.value(:version)
+%p
+  %strong Release:
+  = fileinfo.value(:release)
+%p
+  %strong Architecture:
+  = fileinfo.value(:arch)
+%p
+  %strong Size:
+  = human_readable_fsize(fileinfo.value(:size).to_i)
+%p
+  %strong Build Time:
+  - btime = Time.at(fileinfo.value(:mtime).to_i)
+  #{btime} (#{fuzzy_time_string(btime.ctime)})
+
+= render partial: 'deps', locals: { fileinfo: fileinfo,
+                                  filename: filename,
+                                  project: project,
+                                  package: package,
+                                  repository: repository,
+                                  architecture: architecture }
+

--- a/src/api/app/views/webui2/webui/package/_fileinfo.html.haml
+++ b/src/api/app/views/webui2/webui/package/_fileinfo.html.haml
@@ -1,37 +1,38 @@
-%p
-  %strong Title:
-  = fileinfo.value(:summary)
-%p
-  %strong Description:
-  %br
-  - description = fileinfo.value(:description)
-  - if description
-    - description.split(/\n/).each do |line|
-      = line
-      %br
-  - else
-    %i No description set
-%p
-  %strong Version:
-  = fileinfo.value(:version)
-%p
-  %strong Release:
-  = fileinfo.value(:release)
-%p
-  %strong Architecture:
-  = fileinfo.value(:arch)
-%p
-  %strong Size:
-  = human_readable_fsize(fileinfo.value(:size).to_i)
-%p
-  %strong Build Time:
-  - btime = Time.at(fileinfo.value(:mtime).to_i)
-  #{btime} (#{fuzzy_time_string(btime.ctime)})
+%dl.row.mt-4
+  %dt.col-md-2.text-truncate Title
+  %dd.col-md-10= fileinfo.value(:summary)
+
+  %dt.col-md-2.text-truncate Description
+  %dd.col-md-10
+    - description = fileinfo.value(:description)
+    - if description
+      - description.split(/\n/).each do |line|
+        = line
+        %br
+    - else
+      %i No description set
+
+  %dt.col-md-2.text-truncate Version
+  %dd.col-md-10= fileinfo.value(:version)
+
+  %dt.col-md-2.text-truncate Release
+  %dd.col-md-10= fileinfo.value(:release)
+
+  %dt.col-md-2.text-truncate Architecture
+  %dd.col-md-10= fileinfo.value(:arch)
+
+  %dt.col-md-2.text-truncate Size
+  %dd.col-md-10= human_readable_fsize(fileinfo.value(:size).to_i)
+
+  %dt.col-md-2.text-truncate Build Time
+  %dd.col-md-10
+    - btime = Time.at(fileinfo.value(:mtime).to_i)
+    #{btime} (#{fuzzy_time_string(btime.ctime)})
 
 = render partial: 'deps', locals: { fileinfo: fileinfo,
-                                  filename: filename,
-                                  project: project,
-                                  package: package,
-                                  repository: repository,
-                                  architecture: architecture }
+                                filename: filename,
+                                project: project,
+                                package: package,
+                                repository: repository,
+                                architecture: architecture }
 

--- a/src/api/app/views/webui2/webui/package/binary.html.haml
+++ b/src/api/app/views/webui2/webui/package/binary.html.haml
@@ -11,40 +11,9 @@
         = link_to(@durl, title: 'Download') do
           %i.fas.fa-download.text-secondary
 
-    %div
-      %p
-        %strong Title:
-        = @fileinfo.value('summary')
-      %p
-        %strong Description:
-        %br
-        - description = @fileinfo.value('description')
-        - if description
-          - description.split(/\n/).each do |line|
-            = line
-            %br
-        - else
-          %i No description set
-      %p
-        %strong Version:
-        = @fileinfo.value('version')
-      %p
-        %strong Release:
-        = @fileinfo.value('release')
-      %p
-        %strong Architecture:
-        = @fileinfo.value('arch')
-      %p
-        %strong Size:
-        = human_readable_fsize(@fileinfo.value(:size).to_i)
-      %p
-        %strong Build Time:
-        - btime = Time.at(@fileinfo.value(:mtime).to_i)
-        = btime.to_s + ' (' + fuzzy_time_string(btime.ctime) + ')'
-
-    = render partial: 'deps', locals: { fileinfo: @fileinfo,
-                                        filename: @filename,
-                                        project: @project,
-                                        package: @package,
-                                        repository: @repository,
-                                        architecture: @arch }
+    = render partial: 'fileinfo', locals: { fileinfo: @fileinfo,
+                                            filename: @filename,
+                                            project: @project,
+                                            package: @package,
+                                            repository: @repository,
+                                            architecture: @arch }

--- a/src/api/app/views/webui2/webui/package/dependency.html.haml
+++ b/src/api/app/views/webui2/webui/package/dependency.html.haml
@@ -6,20 +6,21 @@
   .card-body
     %h3 Dependency of #{@filename}
 
-    %div
-      %p
-        %strong Name:
-        = @fileinfo.value(:name)
-      %p
-        %strong Project:
-        = @dependant_project
-      %p
-        %strong Repository:
-        = @dependant_repository
+    %dl.row.mt-4
+      %dt.col-md-2.text-truncate Name
+      %dd.col-md-10= @fileinfo.value(:name)
 
-      = render partial: 'fileinfo', locals: { fileinfo: @fileinfo,
-                                              filename: @filename,
-                                              project: @project,
-                                              package: @package,
-                                              repository: @repository,
-                                              architecture: @arch }
+      %dt.col-md-2.text-truncate Project
+      %dd.col-md-10= @dependant_project
+
+      %dt.col-md-2.text-truncate Repository
+      %dd.col-md-10= @dependant_repository
+
+    %hr
+
+    = render partial: 'fileinfo', locals: { fileinfo: @fileinfo,
+                                            filename: @filename,
+                                            project: @project,
+                                            package: @package,
+                                            repository: @repository,
+                                            architecture: @arch }

--- a/src/api/app/views/webui2/webui/package/dependency.html.haml
+++ b/src/api/app/views/webui2/webui/package/dependency.html.haml
@@ -1,0 +1,54 @@
+- @pagetitle = "Dependency information about #{@filename}"
+
+.card
+  = render partial: 'tabs', locals: { package: @package, project: @project }
+
+  .card-body
+    %h3 Dependency of #{@filename}
+
+    %div
+      %p
+        %strong Name:
+        = @fileinfo.value(:name)
+      %p
+        %strong Project:
+        = @dependant_project
+      %p
+        %strong Repository:
+        = @dependant_repository
+      %p
+        %strong Title:
+        = @fileinfo.value(:summary)
+      %p
+        %strong Description:
+        %br
+        - description = @fileinfo.value(:description)
+        - if description
+          - description.split(/\n/).each do |line|
+            = line
+            %br
+        - else
+          %i No description set
+      %p
+        %strong Version:
+        = @fileinfo.value(:version)
+      %p
+        %strong Release:
+        = @fileinfo.value(:release)
+      %p
+        %strong Architecture:
+        = @fileinfo.value(:arch)
+      %p
+        %strong Size:
+        = human_readable_fsize(@fileinfo.value(:size).to_i)
+      %p
+        %strong Build Time:
+        = btime = Time.at(@fileinfo.value(:mtime).to_i)
+        = btime.to_s + " (" + fuzzy_time_string(btime.ctime) + ")"
+
+      = render partial: 'deps', locals: { fileinfo: @fileinfo,
+                                        filename: @filename,
+                                        project: @project,
+                                        package: @package,
+                                        repository: @repository,
+                                        architecture: @arch }

--- a/src/api/app/views/webui2/webui/package/dependency.html.haml
+++ b/src/api/app/views/webui2/webui/package/dependency.html.haml
@@ -16,39 +16,10 @@
       %p
         %strong Repository:
         = @dependant_repository
-      %p
-        %strong Title:
-        = @fileinfo.value(:summary)
-      %p
-        %strong Description:
-        %br
-        - description = @fileinfo.value(:description)
-        - if description
-          - description.split(/\n/).each do |line|
-            = line
-            %br
-        - else
-          %i No description set
-      %p
-        %strong Version:
-        = @fileinfo.value(:version)
-      %p
-        %strong Release:
-        = @fileinfo.value(:release)
-      %p
-        %strong Architecture:
-        = @fileinfo.value(:arch)
-      %p
-        %strong Size:
-        = human_readable_fsize(@fileinfo.value(:size).to_i)
-      %p
-        %strong Build Time:
-        = btime = Time.at(@fileinfo.value(:mtime).to_i)
-        = btime.to_s + " (" + fuzzy_time_string(btime.ctime) + ")"
 
-      = render partial: 'deps', locals: { fileinfo: @fileinfo,
-                                        filename: @filename,
-                                        project: @project,
-                                        package: @package,
-                                        repository: @repository,
-                                        architecture: @arch }
+      = render partial: 'fileinfo', locals: { fileinfo: @fileinfo,
+                                              filename: @filename,
+                                              project: @project,
+                                              package: @package,
+                                              repository: @repository,
+                                              architecture: @arch }

--- a/src/api/config/routes.rb
+++ b/src/api/config/routes.rb
@@ -104,7 +104,7 @@ OBSApi::Application.routes.draw do
     defaults format: 'html' do
       controller 'webui/package' do
         get 'package/show/:project/:package' => :show, as: 'package_show', constraints: cons
-        get 'package/dependency/:project/:package' => :dependency, constraints: cons
+        get 'package/dependency/:project/:package' => :dependency, constraints: cons, as: 'package_dependency'
         get 'package/binary/:project/:package/:repository/:arch/:filename' => :binary, constraints: cons, as: 'package_binary'
         get 'package/binary/download/:project/:package/:repository/:arch/:filename' => :binary_download,
             constraints: cons, as: 'package_binary_download'


### PR DESCRIPTION
Inside the details of a binary we find some links in the 'Required by' or 'Provided by' columns. The views to which those links point weren't migrated to Bootstrap.

The migrated view had a lot in common with the binary view, so part of the code has been moved to a partial. It also includes some refactoring in HTML and CSS.

Fixes: #7319

**Before:**

![Detailed Informations About openSUSE MicroOS release dvd 1 7 2 i586 rpm   openSUSE Build Service](https://user-images.githubusercontent.com/2581944/56225345-7579d380-6071-11e9-9896-d6c1edded6c8.png)

**After:**

![Dependency information about openSUSE MicroOS release dvd 1 9 1 i586 rpm   Open Build Service(2)](https://user-images.githubusercontent.com/2581944/56227692-5e89b000-6076-11e9-843d-fcb9ed5f7db2.png)

