### PR TITLE
Move autocomplete and tokens from UserController to UsersController

### DIFF
--- a/src/api/app/controllers/webui/user_controller.rb
+++ b/src/api/app/controllers/webui/user_controller.rb
@@ -33,12 +33,4 @@ class Webui::UserController < Webui::WebuiController
       return
     end
   end
-
-  def autocomplete
-    render json: User.autocomplete_login(params[:term])
-  end
-
-  def tokens
-    render json: User.autocomplete_token(params[:q])
-  end
 end

--- a/src/api/app/controllers/webui/users_controller.rb
+++ b/src/api/app/controllers/webui/users_controller.rb
@@ -99,6 +99,14 @@ class Webui::UsersController < Webui::WebuiController
     redirect_back(fallback_location: user_path(@displayed_user))
   end
 
+  def autocomplete
+    render json: User.autocomplete_login(params[:term])
+  end
+
+  def tokens
+    render json: User.autocomplete_token(params[:q])
+  end
+
   private
 
   def create_params

--- a/src/api/config/routes.rb
+++ b/src/api/config/routes.rb
@@ -336,10 +336,6 @@ OBSApi::Application.routes.draw do
 
     controller 'webui/user' do
       post 'user/change_password' => :change_password
-
-      # get 'user/autocomplete' => :autocomplete, as: 'autocomplete_users'
-      # get 'user/tokens' => :tokens
-
       # Only here to make old /home url's work
       get 'home/' => :home, as: 'home'
       get 'home/my_work' => :home
@@ -364,11 +360,13 @@ OBSApi::Application.routes.draw do
     # TODO
     # keep those routes reachable, but remove them later as
     # nobody access it anymore
-    get 'user/signup', to: redirect('/signup')
-    get 'user/register_user', to: redirect('/signup')
-    get 'user/show/:user', to: redirect('/users/%{user}')
-    get 'user/autocomplete', to: redirect('/users/autocomplete')
-    get 'user/tokens', to: redirect('/users/tokens')
+    namespace :user do
+      get '/signup', to: redirect('/signup')
+      get '/register_user', to: redirect('/signup')
+      get '/show/:user', to: redirect('/users/%{user}')
+      get '/autocomplete', to: redirect('/users/autocomplete')
+      get '/tokens', to: redirect('/users/tokens')
+    end
 
     resources :announcements, only: :show, controller: 'webui/announcements'
 

--- a/src/api/config/routes.rb
+++ b/src/api/config/routes.rb
@@ -337,8 +337,8 @@ OBSApi::Application.routes.draw do
     controller 'webui/user' do
       post 'user/change_password' => :change_password
 
-      get 'user/autocomplete' => :autocomplete, as: 'autocomplete_users'
-      get 'user/tokens' => :tokens
+      # get 'user/autocomplete' => :autocomplete, as: 'autocomplete_users'
+      # get 'user/tokens' => :tokens
 
       # Only here to make old /home url's work
       get 'home/' => :home, as: 'home'
@@ -353,6 +353,10 @@ OBSApi::Application.routes.draw do
 
     resources :users, controller: 'webui/users', param: :login, constraints: cons do
       resources :requests, only: [:index], controller: 'webui/users/bs_requests'
+      collection do
+        get 'autocomplete'
+        get 'tokens'
+      end
     end
 
     get 'signup', to: 'webui/users#new', as: :signup
@@ -363,6 +367,9 @@ OBSApi::Application.routes.draw do
     get 'user/signup', to: redirect('/signup')
     get 'user/register_user', to: redirect('/signup')
     get 'user/show/:user', to: redirect('/users/%{user}')
+    get 'user/autocomplete', to: redirect('/users/autocomplete')
+    get 'user/tokens', to: redirect('/users/tokens')
+
     resources :announcements, only: :show, controller: 'webui/announcements'
 
     resource :session, only: [:new, :create, :destroy], controller: 'webui/session'

--- a/src/api/spec/controllers/webui/user_controller_spec.rb
+++ b/src/api/spec/controllers/webui/user_controller_spec.rb
@@ -7,10 +7,6 @@ RSpec.describe Webui::UserController do
   let(:deleted_user) { create(:deleted_user) }
   let!(:non_admin_user_request) { create(:set_bugowner_request, priority: 'critical', creator: non_admin_user) }
 
-  describe 'GET #home' do
-    skip
-  end
-
   describe 'POST #change_password' do
     before do
       login non_admin_user
@@ -22,35 +18,5 @@ RSpec.describe Webui::UserController do
     it 'shows an error message when in LDAP mode' do
       expect(controller).to set_flash[:error]
     end
-  end
-
-  describe 'GET #autocomplete' do
-    let!(:user) { create(:user, login: 'foobar') }
-
-    it 'returns user login' do
-      get :autocomplete, params: { term: 'foo', format: :json }
-      expect(JSON.parse(response.body)).to match_array(['foobar'])
-    end
-  end
-
-  describe 'GET #tokens' do
-    let!(:user) { create(:user, login: 'foobaz') }
-
-    it 'returns user token as array of hash' do
-      get :tokens, params: { q: 'foo', format: :json }
-      expect(JSON.parse(response.body)).to match_array(['name' => 'foobaz'])
-    end
-  end
-
-  describe 'GET #notifications' do
-    skip
-  end
-
-  describe 'GET #update_notifications' do
-    skip
-  end
-
-  describe 'GET #list_users(prefix = nil, hash = nil)' do
-    skip
   end
 end

--- a/src/api/spec/controllers/webui/users_controller_spec.rb
+++ b/src/api/spec/controllers/webui/users_controller_spec.rb
@@ -358,4 +358,22 @@ RSpec.describe Webui::UsersController do
       end
     end
   end
+
+  describe 'GET #autocomplete' do
+    let!(:user) { create(:user, login: 'foobar') }
+
+    it 'returns user login' do
+      get :autocomplete, params: { term: 'foo', format: :json }
+      expect(JSON.parse(response.body)).to match_array(['foobar'])
+    end
+  end
+
+  describe 'GET #tokens' do
+    let!(:user) { create(:user, login: 'foobaz') }
+
+    it 'returns user token as array of hash' do
+      get :tokens, params: { q: 'foo', format: :json }
+      expect(JSON.parse(response.body)).to match_array(['name' => 'foobaz'])
+    end
+  end
 end


### PR DESCRIPTION
Move the actions `autocomplete` and `tokens` from `UserController` to `UsersController`

This PR includes:

- route changes and route redirects to the old routes
- adapted specs

How to test it:

- The routes are accessible via json, so a `osc -A $DEV_SERVER api '/users/autocomplete.json` should do the trick.

- Beside it the endpoints are used in the following workflows:
  - Add reviewer to a request
  - Add user to a group
  - Edit patchinfo
  - Request bugowner change