### PR TITLE
Use ActiveRecord's #update_column instead of #update_attribute

### DIFF
--- a/src/api/spec/factories/users.rb
+++ b/src/api/spec/factories/users.rb
@@ -25,9 +25,9 @@ FactoryBot.define do
       if evaluator.create_home_project
         # rubocop:disable Rails/SkipsModelValidations
         # Avoid triggering the callbacks to propagate the change to the backend
-        Configuration.update_attribute(:allow_user_to_create_home_project, true)
+        Configuration.update_column(:allow_user_to_create_home_project, true)
         user.save!
-        Configuration.update_attribute(:allow_user_to_create_home_project, false)
+        Configuration.update_column(:allow_user_to_create_home_project, false)
         # rubocop:enable Rails/SkipsModelValidations
       else
         user.save!


### PR DESCRIPTION
For some changes we need to run the bootstrap specs with the VCR on (#7934). Doing so,
we get a ton of unwanted cassettes of requests going to the `/configuration`
endpoint in the backend.

We tried to fix that (#7968) by using `#update_attribute` instead of the `#update method`
on the user factory so we didn't trigger the callbacks that perform the call to the backend, but `#update_attributes` skips the validations but not the callbacks. `#update_column` skips both the
validations and the callbacks, so its the one we have to use here.



<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md
-->
