### PR TITLE
Fix comments word break, use hyphens instead

### DIFF
--- a/src/api/app/assets/stylesheets/webui2/comments.scss
+++ b/src/api/app/assets/stylesheets/webui2/comments.scss
@@ -1,6 +1,6 @@
 #comments {
   .media .media-body {
-    @extend .text-word-break-all;
+    hyphens: auto;
 
     pre, code {
       @extend .p-2;


### PR DESCRIPTION
Using `word-break: break-all;` the comment looks nice when we have long words, but it's true that breaking the word at any character is not a good idea. It looks like this:

![Screenshot-2019-6-21  home Admin(4)](https://user-images.githubusercontent.com/2581944/59938902-9f2aee80-9456-11e9-82f4-33b6c343224b.png)

If we remove the `word-break: break-all;` CSS rule, the comment exceeds the area and looks like follows: 

![Screenshot-2019-6-21  home Admin(1)](https://user-images.githubusercontent.com/2581944/59935594-6b4bcb00-944e-11e9-8efe-e82e3f8dc9b6.png)

So, taking into account that with or without `word-break: break-all;` the result is not ideal... I propose to remove that rule and use `hyphens: auto` instead. It doesn't break the normal words but add a hyphen to the long ones.

![Screenshot-2019-6-21  home Admin(2)](https://user-images.githubusercontent.com/2581944/59939324-e8c80900-9457-11e9-81a7-5d4c23216751.png)

Fixes #7653