### PR TITLE
 Don't throw an exception on a rss notification when a target project can not be found

### DIFF
--- a/src/api/app/models/event/request.rb
+++ b/src/api/app/models/event/request.rb
@@ -83,8 +83,12 @@ module Event
       payload['actions'].any? { |action| Project.unscoped.is_remote_project?(action['sourceproject'], true) }
     end
 
+    def payload_without_target_project?
+      payload['actions'].any? { |action| !Project.exists_by_name(action['targetproject']) }
+    end
+
     def payload_with_diff
-      return payload if source_from_remote?
+      return payload if source_from_remote? || payload_without_target_project?
 
       ret = payload
       payload['actions'].each do |a|


### PR DESCRIPTION
Prevent notification feeds to fail on notifications with deleted projects.

Fixes #7094.

Co-authored-by: Saray Cabrera Padrón <scabrerapadron@suse.de>
