### PR TITLE
Use correct path for partials in shared directory

### DIFF
--- a/src/api/app/views/webui/shared/user_or_groups_roles/_add_group_dialog.html.haml
+++ b/src/api/app/views/webui/shared/user_or_groups_roles/_add_group_dialog.html.haml
@@ -5,12 +5,12 @@
         .modal-header
           %h5.modal-title#edit-modal-label Add Group
         .modal-body
-          = render partial: 'webui/autocomplete', locals: { html_id: 'groupid', label: 'Group:',
-                                                            data: { source: autocomplete_groups_path } }
+          = render partial: 'webui/shared/autocomplete', locals: { html_id: 'groupid', label: 'Group:',
+                                                                   data: { source: autocomplete_groups_path } }
           .form-group
             = label_tag(:role, 'Role:')
             = select_tag 'role', options_for_select(Role.local_roles, nil), required: true, class: 'form-control'
           = hidden_field_tag 'package', package
           = hidden_field_tag 'project', project
         .modal-footer
-          = render partial: 'webui2/shared/dialog_action_buttons'
+          = render partial: 'webui/shared/dialog_action_buttons'

--- a/src/api/app/views/webui/shared/user_or_groups_roles/_add_user_dialog.html.haml
+++ b/src/api/app/views/webui/shared/user_or_groups_roles/_add_user_dialog.html.haml
@@ -5,13 +5,12 @@
         .modal-header
           %h5.modal-title#edit-modal-label Add User
         .modal-body
-          = render partial: 'webui/autocomplete', locals: { html_id: 'userid', label: 'User:',
-                                                            data: { source: autocomplete_users_path } }
+          = render partial: 'webui/shared/autocomplete', locals: { html_id: 'userid', label: 'User:',
+                                                                   data: { source: autocomplete_users_path } }
           .form-group
             = label_tag(:role, 'Role:')
             = select_tag 'role', options_for_select(Role.local_roles, nil), required: true, class: 'form-control'
           = hidden_field_tag 'package', package
           = hidden_field_tag 'project', project
-          = hidden_field_tag 'webui2', true
         .modal-footer
-          = render partial: 'webui2/shared/dialog_action_buttons'
+          = render partial: 'webui/shared/dialog_action_buttons'

--- a/src/api/app/views/webui/shared/user_or_groups_roles/_index.html.haml
+++ b/src/api/app/views/webui/shared/user_or_groups_roles/_index.html.haml
@@ -23,7 +23,7 @@
             %td= role.title.capitalize
           %td
       %tbody
-        = render partial: 'webui2/shared/user_or_groups_roles/list',
+        = render partial: 'webui/shared/user_or_groups_roles/list',
                  locals: { records: users, roles: roles, type: 'user',
                            user_is_maintainer: user_is_maintainer,
                            project: project, package: package }
@@ -31,11 +31,11 @@
   - if user_is_maintainer
     %ul.list-inline
       %li.list-inline-item
-        = render(partial: 'webui2/shared/user_or_groups_roles/add_user_dialog', locals: { project: project.to_param, package: package.to_param })
+        = render(partial: 'webui/shared/user_or_groups_roles/add_user_dialog', locals: { project: project.to_param, package: package.to_param })
         = link_to('#', data: { toggle: 'modal', target: '#add-user-role-modal' }, id: 'add-user', class: 'nav-link') do
           %i.fas.fa-plus-circle.text-primary
           Add User
-        = render(partial: 'webui2/shared/user_or_groups_roles/delete_dialog')
+        = render(partial: 'webui/shared/user_or_groups_roles/delete_dialog')
 
   %hr
 
@@ -50,14 +50,14 @@
           - if user_is_maintainer
             %td
       %tbody
-        = render partial: 'webui2/shared/user_or_groups_roles/list',
+        = render partial: 'webui/shared/user_or_groups_roles/list',
                  locals: { records: groups, roles: roles, type: 'group',
                            user_is_maintainer: user_is_maintainer,
                            project: project, package: package }
   - if user_is_maintainer
     %ul.list-inline
       %li.list-inline-item
-        = render(partial: 'webui2/shared/user_or_groups_roles/add_group_dialog', locals: { project: project.to_param, package: package.to_param })
+        = render(partial: 'webui/shared/user_or_groups_roles/add_group_dialog', locals: { project: project.to_param, package: package.to_param })
         = link_to('#', data: { toggle: 'modal', target: '#add-group-role-modal' }, id: 'add-group', class: 'nav-link') do
           %i.fas.fa-plus-circle.text-primary
           Add Group


### PR DESCRIPTION
During the migration of the shared partials we forgot to change the
namespace to use `webui` instead of `webui2`.

<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn
how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md

In order to make it as easy as possible for other developers to review your
pull request we ask you to:

- Explain what this PR is about in the description
- Explain the steps the reviewer has to follow to verify your change
- If the reviewer needs sample data to verify your change, please explain how to
  create that data
- If you include visual changes in this PR, please add screenshots or GIFs
- If you address performance in this PR, add benchmark data or explain how the
  reviewer can benchmark this

This is a good PR description example:

Hey Friends,

this introduces labels for the different build result states on the project
monitor page. This makes it easier to get a visual overview of what is going on
in your project.

To verify this feature

- Enable the interconnect to build.opensuse.org
- Create the project home:Admin
- Add 'openSUSE Tumbleweed' as a repository to the project
- Branch a couple of packages into the project:
  ```
  for i in `osc -A http://0.0.0.0:3000 ls openSUSE.org:home:hennevogel`; do osc -A http://0.0.0.0:3000 copypac openSUSE.org:home:hennevogel $i home:Admin; done
  ```
- Visit the monitor page and see the new labels for the different states.

Here is a screenshot of how it looks:

** Before **
![Screenshot of the project monitor](https://example.com/screenshot1.png)

** After **
![Screenshot of the project monitor](https://example.com/screenshot2.png)

-->
