### PR TITLE
Display revisions count in a badge

### DIFF
--- a/src/api/app/views/webui2/webui/package/revisions.html.haml
+++ b/src/api/app/views/webui2/webui/package/revisions.html.haml
@@ -4,7 +4,9 @@
   = render(partial: 'tabs', locals: { project: @project, package: @package })
 
   .card-body
-    %h3 #{@pagetitle} (#{@revisions.count})
+    %h3
+      = @pagetitle
+      %span.badge.badge-primary= @revisions.count
     - if @revisions.present?
       .list-group
         - @revisions.each do |revision|


### PR DESCRIPTION
To be consistent with other views

Closes #8001

Before:
![before](https://user-images.githubusercontent.com/1102934/62630908-15fd4780-b930-11e9-89cb-020bee39ebde.png)

After:
![after](https://user-images.githubusercontent.com/1102934/62630910-18f83800-b930-11e9-83ae-1d04fdf990b8.png)