### PR TITLE
Consistent autocomplete style submit package

### DIFF
--- a/src/api/app/assets/javascripts/webui2/request.js
+++ b/src/api/app/assets/javascripts/webui2/request.js
@@ -49,19 +49,8 @@ function setupRequestDialog() { // jshint ignore:line
     $('#targetproject').attr('value', $('#devel-project-name').html());
   });
 
-  $('#targetproject').autocomplete({
-    appendTo: '.modal-body',
-    source: $('#targetproject').data('autocomplete-url'),
-    search: function() {
-      $(this).addClass('loading-spinner');
-    },
-    response: function() {
-      $(this).removeClass('loading-spinner');
-    },
-    minLength: 2,
-    select: updateSupersedeAndDevelPackageDisplay,
-    change: updateSupersedeAndDevelPackageDisplay,
-    max: 50
+  $('#targetproject.obs-autocomplete').on('autocompleteselect autocompletechange', function() {
+    updateSupersedeAndDevelPackageDisplay();
   });
 
   updateSupersedeAndDevelPackageDisplay();

--- a/src/api/app/controllers/webui/package_controller.rb
+++ b/src/api/app/controllers/webui/package_controller.rb
@@ -250,6 +250,7 @@ class Webui::PackageController < Webui::WebuiController
     switch_to_webui2
   end
 
+  # TODO: bento_only
   def submit_request_dialog
     if params[:revision]
       @revision = params[:revision]
@@ -268,7 +269,6 @@ class Webui::PackageController < Webui::WebuiController
 
     @description = @package.commit_message(@tprj, @tpkg)
 
-    return if switch_to_webui2
     render_dialog
   end
 

--- a/src/api/app/controllers/webui2/package_controller.rb
+++ b/src/api/app/controllers/webui2/package_controller.rb
@@ -7,12 +7,6 @@ module Webui2::PackageController
     redirect_to action: :show, project: params[:project], package: params[:package]
   end
 
-  def webui2_submit_request_dialog
-    respond_to do |format|
-      format.js { render 'submit_request_dialog' }
-    end
-  end
-
   def webui2_rpmlint_result
     if @repo_list.empty?
       render partial: 'no_repositories', locals: { project: @project }

--- a/src/api/app/views/webui2/shared/user_or_groups_roles/_add_group_dialog.html.haml
+++ b/src/api/app/views/webui2/shared/user_or_groups_roles/_add_group_dialog.html.haml
@@ -6,7 +6,7 @@
           %h5.modal-title#edit-modal-label Add Group
         .modal-body
           = render partial: 'webui/autocomplete', locals: { html_id: 'groupid', label: 'Group:',
-                                                            source: autocomplete_groups_path }
+                                                            data: { source: autocomplete_groups_path } }
           .form-group
             = label_tag(:role, 'Role:')
             = select_tag 'role', options_for_select(Role.local_roles, nil), required: true, class: 'form-control'

--- a/src/api/app/views/webui2/shared/user_or_groups_roles/_add_user_dialog.html.haml
+++ b/src/api/app/views/webui2/shared/user_or_groups_roles/_add_user_dialog.html.haml
@@ -6,7 +6,7 @@
           %h5.modal-title#edit-modal-label Add User
         .modal-body
           = render partial: 'webui/autocomplete', locals: { html_id: 'userid', label: 'User:',
-                                                            source: autocomplete_users_path }
+                                                            data: { source: autocomplete_users_path } }
           .form-group
             = label_tag(:role, 'Role:')
             = select_tag 'role', options_for_select(Role.local_roles, nil), required: true, class: 'form-control'

--- a/src/api/app/views/webui2/webui/_autocomplete.html.haml
+++ b/src/api/app/views/webui2/webui/_autocomplete.html.haml
@@ -1,6 +1,7 @@
 :ruby
   required = local_assigns.fetch(:required, true)
   value = local_assigns.fetch(:value, '')
+  disabled = local_assigns.fetch(:disabled, false)
 
 .form-group.ui-front
   = label_tag(html_id, label)
@@ -10,5 +11,5 @@
     .input-group-prepend
       %span.input-group-text
         %i.fas.fa-search
-    = text_field_tag(html_id, value, required: required, placeholder: 'Type to autocomplete...',
+    = text_field_tag(html_id, value, required: required, disabled: disabled, placeholder: 'Type to autocomplete...',
                      class: 'obs-autocomplete form-control', data: { source: source })

--- a/src/api/app/views/webui2/webui/_autocomplete.html.haml
+++ b/src/api/app/views/webui2/webui/_autocomplete.html.haml
@@ -2,6 +2,7 @@
   required = local_assigns.fetch(:required, true)
   value = local_assigns.fetch(:value, '')
   disabled = local_assigns.fetch(:disabled, false)
+  data = local_assigns.fetch(:data, {})
 
 .form-group.ui-front
   = label_tag(html_id, label)
@@ -12,4 +13,4 @@
       %span.input-group-text
         %i.fas.fa-search
     = text_field_tag(html_id, value, required: required, disabled: disabled, placeholder: 'Type to autocomplete...',
-                     class: 'obs-autocomplete form-control', data: { source: source })
+                     class: 'obs-autocomplete form-control', data: data)

--- a/src/api/app/views/webui2/webui/groups/_add_group_user_modal.html.haml
+++ b/src/api/app/views/webui2/webui/groups/_add_group_user_modal.html.haml
@@ -7,6 +7,6 @@
           %h5.modal-title#add-group-user-modal-label Add Member
         .modal-body
           = render partial: 'webui/autocomplete', locals: { html_id: 'user_login', label: 'User:',
-                                                            source: autocomplete_users_path }
+                                                            data: { source: autocomplete_users_path } }
         .modal-footer
           = render partial: 'webui2/shared/dialog_action_buttons'

--- a/src/api/app/views/webui2/webui/package/_submit_request_dialog.html.haml
+++ b/src/api/app/views/webui2/webui/package/_submit_request_dialog.html.haml
@@ -1,55 +1,57 @@
-.modal-dialog.modal-dialog-centered{ role: 'document' }
-  .modal-content
-    = form_tag({ controller: 'package', action: 'submit_request' }, method: 'post') do
-      .modal-header
-        %h5.modal-title Create Submit Request
-      .modal-body
-        %p
-          Do you want to submit #{package_link package, rev: revision}?
-        %p.font-italic
-          You are about to send a request to the owner of the original #{package ? 'package' : 'project'}. Please describe what you have done and
-          why they should apply your changes. The owner will be notified with the following details.
+.modal.fade#submit-request-modal{ tabindex: -1, role: 'dialog', aria: { labelledby: 'submit-request-modal-label', hidden: true } }
+  .modal-dialog.modal-dialog-centered{ role: 'document' }
+    .modal-content
+      = form_tag({ controller: 'package', action: 'submit_request' }, method: 'post') do
+        .modal-header
+          %h5.modal-title#submit-request-modal-label Create Submit Request
+        .modal-body
+          %p
+            Do you want to submit #{package_link package, rev: revision}?
+          %p.font-italic
+            You are about to send a request to the owner of the original #{package ? 'package' : 'project'}. Please describe what you have done and
+            why they should apply your changes. The owner will be notified with the following details.
 
-          = hidden_field_tag(:project, project)
-          = hidden_field_tag(:package, package)
-          = hidden_field_tag(:rev, revision)
-          .form-group
-            = label_tag(:sourceproject, 'From source project:')
-            = text_field_tag(:sourceproject, project.name, disabled: true, class: 'form-control text-truncate')
-          .form-group
-            = label_tag(:targetproject, 'To target project:')
-            = text_field_tag(:targetproject, target_project, disabled: params[:readonly], required: true, class: 'form-control',
-                             data: { autocomplete_url: autocomplete_projects_path,
-                                     requests_url: request_list_small_path,
-                                     develpackage_url: package_devel_project_path })
-            - if params[:readonly]
-              = hidden_field_tag(:targetproject, target_project)
+            = hidden_field_tag(:project, project)
+            = hidden_field_tag(:package, package)
+            = hidden_field_tag(:rev, revision)
+            .form-group
+              = label_tag(:sourceproject, 'From source project:')
+              = text_field_tag(:sourceproject, project.name, disabled: true, class: 'form-control text-truncate')
+            .form-group
+              = render partial: 'webui/autocomplete', locals: { html_id: 'targetproject', label: 'To target project:',
+                                                                disabled: params[:readonly],
+                                                                data: { source: autocomplete_projects_path,
+                                                                        requests_url: request_list_small_path,
+                                                                        develpackage_url: package_devel_project_path } }
+              - if params[:readonly]
+                = hidden_field_tag(:targetproject, target_project)
 
-          .form-group
-            = label_tag(:targetpackage, 'To target package:')
-            = text_field_tag(:targetpackage, target_package, disabled: params[:readonly], class: 'form-control')
-            - if params[:readonly]
-              = hidden_field_tag(:targetpackage, target_package)
+            .form-group
+              = label_tag(:targetpackage, 'To target package:')
+              = text_field_tag(:targetpackage, target_package, disabled: params[:readonly], class: 'form-control')
+              - if params[:readonly]
+                = hidden_field_tag(:targetpackage, target_package)
 
-          .form-group
-            = label_tag(:description, 'Description:')
-            ~ text_area_tag(:description, description, size: '40x3', class: 'form-control', required: true)
+            .form-group
+              = label_tag(:description, 'Description:')
+              %abbr.text-danger{ title: 'required' } *
+              ~ text_area_tag(:description, description, size: '40x3', class: 'form-control', required: true)
 
-          .form-group.d-none#supersede-display
-            = label_tag(:supersede_requests, 'Supersede requests:')
-            #supersede-requests
+            .form-group.d-none#supersede-display
+              = label_tag(:supersede_requests, 'Supersede requests:')
+              #supersede-requests
 
-          .custom-control.custom-checkbox#sourceupdate-display
-            = check_box_tag(:sourceupdate, 'cleanup', cleanup_source, class: 'custom-control-input')
-            = label_tag(:sourceupdate, 'Remove local package if request is accepted', class: 'custom-control-label')
+            .custom-control.custom-checkbox#sourceupdate-display
+              = check_box_tag(:sourceupdate, 'cleanup', cleanup_source, class: 'custom-control-input')
+              = label_tag(:sourceupdate, 'Remove local package if request is accepted', class: 'custom-control-label')
 
-          %p.d-none#devel-project-warning
-            You are about to bypass the devel project, please submit to
-            %b#devel-project-name
-            instead.
+            %p.d-none#devel-project-warning
+              You are about to bypass the devel project, please submit to
+              %b#devel-project-name
+              instead.
 
-      .modal-footer
-        = render partial: 'webui2/shared/dialog_action_buttons', locals: { submit_tag_text: 'Create' }
+        .modal-footer
+          = render partial: 'webui2/shared/dialog_action_buttons', locals: { submit_tag_text: 'Create' }
 
-:javascript
+= content_for(:ready_function) do
   setupRequestDialog();

--- a/src/api/app/views/webui2/webui/package/bottom_actions/_submit_package.html.haml
+++ b/src/api/app/views/webui2/webui/package/bottom_actions/_submit_package.html.haml
@@ -1,4 +1,4 @@
 %li.list-inline-item
-  = link_to(package_submit_request_dialog_path(project: project, package: package, revision: revision), remote: true, class: 'nav-link') do
+  = link_to('#', class: 'nav-link', data: { toggle: 'modal', target: '#submit-request-modal' }) do
     %i.fas.fa-share-square.text-warning
     Submit package

--- a/src/api/app/views/webui2/webui/package/show.html.haml
+++ b/src/api/app/views/webui2/webui/package/show.html.haml
@@ -84,6 +84,9 @@
 - unless User.current.is_nobody?
   - if @current_rev
     = render partial: 'branch_dialog', locals: { project: @project, package: @package, revision: @revision }
+    = render partial: 'submit_request_dialog', locals: { project: @project, package: @package, revision: @revision,
+                                                         target_project: @tprj, target_package: @tpkg,
+                                                         description: @description, cleanup_source: @cleanup_source }
   - if User.current.can_modify?(@package)
     = render partial: 'edit_dialog', locals: { project: @project, package: @package }
     = render partial: 'delete_dialog', locals: { project: @project, package: @package, cleanup_source: @cleanup_source }

--- a/src/api/app/views/webui2/webui/package/submit_request_dialog.js.haml
+++ b/src/api/app/views/webui2/webui/package/submit_request_dialog.js.haml
@@ -1,6 +1,0 @@
-:plain
-  $('#modal').html("#{escape_javascript(render(partial: 'submit_request_dialog',
-                                               locals: { project: @project, package: @package,
-                                               revision: @revision, target_project: @tprj, target_package: @tpkg,
-                                               description: @description, cleanup_source: @cleanup_source }))}")
-  $('#modal').modal('show');

--- a/src/api/app/views/webui2/webui/patchinfo/edit.html.haml
+++ b/src/api/app/views/webui2/webui/patchinfo/edit.html.haml
@@ -9,7 +9,7 @@
       = form.hidden_field(:name)
       .form-group.col-8.col-md-4
         = render partial: 'webui/autocomplete', locals: { html_id: 'patchinfo[packager]', label: 'Packager', value: @patchinfo.packager,
-                                                          source: url_for(controller: '/webui/user', action: 'autocomplete') }
+                                                          data: { source: autocomplete_users_path } }
       .form-group.col-md-6
         = form.label(:summary)
         %abbr.text-danger{ title: 'required (minimum 10 characters)' } *

--- a/src/api/app/views/webui2/webui/project/_new_package_branch_modal.html.haml
+++ b/src/api/app/views/webui2/webui/project/_new_package_branch_modal.html.haml
@@ -22,9 +22,9 @@
                 = link_to("#{name}: #{title}", project_show_path(project: name))
         = form_tag(package_branch_path) do
           = render partial: 'webui/autocomplete', locals: { html_id: 'linked_project', label: 'Original project name',
-                                                            source: autocomplete_projects_path }
+                                                            data: { source: autocomplete_projects_path } }
           = render partial: 'webui/autocomplete', locals: { html_id: 'linked_package', label: 'Original package name',
-                                                            source: autocomplete_packages_path }
+                                                            data: { source: autocomplete_packages_path } }
           = hidden_field_tag 'target_project', project
           = render partial: 'shared/package_branch_form', locals: { show_project_field: false, target_project: project,
                                                                     package: nil, revision: nil }

--- a/src/api/app/views/webui2/webui/repositories/_add_repository_from_project_modal.html.haml
+++ b/src/api/app/views/webui2/webui/repositories/_add_repository_from_project_modal.html.haml
@@ -6,7 +6,7 @@
           %h5.modal-title Add Repository to #{project}
         .modal-body.repository-autocomplete
           = render partial: 'webui/autocomplete', locals: { html_id: 'target_project', label: '<strong>Project:</strong>'.html_safe,
-                                                            source: autocomplete_projects_path }
+                                                            data: { source: autocomplete_projects_path } }
 
           .form-group
             = label_tag :repositories do

--- a/src/api/app/views/webui2/webui/repositories/_add_repository_path_modal.html.haml
+++ b/src/api/app/views/webui2/webui/repositories/_add_repository_path_modal.html.haml
@@ -6,7 +6,7 @@
           %h5.modal-title Add additional path to #{repository}
         .modal-body.repository-autocomplete
           = render partial: 'webui/autocomplete', locals: { html_id: 'target_project', label: '<strong>Project:</strong>'.html_safe,
-                                                            source: autocomplete_projects_path }
+                                                            data: { source: autocomplete_projects_path } }
           .form-group
             = label_tag :repositories do
               %strong Repositories:

--- a/src/api/app/views/webui2/webui/request/_add_reviewer_dialog.html.haml
+++ b/src/api/app/views/webui2/webui/request/_add_reviewer_dialog.html.haml
@@ -12,18 +12,18 @@
                                                            %w[Project review-project], %w[Package review-package]]), class: 'custom-select')
           .hideable.review-user
             = render partial: 'webui/autocomplete', locals: { html_id: 'review_user', label: 'User:',
-                                                              source: autocomplete_users_path }
+                                                              data: { source: autocomplete_users_path } }
 
           .hideable.review-group.d-none
             = render partial: 'webui/autocomplete', locals: { html_id: 'review_group', label: 'Group:',
-                                                              source: autocomplete_groups_path }
+                                                              data: { source: autocomplete_groups_path } }
           .hideable.review-project.review-package.d-none
             = render partial: 'webui/autocomplete', locals: { html_id: 'review_project', label: 'Project:',
-                                                              source: autocomplete_projects_path }
+                                                              data: { source: autocomplete_projects_path } }
 
           .hideable.review-package.d-none
             = render partial: 'webui/autocomplete', locals: { html_id: 'review_package', label: 'Package:',
-                                                              source: autocomplete_packages_path }
+                                                              data: { source: autocomplete_packages_path } }
 
           .form-group
             = label_tag(:review_comment, 'Comment for reviewer:')

--- a/src/api/app/views/webui2/webui/request/_change_devel_request_dialog.html.haml
+++ b/src/api/app/views/webui2/webui/request/_change_devel_request_dialog.html.haml
@@ -11,7 +11,7 @@
             \#{project_or_package_link(project: package.develpackage.project.name)}?
           = render partial: 'webui/autocomplete', locals: { html_id: 'devel_project',
                                                             label: 'New Devel project (leave free to delete the current one):',
-                                                            source: autocomplete_projects_path }
+                                                            data: { source: autocomplete_projects_path } }
           .form-group
             = label_tag(:description, 'Description:')
             = text_area_tag(:description, '', row: 3, class: 'form-control')

--- a/src/api/app/views/webui2/webui/staging/workflows/_create_staging_project.html.haml
+++ b/src/api/app/views/webui2/webui/staging/workflows/_create_staging_project.html.haml
@@ -7,7 +7,7 @@
         .modal-body
           = render partial: 'webui/autocomplete', locals: { html_id: 'staging_project_name',
                                                             label: 'Please enter a project you have permissions to',
-                                                            source: autocomplete_projects_path }
+                                                            data: { source: autocomplete_projects_path } }
           %small.text-muted
             %i.fa.fa-info-circle.text-info{ title: 'Info' }
             If the project already exists, it will simply be assigned to the Staging.

--- a/src/api/app/views/webui2/webui/staging/workflows/_staging_managers_group.html.haml
+++ b/src/api/app/views/webui2/webui/staging/workflows/_staging_managers_group.html.haml
@@ -11,6 +11,6 @@
             %strong= actual_group
 
           = render partial: 'webui/autocomplete', locals: { html_id: 'managers_title', label: 'Replace the group with:',
-                                                            source: autocomplete_groups_path }
+                                                            data: { source: autocomplete_groups_path } }
         .modal-footer
           = render partial: 'webui2/shared/dialog_action_buttons'

--- a/src/api/app/views/webui2/webui/staging/workflows/new.html.haml
+++ b/src/api/app/views/webui2/webui/staging/workflows/new.html.haml
@@ -15,6 +15,6 @@
       = form_for @staging_workflow, method: :post do |f|
         = hidden_field_tag :project_name, @project
         = render partial: 'webui/autocomplete', locals: { html_id: 'managers_title', label: 'Managers Group:',
-                                                          source: autocomplete_groups_path }
+                                                          data: { source: autocomplete_groups_path } }
         .text-center
           = f.submit 'Create Staging Projects', class: 'btn btn-primary'


### PR DESCRIPTION
While submitting a package on OBS, I realized that the submit package modal and its autocomplete are not consistent with other modals/autocompletes.

See the commits for details on what has been done.

Before:
![before](https://user-images.githubusercontent.com/1102934/56736281-0df60f00-6768-11e9-9d9c-8fffd8019fc3.png)

After:
![after](https://user-images.githubusercontent.com/1102934/56736277-0b93b500-6768-11e9-9eb1-617c86653923.png)