### PR TITLE
Remove grid witdth definition of second column in build results for projects

### DIFF
--- a/src/api/app/views/webui/project/_buildstatus.html.haml
+++ b/src/api/app/views/webui/project/_buildstatus.html.haml
@@ -50,7 +50,7 @@
                                                   deleting: 1,
                                                   defaults: 0 }, rel: 'nofollow', class: 'nowrap')
 
-              .col-6.col-sm-5.text-nowrap
+              .col.text-nowrap
                 .d-flex.flex-column
                   - build_result.summary.each do |status_count|
                     %div


### PR DESCRIPTION
Prevents overlapping of columns in small displays.

Apply the same work done in #8405 in package build results, but this time for project build results.

To verify the changes:
- Go to [this page](https://obs-reviewlab.opensuse.org/eduardoj-fix_buildresults_for_projects/project/show/home:Admin) of the review app.
- Enter the responsive design mode of your browser (Ctrl + Shift + M in Firefox).
- Play with the width of the display window.

<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn
how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md

In order to make it as easy as possible for other developers to review your
pull request we ask you to:

- Explain what this PR is about in the description
- Explain the steps the reviewer has to follow to verify your change
- If the reviewer needs sample data to verify your change, please explain how to
  create that data
- If you include visual changes in this PR, please add screenshots or GIFs
- If you address performance in this PR, add benchmark data or explain how the
  reviewer can benchmark this

This is a good PR description example:

Hey Friends,

this introduces labels for the different build result states on the project
monitor page. This makes it easier to get a visual overview of what is going on
in your project.

To verify this feature

- Enable the interconnect to build.opensuse.org
- Create the project home:Admin
- Add 'openSUSE Tumbleweed' as a repository to the project
- Branch a couple of packages into the project:
  ```
  for i in `osc -A http://0.0.0.0:3000 ls openSUSE.org:home:hennevogel`; do osc -A http://0.0.0.0:3000 copypac openSUSE.org:home:hennevogel $i home:Admin; done
  ```
- Visit the monitor page and see the new labels for the different states.

Here is a screenshot of how it looks:

** Before **
![Screenshot of the project monitor](https://example.com/screenshot1.png)

** After **
![Screenshot of the project monitor](https://example.com/screenshot2.png)

-->
