### PR TITLE
Change missing review output

### DIFF
--- a/src/api/app/models/concerns/staging_project.rb
+++ b/src/api/app/models/concerns/staging_project.rb
@@ -257,7 +257,7 @@ module StagingProject
       who = review.send(review_by)
       next unless who
 
-      extracted.merge!(id: review.id, request: request.number, state: review.state.to_s,
+      extracted.merge!(id: review.id, request: request.number, state: review.state.to_s, creator: review.creator,
                        package: request.first_target_package, by: who, review_type: review_by.to_s)
       # No need to duplicate reviews
       break extracted

--- a/src/api/app/views/staging/staging_projects/_missing_reviews.xml.builder
+++ b/src/api/app/views/staging/staging_projects/_missing_reviews.xml.builder
@@ -1,5 +1,6 @@
 builder.missing_reviews(count: count) do |missing_review|
-  missing_reviews.each do |bs_request|
-    missing_review.review(id: bs_request[:id], creator: bs_request[:by], state: bs_request[:state], package: bs_request[:package])
+  missing_reviews.each do |review|
+    missing_review.review(request: review[:request], state: review[:state], package: review[:package],
+                          creator: review[:creator], review[:review_type] => review[:by])
   end
 end

--- a/src/api/spec/models/project/staging_project_spec.rb
+++ b/src/api/spec/models/project/staging_project_spec.rb
@@ -47,20 +47,20 @@ RSpec.describe Project, vcr: true do
       let(:other_user) { create(:confirmed_user) }
       let(:other_package) { create(:package) }
       let(:group) { create(:group) }
-      let!(:review_1) { create(:review, by_user:    other_user,            bs_request: submit_request) }
-      let!(:review_2) { create(:review, by_group:   group,                 bs_request: submit_request) }
-      let!(:review_3) { create(:review, by_project: other_package.project, bs_request: submit_request) }
-      let!(:review_4) { create(:review, by_package: other_package,         by_project: other_package.project, bs_request: submit_request) }
+      let!(:review_1) { create(:review, creator: user, by_user: other_user, bs_request: submit_request) }
+      let!(:review_2) { create(:review, creator: user, by_group: group, bs_request: submit_request) }
+      let!(:review_3) { create(:review, creator: user, by_project: other_package.project, bs_request: submit_request) }
+      let!(:review_4) { create(:review, creator: user, by_package: other_package, by_project: other_package.project, bs_request: submit_request) }
 
       subject { staging_project.missing_reviews }
 
       it 'contains all open reviews of staged requests' do
         # rubocop:disable Style/BracesAroundHashParameters
         expect(subject).to contain_exactly(
-          { id: review_1.id, request: submit_request.number, state: 'new', package: target_package.name, by: other_user.login, review_type: 'by_user' },
-          { id: review_2.id, request: submit_request.number, state: 'new', package: target_package.name, by: group.title, review_type: 'by_group' },
-          { id: review_3.id, request: submit_request.number, state: 'new', package: target_package.name, by: other_package.project.name, review_type: 'by_project' },
-          { id: review_4.id, request: submit_request.number, state: 'new', package: target_package.name, by: other_package.name, review_type: 'by_package' }
+          { id: review_1.id, request: submit_request.number, state: 'new', package: target_package.name, creator: user.login, by: other_user.login, review_type: 'by_user' },
+          { id: review_2.id, request: submit_request.number, state: 'new', package: target_package.name, creator: user.login, by: group.title, review_type: 'by_group' },
+          { id: review_3.id, request: submit_request.number, state: 'new', package: target_package.name, creator: user.login, by: other_package.project.name, review_type: 'by_project' },
+          { id: review_4.id, request: submit_request.number, state: 'new', package: target_package.name, creator: user.login, by: other_package.name, review_type: 'by_package' }
         )
         # rubocop:enable Style/BracesAroundHashParameters
       end


### PR DESCRIPTION
Show the request number instead the internal id. Also show the submitter and reviewers (by_group, by_user, by_package and by_package).

Fixes #8575.

Co-authored-by: David Kang <dkang@suse.com>
Co-authored-by: Saray Cabrera Padrón <scabrerapadron@suse.de>