### PR TITLE
[dist] fix for upgrade obs-api 2.9 to 2.10

### DIFF
--- a/dist/obs-server.spec
+++ b/dist/obs-server.spec
@@ -567,6 +567,16 @@ getent passwd obsapidelayed >/dev/null || \
   /usr/sbin/useradd -r -s /bin/bash -c "User for build service api delayed jobs" -d /srv/www/obs/api -g www obsapidelayed
 %service_add_pre %{obs_api_support_scripts}
 
+# On upgrade keep the values for the %post script
+if [ "$1" == 2 ]; then
+  systemctl --quiet is-enabled obsapidelayed.service && touch %{_rundir}/enable_obs-api-support.target
+  if systemctl --quiet is-active  obsapidelayed.service;then
+    touch %{_rundir}/start_obs-api-support.target
+    systemctl stop    obsapidelayed.service
+    systemctl disable obsapidelayed.service
+  fi
+fi
+
 %post -n obs-common
 %service_add_post obsstoragesetup.service
 %{fillup_and_insserv -n obs-server}
@@ -602,15 +612,13 @@ chown %{apache_user}:%{apache_group} /srv/www/obs/api/log/production.log
 touch /srv/www/obs/api/last_deploy || true
 
 # Upgrading from SysV obsapidelayed.service to systemd obs-api-support.target
-if [ "$1" -gt 1 ]; then
-  if systemctl --quiet is-enabled obsapidelayed.service 2> /dev/null; then
-    systemctl enable obs-api-support.target
-  fi
-  if systemctl --quiet is-active obsapidelayed.service; then
-    systemctl stop obsapidelayed.service
-    systemctl daemon-reload
-    systemctl start obs-api-support.target
-  fi
+if [ -e %{_rundir}/enable_obs-api-support.target ];then
+  systemctl enable obs-api-support.target
+  rm %{_rundir}/enable_obs-api-support.target
+fi
+if [ -e %{_rundir}/start_obs-api-support.target ];then
+  systemctl start  obs-api-support.target
+  rm %{_rundir}/start_obs-api-support.target
 fi
 
 %postun -n obs-api


### PR DESCRIPTION
From 2.9 to 2.10 obsapidelayed.service changed to
obs-api-support.target. The restart and enabling of obs-api-support.target
was tried in the post script. This is to late as the obsapidelayed.service
is already deinstalled at this point and the systemctl command will return
an error.

This change ensures that "systemctl is-enabled/is-active" will be executed
in the %pre section while upgrading the package and the state will be stored
files in the %_run_dir. In the %post section we check for this files and
try to enable/start obs-api-support.target.

NEEDS BACKPORT TO 2.10



<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md
-->
