### PR TITLE
Align usage of icons for projects/packages in the UI

### DIFF
--- a/src/api/app/helpers/webui/staging/workflow_helper.rb
+++ b/src/api/app/helpers/webui/staging/workflow_helper.rb
@@ -43,19 +43,22 @@ module Webui::Staging::WorkflowHelper
     end
   end
 
-  def reviewers_gravatar(request, users_hash, groups_hash)
+  def reviewers_icon(request, users_hash, groups_hash)
     missing_reviews = request[:missing_reviews]
-    image_tags = []
+    tags = []
     missing_reviews.each do |review|
       case review[:review_type]
       when 'by_group'
-        object = groups_hash[review[:by]]
+        tags << image_tag_for(groups_hash[review[:by]], size: 20)
       when 'by_user'
-        object = users_hash[review[:by]]
+        tags << image_tag_for(users_hash[review[:by]], size: 20)
+      when 'by_project'
+        tags << content_tag(:i, nil, class: 'fa fa-cubes text-secondary ml-1', title: review[:by])
+      when 'by_package'
+        tags << content_tag(:i, nil, class: 'fa fa-archive text-dark ml-1', title: review[:by])
       end
-      image_tags << image_tag_for(object, size: 20)
     end
-    image_tags
+    tags
   end
 
   def create_request_links(request, users_hash, groups_hash)
@@ -63,7 +66,7 @@ module Webui::Staging::WorkflowHelper
     css = 'review' if request[:missing_reviews].present?
     css = 'obsolete' if request[:state].in?(BsRequest::OBSOLETE_STATES)
     link_content = [request[:package]]
-    link_content << reviewers_gravatar(request, users_hash, groups_hash) if request[:missing_reviews].present?
+    link_content << reviewers_icon(request, users_hash, groups_hash) if request[:missing_reviews].present?
     content_tag(:span, class: "badge state-#{css}") do
       link_to(request_show_path(request[:number]), class: 'request') do
         safe_join(link_content)

--- a/src/api/app/views/webui/request/_reviewer.html.haml
+++ b/src/api/app/views/webui/request/_reviewer.html.haml
@@ -6,6 +6,8 @@
   = group_with_icon(review[:by_group])
 - elsif review[:by_project]
   - if review[:by_package]
+    %i.fa.fa-archive.text-warning
     = link_to("#{review[:by_project]} / #{review[:by_package]}", package_users_path(project: review[:by_project], package: review[:by_package]))
   - else
+    %i.fa.fa-cubes.text-secondary
     = link_to(review[:by_project], project_users_path(project: review[:by_project]))


### PR DESCRIPTION
To follow what we already do in the 'Latest Updates' section on the homepage.

Fixes #8480

On the staging workflow page, I couldn't use `text-warning`, so I went with `text-dark` instead.
![staging-workflow-after](https://user-images.githubusercontent.com/1102934/66823195-07419b00-ef46-11e9-9abf-450900bd5c10.png)
On the request page:
![request-after](https://user-images.githubusercontent.com/1102934/66823200-09a3f500-ef46-11e9-8b92-cedfbd5ad123.png)

As a reference, this is what we already do in the `Latest Updates` section:
![latest-updates](https://user-images.githubusercontent.com/1102934/66823320-47088280-ef46-11e9-9519-7a03ccb69126.png)