### PR TITLE
fix permission handling for tokens on packages via project links

### DIFF
--- a/src/api/app/controllers/trigger_controller.rb
+++ b/src/api/app/controllers/trigger_controller.rb
@@ -11,6 +11,8 @@ class TriggerController < ApplicationController
   #
   skip_before_action :extract_user
   skip_before_action :require_login
+  skip_before_action :validate_params # new gitlab versions send other data as parameters,
+  # which which we may need to ignore here. Like the project hash.
 
   # to get access to the method release_package
   include MaintenanceHelper


### PR DESCRIPTION
We need to validate the project permissions in that case
for "rebuild" operations instead of the package permissions.

move some checks from generic method in the operation specific ones
therefore



<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md
-->
