### PR TITLE
Remove 'btn-sm' and 'px-4' class from filter button

### DIFF
--- a/src/api/app/views/webui2/webui/project/status.html.haml
+++ b/src/api/app/views/webui2/webui/project/status.html.haml
@@ -27,7 +27,7 @@
       .custom-control.custom-checkbox
         = check_box_tag(:include_versions, true, @include_versions, class: 'custom-control-input')
         = label_tag(:include_versions, 'Include version updates', class: 'custom-control-label')
-      = submit_tag('Filter results', class: 'btn btn-sm btn-primary px-4 mt-2')
+      = submit_tag('Filter results', class: 'btn btn-primary mt-2')
 
     - if @packages.present?
       .mt-4


### PR DESCRIPTION
We removed some classes to make the button consistent.

### Before
![Screenshot_2019-08-07 Open Build Service(2)](https://user-images.githubusercontent.com/1212806/62615704-1389f600-b90e-11e9-8b4a-fb03426dfb7e.png)


### After
![Screenshot_2019-08-07 Open Build Service(1)](https://user-images.githubusercontent.com/1212806/62615709-18e74080-b90e-11e9-88f9-19aeba3d4771.png)

Co-authored-by: Victor Pereira <vpereira@suse.com>



<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md
-->
