### PR TITLE
Let editor insert spaces instead of tabs

### DIFF
--- a/src/api/app/assets/javascripts/webui/cm2/use-codemirror.js
+++ b/src/api/app/assets/javascripts/webui/cm2/use-codemirror.js
@@ -23,14 +23,27 @@ function use_codemirror(id, read_only, mode, big_editor) {
     mode: mode,
     theme: "bootstrap"
   };
+
   if (read_only) {
     codeMirrorOptions['readOnly'] = true;
   }
   else {
     codeMirrorOptions['addToolBars'] = 0;
-    if (mode.length)
+    if (mode.length) {
       codeMirrorOptions['mode'] = mode;
-    codeMirrorOptions['extraKeys'] = {"Tab": "defaultTab", "Shift-Tab": "indentLess"};
+    }
+    codeMirrorOptions['extraKeys'] = {
+        // Insert spaces instead of a tab
+        "Tab": function(cm) {
+            var spaces = '';
+            var indentUnit = cm.getOption('indentUnit');
+            for (var i = 0; i < indentUnit; i++) {
+                spaces += ' ';
+            }
+            cm.replaceSelection(spaces);
+        },
+        "Shift-Tab": "indentLess"
+    };
   }
 
   var textarea = $('#editor_' + id);


### PR DESCRIPTION
This PR changes the default CodeMirror editor behavior.

Before: when pressing Tab key, insert a tab indention.

After: when pressing Tab key, insert two spaces indention.

It should fix #8504 