### PR TITLE
Add autocomplete for request add reviewer modal

### DIFF
--- a/src/api/app/assets/javascripts/webui2/autocomplete.js
+++ b/src/api/app/assets/javascripts/webui2/autocomplete.js
@@ -52,15 +52,15 @@ $(document).ready(function() {
     });
   });
 
-  $('#linked_project').on('autocompletechange', function() {
+  $('#linked_project, #review_project').on('autocompletechange', function() {
     var projectName = $(this).val(),
-        source = $('#linked_package').autocomplete('option', 'source');
+        source = $('#linked_package, #review_package').autocomplete('option', 'source');
 
     if (!projectName) return;
 
     // Ensure old parameters got removed
     source = source.replace(/\?.+/, '') + '?project=' + projectName;
     // Update the source target of the package autocomplete
-    $('#linked_package').autocomplete('option', { source: source });
+    $('#linked_package, #review_package').autocomplete('option', { source: source });
   });
 });

--- a/src/api/app/assets/javascripts/webui2/request.js
+++ b/src/api/app/assets/javascripts/webui2/request.js
@@ -68,56 +68,16 @@ function setupRequestDialog() { // jshint ignore:line
 }
 
 function requestAddReviewAutocomplete() { // jshint ignore:line
-  $('#review_type').change(function () {
-    $('span').addClass('d-none');
-    var selected = $('#review_type option:selected').attr('value');
-    $('.' + selected).removeClass('d-none');
+  $('.modal').on('shown.bs.modal', function() {
+    $('.hideable input:not(:visible)').removeAttr('required');
   });
 
-  $("#review_group").autocomplete({source: '/group/autocomplete', minChars: 2, matchCase: true, max: 50,
-  search: function() {
-    $(this).addClass('loading-spinner');
-  },
-  response: function() {
-    $(this).removeClass('loading-spinner');
-  }});
-  $("#review_user").autocomplete({source: '/user/autocomplete', minChars: 2, matchCase: true, max: 50,
-  search: function() {
-    $(this).addClass('loading-spinner');
-  },
-  response: function() {
-    $(this).removeClass('loading-spinner');
-  }});
-  $("#review_project").autocomplete({source: '/project/autocomplete_projects', minChars: 2, matchCase: true, max: 50,
-  search: function() {
-    $(this).addClass('loading-spinner');
-  },
-  response: function() {
-    $(this).removeClass('loading-spinner');
-  }});
-  $("#review_package").autocomplete({
-    source: function (request, response) {
-      $.ajax({
-        url: '/project/autocomplete_packages',
-        dataType: "json",
-        data: {
-          term: request.term,
-          project: $("#review_project").val()
-        },
-        success: function (data) {
-          response(data);
-        }
-      });
-    },
-    search: function() {
-      $(this).addClass('loading-spinner');
-    },
-    response: function() {
-      $(this).removeClass('loading-spinner');
-    },
-    minLength: 2,
-    minChars: 0,
-    matchCase: true,
-    max: 50
+  $('#review_type').change(function () {
+    $('.hideable').addClass('d-none');
+    $('.hideable input:not(:visible)').removeAttr('required');
+
+    var selected = $('#review_type option:selected').attr('value');
+    $('.' + selected).removeClass('d-none');
+    $('.hideable input:visible').attr('required', true);
   });
 }

--- a/src/api/app/views/webui2/webui/groups/new.html.haml
+++ b/src/api/app/views/webui2/webui/groups/new.html.haml
@@ -11,7 +11,8 @@
           = form.text_field(:title, class: 'form-control', required: true, autofocus: true)
         .form-group
           = label_tag(:members)
-          = text_field_tag('group[members]', @members, id: 'group-members', class: 'form-control tag-input', data: { source: user_autocomplete_path })
+          = text_field_tag('group[members]', @members, id: 'group-members', class: 'form-control tag-input',
+                                                       data: { source: autocomplete_users_path })
         = form.submit('Create', class: 'btn btn-primary', data: { disable_with: 'Creating...' })
 
 = content_for(:ready_function) do

--- a/src/api/app/views/webui2/webui/request/_add_reviewer_dialog.html.haml
+++ b/src/api/app/views/webui2/webui/request/_add_reviewer_dialog.html.haml
@@ -1,36 +1,35 @@
 .modal.fade#add-reviewer-modal{ tabindex: -1, role: 'dialog', aria: { labelledby: 'add-reviewer-modal-label', hidden: true } }
   .modal-dialog.modal-dialog-centered{ role: 'document' }
     .modal-content
-      .modal-header
-        %h5.modal-title#add-reviewer-modal-label Add a reviewer to request #{params['number']}
-      .modal-body
-        = form_tag(action: 'add_reviewer') do
+      = form_tag(action: 'add_reviewer') do
+        .modal-header
+          %h5.modal-title#add-reviewer-modal-label Add a reviewer to request #{params['number']}
+        .modal-body
           = hidden_field_tag(:number, params['number'])
           .form-group
             = label_tag(:review_type, 'Type:')
             = select_tag(:review_type, options_for_select([%w[User review-user], %w[Group review-group],
                                                            %w[Project review-project], %w[Package review-package]]), class: 'custom-select')
-          .form-group
-            %span.review-user
-              = label_tag(:review_user, 'User:')
-              = text_field_tag(:review_user, '', class: 'form-control')
-          .form-group
-            %span.d-none.review-group
-              = label_tag(:review_group, 'Group:')
-              = text_field_tag(:review_group, '', class: 'form-control')
-          .form-group
-            %span.d-none.review-project.review-package
-              = label_tag(:review_project, 'Project:')
-              = text_field_tag(:review_project, '', class: 'form-control')
-          .form-group
-            %span.d-none.review-package
-              = label_tag(:review_package, 'Package:')
-              = text_field_tag(:review_package, '', class: 'form-control')
+          .hideable.review-user
+            = render partial: 'webui/autocomplete', locals: { html_id: 'review_user', label: 'User:',
+                                                              source: autocomplete_users_path }
+
+          .hideable.review-group.d-none
+            = render partial: 'webui/autocomplete', locals: { html_id: 'review_group', label: 'Group:',
+                                                              source: autocomplete_groups_path }
+          .hideable.review-project.review-package.d-none
+            = render partial: 'webui/autocomplete', locals: { html_id: 'review_project', label: 'Project:',
+                                                              source: autocomplete_projects_path }
+
+          .hideable.review-package.d-none
+            = render partial: 'webui/autocomplete', locals: { html_id: 'review_package', label: 'Package:',
+                                                              source: autocomplete_packages_path }
+
           .form-group
             = label_tag(:review_comment, 'Comment for reviewer:')
             = text_area_tag('review_comment', '', row: 3, class: 'form-control')
-          .modal-footer
-            = render partial: 'webui2/shared/dialog_action_buttons'
+        .modal-footer
+          = render partial: 'webui2/shared/dialog_action_buttons'
 
 = content_for :ready_function do
   requestAddReviewAutocomplete();

--- a/src/api/config/routes.rb
+++ b/src/api/config/routes.rb
@@ -399,7 +399,7 @@ OBSApi::Application.routes.draw do
       patch 'user' => :update, as: 'user_update'
       delete 'user' => :delete, as: 'user_delete'
 
-      get 'user/autocomplete' => :autocomplete
+      get 'user/autocomplete' => :autocomplete, as: 'autocomplete_users'
       get 'user/tokens' => :tokens
 
       get 'user/edit/:user' => :edit, constraints: cons, as: 'user_edit'
@@ -453,7 +453,7 @@ OBSApi::Application.routes.draw do
       # TODO: bento_only: Drop group_edit_title and group_user_delete route
       get 'group/edit/:title' => :edit, constraints: { title: /[^\/]*/ }, as: :group_edit_title
       post 'group/update/:title' => :update, constraints: { title: /[^\/]*/ }, as: :group_update
-      get 'group/autocomplete' => :autocomplete
+      get 'group/autocomplete' => :autocomplete, as: 'autocomplete_groups'
       delete 'group/:title/delete/:user' => :delete, constraints: { title: /[^\/]*/ }, as: :group_user_delete
     end
 


### PR DESCRIPTION
It used the old version of autocomplete. We got rid of many JavaScript
code. Some fields are hidden depending on the review type, we have to
make them "not required" to be able to send the form.

**Before:**

![before](https://user-images.githubusercontent.com/16052290/54346406-41139180-4645-11e9-820f-9a3072d9bff3.png)

**After:**

![Request 6   Open Build Service](https://user-images.githubusercontent.com/2581944/56578455-fe42c300-65cd-11e9-9242-5e2dceb6ee6e.png)

Fixes: #7185

Co-authored-by: David Kang <dkang@suse.com>

