### PR TITLE
Adjust typography for source diff area in request page

### DIFF
--- a/src/api/app/assets/stylesheets/webui2/diff.scss
+++ b/src/api/app/assets/stylesheets/webui2/diff.scss
@@ -5,7 +5,7 @@
 
 .diff-menu-buttons {
   position: absolute;
-  top: 0.55rem;
+  top: 0.65rem;
   right: 0.55rem;
   z-index: 4;
 }

--- a/src/api/app/views/webui2/webui/package/_revision_diff_detail.html.haml
+++ b/src/api/app/views/webui2/webui/package/_revision_diff_detail.html.haml
@@ -4,7 +4,7 @@
   locals: { file_view_path: file_view_path, filename: filename, index: index, last: last, has_content: diff_content.present? }
   - if diff_content.present?
     %details.card.details-with-codemirror{ open: expand_diff?(filename, file['state']), id: "revision_details_#{index}", data: { package: package } }
-      %summary.card-header
+      %summary.card-header.py-3
         .diff-card-header
           = calculate_filename(filename, file)
           %span.badge{ class: "badge-#{file['state']}" }= file['state'].capitalize

--- a/src/api/app/views/webui2/webui/package/_revision_diff_detail_buttons.html.haml
+++ b/src/api/app/views/webui2/webui/package/_revision_diff_detail_buttons.html.haml
@@ -1,17 +1,17 @@
 .btn-group.diff-menu-buttons{ role: :group }
-  %a.btn.btn-sm.btn-outline-secondary.d-none.d-sm-none.d-md-block{ class: ('disabled' if index.zero?),
+  %a.btn.btn-outline-secondary.d-none.d-sm-none.d-md-block{ class: ('disabled' if index.zero?),
   href: "#revision_details_#{index - 1}",
   title: 'Go up to the previous diff' }
     %i.fas.fa-chevron-up
-  %a.btn.btn-sm.btn-outline-secondary.d-none.d-sm-none.d-md-block{ class: ('disabled' if last),
+  %a.btn.btn-outline-secondary.d-none.d-sm-none.d-md-block{ class: ('disabled' if last),
   href: "#revision_details_#{index + 1}",
   title: 'Go down to the next diff' }
     %i.fas.fa-chevron-down
   - if file_view_path && has_content && !@linkinfo && viewable_file?(filename)
-    = link_to(file_view_path, class: 'btn btn-sm btn-outline-secondary', title: 'View the whole file') do
+    = link_to(file_view_path, class: 'btn btn-outline-secondary', title: 'View the whole file') do
       %span.d-none.d-sm-none.d-md-block View file
       %i.far.fa-file.d-block.d-sm-block.d-md-none
   - else
-    %a.btn.btn-sm.btn-outline-secondary.disabled{ href: '' }
+    %a.btn.btn-outline-secondary.disabled{ href: '' }
       %span.d-none.d-sm-none.d-md-block View file
       %i.far.fa-file.d-block.d-sm-block.d-md-none

--- a/src/api/app/views/webui2/webui/request/_sourcediff_tab.html.haml
+++ b/src/api/app/views/webui2/webui/request/_sourcediff_tab.html.haml
@@ -11,9 +11,9 @@
       .col-md-8
         .clearfix.mb-2
           .btn-group.float-right
-            %button.btn.btn-sm.btn-outline-secondary.expand-diffs{ data: { package: action[:spkg] } }
+            %button.btn.btn-outline-secondary.expand-diffs{ data: { package: action[:spkg] } }
               Expand all
-            %button.btn.btn-sm.btn-outline-secondary.collapse-diffs{ data: { package: action[:spkg] } }
+            %button.btn.btn-outline-secondary.collapse-diffs{ data: { package: action[:spkg] } }
               Collapse all
 
         - if sourcediff[:error]


### PR DESCRIPTION
We fit the paddings for the summary header and the position of the buttons on it. This way we show them in the middle and with enough space around.

Co-authored-by: Lukas Krause <lkrause@suse.de>

**Before:**

![source_diff_before](https://user-images.githubusercontent.com/2581944/62713526-2e876380-b9fd-11e9-9e5e-7d78971949c1.png)

**After:**

![source_diff_after](https://user-images.githubusercontent.com/2581944/62713549-37783500-b9fd-11e9-9f85-7e42fcc8e40c.png)



<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md
-->
