### PR TITLE
Use symbol instead of string to access broken_packages hash in staging project

### DIFF
--- a/src/api/app/models/concerns/staging_project.rb
+++ b/src/api/app/models/concerns/staging_project.rb
@@ -194,7 +194,7 @@ module StagingProject
       add_building_repositories(result) if building
     end
 
-    @broken_packages.reject! { |package| package['state'] == 'unresolvable' } if @building_repositories.present?
+    @broken_packages.reject! { |package| package[:state] == 'unresolvable' } if @building_repositories.present?
   end
 
   def add_broken_packages(result, building)


### PR DESCRIPTION

While migrating the old staging workflow to the new one, the
broken_packages hash moved from strings to symbols for the keys.
One of the checks still uses strings to access the hash, which
led to wrong results.

Fixes #7351

<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn
how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md

In order to make it as easy as possible for other developers to review your
pull request we ask you to:

- Explain what this PR is about in the description
- Explain the steps the reviewer has to follow to verify your change
- If the reviewer needs sample data to verify your change, please explain how to
  create that data
- If you include visual changes in this PR, please add screenshots or GIFs
- If you address performance in this PR, add benchmark data or explain how the
  reviewer can benchmark this

This is a good PR description example:

Hey Friends,

this introduces labels for the different build result states on the project
monitor page. This makes it easier to get a visual overview of what is going on
in your project.

To verify this feature

- Enable the interconnect to build.opensuse.org
- Create the project home:Admin
- Add 'openSUSE Tumbleweed' as a repository to the project
- Branch a couple of packages into the project:
  ```
  for i in `osc -A http://0.0.0.0:3000 ls openSUSE.org:home:hennevogel`; do osc -A http://0.0.0.0:3000 copypac openSUSE.org:home:hennevogel $i home:Admin; done
  ```
- Visit the monitor page and see the new labels for the different states.

Here is a screenshot of how it looks:

** Before **
![Screenshot of the project monitor](https://example.com/screenshot1.png)

** After **
![Screenshot of the project monitor](https://example.com/screenshot2.png)

-->
