### PR TITLE
Improve boostrap version from monitor

### DIFF
--- a/src/api/app/assets/stylesheets/webui2/monitor.scss
+++ b/src/api/app/assets/stylesheets/webui2/monitor.scss
@@ -12,104 +12,30 @@
   margin-top: 3px;
   margin: 3px;
   border: 8px transparent;
-  list-style: none;
-  float: left;
-}
-
-.builderboxtitle {
-  font-weight: bold;
-  padding: 0;
-  margin: 0 0 0.2em;
 }
 
 .monitorboxrow {
-  list-style: none;
-  clear: both;
   margin-bottom: 1em;
-  overflow: hidden;
   li {
     margin-top: 3px !important;
   }
 }
 
-.monitorpb_track {
-  padding: 0;
-  background-color: transparent;
-  background-repeat: repeat-x;
-  background-attachment: scroll;
-  background-position: left -22px;
-  width: 100%;
-  height: 100%;
-  moz-background-clip: border;
-  moz-background-origin: padding;
-  moz-background-inline-policy: continuous;
-  position: absolute;
-  left: 2px;
-  top: 0px;
-  overflow: hidden;
-  margin-right: -20px;
-}
-
-.monitorpb_right {
-  margin: 0;
-  padding: 0;
-  overflow: hidden;
-  width: 2px;
-  height: 100%;
-  background-position: -4px -44px;
-  position: absolute;
-  right: 0px;
-  top: 0px;
-}
-
-.monitorpb_left {
-  position: absolute;
-  left: 0px;
-  top: 0px;
-  margin: 0pt;
-  padding: 0pt;
-  overflow: hidden;
-  width: 2px;
-  height: 100%;
-  float: left;
-  background-position: -2px -44px;
-}
-
 .monitorpb_text {
-  position: absolute;
   left: 4px;
-  top: 2px;
-  overflow: hidden;
-  white-space: nowrap;
-}
-
-.monitorpb_ctrl {
-  margin: 0;
-  padding: 0;
-  background-color: transparent;
-  background-repeat: repeat-x;
-  background-attachment: scroll;
-  background-position: left -1px;
-  width: 100%;
-  height: 100%;
-  moz-background-clip: border;
-  moz-background-origin: padding;
-  moz-background-inline-policy: continuous;
 }
 
 .monitorpb {
   padding: 0;
   height: 22px;
-  position: relative;
   left: 0;
   top: 0;
   max-height: 22px;
-  overflow: hidden;
   margin-top: 1px;
   a {
     color: black ! important;
   }
   .progress-bar {
-    width: 10%;
+    font-size: 14px;
   }
 }

--- a/src/api/app/views/webui2/webui/monitor/_workers_table.html.haml
+++ b/src/api/app/views/webui2/webui/monitor/_workers_table.html.haml
@@ -21,20 +21,19 @@
   %p
     %i No workers
 - else
-  - workers_sorted.each_slice(5) do |row|
-    %ul.monitorboxrow
-      %li.hidden
-        - row.each do |name, hash|
-          %li.builderbox
-            .builderboxtitle #{name} (#{hash['_arch']})
-            - hash.each do |subid, id|
-              - if subid != '_arch'
-                .monitorpb{ id: "p#{id}" }
-                  .progress
-                    .progress-bar.progress-bar-striped{ 'aria-valuemax' => '100', 'aria-valuemin' => '0',
-                                                        'role' => 'progressbar' }
+  .d-flex.flex-wrap
+    - workers_sorted.each do |name, hash|
+      %ul.monitorboxrow.list-unstyled.overflow-hidden
+        %li.builderbox.float-left
+          %span.font-weight-bold #{name} (#{hash['_arch']})
+          - hash.each do |subid, id|
+            - if subid != '_arch'
+              .monitorpb.position-relative{ id: "p#{id}" }
+                .progress
+                  .progress-bar.progress-bar-striped{ 'aria-valuemax' => '100', 'aria-valuemin' => '0',
+                                                      'role' => 'progressbar' }
 
-                      = link_to('#', '', rel: 'nofollow', class: 'monitorpb_text')
+                    = link_to('', '#', rel: 'nofollow', class: 'monitorpb_text position-absolute no-wrap')
 
 - content_for :ready_function do
   :plain


### PR DESCRIPTION
Fixes #7742 

I took care of some issues related with that, specially css related. Including:

- removed unused css classes
- wrap all workers progress bars in a flex div, removing the limit of 5 per row
- increased the font-size inside the progress bar
- set initial value of the progress to 0
- fixed usage of `link_to` when linking to the project inside the progress bar

![Screenshot_2019-06-18_10-18-54](https://user-images.githubusercontent.com/37418/59669982-6cb19500-91bb-11e9-9359-182c8abc5813.png)
![Screenshot_2019-06-18_10-19-37](https://user-images.githubusercontent.com/37418/59669983-6d4a2b80-91bb-11e9-9bf7-601f3f0fdcc7.png)

