### PR TITLE
Remove strong tag from repository tables

### DIFF
--- a/src/api/app/views/webui2/shared/_repositories_flag_table.html.haml
+++ b/src/api/app/views/webui2/shared/_repositories_flag_table.html.haml
@@ -11,13 +11,12 @@
         %tr
           %td.reponame.text-word-break-all
             - repository_name = repository.try(&:name)
-            %strong{ title: repository_name || 'All' }
-              - if repository.nil?
-                All
-              - elsif package
-                = link_to(repository_name, package_binaries_path(project: project, package: package, repository: repository_name))
-              - else
-                = link_to(repository_name, action: :state, project: project, repository: repository_name)
+            - if repository.nil?
+              All
+            - elsif package
+              = link_to(repository_name, package_binaries_path(project: project, package: package, repository: repository_name))
+            - else
+              = link_to(repository_name, action: :state, project: project, repository: repository_name)
           - ([nil] + architectures).each do |architecture|
             %td.text-center{ class: architecture && repository ? nil : 'all_flag' }
               = flag_column(flags, repository_name, architecture.try(&:name))


### PR DESCRIPTION
The name of the project in the repository table is not important enough to be that strong. So we decided to remove it

Co-authored-by: Dany Marcoux <dmarcoux@suse.com>

Before:
![before](https://user-images.githubusercontent.com/1102934/62627879-86a16580-b92a-11e9-8535-7da8374ffb56.png)

After:
![after](https://user-images.githubusercontent.com/1102934/62627892-8b661980-b92a-11e9-98f3-33138cc7bbb6.png)