### PR TITLE
Typography - User/Group Tasks

### DIFF
--- a/src/api/app/assets/stylesheets/webui2/datatables.scss
+++ b/src/api/app/assets/stylesheets/webui2/datatables.scss
@@ -26,6 +26,6 @@ table.dataTable.table-sm {
 
   td { 
     white-space: normal !important;
-    word-break: break-all;
+    @extend .text-break;
   }
 }


### PR DESCRIPTION
Deal with long words properly in all browsers

Before:
![before](https://user-images.githubusercontent.com/1102934/63349940-bdc93b00-c35c-11e9-9709-1d1556cfca95.png)

After:
![after](https://user-images.githubusercontent.com/1102934/63349930-bb66e100-c35c-11e9-891d-cd91580dead9.png)

