### PR TITLE
Run sphinx after OBS api setup is done

### DIFF
--- a/dist/systemd/obs-sphinx.service
+++ b/dist/systemd/obs-sphinx.service
@@ -2,6 +2,7 @@
 Description = Open Build Service Sphinx Search Daemon
 BindsTo = obs-api-support.target
 Conflicts = searchd.service
+After = obsapisetup.service
 
 [Service]
 Environment = "RAILS_ENV=production"


### PR DESCRIPTION
This way we prevent Sphinx to throw errors of connection to mariadb when the setup of OBS is not finished. This happens the first time the appliance is booted.

Co-authored-by: Henne Vogelsang <hvogel@opensuse.org>
