### PR TITLE
Add well-formed xml check for workflows controller

### DIFF
--- a/src/api/app/controllers/staging/workflows_controller.rb
+++ b/src/api/app/controllers/staging/workflows_controller.rb
@@ -3,13 +3,14 @@ class Staging::WorkflowsController < Staging::StagingController
   before_action :set_project
   before_action :check_staging_workflow, only: :create
   before_action :set_staging_workflow, only: [:update, :destroy]
+  before_action :set_xml_hash, only: [:create, :update]
   after_action :verify_authorized
 
   def create
     staging_workflow = @project.build_staging
     authorize staging_workflow
 
-    staging_workflow.managers_group = Group.find_by!(title: xml_hash['managers'])
+    staging_workflow.managers_group = Group.find_by!(title: @parsed_xml[:managers])
 
     if staging_workflow.save
       render_ok
@@ -36,7 +37,7 @@ class Staging::WorkflowsController < Staging::StagingController
   def update
     authorize @staging_workflow
 
-    @staging_workflow.managers_group = Group.find_by!(title: xml_hash['managers'])
+    @staging_workflow.managers_group = Group.find_by!(title: @parsed_xml[:managers])
 
     if @staging_workflow.save
       render_ok
@@ -59,9 +60,5 @@ class Staging::WorkflowsController < Staging::StagingController
       errorcode: 'staging_workflow_exists',
       message: "Project #{@project} already has an associated Staging Workflow with id: #{@project.staging.id}"
     )
-  end
-
-  def xml_hash
-    Xmlhash.parse(request.body.read) || {}
   end
 end

--- a/src/api/spec/controllers/staging/workflows_controller_spec.rb
+++ b/src/api/spec/controllers/staging/workflows_controller_spec.rb
@@ -48,7 +48,7 @@ RSpec.describe Staging::WorkflowsController do
         post :create, params: { staging_workflow_project: project, format: :xml }
       end
 
-      it { expect(response).to have_http_status(:not_found) }
+      it { expect(response).to have_http_status(:bad_request) }
       it { expect(project.staging).to be_nil }
     end
   end


### PR DESCRIPTION
We check for empty and well-formed xml, providing a better error message output.

Co-authored-by: David Kang <dkang@suse.com>