### PR TITLE
Enhance contrast of footer and header

### DIFF
--- a/src/api/app/assets/stylesheets/webui2/sticky-footer.scss
+++ b/src/api/app/assets/stylesheets/webui2/sticky-footer.scss
@@ -7,14 +7,26 @@ body {
 }
 
 #footer {
-  background-color: $gray-300;
+  strong {
+    color: $gray-300;
+  }
 
   & a {
     font-size: .9rem;
-    color: $link-hover-color;
+    color: $gray-400;
 
     &:hover {
-        color: $link-color;
+        color: $gray-300;
+    }
+  }
+
+  ul {
+    @extend .list-unstyled;
+    @extend .mt-1;
+  }
+  #footer-legal {
+    p {
+      color: $gray-300;
     }
   }
 }

--- a/src/api/app/assets/stylesheets/webui2/watchlist.scss
+++ b/src/api/app/assets/stylesheets/webui2/watchlist.scss
@@ -4,4 +4,12 @@
       z-index: 1050;
     }
   }
+
+  #watchlist {
+    color: $gray-400;
+
+    &:hover {
+      color: $gray-300;
+    }
+  }
 }

--- a/src/api/app/views/layouts/webui2/_footer.html.haml
+++ b/src/api/app/views/layouts/webui2/_footer.html.haml
@@ -1,7 +1,7 @@
 .row
   - if User.session
     .col
-      %strong
+      %strong.text-uppercase
         = User.session!
       %ul
         %li= link_to('Your Profile', user_show_path(User.session!))
@@ -12,14 +12,14 @@
         %li= link_to('Logout', session_destroy_path, method: :delete)
   - if ::Configuration.anonymous
     .col
-      %strong Locations
+      %strong.text-uppercase Locations
       %ul
         %li= link_to('Projects', projects_path)
         %li= link_to('Search', search_path, class: 'search-link')
         - unless @spider_bot
           %li= link_to('Status Monitor', monitor_path)
   .col
-    %strong Help
+    %strong.text-uppercase Help
     %ul
       %li= link_to('Open Build Service', 'http://openbuildservice.org/')
       %li= link_to('OBS Manuals', 'http://openbuildservice.org/help/manuals/')
@@ -29,13 +29,13 @@
       - if Announcement.last.present?
         %li= link_to('Latest Announcement', announcement_path(Announcement.last))
   .col
-    %strong Contact
+    %strong.text-uppercase Contact
     %ul
       %li= link_to('Mailing List', 'http://lists.opensuse.org/opensuse-buildservice/')
       %li= link_to('Forums', 'http://forums.opensuse.org/forumdisplay.php/692-Open-Build-Service-%28OBS%29')
       %li= link_to('Chat (IRC)', 'irc://irc.opensuse.org/opensuse-buildservice')
       %li= link_to('Twitter', 'http://twitter.com/OBShq')
-.row#footer-legal
+.row.mt-4#footer-legal
   .col
     %p.text-center
       = link_to('Open Build Service (OBS)', 'http://openbuildservice.org')

--- a/src/api/app/views/layouts/webui2/webui.html.haml
+++ b/src/api/app/views/layouts/webui2/webui.html.haml
@@ -54,6 +54,6 @@
 
     .container.flex-grow#content
       = yield
-    .container-fluid.py-4.mt-4.text-dark#footer
+    .container-fluid.py-4.mt-4.bg-dark#footer
       .container
         = render partial: 'layouts/webui2/footer'


### PR DESCRIPTION
The text/links were hard to read in the footer/header and didn't
follow the wave recommendation (AA) regarding the contrast.

Co-authored-by: Daniel Donisa <daniel.donisa@suse.com>
Co-authored-by: David Kang <dkang@suse.com>
Co-authored-by: Saray Cabrera Padrón <scabrerapadron@suse.de>

**Before**
![Screenshot-2019-8-9 Open Build Service(1)](https://user-images.githubusercontent.com/22001671/62779240-ed518b00-bab2-11e9-8b9d-66b9e9aaf3dc.png)

**After**
![Screenshot-2019-8-9 Open Build Service](https://user-images.githubusercontent.com/22001671/62779247-f5112f80-bab2-11e9-8504-74c10f21aa45.png)

