### PR TITLE
Migrate Cloud Upload Azure form to Bootstrap

### DIFF
--- a/src/api/app/controllers/webui/cloud/azure/upload_jobs_controller.rb
+++ b/src/api/app/controllers/webui/cloud/azure/upload_jobs_controller.rb
@@ -5,7 +5,8 @@ module Webui
         def new
           xml_object = OpenStruct.new(params.slice(:project, :package, :repository, :arch, :filename))
           @upload_job = ::Cloud::Backend::UploadJob.new(xml_object: xml_object)
-          @crumb_list.push << 'Azure'
+          @crumb_list.push << 'Azure' # TODO: bento_only
+          switch_to_webui2
         end
 
         private

--- a/src/api/app/views/webui2/webui/cloud/azure/upload_jobs/_breadcrumb_items.html.haml
+++ b/src/api/app/views/webui2/webui/cloud/azure/upload_jobs/_breadcrumb_items.html.haml
@@ -1,0 +1,6 @@
+= render partial: 'webui/main/breadcrumb_items'
+
+%li.breadcrumb-item
+  = link_to 'Cloud Upload', cloud_upload_index_path
+%li.breadcrumb-item.active{ 'aria-current' => 'page' }
+  Microsoft Azure

--- a/src/api/app/views/webui2/webui/cloud/azure/upload_jobs/new.html.haml
+++ b/src/api/app/views/webui2/webui/cloud/azure/upload_jobs/new.html.haml
@@ -1,0 +1,49 @@
+- @pagetitle = 'Upload to Microsoft Azure'
+
+.card
+  .card-body
+    %h3 Upload to Microsoft Azure
+
+    = form_for @upload_job, url: cloud_azure_upload_path, method: :post, html: { class: 'cloud_form' } do |upload_job_form|
+      = upload_job_form.hidden_field :project
+      = upload_job_form.hidden_field :package
+      = upload_job_form.hidden_field :arch
+      = upload_job_form.hidden_field :repository
+      = upload_job_form.hidden_field :filename
+      = upload_job_form.hidden_field :target, value: 'azure'
+
+      .form-group.row
+        = label_tag(:filename, 'Filename:', class: 'col-md-2 col-form-label')
+        .col-md-10.pt-2
+          %b= @upload_job.filename
+      .form-group.row
+        .col-md-2
+          = upload_job_form.label(:image_name, 'Image Name:', class: 'col-form-label')
+          %abbr.text-danger{ title: 'required' } *
+        .col-md-10
+          = text_field('cloud_backend_upload_job', 'image_name', size: 35, required: true)
+      .form-group.row
+        .col-md-2
+          = upload_job_form.label(:subscription, 'Subscription:', class: 'col-form-label')
+          %abbr.text-danger{ title: 'required' } *
+        .col-md-10
+          = text_field('cloud_backend_upload_job', 'subscription', size: 35, required: true)
+      .form-group.row
+        .col-md-2
+          = upload_job_form.label(:storage_account, 'Storage Account:', class: 'col-form-label')
+          %abbr.text-danger{ title: 'required' } *
+        .col-md-10
+          = text_field('cloud_backend_upload_job', 'storage_account', size: 35, required: true)
+      .form-group.row
+        .col-md-2
+          = upload_job_form.label(:resource_group, 'Resource Group:', class: 'col-form-label')
+          %abbr.text-danger{ title: 'required' } *
+        .col-md-10
+          = text_field('cloud_backend_upload_job', 'resource_group', size: 35, required: true)
+      .form-group.row
+        .col-md-2
+          = upload_job_form.label(:container, 'Container:', class: 'col-form-label')
+          %abbr.text-danger{ title: 'required' } *
+        .col-md-10
+          = text_field('cloud_backend_upload_job', 'container', size: 35, required: true)
+      = submit_tag('Upload Image', class: 'btn btn-primary')


### PR DESCRIPTION
To test this locally, I did like @dmarcoux did [here](https://github.com/openSUSE/open-build-service/pull/7683#issue-285322443):

1. [Download an Azure image](https://build.opensuse.org/package/binaries/openSUSE:Templates:Images:42.3:Azure/openSUSE-Leap-42.3-Azure-Guest/images) from our public instance.
2. Add the downloaded image to the `ctris` package in `home:Admin`
3. Go directly to this route: http://localhost:3000/cloud/azure/upload/new/home:Admin/ctris/openSUSE_Tumbleweed/x86_64/openSUSE-Leap-42.3-Azure.x86_64-0.1.2-Build1.241.vhdfixed.xz
4. Click on the `Microsoft Azure` button.
5. See the form migrated in this PR.

Before:

![Screenshot from 2019-06-05 17-42-43_azure_form_before](https://user-images.githubusercontent.com/24919/58970291-6f72ba00-87b9-11e9-9316-be73e9634f7f.png)

After:

![Screenshot from 2019-06-05 17-43-15_azure_form_after](https://user-images.githubusercontent.com/24919/58970300-75689b00-87b9-11e9-8e44-e1435674bcae.png)