### PR TITLE
Rework the feature selection

### DIFF
--- a/src/api/app/controllers/webui/webui_controller.rb
+++ b/src/api/app/controllers/webui/webui_controller.rb
@@ -198,6 +198,7 @@ class Webui::WebuiController < ActionController::Base
     elsif previous_user != User.possibly_nobody.login
       RabbitmqBus.send_to_bus('metrics', 'login,access_point=webui value=1')
     end
+    Feature.use_beta_features(User.possibly_nobody.in_beta?)
   end
 
   def check_display_user

--- a/src/api/config/feature.yml
+++ b/src/api/config/feature.yml
@@ -1,30 +1,26 @@
-production:
-  features: &default
-    image_templates: true
-    kiwi_image_editor: false
-    cloud_upload: false
-    cloud_upload_azure: false
-    bootstrap: false
+# (keep aligned with lib/feature_switch/obs_repository.rb)
+#production:
+#  features:
+#   image_templates: true
+#   cloud_upload: false
+#   cloud_upload_azure: false
+#   bootstrap: false
+#   kiwi_image_editor: false
 
 development:
   features:
-    <<: *default
     kiwi_image_editor: true
     cloud_upload: true
     cloud_upload_azure: true
-    bootstrap: false
 
 test:
   features:
-    <<: *default
     kiwi_image_editor: true
     cloud_upload: true
     cloud_upload_azure: true
-    bootstrap: false
 
 beta:
   features:
-    <<: *default
     kiwi_image_editor: true
     cloud_upload: true
     cloud_upload_azure: true

--- a/src/api/config/feature.yml
+++ b/src/api/config/feature.yml
@@ -1,4 +1,3 @@
-# (keep aligned with lib/feature_switch/obs_repository.rb)
 #production:
 #  features:
 #   image_templates: true

--- a/src/api/lib/authenticator.rb
+++ b/src/api/lib/authenticator.rb
@@ -225,6 +225,7 @@ class Authenticator
     end
 
     User.session = @http_user
+    Feature.use_beta_features(@http_user.in_beta?)
 
     if @http_user.state == 'confirmed'
       Rails.logger.debug "USER found: #{@http_user.login}"
@@ -247,6 +248,7 @@ class Authenticator
   def load_nobody
     @http_user = User.find_nobody!
     User.session = @http_user
+    Feature.use_beta_features(false)
     @user_permissions = Suse::Permission.new(@http_user)
   end
 end

--- a/src/api/lib/feature_switch/feature.rb
+++ b/src/api/lib/feature_switch/feature.rb
@@ -1,17 +1,7 @@
 module Feature
-  @perform_initial_refresh_for_user = true
-
-  def self.active?(feature)
-    if User.possibly_nobody.in_beta?
-      # caching the feature.yml file, this is basically taken from Feature.active_features
-      if @auto_refresh || @perform_initial_refresh_for_user || (@next_refresh_after && Time.now > @next_refresh_after)
-        @data = YAML.load_file("#{Rails.root}/config/feature.yml").with_indifferent_access
-        @perform_initial_refresh_for_user = false
-      end
-
-      Repository::ObsRepository::DEFAULTS.merge(@data.dig('beta', 'features') || {}).with_indifferent_access.fetch(feature, false)
-    else
-      active_features.include?(feature)
-    end
+  def self.use_beta_features(enable)
+    return if (@repository.use_beta_features || false) == enable
+    @repository.use_beta_features = enable
+    @perform_initial_refresh = true
   end
 end

--- a/src/api/lib/feature_switch/obs_repository.rb
+++ b/src/api/lib/feature_switch/obs_repository.rb
@@ -5,17 +5,13 @@ module Feature
     class ObsRepository < YamlRepository
       DEFAULTS = {
         image_templates: true,
-        cloud_upload: false
-      }.freeze
+        cloud_upload: false,
+        cloud_upload_azure: false,
+        bootstrap: false,
+        kiwi_image_editor: false
+      }.with_indifferent_access
 
-      # Read given file, perform erb evaluation and yaml parsing
-      #
-      # @param file_name [String] the file name fo the yaml config
-      # @return [Hash]
-      #
-      def read_file(file_name)
-        super.with_indifferent_access
-      end
+      attr_accessor :use_beta_features
 
       # Extracts active features from given hash
       #
@@ -23,7 +19,12 @@ module Feature
       # @param selector [String] uses the value for this key as source of feature data
       #
       def get_active_features(data, selector)
-        data[@environment]['features'] = DEFAULTS.merge(data[@environment]['features'])
+        data[selector] ||= {}
+        features = data[selector].fetch('features', {})
+        if use_beta_features && data.dig('beta', 'features')
+          features.merge!(data['beta']['features'])
+        end
+        data[selector]['features'] = DEFAULTS.merge(features)
         super
       end
     end

--- a/src/api/lib/feature_switch/obs_repository.rb
+++ b/src/api/lib/feature_switch/obs_repository.rb
@@ -3,6 +3,7 @@ module Feature
     # ObsRepository for active and inactive features based on YamlRepository having default values for each key in OBS
     #
     class ObsRepository < YamlRepository
+      # remember to update comments in config/features.yml if changing
       DEFAULTS = {
         image_templates: true,
         cloud_upload: false,

--- a/src/api/spec/lib/feature_switch/feature_spec.rb
+++ b/src/api/spec/lib/feature_switch/feature_spec.rb
@@ -1,25 +1,35 @@
 require 'rails_helper'
 
 RSpec.describe Feature do
-  let(:user) { create(:confirmed_user, :in_beta, login: 'Tom') }
-  subject { Feature.active?('bootstrap') }
+  subject { Feature.active?(:bootstrap) }
+
+  let(:is_beta) { false }
+
+  before do
+    allow(YAML).to receive(:load).and_return(yaml)
+    Feature.use_beta_features(is_beta)
+    Feature.refresh!
+  end
+
+  context 'with true test settings' do
+    let(:yaml) { { 'test' => { 'features' => { 'bootstrap': true } } } }
+    it { is_expected.to be_truthy }
+  end
+
+  context 'with false test settings' do
+    let(:yaml) { { 'test' => { 'features' => { 'bootstrap': false } } } }
+    it { is_expected.to be_falsey }
+  end
 
   context 'with beta users' do
-    before do
-      User.session = user
-      Feature.instance_variable_set(:@perform_initial_refresh_for_user, true)
-    end
+    let(:is_beta) { true }
+    let(:yaml) { { 'beta' => { 'features' => { 'bootstrap': true } } } }
 
-    context 'when the file has "beta" key' do
-      it { expect(subject).to be_truthy }
-    end
+    it { is_expected.to be_truthy }
 
     context 'when the file doesn\'t have "beta" key' do
-      before do
-        allow(YAML).to receive(:load_file).and_return({})
-      end
-
-      it { expect(subject).to be_falsey }
+      let(:yaml) { {} }
+      it { is_expected.to be_falsey }
     end
   end
 end

--- a/src/api/spec/rails_helper.rb
+++ b/src/api/spec/rails_helper.rb
@@ -83,3 +83,6 @@ require 'support/migration'
 
 # support rabbitmq
 require 'support/rabbitmq'
+
+# reset features
+require 'support/feature'

--- a/src/api/spec/support/feature.rb
+++ b/src/api/spec/support/feature.rb
@@ -1,0 +1,6 @@
+RSpec.configure do |config|
+  config.after do
+    # reset to default
+    Feature.use_beta_features(false)
+  end
+end


### PR DESCRIPTION
- Put production defaults into code, so left over configuration   files from earlier versions don't interfere with new features  in new releases (current config files left over will still overrule though). There were defaults for some features but not for all
- Do not monkey patch Feature class, but use our custom config loading class to merge beta features if configured
- Provide a beta switching function in Feature and use it from login

