### PR TITLE
[dist] start obsapisetup after mariadb

### DIFF
--- a/dist/systemd/obsapisetup.service
+++ b/dist/systemd/obsapisetup.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=OBS API Setup
 Before=apache2.service
-After=network-online.target
+After=network-online.target mariadb.service
 
 [Service]
 Type=oneshot


### PR DESCRIPTION
setup-appliance.sh does datatbase actions. The service "mariadb" needs
to be started before.

mariadb has the

ExecStartPre=/usr/lib/mysql/mysql-systemd-helper  upgrade

condition, which may result in delayed upstart of mariadb after package
upgrade.

HINT: needs to be backported to 2.10 also



<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md
-->
