### PR TITLE
Fix renaming of the 'c' variable to 'problem'

### DIFF
--- a/src/api/app/helpers/webui/projects/status_helper.rb
+++ b/src/api/app/helpers/webui/projects/status_helper.rb
@@ -25,7 +25,7 @@ module Webui::Projects::StatusHelper
           sortkey = "7-changes#{package['name']}"
           icon = 'changes'
         elsif problem.match?(/^error-/)
-          outs << link_to(c[6..-1], package_show_path(project: package['develproject'], package: package['develpackage']))
+          outs << link_to(problem[6..-1], package_show_path(project: package['develproject'], package: package['develpackage']))
           sortkey = "1-problem-#{package['name']}"
           icon = 'error'
         elsif problem == 'currently_declined'
@@ -34,7 +34,7 @@ module Webui::Projects::StatusHelper
           sortkey = "2-declines-#{package['name']}"
           icon = 'error'
         else
-          outs << link_to(c, package_show_path(project: package['develproject'], package: package['develpackage']))
+          outs << link_to(problem, package_show_path(project: package['develproject'], package: package['develpackage']))
           sortkey = "1-changes-#{package['name']}"
           icon = 'error'
         end


### PR DESCRIPTION
In 3004f02e43d the variable `c` was renamed to `problem`, but this two occurrences were not renamed.

Fixes #6909.

Co-authored-by: David Kang <dkang@suse.com>

<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn
how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md

In order to make it as easy as possible for other developers to review your
pull request we ask you to:

- Explain what this PR is about in the description
- Explain the steps the reviewer has to follow to verify your change
- If the reviewer needs sample data to verify your change, please explain how to
  create that data
- If you include visual changes in this PR, please add screenshots or GIFs
- If you address performance in this PR, add benchmark data or explain how the
  reviewer can benchmark this

This is a good PR description example:

Hey Friends,

this introduces labels for the different build result states on the project
monitor page. This makes it easier to get a visual overview of what is going on
in your project.

To verify this feature

- Enable the interconnect to build.opensuse.org
- Create the project home:Admin
- Add 'openSUSE Tumbleweed' as a repository to the project
- Branch a couple of packages into the project:
  ```
  for i in `osc -A http://0.0.0.0:3000 ls openSUSE.org:home:hennevogel`; do osc -A http://0.0.0.0:3000 copypac openSUSE.org:home:hennevogel $i home:Admin; done
  ```
- Visit the monitor page and see the new labels for the different states.

Here is a screenshot of how it looks:

** Before **
![Screenshot of the project monitor](https://example.com/screenshot1.png)

** After **
![Screenshot of the project monitor](https://example.com/screenshot2.png)

-->
