### PR TITLE
Show URL the same way as on Package#show

### DIFF
--- a/src/api/app/views/webui2/webui/project/show.html.haml
+++ b/src/api/app/views/webui2/webui/project/show.html.haml
@@ -11,8 +11,8 @@
       .col-md-8
         %h3#project-title
           = @project.title.presence || @project
-          - if @project.url.present?
-            %small= link_to(@project.url, @project.url)
+        - if @project.url.present?
+          = link_to(@project.url, @project.url, class: 'mb-3 d-block')
         #description-text
           - if @project.description.blank?
             %i No description set


### PR DESCRIPTION
The URL of the project was too small and inconsistent to other sections like package#show view.

### Before:
![Screenshot_2019-08-08 home Admin(3)](https://user-images.githubusercontent.com/1212806/62707886-7ce33500-b9f2-11e9-930f-15d7f6bb8069.png)

### After:
![Screenshot_2019-08-08 home Admin(2)](https://user-images.githubusercontent.com/1212806/62707893-810f5280-b9f2-11e9-9184-a59371ce5ab7.png)




<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md
-->
