### PR TITLE
Migrate Amazon EC2 Configuration page to Bootstrap

### DIFF
--- a/src/api/app/controllers/webui/cloud/ec2/configurations_controller.rb
+++ b/src/api/app/controllers/webui/cloud/ec2/configurations_controller.rb
@@ -7,6 +7,7 @@ module Webui
         before_action -> { feature_active?(:cloud_upload) }
 
         def show
+          switch_to_webui2
           @crumb_list << 'EC2'
           @ec2_configuration = User.session!.ec2_configuration || User.session!.create_ec2_configuration
           @aws_account_id = CONFIG['aws_account_id']

--- a/src/api/app/views/webui2/webui/cloud/ec2/configurations/_breadcrumb_items.html.haml
+++ b/src/api/app/views/webui2/webui/cloud/ec2/configurations/_breadcrumb_items.html.haml
@@ -1,0 +1,8 @@
+= render partial: 'webui/main/breadcrumb_items'
+
+%li.breadcrumb-item
+  = link_to 'Cloud Upload', cloud_upload_index_path
+%li.breadcrumb-item
+  = link_to 'Cloud Configuration', cloud_configuration_index_path
+%li.breadcrumb-item.active
+  Amazon EC2 Configuration

--- a/src/api/app/views/webui2/webui/cloud/ec2/configurations/show.html.haml
+++ b/src/api/app/views/webui2/webui/cloud/ec2/configurations/show.html.haml
@@ -1,0 +1,53 @@
+.card.mb-3
+  .card-body
+    %h3.mb-3
+      Amazon EC2 Configuration
+    %p
+      Amazon EC2 allows you to easily run instances of your appliance on Amazon's webservers.
+
+    %h4
+      Roles and permissions
+
+    %p
+      To upload your appliances to Amazon EC2, the Open Build Service requires permission to run EC2 instances. This may incur costs,
+      = link_to 'https://aws.amazon.com/partners/suse/', target: '_blank', rel: 'noopener' do
+        read Amazon's price list
+      for details.
+
+    %p
+      %ul
+        %li
+          Go to
+          %i
+            IAM -> Roles -> Create role
+          and select
+          %i
+            Another AWS Account.
+        %li
+          Enter
+          %b
+            = @aws_account_id
+          as
+          %i
+            Account ID.
+        %li
+          Select option
+          %i
+            Require external ID
+          and enter
+          %b
+            = @ec2_configuration.external_id
+          as External ID.
+        %li
+          Attach
+          %i
+            AmazonEC2FullAccess
+          permission policy and create the role.
+    = form_for @ec2_configuration, url: cloud_ec2_configuration_path, method: :put do |f|
+      .form-group
+        = f.label :arn do
+          Please enter now the obtained
+          %b
+            Amazon Resouce Name (ARN):
+        = f.text_field :arn, value: @ec2_configuration.arn, class: 'form-control', name: 'ec2_configuration[arn]'
+      = f.submit 'Submit', class: 'btn btn-primary'


### PR DESCRIPTION
Before:

![Screenshot from 2019-06-03 14-46-43_amazon_ec2_configuration_befor](https://user-images.githubusercontent.com/24919/58802905-9476f980-860e-11e9-9a25-653d9923de08.png)

After:

![Screenshot from 2019-06-03 14-47-38_amazon_ec2_configuration_after](https://user-images.githubusercontent.com/24919/58802916-9b9e0780-860e-11e9-9735-62dfc65e918a.png)
