### PR TITLE
Fix package build updating sassc and rake

### DIFF
--- a/dist/obs-bundled-gems.spec
+++ b/dist/obs-bundled-gems.spec
@@ -51,7 +51,7 @@ BuildRoot:      %{_tmppath}/%{name}-%{version}-build
 This package bundles all the gems required by the Open Build Service
 to make it easier to deploy the obs-server package.
 
-%define rake_version 13.0.0
+%define rake_version 13.0.1
 %define rack_version 2.0.7
 
 %package -n obs-api-deps

--- a/src/api/Gemfile
+++ b/src/api/Gemfile
@@ -190,8 +190,6 @@ group :assets do
   gem 'cssmin', '>= 1.0.2'
   # for minifying JavaScript
   gem 'uglifier', '>= 1.2.2'
-  # sassc 2.2.0 is throwing exception
-  gem 'sassc', '~> 2.1.0'
   # to use sass in the asset pipeline
   gem 'sassc-rails'
   # assets for jQuery DataTables

--- a/src/api/Gemfile.lock
+++ b/src/api/Gemfile.lock
@@ -322,7 +322,7 @@ GEM
       rake (>= 0.8.7)
       thor (>= 0.19.0, < 2.0)
     rainbow (3.0.0)
-    rake (13.0.0)
+    rake (13.0.1)
     rantly (2.0.0)
     rbtree3 (0.5.0)
     rdoc (6.2.0)
@@ -381,7 +381,7 @@ GEM
       crass (~> 1.0.2)
       nokogiri (>= 1.8.0)
       nokogumbo (~> 2.0)
-    sassc (2.1.0)
+    sassc (2.2.1)
       ffi (~> 1.9)
     sassc-rails (2.1.2)
       railties (>= 4.0.0)
@@ -540,7 +540,6 @@ DEPENDENCIES
   rubocop-rspec
   ruby-ldap
   sanitize
-  sassc (~> 2.1.0)
   sassc-rails
   selenium-webdriver
   shoulda-matchers (~> 4.0)

--- a/src/api/docker-files/Dockerfile
+++ b/src/api/docker-files/Dockerfile
@@ -25,6 +25,7 @@ RUN chown -R frontend /obs/src/api
 USER frontend
 WORKDIR /obs/src/api
 
+ENV BUNDLE_BUILD__SASSC=--disable-march-tune-native
 # Refresh our bundle
 RUN export NOKOGIRI_USE_SYSTEM_LIBRARIES=1; bundle install --jobs=3 --retry=3 || bundle install --jobs=3 --retry=3
 


### PR DESCRIPTION
They don't like to play well with each other, so at least update them to their latest version.

For sassc we need to disable the cpu specific optimization to avoid running into issue 146 again
