### PR TITLE
Remove bento only requirements from cloud upload jobs log controller

### DIFF
--- a/src/api/app/controllers/webui/cloud/upload_job/logs_controller.rb
+++ b/src/api/app/controllers/webui/cloud/upload_job/logs_controller.rb
@@ -3,7 +3,7 @@ module Webui
     module UploadJob
       class LogsController < WebuiController
         before_action :require_login
-        before_action :validate_configuration_presence, :set_breadcrump, :set_log
+        before_action :validate_configuration_presence, :set_log
 
         def show
           authorize @upload_job, :show?
@@ -18,10 +18,6 @@ module Webui
           return if @upload_job.present?
           flash[:error] = "No log file found for #{params[:upload_id]} found."
           redirect_to cloud_upload_index_path
-        end
-
-        def set_breadcrump
-          @crumb_list = ['Cloud Upload', 'Log']
         end
 
         def validate_configuration_presence


### PR DESCRIPTION
Certain things in the controller are only need by the old
bento views, and can be removed as part of the migration
to bootstrap. 
The cloud upload logs only consists out of plain
text rendering through the controller, so no views need to be
removed.

<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn
how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md

In order to make it as easy as possible for other developers to review your
pull request we ask you to:

- Explain what this PR is about in the description
- Explain the steps the reviewer has to follow to verify your change
- If the reviewer needs sample data to verify your change, please explain how to
  create that data
- If you include visual changes in this PR, please add screenshots or GIFs
- If you address performance in this PR, add benchmark data or explain how the
  reviewer can benchmark this

This is a good PR description example:

Hey Friends,

this introduces labels for the different build result states on the project
monitor page. This makes it easier to get a visual overview of what is going on
in your project.

To verify this feature

- Enable the interconnect to build.opensuse.org
- Create the project home:Admin
- Add 'openSUSE Tumbleweed' as a repository to the project
- Branch a couple of packages into the project:
  ```
  for i in `osc -A http://0.0.0.0:3000 ls openSUSE.org:home:hennevogel`; do osc -A http://0.0.0.0:3000 copypac openSUSE.org:home:hennevogel $i home:Admin; done
  ```
- Visit the monitor page and see the new labels for the different states.

Here is a screenshot of how it looks:

** Before **
![Screenshot of the project monitor](https://example.com/screenshot1.png)

** After **
![Screenshot of the project monitor](https://example.com/screenshot2.png)

-->
