### PR TITLE
Remove render_dialog method

### DIFF
--- a/src/api/app/controllers/webui/webui_controller.rb
+++ b/src/api/app/controllers/webui/webui_controller.rb
@@ -21,7 +21,6 @@ class Webui::WebuiController < ActionController::Base
   before_action :set_influxdb_additional_tags
   before_action :require_configuration
   before_action :set_pending_announcement
-  before_action :check_ajax, only: :render_dialog
   after_action :clean_cache
 
   # :notice and :alert are default, we add :success and :error
@@ -301,13 +300,6 @@ class Webui::WebuiController < ActionController::Base
 
   def pundit_user
     User.possibly_nobody
-  end
-
-  # dialog_init is a function name called before dialog is shown
-  def render_dialog(dialog_init = nil, locals = {})
-    @dialog_html = ActionController::Base.helpers.escape_javascript(render_to_string(partial: action_name, locals: locals))
-    @dialog_init = dialog_init
-    render partial: 'dialog', content_type: 'application/javascript'
   end
 
   # TODO: disable bootstrap flip in production after migrating all the controllers


### PR DESCRIPTION
This method was only used in the old UI. Now, that we completly switch
to the new interface, this method is unused.

<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn
how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md

In order to make it as easy as possible for other developers to review your
pull request we ask you to:

- Explain what this PR is about in the description
- Explain the steps the reviewer has to follow to verify your change
- If the reviewer needs sample data to verify your change, please explain how to
  create that data
- If you include visual changes in this PR, please add screenshots or GIFs
- If you address performance in this PR, add benchmark data or explain how the
  reviewer can benchmark this

This is a good PR description example:

Hey Friends,

this introduces labels for the different build result states on the project
monitor page. This makes it easier to get a visual overview of what is going on
in your project.

To verify this feature

- Enable the interconnect to build.opensuse.org
- Create the project home:Admin
- Add 'openSUSE Tumbleweed' as a repository to the project
- Branch a couple of packages into the project:
  ```
  for i in `osc -A http://0.0.0.0:3000 ls openSUSE.org:home:hennevogel`; do osc -A http://0.0.0.0:3000 copypac openSUSE.org:home:hennevogel $i home:Admin; done
  ```
- Visit the monitor page and see the new labels for the different states.

Here is a screenshot of how it looks:

** Before **
![Screenshot of the project monitor](https://example.com/screenshot1.png)

** After **
![Screenshot of the project monitor](https://example.com/screenshot2.png)

-->
