### PR TITLE
Get rid of Selenium deprecation

### DIFF
--- a/dist/t/spec/support/capybara.rb
+++ b/dist/t/spec/support/capybara.rb
@@ -3,7 +3,7 @@ require 'capybara/dsl'
 require 'selenium-webdriver'
 require 'socket'
 
-Selenium::WebDriver::Chrome.driver_path = '/usr/lib64/chromium/chromedriver'
+Selenium::WebDriver::Chrome::Service.driver_path = '/usr/lib64/chromium/chromedriver'
 
 Capybara.register_driver :selenium_chrome_headless do |app|
   browser_options = ::Selenium::WebDriver::Chrome::Options.new

--- a/src/api/spec/support/capybara.rb
+++ b/src/api/spec/support/capybara.rb
@@ -6,7 +6,7 @@ Capybara.disable_animation = true
 
 # we use RSPEC_HOST as trigger to use remote selenium
 if ENV['RSPEC_HOST'].blank?
-  Selenium::WebDriver::Chrome.driver_path = '/usr/lib64/chromium/chromedriver'
+  Selenium::WebDriver::Chrome::Service.driver_path = '/usr/lib64/chromium/chromedriver'
 
   Capybara.register_driver :selenium_chrome_headless do |app|
     Capybara::Selenium::Driver.load_selenium


### PR DESCRIPTION
When tests are run, this message is shown in the console:

```
[DEPRECATION] Selenium::WebDriver::Chrome#driver_path= is deprecated. Use Selenium::WebDriver::Chrome::Service#driver_path= instead.
```

This commit stops using a deprecated method, and therefore prevents this message to be shown.