### PR TITLE
Improve constrast of added/removed lines in CodeMirror

### DIFF
--- a/src/api/app/assets/stylesheets/webui2/cm2/bootstrap.scss
+++ b/src/api/app/assets/stylesheets/webui2/cm2/bootstrap.scss
@@ -40,18 +40,18 @@
   .cm-error {color: $danger;}
 
   .cm-negative {
-    color: $danger;
+    color: inherit;
   }
 
   .CodeMirror-negative-line {
-    background: rgba($danger, 0.1);
+    background: rgba($danger, 0.3);
   }
   .cm-positive {
-    color: $success;
+    color: inherit;
   }
 
   .CodeMirror-positive-line {
-    background: rgba($success, 0.1);
+    background: rgba($success, 0.3);
   }
 
   .CodeMirror-gutters {


### PR DESCRIPTION
Somehow WAVE still seems to flag the new version as not having a good enough contrast. I double-checked on WebAIM and it's good. Refer to the links below.

Black on red: https://webaim.org/resources/contrastchecker/?fcolor=212529&bcolor=F5C2C7
Black on green: https://webaim.org/resources/contrastchecker/?fcolor=212529&bcolor=B2E0B2

Before:
![codemirror-before](https://user-images.githubusercontent.com/1102934/62863533-55011380-bd09-11e9-8562-b7ff4c0faba2.png)

After:
![codemirror-after](https://user-images.githubusercontent.com/1102934/62863532-55011380-bd09-11e9-8178-68c40d99739b.png)