### PR TITLE
Display user email on user#show view only to logged-in users

### DIFF
--- a/src/api/app/views/webui2/webui/user/_info.html.haml
+++ b/src/api/app/views/webui2/webui/user/_info.html.haml
@@ -11,7 +11,7 @@
       %span.badge.badge-secondary.align-top
         = title.upcase
 
-    - unless user.is_nobody?
+    - unless User.possibly_nobody.is_nobody?
       %p
         = mail_to user.email, title: "Send mail to #{user.name}" do
           %i.fas.fa-envelope

--- a/src/api/spec/features/webui/users/user_home_page_spec.rb
+++ b/src/api/spec/features/webui/users/user_home_page_spec.rb
@@ -8,56 +8,76 @@ RSpec.feature "User's home project creation", type: :feature, js: true do
            email: 'jim.knopf@puppenkiste.com')
   end
 
-  before do
-    login user
-    visit home_path
+  describe 'as an anonymous user' do
+    before do
+      visit user_show_path(user)
+    end
+
+    scenario 'view home page of another user' do
+      expect(page).to have_css('#home-realname', text: 'Jim Knopf')
+      expect(page).not_to have_css("a[href='mailto:jim.knopf@puppenkiste.com']", text: 'jim.knopf@puppenkiste.com')
+
+      expect(page).not_to have_text('Edit your account')
+      expect(page).not_to have_text('Change your password')
+
+      expect(page).to have_link('Involved Packages')
+      expect(page).to have_link('Involved Projects')
+      expect(page).to have_link('Owned Project/Packages')
+    end
   end
 
-  scenario 'view home page' do
-    expect(page).to have_css('#home-realname', text: 'Jim Knopf')
-    expect(page).to have_css("a[href='mailto:jim.knopf@puppenkiste.com']", text: 'jim.knopf@puppenkiste.com')
+  describe 'as a logged-in user' do
+    before do
+      login user
+      visit home_path
+    end
 
-    expect(page).to have_text('Edit your account')
-    expect(page).to have_text('Change your password')
+    scenario 'view home page' do
+      expect(page).to have_css('#home-realname', text: 'Jim Knopf')
+      expect(page).to have_css("a[href='mailto:jim.knopf@puppenkiste.com']", text: 'jim.knopf@puppenkiste.com')
 
-    expect(page).to have_link('Involved Packages')
-    expect(page).to have_link('Involved Projects')
-    expect(page).to have_link('Owned Project/Packages')
-  end
+      expect(page).to have_text('Edit your account')
+      expect(page).to have_text('Change your password')
 
-  scenario 'view tasks page' do
-    visit user_tasks_path(user)
+      expect(page).to have_link('Involved Packages')
+      expect(page).to have_link('Involved Projects')
+      expect(page).to have_link('Owned Project/Packages')
+    end
 
-    expect(page).to have_link('Incoming Requests')
-    expect(page).to have_link('Outgoing Requests')
-    expect(page).to have_link('Declined Requests')
-    expect(page).to have_link('All Requests')
+    scenario 'view tasks page' do
+      visit user_tasks_path(user)
 
-    expect(page).not_to have_link('Maintenance Requests')
-  end
+      expect(page).to have_link('Incoming Requests')
+      expect(page).to have_link('Outgoing Requests')
+      expect(page).to have_link('Declined Requests')
+      expect(page).to have_link('All Requests')
 
-  scenario 'edit account information' do
-    click_link('Edit your account')
+      expect(page).not_to have_link('Maintenance Requests')
+    end
 
-    fill_in('user_realname', with: 'John Doe')
-    fill_in('user_email', with: 'john.doe@opensuse.org')
-    find('input[type="submit"]').click
+    scenario 'edit account information' do
+      click_link('Edit your account')
 
-    expect(page).to have_text("User data for user 'Jim' successfully updated.")
-    expect(page).to have_css('#home-realname', text: 'John Doe')
-    expect(page).to have_css("a[href='mailto:john.doe@opensuse.org']", text: 'john.doe@opensuse.org')
-  end
+      fill_in('user_realname', with: 'John Doe')
+      fill_in('user_email', with: 'john.doe@opensuse.org')
+      find('input[type="submit"]').click
 
-  scenario 'public beta program' do
-    # TODO: Change by have_text('In public beta program') when dropping old UI
-    expect(page).not_to have_content(/(Participates in|In) public beta program/)
+      expect(page).to have_text("User data for user 'Jim' successfully updated.")
+      expect(page).to have_css('#home-realname', text: 'John Doe')
+      expect(page).to have_css("a[href='mailto:john.doe@opensuse.org']", text: 'john.doe@opensuse.org')
+    end
 
-    click_link('Join public beta program')
-    expect(page).to have_text("User data for user 'Jim' successfully updated.")
-    expect(page).to have_content(/(Participates in|In) public beta program/)
+    scenario 'public beta program' do
+      # TODO: Change by have_text('In public beta program') when dropping old UI
+      expect(page).not_to have_content(/(Participates in|In) public beta program/)
 
-    click_link('Leave public beta program')
-    expect(page).to have_text("User data for user 'Jim' successfully updated.")
-    expect(page).not_to have_content(/(Participates in|In) public beta program/)
+      click_link('Join public beta program')
+      expect(page).to have_text("User data for user 'Jim' successfully updated.")
+      expect(page).to have_content(/(Participates in|In) public beta program/)
+
+      click_link('Leave public beta program')
+      expect(page).to have_text("User data for user 'Jim' successfully updated.")
+      expect(page).not_to have_content(/(Participates in|In) public beta program/)
+    end
   end
 end


### PR DESCRIPTION
Fixes #7744 

This is testable locally:
1. Add `return true` as the first line in [switch_to_webui2?](https://github.com/openSUSE/open-build-service/blob/e896f17e38d3ce5438e907486e0ff69acd4c7f3f/src/api/app/controllers/webui/webui_controller.rb#L305)
2. Visit http://localhost:3000/user/show/Admin as an anonymous user
3. Do not see the email of _Admin_ (as you can see in the screenshot below)

![issue-7744](https://user-images.githubusercontent.com/1102934/59444347-ff3de700-8dfd-11e9-81f9-7de8e66416a5.png)