### PR TITLE
[ci] change compression xz to gz in osc based test cases

### DIFF
--- a/dist/t/osc/fixtures/obs-testpackage._service
+++ b/dist/t/osc/fixtures/obs-testpackage._service
@@ -7,7 +7,7 @@
   </service>
   <service name="tar" mode="buildtime"/>
   <service name="recompress" mode="buildtime">
-    <param name="compression">xz</param>
+    <param name="compression">gz</param>
     <param name="file">*.tar</param>
   </service>
 </services>


### PR DESCRIPTION
Without this patch the test build will fail with following error:

[   84s] error: File /home/abuild/rpmbuild/SOURCES/obs-testpackage-0.0.1.tar.gz: No such file or directory
