### PR TITLE
Fix comment box for long phrases without whitespaces

### DIFF
--- a/src/api/app/assets/stylesheets/webui2/comments.scss
+++ b/src/api/app/assets/stylesheets/webui2/comments.scss
@@ -1,5 +1,7 @@
 #comments {
   .media .media-body {
+    @extend .text-word-break-all;
+
     pre, code {
       @extend .p-2;
       @extend .bg-light;


### PR DESCRIPTION
#### Before
![Screenshot_2019-04-26 home Admin](https://user-images.githubusercontent.com/1212806/56802664-e9aa3900-6820-11e9-84cc-b15114c2945d.png)


#### After
![Screenshot_2019-04-26 home Admin(1)](https://user-images.githubusercontent.com/1212806/56802680-f464ce00-6820-11e9-9290-7b1b57c6fdb9.png)

fix #7302 
