### PR TITLE
Revert "Remember number of shown entries for project monitor datatable"

### DIFF
--- a/src/api/app/assets/javascripts/webui2/project_monitor.js
+++ b/src/api/app/assets/javascripts/webui2/project_monitor.js
@@ -38,7 +38,7 @@ function initializeMonitorDataTable() {
   initializeDataTable('#project-monitor-table', { // jshint ignore:line
     scrollX: true,
     fixedColumns: true,
-    pageLength: $('#shown-entries').val(),
+    pageLength: 50,
     lengthMenu: [[10, 25, 50, 100, -1], [10, 25, 50, 100, "All"]],
     data: packageNames,
     search: {
@@ -70,10 +70,6 @@ function initializeMonitorDataTable() {
 
 function setupProjectMonitor() { // jshint ignore:line
   initializeMonitorDataTable();
-
-  $('select[name="project-monitor-table_length"]').change(function(){
-    $('#shown-entries').val($(this).val());
-  });
 
   $('#table-spinner').addClass('d-none');
   $('#project-monitor .obs-dataTable').removeClass('invisible');

--- a/src/api/app/controllers/webui/project_controller.rb
+++ b/src/api/app/controllers/webui/project_controller.rb
@@ -365,7 +365,6 @@ class Webui::ProjectController < Webui::WebuiController
     end
 
     monitor_parse_buildresult(buildresult)
-    @shown_entries = params.fetch('shown-entries', 50)
 
     # extract repos
     repohash = {}

--- a/src/api/app/views/webui2/webui/project/_monitor_control.html.haml
+++ b/src/api/app/views/webui2/webui/project/_monitor_control.html.haml
@@ -2,7 +2,6 @@
   .col-md-12
     = form_tag(project_monitor_path, project: project, method: :get) do
       = hidden_field_tag :defaults, 0
-      = hidden_field_tag 'shown-entries', shown_entries
       %span.dropdown#project-monitor-status-dropdown
         %button.btn.btn-outline-secondary.dropdown-toggle{ data: { toggle: :dropdown }, type: :button }
           %span.caret

--- a/src/api/app/views/webui2/webui/project/monitor.html.haml
+++ b/src/api/app/views/webui2/webui/project/monitor.html.haml
@@ -8,7 +8,7 @@
       %p Unavailable Build Results.
     - else
       = render partial: 'monitor_control',
-        locals: { project: @project, activate_client_search: @activate_client_search, shown_entries: @shown_entries,
+        locals: { project: @project, activate_client_search: @activate_client_search,
         status: @avail_status_values, repositories: @avail_repo_values, architectures: @avail_arch_values,
         repository_filter: @repo_filter, architecture_filter: @arch_filter, status_filter: @status_filter }
       - tableinfo = []


### PR DESCRIPTION
This reverts commit caeef35e173e52c93c57b146e8c9393ee5e831ae.

We now use DataTables state saving which stores the last used pagination
entries count. Therefor we can drop our custom code for this.

  https://datatables.net/examples/basic_init/state_save.html


Fixes #7555
