### PR TITLE
Migrate request reviewer partial to Bootstrap

### DIFF
--- a/src/api/app/views/webui2/webui/request/_reviewer.html.haml
+++ b/src/api/app/views/webui2/webui/request/_reviewer.html.haml
@@ -1,0 +1,11 @@
+- no_icon ||= false
+
+- if review[:by_user]
+  = user_with_realname_and_icon(review[:by_user], short: true, no_icon: no_icon)
+- elsif review[:by_group]
+  = group_with_icon(review[:by_group])
+- elsif review[:by_project]
+  - if review[:by_package]
+    = link_to("#{review[:by_project]} / #{review[:by_package]}", package_users_path(project: review[:by_project], package: review[:by_package]))
+  - else
+    = link_to(review[:by_project], project_users_path(project: review[:by_project]))


### PR DESCRIPTION
The Bento version is src/api/app/views/webui/request/_reviewer.html.erb

Closes #8223 

Preview from the [review app](https://obs-reviewlab.opensuse.org/dmarcoux-bootstrap-reviewer-partial/request/show/1):
![preview](https://user-images.githubusercontent.com/1102934/64335372-f44cba00-cfda-11e9-89af-8e01186d61bc.png)