### PR TITLE
Improve contrast for all states of build results in striped tables

### DIFF
--- a/src/api/app/assets/stylesheets/webui2/build-results.scss
+++ b/src/api/app/assets/stylesheets/webui2/build-results.scss
@@ -48,7 +48,7 @@
 }
 
 .build-state-scheduled-warning, .build-state-unknown {
-  color: $yellow;
+  color: $orange;
 }
 
 .table-striped .odd {
@@ -56,8 +56,16 @@
     color: darken($green, 5%);
   }
 
+  .build-state-scheduled {
+    color: darken($cyan, 5%);
+  }
+
   .build-state-unresolvable, .build-state-broken, .build-state-failed {
     color: darken($red, 10%);
+  }
+
+  .build-state-scheduled-warning, .build-state-unknown {
+    color: darken($orange, 5%);
   }
 }
 


### PR DESCRIPTION
Before:
![project-monitor-before](https://user-images.githubusercontent.com/1102934/62923463-0c4f6600-bdae-11e9-8fef-e67c0e485ba3.png)

After:
![project-monitor-after](https://user-images.githubusercontent.com/1102934/62923461-0c4f6600-bdae-11e9-92c9-641914b3b0af.png)