### PR TITLE
Fix expand and collapse in review

### DIFF
--- a/src/api/app/assets/javascripts/webui/packages.js
+++ b/src/api/app/assets/javascripts/webui/packages.js
@@ -14,25 +14,15 @@ $(function ($) {
     }
   });
 
-  $('details.details-with-codemirror').on('click', function () {
-    var editor = $(this).find('.CodeMirror')[0].CodeMirror;
-    window.setTimeout(function() {
-      editor.refresh();
-    },1);
-  });
-
   $('.expand-diffs').on('click', function () {
     var forPackage = $(this).data('package');
-    var details = $('details.card.details-with-codemirror[data-package="' + forPackage + '"]');
+    var details = $('details.card.details-with-coderay[data-package="' + forPackage + '"]');
     details.attr('open', 'open');
-    details.find('.CodeMirror').each(function(){
-      $(this)[0].CodeMirror.refresh();
-    });
   });
 
   $('.collapse-diffs').on('click', function () {
     var forPackage = $(this).data('package');
-    var details = $('details.card.details-with-codemirror[data-package="' + forPackage + '"]');
+    var details = $('details.card.details-with-coderay[data-package="' + forPackage + '"]');
     details.attr('open', null);
   });
 });

--- a/src/api/app/views/webui/package/_revision_diff_detail.html.haml
+++ b/src/api/app/views/webui/package/_revision_diff_detail.html.haml
@@ -3,7 +3,7 @@
   = render partial: 'webui/package/revision_diff_detail_buttons',
   locals: { file_view_path: file_view_path, filename: filename, index: index, last: last, has_content: diff_content.present? }
   - if diff_content.present?
-    %details.card.details-with-codemirror{ open: expand_diff?(filename, file['state']), id: "revision_details_#{index}", data: { package: package } }
+    %details.card.details-with-coderay{ open: expand_diff?(filename, file['state']), id: "revision_details_#{index}", data: { package: package } }
       %summary.card-header.py-3
         .diff-card-header
           = calculate_filename(filename, file)


### PR DESCRIPTION
In the request diff we changed CodeMirror in favour of CodeRay.
But in the javascript we have some reference to CodeMirror.

Fix #8288

<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn
how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md

In order to make it as easy as possible for other developers to review your
pull request we ask you to:

- Explain what this PR is about in the description
- Explain the steps the reviewer has to follow to verify your change
- If the reviewer needs sample data to verify your change, please explain how to
  create that data
- If you include visual changes in this PR, please add screenshots or GIFs
- If you address performance in this PR, add benchmark data or explain how the
  reviewer can benchmark this

This is a good PR description example:

Hey Friends,

this introduces labels for the different build result states on the project
monitor page. This makes it easier to get a visual overview of what is going on
in your project.

To verify this feature

- Enable the interconnect to build.opensuse.org
- Create the project home:Admin
- Add 'openSUSE Tumbleweed' as a repository to the project
- Branch a couple of packages into the project:
  ```
  for i in `osc -A http://0.0.0.0:3000 ls openSUSE.org:home:hennevogel`; do osc -A http://0.0.0.0:3000 copypac openSUSE.org:home:hennevogel $i home:Admin; done
  ```
- Visit the monitor page and see the new labels for the different states.

Here is a screenshot of how it looks:

** Before **
![Screenshot of the project monitor](https://example.com/screenshot1.png)

** After **
![Screenshot of the project monitor](https://example.com/screenshot2.png)

-->
