### PR TITLE
Show a proper error message when excluding a request

### DIFF
--- a/src/api/app/controllers/staging/excluded_requests_controller.rb
+++ b/src/api/app/controllers/staging/excluded_requests_controller.rb
@@ -18,7 +18,7 @@ class Staging::ExcludedRequestsController < ApplicationController
       render_error(
         status: 400,
         errorcode: 'invalid_request',
-        message: "Excluding requests for #{@staging_workflow} failed: #{result.errors.join(' ')}"
+        message: "Excluding requests for #{@staging_workflow.project} failed: #{result.errors.join(' ')}"
       )
     end
   end

--- a/src/api/app/controllers/webui/staging/excluded_requests_controller.rb
+++ b/src/api/app/controllers/webui/staging/excluded_requests_controller.rb
@@ -28,6 +28,11 @@ module Webui
           redirect_back(fallback_location: root_path, error: "Request #{params[:number]} doesn't exist or it doesn't belong to this project")
           return
         end
+        if request.staging_project
+          redirect_back(fallback_location: root_path,
+                        error: "Request #{params[:number]} could not be excluded because is staged in: #{request.staging_project}")
+          return
+        end
 
         request_exclusion = @staging_workflow.request_exclusions.build(bs_request: request, description: staging_request_exclusion[:description])
 

--- a/src/api/spec/controllers/staging/excluded_requests_controller_spec.rb
+++ b/src/api/spec/controllers/staging/excluded_requests_controller_spec.rb
@@ -99,6 +99,17 @@ RSpec.describe Staging::ExcludedRequestsController do
 
       it { expect(response).to have_http_status(400) }
     end
+
+    context 'fails: request belongs to a staging project, invalid request exclusion' do
+      before do
+        bs_request.staging_project = staging_workflow.staging_projects.first
+        bs_request.save
+        post :create, params: { staging_workflow_project: staging_workflow.project.name, format: :xml },
+                      body: "<excluded_requests><request number='43_543'/></excluded_requests>"
+      end
+
+      it { expect(response).to have_http_status(400) }
+    end
   end
 
   describe 'DELETE #destroy' do


### PR DESCRIPTION
Make API and web UI consistent with the same behaviour and error messages.

Fixes #8355.

Co-authored-by: David Kang <dkang@suse.com>

<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn
how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md

In order to make it as easy as possible for other developers to review your
pull request we ask you to:

- Explain what this PR is about in the description
- Explain the steps the reviewer has to follow to verify your change
- If the reviewer needs sample data to verify your change, please explain how to
  create that data
- If you include visual changes in this PR, please add screenshots or GIFs
- If you address performance in this PR, add benchmark data or explain how the
  reviewer can benchmark this

This is a good PR description example:

Hey Friends,

this introduces labels for the different build result states on the project
monitor page. This makes it easier to get a visual overview of what is going on
in your project.

To verify this feature

- Enable the interconnect to build.opensuse.org
- Create the project home:Admin
- Add 'openSUSE Tumbleweed' as a repository to the project
- Branch a couple of packages into the project:
  ```
  for i in `osc -A http://0.0.0.0:3000 ls openSUSE.org:home:hennevogel`; do osc -A http://0.0.0.0:3000 copypac openSUSE.org:home:hennevogel $i home:Admin; done
  ```
- Visit the monitor page and see the new labels for the different states.

Here is a screenshot of how it looks:

** Before **
![Screenshot of the project monitor](https://example.com/screenshot1.png)

** After **
![Screenshot of the project monitor](https://example.com/screenshot2.png)

-->
