### PR TITLE
Fix maintained projects link

### DIFF
--- a/src/api/app/views/webui2/webui/project/side_links/_maintenance_project.html.haml
+++ b/src/api/app/views/webui2/webui/project/side_links/_maintenance_project.html.haml
@@ -10,5 +10,5 @@
     %i.fa.fa-exclamation-circle.text-danger
   - else
     %i.fa.fa-check-circle.text-success
-  = link_to(project_maintained_projects_path(project)) do
+  = link_to(projects_project_maintained_projects_path(project)) do
     = pluralize(maintained_projects.size, 'maintained project')


### PR DESCRIPTION
During the migration to the new UI we forgot to change the link of the
maintained projects to point to the new controller.



<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md
-->
