### PR TITLE
Migrate monitor#old to Bootstrap

### DIFF
--- a/src/api/app/controllers/webui/monitor_controller.rb
+++ b/src/api/app/controllers/webui/monitor_controller.rb
@@ -6,7 +6,9 @@ class Webui::MonitorController < Webui::WebuiController
 
   DEFAULT_SEARCH_RANGE = 24
 
-  def old; end
+  def old
+    switch_to_webui2
+  end
 
   def index
     if request.post? && !params[:project].nil? && Project.valid_name?(params[:project])

--- a/src/api/app/views/webui2/webui/monitor/_breadcrumb_items.html.haml
+++ b/src/api/app/views/webui2/webui/monitor/_breadcrumb_items.html.haml
@@ -1,3 +1,11 @@
 = render partial: 'webui/main/breadcrumb_items'
 
-%li.breadcrumb-item.active{ 'aria-current' => 'page' } Monitor
+- case action_name
+- when 'index'
+  %li.breadcrumb-item.active{ 'aria-current' => 'page' }
+    Monitor
+- when 'old'
+  %li.breadcrumb-item
+    = link_to('Monitor', monitor_path)
+  %li.breadcrumb-item.active{ 'aria-current' => 'page' }
+    Detailed

--- a/src/api/app/views/webui2/webui/monitor/_building.html.haml
+++ b/src/api/app/views/webui2/webui/monitor/_building.html.haml
@@ -1,0 +1,32 @@
+- max_clients = worker_status['clients']
+- build_count = worker_status.elements('building').length
+#building-all
+  %h2 Building
+  - if build_count > 0
+    %p.info Hover the job time field to see the start time.
+    %p.info
+      = configuration_title
+      reports #{build_count} running jobs.
+    = render partial: 'building_table', locals: { worker_status: worker_status, dead_line: dead_line, intervel_steps: interval_steps,
+                                                  max_color: max_color, time_now: time_now, project_filter: project_filter }
+    %h5.mt-3 Job Time Legend
+    .clearfix
+      .float-left.mx-1
+        = distance_of_time_in_words(time_now, dead_line)
+      - max_color.downto(0) do |n|
+        - color = "rgb(255,#{n},0)"
+        -# haml-lint:disable InlineStyles
+        .m-0.float-left{ style: "background-color: #{color}; width: 3px ; height: 1em;" }  
+        -# haml-lint:enable InlineStyles
+      .float-left.ml-1
+        = distance_of_time_in_words(time_now, dead_line - (max_color * interval_steps * 60))
+  - else
+    .info
+      %p
+        - if max_clients
+          - if project_filter
+            No package of the "#{project_filter}" project is building. Maybe remove the filter?:)
+          - else
+            All #{max_clients} hosts are idle!
+        - else
+          Nothing to do here!

--- a/src/api/app/views/webui2/webui/monitor/_building_table.html.haml
+++ b/src/api/app/views/webui2/webui/monitor/_building_table.html.haml
@@ -1,0 +1,54 @@
+#building-list
+  - if worker_status.key?('building')
+    .table-responsive
+      %table.table.table-sm.table-striped.table-bordered.w-100#building-table
+        %thead
+          %tr
+            %th Project
+            %th Package
+            %th Repository - Build Arch
+            %th Job Time
+            %th Build Host
+            %th Host Arch
+        %tbody
+          - worker_status.elements('building').sort { |a, b| b['starttime'] <=> a['starttime'] }.each do |building|
+            :ruby
+              project = building['project']
+              package = building['package']
+              repository = building['repository']
+              architecture = building['arch']
+            %tr
+              %td.project
+                - if project.include? '---'
+                  \-------
+                - else
+                  = link_to(project, project_show_path(project))
+              %td.package
+                - if package.include? '---'
+                  \-------
+                - else
+                  = link_to(package, package_show_path(project, package))
+              %td.repository.arch
+                - if repository.include? '---'
+                  \-------
+                - else
+                  = link_to(repository + ' - ' + architecture, package_live_build_log_path(project, package, repository, architecture))
+              - start_time = Time.at(building['starttime'].to_i)
+              - warning_style = nil
+              - if start_time < dead_line
+                :ruby
+                  n = ((start_time - dead_line).abs / 60 / interval_steps).round
+                  n = (max_color < n ? 0 : max_color - n)
+                  warning_style = "background-color: rgb(255,#{n},0);"
+              -# haml-lint:disable InlineStyles
+              %td.starttime{ style: warning_style, title: "start time: #{start_time.iso8601}" }
+                -# haml-lint:enable InlineStyles
+                %span.sorttime.d-none
+                  = building['starttime'].to_i
+                = distance_of_time_in_words(time_now, start_time)
+              %td.uri= building['workerid']
+              %td.hostarch= building['hostarch']
+
+= content_for :ready_function do
+  :plain
+    initializeDataTable('#building-table', order: [[3, 'desc']]);

--- a/src/api/app/views/webui2/webui/monitor/_idle.html.haml
+++ b/src/api/app/views/webui2/webui/monitor/_idle.html.haml
@@ -1,0 +1,21 @@
+- idle_hosts = worker_status.elements('idle')
+
+.mt-3#idlehosts
+  %h2 Idle Hosts
+  - if idle_hosts.empty?
+    %p
+      None of the #{pluralize(worker_status['clients'], 'host')} idle.
+  - else
+    %p
+      = idle_hosts.size
+      of #{pluralize(worker_status['clients'], 'host')} idle.
+    %table.responsive.table.table-sm.table-striped.table-bordered
+      %thead
+        %tr
+          %th Host
+          %th Arch
+      %tbody
+        - idle_hosts.each do |idle_host|
+          %tr
+            %td= idle_host['workerid']
+            %td= idle_host['hostarch']

--- a/src/api/app/views/webui2/webui/monitor/_stats.html.haml
+++ b/src/api/app/views/webui2/webui/monitor/_stats.html.haml
@@ -1,0 +1,27 @@
+- if worker_status.elements('waiting').empty?
+  %p
+    %i No scheduler statistics
+- else
+  %table.responsive.table.table-sm.table-striped.table-bordered
+    %thead
+      %tr
+        %th Host Arch
+        %th Packages in waiting queue
+        %th Packages in blocked queue
+        %th Average Job time
+    %tbody
+      - worker_status.elements('waiting').sort_by { |a| a['arch'] }.each do |entrywaiting|
+        - outblocked = nil
+        - outbuildavg = nil
+        %tr
+          %td.arch= entrywaiting['arch']
+          %td.waiting= entrywaiting['jobs']
+          %td.blocked
+            - worker_status.elements('blocked') do |blocked|
+              - outblocked = blocked['jobs'] if blocked['arch'] == entrywaiting['arch']
+            = outblocked || ' - '
+          %td.avgjobtime
+            - worker_status.elements('buildavg') do |build_avg|
+              - if build_avg['arch'] == entrywaiting['arch']
+                - outbuildavg = distance_of_time_in_words(Time.at(build_avg['buildavg'].to_i), Time.at(0), include_seconds: true)
+            = outbuildavg || ' - '

--- a/src/api/app/views/webui2/webui/monitor/old.html.haml
+++ b/src/api/app/views/webui2/webui/monitor/old.html.haml
@@ -1,0 +1,9 @@
+- @pagetitle = 'Build Status Monitor - Detailed'
+- @metarobots = 'nofollow'
+.card
+  .card-body
+    = render partial: 'building', locals: { worker_status: @workerstatus, configuration_title: @configuration['title'], time_now: @time_now,
+                                            dead_line: @dead_line, max_color: @max_color, interval_steps: @interval_steps,
+                                            project_filter: @project_filter }
+    = render partial: 'idle', locals: { worker_status: @workerstatus }
+    = render partial: 'stats', locals: { worker_status: @workerstatus }


### PR DESCRIPTION
To review, see this [comment from @vpereira](https://github.com/openSUSE/open-build-service/pull/7671#issuecomment-498583815) (thank you!). I find it easier to review locally, but it's also possible in the review app.

**Review link:** https://obs-reviewlab.opensuse.org/dmarcoux-bootstrap-monitor-old/monitor/old

Please keep in mind that I ported the view with minor changes and fixed most of the Rubocop offenses.  I ignored some `InlineStyles` offenses to keep the legend as it is.

Before:
![bento-monitor#old](https://user-images.githubusercontent.com/1102934/58873926-baaca000-86c7-11e9-8a70-d77cc1df3e3e.png)

Now:
![bootstrap-monitor#old](https://user-images.githubusercontent.com/1102934/58873920-b7191900-86c7-11e9-9adb-d655c1204067.png)