### PR TITLE
Improvements in datatables filtering

### DIFF
--- a/src/api/app/datatables/package_datatable.rb
+++ b/src/api/app/datatables/package_datatable.rb
@@ -13,7 +13,7 @@ class PackageDatatable < Datatable
     # Declare strings in this format: ModelName.column_name
     # or in aliased_join_table.column_name format
     @view_columns ||= {
-      name: { source: 'Package.name', cond: :like },
+      name: { source: 'Package.name' },
       changed: { source: 'Package.updated_at', searchable: false }
     }
   end

--- a/src/api/app/datatables/package_datatable.rb
+++ b/src/api/app/datatables/package_datatable.rb
@@ -14,7 +14,7 @@ class PackageDatatable < Datatable
     # or in aliased_join_table.column_name format
     @view_columns ||= {
       name: { source: 'Package.name', cond: :like },
-      changed: { source: 'Package.updated_at', cond: :like }
+      changed: { source: 'Package.updated_at', searchable: false }
     }
   end
 

--- a/src/api/app/datatables/project_datatable.rb
+++ b/src/api/app/datatables/project_datatable.rb
@@ -4,8 +4,8 @@ class ProjectDatatable < Datatable
 
   def view_columns
     @view_columns ||= {
-      name: { source: 'Project.name', cond: :like },
-      title: { source: 'Project.title', cond: :like }
+      name: { source: 'Project.name' },
+      title: { source: 'Project.title' }
     }
   end
 

--- a/src/api/app/datatables/user_configuration_datatable.rb
+++ b/src/api/app/datatables/user_configuration_datatable.rb
@@ -5,7 +5,7 @@ class UserConfigurationDatatable < Datatable
   def view_columns
     @view_columns ||= {
       name: { source: 'User.login' },
-      local_user: { source: 'User.ignore_auth_services' },
+      local_user: { source: 'User.ignore_auth_services', searchable: false },
       state: { source: 'User.state' }
     }
   end

--- a/src/api/app/datatables/user_configuration_datatable.rb
+++ b/src/api/app/datatables/user_configuration_datatable.rb
@@ -4,9 +4,9 @@ class UserConfigurationDatatable < Datatable
 
   def view_columns
     @view_columns ||= {
-      name: { source: 'User.login', cond: :like },
+      name: { source: 'User.login' },
       local_user: { source: 'User.ignore_auth_services' },
-      state: { source: 'User.state', cond: :like }
+      state: { source: 'User.state' }
     }
   end
 


### PR DESCRIPTION
- Do not filter by timestamp and boolean using like condition
- Remove `cond: :like` as it is the default
<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md
-->
