### PR TITLE
Append ' ago' to the time duration in the package change column

### DIFF
--- a/src/api/app/datatables/package_datatable.rb
+++ b/src/api/app/datatables/package_datatable.rb
@@ -30,7 +30,8 @@ class PackageDatatable < Datatable
     records.map do |record|
       {
         name: name_with_link(record),
-        changed: time_ago_in_words(Time.at(record.updated_at.to_i))
+        changed: format('%{duration} ago',
+                        duration: time_ago_in_words(Time.at(record.updated_at.to_i)))
       }
     end
   end


### PR DESCRIPTION
We use the same convention in some other places.

**Before**
![image](https://user-images.githubusercontent.com/2650/66047073-686d7580-e527-11e9-9e09-00f7077e00cb.png)

**After**
![image](https://user-images.githubusercontent.com/2650/66047129-8509ad80-e527-11e9-8a9a-b02c9d7f9fa9.png)
