### PR TITLE
setup-appliance.sh: Fix failure to find systemd services

### DIFF
--- a/dist/setup-appliance.sh
+++ b/dist/setup-appliance.sh
@@ -447,8 +447,11 @@ function check_recommended_backend_services {
   RECOMMENDED_SERVICES="obsdodup obsdeltastore obssigner obssignd obsservicedispatch"
 
   for srv in $RECOMMENDED_SERVICES;do
-    STATE=$(chkconfig $srv|awk '{print $2}')
-    if [[ $STATE != on ]];then
+    ENABLED=`systemctl is-enabled $srv`
+    if [[ "$ENABLED" == "enabled" ]];then
+        ACTIVE=`systemctl is-active $srv`
+        [[ "$ACTIVE" == "active" ]] || systemctl start $srv
+    else
       ask "Service $srv is not enabled. Would you like to enable it? [Yn]" "y"
       case $rv in
         y|yes|Y|YES)
@@ -472,8 +475,11 @@ function check_optional_backend_services {
   OPTIONAL_SERVICES="obswarden obsapisetup obsstoragesetup obsworker obsservice"
 
   for srv in $OPTIONAL_SERVICES;do
-    STATE=$(chkconfig $srv|awk '{print $2}')
-    if [[ $STATE != on ]];then
+    ENABLED=`systemctl is-enabled $srv`
+    if [[ "$ENABLED" == "enabled" ]];then
+        ACTIVE=`systemctl is-active $srv`
+        [[ "$ACTIVE" == "active" ]] || systemctl start $srv
+    else
       ask "Service $srv is not enabled. Would you like to enable it? [yN]" $DEFAULT_ANSWER
       case $rv in
         y|yes|Y|YES)

--- a/dist/setup-appliance.sh
+++ b/dist/setup-appliance.sh
@@ -23,10 +23,16 @@ function check_unit {
 
   echo "Checking unit $srv ..."
 
-  logline "Enabling $srv"
-  execute_silently systemctl enable $srv
-  if [[ $? -gt 0 ]];then
-    logline "WARNING: Enabling $srv daemon failed."
+  ENABLED=`systemctl is-enabled $srv 2>/dev/null`
+  if [[ "$ENABLED" != "enabled" ]]; then
+    systemctl enable $srv
+    if [[ $? -gt 0 ]];then
+      logline "WARNING: Enabling $srv daemon failed."
+    else
+      logline "Enabling $srv"
+    fi
+  else
+    logline "$srv is already enabled"
   fi
 
   STATUS=`systemctl is-active $srv 2>/dev/null`

--- a/dist/setup-appliance.sh
+++ b/dist/setup-appliance.sh
@@ -25,7 +25,7 @@ function check_unit {
 
   ENABLED=`systemctl is-enabled $srv 2>/dev/null`
   if [[ "$ENABLED" != "enabled" ]]; then
-    systemctl enable $srv
+    systemctl enable --now $srv
     if [[ $? -gt 0 ]];then
       logline "WARNING: Enabling $srv daemon failed."
     else
@@ -441,7 +441,7 @@ function check_required_backend_services {
   for srv in $REQUIRED_SERVICES ;do
     ENABLED=`systemctl is-enabled $srv`
     ACTIVE=`systemctl is-active $srv`
-    [[ "$ENABLED" == "enabled" ]] || systemctl enable $srv
+    [[ "$ENABLED" == "enabled" ]] || systemctl enable --now $srv
     [[ "$ACTIVE" == "active" ]] || systemctl start $srv
   done
 
@@ -461,7 +461,7 @@ function check_recommended_backend_services {
       ask "Service $srv is not enabled. Would you like to enable it? [Yn]" "y"
       case $rv in
         y|yes|Y|YES)
-          systemctl enable $srv
+          systemctl enable --now $srv
           systemctl start $srv
         ;;
       esac


### PR DESCRIPTION
With the new function check_service() System V and systemd services can
be queried via a uniform interface.

fixes #7995