### PR TITLE
Fix saving of project meta if containing current user as maintainer

### DIFF
--- a/src/api/app/controllers/source_project_meta_controller.rb
+++ b/src/api/app/controllers/source_project_meta_controller.rb
@@ -70,7 +70,10 @@ class SourceProjectMetaController < SourceController
         project = Project.new(name: @project_name)
         project.update_from_xml!(@request_data)
         # FIXME3.0: don't modify send data
-        project.relationships.build(user: User.session!, role: Role.find_by_title!('maintainer'))
+        maintainer_role = Role.find_by_title!('maintainer')
+        unless project.relationships.any? { |relationship| relationship.user == User.session! && relationship.role == maintainer_role }
+          project.relationships.find_or_initialize_by(user: User.session!, role: maintainer_role)
+        end
       end
       project.store(comment: params[:comment])
     end


### PR DESCRIPTION
If the uploaded XML contains the same relationship that the
source controller wants to create (current user as maintainer),
we get an invalid project and active record aborts the save!.

It took quite a while to debug this as we expected save! to throw
an exception for invalid projects. As this behaviour started
with rails 5.2.1 to trigger, we believe it is a Rails bug.

Fixes #7844

Co-authored-by: Ana María Martínez Gómez <anamaria@martinezgomez.name>
