### PR TITLE
Remove unneeded project#packages_simple action

### DIFF
--- a/src/api/app/controllers/webui/project_controller.rb
+++ b/src/api/app/controllers/webui/project_controller.rb
@@ -12,7 +12,7 @@ class Webui::ProjectController < Webui::WebuiController
   before_action :set_project, only: [:autocomplete_repositories, :users, :subprojects,
                                      :new_package,
                                      :show, :buildresult,
-                                     :destroy, :remove_path_from_target, :rebuild_time, :packages_simple,
+                                     :destroy, :remove_path_from_target, :rebuild_time,
                                      :requests, :save, :monitor, :toggle_watch,
                                      :edit_comment, :status,
                                      :unlock, :save_person, :save_group, :remove_role,
@@ -20,7 +20,7 @@ class Webui::ProjectController < Webui::WebuiController
 
   before_action :set_project_by_id, only: [:update]
 
-  before_action :load_project_info, only: [:show, :packages_simple, :rebuild_time]
+  before_action :load_project_info, only: [:show, :rebuild_time]
 
   before_action :load_releasetargets, only: :show
 
@@ -28,7 +28,7 @@ class Webui::ProjectController < Webui::WebuiController
 
   after_action :verify_authorized, except: [:index, :autocomplete_projects, :autocomplete_incidents, :autocomplete_packages,
                                             :autocomplete_repositories, :users, :subprojects, :new, :show,
-                                            :packages_simple, :buildresult, :requests, :monitor, :status, :new_release_request,
+                                            :buildresult, :requests, :monitor, :status, :new_release_request,
                                             :remove_target_request, :toggle_watch, :edit_comment, :edit_comment_form]
 
   def index
@@ -134,8 +134,6 @@ class Webui::ProjectController < Webui::WebuiController
     @comments = @project.comments
     @comment = Comment.new
   end
-
-  def packages_simple; end
 
   def buildresult
     render partial: 'buildstatus', locals: { project: @project,

--- a/src/api/config/routes.rb
+++ b/src/api/config/routes.rb
@@ -242,7 +242,6 @@ OBSApi::Application.routes.draw do
       get 'project/new_package/:project' => :new_package, constraints: cons, as: 'project_new_package'
       post 'project/new_release_request/(:project)' => :new_release_request, constraints: cons, as: :project_new_release_request
       get 'project/show/:project' => :show, constraints: cons, as: 'project_show'
-      get 'project/packages_simple/:project' => :packages_simple, constraints: cons
       get 'project/buildresult' => :buildresult, constraints: cons, as: 'project_buildresult'
       get 'project/new' => :new, as: 'new_project'
       post 'project/create' => :create, constraints: cons, as: 'projects_create'


### PR DESCRIPTION
The view wasn't migrated to Bootstrap and it's not accessible without knowing the URL, so this can be removed.

The Bento version of the view was removed in 0991846.