### PR TITLE
Enable RFS in bootstrap for responsive font-sizes

### DIFF
--- a/src/api/app/assets/stylesheets/webui2/bootstrap_variables/fonts.scss
+++ b/src/api/app/assets/stylesheets/webui2/bootstrap_variables/fonts.scss
@@ -1,1 +1,10 @@
 $seventy-five-chars: 75ch;
+
+// enable responsive fonts in bootstrap (RFS)
+$enable-responsive-font-sizes: true;
+
+// stop scaling down at a font-size of 16px (default 1.25rem)
+$rfs-base-font-size: 1rem;
+
+// set the scaling factor (default=10)
+$rfs-factor: 2.5;


### PR DESCRIPTION
Just a preview for you to see the webui with responsive font-sizes enabled. In this example it scales down to 14px at max (default is to stop at 16px, which needs to be discussed). It starts the scaling at large screens (960px width). Check it out in the review app :)
