### PR TITLE
Make possible to find deleted users in the UsersController#update

### DIFF
--- a/src/api/app/controllers/webui/users_controller.rb
+++ b/src/api/app/controllers/webui/users_controller.rb
@@ -1,7 +1,7 @@
 class Webui::UsersController < Webui::WebuiController
   before_action :require_login, only: [:index, :edit, :destroy, :update]
   before_action :require_admin, only: [:index, :edit, :destroy]
-  before_action :get_displayed_user, only: [:show, :edit]
+  before_action :get_displayed_user, only: [:show, :edit, :update]
 
   def index
     respond_to do |format|
@@ -76,8 +76,6 @@ class Webui::UsersController < Webui::WebuiController
   end
 
   def update
-    @displayed_user = User.find_by_login!(params[:user][:login])
-
     unless User.admin_session?
       if User.session! != @displayed_user || !@configuration.accounts_editable?(@displayed_user)
         flash[:error] = "Can't edit #{@displayed_user.login}"

--- a/src/api/spec/controllers/webui/users_controller_spec.rb
+++ b/src/api/spec/controllers/webui/users_controller_spec.rb
@@ -193,7 +193,7 @@ RSpec.describe Webui::UsersController do
     context "when user is trying to update another user's profile" do
       before do
         login user
-        post :update, params: { user: { login: non_admin_user.login, realname: 'another real name', email: 'new_valid@email.es' }, login: user.login }
+        post :update, params: { user: { login: non_admin_user.login, realname: 'another real name', email: 'new_valid@email.es' }, login: non_admin_user.login }
         non_admin_user.reload
       end
 
@@ -239,6 +239,23 @@ RSpec.describe Webui::UsersController do
       it 'does not remove non global roles' do
         expect(user.roles).to include(*local_roles)
       end
+    end
+
+    context 'admin activate a deleted user back' do
+      before  do
+        login admin_user
+        post :update, params: {
+          login: deleted_user.login,
+          user: {
+            login: deleted_user.login,
+            state: 'confirmed'
+          }
+        }
+        deleted_user.reload
+      end
+
+      it { expect(controller).to set_flash[:success] }
+      it { expect(deleted_user.state).to eq('confirmed') }
     end
 
     context 'when roles parameter is empty' do


### PR DESCRIPTION
It fixes #8382 and #8164 

Both are the same issue, but the #8164 is now invalid since we migrated the user resource to users resources.

How to test:

As Admin:

- Create an user $USER
- Delete this $USER
- Go to /users 
- Find the $USER, click on that or go to /users/$USER/edit
- Set the $USER state to confirm
- Click on update

Expected:

The user should be confirmed and therefore active again
