### PR TITLE
Fix 'No tab display in web editor'

### DIFF
--- a/src/api/app/assets/stylesheets/webui/application/cm2/suse.scss
+++ b/src/api/app/assets/stylesheets/webui/application/cm2/suse.scss
@@ -39,6 +39,12 @@
     .save.working { display: none; }
 }
 
+.cm-tab {
+  background: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAADAAAAAMCAYAAAAkuj5RAAAAAXNSR0IArs4c6QAAAGFJREFUSMft1LsRQFAQheHPowAKoACx3IgEKtaEHujDjORSgWTH/ZOdnZOcM/sgk/kFFWY0qV8foQwS4MKBCS3qR6ixBJvElOobYAtivseIE120FaowJPN75GMu8j/LfMwNjh4HUpwg4LUAAAAASUVORK5CYII=);
+  background-position: right;
+  background-repeat: no-repeat;
+}
+
 /* RPM spec styles */
 .cm-s-default span.cm-preamble {color: #b26818; font-weight: bold;}
 .cm-s-default span.cm-macro {color: #b218b2;}

--- a/src/api/app/assets/stylesheets/webui2/cm2/bootstrap.scss
+++ b/src/api/app/assets/stylesheets/webui2/cm2/bootstrap.scss
@@ -31,6 +31,11 @@
   .cm-attribute {color: $blue;}
   .cm-hr {color: $secondary;}
   .cm-link {color: $link-color;}
+  .cm-tab {
+    background: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAADAAAAAMCAYAAAAkuj5RAAAAAXNSR0IArs4c6QAAAGFJREFUSMft1LsRQFAQheHPowAKoACx3IgEKtaEHujDjORSgWTH/ZOdnZOcM/sgk/kFFWY0qV8foQwS4MKBCS3qR6ixBJvElOobYAtivseIE120FaowJPN75GMu8j/LfMwNjh4HUpwg4LUAAAAASUVORK5CYII=);
+    background-position: right;
+    background-repeat: no-repeat;
+  }
 
   .cm-error {color: $danger;}
 


### PR DESCRIPTION
This patch adds a CSS style to the web editor to see tabs that helps users avoid mixed spaces.
Fixes https://github.com/openSUSE/open-build-service/issues/7849

![Screenshot from 2019-07-08 15-17-58](https://user-images.githubusercontent.com/514785/60813248-9f83f300-a193-11e9-853c-6e549c9a3c6a.png)

-> https://obs-reviewlab.opensuse.org/rhabacker-master-display-tab-in-editor/package/view_file/home:Admin/ctris/ctris.spec?expand=1