### PR TITLE
[backend] allow to disable early kiwi publishing

### DIFF
--- a/src/backend/bs_sched
+++ b/src/backend/bs_sched
@@ -1063,6 +1063,7 @@ eval {
     ($state, $details) = $ctx->checkpkgs();
 
     my $isfinished = $state eq 'finished' ? 1 : 0;
+    my $bconf = $ctx->{'conf'};
 
     # notify remote build services of repository changes or block state changes
     # we alse send it if we finish a prp to give linked aggregates a chance to work
@@ -1070,7 +1071,7 @@ eval {
     sendrepochangeevent($gctx, $prp);
 
     # free memory
-    Build::forgetdeps($ctx->{'conf'});
+    Build::forgetdeps($bconf);
 
     $ctx->printstats();
 
@@ -1080,7 +1081,7 @@ eval {
     }
 
     # we always publish kiwi...
-    if ($isfinished || $ctx->{'prptype'} eq 'kiwi') {
+    if ($isfinished || (!$bconf->{'publishflags:noearlykiwipublish'} && $ctx->{'prptype'} eq 'kiwi')) {
       my ($pubstate, $pubdetails) = $ctx->publish();
       ($state, $details) = ($pubstate, $pubdetails) if $pubstate && $pubstate ne 'done';
     }


### PR DESCRIPTION
jsc#OBS-42

<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn
how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md

In order to make it as easy as possible for other developers to review your
pull request we ask you to:

- Explain what this PR is about in the description
- Explain the steps the reviewer has to follow to verify your change
- If the reviewer needs sample data to verify your change, please explain how to
  create that data
- If you include visual changes in this PR, please add screenshots or GIFs
- If you address performance in this PR, add benchmark data or explain how the
  reviewer can benchmark this

This is a good PR description example:

Hey Friends,

this introduces labels for the different build result states on the project
monitor page. This makes it easier to get a visual overview of what is going on
in your project.

To verify this feature

- Enable the interconnect to build.opensuse.org
- Create the project home:Admin
- Add 'openSUSE Tumbleweed' as a repository to the project
- Branch a couple of packages into the project:
  ```
  for i in `osc -A http://0.0.0.0:3000 ls openSUSE.org:home:hennevogel`; do osc -A http://0.0.0.0:3000 copypac openSUSE.org:home:hennevogel $i home:Admin; done
  ```
- Visit the monitor page and see the new labels for the different states.

Here is a screenshot of how it looks:

** Before **
![Screenshot of the project monitor](https://example.com/screenshot1.png)

** After **
![Screenshot of the project monitor](https://example.com/screenshot2.png)

-->
