### PR TITLE
Remove Bento unused actions in request controller

### DIFF
--- a/src/api/app/controllers/webui/request_controller.rb
+++ b/src/api/app/controllers/webui/request_controller.rb
@@ -11,11 +11,6 @@ class Webui::RequestController < Webui::WebuiController
 
   before_action :check_ajax, only: :sourcediff
 
-  def add_reviewer_dialog
-    @request_number = params[:number]
-    render_dialog('requestAddReviewAutocomplete')
-  end
-
   def add_reviewer
     begin
       opts = {}

--- a/src/api/app/controllers/webui/request_controller.rb
+++ b/src/api/app/controllers/webui/request_controller.rb
@@ -169,12 +169,6 @@ class Webui::RequestController < Webui::WebuiController
     redirect_to request_show_path(number: request.number)
   end
 
-  def add_role_request_dialog
-    @project = params[:project]
-    @package = params[:package] if params[:package]
-    render_dialog
-  end
-
   def add_role_request
     request = nil
     begin

--- a/src/api/app/controllers/webui/request_controller.rb
+++ b/src/api/app/controllers/webui/request_controller.rb
@@ -149,12 +149,6 @@ class Webui::RequestController < Webui::WebuiController
     render partial: 'requests_small', locals: { requests: requests }
   end
 
-  def delete_request_dialog
-    @project = params[:project]
-    @package = params[:package] if params[:package]
-    render_dialog
-  end
-
   def delete_request
     request = nil
     begin

--- a/src/api/app/controllers/webui/request_controller.rb
+++ b/src/api/app/controllers/webui/request_controller.rb
@@ -235,10 +235,6 @@ class Webui::RequestController < Webui::WebuiController
     redirect_to request_show_path(number: request.number)
   end
 
-  def set_incident_dialog
-    render_dialog
-  end
-
   def set_incident
     request = BsRequest.find_by_number(params[:number])
     if request.nil?

--- a/src/api/app/views/webui/request/show.html.haml
+++ b/src/api/app/views/webui/request/show.html.haml
@@ -25,8 +25,7 @@
       - if @can_add_reviews
         %ul.list-inline.mb-0
           %li.list-inline-item
-            = link_to(add_reviewer_dialog_path(number: @bs_request.number),
-                      data: { toggle: 'modal', target: '#add-reviewer-modal' }, class: 'nav-link') do
+            = link_to('#', data: { toggle: 'modal', target: '#add-reviewer-modal' }, class: 'nav-link') do
               %i.fas.fa-plus-circle.text-primary
               Add a Review
 

--- a/src/api/config/routes.rb
+++ b/src/api/config/routes.rb
@@ -354,7 +354,6 @@ OBSApi::Application.routes.draw do
       post 'request/changerequest' => :changerequest
       get 'request/diff/:number' => :diff
       get 'request/list_small' => :list_small, as: 'request_list_small'
-      get 'request/delete_request_dialog' => :delete_request_dialog, as: 'request_delete_dialog'
       post 'request/delete_request/:project' => :delete_request, constraints: cons, as: 'delete_request'
       get 'request/add_role_request_dialog' => :add_role_request_dialog, as: 'request_add_role_dialog'
       post 'request/add_role_request/:project' => :add_role_request, constraints: cons, as: 'add_role_request'

--- a/src/api/config/routes.rb
+++ b/src/api/config/routes.rb
@@ -347,7 +347,6 @@ OBSApi::Application.routes.draw do
     end
 
     controller 'webui/request' do
-      get 'request/add_reviewer_dialog' => :add_reviewer_dialog, as: :add_reviewer_dialog
       post 'request/add_reviewer' => :add_reviewer
       post 'request/modify_review' => :modify_review
       get 'request/show/:number' => :show, as: 'request_show', constraints: cons

--- a/src/api/config/routes.rb
+++ b/src/api/config/routes.rb
@@ -355,7 +355,6 @@ OBSApi::Application.routes.draw do
       get 'request/diff/:number' => :diff
       get 'request/list_small' => :list_small, as: 'request_list_small'
       post 'request/delete_request/:project' => :delete_request, constraints: cons, as: 'delete_request'
-      get 'request/add_role_request_dialog' => :add_role_request_dialog, as: 'request_add_role_dialog'
       post 'request/add_role_request/:project' => :add_role_request, constraints: cons, as: 'add_role_request'
       post 'request/set_bugowner_request' => :set_bugowner_request
       post 'request/change_devel_request/:project/:package' => :change_devel_request, constraints: cons, as: 'change_devel_request'

--- a/src/api/test/functional/webui/spider_test.rb
+++ b/src/api/test/functional/webui/spider_test.rb
@@ -56,7 +56,6 @@ class Webui::SpiderTest < Webui::IntegrationTest
   def raiseit(message, url)
     # known issues
     return if url =~ %r{/source/}
-    return if url.end_with?('/request/add_reviewer_dialog?number=10')
 
     warn "Found #{message} on #{url}, crawling path"
     indent = ' '

--- a/src/api/test/functional/webui/spider_test.rb
+++ b/src/api/test/functional/webui/spider_test.rb
@@ -33,6 +33,8 @@ class Webui::SpiderTest < Webui::IntegrationTest
       next unless link.port == baseuri.port
       link = link.to_s
       next if link =~ %r{/mini-profiler-resources}
+      # we do not really serve binary packages in the test environment
+      next if link =~ %r{/package/binary/}
       # that link is just a top ref
       next if link.end_with?('/package/rdiff')
       # admin can see even the hidden


### PR DESCRIPTION
As @dmarcoux [pointed out,](https://github.com/openSUSE/open-build-service/pull/8325#issuecomment-530779012) some actions were not removed from the request controller, those ending in _dialog.