### PR TITLE
Refactor check_user method from WebuiController

### DIFF
--- a/src/api/app/services/webui_controller_service/user_checker.rb
+++ b/src/api/app/services/webui_controller_service/user_checker.rb
@@ -1,0 +1,41 @@
+module WebuiControllerService
+  class UserChecker
+    attr_reader :user_login, :http_request
+    def initialize(http_request:, config:)
+      @http_request = http_request
+      @config = config
+      @user_login = extract_user_login_from_http_request
+    end
+
+    def proxy_enabled?
+      @config['proxy_auth_mode'] == :on
+    end
+
+    def extract_user_login_from_http_request
+      http_request.env['HTTP_X_USERNAME']
+    end
+
+    def find_or_create_user!
+      if user.exists?
+        User.find_by!(login: user_login)
+      else
+        User.create_user_with_fake_pw!(login: user_login,
+                                       email: http_request.env['HTTP_X_EMAIL'],
+                                       state: User.default_user_state,
+                                       realname: realname)
+      end
+    end
+
+    def login_exists?
+      user.exists?
+    end
+
+    def user
+      User.where(login: user_login)
+    end
+
+    def realname
+      "#{http_request.env['HTTP_X_FIRSTNAME']} #{http_request.env['HTTP_X_LASTNAME']}".strip
+    end
+  end
+end

--- a/src/api/spec/services/webui_controller_service/user_checker_spec.rb
+++ b/src/api/spec/services/webui_controller_service/user_checker_spec.rb
@@ -1,0 +1,59 @@
+require 'rails_helper'
+require 'ostruct'
+
+RSpec.describe ::WebuiControllerService::UserChecker do
+  let(:user) { create(:confirmed_user, login: 'foo') }
+  let(:user_checker) { described_class.new(http_request: request, config: config) }
+
+  describe '#proxy_enabled?' do
+    let(:user_login) { user.login }
+    let(:request) { OpenStruct.new(env: { 'HTTP_X_USERNAME' => user_login }) }
+    subject { user_checker.proxy_enabled? }
+
+    context 'when its enabled' do
+      let(:config) { { 'proxy_auth_mode' => :on } }
+      it { expect(subject).to be(true) }
+    end
+
+    context 'when its disabled' do
+      let(:config) { { 'proxy_auth_mode' => :off } }
+      it { expect(subject).to be(false) }
+    end
+  end
+
+  describe '#login_exists?' do
+    let(:request) { OpenStruct.new(env: { 'HTTP_X_USERNAME' => user_login }) }
+    let(:config) { { 'proxy_auth_mode' => :on } }
+    subject { user_checker.login_exists? }
+
+    context 'user exists' do
+      let(:user_login) { user.login }
+      it { expect(subject).to be(true) }
+    end
+
+    context 'user does not exist' do
+      let(:user_login) { 'bar' }
+      it { expect(subject).to be(false) }
+    end
+  end
+
+  describe '#find_or_create_user!' do
+    let(:request) do
+      OpenStruct.new(env: { 'HTTP_X_USERNAME' => user_login,
+                            'HTTP_X_FIRSTNAME' => 'foo', 'HTTP_X_LASTNAME' => 'bar',
+                            'HTTP_X_EMAIL' => 'foo@example.org' })
+    end
+    let(:config) { { 'proxy_auth_mode' => :on } }
+    subject { user_checker.find_or_create_user! }
+
+    context 'it will find an user' do
+      let(:user_login) { user.login }
+      it { expect(subject).to eq(user) }
+    end
+
+    context 'it will create an user' do
+      let(:user_login) { 'bar' }
+      it { expect { subject }.to change(User, :count).by(1) }
+    end
+  end
+end


### PR DESCRIPTION
To reduce the amount of unstructured and untested code in the controller level, move partially the code of `check_user` to a service. The calls to `User.session` wasn't moved to the service to make easier to understand the logic flow used to set it