### PR TITLE
obs_factory: Licensedigger is the bot user for legal reviews

### DIFF
--- a/src/api/app/presenters/obs_factory/staging_project_presenter.rb
+++ b/src/api/app/presenters/obs_factory/staging_project_presenter.rb
@@ -34,7 +34,7 @@ module ObsFactory
         'user-shield'
       when 'maintenance-team' then
         'medkit'
-      when 'legal-team', 'legal-auto' then
+      when 'legal-team', 'legal-auto', 'licensedigger' then
         'graduation-cap'
       when 'leaper', 'origin-manager' then
         'code-fork'


### PR DESCRIPTION
Factory changed the setup away from legal-auto, the group, directly to licensdigger, the user. There is basically no gain in having a group over the user. The only acceptable response for legal reviews comes from cavil