### PR TITLE
Check if parenthesis matching element exists

### DIFF
--- a/src/api/app/assets/javascripts/webui/cm2/toolbars.js
+++ b/src/api/app/assets/javascripts/webui/cm2/toolbars.js
@@ -55,7 +55,7 @@
 	var line = position.line + this.cm.getOption('firstLineNumber');
 	if(document.getElementById('ln_'+this.cm.id) != null) document.getElementById('ln_'+this.cm.id).innerHTML = line;
 	if(document.getElementById('ch_'+this.cm.id) != null) document.getElementById('ch_'+this.cm.id).innerHTML = position.ch;
-	if(document.getElementById('match_'+this.cm.id).value == 'on') {
+	if(document.getElementById('match_'+this.cm.id) != null && document.getElementById('match_'+this.cm.id).value == 'on') {
 	    this.cm.matchHighlight("CodeMirror-matchhighlight");
 	}
     }


### PR DESCRIPTION
On read only mode, we don't render the toolbar and options on the editor.
So the element is not found.

Fix #8273

<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn
how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md

In order to make it as easy as possible for other developers to review your
pull request we ask you to:

- Explain what this PR is about in the description
- Explain the steps the reviewer has to follow to verify your change
- If the reviewer needs sample data to verify your change, please explain how to
  create that data
- If you include visual changes in this PR, please add screenshots or GIFs
- If you address performance in this PR, add benchmark data or explain how the
  reviewer can benchmark this

This is a good PR description example:

Hey Friends,

this introduces labels for the different build result states on the project
monitor page. This makes it easier to get a visual overview of what is going on
in your project.

To verify this feature

- Enable the interconnect to build.opensuse.org
- Create the project home:Admin
- Add 'openSUSE Tumbleweed' as a repository to the project
- Branch a couple of packages into the project:
  ```
  for i in `osc -A http://0.0.0.0:3000 ls openSUSE.org:home:hennevogel`; do osc -A http://0.0.0.0:3000 copypac openSUSE.org:home:hennevogel $i home:Admin; done
  ```
- Visit the monitor page and see the new labels for the different states.

Here is a screenshot of how it looks:

** Before **
![Screenshot of the project monitor](https://example.com/screenshot1.png)

** After **
![Screenshot of the project monitor](https://example.com/screenshot2.png)

-->
