### PR TITLE
Fix 'No tab display in web editor'

### DIFF
--- a/src/api/app/assets/stylesheets/webui/application/cm2/suse.scss
+++ b/src/api/app/assets/stylesheets/webui/application/cm2/suse.scss
@@ -23,6 +23,12 @@
     line-height: 1.1;
 }
 
+.cm-tab {
+    background: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAADAAAAAMCAYAAAAkuj5RAAAAAXNSR0IArs4c6QAAAGFJREFUSMft1LsRQFAQheHPowAKoACx3IgEKtaEHujDjORSgWTH/ZOdnZOcM/sgk/kFFWY0qV8foQwS4MKBCS3qR6ixBJvElOobYAtivseIE120FaowJPN75GMu8j/LfMwNjh4HUpwg4LUAAAAASUVORK5CYII=);
+    background-position: right;
+    background-repeat: no-repeat;
+}
+
 .toolbar {
     .inputs {
 	/* toolbars default is 130, but we need a little more space */


### PR DESCRIPTION
This patch adds a CSS style to the web editor to see tabs that helps users avoid mixed spaces.

Fixes #7849