### PR TITLE
Add 'cloud_upload_azure` to the default configuration

### DIFF
--- a/src/api/lib/feature_switch/obs_repository.rb
+++ b/src/api/lib/feature_switch/obs_repository.rb
@@ -5,7 +5,8 @@ module Feature
     class ObsRepository < YamlRepository
       DEFAULTS = {
         image_templates: true,
-        cloud_upload: false
+        cloud_upload: false,
+        cloud_upload_azure: false
       }.freeze
 
       # Read given file, perform erb evaluation and yaml parsing


### PR DESCRIPTION
We added `cloud_upload_azure` as `false` in the default configuration of
`feature switch`



<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md
-->
