### PR TITLE
Fix collapse on problems list

### DIFF
--- a/src/api/app/views/webui/staging/workflows/_problems.html.haml
+++ b/src/api/app/views/webui/staging/workflows/_problems.html.haml
@@ -1,6 +1,6 @@
 :ruby
   max_shown = 5
-  project_class = staging_project.name.tr(':', '_')
+  project_class = staging_project.name.tr(':.', '_')
   item_project_class = 'hidden-item-' + project_class
   checks_problems = staging_project.checks.failed
   build_problems = staging_project.problems


### PR DESCRIPTION
We have project names with `.`, that was causing the issue. Now apart
from replacing `:` in the project name we also substitute `.` with `_`.

Fix #8749.