### PR TITLE
Provide an option to show all results in monitor detailed page

### DIFF
--- a/src/api/app/views/webui2/webui/monitor/_building_table.html.haml
+++ b/src/api/app/views/webui2/webui/monitor/_building_table.html.haml
@@ -49,6 +49,5 @@
               %td.uri= building['workerid']
               %td.hostarch= building['hostarch']
 
-= content_for :ready_function do
-  :plain
-    initializeDataTable('#building-table', { order: [[3, 'desc']] });
+- content_for :ready_function do
+  initializeDataTable('#building-table', { order: [[3, 'desc']], lengthMenu: [[10, 25, 50, 100, -1], [10, 25, 50, 100, "All"]] });


### PR DESCRIPTION
As pagination was introduced, the option to see all the results of the table was lost. Now both options, pagination and all results, are provided.

Now:
![2019-06-07_18-27_monitor_old_all](https://user-images.githubusercontent.com/24919/59119035-05414d00-8952-11e9-9c85-7db8bcb6938c.png)
