### PR TITLE
Display obs quality category setting next to the project name

### DIFF
--- a/src/api/app/assets/stylesheets/webui/datatables.scss
+++ b/src/api/app/assets/stylesheets/webui/datatables.scss
@@ -33,3 +33,9 @@ table.dataTable.table-sm {
 .table-hover tbody tr:hover {
   background-color: $gray-300;
 }
+
+table.dataTable {
+  .quality-category.badge {
+    margin-left: 0.5em;
+  }
+}

--- a/src/api/app/controllers/webui/project_controller.rb
+++ b/src/api/app/controllers/webui/project_controller.rb
@@ -35,8 +35,7 @@ class Webui::ProjectController < Webui::WebuiController
     respond_to do |format|
       format.html do
         render :index,
-               locals: { important_projects:
-                         active_very_important_projects.pluck(:name, :title) }
+               locals: { important_projects: Project::Categorized.vips_with_categories }
       end
       format.json { render json: ProjectDatatable.new(params, view_context: view_context, show_all: show_all?) }
     end
@@ -408,14 +407,6 @@ class Webui::ProjectController < Webui::WebuiController
 
   def show_all?
     (params[:all].to_s == 'true')
-  end
-
-  def active_very_important_projects
-    Project.find_by_attribute_type(very_important_project_attribute)
-  end
-
-  def very_important_project_attribute
-    AttribType.find_by_namespace_and_name!('OBS', 'VeryImportantProject')
   end
 
   def project_for_datatable

--- a/src/api/app/datatables/project_datatable.rb
+++ b/src/api/app/datatables/project_datatable.rb
@@ -1,6 +1,8 @@
 class ProjectDatatable < Datatable
   def_delegator :@view, :link_to
   def_delegator :@view, :project_show_path
+  def_delegator :@view, :category_badge
+  def_delegator :@view, :safe_join
 
   def view_columns
     @view_columns ||= {
@@ -30,7 +32,8 @@ class ProjectDatatable < Datatable
   def data
     records.map do |record|
       {
-        name: link_to(record.name, project_show_path(record)),
+        name: link_to(record.name, project_show_path(record)) +
+          safe_join(record.quality.map { |q| category_badge(q) }),
         title: record.title
       }
     end

--- a/src/api/app/datatables/project_datatable.rb
+++ b/src/api/app/datatables/project_datatable.rb
@@ -33,7 +33,7 @@ class ProjectDatatable < Datatable
     records.map do |record|
       {
         name: link_to(record.name, project_show_path(record)) +
-          safe_join(record.quality.map { |q| category_badge(q) }),
+          safe_join(record.categories.map { |q| category_badge(q) }),
         title: record.title
       }
     end

--- a/src/api/app/helpers/webui/projects/attributes_helper.rb
+++ b/src/api/app/helpers/webui/projects/attributes_helper.rb
@@ -1,7 +1,6 @@
 module Webui::Projects::AttributesHelper
   def category_badge(category)
     return unless category
-    
     badge_type = case category
                  when 'Stable'
                    'badge-success'
@@ -12,7 +11,6 @@ module Webui::Projects::AttributesHelper
                  else
                    'badge-dark'
                  end
-    
     content_tag(:span, category, class: ['quality-category', 'badge', badge_type].join(' '))
   end
 end

--- a/src/api/app/helpers/webui/projects/attributes_helper.rb
+++ b/src/api/app/helpers/webui/projects/attributes_helper.rb
@@ -1,0 +1,18 @@
+module Webui::Projects::AttributesHelper
+  def category_badge(category)
+    return unless category
+    
+    badge_type = case category
+                 when 'Stable'
+                   'badge-success'
+                 when 'Testing'
+                   'badge-warning'
+                 when 'Development'
+                   'badge-info'
+                 else
+                   'badge-dark'
+                 end
+    
+    content_tag(:span, category, class: ['quality-category', 'badge', badge_type].join(' '))
+  end
+end

--- a/src/api/app/models/project.rb
+++ b/src/api/app/models/project.rb
@@ -106,6 +106,11 @@ class Project < ApplicationRecord
 
   scope :for_user, ->(user_id) { joins(:relationships).where(relationships: { user_id: user_id, role_id: Role.hashed['maintainer'] }) }
   scope :for_group, ->(group_id) { joins(:relationships).where(relationships: { group_id: group_id, role_id: Role.hashed['maintainer'] }) }
+  scope :vips_with_attributes, lambda {
+    joins(attribs: { attrib_type: :attrib_namespace })
+      .where(attrib_namespaces: { name: 'OBS' },
+             attrib_types: { name: 'VeryImportantProject' })
+  }
 
   validates :name, presence: true, length: { maximum: 200 }, uniqueness: true
   validates :title, length: { maximum: 250 }
@@ -1539,7 +1544,7 @@ class Project < ApplicationRecord
     name.include?(':branches:') # Rather ugly decision finding...
   end
 
-  def quality
+  def categories
     AttribValue
       .joins(attrib: { attrib_type: :attrib_namespace })
       .where(attribs: { project: self },

--- a/src/api/app/models/project.rb
+++ b/src/api/app/models/project.rb
@@ -1539,6 +1539,15 @@ class Project < ApplicationRecord
     name.include?(':branches:') # Rather ugly decision finding...
   end
 
+  def quality
+     AttribValue
+       .joins(attrib: { attrib_type: :attrib_namespace })
+       .where(attribs: { project: self },
+              attrib_types: { name: 'QualityCategory' },
+              attrib_namespaces: { name: 'OBS' })
+       .map(&:value)
+  end
+
   private
 
   def discard_cache

--- a/src/api/app/models/project.rb
+++ b/src/api/app/models/project.rb
@@ -1540,12 +1540,12 @@ class Project < ApplicationRecord
   end
 
   def quality
-     AttribValue
-       .joins(attrib: { attrib_type: :attrib_namespace })
-       .where(attribs: { project: self },
-              attrib_types: { name: 'QualityCategory' },
-              attrib_namespaces: { name: 'OBS' })
-       .map(&:value)
+    AttribValue
+      .joins(attrib: { attrib_type: :attrib_namespace })
+      .where(attribs: { project: self },
+             attrib_types: { name: 'QualityCategory' },
+             attrib_namespaces: { name: 'OBS' })
+      .map(&:value)
   end
 
   private

--- a/src/api/app/models/project/categorized.rb
+++ b/src/api/app/models/project/categorized.rb
@@ -1,0 +1,7 @@
+class Project::Categorized
+  def self.vips_with_categories
+    Project.vips_with_attributes.map do |p|
+      [p.name, p.title, p.categories]
+    end
+  end
+end

--- a/src/api/app/views/webui/project/index.html.haml
+++ b/src/api/app/views/webui/project/index.html.haml
@@ -11,12 +11,14 @@
               %th Name
               %th Title
           %tbody
-            - important_projects.each do |project|
+            - important_projects.each do |name, title, categories|
               %tr
                 %td
-                  = link_to(project.first, action: :show, project: project.first)
+                  = link_to(name, action: :show, project: name)
+                  - categories.each do |category|
+                    = category_badge(category)
                 %td
-                  #{project.second}
+                  #{title}
   .card-body
     %h3= @pagetitle
     %ul.list-inline

--- a/src/api/app/views/webui/project/show.html.haml
+++ b/src/api/app/views/webui/project/show.html.haml
@@ -11,9 +11,9 @@
       .col-md-8
         %h3#project-title
           = @project.title.presence || @project
-        - if @project.quality.any?
-          - @project.quality.each do |attribute|
-            = category_badge(attribute)
+        - if @project.categories.any?
+          - @project.categories.each do |category|
+            = category_badge(category)
         - if @project.url.present?
           = link_to(@project.url, @project.url, class: 'mb-3 d-block')
         #description-text

--- a/src/api/app/views/webui/project/show.html.haml
+++ b/src/api/app/views/webui/project/show.html.haml
@@ -11,6 +11,9 @@
       .col-md-8
         %h3#project-title
           = @project.title.presence || @project
+        - if @project.quality.any?
+          - @project.quality.each do |attribute|
+            = category_badge(attribute)
         - if @project.url.present?
           = link_to(@project.url, @project.url, class: 'mb-3 d-block')
         #description-text

--- a/src/api/db/attribute_descriptions.rb
+++ b/src/api/db/attribute_descriptions.rb
@@ -22,7 +22,7 @@ def update_all_attrib_type_descriptions
     'BranchSkipRepositories' => 'Skip the listed repositories when branching from this projet.',
     'AutoCleanup' => 'The object will recieve a delete request at specified time (YYYY-MM-DD HH:MM:SS) in the value',
     'Issues' => 'Use this attribute to reference issues this object has',
-    'QualityCategory' => 'Use this attrbitue to classify the usability of a project. This gets used by the user package search for instance.',
+    'QualityCategory' => 'Use this attribute to classify the usability of a project. This gets used by the user package search for instance.',
     'IncidentPriority' => 'A numeric value which defines the importance of this incident project.',
     'EmbargoDate' => 'A timestamp until outgoing requests can not get accepted.',
     'PlannedReleaseDate' => 'A timestamp for the planned release date of an incident.',


### PR DESCRIPTION
This PR adds the Quality category attribute next to the project name. This makes easier to spot the category of such projects.

Before you had to go and click each one of the projects, go to its Attributes tab and then look at the attributes you needed.

Here is a screenshot of how it looks:

**Before**
![image](https://user-images.githubusercontent.com/2650/65956633-1d7e3000-e44b-11e9-9ee1-7496348f4219.png)


**After**
![image](https://user-images.githubusercontent.com/2650/65964360-1d872b80-e45d-11e9-80ae-28f84189a6aa.png)