### PR TITLE
Make CircleCI use SLE12SP4 instead of SLE12SP3

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,21 +7,21 @@ images:
       NOKOGIRI_USE_SYSTEM_LIBRARIES: 1
 
   - &mariadb
-    image: registry.opensuse.org/obs/server/unstable/container/sle12/sp3/containers/openbuildservice/mariadb:latest
+    image: registry.opensuse.org/obs/server/unstable/container/sle12/sp4/containers/openbuildservice/mariadb:latest
     command: |
       /bin/bash -c 'echo -e "[mysqld]\ndatadir = /dev/shm" > /etc/my.cnf.d/obs.cnf && cp -a /var/lib/mysql/* /dev/shm && /usr/lib/mysql/mysql-systemd-helper start'
     name: db
 
-  - &backend registry.opensuse.org/obs/server/unstable/container/sle12/sp3/containers/openbuildservice/backend:latest
+  - &backend registry.opensuse.org/obs/server/unstable/container/sle12/sp4/containers/openbuildservice/backend:latest
 
   - &frontend_backend
-    image: registry.opensuse.org/obs/server/unstable/container/sle12/sp3/containers/openbuildservice/frontend-backend:latest
+    image: registry.opensuse.org/obs/server/unstable/container/sle12/sp4/containers/openbuildservice/frontend-backend:latest
     <<: *common_frontend_config
     environment:
       EAGER_LOAD: 1
 
   - &frontend_base
-    image: registry.opensuse.org/obs/server/unstable/container/sle12/sp3/containers/openbuildservice/frontend-base:latest
+    image: registry.opensuse.org/obs/server/unstable/container/sle12/sp4/containers/openbuildservice/frontend-base:latest
     <<: *common_frontend_config
 
 aliases:


### PR DESCRIPTION
Now that docker images for SLE12SP4 are available, we should use them in CircleCI.
