### PR TITLE
Remove Y axis label width in monitor page plot graphics

### DIFF
--- a/src/api/app/assets/javascripts/webui/monitor.js
+++ b/src/api/app/assets/javascripts/webui/monitor.js
@@ -57,7 +57,7 @@ function eventsPlot(data) {
       },
       legend: { noColumns: 3, position: "ne", container: "#legend-events" },
       xaxis: { mode: 'time' },
-      yaxis: { min: 0, max: data.events_max, position: "left", labelWidth: 25 }
+      yaxis: { min: 0, max: data.events_max, position: "left" }
     });
 }
 
@@ -73,7 +73,7 @@ function buildingPlot(data) {
         lines: { show: true, steps: false, fill: true }
       },
       xaxis: { mode: 'time' },
-      yaxis: { min: 0, position: "left", labelWidth: 25 },
+      yaxis: { min: 0, position: "left" },
       legend: { noColumns: 3, position: "ne", container: "#legend-building" }
     });
 }
@@ -87,7 +87,7 @@ function jobPlot(data) {
         lines: { show: true, steps: false, fill: true },
       },
       xaxis: { mode: 'time' },
-      yaxis: { max: data.jobs_max, position: "left", labelWidth: 25 },
+      yaxis: { max: data.jobs_max, position: "left" },
       legend: { noColumns: 3, position: "ne", container: "#legend-jobs" }
     });
 }


### PR DESCRIPTION
Not setting a width in Y axis labels results in not breaking numbers with more than 4 digits in two lines.

Fixes #8222.

Screenshot of one graphic with test data:

![Screenshot from 2019-10-07 12-40-38](https://user-images.githubusercontent.com/24919/66305533-cd4a1680-e8ff-11e9-8e39-8909fcd00e16.png)


<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn
how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md

In order to make it as easy as possible for other developers to review your
pull request we ask you to:

- Explain what this PR is about in the description
- Explain the steps the reviewer has to follow to verify your change
- If the reviewer needs sample data to verify your change, please explain how to
  create that data
- If you include visual changes in this PR, please add screenshots or GIFs
- If you address performance in this PR, add benchmark data or explain how the
  reviewer can benchmark this

This is a good PR description example:

Hey Friends,

this introduces labels for the different build result states on the project
monitor page. This makes it easier to get a visual overview of what is going on
in your project.

To verify this feature

- Enable the interconnect to build.opensuse.org
- Create the project home:Admin
- Add 'openSUSE Tumbleweed' as a repository to the project
- Branch a couple of packages into the project:
  ```
  for i in `osc -A http://0.0.0.0:3000 ls openSUSE.org:home:hennevogel`; do osc -A http://0.0.0.0:3000 copypac openSUSE.org:home:hennevogel $i home:Admin; done
  ```
- Visit the monitor page and see the new labels for the different states.

Here is a screenshot of how it looks:

** Before **
![Screenshot of the project monitor](https://example.com/screenshot1.png)

** After **
![Screenshot of the project monitor](https://example.com/screenshot2.png)

-->
