### PR TITLE
Disable use of concurrency in asset compilation

### DIFF
--- a/src/api/config/application.rb
+++ b/src/api/config/application.rb
@@ -91,6 +91,11 @@ module OBSApi
     # avoid a warning
     I18n.enforce_available_locales = true
 
+    config.assets.configure do |env|
+      # https://github.com/rails/sprockets/issues/581
+      env.export_concurrent = false
+    end
+
     # we're not threadsafe
     config.allow_concurrency = false
 


### PR DESCRIPTION
sassc is not thread safe and there are tons of crashes while building packages. Unfortunately #8555 was merged even though the problem was noted there, so applying workaround from the upstream issue.
