### PR TITLE
Update gem ffi to 1.11.1

### DIFF
--- a/src/api/Gemfile.lock
+++ b/src/api/Gemfile.lock
@@ -153,7 +153,7 @@ GEM
     faker (1.9.3)
       i18n (>= 0.7)
     feature (1.4.0)
-    ffi (1.11.0)
+    ffi (1.11.1)
     flot-rails (0.0.7)
       jquery-rails
     font-awesome-sass (5.8.1)


### PR DESCRIPTION
Beep, boop, I'm the Depfu bot... But seriously, I'm sending this because it's a blocker. It's not possible to bundle right now.

ffi has been removed from RubyGems, so it cannot be found. If you try to bundle, you will get this lovely error:

```
frontend@3b633f0bb5c9:/obs/src/api> bundle
Fetching gem metadata from https://rubygems.org/.........
Your bundle is locked to ffi (1.11.0), but that version could not be found in any of the sources listed in your Gemfile. If you haven't changed sources, that means the author of ffi (1.11.0) has removed it. You'll need to update your
bundle to a version other than ffi (1.11.0) that hasn't been removed in order to install.
```

For details: https://github.com/ffi/ffi/issues/701