### PR TITLE
Use param project_name instead of project

### DIFF
--- a/src/api/app/controllers/webui/projects/status_controller.rb
+++ b/src/api/app/controllers/webui/projects/status_controller.rb
@@ -22,7 +22,7 @@ module Webui
         @filter_for_user = params[:filter_for_user]
 
         @develprojects = {}
-        ps = calc_status(params[:project])
+        ps = calc_status(params[:project_name])
 
         @packages = ps[:packages]
         @develprojects = ps[:projects].sort_by(&:downcase)


### PR DESCRIPTION
Fixes #8568 parameter changed from project to project_name. Looks like our specs doesn't cover it.