### PR TITLE
Remove actions for Bento modals in user_controller.rb

### DIFF
--- a/src/api/app/controllers/webui/user_controller.rb
+++ b/src/api/app/controllers/webui/user_controller.rb
@@ -62,14 +62,6 @@ class Webui::UserController < Webui::WebuiController
     redirect_back(fallback_location: user_path(other_user))
   end
 
-  def save_dialog
-    render_dialog
-  end
-
-  def password_dialog
-    render_dialog
-  end
-
   def change_password
     user = User.session!
 

--- a/src/api/config/routes.rb
+++ b/src/api/config/routes.rb
@@ -371,10 +371,8 @@ OBSApi::Application.routes.draw do
 
     controller 'webui/user' do
       post 'user/save' => :save, constraints: cons
-      get 'user/save_dialog' => :save_dialog
 
       post 'user/change_password' => :change_password
-      get 'user/password_dialog' => :password_dialog
 
       patch 'user' => :update, as: 'user_update'
 

--- a/src/api/spec/controllers/webui/user_controller_spec.rb
+++ b/src/api/spec/controllers/webui/user_controller_spec.rb
@@ -245,14 +245,6 @@ RSpec.describe Webui::UserController do
     end
   end
 
-  describe 'GET #save_dialog' do
-    skip
-  end
-
-  describe 'GET #password_dialog' do
-    skip
-  end
-
   describe 'POST #change_password' do
     before do
       login non_admin_user


### PR DESCRIPTION
`render_dialog` is for Bento modals which we don't need anymore. Their routes and specs were also removed.