### PR TITLE
Avoid duplication in broken packages list

### DIFF
--- a/src/api/app/models/concerns/staging_project.rb
+++ b/src/api/app/models/concerns/staging_project.rb
@@ -197,7 +197,7 @@ module StagingProject
     result.elements('status') do |status|
       code = status.get('code')
 
-      if code.in?(['broken', 'failed']) || (code == 'unresolvable' && !building)
+      if @broken_packages.none? { |p| p[:package] == status['package'] } && broken_code?(code, building)
         @broken_packages << { package: status['package'],
                               project: name,
                               state: code,
@@ -206,6 +206,10 @@ module StagingProject
                               arch: result['arch'] }
       end
     end
+  end
+
+  def broken_code?(code, building)
+    code.in?(['broken', 'failed']) || (code == 'unresolvable' && !building)
   end
 
   def add_building_repositories(result)

--- a/src/api/spec/controllers/staging/staging_projects_controller_spec.rb
+++ b/src/api/spec/controllers/staging/staging_projects_controller_spec.rb
@@ -106,7 +106,7 @@ RSpec.describe Staging::StagingProjectsController do
             assert_select 'entry', 1
           end
           assert_select 'broken_packages', 1 do
-            assert_select 'entry', 2
+            assert_select 'entry', 1
           end
           assert_select 'history', 1
         end


### PR DESCRIPTION
The same package appeared more than once because it failed with
different architectures. However, the list is not making distinction by
architecture and the link always points to the same page. So, we will
show each package only once.

Fixes #7362
