### PR TITLE
Set max line-length for obs description at root page

### DIFF
--- a/src/api/app/assets/stylesheets/webui2/card-component.scss
+++ b/src/api/app/assets/stylesheets/webui2/card-component.scss
@@ -8,6 +8,14 @@
     h1, h2, h3, h4, h5, h6 {
       color: $primary;
     }
+
+    .description {
+      max-width: $seventy-five-chars;
+    }
+
+    #proceed-list {
+      max-width: $seventy-five-chars;
+    }
   }
 
   .nav-tabs .nav-link.active {

--- a/src/api/app/views/webui2/webui/main/index.html.haml
+++ b/src/api/app/views/webui2/webui/main/index.html.haml
@@ -1,7 +1,7 @@
 - @pagetitle = 'Welcome'
 
 .row
-  .col-md-8
+  .col-md-8.col-lg-7
     .card.mb-3
       .card-body
         %h2
@@ -17,7 +17,7 @@
                                                  waiting_packages: @waiting_packages,
                                                  host_title: @configuration['title'],
                                                  system_stats: @system_stats })
-  .col-md-4
+  .col-md-4.col-lg-5
     - if !User.session && can_register
       .card.mb-3
         %h5.card-header New here? Sign up!


### PR DESCRIPTION
To be consistent with the maximum line-length for text at other places
of obs.

**Before**
![Screenshot-2019-8-15 Open Build Service(1)](https://user-images.githubusercontent.com/22001671/63097536-fccc4a80-bf70-11e9-96c3-53dcd61919cc.png)

**After**
![Screenshot-2019-8-15 Open Build Service](https://user-images.githubusercontent.com/22001671/63097544-02299500-bf71-11e9-834f-e3f0959ebd95.png)
