### PR TITLE
Create rake tasks for rollout program

### DIFF
--- a/src/api/lib/tasks/rollout.rake
+++ b/src/api/lib/tasks/rollout.rake
@@ -1,0 +1,37 @@
+# rubocop:disable Rails/SkipsModelValidations
+namespace :rollout do
+  desc 'Move all the users to rollout program'
+  task :all_on do
+    User.all_without_nobody.where(in_rollout: false).in_batches.update_all(in_rollout: true)
+  end
+
+  desc 'Move all the users out of the rollout program'
+  task :all_off do
+    User.where(in_rollout: true).in_batches.update_all(in_rollout: false)
+  end
+
+  desc 'Move the users already in beta to rollout program'
+  task :from_beta do
+    User.where(in_beta: true, in_rollout: false).in_batches.update_all(in_rollout: true)
+  end
+
+  desc 'Move the members of groups to rollout program'
+  task :from_groups do
+    User.where(in_rollout: false).joins(:groups_users).distinct.in_batches.update_all(in_rollout: true)
+  end
+
+  desc 'Move the users with recent activity to rollout program'
+  task :recently_logged_users do
+    User.all_without_nobody
+        .where(in_rollout: false, last_logged_in_at: 3.months.ago.midnight..Time.zone.now)
+        .in_batches.update_all(in_rollout: true)
+  end
+
+  desc 'Move the users without recent activity to rollout program'
+  task :non_recently_logged_users do
+    User.all_without_nobody
+        .where.not(in_rollout: true, last_logged_in_at: 3.months.ago.midnight..Time.zone.now)
+        .in_batches.update_all(in_rollout: true)
+  end
+end
+# rubocop:enable Rails/SkipsModelValidations

--- a/src/api/spec/factories/users.rb
+++ b/src/api/spec/factories/users.rb
@@ -13,6 +13,10 @@ FactoryBot.define do
       in_beta { true }
     end
 
+    trait :in_rollout do
+      in_rollout { true }
+    end
+
     trait :with_home do
       create_home_project { true }
     end

--- a/src/api/spec/lib/tasks/rollout_spec.rb
+++ b/src/api/spec/lib/tasks/rollout_spec.rb
@@ -1,0 +1,80 @@
+require 'rails_helper'
+
+# rubocop:disable RSpec/DescribeClass
+RSpec.describe 'rollout' do
+  # rubocop:enable RSpec/DescribeClass
+  include_context 'rake'
+  let!(:rollout_user) { create(:confirmed_user) }
+  let!(:non_rollout_user) { create(:confirmed_user, in_rollout: false) }
+  let!(:in_rollout_in_beta_user) { create(:confirmed_user, :in_beta) }
+  let!(:non_rollout_in_beta_user) { create(:confirmed_user, :in_beta, in_rollout: false) }
+  let!(:in_rollout_in_group_user) { create(:user_with_groups) }
+  let!(:non_rollout_in_group_user) { create(:user_with_groups, in_rollout: false) }
+  let!(:non_recently_logged_user) do
+    user = create(:confirmed_user, in_rollout: false)
+    user.last_logged_in_at = Time.now - 1.year
+    user.save!
+  end
+
+  let(:all_in_rollout_users) { User.where(in_rollout: true) }
+
+  describe 'all_on' do
+    let(:task) { 'rollout:all_on' }
+
+    it 'will move all the users to Rollout Program' do
+      expect { rake_task.invoke }.to change(User.where(in_rollout: true), :count).from(3).to(7)
+    end
+  end
+
+  describe 'all_off' do
+    let(:task) { 'rollout:all_off' }
+
+    it 'will move all the users out of Rollout Program' do
+      expect { rake_task.invoke }.to change(User.where(in_rollout: false), :count).from(4).to(7)
+    end
+  end
+
+  describe 'from_beta' do
+    let(:task) { 'rollout:from_beta' }
+    let(:users) { User.where(in_beta: true) }
+
+    it 'will move all the users in Beta Program to Rollout Program' do
+      expect { rake_task.invoke }.to change(users.where(in_rollout: true), :count).from(1).to(2)
+    end
+
+    it { expect { rake_task.invoke }.to change(all_in_rollout_users, :count).from(3).to(4) }
+  end
+
+  describe 'from_groups' do
+    let(:task) { 'rollout:from_groups' }
+    let(:users) { User.joins(:groups_users).distinct }
+
+    it 'will move all the users from groups to Rollout Program' do
+      expect { rake_task.invoke }.to change(users.where(in_rollout: true), :count).from(1).to(2)
+    end
+
+    it { expect { rake_task.invoke }.to change(all_in_rollout_users, :count).from(3).to(4) }
+  end
+
+  describe 'recently_logged_users' do
+    let(:task) { 'rollout:recently_logged_users' }
+    let(:users) { User.where(last_logged_in_at: 3.months.ago.midnight..Time.zone.now) }
+
+    it 'will move all recently logged users to Rollout Program' do
+      expect { rake_task.invoke }.to change(users.where(in_rollout: true), :count).from(3).to(6)
+    end
+
+    it { expect { rake_task.invoke }.to change(all_in_rollout_users, :count).from(3).to(6) }
+  end
+
+  describe 'non_recently_logged_users' do
+    let(:task) { 'rollout:non_recently_logged_users' }
+    let(:users) { User.where.not(last_logged_in_at: 3.months.ago.midnight..Time.zone.now) }
+
+    it 'will move all non-recently-logged users to Rollout Program' do
+      expect { rake_task.invoke }.to change(users.where(in_rollout: true), :count).from(0).to(1)
+    end
+
+    it { expect { rake_task.invoke }.to change(all_in_rollout_users, :count).from(3).to(4) }
+  end
+end

--- a/src/api/spec/support/shared_contexts/rake.rb
+++ b/src/api/spec/support/shared_contexts/rake.rb
@@ -1,0 +1,17 @@
+RSpec.shared_context 'rake' do
+  # You define `task` inside your actual test example.
+  let(:rake_task) { Rake.application[task] }
+
+  before :all do
+    Rake.application = Rake::Application.new
+    Rake.application.rake_require(
+      self.class.top_level_description,
+      [Rails.root.join('lib', 'tasks').to_s]
+    )
+    Rake::Task.define_task(:environment)
+  end
+
+  before do
+    rake_task.reenable
+  end
+end


### PR DESCRIPTION
When we want to move a feature out of the Beta Program because it's ready to go live, we can enable it for all the users at the same time or little by little to batches/groups of users. In case we choose the second option, we are talking about the Rollout Program.

We are going to run some tasks every couple of days/weeks to add batches of users to the Rollout Program and let them use the new feature.

We'll move all the users out of the Rollout Program every time we're going to publish a new Rollout Feature and then we will start adding them. New users coming from that time on, are going to be in rollout by default.

Co-authored-by: Saray Cabrera Padrón scabrerapadron@suse.de
Co-authored-by: Eduardo Navarro enavarro@suse.com

<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md
-->
