### PR TITLE
Add the Flipper groups registry to its initializer

### DIFF
--- a/src/api/config/initializers/flipper.rb
+++ b/src/api/config/initializers/flipper.rb
@@ -3,4 +3,16 @@ Flipper.configure do |config|
     adapter = Flipper::Adapters::ActiveRecord.new
     Flipper.new(adapter)
   end
+
+  # Register beta and rollout groups by default.
+  # We need to add it when initializing because Flipper.register doesn't
+  # store anything in database.
+
+  Flipper.register(:beta) do |user|
+    user.respond_to?(:in_beta?) && user.in_beta?
+  end
+
+  Flipper.register(:rollout) do |user|
+    user.respond_to?(:in_rollout?) && user.in_rollout?
+  end
 end


### PR DESCRIPTION
Flipper.register doesn't store anything in the database, so we need to
set the groups when initializing to make it persistent.

Co-authored-by: David Kang <dkang@suse.com>



<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md
-->
