### PR TITLE
Typography - Search

### DIFF
--- a/src/api/app/views/webui2/webui/search/_results.html.haml
+++ b/src/api/app/views/webui2/webui/search/_results.html.haml
@@ -15,7 +15,7 @@
         = project_or_package_link(project: project, package: package, short: false, trim_to: nil)
         %span.d-none= result.sphinx_attributes
         = ": #{result.title}" if result.title.present?
-      %p.pl-4.small.text-muted
+      %p.pl-4
         - if result.description.blank?
           = '...'
         - else

--- a/src/api/app/views/webui2/webui/search/_results_issue.html.haml
+++ b/src/api/app/views/webui2/webui/search/_results_issue.html.haml
@@ -15,7 +15,7 @@
         = project_or_package_link(project: project, package: package, short: false, trim_to: nil)
         %span.d-none= result.sphinx_attributes
         = ": #{result.title}" if result.title.present?
-      %p.pl-4.small.text-muted
+      %p.pl-4
         - if result.description.blank?
           = '...'
         - else

--- a/src/api/app/views/webui2/webui/search/_results_owner.html.haml
+++ b/src/api/app/views/webui2/webui/search/_results_owner.html.haml
@@ -2,10 +2,9 @@
   %h4 Results:
   - results.each do |result|
     .search_result.mt-3
-      %h6
-        Responsible for
-        #{project_or_package_link project: result.project, package: result.package, short: false}
-        in #{result.rootproject}
+      Responsible for
+      #{project_or_package_link project: result.project, package: result.package, short: false}
+      in #{result.rootproject}
 
       %ul.list-unstyled
         - users_and_groups = (result.users || {}).merge(result.groups || {}) { |_role, user, group| user.concat(group) }
@@ -13,10 +12,11 @@
           %li.mt-3
             :ruby
               emails = records.map(&:email).reject(&:blank?).join(', ')
-            = role.capitalize.pluralize
-            - if emails.present? && User.session
-              = mail_to(emails) do
-                %i.far.fa-envelope.ml-1{ title: "Send email to #{role.pluralize(records.size)}" }
+            %h6
+              = role.capitalize.pluralize
+              - if emails.present? && User.session
+                = mail_to(emails) do
+                  %i.far.fa-envelope.ml-1{ title: "Send email to #{role.pluralize(records.size)}" }
             .d-flex.flex-wrap.flex-column.flex-md-row
               - records.each do |record|
                 .card.m-1.p-2.search-result


### PR DESCRIPTION
Stick to default font for results' description in the search (same thing for the search issues page)

Before:
![search-before](https://user-images.githubusercontent.com/1102934/63097325-68fa7e80-bf70-11e9-8041-f3f60eca8adb.png)

After:
![search-after](https://user-images.githubusercontent.com/1102934/63097324-68fa7e80-bf70-11e9-8716-02dfde458472.png)

---

Improve text hierarchy in the search owners page. For the user cards, we stick with the emphasis on the user names, so this explains why the user logins are smaller. 

Before:
![search-owners-before](https://user-images.githubusercontent.com/1102934/63097327-69931500-bf70-11e9-905b-a5eb455d7cdd.png)

After:
![search-owners-after](https://user-images.githubusercontent.com/1102934/63097326-69931500-bf70-11e9-8997-1d337cdfdfdf.png)

