### PR TITLE
Increase contrast on default text

### DIFF
--- a/src/api/app/assets/stylesheets/webui2/bootstrap_variables/colors.scss
+++ b/src/api/app/assets/stylesheets/webui2/bootstrap_variables/colors.scss
@@ -1,4 +1,5 @@
 // Override Bootstrap's default colors
+$body-color: #000000;
 $body-bg: #f6f6f6;
 $gray-100: #f8f9fa;
 $gray-200: #f0f0f0;
@@ -15,6 +16,7 @@ $secondary: $obs_blue;
 $warning: $obs_yellow;
 
 $card-cap-bg: $gray-200;
+$input-color: #000000;
 $link-hover-color: $obs_green;
 $link-color: $obs_blue;
 


### PR DESCRIPTION
The colors used by Bootstrap for the generic text (text-body) and for form controls are not #000000. Changing it to #000000 the contrast on default text is increased.

Fixes #7254.