### PR TITLE
Bs request action (refactoring model and specs)

### DIFF
--- a/src/api/app/models/bs_request_action.rb
+++ b/src/api/app/models/bs_request_action.rb
@@ -1,5 +1,3 @@
-require 'api_error'
-
 class BsRequestAction < ApplicationRecord
   #### Includes and extends
   include ParsePackageDiff
@@ -414,10 +412,9 @@ class BsRequestAction < ApplicationRecord
 
   def check_maintenance_release(pkg, repo, arch)
     binaries = Xmlhash.parse(Backend::Api::BuildResults::Binaries.files(pkg.project.name, repo.name, arch.name, pkg.name))
-    l = binaries.elements('binary')
-    unless l && l.count > 0
-      raise BuildNotFinished, "patchinfo #{pkg.name} is not yet build for repository '#{repo.name}'"
-    end
+    binary_elements = binaries.elements('binary')
+
+    raise BuildNotFinished, "patchinfo #{pkg.name} is not yet build for repository '#{repo.name}'" if binary_elements.empty?
 
     # check that we did not skip a source change of patchinfo
     data = Directory.hashed(project: pkg.project.name, package: pkg.name, expand: 1)

--- a/src/api/spec/cassettes/BsRequestAction/_check_maintenance_release/last_patchinfo_is_not_build/1_7_3_1.yml
+++ b/src/api/spec/cassettes/BsRequestAction/_check_maintenance_release/last_patchinfo_is_not_build/1_7_3_1.yml
@@ -1,0 +1,311 @@
+---
+http_interactions:
+- request:
+    method: put
+    uri: http://backend:5352/source/home:request_user/_meta?user=request_user
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:request_user">
+          <title/>
+          <description/>
+          <person userid="request_user" role="maintainer"/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '147'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:request_user">
+          <title></title>
+          <description></description>
+          <person userid="request_user" role="maintainer" />
+        </project>
+    http_version: 
+  recorded_at: Wed, 29 May 2019 13:44:48 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/super_source_pkg/_meta?user=user_13
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="super_source_pkg">
+          <title>The Golden Apples of the Sun</title>
+          <description/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '121'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="super_source_pkg">
+          <title>The Golden Apples of the Sun</title>
+          <description></description>
+        </project>
+    http_version: 
+  recorded_at: Wed, 29 May 2019 13:44:48 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/super_source_pkg/super_source_pkg/_meta?user=request_user
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="super_source_pkg" project="super_source_pkg">
+          <title>A Passage to India</title>
+          <description>Quae est in et.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '153'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="super_source_pkg" project="super_source_pkg">
+          <title>A Passage to India</title>
+          <description>Quae est in et.</description>
+        </package>
+    http_version: 
+  recorded_at: Wed, 29 May 2019 13:44:48 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/super_source_pkg/super_source_pkg/_meta?user=request_user
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="super_source_pkg" project="super_source_pkg">
+          <title>A Passage to India</title>
+          <description>Quae est in et.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '153'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="super_source_pkg" project="super_source_pkg">
+          <title>A Passage to India</title>
+          <description>Quae est in et.</description>
+        </package>
+    http_version: 
+  recorded_at: Wed, 29 May 2019 13:44:48 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/project_12/_meta?user=user_14
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="project_12">
+          <title>The Torment of Others</title>
+          <description/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '108'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="project_12">
+          <title>The Torment of Others</title>
+          <description></description>
+        </project>
+    http_version: 
+  recorded_at: Wed, 29 May 2019 13:44:48 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/project_12/package_12/_meta?user=request_user
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="package_12" project="project_12">
+          <title>The Monkey's Raincoat</title>
+          <description>Molestiae rem earum et.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '152'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="package_12" project="project_12">
+          <title>The Monkey's Raincoat</title>
+          <description>Molestiae rem earum et.</description>
+        </package>
+    http_version: 
+  recorded_at: Wed, 29 May 2019 13:44:48 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/project_12/package_12/_meta?user=request_user
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="package_12" project="project_12">
+          <title>The Monkey's Raincoat</title>
+          <description>Molestiae rem earum et.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '152'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="package_12" project="project_12">
+          <title>The Monkey's Raincoat</title>
+          <description>Molestiae rem earum et.</description>
+        </package>
+    http_version: 
+  recorded_at: Wed, 29 May 2019 13:44:48 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/super_source_pkg/super_source_pkg?expand=1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '91'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="super_source_pkg" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
+        </directory>
+    http_version: 
+  recorded_at: Wed, 29 May 2019 13:44:48 GMT
+recorded_with: VCR 4.0.0

--- a/src/api/spec/cassettes/BsRequestAction/encoding_of_sourcediffs/1_1_1.yml
+++ b/src/api/spec/cassettes/BsRequestAction/encoding_of_sourcediffs/1_1_1.yml
@@ -40,7 +40,7 @@ http_interactions:
           <person userid="request_user" role="maintainer" />
         </project>
     http_version: 
-  recorded_at: Thu, 05 Apr 2018 13:38:30 GMT
+  recorded_at: Wed, 29 May 2019 13:44:52 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:request_user/package_encoding_1/_meta?user=request_user
@@ -48,8 +48,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="package_encoding_1" project="home:request_user">
-          <title>The Curious Incident of the Dog in the Night-Time</title>
-          <description>Error odit quaerat qui exercitationem.</description>
+          <title>Rosemary Sutcliff</title>
+          <description>Architecto pariatur deleniti sunt.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -70,25 +70,25 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '210'
+      - '174'
     body:
       encoding: UTF-8
       string: |
         <package name="package_encoding_1" project="home:request_user">
-          <title>The Curious Incident of the Dog in the Night-Time</title>
-          <description>Error odit quaerat qui exercitationem.</description>
+          <title>Rosemary Sutcliff</title>
+          <description>Architecto pariatur deleniti sunt.</description>
         </package>
     http_version: 
-  recorded_at: Thu, 05 Apr 2018 13:38:31 GMT
+  recorded_at: Wed, 29 May 2019 13:44:52 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:request_user/package_encoding_1/_meta
+    uri: http://backend:5352/source/home:request_user/package_encoding_1/_meta?user=request_user
     body:
       encoding: UTF-8
       string: |
         <package name="package_encoding_1" project="home:request_user">
-          <title>The Curious Incident of the Dog in the Night-Time</title>
-          <description>Error odit quaerat qui exercitationem.</description>
+          <title>Rosemary Sutcliff</title>
+          <description>Architecto pariatur deleniti sunt.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -109,23 +109,22 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '210'
+      - '174'
     body:
       encoding: UTF-8
       string: |
         <package name="package_encoding_1" project="home:request_user">
-          <title>The Curious Incident of the Dog in the Night-Time</title>
-          <description>Error odit quaerat qui exercitationem.</description>
+          <title>Rosemary Sutcliff</title>
+          <description>Architecto pariatur deleniti sunt.</description>
         </package>
     http_version: 
-  recorded_at: Thu, 05 Apr 2018 13:38:31 GMT
+  recorded_at: Wed, 29 May 2019 13:44:52 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:request_user/package_encoding_1/_config
     body:
       encoding: UTF-8
-      string: Harum tempora quia sint totam. Sed harum vel delectus porro quisquam
-        doloribus. Possimus omnis illo delectus et sit illum nulla.
+      string: Tenetur laudantium consequatur. Deserunt omnis quia. Tempora et ea.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -149,16 +148,16 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <revision rev="1" vrev="1">
-          <srcmd5>695e534d8bea30b8296bfa6d9a79fbf9</srcmd5>
+        <revision rev="5" vrev="5">
+          <srcmd5>f6dccc99cf77c7ad2f2715286a926a9f</srcmd5>
           <version>unknown</version>
-          <time>1522935511</time>
+          <time>1559137492</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
     http_version: 
-  recorded_at: Thu, 05 Apr 2018 13:38:31 GMT
+  recorded_at: Wed, 29 May 2019 13:44:52 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:request_user/package_encoding_1/somefile.txt
@@ -190,16 +189,16 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <revision rev="2" vrev="2">
-          <srcmd5>78e19cbc9018cc5187a26cd78d2552c9</srcmd5>
+        <revision rev="6" vrev="6">
+          <srcmd5>f6dccc99cf77c7ad2f2715286a926a9f</srcmd5>
           <version>unknown</version>
-          <time>1522935511</time>
+          <time>1559137492</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
     http_version: 
-  recorded_at: Thu, 05 Apr 2018 13:38:31 GMT
+  recorded_at: Wed, 29 May 2019 13:44:52 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:request_user/package_encoding_2/_meta?user=request_user
@@ -207,8 +206,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="package_encoding_2" project="home:request_user">
-          <title>Edna O'Brien</title>
-          <description>Et sint et error et consequuntur ratione.</description>
+          <title>Postern of Fate</title>
+          <description>Dolore quisquam et asperiores.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -229,25 +228,25 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '176'
+      - '168'
     body:
       encoding: UTF-8
       string: |
         <package name="package_encoding_2" project="home:request_user">
-          <title>Edna O'Brien</title>
-          <description>Et sint et error et consequuntur ratione.</description>
+          <title>Postern of Fate</title>
+          <description>Dolore quisquam et asperiores.</description>
         </package>
     http_version: 
-  recorded_at: Thu, 05 Apr 2018 13:38:31 GMT
+  recorded_at: Wed, 29 May 2019 13:44:52 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:request_user/package_encoding_2/_meta
+    uri: http://backend:5352/source/home:request_user/package_encoding_2/_meta?user=request_user
     body:
       encoding: UTF-8
       string: |
         <package name="package_encoding_2" project="home:request_user">
-          <title>Edna O'Brien</title>
-          <description>Et sint et error et consequuntur ratione.</description>
+          <title>Postern of Fate</title>
+          <description>Dolore quisquam et asperiores.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -268,23 +267,22 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '176'
+      - '168'
     body:
       encoding: UTF-8
       string: |
         <package name="package_encoding_2" project="home:request_user">
-          <title>Edna O'Brien</title>
-          <description>Et sint et error et consequuntur ratione.</description>
+          <title>Postern of Fate</title>
+          <description>Dolore quisquam et asperiores.</description>
         </package>
     http_version: 
-  recorded_at: Thu, 05 Apr 2018 13:38:31 GMT
+  recorded_at: Wed, 29 May 2019 13:44:52 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:request_user/package_encoding_2/_config
     body:
       encoding: UTF-8
-      string: Molestias exercitationem non et velit consequatur. Iste amet veniam.
-        Magnam dolorem ad. Atque autem consequatur exercitationem iure a minima.
+      string: Saepe modi est. Placeat odio rem. Cupiditate veniam officiis.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -308,16 +306,16 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <revision rev="1" vrev="1">
-          <srcmd5>3f2496b400053289d7d4797deedeb58c</srcmd5>
+        <revision rev="5" vrev="5">
+          <srcmd5>edf09ada560abe98db42ae93fd1fd643</srcmd5>
           <version>unknown</version>
-          <time>1522935511</time>
+          <time>1559137492</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
     http_version: 
-  recorded_at: Thu, 05 Apr 2018 13:38:31 GMT
+  recorded_at: Wed, 29 May 2019 13:44:52 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:request_user/package_encoding_2/somefile.txt
@@ -347,16 +345,16 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <revision rev="2" vrev="2">
-          <srcmd5>f5e2a9168861ef19cccacc6b0b1bdf9d</srcmd5>
+        <revision rev="6" vrev="6">
+          <srcmd5>edf09ada560abe98db42ae93fd1fd643</srcmd5>
           <version>unknown</version>
-          <time>1522935511</time>
+          <time>1559137492</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
     http_version: 
-  recorded_at: Thu, 05 Apr 2018 13:38:31 GMT
+  recorded_at: Wed, 29 May 2019 13:44:52 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:request_user/package_encoding_2
@@ -382,16 +380,16 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '305'
+      - '304'
     body:
       encoding: UTF-8
       string: |
-        <directory name="package_encoding_2" rev="2" vrev="2" srcmd5="f5e2a9168861ef19cccacc6b0b1bdf9d">
-          <entry name="_config" md5="046fd966c158ccc624c83e4b8c7056be" size="141" mtime="1522935511" />
-          <entry name="somefile.txt" md5="098f6bcd4621d373cade4e832627b4f6" size="4" mtime="1522934507" />
+        <directory name="package_encoding_2" rev="6" vrev="6" srcmd5="edf09ada560abe98db42ae93fd1fd643">
+          <entry name="_config" md5="b317775948352a39190fd548825e57ef" size="61" mtime="1559137492" />
+          <entry name="somefile.txt" md5="098f6bcd4621d373cade4e832627b4f6" size="4" mtime="1559134147" />
         </directory>
     http_version: 
-  recorded_at: Thu, 05 Apr 2018 13:38:31 GMT
+  recorded_at: Wed, 29 May 2019 13:44:52 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:request_user/package_encoding_2?cmd=diff&expand=1&filelimit=10000&opackage=package_encoding_1&oproject=home:request_user&tarlimit=10000
@@ -419,11 +417,11 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '529'
+      - '388'
     body:
       encoding: ASCII-8BIT
       string: !binary |-
-        CisrKysrKyBfY29uZmlnCi0tLSBfY29uZmlnCisrKyBfY29uZmlnCkBAIC0xLDEgKzEsMSBAQAotSGFydW0gdGVtcG9yYSBxdWlhIHNpbnQgdG90YW0uIFNlZCBoYXJ1bSB2ZWwgZGVsZWN0dXMgcG9ycm8gcXVpc3F1YW0gZG9sb3JpYnVzLiBQb3NzaW11cyBvbW5pcyBpbGxvIGRlbGVjdHVzIGV0IHNpdCBpbGx1bSBudWxsYS4KXCBObyBuZXdsaW5lIGF0IGVuZCBvZiBmaWxlCitNb2xlc3RpYXMgZXhlcmNpdGF0aW9uZW0gbm9uIGV0IHZlbGl0IGNvbnNlcXVhdHVyLiBJc3RlIGFtZXQgdmVuaWFtLiBNYWduYW0gZG9sb3JlbSBhZC4gQXRxdWUgYXV0ZW0gY29uc2VxdWF0dXIgZXhlcmNpdGF0aW9uZW0gaXVyZSBhIG1pbmltYS4KXCBObyBuZXdsaW5lIGF0IGVuZCBvZiBmaWxlCgorKysrKysgc29tZWZpbGUudHh0Ci0tLSBzb21lZmlsZS50eHQKKysrIHNvbWVmaWxlLnR4dApAQCAtMSArMSBAQAotLXuiOvoqo3EQwlhcnQpcIE5vIG5ld2xpbmUgYXQgZW5kIG9mIGZpbGUKK3Rlc3QKXCBObyBuZXdsaW5lIGF0IGVuZCBvZiBmaWxlCg==
+        CisrKysrKyBfY29uZmlnCi0tLSBfY29uZmlnCisrKyBfY29uZmlnCkBAIC0xLDEgKzEsMSBAQAotVGVuZXR1ciBsYXVkYW50aXVtIGNvbnNlcXVhdHVyLiBEZXNlcnVudCBvbW5pcyBxdWlhLiBUZW1wb3JhIGV0IGVhLgpcIE5vIG5ld2xpbmUgYXQgZW5kIG9mIGZpbGUKK1NhZXBlIG1vZGkgZXN0LiBQbGFjZWF0IG9kaW8gcmVtLiBDdXBpZGl0YXRlIHZlbmlhbSBvZmZpY2lpcy4KXCBObyBuZXdsaW5lIGF0IGVuZCBvZiBmaWxlCgorKysrKysgc29tZWZpbGUudHh0Ci0tLSBzb21lZmlsZS50eHQKKysrIHNvbWVmaWxlLnR4dApAQCAtMSArMSBAQAotLXuiOvoqo3EQwlhcnQpcIE5vIG5ld2xpbmUgYXQgZW5kIG9mIGZpbGUKK3Rlc3QKXCBObyBuZXdsaW5lIGF0IGVuZCBvZiBmaWxlCg==
     http_version: 
-  recorded_at: Thu, 05 Apr 2018 13:38:31 GMT
+  recorded_at: Wed, 29 May 2019 13:44:52 GMT
 recorded_with: VCR 4.0.0

--- a/src/api/spec/cassettes/BsRequestAction/encoding_of_sourcediffs/1_1_2.yml
+++ b/src/api/spec/cassettes/BsRequestAction/encoding_of_sourcediffs/1_1_2.yml
@@ -40,7 +40,7 @@ http_interactions:
           <person userid="request_user" role="maintainer" />
         </project>
     http_version: 
-  recorded_at: Fri, 06 Apr 2018 07:56:35 GMT
+  recorded_at: Wed, 29 May 2019 13:44:52 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:request_user/package_encoding_1/_meta?user=request_user
@@ -48,8 +48,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="package_encoding_1" project="home:request_user">
-          <title>The Sun Also Rises</title>
-          <description>Ea et sit officiis amet ut.</description>
+          <title>An Evil Cradling</title>
+          <description>Cum iste nihil qui.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -70,25 +70,25 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '168'
+      - '158'
     body:
       encoding: UTF-8
       string: |
         <package name="package_encoding_1" project="home:request_user">
-          <title>The Sun Also Rises</title>
-          <description>Ea et sit officiis amet ut.</description>
+          <title>An Evil Cradling</title>
+          <description>Cum iste nihil qui.</description>
         </package>
     http_version: 
-  recorded_at: Fri, 06 Apr 2018 07:56:47 GMT
+  recorded_at: Wed, 29 May 2019 13:44:52 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:request_user/package_encoding_1/_meta
+    uri: http://backend:5352/source/home:request_user/package_encoding_1/_meta?user=request_user
     body:
       encoding: UTF-8
       string: |
         <package name="package_encoding_1" project="home:request_user">
-          <title>The Sun Also Rises</title>
-          <description>Ea et sit officiis amet ut.</description>
+          <title>An Evil Cradling</title>
+          <description>Cum iste nihil qui.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -109,23 +109,22 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '168'
+      - '158'
     body:
       encoding: UTF-8
       string: |
         <package name="package_encoding_1" project="home:request_user">
-          <title>The Sun Also Rises</title>
-          <description>Ea et sit officiis amet ut.</description>
+          <title>An Evil Cradling</title>
+          <description>Cum iste nihil qui.</description>
         </package>
     http_version: 
-  recorded_at: Fri, 06 Apr 2018 07:56:47 GMT
+  recorded_at: Wed, 29 May 2019 13:44:52 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:request_user/package_encoding_1/_config
     body:
       encoding: UTF-8
-      string: Culpa maiores molestiae et consequuntur asperiores. Dolorum ut eos laboriosam
-        earum nisi dolorem magnam. Velit quod ea sint in impedit.
+      string: Rerum ipsum est. Vel ullam rerum. Sit occaecati odit.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -149,16 +148,16 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <revision rev="3" vrev="3">
-          <srcmd5>0f48369641b2e7198f224f17edac2230</srcmd5>
+        <revision rev="7" vrev="7">
+          <srcmd5>1041cc5d048332f7ab90510f8644d097</srcmd5>
           <version>unknown</version>
-          <time>1523001407</time>
+          <time>1559137492</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
     http_version: 
-  recorded_at: Fri, 06 Apr 2018 07:56:47 GMT
+  recorded_at: Wed, 29 May 2019 13:44:53 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:request_user/package_encoding_1/somefile.txt
@@ -190,16 +189,16 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <revision rev="4" vrev="4">
-          <srcmd5>0f48369641b2e7198f224f17edac2230</srcmd5>
+        <revision rev="8" vrev="8">
+          <srcmd5>1041cc5d048332f7ab90510f8644d097</srcmd5>
           <version>unknown</version>
-          <time>1523001407</time>
+          <time>1559137493</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
     http_version: 
-  recorded_at: Fri, 06 Apr 2018 07:56:47 GMT
+  recorded_at: Wed, 29 May 2019 13:44:53 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:request_user/package_encoding_2/_meta?user=request_user
@@ -207,8 +206,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="package_encoding_2" project="home:request_user">
-          <title>The World, the Flesh and the Devil</title>
-          <description>Pariatur sunt iure dolores voluptatem ut id eveniet temporibus.</description>
+          <title>A Swiftly Tilting Planet</title>
+          <description>Mollitia voluptatem quia neque.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -229,25 +228,25 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '220'
+      - '178'
     body:
       encoding: UTF-8
       string: |
         <package name="package_encoding_2" project="home:request_user">
-          <title>The World, the Flesh and the Devil</title>
-          <description>Pariatur sunt iure dolores voluptatem ut id eveniet temporibus.</description>
+          <title>A Swiftly Tilting Planet</title>
+          <description>Mollitia voluptatem quia neque.</description>
         </package>
     http_version: 
-  recorded_at: Fri, 06 Apr 2018 07:56:47 GMT
+  recorded_at: Wed, 29 May 2019 13:44:53 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:request_user/package_encoding_2/_meta
+    uri: http://backend:5352/source/home:request_user/package_encoding_2/_meta?user=request_user
     body:
       encoding: UTF-8
       string: |
         <package name="package_encoding_2" project="home:request_user">
-          <title>The World, the Flesh and the Devil</title>
-          <description>Pariatur sunt iure dolores voluptatem ut id eveniet temporibus.</description>
+          <title>A Swiftly Tilting Planet</title>
+          <description>Mollitia voluptatem quia neque.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -268,24 +267,22 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '220'
+      - '178'
     body:
       encoding: UTF-8
       string: |
         <package name="package_encoding_2" project="home:request_user">
-          <title>The World, the Flesh and the Devil</title>
-          <description>Pariatur sunt iure dolores voluptatem ut id eveniet temporibus.</description>
+          <title>A Swiftly Tilting Planet</title>
+          <description>Mollitia voluptatem quia neque.</description>
         </package>
     http_version: 
-  recorded_at: Fri, 06 Apr 2018 07:56:47 GMT
+  recorded_at: Wed, 29 May 2019 13:44:53 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:request_user/package_encoding_2/_config
     body:
       encoding: UTF-8
-      string: Voluptatem dolores fugiat sit molestiae sed necessitatibus. Excepturi
-        eaque itaque odit exercitationem iure quae. Temporibus et doloremque dolor
-        omnis aut ut quos.
+      string: Perferendis voluptas et. Vero quos architecto. In excepturi voluptatem.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -309,16 +306,16 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <revision rev="3" vrev="3">
-          <srcmd5>7f0345be05d70bf7572c566e466cd1d3</srcmd5>
+        <revision rev="7" vrev="7">
+          <srcmd5>f48ef19cba3ae2f8fbf57ae7a4be36a2</srcmd5>
           <version>unknown</version>
-          <time>1523001407</time>
+          <time>1559137493</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
     http_version: 
-  recorded_at: Fri, 06 Apr 2018 07:56:47 GMT
+  recorded_at: Wed, 29 May 2019 13:44:53 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:request_user/package_encoding_2/somefile.txt
@@ -348,16 +345,16 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <revision rev="4" vrev="4">
-          <srcmd5>7f0345be05d70bf7572c566e466cd1d3</srcmd5>
+        <revision rev="8" vrev="8">
+          <srcmd5>f48ef19cba3ae2f8fbf57ae7a4be36a2</srcmd5>
           <version>unknown</version>
-          <time>1523001407</time>
+          <time>1559137493</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
     http_version: 
-  recorded_at: Fri, 06 Apr 2018 07:56:47 GMT
+  recorded_at: Wed, 29 May 2019 13:44:53 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:request_user/package_encoding_2
@@ -383,16 +380,16 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '305'
+      - '304'
     body:
       encoding: UTF-8
       string: |
-        <directory name="package_encoding_2" rev="4" vrev="4" srcmd5="7f0345be05d70bf7572c566e466cd1d3">
-          <entry name="_config" md5="01a3ff5fce16b3977f84fc7e5788ac53" size="163" mtime="1523001407" />
-          <entry name="somefile.txt" md5="098f6bcd4621d373cade4e832627b4f6" size="4" mtime="1522934507" />
+        <directory name="package_encoding_2" rev="8" vrev="8" srcmd5="f48ef19cba3ae2f8fbf57ae7a4be36a2">
+          <entry name="_config" md5="577e056796f8fa71fb8d1e68cdea97bd" size="71" mtime="1559137493" />
+          <entry name="somefile.txt" md5="098f6bcd4621d373cade4e832627b4f6" size="4" mtime="1559134147" />
         </directory>
     http_version: 
-  recorded_at: Fri, 06 Apr 2018 07:56:47 GMT
+  recorded_at: Wed, 29 May 2019 13:44:53 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:request_user/package_encoding_2?cmd=diff&expand=1&filelimit=10000&opackage=package_encoding_1&oproject=home:request_user&tarlimit=10000
@@ -420,149 +417,11 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '558'
+      - '384'
     body:
       encoding: ASCII-8BIT
       string: !binary |-
-        CisrKysrKyBfY29uZmlnCi0tLSBfY29uZmlnCisrKyBfY29uZmlnCkBAIC0xLDEgKzEsMSBAQAotQ3VscGEgbWFpb3JlcyBtb2xlc3RpYWUgZXQgY29uc2VxdXVudHVyIGFzcGVyaW9yZXMuIERvbG9ydW0gdXQgZW9zIGxhYm9yaW9zYW0gZWFydW0gbmlzaSBkb2xvcmVtIG1hZ25hbS4gVmVsaXQgcXVvZCBlYSBzaW50IGluIGltcGVkaXQuClwgTm8gbmV3bGluZSBhdCBlbmQgb2YgZmlsZQorVm9sdXB0YXRlbSBkb2xvcmVzIGZ1Z2lhdCBzaXQgbW9sZXN0aWFlIHNlZCBuZWNlc3NpdGF0aWJ1cy4gRXhjZXB0dXJpIGVhcXVlIGl0YXF1ZSBvZGl0IGV4ZXJjaXRhdGlvbmVtIGl1cmUgcXVhZS4gVGVtcG9yaWJ1cyBldCBkb2xvcmVtcXVlIGRvbG9yIG9tbmlzIGF1dCB1dCBxdW9zLgpcIE5vIG5ld2xpbmUgYXQgZW5kIG9mIGZpbGUKCisrKysrKyBzb21lZmlsZS50eHQKLS0tIHNvbWVmaWxlLnR4dAorKysgc29tZWZpbGUudHh0CkBAIC0xICsxIEBACi0te6I6+iqjcRDCWFydClwgTm8gbmV3bGluZSBhdCBlbmQgb2YgZmlsZQordGVzdApcIE5vIG5ld2xpbmUgYXQgZW5kIG9mIGZpbGUK
+        CisrKysrKyBfY29uZmlnCi0tLSBfY29uZmlnCisrKyBfY29uZmlnCkBAIC0xLDEgKzEsMSBAQAotUmVydW0gaXBzdW0gZXN0LiBWZWwgdWxsYW0gcmVydW0uIFNpdCBvY2NhZWNhdGkgb2RpdC4KXCBObyBuZXdsaW5lIGF0IGVuZCBvZiBmaWxlCitQZXJmZXJlbmRpcyB2b2x1cHRhcyBldC4gVmVybyBxdW9zIGFyY2hpdGVjdG8uIEluIGV4Y2VwdHVyaSB2b2x1cHRhdGVtLgpcIE5vIG5ld2xpbmUgYXQgZW5kIG9mIGZpbGUKCisrKysrKyBzb21lZmlsZS50eHQKLS0tIHNvbWVmaWxlLnR4dAorKysgc29tZWZpbGUudHh0CkBAIC0xICsxIEBACi0te6I6+iqjcRDCWFydClwgTm8gbmV3bGluZSBhdCBlbmQgb2YgZmlsZQordGVzdApcIE5vIG5ld2xpbmUgYXQgZW5kIG9mIGZpbGUK
     http_version: 
-  recorded_at: Fri, 06 Apr 2018 07:56:47 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/home:request_user/package_encoding_2
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '305'
-    body:
-      encoding: UTF-8
-      string: |
-        <directory name="package_encoding_2" rev="4" vrev="4" srcmd5="7f0345be05d70bf7572c566e466cd1d3">
-          <entry name="_config" md5="01a3ff5fce16b3977f84fc7e5788ac53" size="163" mtime="1523001407" />
-          <entry name="somefile.txt" md5="098f6bcd4621d373cade4e832627b4f6" size="4" mtime="1522934507" />
-        </directory>
-    http_version: 
-  recorded_at: Fri, 06 Apr 2018 07:57:12 GMT
-- request:
-    method: post
-    uri: http://backend:5352/source/home:request_user/package_encoding_2?cmd=diff&expand=1&filelimit=10000&opackage=package_encoding_1&oproject=home:request_user&tarlimit=10000
-    body:
-      encoding: UTF-8
-      string: ''
-    headers:
-      Content-Type:
-      - application/octet-stream
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/plain
-      Content-Length:
-      - '558'
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        CisrKysrKyBfY29uZmlnCi0tLSBfY29uZmlnCisrKyBfY29uZmlnCkBAIC0xLDEgKzEsMSBAQAotQ3VscGEgbWFpb3JlcyBtb2xlc3RpYWUgZXQgY29uc2VxdXVudHVyIGFzcGVyaW9yZXMuIERvbG9ydW0gdXQgZW9zIGxhYm9yaW9zYW0gZWFydW0gbmlzaSBkb2xvcmVtIG1hZ25hbS4gVmVsaXQgcXVvZCBlYSBzaW50IGluIGltcGVkaXQuClwgTm8gbmV3bGluZSBhdCBlbmQgb2YgZmlsZQorVm9sdXB0YXRlbSBkb2xvcmVzIGZ1Z2lhdCBzaXQgbW9sZXN0aWFlIHNlZCBuZWNlc3NpdGF0aWJ1cy4gRXhjZXB0dXJpIGVhcXVlIGl0YXF1ZSBvZGl0IGV4ZXJjaXRhdGlvbmVtIGl1cmUgcXVhZS4gVGVtcG9yaWJ1cyBldCBkb2xvcmVtcXVlIGRvbG9yIG9tbmlzIGF1dCB1dCBxdW9zLgpcIE5vIG5ld2xpbmUgYXQgZW5kIG9mIGZpbGUKCisrKysrKyBzb21lZmlsZS50eHQKLS0tIHNvbWVmaWxlLnR4dAorKysgc29tZWZpbGUudHh0CkBAIC0xICsxIEBACi0te6I6+iqjcRDCWFydClwgTm8gbmV3bGluZSBhdCBlbmQgb2YgZmlsZQordGVzdApcIE5vIG5ld2xpbmUgYXQgZW5kIG9mIGZpbGUK
-    http_version: 
-  recorded_at: Fri, 06 Apr 2018 07:57:12 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/home:request_user/package_encoding_2
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '305'
-    body:
-      encoding: UTF-8
-      string: |
-        <directory name="package_encoding_2" rev="4" vrev="4" srcmd5="7f0345be05d70bf7572c566e466cd1d3">
-          <entry name="_config" md5="01a3ff5fce16b3977f84fc7e5788ac53" size="163" mtime="1523001407" />
-          <entry name="somefile.txt" md5="098f6bcd4621d373cade4e832627b4f6" size="4" mtime="1522934507" />
-        </directory>
-    http_version: 
-  recorded_at: Fri, 06 Apr 2018 07:57:19 GMT
-- request:
-    method: post
-    uri: http://backend:5352/source/home:request_user/package_encoding_2?cmd=diff&expand=1&filelimit=10000&opackage=package_encoding_1&oproject=home:request_user&tarlimit=10000
-    body:
-      encoding: UTF-8
-      string: ''
-    headers:
-      Content-Type:
-      - application/octet-stream
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/plain
-      Content-Length:
-      - '558'
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        CisrKysrKyBfY29uZmlnCi0tLSBfY29uZmlnCisrKyBfY29uZmlnCkBAIC0xLDEgKzEsMSBAQAotQ3VscGEgbWFpb3JlcyBtb2xlc3RpYWUgZXQgY29uc2VxdXVudHVyIGFzcGVyaW9yZXMuIERvbG9ydW0gdXQgZW9zIGxhYm9yaW9zYW0gZWFydW0gbmlzaSBkb2xvcmVtIG1hZ25hbS4gVmVsaXQgcXVvZCBlYSBzaW50IGluIGltcGVkaXQuClwgTm8gbmV3bGluZSBhdCBlbmQgb2YgZmlsZQorVm9sdXB0YXRlbSBkb2xvcmVzIGZ1Z2lhdCBzaXQgbW9sZXN0aWFlIHNlZCBuZWNlc3NpdGF0aWJ1cy4gRXhjZXB0dXJpIGVhcXVlIGl0YXF1ZSBvZGl0IGV4ZXJjaXRhdGlvbmVtIGl1cmUgcXVhZS4gVGVtcG9yaWJ1cyBldCBkb2xvcmVtcXVlIGRvbG9yIG9tbmlzIGF1dCB1dCBxdW9zLgpcIE5vIG5ld2xpbmUgYXQgZW5kIG9mIGZpbGUKCisrKysrKyBzb21lZmlsZS50eHQKLS0tIHNvbWVmaWxlLnR4dAorKysgc29tZWZpbGUudHh0CkBAIC0xICsxIEBACi0te6I6+iqjcRDCWFydClwgTm8gbmV3bGluZSBhdCBlbmQgb2YgZmlsZQordGVzdApcIE5vIG5ld2xpbmUgYXQgZW5kIG9mIGZpbGUK
-    http_version: 
-  recorded_at: Fri, 06 Apr 2018 07:57:19 GMT
+  recorded_at: Wed, 29 May 2019 13:44:53 GMT
 recorded_with: VCR 4.0.0


### PR DESCRIPTION
The `BsRequestAction` is one of the models with lowest test coverage. Looking in the code, I was able to see some issues with the specs and the cassettes. After making the `User.current` private, some specs should be updated and the cassettes refreshed. Beside it I expanded the test coverage on the `BsRequestAction` model and refactored it little bit. Later on, @hennevogel found out that this test didn't need the VCRs at all.