### PR TITLE
Revert "Update sassc to version 2.2.1"

### DIFF
--- a/src/api/Gemfile
+++ b/src/api/Gemfile
@@ -191,7 +191,7 @@ group :assets do
   # for minifying JavaScript
   gem 'uglifier', '>= 1.2.2'
   # sassc 2.2.0 is throwing exception
-  gem 'sassc', '~> 2.2.1'
+  gem 'sassc', '~> 2.1.0'
   # to use sass in the asset pipeline
   gem 'sassc-rails'
   # assets for jQuery DataTables

--- a/src/api/Gemfile.lock
+++ b/src/api/Gemfile.lock
@@ -383,7 +383,7 @@ GEM
       crass (~> 1.0.2)
       nokogiri (>= 1.8.0)
       nokogumbo (~> 2.0)
-    sassc (2.2.1)
+    sassc (2.1.0)
       ffi (~> 1.9)
     sassc-rails (2.1.2)
       railties (>= 4.0.0)
@@ -542,7 +542,7 @@ DEPENDENCIES
   rubocop-rspec
   ruby-ldap
   sanitize
-  sassc (~> 2.2.1)
+  sassc (~> 2.1.0)
   sassc-rails
   selenium-webdriver
   shoulda-matchers (~> 4.0)


### PR DESCRIPTION
This update is causing problems when setting docker from scratch, so we downgrade it to 2.1.0 again. We are waiting for this issue to be fixed: https://github.com/sass/sassc-ruby/issues/146

