### PR TITLE
Improve feedback in forms

### DIFF
--- a/src/api/Gemfile
+++ b/src/api/Gemfile
@@ -84,6 +84,8 @@ gem 'rails-timeago', '~> 2.0'
 gem 'deep_cloneable', '~> 2.4.0'
 # Server-side datatables
 gem 'ajax-datatables-rails'
+# Client side validations in forms using HTML5
+gem 'html5_validators'
 
 group :development, :production do
   # to have the delayed job daemon

--- a/src/api/Gemfile.lock
+++ b/src/api/Gemfile.lock
@@ -182,6 +182,8 @@ GEM
       haml (>= 4.0, < 6)
       nokogiri (>= 1.6.0)
       ruby_parser (~> 3.5)
+    html5_validators (1.9.0)
+      activemodel
     i18n (1.6.0)
       concurrent-ruby (~> 1.0)
     influxdb (0.7.0)
@@ -494,6 +496,7 @@ DEPENDENCIES
   haml
   haml-rails
   haml_lint
+  html5_validators
   jquery-datatables
   jquery-rails
   jquery-ui-rails (~> 4.2.1)

--- a/src/api/app/views/webui/comment/_new.html.haml
+++ b/src/api/app/views/webui/comment/_new.html.haml
@@ -10,5 +10,5 @@
     = hidden_field_tag :commentable_type, commentable.class
     = hidden_field_tag :commentable_id, commentable.id
     = hidden_field_tag :no_switch, true
-    ~ f.text_area :body, size: '80x4', onkeyup: 'sz(this);', onclick: 'sz(this);', placeholder: 'Add a new comment (markdown markup supported)', required: 'required'
+    ~ f.text_area :body, size: '80x4', onkeyup: 'sz(this);', onclick: 'sz(this);', placeholder: 'Add a new comment (markdown markup supported)'
     = f.submit 'Add comment'

--- a/src/api/app/views/webui/comment/_reply.html.haml
+++ b/src/api/app/views/webui/comment/_reply.html.haml
@@ -4,7 +4,7 @@
       = hidden_field_tag :commentable_type, commentable.class
       = hidden_field_tag :commentable_id, commentable.id
       = hidden_field_tag :no_switch, true
-      ~ f.text_area :body, size: '80x1', onkeyup: 'sz(this);', onclick: 'sz(this);', class: 'comment_reply_body', id: "reply_body_#{comment.id}", placeholder: 'Comment Text', required: true
+      ~ f.text_area :body, size: '80x1', onkeyup: 'sz(this);', onclick: 'sz(this);', class: 'comment_reply_body', id: "reply_body_#{comment.id}", placeholder: 'Comment Text'
       = f.hidden_field :parent_id, value: comment.id, id: "reply_parent_id_#{comment.id}"
     %p
       = f.submit 'Add reply', id: "add_reply_#{comment.id}"

--- a/src/api/app/views/webui/interconnects/new.html.haml
+++ b/src/api/app/views/webui/interconnects/new.html.haml
@@ -34,7 +34,7 @@
       = f.label :name do
         %strong Local Project Name
         %abbr{ title: 'required' } *
-      = f.text_field :name, required: true, placeholder: 'Add a name for your project'
+      = f.text_field :name, placeholder: 'Add a name for your project'
     .form-group
       = f.label :remoteurl do
         %strong Remote OBS api url

--- a/src/api/app/views/webui/patchinfo/_form.html.haml
+++ b/src/api/app/views/webui/patchinfo/_form.html.haml
@@ -1,5 +1,5 @@
 = render partial: 'webui/package/tabs'
-= form_for(@patchinfo, url: update_patchinfo_path(project: @project, package: @package), method: :put, html: { id: 'patchinfo' }) do |f|
+= form_for(@patchinfo, url: update_patchinfo_path(project: @project, package: @package, auto_html5_validation: false), method: :put, html: { id: 'patchinfo' }) do |f|
   .section
     .grid_8.alpha
       .box.show_left.show_right

--- a/src/api/app/views/webui/project/_form.html.erb
+++ b/src/api/app/views/webui/project/_form.html.erb
@@ -6,7 +6,7 @@
             <%= hidden_field_tag :ns, ns %>
             <%= ns + ':'%>
       <% end %>
-      <%= f.text_field :name, size: 50, required: true %>
+      <%= f.text_field :name, size: 50 %>
       <br/>
       <label for="title"><b>Title: </b></label>
       <br/>

--- a/src/api/app/views/webui/user/_save_dialog.html.haml
+++ b/src/api/app/views/webui/user/_save_dialog.html.haml
@@ -10,5 +10,5 @@
           = f.text_field(:realname)
         %p
           = f.label(:email, "e-Mail:")
-          = f.text_field(:email, required: true, email: true)
+          = f.email_field(:email, required: true)
         = render partial: '/webui/shared/dialog_action_buttons'

--- a/src/api/app/views/webui/user/edit.html.haml
+++ b/src/api/app/views/webui/user/edit.html.haml
@@ -16,7 +16,7 @@
   %p
     = f.label(:email, "e-Mail:")
     %br
-    = f.text_field(:email, required: true, email: true, disabled: @configuration.ldap_enabled? && !@displayed_user.ignore_auth_services?)
+    = f.email_field(:email, required: true, disabled: @configuration.ldap_enabled? && !@displayed_user.ignore_auth_services?)
   %p
     = f.collection_check_boxes(:role_ids, Role.global, :id, :title)
   %p

--- a/src/api/app/views/webui2/webui/project/_form.html.haml
+++ b/src/api/app/views/webui2/webui/project/_form.html.haml
@@ -7,10 +7,10 @@
         .input-group-prepend
           %span.input-group-text
             #{namespace}:
-        = form.text_field(:name, required: true, class: 'form-control')
+        = form.text_field(:name, class: 'form-control')
     - else
       = form.label(:name, 'Project Name:')
-      = form.text_field(:name, required: true, class: 'form-control')
+      = form.text_field(:name, class: 'form-control')
   .form-group
     = form.label(:title, 'Title:')
     = form.text_field(:title, class: 'form-control')

--- a/src/api/app/views/webui2/webui/repositories/_dod_source_fields.html.haml
+++ b/src/api/app/views/webui2/webui/repositories/_dod_source_fields.html.haml
@@ -17,7 +17,7 @@
         .form-group.row
           = f.label :url, 'Url', class: 'col-sm-4 col-form-label'
           .col-sm-8
-            = f.text_field(:url, required: true, class: 'form-control')
+            = f.text_field(:url, class: 'form-control')
         .form-group.row
           = f.label :archfilter, 'Arch. Filter', class: 'col-sm-4 col-form-label'
           .col-sm-8

--- a/src/api/app/views/webui2/webui/user/_edit_dialog.html.haml
+++ b/src/api/app/views/webui2/webui/user/_edit_dialog.html.haml
@@ -11,6 +11,6 @@
             = f.text_field(:realname, class: 'form-control')
           .form-group
             = f.label(:email, 'Email:')
-            = f.text_field(:email, required: true, email: true, class: 'form-control')
+            = f.email_field(:email, required: true, class: 'form-control')
         .modal-footer
           = render partial: 'webui2/shared/dialog_action_buttons', locals: { submit_tag_text: 'Update' }

--- a/src/api/app/views/webui2/webui/user/edit.html.haml
+++ b/src/api/app/views/webui2/webui/user/edit.html.haml
@@ -12,7 +12,7 @@
         .form-group
           = form.label(:email, 'Email:')
           %abbr.text-danger{ title: 'required' } *
-          = form.text_field(:email, required: true, email: true, disabled: user_is_configurable(@configuration, @displayed_user),
+          = form.email_field(:email, required: true, disabled: user_is_configurable(@configuration, @displayed_user),
             class: 'form-control')
         .form-group
           = form.collection_check_boxes(:role_ids, Role.global, :id, :title, {}) do |checkbox|


### PR DESCRIPTION
Add [html5_validators](https://github.com/amatsuda/html5_validators) gem, which provides automatic client-side validation using HTML5 based on the models validations. This makes much easier to keep views and backend code consistent and
provide early feedback to users. This is also changing many forms in the whole application. It should be though a save change as it is consistent with our model validations and the errors would have just been shown later.

I have removed from our views code SOME of the html validations that are now provided by HTML5Validators, by using our models validations. There may still be some repetition and differences but I had to stop somewhere. In the future when realizing of the discrepancies, it should be as easy as remove the view code. Some more PR for more validation improvements are coming.

I have also change some emails fields to use[ `email_field`](https://apidock.com/rails/ActionView/Helpers/FormHelper/email_field) Rails helper, which generates a `text_field` of type `email`, providing feedback to users when introducing a wrong email without sending the form.

It helps addressing https://github.com/openSUSE/open-build-service/issues/7011.
<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md
-->
