### PR TITLE
Remove Bento specific route definition for maintained projects

### DIFF
--- a/src/api/app/controllers/webui/projects/maintained_projects_controller.rb
+++ b/src/api/app/controllers/webui/projects/maintained_projects_controller.rb
@@ -28,7 +28,7 @@ module Webui
                           { error: "Failed to disable Maintenance for #{maintenance_project.project}: #{@project.errors.full_messages.to_sentence}" }
                         end
 
-        redirect_to(projects_project_maintained_projects_path(project_name: @project.name), flash_message)
+        redirect_to(project_maintained_projects_path(project_name: @project.name), flash_message)
       end
 
       def create
@@ -42,7 +42,7 @@ module Webui
                           { error: "Failed to enable Maintenance for #{@maintained_project}: #{@project.errors.full_messages.to_sentence}" }
                         end
 
-        redirect_to(projects_project_maintained_projects_path(project_name: @project.name), flash_message)
+        redirect_to(project_maintained_projects_path(project_name: @project.name), flash_message)
       end
 
       private

--- a/src/api/app/views/webui/project/_tabs.html.haml
+++ b/src/api/app/views/webui/project/_tabs.html.haml
@@ -7,7 +7,7 @@
         %li.nav-item
           = tab_link('Incidents', project_maintenance_incidents_path(project))
         %li.nav-item
-          = tab_link('Maintained Projects', projects_project_maintained_projects_path(project))
+          = tab_link('Maintained Projects', project_maintained_projects_path(project))
       - unless project.defines_remote_instance? || project.is_maintenance?
         %li.nav-item
           = tab_link('Repositories', repositories_path(project))

--- a/src/api/app/views/webui/project/side_links/_maintenance_project.html.haml
+++ b/src/api/app/views/webui/project/side_links/_maintenance_project.html.haml
@@ -10,5 +10,5 @@
     %i.fa.fa-exclamation-circle.text-danger
   - else
     %i.fa.fa-check-circle.text-success
-  = link_to(projects_project_maintained_projects_path(project)) do
+  = link_to(project_maintained_projects_path(project)) do
     = pluralize(maintained_projects.size, 'maintained project')

--- a/src/api/app/views/webui/projects/maintained_projects/index.html.haml
+++ b/src/api/app/views/webui/projects/maintained_projects/index.html.haml
@@ -1,7 +1,7 @@
 :ruby
   @pagetitle = "Projects Maintained by #{@project}"
   update_policy = policy(@project).update?
-  data_source = projects_project_maintained_projects_path(@project, :json)
+  data_source = project_maintained_projects_path(@project, :json)
 
 .card
   = render partial: 'webui/project/tabs', locals: { project: @project }

--- a/src/api/config/routes.rb
+++ b/src/api/config/routes.rb
@@ -300,13 +300,7 @@ OBSApi::Application.routes.draw do
 
     resources :projects, only: [], param: :name do
       resources :maintained_projects, controller: 'webui/projects/maintained_projects',
-                                      param: :maintained_project, only: [:destroy, :create], constraints: cons do
-        # TODO
-        # the index route points already to the ProjectController#maintained_projects
-        # It's bento only and as soon bento is gone, we can add index to the resource and delete it
-        get :index, as: :projects, on: :collection
-      end
-
+                                      param: :maintained_project, only: [:index, :destroy, :create], constraints: cons
       resource :public_key, controller: 'webui/projects/public_key', only: [:show], constraints: cons
       resource :ssl_certificate, controller: 'webui/projects/ssl_certificate', only: [:show], constraints: cons
       resource :pulse, controller: 'webui/projects/pulse', only: [:show], constraints: cons

--- a/src/api/spec/features/webui/maintained_projects_spec.rb
+++ b/src/api/spec/features/webui/maintained_projects_spec.rb
@@ -14,7 +14,7 @@ RSpec.feature 'MaintainedProjects', type: :feature, js: true do
       end
 
       scenario 'maintenance projects are not shown' do
-        visit projects_project_maintained_projects_path(project_name: maintenance_project.name)
+        visit project_maintained_projects_path(project_name: maintenance_project.name)
         expect(page).to have_text('Maintained Projects')
         expect(page).not_to have_selector('#new-maintenance-project-modal')
         expect(page).not_to have_selector('#delete-maintained-project-modal')
@@ -24,7 +24,7 @@ RSpec.feature 'MaintainedProjects', type: :feature, js: true do
     context 'with admin login' do
       scenario 'initial state' do
         login admin_user
-        visit projects_project_maintained_projects_path(project_name: maintenance_project.name)
+        visit project_maintained_projects_path(project_name: maintenance_project.name)
 
         expect(page).to have_text('Maintained Projects')
         expect(page).to have_selector('#new-maintenance-project-modal', visible: false)
@@ -33,7 +33,7 @@ RSpec.feature 'MaintainedProjects', type: :feature, js: true do
 
       scenario 'click on add new project' do
         login admin_user
-        visit projects_project_maintained_projects_path(project_name: maintenance_project.name)
+        visit project_maintained_projects_path(project_name: maintenance_project.name)
 
         expect(page).to have_selector('#new-maintenance-project-modal', visible: false)
         click_link('Add Project to Maintain')
@@ -44,7 +44,7 @@ RSpec.feature 'MaintainedProjects', type: :feature, js: true do
 
       scenario 'click on delete project' do
         login admin_user
-        visit projects_project_maintained_projects_path(project_name: maintenance_project.name)
+        visit project_maintained_projects_path(project_name: maintenance_project.name)
 
         expect(page).to have_selector('#new-maintenance-project-modal', visible: false)
 
@@ -56,7 +56,7 @@ RSpec.feature 'MaintainedProjects', type: :feature, js: true do
 
       scenario 'delete project' do
         login admin_user
-        visit projects_project_maintained_projects_path(project_name: maintenance_project.name)
+        visit project_maintained_projects_path(project_name: maintenance_project.name)
 
         click_link('Delete Project')
 


### PR DESCRIPTION
The route helper for `projects/maintained_projects#index` changed from `projects_project_maintained_projects_path` to `project_maintained_projects_path`.