### PR TITLE
Fixes #8286: Return XML if staging workflow was successfully deleted

### DIFF
--- a/src/api/app/controllers/staging/workflows_controller.rb
+++ b/src/api/app/controllers/staging/workflows_controller.rb
@@ -25,6 +25,7 @@ class Staging::WorkflowsController < ApplicationController
     authorize @staging_workflow
 
     @staging_workflow.destroy!
+    render_ok
   end
 
   def update


### PR DESCRIPTION
If an User deletes a staging workflow via API, it should return the "OK" XML as every other endpoint.

Fixes: #8286 