### PR TITLE
Migrate to Bootstrap the page to choose Cloud Upload

### DIFF
--- a/src/api/app/assets/stylesheets/webui2/cloud_upload.scss
+++ b/src/api/app/assets/stylesheets/webui2/cloud_upload.scss
@@ -1,0 +1,1 @@
+.cloud-buttons .btn { min-width: 13rem; }

--- a/src/api/app/assets/stylesheets/webui2/webui2.css.scss
+++ b/src/api/app/assets/stylesheets/webui2/webui2.css.scss
@@ -58,6 +58,7 @@
 @import 'image_templates';
 @import 'search';
 @import 'monitor';
+@import 'cloud_upload';
 
 html {
     overflow-y: scroll !important;

--- a/src/api/app/controllers/webui/cloud/upload_jobs_controller.rb
+++ b/src/api/app/controllers/webui/cloud/upload_jobs_controller.rb
@@ -21,6 +21,7 @@ module Webui
         @azure_configured = Feature.active?(:cloud_upload_azure)
         @user_ec2_configured = User.session!.ec2_configuration.present?
         @user_azure_configured = User.session!.azure_configuration.present?
+        switch_to_webui2
       end
 
       def create

--- a/src/api/app/views/webui2/webui/cloud/upload_jobs/_breadcrumb_items.html.haml
+++ b/src/api/app/views/webui2/webui/cloud/upload_jobs/_breadcrumb_items.html.haml
@@ -1,4 +1,10 @@
 = render partial: 'webui/main/breadcrumb_items'
 
-%li.breadcrumb-item.active{ 'aria-current' => 'page' }
-  Cloud Upload
+- if action_name == 'index'
+  %li.breadcrumb-item.active{ 'aria-current' => 'page' }
+    Cloud Upload
+- else
+  %li.breadcrumb-item
+    = link_to 'Cloud Upload', cloud_upload_index_path
+  %li.breadcrumb-item.active
+    Choose your Cloud

--- a/src/api/app/views/webui2/webui/cloud/upload_jobs/new.html.haml
+++ b/src/api/app/views/webui2/webui/cloud/upload_jobs/new.html.haml
@@ -1,0 +1,28 @@
+- @pagetitle = 'Choose your Cloud'
+.card
+  .card-body
+    %h2 Choose your Cloud
+    .cloud-buttons.d-flex.flex-wrap.justify-content-center.mt-3
+      - if @ec2_configured
+        .p-2.text-center
+          - if @user_ec2_configured
+            = link_to('Amazon EC2', new_cloud_ec2_upload_path(project: params[:project],
+                      package: @package, repository: params[:repository], arch: params[:arch], filename: params[:filename]),
+                      class: 'btn btn-lg btn-outline-secondary', title: 'Upload to Amazon EC2')
+          - else
+            %button.btn.btn-lg.btn-outline-secondary{ type: 'button', disabled: true } Amazon EC2
+            %p.small.text-danger
+              Configure your credentials
+              = link_to('here', cloud_ec2_configuration_path, title: 'Configure the credentials for your Amazon EC2')
+      - if @azure_configured
+        .p-2.text-center
+          - if @user_azure_configured
+            = link_to('Microsoft Azure', new_cloud_azure_upload_path(project: params[:project],
+                      package: @package, repository: params[:repository], arch: params[:arch], filename: params[:filename]),
+                      class: 'btn btn-lg btn-outline-secondary', title: 'Upload to Microsoft Azure')
+          - else
+            %button.btn.btn-lg.btn-outline-secondary{ type: 'button', disabled: true } Microsoft Azure
+            %p.small.text-danger
+              Configure your credentials
+              = link_to('here', cloud_azure_configuration_path, title: 'Configure the credentials for your Microsoft Azure')
+


### PR DESCRIPTION
This page includes two buttons that are only visible if, at least, one of the clouds is configured.

**Before:**

![Screenshot-2019-6-4 Open Build Service](https://user-images.githubusercontent.com/2581944/58892339-50f3bc80-86ee-11e9-98ba-ef002bd6f38a.png)


**After:**

![Choose your Cloud   Open Build Service](https://user-images.githubusercontent.com/2581944/58890986-fb1e1500-86eb-11e9-9ad0-26513ff08240.png)

Co-authored-by: David Kang <dkang@suse.com>

**Small screen:**

![Screenshot-2019-6-4 Open Build Service(2)](https://user-images.githubusercontent.com/2581944/58893888-4c7cd300-86f1-11e9-9fc4-296326ec53cd.png)

<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md
-->
