### PR TITLE
Revert update from sassc gem

### DIFF
--- a/dist/obs-bundled-gems.spec
+++ b/dist/obs-bundled-gems.spec
@@ -43,6 +43,7 @@ BuildRequires:  openldap2-devel
 BuildRequires:  python-devel
 BuildRequires:  ruby2.5-devel
 BuildRequires:  rubygem(ruby:2.5.0:bundler)
+BuildRequires:  chrpath
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build
 
@@ -139,6 +140,9 @@ done
 find %{buildroot} -type f -print0 | xargs -0 grep -l /usr/bin/env | while read file; do
   chmod a-x $file
 done
+
+# Remove rpaths from files
+chrpath --delete %{buildroot}%_libdir/obs-api/ruby/*/gems/sassc-*-x86_64-linux/lib/sassc/libsass.so
 
 %files
 %_libdir/obs-api

--- a/src/api/Gemfile
+++ b/src/api/Gemfile
@@ -190,6 +190,8 @@ group :assets do
   gem 'cssmin', '>= 1.0.2'
   # for minifying JavaScript
   gem 'uglifier', '>= 1.2.2'
+  # sassc 2.2.0 is throwing exception
+  gem 'sassc', '~> 2.1.0'
   # to use sass in the asset pipeline
   gem 'sassc-rails'
   # assets for jQuery DataTables

--- a/src/api/Gemfile.lock
+++ b/src/api/Gemfile.lock
@@ -385,7 +385,7 @@ GEM
       crass (~> 1.0.2)
       nokogiri (>= 1.8.0)
       nokogumbo (~> 2.0)
-    sassc (2.2.0)
+    sassc (2.1.0)
       ffi (~> 1.9)
     sassc-rails (2.1.2)
       railties (>= 4.0.0)
@@ -544,6 +544,7 @@ DEPENDENCIES
   rubocop-rspec
   ruby-ldap
   sanitize
+  sassc (~> 2.1.0)
   sassc-rails
   selenium-webdriver
   shoulda-matchers (~> 4.0)


### PR DESCRIPTION
It reverts:
fc796482d8abac4dd65881ad1b88ab1bc76ac89d
6df0143ecb02a669048cb6bbeaeb9ba8a16d4b28

sassc 2.2.0 throws FFI exception. Reverting it fixes it
