### PR TITLE
Rebuild thinking sphinx indexes through a data migration

### DIFF
--- a/src/api/db/data/20191028163000_rebuild_ts_realtime_indexes.rb
+++ b/src/api/db/data/20191028163000_rebuild_ts_realtime_indexes.rb
@@ -1,0 +1,9 @@
+class RebuildTsRealtimeIndexes < ActiveRecord::Migration[5.2]
+  def up
+    Rake::Task['ts:rebuild'].invoke
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end


### PR DESCRIPTION
After switching from SQL-backed indexes to real-time indexes
running 'ts:rebuild' is needed in order to index the already
existing packages and projects.

Co-authored-by: Saray Cabrera Padrón <scabrerapadron@suse.de>

Related to https://github.com/openSUSE/open-build-service/issues/8623