### PR TITLE
Remove `fa-xs` class on project monitor

### DIFF
--- a/src/api/app/views/webui2/webui/project/monitor.html.haml
+++ b/src/api/app/views/webui2/webui/project/monitor.html.haml
@@ -29,7 +29,7 @@
                   - archlist.each do |arch|
                     - tableinfo << [repo, arch]
                     %th.text-center
-                      = webui2_repository_status_icon(status: @repostatushash[repo][arch], html_class: 'fa-xs mr-1')
+                      = webui2_repository_status_icon(status: @repostatushash[repo][arch], html_class: 'mr-1')
                       = arch
             %tbody{ data: { packagenames: @packagenames, project: @project, statushash: @statushash.to_json, tableinfo: tableinfo } }
 


### PR DESCRIPTION
This class was making the repository icon too small.

### Before
![Screenshot_2019-08-07 Open Build Service(5)](https://user-images.githubusercontent.com/1212806/62624002-6a99c600-b922-11e9-9f05-be284751e633.png)

### After
![Screenshot_2019-08-07 Open Build Service(6)](https://user-images.githubusercontent.com/1212806/62623978-5eae0400-b922-11e9-8fb9-2bca3ad5ab0c.png)


<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md
-->
