### PR TITLE
Migrate Server Status to Bootstrap on status monitor page

### DIFF
--- a/src/api/app/assets/javascripts/webui/application.js.erb
+++ b/src/api/app/assets/javascripts/webui/application.js.erb
@@ -147,6 +147,7 @@ function project_monitor_ready() {
     });
 }
 
+// TODO: bento_only
 function monitor_ready() {
     $(".scheduler_status").hover(
         function () {

--- a/src/api/app/helpers/webui/kiwi/image_helper.rb
+++ b/src/api/app/helpers/webui/kiwi/image_helper.rb
@@ -9,4 +9,15 @@ module Webui::Kiwi::ImageHelper
     args.insert(0, link_to(@package, package_show_path(project: @project, package: @package)))
     project_bread_crumb(*args)
   end
+
+  def icon_for_daemon(state)
+    case state
+    when 'dead'
+      'fa-exclamation-circle text-danger'
+    when 'booting'
+      'fa-exclamation-triangle text-warning'
+    else
+      'fa-check-circle text-success'
+    end
+  end
 end

--- a/src/api/app/views/webui2/webui/monitor/_lights.html.haml
+++ b/src/api/app/views/webui2/webui/monitor/_lights.html.haml
@@ -1,1 +1,13 @@
 %h2 Server Status
+- workerstatus.elements('partition') do |partition|
+  - if partition['name'].present?
+    %h3= partition['name']
+  - if partition.key?('daemon')
+    .row.p-2.no-gutters
+      - partition.elements('daemon') do |daemon|
+        .col-6.col-sm-3.col-md-2.col-lg-1.p-1
+          .h-100.p-2.border.text-center
+            %i.fa{ class: icon_for_daemon(daemon['state']), title: "#{daemon['state']}" }
+            %span.d-block= daemon['arch'] || daemon['type']
+  - else
+    %p No daemons running!

--- a/src/api/app/views/webui2/webui/monitor/index.html.haml
+++ b/src/api/app/views/webui2/webui/monitor/index.html.haml
@@ -3,7 +3,7 @@
 .card
   .card-body
     - if @workerstatus
-      = render partial: 'lights'
+      = render partial: 'lights', locals: { workerstatus: @workerstatus }
       = render partial: 'workers_table'
       = render partial: 'events'
     - else


### PR DESCRIPTION
In the old code there were some JavaSscript that showed some hidden text
when hovering an element with class 'scheduler_status'. However, it's
impossible to find that class in the code, so it seems that
functionality is not used anymore.

![Screenshot-2019-5-31 Open Build Service](https://user-images.githubusercontent.com/2581944/58718619-3065f280-83ce-11e9-8555-5140d7db11c6.png)


<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md
-->
