### PR TITLE
Fix incident summary on index view

### DIFF
--- a/src/api/app/helpers/webui/maintenance_incident_helper.rb
+++ b/src/api/app/helpers/webui/maintenance_incident_helper.rb
@@ -1,7 +1,7 @@
 module Webui::MaintenanceIncidentHelper
   def incident_label(incident_project, patchinfo)
     incident_number = incident_project.name.rpartition(':').last
-    title = patchinfo.dig(:summary) || incident_project.title || incident_project.name
+    title = patchinfo.dig(:summary).presence || incident_project.title || incident_project.name
 
     "#{incident_number}: #{title}"
   end


### PR DESCRIPTION
Some of the patchinfos in build.o.o have an empty summary.
In such a case the incident summary would look like '6005: {}'.
This patch ensures that we only show the summary when it's not empty.



<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md
-->
