### PR TITLE
Refactor a little bit

### DIFF
--- a/src/api/app/controllers/webui/project_controller.rb
+++ b/src/api/app/controllers/webui/project_controller.rb
@@ -18,9 +18,9 @@ class Webui::ProjectController < Webui::WebuiController
                                      :unlock, :save_person, :save_group, :remove_role,
                                      :move_path, :clear_failed_comment, :pulse]
 
-  before_action :set_project_by_id, only: [:update]
+  before_action :set_project_by_id, only: :update
 
-  before_action :load_project_info, only: [:show]
+  before_action :load_project_info, only: :show
 
   before_action :load_releasetargets, only: :show
 
@@ -543,13 +543,8 @@ class Webui::ProjectController < Webui::WebuiController
   def load_project_info
     find_maintenance_infos
 
-    # TODO: bento_only, webui2 fetching this in the PackageDatatable model
-    @packages = []
-    @project.packages.order_by_name.pluck(:name, :updated_at).each do |p|
-      @packages << [p[0], p[1].to_i.to_s] # convert Time to epoch ts and then to string
-    end
-
-    @ipackages = @project.expand_all_packages.find_all { |ip| !@packages.map { |p| p[0] }.include?(ip[0]) }
+    @packages = @project.packages.pluck(:name)
+    @inherited_packages = @project.expand_all_packages.find_all { |inherited_package| !@packages.include?(inherited_package[0]) }
     @linking_projects = @project.linked_by_projects.pluck(:name)
 
     reqs = @project.open_requests

--- a/src/api/app/views/webui/project/show.html.haml
+++ b/src/api/app/views/webui/project/show.html.haml
@@ -49,18 +49,18 @@
               Packages
               %span.badge.badge-primary
                 = @packages.length
-          - if @ipackages.present?
+          - if @inherited_packages.present?
             %li.nav-item
               %a.nav-link#inherited-packages-tab{ href: '#inherited-packages', role: 'tab', data: { toggle: 'tab' },
               aria: { controls: 'inherited-packages', selected: 'false' } }
                 Inherited Packages
                 %span.badge.badge-primary
-                  = @ipackages.length
+                  = @inherited_packages.length
       .tab-content#packages-tabs-content
         .tab-pane.fade.show.active#packages{ role: 'tabpanel', aria: { labelledby: 'packages-tab' } }
           = render partial: 'project_packages', locals: { project: @project, packages: @packages }
         .tab-pane.fade#inherited-packages{ role: 'tabpanel', aria: { labelledby: 'inherited-packages-tab' } }
-          = render partial: 'project_inherited_packages', locals: { project: @project, inherited_packages: @ipackages }
+          = render partial: 'project_inherited_packages', locals: { project: @project, inherited_packages: @inherited_packages }
   .comments
     .card
       %h5.card-header.text-word-break-all


### PR DESCRIPTION
These variables `@packages` and `@ipackages` are still used in the new
interfaces.

Co-authored-by: Eduardo Navarro <enavarro@suse.com>

<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn
how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md

In order to make it as easy as possible for other developers to review your
pull request we ask you to:

- Explain what this PR is about in the description
- Explain the steps the reviewer has to follow to verify your change
- If the reviewer needs sample data to verify your change, please explain how to
  create that data
- If you include visual changes in this PR, please add screenshots or GIFs
- If you address performance in this PR, add benchmark data or explain how the
  reviewer can benchmark this

This is a good PR description example:

Hey Friends,

this introduces labels for the different build result states on the project
monitor page. This makes it easier to get a visual overview of what is going on
in your project.

To verify this feature

- Enable the interconnect to build.opensuse.org
- Create the project home:Admin
- Add 'openSUSE Tumbleweed' as a repository to the project
- Branch a couple of packages into the project:
  ```
  for i in `osc -A http://0.0.0.0:3000 ls openSUSE.org:home:hennevogel`; do osc -A http://0.0.0.0:3000 copypac openSUSE.org:home:hennevogel $i home:Admin; done
  ```
- Visit the monitor page and see the new labels for the different states.

Here is a screenshot of how it looks:

** Before **
![Screenshot of the project monitor](https://example.com/screenshot1.png)

** After **
![Screenshot of the project monitor](https://example.com/screenshot2.png)

-->
