### PR TITLE
Add delayedjob worker for thinking sphinx indexing

### DIFF
--- a/ReleaseNotes-2.11
+++ b/ReleaseNotes-2.11
@@ -32,17 +32,19 @@ Generic:
 
 User Interface:
  * Colors were adjusted to improve contrast thus improving readability
- * The diff box from requests are now being rendered with ruby and coderay instead of CodeMirror 
+ * The diff box from requests are now being rendered with ruby and coderay instead of CodeMirror
 
 Backend & build support:
- * 
+ *
 
 Bugfixes:
- * 
+ *
 
 
 Intentional changes:
 ====================
+
+  * Added a new delayjob worker systemd-service for Thinking Sphinx indexing ("obs-delayedjob-queue-sphinx-indexing.service")
 
   Features enabled by default:
     * Image Template

--- a/dist/Makefile
+++ b/dist/Makefile
@@ -4,7 +4,7 @@ LOGROTATE_CONFIGS     := obs-api obs-server obs-source_service
 OBS_BIN_SCRIPTS       := obs_productconvert
 OBS_SBIN_SCRIPTS      := obs_admin obs_serverstatus obsscheduler obsworker obsstoragesetup
 SYSTEMD_TARGET_FILES  := obs-api-support
-SYSTEMD_SERVICE_FILES := obs-clockwork obs-delayedjob-queue-project_log_rotate obs-delayedjob-queue-consistency_check obs-delayedjob-queue-default obs-delayedjob-queue-releasetracking obs-delayedjob-queue-issuetracking obs-delayedjob-queue-mailers obs-delayedjob-queue-staging obs-sphinx obsdeltastore obsdispatcher obsdodup obswarden obssrcserver obsrepserver obspublisher obssigner obsservice obsservicedispatch obsgetbinariesproxy obsclouduploadserver obsclouduploadworker obsscheduler obsworker obsstoragesetup obsapisetup obsnotifyforward obsredis
+SYSTEMD_SERVICE_FILES := obs-clockwork obs-delayedjob-queue-project_log_rotate obs-delayedjob-queue-consistency_check obs-delayedjob-queue-default obs-delayedjob-queue-releasetracking obs-delayedjob-queue-issuetracking obs-delayedjob-queue-mailers obs-delayedjob-queue-staging obs-delayedjob-queue-sphinx-indexing obs-sphinx obsdeltastore obsdispatcher obsdodup obswarden obssrcserver obsrepserver obspublisher obssigner obsservice obsservicedispatch obsgetbinariesproxy obsclouduploadserver obsclouduploadworker obsscheduler obsworker obsstoragesetup obsapisetup obsnotifyforward obsredis
 SYSTEMD_SERVICE_FILES_WITHOUT_LINK := obs-delayedjob-queue-quick@
 
 FILLUPDIR             := /var/adm/fillup-templates

--- a/dist/obs-server.spec
+++ b/dist/obs-server.spec
@@ -789,6 +789,7 @@ usermod -a -G docker obsservicerun
 %{_unitdir}/obs-delayedjob-queue-quick@.service
 %{_unitdir}/obs-delayedjob-queue-releasetracking.service
 %{_unitdir}/obs-delayedjob-queue-staging.service
+%{_unitdir}/obs-delayedjob-queue-sphinx-indexing.service
 %{_unitdir}/obs-sphinx.service
 %{_sbindir}/rcobs-api-support
 %{_sbindir}/rcobs-clockwork
@@ -799,6 +800,7 @@ usermod -a -G docker obsservicerun
 %{_sbindir}/rcobs-delayedjob-queue-project_log_rotate
 %{_sbindir}/rcobs-delayedjob-queue-releasetracking
 %{_sbindir}/rcobs-delayedjob-queue-staging
+%{_sbindir}/rcobs-delayedjob-queue-sphinx-indexing
 %{_sbindir}/rcobs-sphinx
 %{_sbindir}/rcobsapisetup
 /srv/www/obs/api/app

--- a/dist/systemd/obs-api-support.target
+++ b/dist/systemd/obs-api-support.target
@@ -1,6 +1,6 @@
 [Unit]
 Description = Open Build Service API Support Daemons
-Wants = obs-clockwork.service obs-delayedjob-queue-consistency_check.service obs-delayedjob-queue-default.service obs-delayedjob-queue-issuetracking.service obs-delayedjob-queue-mailers.service obs-delayedjob-queue-project_log_rotate.service obs-delayedjob-queue-quick@0.service obs-delayedjob-queue-quick@1.service obs-delayedjob-queue-quick@2.service obs-delayedjob-queue-releasetracking.service obs-delayedjob-queue-staging.service obs-sphinx.service
+Wants = obs-clockwork.service obs-delayedjob-queue-consistency_check.service obs-delayedjob-queue-default.service obs-delayedjob-queue-issuetracking.service obs-delayedjob-queue-mailers.service obs-delayedjob-queue-project_log_rotate.service obs-delayedjob-queue-quick@0.service obs-delayedjob-queue-quick@1.service obs-delayedjob-queue-quick@2.service obs-delayedjob-queue-releasetracking.service obs-delayedjob-queue-staging.service obs-sphinx.service obs-delayedjob-queue-sphinx-indexing.service
 After = network.target
 AllowIsolate = yes
 

--- a/dist/systemd/obs-delayedjob-queue-sphinx-indexing.service
+++ b/dist/systemd/obs-delayedjob-queue-sphinx-indexing.service
@@ -1,0 +1,16 @@
+[Unit]
+Description = Open Build Service DelayedJob Queue Instance: sphinx indexing
+BindsTo = obs-api-support.target
+
+[Service]
+Environment = "RAILS_ENV=production"
+User = wwwrun
+Group = www
+WorkingDirectory = /srv/www/obs/api
+ExecStart = /usr/bin/bundle.ruby2.5 exec script/delayed_job.api.rb --queue=sphinx_indexing start -i 1070
+ExecStop = /usr/bin/bundle.ruby2.5 exec script/delayed_job.api.rb --queue=sphinx_indexing stop -i 1070
+Type = forking
+PIDFile = /srv/www/obs/api/tmp/pids/delayed_job.1070.pid
+
+[Install]
+WantedBy = obs-api-support.target

--- a/src/api/app/jobs/full_text_index_job.rb
+++ b/src/api/app/jobs/full_text_index_job.rb
@@ -5,7 +5,7 @@ class ThinkingSphinx::GuardfileExistsError < StandardError
 end
 
 class FullTextIndexJob < ApplicationJob
-  queue_as :quick
+  queue_as :sphinx_indexing
 
   def perform
     return unless Rails.env.production?


### PR DESCRIPTION
Thinking Sphinx indexing jobs should not be processed in parallel
since it can lead to conflicts between them.

Fixes #8208



<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md
-->
