### PR TITLE
Fix image template description for remote templates

### DIFF
--- a/src/api/app/models/project.rb
+++ b/src/api/app/models/project.rb
@@ -176,9 +176,9 @@ class Project < ApplicationRecord
     # We don't store the project and packages objects because they're fetched from remote instances and stored in cache
     project = Project.new(name: "#{remote_project.name}:#{image_template_project['name']}")
     image_template_project.elements('image_template_package').each do |image_template_package|
-      project.packages.new(name: image_template_package['name'],
-                           title: image_template_package['title'],
-                           description: image_template_package['description'])
+      project.packages.new(name: image_template_package['name'].presence,
+                           title: image_template_package['title'].presence,
+                           description: image_template_package['description'].presence)
     end
     project
   end


### PR DESCRIPTION
Since we use XMLHash to parse image templates of remote instances,
we get a string like '{}' when such an template description is empty.

This commit ensures that we don't show such strings in the UI.

Before:

![2019-05-17_12-16](https://user-images.githubusercontent.com/968949/57921416-98301f80-789d-11e9-812d-7dd487e6d7d1.png)

After:

![2019-05-17_12-10](https://user-images.githubusercontent.com/968949/57921422-9c5c3d00-789d-11e9-936f-5e78ddc274f6.png)
