### PR TITLE
Remove Rails.env.development guard for monitor controller

### DIFF
--- a/src/api/app/controllers/webui/monitor_controller.rb
+++ b/src/api/app/controllers/webui/monitor_controller.rb
@@ -38,7 +38,7 @@ class Webui::MonitorController < Webui::WebuiController
       @workers_sorted = workers.sort_by { |a| a[0] } if workers
       @available_arch_list = Architecture.available.order(:name).pluck(:name)
     end
-    switch_to_webui2 if Rails.env.development?
+    switch_to_webui2
   end
 
   def update_building


### PR DESCRIPTION
Because we are done with the monitor pages migration, we are removing the constrain to run the bootstrap version just on dev environment