### PR TITLE
 Consolidate duplicated methods from project and package controller 

### DIFF
--- a/src/api/app/controllers/webui/package_controller.rb
+++ b/src/api/app/controllers/webui/package_controller.rb
@@ -1097,10 +1097,6 @@ class Webui::PackageController < Webui::WebuiController
     files
   end
 
-  def add_path(action)
-    url_for(action: action, project: @project, role: params[:role], userid: params[:userid], package: @package)
-  end
-
   # Basically backend stores date in /source (package sources) and /build (package
   # build related). Logically build logs are stored in /build. Though build logs also
   # contain information related to source packages.

--- a/src/api/app/controllers/webui/package_controller.rb
+++ b/src/api/app/controllers/webui/package_controller.rb
@@ -1097,10 +1097,6 @@ class Webui::PackageController < Webui::WebuiController
     files
   end
 
-  def users_path
-    url_for(action: :users, project: @project, package: @package)
-  end
-
   def add_path(action)
     url_for(action: action, project: @project, role: params[:role], userid: params[:userid], package: @package)
   end

--- a/src/api/app/controllers/webui/project_controller.rb
+++ b/src/api/app/controllers/webui/project_controller.rb
@@ -883,10 +883,6 @@ class Webui::ProjectController < Webui::WebuiController
     ret
   end
 
-  def users_path
-    url_for(action: :users, project: @project.name)
-  end
-
   def add_path(action)
     url_for(action: action, project: @project.name, role: params[:role], userid: params[:userid])
   end

--- a/src/api/app/controllers/webui/project_controller.rb
+++ b/src/api/app/controllers/webui/project_controller.rb
@@ -883,10 +883,6 @@ class Webui::ProjectController < Webui::WebuiController
     ret
   end
 
-  def add_path(action)
-    url_for(action: action, project: @project.name, role: params[:role], userid: params[:userid])
-  end
-
   def set_project_by_name
     @project = Project.get_by_name(params['project'])
   rescue Project::UnknownObjectError

--- a/src/api/app/mixins/webui/manage_relationships.rb
+++ b/src/api/app/mixins/webui/manage_relationships.rb
@@ -7,19 +7,19 @@ module Webui::ManageRelationships
     rescue NotFoundError,
            Relationship::AddRole::SaveError => e
       flash[:error] = e.to_s
-      return redirect_to(users_path)
+      return redirect_to(custom_users_path)
     end
     respond_to do |format|
       format.js { render json: {}, status: :ok }
       format.html do
         success_str = what == :person ? "user #{params[:userid]}" : "group #{params[:groupid]}"
         flash[:success] = "Added #{success_str} with role #{params[:role]}"
-        redirect_to users_path
+        redirect_to custom_users_path
       end
     end
   end
 
-  def users_path
+  def custom_users_path
     url_for(action: :users, project: @project, package: @package)
   end
 
@@ -55,7 +55,7 @@ module Webui::ManageRelationships
         else
           flash[:success] = "Removed group '#{params[:groupid]}'"
         end
-        redirect_to users_path
+        redirect_to custom_users_path
       end
     end
   end

--- a/src/api/app/mixins/webui/manage_relationships.rb
+++ b/src/api/app/mixins/webui/manage_relationships.rb
@@ -1,14 +1,4 @@
 module Webui::ManageRelationships
-  def redirect_after_save
-    if switch_to_webui2
-      redirect_to(users_path)
-    elsif what == :person
-      redirect_to(add_path(:add_person))
-    else
-      redirect_to(add_path(:add_group))
-    end
-  end
-
   def save_person_or_group(what)
     authorize main_object, :update?
     begin
@@ -17,7 +7,7 @@ module Webui::ManageRelationships
     rescue NotFoundError,
            Relationship::AddRole::SaveError => e
       flash[:error] = e.to_s
-      return redirect_after_save
+      return redirect_to(users_path)
     end
     respond_to do |format|
       format.js { render json: {}, status: :ok }

--- a/src/api/app/mixins/webui/manage_relationships.rb
+++ b/src/api/app/mixins/webui/manage_relationships.rb
@@ -1,5 +1,5 @@
 module Webui::ManageRelationships
-  def redirect_after_save(what)
+  def redirect_after_save
     if switch_to_webui2
       redirect_to(users_path)
     elsif what == :person
@@ -17,7 +17,7 @@ module Webui::ManageRelationships
     rescue NotFoundError,
            Relationship::AddRole::SaveError => e
       flash[:error] = e.to_s
-      return redirect_after_save(what)
+      return redirect_after_save
     end
     respond_to do |format|
       format.js { render json: {}, status: :ok }
@@ -27,6 +27,10 @@ module Webui::ManageRelationships
         redirect_to users_path
       end
     end
+  end
+
+  def users_path
+    url_for(action: :users, project: @project, package: @package)
   end
 
   def save_person


### PR DESCRIPTION
Due to the migration from bento to bootstrap, certain
methods turned unnecessary and can be removed.

<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn
how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md

In order to make it as easy as possible for other developers to review your
pull request we ask you to:

- Explain what this PR is about in the description
- Explain the steps the reviewer has to follow to verify your change
- If the reviewer needs sample data to verify your change, please explain how to
  create that data
- If you include visual changes in this PR, please add screenshots or GIFs
- If you address performance in this PR, add benchmark data or explain how the
  reviewer can benchmark this

This is a good PR description example:

Hey Friends,

this introduces labels for the different build result states on the project
monitor page. This makes it easier to get a visual overview of what is going on
in your project.

To verify this feature

- Enable the interconnect to build.opensuse.org
- Create the project home:Admin
- Add 'openSUSE Tumbleweed' as a repository to the project
- Branch a couple of packages into the project:
  ```
  for i in `osc -A http://0.0.0.0:3000 ls openSUSE.org:home:hennevogel`; do osc -A http://0.0.0.0:3000 copypac openSUSE.org:home:hennevogel $i home:Admin; done
  ```
- Visit the monitor page and see the new labels for the different states.

Here is a screenshot of how it looks:

** Before **
![Screenshot of the project monitor](https://example.com/screenshot1.png)

** After **
![Screenshot of the project monitor](https://example.com/screenshot2.png)

-->
