### PR TITLE
[ci] removed set_version from test case

### DIFF
--- a/dist/t/osc/fixtures/obs-testpackage._service
+++ b/dist/t/osc/fixtures/obs-testpackage._service
@@ -10,5 +10,4 @@
     <param name="compression">gz</param>
     <param name="file">*.tar</param>
   </service>
-  <service name="set_version" mode="buildtime"/>
 </services>


### PR DESCRIPTION
obs-service-set_version is no longer built for i586 and leads to an unresolvable error.
