### PR TITLE
Override Bootstrap monospace fonts with 'monospace'

### DIFF
--- a/src/api/app/assets/stylesheets/webui2/bootstrap_variables/fonts.scss
+++ b/src/api/app/assets/stylesheets/webui2/bootstrap_variables/fonts.scss
@@ -1,0 +1,2 @@
+// Override Bootstrap's default fonts
+$font-family-monospace: monospace;

--- a/src/api/app/assets/stylesheets/webui2/cm2/suse.scss
+++ b/src/api/app/assets/stylesheets/webui2/cm2/suse.scss
@@ -1,6 +1,6 @@
 .cm-s-bootstrap {
   &.CodeMirror {
-    font-family: $font-family-monospace, monospace;
+    font-family: $font-family-monospace;
     height: auto;
     background: $card-bg;
     color: $body-color;

--- a/src/api/app/assets/stylesheets/webui2/webui2.css.scss
+++ b/src/api/app/assets/stylesheets/webui2/webui2.css.scss
@@ -14,6 +14,7 @@
 
 @import 'bootstrap_variables/breakpoints';
 @import 'bootstrap_variables/colors';
+@import 'bootstrap_variables/fonts';
 @import 'bootstrap_variables/spacers';
 @import 'bootstrap';
 @import 'bootstrap-modal';


### PR DESCRIPTION
This way the monospace font defined in the browser will be used instead of those defined in Bootstrap.

Fixes #7253.