### PR TITLE
[backend] make the deltagen -m option configurable

### DIFF
--- a/src/backend/bs_worker
+++ b/src/backend/bs_worker
@@ -3062,6 +3062,24 @@ sub dobuild {
   my $config = BSRPC::rpc("$server/getconfig", undef, "project=$projid", "repository=$repoid", @configpath);
   writestr("$buildroot/.build.config", undef, $config);
 
+  if ($deltamode) {
+    # replace @mopt@ in specfile
+    my $spec = readstr("$srcdir/worker-deltagen.spec");
+    my $mopt;
+    $mopt = $BSConfig::deltagen_mopt if defined $BSConfig::deltagen_mopt;
+    importbuild() unless defined &Build::queryhdrmd5;
+    eval {
+      my $bconf = Build::read_config($buildinfo->{'arch'}, [ split("\n", $config) ]);
+      for (@{$bconf->{'repotype'}}) {
+        $mopt = $1 eq '' ? undef : $1 if /^deltagen-mopt:(\d*)/;
+      }
+    };
+    $mopt = 512 unless defined $mopt;
+    $mopt = '' unless $mopt;
+    $spec =~ s/\@mopt\@/$mopt/sg;
+    writestr("$srcdir/worker-deltagen.spec", undef, $spec);
+  }
+
   my $release = $buildinfo->{'release'};
   #FIXME2.6: drop the following line
   my $disturl = "obs://$BSConfig::obsname/$projid/$repoid/$buildinfo->{'srcmd5'}-$packid";

--- a/src/backend/worker-deltagen.spec
+++ b/src/backend/worker-deltagen.spec
@@ -14,10 +14,12 @@ mkdir -p "$odir"
 
 # check if makedeltarpm supports the '-m' option
 mopt=
-case `makedeltarpm -m 512 /dev/null /dev/null /dev/null 2>&1` in
+if test -n "@mopt@" ; them
+case `makedeltarpm -m @mopt@ /dev/null /dev/null /dev/null 2>&1` in
   *invalid\ option*) ;;
-  *) mopt="-m 512" ;;
+  *) mopt="-m @mopt@" ;;
 esac
+fi
 
 for i in *.old ; do
   if ! test -e "$i"; then


### PR DESCRIPTION
It can be set both in BSConfig.pm and in the project config.
The default is still '512'.



<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md
-->
