### PR TITLE
Replace request number by package name in excluded requests

### DIFF
--- a/src/api/app/datatables/excluded_request_datatable.rb
+++ b/src/api/app/datatables/excluded_request_datatable.rb
@@ -10,7 +10,7 @@ class ExcludedRequestDatatable < Datatable
 
   def view_columns
     @view_columns ||= {
-      request: { source: 'BsRequest.number', cond: :like },
+      request: { source: 'BsRequestAction.target_package', cond: :like },
       description: { source: 'Staging::RequestExclusion.description', cond: :like }
     }
   end
@@ -18,7 +18,7 @@ class ExcludedRequestDatatable < Datatable
   def data
     records.map do |record|
       {
-        request: link_to(record.bs_request.number, request_show_path(record.bs_request.number)),
+        request: link_to(record.bs_request.first_target_package, request_show_path(record.bs_request.number)),
         description: record.description,
         actions: process_policy(record)
       }
@@ -27,7 +27,7 @@ class ExcludedRequestDatatable < Datatable
 
   # rubocop:disable Naming/AccessorMethodName
   def get_raw_records
-    @staging_workflow.request_exclusions.includes(:bs_request)
+    @staging_workflow.request_exclusions.includes(bs_request: :bs_request_actions).references(:bs_request).distinct
   end
   # rubocop:enable Naming/AccessorMethodName
 

--- a/src/api/app/views/staging/excluded_requests/index.xml.builder
+++ b/src/api/app/views/staging/excluded_requests/index.xml.builder
@@ -1,5 +1,7 @@
 xml.excluded_requests do
   @request_exclusions.each do |request_exclusion|
-    xml.request(id: request_exclusion.bs_request.number, description: request_exclusion.description)
+    xml.request(id: request_exclusion.bs_request.number,
+                package: request_exclusion.bs_request.first_target_package,
+                description: request_exclusion.description)
   end
 end

--- a/src/api/spec/controllers/staging/excluded_requests_controller_spec.rb
+++ b/src/api/spec/controllers/staging/excluded_requests_controller_spec.rb
@@ -41,6 +41,11 @@ RSpec.describe Staging::ExcludedRequestsController do
     it 'returns the excluded_requests xml' do
       assert_select 'excluded_requests', 1 do
         assert_select 'request', 2 do
+          assert_select "[id='#{bs_request.number}']"
+          assert_select "[id='#{bs_request_2.number}']"
+          assert_select "[package='#{bs_request.first_target_package}']"
+          assert_select "[package='#{bs_request_2.first_target_package}']"
+          assert_select "[description='Request 2']"
           assert_select "[description='Request 1']"
           assert_select "[description='Request 2']"
         end


### PR DESCRIPTION
In both webui and API, excluded requests list shows the package name, before there was only the request number.

Fixes: #8524

How to test?

```
osc api -X GET '/staging/<project>/excluded_requests'
```
or in webui

```
/staging_workflows/<staging_workflow_id>/excluded_requests
```

<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn
how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md

In order to make it as easy as possible for other developers to review your
pull request we ask you to:

- Explain what this PR is about in the description
- Explain the steps the reviewer has to follow to verify your change
- If the reviewer needs sample data to verify your change, please explain how to
  create that data
- If you include visual changes in this PR, please add screenshots or GIFs
- If you address performance in this PR, add benchmark data or explain how the
  reviewer can benchmark this

This is a good PR description example:

Hey Friends,

this introduces labels for the different build result states on the project
monitor page. This makes it easier to get a visual overview of what is going on
in your project.

To verify this feature

- Enable the interconnect to build.opensuse.org
- Create the project home:Admin
- Add 'openSUSE Tumbleweed' as a repository to the project
- Branch a couple of packages into the project:
  ```
  for i in `osc -A http://0.0.0.0:3000 ls openSUSE.org:home:hennevogel`; do osc -A http://0.0.0.0:3000 copypac openSUSE.org:home:hennevogel $i home:Admin; done
  ```
- Visit the monitor page and see the new labels for the different states.

Here is a screenshot of how it looks:

** Before **
![Screenshot of the project monitor](https://example.com/screenshot1.png)

** After **
![Screenshot of the project monitor](https://example.com/screenshot2.png)

-->
