### PR TITLE
Remove repeated check_display(ed)_user method and refactor user/requests routes

### DIFF
--- a/src/api/app/controllers/webui/users/bs_requests_controller.rb
+++ b/src/api/app/controllers/webui/users/bs_requests_controller.rb
@@ -2,7 +2,7 @@ module Webui
   module Users
     class BsRequestsController < WebuiController
       include Webui::Mixins::BsRequestsControllerMixin
-      before_action :check_display_user
+      before_action :check_displayed_user
       before_action :set_user
 
       REQUEST_METHODS = {

--- a/src/api/app/controllers/webui/users_controller.rb
+++ b/src/api/app/controllers/webui/users_controller.rb
@@ -108,15 +108,4 @@ class Webui::UsersController < Webui::WebuiController
       email: params[:email]
     }
   end
-
-  def check_displayed_user
-    begin
-      @displayed_user = User.find_by_login!(params[:login])
-    rescue NotFoundError
-      # admins can see deleted users
-      @displayed_user = User.find_by_login(params[:login]) if User.admin_session?
-      redirect_back(fallback_location: root_path, error: "User not found #{params[:login]}") unless @displayed_user
-    end
-    @is_displayed_user = (User.session == @displayed_user)
-  end
 end

--- a/src/api/app/controllers/webui/webui_controller.rb
+++ b/src/api/app/controllers/webui/webui_controller.rb
@@ -198,14 +198,15 @@ class Webui::WebuiController < ActionController::Base
     end
   end
 
-  def check_display_user
-    if params['user'].present?
+  def check_displayed_user
+    param_login = params[:login] || params[:user_login]
+    if param_login.present?
       begin
-        @displayed_user = User.find_by_login!(params['user'])
+        @displayed_user = User.find_by_login!(param_login)
       rescue NotFoundError
         # admins can see deleted users
-        @displayed_user = User.find_by_login(params['user']) if User.admin_session?
-        redirect_back(fallback_location: root_path, error: "User not found #{params['user']}") unless @displayed_user
+        @displayed_user = User.find_by_login(param_login) if User.admin_session?
+        redirect_back(fallback_location: root_path, error: "User not found #{param_login}") unless @displayed_user
       end
     else
       @displayed_user = User.possibly_nobody

--- a/src/api/config/routes.rb
+++ b/src/api/config/routes.rb
@@ -351,7 +351,9 @@ OBSApi::Application.routes.draw do
       post 'users/announcements/:id' => :create, as: 'user_announcements'
     end
 
-    resources :users, controller: 'webui/users', param: :login, constraints: cons
+    resources :users, controller: 'webui/users', param: :login, constraints: cons do
+      resources :requests, only: [:index], controller: 'webui/users/bs_requests'
+    end
 
     get 'signup', to: 'webui/users#new', as: :signup
 
@@ -369,13 +371,6 @@ OBSApi::Application.routes.draw do
     put 'user/notifications' => :update, constraints: cons, controller: 'webui/users/subscriptions'
 
     get 'user/tasks' => :index, constraints: cons, controller: 'webui/users/tasks', as: 'user_tasks'
-
-    # Hardcoding this routes is necessary because we rely on the :user parameter
-    # in check_display_user before filter. Overwriting of the parameter is not
-    # possible for nested resources atm.
-    controller 'webui/users/bs_requests' do
-      get 'users/(:user)/requests' => :index, as: 'user_requests'
-    end
 
     controller 'webui/groups/bs_requests' do
       get 'groups/(:title)/requests' => :index, constraints: { title: /[^\/]*/ }, as: 'group_requests'

--- a/src/api/spec/controllers/webui/users/bs_requests_controller_spec.rb
+++ b/src/api/spec/controllers/webui/users/bs_requests_controller_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe Webui::Users::BsRequestsController do
   describe 'GET #index' do
     include_context 'a set of bs requests'
 
-    let(:base_params) { { user: user, format: :json } }
+    let(:base_params) { { user_login: user, format: :json } }
     let(:context_params) { {} }
     let(:params) { base_params.merge(context_params) }
 

--- a/src/api/spec/routing/webui/users/requests_spec.rb
+++ b/src/api/spec/routing/webui/users/requests_spec.rb
@@ -5,6 +5,6 @@ RSpec.describe '/users/:user/requests routes', type: :routing do
 
   it do
     expect(get("/users/#{user}/requests"))
-      .to route_to('webui/users/bs_requests#index', user: user)
+      .to route_to('webui/users/bs_requests#index', user_login: user)
   end
 end


### PR DESCRIPTION
There were two similar methods named `WebUIController#check_display_user`
and `UsersController#check_displayed_user` method, just with a different
parameter. Merged both in one and adapted the routes and specs for the
users/requests resource
