### PR TITLE
Dont shorten request source path text in webui2

### DIFF
--- a/src/api/app/helpers/webui/request_helper.rb
+++ b/src/api/app/helpers/webui/request_helper.rb
@@ -153,7 +153,7 @@ module Webui::RequestHelper
 
   # rubocop:disable Style/FormatStringToken, Style/FormatString
   def request_action_header(action, creator)
-    source_project_hash = { project: action[:sprj], package: action[:spkg] }
+    source_project_hash = { project: action[:sprj], package: action[:spkg], trim_to: nil }
 
     case action[:type]
     when :submit

--- a/src/api/app/views/webui2/shared/bs_requests/index.json.erb
+++ b/src/api/app/views/webui2/shared/bs_requests/index.json.erb
@@ -7,7 +7,7 @@
       [
         "<%= escape_javascript(fuzzy_time(row.created_at, false)) %>",
         <% cache "request-table-row-#{row.id}-#{row.updated_at.to_i}" do %>
-          "<%= escape_javascript(project_or_package_link(project: row.source_project, package: row.source_package, creator: row.creator, trim_to: 40, short: true)) %>",
+          "<%= escape_javascript(project_or_package_link(project: row.source_project, package: row.source_package, creator: row.creator, trim_to: nil, short: true)) %>",
           "<%= escape_javascript(target_project_link(row)) %>",
           "<%= escape_javascript(user_with_realname_and_icon(row.creator, short: true)) %>",
           "<%= escape_javascript(new_or_update_request(row)) %>",


### PR DESCRIPTION
Looking at the shortend/trimmed source path of a request
makes it sometimes difficult to identify the source, especially
if its through an interconnect (since its not a link to the source
in this case). Bootstrap handles long text quite well in this case.
So trimming the text after 40 characters is not necessary.

Before:
![Screenshot-2019-7-11 Request 12 (new)(1)](https://user-images.githubusercontent.com/22001671/61032383-a09a6780-a3c1-11e9-9a10-4d086acad6bd.png)

After:
![Screenshot-2019-7-11 Request 12 (new)](https://user-images.githubusercontent.com/22001671/61032415-b314a100-a3c1-11e9-97a8-cd81b360d54f.png)

Related to #7378

This would be sufficient solution for now, until https://github.com/openSUSE/open-build-service/pull/7846 is ready :)

