### PR TITLE
Make prjconf routes resourceful

### DIFF
--- a/src/api/app/views/webui/project/prjconf.html.haml
+++ b/src/api/app/views/webui/project/prjconf.html.haml
@@ -10,7 +10,7 @@
     %h3= @pagetitle
     - if User.possibly_nobody.can_modify?(@project)
       = render partial: 'webui/shared/editor', locals: { text: @content, mode: 'prjconf',
-        save: { url: save_project_config_path, method: :post,
-        data: { project: @project.name, submit: 'config' } } }
+        save: { url: project_config_path, method: :put,
+        data: { project_name: @project.name, submit: 'config' } } }
     - else
       = render partial: 'webui/shared/editor', locals: { text: @content, mode: 'prjconf', style: { read_only: true } }

--- a/src/api/app/views/webui/projects/project_configuration/show.html.haml
+++ b/src/api/app/views/webui/projects/project_configuration/show.html.haml
@@ -10,7 +10,7 @@
     %h3= @pagetitle
     - if User.possibly_nobody.can_modify?(@project)
       = render partial: 'webui/shared/editor', locals: { text: @content, mode: 'prjconf',
-        save: { url: save_project_config_path, method: :post,
-        data: { project: @project.name, submit: 'config' } } }
+        save: { url: project_config_path, method: :put,
+        data: { project_name: @project.name, submit: 'config' } } }
     - else
       = render partial: 'webui/shared/editor', locals: { text: @content, mode: 'prjconf', style: { read_only: true } }

--- a/src/api/config/routes/webui_routes.rb
+++ b/src/api/config/routes/webui_routes.rb
@@ -244,6 +244,9 @@ OBSApi::Application.routes.draw do
     controller 'webui/projects/maintenance_incidents' do
       get 'project/maintenance_incidents/:project', to: redirect('/projects/%{project}/maintenance_incidents')
     end
+    controller 'webui/projects/project_configuration' do
+      get 'project/prjconf/:project', to: redirect('/projects/%{project}/prjconf')
+    end
     # \For backward compatibility
 
     resources :projects, only: [], param: :name do

--- a/src/api/config/routes/webui_routes.rb
+++ b/src/api/config/routes/webui_routes.rb
@@ -176,11 +176,6 @@ OBSApi::Application.routes.draw do
       end
     end
 
-    controller 'webui/projects/project_configuration' do
-      get 'project/prjconf/:project' => :show, constraints: cons, as: :project_config
-      post 'project/save_prjconf/:project' => :update, constraints: cons, as: :save_project_config
-    end
-
     controller 'webui/project' do
       get 'project/' => :index, as: 'projects'
       get 'project/list_public' => :index, as: 'project_list_public'
@@ -258,6 +253,7 @@ OBSApi::Application.routes.draw do
       resource :ssl_certificate, controller: 'webui/projects/ssl_certificate', only: [:show], constraints: cons
       resource :pulse, controller: 'webui/projects/pulse', only: [:show], constraints: cons
       resource :meta, controller: 'webui/projects/meta', only: [:show, :update], constraints: cons
+      resource :prjconf, controller: 'webui/projects/project_configuration', only: [:show, :update], as: :config, constraints: cons
       resource :rebuild_time, controller: 'webui/projects/rebuild_times', only: [:show], constraints: cons do
         get 'rebuild_time_png'
       end

--- a/src/api/spec/controllers/webui/projects/project_configuration_controller_spec.rb
+++ b/src/api/spec/controllers/webui/projects/project_configuration_controller_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe Webui::Projects::ProjectConfigurationController, vcr: true do
         }
       end
 
-      it { expect { get :show, params: { project: apache_project } }.not_to raise_error }
+      it { expect { get :show, params: { project_name: apache_project.name } }.not_to raise_error }
     end
 
     context 'Can not load project config' do
@@ -27,7 +27,7 @@ RSpec.describe Webui::Projects::ProjectConfigurationController, vcr: true do
         }
       end
 
-      it { expect { get :show, params: { project: apache_project } }.to raise_error(ActiveRecord::RecordNotFound) }
+      it { expect { get :show, params: { project_name: apache_project.name } }.to raise_error(ActiveRecord::RecordNotFound) }
     end
   end
 
@@ -41,7 +41,7 @@ RSpec.describe Webui::Projects::ProjectConfigurationController, vcr: true do
         allow(::ProjectConfigurationService::ProjectConfigurationUpdater).to receive(:new) {
           -> { OpenStruct.new(saved?: true) }
         }
-        post :update, params: { project: user.home_project.name, config: 'save config' }
+        post :update, params: { project_name: user.home_project.name, config: 'save config' }
       end
 
       it { expect(flash[:success]).to eq('Config successfully saved!') }
@@ -53,7 +53,7 @@ RSpec.describe Webui::Projects::ProjectConfigurationController, vcr: true do
         allow(::ProjectConfigurationService::ProjectConfigurationUpdater).to receive(:new) {
           -> { OpenStruct.new(saved?: false, errors: 'yay') }
         }
-        post :update, params: { project: user.home_project.name, config: '' }
+        post :update, params: { project_name: user.home_project.name, config: '' }
       end
 
       it { expect(flash[:error]).not_to be_nil }
@@ -62,7 +62,7 @@ RSpec.describe Webui::Projects::ProjectConfigurationController, vcr: true do
 
     context 'cannot save with an unauthorized user' do
       before do
-        post :update, params: { project: another_project.name, config: 'save config' }
+        post :update, params: { project_name: another_project.name, config: 'save config' }
       end
 
       it { expect(flash[:error]).to eq('Sorry, you are not authorized to update this Project.') }
@@ -71,7 +71,7 @@ RSpec.describe Webui::Projects::ProjectConfigurationController, vcr: true do
     end
 
     context 'with a non existing project' do
-      let(:post_update) { post :update, params: { project: 'non:existing:project', config: 'save config' } }
+      let(:post_update) { post :update, params: { project_name: 'non:existing:project', config: 'save config' } }
 
       it 'raise a RecordNotFound Exception' do
         expect { post_update }.to raise_error ActiveRecord::RecordNotFound


### PR DESCRIPTION
Move prjconf related routes inside of `resources :project` and create a redirect to the old routes 