### PR TITLE
Use a "big_editor" for SR/MR diff views

### DIFF
--- a/src/api/app/views/webui2/webui/package/_revision_diff_detail.html.haml
+++ b/src/api/app/views/webui2/webui/package/_revision_diff_detail.html.haml
@@ -9,7 +9,7 @@
           = calculate_filename(filename, file)
           %span.badge{ class: "badge-#{file['state']}" }= file['state'].capitalize
       %div
-        = render partial: 'shared/editor', locals: { text: diff_content, mode: 'diff', style: { read_only: true, big_editor: false } }
+        = render partial: 'shared/editor', locals: { text: diff_content, mode: 'diff', style: { read_only: true, big_editor: true } }
   - else
     .card{ id: "revision_details_#{index}" }
       .card-header


### PR DESCRIPTION
This change because ...:
* Having multiple scrollbars on the same page is annoying
* In most cases, the diffs to the .spec/.changes files are not that
  long but seeing just ~20 lines of a file's diff at a time is really
  limiting the ability to get an overview of the changes
* You can fold the diffs if you don't want to scroll
