### PR TITLE
Remove not yet implemented is_delete? method

### DIFF
--- a/src/api/app/models/staging/staged_requests.rb
+++ b/src/api/app/models/staging/staged_requests.rb
@@ -9,9 +9,8 @@ class Staging::StagedRequests
       bs_request_action = request.bs_request_actions.first
       if bs_request_action.is_submit?
         link_package(bs_request_action)
-      elsif bs_request_action.is_delete?
-        # TODO: implement delete requests
       end
+      # TODO: implement delete requests
     end
 
     result.each { |request| add_review_for_staged_request(request) }


### PR DESCRIPTION
As code for handling delete requests is not yet implemented, we remove the call to the not defined method `is_delete?`.

Fix #8734.

Co-authored-by: David Kang <dkang@suse.com>