### PR TITLE
Remove zebra striped rows from datatables 

### DIFF
--- a/src/api/app/assets/stylesheets/webui2/bootstrap_variables/tables.scss
+++ b/src/api/app/assets/stylesheets/webui2/bootstrap_variables/tables.scss
@@ -1,2 +1,0 @@
-// For better contrast in tables using .table-striped
-$table-accent-bg: $gray-300;

--- a/src/api/app/assets/stylesheets/webui2/webui2.css.scss
+++ b/src/api/app/assets/stylesheets/webui2/webui2.css.scss
@@ -16,7 +16,6 @@
 @import 'bootstrap_variables/colors';
 @import 'bootstrap_variables/spacers';
 @import 'bootstrap_variables/fonts';
-@import 'bootstrap_variables/tables';
 @import 'bootstrap';
 @import 'bootstrap-modal';
 @import "font-awesome-sprockets";

--- a/src/api/app/views/webui2/shared/_patchinfos_table.html.haml
+++ b/src/api/app/views/webui2/shared/_patchinfos_table.html.haml
@@ -1,4 +1,4 @@
-%table.responsive.table.table-sm.table-bordered.w-100#open-patchinfos-table{ title: 'Running Maintenance Updates' }
+%table.responsive.table.table-sm.table-bordered.table-hover.w-100#open-patchinfos-table{ title: 'Running Maintenance Updates' }
   %thead
     %tr
       %th Project

--- a/src/api/app/views/webui2/shared/_patchinfos_table.html.haml
+++ b/src/api/app/views/webui2/shared/_patchinfos_table.html.haml
@@ -1,4 +1,4 @@
-%table.responsive.table.table-sm.table-striped.table-bordered.w-100#open-patchinfos-table{ title: 'Running Maintenance Updates' }
+%table.responsive.table.table-sm.table-bordered.w-100#open-patchinfos-table{ title: 'Running Maintenance Updates' }
   %thead
     %tr
       %th Project

--- a/src/api/app/views/webui2/shared/_requests_table.html.haml
+++ b/src/api/app/views/webui2/shared/_requests_table.html.haml
@@ -1,4 +1,4 @@
-%table.responsive.requests-datatable.table.table-sm.table-striped.table-bordered.w-100{ data: { source: source_url,
+%table.responsive.requests-datatable.table.table-sm.table-bordered.w-100{ data: { source: source_url,
   'page-length': local_assigns[:page_length] }, id: id }
   %thead
     %tr

--- a/src/api/app/views/webui2/shared/_requests_table.html.haml
+++ b/src/api/app/views/webui2/shared/_requests_table.html.haml
@@ -1,4 +1,4 @@
-%table.responsive.requests-datatable.table.table-sm.table-bordered.w-100{ data: { source: source_url,
+%table.responsive.requests-datatable.table.table-sm.table-bordered.table-hover.w-100{ data: { source: source_url,
   'page-length': local_assigns[:page_length] }, id: id }
   %thead
     %tr

--- a/src/api/app/views/webui2/shared/user_or_groups_roles/_index.html.haml
+++ b/src/api/app/views/webui2/shared/user_or_groups_roles/_index.html.haml
@@ -15,7 +15,7 @@
 #involved-users{ data: data }
   - if users.present?
     %h3 User Roles
-    %table.responsive.table.table-sm.table-bordered.w-100#user-table
+    %table.responsive.table.table-sm.table-bordered.table-hover.w-100#user-table
       %thead
         %tr
           %td Username
@@ -41,7 +41,7 @@
 
   - if @groups.present?
     %h3 Group Roles
-    %table.responsive.table.table-sm.table-bordered.w-100#group-table
+    %table.responsive.table.table-sm.table-bordered.table-hover.w-100#group-table
       %thead
         %tr
           %td Group name

--- a/src/api/app/views/webui2/shared/user_or_groups_roles/_index.html.haml
+++ b/src/api/app/views/webui2/shared/user_or_groups_roles/_index.html.haml
@@ -15,7 +15,7 @@
 #involved-users{ data: data }
   - if users.present?
     %h3 User Roles
-    %table.responsive.table.table-sm.table-striped.table-bordered.w-100#user-table
+    %table.responsive.table.table-sm.table-bordered.w-100#user-table
       %thead
         %tr
           %td Username
@@ -41,7 +41,7 @@
 
   - if @groups.present?
     %h3 Group Roles
-    %table.responsive.table.table-sm.table-striped.table-bordered.w-100#group-table
+    %table.responsive.table.table-sm.table-bordered.w-100#group-table
       %thead
         %tr
           %td Group name

--- a/src/api/app/views/webui2/webui/attribute/index.html.haml
+++ b/src/api/app/views/webui2/webui/attribute/index.html.haml
@@ -7,7 +7,7 @@
   .card-body
     %h3= @pagetitle
     - if @attributes.present?
-      %table.responsive.table.table-striped.table-bordered.w-100#attributes
+      %table.responsive.table.table-bordered.w-100#attributes
         %thead
           %tr
             %th Attributes

--- a/src/api/app/views/webui2/webui/attribute/index.html.haml
+++ b/src/api/app/views/webui2/webui/attribute/index.html.haml
@@ -7,7 +7,7 @@
   .card-body
     %h3= @pagetitle
     - if @attributes.present?
-      %table.responsive.table.table-bordered.w-100#attributes
+      %table.responsive.table.table-bordered.table-hover.w-100#attributes
         %thead
           %tr
             %th Attributes

--- a/src/api/app/views/webui2/webui/cloud/upload_jobs/index.html.haml
+++ b/src/api/app/views/webui2/webui/cloud/upload_jobs/index.html.haml
@@ -9,7 +9,7 @@
     %br
 
     %p
-      %table.responsive.table.table-sm.table-striped.table-bordered#upload-jobs
+      %table.responsive.table.table-sm.table-bordered#upload-jobs
         %thead
           %tr
             %th #

--- a/src/api/app/views/webui2/webui/cloud/upload_jobs/index.html.haml
+++ b/src/api/app/views/webui2/webui/cloud/upload_jobs/index.html.haml
@@ -9,7 +9,7 @@
     %br
 
     %p
-      %table.responsive.table.table-sm.table-bordered#upload-jobs
+      %table.responsive.table.table-sm.table-bordered.table-hover#upload-jobs
         %thead
           %tr
             %th #

--- a/src/api/app/views/webui2/webui/groups/index.html.haml
+++ b/src/api/app/views/webui2/webui/groups/index.html.haml
@@ -4,7 +4,7 @@
   = render partial: 'webui/configuration/tabs'
   .card-body
     %h3= @pagetitle
-    %table.responsive.table.table-sm.table-bordered.w-100#manage-groups-table
+    %table.responsive.table.table-sm.table-bordered.table-hover.w-100#manage-groups-table
       %thead
         %tr
           %th Group Name

--- a/src/api/app/views/webui2/webui/groups/index.html.haml
+++ b/src/api/app/views/webui2/webui/groups/index.html.haml
@@ -4,7 +4,7 @@
   = render partial: 'webui/configuration/tabs'
   .card-body
     %h3= @pagetitle
-    %table.responsive.table.table-sm.table-striped.table-bordered.w-100#manage-groups-table
+    %table.responsive.table.table-sm.table-bordered.w-100#manage-groups-table
       %thead
         %tr
           %th Group Name

--- a/src/api/app/views/webui2/webui/monitor/_building_table.html.haml
+++ b/src/api/app/views/webui2/webui/monitor/_building_table.html.haml
@@ -1,7 +1,7 @@
 #building-list
   - if worker_status.key?('building')
     .table-responsive
-      %table.table.table-sm.table-bordered.w-100#building-table
+      %table.table.table-sm.table-bordered.table-hover.w-100#building-table
         %thead
           %tr
             %th Project

--- a/src/api/app/views/webui2/webui/monitor/_building_table.html.haml
+++ b/src/api/app/views/webui2/webui/monitor/_building_table.html.haml
@@ -1,7 +1,7 @@
 #building-list
   - if worker_status.key?('building')
     .table-responsive
-      %table.table.table-sm.table-striped.table-bordered.w-100#building-table
+      %table.table.table-sm.table-bordered.w-100#building-table
         %thead
           %tr
             %th Project

--- a/src/api/app/views/webui2/webui/monitor/_idle.html.haml
+++ b/src/api/app/views/webui2/webui/monitor/_idle.html.haml
@@ -9,7 +9,7 @@
     %p
       = idle_hosts.size
       of #{pluralize(worker_status['clients'], 'host')} idle.
-    %table.responsive.table.table-sm.table-striped.table-bordered
+    %table.responsive.table.table-sm.table-bordered
       %thead
         %tr
           %th Host

--- a/src/api/app/views/webui2/webui/monitor/_idle.html.haml
+++ b/src/api/app/views/webui2/webui/monitor/_idle.html.haml
@@ -9,7 +9,7 @@
     %p
       = idle_hosts.size
       of #{pluralize(worker_status['clients'], 'host')} idle.
-    %table.responsive.table.table-sm.table-bordered
+    %table.responsive.table.table-sm.table-bordered.table-hover
       %thead
         %tr
           %th Host

--- a/src/api/app/views/webui2/webui/monitor/_stats.html.haml
+++ b/src/api/app/views/webui2/webui/monitor/_stats.html.haml
@@ -2,7 +2,7 @@
   %p
     %i No scheduler statistics
 - else
-  %table.responsive.table.table-sm.table-bordered
+  %table.responsive.table.table-sm.table-bordered.table-hover
     %thead
       %tr
         %th Host Arch

--- a/src/api/app/views/webui2/webui/monitor/_stats.html.haml
+++ b/src/api/app/views/webui2/webui/monitor/_stats.html.haml
@@ -2,7 +2,7 @@
   %p
     %i No scheduler statistics
 - else
-  %table.responsive.table.table-sm.table-striped.table-bordered
+  %table.responsive.table.table-sm.table-bordered
     %thead
       %tr
         %th Host Arch

--- a/src/api/app/views/webui2/webui/package/_deps.html.haml
+++ b/src/api/app/views/webui2/webui/package/_deps.html.haml
@@ -1,7 +1,7 @@
 .row
   .table-responsive.col-sm-12.col-md-6.mt-4
     %h4 Provides
-    %table.table.table-striped.table-bordered.table-sm
+    %table.table.table-bordered.table-sm
       %thead
         %tr
           %th.w-75 Symbol
@@ -30,7 +30,7 @@
 
   .table-responsive.col-sm-12.col-md-6.mt-4
     %h4 Requires
-    %table.table.table-striped.table-bordered.table-sm
+    %table.table.table-bordered.table-sm
       %thead
         %tr
           %th.w-75 Symbol
@@ -59,7 +59,7 @@
 
   .table-responsive.col-sm-12.col-md-6.mt-4
     %h4 Recommends
-    %table.table.table-striped.table-bordered.table-sm
+    %table.table.table-bordered.table-sm
       %thead
         %tr
           %th.w-75 Symbol

--- a/src/api/app/views/webui2/webui/package/_deps.html.haml
+++ b/src/api/app/views/webui2/webui/package/_deps.html.haml
@@ -1,7 +1,7 @@
 .row
   .table-responsive.col-sm-12.col-md-6.mt-4
     %h4 Provides
-    %table.table.table-bordered.table-sm
+    %table.table.table-bordered.table-hover.table-sm
       %thead
         %tr
           %th.w-75 Symbol
@@ -30,7 +30,7 @@
 
   .table-responsive.col-sm-12.col-md-6.mt-4
     %h4 Requires
-    %table.table.table-bordered.table-sm
+    %table.table.table-bordered.table-hover.table-sm
       %thead
         %tr
           %th.w-75 Symbol
@@ -59,7 +59,7 @@
 
   .table-responsive.col-sm-12.col-md-6.mt-4
     %h4 Recommends
-    %table.table.table-bordered.table-sm
+    %table.table.table-bordered.table-hover.table-sm
       %thead
         %tr
           %th.w-75 Symbol

--- a/src/api/app/views/webui2/webui/package/_files_view.html.haml
+++ b/src/api/app/views/webui2/webui/package/_files_view.html.haml
@@ -2,7 +2,7 @@
 
 .card-body
   - if files.present?
-    %table.table.table-bordered.table-sm.dt-responsive.w-100#files-table
+    %table.table.table-bordered.table-hover.table-sm.dt-responsive.w-100#files-table
       %thead
         %tr
           %th Filename

--- a/src/api/app/views/webui2/webui/package/_files_view.html.haml
+++ b/src/api/app/views/webui2/webui/package/_files_view.html.haml
@@ -2,7 +2,7 @@
 
 .card-body
   - if files.present?
-    %table.table.table-striped.table-bordered.table-sm.dt-responsive.w-100#files-table
+    %table.table.table-bordered.table-sm.dt-responsive.w-100#files-table
       %thead
         %tr
           %th Filename

--- a/src/api/app/views/webui2/webui/packages/build_reason/index.html.haml
+++ b/src/api/app/views/webui2/webui/packages/build_reason/index.html.haml
@@ -23,7 +23,7 @@
           %strong
             #{@package.name}.
         .table-responsive
-          %table.table.table-sm.table-striped.table-bordered#changed-packages
+          %table.table.table-sm.table-bordered#changed-packages
             %thead
               %tr
                 %th Package

--- a/src/api/app/views/webui2/webui/packages/build_reason/index.html.haml
+++ b/src/api/app/views/webui2/webui/packages/build_reason/index.html.haml
@@ -23,7 +23,7 @@
           %strong
             #{@package.name}.
         .table-responsive
-          %table.table.table-sm.table-bordered#changed-packages
+          %table.table.table-sm.table-bordered.table-hover#changed-packages
             %thead
               %tr
                 %th Package

--- a/src/api/app/views/webui2/webui/packages/job_history/index.html.haml
+++ b/src/api/app/views/webui2/webui/packages/job_history/index.html.haml
@@ -9,7 +9,7 @@
     %h6.subtitle
       Repository / Architecture: #{params[:repository]} / #{params[:arch]}
 
-    %table.responsive.table.table-sm.table-striped.table-bordered.w-100#jobhistory-table
+    %table.responsive.table.table-sm.table-bordered.w-100#jobhistory-table
       %thead
         %th Revision
         %th Time (not formatted)

--- a/src/api/app/views/webui2/webui/packages/job_history/index.html.haml
+++ b/src/api/app/views/webui2/webui/packages/job_history/index.html.haml
@@ -9,7 +9,7 @@
     %h6.subtitle
       Repository / Architecture: #{params[:repository]} / #{params[:arch]}
 
-    %table.responsive.table.table-sm.table-bordered.w-100#jobhistory-table
+    %table.responsive.table.table-sm.table-bordered.table-hover.w-100#jobhistory-table
       %thead
         %th Revision
         %th Time (not formatted)

--- a/src/api/app/views/webui2/webui/project/_project_inherited_packages.html.haml
+++ b/src/api/app/views/webui2/webui/project/_project_inherited_packages.html.haml
@@ -1,7 +1,7 @@
 .card-body
   - if inherited_packages.present?
     .obs-dataTable
-      %table.table.table-sm.table-fixed.table-bordered#inherited-packages-table
+      %table.table.table-sm.table-fixed.table-bordered.table-hover#inherited-packages-table
         %thead
           %tr
             %th.w-75 Name

--- a/src/api/app/views/webui2/webui/project/_project_inherited_packages.html.haml
+++ b/src/api/app/views/webui2/webui/project/_project_inherited_packages.html.haml
@@ -1,7 +1,7 @@
 .card-body
   - if inherited_packages.present?
     .obs-dataTable
-      %table.table.table-sm.table-fixed.table-striped.table-bordered#inherited-packages-table
+      %table.table.table-sm.table-fixed.table-bordered#inherited-packages-table
         %thead
           %tr
             %th.w-75 Name

--- a/src/api/app/views/webui2/webui/project/_project_packages.html.haml
+++ b/src/api/app/views/webui2/webui/project/_project_packages.html.haml
@@ -1,7 +1,7 @@
 .card-body
   - if packages.present?
     .obs-dataTable
-      %table.table.table-sm.table-striped.table-bordered.w-100#packages-table{ data: { source: package_index_path(project: project) } }
+      %table.table.table-sm.table-bordered.w-100#packages-table{ data: { source: package_index_path(project: project) } }
         %thead
           %tr
             %th.w-75 Name

--- a/src/api/app/views/webui2/webui/project/_project_packages.html.haml
+++ b/src/api/app/views/webui2/webui/project/_project_packages.html.haml
@@ -1,7 +1,7 @@
 .card-body
   - if packages.present?
     .obs-dataTable
-      %table.table.table-sm.table-bordered.w-100#packages-table{ data: { source: package_index_path(project: project) } }
+      %table.table.table-sm.table-bordered.table-hover.w-100#packages-table{ data: { source: package_index_path(project: project) } }
         %thead
           %tr
             %th.w-75 Name

--- a/src/api/app/views/webui2/webui/project/_projects_table.html.haml
+++ b/src/api/app/views/webui2/webui/project/_projects_table.html.haml
@@ -1,6 +1,6 @@
 %h3 #{table_title.pluralize} of #{project}
 - table_id = table_title.tr(' ', '_')
-%table.responsive.table.table-sm.table-striped.table-bordered.w-100{ data: { source: project_subprojects_path(project,
+%table.responsive.table.table-sm.table-bordered.w-100{ data: { source: project_subprojects_path(project,
   type: table_title.downcase) }, id: table_id }
   %thead
     %tr

--- a/src/api/app/views/webui2/webui/project/_projects_table.html.haml
+++ b/src/api/app/views/webui2/webui/project/_projects_table.html.haml
@@ -1,6 +1,6 @@
 %h3 #{table_title.pluralize} of #{project}
 - table_id = table_title.tr(' ', '_')
-%table.responsive.table.table-sm.table-bordered.w-100{ data: { source: project_subprojects_path(project,
+%table.responsive.table.table-sm.table-bordered.table-hover.w-100{ data: { source: project_subprojects_path(project,
   type: table_title.downcase) }, id: table_id }
   %thead
     %tr

--- a/src/api/app/views/webui2/webui/project/bottom_actions/_gpg_key_ssl_certificate.html.haml
+++ b/src/api/app/views/webui2/webui/project/bottom_actions/_gpg_key_ssl_certificate.html.haml
@@ -10,7 +10,7 @@
           %h5.modal-title#gpgp-key-modal-label #{project} keys
         .modal-body
           .table-responsive
-            %table.table.table-sm.table-bordered
+            %table.table.table-sm.table-bordered.table-hover
               %thead
                 %tr
                   %th Size
@@ -35,7 +35,7 @@
                     %td= project.key_info.origin
 
           .table-responsive
-            %table.table.table-sm.table-bordered
+            %table.table.table-sm.table-bordered.table-hover
               %thead
                 %tr
                   %th Fingerprint

--- a/src/api/app/views/webui2/webui/project/bottom_actions/_gpg_key_ssl_certificate.html.haml
+++ b/src/api/app/views/webui2/webui/project/bottom_actions/_gpg_key_ssl_certificate.html.haml
@@ -10,7 +10,7 @@
           %h5.modal-title#gpgp-key-modal-label #{project} keys
         .modal-body
           .table-responsive
-            %table.table.table-sm.table-striped.table-bordered
+            %table.table.table-sm.table-bordered
               %thead
                 %tr
                   %th Size
@@ -35,7 +35,7 @@
                     %td= project.key_info.origin
 
           .table-responsive
-            %table.table.table-sm.table-striped.table-bordered
+            %table.table.table-sm.table-bordered
               %thead
                 %tr
                   %th Fingerprint

--- a/src/api/app/views/webui2/webui/project/index.html.haml
+++ b/src/api/app/views/webui2/webui/project/index.html.haml
@@ -5,7 +5,7 @@
     .card-body
       %h3 Main Projects
       .table-responsive
-        %table.table.table-sm.table-bordered
+        %table.table.table-sm.table-bordered.table-hover
           %thead
             %tr
               %th Name
@@ -32,8 +32,8 @@
             Add New Project
           = render partial: 'new_project_modal', locals: { configuration: @configuration }
 
-    %table.responsive.table.table-sm.table-hover.table-bordered.w-100#projects-datatable{ data: { source: projects_path(format: :json),
-                                                                                                    all: 'false' } }
+    %table.responsive.table.table-sm.table-bordered.table-hover.w-100#projects-datatable{ data: { source: projects_path(format: :json),
+                                                                                                  all: 'false' } }
       %thead
         %tr
           %th Name

--- a/src/api/app/views/webui2/webui/project/index.html.haml
+++ b/src/api/app/views/webui2/webui/project/index.html.haml
@@ -5,7 +5,7 @@
     .card-body
       %h3 Main Projects
       .table-responsive
-        %table.table.table-sm.table-striped.table-bordered
+        %table.table.table-sm.table-bordered
           %thead
             %tr
               %th Name
@@ -32,7 +32,7 @@
             Add New Project
           = render partial: 'new_project_modal', locals: { configuration: @configuration }
 
-    %table.responsive.table.table-sm.table-striped.table-bordered.w-100#projects-datatable{ data: { source: projects_path(format: :json),
+    %table.responsive.table.table-sm.table-hover.table-bordered.w-100#projects-datatable{ data: { source: projects_path(format: :json),
                                                                                                     all: 'false' } }
       %thead
         %tr

--- a/src/api/app/views/webui2/webui/project/monitor.html.haml
+++ b/src/api/app/views/webui2/webui/project/monitor.html.haml
@@ -15,7 +15,7 @@
       - tableinfo = []
       .row.mt-4
         .col-md-12.obs-dataTable.invisible
-          %table.table.table-sm.table-striped.table-bordered.text-nowrap#project-monitor-table
+          %table.table.table-sm.table-bordered.text-nowrap#project-monitor-table
             %thead.header
               %tr
                 %th

--- a/src/api/app/views/webui2/webui/project/monitor.html.haml
+++ b/src/api/app/views/webui2/webui/project/monitor.html.haml
@@ -15,7 +15,7 @@
       - tableinfo = []
       .row.mt-4
         .col-md-12.obs-dataTable.invisible
-          %table.table.table-sm.table-bordered.text-nowrap#project-monitor-table
+          %table.table.table-sm.table-bordered.table-hover.text-nowrap#project-monitor-table
             %thead.header
               %tr
                 %th

--- a/src/api/app/views/webui2/webui/project/status.html.haml
+++ b/src/api/app/views/webui2/webui/project/status.html.haml
@@ -39,7 +39,7 @@
 
         - show_devel_project = @packages.any? { |p| p['develproject'].present? }
 
-        %table.responsive.table.table-sm.table-striped.table-bordered.w-100#status-table
+        %table.responsive.table.table-sm.table-bordered.w-100#status-table
           %thead
             %tr
               %th

--- a/src/api/app/views/webui2/webui/project/status.html.haml
+++ b/src/api/app/views/webui2/webui/project/status.html.haml
@@ -39,7 +39,7 @@
 
         - show_devel_project = @packages.any? { |p| p['develproject'].present? }
 
-        %table.responsive.table.table-sm.table-bordered.w-100#status-table
+        %table.responsive.table.table-sm.table-bordered.table-hover.w-100#status-table
           %thead
             %tr
               %th

--- a/src/api/app/views/webui2/webui/projects/maintenance_incidents/index.html.haml
+++ b/src/api/app/views/webui2/webui/projects/maintenance_incidents/index.html.haml
@@ -9,7 +9,7 @@
         = @incidents.count
 
     -# haml-lint:disable MultilinePipe
-    %table.w-100.responsive.table.table-sm.table-striped.table-bordered#incident-table{ data: { |
+    %table.w-100.responsive.table.table-sm.table-bordered#incident-table{ data: { |
     source: project_maintenance_incidents_path(project_name: @project.name) } } |
       -# haml-lint:enable MultilinePipe
       %thead

--- a/src/api/app/views/webui2/webui/projects/maintenance_incidents/index.html.haml
+++ b/src/api/app/views/webui2/webui/projects/maintenance_incidents/index.html.haml
@@ -9,7 +9,7 @@
         = @incidents.count
 
     -# haml-lint:disable MultilinePipe
-    %table.w-100.responsive.table.table-sm.table-bordered#incident-table{ data: { |
+    %table.w-100.responsive.table.table-sm.table-bordered.table-hover#incident-table{ data: { |
     source: project_maintenance_incidents_path(project_name: @project.name) } } |
       -# haml-lint:enable MultilinePipe
       %thead

--- a/src/api/app/views/webui2/webui/staging/excluded_requests/index.html.haml
+++ b/src/api/app/views/webui2/webui/staging/excluded_requests/index.html.haml
@@ -5,7 +5,7 @@
       .card-body
         %h3 Excluded Requests
         -# haml-lint:disable MultilinePipe
-        %table.responsive.table.table-sm.table-striped.table-bordered.w-100#excluded-requests-datatable{ |
+        %table.responsive.table.table-sm.table-bordered.w-100#excluded-requests-datatable{ |
         data: excluded_requests_remote_url(@staging_workflow.id) } |
           -# haml-lint:enable MultilinePipe
           %thead

--- a/src/api/app/views/webui2/webui/staging/excluded_requests/index.html.haml
+++ b/src/api/app/views/webui2/webui/staging/excluded_requests/index.html.haml
@@ -5,7 +5,7 @@
       .card-body
         %h3 Excluded Requests
         -# haml-lint:disable MultilinePipe
-        %table.responsive.table.table-sm.table-bordered.w-100#excluded-requests-datatable{ |
+        %table.responsive.table.table-sm.table-bordered.table-hover.w-100#excluded-requests-datatable{ |
         data: excluded_requests_remote_url(@staging_workflow.id) } |
           -# haml-lint:enable MultilinePipe
           %thead

--- a/src/api/app/views/webui2/webui/staging/projects/show.html.haml
+++ b/src/api/app/views/webui2/webui/staging/projects/show.html.haml
@@ -13,7 +13,7 @@
     .card.mb-3
       %h5.card-header Status
       .card-body
-        %table.table.table-striped.table-borderless.table-sm.dt-responsive.w-100
+        %table.table.table-borderless.table-sm.dt-responsive.w-100
           %tbody
             %tr
               = render partial: 'status_items',

--- a/src/api/app/views/webui2/webui/staging/workflows/_staging_projects_table.html.haml
+++ b/src/api/app/views/webui2/webui/staging/workflows/_staging_projects_table.html.haml
@@ -1,4 +1,4 @@
-%table.table.table-bordered.table-sm.dt-responsive.w-100#staging-projects-datatable
+%table.table.table-bordered.table-hover.table-sm.dt-responsive.w-100#staging-projects-datatable
   %thead
     %tr.text-center
       %th Staging Project

--- a/src/api/app/views/webui2/webui/staging/workflows/_staging_projects_table.html.haml
+++ b/src/api/app/views/webui2/webui/staging/workflows/_staging_projects_table.html.haml
@@ -1,4 +1,4 @@
-%table.table.table-striped.table-bordered.table-sm.dt-responsive.w-100#staging-projects-datatable
+%table.table.table-bordered.table-sm.dt-responsive.w-100#staging-projects-datatable
   %thead
     %tr.text-center
       %th Staging Project

--- a/src/api/app/views/webui2/webui/user/_involvement.html.haml
+++ b/src/api/app/views/webui2/webui/user/_involvement.html.haml
@@ -30,7 +30,7 @@
           %p.md-3
             #{user.name} is not involved in any packages
         - else
-          %table.table.table-sm.table-fixed.table-striped.table-bordered#involved-packages-table
+          %table.table.table-sm.table-fixed.table-bordered#involved-packages-table
             %thead
               %tr
                 %th Package
@@ -48,7 +48,7 @@
           %p.mt-3
             #{user.name} is not involved in any project
         - else
-          %table.table.table-sm.table-fixed.table-striped.table-bordered#involved-projects-table
+          %table.table.table-sm.table-fixed.table-bordered#involved-projects-table
             %thead
               %tr
                 %th Name
@@ -66,7 +66,7 @@
           %p.mt-3
             #{user.name} doesn't own any project or package
         - else
-          %table.table.table-sm.table-fixed.table-striped.table-bordered#owned-table
+          %table.table.table-sm.table-fixed.table-bordered#owned-table
             %thead
               %tr
                 %th Package

--- a/src/api/app/views/webui2/webui/user/_involvement.html.haml
+++ b/src/api/app/views/webui2/webui/user/_involvement.html.haml
@@ -30,7 +30,7 @@
           %p.md-3
             #{user.name} is not involved in any packages
         - else
-          %table.table.table-sm.table-fixed.table-bordered#involved-packages-table
+          %table.table.table-sm.table-fixed.table-bordered.table-hover#involved-packages-table
             %thead
               %tr
                 %th Package
@@ -48,7 +48,7 @@
           %p.mt-3
             #{user.name} is not involved in any project
         - else
-          %table.table.table-sm.table-fixed.table-bordered#involved-projects-table
+          %table.table.table-sm.table-fixed.table-bordered.table-hover#involved-projects-table
             %thead
               %tr
                 %th Name
@@ -66,7 +66,7 @@
           %p.mt-3
             #{user.name} doesn't own any project or package
         - else
-          %table.table.table-sm.table-fixed.table-bordered#owned-table
+          %table.table.table-sm.table-fixed.table-bordered.table-hover#owned-table
             %thead
               %tr
                 %th Package

--- a/src/api/app/views/webui2/webui/user/index.html.haml
+++ b/src/api/app/views/webui2/webui/user/index.html.haml
@@ -4,7 +4,7 @@
   = render partial: 'webui/configuration/tabs'
   .card-body
     %h3= @pagetitle
-    %table.responsive.table.table-sm.table-striped.table-bordered#user-table{ data: { source: users_path } }
+    %table.responsive.table.table-sm.table-bordered#user-table{ data: { source: users_path } }
       %thead
         %tr
           %th

--- a/src/api/app/views/webui2/webui/user/index.html.haml
+++ b/src/api/app/views/webui2/webui/user/index.html.haml
@@ -4,7 +4,7 @@
   = render partial: 'webui/configuration/tabs'
   .card-body
     %h3= @pagetitle
-    %table.responsive.table.table-sm.table-bordered#user-table{ data: { source: users_path } }
+    %table.responsive.table.table-sm.table-bordered.table-hover#user-table{ data: { source: users_path } }
       %thead
         %tr
           %th


### PR DESCRIPTION
People with limited color vision have issues to read
colored text/items on the stronger gray of the zebra striped
tables.

Fixes #8116

**Before**
![Screenshot-2019-8-21 Open Build Service(1)](https://user-images.githubusercontent.com/22001671/63432825-37772c80-c422-11e9-8297-5ae122149747.png)

**After**
![Screenshot-2019-8-21 Open Build Service](https://user-images.githubusercontent.com/22001671/63432837-4067fe00-c422-11e9-812a-6a568e2e1f51.png)

I would suggest to make the zebra effect a bit lighter. Incase people still having issues to read the content, we still can remove it completly.

Here some interesting article regarding this topic:
https://alistapart.com/article/zebrastripingdoesithelp/

I added a hover effect to the datatables, this makes it easier to keep track of the currently selected row. 
