### PR TITLE
Replace release_targets_ng method with SQL queries

### DIFF
--- a/src/api/app/datatables/maintenance_incident_datatable.rb
+++ b/src/api/app/datatables/maintenance_incident_datatable.rb
@@ -24,7 +24,7 @@ class MaintenanceIncidentDatatable < Datatable
       {
         summary: summary_cell(record, patchinfo),
         category: category_cell(record, patchinfo),
-        packages: packages_cell(record, release_targets_ng),
+        packages: packages_cell(record),
         info: info_cell(record, patchinfo),
         release_targets: release_targets_cell(record, release_targets_ng)
       }

--- a/src/api/app/datatables/maintenance_incident_datatable.rb
+++ b/src/api/app/datatables/maintenance_incident_datatable.rb
@@ -19,14 +19,13 @@ class MaintenanceIncidentDatatable < Datatable
   def data
     records.map do |record|
       patchinfo = patchinfo_data(record.patchinfos.first)
-      release_targets_ng = record.release_targets_ng
 
       {
         summary: summary_cell(record, patchinfo),
         category: category_cell(record, patchinfo),
         packages: packages_cell(record),
         info: info_cell(record, patchinfo),
-        release_targets: release_targets_cell(record, release_targets_ng)
+        release_targets: release_targets_cell(record)
       }
     end
   end

--- a/src/api/app/helpers/webui/maintenance_incident_helper.rb
+++ b/src/api/app/helpers/webui/maintenance_incident_helper.rb
@@ -58,13 +58,13 @@ module Webui::MaintenanceIncidentHelper
     end
   end
 
-  def packages_cell(incident, release_targets_ng)
-    release_target = release_targets_ng.values.first
-    return if release_target[:packages].blank?
-    first_pkg = release_target[:packages].first
+  def packages_cell(incident)
+    packages = incident.packages_with_release_target.limit(2).pluck(:name)
+    return if packages.empty?
+    first_package = packages.first
     safe_join([
-                link_to(first_pkg.name.split('.', 2)[0], package_show_path(project: incident.name, package: first_pkg.name)),
-                (', ...' if release_target[:packages].length > 1)
+                link_to(first_package.split('.', 2)[0], package_show_path(project: incident.name, package: first_package)),
+                (', ...' if packages.length > 1)
               ])
   end
 

--- a/src/api/app/helpers/webui/maintenance_incident_helper.rb
+++ b/src/api/app/helpers/webui/maintenance_incident_helper.rb
@@ -6,8 +6,8 @@ module Webui::MaintenanceIncidentHelper
     "#{incident_number}: #{title}"
   end
 
-  def incident_build_icon_class(incident, release_target)
-    incident.build_succeeded?(release_target[:reponame]) ? 'text-success fa-check' : 'text-danger fa-exclamation-circle'
+  def incident_build_icon_class(incident, release_target_repo)
+    incident.build_succeeded?(release_target_repo) ? 'text-success fa-check' : 'text-danger fa-exclamation-circle'
   end
 
   def open_requests_icon(incident)
@@ -79,17 +79,17 @@ module Webui::MaintenanceIncidentHelper
     end
   end
 
-  def release_targets_cell(incident, release_targets_ng)
+  def release_targets_cell(incident)
     safe_join(
       [
-        release_targets_ng.map do |release_target_project, release_target_ng|
+        incident.target_repositories.map do |target_repo|
           content_tag(:div) do
             safe_join(
               [
                 link_to(project_show_path(project: incident.name)) do
-                  content_tag(:i, nil, class: "fas pr-1 #{incident_build_icon_class(incident, release_target_ng)}", title: 'Build results')
+                  content_tag(:i, nil, class: "fas pr-1 #{incident_build_icon_class(incident, target_repo.name)}", title: 'Build results')
                 end,
-                link_to(release_target_project, project_show_path(project: release_target_project))
+                link_to(target_repo.project, project_show_path(project: target_repo.project))
               ]
             )
           end

--- a/src/api/app/models/project.rb
+++ b/src/api/app/models/project.rb
@@ -44,6 +44,7 @@ class Project < ApplicationRecord
   has_many :attribs, dependent: :destroy
 
   has_many :repositories, dependent: :destroy, foreign_key: :db_project_id
+  has_many :release_targets, through: :repositories
   has_many :path_elements, through: :repositories
   has_many :linked_repositories, through: :path_elements, source: :link, foreign_key: :repository_id
   has_many :repository_architectures, -> { order('position') }, through: :repositories
@@ -1365,33 +1366,17 @@ class Project < ApplicationRecord
       repo.release_targets.each do |rt|
         release_targets_ng[rt.target_repository.project.name] = {
           reponame: repo.name,
-          packages: [],
           package_issues: {},
           package_issues_by_tracker: {}
         }
       end
     end
 
-    # One catch, currently there's only one patchinfo per incident, but things keep changing every
-    # other day, so it never hurts to have a look into the future:
-    package_count = 0
-    packages.where.not(id: patchinfos).select(:name, :id).each do |pkg|
-      # Current ui is only showing the first found package and a symbol for any additional package.
-      break if package_count > 2
-
-      rt_name = pkg.name.split('.', 2).last
-      next unless rt_name
-      # Here we try hard to find the release target our current package is build for:
-      rt_name = guess_release_target_from_package(pkg, release_targets_ng)
-
-      # Build-disabled packages can't be matched to release targets....
-      next unless rt_name
-      # Let's silently hope that an incident newer introduces new (sub-)packages....
-      release_targets_ng[rt_name][:packages] << pkg
-      package_count += 1
-    end
-
     release_targets_ng
+  end
+
+  def packages_with_release_target
+    packages.joins(:flags).where(flags: { flag: :build, status: 'enable', repo: release_targets.select(:name) })
   end
 
   def self.source_path(project, file = nil, opts = {})
@@ -1604,26 +1589,6 @@ class Project < ApplicationRecord
 
   def discard_cache
     Relationship.discard_cache
-  end
-
-  # Go through all enabled build flags and look for a repo name that matches a
-  # previously parsed release target name (from "release_targets_ng").
-  #
-  # If one was found return the project name, otherwise return nil.
-  def guess_release_target_from_package(package, parsed_targets)
-    # Stone cold map'o'rama of package.$SOMETHING with package/build/enable/@repository=$ANOTHERTHING to
-    # project/repository/releasetarget/@project=$YETSOMETINGDIFFERENT. Piece o' cake, eh?
-    target_mapping = {}
-    parsed_targets.each do |rt_key, rt_value|
-      target_mapping[rt_value[:reponame]] = rt_key
-    end
-
-    package.flags.where(flag: :build, status: 'enable').find_each do |flag|
-      rt_key = target_mapping[flag.repo]
-      return rt_key if rt_key
-    end
-
-    nil
   end
 
   def has_remote_distribution(project_name, repository)

--- a/src/api/app/views/webui/projects/maintenance_incidents/_incident_table_entries.html.erb
+++ b/src/api/app/views/webui/projects/maintenance_incidents/_incident_table_entries.html.erb
@@ -22,13 +22,7 @@
                 <% end %>
               </td>
               <td rowspan="<%= release_targets_ng.length %>">
-                  <% unless rt[:packages].blank? %>
-                    <% first_pkg = rt[:packages].first %>
-                    <%= link_to(first_pkg.name.split('.', 2)[0], package_show_path(project: incident.name, package: first_pkg.name)) %>
-                    <% if rt[:packages].length > 1 %>
-                        , ...
-                    <% end %>
-                <% end %>
+                <%= packages_cell(incident) %>
               </td>
               <td rowspan="<%= release_targets_ng.length %>" class="nowrap">
                 <% rqs_in = BsRequest.list_numbers(roles: %w(target), states: %w(new review), project: incident.name) %>

--- a/src/api/app/views/webui/projects/maintenance_incidents/_incident_table_entries.html.erb
+++ b/src/api/app/views/webui/projects/maintenance_incidents/_incident_table_entries.html.erb
@@ -1,16 +1,17 @@
 <% incidents.each do |incident| %>
     <% index = 0 %>
-    <% release_targets_ng = incident.release_targets_ng() %>
+    <% release_targets = incident.target_repositories %>
+    <% row_count = release_targets.count %>
     <% patchinfo = patchinfo_data(incident.patchinfos.first) %>
-    <% release_targets_ng.each do |rt_name, rt| %>
+    <% release_targets.each do |release_target| %>
         <tr>
           <% if index == 0 %>
-              <td rowspan="<%= release_targets_ng.length %>">
+              <td rowspan="<%= row_count %>">
                 <% title =  patchinfo.dig(:summary).presence || incident.title || incident.name %>
                 <% title = "#{short_incident_name(incident)}: #{title}" %>
                 <%= link_to(elide(title, 60, :right), project_show_path(project: incident.name), title: title) %>
               </td>
-              <td rowspan="<%= release_targets_ng.length %>">
+              <td rowspan="<%= row_count %>">
                 <% if patchinfo.present? %>
                     <%= link_to(patchinfo[:category],
                           patchinfo_show_path(project: incident.name, package: "patchinfo", file: "_patchinfo"),
@@ -21,10 +22,10 @@
                           { style: 'color: red;', method: :post }) %>
                 <% end %>
               </td>
-              <td rowspan="<%= release_targets_ng.length %>">
+              <td rowspan="<%= row_count %>">
                 <%= packages_cell(incident) %>
               </td>
-              <td rowspan="<%= release_targets_ng.length %>" class="nowrap">
+              <td rowspan="<%= row_count %>" class="nowrap">
                 <% rqs_in = BsRequest.list_numbers(roles: %w(target), states: %w(new review), project: incident.name) %>
                 <% if rqs_in.count > 0 %>
                     <% if rqs_in.count == 1 %>
@@ -52,10 +53,10 @@
                 <% end %>
               </td>
           <% end %>
-          <td><b><%= rt_name %></b></td>
+          <td><b><%= release_target.project %></b></td>
           <td>
-            <% buildresult_css_id = "incident_#{valid_xml_id(incident.name)}_results_#{valid_xml_id(rt_name)}" %>
-            <% if incident.build_succeeded?(rt[:reponame]) %>
+            <% buildresult_css_id = "incident_#{valid_xml_id(incident.name)}_results_#{valid_xml_id(release_target.project)}" %>
+            <% if incident.build_succeeded?(release_target.name) %>
                 <%= link_to(sprite_tag('tick', title: 'Build results', id: buildresult_css_id), project_show_path(project: incident.name)) %>
             <% else %>
                 <%= link_to(sprite_tag('exclamation', title: 'Build results', id: buildresult_css_id), project_show_path(project: incident.name)) %>

--- a/src/api/spec/bootstrap/features/webui/projects_spec.rb
+++ b/src/api/spec/bootstrap/features/webui/projects_spec.rb
@@ -67,7 +67,7 @@ RSpec.feature 'Bootstrap_Projects', type: :feature, js: true, vcr: true do
 
   describe 'maintenance incidents' do
     let(:maintenance_project) { create(:maintenance_project, name: "#{project.name}:maintenance_project") }
-    let(:target_repository) { create(:repository) }
+    let(:target_repository) { create(:repository, name: 'theone') }
 
     scenario 'visiting the maintenance overview' do
       login user

--- a/src/api/spec/cassettes/Bootstrap_Projects/maintenance_incidents/visiting_the_maintenance_overview.yml
+++ b/src/api/spec/cassettes/Bootstrap_Projects/maintenance_incidents/visiting_the_maintenance_overview.yml
@@ -516,7 +516,7 @@ http_interactions:
   recorded_at: Mon, 20 May 2019 20:02:35 GMT
 - request:
     method: get
-    uri: http://backend:5352/build/home:Jane:maintenance_project:0/_result?code=unresolvable&repository=target&view=summary
+    uri: http://backend:5352/build/home:Jane:maintenance_project:0/_result?code=unresolvable&repository=theone&view=summary
     body:
       encoding: US-ASCII
       string: ''

--- a/src/api/spec/factories/flag.rb
+++ b/src/api/spec/factories/flag.rb
@@ -1,6 +1,5 @@
 FactoryBot.define do
   factory :flag do
-    project
     position { 1 }
     status { 'enable' }
 

--- a/src/api/spec/factories/project.rb
+++ b/src/api/spec/factories/project.rb
@@ -130,9 +130,6 @@ FactoryBot.define do
       end
 
       before(:create) do |project, evaluator|
-        create(:build_flag, project: project, status: 'disable')
-        create(:publish_flag, project: project, status: 'disable')
-
         if evaluator.maintenance_project
           evaluator.maintenance_project.relationships.each do |role|
             project.relationships.create(user: role.user, role: role.role, group: role.group)
@@ -147,6 +144,10 @@ FactoryBot.define do
       transient do
         target_project { nil }
         create_patchinfo { false }
+      end
+
+      before(:create) do |project|
+        create(:build_flag, project: project, status: 'disable')
       end
 
       after(:create) do |project, evaluator|

--- a/src/api/spec/models/project/maintenance_incidents_spec.rb
+++ b/src/api/spec/models/project/maintenance_incidents_spec.rb
@@ -1,0 +1,22 @@
+require 'rails_helper'
+require 'rantly/rspec_extensions'
+
+RSpec.describe Project, vcr: true do
+  let(:maintenance_incident) { create(:maintenance_incident_project) }
+  let!(:target_repo_1) { create(:repository_with_release_target, project: maintenance_incident) }
+  let!(:target_repo_2) { create(:repository_with_release_target, project: maintenance_incident) }
+
+  describe '#packages_with_release_target' do
+    let(:package_1) { create(:package, name: "my_package_1.#{target_repo_1}", project: maintenance_incident) }
+    let!(:build_flag_1) { create(:build_flag, package: package_1, repo: target_repo_1) }
+    let(:package_2) { create(:package, name: "my_package_2.#{target_repo_2}", project: maintenance_incident) }
+    let!(:build_flag_2) { create(:build_flag, package: package_2, repo: target_repo_2) }
+    let(:package_3) { create(:package, name: "my_package_3.#{target_repo_2}", project: maintenance_incident) }
+
+    subject { maintenance_incident.packages_with_release_target }
+
+    context 'returns all packages that build for release target repositories of the incident' do
+      it { is_expected.to contain_exactly(package_1, package_2) }
+    end
+  end
+end

--- a/src/api/test/unit/project_test.rb
+++ b/src/api/test/unit/project_test.rb
@@ -346,35 +346,6 @@ class ProjectTest < ActiveSupport::TestCase
     project2.destroy
   end
 
-  def test_release_targets_ng
-    User.session = User.find_by_login('king')
-
-    project = Project.create(name: 'ABC', kind: 'maintenance')
-    project.store
-
-    subproject = Project.create(name: 'ABC:D', kind: 'maintenance_incident')
-    subproject.store
-
-    repo_1 = Repository.create(name: 'repo_1', db_project_id: subproject.id)
-    repo_2 = Repository.create(name: 'repo_2', db_project_id: subproject.id)
-    repo_1.release_targets.create(trigger: 'maintenance', target_repository_id: repo_2.id)
-
-    package = subproject.packages.create(name: 'test2')
-    package.flags.create(flag: :build, status: 'enable', repo: 'repo_1')
-
-    result = subproject.reload.release_targets_ng
-    assert_equal ['ABC:D'], result.keys
-    assert_equal 'repo_1',  result['ABC:D'][:reponame]
-
-    assert_equal 1, result['ABC:D'][:packages].count
-    assert_equal package.id, result['ABC:D'][:packages].first.id
-    assert_equal 'test2', result['ABC:D'][:packages].first.name
-  ensure
-    # Prevent AAAPreConsistency check to fail
-    project.destroy
-    subproject.destroy
-  end
-
   def test_flags_to_axml
     # check precondition
     assert_equal 2, @project.flags.of_type('build').size


### PR DESCRIPTION
Instead of (sql) querying the data first and then using hashes to map and evaluate the data as needed we now have two separate queries that fetch the incident packages and the release target project names individually.
As a result the code becomes much shorter and more readable.