### PR TITLE
Add flipper gem and initial setup

### DIFF
--- a/src/api/Gemfile
+++ b/src/api/Gemfile
@@ -61,6 +61,8 @@ gem 'mousetrap-rails'
 gem 'xmlrpc'
 # Multiple feature switch
 gem 'feature'
+gem 'flipper'
+gem 'flipper-active_record'
 # for profiling
 gem 'peek'
 gem 'peek-dalli'

--- a/src/api/Gemfile.lock
+++ b/src/api/Gemfile.lock
@@ -153,6 +153,10 @@ GEM
       i18n (>= 0.7)
     feature (1.4.0)
     ffi (1.11.1)
+    flipper (0.16.2)
+    flipper-active_record (0.16.2)
+      activerecord (>= 3.2, < 6)
+      flipper (~> 0.16.2)
     flot-rails (0.0.7)
       jquery-rails
     font-awesome-sass (5.8.1)
@@ -492,6 +496,8 @@ DEPENDENCIES
   factory_bot_rails
   faker
   feature
+  flipper
+  flipper-active_record
   flot-rails
   font-awesome-sass
   gssapi

--- a/src/api/app/models/user.rb
+++ b/src/api/app/models/user.rb
@@ -112,6 +112,8 @@ class User < ApplicationRecord
   after_create :create_home_project, :track_create
   before_save :send_metric_for_beta_change, if: :in_beta_changed?
 
+  alias flipper_id id
+
   def track_create
     RabbitmqBus.send_to_bus('metrics', 'user.create value=1')
   end

--- a/src/api/config/initializers/flipper.rb
+++ b/src/api/config/initializers/flipper.rb
@@ -1,0 +1,6 @@
+Flipper.configure do |config|
+  config.default do
+    adapter = Flipper::Adapters::ActiveRecord.new
+    Flipper.new(adapter)
+  end
+end

--- a/src/api/db/migrate/20190710094253_create_flipper_tables.rb
+++ b/src/api/db/migrate/20190710094253_create_flipper_tables.rb
@@ -1,0 +1,19 @@
+class CreateFlipperTables < ActiveRecord::Migration[5.2]
+  def change
+    create_table :flipper_features, options: 'CHARSET=utf8 COLLATE=utf8_bin ROW_FORMAT=DYNAMIC', id: :integer do |t|
+      t.string :key, null: false
+      t.timestamps null: false
+
+      t.index :key, unique: true
+    end
+
+    create_table :flipper_gates, options: 'CHARSET=utf8 COLLATE=utf8_bin ROW_FORMAT=DYNAMIC', id: :integer do |t|
+      t.string :feature_key, null: false
+      t.string :key, null: false
+      t.string :value
+      t.timestamps null: false
+
+      t.index [:feature_key, :key, :value], unique: true
+    end
+  end
+end

--- a/src/api/db/structure.sql
+++ b/src/api/db/structure.sql
@@ -555,6 +555,26 @@ CREATE TABLE `flags` (
   CONSTRAINT `flags_ibfk_5` FOREIGN KEY (`package_id`) REFERENCES `packages` (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
 
+CREATE TABLE `flipper_features` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `key` varchar(255) COLLATE utf8_bin NOT NULL,
+  `created_at` datetime NOT NULL,
+  `updated_at` datetime NOT NULL,
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `index_flipper_features_on_key` (`key`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin ROW_FORMAT=DYNAMIC;
+
+CREATE TABLE `flipper_gates` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `feature_key` varchar(255) COLLATE utf8_bin NOT NULL,
+  `key` varchar(255) COLLATE utf8_bin NOT NULL,
+  `value` varchar(255) COLLATE utf8_bin DEFAULT NULL,
+  `created_at` datetime NOT NULL,
+  `updated_at` datetime NOT NULL,
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `index_flipper_gates_on_feature_key_and_key_and_value` (`feature_key`,`key`,`value`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin ROW_FORMAT=DYNAMIC;
+
 CREATE TABLE `group_maintainers` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `group_id` int(11) DEFAULT NULL,
@@ -1458,6 +1478,7 @@ INSERT INTO `schema_migrations` (version) VALUES
 ('20190328131711'),
 ('20190412130831'),
 ('20190520130009'),
-('20190704072437');
+('20190704072437'),
+('20190710094253');
 
 


### PR DESCRIPTION
We want to switch the management of the features from the actual [feature](https://github.com/mgsnova/feature) gem to the [flipper](https://github.com/jnunemaker/flipper) gem.

Co-authored-by: David Kang <dkang@suse.com>
Co-authored-by: Henne Vogelsang <hvogel@opensuse.org>
Co-authored-by: Saray Cabrera Padrón <scabrerapadron@suse.de>                                                                                       
Co-authored-by: Victor Pereira <vpereira@suse.com>