### PR TITLE
Pass user (possibly nobody) to pundit

### DIFF
--- a/src/api/app/controllers/webui/webui_controller.rb
+++ b/src/api/app/controllers/webui/webui_controller.rb
@@ -288,7 +288,7 @@ class Webui::WebuiController < ActionController::Base
   end
 
   def pundit_user
-    User.session! if User.session
+    User.possibly_nobody
   end
 
   # dialog_init is a function name called before dialog is shown


### PR DESCRIPTION
In some views we try to do policy validation, however some views do not
require authentication, therefore no user object is avaliable to pundit
which raises an exception (look app/policies/application_policy.rb)

Fixes #7743



<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md
-->
