### PR TITLE
Improvements for Package Attributes

### DIFF
--- a/src/api/app/views/webui2/webui/attribute/_form.html.haml
+++ b/src/api/app/views/webui2/webui/attribute/_form.html.haml
@@ -26,7 +26,7 @@
         = render('issue_fields', { f: issue }.merge(issue_fields_locals))
     %p
       = link_to_add_association(form, :issues, render_options: { locals: issue_fields_locals }, title: 'Add an issue') do
-        %i.fas.fa-plus-circle.text-success
+        %i.fas.fa-plus-circle.text-primary
         Add an issue
 
   = link_to('Back', index_attribs_path, class: 'btn btn-outline-secondary', role: 'button')

--- a/src/api/app/views/webui2/webui/attribute/index.html.haml
+++ b/src/api/app/views/webui2/webui/attribute/index.html.haml
@@ -7,11 +7,11 @@
   .card-body
     %h3= @pagetitle
     - if @attributes.present?
-      %table.responsive.table.table-striped.table-bordered#attributes
+      %table.responsive.table.table-striped.table-bordered.w-100#attributes
         %thead
           %tr
-            %th.w-50 Attributes
-            %th.w-25 Values
+            %th Attributes
+            %th Values
             - if can_update_container
               %th Actions
         %tbody


### PR DESCRIPTION
Use .text-primary for consistency 

Before:
![add-an-issue-before](https://user-images.githubusercontent.com/1102934/62692853-b192c480-b9d1-11e9-8ee9-c8cf80ac228e.png)

After:
![add-an-issue-after](https://user-images.githubusercontent.com/1102934/62692857-b35c8800-b9d1-11e9-9ae3-671fd2a1edcd.png)

Prevent attributes table from overflowing

Before:
![package-attributes-before](https://user-images.githubusercontent.com/1102934/62693064-10f0d480-b9d2-11e9-9661-aace0378a07e.png)

After:
![package-attributes-after](https://user-images.githubusercontent.com/1102934/62693073-13ebc500-b9d2-11e9-96e5-34f639a8ef0c.png)