### PR TITLE
Fix issue 7419

### DIFF
--- a/src/api/app/models/attrib.rb
+++ b/src/api/app/models/attrib.rb
@@ -85,7 +85,7 @@ class Attrib < ApplicationRecord
   end
 
   def write_container_attributes
-    container.try(:write_attributes)
+    container.write_attributes if container && !container.destroyed?
   end
 
   def update_with_associations(values = [], issues = [])

--- a/src/api/app/models/attrib.rb
+++ b/src/api/app/models/attrib.rb
@@ -85,9 +85,7 @@ class Attrib < ApplicationRecord
   end
 
   def write_container_attributes
-    # also called if container is deleted...
-    return unless (c = container)
-    c.write_attributes
+    container.try(:write_attributes)
   end
 
   def update_with_associations(values = [], issues = [])


### PR DESCRIPTION
After deletion of attribute instances we send a request to the backend
to update it there. But if the attribute deletion happens as part of the
project / package deletion we don't want this to happen.
Otherwise it could happen that the attribute deletion (after_commit
callback) is requested from the backend after the project / package
was deleted.

Admittedly this is a shot in the dark, as I couldn't reproduce this
issue. But this seems to be the only possible cause for the reported
failure.