### PR TITLE
Add space between parent table and subproject table

### DIFF
--- a/src/api/app/views/webui2/webui/project/subprojects.html.haml
+++ b/src/api/app/views/webui2/webui/project/subprojects.html.haml
@@ -8,7 +8,7 @@
       .col-md-12
         - if @project.ancestors.exists?
           = render partial: 'projects_table', locals: { table_title: 'Parent Project', project: @project }
-    .row{ class: ('mt-3' if @parentprojects.present?) }
+    .row{ class: ('mt-3' if @project.ancestors.exists?) }
       .col-md-12
         - if @project.subprojects.exists?
           = render partial: 'projects_table', locals: { table_title: 'Subproject', project: @project }


### PR DESCRIPTION
`@parentproject` was not used in the new UI, then the class `mt-3` was never applied.

### Before
![Screenshot_2019-08-08 Open Build Service(1)](https://user-images.githubusercontent.com/1212806/62699654-57e5c680-b9e0-11e9-960d-f0a59474725f.png)


### After
![Screenshot_2019-08-08 Open Build Service](https://user-images.githubusercontent.com/1212806/62699661-5a482080-b9e0-11e9-8227-047a9ae97a7d.png)



<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md
-->
