### PR TITLE
Show correct output when excluding an already excluded request

### DIFF
--- a/src/api/app/models/staging/request_excluder.rb
+++ b/src/api/app/models/staging/request_excluder.rb
@@ -61,7 +61,7 @@ class Staging::RequestExcluder
 
     return if request_excluded.save
 
-    errors << "Request #{request_excluded.bs_request_id}: #{request_excluded.errors.full_messages.to_sentence}."
+    errors << "Request #{request_excluded.number}: #{request_excluded.errors.full_messages.to_sentence}."
   end
 
   def requests_to_be_excluded


### PR DESCRIPTION
We must show the request id (number) and not the internal id.

Fixes #8758.

Co-authored-by: David Kang <dkang@suse.com>