### PR TITLE
Fix pre-filling of the Submit Request Form

### DIFF
--- a/src/api/app/assets/javascripts/webui2/request.js
+++ b/src/api/app/assets/javascripts/webui2/request.js
@@ -53,7 +53,31 @@ function setupRequestDialog() { // jshint ignore:line
     updateSupersedeAndDevelPackageDisplay();
   });
 
+  prefillSubmitRequestForm();
+
   updateSupersedeAndDevelPackageDisplay();
+}
+
+/*
+  This prefills the dialog with data coming from the package prefill endpoint.
+  The actual url has to be set in the link that shows the modal (coming as `e.relatedTarget`),
+  as a url data attribute.
+ */
+function prefillSubmitRequestForm() {
+  $('#submit-request-modal').on('show.bs.modal', function(e) {
+    $.ajax({
+      url: $(e.relatedTarget).data().url,
+      dataType: 'json',
+      contentType: 'application/json; charset=utf-8',
+      accept: 'application/json',
+      success: function (e) {
+        $('#targetpackage').attr('value', e.targetPackage);
+        $('#targetproject').attr('value', e.targetProject);
+        $('#description').val(e.description);
+        $('#sourceupdate').attr('checked', e.cleanupSource);
+      }
+    });
+  });
 }
 
 function requestAddReviewAutocomplete() { // jshint ignore:line

--- a/src/api/app/controllers/webui/package_controller.rb
+++ b/src/api/app/controllers/webui/package_controller.rb
@@ -10,6 +10,7 @@ class Webui::PackageController < Webui::WebuiController
 
   before_action :set_project, only: [:show, :index, :users, :linking_packages, :dependency, :binary, :binaries,
                                      :requests, :statistics, :commit, :revisions, :submit_request_dialog,
+                                     :branch_diff_info,
                                      :add_person, :add_group, :rdiff, :save_new,
                                      :save, :delete_dialog,
                                      :remove, :add_file, :save_file, :remove_file, :save_person,
@@ -20,6 +21,7 @@ class Webui::PackageController < Webui::WebuiController
 
   before_action :require_package, only: [:show, :linking_packages, :dependency, :binary, :binaries,
                                          :requests, :statistics, :commit, :revisions, :submit_request_dialog,
+                                         :branch_diff_info,
                                          :add_person, :add_group, :rdiff,
                                          :save, :save_meta, :delete_dialog,
                                          :remove, :add_file, :save_file, :remove_file, :save_person,
@@ -35,6 +37,7 @@ class Webui::PackageController < Webui::WebuiController
   before_action :check_ajax, only: [:update_build_log, :devel_project, :buildresult, :rpmlint_result]
   # make sure it's after the require_, it requires both
   before_action :require_login, except: [:show, :index, :linking_packages, :linking_packages, :dependency,
+                                         :branch_diff_info,
                                          :binary, :binaries, :users, :requests, :statistics, :commit,
                                          :revisions, :rdiff, :view_file, :live_build_log,
                                          :update_build_log, :devel_project, :buildresult, :rpmlint_result,
@@ -540,6 +543,10 @@ class Webui::PackageController < Webui::WebuiController
       return false
     end
     true
+  end
+
+  def branch_diff_info
+    switch_to_webui2
   end
 
   private :check_package_name_for_new

--- a/src/api/app/controllers/webui2/package_controller.rb
+++ b/src/api/app/controllers/webui2/package_controller.rb
@@ -25,4 +25,20 @@ module Webui2::PackageController
                                                       repository: @repository,
                                                       architecture: params[:arch]).results
   end
+
+  def webui2_branch_diff_info
+    linked_package = @package.backend_package.links_to
+    if linked_package
+      target_project = linked_package.project.name
+      target_package = linked_package.name
+      description = @package.commit_message(target_project, target_package)
+    end
+
+    render json: {
+      'targetProject': defined?(target_project) ? target_project : '',
+      'targetPackage': defined?(target_package) ? target_package : '',
+      'description': defined?(description) ? description : '',
+      'cleanupSource': @project.branch? # We should remove the package if this request is a branch
+    }
+  end
 end

--- a/src/api/app/models/project.rb
+++ b/src/api/app/models/project.rb
@@ -1535,6 +1535,12 @@ class Project < ApplicationRecord
     @missing_checks ||= calculate_missing_checks
   end
 
+  # This is not what makes a Package a branch, we only use this to prefill the submit request
+  # dialog in the UI. Please do not rely on this!
+  def branch?
+    name.include?(':branches:') # Rather ugly decision finding...
+  end
+
   private
 
   def discard_cache

--- a/src/api/app/views/webui2/webui/package/_submit_request_dialog.html.haml
+++ b/src/api/app/views/webui2/webui/package/_submit_request_dialog.html.haml
@@ -19,30 +19,30 @@
               = text_field_tag(:sourceproject, project.name, disabled: true, class: 'form-control text-truncate')
             .form-group
               = render partial: 'webui/autocomplete', locals: { html_id: 'targetproject', label: 'To target project:',
-                                                                disabled: params[:readonly], value: target_project,
+                                                                disabled: params[:readonly], value: nil,
                                                                 data: { source: autocomplete_projects_path,
                                                                         requests_url: request_list_small_path,
                                                                         develpackage_url: package_devel_project_path } }
               - if params[:readonly]
-                = hidden_field_tag(:targetproject, target_project)
+                = hidden_field_tag(:targetproject, nil)
 
             .form-group
               = label_tag(:targetpackage, 'To target package:')
-              = text_field_tag(:targetpackage, target_package, disabled: params[:readonly], class: 'form-control')
+              = text_field_tag(:targetpackage, nil, disabled: params[:readonly], class: 'form-control')
               - if params[:readonly]
-                = hidden_field_tag(:targetpackage, target_package)
+                = hidden_field_tag(:targetpackage, nil)
 
             .form-group
               = label_tag(:description, 'Description:')
               %abbr.text-danger{ title: 'required' } *
-              ~ text_area_tag(:description, description, size: '40x3', class: 'form-control', required: true)
+              ~ text_area_tag(:description, nil, size: '40x3', class: 'form-control', required: true)
 
             .form-group.d-none#supersede-display
               = label_tag(:supersede_requests, 'Supersede requests:')
               #supersede-requests
 
             .custom-control.custom-checkbox#sourceupdate-display
-              = check_box_tag(:sourceupdate, 'cleanup', cleanup_source, class: 'custom-control-input')
+              = check_box_tag(:sourceupdate, 'cleanup', nil, class: 'custom-control-input')
               = label_tag(:sourceupdate, 'Remove local package if request is accepted', class: 'custom-control-label')
 
             %p.d-none#devel-project-warning

--- a/src/api/app/views/webui2/webui/package/bottom_actions/_submit_package.html.haml
+++ b/src/api/app/views/webui2/webui/package/bottom_actions/_submit_package.html.haml
@@ -1,4 +1,8 @@
 %li.list-inline-item
-  = link_to('#', class: 'nav-link', data: { toggle: 'modal', target: '#submit-request-modal' }) do
+  = link_to('#',
+      class: 'nav-link',
+      data: { toggle: 'modal',
+              target: '#submit-request-modal',
+              url: package_branch_diff_info_path(@project.name, @package.name) }) do
     %i.fas.fa-share-square.text-warning
     Submit package

--- a/src/api/app/views/webui2/webui/package/show.html.haml
+++ b/src/api/app/views/webui2/webui/package/show.html.haml
@@ -84,9 +84,7 @@
 - if User.session
   - if @current_rev
     = render partial: 'branch_dialog', locals: { project: @project, package: @package, revision: @revision }
-    = render partial: 'submit_request_dialog', locals: { project: @project, package: @package, revision: @revision,
-                                                         target_project: @tprj, target_package: @tpkg,
-                                                         description: @description, cleanup_source: @cleanup_source }
+    = render partial: 'submit_request_dialog', locals: { project: @project, package: @package, revision: @revision }
   - if User.possibly_nobody.can_modify?(@package)
     = render partial: 'edit_dialog', locals: { project: @project, package: @package }
     = render partial: 'delete_dialog', locals: { project: @project, package: @package, cleanup_source: @cleanup_source }

--- a/src/api/config/routes.rb
+++ b/src/api/config/routes.rb
@@ -100,6 +100,7 @@ OBSApi::Application.routes.draw do
     defaults format: 'html' do
       controller 'webui/package' do
         get 'package/show/:project/:package' => :show, as: 'package_show', constraints: cons
+        get 'package/branch_diff_info/:project/:package' => :branch_diff_info, as: 'package_branch_diff_info', constraints: cons
         get 'package/dependency/:project/:package' => :dependency, constraints: cons, as: 'package_dependency'
         get 'package/binary/:project/:package/:repository/:arch/:filename' => :binary, constraints: cons, as: 'package_binary'
         get 'package/binary/download/:project/:package/:repository/:arch/:filename' => :binary_download,


### PR DESCRIPTION
After branching and submitting a package, the form was not pre-filled with the
project and package.

This fix, pre-fills the Submit when hitting the Project overview's
"Submit package" link.

Fixes #7551

Co-authored-by: Eduardo Navarro <enavarro@suse.com>



<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md
-->
