### PR TITLE
Re-organize staging projects XML results

### DIFF
--- a/docs/api/api/api.txt
+++ b/docs/api/api/api.txt
@@ -1944,7 +1944,7 @@ GET /staging/<staging_workflow_project>/staging_projects?requests=1&status=1&his
   Get the overall state of all staging projects belonging to a staging workflow project.
   Extra information can be requested by adding any combination of these parameters in the URL: requests, status and history.
 
-  - If requests is present, the output includes the staged requests.
+  - If requests is present, the output includes the staged, untracked and obsole requests as well as missing reviews.
   - If status is present, the output includes the overall state and the status xml (broken packages, missing reviews, checks, etc.)
   - If history is present, the output includes the history of the staging project.
 
@@ -1954,7 +1954,7 @@ GET /staging/<staging_workflow_project>/staging_projects/<staging_project>?reque
   Get the overall state of a staging project.
   Extra information can be requested by adding any combination of these parameters in the URL: requests, status and history.
 
-  - If requests is present, the output includes the staged requests.
+  - If requests is present, the output includes the staged, untracked and obsole requests as well as missing reviews.
   - If status is present, the output includes the overall state and the status xml (broken packages, missing reviews, checks, etc.)
   - If history is present, the output includes the history of the staging project.
 

--- a/src/api/app/views/staging/staging_projects/_staging_project_item.xml.builder
+++ b/src/api/app/views/staging/staging_projects/_staging_project_item.xml.builder
@@ -6,14 +6,8 @@ builder.staging_project(attributes) do
     builder.staged_requests(count: staging_project.staged_requests.count) do
       render(partial: 'staging/shared/requests', locals: { requests: staging_project.staged_requests, builder: builder })
     end
-  end
-
-  if options[:status]
     builder.untracked_requests(count: staging_project.untracked_requests.count) do
       render(partial: 'staging/shared/requests', locals: { requests: staging_project.untracked_requests, builder: builder })
-    end
-    builder.requests_to_review(count: staging_project.requests_to_review.count) do
-      render(partial: 'staging/shared/requests', locals: { requests: staging_project.requests_to_review, builder: builder })
     end
     builder.obsolete_requests(count: staging_project.staged_requests.obsolete.count) do
       render(partial: 'staging/shared/requests', locals: { requests: staging_project.staged_requests.obsolete, builder: builder })
@@ -21,6 +15,9 @@ builder.staging_project(attributes) do
     render(partial: 'missing_reviews', locals: { missing_reviews: staging_project.missing_reviews,
                                                  count: staging_project.missing_reviews.count,
                                                  builder: builder })
+  end
+
+  if options[:status]
     render(partial: 'building_repositories', locals: { building_repositories: staging_project.building_repositories,
                                                        count: staging_project.building_repositories.count,
                                                        builder: builder })

--- a/src/api/spec/controllers/staging/staging_projects_controller_spec.rb
+++ b/src/api/spec/controllers/staging/staging_projects_controller_spec.rb
@@ -101,15 +101,16 @@ RSpec.describe Staging::StagingProjectsController do
           assert_select 'staging_project' do
             assert_select 'staged_requests', 0
             assert_select 'untracked_requests', 0
-            assert_select 'requests_to_review', 0
+            assert_select 'obsolete_requests', 0
             assert_select 'missing_reviews', 0
             assert_select 'broken_packages', 0
+            assert_select 'checks', 0
             assert_select 'history', 0
           end
         end
       end
 
-      context 'with staged requests' do
+      context 'with requests' do
         before do
           get :show, params: { staging_workflow_project: staging_workflow.project.name, staging_project_name: staging_project.name,
                                requests: 1, format: :xml }
@@ -119,15 +120,20 @@ RSpec.describe Staging::StagingProjectsController do
 
         it { expect(response.body).not_to include("<staging_project name=\"#{staging_project.name}\" state=") }
 
-        it 'returns the staging_project with staged requests xml' do
+        it 'returns the staging_project with requests xml' do
           assert_select 'staging_project' do
             assert_select 'staged_requests', 1 do
               assert_select 'request', 3
             end
-            assert_select 'untracked_requests', 0
-            assert_select 'requests_to_review', 0
-            assert_select 'missing_reviews', 0
+            assert_select 'untracked_requests', 1 do
+              assert_select 'request', 1
+            end
+            assert_select 'obsolete_requests', 1
+            assert_select 'missing_reviews', 1 do
+              assert_select 'review', 1
+            end
             assert_select 'broken_packages', 0
+            assert_select 'checks', 0
             assert_select 'history', 0
           end
         end
@@ -146,18 +152,13 @@ RSpec.describe Staging::StagingProjectsController do
         it 'returns the staging_project with status xml' do
           assert_select 'staging_project' do
             assert_select 'staged_requests', 0
-            assert_select 'untracked_requests', 1 do
-              assert_select 'request', 1
-            end
-            assert_select 'requests_to_review', 1 do
-              assert_select 'request', 2
-            end
-            assert_select 'missing_reviews', 1 do
-              assert_select 'review', 1
-            end
+            assert_select 'untracked_requests', 0
+            assert_select 'obsolete_requests', 0
+            assert_select 'missing_reviews', 0
             assert_select 'broken_packages', 1 do
               assert_select 'package', 1
             end
+            assert_select 'checks', 1
             assert_select 'history', 0
           end
         end
@@ -177,7 +178,7 @@ RSpec.describe Staging::StagingProjectsController do
           assert_select 'staging_project' do
             assert_select 'staged_requests', 0
             assert_select 'untracked_requests', 0
-            assert_select 'requests_to_review', 0
+            assert_select 'obsolete_requests', 0
             assert_select 'missing_reviews', 0
             assert_select 'broken_packages', 0
             assert_select 'history', 1
@@ -203,9 +204,7 @@ RSpec.describe Staging::StagingProjectsController do
             assert_select 'untracked_requests', 1 do
               assert_select 'request', 1
             end
-            assert_select 'requests_to_review', 1 do
-              assert_select 'request', 2
-            end
+            assert_select 'obsolete_requests', 1
             assert_select 'missing_reviews', 1 do
               assert_select 'review', 1
             end


### PR DESCRIPTION
The "requests_to_review" group has been removed, it contains redundant data.

Untracked requests, obsolete requests and missing reviews have been moved from "status" scope to "requests" scope. So they are shown when retrieving staging projects via API with 'requests=1' and not with 'status=1'.

Related tests and API doc has been updated.

Fixes: #8684 

How to test?

```
osc api -X GET '/staging/<project>/staging_projects/<staging_project>?requests=1'

osc api -X GET '/staging/<project>/staging_projects/<staging_project>?status=1'
```

<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn
how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md

In order to make it as easy as possible for other developers to review your
pull request we ask you to:

- Explain what this PR is about in the description
- Explain the steps the reviewer has to follow to verify your change
- If the reviewer needs sample data to verify your change, please explain how to
  create that data
- If you include visual changes in this PR, please add screenshots or GIFs
- If you address performance in this PR, add benchmark data or explain how the
  reviewer can benchmark this

This is a good PR description example:

Hey Friends,

this introduces labels for the different build result states on the project
monitor page. This makes it easier to get a visual overview of what is going on
in your project.

To verify this feature

- Enable the interconnect to build.opensuse.org
- Create the project home:Admin
- Add 'openSUSE Tumbleweed' as a repository to the project
- Branch a couple of packages into the project:
  ```
  for i in `osc -A http://0.0.0.0:3000 ls openSUSE.org:home:hennevogel`; do osc -A http://0.0.0.0:3000 copypac openSUSE.org:home:hennevogel $i home:Admin; done
  ```
- Visit the monitor page and see the new labels for the different states.

Here is a screenshot of how it looks:

** Before **
![Screenshot of the project monitor](https://example.com/screenshot1.png)

** After **
![Screenshot of the project monitor](https://example.com/screenshot2.png)

-->
