### PR TITLE
Add more attributes to requests' XML

### DIFF
--- a/src/api/app/views/staging/shared/_requests.xml.builder
+++ b/src/api/app/views/staging/shared/_requests.xml.builder
@@ -3,5 +3,7 @@ requests.each do |bs_request|
                   type: bs_request.bs_request_actions.first.action_type,
                   creator: bs_request.creator,
                   state: bs_request.state,
-                  package: bs_request.first_target_package)
+                  package: bs_request.first_target_package,
+                  superseded_by: bs_request.superseded_by,
+                  updated: bs_request.updated_at.xmlschema)
 end

--- a/src/api/app/views/staging/staging_projects/_requests.xml.builder
+++ b/src/api/app/views/staging/staging_projects/_requests.xml.builder
@@ -1,3 +1,0 @@
-requests.each do |request|
-  builder.request(id: request.number, creator: request.creator, state: request.state, package: request.first_target_package)
-end

--- a/src/api/app/views/staging/staging_projects/_staging_project_item.xml.builder
+++ b/src/api/app/views/staging/staging_projects/_staging_project_item.xml.builder
@@ -4,19 +4,19 @@ attributes.merge!(state: staging_project.overall_state) if options[:status]
 builder.staging_project(attributes) do
   if options[:requests]
     builder.staged_requests(count: staging_project.staged_requests.count) do
-      render(partial: 'requests', locals: { requests: staging_project.staged_requests, builder: builder })
+      render(partial: 'staging/shared/requests', locals: { requests: staging_project.staged_requests, builder: builder })
     end
   end
 
   if options[:status]
     builder.untracked_requests(count: staging_project.untracked_requests.count) do
-      render(partial: 'requests', locals: { requests: staging_project.untracked_requests, builder: builder })
+      render(partial: 'staging/shared/requests', locals: { requests: staging_project.untracked_requests, builder: builder })
     end
     builder.requests_to_review(count: staging_project.requests_to_review.count) do
-      render(partial: 'requests', locals: { requests: staging_project.requests_to_review, builder: builder })
+      render(partial: 'staging/shared/requests', locals: { requests: staging_project.requests_to_review, builder: builder })
     end
     builder.obsolete_requests(count: staging_project.staged_requests.obsolete.count) do
-      render(partial: 'requests', locals: { requests: staging_project.staged_requests.obsolete, builder: builder })
+      render(partial: 'staging/shared/requests', locals: { requests: staging_project.staged_requests.obsolete, builder: builder })
     end
     render(partial: 'missing_reviews', locals: { missing_reviews: staging_project.missing_reviews,
                                                  count: staging_project.missing_reviews.count,


### PR DESCRIPTION
There are different calls to the API where requests' XML is given as result: when retrieving staged requests, backlog requests or even staging projects with the 'requests' option set to truthy.

For those three cases the code has been unified and the XML include attributes like 'superseded_by' and 'updated_at' in addition to 'id/number', 'type', 'package', 'creator' and 'state'.

Fixes: #8540

Before:
```
  <staged_requests count="2">
    <request id="1" type="submit" creator="requester_2_1572891366_0" state="new" package="target_package_2_1572891366_0"/>                                                  
    <request id="2" type="submit" creator="requester_2_1572891366_1" state="new" package="target_package_2_1572891366_1"/>                                                  
  </staged_requests>
```

After:
```
<staged_requests>
  <request id="1" type="submit" creator="requester_2_1572891366_0" state="new" package="target_package_2_1572891366_0" superseded_by="" updated="2019-11-04T18:16:17Z"/>
  <request id="2" type="submit" creator="requester_2_1572891366_1" state="new" package="target_package_2_1572891366_1" superseded_by="" updated="2019-11-04T18:16:21Z"/>
</staged_requests>
```

How to test?
```
osc api -X GET 'staging/<project>/staging_projects/<staging_project>/staged_requests'

osc api -X GET 'staging/<project>/backlog'

osc api -X GET '/staging/<project>/staging_projects/<staging_project>?requests=1'
```

<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn
how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md

In order to make it as easy as possible for other developers to review your
pull request we ask you to:

- Explain what this PR is about in the description
- Explain the steps the reviewer has to follow to verify your change
- If the reviewer needs sample data to verify your change, please explain how to
  create that data
- If you include visual changes in this PR, please add screenshots or GIFs
- If you address performance in this PR, add benchmark data or explain how the
  reviewer can benchmark this

This is a good PR description example:

Hey Friends,

this introduces labels for the different build result states on the project
monitor page. This makes it easier to get a visual overview of what is going on
in your project.

To verify this feature

- Enable the interconnect to build.opensuse.org
- Create the project home:Admin
- Add 'openSUSE Tumbleweed' as a repository to the project
- Branch a couple of packages into the project:
  ```
  for i in `osc -A http://0.0.0.0:3000 ls openSUSE.org:home:hennevogel`; do osc -A http://0.0.0.0:3000 copypac openSUSE.org:home:hennevogel $i home:Admin; done
  ```
- Visit the monitor page and see the new labels for the different states.

Here is a screenshot of how it looks:

** Before **
![Screenshot of the project monitor](https://example.com/screenshot1.png)

** After **
![Screenshot of the project monitor](https://example.com/screenshot2.png)

-->
