### PR TITLE
Simplify and fix smoke tests for 2.10 branch

### DIFF
--- a/dist/t/spec/features/0020_interconnect_spec.rb
+++ b/dist/t/spec/features/0020_interconnect_spec.rb
@@ -11,9 +11,9 @@ RSpec.describe "Interconnect" do
 
   it "should be able to create link" do
     visit "/interconnects/new"
-    # Don't wait for the javascript text replacement...
-    page.execute_script("$('input[type=\"submit\"]').prop('disabled', false)")
-    click_button('Create Remote project')
+    within('div[data-interconnect="openSUSE.org"]') do
+      click_button('Connect')
+    end
     expect(page).to have_content("Project 'openSUSE.org' was successfully created.")
   end
 end

--- a/dist/t/spec/features/0030_project_spec.rb
+++ b/dist/t/spec/features/0030_project_spec.rb
@@ -10,20 +10,20 @@ RSpec.describe "Project" do
   end
 
   it "should be able to create" do
-    within("div#subheader") do
+    within("div#personal-navigation") do
       click_link('Create Home')
     end
-    page.has_button?('Create Project') ? click_button('Create Project') : click_button('Accept')
+    click_button('Accept')
     expect(page).to have_content("Project 'home:Admin' was created successfully")
   end
 
   it "should be able to add repositories" do
-    within("div#subheader") do
+    within("div#personal-navigation") do
       click_link('Home Project')
     end
     click_link('Repositories')
-    click_link('Add repositories')
-    check('repo_openSUSE_Leap_42_3')
+    click_link('Add from a Distribution')
+    check('repo_openSUSE_Leap_42_3', allow_label_click: true)
     expect(page).to have_content("Successfully added repository 'openSUSE_Leap_42.3'")
   end
 end

--- a/dist/t/spec/features/0040_package_spec.rb
+++ b/dist/t/spec/features/0040_package_spec.rb
@@ -10,51 +10,53 @@ RSpec.describe "Package" do
   end
 
   it "should be able to create new" do
-    within("div#subheader") do
+    within("div#personal-navigation") do
       click_link('Home Project')
     end
-    page.has_link?('Create package') ? click_link('Create package') : click_link('Create Package')
+    click_link('Create Package')
     fill_in 'name', with: 'ctris'
     fill_in 'title', with: 'ctris'
     fill_in 'description', with: 'ctris'
-    page.has_button?('Save changes') ? click_button('Save changes') : click_button('Accept')
+    click_button('Create')
     expect(page).to have_content("Package 'ctris' was created successfully")
   end
 
   it "should be able to upload files" do
-    within("div#subheader") do
+    within("div#personal-navigation") do
       click_link('Home Project')
     end
     click_link('ctris')
     click_link('Add file')
-    attach_file("file", File.expand_path('../../fixtures/ctris.spec', __FILE__))
+    attach_file("file", File.expand_path('../../fixtures/ctris.spec', __FILE__), make_visible: true)
     click_button('Save')
     expect(page).to have_content("The file 'ctris.spec' has been successfully saved.")
 
     # second line of defense ;-)
     click_link('Add file')
-    attach_file("file", File.expand_path('../../fixtures/ctris-0.42.tar.bz2', __FILE__))
+    attach_file("file", File.expand_path('../../fixtures/ctris-0.42.tar.bz2', __FILE__), make_visible: true)
     click_button('Save')
     expect(page).to have_content("The file 'ctris-0.42.tar.bz2' has been successfully saved.")
   end
 
   it "should be able to branch" do
-    within("div#subheader") do
+    within("div#personal-navigation") do
       click_link('Home Project')
     end
-    page.has_link?('Branch existing package') ? click_link('Branch existing package') : click_link('Branch Existing Package')
+    click_link('Branch Existing Package')
     fill_in 'linked_project', with: 'openSUSE.org:openSUSE:Tools'
     fill_in 'linked_package', with: 'build'
-    # Do not wait for autocomplete
-    page.execute_script("$('input[type=\"submit\"]').prop('disabled', false)")
-    page.has_button?('Create Branch') ? click_button('Create Branch') : click_button('Accept')
+    click_button('Accept')
     expect(page).to have_content('build.spec')
   end
 
   it 'should be able to delete' do
+    within("div#personal-navigation") do
+      click_link('Home Project')
+    end
+    click_link('build')
     click_link('Delete package')
     expect(page).to have_content('Do you really want to delete this package?')
-    page.has_button?('Ok') ? click_button('Ok') : click_button('Accept')
+    click_button('Delete')
     expect(page).to have_content('Package was successfully removed.')
   end
 
@@ -64,7 +66,7 @@ RSpec.describe "Package" do
       # wait for the build results ajax call
       sleep(5)
       puts "Refreshed build results, #{counter} retries left."
-      succeed_build = page.all('td', class: 'status_succeeded')
+      succeed_build = page.all('a', class: 'build-state-succeeded')
       if succeed_build.length == 1
         break
       end

--- a/dist/t/spec/spec_helper.rb
+++ b/dist/t/spec/spec_helper.rb
@@ -45,7 +45,7 @@ def login
 end
 
 def logout
-  within("div#subheader") do
+  within("div#personal-navigation") do
     click_link('Logout')
   end
   expect(page).to have_no_link('link-to-user-home')


### PR DESCRIPTION
As smoke tests for each branch are run in the same branch, it is not neccessary to include code to take in account other branches.

After merging this pull request, [tests for 2.10 in openQA](https://openqa.opensuse.org/group_overview/63) should work again.

To review this pull request works, do like openQA:
- Download the qcow image from 2.10: http://download.opensuse.org/repositories/OBS:/Server:/2.10/images/
- Inside this appliance, execute the lines 18 till 22 run in the script [rspec_webui_tests.pm](https://github.com/os-autoinst/os-autoinst-distri-obs/blob/master/tests/rspec_webui_tests.pm).