### PR TITLE
Add webui2 version of kiwi images

### DIFF
--- a/src/api/app/assets/javascripts/webui2/application.js
+++ b/src/api/app/assets/javascripts/webui2/application.js
@@ -50,3 +50,4 @@
 //= require webui2/patchinfo.js
 //= require webui2/image_templates.js
 //= require rails-timeago
+//= require webui2/kiwi_editor.js

--- a/src/api/app/assets/javascripts/webui2/autocomplete.js
+++ b/src/api/app/assets/javascripts/webui2/autocomplete.js
@@ -1,4 +1,4 @@
-$(document).ready(function() {
+function setupAutocomplete() {
   $('.obs-autocomplete').each(function() {
     $(this).autocomplete({
       // Note: 'append' is optional and only needed when there is no element with class ui-front
@@ -13,6 +13,11 @@ $(document).ready(function() {
       }
     });
   });
+}
+
+$(document).ready(function() {
+
+  setupAutocomplete();
 
   $('.repository-autocomplete').on('autocompleteselect autocompletechange', function(event, ui) {
     var projectName,

--- a/src/api/app/assets/javascripts/webui2/kiwi_editor.js
+++ b/src/api/app/assets/javascripts/webui2/kiwi_editor.js
@@ -1,0 +1,301 @@
+var canSave = false;
+
+function hideOverlay() {
+  $('.modal.show').modal('hide');
+}
+
+function saveImage() { // jshint ignore:line
+  if (canSave) {
+    $.ajax({ url: isOutdatedUrl,
+      dataType: 'json',
+      success: function(json) {
+        var isOutdated = json.isOutdated;
+        if (isOutdated && !window.confirm("This image has been modified while you were editing it.\nDo you want to apply the changes anyway?"))
+          return;
+        $('#kiwi-image-update-form').submit();
+      }
+    });
+  }
+}
+
+function enableSave() {
+  canSave = true;
+  $('#kiwi-image-update-form-save, #kiwi-image-update-form-revert').removeClass('disabled');
+}
+
+function editRepositoryDialog() { // jshint ignore:line
+  var fields = $(this).parents('.nested-fields');
+  var dialog = fields.find('.modal');
+  var sourcePath = fields.find("[id$='source_path']");
+
+  dialog.modal('show');
+  var matchedObsSourcePath = sourcePath.val().match(/^obs:\/\/([^\/]+)\/([^\/]+)$/);
+  if (matchedObsSourcePath) {
+    var projectField = fields.find('[name=target_project]');
+    var repoField = fields.find('[name=target_repo]');
+    var aliasField = fields.find('[name=alias_for_repo]');
+    var expertRepoAlias = fields.find("[id$='alias']");
+    var repoTypeField = fields.find("[id$='repo_type']");
+    aliasField.val(expertRepoAlias.val());
+    projectField.val(matchedObsSourcePath[1]);
+    repoField.html('');
+    repoField.append(new Option(matchedObsSourcePath[2]));
+    repoField.val(matchedObsSourcePath[2]);
+    repoTypeField.val('rpm-md');
+  }
+
+  $('span[role=status]').text(''); // empty autocomplete status
+}
+
+function addRepositoryErrorMessage(sourcePath, field) {
+  if (sourcePath === 'obsrepositories:/') {
+    field.text('If you want use obsrepositories:/ as source_path, please check the checkbox "use project repositories".');
+  }
+  else {
+    field.text('The source path can not be empty!');
+  }
+
+  field.removeClass('d-none');
+}
+
+function closeKiwiDescriptionDialog() { // jshint ignore:line
+  var fields = $(this).parents('.nested-fields');
+  var dialog = fields.find('.modal.show');
+  var name = dialog.find("[id$='name']");
+
+  if (name.val() !== '') {
+    $('#image-name').text(name.val());
+  }
+  else {
+    fields.find(".ui-state-error").removeClass('d-none');
+    return false;
+  }
+
+  var elements = fields.find('.fill');
+  for(var i=0; i < elements.length; i++) {
+    var object = dialog.find("[id$='" + $(elements[i]).data('tag') + "']");
+    if ( object.val() !== "") {
+      $(elements[i]).text(object.val());
+    }
+  }
+
+  addDefault(dialog);
+
+  if (!canSave) {
+    enableSave();
+  }
+
+  fields.find(".ui-state-error").addClass('d-none');
+
+  hideOverlay();
+}
+
+function closeKiwiPreferencesDialog() { // jshint ignore:line
+  var fields = $(this).parents('.nested-fields');
+  var dialog = fields.find('.modal.show');
+
+  var elements = fields.find('.fill');
+  for(var i=0; i < elements.length; i++) {
+    var object = dialog.find("[id$='_" + i + "_" + $(elements[i]).data('tag') + "']");
+    if ( object.val() !== "") {
+      if ( $(elements[i]).data('tag') === 'type_image' ) {
+        $(elements[i]).text(object.find(":selected").text());
+      }
+      else {
+        $(elements[i]).text(object.val());
+      }
+    }
+  }
+
+  addDefault(dialog);
+
+  if (!canSave) {
+    enableSave();
+  }
+
+  hideOverlay();
+}
+
+function closeKiwiDialog() { // jshint ignore:line
+  var fields = $(this).parents('.nested-fields'),
+      isRepository = fields.parents('#kiwi-repositories-list').length === 1,
+      name = fields.find('.kiwi_element_name'),
+      dialog = fields.find('.modal.show'),
+      arch;
+
+  if(isRepository) {
+    var sourcePath = dialog.find("[id$='source_path']");
+    if(sourcePath.val() !== '' && sourcePath.val() !== 'obsrepositories:/') {
+      var alias = dialog.find("[id$='alias']");
+      if (alias.val() !== '') {
+        name.text(alias.val());
+      }
+      else {
+        name.text(sourcePath.val().replace(/\//g, '_'));
+      }
+    }
+    else {
+      addRepositoryErrorMessage(sourcePath.val(), fields.find(".ui-state-error"));
+      return false;
+    }
+  }
+  else {
+    var namePackage = dialog.find("[id$='name']").val();
+    if(namePackage !== '') {
+      name.text(namePackage);
+
+      arch = dialog.find("[id$='arch']").val();
+      if(arch !== '') {
+        name.append(" <small>(" + arch + ")</small>");
+      }
+    }
+    else {
+      fields.find(".ui-state-error").removeClass('d-none');
+      return false;
+    }
+  }
+
+  addDefault(dialog);
+
+  if( /^Add/.test(dialog.find('.modal-title').text())) {
+    dialog.find('.modal-title').text('Edit '+ dialog.find('.modal-title').text().split(' ')[1]);
+  }
+
+  fields.find(".ui-state-error").addClass('d-none');
+  fields.find('.kiwi_list_item').removeClass('has-error');
+  dialog.removeClass('new_element');
+
+  if (!canSave) {
+    enableSave();
+  }
+
+  hideOverlay();
+}
+
+function revertDialog() { // jshint ignore:line
+  var fields = $(this).parents('.nested-fields');
+  var dialog = fields.find('.modal');
+  dialog.find(".ui-state-error").addClass('d-none');
+
+  if(dialog.hasClass('new_element')) {
+    hideOverlay(dialog);
+
+    fields.find('.remove_fields').click();
+  }
+  else {
+    $.each(dialog.find('input, select'), function(index, input) {
+      if (input.type === 'checkbox') {
+        $(input).prop('checked', input.getAttribute('data-default') === 'true');
+      }
+      else {
+        $(input).val(input.getAttribute('data-default'));
+      }
+    });
+
+    hideOverlay();
+  }
+}
+
+function addDefault(dialog) {
+  $.each(dialog.find('input, select'), function(index, input) {
+    if (input.type === 'checkbox') {
+      input.setAttribute('data-default', input.checked);
+    }
+    else {
+      input.setAttribute('data-default', $(input).val());
+    }
+  });
+}
+
+function showOnAddition(list, show) { // jshint ignore:line
+  list.on('cocoon:after-remove', function() {
+    if ($(this).find('.nested-fields:visible').length === 0) {
+      show.removeClass('d-none');
+    }
+  });
+}
+
+function initializeTabs() { // jshint ignore:line
+  $("#kiwi-details-trigger").click(function() {
+    $("#kiwi-image-details-section").removeClass('d-none');
+    $("#kiwi-preferences").removeClass('d-none');
+    $(".detailed-info").removeClass('d-none');
+    $("#kiwi-image-profiles-section").addClass('d-none');
+    $("#kiwi-image-repositories-section").addClass('d-none');
+    $("#kiwi-image-packages-section").addClass('d-none');
+    $("#kiwi-software-trigger").removeClass("active");
+    $("#kiwi-details-trigger").addClass("active");
+  });
+
+  $("#kiwi-software-trigger").click(function() {
+    $("#kiwi-image-profiles-section").removeClass('d-none');
+    $("#kiwi-image-repositories-section").removeClass('d-none');
+    $("#kiwi-image-packages-section").removeClass('d-none');
+    $("#kiwi-preferences").addClass('d-none');
+    $(".detailed-info").addClass('d-none');
+    $("#kiwi-image-details-section").addClass('d-none');
+    $("#kiwi-software-trigger").addClass("active");
+    $("#kiwi-details-trigger").removeClass("active");
+  });
+}
+
+function initializeKiwi(isOutdatedUrl) { // jshint ignore:line
+  // Save image
+  $('#kiwi-image-update-form-save').click(saveImage);
+  $('#kiwi_image_use_project_repositories').click(function(){
+    $('#kiwi-repositories-list, #use-project-repositories-text').toggleClass('d-none');
+    enableSave();
+  });
+
+  $('[id^="kiwi_image_profiles_attributes_"]').click(enableSave);
+
+  // Revert image
+  $('#kiwi-image-update-form-revert').click(function(){
+    if (!$(this).hasClass('disabled')) {
+      if (window.confirm('Attention! All unsaved data will be lost! Continue?')) {
+        window.location.reload();
+      }
+    }
+  });
+
+  // Enable save button
+  $('.remove_fields').click(enableSave);
+
+  // Edit dialog for Description
+  $('.close-description-dialog').click(closeKiwiDescriptionDialog);
+
+  // Edit dialog for Description
+  $('.close-preferences-dialog').click(closeKiwiPreferencesDialog);
+
+  // Edit dialog for Repositories and Packages
+  $('.repository_edit').click(editRepositoryDialog);
+  $('#kiwi-repositories-list .close-dialog, #kiwi-packages-list .close-dialog').click(closeKiwiDialog);
+  $('.revert-dialog').click(revertDialog);
+
+  // After inserting new repositories add the Callbacks
+  $('#kiwi-repositories-list').on('cocoon:after-insert', function(e, addedFields) {
+    var lastOrder = 0;
+    var orders = $(this).find("[id$='order']");
+    var lastNode = $(orders[orders.length - 2]);
+    if (lastNode.length > 0) {
+      lastOrder = parseInt(lastNode.val());
+    }
+    $(addedFields).find("[id$='order']").val(lastOrder + 1);
+    $(addedFields).find('.repository_edit').click(editRepositoryDialog);
+    $(addedFields).find('.close-dialog').click(closeKiwiDialog);
+    $(addedFields).find('.revert-dialog').click(revertDialog);
+    $('#no-repositories').addClass('d-none');
+  });
+
+  showOnAddition($('#kiwi-repositories-list'), $('#no-repositories'));
+
+  // After inserting new packages add the Callbacks
+  $('#kiwi-packages-list').on('cocoon:after-insert', function(e, addedFields) {
+    $(addedFields).find('.close-dialog').click(closeKiwiDialog);
+    $(addedFields).find('.revert-dialog').click(revertDialog);
+    $('#no-packages').addClass('d-none');
+  });
+
+  showOnAddition($('#kiwi-packages-list'), $('#no-packages'));
+}
+

--- a/src/api/app/controllers/webui/kiwi/images_controller.rb
+++ b/src/api/app/controllers/webui/kiwi/images_controller.rb
@@ -90,13 +90,12 @@ module Webui
       end
 
       def build_result
+        switch_to_webui2
         if @image.package.project.repositories.any?
           @build_results = @image.build_results
-          switch_to_webui2 if params[:switch].present?
           render partial: 'build_status'
         else
           @project = @image.package.project
-          switch_to_webui2 if params[:switch].present?
           render partial: '/webui/package/no_repositories'
         end
       end

--- a/src/api/app/controllers/webui/kiwi/images_controller.rb
+++ b/src/api/app/controllers/webui/kiwi/images_controller.rb
@@ -47,7 +47,7 @@ module Webui
         @is_edit_software_action = false
 
         respond_to do |format|
-          format.html
+          format.html { switch_to_webui2 }
           format.json { render json: { isOutdated: @image.outdated? } }
         end
       end
@@ -65,7 +65,7 @@ module Webui
         @is_edit_software_action = params[:section] == 'software'
 
         respond_to do |format|
-          format.html
+          format.html { switch_to_webui2 }
         end
       end
 
@@ -92,9 +92,11 @@ module Webui
       def build_result
         if @image.package.project.repositories.any?
           @build_results = @image.build_results
+          switch_to_webui2 if params[:switch].present?
           render partial: 'build_status'
         else
           @project = @image.package.project
+          switch_to_webui2 if params[:switch].present?
           render partial: '/webui/package/no_repositories'
         end
       end

--- a/src/api/app/controllers/webui/package_controller.rb
+++ b/src/api/app/controllers/webui/package_controller.rb
@@ -945,13 +945,13 @@ class Webui::PackageController < Webui::WebuiController
       show_all = params[:show_all] == 'true'
       @index = params[:index]
       @buildresults = @package.buildresult(@project, show_all)
-      switch_to_webui2 if params[:switch].present?
+      switch_to_webui2
       render partial: 'buildstatus', locals: { buildresults: @buildresults,
                                                index: @index,
                                                project: @project,
                                                collapsed_repositories: params.fetch(:collapsedRepositories, {}) }
     else
-      switch_to_webui2 if params[:switch].present?
+      switch_to_webui2
       render partial: 'no_repositories', locals: { project: @project }
     end
   end
@@ -976,7 +976,7 @@ class Webui::PackageController < Webui::WebuiController
       [repo_name, valid_xml_id(elide(repo_name, 30))]
     end
 
-    return if params[:switch].present? && switch_to_webui2
+    return if switch_to_webui2
 
     if @repo_list.empty?
       render partial: 'no_repositories', locals: { project: @project }

--- a/src/api/app/controllers/webui/project_controller.rb
+++ b/src/api/app/controllers/webui/project_controller.rb
@@ -190,7 +190,7 @@ class Webui::ProjectController < Webui::WebuiController
   end
 
   def buildresult
-    switch_to_webui2 if params[:switch].present?
+    switch_to_webui2
     render partial: 'buildstatus', locals: { project: @project,
                                              buildresults: @project.buildresults,
                                              collapsed_repositories: params.fetch(:collapsedRepositories, {}) }

--- a/src/api/app/views/webui/kiwi/images/show.html.haml
+++ b/src/api/app/views/webui/kiwi/images/show.html.haml
@@ -1,10 +1,9 @@
 - @layouttype = 'custom'
 
-= form_for @image, html: { id: 'kiwi-image-update-form' } do |f|
-  .grid_16.alpha.omega.box.box-shadow
-    = render partial: 'webui/kiwi/tabs'
-    = render partial: 'base_info'
-  .grid_10.alpha.box.box-shadow
-    = render partial: 'details_overview'
-  .grid_6.omega.box.box-shadow
-    = render partial: 'build_info'
+.grid_16.alpha.omega.box.box-shadow
+  = render partial: 'webui/kiwi/tabs'
+  = render partial: 'base_info'
+.grid_10.alpha.box.box-shadow
+  = render partial: 'details_overview'
+.grid_6.omega.box.box-shadow
+  = render partial: 'build_info'

--- a/src/api/app/views/webui2/shared/_buildresult_box.html.haml
+++ b/src/api/app/views/webui2/shared/_buildresult_box.html.haml
@@ -1,7 +1,6 @@
 :ruby
   index ||= ''
   ajax_data = {}
-  ajax_data['switch'] = 'true' # FIXME: Remove this when request show is available in bootstrap
   ajax_data['project'] = h(project) if defined?(project)
   ajax_data['package'] = h(package) if defined?(package)
   ajax_data['index'] = h(index) if defined?(index)

--- a/src/api/app/views/webui2/webui/kiwi/_tabs.html.haml
+++ b/src/api/app/views/webui2/webui/kiwi/_tabs.html.haml
@@ -1,0 +1,13 @@
+.bg-light
+  %ul.nav.nav-tabs.pt-2.px-3.flex-nowrap.collapsible{ 'role': 'tablist' }
+    %li.nav-item
+      = link_to('Overview', { controller: 'kiwi/images', action: 'show' }, class: "nav-link #{'active' if action_name == 'show'}")
+    %li.nav-item
+      = link_to 'Details', action_name == 'edit' ? '#' : { controller: 'kiwi/images', action: 'edit', section: 'details' },
+        id: 'kiwi-details-trigger', class: "nav-link #{'active' if params[:section] == 'details'}"
+    %li.nav-item
+      = link_to 'Software', action_name == 'edit' ? '#' : { controller: 'kiwi/images', action: 'edit', section: 'software' },
+        id: 'kiwi-software-trigger', class: "nav-link #{'active' if params[:section] == 'software'}"
+
+= content_for :ready_function do
+  initializeTabs();

--- a/src/api/app/views/webui2/webui/kiwi/images/_base_info.html.haml
+++ b/src/api/app/views/webui2/webui/kiwi/images/_base_info.html.haml
@@ -1,0 +1,30 @@
+#kiwi-description
+  .nested-fields
+    %h2#image-name
+      = image.name
+    %p.detailed-info{ class: "#{'d-none' if is_edit_software_action}" }
+      %span.fill{ data: { tag: 'specification' } }
+        = description
+    %ul.list-inline{ class: "#{'d-none' unless is_edit_details_action}" }
+      %li.list-inline-item
+        %strong Author:
+        %span.fill{ data: { tag: 'author' } }= author
+      %li.list-inline-item
+        %strong Contact:
+        %span.fill{ data: { tag: 'contact' } }= contact
+    %ul.list-inline.mb-0
+      %li.list-inline-item
+        = link_to(package_show_path(package.project, package)) do
+          %i.text-warning.fa.fa-archive
+          View package
+      %li.list-inline-item{ class: "#{'d-none' unless is_edit_details_action}" }
+        = link_to('#', data: { 'target': '#description-edit', 'toggle': 'modal' }) do
+          %i.text-info.fa.fa-cog
+          Edit details
+      - if Feature.active?(:cloud_upload) && User.session
+        %li.list-inline-item
+          = link_to(cloud_upload_index_path, id: 'cloud-upload') do
+            %i.text-info.fa.fa-cloud
+            Cloud upload
+    - if action_name == 'edit'
+      = render partial: 'description_form', locals: { f: f }

--- a/src/api/app/views/webui2/webui/kiwi/images/_breadcrumb_items.html.haml
+++ b/src/api/app/views/webui2/webui/kiwi/images/_breadcrumb_items.html.haml
@@ -1,0 +1,10 @@
+- @project = @image.package.try(:project)
+- @package = @image.package
+= render partial: 'webui/main/breadcrumb_items'
+
+%li.breadcrumb-item
+  = link_to(@image.package.try(:project), project_show_path(project: @image.package.try(:project)))
+%li.breadcrumb-item
+  = link_to(@package, package_show_path(project: @project, package: @package))
+%li.breadcrumb-item.active{ 'aria-current' => 'page' }
+  = @image.name

--- a/src/api/app/views/webui2/webui/kiwi/images/_build_info.html.haml
+++ b/src/api/app/views/webui2/webui/kiwi/images/_build_info.html.haml
@@ -1,7 +1,6 @@
 :ruby
   index ||= ''
   ajax_data = {}
-  ajax_data['switch'] = 'true' # FIXME: Remove this when request show is available in bootstrap
   ajax_data['project'] = h(project) if defined?(project)
   ajax_data['package'] = h(package) if defined?(package)
   ajax_data['index'] = h(index) if defined?(index)

--- a/src/api/app/views/webui2/webui/kiwi/images/_build_info.html.haml
+++ b/src/api/app/views/webui2/webui/kiwi/images/_build_info.html.haml
@@ -1,0 +1,26 @@
+:ruby
+  index ||= ''
+  ajax_data = {}
+  ajax_data['switch'] = 'true' # FIXME: Remove this when request show is available in bootstrap
+  ajax_data['project'] = h(project) if defined?(project)
+  ajax_data['package'] = h(package) if defined?(package)
+  ajax_data['index'] = h(index) if defined?(index)
+
+.card
+  .bg-light#buildresult-urls{ data: { buildresult_url: defined?(package) ? package_buildresult_path : project_buildresult_path } }
+    %ul.nav.nav-tabs.pt-2.px-3.flex-nowrap#buildresult-box{ role: 'tablist', data: ajax_data }
+      %li.nav-item
+        = link_to("#build#{index}", id: "build#{index}-tab", class: 'nav-link active text-nowrap',
+          data: { toggle: 'tab' }, role: 'tab', aria: { controls: "build#{index}", selected: true }) do
+          Build Results
+  .card-body
+    .tab-content
+      .tab-pane.fade.show.active{ id: "build#{index}", role: 'tabpanel', aria: { labelledby: "build#{index}-tab" } }
+        .btn.btn-sm.btn-outline-primary.mb-2.build-refresh{ accesskey: 'r', title: 'Refresh Build Results' }
+          Refresh
+          %i.fas.fa-sm.fa-sync-alt{ id: "build#{index}-reload" }
+        .result
+
+:javascript
+  updateBuildResult('#{index}');
+  $('.build-refresh').click(function() { updateBuildResult('#{index}'); });

--- a/src/api/app/views/webui2/webui/kiwi/images/_description_form.html.haml
+++ b/src/api/app/views/webui2/webui/kiwi/images/_description_form.html.haml
@@ -1,0 +1,26 @@
+.modal.fade#description-edit{ 'tabindex': '-1', role: 'dialog' }
+  .modal-dialog{ role: 'document' }
+    .modal-content
+      .modal-header
+        %h5.modal-title Edit Kiwi Details
+
+      #flash-messages
+        %p.ui-state-error.alert-danger.p-3.mb-0.d-none
+          Kiwi Image name cannot be empty!
+      .modal-body
+        .dialog
+          = f.label :name
+          = f.text_field :name, data: { default: f.object.name }, class: 'form-control'
+
+          = f.fields_for :description, f.object.description do |description_fields|
+            = description_fields.label :author
+            = description_fields.text_field :author, data: { default: description_fields.object.author }, class: 'form-control'
+            = description_fields.label :contact
+            = description_fields.text_field :contact, data: { default: description_fields.object.contact }, class: 'form-control'
+            = description_fields.label :specification
+            = description_fields.text_field :specification, data: { default: description_fields.object.specification }, class: 'form-control'
+
+      .modal-footer
+        %a.btn.btn-sm.btn-outline-danger.px-4{ data: { dismiss: 'modal' } }
+          Cancel
+        = link_to('Continue', '#', title: 'Continue', class: 'btn btn-sm btn-primary px-4 close-description-dialog')

--- a/src/api/app/views/webui2/webui/kiwi/images/_details_overview.html.haml
+++ b/src/api/app/views/webui2/webui/kiwi/images/_details_overview.html.haml
@@ -1,0 +1,18 @@
+%h5.card-header Details
+.card-body
+  %p
+    %strong Author
+  %p
+    = author
+    = "(#{contact})" if contact.present?
+  %p
+    %strong Software
+  %p
+    - if image.use_project_repositories
+      This image uses the repositories set in the project
+    - else
+      = repositories_count
+      repositories selected
+  %p
+    = pluralize(packages_count, 'package', plural: 'packages')
+    selected

--- a/src/api/app/views/webui2/webui/kiwi/images/_package_fields.html.haml
+++ b/src/api/app/views/webui2/webui/kiwi/images/_package_fields.html.haml
@@ -1,0 +1,46 @@
+.nested-fields.kiwi_fields.col-lg-2.col-md-3.col-sm-4
+  %div{ class: "d-flex justify-content-between kiwi_list_item #{'has-error' if f.object.errors.present?}" }
+    %span.btn.btn-link.text-truncate{ title: f.object.name }
+      = link_to '', class: 'package_edit kiwi_element_name', data: { 'target': "#package-#{f.object.name}", 'toggle': 'modal' } do
+        = f.object.name
+        - if f.object.arch.present?
+          %small (#{f.object.arch})
+    %span.btn.btn-link.kiwi_actions
+      = link_to_remove_association f do
+        %i.fas.fa-times.text-danger
+
+%div{ 'tabindex': '-1', role: 'dialog', id: "#{f.object.name.present? ? 'package-' + f.object.name : 'add-package'}",
+class: "modal fade #{'new_element' if f.object.new_record?}" }
+  .modal-dialog{ role: 'document' }
+    .modal-content
+      .modal-header
+        %h5.modal-title #{f.object.name.present? ? 'Edit' : 'Add'} package
+
+      #flash-messages
+        %p.ui-state-error.alert-danger.p-3.mb-0.d-none
+          The name can not be empty!
+
+      .modal-body
+        %p
+          = render partial: 'webui/autocomplete', locals: { html_id: :name, label: 'Name:'.html_safe,
+                                                              source: url_for(controller: '/webui/kiwi/images', action: 'autocomplete_binaries'),
+                                                              value: f.object.name }
+          = f.label :arch, 'Arch:'
+          = f.text_field :arch, data: { default: f.object.arch }, class: 'form-control'
+          = f.label :replaces, 'Replaces:'
+          = f.text_field :replaces, data: { default: f.object.replaces }, class: 'form-control'
+        .custom-control.custom-checkbox
+          = f.check_box :bootinclude, data: { default: f.object.bootinclude }, class: 'custom-control-input'
+          = f.label :bootinclude, class: 'custom-control-label'
+        .custom-control.custom-checkbox
+          = f.check_box :bootdelete, data: { default: f.object.bootdelete }, class: 'custom-control-input'
+          = f.label :bootdelete, class: 'custom-control-label'
+
+      .modal-footer
+        = link_to('Cancel', '#', title: 'Cancel', class: 'revert-dialog btn btn-sm btn-outline-danger px-4')
+        = link_to('Continue', '#', title: 'Continue', class: 'close-dialog btn btn-sm btn-primary px-4')
+
+- if f.object.name.blank?
+  :javascript
+    $("#add-package").modal('show');
+    setupAutocomplete();

--- a/src/api/app/views/webui2/webui/kiwi/images/_packages.html.haml
+++ b/src/api/app/views/webui2/webui/kiwi/images/_packages.html.haml
@@ -1,0 +1,12 @@
+%h5.card-header Packages
+.card-body#kiwi-packages-list
+  %p#no-packages{ class: "#{'d-none' if package_groups.packages.present?}" }= 'There are no packages.'
+
+  = f.fields_for :package_groups do |package_group_fields|
+    .row
+      = package_group_fields.fields_for :packages do |kiwi_package_fields|
+        = render 'package_fields', f: kiwi_package_fields
+    %p
+      = link_to_add_association(package_group_fields, :packages) do
+        %i.fas.fa-plus-circle.text-success
+        Add Package

--- a/src/api/app/views/webui2/webui/kiwi/images/_preferences.html.haml
+++ b/src/api/app/views/webui2/webui/kiwi/images/_preferences.html.haml
@@ -1,0 +1,26 @@
+.card.mb-2
+  .nested-fields
+    %h5.card-header#image-name
+      Preferences
+    .card-body
+      - @image.preferences.each do |preference|
+        %h6= preference.profile
+        %ul.list-inline
+          %li.list-inline-item
+            %strong Image type:
+            %span{ data: { tag: 'type_image' } }= preference.type_image
+          %li.list-inline-item
+            %strong Version:
+            %span.fill{ data: { tag: 'version' } }= preference.version
+          - if preference.containerconfig_fields_editable?
+            %li.list-inline-item
+              %strong Container config name:
+              %span.fill{ data: { tag: 'type_containerconfig_name' } }= preference.type_containerconfig_name
+            %li.list-inline-item
+              %strong Container config tag:
+              %span.fill{ data: { tag: 'type_containerconfig_tag' } }= preference.type_containerconfig_tag
+      %p
+        = link_to('#', data: { 'target': '#preferences-edit', 'toggle': 'modal' }) do
+          %i.fas.fa-cog.text-secondary
+          Edit Preferences
+        = render partial: 'preferences_form', locals: { f: f }

--- a/src/api/app/views/webui2/webui/kiwi/images/_preferences_form.html.haml
+++ b/src/api/app/views/webui2/webui/kiwi/images/_preferences_form.html.haml
@@ -1,0 +1,31 @@
+.modal.fade#preferences-edit{ 'tabindex': '-1', role: 'dialog' }
+  .modal-dialog{ role: 'document' }
+    .modal-content
+      .modal-header
+        %h5.modal-title Edit Kiwi Preferences
+
+      #flash-messages
+        %p.ui-state-error.alert-danger.p-3.mb-0.d-none
+          Kiwi Image name cannot be empty!
+      .modal-body
+        .dialog
+          - @image.preferences.each do |preference|
+            = f.fields_for(:preferences, preference) do |preference_fields|
+              %h4= preference.profile
+              = preference_fields.label :version do
+                Version
+                %small.text-muted
+                  (must be in form Major.Minor.Release)
+              = preference_fields.text_field :version, data: { default: preference_fields.object.version }, class: 'form-control'
+              - if preference_fields.object.containerconfig_fields_editable?
+                = preference_fields.label :type_containerconfig_name, 'Container Config Name'
+                = preference_fields.text_field :type_containerconfig_name, data: { default: preference_fields.object.type_containerconfig_name },
+                class: 'form-control'
+                = preference_fields.label :type_containerconfig_tag, 'Container Config Tag'
+                = preference_fields.text_field :type_containerconfig_tag, data: { default: preference_fields.object.type_containerconfig_tag },
+                class: 'form-control'
+
+      .modal-footer
+        %a.btn.btn-sm.btn-outline-danger.px-4{ data: { dismiss: 'modal' } }
+          Cancel
+        = link_to('Continue', '#', title: 'Continue', class: 'btn btn-sm btn-primary px-4 close-preferences-dialog')

--- a/src/api/app/views/webui2/webui/kiwi/images/_profiles.html.haml
+++ b/src/api/app/views/webui2/webui/kiwi/images/_profiles.html.haml
@@ -1,0 +1,15 @@
+.nested-fields
+  %h5.card-header
+    Profiles
+  .card-body
+    %p Select one or more profiles to build. At least one profile needs to be selected to trigger builds.
+    - if @image.profiles.empty?
+      %p There are no profiles
+    - else
+      %ul.list-unstyled
+        - @image.profiles.each do |profile|
+          %li
+            = f.fields_for(:profiles, profile) do |profile_fields|
+              .custom-control.custom-checkbox
+                = profile_fields.check_box(:selected, class: 'custom-control-input')
+                = profile_fields.label(:selected, profile.name, class: 'custom-control-label')

--- a/src/api/app/views/webui2/webui/kiwi/images/_repositories.html.haml
+++ b/src/api/app/views/webui2/webui/kiwi/images/_repositories.html.haml
@@ -1,0 +1,17 @@
+%h5.card-header Repositories
+.card-body
+  #kiwi-use-project-repositories
+    .custom-control.custom-checkbox
+      = f.check_box :use_project_repositories, class: 'custom-control-input'
+      = f.label :use_project_repositories, class: 'custom-control-label'
+    %p.alert.alert-info#use-project-repositories-text{ class: "#{'d-none' unless f.object.use_project_repositories?}" }
+      %i.fas.fa-info-circle.text-info
+      This option will use the repositories from the current project. Other repositories set in this Kiwi Image will be REMOVED.
+  #kiwi-repositories-list{ class: "#{'d-none' if f.object.use_project_repositories?}" }
+    %hr
+    %p#no-repositories{ class: "#{'d-none' if image.repositories.present?}" }= 'There are no repositories.'
+    = f.fields_for :repositories do |repository_fields|
+      = render 'repository_fields', f: repository_fields
+    = link_to_add_association(f, :repositories, partial: 'repository_fields', data: { 'target': '#add-repository', 'toggle': 'modal' }) do
+      %i.fas.fa-plus-circle.text-success
+      Add repository

--- a/src/api/app/views/webui2/webui/kiwi/images/_repository_fields.html.haml
+++ b/src/api/app/views/webui2/webui/kiwi/images/_repository_fields.html.haml
@@ -1,0 +1,72 @@
+.nested-fields.kiwi_fields
+  %div{ class: "kiwi_list_item #{'has-error' if f.object.errors.present?}" }
+    %span
+      = link_to f.object.name, '',
+      data: { 'target': "##{f.object.source_path.present? ? 'edit-' + f.object.name.gsub(/[^0-9a-z]/i, '') : 'add-repository'}", 'toggle': 'modal' }
+    %span.kiwi_actions.d-none
+      = link_to_remove_association(f) do
+        %i.fas.fa-times.text-danger
+
+%div{ 'tabindex': '-1', role: 'dialog', id: "#{f.object.source_path.present? ? 'edit-' + f.object.name.gsub(/[^0-9a-z]/i, '') : 'add-repository'}",
+class: "modal fade #{'new_element' if f.object.new_record?}" }
+  .modal-dialog{ role: 'document' }
+    .modal-content
+      .modal-header
+        %h5.modal-title #{f.object.source_path.present? ? 'Edit' : 'Add'} repository
+
+      #flash-messages
+        %p.ui-state-error.alert-danger.p-3.mb-0.d-none
+
+      .modal-body
+        .normal-mode
+          .repository-autocomplete
+            = render partial: 'webui/autocomplete', locals: { html_id: 'target_project', label: '<strong>Project:</strong>'.html_safe,
+                                                              source: url_for(controller: '/webui/project', action: 'autocomplete_projects') }
+            .form-group
+              = label_tag :repositories do
+                %strong Repositories:
+              = select_tag 'target_repo', options_for_select(['']), required: true,
+                                                                    disabled: true,
+                                                                    class: 'repository-dropdown custom-select',
+                                                                    data: { source: url_for(controller: '/webui/project',
+                                                                    action: :autocomplete_repositories) }
+            = label_tag 'Alias:'
+            = text_field_tag 'alias_for_repo', f.object.alias, data: { default: f.object.alias }, class: 'form-control'
+        .collapse#collapse-expert
+          = f.hidden_field :order, data: { default: f.object.order }, class: 'form-control'
+          = f.label :repo_type, 'Type:'
+          = f.select :repo_type, Kiwi::Repository::REPO_TYPES, {}, data: { default: f.object.repo_type }, class: 'custom-select'
+          = f.label :priority, 'Priority:'
+          = f.number_field :priority, maxlength: 4, in: 0...99, data: { default: f.object.priority }, class: 'custom-select'
+          = f.label :alias, 'Alias:'
+          = f.text_field :alias, data: { default: f.object.alias }, class: 'form-control'
+          = f.label :source_path, 'Source:'
+          = f.text_field :source_path, data: { default: f.object.source_path }, class: 'form-control'
+          %span.small-text
+            Write a valid source path
+
+          = f.label :username, 'User:'
+          = f.text_field :username, data: { default: f.object.username }, class: 'form-control'
+          = f.label :password, 'Password:'
+          = f.text_field :password, data: { default: f.object.password }, class: 'form-control'
+
+          .custom-control.custom-checkbox
+            = f.check_box :prefer_license, data: { default: f.object.prefer_license }, class: 'custom-control-input'
+            = f.label :prefer_license, class: 'custom-control-label'
+          .custom-control.custom-checkbox
+            = f.check_box :imageinclude, data: { default: f.object.imageinclude }, class: 'custom-control-input'
+            = f.label :imageinclude, 'Image include', class: 'custom-control-label'
+          .custom-control.custom-checkbox
+            = f.check_box :replaceable, data: { default: f.object.replaceable }, class: 'custom-control-input'
+            = f.label :replaceable, class: 'custom-control-label'
+
+      .modal-footer
+        = link_to('Expert Mode', '#collapse-expert', title: 'Mode Toggle', class: 'kiwi-repository-mode-toggle btn btn-warning',
+                   role: 'button', data: { 'toggle': 'collapse' })
+        = link_to('Cancel', '#', title: 'Cancel', class: 'revert-dialog btn btn-secondary')
+        = link_to('Continue', '#', title: 'Continue', class: 'close-dialog btn btn-primary')
+
+- if f.object.source_path.blank?
+  :javascript
+    $("#add-repository").modal('show');
+    setupAutocomplete();

--- a/src/api/app/views/webui2/webui/kiwi/images/edit.html.haml
+++ b/src/api/app/views/webui2/webui/kiwi/images/edit.html.haml
@@ -1,0 +1,39 @@
+- @layouttype = 'custom'
+- @package = @image.package
+
+= form_for @image, html: { id: 'kiwi-image-update-form' } do |f|
+  .row
+    .col-12
+      .card.mb-3
+        = render partial: 'webui/kiwi/tabs'
+        .card-body
+          = render partial: 'base_info', locals: { f: f, author: @author, contact: @contact,
+                                                   image: @image, description: @description, package: @package,
+                                                   is_edit_software_action: @is_edit_software_action,
+                                                   is_edit_details_action: @is_edit_details_action }
+
+    .col-12
+      = render partial: 'webui/kiwi/images/preferences', locals: { f: f }
+
+    .col-12#kiwi-image-profiles-section{ class: "#{'d-none' unless @is_edit_software_action}" }
+      .card.mb-3
+        = render partial: 'webui/kiwi/images/profiles', locals: { f: f }
+
+    .col-12#kiwi-image-repositories-section{ class: "#{'d-none' unless @is_edit_software_action}" }
+      .card.mb-3
+        = render partial: 'webui/kiwi/images/repositories', locals: { f: f, image: @image }
+
+    .col-12#kiwi-image-packages-section{ class: "#{'d-none' unless @is_edit_software_action}" }
+      .card.mb-3
+        = render partial: 'webui/kiwi/images/packages', locals: { f: f, package_groups: @package_groups }
+
+    .col-12.d-flex.justify-content-end
+      .btn.btn-primary.disabled#kiwi-image-update-form-save
+        %i.fas.fa-save
+        Save
+      .btn.btn-danger.ml-3#kiwi-image-update-form-revert{ class: "#{'disabled' unless flash[:error]}" }
+        %i.fas.fa-undo
+        Revert
+
+= content_for :ready_function do
+  initializeKiwi('#{url_for(controller: 'kiwi/images', action: :show, id: @image)}')

--- a/src/api/app/views/webui2/webui/kiwi/images/show.html.haml
+++ b/src/api/app/views/webui2/webui/kiwi/images/show.html.haml
@@ -1,0 +1,20 @@
+:ruby
+  @layouttype = 'custom'
+  @project = @image.package.try(:project)
+  @package = @image.package
+
+.row
+  .col-12
+    .card.mb-3
+      = render partial: 'webui/kiwi/tabs'
+      .card-body
+        = render partial: 'base_info', locals: { author: @author, contact: @contact, image: @image,
+                                                 description: @description, package: @package,
+                                                 is_edit_software_action: @is_edit_software_action, is_edit_details_action: @is_edit_details_action }
+  .col-md-8
+    .card.mb-3
+      = render partial: 'details_overview', locals: { author: @author, contact: @contact, image: @image,
+                                                      repositories_count: @repositories_count, packages_count: @packages_count }
+  .col-md-4
+    .mb-3
+      = render partial: 'build_info', locals: { project: @project.name, package: @package.name }

--- a/src/api/spec/bootstrap/features/webui/image_templates_spec.rb
+++ b/src/api/spec/bootstrap/features/webui/image_templates_spec.rb
@@ -73,8 +73,7 @@ RSpec.feature 'Bootstrap_ImageTemplates', type: :feature, js: true, vcr: true do
       fill_in 'target_package', with: 'package_with_kiwi_image'
 
       click_button('Create appliance')
-      find('#kiwi-image-update-form')
-      expect(page).to have_text('home:tom:branches:my_project > package_with_kiwi_image')
+      expect(page).to have_text("home:tom:branches:my_project\npackage_with_kiwi_image")
     end
   end
 end

--- a/src/api/spec/cassettes/Bootstrap_ImageTemplates/branching/branch_Kiwi_image_template.yml
+++ b/src/api/spec/cassettes/Bootstrap_ImageTemplates/branching/branch_Kiwi_image_template.yml
@@ -40,7 +40,7 @@ http_interactions:
           <person userid="tom" role="maintainer" />
         </project>
     http_version: 
-  recorded_at: Wed, 15 May 2019 14:56:11 GMT
+  recorded_at: Thu, 16 May 2019 15:48:49 GMT
 - request:
     method: put
     uri: http://backend:5352/source/my_project/_meta?user=tom
@@ -48,7 +48,7 @@ http_interactions:
       encoding: UTF-8
       string: |
         <project name="my_project">
-          <title>The Mirror Crack'd from Side to Side</title>
+          <title>Wildfire at Midnight</title>
           <description/>
         </project>
     headers:
@@ -70,16 +70,16 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '123'
+      - '107'
     body:
       encoding: UTF-8
       string: |
         <project name="my_project">
-          <title>The Mirror Crack'd from Side to Side</title>
+          <title>Wildfire at Midnight</title>
           <description></description>
         </project>
     http_version: 
-  recorded_at: Wed, 15 May 2019 14:56:11 GMT
+  recorded_at: Thu, 16 May 2019 15:48:49 GMT
 - request:
     method: put
     uri: http://backend:5352/source/my_project/first_package/_meta?user=tom
@@ -88,7 +88,7 @@ http_interactions:
       string: |
         <package name="first_package" project="my_project">
           <title>a</title>
-          <description>Debitis repellat corporis distinctio.</description>
+          <description>Vel ut voluptates aut.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -109,16 +109,16 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '149'
+      - '134'
     body:
       encoding: UTF-8
       string: |
         <package name="first_package" project="my_project">
           <title>a</title>
-          <description>Debitis repellat corporis distinctio.</description>
+          <description>Vel ut voluptates aut.</description>
         </package>
     http_version: 
-  recorded_at: Wed, 15 May 2019 14:56:11 GMT
+  recorded_at: Thu, 16 May 2019 15:48:49 GMT
 - request:
     method: put
     uri: http://backend:5352/source/my_project/first_package/_meta?user=tom
@@ -127,7 +127,7 @@ http_interactions:
       string: |
         <package name="first_package" project="my_project">
           <title>a</title>
-          <description>Debitis repellat corporis distinctio.</description>
+          <description>Vel ut voluptates aut.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -148,22 +148,22 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '149'
+      - '134'
     body:
       encoding: UTF-8
       string: |
         <package name="first_package" project="my_project">
           <title>a</title>
-          <description>Debitis repellat corporis distinctio.</description>
+          <description>Vel ut voluptates aut.</description>
         </package>
     http_version: 
-  recorded_at: Wed, 15 May 2019 14:56:11 GMT
+  recorded_at: Thu, 16 May 2019 15:48:49 GMT
 - request:
     method: put
     uri: http://backend:5352/source/my_project/first_package/_config
     body:
       encoding: UTF-8
-      string: Quo quasi neque. Alias quos rerum. Adipisci inventore voluptatem.
+      string: Debitis laboriosam nulla. Qui aut voluptas. Itaque magnam illum.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -183,26 +183,26 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '207'
+      - '209'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="3" vrev="3">
-          <srcmd5>30b6c2367609665f583b625ca2a2381a</srcmd5>
+        <revision rev="17" vrev="17">
+          <srcmd5>6a5b9620bb6bbc4c503123c520201bab</srcmd5>
           <version>unknown</version>
-          <time>1557932171</time>
+          <time>1558021729</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
     http_version: 
-  recorded_at: Wed, 15 May 2019 14:56:11 GMT
+  recorded_at: Thu, 16 May 2019 15:48:49 GMT
 - request:
     method: put
     uri: http://backend:5352/source/my_project/first_package/somefile.txt
     body:
       encoding: UTF-8
-      string: Dolorem voluptate eveniet. Nostrum quod perferendis. At voluptas soluta.
+      string: Rerum non saepe. Est ea modi. Dolorem velit quidem.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -222,20 +222,20 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '207'
+      - '209'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="4" vrev="4">
-          <srcmd5>7c006b82b57fbdcef205bdc99170823b</srcmd5>
+        <revision rev="18" vrev="18">
+          <srcmd5>62b17cbb342fb5e22359ac364a31c165</srcmd5>
           <version>unknown</version>
-          <time>1557932171</time>
+          <time>1558021729</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
     http_version: 
-  recorded_at: Wed, 15 May 2019 14:56:11 GMT
+  recorded_at: Thu, 16 May 2019 15:48:49 GMT
 - request:
     method: put
     uri: http://backend:5352/source/my_project/second_package/_meta?user=tom
@@ -244,7 +244,7 @@ http_interactions:
       string: |
         <package name="second_package" project="my_project">
           <title>c</title>
-          <description>Sed fugit occaecati velit.</description>
+          <description>Necessitatibus quas ea dolores.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -265,16 +265,16 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '139'
+      - '144'
     body:
       encoding: UTF-8
       string: |
         <package name="second_package" project="my_project">
           <title>c</title>
-          <description>Sed fugit occaecati velit.</description>
+          <description>Necessitatibus quas ea dolores.</description>
         </package>
     http_version: 
-  recorded_at: Wed, 15 May 2019 14:56:11 GMT
+  recorded_at: Thu, 16 May 2019 15:48:49 GMT
 - request:
     method: put
     uri: http://backend:5352/source/my_project/second_package/_meta?user=tom
@@ -283,7 +283,7 @@ http_interactions:
       string: |
         <package name="second_package" project="my_project">
           <title>c</title>
-          <description>Sed fugit occaecati velit.</description>
+          <description>Necessitatibus quas ea dolores.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -304,22 +304,22 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '139'
+      - '144'
     body:
       encoding: UTF-8
       string: |
         <package name="second_package" project="my_project">
           <title>c</title>
-          <description>Sed fugit occaecati velit.</description>
+          <description>Necessitatibus quas ea dolores.</description>
         </package>
     http_version: 
-  recorded_at: Wed, 15 May 2019 14:56:11 GMT
+  recorded_at: Thu, 16 May 2019 15:48:49 GMT
 - request:
     method: put
     uri: http://backend:5352/source/my_project/second_package/_config
     body:
       encoding: UTF-8
-      string: Voluptas rerum ut. Atque dicta velit. Impedit sunt necessitatibus.
+      string: Sint est aliquid. Quasi iusto tempore. Et in quas.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -339,26 +339,27 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '207'
+      - '209'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="3" vrev="3">
-          <srcmd5>c2cdee99b3348429f4e2382c8d82955f</srcmd5>
+        <revision rev="17" vrev="17">
+          <srcmd5>12a29ba554a375086e63fca056490d98</srcmd5>
           <version>unknown</version>
-          <time>1557932171</time>
+          <time>1558021729</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
     http_version: 
-  recorded_at: Wed, 15 May 2019 14:56:11 GMT
+  recorded_at: Thu, 16 May 2019 15:48:49 GMT
 - request:
     method: put
     uri: http://backend:5352/source/my_project/second_package/somefile.txt
     body:
       encoding: UTF-8
-      string: Recusandae dolorem in. Nostrum quia pariatur. Vel numquam quia.
+      string: Sint cupiditate explicabo. Eum necessitatibus consequatur. Veniam voluptatem
+        cumque.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -378,20 +379,20 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '207'
+      - '209'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="4" vrev="4">
-          <srcmd5>55e41c0e78327f55a326f4346c04a9d5</srcmd5>
+        <revision rev="18" vrev="18">
+          <srcmd5>f4eb0b1a1230d73fffc548abec0be21d</srcmd5>
           <version>unknown</version>
-          <time>1557932171</time>
+          <time>1558021729</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
     http_version: 
-  recorded_at: Wed, 15 May 2019 14:56:11 GMT
+  recorded_at: Thu, 16 May 2019 15:48:49 GMT
 - request:
     method: put
     uri: http://backend:5352/source/my_project/third_package/_meta?user=tom
@@ -400,7 +401,7 @@ http_interactions:
       string: |
         <package name="third_package" project="my_project">
           <title>b</title>
-          <description>Quis quos aliquid odit.</description>
+          <description>Cupiditate sit tenetur minus.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -421,16 +422,16 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '135'
+      - '141'
     body:
       encoding: UTF-8
       string: |
         <package name="third_package" project="my_project">
           <title>b</title>
-          <description>Quis quos aliquid odit.</description>
+          <description>Cupiditate sit tenetur minus.</description>
         </package>
     http_version: 
-  recorded_at: Wed, 15 May 2019 14:56:11 GMT
+  recorded_at: Thu, 16 May 2019 15:48:49 GMT
 - request:
     method: put
     uri: http://backend:5352/source/my_project/third_package/_meta?user=tom
@@ -439,7 +440,7 @@ http_interactions:
       string: |
         <package name="third_package" project="my_project">
           <title>b</title>
-          <description>Quis quos aliquid odit.</description>
+          <description>Cupiditate sit tenetur minus.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -460,23 +461,22 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '135'
+      - '141'
     body:
       encoding: UTF-8
       string: |
         <package name="third_package" project="my_project">
           <title>b</title>
-          <description>Quis quos aliquid odit.</description>
+          <description>Cupiditate sit tenetur minus.</description>
         </package>
     http_version: 
-  recorded_at: Wed, 15 May 2019 14:56:11 GMT
+  recorded_at: Thu, 16 May 2019 15:48:49 GMT
 - request:
     method: put
     uri: http://backend:5352/source/my_project/third_package/_config
     body:
       encoding: UTF-8
-      string: Earum consequuntur explicabo. Cumque consequuntur illum. Quo repudiandae
-        accusamus.
+      string: Voluptas cum aliquam. Aperiam sint laborum. Dolorem alias nam.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -496,26 +496,26 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '207'
+      - '209'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="3" vrev="3">
-          <srcmd5>ac26d0501242f6cd74d0a158f107eaeb</srcmd5>
+        <revision rev="17" vrev="17">
+          <srcmd5>7c41879db6154595b98c8da00e2711e5</srcmd5>
           <version>unknown</version>
-          <time>1557932171</time>
+          <time>1558021729</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
     http_version: 
-  recorded_at: Wed, 15 May 2019 14:56:11 GMT
+  recorded_at: Thu, 16 May 2019 15:48:50 GMT
 - request:
     method: put
     uri: http://backend:5352/source/my_project/third_package/somefile.txt
     body:
       encoding: UTF-8
-      string: Doloribus ipsa est. Maxime quo recusandae. Perspiciatis sunt omnis.
+      string: Qui quaerat aut. Sed nostrum dicta. Ratione velit sequi.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -535,20 +535,20 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '207'
+      - '209'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="4" vrev="4">
-          <srcmd5>1a5ab546c84b864833f33e4a8e6603a8</srcmd5>
+        <revision rev="18" vrev="18">
+          <srcmd5>c5580e02210f36dcd1ecde1cfdbec8bd</srcmd5>
           <version>unknown</version>
-          <time>1557932171</time>
+          <time>1558021730</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
     http_version: 
-  recorded_at: Wed, 15 May 2019 14:56:11 GMT
+  recorded_at: Thu, 16 May 2019 15:48:50 GMT
 - request:
     method: put
     uri: http://backend:5352/source/my_project/package_with_kiwi_image/_meta?user=tom
@@ -556,8 +556,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="package_with_kiwi_image" project="my_project">
-          <title>Antic Hay</title>
-          <description>Dolorem voluptas et voluptatum.</description>
+          <title>The Mermaids Singing</title>
+          <description>Autem et eum et.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -578,16 +578,16 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '161'
+      - '157'
     body:
       encoding: UTF-8
       string: |
         <package name="package_with_kiwi_image" project="my_project">
-          <title>Antic Hay</title>
-          <description>Dolorem voluptas et voluptatum.</description>
+          <title>The Mermaids Singing</title>
+          <description>Autem et eum et.</description>
         </package>
     http_version: 
-  recorded_at: Wed, 15 May 2019 14:56:12 GMT
+  recorded_at: Thu, 16 May 2019 15:48:50 GMT
 - request:
     method: put
     uri: http://backend:5352/source/my_project/package_with_kiwi_image/_meta?user=tom
@@ -595,8 +595,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="package_with_kiwi_image" project="my_project">
-          <title>Antic Hay</title>
-          <description>Dolorem voluptas et voluptatum.</description>
+          <title>The Mermaids Singing</title>
+          <description>Autem et eum et.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -617,16 +617,16 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '161'
+      - '157'
     body:
       encoding: UTF-8
       string: |
         <package name="package_with_kiwi_image" project="my_project">
-          <title>Antic Hay</title>
-          <description>Dolorem voluptas et voluptatum.</description>
+          <title>The Mermaids Singing</title>
+          <description>Autem et eum et.</description>
         </package>
     http_version: 
-  recorded_at: Wed, 15 May 2019 14:56:12 GMT
+  recorded_at: Thu, 16 May 2019 15:48:50 GMT
 - request:
     method: put
     uri: http://backend:5352/source/my_project/package_with_kiwi_image/package_with_kiwi_image.kiwi
@@ -660,16 +660,16 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <revision rev="2" vrev="2">
+        <revision rev="9" vrev="9">
           <srcmd5>801c545be09c1c468ff2d99b40415aac</srcmd5>
           <version>0.0.1</version>
-          <time>1557932172</time>
+          <time>1558021730</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
     http_version: 
-  recorded_at: Wed, 15 May 2019 14:56:12 GMT
+  recorded_at: Thu, 16 May 2019 15:48:50 GMT
 - request:
     method: put
     uri: http://backend:5352/source/my_project/package_with_kiwi_image/_meta?user=tom
@@ -677,8 +677,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="package_with_kiwi_image" project="my_project">
-          <title>Antic Hay</title>
-          <description>Dolorem voluptas et voluptatum.</description>
+          <title>The Mermaids Singing</title>
+          <description>Autem et eum et.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -699,16 +699,16 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '161'
+      - '157'
     body:
       encoding: UTF-8
       string: |
         <package name="package_with_kiwi_image" project="my_project">
-          <title>Antic Hay</title>
-          <description>Dolorem voluptas et voluptatum.</description>
+          <title>The Mermaids Singing</title>
+          <description>Autem et eum et.</description>
         </package>
     http_version: 
-  recorded_at: Wed, 15 May 2019 14:56:12 GMT
+  recorded_at: Thu, 16 May 2019 15:48:50 GMT
 - request:
     method: get
     uri: http://backend:5352/source/my_project/package_with_kiwi_image
@@ -738,11 +738,11 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="package_with_kiwi_image" rev="2" vrev="2" srcmd5="801c545be09c1c468ff2d99b40415aac">
+        <directory name="package_with_kiwi_image" rev="9" vrev="9" srcmd5="801c545be09c1c468ff2d99b40415aac">
           <entry name="package_with_kiwi_image.kiwi" md5="1c5276faed68b141541d9ecaf6a2f3b6" size="289" mtime="1557931989" />
         </directory>
     http_version: 
-  recorded_at: Wed, 15 May 2019 14:56:12 GMT
+  recorded_at: Thu, 16 May 2019 15:48:50 GMT
 - request:
     method: put
     uri: http://backend:5352/source/my_project/_project/_attribute?meta=1&user=tom
@@ -771,19 +771,19 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '165'
+      - '166'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="4">
-          <srcmd5>089e16a7a2bcdb09ded8065b880e5ecc</srcmd5>
-          <time>1557932172</time>
+        <revision rev="18">
+          <srcmd5>93ef1499696d89421bf30b4679db5ce4</srcmd5>
+          <time>1558021730</time>
           <user>tom</user>
           <comment></comment>
           <requestid/>
         </revision>
     http_version: 
-  recorded_at: Wed, 15 May 2019 14:56:12 GMT
+  recorded_at: Thu, 16 May 2019 15:48:50 GMT
 - request:
     method: get
     uri: http://backend:5352/source/my_project/first_package
@@ -809,16 +809,16 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '300'
+      - '302'
     body:
       encoding: UTF-8
       string: |
-        <directory name="first_package" rev="4" vrev="4" srcmd5="7c006b82b57fbdcef205bdc99170823b">
-          <entry name="_config" md5="244651eb97606e0c941bec3494cb5c22" size="65" mtime="1557932171" />
-          <entry name="somefile.txt" md5="e9a938b0def484004a22f4a5adbff281" size="72" mtime="1557932171" />
+        <directory name="first_package" rev="18" vrev="18" srcmd5="62b17cbb342fb5e22359ac364a31c165">
+          <entry name="_config" md5="661226f83d2f3ccf230e8b24ed39ee8f" size="64" mtime="1558021729" />
+          <entry name="somefile.txt" md5="fd07eaf377a67e849df8dd0546a9446e" size="51" mtime="1558021729" />
         </directory>
     http_version: 
-  recorded_at: Wed, 15 May 2019 14:56:13 GMT
+  recorded_at: Thu, 16 May 2019 15:48:51 GMT
 - request:
     method: get
     uri: http://backend:5352/source/my_project/first_package
@@ -844,16 +844,16 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '300'
+      - '302'
     body:
       encoding: UTF-8
       string: |
-        <directory name="first_package" rev="4" vrev="4" srcmd5="7c006b82b57fbdcef205bdc99170823b">
-          <entry name="_config" md5="244651eb97606e0c941bec3494cb5c22" size="65" mtime="1557932171" />
-          <entry name="somefile.txt" md5="e9a938b0def484004a22f4a5adbff281" size="72" mtime="1557932171" />
+        <directory name="first_package" rev="18" vrev="18" srcmd5="62b17cbb342fb5e22359ac364a31c165">
+          <entry name="_config" md5="661226f83d2f3ccf230e8b24ed39ee8f" size="64" mtime="1558021729" />
+          <entry name="somefile.txt" md5="fd07eaf377a67e849df8dd0546a9446e" size="51" mtime="1558021729" />
         </directory>
     http_version: 
-  recorded_at: Wed, 15 May 2019 14:56:13 GMT
+  recorded_at: Thu, 16 May 2019 15:48:51 GMT
 - request:
     method: get
     uri: http://backend:5352/source/my_project/second_package
@@ -879,16 +879,16 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '301'
+      - '303'
     body:
       encoding: UTF-8
       string: |
-        <directory name="second_package" rev="4" vrev="4" srcmd5="55e41c0e78327f55a326f4346c04a9d5">
-          <entry name="_config" md5="fdcbdcd1e8a6dd14cd97f2eee3f16445" size="66" mtime="1557932171" />
-          <entry name="somefile.txt" md5="eabea33a6b9adbd1a220f20b3622b150" size="63" mtime="1557932171" />
+        <directory name="second_package" rev="18" vrev="18" srcmd5="f4eb0b1a1230d73fffc548abec0be21d">
+          <entry name="_config" md5="92a7ddc9beb20a6da4736ab6f76ef02b" size="50" mtime="1558021729" />
+          <entry name="somefile.txt" md5="d9ac4a86da681555603c2679bdd6ed3a" size="84" mtime="1558021729" />
         </directory>
     http_version: 
-  recorded_at: Wed, 15 May 2019 14:56:13 GMT
+  recorded_at: Thu, 16 May 2019 15:48:51 GMT
 - request:
     method: get
     uri: http://backend:5352/source/my_project/second_package
@@ -914,16 +914,16 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '301'
+      - '303'
     body:
       encoding: UTF-8
       string: |
-        <directory name="second_package" rev="4" vrev="4" srcmd5="55e41c0e78327f55a326f4346c04a9d5">
-          <entry name="_config" md5="fdcbdcd1e8a6dd14cd97f2eee3f16445" size="66" mtime="1557932171" />
-          <entry name="somefile.txt" md5="eabea33a6b9adbd1a220f20b3622b150" size="63" mtime="1557932171" />
+        <directory name="second_package" rev="18" vrev="18" srcmd5="f4eb0b1a1230d73fffc548abec0be21d">
+          <entry name="_config" md5="92a7ddc9beb20a6da4736ab6f76ef02b" size="50" mtime="1558021729" />
+          <entry name="somefile.txt" md5="d9ac4a86da681555603c2679bdd6ed3a" size="84" mtime="1558021729" />
         </directory>
     http_version: 
-  recorded_at: Wed, 15 May 2019 14:56:13 GMT
+  recorded_at: Thu, 16 May 2019 15:48:51 GMT
 - request:
     method: get
     uri: http://backend:5352/source/my_project/third_package
@@ -949,16 +949,16 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '300'
+      - '302'
     body:
       encoding: UTF-8
       string: |
-        <directory name="third_package" rev="4" vrev="4" srcmd5="1a5ab546c84b864833f33e4a8e6603a8">
-          <entry name="_config" md5="baa46fb9d6197105d13f3947521d332f" size="83" mtime="1557932171" />
-          <entry name="somefile.txt" md5="57c4166c1db58a78300743ac0bf409df" size="67" mtime="1557932171" />
+        <directory name="third_package" rev="18" vrev="18" srcmd5="c5580e02210f36dcd1ecde1cfdbec8bd">
+          <entry name="_config" md5="e3b732c2642b2ba80975961e825be6bc" size="62" mtime="1558021729" />
+          <entry name="somefile.txt" md5="f1d6a65dd9b34fde9b2cac2563f9288f" size="56" mtime="1558021730" />
         </directory>
     http_version: 
-  recorded_at: Wed, 15 May 2019 14:56:13 GMT
+  recorded_at: Thu, 16 May 2019 15:48:51 GMT
 - request:
     method: get
     uri: http://backend:5352/source/my_project/third_package
@@ -984,16 +984,16 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '300'
+      - '302'
     body:
       encoding: UTF-8
       string: |
-        <directory name="third_package" rev="4" vrev="4" srcmd5="1a5ab546c84b864833f33e4a8e6603a8">
-          <entry name="_config" md5="baa46fb9d6197105d13f3947521d332f" size="83" mtime="1557932171" />
-          <entry name="somefile.txt" md5="57c4166c1db58a78300743ac0bf409df" size="67" mtime="1557932171" />
+        <directory name="third_package" rev="18" vrev="18" srcmd5="c5580e02210f36dcd1ecde1cfdbec8bd">
+          <entry name="_config" md5="e3b732c2642b2ba80975961e825be6bc" size="62" mtime="1558021729" />
+          <entry name="somefile.txt" md5="f1d6a65dd9b34fde9b2cac2563f9288f" size="56" mtime="1558021730" />
         </directory>
     http_version: 
-  recorded_at: Wed, 15 May 2019 14:56:13 GMT
+  recorded_at: Thu, 16 May 2019 15:48:51 GMT
 - request:
     method: get
     uri: http://backend:5352/source/my_project/package_with_kiwi_image
@@ -1023,11 +1023,11 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="package_with_kiwi_image" rev="2" vrev="2" srcmd5="801c545be09c1c468ff2d99b40415aac">
+        <directory name="package_with_kiwi_image" rev="9" vrev="9" srcmd5="801c545be09c1c468ff2d99b40415aac">
           <entry name="package_with_kiwi_image.kiwi" md5="1c5276faed68b141541d9ecaf6a2f3b6" size="289" mtime="1557931989" />
         </directory>
     http_version: 
-  recorded_at: Wed, 15 May 2019 14:56:13 GMT
+  recorded_at: Thu, 16 May 2019 15:48:51 GMT
 - request:
     method: get
     uri: http://backend:5352/source/my_project/package_with_kiwi_image
@@ -1057,11 +1057,11 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="package_with_kiwi_image" rev="2" vrev="2" srcmd5="801c545be09c1c468ff2d99b40415aac">
+        <directory name="package_with_kiwi_image" rev="9" vrev="9" srcmd5="801c545be09c1c468ff2d99b40415aac">
           <entry name="package_with_kiwi_image.kiwi" md5="1c5276faed68b141541d9ecaf6a2f3b6" size="289" mtime="1557931989" />
         </directory>
     http_version: 
-  recorded_at: Wed, 15 May 2019 14:56:13 GMT
+  recorded_at: Thu, 16 May 2019 15:48:51 GMT
 - request:
     method: get
     uri: http://backend:5352/build/_workerstatus
@@ -1087,7 +1087,7 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '1206'
+      - '1205'
     body:
       encoding: UTF-8
       string: |
@@ -1101,23 +1101,23 @@ http_interactions:
           <buildavg arch="i586" buildavg="1200" />
           <buildavg arch="x86_64" buildavg="1200" />
           <partition>
-            <daemon type="srcserver" state="running" starttime="1557929481" />
-            <daemon type="servicedispatch" state="running" starttime="1557929486" />
-            <daemon type="service" state="running" starttime="1557929486" />
-            <daemon type="scheduler" arch="i586" state="running" starttime="1557929487">
+            <daemon type="srcserver" state="running" starttime="1558021240" />
+            <daemon type="servicedispatch" state="running" starttime="1558021246" />
+            <daemon type="service" state="running" starttime="1558021246" />
+            <daemon type="scheduler" arch="i586" state="running" starttime="1558021246">
               <queue high="0" med="0" low="2" next="0" />
             </daemon>
-            <daemon type="scheduler" arch="x86_64" state="running" starttime="1557929487">
-              <queue high="0" med="0" low="13" next="0" />
+            <daemon type="scheduler" arch="x86_64" state="running" starttime="1558021246">
+              <queue high="0" med="0" low="3" next="0" />
             </daemon>
-            <daemon type="repserver" state="running" starttime="1557929484" />
-            <daemon type="dispatcher" state="running" starttime="1557929486" />
-            <daemon type="publisher" state="running" starttime="1557929486" />
-            <daemon type="signer" state="running" starttime="1557929487" />
+            <daemon type="repserver" state="running" starttime="1558021244" />
+            <daemon type="dispatcher" state="running" starttime="1558021246" />
+            <daemon type="publisher" state="running" starttime="1558021246" />
+            <daemon type="signer" state="running" starttime="1558021246" />
           </partition>
         </workerstatus>
     http_version: 
-  recorded_at: Wed, 15 May 2019 14:56:14 GMT
+  recorded_at: Thu, 16 May 2019 15:48:52 GMT
 - request:
     method: get
     uri: http://backend:5352/source/my_project/first_package
@@ -1143,16 +1143,16 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '300'
+      - '302'
     body:
       encoding: UTF-8
       string: |
-        <directory name="first_package" rev="4" vrev="4" srcmd5="7c006b82b57fbdcef205bdc99170823b">
-          <entry name="_config" md5="244651eb97606e0c941bec3494cb5c22" size="65" mtime="1557932171" />
-          <entry name="somefile.txt" md5="e9a938b0def484004a22f4a5adbff281" size="72" mtime="1557932171" />
+        <directory name="first_package" rev="18" vrev="18" srcmd5="62b17cbb342fb5e22359ac364a31c165">
+          <entry name="_config" md5="661226f83d2f3ccf230e8b24ed39ee8f" size="64" mtime="1558021729" />
+          <entry name="somefile.txt" md5="fd07eaf377a67e849df8dd0546a9446e" size="51" mtime="1558021729" />
         </directory>
     http_version: 
-  recorded_at: Wed, 15 May 2019 14:56:14 GMT
+  recorded_at: Thu, 16 May 2019 15:48:52 GMT
 - request:
     method: get
     uri: http://backend:5352/source/my_project/first_package
@@ -1178,16 +1178,16 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '300'
+      - '302'
     body:
       encoding: UTF-8
       string: |
-        <directory name="first_package" rev="4" vrev="4" srcmd5="7c006b82b57fbdcef205bdc99170823b">
-          <entry name="_config" md5="244651eb97606e0c941bec3494cb5c22" size="65" mtime="1557932171" />
-          <entry name="somefile.txt" md5="e9a938b0def484004a22f4a5adbff281" size="72" mtime="1557932171" />
+        <directory name="first_package" rev="18" vrev="18" srcmd5="62b17cbb342fb5e22359ac364a31c165">
+          <entry name="_config" md5="661226f83d2f3ccf230e8b24ed39ee8f" size="64" mtime="1558021729" />
+          <entry name="somefile.txt" md5="fd07eaf377a67e849df8dd0546a9446e" size="51" mtime="1558021729" />
         </directory>
     http_version: 
-  recorded_at: Wed, 15 May 2019 14:56:14 GMT
+  recorded_at: Thu, 16 May 2019 15:48:52 GMT
 - request:
     method: get
     uri: http://backend:5352/source/my_project/second_package
@@ -1213,16 +1213,16 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '301'
+      - '303'
     body:
       encoding: UTF-8
       string: |
-        <directory name="second_package" rev="4" vrev="4" srcmd5="55e41c0e78327f55a326f4346c04a9d5">
-          <entry name="_config" md5="fdcbdcd1e8a6dd14cd97f2eee3f16445" size="66" mtime="1557932171" />
-          <entry name="somefile.txt" md5="eabea33a6b9adbd1a220f20b3622b150" size="63" mtime="1557932171" />
+        <directory name="second_package" rev="18" vrev="18" srcmd5="f4eb0b1a1230d73fffc548abec0be21d">
+          <entry name="_config" md5="92a7ddc9beb20a6da4736ab6f76ef02b" size="50" mtime="1558021729" />
+          <entry name="somefile.txt" md5="d9ac4a86da681555603c2679bdd6ed3a" size="84" mtime="1558021729" />
         </directory>
     http_version: 
-  recorded_at: Wed, 15 May 2019 14:56:14 GMT
+  recorded_at: Thu, 16 May 2019 15:48:52 GMT
 - request:
     method: get
     uri: http://backend:5352/source/my_project/second_package
@@ -1248,16 +1248,16 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '301'
+      - '303'
     body:
       encoding: UTF-8
       string: |
-        <directory name="second_package" rev="4" vrev="4" srcmd5="55e41c0e78327f55a326f4346c04a9d5">
-          <entry name="_config" md5="fdcbdcd1e8a6dd14cd97f2eee3f16445" size="66" mtime="1557932171" />
-          <entry name="somefile.txt" md5="eabea33a6b9adbd1a220f20b3622b150" size="63" mtime="1557932171" />
+        <directory name="second_package" rev="18" vrev="18" srcmd5="f4eb0b1a1230d73fffc548abec0be21d">
+          <entry name="_config" md5="92a7ddc9beb20a6da4736ab6f76ef02b" size="50" mtime="1558021729" />
+          <entry name="somefile.txt" md5="d9ac4a86da681555603c2679bdd6ed3a" size="84" mtime="1558021729" />
         </directory>
     http_version: 
-  recorded_at: Wed, 15 May 2019 14:56:14 GMT
+  recorded_at: Thu, 16 May 2019 15:48:52 GMT
 - request:
     method: get
     uri: http://backend:5352/source/my_project/third_package
@@ -1283,16 +1283,16 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '300'
+      - '302'
     body:
       encoding: UTF-8
       string: |
-        <directory name="third_package" rev="4" vrev="4" srcmd5="1a5ab546c84b864833f33e4a8e6603a8">
-          <entry name="_config" md5="baa46fb9d6197105d13f3947521d332f" size="83" mtime="1557932171" />
-          <entry name="somefile.txt" md5="57c4166c1db58a78300743ac0bf409df" size="67" mtime="1557932171" />
+        <directory name="third_package" rev="18" vrev="18" srcmd5="c5580e02210f36dcd1ecde1cfdbec8bd">
+          <entry name="_config" md5="e3b732c2642b2ba80975961e825be6bc" size="62" mtime="1558021729" />
+          <entry name="somefile.txt" md5="f1d6a65dd9b34fde9b2cac2563f9288f" size="56" mtime="1558021730" />
         </directory>
     http_version: 
-  recorded_at: Wed, 15 May 2019 14:56:14 GMT
+  recorded_at: Thu, 16 May 2019 15:48:52 GMT
 - request:
     method: get
     uri: http://backend:5352/source/my_project/third_package
@@ -1318,16 +1318,16 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '300'
+      - '302'
     body:
       encoding: UTF-8
       string: |
-        <directory name="third_package" rev="4" vrev="4" srcmd5="1a5ab546c84b864833f33e4a8e6603a8">
-          <entry name="_config" md5="baa46fb9d6197105d13f3947521d332f" size="83" mtime="1557932171" />
-          <entry name="somefile.txt" md5="57c4166c1db58a78300743ac0bf409df" size="67" mtime="1557932171" />
+        <directory name="third_package" rev="18" vrev="18" srcmd5="c5580e02210f36dcd1ecde1cfdbec8bd">
+          <entry name="_config" md5="e3b732c2642b2ba80975961e825be6bc" size="62" mtime="1558021729" />
+          <entry name="somefile.txt" md5="f1d6a65dd9b34fde9b2cac2563f9288f" size="56" mtime="1558021730" />
         </directory>
     http_version: 
-  recorded_at: Wed, 15 May 2019 14:56:14 GMT
+  recorded_at: Thu, 16 May 2019 15:48:52 GMT
 - request:
     method: get
     uri: http://backend:5352/source/my_project/package_with_kiwi_image
@@ -1357,11 +1357,11 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="package_with_kiwi_image" rev="2" vrev="2" srcmd5="801c545be09c1c468ff2d99b40415aac">
+        <directory name="package_with_kiwi_image" rev="9" vrev="9" srcmd5="801c545be09c1c468ff2d99b40415aac">
           <entry name="package_with_kiwi_image.kiwi" md5="1c5276faed68b141541d9ecaf6a2f3b6" size="289" mtime="1557931989" />
         </directory>
     http_version: 
-  recorded_at: Wed, 15 May 2019 14:56:14 GMT
+  recorded_at: Thu, 16 May 2019 15:48:52 GMT
 - request:
     method: get
     uri: http://backend:5352/source/my_project/package_with_kiwi_image
@@ -1391,11 +1391,11 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="package_with_kiwi_image" rev="2" vrev="2" srcmd5="801c545be09c1c468ff2d99b40415aac">
+        <directory name="package_with_kiwi_image" rev="9" vrev="9" srcmd5="801c545be09c1c468ff2d99b40415aac">
           <entry name="package_with_kiwi_image.kiwi" md5="1c5276faed68b141541d9ecaf6a2f3b6" size="289" mtime="1557931989" />
         </directory>
     http_version: 
-  recorded_at: Wed, 15 May 2019 14:56:14 GMT
+  recorded_at: Thu, 16 May 2019 15:48:52 GMT
 - request:
     method: get
     uri: http://backend:5352/source/my_project/package_with_kiwi_image?expand=1
@@ -1425,14 +1425,14 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="package_with_kiwi_image" rev="2" vrev="2" srcmd5="801c545be09c1c468ff2d99b40415aac">
+        <directory name="package_with_kiwi_image" rev="9" vrev="9" srcmd5="801c545be09c1c468ff2d99b40415aac">
           <entry name="package_with_kiwi_image.kiwi" md5="1c5276faed68b141541d9ecaf6a2f3b6" size="289" mtime="1557931989" />
         </directory>
     http_version: 
-  recorded_at: Wed, 15 May 2019 14:56:15 GMT
+  recorded_at: Thu, 16 May 2019 15:48:53 GMT
 - request:
     method: get
-    uri: http://backend:5352/source/my_project/package_with_kiwi_image?rev=2
+    uri: http://backend:5352/source/my_project/package_with_kiwi_image?rev=9
     body:
       encoding: US-ASCII
       string: ''
@@ -1459,11 +1459,11 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="package_with_kiwi_image" rev="2" vrev="2" srcmd5="801c545be09c1c468ff2d99b40415aac">
+        <directory name="package_with_kiwi_image" rev="9" vrev="9" srcmd5="801c545be09c1c468ff2d99b40415aac">
           <entry name="package_with_kiwi_image.kiwi" md5="1c5276faed68b141541d9ecaf6a2f3b6" size="289" mtime="1557931989" />
         </directory>
     http_version: 
-  recorded_at: Wed, 15 May 2019 14:56:15 GMT
+  recorded_at: Thu, 16 May 2019 15:48:53 GMT
 - request:
     method: post
     uri: http://backend:5352/search/package/id?match=(linkinfo/@package=%22package_with_kiwi_image%22%20and%20linkinfo/@project=%22my_project%22%20and%20@project=%22my_project%22)
@@ -1498,7 +1498,7 @@ http_interactions:
         <collection>
         </collection>
     http_version: 
-  recorded_at: Wed, 15 May 2019 14:56:15 GMT
+  recorded_at: Thu, 16 May 2019 15:48:53 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom:branches:my_project/_meta?user=tom
@@ -1539,7 +1539,7 @@ http_interactions:
           <person userid="tom" role="maintainer" />
         </project>
     http_version: 
-  recorded_at: Wed, 15 May 2019 14:56:15 GMT
+  recorded_at: Thu, 16 May 2019 15:48:53 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom:branches:my_project/_project/_attribute?meta=1&user=tom
@@ -1548,7 +1548,7 @@ http_interactions:
       string: |
         <attributes>
           <attribute name="AutoCleanup" namespace="OBS">
-            <value>2019-05-18 14:56:15 +0000</value>
+            <value>2019-05-19 15:48:53 +0000</value>
           </attribute>
         </attributes>
     headers:
@@ -1570,19 +1570,19 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '165'
+      - '166'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="5">
-          <srcmd5>246a34a02da356c13245eb69b3b16e51</srcmd5>
-          <time>1557932175</time>
+        <revision rev="20">
+          <srcmd5>1b3b068fb59d2019bf8bfc2017ec1ec6</srcmd5>
+          <time>1558021733</time>
           <user>tom</user>
           <comment></comment>
           <requestid/>
         </revision>
     http_version: 
-  recorded_at: Wed, 15 May 2019 14:56:15 GMT
+  recorded_at: Thu, 16 May 2019 15:48:53 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom:branches:my_project/package_with_kiwi_image/_meta?user=tom
@@ -1590,8 +1590,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="package_with_kiwi_image" project="home:tom:branches:my_project">
-          <title>Antic Hay</title>
-          <description>Dolorem voluptas et voluptatum.</description>
+          <title>The Mermaids Singing</title>
+          <description>Autem et eum et.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -1612,16 +1612,16 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '179'
+      - '175'
     body:
       encoding: UTF-8
       string: |
         <package name="package_with_kiwi_image" project="home:tom:branches:my_project">
-          <title>Antic Hay</title>
-          <description>Dolorem voluptas et voluptatum.</description>
+          <title>The Mermaids Singing</title>
+          <description>Autem et eum et.</description>
         </package>
     http_version: 
-  recorded_at: Wed, 15 May 2019 14:56:15 GMT
+  recorded_at: Thu, 16 May 2019 15:48:53 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:tom:branches:my_project/package_with_kiwi_image?cmd=branch&noservice=1&opackage=package_with_kiwi_image&oproject=my_project&orev=801c545be09c1c468ff2d99b40415aac&user=tom
@@ -1653,16 +1653,16 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <revision rev="2" vrev="2">
+        <revision rev="6" vrev="6">
           <srcmd5>00d929e44f732106a7aa255543b32f11</srcmd5>
           <version>unknown</version>
-          <time>1557932175</time>
+          <time>1558021733</time>
           <user>tom</user>
           <comment></comment>
           <requestid/>
         </revision>
     http_version: 
-  recorded_at: Wed, 15 May 2019 14:56:15 GMT
+  recorded_at: Thu, 16 May 2019 15:48:54 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom:branches:my_project/package_with_kiwi_image/_meta?user=tom
@@ -1670,8 +1670,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="package_with_kiwi_image" project="home:tom:branches:my_project">
-          <title>Antic Hay</title>
-          <description>Dolorem voluptas et voluptatum.</description>
+          <title>The Mermaids Singing</title>
+          <description>Autem et eum et.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -1692,16 +1692,16 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '179'
+      - '175'
     body:
       encoding: UTF-8
       string: |
         <package name="package_with_kiwi_image" project="home:tom:branches:my_project">
-          <title>Antic Hay</title>
-          <description>Dolorem voluptas et voluptatum.</description>
+          <title>The Mermaids Singing</title>
+          <description>Autem et eum et.</description>
         </package>
     http_version: 
-  recorded_at: Wed, 15 May 2019 14:56:15 GMT
+  recorded_at: Thu, 16 May 2019 15:48:54 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:tom:branches:my_project/package_with_kiwi_image
@@ -1731,13 +1731,13 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="package_with_kiwi_image" rev="2" vrev="2" srcmd5="00d929e44f732106a7aa255543b32f11">
+        <directory name="package_with_kiwi_image" rev="6" vrev="6" srcmd5="00d929e44f732106a7aa255543b32f11">
           <linkinfo project="my_project" package="package_with_kiwi_image" rev="801c545be09c1c468ff2d99b40415aac" srcmd5="801c545be09c1c468ff2d99b40415aac" baserev="801c545be09c1c468ff2d99b40415aac" xsrcmd5="067709a3aecd96cf74107fa909e67564" lsrcmd5="00d929e44f732106a7aa255543b32f11" />
           <entry name="_link" md5="4e48143c1ab3ebf7faf55f7286d870d4" size="157" mtime="1557931992" />
           <entry name="package_with_kiwi_image.kiwi" md5="1c5276faed68b141541d9ecaf6a2f3b6" size="289" mtime="1557931989" />
         </directory>
     http_version: 
-  recorded_at: Wed, 15 May 2019 14:56:15 GMT
+  recorded_at: Thu, 16 May 2019 15:48:54 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:tom:branches:my_project/package_with_kiwi_image?view=info
@@ -1767,12 +1767,12 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <sourceinfo package="package_with_kiwi_image" rev="2" vrev="2" srcmd5="067709a3aecd96cf74107fa909e67564" lsrcmd5="00d929e44f732106a7aa255543b32f11" verifymd5="801c545be09c1c468ff2d99b40415aac">
+        <sourceinfo package="package_with_kiwi_image" rev="6" vrev="6" srcmd5="067709a3aecd96cf74107fa909e67564" lsrcmd5="00d929e44f732106a7aa255543b32f11" verifymd5="801c545be09c1c468ff2d99b40415aac">
           <filename>package_with_kiwi_image.kiwi</filename>
           <linked project="my_project" package="package_with_kiwi_image" />
         </sourceinfo>
     http_version: 
-  recorded_at: Wed, 15 May 2019 14:56:15 GMT
+  recorded_at: Thu, 16 May 2019 15:48:54 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:tom:branches:my_project/package_with_kiwi_image
@@ -1802,13 +1802,13 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="package_with_kiwi_image" rev="2" vrev="2" srcmd5="00d929e44f732106a7aa255543b32f11">
+        <directory name="package_with_kiwi_image" rev="6" vrev="6" srcmd5="00d929e44f732106a7aa255543b32f11">
           <linkinfo project="my_project" package="package_with_kiwi_image" rev="801c545be09c1c468ff2d99b40415aac" srcmd5="801c545be09c1c468ff2d99b40415aac" baserev="801c545be09c1c468ff2d99b40415aac" xsrcmd5="067709a3aecd96cf74107fa909e67564" lsrcmd5="00d929e44f732106a7aa255543b32f11" />
           <entry name="_link" md5="4e48143c1ab3ebf7faf55f7286d870d4" size="157" mtime="1557931992" />
           <entry name="package_with_kiwi_image.kiwi" md5="1c5276faed68b141541d9ecaf6a2f3b6" size="289" mtime="1557931989" />
         </directory>
     http_version: 
-  recorded_at: Wed, 15 May 2019 14:56:15 GMT
+  recorded_at: Thu, 16 May 2019 15:48:54 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:tom:branches:my_project/package_with_kiwi_image?cmd=diff&linkrev=base&onlyissues=1&orev=0&view=xml
@@ -1840,15 +1840,15 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="affe0613e7178bea8d035bba86acc7a4">
+        <sourcediff key="a1531a9d6538e3faacc58ae7c2354b0f">
           <old project="home:tom:branches:my_project" package="package_with_kiwi_image" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e" />
-          <new project="home:tom:branches:my_project" package="package_with_kiwi_image" rev="2" srcmd5="00d929e44f732106a7aa255543b32f11" />
+          <new project="home:tom:branches:my_project" package="package_with_kiwi_image" rev="6" srcmd5="00d929e44f732106a7aa255543b32f11" />
           <files />
           <issues>
           </issues>
         </sourcediff>
     http_version: 
-  recorded_at: Wed, 15 May 2019 14:56:16 GMT
+  recorded_at: Thu, 16 May 2019 15:48:54 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:tom:branches:my_project/package_with_kiwi_image?cmd=linkdiff&linkrev=base&onlyissues=1&view=xml
@@ -1886,7 +1886,7 @@ http_interactions:
           <files />
         </sourcediff>
     http_version: 
-  recorded_at: Wed, 15 May 2019 14:56:16 GMT
+  recorded_at: Thu, 16 May 2019 15:48:54 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom:branches:my_project/_meta?user=tom
@@ -1933,7 +1933,7 @@ http_interactions:
           </publish>
         </project>
     http_version: 
-  recorded_at: Wed, 15 May 2019 14:56:16 GMT
+  recorded_at: Thu, 16 May 2019 15:48:54 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:tom:branches:my_project/package_with_kiwi_image
@@ -1963,13 +1963,13 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="package_with_kiwi_image" rev="2" vrev="2" srcmd5="00d929e44f732106a7aa255543b32f11">
+        <directory name="package_with_kiwi_image" rev="6" vrev="6" srcmd5="00d929e44f732106a7aa255543b32f11">
           <linkinfo project="my_project" package="package_with_kiwi_image" rev="801c545be09c1c468ff2d99b40415aac" srcmd5="801c545be09c1c468ff2d99b40415aac" baserev="801c545be09c1c468ff2d99b40415aac" xsrcmd5="067709a3aecd96cf74107fa909e67564" lsrcmd5="00d929e44f732106a7aa255543b32f11" />
           <entry name="_link" md5="4e48143c1ab3ebf7faf55f7286d870d4" size="157" mtime="1557931992" />
           <entry name="package_with_kiwi_image.kiwi" md5="1c5276faed68b141541d9ecaf6a2f3b6" size="289" mtime="1557931989" />
         </directory>
     http_version: 
-  recorded_at: Wed, 15 May 2019 14:56:16 GMT
+  recorded_at: Thu, 16 May 2019 15:48:54 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:tom:branches:my_project/package_with_kiwi_image
@@ -1999,13 +1999,13 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="package_with_kiwi_image" rev="2" vrev="2" srcmd5="00d929e44f732106a7aa255543b32f11">
+        <directory name="package_with_kiwi_image" rev="6" vrev="6" srcmd5="00d929e44f732106a7aa255543b32f11">
           <linkinfo project="my_project" package="package_with_kiwi_image" rev="801c545be09c1c468ff2d99b40415aac" srcmd5="801c545be09c1c468ff2d99b40415aac" baserev="801c545be09c1c468ff2d99b40415aac" xsrcmd5="067709a3aecd96cf74107fa909e67564" lsrcmd5="00d929e44f732106a7aa255543b32f11" />
           <entry name="_link" md5="4e48143c1ab3ebf7faf55f7286d870d4" size="157" mtime="1557931992" />
           <entry name="package_with_kiwi_image.kiwi" md5="1c5276faed68b141541d9ecaf6a2f3b6" size="289" mtime="1557931989" />
         </directory>
     http_version: 
-  recorded_at: Wed, 15 May 2019 14:56:16 GMT
+  recorded_at: Thu, 16 May 2019 15:48:54 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:tom:branches:my_project/package_with_kiwi_image/package_with_kiwi_image.kiwi
@@ -2040,7 +2040,7 @@ http_interactions:
         primary=\"true\" boot=\"oemboot/suse-13.2\"/>\n    </preferences>\n  </image>\n
         \ "
     http_version: 
-  recorded_at: Wed, 15 May 2019 14:56:16 GMT
+  recorded_at: Thu, 16 May 2019 15:48:54 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:tom:branches:my_project/package_with_kiwi_image
@@ -2070,13 +2070,13 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="package_with_kiwi_image" rev="2" vrev="2" srcmd5="00d929e44f732106a7aa255543b32f11">
+        <directory name="package_with_kiwi_image" rev="6" vrev="6" srcmd5="00d929e44f732106a7aa255543b32f11">
           <linkinfo project="my_project" package="package_with_kiwi_image" rev="801c545be09c1c468ff2d99b40415aac" srcmd5="801c545be09c1c468ff2d99b40415aac" baserev="801c545be09c1c468ff2d99b40415aac" xsrcmd5="067709a3aecd96cf74107fa909e67564" lsrcmd5="00d929e44f732106a7aa255543b32f11" />
           <entry name="_link" md5="4e48143c1ab3ebf7faf55f7286d870d4" size="157" mtime="1557931992" />
           <entry name="package_with_kiwi_image.kiwi" md5="1c5276faed68b141541d9ecaf6a2f3b6" size="289" mtime="1557931989" />
         </directory>
     http_version: 
-  recorded_at: Wed, 15 May 2019 14:56:16 GMT
+  recorded_at: Thu, 16 May 2019 15:48:54 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom:branches:my_project/package_with_kiwi_image/_meta?user=tom
@@ -2084,8 +2084,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="package_with_kiwi_image" project="home:tom:branches:my_project">
-          <title>Antic Hay</title>
-          <description>Dolorem voluptas et voluptatum.</description>
+          <title>The Mermaids Singing</title>
+          <description>Autem et eum et.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -2106,16 +2106,16 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '179'
+      - '175'
     body:
       encoding: UTF-8
       string: |
         <package name="package_with_kiwi_image" project="home:tom:branches:my_project">
-          <title>Antic Hay</title>
-          <description>Dolorem voluptas et voluptatum.</description>
+          <title>The Mermaids Singing</title>
+          <description>Autem et eum et.</description>
         </package>
     http_version: 
-  recorded_at: Wed, 15 May 2019 14:56:16 GMT
+  recorded_at: Thu, 16 May 2019 15:48:54 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom:branches:my_project/package_with_kiwi_image/_meta?user=tom
@@ -2123,8 +2123,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="package_with_kiwi_image" project="home:tom:branches:my_project">
-          <title>Antic Hay</title>
-          <description>Dolorem voluptas et voluptatum.</description>
+          <title>The Mermaids Singing</title>
+          <description>Autem et eum et.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -2145,14 +2145,14 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '179'
+      - '175'
     body:
       encoding: UTF-8
       string: |
         <package name="package_with_kiwi_image" project="home:tom:branches:my_project">
-          <title>Antic Hay</title>
-          <description>Dolorem voluptas et voluptatum.</description>
+          <title>The Mermaids Singing</title>
+          <description>Autem et eum et.</description>
         </package>
     http_version: 
-  recorded_at: Wed, 15 May 2019 14:56:16 GMT
+  recorded_at: Thu, 16 May 2019 15:48:54 GMT
 recorded_with: VCR 4.0.0

--- a/src/api/spec/features/webui/image_templates_spec.rb
+++ b/src/api/spec/features/webui/image_templates_spec.rb
@@ -77,7 +77,6 @@ RSpec.feature 'ImageTemplates', type: :feature, js: true do
       fill_in 'target_package', with: 'package_with_kiwi_image'
 
       click_button('Create appliance')
-      find('#kiwi-image-update-form')
       expect(page).to have_text('home:tom:branches:my_project > package_with_kiwi_image')
     end
   end

--- a/src/api/spec/features/webui/image_templates_spec.rb
+++ b/src/api/spec/features/webui/image_templates_spec.rb
@@ -52,7 +52,6 @@ RSpec.feature 'ImageTemplates', type: :feature, js: true do
 
     scenario 'branch Kiwi image template' do
       skip_if_bootstrap
-
       visit image_templates_path
       expect(page).to have_css('input.create_appliance[disabled]')
 


### PR DESCRIPTION

![image](https://user-images.githubusercontent.com/16052290/57854750-4463fe80-77e9-11e9-8d27-1c32712e9cf0.png)

![image](https://user-images.githubusercontent.com/16052290/57854767-55147480-77e9-11e9-9d34-7c3206c67535.png)

![image](https://user-images.githubusercontent.com/16052290/57854813-6bbacb80-77e9-11e9-99ad-1e7582f5a98c.png)

![image](https://user-images.githubusercontent.com/16052290/57854943-c2280a00-77e9-11e9-8228-577de733824e.png)


Supersedes https://github.com/openSUSE/open-build-service/pull/6170

Remember that by now we don't want to refactor/get ride of the horrible JavaScript. It was like that in the old UI and by now we just migrate it and we will refactor if afterwards.

