### PR TITLE
Update colors for obs_green, bootstrap-info and bootstrap-success

### DIFF
--- a/src/api/app/assets/stylesheets/webui2/bootstrap_variables/colors.scss
+++ b/src/api/app/assets/stylesheets/webui2/bootstrap_variables/colors.scss
@@ -6,25 +6,22 @@ $gray-300: #e9ecef;
 $gray-400: #aeaeae;
 $gray-500: #878c92;
 
-$obs_green: #008000;
-$obs_blue: #069;
-$obs_yellow: #f0ad4e;
-$obs_cyan: #007a7c;
-
-$primary: $obs_green;
-$secondary: $obs_blue;
-$warning: $obs_yellow;
-$info: $obs_cyan;
-$success: $obs_green;
-
-$card-cap-bg: $gray-200;
-$link-hover-color: $obs_green;
-$link-color: $obs_blue;
-
-$blue: #00f;
-$green: #090;
+$blue: #069;
+$green: #008000;
 $pink: #708;
 $indigo: #219;
 $purple: #30a;
 $teal: #164;
 $orange: #a50;
+$yellow: #f0ad4e;
+$cyan: #007a7c;
+
+$primary: $green;
+$secondary: $blue;
+$warning: $yellow;
+$info: $cyan;
+$success: $green;
+
+$card-cap-bg: $gray-200;
+$link-hover-color: $green;
+$link-color: $blue;

--- a/src/api/app/assets/stylesheets/webui2/bootstrap_variables/colors.scss
+++ b/src/api/app/assets/stylesheets/webui2/bootstrap_variables/colors.scss
@@ -6,13 +6,16 @@ $gray-300: #e9ecef;
 $gray-400: #aeaeae;
 $gray-500: #878c92;
 
-$obs_green: #690;
+$obs_green: #008000;
 $obs_blue: #069;
 $obs_yellow: #f0ad4e;
+$obs_cyan: #007a7c;
 
 $primary: $obs_green;
 $secondary: $obs_blue;
 $warning: $obs_yellow;
+$info: $obs_cyan;
+$success: $obs_green;
 
 $card-cap-bg: $gray-200;
 $link-hover-color: $obs_green;

--- a/src/api/app/assets/stylesheets/webui2/pulse.scss
+++ b/src/api/app/assets/stylesheets/webui2/pulse.scss
@@ -1,14 +1,14 @@
 #pulse {
   .request-state-new {
-    color: $obs_blue;
+    color: $blue;
   }
 
   .request-state-review {
-    color: $obs_yellow;
+    color: $yellow;
   }
 
   .request-state-accepted {
-    color: $obs_green;
+    color: $green;
   }
 
   .request-state-declined {
@@ -24,15 +24,15 @@
   }
 
   .progress-state-new {
-    background-color: $obs_blue;
+    background-color: $blue;
   }
 
   .progress-state-review {
-    background-color: $obs_yellow;
+    background-color: $yellow;
   }
 
   .progress-state-accepted {
-    background-color: $obs_green;
+    background-color: $green;
   }
 
   .progress-state-declined {


### PR DESCRIPTION
The colors had a bad contrast in many areas of the OBS
webui

**Before**
![Screenshot-2019-8-12 ctris(1)](https://user-images.githubusercontent.com/22001671/62864253-7c58e000-bd0b-11e9-9078-007e0f946e5d.png)

**After**
![Screenshot-2019-8-12 ctris(2)](https://user-images.githubusercontent.com/22001671/62864267-85e24800-bd0b-11e9-9c10-4006178d97cd.png)

