### PR TITLE
Fix openqa test for 2.9

### DIFF
--- a/dist/t/spec/features/0030_project_spec.rb
+++ b/dist/t/spec/features/0030_project_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe "Project" do
     end
     click_link('Repositories')
     click_link('Add repositories')
-    check('repo_openSUSE_Leap_42_3')
-    expect(page).to have_content("Successfully added repository 'openSUSE_Leap_42.3'")
+    check('repo_openSUSE_Leap_15_1')
+    expect(page).to have_content("Successfully added repository 'openSUSE_Leap_15.1'")
   end
 end


### PR DESCRIPTION
The repository openSUSE Leap 42.3 was removed.



<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md
-->
