### PR TITLE
Prevent showing "Add user as maintaner" checkbox of a delete request

### DIFF
--- a/src/api/app/views/webui/request/_decision_tab.html.haml
+++ b/src/api/app/views/webui/request/_decision_tab.html.haml
@@ -3,7 +3,7 @@
   %p
     = text_area_tag(:reason, nil, placeholder: 'Please add a comment', rows: 4, class: 'w-100 form-control')
   - if single_action_request && is_target_maintainer && state.in?(['new', 'review'])
-    - if state.in?(['new', 'review']) && !action[:creator_is_target_maintainer]
+    - if !action[:creator_is_target_maintainer] && action[:type] == :submit
       .custom-control.custom-checkbox
         = check_box_tag('add_submitter_as_maintainer_0', "#{action[:tprj]}_#_#{action[:tpkg]}", false, class: 'custom-control-input')
         %label.custom-control-label{ for: 'add_submitter_as_maintainer_0' }


### PR DESCRIPTION
Fixes #7297 and #8403.

The issue happens, for example, when a user receives a delete request from the Admin bot to remove a project to free resources on our always crowded server. It doesn't make much sense to ask for making the requestor to be maintainer of a project that is going to be deleted in the same request.

To verify the changes:
- Go to https://obs-reviewlab.opensuse.org/eduardoj-fix_8403/request/show/2
- Log in with the user 'Iggy'.
- Verify there isn't any "Add user as maintaner" checkbox at the end of the page.

Co-authored-by: David Kang <dkang@suse.com>

**Update:**
The pull request was modified to take in account the cases where the requests were not of the type `submit`.

<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn
how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md

In order to make it as easy as possible for other developers to review your
pull request we ask you to:

- Explain what this PR is about in the description
- Explain the steps the reviewer has to follow to verify your change
- If the reviewer needs sample data to verify your change, please explain how to
  create that data
- If you include visual changes in this PR, please add screenshots or GIFs
- If you address performance in this PR, add benchmark data or explain how the
  reviewer can benchmark this

This is a good PR description example:

Hey Friends,

this introduces labels for the different build result states on the project
monitor page. This makes it easier to get a visual overview of what is going on
in your project.

To verify this feature

- Enable the interconnect to build.opensuse.org
- Create the project home:Admin
- Add 'openSUSE Tumbleweed' as a repository to the project
- Branch a couple of packages into the project:
  ```
  for i in `osc -A http://0.0.0.0:3000 ls openSUSE.org:home:hennevogel`; do osc -A http://0.0.0.0:3000 copypac openSUSE.org:home:hennevogel $i home:Admin; done
  ```
- Visit the monitor page and see the new labels for the different states.

Here is a screenshot of how it looks:

** Before **
![Screenshot of the project monitor](https://example.com/screenshot1.png)

** After **
![Screenshot of the project monitor](https://example.com/screenshot2.png)

-->
