### PR TITLE
Disable W3C mode for Capybara in the openqa tests

### DIFF
--- a/dist/t/spec/support/capybara.rb
+++ b/dist/t/spec/support/capybara.rb
@@ -10,6 +10,7 @@ Capybara.register_driver :selenium_chrome_headless do |app|
   browser_options.args << '--headless'
   browser_options.args << '--no-sandbox'
   browser_options.args << '--allow-insecure-localhost'
+  browser_options.add_option('w3c', false)
   Capybara::Selenium::Driver.new(app, browser: :chrome, options: browser_options)
 end
 


### PR DESCRIPTION
Backport from necessary change to make openQA work again