### PR TITLE
[2.10 backport] Make editor big where needed

### DIFF
--- a/src/api/app/assets/javascripts/webui2/cm2/use-codemirror.js
+++ b/src/api/app/assets/javascripts/webui2/cm2/use-codemirror.js
@@ -15,7 +15,7 @@ function cmMarkDiffLines(id) {
   $('#revision_details_' + id + ' .cm-negative').parents('.CodeMirror-line').addClass('CodeMirror-negative-line');
 }
 
-function use_codemirror(id, read_only, mode) {
+function use_codemirror(id, read_only, mode, big_editor) {
   var codeMirrorOptions = {
     lineNumbers: true,
     matchBrackets: false,
@@ -36,6 +36,10 @@ function use_codemirror(id, read_only, mode) {
   var textarea = $('#editor_' + id);
   var editor = CodeMirror.fromTextArea(document.getElementById("editor_" + id), codeMirrorOptions);
   editor.id = id;
+  if (big_editor) {
+    $(editor.getWrapperElement()).addClass('big-editor');
+    editor.refresh();
+  }
 
   cmMarkDiffLines(id);
   editor.on('scroll', function() { cmMarkDiffLines(id); });

--- a/src/api/app/assets/stylesheets/webui2/cm2.scss
+++ b/src/api/app/assets/stylesheets/webui2/cm2.scss
@@ -8,3 +8,7 @@
 .short-progress {
     height: 5px;
 }
+
+.big-editor {
+    height: auto;
+}

--- a/src/api/app/views/webui2/shared/_editor.html.haml
+++ b/src/api/app/views/webui2/shared/_editor.html.haml
@@ -1,6 +1,6 @@
 :ruby
   save ||= {}
-  style ||= { read_only: false }
+  style ||= { read_only: false, big_editor: true }
   uid ||= next_codemirror_uid
   content_for(:head_style, codemirror_style(style))
 
@@ -55,4 +55,4 @@
   = render partial: 'shared/editor_modal', locals: { uid: uid }
 
 - content_for :ready_function do
-  use_codemirror(#{uid}, #{style[:read_only]}, '#{mode}');
+  use_codemirror(#{uid}, #{style[:read_only]}, '#{mode}', #{style[:big_editor]});

--- a/src/api/app/views/webui2/webui/package/_revision_diff_detail.html.haml
+++ b/src/api/app/views/webui2/webui/package/_revision_diff_detail.html.haml
@@ -9,7 +9,7 @@
           = calculate_filename(filename, file)
           %span.badge{ class: "badge-#{file['state']}" }= file['state'].capitalize
       %div
-        = render partial: 'shared/editor', locals: { text: diff_content, mode: 'diff', style: { read_only: true } }
+        = render partial: 'shared/editor', locals: { text: diff_content, mode: 'diff', style: { read_only: true, big_editor: false } }
   - else
     .card{ id: "revision_details_#{index}" }
       .card-header


### PR DESCRIPTION
This way the editor textarea gets maximized most of the times, that is what users want.
Don't show always the bottom box. We prefer to see more from the editor textarea.

Originally authored by @hellcp and @eduardoj 

Backported from #7958.

(cherry picked from commit eb30e4ad3ca6262c7749905db9fb2dde8efedd91)