### PR TITLE
Add filter for spec and test directory

### DIFF
--- a/src/api/spec/support/coverage.rb
+++ b/src/api/spec/support/coverage.rb
@@ -11,5 +11,9 @@ SimpleCov.start 'rails' do
   add_filter '/lib/templates/'
   add_filter '/lib/memory_debugger.rb'
   add_filter '/lib/memory_dumper.rb'
+
+  # filter spec directory not in sync with test/test_helper
+  add_filter 'spec'
+  add_filter 'test'
   merge_timeout 3600
 end


### PR DESCRIPTION
We should exclude the `test` and `spec` directories from simplecov coverage calculation

We can accomplish it using `add_filter` as explained here https://rubydoc.info/gems/simplecov/SimpleCov/Configuration#add_filter-instance_method