### PR TITLE
[dist] obsdodup starts after obsapisetup

### DIFF
--- a/dist/systemd/obsdodup.service
+++ b/dist/systemd/obsdodup.service
@@ -1,6 +1,7 @@
 [Unit]
 Description=OBS dodup, updates download on demand metadata
 After=network.target
+After=obsapisetup.service
 
 [Service]
 EnvironmentFile=/etc/sysconfig/obs-server


### PR DESCRIPTION
otherwise the following errors could occur:

```
Jun 07 12:14:21 localhost systemd[1]: Started OBS dodup, updates download on demand metadata.
Jun 07 12:14:22 localhost bs_dodup[1414]: BSConfig.pm did not return a true value at /usr/lib/obs/server/BSConfiguration.pm line 27.
Jun 07 12:14:22 localhost bs_dodup[1414]: BEGIN failed--compilation aborted at /usr/lib/obs/server/BSConfiguration.pm line 27.
Jun 07 12:14:22 localhost bs_dodup[1414]: Compilation failed in require at /usr/lib/obs/server/bs_dodup line 19.
Jun 07 12:14:22 localhost bs_dodup[1414]: BEGIN failed--compilation aborted at /usr/lib/obs/server/bs_dodup line 19.
Jun 07 12:14:22 localhost systemd[1]: obsdodup.service: Main process exited, code=exited, status=255/n/a
Jun 07 12:14:22 localhost systemd[1]: obsdodup.service: Unit entered failed state.
Jun 07 12:14:22 localhost systemd[1]: obsdodup.service: Failed with result 'exit-code'.
```
