### PR TITLE
Fix clearfix class in login form

### DIFF
--- a/src/api/app/views/layouts/webui2/_login_form.html.haml
+++ b/src/api/app/views/layouts/webui2/_login_form.html.haml
@@ -19,5 +19,4 @@
           = label_tag(:password, 'Password', class: 'text-light')
           = password_field_tag(:password, nil, placeholder: 'Password', required: true, class: 'form-control')
         .clearfix
-          .float-right
-            = submit_tag('Log In', class: 'btn btn-success')
+          = submit_tag('Log In', class: 'btn btn-success float-right')

--- a/src/api/app/views/layouts/webui2/_login_form.html.haml
+++ b/src/api/app/views/layouts/webui2/_login_form.html.haml
@@ -18,6 +18,6 @@
         .form-group
           = label_tag(:password, 'Password', class: 'text-light')
           = password_field_tag(:password, nil, placeholder: 'Password', required: true, class: 'form-control')
-        .float-right
-          = submit_tag('Log In', class: 'btn btn-success')
         .clearfix
+          .float-right
+            = submit_tag('Log In', class: 'btn btn-success')


### PR DESCRIPTION
We want to use the `clearfix` CSS class as it is described in the [Bootstrap documentation](https://getbootstrap.com/docs/4.3/utilities/clearfix/):

> Easily clear floats by adding `.clearfix` **to the parent element**.

It is also included a little refactoring related to the submit button.