### PR TITLE
Status Monitor Skeleton in Bootstrap

### DIFF
--- a/src/api/app/controllers/webui/monitor_controller.rb
+++ b/src/api/app/controllers/webui/monitor_controller.rb
@@ -36,6 +36,7 @@ class Webui::MonitorController < Webui::WebuiController
       @workers_sorted = workers.sort_by { |a| a[0] } if workers
       @available_arch_list = Architecture.available.order(:name).pluck(:name)
     end
+    switch_to_webui2 if Rails.env.development?
   end
 
   def update_building

--- a/src/api/app/views/webui2/webui/monitor/_breadcrumb_items.html.haml
+++ b/src/api/app/views/webui2/webui/monitor/_breadcrumb_items.html.haml
@@ -1,0 +1,3 @@
+= render partial: 'webui/main/breadcrumb_items'
+
+%li.breadcrumb-item.active{ 'aria-current' => 'page' } Monitor

--- a/src/api/app/views/webui2/webui/monitor/_events.html.haml
+++ b/src/api/app/views/webui2/webui/monitor/_events.html.haml
@@ -1,0 +1,1 @@
+%h2 Statistical Plots

--- a/src/api/app/views/webui2/webui/monitor/_lights.html.haml
+++ b/src/api/app/views/webui2/webui/monitor/_lights.html.haml
@@ -1,0 +1,1 @@
+%h2 Server Status

--- a/src/api/app/views/webui2/webui/monitor/_workers_table.html.haml
+++ b/src/api/app/views/webui2/webui/monitor/_workers_table.html.haml
@@ -1,0 +1,1 @@
+%h2 Workers

--- a/src/api/app/views/webui2/webui/monitor/index.html.haml
+++ b/src/api/app/views/webui2/webui/monitor/index.html.haml
@@ -1,0 +1,10 @@
+- @pagetitle = 'Build Status Monitor'
+- @metarobots = 'nofollow'
+.card
+  .card-body
+    - if @workerstatus
+      = render partial: 'lights'
+      = render partial: 'workers_table'
+      = render partial: 'events'
+    - else
+      %p.font-weight-bold Unable to determine status of workers


### PR DESCRIPTION
The skeleton is already migrated and includes a partial for each of the three sections on Status Monitor. We now can work on this in parallel.

![Screenshot-2019-5-29 Open Build Service](https://user-images.githubusercontent.com/2581944/58568016-c285c380-8233-11e9-9698-b507ef3e0dca.png)
