### PR TITLE
[dist] changed reload of SysV init to systemd

### DIFF
--- a/dist/setup-appliance.sh
+++ b/dist/setup-appliance.sh
@@ -635,12 +635,8 @@ if [[ ! $BOOTSTRAP_TEST_MODE == 1 && $0 != "-bash" ]];then
   prepare_obssigner
 
   if [[ $GPG_KEY_CREATED == 1 ]];then
-    pushd .
-    # avoid systemctl
-    cd /etc/init.d
-    ./obssrcserver reload
-    ./obsrepserver reload
-    popd
+    systemctl reload obssrcserver
+    systemctl reload obsrepserver
   fi
 
   check_required_backend_services


### PR DESCRIPTION
As our src/rep server nowadays use native systemd services we need to
use "systemctl restart" instead of trying to reload via the old SysV
init scripts.

Fixes: #7944



<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md
-->
