### PR TITLE
Handle exception in `Feature.active?` method

### DIFF
--- a/ReleaseNotes-2.10
+++ b/ReleaseNotes-2.10
@@ -42,6 +42,7 @@ Frontend:
    feature, switch database.yml to utf8mb4 encoding
  * Admins can write Terms of Services, via the API, and they will be shown in the WebUI to
    users unless they acknowledge them.
+ * Added `beta` environment in 'config/feature.yml' to toggle features in the beta program.
 
 Backend:
 

--- a/src/api/lib/feature_switch/feature.rb
+++ b/src/api/lib/feature_switch/feature.rb
@@ -9,7 +9,7 @@ module Feature
         @perform_initial_refresh_for_user = false
       end
 
-      Repository::ObsRepository::DEFAULTS.merge(@data['beta']['features']).with_indifferent_access.fetch(feature, false)
+      Repository::ObsRepository::DEFAULTS.merge(@data.dig('beta', 'features') || {}).with_indifferent_access.fetch(feature, false)
     else
       active_features.include?(feature)
     end

--- a/src/api/spec/lib/feature_switch/feature_spec.rb
+++ b/src/api/spec/lib/feature_switch/feature_spec.rb
@@ -1,0 +1,25 @@
+require 'rails_helper'
+
+RSpec.describe Feature do
+  let(:user) { create(:confirmed_user, :in_beta, login: 'Tom') }
+  subject { Feature.active?('bootstrap') }
+
+  context 'with beta users' do
+    before do
+      User.session = user
+      Feature.instance_variable_set(:@perform_initial_refresh_for_user, true)
+    end
+
+    context 'when the file has "beta" key' do
+      it { expect(subject).to be_truthy }
+    end
+
+    context 'when the file doesn\'t have "beta" key' do
+      before do
+        allow(YAML).to receive(:load_file).and_return({})
+      end
+
+      it { expect(subject).to be_falsey }
+    end
+  end
+end


### PR DESCRIPTION
We decide to use the `dig` method to make the `Feature.active?` more robust
if the configuration isn't in a proper format.

Co-authored-by: Victor Pereira <vpereira@suse.com>



<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md
-->
