### PR TITLE
Use request instead of entry in the xml

### DIFF
--- a/docs/api/api/staging_project.xml
+++ b/docs/api/api/staging_project.xml
@@ -1,19 +1,19 @@
 <staging_project name="home:user_2:Staging:B" state="unacceptable">
   <staged_requests count="1">
-    <entry id="3" creator="user_1" state="new" package="ctris"/>
+    <request id="3" creator="user_1" state="new" package="ctris"/>
   </staged_requests>
   <untracked_requests count="1">
-    <entry id="4" creator="user_1" state="review" package="ctris"/>
+    <request id="4" creator="user_1" state="review" package="ctris"/>
   </untracked_requests>
   <requests_to_review count="1">
-    <entry id="5" creator="user_1" state="review" package="ctris"/>
+    <request id="5" creator="user_1" state="review" package="ctris"/>
   </requests_to_review>
   <obsolete_requests count="0"/>
   <missing_reviews count="1">
-    <entry id="6" creator="by_group" state="new" package="ctris"/>
+    <review id="6" creator="by_group" state="new" package="ctris"/>
   </missing_reviews>
   <broken_packages count="1">
-    <entry package="ctris" project="home:user_1"/>
+    <package package="ctris" project="home:user_1"/>
   </broken_packages>
   <checks count="1">
     <check name="unit tests" required="false">
@@ -23,6 +23,6 @@
     </check>
   </checks>
   <missing_checks count="1">
-    <missing_check name="ci" state="pending" required="true"/>
+    <check name="ci" state="pending" required="true"/>
   </missing_checks>
 </staging_project>

--- a/src/api/app/views/staging/staging_projects/_broken_packages.xml.builder
+++ b/src/api/app/views/staging/staging_projects/_broken_packages.xml.builder
@@ -1,5 +1,5 @@
 builder.broken_packages(count: count) do |broken_package|
   broken_packages.each do |package|
-    broken_package.entry(package: package[:package], project: package[:project])
+    broken_package.package(package: package[:package], project: package[:project])
   end
 end

--- a/src/api/app/views/staging/staging_projects/_missing_checks.xml.builder
+++ b/src/api/app/views/staging/staging_projects/_missing_checks.xml.builder
@@ -1,5 +1,5 @@
 builder.missing_checks(count: missing_checks.count) do
   missing_checks.each do |name|
-    builder.missing_check(name: name, state: :pending, required: true)
+    builder.check(name: name, state: :pending, required: true)
   end
 end

--- a/src/api/app/views/staging/staging_projects/_missing_reviews.xml.builder
+++ b/src/api/app/views/staging/staging_projects/_missing_reviews.xml.builder
@@ -1,5 +1,5 @@
 builder.missing_reviews(count: count) do |missing_review|
   missing_reviews.each do |bs_request|
-    missing_review.entry(id: bs_request[:id], creator: bs_request[:by], state: bs_request[:state], package: bs_request[:package])
+    missing_review.review(id: bs_request[:id], creator: bs_request[:by], state: bs_request[:state], package: bs_request[:package])
   end
 end

--- a/src/api/app/views/staging/staging_projects/_requests.xml.builder
+++ b/src/api/app/views/staging/staging_projects/_requests.xml.builder
@@ -1,3 +1,3 @@
 requests.each do |request|
-  builder.entry(id: request.number, creator: request.creator, state: request.state, package: request.first_target_package)
+  builder.request(id: request.number, creator: request.creator, state: request.state, package: request.first_target_package)
 end

--- a/src/api/spec/controllers/staging/staging_projects_controller_spec.rb
+++ b/src/api/spec/controllers/staging/staging_projects_controller_spec.rb
@@ -94,19 +94,19 @@ RSpec.describe Staging::StagingProjectsController do
       it 'returns the staging_project name xml' do
         assert_select 'staging_project' do
           assert_select 'staged_requests', 1 do
-            assert_select 'entry', 3
+            assert_select 'request', 3
           end
           assert_select 'untracked_requests', 1 do
-            assert_select 'entry', 1
+            assert_select 'request', 1
           end
           assert_select 'requests_to_review', 1 do
-            assert_select 'entry', 2
+            assert_select 'request', 2
           end
           assert_select 'missing_reviews', 1 do
-            assert_select 'entry', 1
+            assert_select 'review', 1
           end
           assert_select 'broken_packages', 1 do
-            assert_select 'entry', 1
+            assert_select 'package', 1
           end
           assert_select 'history', 1
         end


### PR DESCRIPTION
Fixes #8542 

In the returned XML uses `request` element instead of `entry`
