### PR TITLE
Use coderay instead codemirror to present read-only diffs

### DIFF
--- a/ReleaseNotes-2.11
+++ b/ReleaseNotes-2.11
@@ -31,6 +31,7 @@ Generic:
 
 User Interface:
  * Colors were adjusted to improve contrast thus improving readability
+ * The diff box from requests are now being rendered with ruby and coderay instead of CodeMirror 
 
 Backend & build support:
  * 

--- a/src/api/Gemfile
+++ b/src/api/Gemfile
@@ -85,6 +85,8 @@ gem 'rails-timeago', '~> 2.0'
 gem 'deep_cloneable', '~> 2.4.0'
 # Server-side datatables
 gem 'ajax-datatables-rails'
+# Add syntax highlight in ruby
+gem 'coderay'
 
 group :development, :production do
   # to have the delayed job daemon

--- a/src/api/Gemfile.lock
+++ b/src/api/Gemfile.lock
@@ -481,6 +481,7 @@ DEPENDENCIES
   cocoon
   codecov
   codemirror-rails
+  coderay
   coffee-rails
   colorize
   coveralls

--- a/src/api/app/assets/stylesheets/webui2/coderay.scss
+++ b/src/api/app/assets/stylesheets/webui2/coderay.scss
@@ -1,0 +1,131 @@
+.CodeRay {
+  background-color:#fff;
+  border: 1px solid silver;
+  color: black;
+}
+.CodeRay pre {
+  margin: 0px;
+}
+
+span.CodeRay { white-space: pre; border: 0px; padding: 2px; }
+
+table.CodeRay { border-collapse: collapse; width: 100%; padding: 2px; }
+table.CodeRay td { padding: 2px 4px; vertical-align: top; }
+
+.CodeRay .line-numbers {
+  background-color: hsl(180,65%,90%);
+  color: gray;
+  text-align: right;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  user-select: none;
+}
+.CodeRay .line-numbers a {
+  background-color: hsl(180,65%,90%) !important;
+  color: gray !important;
+  text-decoration: none !important;
+}
+.CodeRay .line-numbers pre {
+  word-break: normal;
+}
+.CodeRay .line-numbers a:target { color: blue !important; }
+.CodeRay .line-numbers .highlighted { color: red !important; }
+.CodeRay .line-numbers .highlighted a { color: red !important; }
+.CodeRay span.line-numbers { padding: 0px 4px; }
+.CodeRay .line { width: 100%; }
+.CodeRay .code { width: 100%; }
+
+.CodeRay .debug { color: white !important; background: blue !important; }
+
+.CodeRay .annotation { color:#007 }
+.CodeRay .attribute-name { color:#b48 }
+.CodeRay .attribute-value { color:#700 }
+.CodeRay .binary { color:#549 }
+.CodeRay .binary .char { color:#325 }
+.CodeRay .binary .delimiter { color:#325 }
+.CodeRay .char { color:#D20 }
+.CodeRay .char .content { color:#D20 }
+.CodeRay .char .delimiter { color:#710 }
+.CodeRay .class { color:#B06; font-weight:bold }
+.CodeRay .class-variable { color:#369 }
+.CodeRay .color { color:#0A0 }
+.CodeRay .comment { color:#777 }
+.CodeRay .comment .char { color:#444 }
+.CodeRay .comment .delimiter { color:#444 }
+.CodeRay .constant { color:#036; font-weight:bold }
+.CodeRay .decorator { color:#B0B }
+.CodeRay .definition { color:#099; font-weight:bold }
+.CodeRay .delimiter { color:black }
+.CodeRay .directive { color:#088; font-weight:bold }
+.CodeRay .docstring { color:#D42; }
+.CodeRay .doctype { color:#34b }
+.CodeRay .done { text-decoration: line-through; color: gray }
+.CodeRay .entity { color:#800; font-weight:bold }
+.CodeRay .error { color:#F00; background-color:#FAA }
+.CodeRay .escape  { color:#666 }
+.CodeRay .exception { color:#C00; font-weight:bold }
+.CodeRay .float { color:#60E }
+.CodeRay .function { color:#06B; font-weight:bold }
+.CodeRay .function .delimiter { color:#059 }
+.CodeRay .function .content { color:#037 }
+.CodeRay .global-variable { color:#d70 }
+.CodeRay .hex { color:#02b }
+.CodeRay .id  { color:#33D; font-weight:bold }
+.CodeRay .include { color:#B44; font-weight:bold }
+.CodeRay .inline { background-color: hsla(0,0%,0%,0.07); color: black }
+.CodeRay .inline-delimiter { font-weight: bold; color: #666 }
+.CodeRay .instance-variable { color:#33B }
+.CodeRay .integer  { color:#00D }
+.CodeRay .imaginary { color:#f00 }
+.CodeRay .important { color:#D00 }
+.CodeRay .key { color: #606 }
+.CodeRay .key .char { color: #60f }
+.CodeRay .key .delimiter { color: #404 }
+.CodeRay .keyword { color:#080; font-weight:bold }
+.CodeRay .label { color:#970; font-weight:bold }
+.CodeRay .local-variable { color:#950 }
+.CodeRay .map .content { color:#808 }
+.CodeRay .map .delimiter { color:#40A}
+.CodeRay .map { background-color:hsla(200,100%,50%,0.06); }
+.CodeRay .namespace { color:#707; font-weight:bold }
+.CodeRay .octal { color:#40E }
+.CodeRay .operator { }
+.CodeRay .predefined { color:#369; font-weight:bold }
+.CodeRay .predefined-constant { color:#069 }
+.CodeRay .predefined-type { color:#0a8; font-weight:bold }
+.CodeRay .preprocessor { color:#579 }
+.CodeRay .pseudo-class { color:#00C; font-weight:bold }
+.CodeRay .regexp { background-color:hsla(300,100%,50%,0.06); }
+.CodeRay .regexp .content { color:#808 }
+.CodeRay .regexp .delimiter { color:#404 }
+.CodeRay .regexp .modifier { color:#C2C }
+.CodeRay .reserved { color:#080; font-weight:bold }
+.CodeRay .shell { background-color:hsla(120,100%,50%,0.06); }
+.CodeRay .shell .content { color:#2B2 }
+.CodeRay .shell .delimiter { color:#161 }
+.CodeRay .string { background-color:hsla(0,100%,50%,0.05); }
+.CodeRay .string .char { color: #b0b }
+.CodeRay .string .content { color: #D20 }
+.CodeRay .string .delimiter { color: #710 }
+.CodeRay .string .modifier { color: #E40 }
+.CodeRay .symbol { color:#A60 }
+.CodeRay .symbol .content { color:#A60 }
+.CodeRay .symbol .delimiter { color:#740 }
+.CodeRay .tag { color:#070; font-weight:bold }
+.CodeRay .type { color:#339; font-weight:bold }
+.CodeRay .value { color: #088 }
+.CodeRay .variable { color:#037 }
+
+.CodeRay .insert { background: hsla(120,100%,50%,0.12) }
+.CodeRay .delete { background: hsla(0,100%,50%,0.12) }
+.CodeRay .change { color: rgb(0, 0, 0); background: rgb(255, 255, 255) }
+.CodeRay .head { color: #f8f; background: #505 }
+.CodeRay .head .filename { color: white; }
+
+.CodeRay .delete .eyecatcher { background-color: hsla(0,100%,50%,0.2); border: 1px solid hsla(0,100%,45%,0.5); margin: -1px; border-bottom: none; border-top-left-radius: 5px; border-top-right-radius: 5px; }
+.CodeRay .insert .eyecatcher { background-color: hsla(120,100%,50%,0.2); border: 1px solid hsla(120,100%,25%,0.5); margin: -1px; border-top: none; border-bottom-left-radius: 5px; border-bottom-right-radius: 5px; }
+
+.CodeRay .insert .insert { color: #0c0; background:transparent; font-weight:bold }
+.CodeRay .delete .delete { color: #c00; background:transparent; font-weight:bold }
+.CodeRay .change .change { color: rgb(0, 0, 0) }
+.CodeRay .head .head { color: #f4f }

--- a/src/api/app/assets/stylesheets/webui2/webui2.css.scss
+++ b/src/api/app/assets/stylesheets/webui2/webui2.css.scss
@@ -32,6 +32,7 @@
 @import 'list-group-item-integrated';
 @import 'icons';
 @import 'kaminari';
+@import 'coderay';
 @import 'system-status';
 @import 'texts';
 @import 'build-results';

--- a/src/api/app/helpers/application_helper.rb
+++ b/src/api/app/helpers/application_helper.rb
@@ -1,3 +1,6 @@
 # Methods added to this helper will be available to all templates in the application.
 module ApplicationHelper
+  def render_diff(content)
+    sanitize(CodeRay.scan(content, :diff).div(line_numbers: :inline, css: :class))
+  end
 end

--- a/src/api/app/views/webui2/webui/package/_revision_diff_detail.html.haml
+++ b/src/api/app/views/webui2/webui/package/_revision_diff_detail.html.haml
@@ -9,7 +9,7 @@
           = calculate_filename(filename, file)
           %span.badge{ class: "badge-#{file['state']}" }= file['state'].capitalize
       %div
-        = render partial: 'shared/editor', locals: { text: diff_content, mode: 'diff', style: { read_only: true, big_editor: false } }
+        = render_diff(diff_content)
   - else
     .card{ id: "revision_details_#{index}" }
       .card-header


### PR DESCRIPTION
To offer an options  to the users to check a set of one or more diffs, we were using CodeMirror, a javascript based Editor.

However when the request has more than a few diffs, it starts to get
slow. As drop-in solution I'm proposing to go  with [CodeRay](https://github.com/rubychan/coderay).

Fixes #8072

How it looks:

![Screenshot_2019-08-14_11-59-44](https://user-images.githubusercontent.com/37418/63012873-47739700-be8b-11e9-8f2a-6f8c524bed0e.png)


Benchmark loading 50 diffs in one request:

With CodeMirror:
```
 Completed 200 OK in 61ms (Views: 3.8ms | ActiveRecord: 7.4ms | Backend: 17.4ms)
```
With CodeRay (with tables or div, no real performance difference among them):
```
Completed 200 OK in 47ms (Views: 0.9ms | ActiveRecord: 5.7ms | Backend: 17.3ms)
```

TODO:
- [x] probably fix some test case
- [x] adapt the css to our needs
- [x] add to the changes for 2.11