### PR TITLE
Remove switch_to_webui2 method

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -105,9 +105,6 @@ jobs:
             cd src/api
             pickfile=log/pick.$CIRCLE_NODE_INDEX.list
 
-            # TODO: Remove this when switch_to_webui2 is removed
-            export BOOTSTRAP=1
-
             # single out db specs
             circleci tests glob 'spec/**/*_spec.rb' | grep -v 'spec/db/' > spec.list
             circleci tests split --total $CIRCLE_NODE_TOTAL --split-by=timings < spec.list > $pickfile

--- a/dist/obs-api-testsuite-rspec.spec
+++ b/dist/obs-api-testsuite-rspec.spec
@@ -60,8 +60,7 @@ export RAILS_ENV=test
 bin/rake db:create db:setup
 bin/rails assets:precompile
 
-# run all specs with BOOTSTRAP enabled (default)
-BOOTSTRAP=1 bin/rspec -f d --exclude-pattern 'spec/db/**/*_spec.rb'
+bin/rspec -f d --exclude-pattern 'spec/db/**/*_spec.rb'
 
 # now migration tests (if they fail they create tons of follow up errors, so run them last)
 bin/rspec -f d -P 'spec/db/**/*_spec.rb'

--- a/src/api/app/assets/javascripts/webui/requests_table.js.erb
+++ b/src/api/app/assets/javascripts/webui/requests_table.js.erb
@@ -29,7 +29,6 @@ $(document).ready(function() {
           d.dataTableId = dataTableId;
           d.type = typeDropdown.val();
           d.state = stateDropdown.val();
-          d.switch_to_webui2 = true;
         }
       },
       stateSave: true,

--- a/src/api/app/controllers/webui/announcements_controller.rb
+++ b/src/api/app/controllers/webui/announcements_controller.rb
@@ -4,6 +4,5 @@ class Webui::AnnouncementsController < Webui::WebuiController
     @announcement = Announcement.find_by(id: params[:id])
 
     redirect_back(fallback_location: root_path, error: "Couldn't find announcement") unless @announcement
-    switch_to_webui2
   end
 end

--- a/src/api/app/controllers/webui/apidocs_controller.rb
+++ b/src/api/app/controllers/webui/apidocs_controller.rb
@@ -1,14 +1,11 @@
 class Webui::ApidocsController < Webui::WebuiController
   def index
     @filename = File.expand_path(CONFIG['apidocs_location']) + '/index.html'
-    if File.exist?(@filename)
-      return if switch_to_webui2
-      render file: @filename, formats: [:html]
-    else
-      logger.error "Unable to load apidocs index file from #{CONFIG['apidocs_location']}. Did you create the apidocs?"
-      flash[:error] = 'Unable to load API documentation.'
-      redirect_back(fallback_location: root_path)
-    end
+    return if File.exist?(@filename)
+
+    logger.error "Unable to load apidocs index file from #{CONFIG['apidocs_location']}. Did you create the apidocs?"
+    flash[:error] = 'Unable to load API documentation.'
+    redirect_back(fallback_location: root_path)
   end
 
   def file

--- a/src/api/app/controllers/webui/architectures_controller.rb
+++ b/src/api/app/controllers/webui/architectures_controller.rb
@@ -4,9 +4,6 @@ class Webui::ArchitecturesController < Webui::WebuiController
 
   def index
     @architectures = Architecture.order(:name)
-
-    # TODO: Remove the statement after migration is finished
-    switch_to_webui2
   end
 
   def update

--- a/src/api/app/controllers/webui/attribute_controller.rb
+++ b/src/api/app/controllers/webui/attribute_controller.rb
@@ -10,8 +10,6 @@ class Webui::AttributeController < Webui::WebuiController
 
   def index
     @attributes = @container.attribs.includes(:issues, :values, attrib_type: [:attrib_namespace]).sort_by(&:fullname)
-
-    switch_to_webui2
   end
 
   def new
@@ -24,8 +22,6 @@ class Webui::AttributeController < Webui::WebuiController
     authorize @attribute, :create?
 
     @attribute_types = AttribType.includes(:attrib_namespace).all.sort_by(&:fullname)
-
-    switch_to_webui2
   end
 
   def edit
@@ -45,8 +41,6 @@ class Webui::AttributeController < Webui::WebuiController
     end
 
     @allowed_values = @attribute.attrib_type.allowed_values.map(&:value)
-
-    switch_to_webui2
   end
 
   def create

--- a/src/api/app/controllers/webui/cloud/azure/configurations_controller.rb
+++ b/src/api/app/controllers/webui/cloud/azure/configurations_controller.rb
@@ -5,9 +5,6 @@ module Webui
         before_action :require_login
         before_action :set_azure_configuration
 
-        # GET /cloud/azure/configuration
-        def show; end
-
         # PATCH/PUT /cloud/azure/configuration
         def update
           if @azure_configuration.update(permitted_params)

--- a/src/api/app/controllers/webui/cloud/azure/configurations_controller.rb
+++ b/src/api/app/controllers/webui/cloud/azure/configurations_controller.rb
@@ -6,9 +6,7 @@ module Webui
         before_action :set_azure_configuration
 
         # GET /cloud/azure/configuration
-        def show
-          switch_to_webui2
-        end
+        def show; end
 
         # PATCH/PUT /cloud/azure/configuration
         def update

--- a/src/api/app/controllers/webui/cloud/azure/upload_jobs_controller.rb
+++ b/src/api/app/controllers/webui/cloud/azure/upload_jobs_controller.rb
@@ -5,7 +5,6 @@ module Webui
         def new
           xml_object = OpenStruct.new(params.slice(:project, :package, :repository, :arch, :filename))
           @upload_job = ::Cloud::Backend::UploadJob.new(xml_object: xml_object)
-          switch_to_webui2
         end
 
         private

--- a/src/api/app/controllers/webui/cloud/configurations_controller.rb
+++ b/src/api/app/controllers/webui/cloud/configurations_controller.rb
@@ -1,9 +1,7 @@
 module Webui
   module Cloud
     class ConfigurationsController < WebuiController
-      def index
-        switch_to_webui2
-      end
+      def index; end
     end
   end
 end

--- a/src/api/app/controllers/webui/cloud/configurations_controller.rb
+++ b/src/api/app/controllers/webui/cloud/configurations_controller.rb
@@ -1,7 +1,6 @@
 module Webui
   module Cloud
     class ConfigurationsController < WebuiController
-      def index; end
     end
   end
 end

--- a/src/api/app/controllers/webui/cloud/ec2/configurations_controller.rb
+++ b/src/api/app/controllers/webui/cloud/ec2/configurations_controller.rb
@@ -5,7 +5,6 @@ module Webui
         before_action :require_login
 
         def show
-          switch_to_webui2
           @ec2_configuration = User.session!.ec2_configuration || User.session!.create_ec2_configuration
           @aws_account_id = CONFIG['aws_account_id']
         end

--- a/src/api/app/controllers/webui/cloud/ec2/upload_jobs_controller.rb
+++ b/src/api/app/controllers/webui/cloud/ec2/upload_jobs_controller.rb
@@ -6,7 +6,6 @@ module Webui
           xml_object = OpenStruct.new(params.slice(:project, :package, :repository, :arch, :filename))
           @upload_job = ::Cloud::Backend::UploadJob.new(xml_object: xml_object)
           @regions = ::Cloud::Ec2::Configuration::REGIONS
-          switch_to_webui2
         end
 
         private

--- a/src/api/app/controllers/webui/cloud/upload_jobs_controller.rb
+++ b/src/api/app/controllers/webui/cloud/upload_jobs_controller.rb
@@ -8,14 +8,12 @@ module Webui
       before_action :set_upload_job, only: :destroy
 
       def index
-        switch_to_webui2
         @upload_jobs = ::Cloud::Backend::UploadJob.all(User.session!)
       end
 
       def new
         @user_ec2_configured = User.session!.ec2_configuration.present?
         @user_azure_configured = User.session!.azure_configuration.present?
-        switch_to_webui2
       end
 
       def create

--- a/src/api/app/controllers/webui/comments_controller.rb
+++ b/src/api/app/controllers/webui/comments_controller.rb
@@ -3,8 +3,6 @@ class Webui::CommentsController < Webui::WebuiController
   before_action :find_commentable, only: :create
 
   def create
-    switch_to_webui2
-
     comment = @commented.comments.new(permitted_params)
     User.session!.comments << comment
     @commentable = comment.commentable
@@ -24,8 +22,6 @@ class Webui::CommentsController < Webui::WebuiController
   end
 
   def destroy
-    switch_to_webui2
-
     comment = Comment.find(params[:id])
     authorize comment, :destroy?
     @commentable = comment.commentable

--- a/src/api/app/controllers/webui/configuration_controller.rb
+++ b/src/api/app/controllers/webui/configuration_controller.rb
@@ -2,8 +2,6 @@ class Webui::ConfigurationController < Webui::WebuiController
   before_action :require_admin
   before_action :set_configuration, only: [:update]
 
-  def index; end
-
   def update
     respond_to do |format|
       if @configuration.update(configuration_params)

--- a/src/api/app/controllers/webui/configuration_controller.rb
+++ b/src/api/app/controllers/webui/configuration_controller.rb
@@ -2,10 +2,7 @@ class Webui::ConfigurationController < Webui::WebuiController
   before_action :require_admin
   before_action :set_configuration, only: [:update]
 
-  def index
-    # TODO: Remove the statement after migration is finished
-    switch_to_webui2
-  end
+  def index; end
 
   def update
     respond_to do |format|

--- a/src/api/app/controllers/webui/groups_controller.rb
+++ b/src/api/app/controllers/webui/groups_controller.rb
@@ -6,20 +6,12 @@ class Webui::GroupsController < Webui::WebuiController
   def index
     authorize Group, :index?
     @groups = Group.all.includes(:users)
-
-    # TODO: Remove the statement after migration is finished
-    switch_to_webui2
   end
 
-  def show
-    switch_to_webui2
-  end
+  def show; end
 
   def new
     authorize Group, :create?
-
-    # TODO: Remove the statement after migration is finished
-    switch_to_webui2
   end
 
   def create

--- a/src/api/app/controllers/webui/image_templates_controller.rb
+++ b/src/api/app/controllers/webui/image_templates_controller.rb
@@ -2,7 +2,6 @@ class Webui::ImageTemplatesController < Webui::WebuiController
   def index
     @projects = Project.image_templates
 
-    switch_to_webui2
     respond_to do |format|
       format.html
       format.xml

--- a/src/api/app/controllers/webui/interconnects_controller.rb
+++ b/src/api/app/controllers/webui/interconnects_controller.rb
@@ -1,13 +1,9 @@
 class Webui::InterconnectsController < Webui::WebuiController
   before_action :require_admin
 
-  def new
-    switch_to_webui2
-  end
+  def new; end
 
   def create
-    switch_to_webui2
-
     @project = RemoteProject.new(project_params)
 
     respond_to do |format|

--- a/src/api/app/controllers/webui/interconnects_controller.rb
+++ b/src/api/app/controllers/webui/interconnects_controller.rb
@@ -1,8 +1,6 @@
 class Webui::InterconnectsController < Webui::WebuiController
   before_action :require_admin
 
-  def new; end
-
   def create
     @project = RemoteProject.new(project_params)
 

--- a/src/api/app/controllers/webui/kiwi/images_controller.rb
+++ b/src/api/app/controllers/webui/kiwi/images_controller.rb
@@ -47,7 +47,7 @@ module Webui
         @is_edit_software_action = false
 
         respond_to do |format|
-          format.html { switch_to_webui2 }
+          format.html
           format.json { render json: { isOutdated: @image.outdated? } }
         end
       end
@@ -63,10 +63,6 @@ module Webui
 
         @is_edit_details_action = params[:section] == 'details' || params[:section].nil?
         @is_edit_software_action = params[:section] == 'software'
-
-        respond_to do |format|
-          format.html { switch_to_webui2 }
-        end
       end
 
       def update
@@ -90,7 +86,6 @@ module Webui
       end
 
       def build_result
-        switch_to_webui2
         if @image.package.project.repositories.any?
           @build_results = @image.build_results
           render partial: 'build_status'

--- a/src/api/app/controllers/webui/main_controller.rb
+++ b/src/api/app/controllers/webui/main_controller.rb
@@ -25,8 +25,6 @@ class Webui::MainController < Webui::WebuiController
         users: User.count
       }
     end
-
-    switch_to_webui2
   end
 
   private

--- a/src/api/app/controllers/webui/monitor_controller.rb
+++ b/src/api/app/controllers/webui/monitor_controller.rb
@@ -6,9 +6,7 @@ class Webui::MonitorController < Webui::WebuiController
 
   DEFAULT_SEARCH_RANGE = 24
 
-  def old
-    switch_to_webui2
-  end
+  def old; end
 
   def index
     if request.post? && !params[:project].nil? && Project.valid_name?(params[:project])
@@ -38,7 +36,6 @@ class Webui::MonitorController < Webui::WebuiController
       @workers_sorted = workers.sort_by { |a| a[0] } if workers
       @available_arch_list = Architecture.available.order(:name).pluck(:name)
     end
-    switch_to_webui2
   end
 
   def update_building

--- a/src/api/app/controllers/webui/monitor_controller.rb
+++ b/src/api/app/controllers/webui/monitor_controller.rb
@@ -6,8 +6,6 @@ class Webui::MonitorController < Webui::WebuiController
 
   DEFAULT_SEARCH_RANGE = 24
 
-  def old; end
-
   def index
     if request.post? && !params[:project].nil? && Project.valid_name?(params[:project])
       redirect_to project: params[:project]

--- a/src/api/app/controllers/webui/packages/bs_requests_controller.rb
+++ b/src/api/app/controllers/webui/packages/bs_requests_controller.rb
@@ -12,7 +12,6 @@ module Webui
         respond_to do |format|
           format.json { render 'webui/shared/bs_requests/index' }
         end
-        switch_to_webui2
       end
     end
   end

--- a/src/api/app/controllers/webui/packages/build_reason_controller.rb
+++ b/src/api/app/controllers/webui/packages/build_reason_controller.rb
@@ -8,7 +8,6 @@ module Webui
 
       def index
         @details = @package.last_build_reason(@repository, @architecture.name, @package_name)
-        switch_to_webui2
         return if @details.explain.present?
 
         redirect_back(fallback_location: package_binaries_path(package: @package, project: @project, repository: @repository.name),

--- a/src/api/app/controllers/webui/packages/job_history_controller.rb
+++ b/src/api/app/controllers/webui/packages/job_history_controller.rb
@@ -8,7 +8,6 @@ module Webui
 
       def index
         @jobshistory = @package.jobhistory(repository_name: @repository.name, arch_name: @architecture.name, package_name: @package_name)
-        switch_to_webui2
       end
 
       private

--- a/src/api/app/controllers/webui/patchinfo_controller.rb
+++ b/src/api/app/controllers/webui/patchinfo_controller.rb
@@ -29,21 +29,15 @@ class Webui::PatchinfoController < Webui::WebuiController
     # TODO: check that @tracker has sense if it's coming from create (new_patchinfo) action
     @tracker = ::Configuration.default_tracker
     @patchinfo.binaries.each { |bin| @binarylist.delete(bin) }
-
-    switch_to_webui2
   end
 
   def show
     @pkg_names = @project.packages.pluck(:name)
     @pkg_names.delete('patchinfo')
     @packager = User.where(login: @patchinfo.packager).first
-
-    switch_to_webui2
   end
 
   def update
-    switch_to_webui2
-
     authorize @package, :update?
     @patchinfo = Patchinfo.new(patchinfo_params)
     if @patchinfo.valid?

--- a/src/api/app/controllers/webui/project_controller.rb
+++ b/src/api/app/controllers/webui/project_controller.rb
@@ -32,8 +32,6 @@ class Webui::ProjectController < Webui::WebuiController
                                             :remove_target_request, :toggle_watch, :edit_comment, :edit_comment_form]
 
   def index
-    switch_to_webui2
-
     respond_to do |format|
       format.html do
         render :index,
@@ -69,13 +67,9 @@ class Webui::ProjectController < Webui::WebuiController
     @users = @project.users
     @groups = @project.groups
     @roles = Role.local_roles
-
-    switch_to_webui2
   end
 
   def subprojects
-    switch_to_webui2
-
     respond_to do |format|
       format.html
       format.json do
@@ -89,14 +83,10 @@ class Webui::ProjectController < Webui::WebuiController
     @project.name = params[:name] if params[:name]
 
     @show_restore_message = params[:restore_option] && Project.deleted?(params[:name])
-
-    switch_to_webui2
   end
 
   def new_package
     authorize @project, :update?
-
-    switch_to_webui2
   end
 
   def new_release_request
@@ -143,14 +133,11 @@ class Webui::ProjectController < Webui::WebuiController
     @has_patchinfo = @project.patchinfos.exists?
     @comments = @project.comments
     @comment = Comment.new
-
-    switch_to_webui2
   end
 
   def packages_simple; end
 
   def buildresult
-    switch_to_webui2
     render partial: 'buildstatus', locals: { project: @project,
                                              buildresults: @project.buildresults,
                                              collapsed_repositories: params.fetch(:collapsedRepositories, {}) }
@@ -176,7 +163,6 @@ class Webui::ProjectController < Webui::WebuiController
     @requests = @project.open_requests
     @default_request_type = params[:type] if params[:type]
     @default_request_state = params[:state] if params[:state]
-    switch_to_webui2
   end
 
   def create
@@ -309,7 +295,6 @@ class Webui::ProjectController < Webui::WebuiController
   end
 
   def monitor
-    switch_to_webui2
     unless (buildresult = monitor_buildresult)
       @buildresult_unavailable = true
       return
@@ -356,18 +341,14 @@ class Webui::ProjectController < Webui::WebuiController
       format.html { redirect_to({ action: :status, project: @project }, success: 'Cleared comments for packages.') }
       format.js { render 'clear_failed_comment' }
     end
-    switch_to_webui2
   end
 
-  def edit_comment_form
-    switch_to_webui2
-  end
+  def edit_comment_form; end
 
   # FIXME: This should authorize create on this attribute
   def edit_comment
     @package = @project.find_package(params[:package])
 
-    switch_to_webui2
     at = AttribType.find_by_namespace_and_name!('OBS', 'ProjectStatusPackageFailComment')
     unless User.session!.can_create_attribute_in?(@package, at)
       @comment = params[:last_comment]
@@ -416,8 +397,6 @@ class Webui::ProjectController < Webui::WebuiController
       end
       format.html
     end
-
-    switch_to_webui2
   end
 
   def unlock

--- a/src/api/app/controllers/webui/project_controller.rb
+++ b/src/api/app/controllers/webui/project_controller.rb
@@ -343,8 +343,6 @@ class Webui::ProjectController < Webui::WebuiController
     end
   end
 
-  def edit_comment_form; end
-
   # FIXME: This should authorize create on this attribute
   def edit_comment
     @package = @project.find_package(params[:package])

--- a/src/api/app/controllers/webui/projects/bs_requests_controller.rb
+++ b/src/api/app/controllers/webui/projects/bs_requests_controller.rb
@@ -11,7 +11,6 @@ module Webui
         respond_to do |format|
           format.json { render 'webui/shared/bs_requests/index' }
         end
-        switch_to_webui2
       end
     end
   end

--- a/src/api/app/controllers/webui/projects/maintained_projects_controller.rb
+++ b/src/api/app/controllers/webui/projects/maintained_projects_controller.rb
@@ -13,7 +13,6 @@ module Webui
                                                                 project: @project, current_user: User.possibly_nobody)
           end
         end
-        switch_to_webui2
       end
 
       def destroy

--- a/src/api/app/controllers/webui/projects/maintenance_incidents_controller.rb
+++ b/src/api/app/controllers/webui/projects/maintenance_incidents_controller.rb
@@ -16,7 +16,6 @@ module Webui
             render json: MaintenanceIncidentDatatable.new(params, view_context: view_context, project: @project)
           end
         end
-        switch_to_webui2
       end
 
       def create

--- a/src/api/app/controllers/webui/projects/meta_controller.rb
+++ b/src/api/app/controllers/webui/projects/meta_controller.rb
@@ -7,7 +7,6 @@ module Webui
 
       def show
         @meta = @project.render_xml
-        switch_to_webui2
       end
 
       def update
@@ -21,7 +20,6 @@ module Webui
                    flash.now[:error] = updater.errors
                    400
                  end
-        switch_to_webui2
         render layout: false, status: status, partial: 'layouts/webui/flash', object: flash
       end
 

--- a/src/api/app/controllers/webui/projects/project_configuration_controller.rb
+++ b/src/api/app/controllers/webui/projects/project_configuration_controller.rb
@@ -8,7 +8,6 @@ module Webui
         result = ::ProjectConfigurationService::ProjectConfigurationPresenter.new(@project, params).call
         @content = result.config if result.valid?
 
-        switch_to_webui2
         return if @content
         raise ActiveRecord::RecordNotFound, 'Not Found'
       end
@@ -23,7 +22,6 @@ module Webui
                    flash.now[:error] = result.errors
                    400
                  end
-        switch_to_webui2
         render layout: false, status: status, partial: 'layouts/webui/flash', object: flash
       end
     end

--- a/src/api/app/controllers/webui/projects/pulse_controller.rb
+++ b/src/api/app/controllers/webui/projects/pulse_controller.rb
@@ -6,7 +6,6 @@ module Webui
       before_action :set_pulse, if: -> { request.xhr? }
 
       def show
-        switch_to_webui2
         @pulse = @project.project_log_entries.page(params[:page])
       end
 

--- a/src/api/app/controllers/webui/projects/rebuild_times_controller.rb
+++ b/src/api/app/controllers/webui/projects/rebuild_times_controller.rb
@@ -43,8 +43,6 @@ module Webui
         # we append 4 empty paths, so there are always at least 4 in the array
         # to simplify the view code
         4.times { @longestpaths << [] }
-
-        switch_to_webui2
       end
 
       def rebuild_time_png

--- a/src/api/app/controllers/webui/repositories_controller.rb
+++ b/src/api/app/controllers/webui/repositories_controller.rb
@@ -11,8 +11,6 @@ class Webui::RepositoriesController < Webui::WebuiController
   # GET package/repositories/:project/:package
   # GET project/repositories/:project
   def index
-    switch_to_webui2
-
     @available_architectures = Architecture.available
     @repositories = @project.repositories.preload({ path_elements: { link: :project } }, :architectures)
     @repositories = @repositories.includes(:download_repositories)
@@ -36,8 +34,6 @@ class Webui::RepositoriesController < Webui::WebuiController
       @distributions[dis['vendor']] ||= []
       @distributions[dis['vendor']] << dis
     end
-
-    switch_to_webui2
 
     return unless @distributions.empty?
     redirect_to(action: 'new', project: @project) && return unless User.admin_session?
@@ -73,8 +69,6 @@ class Webui::RepositoriesController < Webui::WebuiController
         format.js
       end
     end
-
-    switch_to_webui2
   end
 
   # POST project/update_target/:project
@@ -116,14 +110,10 @@ class Webui::RepositoriesController < Webui::WebuiController
         format.js
       end
     end
-
-    switch_to_webui2
   end
 
   # GET project/repository_state/:project/:repository
-  def state
-    switch_to_webui2
-  end
+  def state; end
 
   # POST /project/create_dod_repository
   def create_dod_repository

--- a/src/api/app/controllers/webui/repositories_controller.rb
+++ b/src/api/app/controllers/webui/repositories_controller.rb
@@ -174,7 +174,6 @@ class Webui::RepositoriesController < Webui::WebuiController
   # POST flag/:project(/:package)
   def change_flag
     required_parameters :flag, :command
-    set_webui2_views
     authorize @main_object, :update?
 
     flag_type = params[:flag]

--- a/src/api/app/controllers/webui/request_controller.rb
+++ b/src/api/app/controllers/webui/request_controller.rb
@@ -93,7 +93,6 @@ class Webui::RequestController < Webui::WebuiController
     @comments = @bs_request.comments
     @comment = Comment.new
 
-    switch_to_webui2
     @actions = @bs_request.webui_actions(filelimit: diff_limit, tarlimit: diff_limit, diff_to_superseded: @diff_to_superseded, diffs: true)
     # print a hint that the diff is not fully shown (this only needs to be verified for submit actions)
     @not_full_diff = BsRequest.truncated_diffs?(@actions)
@@ -145,7 +144,6 @@ class Webui::RequestController < Webui::WebuiController
   def list_small
     redirect_to(user_path(User.possibly_nobody)) && return unless request.xhr? # non ajax request
     requests = BsRequest.list(params)
-    switch_to_webui2
     render partial: 'requests_small', locals: { requests: requests }
   end
 

--- a/src/api/app/controllers/webui/search_controller.rb
+++ b/src/api/app/controllers/webui/search_controller.rb
@@ -4,14 +4,10 @@ class Webui::SearchController < Webui::WebuiController
   before_action :set_parameters, except: :issue
 
   def index
-    switch_to_webui2
-
     search
   end
 
   def owner
-    switch_to_webui2
-
     Backend::Test.start if Rails.env.test?
 
     # If the search is too short, return
@@ -26,7 +22,6 @@ class Webui::SearchController < Webui::WebuiController
   end
 
   def issue
-    switch_to_webui2
     return unless params[:issue] && params[:issue_tracker]
 
     search_issue

--- a/src/api/app/controllers/webui/session_controller.rb
+++ b/src/api/app/controllers/webui/session_controller.rb
@@ -7,9 +7,7 @@ class Webui::SessionController < Webui::WebuiController
 
   skip_before_action :check_anonymous, only: [:create]
 
-  def new
-    switch_to_webui2
-  end
+  def new; end
 
   def create
     User.session = @session_creator.user

--- a/src/api/app/controllers/webui/staging/projects_controller.rb
+++ b/src/api/app/controllers/webui/staging/projects_controller.rb
@@ -4,7 +4,6 @@ module Webui
       before_action :require_login
       before_action :set_staging_workflow
       after_action :verify_authorized, except: :show
-      before_action :set_webui2_views
 
       def create
         authorize @staging_workflow

--- a/src/api/app/controllers/webui/staging/workflows_controller.rb
+++ b/src/api/app/controllers/webui/staging/workflows_controller.rb
@@ -1,6 +1,5 @@
 class Webui::Staging::WorkflowsController < Webui::WebuiController
   before_action :require_login, except: [:show]
-  before_action :set_webui2_views
   before_action :set_project, only: [:new, :create]
   before_action :set_staging_workflow, except: [:new, :create]
   after_action :verify_authorized, except: [:show, :new]

--- a/src/api/app/controllers/webui/subscriptions_controller.rb
+++ b/src/api/app/controllers/webui/subscriptions_controller.rb
@@ -3,9 +3,6 @@ class Webui::SubscriptionsController < Webui::WebuiController
 
   def index
     @subscriptions_form = subscriptions_form
-
-    # TODO: Remove the statement after migration is finished
-    switch_to_webui2
   end
 
   def update

--- a/src/api/app/controllers/webui/users/subscriptions_controller.rb
+++ b/src/api/app/controllers/webui/users/subscriptions_controller.rb
@@ -2,7 +2,6 @@ class Webui::Users::SubscriptionsController < Webui::WebuiController
   before_action :require_login
 
   def index
-    switch_to_webui2
     @user = User.session!
     @groups_users = @user.groups_users
 

--- a/src/api/app/controllers/webui/users/tasks_controller.rb
+++ b/src/api/app/controllers/webui/users/tasks_controller.rb
@@ -3,9 +3,7 @@ module Webui
     class TasksController < WebuiController
       before_action :require_login
 
-      def index
-        switch_to_webui2
-      end
+      def index; end
     end
   end
 end

--- a/src/api/app/controllers/webui/users/tasks_controller.rb
+++ b/src/api/app/controllers/webui/users/tasks_controller.rb
@@ -2,8 +2,6 @@ module Webui
   module Users
     class TasksController < WebuiController
       before_action :require_login
-
-      def index; end
     end
   end
 end

--- a/src/api/app/controllers/webui/users_controller.rb
+++ b/src/api/app/controllers/webui/users_controller.rb
@@ -8,8 +8,6 @@ class Webui::UsersController < Webui::WebuiController
       format.html
       format.json { render json: UserConfigurationDatatable.new(params, view_context: view_context) }
     end
-    # TODO: Remove the statement after migration is finished
-    switch_to_webui2
   end
 
   def show
@@ -20,7 +18,7 @@ class Webui::UsersController < Webui::WebuiController
     @role_titles = @displayed_user.roles.global.pluck(:title)
     @account_edit_link = CONFIG['proxy_auth_account_page']
 
-    return unless switch_to_webui2 && (CONFIG['contribution_graph'] != :off)
+    return if CONFIG['contribution_graph'] == :off
 
     @last_day = Time.zone.today
 
@@ -34,7 +32,6 @@ class Webui::UsersController < Webui::WebuiController
   def new
     @pagetitle = params[:pagetitle] || 'Sign up'
     @submit_btn_text = params[:submit_btn_text] || 'Sign up'
-    switch_to_webui2
   end
 
   def create
@@ -61,9 +58,7 @@ class Webui::UsersController < Webui::WebuiController
     end
   end
 
-  def edit
-    switch_to_webui2
-  end
+  def edit; end
 
   def destroy
     user = User.find_by(login: params[:login])

--- a/src/api/app/controllers/webui/webui_controller.rb
+++ b/src/api/app/controllers/webui/webui_controller.rb
@@ -302,25 +302,6 @@ class Webui::WebuiController < ActionController::Base
     User.possibly_nobody
   end
 
-  # TODO: disable bootstrap flip in production after migrating all the controllers
-  def switch_to_webui2?
-    true
-  end
-
-  # TODO: remove after migrating all the controller
-  def switch_to_webui2
-    if switch_to_webui2?
-      @switch_to_webui2 = true
-
-      set_webui2_views
-
-      prefixed_action_name = "webui2_#{action_name}"
-      send(prefixed_action_name) if action_methods.include?(prefixed_action_name)
-      return true
-    end
-    @switch_to_webui2 = false
-  end
-
   def set_pending_announcement
     return if Announcement.last.in?(User.possibly_nobody.announcements)
     @pending_announcement = Announcement.last

--- a/src/api/app/controllers/webui/webui_controller.rb
+++ b/src/api/app/controllers/webui/webui_controller.rb
@@ -341,9 +341,4 @@ class Webui::WebuiController < ActionController::Base
 
     InfluxDB::Rails.current.tags = InfluxDB::Rails.current.tags.merge(tags)
   end
-
-  # NOTE: remove when bootstrap migration is done (related to switch_to_webui2)
-  def set_webui2_views
-    prepend_view_path('app/views/webui2')
-  end
 end

--- a/src/api/app/views/webui/package/meta.html.haml
+++ b/src/api/app/views/webui/package/meta.html.haml
@@ -9,6 +9,6 @@
     - if User.possibly_nobody.can_modify? @package
       = render partial: 'webui/shared/editor', locals: { text: @meta, mode: 'xml',
         save: { url: package_save_meta_path, method: :post,
-        data: { project: @project.name, package: @package.name, submit: 'meta', use_webui2: true } } }
+        data: { project: @project.name, package: @package.name, submit: 'meta' } } }
     - else
       = render partial: 'webui/shared/editor', locals: { text: @meta, mode: 'xml', style: { read_only: true } }

--- a/src/api/test/functional/webui/spider_test.rb
+++ b/src/api/test/functional/webui/spider_test.rb
@@ -3,9 +3,6 @@ require_relative '../../test_helper'
 require 'benchmark'
 require 'nokogiri'
 
-# TODO: Remove this when switch_to_webui2 is removed
-ENV['BOOTSTRAP'] = '1'
-
 class Webui::SpiderTest < Webui::IntegrationTest
   def ignore_link?(link)
     return true if link =~ %r{/mini-profiler-resources}


### PR DESCRIPTION
Since we are done with the integration of the new UI, this method is not
needed anymore.

<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn
how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md

In order to make it as easy as possible for other developers to review your
pull request we ask you to:

- Explain what this PR is about in the description
- Explain the steps the reviewer has to follow to verify your change
- If the reviewer needs sample data to verify your change, please explain how to
  create that data
- If you include visual changes in this PR, please add screenshots or GIFs
- If you address performance in this PR, add benchmark data or explain how the
  reviewer can benchmark this

This is a good PR description example:

Hey Friends,

this introduces labels for the different build result states on the project
monitor page. This makes it easier to get a visual overview of what is going on
in your project.

To verify this feature

- Enable the interconnect to build.opensuse.org
- Create the project home:Admin
- Add 'openSUSE Tumbleweed' as a repository to the project
- Branch a couple of packages into the project:
  ```
  for i in `osc -A http://0.0.0.0:3000 ls openSUSE.org:home:hennevogel`; do osc -A http://0.0.0.0:3000 copypac openSUSE.org:home:hennevogel $i home:Admin; done
  ```
- Visit the monitor page and see the new labels for the different states.

Here is a screenshot of how it looks:

** Before **
![Screenshot of the project monitor](https://example.com/screenshot1.png)

** After **
![Screenshot of the project monitor](https://example.com/screenshot2.png)

-->
