### PR TITLE
Enhance contrast of the breadcrumbs

### DIFF
--- a/src/api/app/assets/stylesheets/webui2/breadcrumbs-component.scss
+++ b/src/api/app/assets/stylesheets/webui2/breadcrumbs-component.scss
@@ -4,8 +4,13 @@ ol.breadcrumb {
   & li {
     font-size: 0.9rem;
 
+    &.active {
+      color: $gray-700;
+      font-weight: bold;
+    }
+
     & a {
-      color: $gray-600;
+      color: $gray-700;
     }
   }
 }


### PR DESCRIPTION
The contrast of the breadcrumbs was too low and didn't
match the wave recommendation.

Co-authored-by: Daniel Donisa <daniel.donisa@suse.com>
Co-authored-by: David Kang <dkang@suse.com>
Co-authored-by: Saray Cabrera Padrón <scabrerapadron@suse.de>

**Before**
![Screenshot-2019-8-9 2 9 version of the Open Build Service Server](https://user-images.githubusercontent.com/22001671/62784922-d06f8480-babf-11e9-8c0b-d6ddcb26b88f.png)

**After**
![Screenshot-2019-8-9 This is a test project](https://user-images.githubusercontent.com/22001671/62784940-d9605600-babf-11e9-92e9-db3c4b6d0c57.png)



