### PR TITLE
Fix sorting bug on project monitor page

### DIFF
--- a/src/api/app/assets/javascripts/webui2/project_monitor.js
+++ b/src/api/app/assets/javascripts/webui2/project_monitor.js
@@ -8,6 +8,7 @@ function statusCell(meta, statusHash, tableInfo, projectName, packageName) {
   var architecture = info[1];
   var status = statusHash[repository][architecture][packageName] || {};
   var code = status.code;
+  var cellContent = {};
   if (code === undefined) return null;
 
   var klass = 'build-state-' + code;
@@ -25,7 +26,11 @@ function statusCell(meta, statusHash, tableInfo, projectName, packageName) {
     }
   }
   output += ' class="' + klass + '">' + code + '</a>';
-  return output;
+
+  cellContent.display = output;
+  cellContent.value = code;
+
+  return cellContent;
 }
 
 function initializeMonitorDataTable() {
@@ -61,7 +66,12 @@ function initializeMonitorDataTable() {
         data: null,
         className: 'text-center',
         render: function (packageName, type, row, meta) {
-          return statusCell(meta, statusHash, tableInfo, projectName, packageName);
+          var cellContent = statusCell(meta, statusHash, tableInfo, projectName, packageName);
+          if (cellContent === null) return null;
+          // Value to display in the cell
+          if (type === 'display') return cellContent.display;
+          // Value to sort or filter by
+          return cellContent.value;
         }
       }
     ]


### PR DESCRIPTION
When sorting by a certain column, the cells with the same content weren't always placed together. See _unresolvable_ cells in the image:

![sorting_wrong](https://user-images.githubusercontent.com/2581944/61793159-bcb8f280-ae1e-11e9-9d68-75d1e965e722.png)

The problem is that Datatables sorts by the content of the cell, which is not a simple value ('unresolvable', 'failed'...) but an HTML tag to be displayed. So, it's trying to sort by values like "<a href=...".

Now we specify the value to be displayed and the value to sort/filter by.

Useful links:
- https://datatables.net/manual/data/orthogonal-data
- https://datatables.net/examples/advanced_init/html5-data-attributes.html

Fixes: #7916

Co-authored-by: Henne Vogelsang <hvogel@opensuse.org>



<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md
-->
