### PR TITLE
Show Preferences box only in Kiwi Details tab

### DIFF
--- a/src/api/app/views/webui2/webui/kiwi/images/edit.html.haml
+++ b/src/api/app/views/webui2/webui/kiwi/images/edit.html.haml
@@ -12,7 +12,7 @@
                                                    is_edit_software_action: @is_edit_software_action,
                                                    is_edit_details_action: @is_edit_details_action }
 
-    .col-12
+    .col-12#kiwi-preferences{ class: "#{'d-none' unless @is_edit_details_action}" }
       = render partial: 'webui/kiwi/images/preferences', locals: { f: f }
 
     .col-12#kiwi-image-profiles-section{ class: "#{'d-none' unless @is_edit_software_action}" }


### PR DESCRIPTION
Switching between the Details and Software tabs (using Javascript) caused the Preferences box not to be shown properly. This fixes this behaviour.

Co-authored-by: Saray Cabrera Padrón <scabrerapadron@suse.de>