### PR TITLE
Show the package's URL under the title

### DIFF
--- a/src/api/app/views/webui2/webui/package/show.html.haml
+++ b/src/api/app/views/webui2/webui/package/show.html.haml
@@ -12,8 +12,8 @@
       .col-md-8
         %h3#package-title
           = @package.title.presence || @package.name
-          - if @package.url.present?
-            %small= link_to(@package.url, @package.url)
+        - if @package.url.present?
+          = link_to(@package.url, @package.url, class: 'small mb-3 d-block')
         #description-text
           - if @package.description.blank?
             %i No description set


### PR DESCRIPTION
The URL next to the title made that line too "overloaded".
Fixes: #7365

**Before:**
![Screenshot-2019-4-16 Project1-Package2](https://user-images.githubusercontent.com/2581944/56229658-b32f2a00-607a-11e9-87ed-d4fdeac1e4b7.png)

**After:**

![Show Project1   Project1 Package2   Open Build Service(1)](https://user-images.githubusercontent.com/2581944/56229411-2a17f300-607a-11e9-8de4-9a6fe49cbc9d.png)

