### PR TITLE
Enable bootstrap for the group beta on development data

### DIFF
--- a/src/api/lib/tasks/dev.rake
+++ b/src/api/lib/tasks/dev.rake
@@ -287,6 +287,9 @@ namespace :dev do
 
       # Trigger package builds for home:admin
       home_admin.store
+
+      # Enable Bootstrap for the group beta
+      Flipper[:bootstrap].enable_group(:beta)
     end
   end
 end


### PR DESCRIPTION
For the review app we use the development data, due to we changes from
FeatureToggle to Flipper we need to enable bootstrap for the group beta
and not on rollout to be able to switch into UI's



<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md
-->
