### PR TITLE
Fix package table responsiveness and make pagination consistent

### DIFF
--- a/src/api/app/assets/javascripts/webui2/datatables.js
+++ b/src/api/app/assets/javascripts/webui2/datatables.js
@@ -21,8 +21,7 @@ function initializeRemoteDatatable(cssSelector, params) { // jshint ignore:line
   var defaultRemoteParams = {
     processing: true,
     serverSide: true,
-    ajax: $(cssSelector).data('source'),
-    pagingType: 'full_numbers'
+    ajax: $(cssSelector).data('source')
   };
   var newParams = $.extend(defaultRemoteParams, DEFAULT_DT_PARAMS, params);
 

--- a/src/api/app/assets/javascripts/webui2/requests_table.js.erb
+++ b/src/api/app/assets/javascripts/webui2/requests_table.js.erb
@@ -17,7 +17,6 @@ $(document).ready(function() {
       ],
       paging: true,
       pageLength: pageLength,
-      pagingType: "full_numbers",
       processing: true,
       language: {
         processing: "<span>Processing...<i class='fas fa-spinner fa-spin'></span>"

--- a/src/api/app/views/webui2/webui/project/_project_packages.html.haml
+++ b/src/api/app/views/webui2/webui/project/_project_packages.html.haml
@@ -1,7 +1,7 @@
 .card-body
   - if packages.present?
     .obs-dataTable
-      %table.table.table-sm.table-fixed.table-striped.table-bordered#packages-table{ data: { source: package_index_path(project: project) } }
+      %table.table.table-sm.table-striped.table-bordered.w-100#packages-table{ data: { source: package_index_path(project: project) } }
         %thead
           %tr
             %th.w-75 Name


### PR DESCRIPTION
We fix the responsiveness of package table and we also make the pagination consistent

### Before
![Screenshot_2019-08-08 home Admin(1)](https://user-images.githubusercontent.com/1212806/62703019-7ea7fb00-b9e8-11e9-946b-72255c0591ed.png)

### After
![Screenshot_2019-08-08 home Admin](https://user-images.githubusercontent.com/1212806/62703028-823b8200-b9e8-11e9-9bfe-9122d08feed8.png)


## Pagination

### full_number
![Screenshot_2019-08-08 glibc](https://user-images.githubusercontent.com/1212806/62703108-bc0c8880-b9e8-11e9-9074-2b7fca1c28a6.png)

### single_number
![Screenshot_2019-08-08 glibc(1)](https://user-images.githubusercontent.com/1212806/62703128-c6c71d80-b9e8-11e9-8692-d961906d2f34.png)

We were using two different paginations in different places. Now we use the default of DataTable (simple_numbers).

<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md
-->
