### PR TITLE
Make subproject tables responsive

### DIFF
--- a/src/api/app/views/webui2/webui/project/_projects_table.html.haml
+++ b/src/api/app/views/webui2/webui/project/_projects_table.html.haml
@@ -1,6 +1,6 @@
 %h3 #{table_title.pluralize} of #{project}
 - table_id = table_title.tr(' ', '_')
-%table.responsive.table.table-sm.table-striped.table-bordered.projects-table{ data: { source: project_subprojects_path(project,
+%table.responsive.table.table-sm.table-striped.table-bordered{ data: { source: project_subprojects_path(project,
   type: table_title.downcase) }, id: table_id }
   %thead
     %tr

--- a/src/api/app/views/webui2/webui/project/_projects_table.html.haml
+++ b/src/api/app/views/webui2/webui/project/_projects_table.html.haml
@@ -1,6 +1,6 @@
 %h3 #{table_title.pluralize} of #{project}
 - table_id = table_title.tr(' ', '_')
-%table.responsive.table.table-sm.table-striped.table-bordered{ data: { source: project_subprojects_path(project,
+%table.responsive.table.table-sm.table-striped.table-bordered.w-100{ data: { source: project_subprojects_path(project,
   type: table_title.downcase) }, id: table_id }
   %thead
     %tr

--- a/src/api/app/views/webui2/webui/project/list.html.haml
+++ b/src/api/app/views/webui2/webui/project/list.html.haml
@@ -32,14 +32,13 @@
             Add New Project
           = render partial: 'new_project_modal', locals: { configuration: @configuration }
 
-    #project-list
-      %table.responsive.table.table-sm.table-striped.table-bordered.w-100#projects-datatable{ data: { source: projects_path(format: :json),
-                                                                                                      all: 'false' } }
-        %thead
-          %tr
-            %th Name
-            %th Title
-        %tbody
+    %table.responsive.table.table-sm.table-striped.table-bordered.w-100#projects-datatable{ data: { source: projects_path(format: :json),
+                                                                                                    all: 'false' } }
+      %thead
+        %tr
+          %th Name
+          %th Title
+      %tbody
 
 - content_for :ready_function do
   initializeProjectDatatable();


### PR DESCRIPTION
A `w-100` CSS class was missing.

Fixes #7518.