### PR TITLE
Avoid having associations with user _nodody_

### DIFF
--- a/src/api/app/models/groups_user.rb
+++ b/src/api/app/models/groups_user.rb
@@ -1,10 +1,13 @@
 class GroupsUser < ApplicationRecord
+  include ActiveModel::Validations
+
   belongs_to :user
   belongs_to :group
 
   validates :user, presence: true
   validates :group, presence: true
   validate :validate_duplicates
+  validates_with AllowedUserValidator
 
   protected
 

--- a/src/api/app/models/relationship.rb
+++ b/src/api/app/models/relationship.rb
@@ -36,6 +36,8 @@ class Relationship < ApplicationRecord
     message: 'User and group can not exist at the same time'
   }, if: proc { |relationship| relationship.group.present? }
 
+  validate :allowed_user
+
   # don't use "is not null" - it won't be in index
   scope :projects, -> { where.not(project_id: nil) }
   scope :packages, -> { where.not(package_id: nil) }
@@ -125,6 +127,13 @@ class Relationship < ApplicationRecord
     return unless role && role.global
     errors.add(:base,
                "global role #{role.title} is not allowed.")
+  end
+
+  # NOTE: Adding a normal validation, the error doesn't reach the view due to
+  # Relationship::AddRole#add_role handling.
+  # We could also check other banned users, not only nobody.
+  def allowed_user
+    raise NotFoundError, "Couldn't find user #{user.login}" if user && user.is_nobody?
   end
 end
 

--- a/src/api/app/models/review.rb
+++ b/src/api/app/models/review.rb
@@ -1,6 +1,8 @@
 require 'api_error'
 
 class Review < ApplicationRecord
+  include ActiveModel::Validations
+
   class NotFoundError < APIError
     setup 'review_not_found', 404, 'Review not found'
   end
@@ -23,6 +25,7 @@ class Review < ApplicationRecord
   # Validate the review is not assigned to a review which is already assigned to this review
   validate :validate_non_symmetric_assignment
   validate :validate_not_self_assigned
+  validates_with AllowedUserValidator
 
   belongs_to :user
   belongs_to :group

--- a/src/api/app/validators/allowed_user_validator.rb
+++ b/src/api/app/validators/allowed_user_validator.rb
@@ -1,0 +1,6 @@
+class AllowedUserValidator < ActiveModel::Validator
+  def validate(record)
+    # NOTE: it could be more generic and check 'locked' users or other possible banned ones
+    record.errors.add(:base, "Couldn't find user #{record.user.login}") if record.user && record.user.is_nobody?
+  end
+end

--- a/src/api/spec/models/group_spec.rb
+++ b/src/api/spec/models/group_spec.rb
@@ -23,6 +23,15 @@ RSpec.describe Group do
       end
     end
 
+    context 'with user _nobody_' do
+      let(:nobody) { create(:user_nobody) }
+
+      it 'does not add the user' do
+        group.replace_members([nobody.login])
+        expect(group.errors.full_messages).to eq(["Validation failed: Couldn't find user _nobody_"])
+      end
+    end
+
     context 'with invalid user input' do
       before(:each) do
         group.users << user

--- a/src/api/spec/models/relationship_spec.rb
+++ b/src/api/spec/models/relationship_spec.rb
@@ -43,6 +43,14 @@ RSpec.describe Relationship do
       skip('This is imposible to happen with the actual validations and how the object is created')
     end
 
+    context 'with banned user' do
+      let(:nobody) { create(:user_nobody) }
+
+      subject { Relationship.add_user(project, nobody, role, true, true) }
+
+      it { expect { subject }.to raise_error(NotFoundError, "Couldn't find user #{nobody.login}") }
+    end
+
     context 'with valid data' do
       before do
         subject

--- a/src/api/spec/models/review_spec.rb
+++ b/src/api/spec/models/review_spec.rb
@@ -92,10 +92,19 @@ RSpec.describe Review do
     end
 
     context 'with invalid attributes' do
+      let!(:nobody) { create(:user_nobody) }
       it 'does not set user association when by_user object does not exist' do
         review = Review.new(by_user: 'not-existent')
         expect(review.user).to eq(nil)
         expect(review.valid?).to eq(false)
+      end
+
+      it 'does not set user association when by_user object is _nobody_' do
+        review = Review.new(by_user: nobody)
+        expect(review.user).to eq(nil)
+        expect(review.valid?).to eq(false)
+        expect(review.errors.messages[:base]).
+          to eq(["Couldn't find user #{nobody.login}"])
       end
 
       it 'does not set group association when by_group object does not exist' do


### PR DESCRIPTION
For now, we ban _nobody_ to have a relationship with project or package (Relationship model) and also to be a member of a group or be a reviewer for a request.

A custom validation was added because it's going to be checked in more than one model.

Fixes: #7749