### PR TITLE
Fix flash movement when a modal is open

### DIFF
--- a/src/api/app/assets/stylesheets/webui2/bootstrap-modal.scss
+++ b/src/api/app/assets/stylesheets/webui2/bootstrap-modal.scss
@@ -1,0 +1,12 @@
+// FIXME: This a bug reported in https://github.com/twbs/bootstrap/issues/27071
+// please remove this file when the bug is fixed.
+
+body { padding: 0 !important; }
+
+.container{
+  &.sticky-top {
+    margin-right: auto !important;
+    padding-right: 1rem !important;
+  }
+}
+

--- a/src/api/app/assets/stylesheets/webui2/webui2.css.scss
+++ b/src/api/app/assets/stylesheets/webui2/webui2.css.scss
@@ -16,6 +16,7 @@
 @import 'bootstrap_variables/colors';
 @import 'bootstrap_variables/spacers';
 @import 'bootstrap';
+@import 'bootstrap-modal';
 @import "font-awesome-sprockets";
 @import 'font-awesome';
 @import 'tokenfield';


### PR DESCRIPTION
Avoid flash to move to the right side when a modal is open.

**Before:**

![before](https://user-images.githubusercontent.com/2581944/55216731-d3976180-51fd-11e9-8922-7008fae80836.png)


**After:**

![Screenshot_2019-04-23 perl-Citrix](https://user-images.githubusercontent.com/1212806/56570460-4dcbc380-65bb-11e9-9dfd-2139a1618af2.png)

Fix #7298


Co-authored-by: Saray Cabrera Padrón <scabrerapadron@suse.de>



<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md
-->
