### PR TITLE
[dist] setup-appliance.sh: wait for 'real' FQHN

### DIFF
--- a/dist/setup-appliance.sh
+++ b/dist/setup-appliance.sh
@@ -140,7 +140,7 @@ function get_hostname {
     FQHOSTNAME=$1
   else
     TIMEOUT=600
-    while [ -z "$FQHOSTNAME" ];do
+    while [ -z "$FQHOSTNAME" -o "$FQHOSTNAME" = "localhost" ];do
       FQHOSTNAME=`hostname -f 2>/dev/null`
       TIMEOUT=$(($TIMEOUT-1))
       [ "$TIMEOUT" -le 0 ] && break


### PR DESCRIPTION
While booting a new appliance we have a short timeframe
where `hostname -f` gives back "localhost", which is invalid
for generating the SSL cert.

With this patch we wait for a FQHN which is not empty and not localhost.


