### PR TITLE
track cpeid of rpm release packages

### DIFF
--- a/src/api/app/models/binary_release.rb
+++ b/src/api/app/models/binary_release.rb
@@ -82,6 +82,7 @@ class BinaryRelease < ApplicationRecord
         hash[:binary_buildtime] = Time.strptime(binary['buildtime'].to_s, '%s') if binary['buildtime'].present?
         hash[:binary_disturl] = binary['disturl']
         hash[:binary_supportstatus] = binary['supportstatus']
+        hash[:binary_cpeid] = binary['cpeid']
         if binary['updateinfoid']
           hash[:binary_updateinfo] = binary['updateinfoid']
           hash[:binary_updateinfo_version] = binary['updateinfoversion']
@@ -182,6 +183,7 @@ class BinaryRelease < ApplicationRecord
 
       binary.binaryid(binary_id) if binary_id
       binary.supportstatus(binary_supportstatus) if binary_supportstatus
+      binary.cpeid(binary_cpeid) if binary_cpeid
       binary.updateinfo(id: binary_updateinfo, version: binary_updateinfo_version) if binary_updateinfo
       binary.maintainer(binary_maintainer) if binary_maintainer
       binary.disturl(binary_disturl) if binary_disturl

--- a/src/api/db/migrate/20190712084813_add_cpeid_to_binary_release.rb
+++ b/src/api/db/migrate/20190712084813_add_cpeid_to_binary_release.rb
@@ -1,0 +1,9 @@
+class AddCpeidToBinaryRelease < ActiveRecord::Migration[4.2]
+  def self.up
+    add_column :binary_releases, :binary_cpeid, :string, charset: 'utf8'
+  end
+
+  def self.down
+    remove_column :binary_releases, :binary_cpeid
+  end
+end

--- a/src/api/db/structure.sql
+++ b/src/api/db/structure.sql
@@ -194,6 +194,7 @@ CREATE TABLE `binary_releases` (
   `on_medium_id` int(11) DEFAULT NULL,
   `binary_id` varchar(255) CHARACTER SET utf8 DEFAULT NULL,
   `flavor` varchar(255) CHARACTER SET utf8 DEFAULT NULL,
+  `binary_cpeid` varchar(255) CHARACTER SET utf8 DEFAULT NULL,
   PRIMARY KEY (`id`),
   KEY `ra_name_index` (`repository_id`,`binary_name`),
   KEY `exact_search_index` (`binary_name`,`binary_epoch`,`binary_version`,`binary_release`,`binary_arch`),
@@ -1479,6 +1480,7 @@ INSERT INTO `schema_migrations` (version) VALUES
 ('20190412130831'),
 ('20190520130009'),
 ('20190704072437'),
-('20190710094253');
+('20190710094253'),
+('20190712084813');
 
 

--- a/src/api/lib/xpath_engine.rb
+++ b/src/api/lib/xpath_engine.rb
@@ -150,6 +150,7 @@ class XpathEngine
         '@medium' => { cpart: 'medium' },
         'disturl' => { cpart: 'binary_disturl' },
         'binaryid' => { cpart: 'binary_id' },
+        'cpeid' => { cpart: 'binary_cpeid' },
         'supportstatus' => { cpart: 'binary_supportstatus' },
         'updateinfo/@id' => { cpart: 'binary_updateinfo' },
         'updateinfo/@version' => { cpart: 'binary_updateinfo_version' },

--- a/src/api/lib/xpath_engine.rb
+++ b/src/api/lib/xpath_engine.rb
@@ -386,22 +386,23 @@ class XpathEngine
         end
         __send__(fname_int, root, *stack.shift)
       when :child
-        t = stack.shift
-        if t == :qname
+        qtype = stack.shift
+        if qtype == :qname
           stack.shift
           root << stack.shift
-          t = stack.shift
-          t = stack.shift
-          if t == :predicate
+          qtype = stack.shift
+          qtype = stack.shift
+          if qtype == :predicate
             parse_predicate(root, stack[0])
             stack.shift
+          elsif qtype.nil? || qtype == :qname
+            # just a plain existens test
+            xpath_func_boolean(root, stack)
           else
-            parse_predicate(root, t)
-            #            stack.shift
-            #            raise IllegalXpathError, "unhandled token in :qname '#{t.inspect}'"
+            parse_predicate(root, qtype)
           end
           root.pop
-        elsif t == :any
+        elsif qtype == :any
           # noop, already shifted
         else
           raise IllegalXpathError, "unhandled token '#{t.inspect}'"
@@ -428,6 +429,8 @@ class XpathEngine
     until expr.empty?
       token = expr.shift
       case token
+      when ''
+        a << expr.shift
       when :child
         expr.shift # qname
         expr.shift # namespace
@@ -585,13 +588,8 @@ class XpathEngine
   def xpath_func_boolean(root, expr)
     # logger.debug "-- xpath_func_boolean(#{expr}) --"
 
-    @condition_values_needed = 2
     cond = evaluate_expr(expr, root)
-
-    condition = "NOT (NOT #{cond} OR ISNULL(#{cond}))"
-    # logger.debug "-- condition : [#{condition}]"
-
-    @condition_values_needed = 1
+    condition = "NOT (ISNULL(#{cond}))"
     @conditions << condition
   end
 

--- a/src/api/test/functional/binary_release_test.rb
+++ b/src/api/test/functional/binary_release_test.rb
@@ -46,6 +46,10 @@ class BinaryReleaseTest < ActionDispatch::IntegrationTest
     assert_response :success
     assert_xml_tag tag: 'binary', attributes: { project: 'BaseDistro3', repository: 'BaseDistro3_repo', name: 'package', version: '1.0', release: '1', arch: 'i586' }
 
+    # by cpeid ... we have no data, but must not crash at least
+    get '/search/released/binary', params: { match: 'cpeid' }
+    assert_response :success
+
     # search via publish container
     get '/search/released/binary/id', params: { match: "publish/@package = 'pack2'" }
     assert_response :success

--- a/src/api/test/functional/channel_maintenance_test.rb
+++ b/src/api/test/functional/channel_maintenance_test.rb
@@ -740,9 +740,17 @@ class ChannelMaintenanceTests < ActionDispatch::IntegrationTest
     get '/search/channel/binary?match=updatefor/[@project="BaseDistro"+and+@product="fixed"]+and+not(target/disabled)'
     assert_response :success
     assert_xml_tag tag: 'collection', attributes: { matches: '0' }
+
+    # the old way we used to do
     get '/search/channel/binary?match=updatefor/[@project="BaseDistro"+and+@product="fixed"]+and+boolean(target/disabled)'
     assert_response :success
     assert_xml_tag tag: 'collection', attributes: { matches: '2' }
+
+    # node existens check does not need a boolean()
+    get '/search/channel/binary?match=updatefor/[@project="BaseDistro"+and+@product="fixed"]+and+target/disabled'
+    assert_response :success
+    assert_xml_tag tag: 'collection', attributes: { matches: '2' }
+
     get '/search/channel/binary?match=not(target/disabled)'
     assert_response :success
     assert_xml_tag tag: 'collection', attributes: { matches: '1' }

--- a/src/backend/BSXML.pm
+++ b/src/backend/BSXML.pm
@@ -1847,6 +1847,7 @@ our $report = [
 	    'disturl',
 	    'binaryid',
 	    'supportstatus',
+	    'cpeid',
 
 	    'project',
 	    'repository',

--- a/src/backend/bs_publish
+++ b/src/backend/bs_publish
@@ -2376,7 +2376,7 @@ sub publish {
 	next unless @s;
 	my $c = $cache{"$bin/$s[9]/$s[7]/$s[1]"};
 	if ($c) {
-	  my @d = qw{arch name epoch version release disturl buildtime};
+	  my @d = qw{arch name epoch version release disturl buildtime provides};
 	  $res = {};
 	  for (@$c) {
 	    my $dd = shift @d;
@@ -2397,6 +2397,11 @@ sub publish {
 	$pt->{'binaryarch'} = $res->{'arch'} if defined $res->{'arch'};
 	$pt->{'binaryid'} = $res->{'hdrmd5'} if defined $res->{'hdrmd5'};
 	$pt->{'id'} = "$bin/$s[9]/$s[7]/$s[1]";
+        # catch provided product cpeid strings
+        if (my ($cpeid) = grep {$_ =~ m/^product-cpeid\(\)/} @{$res->{"provides"}}) {
+          $cpeid =~ s/.* = //;
+          $pt->{'cpeid'} = BSHTTP::urldecode($cpeid);
+        }
 	$packtrack->{$bin} = $pt;
 	if ($pt->{'arch'}) {
 	  $reportfile = $bin;
@@ -2438,6 +2443,7 @@ sub publish {
 	$pt->{'release'} = defined($report->{'release'}) ? $report->{'release'} : '0';
 	$pt->{'binaryarch'} = $report->{'binaryarch'} || $pt->{'arch'} || 'noarch';
 	$pt->{'buildtime'} = $report->{'buildtime'} if $report->{'buildtime'};
+	$pt->{'cpeid'} = BSHTTP::urldecode($report->{'cpeid'}) if $report->{'cpeid'};
         # need a way to get disturl, buildtime and binaryid...
 	$pt->{'disturl'} = $report->{'disturl'} if $report->{'disturl'};
 	$pt->{'ismedium'} = $medium;

--- a/src/backend/bs_worker
+++ b/src/backend/bs_worker
@@ -48,6 +48,7 @@ use BSKiwiXML;
 use BSHTTP;
 use BSBuild;
 use BSCando;
+use BSVerify;
 
 my $can_rewrite_containers;
 eval {
@@ -2692,10 +2693,21 @@ sub addreportdata {
   $report->{'disturl'} = $buildinfo->{'disturl'} if $buildinfo->{'disturl'};
 }
 
+sub cpeid_from_rpm {
+  my ($rpm_file) = @_;
+
+  my $header = Build::query($rpm_file, "evra" => 1);
+  if (my ($cpeid) = grep {$_ =~ m/^product-cpeid\(\)/} @{$header->{"provides"}}) {
+    $cpeid =~ s/.* = //;
+    # the cpeid is still URL encoded. decoding will happen in publisher
+    return $cpeid;
+  }
+}
+
 # parse all .report files and create a channel file from them
 # also update the data in the .report files with the binary origins
 sub createchannel {
-  my ($buildinfo, $dir, $kiwiorigins) = @_;
+  my ($buildinfo, $dir, $kiwiorigins, $srcdir) = @_;
   my @reports = grep {/\.report$/} ls($dir);
   my %channel;
   my $hasunknown;
@@ -2711,7 +2723,17 @@ sub createchannel {
       if (!$prpap) {
 	$prpap = 'UNKNOWN/UNKNOWN/UNKNOWN/UNKNOWN';
 	$hasunknown = 1;
+      } elsif (!defined($bin->{'cpeid'}) && $bin->{'name'} =~ /-release$/) {
+        # current product builders should provide cpeid already
+        # add them for old tools, but only for -release packages for speed reasons
+        my $rpm_file = $bin->{'_content'};
+        $rpm_file =~ s/obs:\//$srcdir\/repos/;
+        if (-e $rpm_file) {
+          my $cpeid = cpeid_from_rpm($rpm_file);
+          $bin->{'cpeid'} = $cpeid if $cpeid;
+        }
       }
+
       my ($projid, $repoid, $arch, $packid) = split('/', $prpap, 4);
       $bin->{'project'} = $projid;
       $bin->{'repository'} = $repoid;
@@ -2796,7 +2818,7 @@ sub createchannel {
 
 # create a .report file from a .packages file by adding binary origin information
 sub createreport {
-  my ($buildinfo, $dir, $kiwiorigins) = @_;
+  my ($buildinfo, $dir, $kiwiorigins, $srcdir) = @_;
 
   local *F;
   for my $file (grep {/\.packages$/} sort(ls($dir))) {
@@ -2834,6 +2856,18 @@ sub createreport {
         $bin->{'repository'} = $repoid;
         $bin->{'arch'} = $arch;
         $bin->{'package'} = $packid if $packid;
+
+        # add cpeid from release rpms only so far for speed reasons
+        if ($bin->{'name'} =~ /-release$/) {
+          BSVerify::verify_projid($projid);
+          BSVerify::verify_repoid($repoid);
+          BSVerify::verify_packid($bin->{'name'}); # not exactly, but hopefully good enough
+          my $rpm_file = "$srcdir/repos/$projid/$repoid/$bin->{'name'}.rpm";
+          if (-e $rpm_file) {
+            my $cpeid = cpeid_from_rpm($rpm_file);
+            $bin->{'cpeid'} = $cpeid if $cpeid;
+          }
+        }
       }
       push @bins, $bin;
     }
@@ -3248,12 +3282,12 @@ sub dobuild {
     $buildinfo->{'buildtime'} = time();
     if (!$kiwimode) {
       # some builds like python-venv also write a .packages file
-      createreport($buildinfo, "$buildroot/.build.packages/OTHER", $kiwiorigins);
+      createreport($buildinfo, "$buildroot/.build.packages/OTHER", $kiwiorigins, $srcdir);
     } elsif ($kiwimode ne 'product') {
-      createreport($buildinfo, "$buildroot/.build.packages/KIWI", $kiwiorigins);
+      createreport($buildinfo, "$buildroot/.build.packages/KIWI", $kiwiorigins, $srcdir);
     } else {
       # as a special service we also create a channel file from the report files
-      createchannel($buildinfo, "$buildroot/.build.packages/OTHER", $kiwiorigins);
+      createchannel($buildinfo, "$buildroot/.build.packages/OTHER", $kiwiorigins, $srcdir);
     }
   }
 

--- a/src/backend/worker/BSVerify.pm
+++ b/src/backend/worker/BSVerify.pm
@@ -1,0 +1,1 @@
+../BSVerify.pm


### PR DESCRIPTION
- also inside of products
- compat code for old product builders not exporting it
- release binary view and search interface
- tracking inside of products
- tracking inside of kiwi appliances
- tracking inside of publisher repositories

still needs to be done:
- tracking inside of containers



<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md
-->
