### PR TITLE
Configuration updates for users do not need to be propagated to the backend

### DIFF
--- a/src/api/spec/bootstrap/features/webui/maintained_projects_spec.rb
+++ b/src/api/spec/bootstrap/features/webui/maintained_projects_spec.rb
@@ -7,11 +7,18 @@ RSpec.feature 'Bootstrap_MaintainedProjects', type: :feature, js: true, vcr: tru
   let(:maintenance_project) { create(:maintenance_project, name: 'maintenance_project', target_project: openSUSE_project) }
 
   describe 'index page' do
-    scenario 'without login' do
-      visit projects_project_maintained_projects_path(project_name: maintenance_project.name)
-      expect(page).to have_text('Maintained Projects')
-      expect(page).not_to have_selector('#new-maintenance-project-modal')
-      expect(page).not_to have_selector('#delete-maintained-project-modal')
+    context 'without login' do
+      before do
+        # The maintenance project factory needs a user logged in, so we fake it just for the creation
+        admin_user.run_as { maintenance_project }
+      end
+
+      scenario 'maintenance projects are not shown' do
+        visit projects_project_maintained_projects_path(project_name: maintenance_project.name)
+        expect(page).to have_text('Maintained Projects')
+        expect(page).not_to have_selector('#new-maintenance-project-modal')
+        expect(page).not_to have_selector('#delete-maintained-project-modal')
+      end
     end
 
     context 'with admin login' do

--- a/src/api/spec/factories/users.rb
+++ b/src/api/spec/factories/users.rb
@@ -23,9 +23,12 @@ FactoryBot.define do
 
     to_create do |user, evaluator|
       if evaluator.create_home_project
-        Configuration.update(allow_user_to_create_home_project: true)
+        # rubocop:disable Rails/SkipsModelValidations
+        # Avoid triggering the callbacks to propagate the change to the backend
+        Configuration.update_attribute(:allow_user_to_create_home_project, true)
         user.save!
-        Configuration.update(allow_user_to_create_home_project: false)
+        Configuration.update_attribute(:allow_user_to_create_home_project, false)
+        # rubocop:enable Rails/SkipsModelValidations
       else
         user.save!
       end


### PR DESCRIPTION
The changes to the Configuration regarding user properties do not need to be
sent to the backend.

Doing so, we skip the creation of new cassettes involving backend configuration
calls.

This will make some of the extra cassettes being recorded in https://github.com/openSUSE/open-build-service/pull/7551 to not happen anymore.

<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md
-->
