### PR TITLE
Rename User.current= to User.session=

### DIFF
--- a/src/api/app/controllers/application_controller.rb
+++ b/src/api/app/controllers/application_controller.rb
@@ -460,7 +460,7 @@ class ApplicationController < ActionController::Base
   end
 
   def set_nobody
-    User.current = User.find_nobody!
+    User.session = User.find_nobody!
   end
 
   def set_influxdb_data

--- a/src/api/app/controllers/webui/session_controller.rb
+++ b/src/api/app/controllers/webui/session_controller.rb
@@ -20,7 +20,7 @@ class Webui::SessionController < Webui::WebuiController
       return
     end
 
-    User.current = user
+    User.session = user
     session[:login] = user.login
     Rails.logger.debug "Authenticated as user '#{user.login}'"
     RabbitmqBus.send_to_bus('metrics', 'login,access_point=webui value=1')
@@ -33,7 +33,7 @@ class Webui::SessionController < Webui::WebuiController
 
     reset_session
     RabbitmqBus.send_to_bus('metrics', 'logout,access_point=webui value=1')
-    User.current = nil
+    User.session = nil
 
     redirect_on_logout
   end

--- a/src/api/app/controllers/webui/user_controller.rb
+++ b/src/api/app/controllers/webui/user_controller.rb
@@ -116,7 +116,7 @@ class Webui::UserController < Webui::WebuiController
       redirect_to controller: :user, action: :index
     else
       session[:login] = opts[:login]
-      User.current = User.find_by_login(session[:login])
+      User.session = User.find_by_login(session[:login])
       if User.current.home_project
         redirect_to project_show_path(User.current.home_project)
       else

--- a/src/api/app/jobs/consistency_check_job.rb
+++ b/src/api/app/jobs/consistency_check_job.rb
@@ -74,7 +74,7 @@ class ConsistencyCheckJob < ApplicationJob
   end
 
   def init
-    User.current ||= User.get_default_admin
+    User.session = User.current || User.get_default_admin
     @errors = ''
   end
 

--- a/src/api/app/jobs/project_create_auto_cleanup_requests.rb
+++ b/src/api/app/jobs/project_create_auto_cleanup_requests.rb
@@ -11,7 +11,7 @@ Such requests get not created for projects with open requests or if you remove t
     return unless cleanup_days && cleanup_days > 0
 
     # defaults
-    User.current ||= User.find_by_login('Admin')
+    User.session = User.current || User.find_by_login('Admin')
     @cleanup_attribute = AttribType.find_by_namespace_and_name!('OBS', 'AutoCleanup')
     @cleanup_time = Time.now + cleanup_days.days
 

--- a/src/api/app/jobs/staging_project_accept_job.rb
+++ b/src/api/app/jobs/staging_project_accept_job.rb
@@ -3,9 +3,9 @@ class StagingProjectAcceptJob < ApplicationJob
 
   def perform(payload)
     current_user_before = User.current
-    User.current = User.find_by(login: payload[:user_login])
+    User.session = User.find_by(login: payload[:user_login])
     accept(Project.find(payload[:project_id]))
-    User.current = current_user_before
+    User.session = current_user_before
   end
 
   def accept(staging_project)

--- a/src/api/app/jobs/staging_project_copy_job.rb
+++ b/src/api/app/jobs/staging_project_copy_job.rb
@@ -1,7 +1,7 @@
 class StagingProjectCopyJob < ApplicationJob
   def perform(staging_workflow_project_name, original_staging_project_name, staging_project_copy_name, user_id)
     # This is needed as the job depends on the current user and without it, it will failed when performed later
-    User.current ||= User.find(user_id)
+    User.session = User.current || User.find(user_id)
 
     staging_workflow_project = Project.find_by!(name: staging_workflow_project_name)
     original_staging_project = staging_workflow_project.staging.staging_projects.find_by!(name: original_staging_project_name)

--- a/src/api/app/models/bs_request.rb
+++ b/src/api/app/models/bs_request.rb
@@ -908,9 +908,9 @@ class BsRequest < ApplicationRecord
 
     with_lock do
       if accept_at
-        User.current = User.find_by_login(creator)
+        User.session = User.find_by_login(creator)
       elsif approver
-        User.current = User.find_by_login(approver)
+        User.session = User.find_by_login(approver)
       end
       raise 'Request lacks definition of owner for auto accept' unless User.current
 

--- a/src/api/app/models/project.rb
+++ b/src/api/app/models/project.rb
@@ -1076,7 +1076,7 @@ class Project < ApplicationRecord
   # called either directly or from delayed job
   def do_project_copy(params)
     # set user if nil, needed for delayed job in Package model
-    User.current ||= User.find_by_login(params[:user])
+    User.session = User.current || User.find_by_login(params[:user])
 
     check_write_access!
 
@@ -1116,7 +1116,7 @@ class Project < ApplicationRecord
 
   # called either directly or from delayed job
   def do_project_release(params)
-    User.current ||= User.find_by_login(params[:user])
+    User.session = User.current || User.find_by_login(params[:user])
 
     # uniq timestring for all targets
     time_now = Time.now.utc

--- a/src/api/app/models/update_notification_events.rb
+++ b/src/api/app/models/update_notification_events.rb
@@ -44,7 +44,7 @@ class UpdateNotificationEvents
     end
 
     # pick first admin so we can see all projects - as this function is called from delayed job
-    User.current ||= User.get_default_admin
+    User.session = User.current || User.get_default_admin
 
     loop do
       semaphore.synchronize do

--- a/src/api/app/models/user.rb
+++ b/src/api/app/models/user.rb
@@ -233,7 +233,7 @@ class User < ApplicationRecord
     current || nobody
   end
 
-  def self.current=(user)
+  def self.session=(user)
     Thread.current[:user] = user
   end
 

--- a/src/api/config/clock.rb
+++ b/src/api/config/clock.rb
@@ -41,7 +41,7 @@ module Clockwork
   end
 
   every(1.hour, 'accept requests') do
-    User.current = User.get_default_admin
+    User.session = User.get_default_admin
     BsRequest.delayed_auto_accept
   end
 
@@ -69,7 +69,7 @@ module Clockwork
   end
 
   every(1.day, 'create cleanup requests', at: '06:00') do
-    User.current = User.get_default_admin
+    User.session = User.get_default_admin
     ProjectCreateAutoCleanupRequests.perform_later
   end
 

--- a/src/api/db/checker.rb
+++ b/src/api/db/checker.rb
@@ -93,7 +93,7 @@ module DB
     def resolve_devel_packages
       print "\nChecking devel packages "
       begin
-        User.current = User.find_by_login('_nobody_')
+        User.session = User.find_by_login('_nobody_')
         projects = {}
         Package.where('develpackage_id is not null').each do |package|
           begin

--- a/src/api/lib/authenticator.rb
+++ b/src/api/lib/authenticator.rb
@@ -224,7 +224,7 @@ class Authenticator
                                   'is a registered account, but it is not yet approved for the OBS by admin.'
     end
 
-    User.current = @http_user
+    User.session = @http_user
 
     if @http_user.state == 'confirmed'
       Rails.logger.debug "USER found: #{@http_user.login}"
@@ -246,7 +246,7 @@ class Authenticator
   # to become _public_ special user
   def load_nobody
     @http_user = User.find_nobody!
-    User.current = @http_user
+    User.session = @http_user
     @user_permissions = Suse::Permission.new(User.current)
   end
 end

--- a/src/api/lib/tasks/dev.rake
+++ b/src/api/lib/tasks/dev.rake
@@ -157,7 +157,7 @@ namespace :dev do
       include FactoryBot::Syntax::Methods
       timestamp = Time.now.to_i
       maintainer = create(:confirmed_user, login: "maintainer_#{timestamp}")
-      User.current = maintainer
+      User.session = maintainer
       managers_group = create(:group, title: "managers_group_#{timestamp}")
       staging_workflow = create(:staging_workflow_with_staging_projects, project: maintainer.home_project, managers_group: managers_group)
       staging_workflow.managers_group.add_user(maintainer)
@@ -190,7 +190,7 @@ namespace :dev do
 
       iggy = create(:confirmed_user, login: 'Iggy')
       admin = User.where(login: 'Admin').first
-      User.current = admin
+      User.session = admin
 
       interconnect = create(:project, name: 'openSUSE.org', remoteurl: 'https://api.opensuse.org/public')
       tw_repository = create(:repository, name: 'snapshot', project: interconnect, remote_project_name: 'openSUSE:Factory')
@@ -225,7 +225,7 @@ namespace :dev do
       create(:path_element, link: tw_repository, repository: leap_repository)
 
       # we need to set the user again because some factories set the user back to nil :(
-      User.current = admin
+      User.session = admin
       update_project = create(:update_project, target_project: leap, name: "#{leap.name}:Update")
       create(
         :maintenance_project,
@@ -254,19 +254,19 @@ namespace :dev do
           source_package: leap_apache,
           review_by_user: checker
         )
-        User.current = iggy
+        User.session = iggy
         req.reviews.create(by_group: osrt.title)
         req
       end
 
       travel_to(88.minutes.ago) do
-        User.current = checker
+        User.session = checker
         req.change_review_state(:accepted, by_user: checker.login, comment: 'passed')
       end
 
       travel_to(20.minutes.ago) do
         # accepting last review - new state
-        User.current = reviewhero
+        User.session = reviewhero
         req.change_review_state(:accepted, by_group: osrt.title, comment: 'looks good')
       end
 
@@ -275,7 +275,7 @@ namespace :dev do
       end
       create(:comment, commentable: req, parent: comment)
 
-      User.current = iggy
+      User.session = iggy
       req.addreview(by_user: admin.login, comment: 'is this really fine?')
 
       create(:project, name: 'openSUSE:Factory:Rings:0-Bootstrap')

--- a/src/api/lib/tasks/extract.rake
+++ b/src/api/lib/tasks/extract.rake
@@ -30,7 +30,7 @@ namespace :db do
     sql = 'SELECT * FROM %s'
     skip_tables = ['schema_info', 'sessions', 'schema_migrations']
     ActiveRecord::Base.establish_connection
-    User.current = User.find_by_login('Admin')
+    User.session = User.find_by_login('Admin')
     tables = ENV['FIXTURES'] ? ENV['FIXTURES'].split(/,/) : ActiveRecord::Base.connection.tables - skip_tables
     tables.each do |table_name|
       i = '000'

--- a/src/api/script/start_test_backend
+++ b/src/api/script/start_test_backend
@@ -61,7 +61,7 @@ FileUtils.rm_rf(backend_config)
 # minimal auth
 @http_user = User.find_by_login('king')
 raise 'NO fixtures - run rake db:fixtures:load RAILS_ENV=test' unless @http_user
-User.current = @http_user
+User.session = @http_user
 
 puts "Creating backend config at #{backend_config}/BSConfig.pm"
 FileUtils.mkdir backend_config
@@ -318,7 +318,7 @@ ActiveRecord::Base.transaction(requires_new: true) do
 end
 
 @http_user = nil
-User.current = nil
+User.session = nil
 
 scheduler_thread = nil
 

--- a/src/api/spec/bootstrap/features/webui/attributes_spec.rb
+++ b/src/api/spec/bootstrap/features/webui/attributes_spec.rb
@@ -8,9 +8,9 @@ RSpec.feature 'Bootstrap_Attributes', type: :feature, js: true do
   context 'with an attribute' do
     before do
       # create attrib as user
-      User.current = user
+      User.session = user
       attribute
-      User.current = nil
+      User.session = nil
     end
 
     context 'for a project' do

--- a/src/api/spec/bootstrap/features/webui/image_templates_spec.rb
+++ b/src/api/spec/bootstrap/features/webui/image_templates_spec.rb
@@ -14,9 +14,9 @@ RSpec.feature 'Bootstrap_ImageTemplates', type: :feature, js: true, vcr: true do
 
     before do
       # create attrib as user
-      User.current = user
+      User.session = user
       attrib
-      User.current = nil
+      User.session = nil
     end
 
     scenario 'branch image template' do

--- a/src/api/spec/bootstrap/features/webui/maintenance_workflow_spec.rb
+++ b/src/api/spec/bootstrap/features/webui/maintenance_workflow_spec.rb
@@ -17,7 +17,7 @@ RSpec.feature 'Bootstrap_MaintenanceWorkflow', type: :feature, js: true, vcr: tr
   end
 
   before do
-    User.current = admin_user
+    User.session = admin_user
     create(:maintenance_project_attrib, project: maintenance_project)
   end
 

--- a/src/api/spec/controllers/staging/staging_projects_controller_spec.rb
+++ b/src/api/spec/controllers/staging/staging_projects_controller_spec.rb
@@ -181,7 +181,7 @@ RSpec.describe Staging::StagingProjectsController, type: :controller, vcr: true 
 
       before do
         allow(StagingProjectAcceptJob).to receive(:perform_later)
-        User.current = user
+        User.session = user
       end
 
       subject do

--- a/src/api/spec/factories/bs_requests.rb
+++ b/src/api/spec/factories/bs_requests.rb
@@ -63,7 +63,7 @@ FactoryBot.define do
     after(:create) do |request, evaluator|
       next unless request.staging_project && evaluator.staging_owner
 
-      User.current = evaluator.staging_owner
+      User.session = evaluator.staging_owner
       request.bs_request_actions.where(type: :submit).each do |action|
         BranchPackage.new(
           project: action.source_project,
@@ -72,7 +72,7 @@ FactoryBot.define do
           target_package: action.target_package
         ).branch
       end
-      User.current = evaluator.before_current_user
+      User.session = evaluator.before_current_user
     end
 
     transient do
@@ -102,7 +102,7 @@ FactoryBot.define do
     after(:build) do |request, evaluator|
       # Monkeypatch to avoid errors caused by permission checks made
       # in user and bs_request model
-      User.current = evaluator.creating_user
+      User.session = evaluator.creating_user
       request[:state] ||= 'new'
     end
 
@@ -115,7 +115,7 @@ FactoryBot.define do
         request.update_attributes(state: state)
         request.reload
       end
-      User.current = evaluator.before_current_user
+      User.session = evaluator.before_current_user
     end
 
     factory :bs_request_with_submit_action do

--- a/src/api/spec/factories/project.rb
+++ b/src/api/spec/factories/project.rb
@@ -152,9 +152,9 @@ FactoryBot.define do
         end
         if evaluator.create_patchinfo
           old_user = User.current
-          User.current = evaluator.maintainer
+          User.session = evaluator.maintainer
           Patchinfo.new.create_patchinfo(project.name, nil, comment: 'Fake comment', force: true)
-          User.current = old_user
+          User.session = old_user
         end
       end
 

--- a/src/api/spec/features/webui/image_templates_spec.rb
+++ b/src/api/spec/features/webui/image_templates_spec.rb
@@ -14,9 +14,9 @@ RSpec.feature 'ImageTemplates', type: :feature, js: true do
 
     before do
       # create attrib as user
-      User.current = user
+      User.session = user
       attrib
-      User.current = nil
+      User.session = nil
     end
 
     scenario 'branch image template' do

--- a/src/api/spec/features/webui/maintenance_workflow_spec.rb
+++ b/src/api/spec/features/webui/maintenance_workflow_spec.rb
@@ -17,7 +17,7 @@ RSpec.feature 'MaintenanceWorkflow', type: :feature, js: true do
   end
 
   before do
-    User.current = admin_user
+    User.session = admin_user
     create(:maintenance_project_attrib, project: maintenance_project)
   end
 

--- a/src/api/spec/features/webui/packages_spec.rb
+++ b/src/api/spec/features/webui/packages_spec.rb
@@ -27,7 +27,7 @@ RSpec.feature 'Packages', type: :feature, js: true do
 
     before do
       # Needed for branching
-      User.current = user
+      User.session = user
     end
 
     scenario "has a mime like suffix in it's name" do

--- a/src/api/spec/helpers/webui/search_helper_spec.rb
+++ b/src/api/spec/helpers/webui/search_helper_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe Webui::SearchHelper, type: :helper do
     end
 
     it 'creates an icon with link for each user' do
-      User.current = user
+      User.session = user
       expected_result = maintainer.map { |user| user_and_role(user, 'maintainer') }
       expected_result.concat(foo_user.map { |user| user_and_role(user, 'foo') })
 

--- a/src/api/spec/helpers/webui/user_helper_spec.rb
+++ b/src/api/spec/helpers/webui/user_helper_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Webui::UserHelper do
 
     context 'for logged in users' do
       before do
-        User.current = logged_in_user
+        User.session = logged_in_user
       end
 
       it 'displays the users realname to a user that is logged in' do
@@ -47,7 +47,7 @@ RSpec.describe Webui::UserHelper do
       before do
         user.email = 'greatguy@nowhere.fi'
         user.save
-        User.current = anonymous_user
+        User.session = anonymous_user
       end
 
       it 'does not link to user profiles' do

--- a/src/api/spec/helpers/webui/webui_helper_spec.rb
+++ b/src/api/spec/helpers/webui/webui_helper_spec.rb
@@ -277,7 +277,7 @@ RSpec.describe Webui::WebuiHelper do
   describe '#can_register' do
     context 'current user is admin' do
       before do
-        User.current = create(:admin_user)
+        User.session = create(:admin_user)
       end
 
       it { expect(can_register).to be(true) }
@@ -285,7 +285,7 @@ RSpec.describe Webui::WebuiHelper do
 
     context 'user is not registered' do
       before do
-        User.current = create(:user)
+        User.session = create(:user)
         allow(UnregisteredUser).to receive(:can_register?).and_raise(APIError)
       end
 

--- a/src/api/spec/jobs/staging_project_accept_job_spec.rb
+++ b/src/api/spec/jobs/staging_project_accept_job_spec.rb
@@ -44,7 +44,7 @@ RSpec.describe StagingProjectAcceptJob, type: :job, vcr: true do
     end
 
     before do
-      User.current = user
+      User.session = user
     end
 
     subject { StagingProjectAcceptJob.perform_now(project_id: staging_project.id, user_login: user.login) }

--- a/src/api/spec/jobs/update_package_meta_job_spec.rb
+++ b/src/api/spec/jobs/update_package_meta_job_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe UpdatePackageMetaJob, type: :job, vcr: true do
     let!(:kind_patchinfo) { PackageKind.create(package_id: package2.id, kind: 'patchinfo') }
 
     before do
-      User.current = user
+      User.session = user
       branch_package.branch
       Package.last.update_backendinfo
     end
@@ -36,7 +36,7 @@ RSpec.describe UpdatePackageMetaJob, type: :job, vcr: true do
   describe '#scan_links' do
     # If the package has a link it will check if a BackendPackage exists, otherwise, it will create it.
     before do
-      User.current = user
+      User.session = user
       branch_package.branch
     end
 

--- a/src/api/spec/policies/user_policy_spec.rb
+++ b/src/api/spec/policies/user_policy_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe UserPolicy do
   let(:other_user) { create(:confirmed_user) }
 
   before do
-    User.current = user
+    User.session = user
   end
 
   subject { UserPolicy }

--- a/src/api/spec/services/meta_controller_service/project_updater_spec.rb
+++ b/src/api/spec/services/meta_controller_service/project_updater_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe ::MetaControllerService::ProjectUpdater do
   let(:admin_user) { create(:admin_user, login: 'Admin') }
 
   before do
-    User.current = admin_user
+    User.session = admin_user
   end
 
   context 'with valid meta' do

--- a/src/api/spec/services/staging/staging_project_creator_spec.rb
+++ b/src/api/spec/services/staging/staging_project_creator_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe ::Staging::StagingProjectCreator do
   end
 
   before do
-    User.current = user
+    User.session = user
   end
 
   describe '#staging_projects' do

--- a/src/api/spec/support/controllers/controllers_authentication.rb
+++ b/src/api/spec/support/controllers/controllers_authentication.rb
@@ -1,7 +1,7 @@
 module ControllersAuthentication
   def login(user)
     request.session[:login] = user.login
-    User.current = user
+    User.session = user
   end
 
   def logout

--- a/src/api/spec/support/database_cleaner.rb
+++ b/src/api/spec/support/database_cleaner.rb
@@ -41,6 +41,6 @@ RSpec.configure do |config|
 
   config.after(:each) do
     DatabaseCleaner.clean
-    User.current = nil
+    User.session = nil
   end
 end

--- a/src/api/spec/support/features/features_authentication.rb
+++ b/src/api/spec/support/features/features_authentication.rb
@@ -6,13 +6,13 @@ module FeaturesAuthentication
     fill_in 'user-password', with: password
     click_button 'Log In »'
     expect(page).to have_link 'link-to-user-home'
-    User.current = user
+    User.session = user
   end
 
   def logout
     visit session_destroy_path
     expect(page).to have_no_link('link-to-user-home')
-    User.current = nil
+    User.session = nil
   end
 end
 

--- a/src/api/spec/support/models/models_authentication.rb
+++ b/src/api/spec/support/models/models_authentication.rb
@@ -1,10 +1,10 @@
 module ModelsAuthentication
   def login(user)
-    User.current = user
+    User.session = user
   end
 
   def logout
-    User.current = nil
+    User.session = nil
   end
 end
 

--- a/src/api/test/functional/maintenance_test.rb
+++ b/src/api/test/functional/maintenance_test.rb
@@ -1419,9 +1419,9 @@ class MaintenanceTests < ActionDispatch::IntegrationTest
     assert_difference 'ActionMailer::Base.deliveries.size', +1 do
       post create_request_comment_path(request_number: reqid), params: 'Slave, can you release it? The master is gone'
       assert_response :success
-      User.current = User.find_by_login('king')
+      User.session = User.find_by_login('king')
       SendEventEmailsJob.new.perform
-      User.current = nil
+      User.session = nil
     end
 
     email = ActionMailer::Base.deliveries.last

--- a/src/api/test/functional/person_controller_test.rb
+++ b/src/api/test/functional/person_controller_test.rb
@@ -268,7 +268,7 @@ class PersonControllerTest < ActionDispatch::IntegrationTest
     put '/person/new_user', params: doc.to_s
     assert_response :success
     # cleanup
-    User.current = User.find_by(login: 'new_user')
+    User.session = User.find_by(login: 'new_user')
     Project.find_by(name: 'home:new_user').destroy
 
     # check global role
@@ -368,7 +368,7 @@ class PersonControllerTest < ActionDispatch::IntegrationTest
     assert_response 404
 
     # cleanup
-    User.current = User.find_by(login: 'lost_guy')
+    User.session = User.find_by(login: 'lost_guy')
   end
 
   def test_register_disabled
@@ -479,7 +479,7 @@ class PersonControllerTest < ActionDispatch::IntegrationTest
     assert_equal u.email, 'adrian@example.com'
     assert_equal u.realname, 'Adrian Schroeter'
     assert_nil u.adminnote
-    User.current = u
+    User.session = u
     Project.find_by(name: 'home:adrianSuSE').destroy
     u.destroy
   end

--- a/src/api/test/functional/source_controller_test.rb
+++ b/src/api/test/functional/source_controller_test.rb
@@ -3591,9 +3591,9 @@ class SourceControllerTest < ActionDispatch::IntegrationTest
 
     # in future
     Timecop.freeze(10.days) do
-      User.current = User.find_by_login('fredlibs')
+      User.session = User.find_by_login('fredlibs')
       ProjectCreateAutoCleanupRequests.new.perform
-      User.current = nil
+      User.session = nil
     end
     # validate request
     br = BsRequest.all.last

--- a/src/api/test/models/event_test.rb
+++ b/src/api/test/models/event_test.rb
@@ -69,7 +69,7 @@ class EventTest < ActionDispatch::IntegrationTest
   end
 
   test 'create request' do
-    User.current = users(:Iggy)
+    User.session = users(:Iggy)
     req = bs_requests(:submit_from_home_project)
     myid = req.number
     SendEventEmailsJob.new.perform # empty queue
@@ -128,7 +128,7 @@ class EventTest < ActionDispatch::IntegrationTest
 
   test 'package maintainer mail' do
     ActionMailer::Base.deliveries.clear
-    User.current = users(:Iggy)
+    User.session = users(:Iggy)
     req = bs_requests(:submit_from_home_project)
     myid = req.number
     SendEventEmailsJob.new.perform # empty queue

--- a/src/api/test/models/full_text_search_test.rb
+++ b/src/api/test/models/full_text_search_test.rb
@@ -6,7 +6,7 @@ class FullTextSearchTest < ActiveSupport::TestCase
 
   def setup
     OBSApi::TestSphinx.ensure
-    User.current = nil
+    User.session = nil
   end
 
   test 'search for basedistro' do
@@ -73,18 +73,18 @@ class FullTextSearchTest < ActiveSupport::TestCase
   test 'searching for a hidden project' do
     s = FullTextSearch.new(text: 'HiddenProject')
     assert_equal 0, s.search.total_entries
-    User.current = users(:adrian)
+    User.session = users(:adrian)
     assert_equal 1, s.search.total_entries
-    User.current = users(:fred)
+    User.session = users(:fred)
     assert_equal 0, s.search.total_entries
   end
 
   test 'searching for a hidden package' do
     s = FullTextSearch.new(text: 'packcopy')
     assert_equal 0, s.search.total_entries
-    User.current = users(:adrian)
+    User.session = users(:adrian)
     assert_equal 1, s.search.total_entries
-    User.current = users(:fred)
+    User.session = users(:fred)
     assert_equal 0, s.search.total_entries
   end
 end

--- a/src/api/test/test_consistency_helper.rb
+++ b/src/api/test/test_consistency_helper.rb
@@ -18,9 +18,9 @@ def resubmit_all_fixtures
     get "/source/#{name}/_meta"
     assert_response :success
     r = @response.body
-    User.current = User.find_by_login('king')
+    User.session = User.find_by_login('king')
     next if Project.find_by_name(name).is_locked?
-    User.current = nil
+    User.session = nil
     # FIXME: add some more validation checks here
     put "/source/#{name}/_meta", params: r.dup
     assert_response :success

--- a/src/api/test/test_helper.rb
+++ b/src/api/test/test_helper.rb
@@ -265,7 +265,7 @@ module ActionDispatch
     @@auth = nil
 
     def reset_auth
-      User.current = nil
+      User.session = nil
       @@auth = nil
     end
 

--- a/src/api/test/unit/attribute_test.rb
+++ b/src/api/test/unit/attribute_test.rb
@@ -120,7 +120,7 @@ class AttributeTest < ActiveSupport::TestCase
   end
 
   def test_attrib
-    User.current = users(:king)
+    User.session = users(:king)
 
     # check precondition
     assert_equal 'OBS', @attrib_ns.name
@@ -179,6 +179,6 @@ class AttributeTest < ActiveSupport::TestCase
     end
     assert_match %r{Values has 1 values, but only 0 are allowed}, e.message
 
-    User.current = nil
+    User.session = nil
   end
 end

--- a/src/api/test/unit/binary_release.rb
+++ b/src/api/test/unit/binary_release.rb
@@ -5,7 +5,7 @@ class BinaryReleaseTest < ActiveSupport::TestCase
 
   def setup
     super
-    User.current = nil
+    User.session = nil
   end
 
   def teardown

--- a/src/api/test/unit/bs_request_test.rb
+++ b/src/api/test/unit/bs_request_test.rb
@@ -4,7 +4,7 @@ class BsRequestTest < ActiveSupport::TestCase
   fixtures :all
 
   def setup
-    User.current = users(:Iggy)
+    User.session = users(:Iggy)
   end
 
   test 'if create works' do
@@ -20,7 +20,7 @@ class BsRequestTest < ActiveSupport::TestCase
     assert_equal 1, req.bs_request_actions.length
     req.save!
 
-    User.current = users(:_nobody_)
+    User.session = users(:_nobody_)
     req = BsRequest.new_from_xml(xml)
     assert req.number.nil?
     exception = assert_raise ActiveRecord::RecordInvalid do
@@ -63,7 +63,7 @@ class BsRequestTest < ActiveSupport::TestCase
     assert_equal wia[:role], 'reviewer'
     assert_equal wia[:user], 'Iggy'
 
-    User.current = users(:fred)
+    User.session = users(:fred)
 
     assert_equal req.state, :review
     assert_equal req.creator, 'Iggy'
@@ -146,7 +146,7 @@ class BsRequestTest < ActiveSupport::TestCase
 
   def check_user_targets(user, *trues)
     Backend::Test.start
-    User.current = User.find_by_login(user)
+    User.session = User.find_by_login(user)
     BsRequest.all.each do |r|
       # puts r.render_xml
       expect = trues.include?(r.number)

--- a/src/api/test/unit/channel_test.rb
+++ b/src/api/test/unit/channel_test.rb
@@ -7,7 +7,7 @@ class ChannelTest < ActiveSupport::TestCase
     super
     @package = packages(:home_Iggy_TestPack)
     @channel = Channel.create(package: @package)
-    User.current = nil
+    User.session = nil
   end
 
   def teardown

--- a/src/api/test/unit/event_mailer_test.rb
+++ b/src/api/test/unit/event_mailer_test.rb
@@ -51,7 +51,7 @@ class EventMailerTest < ActionMailer::TestCase
   end
 
   test 'group emails' do
-    User.current = users(:Iggy)
+    User.session = users(:Iggy)
 
     # the default is reviewer groups get email, so check that adrian gets an email
     req = bs_requests(:submit_from_home_project)
@@ -72,7 +72,7 @@ class EventMailerTest < ActionMailer::TestCase
 
   # now check that disabling it for users in groups works too
   test 'group emails to users disabled' do
-    User.current = users(:Iggy)
+    User.session = users(:Iggy)
 
     req = bs_requests(:submit_from_home_project)
 

--- a/src/api/test/unit/package_remove_test.rb
+++ b/src/api/test/unit/package_remove_test.rb
@@ -9,7 +9,7 @@ class PackageRemoveTest < ActiveSupport::TestCase
   end
 
   def test_destroy_source_revokes_request
-    User.current = users(:Iggy)
+    User.session = users(:Iggy)
     branch_package
     create_request
 
@@ -25,7 +25,7 @@ class PackageRemoveTest < ActiveSupport::TestCase
     project = Project.find_by(name: 'Apache')
     review_package = project.packages.create(name: 'test_review_gets_removed')
 
-    User.current = users(:Iggy)
+    User.session = users(:Iggy)
     branch_package
     create_request
     @request.addreview(by_project: review_package.project.name, by_package: review_package.name)
@@ -48,16 +48,16 @@ class PackageRemoveTest < ActiveSupport::TestCase
   end
 
   def test_destroy_target_declines_request
-    User.current = users(:king)
+    User.session = users(:king)
     project = Project.create(name: 'test_destroy_target_declines_request')
     project.store
     project.packages.create(name: 'pack')
 
-    User.current = users(:Iggy)
+    User.session = users(:Iggy)
     branch_package('test_destroy_target_declines_request', 'pack')
     create_request('test_destroy_target_declines_request', 'pack')
 
-    User.current = users(:king)
+    User.session = users(:king)
     Package.find_by_project_and_name('test_destroy_target_declines_request', 'pack').destroy
 
     @request.reload

--- a/src/api/test/unit/package_test.rb
+++ b/src/api/test/unit/package_test.rb
@@ -8,7 +8,7 @@ class PackageTest < ActiveSupport::TestCase
   def setup
     super
     @package = packages(:home_Iggy_TestPack)
-    User.current = nil
+    User.session = nil
   end
 
   def teardown

--- a/src/api/test/unit/project_remove_test.rb
+++ b/src/api/test/unit/project_remove_test.rb
@@ -10,7 +10,7 @@ class ProjectRemoveTest < ActiveSupport::TestCase
   end
 
   def test_destroy_source_revokes_request
-    User.current = users(:Iggy)
+    User.session = users(:Iggy)
     branch_package
     create_request
 
@@ -23,16 +23,16 @@ class ProjectRemoveTest < ActiveSupport::TestCase
   end
 
   def test_destroy_target_declines_request
-    User.current = users(:king)
+    User.session = users(:king)
     project = Project.create(name: 'test_destroy_target_declines_request')
     project.store
 
-    User.current = users(:Iggy)
+    User.session = users(:Iggy)
     other_project = Project.find_by(name: 'home:Iggy')
     other_package = other_project.packages.create(name: 'pack')
     create_request('test_destroy_target_declines_request', 'pack', 'home:Iggy')
 
-    User.current = users(:king)
+    User.session = users(:king)
     project.destroy
 
     @request.reload
@@ -44,11 +44,11 @@ class ProjectRemoveTest < ActiveSupport::TestCase
   end
 
   def test_accept_request_does_not_revoke_request_for_single_package
-    User.current = users(:Iggy)
+    User.session = users(:Iggy)
     branch_package
     create_request
 
-    User.current = users(:fred)
+    User.session = users(:fred)
     @request.change_state(newstate: 'accepted',
                           force: true,
                           user: 'fred')
@@ -60,13 +60,13 @@ class ProjectRemoveTest < ActiveSupport::TestCase
   end
 
   def test_accept_request_does_not_revoke_request_for_multiple_packages
-    User.current = users(:Iggy)
+    User.session = users(:Iggy)
     branch_package
     project = Project.find_by(name: 'home:Iggy:branches:Apache')
     project.packages.create!(name: 'pack')
     create_request
 
-    User.current = users(:fred)
+    User.session = users(:fred)
     @request.change_state(newstate: 'accepted',
                           force: true,
                           user: 'fred')
@@ -80,7 +80,7 @@ class ProjectRemoveTest < ActiveSupport::TestCase
   def test_review_gets_obsoleted
     review_project = Project.create(name: 'test_review_gets_removed')
 
-    User.current = users(:Iggy)
+    User.session = users(:Iggy)
     branch_package
     create_request
     @request.addreview(by_project: review_project.name)

--- a/src/api/test/unit/project_test.rb
+++ b/src/api/test/unit/project_test.rb
@@ -33,7 +33,7 @@ class ProjectTest < ActiveSupport::TestCase
   end
 
   def test_flags_inheritance
-    User.current = users(:Iggy)
+    User.session = users(:Iggy)
 
     project = Project.create(name: 'home:Iggy:flagtest')
 
@@ -347,7 +347,7 @@ class ProjectTest < ActiveSupport::TestCase
   end
 
   def test_release_targets_ng
-    User.current = User.find_by_login('king')
+    User.session = User.find_by_login('king')
 
     project = Project.create(name: 'ABC', kind: 'maintenance')
     project.store
@@ -392,7 +392,7 @@ class ProjectTest < ActiveSupport::TestCase
   end
 
   def test_add_new_flags_from_xml
-    User.current = users(:Iggy)
+    User.session = users(:Iggy)
 
     # precondition check
     @project.flags.delete_all
@@ -451,7 +451,7 @@ class ProjectTest < ActiveSupport::TestCase
   end
 
   def test_delete_flags_through_xml
-    User.current = users(:Iggy)
+    User.session = users(:Iggy)
 
     # check precondition
     assert_equal 2, @project.flags.of_type('build').size
@@ -471,7 +471,7 @@ class ProjectTest < ActiveSupport::TestCase
   end
 
   def test_store_axml
-    User.current = users(:Iggy)
+    User.session = users(:Iggy)
 
     original = @project.to_axml
 
@@ -499,7 +499,7 @@ class ProjectTest < ActiveSupport::TestCase
   end
 
   def test_ordering
-    User.current = users(:Iggy)
+    User.session = users(:Iggy)
 
     # project is given as axml
     axml = Xmlhash.parse(
@@ -545,7 +545,7 @@ class ProjectTest < ActiveSupport::TestCase
   end
 
   def test_maintains
-    User.current = users(:Iggy)
+    User.session = users(:Iggy)
 
     # project is given as axml
     axml = Xmlhash.parse(
@@ -610,7 +610,7 @@ class ProjectTest < ActiveSupport::TestCase
   end
 
   test 'duplicated repos' do
-    User.current = users(:king)
+    User.session = users(:king)
     orig = @project.render_xml
 
     axml = Xmlhash.parse(
@@ -635,7 +635,7 @@ class ProjectTest < ActiveSupport::TestCase
   end
 
   test 'duplicated repos with remote' do
-    User.current = users(:Iggy)
+    User.session = users(:Iggy)
     orig = @project.render_xml
 
     xml = <<-END.strip_heredoc
@@ -663,7 +663,7 @@ class ProjectTest < ActiveSupport::TestCase
   end
 
   test 'not duplicated repos with remote' do
-    User.current = users(:Iggy)
+    User.session = users(:Iggy)
     xml = <<-END.strip_heredoc
       <project name="home:Iggy">
         <title>Iggy"s Home Project</title>
@@ -690,7 +690,7 @@ class ProjectTest < ActiveSupport::TestCase
 
   def test_handle_project_links
     Backend::Test.start
-    User.current = users(:Iggy)
+    User.session = users(:Iggy)
 
     # project A
     axml = Xmlhash.parse(
@@ -730,7 +730,7 @@ class ProjectTest < ActiveSupport::TestCase
   end
 
   def test_repository_with_download_url
-    User.current = users(:king)
+    User.session = users(:king)
 
     prj = Project.new(name: 'DoD')
     prj.update_from_xml!(Xmlhash.parse(
@@ -758,9 +758,9 @@ class ProjectTest < ActiveSupport::TestCase
   def test_validate_remote_permissions
     # Single repository elements
     request_data = Xmlhash.parse(load_backend_file('download_on_demand/project_with_dod.xml'))
-    User.current = users(:king)
+    User.session = users(:king)
     assert Project.validate_remote_permissions(request_data).empty?
-    User.current = users(:user5)
+    User.session = users(:user5)
     assert_equal 'Admin rights are required to change projects using remote resources',
                  Project.validate_remote_permissions(request_data)[:error]
 
@@ -784,12 +784,12 @@ class ProjectTest < ActiveSupport::TestCase
         </repository>
       </project>
     ")
-    User.current = users(:king)
+    User.session = users(:king)
     assert Project.validate_remote_permissions(request_data).empty?
   end
 
   def test_repository_path_sync
-    User.current = users(:king)
+    User.session = users(:king)
 
     prj = Project.new(name: 'Enterprise-SP0:GA')
     prj.update_from_xml!(Xmlhash.parse(
@@ -913,7 +913,7 @@ class ProjectTest < ActiveSupport::TestCase
   end
 
   def test_cycle_handling
-    User.current = users(:king)
+    User.session = users(:king)
 
     prj_a = Project.new(name: 'Project:A')
     prj_a.update_from_xml!(Xmlhash.parse(
@@ -946,7 +946,7 @@ class ProjectTest < ActiveSupport::TestCase
   end
 
   test 'exists_by_name' do
-    User.current = users(:Iggy)
+    User.session = users(:Iggy)
 
     assert Project.exists_by_name('home:Iggy')
     assert Project.exists_by_name('RemoteInstance')
@@ -959,7 +959,7 @@ class ProjectTest < ActiveSupport::TestCase
   end
 
   test 'validate_maintenance_xml_attribute returns an error if User can not modify target project' do
-    User.current = users(:tom)
+    User.session = users(:tom)
     xml = <<-XML.strip_heredoc
       <project name="the_project">
         <title>Up-to-date project</title>
@@ -974,7 +974,7 @@ class ProjectTest < ActiveSupport::TestCase
   end
 
   test 'validate_maintenance_xml_attribute returns no error if User can modify target project' do
-    User.current = users(:king)
+    User.session = users(:king)
 
     xml = <<-XML.strip_heredoc
       <project name="the_project">
@@ -989,7 +989,7 @@ class ProjectTest < ActiveSupport::TestCase
   end
 
   test 'validate_link_xml_attribute returns no error if target project is not disabled' do
-    User.current = users(:Iggy)
+    User.session = users(:Iggy)
     project = projects(:home_Iggy)
 
     xml = <<-XML.strip_heredoc
@@ -1005,7 +1005,7 @@ class ProjectTest < ActiveSupport::TestCase
   end
 
   test 'validate_link_xml_attribute returns an error if target project access is disabled' do
-    User.current = users(:Iggy)
+    User.session = users(:Iggy)
     project = projects(:home_Iggy)
 
     xml = <<-XML.strip_heredoc
@@ -1025,7 +1025,7 @@ class ProjectTest < ActiveSupport::TestCase
   end
 
   test 'validate_repository_xml_attribute returns no error if project access is not disabled' do
-    User.current = users(:Iggy)
+    User.session = users(:Iggy)
 
     xml = <<-XML.strip_heredoc
       <project name='other_project'>
@@ -1041,7 +1041,7 @@ class ProjectTest < ActiveSupport::TestCase
   end
 
   test 'returns an error if repository access is disabled' do
-    User.current = users(:Iggy)
+    User.session = users(:Iggy)
     project = projects(:home_Iggy)
     flag = project.add_flag('access', 'disable')
     flag.save
@@ -1060,7 +1060,7 @@ class ProjectTest < ActiveSupport::TestCase
   end
 
   test 'returns no error if target project equals project' do
-    User.current = users(:Iggy)
+    User.session = users(:Iggy)
     project = projects(:home_Iggy)
     flag = project.add_flag('access', 'disable')
     flag.save
@@ -1079,7 +1079,7 @@ class ProjectTest < ActiveSupport::TestCase
   end
 
   test 'get_removed_repositories returns all repositories if new_repositories does not contain the old repositories' do
-    User.current = users(:Iggy)
+    User.session = users(:Iggy)
     project = projects(:home_Iggy)
     project.repositories << repositories(:repositories_96)
 
@@ -1097,7 +1097,7 @@ class ProjectTest < ActiveSupport::TestCase
   end
 
   test 'get_removed_repositories returns the repository if new_repositories does not include it' do
-    User.current = users(:Iggy)
+    User.session = users(:Iggy)
     project = projects(:home_Iggy)
     project.repositories << repositories(:repositories_96)
 
@@ -1115,7 +1115,7 @@ class ProjectTest < ActiveSupport::TestCase
   end
 
   test 'get_removed_repositories returns no repository if new_repositories matches old_repositories' do
-    User.current = users(:Iggy)
+    User.session = users(:Iggy)
     project = projects(:home_Iggy)
     project.repositories << repositories(:repositories_96)
 
@@ -1133,7 +1133,7 @@ class ProjectTest < ActiveSupport::TestCase
   end
 
   test 'get_removed_repositories returns all repositories if new_repositories is empty' do
-    User.current = users(:Iggy)
+    User.session = users(:Iggy)
     project = projects(:home_Iggy)
     project.repositories << repositories(:repositories_96)
 
@@ -1149,7 +1149,7 @@ class ProjectTest < ActiveSupport::TestCase
   end
 
   test 'get_removed_repositories returns nothing if repositories is empty' do
-    User.current = users(:Iggy)
+    User.session = users(:Iggy)
     project = projects(:home_Iggy)
     project.repositories.destroy_all
 
@@ -1167,7 +1167,7 @@ class ProjectTest < ActiveSupport::TestCase
   end
 
   test 'get_removed_repositories does not include repositories which belong to a remote project' do
-    User.current = users(:Iggy)
+    User.session = users(:Iggy)
     project = projects(:home_Iggy)
     first_repository = project.repositories.first
 
@@ -1188,13 +1188,13 @@ class ProjectTest < ActiveSupport::TestCase
   end
 
   test 'check repositories returns no error if no linking and no linking taget repository exists' do
-    User.current = users(:Iggy)
+    User.session = users(:Iggy)
     actual = Project.check_repositories(@project.repositories)
     assert_equal actual, {}
   end
 
   test 'check repositories returns an error if a linking repository exists' do
-    User.current = users(:Iggy)
+    User.session = users(:Iggy)
 
     path = path_elements(:record_0)
     repository = @project.repositories.first
@@ -1209,7 +1209,7 @@ class ProjectTest < ActiveSupport::TestCase
   end
 
   test 'check repositories returns an error if a linking target repository exists' do
-    User.current = users(:Iggy)
+    User.session = users(:Iggy)
 
     release_target = release_targets(:release_targets_913785863)
     repository = @project.repositories.first
@@ -1328,7 +1328,7 @@ class ProjectTest < ActiveSupport::TestCase
     project_config = File.read('test/fixtures/files/home_iggy_project_config.txt')
     new_project_config = File.read('test/fixtures/files/new_home_iggy_project_config.txt')
 
-    User.current = users(:Iggy)
+    User.session = users(:Iggy)
     query_params = { user: User.current.login, comment: 'Updated by test' }
     assert @project.config.save(query_params, new_project_config)
     assert_equal @project.config.content, new_project_config

--- a/src/api/test/unit/watched_project_test.rb
+++ b/src/api/test/unit/watched_project_test.rb
@@ -4,7 +4,7 @@ class WatchedProjectTest < ActiveSupport::TestCase
   fixtures :all
 
   def test_watchlist_cleaned_after_project_removal
-    User.current = users(:Iggy)
+    User.session = users(:Iggy)
     tmp_prj = Project.create(name: 'home:Iggy:whatever')
     tmp_prj.write_to_backend
     user_ids = User.limit(5).map(&:id) # Roundup some users to watch tmp_prj


### PR DESCRIPTION
In alignment of deprecating User.current, rename the assignment operator to session=



<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md
-->
