### PR TITLE
Colorize build status and repository status icons

### DIFF
--- a/src/api/app/assets/stylesheets/webui2/build-results.scss
+++ b/src/api/app/assets/stylesheets/webui2/build-results.scss
@@ -58,3 +58,15 @@
 .repository-state-outdated {
   @extend .text-gray-400;
 }
+
+.repository-state-broken {
+  @extend .text-danger;
+}
+
+.repository-state-building, .repository-state-finished, .repository-state-publishing {
+  color: $gray-600;
+}
+
+.repository-state-published {
+  @extend .text-success;
+}

--- a/src/api/app/helpers/webui/webui_helper.rb
+++ b/src/api/app/helpers/webui/webui_helper.rb
@@ -142,9 +142,15 @@ module Webui::WebuiHelper
     description << repo_status_description(status)
     description << " (#{details})" if details
 
-    repo_state_class = outdated ? 'outdated' : 'default'
+    repo_state_class = webui2_repository_state_class(outdated, status)
+
     content_tag(:i, '', class: "repository-state-#{repo_state_class} #{html_class} fas fa-#{webui2_repo_status_icon(status)}",
                         data: { content: description, placement: 'top', toggle: 'popover' })
+  end
+
+  def webui2_repository_state_class(outdated, status)
+    return 'outdated' if outdated
+    return status =~ /broken|building|finished|publishing|published/ ? status : 'default'
   end
 
   # TODO: bento_only


### PR DESCRIPTION
Make more clear to know the status of monitor pages and build status results by adding colors. Having all the icons in the same color makes not so easy to distinguish at a glance the status of the builds.

These colors were added for the following states:
- Green: published
- Red: broken
- Dark gray: building, finished, publishing

![Screenshot from 2019-06-06 15-38-41_monitor_with_colors](https://user-images.githubusercontent.com/24919/59037250-36961c00-8871-11e9-8a3a-f979c1e4276b.png)
