### PR TITLE
Make the staging_project#copy action a little more secure

### DIFF
--- a/src/api/app/controllers/staging/staging_projects_controller.rb
+++ b/src/api/app/controllers/staging/staging_projects_controller.rb
@@ -36,6 +36,9 @@ class Staging::StagingProjectsController < ApplicationController
   def copy
     authorize @main_project.staging
 
+    project = Project.where(name: params[:staging_project_copy_name]).first_or_initialize
+    authorize project, :create_new?
+
     StagingProjectCopyJob.perform_later(params[:staging_workflow_project], params[:staging_project_name], params[:staging_project_copy_name], User.session!.id)
     render_ok
   end

--- a/src/api/app/policies/project_policy.rb
+++ b/src/api/app/policies/project_policy.rb
@@ -39,6 +39,10 @@ class ProjectPolicy < ApplicationPolicy
     User.admin_session? || !record.disabled_for?('sourceaccess', nil, nil)
   end
 
+  def create_new?
+    record.new_record? && create?
+  end
+
   private
 
   def no_remote_instance_defined_and_has_not_remote_repositories?

--- a/src/api/spec/controllers/staging/staging_projects_controller_spec.rb
+++ b/src/api/spec/controllers/staging/staging_projects_controller_spec.rb
@@ -115,6 +115,7 @@ RSpec.describe Staging::StagingProjectsController do
     let(:staging_workflow_project) { staging_workflow.project.name }
     let(:original_staging_project_name) { staging_workflow.staging_projects.first.name }
     let(:staging_project_copy_name) { "#{original_staging_project_name}-copy" }
+    let(:existingproject) { create(:project) }
     let(:params) do
       {
         staging_workflow_project: staging_workflow_project,
@@ -137,6 +138,14 @@ RSpec.describe Staging::StagingProjectsController do
                                                                                                            original_staging_project_name,
                                                                                                            staging_project_copy_name,
                                                                                                            user.id)
+    end
+
+    it 'does not allow unauthoried access' do
+      post :copy, format: :xml, params: params.merge(staging_project_copy_name: 'newtoplevelproject')
+      expect(response).to have_http_status(:forbidden)
+
+      post :copy, format: :xml, params: params.merge(staging_project_copy_name: existingproject.name)
+      expect(response).to have_http_status(:forbidden)
     end
   end
 


### PR DESCRIPTION
I disabled the code in production to avoid abuses of this rather big hole