### PR TITLE
haml-lint missing views

### DIFF
--- a/src/api/.haml-lint.yml
+++ b/src/api/.haml-lint.yml
@@ -42,7 +42,6 @@ exclude:
 - 'app/views/build/**/*'
 - 'app/views/comments/**/*'
 - 'app/views/distributions/**/*'
-- 'app/views/event_mailer/**/*'
 - 'app/views/exception_notifier/**/*'
 - 'app/views/group/**/*'
 - 'app/views/ichain_notifier/**/*'

--- a/src/api/.haml-lint.yml
+++ b/src/api/.haml-lint.yml
@@ -46,7 +46,7 @@ exclude:
 - 'app/views/exception_notifier/**/*'
 - 'app/views/group/**/*'
 - 'app/views/ichain_notifier/**/*'
-- 'app/views/layouts/**/*'
+- 'app/views/layouts/webui/**/*'
 - 'app/views/main/**/*'
 - 'app/views/message/**/*'
 - 'app/views/models/**/*'

--- a/src/api/.haml-lint.yml
+++ b/src/api/.haml-lint.yml
@@ -46,7 +46,6 @@ exclude:
 - 'app/views/group/**/*'
 - 'app/views/ichain_notifier/**/*'
 - 'app/views/layouts/webui/**/*'
-- 'app/views/main/**/*'
 - 'app/views/message/**/*'
 - 'app/views/models/**/*'
 - 'app/views/person/**/*'

--- a/src/api/app/assets/stylesheets/webui2/personal-navigation.scss
+++ b/src/api/app/assets/stylesheets/webui2/personal-navigation.scss
@@ -15,4 +15,8 @@
     .nav-pills .show > .nav-link {
         color: $white !important;
     }
+
+    #login-form {
+      width: 300px;
+    }
 }

--- a/src/api/app/views/event_mailer/comment_for_package.html.haml
+++ b/src/api/app/views/event_mailer/comment_for_package.html.haml
@@ -1,5 +1,5 @@
 %p
-  Visit #{link_to(*[url_for(project: event['project'], package: event['package'], controller: 'webui/package', action: :show, only_path: false, host: @host)]*2)}
+  Visit #{link_to(nil, package_show_url(event['project'], event['package'], only_path: false, host: @host))}
 %p
   = event['commenter'].realname
   wrote in package #{event['project']}/#{event['package']}:

--- a/src/api/app/views/event_mailer/comment_for_project.html.haml
+++ b/src/api/app/views/event_mailer/comment_for_project.html.haml
@@ -1,5 +1,5 @@
 %p
-  Visit #{link_to(*[url_for(project: event['project'], controller: 'webui/project', action: :show, only_path: false, host: @host)]*2)}
+  Visit #{link_to(nil, project_show_url(event['project'], only_path: false, host: @host))}
 %p
   = event['commenter'].realname
   wrote in project #{event['project']}:

--- a/src/api/app/views/event_mailer/comment_for_request.html.haml
+++ b/src/api/app/views/event_mailer/comment_for_request.html.haml
@@ -1,5 +1,5 @@
 %p
-  Visit #{link_to(*[url_for(controller: 'webui/request', action: :show, number: event['number'], host: @host, only_path: false)]*2)}
+  Visit #{link_to(nil, request_show_url(event['number'], only_path: false, host: @host))}
 %p
   = event['commenter'].realname
   wrote in request #{event['number']}:

--- a/src/api/app/views/layouts/event_mailer.html.haml
+++ b/src/api/app/views/layouts/event_mailer.html.haml
@@ -2,8 +2,8 @@
 %br/
 \--
 %br/
-Configure notifications at #{link_to(*[url_for(controller: 'webui/users/subscriptions', action: :index, only_path: false, host: @host)]*2)}
+Configure notifications at #{link_to(*[url_for(controller: 'webui/users/subscriptions', action: :index, only_path: false, host: @host)] * 2)}
 %br/
 = @configuration['title']
-(#{link_to(*[url_for(controller: 'webui/main', action: :index, only_path: false, host: @host)]*2)})
+(#{link_to(*[url_for(controller: 'webui/main', action: :index, only_path: false, host: @host)] * 2)})
 %br/

--- a/src/api/app/views/layouts/webui2/_announcement.html.haml
+++ b/src/api/app/views/layouts/webui2/_announcement.html.haml
@@ -1,12 +1,12 @@
-- if @pending_announcement.present?
+- if pending_announcement.present?
   .row.justify-content-center
     .col-12
       .alert.fade.show.alert-notice
         .row
           .col-md-10
             There has been new announcements!
-            = link_to('Read more', announcement_path(@pending_announcement), class: 'alert-link ')
+            = link_to('Read more', announcement_path(pending_announcement), class: 'alert-link')
           .col-md-2
             - unless User.current.is_nobody?
-              = form_tag(user_announcements_path(@pending_announcement), remote: true, class: 'text-right' ) do
+              = form_tag(user_announcements_path(pending_announcement), remote: true, class: 'text-right') do
                 = submit_tag 'Got it', class: 'btn btn-sm btn-secondary'

--- a/src/api/app/views/layouts/webui2/_breadcrumbs.html.haml
+++ b/src/api/app/views/layouts/webui2/_breadcrumbs.html.haml
@@ -1,3 +1,3 @@
-%nav{ "aria-label" => "breadcrumb" }
+%nav{ 'aria-label' => 'breadcrumb' }
   %ol.breadcrumb.bg-transparent
     = render partial: 'breadcrumb_items'

--- a/src/api/app/views/layouts/webui2/_flash.html.haml
+++ b/src/api/app/views/layouts/webui2/_flash.html.haml
@@ -4,11 +4,14 @@
       .alert.alert-dismissible.fade.show{ class: "alert-#{type}" }
         %i.fas
         = flash_content(message)
+        -# haml-lint:disable InstanceVariables
+           FIXME: This is used in only one action of the package controller
         - if @more_info
           = link_to('more info', 'javascript:void(0)', class: 'btn-more alert-link')
           .more_info.d-none
             .more-info-content
               = simple_format(@more_info)
+        -# haml-lint:enable InstanceVariables
         %button.close{ type: 'button', 'data-dismiss': 'alert', 'aria-label': 'Close' }
           %span{ 'aria-hidden': 'true' }
             &times;

--- a/src/api/app/views/layouts/webui2/_login_form.html.haml
+++ b/src/api/app/views/layouts/webui2/_login_form.html.haml
@@ -1,9 +1,9 @@
 %li.nav-item
   = link_to('Sign Up', signup_url, class: 'nav-link')
 %li.nav-item.dropdown
-  = link_to('#', id: 'login-trigger', class: 'nav-link dropdown-toggle', "data-toggle": "dropdown") do
+  = link_to('#', id: 'login-trigger', class: 'nav-link dropdown-toggle', 'data-toggle': 'dropdown') do
     Log In
-  .dropdown-menu.dropdown-menu-right.shadow-lg.bg-dark{ "aria-labelledby": "dropdownMenuButton", style: 'width: 350px' }
+  .dropdown-menu.dropdown-menu-right.shadow-lg.bg-dark{ 'aria-labelledby': 'dropdownMenuButton' }
     .px-4.py-3#login-form
       = form_tag(form_options) do
         - if proxy

--- a/src/api/app/views/layouts/webui2/_navigation.html.haml
+++ b/src/api/app/views/layouts/webui2/_navigation.html.haml
@@ -1,7 +1,8 @@
 %nav.navbar.navbar-expand-md.navbar-dark.bg-dark
-  = link_to root_path, { class: 'navbar-brand', alt: 'Logo' } do
-    = image_tag('obs-logo_small.svg', height: '30' )
-  %button.navbar-toggler{ 'type': "button", 'data-toggle': "collapse", 'data-target': "#global-navigation", 'aria-controls': "global-navigation", 'aria-expanded': "false", 'aria-label': "Toggle navigation" }
+  = link_to(root_path, class: 'navbar-brand', alt: 'Logo') do
+    = image_tag('obs-logo_small.svg', height: '30')
+  %button.navbar-toggler{ 'type': 'button', data: { toggle: 'collapse', target: '#global-navigation' },
+                          aria: { controls: 'global-navigation', expanded: 'false', label: 'Toggle navigation' } }
     %span.navbar-toggler-icon
   .collapse.navbar-collapse#global-navigation
     %ul.navbar-nav.ml-auto

--- a/src/api/app/views/layouts/webui2/_personal_navigation.html.haml
+++ b/src/api/app/views/layouts/webui2/_personal_navigation.html.haml
@@ -9,8 +9,7 @@
                                                                              method: :post,
                                                                              enctype: 'application/x-www-form-urlencoded' },
                                                              proxy: true }
-  - else
-    - if can_register
-      = render partial: 'layouts/webui2/login_form', locals: { signup_url: user_signup_path,
-                                                               form_options: session_create_path,
-                                                               proxy: false }
+  - elsif can_register
+    = render partial: 'layouts/webui2/login_form', locals: { signup_url: user_signup_path,
+                                                             form_options: session_create_path,
+                                                             proxy: false }

--- a/src/api/app/views/layouts/webui2/_search.html.haml
+++ b/src/api/app/views/layouts/webui2/_search.html.haml
@@ -1,2 +1,2 @@
-= form_tag(search_path(project: 1, package: 1, name: 1), { class: 'form-inline' }) do
-  %input.form-control.w-100{ "aria-label": "Search", name: 'search_text', placeholder: "Search", type: "text" }/
+= form_tag(search_path(project: 1, package: 1, name: 1), class: 'form-inline') do
+  %input.form-control.w-100{ 'aria-label': 'Search', name: 'search_text', placeholder: 'Search', type: 'text' }/

--- a/src/api/app/views/layouts/webui2/webui.html.haml
+++ b/src/api/app/views/layouts/webui2/webui.html.haml
@@ -1,22 +1,22 @@
 !!!
-%html{ lang: "en" }
+%html{ lang: 'en' }
   %head
-    %meta{ content: "charset=utf-8" }/
-    %meta{ name: "viewport", content: "width=device-width, initial-scale=1, shrink-to-fit=no" }
+    %meta{ content: 'charset=utf-8' }/
+    %meta{ name: 'viewport', content: 'width=device-width, initial-scale=1, shrink-to-fit=no' }
     - if @metarobots
-      %meta{ content: "#{@metarobots}", name: "robots" }/
+      %meta{ content: @metarobots, name: 'robots' }/
     = favicon_link_tag
     %title
       = "#{@pagetitle} - " if @pagetitle
       = home_title
-    %meta{ property: "og:title", content: meta_title }
-    %meta{ property: "og:site_name", content: home_title }
-    %meta{ property: "og:type", content: 'website' }
-    %meta{ property: "og:url", content: request.original_url }
-    %meta{ property: "og:image", content: meta_image }
+    %meta{ property: 'og:title', content: meta_title }
+    %meta{ property: 'og:site_name', content: home_title }
+    %meta{ property: 'og:type', content: 'website' }
+    %meta{ property: 'og:url', content: request.original_url }
+    %meta{ property: 'og:image', content: meta_image }
     - if meta_description
-      %meta{ property: "og:description", content: meta_description }
-    
+      %meta{ property: 'og:description', content: meta_description }
+
     = stylesheet_link_tag 'webui2/webui2'
     = javascript_include_tag 'webui2/application'
 
@@ -29,11 +29,11 @@
       var _paq = _paq || [];
       $(function() { #{yield :ready_function} });
 
-    = auto_discovery_link_tag(:rss, news_feed_path(format: 'rss'), {:title => 'News'})
+    = auto_discovery_link_tag(:rss, news_feed_path(format: 'rss'), title: 'News')
     = csrf_meta_tag
     - if User.current.try(:rss_token)
-      = auto_discovery_link_tag(:rss, user_rss_notifications_url(token: User.current.rss_token.string, format: :rss), { title: 'Notifications' })
-    = auto_discovery_link_tag(:rss, latest_updates_feed_path(format: 'rss'), { title: 'Latest updates' })
+      = auto_discovery_link_tag(:rss, user_rss_notifications_url(token: User.current.rss_token.string, format: :rss), title: 'Notifications')
+    = auto_discovery_link_tag(:rss, latest_updates_feed_path(format: 'rss'), title: 'Latest updates')
   %body.d-flex.flex-column
     = render 'peek/bar'
     #navigation
@@ -42,14 +42,14 @@
     .container
       .row
         .col
-          = render partial: "layouts/webui2/breadcrumbs"
+          = render partial: 'layouts/webui2/breadcrumbs'
         .col-auto.ml-auto#personal-navigation
-          = render partial: "layouts/webui2/personal_navigation"
+          = render partial: 'layouts/webui2/personal_navigation'
 
     .container.sticky-top.flash-and-announcement.text-word-break-all
       - unless @hide_announcement_notification
-        #announcement= render partial: 'layouts/webui2/announcement'
-      #flash= render partial: "layouts/webui2/flash", object: flash
+        #announcement= render partial: 'layouts/webui2/announcement', locals: { pending_announcement: @pending_announcement }
+      #flash= render partial: 'layouts/webui2/flash', object: flash
     .modal.fade#modal{ tabindex: '-1', role: 'dialog', aria: { labelledby: 'modalLabel', hidden: true } }
 
     .container.flex-grow#content


### PR DESCRIPTION
Following PRs from @vpereira regarding `haml-lint` (#7466, #7468, #7470), I realized that we didn't fully cover the views for the Bootstrap UI and both UIs (mailers, error pages, etc..). They are now covered with this PR, so they will be linted. Other views are for the bento UI only, which we don't want to lint since they will be removed once we complete the Bootstrap migration.
