### PR TITLE
Drop no longer used attributes created and updated from the documentaion

### DIFF
--- a/docs/api/api/package.rng
+++ b/docs/api/api/package.rng
@@ -46,12 +46,6 @@
       <optional>
         <attribute name="project"/>
       </optional>
-      <optional>
-        <attribute name="created"/>
-      </optional>
-      <optional>
-        <attribute name="updated"/>
-      </optional>
 
       <element ns="" name="title">
         <text/>

--- a/docs/api/api/project.rng
+++ b/docs/api/api/project.rng
@@ -64,12 +64,6 @@
           </choice>
         </attribute>
       </optional>
-      <optional>
-        <attribute name="created"/>
-      </optional>
-      <optional>
-        <attribute name="updated"/>
-      </optional>
 
       <element ns="" name="title">
         <text/>


### PR DESCRIPTION
These attributes have been removed in 2007 and shouldn't be used anymore.
This fixes #8725.