### PR TITLE
Move link for incident creation to maintenance incidents index page

### DIFF
--- a/src/api/app/views/webui2/webui/project/bottom_actions/_create_maintenance_incident.html.haml
+++ b/src/api/app/views/webui2/webui/project/bottom_actions/_create_maintenance_incident.html.haml
@@ -1,4 +1,0 @@
-%li.list-inline-item
-  = link_to(project_maintenance_incidents_path(project.name), method: :post, class: 'nav-link') do
-    %i.fas.fa-plus-circle.text-primary
-    Create Maintenance Incident

--- a/src/api/app/views/webui2/webui/project/bottom_actions/_modify_project.html.haml
+++ b/src/api/app/views/webui2/webui/project/bottom_actions/_modify_project.html.haml
@@ -1,8 +1,6 @@
 - unless project.defines_remote_instance?
   - if project.is_maintenance_incident? && packages.present? && has_patchinfo && open_release_requests.blank?
     = render partial: 'webui2/webui/project/bottom_actions/request_to_release', locals: { project: project }
-  - elsif project.is_maintenance?
-    = render partial: 'webui2/webui/project/bottom_actions/create_maintenance_incident', locals: { project: project }
   - else
     = render partial: 'webui2/webui/project/bottom_actions/patchinfo', locals: { project: project, has_patchinfo: has_patchinfo }
     = render partial: 'webui2/webui/project/bottom_actions/submit_as_update', locals: { release_targets: release_targets, project: project }

--- a/src/api/app/views/webui2/webui/projects/maintenance_incidents/index.html.haml
+++ b/src/api/app/views/webui2/webui/projects/maintenance_incidents/index.html.haml
@@ -25,6 +25,13 @@
           %th
             Release Targets
       %tbody
+    - if policy(@project).create?
+      .pt-4
+        %ul.list-inline
+          %li.list-inline-item
+            = link_to(project_maintenance_incidents_path(@project.name), method: :post, class: 'nav-link') do
+              %i.fas.fa-plus-circle.text-primary
+              Create Maintenance Incident
 
 - content_for :ready_function do
   :plain

--- a/src/api/spec/bootstrap/features/webui/projects_spec.rb
+++ b/src/api/spec/bootstrap/features/webui/projects_spec.rb
@@ -78,7 +78,7 @@ RSpec.feature 'Bootstrap_Projects', type: :feature, js: true, vcr: true do
       expect(page).to have_css('#flash', text: "Created maintenance incident project #{project.name}:maintenance_project:0")
 
       # We can not create this via the Bootstrap UI, except by adding plain XML to the meta editor
-      repository = create(:repository, project: Project.find_by(name: "#{project.name}:maintenance_project:0"))
+      repository = create(:repository, project: Project.find_by(name: "#{project.name}:maintenance_project:0"), name: 'target')
       create(:release_target, repository: repository, target_repository: target_repository, trigger: 'maintenance')
 
       visit project_show_path(maintenance_project)

--- a/src/api/spec/bootstrap/features/webui/projects_spec.rb
+++ b/src/api/spec/bootstrap/features/webui/projects_spec.rb
@@ -64,4 +64,31 @@ RSpec.feature 'Bootstrap_Projects', type: :feature, js: true, vcr: true do
       expect(page).to have_current_path(project_show_path('home:Jane'))
     end
   end
+
+  describe 'maintenance incidents' do
+    let(:maintenance_project) { create(:maintenance_project, name: "#{project.name}:maintenance_project") }
+    let(:target_repository) { create(:repository) }
+
+    scenario 'visiting the maintenance overview' do
+      login user
+
+      visit project_show_path(maintenance_project)
+      click_link('Incidents')
+      click_link('Create Maintenance Incident')
+      expect(page).to have_css('#flash', text: "Created maintenance incident project #{project.name}:maintenance_project:0")
+
+      # We can not create this via the Bootstrap UI, except by adding plain XML to the meta editor
+      repository = create(:repository, project: Project.find_by(name: "#{project.name}:maintenance_project:0"))
+      create(:release_target, repository: repository, target_repository: target_repository, trigger: 'maintenance')
+
+      visit project_show_path(maintenance_project)
+      click_link('Incidents')
+
+      within('#incident-table') do
+        maintenance_project.maintenance_incidents.each do |incident|
+          expect(page).to have_link("0: #{incident.name}", href: project_show_path(incident.name))
+        end
+      end
+    end
+  end
 end

--- a/src/api/spec/cassettes/Bootstrap_Projects/maintenance_incidents/visiting_the_maintenance_overview.yml
+++ b/src/api/spec/cassettes/Bootstrap_Projects/maintenance_incidents/visiting_the_maintenance_overview.yml
@@ -1,0 +1,298 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://backend:5352/build/home:Jane:maintenance_project/_result?code=unresolvable&view=status
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '56'
+    body:
+      encoding: UTF-8
+      string: '<resultlist state="00000000000000000000000000000000" />
+
+'
+    http_version: 
+  recorded_at: Wed, 15 May 2019 09:16:33 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:Jane:maintenance_project/_keyinfo?donotcreatecert=1&withsslcert=1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '12'
+    body:
+      encoding: UTF-8
+      string: "<keyinfo />\n"
+    http_version: 
+  recorded_at: Wed, 15 May 2019 09:16:33 GMT
+- request:
+    method: get
+    uri: http://backend:5352/build/home:Jane:maintenance_project/_result?view=summary
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '56'
+    body:
+      encoding: UTF-8
+      string: '<resultlist state="00000000000000000000000000000000" />
+
+'
+    http_version: 
+  recorded_at: Wed, 15 May 2019 09:16:33 GMT
+- request:
+    method: get
+    uri: http://backend:5352/build/home:Jane:maintenance_project:0/_result?code=unresolvable&view=status
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '56'
+    body:
+      encoding: UTF-8
+      string: '<resultlist state="00000000000000000000000000000000" />
+
+'
+    http_version: 
+  recorded_at: Wed, 15 May 2019 09:16:34 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:Jane:maintenance_project:0/_keyinfo?donotcreatecert=1&withsslcert=1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '12'
+    body:
+      encoding: UTF-8
+      string: "<keyinfo />\n"
+    http_version: 
+  recorded_at: Wed, 15 May 2019 09:16:34 GMT
+- request:
+    method: get
+    uri: http://backend:5352/build/home:Jane:maintenance_project:0/_result?view=summary
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '56'
+    body:
+      encoding: UTF-8
+      string: '<resultlist state="00000000000000000000000000000000" />
+
+'
+    http_version: 
+  recorded_at: Wed, 15 May 2019 09:16:34 GMT
+- request:
+    method: get
+    uri: http://backend:5352/build/home:Jane:maintenance_project/_result?code=unresolvable&view=status
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '56'
+    body:
+      encoding: UTF-8
+      string: '<resultlist state="00000000000000000000000000000000" />
+
+'
+    http_version: 
+  recorded_at: Wed, 15 May 2019 09:16:35 GMT
+- request:
+    method: get
+    uri: http://backend:5352/build/home:Jane:maintenance_project/_result?view=summary
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '56'
+    body:
+      encoding: UTF-8
+      string: '<resultlist state="00000000000000000000000000000000" />
+
+'
+    http_version: 
+  recorded_at: Wed, 15 May 2019 09:16:35 GMT
+- request:
+    method: get
+    uri: http://backend:5352/build/home:Jane:maintenance_project:0/_result?code=unresolvable&repository=repository_1&view=summary
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 404
+      message: unknown repository 'repository_1'
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '144'
+    body:
+      encoding: UTF-8
+      string: |
+        <status code="404">
+          <summary>unknown repository 'repository_1'</summary>
+          <details>404 unknown repository 'repository_1'</details>
+        </status>
+    http_version: 
+  recorded_at: Wed, 15 May 2019 09:16:35 GMT
+recorded_with: VCR 4.0.0

--- a/src/api/spec/cassettes/Bootstrap_Projects/maintenance_incidents/visiting_the_maintenance_overview.yml
+++ b/src/api/spec/cassettes/Bootstrap_Projects/maintenance_incidents/visiting_the_maintenance_overview.yml
@@ -1,6 +1,168 @@
 ---
 http_interactions:
 - request:
+    method: put
+    uri: http://backend:5352/source/home:Jane/_meta?user=Jane
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:Jane">
+          <title/>
+          <description/>
+          <person userid="Jane" role="maintainer"/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '131'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:Jane">
+          <title></title>
+          <description></description>
+          <person userid="Jane" role="maintainer" />
+        </project>
+    http_version: 
+  recorded_at: Mon, 20 May 2019 20:02:30 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:user_1/_meta?user=user_1
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:user_1">
+          <title/>
+          <description/>
+          <person userid="user_1" role="maintainer"/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '135'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:user_1">
+          <title></title>
+          <description></description>
+          <person userid="user_1" role="maintainer" />
+        </project>
+    http_version: 
+  recorded_at: Mon, 20 May 2019 20:02:30 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:Jane:maintenance_project/_meta?user=Jane
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:Jane:maintenance_project" kind="maintenance">
+          <title>Death Be Not Proud</title>
+          <description/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '143'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:Jane:maintenance_project" kind="maintenance">
+          <title>Death Be Not Proud</title>
+          <description></description>
+        </project>
+    http_version: 
+  recorded_at: Mon, 20 May 2019 20:02:33 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:Jane:maintenance_project/_project/_attribute?meta=1&user=Jane
+    body:
+      encoding: UTF-8
+      string: |
+        <attributes>
+          <attribute name="MaintenanceProject" namespace="OBS"/>
+        </attributes>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '166'
+    body:
+      encoding: UTF-8
+      string: |
+        <revision rev="4">
+          <srcmd5>a7bfa5457f16c4fabe56a3eef3cbbf43</srcmd5>
+          <time>1558382553</time>
+          <user>Jane</user>
+          <comment></comment>
+          <requestid/>
+        </revision>
+    http_version: 
+  recorded_at: Mon, 20 May 2019 20:02:33 GMT
+- request:
     method: get
     uri: http://backend:5352/build/home:Jane:maintenance_project/_result?code=unresolvable&view=status
     body:
@@ -32,7 +194,7 @@ http_interactions:
 
 '
     http_version: 
-  recorded_at: Wed, 15 May 2019 09:16:33 GMT
+  recorded_at: Mon, 20 May 2019 20:02:33 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Jane:maintenance_project/_keyinfo?donotcreatecert=1&withsslcert=1
@@ -63,7 +225,7 @@ http_interactions:
       encoding: UTF-8
       string: "<keyinfo />\n"
     http_version: 
-  recorded_at: Wed, 15 May 2019 09:16:33 GMT
+  recorded_at: Mon, 20 May 2019 20:02:33 GMT
 - request:
     method: get
     uri: http://backend:5352/build/home:Jane:maintenance_project/_result?view=summary
@@ -96,7 +258,60 @@ http_interactions:
 
 '
     http_version: 
-  recorded_at: Wed, 15 May 2019 09:16:33 GMT
+  recorded_at: Mon, 20 May 2019 20:02:33 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:Jane:maintenance_project:0/_meta?user=Jane
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:Jane:maintenance_project:0" kind="maintenance_incident">
+          <title/>
+          <description/>
+          <person userid="Jane" role="bugowner"/>
+          <build>
+            <disable/>
+          </build>
+          <publish>
+            <disable/>
+          </publish>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '257'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:Jane:maintenance_project:0" kind="maintenance_incident">
+          <title></title>
+          <description></description>
+          <person userid="Jane" role="bugowner" />
+          <build>
+            <disable />
+          </build>
+          <publish>
+            <disable />
+          </publish>
+        </project>
+    http_version: 
+  recorded_at: Mon, 20 May 2019 20:02:34 GMT
 - request:
     method: get
     uri: http://backend:5352/build/home:Jane:maintenance_project:0/_result?code=unresolvable&view=status
@@ -129,7 +344,7 @@ http_interactions:
 
 '
     http_version: 
-  recorded_at: Wed, 15 May 2019 09:16:34 GMT
+  recorded_at: Mon, 20 May 2019 20:02:34 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Jane:maintenance_project:0/_keyinfo?donotcreatecert=1&withsslcert=1
@@ -160,7 +375,7 @@ http_interactions:
       encoding: UTF-8
       string: "<keyinfo />\n"
     http_version: 
-  recorded_at: Wed, 15 May 2019 09:16:34 GMT
+  recorded_at: Mon, 20 May 2019 20:02:34 GMT
 - request:
     method: get
     uri: http://backend:5352/build/home:Jane:maintenance_project:0/_result?view=summary
@@ -193,7 +408,46 @@ http_interactions:
 
 '
     http_version: 
-  recorded_at: Wed, 15 May 2019 09:16:34 GMT
+  recorded_at: Mon, 20 May 2019 20:02:34 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/project_1/_meta?user=Jane
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="project_1">
+          <title>A Time to Kill</title>
+          <description/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '100'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="project_1">
+          <title>A Time to Kill</title>
+          <description></description>
+        </project>
+    http_version: 
+  recorded_at: Mon, 20 May 2019 20:02:34 GMT
 - request:
     method: get
     uri: http://backend:5352/build/home:Jane:maintenance_project/_result?code=unresolvable&view=status
@@ -226,7 +480,7 @@ http_interactions:
 
 '
     http_version: 
-  recorded_at: Wed, 15 May 2019 09:16:35 GMT
+  recorded_at: Mon, 20 May 2019 20:02:34 GMT
 - request:
     method: get
     uri: http://backend:5352/build/home:Jane:maintenance_project/_result?view=summary
@@ -259,10 +513,10 @@ http_interactions:
 
 '
     http_version: 
-  recorded_at: Wed, 15 May 2019 09:16:35 GMT
+  recorded_at: Mon, 20 May 2019 20:02:35 GMT
 - request:
     method: get
-    uri: http://backend:5352/build/home:Jane:maintenance_project:0/_result?code=unresolvable&repository=repository_1&view=summary
+    uri: http://backend:5352/build/home:Jane:maintenance_project:0/_result?code=unresolvable&repository=target&view=summary
     body:
       encoding: US-ASCII
       string: ''
@@ -276,7 +530,7 @@ http_interactions:
   response:
     status:
       code: 404
-      message: unknown repository 'repository_1'
+      message: unknown repository 'target'
     headers:
       Content-Type:
       - text/xml
@@ -285,14 +539,14 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '144'
+      - '132'
     body:
       encoding: UTF-8
       string: |
         <status code="404">
-          <summary>unknown repository 'repository_1'</summary>
-          <details>404 unknown repository 'repository_1'</details>
+          <summary>unknown repository 'target'</summary>
+          <details>404 unknown repository 'target'</details>
         </status>
     http_version: 
-  recorded_at: Wed, 15 May 2019 09:16:35 GMT
+  recorded_at: Mon, 20 May 2019 20:02:35 GMT
 recorded_with: VCR 4.0.0


### PR DESCRIPTION
It seems to fit there better than on the general project view.

Before:

![2019-04-29_14-34](https://user-images.githubusercontent.com/968949/56896455-10b87300-6a8c-11e9-8b96-3851b17c7596.png)

![2019-04-29_14-34_1](https://user-images.githubusercontent.com/968949/56896481-1ca43500-6a8c-11e9-9e89-02529f9c2305.png)

After:

![2019-04-29_14-35_1](https://user-images.githubusercontent.com/968949/56896516-32195f00-6a8c-11e9-8845-d4a7916edf72.png)

![2019-04-29_14-35](https://user-images.githubusercontent.com/968949/56896508-2cbc1480-6a8c-11e9-9efb-10c433a1dae0.png)
