### PR TITLE
Migrate Statistics Plots to Bootstrap on status monitor page

### DIFF
--- a/src/api/.jshintignore
+++ b/src/api/.jshintignore
@@ -2,3 +2,4 @@ app/assets/javascripts/webui/application/bento
 app/assets/javascripts/webui/application/cm2
 app/assets/javascripts/webui2/cm2
 app/assets/javascripts/webui2/*.min.js
+app/assets/javascripts/webui2/monitor.js

--- a/src/api/app/assets/javascripts/webui2/application.js
+++ b/src/api/app/assets/javascripts/webui2/application.js
@@ -51,3 +51,4 @@
 //= require webui2/image_templates.js
 //= require rails-timeago
 //= require webui2/kiwi_editor.js
+//= require webui2/monitor.js

--- a/src/api/app/assets/javascripts/webui2/monitor.js
+++ b/src/api/app/assets/javascripts/webui2/monitor.js
@@ -1,0 +1,93 @@
+function initializePlots() {
+  /* plot an empty set */
+  plotValues({ 'building': [],
+               'idle': [],
+               'waiting': [],
+               'blocked': [],
+               'squeue_low': [],
+               'squeue_med': [],
+               'squeue_high': []
+               });
+
+  updatePlots();
+  setInterval("updatePlots();", 80000);
+
+  $("#architecture_display, #time_display").change(function() {
+    $selector = $(this);
+    $selector.find("option:selected").each(function() {
+      option = ($selector.attr('id') == "architecture_display") ? 'archToShow' : 'timeToShow'
+      $('#graphs').data(option, $(this).attr("value"));
+    });
+    updatePlots();
+  });
+}
+
+function updatePlots() {
+  var archToShow = $('#graphs').data('archToShow');
+  var monitorPath= $('#graphs').data('monitorPath');
+  var timeToShow = $('#graphs').data('timeToShow');
+
+  $('#graphs i.fas.fa-spin').removeClass('d-none');
+  $.ajax({ url: monitorPath,
+    dataType: 'json',
+    data: { "range": timeToShow,
+            "arch": archToShow },
+    success: function(json) {
+      plotValues(json);
+      $('#graphs i.fas.fa-spin').addClass('d-none');
+      /* fade out now */
+    }
+  });
+}
+
+function plotValues(data) {
+  eventsPlot(data);
+  buildingPlot(data);
+  jobPlot(data);
+}
+
+function eventsPlot(data) {
+  $.plot($("#events"), [ { data: data.squeue_high, label: "High", color: "red" },
+                         { data: data.squeue_med, label: "Medium", color: 1 },
+                         { data: data.squeue_low, label: "Low Priority", color: 2 } ],
+    {
+      series: {
+        lines: { show: true, fill: true },
+        stack: true
+      },
+      legend: { noColumns: 3, position: "ne", container: "#legend-events" },
+      xaxis: { mode: 'time' },
+      yaxis: { min: 0, max: data.events_max, position: "left", labelWidth: 25 }
+    });
+}
+
+function buildingPlot(data) {
+  $.plot($("#building"), [ { data: data.building, label: "building", color: 3},
+                           { data: data.idle, label: "idle", color: 4 },
+                           { data: data.away, label: "away", color: 6 },
+                           { data: data.down, label: "down", color: 5 },
+                           { data: data.dead, label: "dead", color: 7 } ],
+    {
+      series: {
+        stack: true,
+        lines: { show: true, steps: false, fill: true }
+      },
+      xaxis: { mode: 'time' },
+      yaxis: { min: 0, position: "left", labelWidth: 25 },
+      legend: { noColumns: 3, position: "ne", container: "#legend-building" }
+    });
+}
+
+function jobPlot(data) {
+  $.plot($("#jobs"), [ { data: data.waiting, label: "Ready to build", color: 5},
+                       {  data: data.blocked, label: "Blocked build job", color: 6 } ],
+    {
+      series: {
+        stack: true,
+        lines: { show: true, steps: false, fill: true },
+      },
+      xaxis: { mode: 'time' },
+      yaxis: { max: data.jobs_max, position: "left", labelWidth: 25 },
+      legend: { noColumns: 3, position: "ne", container: "#legend-jobs" }
+    });
+}

--- a/src/api/app/assets/stylesheets/webui2/monitor.scss
+++ b/src/api/app/assets/stylesheets/webui2/monitor.scss
@@ -1,0 +1,7 @@
+#graphs {
+  #building,
+  #events,
+  #jobs {
+    height: 300px;
+  }
+}

--- a/src/api/app/assets/stylesheets/webui2/webui2.css.scss
+++ b/src/api/app/assets/stylesheets/webui2/webui2.css.scss
@@ -57,6 +57,7 @@
 @import 'patchinfo';
 @import 'image_templates';
 @import 'search';
+@import 'monitor';
 
 html {
     overflow-y: scroll !important;

--- a/src/api/app/views/webui2/webui/monitor/_events.html.haml
+++ b/src/api/app/views/webui2/webui/monitor/_events.html.haml
@@ -1,1 +1,33 @@
-%h2 Statistical Plots
+%h2.mt-4 Statistical Plots
+- unless available_arch_list.empty?
+  .d-flex.justify-content-center
+    = form_tag(controller: 'main', action: 'index') do
+      .form-row
+        .col-sm-12.col-md-6.py-2
+          %label Architecture:
+          = select_tag(:architecture_display, options_for_select(available_arch_list, default_architecture), class: 'custom-select')
+        .col-sm-12.col-md-6.py-2
+          %label Timeframe:
+          - options = [['1 day', '24'], ['1 hour', 1], ['1 week', '168'], ['1 month', '720'], ['1 year', '8760']]
+          = select_tag(:time_display, options_for_select(options, '24'), class: 'custom-select')
+
+.row#graphs{ data: { arch_to_show: default_architecture, monitor_path: monitor_events_path, time_to_show: '24' } }
+  .col-md-12.col-lg-6.py-4.text-center
+    #building
+    %p.my-2 Workers
+    .d-flex.justify-content-center.flot_legend#legend-building
+    %i.fas.fa-spinner.fa-spin.d-none
+  .col-md-12.col-lg-6.py-4.text-center
+    #events
+    %p.my-2 Repositories to recalculate
+    .d-flex.justify-content-center.flot_legend#legend-events
+    %i.fas.fa-spinner.fa-spin.d-none
+  .col-md-12.col-lg-6.py-4.text-center
+    #jobs
+    %p.my-2 Packages scheduled for building
+    .d-flex.justify-content-center.flot_legend#legend-jobs
+    %i.fas.fa-spinner.fa-spin.d-none
+
+= content_for :ready_function do
+  :plain
+    initializePlots();

--- a/src/api/app/views/webui2/webui/monitor/index.html.haml
+++ b/src/api/app/views/webui2/webui/monitor/index.html.haml
@@ -5,6 +5,6 @@
     - if @workerstatus
       = render partial: 'lights'
       = render partial: 'workers_table'
-      = render partial: 'events'
+      = render partial: 'events', locals: { available_arch_list: @available_arch_list, default_architecture: @default_architecture }
     - else
       %p.font-weight-bold Unable to determine status of workers


### PR DESCRIPTION
Move all the JavaScript code from the view to an assets file.
Instead of passing values to JS as parameters, it uses data attributes now.

**Large screen:**

![Build Status Monitor   Open Build Service](https://user-images.githubusercontent.com/2581944/58768170-162b4080-8597-11e9-978e-6e85dc3ec7c8.png)

**Small screen:**

![Build Status Monitor   Open Build Service(1)](https://user-images.githubusercontent.com/2581944/58768171-1deae500-8597-11e9-86a8-223ea4f4b07e.png)
