### PR TITLE
Disable LineLength cop for haml-linter

### DIFF
--- a/src/api/.haml-lint.yml
+++ b/src/api/.haml-lint.yml
@@ -1,6 +1,6 @@
 linters:
   LineLength:
-    max: 150
+    enabled: false
 
   # Apply lint in all partials, but exclude 'breadcrumb_items' partials
   InstanceVariables:


### PR DESCRIPTION
The LineLength under 200 is too short mainly because datatables. LineLength over 200 is almost the same as disable it, so why not disable it? 

What do you think @openSUSE/obs-frontend ?

Examples that wouldn't be allowed by this cop, but that just passes because we ignore the `webui/*` and `shared/*` folder:

```
webui2/webui/project/list.html.haml
36:      %table.responsive.table.table-sm.table-striped.table-bordered.w-100#projects-datatable{ data: { source: projects_path(format: :json),
```


```
webui2/webui/project/_project_inherited_packages.html.haml
4:      %table.table.table-sm.table-fixed.table-striped.table-bordered#inherited-packages-table

```

```
webui2/webui/project/_projects_table.html.haml
3:%table.responsive.table.table-sm.table-striped.table-bordered.projects-table{ data: { source: project_subprojects_path(project,
```

```
webui2/webui/project/_project_packages.html.haml
4:      %table.table.table-sm.table-fixed.table-striped.table-bordered#packages-table{ data: { source: package_index_path(project: project) } }
```

other tables which should be refactored to support remote pagination will probably suffer from the same issue. To sacrifice readability doing some funky line breaking, variable abbreviation and others tricks just to make the linter happy, IMO is bad smell.  