### PR TITLE
Take into account `nobody` user for Feature Toggle

### DIFF
--- a/src/api/app/controllers/webui/webui_controller.rb
+++ b/src/api/app/controllers/webui/webui_controller.rb
@@ -305,7 +305,7 @@ class Webui::WebuiController < ActionController::Base
       # The feature switch depends on the user (e.g. Admin or Staff)
       ENV['BOOTSTRAP'].present?
     else
-      Flipper.enabled?(:bootstrap, User.session)
+      Flipper.enabled?(:bootstrap, User.possibly_nobody)
     end
   end
 

--- a/src/api/app/mixins/flipper_feature.rb
+++ b/src/api/app/mixins/flipper_feature.rb
@@ -1,6 +1,6 @@
 module FlipperFeature
   def feature_enabled?(feature)
-    return if Flipper.enabled?(feature.to_sym, User.session)
+    return if Flipper.enabled?(feature.to_sym, User.possibly_nobody)
     render file: Rails.root.join('public/404'), status: :not_found, layout: false
   end
 end


### PR DESCRIPTION
The non-logged users could see the feature in rollout before they log in.

Co-authored-by: Saray Cabrera Padrón <scabrerapadron@suse.de>



<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md
-->
