### PR TITLE
Fix issue with semi-transparent table highlight

### DIFF
--- a/src/api/app/assets/stylesheets/webui2/datatables.scss
+++ b/src/api/app/assets/stylesheets/webui2/datatables.scss
@@ -24,8 +24,12 @@ table.dataTable.table-sm {
     bottom: 0.3em;
   }
 
-  td { 
+  td {
     white-space: normal !important;
     @extend .text-break;
   }
+}
+
+.table-hover tbody tr:hover {
+  background-color: $gray-300;
 }


### PR DESCRIPTION
When doing horizontal scrolling in the project monitor page and then mouse over, some of the cells show the info behind. This happens because Bootstrap set a semi-transparent color as background and we have an special feature in the monitor page: two tables, one for the package names and the other one for the states which hides behind the first one.

Making the row highlight color opaque, it doesn't look broken.

Fixes:  #8183

**Before:**

![63779778 693b3800 c8e7 11e9 9954 58aee8235266 png  PNG Image  1267 × 688 pixels ](https://user-images.githubusercontent.com/2581944/63784275-b53dab00-c8ee-11e9-899b-566fd578c845.png)


**After:**

![63784290 ba9af580 c8ee 11e9 8494 1ddb4292f755 png  PNG Image  527 × 673 pixels ](https://user-images.githubusercontent.com/2581944/63784440-f209a200-c8ee-11e9-8f65-b4f36434b801.png)
