### PR TITLE
[ci] wait for outdated repos while testing build

### DIFF
--- a/dist/t/osc/0030_create_and_build_package.ts
+++ b/dist/t/osc/0030_create_and_build_package.ts
@@ -107,6 +107,7 @@ sub wait_for_buildresults {
     my $recalculation = 0;
     my @result        = `osc r -v`;
     for my $line (@result) {
+      $recalculation = 1 if ($line =~ /outdated/);
       if ($line =~ $regex) {
 	if (($2 || q{}) eq q{*}) {
 	  $recalculation = 1;


### PR DESCRIPTION
Without this commit, the test cases in

0030_create_and_build_package.ts

will break, even if the result is outdated.

This is a regression that was introduced with #9b9f3a873d .
As we changed from "osc r" to "osc r -v" the output has changed,
but the regex to detect outdated repos was never fixed

With this fix we ensure, not to check as long as we have
outdated results.



<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md
-->
