### PR TITLE
[api] remove personal data on user delete

### DIFF
--- a/src/api/spec/controllers/webui/users_controller_spec.rb
+++ b/src/api/spec/controllers/webui/users_controller_spec.rb
@@ -132,14 +132,8 @@ RSpec.describe Webui::UsersController do
       it "changes the state to 'deleted'" do
         delete :destroy, params: { login: user.login }
         expect(user.reload.state).to eq('deleted')
-      end
-
-      it 'handles validation errors' do
-        user.update_attributes(email: 'invalid')
-        user.save!(validate: false)
-        delete :destroy, params: { login: user.login }
-        expect(user.reload.state).to eq('confirmed')
-        expect(flash[:error]).to eq("Marking user '#{user.login}' as deleted failed: Email must be a valid email address")
+        expect(user.reload.email).to eq('')
+        expect(user.reload.realname).to eq('')
       end
     end
 

--- a/src/api/test/functional/person_controller_test.rb
+++ b/src/api/test/functional/person_controller_test.rb
@@ -343,6 +343,11 @@ class PersonControllerTest < ActionDispatch::IntegrationTest
     post '/person/lost_guy?cmd=delete'
     assert_response 403
 
+    # verify data exists
+    lost_guy = User.find_by(login: 'lost_guy')
+    assert_equal 'lonely_person@universe.com', lost_guy.email
+    assert_equal 'The Other Guy', lost_guy.realname
+
     # but the admin can ...
     login_king
     post '/person/lost_guy?cmd=lock'
@@ -367,8 +372,11 @@ class PersonControllerTest < ActionDispatch::IntegrationTest
     get '/source/home:lost_guy/_meta'
     assert_response 404
 
-    # cleanup
-    User.session = User.find_by(login: 'lost_guy')
+    # delete has removed the right user data, but entry is still there
+    lost_guy = User.find_by(login: 'lost_guy')
+    assert_equal 'deleted', lost_guy.state
+    assert_equal '', lost_guy.email
+    assert_equal '', lost_guy.realname
   end
 
   def test_register_disabled


### PR DESCRIPTION
also fix code which may remove other users home projects with
starting with same login string

should be backported to 2.10 therefore.

<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn
how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md

In order to make it as easy as possible for other developers to review your
pull request we ask you to:

- Explain what this PR is about in the description
- Explain the steps the reviewer has to follow to verify your change
- If the reviewer needs sample data to verify your change, please explain how to
  create that data
- If you include visual changes in this PR, please add screenshots or GIFs
- If you address performance in this PR, add benchmark data or explain how the
  reviewer can benchmark this

This is a good PR description example:

Hey Friends,

this introduces labels for the different build result states on the project
monitor page. This makes it easier to get a visual overview of what is going on
in your project.

To verify this feature

- Enable the interconnect to build.opensuse.org
- Create the project home:Admin
- Add 'openSUSE Tumbleweed' as a repository to the project
- Branch a couple of packages into the project:
  ```
  for i in `osc -A http://0.0.0.0:3000 ls openSUSE.org:home:hennevogel`; do osc -A http://0.0.0.0:3000 copypac openSUSE.org:home:hennevogel $i home:Admin; done
  ```
- Visit the monitor page and see the new labels for the different states.

Here is a screenshot of how it looks:

** Before **
![Screenshot of the project monitor](https://example.com/screenshot1.png)

** After **
![Screenshot of the project monitor](https://example.com/screenshot2.png)

-->
