### PR TITLE
Add more space between progress bars with bootstrap

### DIFF
--- a/src/api/app/assets/stylesheets/webui2/monitor.scss
+++ b/src/api/app/assets/stylesheets/webui2/monitor.scss
@@ -9,13 +9,10 @@
 
 .builderbox {
   width: 168px;
-  margin-top: 3px;
-  margin: 3px;
   border: 8px transparent;
 }
 
 .monitorboxrow {
-  margin-bottom: 1em;
   li {
     margin-top: 3px !important;
   }
@@ -26,12 +23,10 @@
 }
 
 .monitorpb {
-  padding: 0;
   height: 22px;
   left: 0;
   top: 0;
   max-height: 22px;
-  margin-top: 1px;
   a {
     color: black ! important;
   }

--- a/src/api/app/views/webui2/webui/monitor/_workers_table.html.haml
+++ b/src/api/app/views/webui2/webui/monitor/_workers_table.html.haml
@@ -23,12 +23,12 @@
 - else
   .d-flex.flex-wrap
     - workers_sorted.each do |name, hash|
-      %ul.monitorboxrow.list-unstyled.overflow-hidden
+      %ul.monitorboxrow.list-unstyled.overflow-hidden.m-3
         %li.builderbox.float-left
           %span.font-weight-bold #{name} (#{hash['_arch']})
           - hash.each do |subid, id|
             - if subid != '_arch'
-              .monitorpb.position-relative{ id: "p#{id}" }
+              .monitorpb.position-relative.mt-1{ id: "p#{id}" }
                 .progress
                   .progress-bar.progress-bar-striped{ 'aria-valuemax' => '100', 'aria-valuemin' => '0',
                                                       'role' => 'progressbar' }


### PR DESCRIPTION
A new iteration, now adding more space between the workers progress bars.. 

Before:

![Screenshot_2019-06-18_21-50-18-before](https://user-images.githubusercontent.com/37418/59715714-c3978880-9214-11e9-9b98-880e2fa85877.png)


After:

![Screenshot_2019-06-18_21-49-38-after](https://user-images.githubusercontent.com/37418/59715735-cd20f080-9214-11e9-918a-22ce80d1407e.png)

