### PR TITLE
Add environment argument to rollout tasks

### DIFF
--- a/src/api/lib/tasks/rollout.rake
+++ b/src/api/lib/tasks/rollout.rake
@@ -1,34 +1,34 @@
 # rubocop:disable Rails/SkipsModelValidations
 namespace :rollout do
   desc 'Move all the users to rollout program'
-  task :all_on do
+  task all_on: :environment do
     User.all_without_nobody.where(in_rollout: false).in_batches.update_all(in_rollout: true)
   end
 
   desc 'Move all the users out of the rollout program'
-  task :all_off do
+  task all_off: :environment do
     User.where(in_rollout: true).in_batches.update_all(in_rollout: false)
   end
 
   desc 'Move the users already in beta to rollout program'
-  task :from_beta do
+  task from_beta: :environment do
     User.where(in_beta: true, in_rollout: false).in_batches.update_all(in_rollout: true)
   end
 
   desc 'Move the members of groups to rollout program'
-  task :from_groups do
+  task from_groups: :environment do
     User.where(in_rollout: false).joins(:groups_users).distinct.in_batches.update_all(in_rollout: true)
   end
 
   desc 'Move the users with recent activity to rollout program'
-  task :recently_logged_users do
+  task recently_logged_users: :environment do
     User.all_without_nobody
         .where(in_rollout: false, last_logged_in_at: 3.months.ago.midnight..Time.zone.now)
         .in_batches.update_all(in_rollout: true)
   end
 
   desc 'Move the users without recent activity to rollout program'
-  task :non_recently_logged_users do
+  task non_recently_logged_users: :environment do
     User.all_without_nobody
         .where.not(in_rollout: true, last_logged_in_at: 3.months.ago.midnight..Time.zone.now)
         .in_batches.update_all(in_rollout: true)


### PR DESCRIPTION
The :environment argument was missing in the tasks definitions.
The tests passed without it, but running the tasks manually without it
fails.

Co-authored-by: David Kang <dkang@suse.com>



<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md
-->
