### PR TITLE
Fix partial editor option hash defaults

### DIFF
--- a/src/api/app/views/webui2/shared/_editor.html.haml
+++ b/src/api/app/views/webui2/shared/_editor.html.haml
@@ -1,6 +1,7 @@
 :ruby
   save ||= {}
-  style ||= { read_only: false, big_editor: true }
+  style ||= {}
+  style.reverse_merge!(read_only: false, big_editor: true)
   uid ||= next_codemirror_uid
   content_for(:head_style, codemirror_style(style))
 


### PR DESCRIPTION
We've setup some defaults, but only if you do not pass a `style` local to the
editor partial. Also set defaults if they are not passed in with `style`.



<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md
-->
