### PR TITLE
[dist] Fixing our spec file license tag.

### DIFF
--- a/dist/obs-api-testsuite-rspec.spec
+++ b/dist/obs-api-testsuite-rspec.spec
@@ -20,7 +20,7 @@ Name:           obs-api-testsuite-rspec
 Version:        2.10~pre
 Release:        0
 Summary:        The Open Build Service -- RSpec test suite
-License:        GPL-2.0-only
+License:        GPL-2.0-only OR GPL-3.0-only
 Group:          Productivity/Networking/Web/Utilities
 Url:            http://www.openbuildservice.org
 Source0:        open-build-service-%version.tar.xz

--- a/dist/obs-bundled-gems.spec
+++ b/dist/obs-bundled-gems.spec
@@ -22,7 +22,7 @@ Release:        0
 Summary:        The Open Build Service -- Bundled Gems
 # The actual license is from the gems, but we take a more restrictive
 # license to bundle them. Most are MIT anyway (TODO for Ana: check)
-License:        GPL-2.0-only
+License:        GPL-2.0-only OR GPL-3.0-only
 Group:          Productivity/Networking/Web/Utilities
 Url:            http://www.openbuildservice.org
 Source0:        Gemfile

--- a/dist/obs-server.spec
+++ b/dist/obs-server.spec
@@ -87,7 +87,7 @@ fi										\
 
 Name:           obs-server
 Summary:        The Open Build Service -- Server Component
-License:        GPL-2.0-only AND GPL-3.0-only
+License:        GPL-2.0-only OR GPL-3.0-only
 Group:          Productivity/Networking/Web/Utilities
 Version:        2.10~pre
 Release:        0


### PR DESCRIPTION
OBS source can be either used under GPL version 2.0 _or_ under
GPL version 3.0 terms.

This is not a re-licensing, just a fix of the former tagging in spec
files. (GPL v2.0 only and v3.0 only is basically not fullfillable, due
to the fact that v2.0 and v3.0 are incompatible)

Checked with SUSE legal dept.



<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md
-->
