### PR TITLE
Move set_sourceupdate_default to an explicit action in the controller

### DIFF
--- a/src/api/app/controllers/request_controller.rb
+++ b/src/api/app/controllers/request_controller.rb
@@ -152,8 +152,12 @@ class RequestController < ApplicationController
     end
 
     # cache the diff (in the backend)
-    @req.bs_request_actions.each do |a|
-      BsRequestActionWebuiInfosJob.perform_later(a)
+    @req.bs_request_actions.each do |action|
+      # cleanup implicit home branches.
+      # FIXME3.0: remove this, the clients should do this automatically meanwhile
+      action.set_sourceupdate_default(User.session!)
+      # cache the diff (in the backend)
+      BsRequestActionWebuiInfosJob.perform_later(action)
     end
 
     render xml: @req.render_xml


### PR DESCRIPTION
The default is in the UI view, so it's all about the API controller and that one knows when to call it, no reason to 'fix it' in the check functions of the model



<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md
-->
