### PR TITLE
Deal with long words properly in all browsers

### DIFF
--- a/src/api/app/assets/stylesheets/webui2/requests.scss
+++ b/src/api/app/assets/stylesheets/webui2/requests.scss
@@ -31,3 +31,9 @@
 .request-flag-declined {
   @extend .text-danger;
 }
+
+#request-history {
+  .media .media-body {
+    @extend .text-break;
+  }
+}


### PR DESCRIPTION
When a comment in the request history is too long, it was floating out of the media-body. 

I set the `max-width` to 30ch to be proportional to the comments section.

![Screenshot_2019-08-20_09-10-10](https://user-images.githubusercontent.com/37418/63325657-e0daf700-c32a-11e9-829a-52e637d55da2.png)


Fixes #8130