### PR TITLE
Add error message if a StagingWorkflow doesn't exist

### DIFF
--- a/src/api/app/controllers/staging/staging_projects_controller.rb
+++ b/src/api/app/controllers/staging/staging_projects_controller.rb
@@ -10,7 +10,11 @@ class Staging::StagingProjectsController < ApplicationController
       @staging_workflow = @main_project.staging
       @staging_projects = @staging_workflow.staging_projects
     else
-      render_error status: 400, errcode: 'project_has_no_staging_workflow'
+      render_error(
+        status: 404,
+        errorcode: 'project_has_no_staging_workflow',
+        message: "No staging workflow for project '#{@main_project}'"
+      )
     end
   end
 

--- a/src/api/spec/controllers/staging/staging_projects_controller_spec.rb
+++ b/src/api/spec/controllers/staging/staging_projects_controller_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe Staging::StagingProjectsController do
         get :index, params: { staging_workflow_project: project_without_staging.name, format: :xml }
       end
 
-      it { expect(response).to have_http_status(:bad_request) }
+      it { expect(response).to have_http_status(:not_found) }
     end
   end
 


### PR DESCRIPTION
We improve the user experience adding an error message, giving a clue of
what is happening.

Fix #8298

<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn
how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md

In order to make it as easy as possible for other developers to review your
pull request we ask you to:

- Explain what this PR is about in the description
- Explain the steps the reviewer has to follow to verify your change
- If the reviewer needs sample data to verify your change, please explain how to
  create that data
- If you include visual changes in this PR, please add screenshots or GIFs
- If you address performance in this PR, add benchmark data or explain how the
  reviewer can benchmark this

This is a good PR description example:

Hey Friends,

this introduces labels for the different build result states on the project
monitor page. This makes it easier to get a visual overview of what is going on
in your project.

To verify this feature

- Enable the interconnect to build.opensuse.org
- Create the project home:Admin
- Add 'openSUSE Tumbleweed' as a repository to the project
- Branch a couple of packages into the project:
  ```
  for i in `osc -A http://0.0.0.0:3000 ls openSUSE.org:home:hennevogel`; do osc -A http://0.0.0.0:3000 copypac openSUSE.org:home:hennevogel $i home:Admin; done
  ```
- Visit the monitor page and see the new labels for the different states.

Here is a screenshot of how it looks:

** Before **
![Screenshot of the project monitor](https://example.com/screenshot1.png)

** After **
![Screenshot of the project monitor](https://example.com/screenshot2.png)

-->
