### PR TITLE
Fix JavaScript syntax error

### DIFF
--- a/src/api/app/views/webui2/webui/monitor/_building_table.html.haml
+++ b/src/api/app/views/webui2/webui/monitor/_building_table.html.haml
@@ -51,4 +51,4 @@
 
 = content_for :ready_function do
   :plain
-    initializeDataTable('#building-table', order: [[3, 'desc']]);
+    initializeDataTable('#building-table', { order: [[3, 'desc']] });


### PR DESCRIPTION
The error is `SyntaxError: missing ) after argument list`. It's not so obvious at first, but we need to pass the options as an object.
