### PR TITLE
Typography - patchinfo show

### DIFF
--- a/src/api/app/helpers/webui/patchinfo_helper.rb
+++ b/src/api/app/helpers/webui/patchinfo_helper.rb
@@ -22,7 +22,7 @@ module Webui::PatchinfoHelper
   private
 
   def header_title(patchinfo, text, list)
-    haml_tag(:h3, class: 'mb-0') do
+    haml_tag(:h3) do
       haml_tag(:span, text, title: list)
       haml_tag(:span, patchinfo.category, class: "badge badge-category #{patchinfo.category}", title: 'Category of this patchinfo')
       haml_tag(:span, patchinfo.rating, class: "badge badge-rating #{patchinfo.rating}", title: 'Rating of this patchinfo')
@@ -30,6 +30,6 @@ module Webui::PatchinfoHelper
   end
 
   def header_subtitle(summary)
-    haml_tag(:small, summary, class: 'text-muted') if summary.present?
+    haml_tag(:div, summary, class: 'mb-3 text-muted') if summary.present?
   end
 end

--- a/src/api/app/views/webui2/webui/patchinfo/_side_elements.html.haml
+++ b/src/api/app/views/webui2/webui/patchinfo/_side_elements.html.haml
@@ -6,7 +6,7 @@
         .block-reason
           %span Release is blocked
           - if patchinfo.block_reason.present?
-            %small.d-block.mb-1.text-muted= patchinfo.block_reason
+            %span.d-block.mb-2.text-muted= patchinfo.block_reason
 
   - if packager
     %li

--- a/src/api/app/views/webui2/webui/patchinfo/show.html.haml
+++ b/src/api/app/views/webui2/webui/patchinfo/show.html.haml
@@ -42,7 +42,7 @@
             .media-body.mb-3
               = patchinfo_issue_link(issue[1], issue[0], issue[2])
               - if issue[3].present?
-                %small.d-block.text-muted= issue[3]
+                %div= issue[3]
   .col-md-6
     .card.mb-3
       %h5.card-header Selected Binaries

--- a/src/api/app/views/webui2/webui/patchinfo/show.html.haml
+++ b/src/api/app/views/webui2/webui/patchinfo/show.html.haml
@@ -6,7 +6,7 @@
     .patchinfo.row
       .col-md-8
         = patchinfo_header(@patchinfo, @pkg_names)
-        .mt-3#description-text
+        #description-text
           = render partial: 'webui/webui/collapsible_text', locals: { text: @patchinfo.description }
       .col-md-4
         = render partial: 'side_elements', locals: { patchinfo: @patchinfo, packager: @packager }


### PR DESCRIPTION
We removed the `small` class from summary and block reason. This information was too attenuated because of the small font size and and light gray colour.

#### Before
![Screenshot_2019-08-16 Open Build Service](https://user-images.githubusercontent.com/1212806/63157916-618eb000-c018-11e9-907b-031d2e80717f.png)



#### After
![Screenshot_2019-08-16 Open Build Service](https://user-images.githubusercontent.com/1212806/63164432-b0444600-c028-11e9-9168-83bc9c5727ac.png)



<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md
-->
