### PR TITLE
Move user specific urls under scope 'my'

### DIFF
--- a/src/api/app/controllers/webui/users/rss_tokens_controller.rb
+++ b/src/api/app/controllers/webui/users/rss_tokens_controller.rb
@@ -13,7 +13,7 @@ module Webui
           flash[:success] = 'Successfully generated your RSS feed url'
           User.session!.create_rss_token
         end
-        redirect_back(fallback_location: user_notifications_path)
+        redirect_back(fallback_location: my_notifications_path)
       end
     end
   end

--- a/src/api/app/views/layouts/webui/_announcement.html.haml
+++ b/src/api/app/views/layouts/webui/_announcement.html.haml
@@ -8,5 +8,5 @@
             = link_to('Read more...', announcement_path(pending_announcement), class: 'alert-link')
           .col-md-2
             - if User.session
-              = form_tag(user_announcements_path(pending_announcement), remote: true, class: 'text-right') do
+              = form_tag(my_announcements_path(pending_announcement), remote: true, class: 'text-right') do
                 = submit_tag 'Got it', class: 'btn btn-sm btn-secondary'

--- a/src/api/app/views/layouts/webui/_logged_in_user_navigation.html.haml
+++ b/src/api/app/views/layouts/webui/_logged_in_user_navigation.html.haml
@@ -3,7 +3,7 @@
     = User.session!.login
 %li.nav-item
   - tasks = User.session!.tasks
-  = link_to(user_tasks_path, class: 'nav-link') do
+  = link_to(my_tasks_path, class: 'nav-link') do
     - if tasks.positive?
       %span{ title: 'where an action is requested from you' }
         = pluralize(tasks, 'Task')

--- a/src/api/app/views/layouts/webui/obs_factory/_announcement.html.haml
+++ b/src/api/app/views/layouts/webui/obs_factory/_announcement.html.haml
@@ -6,5 +6,5 @@
           = @pending_announcement.title
           = link_to('Read more', announcement_path(@pending_announcement))
       - if User.session
-        = form_tag(user_announcements_path(@pending_announcement), remote: true, class: 'announcement-actions') do
+        = form_tag(my_announcements_path(@pending_announcement), remote: true, class: 'announcement-actions') do
           = submit_tag 'Got it'

--- a/src/api/app/views/layouts/webui/obs_factory/_personal_navigation.html.haml
+++ b/src/api/app/views/layouts/webui/obs_factory/_personal_navigation.html.haml
@@ -4,7 +4,7 @@
       = User.session!.login
     |
     - tasks = User.session!.tasks
-    = link_to(user_tasks_path) do
+    = link_to(my_tasks_path) do
       - if tasks > 0
         %span{ title: 'where an action is requested from you' }
           = pluralize(tasks, 'Task')

--- a/src/api/app/views/webui/announcements/show.html.haml
+++ b/src/api/app/views/webui/announcements/show.html.haml
@@ -5,5 +5,5 @@
     %h2= @announcement.title
     %p= render_as_markdown(@announcement.content)
     - if User.session && @announcement == @pending_announcement
-      = form_tag(user_announcements_path(@announcement), remote: true) do
+      = form_tag(my_announcements_path(@announcement), remote: true) do
         = submit_tag 'Got it', class: 'btn btn-primary'

--- a/src/api/app/views/webui/user/_info.html.haml
+++ b/src/api/app/views/webui/user/_info.html.haml
@@ -50,7 +50,7 @@
           = link_to('#', data: { toggle: 'modal', target: '#password-modal' }, class: 'd-block') do
             %i.fas.fa-key
             Change your password
-        = link_to(user_notifications_path, class: 'd-block') do
+        = link_to(my_notifications_path, class: 'd-block') do
           %i.fas.fa-bell
           Change your notifications
         - if user.rss_token

--- a/src/api/app/views/webui/users/subscriptions/_breadcrumb_items.html.haml
+++ b/src/api/app/views/webui/users/subscriptions/_breadcrumb_items.html.haml
@@ -1,4 +1,4 @@
 = render partial: 'webui/main/breadcrumb_items'
-- if current_page?(user_notifications_path)
+- if current_page?(my_notifications_path)
   %li.breadcrumb-item.active{ 'aria-current' => 'page' }
     Notifications

--- a/src/api/app/views/webui/users/subscriptions/index.html.haml
+++ b/src/api/app/views/webui/users/subscriptions/index.html.haml
@@ -11,19 +11,19 @@
         - @groups_users.each do |group_user|
           .custom-control.custom-checkbox.custom-control-inline
             = check_box_tag group_user.group, '1', group_user.email, class: 'custom-control-input', id: "checkbox-#{group_user.group}",
-              data: { url: user_notifications_path, method: :put, remote: true }
+              data: { url: my_notifications_path, method: :put, remote: true }
             = label_tag group_user.group.title, nil, class: 'custom-control-label', for: "checkbox-#{group_user.group}"
             %i.fas.fa-spinner.invisible
   .card-body
     %h4.card-title Events
     %p Choose from which events you want to get an email
     #subscriptions-form
-      = render partial: 'webui/subscriptions/subscriptions_form', locals: { path: user_notifications_path, subscriptions_form: @subscriptions_form }
+      = render partial: 'webui/subscriptions/subscriptions_form', locals: { path: my_notifications_path, subscriptions_form: @subscriptions_form }
 
 .card.mt-3
   .card-body
     %h4.card-title RSS Feed
-    = form_tag(user_rss_token_path, id: 'generate_rss_token_form', method: :post) do
+    = form_tag(my_rss_token_path, id: 'generate_rss_token_form', method: :post) do
       %p
       - if @user.rss_token
         To access your RSS feeds, use the following url:

--- a/src/api/config/routes.rb
+++ b/src/api/config/routes.rb
@@ -334,10 +334,6 @@ OBSApi::Application.routes.draw do
       get 'search/issue' => :issue
     end
 
-    controller 'webui/users/announcements' do
-      post 'users/announcements/:id' => :create, as: 'user_announcements'
-    end
-
     resources :users, controller: 'webui/users', param: :login, constraints: cons do
       resources :requests, only: [:index], controller: 'webui/users/bs_requests'
       collection do
@@ -347,6 +343,15 @@ OBSApi::Application.routes.draw do
       member do
         post 'change_password'
       end
+    end
+
+    scope :my do
+      resources :tasks, only: [:index], controller: 'webui/users/tasks', as: :my_tasks
+      get 'notifications' => :index,  controller: 'webui/users/subscriptions', as: :my_notifications
+      put 'notifications' => :update, controller: 'webui/users/subscriptions'
+      post 'rss_tokens' => :create, controller: 'webui/users/rss_tokens', as: :my_rss_token
+      # To accept announcements as user
+      post 'announcements/:id' => :create, controller: 'webui/users/announcements', as: :my_announcements
     end
 
     get 'home', to: 'webui/webui#home', as: :home
@@ -369,17 +374,8 @@ OBSApi::Application.routes.draw do
 
     resource :session, only: [:new, :create, :destroy], controller: 'webui/session'
 
-    get 'user/notifications' => :index, constraints: cons, controller: 'webui/users/subscriptions'
-    put 'user/notifications' => :update, constraints: cons, controller: 'webui/users/subscriptions'
-
-    get 'user/tasks' => :index, constraints: cons, controller: 'webui/users/tasks', as: 'user_tasks'
-
     controller 'webui/groups/bs_requests' do
       get 'groups/(:title)/requests' => :index, constraints: { title: /[^\/]*/ }, as: 'group_requests'
-    end
-
-    controller 'webui/users/rss_tokens' do
-      post 'users/rss_tokens' => :create, as: 'user_rss_token'
     end
 
     controller 'webui/groups' do

--- a/src/api/spec/controllers/webui/users/rss_tokens_controller_spec.rb
+++ b/src/api/spec/controllers/webui/users/rss_tokens_controller_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe Webui::Users::RssTokensController do
       end
 
       it { expect(flash[:success]).to eq('Successfully generated your RSS feed url') }
-      it { is_expected.to redirect_to(user_notifications_path) }
+      it { is_expected.to redirect_to(my_notifications_path) }
       it { expect(user.reload.rss_token.string).not_to eq(last_token) }
     end
 
@@ -28,7 +28,7 @@ RSpec.describe Webui::Users::RssTokensController do
       end
 
       it { expect(flash[:success]).to eq('Successfully generated your RSS feed url') }
-      it { is_expected.to redirect_to(user_notifications_path) }
+      it { is_expected.to redirect_to(my_notifications_path) }
       it { expect(user.reload.rss_token).not_to be_nil }
       it { expect(last_token).to be_nil }
     end

--- a/src/api/spec/features/webui/notifications_spec.rb
+++ b/src/api/spec/features/webui/notifications_spec.rb
@@ -35,7 +35,7 @@ RSpec.feature 'Notifications', type: :feature, js: true do
     it_behaves_like 'updatable' do
       let(:title) { 'Choose from which events you want to get an email' }
       let(:user) { create(:confirmed_user, login: 'eisendieter') }
-      let(:path) { user_notifications_path }
+      let(:path) { my_notifications_path }
     end
   end
 end

--- a/src/api/spec/features/webui/users/user_home_page_spec.rb
+++ b/src/api/spec/features/webui/users/user_home_page_spec.rb
@@ -45,7 +45,7 @@ RSpec.feature "User's home project creation", type: :feature, js: true do
     end
 
     scenario 'view tasks page' do
-      visit user_tasks_path(user)
+      visit my_tasks_path
 
       expect(page).to have_link('Incoming Requests')
       expect(page).to have_link('Outgoing Requests')

--- a/src/api/test/fixtures/event_mailer/another_comment_event
+++ b/src/api/test/fixtures/event_mailer/another_comment_event
@@ -35,7 +35,7 @@ Thor wrote in request 4:
 Another Body
 
 -- 
-Configure notifications at http://localhost/user/notifications
+Configure notifications at http://localhost/my/notifications
 Open Build Service (http://localhost/)
 
 Content-Type: text/html;
@@ -50,6 +50,6 @@ Content-Transfer-Encoding: 7bit
 </div>
 <br/>
 -- <br/>
-Configure notifications at <a href="http://localhost/user/notifications">http://localhost/user/notifications</a><br/>
+Configure notifications at <a href="http://localhost/my/notifications">http://localhost/my/notifications</a><br/>
 Open Build Service (<a href="http://localhost/">http://localhost/</a>)<br/>
 

--- a/src/api/test/fixtures/event_mailer/comment_event
+++ b/src/api/test/fixtures/event_mailer/comment_event
@@ -37,7 +37,7 @@ Thor wrote in request 4:
 Comment Body
 
 -- 
-Configure notifications at http://localhost/user/notifications
+Configure notifications at http://localhost/my/notifications
 Open Build Service (http://localhost/)
 
 Content-Type: text/html;
@@ -52,6 +52,6 @@ Content-Transfer-Encoding: 7bit
 </div>
 <br/>
 -- <br/>
-Configure notifications at <a href="http://localhost/user/notifications">http://localhost/user/notifications</a><br/>
+Configure notifications at <a href="http://localhost/my/notifications">http://localhost/my/notifications</a><br/>
 Open Build Service (<a href="http://localhost/">http://localhost/</a>)<br/>
 

--- a/src/api/test/fixtures/event_mailer/commit_event
+++ b/src/api/test/fixtures/event_mailer/commit_event
@@ -18,5 +18,5 @@ Check out the package for editing:
    osc checkout BaseDistro pack1
 
 -- 
-Configure notifications at http://localhost/user/notifications
+Configure notifications at http://localhost/my/notifications
 Open Build Service (http://localhost/)

--- a/src/api/test/fixtures/event_mailer/project_comment
+++ b/src/api/test/fixtures/event_mailer/project_comment
@@ -28,7 +28,7 @@ Thor wrote in project home:Iggy:
 Comment Body
 
 -- 
-Configure notifications at http://localhost/user/notifications
+Configure notifications at http://localhost/my/notifications
 Open Build Service (http://localhost/)
 
 Content-Type: text/html;
@@ -48,7 +48,7 @@ wrote in project home:Iggy:
 <br>
 --
 <br>
-Configure notifications at <a href="http://localhost/user/notifications">http://localhost/user/notifications</a>
+Configure notifications at <a href="http://localhost/my/notifications">http://localhost/my/notifications</a>
 <br>
 Open Build Service
 (<a href="http://localhost/">http://localhost/</a>)

--- a/src/api/test/fixtures/event_mailer/repo_delete_request
+++ b/src/api/test/fixtures/event_mailer/repo_delete_request
@@ -37,5 +37,5 @@ To REVOKE the request:
    osc request revoke REQUESTID --message="retracted because ..., sorry / thx / see better version ..."
 
 -- 
-Configure notifications at http://localhost/user/notifications
+Configure notifications at http://localhost/my/notifications
 Open Build Service (http://localhost/)

--- a/src/api/test/fixtures/event_mailer/request_event
+++ b/src/api/test/fixtures/event_mailer/request_event
@@ -37,5 +37,5 @@ To REVOKE the request:
    osc request revoke REQUESTID --message="retracted because ..., sorry / thx / see better version ..."
 
 -- 
-Configure notifications at http://localhost/user/notifications
+Configure notifications at http://localhost/my/notifications
 Open Build Service (http://localhost/)

--- a/src/api/test/fixtures/event_mailer/review_wanted
+++ b/src/api/test/fixtures/event_mailer/review_wanted
@@ -51,5 +51,5 @@ other changes:
 
 
 -- 
-Configure notifications at http://localhost/user/notifications
+Configure notifications at http://localhost/my/notifications
 Open Build Service (http://localhost/)

--- a/src/api/test/fixtures/event_mailer/set_bugowner_event
+++ b/src/api/test/fixtures/event_mailer/set_bugowner_event
@@ -37,5 +37,5 @@ To REVOKE the request:
    osc request revoke REQUESTID --message="retracted because ..., sorry / thx / see better version ..."
 
 -- 
-Configure notifications at http://localhost/user/notifications
+Configure notifications at http://localhost/my/notifications
 Open Build Service (http://localhost/)

--- a/src/api/test/fixtures/event_mailer/tom_declined
+++ b/src/api/test/fixtures/event_mailer/tom_declined
@@ -31,5 +31,5 @@ Actions:
 - set the bugowner of project home:tom to Iggy
 
 -- 
-Configure notifications at http://localhost/user/notifications
+Configure notifications at http://localhost/my/notifications
 Open Build Service (http://localhost/)

--- a/src/api/test/fixtures/event_mailer/tom_gets_mail_too
+++ b/src/api/test/fixtures/event_mailer/tom_gets_mail_too
@@ -39,5 +39,5 @@ To REVOKE the request:
    osc request revoke REQUESTID --message="retracted because ..., sorry / thx / see better version ..."
 
 -- 
-Configure notifications at http://localhost/user/notifications
+Configure notifications at http://localhost/my/notifications
 Open Build Service (http://localhost/)


### PR DESCRIPTION
Some routes are user specific and they are bounded with User.session! therefore instead of force it to be under /users, we can create the routes like:

- /my/tasks
- /my/notifications
...

