### PR TITLE
Replace symbols by strings to get fileinfo values

### DIFF
--- a/src/api/app/views/webui2/webui/package/_fileinfo.html.haml
+++ b/src/api/app/views/webui2/webui/package/_fileinfo.html.haml
@@ -1,10 +1,10 @@
 %dl.row.mt-4
   %dt.col-md-2.text-truncate Title
-  %dd.col-md-10= fileinfo.value(:summary)
+  %dd.col-md-10= fileinfo.value('summary')
 
   %dt.col-md-2.text-truncate Description
   %dd.col-md-10
-    - description = fileinfo.value(:description)
+    - description = fileinfo.value('description')
     - if description
       - description.split(/\n/).each do |line|
         = line
@@ -13,20 +13,20 @@
       %i No description set
 
   %dt.col-md-2.text-truncate Version
-  %dd.col-md-10= fileinfo.value(:version)
+  %dd.col-md-10= fileinfo.value('version')
 
   %dt.col-md-2.text-truncate Release
-  %dd.col-md-10= fileinfo.value(:release)
+  %dd.col-md-10= fileinfo.value('release')
 
   %dt.col-md-2.text-truncate Architecture
-  %dd.col-md-10= fileinfo.value(:arch)
+  %dd.col-md-10= fileinfo.value('arch')
 
   %dt.col-md-2.text-truncate Size
-  %dd.col-md-10= human_readable_fsize(fileinfo.value(:size).to_i)
+  %dd.col-md-10= human_readable_fsize(fileinfo.value('size').to_i)
 
   %dt.col-md-2.text-truncate Build Time
   %dd.col-md-10
-    - btime = Time.at(fileinfo.value(:mtime).to_i)
+    - btime = Time.at(fileinfo.value('mtime').to_i)
     #{btime} (#{fuzzy_time_string(btime.ctime)})
 
 = render partial: 'deps', locals: { fileinfo: fileinfo,


### PR DESCRIPTION
When we access the value, e.g. fileinfo.value(:summary), the argument is
first converted to string (.to_s), so using strings instead of symbols
makes it a little faster.


Related to https://github.com/openSUSE/open-build-service/pull/7417#pullrequestreview-227374850