### PR TITLE
[doc] "setup-appliance.sh --force" in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ After finishing the installation of your base system, follow these steps:
 3. Run our setup wizard
 
    ```shell
-   /usr/lib/obs/server/setup-appliance.sh
+   /usr/lib/obs/server/setup-appliance.sh --force
    ```
 
 ## Advanced Setup


### PR DESCRIPTION
Fixes: #7938

Fixed our documentation to include the --force option for setup-appliance.sh
in our README.md.

Otherwise the installation as described in README.md will fail with an error
message like this:

```OBS API Autosetup is not enabled in sysconfig, skipping```

"--force" overwrite the variable "OBS_API_AUTOSETUP" taken from
/etc/sysconfig/obs-server to "yes".
