### PR TITLE
Extend User's API

### DIFF
--- a/src/api/app/controllers/webui/webui_controller.rb
+++ b/src/api/app/controllers/webui/webui_controller.rb
@@ -100,7 +100,7 @@ class Webui::WebuiController < ActionController::Base
     if CONFIG['kerberos_mode']
       kerberos_auth
     else
-      if User.current_or_nobody.is_nobody?
+      if User.possibly_nobody.is_nobody?
         render(text: 'Please login') && (return false) if request.xhr?
 
         flash[:error] = 'Please login to access the requested page.'

--- a/src/api/app/models/bs_request_action.rb
+++ b/src/api/app/models/bs_request_action.rb
@@ -853,7 +853,7 @@ class BsRequestAction < ApplicationRecord
         # the target, the request creator (who must have permissions to read source)
         # wanted the target owner to review it
         tprj = Project.find_by_name(target_project)
-        if tprj.nil? || !User.current_or_nobody.can_modify?(tprj)
+        if tprj.nil? || !User.possibly_nobody.can_modify?(tprj)
           # produce an error for the source
           Package.get_by_project_and_name(source_project, source_package)
         end


### PR DESCRIPTION
Deprecate User.current in favor of split usage of User.possibly_nobody and User.required

The later will throw an exception if no user is logged in (controller needs to make sure it requires login), the former behaves like User.current

In addition introduce User.not_required that may return nil if no user is logged in and User.admin_session? as wrapper to simplify checks for admin user being logged in.
