### PR TITLE
Fix style of breadcrumb items

### DIFF
--- a/src/api/app/views/webui2/webui/cloud/configurations/_breadcrumb_items.html.haml
+++ b/src/api/app/views/webui2/webui/cloud/configurations/_breadcrumb_items.html.haml
@@ -1,6 +1,6 @@
 = render partial: 'webui/main/breadcrumb_items'
 
-%li.breadcrumb-item.active
+%li.breadcrumb-item
   = link_to 'Cloud Upload', cloud_upload_index_path
-%li.breadcrumb-item.active
+%li.breadcrumb-item.active{ 'aria-current' => 'page' }
   Cloud Configuration


### PR DESCRIPTION
We removed the unneeded `active` class.

Also `aria-current => page` was added to a final breadcrumb item, as defined in our [pattern library](https://obs-patterns.netlify.com/molecules/breadcrumbs.html).
