### PR TITLE
Adjust fontsize of dialog action buttons

### DIFF
--- a/src/api/app/views/webui2/shared/_dialog_action_buttons.html.haml
+++ b/src/api/app/views/webui2/shared/_dialog_action_buttons.html.haml
@@ -1,5 +1,5 @@
 - submit_tag_text ||= 'Accept'
 
-%a.btn.btn-sm.btn-outline-danger.px-4{ data: { dismiss: 'modal' } }
+%a.btn.btn-outline-danger.px-4{ data: { dismiss: 'modal' } }
   Cancel
-= submit_tag(submit_tag_text, class: 'btn btn-sm btn-primary px-4')
+= submit_tag(submit_tag_text, class: 'btn btn-primary px-4')


### PR DESCRIPTION
The bootstrap sm class led to a too small font size in the buttons

Before:
![Screenshot-2019-8-7 Request 4 (review)](https://user-images.githubusercontent.com/22001671/62628272-48587600-b92b-11e9-9e1f-6b3c12f876bf.png)

After:
![Screenshot-2019-8-7 Request 4 (new)](https://user-images.githubusercontent.com/22001671/62628302-53aba180-b92b-11e9-96d9-0023693927c7.png)
