### PR TITLE
Update last_logged_in_at when a user logs in via proxy

### DIFF
--- a/src/api/app/controllers/webui/webui_controller.rb
+++ b/src/api/app/controllers/webui/webui_controller.rb
@@ -177,9 +177,7 @@ class Webui::WebuiController < ActionController::Base
       User.session = user_checker.find_or_create_user!
 
       if User.session!.is_active?
-        User.session!.update_user_info_from_proxy_env(request.env)
-        User.session!.mark_login!
-        send_login_information_rabbitmq(:success)
+        User.session!.update_login_values(request.env)
       else
         User.session!.count_login_failure
         session[:login] = nil

--- a/src/api/app/controllers/webui/webui_controller.rb
+++ b/src/api/app/controllers/webui/webui_controller.rb
@@ -178,7 +178,10 @@ class Webui::WebuiController < ActionController::Base
 
       if User.session!.is_active?
         User.session!.update_user_info_from_proxy_env(request.env)
+        User.session!.mark_login!
+        send_login_information_rabbitmq(:success)
       else
+        User.session!.count_login_failure
         session[:login] = nil
         User.session = User.find_nobody!
         send_login_information_rabbitmq(:disabled) if previous_user != User.possibly_nobody.login

--- a/src/api/app/models/user.rb
+++ b/src/api/app/models/user.rb
@@ -281,7 +281,7 @@ class User < ApplicationRecord
       mark_login!
       self
     else
-      update_attributes!(login_failure_count: login_failure_count + 1)
+      count_login_failure
       nil
     end
   end
@@ -860,6 +860,10 @@ class User < ApplicationRecord
 
   def mark_login!
     update_attributes(last_logged_in_at: Time.now, login_failure_count: 0)
+  end
+
+  def count_login_failure
+    update_attributes(login_failure_count: login_failure_count + 1)
   end
 
   def send_metric_for_beta_change

--- a/src/api/app/models/user.rb
+++ b/src/api/app/models/user.rb
@@ -149,7 +149,7 @@ class User < ApplicationRecord
     self.state ||= 'unconfirmed'
 
     # Set the last login time etc. when the record is created at first.
-    self.last_logged_in_at = Time.now
+    self.last_logged_in_at = Time.zone.today
 
     self.login_failure_count = 0 if login_failure_count.nil?
   end
@@ -859,7 +859,7 @@ class User < ApplicationRecord
   end
 
   def mark_login!
-    update_attributes(last_logged_in_at: Time.now, login_failure_count: 0)
+    update_attributes(last_logged_in_at: Time.zone.today, login_failure_count: 0)
   end
 
   def count_login_failure

--- a/src/api/app/services/webui_controller_service/user_checker.rb
+++ b/src/api/app/services/webui_controller_service/user_checker.rb
@@ -19,6 +19,7 @@ module WebuiControllerService
       if user.exists?
         User.find_by!(login: user_login)
       else
+        # This will end up in a before_validation(on: :create) that updates last_logged_in_at.
         User.create_user_with_fake_pw!(login: user_login,
                                        email: http_request.env['HTTP_X_EMAIL'],
                                        state: User.default_user_state,

--- a/src/api/lib/authenticator.rb
+++ b/src/api/lib/authenticator.rb
@@ -185,9 +185,7 @@ class Authenticator
         @http_user = User.create_user_with_fake_pw!(login: proxy_user, state: User.default_user_state)
       end
 
-      @http_user.last_logged_in_at = Time.now
-      # update user data from login proxy headers
-      @http_user.update_user_info_from_proxy_env(request.env)
+      @http_user.update_login_values(request.env)
     else
       Rails.logger.error 'No X-username header was sent by login proxy!'
     end

--- a/src/api/lib/tasks/rollout.rake
+++ b/src/api/lib/tasks/rollout.rake
@@ -30,7 +30,7 @@ namespace :rollout do
   task recently_logged_users: :environment do
     User.all_without_nobody
         .not_staff
-        .where(in_rollout: false, last_logged_in_at: 3.months.ago.midnight..Time.zone.now)
+        .where(in_rollout: false, last_logged_in_at: Time.zone.today.prev_month(3)..Time.zone.today)
         .in_batches.update_all(in_rollout: true)
   end
 
@@ -38,7 +38,7 @@ namespace :rollout do
   task non_recently_logged_users: :environment do
     User.all_without_nobody
         .not_staff
-        .where.not(in_rollout: true, last_logged_in_at: 3.months.ago.midnight..Time.zone.now)
+        .where.not(in_rollout: true, last_logged_in_at: Time.zone.today.prev_month(3)..Time.zone.today)
         .in_batches.update_all(in_rollout: true)
   end
 

--- a/src/api/spec/controllers/webui/session_controller_spec.rb
+++ b/src/api/spec/controllers/webui/session_controller_spec.rb
@@ -149,12 +149,11 @@ RSpec.describe Webui::SessionController do
         expect(User.session!).to eq(user)
       end
 
-      it 'updates last_logged_in_at and login_failure_count' do
+      it 'updates last_logged_in_at' do
         user.update_attributes(last_logged_in_at: nil)
 
         get :new
-        expect(user.reload.last_logged_in_at).not_to be_nil
-        expect(user.login_failure_count).to eq(0)
+        expect(user.reload.last_logged_in_at).to eq(Time.zone.today)
       end
     end
 
@@ -174,11 +173,10 @@ RSpec.describe Webui::SessionController do
         expect(User.session!.login).to eq(user.first.login)
       end
 
-      it 'sets last_logged_in_at and login_failure_count on creation' do
+      it 'sets last_logged_in_at on creation' do
         get :new
         user = User.find_by(login: username, realname: 'Bob Geldof', email: 'new_user@obs.com')
-        expect(user.last_logged_in_at).not_to be_nil
-        expect(user.login_failure_count).to eq(0)
+        expect(user.last_logged_in_at).to eq(Time.zone.today)
       end
     end
 

--- a/src/api/spec/lib/authenticator_spec.rb
+++ b/src/api/spec/lib/authenticator_spec.rb
@@ -9,6 +9,11 @@ RSpec.describe Authenticator do
 
     before do
       allow(session_mock).to receive(:[]).with(:login)
+      Timecop.freeze(Time.zone.today)
+    end
+
+    after do
+      Timecop.return
     end
 
     context 'in proxy mode' do
@@ -101,7 +106,7 @@ RSpec.describe Authenticator do
             expect(authenticator.http_user).to eq(new_user.first)
           end
 
-          it { expect(authenticator.http_user.last_logged_in_at).to be_within(30.seconds).of(Time.now) }
+          it { expect(authenticator.http_user.last_logged_in_at).to eq(Time.zone.today) }
         end
 
         context 'but user is unconfirmed' do

--- a/src/api/spec/models/user_spec.rb
+++ b/src/api/spec/models/user_spec.rb
@@ -9,6 +9,14 @@ RSpec.describe User do
   let(:input) { { 'Event::RequestCreate' => { source_maintainer: '1' } } }
   let(:project_with_package) { create(:project_with_package, name: 'project_b') }
 
+  before do
+    Timecop.freeze(Time.zone.today)
+  end
+
+  after do
+    Timecop.return
+  end
+
   describe 'validations' do
     it { is_expected.to validate_presence_of(:login).with_message('must be given') }
     it { is_expected.to validate_length_of(:login).is_at_least(2).with_message('must have more than two characters') }
@@ -85,7 +93,7 @@ RSpec.describe User do
       user = User.new
       expect(user.last_logged_in_at).to be(nil)
       user.save
-      expect(user.last_logged_in_at).to be_within(30.seconds).of(Time.now)
+      expect(user.last_logged_in_at).to eq(Time.zone.today)
     end
   end
 
@@ -418,12 +426,12 @@ RSpec.describe User do
 
   describe '.mark_login!' do
     before do
-      user.update_attributes!(login_failure_count: 7, last_logged_in_at: 3.hours.ago)
+      user.update_attributes!(login_failure_count: 7, last_logged_in_at: Time.zone.yesterday)
       user.mark_login!
     end
 
     it "updates the 'last_logged_in_at'" do
-      expect(user.last_logged_in_at).to be > 30.seconds.ago
+      expect(user.last_logged_in_at).to eq(Time.zone.today)
     end
 
     it "resets the 'login_failure_count'" do
@@ -432,14 +440,14 @@ RSpec.describe User do
   end
 
   describe '#find_with_credentials' do
-    let(:user) { create(:user, login: 'login_test', login_failure_count: 7, last_logged_in_at: 3.hours.ago) }
+    let(:user) { create(:user, login: 'login_test', login_failure_count: 7, last_logged_in_at: Time.zone.yesterday) }
 
     context 'when user exists' do
       subject { User.find_with_credentials(user.login, 'buildservice') }
 
       it { is_expected.to eq(user) }
       it { expect(subject.login_failure_count).to eq(0) }
-      it { expect(subject.last_logged_in_at).to be > 30.seconds.ago }
+      it { expect(subject.last_logged_in_at).to eq(Time.zone.today) }
     end
 
     context 'when user does not exist' do
@@ -461,7 +469,7 @@ RSpec.describe User do
       end
 
       let(:user) do
-        create(:user, login: 'tux', realname: 'penguin', login_failure_count: 7, last_logged_in_at: 3.hours.ago, email: 'tux@suse.de')
+        create(:user, login: 'tux', realname: 'penguin', login_failure_count: 7, last_logged_in_at: Time.zone.yesterday, email: 'tux@suse.de')
       end
 
       before do
@@ -475,7 +483,7 @@ RSpec.describe User do
 
         it { is_expected.to eq(user) }
         it { expect(subject.login_failure_count).to eq(0) }
-        it { expect(subject.last_logged_in_at).to be > 30.seconds.ago }
+        it { expect(subject.last_logged_in_at).to eq(Time.zone.today) }
 
         it 'updates user data received from the LDAP server' do
           expect(subject.email).to eq('John@obs.de')
@@ -493,7 +501,7 @@ RSpec.describe User do
           expect(subject.realname).to eq('new_user')
           expect(subject.state).to eq('confirmed')
           expect(subject.login_failure_count).to eq(0)
-          expect(subject.last_logged_in_at).to be > 30.seconds.ago
+          expect(subject.last_logged_in_at).to eq(Time.zone.today)
         end
       end
     end

--- a/src/api/spec/support/shared_examples/a_confirmed_user_logs_in.rb
+++ b/src/api/spec/support/shared_examples/a_confirmed_user_logs_in.rb
@@ -8,6 +8,6 @@ RSpec.shared_examples 'a confirmed user logs in' do
     end
 
     it { expect(authenticator.http_user).to eq(user) }
-    it { expect(authenticator.http_user.last_logged_in_at).to be_within(30.seconds).of(Time.now) }
+    it { expect(authenticator.http_user.last_logged_in_at).to eq(Time.zone.today) }
   end
 end


### PR DESCRIPTION
When users logged in via proxy `last_logged_in_at` and `login_failure_count` were not updated. Now we do it every time we check the user.

We also set RabbitMQ messages when needed.

Fixes: #8068


<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md
-->
