### PR TITLE
Call explicitly name on a class

### DIFF
--- a/src/api/app/views/webui/comment/_comment_field.html.haml
+++ b/src/api/app/views/webui/comment/_comment_field.html.haml
@@ -1,5 +1,5 @@
 = form_for(comment, action: 'create', method: :post, remote: true, html: { class: 'new-comment-form' }) do |f|
-  = hidden_field_tag :commentable_type, commentable.class
+  = hidden_field_tag :commentable_type, commentable.class.name
   = hidden_field_tag :commentable_id, commentable.id
   = f.hidden_field :parent_id, value: comment.parent_id
   ~ f.text_area :body, rows: '4', placeholder: 'Add a new comment (markdown markup supported)', required: true,


### PR DESCRIPTION
This way we make sure that a string is returned, instead of a class.

Errbit is receiving exceptions where the parameters receive something like this:

```
"commentable_type" => "+HCX3IyBjrtZ6Z3UQhVYa8OT3v7eye52V1jbcILfgWtlzj7...",
```

This should fix #8232.

Co-authored-by: David Kang <dkang@suse.com>

<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn
how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md

In order to make it as easy as possible for other developers to review your
pull request we ask you to:

- Explain what this PR is about in the description
- Explain the steps the reviewer has to follow to verify your change
- If the reviewer needs sample data to verify your change, please explain how to
  create that data
- If you include visual changes in this PR, please add screenshots or GIFs
- If you address performance in this PR, add benchmark data or explain how the
  reviewer can benchmark this

This is a good PR description example:

Hey Friends,

this introduces labels for the different build result states on the project
monitor page. This makes it easier to get a visual overview of what is going on
in your project.

To verify this feature

- Enable the interconnect to build.opensuse.org
- Create the project home:Admin
- Add 'openSUSE Tumbleweed' as a repository to the project
- Branch a couple of packages into the project:
  ```
  for i in `osc -A http://0.0.0.0:3000 ls openSUSE.org:home:hennevogel`; do osc -A http://0.0.0.0:3000 copypac openSUSE.org:home:hennevogel $i home:Admin; done
  ```
- Visit the monitor page and see the new labels for the different states.

Here is a screenshot of how it looks:

** Before **
![Screenshot of the project monitor](https://example.com/screenshot1.png)

** After **
![Screenshot of the project monitor](https://example.com/screenshot2.png)

-->
