### PR TITLE
Pass default params to cloud upload jobs DataTable

### DIFF
--- a/src/api/app/views/webui2/webui/cloud/upload_jobs/index.html.haml
+++ b/src/api/app/views/webui2/webui/cloud/upload_jobs/index.html.haml
@@ -35,4 +35,4 @@
                   = link_to 'Abort', cloud_upload_path(job.id), method: :delete, data: { confirm: "Do you really want to abort job #{job.id}?" }
 
 - content_for :ready_function do
-  initializeDataTable('#upload-jobs');
+  initializeDataTable('#upload-jobs', { order: [[0, 'desc']], pageLength: 25, responsive: true });


### PR DESCRIPTION
With the migration from the old UI to the new UI the default parameters to initialize the cloud upload jobs DataTable were not included. Now they are added, and also it is added the 'responsive' parameter.
