### PR TITLE
Allow to specify commit messages when changing files

### DIFF
--- a/src/api/app/assets/javascripts/webui/application/cm2/use-codemirror.js
+++ b/src/api/app/assets/javascripts/webui/application/cm2/use-codemirror.js
@@ -26,10 +26,13 @@ function use_codemirror(id, read_only, mode) {
     editor.on('change', function (cm) {
       var changed = true;
       cm.updateHistory(cm);
-      if (cm.historySize().undo > 0)
+      if (cm.historySize().undo > 0) {
         $("#save_" + id).removeClass('inactive');
-      else
+        $("#comment_" + id).prop('disabled', false);
+      } else {
         $("#save_" + id).addClass('inactive');
+        $("#comment_" + id).prop('disabled', true);
+      }
     });
     CodeMirror.signal(editor, 'cursorActivity', editor);
 
@@ -40,18 +43,22 @@ function use_codemirror(id, read_only, mode) {
       $('#flash-messages').remove();
       var data = textarea.data('data');
       data[data['submit']] = editors[id].getValue();
+      data['comment'] = $("#comment_" + id).val();
       $("#save_" + id).addClass("inactive").addClass("working");
+      $("#comment_" + id).prop('disabled', true);
       $.ajax({
         url: textarea.data('save-url'),
         type: (textarea.data('save-method') || 'put'),
         data: data,
         success: function (data, textStatus, xhdr) {
           $("#save_" + id).removeClass("working");
+          $("#comment_" + id).prop('disabled', true).val('');
           // The filter is necessary because we don't return a flash everywhere atm
           $(data).filter('#flash-messages').insertAfter('#subheader').fadeIn('slow');
         },
         error: function (xhdr, textStatus, errorThrown) {
           $("#save_" + id).removeClass("inactive").removeClass("working");
+          $("#comment_" + id).prop('disabled', false);
           // The filter is necessary because we don't return a flash everywhere atm
           $(xhdr.responseText).filter('#flash-messages').insertAfter('#subheader').fadeIn('slow');
         }
@@ -59,6 +66,7 @@ function use_codemirror(id, read_only, mode) {
     });
   } else {
     $("#save_" + id).hide();
+    $("#comment_" + id).hide();
   }
   editors[id] = editor;
 }

--- a/src/api/app/assets/javascripts/webui2/cm2/use-codemirror.js
+++ b/src/api/app/assets/javascripts/webui2/cm2/use-codemirror.js
@@ -53,6 +53,7 @@ function use_codemirror(id, read_only, mode) {
       $("#undo_" + id).prop('disabled', !undoChanged);
       $("#redo_" + id).prop('disabled', !redoChanged);
       $("#save_" + id).prop('disabled', !undoChanged);
+      $("#comment_" + id).prop('disabled', !undoChanged);
     });
     CodeMirror.signal(editor, 'cursorActivity', editor);
 
@@ -62,6 +63,7 @@ function use_codemirror(id, read_only, mode) {
     $('#save_' + id).click(function () {
       var data = textarea.data('data');
       data[data['submit']] = editors[id].getValue();
+      data['comment'] = $("#comment_" + id).val();
       $("#loading_" + id).attr('disabled', true).removeClass("d-none");
       $.ajax({
         url: textarea.data('save-url'),
@@ -75,6 +77,8 @@ function use_codemirror(id, read_only, mode) {
           $("#undo_" + id).prop('disabled', true);
           $("#redo_" + id).prop('disabled', true);
           $("#save_" + id).prop('disabled', true);
+          $("#comment_" + id).prop('disabled', true);
+          $("#comment_" + id).val('');
         },
         error: function (xhdr, textStatus, errorThrown) {
           $("#loading_" + id).removeAttr('disabled').addClass("d-none");
@@ -86,6 +90,7 @@ function use_codemirror(id, read_only, mode) {
     });
   } else {
     $("#save_" + id).hide();
+    $("#comment_" + id).hide();
   }
   editors[id] = editor;
 }

--- a/src/api/app/views/shared/_editor.html.haml
+++ b/src/api/app/views/shared/_editor.html.haml
@@ -7,6 +7,7 @@
     .toolbar
       %span{ style: 'float: left' }
         %input.tools.buttons.small.save.inactive{ id: "save_#{uid}", type: 'button', value: 'Save' }/
+        %input.tools.inputs.inactive{ id: "comment_#{uid}", type: 'text', style: 'width: 300px', size: '60', value: '' }/
         %input.tools.buttons.undo{ id: "undo_#{uid}", onclick: "editors[#{uid}].Undo(this);", style: 'background: transparent', type: 'button', value: 'undo' }/
         %input.tools.buttons.redo{ id: "redo_#{uid}", onclick: "editors[#{uid}].Redo(this);", style: 'background: transparent', type: 'button', value: 'redo' }/
       %span{ style: 'float: right' }

--- a/src/api/app/views/webui2/shared/_editor.html.haml
+++ b/src/api/app/views/webui2/shared/_editor.html.haml
@@ -12,6 +12,7 @@
           %button.btn.btn-danger.btn-sm.save{ id: "save_#{uid}", disabled: true }
             %i.fa.fa-save
             Save
+          %input.form-control.form-control-sm{ id: "comment_#{uid}", type: 'text', size: '40', disabled: true }
           .btn-group.pl-2
             %button.btn.btn-secondary.btn-sm{ id: "undo_#{uid}", onclick: "editors[#{uid}].Undo(this);", disabled: true }
               %i.fa.fa-undo


### PR DESCRIPTION
Fixes #3179 
webui: 

- The commit input field is disabled by default or by pressing undo
![image](https://user-images.githubusercontent.com/602903/60139416-1ee5ef80-97ae-11e9-9e1e-3adf0f9c5871.png)

- After changing any text in the edit field, the commit input field can be edited
![image](https://user-images.githubusercontent.com/602903/60139246-7fc0f800-97ad-11e9-9d92-57a863bac799.png)

- After pressing **Save** the message is added to the revision
![image](https://user-images.githubusercontent.com/602903/60139151-1e008e00-97ad-11e9-919d-fb238048bea9.png)

webui2:
- The commit input field is disabled by default or by pressing undo
![grafik](https://user-images.githubusercontent.com/602903/60168203-aeb68880-9804-11e9-88ba-ec9298062d0e.png)

- After changing any text in the edit field, the commit input field can be edited
![grafik](https://user-images.githubusercontent.com/602903/60168277-d279ce80-9804-11e9-8cad-f34512f0674d.png)

- After pressing **Save** the message input is disabled again
![grafik](https://user-images.githubusercontent.com/602903/60168321-ede4d980-9804-11e9-830b-7824daccb195.png)

- and the commit message is added to the revision
![grafik](https://user-images.githubusercontent.com/602903/60168388-05bc5d80-9805-11e9-84de-456f4b86398d.png)
