### PR TITLE
Make sure language exists

### DIFF
--- a/src/api/lib/obsapi/markdown_renderer.rb
+++ b/src/api/lib/obsapi/markdown_renderer.rb
@@ -1,4 +1,5 @@
 require 'uri'
+require 'cgi'
 
 module OBSApi
   class MarkdownRenderer < Redcarpet::Render::HTML
@@ -35,10 +36,11 @@ module OBSApi
         link = URI.join(::Configuration.obs_url, link)
       rescue URI::InvalidURIError
       end
-      "<a href='#{link}'#{title}>#{content}</a>"
+      "<a href='#{link}'#{title}>#{CGI.escape_html(content)}</a>"
     end
 
     def block_code(code, language)
+      language ||= :plaintext
       CodeRay.scan(code, language).div(css: :class)
     end
   end

--- a/src/api/spec/helpers/webui/markdown_helper_spec.rb
+++ b/src/api/spec/helpers/webui/markdown_helper_spec.rb
@@ -28,5 +28,31 @@ please review.</p>\n"
         "<p>anbox<a href='the number'>400000+22d000</a></p>\n"
       )
     end
+
+    it 'does not crash due to a missing language in a code block' do
+      expect(render_as_markdown("```\ntext\n```")).to eq("<div class=\"CodeRay\">\n  <div class=\"code\"><pre>text\n</pre></div>\n</div>\n")
+    end
+
+    it 'does apply a class to a code block with a language' do
+      expect(render_as_markdown("```ruby\ndef\n```")).to eq("<div class=\"CodeRay\">\n  <div class=\"code\"><pre><span class=\"keyword\">def</span>\n</pre></div>\n</div>\n")
+    end
+
+    it 'does remove dangerous html from the view' do
+      expect(render_as_markdown('<script></script>')).to eq("\n")
+    end
+
+    it 'does remove dangerous html from inside the code blocks with a language' do
+      expect(render_as_markdown("```html\n<script></script>\n```")).to eq(
+        "<div class=\"CodeRay\">\n  <div class=\"code\"><pre><span class=\"tag\">&lt;script&gt;</span><span class=\"tag\">&lt;/script&gt;</span>\n</pre></div>\n</div>\n"
+      )
+    end
+
+    it 'does remove dangerous html from inside the code blocks without a language' do
+      expect(render_as_markdown("```\n<script></script>\n```")).to eq("<div class=\"CodeRay\">\n  <div class=\"code\"><pre>&lt;script&gt;&lt;/script&gt;\n</pre></div>\n</div>\n")
+    end
+
+    it 'does remove dangerous html from inside the links' do
+      expect(render_as_markdown('[<script></script>](https://build.opensuse.org)')).to eq("<p><a href='https://build.opensuse.org'>&lt;script&gt;&lt;/script&gt;</a></p>\n")
+    end
   end
 end


### PR DESCRIPTION
Fixes #8167

Skips over coderay entirely if no language is input, to save on having additional processing for that, and additional classes coderay would insert for text.