### PR TITLE
Store the pagination count of DataTables that we use in bootstrap

### DIFF
--- a/src/api/app/assets/javascripts/webui2/datatables.js
+++ b/src/api/app/assets/javascripts/webui2/datatables.js
@@ -5,27 +5,25 @@
 //= require datatables/extensions/FixedColumns/fixedColumns.bootstrap4
 //= require datatables/extensions/FixedColumns/dataTables.fixedColumns
 
+var DEFAULT_DT_PARAMS = {
+  language: { search: '', searchPlaceholder: "Search..." },
+  stateSave: true,
+  stateDuration: 172800 // 2 days
+};
+
 function initializeDataTable(cssSelector, params){ // jshint ignore:line
-  var defaultParams = {
-    language: { search: '', searchPlaceholder: "Search..." },
-    stateSave: true,
-    stateDuration: 172800 // 2 days
-  };
-  var newParams = $.extend(defaultParams, params);
+  var newParams = $.extend({}, DEFAULT_DT_PARAMS, params);
   $(cssSelector).DataTable(newParams);
 }
 
 function initializeRemoteDatatable(cssSelector, params) { // jshint ignore:line
-  var defaultParams = {
-    language: { search: '', searchPlaceholder: "Search..." },
+  var defaultRemoteParams = {
     processing: true,
     serverSide: true,
     ajax: $(cssSelector).data('source'),
-    pagingType: 'full_numbers',
-    stateSave: true,
-    stateDuration: 172800 // 2 days
+    pagingType: 'full_numbers'
   };
-  var newParams = $.extend(defaultParams, params);
+  var newParams = $.extend(defaultRemoteParams, DEFAULT_DT_PARAMS, params);
 
   $(cssSelector).dataTable(newParams);
 }

--- a/src/api/app/assets/javascripts/webui2/datatables.js
+++ b/src/api/app/assets/javascripts/webui2/datatables.js
@@ -8,6 +8,8 @@
 function initializeDataTable(cssSelector, params){ // jshint ignore:line
   var defaultParams = {
     language: { search: '', searchPlaceholder: "Search..." },
+    stateSave: true,
+    stateDuration: 172800 // 2 days
   };
   var newParams = $.extend(defaultParams, params);
   $(cssSelector).DataTable(newParams);
@@ -19,7 +21,9 @@ function initializeRemoteDatatable(cssSelector, params) { // jshint ignore:line
     processing: true,
     serverSide: true,
     ajax: $(cssSelector).data('source'),
-    pagingType: 'full_numbers'
+    pagingType: 'full_numbers',
+    stateSave: true,
+    stateDuration: 172800 // 2 days
   };
   var newParams = $.extend(defaultParams, params);
 

--- a/src/api/app/assets/javascripts/webui2/requests_table.js.erb
+++ b/src/api/app/assets/javascripts/webui2/requests_table.js.erb
@@ -32,7 +32,9 @@ $(document).ready(function() {
           d.state = stateDropdown.val();
           d.switch_to_webui2 = true;
         }
-      }
+      },
+      stateSave: true,
+      stateDuration: 172800 // 2 days
     });
   });
 

--- a/src/api/app/views/shared/_involved_users.html.haml
+++ b/src/api/app/views/shared/_involved_users.html.haml
@@ -93,6 +93,8 @@
     'searching': false,
     'info': false,
     'paging': false,
+    stateSave: true,
+    stateDuration: #{2.days}
     });
   - if user_is_maintainer
     $('.trigger').click(function() { change_role($(this)) } );

--- a/src/api/app/views/webui2/shared/_patchinfos_table.html.haml
+++ b/src/api/app/views/webui2/shared/_patchinfos_table.html.haml
@@ -23,6 +23,10 @@
 = javascript_tag do
   :plain
     $(function() {
-      $('#open-patchinfos-table').dataTable({ 'iDisplayLength': 10 });
+      $('#open-patchinfos-table').dataTable({
+        iDisplayLength: 10,
+        stateSave: true,
+        stateDuration: #{2.days}
+      });
     });
 

--- a/src/api/app/views/webui2/webui/project/status.html.haml
+++ b/src/api/app/views/webui2/webui/project/status.html.haml
@@ -80,7 +80,14 @@
                                                                 comment: package['failedcomment'], project: @project }
 
         - content_for :ready_function do
-          $('#status-table').dataTable({ 'iDisplayLength': 50, responsive: true, 'columnDefs': [ { 'width': '20%', 'targets': 0 } ] });
+          :plain
+            $('#status-table').dataTable({
+              iDisplayLength: 50,
+              responsive: true,
+              columnDefs: [ { 'width': '20%', 'targets': 0 } ],
+              stateSave: true,
+              stateDuration: #{2.days}
+            });
 
 - if User.current.can_modify?(@project) && parsed_result[:comments_to_clear].present?
   = link_to("Clear all comments of not failing packages (#{parsed_result[:comments_to_clear].join(',')})",

--- a/src/api/app/views/webui2/webui/staging/workflows/_staging_projects_table.html.haml
+++ b/src/api/app/views/webui2/webui/staging/workflows/_staging_projects_table.html.haml
@@ -16,4 +16,13 @@
           = render partial: 'problems', locals: { staging_project: staging_project }
 
 - content_for :ready_function do
-  $('#staging-projects-datatable').DataTable({responsive: true, paging: false, ordering: false, searching: false, info: false});
+  :plain
+    $('#staging-projects-datatable').DataTable({
+      responsive: true,
+      paging: false,
+      ordering: false,
+      searching: false,
+      info: false,
+      stateSave: true,
+      stateDuration: #{2.days}
+    });


### PR DESCRIPTION
The pagination count will be store in local storage for 2 days.



<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md
-->
