### PR TITLE
Remove UserController

### DIFF
--- a/ReleaseNotes-2.11
+++ b/ReleaseNotes-2.11
@@ -51,3 +51,9 @@ Intentional changes:
     * Kiwi Image Editor
     * Cloud upload for EC2
     * Cloud upload for Azure
+ 
+ * Removed the following routes:
+
+    - /home/my_work
+    - /home/home_project
+    - /home/list_my

--- a/src/api/app/controllers/webui/user_controller.rb
+++ b/src/api/app/controllers/webui/user_controller.rb
@@ -1,9 +1,0 @@
-class Webui::UserController < Webui::WebuiController
-  def home
-    if params[:user].present?
-      redirect_to user_path(params[:user])
-    else
-      redirect_to user_path(User.possibly_nobody)
-    end
-  end
-end

--- a/src/api/app/controllers/webui/webui_controller.rb
+++ b/src/api/app/controllers/webui/webui_controller.rb
@@ -81,6 +81,14 @@ class Webui::WebuiController < ActionController::Base
     CGI.escapeHTML(rawid.gsub(/[+&: .\/\~\(\)@#]/, '_'))
   end
 
+  def home
+    if params[:login].present?
+      redirect_to user_path(params[:login])
+    else
+      redirect_to user_path(User.possibly_nobody)
+    end
+  end
+
   protected
 
   # We execute both strategies here. The default rails strategy (resetting the session)

--- a/src/api/app/views/layouts/webui/_logged_in_user_navigation.html.haml
+++ b/src/api/app/views/layouts/webui/_logged_in_user_navigation.html.haml
@@ -1,5 +1,5 @@
 %li.nav-item
-  = link_to(home_path, id: 'link-to-user-home', class: 'nav-link') do
+  = link_to(user_path(User.session!), id: 'link-to-user-home', class: 'nav-link') do
     = User.session!.login
 %li.nav-item
   - tasks = User.session!.tasks

--- a/src/api/app/views/layouts/webui/obs_factory/_personal_navigation.html.haml
+++ b/src/api/app/views/layouts/webui/obs_factory/_personal_navigation.html.haml
@@ -1,6 +1,6 @@
 .grid_6.omega{ style: 'text-align: right' }
   - if User.session
-    = link_to(home_path, id: 'link-to-user-home') do
+    = link_to(user_path(User.session), id: 'link-to-user-home') do
       = User.session!.login
     |
     - tasks = User.session!.tasks

--- a/src/api/config/routes.rb
+++ b/src/api/config/routes.rb
@@ -334,14 +334,6 @@ OBSApi::Application.routes.draw do
       get 'search/issue' => :issue
     end
 
-    controller 'webui/user' do
-      # Only here to make old /home url's work
-      get 'home/' => :home, as: 'home'
-      get 'home/my_work' => :home
-      get 'home/list_my' => :home
-      get 'home/home_project' => :home_project
-    end
-
     controller 'webui/users/announcements' do
       post 'users/announcements/:id' => :create, as: 'user_announcements'
     end
@@ -357,11 +349,13 @@ OBSApi::Application.routes.draw do
       end
     end
 
+    get 'home', to: 'webui/webui#home', as: :home
     get 'signup', to: 'webui/users#new', as: :signup
 
     # TODO
     # keep those routes reachable, but remove them later as
     # nobody access it anymore
+    # Legacy routes start
     namespace :user do
       get '/signup', to: redirect('/signup')
       get '/register_user', to: redirect('/signup')
@@ -369,6 +363,7 @@ OBSApi::Application.routes.draw do
       get '/autocomplete', to: redirect('/users/autocomplete')
       get '/tokens', to: redirect('/users/tokens')
     end
+    # Legacy routes end
 
     resources :announcements, only: :show, controller: 'webui/announcements'
 

--- a/src/api/spec/features/webui/users/user_home_page_spec.rb
+++ b/src/api/spec/features/webui/users/user_home_page_spec.rb
@@ -29,7 +29,7 @@ RSpec.feature "User's home project creation", type: :feature, js: true do
   describe 'as a logged-in user' do
     before do
       login user
-      visit home_path
+      visit user_path(user)
     end
 
     scenario 'view home page' do


### PR DESCRIPTION
To accomplish it we did:

- Moved home action to WebuiController and adapted the routes
- Removed the old and unused routes '/home/my_work' and '/home/my_project'
- Removed the UserController


Note:

Since nobody access the following routes, and they were already marked as "old routes" since 2.9, I dropped them. Should I add a note to the release notes?

The routes: 

```
  get 'home/my_work' => :home
  get 'home/list_my' => :home
  get 'home/home_project' => :home_project
```

For me it would be ok  to remove the '/home' endpoint too and instead use the `/users/$USER` directly. What do you think @hennevogel ? I deprecated it,  removing it from the partials `_logged_in_user_navigation.html.haml` and `obs_factory/_personal_navigation.html.haml` but it still accessible. 