### PR TITLE
Allow a requestor to modify a request

### DIFF
--- a/src/api/app/models/bs_request_permission_check.rb
+++ b/src/api/app/models/bs_request_permission_check.rb
@@ -231,12 +231,14 @@ class BsRequestPermissionCheck
       raise SetPriorityNoPermission, 'The request is not in state new or review'
     end
 
+    return if req.creator == User.session!.login
+
     req.bs_request_actions.each do |action|
       set_permissions_for_action(action)
     end
     return if @write_permission_in_target
 
-    raise SetPriorityNoPermission, 'No write permission in target of request actions'
+    raise SetPriorityNoPermission, "You have not created the request and don't have write permission in target of request actions"
   end
 
   def cmd_setincident_permissions


### PR DESCRIPTION
Currently changing the priorities is only allowed if you can write the target project. This should also be allowed to the creator of the request.

Fixes #7619.