### PR TITLE
Revert "Override Bootstrap monospace fonts with 'monospace'"

### DIFF
--- a/src/api/app/assets/stylesheets/webui2/bootstrap_variables/fonts.scss
+++ b/src/api/app/assets/stylesheets/webui2/bootstrap_variables/fonts.scss
@@ -1,2 +1,0 @@
-// Override Bootstrap's default fonts
-$font-family-monospace: monospace;

--- a/src/api/app/assets/stylesheets/webui2/cm2/suse.scss
+++ b/src/api/app/assets/stylesheets/webui2/cm2/suse.scss
@@ -1,6 +1,6 @@
 .cm-s-bootstrap {
   &.CodeMirror {
-    font-family: $font-family-monospace;
+    font-family: $font-family-monospace, monospace;
     height: auto;
     background: $card-bg;
     color: $body-color;

--- a/src/api/app/assets/stylesheets/webui2/webui2.css.scss
+++ b/src/api/app/assets/stylesheets/webui2/webui2.css.scss
@@ -14,7 +14,6 @@
 
 @import 'bootstrap_variables/breakpoints';
 @import 'bootstrap_variables/colors';
-@import 'bootstrap_variables/fonts';
 @import 'bootstrap_variables/spacers';
 @import 'bootstrap';
 @import 'bootstrap-modal';


### PR DESCRIPTION
Reverts openSUSE/open-build-service#7570.

Related to issue openSUSE/open-build-service#7253.

We prefer to define a fixed group of fonts than to rely on the font configured in the browser. This way the aspect of the page will be more homogeneous.

The user that wants to override the font defined in the web page can also configure the browser accordingly. For users of firefox see [this page](https://support.mozilla.org/en-US/kb/change-fonts-and-colors-websites-use#w_custom-fonts).