### PR TITLE
[dist] obs-bundled-gems.spec: fix build on ppc by dropping

### DIFF
--- a/dist/obs-bundled-gems.spec
+++ b/dist/obs-bundled-gems.spec
@@ -100,6 +100,7 @@ mkdir -p vendor/cache
 cp %{_sourcedir}/vendor/cache/*.gem vendor/cache
 export GEM_HOME=~/.gems
 bundle config build.nokogiri --use-system-libraries
+bundle config build.sassc --disable-march-tune-native
 
 %install
 bundle --local --path %{buildroot}%_libdir/obs-api/


### PR DESCRIPTION
 the useless "-march=native" compile flag unsupported on power when building rubygem-sassc



<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md
-->
