### PR TITLE
Apply background color in the diff section when switching between tabs of a request

### DIFF
--- a/src/api/app/assets/javascripts/webui/application/request.js
+++ b/src/api/app/assets/javascripts/webui/application/request.js
@@ -203,7 +203,7 @@ function setupActionLink() { // jshint ignore:line
     $('#action_display_' + index).show();
     // It is necessary to refresh the CodeMirror editors after switching tabs to initialise the dimensions again.
     // Otherwise the editors are empty after calling show().
-    editors.forEach( function(editor) { editor.refresh(); });
+    editors.forEach( function(editor) { editor.refresh(); cm_mark_diff_lines(); });
     return false;
   });
 }

--- a/src/api/app/assets/javascripts/webui/application/request.js
+++ b/src/api/app/assets/javascripts/webui/application/request.js
@@ -203,7 +203,7 @@ function setupActionLink() { // jshint ignore:line
     $('#action_display_' + index).show();
     // It is necessary to refresh the CodeMirror editors after switching tabs to initialise the dimensions again.
     // Otherwise the editors are empty after calling show().
-    editors.forEach( function(editor) { editor.refresh(); cm_mark_diff_lines(); });
+    editors.forEach( function(editor) { editor.refresh(); cmMarkDiffLines(); }); // jshint ignore:line
     return false;
   });
 }

--- a/src/api/app/assets/javascripts/webui2/cm2/use-codemirror.js
+++ b/src/api/app/assets/javascripts/webui2/cm2/use-codemirror.js
@@ -9,7 +9,7 @@ window.onbeforeunload = function() {
   }
 }
 
-function cm_mark_diff_lines() {
+function cmMarkDiffLines() {
   // as we can't use css to mark parents we use javascript to propagate diff lines
   $('.cm-positive').parents('.CodeMirror-line').addClass('CodeMirror-positive-line');
   $('.cm-negative').parents('.CodeMirror-line').addClass('CodeMirror-negative-line');
@@ -37,8 +37,8 @@ function use_codemirror(id, read_only, mode) {
   var editor = CodeMirror.fromTextArea(document.getElementById("editor_" + id), codeMirrorOptions);
   editor.id = id;
 
-  cm_mark_diff_lines();
-  editor.on('scroll', cm_mark_diff_lines);
+  cmMarkDiffLines();
+  editor.on('scroll', cmMarkDiffLines);
 
   if (!read_only) {
     editor.setSelections(editor);

--- a/src/api/app/views/webui2/webui/request/show.html.haml
+++ b/src/api/app/views/webui2/webui/request/show.html.haml
@@ -91,5 +91,5 @@
 = content_for :ready_function do
   :plain
     $('.request-tab').on('shown.bs.tab', function() {
-      editors.forEach( function(editor) { editor.refresh(); });
+      editors.forEach( function(editor) { editor.refresh(); cm_mark_diff_lines(); });
     });

--- a/src/api/app/views/webui2/webui/request/show.html.haml
+++ b/src/api/app/views/webui2/webui/request/show.html.haml
@@ -91,5 +91,5 @@
 = content_for :ready_function do
   :plain
     $('.request-tab').on('shown.bs.tab', function() {
-      editors.forEach( function(editor) { editor.refresh(); cm_mark_diff_lines(); });
+      editors.forEach( function(editor) { editor.refresh(); cmMarkDiffLines(); });
     });


### PR DESCRIPTION
When there's a submission with several packages, the diff highlighting gets partially removed when switching between tabs. This means, the color highlighting is there, but the background color is gone. This PR fixes the issue.

Fixes #7500.

![request_tabs_background](https://user-images.githubusercontent.com/24919/57142415-b5082580-6dbc-11e9-9850-4666d4b55bc1.gif)
