### PR TITLE
Catch unhandled backend errors and show a proper error message in the UI

### DIFF
--- a/src/api/app/controllers/webui/download_on_demand_controller.rb
+++ b/src/api/app/controllers/webui/download_on_demand_controller.rb
@@ -14,7 +14,7 @@ class Webui::DownloadOnDemandController < Webui::WebuiController
         @download_on_demand.save!
         @project.store
       end
-    rescue ActiveRecord::RecordInvalid, Backend::Error => e
+    rescue ActiveRecord::RecordInvalid => e
       redirect_back(fallback_location: root_path, error: "Download on Demand can't be created: #{e.message}")
       return
     end
@@ -35,7 +35,7 @@ class Webui::DownloadOnDemandController < Webui::WebuiController
         @download_on_demand.update_attributes!(permitted_params)
         @project.store
       end
-    rescue ActiveRecord::RecordInvalid, Backend::Error => exception
+    rescue ActiveRecord::RecordInvalid => exception
       redirect_back(fallback_location: root_path, error: "Download on Demand can't be updated: #{exception.message}")
       return
     end
@@ -57,7 +57,7 @@ class Webui::DownloadOnDemandController < Webui::WebuiController
         @download_on_demand.destroy!
         @project.store
       end
-    rescue ActiveRecord::RecordInvalid, Backend::Error => exception
+    rescue ActiveRecord::RecordInvalid => exception
       redirect_back(fallback_location: root_path, error: "Download on Demand can't be removed: #{exception.message}")
       return
     end

--- a/src/api/app/controllers/webui/package_controller.rb
+++ b/src/api/app/controllers/webui/package_controller.rb
@@ -147,6 +147,7 @@ class Webui::PackageController < Webui::WebuiController
   end
   # rubocop:enable Lint/NonLocalExitFromIterator
 
+  # TODO: bento_only
   def statistics
     return if switch_to_webui2
     @arch = params[:arch]
@@ -618,7 +619,7 @@ class Webui::PackageController < Webui::WebuiController
   rescue CreateProjectNoPermission
     flash[:error] = 'Sorry, you are not authorized to create this Project.'
     redirect_back(fallback_location: root_path)
-  rescue APIError, ActiveRecord::RecordInvalid, Backend::Error => exception
+  rescue APIError, ActiveRecord::RecordInvalid => exception
     flash[:error] = "Failed to branch: #{exception.message}"
     redirect_back(fallback_location: root_path)
   end

--- a/src/api/app/controllers/webui/package_controller.rb
+++ b/src/api/app/controllers/webui/package_controller.rb
@@ -171,11 +171,7 @@ class Webui::PackageController < Webui::WebuiController
     # Ensure it really is just a file name, no '/..', etc.
     @filename = File.basename(params[:filename])
 
-    begin
-      @fileinfo = Backend::Api::BuildResults::Binaries.fileinfo_ext(@project, @package_name, @repository.name, @arch.name, @filename)
-    rescue Backend::Error
-      raise ActiveRecord::RecordNotFound, 'Not Found'
-    end
+    @fileinfo = Backend::Api::BuildResults::Binaries.fileinfo_ext(@project, @package_name, @repository.name, @arch.name, @filename)
     unless @fileinfo
       raise ActiveRecord::RecordNotFound, 'Not Found'
     end

--- a/src/api/spec/controllers/webui/package_controller_spec.rb
+++ b/src/api/spec/controllers/webui/package_controller_spec.rb
@@ -1442,7 +1442,7 @@ RSpec.describe Webui::PackageController, vcr: true do
         allow(Backend::Api::BuildResults::Binaries).to receive(:fileinfo_ext).and_raise(Backend::Error, 'fake message')
       end
 
-      let(:get_binary) do
+      subject do
         get :binary, params: { package: source_package,
                                project: source_project,
                                repository: repo_for_source_project.name,
@@ -1450,7 +1450,7 @@ RSpec.describe Webui::PackageController, vcr: true do
                                filename: 'filename.txt' }
       end
 
-      it { expect { get_binary }.to raise_error(ActiveRecord::RecordNotFound) }
+      it { expect { subject }.to raise_error(ActiveRecord::RecordNotFound) }
     end
 
     context 'without file info' do
@@ -1458,7 +1458,7 @@ RSpec.describe Webui::PackageController, vcr: true do
         allow(Backend::Api::BuildResults::Binaries).to receive(:fileinfo_ext).and_return(nil)
       end
 
-      let(:get_binary) do
+      subject do
         get :binary, params: { package: source_package,
                                project: source_project,
                                repository: repo_for_source_project.name,
@@ -1466,7 +1466,7 @@ RSpec.describe Webui::PackageController, vcr: true do
                                filename: 'filename.txt' }
       end
 
-      it { expect { get_binary }.to raise_error(ActiveRecord::RecordNotFound) }
+      it { expect { subject }.to raise_error(ActiveRecord::RecordNotFound) }
     end
 
     context 'without a valid architecture' do

--- a/src/api/spec/controllers/webui/package_controller_spec.rb
+++ b/src/api/spec/controllers/webui/package_controller_spec.rb
@@ -1450,7 +1450,11 @@ RSpec.describe Webui::PackageController, vcr: true do
                                filename: 'filename.txt' }
       end
 
-      it { expect { subject }.to raise_error(ActiveRecord::RecordNotFound) }
+      it { expect(response).to have_http_status(:success) }
+      it 'shows an error message' do
+        subject
+        expect(flash[:error]).to eq('There has been an internal error. Please try again.')
+      end
     end
 
     context 'without file info' do


### PR DESCRIPTION
This will catch Backend::Error and Timeout::Error exeptions and
redirect users the previous page. The execption will be send to errbit.

Many of the webui controllers call store without worrying about
possible exceptions that could be raised. This change makes sure
that we have a generic solution for this.



<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md
-->
