### PR TITLE
WIP: Improve rendering/loading time of staging project show

### DIFF
--- a/src/api/app/views/webui/staging/projects/_history_elements.html.haml
+++ b/src/api/app/views/webui/staging/projects/_history_elements.html.haml
@@ -4,6 +4,12 @@
       = element.event_type.humanize
       - case element.event_type
       - when 'unstaged_request', 'staged_request'
-        = render(partial: 'unstaged_staged_request_history', locals: { history: element })
+        = link_to("##{element.bs_request.number}", request_show_path(element.bs_request.number))
+        for package
+        %b= element.package_name
+        submitted by
+        %b= element.user_name
       - when 'staging_project_created'
-        = render(partial: 'staging_project_created_history', locals: { history: element })
+        %b #{time_ago_in_words(Time.at(element.datetime.to_i))} ago
+        by
+        %b= element.user_name

--- a/src/api/app/views/webui/staging/projects/_staging_project_created_history.html.haml
+++ b/src/api/app/views/webui/staging/projects/_staging_project_created_history.html.haml
@@ -1,3 +1,0 @@
-%b #{time_ago_in_words(Time.at(history.datetime.to_i))} ago
-by
-%b= history.user_name

--- a/src/api/app/views/webui/staging/projects/_unstaged_staged_request_history.html.haml
+++ b/src/api/app/views/webui/staging/projects/_unstaged_staged_request_history.html.haml
@@ -1,5 +1,0 @@
-= link_to("##{history.bs_request.number}", request_show_path(history.bs_request.number))
-for package
-%b= history.package_name
-submitted by
-%b= history.user_name


### PR DESCRIPTION
Related to #7350

<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn
how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md

In order to make it as easy as possible for other developers to review your
pull request we ask you to:

- Explain what this PR is about in the description
- Explain the steps the reviewer has to follow to verify your change
- If the reviewer needs sample data to verify your change, please explain how to
  create that data
- If you include visual changes in this PR, please add screenshots or GIFs
- If you address performance in this PR, add benchmark data or explain how the
  reviewer can benchmark this

This is a good PR description example:

Hey Friends,

this introduces labels for the different build result states on the project
monitor page. This makes it easier to get a visual overview of what is going on
in your project.

To verify this feature

- Enable the interconnect to build.opensuse.org
- Create the project home:Admin
- Add 'openSUSE Tumbleweed' as a repository to the project
- Branch a couple of packages into the project:
  ```
  for i in `osc -A http://0.0.0.0:3000 ls openSUSE.org:home:hennevogel`; do osc -A http://0.0.0.0:3000 copypac openSUSE.org:home:hennevogel $i home:Admin; done
  ```
- Visit the monitor page and see the new labels for the different states.

Here is a screenshot of how it looks:

** Before **
![Screenshot of the project monitor](https://example.com/screenshot1.png)

** After **
![Screenshot of the project monitor](https://example.com/screenshot2.png)

-->
