### PR TITLE
Split number of request into incoming/outgoing #4602

### DIFF
--- a/src/api/app/controllers/webui/project_controller.rb
+++ b/src/api/app/controllers/webui/project_controller.rb
@@ -654,7 +654,9 @@ class Webui::ProjectController < Webui::WebuiController
     @linking_projects = @project.linked_by_projects.pluck(:name)
 
     reqs = @project.open_requests
-    @requests = (reqs[:reviews] + reqs[:targets] + reqs[:incidents] + reqs[:maintenance_release]).sort!.uniq
+    @incoming_requests = reqs[:incidents] | reqs[:maintenance_release]
+    @outgoing_requests = reqs[:targets] | reqs[:reviews]
+    @requests = @incoming_requests | @outgoing_requests
 
     @nr_of_problem_packages = @project.number_of_build_problems
   end

--- a/src/api/app/controllers/webui/project_controller.rb
+++ b/src/api/app/controllers/webui/project_controller.rb
@@ -653,9 +653,8 @@ class Webui::ProjectController < Webui::WebuiController
     @ipackages = @project.expand_all_packages.find_all { |ip| !@packages.map { |p| p[0] }.include?(ip[0]) }
     @linking_projects = @project.linked_by_projects.pluck(:name)
 
-    reqs = @project.open_requests
-    @incoming_requests = reqs[:incidents] | reqs[:maintenance_release]
-    @outgoing_requests = reqs[:targets] | reqs[:reviews]
+    @incoming_requests = @project.incoming_requests
+    @outgoing_requests = @project.outgoing_requests
     @requests = @incoming_requests | @outgoing_requests
 
     @nr_of_problem_packages = @project.number_of_build_problems

--- a/src/api/app/models/project.rb
+++ b/src/api/app/models/project.rb
@@ -1253,17 +1253,17 @@ class Project < ApplicationRecord
 
   def outgoing_requests
     incidents = BsRequest.with_involved_projects(id)
-    .or(BsRequest.from_source_project(name))
-    .in_states(:new)
-    .with_types(:maintenance_incident)
-    .pluck(:number)
+                         .or(BsRequest.from_source_project(name))
+                         .in_states(:new)
+                         .with_types(:maintenance_incident)
+                         .pluck(:number)
 
     if is_maintenance?
       maintenance_release = BsRequest.with_target_subprojects(name + ':%')
-                      .or(BsRequest.with_source_subprojects(name + ':%'))
-                      .in_states(:new)
-                      .with_types(:maintenance_release)
-                      .pluck(:number)
+                                     .or(BsRequest.with_source_subprojects(name + ':%'))
+                                     .in_states(:new)
+                                     .with_types(:maintenance_release)
+                                     .pluck(:number)
     else
       maintenance_release = []
     end

--- a/src/api/app/views/webui2/webui/project/_side_links.html.haml
+++ b/src/api/app/views/webui2/webui/project/_side_links.html.haml
@@ -22,6 +22,8 @@
 
   - if requests.present?
     = render partial: 'webui2/webui/project/side_links/requests', locals: { requests: requests,
+                                                                            incoming_requests: incoming_requests,
+                                                                            outgoing_requests: outgoing_requests,
                                                                             project: project,
                                                                             package: package }
 

--- a/src/api/app/views/webui2/webui/project/show.html.haml
+++ b/src/api/app/views/webui2/webui/project/show.html.haml
@@ -27,6 +27,8 @@
                                                   open_release_requests: @open_release_requests,
                                                   release_targets: @releasetargets,
                                                   requests: @requests,
+                                                  incoming_requests: @incoming_requests,
+                                                  outgoing_requests: @outgoing_requests,
                                                   package: @package,
                                                   linking_projects: @linking_projects,
                                                   project_maintenance_project: @project_maintenance_project }

--- a/src/api/app/views/webui2/webui/project/side_links/_requests.html.haml
+++ b/src/api/app/views/webui2/webui/project/side_links/_requests.html.haml
@@ -7,6 +7,11 @@
     else
       path = project_requests_path(project)
     end
-  %i.fa.fa-info-circle.text-info
-  = link_to(path) do
-    = pluralize(requests.size, 'open request')
+  %li
+    %i.fa.fa-info-circle.text-info
+    = link_to(path) do
+      = pluralize(incoming_requests.size, 'Incoming request')
+  %li
+    %i.fa.fa-info-circle.text-info
+    = link_to(path) do
+      = pluralize(outgoing_requests.size, 'Outgoing request')


### PR DESCRIPTION
Add incoming_requests and outgoing_requests variables dividing `requests`
variable: reqs incidents and maintanance_release to incoming and targets and
reviews in the outgoing.
Use these variables in show, side_links and requests views.
change requests value as incomin+outgoing requests

Closes #4602