### PR TITLE
Improve constrast of red/green for build results in striped tables

### DIFF
--- a/src/api/app/assets/stylesheets/webui2/build-results.scss
+++ b/src/api/app/assets/stylesheets/webui2/build-results.scss
@@ -51,6 +51,16 @@
   color: $yellow;
 }
 
+.table-striped .odd {
+  .build-state-succeeded {
+    color: darken($green, 5%);
+  }
+
+  .build-state-unresolvable, .build-state-broken, .build-state-failed {
+    color: darken($red, 10%);
+  }
+}
+
 .repository-state-default {
   @extend .text-black-50;
 }


### PR DESCRIPTION
The new version makes the page pass the WAVE contrast checks. The changes are minor since the contrast was almost already fine. It just needed a small boost :wink:

Before:
![project-monitor-before](https://user-images.githubusercontent.com/1102934/62874843-36f3dd00-bd22-11e9-90ab-a4eff47232fb.png)

After:
![project-monitor-after](https://user-images.githubusercontent.com/1102934/62874842-36f3dd00-bd22-11e9-9111-d92fbc2d0502.png)