### PR TITLE
code2index must be a class method

### DIFF
--- a/src/api/app/models/buildresult.rb
+++ b/src/api/app/models/buildresult.rb
@@ -93,9 +93,7 @@ class Buildresult
     local_build_results
   end
 
-  private
-
-  def code2index(code)
+  def self.code2index(code)
     index = AVAIL_STATUS_VALUES[code.to_sym]
     return index if index
     raise ArgumentError, "code '#{code}' unknown #{AVAIL_STATUS_VALUES.inspect}"


### PR DESCRIPTION
In the method `summary` there is no instance of `Buildresult` therefore the method must be a class method.

Fixing https://errbit-opensuse.herokuapp.com/apps/5620ca2bdc71fa00b1000000/problems/5d6642a5a98d9a000c965abc

introduced by https://github.com/openSUSE/open-build-service/pull/8174