### PR TITLE
Fix staging workflow routes

### DIFF
--- a/src/api/app/controllers/staging/staging_projects_controller.rb
+++ b/src/api/app/controllers/staging/staging_projects_controller.rb
@@ -19,7 +19,7 @@ class Staging::StagingProjectsController < ApplicationController
   end
 
   def show
-    @staging_project = @main_project.staging.staging_projects.find_by!(name: params[:name])
+    @staging_project = @main_project.staging.staging_projects.find_by!(name: params[:staging_project_name])
   end
 
   def create

--- a/src/api/config/routes/api_routes.rb
+++ b/src/api/config/routes/api_routes.rb
@@ -269,14 +269,14 @@ OBSApi::Application.routes.draw do
   end
 
   # StagingWorkflow API
-  resources :staging, only: [], param: 'workflow_project', module: 'staging' do
+  resources :staging, only: [], param: 'workflow_project', module: 'staging', constraints: cons do
     resource :workflow, only: [:create, :destroy, :update], constraints: cons
-    resources :staging_projects, only: [:index, :show, :create], param: :name do
+    resources :staging_projects, only: [:index, :show, :create], param: :name, constraints: cons do
       post 'copy/:staging_project_copy_name' => :copy
       post :accept
 
-      get 'staged_requests' => 'staged_requests#index', constraints: cons
-      resource :staged_requests, only: [:create, :destroy], constraints: cons
+      get 'staged_requests' => 'staged_requests#index'
+      resource :staged_requests, only: [:create, :destroy]
     end
 
     resources :excluded_requests, only: [:index], constraints: cons

--- a/src/api/config/routes/api_routes.rb
+++ b/src/api/config/routes/api_routes.rb
@@ -271,7 +271,8 @@ OBSApi::Application.routes.draw do
   # StagingWorkflow API
   resources :staging, only: [], param: 'workflow_project', module: 'staging', constraints: cons do
     resource :workflow, only: [:create, :destroy, :update], constraints: cons
-    resources :staging_projects, only: [:index, :show, :create], param: :name, constraints: cons do
+    resources :staging_projects, only: [:index, :create], param: :name, constraints: cons do
+      get '' => :show
       post 'copy/:staging_project_copy_name' => :copy
       post :accept
 

--- a/src/api/config/routes/routes_helper.rb
+++ b/src/api/config/routes/routes_helper.rb
@@ -15,7 +15,10 @@ module RoutesContrains
     service: %r{\w[^\/]*},
     title: %r{[^\/]*},
     user: %r{[^\/]*},
-    repository_publish_build_id: %r{[^\/]*}
+    repository_publish_build_id: %r{[^\/]*},
+    workflow_project: %r{[^\/]*},
+    staging_project_name: %r{[^\/]*},
+    staging_project_copy_name: %r{[^\/]*}
   }.freeze
 end
 

--- a/src/api/spec/controllers/staging/staging_projects_controller_spec.rb
+++ b/src/api/spec/controllers/staging/staging_projects_controller_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe Staging::StagingProjectsController do
   describe 'GET #show' do
     context 'not existing project' do
       before do
-        get :show, params: { staging_workflow_project: staging_workflow.project.name, name: 'does-not-exist', format: :xml }
+        get :show, params: { staging_workflow_project: staging_workflow.project.name, staging_project_name: 'does-not-exist', format: :xml }
       end
 
       it { expect(response).to have_http_status(:not_found) }
@@ -80,11 +80,13 @@ RSpec.describe Staging::StagingProjectsController do
       before do
         stub_request(:get, broken_packages_path).and_return(body: broken_packages_backend)
         # staging select
+        login(user)
         bs_request_to_review.change_review_state(:accepted, by_group: staging_workflow.managers_group.title)
         bs_request_missing_review.change_review_state(:accepted, by_group: staging_workflow.managers_group.title)
         untracked_request.change_review_state(:accepted, by_group: staging_workflow.managers_group.title)
         bs_request.change_review_state(:accepted, by_group: staging_workflow.managers_group.title)
-        get :show, params: { staging_workflow_project: staging_workflow.project.name, name: staging_project.name, format: :xml }
+        logout
+        get :show, params: { staging_workflow_project: staging_workflow.project.name, staging_project_name: staging_project.name, format: :xml }
       end
 
       it { expect(response).to have_http_status(:success) }


### PR DESCRIPTION
As was pointed out by @coolo, some routes were returning a 'Not route found' error. After applying constraints to the routes the problem is solved.

Fixes #8473.

<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn
how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md

In order to make it as easy as possible for other developers to review your
pull request we ask you to:

- Explain what this PR is about in the description
- Explain the steps the reviewer has to follow to verify your change
- If the reviewer needs sample data to verify your change, please explain how to
  create that data
- If you include visual changes in this PR, please add screenshots or GIFs
- If you address performance in this PR, add benchmark data or explain how the
  reviewer can benchmark this

This is a good PR description example:

Hey Friends,

this introduces labels for the different build result states on the project
monitor page. This makes it easier to get a visual overview of what is going on
in your project.

To verify this feature

- Enable the interconnect to build.opensuse.org
- Create the project home:Admin
- Add 'openSUSE Tumbleweed' as a repository to the project
- Branch a couple of packages into the project:
  ```
  for i in `osc -A http://0.0.0.0:3000 ls openSUSE.org:home:hennevogel`; do osc -A http://0.0.0.0:3000 copypac openSUSE.org:home:hennevogel $i home:Admin; done
  ```
- Visit the monitor page and see the new labels for the different states.

Here is a screenshot of how it looks:

** Before **
![Screenshot of the project monitor](https://example.com/screenshot1.png)

** After **
![Screenshot of the project monitor](https://example.com/screenshot2.png)

-->
