### PR TITLE
Refactor feature_spec to avoid saving information in the db if not necessary

### DIFF
--- a/src/api/spec/lib/feature_switch/feature_spec.rb
+++ b/src/api/spec/lib/feature_switch/feature_spec.rb
@@ -1,12 +1,12 @@
 require 'rails_helper'
 
 RSpec.describe Feature do
-  let(:user) { create(:confirmed_user, :in_beta, login: 'Tom') }
+  let(:user) { build(:confirmed_user, :in_beta, login: 'Tom') }
   subject { Feature.active?('bootstrap') }
 
   context 'with beta users' do
     before do
-      User.session = user
+      allow(User).to receive(:possibly_nobody).and_return(user)
       Feature.instance_variable_set(:@perform_initial_refresh_for_user, true)
     end
 

--- a/src/api/spec/lib/feature_switch/feature_spec.rb
+++ b/src/api/spec/lib/feature_switch/feature_spec.rb
@@ -1,12 +1,12 @@
 require 'rails_helper'
 
-RSpec.describe Feature do
+RSpec.describe Feature, type: :model do
   let(:user) { build(:confirmed_user, :in_beta, login: 'Tom') }
   subject { Feature.active?('bootstrap') }
 
   context 'with beta users' do
     before do
-      allow(User).to receive(:possibly_nobody).and_return(user)
+      login(user)
       Feature.instance_variable_set(:@perform_initial_refresh_for_user, true)
     end
 


### PR DESCRIPTION
Avoid creating user in the db if necessary. Prefer to stub authentiction methods, than setting globals


