### PR TITLE
Use icons in project monitor page and highlight more relavant states

### DIFF
--- a/src/api/app/assets/javascripts/webui2/project_monitor.js
+++ b/src/api/app/assets/javascripts/webui2/project_monitor.js
@@ -25,7 +25,7 @@ function statusCell(meta, statusHash, tableInfo, projectName, packageName) {
       output += ' data-content="' + status.details + '" data-placement="right" data-toggle="popover"';
     }
   }
-  output += ' class="' + klass + '">' + code + '</a>';
+  output += ' class="' + klass + '">' + '<i class="fa"></i>' + ' ' + code + '</a>';
 
   cellContent.display = output;
   cellContent.value = code;

--- a/src/api/app/assets/stylesheets/webui2/build-results.scss
+++ b/src/api/app/assets/stylesheets/webui2/build-results.scss
@@ -20,14 +20,17 @@
 
 .build-state-succeeded {
   color: $green;
+  & i.fa { @extend .fa-check; }
 }
 
 .build-state-building {
   color: $blue;
+  & i.fa { @extend .fa-cog; }
 }
 
 .build-state-scheduled {
   color: $cyan;
+  & i.fa { @extend .fa-calendar-alt; }
 }
 
 .build-state-signing, .build-state-finished {
@@ -35,7 +38,10 @@
 }
 
 .build-state-unresolvable, .build-state-broken, .build-state-failed {
-  color: $red;
+  @extend .text-white;
+  @extend .bg-danger;
+  @extend .px-1;
+  & i.fa { @extend .fa-exclamation-triangle; }
 }
 
 .build-state-disabled {
@@ -45,10 +51,17 @@
   @extend .text-white;
   @extend .bg-secondary;
   @extend .px-1;
+  & i.fa { @extend .fa-lock; }
 }
 
-.build-state-scheduled-warning, .build-state-unknown {
+.build-state-scheduled-warning {
   color: $orange;
+  & i.fa { @extend .fa-bolt; }
+}
+
+.build-state-unknown {
+  color: $orange;
+  & i.fa { @extend .fa-eye; }
 }
 
 .table-striped .odd {


### PR DESCRIPTION
The icons will help people who are not able to perceive
the colors, which are indicating the build state, to
recognize the state of the packages easier and faster.

** Before **
![Screenshot-2019-8-22 Open Build Service(4)](https://user-images.githubusercontent.com/22001671/63546791-e30ba400-c52a-11e9-888b-c216ff6b6ec7.png)
![Screenshot-2019-8-22 home Admin(1)](https://user-images.githubusercontent.com/22001671/63546824-fb7bbe80-c52a-11e9-93e9-ad4c4dd9025e.png)

** After **
![Screenshot-2019-8-22 Open Build Service(5)](https://user-images.githubusercontent.com/22001671/63548882-878fe500-c52f-11e9-8099-d9015c358674.png)

![Screenshot-2019-8-22 home Admin](https://user-images.githubusercontent.com/22001671/63546919-3251d480-c52b-11e9-9520-6cff913a509f.png)

Related to https://github.com/openSUSE/open-build-service/issues/8116

If this PR receives positiv feedback I could also distinguish between the state broken, failed etc. by adding new icons to our patterns and maybe adding the icons to the build results in the show view as well :)
