### PR TITLE
[backend] make clean_obsolete_dodpackages module aware

### DIFF
--- a/src/backend/BSSched/BuildRepo.pm
+++ b/src/backend/BSSched/BuildRepo.pm
@@ -994,7 +994,7 @@ sub addrepo_scan {
   return undef unless $r;
   # write solv file (unless alien arch)
   if ($dirty && $arch eq $gctx->{'arch'}) {
-    @bins = BSSched::DoD::clean_obsolete_dodpackages($r, $dir, @bins) if $doddata;
+    @bins = BSSched::DoD::clean_obsolete_dodpackages($pool, $r, $dir, @bins) if $doddata;
     writesolv("$dir.solv.new", "$dir.solv", $r);
   }
   $repocache->setcache($prp, $arch) if $repocache;

--- a/src/backend/bs_repserver
+++ b/src/backend/bs_repserver
@@ -134,22 +134,20 @@ sub fetchdodbinary {
   die("$path has an unsupported suffix\n") unless $path =~ /\.($binsufsre)$/;
   my $suf = $1;
   my $pkgname = $pool->pkg2name($p);
+  if (defined(&BSSolv::pool::pkg2inmodule) && $pool->pkg2inmodule($p)) {
+    $pkgname .= '-' . $pool->pkg2evr($p) . '.' . $pool->pkg2arch($p);
+  }
+  $pkgname .= ".$suf";
   BSVerify::verify_filename($pkgname);
   BSVerify::verify_simple($pkgname);
-  my $localname = "$reporoot/$reponame/$arch/:full/$pkgname.$suf";
-  if (defined(&BSSolv::pool::pkg2inmodule) && $pool->pkg2inmodule($p)) {
-    # use nevra for module packages
-    my $evr = $pool->pkg2evr($p);
-    my $arch = $pool->pkg2arch($p);
-    $localname = "$reporoot/$reponame/$arch/:full/$pkgname-$evr.$arch.$suf";
-  }
+  my $localname = "$reporoot/$reponame/$arch/:full/$pkgname";
   return $localname if -e $localname;
   # we really need to download, handoff to ajax if not already done
   BSHandoff::handoff(@$handoff) if $handoff && !$BSStdServer::isajax;
   my $url = $repo->dodurl();
   $url .= '/' unless $url =~ /\/$/;
   $url .= $pool->pkg2path($p);
-  my $tmp = "$reporoot/$reponame/$arch/:full/.dod.$$.$pkgname.$suf";
+  my $tmp = "$reporoot/$reponame/$arch/:full/.dod.$$.$pkgname";
   #print "fetching: $url\n";
   my $param = {'uri' => $url, 'filename' => $tmp, 'receiver' => \&BSHTTP::file_receiver, 'proxy' => $proxy};
   $param->{'maxredirects'} = $maxredirects if defined $maxredirects;

--- a/src/backend/bs_srcserver
+++ b/src/backend/bs_srcserver
@@ -4177,8 +4177,7 @@ sub getbinary {
     return published_path($cgi, $projid, $repoid);
   }
   my $reposerver = $BSConfig::partitioning ? BSSrcServer::Partition::projid2reposerver($projid) : $BSConfig::reposerver;
-  my @args;
-  push @args, "view=$view" if $view;
+  my @args = BSRPC::args($cgi, 'view', 'module');
   my $param = {
     'uri' => "$reposerver/build/$projid/$repoid/$arch/$packid/$filename",
     'ignorestatus' => 1,


### PR DESCRIPTION
<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn
how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md

In order to make it as easy as possible for other developers to review your
pull request we ask you to:

- Explain what this PR is about in the description
- Explain the steps the reviewer has to follow to verify your change
- If the reviewer needs sample data to verify your change, please explain how to
  create that data
- If you include visual changes in this PR, please add screenshots or GIFs
- If you address performance in this PR, add benchmark data or explain how the
  reviewer can benchmark this

This is a good PR description example:

Hey Friends,

this introduces labels for the different build result states on the project
monitor page. This makes it easier to get a visual overview of what is going on
in your project.

To verify this feature

- Enable the interconnect to build.opensuse.org
- Create the project home:Admin
- Add 'openSUSE Tumbleweed' as a repository to the project
- Branch a couple of packages into the project:
  ```
  for i in `osc -A http://0.0.0.0:3000 ls openSUSE.org:home:hennevogel`; do osc -A http://0.0.0.0:3000 copypac openSUSE.org:home:hennevogel $i home:Admin; done
  ```
- Visit the monitor page and see the new labels for the different states.

Here is a screenshot of how it looks:

** Before **
![Screenshot of the project monitor](https://example.com/screenshot1.png)

** After **
![Screenshot of the project monitor](https://example.com/screenshot2.png)

-->
