### PR TITLE
Pass memory limit for lxc workers

### DIFF
--- a/dist/obsworker
+++ b/dist/obsworker
@@ -461,6 +461,12 @@ case "$1" in
                 WORKER="--vm-worker ${WORKERS[$I_INDEX]}"
                 WORKER_NR="--vm-worker-nr $I"
                 OBS_WORKER_OPT="$OBS_WORKER_OPT1 $WORKER $WORKER_NR $VMDISK_FILESYSTEM $VMDISK_MOUNT_OPTIONS $VMDISK_CLEAN"
+            elif [ -n "$vmopt" -a "$OBS_VM_TYPE" = 'lxc' ]; then
+                DEVICE=
+                SWAP=
+                if [ -n "$OBS_INSTANCE_MEMORY" ]; then
+                    MEMORY="--vm-memory $OBS_INSTANCE_MEMORY"
+                fi
             else
                 DEVICE=
                 SWAP=

--- a/src/backend/bs_worker
+++ b/src/backend/bs_worker
@@ -309,7 +309,7 @@ Usage: $0 [OPTION] --root <directory> --statedir <directory>
 
        --vm-initrd : set initrd to use (xen/kvm)
 
-       --vm-memory : set amount of memory to use (xen/kvm)
+       --vm-memory : set amount of memory to use (xen/kvm/lxc)
 
        --vm-worker NAME
                    : (z/VM) set name of the actual worker
@@ -3143,6 +3143,10 @@ sub dobuild {
     push @args, "--vm-worker", $vm_worker_name;
     push @args, "--vm-kernel", $vm_kernel;
     push @args, "--openstack-flavor", "$openstack_flavor";
+  } elsif ($vm eq 'lxc') {
+    push @args, '--root', $buildroot;
+    push @args, '--vm-type', $vm;
+    push @args, '--memory', $vm_memory if $vm_memory;
   } else {
     print "VM-TYPE $vm not detected" if $vm;
     push @args, '--root', $buildroot;


### PR DESCRIPTION
After https://github.com/openSUSE/obs-build/pull/287, lxc containers
can now use memory limit.

Signed-off-by: Luiz Angelo Daros de Luca <luizluca@gmail.com>



<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md
-->
