### PR TITLE
Fix saving of project meta if containing current user as maintainer

### DIFF
--- a/ReleaseNotes-2.10
+++ b/ReleaseNotes-2.10
@@ -2,25 +2,13 @@
 # Open Build Service 2.10
 #
 
-WARNING:
-WARNING: This is a development release, not for production usage!
-WARNING:
-
-
-
-
-Please read the README.SETUP file for initial installation
+Please read the README.md file for initial installation
 instructions or use the OBS Appliance from
 
   http://openbuildservice.org/download/
 
-There is also an install medium which installs OBS on hard disk now.
-
-dist/README.UPDATERS file has information for updaters.
-
-OBS Appliance users who have setup their LVM can just replace
-their appliance image without data loss. The migration will
-happen automatically.
+The dist/README.UPDATERS file has information for people updating
+from a previous OBS release.
 
 
 Features
@@ -58,10 +46,10 @@ Backend & build support:
  * new publisher features
    - vagrant box publishing
    - zchunk compressed files in rpm-md metadata
- 
+
  * binary tracking improvements
    - tracking of appliances and containers
- 
+
  * container improvements
    - support multi-arch container manifest generation
    - kiwi profile handling
@@ -71,12 +59,12 @@ Backend & build support:
      conflict over a tag
    - disk space savings with container layer deduplication
    - integrated container registry
- 
+
  * speed improvements
    - faster repository publishing and product generation
    - incremental project updates in the scheduler
    - reducred interconnect load due to a lastevents proxy
- 
+
  * odds and ends
    - obs-build: shell support in KVM
    - prjconf package exclude feature ("onlybuild")

--- a/dist/README.UPDATERS
+++ b/dist/README.UPDATERS
@@ -1,3 +1,7 @@
+OBS Appliance users who have setup their LVM can just replace
+their appliance image without data loss. The migration will
+happen automatically.
+
 For Updaters from OBS 2.9 to OBS 2.10
 =====================================
 

--- a/src/api/app/controllers/source_project_meta_controller.rb
+++ b/src/api/app/controllers/source_project_meta_controller.rb
@@ -70,7 +70,10 @@ class SourceProjectMetaController < SourceController
         project = Project.new(name: @project_name)
         project.update_from_xml!(@request_data)
         # FIXME3.0: don't modify send data
-        project.relationships.build(user: User.session!, role: Role.find_by_title!('maintainer'))
+        maintainer_role = Role.find_by_title!('maintainer')
+        unless project.relationships.any? { |relationship| relationship.user == User.session! && relationship.role == maintainer_role }
+          project.relationships.find_or_initialize_by(user: User.session!, role: maintainer_role)
+        end
       end
       project.store(comment: params[:comment])
     end


### PR DESCRIPTION
If the uploaded XML contains the same relationship that the
source controller wants to create (current user as maintainer),
we get an invalid project and active record aborts the save!.

It took quite a while to debug this as we expected save! to throw
an exception for invalid projects. As this behaviour started
with rails 5.2.1 to trigger, we believe it is a Rails bug.

Fixes #7844

Co-authored-by: Ana María Martínez Gómez <anamaria@martinezgomez.name>



<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md
-->
