### PR TITLE
[2.10 backport] Fixes for obs-sphinx.service to fix upgrades from 2.9 to 2.10

### DIFF
--- a/dist/systemd/obs-sphinx.service
+++ b/dist/systemd/obs-sphinx.service
@@ -2,6 +2,7 @@
 Description = Open Build Service Sphinx Search Daemon
 BindsTo = obs-api-support.target
 Conflicts = searchd.service
+After = obsapisetup.service
 
 [Service]
 Environment = "RAILS_ENV=production"

--- a/dist/systemd/obs-sphinx.service
+++ b/dist/systemd/obs-sphinx.service
@@ -8,7 +8,7 @@ Environment = "RAILS_ENV=production"
 User = wwwrun
 Group = www
 WorkingDirectory = /srv/www/obs/api
-ExecStart = /bin/bash -c "if [ `stat -c '%s' /srv/www/obs/api/config/production.sphinx.conf` -eq 0 ]; then /usr/bin/bundle.ruby2.5 exec rails ts:rebuild; else /usr/bin/bundle.ruby2.5 exec rails ts:start; fi"
+ExecStart = /usr/bin/bundle.ruby2.5 exec rails sphinx:start
 ExecStop = /usr/bin/bundle.ruby2.5 exec rails ts:stop
 Type = forking
 PIDFile = /srv/www/obs/api/log/production.sphinx.pid

--- a/src/api/lib/tasks/sphinx.rake
+++ b/src/api/lib/tasks/sphinx.rake
@@ -1,0 +1,15 @@
+namespace :sphinx do
+  desc 'Start the sphinx daemon'
+  task start: :environment do
+    if index_to_build?
+      puts 'Index does not exist, creating it...'
+      Rake::Task['ts:rebuild'].invoke
+    else
+      Rake::Task['ts:start'].invoke
+    end
+  end
+end
+
+def index_to_build?
+  File.zero?("config/#{Rails.env}.sphinx.conf")
+end


### PR DESCRIPTION
This pull request contains backports of #8645 and #8667 to 2.10 to fix issues I encountered getting the `obs-sphinx` service working while doing an appliance upgrade from 2.9 to 2.10.

These fixes were originally authored by @eduardoj and @hennevogel.