### PR TITLE
Replace error in the comment's cell by flash error

### DIFF
--- a/src/api/app/controllers/webui/project_controller.rb
+++ b/src/api/app/controllers/webui/project_controller.rb
@@ -430,7 +430,7 @@ class Webui::ProjectController < Webui::WebuiController
     at = AttribType.find_by_namespace_and_name!('OBS', 'ProjectStatusPackageFailComment')
     unless User.session!.can_create_attribute_in?(@package, at)
       @comment = params[:last_comment]
-      @error = "Can't create attributes in #{@package}"
+      flash.now[:error] = "Can't create attributes in #{@package}"
       return
     end
 

--- a/src/api/app/views/webui2/webui/project/_edit_comment.html.haml
+++ b/src/api/app/views/webui2/webui/project/_edit_comment.html.haml
@@ -1,8 +1,3 @@
 %div
-
-  - if error
-    %i.fa.fa-exclamation-triangle.text-warning
-    = error
-
   = render partial: 'webui2/webui/project/status_comment', locals: { package_name: package_name, editable: true, comment: comment, project: project }
 

--- a/src/api/app/views/webui2/webui/project/edit_comment.js.erb
+++ b/src/api/app/views/webui2/webui/project/edit_comment.js.erb
@@ -1,2 +1,6 @@
+<% if flash[:error] %>
+  $('#flash').html("<%= escape_javascript(render(layout: false, partial: 'layouts/webui2/flash', object: flash)) %>");
+<% end %>
+
 $('td[data-package-name="<%= @package.name %>"]').
-  html('<%= escape_javascript(render(partial: 'edit_comment', locals: { package_name: @package.name, editable: true, comment: @comment, project: @project, error: @error })) %>');
+  html('<%= escape_javascript(render(partial: 'edit_comment', locals: { package_name: @package.name, editable: true, comment: @comment, project: @project })) %>');


### PR DESCRIPTION
In the project Status tab, if there was any error while adding a comment, the error was shown in the cell. We have changed this behavior and now is shown as a flash message.

**Before:**

![Screenshot-2019-8-8 62666726-e0367e00-b984-11e9-8ad2-ace0c58189d5 gif (GIF Image, 1053 × 621 pixels)](https://user-images.githubusercontent.com/2581944/62720850-31895080-ba0b-11e9-9420-f89b16c75645.png)

**After:**

![AwesomeScreenshot-localhost-project-status-home_Admin_branches_home_Admin-2019-08-08_6_32](https://user-images.githubusercontent.com/2581944/62720778-0999ed00-ba0b-11e9-9011-0fe858d360c7.png)

<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md
-->
