### PR TITLE
Simplify API staging projects results

### DIFF
--- a/docs/api/api/api.txt
+++ b/docs/api/api/api.txt
@@ -1940,12 +1940,24 @@ DELETE /staging/<staging_workflow_project>/workflow
   Delete a staging workflow associated to a given project.
 XmlResult: status_ok
 
-GET /staging/<staging_workflow_project>/staging_projects
-  Get the overall state of all staging projects belonging to a staging workflow project
+GET /staging/<staging_workflow_project>/staging_projects?requests=1&status=1&history=1
+  Get the overall state of all staging projects belonging to a staging workflow project.
+  Extra information can be requested by adding any combination of these parameters in the URL: requests, status and history.
+
+  - If requests is present, the output includes the staged requests.
+  - If status is present, the output includes the overall state and the status xml (broken packages, missing reviews, checks, etc.)
+  - If history is present, the output includes the history of the staging project.
+
 XmlResult: staging_projects
 
-GET /staging/<staging_workflow_project>/staging_projects/<staging_project>
-  Get the overall state of a staging project
+GET /staging/<staging_workflow_project>/staging_projects/<staging_project>?requests=1&status=1&history=1
+  Get the overall state of a staging project.
+  Extra information can be requested by adding any combination of these parameters in the URL: requests, status and history.
+
+  - If requests is present, the output includes the staged requests.
+  - If status is present, the output includes the overall state and the status xml (broken packages, missing reviews, checks, etc.)
+  - If history is present, the output includes the history of the staging project.
+
 XmlResult: staging_project
 
 POST /staging/<staging_workflow_project>/staging_projects/<staging_project>/copy/<staging_project_copy_name>

--- a/src/api/app/controllers/staging/staging_projects_controller.rb
+++ b/src/api/app/controllers/staging/staging_projects_controller.rb
@@ -2,6 +2,7 @@ class Staging::StagingProjectsController < Staging::StagingController
   before_action :require_login, except: [:index, :show]
   before_action :set_project
   before_action :set_staging_workflow, only: :create
+  before_action :set_options, only: [:index, :show]
 
   validate_action create: { method: :post, request: :staging_project }
 
@@ -58,5 +59,14 @@ class Staging::StagingProjectsController < Staging::StagingController
     end
     StagingProjectAcceptJob.perform_later(project_id: staging_project.id, user_login: User.session!.login)
     render_ok
+  end
+
+  private
+
+  def set_options
+    @options = {}
+    [:requests, :history, :status].each do |option|
+      @options[option] = params[option].present?
+    end
   end
 end

--- a/src/api/app/views/staging/staging_projects/_staging_project_item.xml.builder
+++ b/src/api/app/views/staging/staging_projects/_staging_project_item.xml.builder
@@ -1,24 +1,41 @@
-builder.staging_project(name: staging_project.name, state: staging_project.overall_state) do
-  builder.staged_requests(count: staging_project.staged_requests.count) do
-    render(partial: 'requests', locals: { requests: staging_project.staged_requests, builder: builder })
+attributes = { name: staging_project.name }
+attributes.merge!(state: staging_project.overall_state) if options[:status]
+
+builder.staging_project(attributes) do
+  if options[:requests]
+    builder.staged_requests(count: staging_project.staged_requests.count) do
+      render(partial: 'requests', locals: { requests: staging_project.staged_requests, builder: builder })
+    end
   end
-  builder.untracked_requests(count: staging_project.untracked_requests.count) do
-    render(partial: 'requests', locals: { requests: staging_project.untracked_requests, builder: builder })
+
+  if options[:status]
+    builder.untracked_requests(count: staging_project.untracked_requests.count) do
+      render(partial: 'requests', locals: { requests: staging_project.untracked_requests, builder: builder })
+    end
+    builder.requests_to_review(count: staging_project.requests_to_review.count) do
+      render(partial: 'requests', locals: { requests: staging_project.requests_to_review, builder: builder })
+    end
+    builder.obsolete_requests(count: staging_project.staged_requests.obsolete.count) do
+      render(partial: 'requests', locals: { requests: staging_project.staged_requests.obsolete, builder: builder })
+    end
+    render(partial: 'missing_reviews', locals: { missing_reviews: staging_project.missing_reviews,
+                                                 count: staging_project.missing_reviews.count,
+                                                 builder: builder })
+    render(partial: 'building_repositories', locals: { building_repositories: staging_project.building_repositories,
+                                                       count: staging_project.building_repositories.count,
+                                                       builder: builder })
+    render(partial: 'broken_packages', locals: { broken_packages: staging_project.broken_packages,
+                                                 count: staging_project.broken_packages.count,
+                                                 builder: builder })
+    render(partial: 'checks', locals: { checks: staging_project.checks, builder: builder })
+    render(partial: 'missing_checks', locals: { missing_checks: staging_project.missing_checks, builder: builder })
   end
-  builder.requests_to_review(count: staging_project.requests_to_review.count) do
-    render(partial: 'requests', locals: { requests: staging_project.requests_to_review, builder: builder })
-  end
-  builder.obsolete_requests(count: staging_project.staged_requests.obsolete.count) do
-    render(partial: 'requests', locals: { requests: staging_project.staged_requests.obsolete, builder: builder })
-  end
-  render(partial: 'missing_reviews', locals: { missing_reviews: staging_project.missing_reviews, count: staging_project.missing_reviews.count, builder: builder })
-  render(partial: 'building_repositories', locals: { building_repositories: staging_project.building_repositories, count: staging_project.building_repositories.count, builder: builder })
-  render(partial: 'broken_packages', locals: { broken_packages: staging_project.broken_packages, count: staging_project.broken_packages.count, builder: builder })
-  render(partial: 'checks', locals: { checks: staging_project.checks, builder: builder })
-  render(partial: 'missing_checks', locals: { missing_checks: staging_project.missing_checks, builder: builder })
-  builder.history(count: staging_project.project_log_entries.where(event_type: [:staged_request, :unstaged_request]).count) do
-    render(partial: 'history_elements', locals: { builder: builder,
-                                                  elements: staging_project.project_log_entries.where(event_type:
-                                                                                                      [:staged_request, :unstaged_request]).includes(:bs_request) })
+
+  if options[:history]
+    builder.history(count: staging_project.project_log_entries.where(event_type: [:staged_request, :unstaged_request]).count) do
+      render(partial: 'history_elements', locals: { builder: builder,
+                                                    elements: staging_project.project_log_entries.where(event_type:
+                                                      [:staged_request, :unstaged_request]).includes(:bs_request) })
+    end
   end
 end

--- a/src/api/app/views/staging/staging_projects/index.xml.builder
+++ b/src/api/app/views/staging/staging_projects/index.xml.builder
@@ -1,5 +1,5 @@
 xml.staging_projects do
   @staging_projects.each do |staging_project|
-    render(partial: 'staging_project_item', locals: { staging_project: staging_project, builder: xml })
+    render(partial: 'staging_project_item', locals: { staging_project: staging_project, options: @options, builder: xml })
   end
 end

--- a/src/api/app/views/staging/staging_projects/show.xml.builder
+++ b/src/api/app/views/staging/staging_projects/show.xml.builder
@@ -1,1 +1,1 @@
-render(partial: 'staging_project_item', locals: { staging_project: @staging_project, builder: xml })
+render(partial: 'staging_project_item', locals: { staging_project: @staging_project, options: @options, builder: xml })


### PR DESCRIPTION
When retrieving staging projects via API, only a minimal set of information is going to be shown. Any extra information like history, status or even staged requests can be ordered optionally by setting the corresponding parameter in the URL.

Examples:
  - `staging/<project>/staging_projects?requests=1&status=1`
  - `staging/<project>/staging_projects/<staging_project>?requests=1&status=1&history=1`

This fixes #8527 and fixes #8534 

<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn
how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md

In order to make it as easy as possible for other developers to review your
pull request we ask you to:

- Explain what this PR is about in the description
- Explain the steps the reviewer has to follow to verify your change
- If the reviewer needs sample data to verify your change, please explain how to
  create that data
- If you include visual changes in this PR, please add screenshots or GIFs
- If you address performance in this PR, add benchmark data or explain how the
  reviewer can benchmark this

This is a good PR description example:

Hey Friends,

this introduces labels for the different build result states on the project
monitor page. This makes it easier to get a visual overview of what is going on
in your project.

To verify this feature

- Enable the interconnect to build.opensuse.org
- Create the project home:Admin
- Add 'openSUSE Tumbleweed' as a repository to the project
- Branch a couple of packages into the project:
  ```
  for i in `osc -A http://0.0.0.0:3000 ls openSUSE.org:home:hennevogel`; do osc -A http://0.0.0.0:3000 copypac openSUSE.org:home:hennevogel $i home:Admin; done
  ```
- Visit the monitor page and see the new labels for the different states.

Here is a screenshot of how it looks:

** Before **
![Screenshot of the project monitor](https://example.com/screenshot1.png)

** After **
![Screenshot of the project monitor](https://example.com/screenshot2.png)

-->
