### PR TITLE
Make username field to get focus automatically

### DIFF
--- a/src/api/app/assets/javascripts/webui/application.js
+++ b/src/api/app/assets/javascripts/webui/application.js
@@ -24,6 +24,7 @@
 //= require webui/plotbusyworkers.js
 //= require webui/datatables.js
 //= require webui/flash.js
+//= require webui/login-form.js
 //= require webui/tabs.js
 //= require webui/requests_table.js
 //= require webui/attributes.js

--- a/src/api/app/assets/javascripts/webui/login-form.js
+++ b/src/api/app/assets/javascripts/webui/login-form.js
@@ -1,0 +1,5 @@
+$(document).ready(function() {
+  $('#login-form-dropdown').on('shown.bs.dropdown', function() {
+    $("#username").focus();
+  });
+});

--- a/src/api/app/views/layouts/webui/_login_form.html.haml
+++ b/src/api/app/views/layouts/webui/_login_form.html.haml
@@ -1,7 +1,7 @@
 - if can_signup
   %li.nav-item
     = link_to('Sign Up', signup_url, class: 'nav-link')
-%li.nav-item.dropdown
+%li.nav-item.dropdown#login-form-dropdown
   = link_to('#', id: 'login-trigger', class: 'nav-link dropdown-toggle', 'data-toggle': 'dropdown') do
     Log In
   .dropdown-menu.dropdown-menu-right.shadow-lg.bg-dark.top-of-flash{ 'aria-labelledby': 'dropdownMenuButton' }


### PR DESCRIPTION
Fixes #8517.

Co-authored-by: David Kang <dkang@suse.com>

<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn
how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md

In order to make it as easy as possible for other developers to review your
pull request we ask you to:

- Explain what this PR is about in the description
- Explain the steps the reviewer has to follow to verify your change
- If the reviewer needs sample data to verify your change, please explain how to
  create that data
- If you include visual changes in this PR, please add screenshots or GIFs
- If you address performance in this PR, add benchmark data or explain how the
  reviewer can benchmark this

This is a good PR description example:

Hey Friends,

this introduces labels for the different build result states on the project
monitor page. This makes it easier to get a visual overview of what is going on
in your project.

To verify this feature

- Enable the interconnect to build.opensuse.org
- Create the project home:Admin
- Add 'openSUSE Tumbleweed' as a repository to the project
- Branch a couple of packages into the project:
  ```
  for i in `osc -A http://0.0.0.0:3000 ls openSUSE.org:home:hennevogel`; do osc -A http://0.0.0.0:3000 copypac openSUSE.org:home:hennevogel $i home:Admin; done
  ```
- Visit the monitor page and see the new labels for the different states.

Here is a screenshot of how it looks:

** Before **
![Screenshot of the project monitor](https://example.com/screenshot1.png)

** After **
![Screenshot of the project monitor](https://example.com/screenshot2.png)

-->
