### PR TITLE
Add obs api support target to tests

### DIFF
--- a/dist/t/0070-check_recommended_services.ts
+++ b/dist/t/0070-check_recommended_services.ts
@@ -29,32 +29,30 @@ if ( Build::Rpm::verscmp($pkg_ver, "2.8.99") > 0) {
 plan tests => $test_count;
 
 foreach my $srv (@daemons) {
-	my @state=`systemctl is-enabled $srv\.service 2>/dev/null`;
-	chomp($state[-1]);
-	is($state[-1],"enabled","Checking if recommended service $srv is enabled");
+  my @state=`systemctl is-enabled $srv\.service 2>/dev/null`;
+  chomp($state[-1]);
+  s($state[-1], 'enabled', "Checking if recommended service $srv is enabled");
 }
 
 my %srv_state=();
 
 while ($max_wait > 0) {
-	
-	foreach my $srv (@daemons) {
-		my @state=`systemctl is-active $srv\.service 2>/dev/null`;
-		chomp($state[0]);
-		if ( $state[0] eq 'active') {
-			$srv_state{$srv} = 'active';
-		}
-	}
-	if ( keys(%srv_state) == scalar(@daemons) ) {
-		last;
-	}
-	$max_wait--;
-	sleep 1;
+  foreach my $srv (@daemons) {
+    my @state=`systemctl is-active $srv\.service 2>/dev/null`;
+    chomp($state[0]);
+    if ( $state[0] eq 'active') {
+      $srv_state{$srv} = 'active';
+    }
+  }
+  if ( keys(%srv_state) == scalar(@daemons) ) {
+    last;
+  }
+  $max_wait--;
+  sleep 1;
 }
 
 foreach my $srv ( @daemons ) {
-	is($srv_state{$srv} || 'timeout','active',"Checking recommended service '$srv' status");
+  is($srv_state{$srv} || 'timeout', 'active', "Checking recommended service '$srv' status");
 }
-
 
 exit 0;

--- a/dist/t/0070-check_recommended_units.ts
+++ b/dist/t/0070-check_recommended_units.ts
@@ -19,26 +19,30 @@ use Build::Rpm;
 my $test_count = 6;
 my $max_wait = 300;
 
-my @daemons = qw/obsdodup obssigner obsdeltastore/;
+my @daemons = qw/obsdodup.service obssigner.service obsdeltastore.service/;
 my $pkg_ver = OBS::Test::Utils::get_package_version('obs-server', 2);
 if ( Build::Rpm::verscmp($pkg_ver, "2.8.99") > 0) {
-  $test_count = 8;
-  push (@daemons, 'obsservicedispatch');
+  $test_count += 2;
+  push (@daemons, 'obsservicedispatch.service');
+}
+if ( Build::Rpm::verscmp($pkg_ver, "2.9.99") > 0) {
+  $test_count += 2;
+  push (@daemons, 'obs-api-support.target');
 }
 
 plan tests => $test_count;
 
 foreach my $srv (@daemons) {
-  my @state=`systemctl is-enabled $srv\.service 2>/dev/null`;
+  my @state=`systemctl is-enabled $srv 2>/dev/null`;
   chomp($state[-1]);
-  s($state[-1], 'enabled', "Checking if recommended service $srv is enabled");
+  is($state[-1], 'enabled', "Checking if recommended unit $srv is enabled");
 }
 
 my %srv_state=();
 
 while ($max_wait > 0) {
   foreach my $srv (@daemons) {
-    my @state=`systemctl is-active $srv\.service 2>/dev/null`;
+    my @state=`systemctl is-active $srv 2>/dev/null`;
     chomp($state[0]);
     if ( $state[0] eq 'active') {
       $srv_state{$srv} = 'active';
@@ -52,7 +56,7 @@ while ($max_wait > 0) {
 }
 
 foreach my $srv ( @daemons ) {
-  is($srv_state{$srv} || 'timeout', 'active', "Checking recommended service '$srv' status");
+  is($srv_state{$srv} || 'timeout', 'active', "Checking recommended unit '$srv' status");
 }
 
 exit 0;


### PR DESCRIPTION
This will help us to run migration tests from 2.9 to 2.10 in kanku, and check for the status of systemd units.

Co-authored-by: David Kang <dkang@suse.com>
Co-authored-by: Frank Schreiner <schreiner@suse.de>