### PR TITLE
Add data migration for attribute default values.

### DIFF
--- a/src/api/db/data/20190902110039_add_attribute_default_values.rb
+++ b/src/api/db/data/20190902110039_add_attribute_default_values.rb
@@ -1,0 +1,16 @@
+class AddAttributeDefaultValues < ActiveRecord::Migration[5.2]
+  def up
+    ans = AttribNamespace.where(name: 'OBS').first
+    return unless ans.exists?
+
+    at = ans.attrib_types.where(name: 'QualityCategory').first
+    at.default_values.where(value: 'Development', position: 1).first_or_create if at
+
+    at = ans.attrib_types.where(name: 'MaintenanceIdTemplate').first
+    at.default_values.where(value: '%Y-%C', position: 1).first_or_create if at
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end


### PR DESCRIPTION
On certain instances of the Open Build Service the default
attribute values got lost, since they are only created once
at the first setup by the seeds. This causes failing validations
when creating certain attribute, since they rely on the default values.

Fixes #8143



<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md
-->
