### PR TITLE
Switching the reserve SQL strategy for DelayedJob

### DIFF
--- a/src/api/config/initializers/delayed_job_config.rb
+++ b/src/api/config/initializers/delayed_job_config.rb
@@ -1,2 +1,5 @@
 Delayed::Worker.delay_jobs = !Rails.env.test?
 Delayed::Worker.default_queue_name = 'quick'
+# There are too many problems with the optimized SQL for locking jobs,
+# it takes about 2 seconds on build.o.o, if there are over 10K jobs.
+Delayed::Backend::ActiveRecord.configuration.reserve_sql_strategy = :default_sql


### PR DESCRIPTION
There are too many problems with the optimized SQL for locking jobs,
if there are over 10K jobs it takes about 2 seconds on build.o.o.

Co-authored-by: Stephan Kulow <coolo@suse.de>