### PR TITLE
Fix javascript error reporting

### DIFF
--- a/src/api/app/assets/javascripts/webui2/airbrake-js.js
+++ b/src/api/app/assets/javascripts/webui2/airbrake-js.js
@@ -1,12 +1,14 @@
 //= require airbrake-js-client
-var errbit_id = "<%= CONFIG['errbit_javascript_api_key'] %>";
-var errbit_host = "<%= CONFIG['errbit_javascript_host'] %>";
 
-if (errbit_id) {
+/* global console, airbrakeJs */
+var errbitId = $("meta[property='errbit:key']").attr('content');
+var errbitHost = $("meta[property='errbit:host']").attr('content');
+
+if (errbitId) {
   var airbrake = new airbrakeJs.Client({
     projectId: 1,
-    projectKey: errbit_id,
-    host: errbit_host,
+    projectKey: errbitId,
+    host: errbitHost,
     environment: 'production',
   });
 
@@ -22,4 +24,4 @@ if (errbit_id) {
       }
     });
   };
-};
+}

--- a/src/api/app/views/layouts/webui2/webui.html.haml
+++ b/src/api/app/views/layouts/webui2/webui.html.haml
@@ -17,6 +17,10 @@
     - if meta_description
       %meta{ property: 'og:description', content: meta_description }
 
+    - if CONFIG['errbit_javascript_api_key'] && CONFIG['errbit_javascript_host']
+      %meta{ property: 'errbit:key', content: CONFIG['errbit_javascript_api_key'] }
+      %meta{ property: 'errbit:host', content: CONFIG['errbit_javascript_host'] }
+
     = stylesheet_link_tag 'webui2/webui2'
     = javascript_include_tag 'webui2/application'
 


### PR DESCRIPTION
Getting data from CONFIG does not work if you compile your assets
before shipping them to production. Use meta tags instead.
