### PR TITLE
Display the 'Staging' tab only for authorized users

### DIFF
--- a/src/api/app/views/webui/project/_tabs.html.haml
+++ b/src/api/app/views/webui/project/_tabs.html.haml
@@ -33,7 +33,7 @@
       %li.nav-item
         = tab_link('Pulse', project_pulse_path(project))
       - active = controller_path.starts_with?('webui/staging')
-      - if !project.staging_project? || active
+      - if (!project.staging_project? && policy(Staging::Workflow.new(project: project)).create?) || active
         %li.nav-item
           = tab_link('Staging', new_staging_workflow_path(project: project), active)
     %li.nav-item.dropdown


### PR DESCRIPTION
When the project isn't a staging project.

The other case is when the 'Staging' tab is active. It doesn't rely on authorization.

Fixes #8409