### PR TITLE
Improve beta program help text

### DIFF
--- a/src/api/app/views/webui2/webui/user/_info.html.haml
+++ b/src/api/app/views/webui2/webui/user/_info.html.haml
@@ -34,9 +34,8 @@
             = label_tag 'Public Beta Program', nil, class: 'custom-control-label', for: 'beta-switch'
             = hidden_field_tag('user[login]', user.login)
             %i.fa.fa-question-circle.text-info{ data: { placement: 'top', toggle: 'popover', html: 'true',
-                                                        content: 'In our <strong>beta program</strong> you can try the latest features we ' + |
-                                                                  'develop, so you can give us feedback before we release them.' } } |
-
+                                                        content: 'Join the <strong>beta program</strong> to try the latest ' + |
+                                                                 'features we develop and give us feedback on them before they go live.' } } |
       .mt-4
         - if configuration.accounts_editable?(user)
           - if account_edit_link.present?


### PR DESCRIPTION
Call users to action by starting the text with a verb.

Before:
![beta-program-help-text-before](https://user-images.githubusercontent.com/1102934/63763012-316ec900-c8c4-11e9-9ef1-d8cfb939788d.png)

After:
![beta-program-help-text-after](https://user-images.githubusercontent.com/1102934/63763024-359ae680-c8c4-11e9-8847-647cfccceed2.png)