### PR TITLE
Fix user home creation for users with certain login names

### DIFF
--- a/ReleaseNotes-2.10
+++ b/ReleaseNotes-2.10
@@ -59,7 +59,9 @@ Bugfixes:
   * In WebUI, only admins are allowed to create sourceaccess/access repositories flags.
   * Added missing authorization to move repository path in Webui::ProjectController.
   * Require sourceaccess by default in `require_package`.
-
+  * Users with a login that started with '.', ':' or '_' would get an error when creating
+    their home project. This got solved, though such user home projects are now of the format
+    home:project<login>
 
 Intentional changes:
 ====================

--- a/src/api/app/models/user.rb
+++ b/src/api/app/models/user.rb
@@ -374,7 +374,11 @@ class User < ApplicationRecord
   end
 
   def home_project_name
-    "home:#{login}"
+    if login.starts_with?('.', ':', '_')
+      "home:project#{login}"
+    else
+      "home:#{login}"
+    end
   end
 
   def home_project

--- a/src/api/spec/models/user_spec.rb
+++ b/src/api/spec/models/user_spec.rb
@@ -550,4 +550,14 @@ RSpec.describe User do
       expect(user.can_create_project?('foo:bar')).to be(true)
     end
   end
+
+  describe '#home_project_name' do
+    it { expect(build(:user, login: 'tux').home_project_name).to eq('home:tux') }
+
+    context 'when user login starts with an invalid character' do
+      it { expect(build(:user, login: '.tux').home_project_name).to eq('home:project.tux') }
+      it { expect(build(:user, login: ':tux').home_project_name).to eq('home:project:tux') }
+      it { expect(build(:user, login: '_tux').home_project_name).to eq('home:project_tux') }
+    end
+  end
 end


### PR DESCRIPTION
It's possible that user login names start with '.', ':' or '_'. This
causes a problem when creating home projects, because they can not
contain a ':' followed by one of aboves characters, like 'home:.tux'
in case of user login '.tux'.

On the other hand we support authentication via LDAP, Kerberos and alike
and we have some older user records start with a '_' in some OBS
instances.
Therefor we keep above user records valid and add a prefix for home
projects of such users, e.g. 'home:project.tux'.

