### PR TITLE
Add missing informations to broken packages xml api response 

### DIFF
--- a/src/api/app/views/staging/staging_projects/_broken_packages.xml.builder
+++ b/src/api/app/views/staging/staging_projects/_broken_packages.xml.builder
@@ -1,5 +1,6 @@
 builder.broken_packages(count: count) do |broken_package|
   broken_packages.each do |package|
-    broken_package.package(package: package[:package], project: package[:project])
+    broken_package.package(package: package[:package], project: package[:project], state: package[:state],
+                           repository: package[:repository], arch: package[:arch])
   end
 end

--- a/src/api/app/views/staging/staging_projects/_building_repositories.xml.builder
+++ b/src/api/app/views/staging/staging_projects/_building_repositories.xml.builder
@@ -1,6 +1,6 @@
-xml.building_repositories(count: count) do |building_repository|
+builder.building_repositories(count: count) do |building_repository|
   building_repositories.each do |repo|
-    # missing , tobuild: repo[''], final: repo['']
-    building_repository.entry(name: repo['repository'], arch: repo['arch'], code: repo['code'], state: repo['state'])
+    building_repository.repo(name: repo['repository'], arch: repo['arch'], code: repo['code'], state: repo['state'],
+                             to_build: repo[:tobuild], final: repo[:final])
   end
 end


### PR DESCRIPTION
When checking the overall state of a staging project through
the api, it's not only interesting to know which packages are
broken, but also for which repository, architecture and the
exact state of it.

The building repositories were missing when checking the
overall state of a staging project through the api. This
was caused by syntactically mistakes

Fixes #8529

<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn
how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md

In order to make it as easy as possible for other developers to review your
pull request we ask you to:

- Explain what this PR is about in the description
- Explain the steps the reviewer has to follow to verify your change
- If the reviewer needs sample data to verify your change, please explain how to
  create that data
- If you include visual changes in this PR, please add screenshots or GIFs
- If you address performance in this PR, add benchmark data or explain how the
  reviewer can benchmark this

This is a good PR description example:

Hey Friends,

this introduces labels for the different build result states on the project
monitor page. This makes it easier to get a visual overview of what is going on
in your project.

To verify this feature

- Enable the interconnect to build.opensuse.org
- Create the project home:Admin
- Add 'openSUSE Tumbleweed' as a repository to the project
- Branch a couple of packages into the project:
  ```
  for i in `osc -A http://0.0.0.0:3000 ls openSUSE.org:home:hennevogel`; do osc -A http://0.0.0.0:3000 copypac openSUSE.org:home:hennevogel $i home:Admin; done
  ```
- Visit the monitor page and see the new labels for the different states.

Here is a screenshot of how it looks:

** Before **
![Screenshot of the project monitor](https://example.com/screenshot1.png)

** After **
![Screenshot of the project monitor](https://example.com/screenshot2.png)

-->
