### PR TITLE
Adjust openQA feature tests

### DIFF
--- a/dist/t/spec/features/0010_authentication_spec.rb
+++ b/dist/t/spec/features/0010_authentication_spec.rb
@@ -7,11 +7,13 @@ RSpec.describe "Authentication" do
 
   it "should be able to sign up" do
     visit "/"
-    fill_in 'login', with: 'test_user'
-    fill_in 'email', with: 'test_user@openqa.com'
-    fill_in 'pwd', with: 'opensuse'
-    fill_in 'pwd_confirmation', with: 'opensuse'
-    click_button('Sign Up')
+    within('.sign-up') do
+      fill_in 'login', with: 'test_user'
+      fill_in 'email', with: 'test_user@openqa.com'
+      fill_in 'pwd', with: 'opensuse'
+      fill_in 'pwd_confirmation', with: 'opensuse'
+      click_button('Sign Up')
+    end
     expect(page).to have_content("The account 'test_user' is now active.")
     expect(page).to have_link('link-to-user-home')
   end

--- a/dist/t/spec/features/0020_interconnect_spec.rb
+++ b/dist/t/spec/features/0020_interconnect_spec.rb
@@ -11,9 +11,9 @@ RSpec.describe "Interconnect" do
 
   it "should be able to create link" do
     visit "/interconnects/new"
-    # Don't wait for the javascript text replacement...
-    page.execute_script("$('input[type=\"submit\"]').prop('disabled', false)")
-    click_button('Create Remote project')
+    within('div[data-interconnect="openSUSE.org"]') do
+      click_button('Connect')
+    end
     expect(page).to have_content("Project 'openSUSE.org' was successfully created.")
   end
 end

--- a/dist/t/spec/features/0030_project_spec.rb
+++ b/dist/t/spec/features/0030_project_spec.rb
@@ -10,20 +10,20 @@ RSpec.describe "Project" do
   end
 
   it "should be able to create" do
-    within("div#subheader") do
+    within("div#personal-navigation") do
       click_link('Create Home')
     end
-    page.has_button?('Create Project') ? click_button('Create Project') : click_button('Accept')
+    click_button('Accept')
     expect(page).to have_content("Project 'home:Admin' was created successfully")
   end
 
   it "should be able to add repositories" do
-    within("div#subheader") do
+    within("div#personal-navigation") do
       click_link('Home Project')
     end
     click_link('Repositories')
-    click_link('Add repositories')
-    check('repo_openSUSE_Leap_15_1')
+    click_link('Add from a Distribution')
+    check('repo_openSUSE_Leap_15_1', allow_label_click: true)
     expect(page).to have_content("Successfully added repository 'openSUSE_Leap_15.1'")
   end
 end

--- a/dist/t/spec/features/0040_package_spec.rb
+++ b/dist/t/spec/features/0040_package_spec.rb
@@ -10,51 +10,55 @@ RSpec.describe "Package" do
   end
 
   it "should be able to create new" do
-    within("div#subheader") do
+    within("div#personal-navigation") do
       click_link('Home Project')
     end
-    page.has_link?('Create package') ? click_link('Create package') : click_link('Create Package')
+    click_link('Create Package')
     fill_in 'name', with: 'ctris'
     fill_in 'title', with: 'ctris'
     fill_in 'description', with: 'ctris'
-    page.has_button?('Save changes') ? click_button('Save changes') : click_button('Accept')
+    click_button('Create')
     expect(page).to have_content("Package 'ctris' was created successfully")
   end
 
   it "should be able to upload files" do
-    within("div#subheader") do
+    within("div#personal-navigation") do
       click_link('Home Project')
     end
     click_link('ctris')
     click_link('Add file')
-    attach_file("file", File.expand_path('../fixtures/ctris.spec', __dir__))
+    attach_file("file", File.expand_path('../fixtures/ctris.spec', __dir__), make_visible: true)
     click_button('Save')
     expect(page).to have_content("The file 'ctris.spec' has been successfully saved.")
 
     # second line of defense ;-)
     click_link('Add file')
-    attach_file("file", File.expand_path('../fixtures/ctris-0.42.tar.bz2', __dir__))
+    attach_file("file", File.expand_path('../fixtures/ctris-0.42.tar.bz2', __dir__), make_visible: true)
     click_button('Save')
     expect(page).to have_content("The file 'ctris-0.42.tar.bz2' has been successfully saved.")
   end
 
   it "should be able to branch" do
-    within("div#subheader") do
+    within("div#personal-navigation") do
       click_link('Home Project')
     end
-    page.has_link?('Branch existing package') ? click_link('Branch existing package') : click_link('Branch Existing Package')
-    fill_in 'linked_project', with: 'openSUSE.org:openSUSE:Tools'
-    fill_in 'linked_package', with: 'build'
-    # Do not wait for autocomplete
-    page.execute_script("$('input[type=\"submit\"]').prop('disabled', false)")
-    page.has_button?('Create Branch') ? click_button('Create Branch') : click_button('Accept')
+    click_link('Branch Existing Package')
+    within('#new-package-branch-modal') do
+      fill_in 'linked_project', with: 'openSUSE.org:openSUSE:Tools'
+      fill_in 'linked_package', with: 'build'
+      click_button('Accept')
+    end
     expect(page).to have_content('build.spec')
   end
 
   it 'should be able to delete' do
+    within("div#personal-navigation") do
+      click_link('Home Project')
+    end
+    click_link('build')
     click_link('Delete package')
     expect(page).to have_content('Do you really want to delete this package?')
-    page.has_button?('Ok') ? click_button('Ok') : click_button('Accept')
+    click_button('Delete')
     expect(page).to have_content('Package was successfully removed.')
   end
 
@@ -64,7 +68,7 @@ RSpec.describe "Package" do
       # wait for the build results ajax call
       sleep(5)
       puts "Refreshed build results, #{counter} retries left."
-      succeed_build = page.all('td', class: 'status_succeeded')
+      succeed_build = page.all('a', class: 'build-state-succeeded')
       break if succeed_build.length == 1
     end
   end

--- a/dist/t/spec/spec_helper.rb
+++ b/dist/t/spec/spec_helper.rb
@@ -37,15 +37,16 @@ end
 
 def login
   visit "/session/new"
-  fill_in 'user-login', with: 'Admin'
-  fill_in 'user-password', with: 'opensuse'
-  click_button('log-in-button')
-
+  within('#loginform') do
+    fill_in 'user-login', with: 'Admin'
+    fill_in 'user-password', with: 'opensuse'
+    click_button('Log In')
+  end
   expect(page).to have_link('link-to-user-home')
 end
 
 def logout
-  within("div#subheader") do
+  within("#personal-navigation") do
     click_link('Logout')
   end
   expect(page).to have_no_link('link-to-user-home')


### PR DESCRIPTION
Since the OBS webui changed quite a lot, the feature
tests needed some adjustment.

Big parts of the adjustments are copied over from
the 2.10 branch.

Co-authored-by: Eduardo Navarro <enavarro@suse.com>
Co-authored-by: David Kang <dkang@suse.com>

<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn
how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md

In order to make it as easy as possible for other developers to review your
pull request we ask you to:

- Explain what this PR is about in the description
- Explain the steps the reviewer has to follow to verify your change
- If the reviewer needs sample data to verify your change, please explain how to
  create that data
- If you include visual changes in this PR, please add screenshots or GIFs
- If you address performance in this PR, add benchmark data or explain how the
  reviewer can benchmark this

This is a good PR description example:

Hey Friends,

this introduces labels for the different build result states on the project
monitor page. This makes it easier to get a visual overview of what is going on
in your project.

To verify this feature

- Enable the interconnect to build.opensuse.org
- Create the project home:Admin
- Add 'openSUSE Tumbleweed' as a repository to the project
- Branch a couple of packages into the project:
  ```
  for i in `osc -A http://0.0.0.0:3000 ls openSUSE.org:home:hennevogel`; do osc -A http://0.0.0.0:3000 copypac openSUSE.org:home:hennevogel $i home:Admin; done
  ```
- Visit the monitor page and see the new labels for the different states.

Here is a screenshot of how it looks:

** Before **
![Screenshot of the project monitor](https://example.com/screenshot1.png)

** After **
![Screenshot of the project monitor](https://example.com/screenshot2.png)

-->
