### PR TITLE
Fix status_messages_controller_spec: severity is integer

### DIFF
--- a/src/api/spec/controllers/webui/status_messages_controller_spec.rb
+++ b/src/api/spec/controllers/webui/status_messages_controller_spec.rb
@@ -8,9 +8,9 @@ RSpec.describe Webui::StatusMessagesController do
     it 'create a status message' do
       login(admin_user)
 
-      post :create, params: { message: 'Some message', severity: 'Green' }
+      post :create, params: { message: 'Some message', severity: 1 }
       expect(response).to redirect_to(root_path)
-      message = StatusMessage.where(user: admin_user, message: 'Some message', severity: 'Green')
+      message = StatusMessage.where(user: admin_user, message: 'Some message', severity: 1)
       expect(message).to exist
     end
 
@@ -24,7 +24,7 @@ RSpec.describe Webui::StatusMessagesController do
       expect(flash[:error]).to eq("Could not create status message: Severity can't be blank")
 
       expect do
-        post :create, params: { severity: 'Green' }
+        post :create, params: { severity: 1 }
       end.not_to change(StatusMessage, :count)
       expect(response).to redirect_to(root_path)
       expect(flash[:error]).to eq("Could not create status message: Message can't be blank")
@@ -34,12 +34,12 @@ RSpec.describe Webui::StatusMessagesController do
       before do
         login(user)
 
-        post :create, params: { message: 'Some message', severity: 'Green' }
+        post :create, params: { message: 'Some message', severity: 1 }
       end
 
       it 'does not create a status message' do
         expect(response).to redirect_to(root_path)
-        message = StatusMessage.where(user: admin_user, message: 'Some message', severity: 'Green')
+        message = StatusMessage.where(user: admin_user, message: 'Some message', severity: 1)
         expect(message).not_to exist
       end
     end
@@ -47,7 +47,7 @@ RSpec.describe Webui::StatusMessagesController do
     context 'empty message' do
       before do
         login(admin_user)
-        post :create, params: { severity: 'Green' }
+        post :create, params: { severity: 1 }
       end
 
       it { expect(flash[:error]).to eq("Could not create status message: Message can't be blank") }
@@ -66,7 +66,7 @@ RSpec.describe Webui::StatusMessagesController do
       before do
         login(admin_user)
         allow_any_instance_of(StatusMessage).to receive(:save).and_return(false)
-        post :create, params: { message: 'Some message', severity: 'Green' }
+        post :create, params: { message: 'Some message', severity: 1 }
       end
 
       it { expect(flash[:error]).not_to be(nil) }


### PR DESCRIPTION
And strings are mappend in rails 6 sometimes to 0 and sometimes to NULL, which makes a difference