### PR TITLE
Typography - Project Repositories

### DIFF
--- a/src/api/app/views/webui2/webui/repositories/_repository_card_content.html.haml
+++ b/src/api/app/views/webui2/webui/repositories/_repository_card_content.html.haml
@@ -2,7 +2,7 @@
 .card-body
   - if repository.path_elements.present?
     %strong Repository paths:
-    %ul.list-unstyled.ml-3
+    %ol.list-unstyled.ml-3
       - repository.path_elements.each_with_index do |path, index|
         - if index < number_paths
           = render partial: 'repository_path_item', locals: { project: project, repository: repository, path: path,

--- a/src/api/app/views/webui2/webui/repositories/_repository_card_content.html.haml
+++ b/src/api/app/views/webui2/webui/repositories/_repository_card_content.html.haml
@@ -1,7 +1,7 @@
 - number_paths = 3
 .card-body
   - if repository.path_elements.present?
-    Repository paths:
+    %strong Repository paths:
     %ul.list-unstyled.ml-3
       - repository.path_elements.each_with_index do |path, index|
         - if index < number_paths

--- a/src/api/app/views/webui2/webui/repositories/_repository_entry.html.haml
+++ b/src/api/app/views/webui2/webui/repositories/_repository_entry.html.haml
@@ -2,11 +2,11 @@
   .card.mb-3.repository-card
     .card-header
       = link_to(repository, project_repository_state_path(project: project, repository: repository.name), class: 'font-weight-bold')
-      .small
-        - if repository.architectures.empty?
-          No architecture selected
-        - else
-          #{repository.architectures.pluck(:name).join(', ')}
+      - if repository.architectures.empty?
+        %i No architecture selected
+      - else
+        - repository.architectures.pluck(:name).each do |architecture|
+          %span.badge.badge-primary= architecture
     - if repository.is_dod_repository?
       = render partial: 'dod_repository_card_content', locals: { project: project, repository: repository,
                  available_architectures: available_architectures }

--- a/src/api/app/views/webui2/webui/repositories/_repository_path_item.html.haml
+++ b/src/api/app/views/webui2/webui/repositories/_repository_path_item.html.haml
@@ -1,21 +1,20 @@
 %li
-  %small.font-weight-bold
-    - if path.link.project == 'deleted'
-      %i.fas.fa-exclamation-circle.text-warning
-      Target repository has been removed
-    - else
-      = path_name = "#{path.link.project}/#{path.link.name}"
-      - if user_can_modify
-        - if repository.path_elements.size > 1
-          - unless path == repository.path_elements.first
-            = link_to(move_repository_path_path(project: project, repository: repository, path: path, direction: 'up'), method: :post,
-                      title: 'Move Up the Repository Path') do
-              %i.fas.fa-arrow-alt-circle-up.fa-lg.text-info
-          - unless path == repository.path_elements.last
-            = link_to(move_repository_path_path(project: project, repository: repository, path: path, direction: 'down'), method: :post,
-                      title: 'Move Down the Repository Path') do
-              %i.fas.fa-arrow-alt-circle-down.fa-lg.text-info
-        = link_to('#', title: "Delete '#{path_name}' repository path", data: { toggle: 'modal', target: '#delete-path-modal',
-          action: remove_repository_path_path(project: project, repository: repository, path: path),
-          path_name: path_name, repository: repository.name }) do
-          %i.fas.fa-times-circle.fa-lg.text-danger
+  - if path.link.project == 'deleted'
+    %i.fas.fa-exclamation-circle.text-warning
+    Target repository has been removed
+  - else
+    = path_name = "#{path.link.project}/#{path.link.name}"
+    - if user_can_modify
+      - if repository.path_elements.size > 1
+        - unless path == repository.path_elements.first
+          = link_to(move_repository_path_path(project: project, repository: repository, path: path, direction: 'up'), method: :post,
+                    title: 'Move Up the Repository Path') do
+            %i.fas.fa-arrow-alt-circle-up.text-info
+        - unless path == repository.path_elements.last
+          = link_to(move_repository_path_path(project: project, repository: repository, path: path, direction: 'down'), method: :post,
+                    title: 'Move Down the Repository Path') do
+            %i.fas.fa-arrow-alt-circle-down.text-info
+      = link_to('#', title: "Delete '#{path_name}' repository path", data: { toggle: 'modal', target: '#delete-path-modal',
+        action: remove_repository_path_path(project: project, repository: repository, path: path),
+        path_name: path_name, repository: repository.name }) do
+        %i.fas.fa-times-circle.text-danger


### PR DESCRIPTION
This page needs a redesign, but for now this will already improve the view a bit. The `Repositories Flags` section is already addressed in #8039.

Reorganize hierarchy of repository paths and put emphasis on a repository's architectures.

Before:
![project-repositories-before](https://user-images.githubusercontent.com/1102934/62703985-ac8e3f00-b9ea-11e9-8fad-3238a2fada58.png)

After:
![project-repositories](https://user-images.githubusercontent.com/1102934/62703983-ac8e3f00-b9ea-11e9-8c4f-71e737428e01.png)


