### PR TITLE
Adjust typography on Rpmlint and Build Result tabs

### DIFF
--- a/src/api/app/assets/stylesheets/webui2/build-results.scss
+++ b/src/api/app/assets/stylesheets/webui2/build-results.scss
@@ -1,5 +1,5 @@
 .rpmlint-result {
-  font-size: .7rem;
+  font-size: .95em;
   max-height: 35rem;
 }
 

--- a/src/api/app/views/webui2/webui/package/_buildstatus.html.haml
+++ b/src/api/app/views/webui2/webui/package/_buildstatus.html.haml
@@ -1,5 +1,5 @@
 - unless buildresults.excluded_counter.zero? && !buildresults.show_all
-  .mt-3.small.custom-control-checkbox
+  .mt-3.custom-control-checkbox
     = check_box_tag("show_all_#{index}", true, buildresults.show_all, class: 'custom-control-input d-none',
                     onchange: "updateBuildResult('#{index}')")
     - label_message = buildresults.excluded_counter.zero? ? 'Hide' : "Show #{buildresults.excluded_counter}"
@@ -9,7 +9,7 @@
 - buildresults.results.each_pair do |package, results|
   %h5.text-primary.mt-3.mb-3= package
   .mb-2#package-buildstatus
-    .small.px-3
+    .px-3
       - if results.present?
         - previous_repo = nil
         - results.each do |result|
@@ -31,7 +31,7 @@
           .collapse{ class: "collapse-#{package_name}-#{repository_name}#{expanded ? ' show' : ''}",
                      data: { repository: repository_name, main: package_name } }
             .row.py-1
-              .col-4.col-sm-3.offset-2.offset-sm-4.text-nowrap
+              .col-4.col-sm-3.offset-1.offset-sm-2.text-nowrap
                 - if !result.is_repository_in_db
                   %i.fas.fa-clock.text-warning{ title: 'This result is outdated' }
                 - else

--- a/src/api/app/views/webui2/webui/package/_buildstatus.html.haml
+++ b/src/api/app/views/webui2/webui/package/_buildstatus.html.haml
@@ -31,14 +31,14 @@
           .collapse{ class: "collapse-#{package_name}-#{repository_name}#{expanded ? ' show' : ''}",
                      data: { repository: repository_name, main: package_name } }
             .row.py-1
-              .col-4.col-sm-3.offset-1.offset-sm-2.text-nowrap
+              .col-4.col-sm-4.col-xl-3.ml-2.text-nowrap
                 - if !result.is_repository_in_db
                   %i.fas.fa-clock.text-warning{ title: 'This result is outdated' }
                 - else
                   = webui2_repository_status_icon(status: result.state, details: result.details)
                 %span.ml-1
                   = result.architecture
-              .col-6.col-sm-5.text-nowrap
+              .col-6.col-sm-5.col-xl-6.ml-2.text-nowrap
                 = webui2_arch_repo_table_cell(result.repository, result.architecture, package, 'code' => result.code, 'details' => result.details)
           - previous_repo = result.repository
       - else

--- a/src/api/app/views/webui2/webui/package/_rpmlint_result.html.haml
+++ b/src/api/app/views/webui2/webui/package/_rpmlint_result.html.haml
@@ -4,10 +4,10 @@
   - unless repository_list.empty?
     .form-inline
       = select_tag("rpmlint_repo_select_#{index}", options_for_select(repository_list.sort),
-                   class: 'custom-select custom-select-sm', onchange: "updateArchDisplay('#{index}')")
+                   class: 'custom-select', onchange: "updateArchDisplay('#{index}')")
       - repo_arch_hash.each do |repository, architectures|
         = select_tag("rpmlint_arch_select_#{index}_#{repository}", options_for_select(architectures.reverse),
-                     class: "rpmlint_arch_select_#{index} custom-select custom-select-sm", onchange: "updateRpmlintDisplay('#{index}')")
+                     class: "rpmlint_arch_select_#{index} custom-select", onchange: "updateRpmlintDisplay('#{index}')")
 %pre.rpmlint-result.text-pre-wrap{ id: "rpmlint_display_#{index}" }
 
 :javascript


### PR DESCRIPTION
We changed the Rpmlint and Build Results partials for the package's build result box which appears in the request page as well.

We decided to change the font family of the Rpmlint result, that was in a `<pre>`tag, in order to reduce the number of different font families and increase readability.

Co-authored-by: Lukas Krause <lkrause@suse.de>

**Before:**
![Screenshot-2019-8-7 Request 8 (new)(5)](https://user-images.githubusercontent.com/2581944/62622537-e42fb500-b91e-11e9-8c89-97b08c6ab72c.png)
![Screenshot-2019-8-7 Request 8 (new)(4)](https://user-images.githubusercontent.com/2581944/62622546-e7c33c00-b91e-11e9-9612-b7f95380ad47.png)


**After:**

![Screenshot-2019-8-7 Request 8 (new)(2)](https://user-images.githubusercontent.com/2581944/62622466-b21e5300-b91e-11e9-81e3-22c623f611c4.png)
![Screenshot-2019-8-7 Request 8 (new)(3)](https://user-images.githubusercontent.com/2581944/62622475-b64a7080-b91e-11e9-809d-d7562f3a37ca.png)
