### PR TITLE
Improve regular expression for rendering users

### DIFF
--- a/src/api/lib/obsapi/markdown_renderer.rb
+++ b/src/api/lib/obsapi/markdown_renderer.rb
@@ -13,8 +13,8 @@ module OBSApi
       # request#12345 links
       fulldoc.gsub!(/(sr|req|request)#(\d+)/i) { |s| "[#{s}](#{request_show_url(number: Regexp.last_match(2))})" }
       # @user links
-      fulldoc.gsub!(/([^\w]|^)?@([-\w]+)([^\w]|$)/) \
-                   { "#{Regexp.last_match(1)}[@#{Regexp.last_match(2)}](#{user_show_url(Regexp.last_match(2))})#{Regexp.last_match(3)}" }
+      fulldoc.gsub!(/([^\w]|^)@(\b[-\w]+\b)(?:\b|$)/) \
+                   { "#{Regexp.last_match(1)}[@#{Regexp.last_match(2)}](#{user_show_url(Regexp.last_match(2))})" }
       # bnc#12345 links
       IssueTracker.all.each do |t|
         fulldoc = t.get_markdown(fulldoc)

--- a/src/api/spec/helpers/webui/markdown_helper_spec.rb
+++ b/src/api/spec/helpers/webui/markdown_helper_spec.rb
@@ -14,12 +14,18 @@ RSpec.describe Webui::MarkdownHelper do
       )
     end
 
-    it 'detects all the metions to users' do
-      expect(render_as_markdown('@alfie @milo and @Admin, please review.')).to eq(
+    it 'detects all the mentions to users' do
+      expect(render_as_markdown('@alfie @milo and @Admin, please review. Also you, @test1.')).to eq(
         "<p><a href='https://unconfigured.openbuildservice.org/user/show/alfie'>@alfie</a> \
 <a href='https://unconfigured.openbuildservice.org/user/show/milo'>@milo</a> \
 and <a href='https://unconfigured.openbuildservice.org/user/show/Admin'>@Admin</a>, \
-please review.</p>\n"
+please review. Also you, <a href='https://unconfigured.openbuildservice.org/user/show/test1'>@test1</a>.</p>\n"
+      )
+    end
+
+    it "don't render users inside the text of html links" do
+      expect(render_as_markdown('Group [openSUSE Leap 15.0 Incidents@DVD-Incidents](https://openqa.opensuse.org/tests/overview)')).to eq(
+        "<p>Group <a href='https://openqa.opensuse.org/tests/overview'>openSUSE Leap 15.0 Incidents@DVD-Incidents</a></p>\n"
       )
     end
 


### PR DESCRIPTION
Use word boundaries to the regular expression that identifies users. This way a string will not match a user when it has word characters before the "@" character.

A test case for not rendering users inside the text of html links is also added.

Fixes #8178.