### PR TITLE
Make the contribution graph optional

### DIFF
--- a/src/api/app/controllers/webui/user_controller.rb
+++ b/src/api/app/controllers/webui/user_controller.rb
@@ -22,7 +22,8 @@ class Webui::UserController < Webui::WebuiController
     @role_titles = @displayed_user.roles.global.pluck(:title)
     @account_edit_link = CONFIG['proxy_auth_account_page']
 
-    return unless switch_to_webui2
+    return unless switch_to_webui2 && (CONFIG['contribution_graph'] != :off)
+
     @last_day = Time.zone.today
 
     @first_day = @last_day - 52.weeks

--- a/src/api/app/views/webui2/webui/user/show.html.haml
+++ b/src/api/app/views/webui2/webui/user/show.html.haml
@@ -13,9 +13,10 @@
                                                           configuration: @configuration,
                                                           account_edit_link: @account_edit_link }
   .col-12.col-md-8.col-lg-9
-    = render partial: 'webui2/webui/user/activity', locals: { activity_hash: @activity_hash,
-                                                              first_day: @first_day,
-                                                              last_day: @last_day }
+    - unless CONFIG['contribution_graph'] == :off
+      = render partial: 'webui2/webui/user/activity', locals: { activity_hash: @activity_hash,
+                                                                first_day: @first_day,
+                                                                last_day: @last_day }
     = render partial: 'webui2/webui/user/involvement', locals: { user: @displayed_user,
                                                                  owned: @owned,
                                                                  involved_projects: @iprojects,

--- a/src/api/config/options.yml.example
+++ b/src/api/config/options.yml.example
@@ -197,6 +197,9 @@ default: &default
   # Enable (true) / Disable (false) Ruby on Rails profiling top-bar in the web ui
   peek_enabled: false
 
+  # Disable the contribution graph on the user home page
+  # contribution_graph: :off
+
 production:
   <<: *default
 

--- a/src/api/spec/bootstrap/features/webui/users_spec.rb
+++ b/src/api/spec/bootstrap/features/webui/users_spec.rb
@@ -3,22 +3,51 @@ require 'browser_helper'
 RSpec.feature 'Bootstrap_User Contributions', type: :feature, js: true do
   let!(:user) { create(:confirmed_user) }
 
-  context 'no contributions' do
-    it 'shows 0' do
+  context 'without contribution graph option' do
+    it 'shows the contribution graph' do
       visit user_show_path(user: user.login)
-
-      expect(page).to have_text('0 contributions')
+      expect(page).to have_css('#contributors-table')
     end
   end
 
-  context 'with contributions' do
-    let!(:request) { create(:set_bugowner_request, creator: user) }
-    let!(:comment) { create(:comment_request, commentable: request, user: user) }
-    let!(:review) { create(:review, bs_request: request, reviewer: user, by_user: user, state: :accepted) }
+  context 'with contribution graph disabled' do
+    before do
+      stub_const('CONFIG', CONFIG.merge('contribution_graph' => :off))
+    end
 
-    it 'shows 3' do
+    it 'does not show the contribution table' do
       visit user_show_path(user: user.login)
-      expect(page).to have_text('3 contributions')
+      expect(page).not_to have_css('#contributors-table')
+    end
+  end
+
+  context 'with contribution graph enabled' do
+    before do
+      stub_const('CONFIG', CONFIG.merge('contribution_graph' => :on))
+    end
+
+    it 'shows the contribution graph' do
+      visit user_show_path(user: user.login)
+      expect(page).to have_css('#contributors-table')
+    end
+
+    context 'no contributions' do
+      it 'shows 0' do
+        visit user_show_path(user: user.login)
+
+        expect(page).to have_text('0 contributions')
+      end
+    end
+
+    context 'with contributions' do
+      let!(:request) { create(:set_bugowner_request, creator: user) }
+      let!(:comment) { create(:comment_request, commentable: request, user: user) }
+      let!(:review) { create(:review, bs_request: request, reviewer: user, by_user: user, state: :accepted) }
+
+      it 'shows 3' do
+        visit user_show_path(user: user.login)
+        expect(page).to have_text('3 contributions')
+      end
     end
   end
 end


### PR DESCRIPTION
In config/options.yml 'contribution_graph' is set to false by default.
It should be decided by instance if it is enabled or not.


<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md
-->
