### PR TITLE
Add lang="en" to webui page template

### DIFF
--- a/src/api/app/views/layouts/webui/webui.html.erb
+++ b/src/api/app/views/layouts/webui/webui.html.erb
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
     <% if @metarobots %>


### PR DESCRIPTION
I saw webui2 already added `lang="en"` to `<html>` root element. https://github.com/openSUSE/open-build-service/blob/master/src/api/app/views/layouts/webui2/webui.html.haml#L2

It will help browser understand the page language and choose proper fonts, time format, spell checking, etc.



<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md
-->
