### PR TITLE
Safeguard against anonymous requesting large diffs

### DIFF
--- a/src/api/app/controllers/webui/package_controller.rb
+++ b/src/api/app/controllers/webui/package_controller.rb
@@ -318,8 +318,8 @@ class Webui::PackageController < Webui::WebuiController
       options[k] = params[k] if params[k].present?
     end
     options[:rev] = @rev if @rev
-    options[:filelimit] = 0 if params[:full_diff]
-    options[:tarlimit] = 0 if params[:full_diff]
+    options[:filelimit] = 0 if params[:full_diff] && User.session
+    options[:tarlimit] = 0 if params[:full_diff] && User.session
     return unless get_diff(@project.name, @package.name, options)
 
     # we only look at [0] because this is a generic function for multi diffs - but we're sure we get one

--- a/src/api/app/views/webui/package/rdiff.html.haml
+++ b/src/api/app/views/webui/package/rdiff.html.haml
@@ -1,7 +1,7 @@
 - content_for(:content_for_head, javascript_include_tag('webui/cm2/index-diff'))
 - @pagetitle = "Changes of Revision #{@rev}"
 
-- if @not_full_diff
+- if @not_full_diff && User.session
   - path_variables = { project: @project, package: @package, linkrev: @linkrev, rev: @rev, full_diff: true }
   - if @opackage
     - path_variables[:oproject] = @oproject

--- a/src/api/app/views/webui/request/show.html.haml
+++ b/src/api/app/views/webui/request/show.html.haml
@@ -4,7 +4,7 @@
   content_for(:meta_description, @bs_request.description)
   content_for(:meta_image, gravatar_url(User.find_by_login(@bs_request.creator).email))
 
-- if @not_full_diff
+- if @not_full_diff && User.session
   = render partial: 'webui/shared/truncated_diff_hint', locals: { path: request_show_path(number: @bs_request.number, full_diff: true) }
 
 = render partial: 'superseded_by_message', locals: { superseded_by: @bs_request.superseded_by,

--- a/src/api/spec/controllers/webui/package_controller_spec.rb
+++ b/src/api/spec/controllers/webui/package_controller_spec.rb
@@ -909,12 +909,14 @@ RSpec.describe Webui::PackageController, vcr: true do
 
       context 'full diff requested' do
         it 'does not show a hint' do
+          login user
           get :rdiff, params: { project: source_project, package: package_ascii_file, full_diff: true, rev: 2 }
           expect(assigns(:not_full_diff)).to be_falsy
         end
 
         context 'for ASCII files' do
           before do
+            login user
             get :rdiff, params: { project: source_project, package: package_ascii_file, full_diff: true, rev: 2 }
           end
 
@@ -926,6 +928,7 @@ RSpec.describe Webui::PackageController, vcr: true do
 
         context 'for archives' do
           before do
+            login user
             get :rdiff, params: { project: source_project, package: package_binary_file, full_diff: true }
           end
 


### PR DESCRIPTION
Requesting a full diff can mean loading a shitload of data, only allow this for logged in users.