### PR TITLE
Improve alignment of reviewers icons in staging workflow

### DIFF
--- a/src/api/app/assets/stylesheets/webui/staging-workflow.scss
+++ b/src/api/app/assets/stylesheets/webui/staging-workflow.scss
@@ -94,6 +94,8 @@ ul .table-list-group-item {
       a.request {
         @extend .text-white;
         padding: 0 0.125rem 0.25rem;
+        display: flex;
+        align-items: center;
 
         &:hover {
           text-decoration: none;
@@ -103,6 +105,9 @@ ul .table-list-group-item {
           border-radius: 50%;
           height: 20px;
           width: 20px;
+        }
+
+        img, i {
           margin-left: 5px;
         }
       }

--- a/src/api/app/helpers/webui/staging/workflow_helper.rb
+++ b/src/api/app/helpers/webui/staging/workflow_helper.rb
@@ -53,9 +53,9 @@ module Webui::Staging::WorkflowHelper
       when 'by_user'
         tags << image_tag_for(users_hash[review[:by]], size: 20)
       when 'by_project'
-        tags << content_tag(:i, nil, class: 'fa fa-cubes text-secondary ml-1', title: review[:by])
+        tags << content_tag(:i, nil, class: 'fa fa-cubes text-secondary', title: review[:by])
       when 'by_package'
-        tags << content_tag(:i, nil, class: 'fa fa-archive text-dark ml-1', title: review[:by])
+        tags << content_tag(:i, nil, class: 'fa fa-archive text-dark', title: review[:by])
       end
     end
     tags


### PR DESCRIPTION
It's a small difference, but still noticeable. We now use a flex container to center icons of reviewers on the staging workflow page.

This is a follow-up to #8579.

Before:
![before](https://user-images.githubusercontent.com/1102934/67206146-605f7200-f411-11e9-817a-917526e6c152.png)

After:
![after](https://user-images.githubusercontent.com/1102934/67206149-605f7200-f411-11e9-9af6-cb75b1f4bd3d.png)