### PR TITLE
Remove the .small class from Status Message and Last updates to improve readability

### DIFF
--- a/src/api/app/views/webui2/status_messages/_item.html.haml
+++ b/src/api/app/views/webui2/status_messages/_item.html.haml
@@ -1,11 +1,10 @@
-.list-group-item.list-group-item-integrated.border-left-0.border-right-0.small
+.list-group-item.list-group-item-integrated.border-left-0.border-right-0
   .row
     .col-1
       %i.fa.fa-lg{ icon_for_status(message) }
     .col
-      %small
-        = user_with_realname_and_icon(message.user, short: true)
-        wrote #{time_ago_in_words(message.created_at)} ago
+      = user_with_realname_and_icon(message.user, short: true)
+      wrote #{time_ago_in_words(message.created_at)} ago
       - if User.admin_session?
         .float-right
           = link_to(status_message_path(message), method: :delete, title: 'Remove status message') do

--- a/src/api/app/views/webui2/webui/main/_latest_updates.html.haml
+++ b/src/api/app/views/webui2/webui/main/_latest_updates.html.haml
@@ -7,7 +7,7 @@
         %i.fa.fa-rss
   .list-group
     - @latest_updates.each do |update|
-      .list-group-item.list-group-item-integrated.border-left-0.border-right-0.small
+      .list-group-item.list-group-item-integrated.border-left-0.border-right-0
         .row
           .col-1
             - if update[1] == :package
@@ -22,5 +22,5 @@
               - else
                 = link_to(project_show_path(update[1])) do
                   = update[1]
-            %p.small.mt-1.mb-0
+            %p.mt-1.mb-0
               = fuzzy_time(update[0])


### PR DESCRIPTION

**Status Message**

After this PR:

![Screenshot_2019-07-17_15-44-20](https://user-images.githubusercontent.com/37418/61380674-1fa00c00-a8aa-11e9-8eb4-428c003e6dea.png)

Before:

![Screenshot_2019-07-17_15-47-51](https://user-images.githubusercontent.com/37418/61380917-89b8b100-a8aa-11e9-884e-dec836ba6c6c.png)

**Last News**

After this PR:
![Screenshot_2019-07-17_16-51-15](https://user-images.githubusercontent.com/37418/61385989-b7562800-a8b3-11e9-90c4-1257561f02fc.png)


Before:
![Screenshot_2019-07-17_16-53-02](https://user-images.githubusercontent.com/37418/61386000-bcb37280-a8b3-11e9-906c-e4ebbfc4152c.png)


Related with #7927 