### PR TITLE
Set review for staged requests if request state new or review

### DIFF
--- a/src/api/app/models/staging/staged_requests.rb
+++ b/src/api/app/models/staging/staged_requests.rb
@@ -29,7 +29,7 @@ class Staging::StagedRequests
     not_deleted_packages = package_names - result.pluck(:name)
 
     requests.each do |request|
-      add_review_for_unstaged_request(request)
+      add_review_for_unstaged_request(request) if request.state.in?([:new, :review])
 
       ProjectLogEntry.create!(
         project: staging_project,

--- a/src/api/spec/controllers/staging/staged_requests_controller_spec.rb
+++ b/src/api/spec/controllers/staging/staged_requests_controller_spec.rb
@@ -155,6 +155,20 @@ RSpec.describe Staging::StagedRequestsController do
         it { expect(staging_project.packages).to be_empty }
         it { expect(staging_project.staged_requests).to be_empty }
       end
+
+      context 'with revoked request' do
+        before do
+          login user
+          bs_request.state = :revoked
+          bs_request.save
+          delete :destroy, params: { staging_workflow_project: staging_workflow.project.name, staging_project_name: staging_project.name, format: :xml },
+                           body: "<requests><number>#{bs_request.number}</number></requests>"
+        end
+
+        it { expect(response).to have_http_status(:success) }
+        it { expect(staging_project.packages).to be_empty }
+        it { expect(staging_project.staged_requests).to be_empty }
+      end
     end
 
     context 'with valid staging_project but staging project is being merged' do


### PR DESCRIPTION
Fixes #8522 

Just update the reviews in a request if the request state is `new` or `review`

Add a spec to test to cover the case where request state is `revoked`
