### PR TITLE
Initialize '#files-table' with proper defaults

### DIFF
--- a/src/api/app/assets/javascripts/webui2/requests_table.js.erb
+++ b/src/api/app/assets/javascripts/webui2/requests_table.js.erb
@@ -37,10 +37,6 @@ $(document).ready(function() {
       stateDuration: 172800 // 2 days
     });
   });
-
-  $('#files-table').dataTable({
-    'columns': [null, null, null, {'orderable': false}],
-  });
 });
 
 // The dropdowns on the package request tabs

--- a/src/api/app/views/webui2/webui/package/_files_view.html.haml
+++ b/src/api/app/views/webui2/webui/package/_files_view.html.haml
@@ -34,3 +34,6 @@
   - elsif srcmd5
     %h5
       Source MD5 is #{srcmd5} (latest revision is #{current_rev})
+
+= content_for(:ready_function) do
+  initializeDataTable('#files-table');


### PR DESCRIPTION
By using `initializeDataTable`, the table is consistent with other datatables. Ordering can be useful here, so we don't disable it anymore. The code is also in the view where the table is defined.

Fixes #7724