### PR TITLE
Migrate appliances to Leap 15.1

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,5 +1,5 @@
 CONTAINER_USERID = %x(id -u).freeze
-VERSION = '42.3'.freeze
+VERSION = '15.1'.freeze
 
 namespace :docker do
   desc 'Build our development environment'

--- a/docker-files/base/Dockerfile.15.1
+++ b/docker-files/base/Dockerfile.15.1
@@ -1,18 +1,18 @@
-FROM opensuse:42.3
+FROM opensuse/leap:15.1
 
 # Add our repo
 RUN echo 'solver.allowVendorChange = true' >> /etc/zypp/zypp.conf; \
-    zypper ar -f http://download.opensuse.org/repositories/OBS:/Server:/Unstable/openSUSE_42.3/OBS:Server:Unstable.repo; \
-    zypper ar -f http://download.opensuse.org/repositories/openSUSE:/Tools/openSUSE_42.3/openSUSE:Tools.repo; \
+    zypper ar -f http://download.opensuse.org/repositories/OBS:/Server:/Unstable/openSUSE_15.1/OBS:Server:Unstable.repo; \
+    zypper ar -f http://download.opensuse.org/repositories/openSUSE:/Tools/openSUSE_15.1/openSUSE:Tools.repo; \
     zypper --gpg-auto-import-keys refresh
 
 # Install requirements for all our containers
 RUN zypper -n install --no-recommends --replacefiles \
   make gcc gcc-c++ patch curl vim vim-data psmisc \
-  timezone ack glibc-locale sudo aaa_base hostname
+  timezone ack glibc-locale sudo aaa_base hostname system-user-nobody
 
 # Add our bootstrap script
-ADD docker-bootstrap.sh /root/bin/docker-bootstrap.sh
+ADD docker-bootstrap-15.1.sh /root/bin/docker-bootstrap.sh
 
 # Add our user
 RUN useradd -m frontend

--- a/docker-files/base/docker-bootstrap-15.1.sh
+++ b/docker-files/base/docker-bootstrap-15.1.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+
+for option in "$@"
+do
+  case "${option}" in
+  frontend)
+    zypper -n install --no-recommends --replacefiles \
+      sphinx \
+      nodejs10 npm10 \
+      mariadb-client \
+      mysql-devel \
+      sqlite3-devel \
+      git-core \
+      ruby2.5-devel cyrus-sasl-devel openldap2-devel libxml2-devel zlib-devel libxslt-devel \
+      perl-XML-Parser \
+      libffi-devel autoconf \
+      ruby2.5-rubygem-bundler
+    ;;
+
+  backend)
+    zypper ar -f https://download.opensuse.org/repositories/Cloud:/Tools/openSUSE_Leap_15.1/Cloud:Tools.repo
+    zypper ar -f https://download.opensuse.org/repositories/devel:/languages:/python/openSUSE_Leap_15.1/devel:languages:python.repo
+    zypper --gpg-auto-import-keys refresh
+    zypper -n install --no-recommends --replacefiles \
+      inst-source-utils \
+      obs-server obs-signd \
+      obs-service-download_src_package obs-service-download_files \
+      obs-service-download_url \
+      obs-service-format_spec_file obs-service-kiwi_import \
+      perl-Devel-Cover perl-Diff-LibXDiff \
+      python3-setuptools \
+      python3-ec2uploadimg \
+      aws-cli \
+      osc
+      #
+      # Azure client disabled temporarily till python3-pydocumentdb 2.0.1 can
+      # build for Leap 15.1
+      # azure-cli
+    ;;
+
+  memcached)
+    zypper -n install --no-recommends --replacefiles memcached
+    ;;
+
+  *)
+    echo "Error: possible options are: frontend|backend|memcached"
+    exit
+    ;;
+
+  esac
+done

--- a/docker-files/mariadb/Dockerfile.mariadb
+++ b/docker-files/mariadb/Dockerfile.mariadb
@@ -11,4 +11,5 @@ RUN /usr/lib/mysql/mysql-systemd-helper install; \
     kill `cat /var/lib/mysql/*.pid`; \
     sleep 10
 
+ADD bind-any.cnf /etc/my.cnf.d/
 CMD ["/usr/lib/mysql/mysql-systemd-helper", "start"]

--- a/docker-files/mariadb/bind-any.cnf
+++ b/docker-files/mariadb/bind-any.cnf
@@ -1,0 +1,3 @@
+[mysqld]
+bind-address    = 0.0.0.0
+


### PR DESCRIPTION
Things that changed by default in 15.1:

- mysql listeing on localhost
- no user nobody available (necessary for installing npm modules)

The PR is done, I'm able to build the images locally and so on. However would be good if @hennevogel could try it out and if it's ok upload the images to the registry

