### PR TITLE
Display correctly delete requests

### DIFF
--- a/src/api/app/assets/stylesheets/webui/staging-workflow.scss
+++ b/src/api/app/assets/stylesheets/webui/staging-workflow.scss
@@ -88,7 +88,6 @@ ul .table-list-group-item {
     @extend .w-50;
 
     span.badge {
-
       margin-left: 10px;
 
       a.request {
@@ -128,6 +127,12 @@ ul .table-list-group-item {
 
       &.state-untracked {
         @extend .badge-dark;
+      }
+
+      &.delete {
+        a.request {
+          text-decoration: line-through;
+        }
       }
     }
     a, div.collapse, div.collapsing {

--- a/src/api/app/helpers/webui/staging/workflow_helper.rb
+++ b/src/api/app/helpers/webui/staging/workflow_helper.rb
@@ -65,6 +65,7 @@ module Webui::Staging::WorkflowHelper
     css = 'ready'
     css = 'review' if request[:missing_reviews].present?
     css = 'obsolete' if request[:state].in?(BsRequest::OBSOLETE_STATES)
+    css += ' delete' if request[:request_type] == 'delete'
     link_content = [request[:package]]
     link_content << reviewers_icon(request, users_hash, groups_hash) if request[:missing_reviews].present?
     content_tag(:span, class: "badge state-#{css}") do


### PR DESCRIPTION
Delete requests weren't rendered as specified in the legend.

Fix #8739.

#### Before
![Screenshot_2019-11-20 Open Build Service(3)](https://user-images.githubusercontent.com/1212806/69237514-2ad7b100-0b96-11ea-94df-fc2e62d3ffb6.png)

![Screenshot_2019-11-20 Open Build Service(2)](https://user-images.githubusercontent.com/1212806/69237519-2dd2a180-0b96-11ea-891c-9cae1ede760a.png)


#### After
![Screenshot_2019-11-20 Open Build Service(8)](https://user-images.githubusercontent.com/1212806/69248335-667d7580-0bac-11ea-8a96-2eb204faddca.png)


![Screenshot_2019-11-20 Open Build Service(7)](https://user-images.githubusercontent.com/1212806/69248288-506fb500-0bac-11ea-950f-1de313f6f5fc.png)

