### PR TITLE
Add a Backlog API endpoint

### DIFF
--- a/docs/api/api/api.txt
+++ b/docs/api/api/api.txt
@@ -1961,9 +1961,18 @@ POST /staging/<staging_workflow_project>/staging_projects
 XmlBody: create_staging_projects
 XmlResult: status_ok
 
+
+=== Backlog
+
+<staging_workflow_project>: The name of the staging workflow project, e.g. home:user1
+
+GET /staging/<staging_workflow_project>/backlog
+  Get the list of requests that are not added into any staging project or excluded.
+XmlResult: backlog
+
 === Excluded Requests
 
-<project>: The name of the main project of a Staging, e.g. openSUSE_Tumbleweed
+<project>: The name of the main project of a Staging, e.g. openSUSE:Factory
 <request>: The number of the request, e.g. 12345
 <description>: A string of text (url encoded)
 

--- a/docs/api/api/backlog.xml
+++ b/docs/api/api/backlog.xml
@@ -1,0 +1,4 @@
+<backlog>
+  <request id="7" type="submit" creator="tux" state="new" package="aaa_base"/>
+  <request id="13" type="submit" creator="bob" state="review" package="ruby"/>
+</backlog>

--- a/src/api/app/controllers/staging/backlog_controller.rb
+++ b/src/api/app/controllers/staging/backlog_controller.rb
@@ -1,0 +1,28 @@
+class Staging::BacklogController < ApplicationController
+  before_action :require_login, except: [:index]
+  before_action :set_project
+  before_action :set_staging_workflow
+
+  def index
+    @backlog = @staging_workflow.unassigned_requests
+  end
+
+  private
+
+  def set_project
+    @project = Project.get_by_name(params[:staging_workflow_project])
+  rescue Project::UnknownObjectError
+    render_error(
+      status: 404,
+      errorcode: 'not_found',
+      message: "Project '#{params[:staging_workflow_project]}' not found."
+    )
+  end
+
+  def set_staging_workflow
+    @staging_workflow = @project.staging
+    return if @staging_workflow
+
+    raise InvalidParameterError, "Project #{params[:staging_workflow_project]} doesn't have an asociated Staging Workflow"
+  end
+end

--- a/src/api/app/views/staging/backlog/index.xml.builder
+++ b/src/api/app/views/staging/backlog/index.xml.builder
@@ -1,0 +1,3 @@
+xml.backlog do
+  render(partial: 'staging/shared/requests', locals: { requests: @backlog, builder: xml })
+end

--- a/src/api/app/views/staging/shared/_requests.xml.builder
+++ b/src/api/app/views/staging/shared/_requests.xml.builder
@@ -1,0 +1,7 @@
+requests.each do |bs_request|
+  builder.request(id: bs_request.number,
+                  type: bs_request.bs_request_actions.first.action_type,
+                  creator: bs_request.creator,
+                  state: bs_request.state,
+                  package: bs_request.first_target_package)
+end

--- a/src/api/app/views/staging/staged_requests/index.xml.builder
+++ b/src/api/app/views/staging/staged_requests/index.xml.builder
@@ -1,9 +1,3 @@
 xml.staged_requests do
-  @requests.each do |bs_request|
-    xml.request(id: bs_request.number,
-                type: bs_request.bs_request_actions.first.action_type,
-                creator: bs_request.creator,
-                state: bs_request.state,
-                package: bs_request.first_target_package)
-  end
+  render(partial: 'staging/shared/requests', locals: { requests: @requests, builder: xml })
 end

--- a/src/api/config/routes/api_routes.rb
+++ b/src/api/config/routes/api_routes.rb
@@ -271,6 +271,7 @@ OBSApi::Application.routes.draw do
   # StagingWorkflow API
   resources :staging, only: [], param: 'workflow_project', module: 'staging', constraints: cons do
     resource :workflow, only: [:create, :destroy, :update], constraints: cons
+    resources :backlog, only: [:index]
     resources :staging_projects, only: [:index, :create], param: :name, constraints: cons do
       get '' => :show
       post 'copy/:staging_project_copy_name' => :copy

--- a/src/api/spec/controllers/staging/backlog_controller_spec.rb
+++ b/src/api/spec/controllers/staging/backlog_controller_spec.rb
@@ -1,0 +1,64 @@
+require 'rails_helper'
+
+RSpec.describe Staging::BacklogController do
+  render_views
+
+  let(:other_user) { create(:confirmed_user, :with_home, login: 'unpermitted_user') }
+  let(:user) { create(:confirmed_user, :with_home, login: 'permitted_user') }
+  let(:project) { user.home_project }
+  let(:staging_workflow) { create(:staging_workflow_with_staging_projects, project: project) }
+  let(:group) { staging_workflow.managers_group }
+  let(:staging_project) { staging_workflow.staging_projects.first }
+  let(:source_project) { create(:project, name: 'source_project') }
+  let(:target_package) { create(:package, name: 'target_package', project: project) }
+  let(:source_package) { create(:package, name: 'source_package', project: source_project) }
+  let!(:bs_request) do
+    create(:bs_request_with_submit_action,
+           state: :review,
+           creator: other_user,
+           target_package: target_package,
+           source_package: source_package,
+           description: 'BsRequest 1',
+           review_by_group: group)
+  end
+
+  describe 'GET #index' do
+    context 'when the project has an Staging Workflow' do
+      before do
+        get :index, params: { staging_workflow_project: staging_workflow.project.name, format: :xml }
+      end
+
+      it { expect(response).to have_http_status(:success) }
+
+      it 'returns the backlog xml' do
+        assert_select 'backlog' do
+          assert_select 'request', 1
+        end
+      end
+    end
+
+    context 'when the project does not exist' do
+      before do
+        get :index, params: { staging_workflow_project: 'non-existent', format: :xml }
+      end
+
+      it { expect(response).to have_http_status(:not_found) }
+    end
+
+    context 'when the project has no Staging Workflow' do
+      let(:other_project) { other_user.home_project }
+
+      before do
+        get :index, params: { staging_workflow_project: other_project, format: :xml }
+      end
+
+      it { expect(response).to have_http_status(:bad_request) }
+
+      it 'responds_with_an_error' do
+        assert_select 'status' do
+          assert_select 'summary', text: "Project #{other_project} doesn't have an asociated Staging Workflow"
+        end
+      end
+    end
+  end
+end

--- a/src/api/test/functional/backend_test.rb
+++ b/src/api/test/functional/backend_test.rb
@@ -21,7 +21,7 @@ class BackendTests < ActionDispatch::IntegrationTest
           'productlist', 'binary_released', 'check', 'required_checks', 'status_report',
           'staged_requests', 'remove_staged_requests', 'status_ok', 'staging_project',
           'staging_projects', 'create_staging_workflow', 'update_staging_workflow', 'accept_staging_projects',
-          'excluded_requests', 'create_excluded_requests', 'delete_excluded_requests', 'create_staging_projects'].include?(schema)
+          'excluded_requests', 'create_excluded_requests', 'delete_excluded_requests', 'create_staging_projects', 'backlog'].include?(schema)
         # no backend schema exists
         next
       elsif schema == 'aggregate'


### PR DESCRIPTION
This PR adds a new API endpoint under `/staging_workflow/:project_name/backlog`

And the output is:
```                                                                                                           
<backlog>
  <request id="6" type="delete" creator="Iggy" state="review" package="doom"/>
</backlog>
```

Fixes #7393

Co-authored-by: David Kang <dkang@suse.com>

<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn
how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md

In order to make it as easy as possible for other developers to review your
pull request we ask you to:

- Explain what this PR is about in the description
- Explain the steps the reviewer has to follow to verify your change
- If the reviewer needs sample data to verify your change, please explain how to
  create that data
- If you include visual changes in this PR, please add screenshots or GIFs
- If you address performance in this PR, add benchmark data or explain how the
  reviewer can benchmark this

This is a good PR description example:

Hey Friends,

this introduces labels for the different build result states on the project
monitor page. This makes it easier to get a visual overview of what is going on
in your project.

To verify this feature

- Enable the interconnect to build.opensuse.org
- Create the project home:Admin
- Add 'openSUSE Tumbleweed' as a repository to the project
- Branch a couple of packages into the project:
  ```
  for i in `osc -A http://0.0.0.0:3000 ls openSUSE.org:home:hennevogel`; do osc -A http://0.0.0.0:3000 copypac openSUSE.org:home:hennevogel $i home:Admin; done
  ```
- Visit the monitor page and see the new labels for the different states.

Here is a screenshot of how it looks:

** Before **
![Screenshot of the project monitor](https://example.com/screenshot1.png)

** After **
![Screenshot of the project monitor](https://example.com/screenshot2.png)

-->
