### PR TITLE
Make installation instructions work again

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,10 +32,10 @@ If that is not for you because you have some special needs for your setup (e.g. 
 
 After finishing the installation of your base system, follow these steps:
 
-1. Add the OBS software repository with zypper. Please be aware, that the needed URL differs, depending on your Base Operating System. We use openSUSE Leap 15 in this example.
+1. Add the OBS software repository with zypper. Please be aware, that the needed URL differs, depending on your Base Operating System. We use openSUSE Leap 15.1 in this example.
 
     ```shell
-    zypper ar -f http://download.opensuse.org/repositories/OBS:/Server:/2.10/openSUSE_15/OBS:Server:2.10.repo
+    zypper ar -f http://download.opensuse.org/repositories/OBS:/Server:/2.10/openSUSE_15.1/OBS:Server:2.10.repo
     ```
 
 2. Install the package


### PR DESCRIPTION
the url http://download.opensuse.org/repositories/OBS:/Server:/2.10/openSUSE_15/OBS:Server:2.10.repo returns a 404 error, but http://download.opensuse.org/repositories/OBS:/Server:/2.10/openSUSE_15.1/OBS:Server:2.10.repo works