### PR TITLE
Use File.read to force the new routes files to be reloaded

### DIFF
--- a/src/api/config/routes.rb
+++ b/src/api/config/routes.rb
@@ -1,8 +1,15 @@
+require_relative 'routes/routes_helper'
+
+class ActionDispatch::Routing::Mapper
+  def draw(routes_name)
+    instance_eval(File.read(Rails.root.join("config/routes/#{routes_name}_routes.rb")))
+  end
+end
+
 OBSApi::Application.routes.draw do
   mount Peek::Railtie => '/peek'
-  require_relative 'routes/routes_helper'
-  require_relative 'routes/webui_routes'
-  require_relative 'routes/api_routes'
+  draw :webui
+  draw :api
 end
 
 OBSEngine::Base.subclasses.each(&:mount_it)

--- a/src/api/config/routes/api_routes.rb
+++ b/src/api/config/routes/api_routes.rb
@@ -1,5 +1,3 @@
-require_relative 'routes_helper'
-
 OBSApi::Application.routes.draw do
   cons = RoutesContrains::CONS
 

--- a/src/api/config/routes/webui_routes.rb
+++ b/src/api/config/routes/webui_routes.rb
@@ -1,5 +1,3 @@
-require_relative 'routes_helper'
-
 OBSApi::Application.routes.draw do
   cons = RoutesContrains::CONS
 


### PR DESCRIPTION
In development environment, after a file change, the routes.rb were
reloaded but the files under config/routes don't. In that way, the `File.read` will run always when `routes.rb` gets reloaded.

How to test it:

- run it locally (yes you have to checkout the branch)
- change a controller, i.e open the webui/project_controller#show and add an instance variable `foo = true` go to your browser and try to reload the application.. all routes should be still accessible.

