### PR TITLE
[ci] capybara tests more flexible

### DIFF
--- a/dist/t/spec/support/capybara.rb
+++ b/dist/t/spec/support/capybara.rb
@@ -29,7 +29,7 @@ if hostname.empty?
   hostname = ipaddress
 end
 
-Capybara.app_host = ENV['SMOKETEST_HOST'].nil? ? "https://#{hostname}" : "http://localhost:3000"
+Capybara.app_host = ENV.fetch('SMOKETEST_HOST', "https://#{hostname}")
 
 RSpec.configure do |config|
   config.include Capybara::DSL


### PR DESCRIPTION
This PR contains changes to hand over an specific hostname
to the frontend functional tests so we can use the test suite on an
jump host to test our installation from the outside

