### PR TITLE
Change partials namespace

### DIFF
--- a/src/api/app/views/webui/interconnects/_interconnect_modal.html.haml
+++ b/src/api/app/views/webui/interconnects/_interconnect_modal.html.haml
@@ -23,4 +23,4 @@
             = f.text_field :description, class: 'form-control', required: true,
                                          placeholder: 'This project is representing a remote build service instance.'
         .modal-footer
-          = render partial: 'webui2/shared/dialog_action_buttons'
+          = render partial: 'webui/shared/dialog_action_buttons'

--- a/src/api/app/views/webui/main/_add_status_message_modal.html.haml
+++ b/src/api/app/views/webui/main/_add_status_message_modal.html.haml
@@ -12,4 +12,4 @@
             = label_tag(:severity, 'Severity:')
             = select_tag(:severity, options_for_select([['Information', 0], ['Green', 1], ['Yellow', 2], ['Red', 3]]), class: 'form-control')
           .modal-footer
-            = render partial: 'webui2/shared/dialog_action_buttons'
+            = render partial: 'webui/shared/dialog_action_buttons'

--- a/src/api/app/views/webui/patchinfo/edit.html.haml
+++ b/src/api/app/views/webui/patchinfo/edit.html.haml
@@ -8,8 +8,8 @@
     = form_for(@patchinfo, url: update_patchinfo_path(project: @project, package: @package), method: :put, html: { id: 'patchinfo' }) do |form|
       = form.hidden_field(:name)
       .form-group.col-md-8.col-lg-4
-        = render partial: 'webui/autocomplete', locals: { html_id: 'patchinfo[packager]', label: 'Packager', value: @patchinfo.packager,
-                                                          data: { source: autocomplete_users_path } }
+        = render partial: 'webui/shared/autocomplete', locals: { html_id: 'patchinfo[packager]', label: 'Packager', value: @patchinfo.packager,
+                                                                 data: { source: autocomplete_users_path } }
       .form-group.col-md-6
         = form.label(:summary) do
           Summary

--- a/src/api/app/views/webui/projects/maintained_projects/_create_dialog.html.haml
+++ b/src/api/app/views/webui/projects/maintained_projects/_create_dialog.html.haml
@@ -6,10 +6,10 @@
           %h5.modal-title#new-maintenance-project-modal
             Add maintained project to #{project_name}
         .modal-body
-          = render partial: 'webui2/webui/autocomplete', locals: { html_id: 'maintained_project', label: 'Project to be maintained:',
+          = render partial: 'webui/shared/autocomplete', locals: { html_id: 'maintained_project', label: 'Project to be maintained:',
                                                             source: autocomplete_projects_path }
         .modal-footer
-          = render partial: 'webui2/shared/dialog_action_buttons', locals: { submit_tag_text: 'Add' }
+          = render partial: 'webui/shared/dialog_action_buttons', locals: { submit_tag_text: 'Add' }
 
 = content_for :ready_function do
   :plain

--- a/src/api/app/views/webui/repositories/_add_dod_repository_modal.html.haml
+++ b/src/api/app/views/webui/repositories/_add_dod_repository_modal.html.haml
@@ -43,4 +43,4 @@
             .col-sm-8
               = text_area_tag :pubkey, nil, row: 2, class: 'form-control'
         .modal-footer
-          = render partial: 'webui2/shared/dialog_action_buttons'
+          = render partial: 'webui/shared/dialog_action_buttons'

--- a/src/api/app/views/webui/repositories/_add_repository_from_project_modal.html.haml
+++ b/src/api/app/views/webui/repositories/_add_repository_from_project_modal.html.haml
@@ -5,8 +5,8 @@
         .modal-header
           %h5.modal-title Add Repository to #{project}
         .modal-body.repository-autocomplete
-          = render partial: 'webui/autocomplete', locals: { html_id: 'target_project', label: '<strong>Project:</strong>'.html_safe,
-                                                            data: { source: autocomplete_projects_path } }
+          = render partial: 'webui/shared/autocomplete', locals: { html_id: 'target_project', label: '<strong>Project:</strong>'.html_safe,
+                                                                   data: { source: autocomplete_projects_path } }
 
           .form-group
             = label_tag :repositories do
@@ -28,4 +28,4 @@
                 = label_tag :architecture, architecture.name, class: 'custom-control-label', for: "architecture_#{architecture.name}"
 
         .modal-footer
-          = render partial: 'webui2/shared/dialog_action_buttons'
+          = render partial: 'webui/shared/dialog_action_buttons'

--- a/src/api/app/views/webui/repositories/_add_repository_path_modal.html.haml
+++ b/src/api/app/views/webui/repositories/_add_repository_path_modal.html.haml
@@ -5,8 +5,8 @@
         .modal-header
           %h5.modal-title Add additional path to #{repository}
         .modal-body.repository-autocomplete
-          = render partial: 'webui/autocomplete', locals: { html_id: 'target_project', label: '<strong>Project:</strong>'.html_safe,
-                                                            data: { source: autocomplete_projects_path } }
+          = render partial: 'webui/shared/autocomplete', locals: { html_id: 'target_project', label: '<strong>Project:</strong>'.html_safe,
+                                                                   data: { source: autocomplete_projects_path } }
           .form-group
             = label_tag :repositories do
               %strong Repositories:
@@ -17,5 +17,5 @@
           = hidden_field_tag :repository, repository
 
         .modal-footer
-          = render partial: 'webui2/shared/dialog_action_buttons'
+          = render partial: 'webui/shared/dialog_action_buttons'
 

--- a/src/api/app/views/webui/repositories/_dod_source_fields.html.haml
+++ b/src/api/app/views/webui/repositories/_dod_source_fields.html.haml
@@ -38,4 +38,4 @@
           = f.hidden_field :repository_id
           = hidden_field_tag :project, project
       .modal-footer
-        = render partial: 'webui2/shared/dialog_action_buttons'
+        = render partial: 'webui/shared/dialog_action_buttons'

--- a/src/api/app/views/webui/repositories/_edit_repository_modal.html.haml
+++ b/src/api/app/views/webui/repositories/_edit_repository_modal.html.haml
@@ -18,4 +18,4 @@
             = hidden_field_tag :repo, repository
 
         .modal-footer
-          = render partial: 'webui2/shared/dialog_action_buttons', locals: { submit_tag_text: 'Update' }
+          = render partial: 'webui/shared/dialog_action_buttons', locals: { submit_tag_text: 'Update' }

--- a/src/api/app/views/webui/repositories/_request_delete_repository_modal.html.haml
+++ b/src/api/app/views/webui/repositories/_request_delete_repository_modal.html.haml
@@ -17,7 +17,7 @@
             = label_tag :description
             = text_area_tag :description, '', row: 3, class: 'form-control'
         .modal-footer
-          = render partial: 'webui2/shared/dialog_action_buttons', locals: { submit_tag_text: 'Request' }
+          = render partial: 'webui/shared/dialog_action_buttons', locals: { submit_tag_text: 'Request' }
 - content_for :ready_function do
   :plain
     $('#request-delete-repository').on('show.bs.modal', function (event) {

--- a/src/api/app/views/webui/request/_add_reviewer_dialog.html.haml
+++ b/src/api/app/views/webui/request/_add_reviewer_dialog.html.haml
@@ -11,25 +11,25 @@
             = select_tag(:review_type, options_for_select([%w[User review-user], %w[Group review-group],
                                                            %w[Project review-project], %w[Package review-package]]), class: 'custom-select')
           .hideable.review-user
-            = render partial: 'webui/autocomplete', locals: { html_id: 'review_user', label: 'User:', required: true,
-                                                              data: { source: autocomplete_users_path } }
+            = render partial: 'webui/shared/autocomplete', locals: { html_id: 'review_user', label: 'User:', required: true,
+                                                                     data: { source: autocomplete_users_path } }
 
           .hideable.review-group.d-none
-            = render partial: 'webui/autocomplete', locals: { html_id: 'review_group', label: 'Group:', required: true,
-                                                              data: { source: autocomplete_groups_path } }
+            = render partial: 'webui/shared/autocomplete', locals: { html_id: 'review_group', label: 'Group:', required: true,
+                                                                     data: { source: autocomplete_groups_path } }
           .hideable.review-project.review-package.d-none
-            = render partial: 'webui/autocomplete', locals: { html_id: 'review_project', label: 'Project:', required: true,
-                                                              data: { source: autocomplete_projects_path } }
+            = render partial: 'webui/shared/autocomplete', locals: { html_id: 'review_project', label: 'Project:', required: true,
+                                                                     data: { source: autocomplete_projects_path } }
 
           .hideable.review-package.d-none
-            = render partial: 'webui/autocomplete', locals: { html_id: 'review_package', label: 'Package:', required: true,
-                                                              data: { source: autocomplete_packages_path } }
+            = render partial: 'webui/shared/autocomplete', locals: { html_id: 'review_package', label: 'Package:', required: true,
+                                                                     data: { source: autocomplete_packages_path } }
 
           .form-group
             = label_tag(:review_comment, 'Comment for reviewer:')
             = text_area_tag('review_comment', '', row: 3, class: 'form-control')
         .modal-footer
-          = render partial: 'webui2/shared/dialog_action_buttons'
+          = render partial: 'webui/shared/dialog_action_buttons'
 
 - content_for :ready_function do
   requestAddReviewAutocomplete();

--- a/src/api/app/views/webui/request/_add_role_request_dialog.html.haml
+++ b/src/api/app/views/webui/request/_add_role_request_dialog.html.haml
@@ -29,4 +29,4 @@
             = label_tag(:description, 'Description:')
             = text_area_tag(:description, '', row: 3, class: 'form-control')
           .modal-footer
-            = render partial: 'webui2/shared/dialog_action_buttons', locals: { submit_tag_text: 'Create' }
+            = render partial: 'webui/shared/dialog_action_buttons', locals: { submit_tag_text: 'Create' }

--- a/src/api/app/views/webui/request/_change_devel_request_dialog.html.haml
+++ b/src/api/app/views/webui/request/_change_devel_request_dialog.html.haml
@@ -9,11 +9,11 @@
             -# FIXME: get rid of this helper
             Do you want to request to change the devel project for #{package_link(package)} from
             \#{project_or_package_link(project: package.develpackage.project.name)}?
-          = render partial: 'webui/autocomplete', locals: { html_id: 'devel_project',
-                                                            label: 'New Devel project (leave free to delete the current one):',
-                                                            data: { source: autocomplete_projects_path } }
+          = render partial: 'webui/shared/autocomplete', locals: { html_id: 'devel_project',
+                                                                   label: 'New Devel project (leave free to delete the current one):',
+                                                                   data: { source: autocomplete_projects_path } }
           .form-group
             = label_tag(:description, 'Description:')
             = text_area_tag(:description, '', row: 3, class: 'form-control')
         .modal-footer
-          = render partial: 'webui2/shared/dialog_action_buttons', locals: { submit_tag_text: 'Create' }
+          = render partial: 'webui/shared/dialog_action_buttons', locals: { submit_tag_text: 'Create' }

--- a/src/api/app/views/webui/request/_delete_request_dialog.html.haml
+++ b/src/api/app/views/webui/request/_delete_request_dialog.html.haml
@@ -27,4 +27,4 @@
             = label_tag(:description, 'Please explain why:')
             = text_area_tag(:description, '', row: 3, class: 'form-control', required: true)
         .modal-footer
-          = render partial: 'webui2/shared/dialog_action_buttons', locals: { submit_tag_text: 'Create' }
+          = render partial: 'webui/shared/dialog_action_buttons', locals: { submit_tag_text: 'Create' }

--- a/src/api/app/views/webui/request/_sourcediff_tab.html.haml
+++ b/src/api/app/views/webui/request/_sourcediff_tab.html.haml
@@ -43,6 +43,6 @@
               %p.lead
                 No source changes.
       .col-lg-4
-        = render partial: 'webui2/shared/buildresult_box', locals: { project: action[:sprj], package: action[:spkg], index: action_counter }
+        = render partial: 'webui/shared/buildresult_box', locals: { project: action[:sprj], package: action[:spkg], index: action_counter }
         - if sourcediff['issues'].present?
           = render partial: 'issues_table', locals: { issues: sourcediff['issues'] }

--- a/src/api/app/views/webui/request/show.html.haml
+++ b/src/api/app/views/webui/request/show.html.haml
@@ -5,7 +5,7 @@
   content_for(:meta_image, gravatar_url(User.find_by_login(@bs_request.creator).email))
 
 - if @not_full_diff
-  = render partial: 'webui2/shared/truncated_diff_hint', locals: { path: request_show_path(number: @bs_request.number, full_diff: true) }
+  = render partial: 'webui/shared/truncated_diff_hint', locals: { path: request_show_path(number: @bs_request.number, full_diff: true) }
 
 = render partial: 'superseded_by_message', locals: { superseded_by: @bs_request.superseded_by,
                                                      number: @bs_request.number,

--- a/src/api/app/views/webui/search/_request_bugowner_change_dialog.html.haml
+++ b/src/api/app/views/webui/search/_request_bugowner_change_dialog.html.haml
@@ -10,11 +10,11 @@
             = select_tag(:review_type, options_for_select([%w[User review-user], %w[Group review-group]], 'review-user'), class: 'custom-select')
 
           .hideable.review-user
-            = render partial: 'webui/autocomplete', locals: { html_id: 'user', label: 'User:', required: true,
-                                                              data: { source: autocomplete_users_path } }
+            = render partial: 'webui/shared/autocomplete', locals: { html_id: 'user', label: 'User:', required: true,
+                                                                     data: { source: autocomplete_users_path } }
           .hideable.review-group.d-none
-            = render partial: 'webui/autocomplete', locals: { html_id: 'group', label: 'Group:', required: true,
-                                                              data: { source: autocomplete_groups_path } }
+            = render partial: 'webui/shared/autocomplete', locals: { html_id: 'group', label: 'Group:', required: true,
+                                                                     data: { source: autocomplete_groups_path } }
           .form-group
             For:
             - projects_and_packages.each do |project_and_package|
@@ -38,7 +38,7 @@
             ~ text_area_tag(:description, nil, size: '40x3', class: 'form-control', required: true)
 
         .modal-footer
-          = render partial: 'webui2/shared/dialog_action_buttons', locals: { submit_tag_text: 'Submit' }
+          = render partial: 'webui/shared/dialog_action_buttons', locals: { submit_tag_text: 'Submit' }
 
 - content_for :ready_function do
   requestAddReviewAutocomplete();

--- a/src/api/app/views/webui/user/_edit_dialog.html.haml
+++ b/src/api/app/views/webui/user/_edit_dialog.html.haml
@@ -13,4 +13,4 @@
             = f.label(:email, 'Email:')
             = f.text_field(:email, required: true, email: true, class: 'form-control')
         .modal-footer
-          = render partial: 'webui2/shared/dialog_action_buttons', locals: { submit_tag_text: 'Update' }
+          = render partial: 'webui/shared/dialog_action_buttons', locals: { submit_tag_text: 'Update' }

--- a/src/api/app/views/webui/user/_password_dialog.html.haml
+++ b/src/api/app/views/webui/user/_password_dialog.html.haml
@@ -15,4 +15,4 @@
             = label_tag :repeat_password, 'Repeat Password:'
             = text_field_tag :repeat_password, nil, type: 'password', autocomplete: 'off', required: 'true', class: 'form-control'
         .modal-footer
-          = render partial: 'webui2/shared/dialog_action_buttons', locals: { submit_tag_text: 'Update' }
+          = render partial: 'webui/shared/dialog_action_buttons', locals: { submit_tag_text: 'Update' }


### PR DESCRIPTION
During the migration we forgot to change the path of the partials to use
the correct shared directoy.

<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn
how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md

In order to make it as easy as possible for other developers to review your
pull request we ask you to:

- Explain what this PR is about in the description
- Explain the steps the reviewer has to follow to verify your change
- If the reviewer needs sample data to verify your change, please explain how to
  create that data
- If you include visual changes in this PR, please add screenshots or GIFs
- If you address performance in this PR, add benchmark data or explain how the
  reviewer can benchmark this

This is a good PR description example:

Hey Friends,

this introduces labels for the different build result states on the project
monitor page. This makes it easier to get a visual overview of what is going on
in your project.

To verify this feature

- Enable the interconnect to build.opensuse.org
- Create the project home:Admin
- Add 'openSUSE Tumbleweed' as a repository to the project
- Branch a couple of packages into the project:
  ```
  for i in `osc -A http://0.0.0.0:3000 ls openSUSE.org:home:hennevogel`; do osc -A http://0.0.0.0:3000 copypac openSUSE.org:home:hennevogel $i home:Admin; done
  ```
- Visit the monitor page and see the new labels for the different states.

Here is a screenshot of how it looks:

** Before **
![Screenshot of the project monitor](https://example.com/screenshot1.png)

** After **
![Screenshot of the project monitor](https://example.com/screenshot2.png)

-->
