### PR TITLE
bring back remove_dialog_tag helper method

### DIFF
--- a/src/api/app/helpers/webui/webui_helper.rb
+++ b/src/api/app/helpers/webui/webui_helper.rb
@@ -4,6 +4,10 @@ module Webui::WebuiHelper
   include ActionView::Helpers::AssetTagHelper
   include Webui::BuildresultHelper
 
+  def remove_dialog_tag(text)
+    link_to(text, '#', title: 'Close', id: 'remove_dialog', class: 'close-dialog')
+  end
+
   def bugzilla_url(email_list = '', desc = '')
     return '' if @configuration['bugzilla_url'].blank?
     assignee = email_list.first if email_list


### PR DESCRIPTION
bring method back, since we still have some old views using it