### PR TITLE
Syntax highlighting in the comments

### DIFF
--- a/src/api/app/assets/stylesheets/webui2/coderay.scss
+++ b/src/api/app/assets/stylesheets/webui2/coderay.scss
@@ -1,131 +1,93 @@
-.CodeRay {
-  background-color:#fff;
-  border: 1px solid silver;
-  color: black;
+.CodeRay, .CodeRay .change {
+  background: $card-bg;
+  color: $body-color;
 }
-.CodeRay pre {
-  margin: 0px;
-}
-
-span.CodeRay { white-space: pre; border: 0px; padding: 2px; }
-
-table.CodeRay { border-collapse: collapse; width: 100%; padding: 2px; }
-table.CodeRay td { padding: 2px 4px; vertical-align: top; }
+.CodeRay pre { margin: 0 }
+span.CodeRay { white-space: pre }
 
 .CodeRay .line-numbers {
-  background-color: hsl(180,65%,90%);
-  color: gray;
-  text-align: right;
-  -webkit-user-select: none;
-  -moz-user-select: none;
-  user-select: none;
+  display: inline-block;
+  background: opacify( mix( $card-bg, opacify( $card-cap-bg, 1 ), ( 1 - alpha( $card-cap-bg ) ) * 100% ), 1 );
+  border-right: $card-border-width solid $card-border-color;
 }
-.CodeRay .line-numbers a {
-  background-color: hsl(180,65%,90%) !important;
-  color: gray !important;
-  text-decoration: none !important;
-}
+
 .CodeRay .line-numbers pre {
   word-break: normal;
 }
-.CodeRay .line-numbers a:target { color: blue !important; }
-.CodeRay .line-numbers .highlighted { color: red !important; }
-.CodeRay .line-numbers .highlighted a { color: red !important; }
-.CodeRay span.line-numbers { padding: 0px 4px; }
-.CodeRay .line { width: 100%; }
-.CodeRay .code { width: 100%; }
+.CodeRay .line-numbers a {
+  color: $text-muted;
+  text-decoration: none;
+  display: inline-block;
+  padding: 0 0.25rem;
+}
+.CodeRay .line-numbers a:target {
+  background-color: rgba($warning, 0.3);
+  color: $body-color;
+}
 
-.CodeRay .debug { color: white !important; background: blue !important; }
+.CodeRay .line, .CodeRay .code { width: 100% }
+.CodeRay .line { padding-left: 0.25rem }
 
-.CodeRay .annotation { color:#007 }
-.CodeRay .attribute-name { color:#b48 }
-.CodeRay .attribute-value { color:#700 }
-.CodeRay .binary { color:#549 }
-.CodeRay .binary .char { color:#325 }
-.CodeRay .binary .delimiter { color:#325 }
-.CodeRay .char { color:#D20 }
-.CodeRay .char .content { color:#D20 }
-.CodeRay .char .delimiter { color:#710 }
-.CodeRay .class { color:#B06; font-weight:bold }
-.CodeRay .class-variable { color:#369 }
-.CodeRay .color { color:#0A0 }
-.CodeRay .comment { color:#777 }
-.CodeRay .comment .char { color:#444 }
-.CodeRay .comment .delimiter { color:#444 }
-.CodeRay .constant { color:#036; font-weight:bold }
-.CodeRay .decorator { color:#B0B }
-.CodeRay .definition { color:#099; font-weight:bold }
-.CodeRay .delimiter { color:black }
-.CodeRay .directive { color:#088; font-weight:bold }
-.CodeRay .docstring { color:#D42; }
-.CodeRay .doctype { color:#34b }
-.CodeRay .done { text-decoration: line-through; color: gray }
-.CodeRay .entity { color:#800; font-weight:bold }
-.CodeRay .error { color:#F00; background-color:#FAA }
-.CodeRay .escape  { color:#666 }
-.CodeRay .exception { color:#C00; font-weight:bold }
-.CodeRay .float { color:#60E }
-.CodeRay .function { color:#06B; font-weight:bold }
-.CodeRay .function .delimiter { color:#059 }
-.CodeRay .function .content { color:#037 }
-.CodeRay .global-variable { color:#d70 }
-.CodeRay .hex { color:#02b }
-.CodeRay .id  { color:#33D; font-weight:bold }
-.CodeRay .include { color:#B44; font-weight:bold }
-.CodeRay .inline { background-color: hsla(0,0%,0%,0.07); color: black }
-.CodeRay .inline-delimiter { font-weight: bold; color: #666 }
-.CodeRay .instance-variable { color:#33B }
-.CodeRay .integer  { color:#00D }
-.CodeRay .imaginary { color:#f00 }
-.CodeRay .important { color:#D00 }
-.CodeRay .key { color: #606 }
-.CodeRay .key .char { color: #60f }
-.CodeRay .key .delimiter { color: #404 }
-.CodeRay .keyword { color:#080; font-weight:bold }
-.CodeRay .label { color:#970; font-weight:bold }
-.CodeRay .local-variable { color:#950 }
-.CodeRay .map .content { color:#808 }
-.CodeRay .map .delimiter { color:#40A}
-.CodeRay .map { background-color:hsla(200,100%,50%,0.06); }
-.CodeRay .namespace { color:#707; font-weight:bold }
-.CodeRay .octal { color:#40E }
-.CodeRay .operator { }
-.CodeRay .predefined { color:#369; font-weight:bold }
-.CodeRay .predefined-constant { color:#069 }
-.CodeRay .predefined-type { color:#0a8; font-weight:bold }
-.CodeRay .preprocessor { color:#579 }
-.CodeRay .pseudo-class { color:#00C; font-weight:bold }
-.CodeRay .regexp { background-color:hsla(300,100%,50%,0.06); }
-.CodeRay .regexp .content { color:#808 }
-.CodeRay .regexp .delimiter { color:#404 }
-.CodeRay .regexp .modifier { color:#C2C }
-.CodeRay .reserved { color:#080; font-weight:bold }
-.CodeRay .shell { background-color:hsla(120,100%,50%,0.06); }
-.CodeRay .shell .content { color:#2B2 }
-.CodeRay .shell .delimiter { color:#161 }
-.CodeRay .string { background-color:hsla(0,100%,50%,0.05); }
-.CodeRay .string .char { color: #b0b }
-.CodeRay .string .content { color: #D20 }
-.CodeRay .string .delimiter { color: #710 }
-.CodeRay .string .modifier { color: #E40 }
-.CodeRay .symbol { color:#A60 }
-.CodeRay .symbol .content { color:#A60 }
-.CodeRay .symbol .delimiter { color:#740 }
-.CodeRay .tag { color:#070; font-weight:bold }
-.CodeRay .type { color:#339; font-weight:bold }
-.CodeRay .value { color: #088 }
-.CodeRay .variable { color:#037 }
+.CodeRay .debug { color: $card-bg; background: $blue }
 
-.CodeRay .insert { background: hsla(120,100%,50%,0.12) }
-.CodeRay .delete { background: hsla(0,100%,50%,0.12) }
-.CodeRay .change { color: rgb(0, 0, 0); background: rgb(255, 255, 255) }
-.CodeRay .head { color: #f8f; background: #505 }
-.CodeRay .head .filename { color: white; }
+.CodeRay .done, .CodeRay .comment, .CodeRay .escape,
+.CodeRay .inline-delimiter { color: $text-muted }
 
-.CodeRay .delete .eyecatcher { background-color: hsla(0,100%,50%,0.2); border: 1px solid hsla(0,100%,45%,0.5); margin: -1px; border-bottom: none; border-top-left-radius: 5px; border-top-right-radius: 5px; }
-.CodeRay .insert .eyecatcher { background-color: hsla(120,100%,50%,0.2); border: 1px solid hsla(120,100%,25%,0.5); margin: -1px; border-top: none; border-bottom-left-radius: 5px; border-bottom-right-radius: 5px; }
+.CodeRay .delimiter, .CodeRay .inline { color: $body-color }
 
-.CodeRay .insert .insert { color: #0c0; background:transparent; font-weight:bold }
-.CodeRay .delete .delete { color: #c00; background:transparent; font-weight:bold }
-.CodeRay .change .change { color: rgb(0, 0, 0) }
-.CodeRay .head .head { color: #f4f }
+.CodeRay .binary .char, .CodeRay .binary .delimiter,
+.CodeRay .map .content, .CodeRay .map .delimiter, .CodeRay .octal,
+.CodeRay .regexp .content, .CodeRay .head .head { color: $purple }
+
+.CodeRay .comment .char, .CodeRay .comment .delimiter,
+.CodeRay .done, .CodeRay .preprocessor { color: $dark }
+
+.CodeRay .char, .CodeRay .char .content, .CodeRay .attribute-value,
+.CodeRay .char .delimiter, .CodeRay .docstring,
+.CodeRay .entity, .CodeRay .string, .CodeRay .string .content,
+.CodeRay .global-variable, .CodeRay .imaginary, .CodeRay .important,
+.CodeRay .label, .CodeRay .local-variable,
+.CodeRay .string .delimiter, .CodeRay .line-numbers .highlighted,
+.CodeRay .line-numbers .highlighted a { color: $red }
+
+.CodeRay .error, .CodeRay .exception,
+.CodeRay .string .modifier { color: $danger }
+
+.CodeRay .annotation, .CodeRay .function, .CodeRay .predefined,
+.CodeRay .predefined-constant, .CodeRay .variable { color: $blue }
+
+.CodeRay .attribute-name, .CodeRay .keyword,
+.CodeRay .regexp .delimiter { color: $pink }
+
+.CodeRay .binary, .CodeRay .binary .char,
+.CodeRay .binary .delimiter, .CodeRay .constant,
+.CodeRay .regexp .modifier, .CodeRay .type { color: $indigo }
+
+.CodeRay .class, .CodeRay .class-variable, .CodeRay .color,
+.CodeRay .definition, .CodeRay .directive, .CodeRay .doctype,
+.CodeRay .float, .CodeRay .function .delimiter, .CodeRay .reserved,
+.CodeRay .shell .delimiter, .CodeRay .tag { color: $green }
+
+.CodeRay .function .content, .CodeRay .hex, .CodeRay .id,
+.CodeRay .instance-variable, .CodeRay .integer, .CodeRay .key .char,
+.CodeRay .pseudo-class, .CodeRay .shell .content { color: $success }
+
+.CodeRay .decorator, .CodeRay .key, .CodeRay .key .delimiter,
+.CodeRay .namespace, .CodeRay .symbol, .CodeRay .symbol .content { color: $yellow }
+
+.CodeRay .string .char, .CodeRay .include, .CodeRay .symbol .delimiter { color: $orange }
+
+.CodeRay .predefined-type, .CodeRay .shell, .CodeRay .value { color: $teal }
+
+.CodeRay .done { text-decoration: line-through }
+
+.CodeRay .insert { background: rgba($success, 0.1); display: inline-block }
+.CodeRay .delete { background: rgba($danger, 0.1); display: inline-block }
+.CodeRay .head { color: $light; background: $dark }
+
+.CodeRay .delete .eyecatcher { background-color: rgba($danger, 0.3) }
+.CodeRay .insert .eyecatcher { background-color: rgba($success, 0.3) }
+
+.CodeRay .insert .insert { color: $success; background: transparent }
+.CodeRay .delete .delete { color: $danger; background: transparent }
+.CodeRay .change .change { color: $body-color }

--- a/src/api/lib/obsapi/markdown_renderer.rb
+++ b/src/api/lib/obsapi/markdown_renderer.rb
@@ -33,5 +33,9 @@ module OBSApi
       end
       "<a href='#{link}'#{title}>#{content}</a>"
     end
+
+    def block_code(code, language)
+      CodeRay.scan(code, language).div(css: :class)
+    end
   end
 end


### PR DESCRIPTION
CSS fixes to:
* Bring the style of coderay to how the code looks in codemirror (it isn't the same, but as close as I could get it)
* Make diff styling nicer
![Screenshot from 2019-08-21 15-23-36](https://user-images.githubusercontent.com/30577011/63435731-b9b61f80-c427-11e9-885f-4e607d18a5b3.png)