### PR TITLE
Package Show - Typography

### DIFF
--- a/src/api/app/views/webui2/webui/package/_buildstatus.html.haml
+++ b/src/api/app/views/webui2/webui/package/_buildstatus.html.haml
@@ -38,7 +38,7 @@
                   = webui2_repository_status_icon(status: result.state, details: result.details)
                 %span.ml-1
                   = result.architecture
-              .col-6.col-sm-5.buildstatus.text-nowrap
+              .col-6.col-sm-5.text-nowrap
                 = webui2_arch_repo_table_cell(result.repository, result.architecture, package, 'code' => result.code, 'details' => result.details)
           - previous_repo = result.repository
       - else

--- a/src/api/app/views/webui2/webui/package/show.html.haml
+++ b/src/api/app/views/webui2/webui/package/show.html.haml
@@ -13,7 +13,7 @@
         %h3#package-title
           = @package.title.presence || @package.name
         - if @package.url.present?
-          = link_to(@package.url, @package.url, class: 'small mb-3 d-block')
+          = link_to(@package.url, @package.url, class: 'mb-3 d-block')
         #description-text
           - if @package.description.blank?
             %i No description set

--- a/src/api/spec/bootstrap/features/webui/packages_spec.rb
+++ b/src/api/spec/bootstrap/features/webui/packages_spec.rb
@@ -136,7 +136,7 @@ RSpec.feature 'Bootstrap_Packages', type: :feature, js: true, vcr: true do
       visit package_show_path(project: user.home_project, package: package)
       # test reload and wait for the build to finish
       find('.build-refresh').click
-      find('.buildstatus a', text: 'succeeded').click
+      find('#package-buildstatus a', text: 'succeeded').click
       expect(page).to have_text('[1] this is my dummy logfile -> ümlaut')
       first(:link, 'Download logfile').click
       # don't bother with the umlaut


### PR DESCRIPTION
The description and comments didn't need to change due to the changes we did together in the mob programming session this Tuesday.

The build results and rpmlint is already taken care of in #8036. We removed an unneeded class in the build results (this is something we noticed when reviewing the changes from @saraycp's and @krauselukas' PR.

Other sections of the package show page were reviewed and we didn't change things there.

The package URL changes:
Before:
![package-url-before](https://user-images.githubusercontent.com/1102934/62629322-38da2c80-b92d-11e9-965a-821fe72440e1.png)

After:
![package-url-after](https://user-images.githubusercontent.com/1102934/62629334-3e377700-b92d-11e9-84b8-6db81a471736.png)