### PR TITLE
Break lines on words, in the collapsible text component

### DIFF
--- a/src/api/app/assets/stylesheets/webui2/collapsible-text.scss
+++ b/src/api/app/assets/stylesheets/webui2/collapsible-text.scss
@@ -1,6 +1,6 @@
 @mixin collapsible($maxHeight: 4.5em) {
   .obs-collapsible-textbox {
-    word-break: break-all;
+    word-break: break-word;
     padding-right: 1em;
     text-align: justify;
 


### PR DESCRIPTION
Fixes #7796

I believe this will be fine since it's used only for comments and in descriptions of packages, projects, patchinfos and requests.