### PR TITLE
Fix value of worker log directory variable (OBS_LOG_DIR)

### DIFF
--- a/dist/obsworker
+++ b/dist/obsworker
@@ -424,10 +424,10 @@ case "$1" in
                 WORKERID="${HOSTNAME}:$I"
             fi
             R=$OBS_WORKER_DIRECTORY/root_$I
+            mkdir -p $R
             # prepare obsworker startup in screen...
             TMPFS=
             if [ "$OBS_VM_TYPE" = "xen" -o "$OBS_VM_TYPE" = "kvm" -o "${OBS_VM_TYPE#emulator:}" != "$OBS_VM_TYPE" ] ; then
-                mkdir -p $R
                 DEVICE="$OBS_WORKER_DIRECTORY/root_$I/root"
                 SWAP="$OBS_WORKER_DIRECTORY/root_$I/swap"
                 if [ -n "$OBS_VM_DISK_AUTOSETUP_ROOT_FILESIZE" ]; then
@@ -446,7 +446,6 @@ case "$1" in
                     HUGETLBFS="--hugetlbfs $OBS_VM_USE_HUGETLBFS"
                 fi
             elif [ "$OBS_VM_TYPE" = 'openstack' ]; then
-                mkdir -p $R
                 # Without a worker being defined, we would not be in this loop.
                 VM_SERVER="--vm-server $OBS_WORKER_CONTROL_INSTANCE"
                 VM_FLAVOR="--openstack-flavor $OBS_WORKER_OS_FLAVOR"
@@ -456,13 +455,11 @@ case "$1" in
                 VM_SWAP="--swap $OBS_WORKER_PREFIX$I-swap"
                 OBS_WORKER_OPT="$OBS_WORKER_OPT1 $WORKER $VM_KERNEL $VM_DISK $VM_SWAP $VM_SERVER $VM_FLAVOR $VMDISK_ROOT_FILESIZE $VMDISK_SWAP_FILESIZE "
             elif [ -n "$vmopt" -a "$OBS_VM_TYPE" = 'zvm' ]; then
-                mkdir -p $R
                 # Without a worker being defined, we would not be in this loop.
                 WORKER="--vm-worker ${WORKERS[$I_INDEX]}"
                 WORKER_NR="--vm-worker-nr $I"
                 OBS_WORKER_OPT="$OBS_WORKER_OPT1 $WORKER $WORKER_NR $VMDISK_FILESYSTEM $VMDISK_MOUNT_OPTIONS $VMDISK_CLEAN"
             else
-                mkdir -p $R
                 DEVICE=
                 SWAP=
                 MEMORY=

--- a/dist/obsworker
+++ b/dist/obsworker
@@ -61,7 +61,7 @@ if [ -z "$OBS_RUN_DIR" ]; then
     OBS_RUN_DIR="/var/run/obs"
 fi
 if [ -z "$OBS_LOG_DIR" ]; then
-    OBS_LOG_DIR="/var/log/obs"
+    OBS_LOG_DIR="/srv/obs/log"
 fi
 if [ -z "$OBS_REPO_SERVERS" ]; then
     OBS_REPO_SERVERS="localhost:5252"

--- a/dist/obsworker
+++ b/dist/obsworker
@@ -4,7 +4,7 @@
 # Author: adrian@suse.de
 #
 # /etc/init.d/obsworker
-#   and its symbolic  link
+#   and its symbolic link
 # /usr/sbin/rcobsworker
 #
 ### BEGIN INIT INFO
@@ -25,22 +25,22 @@
 # It lacks the complete path to build other distros then
 bash_bin=`type -p bash`
 if [ "$bash_bin" != "${bash_bin#/usr}" ]; then
-  export PATH="/bin:$PATH"
+    export PATH="/bin:$PATH"
 fi
 
 if test -e /etc/sysconfig/proxy; then
-  . /etc/sysconfig/proxy
-  export http_proxy="$HTTP_PROXY"
-  export HTTPS_PROXY
-  export NO_PROXY
+    . /etc/sysconfig/proxy
+    export http_proxy="$HTTP_PROXY"
+    export HTTPS_PROXY
+    export NO_PROXY
 fi
 if test -e /etc/sysconfig/obs-server; then
-  # optional on workers
-  . /etc/sysconfig/obs-server
+    # optional on workers
+    . /etc/sysconfig/obs-server
 fi
 # This file may still exist from OBS 2.1 and before.
 if test -e /etc/sysconfig/obs-worker; then
-. /etc/sysconfig/obs-worker
+    . /etc/sysconfig/obs-worker
 fi
 
 # Determine the base and follow a runlevel link name.
@@ -160,13 +160,13 @@ fi
 if [ "$OBS_VM_TYPE" = "zvm" ]; then
     # for z/VM, the disks are already setup with the workers.
     if [ -n "$OBS_VM_DISK_AUTOSETUP_FILESYSTEM" ]; then
-            VMDISK_FILESYSTEM="--vmdisk-filesystem ${OBS_VM_DISK_AUTOSETUP_FILESYSTEM}"
+        VMDISK_FILESYSTEM="--vmdisk-filesystem ${OBS_VM_DISK_AUTOSETUP_FILESYSTEM}"
     fi
     if [ -n "$OBS_VM_DISK_AUTOSETUP_MOUNT_OPTIONS" ]; then
-            VMDISK_MOUNT_OPTIONS="--vmdisk-mount-options ${OBS_VM_DISK_AUTOSETUP_MOUNT_OPTIONS}"
+        VMDISK_MOUNT_OPTIONS="--vmdisk-mount-options ${OBS_VM_DISK_AUTOSETUP_MOUNT_OPTIONS}"
     fi
     if [ -n "$OBS_VM_DISK_CLEAN" ];then
-            VMDISK_CLEAN="--vmdisk-clean"
+        VMDISK_CLEAN="--vmdisk-clean"
     fi
 fi
 
@@ -190,22 +190,18 @@ if [ "$OBS_VM_TYPE" = "xen" -o "$OBS_VM_TYPE" = "kvm" -o "${OBS_VM_TYPE#emulator
 fi
 
 if [ "$OBS_VM_TYPE" = "openstack" ]; then
-
-    #
     if [ -z "$OBS_WORKER_CONTROL_INSTANCE" ];then
-	echo "Please specify OBS_WORKER_CONTROL_INSTANCE in /etc/sysconfig/obs-server!"
+        echo "Please specify OBS_WORKER_CONTROL_INSTANCE in /etc/sysconfig/obs-server!"
         exit 1
     fi
 
-    #
     if [ -z "$OBS_WORKER_OS_FLAVOR" ];then
-	echo "Please specify OBS_WORKER_OS_FLAVOR in /etc/sysconfig/obs-server!"
+        echo "Please specify OBS_WORKER_OS_FLAVOR in /etc/sysconfig/obs-server!"
         exit 1
     fi
 
-    # 
     if [ "$OBS_WORKER_INSTANCES" -lt 1 ]; then
-         OBS_WORKER_INSTANCES=1
+        OBS_WORKER_INSTANCES=1
     fi
 
     # ENVIRONMENT variables for openstack clients
@@ -281,6 +277,7 @@ if [ "$OBS_VM_TYPE" = "openstack" ]; then
     if [ -n "$OBS_OPENSTACK_SWAP_SIZE" ];then
         VMDISK_SWAP_FILESIZE="--vmdisk-swapsize ${OBS_OPENSTACK_SWAP_SIZE}"
     fi
+
     if [ -n "$OBS_OPENSTACK_MEMORY_SIZE" ];then
         MEMORY="--vm-memory ${OBS_OPENSTACK_MEMORY_SIZE}"
     fi
@@ -288,50 +285,50 @@ fi
 
 check_vmcp()
 {
-	# try to load the kernel module
-	modprobe vmcp 2> /dev/null || :
-	# run a vmcp command that always works from within z/VM
-	vmcp q privclass
+    # try to load the kernel module
+    modprobe vmcp 2> /dev/null || :
+    # run a vmcp command that always works from within z/VM
+    vmcp q privclass
 }
 
 create_initrd()
 {
-        # $1 name of kernel
-        # $2 name of initrd
-        # 0150 is already included from the local guest
-        if test -z "$2" ; then
-                echo "Please define a name for the new initrd in /etc/sysconfig/obs-server"
-                return 1
-        else
-		# create initrd with system scripts
-                mkinitrd -k $1 -i $2 -m "xfs reiserfs ext3 ext4 fat vfat" -B -S
-                TEMPDIR=$(mktemp -d /tmp/initrd.XXX)
-                pushd $TEMPDIR
-		# unpack initrd to add some extra files 
-                zcat $2 | cpio -i
-                cat - > etc/udev/rules.d/51-dasd-0.0.0250.rules <<EOF
+    # $1 name of kernel
+    # $2 name of initrd
+    # 0150 is already included from the local guest
+    if test -z "$2" ; then
+        echo "Please define a name for the new initrd in /etc/sysconfig/obs-server"
+        return 1
+    else
+        # create initrd with system scripts
+        mkinitrd -k $1 -i $2 -m "xfs reiserfs ext3 ext4 fat vfat" -B -S
+        TEMPDIR=$(mktemp -d /tmp/initrd.XXX)
+        pushd $TEMPDIR
+        # unpack initrd to add some extra files
+        zcat $2 | cpio -i
+        cat - > etc/udev/rules.d/51-dasd-0.0.0250.rules <<EOF
 ACTION=="add", SUBSYSTEM=="ccw", KERNEL=="0.0.0250",
 IMPORT{program}="collect 0.0.0250 %k 0.0.0250 dasd-eckd"
 ACTION=="add", SUBSYSTEM=="drivers", KERNEL=="dasd-eckd",
 IMPORT{program}="collect 0.0.0250 %k 0.0.0250 dasd-eckd"
 ACTION=="add", ENV{COLLECT_0.0.0250}=="0", ATTR{[ccw/0.0.0250]online}="1"
 EOF
-                # lets activate the alias devices too
-                for device in {1..2}E{C..F}; do
-                cat - > etc/udev/rules.d/51-dasd-0.0.0${device}.rules <<EOF
+        # lets activate the alias devices too
+        for device in {1..2}E{C..F}; do
+        cat - > etc/udev/rules.d/51-dasd-0.0.0${device}.rules <<EOF
 ACTION=="add", SUBSYSTEM=="ccw", KERNEL=="0.0.0${device}",
 IMPORT{program}="collect 0.0.0${device} %k 0.0.0${device} dasd-eckd"
 ACTION=="add", SUBSYSTEM=="drivers", KERNEL=="dasd-eckd",
 IMPORT{program}="collect 0.0.0${device} %k 0.0.0${device} dasd-eckd"
 ACTION=="add", ENV{COLLECT_0.0.0${device}}=="0", ATTR{[ccw/0.0.0${device}]online}="1"
 EOF
-                done
-                cp -a /usr/sbin/xfs_check /sbin/fsck.xfs /usr/sbin/xfs_db sbin/
-		# create new initrd:
-                find . | cpio -H newc -o | gzip -9 -c > $2
-                popd
-                rm -rf $TEMPDIR
-        fi
+        done
+        cp -a /usr/sbin/xfs_check /sbin/fsck.xfs /usr/sbin/xfs_db sbin/
+        # create new initrd:
+        find . | cpio -H newc -o | gzip -9 -c > $2
+        popd
+        rm -rf $TEMPDIR
+    fi
 }
 
 rc_reset
@@ -352,31 +349,31 @@ case "$1" in
             # start one build backend per CPU
             NUM=`ls -d /sys/devices/system/cpu/cpu[0-9]* | wc -l`
         fi
-	if [ "--zvm" == "$vmopt" ]; then
-	    check_vmcp || rc_status -v
-	    create_initrd $OBS_VM_KERNEL $OBS_VM_INITRD || rc_status -v
+        if [ "--zvm" == "$vmopt" ]; then
+            check_vmcp || rc_status -v
+            create_initrd $OBS_VM_KERNEL $OBS_VM_INITRD || rc_status -v
             if [ -n "$OBS_WORKER_INSTANCE_NAMES" ]; then
                 WORKERS=($OBS_WORKER_INSTANCE_NAMES)
                 NUM=${#WORKERS[*]}
             fi
-	fi
+        fi
 
         if [ -n "$OBS_WORKER_OWNER" ]; then
             HOSTOWNER="--owner $OBS_WORKER_OWNER"
         fi
 
-	# print some config data
+        # print some config data
         echo "Run $NUM obsworker using $OBS_WORKER_DIRECTORY"
         echo -n "Type of obsworker is "
-	if [ "--kvm" == "$vmopt" ]; then echo "KVM virtual machine"
-	elif [ "--xen" == "$vmopt" ]; then echo "XEN virtual machine"
-	elif [ "--zvm" == "$vmopt" ]; then echo "z/VM virtual machine"
-	elif [ "--pvm" == "$vmopt" ]; then echo "PowerVM LPAR"
-	elif [ "--emulator" == "$vmopt" ]; then echo "System emulated virtual machine"
-	elif [ "--lxc" == "$vmopt" ]; then echo "LXC container"
-	elif [ "openstack" == "$OBS_VM_TYPE" ]; then echo "OpenStack virtual machine"
-	else  echo "chroot"
-	fi
+        if [ "--kvm" == "$vmopt" ]; then echo "KVM virtual machine"
+        elif [ "--xen" == "$vmopt" ]; then echo "XEN virtual machine"
+        elif [ "--zvm" == "$vmopt" ]; then echo "z/VM virtual machine"
+        elif [ "--pvm" == "$vmopt" ]; then echo "PowerVM LPAR"
+        elif [ "--emulator" == "$vmopt" ]; then echo "System emulated virtual machine"
+        elif [ "--lxc" == "$vmopt" ]; then echo "LXC container"
+        elif [ "openstack" == "$OBS_VM_TYPE" ]; then echo "OpenStack virtual machine"
+        else  echo "chroot"
+        fi
 
         # find SLP announced OBS servers
         if [ "$OBS_USE_SLP" == "yes" ]; then
@@ -395,21 +392,21 @@ case "$1" in
         pushd "$workerbootdir" > /dev/null
         I=0
         while ! curl -s "$WORKER_CODE"/getworkercode | cpio --quiet --extract ; do
-          # we need to wait for rep server maybe
-          echo >&2 "WARNING: Could not reach rep server $WORKER_CODE. Trying again."
-          I=$(( $I + 1 ))
-          if test "10" -lt "$I"; then
-             echo >&2 "ERROR: Unable to reach rep server $WORKER_CODE!"
-             exit 1
-          fi
-          sleep 10
+            # we need to wait for rep server maybe
+            echo >&2 "WARNING: Could not reach rep server $WORKER_CODE. Trying again."
+            I=$(( $I + 1 ))
+            if test "10" -lt "$I"; then
+                 echo >&2 "ERROR: Unable to reach rep server $WORKER_CODE!"
+                 exit 1
+            fi
+            sleep 10
         done
-        ln -s . XML 
+        ln -s . XML
         chmod 755 bs_worker
         popd > /dev/null
 
         for i in $OBS_WORKER_HOSTLABELS; do
-           HOSTLABELS="$HOSTLABELS --hostlabel $i"
+            HOSTLABELS="$HOSTLABELS --hostlabel $i"
         done
         OBS_WORKER_OPT1="$OBS_WORKER_OPT"
         I=0
@@ -420,13 +417,13 @@ case "$1" in
             else
                 port=""
             fi
-	    I_INDEX=$I
+            I_INDEX=$I
             I=$(( $I + 1 ))
-	    if [ "$OBS_VM_TYPE" = 'zvm' ]; then
-		WORKERID="${HOSTNAME}:${WORKERS[$I_INDEX]}"
-	    else
+            if [ "$OBS_VM_TYPE" = 'zvm' ]; then
+                WORKERID="${HOSTNAME}:${WORKERS[$I_INDEX]}"
+            else
                 WORKERID="${HOSTNAME}:$I"
-	    fi
+            fi
             R=$OBS_WORKER_DIRECTORY/root_$I
             # prepare obsworker startup in screen...
             TMPFS=
@@ -449,34 +446,34 @@ case "$1" in
                 if [ -n "$OBS_VM_USE_HUGETLBFS" ]; then
                     HUGETLBFS="--hugetlbfs $OBS_VM_USE_HUGETLBFS"
                 fi
-	    elif [ "$OBS_VM_TYPE" = 'openstack' ]; then
-		mkdir -p $R
-		# Without a worker being defined, we would not be in this loop.
+            elif [ "$OBS_VM_TYPE" = 'openstack' ]; then
+                mkdir -p $R
+                # Without a worker being defined, we would not be in this loop.
                 VM_SERVER="--vm-server $OBS_WORKER_CONTROL_INSTANCE"
                 VM_FLAVOR="--openstack-flavor $OBS_WORKER_OS_FLAVOR"
-		WORKER="--vm-worker $OBS_WORKER_PREFIX$I"
+                WORKER="--vm-worker $OBS_WORKER_PREFIX$I"
                 VM_KERNEL="--vm-kernel $OBS_WORKER_PREFIX$I-grub-image"
                 VM_DISK="--device $OBS_WORKER_PREFIX$I-root"
                 VM_SWAP="--swap $OBS_WORKER_PREFIX$I-swap"
-		OBS_WORKER_OPT="$OBS_WORKER_OPT1 $WORKER $VM_KERNEL $VM_DISK $VM_SWAP $VM_SERVER $VM_FLAVOR $VMDISK_ROOT_FILESIZE $VMDISK_SWAP_FILESIZE "
-	    elif [ -n "$vmopt" -a "$OBS_VM_TYPE" = 'zvm' ]; then
-		mkdir -p $R
-		# Without a worker being defined, we would not be in this loop.
-		WORKER="--vm-worker ${WORKERS[$I_INDEX]}"
-		WORKER_NR="--vm-worker-nr $I"
-		OBS_WORKER_OPT="$OBS_WORKER_OPT1 $WORKER $WORKER_NR $VMDISK_FILESYSTEM $VMDISK_MOUNT_OPTIONS $VMDISK_CLEAN"
+                OBS_WORKER_OPT="$OBS_WORKER_OPT1 $WORKER $VM_KERNEL $VM_DISK $VM_SWAP $VM_SERVER $VM_FLAVOR $VMDISK_ROOT_FILESIZE $VMDISK_SWAP_FILESIZE "
+            elif [ -n "$vmopt" -a "$OBS_VM_TYPE" = 'zvm' ]; then
+                mkdir -p $R
+                # Without a worker being defined, we would not be in this loop.
+                WORKER="--vm-worker ${WORKERS[$I_INDEX]}"
+                WORKER_NR="--vm-worker-nr $I"
+                OBS_WORKER_OPT="$OBS_WORKER_OPT1 $WORKER $WORKER_NR $VMDISK_FILESYSTEM $VMDISK_MOUNT_OPTIONS $VMDISK_CLEAN"
             else
                 mkdir -p $R
                 DEVICE=
                 SWAP=
                 MEMORY=
             fi
-	    echo "screen -t $WORKERID nice -n $OBS_NICE ./bs_worker --hardstatus $vmopt $port --root $R" \
+            echo "screen -t $WORKERID nice -n $OBS_NICE ./bs_worker --hardstatus $vmopt $port --root $R" \
                 "--statedir $workerdir/$I --id $WORKERID $REPO_PARAM $HUGETLBFS $HOSTLABELS" \
                 "$HOSTOWNER $OBS_JOBS $OBS_THREADS $OBS_TEST $OBS_WORKER_OPT $TMPFS $DEVICE $SWAP $MEMORY" \
                 "$OBS_CLEANUP_CHROOT $OBS_WIPE_AFTER_BUILD $ARCH $EMULATOR" \
                 >> $screenrc
-	    mkdir -p $workerdir/$I
+            mkdir -p $workerdir/$I
         done
         pushd "$workerbootdir" > /dev/null
         screen -S obsworker -m -d -c $screenrc
@@ -485,13 +482,13 @@ case "$1" in
     stop)
         echo -n "Shutting down obsworker"
         for I in "$workerdir"/*; do
-	    test -d "$I" || continue
-	    test -e "$I/state" || continue
-	    pushd "$workerbootdir" > /dev/null
-	    ./bs_worker --statedir "$I" --exit &
-	    popd > /dev/null
+            test -d "$I" || continue
+            test -e "$I/state" || continue
+            pushd "$workerbootdir" > /dev/null
+            ./bs_worker --statedir "$I" --exit &
+            popd > /dev/null
         done
-	wait
+        wait
         killall bs_worker 2>/dev/null
         sleep 2
         killall -s 9 bs_worker 2>/dev/null

--- a/dist/obsworker
+++ b/dist/obsworker
@@ -388,7 +388,6 @@ case "$1" in
 
         # fetch worker sources from server
         echo "Fetching initial worker code from $WORKER_CODE/getworkercode"
-        mkdir -p "$workerbootdir"
         pushd "$workerbootdir" > /dev/null
         I=0
         while ! curl -s "$WORKER_CODE"/getworkercode | cpio --quiet --extract ; do


### PR DESCRIPTION
Trying to setup a worker with rpm packages in a bare metal machine resulted in failures creating the log files. The default directory for the log files of workers should be the same as for the other OBS services.

Another reason to change to the default directory is that there is no code to create this log subdirectory.

Some code of the `obsworker` script was also cleaned up.