### PR TITLE
Remove darkened colors for striped tables

### DIFF
--- a/src/api/app/assets/stylesheets/webui2/build-results.scss
+++ b/src/api/app/assets/stylesheets/webui2/build-results.scss
@@ -51,24 +51,6 @@
   color: $orange;
 }
 
-.table-striped .odd {
-  .build-state-succeeded {
-    color: darken($green, 5%);
-  }
-
-  .build-state-scheduled {
-    color: darken($cyan, 5%);
-  }
-
-  .build-state-unresolvable, .build-state-broken, .build-state-failed {
-    color: darken($red, 10%);
-  }
-
-  .build-state-scheduled-warning, .build-state-unknown {
-    color: darken($orange, 5%);
-  }
-}
-
 .repository-state-default {
   @extend .text-black-50;
 }


### PR DESCRIPTION
Since the zebra striped tables got removed, the darker
colors for the odd rows are not needed anymore.
