### PR TITLE
Fix smoke tests

### DIFF
--- a/dist/t/spec/features/0040_package_spec.rb
+++ b/dist/t/spec/features/0040_package_spec.rb
@@ -43,6 +43,7 @@ RSpec.describe "Package" do
       click_link('Home Project')
     end
     click_link('Branch Existing Package')
+    page.evaluate_script('$.fx.off = true;') # Needed to disable javascript animations to avoid race conditions
     within('#new-package-branch-modal') do
       fill_in 'linked_project', with: 'openSUSE.org:openSUSE:Tools'
       fill_in 'linked_package', with: 'build'

--- a/src/backend/BSRPC.pm
+++ b/src/backend/BSRPC.pm
@@ -398,7 +398,7 @@ sub rpc {
     }
     if (!$param->{'ignorestatus'}) {
       close $sock;
-      die("$1 remote error: $2\n") if $status =~ /^(\d+) +(.*?)$/;
+      die("$1 remote error: $2 ($uri)\n") if $status =~ /^(\d+) +(.*?)$/;
       die("remote error: $status\n");
     }
   }


### PR DESCRIPTION
Without this patch only a part of the string 'openSUSE.org:openSUSE:Tools'
gets passed to the backend, which quits with a 404 from the remote side.

This behavior is non-determenistic.

SEE ALSO:
teamcapybara/capybara#1890

Fix taken from here:

teamcapybara/capybara#1890 (comment)

This patch

* adds a sleep after clicking "Branch existing project" before entering the strings
  to give jQuery the time to complete the animation
* sends the strings char by char to avoid race conditions with autocompletion