### PR TITLE
Make build results more responsive friendly

### DIFF
--- a/src/api/app/helpers/webui/buildresult_helper.rb
+++ b/src/api/app/helpers/webui/buildresult_helper.rb
@@ -28,4 +28,9 @@ module Webui::BuildresultHelper
       end
     end
   end
+
+  def repository_expanded?(collapsed_repositories, repository_name, key = 'project')
+    return collapsed_repositories[key].exclude?(repository_name) if collapsed_repositories[key]
+    true
+  end
 end

--- a/src/api/app/views/webui/package/_buildstatus.html.haml
+++ b/src/api/app/views/webui/package/_buildstatus.html.haml
@@ -9,38 +9,37 @@
 - buildresults.results.each_pair do |package, results|
   %h5.text-primary.mt-3.mb-3= package
   #package-buildstatus
-    %div
-      - if results.present?
-        - previous_repo = nil
-        - results.each do |result|
-          :ruby
-            repository_name = result.repository.tr('.', '_')
-            package_name = package.tr('.:', '_')
-            expanded = collapsed_repositories[package_name] ? collapsed_repositories[package_name].exclude?(repository_name) : true
-          - if result.repository != previous_repo
-            .row.no-gutters.py-1.bg-light
-              .col.pl-1.pl-sm-2{ title: result.repository.to_s }
-                = link_to(word_break(result.repository, 22),
-                  package_binaries_path(project: project, package: package, repository: result.repository),
-                  data: { content: "Binaries for #{result.repository}", placement: 'top', toggle: 'popover' })
-                = link_to('#', aria: { controls: "collapse-#{package_name}-#{repository_name}", expanded: expanded }, class: 'ml-1',
-                          data: { toggle: 'collapse' }, href: ".collapse-#{package_name}-#{repository_name}", role: 'button') do
-                  %i.fas.fa-chevron-left.expander{ title: 'Show build results for this repository' }
-                  %i.fas.fa-chevron-down.collapser{ title: 'Hide build results for this repository' }
+    - if results.present?
+      - previous_repo = nil
+      - results.each do |result|
+        :ruby
+          repository_name = result.repository.tr('.', '_')
+          package_name = package.tr('.:', '_')
+          expanded = collapsed_repositories[package_name] ? collapsed_repositories[package_name].exclude?(repository_name) : true
+        - if result.repository != previous_repo
+          .row.no-gutters.py-1.bg-light
+            .col.pl-1.pl-sm-2{ title: result.repository.to_s }
+              = link_to(word_break(result.repository, 22),
+                package_binaries_path(project: project, package: package, repository: result.repository),
+                data: { content: "Binaries for #{result.repository}", placement: 'top', toggle: 'popover' })
+              = link_to('#', aria: { controls: "collapse-#{package_name}-#{repository_name}", expanded: expanded }, class: 'ml-1',
+                        data: { toggle: 'collapse' }, href: ".collapse-#{package_name}-#{repository_name}", role: 'button') do
+                %i.fas.fa-chevron-left.expander{ title: 'Show build results for this repository' }
+                %i.fas.fa-chevron-down.collapser{ title: 'Hide build results for this repository' }
 
-          .collapse{ class: "collapse-#{package_name}-#{repository_name}#{expanded ? ' show' : ''}",
-                     data: { repository: repository_name, main: package_name } }
-            .row.no-gutters.py-1
-              .col-6.col-sm-5.col-xl-4.pl-1.pl-sm-3.text-nowrap
-                - if !result.is_repository_in_db
-                  %i.fas.fa-clock.text-warning{ title: 'This result is outdated' }
-                - else
-                  = repository_status_icon(status: result.state, details: result.details)
-                %span.ml-1
-                  = result.architecture
-              .col.pl-1.pl-sm-2.text-nowrap
-                = arch_repo_table_cell(result.repository, result.architecture, package, 'code' => result.code, 'details' => result.details)
-          - previous_repo = result.repository
-      - else
-        All the results have state
-        %strong excluded/disabled
+        .collapse{ class: "collapse-#{package_name}-#{repository_name}#{expanded ? ' show' : ''}",
+                   data: { repository: repository_name, main: package_name } }
+          .row.no-gutters.py-1
+            .col-6.col-sm-5.col-xl-4.pl-1.pl-sm-3.text-nowrap
+              - if !result.is_repository_in_db
+                %i.fas.fa-clock.text-warning{ title: 'This result is outdated' }
+              - else
+                = repository_status_icon(status: result.state, details: result.details)
+              %span.ml-1
+                = result.architecture
+            .col.pl-1.pl-sm-2.text-nowrap
+              = arch_repo_table_cell(result.repository, result.architecture, package, 'code' => result.code, 'details' => result.details)
+        - previous_repo = result.repository
+    - else
+      All the results have state
+      %strong excluded/disabled

--- a/src/api/app/views/webui/package/_buildstatus.html.haml
+++ b/src/api/app/views/webui/package/_buildstatus.html.haml
@@ -15,7 +15,7 @@
         :ruby
           repository_name = result.repository.tr('.', '_')
           package_name = package.tr('.:', '_')
-          expanded = collapsed_repositories[package_name] ? collapsed_repositories[package_name].exclude?(repository_name) : true
+          expanded = repository_expanded?(collapsed_repositories, repository_name, package_name)
         - if result.repository != previous_repo
           .row.no-gutters.py-1.bg-light
             .col.pl-1.pl-sm-2{ title: result.repository.to_s }

--- a/src/api/app/views/webui/package/_buildstatus.html.haml
+++ b/src/api/app/views/webui/package/_buildstatus.html.haml
@@ -8,8 +8,8 @@
 
 - buildresults.results.each_pair do |package, results|
   %h5.text-primary.mt-3.mb-3= package
-  .mb-2#package-buildstatus
-    .px-3
+  #package-buildstatus
+    %div
       - if results.present?
         - previous_repo = nil
         - results.each do |result|
@@ -18,8 +18,8 @@
             package_name = package.tr('.:', '_')
             expanded = collapsed_repositories[package_name] ? collapsed_repositories[package_name].exclude?(repository_name) : true
           - if result.repository != previous_repo
-            .row.py-1.bg-light
-              .col{ title: result.repository.to_s }
+            .row.no-gutters.py-1.bg-light
+              .col.pl-1.pl-sm-2{ title: result.repository.to_s }
                 = link_to(word_break(result.repository, 22),
                   package_binaries_path(project: project, package: package, repository: result.repository),
                   data: { content: "Binaries for #{result.repository}", placement: 'top', toggle: 'popover' })
@@ -30,15 +30,15 @@
 
           .collapse{ class: "collapse-#{package_name}-#{repository_name}#{expanded ? ' show' : ''}",
                      data: { repository: repository_name, main: package_name } }
-            .row.py-1
-              .col-4.col-sm-4.col-xl-3.ml-2.text-nowrap
+            .row.no-gutters.py-1
+              .col-6.col-sm-5.col-xl-4.pl-1.pl-sm-3.text-nowrap
                 - if !result.is_repository_in_db
                   %i.fas.fa-clock.text-warning{ title: 'This result is outdated' }
                 - else
                   = repository_status_icon(status: result.state, details: result.details)
                 %span.ml-1
                   = result.architecture
-              .col-6.col-sm-5.col-xl-6.ml-2.text-nowrap
+              .col.pl-1.pl-sm-2.text-nowrap
                 = arch_repo_table_cell(result.repository, result.architecture, package, 'code' => result.code, 'details' => result.details)
           - previous_repo = result.repository
       - else

--- a/src/api/app/views/webui/project/_buildstatus.html.haml
+++ b/src/api/app/views/webui/project/_buildstatus.html.haml
@@ -15,7 +15,7 @@
   - else
     - buildresults.each do |repository, build_results|
       - repository_name = repository.tr('.', '_')
-      - expanded = collapsed_repositories['project'] ? collapsed_repositories['project'].exclude?(repository_name) : true
+      - expanded = repository_expanded?(collapsed_repositories, repository_name)
       .d-flex.flex-column
         .d-flex.flex-row.py-1.bg-light.pl-3
           = link_to(word_break(repository, 12),


### PR DESCRIPTION
Fixes #8101.

To verify the changes:
- Go to [this page](https://obs-reviewlab.opensuse.org/eduardoj-fix_buildresults/package/show/home:Admin/ctris) of the review app.
- Click on "Hide excluded/disabled results".
- Enter the responsive design mode of your browser (Ctrl + Shift + M in Firefox).
- Play with the width of the display window.

<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn
how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md

In order to make it as easy as possible for other developers to review your
pull request we ask you to:

- Explain what this PR is about in the description
- Explain the steps the reviewer has to follow to verify your change
- If the reviewer needs sample data to verify your change, please explain how to
  create that data
- If you include visual changes in this PR, please add screenshots or GIFs
- If you address performance in this PR, add benchmark data or explain how the
  reviewer can benchmark this

This is a good PR description example:

Hey Friends,

this introduces labels for the different build result states on the project
monitor page. This makes it easier to get a visual overview of what is going on
in your project.

To verify this feature

- Enable the interconnect to build.opensuse.org
- Create the project home:Admin
- Add 'openSUSE Tumbleweed' as a repository to the project
- Branch a couple of packages into the project:
  ```
  for i in `osc -A http://0.0.0.0:3000 ls openSUSE.org:home:hennevogel`; do osc -A http://0.0.0.0:3000 copypac openSUSE.org:home:hennevogel $i home:Admin; done
  ```
- Visit the monitor page and see the new labels for the different states.

Here is a screenshot of how it looks:

** Before **
![Screenshot of the project monitor](https://example.com/screenshot1.png)

** After **
![Screenshot of the project monitor](https://example.com/screenshot2.png)

-->
