### PR TITLE
Use 'robohash' style of default Gravatars instead of 'wavatar'

### DIFF
--- a/src/api/app/helpers/webui/user_helper.rb
+++ b/src/api/app/helpers/webui/user_helper.rb
@@ -22,7 +22,7 @@ module Webui::UserHelper
     alt = user.try(:login) if alt.empty?
     size = opt[:size] || 20
     if user.try(:email) && ::Configuration.gravatar
-      url = "https://www.gravatar.com/avatar/#{Digest::MD5.hexdigest(user.email.downcase)}?s=#{size}&d=wavatar"
+      url = "https://www.gravatar.com/avatar/#{Digest::MD5.hexdigest(user.email.downcase)}?s=#{size}&d=robohash"
     else
       url = 'default_face.png'
     end

--- a/src/api/app/helpers/webui/webui_helper.rb
+++ b/src/api/app/helpers/webui/webui_helper.rb
@@ -429,7 +429,7 @@ module Webui::WebuiHelper
 
   def gravatar_icon(email, size)
     if ::Configuration.gravatar && email
-      "https://www.gravatar.com/avatar/#{Digest::MD5.hexdigest(email.downcase)}?s=#{size}&d=wavatar"
+      "https://www.gravatar.com/avatar/#{Digest::MD5.hexdigest(email.downcase)}?s=#{size}&d=robohash"
     else
       'default_face.png'
     end

--- a/src/api/spec/helpers/webui/user_helper_spec.rb
+++ b/src/api/spec/helpers/webui/user_helper_spec.rb
@@ -53,7 +53,7 @@ RSpec.describe Webui::UserHelper do
       it 'does not link to user profiles' do
         expect(user_and_role(user.login)).to eq(
           "<img width=\"20\" height=\"20\" alt=\"#{CGI.escapeHTML(user.realname)}\" " \
-          "src=\"https://www.gravatar.com/avatar/803d88429659fa6549ee1a10ccdfbd47?s=20&amp;d=wavatar\" />#{CGI.escapeHTML(user.realname)} (#{user.login})"
+          "src=\"https://www.gravatar.com/avatar/803d88429659fa6549ee1a10ccdfbd47?s=20&amp;d=robohash\" />#{CGI.escapeHTML(user.realname)} (#{user.login})"
         )
       end
     end
@@ -94,7 +94,7 @@ RSpec.describe Webui::UserHelper do
 
     context 'with gravatar configuration enabled' do
       it 'returns gravatar url' do
-        expect(user_image_tag(user)).to eq('<img width="20" height="20" alt="Digger" src="https://www.gravatar.com/avatar/66ada5090a2f94d4cfec83801081f3a2?s=20&amp;d=wavatar" />')
+        expect(user_image_tag(user)).to eq('<img width="20" height="20" alt="Digger" src="https://www.gravatar.com/avatar/66ada5090a2f94d4cfec83801081f3a2?s=20&amp;d=robohash" />')
       end
     end
   end


### PR DESCRIPTION
Robohash looks (IMO) more modern and is less pixelated.

For comparison: 

* Wavatar example: https://www.gravatar.com/avatar/00000000000000000000000000000000?d=wavatar&f=y&size=500
* Robohash example: https://www.gravatar.com/avatar/00000000000000000000000000000000?d=robohash&f=y&size=500