### PR TITLE
Refactor look_incident_package method to its own class

### DIFF
--- a/src/api/app/models/branch_package.rb
+++ b/src/api/app/models/branch_package.rb
@@ -500,6 +500,7 @@ class BranchPackage
 
   def lookup_incident_pkg(p)
     return unless p[:package].is_a?(Package)
+    return if p[:link_target_project].maintenance_projects.empty?
     BranchPackage::LookupIncidentPackage.new(p).package
   end
 

--- a/src/api/app/models/branch_package.rb
+++ b/src/api/app/models/branch_package.rb
@@ -500,32 +500,7 @@ class BranchPackage
 
   def lookup_incident_pkg(p)
     return unless p[:package].is_a?(Package)
-    @obs_maintenanceproject ||= AttribType.find_by_namespace_and_name!('OBS', 'MaintenanceProject')
-    @maintenance_projects ||= Project.find_by_attribute_type(@obs_maintenanceproject)
-    incident_pkg = nil
-    p[:link_target_project].maintenance_projects.each do |mp|
-      # no defined devel area or no package inside, but we branch from a release are: check in open incidents
-
-      # only approved maintenance projects
-      next unless @maintenance_projects.include?(mp.maintenance_project)
-
-      answer = Backend::Api::Search.incident_packages(p[:link_target_project].name, p[:package].name, mp.maintenance_project.name)
-      data = REXML::Document.new(answer)
-      data.elements.each('collection/package') do |e|
-        ipkg = Package.find_by_project_and_name(e.attributes['project'], e.attributes['name'])
-        if ipkg.nil?
-          logger.error 'read permission or data inconsistency, backend delivered package ' \
-                       "as linked package where no database object exists: #{e.attributes['project']} / #{e.attributes['name']}"
-        elsif ipkg.project.is_maintenance_incident? && ipkg.project.is_unreleased? # is incident ?
-          # is a newer incident ?
-          if incident_pkg.nil? || ipkg.project.name.gsub(/.*:/, '').to_i > incident_pkg.project.name.gsub(/.*:/, '').to_i
-            incident_pkg = ipkg
-          end
-        end
-      end
-    end
-    # newest incident pkg or nil
-    incident_pkg
+    BranchPackage::LookupIncidentPackage.new(p).package
   end
 
   def report_dryrun

--- a/src/api/app/models/branch_package/lookup_incident_package.rb
+++ b/src/api/app/models/branch_package/lookup_incident_package.rb
@@ -1,0 +1,53 @@
+class BranchPackage::LookupIncidentPackage
+  def initialize(params)
+    @package = params[:package]
+    @link_target_project = params[:link_target_project]
+  end
+
+  def package
+    possible_packages = @link_target_project.maintenance_projects.collect do |mp|
+      # only approved maintenance projects
+      next unless maintenance_projects.include?(mp.maintenance_project)
+      # extract possible packages
+      possible_packages(mp.maintenance_project)
+    end.flatten
+    pkg = nil
+    # choose the last one based on the project id in the name openSUSE:Maintenance:1234
+    # can we use the MaintenanceIncident#incident_id ?
+    possible_packages.each do |possible_package|
+      pkg = possible_package if pkg.nil? || possible_package.project.name.gsub(/.*:/, '').to_i > pkg.project.name.gsub(/.*:/, '').to_i
+    end
+    pkg
+  end
+
+  def possible_packages(maintenance_project)
+    data = incident_packages(maintenance_project)
+    data.xpath('collection/package').collect do |e|
+      possible_package = Package.find_by_project_and_name(e.attributes['project'].value,
+                                                          e.attributes['name'].value)
+      next if possible_package.nil? || !incident?(possible_package)
+      possible_package
+    end
+  end
+
+  def incident_packages(maintenance_project)
+    incident_packages = Backend::Api::Search.incident_packages(@link_target_project.name, @package.name,
+                                                               maintenance_project.name)
+    Nokogiri::XML(incident_packages)
+  end
+
+  private
+
+  # TODO: there is not a better way to find it?
+  def incident?(pkg)
+    pkg.project.is_maintenance_incident? && pkg.project.is_unreleased?
+  end
+
+  def obs_maintenance_project
+    @obs_maintenance_project ||= AttribType.find_by_namespace_and_name!('OBS', 'MaintenanceProject')
+  end
+
+  def maintenance_projects
+    @maintenance_projects ||= Project.find_by_attribute_type(obs_maintenance_project)
+  end
+end

--- a/src/api/app/models/branch_package/lookup_incident_package.rb
+++ b/src/api/app/models/branch_package/lookup_incident_package.rb
@@ -12,10 +12,9 @@ class BranchPackage::LookupIncidentPackage
       possible_packages(mp.maintenance_project)
     end.flatten
     pkg = nil
-    # choose the last one based on the project id in the name openSUSE:Maintenance:1234
-    # can we use the MaintenanceIncident#incident_id ?
+    # choose the last one based on the incident number (incremental sequence)
     possible_packages.each do |possible_package|
-      pkg = possible_package if pkg.nil? || possible_package.project.name.gsub(/.*:/, '').to_i > pkg.project.name.gsub(/.*:/, '').to_i
+      pkg = possible_package if pkg.nil? || possible_package.project.incident_id > pkg.project.incident_id
     end
     pkg
   end

--- a/src/api/spec/models/branch_package/lookup_incident_package_spec.rb
+++ b/src/api/spec/models/branch_package/lookup_incident_package_spec.rb
@@ -1,0 +1,82 @@
+require 'rails_helper'
+
+RSpec.describe BranchPackage::LookupIncidentPackage, vcr: false do
+  let(:user) { create(:confirmed_user, :with_home, login: 'tom') }
+
+  before do
+    login user
+  end
+
+  describe 'incident_package' do
+    let(:link_target_project) { create(:project, name: 'openSUSE:Maintenance') }
+    let(:maintenance_project) { create(:maintenance_project, target_project: link_target_project) }
+    let(:package_1) { create(:package, name: 'chromium', project: link_target_project) }
+    let!(:lookup_incident_package) do
+      BranchPackage::LookupIncidentPackage.new(package: package_1,
+                                               maintenance_project: maintenance_project, link_target_project: link_target_project)
+    end
+    let(:xml_response) do
+      <<~XML_BODY
+        <collection>
+          <package name=\"chromium.openSUSE_Leap_15.1_Update\" project=\"openSUSE:Maintenance:10258\"/>
+          <package name=\"chromium.openSUSE_Leap_15.1_Update\" project=\"openSUSE:Maintenance:11261\"/>
+        </collection>
+      XML_BODY
+    end
+
+    before do
+      allow(Backend::Api::Search).to receive(:incident_packages).and_return(xml_response)
+    end
+
+    subject { lookup_incident_package.incident_packages(link_target_project) }
+
+    it { expect(subject.xpath('//collection')).not_to be_empty }
+    it { expect(subject.xpath('//collection//package').count).to eq(2) }
+  end
+
+  describe 'possible_packages' do
+    let!(:project_1) do
+      create(:project_with_package, package_name: 'chromium.openSUSE_Leap_15.1_Update',
+                                    name: 'openSUSE:Maintenance:11261')
+    end
+
+    let(:package_1) { project_1.packages.first }
+    let(:lookup_incident_package) { BranchPackage::LookupIncidentPackage.new(package: 'chromium', link_target_project: 'openSUSE:Leap:15.01:Update') }
+
+    let(:xml_response) do
+      <<~XML_BODY
+        <collection>
+          <package name=\"chromium.openSUSE_Leap_15.1_Update\" project=\"openSUSE:Maintenance:11261\"/>
+        </collection>
+      XML_BODY
+    end
+
+    before do
+      allow_any_instance_of(BranchPackage::LookupIncidentPackage).to receive(:incident_packages).and_return(Nokogiri::XML(xml_response))
+      allow(Package).to receive(:find_by_project_and_name).with(project_1.name, package_1.name).and_return(package_1)
+      allow_any_instance_of(Project).to receive(:is_maintenance_incident?).and_return(true)
+      allow(Package).to receive(:find_by_project_and_name).with(project_1.name, package_1.name).and_return(package_1)
+    end
+
+    subject { lookup_incident_package.possible_packages('openSUSE:Maintenance') }
+
+    it { expect(subject).to be_instance_of(Array) }
+    it { expect(subject).not_to be_empty }
+    it { expect(subject).to include(project_1.packages.first) }
+  end
+
+  describe 'package' do
+    let(:link_target_project) { create(:project_with_package, name: 'openSUSE:Maintenance', package_name: 'chromium') }
+    let(:maintenance_project) { create(:maintenance_project, target_project: link_target_project) }
+    let(:package_1) { link_target_project.packages.first }
+    let(:lookup_incident_package) { BranchPackage::LookupIncidentPackage.new(package: 'chromium', link_target_project: link_target_project) }
+    before do
+      allow_any_instance_of(BranchPackage::LookupIncidentPackage).to receive(:possible_packages).and_return(link_target_project.packages)
+      allow_any_instance_of(BranchPackage::LookupIncidentPackage).to receive(:maintenance_projects).and_return([maintenance_project])
+    end
+
+    subject { lookup_incident_package.package }
+
+    it { expect(subject).to eq(package_1) }
+  end
+end


### PR DESCRIPTION
Refactoring the `BranchPackage` "method"

I extracted one more method in a class, beside it:

- Migrate usage of REXML to Nokogiri 
- Extract and Refactor methods
- Add spec for the new class
- Adapt branch_package

