### PR TITLE
Create Sphinx start Rails task for development environment

### DIFF
--- a/src/api/Procfile
+++ b/src/api/Procfile
@@ -1,5 +1,5 @@
 web: bundle exec rails server -b 0.0.0.0
 delayed: bundle exec script/delayed_job.api.rb run
 clock: bundle exec clockworkd --log-dir=log -l -c config/clock.rb run
-search: (sleep 60 && bundle exec rake ts:rt:index) & bundle exec rake ts:rebuild NODETACH=true && fg
+search: bundle exec rails sphinx:start_for_development
 mailcatcher: mailcatcher --ip 0.0.0.0 -f --no-quit -v

--- a/src/api/lib/tasks/sphinx.rake
+++ b/src/api/lib/tasks/sphinx.rake
@@ -8,8 +8,31 @@ namespace :sphinx do
       Rake::Task['ts:start'].invoke
     end
   end
+
+  desc 'Start the sphinx daemon for the development environment'
+  task start_for_development: :environment do
+    if index_to_build?
+      Rake::Task['ts:clear'].invoke
+      Rake::Task['ts:configure'].invoke
+      t = Thread.new do
+        retries = 0
+        sphinx_is_running = false
+        while !sphinx_is_running && retries < 10
+          sleep(5)
+          sphinx_is_running = `rails ts:status`.chomp == 'The Sphinx daemon searchd is currently running.'
+          retries += 1
+        end
+        Rake::Task['ts:rt:index'].invoke if sphinx_is_running
+      end
+      sh('rails ts:start NODETACH=true')
+      t.join
+    else
+      exec('rails ts:start NODETACH=true')
+    end
+  end
 end
 
 def index_to_build?
-  File.zero?("config/#{Rails.env}.sphinx.conf")
+  filename = "config/#{Rails.env}.sphinx.conf"
+  !File.file?(filename) || File.zero?(filename)
 end


### PR DESCRIPTION
Provide a way to reindex Sphinx when it is started in `NODETACHED` mode. This is only needed in development environment.

The check for rebuilding the configuration of the index was modified to include the condition of no existence of the `config/*.sphinx.conf` file. That is the case of the development environment.

This is a workaround until pat/thinking-sphinx#1150 is fixed.