### PR TITLE
Display review box only for requests which are new or in review

### DIFF
--- a/src/api/app/controllers/webui/request_controller.rb
+++ b/src/api/app/controllers/webui/request_controller.rb
@@ -96,7 +96,6 @@ class Webui::RequestController < Webui::WebuiController
     @is_author = @bs_request.creator == User.possibly_nobody.login
 
     @is_target_maintainer = @bs_request.is_target_maintainer?(User.session)
-    @can_add_reviews = @bs_request.state.in?([:new, :review]) && (@is_author || @is_target_maintainer || @my_open_reviews.present?)
     @can_handle_request = @bs_request.state.in?([:new, :review, :declined]) && (@is_target_maintainer || @is_author)
 
     @history = @bs_request.history_elements.includes(:user)
@@ -118,6 +117,7 @@ class Webui::RequestController < Webui::WebuiController
     reviews = @bs_request.reviews.where(state: 'new')
     user = User.session # might be nil
     @my_open_reviews = reviews.select { |review| review.matches_user?(user) }
+    @can_add_reviews = @bs_request.state.in?([:new, :review]) && (@is_author || @is_target_maintainer || @my_open_reviews.present?)
   end
 
   def sourcediff

--- a/src/api/app/views/webui/request/show.html.erb
+++ b/src/api/app/views/webui/request/show.html.erb
@@ -192,7 +192,7 @@
                     <a class="review_descision_link" id="review_descision_link_-1" href="#">My Decision</a>
                   </li>
               <% end %>
-              <% if @my_open_reviews.length > 0 %>
+              <% if @can_add_reviews && @my_open_reviews.length > 0 %>
                   <% @my_open_reviews.each_with_index do |open_review, index| %>
                       <li class="<%= 'selected' if @my_open_reviews.length > 0 && index == 0 %>">
                         <a class="review_descision_link" id="review_descision_link_<%= index %>" href="#">
@@ -248,23 +248,25 @@
               <% end %>
           <% end %>
         </div>
-        <% @my_open_reviews.each_with_index do |review, index| %>
-            <div class="review_descision_display <%= 'hidden' if index != 0 %>" id="review_descision_display_<%= index %>">
-              <%= form_tag(action: 'modify_review') do %>
-                  <% if review[:creator] %>
-                    <p><%= user_with_realname_and_icon(review[:creator], short: true) %> requested:</p>
-                    <p><%= simple_format(review[:reason] || 'No reason given') %></p>
-                  <% end %>
-                  <p><%= text_area_tag('comment', '', size: '80x2', style: 'width: 99%', class: 'review_comment', placeholder: 'Please comment on your decision') %></p>
+        <% if @can_add_reviews %>
+          <% @my_open_reviews.each_with_index do |review, index| %>
+              <div class="review_descision_display <%= 'hidden' if index != 0 %>" id="review_descision_display_<%= index %>">
+                <%= form_tag(action: 'modify_review') do %>
+                    <% if review[:creator] %>
+                      <p><%= user_with_realname_and_icon(review[:creator], short: true) %> requested:</p>
+                      <p><%= simple_format(review[:reason] || 'No reason given') %></p>
+                    <% end %>
+                    <p><%= text_area_tag('comment', '', size: '80x2', style: 'width: 99%', class: 'review_comment', placeholder: 'Please comment on your decision') %></p>
 
-                  <p>
-                    <%= hidden_field_tag("request_number", @bs_request.number) %>
-                    <%= hidden_review_payload(review) %>
-                    <%= submit_tag 'Approve', name: 'new_state', class: 'review_accept_button', title: 'Give this request your blessing, it will continue.' %>
-                    <%= submit_tag 'Disregard', name: 'new_state', title: 'Veto this request, it will be declined.' %>
-                  </p>
-              <% end %>
-            </div>
+                    <p>
+                      <%= hidden_field_tag("request_number", @bs_request.number) %>
+                      <%= hidden_review_payload(review) %>
+                      <%= submit_tag 'Approve', name: 'new_state', class: 'review_accept_button', title: 'Give this request your blessing, it will continue.' %>
+                      <%= submit_tag 'Disregard', name: 'new_state', title: 'Veto this request, it will be declined.' %>
+                    </p>
+                <% end %>
+              </div>
+          <% end %>
         <% end %>
       </div>
     </div>

--- a/src/api/app/views/webui2/webui/request/show.html.haml
+++ b/src/api/app/views/webui2/webui/request/show.html.haml
@@ -46,7 +46,7 @@
   .col-md-8
     .card.mb-3
       = render partial: 'request_comments', locals: { comments: @comments, bs_request: @bs_request }
-    - if @can_handle_request || @my_open_reviews.any?
+    - if @can_handle_request || (@can_add_reviews && @my_open_reviews.any?)
       .card.mb-3
         .bg-light
           %ul.nav.nav-tabs{ role: 'tablist' }
@@ -54,17 +54,16 @@
               %li.nav-item
                 %a.nav-link.text-nowrap.active{ href: '#decision', data: { toggle: 'tab' }, role: 'tab' }
                   My decision
-            - @my_open_reviews.each_with_index do |review, index|
-              %li.nav-item
-                %a.nav-link.text-nowrap{ href: "#review-#{index}", data: { toggle: 'tab' }, role: 'tab',
-                  class: ('active' if index.zero? && !@can_handle_request) }
-                  Review for
-                  - if review.by_package
-                    = review.by_project
-                    /
-                    = review.by_package
-                  - else
-                    = review.by_user || review.by_group || review.by_project
+            - if @can_add_reviews
+              - @my_open_reviews.each_with_index do |review, index|
+                %li.nav-item
+                  %a.nav-link.text-nowrap{ href: "#review-#{index}", data: { toggle: 'tab' }, role: 'tab',
+                    class: ('active' if index.zero? && !@can_handle_request) }
+                    Review for
+                    - if review.by_package
+                      #{review.by_project}/#{review.by_package}
+                    - else
+                      = review.by_user || review.by_group || review.by_project
         .card-body
           - if @can_handle_request && @show_project_maintainer_hint
             .alert.alert-warning
@@ -77,9 +76,10 @@
                 = render('decision_tab', request_number: @bs_request.number, request_creator: @bs_request.creator,
                          is_target_maintainer: @is_target_maintainer, state: @bs_request.state.to_s,
                          is_author: @is_author, single_action_request: @actions.count == 1, action: @actions.first)
-            - @my_open_reviews.each_with_index do |review, index|
-              .tab-pane.fade.show{ id: "review-#{index}", class: ('active' if index.zero? && !@can_handle_request) }
-                = render('review_tab', review: review, bs_request: @bs_request)
+            - if @can_add_reviews
+              - @my_open_reviews.each_with_index do |review, index|
+                .tab-pane.fade.show{ id: "review-#{index}", class: ('active' if index.zero? && !@can_handle_request) }
+                  = render('review_tab', review: review, bs_request: @bs_request)
 
   .col-md-4
     .card


### PR DESCRIPTION
Closes #7442

Try it in the review app by submitting a request to the project `home:Iggy` for the package `ruby` by superseding the existing request (Do it [here](https://obs-reviewlab.opensuse.org/dmarcoux-issue-7442/package/show/home:Admin/ruby)). Then add a review for the current user (I suggest using `Admin`). You should see the review tab, but as soon as you supersede the request, the review form won't be visible anymore.