### PR TITLE
Allow to specify commit messages when changing files

### DIFF
--- a/src/api/app/assets/javascripts/webui/application/cm2/use-codemirror.js
+++ b/src/api/app/assets/javascripts/webui/application/cm2/use-codemirror.js
@@ -26,10 +26,13 @@ function use_codemirror(id, read_only, mode) {
     editor.on('change', function (cm) {
       var changed = true;
       cm.updateHistory(cm);
-      if (cm.historySize().undo > 0)
+      if (cm.historySize().undo > 0) {
         $("#save_" + id).removeClass('inactive');
-      else
+        $("#comment_" + id).prop('disabled', false);
+      } else {
         $("#save_" + id).addClass('inactive');
+        $("#comment_" + id).prop('disabled', true);
+      }
     });
     CodeMirror.signal(editor, 'cursorActivity', editor);
 
@@ -40,18 +43,22 @@ function use_codemirror(id, read_only, mode) {
       $('#flash-messages').remove();
       var data = textarea.data('data');
       data[data['submit']] = editors[id].getValue();
+      data['comment'] = $("#comment_" + id).val();
       $("#save_" + id).addClass("inactive").addClass("working");
+      $("#comment_" + id).prop('disabled', true);
       $.ajax({
         url: textarea.data('save-url'),
         type: (textarea.data('save-method') || 'put'),
         data: data,
         success: function (data, textStatus, xhdr) {
           $("#save_" + id).removeClass("working");
+          $("#comment_" + id).prop('disabled', true).val('');
           // The filter is necessary because we don't return a flash everywhere atm
           $(data).filter('#flash-messages').insertAfter('#subheader').fadeIn('slow');
         },
         error: function (xhdr, textStatus, errorThrown) {
           $("#save_" + id).removeClass("inactive").removeClass("working");
+          $("#comment_" + id).prop('disabled', false);
           // The filter is necessary because we don't return a flash everywhere atm
           $(xhdr.responseText).filter('#flash-messages').insertAfter('#subheader').fadeIn('slow');
         }
@@ -59,6 +66,7 @@ function use_codemirror(id, read_only, mode) {
     });
   } else {
     $("#save_" + id).hide();
+    $("#comment_" + id).hide();
   }
   editors[id] = editor;
 }

--- a/src/api/app/views/shared/_editor.html.haml
+++ b/src/api/app/views/shared/_editor.html.haml
@@ -7,6 +7,7 @@
     .toolbar
       %span{ style: 'float: left' }
         %input.tools.buttons.small.save.inactive{ id: "save_#{uid}", type: 'button', value: 'Save' }/
+        %input.tools.inputs.inactive{ id: "comment_#{uid}", type: 'text', style: 'width: 300px', size: '60', value: '' }/
         %input.tools.buttons.undo{ id: "undo_#{uid}", onclick: "editors[#{uid}].Undo(this);", style: 'background: transparent', type: 'button', value: 'undo' }/
         %input.tools.buttons.redo{ id: "redo_#{uid}", onclick: "editors[#{uid}].Redo(this);", style: 'background: transparent', type: 'button', value: 'redo' }/
       %span{ style: 'float: right' }


### PR DESCRIPTION
Fixes #3179  (for 2.9 branch)

- The commit input field is disabled by default or by pressing undo
![image](https://user-images.githubusercontent.com/602903/60139416-1ee5ef80-97ae-11e9-9e1e-3adf0f9c5871.png)

- After changing any text in the edit field, the commit input field can be edited
![image](https://user-images.githubusercontent.com/602903/60139246-7fc0f800-97ad-11e9-9d92-57a863bac799.png)

- After pressing **Save** the message is added to the revision
![image](https://user-images.githubusercontent.com/602903/60139151-1e008e00-97ad-11e9-919d-fb238048bea9.png)


