### PR TITLE
[dist] Include backend data dirs in package

### DIFF
--- a/dist/obs-server.spec
+++ b/dist/obs-server.spec
@@ -31,6 +31,7 @@
 %endif
 
 %define secret_key_file /srv/www/obs/api/config/secret.key
+%define obs_backend_data_dir /srv/obs
 
 %if ! %{defined _restart_on_update_reload}
 %define _restart_on_update_reload() (\
@@ -703,6 +704,17 @@ fi
 # created via %%post, since rpm fails otherwise while switching from
 # directory to symlink
 %ghost /usr/lib/obs/server/build
+%attr(0775, obsrun, obsrun) %dir %{obs_backend_data_dir}
+%attr(0755, obsrun, obsrun) %dir %{obs_backend_data_dir}/build
+%attr(0755, obsrun, obsrun) %dir %{obs_backend_data_dir}/events
+%attr(0700, root, root)     %dir %{obs_backend_data_dir}/gnupg
+%attr(0755, obsrun, obsrun) %dir %{obs_backend_data_dir}/info
+%attr(0755, obsrun, obsrun) %dir %{obs_backend_data_dir}/jobs
+%attr(0775, obsrun, obsrun) %dir %{obs_backend_data_dir}/log
+%attr(0755, obsrun, obsrun) %dir %{obs_backend_data_dir}/projects
+%attr(0775, obsrun, obsrun) %dir %{obs_backend_data_dir}/run
+%attr(0755, obsservicerun, obsrun) %dir %{obs_backend_data_dir}/service
+
 
 # formerly obs-source_service
 %{_unitdir}/obsservice.service

--- a/src/backend/Makefile
+++ b/src/backend/Makefile
@@ -1,6 +1,6 @@
 include ../../Makefile.include
 
-OBS_BACKEND_DATA_SUBDIRS := build events info jobs log projects repos run sources trees workers
+OBS_BACKEND_DATA_SUBDIRS := build events info jobs log projects repos run sources trees workers service
 OBS_BACKEND_DATA_DIR := /srv/obs
 
 prepare_dirs:
@@ -27,6 +27,7 @@ install_data_dirs: prepare_dirs
 	$(foreach data_dir,$(OBS_BACKEND_DATA_SUBDIRS), \
 		$(shell $(INSTALL) -d -m 755 $(DESTDIR)$(OBS_BACKEND_DATA_DIR)/$(data_dir) ) \
 	)
+	install -d -m 700 $(DESTDIR)$(OBS_BACKEND_DATA_DIR)/gnupg
 
 
 test_unit: bs_config


### PR DESCRIPTION
Setting proper permissions for the top level directories in /srv/obs.
This was formerly done by "obsstoragesetup" only.
As "obsstoragesetup" should not be mandatory to run to get an working OBS
server, now this also done in the package. We also keep the old method in
"obsstoragesetup" as it gives the possibility to change OBS_BASE_DIR to users
needs.

Fixes #7984

NEEDS BACKPORT TO 2.10

<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md
-->
