### PR TITLE
Refactor routes patchinfo

### DIFF
--- a/src/api/app/controllers/webui/patchinfo_controller.rb
+++ b/src/api/app/controllers/webui/patchinfo_controller.rb
@@ -71,7 +71,7 @@ class Webui::PatchinfoController < Webui::WebuiController
     if @package.check_weak_dependencies? && @package.destroy
       redirect_to(project_show_path(@project), success: 'Patchinfo was successfully removed.')
     else
-      redirect_to(patchinfo_show_path(package: @package, project: @project),
+      redirect_to(show_patchinfo_path(package: @package, project: @project),
                   notice: "Patchinfo can't be removed: #{@package.errors.full_messages.to_sentence}")
     end
   end

--- a/src/api/app/helpers/webui/maintenance_incident_helper.rb
+++ b/src/api/app/helpers/webui/maintenance_incident_helper.rb
@@ -48,7 +48,7 @@ module Webui::MaintenanceIncidentHelper
 
   def category_cell(incident, patchinfo)
     if patchinfo.present?
-      link_to(patchinfo[:category], patchinfo_show_path(project: incident.name, package: 'patchinfo'),
+      link_to(patchinfo[:category], show_patchinfo_path(project: incident.name, package: 'patchinfo'),
               class: "patchinfo-category-#{patchinfo[:category]}")
     else
       link_to(patchinfo_path(project: incident.name, package: 'patchinfo'), method: :post, class: 'text-danger') do

--- a/src/api/app/views/webui/package/_tabs.html.haml
+++ b/src/api/app/views/webui/package/_tabs.html.haml
@@ -4,7 +4,7 @@
       = tab_link('Overview', package_show_path(project, package))
     - if package.name == 'patchinfo'
       %li.nav-item
-        = tab_link('Details', patchinfo_show_path(project, package))
+        = tab_link('Details', show_patchinfo_path(project, package))
     - unless @spider_bot
       %li.nav-item
         = tab_link('Repositories', repositories_path(project, package))

--- a/src/api/app/views/webui/package/side_links/_show_patchinfo.html.haml
+++ b/src/api/app/views/webui/package/side_links/_show_patchinfo.html.haml
@@ -1,6 +1,6 @@
 %li
   %i.fas.fa-info-circle.text-info
   Has a
-  = link_to 'patchinfo', patchinfo_show_path(package: package, project: project)
+  = link_to 'patchinfo', show_patchinfo_path(package: package, project: project)
   for
   = link_to 'maintenance updates', 'http://en.opensuse.org/Portal:Maintenance'

--- a/src/api/app/views/webui/patchinfo/edit.html.haml
+++ b/src/api/app/views/webui/patchinfo/edit.html.haml
@@ -5,7 +5,7 @@
   .card-body
     %h3= @pagetitle
 
-    = form_for(@patchinfo, url: update_patchinfo_path(project: @project, package: @package), method: :put, html: { id: 'patchinfo' }) do |form|
+    = form_for(@patchinfo, url: patchinfo_path(project: @project, package: @package), method: :put, html: { id: 'patchinfo' }) do |form|
       = form.hidden_field(:name)
       .form-group.col-md-8.col-lg-4
         = render partial: 'webui/shared/autocomplete', locals: { html_id: 'patchinfo[packager]', label: 'Packager', value: @patchinfo.packager,

--- a/src/api/app/views/webui/patchinfo/form/_issues.html.haml
+++ b/src/api/app/views/webui/patchinfo/form/_issues.html.haml
@@ -7,7 +7,7 @@
                 target: '_blank', rel: 'noopener') do
         List of supported trackers.
   = text_field_tag(:issue_ids, '', class: 'form-control w-auto d-inline-block')
-  = link_to(patchinfo_new_tracker_url, id: 'add-issues', title: 'Add Issues', remote: true, data: { dataType: 'json', project: project.name }) do
+  = link_to(new_tracker_patchinfo_url, id: 'add-issues', title: 'Add Issues', remote: true, data: { dataType: 'json', project: project.name }) do
     %i.fas.fa-plus-circle.text-primary
     %i.fas.fa-spinner.fa-spin.d-none
     Add issues

--- a/src/api/app/views/webui/project/bottom_actions/_patchinfo.html.haml
+++ b/src/api/app/views/webui/project/bottom_actions/_patchinfo.html.haml
@@ -1,6 +1,6 @@
 - if has_patchinfo
   %li.list-inline-item
-    = link_to(patchinfo_show_path(project, 'patchinfo'), class: 'nav-link') do
+    = link_to(show_patchinfo_path(project, 'patchinfo'), class: 'nav-link') do
       %span.fa-stack.half-font-size.text-secondary
         %i.far.fa-file.fa-stack-2x
         %i.fas.fa-search.fa-stack-1x

--- a/src/api/app/views/webui/project/side_links/_patchinfo_present.html.haml
+++ b/src/api/app/views/webui/project/side_links/_patchinfo_present.html.haml
@@ -1,4 +1,4 @@
 %li
   %i.fa.fa-check-circle.text-success
-  = link_to(patchinfo_show_path(project, 'patchinfo')) do
+  = link_to(show_patchinfo_path(project, 'patchinfo')) do
     Patchinfo present

--- a/src/api/config/routes/webui_routes.rb
+++ b/src/api/config/routes/webui_routes.rb
@@ -115,10 +115,9 @@ OBSApi::Application.routes.draw do
       end
     end
 
-    resource :patchinfo, except: [:show, :update], controller: 'webui/patchinfo' do
+    resource :patchinfo, except: [:show], controller: 'webui/patchinfo' do
       get 'new_tracker' => :new_tracker
       post 'update_issues/:project/:package' => :update_issues, as: :update_issues
-      put ':project/:package' => :update, constraints: cons, as: :update
       get 'show/:project/:package' => :show, as: :show, constraints: cons
     end
 

--- a/src/api/config/routes/webui_routes.rb
+++ b/src/api/config/routes/webui_routes.rb
@@ -115,14 +115,14 @@ OBSApi::Application.routes.draw do
       end
     end
 
+    resource :patchinfo, except: [:show, :update], controller: 'webui/patchinfo' do
+      get 'new_tracker' => :new_tracker
+      post 'update_issues/:project/:package' => :update_issues, as: :update_issues
+    end
+
     controller 'webui/patchinfo' do
-      post 'patchinfo' => :create
-      get 'patchinfo/edit' => :edit, as: 'edit_patchinfo'
       put 'patchinfo/:project/:package' => :update, constraints: cons, as: 'update_patchinfo'
-      delete 'patchinfo' => :destroy
-      post 'patchinfo/update_issues/:project/:package' => :update_issues, as: 'update_issues_patchinfo'
       get 'patchinfo/show/:project/:package' => :show, as: 'patchinfo_show', constraints: cons, defaults: { format: 'html' }
-      get 'patchinfo/new_tracker' => :new_tracker
     end
 
     controller 'webui/repositories' do

--- a/src/api/config/routes/webui_routes.rb
+++ b/src/api/config/routes/webui_routes.rb
@@ -118,10 +118,10 @@ OBSApi::Application.routes.draw do
     resource :patchinfo, except: [:show, :update], controller: 'webui/patchinfo' do
       get 'new_tracker' => :new_tracker
       post 'update_issues/:project/:package' => :update_issues, as: :update_issues
+      put ':project/:package' => :update, constraints: cons, as: :update
     end
 
     controller 'webui/patchinfo' do
-      put 'patchinfo/:project/:package' => :update, constraints: cons, as: 'update_patchinfo'
       get 'patchinfo/show/:project/:package' => :show, as: 'patchinfo_show', constraints: cons, defaults: { format: 'html' }
     end
 

--- a/src/api/config/routes/webui_routes.rb
+++ b/src/api/config/routes/webui_routes.rb
@@ -119,7 +119,7 @@ OBSApi::Application.routes.draw do
       get 'new_tracker' => :new_tracker
       post 'update_issues/:project/:package' => :update_issues, as: :update_issues
       put ':project/:package' => :update, constraints: cons, as: :update
-      get 'show/:project/:package' => :show, as: :show, constraints: cons, defaults: { format: 'html' }
+      get 'show/:project/:package' => :show, as: :show, constraints: cons
     end
 
     controller 'webui/repositories' do

--- a/src/api/config/routes/webui_routes.rb
+++ b/src/api/config/routes/webui_routes.rb
@@ -119,10 +119,7 @@ OBSApi::Application.routes.draw do
       get 'new_tracker' => :new_tracker
       post 'update_issues/:project/:package' => :update_issues, as: :update_issues
       put ':project/:package' => :update, constraints: cons, as: :update
-    end
-
-    controller 'webui/patchinfo' do
-      get 'patchinfo/show/:project/:package' => :show, as: 'patchinfo_show', constraints: cons, defaults: { format: 'html' }
+      get 'show/:project/:package' => :show, as: :show, constraints: cons, defaults: { format: 'html' }
     end
 
     controller 'webui/repositories' do

--- a/src/api/spec/controllers/webui/patchinfo_controller_spec.rb
+++ b/src/api/spec/controllers/webui/patchinfo_controller_spec.rb
@@ -266,7 +266,7 @@ RSpec.describe Webui::PatchinfoController, vcr: true do
       end
 
       it { expect(flash[:notice]).to eq("Patchinfo can't be removed: ") }
-      it { expect(response).to redirect_to(patchinfo_show_path(package: patchinfo_package, project: user.home_project)) }
+      it { expect(response).to redirect_to(show_patchinfo_path(package: patchinfo_package, project: user.home_project)) }
     end
   end
 

--- a/src/api/spec/features/webui/patchinfo_spec.rb
+++ b/src/api/spec/features/webui/patchinfo_spec.rb
@@ -35,7 +35,7 @@ RSpec.feature 'Patchinfo', type: :feature, js: true do
       fill_in 'patchinfo[summary]', with: 'A' * 15
       fill_in 'patchinfo[description]', with: 'A' * 55
       click_button 'Save'
-      expect(page).to have_current_path(patchinfo_show_path(project: project, package: 'patchinfo'))
+      expect(page).to have_current_path(show_patchinfo_path(project: project, package: 'patchinfo'))
       expect(page).to have_text('Successfully edited patchinfo')
     end
   end
@@ -52,7 +52,7 @@ RSpec.feature 'Patchinfo', type: :feature, js: true do
     end
 
     scenario 'delete' do
-      visit patchinfo_show_path(project: project, package: 'patchinfo')
+      visit show_patchinfo_path(project: project, package: 'patchinfo')
       expect(page).to have_link('Delete patchinfo')
       click_link('Delete patchinfo')
       within('#delete-patchinfo-modal') do


### PR DESCRIPTION
Refactor `Patchinfo` related routes to a singular resource, with one exception:  `show` 
The missing route is going to be tackled later by some redirects rules because it follows a special routes naming. It would be done in a follow-up PR