### PR TITLE
Adjust typography and elements size and position in group show page

### DIFF
--- a/src/api/app/assets/stylesheets/webui2/groups.scss
+++ b/src/api/app/assets/stylesheets/webui2/groups.scss
@@ -1,5 +1,14 @@
 #group-users {
   .group-user {
-    min-width: 26rem;
+    width: 19.7rem;
+
+    @include media-breakpoint-up(xl) {
+      width: 21.7rem;
+    }
+
+    @include media-breakpoint-up(xxl) {
+      width: 22.4rem;
+    }
   }
 }
+

--- a/src/api/app/helpers/webui/user_or_groups_roles_helper.rb
+++ b/src/api/app/helpers/webui/user_or_groups_roles_helper.rb
@@ -1,9 +1,13 @@
 module Webui::UserOrGroupsRolesHelper
   def display_name(object)
     if object.is_a?(User) && object.realname.present?
-      "#{object.name} (#{object.login})"
+      content_tag :span do
+        concat "#{object.name} ("
+        concat content_tag(:i, object.login)
+        concat ')'
+      end
     else
-      object.name
+      content_tag(:span, object.name)
     end
   end
 

--- a/src/api/app/views/webui2/webui/groups/_group_members.html.haml
+++ b/src/api/app/views/webui2/webui/groups/_group_members.html.haml
@@ -25,11 +25,10 @@
                   class: 'group-member-removal float-right', title: 'Remove member from group') do
                   %i.fas.fa-sm.fa-times-circle.text-danger
               .card-body.ml-2
-                %b
-                  = link_to(user_show_path(user)) do
-                    = display_name(user)
+                = link_to(user_show_path(user)) do
+                  = display_name(user)
 
-                .custom-control.custom-checkbox
+                .custom-control.custom-checkbox.mt-2
                   = check_box_tag("maintainer_#{user.login}", true, group.maintainer?(user), class: 'custom-control-input group-maintainership',
                     name: :maintainer, disabled: !write_access, data: { method: :patch,
                     url: group_user_path(group_title: group.title, user_login: user.login), remote: true })

--- a/src/api/app/views/webui2/webui/groups/_group_members.html.haml
+++ b/src/api/app/views/webui2/webui/groups/_group_members.html.haml
@@ -16,15 +16,15 @@
     .d-flex.flex-wrap
       - group.users.each do |user|
         .card.m-1.p-2.group-user
+          - if write_access
+            = link_to(group_user_path(group_title: group.title, user_login: user.login), data: { method: :delete, remote: true },
+              id: user.login, class: 'group-member-removal text-right', title: 'Remove member from group') do
+              %i.fas.fa-sm.fa-times-circle.text-danger
           .row.no-gutters
-            .col-md-2
+            .col-md-3
               = image_tag_for(user, size: 80, custom_class: 'align-self-center')
-            .col-md-10
-              - if write_access
-                = link_to(group_user_path(group_title: group.title, user_login: user.login), data: { method: :delete, remote: true },
-                  class: 'group-member-removal float-right', title: 'Remove member from group') do
-                  %i.fas.fa-sm.fa-times-circle.text-danger
-              .card-body.ml-2
+            .col-md-9
+              .card-body.py-1
                 = link_to(user_show_path(user)) do
                   = display_name(user)
 


### PR DESCRIPTION
Adjusts typography

**Before:**

![Screenshot-2019-8-19 Open Build Service(2)](https://user-images.githubusercontent.com/2581944/63277610-ed693c00-c2a5-11e9-9e30-2727e3476730.png)

**After:**
![Screenshot-2019-8-20 Open Build Service(6)](https://user-images.githubusercontent.com/2581944/63358452-5797e480-c36b-11e9-85fc-95ab5fdc0f36.png)


And also sets the same width for all the boxes:

**Before:**

![group_members_beforee](https://user-images.githubusercontent.com/2581944/63358193-f112c680-c36a-11e9-8c09-a7e349855315.gif)


**After:**

![group_members_after](https://user-images.githubusercontent.com/2581944/63358216-fb34c500-c36a-11e9-9b02-0bc6499074da.gif)
