### PR TITLE
Use correct path for collapsible_text partial

### DIFF
--- a/src/api/app/views/webui/package/show.html.haml
+++ b/src/api/app/views/webui/package/show.html.haml
@@ -18,7 +18,7 @@
           - if @package.description.blank?
             %i No description set
           - else
-            = render partial: 'webui/webui/collapsible_text', locals: { text: @package.description }
+            = render partial: 'webui/shared/collapsible_text', locals: { text: @package.description }
       .col-md-4
         = render partial: 'side_links', locals: { devel_package: devel_package,
                                                   failures: @failures,

--- a/src/api/app/views/webui/patchinfo/show.html.haml
+++ b/src/api/app/views/webui/patchinfo/show.html.haml
@@ -7,7 +7,7 @@
       .col-md-8
         = patchinfo_header(@patchinfo, @pkg_names)
         #description-text
-          = render partial: 'webui/webui/collapsible_text', locals: { text: @patchinfo.description }
+          = render partial: 'webui/shared/collapsible_text', locals: { text: @patchinfo.description }
       .col-md-4
         = render partial: 'side_elements', locals: { patchinfo: @patchinfo, packager: @packager }
 

--- a/src/api/app/views/webui/request/_request_history.html.haml
+++ b/src/api/app/views/webui/request/_request_history.html.haml
@@ -8,6 +8,6 @@
       = link_to('#request-creation', title: l(bs_request.created_at.utc), name: 'request-creation') do
         #{time_ago_in_words(bs_request.created_at)} ago
 
-    = render partial: 'webui/webui/collapsible_text', locals: { text: bs_request.description }
+    = render partial: 'webui/shared/collapsible_text', locals: { text: bs_request.description }
 
 = render partial: 'request_history_element', collection: history, as: :element

--- a/src/api/app/views/webui/request/_request_history_element.html.haml
+++ b/src/api/app/views/webui/request/_request_history_element.html.haml
@@ -11,4 +11,4 @@
       = link_to("#status-history-#{element.id}", title: l(element.created_at.utc), name: "status-history-#{element.id}") do
         #{time_ago_in_words(element.created_at)} ago
 
-    = render partial: 'webui/webui/collapsible_text', locals: { text: element.comment }
+    = render partial: 'webui/shared/collapsible_text', locals: { text: element.comment }

--- a/src/api/app/views/webui/request/_show_overview.html.haml
+++ b/src/api/app/views/webui/request/_show_overview.html.haml
@@ -3,6 +3,6 @@
 
 #description-text
   - if bs_request.description.present?
-    = render partial: 'webui/webui/collapsible_text', locals: { text: bs_request.description }
+    = render partial: 'webui/shared/collapsible_text', locals: { text: bs_request.description }
   - else
     %i No description set


### PR DESCRIPTION
During the migration this partial was moved into `webui/shared`
directory.

<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn
how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md

In order to make it as easy as possible for other developers to review your
pull request we ask you to:

- Explain what this PR is about in the description
- Explain the steps the reviewer has to follow to verify your change
- If the reviewer needs sample data to verify your change, please explain how to
  create that data
- If you include visual changes in this PR, please add screenshots or GIFs
- If you address performance in this PR, add benchmark data or explain how the
  reviewer can benchmark this

This is a good PR description example:

Hey Friends,

this introduces labels for the different build result states on the project
monitor page. This makes it easier to get a visual overview of what is going on
in your project.

To verify this feature

- Enable the interconnect to build.opensuse.org
- Create the project home:Admin
- Add 'openSUSE Tumbleweed' as a repository to the project
- Branch a couple of packages into the project:
  ```
  for i in `osc -A http://0.0.0.0:3000 ls openSUSE.org:home:hennevogel`; do osc -A http://0.0.0.0:3000 copypac openSUSE.org:home:hennevogel $i home:Admin; done
  ```
- Visit the monitor page and see the new labels for the different states.

Here is a screenshot of how it looks:

** Before **
![Screenshot of the project monitor](https://example.com/screenshot1.png)

** After **
![Screenshot of the project monitor](https://example.com/screenshot2.png)

-->
