### PR TITLE
Improve responsiveness on pulse page

### DIFF
--- a/src/api/app/views/webui2/webui/projects/pulse/_pulse_list.html.haml
+++ b/src/api/app/views/webui2/webui/projects/pulse/_pulse_list.html.haml
@@ -1,5 +1,5 @@
-.row
-  .col
+.row.mb-3
+  .col-12.col-md-5
     %p
       During this period
       = render partial: 'pulse_list_commits', locals: { commits: commits, updates: updates }
@@ -11,7 +11,7 @@
       = render partial: 'pulse_list_branches', locals: { branches: branches }
       = render partial: 'pulse_list_comments', locals: { comments: comments }
 
-  .col
+  .col-12.col-md-7
     = render partial: 'pulse_list_requests_box', locals: { project: project,
                                                            requests: requests,
                                                            requests_by_percentage: requests_by_percentage,

--- a/src/api/app/views/webui2/webui/projects/pulse/_pulse_list_requests.html.haml
+++ b/src/api/app/views/webui2/webui/projects/pulse/_pulse_list_requests.html.haml
@@ -1,9 +1,9 @@
 .row
   - @requests.take(30).each do |request|
-    %dt.col-1
+    %dt.col-12.col-md-2.col-lg-1
       %span{ class: "badge progress-state-#{request.state} text-light" }
         = request.state.to_s
-    %dd.col-11
+    %dd.col-12.col-md-10.col-lg-11
       = link_to(request_show_path(request.number), title: request.description) do
         = request.number
       - if request.request_history_elements.any?

--- a/src/api/app/views/webui2/webui/projects/pulse/show.html.haml
+++ b/src/api/app/views/webui2/webui/projects/pulse/show.html.haml
@@ -4,8 +4,8 @@
   = render(partial: 'tabs', locals: { project: @project })
 
   .card-body
-    .row
-      .col-8.mb-3
+    .row.mb-3
+      .col-sm-12.col-md-8
         %h3#range-header
           = pulse_period(@range)
       .col


### PR DESCRIPTION
We improve the responsiveness in small and medium break-points of the pulse page.

### Before
![Screenshot_2019-08-09 Open Build Service(3)](https://user-images.githubusercontent.com/1212806/62772114-ff293300-ba9e-11e9-930e-5cbb929b8dc3.png)

### After
![Screenshot_2019-08-09 Open Build Service](https://user-images.githubusercontent.com/1212806/62772044-d86afc80-ba9e-11e9-8c11-1a5d62940b1e.png)

<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md
-->
