### PR TITLE
Migrate apidocs to Bootstrap

### DIFF
--- a/src/api/app/controllers/webui/apidocs_controller.rb
+++ b/src/api/app/controllers/webui/apidocs_controller.rb
@@ -1,8 +1,9 @@
 class Webui::ApidocsController < Webui::WebuiController
   def index
-    filename = File.expand_path(CONFIG['apidocs_location']) + '/index.html'
-    if File.exist?(filename)
-      render file: filename, formats: [:html]
+    @filename = File.expand_path(CONFIG['apidocs_location']) + '/index.html'
+    if File.exist?(@filename)
+      return if switch_to_webui2
+      render file: @filename, formats: [:html]
     else
       logger.error "Unable to load apidocs index file from #{CONFIG['apidocs_location']}. Did you create the apidocs?"
       flash[:error] = 'Unable to load API documentation.'

--- a/src/api/app/views/webui2/webui/apidocs/_breadcrumb_items.html.haml
+++ b/src/api/app/views/webui2/webui/apidocs/_breadcrumb_items.html.haml
@@ -1,0 +1,5 @@
+= render partial: 'webui/main/breadcrumb_items'
+
+%li.breadcrumb-item.active{ 'aria-current' => 'page' }
+  API Documentation
+

--- a/src/api/app/views/webui2/webui/apidocs/index.html.haml
+++ b/src/api/app/views/webui2/webui/apidocs/index.html.haml
@@ -1,0 +1,3 @@
+.card
+  .card-body
+    = render file: @filename, formats: [:html]

--- a/src/api/spec/bootstrap/features/webui/apidocs_spec.rb
+++ b/src/api/spec/bootstrap/features/webui/apidocs_spec.rb
@@ -1,0 +1,29 @@
+require 'browser_helper'
+
+RSpec.feature 'Apidocs', type: :feature, js: true do
+  let(:user) { create(:confirmed_user) }
+  let(:tmp_dir) { Dir.mktmpdir }
+  let(:tmp_file) { "#{tmp_dir}/index.html" }
+
+  before do
+    login user
+    File.open(tmp_file, 'w') do |f|
+      f.write('<html><head></head><body><h1>API Documentation</h1></body></html>')
+    end
+    CONFIG['apidocs_location'] = tmp_dir
+    visit apidocs_index_path
+  end
+
+  after do
+    File.delete(tmp_file)
+    Dir.rmdir(tmp_dir)
+  end
+
+  scenario 'is wrapped by a Bootstrap class' do
+    expect(page).to have_css('#content > .card')
+  end
+
+  scenario 'includes the file content' do
+    expect(page).to have_content('API Documentation')
+  end
+end


### PR DESCRIPTION
Very simple and straight-forward way to migrate the apidocs to Bootstrap.
Improvements to this page can be added in the future, for example, by overwriting  [restility](https://github.com/openSUSE/restility) HTML generator to use Bootstrap classes.

Fixes: #7909


**Before:**

![Screenshot-2019-7-17 Open Build Service(1)](https://user-images.githubusercontent.com/2581944/61375289-d4ccc700-a89e-11e9-9328-2c1e74d34efa.png)


**After:**

![Screenshot-2019-7-17 Open Build Service](https://user-images.githubusercontent.com/2581944/61375293-d8f8e480-a89e-11e9-84c2-91404f84e5d9.png)

