### PR TITLE
Migrate Cloud Upload EC2 form to Bootstrap

### DIFF
--- a/src/api/app/controllers/webui/cloud/ec2/upload_jobs_controller.rb
+++ b/src/api/app/controllers/webui/cloud/ec2/upload_jobs_controller.rb
@@ -6,7 +6,8 @@ module Webui
           xml_object = OpenStruct.new(params.slice(:project, :package, :repository, :arch, :filename))
           @upload_job = ::Cloud::Backend::UploadJob.new(xml_object: xml_object)
           @regions = ::Cloud::Ec2::Configuration::REGIONS
-          @crumb_list.push << 'EC2'
+          @crumb_list.push << 'EC2' # TODO: bento_only
+          switch_to_webui2
         end
 
         private

--- a/src/api/app/views/webui2/webui/cloud/ec2/upload_jobs/_breadcrumb_items.html.haml
+++ b/src/api/app/views/webui2/webui/cloud/ec2/upload_jobs/_breadcrumb_items.html.haml
@@ -1,0 +1,6 @@
+= render partial: 'webui/main/breadcrumb_items'
+
+%li.breadcrumb-item
+  = link_to 'Cloud Upload', cloud_upload_index_path
+%li.breadcrumb-item.active{ 'aria-current' => 'page' }
+  Amazon EC2

--- a/src/api/app/views/webui2/webui/cloud/ec2/upload_jobs/new.html.haml
+++ b/src/api/app/views/webui2/webui/cloud/ec2/upload_jobs/new.html.haml
@@ -1,0 +1,34 @@
+- @pagetitle = 'Upload to Amazon EC2'
+
+.card
+  .card-body
+    %h3 Upload to Amazon EC2
+
+    = form_for(@upload_job, url: cloud_ec2_upload_path, method: :post, html: { class: 'cloud_form' }) do |upload_job_form|
+      = upload_job_form.hidden_field :project
+      = upload_job_form.hidden_field :package
+      = upload_job_form.hidden_field :arch
+      = upload_job_form.hidden_field :repository
+      = upload_job_form.hidden_field :filename
+      = upload_job_form.hidden_field :target, value: 'ec2'
+
+      .form-group.row
+        = label_tag(:filename, 'Filename:', class: 'col-md-2 col-form-label')
+        .col-md-10.pt-2
+          %b= @upload_job.filename
+      .form-group.row
+        .col-md-2
+          = upload_job_form.label('cloud_backend_upload_job[ami_name]', 'AMI Name:', class: 'col-form-label')
+          %abbr.text-danger{ title: 'required' } *
+        .col-md-10
+          = text_field('cloud_backend_upload_job', 'ami_name', size: 35, required: true)
+      .form-group.row
+        = upload_job_form.label('cloud_backend_upload_job[region]', 'Region:', class: 'col-md-2 col-form-label')
+        .col-md-10
+          = select_tag('cloud_backend_upload_job[region]', options_for_select(@regions), class: 'custom-select w-auto')
+      .form-group.row
+        = upload_job_form.label('cloud_backend_upload_job[vpc_subnet_id]', 'VPC Subnet ID:', class: 'col-md-2 col-form-label')
+        .col-md-10
+          = text_field('cloud_backend_upload_job', 'vpc_subnet_id', size: 35, placeholder: 'eg. subnet-12345678')
+          %small.form-text.text-muted We create a temporary subnet, if you don't provide one.
+      = submit_tag('Upload Image', class: 'btn btn-primary')


### PR DESCRIPTION
To test this locally, I did this:

1. [Download an EC2 image](https://build.opensuse.org/package/binaries/openSUSE:Templates:Images:42.3:AWS/openSUSE-Leap-42.3-EC2-HVM-Guest/images) from our public instance
2. Add the downloaded image to the `ctris` package in `home:Admin`
3. Go directly to this route: http://localhost:3000/cloud/upload/new/home:Admin/ctris/openSUSE_Tumbleweed/x86_64/openSUSE-Leap-42.3-EC2-HVM.x86_64-0.1.4-Build2.225.raw.xz
4. Click on the `Amazon EC2` button
5. See the form migrated in this PR

It's a workaround to building _Amazon EC2_ images, but I didn't have to disable/comment anything to get there.

Before:
![ec2-form-bento](https://user-images.githubusercontent.com/1102934/58950860-06c31780-8790-11e9-9b08-7b33aed2c700.png)

Now:
![ec2-form-bootstrap](https://user-images.githubusercontent.com/1102934/58950863-09be0800-8790-11e9-8ff0-ba7cf068da2c.png)