### PR TITLE
[api] fix editing of issue tracker entries

### DIFF
--- a/docs/api/api/api.txt
+++ b/docs/api/api/api.txt
@@ -97,7 +97,7 @@ POST /issue_tracker/<name>
 
   Create new issue tracker.
 
-XmlResult: issue_tracker
+XmlResult: status
 
 DELETE /issue_tracker/<name>
 

--- a/src/api/app/controllers/issue_trackers_controller.rb
+++ b/src/api/app/controllers/issue_trackers_controller.rb
@@ -3,24 +3,19 @@ class IssueTrackersController < ApplicationController
 
   validate_action index: { method: :get, response: :issue_trackers }
   validate_action show: { method: :get, response: :issue_tracker }
-  validate_action create: { method: :post, request: :issue_tracker, response: :issue_tracker }
+  validate_action create: { method: :post, request: :issue_tracker, response: :status }
   validate_action update: { method: :put, request: :issue_tracker }
 
   # GET /issue_trackers
-  # GET /issue_trackers.json
-  # GET /issue_trackers.xml
   def index
     @issue_trackers = IssueTracker.all
 
     respond_to do |format|
       format.xml  { render xml: @issue_trackers.to_xml(IssueTracker::DEFAULT_RENDER_PARAMS) }
-      format.json { render json: @issue_trackers.to_json(IssueTracker::DEFAULT_RENDER_PARAMS) }
     end
   end
 
-  # GET /issue_trackers/bnc
-  # GET /issue_trackers/bnc.json
-  # GET /issue_trackers/bnc.xml
+  # GET /issue_trackers/<id>
   def show
     @issue_tracker = IssueTracker.find_by_name(params[:id])
     unless @issue_tracker
@@ -29,15 +24,11 @@ class IssueTrackersController < ApplicationController
 
     respond_to do |format|
       format.xml  { render xml: @issue_tracker.to_xml(IssueTracker::DEFAULT_RENDER_PARAMS) }
-      format.json { render json: @issue_tracker.to_json(IssueTracker::DEFAULT_RENDER_PARAMS) }
     end
   end
 
   # POST /issue_trackers
-  # POST /issue_trackers.json
-  # POST /issue_trackers.xml
   def create
-    # User didn't really upload www-form-urlencoded data but raw XML, try to parse that
     xml = Nokogiri::XML(request.raw_post, &:strict).root
     @issue_tracker = IssueTracker.create(name: xml.xpath('name[1]/text()').to_s,
                                          kind: xml.xpath('kind[1]/text()').to_s,
@@ -50,18 +41,14 @@ class IssueTrackersController < ApplicationController
                                          show_url: xml.xpath('show-url[1]/text()').to_s)
     respond_to do |format|
       if @issue_tracker
-        format.xml  { render xml: @issue_tracker.to_xml(IssueTracker::DEFAULT_RENDER_PARAMS), status: :created, location: @issue_tracker }
-        format.json { render json: @issue_tracker.to_json(IssueTracker::DEFAULT_RENDER_PARAMS), status: :created, location: @issue_tracker }
+        format.xml  { render_ok }
       else
         format.xml  { render xml: @issue_tracker.errors, status: :unprocessable_entity }
-        format.json { render json: @issue_tracker.errors, status: :unprocessable_entity }
       end
     end
   end
 
   # PUT /issue_trackers/bnc
-  # PUT /issue_trackers/bnc.json
-  # PUT /issue_trackers/bnc.xml
   def update
     respond_to do |format|
       xml = Nokogiri::XML(request.raw_post, &:strict).root
@@ -83,14 +70,11 @@ class IssueTrackersController < ApplicationController
       else
         IssueTracker.create(attribs)
       end
-      format.xml { head :ok }
-      format.json { head :ok }
+      format.xml { render_ok }
     end
   end
 
   # DELETE /issue_trackers/bnc
-  # DELETE /issue_trackers/bnc.xml
-  # DELETE /issue_trackers/bnc.json
   def destroy
     @issue_tracker = IssueTracker.find_by_name(params[:id])
     unless @issue_tracker
@@ -98,9 +82,6 @@ class IssueTrackersController < ApplicationController
     end
     @issue_tracker.destroy
 
-    respond_to do |format|
-      format.xml  { head :ok }
-      format.json { head :ok }
-    end
+    render_ok
   end
 end

--- a/src/api/test/functional/issue_trackers_controller_test.rb
+++ b/src/api/test/functional/issue_trackers_controller_test.rb
@@ -50,8 +50,6 @@ class IssueTrackersControllerTest < ActionDispatch::IntegrationTest
     assert_xml_tag tag: 'url', content: 'http://example.com'
     assert_xml_tag tag: 'show-url', content: 'http://example.com/@@@'
     assert_no_xml_tag tag: 'password'
-    get '/issue_trackers/test.json'
-    assert_response :success
 
     # FIXME: check backend data
 

--- a/src/api/test/functional/issue_trackers_controller_test.rb
+++ b/src/api/test/functional/issue_trackers_controller_test.rb
@@ -69,10 +69,10 @@ class IssueTrackersControllerTest < ActionDispatch::IntegrationTest
     </issue-tracker>
     EOF
     login_adrian
-    put '/issue_trackers/test', params: issue_tracker_xml
+    raw_put '/issue_trackers/test', issue_tracker_xml
     assert_response 403
     login_king
-    put '/issue_trackers/test', params: issue_tracker_xml
+    raw_put '/issue_trackers/test', issue_tracker_xml
     assert_response :success
     get '/issue_trackers/test'
     assert_response :success


### PR DESCRIPTION
eg. via

` # osc api -e /issue_trackers/$tracker
`
we need to backport in case 2.10 is also affected.

Also all other places in test suite where "put ...., params: $body_data"
is used needs to be checked if we broke the api there as well.
needs to become raw_put again...

<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn
how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md

In order to make it as easy as possible for other developers to review your
pull request we ask you to:

- Explain what this PR is about in the description
- Explain the steps the reviewer has to follow to verify your change
- If the reviewer needs sample data to verify your change, please explain how to
  create that data
- If you include visual changes in this PR, please add screenshots or GIFs
- If you address performance in this PR, add benchmark data or explain how the
  reviewer can benchmark this

This is a good PR description example:

Hey Friends,

this introduces labels for the different build result states on the project
monitor page. This makes it easier to get a visual overview of what is going on
in your project.

To verify this feature

- Enable the interconnect to build.opensuse.org
- Create the project home:Admin
- Add 'openSUSE Tumbleweed' as a repository to the project
- Branch a couple of packages into the project:
  ```
  for i in `osc -A http://0.0.0.0:3000 ls openSUSE.org:home:hennevogel`; do osc -A http://0.0.0.0:3000 copypac openSUSE.org:home:hennevogel $i home:Admin; done
  ```
- Visit the monitor page and see the new labels for the different states.

Here is a screenshot of how it looks:

** Before **
![Screenshot of the project monitor](https://example.com/screenshot1.png)

** After **
![Screenshot of the project monitor](https://example.com/screenshot2.png)

-->
