### PR TITLE
Fix how non deleted packages are counted

### DIFF
--- a/src/api/app/models/staging/stage_requests.rb
+++ b/src/api/app/models/staging/stage_requests.rb
@@ -22,8 +22,10 @@ class Staging::StageRequests
     staging_project.staged_requests.delete(requests)
     not_unassigned_requests = request_numbers - requests.pluck(:number).map(&:to_s)
 
-    result = staging_project.packages.where(name: package_names).destroy_all
-    not_deleted_packages = package_names - result.pluck(:name)
+    staging_project_packages = staging_project.packages.where(name: package_names)
+    staging_project_packages_names = staging_project_packages.pluck(:name)
+    deleted_packages = staging_project_packages.destroy_all
+    not_deleted_packages = staging_project_packages_names - deleted_packages.pluck(:name)
 
     requests.each do |request|
       ProjectLogEntry.create!(


### PR DESCRIPTION
Before unasigning a request took into account packages that were already deleted.

Now only currently existing packages are deleted. This prevents to throw an error on trying to delete an already deleted package.

Fixes #7347 and also fixes #7377.

Co-authored-by: David Kang <dkang@suse.com>

<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn
how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md

In order to make it as easy as possible for other developers to review your
pull request we ask you to:

- Explain what this PR is about in the description
- Explain the steps the reviewer has to follow to verify your change
- If the reviewer needs sample data to verify your change, please explain how to
  create that data
- If you include visual changes in this PR, please add screenshots or GIFs
- If you address performance in this PR, add benchmark data or explain how the
  reviewer can benchmark this

This is a good PR description example:

Hey Friends,

this introduces labels for the different build result states on the project
monitor page. This makes it easier to get a visual overview of what is going on
in your project.

To verify this feature

- Enable the interconnect to build.opensuse.org
- Create the project home:Admin
- Add 'openSUSE Tumbleweed' as a repository to the project
- Branch a couple of packages into the project:
  ```
  for i in `osc -A http://0.0.0.0:3000 ls openSUSE.org:home:hennevogel`; do osc -A http://0.0.0.0:3000 copypac openSUSE.org:home:hennevogel $i home:Admin; done
  ```
- Visit the monitor page and see the new labels for the different states.

Here is a screenshot of how it looks:

** Before **
![Screenshot of the project monitor](https://example.com/screenshot1.png)

** After **
![Screenshot of the project monitor](https://example.com/screenshot2.png)

-->
