### PR TITLE
Use find_by instead of get_by_name

### DIFF
--- a/src/api/app/models/package.rb
+++ b/src/api/app/models/package.rb
@@ -723,12 +723,11 @@ class Package < ApplicationRecord
         # Take project wide devel project definitions into account
         prj = pkg.project.develproject
         prj_name = prj.name
-        pkg = prj.packages.get_by_name(pkg.name)
+        pkg = prj.packages.find_by(name: pkg.name)
         return if pkg.nil?
       end
       pkg = self if pkg.id == id
     end
-    # logger.debug "WORKED - #{pkg.inspect}"
     pkg
   end
 


### PR DESCRIPTION
If a project uses a develproject setting, resolve_devel_package method
crashes, because it's using get_by_name that is not defined on the
collection proxy.

Fixes:  #8047

Co-authored-by: Daniel Donisa <daniel.donisa@suse.com>
Co-authored-by: Saray Cabrera Padrón <scabrerapadron@suse.de>
Co-authored-by: Henne Vogelsang <hvogel@opensuse.org>



<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md
-->
