### PR TITLE
[dist] chrpath in obs-bundled-gems.spec no longer mandatory

### DIFF
--- a/dist/obs-bundled-gems.spec
+++ b/dist/obs-bundled-gems.spec
@@ -142,9 +142,6 @@ find %{buildroot} -type f -print0 | xargs -0 grep -l /usr/bin/env | while read f
   chmod a-x $file
 done
 
-# Remove rpaths from files
-chrpath --delete %{buildroot}%_libdir/obs-api/ruby/*/gems/sassc-*-x86_64-linux/lib/sassc/libsass.so
-
 %files
 %_libdir/obs-api
 


### PR DESCRIPTION
The new version of obs-service-bundle_gems has the
"force_ruby_platform" enabled. This leads to the following error
while build obs-bundle-gems:

```
[  396s] + chrpath --delete '/home/abuild/rpmbuild/BUILDROOT/obs-bundled-gems-2.11~alpha.20190925T165156.cb40d16c84-8857.1.x86_64/usr/lib64/obs-api/ruby/*/gems/sassc-*-x86_64-linux/lib/sassc/libsass.so'
[  396s] open: No such file or directory
[  396s] elf_open: Invalid argument
```

because "libsass.so" no longer gets packaged.

This patch simply returns a "true" value if chrpath fails so the %install
section does not break anymore.

This PR is a follow up for

https://github.com/openSUSE/obs-service-bundle_gems/pull/14

@bugfinder - Thanks for preparing
