### PR TITLE
Introduces sphinx start task

### DIFF
--- a/dist/systemd/obs-sphinx.service
+++ b/dist/systemd/obs-sphinx.service
@@ -8,7 +8,7 @@ Environment = "RAILS_ENV=production"
 User = wwwrun
 Group = www
 WorkingDirectory = /srv/www/obs/api
-ExecStart = /bin/bash -c "if [ `stat -c '%s' /srv/www/obs/api/config/production.sphinx.conf` -eq 0 ]; then /usr/bin/bundle.ruby2.5 exec rails ts:rebuild; else /usr/bin/bundle.ruby2.5 exec rails ts:start; fi"
+ExecStart = /usr/bin/bundle.ruby2.5 exec rails sphinx:start
 ExecStop = /usr/bin/bundle.ruby2.5 exec rails ts:stop
 Type = forking
 PIDFile = /srv/www/obs/api/log/production.sphinx.pid

--- a/src/api/lib/tasks/sphinx.rake
+++ b/src/api/lib/tasks/sphinx.rake
@@ -1,0 +1,15 @@
+namespace :sphinx do
+  desc 'Start the sphinx daemon'
+  task start: :environment do
+    if index_to_build?
+      puts 'Index does not exist, creating it...'
+      Rake::Task['ts:rebuild'].invoke
+    else
+      Rake::Task['ts:start'].invoke
+    end
+  end
+end
+
+def index_to_build?
+  File.zero?("config/#{Rails.env}.sphinx.conf")
+end


### PR DESCRIPTION
Move the logic of when to build indexes while starting sphinx from the systemd unit
to a rake tasks so it's more robust and easier to understand.

<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn
how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md

In order to make it as easy as possible for other developers to review your
pull request we ask you to:

- Explain what this PR is about in the description
- Explain the steps the reviewer has to follow to verify your change
- If the reviewer needs sample data to verify your change, please explain how to
  create that data
- If you include visual changes in this PR, please add screenshots or GIFs
- If you address performance in this PR, add benchmark data or explain how the
  reviewer can benchmark this

This is a good PR description example:

Hey Friends,

this introduces labels for the different build result states on the project
monitor page. This makes it easier to get a visual overview of what is going on
in your project.

To verify this feature

- Enable the interconnect to build.opensuse.org
- Create the project home:Admin
- Add 'openSUSE Tumbleweed' as a repository to the project
- Branch a couple of packages into the project:
  ```
  for i in `osc -A http://0.0.0.0:3000 ls openSUSE.org:home:hennevogel`; do osc -A http://0.0.0.0:3000 copypac openSUSE.org:home:hennevogel $i home:Admin; done
  ```
- Visit the monitor page and see the new labels for the different states.

Here is a screenshot of how it looks:

** Before **
![Screenshot of the project monitor](https://example.com/screenshot1.png)

** After **
![Screenshot of the project monitor](https://example.com/screenshot2.png)

-->
