### PR TITLE
Use hyphens: auto, just when supported

### DIFF
--- a/src/api/app/assets/stylesheets/webui2/comments.scss
+++ b/src/api/app/assets/stylesheets/webui2/comments.scss
@@ -1,6 +1,16 @@
 #comments {
   .media .media-body {
-    hyphens: auto;
+
+    // hyphens isn't supported on Desktop chrome
+    // https://caniuse.com/#search=hyphens
+    @supports(hyphens:auto) {
+      hyphens: auto;
+    }
+    @supports not(hyphens: auto) {
+      // break-word is depreacted. But works on Chrome well
+      // https://developer.mozilla.org/en-US/docs/Web/CSS/word-break
+      word-break: break-word;
+    }
 
     p:not(:first-child) {
       max-width: $seventy-five-chars;


### PR DESCRIPTION
Unfortunately the hyphens: auto, doesn't work on Chrome desktop properly
therefore we are falling back to word-break: break-word when hyphens
aren't supported

We can see in the following screenshots how it looks like:

On Firefox:

![Screenshot_2019-08-15_11-31-29-firefox](https://user-images.githubusercontent.com/37418/63087126-aac7fc80-bf51-11e9-969c-aeb54207f9a3.png)


On Chrome:

With the alternative to `word-break: break-word`: (`word-break: normal;overflow-wrap: anywhere`) 
suggested in https://developer.mozilla.org/en-US/docs/Web/CSS/word-break

![Screenshot_2019-08-15_11-30-19-word-break-normal](https://user-images.githubusercontent.com/37418/63087148-b5829180-bf51-11e9-8e79-f35338f425e2.png)

On Chrome:

With the `word-break: break-word`

![Screenshot_2019-08-15_11-28-31-word-break](https://user-images.githubusercontent.com/37418/63087283-10b48400-bf52-11e9-8a60-02de3cb69fe8.png)


So even if `word-break: break-word` is deprecated it is a temporary solution while Chrome doesn't support it well.

Fixes #8100


