### PR TITLE
Migrate project#new_package

### DIFF
--- a/src/api/app/controllers/webui/project_controller.rb
+++ b/src/api/app/controllers/webui/project_controller.rb
@@ -110,6 +110,8 @@ class Webui::ProjectController < Webui::WebuiController
 
   def new_package
     authorize @project, :update?
+
+    switch_to_webui2
   end
 
   def new_package_branch

--- a/src/api/app/views/webui2/webui/project/_create_package_form.html.haml
+++ b/src/api/app/views/webui2/webui/project/_create_package_form.html.haml
@@ -1,0 +1,20 @@
+= form_tag(save_new_package_path(project)) do
+  .form-group
+    %label{ for: 'name' } Name:
+    %abbr.text-danger{ title: 'required' } *
+    = text_field_tag 'name', nil, size: 80, required: true, class: 'form-control', placeholder: 'Enter Name'
+  .form-group
+    %label{ for: 'title' } Title:
+    = text_field_tag 'title', nil, size: 80, class: 'form-control', placeholder: 'Enter Title'
+  .form-group
+    %label{ for: 'description' } Description:
+    = text_area_tag 'description', nil, cols: 80, rows: 10, class: 'form-control'
+  - unless @configuration['hide_private_options']
+    .form-group.custom-control.custom-checkbox
+      = check_box_tag :source_protection, 1, false, class: 'custom-control-input', type: 'checkbox'
+      %label.custom-control-label{ for: 'source_protection' } Deny access to source of package
+  .form-group.custom-control.custom-checkbox
+    = check_box_tag :disable_publishing, 1, false, class: 'custom-control-input', type: 'checkbox'
+    %label.custom-control-label{ for: 'disable_publishing' } Disable build results publishing
+  .modal-footer
+    = render partial: 'webui2/shared/dialog_action_buttons', locals: { submit_tag_text: 'Create' }

--- a/src/api/app/views/webui2/webui/project/_create_package_form.html.haml
+++ b/src/api/app/views/webui2/webui/project/_create_package_form.html.haml
@@ -16,5 +16,8 @@
   .form-group.custom-control.custom-checkbox
     = check_box_tag :disable_publishing, 1, false, class: 'custom-control-input', type: 'checkbox'
     %label.custom-control-label{ for: 'disable_publishing' } Disable build results publishing
-  .modal-footer
-    = render partial: 'webui2/shared/dialog_action_buttons', locals: { submit_tag_text: 'Create' }
+  - if defined?(modal)
+    .modal-footer
+      = render partial: 'webui2/shared/dialog_action_buttons', locals: { submit_tag_text: 'Create' }
+  - else
+    = submit_tag('Create', class: 'btn btn-primary px-4')

--- a/src/api/app/views/webui2/webui/project/_create_package_modal.html.haml
+++ b/src/api/app/views/webui2/webui/project/_create_package_modal.html.haml
@@ -5,22 +5,4 @@
         %h5.modal-title#new-package-modal-label
           Create Package for #{project.name}
       .modal-body
-        = form_tag(save_new_package_path(project)) do
-          .form-group
-            %label{ for: 'name' } Name:
-            = text_field_tag 'name', nil, size: 80, required: true, class: 'form-control', placeholder: 'Enter Name'
-          .form-group
-            %label{ for: 'title' } Title:
-            = text_field_tag 'title', nil, size: 80, class: 'form-control', placeholder: 'Enter Title'
-          .form-group
-            %label{ for: 'description' } Description:
-            = text_area_tag 'description', nil, cols: 80, rows: 10, class: 'form-control'
-          - unless @configuration['hide_private_options']
-            .form-group.custom-control.custom-checkbox
-              = check_box_tag :source_protection, 1, false, class: 'custom-control-input', type: 'checkbox'
-              %label.custom-control-label{ for: 'source_protection' } Deny access to source of package
-          .form-group.custom-control.custom-checkbox
-            = check_box_tag :disable_publishing, 1, false, class: 'custom-control-input', type: 'checkbox'
-            %label.custom-control-label{ for: 'disable_publishing' } Disable build results publishing
-          .modal-footer
-            = render partial: 'webui2/shared/dialog_action_buttons', locals: { submit_tag_text: 'Create' }
+        = render partial: 'create_package_form', locals: { project: project }

--- a/src/api/app/views/webui2/webui/project/_create_package_modal.html.haml
+++ b/src/api/app/views/webui2/webui/project/_create_package_modal.html.haml
@@ -5,4 +5,4 @@
         %h5.modal-title#new-package-modal-label
           Create Package for #{project.name}
       .modal-body
-        = render partial: 'create_package_form', locals: { project: project }
+        = render partial: 'create_package_form', locals: { project: project, modal: true }

--- a/src/api/app/views/webui2/webui/project/new_package.html.haml
+++ b/src/api/app/views/webui2/webui/project/new_package.html.haml
@@ -1,0 +1,7 @@
+- @pagetitle = "Create package for #{@project}"
+
+.card.mb-3
+  = render partial: 'tabs', locals: { project: @project }
+  .card-body
+    %h3= @pagetitle
+    = render partial: 'create_package_form', locals: { project: @project }


### PR DESCRIPTION
Preview:
![create_package_form](https://user-images.githubusercontent.com/1102934/64121333-d266f380-cd9e-11e9-8a2e-bd12dbc630a7.png)

The modal which is now using the same partial as `project#new_package` didn't change, except for marking the `name` field as required.

![create_package_modal](https://user-images.githubusercontent.com/1102934/64121402-0c37fa00-cd9f-11e9-8946-29fada32dee6.png)

/rant

We have 2 ways to create packages. One with a modal and with project#new_package when a validation fails in the modal. Another case of a modal which is useless.