### PR TITLE
Return bugowners even if they are a subaccount

### DIFF
--- a/src/api/app/models/owner_search/base.rb
+++ b/src/api/app/models/owner_search/base.rb
@@ -59,7 +59,7 @@ module OwnerSearch
     def filter_users(owner, container, rolefilter, user)
       rel = filter_roles(container.relationships.users, rolefilter)
       rel = rel.where(user: user) if user
-      rel = rel.joins(:user).where(relationships: { users: { state: 'confirmed' } })
+      rel = rel.joins(:user).where(relationships: { users: { state: %w[confirmed subaccount] } })
       rel.each do |p|
         owner.users ||= {}
         entries = owner.users.fetch(p.role.title, []) << p.user

--- a/src/api/app/models/owner_search/base.rb
+++ b/src/api/app/models/owner_search/base.rb
@@ -81,7 +81,6 @@ module OwnerSearch
     def extract_from_container(owner, container, rolefilter, user_or_group = nil)
       filter_users(owner, container, rolefilter, user_or_group) unless user_or_group.class == Group
       filter_groups(owner, container, rolefilter, user_or_group) unless user_or_group.class == User
-      owner
     end
   end
 end

--- a/src/api/app/models/owner_search/base.rb
+++ b/src/api/app/models/owner_search/base.rb
@@ -59,7 +59,7 @@ module OwnerSearch
     def filter_users(owner, container, rolefilter, user)
       rel = filter_roles(container.relationships.users, rolefilter)
       rel = rel.where(user: user) if user
-      rel = rel.joins(:user).where(relationships: { users: { state: %w[confirmed subaccount] } })
+      rel = rel.joins(:user).where(relationships: { user_id: User.active })
       rel.each do |p|
         owner.users ||= {}
         entries = owner.users.fetch(p.role.title, []) << p.user

--- a/src/api/app/models/user.rb
+++ b/src/api/app/models/user.rb
@@ -66,10 +66,12 @@ class User < ApplicationRecord
   has_and_belongs_to_many :announcements
   has_many :commit_activities
 
+  scope :confirmed, -> { where(state: 'confirmed') }
   scope :all_without_nobody, -> { where('login != ?', NOBODY_LOGIN) }
   scope :not_deleted, -> { where.not(state: 'deleted') }
   scope :not_locked, -> { where.not(state: 'locked') }
   scope :with_login_prefix, ->(prefix) { where('login LIKE ?', "#{prefix}%") }
+  scope :active, -> { confirmed.or(User.where(state: :subaccount, owner: User.confirmed)) }
 
   scope :list, lambda {
     all_without_nobody.includes(:owner).select(:id, :login, :email, :state, :realname, :owner_id, :updated_at, :ignore_auth_services)

--- a/src/api/spec/models/owner_search_spec.rb
+++ b/src/api/spec/models/owner_search_spec.rb
@@ -138,6 +138,14 @@ RSpec.describe OwnerSearch do
           expect(OwnerSearch::Assignee.new(filter: 'bugowner').for('package_42').first.users).to eq('bugowner' => [other_user])
           expect(OwnerSearch::Assignee.new(filter: 'bugowner').for('patchinfo_42').first.users).to eq('bugowner' => [other_user])
         end
+
+        context 'with gone owner' do
+          let(:owning) { create(:locked_user) }
+
+          it 'does not return bugowners' do
+            expect(OwnerSearch::Assignee.new(filter: 'bugowner').for('package')).to be_empty
+          end
+        end
       end
     end
   end

--- a/src/api/spec/models/owner_search_spec.rb
+++ b/src/api/spec/models/owner_search_spec.rb
@@ -126,6 +126,19 @@ RSpec.describe OwnerSearch do
         expect(OwnerSearch::Assignee.new.for('package_42').first.users).to eq('bugowner' => [other_user])
         expect(OwnerSearch::Assignee.new.for('patchinfo_42').first.users).to eq('bugowner' => [other_user])
       end
+
+      context 'with owned user' do
+        let(:owning) { create(:confirmed_user) }
+        before do
+          other_user.update_attributes(owner: owning, state: :subaccount)
+        end
+
+        it 'still returns the owned user as bugowner' do
+          expect(OwnerSearch::Assignee.new(filter: 'bugowner').for('package').first.users).to eq('bugowner' => [other_user])
+          expect(OwnerSearch::Assignee.new(filter: 'bugowner').for('package_42').first.users).to eq('bugowner' => [other_user])
+          expect(OwnerSearch::Assignee.new(filter: 'bugowner').for('patchinfo_42').first.users).to eq('bugowner' => [other_user])
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
For SLE we have a lot of team accounts that are bugowners for packages.

Those accounts are not confirmed (they are not employees), but they are in state :subaccount - but they still are a valid answer if looking for a owner of a package
