### PR TITLE
Improve error message during staging request

### DIFF
--- a/src/api/app/models/staging/request_excluder.rb
+++ b/src/api/app/models/staging/request_excluder.rb
@@ -49,12 +49,14 @@ class Staging::RequestExcluder
   end
 
   def valid_request?(bs_request, request_number)
-    return true if bs_request && bs_request.staging_project.nil?
+    return true if bs_request.present? && bs_request.staging_project.nil?
 
-    errors << if bs_request
+    errors << if bs_request.present?
                 "Request #{request_number} could not be excluded because is staged in: #{bs_request.staging_project}"
+              elsif BsRequest.exists?(number: request_number)
+                "Request #{request_number} not found in Staging for project #{staging_workflow.project}"
               else
-                "Request #{request_number} doesn't exist or it doesn't belong to this project"
+                "Request #{request_number} doesn't exist"
               end
     return false
   end

--- a/src/api/app/models/staging/stage_requests.rb
+++ b/src/api/app/models/staging/stage_requests.rb
@@ -59,7 +59,11 @@ class Staging::StageRequests
 
   def add_request_not_found_errors
     not_found_requests.each do |request_number|
-      errors << "Request '#{request_number}' does not exist or target_project is not '#{request_target_project}'"
+      errors << if BsRequest.exists?(number: request_number)
+                  "Request #{request_number} not found in Staging for project #{request_target_project}"
+                else
+                  "Request #{request_number} doesn't exist"
+                end
     end
   end
 


### PR DESCRIPTION
Make it clear that a request was not found in a Staging for a project.

Fixes #7355.

Co-authored-by: David Kang <dkang@suse.com>

<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn
how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md

In order to make it as easy as possible for other developers to review your
pull request we ask you to:

- Explain what this PR is about in the description
- Explain the steps the reviewer has to follow to verify your change
- If the reviewer needs sample data to verify your change, please explain how to
  create that data
- If you include visual changes in this PR, please add screenshots or GIFs
- If you address performance in this PR, add benchmark data or explain how the
  reviewer can benchmark this

This is a good PR description example:

Hey Friends,

this introduces labels for the different build result states on the project
monitor page. This makes it easier to get a visual overview of what is going on
in your project.

To verify this feature

- Enable the interconnect to build.opensuse.org
- Create the project home:Admin
- Add 'openSUSE Tumbleweed' as a repository to the project
- Branch a couple of packages into the project:
  ```
  for i in `osc -A http://0.0.0.0:3000 ls openSUSE.org:home:hennevogel`; do osc -A http://0.0.0.0:3000 copypac openSUSE.org:home:hennevogel $i home:Admin; done
  ```
- Visit the monitor page and see the new labels for the different states.

Here is a screenshot of how it looks:

** Before **
![Screenshot of the project monitor](https://example.com/screenshot1.png)

** After **
![Screenshot of the project monitor](https://example.com/screenshot2.png)

-->
