### PR TITLE
Fixed manual for initial interconnect setup, added note about docker

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -208,7 +208,7 @@ make sure you run all this from a filesystem that supports this.
    git submodule update
    ```
 
-5. Build your development environment with (make sure your user has access to Docker):
+5. Build your development environment with:
 
     ```
     rake docker:build

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -208,7 +208,7 @@ make sure you run all this from a filesystem that supports this.
    git submodule update
    ```
 
-5. Build your development environment with:
+5. Build your development environment with (make sure your user has access to Docker):
 
     ```
     rake docker:build
@@ -228,7 +228,7 @@ You can access the frontend at [localhost:3000](http://localhost:3000). Whatever
      The easiest way to start building is to create an interconnect to our reference server. All resources from the openSUSE instance, including the base distributions, can be used that way.
      To set this up, follow these steps:
      * Login as Admin and go to 'Configuration' page.
-     * Go to the 'Interconnect' tab and press 'Save changes'. That creates an interconnect to build.opensuse.org.
+     * Go to the 'Interconnect' tab and press 'Connect' on 'Standard OBS instance'. That creates an interconnect to build.opensuse.org.
      * Now in any other project you can choose from a wide range of distributions to build your packages on the 'Repositories' tab.
 
 9. Changed something in the frontend? Test your changes!


### PR DESCRIPTION
The interconnect button name changed, and on a default SUSE system, you need to make sure your user is in the docker group before running  `rake docker build`.