### PR TITLE
[backend] fix typo in alllocked test

### DIFF
--- a/src/backend/BSSched/ProjPacks.pm
+++ b/src/backend/BSSched/ProjPacks.pm
@@ -1032,10 +1032,10 @@ sub setup_projects {
 
       # check if all packages are locked
       my $alllocked;
-      if ($proj->{'locked'} && BSUtil::enabled($repoid, $proj->{'locked'}, 0, $myarch)) {
+      if ($proj->{'lock'} && BSUtil::enabled($repoid, $proj->{'lock'}, 0, $myarch)) {
 	$alllocked = 1;
-	for my $pack (grep {$_->{'locked'}} values(%{$proj->{'package'} || {}})) {
-	  $alllocked = 0 unless BSUtil::enabled($repoid, $pack->{'locked'}, 1, $myarch);
+	for my $pack (grep {$_->{'lock'}} values(%{$proj->{'package'} || {}})) {
+	  $alllocked = 0 unless BSUtil::enabled($repoid, $pack->{'lock'}, 1, $myarch);
 	}
       }
       if ($alllocked) {


### PR DESCRIPTION
Commit 8ad93245da741b2552f88497ea6afbdc019046f7 changed the code
to not propagate med events to locked projects. Unfortunately
it used 'locked' instead of the correct 'lock' to check for
locked projects.

<!---
If you haven't done so already, please read the CONTRIBUTING.md file to learn
how we work and what we expect from all contributors.

https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md

In order to make it as easy as possible for other developers to review your
pull request we ask you to:

- Explain what this PR is about in the description
- Explain the steps the reviewer has to follow to verify your change
- If the reviewer needs sample data to verify your change, please explain how to
  create that data
- If you include visual changes in this PR, please add screenshots or GIFs
- If you address performance in this PR, add benchmark data or explain how the
  reviewer can benchmark this

This is a good PR description example:

Hey Friends,

this introduces labels for the different build result states on the project
monitor page. This makes it easier to get a visual overview of what is going on
in your project.

To verify this feature

- Enable the interconnect to build.opensuse.org
- Create the project home:Admin
- Add 'openSUSE Tumbleweed' as a repository to the project
- Branch a couple of packages into the project:
  ```
  for i in `osc -A http://0.0.0.0:3000 ls openSUSE.org:home:hennevogel`; do osc -A http://0.0.0.0:3000 copypac openSUSE.org:home:hennevogel $i home:Admin; done
  ```
- Visit the monitor page and see the new labels for the different states.

Here is a screenshot of how it looks:

** Before **
![Screenshot of the project monitor](https://example.com/screenshot1.png)

** After **
![Screenshot of the project monitor](https://example.com/screenshot2.png)

-->
