### PR TITLE
Add a background to build states which are still in flux

### DIFF
--- a/src/api/app/assets/stylesheets/webui2/build-results.scss
+++ b/src/api/app/assets/stylesheets/webui2/build-results.scss
@@ -23,15 +23,21 @@
 }
 
 .build-state-building {
-  color: $blue;
+  @extend .text-white;
+  @extend .px-1;
+  background-color: $blue;
 }
 
 .build-state-scheduled {
-  color: $cyan;
+  @extend .text-white;
+  @extend .px-1;
+  background-color: $cyan;
 }
 
 .build-state-signing, .build-state-finished {
-  color: $dark;
+  color: black;
+  @extend .px-1;
+  background-color: $yellow;
 }
 
 .build-state-unresolvable, .build-state-broken, .build-state-failed {
@@ -39,15 +45,24 @@
 }
 
 .build-state-disabled {
-  @extend .text-black-50;
-}
-.build-state-blocked {
   @extend .text-white;
-  @extend .bg-secondary;
   @extend .px-1;
+  background-color: $gray-600;
 }
 
-.build-state-scheduled-warning, .build-state-unknown {
+.build-state-blocked {
+  @extend .text-white;
+  @extend .px-1;
+  background-color: $gray-600;
+}
+
+.build-state-scheduled-warning {
+  @extend .text-white;
+  @extend .px-1;
+  background-color: $orange;
+}
+
+.build-state-unknown {
   color: $orange;
 }
 


### PR DESCRIPTION
The old webui used to set a background to states which suppose to change.

** Old Webui**
![Screenshot-2019-8-23 openSUSE Build Service(2)](https://user-images.githubusercontent.com/22001671/63604372-d4c19480-c5cb-11e9-9da8-fe5ad4da0995.png)

** Same with colors in our new Webui**
![Screenshot-2019-8-23 Open Build Service(1)](https://user-images.githubusercontent.com/22001671/63605858-16077380-c5cf-11e9-84d4-1948257f3adc.png)


