### PR TITLE
Migrate search page to Bootstrap

### DIFF
--- a/src/api/.haml-lint.yml
+++ b/src/api/.haml-lint.yml
@@ -59,3 +59,5 @@ exclude:
 - 'app/views/statistics/**/*'
 - 'app/views/status/**/*'
 - 'app/views/webui/**/*'
+# Kaminari views were created by its generator, they don't pass lint tests
+- 'app/views/webui2/webui/kaminari/**/*'

--- a/src/api/app/assets/stylesheets/webui/application/search.scss
+++ b/src/api/app/assets/stylesheets/webui/application/search.scss
@@ -1,3 +1,5 @@
+// TODO: bento_only
+
 #search-form {
   width: 600px;
   margin-left: auto ;

--- a/src/api/app/controllers/webui/search_controller.rb
+++ b/src/api/app/controllers/webui/search_controller.rb
@@ -1,11 +1,11 @@
 class Webui::SearchController < Webui::WebuiController
   before_action :set_attribute_list
   before_action :set_tracker_list
-  before_action :set_parameters
+  before_action :set_parameters, except: :issue
+  before_action :check_beta, only: :issue
 
   def index
-    # TODO: Remove if once migration of the view is finished
-    switch_to_webui2 if Rails.env.development?
+    switch_to_webui2
 
     search
   end
@@ -24,6 +24,26 @@ class Webui::SearchController < Webui::WebuiController
     end
 
     @results = OwnerSearch::Assignee.new(limit: @owner_limit.to_s, devel: @owner_devel.to_s).for(@search_text)
+    flash[:notice] = 'Your search did not return any results.' if @results.empty?
+  end
+
+  def issue
+    switch_to_webui2
+    return unless params[:issue] && params[:issue_tracker]
+
+    search_issue
+    search_what
+
+    if @search_issue.blank?
+      flash[:error] = 'Issue ID can not be empty.'
+      return
+    end
+
+    @per_page = 20
+    search = FullTextSearch.new(classes: @search_what,
+                                issue_name: @search_issue,
+                                issue_tracker_name: @search_tracker)
+    @results = search.search(page: params[:page], per_page: @per_page)
     flash[:notice] = 'Your search did not return any results.' if @results.empty?
   end
 
@@ -106,20 +126,13 @@ class Webui::SearchController < Webui::WebuiController
     @search_attrib_type_id = nil
     @search_attrib_type_id = params[:attrib_type_id] if params[:attrib_type_id].present?
 
-    @search_issue = nil
-    @search_issue = params[:issue].strip if params[:issue].present?
-
-    @search_tracker = nil
-    @search_tracker = params[:issue_tracker] if params[:issue_tracker].present?
+    search_issue
 
     @search_text = ''
     @search_text = params[:search_text].strip if params[:search_text].present?
     @search_text = @search_text.delete("'[]\n")
 
-    @search_what = []
-    @search_what << 'package' if params[:package] == '1'
-    @search_what << 'project' if params[:project] == '1' || !@search_issue
-    @search_what << 'owner' if params[:owner] == '1' && !@search_issue
+    search_what
 
     @search_where = []
     @search_where << 'name' if params[:name] == '1'
@@ -135,6 +148,30 @@ class Webui::SearchController < Webui::WebuiController
     @owner_devel = '1' if params[:devel] == 'on'
   end
 
+  def search_issue
+    @search_issue = params[:issue].presence.try(:strip)
+
+    @search_tracker = params[:issue_tracker].presence
+  end
+
+  def search_what
+    # FIXME: Simplify this after webui2 final migration.
+    @search_what = []
+    switch_to_webui2? ? search_what_for_webui2 : search_what_for_bento
+    @search_what << 'owner' if params[:owner] == '1' && !@search_issue
+  end
+
+  def search_what_for_webui2
+    @search_what << 'package' if params[:search_for].in?(['0', '2'])
+    @search_what << 'project' if params[:search_for].in?(['0', '1'])
+  end
+
+  def search_what_for_bento
+    # TODO: bento_only
+    @search_what << 'package' if params[:package] == '1'
+    @search_what << 'project' if params[:project] == '1' || !@search_issue
+  end
+
   def set_attribute_list
     @attrib_type_list = AttribType.includes(:attrib_namespace).map do |t|
       ["#{t.attrib_namespace.name}:#{t.name}", t['id']]
@@ -148,5 +185,12 @@ class Webui::SearchController < Webui::WebuiController
       ["#{t.name} (#{t.description})", t.name]
     end
     @default_tracker = ::Configuration.default_tracker
+  end
+
+  # FIXME: bento_only remove this callback when we have fully migrated to Boostrap
+  # This view only exists for webui2, if the user leaves the beta program at this point,
+  # they are redirected to the index page.
+  def check_beta
+    redirect_to action: :index unless switch_to_webui2?
   end
 end

--- a/src/api/app/views/webui2/webui/kaminari/_first_page.html.haml
+++ b/src/api/app/views/webui2/webui/kaminari/_first_page.html.haml
@@ -1,0 +1,2 @@
+%li.page-item
+  = link_to_unless current_page.first?, raw(t 'views.webui2.pagination.first'), url, remote: remote, class: 'page-link'

--- a/src/api/app/views/webui2/webui/kaminari/_gap.html.haml
+++ b/src/api/app/views/webui2/webui/kaminari/_gap.html.haml
@@ -1,0 +1,2 @@
+%li.page-item.disabled
+  = link_to raw(t 'views.webui2.pagination.truncate'), '#', class: 'page-link'

--- a/src/api/app/views/webui2/webui/kaminari/_last_page.html.haml
+++ b/src/api/app/views/webui2/webui/kaminari/_last_page.html.haml
@@ -1,0 +1,2 @@
+%li.page-item
+  = link_to_unless current_page.last?, raw(t 'views.webui2.pagination.last'), url, remote: remote, class: 'page-link'

--- a/src/api/app/views/webui2/webui/kaminari/_next_page.html.haml
+++ b/src/api/app/views/webui2/webui/kaminari/_next_page.html.haml
@@ -1,0 +1,2 @@
+%li.page-item
+  = link_to_unless current_page.last?, raw(t 'views.webui2.pagination.next'), url, rel: 'next', remote: remote, class: 'page-link'

--- a/src/api/app/views/webui2/webui/kaminari/_page.html.haml
+++ b/src/api/app/views/webui2/webui/kaminari/_page.html.haml
@@ -1,0 +1,6 @@
+- if page.current?
+  %li.page-item.active
+    = content_tag :a, page, data: { remote: remote }, rel: (page.next? ? 'next' : (page.prev? ? 'prev' : nil)), class: 'page-link'
+- else
+  %li.page-item
+    = link_to page, url, remote: remote, rel: (page.next? ? 'next' : (page.prev? ? 'prev' : nil)), class: 'page-link'

--- a/src/api/app/views/webui2/webui/kaminari/_paginator.html.haml
+++ b/src/api/app/views/webui2/webui/kaminari/_paginator.html.haml
@@ -1,0 +1,12 @@
+= paginator.render do
+  %nav
+    %ul.pagination.justify-content-center
+      = first_page_tag unless current_page.first?
+      = prev_page_tag unless current_page.first?
+      - each_page do |page|
+        - if page.left_outer? || page.right_outer? || page.inside_window?
+          = page_tag page
+        - elsif !page.was_truncated?
+          = gap_tag
+      = next_page_tag unless current_page.last?
+      = last_page_tag unless current_page.last?

--- a/src/api/app/views/webui2/webui/kaminari/_prev_page.html.haml
+++ b/src/api/app/views/webui2/webui/kaminari/_prev_page.html.haml
@@ -1,0 +1,2 @@
+%li.page-item
+  = link_to_unless current_page.first?, raw(t 'views.webui2.pagination.previous'), url, rel: 'prev', remote: remote, class: 'page-link'

--- a/src/api/app/views/webui2/webui/patchinfo/form/_issues.html.haml
+++ b/src/api/app/views/webui2/webui/patchinfo/form/_issues.html.haml
@@ -30,4 +30,3 @@
 .form-group.col-md-6
   = link_to('Update issues from sources', update_issues_patchinfo_path(project: project, package: package),
             data: { confirm: 'Attention! All unsaved data will be lost! Continue?' }, method: :post)
-

--- a/src/api/app/views/webui2/webui/search/_advanced_search.html.haml
+++ b/src/api/app/views/webui2/webui/search/_advanced_search.html.haml
@@ -1,0 +1,19 @@
+.form-group
+  .card.mt-2.collapse#advanced-container
+    .card-body
+      %label Search in:
+      .form-group
+        .custom-control.custom-checkbox
+          = check_box_tag('name', 1, params[:name].nil? || params[:name] == '1', class: 'custom-control-input')
+          %label.custom-control-label{ for: 'name' } Name
+        .custom-control.custom-checkbox
+          = check_box_tag('title', 1, params[:title] == '1', class: 'custom-control-input')
+          %label.custom-control-label{ for: 'title' } Title
+        .custom-control.custom-checkbox
+          = check_box_tag('description', 1, params[:description] == '1', class: 'custom-control-input')
+          %label.custom-control-label{ for: 'description' } Description
+      .form-group.row
+        .col-12.col-md-6
+          %label.d-block{ for: 'attrib_list' } Require attribute:
+          = select_tag(:attrib_type_id, options_for_select(attrib_type_list, params[:attrib_type_id]),
+                       id: 'attribute_list', class: 'custom-select')

--- a/src/api/app/views/webui2/webui/search/_breadcrumb_items.html.haml
+++ b/src/api/app/views/webui2/webui/search/_breadcrumb_items.html.haml
@@ -4,5 +4,7 @@
   - case action_name
   - when 'index'
     Search
+  - when 'issue'
+    Search Issues
   - when 'owner'
     Search Owners

--- a/src/api/app/views/webui2/webui/search/_results.html.haml
+++ b/src/api/app/views/webui2/webui/search/_results.html.haml
@@ -1,0 +1,26 @@
+.mt-4#search-results
+  %h4 Results:
+  - results.each do |result|
+    :ruby
+      if result.is_a? Project
+        project = result.name
+        package = nil
+      else
+        project = result.project_name
+        package = result.name
+      end
+    .search_result.mt-3
+      %h6
+        %i.mr-1.fa{ class: result.is_a?(Project) ? 'fa-cubes text-secondary' : 'fa-archive text-warning' }
+        = project_or_package_link(project: project, package: package, short: false, trim_to: nil)
+        %span.d-none= result.sphinx_attributes
+        = ": #{result.title}" if result.title.present?
+      %p.pl-4.small.text-muted
+        - if result.description.blank?
+          = '...'
+        - else
+          - desc = truncate(result.description, length: 80)
+          - desc.split(/\n/).each do |line|
+            = highlight(line, search_text, highlighter: '<b>\1</b>')
+  - if per_page
+    = paginate results, views_prefix: 'webui2/webui'

--- a/src/api/app/views/webui2/webui/search/_results_issue.html.haml
+++ b/src/api/app/views/webui2/webui/search/_results_issue.html.haml
@@ -1,0 +1,24 @@
+.mt-4#search-results
+  %h4 Results:
+  - results.each do |result|
+    :ruby
+      if result.is_a? Project
+        project = result.name
+        package = nil
+      else
+        project = result.project_name
+        package = result.name
+      end
+    .search_result.mt-3
+      %h6
+        %i.mr-1.fa{ class: result.is_a?(Project) ? 'fa-cubes text-secondary' : 'fa-archive text-warning' }
+        = project_or_package_link(project: project, package: package, short: false, trim_to: nil)
+        %span.d-none= result.sphinx_attributes
+        = ": #{result.title}" if result.title.present?
+      %p.pl-4.small.text-muted
+        - if result.description.blank?
+          = '...'
+        - else
+          = truncate(result.description, length: 80)
+  - if per_page
+    = paginate results, views_prefix: 'webui2/webui'

--- a/src/api/app/views/webui2/webui/search/_search_for.html.haml
+++ b/src/api/app/views/webui2/webui/search/_search_for.html.haml
@@ -1,0 +1,14 @@
+.form-group.form-inline
+  - search_for_options = options_for_select([['All', '0'], ['Projects', '1'], ['Packages', '2']], params.fetch(:search_for, '0'))
+  -# FIXME: The dropdown arrow is a bit far when 'All' is selected
+  = select_tag('search_for', search_for_options, class: 'custom-select border-0 pl-0 w-auto')
+
+  %button.btn.btn-outline-secondary.ml-2.collapsed{ type: 'button', aria: { controls: 'collapse-1', expanded: 'false' },
+                                                'data-toggle' => 'collapse', href: '#advanced-container', role: 'button' }
+    %span.collapser
+      %span.d-none.d-md-inline-block Advanced
+      %i.fa.fa-caret-up
+    %span.expander
+      %span.d-none.d-md-inline-block Advanced
+      %i.fa.fa-caret-down
+

--- a/src/api/app/views/webui2/webui/search/_tabs.html.haml
+++ b/src/api/app/views/webui2/webui/search/_tabs.html.haml
@@ -3,4 +3,6 @@
     %li.nav-item
       = tab_link('Packages/Projects', search_path, action_name == 'index', false)
     %li.nav-item
+      = tab_link('Issues', search_issue_path, action_name == 'issue', false)
+    %li.nav-item
       = tab_link('Owners', search_owner_path, action_name == 'owner', false)

--- a/src/api/app/views/webui2/webui/search/index.html.haml
+++ b/src/api/app/views/webui2/webui/search/index.html.haml
@@ -4,3 +4,18 @@
   = render partial: 'tabs'
   .card-body
     %h3 Search for packages or projects:
+    .d-flex.justify-content-center
+      = form_tag(search_path, method: :get, class: 'my-3 w-75') do
+        .form-group.input-group
+          = text_field_tag('search_text', params[:search_text], placeholder: 'Search', autofocus: true,
+                           required: true, minlength: 2, class: 'form-control rounded', id: 'search_input')
+          %button.btn.btn-primary.ml-1{ type: 'submit', title: 'Search' }
+            %i.fa.fa-search
+
+        = render(partial: 'search_for')
+        = render(partial: 'advanced_search', locals: { attrib_type_list: @attrib_type_list,
+                                                         issue_tracker_list: @issue_tracker_list,
+                                                         default_tracker: @default_tracker })
+
+    - if @results.present?
+      = render(partial: 'results', locals: { results: @results, per_page: @per_page, search_text: @search_text })

--- a/src/api/app/views/webui2/webui/search/issue.html.haml
+++ b/src/api/app/views/webui2/webui/search/issue.html.haml
@@ -1,0 +1,20 @@
+- @pagetitle = 'Search Issues'
+
+.card.mb-3
+  = render partial: 'tabs'
+  .card-body
+    %h3 Search issues:
+    .d-flex.justify-content-center
+      = form_tag(search_issue_path, method: :get, class: 'my-3 w-75') do
+        .form-group.input-group
+          = text_field_tag('issue', params[:issue], placeholder: 'Issue ID', autofocus: true, required: true, class: 'form-control')
+
+          = select_tag(:issue_tracker, options_for_select(@issue_tracker_list, params[:issue_tracker] || @default_tracker),
+                      class: 'custom-select rounded-right')
+
+          %button.btn.btn-primary.ml-1{ type: 'submit', title: 'Search' }
+            %i.fa.fa-search
+        = render(partial: 'search_for')
+
+    - if @results.present?
+      = render(partial: 'results_issue', locals: { results: @results, per_page: @per_page })

--- a/src/api/config/locales/kaminari.en.yml
+++ b/src/api/config/locales/kaminari.en.yml
@@ -7,3 +7,11 @@ en:
       previous: "&lt;Prev"
       next: "Next&gt;"
       truncate: "..."
+    # TODO: Use these translations when switch_to_webui2, without webui2 namespace. Modify also the kaminari views affected.
+    webui2:
+      pagination:
+        first: "First"
+        last: "Last"
+        previous: "Previous"
+        next: "Next"
+        truncate: "..."

--- a/src/api/config/routes.rb
+++ b/src/api/config/routes.rb
@@ -381,6 +381,7 @@ OBSApi::Application.routes.draw do
     controller 'webui/search' do
       match 'search' => :index, via: [:get, :post]
       get 'search/owner' => :owner
+      get 'search/issue' => :issue
     end
 
     controller 'webui/user' do

--- a/src/api/spec/features/webui/search_spec.rb
+++ b/src/api/spec/features/webui/search_spec.rb
@@ -27,7 +27,7 @@ RSpec.feature 'Search', type: :feature, js: true do
     page.evaluate_script('$.fx.off = true;') # Needed to disable javascript animations that can end in not checking the checkboxes properly
 
     fill_in 'search_input', with: package.name
-    click_button 'search_button'
+    click_button 'Search'
 
     within '#search-results' do
       expect(page).to have_link(user.home_project_name)
@@ -44,9 +44,14 @@ RSpec.feature 'Search', type: :feature, js: true do
 
     fill_in 'search_input', with: apache2.name
     click_button 'Advanced'
-    check 'project'
-    uncheck 'package'
-    click_button 'search_button'
+    if is_bootstrap?
+      select('Projects', from: 'search_for')
+    else
+      check('project')
+      uncheck('package')
+    end
+
+    click_button 'Search'
 
     within '#search-results' do
       expect(page).to have_link(apache2.name)
@@ -65,10 +70,15 @@ RSpec.feature 'Search', type: :feature, js: true do
 
     fill_in 'search_input', with: 'goal'
     click_button 'Advanced'
-    check 'package'
-    uncheck 'project'
-    check 'title'
-    click_button 'search_button'
+    if is_bootstrap?
+      select('Packages', from: 'search_for')
+    else
+      check('package')
+      uncheck('project')
+    end
+
+    check 'title', allow_label_click: true
+    click_button 'Search'
 
     within '#search-results' do
       expect(page).to have_link(user.home_project_name)
@@ -87,10 +97,10 @@ RSpec.feature 'Search', type: :feature, js: true do
 
     fill_in 'search_input', with: 'awesome'
     click_button 'Advanced'
-    check 'title'
-    uncheck 'name'
-    uncheck 'description'
-    click_button 'search_button'
+    check 'title', allow_label_click: true
+    uncheck 'name', allow_label_click: true
+    uncheck 'description', allow_label_click: true
+    click_button 'Search'
 
     within '#search-results' do
       expect(page).to have_link(apache.name)
@@ -108,10 +118,10 @@ RSpec.feature 'Search', type: :feature, js: true do
 
     fill_in 'search_input', with: 'awesome'
     click_button 'Advanced'
-    uncheck 'title'
-    uncheck 'name'
-    check 'description'
-    click_button 'search_button'
+    uncheck 'title', allow_label_click: true
+    uncheck 'name', allow_label_click: true
+    check 'description', allow_label_click: true
+    click_button 'Search'
 
     within '#search-results' do
       expect(page).to have_link(apache.name)
@@ -128,13 +138,20 @@ RSpec.feature 'Search', type: :feature, js: true do
     page.evaluate_script('$.fx.off = true;') # Needed to disable javascript animations that can end in not checking the checkboxes properly
 
     fill_in 'search_input', with: 'fooo'
-    click_button 'search_button'
+    click_button 'Search'
 
-    expect(find('#flash-messages')).to have_text('Your search did not return any results.')
+    if is_bootstrap?
+      within('#flash') do
+        expect(page).to have_text('Your search did not return any results.')
+      end
+    else
+      expect(find('#flash-messages')).to have_text('Your search did not return any results.')
+    end
     expect(page).to have_selector('#search-results', count: 0)
   end
 
   scenario 'search in no types' do
+    skip_if_bootstrap # This specs doesn't make sense in the Bootstrap UI since we search for packages, projects or both.
     apache2
     reindex_for_search
 
@@ -145,9 +162,15 @@ RSpec.feature 'Search', type: :feature, js: true do
     click_button 'Advanced'
     uncheck 'project'
     uncheck 'package'
-    click_button 'search_button'
+    click_button 'Search'
 
-    expect(find('#flash-messages')).to have_text('Your search did not return any results.')
+    if is_bootstrap?
+      within('#flash') do
+        expect(page).to have_text('Your search did not return any results.')
+      end
+    else
+      expect(find('#flash-messages')).to have_text('Your search did not return any results.')
+    end
     expect(page).to have_selector('#search-results', count: 0)
   end
 
@@ -160,12 +183,18 @@ RSpec.feature 'Search', type: :feature, js: true do
 
     fill_in 'search_input', with: 'awesome'
     click_button 'Advanced'
-    uncheck 'title'
-    uncheck 'name'
-    uncheck 'description'
-    click_button 'search_button'
+    uncheck 'title', allow_label_click: true
+    uncheck 'name', allow_label_click: true
+    uncheck 'description', allow_label_click: true
+    click_button 'Search'
 
-    expect(find('#flash-messages')).to have_text('You have to search for awesome in something. Click the advanced button...')
+    if is_bootstrap?
+      within('#flash') do
+        expect(page).to have_text('You have to search for awesome in something. Click the advanced button...')
+      end
+    else
+      expect(find('#flash-messages')).to have_text('You have to search for awesome in something. Click the advanced button...')
+    end
     expect(page).to have_selector('#search-results', count: 0)
   end
 
@@ -178,9 +207,9 @@ RSpec.feature 'Search', type: :feature, js: true do
 
     fill_in 'search_input', with: 'вокябюч'
     click_button 'Advanced'
-    uncheck 'name'
-    check 'title'
-    click_button 'search_button'
+    uncheck 'name', allow_label_click: true
+    check 'title', allow_label_click: true
+    click_button 'Search'
 
     within '#search-results' do
       expect(page).to have_link(russian_project.name)
@@ -199,10 +228,16 @@ RSpec.feature 'Search', type: :feature, js: true do
 
       fill_in 'search_input', with: 'hidden'
       click_button 'Advanced'
-      check 'title'
-      click_button 'search_button'
+      check 'title', allow_label_click: true
+      click_button 'Search'
 
-      expect(find('#flash-messages')).to have_text('Your search did not return any results.')
+      if is_bootstrap?
+        within('#flash') do
+          expect(page).to have_text('Your search did not return any results.')
+        end
+      else
+        expect(find('#flash-messages')).to have_text('Your search did not return any results.')
+      end
       expect(page).to have_selector('#search-results', count: 0)
     end
 
@@ -218,8 +253,8 @@ RSpec.feature 'Search', type: :feature, js: true do
 
       fill_in 'search_input', with: 'hidden'
       click_button 'Advanced'
-      check 'title'
-      click_button 'search_button'
+      check 'title', allow_label_click: true
+      click_button 'Search'
 
       within '#search-results' do
         expect(page).to have_link(hidden_package.name)


### PR DESCRIPTION
Also modifies kaminari views and locales, so pagination is now more Bootstrap style.

**Before:**

![Search_no_bootstrap](https://user-images.githubusercontent.com/2581944/57928493-2feb3900-78b1-11e9-9eda-7db895698e77.png)

**After - for large screens:**

**- Packages/Projects**

![Search   Open Build Service(2)](https://user-images.githubusercontent.com/2581944/58156874-6b9e4e00-7c77-11e9-9c9f-743aab35e504.png)

**- Issues**

![Search Issues   Open Build Service](https://user-images.githubusercontent.com/2581944/58156948-95577500-7c77-11e9-8fba-f266c3f8af6f.png)

**After - for small screens:**

![Screenshot-2019-5-22 Open Build Service](https://user-images.githubusercontent.com/2581944/58156860-60e3b900-7c77-11e9-8802-aa4be64f6e60.png)



Co-authored-by: David Kang <dkang@suse.com>