### PR TITLE
Remove Gitlab webhook event restriction during authentication.

### DIFF
--- a/src/api/app/services/trigger_controller_service/token_extractor.rb
+++ b/src/api/app/services/trigger_controller_service/token_extractor.rb
@@ -10,7 +10,8 @@ module TriggerControllerService
     end
 
     def extract_auth_token
-      @auth_token = if @http_request.env['HTTP_X_GITLAB_EVENT'] == 'Push Hook'
+      events = ['Push Hook', 'Tag Push Hook', 'Merge Request Hook']
+      @auth_token = if events.any? { |event| event == @http_request.env['HTTP_X_GITLAB_EVENT'] }
                       'Token ' + @http_request.env['HTTP_X_GITLAB_TOKEN']
                     else
                       @http_request.env['HTTP_AUTHORIZATION']


### PR DESCRIPTION
When validating Gitlab webhook triggers the authentication token
is only valid for "Push Hook" events.  Gitlab has multiple events
that could be valid.  Choosing to accept the Gitlab authentication
header does not need to be dependent on the webhook event.

This single line patch only checks for the http header X-GITLAB-TOKEN
and removes the dependency on the X-GITLAB-EVENT.
