### PR TITLE
Improve constrast for striped tables

### DIFF
--- a/src/api/app/assets/stylesheets/webui2/bootstrap_variables/tables.scss
+++ b/src/api/app/assets/stylesheets/webui2/bootstrap_variables/tables.scss
@@ -1,0 +1,2 @@
+// For better contrast in tables using .table-striped
+$table-accent-bg: $gray-300;

--- a/src/api/app/assets/stylesheets/webui2/webui2.css.scss
+++ b/src/api/app/assets/stylesheets/webui2/webui2.css.scss
@@ -16,6 +16,7 @@
 @import 'bootstrap_variables/colors';
 @import 'bootstrap_variables/spacers';
 @import 'bootstrap_variables/fonts';
+@import 'bootstrap_variables/tables';
 @import 'bootstrap';
 @import 'bootstrap-modal';
 @import "font-awesome-sprockets";


### PR DESCRIPTION
This is especially improving contrast when table cells contain a link.

Before:
![striped-table-before](https://user-images.githubusercontent.com/1102934/62857483-0b5bfd00-bcf8-11e9-8c28-a2e0f746a931.png)

After:
![striped-table-after](https://user-images.githubusercontent.com/1102934/62857531-2cbce900-bcf8-11e9-9579-ad1b45a3b292.png)