### PR TITLE
Fix build results box in request view on medium sized screen

### DIFF
--- a/src/api/app/views/webui2/webui/request/_sourcediff_tab.html.haml
+++ b/src/api/app/views/webui2/webui/request/_sourcediff_tab.html.haml
@@ -8,7 +8,7 @@
   %hr
   .row
     - (action[:sourcediff] || []).each do |sourcediff|
-      .col-md-8
+      .col-lg-8
         .clearfix.mb-2
           .btn-group.float-right
             %button.btn.btn-sm.btn-outline-secondary.expand-diffs{ data: { package: action[:spkg] } }
@@ -42,7 +42,7 @@
             .mb-2
               %p.lead
                 No source changes.
-      .col-md-4
+      .col-lg-4
         = render partial: 'webui2/shared/buildresult_box', locals: { project: action[:sprj], package: action[:spkg], index: action_counter }
         - if sourcediff['issues'].present?
           = render partial: 'issues_table', locals: { issues: sourcediff['issues'] }


### PR DESCRIPTION
On medium sized screens the content of the build result
box started to overflow and overlap.

**Before**
![Screenshot-2019-8-8 Request 1 (review)(2)](https://user-images.githubusercontent.com/22001671/62717129-9fca1500-ba03-11e9-99e4-d82b3d876287.png)

**After**
![Screenshot-2019-8-8 Request 1 (review)(1)](https://user-images.githubusercontent.com/22001671/62717163-ad7f9a80-ba03-11e9-8c0c-5f48efdf9cd9.png)

