### PR TITLE
Get rid of n+1 queries and improve rendering time of staging project/workflow

### DIFF
--- a/src/api/app/helpers/webui/staging/workflow_helper.rb
+++ b/src/api/app/helpers/webui/staging/workflow_helper.rb
@@ -75,12 +75,13 @@ module Webui::Staging::WorkflowHelper
   end
 
   def requests(staging_project, users_hash, groups_hash)
-    number_of_requests = staging_project.classified_requests.size
+    classified_requests = staging_project.classified_requests
+    number_of_requests = classified_requests.size
 
     return 'None' if number_of_requests == 0
 
     requests_visible_by_default = 10
-    requests_links = staging_project.classified_requests.map do |request|
+    requests_links = classified_requests.map do |request|
       create_request_links(request, users_hash, groups_hash)
     end
 

--- a/src/api/app/models/bs_request.rb
+++ b/src/api/app/models/bs_request.rb
@@ -99,6 +99,7 @@ class BsRequest < ApplicationRecord
 
   belongs_to :staging_project, class_name: 'Project', foreign_key: 'staging_project_id'
   has_one :request_exclusion, class_name: 'Staging::RequestExclusion', foreign_key: 'bs_request_id', dependent: :destroy
+  has_many :not_accepted_reviews, -> { where.not(state: :accepted) }, class_name: 'Review'
 
   validates :state, inclusion: { in: VALID_REQUEST_STATES }
   validates :creator, presence: true

--- a/src/api/app/models/concerns/staging_project.rb
+++ b/src/api/app/models/concerns/staging_project.rb
@@ -99,7 +99,7 @@ module StagingProject
 
     @missing_reviews = []
 
-    Review.includes(:bs_request).where(bs_request_id: staged_requests.select(:id)).where.not(state: :accepted).find_each do |review|
+    Review.includes(bs_request: [:bs_request_actions]).where(bs_request_id: staged_requests.select(:id)).where.not(state: :accepted).find_each do |review|
       # We skip reviews for the staging project since these reviews are used
       # by the openSUSE release tools _after_ the overall_state switched to
       # 'accepted'.

--- a/src/api/app/models/concerns/staging_project.rb
+++ b/src/api/app/models/concerns/staging_project.rb
@@ -58,8 +58,7 @@ module StagingProject
         state: request.state,
         package: request.first_target_package,
         request_type: request.bs_request_actions.first.type,
-        missing_reviews: missing_reviews.select { |review| review[:request] == request.number },
-        tracked: requests_to_review.include?(request)
+        missing_reviews: missing_reviews.select { |review| review[:request] == request.number }
       }
     end
 


### PR DESCRIPTION
A couple of improvements to reduce the rendering/loading time of the staging project show view.
Since the package table is also used in the staging workflow show view, it also improves the loading time there.

**Here some numbers**
A staging project with 200 requests and 200 missing reviews:

Before:
(Views: 2451.375ms | ActiveRecord: 122.6ms | Backend: 5.2ms)

After:
(Views: 1390.375ms | ActiveRecord: 25.15ms | Backend: 5.3ms)

It's the avarage result of 4 loading attempts.

Still not blazing fast, but a step in the right direction I would say. :)

Fixes #7350 

<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn
how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md

In order to make it as easy as possible for other developers to review your
pull request we ask you to:

- Explain what this PR is about in the description
- Explain the steps the reviewer has to follow to verify your change
- If the reviewer needs sample data to verify your change, please explain how to
  create that data
- If you include visual changes in this PR, please add screenshots or GIFs
- If you address performance in this PR, add benchmark data or explain how the
  reviewer can benchmark this

This is a good PR description example:

Hey Friends,

this introduces labels for the different build result states on the project
monitor page. This makes it easier to get a visual overview of what is going on
in your project.

To verify this feature

- Enable the interconnect to build.opensuse.org
- Create the project home:Admin
- Add 'openSUSE Tumbleweed' as a repository to the project
- Branch a couple of packages into the project:
  ```
  for i in `osc -A http://0.0.0.0:3000 ls openSUSE.org:home:hennevogel`; do osc -A http://0.0.0.0:3000 copypac openSUSE.org:home:hennevogel $i home:Admin; done
  ```
- Visit the monitor page and see the new labels for the different states.

Here is a screenshot of how it looks:

** Before **
![Screenshot of the project monitor](https://example.com/screenshot1.png)

** After **
![Screenshot of the project monitor](https://example.com/screenshot2.png)

-->
