### PR TITLE
Adjust fontsize and gravatar in request history box

### DIFF
--- a/src/api/app/views/webui2/webui/request/_request_history.html.haml
+++ b/src/api/app/views/webui2/webui/request/_request_history.html.haml
@@ -8,7 +8,6 @@
       = link_to('#request-creation', title: l(bs_request.created_at.utc), name: 'request-creation') do
         #{time_ago_in_words(bs_request.created_at)} ago
 
-    .text-muted
-      = render partial: 'webui/webui/collapsible_text', locals: { text: bs_request.description }
+    = render partial: 'webui/webui/collapsible_text', locals: { text: bs_request.description }
 
 = render partial: 'request_history_element', collection: history, as: :element

--- a/src/api/app/views/webui2/webui/request/_request_history.html.haml
+++ b/src/api/app/views/webui2/webui/request/_request_history.html.haml
@@ -1,6 +1,6 @@
 .media
   - user = User.find_by_login(bs_request.creator)
-  = image_tag_for(user, size: 32, custom_class: 'mr-3')
+  = image_tag_for(user, size: 38, custom_class: 'mr-3')
   .media-body
     %p
       = link_to(user, user_show_path(user))

--- a/src/api/app/views/webui2/webui/request/_request_history_element.html.haml
+++ b/src/api/app/views/webui2/webui/request/_request_history_element.html.haml
@@ -11,5 +11,4 @@
       = link_to("#status-history-#{element.id}", title: l(element.created_at.utc), name: "status-history-#{element.id}") do
         #{time_ago_in_words(element.created_at)} ago
 
-    .text-muted
-      = render partial: 'webui/webui/collapsible_text', locals: { text: element.comment }
+    = render partial: 'webui/webui/collapsible_text', locals: { text: element.comment }

--- a/src/api/app/views/webui2/webui/request/_request_history_element.html.haml
+++ b/src/api/app/views/webui2/webui/request/_request_history_element.html.haml
@@ -1,6 +1,6 @@
 %hr
 .media.mt-2
-  = image_tag_for(element.user, size: 32, custom_class: 'mr-3')
+  = image_tag_for(element.user, size: 38, custom_class: 'mr-3')
   .media-body
     %p
       = link_to(element.user, user_show_path(element.user))

--- a/src/api/app/views/webui2/webui/request/show.html.haml
+++ b/src/api/app/views/webui2/webui/request/show.html.haml
@@ -84,7 +84,7 @@
       .card-header.d-flex.justify-content-between
         %h5
           Request History
-      .card-body.small#request-history
+      .card-body#request-history
         = render partial: 'request_history', locals: { bs_request: @bs_request, history: @history }
 
 - if User.session


### PR DESCRIPTION
The fontsize was too small. Now it's consistent with
the other content of the page

Co-authored-by: Saray Cabrera Padrón <scabrerapadron@suse.de>

Before:
![Screenshot-2019-8-7 Request 4 (review)(2)](https://user-images.githubusercontent.com/22001671/62634772-bce4e200-b936-11e9-871d-d59cdd49e331.png)

After:
![Screenshot-2019-8-7 Request 4 (review)(1)](https://user-images.githubusercontent.com/22001671/62634785-c40bf000-b936-11e9-894a-e4af5728e677.png)

