### PR TITLE
Unify route names on the autocomplete partial calls

### DIFF
--- a/src/api/app/views/webui2/shared/user_or_groups_roles/_add_group_dialog.html.haml
+++ b/src/api/app/views/webui2/shared/user_or_groups_roles/_add_group_dialog.html.haml
@@ -6,7 +6,7 @@
           %h5.modal-title#edit-modal-label Add Group
         .modal-body
           = render partial: 'webui/autocomplete', locals: { html_id: 'groupid', label: 'Group:',
-                                                            source: url_for(controller: 'groups', action: 'autocomplete') }
+                                                            source: autocomplete_groups_path }
           .form-group
             = label_tag(:role, 'Role:')
             = select_tag 'role', options_for_select(Role.local_roles, nil), required: true, class: 'form-control'

--- a/src/api/app/views/webui2/shared/user_or_groups_roles/_add_user_dialog.html.haml
+++ b/src/api/app/views/webui2/shared/user_or_groups_roles/_add_user_dialog.html.haml
@@ -6,7 +6,7 @@
           %h5.modal-title#edit-modal-label Add User
         .modal-body
           = render partial: 'webui/autocomplete', locals: { html_id: 'userid', label: 'User:',
-                                                            source: url_for(controller: 'user', action: 'autocomplete') }
+                                                            source: autocomplete_users_path }
           .form-group
             = label_tag(:role, 'Role:')
             = select_tag 'role', options_for_select(Role.local_roles, nil), required: true, class: 'form-control'

--- a/src/api/app/views/webui2/webui/groups/_add_group_user_modal.html.haml
+++ b/src/api/app/views/webui2/webui/groups/_add_group_user_modal.html.haml
@@ -7,6 +7,6 @@
           %h5.modal-title#add-group-user-modal-label Add Member
         .modal-body
           = render partial: 'webui/autocomplete', locals: { html_id: 'user_login', label: 'User:',
-                                                            source: url_for(controller: '/webui/user', action: 'autocomplete') }
+                                                            source: autocomplete_users_path }
         .modal-footer
           = render partial: 'webui2/shared/dialog_action_buttons'

--- a/src/api/app/views/webui2/webui/repositories/_add_repository_from_project_modal.html.haml
+++ b/src/api/app/views/webui2/webui/repositories/_add_repository_from_project_modal.html.haml
@@ -6,7 +6,7 @@
           %h5.modal-title Add Repository to #{project}
         .modal-body.repository-autocomplete
           = render partial: 'webui/autocomplete', locals: { html_id: 'target_project', label: '<strong>Project:</strong>'.html_safe,
-                                                            source: url_for(controller: 'project', action: 'autocomplete_projects') }
+                                                            source: autocomplete_projects_path }
 
           .form-group
             = label_tag :repositories do
@@ -14,8 +14,7 @@
             = select_tag 'target_repo', options_for_select(['']), required: true,
                                                                   disabled: true,
                                                                   class: 'repository-dropdown custom-select',
-                                                                  data: { source: url_for(controller: :project,
-                                                                                              action: :autocomplete_repositories) }
+                                                                  data: { source: autocomplete_repositories_path }
           .form-group
             = label_tag :name do
               %strong Name:

--- a/src/api/app/views/webui2/webui/repositories/_add_repository_path_modal.html.haml
+++ b/src/api/app/views/webui2/webui/repositories/_add_repository_path_modal.html.haml
@@ -6,15 +6,14 @@
           %h5.modal-title Add additional path to #{repository}
         .modal-body.repository-autocomplete
           = render partial: 'webui/autocomplete', locals: { html_id: 'target_project', label: '<strong>Project:</strong>'.html_safe,
-                                                            source: url_for(controller: 'project', action: 'autocomplete_projects') }
+                                                            source: autocomplete_projects_path }
           .form-group
             = label_tag :repositories do
               %strong Repositories:
             = select_tag 'target_repo', options_for_select(['']), required: true,
                                                                   disabled: true,
                                                                   class: 'repository-dropdown custom-select',
-                                                                  data: { source: url_for(controller: :project,
-                                                                                              action: :autocomplete_repositories) }
+                                                                  data: { source: autocomplete_repositories_path }
           = hidden_field_tag :repository, repository
 
         .modal-footer

--- a/src/api/app/views/webui2/webui/staging/workflows/_create_staging_project.html.haml
+++ b/src/api/app/views/webui2/webui/staging/workflows/_create_staging_project.html.haml
@@ -7,7 +7,7 @@
         .modal-body
           = render partial: 'webui/autocomplete', locals: { html_id: 'staging_project_name',
                                                             label: 'Please enter a project you have permissions to',
-                                                            source: url_for(controller: '/webui/project', action: 'autocomplete_projects') }
+                                                            source: autocomplete_projects_path }
           %small.text-muted
             %i.fa.fa-info-circle.text-info{ title: 'Info' }
             If the project already exists, it will simply be assigned to the Staging.

--- a/src/api/app/views/webui2/webui/staging/workflows/_staging_managers_group.html.haml
+++ b/src/api/app/views/webui2/webui/staging/workflows/_staging_managers_group.html.haml
@@ -11,6 +11,6 @@
             %strong= actual_group
 
           = render partial: 'webui/autocomplete', locals: { html_id: 'managers_title', label: 'Replace the group with:',
-                                                            source: url_for(controller: '/webui/groups', action: 'autocomplete') }
+                                                            source: autocomplete_groups_path }
         .modal-footer
           = render partial: 'webui2/shared/dialog_action_buttons'

--- a/src/api/app/views/webui2/webui/staging/workflows/new.html.haml
+++ b/src/api/app/views/webui2/webui/staging/workflows/new.html.haml
@@ -15,6 +15,6 @@
       = form_for @staging_workflow, method: :post do |f|
         = hidden_field_tag :project_name, @project
         = render partial: 'webui/autocomplete', locals: { html_id: 'managers_title', label: 'Managers Group:',
-                                                          source: url_for(controller: '/webui/groups', action: 'autocomplete') }
+                                                          source: autocomplete_groups_path }
         .text-center
           = f.submit 'Create Staging Projects', class: 'btn btn-primary'

--- a/src/api/config/routes.rb
+++ b/src/api/config/routes.rb
@@ -250,9 +250,9 @@ OBSApi::Application.routes.draw do
       get 'project/list_all' => :index, show_all: true, as: 'project_list_all'
       get 'project/list' => :index, as: 'project_list'
       get 'project/autocomplete_projects' => :autocomplete_projects, as: 'autocomplete_projects'
-      get 'project/autocomplete_incidents' => :autocomplete_incidents
+      get 'project/autocomplete_incidents' => :autocomplete_incidents, as: 'autocomplete_incidents'
       get 'project/autocomplete_packages' => :autocomplete_packages, as: 'autocomplete_packages'
-      get 'project/autocomplete_repositories' => :autocomplete_repositories
+      get 'project/autocomplete_repositories' => :autocomplete_repositories, as: 'autocomplete_repositories'
       get 'project/users/:project' => :users, constraints: cons, as: 'project_users'
       get 'project/subprojects/:project' => :subprojects, constraints: cons, as: 'project_subprojects'
       get 'project/attributes/:project', to: redirect('/attribs/%{project}'), constraints: cons


### PR DESCRIPTION
Now all the autocomplete routes look like "autocomplete_*", we use the
same pattern for all of them.
