### PR TITLE
Improve repository's name validation

### DIFF
--- a/src/api/spec/bootstrap/features/webui/repositories_spec.rb
+++ b/src/api/spec/bootstrap/features/webui/repositories_spec.rb
@@ -89,7 +89,7 @@ RSpec.feature 'Bootstrap_Repositories', type: :feature, js: true, vcr: true do
     scenario 'add DoD repositories' do
       visit(project_repositories_path(project: admin_user.home_project_name))
       click_link('Add DoD Repository')
-      fill_in('Repository name', with: 'My DoD repository')
+      fill_in('Repository name', with: 'My_DoD_repository')
       select('i586', from: 'Architecture')
       select('rpmmd', from: 'Type')
       fill_in('Url', with: 'http://somerandomurl.es')
@@ -102,7 +102,7 @@ RSpec.feature 'Bootstrap_Repositories', type: :feature, js: true, vcr: true do
       expect(page).to have_css('.repository-card')
 
       within '.repository-card' do
-        expect(page).to have_link('My DoD repository')
+        expect(page).to have_link('My_DoD_repository')
         expect(page).to have_link('Add Download on Demand Source')
         expect(page).to have_link('Delete Repository')
         # DoD source

--- a/src/api/spec/controllers/webui/repositories_controller_spec.rb
+++ b/src/api/spec/controllers/webui/repositories_controller_spec.rb
@@ -117,7 +117,7 @@ RSpec.describe Webui::RepositoriesController, vcr: true do
 
       it 'should eq Successfully added repositories' do
         action
-        expect(flash[:error]).to eq("Can not add repository: Name must not start with '_' or contain any of these characters ':/'")
+        expect(flash[:error]).to eq('Can not add repository: Name is illegal')
       end
 
       it { expect(action).to redirect_to(root_url) }
@@ -165,7 +165,7 @@ RSpec.describe Webui::RepositoriesController, vcr: true do
       it {
         expect(flash[:error]).to eq('Can not add repository: ' \
           'Name is too short (minimum is 1 character) and ' \
-          "Name must not start with '_' or contain any of these characters ':/'")
+          'Name is illegal')
       }
       it { is_expected.to redirect_to(root_url) }
       it { expect(assigns(:project).repositories.count).to eq(0) }

--- a/src/api/spec/models/repository_spec.rb
+++ b/src/api/spec/models/repository_spec.rb
@@ -13,7 +13,10 @@ RSpec.describe Repository do
     it { is_expected.not_to(allow_value('_foo').for(:name)) }
     it { is_expected.not_to(allow_value('f:oo').for(:name)) }
     it { is_expected.not_to(allow_value('f/oo').for(:name)) }
+    it { is_expected.not_to(allow_value('f oo').for(:name)) }
     it { is_expected.not_to(allow_value("f\noo").for(:name)) }
+    it { is_expected.to allow_value('fOo_c++').for(:name) }
+    it { is_expected.to allow_value('f0o-c++_4.5').for(:name) }
     it { is_expected.to allow_value('fOO_-§$&!#+~()=?\\"').for(:name) }
     it { is_expected.to allow_value('f').for(:name) }
 


### PR DESCRIPTION
Until now, the validation for the repository name didn't avoid:
  - spaces
  - characters like: * or ;
  - double hyphens or underscores

Please read the issue first, there are some cases I'm not sure if we have to validate.
Fixes: #7021