### PR TITLE
Move Workers section to bootstrap

### DIFF
--- a/src/api/app/assets/javascripts/webui2/monitor.js
+++ b/src/api/app/assets/javascripts/webui2/monitor.js
@@ -91,3 +91,57 @@ function jobPlot(data) {
       legend: { noColumns: 3, position: "ne", container: "#legend-jobs" }
     });
 }
+
+function processProgressBar(id, item)
+{
+  var delta = item["delta"];
+
+  var container = $('#p' + id);
+  var el_text = container.find(".monitorpb_text");
+  var ctrl = container.find(".progress-bar");
+
+  var logfileinfo = $("#worker-display option:selected").val();
+
+  if (delta) {
+    el_text.text(item[logfileinfo]);
+    ctrl.css("width", delta + "%").attr("aria-valuenow", delta);
+    var url = $('#workers').data('buildLogPath');
+    url = url.replace('ARCH', item["arch"]);
+    url = url.replace('PROJECT', item["project"]);
+    url = url.replace('PACKAGE', item["package"]);
+    url = url.replace('REPOSITORY', item["repository"]);
+
+    el_text.attr("href", url);
+
+    if (delta <= 50) {
+      ctrl.addClass("bg-success");
+      ctrl.removeClass('bg-warning bg-danger');
+    } else if (delta >= 50 && delta < 80) {
+      ctrl.addClass("bg-warning");
+      ctrl.removeClass('bg-success bg-danger');
+    } else {
+      ctrl.addClass("bg-danger");
+      ctrl.removeClass('bg-success bg-warning');
+    }
+  }
+  else {
+    el_text.html("idle");
+    ctrl.css("width", "0%");
+    ctrl.css("aria-valuenow", 0)
+    el_text.attr("href", "#");
+  }
+}
+
+function updateProgressBar()
+{
+  $("#workers-updating").fadeIn(1200);
+
+  var monitorPath=$('#workers').data('monitorPath');
+
+  $.getJSON(monitorPath, function(json) {
+    $.each(json, function(i,item) {
+            processProgressBar(i, item);
+    });
+    $("#workers-updating").fadeOut(1200);
+  });
+}

--- a/src/api/app/assets/stylesheets/webui2/monitor.scss
+++ b/src/api/app/assets/stylesheets/webui2/monitor.scss
@@ -5,3 +5,111 @@
     height: 300px;
   }
 }
+
+
+.builderbox {
+  width: 168px;
+  margin-top: 3px;
+  margin: 3px;
+  border: 8px transparent;
+  list-style: none;
+  float: left;
+}
+
+.builderboxtitle {
+  font-weight: bold;
+  padding: 0;
+  margin: 0 0 0.2em;
+}
+
+.monitorboxrow {
+  list-style: none;
+  clear: both;
+  margin-bottom: 1em;
+  overflow: hidden;
+  li {
+    margin-top: 3px !important;
+  }
+}
+
+.monitorpb_track {
+  padding: 0;
+  background-color: transparent;
+  background-repeat: repeat-x;
+  background-attachment: scroll;
+  background-position: left -22px;
+  width: 100%;
+  height: 100%;
+  moz-background-clip: border;
+  moz-background-origin: padding;
+  moz-background-inline-policy: continuous;
+  position: absolute;
+  left: 2px;
+  top: 0px;
+  overflow: hidden;
+  margin-right: -20px;
+}
+
+.monitorpb_right {
+  margin: 0;
+  padding: 0;
+  overflow: hidden;
+  width: 2px;
+  height: 100%;
+  background-position: -4px -44px;
+  position: absolute;
+  right: 0px;
+  top: 0px;
+}
+
+.monitorpb_left {
+  position: absolute;
+  left: 0px;
+  top: 0px;
+  margin: 0pt;
+  padding: 0pt;
+  overflow: hidden;
+  width: 2px;
+  height: 100%;
+  float: left;
+  background-position: -2px -44px;
+}
+
+.monitorpb_text {
+  position: absolute;
+  left: 4px;
+  top: 2px;
+  overflow: hidden;
+  white-space: nowrap;
+}
+
+.monitorpb_ctrl {
+  margin: 0;
+  padding: 0;
+  background-color: transparent;
+  background-repeat: repeat-x;
+  background-attachment: scroll;
+  background-position: left -1px;
+  width: 100%;
+  height: 100%;
+  moz-background-clip: border;
+  moz-background-origin: padding;
+  moz-background-inline-policy: continuous;
+}
+
+.monitorpb {
+  padding: 0;
+  height: 22px;
+  position: relative;
+  left: 0;
+  top: 0;
+  max-height: 22px;
+  overflow: hidden;
+  margin-top: 1px;
+  a {
+    color: black ! important;
+  }
+  .progress-bar {
+    width: 10%;
+  }
+}

--- a/src/api/app/controllers/webui/monitor_controller.rb
+++ b/src/api/app/controllers/webui/monitor_controller.rb
@@ -54,6 +54,7 @@ class Webui::MonitorController < Webui::WebuiController
       delta = max_time if delta > max_time
       delta = (100 * Math.sin(Math.acos(1 - (Float(delta) / max_time)))).round
       delta = 100 if delta > 100
+
       workers[id] = { 'delta' => delta, 'project' => b['project'], 'repository' => b['repository'],
                       'package' => b['package'], 'arch' => b['arch'], 'starttime' => b['starttime'] }
     end

--- a/src/api/app/views/webui2/webui/monitor/_workers_table.html.haml
+++ b/src/api/app/views/webui2/webui/monitor/_workers_table.html.haml
@@ -1,1 +1,47 @@
-%h2 Workers
+%form.form-inline.float-sm-right{ action: '/' }
+  %label.mr-2 Show:
+  - worker_display_options = [['Package name', 'package'], ['Project', 'project'], ['Repository', 'repository'], ['Architecture', 'arch']]
+  = select_tag(:worker_display, options_for_select(worker_display_options, 'package'), id: 'worker-display', class: 'custom-select')
+
+%h2.nowrap#workers-title
+  Workers
+  %span.hidden#workers-updating (updating...)
+
+#workers{ data: { monitor_path: monitor_update_building_path,
+                  build_log_path: "#{package_live_build_log_path(project: 'PROJECT', package: 'PACKAGE', arch: 'ARCH', repository: 'REPOSITORY')}" } }
+  %p
+    This shows the single workers and their jobs. The
+    %em progress
+    shown (and color) is not for the time it will take (we don't know that before),
+    but just relative against each other. The exact percentage shown has no real meaning,
+    just one thing is certain: the bar reaches its maximum at 4h.
+  %p
+    The monitor is meant to entertain and not to be exact, if you need to know more details, check the #{link_to 'detailed page', action: :old}.
+- if workers_sorted.empty?
+  %p
+    %i No workers
+- else
+  - workers_sorted.each_slice(5) do |row|
+    %ul.monitorboxrow
+      %li.hidden
+        - row.each do |name, hash|
+          %li.builderbox
+            .builderboxtitle #{name} (#{hash['_arch']})
+            - hash.each do |subid, id|
+              - if subid != '_arch'
+                .monitorpb{ id: "p#{id}" }
+                  .progress
+                    .progress-bar.progress-bar-striped{ 'aria-valuemax' => '100', 'aria-valuemin' => '0',
+                                                        'role' => 'progressbar' }
+
+                      = link_to('#', '', rel: 'nofollow', class: 'monitorpb_text')
+
+= content_for :ready_function do
+  :plain
+    updateProgressBar();
+
+    setInterval("updateProgressBar()", 100000 );
+
+    $("#worker-display").change(function(logfileinfo) {
+      updateProgressBar();
+    });

--- a/src/api/app/views/webui2/webui/monitor/index.html.haml
+++ b/src/api/app/views/webui2/webui/monitor/index.html.haml
@@ -4,7 +4,7 @@
   .card-body
     - if @workerstatus
       = render partial: 'lights', locals: { workerstatus: @workerstatus }
-      = render partial: 'workers_table'
+      = render partial: 'workers_table', locals: { workers_sorted: @workers_sorted }
       = render partial: 'events', locals: { available_arch_list: @available_arch_list, default_architecture: @default_architecture }
     - else
       %p.font-weight-bold Unable to determine status of workers


### PR DESCRIPTION
This PR is mainly a bento -> bootstrap migration, however some
improvements where done. Among them:

- move javascript to assets
- use bootstrap progress bar
- remove instance variables from partials
- remove inline css styling

Last version of the page, the idea is to show the select box with the `custom-select` applied:

![Screenshot_2019-06-05_10-06-23](https://user-images.githubusercontent.com/37418/58940377-9e693b80-8779-11e9-96e3-ba6f93141ab2.png)


The idea is to show how the progress bar change their color based on the delta:


![Screenshot_2019-06-04_11-58-21](https://user-images.githubusercontent.com/37418/58870356-5b975d00-86c0-11e9-95f5-97fc45706999.png)

![Screenshot_2019-06-04_11-59-34](https://user-images.githubusercontent.com/37418/58870359-5b975d00-86c0-11e9-9215-2ab71f427d15.png)

![Screenshot_2019-06-04_11-59-46](https://user-images.githubusercontent.com/37418/58870360-5b975d00-86c0-11e9-914d-dcb0c8acaa6e.png)
