### PR TITLE
Fix cpeid handling and add support for the ymp distversion attribute

### DIFF
--- a/src/backend/bs_publish
+++ b/src/backend/bs_publish
@@ -82,6 +82,8 @@ my $binsufsre = join('|', map {"\Q$_\E"} @binsufs);
 my @binsufsrsync = map {"--include=*.$_"} @binsufs;
 my $binarchs = join("|", keys(%BSCando::knownarch));
 
+my $trackercacheversion = 2;
+
 my $testmode;
 
 # convert hooks with filenames to real code refs
@@ -2321,7 +2323,7 @@ sub publish {
   my $packtrackcache;
   if (-s "$reporoot/$prp/:repoinfo") {
     $oldrepoinfo = BSUtil::retrieve("$reporoot/$prp/:repoinfo");
-    $packtrackcache = $oldrepoinfo->{'trackercache'} if $oldrepoinfo->{'trackercache'} && ($oldrepoinfo->{'trackercacheversion'} || '') eq '1';
+    $packtrackcache = $oldrepoinfo->{'trackercache'} if $oldrepoinfo->{'trackercache'} && ($oldrepoinfo->{'trackercacheversion'} || '') eq $trackercacheversion;
     $publishid = $oldrepoinfo->{'publishid'} + 1 if $oldrepoinfo->{'publishid'};
   }
   $publishid ||= $starttime;
@@ -2383,7 +2385,7 @@ sub publish {
 	next unless @s;
 	my $c = $cache{"$bin/$s[9]/$s[7]/$s[1]"};
 	if ($c) {
-	  my @d = qw{arch name epoch version release disturl buildtime provides};
+	  my @d = qw{arch name epoch version release disturl buildtime cpeid};
 	  $res = {};
 	  for (@$c) {
 	    my $dd = shift @d;
@@ -2394,6 +2396,12 @@ sub publish {
             $res = Build::query("$extrep/$bin", 'evra' => 1, 'buildtime' => 1, 'disturl' => 1);
 	  };
 	  next unless $res;
+          # catch provided product cpeid strings
+	  my ($cpeid) = grep {/^product-cpeid\(\)/} @{$res->{'provides'} || []};
+	  if ($cpeid) {
+	    $cpeid =~ s/.* = //;
+	    $res->{'cpeid'} = BSHTTP::urldecode($cpeid);
+	  }
 	}
 	my $pt = { 'project' => $projid, 'repository' => $repoid };
 	$pt->{'arch'} = $1 if $bins{$bin} =~ /^\Q$reporoot\E\/\Q$prp\E\/([^\/]+)\//;
@@ -2404,11 +2412,7 @@ sub publish {
 	$pt->{'binaryarch'} = $res->{'arch'} if defined $res->{'arch'};
 	$pt->{'binaryid'} = $res->{'hdrmd5'} if defined $res->{'hdrmd5'};
 	$pt->{'id'} = "$bin/$s[9]/$s[7]/$s[1]";
-        # catch provided product cpeid strings
-        if (my ($cpeid) = grep {$_ =~ m/^product-cpeid\(\)/} @{$res->{"provides"}}) {
-          $cpeid =~ s/.* = //;
-          $pt->{'cpeid'} = BSHTTP::urldecode($cpeid);
-        }
+	$pt->{'cpeid'} = $res->{'cpeid'} if $res->{'cpeid'};
 	$packtrack->{$bin} = $pt;
 	if ($pt->{'arch'}) {
 	  $reportfile = $bin;
@@ -2779,12 +2783,12 @@ publishprog_done:
     my @newcache;
     for my $pt (values %$packtrack) {
       my $id = delete $pt->{'id'};
-      push @newcache, $id, [ map {$pt->{$_ eq 'arch' ? 'binaryarch' : $_}} qw{arch name epoch version release disturl buildtime} ] if $id;
+      push @newcache, $id, [ map {$pt->{$_ eq 'arch' ? 'binaryarch' : $_}} qw{arch name epoch version release disturl buildtime cpeid} ] if $id;
     }
     $repoinfo = BSUtil::retrieve("$reporoot/$prp/:repoinfo", 1) || {};
     if (%$repoinfo) {
       $repoinfo->{'trackercache'} = \@newcache;
-      $repoinfo->{'trackercacheversion'} = '1';
+      $repoinfo->{'trackercacheversion'} = $trackercacheversion;
       BSUtil::store("$reporoot/$prp/.:repoinfo", "$reporoot/$prp/:repoinfo", $repoinfo);
       @newcache = ();	# free mem
       undef $repoinfo;	# free mem

--- a/src/backend/bs_publish
+++ b/src/backend/bs_publish
@@ -54,6 +54,7 @@ use BSVerify;
 use BSStdRunner;
 use BSUrlmapper;
 use BSPGP;
+use BSHTTP;
 use BSRepServer::Containerinfo;
 use BSPublisher::Container;
 use BSPublisher::Util;
@@ -1345,6 +1346,13 @@ sub createpatterns_ymp {
     %nprojpack = map {$_->{'name'} => $_} @{$nprojpack->{'project'} || []};
   }
 
+  # get ymp distversion list from config
+  my @ympdist;
+  for (@{$data->{'config'}->{'publishflags'} || []}) {
+    push @ympdist, BSHTTP::urldecode($1) if /^ympdist:(.*)$/s;
+  }
+  @ympdist = BSUtil::unify(@ympdist) if @ympdist;
+
   for my $pattern (@$patterns) {
     my $ympname = $pattern->{'name'};
     $ympname =~ s/\.xml$//;
@@ -1400,7 +1408,8 @@ sub createpatterns_ymp {
       fillpkgdescription($software[-1], $extrep, $repoinfo, $entry->{'name'});
     }
     $group->{'software'} = { 'item' => \@software };
-    $ymp->{'group'} = [ $group ];
+    push @{$ymp->{'group'}}, { %$group, 'distversion' => $_ } for @ympdist;
+    $ymp->{'group'} ||= [ $group ];
 
     writexml("$extrep/.$ympname", "$extrep/$ympname", $ymp, $BSXML::ymp);
 
@@ -2652,6 +2661,7 @@ sub publish {
     'packtrack' => $packtrack,
     'repotags' => \@repotags,
     'chksumfiles' => \@chksumfiles,
+    'config' => $config,
   };
 
   if ($repotype{'rpm-md'}) {

--- a/src/backend/bs_srcserver
+++ b/src/backend/bs_srcserver
@@ -5048,7 +5048,7 @@ sub published {
   if (defined($projid) && defined($repoid) && $cgi->{'view'} && $cgi->{'view'} eq 'ymp') {
     # attach projpack data so that the repo server does not need to
     # reconnect us
-    $projpack = (getprojpack({'nopackages' => 1, 'withrepos' => 1, 'expandedrepos' => 1}, [ $projid ], [ $repoid ], undef, 'noarch'))[0];
+    $projpack = (getprojpack({'nopackages' => 1, 'withrepos' => 1, 'expandedrepos' => 1, 'withconfig' => 1}, [ $projid ], [ $repoid ], undef, 'noarch'))[0];
     my $proj = $projpack->{'project'}->[0];
     die("no such project\n") unless $proj && $proj->{'name'} eq $projid;
     my $repo = $proj->{'repository'}->[0];
@@ -5057,11 +5057,12 @@ sub published {
     my @nprojids = grep {$_ ne $projid} map {$_->{'project'}} @{$repo->{'path'} || []};
     @nprojids = BSUtil::unify(@nprojids);
     for my $nprojid (@nprojids) {
-      my $nproj = (getproject({}, $nprojid))[0];
+      my $nproj = (getproject({'withconfig' => 1}, $nprojid))[0];
       push @{$projpack->{'project'}}, {
 	'name' => $nprojid,
 	'title' => $nproj->{'title'} || '',
 	'description' => $nproj->{'description'} || '',
+	'config' => $nproj->{'config'} || '',
       };
     }
   }


### PR DESCRIPTION
<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn
how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md

In order to make it as easy as possible for other developers to review your
pull request we ask you to:

- Explain what this PR is about in the description
- Explain the steps the reviewer has to follow to verify your change
- If the reviewer needs sample data to verify your change, please explain how to
  create that data
- If you include visual changes in this PR, please add screenshots or GIFs
- If you address performance in this PR, add benchmark data or explain how the
  reviewer can benchmark this

This is a good PR description example:

Hey Friends,

this introduces labels for the different build result states on the project
monitor page. This makes it easier to get a visual overview of what is going on
in your project.

To verify this feature

- Enable the interconnect to build.opensuse.org
- Create the project home:Admin
- Add 'openSUSE Tumbleweed' as a repository to the project
- Branch a couple of packages into the project:
  ```
  for i in `osc -A http://0.0.0.0:3000 ls openSUSE.org:home:hennevogel`; do osc -A http://0.0.0.0:3000 copypac openSUSE.org:home:hennevogel $i home:Admin; done
  ```
- Visit the monitor page and see the new labels for the different states.

Here is a screenshot of how it looks:

** Before **
![Screenshot of the project monitor](https://example.com/screenshot1.png)

** After **
![Screenshot of the project monitor](https://example.com/screenshot2.png)

-->
