### PR TITLE
Migrate Cloud::ConfigurationController#index to bootstrap

### DIFF
--- a/src/api/app/controllers/webui/cloud/configurations_controller.rb
+++ b/src/api/app/controllers/webui/cloud/configurations_controller.rb
@@ -4,6 +4,8 @@ module Webui
       before_action :set_breadcrumb
 
       def index
+        # FIXME: remove it when cloud upload are ready to production
+        switch_to_webui2 if Rails.env.development?
         @crumb_list.push << 'Configuration'
       end
 

--- a/src/api/app/views/webui2/webui/cloud/configurations/_breadcrumb_items.html.haml
+++ b/src/api/app/views/webui2/webui/cloud/configurations/_breadcrumb_items.html.haml
@@ -1,0 +1,6 @@
+= render partial: 'webui/main/breadcrumb_items'
+
+%li.breadcrumb-item.active
+  = link_to 'Cloud Upload', cloud_upload_index_path
+%li.breadcrumb-item.active
+  Cloud Configuration

--- a/src/api/app/views/webui2/webui/cloud/configurations/index.html.haml
+++ b/src/api/app/views/webui2/webui/cloud/configurations/index.html.haml
@@ -1,0 +1,12 @@
+.card.mb-3
+  .card-body
+    %h3.mb-3
+      Cloud Upload Configuration
+    %p
+      You need to configure the cloud service providers you want to upload to.
+    %ul
+      %li
+        = link_to 'Configure Amazon EC2', cloud_ec2_configuration_path
+      - if Feature.active?(:cloud_upload_azure)
+        %li
+          = link_to 'Configure Microsoft Azure', cloud_azure_configuration_path


### PR DESCRIPTION
Migrate the `Cloud::ConfigurationController#index` to boostrap:

![Screenshot_2019-05-31_11-35-14](https://user-images.githubusercontent.com/37418/58696606-32ad5a00-8398-11e9-87fb-0bda8d9aa76f.png)

