### PR TITLE
Show the error raised when editting status comment

### DIFF
--- a/src/api/app/controllers/webui/project_controller.rb
+++ b/src/api/app/controllers/webui/project_controller.rb
@@ -426,6 +426,7 @@ class Webui::ProjectController < Webui::WebuiController
   def edit_comment
     @package = @project.find_package(params[:package])
 
+    switch_to_webui2
     at = AttribType.find_by_namespace_and_name!('OBS', 'ProjectStatusPackageFailComment')
     unless User.session!.can_create_attribute_in?(@package, at)
       @comment = params[:last_comment]
@@ -440,7 +441,6 @@ class Webui::ProjectController < Webui::WebuiController
     attr.save!
     v.save!
     @comment = params[:text]
-    switch_to_webui2
   end
 
   def status

--- a/src/api/app/views/webui2/webui/project/edit_comment.js.erb
+++ b/src/api/app/views/webui2/webui/project/edit_comment.js.erb
@@ -1,2 +1,2 @@
 $('td[data-package-name="<%= @package.name %>"]').
-  html('<%= escape_javascript(render(partial: 'edit_comment', locals: { package_name: @package.name, editable: true, comment: @comment, project: @project })) %>');
+  html('<%= escape_javascript(render(partial: 'edit_comment', locals: { package_name: @package.name, editable: true, comment: @comment, project: @project, error: @error })) %>');


### PR DESCRIPTION
In the status tab/page of a project there is a list of failing packages. A maintainer user can add a comment to each of the failing packages. However, if there were any trouble while adding the comment, the error wasn't visible.

Now the error is visible inside the comment cell.

![error_status](https://user-images.githubusercontent.com/2581944/62666726-e0367e00-b984-11e9-8ad2-ace0c58189d5.gif)



<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md
-->
