### PR TITLE
Disable 15.0 and 15.1 as valid distributions

### DIFF
--- a/src/api/app/models/obs_factory/distribution.rb
+++ b/src/api/app/models/obs_factory/distribution.rb
@@ -200,6 +200,7 @@ module ObsFactory
       s = case project.name
           when 'openSUSE:Factory' then DistributionStrategyFactory.new(staging_manager: 'factory-staging')
           when 'openSUSE:Factory:PowerPC' then DistributionStrategyFactoryPPC.new(staging_manager: 'factory-staging')
+          when /^openSUSE:Leap:15\.[01]/ then raise UnknownDistribution
           when /^openSUSE:Leap:15\.*/ then DistributionStrategyOpenSUSELeap15.new(staging_manager: 'factory-staging')
           when /^SUSE:.*CASP\d*$/ then DistributionStrategyFactory.new(staging_manager: 'caasp-staging-managers')
           when /^SUSE:.*Cloud\d*$/ then DistributionStrategyFactory.new(staging_manager: 'cloud-staging-managers')

--- a/src/api/spec/helpers/webui/obs_factory/application_helper_spec.rb
+++ b/src/api/spec/helpers/webui/obs_factory/application_helper_spec.rb
@@ -2,18 +2,18 @@ require 'rails_helper'
 
 RSpec.describe Webui::ObsFactory::ApplicationHelper, type: :helper do
   describe '#distribution_tests_link' do
-    let(:distribution) { ObsFactory::Distribution.new(create(:project, name: 'openSUSE:Leap:15.1')) }
+    let(:distribution) { ObsFactory::Distribution.new(create(:project, name: 'openSUSE:Leap:15.2')) }
 
     it 'creates a url to the openqa distribution tests' do
       expect(distribution_tests_url(distribution)).to eq(
-        'https://openqa.opensuse.org/tests/overview?distri=opensuse&version=15.1'
+        'https://openqa.opensuse.org/tests/overview?distri=opensuse&version=15.2'
       )
     end
 
     context 'when a version is provided' do
       it 'adds the version to the version to the url' do
         expect(distribution_tests_url(distribution, 'my_version')).to eq(
-          'https://openqa.opensuse.org/tests/overview?distri=opensuse&version=15.1&build=my_version'
+          'https://openqa.opensuse.org/tests/overview?distri=opensuse&version=15.2&build=my_version'
         )
       end
     end

--- a/src/api/spec/models/obs_factory/distribution_spec.rb
+++ b/src/api/spec/models/obs_factory/distribution_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe ObsFactory::Distribution do
 
     it { expect(distribution.strategy).to                    be_kind_of(ObsFactory::DistributionStrategyFactory) }
     it { expect(strategy_for('openSUSE:Factory:PowerPC')).to be_kind_of(ObsFactory::DistributionStrategyFactoryPPC) }
-    it { expect(strategy_for('openSUSE:Leap:15.1')).to be_kind_of(ObsFactory::DistributionStrategyOpenSUSELeap15) }
+    it { expect(strategy_for('openSUSE:Leap:15.2')).to be_kind_of(ObsFactory::DistributionStrategyOpenSUSELeap15) }
     it { expect(strategy_for('SUSE:SLE-12-SP1:GA')).to       be_kind_of(ObsFactory::DistributionStrategyFactory) }
     it { expect(strategy_for('SUSE:SLE-15:GA')).to           be_kind_of(ObsFactory::DistributionStrategyFactory) }
     it { expect(strategy_for('SUSE:SLE-15-SP1:GA')).to       be_kind_of(ObsFactory::DistributionStrategyFactory) }
@@ -22,6 +22,7 @@ RSpec.describe ObsFactory::Distribution do
 
     it { expect { strategy_for('openSUSE:42.3') }.to raise_error(ObsFactory::UnknownDistribution) }
     it { expect { strategy_for('openSUSE:Leap:42.3') }.to raise_error(ObsFactory::UnknownDistribution) }
+    it { expect { strategy_for('openSUSE:Leap:15.1') }.to raise_error(ObsFactory::UnknownDistribution) }
 
     def manager_for(name)
       strategy_for(name).staging_manager

--- a/src/api/spec/models/obs_factory/distribution_strategy_opensuse_leap15_spec.rb
+++ b/src/api/spec/models/obs_factory/distribution_strategy_opensuse_leap15_spec.rb
@@ -2,16 +2,16 @@ require 'rails_helper'
 require 'webmock/rspec'
 
 RSpec.describe ObsFactory::DistributionStrategyOpenSUSELeap15 do
-  let(:project) { create(:project, name: 'openSUSE:Leap:15.1') }
+  let(:project) { create(:project, name: 'openSUSE:Leap:15.2') }
   let(:distribution) { ObsFactory::Distribution.new(project) }
   let(:strategy) { distribution.strategy }
 
   describe '#openqa_version' do
-    it { expect(strategy.openqa_version).to eq('15.1') }
+    it { expect(strategy.openqa_version).to eq('15.2') }
   end
 
   describe '#opensuse_leap_version' do
-    it { expect(strategy.opensuse_leap_version).to eq('15.1') }
+    it { expect(strategy.opensuse_leap_version).to eq('15.2') }
   end
 
   describe '#openqa_group' do
@@ -19,11 +19,11 @@ RSpec.describe ObsFactory::DistributionStrategyOpenSUSELeap15 do
   end
 
   describe '#repo_url' do
-    it { expect(strategy.repo_url).to eq('http://download.opensuse.org/distribution/leap/15.1/repo/oss/media.1/media') }
+    it { expect(strategy.repo_url).to eq('http://download.opensuse.org/distribution/leap/15.2/repo/oss/media.1/media') }
   end
 
   describe '#url_suffix' do
-    it { expect(strategy.url_suffix).to eq('distribution/leap/15.1/iso') }
+    it { expect(strategy.url_suffix).to eq('distribution/leap/15.2/iso') }
   end
 
   describe '#published_arch' do
@@ -39,7 +39,7 @@ RSpec.describe ObsFactory::DistributionStrategyOpenSUSELeap15 do
   end
 
   describe '#published_version' do
-    let(:file) { "openSUSE - openSUSE-15.1-x86_64-Build317.2-Media\nopenSUSE-15.1-x86_64-Build317.2\n1" }
+    let(:file) { "openSUSE - openSUSE-15.2-x86_64-Build317.2-Media\nopenSUSE-15.2-x86_64-Build317.2\n1" }
 
     before do
       stub_request(:get, strategy.repo_url).and_return(body: file)

--- a/src/api/spec/models/obs_factory/staging_project_spec.rb
+++ b/src/api/spec/models/obs_factory/staging_project_spec.rb
@@ -10,9 +10,9 @@ RSpec.describe ObsFactory::StagingProject do
   let!(:staging_b_dvd) { create(:project, name: 'openSUSE:Factory:Staging:B:DVD') }
   let!(:staging_c) { create(:project, name: 'openSUSE:Factory:Staging:C') }
   let!(:staging_c_dvd) { create(:project, name: 'openSUSE:Factory:Staging:C:DVD') }
-  let(:opensuse_leap) { create(:project, name: 'openSUSE:Leap:15.1') }
-  let!(:opensuse_staging_a) { create(:project, name: 'openSUSE:Leap:15.1:Staging:A') }
-  let!(:opensuse_staging_b) { create(:project, name: 'openSUSE:Leap:15.1:Staging:B') }
+  let(:opensuse_leap) { create(:project, name: 'openSUSE:Leap:15.2') }
+  let!(:opensuse_staging_a) { create(:project, name: 'openSUSE:Leap:15.2:Staging:A') }
+  let!(:opensuse_staging_b) { create(:project, name: 'openSUSE:Leap:15.2:Staging:B') }
   let(:factory_distribution) { ObsFactory::Distribution.find(factory.name) }
   let(:staging_project_a) { ObsFactory::StagingProject.new(project: staging_a, distribution: factory_distribution) }
   let(:staging_project_adi) { ObsFactory::StagingProject.new(project: staging_adi, distribution: factory_distribution) }
@@ -31,7 +31,7 @@ RSpec.describe ObsFactory::StagingProject do
       it { expect(subject.map(&:project)).to eq([staging_a, staging_b, staging_c]) }
     end
 
-    context 'openSUSE:Leap:15.1' do
+    context 'openSUSE:Leap:15.2' do
       let(:opensuse_distribution) { ObsFactory::Distribution.find(opensuse_leap.name) }
       subject { ObsFactory::StagingProject.for(opensuse_distribution) }
 


### PR DESCRIPTION
We only care for openSUSE Leap 15.2 going forward

Co-authored-by: @lnussel 