### PR TITLE
Correctly link to full diffs of a linked package

### DIFF
--- a/src/api/app/views/webui/package/rdiff.html.haml
+++ b/src/api/app/views/webui/package/rdiff.html.haml
@@ -2,8 +2,10 @@
 - @pagetitle = "Changes of Revision #{@rev}"
 
 - if @not_full_diff
-  = render partial: 'webui/shared/truncated_diff_hint',
-  locals: { path: package_rdiff_path(project: @project, package: @package, linkrev: @linkrev, rev: @rev, full_diff: true) }
+  - path_variables = { project: @project, package: @package, linkrev: @linkrev, rev: @rev, full_diff: true }
+  - path_variables.merge!({ oproject: @oproject, opackage: @opackage }) if @opackage
+
+  = render partial: 'webui/shared/truncated_diff_hint', locals: { path: package_rdiff_path(path_variables) }
 
 .card
   = render partial: 'tabs', locals: { project: @project, package: @package }


### PR DESCRIPTION
The original package and project were not passed to the full diffs link for a linked package.

Fixes #8360

For reviewers, these pages to see/try the full diffs link for:
- a package's revision:  https://obs-reviewlab.opensuse.org/dmarcoux-issue-8360/package/rdiff/home:Admin:branches:home:Admin/php7?rev=2
- a linked package: https://obs-reviewlab.opensuse.org/dmarcoux-issue-8360/package/rdiff/home:Admin:branches:home:Admin/php7?opackage=php7&oproject=home%3AAdmin&rev=2