### PR TITLE
Remove background from build state disabled

### DIFF
--- a/src/api/app/assets/stylesheets/webui2/build-results.scss
+++ b/src/api/app/assets/stylesheets/webui2/build-results.scss
@@ -45,9 +45,7 @@
 }
 
 .build-state-disabled {
-  @extend .text-white;
-  @extend .px-1;
-  background-color: $gray-600;
+  color: $gray-600;
 }
 
 .build-state-blocked {


### PR DESCRIPTION
The build state disabled is a conscious decision and
therefore it is not necessary/too much to highlight it with
a background color.

**before**
![Screenshot-2019-9-6 test_project(1)](https://user-images.githubusercontent.com/22001671/64434889-d6a65000-d0c1-11e9-929d-a13399c4900c.png)

**after**
![Screenshot-2019-9-6 test_project](https://user-images.githubusercontent.com/22001671/64434898-db6b0400-d0c1-11e9-812d-f93d31fb3faf.png)

<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn
how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md

In order to make it as easy as possible for other developers to review your
pull request we ask you to:

- Explain what this PR is about in the description
- Explain the steps the reviewer has to follow to verify your change
- If the reviewer needs sample data to verify your change, please explain how to
  create that data
- If you include visual changes in this PR, please add screenshots or GIFs
- If you address performance in this PR, add benchmark data or explain how the
  reviewer can benchmark this

This is a good PR description example:

Hey Friends,

this introduces labels for the different build result states on the project
monitor page. This makes it easier to get a visual overview of what is going on
in your project.

To verify this feature

- Enable the interconnect to build.opensuse.org
- Create the project home:Admin
- Add 'openSUSE Tumbleweed' as a repository to the project
- Branch a couple of packages into the project:
  ```
  for i in `osc -A http://0.0.0.0:3000 ls openSUSE.org:home:hennevogel`; do osc -A http://0.0.0.0:3000 copypac openSUSE.org:home:hennevogel $i home:Admin; done
  ```
- Visit the monitor page and see the new labels for the different states.

Here is a screenshot of how it looks:

** Before **
![Screenshot of the project monitor](https://example.com/screenshot1.png)

** After **
![Screenshot of the project monitor](https://example.com/screenshot2.png)

-->
