### PR TITLE
[backend] bs_worker: fix typo when creating the checksum cache for pr…

### DIFF
--- a/src/backend/bs_worker
+++ b/src/backend/bs_worker
@@ -1771,7 +1771,7 @@ sub getbinaries_kiwiproduct {
 	    'uri' => "$server/build/$projid/$repoid/$arch",
 	    'timeout' => $gettimeout,
 	  }, $BSXML::packagebinarychecksums, 'view=binarychecksums');
-	  $chk = { map { $_->{'name'} => $_->{'_content'} } @{$chk->{'binarychecksums'} || []} };
+	  $chk = { map { $_->{'package'} => $_->{'_content'} } @{$chk->{'binarychecksums'} || []} };
 	  BSUtil::store("$ddir/.checksums.$arch", undef, $chk);
 	} else {
 	  BSRPC::rpc({


### PR DESCRIPTION
…oduct builds

The code used 'name' instead of 'package' when accessing remote projects.



<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md
-->
