### PR TITLE
Display a link badge next to link in the package list

### DIFF
--- a/src/api/app/datatables/package_datatable.rb
+++ b/src/api/app/datatables/package_datatable.rb
@@ -3,6 +3,8 @@ class PackageDatatable < Datatable
   def_delegator :@view, :link_to
   def_delegator :@view, :package_show_path
   def_delegator :@view, :time_ago_in_words
+  def_delegator :@view, :content_tag
+  def_delegator :@view, :safe_join
 
   def initialize(params, opts = {})
     @project = opts[:project]
@@ -27,9 +29,15 @@ class PackageDatatable < Datatable
   def data
     records.map do |record|
       {
-        name: link_to(record.name, package_show_path(package: record, project: @project)),
+        name: name_with_link(record),
         changed: time_ago_in_words(Time.at(record.updated_at.to_i))
       }
     end
+  end
+  def name_with_link(record)
+    name = []
+    name << link_to(record.name, package_show_path(package: record, project: @project))
+    name << content_tag(:span, 'Link', class: 'badge badge-info') if record.is_link?
+    safe_join(name, ' ')
   end
 end

--- a/src/api/app/datatables/package_datatable.rb
+++ b/src/api/app/datatables/package_datatable.rb
@@ -34,6 +34,7 @@ class PackageDatatable < Datatable
       }
     end
   end
+
   def name_with_link(record)
     name = []
     name << link_to(record.name, package_show_path(package: record, project: @project))


### PR DESCRIPTION
Fixes #786
Allows to quickly spot a linked package in between other kinds of packages
![Screenshot from 2019-08-18 19-19-47](https://user-images.githubusercontent.com/30577011/63228009-593b9e00-c1ed-11e9-8de4-a1df3b0956df.png)
