### PR TITLE
Remove warning message from release notes

### DIFF
--- a/docs/ReleaseNotes-2.10
+++ b/docs/ReleaseNotes-2.10
@@ -2,12 +2,6 @@
 # Open Build Service 2.10
 #
 
-WARNING:
-WARNING: This is a development release, not for production usage!
-WARNING:
-
-
-
 
 Please read the README.SETUP file for initial installation
 instructions or use the OBS Appliance from
@@ -58,10 +52,10 @@ Backend & build support:
  * new publisher features
    - vagrant box publishing
    - zchunk compressed files in rpm-md metadata
- 
+
  * binary tracking improvements
    - tracking of appliances and containers
- 
+
  * container improvements
    - support multi-arch container manifest generation
    - kiwi profile handling
@@ -71,12 +65,12 @@ Backend & build support:
      conflict over a tag
    - disk space savings with container layer deduplication
    - integrated container registry
- 
+
  * speed improvements
    - faster repository publishing and product generation
    - incremental project updates in the scheduler
    - reducred interconnect load due to a lastevents proxy
- 
+
  * odds and ends
    - obs-build: shell support in KVM
    - prjconf package exclude feature ("onlybuild")
@@ -156,4 +150,3 @@ Intentional changes:
 
   * Public route dropped for reading patchinfo
     - GET 'patchinfo/read_patchinfo'
-

--- a/docs/ReleaseNotes-2.6
+++ b/docs/ReleaseNotes-2.6
@@ -1,13 +1,6 @@
-
 #
 # Open Build Service 2.6
 #
-
-WARNING:
-WARNING: This is a development release, not for production usage!
-WARNING:
-
-
 
 
 Please read the README.SETUP file for initial installation
@@ -19,8 +12,8 @@ There is also an install medium with installs OBS on hard disc now.
 
 dist/README.UPDATERS file has informations for updaters.
 
-OBS Appliance users who have setup their LVM can just replace 
-their appliance image without data loss. The migration will 
+OBS Appliance users who have setup their LVM can just replace
+their appliance image without data loss. The migration will
 happen automatically.
 
 
@@ -39,7 +32,7 @@ Features
  * Groups can have maintainers now, who can modify the member list
 
  * Requests can have a priority now. Request search is sorting by the priority
-   first and by the age of the request second. 
+   first and by the age of the request second.
 
  * The request history system got a big overhaul
    - reviews have a history too now
@@ -55,11 +48,11 @@ Changes on purpose:
 Incompatible changes:
 =====================
 
- * You get also an update of sphinx searchd. The on-disk db files became 
+ * You get also an update of sphinx searchd. The on-disk db files became
    incompatible, so please remove all files in following directory to
    enforce a re-index to avoid problems:
 
-      /srv/www/obs/api/db/sphinx/production/ 
+      /srv/www/obs/api/db/sphinx/production/
 
  * maintenance tag handling via _channel files got replaced with an option
    to re-define the updateinfo scheme template.
@@ -72,7 +65,7 @@ Incompatible changes:
         (we do support updates from 2.5 only anyway)
     - Also old clients will not show history anymore by default. Use osc 0.148
       for full new support of request histories
-      
+
 
 Notes for systems using systemd:
 ================================
@@ -95,4 +88,3 @@ To avoid these problems you need switch directory to avoid the systemd mapper:
 
  # cd /etc/init.d
  # ./obssrcserver status|stop|start
-

--- a/docs/ReleaseNotes-2.8
+++ b/docs/ReleaseNotes-2.8
@@ -1,13 +1,6 @@
-
 #
 # Open Build Service 2.8
 #
-
-WARNING:
-WARNING: This is a development release, not for production usage!
-WARNING:
-
-
 
 
 Please read the README.SETUP file for initial installation

--- a/docs/ReleaseNotes-2.9
+++ b/docs/ReleaseNotes-2.9
@@ -1,13 +1,6 @@
-
 #
 # Open Build Service 2.9
 #
-
-WARNING:
-WARNING: This is a development release, not for production usage!
-WARNING:
-
-
 
 
 Please read the README.SETUP file for initial installation


### PR DESCRIPTION
This warning message should have been removed when the releases were published.

<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn
how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md

In order to make it as easy as possible for other developers to review your
pull request we ask you to:

- Explain what this PR is about in the description
- Explain the steps the reviewer has to follow to verify your change
- If the reviewer needs sample data to verify your change, please explain how to
  create that data
- If you include visual changes in this PR, please add screenshots or GIFs
- If you address performance in this PR, add benchmark data or explain how the
  reviewer can benchmark this

This is a good PR description example:

Hey Friends,

this introduces labels for the different build result states on the project
monitor page. This makes it easier to get a visual overview of what is going on
in your project.

To verify this feature

- Enable the interconnect to build.opensuse.org
- Create the project home:Admin
- Add 'openSUSE Tumbleweed' as a repository to the project
- Branch a couple of packages into the project:
  ```
  for i in `osc -A http://0.0.0.0:3000 ls openSUSE.org:home:hennevogel`; do osc -A http://0.0.0.0:3000 copypac openSUSE.org:home:hennevogel $i home:Admin; done
  ```
- Visit the monitor page and see the new labels for the different states.

Here is a screenshot of how it looks:

** Before **
![Screenshot of the project monitor](https://example.com/screenshot1.png)

** After **
![Screenshot of the project monitor](https://example.com/screenshot2.png)

-->
