### PR TITLE
creating extra appdata-icons.xml.gz for SLE15+ (issue #8259)

### DIFF
--- a/src/backend/bs_publish
+++ b/src/backend/bs_publish
@@ -647,7 +647,7 @@ sub createrepo_rpmmd {
   }
 
   # add appdata
-  unlink("$extrep/repodata/$_") for grep {/appdata\.xml/ || /app-icons/} @oldrepodata;
+  unlink("$extrep/repodata/$_") for grep {/appdata\.xml/ || /app-icons/ || /appdata-icons/} @oldrepodata;
   if (%{$data->{'appdatas'} || {}}) {
     create_appdata_files("$extrep/repodata", $data->{'appdatas'});
     if (-e "$extrep/repodata/appdata.xml") {
@@ -658,7 +658,10 @@ sub createrepo_rpmmd {
     if (-e "$extrep/repodata/app-icons.tar") {
       print "    adding app-icons.tar to repodata\n";
       qsystem($modifyrepo_bin, "$extrep/repodata/app-icons.tar", "$extrep/repodata", @legacyargs) && die("    modifyrepo failed: $?\n");
-      unlink("$extrep/repodata/app-icons.tar");
+      rename("$extrep/repodata/app-icons.tar", "$extrep/repodata/appdata-icons.tar");
+      print "    adding appdata-icons.tar to repodata\n";
+      qsystem($modifyrepo_bin, "$extrep/repodata/appdata-icons.tar", "$extrep/repodata", @legacyargs) && die("    modifyrepo failed: $?\n");
+      unlink("$extrep/repodata/appdata-icons.tar");
     }
   }
 


### PR DESCRIPTION
Here is my proposed patch to work around the app-icons vs appdata-icons issue with SLE15+. The effect is minimal (only another file published with the same contents as app-icons.xml.gz). These files are usually small, and will allow for the repositories to be used with GNOME Software on both SLE12/Leap 42.3 and Leap 15/SLE15+.
