### PR TITLE
Effect on flash and announcement when scrolling

### DIFF
--- a/src/api/app/assets/javascripts/webui2/application.js
+++ b/src/api/app/assets/javascripts/webui2/application.js
@@ -23,6 +23,7 @@
 //= require tokenfield.js
 //= require webui2/plotbusyworkers.js
 //= require webui2/datatables.js
+//= require webui2/flash.js
 //= require webui2/tabs.js
 //= require webui2/requests_table.js
 //= require webui2/attributes.js

--- a/src/api/app/assets/javascripts/webui2/flash.js
+++ b/src/api/app/assets/javascripts/webui2/flash.js
@@ -1,0 +1,7 @@
+$(window).scroll(function() {
+  if (this.scrollY > 100) {
+    $('.flash-and-announcement').addClass('sticking');
+  } else {
+    $('.flash-and-announcement').removeClass('sticking');
+  }
+});

--- a/src/api/app/assets/stylesheets/webui2/flash.scss
+++ b/src/api/app/assets/stylesheets/webui2/flash.scss
@@ -1,6 +1,9 @@
 .flash-and-announcement.sticky-top {
-  top: 1rem;
   z-index: 1030;
+
+  &.sticking {
+    .alert { margin-bottom: 0; }
+  }
 }
 
 .alert-success {


### PR DESCRIPTION
When scrolling, the flash and announcement boxes get stuck on the top and without space between each other.

Fixes: #7216

![flash_on_scroll](https://user-images.githubusercontent.com/2581944/56509623-c8e39a00-6527-11e9-8882-5443e1789d13.gif)
