### PR TITLE
[dist] fix tests after removal of set_version

### DIFF
--- a/dist/t/osc/fixtures/obs-testpackage._service
+++ b/dist/t/osc/fixtures/obs-testpackage._service
@@ -1,6 +1,6 @@
 <services>
   <service name="obs_scm">
-    <param name="versionformat">%ad</param>
+    <param name="version">0.0.1</param>
     <param name="url">git://github.com/M0ses/obs-testpackage.git</param>
     <param name="scm">git</param>
     <param name="extract">dist/obs-testpackage.spec</param>
@@ -10,5 +10,4 @@
     <param name="compression">xz</param>
     <param name="file">*.tar</param>
   </service>
-  <service name="set_version" mode="buildtime"/>
 </services>


### PR DESCRIPTION
backporting to 2.9