### PR TITLE
Fix wrong job history

### DIFF
--- a/src/api/app/controllers/webui/packages/job_history_controller.rb
+++ b/src/api/app/controllers/webui/packages/job_history_controller.rb
@@ -7,7 +7,7 @@ module Webui
       before_action :set_architecture
 
       def index
-        @jobshistory = @package.jobhistory(repository_name: @repository.name, arch_name: @architecture.name, package_name: @package_name)
+        @jobshistory = @package.jobhistory(repository_name: @repository.name, arch_name: @architecture.name, package_name: @package_name, project_name: @project.name)
       end
 
       private

--- a/src/api/app/models/package.rb
+++ b/src/api/app/models/package.rb
@@ -915,9 +915,9 @@ class Package < ApplicationRecord
   end
 
   # FIXME: That you can overwrite package_name is rather confusing, but needed because of multibuild :-/
-  def jobhistory(repository_name:, arch_name:, package_name: nil, filter: { limit: 100, start_epoch: nil, end_epoch: nil, code: [] })
+  def jobhistory(repository_name:, arch_name:, package_name: name, filter: { limit: 100, start_epoch: nil, end_epoch: nil, code: [] })
     Backend::Api::BuildResults::JobHistory.for_package(project_name: project,
-                                                       package_name: package_name.presence ? package_name : name,
+                                                       package_name: package_name,
                                                        repository_name: repository_name,
                                                        arch_name: arch_name,
                                                        filter: filter)

--- a/src/api/app/models/package.rb
+++ b/src/api/app/models/package.rb
@@ -915,8 +915,8 @@ class Package < ApplicationRecord
   end
 
   # FIXME: That you can overwrite package_name is rather confusing, but needed because of multibuild :-/
-  def jobhistory(repository_name:, arch_name:, package_name: name, filter: { limit: 100, start_epoch: nil, end_epoch: nil, code: [] })
-    Backend::Api::BuildResults::JobHistory.for_package(project_name: project,
+  def jobhistory(repository_name:, arch_name:, package_name: name, project_name: project.name, filter: { limit: 100, start_epoch: nil, end_epoch: nil, code: [] })
+    Backend::Api::BuildResults::JobHistory.for_package(project_name: project_name,
                                                        package_name: package_name,
                                                        repository_name: repository_name,
                                                        arch_name: arch_name,


### PR DESCRIPTION
This way the job history of the project of the actual package is shown, instead of the project that a package inherits.

Fixes #6790.

Co-authored-by: David Kang <dkang@suse.com>