### PR TITLE
Fix the object name of the label helpers

### DIFF
--- a/src/api/app/views/webui2/webui/cloud/ec2/upload_jobs/new.html.haml
+++ b/src/api/app/views/webui2/webui/cloud/ec2/upload_jobs/new.html.haml
@@ -18,16 +18,16 @@
           %b= @upload_job.filename
       .form-group.row
         .col-md-2
-          = upload_job_form.label('cloud_backend_upload_job[ami_name]', 'AMI Name:', class: 'col-form-label')
+          = upload_job_form.label(:ami_name, 'AMI Name:', class: 'col-form-label')
           %abbr.text-danger{ title: 'required' } *
         .col-md-10
           = text_field('cloud_backend_upload_job', 'ami_name', size: 35, required: true)
       .form-group.row
-        = upload_job_form.label('cloud_backend_upload_job[region]', 'Region:', class: 'col-md-2 col-form-label')
+        = upload_job_form.label(:region, 'Region:', class: 'col-md-2 col-form-label')
         .col-md-10
           = select_tag('cloud_backend_upload_job[region]', options_for_select(@regions), class: 'custom-select w-auto')
       .form-group.row
-        = upload_job_form.label('cloud_backend_upload_job[vpc_subnet_id]', 'VPC Subnet ID:', class: 'col-md-2 col-form-label')
+        = upload_job_form.label(:vpc_subnet_id, 'VPC Subnet ID:', class: 'col-md-2 col-form-label')
         .col-md-10
           = text_field('cloud_backend_upload_job', 'vpc_subnet_id', size: 35, placeholder: 'eg. subnet-12345678')
           %small.form-text.text-muted We create a temporary subnet, if you don't provide one.


### PR DESCRIPTION
As the label helpers are prepended with the form object (`upload_job_form.`), it is not needed to include it in the first parameter of the label helper.