### PR TITLE
Variable monitor table package name column width

### DIFF
--- a/src/api/app/assets/javascripts/webui2/project_monitor.js
+++ b/src/api/app/assets/javascripts/webui2/project_monitor.js
@@ -39,6 +39,13 @@ function initializeMonitorDataTable() {
   var statusHash = data.statushash;
   var tableInfo = data.tableinfo;
   var projectName = data.project;
+  var longestPackageName = packageNames.reduce(function (a, b) { return a.length > b.length ? a : b; }).length;
+  if (longestPackageName < '10') {
+    var longestPackageName = '10'
+  }
+  if (longestPackageName > '50') {
+    var longestPackageName = '50'
+  }
 
   initializeDataTable('#project-monitor-table', { // jshint ignore:line
     scrollX: true,
@@ -52,7 +59,7 @@ function initializeMonitorDataTable() {
     },
     columnDefs: [
       {
-        width: 150,
+        width: longestPackageName + 'ch',
         targets: 0,
         className: 'text-left',
         data: null,


### PR DESCRIPTION
Fixing the first column to 150px can lead to very strange looking tables where you have lots of word breaks in the first column, despite having lots of space in general. Let's rather fix it to the content
unless it's to small/big.

Somewhat fixes #8115 but I'm not sure I want to have this. Opinions?

![Screenshot from 2019-08-16 17-21-57](https://user-images.githubusercontent.com/514785/63178495-72f0b000-c04a-11e9-801a-94c16de6ee7e.png)
