### PR TITLE
[backend] fix cross architecture import jobs

### DIFF
--- a/src/backend/BSSched/EventHandler.pm
+++ b/src/backend/BSSched/EventHandler.pm
@@ -113,7 +113,7 @@ sub event_built {
   my $info = readxml("$myjobsdir/$job", $BSXML::buildinfo, 1);
   if (!$info) {
     print "  - $job has bad info\n";
-  } elsif ($info->{'arch'} ne $myarch) {
+  } elsif ($info->{'arch'} ne $myarch && $ev->{'type'} ne 'import') {
     print "  - $job has bad arch\n";
   } else {
     if ($ev->{'type'} eq 'built') {


### PR DESCRIPTION
(aka ExportFilter).  a72e0962d0e introduced a new validation for the job
arch, but we wrote the origin arch into the job since years.

Changing this to the target arch now



<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md
-->
