### PR TITLE
Remove Kiwi Image Editor from FeatureToggle

### DIFF
--- a/ReleaseNotes-2.11
+++ b/ReleaseNotes-2.11
@@ -44,3 +44,4 @@ Intentional changes:
 
   Features enabled by default:
     * Image Template
+    * Kiwi Image Editor

--- a/src/api/app/controllers/webui/kiwi/images_controller.rb
+++ b/src/api/app/controllers/webui/kiwi/images_controller.rb
@@ -1,7 +1,6 @@
 module Webui
   module Kiwi
     class ImagesController < WebuiController
-      before_action -> { feature_active?(:kiwi_image_editor) }
       before_action :set_image, except: [:import_from_package]
       before_action :authorize_update, except: [:import_from_package]
       before_action :check_ajax, only: :build_result

--- a/src/api/app/views/webui/package/show.html.erb
+++ b/src/api/app/views/webui/package/show.html.erb
@@ -119,12 +119,10 @@
                 <li>
                   <%= link_to(sprited_text('package_delete', 'Delete package'), { :action => :delete_dialog, :package => @package, :project => @project }, :remote => true, id: 'delete-package') %>
                 </li>
-                <% Feature.with(:kiwi_image_editor) do %>
-                  <% if @package.kiwi_image? && policy(@package).update? %>
-                    <li>
-                      <%= link_to(sprited_text('package_edit', 'View Image'), import_kiwi_image_path(@package.id), id: 'edit-kiwi') %>
-                    </li>
-                  <% end %>
+                <% if @package.kiwi_image? && policy(@package).update? %>
+                  <li>
+                    <%= link_to(sprited_text('package_edit', 'View Image'), import_kiwi_image_path(@package.id), id: 'edit-kiwi') %>
+                  </li>
                 <% end %>
                 <% if Feature.active?(:cloud_upload) && User.session %>
                   <% if @package.kiwi_image? %>

--- a/src/api/app/views/webui2/webui/package/_bottom_actions.html.haml
+++ b/src/api/app/views/webui2/webui/package/_bottom_actions.html.haml
@@ -12,9 +12,8 @@
       = render partial: 'webui2/webui/package/bottom_actions/edit_description'
       = render partial: 'webui2/webui/package/bottom_actions/delete_package'
 
-      - Feature.with(:kiwi_image_editor) do
-        - if package.kiwi_image? && policy(package).update?
-          = render partial: 'webui2/webui/package/bottom_actions/view_kiwi', locals: { package_id: package.id }
+      - if package.kiwi_image? && policy(package).update?
+        = render partial: 'webui2/webui/package/bottom_actions/view_kiwi', locals: { package_id: package.id }
 
       - if Feature.active?(:cloud_upload)
         - if package.kiwi_image?

--- a/src/api/config/feature.yml
+++ b/src/api/config/feature.yml
@@ -1,6 +1,5 @@
 production:
   features: &default
-    kiwi_image_editor: false
     cloud_upload: false
     cloud_upload_azure: false
     bootstrap: false
@@ -8,7 +7,6 @@ production:
 development:
   features:
     <<: *default
-    kiwi_image_editor: true
     cloud_upload: true
     cloud_upload_azure: true
     bootstrap: false
@@ -16,7 +14,6 @@ development:
 test:
   features:
     <<: *default
-    kiwi_image_editor: true
     cloud_upload: true
     cloud_upload_azure: true
     bootstrap: false
@@ -24,7 +21,6 @@ test:
 beta:
   features:
     <<: *default
-    kiwi_image_editor: true
     cloud_upload: true
     cloud_upload_azure: true
     bootstrap: true


### PR DESCRIPTION
As a finished feature, kiwi image editor shouldn't be behind the
FeatureToggle.



<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md
-->
