### PR TITLE
Handle cases when no users/groups are returned in search#owner

### DIFF
--- a/src/api/app/views/webui2/webui/search/_results_owner.html.haml
+++ b/src/api/app/views/webui2/webui/search/_results_owner.html.haml
@@ -8,7 +8,7 @@
         in #{result.rootproject}
 
       %ul.list-unstyled
-        - users_and_groups = result.users.merge(result.groups) { |_role, user, group| user.concat(group) }
+        - users_and_groups = (result.users || {}).merge(result.groups || {}) { |_role, user, group| user.concat(group) }
         - users_and_groups.each do |role, records|
           %li.mt-3
             :ruby

--- a/src/api/app/views/webui2/webui/search/owner.html.haml
+++ b/src/api/app/views/webui2/webui/search/owner.html.haml
@@ -8,7 +8,8 @@
       = form_tag(search_owner_path, method: :get, class: 'my-3 w-75') do
         %input{ name: 'owner', type: 'hidden', value: '1' }
         .form-group.d-flex
-          = text_field_tag('search_text', params[:search_text], placeholder: 'Search', autofocus: true, required: true, class: 'form-control')
+          = text_field_tag('search_text', params[:search_text], placeholder: 'Search', autofocus: true, required: true, class: 'form-control',
+                           id: 'search_input')
           %button.btn.btn-primary.ml-1{ type: 'submit', title: 'Search' }
             %i.fa.fa-search
         .form-row

--- a/src/api/spec/factories/attribs.rb
+++ b/src/api/spec/factories/attribs.rb
@@ -30,6 +30,10 @@ FactoryBot.define do
       attrib_type { AttribType.find_by_namespace_and_name!('OBS', 'ApprovedRequestSource') }
     end
 
+    factory :owner_root_project_attrib do
+      attrib_type { AttribType.find_by_namespace_and_name!('OBS', 'OwnerRootProject') }
+    end
+
     factory :update_project_attrib do
       transient do
         update_project { nil }

--- a/src/api/spec/fixtures/files/apache_search.xml
+++ b/src/api/spec/fixtures/files/apache_search.xml
@@ -1,0 +1,3 @@
+<collection matches="1">
+  <binary name="apache2" project="Apache" package="apache2" repository="openSUSE_Tumbleweed" version="2.4.39" release="3.4" arch="i586" filename="apache2-2.4.39-3.4.i586.rpm" filepath="Apache/openSUSE_Tumbleweed/i586/apache2-2.4.39-3.4.i586.rpm" baseproject="openSUSE:Factory" type="rpm" />
+</collection>


### PR DESCRIPTION
Fixes #7636.

Define id 'search_input' to differentiate from the search at the top right (next to the watchlist)

TODO:
- [x] Finish feature specs