### PR TITLE
Change the default value for in_rollout to true

### DIFF
--- a/src/api/db/migrate/20190704072437_add_column_in_rollout_to_users.rb
+++ b/src/api/db/migrate/20190704072437_add_column_in_rollout_to_users.rb
@@ -1,5 +1,5 @@
 class AddColumnInRolloutToUsers < ActiveRecord::Migration[5.2]
   def change
-    add_column :users, :in_rollout, :boolean, default: false, index: true
+    add_column :users, :in_rollout, :boolean, default: true, index: true
   end
 end

--- a/src/api/db/structure.sql
+++ b/src/api/db/structure.sql
@@ -1283,7 +1283,7 @@ CREATE TABLE `users` (
   `owner_id` int(11) DEFAULT NULL,
   `ignore_auth_services` tinyint(1) DEFAULT '0',
   `in_beta` tinyint(1) DEFAULT '0',
-  `in_rollout` tinyint(1) DEFAULT '0',
+  `in_rollout` tinyint(1) DEFAULT '1',
   PRIMARY KEY (`id`),
   UNIQUE KEY `users_login_index` (`login`(255)) USING BTREE,
   KEY `users_password_index` (`deprecated_password`) USING BTREE


### PR DESCRIPTION
All new users entries are going to set in_rollout field to true in the
database.



<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md
-->
