### PR TITLE
 Run spider test in the new UI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -191,7 +191,9 @@ jobs:
       - run: *bootstrap_old_test_suite
       - run:
           name: Run spider
-          command: cd src/api; bundle exec rake test:spider
+          command: |
+            cd src/api
+            bundle exec rake test:spider
       - <<: *store_minitest_artefacts
 
   backend_test:

--- a/src/api/test/functional/webui/spider_test.rb
+++ b/src/api/test/functional/webui/spider_test.rb
@@ -131,7 +131,7 @@ class Webui::SpiderTest < Webui::IntegrationTest
     crawl
     ActiveRecord::Base.clear_active_connections!
 
-    @pages_visited.keys.length.must_be :>, 490
+    @pages_visited.keys.length.must_be :>, 345
   end
 
   def test_spider_as_admin
@@ -142,6 +142,6 @@ class Webui::SpiderTest < Webui::IntegrationTest
     crawl
     ActiveRecord::Base.clear_active_connections!
 
-    @pages_visited.keys.length.must_be :>, 900
+    @pages_visited.keys.length.must_be :>, 439
   end
 end

--- a/src/api/test/functional/webui/spider_test.rb
+++ b/src/api/test/functional/webui/spider_test.rb
@@ -55,30 +55,8 @@ class Webui::SpiderTest < Webui::IntegrationTest
 
   def raiseit(message, url)
     # known issues
-    return if url =~ %r{/package/binary/BinaryprotectedProject/.*}
-    return if url =~ %r{/package/binary/download/*}
-    return if url =~ %r{/package/statistics/BinaryprotectedProject/.*}
-    return if url =~ %r{/package/statistics/SourceprotectedProject/.*}
-    return if url.end_with?('/package/binary/SourceprotectedProject/pack?arch=i586&filename=package-1.0-1.src.rpm&repository=repo')
-    return if url =~ %r{/package/revisions/SourceprotectedProject.*}
-    return if url.end_with?('/package/show/kde4/kdelibs?rev=1')
-    return if url.end_with?('/package/show/SourceprotectedProject/target')
-    return if url.end_with?('/package/users/SourceprotectedProject/pack')
-    return if url.end_with?('/package/view_file/BaseDistro:Update/pack2?file=my_file&rev=1')
-    return if url.end_with?('/package/view_file/Devel:BaseDistro:Update/pack2?file=my_file&rev=1')
-    return if url.end_with?('/package/view_file/Devel:BaseDistro:Update/Pack3?file=my_file&rev=1')
-    return if url.end_with?('/package/view_file/LocalProject/remotepackage?file=my_file&rev=1')
-    return if url.end_with?('/package/view_file/BaseDistro2.0:LinkedUpdateProject/pack2.linked?file=myfile&rev=1')
-    return if url.end_with?('/package/view_file/BaseDistro2.0/pack2.linked?file=myfile&rev=1')
-    return if url.end_with?('/package/view_file/BaseDistro2.0:LinkedUpdateProject/pack2.linked?file=package.spec&rev=1')
-    return if url.end_with?('/package/view_file/BaseDistro2.0/pack2.linked?file=package.spec&rev=1')
-    return if url.end_with?('/project/edit/RemoteInstance')
-    return if url.end_with?('/project/meta/HiddenRemoteInstance')
-    return if url.end_with?('/project/show/HiddenRemoteInstance')
-    return if url.end_with?('/project/edit/HiddenRemoteInstance')
-    return if url.end_with?('/user/show/unknown')
-    return if url.end_with?('/user/show/deleted')
     return if url =~ %r{/source/}
+    return if url.end_with?('/request/add_reviewer_dialog?number=10')
 
     warn "Found #{message} on #{url}, crawling path"
     indent = ' '

--- a/src/api/test/functional/webui/spider_test.rb
+++ b/src/api/test/functional/webui/spider_test.rb
@@ -108,7 +108,7 @@ class Webui::SpiderTest < Webui::IntegrationTest
           # puts "ignoring #{page.response_headers.inspect}"
           next
         end
-        page.first(:id, 'header-logo')
+        page.first('.navbar-brand')
       rescue Timeout::Error
         next
       rescue ActionController::RoutingError
@@ -122,7 +122,7 @@ class Webui::SpiderTest < Webui::IntegrationTest
         # puts "HARDCORE!! #{theone}"
       end
       next unless body
-      flashes = body.css('div#flash-messages div.ui-state-error')
+      flashes = body.css('div#flash div.alert-error')
       unless flashes.empty?
         raiseit("flash alert #{flashes.first.content.strip}", theone)
       end

--- a/src/api/test/functional/webui/spider_test.rb
+++ b/src/api/test/functional/webui/spider_test.rb
@@ -3,6 +3,9 @@ require_relative '../../test_helper'
 require 'benchmark'
 require 'nokogiri'
 
+# TODO: Remove this when switch_to_webui2 is removed
+ENV['BOOTSTRAP'] = '1'
+
 class Webui::SpiderTest < Webui::IntegrationTest
   def getlinks(baseuri, body)
     # skip some uninteresting projects


### PR DESCRIPTION
As we plan to remove bento, we need to run the tests in the new UI.

<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md
-->
