### PR TITLE
Change rollout tasks to deal with Staff users

### DIFF
--- a/src/api/app/models/user.rb
+++ b/src/api/app/models/user.rb
@@ -72,6 +72,8 @@ class User < ApplicationRecord
   scope :not_locked, -> { where.not(state: 'locked') }
   scope :with_login_prefix, ->(prefix) { where('login LIKE ?', "#{prefix}%") }
   scope :active, -> { confirmed.or(User.where(state: :subaccount, owner: User.confirmed)) }
+  scope :staff, -> { joins(:roles).where('roles.title = ?', 'Staff') }
+  scope :not_staff, -> { where.not(id: User.staff.pluck(:id)) }
 
   scope :in_beta, -> { where(in_beta: true) }
   scope :in_rollout, -> { where(in_rollout: true) }

--- a/src/api/lib/tasks/rollout.rake
+++ b/src/api/lib/tasks/rollout.rake
@@ -2,27 +2,34 @@
 namespace :rollout do
   desc 'Move all the users to rollout program'
   task all_on: :environment do
-    User.all_without_nobody.where(in_rollout: false).in_batches.update_all(in_rollout: true)
+    User.all_without_nobody
+        .not_staff
+        .where(in_rollout: false).in_batches.update_all(in_rollout: true)
   end
 
   desc 'Move all the users out of the rollout program'
   task all_off: :environment do
-    User.where(in_rollout: true).in_batches.update_all(in_rollout: false)
+    User.all_without_nobody
+        .not_staff
+        .where(in_rollout: true).in_batches.update_all(in_rollout: false)
   end
 
   desc 'Move the users already in beta to rollout program'
   task from_beta: :environment do
-    User.where(in_beta: true, in_rollout: false).in_batches.update_all(in_rollout: true)
+    User.not_staff
+        .where(in_beta: true, in_rollout: false).in_batches.update_all(in_rollout: true)
   end
 
   desc 'Move the members of groups to rollout program'
   task from_groups: :environment do
-    User.where(in_rollout: false).joins(:groups_users).distinct.in_batches.update_all(in_rollout: true)
+    User.not_staff
+        .where(in_rollout: false).joins(:groups_users).distinct.in_batches.update_all(in_rollout: true)
   end
 
   desc 'Move the users with recent activity to rollout program'
   task recently_logged_users: :environment do
     User.all_without_nobody
+        .not_staff
         .where(in_rollout: false, last_logged_in_at: 3.months.ago.midnight..Time.zone.now)
         .in_batches.update_all(in_rollout: true)
   end
@@ -30,8 +37,21 @@ namespace :rollout do
   desc 'Move the users without recent activity to rollout program'
   task non_recently_logged_users: :environment do
     User.all_without_nobody
+        .not_staff
         .where.not(in_rollout: true, last_logged_in_at: 3.months.ago.midnight..Time.zone.now)
         .in_batches.update_all(in_rollout: true)
+  end
+
+  desc 'Move Staff users to rollout program'
+  task staff_on: :environment do
+    User.staff
+        .where(in_rollout: false).in_batches.update_all(in_rollout: true)
+  end
+
+  desc 'Move Staff users out of rollout program'
+  task staff_off: :environment do
+    User.staff
+        .where(in_rollout: true).in_batches.update_all(in_rollout: false)
   end
 end
 # rubocop:enable Rails/SkipsModelValidations

--- a/src/api/spec/lib/tasks/rollout_spec.rb
+++ b/src/api/spec/lib/tasks/rollout_spec.rb
@@ -77,4 +77,31 @@ RSpec.describe 'rollout' do
 
     it { expect { rake_task.invoke }.to change(all_in_rollout_users, :count).from(3).to(4) }
   end
+
+  context 'with Staff users' do
+    let!(:staff_user_1) { create(:staff_user, in_rollout: false) }
+    let!(:staff_user_2) { create(:staff_user, in_rollout: false) }
+    let!(:staff_user_3) { create(:staff_user) }
+    let(:users) { User.staff }
+
+    describe 'staff_on' do
+      let(:task) { 'rollout:staff_on' }
+
+      it 'will move all Staff users to Rollout Program' do
+        expect { rake_task.invoke }.to change(users.where(in_rollout: true), :count).from(1).to(3)
+      end
+
+      it { expect { rake_task.invoke }.to change(all_in_rollout_users, :count).from(4).to(6) }
+    end
+
+    describe 'staff_off' do
+      let(:task) { 'rollout:staff_off' }
+
+      it 'will move all Staff users out of Rollout Program' do
+        expect { rake_task.invoke }.to change(users.where(in_rollout: true), :count).from(1).to(0)
+      end
+
+      it { expect { rake_task.invoke }.to change(all_in_rollout_users, :count).from(4).to(3) }
+    end
+  end
 end


### PR DESCRIPTION
Staff users are excluded from common tasks to add/remove users to/from
Rollout Program. We have now new tasks only for Staff users.



<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md
-->
