### PR TITLE
Update maintenance incidents table

### DIFF
--- a/src/api/app/datatables/maintenance_incident_datatable.rb
+++ b/src/api/app/datatables/maintenance_incident_datatable.rb
@@ -26,8 +26,7 @@ class MaintenanceIncidentDatatable < Datatable
         category: category_cell(record, patchinfo),
         packages: packages_cell(record, release_targets_ng),
         info: info_cell(record, patchinfo),
-        release_targets: release_targets_cell(release_targets_ng),
-        build_results: build_results_cell(record, release_targets_ng)
+        release_targets: release_targets_cell(record, release_targets_ng)
       }
     end
   end

--- a/src/api/app/helpers/webui/maintenance_incident_helper.rb
+++ b/src/api/app/helpers/webui/maintenance_incident_helper.rb
@@ -89,7 +89,7 @@ module Webui::MaintenanceIncidentHelper
                 link_to(project_show_path(project: incident.name)) do
                   content_tag(:i, nil, class: "fas pr-1 #{incident_build_icon_class(incident, release_target_ng)}", title: 'Build results')
                 end,
-                content_tag(:b, release_target_project)
+                link_to(release_target_project, project_show_path(project: release_target_project))
               ]
             )
           end

--- a/src/api/app/helpers/webui/maintenance_incident_helper.rb
+++ b/src/api/app/helpers/webui/maintenance_incident_helper.rb
@@ -101,10 +101,17 @@ module Webui::MaintenanceIncidentHelper
   private
 
   def outgoing_request_links(requests)
-    requests.map do |rq_out|
-      link_to(request_show_path(rq_out['number'])) do
-        content_tag(:i, nil, class: "fas fa-flag request-flag-#{rq_out['state']}", title: "Release request in state '#{rq_out['state']}'")
-      end
+    requests.map do |request|
+      safe_join(
+        [
+          link_to(request_show_path(request['number'])) do
+            content_tag(:i, nil, class: "fas fa-flag pr-1 request-flag-#{request['state']}", title: "Release request in state '#{request['state']}'")
+          end,
+          # rubocop:disable Rails/OutputSafety
+          "Created #{fuzzy_time(request.created_at)}".html_safe
+          # rubocop:enable Rails/OutputSafety
+        ]
+      )
     end
   end
 end

--- a/src/api/app/helpers/webui/maintenance_incident_helper.rb
+++ b/src/api/app/helpers/webui/maintenance_incident_helper.rb
@@ -79,26 +79,23 @@ module Webui::MaintenanceIncidentHelper
     end
   end
 
-  def release_targets_cell(release_targets_ng)
-    safe_join([
-                release_targets_ng.keys.map do |release_target_project|
-                  content_tag(:div) do
-                    content_tag(:b, release_target_project)
-                  end
-                end
-              ])
-  end
-
-  def build_results_cell(incident, release_targets_ng)
-    safe_join([
-                release_targets_ng.values.map do |release_target_ng|
-                  content_tag(:div) do
-                    link_to(project_show_path(project: incident.name)) do
-                      content_tag(:i, nil, class: "fas #{incident_build_icon_class(incident, release_target_ng)}", title: 'Build results')
-                    end
-                  end
-                end
-              ])
+  def release_targets_cell(incident, release_targets_ng)
+    safe_join(
+      [
+        release_targets_ng.map do |release_target_project, release_target_ng|
+          content_tag(:div) do
+            safe_join(
+              [
+                link_to(project_show_path(project: incident.name)) do
+                  content_tag(:i, nil, class: "fas pr-1 #{incident_build_icon_class(incident, release_target_ng)}", title: 'Build results')
+                end,
+                content_tag(:b, release_target_project)
+              ]
+            )
+          end
+        end
+      ]
+    )
   end
 
   private

--- a/src/api/app/views/webui2/webui/projects/maintenance_incidents/index.html.haml
+++ b/src/api/app/views/webui2/webui/projects/maintenance_incidents/index.html.haml
@@ -24,8 +24,6 @@
             Info
           %th
             Release Targets
-          %th
-            Build
       %tbody
 
 - content_for :ready_function do
@@ -39,7 +37,6 @@
         { data: 'category', orderable: false },
         { data: 'packages', orderable: false },
         { data: 'info', orderable: false },
-        { data: 'release_targets', orderable: false },
-        { data: 'build_results', orderable: false }
+        { data: 'release_targets', orderable: false }
       ]
     });


### PR DESCRIPTION
* Merge release targets and build result column
* Make release target project linkable
* Add request creation time next to request flags

Before:

https://build.opensuse.org/projects/openSUSE:Maintenance/maintenance_incidents

After:

![2019-04-26_15-33](https://user-images.githubusercontent.com/968949/56812475-40247100-683b-11e9-8b35-0b410a9f8cc7.png)
