### PR TITLE
Remove Image Templates from FeatureToggle

### DIFF
--- a/ReleaseNotes-2.11
+++ b/ReleaseNotes-2.11
@@ -42,4 +42,5 @@ Bugfixes:
 Intentional changes:
 ====================
 
-
+  Features enabled by default:
+    * Image Template

--- a/src/api/app/controllers/webui/image_templates_controller.rb
+++ b/src/api/app/controllers/webui/image_templates_controller.rb
@@ -1,6 +1,4 @@
 class Webui::ImageTemplatesController < Webui::WebuiController
-  before_action -> { feature_active?(:image_templates) }
-
   def index
     @projects = Project.image_templates
 

--- a/src/api/app/views/webui/main/index.html.haml
+++ b/src/api/app/views/webui/main/index.html.haml
@@ -18,7 +18,7 @@
         = proceed_link "document-new", 'New Project', controller: 'project', action: 'new', ns: User.session!.home_project_name if User.session
       - unless @spider_bot
         = proceed_link 'utilities-system-monitor', 'Status Monitor', controller: 'monitor', action: 'index'
-      = proceed_link 'drive-optical-32', 'New Image', image_templates_path if Feature.active?(:image_templates)
+      = proceed_link 'drive-optical-32', 'New Image', image_templates_path
   = render partial: 'systemstatus'
 .grid_5.omega
   - if !User.session and can_register

--- a/src/api/app/views/webui2/webui/main/_user_proceed-list.html.haml
+++ b/src/api/app/views/webui2/webui/main/_user_proceed-list.html.haml
@@ -15,9 +15,8 @@
       %i.fas.fa-plus-square.fa-2x.text-primary
       %br
       New Project
-- if Feature.active?(:image_templates)
-  .col
-    = link_to(image_templates_path, class: 'btn btn-default', title: 'Create a new image') do
-      %i.fas.fa-compact-disc.fa-2x.text-secondary
-      %br
-      New Image
+.col
+  = link_to(image_templates_path, class: 'btn btn-default', title: 'Create a new image') do
+    %i.fas.fa-compact-disc.fa-2x.text-secondary
+    %br
+    New Image

--- a/src/api/config/feature.yml
+++ b/src/api/config/feature.yml
@@ -1,6 +1,5 @@
 production:
   features: &default
-    image_templates: true
     kiwi_image_editor: false
     cloud_upload: false
     cloud_upload_azure: false

--- a/src/api/lib/feature_switch/obs_repository.rb
+++ b/src/api/lib/feature_switch/obs_repository.rb
@@ -4,7 +4,6 @@ module Feature
     #
     class ObsRepository < YamlRepository
       DEFAULTS = {
-        image_templates: true,
         cloud_upload: false
       }.freeze
 

--- a/src/api/spec/controllers/webui/image_templates_controller_spec.rb
+++ b/src/api/spec/controllers/webui/image_templates_controller_spec.rb
@@ -2,50 +2,6 @@ require 'rails_helper'
 
 RSpec.describe Webui::ImageTemplatesController, type: :controller do
   describe 'GET #index' do
-    context 'image_templates feature is disabled' do
-      context 'for an anonymous user' do
-        before do
-          Feature.run_with_deactivated(:image_templates) do
-            get :index
-          end
-        end
-
-        it { is_expected.to respond_with(:not_found) }
-      end
-
-      context 'for a user' do
-        before do
-          login user
-
-          Feature.run_with_deactivated(:image_templates) do
-            get :index
-          end
-        end
-
-        context 'participating in the beta' do
-          let(:user) { create(:confirmed_user, :in_beta) }
-
-          it { is_expected.to respond_with(:success) }
-        end
-
-        context 'not participating in the beta' do
-          let(:user) { create(:confirmed_user) }
-
-          it { is_expected.to respond_with(:not_found) }
-        end
-      end
-    end
-
-    context 'image_templates feature is enabled' do
-      before do
-        Feature.run_with_activated(:image_templates) do
-          get :index
-        end
-      end
-
-      it { is_expected.to respond_with(:success) }
-    end
-
     context 'without image templates' do
       before do
         get :index


### PR DESCRIPTION
As a finished feature, `image template` shouldn't be behind the FeatureToggle.



<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md
-->
