### PR TITLE
Validate patchinfo summary, not description, in both webui and XML

### DIFF
--- a/src/api/app/models/patchinfo.rb
+++ b/src/api/app/models/patchinfo.rb
@@ -8,6 +8,7 @@ class Patchinfo
 
   class PatchinfoFileExists < APIError; end
   class IncompletePatchinfo < APIError; end
+  class InvalidPatchinfoSummary < APIError; end
 
   class ReleasetargetNotFound < APIError
     setup 404
@@ -45,7 +46,6 @@ class Patchinfo
                 :issueid, :issuetracker, :issueurl, :issuesum
 
   validates :summary, length: { minimum: 10 }
-  validates :description, length: { minimum: 50 }
   validates :packager, presence: true
   validate :issue_tracker_existence
 
@@ -91,6 +91,8 @@ class Patchinfo
       raise TrackerNotFound, "Tracker #{i['tracker']} is not registered in this OBS instance" unless tracker
       raise IssueTracker::InvalidIssueName, "The issue name is not supported: #{i['id']}" unless tracker.valid_issue_name?(i['id'])
     end
+    # validates presence and length of summary
+    raise InvalidPatchinfoSummary, 'Summary should contain at least 10 characters' if data['summary'].length < 10
     # are releasetargets specified ? validate that this project is actually defining them.
     data.elements('releasetarget') { |r| check_releasetarget!(r) }
   end

--- a/src/api/app/views/webui/patchinfo/_form.html.haml
+++ b/src/api/app/views/webui/patchinfo/_form.html.haml
@@ -28,7 +28,7 @@
             %strong
               = image_tag('info.png', title: 'Enter a full description what the update fixes', alt: 'Descriptioninfo')
               = f.label(:description, 'Description:')
-            = f.text_area :description, size: '65x9', required: true, minlength: 50
+            = f.text_area :description, size: '65x9'
           %p
             %strong
               = image_tag('info.png', title: 'Enter a version of this update', alt: 'Versioninfo')

--- a/src/api/spec/features/webui/patchinfo_spec.rb
+++ b/src/api/spec/features/webui/patchinfo_spec.rb
@@ -15,13 +15,10 @@ RSpec.feature 'Patchinfo', type: :feature, js: true do
       expect(page).to have_current_path(edit_patchinfo_path(project: project, package: 'patchinfo'))
       expect(page).to have_text("Edit Patchinfo for #{project.name}")
       fill_in 'patchinfo[summary]', with: 'A' * 9
-      fill_in 'patchinfo[description]', with: 'A' * 30
       click_button 'Save'
       # We check this field using 'minlength' HTML5 control. It opens a tooltip and the error message inside can vary depending on the browser,
       # so we just check its presence and not its content like follows.
       message = page.find('#patchinfo_summary').native.attribute('validationMessage')
-      expect(message).not_to be_empty
-      message = page.find('#patchinfo_description').native.attribute('validationMessage')
       expect(message).not_to be_empty
     end
 
@@ -33,7 +30,6 @@ RSpec.feature 'Patchinfo', type: :feature, js: true do
       expect(page).to have_current_path(edit_patchinfo_path(project: project, package: 'patchinfo'))
       expect(page).to have_text("Edit Patchinfo for #{project.name}")
       fill_in 'patchinfo[summary]', with: 'A' * 15
-      fill_in 'patchinfo[description]', with: 'A' * 55
       click_button 'Save'
       expect(page).to have_current_path(patchinfo_show_path(project: project, package: 'patchinfo'))
       expect(page).to have_text('Successfully edited patchinfo')


### PR DESCRIPTION
According to the usage and the feedback coming from users, it seems that
only the summary field is compulsory. So we ensure summary is present
from webui and XML.