### PR TITLE
Increase the LineLength for the haml-lint

### DIFF
--- a/src/api/.haml-lint.yml
+++ b/src/api/.haml-lint.yml
@@ -1,6 +1,6 @@
 linters:
   LineLength:
-    max: 150
+    max: 180
 
   # Apply lint in all partials, but exclude 'breadcrumb_items' partials
   InstanceVariables:


### PR DESCRIPTION
Because bootstrap, datatables and how specific we are regarding the HTML selector names, the ```LineLength = 150```  is to short. I suggest 180

What do you think @openSUSE/obs-frontend ?