### PR TITLE
Markdown now detects two consecutive mentions to users

### DIFF
--- a/src/api/lib/obsapi/markdown_renderer.rb
+++ b/src/api/lib/obsapi/markdown_renderer.rb
@@ -12,7 +12,7 @@ module OBSApi
       # request#12345 links
       fulldoc.gsub!(/(sr|req|request)#(\d+)/i) { |s| "[#{s}](#{request_show_url(number: Regexp.last_match(2))})" }
       # @user links
-      fulldoc.gsub!(/([^\w]|^)@([-\w]+)([^\w]|$)/) \
+      fulldoc.gsub!(/([^\w]|^)?@([-\w]+)([^\w]|$)/) \
                    { "#{Regexp.last_match(1)}[@#{Regexp.last_match(2)}](#{user_show_url(Regexp.last_match(2))})#{Regexp.last_match(3)}" }
       # bnc#12345 links
       IssueTracker.all.each do |t|

--- a/src/api/spec/helpers/webui/markdown_helper_spec.rb
+++ b/src/api/spec/helpers/webui/markdown_helper_spec.rb
@@ -14,6 +14,15 @@ RSpec.describe Webui::MarkdownHelper do
       )
     end
 
+    it 'detects all the metions to users' do
+      expect(render_as_markdown('@alfie @milo and @Admin, please review.')).to eq(
+        "<p><a href='https://unconfigured.openbuildservice.org/user/show/alfie'>@alfie</a> \
+<a href='https://unconfigured.openbuildservice.org/user/show/milo'>@milo</a> \
+and <a href='https://unconfigured.openbuildservice.org/user/show/Admin'>@Admin</a>, \
+please review.</p>\n"
+      )
+    end
+
     it 'does not crash due to invalid URIs' do
       expect(render_as_markdown("anbox[400000+22d000]\r\n(the number)")).to eq(
         "<p>anbox<a href='the number'>400000+22d000</a></p>\n"


### PR DESCRIPTION
When we had "@user1 @user2" it didn't detect the second mention. Only if there were another character between them like in "@user1, @user2".

**Before:**

![Screenshot-2019-4-29 Request 7 (review)](https://user-images.githubusercontent.com/2581944/56893921-946e6180-6a84-11e9-96a1-0b666e3c3ba2.png)

**After:**

![Screenshot-2019-4-29 Request 7 (review)(1)](https://user-images.githubusercontent.com/2581944/56893926-99331580-6a84-11e9-996d-2585b4d994af.png)


Fixes: #7463
